### PR TITLE
aclk: grow inbound mqtt buffer on demand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,6 +966,7 @@ set(LIBNETDATA_FILES
         src/libnetdata/buffer/functions_fields.h
         src/libnetdata/ringbuffer/ringbuffer.c
         src/libnetdata/ringbuffer/ringbuffer.h
+        src/libnetdata/ringbuffer/ringbuffer-unittest.c
         src/libnetdata/circular_buffer/circular_buffer.c
         src/libnetdata/circular_buffer/circular_buffer.h
         src/libnetdata/clocks/clocks.c
@@ -2282,6 +2283,7 @@ set(MQTT_WEBSOCKETS_FILES
         src/aclk/mqtt_websockets/mqtt_wss_client.h
         src/aclk/mqtt_websockets/ws_client.c
         src/aclk/mqtt_websockets/ws_client.h
+        src/aclk/mqtt_websockets/ws_client-unittest.c
         src/aclk/mqtt_websockets/mqtt_ng.c
         src/aclk/mqtt_websockets/mqtt_ng.h
         src/aclk/mqtt_websockets/common_public.c

--- a/src/aclk/https_client.c
+++ b/src/aclk/https_client.c
@@ -765,7 +765,7 @@ https_client_resp_t https_request(https_req_t *request, https_req_response_t *re
     https_req_ctx_t *ctx = callocz(1, sizeof(https_req_ctx_t));
     ctx->req_start_time = now_realtime_sec();
 
-    ctx->buf_rx = rbuf_create(RX_BUFFER_SIZE);
+    ctx->buf_rx = rbuf_create(RX_BUFFER_SIZE, RX_BUFFER_SIZE);
     if (!ctx->buf_rx) {
         rc = HTTPS_CLIENT_RESP_NO_MEM;
         netdata_log_error("ACLK: couldn't allocate buffer for RX data");

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -656,6 +656,8 @@ static uint8_t get_control_packet_type(uint8_t first_hdr_byte)
     return first_hdr_byte >> 4;
 }
 
+static void mqtt_ng_parser_reset(struct mqtt_ng_parser *parser);
+
 static void mqtt_ng_destroy_rx_alias_hash(c_rhash hash)
 {
     c_rhash_iter_t i = C_RHASH_ITER_T_INITIALIZER;
@@ -690,6 +692,7 @@ static void destroy_timeout_monitor_list(struct mqtt_ng_client *client)
 
 void mqtt_ng_destroy(struct mqtt_ng_client *client)
 {
+    mqtt_ng_parser_reset(&client->parser);
     transaction_buffer_destroy(&client->main_buffer);
 
     mqtt_ng_destroy_tx_alias_hash(client->tx_topic_aliases.stoi_dict);
@@ -1037,7 +1040,7 @@ int mqtt_ng_connect(
     uint16_t keep_alive)
 {
     client->client_state = MQTT_STATE_RAW;
-    client->parser.state = MQTT_PARSE_FIXED_HEADER_PACKET_TYPE;
+    mqtt_ng_parser_reset(&client->parser);
 
     LOCK_HDR_BUFFER(&client->main_buffer);
     client->main_buffer.sending_frag = NULL;
@@ -1537,6 +1540,30 @@ static void mqtt_properties_parser_ctx_reset(struct mqtt_properties_parser_ctx *
     vbi_parser_reset_ctx(&ctx->vbi_parser_ctx);
 }
 
+static void mqtt_ng_parser_reset(struct mqtt_ng_parser *parser)
+{
+    rbuf_t received_data = parser->received_data;
+    uint8_t control_packet_type = get_control_packet_type(parser->mqtt_control_packet_type);
+    bool current_variable_header =
+        parser->state == MQTT_PARSE_VARIABLE_HEADER &&
+        parser->varhdr_state != MQTT_PARSE_VARHDR_INITIAL;
+
+    mqtt_properties_parser_ctx_reset(&parser->properties_parser);
+
+    // VARHDR_INITIAL may still contain stale pointers from an already handled packet.
+    // Incomplete PUBLISH state can own the topic, but payload data is allocated
+    // only after the full payload is available.
+    if (current_variable_header && control_packet_type == MQTT_CPT_PUBLISH)
+        freez(parser->mqtt_packet.publish.topic);
+
+    if (current_variable_header && control_packet_type == MQTT_CPT_SUBACK)
+        freez(parser->mqtt_packet.suback.reason_codes);
+
+    memset(parser, 0, sizeof(*parser));
+    parser->received_data = received_data;
+    parser->state = MQTT_PARSE_FIXED_HEADER_PACKET_TYPE;
+}
+
 struct mqtt_property_type {
     uint8_t id;
     enum mqtt_datatype datatype;
@@ -1868,6 +1895,7 @@ static int parse_publish_varhdr(struct mqtt_ng_client *client)
         case MQTT_PARSE_VARHDR_INITIAL:
             BUF_READ_CHECK_AT_LEAST(parser->received_data, 2)
             publish->topic = NULL;
+            publish->data = NULL;
             publish->qos = ((parser->mqtt_control_packet_type >> 1) & 0x03);
             rbuf_pop(parser->received_data, (char*)&publish->topic_len, 2);
             publish->topic_len = be16toh(publish->topic_len);
@@ -2293,6 +2321,98 @@ int mqtt_ng_sync(struct mqtt_ng_client *client)
         return rc;
 
     return 0;
+}
+
+static int mqtt_ng_unittest_push_bytes(rbuf_t buffer, const char *data, size_t len)
+{
+    return rbuf_push(buffer, data, len) == len ? 0 : 1;
+}
+
+#define MQTT_NG_TEST(condition, msg) do {                                      \
+        if (!(condition)) {                                                    \
+            fprintf(stderr, "mqtt_ng unittest FAILED: %s (%s:%d)\n",          \
+                    (msg), __FUNCTION__, __LINE__);                            \
+            errors++;                                                          \
+        }                                                                      \
+    } while(0)
+
+static int mqtt_ng_unittest_reset_after_partial_publish(void)
+{
+    int errors = 0;
+    rbuf_t input = rbuf_create(128, 128);
+    struct mqtt_ng_init settings = {
+        .data_in = input,
+        .data_out_fnc = NULL,
+        .user_ctx = NULL,
+        .connack_callback = NULL,
+        .puback_callback = NULL,
+        .msg_callback = NULL,
+    };
+    struct mqtt_ng_client *client = mqtt_ng_init(&settings);
+
+    const char partial_publish[] = {
+        (char)(MQTT_CPT_PUBLISH << 4), 23,
+        0, 4, 't', 'e', 's', 't',
+        0,
+    };
+
+    MQTT_NG_TEST(client != NULL, "mqtt_ng_init succeeds");
+    if (!client) {
+        rbuf_free(input);
+        return errors;
+    }
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, partial_publish, sizeof(partial_publish)),
+                 "push partial PUBLISH");
+
+    int rc = handle_incoming_traffic(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_NEED_MORE_BYTES, "partial PUBLISH needs more bytes");
+    MQTT_NG_TEST(client->parser.state == MQTT_PARSE_VARIABLE_HEADER, "partial PUBLISH stays in variable-header parser");
+    MQTT_NG_TEST(client->parser.varhdr_state == MQTT_PARSE_PAYLOAD, "partial PUBLISH waits for payload");
+    MQTT_NG_TEST(client->parser.mqtt_packet.publish.topic != NULL, "partial PUBLISH owns parsed topic");
+
+    struct mqtt_auth_properties auth = {
+        .client_id = "unit-test",
+    };
+
+    MQTT_NG_TEST(mqtt_ng_connect(client, &auth, NULL, 60) == 0, "mqtt_ng_connect resets parser");
+    MQTT_NG_TEST(client->parser.state == MQTT_PARSE_FIXED_HEADER_PACKET_TYPE, "parser state reset");
+    MQTT_NG_TEST(client->parser.mqtt_packet.publish.topic == NULL, "partial PUBLISH topic released");
+    MQTT_NG_TEST(client->parser.properties_parser.head == NULL, "partial properties released");
+
+    const char normal_publish[] = {
+        (char)(MQTT_CPT_PUBLISH << 4), 7,
+        0, 2, 'o', 'k',
+        0,
+        'h', 'i',
+    };
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, normal_publish, sizeof(normal_publish)),
+                 "push normal PUBLISH after reconnect");
+
+    rc = handle_incoming_traffic(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_WANT_WRITE, "normal PUBLISH parses after reconnect reset");
+    MQTT_NG_TEST(client->parser.state == MQTT_PARSE_FIXED_HEADER_PACKET_TYPE, "parser ready after normal PUBLISH");
+
+    mqtt_ng_destroy(client);
+    rbuf_free(input);
+    return errors;
+}
+
+int mqtt_ng_unittest(void)
+{
+    int errors = 0;
+
+    fprintf(stderr, "\nrunning mqtt_ng unittest\n");
+
+    errors += mqtt_ng_unittest_reset_after_partial_publish();
+
+    if (errors)
+        fprintf(stderr, "mqtt_ng unittest: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "mqtt_ng unittest: OK\n");
+
+    return errors;
 }
 
 time_t mqtt_ng_last_send_time(struct mqtt_ng_client *client)

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -754,6 +754,9 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
         case WS_CLIENT_CONNECTION_CLOSED:
             return MQTT_WSS_ERR_CONN_DROP;
 
+        case WS_CLIENT_BUFFER_FULL:
+            return MQTT_WSS_ERR_MSG_TOO_BIG;
+
         default:
             return MQTT_WSS_ERR_PROTO_WS;
     }

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.h
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.h
@@ -12,7 +12,7 @@
 #define MQTT_WSS_ERR_CONN_DROP      -1      // Connection was closed by remote
 #define MQTT_WSS_ERR_PROTO_MQTT     -2      // Error in MQTT protocol (e.g. malformed packet)
 #define MQTT_WSS_ERR_PROTO_WS       -3      // Error in WebSocket protocol (e.g. malformed packet)
-#define MQTT_WSS_ERR_MSG_TOO_BIG    -6      // Message size too big for server
+#define MQTT_WSS_ERR_MSG_TOO_BIG    -6      // Message size too big for server or inbound buffer
 #define MQTT_WSS_ERR_CANT_DO        -8      // if client was initialized with MQTT 3 but MQTT 5 feature
                                             // was requested by user of library
 #define MQTT_WSS_ERR_POLL_FAILED    -9

--- a/src/aclk/mqtt_websockets/ws_client-unittest.c
+++ b/src/aclk/mqtt_websockets/ws_client-unittest.c
@@ -53,6 +53,13 @@ static size_t ws_client_unittest_binary_header(char *dst, size_t payload_len)
     return 2 + sizeof(len);
 }
 
