### PR TITLE
[codex] fix windows events row rendering crashes

### DIFF
--- a/src/collectors/windows-events.plugin/windows-events-providers.c
+++ b/src/collectors/windows-events.plugin/windows-events-providers.c
@@ -114,11 +114,19 @@ static bool provider_property_get(PROVIDER_META_HANDLE *h, WEVT_VARIANT *content
         }
     }
 
+    if (!bufferUsed)
+        goto cleanup;
+
     wevt_variant_resize(content, bufferUsed);
     if (!EvtGetPublisherMetadataProperty(h->hMetadata, property_id, 0, content->size, content->data, &bufferUsed)) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "EvtGetPublisherMetadataProperty() failed after resize");
         goto cleanup;
     }
+
+    content->used = bufferUsed;
+    wevt_variant_count_from_used(content);
+    if(!content->data || !content->count)
+        goto cleanup;
 
     return true;
 
@@ -130,10 +138,11 @@ static bool provider_string_property_exists(PROVIDER_META_HANDLE *h, WEVT_VARIAN
     if(!provider_property_get(h, content, property_id))
         return false;
 
-    if(content->data->Type != EvtVarTypeString)
+    LPCWSTR value = wevt_field_get_string(content->data);
+    if(!value)
         return false;
 
-    if(!content->data->StringVal[0])
+    if(!value[0])
         return false;
 
     return true;
@@ -155,7 +164,7 @@ static void provider_detect_platform(PROVIDER_META_HANDLE *h, WEVT_VARIANT *cont
 }
 
 WEVT_PROVIDER_PLATFORM provider_get_platform(PROVIDER_META_HANDLE *p) {
-    return p->provider->platform;
+    return (p && p->provider) ? p->provider->platform : WEVT_PLATFORM_UNKNOWN;
 }
 
 PROVIDER_META_HANDLE *provider_get(ND_UUID uuid, LPCWSTR providerName) {
@@ -250,7 +259,15 @@ EVT_HANDLE provider_handle(PROVIDER_META_HANDLE *h) {
 }
 
 PROVIDER_META_HANDLE *provider_dup(PROVIDER_META_HANDLE *h) {
-    if(h) h->locks++;
+    if(!h)
+        return NULL;
+
+    spinlock_lock(&pbc.spinlock);
+    fatal_assert(h->owner == gettid_cached());
+    fatal_assert(h->locks > 0);
+    h->locks++;
+    spinlock_unlock(&pbc.spinlock);
+
     return h;
 }
 
@@ -299,13 +316,14 @@ void providers_release_unused_handles(void) {
 
 void provider_release(PROVIDER_META_HANDLE *h) {
     if(!h) return;
+
     pid_t me = gettid_cached();
+    spinlock_lock(&pbc.spinlock);
     fatal_assert(h->owner == me);
     fatal_assert(h->locks > 0);
     if(--h->locks == 0) {
         PROVIDER *p = h->provider;
 
-        spinlock_lock(&pbc.spinlock);
         h->owner = 0;
 
         if(++p->available_handles > MAX_OPEN_HANDLES_PER_PROVIDER) {
@@ -318,8 +336,9 @@ void provider_release(PROVIDER_META_HANDLE *h) {
             DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(p->handles, h, prev, next);
         }
 
-        spinlock_unlock(&pbc.spinlock);
     }
+
+    spinlock_unlock(&pbc.spinlock);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -335,6 +354,9 @@ static bool wevt_get_property_from_array(WEVT_VARIANT *property, EVT_HANDLE hand
             return false;
         }
 
+        if (!used)
+            return false;
+
         wevt_variant_resize(property, used);
         if (!EvtGetObjectArrayProperty(handle, PropertyId, dwIndex, 0, property->size, property->data, &used)) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "EvtGetObjectArrayProperty() failed");
@@ -343,6 +365,10 @@ static bool wevt_get_property_from_array(WEVT_VARIANT *property, EVT_HANDLE hand
     }
 
     property->used = used;
+    wevt_variant_count_from_used(property);
+    if(!property->data || !property->count)
+        return false;
+
     return true;
 }
 
@@ -426,7 +452,10 @@ static void provider_load_list(PROVIDER_META_HANDLE *h, WEVT_VARIANT *content, W
         goto cleanup;
 
     // Get the number of items (e.g., levels, tasks, or opcodes)
-    hArray = content->data->EvtHandleVal;
+    hArray = wevt_field_get_evt_handle(content->data);
+    if(!hArray)
+        goto cleanup;
+
     if (!EvtGetObjectArraySize(hArray, &itemCount)) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "EvtGetObjectArraySize() failed");
         goto cleanup;
@@ -440,71 +469,90 @@ static void provider_load_list(PROVIDER_META_HANDLE *h, WEVT_VARIANT *content, W
 
     // Allocate memory for the list items
     l->array = callocz(itemCount, sizeof(struct provider_data));
-    l->total = itemCount;
+    l->total = 0;
 
     uint64_t min = UINT64_MAX, max = 0, mask = 0;
 
     // Iterate over the list and populate the entries
     for (DWORD i = 0; i < itemCount; ++i) {
-        struct provider_data *d = &l->array[i];
+        struct provider_data tmp = { 0 };
 
         // Get the value (e.g., opcode, task, or level)
+        bool has_value = false;
         if (wevt_get_property_from_array(property, hArray, i, value_id)) {
             switch(value_bits) {
-                case 64:
-                    d->value = wevt_field_get_uint64(property->data);
+                case 64: {
+                    has_value = wevt_field_get_uint64_checked(property->data, &tmp.value);
                     break;
+                }
 
-                case 32:
-                    d->value = wevt_field_get_uint32(property->data);
+                case 32: {
+                    uint32_t value = 0;
+                    has_value = wevt_field_get_uint32_checked(property->data, &value);
+                    tmp.value = value;
                     break;
+                }
             }
 
-            if(d->value < min)
-                min = d->value;
+            if(tmp.value < min)
+                min = tmp.value;
 
-            if(d->value > max)
-                max = d->value;
+            if(tmp.value > max)
+                max = tmp.value;
 
-            mask |= d->value;
+            mask |= tmp.value;
 
-            if(!is_valid(d->value, false))
+            if(!is_valid(tmp.value, false))
                 l->exceeds_data_type = true;
         }
 
+        if(!has_value)
+            continue;
+
         // Get the message ID
         if (wevt_get_property_from_array(property, hArray, i, message_id)) {
-            uint32_t messageID = wevt_field_get_uint32(property->data);
+            uint32_t messageID = 0;
 
-            if (messageID != (uint32_t)-1) {
+            if (wevt_field_get_uint32_checked(property->data, &messageID) && messageID != (uint32_t)-1) {
                 if (EvtFormatMessage_utf16(dst, hMetadata, NULL, messageID, EvtFormatMessageId)) {
                     size_t len;
-                    d->name = utf16_to_utf8_strdupz(dst->data, &len);
-                    d->len = len;
+                    tmp.name = utf16_to_utf8_strdupz(dst->data, &len);
+                    tmp.len = len;
                 }
             }
         }
 
         // Get the name if the message is missing
-        if (!d->name && wevt_get_property_from_array(property, hArray, i, name_id)) {
-            fatal_assert(property->data->Type == EvtVarTypeString);
+        if (!tmp.name && wevt_get_property_from_array(property, hArray, i, name_id)) {
+            LPCWSTR name = wevt_field_get_string(property->data);
+            if(!name)
+                continue;
+
             size_t len;
-            d->name = utf16_to_utf8_strdupz(property->data->StringVal, &len);
-            d->len = len;
+            tmp.name = utf16_to_utf8_strdupz(name, &len);
+            tmp.len = len;
         }
 
         // Calculate the hash for the name
-        if (d->name)
-            d->hash = XXH3_64bits(d->name, d->len);
+        if (tmp.name)
+            tmp.hash = XXH3_64bits(tmp.name, tmp.len);
+
+        l->array[l->total++] = tmp;
+    }
+
+    if(!l->total) {
+        freez(l->array);
+        l->array = NULL;
+        min = max = mask = 0;
     }
 
     l->min = min;
     l->max = max;
     l->mask = mask;
 
-    if(itemCount > 1 && compare_func != NULL) {
+    if(l->total > 1 && compare_func != NULL) {
         // Sort the array based on the value (ascending for all except keywords, descending for keywords)
-        qsort(l->array, itemCount, sizeof(struct provider_data), compare_func);
+        qsort(l->array, l->total, sizeof(struct provider_data), compare_func);
     }
 
 cleanup:

--- a/src/collectors/windows-events.plugin/windows-events-query-evt-variant.c
+++ b/src/collectors/windows-events.plugin/windows-events-query-evt-variant.c
@@ -39,18 +39,50 @@ static inline void append_utf16(BUFFER *b, LPCWSTR utf16Str, const char *separat
     }
 }
 
+static inline void append_ansi(BUFFER *b, LPCSTR ansiStr, const char *separator) {
+    if (!ansiStr || !*ansiStr) return;
+
+    wchar_t wide_stack[1024];
+    for(size_t ansi_len = 0; ansi_len < _countof(wide_stack); ansi_len++) {
+        if(!ansiStr[ansi_len]) {
+            if(any_to_utf16(CP_ACP, wide_stack, _countof(wide_stack), ansiStr, (int)ansi_len, NULL))
+                append_utf16(b, wide_stack, separator);
+
+            return;
+        }
+    }
+
+    size_t wide_len = any_to_utf16(CP_ACP, NULL, 0, ansiStr, -1, NULL);
+    if (!wide_len || wide_len > SIZE_MAX / sizeof(wchar_t))
+        return;
+
+    wchar_t *wide = mallocz(wide_len * sizeof(wchar_t));
+    wide_len = any_to_utf16(CP_ACP, wide, wide_len, ansiStr, -1, NULL);
+    if (wide_len)
+        append_utf16(b, wide, separator);
+
+    freez(wide);
+}
+
 // Function to append binary data to the buffer
 static inline void append_binary(BUFFER *b, PBYTE data, DWORD size, const char *separator) {
     if (data == NULL || size == 0) return;
 
+#if SIZE_MAX <= UINT32_MAX
+    if ((size_t)size > (SIZE_MAX - 1) / 2) return;
+#endif
+    size_t needed = (size_t)size * 2 + 1;
+
     append_separator_if_needed(b, separator);
 
-    buffer_need_bytes(b, size * 4);
+    buffer_need_bytes(b, needed);
     for (DWORD i = 0; i < size; i++) {
         uint8_t value = data[i];
         b->buffer[b->len++] = hex_digits[(value & 0xf0) >> 4];
         b->buffer[b->len++] = hex_digits[(value & 0x0f)];
     }
+
+    b->buffer[b->len] = '\0';
 }
 
 // Function to append size_t to the buffer
@@ -89,6 +121,7 @@ static inline void append_double(BUFFER *b, double n, const char *separator) {
 
 static inline void append_guid(BUFFER *b, GUID *guid, const char *separator) {
     fatal_assert(sizeof(GUID) == sizeof(nd_uuid_t));
+    if (!guid) return;
 
     append_separator_if_needed(b, separator);
 
@@ -102,18 +135,33 @@ static inline void append_guid(BUFFER *b, GUID *guid, const char *separator) {
 }
 
 static inline void append_systime(BUFFER *b, SYSTEMTIME *st, const char *separator) {
+    if (!st) return;
+
     append_separator_if_needed(b, separator);
     buffer_sprintf(b, "%04d-%02d-%02d %02d:%02d:%02d",
                    st->wYear, st->wMonth, st->wDay, st->wHour, st->wMinute, st->wSecond);
 }
 
 static inline void append_filetime(BUFFER *b, FILETIME *ft, const char *separator) {
+    if (!ft) return;
+
     SYSTEMTIME st;
     if (FileTimeToSystemTime(ft, &st))
         append_systime(b, &st, separator);
 }
 
+static inline void append_filetime_value(BUFFER *b, ULONGLONG ft, const char *separator) {
+    FILETIME filetime = {
+        .dwLowDateTime = (DWORD)ft,
+        .dwHighDateTime = (DWORD)(ft >> 32),
+    };
+
+    append_filetime(b, &filetime, separator);
+}
+
 static inline void append_sid(BUFFER *b, PSID sid, const char *separator) {
+    if (!sid) return;
+
     cached_sid_to_buffer_append(sid, b, separator);
 }
 
@@ -159,19 +207,92 @@ static inline void append_evt_xml(BUFFER *b, LPCWSTR xmlData, const char *separa
 }
 
 void evt_variant_to_buffer(BUFFER *b, EVT_VARIANT *ev, const char *separator) {
-    if(ev->Type == EvtVarTypeNull) return;
+    if(!ev)
+        return;
+
+    DWORD type = ev->Type & EVT_VARIANT_TYPE_MASK;
+
+    if(type == EvtVarTypeNull) return;
 
     if (ev->Type & EVT_VARIANT_TYPE_ARRAY) {
+        if(!ev->Count)
+            return;
+
+        switch (type) {
+            case EvtVarTypeString:
+                if(!ev->StringArr) return;
+                break;
+            case EvtVarTypeAnsiString:
+                if(!ev->AnsiStringArr) return;
+                break;
+            case EvtVarTypeSByte:
+                if(!ev->SByteArr) return;
+                break;
+            case EvtVarTypeByte:
+                if(!ev->ByteArr) return;
+                break;
+            case EvtVarTypeInt16:
+                if(!ev->Int16Arr) return;
+                break;
+            case EvtVarTypeUInt16:
+                if(!ev->UInt16Arr) return;
+                break;
+            case EvtVarTypeInt32:
+                if(!ev->Int32Arr) return;
+                break;
+            case EvtVarTypeUInt32:
+            case EvtVarTypeHexInt32:
+                if(!ev->UInt32Arr) return;
+                break;
+            case EvtVarTypeInt64:
+                if(!ev->Int64Arr) return;
+                break;
+            case EvtVarTypeUInt64:
+            case EvtVarTypeHexInt64:
+                if(!ev->UInt64Arr) return;
+                break;
+            case EvtVarTypeSingle:
+                if(!ev->SingleArr) return;
+                break;
+            case EvtVarTypeDouble:
+                if(!ev->DoubleArr) return;
+                break;
+            case EvtVarTypeBoolean:
+                if(!ev->BooleanArr) return;
+                break;
+            case EvtVarTypeGuid:
+                if(!ev->GuidArr) return;
+                break;
+            case EvtVarTypeFileTime:
+                if(!ev->FileTimeArr) return;
+                break;
+            case EvtVarTypeSysTime:
+                if(!ev->SysTimeArr) return;
+                break;
+            case EvtVarTypeSid:
+                if(!ev->SidArr) return;
+                break;
+            case EvtVarTypeSizeT:
+                if(!ev->SizeTArr) return;
+                break;
+            case EvtVarTypeEvtXml:
+                if(!ev->XmlValArr) return;
+                break;
+            case EvtVarTypeBinary:
+            case EvtVarTypeEvtHandle:
+                return;
+            default:
+                return;
+        }
+
         for (DWORD i = 0; i < ev->Count; i++) {
-            switch (ev->Type & EVT_VARIANT_TYPE_MASK) {
+            switch (type) {
                 case EvtVarTypeString:
                     append_utf16(b, ev->StringArr[i], separator);
                     break;
 
                 case EvtVarTypeAnsiString:
-                    if (ev->AnsiStringArr[i] != NULL) {
-                        append_utf16(b, (LPCWSTR)ev->AnsiStringArr[i], separator);
-                    }
+                    append_ansi(b, ev->AnsiStringArr[i], separator);
                     break;
 
                 case EvtVarTypeSByte:
@@ -214,6 +335,11 @@ void evt_variant_to_buffer(BUFFER *b, EVT_VARIANT *ev, const char *separator) {
                     append_double(b, ev->DoubleArr[i], separator);
                     break;
 
+                case EvtVarTypeBoolean:
+                    append_separator_if_needed(b, separator);
+                    buffer_strcat(b, ev->BooleanArr[i] ? "true" : "false");
+                    break;
+
                 case EvtVarTypeGuid:
                     append_guid(b, &ev->GuidArr[i], separator);
                     break;
@@ -231,7 +357,6 @@ void evt_variant_to_buffer(BUFFER *b, EVT_VARIANT *ev, const char *separator) {
                     break;
 
                 case EvtVarTypeBinary:
-                    append_binary(b, ev->BinaryVal, ev->Count, separator);
                     break;
 
                 case EvtVarTypeSizeT:
@@ -247,7 +372,6 @@ void evt_variant_to_buffer(BUFFER *b, EVT_VARIANT *ev, const char *separator) {
                     break;
 
                 case EvtVarTypeEvtHandle:
-                    append_evt_handle(b, ev->EvtHandleVal, separator);
                     break;
 
                 case EvtVarTypeEvtXml:
@@ -260,7 +384,7 @@ void evt_variant_to_buffer(BUFFER *b, EVT_VARIANT *ev, const char *separator) {
             }
         }
     } else {
-        switch (ev->Type & EVT_VARIANT_TYPE_MASK) {
+        switch (type) {
             case EvtVarTypeNull:
                 // Do nothing for null types
                 break;
@@ -270,7 +394,7 @@ void evt_variant_to_buffer(BUFFER *b, EVT_VARIANT *ev, const char *separator) {
                 break;
 
             case EvtVarTypeAnsiString:
-                append_utf16(b, (LPCWSTR)ev->AnsiStringVal, separator);
+                append_ansi(b, ev->AnsiStringVal, separator);
                 break;
 
             case EvtVarTypeSByte:
@@ -320,6 +444,18 @@ void evt_variant_to_buffer(BUFFER *b, EVT_VARIANT *ev, const char *separator) {
 
             case EvtVarTypeGuid:
                 append_guid(b, ev->GuidVal, separator);
+                break;
+
+            case EvtVarTypeFileTime:
+                append_filetime_value(b, ev->FileTimeVal, separator);
+                break;
+
+            case EvtVarTypeSysTime:
+                append_systime(b, ev->SysTimeVal, separator);
+                break;
+
+            case EvtVarTypeSid:
+                append_sid(b, ev->SidVal, separator);
                 break;
 
             case EvtVarTypeBinary:

--- a/src/collectors/windows-events.plugin/windows-events-query.c
+++ b/src/collectors/windows-events.plugin/windows-events-query.c
@@ -51,12 +51,18 @@ bool EvtFormatMessage_utf16(
         }
 
         // Try again with the resized buffer
+        if(!size)
+            goto cleanup;
+
         txt_utf16_resize(dst, size, false);
         if (!EvtFormatMessage(hMetadata, hEvent, dwMessageId, 0, NULL, flags, dst->size, dst->data, &size)) {
             // nd_log(NDLS_COLLECTORS, NDLP_ERR, "EvtFormatMessage() failed after resizing buffer.");
             goto cleanup;
         }
     }
+
+    if(!size || !dst->size)
+        goto cleanup;
 
     // make sure it is null terminated
     if(size <= dst->size)
@@ -333,6 +339,9 @@ static inline bool wEvtRender(WEVT_LOG *log, EVT_HANDLE context, WEVT_VARIANT *r
             return false;
         }
 
+        if (!bytes_used)
+            return false;
+
         wevt_variant_resize(raw, bytes_used);
         if (!EvtRender(context, log->hEvent, EvtRenderEventValues, raw->size, raw->data, &bytes_used, &property_count)) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR,
@@ -341,6 +350,17 @@ static inline bool wEvtRender(WEVT_LOG *log, EVT_HANDLE context, WEVT_VARIANT *r
             return false;
         }
     }
+
+    if (property_count) {
+#if SIZE_MAX <= UINT32_MAX
+        if ((size_t)property_count > SIZE_MAX / sizeof(*raw->data))
+            return false;
+#endif
+
+        if (!raw->data || bytes_used < property_count * sizeof(*raw->data))
+            return false;
+    }
+
     raw->used = bytes_used;
     raw->count = property_count;
 
@@ -354,6 +374,13 @@ static bool wevt_get_next_event_one(WEVT_LOG *log, WEVT_EVENT *ev) {
         goto cleanup;
 
     EVT_VARIANT *content = log->ops.raw.system.data;
+    if(!content || log->ops.raw.system.count < EvtSystemPropertyIdEND) {
+        nd_log_limit_static_thread_var(system_fields_log_limit, 60, 0);
+        nd_log_limit(&system_fields_log_limit, NDLS_COLLECTORS, NDLP_ERR,
+                     "EvtRender() returned %u system fields, expected at least %u",
+                     log->ops.raw.system.count, EvtSystemPropertyIdEND);
+        goto cleanup;
+    }
 
     ev->id          = wevt_field_get_uint64(&content[EvtSystemEventRecordId]);
     ev->event_id    = wevt_field_get_uint16(&content[EvtSystemEventID]);
@@ -377,7 +404,7 @@ static bool wevt_get_next_event_one(WEVT_LOG *log, WEVT_EVENT *ev) {
         wevt_field_get_sid(&content[EvtSystemUserID], &log->ops.account, &log->ops.domain, &log->ops.sid);
 
         PROVIDER_META_HANDLE *p = log->provider =
-                provider_get(ev->provider, content[EvtSystemProviderName].StringVal);
+                provider_get(ev->provider, wevt_field_get_string(&content[EvtSystemProviderName]));
 
         ev->platform = provider_get_platform(p);
 

--- a/src/collectors/windows-events.plugin/windows-events-query.h
+++ b/src/collectors/windows-events.plugin/windows-events-query.h
@@ -146,14 +146,19 @@ void evt_variant_to_buffer(BUFFER *b, EVT_VARIANT *ev, const char *separator);
 
 static inline void wevt_variant_cleanup(WEVT_VARIANT *v) {
     freez(v->data);
+    v->data = NULL;
+    v->size = 0;
+    v->used = 0;
+    v->count = 0;
 }
 
 static inline void wevt_variant_resize(WEVT_VARIANT *v, size_t required_size) {
-    if(required_size < v->size)
+    if(required_size <= v->size)
         return;
 
+    size_t old_size = v->size;
     wevt_variant_cleanup(v);
-    v->size = txt_compute_new_size(v->size, required_size);
+    v->size = txt_compute_new_size(old_size, required_size);
     v->data = mallocz(v->size);
 }
 
@@ -161,74 +166,132 @@ static inline void wevt_variant_count_from_used(WEVT_VARIANT *v) {
     v->count = v->used / sizeof(*v->data);
 }
 
-static inline uint8_t wevt_field_get_uint8(EVT_VARIANT *ev) {
-    if((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeNull)
-        return 0;
+static inline EVT_VARIANT_TYPE wevt_field_type(EVT_VARIANT *ev) {
+    return ev ? (EVT_VARIANT_TYPE)(ev->Type & EVT_VARIANT_TYPE_MASK) : EvtVarTypeNull;
+}
 
-    fatal_assert((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeByte);
-    return ev->ByteVal;
+static inline bool wevt_field_is_array(EVT_VARIANT *ev) {
+    return ev && (ev->Type & EVT_VARIANT_TYPE_ARRAY);
+}
+
+static inline bool wevt_field_get_uint8_checked(EVT_VARIANT *ev, uint8_t *dst) {
+    if(dst) *dst = 0;
+    if(wevt_field_is_array(ev) || wevt_field_type(ev) != EvtVarTypeByte)
+        return false;
+
+    if(dst) *dst = ev->ByteVal;
+    return true;
+}
+
+static inline uint8_t wevt_field_get_uint8(EVT_VARIANT *ev) {
+    uint8_t value = 0;
+    wevt_field_get_uint8_checked(ev, &value);
+    return value;
+}
+
+static inline bool wevt_field_get_bool_checked(EVT_VARIANT *ev, bool *dst) {
+    if(dst) *dst = false;
+    if(wevt_field_is_array(ev) || wevt_field_type(ev) != EvtVarTypeBoolean)
+        return false;
+
+    if(dst) *dst = ev->BooleanVal;
+    return true;
+}
+
+static inline bool wevt_field_get_uint16_checked(EVT_VARIANT *ev, uint16_t *dst) {
+    if(dst) *dst = 0;
+    if(wevt_field_is_array(ev) || wevt_field_type(ev) != EvtVarTypeUInt16)
+        return false;
+
+    if(dst) *dst = ev->UInt16Val;
+    return true;
 }
 
 static inline uint16_t wevt_field_get_uint16(EVT_VARIANT *ev) {
-    if((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeNull)
-        return 0;
+    uint16_t value = 0;
+    wevt_field_get_uint16_checked(ev, &value);
+    return value;
+}
 
-    fatal_assert((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeUInt16);
-    return ev->UInt16Val;
+static inline bool wevt_field_get_uint32_checked(EVT_VARIANT *ev, uint32_t *dst) {
+    if(dst) *dst = 0;
+    if(wevt_field_is_array(ev) || wevt_field_type(ev) != EvtVarTypeUInt32)
+        return false;
+
+    if(dst) *dst = ev->UInt32Val;
+    return true;
 }
 
 static inline uint32_t wevt_field_get_uint32(EVT_VARIANT *ev) {
-    if((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeNull)
-        return 0;
+    uint32_t value = 0;
+    wevt_field_get_uint32_checked(ev, &value);
+    return value;
+}
 
-    fatal_assert((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeUInt32);
-    return ev->UInt32Val;
+static inline bool wevt_field_get_uint64_checked(EVT_VARIANT *ev, uint64_t *dst) {
+    if(dst) *dst = 0;
+    if(wevt_field_is_array(ev) || wevt_field_type(ev) != EvtVarTypeUInt64)
+        return false;
+
+    if(dst) *dst = ev->UInt64Val;
+    return true;
 }
 
 static inline uint64_t wevt_field_get_uint64(EVT_VARIANT *ev) {
-    if((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeNull)
-        return 0;
+    uint64_t value = 0;
+    wevt_field_get_uint64_checked(ev, &value);
+    return value;
+}
 
-    fatal_assert((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeUInt64);
-    return ev->UInt64Val;
+static inline bool wevt_field_get_uint64_hex_checked(EVT_VARIANT *ev, uint64_t *dst) {
+    if(dst) *dst = 0;
+    if(wevt_field_is_array(ev) || wevt_field_type(ev) != EvtVarTypeHexInt64)
+        return false;
+
+    if(dst) *dst = ev->UInt64Val;
+    return true;
 }
 
 static inline uint64_t wevt_field_get_uint64_hex(EVT_VARIANT *ev) {
-    if((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeNull)
-        return 0;
+    uint64_t value = 0;
+    wevt_field_get_uint64_hex_checked(ev, &value);
+    return value;
+}
 
-    fatal_assert((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeHexInt64);
-    return ev->UInt64Val;
+static inline LPCWSTR wevt_field_get_string(EVT_VARIANT *ev) {
+    return !wevt_field_is_array(ev) && wevt_field_type(ev) == EvtVarTypeString ? ev->StringVal : NULL;
+}
+
+static inline EVT_HANDLE wevt_field_get_evt_handle(EVT_VARIANT *ev) {
+    return !wevt_field_is_array(ev) && wevt_field_type(ev) == EvtVarTypeEvtHandle ? ev->EvtHandleVal : NULL;
 }
 
 static inline bool wevt_field_get_string_utf8(EVT_VARIANT *ev, TXT_UTF8 *dst) {
-    if((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeNull) {
+    LPCWSTR src = wevt_field_get_string(ev);
+    if(!src) {
         txt_utf8_empty(dst);
         return false;
     }
 
-    fatal_assert((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeString);
-    return wchar_to_txt_utf8(dst, ev->StringVal, -1);
+    return wchar_to_txt_utf8(dst, src, -1);
 }
 
 bool cached_sid_to_account_domain_sidstr(PSID sid, TXT_UTF8 *dst_account, TXT_UTF8 *dst_domain, TXT_UTF8 *dst_sid_str);
 static inline bool wevt_field_get_sid(EVT_VARIANT *ev, TXT_UTF8 *dst_account, TXT_UTF8 *dst_domain, TXT_UTF8 *dst_sid_str) {
-    if((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeNull) {
+    if(wevt_field_is_array(ev) || wevt_field_type(ev) != EvtVarTypeSid || !ev->SidVal) {
         txt_utf8_empty(dst_account);
         txt_utf8_empty(dst_domain);
         txt_utf8_empty(dst_sid_str);
         return false;
     }
 
-    fatal_assert((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeSid);
     return cached_sid_to_account_domain_sidstr(ev->SidVal, dst_account, dst_domain, dst_sid_str);
 }
 
 static inline uint64_t wevt_field_get_filetime_to_ns(EVT_VARIANT *ev) {
-    if((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeNull)
+    if(wevt_field_is_array(ev) || wevt_field_type(ev) != EvtVarTypeFileTime)
         return 0;
 
-    fatal_assert((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeFileTime);
     return os_windows_ulonglong_to_unix_epoch_ns(ev->FileTimeVal);
 }
 
@@ -244,12 +307,11 @@ static inline bool wevt_GUID_to_ND_UUID(ND_UUID *nd_uuid, const GUID *guid) {
 }
 
 static inline bool wevt_get_uuid_by_type(EVT_VARIANT *ev, ND_UUID *dst) {
-    if((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeNull) {
+    if(wevt_field_is_array(ev) || wevt_field_type(ev) != EvtVarTypeGuid) {
         wevt_GUID_to_ND_UUID(dst, NULL);
         return false;
     }
 
-    fatal_assert((ev->Type & EVT_VARIANT_TYPE_MASK) == EvtVarTypeGuid);
     return wevt_GUID_to_ND_UUID(dst, ev->GuidVal);
 }
 

--- a/src/collectors/windows-events.plugin/windows-events-sources.c
+++ b/src/collectors/windows-events.plugin/windows-events-sources.c
@@ -372,20 +372,28 @@ void wevt_sources_to_json_array(BUFFER *wb) {
 }
 
 static bool ndEvtGetChannelConfigProperty(EVT_HANDLE hChannelConfig, WEVT_VARIANT *pr, EVT_CHANNEL_CONFIG_PROPERTY_ID id) {
+    pr->used = 0;
+    pr->count = 0;
+
     if (!EvtGetChannelConfigProperty(hChannelConfig, id, 0, pr->size, pr->data, &pr->used)) {
         DWORD status = GetLastError();
-        if (ERROR_INSUFFICIENT_BUFFER == status) {
-            wevt_variant_resize(pr, pr->used);
-            if(!EvtGetChannelConfigProperty(hChannelConfig, id, 0, pr->size, pr->data, &pr->used)) {
-                pr->used = 0;
-                pr->count = 0;
-                return false;
-            }
+        if (ERROR_INSUFFICIENT_BUFFER != status || !pr->used)
+            return false;
+
+        wevt_variant_resize(pr, pr->used);
+        pr->used = 0;
+        if(!EvtGetChannelConfigProperty(hChannelConfig, id, 0, pr->size, pr->data, &pr->used)) {
+            pr->used = 0;
+            pr->count = 0;
+            return false;
         }
     }
 
+    if(!pr->data || !pr->used)
+        return false;
+
     wevt_variant_count_from_used(pr);
-    return true;
+    return pr->count > 0;
 }
 
 WEVT_SOURCE_TYPE categorize_channel(const wchar_t *channel_path, const char **provider, WEVT_VARIANT *property) {
@@ -397,10 +405,10 @@ WEVT_SOURCE_TYPE categorize_channel(const wchar_t *channel_path, const char **pr
     if (!hChannelConfig)
         goto cleanup;
 
-    if(ndEvtGetChannelConfigProperty(hChannelConfig, property, EvtChannelConfigType) &
-       property->count &&
-       property->data[0].Type == EvtVarTypeUInt32) {
-        switch (property->data[0].UInt32Val) {
+    uint32_t channel_type;
+    if(ndEvtGetChannelConfigProperty(hChannelConfig, property, EvtChannelConfigType) &&
+       wevt_field_get_uint32_checked(property->data, &channel_type)) {
+        switch (channel_type) {
             case EvtChannelTypeAdmin:
                 result |= WEVTS_ADMIN;
                 break;
@@ -422,26 +430,27 @@ WEVT_SOURCE_TYPE categorize_channel(const wchar_t *channel_path, const char **pr
         }
     }
 
+    bool classic;
     if(ndEvtGetChannelConfigProperty(hChannelConfig, property, EvtChannelConfigClassicEventlog) &&
-       property->count &&
-       property->data[0].Type == EvtVarTypeBoolean &&
-       property->data[0].BooleanVal)
+       wevt_field_get_bool_checked(property->data, &classic) && classic)
         result |= WEVTS_CLASSIC;
 
-    if(ndEvtGetChannelConfigProperty(hChannelConfig, property, EvtChannelConfigOwningPublisher) &&
-       property->count &&
-       property->data[0].Type == EvtVarTypeString) {
-        *provider = provider2utf8(property->data[0].StringVal);
-        if(wcscasecmp(property->data[0].StringVal, L"Microsoft-Windows-EventCollector") == 0)
+    LPCWSTR owning_publisher = NULL;
+    if(ndEvtGetChannelConfigProperty(hChannelConfig, property, EvtChannelConfigOwningPublisher))
+        owning_publisher = wevt_field_get_string(property->data);
+
+    if(owning_publisher) {
+        *provider = provider2utf8(owning_publisher);
+        if(wcscasecmp(owning_publisher, L"Microsoft-Windows-EventCollector") == 0)
             result |= WEVTS_FORWARDED;
     }
     else
         *provider = NULL;
 
+    bool enabled;
     if(ndEvtGetChannelConfigProperty(hChannelConfig, property, EvtChannelConfigEnabled) &&
-       property->count &&
-       property->data[0].Type == EvtVarTypeBoolean) {
-        if(property->data[0].BooleanVal)
+       wevt_field_get_bool_checked(property->data, &enabled)) {
+        if(enabled)
             result |= WEVTS_ENABLED;
         else
             result |= WEVTS_DISABLED;
@@ -450,19 +459,15 @@ WEVT_SOURCE_TYPE categorize_channel(const wchar_t *channel_path, const char **pr
     bool got_retention = false;
     bool retained = false;
     if(ndEvtGetChannelConfigProperty(hChannelConfig, property, EvtChannelLoggingConfigRetention) &&
-       property->count &&
-       property->data[0].Type == EvtVarTypeBoolean) {
+       wevt_field_get_bool_checked(property->data, &retained)) {
         got_retention = true;
-        retained = property->data[0].BooleanVal;
     }
 
     bool got_auto_backup = false;
     bool auto_backup = false;
     if(ndEvtGetChannelConfigProperty(hChannelConfig, property, EvtChannelLoggingConfigAutoBackup) &&
-       property->count &&
-       property->data[0].Type == EvtVarTypeBoolean) {
+       wevt_field_get_bool_checked(property->data, &auto_backup)) {
         got_auto_backup = true;
-        auto_backup = property->data[0].BooleanVal;
     }
 
     if(got_retention && got_auto_backup) {
@@ -491,11 +496,14 @@ void wevt_sources_scan(void) {
     static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
     LPWSTR channel = NULL;
     EVT_HANDLE hChannelEnum = NULL;
+    WEVT_LOG *log = NULL;
+    WEVT_VARIANT property = { 0 };
+    bool locked = false;
 
     if(spinlock_trylock(&spinlock)) {
+        locked = true;
         const usec_t started_ut = now_monotonic_usec();
 
-        WEVT_VARIANT property = { 0 };
         DWORD dwChannelBufferSize = 0;
         DWORD dwChannelBufferUsed = 0;
         DWORD status = ERROR_SUCCESS;
@@ -508,7 +516,7 @@ void wevt_sources_scan(void) {
             goto cleanup;
         }
 
-        WEVT_LOG *log = wevt_openlog6(WEVT_QUERY_RETENTION);
+        log = wevt_openlog6(WEVT_QUERY_RETENTION);
         if(!log) goto cleanup;
 
         while (true) {
@@ -625,6 +633,7 @@ void wevt_sources_scan(void) {
 //        }
 //
         wevt_closelog6(log);
+        log = NULL;
 
         LOGS_QUERY_SOURCE *src;
         dfe_start_write(wevt_sources, src)
@@ -642,11 +651,17 @@ void wevt_sources_scan(void) {
         dictionary_garbage_collect(wevt_sources);
 
         spinlock_unlock(&spinlock);
-
-        wevt_variant_cleanup(&property);
+        locked = false;
     }
 
 cleanup:
+    if(log)
+        wevt_closelog6(log);
+
+    if(locked)
+        spinlock_unlock(&spinlock);
+
+    wevt_variant_cleanup(&property);
     freez(channel);
     EvtClose(hChannelEnum);
 }

--- a/src/collectors/windows-events.plugin/windows-events-xml.c
+++ b/src/collectors/windows-events.plugin/windows-events-xml.c
@@ -27,6 +27,28 @@ const char *append_the_rest(BUFFER *buffer, const char *xml, const char *end) {
 
 static const char *parse_node(BUFFER *buffer, const char *xml, const char *end, int level);
 
+static const char *find_string_in_slice(const char *start, const char *end, const char *needle, size_t needle_len) {
+    if(!needle_len)
+        return start;
+
+    if(!start || !end || start >= end || (size_t)(end - start) < needle_len)
+        return NULL;
+
+    for(const char *p = start; (size_t)(end - p) >= needle_len; p++) {
+        if(*p == *needle && memcmp(p, needle, needle_len) == 0)
+            return p;
+    }
+
+    return NULL;
+}
+
+static const char *find_char_in_slice(const char *start, const char *end, char c) {
+    if(!start || !end || start >= end)
+        return NULL;
+
+    return memchr(start, c, end - start);
+}
+
 // Helper: Parse the value (between > and <) and return the next position to parse
 const char *parse_value_and_closing_tag(BUFFER *buffer, const char *xml, const char *end, int level) {
     const char *start = xml;
@@ -35,7 +57,7 @@ const char *parse_value_and_closing_tag(BUFFER *buffer, const char *xml, const c
     // const char *tag_start = NULL, *tag_end = NULL;
     while (xml < end) {
         if(*xml == '<') {
-            if(xml + 1 < end && *(xml + 1) == '/') {
+            if((size_t)(end - xml) > 1 && *(xml + 1) == '/') {
                 // a closing tag
                 xml += 2;
 
@@ -106,11 +128,11 @@ const char *parse_field_value(BUFFER *buffer, const char *xml, const char *end) 
 
 // Parse a field name and return the next position to parse
 const char *parse_field(BUFFER *buffer, const char *xml, const char *end) {
-    while(isspace((uint8_t)*xml) && xml < end) xml++;
+    while(xml < end && isspace((uint8_t)*xml)) xml++;
 
     const char *start = xml;
 
-    while (*xml != '=' && xml < end)
+    while (xml < end && *xml != '=')
         xml++;
 
     // Append the field name
@@ -132,7 +154,7 @@ const char *parse_field(BUFFER *buffer, const char *xml, const char *end) {
 
 // Parse a node (handles fields and subnodes) and return the next position to parse
 static inline const char *parse_node(BUFFER *buffer, const char *xml, const char *end, int level) {
-    if(*xml != '<')
+    if(xml >= end || *xml != '<')
         return append_the_rest(buffer, xml, end);
 
     const char *start = xml++; // skip the <
@@ -215,6 +237,9 @@ static inline void buffer_pretty_print_xml_object(BUFFER *buffer, const char *xm
 }
 
 void buffer_pretty_print_xml(BUFFER *buffer, const char *xml, size_t xml_len) {
+    if(!xml || !xml_len)
+        return;
+
     const char *end = xml + xml_len;
     buffer_pretty_print_xml_object(buffer, xml, end);
 }
@@ -223,7 +248,12 @@ void buffer_pretty_print_xml(BUFFER *buffer, const char *xml, size_t xml_len) {
 
 bool buffer_extract_and_print_xml_with_cb(BUFFER *buffer, const char *xml, size_t xml_len, const char *prefix, const char *keys[],
                                           void (*cb)(BUFFER *, const char *, const char *, const char *)) {
-    if(!keys || !*keys[0]) {
+    if(!xml)
+        return false;
+
+    const char *limit = xml + xml_len;
+
+    if(!keys || !keys[0] || !*keys[0]) {
         buffer_pretty_print_xml(buffer, xml, xml_len);
         return true;
     }
@@ -233,26 +263,31 @@ bool buffer_extract_and_print_xml_with_cb(BUFFER *buffer, const char *xml, size_
         if(!*keys[k]) continue;
 
         size_t klen = strlen(keys[k]);
+        const char *search_end = end ? end : limit;
         char *tag_open = mallocz(klen + 2);
         tag_open[0] = '<';
         strcpy(&tag_open[1], keys[k]);
         tag_open[klen + 1] = '\0';
 
-        const char *new_start = strstr(start, tag_open);
+        const char *new_start = find_string_in_slice(start, search_end, tag_open, klen + 1);
         freez(tag_open);
         if(!new_start)
             return false;
 
         start = new_start + klen + 1;
+        if(start >= search_end)
+            return false;
 
         if(*start != '>' && !isspace((uint8_t)*start))
             return false;
 
         if(*start != '>') {
-            start = strchr(start, '>');
+            start = find_char_in_slice(start, search_end, '>');
             if(!start) return false;
         }
         start++; // skip the >
+        if(start > search_end)
+            return false;
 
         char *tag_close = mallocz(klen + 4);
         tag_close[0] = '<';
@@ -261,9 +296,9 @@ bool buffer_extract_and_print_xml_with_cb(BUFFER *buffer, const char *xml, size_
         tag_close[klen + 2] = '>';
         tag_close[klen + 3] = '\0';
 
-        const char *new_end = strstr(start, tag_close);
+        const char *new_end = find_string_in_slice(start, search_end, tag_close, klen + 3);
         freez(tag_close);
-        if(!new_end || (end && new_end > end))
+        if(!new_end)
             return false;
 
         end = new_end;
@@ -300,10 +335,11 @@ static void print_value_cb(BUFFER *buffer, const char *prefix, const char *start
     char *d = started;
     const char *s = start;
 
-    while(s < end && s) {
-        if(*s == '&' && s + 3 < end) {
+    while(s && s < end) {
+        size_t remaining = end - s;
+        if(*s == '&' && remaining > 3) {
             if(*(s + 1) == '#') {
-                if(s + 4 < end && *(s + 2) == '1' && *(s + 4) == ';') {
+                if(remaining > 4 && *(s + 2) == '1' && *(s + 4) == ';') {
                     if (*(s + 3) == '0') {
                         s += 5;
                         *d++ = '\n';
@@ -319,7 +355,7 @@ static void print_value_cb(BUFFER *buffer, const char *prefix, const char *start
                     continue;
                 }
             }
-            else if(s + 3 < end && *(s + 2) == 't' && *(s + 3) == ';') {
+            else if(*(s + 2) == 't' && *(s + 3) == ';') {
                 if(*(s + 1) == 'l') {
                     s += 4;
                     *d++ = '<';

--- a/src/collectors/windows-events.plugin/windows-events.c
+++ b/src/collectors/windows-events.plugin/windows-events.c
@@ -133,9 +133,8 @@ static void wevt_lazy_loading_event_and_xml(struct wevt_bin_data *d, FACET_ROW *
                    "Event Record ID of row does not match the bin data associated with it");
 #endif
 
-    // the message needs the xml
     EvtFormatMessage_Xml_utf8(&d->log->ops.unicode, d->provider, d->hEvent, &d->log->ops.xml);
-    EvtFormatMessage_Event_utf8(&d->log->ops.unicode, d->provider, d->hEvent, &d->log->ops.event);
+    txt_utf8_empty(&d->log->ops.event);
     d->rendered = true;
 }
 


### PR DESCRIPTION
## Summary

Fix likely crash paths in `windows-events.plugin` row rendering for events that contain unusual or malformed Windows Event API payloads.

The report was clarified after the draft PR was opened: the observed crash was not an FTS query. It happened with a plain `data=true` query over a specific timeframe, and histogram traversal worked while viewing the rows did not. That points to lazy row rendering, where the dynamic `Message` and `XML` columns format the saved Windows event handle during `facets_report()`.

## Root cause candidates addressed

- Plain `data=true` row rendering formatted XML and then separately formatted the event message for every returned row. The row renderer now formats XML once and uses the existing `RenderingInfo/Message` extraction path for the visible message.
- `EvtFormatMessage_utf16()` trusted `BufferUsed` enough to write `dst->data[size - 1]`. It now treats zero `BufferUsed` as a formatting failure.
- System event fields are rendered from external Windows `EVT_VARIANT` payloads, but the code indexed them without validating the returned property count and used production `fatal_assert()` checks for exact types. Rows now validate the system property count and degrade unexpected types to defaults instead of aborting.
- Provider metadata loading used the same strict field accessors and assumed scalar/object-array/name property shapes. It now rejects array-valued scalar fields, validates metadata buffers and handles, and compacts only usable metadata entries.
- Provider metadata handle refcounts were mutated partly outside the provider-cache spinlock while idle handles can be deleted under that lock. Refcount transitions now use the same lock discipline.
- Channel config property failures could leave stale variant metadata for later source categorization reads. Property fetches now reset result metadata before reuse.
- Source scanning could jump to cleanup while holding the scan lock or with an opened log handle. Cleanup now closes/unlocks consistently on early exits.
- Lazy XML/message extraction had slice-bound order issues and unbounded `strstr()` / `strchr()` searches. It now bounds-checks before dereferencing and searches only within the formatted XML slice.
- The FTS event-data renderer cast ANSI variants to UTF-16. It now converts `EvtVarTypeAnsiString` through `any_to_utf16(CP_ACP, ...)`.
- The FTS array branch treated binary and event-handle arrays as readable even though the local Windows SDK exposes no `BinaryArr` or `EvtHandleArr` union member. Those unsupported array forms are now skipped; scalar binary and event-handle rendering remains unchanged.
- Array-valued variant flattening now checks the relevant array base pointer before indexing when `Count > 0`.

## PR review follow-up

cubic identified four valid hardening issues on the previous commit. This update addresses them by:

- using `(end - p) >= needle_len` in the bounded XML slice scan;
- preserving the previous `WEVT_VARIANT` buffer size when computing resize growth;
- rejecting array-valued variants in provider platform string checks;
- rejecting array-valued variants in provider metadata name extraction.

## Changes

- Make lazy `data=true` row rendering avoid the redundant `EvtFormatMessageEvent` call after XML rendering.
- Add non-fatal checked `EVT_VARIANT` accessors for Windows event/system/provider data.
- Validate rendered system property counts before indexing `EvtSystem*` fields.
- Harden provider metadata property, object-array, and handle-lifetime handling.
- Harden channel source scanning cleanup and channel config property reuse.
- Bound lazy XML extraction to the provided XML slice.
- Decode scalar and array `EvtVarTypeAnsiString` with the existing Windows ANSI conversion path.
- Keep binary variant direct writes NUL-terminated, skip unsupported binary/handle array shapes, and guard array base pointers before indexing.

## Validation

- Full compile of all `src/collectors/windows-events.plugin/*.c` translation units present in `build-cygwin-MSYS/compile_commands.json` passed with no diagnostics.
- `git diff --check` and `git diff --cached --check` passed, aside from local CRLF warnings emitted by Git on Windows.
- Same-failure search confirmed no remaining ANSI-to-UTF16 casts, strict external-variant type assertions, direct provider-name/provider-handle union reads, XML slice-scan pointer arithmetic, or lazy XML bound-order issues under `src/collectors/windows-events.plugin`.
- Static array-index search confirmed the remaining `*Arr[i]` reads are confined to `evt_variant_to_buffer()` behind the new per-type null-base guard.
- `Select-String` around `EvtVarTypeBinary` and `EvtVarTypeEvtHandle` confirmed array branches skip unsupported shapes while scalar branches still render them.
- Lazy-row search confirmed `wevt_lazy_loading_event_and_xml()` no longer calls `EvtFormatMessage_Event_utf8()`; that call remains only in the FTS preload path.
- `.agents/sow/audit.sh` active-SOW checks and sensitive-data scan passed; the audit still reports pre-existing legacy SOW references in unrelated SNMP trap spec research files.

No reproducing Windows host or event payload was available for runtime verification.

References:

- https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage
- https://learn.microsoft.com/en-us/windows/win32/api/winevt/ns-winevt-evt_variant
- https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_variant_type