### PR TITLE
chore(codeowners): own .agents/ with maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,9 @@ src/web/ @thiagoftsm @vkalintiris
 *.mdx @Ancairon @kanelatechnical
 Dockerfile* @netdata/agent-sre
 
+# Ownership by directory (overwrites ownership by filetype; must come after *.md/*.mdx)
+.agents/ @ilyam8 @ktsaou
+
 # Ownership of specific files
 .gitignore @netdata/agent-sre @vkalintiris
 .codacy.yml @netdata/agent-sre


### PR DESCRIPTION
The *.md / *.mdx filetype rules made the docs team code owners of every markdown file under .agents/. Add a .agents/ rule after those rules so last-match-wins routes the SOW framework and skills to the maintainers.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `.agents/` directory ownership to maintainers by adding a directory rule after the `*.md`/`*.mdx` rules, so last-match-wins overrides filetype ownership. This ensures SOW framework and skills under `.agents/` are reviewed by maintainers instead of the docs team.

<sup>Written for commit 0a888f0a24bcfb9cde7d1d3d9af53d0e7da0e617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