+static size_t ws_client_unittest_control_header(char *dst, enum websocket_opcode opcode, size_t payload_len)
+{
+    dst[0] = (char)(0x80 | opcode);
+    dst[1] = (char)payload_len;
+    return 2;
+}
+
 static int ws_client_unittest_process_frame(ws_client *client, size_t payload_len)
 {
     char header[10];
@@ -195,6 +202,78 @@ static int ws_client_unittest_cap_hit(void)
     return errors;
 }
 
+static int ws_client_unittest_reset_frees_partial_close_reason(void)
+{
+    int errors = 0;
+    char frame[4];
+    size_t header_len = ws_client_unittest_control_header(frame, WS_OP_CONNECTION_CLOSE, 5);
+    uint16_t close_code = htobe16(1000);
+    memcpy(&frame[header_len], &close_code, sizeof(close_code));
+
+    ws_client client = {
+        .state = WS_ESTABLISHED,
+        .rx.parse_state = WS_FIRST_2BYTES,
+        .buf_read = rbuf_create(64, 64),
+        .buf_write = rbuf_create(1024, 1024),
+        .buf_to_mqtt = rbuf_create(1024, 1024),
+    };
+
+    WS_TEST(rbuf_push(client.buf_read, frame, sizeof(frame)) == sizeof(frame), "push partial close frame");
+
+    int ret;
+    do {
+        ret = ws_client_process_rx_ws(&client);
+    } while (ret == 0);
+
+    WS_TEST(ret == WS_CLIENT_NEED_MORE_BYTES, "partial close reason needs more bytes");
+    WS_TEST(client.rx.specific_data.op_close.reason != NULL, "partial close reason allocated");
+
+    ws_client_reset(&client);
+
+    WS_TEST(client.rx.specific_data.op_close.reason == NULL, "reset frees partial close reason");
+    WS_TEST(client.rx.payload_processed == 0, "reset clears close payload progress");
+
+    rbuf_free(client.buf_read);
+    rbuf_free(client.buf_write);
+    rbuf_free(client.buf_to_mqtt);
+    return errors;
+}
+
+static int ws_client_unittest_ping_payload_cleanup(void)
+{
+    int errors = 0;
+    const char payload[] = "abc";
+    char frame[2 + sizeof(payload) - 1];
+    size_t header_len = ws_client_unittest_control_header(frame, WS_OP_PING, sizeof(payload) - 1);
+    memcpy(&frame[header_len], payload, sizeof(payload) - 1);
+
+    ws_client client = {
+        .state = WS_ESTABLISHED,
+        .rx.parse_state = WS_FIRST_2BYTES,
+        .buf_read = rbuf_create(64, 64),
+        .buf_write = rbuf_create(1024, 1024),
+        .buf_to_mqtt = rbuf_create(1024, 1024),
+    };
+
+    WS_TEST(rbuf_push(client.buf_read, frame, sizeof(frame)) == sizeof(frame), "push ping frame");
+
+    int ret;
+    do {
+        ret = ws_client_process_rx_ws(&client);
+    } while (ret == 0);
+
+    WS_TEST(ret == WS_CLIENT_PARSING_DONE, "ping frame parses");
+    WS_TEST(client.rx.specific_data.ping_msg == NULL, "ping payload released after PONG generation");
+    WS_TEST(rbuf_bytes_available(client.buf_write) > 0, "PONG queued");
+
+    ws_client_reset(&client);
+
+    rbuf_free(client.buf_read);
+    rbuf_free(client.buf_write);
+    rbuf_free(client.buf_to_mqtt);
+    return errors;
+}
+
 int ws_client_unittest(void)
 {
     int errors = 0;
@@ -205,6 +284,8 @@ int ws_client_unittest(void)
     errors += ws_client_unittest_clamps_mqtt_input_initial_size();
     errors += ws_client_unittest_observed_size_payload();
     errors += ws_client_unittest_cap_hit();
+    errors += ws_client_unittest_reset_frees_partial_close_reason();
+    errors += ws_client_unittest_ping_payload_cleanup();
 
     if (errors)
         fprintf(stderr, "ws_client unittest: %d ERROR(S)\n", errors);

--- a/src/aclk/mqtt_websockets/ws_client-unittest.c
+++ b/src/aclk/mqtt_websockets/ws_client-unittest.c
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "libnetdata/libnetdata.h"
+
+#include "ws_client.h"
+#include "endian_compat.h"
+
+int ws_client_process_rx_ws(ws_client *client);
+
+#define WS_TEST(condition, msg) do {                                           \
+        if (!(condition)) {                                                    \
+            fprintf(stderr, "ws_client unittest FAILED: %s (%s:%d)\n",        \
+                    (msg), __FUNCTION__, __LINE__);                            \
+            errors++;                                                          \
+        }                                                                      \
+    } while(0)
+
+static void ws_client_unittest_payload_fill(char *dst, size_t offset, size_t len)
+{
+    for (size_t i = 0; i < len; i++)
+        dst[i] = (char)('A' + ((offset + i) % 26));
+}
+
+static int ws_client_unittest_payload_check(const char *src, size_t offset, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        if (src[i] != (char)('A' + ((offset + i) % 26)))
+            return 0;
+    }
+
+    return 1;
+}
+
+static size_t ws_client_unittest_binary_header(char *dst, size_t payload_len)
+{
+    dst[0] = (char)(0x80 | WS_OP_BINARY_FRAME);
+
+    if (payload_len < 126) {
+        dst[1] = (char)payload_len;
+        return 2;
+    }
+
+    if (payload_len <= UINT16_MAX) {
+        uint16_t len = htobe16((uint16_t)payload_len);
+        dst[1] = 126;
+        memcpy(&dst[2], &len, sizeof(len));
+        return 2 + sizeof(len);
+    }
+
+    uint64_t len = htobe64((uint64_t)payload_len);
+    dst[1] = 127;
+    memcpy(&dst[2], &len, sizeof(len));
+    return 2 + sizeof(len);
+}
+
+static int ws_client_unittest_process_frame(ws_client *client, size_t payload_len)
+{
+    char header[10];
+    size_t header_len = ws_client_unittest_binary_header(header, payload_len);
+    size_t frame_len = header_len + payload_len;
+    char *frame = mallocz(frame_len);
+
+    memcpy(frame, header, header_len);
+    ws_client_unittest_payload_fill(frame + header_len, 0, payload_len);
+
+    if (rbuf_push(client->buf_read, frame, frame_len) != frame_len) {
+        freez(frame);
+        return WS_CLIENT_INTERNAL_ERROR;
+    }
+
+    freez(frame);
+
+    int ret;
+    do {
+        ret = ws_client_process_rx_ws(client);
+    } while (ret == 0);
+
+    return ret;
+}
+
+static int ws_client_unittest_verify_mqtt_payload(ws_client *client, size_t payload_len)
+{
+    int errors = 0;
+    size_t checked = 0;
+    char out[4096];
+
+    WS_TEST(rbuf_bytes_available(client->buf_to_mqtt) == payload_len, "decoded MQTT payload size");
+
+    while (checked < payload_len) {
+        size_t want = MIN(sizeof(out), payload_len - checked);
+        WS_TEST(rbuf_pop(client->buf_to_mqtt, out, want) == want, "pop decoded MQTT payload chunk");
+        WS_TEST(ws_client_unittest_payload_check(out, checked, want), "decoded MQTT payload byte order");
+        checked += want;
+    }
+
+    WS_TEST(rbuf_bytes_available(client->buf_to_mqtt) == 0, "decoded MQTT payload drained");
+    return errors;
+}
+
+static int ws_client_unittest_create_defaults(void)
+{
+    int errors = 0;
+    char *host = (char *)"localhost";
+    ws_client *client = ws_client_new(1024, &host);
+
+    WS_TEST(client != NULL, "ws_client_new succeeds");
+    if (!client)
+        return errors;
+
+    WS_TEST(rbuf_get_capacity(client->buf_read) == 1024, "buf_read initial capacity");
+    WS_TEST(rbuf_get_max_capacity(client->buf_read) == 1024, "buf_read remains fixed");
+    WS_TEST(rbuf_get_capacity(client->buf_write) == 1024, "buf_write initial capacity");
+    WS_TEST(rbuf_get_max_capacity(client->buf_write) == 1024, "buf_write remains fixed");
+    WS_TEST(rbuf_get_capacity(client->buf_to_mqtt) == 1024, "buf_to_mqtt initial capacity");
+    WS_TEST(rbuf_get_max_capacity(client->buf_to_mqtt) == 16 * 1024 * 1024, "buf_to_mqtt hard cap");
+
+    ws_client_destroy(client);
+    return errors;
+}
+
+static int ws_client_unittest_observed_size_payload(void)
+{
+    int errors = 0;
+    const size_t payload_len = 369065;
+    ws_client client = {
+        .state = WS_ESTABLISHED,
+        .rx.parse_state = WS_FIRST_2BYTES,
+        .buf_read = rbuf_create(payload_len + 10, payload_len + 10),
+        .buf_write = rbuf_create(1024, 1024),
+        .buf_to_mqtt = rbuf_create(128 * 1024, 16 * 1024 * 1024),
+    };
+
+    int ret = ws_client_unittest_process_frame(&client, payload_len);
+    WS_TEST(ret == WS_CLIENT_PARSING_DONE, "observed-size WebSocket payload parses");
+    WS_TEST(rbuf_get_capacity(client.buf_to_mqtt) > 128 * 1024, "observed-size payload grows MQTT buffer");
+    errors += ws_client_unittest_verify_mqtt_payload(&client, payload_len);
+
+    rbuf_free(client.buf_read);
+    rbuf_free(client.buf_write);
+    rbuf_free(client.buf_to_mqtt);
+    return errors;
+}
+
+static int ws_client_unittest_cap_hit(void)
+{
+    int errors = 0;
+    const size_t payload_len = 4097;
+    const size_t recovery_payload_len = 32;
+    ws_client client = {
+        .state = WS_ESTABLISHED,
+        .rx.parse_state = WS_FIRST_2BYTES,
+        .buf_read = rbuf_create(payload_len + 10, payload_len + 10),
+        .buf_write = rbuf_create(1024, 1024),
+        .buf_to_mqtt = rbuf_create(1024, 4096),
+    };
+
+    int ret = ws_client_unittest_process_frame(&client, payload_len);
+    WS_TEST(ret == WS_CLIENT_BUFFER_FULL, "over-cap WebSocket payload reports buffer full");
+    WS_TEST(rbuf_get_capacity(client.buf_to_mqtt) == 4096, "over-cap MQTT buffer stops at cap");
+    WS_TEST(rbuf_bytes_available(client.buf_to_mqtt) == 4096, "over-cap MQTT buffer keeps accepted bytes");
+
+    ws_client_reset(&client);
+    client.state = WS_ESTABLISHED;
+
+    WS_TEST(rbuf_get_capacity(client.buf_to_mqtt) == 4096, "reset keeps grown MQTT buffer capacity");
+
+    ret = ws_client_unittest_process_frame(&client, recovery_payload_len);
+    WS_TEST(ret == WS_CLIENT_PARSING_DONE, "post-cap reset parses next WebSocket payload");
+    errors += ws_client_unittest_verify_mqtt_payload(&client, recovery_payload_len);
+
+    rbuf_free(client.buf_read);
+    rbuf_free(client.buf_write);
+    rbuf_free(client.buf_to_mqtt);
+    return errors;
+}
+
+int ws_client_unittest(void)
+{
+    int errors = 0;
+
+    fprintf(stderr, "\nrunning ws_client unittest\n");
+
+    errors += ws_client_unittest_create_defaults();
+    errors += ws_client_unittest_observed_size_payload();
+    errors += ws_client_unittest_cap_hit();
+
+    if (errors)
+        fprintf(stderr, "ws_client unittest: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "ws_client unittest: OK\n");
+
+    return errors;
+}

--- a/src/aclk/mqtt_websockets/ws_client-unittest.c
+++ b/src/aclk/mqtt_websockets/ws_client-unittest.c
@@ -118,6 +118,27 @@ static int ws_client_unittest_create_defaults(void)
     return errors;
 }
 
