### PR TITLE
refactor(go.d): prepare function publication state

### DIFF
--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -32,13 +32,15 @@ type Controller struct {
 	fnReg      functions.Registry
 	ctx        context.Context
 
-	registry          *moduleFuncRegistry
-	staticMethodsMu   sync.Mutex
-	staticMethodsSeen map[string]struct{}
+	registry     *moduleFuncRegistry
+	publishedMu  sync.Mutex
+	publishedFns *publishedFunctionStore
 }
 
 type functionPublish struct {
-	opts netdataapi.FunctionGlobalOpts
+	name    string
+	handler functions.Handler
+	opts    netdataapi.FunctionGlobalOpts
 }
 
 func New(opts Options) *Controller {
@@ -52,12 +54,12 @@ func New(opts Options) *Controller {
 	}
 
 	return &Controller{
-		Logger:            log,
-		api:               opts.API,
-		jsonWriter:        opts.JSONWriter,
-		fnReg:             reg,
-		registry:          newModuleFuncRegistry(),
-		staticMethodsSeen: make(map[string]struct{}),
+		Logger:       log,
+		api:          opts.API,
+		jsonWriter:   opts.JSONWriter,
+		fnReg:        reg,
+		registry:     newModuleFuncRegistry(),
+		publishedFns: newPublishedFunctionStore(),
 	}
 }
 
