### PR TITLE
refactor(go.d): replace AgentWide with MethodScope

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -67,7 +67,7 @@ source files for evidence.
 - If Functions exist, isolate them in a `<name>func/` subpackage with a narrow
   `Deps` interface declared there. The Function package MUST NOT import the
   collector package or hold `*Collector`.
-- If a single-instance collector exposes `AgentWide` module `Methods`, its
+- If a single-instance collector exposes `MethodScopeAgent` module `Methods`, its
   `MethodHandler(job)` receives the running canonical runtime job. Use
   `job.Collector()` to bind the Function handler to collector-owned state; do
   not add a `__job` parameter or introduce a package-global registry to bridge

--- a/.agents/sow/specs/go-function-publication-lifecycle.md
+++ b/.agents/sow/specs/go-function-publication-lifecycle.md
@@ -27,7 +27,7 @@ publication stream emitted by go.d.
   - the Function remains published until go.d cleanup or restart;
   - withdrawal-on-empty requires a separate explicit lifecycle design.
 - Rechecks MUST reuse the normal funcctl publication path so public names,
-  aliases, tags, `RequireCloud`, `AgentWide`, handler wiring, and collision
+  aliases, tags, `RequireCloud`, `MethodScope`, handler wiring, and collision
   behavior stay consistent.
 
 ## `Available` Predicate Contract

--- a/src/go/pkg/funcapi/response.go
+++ b/src/go/pkg/funcapi/response.go
@@ -2,6 +2,17 @@
 
 package funcapi
 
+// MethodScope controls the public API shape for creator-level module methods.
+type MethodScope uint8
+
+const (
+	// MethodScopeInstance exposes a shared module method selected by __job.
+	MethodScopeInstance MethodScope = iota
+
+	// MethodScopeAgent exposes one agent/module method without __job.
+	MethodScopeAgent
+)
+
 // MethodConfig describes a function method provided by a module.
 type MethodConfig struct {
 	ID string // Method ID (e.g., "top-queries")
@@ -23,10 +34,8 @@ type MethodConfig struct {
 	Available func() bool
 	// RawRequest routes the complete Function request to a RawMethodHandler.
 	// Use this for Function APIs that need raw payloads, args, or full response envelopes.
-	RawRequest bool
-	// AgentWide marks a module/static method as agent-level: funcctl omits
-	// __job from the public API and dispatches the method without a RuntimeJob.
-	AgentWide      bool          // Method is agent-wide (does not require __job selector)
+	RawRequest     bool
+	Scope          MethodScope   // Public module method scope; zero value requires __job selector.
 	RequiredParams []ParamConfig // Required parameters for this method (including __sort if used)
 	// FIXME: Presentation is intentionally untyped here, while the shared UI schema
 	// currently defines only topology-specific presentation payloads.

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -199,8 +199,8 @@ func (c *Controller) registerModuleMethodsOnJobStart(moduleName string) {
 	c.registerAvailableModuleMethods(moduleName, methods, false)
 }
 
-func (c *Controller) registerAvailableModuleMethods(moduleName string, methods []funcapi.MethodConfig, agentWideOnly bool) {
-	publishes := c.collectAvailableModuleMethodPublishes(moduleName, methods, agentWideOnly)
+func (c *Controller) registerAvailableModuleMethods(moduleName string, methods []funcapi.MethodConfig, agentScopeOnly bool) {
+	publishes := c.collectAvailableModuleMethodPublishes(moduleName, methods, agentScopeOnly)
 	for _, publish := range publishes {
 		c.registerFunction(publish.name, publish.handler)
 	}
@@ -212,13 +212,13 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 	}
 }
 
-func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, methods []funcapi.MethodConfig, agentWideOnly bool) []functionPublish {
+func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, methods []funcapi.MethodConfig, agentScopeOnly bool) []functionPublish {
 	c.publishedMu.Lock()
 	defer c.publishedMu.Unlock()
 
 	var publishes []functionPublish
 	for i, method := range methods {
-		if agentWideOnly && !method.AgentWide {
+		if agentScopeOnly && method.Scope != funcapi.MethodScopeAgent {
 			continue
 		}
 		if method.ID != "" && c.allMethodFunctionNamesPublishedLocked(moduleName, method) {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -380,12 +380,12 @@ func TestBuildRequiredParamsUsesSelectType(t *testing.T) {
 	assert.Equal(t, "__sort", params[1]["id"])
 }
 
-func TestBuildRequiredParamsAgentWideOmitsJob(t *testing.T) {
+func TestBuildRequiredParamsAgentScopeOmitsJob(t *testing.T) {
 	controller := New(Options{})
 	controller.RegisterModules(collectorapi.Registry{
 		"snmp": collectorapi.Creator{
 			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "topology:snmp", AgentWide: true}}
+				return []funcapi.MethodConfig{{ID: "topology:snmp", Scope: funcapi.MethodScopeAgent}}
 			},
 		},
 	})
@@ -442,12 +442,12 @@ func TestControllerLifecycleHooks(t *testing.T) {
 
 			assert.Empty(t, reg.registeredNames())
 		},
-		"register modules registers available agent-wide methods": func(t *testing.T) {
+		"register modules registers available agent-scope methods": func(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
 					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{ID: "logs", AgentWide: true}}
+						return []funcapi.MethodConfig{{ID: "logs", Scope: funcapi.MethodScopeAgent}}
 					},
 				},
 			})
@@ -490,7 +490,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 
 			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
 		},
