### PR TITLE
feat(go.d): withdraw unavailable module functions

### DIFF
--- a/.agents/sow/specs/go-function-publication-lifecycle.md
+++ b/.agents/sow/specs/go-function-publication-lifecycle.md
@@ -6,7 +6,7 @@ This spec applies to go.d Functions registered through:
 
 - `collectorapi.Creator.Methods` for module/static methods.
 - `collectorapi.Creator.JobMethods` for per-job methods.
-- `funcapi.MethodConfig.Available` for first-publication gating.
+- `funcapi.MethodConfig.Available` for module/static method availability.
 
 It does not define Netdata Cloud discovery behavior beyond the Agent-side
 publication stream emitted by go.d.
@@ -17,18 +17,23 @@ publication stream emitted by go.d.
 - funcctl owns module/static Function publication. Collectors MUST NOT publish
   their module/static Functions by calling `funcctl`, `dyncfg.Responder`,
   `netdataapi`, or plugins.d `FUNCTION` commands directly.
-- `Available == nil` means the method is available for publication.
-- `Available != nil` gates first publication only.
-- funcctl MAY recheck unpublished module/static methods while jobs are running.
-  jobmgr currently performs this recheck from the running-job tick loop.
-- Publication is monotonic:
-  - once funcctl publishes a module/static Function, later `Available == false`
-    results MUST NOT withdraw it;
-  - the Function remains published until go.d cleanup or restart;
-  - withdrawal-on-empty requires a separate explicit lifecycle design.
+- A module/static Function MUST NOT be published until the module has at least
+  one running provider job.
+- `Available == nil` means the method is available whenever the module has a
+  running provider job.
+- `Available != nil` is authoritative availability state:
+  - funcctl MUST publish the method when the module has a running provider job
+    and `Available()` returns true;
+  - funcctl MUST withdraw the method when `Available()` later returns false;
+  - funcctl MUST withdraw the method when the last running provider job stops.
+- funcctl MAY recheck module/static methods while jobs are running. jobmgr
+  currently performs this recheck from the running-job tick loop and immediately
+  after module job start/stop.
 - Rechecks MUST reuse the normal funcctl publication path so public names,
   aliases, tags, `RequireCloud`, `AgentWide`, handler wiring, and collision
   behavior stay consistent.
+- Direct Function execution MUST fail with `404 unknown function` for withdrawn
+  module/static methods, even if the module's method route is still declared.
 
 ## `Available` Predicate Contract
 
@@ -47,7 +52,7 @@ publication stream emitted by go.d.
 - Per-job methods remain tied to job lifecycle.
 - `collectorapi.Creator.JobMethods` methods are registered for a job on job
   start and unregistered on job stop.
-- This spec does not add late-publication or monotonic behavior to job methods.
+- This spec does not add late-publication behavior to job methods.
 
 ## Validation Guidance
 
@@ -55,6 +60,14 @@ publication stream emitted by go.d.
   - not published at module registration or job start while unavailable;
   - published after a running-job recheck when availability turns true;
   - not duplicated after publication;
-  - not withdrawn when availability later turns false.
+  - withdrawn when availability later turns false;
+  - republished if availability later returns true again;
+  - direct execution of a withdrawn Function returns 404.
+- Tests for module/static provider lifecycle SHOULD cover:
+  - no publication at module registration before any job starts;
+  - first running provider job publishes available methods;
+  - stopping one provider job does not withdraw while another provider still
+    runs;
+  - stopping the last provider job withdraws the module/static methods.
 - Race tests SHOULD cover concurrent running-job rechecks and job lifecycle
   hooks for modules with availability-gated methods.