@@ -173,16 +175,15 @@ func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
 }
 
 func (c *Controller) Cleanup() {
-	c.staticMethodsMu.Lock()
-	names := make([]string, 0, len(c.staticMethodsSeen))
-	for funcName := range c.staticMethodsSeen {
-		c.fnReg.Unregister(funcName)
-		names = append(names, funcName)
-	}
-	c.staticMethodsMu.Unlock()
+	c.publishedMu.Lock()
+	names := c.publishedFns.removeKind(publishedFunctionModuleMethod)
+	c.publishedMu.Unlock()
 
+	sort.Strings(names)
+	for _, funcName := range names {
+		c.fnReg.Unregister(funcName)
+	}
 	if c.api != nil {
-		sort.Strings(names)
 		for _, funcName := range names {
 			c.api.FunctionRemove(funcName)
 		}
@@ -200,6 +201,9 @@ func (c *Controller) registerModuleMethodsOnJobStart(moduleName string) {
 
 func (c *Controller) registerAvailableModuleMethods(moduleName string, methods []funcapi.MethodConfig, agentWideOnly bool) {
 	publishes := c.collectAvailableModuleMethodPublishes(moduleName, methods, agentWideOnly)
+	for _, publish := range publishes {
+		c.registerFunction(publish.name, publish.handler)
+	}
 	if c.api == nil {
 		return
 	}
@@ -209,15 +213,15 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 }
 
 func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, methods []funcapi.MethodConfig, agentWideOnly bool) []functionPublish {
-	c.staticMethodsMu.Lock()
-	defer c.staticMethodsMu.Unlock()
+	c.publishedMu.Lock()
+	defer c.publishedMu.Unlock()
 
 	var publishes []functionPublish
 	for i, method := range methods {
 		if agentWideOnly && !method.AgentWide {
 			continue
 		}
-		if method.ID != "" && c.allStaticMethodNamesSeenLocked(moduleName, method) {
+		if method.ID != "" && c.allMethodFunctionNamesPublishedLocked(moduleName, method) {
 			continue
 		}
 		if !methodAvailable(method) {
@@ -242,11 +246,13 @@ func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, me
 
 		if c.api != nil {
 			for _, funcName := range funcapi.MethodFunctionNames(moduleName, method) {
-				if _, seen := c.staticMethodsSeen[funcName]; seen {
+				if c.publishedFns.has(funcName) {
 					continue
 				}
-				c.registerFunction(funcName, c.makeMethodFuncHandler(moduleName, method.ID))
+				record, _ := c.publishedFns.add(funcName, moduleMethodOwner(moduleName, method.ID))
 				publishes = append(publishes, functionPublish{
+					name:    funcName,
+					handler: c.makePublishedMethodFuncHandler(funcName, record.generation, moduleName, method.ID),
 					opts: netdataapi.FunctionGlobalOpts{
 						Name:     funcName,
 						Timeout:  60,
@@ -257,33 +263,27 @@ func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, me
 						Version:  3,
 					},
 				})
-				c.staticMethodsSeen[funcName] = struct{}{}
 			}
 			continue
 		}
 
 		for _, funcName := range funcapi.MethodFunctionNames(moduleName, method) {
-			if _, seen := c.staticMethodsSeen[funcName]; seen {
+			if c.publishedFns.has(funcName) {
 				continue
 			}
-			c.registerFunction(funcName, c.makeMethodFuncHandler(moduleName, method.ID))
-			c.staticMethodsSeen[funcName] = struct{}{}
+			record, _ := c.publishedFns.add(funcName, moduleMethodOwner(moduleName, method.ID))
+			publishes = append(publishes, functionPublish{
+				name:    funcName,
+				handler: c.makePublishedMethodFuncHandler(funcName, record.generation, moduleName, method.ID),
+			})
 		}
 	}
 	return publishes
 }
 
-func (c *Controller) allStaticMethodNamesSeenLocked(moduleName string, method funcapi.MethodConfig) bool {
+func (c *Controller) allMethodFunctionNamesPublishedLocked(moduleName string, method funcapi.MethodConfig) bool {
 	names := funcapi.MethodFunctionNames(moduleName, method)
-	if len(names) == 0 {
-		return false
-	}
-	for _, name := range names {
-		if _, seen := c.staticMethodsSeen[name]; !seen {
-			return false
-		}
-	}
-	return true
+	return c.publishedFns.all(names)
 }
 
 func methodTags(method funcapi.MethodConfig) string {
@@ -337,27 +337,50 @@ func (c *Controller) registerJobMethods(job collectorapi.RuntimeJob, methods []f
 	// Record methods before publishing handlers so startup-time calls do not race a false 404.
 	c.registry.registerJobMethods(job.ModuleName(), job.Name(), methods)
 
+	publishes := c.collectJobMethodPublishes(job, methods)
+
+	for _, publish := range publishes {
+		c.registerFunction(publish.name, publish.handler)
+		if c.api != nil {
+			c.api.FunctionGlobal(publish.opts)
+		}
+
+		c.Debugf("registered job method: %s for job %s[%s]", publish.name, job.ModuleName(), job.Name())
+	}
+}
+
+func (c *Controller) collectJobMethodPublishes(job collectorapi.RuntimeJob, methods []funcapi.MethodConfig) []functionPublish {
+	c.publishedMu.Lock()
+	defer c.publishedMu.Unlock()
+
+	var publishes []functionPublish
 	for _, method := range methods {
 		if method.ID == "" {
 			continue
 		}
 
 		funcName := fmt.Sprintf("%s:%s", job.ModuleName(), method.ID)
-		c.registerFunction(funcName, c.makeJobMethodFuncHandler(job.ModuleName(), job.Name(), method.ID))
+		if c.publishedFns.has(funcName) {
+			continue
+		}
 
-		if c.api != nil {
-			help := method.Help
-			if help == "" {
-				help = fmt.Sprintf("%s %s data function", job.ModuleName(), method.ID)
-			}
+		record, _ := c.publishedFns.add(funcName, jobMethodOwner(job.ModuleName(), job.Name(), method.ID))
 
-			const cloudAccess = "0x0013"
-			access := "0x0000"
-			if method.RequireCloud {
-				access = cloudAccess
-			}
+		help := method.Help
+		if help == "" {
+			help = fmt.Sprintf("%s %s data function", job.ModuleName(), method.ID)
+		}
 
-			c.api.FunctionGlobal(netdataapi.FunctionGlobalOpts{
+		const cloudAccess = "0x0013"
+		access := "0x0000"
+		if method.RequireCloud {
+			access = cloudAccess
+		}
+
+		publishes = append(publishes, functionPublish{
+			name:    funcName,
+			handler: c.makePublishedJobMethodFuncHandler(funcName, record.generation, job.ModuleName(), job.Name(), method.ID),
+			opts: netdataapi.FunctionGlobalOpts{
 				Name:     funcName,
 				Timeout:  60,
 				Help:     help,
@@ -365,11 +388,10 @@ func (c *Controller) registerJobMethods(job collectorapi.RuntimeJob, methods []f
 				Access:   access,
 				Priority: 100,
 				Version:  3,
-			})
-		}
-
-		c.Debugf("registered job method: %s for job %s[%s]", funcName, job.ModuleName(), job.Name())
+			},
+		})
 	}
+	return publishes
 }
 
 func (c *Controller) unregisterJobMethods(job collectorapi.RuntimeJob) {
@@ -378,14 +400,18 @@ func (c *Controller) unregisterJobMethods(job collectorapi.RuntimeJob) {
 		return
 	}
 
+	var names []string
+	c.publishedMu.Lock()
 	for _, method := range methods {
 		if method.ID == "" {
 			continue
 		}
+		names = append(names, c.publishedFns.removeOwner(jobMethodOwner(job.ModuleName(), job.Name(), method.ID))...)
+	}
+	c.publishedMu.Unlock()
 
-		// FIXME: keep this in sync with registerJobMethods() if job-method alias
-		// support is added later; today only the canonical name is removed here.
-		funcName := fmt.Sprintf("%s:%s", job.ModuleName(), method.ID)
+	sort.Strings(names)
+	for _, funcName := range names {
 		c.fnReg.Unregister(funcName)
 		if c.api != nil {
 			c.api.FunctionRemove(funcName)

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -240,6 +240,30 @@ func TestModuleFuncRegistry_MethodRouteCollisionUsesDeterministicOwner(t *testin
 	assert.Equal(t, "logs", methodID)
 }
 
+func TestModuleFuncRegistry_MethodRouteRefreshesAffectedNames(t *testing.T) {
+	r := newModuleFuncRegistry()
+	r.registerModuleWithMethods("bbb", collectorapi.Creator{}, []funcapi.MethodConfig{{
+		ID:           "logs",
+		FunctionName: "shared:logs",
+	}})
+	r.registerModuleWithMethods("aaa", collectorapi.Creator{}, []funcapi.MethodConfig{{
+		ID:           "logs",
+		FunctionName: "shared:logs",
+	}})
+
+	r.registerModuleWithMethods("aaa", collectorapi.Creator{}, nil)
+
+	moduleName, methodID, ok := r.resolveMethodRoute("shared:logs")
+	require.True(t, ok)
+	assert.Equal(t, "bbb", moduleName)
+	assert.Equal(t, "logs", methodID)
+
+	r.registerModuleWithMethods("bbb", collectorapi.Creator{}, nil)
+
+	_, _, ok = r.resolveMethodRoute("shared:logs")
+	assert.False(t, ok)
+}
+
 func TestModuleFuncRegistry_VerifyJobGeneration_JobStopped(t *testing.T) {
 	r := newModuleFuncRegistry()
 	r.registerModule("postgres", collectorapi.Creator{})
@@ -991,6 +1015,76 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 				assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, reg.registeredNames())
 				assert.Len(t, controller.registry.getJobMethods("mod", "job1"), 2)
 			}
+		})
+	}
+}
+
+func TestControllerPublishedFunctionGenerationInvalidatesStaleHandlers(t *testing.T) {
+	tests := map[string]struct {
+		setup func(*Controller)
+	}{
+		"module method after cleanup": {
+			setup: func(controller *Controller) {
+				controller.RegisterModules(collectorapi.Registry{
+					"mod": collectorapi.Creator{
+						Methods: func() []funcapi.MethodConfig {
+							return []funcapi.MethodConfig{{ID: "a"}}
+						},
+						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+							return &tableTestHandler{}
+						},
+					},
+				})
+				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+				controller.Cleanup()
+			},
+		},
+		"job method after job stop": {
+			setup: func(controller *Controller) {
+				controller.RegisterModules(collectorapi.Registry{
+					"mod": collectorapi.Creator{
+						JobMethods: func(collectorapi.RuntimeJob) []funcapi.MethodConfig {
+							return []funcapi.MethodConfig{{ID: "a"}}
+						},
+						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+							return &tableTestHandler{}
+						},
+					},
+				})
+				job := newTestRuntimeJob("mod", "job1", true)
+				controller.OnJobStart(job)
+				controller.OnJobStop(job)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var gotCode int
+			var gotResp map[string]any
+			var stale func(functions.Function)
+			reg := newTestFunctionRegistry()
+			reg.onRegister = func(name string, fn func(functions.Function)) {
+				if name == "mod:a" {
+					stale = fn
+				}
+			}
+			controller := New(Options{
+				FnReg: reg,
+				JSONWriter: func(data []byte, code int) {
+					gotCode = code
+					require.NoError(t, json.Unmarshal(data, &gotResp))
+				},
+			})
+
+			tc.setup(controller)
+			require.NotNil(t, stale)
+
+			stale(functions.Function{UID: "stale-handler", Timeout: time.Second})
+
+			assert.Equal(t, 404, gotCode)
+			assert.Equal(t, float64(404), gotResp["status"])
+			assert.Equal(t, "unknown function 'mod:a'", gotResp["errorMessage"])
 		})
 	}
 }

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -448,6 +448,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 		"reconcile registers late available static method":              {},
 		"reconcile ignores module with no running job":                  {},
 		"reconcile does not duplicate published static method":          {},
+		"reconcile does not withdraw published static method":           {},
 		"reconcile logs empty static method ID once":                    {},
 		"public method name collision skips colliding module":           {},
 		"rejected module does not poison planned public names":          {},
@@ -603,6 +604,35 @@ func TestControllerLifecycleHooks(t *testing.T) {
 
 				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
 				assert.Equal(t, 1, availableCalls)
+
+			case "reconcile does not withdraw published static method":
+				var buf bytes.Buffer
+				available := true
+				controller = New(Options{
+					FnReg: reg,
+					API:   dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))),
+				})
+				controller.RegisterModules(collectorapi.Registry{
+					"mod": collectorapi.Creator{
+						Methods: func() []funcapi.MethodConfig {
+							return []funcapi.MethodConfig{{
+								ID:        "logs",
+								Available: func() bool { return available },
+							}}
+						},
+					},
+				})
+
+				job := newTestRuntimeJob("mod", "job1", true)
+				controller.OnJobStart(job)
+				assert.Contains(t, buf.String(), "FUNCTION GLOBAL \"mod:logs\"")
+
+				available = false
+				controller.ReconcileModuleMethods(job.ModuleName())
+
+				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+				assert.Empty(t, reg.unregisteredNames())
+				assert.NotContains(t, buf.String(), "FUNCTION_DEL")
 
 			case "reconcile logs empty static method ID once":
 				var logBuf bytes.Buffer
@@ -1015,6 +1045,102 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 				assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, reg.registeredNames())
 				assert.Len(t, controller.registry.getJobMethods("mod", "job1"), 2)
 			}
+		})
+	}
+}
+
+func TestControllerPublishedFunctionWrapperConcurrentMutation(t *testing.T) {
+	tests := map[string]struct {
+		setup  func(*Controller)
+		mutate func(*Controller)
+	}{
+		"module cleanup": {
+			setup: func(controller *Controller) {
+				controller.RegisterModules(collectorapi.Registry{
+					"mod": collectorapi.Creator{
+						Methods: func() []funcapi.MethodConfig {
+							return []funcapi.MethodConfig{{ID: "a"}}
+						},
+						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+							return &tableTestHandler{}
+						},
+					},
+				})
+				controller.OnJobStart(newTestRuntimeJob("mod", "job0", true))
+			},
+			mutate: func(controller *Controller) {
+				for i := range 100 {
+					controller.Cleanup()
+					controller.OnJobStart(newTestRuntimeJob("mod", fmt.Sprintf("job%d", i+1), true))
+				}
+			},
+		},
+		"job stop": {
+			setup: func(controller *Controller) {
+				controller.RegisterModules(collectorapi.Registry{
+					"mod": collectorapi.Creator{
+						JobMethods: func(collectorapi.RuntimeJob) []funcapi.MethodConfig {
+							return []funcapi.MethodConfig{{ID: "a"}}
+						},
+						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+							return &tableTestHandler{}
+						},
+					},
+				})
+				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+			},
+			mutate: func(controller *Controller) {
+				job := newTestRuntimeJob("mod", "job1", true)
+				for range 100 {
+					controller.OnJobStop(job)
+					controller.OnJobStart(job)
+				}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			firstHandler := make(chan func(functions.Function), 1)
+			var captureOnce sync.Once
+			reg.onRegister = func(name string, fn func(functions.Function)) {
+				if name == "mod:a" {
+					captureOnce.Do(func() { firstHandler <- fn })
+				}
+			}
+			controller := New(Options{FnReg: reg})
+			tc.setup(controller)
+
+			var handler func(functions.Function)
+			select {
+			case handler = <-firstHandler:
+			case <-time.After(2 * time.Second):
+				t.Fatal("published handler was not registered")
+			}
+
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			for range 8 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					for range 100 {
+						handler(functions.Function{UID: "wrapped-dispatch", Timeout: time.Second})
+					}
+				}()
+			}
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				tc.mutate(controller)
+			}()
+
+			close(start)
+			wg.Wait()
 		})
 	}
 }

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -65,23 +65,11 @@ func TestModuleFuncRegistry_RegisterModule(t *testing.T) {
 }
 
 func TestModuleFuncRegistry_Operations(t *testing.T) {
-	tests := map[string]struct{}{
-		"add remove job":                                                    {},
-		"job replacement increments generation":                             {},
-		"job re-add after removal increments generation":                    {},
-		"generation verification fails on wrong generation and missing job": {},
-		"get methods":          {},
-		"get job names sorted": {},
-		"operations on unregistered module are no op": {},
-		"get creator": {},
-	}
-
-	for name := range tests {
-		t.Run(name, func(t *testing.T) {
-			r := newModuleFuncRegistry()
-
-			switch name {
-			case "add remove job":
+	tests := map[string]struct {
+		run func(*testing.T, *moduleFuncRegistry)
+	}{
+		"add remove job": {
+			run: func(t *testing.T, r *moduleFuncRegistry) {
 				r.registerModule("postgres", collectorapi.Creator{})
 
 				job1 := newTestRuntimeJob("postgres", "job1", true)
@@ -104,8 +92,10 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 
 				_, ok = r.getJob("postgres", "job1")
 				assert.False(t, ok)
-
-			case "job replacement increments generation":
+			},
+		},
+		"job replacement increments generation": {
+			run: func(t *testing.T, r *moduleFuncRegistry) {
 				r.registerModule("postgres", collectorapi.Creator{})
 
 				job1 := newTestRuntimeJob("postgres", "master", true)
@@ -119,8 +109,10 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 				got, gen2 := r.getJobWithGeneration("postgres", "master")
 				assert.Equal(t, uint64(2), gen2)
 				assert.Equal(t, job2, got)
-
-			case "job re-add after removal increments generation":
+			},
+		},
+		"job re-add after removal increments generation": {
+			run: func(t *testing.T, r *moduleFuncRegistry) {
 				r.registerModule("postgres", collectorapi.Creator{})
 
 				job1 := newTestRuntimeJob("postgres", "master", true)
@@ -135,8 +127,10 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 				got, gen2 := r.getJobWithGeneration("postgres", "master")
 				assert.Equal(t, uint64(2), gen2)
 				assert.Equal(t, job2, got)
-
-			case "generation verification fails on wrong generation and missing job":
+			},
+		},
+		"generation verification fails on wrong generation and missing job": {
+			run: func(t *testing.T, r *moduleFuncRegistry) {
 				r.registerModule("postgres", collectorapi.Creator{})
 
 				job := newTestRuntimeJob("postgres", "master", true)
@@ -146,8 +140,10 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 				assert.False(t, r.verifyJobGeneration("postgres", "master", gen+1))
 				r.removeJob("postgres", "master")
 				assert.False(t, r.verifyJobGeneration("postgres", "master", gen))
-
-			case "get methods":
+			},
+		},
+		"get methods": {
+			run: func(t *testing.T, r *moduleFuncRegistry) {
 				expectedMethods := []funcapi.MethodConfig{{ID: "top-queries", Name: "Top Queries"}}
 				r.registerModule("postgres", collectorapi.Creator{
 					Methods: func() []funcapi.MethodConfig { return expectedMethods },
@@ -155,8 +151,10 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 
 				assert.Equal(t, expectedMethods, r.getMethods("postgres"))
 				assert.Nil(t, r.getMethods("nonexistent"))
-
-			case "get job names sorted":
+			},
+		},
+		"get job names sorted": {
+			run: func(t *testing.T, r *moduleFuncRegistry) {
 				r.registerModule("postgres", collectorapi.Creator{})
 
 				r.addJob("postgres", "zebra-db", newTestRuntimeJob("postgres", "zebra-db", true))
@@ -164,8 +162,10 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 				r.addJob("postgres", "middle-db", newTestRuntimeJob("postgres", "middle-db", true))
 
 				assert.Equal(t, []string{"alpha-db", "middle-db", "zebra-db"}, r.getJobNames("postgres"))
-
-			case "operations on unregistered module are no op":
+			},
+		},
+		"operations on unregistered module are no op": {
+			run: func(t *testing.T, r *moduleFuncRegistry) {
 				r.addJob("nonexistent", "job1", newTestRuntimeJob("nonexistent", "job1", true))
 				r.removeJob("nonexistent", "job1")
 
@@ -175,8 +175,10 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 
 				_, ok := r.getJob("nonexistent", "job1")
 				assert.False(t, ok)
-
-			case "get creator":
+			},
+		},
+		"get creator": {
+			run: func(t *testing.T, r *moduleFuncRegistry) {
 				creator := collectorapi.Creator{JobConfigSchema: "test-schema"}
 				r.registerModule("postgres", creator)
 
@@ -186,7 +188,14 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 
 				_, ok = r.getCreator("nonexistent")
 				assert.False(t, ok)
-			}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := newModuleFuncRegistry()
+			tc.run(t, r)
 		})
 	}
 }
@@ -275,147 +284,125 @@ func TestModuleFuncRegistry_VerifyJobGeneration_JobStopped(t *testing.T) {
 	assert.False(t, r.verifyJobGeneration("postgres", "master", gen))
 }
 
-func TestDispatchHelpers(t *testing.T) {
-	tests := map[string]struct{}{
-		"extract param values": {},
-		"build params":         {},
+func TestExtractParamValues(t *testing.T) {
+	tests := map[string]struct {
+		payload  map[string]any
+		key      string
+		expected []string
+	}{
+		"string value": {
+			payload:  map[string]any{"__job": "local"},
+			key:      "__job",
+			expected: []string{"local"},
+		},
+		"array value": {
+			payload:  map[string]any{"__sort": []any{"calls", "total_time"}},
+			key:      "__sort",
+			expected: []string{"calls", "total_time"},
+		},
+		"string array": {
+			payload:  map[string]any{"__job": []string{"local"}},
+			key:      "__job",
+			expected: []string{"local"},
+		},
+		"missing key": {
+			payload:  map[string]any{"__job": "local"},
+			key:      "__sort",
+			expected: nil,
+		},
+		"prefers selections": {
+			payload: map[string]any{
+				"__job": "root",
+				"selections": map[string]any{
+					"__job": []any{"selected"},
+				},
+			},
+			key:      "__job",
+			expected: []string{"selected"},
+		},
 	}
 
-	for name := range tests {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			switch name {
-			case "extract param values":
-				cases := map[string]struct {
-					payload  map[string]any
-					key      string
-					expected []string
-				}{
-					"string value": {
-						payload:  map[string]any{"__job": "local"},
-						key:      "__job",
-						expected: []string{"local"},
-					},
-					"array value": {
-						payload:  map[string]any{"__sort": []any{"calls", "total_time"}},
-						key:      "__sort",
-						expected: []string{"calls", "total_time"},
-					},
-					"string array": {
-						payload:  map[string]any{"__job": []string{"local"}},
-						key:      "__job",
-						expected: []string{"local"},
-					},
-					"missing key": {
-						payload:  map[string]any{"__job": "local"},
-						key:      "__sort",
-						expected: nil,
-					},
-					"prefers selections": {
-						payload: map[string]any{
-							"__job": "root",
-							"selections": map[string]any{
-								"__job": []any{"selected"},
-							},
-						},
-						key:      "__job",
-						expected: []string{"selected"},
-					},
-				}
-
-				for caseName, tc := range cases {
-					t.Run(caseName, func(t *testing.T) {
-						assert.Equal(t, tc.expected, extractParamValues(tc.payload, tc.key))
-					})
-				}
-
-			case "build params":
-				cases := map[string]struct{}{
-					"build accepted params":                        {},
-					"build required params uses select type":       {},
-					"build required params agent-wide omits __job": {},
-				}
-
-				for caseName := range cases {
-					t.Run(caseName, func(t *testing.T) {
-						switch caseName {
-						case "build accepted params":
-							sortDir := funcapi.FieldSortDescending
-							methodParams := []funcapi.ParamConfig{
-								{ID: "__sort", Selection: funcapi.ParamSelect, Options: []funcapi.ParamOption{{ID: "calls", Name: "Calls", Sort: &sortDir}}},
-								{ID: "db"},
-								{ID: "extra"},
-							}
-
-							assert.Equal(t, []string{"__job", "__sort", "db", "extra"}, buildAcceptedParams(methodParams, true))
-							assert.Equal(t, []string{"__sort", "db", "extra"}, buildAcceptedParams(methodParams, false))
-
-						case "build required params uses select type":
-							controller := New(Options{})
-							controller.RegisterModules(collectorapi.Registry{
-								"postgres": collectorapi.Creator{
-									Methods: func() []funcapi.MethodConfig {
-										return []funcapi.MethodConfig{{ID: "top-queries", Name: "Top Queries"}}
-									},
-								},
-							})
-							controller.registry.addJob("postgres", "master-db", newTestRuntimeJob("postgres", "master-db", true))
-
-							methodParams := []funcapi.ParamConfig{{
-								ID:         "__sort",
-								Name:       "Filter By",
-								Selection:  funcapi.ParamSelect,
-								UniqueView: true,
-								Options: []funcapi.ParamOption{
-									{ID: "total_time", Name: "By Total Time", Default: true},
-								},
-							}}
-							params := controller.buildRequiredParams("postgres", methodParams, true)
-
-							assert.Len(t, params, 2)
-							for _, param := range params {
-								paramType, ok := param["type"]
-								assert.True(t, ok)
-								assert.Equal(t, "select", paramType)
-								assert.Contains(t, param, "id")
-								assert.Contains(t, param, "name")
-								assert.Contains(t, param, "options")
-								assert.Contains(t, param, "unique_view")
-								uniqueView, _ := param["unique_view"].(bool)
-								assert.True(t, uniqueView)
-							}
-
-							assert.Equal(t, "__job", params[0]["id"])
-							assert.Equal(t, "__sort", params[1]["id"])
-
-						case "build required params agent-wide omits __job":
-							controller := New(Options{})
-							controller.RegisterModules(collectorapi.Registry{
-								"snmp": collectorapi.Creator{
-									Methods: func() []funcapi.MethodConfig {
-										return []funcapi.MethodConfig{{ID: "topology:snmp", AgentWide: true}}
-									},
-								},
-							})
-							controller.registry.addJob("snmp", "router", newTestRuntimeJob("snmp", "router", true))
-
-							methodParams := []funcapi.ParamConfig{{
-								ID:        "topology_view",
-								Name:      "Topology View",
-								Selection: funcapi.ParamSelect,
-								Options: []funcapi.ParamOption{
-									{ID: "l2", Name: "L2", Default: true},
-								},
-							}}
-							params := controller.buildRequiredParams("snmp", methodParams, false)
-
-							assert.Len(t, params, 1)
-							assert.Equal(t, "topology_view", params[0]["id"])
-						}
-					})
-				}
-			}
+			assert.Equal(t, tc.expected, extractParamValues(tc.payload, tc.key))
 		})
 	}
+}
+
+func TestBuildAcceptedParams(t *testing.T) {
+	sortDir := funcapi.FieldSortDescending
+	methodParams := []funcapi.ParamConfig{
+		{ID: "__sort", Selection: funcapi.ParamSelect, Options: []funcapi.ParamOption{{ID: "calls", Name: "Calls", Sort: &sortDir}}},
+		{ID: "db"},
+		{ID: "extra"},
+	}
+
+	assert.Equal(t, []string{"__job", "__sort", "db", "extra"}, buildAcceptedParams(methodParams, true))
+	assert.Equal(t, []string{"__sort", "db", "extra"}, buildAcceptedParams(methodParams, false))
+}
+
+func TestBuildRequiredParamsUsesSelectType(t *testing.T) {
+	controller := New(Options{})
+	controller.RegisterModules(collectorapi.Registry{
+		"postgres": collectorapi.Creator{
+			Methods: func() []funcapi.MethodConfig {
+				return []funcapi.MethodConfig{{ID: "top-queries", Name: "Top Queries"}}
+			},
+		},
+	})
+	controller.registry.addJob("postgres", "master-db", newTestRuntimeJob("postgres", "master-db", true))
+
+	methodParams := []funcapi.ParamConfig{{
+		ID:         "__sort",
+		Name:       "Filter By",
+		Selection:  funcapi.ParamSelect,
+		UniqueView: true,
+		Options: []funcapi.ParamOption{
+			{ID: "total_time", Name: "By Total Time", Default: true},
+		},
+	}}
+	params := controller.buildRequiredParams("postgres", methodParams, true)
+
+	assert.Len(t, params, 2)
+	for _, param := range params {
+		paramType, ok := param["type"]
+		assert.True(t, ok)
+		assert.Equal(t, "select", paramType)
+		assert.Contains(t, param, "id")
+		assert.Contains(t, param, "name")
+		assert.Contains(t, param, "options")
+		assert.Contains(t, param, "unique_view")
+		uniqueView, _ := param["unique_view"].(bool)
+		assert.True(t, uniqueView)
+	}
+
+	assert.Equal(t, "__job", params[0]["id"])
+	assert.Equal(t, "__sort", params[1]["id"])
+}
+
+func TestBuildRequiredParamsAgentWideOmitsJob(t *testing.T) {
+	controller := New(Options{})
+	controller.RegisterModules(collectorapi.Registry{
+		"snmp": collectorapi.Creator{
+			Methods: func() []funcapi.MethodConfig {
+				return []funcapi.MethodConfig{{ID: "topology:snmp", AgentWide: true}}
+			},
+		},
+	})
+	controller.registry.addJob("snmp", "router", newTestRuntimeJob("snmp", "router", true))
+
+	methodParams := []funcapi.ParamConfig{{
+		ID:        "topology_view",
+		Name:      "Topology View",
+		Selection: funcapi.ParamSelect,
+		Options: []funcapi.ParamOption{
+			{ID: "l2", Name: "L2", Default: true},
+		},
+	}}
+	params := controller.buildRequiredParams("snmp", methodParams, false)
+
+	assert.Len(t, params, 1)
+	assert.Equal(t, "topology_view", params[0]["id"])
 }
 
 func TestParseArgsParams(t *testing.T) {
@@ -439,380 +426,380 @@ func TestParseArgsParams(t *testing.T) {
 }
 
 func TestControllerLifecycleHooks(t *testing.T) {
-	tests := map[string]struct{}{
-		"register modules does not register static methods yet":         {},
-		"register modules registers available agent-wide methods":       {},
-		"first job start registers static methods once":                 {},
-		"availability-gated static method registers when available":     {},
-		"availability-gated agent-wide method registers when available": {},
-		"reconcile registers late available static method":              {},
-		"reconcile ignores module with no running job":                  {},
-		"reconcile does not duplicate published static method":          {},
-		"reconcile does not withdraw published static method":           {},
-		"reconcile logs empty static method ID once":                    {},
-		"public method name collision skips colliding module":           {},
-		"rejected module does not poison planned public names":          {},
-		"topology methods register direct alias":                        {},
-		"job stop unregisters job methods":                              {},
-		"cleanup unregisters static methods":                            {},
-		"cleanup ignores unavailable static methods":                    {},
-		"cleanup with api configured still unregisters static methods":  {},
-		"api registration honors method tags":                           {},
+	newController := func() (*Controller, *testFunctionRegistry) {
+		reg := newTestFunctionRegistry()
+		return New(Options{FnReg: reg}), reg
 	}
 
-	for name := range tests {
-		t.Run(name, func(t *testing.T) {
+	tests := map[string]func(*testing.T){
+		"register modules does not register static methods yet": func(t *testing.T) {
+			controller, reg := newController()
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+				},
+			})
+
+			assert.Empty(t, reg.registeredNames())
+		},
+		"register modules registers available agent-wide methods": func(t *testing.T) {
+			controller, reg := newController()
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{ID: "logs", AgentWide: true}}
+					},
+				},
+			})
+
+			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+		},
+		"first job start registers static methods once": func(t *testing.T) {
+			controller, reg := newController()
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+				},
+			})
+
+			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+			controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
+
+			assert.Equal(t, []string{"mod:a"}, reg.registeredNames())
+		},
+		"availability-gated static method registers when available": func(t *testing.T) {
+			controller, reg := newController()
+			available := false
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:        "logs",
+							Available: func() bool { return available },
+						}}
+					},
+				},
+			})
+
+			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+			assert.Empty(t, reg.registeredNames())
+
+			available = true
+			controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
+			controller.OnJobStart(newTestRuntimeJob("mod", "job3", true))
+
+			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+		},
+		"availability-gated agent-wide method registers when available": func(t *testing.T) {
+			controller, reg := newController()
+			available := false
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:        "logs",
+							AgentWide: true,
+							Available: func() bool { return available },
+						}}
+					},
+				},
+			})
+
+			assert.Empty(t, reg.registeredNames())
+
+			available = true
+			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+			controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
+
+			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+		},
+		"reconcile registers late available static method": func(t *testing.T) {
+			controller, reg := newController()
+			available := false
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:        "logs",
+							Available: func() bool { return available },
+						}}
+					},
+				},
+			})
+
+			job := newTestRuntimeJob("mod", "job1", true)
+			controller.OnJobStart(job)
+			assert.Empty(t, reg.registeredNames())
+
+			available = true
+			controller.ReconcileModuleMethods(job.ModuleName())
+
+			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+		},
+		"reconcile ignores module with no running job": func(t *testing.T) {
+			controller, reg := newController()
+			available := true
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:        "logs",
+							Available: func() bool { return available },
+						}}
+					},
+				},
+			})
+
+			controller.ReconcileModuleMethods("mod")
+
+			assert.Empty(t, reg.registeredNames())
+		},
+		"reconcile does not duplicate published static method": func(t *testing.T) {
+			controller, reg := newController()
+			availableCalls := 0
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID: "logs",
+							Available: func() bool {
+								availableCalls++
+								return true
+							},
+						}}
+					},
+				},
+			})
+
+			job := newTestRuntimeJob("mod", "job1", true)
+			controller.OnJobStart(job)
+			controller.ReconcileModuleMethods(job.ModuleName())
+			controller.ReconcileModuleMethods(job.ModuleName())
+
+			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+			assert.Equal(t, 1, availableCalls)
+		},
+		"reconcile does not withdraw published static method": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
-			controller := New(Options{FnReg: reg})
-
-			switch name {
-			case "register modules does not register static methods yet":
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+			var buf bytes.Buffer
+			available := true
+			controller := New(Options{
+				FnReg: reg,
+				API:   dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))),
+			})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:        "logs",
+							Available: func() bool { return available },
+						}}
 					},
