### PR TITLE
MCP: limit metadata exposed to anonymous callers

### DIFF
--- a/src/database/rrdfunctions-inflight.c
+++ b/src/database/rrdfunctions-inflight.c
@@ -408,49 +408,23 @@ static inline int rrd_call_function_async(struct rrd_function_inflight *r, bool 
 
 // ----------------------------------------------------------------------------
 
-int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
-                     HTTP_ACCESS user_access, const char *cmd,
-                     bool wait, const char *transaction,
-                     rrd_function_result_callback_t result_cb, void *result_cb_data,
-                     rrd_function_progress_cb_t progress_cb, void *progress_cb_data,
-                     rrd_function_is_cancelled_cb_t is_cancelled_cb, void *is_cancelled_cb_data,
-                     BUFFER *payload, const char *source, bool allow_restricted) {
+int rrd_function_verify_access(RRDHOST *host, BUFFER *result_wb, const char *cmd,
+                              HTTP_ACCESS user_access, bool allow_restricted,
+                              const DICTIONARY_ITEM **out_acquired) {
 
-    int code;
+    if(out_acquired)
+        *out_acquired = NULL;
+
+    if(!host)
+        return HTTP_RESP_INTERNAL_SERVER_ERROR;
+
     char sanitized_cmd[PLUGINSD_LINE_MAX + 1];
-    const DICTIONARY_ITEM *host_function_acquired = NULL;
-
-    const char *source_to_sanitize = source ? source : "";
-    size_t sanitized_source_size = rrd_functions_strlen_bounded(source_to_sanitize, PLUGINSD_LINE_MAX) + 1;
-    CLEAN_CHAR_P *sanitized_source = mallocz(sanitized_source_size);
-    rrd_functions_sanitize(sanitized_source, source_to_sanitize, sanitized_source_size);
-
-    // ------------------------------------------------------------------------
-    // check for the host
-    if(!host) {
-        code = HTTP_RESP_INTERNAL_SERVER_ERROR;
-
-        rrd_call_function_error(result_wb, "No host given for routing this request to.", code);
-
-        if(result_cb)
-            result_cb(result_wb, code, result_cb_data);
-
-        return code;
-    }
-
-    // ------------------------------------------------------------------------
-    // find the function
-
     size_t sanitized_cmd_length = rrd_functions_sanitize(sanitized_cmd, cmd, sizeof(sanitized_cmd));
 
-    code = rrd_functions_find_by_name(host, result_wb, sanitized_cmd, sanitized_cmd_length, &host_function_acquired);
-    if(code != HTTP_RESP_OK) {
-
-        if(result_cb)
-            result_cb(result_wb, code, result_cb_data);
-
+    const DICTIONARY_ITEM *host_function_acquired = NULL;
+    int code = rrd_functions_find_by_name(host, result_wb, sanitized_cmd, sanitized_cmd_length, &host_function_acquired);
+    if(code != HTTP_RESP_OK)
         return code;
-    }
 
     struct rrd_host_function *rdcf = dictionary_acquired_item_value(host_function_acquired);
 
@@ -459,10 +433,6 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
                                        "This feature is not available via this API.",
                                        HTTP_ACCESS_PERMISSION_DENIED_HTTP_CODE(user_access));
         dictionary_acquired_item_release(host->functions, host_function_acquired);
-
-        if(result_cb)
-            result_cb(result_wb, code, result_cb_data);
-
         return code;
     }
 
@@ -501,12 +471,62 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
         }
 
         dictionary_acquired_item_release(host->functions, host_function_acquired);
