### PR TITLE
dyncfg: apply per-node view_access in config tree

### DIFF
--- a/src/daemon/dyncfg/dyncfg-tree.c
+++ b/src/daemon/dyncfg/dyncfg-tree.c
@@ -61,7 +61,7 @@ static void dyncfg_to_json(DYNCFG *df, const char *id, BUFFER *wb, bool anonymou
     buffer_json_object_close(wb);
 }
 
-static void dyncfg_tree_for_host(RRDHOST *host, BUFFER *wb, const char *path, const char *id, bool anonymous) {
+static void dyncfg_tree_for_host(RRDHOST *host, BUFFER *wb, const char *path, const char *id, HTTP_ACCESS user_access, bool anonymous) {
     size_t entries = dictionary_entries(dyncfg_globals.nodes);
     size_t used = 0;
     const DICTIONARY_ITEM **items = entries ? callocz(entries, sizeof(*items)) : NULL;
@@ -84,6 +84,11 @@ static void dyncfg_tree_for_host(RRDHOST *host, BUFFER *wb, const char *path, co
             df->current.status = DYNCFG_STATUS_ORPHAN;
 
         if((id && strcmp(id, df_dfe.name) != 0) && (template && df->template != template))
+            continue;
+
+        // Apply the per-node view_access policy, so the tree does not disclose entries whose
+        // direct view (schema/get/userconfig) the caller is not allowed to access
+        if(!http_access_user_has_enough_access_level_for_endpoint(user_access, df->view_access))
             continue;
 
         items[used++] = dictionary_acquired_item_dup(dyncfg_globals.nodes, df_dfe.item);
@@ -196,7 +201,7 @@ static int dyncfg_config_execute_cb(struct rrd_function_execute *rfe, void *data
         }
 
         code = HTTP_RESP_OK;
-        dyncfg_tree_for_host(host, rfe->result.wb, path, id, !(rfe->user_access & HTTP_ACCESS_SENSITIVE_DATA));
+        dyncfg_tree_for_host(host, rfe->result.wb, path, id, rfe->user_access, !(rfe->user_access & HTTP_ACCESS_SENSITIVE_DATA));
     }
     else {
         const char *name = id;


### PR DESCRIPTION
##### Summary
- GET /api/v3/config?action=tree serialized every dynamic-config node without checking each node's view_access, letting anonymous callers enumerate entries that require signed-in+same-space+view-config
- Direct schema/get on the same IDs returned 412. The tree now applies the same per-node view_access check the direct actions use.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unauthorized disclosure in the dynamic config tree by enforcing per-node view_access checks. The tree output now matches direct schema/get access and stops anonymous users from enumerating restricted nodes.

- **Bug Fixes**
  - Apply per-node `view_access` in `dyncfg_tree_for_host` using `user_access` to filter nodes.
  - `GET /api/v3/config?action=tree` now only returns entries the caller can view (anonymous/cross-space users no longer see restricted IDs).

<sup>Written for commit e6ceb956564a2d09026f4857d9865bb20a9c4131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