--- a/src/go/pkg/funcapi/response.go
+++ b/src/go/pkg/funcapi/response.go
@@ -18,8 +18,8 @@ type MethodConfig struct {
 	Tags         string   // Function tags for registration; empty defaults to "top"
 	ResponseType string   // Response schema type; empty defaults to "table" when dispatched
 	// Available gates publication of module/static methods. Nil means available.
-	// funcctl may recheck unavailable module methods while jobs are running.
-	// Once a Function is published, later false results do not withdraw it.
+	// funcctl rechecks it while provider jobs run and withdraws the Function
+	// when the predicate later returns false.
 	Available func() bool
 	// RawRequest routes the complete Function request to a RawMethodHandler.
 	// Use this for Function APIs that need raw payloads, args, or full response envelopes.

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -43,6 +43,10 @@ type functionPublish struct {
 	opts    netdataapi.FunctionGlobalOpts
 }
 
+type functionWithdraw struct {
+	name string
+}
+
 func New(opts Options) *Controller {
 	log := opts.Logger
 	if log == nil {
@@ -94,7 +98,6 @@ func (c *Controller) RegisterModules(modules collectorapi.Registry) {
 			continue
 		}
 		c.registry.registerModuleWithMethods(name, creator, methods)
-		c.registerAvailableModuleMethods(name, methods, true)
 	}
 }
 
@@ -139,7 +142,7 @@ func (c *Controller) OnJobStart(job collectorapi.RuntimeJob) {
 	}
 
 	c.registry.addJob(job.ModuleName(), job.Name(), job)
-	c.registerModuleMethodsOnJobStart(job.ModuleName())
+	c.ReconcileModuleMethods(job.ModuleName())
 
 	creator, ok := c.registry.getCreator(job.ModuleName())
 	if !ok || creator.JobMethods == nil {
@@ -153,16 +156,17 @@ func (c *Controller) OnJobStart(job collectorapi.RuntimeJob) {
 }
 
 // ReconcileModuleMethods rechecks module/static method availability for modules
-// with at least one registered running job.
+// and publishes or withdraws them to match current provider and availability
+// state.
 func (c *Controller) ReconcileModuleMethods(moduleName string) {
-	if moduleName == "" || !c.registry.hasRunningJob(moduleName) {
+	if moduleName == "" {
 		return
 	}
 	methods := c.registry.getMethods(moduleName)
 	if len(methods) == 0 {
 		return
 	}
-	c.registerAvailableModuleMethods(moduleName, methods, false)
+	c.reconcileModuleMethods(moduleName, methods, c.registry.hasRunningJob(moduleName))
 }
 
 func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
@@ -172,6 +176,7 @@ func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
 
 	c.unregisterJobMethods(job)
 	c.registry.removeJob(job.ModuleName(), job.Name())
+	c.ReconcileModuleMethods(job.ModuleName())
 }
 
 func (c *Controller) Cleanup() {
@@ -190,17 +195,16 @@ func (c *Controller) Cleanup() {
 	}
 }
 
-func (c *Controller) registerModuleMethodsOnJobStart(moduleName string) {
-	methods := c.registry.getMethods(moduleName)
-	if len(methods) == 0 {
-		return
+func (c *Controller) reconcileModuleMethods(moduleName string, methods []funcapi.MethodConfig, hasProvider bool) {
+	publishes, withdraws := c.collectModuleMethodLifecycleChanges(moduleName, methods, hasProvider)
+	for _, withdraw := range withdraws {
+		c.fnReg.Unregister(withdraw.name)
 	}
-
-	c.registerAvailableModuleMethods(moduleName, methods, false)
-}
-
-func (c *Controller) registerAvailableModuleMethods(moduleName string, methods []funcapi.MethodConfig, agentWideOnly bool) {
-	publishes := c.collectAvailableModuleMethodPublishes(moduleName, methods, agentWideOnly)
+	if c.api != nil {
+		for _, withdraw := range withdraws {
+			c.api.FunctionRemove(withdraw.name)
+		}
+	}
 	for _, publish := range publishes {
 		c.registerFunction(publish.name, publish.handler)
 	}
@@ -212,19 +216,24 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 	}
 }
 
-func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, methods []funcapi.MethodConfig, agentWideOnly bool) []functionPublish {
+func (c *Controller) collectModuleMethodLifecycleChanges(moduleName string, methods []funcapi.MethodConfig, hasProvider bool) ([]functionPublish, []functionWithdraw) {
 	c.publishedMu.Lock()
 	defer c.publishedMu.Unlock()
 
 	var publishes []functionPublish
+	var withdraws []functionWithdraw
 	for i, method := range methods {
-		if agentWideOnly && !method.AgentWide {
+		available := hasProvider && methodAvailable(method)
+		if method.ID != "" && !available {
+			for _, funcName := range c.publishedFns.removeOwner(moduleMethodOwner(moduleName, method.ID)) {
+				withdraws = append(withdraws, functionWithdraw{name: funcName})
+			}
 			continue
 		}
 		if method.ID != "" && c.allMethodFunctionNamesPublishedLocked(moduleName, method) {
 			continue
 		}
-		if !methodAvailable(method) {
+		if !available {
 			continue
 		}
 		if method.ID == "" {
@@ -244,29 +253,6 @@ func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, me
 			access = cloudAccess
 		}
 
-		if c.api != nil {
-			for _, funcName := range funcapi.MethodFunctionNames(moduleName, method) {
-				if c.publishedFns.has(funcName) {
-					continue
-				}
-				record, _ := c.publishedFns.add(funcName, moduleMethodOwner(moduleName, method.ID))
-				publishes = append(publishes, functionPublish{
-					name:    funcName,
-					handler: c.makePublishedMethodFuncHandler(funcName, record.generation, moduleName, method.ID),
-					opts: netdataapi.FunctionGlobalOpts{
-						Name:     funcName,
-						Timeout:  60,
-						Help:     help,
-						Tags:     methodTags(method),
-						Access:   access,
-						Priority: 100,
-						Version:  3,
-					},
-				})
-			}
-			continue
-		}
-
 		for _, funcName := range funcapi.MethodFunctionNames(moduleName, method) {
 			if c.publishedFns.has(funcName) {
 				continue
@@ -275,10 +261,20 @@ func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, me
 			publishes = append(publishes, functionPublish{
 				name:    funcName,
 				handler: c.makePublishedMethodFuncHandler(funcName, record.generation, moduleName, method.ID),
+				opts: netdataapi.FunctionGlobalOpts{
+					Name:     funcName,
+					Timeout:  60,
+					Help:     help,
+					Tags:     methodTags(method),
+					Access:   access,
+					Priority: 100,
+					Version:  3,
+				},
 			})
 		}
 	}
-	return publishes
+	sort.Slice(withdraws, func(i, j int) bool { return withdraws[i].name < withdraws[j].name })
+	return publishes, withdraws
 }
 
 func (c *Controller) allMethodFunctionNamesPublishedLocked(moduleName string, method funcapi.MethodConfig) bool {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -442,7 +443,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 
 			assert.Empty(t, reg.registeredNames())
 		},
-		"register modules registers available agent-wide methods": func(t *testing.T) {
+		"register modules does not register available agent-wide methods": func(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
@@ -452,7 +453,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 				},
 			})
 
-			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
+			assert.Empty(t, reg.registeredNames())
 		},
 		"first job start registers static methods once": func(t *testing.T) {
 			controller, reg := newController()
@@ -466,6 +467,50 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
 
 			assert.Equal(t, []string{"mod:a"}, reg.registeredNames())
+		},
+		"job stop keeps static methods while another provider runs": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			var buf bytes.Buffer
+			controller := New(Options{
+				FnReg: reg,
+				API:   dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))),
+			})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+				},
+			})
+
+			job1 := newTestRuntimeJob("mod", "job1", true)
+			job2 := newTestRuntimeJob("mod", "job2", true)
+			controller.OnJobStart(job1)
+			controller.OnJobStart(job2)
+			controller.OnJobStop(job1)
+
+			assert.Equal(t, []string{"mod:a"}, reg.activeNames())
+			assert.Empty(t, reg.unregisteredNames())
+			assert.NotContains(t, buf.String(), "FUNCTION_DEL GLOBAL \"mod:a\"")
+		},
+		"last job stop withdraws static methods": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			var buf bytes.Buffer
+			controller := New(Options{
+				FnReg: reg,
+				API:   dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))),
+			})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+				},
+			})
+
+			job := newTestRuntimeJob("mod", "job1", true)
+			controller.OnJobStart(job)
+			controller.OnJobStop(job)
+
+			assert.Empty(t, reg.activeNames())
+			assert.Equal(t, []string{"mod:a"}, reg.unregisteredNames())
+			assert.Contains(t, buf.String(), "FUNCTION_DEL GLOBAL \"mod:a\"")
 		},
 		"availability-gated static method registers when available": func(t *testing.T) {
 			controller, reg := newController()
@@ -536,6 +581,31 @@ func TestControllerLifecycleHooks(t *testing.T) {
 
 			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
 		},
+		"reconcile republishes method after availability returns": func(t *testing.T) {
+			controller, reg := newController()
+			available := true
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:        "logs",
+							Available: func() bool { return available },
+						}}
+					},
+				},
+			})
+
+			job := newTestRuntimeJob("mod", "job1", true)
+			controller.OnJobStart(job)
+			available = false
+			controller.ReconcileModuleMethods(job.ModuleName())
+			available = true
+			controller.ReconcileModuleMethods(job.ModuleName())
+
+			assert.Equal(t, []string{"mod:logs", "mod:logs"}, reg.registeredNames())
+			assert.Equal(t, []string{"mod:logs"}, reg.unregisteredNames())
+			assert.Equal(t, []string{"mod:logs"}, reg.activeNames())
+		},
 		"reconcile ignores module with no running job": func(t *testing.T) {
 			controller, reg := newController()
 			available := true
@@ -577,9 +647,9 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller.ReconcileModuleMethods(job.ModuleName())
 
 			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
-			assert.Equal(t, 1, availableCalls)
+			assert.Equal(t, 3, availableCalls)
 		},
