### PR TITLE
chore(go.d): add charttpl Group.Clone() and Spec.MarshalTemplate()

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -124,6 +124,13 @@ source files for evidence.
 - To reproduce a V1 chart context in a migration, inject `context_namespace` (the
   fixed prefix, or `prefix.<app>` per job) so autogen rebuilds `prefix.<metric>` /
   `prefix.<app>.<metric>` without hand-built chart IDs.
+- When a collector builds its chart template at RUNTIME (not a static `charts.yaml`):
+  - Emit it with `charttpl.Spec.MarshalTemplate()` (runs `Validate()` only, then
+    marshals with `yaml.v2`, the decoder's library). Do NOT hand-roll `Validate()` +
+    `yaml.Marshal`, and do NOT marshal with `yaml.v3`.
+  - If you mutate a `charttpl.Group` borrowed from a shared profile/catalog, deep-copy
+    it first with `Group.Clone()` so per-job edits cannot corrupt the shared template.
+    A `Group` you decoded yourself per job is already owned and needs no clone.
 - Skip empty distributions -- e.g. a summary whose every quantile is NaN -- so a
   chart waits for real data, matching how scalar NaN values are already skipped.
 - For dynamic surfaces whose label sets churn, `metrix`'s `Vec` handle cache is

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -1063,19 +1063,21 @@ The package exposes a small Go surface for decoding, cloning, and re-emitting te
 |------------------------------------------|------------------------------------------------------------------------------------|
 | `DecodeYAML([]byte) (*Spec, error)`      | Strict parse, apply decode-time defaults, then validate. The canonical read path.  |
 | `Group.Clone() Group`                    | Typed deep copy of a group and everything nested under it.                          |
-| `Spec.MarshalTemplate() (string, error)` | Validate (only) and serialize to YAML, ready to return from `ChartTemplateYAML()`. |
+| `Spec.MarshalTemplate() (string, error)` | Validate (only) and serialize a runtime-built template to YAML.                    |
 
 ### Building a template at runtime
 
-Assemble a `Spec` from `charttpl` types and serialize it with `MarshalTemplate`:
+`CollectorV2.ChartTemplateYAML()` returns a plain `string`, so build the template where the error can be handled — typically once during `Init` — and cache the result; `ChartTemplateYAML()` then returns the cached string. Assemble a `Spec` from `charttpl` types and serialize it with `MarshalTemplate`:
 
 ```go
-spec := charttpl.Spec{
-    Version:          charttpl.VersionV1,
-    ContextNamespace: "myapp",
-    Groups:           groups, // assembled from discovery / profiles
+func buildChartTemplate(groups []charttpl.Group) (string, error) {
+    spec := charttpl.Spec{
+        Version:          charttpl.VersionV1,
+        ContextNamespace: "myapp",
+        Groups:           groups, // assembled from discovery / profiles
+    }
+    return spec.MarshalTemplate()
 }
-return spec.MarshalTemplate()
 ```
 
 `MarshalTemplate` runs `Spec.Validate()` and marshals with `gopkg.in/yaml.v2` — the same library `DecodeYAML` parses with — so a runtime template emits and re-decodes through one consistent YAML implementation. It deliberately does **not** apply decode-time defaults: a field you leave unset stays unset in the emitted YAML, and the chart engine applies the defaults when it re-decodes the template. Treat the returned string as opaque — it is only ever re-decoded, never compared byte-for-byte.

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -1051,3 +1051,43 @@ All rules below produce semantic validation errors unless noted:
 | Group family hierarchy + `chart.family` | Composed into `/`-separated chart family.                                                |
 | `options.multiplier = 0`                | Treated as `1`.                                                                          |
 | `options.divisor = 0`                   | Treated as `1`.                                                                          |
+
+## Programmatic API
+
+> [!NOTE]
+> Most collectors ship a static `charts.yaml` and never touch the Go API. This section is for collectors that **build a chart template at runtime** — for example from discovery results or selected profiles — and return it from `CollectorV2.ChartTemplateYAML()`.
+
+The package exposes a small Go surface for decoding, cloning, and re-emitting templates:
+
+| Function                                 | Purpose                                                                            |
+|------------------------------------------|------------------------------------------------------------------------------------|
+| `DecodeYAML([]byte) (*Spec, error)`      | Strict parse, apply decode-time defaults, then validate. The canonical read path.  |
+| `Group.Clone() Group`                    | Typed deep copy of a group and everything nested under it.                          |
+| `Spec.MarshalTemplate() (string, error)` | Validate (only) and serialize to YAML, ready to return from `ChartTemplateYAML()`. |
+
+### Building a template at runtime
+
+Assemble a `Spec` from `charttpl` types and serialize it with `MarshalTemplate`:
+
+```go
+spec := charttpl.Spec{
+    Version:          charttpl.VersionV1,
+    ContextNamespace: "myapp",
+    Groups:           groups, // assembled from discovery / profiles
+}
+return spec.MarshalTemplate()
+```
+
+`MarshalTemplate` runs `Spec.Validate()` and marshals with `gopkg.in/yaml.v2` — the same library `DecodeYAML` parses with — so a runtime template emits and re-decodes through one consistent YAML implementation. It deliberately does **not** apply decode-time defaults: a field you leave unset stays unset in the emitted YAML, and the chart engine applies the defaults when it re-decodes the template. Treat the returned string as opaque — it is only ever re-decoded, never compared byte-for-byte.
+
+### Cloning a shared template before mutating it
+
+Collectors that derive groups from a **shared catalog** (profiles loaded once and reused across jobs) must not mutate those groups in place — a per-job edit would corrupt the catalog for every other job. `Group.Clone()` returns an isolated deep copy, including nested groups, charts, dimensions, and their option pointers; mutate the clone freely:
+
+```go
+g := profile.Template.Clone()
+g.Metrics = perJobMetrics // safe: the shared catalog copy is untouched
+spec.Groups = append(spec.Groups, g)
+```
+
+`Clone()` is needed only when you mutate a group you do not own. A collector that decodes a fresh `Spec` per job (its own `DecodeYAML` result) already owns it and can mutate it directly.

--- a/src/go/plugin/framework/charttpl/clone.go
+++ b/src/go/plugin/framework/charttpl/clone.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package charttpl
+
+import "slices"
+
+// Clone returns a typed deep copy of the group. Mutating the clone — including
+// nested groups, charts, dimensions, and any options/defaults pointers — never
+// affects the receiver, so a collector can clone a shared catalog template and
+// inject per-job fields without corrupting the catalog.
+func (g Group) Clone() Group {
+	out := g
+	out.Metrics = slices.Clone(g.Metrics)
+	out.ChartDefaults = cloneChartDefaults(g.ChartDefaults)
+	out.Groups = cloneSlice(g.Groups, Group.Clone)
+	out.Charts = cloneSlice(g.Charts, cloneChart)
+	return out
+}
+
+func cloneChartDefaults(in *ChartDefaults) *ChartDefaults {
+	if in == nil {
+		return nil
+	}
+	return &ChartDefaults{
+		LabelPromoted: slices.Clone(in.LabelPromoted),
+		Instances:     cloneInstances(in.Instances),
+	}
+}
+
+func cloneChart(in Chart) Chart {
+	out := in
+	out.LabelPromoted = slices.Clone(in.LabelPromoted)
+	out.Instances = cloneInstances(in.Instances)
+	out.Lifecycle = cloneLifecycle(in.Lifecycle)
+	out.Dimensions = cloneSlice(in.Dimensions, cloneDimension)
+	return out
+}
+
+func cloneLifecycle(in *Lifecycle) *Lifecycle {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.Dimensions != nil {
+		dims := *in.Dimensions
+		out.Dimensions = &dims
+	}
+	return &out
+}
+
+func cloneDimension(in Dimension) Dimension {
+	out := in
+	if in.Options != nil {
+		opts := *in.Options
+		out.Options = &opts
+	}
+	return out
+}
+
+// cloneSlice deep-copies a slice by cloning each element, preserving a nil
+// input as a nil output so a marshaled clone is byte-identical to the original.
+func cloneSlice[T any](in []T, clone func(T) T) []T {
+	if in == nil {
+		return nil
+	}
+	out := make([]T, len(in))
+	for i := range in {
+		out[i] = clone(in[i])
+	}
+	return out
+}

--- a/src/go/plugin/framework/charttpl/clone_test.go
+++ b/src/go/plugin/framework/charttpl/clone_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package charttpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestGroupClone(t *testing.T) {
+	orig := richGroup()
+	origBefore := mustMarshalV2(t, orig)
+
+	clone := orig.Clone()
+
+	// every deep-copied pointer must be a distinct object
+	require.NotSame(t, orig.ChartDefaults, clone.ChartDefaults)
+	require.NotSame(t, orig.ChartDefaults.Instances, clone.ChartDefaults.Instances)
+	require.NotSame(t, orig.Charts[0].Instances, clone.Charts[0].Instances)
+	require.NotSame(t, orig.Charts[0].Lifecycle, clone.Charts[0].Lifecycle)
+	require.NotSame(t, orig.Charts[0].Lifecycle.Dimensions, clone.Charts[0].Lifecycle.Dimensions)
+	require.NotSame(t, orig.Charts[0].Dimensions[0].Options, clone.Charts[0].Dimensions[0].Options)
+	require.NotSame(t, orig.Groups[0].Charts[0].Dimensions[0].Options, clone.Groups[0].Charts[0].Dimensions[0].Options)
+
+	// aggressively mutate every reference-typed field reachable from the clone
+	clone.Family = "MUTATED"
+	clone.Metrics[0] = "mutated"
+	clone.Metrics = append(clone.Metrics, "extra")
+	clone.ChartDefaults.LabelPromoted[0] = "mutated"
+	clone.ChartDefaults.Instances.ByLabels[0] = "mutated"
+	clone.Charts[0].Title = "MUTATED"
+	clone.Charts[0].LabelPromoted[0] = "mutated"
+	clone.Charts[0].Instances.ByLabels[0] = "mutated"
+	clone.Charts[0].Lifecycle.MaxInstances = 999
+	clone.Charts[0].Lifecycle.Dimensions.MaxDims = 999
+	clone.Charts[0].Dimensions[0].Name = "MUTATED"
+	clone.Charts[0].Dimensions[0].Options.Multiplier = 999
+	clone.Groups[0].Family = "MUTATED"
+	clone.Groups[0].Metrics[0] = "mutated"
+	clone.Groups[0].Charts[0].Dimensions[0].Options.Divisor = 999
+
+	// the clone must have actually changed, otherwise the isolation check is vacuous
+	assert.NotEqual(t, origBefore, mustMarshalV2(t, clone))
+	// the original must be untouched by any mutation of the clone
+	assert.Equal(t, origBefore, mustMarshalV2(t, orig))
+}
+
+func TestGroupCloneMarshalsIdentically(t *testing.T) {
+	g := richGroup()
+	assert.Equal(t, mustMarshalV2(t, g), mustMarshalV2(t, g.Clone()))
+}
+
+// richGroup builds a fully populated, validation-clean group exercising every
+// reference-typed field: metrics, chart_defaults (+instances), nested groups,
+// charts with label_promotion/instances/lifecycle, and dimension options.
+func richGroup() Group {
+	return Group{
+		Family:           "Root",
+		ContextNamespace: "ns",
+		Metrics:          []string{"metric_a"},
+		ChartDefaults: &ChartDefaults{
+			LabelPromoted: []string{"region"},
+			Instances:     &Instances{ByLabels: []string{"resource_uid"}},
+		},
+		Charts: []Chart{
+			{
+				Title:         "Chart A",
+				Context:       "chart_a",
+				Units:         "units/s",
+				Type:          "line",
+				LabelPromoted: []string{"zone"},
+				Instances:     &Instances{ByLabels: []string{"id"}},
+				Lifecycle: &Lifecycle{
+					MaxInstances:      10,
+					ExpireAfterCycles: 5,
+					Dimensions:        &DimensionLifecycle{MaxDims: 100, ExpireAfterCycles: 3},
+				},
+				Dimensions: []Dimension{
+					{
+						Selector: "metric_a",
+						Name:     "a",
+						Options:  &DimensionOptions{Multiplier: 2, Divisor: 1000, Hidden: true, Float: true},
+					},
+				},
+			},
+		},
+		Groups: []Group{
+			{
+				Family:  "Child",
+				Metrics: []string{"metric_c"},
+				Charts: []Chart{
+					{
+						Title:   "Chart B",
+						Context: "chart_b",
+						Units:   "units",
+						Type:    "area",
+						Dimensions: []Dimension{
+							{
+								Selector: "metric_c",
+								Name:     "b",
+								Options:  &DimensionOptions{Divisor: 10},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func mustMarshalV2(t *testing.T, v any) string {
+	t.Helper()
+	data, err := yaml.Marshal(v)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/src/go/plugin/framework/charttpl/marshal.go
+++ b/src/go/plugin/framework/charttpl/marshal.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package charttpl
+
+import "gopkg.in/yaml.v2"
+
+// MarshalTemplate validates the spec and serializes it with the same yaml
+// library the decoder uses, so the emitted template round-trips through
+// DecodeYAML unchanged. It runs Validate only — it does NOT apply the
+// decode-time defaults — so a field left unset (for example a chart omitting
+// type) is emitted unset, exactly as the caller assembled it.
+func (s Spec) MarshalTemplate() (string, error) {
+	if err := s.Validate(); err != nil {
+		return "", err
+	}
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/src/go/plugin/framework/charttpl/marshal_test.go
+++ b/src/go/plugin/framework/charttpl/marshal_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package charttpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecMarshalTemplate(t *testing.T) {
+	tests := map[string]struct {
+		spec    Spec
+		wantErr bool
+		check   func(t *testing.T, out string)
+	}{
+		"omits unset optional fields without applying decode defaults": {
+			spec: Spec{
+				Version: VersionV1,
+				Groups: []Group{{
+					Family:  "G",
+					Metrics: []string{"m"},
+					Charts: []Chart{{
+						Title:      "C",
+						Context:    "c",
+						Units:      "u",
+						Dimensions: []Dimension{{Selector: "m", Name: "d"}},
+					}},
+				}},
+			},
+			check: func(t *testing.T, out string) {
+				// applyDefaults would inject type: line; MarshalTemplate must not.
+				assert.NotContains(t, out, "type:")
+			},
+		},
+		"errors when groups missing": {
+			spec:    Spec{Version: VersionV1},
+			wantErr: true,
+		},
+		"errors on wrong version": {
+			spec: Spec{
+				Version: "v2",
+				Groups:  []Group{richGroup()},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			out, err := tc.spec.MarshalTemplate()
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, out)
+				return
+			}
+			require.NoError(t, err)
+			if tc.check != nil {
+				tc.check(t, out)
+			}
+		})
+	}
+}
+
+func TestSpecMarshalTemplateUsesYAMLV2(t *testing.T) {
+	spec := richSpec()
+
+	out, err := spec.MarshalTemplate()
+	require.NoError(t, err)
+
+	// The emitted bytes must be exactly what the decoder's yaml library produces.
+	assert.Equal(t, mustMarshalV2(t, spec), out)
+}
+
+func TestSpecMarshalTemplateRoundTrip(t *testing.T) {
+	// No chart_defaults: decode-time inheritance must not diverge across the
+	// round-trip. The fixture is decoded first so defaults are already applied.
+	const tmpl = `
+version: v1
+context_namespace: ns
+groups:
+  - family: Root
+    metrics: [metric_a]
+    charts:
+      - title: Chart A
+        context: chart_a
+        units: units/s
+        dimensions:
+          - selector: metric_a
+            name: a
+`
+	spec, err := DecodeYAML([]byte(tmpl))
+	require.NoError(t, err)
+
+	out, err := spec.MarshalTemplate()
+	require.NoError(t, err)
+
+	reDecoded, err := DecodeYAML([]byte(out))
+	require.NoError(t, err)
+
+	assert.Equal(t, spec, reDecoded)
+}
+
+func richSpec() Spec {
+	return Spec{
+		Version:          VersionV1,
+		ContextNamespace: "ns",
+		Engine: &Engine{
+			Autogen: &EngineAutogen{Enabled: true, MaxTypeIDLen: 512},
+		},
+		Groups: []Group{richGroup()},
+	}
+}

--- a/src/go/plugin/go.d/collector/azure_monitor/plan.go
+++ b/src/go/plugin/go.d/collector/azure_monitor/plan.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/azure_monitor/azureprofiles"
-	"gopkg.in/yaml.v3"
 )
 
 func buildCollectorRuntimeFromConfig(profileNames []string, profileEntries map[string]ProfileEntryConfig, catalog azureprofiles.Catalog, workloadResourceTagKey string) (*collectorRuntime, error) {
@@ -121,7 +120,7 @@ func buildProfileRuntime(resolved azureprofiles.ResolvedProfile, entry ProfileEn
 		return out.Metrics[i].ID < out.Metrics[j].ID
 	})
 
-	out.Template = resolved.Config.Template
+	out.Template = resolved.Config.Template.Clone()
 	out.Template.Metrics = profileMetricsList(out)
 	return out, nil
 }
@@ -137,15 +136,7 @@ func buildChartTemplate(runtime *collectorRuntime) (string, error) {
 		spec.Groups = append(spec.Groups, p.Template)
 	}
 
-	if err := spec.Validate(); err != nil {
-		return "", err
-	}
-
-	raw, err := yaml.Marshal(spec)
-	if err != nil {
-		return "", err
-	}
-	return string(raw), nil
+	return spec.MarshalTemplate()
 }
 
 func profileMetricsList(p *profileRuntime) []string {

--- a/src/go/plugin/go.d/collector/prometheus/chart_template.go
+++ b/src/go/plugin/go.d/collector/prometheus/chart_template.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
-	"gopkg.in/yaml.v2"
 )
 
 // chartExpireAfterCycles mirrors V1's stale-chart removal (a chart was dropped after 10 missed
@@ -52,14 +51,14 @@ func buildChartTemplate(app string) (string, error) {
 func buildMergedChartTemplate(app string, profiles []promprofiles.Profile) (string, error) {
 	spec := newAutogenSpec(app)
 	for _, p := range profiles {
-		g := p.Template
+		g := p.Template.Clone()
 		// The profile's root context_namespace is the exporter-type segment
 		// (prometheus.<app>.<ns>.<context>). When the resolved app equals that namespace —
 		// e.g. app fell back to the profile's own app: because the job has no app set
 		// (by the user or service discovery) — drop the redundant segment so the
-		// context is prometheus.<app>.<context>, not prometheus.<app>.<app>.<context>. We
-		// overwrite only the scalar ContextNamespace on this local copy (g), so the shared
-		// catalog profile — including its slice fields — is not mutated.
+		// context is prometheus.<app>.<context>, not prometheus.<app>.<app>.<context>. g is
+		// a deep clone of the catalog profile, so clearing its ContextNamespace cannot
+		// mutate the shared catalog.
 		if g.ContextNamespace == app {
 			g.ContextNamespace = ""
 		}
@@ -69,13 +68,9 @@ func buildMergedChartTemplate(app string, profiles []promprofiles.Profile) (stri
 }
 
 func marshalChartSpec(spec charttpl.Spec) (string, error) {
-	if err := spec.Validate(); err != nil {
+	raw, err := spec.MarshalTemplate()
+	if err != nil {
 		return "", fmt.Errorf("build prometheus chart template: %w", err)
 	}
-
-	raw, err := yaml.Marshal(spec)
-	if err != nil {
-		return "", fmt.Errorf("marshal prometheus chart template: %w", err)
-	}
-	return string(raw), nil
+	return raw, nil
 }

--- a/src/go/plugin/go.d/collector/snmp_traps/profile_metric.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/profile_metric.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -2112,14 +2111,11 @@ func buildProfileMetricChartTemplateYAML(rules []*compiledProfileMetricRule, cha
 		}
 		group.Charts = append(group.Charts, profileMetricChartToTemplate(chart, ruleByChart[id]))
 	}
-	if err := spec.Validate(); err != nil {
+	raw, err := spec.MarshalTemplate()
+	if err != nil {
 		return "", fmt.Errorf("invalid chart template: %w", err)
 	}
-	raw, err := yaml.Marshal(spec)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal chart template: %w", err)
-	}
-	return string(raw), nil
+	return raw, nil
 }
 
 func validateSelectedProfileMetricChartDimensions(ruleByChart map[string][]*compiledProfileMetricRule) error {


### PR DESCRIPTION
##### Summary

Add two primitives to the package that owns the chart-template types, for collectors that assemble templates at runtime.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime template builder helpers in `charttpl` to safely clone groups and serialize specs, and refactors collectors to use them. Updates docs with a correct runtime-template example and caching pattern.

- **New Features**
  - `Group.Clone()` deep-copies a group, including nested groups, charts, dimensions, and option pointers.
  - `Spec.MarshalTemplate()` validates and serializes with `gopkg.in/yaml.v2` without applying decode-time defaults.

- **Refactors**
  - `azure_monitor`: clone shared profile templates before mutation; use `MarshalTemplate()`; switch from `gopkg.in/yaml.v3` to `gopkg.in/yaml.v2`.
  - `prometheus`: clone catalog profiles before clearing namespace; use `MarshalTemplate()`.
  - `snmp_traps`: use `MarshalTemplate()` (no clone needed; spec is owned).
  - Docs: clarified Programmatic API in `charttpl/README.md` (fixed runtime example and showed caching pattern) and added runtime guidance in the framework-v2 skill doc.

<sup>Written for commit 4620abb63dc58d207bb736758f711e251ae99757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

