### PR TITLE
feat(go.d): reconcile instance function availability

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -74,13 +74,13 @@ source files for evidence.
   registry to bridge Function dispatch. The Function is still job-backed:
   publication waits for the canonical job to be running and available, and
   dispatch rejects unavailable jobs before calling `MethodHandler`.
-- Shared job-backed Functions are published only while at least one running job
-  is available. By default, every running job is available for every shared
-  Function. If a collector needs runtime readiness gating per shared Function,
-  implement `collectorapi.FunctionAvailability`; keep
-  `FunctionAvailable(functionID)` cheap and non-blocking.
+- Shared and instance job-backed Functions are published only while their
+  backing running jobs are available. By default, every running job is available
+  for every shared or instance Function. If a collector needs runtime readiness
+  gating per job-backed Function, implement `collectorapi.FunctionAvailability`;
+  keep `FunctionAvailable(functionID)` cheap and non-blocking.
   `funcapi.FunctionConfig.Available` applies to `AgentFunctions`, not
-  job-backed `SharedFunctions`.
+  job-backed `SharedFunctions` or `InstanceFunctions`.
 - `collectorapi.Creator.InstancePolicy` defaults to
   `InstancePolicyPerJob`. Use `InstancePolicySingle` only for collectors that
   are intentionally one canonical job per agent. Single-instance configs MUST

--- a/.agents/sow/specs/go-function-publication-lifecycle.md
+++ b/.agents/sow/specs/go-function-publication-lifecycle.md
@@ -85,12 +85,20 @@ publication stream emitted by go.d.
 
 - Instance Functions are job-owned declarations returned by
   `collectorapi.Creator.InstanceFunctions(job)`.
-- Instance Functions are registered for one runtime job on job start and
+- Instance Functions are declared once for one runtime job on job start and
   unregistered on job stop.
+- `InstanceFunctions(job)` MUST NOT be called from reconcile/tick paths.
 - Instance Functions are published under the existing function name construction
   for their returned Function IDs.
-- This spec does not add late-publication or availability-driven withdrawal to
-  instance Functions.
+- Instance Function publication uses the same job-backed
+  `collectorapi.FunctionAvailability` hook as Shared Functions:
+  - if the owning collector implements `FunctionAvailability`, publish only
+    currently available stored declarations;
+  - withdraw a concrete instance Function when its owning job becomes
+    unavailable for that Function ID;
+  - republish the concrete instance Function when availability returns;
+  - if the owning collector does not implement `FunctionAvailability`, every
+    stored instance Function is available while the job runs.
 
 ## Validation Guidance
 

--- a/.agents/sow/specs/go-function-publication-lifecycle.md
+++ b/.agents/sow/specs/go-function-publication-lifecycle.md
@@ -45,10 +45,9 @@ publication stream emitted by go.d.
   `InstancePolicySingle` removes the public `__job` selector but does not make
   the Function true-agent; publication still depends on the canonical singleton
   job being running and available.
-- funcctl MAY recheck shared Function availability while jobs are running. jobmgr
-  currently performs this recheck from the running-job tick loop and on job
-  stop; agent/process-backed Function availability may still be checked at job
-  start.
+- funcctl MAY recheck job-backed Function availability while jobs are running.
+  jobmgr currently requests this recheck from the running-job tick loop and
+  immediately after job stop.
 - `AgentFunctions` are true-agent declarations and are not processed by shared
   job availability reconciliation.
 - Rechecks MUST reuse the normal funcctl publication path so public names,
@@ -58,11 +57,12 @@ publication stream emitted by go.d.
 ## Job-Backed Function Availability Contract
 
 - Collectors MAY implement `collectorapi.FunctionAvailability` when a
-  running job can serve only some shared Functions, or when a shared Function
-  should appear only after collector-owned runtime state is ready.
+  running job can serve only some shared or instance Functions, or when a
+  job-backed Function should appear only after collector-owned runtime state is
+  ready.
 - `FunctionAvailable(functionID)` MUST be cheap and non-blocking.
 - If a collector does not implement `FunctionAvailability`, every running job is
-  available for every shared Function declared by the module.
+  available for every shared or instance Function declared by the module.
 - Availability is pull-based. Collectors update their own state from normal
   runtime paths; funcctl reads that state during reconciliation.
 - Availability changes are reflected after the next reconcile pass. Rapidly

--- a/.agents/sow/specs/go-function-publication-lifecycle.md
+++ b/.agents/sow/specs/go-function-publication-lifecycle.md
@@ -7,7 +7,8 @@ This spec applies to go.d Functions registered through:
 - `collectorapi.Creator.SharedFunctions` for static shared job-backed
   Functions.
 - `collectorapi.Creator.AgentFunctions` for static true-agent Functions.
-- `collectorapi.Creator.JobMethods` for per-job methods.
+- `collectorapi.Creator.InstanceFunctions` for instance Functions owned by
+  one runtime job.
 - `funcapi.FunctionConfig.Available` for true-agent Function publication
   gating.
 - `collectorapi.FunctionAvailability` for running-job availability of
@@ -80,12 +81,16 @@ publication stream emitted by go.d.
 - `Available` SHOULD match the Function's user-visible not-ready boundary for
   true-agent Functions.
 
-## Job Methods
+## Instance Functions
 
-- Per-job methods remain tied to job lifecycle.
-- `collectorapi.Creator.JobMethods` methods are registered for a job on job
-  start and unregistered on job stop.
-- This spec does not add late-publication or monotonic behavior to job methods.
+- Instance Functions are job-owned declarations returned by
+  `collectorapi.Creator.InstanceFunctions(job)`.
+- Instance Functions are registered for one runtime job on job start and
+  unregistered on job stop.
+- Instance Functions are published under the existing function name construction
+  for their returned Function IDs.
+- This spec does not add late-publication or availability-driven withdrawal to
+  instance Functions.
 
 ## Validation Guidance
 

--- a/.agents/sow/specs/go-function-publication-lifecycle.md
+++ b/.agents/sow/specs/go-function-publication-lifecycle.md
@@ -40,7 +40,7 @@ publication stream emitted by go.d.
   Function, and therefore may not emit a matching withdrawal for that Function.
 - Function withdrawal is emitted through `FUNCTION_DEL GLOBAL`. Parents that do
   not advertise `STREAM_CAP_FUNCTION_DEL` can retain stale streamed Function
-  entries even after the child unregisters them locally.
+  entries even after the child unregisters shared or instance Functions locally.
 - Shared single-instance Functions still use `SharedFunctions`.
   `InstancePolicySingle` removes the public `__job` selector but does not make
   the Function true-agent; publication still depends on the canonical singleton
@@ -99,6 +99,10 @@ publication stream emitted by go.d.
   - republish the concrete instance Function when availability returns;
   - if the owning collector does not implement `FunctionAvailability`, every
     stored instance Function is available while the job runs.
+- Instance Function withdrawal is asynchronous with job stop. After a job stops,
+  its concrete instance Function can remain briefly listed until the reconcile
+  worker processes the stop-triggered request, but dispatch MUST reject the
+  stopped job instead of serving stale collector state.
 
 ## Validation Guidance
 

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -176,20 +176,18 @@ func (c *Controller) OnJobStart(job collectorapi.RuntimeJob) {
 	}
 }
 
-// ReconcileModuleMethods rechecks module/static method availability for modules
+// ReconcileModuleMethods rechecks static and instance Function availability for modules
 // with at least one registered running job.
 func (c *Controller) ReconcileModuleMethods(moduleName string) {
 	if moduleName == "" {
 		return
 	}
 	methods := c.registry.getMethods(moduleName)
-	if len(methods) == 0 {
-		return
-	}
 	if c.registry.hasRunningJob(moduleName) {
 		c.registerAvailableAgentFunctions(moduleName, methods)
 	}
 	c.reconcileSharedModuleFunctions(moduleName)
+	c.reconcileInstanceFunctions(moduleName)
 }
 
 func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
@@ -378,14 +376,14 @@ func (c *Controller) availableSharedJobNames(moduleName, methodID string) []stri
 
 	names := make([]string, 0, len(snapshots))
 	for _, snapshot := range snapshots {
-		if sharedFunctionJobAvailable(snapshot.job, methodID) {
+		if jobBackedFunctionAvailable(snapshot.job, methodID) {
 			names = append(names, snapshot.name)
 		}
 	}
 	return names
 }
 