+static int ws_client_unittest_clamps_mqtt_input_initial_size(void)
+{
+    int errors = 0;
+    char *host = (char *)"localhost";
+    const size_t hard_cap = 16 * 1024 * 1024;
+    const size_t oversized = hard_cap + 1;
+    ws_client *client = ws_client_new(oversized, &host);
+
+    WS_TEST(client != NULL, "ws_client_new succeeds with oversized buffer request");
+    if (!client)
+        return errors;
+
+    WS_TEST(rbuf_get_capacity(client->buf_read) == oversized, "buf_read keeps requested fixed capacity");
+    WS_TEST(rbuf_get_capacity(client->buf_write) == oversized, "buf_write keeps requested fixed capacity");
+    WS_TEST(rbuf_get_capacity(client->buf_to_mqtt) == hard_cap, "buf_to_mqtt initial capacity is capped");
+    WS_TEST(rbuf_get_max_capacity(client->buf_to_mqtt) == hard_cap, "buf_to_mqtt max capacity is capped");
+
+    ws_client_destroy(client);
+    return errors;
+}
+
 static int ws_client_unittest_observed_size_payload(void)
 {
     int errors = 0;
@@ -181,6 +202,7 @@ int ws_client_unittest(void)
     fprintf(stderr, "\nrunning ws_client unittest\n");
 
     errors += ws_client_unittest_create_defaults();
+    errors += ws_client_unittest_clamps_mqtt_input_initial_size();
     errors += ws_client_unittest_observed_size_payload();
     errors += ws_client_unittest_cap_hit();
 

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -55,9 +55,26 @@ void ws_client_free_headers(ws_client *client)
     client->hs.hdr_count = 0;
 }
 
