### PR TITLE
refactor(go.d): split function declaration API

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -67,13 +67,13 @@ source files for evidence.
 - If Functions exist, isolate them in a `<name>func/` subpackage with a narrow
   `Deps` interface declared there. The Function package MUST NOT import the
   collector package or hold `*Collector`.
-- If a single-instance collector exposes `MethodScopeAgent` module `Methods`, its
-  `MethodHandler(job)` receives the running canonical runtime job. Use
-  `job.Collector()` to bind the Function handler to collector-owned state; do
-  not add a `__job` parameter or introduce a package-global registry to bridge
-  Function dispatch. During method execution, when the singleton job is not
-  running, the framework returns an unavailable response before calling
-  `MethodHandler`.
+- If a single-instance collector exposes `Creator.SharedFunctions`, its
+  `MethodHandler(job)` receives the running canonical runtime job and the public
+  Function shape has no `__job` parameter. Use `job.Collector()` to bind the
+  Function handler to collector-owned state; do not add a package-global
+  registry to bridge Function dispatch. During method execution, when the
+  singleton job is not running, the framework returns an unavailable response
+  before calling `MethodHandler`.
 - `collectorapi.Creator.InstancePolicy` defaults to
   `InstancePolicyPerJob`. Use `InstancePolicySingle` only for collectors that
   are intentionally one canonical job per agent. Single-instance configs MUST

--- a/.agents/sow/specs/go-function-publication-lifecycle.md
+++ b/.agents/sow/specs/go-function-publication-lifecycle.md
@@ -4,31 +4,36 @@
 
 This spec applies to go.d Functions registered through:
 
-- `collectorapi.Creator.Methods` for module/static methods.
+- `collectorapi.Creator.SharedFunctions` for static shared job-backed
+  Functions.
+- `collectorapi.Creator.AgentFunctions` for static true-agent Functions.
 - `collectorapi.Creator.JobMethods` for per-job methods.
-- `funcapi.MethodConfig.Available` for first-publication gating.
+- `funcapi.FunctionConfig.Available` for first-publication gating.
 
 It does not define Netdata Cloud discovery behavior beyond the Agent-side
 publication stream emitted by go.d.
 
-## Module And Static Methods
+## Static Functions
 
-- Module/static methods MUST be declared through `collectorapi.Creator.Methods`.
-- funcctl owns module/static Function publication. Collectors MUST NOT publish
-  their module/static Functions by calling `funcctl`, `dyncfg.Responder`,
+- Static shared job-backed Functions MUST be declared through
+  `collectorapi.Creator.SharedFunctions`.
+- Static true-agent Functions MUST be declared through
+  `collectorapi.Creator.AgentFunctions`.
+- funcctl owns static Function publication. Collectors MUST NOT publish
+  their static Functions by calling `funcctl`, `dyncfg.Responder`,
   `netdataapi`, or plugins.d `FUNCTION` commands directly.
 - `Available == nil` means the method is available for publication.
 - `Available != nil` gates first publication only.
-- funcctl MAY recheck unpublished module/static methods while jobs are running.
+- funcctl MAY recheck unpublished static Functions while jobs are running.
   jobmgr currently performs this recheck from the running-job tick loop.
 - Publication is monotonic:
-  - once funcctl publishes a module/static Function, later `Available == false`
+  - once funcctl publishes a static Function, later `Available == false`
     results MUST NOT withdraw it;
   - the Function remains published until go.d cleanup or restart;
   - withdrawal-on-empty requires a separate explicit lifecycle design.
 - Rechecks MUST reuse the normal funcctl publication path so public names,
-  aliases, tags, `RequireCloud`, `MethodScope`, handler wiring, and collision
-  behavior stay consistent.
+  aliases, tags, `RequireCloud`, handler wiring, and collision behavior stay
+  consistent.
 
 ## `Available` Predicate Contract
 
@@ -51,7 +56,7 @@ publication stream emitted by go.d.
 
 ## Validation Guidance
 
-- Tests for a module/static method with `Available` SHOULD cover:
+- Tests for a static Function with `Available` SHOULD cover:
   - not published at module registration or job start while unavailable;
   - published after a running-job recheck when availability turns true;
   - not duplicated after publication;

--- a/src/go/cmd/godplugin/main.go
+++ b/src/go/cmd/godplugin/main.go
@@ -271,7 +271,7 @@ func resolveFunctionCLIRequest(functionName string, registry collectorapi.Regist
 			err:    fmt.Errorf("unknown module '%s'", splitModuleName),
 		}
 	}
-	if creator.Methods == nil {
+	if len(functionCLIStaticFunctions(creator)) == 0 {
 		return "", "", collectorapi.Creator{}, functionCLIResolutionError{
 			status: 404,
 			err:    fmt.Errorf("module '%s' does not expose functions", splitModuleName),
@@ -289,19 +289,27 @@ func resolveFunctionCLIRequestByPublicName(functionName string, registry collect
 
 	for _, moduleName := range moduleNames {
 		creator := registry[moduleName]
-		if creator.Methods == nil {
-			continue
-		}
-		for _, method := range creator.Methods() {
+		for _, method := range functionCLIStaticFunctions(creator) {
 			if method.ID == "" {
 				continue
 			}
-			if slices.Contains(funcapi.MethodFunctionNames(moduleName, method), functionName) {
+			if slices.Contains(funcapi.FunctionNames(moduleName, method), functionName) {
 				return moduleName, method.ID, creator, true
 			}
 		}
 	}
 	return "", "", collectorapi.Creator{}, false
+}
+
+func functionCLIStaticFunctions(creator collectorapi.Creator) []funcapi.FunctionConfig {
+	var functions []funcapi.FunctionConfig
+	if creator.SharedFunctions != nil {
+		functions = append(functions, creator.SharedFunctions()...)
+	}
+	if creator.AgentFunctions != nil {
+		functions = append(functions, creator.AgentFunctions()...)
+	}
+	return functions
 }
 
 func readFunctionPayload(raw string) ([]byte, time.Duration, error) {

--- a/src/go/cmd/godplugin/main_test.go
+++ b/src/go/cmd/godplugin/main_test.go
@@ -30,18 +30,18 @@ func TestModuleRegistryWithSystemdPolicy(t *testing.T) {
 func TestResolveFunctionCLIRequest(t *testing.T) {
 	registry := collectorapi.Registry{
 		"snmp": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "topology:snmp", Aliases: []string{"topology:snmp"}}}
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "topology:snmp", Aliases: []string{"topology:snmp"}}}
 			},
 		},
 		"snmp_traps": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "logs", FunctionName: "snmp:traps"}}
+			AgentFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "logs", FunctionName: "snmp:traps"}}
 			},
 		},
 		"plain": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "details"}}
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "details"}}
 			},
 		},
 		"nofunc": collectorapi.Creator{},
@@ -106,13 +106,13 @@ func TestResolveFunctionCLIRequest(t *testing.T) {
 func TestResolveFunctionCLIRequestPublicNameCollisionUsesSortedModule(t *testing.T) {
 	registry := collectorapi.Registry{
 		"bbb": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "logs", FunctionName: "shared:logs"}}
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "logs", FunctionName: "shared:logs"}}
 			},
 		},
 		"aaa": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "logs", FunctionName: "shared:logs"}}
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "logs", FunctionName: "shared:logs"}}
 			},
 		},
 	}

--- a/src/go/pkg/funcapi/handler.go
+++ b/src/go/pkg/funcapi/handler.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-// MethodHandler defines the interface for handling method requests.
-// Methods are defined in Creator.Methods(); this interface handles the requests.
+// MethodHandler defines the interface for handling Function method requests.
+// Functions are declared by collector creators; this interface handles requests.
 //
 // Example implementation:
 //