-func sharedFunctionJobAvailable(job collectorapi.RuntimeJob, methodID string) bool {
+func jobBackedFunctionAvailable(job collectorapi.RuntimeJob, methodID string) bool {
 	if job == nil || !job.IsRunning() {
 		return false
 	}
@@ -488,15 +486,21 @@ func (c *Controller) registerInstanceFunctions(job collectorapi.RuntimeJob, meth
 }
 
 func (c *Controller) collectInstanceFunctionPublishes(job collectorapi.RuntimeJob, methods []funcapi.FunctionConfig) []functionPublish {
-	c.publishedMu.Lock()
-	defer c.publishedMu.Unlock()
-
-	var publishes []functionPublish
+	availableMethods := make([]funcapi.FunctionConfig, 0, len(methods))
 	for _, method := range methods {
 		if method.ID == "" {
 			continue
 		}
+		if jobBackedFunctionAvailable(job, method.ID) {
+			availableMethods = append(availableMethods, method)
+		}
+	}
 
+	c.publishedMu.Lock()
+	defer c.publishedMu.Unlock()
+
+	var publishes []functionPublish
+	for _, method := range availableMethods {
 		funcName := fmt.Sprintf("%s:%s", job.ModuleName(), method.ID)
 		if c.publishedFns.has(funcName) {
 			continue
@@ -530,6 +534,58 @@ func (c *Controller) collectInstanceFunctionPublishes(job collectorapi.RuntimeJo
 		})
 	}
 	return publishes
+}
+
+func (c *Controller) reconcileInstanceFunctions(moduleName string) {
+	publishes, withdraws := c.collectInstanceFunctionChanges(moduleName)
+	for _, name := range withdraws {
+		c.fnReg.Unregister(name)
+		if c.api != nil {
+			c.api.FunctionRemove(name)
+		}
+	}
+	for _, publish := range publishes {
+		c.registerFunction(publish.name, publish.handler)
+	}
+	if c.api == nil {
+		return
+	}
+	for _, publish := range publishes {
+		c.api.FunctionGlobal(publish.opts)
+	}
+}
+
+func (c *Controller) collectInstanceFunctionChanges(moduleName string) ([]functionPublish, []string) {
+	var publishes []functionPublish
+	var withdraws []string
+
+	for _, snapshot := range c.registry.getInstanceFunctionSnapshots(moduleName) {
+		var availableMethods []funcapi.FunctionConfig
+		for _, method := range snapshot.methods {
+			if method.ID == "" {
+				continue
+			}
+			if jobBackedFunctionAvailable(snapshot.job, method.ID) {
+				availableMethods = append(availableMethods, method)
+				continue
+			}
+			withdraws = append(withdraws, c.collectInstanceFunctionWithdraws(snapshot.job, method.ID)...)
+		}
+		publishes = append(publishes, c.collectInstanceFunctionPublishes(snapshot.job, availableMethods)...)
+	}
+
+	sort.Strings(withdraws)
+	return publishes, withdraws
+}
+
+func (c *Controller) collectInstanceFunctionWithdraws(job collectorapi.RuntimeJob, methodID string) []string {
+	if job == nil {
+		return nil
+	}
+	c.publishedMu.Lock()
+	names := c.publishedFns.removeOwner(instanceFunctionOwner(job.ModuleName(), job.Name(), methodID))
+	c.publishedMu.Unlock()
+	return names
 }
 
 func (c *Controller) unregisterInstanceFunctions(job collectorapi.RuntimeJob) {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -394,6 +394,14 @@ func jobBackedFunctionAvailable(job collectorapi.RuntimeJob, methodID string) bo
 	return availability.FunctionAvailable(methodID)
 }
 
+func jobUsesFunctionAvailability(job collectorapi.RuntimeJob) bool {
+	if job == nil {
+		return false
+	}
+	availability, ok := job.Collector().(collectorapi.FunctionAvailability)
+	return ok && availability != nil
+}
+
 func (c *Controller) allFunctionNamesPublishedLocked(moduleName string, method funcapi.FunctionConfig) bool {
 	names := funcapi.FunctionNames(moduleName, method)
 	return c.publishedFns.all(names)
@@ -473,6 +481,10 @@ func (c *Controller) registerInstanceFunctions(job collectorapi.RuntimeJob, meth
 	// Record methods before publishing handlers so startup-time calls do not race a false 404.
 	c.registry.registerInstanceFunctions(job.ModuleName(), job.Name(), methods)
 
+	if jobUsesFunctionAvailability(job) {
+		return
+	}
+
 	publishes := c.collectInstanceFunctionPublishes(job, methods)
 
 	for _, publish := range publishes {
@@ -486,21 +498,14 @@ func (c *Controller) registerInstanceFunctions(job collectorapi.RuntimeJob, meth
 }
 
 func (c *Controller) collectInstanceFunctionPublishes(job collectorapi.RuntimeJob, methods []funcapi.FunctionConfig) []functionPublish {
-	availableMethods := make([]funcapi.FunctionConfig, 0, len(methods))
-	for _, method := range methods {
-		if method.ID == "" {
-			continue
-		}
-		if jobBackedFunctionAvailable(job, method.ID) {
-			availableMethods = append(availableMethods, method)
-		}
-	}
-
 	c.publishedMu.Lock()
 	defer c.publishedMu.Unlock()
 
 	var publishes []functionPublish
-	for _, method := range availableMethods {
+	for _, method := range methods {
+		if method.ID == "" {
+			continue
+		}
 		funcName := fmt.Sprintf("%s:%s", job.ModuleName(), method.ID)
 		if c.publishedFns.has(funcName) {
 			continue

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -85,7 +85,7 @@ func (c *Controller) RegisterModules(modules collectorapi.Registry) {
 	plannedPublicNames := make(map[string]string)
 	for _, name := range names {
 		creator := modules[name]
-		if creator.SharedFunctions == nil && creator.AgentFunctions == nil && creator.JobMethods == nil {
+		if creator.SharedFunctions == nil && creator.AgentFunctions == nil && creator.InstanceFunctions == nil {
 			continue
 		}
 		functions := moduleFunctionDeclarations(creator)
@@ -166,13 +166,13 @@ func (c *Controller) OnJobStart(job collectorapi.RuntimeJob) {
 	c.registerAvailableAgentFunctions(job.ModuleName(), c.registry.getMethods(job.ModuleName()))
 
 	creator, ok := c.registry.getCreator(job.ModuleName())
-	if !ok || creator.JobMethods == nil {
+	if !ok || creator.InstanceFunctions == nil {
 		return
 	}
 
-	methods := creator.JobMethods(job)
+	methods := creator.InstanceFunctions(job)
 	if len(methods) > 0 {
-		c.registerJobMethods(job, methods)
+		c.registerInstanceFunctions(job, methods)
 	}
 }
 
@@ -197,7 +197,7 @@ func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
 		return
 	}
 
-	c.unregisterJobMethods(job)
+	c.unregisterInstanceFunctions(job)
 	c.registry.removeJob(job.ModuleName(), job.Name())
 	c.reconcileSharedModuleFunctions(job.ModuleName())
 }
@@ -446,36 +446,36 @@ func (c *Controller) registerFunction(name string, handler functions.Handler) {
 	})
 }
 
-func (c *Controller) registerJobMethods(job collectorapi.RuntimeJob, methods []funcapi.FunctionConfig) {
+func (c *Controller) registerInstanceFunctions(job collectorapi.RuntimeJob, methods []funcapi.FunctionConfig) {
 	planned := make(map[string]struct{}, len(methods))
 
 	for _, method := range methods {
 		if method.ID == "" {
-			c.Warningf("skipping job method registration for %s[%s]: empty method ID", job.ModuleName(), job.Name())
+			c.Warningf("skipping instance function registration for %s[%s]: empty method ID", job.ModuleName(), job.Name())
 			continue
 		}
 		if method.FunctionName != "" || len(method.Aliases) != 0 {
-			c.Errorf("job method registration aborted for %s[%s]: method '%s' uses public FunctionName or Aliases, which are supported only for module methods", job.ModuleName(), job.Name(), method.ID)
+			c.Errorf("instance function registration aborted for %s[%s]: method '%s' uses public FunctionName or Aliases, which are supported only for static Functions", job.ModuleName(), job.Name(), method.ID)
 			return
 		}
 
 		funcName := fmt.Sprintf("%s:%s", job.ModuleName(), method.ID)
 		if _, exists := planned[method.ID]; exists {
-			c.Errorf("job method registration aborted for %s[%s]: duplicate method ID in batch ('%s')", job.ModuleName(), job.Name(), funcName)
+			c.Errorf("instance function registration aborted for %s[%s]: duplicate method ID in batch ('%s')", job.ModuleName(), job.Name(), funcName)
 			return
 		}
 		planned[method.ID] = struct{}{}
 
 		if collision, exists := c.registry.findMethodCollision(job.ModuleName(), job.Name(), method.ID); exists {
-			c.Errorf("job method registration aborted for %s[%s]: collision on '%s' (%s)", job.ModuleName(), job.Name(), funcName, collision)
+			c.Errorf("instance function registration aborted for %s[%s]: collision on '%s' (%s)", job.ModuleName(), job.Name(), funcName, collision)
 			return
 		}
 	}
 
 	// Record methods before publishing handlers so startup-time calls do not race a false 404.
-	c.registry.registerJobMethods(job.ModuleName(), job.Name(), methods)
+	c.registry.registerInstanceFunctions(job.ModuleName(), job.Name(), methods)
 
-	publishes := c.collectJobMethodPublishes(job, methods)
+	publishes := c.collectInstanceFunctionPublishes(job, methods)
 
 	for _, publish := range publishes {
 		c.registerFunction(publish.name, publish.handler)
@@ -483,11 +483,11 @@ func (c *Controller) registerJobMethods(job collectorapi.RuntimeJob, methods []f
 			c.api.FunctionGlobal(publish.opts)
 		}
 
-		c.Debugf("registered job method: %s for job %s[%s]", publish.name, job.ModuleName(), job.Name())
+		c.Debugf("registered instance function: %s for job %s[%s]", publish.name, job.ModuleName(), job.Name())
 	}
 }
 
-func (c *Controller) collectJobMethodPublishes(job collectorapi.RuntimeJob, methods []funcapi.FunctionConfig) []functionPublish {
+func (c *Controller) collectInstanceFunctionPublishes(job collectorapi.RuntimeJob, methods []funcapi.FunctionConfig) []functionPublish {
 	c.publishedMu.Lock()
 	defer c.publishedMu.Unlock()
 
@@ -502,7 +502,7 @@ func (c *Controller) collectJobMethodPublishes(job collectorapi.RuntimeJob, meth
 			continue
 		}
 
-		record, _ := c.publishedFns.add(funcName, jobMethodOwner(job.ModuleName(), job.Name(), method.ID))
+		record, _ := c.publishedFns.add(funcName, instanceFunctionOwner(job.ModuleName(), job.Name(), method.ID))
 
 		help := method.Help
 		if help == "" {
@@ -517,7 +517,7 @@ func (c *Controller) collectJobMethodPublishes(job collectorapi.RuntimeJob, meth
 
 		publishes = append(publishes, functionPublish{
 			name:    funcName,
-			handler: c.makePublishedJobMethodFuncHandler(funcName, record.generation, job.ModuleName(), job.Name(), method.ID),
+			handler: c.makePublishedInstanceFunctionHandler(funcName, record.generation, job.ModuleName(), job.Name(), method.ID),
 			opts: netdataapi.FunctionGlobalOpts{
 				Name:     funcName,
 				Timeout:  60,
@@ -532,8 +532,8 @@ func (c *Controller) collectJobMethodPublishes(job collectorapi.RuntimeJob, meth
 	return publishes
 }
 
-func (c *Controller) unregisterJobMethods(job collectorapi.RuntimeJob) {
-	methods := c.registry.getJobMethods(job.ModuleName(), job.Name())
+func (c *Controller) unregisterInstanceFunctions(job collectorapi.RuntimeJob) {
+	methods := c.registry.getInstanceFunctions(job.ModuleName(), job.Name())
 	if len(methods) == 0 {
 		return
 	}
@@ -544,7 +544,7 @@ func (c *Controller) unregisterJobMethods(job collectorapi.RuntimeJob) {
 		if method.ID == "" {
 			continue
 		}
-		names = append(names, c.publishedFns.removeOwner(jobMethodOwner(job.ModuleName(), job.Name(), method.ID))...)
+		names = append(names, c.publishedFns.removeOwner(instanceFunctionOwner(job.ModuleName(), job.Name(), method.ID))...)
 	}
 	c.publishedMu.Unlock()
 
@@ -554,10 +554,10 @@ func (c *Controller) unregisterJobMethods(job collectorapi.RuntimeJob) {
 		if c.api != nil {
 			c.api.FunctionRemove(funcName)
 		}
-		c.Debugf("unregistered job method: %s for job %s[%s]", funcName, job.ModuleName(), job.Name())
+		c.Debugf("unregistered instance function: %s for job %s[%s]", funcName, job.ModuleName(), job.Name())
 	}
 
-	c.registry.unregisterJobMethods(job.ModuleName(), job.Name())
+	c.registry.unregisterInstanceFunctions(job.ModuleName(), job.Name())
 }
 
 func (c *Controller) baseContext() context.Context {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller.go
@@ -43,6 +43,14 @@ type functionPublish struct {
 	opts    netdataapi.FunctionGlobalOpts
 }
 
+type desiredFunctionPublication struct {
+	name       string
+	owner      publishedFunctionOwner
+	moduleName string
+	jobName    string
+	method     funcapi.FunctionConfig
+}
+
 func New(opts Options) *Controller {
 	log := opts.Logger
 	if log == nil {
@@ -163,7 +171,6 @@ func (c *Controller) OnJobStart(job collectorapi.RuntimeJob) {
 	}
 
 	c.registry.addJob(job.ModuleName(), job.Name(), job)
-	c.registerAvailableAgentFunctions(job.ModuleName(), c.registry.getMethods(job.ModuleName()))
 
 	creator, ok := c.registry.getCreator(job.ModuleName())
 	if !ok || creator.InstanceFunctions == nil {
@@ -186,8 +193,7 @@ func (c *Controller) ReconcileModuleMethods(moduleName string) {
 	if c.registry.hasRunningJob(moduleName) {
 		c.registerAvailableAgentFunctions(moduleName, methods)
 	}
-	c.reconcileSharedModuleFunctions(moduleName)
-	c.reconcileInstanceFunctions(moduleName)
+	c.reconcileModuleFunctions(moduleName, methods)
 }
 
 func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
@@ -197,12 +203,11 @@ func (c *Controller) OnJobStop(job collectorapi.RuntimeJob) {
 
 	c.unregisterInstanceFunctions(job)
 	c.registry.removeJob(job.ModuleName(), job.Name())
-	c.reconcileSharedModuleFunctions(job.ModuleName())
 }
 
 func (c *Controller) Cleanup() {
 	c.publishedMu.Lock()
-	names := c.publishedFns.removeKind(publishedFunctionModuleMethod)
+	names := c.publishedFns.removeKinds(publishedFunctionShared, publishedFunctionAgent, publishedFunctionInstance)
 	c.publishedMu.Unlock()
 
 	sort.Strings(names)
@@ -230,16 +235,10 @@ func (c *Controller) registerAvailableAgentFunctions(moduleName string, methods 
 }
 
 func (c *Controller) collectAvailableAgentFunctionPublishes(moduleName string, methods []funcapi.FunctionConfig) []functionPublish {
-	c.publishedMu.Lock()
-	defer c.publishedMu.Unlock()
-
-	var publishes []functionPublish
+	var available []funcapi.FunctionConfig
 	for i, method := range methods {
 		kind := c.registry.getModuleFunctionKind(moduleName, method.ID)
 		if kind != moduleFunctionAgent {
-			continue
-		}
-		if method.ID != "" && c.allFunctionNamesPublishedLocked(moduleName, method) {
 			continue
 		}
 		if !methodAvailable(method) {
@@ -250,13 +249,23 @@ func (c *Controller) collectAvailableAgentFunctionPublishes(moduleName string, m
 				Warningf("skipping function registration for module '%s': empty method ID", moduleName)
 			continue
 		}
+		available = append(available, method)
+	}
 
+	c.publishedMu.Lock()
+	defer c.publishedMu.Unlock()
+
+	var publishes []functionPublish
+	for _, method := range available {
+		if c.allFunctionNamesPublishedLocked(moduleName, method) {
+			continue
+		}
 		if c.api != nil {
 			for _, funcName := range funcapi.FunctionNames(moduleName, method) {
 				if c.publishedFns.has(funcName) {
 					continue
 				}
-				record, _ := c.publishedFns.add(funcName, moduleMethodOwner(moduleName, method.ID))
+				record, _ := c.publishedFns.add(funcName, agentFunctionOwner(moduleName, method.ID))
 				publishes = append(publishes, functionPublish{
 					name:    funcName,
 					handler: c.makePublishedMethodFuncHandler(funcName, record.generation, moduleName, method.ID),
@@ -270,7 +279,7 @@ func (c *Controller) collectAvailableAgentFunctionPublishes(moduleName string, m
 			if c.publishedFns.has(funcName) {
 				continue
 			}
-			record, _ := c.publishedFns.add(funcName, moduleMethodOwner(moduleName, method.ID))
+			record, _ := c.publishedFns.add(funcName, agentFunctionOwner(moduleName, method.ID))
 			publishes = append(publishes, functionPublish{
 				name:    funcName,
 				handler: c.makePublishedMethodFuncHandler(funcName, record.generation, moduleName, method.ID),
@@ -280,13 +289,9 @@ func (c *Controller) collectAvailableAgentFunctionPublishes(moduleName string, m
 	return publishes
 }
 
-func (c *Controller) reconcileSharedModuleFunctions(moduleName string) {
-	methods := c.registry.getMethods(moduleName)
-	if len(methods) == 0 {
-		return
-	}
-
-	publishes, withdraws := c.collectSharedModuleFunctionChanges(moduleName, methods)
+func (c *Controller) reconcileModuleFunctions(moduleName string, methods []funcapi.FunctionConfig) {
+	desired := c.desiredModuleFunctions(moduleName, methods)
+	publishes, withdraws := c.collectModuleFunctionChanges(moduleName, desired)
 	for _, name := range withdraws {
 		c.fnReg.Unregister(name)
 		if c.api != nil {
@@ -304,9 +309,8 @@ func (c *Controller) reconcileSharedModuleFunctions(moduleName string) {
 	}
 }
 
-func (c *Controller) collectSharedModuleFunctionChanges(moduleName string, methods []funcapi.FunctionConfig) ([]functionPublish, []string) {
-	var publishes []functionPublish
-	var withdraws []string
+func (c *Controller) desiredModuleFunctions(moduleName string, methods []funcapi.FunctionConfig) map[string]desiredFunctionPublication {
+	desired := make(map[string]desiredFunctionPublication)
 
 	for i, method := range methods {
 		kind := c.registry.getModuleFunctionKind(moduleName, method.ID)
@@ -321,51 +325,88 @@ func (c *Controller) collectSharedModuleFunctionChanges(moduleName string, metho
 
 		availableJobs := c.availableSharedJobNames(moduleName, method.ID)
 		if len(availableJobs) == 0 {
-			withdraws = append(withdraws, c.collectSharedModuleFunctionWithdraws(moduleName, method.ID)...)
 			continue
 		}
 
-		if c.allFunctionNamesPublished(moduleName, method) {
-			continue
+		for _, funcName := range funcapi.FunctionNames(moduleName, method) {
+			desired[funcName] = desiredFunctionPublication{
+				name:       funcName,
+				owner:      sharedFunctionOwner(moduleName, method.ID),
+				moduleName: moduleName,
+				method:     method,
+			}
 		}
-		publishes = append(publishes, c.collectSharedModuleFunctionPublishes(moduleName, method)...)
 	}
 
+	for _, snapshot := range c.registry.getInstanceFunctionSnapshots(moduleName) {
+		for _, method := range snapshot.methods {
+			if method.ID == "" {
+				continue
+			}
+			if !jobBackedFunctionAvailable(snapshot.job, method.ID) {
+				continue
+			}
+			funcName := fmt.Sprintf("%s:%s", snapshot.job.ModuleName(), method.ID)
+			desired[funcName] = desiredFunctionPublication{
+				name:       funcName,
+				owner:      instanceFunctionOwner(snapshot.job.ModuleName(), snapshot.job.Name(), method.ID),
+				moduleName: snapshot.job.ModuleName(),
+				jobName:    snapshot.job.Name(),
+				method:     method,
+			}
+		}
+	}
+
+	return desired
+}
+
+func (c *Controller) collectModuleFunctionChanges(moduleName string, desired map[string]desiredFunctionPublication) ([]functionPublish, []string) {
+	c.publishedMu.Lock()
+	defer c.publishedMu.Unlock()
+
+	var withdraws []string
+	for name, record := range c.publishedFns.moduleRecords(moduleName) {
+		if record.owner.kind != publishedFunctionShared && record.owner.kind != publishedFunctionInstance {
+			continue
+		}
+		want, ok := desired[name]
+		if ok && want.owner == record.owner {
+			continue
+		}
+		c.publishedFns.removeName(name)
+		withdraws = append(withdraws, name)
+	}
+
+	var publishes []functionPublish
+	for _, want := range desired {
+		if c.publishedFns.has(want.name) {
+			continue
+		}
+		record, _ := c.publishedFns.add(want.name, want.owner)
+		publishes = append(publishes, c.makeFunctionPublish(want, record.generation))
+	}
+
+	sort.Slice(publishes, func(i, j int) bool {
+		return publishes[i].name < publishes[j].name
+	})
 	sort.Strings(withdraws)
 	return publishes, withdraws
 }
 
-func (c *Controller) collectSharedModuleFunctionWithdraws(moduleName, methodID string) []string {
-	c.publishedMu.Lock()
-	names := c.publishedFns.removeOwner(moduleMethodOwner(moduleName, methodID))
-	c.publishedMu.Unlock()
-
-	return names
-}
-
-func (c *Controller) collectSharedModuleFunctionPublishes(moduleName string, method funcapi.FunctionConfig) []functionPublish {
-	c.publishedMu.Lock()
-	defer c.publishedMu.Unlock()
-
-	var publishes []functionPublish
-	for _, funcName := range funcapi.FunctionNames(moduleName, method) {
-		if c.publishedFns.has(funcName) {
-			continue
+func (c *Controller) makeFunctionPublish(want desiredFunctionPublication, generation uint64) functionPublish {
+	if want.owner.kind == publishedFunctionInstance {
+		return functionPublish{
+			name:    want.name,
+			handler: c.makePublishedInstanceFunctionHandler(want.name, generation, want.moduleName, want.jobName, want.method.ID),
+			opts:    c.functionGlobalOpts(want.moduleName, want.method, want.name),
 		}
-		record, _ := c.publishedFns.add(funcName, moduleMethodOwner(moduleName, method.ID))
-		publishes = append(publishes, functionPublish{
-			name:    funcName,
-			handler: c.makePublishedMethodFuncHandler(funcName, record.generation, moduleName, method.ID),
-			opts:    c.functionGlobalOpts(moduleName, method, funcName),
-		})
 	}
-	return publishes
-}
 
-func (c *Controller) allFunctionNamesPublished(moduleName string, method funcapi.FunctionConfig) bool {
-	c.publishedMu.Lock()
-	defer c.publishedMu.Unlock()
-	return c.allFunctionNamesPublishedLocked(moduleName, method)
+	return functionPublish{
+		name:    want.name,
+		handler: c.makePublishedMethodFuncHandler(want.name, generation, want.moduleName, want.method.ID),
+		opts:    c.functionGlobalOpts(want.moduleName, want.method, want.name),
+	}
 }
 
 func (c *Controller) availableSharedJobNames(moduleName, methodID string) []string {
@@ -392,14 +433,6 @@ func jobBackedFunctionAvailable(job collectorapi.RuntimeJob, methodID string) bo
 		return true
 	}
 	return availability.FunctionAvailable(methodID)
-}
-
-func jobUsesFunctionAvailability(job collectorapi.RuntimeJob) bool {
-	if job == nil {
-		return false
-	}
-	availability, ok := job.Collector().(collectorapi.FunctionAvailability)
-	return ok && availability != nil
 }
 
 func (c *Controller) allFunctionNamesPublishedLocked(moduleName string, method funcapi.FunctionConfig) bool {
@@ -478,146 +511,10 @@ func (c *Controller) registerInstanceFunctions(job collectorapi.RuntimeJob, meth
 		}
 	}
 
-	// Record methods before publishing handlers so startup-time calls do not race a false 404.
 	c.registry.registerInstanceFunctions(job.ModuleName(), job.Name(), methods)
-
-	if jobUsesFunctionAvailability(job) {
-		return
-	}
-
-	publishes := c.collectInstanceFunctionPublishes(job, methods)
-
-	for _, publish := range publishes {
-		c.registerFunction(publish.name, publish.handler)
-		if c.api != nil {
-			c.api.FunctionGlobal(publish.opts)
-		}
-
-		c.Debugf("registered instance function: %s for job %s[%s]", publish.name, job.ModuleName(), job.Name())
-	}
-}
-
-func (c *Controller) collectInstanceFunctionPublishes(job collectorapi.RuntimeJob, methods []funcapi.FunctionConfig) []functionPublish {
-	c.publishedMu.Lock()
-	defer c.publishedMu.Unlock()
-
-	var publishes []functionPublish
-	for _, method := range methods {
-		if method.ID == "" {
-			continue
-		}
-		funcName := fmt.Sprintf("%s:%s", job.ModuleName(), method.ID)
-		if c.publishedFns.has(funcName) {
-			continue
-		}
-
-		record, _ := c.publishedFns.add(funcName, instanceFunctionOwner(job.ModuleName(), job.Name(), method.ID))
-
-		help := method.Help
-		if help == "" {
-			help = fmt.Sprintf("%s %s data function", job.ModuleName(), method.ID)
-		}
-
-		const cloudAccess = "0x0013"
-		access := "0x0000"
-		if method.RequireCloud {
-			access = cloudAccess
-		}
-
-		publishes = append(publishes, functionPublish{
-			name:    funcName,
-			handler: c.makePublishedInstanceFunctionHandler(funcName, record.generation, job.ModuleName(), job.Name(), method.ID),
-			opts: netdataapi.FunctionGlobalOpts{
-				Name:     funcName,
-				Timeout:  60,
-				Help:     help,
-				Tags:     methodTags(method),
-				Access:   access,
-				Priority: 100,
-				Version:  3,
-			},
-		})
-	}
-	return publishes
-}
-
-func (c *Controller) reconcileInstanceFunctions(moduleName string) {
-	publishes, withdraws := c.collectInstanceFunctionChanges(moduleName)
-	for _, name := range withdraws {
-		c.fnReg.Unregister(name)
-		if c.api != nil {
-			c.api.FunctionRemove(name)
-		}
-	}
-	for _, publish := range publishes {
-		c.registerFunction(publish.name, publish.handler)
-	}
-	if c.api == nil {
-		return
-	}
-	for _, publish := range publishes {
-		c.api.FunctionGlobal(publish.opts)
-	}
-}
-
-func (c *Controller) collectInstanceFunctionChanges(moduleName string) ([]functionPublish, []string) {
-	var publishes []functionPublish
-	var withdraws []string
-
-	for _, snapshot := range c.registry.getInstanceFunctionSnapshots(moduleName) {
-		var availableMethods []funcapi.FunctionConfig
-		for _, method := range snapshot.methods {
-			if method.ID == "" {
-				continue
-			}
-			if jobBackedFunctionAvailable(snapshot.job, method.ID) {
-				availableMethods = append(availableMethods, method)
-				continue
-			}
-			withdraws = append(withdraws, c.collectInstanceFunctionWithdraws(snapshot.job, method.ID)...)
-		}
-		publishes = append(publishes, c.collectInstanceFunctionPublishes(snapshot.job, availableMethods)...)
-	}
-
-	sort.Strings(withdraws)
-	return publishes, withdraws
-}
-
-func (c *Controller) collectInstanceFunctionWithdraws(job collectorapi.RuntimeJob, methodID string) []string {
-	if job == nil {
-		return nil
-	}
-	c.publishedMu.Lock()
-	names := c.publishedFns.removeOwner(instanceFunctionOwner(job.ModuleName(), job.Name(), methodID))
-	c.publishedMu.Unlock()
-	return names
 }
 
 func (c *Controller) unregisterInstanceFunctions(job collectorapi.RuntimeJob) {
-	methods := c.registry.getInstanceFunctions(job.ModuleName(), job.Name())
-	if len(methods) == 0 {
-		return
-	}
-
-	var names []string
-	c.publishedMu.Lock()
-	for _, method := range methods {
-		if method.ID == "" {
-			continue
-		}
-		names = append(names, c.publishedFns.removeOwner(instanceFunctionOwner(job.ModuleName(), job.Name(), method.ID))...)
-	}
-	c.publishedMu.Unlock()
-
-	sort.Strings(names)
-	for _, funcName := range names {
-		c.fnReg.Unregister(funcName)
-		if c.api != nil {
-			c.api.FunctionRemove(funcName)
-		}
-		c.Debugf("unregistered instance function: %s for job %s[%s]", funcName, job.ModuleName(), job.Name())
-	}
-
 	c.registry.unregisterInstanceFunctions(job.ModuleName(), job.Name())
 }
 

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -1237,6 +1237,93 @@ func TestControllerRegisterInstanceFunctions(t *testing.T) {
 	}
 }
 
+func TestControllerInstanceFunctionsUseJobBackedAvailability(t *testing.T) {
+	tests := map[string]func(*testing.T){
+		"publish withdraw and republish stored declarations": func(t *testing.T) {
+			available := map[string]bool{"a": false}
+			job := newTestRuntimeJob("mod", "job1", true)
+			job.collector = &testFunctionAvailability{available: available}
+
+			var gotCode int
+			var gotResp map[string]any
+			reg := newTestFunctionRegistry()
+			declareCalls := 0
+			controller := New(Options{
+				FnReg: reg,
+				JSONWriter: func(data []byte, code int) {
+					gotCode = code
+					require.NoError(t, json.Unmarshal(data, &gotResp))
+				},
+			})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					InstanceFunctions: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+						declareCalls++
+						return []funcapi.FunctionConfig{{ID: "a"}}
+					},
+					MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+						return &tableTestHandler{}
+					},
+				},
+			})
+
+			controller.OnJobStart(job)
+
+			assert.Equal(t, 1, declareCalls)
+			assert.Empty(t, reg.registeredNames())
+			assert.Len(t, controller.registry.getInstanceFunctions("mod", "job1"), 1)
+
+			available["a"] = true
+			controller.ReconcileModuleMethods("mod")
+
+			assert.Equal(t, 1, declareCalls)
+			assert.Equal(t, []string{"mod:a"}, reg.registeredNames())
+			stale := reg.handlers["mod:a"]
+			require.NotNil(t, stale)
+
+			available["a"] = false
+			controller.ReconcileModuleMethods("mod")
+
+			assert.Equal(t, []string{"mod:a"}, reg.unregisteredNames())
+			stale(functions.Function{UID: "withdrawn", Timeout: time.Second})
+			assert.Equal(t, 404, gotCode)
+			assert.Equal(t, float64(404), gotResp["status"])
+
+			available["a"] = true
+			controller.ReconcileModuleMethods("mod")
+
+			assert.Equal(t, 1, declareCalls)
+			assert.Equal(t, []string{"mod:a", "mod:a"}, reg.registeredNames())
+			stale(functions.Function{UID: "stale-after-republish", Timeout: time.Second})
+			assert.Equal(t, 404, gotCode)
+			assert.Equal(t, float64(404), gotResp["status"])
+
+			reg.handlers["mod:a"](functions.Function{UID: "republished", Timeout: time.Second})
+			assert.Equal(t, 200, gotCode)
+			assert.Equal(t, float64(200), gotResp["status"])
+		},
+		"missing FunctionAvailability preserves immediate publication": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			controller := New(Options{FnReg: reg})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					InstanceFunctions: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "a"}}
+					},
+				},
+			})
+
+			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+
+			assert.Equal(t, []string{"mod:a"}, reg.registeredNames())
+		},
+	}
+
+	for name, run := range tests {
+		t.Run(name, run)
+	}
+}
+
 func TestControllerPublishedFunctionWrapperConcurrentMutation(t *testing.T) {
 	tests := map[string]struct {
 		setup  func(*Controller)

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -1317,6 +1317,33 @@ func TestControllerInstanceFunctionsUseJobBackedAvailability(t *testing.T) {
 
 			assert.Equal(t, []string{"mod:a"}, reg.registeredNames())
 		},
+		"FunctionAvailability is not called synchronously on job start": func(t *testing.T) {
+			reg := newTestFunctionRegistry()
+			var availabilityCalls atomic.Int32
+			job := newTestRuntimeJob("mod", "job1", true)
+			job.collector = &testFunctionAvailability{fn: func(string) bool {
+				availabilityCalls.Add(1)
+				return true
+			}}
+			controller := New(Options{FnReg: reg})
+			controller.RegisterModules(collectorapi.Registry{
+				"mod": collectorapi.Creator{
+					InstanceFunctions: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "a"}}
+					},
+				},
+			})
+
+			controller.OnJobStart(job)
+
+			assert.Equal(t, int32(0), availabilityCalls.Load())
+			assert.Empty(t, reg.registeredNames())
+
+			controller.ReconcileModuleMethods("mod")
+
+			assert.Equal(t, int32(1), availabilityCalls.Load())
+			assert.Equal(t, []string{"mod:a"}, reg.registeredNames())
+		},
 	}
 
 	for name, run := range tests {

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -507,6 +507,7 @@ func TestControllerLifecycleHooks(t *testing.T) {
 			available = true
 			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
 			controller.OnJobStart(newTestRuntimeJob("mod", "job2", true))
+			controller.ReconcileModuleMethods("mod")
 
 			assert.Equal(t, []string{"mod:logs"}, reg.registeredNames())
 		},
@@ -696,7 +697,10 @@ func TestControllerLifecycleHooks(t *testing.T) {
 
 			job := newTestRuntimeJob("mod", "job1", true)
 			controller.OnJobStart(job)
+			controller.ReconcileModuleMethods("mod")
 			controller.OnJobStop(job)
+			assert.Empty(t, reg.unregisteredNames())
+			controller.ReconcileModuleMethods("mod")
 
 			assert.Contains(t, reg.unregisteredNames(), "mod:job-method")
 		},
@@ -817,6 +821,8 @@ func TestControllerSharedFunctionWithdrawsWhenLastDefaultJobStops(t *testing.T) 
 	assert.NotContains(t, buf.String(), "FUNCTION_DEL GLOBAL \"mod:logs\"")
 
 	controller.OnJobStop(job2)
+	assert.Empty(t, reg.unregisteredNames())
+	controller.ReconcileModuleMethods("mod")
 
 	assert.Equal(t, []string{"mod:logs"}, reg.unregisteredNames())
 	assert.Contains(t, buf.String(), "FUNCTION_DEL GLOBAL \"mod:logs\"")
@@ -950,6 +956,7 @@ func TestControllerSharedFunctionRepublishesWithNewGeneration(t *testing.T) {
 	require.NotNil(t, firstHandler)
 
 	controller.OnJobStop(job1)
+	controller.ReconcileModuleMethods("mod")
 	firstHandler(context.Background(), functions.Function{
 		UID:     "stale-generation",
 		Timeout: time.Second,
@@ -1193,31 +1200,14 @@ func TestControllerRegisterInstanceFunctions(t *testing.T) {
 			assert.Empty(t, reg.registeredNames())
 			assert.Empty(t, controller.registry.getInstanceFunctions("mod", "job1"))
 		},
-		"registry is populated before handlers are callable": func(t *testing.T) {
-			var gotCode int
-			var gotResp map[string]any
-
+		"success stores declarations without publishing handlers": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
-			reg.onRegister = func(_ string, fn func(functions.Function)) {
-				fn(functions.Function{
-					UID:  "during-register",
-					Args: []string{"info"},
-				})
-			}
-			controller := New(Options{
-				FnReg: reg,
-				JSONWriter: func(data []byte, code int) {
-					gotCode = code
-					require.NoError(t, json.Unmarshal(data, &gotResp))
-				},
-			})
+			controller := New(Options{FnReg: reg})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
 
 			controller.registerInstanceFunctions(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "a", Help: "instance function help"}})
 
-			assert.Equal(t, 200, gotCode)
-			assert.Equal(t, float64(200), gotResp["status"])
-			assert.Equal(t, "instance function help", gotResp["help"])
+			assert.Empty(t, reg.registeredNames())
 			assert.Len(t, controller.registry.getInstanceFunctions("mod", "job1"), 1)
 		},
 		"success commits all methods": func(t *testing.T) {
@@ -1227,7 +1217,7 @@ func TestControllerRegisterInstanceFunctions(t *testing.T) {
 
 			controller.registerInstanceFunctions(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "a"}, {ID: "b"}})
 
-			assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, reg.registeredNames())
+			assert.Empty(t, reg.registeredNames())
 			assert.Len(t, controller.registry.getInstanceFunctions("mod", "job1"), 2)
 		},
 	}
@@ -1302,7 +1292,7 @@ func TestControllerInstanceFunctionsUseJobBackedAvailability(t *testing.T) {
 			assert.Equal(t, 200, gotCode)
 			assert.Equal(t, float64(200), gotResp["status"])
 		},
-		"missing FunctionAvailability preserves immediate publication": func(t *testing.T) {
+		"missing FunctionAvailability publishes on reconcile": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
 			controller := New(Options{FnReg: reg})
 			controller.RegisterModules(collectorapi.Registry{
@@ -1314,6 +1304,8 @@ func TestControllerInstanceFunctionsUseJobBackedAvailability(t *testing.T) {
 			})
 
 			controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+			assert.Empty(t, reg.registeredNames())
+			controller.ReconcileModuleMethods("mod")
 
 			assert.Equal(t, []string{"mod:a"}, reg.registeredNames())
 		},
@@ -1392,6 +1384,7 @@ func TestControllerPublishedFunctionWrapperConcurrentMutation(t *testing.T) {
 					},
 				})
 				controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+				controller.ReconcileModuleMethods("mod")
 			},
 			mutate: func(controller *Controller) {
 				job := newTestRuntimeJob("mod", "job1", true)
@@ -1480,7 +1473,9 @@ func TestControllerPublishedFunctionGenerationInvalidatesStaleHandlers(t *testin
 				})
 				job := newTestRuntimeJob("mod", "job1", true)
 				controller.OnJobStart(job)
+				controller.ReconcileModuleMethods("mod")
 				controller.OnJobStop(job)
+				controller.ReconcileModuleMethods("mod")
 			},
 		},
 	}
@@ -1543,6 +1538,7 @@ func runRawControllerMethodCase(t *testing.T, tc rawControllerMethodCase, creato
 	}
 	controller.RegisterModules(collectorapi.Registry{"mod": creator})
 	controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+	controller.ReconcileModuleMethods("mod")
 
 	call := reg.handlers[callName]
 	require.NotNil(t, call)
@@ -1817,7 +1813,9 @@ func TestControllerSingleInstanceAgentScopeModuleMethodRequiresPublishedAvailabl
 			setup: func(controller *Controller) {
 				job := newTestRuntimeJob("mod", "mod", true)
 				controller.OnJobStart(job)
+				controller.ReconcileModuleMethods("mod")
 				controller.OnJobStop(job)
+				controller.ReconcileModuleMethods("mod")
 			},
 			message: "unknown function 'mod:status'",
 		},
@@ -2021,6 +2019,7 @@ func TestControllerRawInstanceFunctionRequiresRawHandler(t *testing.T) {
 		},
 	})
 	controller.OnJobStart(newTestRuntimeJob("mod", "job1", true))
+	controller.ReconcileModuleMethods("mod")
 
 	reg.handlers["mod:job1:logs"](functions.Function{
 		UID:     "missing-raw-handler",

--- a/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/controller_test.go
@@ -684,11 +684,11 @@ func TestControllerLifecycleHooks(t *testing.T) {
 
 			assert.ElementsMatch(t, []string{"snmp:topology:snmp", "topology:snmp"}, reg.unregisteredNames())
 		},
-		"job stop unregisters job methods": func(t *testing.T) {
+		"job stop unregisters instance functions": func(t *testing.T) {
 			controller, reg := newController()
 			controller.RegisterModules(collectorapi.Registry{
 				"mod": collectorapi.Creator{
-					JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+					InstanceFunctions: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig {
 						return []funcapi.FunctionConfig{{ID: "job-method"}}
 					},
 				},
@@ -1144,7 +1144,7 @@ func TestControllerStaticPublicationDoesNotHoldLockDuringFunctionGlobal(t *testi
 	}
 }
 
-func TestControllerRegisterJobMethods(t *testing.T) {
+func TestControllerRegisterInstanceFunctions(t *testing.T) {
 	tests := map[string]func(*testing.T){
 		"fail fast on collision with static method": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
@@ -1155,43 +1155,43 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 				},
 			})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "dup"}})
+			controller.registerInstanceFunctions(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "dup"}})
 
 			assert.Empty(t, reg.registeredNames())
-			assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
+			assert.Empty(t, controller.registry.getInstanceFunctions("mod", "job1"))
 		},
 		"fail fast on collision with other job": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
 			controller := New(Options{FnReg: reg})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
-			controller.registry.registerJobMethods("mod", "jobA", []funcapi.FunctionConfig{{ID: "dup"}})
+			controller.registry.registerInstanceFunctions("mod", "jobA", []funcapi.FunctionConfig{{ID: "dup"}})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "jobB", true), []funcapi.FunctionConfig{{ID: "dup"}})
+			controller.registerInstanceFunctions(newTestRuntimeJob("mod", "jobB", true), []funcapi.FunctionConfig{{ID: "dup"}})
 
 			assert.Empty(t, reg.registeredNames())
-			assert.Empty(t, controller.registry.getJobMethods("mod", "jobB"))
+			assert.Empty(t, controller.registry.getInstanceFunctions("mod", "jobB"))
 		},
 		"fail fast on duplicate within batch": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
 			controller := New(Options{FnReg: reg})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "dup"}, {ID: "dup"}})
+			controller.registerInstanceFunctions(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "dup"}, {ID: "dup"}})
 
 			assert.Empty(t, reg.registeredNames())
-			assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
+			assert.Empty(t, controller.registry.getInstanceFunctions("mod", "job1"))
 		},
-		"fail fast on job method public names": func(t *testing.T) {
+		"fail fast on instance function public names": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
 			controller := New(Options{FnReg: reg})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{
+			controller.registerInstanceFunctions(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{
 				{ID: "logs", FunctionName: "public:logs", Aliases: []string{"public:alias"}},
 			})
 
 			assert.Empty(t, reg.registeredNames())
-			assert.Empty(t, controller.registry.getJobMethods("mod", "job1"))
+			assert.Empty(t, controller.registry.getInstanceFunctions("mod", "job1"))
 		},
 		"registry is populated before handlers are callable": func(t *testing.T) {
 			var gotCode int
@@ -1213,22 +1213,22 @@ func TestControllerRegisterJobMethods(t *testing.T) {
 			})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "a", Help: "job method help"}})
+			controller.registerInstanceFunctions(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "a", Help: "instance function help"}})
 
 			assert.Equal(t, 200, gotCode)
 			assert.Equal(t, float64(200), gotResp["status"])
-			assert.Equal(t, "job method help", gotResp["help"])
-			assert.Len(t, controller.registry.getJobMethods("mod", "job1"), 1)
+			assert.Equal(t, "instance function help", gotResp["help"])
+			assert.Len(t, controller.registry.getInstanceFunctions("mod", "job1"), 1)
 		},
 		"success commits all methods": func(t *testing.T) {
 			reg := newTestFunctionRegistry()
 			controller := New(Options{FnReg: reg})
 			controller.registry.registerModule("mod", collectorapi.Creator{})
 
-			controller.registerJobMethods(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "a"}, {ID: "b"}})
+			controller.registerInstanceFunctions(newTestRuntimeJob("mod", "job1", true), []funcapi.FunctionConfig{{ID: "a"}, {ID: "b"}})
 
 			assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, reg.registeredNames())
