### PR TITLE
Update systemd journal SDK to 0.7.5

### DIFF
--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -4284,9 +4284,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-common"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c793a2efc3f08d25734328a7842b011b76418e68215d3071c6e7e09405fe954"
+checksum = "6a1a06831d9193c3f1f6c816b16a24a5d0884d6303bbb00a3a45a9d911dba716"
 dependencies = [
  "libc",
  "rustc-hash",
@@ -4297,9 +4297,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-core"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7685a031daa4c1d898a42181eeb867c352a4b89fb87f60b0b6edfbd01f563029"
+checksum = "719a41434e7b67c08d174c8fc283d942cb76eb2bfb9f02ce6449e6660ebce78c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4338,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-engine"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bcd2f740511ff65ce00522634b753bda145da8e02a5c2d24959d75761b3684b"
+checksum = "5147f326d303fe9180befd2e9f9787540a15f1a09c5e0b30b0da488ac6b41e9f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4364,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-host"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad4e15504a664b600e0f5b677661e4b1e64bfaa7da30012cfb47801bd195891c"
+checksum = "4219ce3751d1f434583ef5a0c70e202947ed7dccf91a140d237ce18b539b0633"
 dependencies = [
  "libc",
  "systemd-journal-sdk-common",
@@ -4376,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-index"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfedfd451bde5c0b48d587427a0e433b377f078bfebcffcc861a3aab7c3fb434"
+checksum = "6445f0ffc8d2e2333bb1ce3ce2657cb73a6586151c4fa59b4ecc2cbd5499bb5b"
 dependencies = [
  "regex",
  "roaring 0.11.4",
@@ -4393,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-log-writer"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9569023e702fd76c0031b4c8d11f3960c4a64cc49fb56cc088bbd35ef8ed64ba"
+checksum = "4055a029baad15e17d8f0b30577ef82011ff53364e1bb58e8fc69f4290e058e2"
 dependencies = [
  "itoa",
  "systemd-journal-sdk-common",
@@ -4408,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-registry"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99d983ecab9e2589deffceb481ee16cdedefcdac176fc2234187109415f0911"
+checksum = "063dd2bd800db0f5165f11d6a65dc5ee30884acc3191771a00cbabf0990edd5d"
 dependencies = [
  "notify",
  "parking_lot",

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -24,13 +24,13 @@ clap = { workspace = true, features = ["derive"] }
 # crates). Aliased to the historical names so call sites keep `use journal_*`.
 # Scope: netflow-plugin only; log-viewer/otel still use the vendored workspace
 # crates (tracked as a follow-up). One source of journal-core in this binary.
-journal-common = { package = "systemd-journal-sdk-common", version = "0.7.4" }
-journal-core = { package = "systemd-journal-sdk-core", version = "0.7.4" }
-journal-engine = { package = "systemd-journal-sdk-engine", version = "0.7.4" }
-journal-host = { package = "systemd-journal-sdk-host", version = "0.7.4" }
-journal-index = { package = "systemd-journal-sdk-index", version = "0.7.4" }
-journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.7.4" }
-journal-registry = { package = "systemd-journal-sdk-registry", version = "0.7.4" }
+journal-common = { package = "systemd-journal-sdk-common", version = "0.7.5" }
+journal-core = { package = "systemd-journal-sdk-core", version = "0.7.5" }
+journal-engine = { package = "systemd-journal-sdk-engine", version = "0.7.5" }
+journal-host = { package = "systemd-journal-sdk-host", version = "0.7.5" }
+journal-index = { package = "systemd-journal-sdk-index", version = "0.7.5" }
+journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.7.5" }
+journal-registry = { package = "systemd-journal-sdk-registry", version = "0.7.5" }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 hashbrown = { workspace = true }

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/microsoft/go-mssqldb v1.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0
-	github.com/netdata/systemd-journal-sdk/go v0.7.4
+	github.com/netdata/systemd-journal-sdk/go v0.7.5
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	go.mongodb.org/mongo-driver/v2 v2.7.0

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -322,8 +322,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netdata/systemd-journal-sdk/go v0.7.4 h1:6YHfPZfmwh97CYbOyi141Sq6hwRMN7I7YIIhie+5h7g=
-github.com/netdata/systemd-journal-sdk/go v0.7.4/go.mod h1:A03ryRKYt5zrAhxx81HTbnwZ1W8uLq13N1VWXJvO5Zc=
+github.com/netdata/systemd-journal-sdk/go v0.7.5 h1:M+ql5RL0tLuU8g7m0UD+WCdQ+CH5vM2hwyYoDlZ6YNA=
+github.com/netdata/systemd-journal-sdk/go v0.7.5/go.mod h1:A03ryRKYt5zrAhxx81HTbnwZ1W8uLq13N1VWXJvO5Zc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=

--- a/src/go/plugin/go.d/collector/snmp_traps/journal_sdk_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/journal_sdk_test.go
@@ -57,6 +57,9 @@ func TestNewJournalWriterCreatesCompactUnsealedUncompressedJournal(t *testing.T)
 	assert.NotZero(t, header.IncompatibleFlags()&testJournalIncompatibleCompact)
 	assert.Zero(t, header.IncompatibleFlags()&testJournalIncompatibleCompressed)
 	assert.Zero(t, header.CompatibleFlags()&testJournalCompatibleSealed)
+	assert.Equal(t, w.host.MachineID(), header.MachineID())
+	assert.Equal(t, w.host.BootID(), header.TailEntryBootID())
+	assert.Equal(t, uint64(1), header.NEntries())
 }
 
 func TestJournalWriterWriteAndQueryWithJournalctl(t *testing.T) {


### PR DESCRIPTION
## Summary

- Update NetFlow direct Rust `systemd-journal-sdk-*` dependencies from `0.7.4` to `0.7.5` with SDK-only lockfile churn.
- Update the Go SNMP traps dependency on `github.com/netdata/systemd-journal-sdk/go` from `v0.7.4` to `v0.7.5`.
- Add SNMP trap journal header assertions for machine ID, tail boot ID, and entry count using the new SDK header metadata accessors.

## Validation

- `cd src/crates && cargo check --locked -p netflow-plugin`
- `cd src/crates && cargo test --locked -p netflow-plugin`
- `cd src/go && go test ./plugin/go.d/collector/snmp_traps/...`
- stale `0.7.4` SDK reference search over touched dependency/code surfaces
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade systemd journal SDK to v0.7.5 across Rust and Go. Adds SNMP trap tests that use the new header metadata accessors to verify key fields.

- **Dependencies**
  - Bump Rust crates `systemd-journal-sdk-{common,core,engine,host,index,log-writer,registry}` from 0.7.4 to 0.7.5.
  - Bump Go module `github.com/netdata/systemd-journal-sdk/go` from v0.7.4 to v0.7.5.

- **New Features**
  - SNMP traps: assert header machine ID, tail boot ID, and entry count using the new SDK accessors.

<sup>Written for commit d0ccceede6d83f383af9f4dc1c1bc0fd6c752918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

