### PR TITLE
refactor(go.d): funnel function reconcile through job manager

### DIFF
--- a/src/go/plugin/agent/jobmgr/doc.go
+++ b/src/go/plugin/agent/jobmgr/doc.go
@@ -10,6 +10,10 @@
 //   - Discovery ingestion (runProcessConfGroups) does not mutate manager state directly.
 //     It publishes add/remove intents through channels consumed by Manager.run().
 //
+//   - Tick-triggered Function publication reconcile is manager-run-loop owned.
+//     runNotifyRunningJobs may request module reconcile, but must not perform
+//     Function publication directly.
+//
 //   - runningJobs.items is protected by runningJobs.mux.
 //     All traversals must use runningJobs.snapshot() and execute callbacks outside the lock.
 //     No external API/job callbacks may execute while holding runningJobs.mux.

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -37,6 +37,10 @@ type Controller struct {
 	staticMethodsSeen map[string]struct{}
 }
 
+type functionPublish struct {
+	opts netdataapi.FunctionGlobalOpts
+}
+
 func New(opts Options) *Controller {
 	log := opts.Logger
 	if log == nil {
@@ -158,11 +162,20 @@ func (c *Controller) ReconcileModuleMethodsForJob(job collectorapi.RuntimeJob) {
 	if _, ok := c.registry.getJob(job.ModuleName(), job.Name()); !ok {
 		return
 	}
-	methods := c.registry.getMethods(job.ModuleName())
+	c.ReconcileModuleMethods(job.ModuleName())
+}
+
+// ReconcileModuleMethods rechecks module/static method availability for modules
+// with at least one registered running job.
+func (c *Controller) ReconcileModuleMethods(moduleName string) {
+	if moduleName == "" || !c.registry.hasRunningJob(moduleName) {
+		return
+	}
+	methods := c.registry.getMethods(moduleName)
 	if len(methods) == 0 {
 		return
 	}
-	c.registerAvailableModuleMethods(job.ModuleName(), methods, false)
+	c.registerAvailableModuleMethods(moduleName, methods, false)
 }
 
 func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
@@ -176,11 +189,16 @@ func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
 
 func (c *Controller) Cleanup() {
 	c.staticMethodsMu.Lock()
-	defer c.staticMethodsMu.Unlock()
-
+	names := make([]string, 0, len(c.staticMethodsSeen))
 	for funcName := range c.staticMethodsSeen {
 		c.fnReg.Unregister(funcName)
-		if c.api != nil {
+		names = append(names, funcName)
+	}
+	c.staticMethodsMu.Unlock()
+
+	if c.api != nil {
+		sort.Strings(names)
+		for _, funcName := range names {
 			c.api.FunctionRemove(funcName)
 		}
 	}
@@ -196,9 +214,20 @@ func (c *Controller) registerModuleMethodsOnJobStart(moduleName string) {
 }
 
 func (c *Controller) registerAvailableModuleMethods(moduleName string, methods []funcapi.MethodConfig, agentWideOnly bool) {
+	publishes := c.collectAvailableModuleMethodPublishes(moduleName, methods, agentWideOnly)
+	if c.api == nil {
+		return
+	}
+	for _, publish := range publishes {
+		c.api.FunctionGlobal(publish.opts)
+	}
+}
+
+func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, methods []funcapi.MethodConfig, agentWideOnly bool) []functionPublish {
 	c.staticMethodsMu.Lock()
 	defer c.staticMethodsMu.Unlock()
 
+	var publishes []functionPublish
 	for i, method := range methods {
 		if agentWideOnly && !method.AgentWide {
 			continue
@@ -215,31 +244,33 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 			continue
 		}
 
+		help := method.Help
+		if help == "" {
+			help = fmt.Sprintf("%s %s data function", moduleName, method.ID)
+		}
+
+		const cloudAccess = "0x0013"
+		access := "0x0000"
+		if method.RequireCloud {
+			access = cloudAccess
+		}
+
 		if c.api != nil {
-			help := method.Help
-			if help == "" {
-				help = fmt.Sprintf("%s %s data function", moduleName, method.ID)
-			}
-
-			const cloudAccess = "0x0013"
-			access := "0x0000"
-			if method.RequireCloud {
-				access = cloudAccess
-			}
-
 			for _, funcName := range funcapi.MethodFunctionNames(moduleName, method) {
 				if _, seen := c.staticMethodsSeen[funcName]; seen {
 					continue
 				}
 				c.registerFunction(funcName, c.makeMethodFuncHandler(moduleName, method.ID))
-				c.api.FunctionGlobal(netdataapi.FunctionGlobalOpts{
-					Name:     funcName,
-					Timeout:  60,
-					Help:     help,
-					Tags:     methodTags(method),
-					Access:   access,
-					Priority: 100,
-					Version:  3,
+				publishes = append(publishes, functionPublish{
+					opts: netdataapi.FunctionGlobalOpts{
+						Name:     funcName,
+						Timeout:  60,
+						Help:     help,
+						Tags:     methodTags(method),
+						Access:   access,
+						Priority: 100,
+						Version:  3,
+					},
 				})
 				c.staticMethodsSeen[funcName] = struct{}{}
 			}
@@ -254,6 +285,7 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 			c.staticMethodsSeen[funcName] = struct{}{}
 		}
 	}
+	return publishes
 }
 
 func (c *Controller) allStaticMethodNamesSeenLocked(moduleName string, method funcapi.MethodConfig) bool {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -150,21 +150,6 @@ func (c *Controller) OnJobStart(job collectorapi.RuntimeJob) {
 	}
 }
 
-// ReconcileModuleMethodsForJob rechecks module/static method availability for a running job.
-//
-// This supports late publication for module methods whose availability depends on
-// runtime state that can appear after job start. Publication remains monotonic:
-// already-published methods are never removed here.
-func (c *Controller) ReconcileModuleMethodsForJob(job collectorapi.RuntimeJob) {
-	if job == nil || !job.IsRunning() {
-		return
-	}
-	if _, ok := c.registry.getJob(job.ModuleName(), job.Name()); !ok {
-		return
-	}
-	c.ReconcileModuleMethods(job.ModuleName())
-}
-
 // ReconcileModuleMethods rechecks module/static method availability for modules
 // with at least one registered running job.
 func (c *Controller) ReconcileModuleMethods(moduleName string) {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -852,6 +852,56 @@ func TestControllerReconcileModuleMethodsConcurrentLifecycle(t *testing.T) {
 	assert.ElementsMatch(t, expected, reg.registeredNames())
 }
 
+func TestControllerStaticPublicationDoesNotHoldLockDuringFunctionGlobal(t *testing.T) {
+	reg := newTestFunctionRegistry()
+	writer := newBlockingFunctionWriter()
+	t.Cleanup(writer.Release)
+	controller := New(Options{
+		FnReg: reg,
+		API:   dyncfg.NewResponder(netdataapi.New(writer)),
+	})
+
+	registerDone := make(chan struct{})
+	go func() {
+		controller.RegisterModules(collectorapi.Registry{
+			"mod": collectorapi.Creator{
+				Methods: func() []funcapi.MethodConfig {
+					return []funcapi.MethodConfig{{
+						ID:        "late",
+						AgentWide: true,
+					}}
+				},
+			},
+		})
+		close(registerDone)
+	}()
+
+	select {
+	case <-writer.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("FunctionGlobal write did not start")
+	}
+
+	startDone := make(chan struct{})
+	go func() {
+		controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+		close(startDone)
+	}()
+
+	select {
+	case <-startDone:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("OnJobStart blocked while FunctionGlobal was writing")
+	}
+
+	writer.Release()
+	select {
+	case <-registerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RegisterModules did not finish")
+	}
+}
+
 func TestControllerRegisterJobMethods(t *testing.T) {
 	tests := map[string]struct{}{
 		"fail fast on collision with static method":          {},
@@ -1617,4 +1667,28 @@ func (r *testFunctionRegistry) unregisteredNames() []string {
 	out := make([]string, len(r.unregistered))
 	copy(out, r.unregistered)
 	return out
+}
+
+type blockingFunctionWriter struct {
+	started     chan struct{}
+	release     chan struct{}
+	once        sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingFunctionWriter() *blockingFunctionWriter {
+	return &blockingFunctionWriter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (w *blockingFunctionWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.started) })
+	<-w.release
+	return len(p), nil
+}
+
+func (w *blockingFunctionWriter) Release() {
+	w.releaseOnce.Do(func() { close(w.release) })
 }

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -422,7 +422,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 		"availability-gated static method registers when available":     {},
 		"availability-gated agent-wide method registers when available": {},
 		"reconcile registers late available static method":              {},
-		"reconcile ignores stopped job":                                 {},
+		"reconcile ignores module with no running job":                  {},
 		"reconcile does not duplicate published static method":          {},
 		"reconcile logs empty static method ID once":                    {},
 		"public method name collision skips colliding module":           {},
@@ -535,11 +535,11 @@ func TestControllerLifecycleHooks(t *testing.T) {
 				assert.Empty(t, reg.registeredNames())
 
 				available = true
-				controller.ReconcileModuleMethodsForJob(job)
+				controller.ReconcileModuleMethods(job.ModuleName())
 
 				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
 
-			case "reconcile ignores stopped job":
+			case "reconcile ignores module with no running job":
 				available := true
 				controller.RegisterModules(collectorapi.Registry{
 					"mod": collectorapi.Creator{
@@ -552,7 +552,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 					},
 				})
 
-				controller.ReconcileModuleMethodsForJob(newTestRuntimeJob("mod", "job1", false))
+				controller.ReconcileModuleMethods("mod")
 
 				assert.Empty(t, reg.registeredNames())
 
@@ -574,8 +574,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 
 				job := newTestRuntimeJob("mod", "job1", true)
 				controller.OnJobStart(job)
-				controller.ReconcileModuleMethodsForJob(job)
-				controller.ReconcileModuleMethodsForJob(job)
+				controller.ReconcileModuleMethods(job.ModuleName())
+				controller.ReconcileModuleMethods(job.ModuleName())
 
 				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
 				assert.Equal(t, 1, availableCalls)
@@ -597,9 +597,9 @@ func TestControllerLifecycleHooks(t *testing.T) {
 				job1 := newTestRuntimeJob("mod", "job1", true)
 				job2 := newTestRuntimeJob("mod", "job2", true)
 				controller.OnJobStart(job1)
-				controller.ReconcileModuleMethodsForJob(job1)
+				controller.ReconcileModuleMethods(job1.ModuleName())
 				controller.OnJobStart(job2)
-				controller.ReconcileModuleMethodsForJob(job2)
+				controller.ReconcileModuleMethods(job2.ModuleName())
 
 				assert.Equal(t, 1, strings.Count(logBuf.String(), "empty method ID"))
 
@@ -821,7 +821,7 @@ func TestControllerReconcileModuleMethodsConcurrentLifecycle(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for n := range iterations {
-				controller.ReconcileModuleMethodsForJob(jobs[(worker+n)%len(jobs)])
+				controller.ReconcileModuleMethods(jobs[(worker+n)%len(jobs)].ModuleName())
 			}
 		}(i)
 	}

--- a/src/go/plugin/agent/jobmgr/funcctl/registry.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/registry.go
@@ -188,6 +188,22 @@ func (r *moduleFuncRegistry) getJobNames(moduleName string) []string {
 	return names
 }
 
+func (r *moduleFuncRegistry) hasRunningJob(moduleName string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	module, ok := r.modules[moduleName]
+	if !ok {
+		return false
+	}
+	for _, entry := range module.jobs {
+		if entry.job.IsRunning() {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *moduleFuncRegistry) getJob(moduleName, jobName string) (collectorapi.RuntimeJob, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -55,6 +55,7 @@ const (
 	cmdTestWorkerCap       = 4
 	cmdTestDefaultTimeout  = 60 * time.Second
 	cmdTestWorkerDrainWait = 5 * time.Second
+	funcReconcileQueueSize = 64
 )
 
 func New(cfg Config) *Manager {
@@ -114,11 +115,12 @@ func New(cfg Config) *Manager {
 		runningJobs:       newRunningJobsCache(),
 		retryingTasks:     newRetryingTasksCache(),
 
-		started:    make(chan struct{}),
-		addCh:      make(chan confgroup.Config),
-		rmCh:       make(chan confgroup.Config),
-		dyncfgCh:   make(chan dyncfg.Function, 32),
-		cmdTestSem: make(chan struct{}, cmdTestWorkerCap),
+		started:     make(chan struct{}),
+		addCh:       make(chan confgroup.Config),
+		rmCh:        make(chan confgroup.Config),
+		dyncfgCh:    make(chan dyncfg.Function, 32),
+		funcReconCh: make(chan string, funcReconcileQueueSize),
+		cmdTestSem:  make(chan struct{}, cmdTestWorkerCap),
 
 		dyncfgResponder: api,
 		runtimeService:  cfg.RuntimeService,
@@ -217,13 +219,14 @@ type Manager struct {
 	vnodesCtl          *vnodectl.Controller
 
 	// Runtime loop state.
-	ctx        context.Context
-	started    chan struct{}
-	addCh      chan confgroup.Config
-	rmCh       chan confgroup.Config
-	dyncfgCh   chan dyncfg.Function
-	cmdTestSem chan struct{}
-	cmdTestWG  sync.WaitGroup
+	ctx         context.Context
+	started     chan struct{}
+	addCh       chan confgroup.Config
+	rmCh        chan confgroup.Config
+	dyncfgCh    chan dyncfg.Function
+	funcReconCh chan string
+	cmdTestSem  chan struct{}
+	cmdTestWG   sync.WaitGroup
 
 	// Shared service seams.
 	dyncfgResponder *dyncfg.Responder
@@ -326,14 +329,10 @@ func (m *Manager) runProcessConfGroups(in chan []*confgroup.Group) {
 func (m *Manager) run() {
 	for {
 		if m.collectorHandler.WaitingForDecision() {
-			step, ok := m.collectorHandler.NextWaitDecisionStep(m.ctx, m.dyncfgCh)
-			if !ok {
+			if !m.runWaitDecisionStep() {
 				return
 			}
-			if step.HasCommand {
-				m.dyncfgSeqExec(step.Command)
-				continue
-			}
+			continue
 		} else {
 			select {
 			case <-m.ctx.Done():
@@ -344,6 +343,8 @@ func (m *Manager) run() {
 				m.removeConfig(cfg)
 			case fn := <-m.dyncfgCh:
 				m.dyncfgSeqExec(fn)
+			case moduleName := <-m.funcReconCh:
+				m.funcCtl.ReconcileModuleMethods(moduleName)
 			}
 		}
 	}
@@ -388,6 +389,43 @@ func (m *Manager) addConfig(cfg confgroup.Config) {
 	}
 }
 
+func (m *Manager) runWaitDecisionStep() bool {
+	waitFor, hasTimeout := m.collectorHandler.WaitDecisionRemaining()
+	if !hasTimeout {
+		select {
+		case <-m.ctx.Done():
+			return false
+		case fn := <-m.dyncfgCh:
+			m.dyncfgSeqExec(fn)
+		case moduleName := <-m.funcReconCh:
+			m.funcCtl.ReconcileModuleMethods(moduleName)
+		}
+		return true
+	}
+
+	timer := time.NewTimer(waitFor)
+	defer func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}()
+
+	select {
+	case <-m.ctx.Done():
+		return false
+	case fn := <-m.dyncfgCh:
+		m.dyncfgSeqExec(fn)
+	case moduleName := <-m.funcReconCh:
+		m.funcCtl.ReconcileModuleMethods(moduleName)
+	case <-timer.C:
+		m.collectorHandler.ExpireWaitDecision()
+	}
+	return true
+}
+
 func (m *Manager) removeConfig(cfg confgroup.Config) {
 	m.retryingTasks.remove(cfg)
 
@@ -414,11 +452,31 @@ func (m *Manager) runNotifyRunningJobs() {
 		case <-m.ctx.Done():
 			return
 		case clock := <-tk.C:
+			reconcileModules := make(map[string]struct{})
 			for _, job := range m.runningJobs.snapshot() {
 				job.Tick(clock)
-				m.funcCtl.ReconcileModuleMethodsForJob(job)
+				reconcileModules[job.ModuleName()] = struct{}{}
+			}
+			for moduleName := range reconcileModules {
+				m.requestFunctionReconcile(moduleName)
 			}
 		}
+	}
+}
+
+func (m *Manager) requestFunctionReconcile(moduleName string) {
+	if moduleName == "" {
+		return
+	}
+	ctx := m.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+	case m.funcReconCh <- moduleName:
+	default:
+		// The next running-job tick will retry. Keep the tick path non-blocking.
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -5,6 +5,7 @@ package jobmgr
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -19,6 +20,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
@@ -125,9 +127,11 @@ func TestRunNotifyRunningJobs_TickOutsideLock(t *testing.T) {
 
 func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T) {
 	reg := &recordingFunctionRegistry{}
+	var out bytes.Buffer
 	available := false
 	mgr := New(Config{
 		PluginName: testPluginName,
+		Out:        &out,
 		FnReg:      reg,
 		Modules: collectorapi.Registry{
 			"mod": collectorapi.Creator{
@@ -180,6 +184,7 @@ func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T)
 	case <-time.After(2 * time.Second):
 		t.Fatal("run did not stop")
 	}
+	assert.NotContains(t, out.String(), "FUNCTION_DEL")
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
@@ -243,6 +248,292 @@ func TestRunNotifyRunningJobs_DeduplicatesFunctionReconcileByModule(t *testing.T
 		return slices.Contains(reg.registeredNames(), "mod:late")
 	}, 2*time.Second, 10*time.Millisecond)
 	assert.Equal(t, int32(1), availableCalls.Load())
+
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not stop")
+	}
+	select {
+	case <-notifyDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runNotifyRunningJobs did not stop")
+	}
+}
+
+func TestRunNotifyRunningJobs_DoesNotPublishDirectly(t *testing.T) {
+	reg := &recordingFunctionRegistry{}
+	available := false
+	mgr := New(Config{
+		PluginName: testPluginName,
+		FnReg:      reg,
+		Modules: collectorapi.Registry{
+			"mod": collectorapi.Creator{
+				Methods: func() []funcapi.MethodConfig {
+					return []funcapi.MethodConfig{{
+						ID:        "late",
+						Available: func() bool { return available },
+					}}
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.ctx = ctx
+	mgr.funcCtl.Init(ctx)
+	mgr.funcCtl.RegisterModules(mgr.modules)
+
+	job := &lockProbeJob{
+		fullName:    "mod_job1",
+		moduleName:  "mod",
+		name:        "job1",
+		tickStarted: make(chan struct{}),
+		tickRelease: make(chan struct{}),
+	}
+	mgr.funcCtl.OnJobStart(job)
+	mgr.runningJobs.lock()
+	mgr.runningJobs.add(job.FullName(), job)
+	mgr.runningJobs.unlock()
+
+	done := make(chan struct{})
+	go func() {
+		mgr.runNotifyRunningJobs()
+		close(done)
+	}()
+
+	select {
+	case <-job.tickStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("tick did not start")
+	}
+	available = true
+	close(job.tickRelease)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, reg.registeredNames())
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runNotifyRunningJobs did not stop")
+	}
+}
+
+func TestRequestFunctionReconcile_DroppedRequestCanBeRetried(t *testing.T) {
+	reg := &recordingFunctionRegistry{}
+	available := false
+	mgr := New(Config{
+		PluginName: testPluginName,
+		FnReg:      reg,
+		Modules: collectorapi.Registry{
+			"mod": collectorapi.Creator{
+				Methods: func() []funcapi.MethodConfig {
+					return []funcapi.MethodConfig{{
+						ID:        "late",
+						Available: func() bool { return available },
+					}}
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.ctx = ctx
+	mgr.funcCtl.Init(ctx)
+	mgr.funcCtl.RegisterModules(mgr.modules)
+	mgr.funcCtl.OnJobStart(&tickProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"})
+
+	for i := 0; i < cap(mgr.funcReconCh); i++ {
+		mgr.funcReconCh <- "other"
+	}
+	available = true
+
+	requestDone := make(chan struct{})
+	go func() {
+		mgr.requestFunctionReconcile("mod")
+		close(requestDone)
+	}()
+
+	select {
+	case <-requestDone:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("requestFunctionReconcile blocked on a full queue")
+	}
+	assert.Empty(t, reg.registeredNames())
+
+	for len(mgr.funcReconCh) > 0 {
+		<-mgr.funcReconCh
+	}
+
+	runDone := make(chan struct{})
+	go func() {
+		mgr.run()
+		close(runDone)
+	}()
+	mgr.requestFunctionReconcile("mod")
+
+	require.Eventually(t, func() bool {
+		return slices.Contains(reg.registeredNames(), "mod:late")
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not stop")
+	}
+}
+
+func TestRunWaitDecisionStep(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"drains function reconcile while waiting": {
+			run: func(t *testing.T) {
+				reg := &recordingFunctionRegistry{}
+				available := false
+				mgr := New(Config{
+					PluginName: testPluginName,
+					FnReg:      reg,
+					Modules: collectorapi.Registry{
+						"mod": collectorapi.Creator{
+							Methods: func() []funcapi.MethodConfig {
+								return []funcapi.MethodConfig{{
+									ID:        "late",
+									Available: func() bool { return available },
+								}}
+							},
+						},
+					},
+				})
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				mgr.ctx = ctx
+				mgr.funcCtl.Init(ctx)
+				mgr.funcCtl.RegisterModules(mgr.modules)
+				job := &tickProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"}
+				mgr.funcCtl.OnJobStart(job)
+				available = true
+
+				mgr.collectorHandler.WaitForDecision(prepareUserCfg("other", "job"))
+				mgr.funcReconCh <- "mod"
+
+				require.True(t, mgr.runWaitDecisionStep())
+				assert.Equal(t, []string{"mod:late"}, reg.registeredNames())
+			},
+		},
+		"executes dyncfg command while waiting": {
+			run: func(t *testing.T) {
+				var out bytes.Buffer
+				mgr := New(Config{PluginName: testPluginName, Out: &out})
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				mgr.ctx = ctx
+				mgr.collectorHandler.WaitForDecision(prepareUserCfg("mod", "job"))
+				mgr.dyncfgCh <- dyncfg.NewFunction(functions.Function{
+					UID:  "unknown",
+					Name: "config",
+					Args: []string{"unknown", string(dyncfg.CommandSchema)},
+				})
+
+				require.True(t, mgr.runWaitDecisionStep())
+				assert.Contains(t, out.String(), "unknown function")
+			},
+		},
+		"expires wait decision": {
+			run: func(t *testing.T) {
+				mgr := New(Config{PluginName: testPluginName})
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				mgr.ctx = ctx
+				mgr.collectorHandler = newTestCollectorHandlerWithWaitTimeout(mgr, time.Nanosecond)
+				mgr.collectorHandler.WaitForDecision(prepareUserCfg("mod", "job"))
+
+				require.True(t, mgr.runWaitDecisionStep())
+				assert.False(t, mgr.collectorHandler.WaitingForDecision())
+			},
+		},
+		"context cancel returns false": {
+			run: func(t *testing.T) {
+				mgr := New(Config{PluginName: testPluginName})
+				ctx, cancel := context.WithCancel(context.Background())
+				mgr.ctx = ctx
+				mgr.collectorHandler.WaitForDecision(prepareUserCfg("mod", "job"))
+				cancel()
+
+				assert.False(t, mgr.runWaitDecisionStep())
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+func TestFunctionReconcileFunnelConcurrentLifecycle(t *testing.T) {
+	reg := &recordingFunctionRegistry{}
+	var available atomic.Bool
+	mgr := New(Config{
+		PluginName: testPluginName,
+		FnReg:      reg,
+		Modules: collectorapi.Registry{
+			"mod": collectorapi.Creator{
+				Methods: func() []funcapi.MethodConfig {
+					return []funcapi.MethodConfig{{
+						ID:        "late",
+						Available: available.Load,
+					}}
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.ctx = ctx
+	mgr.funcCtl.Init(ctx)
+	mgr.funcCtl.RegisterModules(mgr.modules)
+
+	runDone := make(chan struct{})
+	go func() {
+		mgr.run()
+		close(runDone)
+	}()
+	notifyDone := make(chan struct{})
+	go func() {
+		mgr.runNotifyRunningJobs()
+		close(notifyDone)
+	}()
+
+	stable := &tickProbeJob{fullName: "mod_stable", moduleName: "mod", name: "stable"}
+	mgr.startRunningJob(stable)
+	available.Store(true)
+
+	var wg sync.WaitGroup
+	for worker := range 4 {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := range 20 {
+				name := fmt.Sprintf("churn-%d-%d", worker, i)
+				fullName := fmt.Sprintf("mod_%s", name)
+				job := &tickProbeJob{fullName: fullName, moduleName: "mod", name: name}
+				mgr.startRunningJob(job)
+				mgr.stopRunningJob(fullName)
+			}
+		}(worker)
+	}
+
+	require.Eventually(t, func() bool {
+		return slices.Contains(reg.registeredNames(), "mod:late")
+	}, 3*time.Second, 10*time.Millisecond)
+	wg.Wait()
 
 	cancel()
 	select {
@@ -667,6 +958,25 @@ func (r *recordingFunctionRegistry) registeredPrefixes() []registeredPrefix {
 	out := make([]registeredPrefix, len(r.prefixes))
 	copy(out, r.prefixes)
 	return out
+}
+
+func newTestCollectorHandlerWithWaitTimeout(mgr *Manager, timeout time.Duration) *dyncfg.Handler[confgroup.Config] {
+	return dyncfg.NewHandler(dyncfg.HandlerOpts[confgroup.Config]{
+		Logger:    mgr.Logger,
+		API:       mgr.dyncfgResponder,
+		Seen:      dyncfg.NewSeenCache[confgroup.Config](),
+		Exposed:   dyncfg.NewExposedCache[confgroup.Config](),
+		Callbacks: mgr.collectorCallbacks,
+		WaitKey: func(cfg confgroup.Config) string {
+			return cfg.FullName()
+		},
+
+		Path:                    fmt.Sprintf(dyncfgCollectorPath, testPluginName),
+		EnableFailCode:          200,
+		RemoveStockOnEnableFail: true,
+		ConfigCommands:          dyncfgCollectorConfigCmds(),
+		WaitTimeout:             timeout,
+	})
 }
 
 type registeredPrefix struct {

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -145,6 +146,11 @@ func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T)
 	mgr.ctx = ctx
 	mgr.funcCtl.Init(ctx)
 	mgr.funcCtl.RegisterModules(mgr.modules)
+	runDone := make(chan struct{})
+	go func() {
+		mgr.run()
+		close(runDone)
+	}()
 
 	job := &tickProbeJob{
 		fullName:   "mod_job1",
@@ -170,7 +176,82 @@ func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T)
 
 	cancel()
 	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not stop")
+	}
+	select {
 	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runNotifyRunningJobs did not stop")
+	}
+}
+
+func TestRunNotifyRunningJobs_DeduplicatesFunctionReconcileByModule(t *testing.T) {
+	reg := &recordingFunctionRegistry{}
+	available := false
+	var availableCalls atomic.Int32
+	mgr := New(Config{
+		PluginName: testPluginName,
+		FnReg:      reg,
+		Modules: collectorapi.Registry{
+			"mod": collectorapi.Creator{
+				Methods: func() []funcapi.MethodConfig {
+					return []funcapi.MethodConfig{{
+						ID: "late",
+						Available: func() bool {
+							if available {
+								availableCalls.Add(1)
+							}
+							return available
+						},
+					}}
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.ctx = ctx
+	mgr.funcCtl.Init(ctx)
+	mgr.funcCtl.RegisterModules(mgr.modules)
+	runDone := make(chan struct{})
+	go func() {
+		mgr.run()
+		close(runDone)
+	}()
+
+	job1 := &tickProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"}
+	job2 := &tickProbeJob{fullName: "mod_job2", moduleName: "mod", name: "job2"}
+	mgr.funcCtl.OnJobStart(job1)
+	mgr.funcCtl.OnJobStart(job2)
+	mgr.runningJobs.lock()
+	mgr.runningJobs.add(job1.FullName(), job1)
+	mgr.runningJobs.add(job2.FullName(), job2)
+	mgr.runningJobs.unlock()
+
+	availableCalls.Store(0)
+	available = true
+	notifyDone := make(chan struct{})
+	go func() {
+		mgr.runNotifyRunningJobs()
+		close(notifyDone)
+	}()
+
+	require.Eventually(t, func() bool {
+		return slices.Contains(reg.registeredNames(), "mod:late")
+	}, 2*time.Second, 10*time.Millisecond)
+	assert.Equal(t, int32(1), availableCalls.Load())
+
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not stop")
+	}
+	select {
+	case <-notifyDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("runNotifyRunningJobs did not stop")
 	}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes function-method reconciliation through the job manager so it runs in the manager loop, stays non-blocking, and is deduplicated per module. Also stops holding controller locks during `FunctionGlobal`/`FunctionRemove`, preventing stalls and repeated work.

- **Refactors**
  - Added `funcReconCh`; reconciliation is handled in `Manager.run` and during wait-decision windows. `runNotifyRunningJobs` now only enqueues via `requestFunctionReconcile` (non-blocking queue, retried on next tick; deduped per module).
  - `funcctl`: `ReconcileModuleMethods(module)` rechecks only modules with running jobs; collects publishes and performs `FunctionGlobal` after releasing locks.
  - `registry`: added `hasRunningJob` for fast running-job checks.
  - `Cleanup` copies and sorts names, then calls `FunctionRemove` outside the static-method lock.

- **Bug Fixes**
  - Prevented `OnJobStart` from blocking when `FunctionGlobal` writes are slow.
  - Ensured late-available methods are evaluated once per module, even with multiple running jobs and while the manager waits for user decisions.

<sup>Written for commit d241c2a2ae27aa43c966c29a1b1d6dcc7e16957a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