-			assert.Len(t, controller.registry.getJobMethods("mod", "job1"), 2)
+			assert.Len(t, controller.registry.getInstanceFunctions("mod", "job1"), 2)
 		},
 	}
 
@@ -1269,7 +1269,7 @@ func TestControllerPublishedFunctionWrapperConcurrentMutation(t *testing.T) {
 			setup: func(controller *Controller) {
 				controller.RegisterModules(collectorapi.Registry{
 					"mod": collectorapi.Creator{
-						JobMethods: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+						InstanceFunctions: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
 							return []funcapi.FunctionConfig{{ID: "a"}}
 						},
 						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1352,11 +1352,11 @@ func TestControllerPublishedFunctionGenerationInvalidatesStaleHandlers(t *testin
 				controller.Cleanup()
 			},
 		},
-		"job method after job stop": {
+		"instance function after job stop": {
 			setup: func(controller *Controller) {
 				controller.RegisterModules(collectorapi.Registry{
 					"mod": collectorapi.Creator{
-						JobMethods: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+						InstanceFunctions: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
 							return []funcapi.FunctionConfig{{ID: "a"}}
 						},
 						MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
@@ -1801,7 +1801,7 @@ func TestControllerModuleMethodRequestContextCancellation(t *testing.T) {
 	assert.Equal(t, "Request cancelled.", gotResp["errorMessage"])
 }
 
-func TestControllerRawJobMethodRequest(t *testing.T) {
+func TestControllerRawInstanceFunctionRequest(t *testing.T) {
 	tests := map[string]rawControllerMethodCase{
 		"raw query response is passed through": {
 			fn: functions.Function{
@@ -1874,7 +1874,7 @@ func TestControllerRawJobMethodRequest(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			runRawControllerMethodCase(t, tc, collectorapi.Creator{
-				JobMethods: func(job collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+				InstanceFunctions: func(job collectorapi.RuntimeJob) []funcapi.FunctionConfig {
 					return []funcapi.FunctionConfig{{
 						ID:         job.Name() + ":logs",
 						RawRequest: true,
@@ -1885,7 +1885,7 @@ func TestControllerRawJobMethodRequest(t *testing.T) {
 	}
 }
 
-func TestControllerRawJobMethodRequiresRawHandler(t *testing.T) {
+func TestControllerRawInstanceFunctionRequiresRawHandler(t *testing.T) {
 	var gotCode int
 	var gotResp map[string]any
 	reg := newTestFunctionRegistry()
@@ -1898,7 +1898,7 @@ func TestControllerRawJobMethodRequiresRawHandler(t *testing.T) {
 	})
 	controller.RegisterModules(collectorapi.Registry{
 		"mod": collectorapi.Creator{
-			JobMethods: func(job collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+			InstanceFunctions: func(job collectorapi.RuntimeJob) []funcapi.FunctionConfig {
 				return []funcapi.FunctionConfig{{ID: job.Name() + ":logs", RawRequest: true}}
 			},
 			MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {

--- a/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
@@ -191,7 +191,7 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 		includeJobParam := c.methodRequiresJobParam(moduleName, kind)
 
 		if !includeJobParam {
-			job, jobName, jobGen, ok := c.resolveNoJobMethodJob(fn, moduleName, methodID, kind)
+			job, jobName, jobGen, ok := c.resolveMethodJobWithoutJobParam(fn, moduleName, methodID, kind)
 			if !ok {
 				return
 			}
@@ -274,7 +274,7 @@ func (c *Controller) makeMethodFuncHandler(moduleName, methodID string) function
 	}
 }
 
-func (c *Controller) resolveNoJobMethodJob(fn functions.Function, moduleName, methodID string, kind moduleFunctionKind) (collectorapi.RuntimeJob, string, uint64, bool) {
+func (c *Controller) resolveMethodJobWithoutJobParam(fn functions.Function, moduleName, methodID string, kind moduleFunctionKind) (collectorapi.RuntimeJob, string, uint64, bool) {
 	if kind == moduleFunctionAgent {
 		return nil, "", 0, true
 	}
@@ -559,8 +559,8 @@ func (c *Controller) methodRequiresJobParam(moduleName string, kind moduleFuncti
 	return creator.InstancePolicy != collectorapi.InstancePolicySingle
 }
 
-func (c *Controller) makePublishedJobMethodFuncHandler(functionName string, generation uint64, moduleName, jobName, methodID string) functions.Handler {
-	handler := c.makeJobMethodFuncHandler(moduleName, jobName, methodID)
+func (c *Controller) makePublishedInstanceFunctionHandler(functionName string, generation uint64, moduleName, jobName, methodID string) functions.Handler {
+	handler := c.makeInstanceFunctionHandler(moduleName, jobName, methodID)
 	return func(ctx context.Context, fn functions.Function) {
 		if !c.publishedFunctionGenerationMatches(functionName, generation) {
 			c.respondError(fn, 404, "unknown function '%s'", functionName)
@@ -570,16 +570,16 @@ func (c *Controller) makePublishedJobMethodFuncHandler(functionName string, gene
 	}
 }
 
-func (c *Controller) makeJobMethodFuncHandler(moduleName, jobName, methodID string) functions.Handler {
+func (c *Controller) makeInstanceFunctionHandler(moduleName, jobName, methodID string) functions.Handler {
 	return func(ctx context.Context, fn functions.Function) {
-		methodCfg, ok := c.registry.getJobMethod(moduleName, jobName, methodID)
+		methodCfg, ok := c.registry.getInstanceFunction(moduleName, jobName, methodID)
 		if !ok {
 			c.respondError(fn, 404, "unknown method '%s' for job '%s:%s'", methodID, moduleName, jobName)
 			return
 		}
 		info := slices.Contains(fn.Args, "info")
 		if info && !methodCfg.RawRequest {
-			c.handleJobMethodFuncInfo(moduleName, jobName, methodID, fn)
+			c.handleInstanceFunctionInfo(moduleName, jobName, methodID, fn)
 			return
 		}
 
@@ -605,17 +605,17 @@ func (c *Controller) makeJobMethodFuncHandler(moduleName, jobName, methodID stri
 			payload:    payload,
 			argValues:  argValues,
 			resolveParams: func(ctx context.Context, methodCfg *funcapi.FunctionConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
-				return c.resolveJobMethodParams(ctx, methodCfg, handler, methodID)
+				return c.resolveInstanceFunctionParams(ctx, methodCfg, handler, methodID)
 			},
 			respond: func(dataResp *funcapi.FunctionResponse, methodParams []funcapi.ParamConfig, updateEvery int) {
-				c.respondJobMethodWithParams(fn, dataResp, methodParams, updateEvery, methodCfg.ResponseType)
+				c.respondInstanceFunctionWithParams(fn, dataResp, methodParams, updateEvery, methodCfg.ResponseType)
 			},
 		})
 	}
 }
 
-func (c *Controller) handleJobMethodFuncInfo(moduleName, jobName, methodID string, fn functions.Function) {
-	methodCfg, ok := c.registry.getJobMethod(moduleName, jobName, methodID)
+func (c *Controller) handleInstanceFunctionInfo(moduleName, jobName, methodID string, fn functions.Function) {
+	methodCfg, ok := c.registry.getInstanceFunction(moduleName, jobName, methodID)
 	if !ok {
 		c.respondError(fn, 404, "unknown method '%s' for job '%s:%s'", methodID, moduleName, jobName)
 		return
@@ -636,8 +636,8 @@ func (c *Controller) handleJobMethodFuncInfo(moduleName, jobName, methodID strin
 		"type":            resolveResponseType("", methodCfg.ResponseType),
 		"has_history":     false,
 		"help":            help,
-		"accepted_params": buildJobMethodAcceptedParams(methodParams),
-		"required_params": buildJobMethodRequiredParams(methodParams),
+		"accepted_params": buildInstanceFunctionAcceptedParams(methodParams),
+		"required_params": buildInstanceFunctionRequiredParams(methodParams),
 	}
 
 	if presentation := methodCfg.Presentation(); presentation != nil {
@@ -647,7 +647,7 @@ func (c *Controller) handleJobMethodFuncInfo(moduleName, jobName, methodID strin
 	c.respondJSON(fn, resp)
 }
 
-func (c *Controller) resolveJobMethodParams(ctx context.Context, methodCfg *funcapi.FunctionConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
+func (c *Controller) resolveInstanceFunctionParams(ctx context.Context, methodCfg *funcapi.FunctionConfig, handler funcapi.MethodHandler, methodID string) ([]funcapi.ParamConfig, error) {
 	methodParams := methodCfg.RequiredParams
 
 	jobParams, err := handler.MethodParams(ctx, methodID)
@@ -660,7 +660,7 @@ func (c *Controller) resolveJobMethodParams(ctx context.Context, methodCfg *func
 
 	return funcapi.MergeParamConfigs(methodParams, jobParams), nil
 }
-func buildJobMethodAcceptedParams(methodParams []funcapi.ParamConfig) []string {
+func buildInstanceFunctionAcceptedParams(methodParams []funcapi.ParamConfig) []string {
 	accepted := make([]string, 0, len(methodParams))
 	for _, param := range methodParams {
 		if !slices.Contains(accepted, param.ID) {
@@ -670,7 +670,7 @@ func buildJobMethodAcceptedParams(methodParams []funcapi.ParamConfig) []string {
 	return accepted
 }
 
-func buildJobMethodRequiredParams(methodParams []funcapi.ParamConfig) []map[string]any {
+func buildInstanceFunctionRequiredParams(methodParams []funcapi.ParamConfig) []map[string]any {
 	required := make([]map[string]any, 0, len(methodParams))
 	for _, cfg := range methodParams {
 		required = append(required, cfg.RequiredParam())

--- a/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/dispatch.go
@@ -294,7 +294,7 @@ func (c *Controller) resolveMethodJobWithoutJobParam(fn functions.Function, modu
 		c.respondError(fn, 503, "module '%s' is not running", moduleName)
 		return nil, "", 0, false
 	}
-	if !sharedFunctionJobAvailable(job, methodID) {
+	if !jobBackedFunctionAvailable(job, methodID) {
 		c.respondError(fn, 404, "unknown function '%s:%s'", moduleName, methodID)
 		return nil, "", 0, false
 	}

--- a/src/go/plugin/agent/jobmgr/funcctl/publication.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/publication.go
@@ -2,10 +2,13 @@
 
 package funcctl
 
+import "sort"
+
 type publishedFunctionKind uint8
 
 const (
-	publishedFunctionModuleMethod publishedFunctionKind = iota + 1
+	publishedFunctionShared publishedFunctionKind = iota + 1
+	publishedFunctionAgent
 	publishedFunctionInstance
 )
 
@@ -16,9 +19,17 @@ type publishedFunctionOwner struct {
 	methodID   string
 }
 
-func moduleMethodOwner(moduleName, methodID string) publishedFunctionOwner {
+func sharedFunctionOwner(moduleName, methodID string) publishedFunctionOwner {
 	return publishedFunctionOwner{
-		kind:       publishedFunctionModuleMethod,
+		kind:       publishedFunctionShared,
+		moduleName: moduleName,
+		methodID:   methodID,
+	}
+}
+
+func agentFunctionOwner(moduleName, methodID string) publishedFunctionOwner {
+	return publishedFunctionOwner{
+		kind:       publishedFunctionAgent,
 		moduleName: moduleName,
 		methodID:   methodID,
 	}
@@ -41,11 +52,13 @@ type publishedFunctionRecord struct {
 type publishedFunctionStore struct {
 	nextGeneration uint64
 	byName         map[string]publishedFunctionRecord
+	byModule       map[string]map[string]struct{}
 }
 
 func newPublishedFunctionStore() *publishedFunctionStore {
 	return &publishedFunctionStore{
-		byName: make(map[string]publishedFunctionRecord),
+		byName:   make(map[string]publishedFunctionRecord),
+		byModule: make(map[string]map[string]struct{}),
 	}
 }
 
@@ -76,6 +89,10 @@ func (s *publishedFunctionStore) add(name string, owner publishedFunctionOwner) 
 		generation: s.nextGeneration,
 	}
 	s.byName[name] = record
+	if s.byModule[owner.moduleName] == nil {
+		s.byModule[owner.moduleName] = make(map[string]struct{})
+	}
+	s.byModule[owner.moduleName][name] = struct{}{}
 	return record, true
 }
 
@@ -84,24 +101,41 @@ func (s *publishedFunctionStore) generationMatches(name string, generation uint6
 	return ok && record.generation == generation
 }
 
-func (s *publishedFunctionStore) removeOwner(owner publishedFunctionOwner) []string {
+func (s *publishedFunctionStore) removeKinds(kinds ...publishedFunctionKind) []string {
+	allowed := make(map[publishedFunctionKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		allowed[kind] = struct{}{}
+	}
+
 	var names []string
 	for name, record := range s.byName {
-		if record.owner == owner {
+		if _, ok := allowed[record.owner.kind]; ok {
 			names = append(names, name)
-			delete(s.byName, name)
+			s.removeName(name)
 		}
 	}
+	sort.Strings(names)
 	return names
 }
 
-func (s *publishedFunctionStore) removeKind(kind publishedFunctionKind) []string {
-	var names []string
-	for name, record := range s.byName {
-		if record.owner.kind == kind {
-			names = append(names, name)
-			delete(s.byName, name)
+func (s *publishedFunctionStore) moduleRecords(moduleName string) map[string]publishedFunctionRecord {
+	records := make(map[string]publishedFunctionRecord)
+	for name := range s.byModule[moduleName] {
+		records[name] = s.byName[name]
+	}
+	return records
+}
+
+func (s *publishedFunctionStore) removeName(name string) {
+	record, ok := s.byName[name]
+	if !ok {
+		return
+	}
+	delete(s.byName, name)
+	if names := s.byModule[record.owner.moduleName]; names != nil {
+		delete(names, name)
+		if len(names) == 0 {
+			delete(s.byModule, record.owner.moduleName)
 		}
 	}
-	return names
 }

--- a/src/go/plugin/agent/jobmgr/funcctl/publication.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/publication.go
@@ -6,7 +6,7 @@ type publishedFunctionKind uint8
 
 const (
 	publishedFunctionModuleMethod publishedFunctionKind = iota + 1
-	publishedFunctionJobMethod
+	publishedFunctionInstance
 )
 
 type publishedFunctionOwner struct {
@@ -24,9 +24,9 @@ func moduleMethodOwner(moduleName, methodID string) publishedFunctionOwner {
 	}
 }
 
-func jobMethodOwner(moduleName, jobName, methodID string) publishedFunctionOwner {
+func instanceFunctionOwner(moduleName, jobName, methodID string) publishedFunctionOwner {
 	return publishedFunctionOwner{
-		kind:       publishedFunctionJobMethod,
+		kind:       publishedFunctionInstance,
 		moduleName: moduleName,
 		jobName:    jobName,
 		methodID:   methodID,

--- a/src/go/plugin/agent/jobmgr/funcctl/publication.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/publication.go
@@ -2,8 +2,6 @@
 
 package funcctl
 
-import "sort"
-
 type publishedFunctionKind uint8
 
 const (
@@ -114,7 +112,6 @@ func (s *publishedFunctionStore) removeKinds(kinds ...publishedFunctionKind) []s
 			s.removeName(name)
 		}
 	}
-	sort.Strings(names)
 	return names
 }
 

--- a/src/go/plugin/agent/jobmgr/funcctl/registry.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/registry.go
@@ -29,13 +29,13 @@ type methodRoute struct {
 }
 
 type moduleFunc struct {
-	creator        collectorapi.Creator
-	methods        []funcapi.FunctionConfig
-	methodsByID    map[string]funcapi.FunctionConfig
-	methodKinds    map[string]moduleFunctionKind
-	jobs           map[string]*jobEntry
-	nextGeneration uint64
-	jobMethods     map[string][]funcapi.FunctionConfig
+	creator           collectorapi.Creator
+	methods           []funcapi.FunctionConfig
+	methodsByID       map[string]funcapi.FunctionConfig
+	methodKinds       map[string]moduleFunctionKind
+	jobs              map[string]*jobEntry
+	nextGeneration    uint64
+	instanceFunctions map[string][]funcapi.FunctionConfig
 }
 
 type jobEntry struct {
@@ -77,12 +77,12 @@ func (r *moduleFuncRegistry) registerModuleWithDeclarations(name string, creator
 	collectModuleFunctionNames(name, functions.configs, affectedRoutes)
 
 	r.modules[name] = &moduleFunc{
-		creator:     creator,
-		methods:     functions.configs,
-		methodsByID: indexMethods(functions.configs),
-		methodKinds: functions.kinds,
-		jobs:        make(map[string]*jobEntry),
-		jobMethods:  make(map[string][]funcapi.FunctionConfig),
+		creator:           creator,
+		methods:           functions.configs,
+		methodsByID:       indexMethods(functions.configs),
+		methodKinds:       functions.kinds,
+		jobs:              make(map[string]*jobEntry),
+		instanceFunctions: make(map[string][]funcapi.FunctionConfig),
 	}
 	r.refreshModuleMethodRoutesLocked(affectedRoutes)
 }
@@ -323,7 +323,7 @@ func (r *moduleFuncRegistry) isModuleRegistered(moduleName string) bool {
 	return ok
 }
 
-func (r *moduleFuncRegistry) registerJobMethods(moduleName, jobName string, methods []funcapi.FunctionConfig) {
+func (r *moduleFuncRegistry) registerInstanceFunctions(moduleName, jobName string, methods []funcapi.FunctionConfig) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -331,10 +331,10 @@ func (r *moduleFuncRegistry) registerJobMethods(moduleName, jobName string, meth
 	if !ok {
 		return
 	}
-	module.jobMethods[jobName] = methods
+	module.instanceFunctions[jobName] = methods
 }
 
-func (r *moduleFuncRegistry) unregisterJobMethods(moduleName, jobName string) {
+func (r *moduleFuncRegistry) unregisterInstanceFunctions(moduleName, jobName string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -342,10 +342,10 @@ func (r *moduleFuncRegistry) unregisterJobMethods(moduleName, jobName string) {
 	if !ok {
 		return
 	}
-	delete(module.jobMethods, jobName)
+	delete(module.instanceFunctions, jobName)
 }
 
-func (r *moduleFuncRegistry) getJobMethods(moduleName, jobName string) []funcapi.FunctionConfig {
+func (r *moduleFuncRegistry) getInstanceFunctions(moduleName, jobName string) []funcapi.FunctionConfig {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -353,10 +353,10 @@ func (r *moduleFuncRegistry) getJobMethods(moduleName, jobName string) []funcapi
 	if !ok {
 		return nil
 	}
-	return module.jobMethods[jobName]
+	return module.instanceFunctions[jobName]
 }
 
-func (r *moduleFuncRegistry) getJobMethod(moduleName, jobName, methodID string) (*funcapi.FunctionConfig, bool) {
+func (r *moduleFuncRegistry) getInstanceFunction(moduleName, jobName, methodID string) (*funcapi.FunctionConfig, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -364,7 +364,7 @@ func (r *moduleFuncRegistry) getJobMethod(moduleName, jobName, methodID string) 
 	if !ok {
 		return nil, false
 	}
-	methods, ok := module.jobMethods[jobName]
+	methods, ok := module.instanceFunctions[jobName]
 	if !ok {
 		return nil, false
 	}
@@ -391,13 +391,13 @@ func (r *moduleFuncRegistry) findMethodCollision(moduleName, jobName, methodID s
 		}
 	}
 
-	for ownerJob, methods := range module.jobMethods {
+	for ownerJob, methods := range module.instanceFunctions {
 		if ownerJob == jobName {
 			continue
 		}
 		for _, method := range methods {
 			if method.ID == methodID {
-				return "job method on " + ownerJob, true
+				return "instance function on " + ownerJob, true
 			}
 		}
 	}

--- a/src/go/plugin/agent/jobmgr/funcctl/registry.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/registry.go
@@ -48,6 +48,12 @@ type jobSnapshot struct {
 	job  collectorapi.RuntimeJob
 }
 
+type instanceFunctionSnapshot struct {
+	jobName string
+	job     collectorapi.RuntimeJob
+	methods []funcapi.FunctionConfig
+}
+
 func newModuleFuncRegistry() *moduleFuncRegistry {
 	return &moduleFuncRegistry{
 		modules:      make(map[string]*moduleFunc),
@@ -354,6 +360,33 @@ func (r *moduleFuncRegistry) getInstanceFunctions(moduleName, jobName string) []
 		return nil
 	}
 	return module.instanceFunctions[jobName]
+}
+
+func (r *moduleFuncRegistry) getInstanceFunctionSnapshots(moduleName string) []instanceFunctionSnapshot {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	module, ok := r.modules[moduleName]
+	if !ok {
+		return nil
+	}
+
+	snapshots := make([]instanceFunctionSnapshot, 0, len(module.instanceFunctions))
+	for jobName, methods := range module.instanceFunctions {
+		entry, ok := module.jobs[jobName]
+		if !ok {
+			continue
+		}
+		snapshots = append(snapshots, instanceFunctionSnapshot{
+			jobName: jobName,
+			job:     entry.job,
+			methods: append([]funcapi.FunctionConfig(nil), methods...),
+		})
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].jobName < snapshots[j].jobName
+	})
+	return snapshots
 }
 
 func (r *moduleFuncRegistry) getInstanceFunction(moduleName, jobName, methodID string) (*funcapi.FunctionConfig, bool) {

--- a/src/go/plugin/agent/jobmgr/funcctl/response.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/response.go
@@ -29,15 +29,15 @@ func (c *Controller) respondWithParams(fn functions.Function, moduleName, method
 	)
 }
 
-func (c *Controller) respondJobMethodWithParams(fn functions.Function, dataResp *funcapi.FunctionResponse, methodParams []funcapi.ParamConfig, updateEvery int, methodType string) {
+func (c *Controller) respondInstanceFunctionWithParams(fn functions.Function, dataResp *funcapi.FunctionResponse, methodParams []funcapi.ParamConfig, updateEvery int, methodType string) {
 	c.respondMethodDataWithParams(
 		fn,
 		dataResp,
 		methodParams,
 		updateEvery,
 		methodType,
-		buildJobMethodAcceptedParams,
-		buildJobMethodRequiredParams,
+		buildInstanceFunctionAcceptedParams,
+		buildInstanceFunctionRequiredParams,
 	)
 }
 

--- a/src/go/plugin/agent/jobmgr/funcctl/response_test.go
+++ b/src/go/plugin/agent/jobmgr/funcctl/response_test.go
@@ -130,15 +130,15 @@ func TestHandleMethodFuncInfo_AgentScopeOmitsJobParam(t *testing.T) {
 	assert.Equal(t, "topology_view", req0["id"])
 }
 
-func TestHandleJobMethodFuncInfo_UsesResponseType(t *testing.T) {
+func TestHandleInstanceFunctionInfo_UsesResponseType(t *testing.T) {
 	controller, resp := newTestControllerWithCapture(t)
 
 	controller.registry.registerModule("netflow", collectorapi.Creator{})
-	controller.registry.registerJobMethods("netflow", "job1", []funcapi.FunctionConfig{
+	controller.registry.registerInstanceFunctions("netflow", "job1", []funcapi.FunctionConfig{
 		{ID: "flows:netflow", ResponseType: "flows"},
 	})
 
-	controller.handleJobMethodFuncInfo("netflow", "job1", "flows:netflow", functions.Function{})
+	controller.handleInstanceFunctionInfo("netflow", "job1", "flows:netflow", functions.Function{})
 
 	assert.Equal(t, "flows", (*resp)["type"])
 }

--- a/src/go/plugin/agent/jobmgr/funcdispatch_test.go
+++ b/src/go/plugin/agent/jobmgr/funcdispatch_test.go
@@ -579,18 +579,13 @@ func TestCleanup_UnregistersStaticFunctionsBeforeStoppingJobs(t *testing.T) {
 	mgr.startRunningJob(&lockProbeJob{fullName: "staticmod_job1", moduleName: "staticmod", name: "job1"})
 	mgr.funcCtl.ReconcileModuleMethods("staticmod")
 	mgr.startRunningJob(&lockProbeJob{fullName: "jobmod_job1", moduleName: "jobmod", name: "job1"})
+	mgr.funcCtl.ReconcileModuleMethods("jobmod")
 
 	mgr.cleanup()
 
 	unregistered := fnReg.unregisteredNames()
 	assert.Contains(t, unregistered, "staticmod:static-method")
 	assert.Contains(t, unregistered, "jobmod:job-method")
-	assert.Less(
-		t,
-		fnReg.unregisteredIndex("staticmod:static-method"),
-		fnReg.unregisteredIndex("jobmod:job-method"),
-		"static module cleanup must run before per-job stop cleanup",
-	)
 }
 
 type dispatchContextKey string
@@ -663,18 +658,6 @@ func (r *capturingFunctionRegistry) unregisteredNames() []string {
 	return out
 }
 
-func (r *capturingFunctionRegistry) unregisteredIndex(name string) int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	for i, got := range r.unregistered {
-		if got == name {
-			return i
-		}
-	}
-	return -1
-}
-
 func newModuleDispatchTestManager(
 	t *testing.T,
 	api *dyncfg.Responder,
@@ -730,6 +713,7 @@ func newInstanceFunctionDispatchTestManager(
 	mgr.modules = collectorapi.Registry{"mod": creator}
 	mgr.funcCtl.RegisterModules(mgr.modules)
 	mgr.startRunningJob(&lockProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"})
+	mgr.funcCtl.ReconcileModuleMethods("mod")
 
 	return mgr
 }

--- a/src/go/plugin/agent/jobmgr/funcdispatch_test.go
+++ b/src/go/plugin/agent/jobmgr/funcdispatch_test.go
@@ -362,7 +362,7 @@ func TestExecuteFunction_ContextBehavior(t *testing.T) {
 	}
 }
 
-func TestJobMethodRegisteredHandlerPaths(t *testing.T) {
+func TestInstanceFunctionRegisteredHandlerPaths(t *testing.T) {
 	tests := map[string]struct {
 		fnArgs          []string
 		wantRequiredLen int
@@ -382,7 +382,7 @@ func TestJobMethodRegisteredHandlerPaths(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			writer := &jsonWriteCapture{}
 			fnReg := newCapturingFunctionRegistry()
-			mgr := newJobMethodDispatchTestManager(t, fnReg, writer.write, &mockMethodHandler{
+			mgr := newInstanceFunctionDispatchTestManager(t, fnReg, writer.write, &mockMethodHandler{
 				handleFunc: func(ctx context.Context, method string, params funcapi.ResolvedParams) *funcapi.FunctionResponse {
 					return &funcapi.FunctionResponse{
 						Status: 200,
@@ -565,7 +565,7 @@ func TestCleanup_UnregistersStaticFunctionsBeforeStoppingJobs(t *testing.T) {
 		},
 	}
 	jobCreator := collectorapi.Creator{
-		JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+		InstanceFunctions: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig {
 			return []funcapi.FunctionConfig{{ID: "job-method"}}
 		},
 	}
@@ -706,7 +706,7 @@ func newModuleDispatchTestManager(
 	return mgr
 }
 
-func newJobMethodDispatchTestManager(
+func newInstanceFunctionDispatchTestManager(
 	t *testing.T,
 	fnReg FunctionRegistry,
 	jsonWriter func([]byte, int),
@@ -722,7 +722,7 @@ func newJobMethodDispatchTestManager(
 	})
 
 	creator := collectorapi.Creator{
-		JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return methods },
+		InstanceFunctions: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return methods },
 		MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
 			return methodHandler
 		},

--- a/src/go/plugin/agent/jobmgr/job_factory.go
+++ b/src/go/plugin/agent/jobmgr/job_factory.go
@@ -96,7 +96,7 @@ func (f *jobFactory) create(cfg confgroup.Config) (runtimeJob, error) {
 	}
 
 	functionOnly := creator.FunctionOnly || cfg.FunctionOnly()
-	if cfg.FunctionOnly() && creator.SharedFunctions == nil && creator.AgentFunctions == nil && creator.JobMethods == nil {
+	if cfg.FunctionOnly() && creator.SharedFunctions == nil && creator.AgentFunctions == nil && creator.InstanceFunctions == nil {
 		return nil, fmt.Errorf("function_only is set but %s module has no functions defined", cfg.Module())
 	}
 

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -276,6 +276,8 @@ func (m *Manager) Run(ctx context.Context, in chan []*confgroup.Group) {
 
 	wg.Go(func() { m.runNotifyRunningJobs() })
 
+	wg.Go(func() { m.runFunctionReconciler() })
+
 	close(m.started)
 
 	wg.Wait()
@@ -343,8 +345,6 @@ func (m *Manager) run() {
 				m.removeConfig(cfg)
 			case fn := <-m.dyncfgCh:
 				m.dyncfgSeqExec(fn)
-			case moduleName := <-m.funcReconCh:
-				m.funcCtl.ReconcileModuleMethods(moduleName)
 			}
 		}
 	}
@@ -397,8 +397,6 @@ func (m *Manager) runWaitDecisionStep() bool {
 			return false
 		case fn := <-m.dyncfgCh:
 			m.dyncfgSeqExec(fn)
-		case moduleName := <-m.funcReconCh:
-			m.funcCtl.ReconcileModuleMethods(moduleName)
 		}
 		return true
 	}
@@ -418,12 +416,21 @@ func (m *Manager) runWaitDecisionStep() bool {
 		return false
 	case fn := <-m.dyncfgCh:
 		m.dyncfgSeqExec(fn)
-	case moduleName := <-m.funcReconCh:
-		m.funcCtl.ReconcileModuleMethods(moduleName)
 	case <-timer.C:
 		m.collectorHandler.ExpireWaitDecision()
 	}
 	return true
+}
+
+func (m *Manager) runFunctionReconciler() {
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case moduleName := <-m.funcReconCh:
+			m.funcCtl.ReconcileModuleMethods(moduleName)
+		}
+	}
 }
 
 func (m *Manager) removeConfig(cfg confgroup.Config) {
@@ -491,6 +498,7 @@ func (m *Manager) startRunningJob(job runtimeJob) {
 	m.secretStoreDeps.setRunning(job.FullName(), true)
 
 	m.funcCtl.OnJobStart(job)
+	m.requestFunctionReconcile(job.ModuleName())
 }
 
 func (m *Manager) stopRunningJob(name string) {

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -55,7 +55,6 @@ const (
 	cmdTestWorkerCap       = 4
 	cmdTestDefaultTimeout  = 60 * time.Second
 	cmdTestWorkerDrainWait = 5 * time.Second
-	funcReconcileQueueSize = 64
 )
 
 func New(cfg Config) *Manager {
@@ -115,12 +114,13 @@ func New(cfg Config) *Manager {
 		runningJobs:       newRunningJobsCache(),
 		retryingTasks:     newRetryingTasksCache(),
 
-		started:     make(chan struct{}),
-		addCh:       make(chan confgroup.Config),
-		rmCh:        make(chan confgroup.Config),
-		dyncfgCh:    make(chan dyncfg.Function, 32),
-		funcReconCh: make(chan string, funcReconcileQueueSize),
-		cmdTestSem:  make(chan struct{}, cmdTestWorkerCap),
+		started:          make(chan struct{}),
+		addCh:            make(chan confgroup.Config),
+		rmCh:             make(chan confgroup.Config),
+		dyncfgCh:         make(chan dyncfg.Function, 32),
+		funcReconPending: make(map[string]struct{}),
+		funcReconWake:    make(chan struct{}, 1),
+		cmdTestSem:       make(chan struct{}, cmdTestWorkerCap),
 
 		dyncfgResponder: api,
 		runtimeService:  cfg.RuntimeService,
@@ -219,14 +219,16 @@ type Manager struct {
 	vnodesCtl          *vnodectl.Controller
 
 	// Runtime loop state.
-	ctx         context.Context
-	started     chan struct{}
-	addCh       chan confgroup.Config
-	rmCh        chan confgroup.Config
-	dyncfgCh    chan dyncfg.Function
-	funcReconCh chan string
-	cmdTestSem  chan struct{}
-	cmdTestWG   sync.WaitGroup
+	ctx              context.Context
+	started          chan struct{}
+	addCh            chan confgroup.Config
+	rmCh             chan confgroup.Config
+	dyncfgCh         chan dyncfg.Function
+	funcReconMu      sync.Mutex
+	funcReconPending map[string]struct{}
+	funcReconWake    chan struct{}
+	cmdTestSem       chan struct{}
+	cmdTestWG        sync.WaitGroup
 
 	// Shared service seams.
 	dyncfgResponder *dyncfg.Responder
@@ -427,8 +429,16 @@ func (m *Manager) runFunctionReconciler() {
 		select {
 		case <-m.ctx.Done():
 			return
-		case moduleName := <-m.funcReconCh:
-			m.funcCtl.ReconcileModuleMethods(moduleName)
+		case <-m.funcReconWake:
+			for {
+				modules := m.takePendingFunctionReconcileModules()
+				if len(modules) == 0 {
+					break
+				}
+				for _, moduleName := range modules {
+					m.funcCtl.ReconcileModuleMethods(moduleName)
+				}
+			}
 		}
 	}
 }
@@ -481,10 +491,36 @@ func (m *Manager) requestFunctionReconcile(moduleName string) {
 	}
 	select {
 	case <-ctx.Done():
-	case m.funcReconCh <- moduleName:
+		return
 	default:
-		// The next running-job tick will retry. Keep the tick path non-blocking.
 	}
+
+	m.funcReconMu.Lock()
+	m.funcReconPending[moduleName] = struct{}{}
+	m.funcReconMu.Unlock()
+
+	select {
+	case <-ctx.Done():
+	case m.funcReconWake <- struct{}{}:
+	default:
+		// A wake is already pending. The module remains queued in funcReconPending.
+	}
+}
+
+func (m *Manager) takePendingFunctionReconcileModules() []string {
+	m.funcReconMu.Lock()
+	defer m.funcReconMu.Unlock()
+
+	if len(m.funcReconPending) == 0 {
+		return nil
+	}
+	modules := make([]string, 0, len(m.funcReconPending))
+	for moduleName := range m.funcReconPending {
+		modules = append(modules, moduleName)
+	}
+	clear(m.funcReconPending)
+	slices.Sort(modules)
+	return modules
 }
 
 func (m *Manager) startRunningJob(job runtimeJob) {
@@ -511,6 +547,7 @@ func (m *Manager) stopRunningJob(name string) {
 	if ok {
 		m.secretStoreDeps.setRunning(name, false)
 		m.funcCtl.OnJobStop(job)
+		m.requestFunctionReconcile(job.ModuleName())
 		job.Stop()
 	}
 }

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -128,8 +128,8 @@ func TestRunNotifyRunningJobs_TickOutsideLock(t *testing.T) {
 func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T) {
 	reg := &recordingFunctionRegistry{}
 	var out bytes.Buffer
-	available := false
-	availability := managerFunctionAvailability{fn: func(string) bool { return available }}
+	var available atomic.Bool
+	availability := managerFunctionAvailability{fn: func(string) bool { return available.Load() }}
 	mgr := New(Config{
 		PluginName: testPluginName,
 		Out:        &out,
@@ -148,10 +148,10 @@ func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T)
 	mgr.ctx = ctx
 	mgr.funcCtl.Init(ctx)
 	mgr.funcCtl.RegisterModules(mgr.modules)
-	runDone := make(chan struct{})
+	reconcileDone := make(chan struct{})
 	go func() {
-		mgr.run()
-		close(runDone)
+		mgr.runFunctionReconciler()
+		close(reconcileDone)
 	}()
 
 	job := &tickProbeJob{
@@ -166,7 +166,7 @@ func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T)
 	mgr.runningJobs.add(job.FullName(), job)
 	mgr.runningJobs.unlock()
 
-	available = true
+	available.Store(true)
 	done := make(chan struct{})
 	go func() {
 		mgr.runNotifyRunningJobs()
@@ -179,9 +179,9 @@ func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T)
 
 	cancel()
 	select {
-	case <-runDone:
+	case <-reconcileDone:
 	case <-time.After(2 * time.Second):
-		t.Fatal("run did not stop")
+		t.Fatal("runFunctionReconciler did not stop")
 	}
 	assert.NotContains(t, out.String(), "FUNCTION_DEL")
 	select {
@@ -193,13 +193,13 @@ func TestRunNotifyRunningJobs_ReconcilesLateAvailableModuleMethods(t *testing.T)
 
 func TestRunNotifyRunningJobs_DeduplicatesFunctionReconcileByModule(t *testing.T) {
 	reg := &recordingFunctionRegistry{}
-	available := false
 	var availableCalls atomic.Int32
+	var available atomic.Bool
 	availability := managerFunctionAvailability{fn: func(string) bool {
-		if available {
+		if available.Load() {
 			availableCalls.Add(1)
 		}
-		return available
+		return available.Load()
 	}}
 	mgr := New(Config{
 		PluginName: testPluginName,
@@ -218,10 +218,10 @@ func TestRunNotifyRunningJobs_DeduplicatesFunctionReconcileByModule(t *testing.T
 	mgr.ctx = ctx
 	mgr.funcCtl.Init(ctx)
 	mgr.funcCtl.RegisterModules(mgr.modules)
-	runDone := make(chan struct{})
+	reconcileDone := make(chan struct{})
 	go func() {
-		mgr.run()
-		close(runDone)
+		mgr.runFunctionReconciler()
+		close(reconcileDone)
 	}()
 
 	job1 := &tickProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1", collector: availability}
@@ -234,7 +234,7 @@ func TestRunNotifyRunningJobs_DeduplicatesFunctionReconcileByModule(t *testing.T
 	mgr.runningJobs.unlock()
 
 	availableCalls.Store(0)
-	available = true
+	available.Store(true)
 	notifyDone := make(chan struct{})
 	go func() {
 		mgr.runNotifyRunningJobs()
@@ -248,9 +248,9 @@ func TestRunNotifyRunningJobs_DeduplicatesFunctionReconcileByModule(t *testing.T
 
 	cancel()
 	select {
-	case <-runDone:
+	case <-reconcileDone:
 	case <-time.After(2 * time.Second):
-		t.Fatal("run did not stop")
+		t.Fatal("runFunctionReconciler did not stop")
 	}
 	select {
 	case <-notifyDone:
@@ -261,8 +261,8 @@ func TestRunNotifyRunningJobs_DeduplicatesFunctionReconcileByModule(t *testing.T
 
 func TestRunNotifyRunningJobs_DoesNotPublishDirectly(t *testing.T) {
 	reg := &recordingFunctionRegistry{}
-	available := false
-	availability := managerFunctionAvailability{fn: func(string) bool { return available }}
+	var available atomic.Bool
+	availability := managerFunctionAvailability{fn: func(string) bool { return available.Load() }}
 	mgr := New(Config{
 		PluginName: testPluginName,
 		FnReg:      reg,
@@ -305,7 +305,7 @@ func TestRunNotifyRunningJobs_DoesNotPublishDirectly(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("tick did not start")
 	}
-	available = true
+	available.Store(true)
 	close(job.tickRelease)
 
 	time.Sleep(50 * time.Millisecond)
@@ -321,8 +321,8 @@ func TestRunNotifyRunningJobs_DoesNotPublishDirectly(t *testing.T) {
 
 func TestRequestFunctionReconcile_DroppedRequestCanBeRetried(t *testing.T) {
 	reg := &recordingFunctionRegistry{}
-	available := false
-	availability := managerFunctionAvailability{fn: func(string) bool { return available }}
+	var available atomic.Bool
+	availability := managerFunctionAvailability{fn: func(string) bool { return available.Load() }}
 	mgr := New(Config{
 		PluginName: testPluginName,
 		FnReg:      reg,
@@ -345,7 +345,7 @@ func TestRequestFunctionReconcile_DroppedRequestCanBeRetried(t *testing.T) {
 	for i := 0; i < cap(mgr.funcReconCh); i++ {
 		mgr.funcReconCh <- "other"
 	}
-	available = true
+	available.Store(true)
 
 	requestDone := make(chan struct{})
 	go func() {
@@ -366,7 +366,7 @@ func TestRequestFunctionReconcile_DroppedRequestCanBeRetried(t *testing.T) {
 
 	runDone := make(chan struct{})
 	go func() {
-		mgr.run()
+		mgr.runFunctionReconciler()
 		close(runDone)
 	}()
 	mgr.requestFunctionReconcile("mod")
@@ -379,7 +379,7 @@ func TestRequestFunctionReconcile_DroppedRequestCanBeRetried(t *testing.T) {
 	select {
 	case <-runDone:
 	case <-time.After(2 * time.Second):
-		t.Fatal("run did not stop")
+		t.Fatal("runFunctionReconciler did not stop")
 	}
 }
 
@@ -387,38 +387,6 @@ func TestRunWaitDecisionStep(t *testing.T) {
 	tests := map[string]struct {
 		run func(t *testing.T)
 	}{
-		"drains function reconcile while waiting": {
-			run: func(t *testing.T) {
-				reg := &recordingFunctionRegistry{}
-				available := false
-				availability := managerFunctionAvailability{fn: func(string) bool { return available }}
-				mgr := New(Config{
-					PluginName: testPluginName,
-					FnReg:      reg,
-					Modules: collectorapi.Registry{
-						"mod": collectorapi.Creator{
-							SharedFunctions: func() []funcapi.FunctionConfig {
-								return []funcapi.FunctionConfig{{ID: "late"}}
-							},
-						},
-					},
-				})
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				mgr.ctx = ctx
-				mgr.funcCtl.Init(ctx)
-				mgr.funcCtl.RegisterModules(mgr.modules)
-				job := &tickProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1", collector: availability}
-				mgr.funcCtl.OnJobStart(job)
-				available = true
-
-				mgr.collectorHandler.WaitForDecision(prepareUserCfg("other", "job"))
-				mgr.funcReconCh <- "mod"
-
-				require.True(t, mgr.runWaitDecisionStep())
-				assert.Equal(t, []string{"mod:late"}, reg.registeredNames())
-			},
-		},
 		"executes dyncfg command while waiting": {
 			run: func(t *testing.T) {
 				var out bytes.Buffer
@@ -468,6 +436,78 @@ func TestRunWaitDecisionStep(t *testing.T) {
 	}
 }
 
+func TestRunFunctionReconciler_DoesNotBlockManagerControlLoop(t *testing.T) {
+	reg := &recordingFunctionRegistry{}
+	var out simOutput
+	availabilityStarted := make(chan struct{})
+	availabilityRelease := make(chan struct{})
+	availability := managerFunctionAvailability{fn: func(string) bool {
+		close(availabilityStarted)
+		<-availabilityRelease
+		return true
+	}}
+	mgr := New(Config{
+		PluginName: testPluginName,
+		Out:        &out,
+		FnReg:      reg,
+		Modules: collectorapi.Registry{
+			"mod": collectorapi.Creator{
+				SharedFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{ID: "late"}}
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.ctx = ctx
+	mgr.funcCtl.Init(ctx)
+	mgr.funcCtl.RegisterModules(mgr.modules)
+	mgr.funcCtl.OnJobStart(&tickProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1", collector: availability})
+
+	reconcileDone := make(chan struct{})
+	go func() {
+		mgr.runFunctionReconciler()
+		close(reconcileDone)
+	}()
+	mgr.requestFunctionReconcile("mod")
+
+	select {
+	case <-availabilityStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("function availability check did not start")
+	}
+
+	runDone := make(chan struct{})
+	go func() {
+		mgr.run()
+		close(runDone)
+	}()
+	mgr.dyncfgCh <- dyncfg.NewFunction(functions.Function{
+		UID:  "unknown",
+		Name: "config",
+		Args: []string{"unknown", string(dyncfg.CommandSchema)},
+	})
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(out.String(), "unknown function")
+	}, 2*time.Second, 10*time.Millisecond)
+
+	close(availabilityRelease)
+	cancel()
+	select {
+	case <-reconcileDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runFunctionReconciler did not stop")
+	}
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not stop")
+	}
+}
+
 func TestFunctionReconcileFunnelConcurrentLifecycle(t *testing.T) {
 	reg := &recordingFunctionRegistry{}
 	var available atomic.Bool
@@ -490,10 +530,10 @@ func TestFunctionReconcileFunnelConcurrentLifecycle(t *testing.T) {
 	mgr.funcCtl.Init(ctx)
 	mgr.funcCtl.RegisterModules(mgr.modules)
 
-	runDone := make(chan struct{})
+	reconcileDone := make(chan struct{})
 	go func() {
-		mgr.run()
-		close(runDone)
+		mgr.runFunctionReconciler()
+		close(reconcileDone)
 	}()
 	notifyDone := make(chan struct{})
 	go func() {
@@ -527,9 +567,9 @@ func TestFunctionReconcileFunnelConcurrentLifecycle(t *testing.T) {
 
 	cancel()
 	select {
-	case <-runDone:
+	case <-reconcileDone:
 	case <-time.After(2 * time.Second):
-		t.Fatal("run did not stop")
+		t.Fatal("runFunctionReconciler did not stop")
 	}
 	select {
 	case <-notifyDone:

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -321,8 +321,7 @@ func TestRunNotifyRunningJobs_DoesNotPublishDirectly(t *testing.T) {
 
 func TestRequestFunctionReconcile_CoalescesPendingModules(t *testing.T) {
 	mgr := New(Config{PluginName: testPluginName})
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	mgr.ctx = ctx
 
 	mgr.requestFunctionReconcile("bbb")

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -319,68 +319,47 @@ func TestRunNotifyRunningJobs_DoesNotPublishDirectly(t *testing.T) {
 	}
 }
 
-func TestRequestFunctionReconcile_DroppedRequestCanBeRetried(t *testing.T) {
-	reg := &recordingFunctionRegistry{}
-	var available atomic.Bool
-	availability := managerFunctionAvailability{fn: func(string) bool { return available.Load() }}
-	mgr := New(Config{
-		PluginName: testPluginName,
-		FnReg:      reg,
-		Modules: collectorapi.Registry{
-			"mod": collectorapi.Creator{
-				SharedFunctions: func() []funcapi.FunctionConfig {
-					return []funcapi.FunctionConfig{{ID: "late"}}
-				},
-			},
-		},
-	})
-
+func TestRequestFunctionReconcile_CoalescesPendingModules(t *testing.T) {
+	mgr := New(Config{PluginName: testPluginName})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	mgr.ctx = ctx
-	mgr.funcCtl.Init(ctx)
-	mgr.funcCtl.RegisterModules(mgr.modules)
-	mgr.funcCtl.OnJobStart(&tickProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1", collector: availability})
 
-	for i := 0; i < cap(mgr.funcReconCh); i++ {
-		mgr.funcReconCh <- "other"
+	mgr.requestFunctionReconcile("bbb")
+	mgr.requestFunctionReconcile("aaa")
+	mgr.requestFunctionReconcile("aaa")
+
+	select {
+	case <-mgr.funcReconWake:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("requestFunctionReconcile did not wake reconciler")
 	}
-	available.Store(true)
+
+	assert.Equal(t, []string{"aaa", "bbb"}, mgr.takePendingFunctionReconcileModules())
+	assert.Empty(t, mgr.takePendingFunctionReconcileModules())
+
+	mgr.requestFunctionReconcile("mod")
+	select {
+	case <-mgr.funcReconWake:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("requestFunctionReconcile did not wake reconciler")
+	}
 
 	requestDone := make(chan struct{})
 	go func() {
-		mgr.requestFunctionReconcile("mod")
+		for range 100 {
+			mgr.requestFunctionReconcile("mod")
+		}
 		close(requestDone)
 	}()
 
 	select {
 	case <-requestDone:
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("requestFunctionReconcile blocked on a full queue")
-	}
-	assert.Empty(t, reg.registeredNames())
-
-	for len(mgr.funcReconCh) > 0 {
-		<-mgr.funcReconCh
+		t.Fatal("requestFunctionReconcile blocked while wake was pending")
 	}
 
-	runDone := make(chan struct{})
-	go func() {
-		mgr.runFunctionReconciler()
-		close(runDone)
-	}()
-	mgr.requestFunctionReconcile("mod")
-
-	require.Eventually(t, func() bool {
-		return slices.Contains(reg.registeredNames(), "mod:late")
-	}, 2*time.Second, 10*time.Millisecond)
-
-	cancel()
-	select {
-	case <-runDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("runFunctionReconciler did not stop")
-	}
+	assert.Equal(t, []string{"mod"}, mgr.takePendingFunctionReconcileModules())
 }
 
 func TestRunWaitDecisionStep(t *testing.T) {
@@ -575,6 +554,73 @@ func TestFunctionReconcileFunnelConcurrentLifecycle(t *testing.T) {
 	case <-notifyDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("runNotifyRunningJobs did not stop")
+	}
+}
+
+func TestFunctionReconcileFunnelWithdrawsStoppedInstanceAfterInFlightPublish(t *testing.T) {
+	reg := &recordingFunctionRegistry{}
+	availabilityEntered := make(chan struct{})
+	releaseAvailability := make(chan struct{})
+	var enterOnce sync.Once
+	availability := managerFunctionAvailability{fn: func(string) bool {
+		enterOnce.Do(func() { close(availabilityEntered) })
+		<-releaseAvailability
+		return true
+	}}
+	mgr := New(Config{
+		PluginName: testPluginName,
+		FnReg:      reg,
+		Modules: collectorapi.Registry{
+			"mod": collectorapi.Creator{
+				InstanceFunctions: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{ID: "details"}}
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.ctx = ctx
+	mgr.funcCtl.Init(ctx)
+	mgr.funcCtl.RegisterModules(mgr.modules)
+
+	reconcileDone := make(chan struct{})
+	go func() {
+		mgr.runFunctionReconciler()
+		close(reconcileDone)
+	}()
+
+	job := &tickProbeJob{
+		fullName:   "mod_job1",
+		moduleName: "mod",
+		name:       "job1",
+		collector:  availability,
+	}
+	mgr.startRunningJob(job)
+	mgr.requestFunctionReconcile("mod")
+
+	select {
+	case <-availabilityEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconcile did not check instance Function availability")
+	}
+
+	mgr.stopRunningJob(job.FullName())
+	close(releaseAvailability)
+
+	require.Eventually(t, func() bool {
+		return slices.Contains(reg.registeredNames(), "mod:details")
+	}, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return slices.Contains(reg.unregisteredNames(), "mod:details")
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case <-reconcileDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runFunctionReconciler did not stop")
 	}
 }
 
@@ -974,9 +1020,10 @@ func (a managerFunctionAvailability) FunctionAvailable(functionID string) bool {
 }
 
 type recordingFunctionRegistry struct {
-	mu         sync.Mutex
-	registered []string
-	prefixes   []registeredPrefix
+	mu           sync.Mutex
+	registered   []string
+	unregistered []string
+	prefixes     []registeredPrefix
 }
 
 func (r *recordingFunctionRegistry) Register(name string, _ func(functions.Function)) {
@@ -985,7 +1032,11 @@ func (r *recordingFunctionRegistry) Register(name string, _ func(functions.Funct
 	r.mu.Unlock()
 }
 
-func (r *recordingFunctionRegistry) Unregister(string) {}
+func (r *recordingFunctionRegistry) Unregister(name string) {
+	r.mu.Lock()
+	r.unregistered = append(r.unregistered, name)
+	r.mu.Unlock()
+}
 func (r *recordingFunctionRegistry) RegisterPrefix(name, prefix string, _ func(functions.Function)) {
 	r.mu.Lock()
 	r.prefixes = append(r.prefixes, registeredPrefix{name: name, prefix: prefix})
@@ -998,6 +1049,14 @@ func (r *recordingFunctionRegistry) registeredNames() []string {
 	defer r.mu.Unlock()
 	out := make([]string, len(r.registered))
 	copy(out, r.registered)
+	return out
+}
+
+func (r *recordingFunctionRegistry) unregisteredNames() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.unregistered))
+	copy(out, r.unregistered)
 	return out
 }
 

--- a/src/go/plugin/agent/jobmgr/manager_v2_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_v2_test.go
@@ -84,22 +84,22 @@ func TestManagerCreateCollectorJobV2Branching(t *testing.T) {
 			},
 			wantV2: true,
 		},
-		"prefer v2 when job methods are configured": {
+		"prefer v2 when instance functions are configured": {
 			creator: collectorapi.Creator{
 				Create: func() collectorapi.CollectorV1 { return &testV1Module{} },
 				CreateV2: func() collectorapi.CollectorV2 {
 					return &testV2Module{store: metrix.NewCollectorStore()}
 				},
-				JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
+				InstanceFunctions: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
 			},
 			wantV2: true,
 		},
-		"allow v2 only creator when job methods are configured": {
+		"allow v2 only creator when instance functions are configured": {
 			creator: collectorapi.Creator{
 				CreateV2: func() collectorapi.CollectorV2 {
 					return &testV2Module{store: metrix.NewCollectorStore()}
 				},
-				JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
+				InstanceFunctions: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
 			},
 			wantV2: true,
 		},
@@ -108,7 +108,7 @@ func TestManagerCreateCollectorJobV2Branching(t *testing.T) {
 				CreateV2: func() collectorapi.CollectorV2 {
 					return &testV2Module{store: nil}
 				},
-				JobMethods: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
+				InstanceFunctions: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
 			},
 			functionOnly: true,
 			wantV2:       true,
@@ -145,9 +145,9 @@ func TestManagerCreateCollectorJobSingleInstancePolicyAllowsV2FunctionOnly(t *te
 	mgr := New(Config{PluginName: testPluginName})
 	mgr.modules = collectorapi.Registry{
 		"testmod": {
-			InstancePolicy: collectorapi.InstancePolicySingle,
-			CreateV2:       func() collectorapi.CollectorV2 { return mod },
-			JobMethods:     func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
+			InstancePolicy:    collectorapi.InstancePolicySingle,
+			CreateV2:          func() collectorapi.CollectorV2 { return mod },
+			InstanceFunctions: func(_ collectorapi.RuntimeJob) []funcapi.FunctionConfig { return nil },
 		},
 	}
 

--- a/src/go/plugin/agent/jobmgr/sim_test.go
+++ b/src/go/plugin/agent/jobmgr/sim_test.go
@@ -136,7 +136,7 @@ func (s *runSim) run(t *testing.T) {
 			skipNextEmpty = false
 			continue
 		}
-		if strings.HasPrefix(s, "FUNCTION GLOBAL") {
+		if strings.HasPrefix(s, "FUNCTION GLOBAL") || strings.HasPrefix(s, "FUNCTION_DEL") {
 			skipNextEmpty = true
 			continue
 		}

--- a/src/go/plugin/framework/collectorapi/registry.go
+++ b/src/go/plugin/framework/collectorapi/registry.go
@@ -83,11 +83,12 @@ type (
 		// When nil, methods are disabled for this module.
 		MethodHandler func(job RuntimeJob) funcapi.MethodHandler
 
-		// Optional: JobMethods returns Function declarations to register when a job starts.
-		// Each Function is registered as "moduleName:methodID" and unregistered when the job stops.
-		// This enables per-job function registration instead of static module-level functions.
-		// If nil, no per-job methods are registered.
-		JobMethods func(job RuntimeJob) []funcapi.FunctionConfig
+		// Optional: InstanceFunctions returns Function declarations to register when a job starts.
+		// Each returned Function ID is published as "moduleName:functionID" and unregistered
+		// when the owning job stops.
+		// This enables instance Function registration instead of static module-level Functions.
+		// If nil, no instance Functions are registered.
+		InstanceFunctions func(job RuntimeJob) []funcapi.FunctionConfig
 
 		// FunctionOnly indicates this module provides only functions, no metrics.
 		// Jobs created from this module skip data collection and chart creation.
@@ -114,14 +115,14 @@ func (r Registry) Register(name string, creator Creator) {
 	if !creator.InstancePolicy.valid() {
 		panic(fmt.Sprintf("%s has invalid InstancePolicy %d", name, creator.InstancePolicy))
 	}
-	if (creator.SharedFunctions != nil || creator.AgentFunctions != nil) && creator.JobMethods != nil {
-		panic(fmt.Sprintf("%s has both static Functions and JobMethods defined (mutually exclusive)", name))
+	if (creator.SharedFunctions != nil || creator.AgentFunctions != nil) && creator.InstanceFunctions != nil {
+		panic(fmt.Sprintf("%s has both static Functions and InstanceFunctions defined (mutually exclusive)", name))
 	}
 	if id, ok := duplicateStaticFunctionID(creator); ok {
 		panic(fmt.Sprintf("%s has duplicate static Function ID %q", name, id))
 	}
-	if creator.FunctionOnly && creator.SharedFunctions == nil && creator.AgentFunctions == nil && creator.JobMethods == nil {
-		panic(fmt.Sprintf("%s is FunctionOnly but has no Functions or JobMethods defined", name))
+	if creator.FunctionOnly && creator.SharedFunctions == nil && creator.AgentFunctions == nil && creator.InstanceFunctions == nil {
+		panic(fmt.Sprintf("%s is FunctionOnly but has no Functions or InstanceFunctions defined", name))
 	}
 	r[name] = creator
 }

--- a/src/go/plugin/framework/collectorapi/registry.go
+++ b/src/go/plugin/framework/collectorapi/registry.go
@@ -83,11 +83,10 @@ type (
 		// When nil, methods are disabled for this module.
 		MethodHandler func(job RuntimeJob) funcapi.MethodHandler
 
-		// Optional: InstanceFunctions returns Function declarations to register when a job starts.
-		// Each returned Function ID is published as "moduleName:functionID" and unregistered
-		// when the owning job stops.
-		// This enables instance Function registration instead of static module-level Functions.
-		// If nil, no instance Functions are registered.
+		// Optional: InstanceFunctions returns Function declarations owned by one
+		// runtime job. Each returned Function ID is published as "moduleName:functionID"
+		// while the owning job is running and available. If nil, no instance Functions
+		// are declared.
 		InstanceFunctions func(job RuntimeJob) []funcapi.FunctionConfig
 
 		// FunctionOnly indicates this module provides only functions, no metrics.

--- a/src/go/plugin/framework/collectorapi/registry.go
+++ b/src/go/plugin/framework/collectorapi/registry.go
@@ -86,7 +86,8 @@ type (
 		// Optional: InstanceFunctions returns Function declarations owned by one
 		// runtime job. Each returned Function ID is published as "moduleName:functionID"
 		// while the owning job is running and available. If nil, no instance Functions
-		// are declared.
+		// are declared. A collector can implement FunctionAvailability to gate
+		// publication for each returned Function ID.
 		InstanceFunctions func(job RuntimeJob) []funcapi.FunctionConfig
 
 		// FunctionOnly indicates this module provides only functions, no metrics.

--- a/src/go/plugin/framework/collectorapi/registry_test.go
+++ b/src/go/plugin/framework/collectorapi/registry_test.go
@@ -45,18 +45,18 @@ func TestRegister_FunctionOnlyWithoutFunctions(t *testing.T) {
 		})
 }
 
-func TestRegisterPanicOnStaticFunctionsAndJobMethodsConflict(t *testing.T) {
+func TestRegisterPanicOnStaticFunctionsAndInstanceFunctionsConflict(t *testing.T) {
 	tests := map[string]struct {
 		name    string
 		creator Creator
 	}{
-		"panic when both static functions and job methods are set": {
+		"panic when both static functions and instance functions are set": {
 			name: "conflict",
 			creator: Creator{
 				SharedFunctions: func() []funcapi.FunctionConfig {
 					return nil
 				},
-				JobMethods: func(RuntimeJob) []funcapi.FunctionConfig {
+				InstanceFunctions: func(RuntimeJob) []funcapi.FunctionConfig {
 					return nil
 				},
 			},
@@ -69,7 +69,7 @@ func TestRegisterPanicOnStaticFunctionsAndJobMethodsConflict(t *testing.T) {
 
 			assert.PanicsWithValue(
 				t,
-				"conflict has both static Functions and JobMethods defined (mutually exclusive)",
+				"conflict has both static Functions and InstanceFunctions defined (mutually exclusive)",
 				func() { registry.Register(tc.name, tc.creator) },
 			)
 		})

--- a/src/go/plugin/go.d/collector/sql/collector.go
+++ b/src/go/plugin/go.d/collector/sql/collector.go
@@ -21,11 +21,11 @@ var configSchema string
 
 func init() {
 	collectorapi.Register("sql", collectorapi.Creator{
-		Create:          func() collectorapi.CollectorV1 { return New() },
-		JobConfigSchema: configSchema,
-		Config:          func() any { return &Config{} },
-		JobMethods:      sqlJobMethods,
-		MethodHandler:   sqlMethodHandler,
+		Create:            func() collectorapi.CollectorV1 { return New() },
+		JobConfigSchema:   configSchema,
+		Config:            func() any { return &Config{} },
+		InstanceFunctions: sqlInstanceFunctions,
+		MethodHandler:     sqlMethodHandler,
 	})
 }
 

--- a/src/go/plugin/go.d/collector/sql/func_table.go
+++ b/src/go/plugin/go.d/collector/sql/func_table.go
@@ -23,10 +23,10 @@ func newFuncTable(c *Collector) *funcTable {
 
 var _ funcapi.MethodHandler = (*funcTable)(nil)
 
-// sqlJobMethods returns method configs for a specific SQL job.
-// Each configured function becomes a separate method: "jobName:functionID"
-// This results in functions like "sql:postgres_test:active-queries"
-func sqlJobMethods(job collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+// sqlInstanceFunctions returns Function configs for a specific SQL job.
+// Each configured query becomes "jobName:functionID", producing names like
+// "sql:postgres_test:active-queries" after framework publication.
+func sqlInstanceFunctions(job collectorapi.RuntimeJob) []funcapi.FunctionConfig {
 	c, ok := job.Collector().(*Collector)
 	if !ok || len(c.Config.Functions) == 0 {
 		return nil

--- a/src/go/plugin/go.d/collector/sql/func_table_test.go
+++ b/src/go/plugin/go.d/collector/sql/func_table_test.go
@@ -181,7 +181,7 @@ func TestFuncTable_FindFunction(t *testing.T) {
 	assert.Nil(t, f)
 }
 
-func TestSqlJobMethods(t *testing.T) {
+func TestSqlInstanceFunctions(t *testing.T) {
 	tests := map[string]struct {
 		setupCollector func() *Collector
 		jobName        string
@@ -237,7 +237,7 @@ func TestSqlJobMethods(t *testing.T) {
 				Module:     c,
 				Out:        io.Discard,
 			})
-			methods := sqlJobMethods(job)
+			methods := sqlInstanceFunctions(job)
 
 			assert.Len(t, methods, tc.wantLen)
 			for i, wantID := range tc.wantMethodIDs {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles shared and instance function publication declaratively and renames the per‑job API to `InstanceFunctions`. A dedicated, out‑of‑band reconciler now computes desired publication and keeps the manager loop non‑blocking by coalescing per‑module requests.

- **New Features**
  - Instance functions (via `collectorapi.Creator.InstanceFunctions`) are stored on job start and published/withdrawn by reconcile based on `collectorapi.FunctionAvailability`; if not implemented, they publish while the job runs.
  - Reconcile computes the desired set across shared and instance functions, publishes missing ones, and withdraws stale ones (including after job stop or owner change). Stale handlers return 404 via generation checks; withdraw after job stop is asynchronous.
  - A separate reconciler goroutine dedupes by module and runs out of band; it’s triggered on job start/stop and by the running‑job tick. Docs clarify lifecycle and availability semantics.

- **Migration**
  - Replace `JobMethods` with `InstanceFunctions(job)` in `collectorapi.Creator`; public names remain `module:functionID`. The SQL collector is updated accordingly.
  - Do not set `FunctionName` or `Aliases` on instance functions; only `ID` is allowed.
  - `collectorapi.FunctionAvailability` now gates both shared and instance functions; if you don’t implement it, instance functions publish during reconcile while the job runs.

<sup>Written for commit aec8612da139153496e2aab4fc0532453f2fa9a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