-		"reconcile does not withdraw published static method": func(t *testing.T) {
+		"reconcile withdraws unavailable published static method": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
 			var buf bytes.Buffer
 			available := true
@@ -605,9 +675,46 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			available = false
 			controller.ReconcileModuleMethods(job.ModuleName())
 
-			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
-			assert.Empty(t, reg.unregisteredNames())
-			assert.NotContains(t, buf.String(), "FUNCTION_DEL")
+			assert.Empty(t, reg.activeNames())
+			assert.Equal(t, []string{"mod:logs"}, reg.unregisteredNames())
+			assert.Contains(t, buf.String(), "FUNCTION_DEL GLOBAL \"mod:logs\"")
+		},
+		"direct execution after withdrawal returns unknown function": func(t *testing.T) {
+			var gotCode int
+			var gotResp map[string]any
+			available := true
+			controller := New(Options{
+				JSONWriter: func(data []byte, code int) {
+					gotCode = code
+					require.NoError(t, json.Unmarshal(data, &gotResp))
+				},
+			})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					Methods: func() []funcapi.MethodConfig {
+						return []funcapi.MethodConfig{{
+							ID:        "logs",
+							Available: func() bool { return available },
+						}}
+					},
+					MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+						return &tableTestHandler{}
+					},
+				},
+			})
+
+			job := newTestRuntimeJob("mod", "job1", true)
+			controller.OnJobStart(job)
+			available = false
+			controller.ReconcileModuleMethods(job.ModuleName())
+			controller.ExecuteFunction("mod:logs", functions.Function{
+				UID:     "withdrawn-direct",
+				Timeout: time.Second,
+			})
+
+			assert.Equal(t, 404, gotCode)
+			assert.Equal(t, float64(404), gotResp["status"])
+			assert.Equal(t, "unknown function 'mod:logs'", gotResp["errorMessage"])
 		},
 		"reconcile logs empty static method ID once": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