-				})
+				},
+			})
 
-				assert.Empty(t, reg.registeredNames())
+			job := newTestRuntimeJob("mod", "job1", true)
+			controller.OnJobStart(job)
+			assert.Contains(t, buf.String(), "FUNCTION GLOBAL \"mod:logs\"")
 
-			case "register modules registers available agent-wide methods":
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{ID: "logs", AgentWide: true}}
-						},
+			available = false
+			controller.ReconcileModuleMethods(job.ModuleName())
+
+			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+			assert.Empty(t, reg.unregisteredNames())
+			assert.NotContains(t, buf.String(), "FUNCTION_DEL")
+		},
+		"reconcile logs empty static method ID once": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			var logBuf bytes.Buffer
+			controller := New(Options{
+				FnReg:  reg,
+				Logger: logger.NewWithWriter(&logBuf),
+			})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{Name: "invalid"}}
 					},
-				})
+				},
+			})
 
-				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+			job1 := newTestRuntimeJob("mod", "job1", true)
+			job2 := newTestRuntimeJob("mod", "job2", true)
+			controller.OnJobStart(job1)
+			controller.ReconcileModuleMethods(job1.ModuleName())
+			controller.OnJobStart(job2)
+			controller.ReconcileModuleMethods(job2.ModuleName())
 