+        return code;
+    }
+
+    if(out_acquired)
+        *out_acquired = host_function_acquired;
+    else
+        dictionary_acquired_item_release(host->functions, host_function_acquired);
+
+    return HTTP_RESP_OK;
+}
+
+int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
+                     HTTP_ACCESS user_access, const char *cmd,
+                     bool wait, const char *transaction,
+                     rrd_function_result_callback_t result_cb, void *result_cb_data,
+                     rrd_function_progress_cb_t progress_cb, void *progress_cb_data,
+                     rrd_function_is_cancelled_cb_t is_cancelled_cb, void *is_cancelled_cb_data,
+                     BUFFER *payload, const char *source, bool allow_restricted) {
+
+    int code;
+    char sanitized_cmd[PLUGINSD_LINE_MAX + 1];
+    const DICTIONARY_ITEM *host_function_acquired = NULL;
+
+    const char *source_to_sanitize = source ? source : "";
+    size_t sanitized_source_size = rrd_functions_strlen_bounded(source_to_sanitize, PLUGINSD_LINE_MAX) + 1;
+    CLEAN_CHAR_P *sanitized_source = mallocz(sanitized_source_size);
+    rrd_functions_sanitize(sanitized_source, source_to_sanitize, sanitized_source_size);
+
+    // ------------------------------------------------------------------------
+    // check for the host
+    if(!host) {
+        code = HTTP_RESP_INTERNAL_SERVER_ERROR;
+
+        rrd_call_function_error(result_wb, "No host given for routing this request to.", code);
 
         if(result_cb)
             result_cb(result_wb, code, result_cb_data);
 
         return code;
     }
+
+    // ------------------------------------------------------------------------
+    // find the function and verify the caller's access
+
+    size_t sanitized_cmd_length = rrd_functions_sanitize(sanitized_cmd, cmd, sizeof(sanitized_cmd));
+
+    code = rrd_function_verify_access(host, result_wb, cmd, user_access, allow_restricted, &host_function_acquired);
+    if(code != HTTP_RESP_OK) {
+
+        if(result_cb)
+            result_cb(result_wb, code, result_cb_data);
+
+        return code;
+    }
+
+    struct rrd_host_function *rdcf = dictionary_acquired_item_value(host_function_acquired);
 
     if(timeout_s <= 0)
         timeout_s = rdcf->timeout;

--- a/src/database/rrdfunctions-inflight.c
+++ b/src/database/rrdfunctions-inflight.c
@@ -416,7 +416,8 @@ int rrd_function_verify_access(RRDHOST *host, BUFFER *result_wb, const char *cmd
         *out_acquired = NULL;
 
     if(!host)
-        return HTTP_RESP_INTERNAL_SERVER_ERROR;
+        return rrd_call_function_error(result_wb, "No host given for routing this request to.",
+                                       HTTP_RESP_INTERNAL_SERVER_ERROR);
 
     char sanitized_cmd[PLUGINSD_LINE_MAX + 1];
     size_t sanitized_cmd_length = rrd_functions_sanitize(sanitized_cmd, cmd, sizeof(sanitized_cmd));

--- a/src/database/rrdfunctions.h
+++ b/src/database/rrdfunctions.h
@@ -85,6 +85,17 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
                      rrd_function_is_cancelled_cb_t is_cancelled_cb, void *is_cancelled_cb_data,
                      BUFFER *payload, const char *source, bool allow_restricted);
 
+// Verify the caller may invoke `cmd` on `host`, applying the same RESTRICTED and access-level
+// checks rrd_function_run() enforces, WITHOUT executing the function. This lets non-execution
+// paths (e.g. MCP metadata/help generation) authorize a caller before disclosing anything.
+// On success returns HTTP_RESP_OK; if out_acquired != NULL it receives an acquired dictionary
+// item the caller MUST release with dictionary_acquired_item_release(host->functions, *out_acquired),
+// otherwise the item is released internally. On failure it writes the error into result_wb,
+// releases any acquired item, sets *out_acquired (if any) to NULL, and returns the HTTP code.
+int rrd_function_verify_access(RRDHOST *host, BUFFER *result_wb, const char *cmd,
+                              HTTP_ACCESS user_access, bool allow_restricted,
+                              const DICTIONARY_ITEM **out_acquired);
+
 bool rrd_function_available(RRDHOST *host, const char *function);
 bool rrd_function_is_available(struct rrd_host_function *rdcf, RRDHOST *host);
 

--- a/src/web/mcp/mcp-tools-execute-function.c
+++ b/src/web/mcp/mcp-tools-execute-function.c
@@ -2638,10 +2638,12 @@ MCP_RETURN_CODE mcp_tool_execute_function_execute(MCP_CLIENT *mcpc, struct json_
             false, NULL);
 
         if (access_code != HTTP_RESP_OK) {
+            // Echo back only the caller-supplied node identifier, never the resolved
+            // hostname, so the denial does not disclose node metadata to an unauthorized caller.
             buffer_sprintf(mcpc->error,
                            "You are not authorized to execute function '%s' on node '%s'.",
                            data.request.function ? data.request.function : "(unknown)",
-                           data.request.host ? rrdhost_hostname(data.request.host) : "(unknown)");
+                           data.request.node ? data.request.node : "(unknown)");
             mcp_functions_data_cleanup(&data);
             return MCP_RC_ERROR;
         }