@@ -694,6 +801,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 					},
 				},
 			})
+			controller.OnJobStart(newTestRuntimeJob("snmp_topology", "job1", true))
 
 			assert.ElementsMatch(t, []string{"snmp:topology:snmp", "topology:snmp"}, reg.registeredNames())
 
@@ -902,18 +1010,20 @@ func TestControllerStaticPublicationDoesNotHoldLockDuringFunctionGlobal(t *testi
 		API:   dyncfg.NewResponder(netdataapi.New(writer)),
 	})
 
+	controller.RegisterModules(collectorapi.Registry{
+		"mod": collectorapi.Creator{
+			Methods: func() []funcapi.MethodConfig {
+				return []funcapi.MethodConfig{{
+					ID:        "late",
+					AgentWide: true,
+				}}
+			},
+		},
+	})
+
 	registerDone := make(chan struct{})
 	go func() {
-		controller.RegisterModules(collectorapi.Registry{
-			"mod": collectorapi.Creator{
-				Methods: func() []funcapi.MethodConfig {
-					return []funcapi.MethodConfig{{
-						ID:        "late",
-						AgentWide: true,
-					}}
-				},
-			},
-		})
+		controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
 		close(registerDone)
 	}()
 
@@ -925,7 +1035,7 @@ func TestControllerStaticPublicationDoesNotHoldLockDuringFunctionGlobal(t *testi
 
 	startDone := make(chan struct{})
 	go func() {
-		controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+		controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
 		close(startDone)
 	}()
 
@@ -1329,7 +1439,7 @@ func TestControllerRawModuleMethodRequest(t *testing.T) {
 	}
 }
 