-			case "first job start registers static methods once":
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+			assert.Equal(t, 1, strings.Count(logBuf.String(), "empty method ID"))
+		},
+		"public method name collision skips colliding module": func(t *testing.T) {
+			controller, reg := newController()
+			controller.RegisterModules(collectorapi.Registry{
+				"aaa": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{ID: "logs", FunctionName: "shared:logs"}}
 					},
-				})
-
-				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
-				controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
-
-				assert.Equal(t, []string{"mod:a"}, reg.registeredNames())
-
-			case "availability-gated static method registers when available":
-				available := false
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{
-								ID:        "logs",
-								Available: func() bool { return available },
-							}}
-						},
+				},
+				"bbb": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{ID: "logs", FunctionName: "shared:logs"}}
 					},
-				})
+				},
+			})
 
-				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
-				assert.Empty(t, reg.registeredNames())
+			controller.OnJobStart(newTestRuntimeJob("aaa", "job1", true))
+			controller.OnJobStart(newTestRuntimeJob("bbb", "job1", true))
 
-				available = true
-				controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
-				controller.OnJobStart(newTestRuntimeJob("mod", "job3", true))
-
-				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
-
-			case "availability-gated agent-wide method registers when available":
-				available := false
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{
-								ID:        "logs",
-								AgentWide: true,
-								Available: func() bool { return available },
-							}}
-						},
+			assert.Equal(t, []string{"shared:logs"}, reg.registeredNames())
+			assert.True(t, controller.registry.isModuleRegistered("aaa"))
+			assert.False(t, controller.registry.isModuleRegistered("bbb"))
+		},
+		"rejected module does not poison planned public names": func(t *testing.T) {
+			controller, reg := newController()
+			controller.RegisterModules(collectorapi.Registry{
+				"aaa": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{
+							{ID: "first", FunctionName: "later:logs"},
+							{ID: "second", FunctionName: "later:logs"},
+						}
 					},
-				})
-
-				assert.Empty(t, reg.registeredNames())
-
-				available = true
-				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
-				controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
-
-				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
-
-			case "reconcile registers late available static method":
-				available := false
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{
-								ID:        "logs",
-								Available: func() bool { return available },
-							}}
-						},
+				},
+				"ccc": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{ID: "logs", FunctionName: "later:logs"}}
 					},