-		"availability-gated agent-wide method registers when available": func(t *testing.T) {
+		"availability-gated agent-scope method registers when available": func(t *testing.T) {
 			controller, reg := newController()
 			available := false
 			controller.RegisterModules(collectorapi.Registry{
@@ -498,7 +498,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 					Methods: func() []funcapi.MethodConfig {
 						return []funcapi.MethodConfig{{
 							ID:        "logs",
-							AgentWide: true,
+							Scope:     funcapi.MethodScopeAgent,
 							Available: func() bool { return available },
 						}}
 					},
@@ -689,7 +689,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 							ID:           "topology:snmp",
 							FunctionName: "snmp:topology:snmp",
 							Aliases:      []string{"topology:snmp"},
-							AgentWide:    true,
+							Scope:        funcapi.MethodScopeAgent,
 						}}
 					},
 				},
@@ -908,8 +908,8 @@ func TestControllerStaticPublicationDoesNotHoldLockDuringFunctionGlobal(t *testi
 			"mod": collectorapi.Creator{
 				Methods: func() []funcapi.MethodConfig {
 					return []funcapi.MethodConfig{{
-						ID:        "late",
-						AgentWide: true,
+						ID:    "late",
+						Scope: funcapi.MethodScopeAgent,
 					}}
 				},
 			},
@@ -1321,7 +1321,7 @@ func TestControllerRawModuleMethodRequest(t *testing.T) {
 					return []funcapi.MethodConfig{{
 						ID:         "logs",
 						RawRequest: true,
-						AgentWide:  true,
+						Scope:      funcapi.MethodScopeAgent,
 					}}
 				},
 			}, "mod:logs")
@@ -1329,7 +1329,7 @@ func TestControllerRawModuleMethodRequest(t *testing.T) {
 	}
 }
 
-func TestControllerRawAgentWideModuleMethodDoesNotRequireRunningJob(t *testing.T) {
+func TestControllerRawAgentScopeModuleMethodDoesNotRequireRunningJob(t *testing.T) {
 	var gotCode int
 	var gotResp map[string]any
 	var gotJob collectorapi.RuntimeJob
@@ -1348,7 +1348,7 @@ func TestControllerRawAgentWideModuleMethodDoesNotRequireRunningJob(t *testing.T
 				return []funcapi.MethodConfig{{
 					ID:         "logs",
 					RawRequest: true,
-					AgentWide:  true,
+					Scope:      funcapi.MethodScopeAgent,
 				}}
 			},
 			MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1367,7 +1367,7 @@ func TestControllerRawAgentWideModuleMethodDoesNotRequireRunningJob(t *testing.T
 	})
 
 	reg.call("mod:logs", context.Background(), functions.Function{
-		UID:     "raw-agent-wide",
+		UID:     "raw-agent-scope",
 		Timeout: time.Second,
 	})
 
@@ -1376,7 +1376,7 @@ func TestControllerRawAgentWideModuleMethodDoesNotRequireRunningJob(t *testing.T
 	assert.Nil(t, gotJob)
 }
 
-func TestControllerRawSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testing.T) {
+func TestControllerRawSingleInstanceAgentScopeModuleMethodUsesRunningJob(t *testing.T) {
 	var gotCode int
 	var gotResp map[string]any
 	var gotJob collectorapi.RuntimeJob
@@ -1395,7 +1395,7 @@ func TestControllerRawSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testi
 				return []funcapi.MethodConfig{{
 					ID:         "logs",
 					RawRequest: true,
-					AgentWide:  true,
+					Scope:      funcapi.MethodScopeAgent,
 				}}
 			},
 			MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1416,7 +1416,7 @@ func TestControllerRawSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testi
 	controller.OnJobStart(job)
 
 	reg.call("mod:logs", context.Background(), functions.Function{
-		UID:     "raw-single-agent-wide",
+		UID:     "raw-single-agent-scope",
 		Timeout: time.Second,
 	})
 
@@ -1425,7 +1425,7 @@ func TestControllerRawSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testi
 	assert.Same(t, job, gotJob)
 }
 
