### PR TITLE
fix(integrations): correct NPM catalog brand icons + brand SNMP-trap tiles

### DIFF
--- a/integrations/gen_npm_catalog.py
+++ b/integrations/gen_npm_catalog.py
@@ -185,15 +185,17 @@ def icon_for(vendor_key):
     """Resolve a brand icon from a vendor name or IANA enterprise slug.
 
     Device profiles pass a short vendor name ('juniper'); the trap catalogue
-    passes the IANA slug ('juniper-networks-inc'). Match exact first, then the
-    longest brand prefix (restricted to keys >= 4 chars so short keys like
-    'hp'/'ibm' do not over-match unrelated slugs)."""
+    passes the IANA slug ('juniper-networks-inc', 'ibm-eserver-x'). Match exact
+    first, then the longest brand prefix. Prefix matching is restricted to keys
+    >= 3 chars: that excludes only the 2-char 'hp' key (too ambiguous to prefix
+    on; HP is still resolved by its exact entry and the 'hewlettpackard' alias),
+    while distinctive 3-char brands like 'ibm'/'hpe' still brand their slugs."""
     k = re.sub(r'[^a-z0-9]', '', (vendor_key or '').lower())
     if not k:
         return FALLBACK_ICON
     if k in VENDOR_ICONS:
         return VENDOR_ICONS[k]
-    for token in sorted((t for t in VENDOR_ICONS if len(t) >= 4), key=len, reverse=True):
+    for token in sorted((t for t in VENDOR_ICONS if len(t) >= 3), key=len, reverse=True):
         if k.startswith(token):
             return VENDOR_ICONS[token]
     return FALLBACK_ICON

--- a/integrations/gen_npm_catalog.py
+++ b/integrations/gen_npm_catalog.py
@@ -71,22 +71,31 @@ LICENSE_RE = re.compile(r'licens', re.IGNORECASE)
 
 # Vendors whose logo is published at netdata.cloud/img/<icon>. Anything not
 # listed falls back to the generic SNMP icon. Keep this conservative: a wrong
-# icon name renders a broken image, the SNMP fallback never does.
+# icon name renders a broken image, the SNMP fallback never does. Every entry
+# is verified to exist on the CDN, and .png vs .svg matters (only some logos
+# are vector). Keys are a short device-vendor name ('juniper') or a normalized
+# IANA enterprise slug ('hewlettpackard'); icon_for() also matches the longest
+# brand prefix so trap slugs like 'junipernetworksinc' resolve to the brand.
 VENDOR_ICONS = {
     'cisco': 'cisco.svg',
-    'juniper': 'juniper.svg',
-    'arista': 'arista.svg',
+    'juniper': 'juniper.png',
     'huawei': 'huawei.svg',
     'fortinet': 'fortinet.svg',
-    'mikrotik': 'mikrotik.svg',
-    'paloaltonetworks': 'paloalto.svg',
+    'mikrotik': 'mikrotik.png',
+    'paloalto': 'paloalto.png',
+    'paloaltonetworks': 'paloalto.png',
     'netapp': 'netapp.svg',
     'vmware': 'vmware.svg',
     'nvidia': 'nvidia.svg',
     'dell': 'dell.svg',
     'hp': 'hp.svg',
-    'hpe': 'hpe.svg',
+    'hewlettpackard': 'hp.svg',
+    'hpe': 'hpe.png',
+    'hewlettpackardenterprise': 'hpe.png',
     'ibm': 'ibm.svg',
+    # 'arista': pending a usable logo on the CDN (only white-on-transparent
+    # variants exist today); falls back to the SNMP icon until netdata/website
+    # ships a visible arista.png.
 }
 FALLBACK_ICON = 'SNMP.png'
 
@@ -173,7 +182,21 @@ def collect_vendors(profiles):
 
 
 def icon_for(vendor_key):
-    return VENDOR_ICONS.get(re.sub(r'[^a-z0-9]', '', vendor_key), FALLBACK_ICON)
+    """Resolve a brand icon from a vendor name or IANA enterprise slug.
+
+    Device profiles pass a short vendor name ('juniper'); the trap catalogue
+    passes the IANA slug ('juniper-networks-inc'). Match exact first, then the
+    longest brand prefix (restricted to keys >= 4 chars so short keys like
+    'hp'/'ibm' do not over-match unrelated slugs)."""
+    k = re.sub(r'[^a-z0-9]', '', (vendor_key or '').lower())
+    if not k:
+        return FALLBACK_ICON
+    if k in VENDOR_ICONS:
+        return VENDOR_ICONS[k]
+    for token in sorted((t for t in VENDOR_ICONS if len(t) >= 4), key=len, reverse=True):
+        if k.startswith(token):
+            return VENDOR_ICONS[token]
+    return FALLBACK_ICON
 
 
 def humanize_vendor(slug):

--- a/src/go/plugin/go.d/collector/snmp/npm-catalog/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/npm-catalog/metadata.yaml
@@ -648,7 +648,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: arista.svg
+        icon_filename: SNMP.png
       keywords:
         - arista
         - switch
@@ -696,7 +696,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: arista.svg
+        icon_filename: SNMP.png
       keywords:
         - arista
         - snmp
@@ -5709,7 +5709,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: juniper.svg
+        icon_filename: juniper.png
       keywords:
         - juniper
         - ex
@@ -5763,7 +5763,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: juniper.svg
+        icon_filename: juniper.png
       keywords:
         - juniper
         - mx
@@ -5815,7 +5815,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: juniper.svg
+        icon_filename: juniper.png
       keywords:
         - juniper
         - pulse
@@ -5865,7 +5865,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: juniper.svg
+        icon_filename: juniper.png
       keywords:
         - juniper
         - qfx
@@ -5916,7 +5916,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: juniper.svg
+        icon_filename: juniper.png
       keywords:
         - juniper
         - srx
@@ -5968,7 +5968,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: juniper.svg
+        icon_filename: juniper.png
       keywords:
         - juniper
         - snmp
@@ -6255,7 +6255,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: mikrotik.svg
+        icon_filename: mikrotik.png
       keywords:
         - mikrotik
         - router
@@ -7028,7 +7028,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: paloalto.svg
+        icon_filename: paloalto.png
       keywords:
         - palo
         - alto
@@ -7077,7 +7077,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.device-metrics
-        icon_filename: paloalto.svg
+        icon_filename: paloalto.png
       keywords:
         - palo
         - alto
@@ -8692,7 +8692,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.bgp
-        icon_filename: arista.svg
+        icon_filename: SNMP.png
       keywords:
         - arista
         - bgp
@@ -8902,7 +8902,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.bgp
-        icon_filename: juniper.svg
+        icon_filename: juniper.png
       keywords:
         - juniper
         - bgp
@@ -9242,7 +9242,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.licensing
-        icon_filename: mikrotik.svg
+        icon_filename: mikrotik.png
       keywords:
         - mikrotik
         - license
@@ -17577,7 +17577,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: cisco.svg
       keywords:
         - ciscosystems
         - snmp
@@ -20472,7 +20472,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: dell.svg
       keywords:
         - dell-inc
         - snmp
@@ -24441,7 +24441,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: fortinet.svg
       keywords:
         - fortinet-inc
         - snmp
@@ -25814,7 +25814,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: hp.svg
       keywords:
         - hewlett-packard
         - snmp
@@ -25864,7 +25864,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: hpe.png
       keywords:
         - hewlett-packard-enterprise
         - snmp
@@ -25962,7 +25962,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: huawei.svg
       keywords:
         - huawei-symantec-technologies-co-ltd
         - snmp
@@ -26011,7 +26011,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: huawei.svg
       keywords:
         - huawei-technology-co-ltd
         - snmp
@@ -28219,7 +28219,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: juniper.png
       keywords:
         - juniper-networks-funk-software
         - snmp
@@ -28268,7 +28268,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: juniper.png
       keywords:
         - juniper-networks-inc
         - snmp
@@ -28317,7 +28317,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: juniper.png
       keywords:
         - juniper-networks-unisphere
         - snmp
@@ -31453,7 +31453,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: mikrotik.svg
+        icon_filename: mikrotik.png
       keywords:
         - mikrotik
         - snmp
@@ -36060,7 +36060,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: paloalto.svg
+        icon_filename: paloalto.png
       keywords:
         - palo-alto-networks
         - snmp
@@ -47233,7 +47233,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: vmware.svg
       keywords:
         - vmware-inc
         - snmp

--- a/src/go/plugin/go.d/collector/snmp/npm-catalog/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/npm-catalog/metadata.yaml
@@ -26210,7 +26210,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: ibm.svg
       keywords:
         - ibm-eserver-x
         - snmp
@@ -26259,7 +26259,7 @@ modules:
         link: ''
         categories:
           - network-performance-monitoring.traps
-        icon_filename: SNMP.png
+        icon_filename: ibm.svg
       keywords:
         - ibm-https-w3-ibm-com-standards
         - snmp


### PR DESCRIPTION
## What

The Network Performance Monitoring SNMP integration catalog rendered broken or generic icons on Learn. Root cause was in `integrations/gen_npm_catalog.py`:

1. **Wrong icon filenames** — `VENDOR_ICONS` hard-coded `<vendor>.svg` names that don't exist on the CDN:
   - `juniper`, `mikrotik`, `hpe` → only `.png` exists (the `.svg` 404s)
   - `paloalto` → `.svg` missing
   - `arista` → no usable logo on the CDN at all
2. **Trap tiles unbranded** — `icon_for()` matched only the short device-vendor key (`juniper`), but SNMP-trap tiles pass the IANA enterprise slug (`juniper-networks-inc`), so every brand trap tile fell back to the generic SNMP icon.

## Fix

- Correct the icon extensions (`juniper`/`mikrotik`/`hpe` → `.png`, `paloalto.png`).
- `icon_for()` now matches the longest brand **prefix**, so trap slugs resolve to the vendor icon. A length guard (keys ≥ 4 chars) keeps short keys (`hp`, `ibm`) from over-matching unrelated vendors.
- `arista` falls back to the clean generic SNMP icon (no broken image) until it has a usable CDN logo.

Verified `icon_for()` against every brand (device names + IANA trap slugs) and false-match cases.

## Companion / notes

- **netdata/website#1268** (merged) ships the new `paloalto.png` and fixes `juniper.png`, which previously contained the **HPE** logo.
- Per-vendor `.md` tiles regenerate via the integrations bot post-merge (the standard pattern).
- Arista will be added in a follow-up once a usable official logo is published.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken vendor icons in the NPM catalog and brands SNMP-trap tiles by correcting CDN filenames and improving icon lookup. IBM trap tiles now brand correctly; users see the right logos and no broken images.

- **Bug Fixes**
  - Corrected icon filenames to match the CDN: `juniper.png`, `mikrotik.png`, `hpe.png`, `hp.svg`, `paloalto.png`; `arista` now falls back to `SNMP.png`.
  - Updated `icon_for()` in `integrations/gen_npm_catalog.py` to try exact match, then the longest brand prefix with a length guard (>=3). Brands slugs like `ibm-*` and `hpe-*`, while keeping `hp` from over-matching.
  - Updated `src/go/plugin/go.d/collector/snmp/npm-catalog/metadata.yaml` to use the correct filenames and branded icons for device and trap tiles (Cisco, Dell, Fortinet, HP/HPE, Huawei, IBM, Juniper, MikroTik, Palo Alto, VMware).

<sup>Written for commit c1ca575d0d422b9c3e05417e5a1bc0c3021564a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