-				})
+				},
+			})
 
-				job := newTestRuntimeJob("mod", "job1", true)
-				controller.OnJobStart(job)
-				assert.Empty(t, reg.registeredNames())
+			controller.OnJobStart(newTestRuntimeJob("aaa", "job1", true))
+			controller.OnJobStart(newTestRuntimeJob("ccc", "job1", true))
 
-				available = true
-				controller.ReconcileModuleMethods(job.ModuleName())
-
-				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
-
-			case "reconcile ignores module with no running job":
-				available := true
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{
-								ID:        "logs",
-								Available: func() bool { return available },
-							}}
-						},
+			assert.False(t, controller.registry.isModuleRegistered("aaa"))
+			assert.True(t, controller.registry.isModuleRegistered("ccc"))
+			assert.Equal(t, []string{"later:logs"}, reg.registeredNames())
+		},
+		"topology methods register direct alias": func(t *testing.T) {
+			controller, reg := newController()
+			controller.RegisterModules(collectorapi.Registry{
+				"snmp_topology": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:           "topology:snmp",
+							FunctionName: "snmp:topology:snmp",
+							Aliases:      []string{"topology:snmp"},
+							AgentWide:    true,
+						}}
 					},
-				})
+				},
+			})
 
-				controller.ReconcileModuleMethods("mod")
+			assert.ElementsMatch(t, []string{"snmp:topology:snmp", "topology:snmp"}, reg.registeredNames())
 
