### PR TITLE
Replace HTTP_ACL_NOCHECK with HTTP_ACL_DASHBOARD on /api/v3/settings

### DIFF
--- a/src/web/api/web_api_v3.c
+++ b/src/web/api/web_api_v3.c
@@ -187,7 +187,10 @@ static struct web_api_command api_commands_v3[] = {
     {
         .api = "settings",
         .hash = 0,
-        .acl = HTTP_ACL_NOCHECK,
+        // settings is a dashboard feature: gate it behind `allow dashboard from` like the rest
+        // of the dashboard, instead of HTTP_ACL_NOCHECK which bypassed the per-feature IP
+        // allowlists and exposed the anonymous state-modifying PUT remotely.
+        .acl = HTTP_ACL_DASHBOARD,
         .access = HTTP_ACCESS_ANONYMOUS_DATA,
         .callback = api_v3_settings,
         .allow_subpaths = 0


### PR DESCRIPTION
##### Summary
- /api/v3/settings used HTTP_ACL_NOCHECK, which bypasses the per-feature IP allowlists. With its anonymous (ANONYMOUS_DATA) access, a remote unauthenticated client could GET/PUT the settings store even when allow dashboard from restricted the dashboard. 
- Switching it to HTTP_ACL_DASHBOARD makes settings honor allow dashboard from like other dashboard endpoints; default behavior (no allowlist) is unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make /api/v3/settings honor dashboard IP allowlists by switching its ACL from `HTTP_ACL_NOCHECK` to `HTTP_ACL_DASHBOARD`. This blocks unauthenticated remote GET/PUT when "allow dashboard from" is set; behavior is unchanged when no allowlist is configured.

<sup>Written for commit e4d42e1eaffd9434bb62b60e21ab71a0f6cb3898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