-func TestControllerSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testing.T) {
+func TestControllerSingleInstanceAgentScopeModuleMethodUsesRunningJob(t *testing.T) {
 	var gotCode int
 	var gotResp map[string]any
 	var gotJob collectorapi.RuntimeJob
@@ -1442,8 +1442,8 @@ func TestControllerSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testing.
 			InstancePolicy: collectorapi.InstancePolicySingle,
 			Methods: func() []funcapi.MethodConfig {
 				return []funcapi.MethodConfig{{
-					ID:        "status",
-					AgentWide: true,
+					ID:    "status",
+					Scope: funcapi.MethodScopeAgent,
 				}}
 			},
 			MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1478,7 +1478,7 @@ func TestControllerSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testing.
 	controller.OnJobStart(job)
 
 	reg.call("mod:status", context.Background(), functions.Function{
-		UID:     "single-agent-wide",
+		UID:     "single-agent-scope",
 		Timeout: time.Second,
 		Payload: []byte(`{"scope":"all"}`),
 	})
@@ -1489,7 +1489,7 @@ func TestControllerSingleInstanceAgentWideModuleMethodUsesRunningJob(t *testing.
 	assert.Equal(t, []any{"scope"}, gotResp["accepted_params"])
 }
 
-func TestControllerSingleInstanceAgentWideModuleMethodRequiresRunningJob(t *testing.T) {
+func TestControllerSingleInstanceAgentScopeModuleMethodRequiresRunningJob(t *testing.T) {
 	tests := map[string]struct {
 		setup   func(*Controller)
 		message string
@@ -1531,8 +1531,8 @@ func TestControllerSingleInstanceAgentWideModuleMethodRequiresRunningJob(t *test
 					InstancePolicy: collectorapi.InstancePolicySingle,
 					Methods: func() []funcapi.MethodConfig {
 						return []funcapi.MethodConfig{{
-							ID:        "status",
-							AgentWide: true,
+							ID:    "status",
+							Scope: funcapi.MethodScopeAgent,
 						}}
 					},
 					MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1546,7 +1546,7 @@ func TestControllerSingleInstanceAgentWideModuleMethodRequiresRunningJob(t *test
 			}
 
 			reg.call("mod:status", context.Background(), functions.Function{
-				UID:     "single-agent-wide-missing-job",
+				UID:     "single-agent-scope-missing-job",
 				Timeout: time.Second,
 			})
 

--- a/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
@@ -79,7 +79,7 @@ func (c *Controller) executeMethodRequest(parent context.Context, in methodExecu
 	handler := creator.MethodHandler(in.job)
 	if handler == nil {
 		if in.job == nil {
-			c.respondError(in.fn, 500, "module '%s' returned nil handler for agent-wide method '%s'", in.moduleName, in.methodID)
+			c.respondError(in.fn, 500, "module '%s' returned nil handler for agent-scope method '%s'", in.moduleName, in.methodID)
 			return
 		}
 		c.respondError(in.fn, 500, "module '%s' returned nil handler for job '%s'", in.moduleName, in.jobName)

--- a/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
@@ -181,7 +181,7 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 		includeJobParam := methodRequiresJobParam(methodCfg)
 
 		if !includeJobParam {
-			job, jobName, jobGen, ok := c.resolveAgentWideMethodJob(fn, moduleName)
+			job, jobName, jobGen, ok := c.resolveAgentScopeMethodJob(fn, moduleName)
 			if !ok {
 				return
 			}
@@ -264,7 +264,7 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 	}
 }
 
-func (c *Controller) resolveAgentWideMethodJob(fn functions.Function, moduleName string) (collectorapi.RuntimeJob, string, uint64, bool) {
+func (c *Controller) resolveAgentScopeMethodJob(fn functions.Function, moduleName string) (collectorapi.RuntimeJob, string, uint64, bool) {
 	creator, ok := c.registry.getCreator(moduleName)
 	if !ok || creator.InstancePolicy != collectorapi.InstancePolicySingle {
 		return nil, "", 0, true
@@ -527,7 +527,7 @@ func buildAcceptedParams(methodParams []funcapi.ParamConfig, includeJobParam boo
 }
 
 func methodRequiresJobParam(cfg *funcapi.MethodConfig) bool {
-	return cfg == nil || !cfg.AgentWide
+	return cfg == nil || cfg.Scope != funcapi.MethodScopeAgent
 }
 
 func (c *Controller) makePublishedJobMethodFuncHandler(functionName string, generation uint64, moduleName, jobName, methodID string) functions.Handler {

--- a/src/go/plugin/agent/jobmgr/funcctl/response_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/response_test.go
@@ -52,7 +52,7 @@ func TestRespondWithParams_MethodTypeFallback(t *testing.T) {
 	assert.Equal(t, "topology", (*resp)["type"])
 }
 
-func TestRespondWithParams_AgentWideOmitsJobParam(t *testing.T) {
+func TestRespondWithParams_AgentScopeOmitsJobParam(t *testing.T) {
 	controller, resp := newTestControllerWithCapture(t)
 
 	dataResp := &funcapi.FunctionResponse{
@@ -95,7 +95,7 @@ func TestHandleMethodFuncInfo_UsesResponseType(t *testing.T) {
 	assert.Equal(t, "topology", (*resp)["type"])
 }
 
-func TestHandleMethodFuncInfo_AgentWideOmitsJobParam(t *testing.T) {
+func TestHandleMethodFuncInfo_AgentScopeOmitsJobParam(t *testing.T) {
 	controller, resp := newTestControllerWithCapture(t)
 
 	controller.registry.registerModule("snmp", collectorapi.Creator{
@@ -103,7 +103,7 @@ func TestHandleMethodFuncInfo_AgentWideOmitsJobParam(t *testing.T) {
 			return []funcapi.MethodConfig{{
 				ID:           "topology:snmp",
 				ResponseType: "topology",
-				AgentWide:    true,
+				Scope:        funcapi.MethodScopeAgent,
 				RequiredParams: []funcapi.ParamConfig{{
 					ID:        "topology_view",
 					Name:      "Topology View",

--- a/src/go/plugin/agent/jobmgr/funcdispatch_test.go
+++ b/src/go/plugin/agent/jobmgr/funcdispatch_test.go
@@ -203,7 +203,7 @@ func TestExecuteFunction_ModuleMethodPublicFunctionName(t *testing.T) {
 	assert.Equal(t, "logs", gotMethod)
 }
 
-func TestExecuteFunction_AgentWideModuleMethodDoesNotRequireRunningJob(t *testing.T) {
+func TestExecuteFunction_AgentScopeModuleMethodDoesNotRequireRunningJob(t *testing.T) {
 	tests := map[string]struct {
 		functionName string
 	}{
@@ -232,7 +232,7 @@ func TestExecuteFunction_AgentWideModuleMethodDoesNotRequireRunningJob(t *testin
 							ID:           "topology:snmp",
 							FunctionName: "snmp:topology:snmp",
 							Aliases:      []string{"topology:snmp"},
-							AgentWide:    true,
+							Scope:        funcapi.MethodScopeAgent,
 							RequiredParams: []funcapi.ParamConfig{{
 								ID:        "scope",
 								Name:      "Scope",
@@ -257,7 +257,7 @@ func TestExecuteFunction_AgentWideModuleMethodDoesNotRequireRunningJob(t *testin
 			mgr.funcCtl.RegisterModules(mgr.modules)
 
 			mgr.ExecuteFunction(tc.functionName, functions.Function{
-				UID:     "agent-wide-public-name",
+				UID:     "agent-scope-public-name",
 				Timeout: time.Second,
 				Args:    []string{"scope:all"},
 			})
@@ -271,7 +271,7 @@ func TestExecuteFunction_AgentWideModuleMethodDoesNotRequireRunningJob(t *testin
 	}
 }
 
-func TestExecuteFunction_AgentWideModuleMethodValidationErrorOmitsJob(t *testing.T) {
+func TestExecuteFunction_AgentScopeModuleMethodValidationErrorOmitsJob(t *testing.T) {
 	writer := &jsonWriteCapture{}
 
 	mgr := New(Config{
@@ -282,8 +282,8 @@ func TestExecuteFunction_AgentWideModuleMethodValidationErrorOmitsJob(t *testing
 		"mod": collectorapi.Creator{
 			Methods: func() []funcapi.MethodConfig {
 				return []funcapi.MethodConfig{{
-					ID:        "logs",
-					AgentWide: true,
+					ID:    "logs",
+					Scope: funcapi.MethodScopeAgent,
 					RequiredParams: []funcapi.ParamConfig{{
 						ID:        "scope",
 						Name:      "Scope",
@@ -303,7 +303,7 @@ func TestExecuteFunction_AgentWideModuleMethodValidationErrorOmitsJob(t *testing
 	mgr.funcCtl.RegisterModules(mgr.modules)
 
 	mgr.ExecuteFunction("mod:logs", functions.Function{
-		UID:     "agent-wide-validation",
+		UID:     "agent-scope-validation",
 		Timeout: time.Second,
 		Args:    []string{"scope:a,b"},
 	})

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -668,14 +668,14 @@ func TestRun_DoesNotRegisterJobBoundModuleMethodsBeforeAnyJobStarts(t *testing.T
 	assert.Empty(t, fnReg.registeredNames(), "static methods must not be registered before first started job")
 }
 
-func TestRun_RegistersAgentWideModuleMethodsBeforeAnyJobStarts(t *testing.T) {
+func TestRun_RegistersAgentScopeModuleMethodsBeforeAnyJobStarts(t *testing.T) {
 	fnReg := &recordingFunctionRegistry{}
 	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
 
 	mgr.modules = collectorapi.Registry{
 		"mod": collectorapi.Creator{
 			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "a", AgentWide: true}}
+				return []funcapi.MethodConfig{{ID: "a", Scope: funcapi.MethodScopeAgent}}
 			},
 		},
 	}

--- a/src/go/plugin/framework/collectorapi/registry.go
+++ b/src/go/plugin/framework/collectorapi/registry.go
@@ -67,10 +67,10 @@ type (
 		Methods func() []funcapi.MethodConfig
 
 		// Optional: MethodHandler returns a handler for method requests.
-		// AgentWide module methods are dispatched with nil job, except that
-		// single-instance collectors receive their running canonical job.
-		// Job-bound module methods and JobMethods are dispatched with the
-		// selected running job.
+		// MethodScopeAgent module methods are dispatched with nil job, except
+		// that single-instance collectors receive their running canonical job.
+		// MethodScopeInstance module methods and JobMethods are dispatched with
+		// the selected running job.
 		// When the canonical single-instance job is not running, dispatch returns
 		// unavailable before calling MethodHandler.
 		// The handler implements funcapi.MethodHandler interface with:

--- a/src/go/plugin/go.d/collector/cato_networks/topology_test.go
+++ b/src/go/plugin/go.d/collector/cato_networks/topology_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/require"
 
+	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
 	topologyv1 "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cato_networks/catofunc"
 )
@@ -45,7 +46,7 @@ func TestTopologyFunction(t *testing.T) {
 		"requires job selection": {
 			check: func(t *testing.T, _ *Collector) {
 				cfg := catofunc.Methods(defaultUpdateEvery)[0]
-				require.False(t, cfg.AgentWide)
+				require.Equal(t, funcapi.MethodScopeInstance, cfg.Scope)
 			},
 		},
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -28,7 +28,7 @@ func TestSNMPTopologyCreatorOwnsTopologyFunction(t *testing.T) {
 	require.Len(t, methods, 1)
 	require.Equal(t, snmptopologyfunc.MethodID, methods[0].ID)
 	require.Equal(t, snmptopologyfunc.FunctionName, methods[0].FunctionName)
-	require.True(t, methods[0].AgentWide)
+	require.Equal(t, funcapi.MethodScopeAgent, methods[0].Scope)
 	require.NotNil(t, methods[0].Available)
 	require.False(t, methods[0].Available())
 

--- a/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/presentation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/presentation.go
@@ -23,7 +23,7 @@ func methodConfig() funcapi.MethodConfig {
 		Help:         "SNMP Layer-2 topology and neighbor discovery data",
 		RequireCloud: true,
 		ResponseType: topologyv1.ResponseType,
-		AgentWide:    true,
+		Scope:        funcapi.MethodScopeAgent,
 		RequiredParams: []funcapi.ParamConfig{
 			nodesIdentityParamConfig(),
 			mapTypeParamConfig(),

--- a/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/topology_test.go
@@ -23,7 +23,7 @@ func TestMethodsIncludesSelectors(t *testing.T) {
 	assert.Equal(t, FunctionName, cfg.FunctionName)
 	assert.Equal(t, []string{MethodID}, cfg.Aliases)
 	assert.Equal(t, "topology", cfg.ResponseType)
-	assert.True(t, cfg.AgentWide)
+	assert.Equal(t, funcapi.MethodScopeAgent, cfg.Scope)
 	require.Len(t, cfg.RequiredParams, 5)
 	require.Nil(t, cfg.Presentation())
 

--- a/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
@@ -37,7 +37,7 @@ func TestSNMPTrapsMethodsExposeLogsOnly(t *testing.T) {
 	assert.Equal(t, "logs", logs.ResponseType)
 	assert.True(t, logs.RawRequest)
 	assert.True(t, logs.RequireCloud)
-	assert.True(t, logs.AgentWide)
+	assert.Equal(t, funcapi.MethodScopeAgent, logs.Scope)
 	assert.NotNil(t, logs.Available)
 }
 

--- a/src/go/plugin/go.d/collector/snmp_traps/reload_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/reload_test.go
@@ -460,7 +460,7 @@ func TestSnmpTrapsMethods(t *testing.T) {
 	}
 
 	logs := byID[snmpTrapsLogsMethodID]
-	assert.True(t, logs.AgentWide)
+	assert.Equal(t, funcapi.MethodScopeAgent, logs.Scope)
 	assert.Equal(t, snmpTrapsFunctionName, logs.FunctionName)
 	assert.True(t, logs.RawRequest)
 	assert.Equal(t, "logs", logs.ResponseType)

--- a/src/go/plugin/go.d/collector/snmp_traps/snmptrapsfunc/func_logs.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/snmptrapsfunc/func_logs.go
@@ -50,7 +50,7 @@ func LogsMethodConfig(available func() bool) funcapi.MethodConfig {
 		ResponseType: "logs",
 		Available:    available,
 		RawRequest:   true,
-		AgentWide:    true,
+		Scope:        funcapi.MethodScopeAgent,
 	}
 }
 

--- a/src/go/plugin/go.d/collector/vsphere/func_readiness_test.go
+++ b/src/go/plugin/go.d/collector/vsphere/func_readiness_test.go
@@ -45,7 +45,7 @@ func TestVSphereMethods(t *testing.T) {
 			require.Equal(t, tc.wantName, method.Name)
 			require.Equal(t, 30, method.UpdateEvery)
 			require.True(t, method.RequireCloud)
-			require.False(t, method.AgentWide)
+			require.Equal(t, funcapi.MethodScopeInstance, method.Scope)
 			if tc.alias != "" {
 				require.Contains(t, method.Aliases, tc.alias)
 			}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `AgentWide` boolean with a `MethodScope` enum to make module method scope explicit and keep the public API consistent. Also aligned error messages and test names to use “agent-scope” wording, with no behavior changes.

- **Refactors**
  - Added `funcapi.MethodScope` with `MethodScopeInstance` and `MethodScopeAgent`.
  - Replaced `MethodConfig.AgentWide` with `MethodConfig.Scope`.
  - Updated `funcctl`: registration/dispatch now use agent “scope” (`resolveAgentScopeMethodJob`, `methodRequiresJobParam`), and agent-scope methods publish before any job starts; error wording uses “agent-scope”.
  - Clarified `collectorapi.Creator.MethodHandler` docs for single-instance scope behavior and updated go.d collectors/tests (`snmp_topology`, `snmp_traps`, `cato_networks`, `vsphere`) and internal docs to `MethodScope`.

- **Migration**
  - Replace `AgentWide: true` with `Scope: funcapi.MethodScopeAgent`.
  - Instance-scoped methods can omit `Scope` (default is instance) or set `Scope: funcapi.MethodScopeInstance`.
  - Update tests to assert `Scope` and use “agent-scope” wording.

<sup>Written for commit bc2aedab0224c531a90a87944e37a8b7e1ad4055. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