-				assert.Empty(t, reg.registeredNames())
+			controller.Cleanup()
 
-			case "reconcile does not duplicate published static method":
-				availableCalls := 0
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{
-								ID: "logs",
-								Available: func() bool {
-									availableCalls++
-									return true
-								},
-							}}
-						},
+			assert.ElementsMatch(t, []string{"snmp:topology:snmp", "topology:snmp"}, reg.unregisteredNames())
+		},
+		"job stop unregisters job methods": func(t *testing.T) {
+			controller, reg := newController()
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{ID: "job-method"}}
 					},
-				})
+				},
+			})
 
-				job := newTestRuntimeJob("mod", "job1", true)
-				controller.OnJobStart(job)
-				controller.ReconcileModuleMethods(job.ModuleName())
-				controller.ReconcileModuleMethods(job.ModuleName())
+			job := newTestRuntimeJob("mod", "job1", true)
+			controller.OnJobStart(job)
+			controller.OnJobStop(job)
 
-				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
-				assert.Equal(t, 1, availableCalls)
+			assert.Contains(t, reg.unregisteredNames(), "mod:job-method")
+		},
+		"cleanup unregisters static methods": func(t *testing.T) {
+			controller, reg := newController()
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+				},
+			})
 
-			case "reconcile does not withdraw published static method":
-				var buf bytes.Buffer
-				available := true
-				controller = New(Options{
-					FnReg: reg,
-					API:   dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))),
-				})
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{
-								ID:        "logs",
-								Available: func() bool { return available },
-							}}
-						},
+			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+			controller.Cleanup()
+
+			assert.Contains(t, reg.unregisteredNames(), "mod:a")
+		},
+		"cleanup ignores unavailable static methods": func(t *testing.T) {
+			controller, reg := newController()
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:        "logs",
+							Available: func() bool { return false },
+						}}
 					},
-				})
+				},
+			})
 
-				job := newTestRuntimeJob("mod", "job1", true)
-				controller.OnJobStart(job)
-				assert.Contains(t, buf.String(), "FUNCTION GLOBAL \"mod:logs\"")
+			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+			controller.Cleanup()
 
-				available = false
-				controller.ReconcileModuleMethods(job.ModuleName())
+			assert.Empty(t, reg.registeredNames())
+			assert.Empty(t, reg.unregisteredNames())
+		},
+		"cleanup with api configured still unregisters static methods": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			var buf bytes.Buffer
+			controller := New(Options{
+				FnReg: reg,
+				API:   dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))),
+			})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+				},
+			})
 
-				assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
-				assert.Empty(t, reg.unregisteredNames())
-				assert.NotContains(t, buf.String(), "FUNCTION_DEL")
+			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+			assert.Contains(t, buf.String(), "FUNCTION GLOBAL \"mod:a\"")
 
-			case "reconcile logs empty static method ID once":
-				var logBuf bytes.Buffer
-				controller = New(Options{
-					FnReg:  reg,
-					Logger: logger.NewWithWriter(&logBuf),
-				})
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{Name: "invalid"}}
-						},
+			controller.Cleanup()
+
+			assert.Contains(t, reg.unregisteredNames(), "mod:a")
+		},
+		"api registration honors method tags": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			var buf bytes.Buffer
+			controller := New(Options{
+				FnReg: reg,
+				API:   dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))),
+			})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:           "logs",
+							FunctionName: "snmp:traps",
+							Tags:         "logs",
+						}}
 					},
-				})
+				},
+			})
 
-				job1 := newTestRuntimeJob("mod", "job1", true)
-				job2 := newTestRuntimeJob("mod", "job2", true)
-				controller.OnJobStart(job1)
-				controller.ReconcileModuleMethods(job1.ModuleName())
-				controller.OnJobStart(job2)
-				controller.ReconcileModuleMethods(job2.ModuleName())
+			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
 
-				assert.Equal(t, 1, strings.Count(logBuf.String(), "empty method ID"))
+			assert.Contains(t, reg.registeredNames(), "snmp:traps")
+			assert.NotContains(t, reg.registeredNames(), "mod:logs")
+			assert.Contains(t, buf.String(), "FUNCTION GLOBAL \"snmp:traps\"")
+			assert.NotContains(t, buf.String(), "FUNCTION GLOBAL \"mod:logs\"")
+			assert.Contains(t, buf.String(), "\"logs\" 0x0000")
+		},
+	}
 
-			case "public method name collision skips colliding module":
-				controller.RegisterModules(collectorapi.Registry{
-					"aaa": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{ID: "logs", FunctionName: "shared:logs"}}
-						},
-					},
-					"bbb": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{ID: "logs", FunctionName: "shared:logs"}}
-						},
-					},
-				})
-
-				controller.OnJobStart(newTestRuntimeJob("aaa", "job1", true))
-				controller.OnJobStart(newTestRuntimeJob("bbb", "job1", true))
-
-				assert.Equal(t, []string{"shared:logs"}, reg.registeredNames())
-				assert.True(t, controller.registry.isModuleRegistered("aaa"))
-				assert.False(t, controller.registry.isModuleRegistered("bbb"))
-
-			case "rejected module does not poison planned public names":
-				controller.RegisterModules(collectorapi.Registry{
-					"aaa": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{
-								{ID: "first", FunctionName: "later:logs"},
-								{ID: "second", FunctionName: "later:logs"},
-							}
-						},
-					},
-					"ccc": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{ID: "logs", FunctionName: "later:logs"}}
-						},
-					},
-				})
-
-				controller.OnJobStart(newTestRuntimeJob("aaa", "job1", true))
-				controller.OnJobStart(newTestRuntimeJob("ccc", "job1", true))
-
-				assert.False(t, controller.registry.isModuleRegistered("aaa"))
-				assert.True(t, controller.registry.isModuleRegistered("ccc"))
-				assert.Equal(t, []string{"later:logs"}, reg.registeredNames())
-
-			case "topology methods register direct alias":
-				controller.RegisterModules(collectorapi.Registry{
-					"snmp_topology": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{
-								ID:           "topology:snmp",
-								FunctionName: "snmp:topology:snmp",
-								Aliases:      []string{"topology:snmp"},
-								AgentWide:    true,
-							}}
-						},
-					},
-				})
-
-				assert.ElementsMatch(t, []string{"snmp:topology:snmp", "topology:snmp"}, reg.registeredNames())
-
-				controller.Cleanup()
-
-				assert.ElementsMatch(t, []string{"snmp:topology:snmp", "topology:snmp"}, reg.unregisteredNames())
-
-			case "job stop unregisters job methods":
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{ID: "job-method"}}
-						},
-					},
-				})
-
-				job := newTestRuntimeJob("mod", "job1", true)
-				controller.OnJobStart(job)
-				controller.OnJobStop(job)
-
-				assert.Contains(t, reg.unregisteredNames(), "mod:job-method")
-
-			case "cleanup unregisters static methods":
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
-					},
-				})
-
-				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
-				controller.Cleanup()
-
-				assert.Contains(t, reg.unregisteredNames(), "mod:a")
-
-			case "cleanup ignores unavailable static methods":
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{
-								ID:        "logs",
-								Available: func() bool { return false },
-							}}
-						},
-					},
-				})
-
-				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
-				controller.Cleanup()
-
-				assert.Empty(t, reg.registeredNames())
-				assert.Empty(t, reg.unregisteredNames())
-
-			case "cleanup with api configured still unregisters static methods":
-				var buf bytes.Buffer
-				controller = New(Options{
-					FnReg: reg,
-					API:   dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))),
-				})
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
-					},
-				})
-
-				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
-				assert.Contains(t, buf.String(), "FUNCTION GLOBAL \"mod:a\"")
-
-				controller.Cleanup()
-
-				assert.Contains(t, reg.unregisteredNames(), "mod:a")
-
-			case "api registration honors method tags":
-				var buf bytes.Buffer
-				controller = New(Options{
-					FnReg: reg,
-					API:   dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))),
-				})
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{
-								ID:           "logs",
-								FunctionName: "snmp:traps",
-								Tags:         "logs",
-							}}
-						},
-					},
-				})
-
-				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
-
-				assert.Contains(t, reg.registeredNames(), "snmp:traps")
-				assert.NotContains(t, reg.registeredNames(), "mod:logs")
-				assert.Contains(t, buf.String(), "FUNCTION GLOBAL \"snmp:traps\"")
-				assert.NotContains(t, buf.String(), "FUNCTION GLOBAL \"mod:logs\"")
-				assert.Contains(t, buf.String(), "\"logs\" 0x0000")
-			}
-		})
+	for name, run := range tests {
+		t.Run(name, run)
 	}
 }
 