-func TestControllerRawAgentWideModuleMethodDoesNotRequireRunningJob(t *testing.T) {
+func TestControllerRawAgentWideModuleMethodDoesNotReceiveRuntimeJob(t *testing.T) {
 	var gotCode int
 	var gotResp map[string]any
 	var gotJob collectorapi.RuntimeJob
@@ -1365,6 +1475,7 @@ func TestControllerRawAgentWideModuleMethodDoesNotRequireRunningJob(t *testing.T
 			},
 		},
 	})
+	controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
 
 	reg.call("mod:logs", context.Background(), functions.Function{
 		UID:     "raw-agent-wide",
@@ -1489,73 +1600,46 @@ func TestControllerSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testing.
 	assert.Equal(t, []any{"scope"}, gotResp["accepted_params"])
 }
 
-func TestControllerSingleInstanceAgentWideModuleMethodRequiresRunningJob(t *testing.T) {
-	tests := map[string]struct {
-		setup   func(*Controller)
-		message string
-	}{
-		"before start": {
-			message: "module 'mod' is not running",
+func TestControllerSingleInstanceAgentWideModuleMethodRejectsStoppedRunningJob(t *testing.T) {
+	var gotCode int
+	var gotResp map[string]any
+	var gotHandler bool
+	reg := newTestFunctionRegistry()
+	controller := New(Options{
+		FnReg: reg,
+		JSONWriter: func(data []byte, code int) {
+			gotCode = code
+			require.NoError(t, json.Unmarshal(data, &gotResp))
 		},
-		"after stop": {
-			setup: func(controller *Controller) {
-				job := newTestRuntimeJob("mod", "mod", true)
-				controller.OnJobStart(job)
-				controller.OnJobStop(job)
+	})
+	controller.RegisterModules(collectorapi.Registry{
+		"mod": collectorapi.Creator{
+			InstancePolicy: collectorapi.InstancePolicySingle,
+			Methods: func() []funcapi.MethodConfig {
+				return []funcapi.MethodConfig{{
+					ID:        "status",
+					AgentWide: true,
+				}}
 			},
-			message: "module 'mod' is not running",
-		},
-		"registered but not running": {
-			setup: func(controller *Controller) {
-				controller.OnJobStart(newTestRuntimeJob("mod", "mod", false))
+			MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+				gotHandler = true
+				return &tableTestHandler{}
 			},
-			message: "job 'mod' is no longer running",
 		},
-	}
+	})
+	job := newTestRuntimeJob("mod", "mod", true)
+	controller.OnJobStart(job)
+	job.running = false
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			var gotCode int
-			var gotResp map[string]any
-			var gotHandler bool
-			reg := newTestFunctionRegistry()
-			controller := New(Options{
-				FnReg: reg,
-				JSONWriter: func(data []byte, code int) {
-					gotCode = code
-					require.NoError(t, json.Unmarshal(data, &gotResp))
-				},
-			})
-			controller.RegisterModules(collectorapi.Registry{
-				"mod": collectorapi.Creator{
-					InstancePolicy: collectorapi.InstancePolicySingle,
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
-							ID:        "status",
-							AgentWide: true,
-						}}
-					},
-					MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
-						gotHandler = true
-						return &tableTestHandler{}
-					},
-				},
-			})
-			if tc.setup != nil {
-				tc.setup(controller)
-			}
+	reg.call("mod:status", context.Background(), functions.Function{
+		UID:     "single-agent-wide-stopped-job",
+		Timeout: time.Second,
+	})
 
-			reg.call("mod:status", context.Background(), functions.Function{
-				UID:     "single-agent-wide-missing-job",
-				Timeout: time.Second,
-			})
-
-			assert.Equal(t, 503, gotCode)
-			assert.Equal(t, float64(503), gotResp["status"])
-			assert.Equal(t, tc.message, gotResp["errorMessage"])
-			assert.False(t, gotHandler)
-		})
-	}
+	assert.Equal(t, 503, gotCode)
+	assert.Equal(t, float64(503), gotResp["status"])
+	assert.Equal(t, "job 'mod' is no longer running", gotResp["errorMessage"])
+	assert.False(t, gotHandler)
 }
 
 func TestControllerModuleMethodRequestContextCancellation(t *testing.T) {
@@ -1860,6 +1944,23 @@ func (r *testFunctionRegistry) registeredNames() []string {
 
 	out := make([]string, len(r.registered))
 	copy(out, r.registered)
+	return out
+}
+
+func (r *testFunctionRegistry) activeNames() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make([]string, 0, len(r.contextHandlers)+len(r.handlers))
+	for name := range r.contextHandlers {
+		out = append(out, name)
+	}
+	for name := range r.handlers {
+		if _, ok := r.contextHandlers[name]; !ok {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
@@ -39,17 +39,26 @@ type methodExecutionInput struct {
 
 func (c *Controller) ExecuteFunction(functionName string, fn functions.Function) {
 	if moduleName, methodID, ok := c.registry.resolveMethodRoute(functionName); ok {
+		if !c.publishedFunctionNameExists(functionName) {
+			c.respondError(fn, 404, "unknown function '%s'", functionName)
+			return
+		}
 		c.makeMethodFuncHandler(moduleName, methodID)(c.baseContext(), fn)
 		return
 	}
 
-	moduleName, methodID, err := functions.SplitFunctionName(functionName)
-	if err != nil {
+	if _, _, err := functions.SplitFunctionName(functionName); err != nil {
 		c.respondError(fn, 400, "%v", err)
 		return
 	}
 
-	c.makeMethodFuncHandler(moduleName, methodID)(c.baseContext(), fn)
+	c.respondError(fn, 404, "unknown function '%s'", functionName)
+}
+
+func (c *Controller) publishedFunctionNameExists(functionName string) bool {
+	c.publishedMu.Lock()
+	defer c.publishedMu.Unlock()
+	return c.publishedFns.has(functionName)
 }
 
 func (c *Controller) publishedFunctionGenerationMatches(functionName string, generation uint64) bool {

--- a/src/go/plugin/agent/jobmgr/funcdispatch_test.go
+++ b/src/go/plugin/agent/jobmgr/funcdispatch_test.go
@@ -203,7 +203,7 @@ func TestExecuteFunction_ModuleMethodPublicFunctionName(t *testing.T) {
 	assert.Equal(t, "logs", gotMethod)
 }
 
-func TestExecuteFunction_AgentWideModuleMethodDoesNotRequireRunningJob(t *testing.T) {
+func TestExecuteFunction_AgentWideModuleMethodDoesNotReceiveRuntimeJob(t *testing.T) {
 	tests := map[string]struct {
 		functionName string
 	}{
@@ -255,6 +255,7 @@ func TestExecuteFunction_AgentWideModuleMethodDoesNotRequireRunningJob(t *testin
 				},
 			}
 			mgr.funcCtl.RegisterModules(mgr.modules)
+			mgr.funcCtl.OnJobStart(&lockProbeJob{fullName: "snmp_topology_job1", moduleName: "snmp_topology", name: "job1"})
 
 			mgr.ExecuteFunction(tc.functionName, functions.Function{
 				UID:     "agent-wide-public-name",
@@ -301,6 +302,7 @@ func TestExecuteFunction_AgentWideModuleMethodValidationErrorOmitsJob(t *testing
 		},
 	}
 	mgr.funcCtl.RegisterModules(mgr.modules)
+	mgr.funcCtl.OnJobStart(&lockProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"})
 
 	mgr.ExecuteFunction("mod:logs", functions.Function{
 		UID:     "agent-wide-validation",

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -668,7 +668,7 @@ func TestRun_DoesNotRegisterJobBoundModuleMethodsBeforeAnyJobStarts(t *testing.T
 	assert.Empty(t, fnReg.registeredNames(), "static methods must not be registered before first started job")
 }
 
-func TestRun_RegistersAgentWideModuleMethodsBeforeAnyJobStarts(t *testing.T) {
+func TestRun_DoesNotRegisterAgentWideModuleMethodsBeforeAnyJobStarts(t *testing.T) {
 	fnReg := &recordingFunctionRegistry{}
 	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
 
@@ -703,7 +703,7 @@ func TestRun_RegistersAgentWideModuleMethodsBeforeAnyJobStarts(t *testing.T) {
 		t.Fatal("manager did not stop after cancel")
 	}
 
-	assert.Equal(t, []string{"mod:a"}, fnReg.registeredNames())
+	assert.Empty(t, fnReg.registeredNames(), "agent-wide module methods still need a running provider job")
 }
 
 func TestStartRunningJob_RegistersModuleMethodsOnFirstStartedJob(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/manager_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_test.go
@@ -2033,8 +2033,6 @@ FUNCTION_RESULT_BEGIN 1-enable 200 application/json
 FUNCTION_RESULT_END
 
 CONFIG test:collector:withfuncs:test status running
-
-FUNCTION_DEL GLOBAL "withfuncs:test-method"
 `,
 				}
 			},
@@ -2067,8 +2065,6 @@ FUNCTION_RESULT_BEGIN 1-enable 200 application/json
 FUNCTION_RESULT_END
 
 CONFIG test:collector:funconly:test status running
-
-FUNCTION_DEL GLOBAL "funconly:test-method"
 `,
 				}
 			},

--- a/src/go/plugin/agent/jobmgr/sim_test.go
+++ b/src/go/plugin/agent/jobmgr/sim_test.go
@@ -140,6 +140,10 @@ func (s *runSim) run(t *testing.T) {
 			skipNextEmpty = true
 			continue
 		}
+		if strings.HasPrefix(s, "FUNCTION_DEL GLOBAL") {
+			skipNextEmpty = true
+			continue
+		}
 		if skipNextEmpty && s == "" {
 			skipNextEmpty = false
 			continue


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish module/static Functions only when a provider job is running, and withdraw them when availability turns false or the last provider stops. Direct calls to withdrawn Functions now return 404.

- New Features
  - Gate module/static publication on an active provider job in `funcctl`.
  - Treat `funcapi.MethodConfig.Available` as authoritative: publish when true, withdraw when false.
  - Keep methods active while any provider job runs; withdraw when the last one stops.
  - Reconcile on job start/stop and during periodic rechecks; maintain consistent naming, tags, and access.
  - Return 404 "unknown function" for withdrawn names; update spec and tests accordingly.

<sup>Written for commit 6af96ff78d8b4a510354515467d08f3ba9f7983e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

