### PR TITLE
Netdata fixes part 1

### DIFF
--- a/src/libnetdata/buffer/buffer.c
+++ b/src/libnetdata/buffer/buffer.c
@@ -171,14 +171,14 @@ void buffer_jsdate(BUFFER *wb, int year, int month, int day, int hours, int minu
     buffer_need_bytes(wb, 30);
 
     char *b = &wb->buffer[wb->len], *p;
-  unsigned int *q = (unsigned int *)b;  
 
   #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    *q++ = 0x65746144;  // "Date" backwards.
+    const uint32_t date = 0x65746144;  // "Date" backwards.
   #else
-    *q++ = 0x44617465;  // "Date"
+    const uint32_t date = 0x44617465;  // "Date"
   #endif
-  p = (char *)q;
+  memcpy(b, &date, sizeof(date));
+  p = b + sizeof(date);
 
   *p++ = '(';
   *p++ = '0' + year / 1000; year %= 1000;
@@ -201,15 +201,15 @@ void buffer_jsdate(BUFFER *wb, int year, int month, int day, int hours, int minu
   *p   = '0' + seconds / 10; if (*p != '0') p++;
   *p++ = '0' + seconds % 10;
 
-  unsigned short *r = (unsigned short *)p;
-
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    *r++ = 0x0029;  // ")\0" backwards.  
+    const uint16_t terminator = 0x0029;  // ")\0" backwards.
   #else
-    *r++ = 0x2900;  // ")\0"
+    const uint16_t terminator = 0x2900;  // ")\0"
   #endif
+    memcpy(p, &terminator, sizeof(terminator));
+    p += sizeof(terminator);
 
-    wb->len += (size_t)((char *)r - b - 1);
+    wb->len += (size_t)(p - b - 1);
 
     // terminate it
     wb->buffer[wb->len] = '\0';

--- a/src/libnetdata/buffer/buffer.c
+++ b/src/libnetdata/buffer/buffer.c
@@ -70,6 +70,7 @@ void buffer_strcat_htmlescape(BUFFER *wb, const char *txt)
         txt++;
     }
 
+    wb->buffer[wb->len] = '\0';
     buffer_overflow_check(wb);
 }
 