@@ -957,95 +944,95 @@ func TestControllerStaticPublicationDoesNotHoldLockDuringFunctionGlobal(t *testi
 }
 
 func TestControllerRegisterJobMethods(t *testing.T) {
-	tests := map[string]struct{}{
-		"fail fast on collision with static method":          {},
-		"fail fast on collision with other job":              {},
-		"fail fast on duplicate within batch":                {},
-		"fail fast on job method public names":               {},
-		"registry is populated before handlers are callable": {},
-		"success commits all methods":                        {},
-	}
-
-	for name := range tests {
-		t.Run(name, func(t *testing.T) {
+	tests := map[string]func(*testing.T){
+		"fail fast on collision with static method": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
 			controller := New(Options{FnReg: reg})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "dup"}} },
+				},
+			})
 
-			switch name {
-			case "fail fast on collision with static method":
-				controller.RegisterModules(collectorapi.Registry{
-					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "dup"}} },
-					},
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "dup"}})
+
+			assert.Empty(t, reg.registeredNames())
+			assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
+		},
+		"fail fast on collision with other job": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			controller := New(Options{FnReg: reg})
+			controller.registry.registerModule("mod", collectorapi.Creator{})
+			controller.registry.registerJobMethods("mod", "jobA", []funcapi.MethodConfig{{ID: "dup"}})
+
+			controller.registerJobMethods(newTestRuntimeJob("mod", "jobB", true), []funcapi.MethodConfig{{ID: "dup"}})
+
+			assert.Empty(t, reg.registeredNames())
+			assert.Empty(t, controller.registry.getJobMethods("mod", "jobB"))
+		},
+		"fail fast on duplicate within batch": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			controller := New(Options{FnReg: reg})
+			controller.registry.registerModule("mod", collectorapi.Creator{})
+
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "dup"}, {ID: "dup"}})
+
+			assert.Empty(t, reg.registeredNames())
+			assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
+		},
+		"fail fast on job method public names": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			controller := New(Options{FnReg: reg})
+			controller.registry.registerModule("mod", collectorapi.Creator{})
+
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{
+				{ID: "logs", FunctionName: "public:logs", Aliases: []string{"public:alias"}},
+			})
+
+			assert.Empty(t, reg.registeredNames())
+			assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
+		},
+		"registry is populated before handlers are callable": func(t *testing.T) {
+			var gotCode int
+			var gotResp map[string]any
+
+			reg := newTestFunctionRegistry()
+			reg.onRegister = func(_ string, fn func(functions.Function)) {
+				fn(functions.Function{
+					UID:  "during-register",
+					Args: []string{"info"},
 				})
-
-				controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "dup"}})
-
-				assert.Empty(t, reg.registeredNames())
-				assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
-
-			case "fail fast on collision with other job":
-				controller.registry.registerModule("mod", collectorapi.Creator{})
-				controller.registry.registerJobMethods("mod", "jobA", []funcapi.MethodConfig{{ID: "dup"}})
-
-				controller.registerJobMethods(newTestRuntimeJob("mod", "jobB", true), []funcapi.MethodConfig{{ID: "dup"}})
-
-				assert.Empty(t, reg.registeredNames())
-				assert.Empty(t, controller.registry.getJobMethods("mod", "jobB"))
-
-			case "fail fast on duplicate within batch":
-				controller.registry.registerModule("mod", collectorapi.Creator{})
-
-				controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "dup"}, {ID: "dup"}})
-
-				assert.Empty(t, reg.registeredNames())
-				assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
-
-			case "fail fast on job method public names":
-				controller.registry.registerModule("mod", collectorapi.Creator{})
-
-				controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{
-					{ID: "logs", FunctionName: "public:logs", Aliases: []string{"public:alias"}},
-				})
-
-				assert.Empty(t, reg.registeredNames())
-				assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
-
-			case "registry is populated before handlers are callable":
-				var gotCode int
-				var gotResp map[string]any
-
-				reg.onRegister = func(_ string, fn func(functions.Function)) {
-					fn(functions.Function{
-						UID:  "during-register",
-						Args: []string{"info"},
-					})
-				}
-				controller = New(Options{
-					FnReg: reg,
-					JSONWriter: func(data []byte, code int) {
-						gotCode = code
-						require.NoError(t, json.Unmarshal(data, &gotResp))
-					},
-				})
-				controller.registry.registerModule("mod", collectorapi.Creator{})
-
-				controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "a", Help: "job method help"}})
-
-				assert.Equal(t, 200, gotCode)
-				assert.Equal(t, float64(200), gotResp["status"])
-				assert.Equal(t, "job method help", gotResp["help"])
-				assert.Len(t, controller.registry.getJobMethods("mod", "job1"), 1)
-
-			case "success commits all methods":
-				controller.registry.registerModule("mod", collectorapi.Creator{})
-
-				controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "a"}, {ID: "b"}})
-
-				assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, reg.registeredNames())
-				assert.Len(t, controller.registry.getJobMethods("mod", "job1"), 2)
 			}
-		})
+			controller := New(Options{
+				FnReg: reg,
+				JSONWriter: func(data []byte, code int) {
+					gotCode = code
+					require.NoError(t, json.Unmarshal(data, &gotResp))
+				},
+			})
+			controller.registry.registerModule("mod", collectorapi.Creator{})
+
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "a", Help: "job method help"}})
+
+			assert.Equal(t, 200, gotCode)
+			assert.Equal(t, float64(200), gotResp["status"])
+			assert.Equal(t, "job method help", gotResp["help"])
+			assert.Len(t, controller.registry.getJobMethods("mod", "job1"), 1)
+		},
+		"success commits all methods": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			controller := New(Options{FnReg: reg})
+			controller.registry.registerModule("mod", collectorapi.Creator{})
+
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "a"}, {ID: "b"}})
+
+			assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, reg.registeredNames())
+			assert.Len(t, controller.registry.getJobMethods("mod", "job1"), 2)
+		},
+	}
+
+	for name, run := range tests {
+		t.Run(name, run)
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -1109,22 +1109,18 @@ func TestControllerPublishedFunctionWrapperConcurrentMutation(t *testing.T) {
 			start := make(chan struct{})
 			var wg sync.WaitGroup
 			for range 8 {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					<-start
 					for range 100 {
 						handler(functions.Function{UID: "wrapped-dispatch", Timeout: time.Second})
 					}
-				}()
+				})
 			}
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				<-start
 				tc.mutate(controller)
-			}()
+			})
 
 			close(start)
 			wg.Wait()

--- a/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
@@ -52,6 +52,12 @@ func (c *Controller) ExecuteFunction(functionName string, fn functions.Function)
 	c.makeMethodFuncHandler(moduleName, methodID)(c.baseContext(), fn)
 }
 