+static void ws_client_rx_free_specific_data(ws_client *client)
+{
+    switch (client->rx.opcode) {
+        case WS_OP_CONNECTION_CLOSE:
+            freez(client->rx.specific_data.op_close.reason);
+            client->rx.specific_data.op_close.reason = NULL;
+            break;
+        case WS_OP_PING:
+            freez(client->rx.specific_data.ping_msg);
+            client->rx.specific_data.ping_msg = NULL;
+            break;
+        default:
+            break;
+    }
+}
+
 void ws_client_destroy(ws_client *client)
 {
     ws_client_free_headers(client);
+    ws_client_rx_free_specific_data(client);
     freez(client->hs.nonce_reply);
     freez(client->hs.http_reply_msg);
     rbuf_free(client->buf_read);
@@ -69,6 +86,7 @@ void ws_client_destroy(ws_client *client)
 void ws_client_reset(ws_client *client)
 {
     ws_client_free_headers(client);
+    ws_client_rx_free_specific_data(client);
     freez(client->hs.nonce_reply);
     client->hs.nonce_reply = NULL;
 
@@ -624,6 +642,7 @@ int ws_client_process_rx_ws(ws_client *client)
             // TODO schedule this instead of sending right away
             // then attempt to send as soon as buffer space clears up
             size = ws_client_send(client, WS_OP_PONG, client->rx.specific_data.ping_msg, client->rx.payload_length);
+            ws_client_rx_free_specific_data(client);
             if (size != client->rx.payload_length) {
                 nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: Unable to send the PONG as one packet back. Closing connection.");
                 return WS_CLIENT_PROTOCOL_ERROR;

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -29,12 +29,13 @@ ws_client *ws_client_new(size_t buf_size, char **host)
     client->host = host;
 
     size_t size = buf_size ? buf_size : DEFAULT_RINGBUFFER_SIZE;
+    size_t mqtt_input_size = (size > MAX_MQTT_INPUT_BUFFER_SIZE) ? MAX_MQTT_INPUT_BUFFER_SIZE : size;
 
     // Fixed: raw WebSocket read staging; dynamic growth is only needed after payload decoding.
     client->buf_read = rbuf_create(size, size);
     // Fixed: the send path masks buffered bytes in-place after rbuf_bump_head().
     client->buf_write = rbuf_create(size, size);
-    client->buf_to_mqtt = rbuf_create(size, MAX_MQTT_INPUT_BUFFER_SIZE);
+    client->buf_to_mqtt = rbuf_create(mqtt_input_size, MAX_MQTT_INPUT_BUFFER_SIZE);
 
     return client;
 }

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -18,6 +18,7 @@ const char *websocket_upgrage_hdr = "GET /mqtt HTTP/1.1\x0D\x0A"
 const char *mqtt_protoid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 #define DEFAULT_RINGBUFFER_SIZE (1024*128)
+#define MAX_MQTT_INPUT_BUFFER_SIZE (16*1024*1024)
 
 ws_client *ws_client_new(size_t buf_size, char **host)
 {
@@ -26,9 +27,14 @@ ws_client *ws_client_new(size_t buf_size, char **host)
 
     ws_client *client = callocz(1, sizeof(ws_client));
     client->host = host;
-    client->buf_read = rbuf_create(buf_size ? buf_size : DEFAULT_RINGBUFFER_SIZE);
-    client->buf_write = rbuf_create(buf_size ? buf_size : DEFAULT_RINGBUFFER_SIZE);
-    client->buf_to_mqtt = rbuf_create(buf_size ? buf_size : DEFAULT_RINGBUFFER_SIZE);
+
+    size_t size = buf_size ? buf_size : DEFAULT_RINGBUFFER_SIZE;
+
+    // Fixed: raw WebSocket read staging; dynamic growth is only needed after payload decoding.
+    client->buf_read = rbuf_create(size, size);
+    // Fixed: the send path masks buffered bytes in-place after rbuf_bump_head().
+    client->buf_write = rbuf_create(size, size);
+    client->buf_to_mqtt = rbuf_create(size, MAX_MQTT_INPUT_BUFFER_SIZE);
 
     return client;
 }
@@ -74,8 +80,12 @@ void ws_client_reset(ws_client *client)
 
     client->state = WS_RAW;
     client->hs.hdr_state = WS_HDR_HTTP;
+    // Reconnect can happen mid-frame, so clear partial RX frame state too.
     client->rx.parse_state = WS_FIRST_2BYTES;
+    client->rx.opcode = 0;
     client->rx.remote_closed = false;
+    client->rx.payload_length = 0;
+    client->rx.payload_processed = 0;
 }
 
 #define MAX_HTTP_HDR_COUNT 128
@@ -527,8 +537,11 @@ int ws_client_process_rx_ws(ws_client *client)
                     return WS_CLIENT_NEED_MORE_BYTES;
                 char *insert = rbuf_get_linear_insert_range(client->buf_to_mqtt, &size);
                 if (!insert) {
-                    nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: WebSocket buffer full! Cannot process payload of %"PRIu64" bytes (processed %"PRIu64"/%"PRIu64"). Buffer capacity: %zu bytes",
-                           remaining, client->rx.payload_processed, client->rx.payload_length, rbuf_get_capacity(client->buf_to_mqtt));
+                    nd_log(NDLS_DAEMON, NDLP_ERR,
+                           "ACLK: inbound WebSocket MQTT buffer full! Cannot process payload of %"PRIu64" bytes "
+                           "(processed %"PRIu64"/%"PRIu64"). Buffer capacity: %zu bytes, max capacity: %zu bytes",
+                           remaining, client->rx.payload_processed, client->rx.payload_length,
+                           rbuf_get_capacity(client->buf_to_mqtt), rbuf_get_max_capacity(client->buf_to_mqtt));
                     return WS_CLIENT_BUFFER_FULL;
                 }
                 size = (size > remaining) ? remaining : size;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -210,6 +210,9 @@ int help(int exitcode) {
     } while(0)
 
 int buffer_unittest(void);
