### PR TITLE
fix(aclk): prevent unbounded one-core CPU spins in the cloud-connection loops

### DIFF
--- a/src/aclk/https_client.c
+++ b/src/aclk/https_client.c
@@ -503,6 +503,11 @@ static int socket_write_all(https_req_ctx_t *ctx, char *data, size_t data_len) {
     ctx->poll_fd.events = POLLOUT;
 
     do {
+        // evaluate the overall request timeout every iteration, not only on a poll() timeout:
+        // otherwise a persistent poll()-ready-but-no-progress state spins the CPU unbounded
+        if (https_req_check_timedout(ctx))
+            return 2;
+
         int ret = poll(&ctx->poll_fd, 1, POLL_TO_MS);
         if (ret < 0) {
             netdata_log_error("ACLK: poll error");
@@ -533,6 +538,11 @@ static int ssl_write_all(https_req_ctx_t *ctx, char *data, size_t data_len) {
     ctx->poll_fd.events |= POLLOUT;
 
     do {
+        // evaluate the overall request timeout every iteration, not only on a poll() timeout:
+        // otherwise a persistent poll()-ready-but-no-progress state spins the CPU unbounded
+        if (https_req_check_timedout(ctx))
+            return 2;
+
         int ret = poll(&ctx->poll_fd, 1, POLL_TO_MS);
         if (ret < 0) {
             netdata_log_error("ACLK: poll error");
@@ -582,6 +592,11 @@ static https_client_resp_t read_parse_response(https_req_ctx_t *ctx) {
 
     ctx->poll_fd.events = POLLIN;
     do {
+        // evaluate the overall request timeout every iteration, not only on a poll() timeout:
+        // otherwise a persistent poll()-ready-but-no-progress state spins the CPU unbounded
+        if (https_req_check_timedout(ctx))
+            return HTTPS_CLIENT_RESP_TIMEOUT;
+
         ret = poll(&ctx->poll_fd, 1, POLL_TO_MS);
         if (ret < 0) {
             netdata_log_error("ACLK: poll error");

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -21,6 +21,14 @@
 #define PING_TIMEOUT    (60)  //Expect a ping response within this time (seconds)
 time_t ping_timeout = 0;
 
+// If mqtt_wss_service() keeps being entered with poll() reporting readiness but makes no
+// forward progress (no bytes moved and no clean poll() timeout) for this long, force a
+// reconnect. This breaks a no-progress one-core 100% CPU spin regardless of its cause (e.g.
+// a runtime poll()/SSL readiness quirk). The caller polls every ~1s and a healthy link
+// refreshes progress on every poll() timeout or byte moved, so this can only elapse during a
+// real spin, never on a quiet-but-healthy connection.
+#define MQTT_WSS_IO_WATCHDOG_SECS (2 * PING_TIMEOUT)
+
 #if (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110) && (SSLEAY_VERSION_NUMBER >= OPENSSL_VERSION_097)
 #include <openssl/conf.h>
 #endif
@@ -89,6 +97,10 @@ struct mqtt_wss_client_struct {
     int write_notif_pipe[2];
     struct pollfd poll_fds[2];
 
+// monotonic time of the last forward progress (bytes moved or a clean poll() timeout);
+// drives the no-progress watchdog in mqtt_wss_service() (see MQTT_WSS_IO_WATCHDOG_SECS)
+    usec_t last_io_progress_ut;
+
     SSL_CTX *ssl_ctx;
     SSL *ssl;
     int ssl_flags;
@@ -123,6 +135,8 @@ static void mws_connack_callback_ng(void *user_ctx, int code)
     switch(code) {
         case 0:
             client->mqtt_connected = 1;
+            // (re)start the no-progress watchdog clock for this fresh connection
+            client->last_io_progress_ut = now_monotonic_usec();
             break;
 //TODO manual labor: all the CONNACK error codes with some nice error message
         default:
@@ -678,6 +692,9 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
 #endif
 
     if (ret == 0) {
+        // a clean poll() timeout means the loop blocked rather than spun: that is forward
+        // progress for the watchdog (a healthy idle link reaches here at the caller cadence)
+        client->last_io_progress_ut = now_monotonic_usec();
         time_t now = now_realtime_sec();
         if (send_keepalive) {
             // otherwise we shortened the timeout ourselves to take care of
@@ -701,6 +718,31 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
     client->stats.time_keepalive += t2 - t1;
 #endif
 
+    // Tear the connection down if the socket reports an unrecoverable error, or if we keep
+    // being re-entered with poll() reporting readiness but making no forward progress (a
+    // spin). In either case drop so the outer loop reconnects, rather than burning a core
+    // indefinitely. Guarded to an established connection (the handshake has its own timeouts).
+    if (client->mqtt_connected) {
+        // POLLERR/POLLNVAL are unrecoverable -> drop now. POLLHUP is intentionally NOT an
+        // immediate drop: it can accompany still-readable data (a graceful close carrying a
+        // final frame), so we let it fall through to SSL_read below, which drains the
+        // remaining bytes and then reports the close cleanly (SSL_ERROR_ZERO_RETURN). A dead
+        // socket that keeps signalling readiness without progress is caught by the watchdog.
+        if (unlikely(client->poll_fds[POLLFD_SOCKET].revents & (POLLERR | POLLNVAL))) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "ACLK: socket poll() reported error (revents=0x%x); dropping connection",
+                   (unsigned)client->poll_fds[POLLFD_SOCKET].revents);
+            return MQTT_WSS_ERR_CONN_DROP;
+        }
+        if (unlikely(now_monotonic_usec() - client->last_io_progress_ut >
+                     (usec_t)MQTT_WSS_IO_WATCHDOG_SECS * USEC_PER_SEC)) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "ACLK: no I/O progress for %d seconds while poll() kept reporting readiness; "
+                   "dropping connection to break a CPU spin", MQTT_WSS_IO_WATCHDOG_SECS);
+            return MQTT_WSS_ERR_CONN_DROP;
+        }
+    }
+
     client->poll_fds[POLLFD_SOCKET].events = 0;
 
     if ((ptr = rbuf_get_linear_insert_range(client->ws_client->buf_read, &size))) {
@@ -711,6 +753,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
             client->stats.bytes_rx += ret;
             spinlock_unlock(&client->stat_lock);
             rbuf_bump_head(client->ws_client->buf_read, ret);
+            client->last_io_progress_ut = now_monotonic_usec();
         } else {
             int errnobkp = errno;
             ret = SSL_get_error(client->ssl, ret);
@@ -788,6 +831,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
             client->stats.bytes_tx += ret;
             spinlock_unlock(&client->stat_lock);
             rbuf_bump_tail(client->ws_client->buf_write, ret);
+            client->last_io_progress_ut = now_monotonic_usec();
         } else {
             int errnobkp = errno;
             ret = SSL_get_error(client->ssl, ret);

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -689,20 +689,23 @@ static void aclk_synchronization_event_loop(void *arg)
                 worker_is_busy(opcode);
 
             // pending_queries is an accounting alias for the number of queries held in
-            // aclk_query_execute->JudyL. If it ever drifts above the real queue length, the
-            // NOOP -> ACLK_QUERY_EXECUTE rewrite below fires every iteration with nothing to
-            // drain and the inner UV_RUN_NOWAIT loop never blocks -> a permanent, silent,
-            // one-core 100% CPU spin that cannot self-recover. Reconcile the alias against the
-            // Judy array (the source of truth) before it can gate the rewrite, so any such
-            // drift heals immediately instead of becoming a lockup. The field trigger is
-            // unproven (suspected Judy/memory corruption on some runtimes); log it if seen.
-            if (opcode == ACLK_DATABASE_NOOP && pending_queries) {
+            // aclk_query_execute->JudyL. Drift in EITHER direction is harmful:
+            //  - too high: the NOOP -> ACLK_QUERY_EXECUTE rewrite below fires every iteration
+            //    with nothing to drain and the inner UV_RUN_NOWAIT loop never blocks -> a
+            //    silent one-core 100% CPU spin that cannot self-recover;
+            //  - too low (e.g. 0 while the queue still holds work): the rewrite never fires and
+            //    those queries stall until an unrelated enqueue happens to nudge execution.
+            // Reconcile the alias against the Judy array (the source of truth) on every idle
+            // pass so drift heals immediately instead of becoming a lockup or a stalled queue.
+            // The field trigger is unproven (suspected Judy/memory corruption on some
+            // runtimes); log it if seen.
+            if (opcode == ACLK_DATABASE_NOOP) {
                 size_t queued = (size_t)JudyLCount(aclk_query_execute->JudyL, 0, -1, PJE0);
                 if (unlikely(queued != pending_queries)) {
                     nd_log_limit_static_global_var(erl, 1, 0);
                     nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
                                  "ACLK: pending query counter (%zu) disagrees with the queued-query count (%zu); "
-                                 "reconciling to prevent a CPU spin (possible memory corruption)",
+                                 "reconciling to prevent a CPU spin or a stalled queue (possible memory corruption)",
                                  pending_queries, queued);
                     pending_queries = queued;
                 }

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -688,6 +688,26 @@ static void aclk_synchronization_event_loop(void *arg)
             if(likely(opcode != ACLK_DATABASE_NOOP && opcode != ACLK_QUERY_EXECUTE))
                 worker_is_busy(opcode);
 
+            // pending_queries is an accounting alias for the number of queries held in
+            // aclk_query_execute->JudyL. If it ever drifts above the real queue length, the
+            // NOOP -> ACLK_QUERY_EXECUTE rewrite below fires every iteration with nothing to
+            // drain and the inner UV_RUN_NOWAIT loop never blocks -> a permanent, silent,
+            // one-core 100% CPU spin that cannot self-recover. Reconcile the alias against the
+            // Judy array (the source of truth) before it can gate the rewrite, so any such
+            // drift heals immediately instead of becoming a lockup. The field trigger is
+            // unproven (suspected Judy/memory corruption on some runtimes); log it if seen.
+            if (opcode == ACLK_DATABASE_NOOP && pending_queries) {
+                size_t queued = (size_t)JudyLCount(aclk_query_execute->JudyL, 0, -1, PJE0);
+                if (unlikely(queued != pending_queries)) {
+                    nd_log_limit_static_global_var(erl, 1, 0);
+                    nd_log_limit(&erl, NDLS_DAEMON, NDLP_WARNING,
+                                 "ACLK: pending query counter (%zu) disagrees with the queued-query count (%zu); "
+                                 "reconciling to prevent a CPU spin (possible memory corruption)",
+                                 pending_queries, queued);
+                    pending_queries = queued;
+                }
+            }
+
             // Check if we have pending commands to execute
             if (opcode == ACLK_DATABASE_NOOP && pending_queries && config->aclk_queries_running < query_thread_count) {
                 opcode = ACLK_QUERY_EXECUTE;


### PR DESCRIPTION
## Problem

Two independent ACLK loops can peg one CPU core at 100% indefinitely (until a
manual restart) while the cloud link still looks healthy. Both were diagnosed on a
standalone Windows Server agent.

### 1. ACLKSYNC dispatch loop (`sqlite_aclk.c`)

`aclk_synchronization_event_loop()` keeps a `pending_queries` counter as an alias for
the number of queries held in `aclk_query_execute->JudyL`. If that counter ever drifts
above the actual queue length, the `ACLK_DATABASE_NOOP -> ACLK_QUERY_EXECUTE` rewrite
fires on every iteration over an empty queue, and the inner `uv_run(UV_RUN_NOWAIT)`
loop never blocks — a silent, work-free 100% CPU spin that cannot self-recover (the
spinning thread is even accounted idle, because `worker_is_busy()` excludes
`ACLK_QUERY_EXECUTE`).

**Fix:** before the rewrite can use it, reconcile `pending_queries` against
`JudyLCount()` (the source of truth) and log the discrepancy (rate-limited) if they
disagree. Inert when they match; self-heals any drift regardless of its origin.

### 2. `mqtt_wss_service()` and the `https_client.c` poll loops

When `poll()` keeps reporting readiness but no bytes/frames make progress (e.g. a
runtime `poll()`/SSL readiness quirk), the only escapes were gated behind `poll() == 0`
and therefore never fired, so the loop spins.

**Fix:**

- `mqtt_wss_service()`: add a per-client no-progress watchdog (drop + reconnect after
  `2 * PING_TIMEOUT`, refreshed on a clean `poll()` timeout and on every byte moved,
  seeded at CONNACK, gated to an established connection), plus a terminal
  socket-`revents` check on `POLLERR | POLLNVAL`. `POLLHUP` intentionally falls through
  to `SSL_read` so a graceful close drains its final frame before the clean
  `SSL_ERROR_ZERO_RETURN`.
- `https_client.c`: evaluate the existing request-timeout check at the top of all three
  poll loops (`socket_write_all`, `ssl_write_all`, `read_parse_response`), not only on
  `poll() == 0`.

## Notes

- All changes are additive and inert on healthy paths, single-threaded where they touch
  state, and platform-independent (no Windows-only special-casing).
- The exact field trigger for the counter drift is not yet pinned down (suspected
  memory/Judy corruption on the MSYS2/Cygwin runtime); the reconcile is defense-in-depth
  that ends the spin for any cause and logs the condition so a recurrence is captured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unbounded one-core CPU spins and stalled ACLK queues by fixing two cloud-connection loops. The agent now self-recovers instead of burning CPU when poll reports readiness without progress.

- **Bug Fixes**
  - ACLKSYNC dispatch loop: on every idle pass, reconcile `pending_queries` with `JudyLCount()` before any rewrite; rate-limit a warning and self-correct drift to prevent both spins (over-count) and stalled queues (under-count).
  - `mqtt_wss_service()`: add a per-client no-progress watchdog (drop/reconnect after `2 * PING_TIMEOUT`) and drop on `POLLERR | POLLNVAL`; `POLLHUP` still drains via `SSL_read`.
  - `https_client.c`: check the overall request timeout on every iteration in `socket_write_all`, `ssl_write_all`, and `read_parse_response` to break spin states.

<sup>Written for commit 975b28147c6b9601402cd2899a6788ffd192e503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