+func (c *Controller) publishedFunctionGenerationMatches(functionName string, generation uint64) bool {
+	c.publishedMu.Lock()
+	defer c.publishedMu.Unlock()
+	return c.publishedFns.generationMatches(functionName, generation)
+}
+
 func (c *Controller) executeMethodRequest(parent context.Context, in methodExecutionInput) {
 	if parent == nil {
 		parent = c.baseContext()
@@ -144,6 +150,17 @@ func (c *Controller) executeMethodRequest(parent context.Context, in methodExecu
 	updateEvery := max(in.methodCfg.UpdateEvery, 1)
 
 	in.respond(dataResp, methodParams, updateEvery)
+}
+
+func (c *Controller) makePublishedMethodFuncHandler(functionName string, generation uint64, moduleName, methodID string) functions.Handler {
+	handler := c.makeMethodFuncHandler(moduleName, methodID)
+	return func(ctx context.Context, fn functions.Function) {
+		if !c.publishedFunctionGenerationMatches(functionName, generation) {
+			c.respondError(fn, 404, "unknown function '%s'", functionName)
+			return
+		}
+		handler(ctx, fn)
+	}
 }
 
 func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) functions.Handler {
@@ -511,6 +528,17 @@ func buildAcceptedParams(methodParams []funcapi.ParamConfig, includeJobParam boo
 
 func methodRequiresJobParam(cfg *funcapi.MethodConfig) bool {
 	return cfg == nil || !cfg.AgentWide
+}
+
+func (c *Controller) makePublishedJobMethodFuncHandler(functionName string, generation uint64, moduleName, jobName, methodID string) functions.Handler {
+	handler := c.makeJobMethodFuncHandler(moduleName, jobName, methodID)
+	return func(ctx context.Context, fn functions.Function) {
+		if !c.publishedFunctionGenerationMatches(functionName, generation) {
+			c.respondError(fn, 404, "unknown function '%s'", functionName)
+			return
+		}
+		handler(ctx, fn)
+	}
 }
 
 func (c *Controller) makeJobMethodFuncHandler(moduleName, jobName, methodID string) functions.Handler {

--- a/src/go/plugin/agent/jobmgr/funcctl/publication.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/publication.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package funcctl
+
+type publishedFunctionKind uint8
+
+const (
+	publishedFunctionModuleMethod publishedFunctionKind = iota + 1
+	publishedFunctionJobMethod
+)
+
+type publishedFunctionOwner struct {
+	kind       publishedFunctionKind
+	moduleName string
+	jobName    string
+	methodID   string
+}
+
+func moduleMethodOwner(moduleName, methodID string) publishedFunctionOwner {
+	return publishedFunctionOwner{
+		kind:       publishedFunctionModuleMethod,
+		moduleName: moduleName,
+		methodID:   methodID,
+	}
+}
+
+func jobMethodOwner(moduleName, jobName, methodID string) publishedFunctionOwner {
+	return publishedFunctionOwner{
+		kind:       publishedFunctionJobMethod,
+		moduleName: moduleName,
+		jobName:    jobName,
+		methodID:   methodID,
+	}
+}
+
+type publishedFunctionRecord struct {
+	owner      publishedFunctionOwner
+	generation uint64
+}
+
+type publishedFunctionStore struct {
+	nextGeneration uint64
+	byName         map[string]publishedFunctionRecord
+}
+
+func newPublishedFunctionStore() *publishedFunctionStore {
+	return &publishedFunctionStore{
+		byName: make(map[string]publishedFunctionRecord),
+	}
+}
+
+func (s *publishedFunctionStore) has(name string) bool {
+	_, ok := s.byName[name]
+	return ok
+}
+
+func (s *publishedFunctionStore) all(names []string) bool {
+	if len(names) == 0 {
+		return false
+	}
+	for _, name := range names {
+		if !s.has(name) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *publishedFunctionStore) add(name string, owner publishedFunctionOwner) (publishedFunctionRecord, bool) {
+	if existing, ok := s.byName[name]; ok {
+		return existing, false
+	}
+	s.nextGeneration++
+	record := publishedFunctionRecord{
+		owner:      owner,
+		generation: s.nextGeneration,
+	}
+	s.byName[name] = record
+	return record, true
+}
+
+func (s *publishedFunctionStore) generationMatches(name string, generation uint64) bool {
+	record, ok := s.byName[name]
+	return ok && record.generation == generation
+}
+
+func (s *publishedFunctionStore) removeOwner(owner publishedFunctionOwner) []string {
+	var names []string
+	for name, record := range s.byName {
+		if record.owner == owner {
+			names = append(names, name)
+			delete(s.byName, name)
+		}
+	}
+	return names
+}
+
+func (s *publishedFunctionStore) removeKind(kind publishedFunctionKind) []string {
+	var names []string
+	for name, record := range s.byName {
+		if record.owner.kind == kind {
+			names = append(names, name)
+			delete(s.byName, name)
+		}
+	}
+	return names
+}

--- a/src/go/plugin/agent/jobmgr/funcctl/registry.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/registry.go
@@ -50,6 +50,12 @@ func (r *moduleFuncRegistry) registerModuleWithMethods(name string, creator coll
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	affectedRoutes := make(map[string]struct{})
+	if existing, ok := r.modules[name]; ok {
+		collectModuleMethodFunctionNames(name, existing.methods, affectedRoutes)
+	}
+	collectModuleMethodFunctionNames(name, methods, affectedRoutes)
+
 	r.modules[name] = &moduleFunc{
 		creator:     creator,
 		methods:     methods,
@@ -57,7 +63,7 @@ func (r *moduleFuncRegistry) registerModuleWithMethods(name string, creator coll
 		jobs:        make(map[string]*jobEntry),
 		jobMethods:  make(map[string][]funcapi.MethodConfig),
 	}
-	r.rebuildMethodRoutesLocked()
+	r.refreshModuleMethodRoutesLocked(affectedRoutes)
 }
 
 func indexMethods(methods []funcapi.MethodConfig) map[string]funcapi.MethodConfig {
@@ -320,8 +326,25 @@ func (r *moduleFuncRegistry) findMethodCollision(moduleName, jobName, methodID s
 	return "", false
 }
 
-func (r *moduleFuncRegistry) rebuildMethodRoutesLocked() {
-	r.methodRoutes = make(map[string]methodRoute)
+func collectModuleMethodFunctionNames(moduleName string, methods []funcapi.MethodConfig, out map[string]struct{}) {
+	for _, method := range methods {
+		if method.ID == "" {
+			continue
+		}
+		for _, functionName := range funcapi.MethodFunctionNames(moduleName, method) {
+			out[functionName] = struct{}{}
+		}
+	}
+}
+
+func (r *moduleFuncRegistry) refreshModuleMethodRoutesLocked(functionNames map[string]struct{}) {
+	if len(functionNames) == 0 {
+		return
+	}
+	for functionName := range functionNames {
+		delete(r.methodRoutes, functionName)
+	}
+
 	moduleNames := make([]string, 0, len(r.modules))
 	for moduleName := range r.modules {
 		moduleNames = append(moduleNames, moduleName)
@@ -336,6 +359,9 @@ func (r *moduleFuncRegistry) rebuildMethodRoutesLocked() {
 			}
 			route := methodRoute{moduleName: moduleName, methodID: method.ID}
 			for _, functionName := range funcapi.MethodFunctionNames(moduleName, method) {
+				if _, affected := functionNames[functionName]; !affected {
+					continue
+				}
 				if _, exists := r.methodRoutes[functionName]; exists {
 					continue
 				}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce function publication state with generation tracking for module and job methods to prevent stale handlers and reduce route rebuilds. Handlers are wrapped with generation checks, and unpublishing is owner-aware to correctly remove aliases on job stop/cleanup.

- **Refactors**
  - Replaced `staticMethodsSeen` with `publishedFunctionStore` that tracks owner and generation, guarded by `publishedMu`.
  - Added generation-validated wrappers for module and job method handlers; register locally first and call API once per function; centralized publish collection.
  - Registry now refreshes only affected function names when a module’s methods change.
  - Added unpublish helpers to remove by owner or kind so aliases are cleaned up together.

- **Bug Fixes**
  - Stale function handlers now return 404 "unknown function" after cleanup or job stop; handlers remain safe under concurrent cleanup/job stop.
  - Prevented duplicate publishes via store and generation checks.
  - Reconcile no longer withdraws already-published static methods when availability flips to false; only newly available methods are published.

<sup>Written for commit 700759d5982853588d23ba0cd19abc5ca275094c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