@@ -26,7 +26,7 @@ import (
 //	}
 type MethodHandler interface {
 	// MethodParams returns dynamic params for a method.
-	// Return nil to use static params from MethodConfig.RequiredParams.
+	// Return nil to use static params from FunctionConfig.RequiredParams.
 	// The context should be used for timeout/cancellation of database queries.
 	MethodParams(ctx context.Context, method string) ([]ParamConfig, error)
 

--- a/src/go/pkg/funcapi/handler_test.go
+++ b/src/go/pkg/funcapi/handler_test.go
@@ -11,12 +11,12 @@ import (
 
 // mockHandler implements MethodHandler for testing.
 type mockHandler struct {
-	methods      []MethodConfig
+	methods      []FunctionConfig
 	methodParams []ParamConfig
 	response     *FunctionResponse
 }
 
-func (m *mockHandler) Methods() []MethodConfig {
+func (m *mockHandler) Methods() []FunctionConfig {
 	return m.methods
 }
 
@@ -35,7 +35,7 @@ func TestMethodHandler_Interface(t *testing.T) {
 	var _ MethodHandler = &mockHandler{}
 
 	h := &mockHandler{
-		methods:  []MethodConfig{{ID: "test", Name: "Test"}},
+		methods:  []FunctionConfig{{ID: "test", Name: "Test"}},
 		response: &FunctionResponse{Status: 200},
 	}
 

--- a/src/go/pkg/funcapi/method.go
+++ b/src/go/pkg/funcapi/method.go
@@ -4,17 +4,17 @@ package funcapi
 
 import "fmt"
 
-// MethodFunctionName returns the primary public Function name for a module method.
-func MethodFunctionName(moduleName string, method MethodConfig) string {
+// FunctionName returns the primary public Function name for a module method.
+func FunctionName(moduleName string, method FunctionConfig) string {
 	if method.FunctionName != "" {
 		return method.FunctionName
 	}
 	return fmt.Sprintf("%s:%s", moduleName, method.ID)
 }
 
-// MethodFunctionNames returns the primary public Function name plus aliases.
-func MethodFunctionNames(moduleName string, method MethodConfig) []string {
-	funcName := MethodFunctionName(moduleName, method)
+// FunctionNames returns the primary public Function name plus aliases.
+func FunctionNames(moduleName string, method FunctionConfig) []string {
+	funcName := FunctionName(moduleName, method)
 	funcNames := []string{funcName}
 	seen := map[string]struct{}{funcName: {}}
 

--- a/src/go/pkg/funcapi/method_test.go
+++ b/src/go/pkg/funcapi/method_test.go
@@ -8,28 +8,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMethodFunctionNames(t *testing.T) {
+func TestFunctionNames(t *testing.T) {
 	tests := map[string]struct {
-		method MethodConfig
+		method FunctionConfig
 		want   []string
 	}{
 		"default module method name": {
-			method: MethodConfig{ID: "logs"},
+			method: FunctionConfig{ID: "logs"},
 			want:   []string{"mod:logs"},
 		},
 		"explicit public function name": {
-			method: MethodConfig{ID: "logs", FunctionName: "snmp:traps"},
+			method: FunctionConfig{ID: "logs", FunctionName: "snmp:traps"},
 			want:   []string{"snmp:traps"},
 		},
 		"aliases are appended once": {
-			method: MethodConfig{
+			method: FunctionConfig{
 				ID:      "topology:snmp",
 				Aliases: []string{"topology:snmp", "topology:snmp", ""},
 			},
 			want: []string{"mod:topology:snmp", "topology:snmp"},
 		},
 		"aliases matching explicit function name are ignored": {
-			method: MethodConfig{
+			method: FunctionConfig{
 				ID:           "logs",
 				FunctionName: "snmp:traps",
 				Aliases:      []string{"snmp:traps", "snmp:trap-events"},
@@ -40,7 +40,7 @@ func TestMethodFunctionNames(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.want, MethodFunctionNames("mod", tc.method))
+			assert.Equal(t, tc.want, FunctionNames("mod", tc.method))
 		})
 	}
 }

--- a/src/go/pkg/funcapi/response.go
+++ b/src/go/pkg/funcapi/response.go
@@ -2,24 +2,13 @@
 
 package funcapi
 
-// MethodScope controls the public API shape for creator-level module methods.
-type MethodScope uint8
-
-const (
-	// MethodScopeInstance exposes a shared module method selected by __job.
-	MethodScopeInstance MethodScope = iota
-
-	// MethodScopeAgent exposes one agent/module method without __job.
-	MethodScopeAgent
-)
-
-// MethodConfig describes a function method provided by a module.
-type MethodConfig struct {
-	ID string // Method ID (e.g., "top-queries")
-	// FunctionName overrides the public Function name for module/static methods.
+// FunctionConfig describes a Function provided by a module.
+type FunctionConfig struct {
+	ID string // Function ID (e.g., "top-queries")
+	// FunctionName overrides the public Function name.
 	// Empty uses the default "<module>:<method>" name.
 	FunctionName string
-	// FIXME: funcctl currently honors aliases only for module/static methods.
+	// FIXME: funcctl currently honors aliases only for module/static Functions.
 	// Job method registration still publishes only the canonical module:method name.
 	Aliases      []string // Additional function names to register for this method
 	Name         string   // Display name (e.g., "Top Queries")
@@ -35,7 +24,6 @@ type MethodConfig struct {
 	// RawRequest routes the complete Function request to a RawMethodHandler.
 	// Use this for Function APIs that need raw payloads, args, or full response envelopes.
 	RawRequest     bool
-	Scope          MethodScope   // Public module method scope; zero value requires __job selector.
 	RequiredParams []ParamConfig // Required parameters for this method (including __sort if used)
 	// FIXME: Presentation is intentionally untyped here, while the shared UI schema
 	// currently defines only topology-specific presentation payloads.
@@ -44,13 +32,13 @@ type MethodConfig struct {
 
 // WithPresentation returns an updated copy with optional presentation metadata attached.
 // This uses builder-style value semantics so it can be chained from composite literals.
-func (cfg MethodConfig) WithPresentation(v any) MethodConfig {
+func (cfg FunctionConfig) WithPresentation(v any) FunctionConfig {
 	cfg.presentation = v
 	return cfg
 }
 
 // Presentation returns optional presentation metadata for the method info response.
-func (cfg MethodConfig) Presentation() any {
+func (cfg FunctionConfig) Presentation() any {
 	return cfg.presentation
 }
 
@@ -59,7 +47,7 @@ type FunctionResponse struct {
 	Status            int            // HTTP-like status code (200, 400, 403, 500, 503)
 	Message           string         // Error message (if Status != 200)
 	Help              string         // Help text for this response
-	ResponseType      string         // Override response schema type (defaults to MethodConfig.ResponseType)
+	ResponseType      string         // Override response schema type (defaults to FunctionConfig.ResponseType)
 	Columns           map[string]any // Column definitions for the table
 	Data              any            // Row data: [][]any (array of arrays, ordered by column index)
 	DefaultSortColumn string         // Default sort column ID
@@ -68,7 +56,7 @@ type FunctionResponse struct {
 	// When set, Status/Message/Columns/Data and framework response wrapping are ignored.
 	RawResponse map[string]any
 
-	// Optional dynamic required params (override MethodConfig.RequiredParams)
+	// Optional dynamic required params (override FunctionConfig.RequiredParams)
 	RequiredParams []ParamConfig
 
 	// Chart configuration for visualization (embedded for JSON compatibility)

--- a/src/go/pkg/funcapi/response_test.go
+++ b/src/go/pkg/funcapi/response_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMethodConfig_WithPresentationReturnsUpdatedCopy(t *testing.T) {
-	cfg := MethodConfig{ID: "topology"}
+func TestFunctionConfig_WithPresentationReturnsUpdatedCopy(t *testing.T) {
+	cfg := FunctionConfig{ID: "topology"}
 
 	updated := cfg.WithPresentation(map[string]any{"mode": "graph"})
 

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -85,34 +85,58 @@ func (c *Controller) RegisterModules(modules collectorapi.Registry) {
 	plannedPublicNames := make(map[string]string)
 	for _, name := range names {
 		creator := modules[name]
-		if creator.Methods == nil && creator.JobMethods == nil {
+		if creator.SharedFunctions == nil && creator.AgentFunctions == nil && creator.JobMethods == nil {
 			continue
 		}
-		methods := moduleMethods(creator)
-		if functionName, owner, collides := c.moduleMethodPublicNameCollision(name, methods, plannedPublicNames); collides {
+		functions := moduleFunctionDeclarations(creator)
+		if functionName, owner, collides := c.moduleMethodPublicNameCollision(name, functions.configs, plannedPublicNames); collides {
 			c.Errorf("skipping function registration for module '%s': public function name '%s' collides with %s", name, functionName, owner)
 			continue
 		}
-		c.registry.registerModuleWithMethods(name, creator, methods)
-		c.registerAvailableModuleMethods(name, methods, true)
+		c.registry.registerModuleWithDeclarations(name, creator, functions)
+		c.registerAvailableModuleMethods(name, functions.configs, true)
 	}
 }
 
-func moduleMethods(creator collectorapi.Creator) []funcapi.MethodConfig {
-	if creator.Methods == nil {
+type moduleFunctionDecls struct {
+	configs []funcapi.FunctionConfig
+	kinds   map[string]moduleFunctionKind
+}
+
+func moduleFunctionDeclarations(creator collectorapi.Creator) moduleFunctionDecls {
+	shared := moduleSharedFunctions(creator)
+	agent := moduleAgentFunctions(creator)
+	configs := make([]funcapi.FunctionConfig, 0, len(shared)+len(agent))
+	configs = append(configs, shared...)
+	configs = append(configs, agent...)
+	return moduleFunctionDecls{
+		configs: configs,
+		kinds:   indexModuleFunctionKinds(shared, agent),
+	}
+}
+
+func moduleSharedFunctions(creator collectorapi.Creator) []funcapi.FunctionConfig {
+	if creator.SharedFunctions == nil {
 		return nil
 	}
-	return creator.Methods()
+	return creator.SharedFunctions()
 }
 
-func (c *Controller) moduleMethodPublicNameCollision(moduleName string, methods []funcapi.MethodConfig, planned map[string]string) (string, string, bool) {
+func moduleAgentFunctions(creator collectorapi.Creator) []funcapi.FunctionConfig {
+	if creator.AgentFunctions == nil {
+		return nil
+	}
+	return creator.AgentFunctions()
+}
+
+func (c *Controller) moduleMethodPublicNameCollision(moduleName string, methods []funcapi.FunctionConfig, planned map[string]string) (string, string, bool) {
 	modulePlanned := make(map[string]string)
 	for _, method := range methods {
 		if method.ID == "" {
 			continue
 		}
 		owner := fmt.Sprintf("%s:%s", moduleName, method.ID)
-		for _, functionName := range funcapi.MethodFunctionNames(moduleName, method) {
+		for _, functionName := range funcapi.FunctionNames(moduleName, method) {
 			if routeModule, routeMethod, ok := c.registry.resolveMethodRoute(functionName); ok {
 				return functionName, fmt.Sprintf("%s:%s", routeModule, routeMethod), true
 			}
@@ -199,7 +223,7 @@ func (c *Controller) registerModuleMethodsOnJobStart(moduleName string) {
 	c.registerAvailableModuleMethods(moduleName, methods, false)
 }
 
-func (c *Controller) registerAvailableModuleMethods(moduleName string, methods []funcapi.MethodConfig, agentScopeOnly bool) {
+func (c *Controller) registerAvailableModuleMethods(moduleName string, methods []funcapi.FunctionConfig, agentScopeOnly bool) {
 	publishes := c.collectAvailableModuleMethodPublishes(moduleName, methods, agentScopeOnly)
 	for _, publish := range publishes {
 		c.registerFunction(publish.name, publish.handler)
@@ -212,16 +236,17 @@ func (c *Controller) registerAvailableModuleMethods(moduleName string, methods [
 	}
 }
 
-func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, methods []funcapi.MethodConfig, agentScopeOnly bool) []functionPublish {
+func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, methods []funcapi.FunctionConfig, agentScopeOnly bool) []functionPublish {
 	c.publishedMu.Lock()
 	defer c.publishedMu.Unlock()
 
 	var publishes []functionPublish
 	for i, method := range methods {
-		if agentScopeOnly && method.Scope != funcapi.MethodScopeAgent {
+		kind := c.registry.getModuleFunctionKind(moduleName, method.ID)
+		if agentScopeOnly && c.methodRequiresJobParam(moduleName, kind) {
 			continue
 		}
-		if method.ID != "" && c.allMethodFunctionNamesPublishedLocked(moduleName, method) {
+		if method.ID != "" && c.allFunctionNamesPublishedLocked(moduleName, method) {
 			continue
 		}
 		if !methodAvailable(method) {
@@ -245,7 +270,7 @@ func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, me
 		}
 
 		if c.api != nil {
-			for _, funcName := range funcapi.MethodFunctionNames(moduleName, method) {
+			for _, funcName := range funcapi.FunctionNames(moduleName, method) {
 				if c.publishedFns.has(funcName) {
 					continue
 				}
@@ -267,7 +292,7 @@ func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, me
 			continue
 		}
 
-		for _, funcName := range funcapi.MethodFunctionNames(moduleName, method) {
+		for _, funcName := range funcapi.FunctionNames(moduleName, method) {
 			if c.publishedFns.has(funcName) {
 				continue
 			}
@@ -281,19 +306,19 @@ func (c *Controller) collectAvailableModuleMethodPublishes(moduleName string, me
 	return publishes
 }
 
-func (c *Controller) allMethodFunctionNamesPublishedLocked(moduleName string, method funcapi.MethodConfig) bool {
-	names := funcapi.MethodFunctionNames(moduleName, method)
+func (c *Controller) allFunctionNamesPublishedLocked(moduleName string, method funcapi.FunctionConfig) bool {
+	names := funcapi.FunctionNames(moduleName, method)
 	return c.publishedFns.all(names)
 }
 
-func methodTags(method funcapi.MethodConfig) string {
+func methodTags(method funcapi.FunctionConfig) string {
 	if method.Tags != "" {
 		return method.Tags
 	}
 	return "top"
 }
 
-func methodAvailable(method funcapi.MethodConfig) bool {
+func methodAvailable(method funcapi.FunctionConfig) bool {
 	return method.Available == nil || method.Available()
 }
 
@@ -308,7 +333,7 @@ func (c *Controller) registerFunction(name string, handler functions.Handler) {
 	})
 }
 
-func (c *Controller) registerJobMethods(job collectorapi.RuntimeJob, methods []funcapi.MethodConfig) {
+func (c *Controller) registerJobMethods(job collectorapi.RuntimeJob, methods []funcapi.FunctionConfig) {
 	planned := make(map[string]struct{}, len(methods))
 
 	for _, method := range methods {
@@ -349,7 +374,7 @@ func (c *Controller) registerJobMethods(job collectorapi.RuntimeJob, methods []f
 	}
 }
 
-func (c *Controller) collectJobMethodPublishes(job collectorapi.RuntimeJob, methods []funcapi.MethodConfig) []functionPublish {
+func (c *Controller) collectJobMethodPublishes(job collectorapi.RuntimeJob, methods []funcapi.FunctionConfig) []functionPublish {
 	c.publishedMu.Lock()
 	defer c.publishedMu.Unlock()
 

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -50,8 +50,8 @@ func TestModuleFuncRegistry_RegisterModule(t *testing.T) {
 
 			for _, module := range tc.modules {
 				r.registerModule(module, collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{ID: "test"}}
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "test"}}
 					},
 				})
 			}
@@ -144,9 +144,9 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 		},
 		"get methods": {
 			run: func(t *testing.T, r *moduleFuncRegistry) {
-				expectedMethods := []funcapi.MethodConfig{{ID: "top-queries", Name: "Top Queries"}}
+				expectedMethods := []funcapi.FunctionConfig{{ID: "top-queries", Name: "Top Queries"}}
 				r.registerModule("postgres", collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig { return expectedMethods },
+					SharedFunctions: func() []funcapi.FunctionConfig { return expectedMethods },
 				})
 
 				assert.Equal(t, expectedMethods, r.getMethods("postgres"))
@@ -203,8 +203,8 @@ func TestModuleFuncRegistry_Operations(t *testing.T) {
 func TestModuleFuncRegistry_Concurrency(t *testing.T) {
 	r := newModuleFuncRegistry()
 	r.registerModule("postgres", collectorapi.Creator{
-		Methods: func() []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{{ID: "test"}}
+		SharedFunctions: func() []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "test"}}
 		},
 	})
 
@@ -234,11 +234,11 @@ func TestModuleFuncRegistry_Concurrency(t *testing.T) {
 
 func TestModuleFuncRegistry_MethodRouteCollisionUsesDeterministicOwner(t *testing.T) {
 	r := newModuleFuncRegistry()
-	r.registerModuleWithMethods("bbb", collectorapi.Creator{}, []funcapi.MethodConfig{{
+	r.registerModuleWithMethods("bbb", collectorapi.Creator{}, []funcapi.FunctionConfig{{
 		ID:           "logs",
 		FunctionName: "shared:logs",
 	}})
-	r.registerModuleWithMethods("aaa", collectorapi.Creator{}, []funcapi.MethodConfig{{
+	r.registerModuleWithMethods("aaa", collectorapi.Creator{}, []funcapi.FunctionConfig{{
 		ID:           "logs",
 		FunctionName: "shared:logs",
 	}})
@@ -251,11 +251,11 @@ func TestModuleFuncRegistry_MethodRouteCollisionUsesDeterministicOwner(t *testin
 
 func TestModuleFuncRegistry_MethodRouteRefreshesAffectedNames(t *testing.T) {
 	r := newModuleFuncRegistry()
-	r.registerModuleWithMethods("bbb", collectorapi.Creator{}, []funcapi.MethodConfig{{
+	r.registerModuleWithMethods("bbb", collectorapi.Creator{}, []funcapi.FunctionConfig{{
 		ID:           "logs",
 		FunctionName: "shared:logs",
 	}})
-	r.registerModuleWithMethods("aaa", collectorapi.Creator{}, []funcapi.MethodConfig{{
+	r.registerModuleWithMethods("aaa", collectorapi.Creator{}, []funcapi.FunctionConfig{{
 		ID:           "logs",
 		FunctionName: "shared:logs",
 	}})
@@ -345,8 +345,8 @@ func TestBuildRequiredParamsUsesSelectType(t *testing.T) {
 	controller := New(Options{})
 	controller.RegisterModules(collectorapi.Registry{
 		"postgres": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "top-queries", Name: "Top Queries"}}
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "top-queries", Name: "Top Queries"}}
 			},
 		},
 	})
@@ -384,8 +384,8 @@ func TestBuildRequiredParamsAgentScopeOmitsJob(t *testing.T) {
 	controller := New(Options{})
 	controller.RegisterModules(collectorapi.Registry{
 		"snmp": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "topology:snmp", Scope: funcapi.MethodScopeAgent}}
+			AgentFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "topology:snmp"}}
 			},
 		},
 	})
@@ -436,7 +436,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+					SharedFunctions: func() []funcapi.FunctionConfig { return []funcapi.FunctionConfig{{ID: "a"}} },
 				},
 			})
 
@@ -446,8 +446,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{ID: "logs", Scope: funcapi.MethodScopeAgent}}
+					AgentFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "logs"}}
 					},
 				},
 			})
@@ -458,7 +458,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+					SharedFunctions: func() []funcapi.FunctionConfig { return []funcapi.FunctionConfig{{ID: "a"}} },
 				},
 			})
 
@@ -472,8 +472,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			available := false
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID:        "logs",
 							Available: func() bool { return available },
 						}}
@@ -495,10 +495,9 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			available := false
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					AgentFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID:        "logs",
-							Scope:     funcapi.MethodScopeAgent,
 							Available: func() bool { return available },
 						}}
 					},
@@ -518,8 +517,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			available := false
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID:        "logs",
 							Available: func() bool { return available },
 						}}
@@ -541,8 +540,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			available := true
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID:        "logs",
 							Available: func() bool { return available },
 						}}
@@ -559,8 +558,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			availableCalls := 0
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID: "logs",
 							Available: func() bool {
 								availableCalls++
@@ -589,8 +588,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			})
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID:        "logs",
 							Available: func() bool { return available },
 						}}
@@ -618,8 +617,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			})
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{Name: "invalid"}}
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{Name: "invalid"}}
 					},
 				},
 			})
@@ -637,13 +636,13 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"aaa": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{ID: "logs", FunctionName: "shared:logs"}}
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "logs", FunctionName: "shared:logs"}}
 					},
 				},
 				"bbb": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{ID: "logs", FunctionName: "shared:logs"}}
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "logs", FunctionName: "shared:logs"}}
 					},
 				},
 			})
@@ -659,16 +658,16 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"aaa": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{
 							{ID: "first", FunctionName: "later:logs"},
 							{ID: "second", FunctionName: "later:logs"},
 						}
 					},
 				},
 				"ccc": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{ID: "logs", FunctionName: "later:logs"}}
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "logs", FunctionName: "later:logs"}}
 					},
 				},
 			})
@@ -684,12 +683,11 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"snmp_topology": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					AgentFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID:           "topology:snmp",
 							FunctionName: "snmp:topology:snmp",
 							Aliases:      []string{"topology:snmp"},
-							Scope:        funcapi.MethodScopeAgent,
 						}}
 					},
 				},
@@ -705,8 +703,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{ID: "job-method"}}
+					JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "job-method"}}
 					},
 				},
 			})
@@ -721,7 +719,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+					SharedFunctions: func() []funcapi.FunctionConfig { return []funcapi.FunctionConfig{{ID: "a"}} },
 				},
 			})
 
@@ -734,8 +732,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID:        "logs",
 							Available: func() bool { return false },
 						}}
@@ -758,7 +756,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			})
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "a"}} },
+					SharedFunctions: func() []funcapi.FunctionConfig { return []funcapi.FunctionConfig{{ID: "a"}} },
 				},
 			})
 
@@ -778,8 +776,8 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			})
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID:           "logs",
 							FunctionName: "snmp:traps",
 							Tags:         "logs",
@@ -822,8 +820,8 @@ func TestControllerReconcileModuleMethodsConcurrentLifecycle(t *testing.T) {
 
 	controller.RegisterModules(collectorapi.Registry{
 		"mod": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{
 					ID:      "late",
 					Aliases: aliases,
 					Available: func() bool {
@@ -906,10 +904,9 @@ func TestControllerStaticPublicationDoesNotHoldLockDuringFunctionGlobal(t *testi
 	go func() {
 		controller.RegisterModules(collectorapi.Registry{
 			"mod": collectorapi.Creator{
-				Methods: func() []funcapi.MethodConfig {
-					return []funcapi.MethodConfig{{
-						ID:    "late",
-						Scope: funcapi.MethodScopeAgent,
+				AgentFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{
+						ID: "late",
 					}}
 				},
 			},
@@ -950,11 +947,11 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 			controller := New(Options{FnReg: reg})
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig { return []funcapi.MethodConfig{{ID: "dup"}} },
+					SharedFunctions: func() []funcapi.FunctionConfig { return []funcapi.FunctionConfig{{ID: "dup"}} },
 				},
 			})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "dup"}})
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "dup"}})
 
 			assert.Empty(t, reg.registeredNames())
 			assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
@@ -963,9 +960,9 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 			reg := newTestFunctionRegistry()
 			controller := New(Options{FnReg: reg})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
-			controller.registry.registerJobMethods("mod", "jobA", []funcapi.MethodConfig{{ID: "dup"}})
+			controller.registry.registerJobMethods("mod", "jobA", []funcapi.FunctionConfig{{ID: "dup"}})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "jobB", true), []funcapi.MethodConfig{{ID: "dup"}})
+			controller.registerJobMethods(newTestRuntimeJob("mod", "jobB", true), []funcapi.FunctionConfig{{ID: "dup"}})
 
 			assert.Empty(t, reg.registeredNames())
 			assert.Empty(t, controller.registry.getJobMethods("mod", "jobB"))
