### PR TITLE
docs(map): route Service Discovery via integration_placeholder

### DIFF
--- a/docs/.map/map.schema.json
+++ b/docs/.map/map.schema.json
@@ -108,7 +108,8 @@
             "logs",
             "flows",
             "agent_notifications",
-            "cloud_notifications"
+            "cloud_notifications",
+            "service_discovery"
           ],
           "description": "Type of integrations to be inserted at this location"
         }

--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -430,8 +430,11 @@ sidebar:
           label: Collectors configuration
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/REFERENCE.md
       - meta:
-          label: Service discovery
-          edit_url: https://github.com/netdata/agent-service-discovery/edit/master/README.md
+          label: Service Discovery
+          edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/SERVICE-DISCOVERY.md
+        items:
+          - type: integration_placeholder
+            integration_kind: service_discovery
       - meta:
           label: StatsD
           edit_url: https://github.com/netdata/netdata/edit/master/src/collectors/statsd.plugin/README.md


### PR DESCRIPTION
## Summary

- Adds `service_discovery` to the `integration_kind` enum in `docs/.map/map.schema.json`
- Changes the Service Discovery node in `docs/.map/map.yaml` from a leaf pointing to the external `agent-service-discovery` README to a category node with `src/collectors/SERVICE-DISCOVERY.md` as the overview and an `integration_placeholder: service_discovery` for the 5 discoverer integration pages

## Background

The 5 service discovery integration pages (`src/go/plugin/go.d/discovery/sdext/discoverer/*/integrations/*.md`) have `learn_status: Published` and `learn_rel_path: "Collecting Metrics/Service Discovery"`. They were publishing to the correct URL by accident — `populate_integrations` in `ingest.py` had no dedicated bucket for them, so they fell into the `alerting_agent_entries` catch-all.

This PR adopts the same pattern as Secrets Management (`integration_placeholder: secretstore`), which gives Service Discovery a proper, intentional placement rather than relying on path fallthrough.

A companion PR in [netdata/learn](https://github.com/netdata/learn) adds the `service_discovery_entries` bucket and `service_discovery_integrations` sentinel replacement to `ingest.py`.

## Test plan

- [ ] `docs/.map/map.yaml` validates against `docs/.map/map.schema.json` with `integration_kind: service_discovery`
- [ ] SERVICE-DISCOVERY.md is the overview (landing page) of the Service Discovery sidebar section on Learn
- [ ] The 5 discoverer pages (Docker, SNMP, Net listeners, HTTP, k8s) appear as children in that section
- [ ] No Docusaurus duplicate-route warning for `/docs/collecting-metrics/service-discovery`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Service Discovery docs through an `integration_placeholder` so the section has a proper landing page and the five discoverer integrations appear as children. Add `service_discovery` to the `integration_kind` enum and convert the map entry from an external leaf to a category using `src/collectors/SERVICE-DISCOVERY.md` as the overview.

<sup>Written for commit 7b9ca70bcebdbcc73f8861613f9f539461a60b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