--- a/src/libnetdata/buffer/buffer.h
+++ b/src/libnetdata/buffer/buffer.h
@@ -693,11 +693,12 @@ ALWAYS_INLINE
 static void buffer_print_netdata_double_hex(BUFFER *wb, NETDATA_DOUBLE value) {
     buffer_need_bytes(wb, DOUBLE_HEX_MAX_LENGTH);
 
-    uint64_t *ptr = (uint64_t *) (&value);
+    uint64_t representation;
+    memcpy(&representation, &value, sizeof(representation));
     buffer_fast_strcat(wb, IEEE754_DOUBLE_HEX_PREFIX, sizeof(IEEE754_DOUBLE_HEX_PREFIX) - 1);
 
     char *s = &wb->buffer[wb->len];
-    char *d = print_uint64_hex_reversed(s, *ptr);
+    char *d = print_uint64_hex_reversed(s, representation);
     char_array_reverse(s, d - 1);
     *d = '\0';
     wb->len += d - s;
@@ -710,11 +711,12 @@ ALWAYS_INLINE
 static void buffer_print_netdata_double_base64(BUFFER *wb, NETDATA_DOUBLE value) {
     buffer_need_bytes(wb, DOUBLE_B64_MAX_LENGTH);
 
-    uint64_t *ptr = (uint64_t *) (&value);
+    uint64_t representation;
+    memcpy(&representation, &value, sizeof(representation));
     buffer_fast_strcat(wb, IEEE754_DOUBLE_B64_PREFIX, sizeof(IEEE754_DOUBLE_B64_PREFIX) - 1);
 
     char *s = &wb->buffer[wb->len];
-    char *d = print_uint64_base64_reversed(s, *ptr);
+    char *d = print_uint64_base64_reversed(s, representation);
     char_array_reverse(s, d - 1);
     *d = '\0';
     wb->len += d - s;

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -432,15 +432,17 @@ static NETDATA_DOUBLE str2ndd_encoded(const char *src, char **endptr) {
     if (*src == IEEE754_DOUBLE_B64_PREFIX[0]) {
         // double parsing from base64
         uint64_t n = str2uint64_base64(src + sizeof(IEEE754_DOUBLE_B64_PREFIX) - 1, endptr);
-        NETDATA_DOUBLE *ptr = (NETDATA_DOUBLE *) (&n);
-        return *ptr;
+        double value;
+        memcpy(&value, &n, sizeof(value));
+        return (NETDATA_DOUBLE)value;
     }
 
     if (*src == IEEE754_DOUBLE_HEX_PREFIX[0]) {
         // double parsing from hex
         uint64_t n = str2uint64_hex(src + sizeof(IEEE754_DOUBLE_HEX_PREFIX) - 1, endptr);
-        NETDATA_DOUBLE *ptr = (NETDATA_DOUBLE *) (&n);
-        return *ptr;
+        double value;
+        memcpy(&value, &n, sizeof(value));
+        return (NETDATA_DOUBLE)value;
     }
 
     double sign = 1.0;

--- a/src/libnetdata/json/json.c
+++ b/src/libnetdata/json/json.c
@@ -181,7 +181,6 @@ static inline void json_jsonc_set_integer(JSON_ENTRY *e, char *key, int64_t valu
  */
 static inline void json_jsonc_parse_array(json_object *ptr, void *callback_data,int (*callback_function)(struct json_entry *)) {
     int end = json_object_array_length(ptr);
-    JSON_ENTRY e;
 
     if(end) {
         int i;
@@ -191,8 +190,7 @@ static inline void json_jsonc_parse_array(json_object *ptr, void *callback_data,
         do {
             json_object *jvalue =  json_object_array_get_idx(ptr, i);
             if(jvalue) {
-                e.callback_data = callback_data;
-                e.type = JSON_OBJECT;
+                JSON_ENTRY e = { .type = JSON_OBJECT, .callback_data = callback_data };
                 callback_function(&e);
                 json_object_object_foreach(jvalue, key, val) {
                     type = json_object_get_type(val);

--- a/src/libnetdata/json/json.c
+++ b/src/libnetdata/json/json.c
@@ -38,7 +38,7 @@ json_object *json_tokenise(char *js) {
 #else
 jsmntok_t *json_tokenise(char *js, size_t len, size_t *count)
 {
-    int n = json_tokens;
+    int n = __atomic_load_n(&json_tokens, __ATOMIC_RELAXED);
     if(!js || !len) {
         netdata_log_error("JSON: json string is empty.");
         return NULL;
@@ -75,7 +75,11 @@ jsmntok_t *json_tokenise(char *js, size_t len, size_t *count)
 
     if(count) *count = (size_t)ret;
 
-    if(json_tokens < n) json_tokens = n;
+    int cached = __atomic_load_n(&json_tokens, __ATOMIC_RELAXED);
+    while(cached < n && !__atomic_compare_exchange_n(
+              &json_tokens, &cached, n, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+        ;
+
     return tokens;
 }
 #endif

--- a/src/libnetdata/storage_number/storage_number.c
+++ b/src/libnetdata/storage_number/storage_number.c
@@ -5,13 +5,12 @@
 bool is_system_ieee754_double(void) {
 //    static bool logged = false;
 
+    if(sizeof(NETDATA_DOUBLE) != sizeof(uint64_t))
+        return false;
+
     struct {
         NETDATA_DOUBLE original;
-
-        union {
-            uint64_t i;
-            NETDATA_DOUBLE d;
-        };
+        uint64_t i;
     } tests[] = {
             { .original = 1.25,                 .i = 0x3FF4000000000000 },
             { .original = 1.0,                  .i = 0x3FF0000000000000 },
@@ -48,12 +47,16 @@ bool is_system_ieee754_double(void) {
     size_t errors = 0;
     size_t elements = sizeof(tests) / sizeof(tests[0]);
     for(size_t i = 0; i < elements ; i++) {
-        uint64_t *ptr = (uint64_t *)&tests[i].original;
+        uint64_t representation;
+        NETDATA_DOUBLE expected;
 
-        if(*ptr != tests[i].i && (tests[i].original == tests[i].d || (isnan(tests[i].original) && isnan(tests[i].d)))) {
+        memcpy(&representation, &tests[i].original, sizeof(representation));
+        memcpy(&expected, &tests[i].i, sizeof(tests[i].i));
+
+        if(representation != tests[i].i && (tests[i].original == expected || (isnan(tests[i].original) && isnan(expected)))) {
 //            if(!logged)
 //                netdata_log_info("IEEE754: test #%zu, value " NETDATA_DOUBLE_FORMAT_G " is represented in this system as %016llX, but it was expected as %016llX",
-//                     i+1, tests[i].original, (long long unsigned int)*ptr, (long long unsigned int)tests[i].i);
+//                     i+1, tests[i].original, (long long unsigned int)representation, (long long unsigned int)tests[i].i);
             errors++;
         }
     }

--- a/src/libnetdata/storage_number/storage_number.h
+++ b/src/libnetdata/storage_number/storage_number.h
@@ -85,14 +85,14 @@ typedef struct storage_number_tier1 {
 
 #define STORAGE_NUMBER_FORMAT "%u"
 
-typedef enum {
-    SN_FLAG_NONE              = 0,
-    SN_FLAG_NOT_ANOMALOUS     = (1 << 24), // the anomaly bit of the value (0:anomalous, 1:not anomalous)
-    SN_FLAG_RESET             = (1 << 25), // the value has been overflown
-    SN_FLAG_NOT_EXISTS_MUL100 = (1 << 26), // very large value (multiplier is 100 instead of 10)
-    SN_FLAG_MULTIPLY          = (1 << 30), // multiply, else divide
-    SN_FLAG_NEGATIVE          = (1 << 31), // negative, else positive
-} SN_FLAGS;
+typedef uint32_t SN_FLAGS;
+
+#define SN_FLAG_NONE              ((SN_FLAGS)0)
+#define SN_FLAG_NOT_ANOMALOUS     ((SN_FLAGS)(UINT32_C(1) << 24)) // the anomaly bit of the value (0:anomalous, 1:not anomalous)
+#define SN_FLAG_RESET             ((SN_FLAGS)(UINT32_C(1) << 25)) // the value has been overflown
+#define SN_FLAG_NOT_EXISTS_MUL100 ((SN_FLAGS)(UINT32_C(1) << 26)) // very large value (multiplier is 100 instead of 10)
+#define SN_FLAG_MULTIPLY          ((SN_FLAGS)(UINT32_C(1) << 30)) // multiply, else divide
+#define SN_FLAG_NEGATIVE          ((SN_FLAGS)(UINT32_C(1) << 31)) // negative, else positive
 
 #define SN_USER_FLAGS (SN_FLAG_NOT_ANOMALOUS | SN_FLAG_RESET)
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several undefined behaviors and a data race in core Netdata code. No behavior or wire-format changes; improves safety and stability.

- **Bug Fixes**
  - Buffer: add NUL terminator after html-escaped appends; use memcpy for fixed “Date” and “)\0”; encode doubles by copying bits to uint64_t before hex/base64 formatting.
  - Parser/JSON: make the `json_tokens` allocation hint atomic; zero-initialize `JSON_ENTRY` for array elements; decode IEEE754 payloads via memcpy in `str2ndd_encoded()`.
  - Storage numbers: validate IEEE754 representation with memcpy and return false if `NETDATA_DOUBLE` is not 64-bit; define `SN_FLAGS` as `uint32_t` and use typed bit macros so the sign flag shift is defined.

<sup>Written for commit 281c1e9f679fdc80cd4a068d138e14536d224acb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

