### PR TITLE
docs(skills): add static-binary build skill; fix Cloud log-query source filtering & time units

### DIFF
--- a/.agents/skills/project-build-static-binary/SKILL.md
+++ b/.agents/skills/project-build-static-binary/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: project-build-static-binary
+description: Build a static, self-extracting Netdata installer (`netdata-<arch>-latest.gz.run`) from this checkout for x86_64, aarch64, armv6l, or armv7l. Use when the user asks to build, produce, package, or test a static binary, makeself installer, `.gz.run` artifact, or "static install" of Netdata; when verifying a PR by deploying it to a Linux machine without a native build toolchain; when reproducing a CI static-builder issue locally. Covers the docker-based build flow under `packaging/makeself/`, mandatory pre-flight checks (submodule init, fresh `netdata/static-builder:v1` image), the 18 ordered jobs the build runs, output artifact layout, the `artifacts/cache/` reuse model, cross-arch QEMU caveats, debug builds, common failures with their fixes, and how to copy/verify the artifact on a target host.
+type: project
+---
+
+# Building a static Netdata binary
+
+The static build produces a self-extracting installer (`netdata-<arch>-latest.gz.run`) that runs on any 64-bit Linux without a native toolchain or system libraries. The output installs under `/opt/netdata`. Use it to test a PR on a target system that lacks build tools (RHEL, old distros, embedded), to ship a prebuilt to a customer host, or to reproduce CI behavior locally.
+
+This skill captures the full local build flow plus the gotchas that block first-time builds. Read top to bottom on first use; the [Common failures](#common-failures) section exists because every one of them has burned a build in this repo.
+
+## TL;DR — x86_64 native
+
+```bash
+# 1. Pre-flight (mandatory)
+docker pull netdata/static-builder:v1     # refresh the cached image — see Gotcha #2
+git submodule update --init --recursive   # populate vendored sources — see Gotcha #1
+
+# 2. Build (~22-25 min cold, ~10-15 min on cache hit, on a 24-core host)
+./packaging/makeself/build-static.sh x86_64
+
+# 3. Output
+ls -la artifacts/
+# artifacts/netdata-x86_64-latest.gz.run        ~190 MB, ready to copy to any 64-bit Linux
+# artifacts/netdata-x86_64-vX.Y.Z-N-nightly.gz.run
+# artifacts/netdata-latest.gz.run               (x86_64 only — alias of the above)
+# artifacts/netdata-vX.Y.Z-N-nightly.gz.run     (x86_64 only — alias)
+```
+
+For debug builds: `./packaging/makeself/build-static.sh x86_64 debug`.
+
+## What you actually run
+
+The orchestrator is `packaging/makeself/build-static.sh`, which:
+
+1. Translates the architecture name (`x86_64`, `aarch64`, `armv6l`, `armv7l`) to a docker `--platform` value via `packaging/makeself/uname2platform.sh`.
+2. Sets per-arch tuning flags (`packaging/makeself/build-static.sh:27-56`):
+   - `x86_64` → `-march=x86-64` baseline (`x86-64-v2` equivalent), Nehalem-v2 QEMU CPU, `GOAMD64=v1`.
+   - `aarch64` → `-march=armv8-a`, Cortex-A53, `GOARM64=v8.0`.
+   - `armv7l` → `-march=armv7-a`, Cortex-A7, `GOARM=7`.
+   - `armv6l` → `-march=armv6zk -mtune=arm1176jzf-s`, ARM1176, `GOARM=6`.
+3. Installs `binfmt`/QEMU emulation if cross-arch and not already registered.
+4. Pulls `netdata/static-builder:v1` if missing locally; removes a mismatched-platform image first.
+5. Bind-mounts `$(pwd)` into the container at `/netdata` and runs `/netdata/packaging/makeself/build.sh` inside it.
+
+The container then runs `packaging/makeself/run-all-jobs.sh`, which executes `packaging/makeself/jobs/*.sh` in lexical order:
+
+| # | Job | What it does |
+|---|-----|--------------|
+| 00 | `prepare-destination` | Lays out `/opt/netdata/{bin,usr,sbin,...}` symlinks |
+| 10 | `libucontext.install` | Builds bundled libucontext (musl context-switch fallback) |
+| 11 | `openssl.install` | Builds OpenSSL 3.6.0 statically |
+| 20 | `libnetfilter_acct.install` | Builds libnetfilter_acct statically |
+| 20 | `libunwind.install` | Builds libunwind statically |
+| 30 | `curl.install` | Builds curl + libcurl statically |
+| 40 | `bash.install` | Builds bash statically |
+| 50 | `ioping.install` | Builds ioping statically |
+| 70 | `netdata-git.install` | Builds Netdata itself (Rust crates + C/CMake + Go plugins) and installs into `/opt/netdata` |
+| 71 | `install-type` | Stamps `.install-type` so the post-installer knows it's a static install |
+| 72 | `conf-fixup` | Strips machine-specific configuration and sample files |
+| 80 | `netdata-static-check` | Verifies key binaries are statically linked |
+| 81 | `netdata-runtime-check` | Boots `/opt/netdata/bin/netdata`, waits for `localhost:19999`, checks `/api/v1/info` |
+| 82 | `cpu-arch-check` | Verifies the produced binaries match the target arch baseline |
+| 89 | `buildinfo.install` | Writes `/opt/netdata/share/netdata/buildinfo.txt` |
+| 90 | `prepare-archive-source` | Copies post-installer scripts into the install tree |
+| 91 | `copy-ca-certificates` | Bundles a CA bundle |
+| 98 | `create-archive` | Runs `makeself.sh --gzip --complevel 9 --notemp --needroot` to build the `.gz.run` |
+| 99 | `copy-archives` | Renames the archive to `netdata-<arch>-<version>.gz.run` and copies aliases |
+
+Source files: `packaging/makeself/build-static.sh`, `packaging/makeself/build.sh`, `packaging/makeself/run-all-jobs.sh`, `packaging/makeself/functions.sh`, `packaging/makeself/jobs/`.
+
+## Pre-flight (DO NOT SKIP)
+
+These two checks save you a wasted 20+ min build.
+
+### Gotcha #1: submodules must be initialized
+
+The build configures with CMake against vendored sources at:
+
+- `src/aclk/aclk-schemas/`
+- `src/collectors/debugfs.plugin/libsensors/vendored/`
+
+If either is empty, CMake aborts after ~2 min with:
+
+```
+Cannot find source file: vendored/lib/access.c
+No SOURCES given to target: vendored_libsensors
+ABORTED  Failed to configure Netdata sources.
+```
+
+A fresh `git clone` does **not** populate submodules. A worktree created from a fork that hasn't initialized submodules does not either. Always run before your first build in a working tree:
+
+```bash
+git submodule update --init --recursive
+```
+
+Verify with `git submodule status` — every line must start with a space (the leading `-` means uninitialized).
+
+### Gotcha #2: refresh the cached docker image
+
+The build pulls `netdata/static-builder:v1` only if no local image exists. If you have an old cached image (the project published a v1 in 2023 based on Alpine 3.18, then refreshed it in 2026 with Alpine 3.23 + coreutils), the build fails inside `packaging/makeself/functions.sh:84` with:
+
+```
+sha256sum: unrecognized option: c
+SHA256 verification of tar file libnetfilter_acct-1.0.3.tar.bz2 failed (rc=1)
+expected: <hash>, got <same-hash>
+```
+
+Why: `functions.sh:84` runs `sha256sum --c --status` (long-option form). BusyBox's sha256sum (Alpine without `coreutils`) does not accept long options, so it fails even though the actual hash matches. The fresh image installs `coreutils`, which symlinks `/usr/bin/sha256sum` to GNU coreutils and accepts the long form.
+
+Fix: always re-pull before a build session:
+
+```bash
+docker pull netdata/static-builder:v1
+```
+
+The pull is a no-op if your cache is already up to date.
+
+## Output artifacts
+
+Job `99-copy-archives.sh` writes to `artifacts/` (gitignored, host-side, owned by your user):
+
+```
+artifacts/
+├── netdata-x86_64-latest.gz.run            # symlink/alias to the latest
+├── netdata-x86_64-v2.10.0-171-nightly.gz.run
+├── netdata-latest.gz.run                   # x86_64 only — generic alias
+├── netdata-v2.10.0-171-nightly.gz.run      # x86_64 only — generic alias
+└── cache/                                  # build cache, see below
+```
+
+For non-x86_64 builds, only the two `netdata-<arch>-*` files are produced (`packaging/makeself/jobs/99-copy-archives.sh:25-30`).
+
+Verify a build:
+
+```bash
+ls -la artifacts/
+sha256sum artifacts/netdata-x86_64-latest.gz.run
+
+# What's inside (read-only inspection, does not run the installer)
+sh artifacts/netdata-x86_64-latest.gz.run --info
+sh artifacts/netdata-x86_64-latest.gz.run --list | head
+```
+
+Each `.gz.run` is a `makeself` archive: a shell prefix that extracts the gzipped tar embedded after it. Run it as root on the target to install.
+
+## Build cache
+
+`artifacts/cache/<arch>/` holds the compiled third-party deps (openssl, curl, bash, libunwind, libnetfilter_acct, ioping) keyed by their pinned source versions in `packaging/makeself/bundled-packages.version`. The fetch logic is in `packaging/makeself/functions.sh` (`fetch()` + `cache_key()`).
+
+Implications:
+
+- First build: ~22-25 min on a 24-core host (most time = third-party compile + Rust crate compile + LTO link of the C plugins).
+- Cache hit: ~10-15 min (skips the third-party deps; only the netdata sources rebuild).
+- The cache survives `git checkout` and `git clean -fd` (it's under the gitignored `artifacts/`).
+- Bumping a version in `bundled-packages.version` invalidates that one entry — the rest still reuse.
+- To force a clean build: `rm -rf artifacts/`.
+
+## Cross-architecture builds (aarch64, armv7l, armv6l)
+
+```bash
+./packaging/makeself/build-static.sh aarch64
+./packaging/makeself/build-static.sh armv7l
+./packaging/makeself/build-static.sh armv6l
+```
+
+The script auto-installs QEMU binfmt handlers via `tonistiigi/binfmt:master` if not already registered (`packaging/makeself/build-static.sh:60-62`). Cross-arch builds:
+
+- Run all C/Rust/Go compilation under QEMU emulation — expect 4-8× slowdown vs native.
+- Are CPU-bound, not network-bound — the source download is one-time.
+- Can fail in ways native builds do not (e.g. Rust LTO under QEMU has historically OOMed; libbpf BPF skeleton generation has hit qemu syscall edge cases). When you see a failure that isn't on x86_64 native, suspect QEMU first.
+
+`SKIP_EMULATION=1` is set automatically when the host already has a `binfmt_misc` entry for the target arch (e.g. on a CI runner with persistent qemu).
+
+## Debug builds
+
+```bash
+./packaging/makeself/build-static.sh x86_64 debug
+```
+
+Sets `NETDATA_BUILD_WITH_DEBUG=1` (`packaging/makeself/build.sh:9-22`), which disables optimization and includes debug symbols. Result: larger archive (~2× size), slower runtime, useful for valgrind/gdb. The `README.md` in `packaging/makeself/` documents valgrind invocation.
+
+## Common failures
+
+| Symptom | Job | Cause | Fix |
+|---------|-----|-------|-----|
+| `Cannot find source file: vendored/lib/access.c` | 70 (CMake configure) | Submodules not initialized | `git submodule update --init --recursive` |
+| `sha256sum: unrecognized option: c` then `expected: X, got X` | 11 / 20 / 30 / 40 / 50 | Stale `static-builder:v1` (Alpine 3.18, no coreutils) | `docker pull netdata/static-builder:v1` |
+| `No cached copy of build directory for X found, fetching sources instead.` (every run) | any third-party | `artifacts/cache/` removed or arch dir missing | Normal on first build; persists for the next run |
+| `Could not find a usable OCI runtime` | n/a | Neither docker nor podman in `$PATH` | Install one |
+| `Waiting for netdata on localhost:19999 ...` hangs forever | 81 (runtime check) | Built binary segfaulted at startup | Read end of `81-netdata-runtime-check.sh` log; reproduce locally with the install path |
+| `not statically linked` warning | 80 (static check) | A new dep introduced a dynamic link | Audit `ldd` of the built binary; check `CMakeLists.txt` for `target_link_libraries` adding a shared lib |
+| OOM kill mid-Rust compile under QEMU | 70 | QEMU + Rust LTO is memory-hungry | Add swap; reduce `-j` via `PROCESSORS` env |
+
+The build script exits with `Build failed.` on any job failure (`packaging/makeself/build.sh:44-52`). If `DEBUG_BUILD_INFRA=1` is set in the environment, the container drops to a `bash` shell instead of exiting — useful when you want to inspect the in-progress install tree.
+
+## Watching a long-running build
+
+Background launch + log tail pattern:
+
+```bash
+LOG=/tmp/netdata-build-$(date +%s).log
+nohup ./packaging/makeself/build-static.sh x86_64 > "$LOG" 2>&1 &
+echo $! > /tmp/netdata-build.pid
+
+# Progress
+grep -E '^ --- running' "$LOG"          # job-level milestones
+tail -f "$LOG"                          # streaming output
+docker stats --no-stream                # CPU/RAM of the running container
+```
+
+Indicators the build is alive (output buffering can stall the log for minutes during heavy compile):
+
+- `ps -eo pid,pcpu,comm --sort=-pcpu | head` shows `rustc`, `cc1`, `lto1-ltrans` near 50-70% each.
+- `docker stats` shows the static-builder container at hundreds of % CPU.
+- The container's working set in `docker stats` keeps changing.
+
+## Deploying to a target
+
+```bash
+# Copy
+scp artifacts/netdata-x86_64-latest.gz.run target-host:/tmp/
+
+# Install (on the target, as root)
+ssh target-host
+sudo sh /tmp/netdata-x86_64-latest.gz.run -- --auto-update
+# installer flags after the bare `--`; common: --dont-start-it, --disable-telemetry,
+# --claim-token <T> --claim-rooms <R>, --no-updates
+```
+
+The installer always installs into `/opt/netdata` (hard-coded; `--target` would change it but the in-archive paths assume `/opt/netdata`, do not override).
+
+Inspecting what's inside without installing:
+
+```bash
+sh artifacts/netdata-x86_64-latest.gz.run --info     # makeself metadata
+sh artifacts/netdata-x86_64-latest.gz.run --list     # full file manifest
+sh artifacts/netdata-x86_64-latest.gz.run --target /tmp/nd-extract --noexec --keep
+```
+
+## How to extend this skill
+
+When you discover a new failure mode, an arch-specific quirk, or a workflow that's worth preserving, add a how-to under `how-tos/` and link it from `how-tos/INDEX.md`. Keep `SKILL.md` tight; push detail into how-tos. The catalog is live — every assistant who solves a non-trivial build problem must commit the recipe before moving on.
+
+## Source-of-truth pointers
+
+- `packaging/makeself/README.md` — high-level user-facing doc (architectures, valgrind notes).
+- `packaging/makeself/build-static.sh` — host-side launcher, arch matrix, docker invocation.
+- `packaging/makeself/build.sh` — in-container entry; debug-flag parsing.
+- `packaging/makeself/run-all-jobs.sh` — job runner.
+- `packaging/makeself/functions.sh` — `fetch()`, `cache()`, `cache_key()`, `progress()`, `run()` helpers.
+- `packaging/makeself/jobs/*.sh` — the 18 ordered build steps.
+- `packaging/makeself/bundled-packages.version` — pinned versions of openssl, curl, bash, libunwind, libnetfilter_acct, ioping.
+- `packaging/makeself/install-alpine-packages.sh` — the package list the static-builder docker image is built from (used when refreshing the image, not on every build).
+- `packaging/makeself/uname2platform.sh` — arch → docker `--platform` translation.
+- `packaging/makeself/makeself.sh`, `makeself-header.sh` — vendored makeself archive builder.

--- a/.agents/skills/project-build-static-binary/how-tos/INDEX.md
+++ b/.agents/skills/project-build-static-binary/how-tos/INDEX.md
@@ -1,0 +1,13 @@
+# How-tos catalog: project-build-static-binary
+
+Live catalog. When you solve a static-build problem that takes more than a couple of wrapper calls or that future-you would not reconstruct in 30 seconds from `SKILL.md`, write a how-to here and link it below before closing the task.
+
+## Conventions
+
+- One how-to per file: `how-tos/<verb>-<noun>.md` (e.g. `recover-from-stale-image.md`).
+- Lead with the symptom (what the user/log shows). End with the fix as a copy/paste recipe.
+- Cite `file:line` for every claim about the build's behavior — the build scripts evolve, and undocumented "I remember it worked like X" rots fast.
+
+## Catalog
+
+(empty — populate as you go)

--- a/docs/netdata-ai/skills/query-netdata-agents/query-logs.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/query-logs.md
@@ -40,7 +40,7 @@ agents_query_agent \
     --host "$AGENT_EVENTS_HOSTNAME:19999" \
     --machine-guid "$AGENT_EVENTS_MACHINE_GUID" \
     POST '/api/v3/function?function=systemd-journal' \
-    '{"after":-3600,"before":0,"last":50,"direction":"backward","__logs_sources":"agent-events"}'
+    '{"after":-3600,"before":0,"last":50,"direction":"backward","selections":{"__logs_sources":["agent-events"]}}'
 ```
 
 The wrapper minted/cached the bearer internally; stdout is the
@@ -59,17 +59,23 @@ agents_query_agent \
 ```
 
 Reads the `info=true` response and lists the `__logs_sources`
-widget options the agent currently exposes. The `name`+`id` of
-each option is what you pass back as the `__logs_sources` value.
+widget options the agent currently exposes. Pass the `id` of each
+option you want back inside the `selections` object as an array --
+`{"selections":{"__logs_sources":["<id>", ...]}}`. A top-level
+`__logs_sources` key is silently ignored by the agent's JSON
+parser (see the Cloud doc's "Selecting log sources" section).
 
 ## Limits and gotchas (single-agent-specific)
 
 - **Single-host only.** The agent answers for itself; for fleet
   queries, use the Cloud-side path or aggregate per-agent
   responses client-side.
-- **Time bounds**: negative values are seconds-relative-to-now.
-  Positive values are unix-microseconds (NOT seconds, NOT
-  milliseconds). Mixing units is the most common bug.
+- **Time bounds**: `after`/`before` are in **seconds** (the agent
+  parses them into `after_s`/`before_s`). Negative = relative
+  seconds from now; positive = absolute Unix seconds. `anchor` and
+  the row timestamps are in **microseconds** -- a different unit, so
+  do not reuse a row timestamp as a positive `after`/`before`.
+  Mixing the two units is the most common bug.
 - **Slow queries**: large windows + wide facets can take seconds.
   Bump `timeout` in the body to 60000 or higher when the default
   10-second cloud-proxy default isn't relevant (the agent itself

--- a/docs/netdata-ai/skills/query-netdata-cloud/query-logs.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/query-logs.md
@@ -73,15 +73,15 @@ agent currently accepts.
 | Key | Type | Purpose |
 |---|---|---|
 | `info` | bool | Discovery only; do not combine with a real query |
-| `after` | int | Unix ms timestamp; lower bound. Negative = relative seconds from `before` |
-| `before` | int | Unix ms timestamp; upper bound. Negative = relative seconds from now |
+| `after` | int | Lower time bound, in **seconds** (struct field `after_s`). Positive = absolute Unix seconds; negative = relative seconds from `before`. NOT ms, NOT µs |
+| `before` | int | Upper time bound, in **seconds** (struct field `before_s`). Positive = absolute Unix seconds; negative = relative seconds from now (`0` = now) |
 | `last` | int | Page size (rows). Default 200 |
 | `direction` | string | `backward` (default; newest first) or `forward` |
-| `anchor` | int | Per-row cursor for pagination |
-| `query` | string | Free-text search across journal fields |
+| `anchor` | int | Per-row cursor for pagination, in **microseconds** (matches the row timestamp values, which are µs — a different unit from `after`/`before`) |
+| `query` | string | Free-text search (FTS) across indexed fields |
 | `facets` | string[] | Field names to group by (returns counts per value) |
 | `histogram` | string | Field name to bucket-by-time |
-| `__logs_sources` | string | Source selector. Common values: `all`, `all-local-logs`, `all-local-system-logs`, `all-local-user-logs`, `all-local-namespaces`, plus per-namespace strings like `<namespace-name>` for a specific journal namespace |
+| `selections` | object | **The only working way to filter by source or by field** in the JSON body. `{"__logs_sources":[...]}` selects sources; `{"FIELD":[...]}` filters a facet. See [Selecting log sources](#selecting-log-sources-info--selections) — passing `__logs_sources` as a top-level key is silently ignored |
 | `if_modified_since` | int | Tail mode -- skip if no new data |
 | `data_only` | bool | Skip metadata for a faster query |
 | `sampling` | int | Cap on rows scanned when search would otherwise be huge |
@@ -91,6 +91,87 @@ agent currently accepts.
 
 `info=true` returns the current authoritative list; rely on it, not
 this table, when in doubt.
+
+---
+
+## Selecting log sources (`info` → `selections`)
+
+This is the single most important mechanism for log queries, and it
+works **identically for every log Function** (`systemd-journal`,
+`windows-events`, `otel-logs`, and any other built on the shared
+libnetdata logs-query library `LQS`). Only the **source id values**
+differ per Function; the request shape is the same.
+
+The agent parses the source selector from the POST body **only** inside
+the `selections` object, as an **array**
+(`<repo>/src/libnetdata/facets/logs_query_status.h:329-410`,
+`lqs_request_parse_json_payload`). There is no top-level
+`__logs_sources` key in the JSON parser, so:
+
+```json
+{ "__logs_sources": "Netdata/Daemon" }          // ❌ silently IGNORED → queries ALL sources
+{ "selections": { "__logs_sources": ["Netdata/Daemon"] } }   // ✅ filters server-side
+```
+
+> The top-level / function-string form `source:<id>` only applies to
+> the on-agent function-string transport. Over the Cloud REST API the
+> body is JSON, so you MUST use `selections.__logs_sources` (an array).
+
+### Step 1 — discover the valid source ids with `info`
+
+The `info=true` response contains a `__logs_sources` widget. Each
+option carries the `id` you pass, plus its size, entry count, and time
+coverage (retention) — invaluable for picking the right source and
+knowing how far back data exists:
+
+```bash
+curl ... -d '{"info":true}' \
+ | jq -r '.. | objects | select(.id=="__logs_sources") | .options[]
+          | "\(.id)\t\(.info)"'
+# windows-events example output:
+#   All-Of-Netdata    4 channels, 3.08MiB, covering 3d 19h, 1.94K entries, last 2026-06-26T04:30:44Z
+#   Netdata/Daemon    1 channel, 1028KiB, covering 3d 19h, 789 entries, last 2026-06-26T04:28:37Z
+#   Netdata/Health    ...
+# systemd-journal ids look different, e.g. all, all-local-system-logs,
+# all-local-namespaces, <namespace-name> — always read them from info.
+```
+
+`__logs_sources` is a **multiselect**: pass one or more ids in the
+array; selecting any source resets the default (which is "all
+sources") so you get exactly the union you asked for
+(`logs_query_status.h:407-410`).
+
+### Step 2 — query with the source filter
+
+```bash
+read -r -d '' PAYLOAD <<'EOF'
+{
+  "after": -3600, "before": 0, "last": 200, "data_only": true,
+  "selections": { "__logs_sources": ["Netdata/Daemon"] }
+}
+EOF
+curl -sS -X POST -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  "https://app.netdata.cloud/api/v2/nodes/$NODE/function?function=windows-events" \
+  -d "$PAYLOAD"
+```
+
+### Why server-side source filtering matters (cost + robustness)
+
+- It is **server-side**: the agent reads only the selected channels /
+  namespaces. An unfiltered query reads *everything*, so on a host
+  where one co-located source is noisy (e.g. a Windows box where
+  `Microsoft-Windows-SystemDataArchiver`/SRUM emits ~10 events/sec),
+  the result is dominated by noise — a 500-row page can span under a
+  minute, and a wide unfiltered window can **time out or make the
+  plugin exit before responding**.
+- Combine with **`data_only:true`** to skip facet-count and histogram
+  aggregation. That aggregation is the usual cause of timeouts on wide
+  windows; `data_only` makes otherwise-failing historical queries
+  succeed.
+- Net recipe for reliable historical pulls: **filter the source via
+  `selections`** + **`data_only:true`** + a bounded `last`. Then a
+  single query can cover a long window cheaply.
 
 ---
 
@@ -191,10 +272,10 @@ already-sliced subset.
 ### Reserved keys inside `selections`
 
 - `__logs_sources` (per `LQS_PARAMETER_SOURCE`,
-  `logs_query_status.h:407`) is treated as the source-type
-  filter (e.g. `all-local-namespaces`, `<namespace-name>`).
-  Using it inside `selections` is equivalent to setting the
-  top-level `__logs_sources` parameter.
+  `logs_query_status.h:407`) is the source-type filter — pass the
+  source ids from `info` as an array. This is the **only** way to
+  scope sources in the JSON body; a top-level `__logs_sources` key is
+  not parsed. See [Selecting log sources](#selecting-log-sources-info--selections).
 - `query` inside `selections` is ignored
   (`logs_query_status.h:398`); use the top-level `query`.
 
@@ -205,8 +286,8 @@ already-sliced subset.
   "after":  -86400,
   "before": 0,
   "last":   500,
-  "__logs_sources": "agent-events",
   "selections": {
+    "__logs_sources":   ["agent-events"],
     "AE_AGENT_HEALTH":  ["crash-first", "crash-loop", "crash-repeated", "crash-entered"],
     "AE_AGENT_VERSION": ["v2.10.0", "v2.10.0-135-nightly"]
   },
@@ -225,7 +306,7 @@ the substring `deadlock`. Index-friendly even on a
 {
   "after":  -604800,
   "before": 0,
-  "__logs_sources": "agent-events",
+  "selections": { "__logs_sources": ["agent-events"] },
   "query": "SIGSEGV"
 }
 ```
@@ -251,7 +332,7 @@ read -r -d '' PAYLOAD <<EOF
   "before": 0,
   "last":   50,
   "direction": "backward",
-  "__logs_sources": "${NAMESPACE}"
+  "selections": { "__logs_sources": ["${NAMESPACE}"] }
 }
 EOF
 
@@ -276,7 +357,7 @@ read -r -d '' PAYLOAD <<'EOF'
   "query":  "OOM",
   "histogram": "PRIORITY",
   "facets":    ["_SYSTEMD_UNIT", "PRIORITY"],
-  "__logs_sources": "all-local-system-logs"
+  "selections": { "__logs_sources": ["all-local-system-logs"] }
 }
 EOF
 
@@ -299,7 +380,7 @@ read -r -d '' PAYLOAD <<EOF
   "anchor":    ${ANCHOR},
   "direction": "forward",
   "last":      200,
-  "__logs_sources": "all-local-logs"
+  "selections": { "__logs_sources": ["all-local-logs"] }
 }
 EOF
 
@@ -314,16 +395,21 @@ curl -sS -X POST \
 
 ## Limits and gotchas
 
-- **Time bounds are unix-microseconds**, not seconds, when given as
-  positive integers. Negative integers are relative seconds (`-3600`
-  = "one hour ago relative to `before`"). Mixing units is the most
-  common bug.
-- **Default cloud timeout is 120 s**, but very large queries
-  (thousands of rows over weeks of data) can hit it. Narrow the
-  window or use `sampling`.
-- **`__logs_sources` is required** to scope to a specific journal
-  namespace. Without it, the query targets all-local-logs which on a
-  busy host can be hundreds of GB.
+- **`after`/`before` are in SECONDS** (struct fields `after_s` /
+  `before_s`, `logs_query_status.h:345-346`): positive = absolute Unix
+  seconds, negative = relative seconds (`before:-3600` = "one hour
+  ago"; `before:0` = now). **`anchor` and the row timestamps are in
+  microseconds** — do not reuse a row timestamp as a positive
+  `after`/`before`. Mixing the two units is the most common bug.
+- **Default cloud timeout is 120 s.** Wide windows that compute facets
+  or a histogram are the usual offenders. Add **`data_only:true`** to
+  skip that aggregation, **filter the source via `selections`**, and/or
+  use `sampling` — see [Selecting log sources](#selecting-log-sources-info--selections).
+  If a query still "exits before responding", narrow the window further.
+- **Always scope the source via `selections.__logs_sources`.** With no
+  source filter the query targets every source, which on a busy host
+  can be hundreds of GB (Linux) or dominated by a noisy channel
+  (Windows) — slow, and prone to timeouts.
 - **Permission**: the cloud token must have a role that includes
   log-read access (function tags include `logs`). `scope:all` works;
   `scope:grafana-plugin` does NOT.
@@ -334,8 +420,10 @@ curl -sS -X POST \
 
 ## Discovering a journal namespace
 
-If the host runs `journalctl --namespace=<name>`, the same name is
-the value of `__logs_sources`. The agent's `info=true` response
-enumerates all visible sources under `accepted_params._logs_sources`
-or under a `required_params` widget -- inspect that widget's
-`options[]` to learn which sources the node actually exposes.
+For `systemd-journal`, if the host runs `journalctl --namespace=<name>`,
+the same `<name>` is a valid source id you pass in
+`selections.__logs_sources`. As always, the authoritative list (with
+per-source size, entry count, and retention coverage) comes from the
+`info=true` response's `__logs_sources` widget `options[]` — see
+[Selecting log sources](#selecting-log-sources-info--selections) for
+the exact `jq` and the request shape.


### PR DESCRIPTION
Two skill/doc updates (one PR, one commit each).

## 1. New developer skill: `project-build-static-binary`

Documents the full local flow for building the static, self-extracting
Netdata installer (`netdata-<arch>-latest.gz.run`) under
`packaging/makeself/`: pre-flight checks (submodule init, fresh
static-builder image), the ordered build jobs, output artifact layout, the
`artifacts/cache/` reuse model, cross-arch QEMU caveats, debug builds, and
the common first-build failures with their fixes. Adds a `how-tos/` index.

## 2. Fix `query-netdata-cloud/query-logs.md` (Cloud log-query skill)

- **Source filtering**: the log-source selector must be passed inside the
  `selections` object as an array —
  `{"selections":{"__logs_sources":[...]}}`. A top-level `__logs_sources`
  key is silently ignored by the agent's JSON parser
  (`lqs_request_parse_json_payload`). Documents discovering valid source ids
  via the `info` query, and that the mechanism is identical across
  `systemd-journal` / `windows-events` / `otel-logs`.
- **Time units**: `after`/`before` are in **seconds** (struct fields
  `after_s`/`before_s`), not milliseconds or microseconds; only `anchor` and
  the row timestamps are microseconds. The previous table and gotcha
  contradicted each other and were both wrong.
- Adds the server-side source-filter + `data_only` recipe for cheap,
  reliable historical queries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new developer skill for building the static, self-extracting Netdata installer locally and updates both Cloud and direct-agent log-query docs to use correct source filtering and time units.

- **New Features**
  - Added `project-build-static-binary` skill: local build flow under `packaging/makeself/` with pre-flight checks, ordered jobs, artifacts/cache layout, cross-arch/QEMU notes, debug builds, common failure fixes, a how-tos index, and steps to verify/deploy the `.gz.run` artifact. Uses `netdata/static-builder:v1`.

- **Bug Fixes**
  - Cloud logs guide (`query-netdata-cloud/query-logs.md`):
    - Source filtering goes in `selections`: `{"selections":{"__logs_sources":[...]}}`; top-level `__logs_sources` is ignored.
    - `after`/`before` are seconds; `anchor` and row timestamps are microseconds. Added `info`-based source discovery and a `selections` + `data_only:true` recipe for reliable historical queries across `systemd-journal`, `windows-events`, and `otel-logs`.
  - Agent logs guide (`query-netdata-agents/query-logs.md`):
    - Mirrored the same fixes: examples now use `selections.__logs_sources` (array) and correct time units (seconds for `after`/`before`, microseconds for `anchor`/timestamps).

<sup>Written for commit 59ab9da353f45976c3f6b3458ab114d4444b0770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

