### PR TITLE
docs(map): fix duplicate Learn route for Service Discovery

### DIFF
--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -430,8 +430,10 @@ sidebar:
           label: Collectors configuration
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/REFERENCE.md
       - meta:
-          label: Service Discovery Reference
+          label: Service Discovery
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/SERVICE-DISCOVERY.md
+          description: Stop hand-writing collector jobs. Netdata's Service Discovery finds monitorable targets in your environment and turns them into collector jobs automatically.
+        items: []
       - meta:
           label: StatsD
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/statsd.plugin/README.md

--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -430,8 +430,8 @@ sidebar:
           label: Collectors configuration
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/REFERENCE.md
       - meta:
-          label: Service discovery
-          edit_url: https://github.com/netdata/agent-service-discovery/edit/master/README.md
+          label: Service Discovery Reference
+          edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/SERVICE-DISCOVERY.md
       - meta:
           label: StatsD
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/statsd.plugin/README.md

--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -432,7 +432,6 @@ sidebar:
       - meta:
           label: Service Discovery
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/SERVICE-DISCOVERY.md
-          description: Stop hand-writing collector jobs. Netdata's Service Discovery finds monitorable targets in your environment and turns them into collector jobs automatically.
         items: []
       - meta:
           label: StatsD

--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -432,7 +432,6 @@ sidebar:
       - meta:
           label: Service Discovery
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/SERVICE-DISCOVERY.md
-        items: []
       - meta:
           label: StatsD
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/statsd.plugin/README.md


### PR DESCRIPTION
\`map.yaml\` had a leaf entry for \`agent-service-discovery/README.md\` at the \`Service discovery\` position. PR #22345 added five discoverer integration pages all with \`learn_rel_path: "Collecting Metrics/Service Discovery"\`, which caused ingest to create a \`docs/Collecting Metrics/Service Discovery/\` directory and auto-generate a grid page inside it — both the leaf and the grid resolved to \`/docs/collecting-metrics/service-discovery\`, producing the duplicate-route Docusaurus warning.

**Fix:** turn the leaf into a category node (\`items: []\`) pointing to \`src/collectors/SERVICE-DISCOVERY.md\` (the hub page from #22345). Ingest treats any node with an \`items\` list as a section and places its \`edit_url\` file at \`docs/Collecting Metrics/Service Discovery/Service Discovery.mdx\` — which is the directory's overview file. With an overview present, the auto-grid is not generated and the collision is gone. The hub page becomes the landing page of the Service Discovery sidebar section; the five discoverer pages appear as its children.