### PR TITLE
docs(npm): add screenshots to Network Performance Monitoring pages

### DIFF
--- a/docs/npm/README.md
+++ b/docs/npm/README.md
@@ -12,6 +12,10 @@ endmeta-->
 
 Network Performance Monitoring (NPM) in Netdata covers your network devices and the traffic between them — metrics, topology, flows, events, and logs — collected by the Netdata Agent and visualized per second in Netdata dashboards and Netdata Cloud.
 
+![Netdata Network Monitor dashboard](https://www.netdata.cloud/img/network/network-monitor-dashboard.png)
+
+The Network Monitor dashboard brings devices, topology, flows, and trap events together on one page in Netdata Cloud.
+
 ## What you can monitor
 
 - **Device metrics (SNMP)** — poll routers, switches, firewalls, access points, UPSs, and PDUs. Netdata matches each device to a vendor profile by its `sysObjectID` and collects interfaces (traffic, errors, discards, operational state), system and host resources, and vendor-specific hardware, environmental, and protocol metrics. Every metric is a chart you can alert on, with interactive per-interface and per-device tables.

--- a/docs/npm/device-metrics/README.md
+++ b/docs/npm/device-metrics/README.md
@@ -12,6 +12,10 @@ endmeta-->
 
 Netdata monitors your network devices over SNMP — routers, switches, firewalls, access points, load balancers, UPS and PDU units. It recognizes each device's model automatically and collects interface, health, and vendor-specific metrics, with no OID lists to build and no per-device dashboards to design.
 
+![Network devices on the Nodes tab](https://www.netdata.cloud/img/dashboard-screens/nodes-tab-network-devices.png)
+
+Each SNMP device becomes its own node — model-recognized, with live interface, health, and vendor metrics.
+
 ## What you can monitor
 
 - **Interfaces** — traffic, errors, discards, and operational status, per interface.

--- a/docs/npm/snmp-traps/README.md
+++ b/docs/npm/snmp-traps/README.md
@@ -14,6 +14,10 @@ Netdata listens for SNMP Trap and INFORM notifications from your network devices
 
 This section is for NetOps, NOC, SRE, SecOps, and MSP operators who need to know which network events a device reported, whether the receiver is healthy, and when trap data should be queried or forwarded.
 
+![SNMP trap events in the Netdata Logs UI](https://www.netdata.cloud/img/network/snmp-trap-logs.png)
+
+Decoded trap and INFORM events in the Netdata Logs tab — named, categorized, and searchable, with severity and source.
+
 ## What trap data is
 
 An SNMP trap is an *asynchronous event notification*. A device sends one when it decides something happened — an interface changed state, an authentication failed, a configuration changed, a sensor crossed a threshold. It is one telemetry leg among several: traps and streaming telemetry carry events, polling confirms current state, syslog carries narrative, flow carries traffic. Traps are indispensable because every device supports them and they catch transient transitions that polling would miss between intervals.

--- a/docs/npm/topology/README.md
+++ b/docs/npm/topology/README.md
@@ -12,6 +12,10 @@ endmeta-->
 
 Netdata shows you how your network is connected — which device links to which, and where each part of your infrastructure sits — built automatically from the devices you already monitor.
 
+![Network topology overview](https://www.netdata.cloud/img/network/snmp-topology-overview.png)
+
+The topology view, assembled automatically from the devices you already monitor — Layer 2 and Layer 3 links, kept current as devices come and go.
+
 ## Built from your devices
 
 When Netdata monitors your SNMP devices, it reads what they already know about their neighbors and assembles the topology, with no extra setup:
@@ -40,6 +44,10 @@ The same topology view brings in other infrastructure, each in the same form so 
 - **Cato Networks** — Cato SASE sites, devices, POPs, and BGP peers (`topology:cato_networks`).
 
 The device fabric (`topology:snmp`), live connections, and streaming come up automatically; vSphere and Cato come from their own collectors, configured separately.
+
+![Live network connections function](https://www.netdata.cloud/img/dashboard-screens/functions-network-connections.png)
+
+Live host and service connections (`topology:network-connections`) appear in the same topology view, alongside your device fabric.
 
 ## Where to start
 


### PR DESCRIPTION
## What

Adds product screenshots to the text-only pages of the **Network Performance Monitoring** docs section, reusing the curated network screenshots already published on netdata.cloud (referenced by `https://www.netdata.cloud/img/...` URLs).

| Page | Screenshot |
|---|---|
| `docs/npm/README.md` | Network Monitor dashboard |
| `docs/npm/device-metrics/README.md` | Network devices on the Nodes tab |
| `docs/npm/topology/README.md` | Topology overview + Live network-connections function |
| `docs/npm/snmp-traps/README.md` | Trap events in the Logs UI |

5 images across 4 pages, embedded in the existing `![alt](url)` + caption style.

## Scope notes

- **Network Flows left unchanged** — already covered (#22840).
- **BGP / Licensing / Syslog pages intentionally have no screenshot** — no accurate asset exists for them yet (no `bgp`/`license`/`syslog` images on the website, no website feature page for BGP/Licensing). A generic Metrics/Logs shot would misrepresent the feature; deferred until accurate assets exist.

## Hosting

Images are referenced from the live netdata.cloud assets (all verified reachable). Note: Docusaurus treats broken images as warnings, not build failures, so a future website `/img` reorg would silently break these — acceptable given the assets were just curated and are stable.

Will appear on learn.netdata.cloud at the next ~3h ingest after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds product screenshots to the Network Performance Monitoring docs to make key pages visual and easier to scan. Five images embedded across four pages, referenced from `https://www.netdata.cloud/img/...`. Flows unchanged; BGP, Licensing, and Syslog intentionally omitted until accurate assets exist.

- New Features
  - docs/npm/README.md: Network Monitor dashboard
  - docs/npm/device-metrics/README.md: Nodes tab with SNMP devices
  - docs/npm/topology/README.md: Topology overview + live network connections
  - docs/npm/snmp-traps/README.md: Trap events in Logs UI

<sup>Written for commit 46bde11005b610a6add3ced5b0e8d7af01461c12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