@@ -975,7 +972,7 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 			controller := New(Options{FnReg: reg})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "dup"}, {ID: "dup"}})
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "dup"}, {ID: "dup"}})
 
 			assert.Empty(t, reg.registeredNames())
 			assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
@@ -985,7 +982,7 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 			controller := New(Options{FnReg: reg})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{
 				{ID: "logs", FunctionName: "public:logs", Aliases: []string{"public:alias"}},
 			})
 
@@ -1012,7 +1009,7 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 			})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "a", Help: "job method help"}})
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "a", Help: "job method help"}})
 
 			assert.Equal(t, 200, gotCode)
 			assert.Equal(t, float64(200), gotResp["status"])
@@ -1024,7 +1021,7 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 			controller := New(Options{FnReg: reg})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.MethodConfig{{ID: "a"}, {ID: "b"}})
+			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "a"}, {ID: "b"}})
 
 			assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, reg.registeredNames())
 			assert.Len(t, controller.registry.getJobMethods("mod", "job1"), 2)
@@ -1045,8 +1042,8 @@ func TestControllerPublishedFunctionWrapperConcurrentMutation(t *testing.T) {
 			setup: func(controller *Controller) {
 				controller.RegisterModules(collectorapi.Registry{
 					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{ID: "a"}}
+						SharedFunctions: func() []funcapi.FunctionConfig {
+							return []funcapi.FunctionConfig{{ID: "a"}}
 						},
 						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
 							return &tableTestHandler{}
@@ -1066,8 +1063,8 @@ func TestControllerPublishedFunctionWrapperConcurrentMutation(t *testing.T) {
 			setup: func(controller *Controller) {
 				controller.RegisterModules(collectorapi.Registry{
 					"mod": collectorapi.Creator{
-						JobMethods: func(collectorapi.RuntimeJob) []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{ID: "a"}}
+						JobMethods: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+							return []funcapi.FunctionConfig{{ID: "a"}}
 						},
 						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
 							return &tableTestHandler{}
@@ -1136,8 +1133,8 @@ func TestControllerPublishedFunctionGenerationInvalidatesStaleHandlers(t *testin
 			setup: func(controller *Controller) {
 				controller.RegisterModules(collectorapi.Registry{
 					"mod": collectorapi.Creator{
-						Methods: func() []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{ID: "a"}}
+						SharedFunctions: func() []funcapi.FunctionConfig {
+							return []funcapi.FunctionConfig{{ID: "a"}}
 						},
 						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
 							return &tableTestHandler{}
@@ -1152,8 +1149,8 @@ func TestControllerPublishedFunctionGenerationInvalidatesStaleHandlers(t *testin
 			setup: func(controller *Controller) {
 				controller.RegisterModules(collectorapi.Registry{
 					"mod": collectorapi.Creator{
-						JobMethods: func(collectorapi.RuntimeJob) []funcapi.MethodConfig {
-							return []funcapi.MethodConfig{{ID: "a"}}
+						JobMethods: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+							return []funcapi.FunctionConfig{{ID: "a"}}
 						},
 						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
 							return &tableTestHandler{}
@@ -1317,11 +1314,10 @@ func TestControllerRawModuleMethodRequest(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			runRawControllerMethodCase(t, tc, collectorapi.Creator{
-				Methods: func() []funcapi.MethodConfig {
-					return []funcapi.MethodConfig{{
+				AgentFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{
 						ID:         "logs",
 						RawRequest: true,
-						Scope:      funcapi.MethodScopeAgent,
 					}}
 				},
 			}, "mod:logs")
@@ -1344,11 +1340,10 @@ func TestControllerRawAgentScopeModuleMethodDoesNotRequireRunningJob(t *testing.
 
 	controller.RegisterModules(collectorapi.Registry{
 		"mod": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{
+			AgentFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{
 					ID:         "logs",
 					RawRequest: true,
-					Scope:      funcapi.MethodScopeAgent,
 				}}
 			},
 			MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1391,11 +1386,10 @@ func TestControllerRawSingleInstanceAgentScopeModuleMethodUsesRunningJob(t *test
 	controller.RegisterModules(collectorapi.Registry{
 		"mod": collectorapi.Creator{
 			InstancePolicy: collectorapi.InstancePolicySingle,
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{
 					ID:         "logs",
 					RawRequest: true,
-					Scope:      funcapi.MethodScopeAgent,
 				}}
 			},
 			MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1440,10 +1434,9 @@ func TestControllerSingleInstanceAgentScopeModuleMethodUsesRunningJob(t *testing
 	controller.RegisterModules(collectorapi.Registry{
 		"mod": collectorapi.Creator{
 			InstancePolicy: collectorapi.InstancePolicySingle,
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{
-					ID:    "status",
-					Scope: funcapi.MethodScopeAgent,
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{
+					ID: "status",
 				}}
 			},
 			MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1529,10 +1522,9 @@ func TestControllerSingleInstanceAgentScopeModuleMethodRequiresRunningJob(t *tes
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
 					InstancePolicy: collectorapi.InstancePolicySingle,
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
-							ID:    "status",
-							Scope: funcapi.MethodScopeAgent,
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
+							ID: "status",
 						}}
 					},
 					MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1574,8 +1566,8 @@ func TestControllerModuleMethodRequestContextCancellation(t *testing.T) {
 	})
 	controller.RegisterModules(collectorapi.Registry{
 		"mod": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "query"}}
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "query"}}
 			},
 			MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
 				return &rawTestHandler{
@@ -1672,8 +1664,8 @@ func TestControllerRawJobMethodRequest(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			runRawControllerMethodCase(t, tc, collectorapi.Creator{
-				JobMethods: func(job collectorapi.RuntimeJob) []funcapi.MethodConfig {
-					return []funcapi.MethodConfig{{
+				JobMethods: func(job collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{
 						ID:         job.Name() + ":logs",
 						RawRequest: true,
 					}}
@@ -1696,8 +1688,8 @@ func TestControllerRawJobMethodRequiresRawHandler(t *testing.T) {
 	})
 	controller.RegisterModules(collectorapi.Registry{
 		"mod": collectorapi.Creator{
-			JobMethods: func(job collectorapi.RuntimeJob) []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: job.Name() + ":logs", RawRequest: true}}
+			JobMethods: func(job collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: job.Name() + ":logs", RawRequest: true}}
 			},
 			MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
 				return &tableTestHandler{}

--- a/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
@@ -18,7 +18,7 @@ const (
 	paramJob = "__job"
 )
 
-type methodParamResolver func(ctx context.Context, methodCfg *funcapi.MethodConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error)
+type methodParamResolver func(ctx context.Context, methodCfg *funcapi.FunctionConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error)
 
 type methodExecutionInput struct {
 	fn            functions.Function
@@ -26,7 +26,7 @@ type methodExecutionInput struct {
 	jobName       string
 	jobLabel      string
 	methodID      string
-	methodCfg     *funcapi.MethodConfig
+	methodCfg     *funcapi.FunctionConfig
 	job           collectorapi.RuntimeJob
 	jobGen        uint64
 	info          bool
@@ -165,7 +165,7 @@ func (c *Controller) makePublishedMethodFuncHandler(functionName string, generat
 
 func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) functions.Handler {
 	return func(ctx context.Context, fn functions.Function) {
-		methodCfg, ok := c.registry.getMethod(moduleName, methodID)
+		methodCfg, kind, ok := c.registry.getMethod(moduleName, methodID)
 		if !ok {
 			c.respondError(fn, 404, "unknown method '%s' for module '%s'", methodID, moduleName)
 			return
@@ -178,10 +178,10 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 
 		payload := parsePayload(fn.Payload)
 		argValues := parseArgsParams(fn.Args)
-		includeJobParam := methodRequiresJobParam(methodCfg)
+		includeJobParam := c.methodRequiresJobParam(moduleName, kind)
 
 		if !includeJobParam {
-			job, jobName, jobGen, ok := c.resolveAgentScopeMethodJob(fn, moduleName)
+			job, jobName, jobGen, ok := c.resolveNoJobMethodJob(fn, moduleName, kind)
 			if !ok {
 				return
 			}
@@ -198,7 +198,7 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 				info:       info,
 				payload:    payload,
 				argValues:  argValues,
-				resolveParams: func(ctx context.Context, methodCfg *funcapi.MethodConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
+				resolveParams: func(ctx context.Context, methodCfg *funcapi.FunctionConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
 					return c.resolveModuleMethodParams(ctx, methodCfg, handler, methodID)
 				},
 				respond: func(dataResp *funcapi.FunctionResponse, methodParams []funcapi.ParamConfig, updateEvery int) {
@@ -251,7 +251,7 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 			info:       info,
 			payload:    payload,
 			argValues:  argValues,
-			resolveParams: func(ctx context.Context, methodCfg *funcapi.MethodConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
+			resolveParams: func(ctx context.Context, methodCfg *funcapi.FunctionConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
 				return c.resolveModuleMethodParams(ctx, methodCfg, handler, methodID)
 			},
 			augmentParams: func(resolvedParams funcapi.ResolvedParams) {
@@ -264,7 +264,11 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 	}
 }
 
-func (c *Controller) resolveAgentScopeMethodJob(fn functions.Function, moduleName string) (collectorapi.RuntimeJob, string, uint64, bool) {
+func (c *Controller) resolveNoJobMethodJob(fn functions.Function, moduleName string, kind moduleFunctionKind) (collectorapi.RuntimeJob, string, uint64, bool) {
+	if kind == moduleFunctionAgent {
+		return nil, "", 0, true
+	}
+
 	creator, ok := c.registry.getCreator(moduleName)
 	if !ok || creator.InstancePolicy != collectorapi.InstancePolicySingle {
 		return nil, "", 0, true
@@ -281,14 +285,14 @@ func (c *Controller) resolveAgentScopeMethodJob(fn functions.Function, moduleNam
 }
 
 func (c *Controller) handleMethodFuncInfo(moduleName, methodID string, fn functions.Function) {
-	methodCfg, ok := c.registry.getMethod(moduleName, methodID)
+	methodCfg, kind, ok := c.registry.getMethod(moduleName, methodID)
 	if !ok {
 		c.respondError(fn, 404, "unknown method '%s' for module '%s'", methodID, moduleName)
 		return
 	}
 
 	methodParams := methodCfg.RequiredParams
-	includeJobParam := methodRequiresJobParam(methodCfg)
+	includeJobParam := c.methodRequiresJobParam(moduleName, kind)
 	help := methodCfg.Help
 	if help == "" {
 		help = fmt.Sprintf("%s %s data function", moduleName, methodID)
@@ -329,7 +333,7 @@ func (c *Controller) buildRequiredParams(moduleName string, methodParams []funca
 	return required
 }
 
-func (c *Controller) resolveModuleMethodParams(ctx context.Context, methodCfg *funcapi.MethodConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
+func (c *Controller) resolveModuleMethodParams(ctx context.Context, methodCfg *funcapi.FunctionConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
 	methodParams := methodCfg.RequiredParams
 
 	handlerParams, err := handler.MethodParams(ctx, methodID)
@@ -526,8 +530,15 @@ func buildAcceptedParams(methodParams []funcapi.ParamConfig, includeJobParam boo
 	return accepted
 }
 
-func methodRequiresJobParam(cfg *funcapi.MethodConfig) bool {
-	return cfg == nil || cfg.Scope != funcapi.MethodScopeAgent
+func (c *Controller) methodRequiresJobParam(moduleName string, kind moduleFunctionKind) bool {
+	if kind == moduleFunctionAgent {
+		return false
+	}
+	creator, ok := c.registry.getCreator(moduleName)
+	if !ok {
+		return true
+	}
+	return creator.InstancePolicy != collectorapi.InstancePolicySingle
 }
 
 func (c *Controller) makePublishedJobMethodFuncHandler(functionName string, generation uint64, moduleName, jobName, methodID string) functions.Handler {
@@ -575,7 +586,7 @@ func (c *Controller) makeJobMethodFuncHandler(moduleName, jobName, methodID stri
 			info:       info,
 			payload:    payload,
 			argValues:  argValues,
-			resolveParams: func(ctx context.Context, methodCfg *funcapi.MethodConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
+			resolveParams: func(ctx context.Context, methodCfg *funcapi.FunctionConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
 				return c.resolveJobMethodParams(ctx, methodCfg, handler, methodID)
 			},
 			respond: func(dataResp *funcapi.FunctionResponse, methodParams []funcapi.ParamConfig, updateEvery int) {
@@ -618,7 +629,7 @@ func (c *Controller) handleJobMethodFuncInfo(moduleName, jobName, methodID strin
 	c.respondJSON(fn, resp)
 }
 
-func (c *Controller) resolveJobMethodParams(ctx context.Context, methodCfg *funcapi.MethodConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
+func (c *Controller) resolveJobMethodParams(ctx context.Context, methodCfg *funcapi.FunctionConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
 	methodParams := methodCfg.RequiredParams
 
 	jobParams, err := handler.MethodParams(ctx, methodID)

--- a/src/go/plugin/agent/jobmgr/funcctl/registry.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/registry.go
@@ -16,6 +16,13 @@ type moduleFuncRegistry struct {
 	methodRoutes map[string]methodRoute
 }
 
+type moduleFunctionKind uint8
+
+const (
+	moduleFunctionShared moduleFunctionKind = iota + 1
+	moduleFunctionAgent
+)
+
 type methodRoute struct {
 	moduleName string
 	methodID   string
@@ -23,11 +30,12 @@ type methodRoute struct {
 
 type moduleFunc struct {
 	creator        collectorapi.Creator
-	methods        []funcapi.MethodConfig
-	methodsByID    map[string]funcapi.MethodConfig
+	methods        []funcapi.FunctionConfig
+	methodsByID    map[string]funcapi.FunctionConfig
+	methodKinds    map[string]moduleFunctionKind
 	jobs           map[string]*jobEntry
 	nextGeneration uint64
-	jobMethods     map[string][]funcapi.MethodConfig
+	jobMethods     map[string][]funcapi.FunctionConfig
 }
 
 type jobEntry struct {
@@ -43,40 +51,77 @@ func newModuleFuncRegistry() *moduleFuncRegistry {
 }
 
 func (r *moduleFuncRegistry) registerModule(name string, creator collectorapi.Creator) {
-	r.registerModuleWithMethods(name, creator, moduleMethods(creator))
+	r.registerModuleWithDeclarations(name, creator, moduleFunctionDeclarations(creator))
 }
 
-func (r *moduleFuncRegistry) registerModuleWithMethods(name string, creator collectorapi.Creator, methods []funcapi.MethodConfig) {
+func (r *moduleFuncRegistry) registerModuleWithMethods(name string, creator collectorapi.Creator, methods []funcapi.FunctionConfig) {
+	r.registerModuleWithDeclarations(name, creator, moduleFunctionDecls{
+		configs: methods,
+		kinds:   indexFunctionKinds(methods, moduleFunctionShared),
+	})
+}
+
+func (r *moduleFuncRegistry) registerModuleWithDeclarations(name string, creator collectorapi.Creator, functions moduleFunctionDecls) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	affectedRoutes := make(map[string]struct{})
 	if existing, ok := r.modules[name]; ok {
-		collectModuleMethodFunctionNames(name, existing.methods, affectedRoutes)
+		collectModuleFunctionNames(name, existing.methods, affectedRoutes)
 	}
-	collectModuleMethodFunctionNames(name, methods, affectedRoutes)
+	collectModuleFunctionNames(name, functions.configs, affectedRoutes)
 
 	r.modules[name] = &moduleFunc{
 		creator:     creator,
-		methods:     methods,
-		methodsByID: indexMethods(methods),
+		methods:     functions.configs,
+		methodsByID: indexMethods(functions.configs),
+		methodKinds: functions.kinds,
 		jobs:        make(map[string]*jobEntry),
-		jobMethods:  make(map[string][]funcapi.MethodConfig),
+		jobMethods:  make(map[string][]funcapi.FunctionConfig),
 	}
 	r.refreshModuleMethodRoutesLocked(affectedRoutes)
 }
 
-func indexMethods(methods []funcapi.MethodConfig) map[string]funcapi.MethodConfig {
+func indexMethods(methods []funcapi.FunctionConfig) map[string]funcapi.FunctionConfig {
 	if len(methods) == 0 {
 		return nil
 	}
 
-	idx := make(map[string]funcapi.MethodConfig, len(methods))
+	idx := make(map[string]funcapi.FunctionConfig, len(methods))
 	for _, method := range methods {
 		if method.ID == "" {
 			continue
 		}
 		idx[method.ID] = method
+	}
+	return idx
+}
+
+func indexModuleFunctionKinds(shared, agent []funcapi.FunctionConfig) map[string]moduleFunctionKind {
+	idx := indexFunctionKinds(shared, moduleFunctionShared)
+	if len(agent) != 0 && idx == nil {
+		idx = make(map[string]moduleFunctionKind, len(agent))
+	}
+	for _, method := range agent {
+		if method.ID != "" {
+			idx[method.ID] = moduleFunctionAgent
+		}
+	}
+	if len(idx) == 0 {
+		return nil
+	}
+	return idx
+}
+
+func indexFunctionKinds(methods []funcapi.FunctionConfig, kind moduleFunctionKind) map[string]moduleFunctionKind {
+	if len(methods) == 0 {
+		return nil
+	}
+	idx := make(map[string]moduleFunctionKind)
+	for _, method := range methods {
+		if method.ID != "" {
+			idx[method.ID] = kind
+		}
 	}
 	return idx
 }
@@ -140,19 +185,30 @@ func (r *moduleFuncRegistry) verifyJobGeneration(moduleName, jobName string, exp
 	return entry.generation == expectedGen
 }
 
-func (r *moduleFuncRegistry) getMethod(moduleName, methodID string) (*funcapi.MethodConfig, bool) {
+func (r *moduleFuncRegistry) getMethod(moduleName, methodID string) (*funcapi.FunctionConfig, moduleFunctionKind, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	module, ok := r.modules[moduleName]
 	if !ok || module.methodsByID == nil {
-		return nil, false
+		return nil, 0, false
 	}
 	cfg, ok := module.methodsByID[methodID]
 	if !ok {
-		return nil, false
+		return nil, 0, false
 	}
-	return &cfg, true
+	return &cfg, module.methodKinds[methodID], true
+}
+
+func (r *moduleFuncRegistry) getModuleFunctionKind(moduleName, methodID string) moduleFunctionKind {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	module, ok := r.modules[moduleName]
+	if !ok {
+		return 0
+	}
+	return module.methodKinds[methodID]
 }
 
 func (r *moduleFuncRegistry) resolveMethodRoute(functionName string) (string, string, bool) {
@@ -166,7 +222,7 @@ func (r *moduleFuncRegistry) resolveMethodRoute(functionName string) (string, st
 	return route.moduleName, route.methodID, true
 }
 
-func (r *moduleFuncRegistry) getMethods(moduleName string) []funcapi.MethodConfig {
+func (r *moduleFuncRegistry) getMethods(moduleName string) []funcapi.FunctionConfig {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -244,7 +300,7 @@ func (r *moduleFuncRegistry) isModuleRegistered(moduleName string) bool {
 	return ok
 }
 
-func (r *moduleFuncRegistry) registerJobMethods(moduleName, jobName string, methods []funcapi.MethodConfig) {
+func (r *moduleFuncRegistry) registerJobMethods(moduleName, jobName string, methods []funcapi.FunctionConfig) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -266,7 +322,7 @@ func (r *moduleFuncRegistry) unregisterJobMethods(moduleName, jobName string) {
 	delete(module.jobMethods, jobName)
 }
 
-func (r *moduleFuncRegistry) getJobMethods(moduleName, jobName string) []funcapi.MethodConfig {
+func (r *moduleFuncRegistry) getJobMethods(moduleName, jobName string) []funcapi.FunctionConfig {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -277,7 +333,7 @@ func (r *moduleFuncRegistry) getJobMethods(moduleName, jobName string) []funcapi
 	return module.jobMethods[jobName]
 }
 
-func (r *moduleFuncRegistry) getJobMethod(moduleName, jobName, methodID string) (*funcapi.MethodConfig, bool) {
+func (r *moduleFuncRegistry) getJobMethod(moduleName, jobName, methodID string) (*funcapi.FunctionConfig, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -326,12 +382,12 @@ func (r *moduleFuncRegistry) findMethodCollision(moduleName, jobName, methodID s
 	return "", false
 }
 
-func collectModuleMethodFunctionNames(moduleName string, methods []funcapi.MethodConfig, out map[string]struct{}) {
+func collectModuleFunctionNames(moduleName string, methods []funcapi.FunctionConfig, out map[string]struct{}) {
 	for _, method := range methods {
 		if method.ID == "" {
 			continue
 		}
-		for _, functionName := range funcapi.MethodFunctionNames(moduleName, method) {
+		for _, functionName := range funcapi.FunctionNames(moduleName, method) {
 			out[functionName] = struct{}{}
 		}
 	}
@@ -358,7 +414,7 @@ func (r *moduleFuncRegistry) refreshModuleMethodRoutesLocked(functionNames map[s
 				continue
 			}
 			route := methodRoute{moduleName: moduleName, methodID: method.ID}
-			for _, functionName := range funcapi.MethodFunctionNames(moduleName, method) {
+			for _, functionName := range funcapi.FunctionNames(moduleName, method) {
 				if _, affected := functionNames[functionName]; !affected {
 					continue
 				}

--- a/src/go/plugin/agent/jobmgr/funcctl/response_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/response_test.go
@@ -85,8 +85,8 @@ func TestHandleMethodFuncInfo_UsesResponseType(t *testing.T) {
 	controller, resp := newTestControllerWithCapture(t)
 
 	controller.registry.registerModule("snmp", collectorapi.Creator{
-		Methods: func() []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{{ID: "topology:snmp", ResponseType: "topology"}}
+		SharedFunctions: func() []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "topology:snmp", ResponseType: "topology"}}
 		},
 	})
 
@@ -99,11 +99,10 @@ func TestHandleMethodFuncInfo_AgentScopeOmitsJobParam(t *testing.T) {
 	controller, resp := newTestControllerWithCapture(t)
 
 	controller.registry.registerModule("snmp", collectorapi.Creator{
-		Methods: func() []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{{
+		AgentFunctions: func() []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{
 				ID:           "topology:snmp",
 				ResponseType: "topology",
-				Scope:        funcapi.MethodScopeAgent,
 				RequiredParams: []funcapi.ParamConfig{{
 					ID:        "topology_view",
 					Name:      "Topology View",
@@ -135,7 +134,7 @@ func TestHandleJobMethodFuncInfo_UsesResponseType(t *testing.T) {
 	controller, resp := newTestControllerWithCapture(t)
 
 	controller.registry.registerModule("netflow", collectorapi.Creator{})
-	controller.registry.registerJobMethods("netflow", "job1", []funcapi.MethodConfig{
+	controller.registry.registerJobMethods("netflow", "job1", []funcapi.FunctionConfig{
 		{ID: "flows:netflow", ResponseType: "flows"},
 	})
 
@@ -148,9 +147,9 @@ func TestHandleMethodFuncInfo_IncludesPresentation(t *testing.T) {
 	controller, resp := newTestControllerWithCapture(t)
 
 	controller.registry.registerModule("snmp", collectorapi.Creator{
-		Methods: func() []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{
-				funcapi.MethodConfig{
+		SharedFunctions: func() []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{
+				funcapi.FunctionConfig{
 					ID:           "topology:snmp",
 					ResponseType: "topology",
 				}.WithPresentation(map[string]any{

--- a/src/go/plugin/agent/jobmgr/funcdispatch_test.go
+++ b/src/go/plugin/agent/jobmgr/funcdispatch_test.go
@@ -44,7 +44,7 @@ func (m *mockMethodHandler) Cleanup(context.Context) {}
 
 func TestExecuteFunction_ModuleMethodPaths(t *testing.T) {
 	tests := map[string]struct {
-		methods           []funcapi.MethodConfig
+		methods           []funcapi.FunctionConfig
 		fnArgs            []string
 		fnPayload         map[string]any
 		generationRace    bool
@@ -57,7 +57,7 @@ func TestExecuteFunction_ModuleMethodPaths(t *testing.T) {
 		wantErrorContains string
 	}{
 		"success with __job resolution": {
-			methods:         []funcapi.MethodConfig{{ID: "details", Help: "details help"}},
+			methods:         []funcapi.FunctionConfig{{ID: "details", Help: "details help"}},
 			fnArgs:          []string{"__job:job1"},
 			wantStatus:      200,
 			wantHelp:        "details help",
@@ -67,7 +67,7 @@ func TestExecuteFunction_ModuleMethodPaths(t *testing.T) {
 			wantResolvedJob: "job1",
 		},
 		"info response includes module and method params": {
-			methods: []funcapi.MethodConfig{{
+			methods: []funcapi.FunctionConfig{{
 				ID:   "details",
 				Help: "details help",
 				RequiredParams: []funcapi.ParamConfig{{
@@ -84,26 +84,26 @@ func TestExecuteFunction_ModuleMethodPaths(t *testing.T) {
 			wantRequiredIDs: []string{"__job", "scope"},
 		},
 		"generation race returns 503": {
-			methods:           []funcapi.MethodConfig{{ID: "details"}},
+			methods:           []funcapi.FunctionConfig{{ID: "details"}},
 			fnArgs:            []string{"__job:job1"},
 			generationRace:    true,
 			wantStatus:        503,
 			wantErrorContains: "replaced during request",
 		},
 		"explicit unknown __job in args returns 404": {
-			methods:           []funcapi.MethodConfig{{ID: "details"}},
+			methods:           []funcapi.FunctionConfig{{ID: "details"}},
 			fnArgs:            []string{"__job:missing"},
 			wantStatus:        404,
 			wantErrorContains: "unknown job 'missing'",
 		},
 		"explicit unknown __job in payload returns 404": {
-			methods:           []funcapi.MethodConfig{{ID: "details"}},
+			methods:           []funcapi.FunctionConfig{{ID: "details"}},
 			fnPayload:         map[string]any{"__job": "missing"},
 			wantStatus:        404,
 			wantErrorContains: "unknown job 'missing'",
 		},
 		"multiple __job values return 400": {
-			methods:           []funcapi.MethodConfig{{ID: "details"}},
+			methods:           []funcapi.FunctionConfig{{ID: "details"}},
 			fnPayload:         map[string]any{"__job": []string{"job1", "job2"}},
 			wantStatus:        400,
 			wantErrorContains: "parameter '__job' expects a single value",
@@ -187,7 +187,7 @@ func TestExecuteFunction_ModuleMethodPublicFunctionName(t *testing.T) {
 			gotMethod = method
 			return &funcapi.FunctionResponse{Status: 200, Help: "trap logs"}
 		},
-	}, []funcapi.MethodConfig{{
+	}, []funcapi.FunctionConfig{{
 		ID:           "logs",
 		FunctionName: "snmp:traps",
 	}})
@@ -227,12 +227,11 @@ func TestExecuteFunction_AgentScopeModuleMethodDoesNotRequireRunningJob(t *testi
 			})
 			mgr.modules = collectorapi.Registry{
 				"snmp_topology": collectorapi.Creator{
-					Methods: func() []funcapi.MethodConfig {
-						return []funcapi.MethodConfig{{
+					AgentFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{
 							ID:           "topology:snmp",
 							FunctionName: "snmp:topology:snmp",
 							Aliases:      []string{"topology:snmp"},
-							Scope:        funcapi.MethodScopeAgent,
 							RequiredParams: []funcapi.ParamConfig{{
 								ID:        "scope",
 								Name:      "Scope",
@@ -280,10 +279,9 @@ func TestExecuteFunction_AgentScopeModuleMethodValidationErrorOmitsJob(t *testin
 	})
 	mgr.modules = collectorapi.Registry{
 		"mod": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{
-					ID:    "logs",
-					Scope: funcapi.MethodScopeAgent,
+			AgentFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{
+					ID: "logs",
 					RequiredParams: []funcapi.ParamConfig{{
 						ID:        "scope",
 						Name:      "Scope",
@@ -347,7 +345,7 @@ func TestExecuteFunction_ContextBehavior(t *testing.T) {
 					}
 					return &funcapi.FunctionResponse{Status: 200}
 				},
-			}, []funcapi.MethodConfig{{ID: "details"}})
+			}, []funcapi.FunctionConfig{{ID: "details"}})
 			if tc.managerCtx != nil {
 				mgr.funcCtl.Init(tc.managerCtx)
 			}
@@ -395,7 +393,7 @@ func TestJobMethodRegisteredHandlerPaths(t *testing.T) {
 						Data: [][]any{{"job1"}},
 					}
 				},
-			}, []funcapi.MethodConfig{{ID: "job-details", Help: "job details help"}})
+			}, []funcapi.FunctionConfig{{ID: "job-details", Help: "job details help"}})
 
 			handler := fnReg.requireHandler(t, "mod:job-details")
 			handler(functions.Function{
@@ -478,7 +476,7 @@ func TestFunctionDispatch_ResponsePaths(t *testing.T) {
 				writer := &jsonWriteCapture{}
 				var responderOut bytes.Buffer
 
-				mgr := newModuleDispatchTestManager(t, dyncfg.NewResponder(netdataapi.New(safewriter.New(&responderOut))), writer.write, handler, []funcapi.MethodConfig{{ID: "details"}})
+				mgr := newModuleDispatchTestManager(t, dyncfg.NewResponder(netdataapi.New(safewriter.New(&responderOut))), writer.write, handler, []funcapi.FunctionConfig{{ID: "details"}})
 				mgr.ExecuteFunction("mod:details", functions.Function{
 					UID:     tc.wantResponderUID,
 					Timeout: time.Second,
@@ -498,7 +496,7 @@ func TestFunctionDispatch_ResponsePaths(t *testing.T) {
 				var firstOut bytes.Buffer
 				var secondOut bytes.Buffer
 
-				mgr := newModuleDispatchTestManager(t, dyncfg.NewResponder(netdataapi.New(safewriter.New(&firstOut))), nil, handler, []funcapi.MethodConfig{{ID: "details"}})
+				mgr := newModuleDispatchTestManager(t, dyncfg.NewResponder(netdataapi.New(safewriter.New(&firstOut))), nil, handler, []funcapi.FunctionConfig{{ID: "details"}})
 				mgr.ExecuteFunction("mod:details", functions.Function{
 					UID:     tc.wantFirstUID,
 					Timeout: time.Second,
@@ -521,7 +519,7 @@ func TestFunctionDispatch_ResponsePaths(t *testing.T) {
 			if tc.nilRebindResponder {
 				var responderOut bytes.Buffer
 
-				mgr := newModuleDispatchTestManager(t, dyncfg.NewResponder(netdataapi.New(safewriter.New(&responderOut))), nil, handler, []funcapi.MethodConfig{{ID: "details"}})
+				mgr := newModuleDispatchTestManager(t, dyncfg.NewResponder(netdataapi.New(safewriter.New(&responderOut))), nil, handler, []funcapi.FunctionConfig{{ID: "details"}})
 				mgr.ExecuteFunction("mod:details", functions.Function{
 					UID:     tc.wantFirstUID,
 					Timeout: time.Second,
@@ -541,7 +539,7 @@ func TestFunctionDispatch_ResponsePaths(t *testing.T) {
 			}
 
 			var responderOut bytes.Buffer
-			mgr := newModuleDispatchTestManager(t, dyncfg.NewResponder(netdataapi.New(safewriter.New(&responderOut))), nil, handler, []funcapi.MethodConfig{{ID: "details"}})
+			mgr := newModuleDispatchTestManager(t, dyncfg.NewResponder(netdataapi.New(safewriter.New(&responderOut))), nil, handler, []funcapi.FunctionConfig{{ID: "details"}})
 			mgr.ExecuteFunction("mod:details", functions.Function{
 				UID:     tc.wantResponderUID,
 				Timeout: time.Second,
@@ -562,13 +560,13 @@ func TestCleanup_UnregistersStaticFunctionsBeforeStoppingJobs(t *testing.T) {
 	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
 
 	staticCreator := collectorapi.Creator{
-		Methods: func() []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{{ID: "static-method"}}
+		SharedFunctions: func() []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "static-method"}}
 		},
 	}
 	jobCreator := collectorapi.Creator{
-		JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{{ID: "job-method"}}
+		JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "job-method"}}
 		},
 	}
 
@@ -681,7 +679,7 @@ func newModuleDispatchTestManager(
 	api *dyncfg.Responder,
 	jsonWriter func([]byte, int),
 	methodHandler funcapi.MethodHandler,
-	methods []funcapi.MethodConfig,
+	methods []funcapi.FunctionConfig,
 ) *Manager {
 	t.Helper()
 
@@ -694,7 +692,7 @@ func newModuleDispatchTestManager(
 	}
 
 	creator := collectorapi.Creator{
-		Methods: func() []funcapi.MethodConfig { return methods },
+		SharedFunctions: func() []funcapi.FunctionConfig { return methods },
 		MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
 			return methodHandler
 		},
@@ -711,7 +709,7 @@ func newJobMethodDispatchTestManager(
 	fnReg FunctionRegistry,
 	jsonWriter func([]byte, int),
 	methodHandler funcapi.MethodHandler,
-	methods []funcapi.MethodConfig,
+	methods []funcapi.FunctionConfig,
 ) *Manager {
 	t.Helper()
 
@@ -722,7 +720,7 @@ func newJobMethodDispatchTestManager(
 	})
 
 	creator := collectorapi.Creator{
-		JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.MethodConfig { return methods },
+		JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return methods },
 		MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
 			return methodHandler
 		},

--- a/src/go/plugin/agent/jobmgr/job_factory.go
+++ b/src/go/plugin/agent/jobmgr/job_factory.go
@@ -96,8 +96,8 @@ func (f *jobFactory) create(cfg confgroup.Config) (runtimeJob, error) {
 	}
 
 	functionOnly := creator.FunctionOnly || cfg.FunctionOnly()
-	if cfg.FunctionOnly() && creator.Methods == nil && creator.JobMethods == nil {
-		return nil, fmt.Errorf("function_only is set but %s module has no methods defined", cfg.Module())
+	if cfg.FunctionOnly() && creator.SharedFunctions == nil && creator.AgentFunctions == nil && creator.JobMethods == nil {
+		return nil, fmt.Errorf("function_only is set but %s module has no functions defined", cfg.Module())
 	}
 
 	var vnode *vnodes.VirtualNode

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -135,8 +135,8 @@ func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T)
 		FnReg:      reg,
 		Modules: collectorapi.Registry{
 			"mod": collectorapi.Creator{
-				Methods: func() []funcapi.MethodConfig {
-					return []funcapi.MethodConfig{{
+				SharedFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{
 						ID:        "late",
 						Available: func() bool { return available },
 					}}
@@ -201,8 +201,8 @@ func TestRunNotifyRunningJobs_DeduplicatesFunctionReconcileByModule(t *testing.T
 		FnReg:      reg,
 		Modules: collectorapi.Registry{
 			"mod": collectorapi.Creator{
-				Methods: func() []funcapi.MethodConfig {
-					return []funcapi.MethodConfig{{
+				SharedFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{
 						ID: "late",
 						Available: func() bool {
 							if available {
@@ -270,8 +270,8 @@ func TestRunNotifyRunningJobs_DoesNotPublishDirectly(t *testing.T) {
 		FnReg:      reg,
 		Modules: collectorapi.Registry{
 			"mod": collectorapi.Creator{
-				Methods: func() []funcapi.MethodConfig {
-					return []funcapi.MethodConfig{{
+				SharedFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{
 						ID:        "late",
 						Available: func() bool { return available },
 					}}
@@ -331,8 +331,8 @@ func TestRequestFunctionReconcile_DroppedRequestCanBeRetried(t *testing.T) {
 		FnReg:      reg,
 		Modules: collectorapi.Registry{
 			"mod": collectorapi.Creator{
-				Methods: func() []funcapi.MethodConfig {
-					return []funcapi.MethodConfig{{
+				SharedFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{
 						ID:        "late",
 						Available: func() bool { return available },
 					}}
@@ -402,8 +402,8 @@ func TestRunWaitDecisionStep(t *testing.T) {
 					FnReg:      reg,
 					Modules: collectorapi.Registry{
 						"mod": collectorapi.Creator{
-							Methods: func() []funcapi.MethodConfig {
-								return []funcapi.MethodConfig{{
+							SharedFunctions: func() []funcapi.FunctionConfig {
+								return []funcapi.FunctionConfig{{
 									ID:        "late",
 									Available: func() bool { return available },
 								}}
@@ -484,8 +484,8 @@ func TestFunctionReconcileFunnelConcurrentLifecycle(t *testing.T) {
 		FnReg:      reg,
 		Modules: collectorapi.Registry{
 			"mod": collectorapi.Creator{
-				Methods: func() []funcapi.MethodConfig {
-					return []funcapi.MethodConfig{{
+				SharedFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{
 						ID:        "late",
 						Available: available.Load,
 					}}
@@ -636,8 +636,8 @@ func TestRun_DoesNotRegisterJobBoundModuleMethodsBeforeAnyJobStarts(t *testing.T
 
 	mgr.modules = collectorapi.Registry{
 		"mod": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "a"}}
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "a"}}
 			},
 		},
 	}
@@ -674,8 +674,8 @@ func TestRun_RegistersAgentScopeModuleMethodsBeforeAnyJobStarts(t *testing.T) {
 
 	mgr.modules = collectorapi.Registry{
 		"mod": collectorapi.Creator{
-			Methods: func() []funcapi.MethodConfig {
-				return []funcapi.MethodConfig{{ID: "a", Scope: funcapi.MethodScopeAgent}}
+			AgentFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "a"}}
 			},
 		},
 	}
@@ -710,8 +710,8 @@ func TestStartRunningJob_RegistersModuleMethodsOnFirstStartedJob(t *testing.T) {
 	fnReg := &recordingFunctionRegistry{}
 	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
 	creator := collectorapi.Creator{
-		Methods: func() []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{{ID: "a"}, {ID: "b"}}
+		SharedFunctions: func() []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "a"}, {ID: "b"}}
 		},
 	}
 	mgr.modules = collectorapi.Registry{"mod": creator}
@@ -727,8 +727,8 @@ func TestStartRunningJob_DoesNotReregisterModuleMethods(t *testing.T) {
 	fnReg := &recordingFunctionRegistry{}
 	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
 	creator := collectorapi.Creator{
-		Methods: func() []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{{ID: "a"}, {ID: "b"}}
+		SharedFunctions: func() []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "a"}, {ID: "b"}}
 		},
 	}
 	mgr.modules = collectorapi.Registry{"mod": creator}

--- a/src/go/plugin/agent/jobmgr/manager_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_test.go
@@ -1997,7 +1997,7 @@ func TestManager_Run_FunctionOnly(t *testing.T) {
 CONFIG test:collector:nofuncs:test create accepted job /collectors/test/Jobs user 'type=user,module=nofuncs,job=test' 'schema get enable disable update restart test userconfig' 0x0000 0x0000
 
 FUNCTION_RESULT_BEGIN 1-enable 400 application/json
-{"status":400,"errorMessage":"invalid configuration: failed to apply configuration: function_only is set but nofuncs module has no methods defined"}
+{"status":400,"errorMessage":"invalid configuration: failed to apply configuration: function_only is set but nofuncs module has no functions defined"}
 FUNCTION_RESULT_END
 
 CONFIG test:collector:nofuncs:test status failed

--- a/src/go/plugin/agent/jobmgr/manager_v2_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_v2_test.go
@@ -90,7 +90,7 @@ func TestManagerCreateCollectorJobV2Branching(t *testing.T) {
 				CreateV2: func() collectorapi.CollectorV2 {
 					return &testV2Module{store: metrix.NewCollectorStore()}
 				},
-				JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.MethodConfig { return nil },
+				JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
 			},
 			wantV2: true,
 		},
@@ -99,7 +99,7 @@ func TestManagerCreateCollectorJobV2Branching(t *testing.T) {
 				CreateV2: func() collectorapi.CollectorV2 {
 					return &testV2Module{store: metrix.NewCollectorStore()}
 				},
-				JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.MethodConfig { return nil },
+				JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
 			},
 			wantV2: true,
 		},
@@ -108,7 +108,7 @@ func TestManagerCreateCollectorJobV2Branching(t *testing.T) {
 				CreateV2: func() collectorapi.CollectorV2 {
 					return &testV2Module{store: nil}
 				},
-				JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.MethodConfig { return nil },
+				JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
 			},
 			functionOnly: true,
 			wantV2:       true,
@@ -147,7 +147,7 @@ func TestManagerCreateCollectorJobSingleInstancePolicyAllowsV2FunctionOnly(t *te
 		"testmod": {
 			InstancePolicy: collectorapi.InstancePolicySingle,
 			CreateV2:       func() collectorapi.CollectorV2 { return mod },
-			JobMethods:     func(_ collectorapi.RuntimeJob) []funcapi.MethodConfig { return nil },
+			JobMethods:     func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
 		},
 	}
 

--- a/src/go/plugin/agent/jobmgr/sim_test.go
+++ b/src/go/plugin/agent/jobmgr/sim_test.go
@@ -248,8 +248,8 @@ func prepareMockRegistry() collectorapi.Registry {
 				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"id1": 1} },
 			}
 		},
-		Methods: func() []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{{ID: "test-method", Name: "Test Method"}}
+		SharedFunctions: func() []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "test-method", Name: "Test Method"}}
 		},
 	})
 
@@ -262,8 +262,8 @@ func prepareMockRegistry() collectorapi.Registry {
 				CollectFunc: func(context.Context) map[string]int64 { return nil },
 			}
 		},
-		Methods: func() []funcapi.MethodConfig {
-			return []funcapi.MethodConfig{{ID: "test-method", Name: "Test Method"}}
+		SharedFunctions: func() []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "test-method", Name: "Test Method"}}
 		},
 	})
 

--- a/src/go/plugin/framework/collectorapi/registry.go
+++ b/src/go/plugin/framework/collectorapi/registry.go
@@ -62,15 +62,19 @@ type (
 		// InstancePolicy defaults to InstancePolicyPerJob when omitted.
 		InstancePolicy InstancePolicy
 
-		// Optional: FunctionProvider fields for exposing data functions
-		// If Methods is non-nil, this module provides functions
-		Methods func() []funcapi.MethodConfig
+		// Optional: SharedFunctions declares static job-backed Functions shared
+		// by all jobs of this module. InstancePolicy controls whether they are
+		// selected through __job or routed to the canonical single instance.
+		SharedFunctions func() []funcapi.FunctionConfig
+
+		// Optional: AgentFunctions declares static process-backed Functions that
+		// do not depend on collector jobs and do not use __job.
+		AgentFunctions func() []funcapi.FunctionConfig
 
 		// Optional: MethodHandler returns a handler for method requests.
-		// MethodScopeAgent module methods are dispatched with nil job, except
-		// that single-instance collectors receive their running canonical job.
-		// MethodScopeInstance module methods and JobMethods are dispatched with
-		// the selected running job.
+		// AgentFunctions are dispatched with nil job. SharedFunctions are
+		// dispatched with the selected running job; for single-instance
+		// collectors they receive the running canonical job.
 		// When the canonical single-instance job is not running, dispatch returns
 		// unavailable before calling MethodHandler.
 		// The handler implements funcapi.MethodHandler interface with:
@@ -79,11 +83,11 @@ type (
 		// When nil, methods are disabled for this module.
 		MethodHandler func(job RuntimeJob) funcapi.MethodHandler
 
-		// Optional: JobMethods returns methods to register when a job starts.
-		// Each method is registered as "moduleName:methodID" and unregistered when the job stops.
+		// Optional: JobMethods returns Function declarations to register when a job starts.
+		// Each Function is registered as "moduleName:methodID" and unregistered when the job stops.
 		// This enables per-job function registration instead of static module-level functions.
 		// If nil, no per-job methods are registered.
-		JobMethods func(job RuntimeJob) []funcapi.MethodConfig
+		JobMethods func(job RuntimeJob) []funcapi.FunctionConfig
 
 		// FunctionOnly indicates this module provides only functions, no metrics.
 		// Jobs created from this module skip data collection and chart creation.
@@ -110,13 +114,41 @@ func (r Registry) Register(name string, creator Creator) {
 	if !creator.InstancePolicy.valid() {
 		panic(fmt.Sprintf("%s has invalid InstancePolicy %d", name, creator.InstancePolicy))
 	}
-	if creator.Methods != nil && creator.JobMethods != nil {
-		panic(fmt.Sprintf("%s has both Methods and JobMethods defined (mutually exclusive)", name))
+	if (creator.SharedFunctions != nil || creator.AgentFunctions != nil) && creator.JobMethods != nil {
+		panic(fmt.Sprintf("%s has both static Functions and JobMethods defined (mutually exclusive)", name))
 	}
-	if creator.FunctionOnly && creator.Methods == nil && creator.JobMethods == nil {
-		panic(fmt.Sprintf("%s is FunctionOnly but has no Methods or JobMethods defined", name))
+	if id, ok := duplicateStaticFunctionID(creator); ok {
+		panic(fmt.Sprintf("%s has duplicate static Function ID %q", name, id))
+	}
+	if creator.FunctionOnly && creator.SharedFunctions == nil && creator.AgentFunctions == nil && creator.JobMethods == nil {
+		panic(fmt.Sprintf("%s is FunctionOnly but has no Functions or JobMethods defined", name))
 	}
 	r[name] = creator
+}
+
+func duplicateStaticFunctionID(creator Creator) (string, bool) {
+	seen := make(map[string]struct{})
+	for _, fn := range staticFunctions(creator) {
+		if fn.ID == "" {
+			continue
+		}
+		if _, ok := seen[fn.ID]; ok {
+			return fn.ID, true
+		}
+		seen[fn.ID] = struct{}{}
+	}
+	return "", false
+}
+
+func staticFunctions(creator Creator) []funcapi.FunctionConfig {
+	var functions []funcapi.FunctionConfig
+	if creator.SharedFunctions != nil {
+		functions = append(functions, creator.SharedFunctions()...)
+	}
+	if creator.AgentFunctions != nil {
+		functions = append(functions, creator.AgentFunctions()...)
+	}
+	return functions
 }
 
 func (r Registry) Lookup(name string) (Creator, bool) {

--- a/src/go/plugin/framework/collectorapi/registry_test.go
+++ b/src/go/plugin/framework/collectorapi/registry_test.go
@@ -34,10 +34,10 @@ func TestRegister(t *testing.T) {
 
 }
 
-func TestRegister_FunctionOnlyWithoutMethods(t *testing.T) {
+func TestRegister_FunctionOnlyWithoutFunctions(t *testing.T) {
 	registry := make(Registry)
 
-	// Panic case: FunctionOnly without Methods
+	// Panic case: FunctionOnly without Functions
 	assert.Panics(
 		t,
 		func() {
@@ -45,18 +45,18 @@ func TestRegister_FunctionOnlyWithoutMethods(t *testing.T) {
 		})
 }
 
-func TestRegisterPanicOnMethodsAndJobMethodsConflict(t *testing.T) {
+func TestRegisterPanicOnStaticFunctionsAndJobMethodsConflict(t *testing.T) {
 	tests := map[string]struct {
 		name    string
 		creator Creator
 	}{
-		"panic when both methods and job methods are set": {
+		"panic when both static functions and job methods are set": {
 			name: "conflict",
 			creator: Creator{
-				Methods: func() []funcapi.MethodConfig {
+				SharedFunctions: func() []funcapi.FunctionConfig {
 					return nil
 				},
-				JobMethods: func(RuntimeJob) []funcapi.MethodConfig {
+				JobMethods: func(RuntimeJob) []funcapi.FunctionConfig {
 					return nil
 				},
 			},
@@ -69,11 +69,75 @@ func TestRegisterPanicOnMethodsAndJobMethodsConflict(t *testing.T) {
 
 			assert.PanicsWithValue(
 				t,
-				"conflict has both Methods and JobMethods defined (mutually exclusive)",
+				"conflict has both static Functions and JobMethods defined (mutually exclusive)",
 				func() { registry.Register(tc.name, tc.creator) },
 			)
 		})
 	}
+}
+
+func TestRegisterPanicOnDuplicateStaticFunctionID(t *testing.T) {
+	tests := map[string]struct {
+		creator Creator
+	}{
+		"duplicate shared function IDs": {
+			creator: Creator{
+				SharedFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{
+						{ID: "logs"},
+						{ID: "logs"},
+					}
+				},
+			},
+		},
+		"duplicate agent function IDs": {
+			creator: Creator{
+				AgentFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{
+						{ID: "logs"},
+						{ID: "logs"},
+					}
+				},
+			},
+		},
+		"duplicate shared and agent function IDs": {
+			creator: Creator{
+				SharedFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{ID: "logs"}}
+				},
+				AgentFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{ID: "logs"}}
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			registry := make(Registry)
+
+			assert.PanicsWithValue(
+				t,
+				`mod has duplicate static Function ID "logs"`,
+				func() { registry.Register("mod", tc.creator) },
+			)
+		})
+	}
+}
+
+func TestRegisterAllowsEmptyStaticFunctionID(t *testing.T) {
+	registry := make(Registry)
+
+	assert.NotPanics(t, func() {
+		registry.Register("mod", Creator{
+			SharedFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: ""}, {ID: ""}}
+			},
+			AgentFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: ""}}
+			},
+		})
+	})
 }
 
 func TestRegister_InstancePolicy(t *testing.T) {

--- a/src/go/plugin/go.d/collector/cato_networks/catofunc/presentation.go
+++ b/src/go/plugin/go.d/collector/cato_networks/catofunc/presentation.go
@@ -7,8 +7,8 @@ import (
 	topologyv1 "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
 )
 
-func topologyMethodConfig(updateEvery int) funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topologyFunctionConfig(updateEvery int) funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:           TopologyMethodID,
 		Aliases:      []string{TopologyMethodID},
 		Name:         "Topology (Cato Networks)",

--- a/src/go/plugin/go.d/collector/cato_networks/catofunc/router.go
+++ b/src/go/plugin/go.d/collector/cato_networks/catofunc/router.go
@@ -46,9 +46,9 @@ func (r *router) Cleanup(ctx context.Context) {
 	}
 }
 
-func Methods(updateEvery int) []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topologyMethodConfig(updateEvery),
+func Methods(updateEvery int) []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topologyFunctionConfig(updateEvery),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/cato_networks/collector.go
+++ b/src/go/plugin/go.d/collector/cato_networks/collector.go
@@ -31,10 +31,10 @@ func init() {
 			UpdateEvery:        defaultUpdateEvery,
 			AutoDetectionRetry: 0,
 		},
-		CreateV2:      func() collectorapi.CollectorV2 { return New() },
-		Config:        func() any { return &Config{} },
-		Methods:       catoMethods,
-		MethodHandler: catoFunctionHandler,
+		CreateV2:        func() collectorapi.CollectorV2 { return New() },
+		Config:          func() any { return &Config{} },
+		SharedFunctions: catoMethods,
+		MethodHandler:   catoFunctionHandler,
 	})
 }
 

--- a/src/go/plugin/go.d/collector/cato_networks/func_deps.go
+++ b/src/go/plugin/go.d/collector/cato_networks/func_deps.go
@@ -20,7 +20,7 @@ func (a funcDepsAdapter) CurrentTopology() (*topologyv1.Data, bool) {
 	return a.store.CurrentTopology()
 }
 
-func catoMethods() []funcapi.MethodConfig {
+func catoMethods() []funcapi.FunctionConfig {
 	return catofunc.Methods(defaultUpdateEvery)
 }
 

--- a/src/go/plugin/go.d/collector/cato_networks/topology_test.go
+++ b/src/go/plugin/go.d/collector/cato_networks/topology_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/require"
 
-	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
 	topologyv1 "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cato_networks/catofunc"
 )
@@ -41,12 +40,6 @@ func TestTopologyFunction(t *testing.T) {
 				require.Equal(t, topologySource, data.Producer.Source)
 				require.Greater(t, data.Actors.Rows, 0)
 				require.Greater(t, data.Links.Rows, 0)
-			},
-		},
-		"requires job selection": {
-			check: func(t *testing.T, _ *Collector) {
-				cfg := catofunc.Methods(defaultUpdateEvery)[0]
-				require.Equal(t, funcapi.MethodScopeInstance, cfg.Scope)
 			},
 		},
 	}

--- a/src/go/plugin/go.d/collector/clickhouse/collector.go
+++ b/src/go/plugin/go.d/collector/clickhouse/collector.go
@@ -23,7 +23,7 @@ func init() {
 		Create:          func() collectorapi.CollectorV1 { return New() },
 		Config:          func() any { return &Config{} },
 		JobConfigSchema: configSchema,
-		Methods:         clickhouseMethods,
+		SharedFunctions: clickhouseMethods,
 		MethodHandler:   clickhouseFunctionHandler,
 	})
 }

--- a/src/go/plugin/go.d/collector/clickhouse/func_router.go
+++ b/src/go/plugin/go.d/collector/clickhouse/func_router.go
@@ -10,9 +10,9 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 )
 
-func clickhouseMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
+func clickhouseMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/clickhouse/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/clickhouse/func_top_queries.go
@@ -19,8 +19,8 @@ const (
 	topQueriesMaxTextLength = 4096
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/cockroachdb/collector.go
+++ b/src/go/plugin/go.d/collector/cockroachdb/collector.go
@@ -28,10 +28,10 @@ func init() {
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: dbSamplingInterval,
 		},
-		Methods:       cockroachMethods,
-		MethodHandler: cockroachFunctionHandler,
-		Create:        func() collectorapi.CollectorV1 { return New() },
-		Config:        func() any { return &Config{} },
+		SharedFunctions: cockroachMethods,
+		MethodHandler:   cockroachFunctionHandler,
+		Create:          func() collectorapi.CollectorV1 { return New() },
+		Config:          func() any { return &Config{} },
 	})
 }
 

--- a/src/go/plugin/go.d/collector/cockroachdb/func_router.go
+++ b/src/go/plugin/go.d/collector/cockroachdb/func_router.go
@@ -116,10 +116,10 @@ func (r *funcRouter) topQueriesLimit() int {
 	return r.collector.topQueriesLimit()
 }
 
-func cockroachMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
-		runningQueriesMethodConfig(),
+func cockroachMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
+		runningQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/cockroachdb/func_running_queries.go
+++ b/src/go/plugin/go.d/collector/cockroachdb/func_running_queries.go
@@ -18,8 +18,8 @@ const (
 	runningQueriesMaxTextLength = 4096
 )
 
-func runningQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func runningQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             runningQueriesMethodID,
 		Name:           "Running Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/cockroachdb/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/cockroachdb/func_top_queries.go
@@ -18,8 +18,8 @@ const (
 	topQueriesMaxTextLength = 4096
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/couchbase/collector.go
+++ b/src/go/plugin/go.d/collector/couchbase/collector.go
@@ -24,10 +24,10 @@ func init() {
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 5,
 		},
-		Create:        func() collectorapi.CollectorV1 { return New() },
-		Config:        func() any { return &Config{} },
-		Methods:       couchbaseMethods,
-		MethodHandler: couchbaseFunctionHandler,
+		Create:          func() collectorapi.CollectorV1 { return New() },
+		Config:          func() any { return &Config{} },
+		SharedFunctions: couchbaseMethods,
+		MethodHandler:   couchbaseFunctionHandler,
 	})
 }
 

--- a/src/go/plugin/go.d/collector/couchbase/func_router.go
+++ b/src/go/plugin/go.d/collector/couchbase/func_router.go
@@ -48,9 +48,9 @@ func (r *funcRouter) Cleanup(ctx context.Context) {
 	}
 }
 
-func couchbaseMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
+func couchbaseMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/couchbase/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/couchbase/func_top_queries.go
@@ -24,8 +24,8 @@ const (
 	topQueriesMaxTextLength = 4096
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/docker/collector.go
+++ b/src/go/plugin/go.d/collector/docker/collector.go
@@ -26,7 +26,7 @@ func init() {
 		JobConfigSchema: configSchema,
 		Create:          func() collectorapi.CollectorV1 { return New() },
 		Config:          func() any { return &Config{} },
-		Methods:         dockerfunc.Methods,
+		SharedFunctions: dockerfunc.Methods,
 		MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
 			c, ok := job.Collector().(*Collector)
 			if !ok {

--- a/src/go/plugin/go.d/collector/docker/dockerfunc/containers.go
+++ b/src/go/plugin/go.d/collector/docker/dockerfunc/containers.go
@@ -49,8 +49,8 @@ const (
 	containersColCreatedUnix = "created_unix"
 )
 
-func containersMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func containersFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:          containersMethodID,
 		Name:        "Containers",
 		UpdateEvery: 10,

--- a/src/go/plugin/go.d/collector/docker/dockerfunc/router.go
+++ b/src/go/plugin/go.d/collector/docker/dockerfunc/router.go
@@ -48,9 +48,9 @@ func (r *router) Cleanup(ctx context.Context) {
 	}
 }
 
-func Methods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		containersMethodConfig(),
+func Methods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		containersFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/elasticsearch/collector.go
+++ b/src/go/plugin/go.d/collector/elasticsearch/collector.go
@@ -25,10 +25,10 @@ func init() {
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 5,
 		},
-		Create:        func() collectorapi.CollectorV1 { return New() },
-		Config:        func() any { return &Config{} },
-		Methods:       elasticsearchMethods,
-		MethodHandler: elasticsearchFunctionHandler,
+		Create:          func() collectorapi.CollectorV1 { return New() },
+		Config:          func() any { return &Config{} },
+		SharedFunctions: elasticsearchMethods,
+		MethodHandler:   elasticsearchFunctionHandler,
 	})
 }
 

--- a/src/go/plugin/go.d/collector/elasticsearch/func_router.go
+++ b/src/go/plugin/go.d/collector/elasticsearch/func_router.go
@@ -48,9 +48,9 @@ func (r *funcRouter) Cleanup(ctx context.Context) {
 	}
 }
 
-func elasticsearchMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
+func elasticsearchMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/elasticsearch/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/elasticsearch/func_top_queries.go
@@ -21,8 +21,8 @@ const (
 	topQueriesMaxTextLength = 4096
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/init_test.go
+++ b/src/go/plugin/go.d/collector/init_test.go
@@ -22,7 +22,8 @@ func TestSNMPFamilyRegistrationUsesSharedDependencies(t *testing.T) {
 	assert.NotNil(t, snmpCreator.Create)
 	assert.Nil(t, snmpCreator.CreateV2)
 	assert.NotNil(t, snmpCreator.Config)
-	assert.NotNil(t, snmpCreator.Methods)
+	assert.NotNil(t, snmpCreator.SharedFunctions)
+	assert.Nil(t, snmpCreator.AgentFunctions)
 	assert.NotNil(t, snmpCreator.MethodHandler)
 	assert.Equal(t, 10, snmpCreator.Defaults.UpdateEvery)
 
@@ -30,13 +31,15 @@ func TestSNMPFamilyRegistrationUsesSharedDependencies(t *testing.T) {
 	assert.NotNil(t, topologyCreator.CreateV2)
 	assert.Equal(t, collectorapi.InstancePolicySingle, topologyCreator.InstancePolicy)
 	assert.False(t, topologyCreator.FunctionOnly)
-	assert.NotNil(t, topologyCreator.Methods)
+	assert.NotNil(t, topologyCreator.SharedFunctions)
+	assert.Nil(t, topologyCreator.AgentFunctions)
 	assert.NotNil(t, topologyCreator.MethodHandler)
 	assert.Equal(t, 60, topologyCreator.Defaults.UpdateEvery)
 
 	assert.Nil(t, trapsCreator.Create)
 	assert.NotNil(t, trapsCreator.CreateV2)
-	assert.NotNil(t, trapsCreator.Methods)
+	assert.Nil(t, trapsCreator.SharedFunctions)
+	assert.NotNil(t, trapsCreator.AgentFunctions)
 	assert.NotNil(t, trapsCreator.MethodHandler)
 	assert.Equal(t, 1, trapsCreator.Defaults.UpdateEvery)
 

--- a/src/go/plugin/go.d/collector/mongodb/collector.go
+++ b/src/go/plugin/go.d/collector/mongodb/collector.go
@@ -23,7 +23,7 @@ func init() {
 		JobConfigSchema: configSchema,
 		Create:          func() collectorapi.CollectorV1 { return New() },
 		Config:          func() any { return &Config{} },
-		Methods:         mongoMethods,
+		SharedFunctions: mongoMethods,
 		MethodHandler:   mongoFunctionHandler,
 	})
 }

--- a/src/go/plugin/go.d/collector/mongodb/func_router.go
+++ b/src/go/plugin/go.d/collector/mongodb/func_router.go
@@ -49,9 +49,9 @@ func (r *funcRouter) Cleanup(ctx context.Context) {
 	}
 }
 
-func mongoMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
+func mongoMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/mongodb/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/mongodb/func_top_queries.go
@@ -26,8 +26,8 @@ const (
 		"Requires profiling enabled on target databases (db.setProfilingLevel)."
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/mssql/collector.go
+++ b/src/go/plugin/go.d/collector/mssql/collector.go
@@ -28,10 +28,10 @@ func init() {
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 10,
 		},
-		Create:        func() collectorapi.CollectorV1 { return New() },
-		Config:        func() any { return &Config{} },
-		Methods:       mssqlMethods,
-		MethodHandler: mssqlFunctionHandler,
+		Create:          func() collectorapi.CollectorV1 { return New() },
+		Config:          func() any { return &Config{} },
+		SharedFunctions: mssqlMethods,
+		MethodHandler:   mssqlFunctionHandler,
 	})
 }
 

--- a/src/go/plugin/go.d/collector/mssql/func_deadlock_info.go
+++ b/src/go/plugin/go.d/collector/mssql/func_deadlock_info.go
@@ -222,8 +222,8 @@ var deadlockColumns = []deadlockColumn{
 	},
 }
 
-func deadlockInfoMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func deadlockInfoFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             deadlockInfoMethodID,
 		Name:           "Deadlock Info",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/mssql/func_error_info.go
+++ b/src/go/plugin/go.d/collector/mssql/func_error_info.go
@@ -126,8 +126,8 @@ var errorInfoColumns = []errorInfoColumn{
 	},
 }
 
-func errorInfoMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func errorInfoFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             errorInfoMethodID,
 		Name:           "Error Info",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/mssql/func_router.go
+++ b/src/go/plugin/go.d/collector/mssql/func_router.go
@@ -51,11 +51,11 @@ func (r *funcRouter) Cleanup(ctx context.Context) {
 	}
 }
 
-func mssqlMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
-		deadlockInfoMethodConfig(),
-		errorInfoMethodConfig(),
+func mssqlMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
+		deadlockInfoFunctionConfig(),
+		errorInfoFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/mssql/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/mssql/func_top_queries.go
@@ -19,8 +19,8 @@ const (
 	topQueriesParamSort     = "__sort"
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/mysql/collector.go
+++ b/src/go/plugin/go.d/collector/mysql/collector.go
@@ -33,7 +33,7 @@ func init() {
 		JobConfigSchema: configSchema,
 		CreateV2:        func() collectorapi.CollectorV2 { return New() },
 		Config:          func() any { return &Config{} },
-		Methods:         mysqlfunc.Methods,
+		SharedFunctions: mysqlfunc.Methods,
 		MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
 			c, ok := job.Collector().(*Collector)
 			if !ok {

--- a/src/go/plugin/go.d/collector/mysql/mysqlfunc/deadlock_info.go
+++ b/src/go/plugin/go.d/collector/mysql/mysqlfunc/deadlock_info.go
@@ -242,8 +242,8 @@ var deadlockColumns = []deadlockColumn{
 	},
 }
 
-func deadlockInfoMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func deadlockInfoFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             deadlockInfoMethodID,
 		Name:           "Deadlock Info",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/mysql/mysqlfunc/error_info.go
+++ b/src/go/plugin/go.d/collector/mysql/mysqlfunc/error_info.go
@@ -108,8 +108,8 @@ var errorInfoColumns = []errorInfoColumn{
 	},
 }
 
-func errorInfoMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func errorInfoFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             errorInfoMethodID,
 		Name:           "Error Info",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/mysql/mysqlfunc/router.go
+++ b/src/go/plugin/go.d/collector/mysql/mysqlfunc/router.go
@@ -55,11 +55,11 @@ func (r *router) Cleanup(ctx context.Context) {
 	}
 }
 
-func Methods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
-		deadlockInfoMethodConfig(),
-		errorInfoMethodConfig(),
+func Methods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
+		deadlockInfoFunctionConfig(),
+		errorInfoFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/mysql/mysqlfunc/top_queries.go
+++ b/src/go/plugin/go.d/collector/mysql/mysqlfunc/top_queries.go
@@ -19,8 +19,8 @@ const (
 	topQueriesParamSort     = "__sort"
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/oracledb/collector.go
+++ b/src/go/plugin/go.d/collector/oracledb/collector.go
@@ -22,7 +22,7 @@ func init() {
 		JobConfigSchema: configSchema,
 		Create:          func() collectorapi.CollectorV1 { return New() },
 		Config:          func() any { return &Config{} },
-		Methods:         oracledbMethods,
+		SharedFunctions: oracledbMethods,
 		MethodHandler:   oracledbFunctionHandler,
 	})
 }

--- a/src/go/plugin/go.d/collector/oracledb/func_router.go
+++ b/src/go/plugin/go.d/collector/oracledb/func_router.go
@@ -55,10 +55,10 @@ func (r *funcRouter) topQueriesLimit() int {
 	return r.collector.topQueriesLimit()
 }
 
-func oracledbMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
-		runningQueriesMethodConfig(),
+func oracledbMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
+		runningQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/oracledb/func_running_queries.go
+++ b/src/go/plugin/go.d/collector/oracledb/func_running_queries.go
@@ -17,8 +17,8 @@ const (
 	runningQueriesMaxTextLength = 4096
 )
 
-func runningQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func runningQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             runningQueriesMethodID,
 		Name:           "Running Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/oracledb/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/oracledb/func_top_queries.go
@@ -17,8 +17,8 @@ const (
 	topQueriesMaxTextLength = 4096
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/postgres/collector.go
+++ b/src/go/plugin/go.d/collector/postgres/collector.go
@@ -28,7 +28,7 @@ func init() {
 		JobConfigSchema: configSchema,
 		Create:          func() collectorapi.CollectorV1 { return New() },
 		Config:          func() any { return &Config{} },
-		Methods:         pgMethods,
+		SharedFunctions: pgMethods,
 		MethodHandler:   pgFunctionHandler,
 	})
 }

--- a/src/go/plugin/go.d/collector/postgres/func_router.go
+++ b/src/go/plugin/go.d/collector/postgres/func_router.go
@@ -50,10 +50,10 @@ func (r *funcRouter) Cleanup(ctx context.Context) {
 	}
 }
 
-func pgMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
-		runningQueriesMethodConfig(),
+func pgMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
+		runningQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/postgres/func_running_queries.go
+++ b/src/go/plugin/go.d/collector/postgres/func_running_queries.go
@@ -17,8 +17,8 @@ const (
 	runningQueriesMaxTextLength = 4096
 )
 
-func runningQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func runningQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             runningQueriesMethodID,
 		Name:           "Running Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/postgres/func_running_queries_test.go
+++ b/src/go/plugin/go.d/collector/postgres/func_running_queries_test.go
@@ -287,8 +287,8 @@ func TestFuncRunningQueries_formatValue_NonQueryStringNotTruncated(t *testing.T)
 	assert.Equal(t, len(longValue), len(resultStr), "non-query string columns should not be truncated")
 }
 
-func TestRunningQueriesMethodConfig(t *testing.T) {
-	config := runningQueriesMethodConfig()
+func TestRunningQueriesFunctionConfig(t *testing.T) {
+	config := runningQueriesFunctionConfig()
 
 	assert.Equal(t, "running-queries", config.ID)
 	assert.Equal(t, "Running Queries", config.Name)

--- a/src/go/plugin/go.d/collector/postgres/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/postgres/func_top_queries.go
@@ -299,8 +299,8 @@ var pgLabelColumnIDs = map[string]bool{
 
 const pgPrimaryLabelID = "database"
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:           topQueriesMethodID,
 		Name:         "Top Queries",
 		UpdateEvery:  10,

--- a/src/go/plugin/go.d/collector/proxysql/collector.go
+++ b/src/go/plugin/go.d/collector/proxysql/collector.go
@@ -24,7 +24,7 @@ func init() {
 		JobConfigSchema: configSchema,
 		Create:          func() collectorapi.CollectorV1 { return New() },
 		Config:          func() any { return &Config{} },
-		Methods:         proxysqlMethods,
+		SharedFunctions: proxysqlMethods,
 		MethodHandler:   proxysqlFunctionHandler,
 	})
 }

--- a/src/go/plugin/go.d/collector/proxysql/func_router.go
+++ b/src/go/plugin/go.d/collector/proxysql/func_router.go
@@ -49,9 +49,9 @@ func (r *funcRouter) Cleanup(ctx context.Context) {
 	}
 }
 
-func proxysqlMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
+func proxysqlMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/proxysql/functions.go
+++ b/src/go/plugin/go.d/collector/proxysql/functions.go
@@ -19,8 +19,8 @@ const (
 	paramSort          = "__sort"
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/redis/collector.go
+++ b/src/go/plugin/go.d/collector/redis/collector.go
@@ -33,7 +33,7 @@ func init() {
 		JobConfigSchema: configSchema,
 		Create:          func() collectorapi.CollectorV1 { return New() },
 		Config:          func() any { return &Config{} },
-		Methods:         redisMethods,
+		SharedFunctions: redisMethods,
 		MethodHandler:   redisFunctionHandler,
 	})
 }

--- a/src/go/plugin/go.d/collector/redis/func_router.go
+++ b/src/go/plugin/go.d/collector/redis/func_router.go
@@ -49,9 +49,9 @@ func (r *funcRouter) Cleanup(ctx context.Context) {
 	}
 }
 
-func redisMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
+func redisMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/redis/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/redis/func_top_queries.go
@@ -20,8 +20,8 @@ const (
 	redisMaxQueryTextLength = 4096
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/rethinkdb/collector.go
+++ b/src/go/plugin/go.d/collector/rethinkdb/collector.go
@@ -20,7 +20,7 @@ func init() {
 		JobConfigSchema: configSchema,
 		Create:          func() collectorapi.CollectorV1 { return New() },
 		Config:          func() any { return &Config{} },
-		Methods:         rethinkdbMethods,
+		SharedFunctions: rethinkdbMethods,
 		MethodHandler:   rethinkdbFunctionHandler,
 	})
 }

--- a/src/go/plugin/go.d/collector/rethinkdb/func_router.go
+++ b/src/go/plugin/go.d/collector/rethinkdb/func_router.go
@@ -53,9 +53,9 @@ func (r *funcRouter) Cleanup(ctx context.Context) {
 	}
 }
 
-func rethinkdbMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		runningQueriesMethodConfig(),
+func rethinkdbMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		runningQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/rethinkdb/func_running_queries.go
+++ b/src/go/plugin/go.d/collector/rethinkdb/func_running_queries.go
@@ -17,8 +17,8 @@ const (
 	rethinkMaxQueryTextLength = 4096
 )
 
-func runningQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func runningQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             runningQueriesMethodID,
 		Name:           "Running Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/snmp/bgp_integration.go
+++ b/src/go/plugin/go.d/collector/snmp/bgp_integration.go
@@ -167,9 +167,9 @@ func collectorSpecificFunctionHandlers() []registeredSNMPFunction {
 	}}
 }
 
-func collectorSpecificMethodConfigs() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		bgpPeersMethodConfig(),
+func collectorSpecificFunctionConfigs() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		bgpPeersFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -37,10 +37,10 @@ func newCreator(store *ddsnmp.DeviceStore) collectorapi.Creator {
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 10,
 		},
-		Create:        func() collectorapi.CollectorV1 { return New(store) },
-		Config:        func() any { return &Config{} },
-		Methods:       snmpMethods,
-		MethodHandler: snmpFunctionHandler,
+		Create:          func() collectorapi.CollectorV1 { return New(store) },
+		Config:          func() any { return &Config{} },
+		SharedFunctions: snmpMethods,
+		MethodHandler:   snmpFunctionHandler,
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp/func_bgp_peers.go
+++ b/src/go/plugin/go.d/collector/snmp/func_bgp_peers.go
@@ -39,8 +39,8 @@ func bgpPeerColumnSet(cols []bgpPeerColumn) funcapi.ColumnSet[bgpPeerColumn] {
 
 var _ funcapi.MethodHandler = (*funcBGPPeers)(nil)
 
-func bgpPeersMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func bgpPeersFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:          bgpPeersMethodID,
 		Name:        "BGP Peers",
 		UpdateEvery: 10,
@@ -63,7 +63,7 @@ func (f *funcBGPPeers) MethodParams(_ context.Context, method string) ([]funcapi
 	if method != bgpPeersMethodID {
 		return nil, nil
 	}
-	return bgpPeersMethodConfig().RequiredParams, nil
+	return bgpPeersFunctionConfig().RequiredParams, nil
 }
 
 func (f *funcBGPPeers) Cleanup(_ context.Context) {}

--- a/src/go/plugin/go.d/collector/snmp/func_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp/func_interfaces.go
@@ -28,8 +28,8 @@ const (
 	ifacesDefaultTypeGroup = "ethernet"
 )
 
-func ifacesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func ifacesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:          ifacesMethodID,
 		Name:        "Network Interfaces",
 		UpdateEvery: 10,

--- a/src/go/plugin/go.d/collector/snmp/func_interfaces_test.go
+++ b/src/go/plugin/go.d/collector/snmp/func_interfaces_test.go
@@ -20,9 +20,9 @@ func newTestFuncInterfaces(cache *ifaceCache) *funcInterfaces {
 func TestSnmpMethods(t *testing.T) {
 	methods := snmpMethods()
 
-	var ifacesMethod *funcapi.MethodConfig
-	var licensesMethod *funcapi.MethodConfig
-	var bgpMethod *funcapi.MethodConfig
+	var ifacesMethod *funcapi.FunctionConfig
+	var licensesMethod *funcapi.FunctionConfig
+	var bgpMethod *funcapi.FunctionConfig
 	methodIDs := make(map[string]bool, len(methods))
 	for i := range methods {
 		methodIDs[methods[i].ID] = true

--- a/src/go/plugin/go.d/collector/snmp/func_licenses.go
+++ b/src/go/plugin/go.d/collector/snmp/func_licenses.go
@@ -14,8 +14,8 @@ import (
 
 const licensesMethodID = "licenses"
 
-func licensesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func licensesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:          licensesMethodID,
 		Name:        "Licenses",
 		UpdateEvery: 10,

--- a/src/go/plugin/go.d/collector/snmp/func_licenses_test.go
+++ b/src/go/plugin/go.d/collector/snmp/func_licenses_test.go
@@ -15,7 +15,7 @@ func newTestFuncLicenses(cache *licenseCache) *funcLicenses {
 	return newFuncLicenses(cache)
 }
 
-func TestLicensesMethodConfig_Parameterless(t *testing.T) {
+func TestLicensesFunctionConfig_Parameterless(t *testing.T) {
 	tests := map[string]struct {
 		method string
 	}{
@@ -26,7 +26,7 @@ func TestLicensesMethodConfig_Parameterless(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cfg := licensesMethodConfig()
+			cfg := licensesFunctionConfig()
 			assert.Empty(t, cfg.RequiredParams)
 
 			params, err := newTestFuncLicenses(newLicenseCache()).MethodParams(context.Background(), tc.method)

--- a/src/go/plugin/go.d/collector/snmp/func_router.go
+++ b/src/go/plugin/go.d/collector/snmp/func_router.go
@@ -94,11 +94,11 @@ func (r *funcRouter) Cleanup(ctx context.Context) {
 	}
 }
 
-func snmpBaseMethods() []funcapi.MethodConfig {
-	methods := []funcapi.MethodConfig{
-		ifacesMethodConfig(),
+func snmpBaseMethods() []funcapi.FunctionConfig {
+	methods := []funcapi.FunctionConfig{
+		ifacesFunctionConfig(),
 	}
-	methods = append(methods, collectorSpecificMethodConfigs()...)
+	methods = append(methods, collectorSpecificFunctionConfigs()...)
 	return methods
 }
 

--- a/src/go/plugin/go.d/collector/snmp/licensing_integration.go
+++ b/src/go/plugin/go.d/collector/snmp/licensing_integration.go
@@ -24,9 +24,9 @@ func (li *licensingIntegration) registerFunction(r *funcRouter) {
 	r.registerHandler(licensesMethodID, newFuncLicenses(li.cache))
 }
 
-func snmpMethods() []funcapi.MethodConfig {
+func snmpMethods() []funcapi.FunctionConfig {
 	methods := snmpBaseMethods()
-	return append(methods, licensesMethodConfig())
+	return append(methods, licensesFunctionConfig())
 }
 
 func (c *Collector) collectLicensing(mx map[string]int64, pms []*ddsnmp.ProfileMetrics) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -43,11 +43,11 @@ func newCreator(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentH
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 60,
 		},
-		CreateV2:       func() collectorapi.CollectorV2 { return newCollector(deviceStore, trapEnrichment, availability) },
-		Config:         func() any { return &Config{} },
-		InstancePolicy: collectorapi.InstancePolicySingle,
-		Methods:        func() []funcapi.MethodConfig { return topologyMethods(availability) },
-		MethodHandler:  topologyFunctionHandler,
+		CreateV2:        func() collectorapi.CollectorV2 { return newCollector(deviceStore, trapEnrichment, availability) },
+		Config:          func() any { return &Config{} },
+		InstancePolicy:  collectorapi.InstancePolicySingle,
+		SharedFunctions: func() []funcapi.FunctionConfig { return topologyMethods(availability) },
+		MethodHandler:   topologyFunctionHandler,
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -20,15 +20,14 @@ func TestSNMPTopologyCreatorOwnsTopologyFunction(t *testing.T) {
 	require.NotNil(t, creator.CreateV2)
 	require.Equal(t, collectorapi.InstancePolicySingle, creator.InstancePolicy)
 	require.False(t, creator.FunctionOnly)
-	require.NotNil(t, creator.Methods)
+	require.NotNil(t, creator.SharedFunctions)
 	require.NotNil(t, creator.MethodHandler)
 	require.Implements(t, (*collectorapi.CollectorV2Runner)(nil), creator.CreateV2())
 
-	methods := creator.Methods()
+	methods := creator.SharedFunctions()
 	require.Len(t, methods, 1)
 	require.Equal(t, snmptopologyfunc.MethodID, methods[0].ID)
 	require.Equal(t, snmptopologyfunc.FunctionName, methods[0].FunctionName)
-	require.Equal(t, funcapi.MethodScopeAgent, methods[0].Scope)
 	require.NotNil(t, methods[0].Available)
 	require.False(t, methods[0].Available())
 
@@ -68,7 +67,7 @@ func TestSNMPTopologyCreatorRequiresSharedDependencies(t *testing.T) {
 
 func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableObservation(t *testing.T) {
 	creator := newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle())
-	methods := creator.Methods()
+	methods := creator.SharedFunctions()
 	require.Len(t, methods, 1)
 	require.NotNil(t, methods[0].Available)
 	require.False(t, methods[0].Available())
@@ -82,12 +81,12 @@ func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableObservation(
 	coll.updateFunctionAvailability()
 
 	require.True(t, methods[0].Available())
-	require.True(t, creator.Methods()[0].Available())
+	require.True(t, creator.SharedFunctions()[0].Available())
 }
 
 func TestSNMPTopologyFunctionAvailabilityResetsWhenReplacementCollectorRuns(t *testing.T) {
 	creator := newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle())
-	methods := creator.Methods()
+	methods := creator.SharedFunctions()
 	require.Len(t, methods, 1)
 	require.NotNil(t, methods[0].Available)
 

--- a/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
@@ -46,7 +46,7 @@ func (a funcDepsAdapter) ManagedDeviceFocusTargets() []topologyoptions.ManagedFo
 	return a.registry.managedDeviceFocusTargets()
 }
 
-func topologyMethods(availability *topologyFunctionAvailability) []funcapi.MethodConfig {
+func topologyMethods(availability *topologyFunctionAvailability) []funcapi.FunctionConfig {
 	methods := snmptopologyfunc.Methods()
 	for i := range methods {
 		if methods[i].ID == snmptopologyfunc.MethodID {

--- a/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/presentation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/presentation.go
@@ -7,14 +7,14 @@ import (
 	topologyv1 "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
 )
 
-func Methods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		methodConfig(),
+func Methods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		functionConfig(),
 	}
 }
 
-func methodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func functionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:           MethodID,
 		FunctionName: FunctionName,
 		Aliases:      []string{MethodID},
@@ -23,7 +23,6 @@ func methodConfig() funcapi.MethodConfig {
 		Help:         "SNMP Layer-2 topology and neighbor discovery data",
 		RequireCloud: true,
 		ResponseType: topologyv1.ResponseType,
-		Scope:        funcapi.MethodScopeAgent,
 		RequiredParams: []funcapi.ParamConfig{
 			nodesIdentityParamConfig(),
 			mapTypeParamConfig(),

--- a/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/snmptopologyfunc/topology_test.go
@@ -23,7 +23,6 @@ func TestMethodsIncludesSelectors(t *testing.T) {
 	assert.Equal(t, FunctionName, cfg.FunctionName)
 	assert.Equal(t, []string{MethodID}, cfg.Aliases)
 	assert.Equal(t, "topology", cfg.ResponseType)
-	assert.Equal(t, funcapi.MethodScopeAgent, cfg.Scope)
 	require.Len(t, cfg.RequiredParams, 5)
 	require.Nil(t, cfg.Presentation())
 

--- a/src/go/plugin/go.d/collector/snmp_traps/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/collector.go
@@ -59,10 +59,10 @@ func newCreator(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 1,
 		},
-		CreateV2:      func() collectorapi.CollectorV2 { return New(deviceStore, topologyEnricher) },
-		Config:        func() any { return &Config{} },
-		Methods:       snmpTrapsMethods,
-		MethodHandler: snmpTrapsMethodHandler,
+		CreateV2:       func() collectorapi.CollectorV2 { return New(deviceStore, topologyEnricher) },
+		Config:         func() any { return &Config{} },
+		AgentFunctions: snmpTrapsMethods,
+		MethodHandler:  snmpTrapsMethodHandler,
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
@@ -25,7 +25,7 @@ func TestSNMPTrapsMethodsExposeLogsOnly(t *testing.T) {
 	methods := snmpTrapsMethods()
 	require.Len(t, methods, 1)
 
-	byID := make(map[string]funcapi.MethodConfig, len(methods))
+	byID := make(map[string]funcapi.FunctionConfig, len(methods))
 	for _, method := range methods {
 		byID[method.ID] = method
 	}
@@ -37,7 +37,6 @@ func TestSNMPTrapsMethodsExposeLogsOnly(t *testing.T) {
 	assert.Equal(t, "logs", logs.ResponseType)
 	assert.True(t, logs.RawRequest)
 	assert.True(t, logs.RequireCloud)
-	assert.Equal(t, funcapi.MethodScopeAgent, logs.Scope)
 	assert.NotNil(t, logs.Available)
 }
 

--- a/src/go/plugin/go.d/collector/snmp_traps/reload.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/reload.go
@@ -13,9 +13,9 @@ const (
 	snmpTrapsFunctionName = snmptrapsfunc.FunctionName
 )
 
-func snmpTrapsMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		snmptrapsfunc.LogsMethodConfig(directJournalLogsAvailable),
+func snmpTrapsMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		snmptrapsfunc.LogsFunctionConfig(directJournalLogsAvailable),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_traps/reload_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/reload_test.go
@@ -454,13 +454,12 @@ func TestSnmpTrapsMethods(t *testing.T) {
 	methods := snmpTrapsMethods()
 	require.Len(t, methods, 1)
 
-	byID := make(map[string]funcapi.MethodConfig, len(methods))
+	byID := make(map[string]funcapi.FunctionConfig, len(methods))
 	for _, method := range methods {
 		byID[method.ID] = method
 	}
 
 	logs := byID[snmpTrapsLogsMethodID]
-	assert.Equal(t, funcapi.MethodScopeAgent, logs.Scope)
 	assert.Equal(t, snmpTrapsFunctionName, logs.FunctionName)
 	assert.True(t, logs.RawRequest)
 	assert.Equal(t, "logs", logs.ResponseType)

--- a/src/go/plugin/go.d/collector/snmp_traps/snmptrapsfunc/func_logs.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/snmptrapsfunc/func_logs.go
@@ -38,8 +38,8 @@ func NewHandler(journalRoot string) *Handler {
 	}
 }
 
-func LogsMethodConfig(available func() bool) funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func LogsFunctionConfig(available func() bool) funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:           LogsMethodID,
 		FunctionName: FunctionName,
 		Name:         "SNMP Trap Logs",
@@ -50,7 +50,6 @@ func LogsMethodConfig(available func() bool) funcapi.MethodConfig {
 		ResponseType: "logs",
 		Available:    available,
 		RawRequest:   true,
-		Scope:        funcapi.MethodScopeAgent,
 	}
 }
 

--- a/src/go/plugin/go.d/collector/sql/func_table.go
+++ b/src/go/plugin/go.d/collector/sql/func_table.go
@@ -26,13 +26,13 @@ var _ funcapi.MethodHandler = (*funcTable)(nil)
 // sqlJobMethods returns method configs for a specific SQL job.
 // Each configured function becomes a separate method: "jobName:functionID"
 // This results in functions like "sql:postgres_test:active-queries"
-func sqlJobMethods(job collectorapi.RuntimeJob) []funcapi.MethodConfig {
+func sqlJobMethods(job collectorapi.RuntimeJob) []funcapi.FunctionConfig {
 	c, ok := job.Collector().(*Collector)
 	if !ok || len(c.Config.Functions) == 0 {
 		return nil
 	}
 
-	methods := make([]funcapi.MethodConfig, 0, len(c.Config.Functions))
+	methods := make([]funcapi.FunctionConfig, 0, len(c.Config.Functions))
 	for _, fn := range c.Config.Functions {
 		// Method ID format: "jobName:functionID" (e.g., "postgres_test:active-queries")
 		// Full function name will be: "sql:postgres_test:active-queries"
@@ -44,7 +44,7 @@ func sqlJobMethods(job collectorapi.RuntimeJob) []funcapi.MethodConfig {
 			help = "Execute SQL query: " + fn.ID
 		}
 
-		methods = append(methods, funcapi.MethodConfig{
+		methods = append(methods, funcapi.FunctionConfig{
 			ID:           methodID,
 			Name:         methodName,
 			Help:         help,

--- a/src/go/plugin/go.d/collector/vsphere/collector.go
+++ b/src/go/plugin/go.d/collector/vsphere/collector.go
@@ -36,10 +36,10 @@ func init() {
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 20,
 		},
-		CreateV2:      func() collectorapi.CollectorV2 { return New() },
-		Config:        func() any { return &Config{} },
-		Methods:       vsphereMethods,
-		MethodHandler: vsphereMethodHandler,
+		CreateV2:        func() collectorapi.CollectorV2 { return New() },
+		Config:          func() any { return &Config{} },
+		SharedFunctions: vsphereMethods,
+		MethodHandler:   vsphereMethodHandler,
 	})
 }
 

--- a/src/go/plugin/go.d/collector/vsphere/func_readiness.go
+++ b/src/go/plugin/go.d/collector/vsphere/func_readiness.go
@@ -108,14 +108,14 @@ type funcReadiness struct {
 
 var _ funcapi.MethodHandler = (*funcReadiness)(nil)
 
-func vsphereMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{{
+func vsphereMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{{
 		ID:           readinessMethodID,
 		Name:         "vSphere Readiness",
 		UpdateEvery:  30,
 		Help:         readinessMethodHelp,
 		RequireCloud: true,
-	}, vsphereTopologyMethodConfig()}
+	}, vsphereTopologyFunctionConfig()}
 }
 
 func vsphereMethodHandler(job collectorapi.RuntimeJob) funcapi.MethodHandler {

--- a/src/go/plugin/go.d/collector/vsphere/func_readiness_test.go
+++ b/src/go/plugin/go.d/collector/vsphere/func_readiness_test.go
@@ -18,7 +18,7 @@ func TestVSphereMethods(t *testing.T) {
 	methods := vsphereMethods()
 
 	require.Len(t, methods, 2)
-	byID := make(map[string]funcapi.MethodConfig, len(methods))
+	byID := make(map[string]funcapi.FunctionConfig, len(methods))
 	for _, method := range methods {
 		byID[method.ID] = method
 	}
@@ -45,7 +45,6 @@ func TestVSphereMethods(t *testing.T) {
 			require.Equal(t, tc.wantName, method.Name)
 			require.Equal(t, 30, method.UpdateEvery)
 			require.True(t, method.RequireCloud)
-			require.Equal(t, funcapi.MethodScopeInstance, method.Scope)
 			if tc.alias != "" {
 				require.Contains(t, method.Aliases, tc.alias)
 			}

--- a/src/go/plugin/go.d/collector/vsphere/func_topology.go
+++ b/src/go/plugin/go.d/collector/vsphere/func_topology.go
@@ -41,8 +41,8 @@ type funcTopology struct {
 
 var _ funcapi.MethodHandler = (*funcTopology)(nil)
 
-func vsphereTopologyMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func vsphereTopologyFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:           topologyMethodID,
 		Aliases:      []string{topologyMethodID},
 		Name:         "vSphere Topology",

--- a/src/go/plugin/go.d/collector/yugabytedb/collector.go
+++ b/src/go/plugin/go.d/collector/yugabytedb/collector.go
@@ -25,10 +25,10 @@ func init() {
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 5,
 		},
-		Methods:       yugabyteMethods,
-		MethodHandler: yugabyteFunctionHandler,
-		Create:        func() collectorapi.CollectorV1 { return New() },
-		Config:        func() any { return &Config{} },
+		SharedFunctions: yugabyteMethods,
+		MethodHandler:   yugabyteFunctionHandler,
+		Create:          func() collectorapi.CollectorV1 { return New() },
+		Config:          func() any { return &Config{} },
 	})
 }
 

--- a/src/go/plugin/go.d/collector/yugabytedb/func_router.go
+++ b/src/go/plugin/go.d/collector/yugabytedb/func_router.go
@@ -114,10 +114,10 @@ func (r *funcRouter) topQueriesLimit() int {
 	return r.collector.topQueriesLimit()
 }
 
-func yugabyteMethods() []funcapi.MethodConfig {
-	return []funcapi.MethodConfig{
-		topQueriesMethodConfig(),
-		runningQueriesMethodConfig(),
+func yugabyteMethods() []funcapi.FunctionConfig {
+	return []funcapi.FunctionConfig{
+		topQueriesFunctionConfig(),
+		runningQueriesFunctionConfig(),
 	}
 }
 

--- a/src/go/plugin/go.d/collector/yugabytedb/func_running_queries.go
+++ b/src/go/plugin/go.d/collector/yugabytedb/func_running_queries.go
@@ -18,8 +18,8 @@ const (
 	runningQueriesMaxTextLength = 4096
 )
 
-func runningQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func runningQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             runningQueriesMethodID,
 		Name:           "Running Queries",
 		UpdateEvery:    10,

--- a/src/go/plugin/go.d/collector/yugabytedb/func_top_queries.go
+++ b/src/go/plugin/go.d/collector/yugabytedb/func_top_queries.go
@@ -19,8 +19,8 @@ const (
 	topQueriesMaxTextLength = 4096
 )
 
-func topQueriesMethodConfig() funcapi.MethodConfig {
-	return funcapi.MethodConfig{
+func topQueriesFunctionConfig() funcapi.FunctionConfig {
+	return funcapi.FunctionConfig{
 		ID:             topQueriesMethodID,
 		Name:           "Top Queries",
 		UpdateEvery:    10,


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the go.d Function declaration API to separate job-backed vs process-wide functions. Replaces module `Methods` with `SharedFunctions` and `AgentFunctions`, unifies configs under `funcapi.FunctionConfig`, and updates dispatch/CLI accordingly.

- **Refactors**
  - `collectorapi.Creator`: add `SharedFunctions` (job-backed, selected via `__job` or canonical job per `InstancePolicy`) and `AgentFunctions` (process-wide, no `__job`); keep `JobMethods` for per-job functions.
  - Replace `funcapi.MethodConfig` with `funcapi.FunctionConfig`; remove `MethodScope`.
  - Rename helpers: `MethodFunctionName(s)` → `FunctionName(s)`.
  - Function CLI resolution now looks up static functions via `SharedFunctions`/`AgentFunctions` and uses `funcapi.FunctionNames`; error when a module has no functions: “does not expose functions.”
  - `funcctl` registry/dispatch rewritten to register/publish by function kind; prevents conflicts between static functions and `JobMethods`.
  - Error when `function_only` has no functions: “no functions defined.”
  - Updated collectors and tests to the new API (e.g., `topQueriesFunctionConfig()`).

- **Migration**
  - Replace `Creator.Methods()` with `Creator.SharedFunctions()` or `Creator.AgentFunctions()`.
  - Change all uses of `MethodConfig` to `FunctionConfig`; drop `Scope`.
  - Update public-name lookups to `funcapi.FunctionName(s)`.
  - If you previously used module/static methods, choose:
    - `SharedFunctions` for job-backed functions (uses `__job` unless single-instance).
    - `AgentFunctions` for process-wide functions (no `__job`).
  - Do not set static functions and `JobMethods` together for the same module.

<sup>Written for commit caec98f315f0bb0a69ddd7bb8c7d70220026855a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

