### PR TITLE
Refactor SPINLOCK_TRACKED to store acquire-site function names inline

### DIFF
--- a/src/libnetdata/locks/spinlock.c
+++ b/src/libnetdata/locks/spinlock.c
@@ -45,14 +45,18 @@ static void spinlock_tracked_deadlock_detect(usec_t *timestamp, const char *func
     usec_t now = now_monotonic_usec();
     if (now - *timestamp >= SPINLOCK_DEADLOCK_TIMEOUT_SEC * USEC_PER_SEC) {
         pid_t holder = __atomic_load_n(&spinlock->holder_tid, __ATOMIC_RELAXED);
-        const char *holder_func = __atomic_load_n(&spinlock->holder_func, __ATOMIC_RELAXED);
         usec_t since = __atomic_load_n(&spinlock->holder_since_ut, __ATOMIC_RELAXED);
         int64_t waited_s = (int64_t)((now - *timestamp) / USEC_PER_SEC);
 
         if (holder)
+            // holder_func is an inline buffer in the lock's own memory; print it
+            // with a bounded "%.*s" so a corrupted (non-NUL-terminated) buffer
+            // cannot read past it, and never dereference a pointer that could be
+            // wild if the lock memory itself is corrupted.
             fatal("DEADLOCK DETECTED: spinlock in function '%s' could not be acquired for %"PRIi64" seconds "
-                  "[holder: tid=%d func='%s' held_for=%"PRIi64"s]",
-                  func, waited_s, holder, holder_func ? holder_func : "(unknown)",
+                  "[holder: tid=%d func='%.*s' held_for=%"PRIi64"s]",
+                  func, waited_s, holder,
+                  (int)sizeof(spinlock->holder_func), spinlock->holder_func,
                   since ? (int64_t)((now - since) / USEC_PER_SEC) : (int64_t)-1);
         else
             fatal("DEADLOCK DETECTED: spinlock in function '%s' could not be acquired for %"PRIi64" seconds "
@@ -65,7 +69,10 @@ static void spinlock_tracked_deadlock_detect(usec_t *timestamp, const char *func
 // Called immediately after the lock is acquired (lock and trylock paths).
 static ALWAYS_INLINE void spinlock_tracked_record_holder(SPINLOCK_TRACKED *spinlock, const char *func) {
     __atomic_store_n(&spinlock->holder_tid, gettid_cached(), __ATOMIC_RELAXED);
-    __atomic_store_n(&spinlock->holder_func, func, __ATOMIC_RELAXED);
+    // Copy the name inline (best-effort, racy-but-bounded, like the RELAXED
+    // fields around it) so the detector never has to dereference a stored
+    // pointer; see SPINLOCK_TRACKED.holder_func.
+    strncpyz(spinlock->holder_func, func ? func : "", sizeof(spinlock->holder_func) - 1);
     __atomic_store_n(&spinlock->holder_since_ut, now_monotonic_usec(), __ATOMIC_RELAXED);
 }
 
@@ -186,7 +193,10 @@ void spinlock_tracked_init_with_trace(SPINLOCK_TRACKED *spinlock, const char *fu
 
 static ALWAYS_INLINE void spinlock_tracked_record_holder(SPINLOCK_TRACKED *spinlock, const char *func) {
     __atomic_store_n(&spinlock->holder_tid, gettid_cached(), __ATOMIC_RELAXED);
-    __atomic_store_n(&spinlock->holder_func, func, __ATOMIC_RELAXED);
+    // Copy the name inline (best-effort, racy-but-bounded, like the RELAXED
+    // fields around it) so the detector never has to dereference a stored
+    // pointer; see SPINLOCK_TRACKED.holder_func.
+    strncpyz(spinlock->holder_func, func ? func : "", sizeof(spinlock->holder_func) - 1);
     __atomic_store_n(&spinlock->holder_since_ut, now_monotonic_usec(), __ATOMIC_RELAXED);
 }
 

--- a/src/libnetdata/locks/spinlock.h
+++ b/src/libnetdata/locks/spinlock.h
@@ -71,13 +71,21 @@ bool spinlock_trylock_with_trace(SPINLOCK *spinlock, const char *func __maybe_un
 // integrates a holder-aware deadlock detector into the spin loop; the
 // mutex-backed implementation (SPINLOCK_IMPL_WITH_MUTEX) only records the
 // holder fields, since it does not spin and cannot self-detect deadlocks.
+#define SPINLOCK_HOLDER_FUNC_MAX 48 // enough for any acquire-site __FUNCTION__
+
 typedef struct netdata_spinlock_tracked {
     SPINLOCK spinlock;
     // The holder fields are NOT cleared on unlock; they describe the most
     // recent holder and are overwritten by the next acquirer. The detector
     // reads them only while the lock is held, so a free lock is never reported.
     pid_t holder_tid;           // gettid_cached() of the most recent holder; 0 before first acquire
-    const char *holder_func;    // acquire-site function (rodata literal); NULL before first acquire
+    // The acquire-site function name is copied INLINE (not stored as a pointer)
+    // so the detector can format it without dereferencing a possibly-wild
+    // pointer: when the lock memory is corrupted (the case the detector exists
+    // to report), a stored pointer would be garbage and crash vsnprintf, while
+    // an inline buffer is part of the lock's own (mapped) memory and is read
+    // with a bounded "%.*s". Empty before the first acquire.
+    char holder_func[SPINLOCK_HOLDER_FUNC_MAX];
     usec_t holder_since_ut;     // monotonic time the most recent holder acquired the lock
 } SPINLOCK_TRACKED;
 


### PR DESCRIPTION
##### Summary
- Store the name inline (`char holder_func[48]`) and format it with a bounded `%.*s` over the lock's own mapped memory, so the detector can never deref a wild pointer.  A garbage name now cleanly signals lock-struct corruption instead of
faulting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `SPINLOCK_TRACKED` to store the acquire-site function name inline, preventing the deadlock detector from dereferencing invalid pointers and crashing. Corruption now surfaces as a bounded, readable name instead of a fault.

- **Bug Fixes**
  - Replaced `const char *holder_func` with `char holder_func[SPINLOCK_HOLDER_FUNC_MAX]` (48 bytes).
  - On acquire, copy `func` into the inline buffer; never store or dereference external pointers.
  - Log with a bounded "%.*s" using `sizeof(holder_func)` to avoid overreads during corruption.

<sup>Written for commit 3fcc521410ef41551246be05064554f9b4da3f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