--- a/src/web/mcp/mcp-tools-execute-function.c
+++ b/src/web/mcp/mcp-tools-execute-function.c
@@ -2624,7 +2624,29 @@ MCP_RETURN_CODE mcp_tool_execute_function_execute(MCP_CLIENT *mcpc, struct json_
         mcp_functions_data_cleanup(&data);
         return rc;
     }
-    
+
+    // Authorize the caller BEFORE fetching or disclosing any function metadata.
+    // The function "info" path used to build required_params/options runs with elevated
+    // privileges, so without this gate an unauthorized caller could read protected metadata
+    // (log source names, file counts, sizes, coverage, timestamps) that the normal
+    // /api/v3/function path denies. Enforce the same access here (GHSA-6628-vxm3-4g8g).
+    {
+        CLEAN_BUFFER *access_error = buffer_create(0, NULL);
+        int access_code = rrd_function_verify_access(
+            data.request.host, access_error, data.request.function,
+            data.request.auth ? data.request.auth->access : HTTP_ACCESS_NONE,
+            false, NULL);
+
+        if (access_code != HTTP_RESP_OK) {
+            buffer_sprintf(mcpc->error,
+                           "You are not authorized to execute function '%s' on node '%s'.",
+                           data.request.function ? data.request.function : "(unknown)",
+                           data.request.host ? rrdhost_hostname(data.request.host) : "(unknown)");
+            mcp_functions_data_cleanup(&data);
+            return MCP_RC_ERROR;
+        }
+    }
+
     // Get function registry entry
     CLEAN_BUFFER *registry_error = buffer_create(0, NULL);
     MCP_FUNCTION_REGISTRY_ENTRY *registry_entry = mcp_functions_registry_get(data.request.host, data.request.function, registry_error);


### PR DESCRIPTION
##### Summary
- MCP execute_function returned protected function metadata (e.g. systemd-journal info: log source names, file counts, sizes, coverage, timestamps) to anonymous callers that /api/v3/function denies with HTTP 412. 
- Now enforces the same access check on the MCP path before fetching the function info, so both paths behave identically.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a metadata disclosure in MCP `execute_function` by enforcing the same access checks as `/api/v3/function`. Also refactors access logic and hardens errors to avoid leaking node details.

- **Bug Fixes**
  - Gate MCP function info/metadata with `rrd_function_verify_access` so anonymous/unauthorized users are denied before any info is fetched.
  - Refactor `rrd_function_run` to delegate authorization to `rrd_function_verify_access`, unifying restricted/role checks across exec and non-exec paths.
  - Return non-disclosing errors for unauthorized MCP calls (echo only the caller-supplied node) and improve “missing host” routing errors; behavior unchanged for authorized users.

<sup>Written for commit 984bb29fd46f9f813e94ab47bb9105c958377be4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