+int ringbuffer_unittest(void);
+int ws_client_unittest(void);
+int mqtt_ng_unittest(void);
 int pgc_unittest(void);
 int mrg_unittest(void);
 int pluginsd_parser_unittest(void);
@@ -434,6 +437,9 @@ int netdata_main(int argc, char **argv) {
                             if (unit_test_buffer()) return 1;
                             if (unit_test_str2ld()) return 1;
                             if (buffer_unittest()) return 1;
+                            if (ringbuffer_unittest()) return 1;
+                            if (ws_client_unittest()) return 1;
+                            if (mqtt_ng_unittest()) return 1;
 
                             // No call to load the config file on this code-path
                             if (unittest_prepare_rrd(&user)) return 1;
@@ -537,6 +543,18 @@ int netdata_main(int argc, char **argv) {
                         else if(strcmp(optarg, "buffertest") == 0) {
                             unittest_running = true;
                             return buffer_unittest();
+                        }
+                        else if(strcmp(optarg, "ringbuffertest") == 0) {
+                            unittest_running = true;
+                            return ringbuffer_unittest();
+                        }
+                        else if(strcmp(optarg, "wsclienttest") == 0) {
+                            unittest_running = true;
+                            return ws_client_unittest();
+                        }
+                        else if(strcmp(optarg, "mqttngtest") == 0) {
+                            unittest_running = true;
+                            return mqtt_ng_unittest();
                         }
                         else if(strcmp(optarg, "test_cmd_pool_fifo") == 0) {
                             unittest_running = true;

--- a/src/libnetdata/ringbuffer/ringbuffer-unittest.c
+++ b/src/libnetdata/ringbuffer/ringbuffer-unittest.c
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../libnetdata.h"
+
+#define RB_TEST(condition, msg) do {                                           \
+        if (!(condition)) {                                                    \
+            fprintf(stderr, "ringbuffer unittest FAILED: %s (%s:%d)\n",       \
+                    (msg), __FUNCTION__, __LINE__);                            \
+            errors++;                                                          \
+        }                                                                      \
+    } while(0)
+
+static int ringbuffer_fixed_size_unittest(void)
+{
+    int errors = 0;
+    rbuf_t buffer = rbuf_create(8, 8);
+
+    RB_TEST(rbuf_get_capacity(buffer) == 8, "fixed buffer initial capacity");
+    RB_TEST(rbuf_get_max_capacity(buffer) == 8, "fixed buffer max capacity");
+    RB_TEST(rbuf_push(buffer, "abcdefgh", 8) == 8, "fixed buffer fill");
+    RB_TEST(rbuf_bytes_free(buffer) == 0, "fixed buffer has no free bytes");
+
+    size_t bytes = 1;
+    RB_TEST(rbuf_get_linear_insert_range(buffer, &bytes) == NULL, "fixed full buffer refuses insert");
+    RB_TEST(bytes == 0, "fixed full buffer returns zero insert bytes");
+    RB_TEST(rbuf_get_capacity(buffer) == 8, "fixed full buffer does not grow");
+
+    char out[8];
+    RB_TEST(rbuf_pop(buffer, out, sizeof(out)) == sizeof(out), "fixed buffer pop");
+    RB_TEST(memcmp(out, "abcdefgh", sizeof(out)) == 0, "fixed buffer FIFO order");
+
+    rbuf_free(buffer);
+    return errors;
+}
+
+static int ringbuffer_linear_growth_unittest(void)
+{
+    int errors = 0;
+    rbuf_t buffer = rbuf_create(4, 16);
+
+    RB_TEST(rbuf_push(buffer, "abcd", 4) == 4, "growable buffer fill");
+    RB_TEST(rbuf_get_capacity(buffer) == 4, "growable buffer starts at initial capacity");
+
+    size_t bytes = 0;
+    char *insert = rbuf_get_linear_insert_range(buffer, &bytes);
+    RB_TEST(insert != NULL, "full growable buffer grows");
+    RB_TEST(rbuf_get_capacity(buffer) == 8, "growable buffer doubles on first growth");
+    RB_TEST(bytes == 4, "growth exposes the new free suffix");
+
+    memcpy(insert, "efgh", 4);
+    RB_TEST(rbuf_bump_head(buffer, 4), "bump head after linear growth");
+
+    char out[8];
+    RB_TEST(rbuf_pop(buffer, out, sizeof(out)) == sizeof(out), "pop after linear growth");
+    RB_TEST(memcmp(out, "abcdefgh", sizeof(out)) == 0, "linear growth preserves FIFO order");
+
+    rbuf_free(buffer);
+    return errors;
+}
+
+static int ringbuffer_wrapped_growth_unittest(void)
+{
+    int errors = 0;
+    rbuf_t buffer = rbuf_create(8, 16);
+    char dropped[5];
+
+    RB_TEST(rbuf_push(buffer, "abcdef", 6) == 6, "wrapped setup push");
+    RB_TEST(rbuf_pop(buffer, dropped, sizeof(dropped)) == sizeof(dropped), "wrapped setup pop");
+    RB_TEST(memcmp(dropped, "abcde", sizeof(dropped)) == 0, "wrapped setup pop order");
+    RB_TEST(rbuf_push(buffer, "ghijklm", 7) == 7, "wrapped setup fill");
+    RB_TEST(rbuf_bytes_available(buffer) == 8, "wrapped setup is full");
+    RB_TEST(rbuf_get_capacity(buffer) == 8, "wrapped setup initial capacity");
+
+    size_t bytes = 0;
+    char *insert = rbuf_get_linear_insert_range(buffer, &bytes);
+    RB_TEST(insert != NULL, "wrapped full buffer grows");
+    RB_TEST(rbuf_get_capacity(buffer) == 16, "wrapped growth doubles capacity");
+    RB_TEST(bytes == 8, "wrapped growth exposes free suffix");
+
+    memcpy(insert, "nop", 3);
+    RB_TEST(rbuf_bump_head(buffer, 3), "bump head after wrapped growth");
+
+    char out[11];
+    RB_TEST(rbuf_pop(buffer, out, sizeof(out)) == sizeof(out), "pop after wrapped growth");
+    RB_TEST(memcmp(out, "fghijklmnop", sizeof(out)) == 0, "wrapped growth preserves FIFO order");
+
+    rbuf_free(buffer);
+    return errors;
+}
+
+static int ringbuffer_cap_unittest(void)
+{
+    int errors = 0;
+    rbuf_t buffer = rbuf_create(4, 8);
+
+    RB_TEST(rbuf_push(buffer, "abcdefgh", 8) == 8, "growable buffer fills to cap");
+    RB_TEST(rbuf_get_capacity(buffer) == 8, "growable buffer reaches cap");
+    RB_TEST(rbuf_get_max_capacity(buffer) == 8, "growable buffer max remains cap");
+    RB_TEST(rbuf_bytes_free(buffer) == 0, "capped buffer has no free bytes");
+
+    size_t bytes = 1;
+    RB_TEST(rbuf_get_linear_insert_range(buffer, &bytes) == NULL, "capped full buffer refuses insert");
+    RB_TEST(bytes == 0, "capped full buffer returns zero insert bytes");
+    RB_TEST(rbuf_get_capacity(buffer) == 8, "capped full buffer does not grow past cap");
+
+    char out[8];
+    RB_TEST(rbuf_pop(buffer, out, sizeof(out)) == sizeof(out), "capped buffer pop");
+    RB_TEST(memcmp(out, "abcdefgh", sizeof(out)) == 0, "capped buffer FIFO order");
+
+    rbuf_free(buffer);
+    return errors;
+}
+
+static int ringbuffer_flush_keeps_capacity_unittest(void)
+{
+    int errors = 0;
+    rbuf_t buffer = rbuf_create(4, 16);
+
+    RB_TEST(rbuf_push(buffer, "abcdefgh", 8) == 8, "flush setup grows buffer");
+    RB_TEST(rbuf_get_capacity(buffer) == 8, "flush setup capacity");
+
+    rbuf_flush(buffer);
+    RB_TEST(rbuf_get_capacity(buffer) == 8, "flush does not shrink buffer");
+    RB_TEST(rbuf_get_max_capacity(buffer) == 16, "flush preserves max capacity");
+    RB_TEST(rbuf_bytes_available(buffer) == 0, "flush clears readable bytes");
+    RB_TEST(rbuf_bytes_free(buffer) == 8, "flush restores free bytes at current capacity");
+
+    rbuf_free(buffer);
+    return errors;
+}
+
+int ringbuffer_unittest(void)
+{
+    int errors = 0;
+
+    fprintf(stderr, "\nrunning ringbuffer unittest\n");
+
+    errors += ringbuffer_fixed_size_unittest();
+    errors += ringbuffer_linear_growth_unittest();
+    errors += ringbuffer_wrapped_growth_unittest();
+    errors += ringbuffer_cap_unittest();
+    errors += ringbuffer_flush_keeps_capacity_unittest();
+
+    if (errors)
+        fprintf(stderr, "ringbuffer unittest: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "ringbuffer unittest: OK\n");
+
+    return errors;
+}

--- a/src/libnetdata/ringbuffer/ringbuffer.c
+++ b/src/libnetdata/ringbuffer/ringbuffer.c
@@ -3,16 +3,17 @@
 #include "../libnetdata.h"
 #include "ringbuffer_internal.h"
 
-rbuf_t rbuf_create(size_t size)
+rbuf_t rbuf_create(size_t size, size_t max_size)
 {
-    rbuf_t buffer = mallocz(sizeof(struct rbuf) + size);
+    rbuf_t buffer = mallocz(sizeof(struct rbuf));
     memset(buffer, 0, sizeof(struct rbuf));
 
-    buffer->data = ((char*)buffer) + sizeof(struct rbuf);
+    buffer->data = mallocz(size);
 
     buffer->head = buffer->data;
     buffer->tail = buffer->data;
     buffer->size = size;
+    buffer->max_size = (max_size > size) ? max_size : size;
     buffer->end = buffer->data + size;
 
     return buffer;
@@ -20,6 +21,7 @@ rbuf_t rbuf_create(size_t size)
 
 void rbuf_free(rbuf_t buffer)
 {
+    freez(buffer->data);
     freez(buffer);
 }
 
@@ -30,11 +32,58 @@ void rbuf_flush(rbuf_t buffer)
     buffer->size_data = 0;
 }
 
+static bool rbuf_grow(rbuf_t buffer)
+{
+    if (buffer->size >= buffer->max_size)
+        return false;
+
+    size_t new_size = buffer->size * 2;
+    if (new_size < buffer->size || new_size > buffer->max_size)
+        new_size = buffer->max_size;
+
+    if (new_size <= buffer->size)
+        return false;
+
+    char *new_data = mallocz(new_size);
+    size_t copied = 0;
+
+    if (buffer->size_data) {
+        if (buffer->tail < buffer->head) {
+            memcpy(new_data, buffer->tail, buffer->size_data);
+            copied = buffer->size_data;
+        }
+        else {
+            size_t top = buffer->end - buffer->tail;
+            memcpy(new_data, buffer->tail, top);
+            copied = top;
+
+            if (buffer->head > buffer->data) {
+                size_t bottom = buffer->head - buffer->data;
+                memcpy(new_data + copied, buffer->data, bottom);
+                copied += bottom;
+            }
+        }
+    }
+
+    assert(copied == buffer->size_data);
+
+    freez(buffer->data);
+    buffer->data = new_data;
+    buffer->size = new_size;
+    buffer->end = buffer->data + buffer->size;
+    buffer->tail = buffer->data;
+    buffer->head = buffer->data + buffer->size_data;
+
+    return true;
+}
+
 char *rbuf_get_linear_insert_range(rbuf_t buffer, size_t *bytes)
 {
     *bytes = 0;
-    if (buffer->head == buffer->tail && buffer->size_data)
-        return NULL;
+    if (buffer->head == buffer->tail && buffer->size_data) {
+        if (!rbuf_grow(buffer))
+            return NULL;
+    }
 
     *bytes = ((buffer->head >= buffer->tail) ? buffer->end : buffer->tail) - buffer->head;
     return buffer->head;
@@ -56,7 +105,7 @@ int rbuf_bump_head(rbuf_t buffer, size_t bytes)
     size_t free_bytes = rbuf_bytes_free(buffer);
     if (bytes > free_bytes)
         return 0;
-    int i = buffer->head - buffer->data;
+    size_t i = buffer->head - buffer->data;
     buffer->head = &buffer->data[(i + bytes) % buffer->size];
     buffer->size_data += bytes;
     return 1;
@@ -66,7 +115,7 @@ int rbuf_bump_tail_noopt(rbuf_t buffer, size_t bytes)
 {
     if (bytes > buffer->size_data)
         return 0;
-    int i = buffer->tail - buffer->data;
+    size_t i = buffer->tail - buffer->data;
     buffer->tail = &buffer->data[(i + bytes) % buffer->size];
     buffer->size_data -= bytes;
 
@@ -94,6 +143,11 @@ int rbuf_bump_tail(rbuf_t buffer, size_t bytes)
 size_t rbuf_get_capacity(rbuf_t buffer)
 {
     return buffer->size;
+}
+
+size_t rbuf_get_max_capacity(rbuf_t buffer)
+{
+    return buffer->max_size;
 }
 
 size_t rbuf_bytes_available(rbuf_t buffer)

--- a/src/libnetdata/ringbuffer/ringbuffer.h
+++ b/src/libnetdata/ringbuffer/ringbuffer.h
@@ -6,7 +6,7 @@
 
 typedef struct rbuf *rbuf_t;
 
-rbuf_t rbuf_create(size_t size);
+rbuf_t rbuf_create(size_t size, size_t max_size);
 void rbuf_free(rbuf_t buffer);
 void rbuf_flush(rbuf_t buffer);
 
@@ -23,6 +23,7 @@ int rbuf_bump_tail(rbuf_t buffer, size_t bytes);
  * @returns total capacity of buffer in bytes (not free/used)
  */
 size_t rbuf_get_capacity(rbuf_t buffer);
+size_t rbuf_get_max_capacity(rbuf_t buffer);
 
 /* @param buffer related buffer instance
  * @returns count of bytes stored in the buffer
@@ -42,5 +43,7 @@ size_t rbuf_pop(rbuf_t buffer, char *data, size_t len);
 
 char *rbuf_find_bytes(rbuf_t buffer, const char *needle, size_t needle_bytes, int *found_idx);
 int rbuf_memcmp_n(rbuf_t buffer, const char *to_cmp, size_t to_cmp_bytes);
+
+int ringbuffer_unittest(void);
 
 #endif

--- a/src/libnetdata/ringbuffer/ringbuffer_internal.h
+++ b/src/libnetdata/ringbuffer/ringbuffer_internal.h
@@ -18,6 +18,7 @@ struct rbuf {
     char *end;
 
     size_t size;
+    size_t max_size;
     size_t size_data;
 };
 

--- a/src/streaming/stream-connector.c
+++ b/src/streaming/stream-connector.c
@@ -149,7 +149,7 @@ static int stream_connect_upgrade_prelude(RRDHOST *host __maybe_unused, struct s
         return 1;
     }
 
-    rbuf_t buf = rbuf_create(bytes);
+    rbuf_t buf = rbuf_create(bytes, bytes);
     rbuf_push(buf, http, bytes);
 
     http_parse_ctx ctx;


### PR DESCRIPTION
## Summary

- Add bounded opt-in growth to `rbuf_t` through `rbuf_create(size, max_size)`.
- Keep existing non-target buffers fixed-size by passing `max_size == size`.
- Allow ACLK inbound decoded MQTT staging (`buf_to_mqtt`) to grow from 128 KiB up to a hard 16 MiB cap.
- Map inbound receive-buffer cap hits to the existing message-too-big path instead of a generic WebSocket protocol error.
- Reset partial WebSocket frame and MQTT parser state across reconnects after cap hits.
- Add focused ringbuffer, WebSocket receive-path, and MQTT parser reset unittests.

## Root Cause

Large Cloud-to-agent MQTT/WebSocket payloads were staged in a fixed 128 KiB decoded MQTT ring buffer before the MQTT parser consumed them. When the decoded payload exceeded that staging capacity, the WebSocket receive path returned buffer-full, and the service loop treated it as a generic WebSocket protocol error. Reconnect after a mid-payload cap hit could also leave partial parser-owned MQTT allocations in the reused client object.

## Validation

- `cmake --build build-codex --target mqttwebsockets netdata -j 8`
- `build-codex/netdata -W ringbuffertest`
- `build-codex/netdata -W wsclienttest`
- `build-codex/netdata -W mqttngtest`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grows the ACLK inbound decoded MQTT buffer on demand and clamps its initial size to 16 MiB to handle large Cloud→agent payloads without false protocol errors. Also frees WebSocket RX scratch buffers on reset/destroy to prevent leaks after reconnects.

- **New Features**
  - Bounded-growth ring buffer via `rbuf_create(size, max_size)` (doubling up to a cap); exposes `rbuf_get_max_capacity()` and keeps capacity across `rbuf_flush()`.
  - `buf_to_mqtt` grows from 128 KiB up to 16 MiB; initial size is clamped to 16 MiB if a larger `buf_size` is requested; `buf_read`/`buf_write` remain fixed-size (pass `max_size == size`).
  - Unit tests: ringbuffer growth/cap; WS receive path growth/limits and initial-size clamp; MQTT parser reset; wired into `-W ringbuffertest`, `-W wsclienttest`, `-W mqttngtest`.

- **Bug Fixes**
  - Map inbound cap hits to `MQTT_WSS_ERR_MSG_TOO_BIG` instead of a generic WebSocket protocol error.
  - On reconnect/destroy, reset MQTT parser and free partial allocations (PUBLISH topic, SUBACK reason codes).
  - Release WebSocket RX scratch buffers (partial close reason, ping payload) on reset/destroy and after sending PONG.

<sup>Written for commit 1a2eaef74249689ac3b83ffb40d9590e3374c344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

