### PR TITLE
Netdata fixes part 2

### DIFF
--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -801,7 +801,7 @@ static void aral_del_page___no_lock_needed(ARAL *ar, ARAL_PAGE *page TRACE_ALLOC
 
         nd_munmap(page->data, page->size);
 
-        if (unlikely(unlink(page->filename) == 1))
+        if (unlikely(unlink(page->filename) == -1))
             netdata_log_error("Cannot delete file '%s'", page->filename);
 
         freez((void *)page->filename);

--- a/src/libnetdata/memory/nd-mallocz.c
+++ b/src/libnetdata/memory/nd-mallocz.c
@@ -140,6 +140,9 @@ void *realloc(void *ptr, size_t size) {
 }
 
 void *reallocarray(void *ptr, size_t n, size_t size) {
+    if(unlikely(size && n > SIZE_MAX / size))
+        fatal("reallocarray() cannot allocate %zu members of %zu bytes.", n, size);
+
     return reallocz(ptr, n * size);
 }
 
@@ -253,6 +256,9 @@ void malloc_trace_munmap(size_t size) {
 }
 
 void *mallocz_int(size_t size, const char *file, const char *function, size_t line) {
+    if(unlikely(size > SIZE_MAX - malloc_header_size))
+        fatal("mallocz() cannot allocate %zu bytes of memory.", size);
+
     struct malloc_trace *p = malloc_trace_find_or_create(file, function, line);
 
     size_t_atomic_count(add, p->malloc_calls, 1);
@@ -274,6 +280,9 @@ void *mallocz_int(size_t size, const char *file, const char *function, size_t li
 }
 
 void *callocz_int(size_t nmemb, size_t size, const char *file, const char *function, size_t line) {
+    if(unlikely(size && nmemb > (SIZE_MAX - malloc_header_size) / size))
+        fatal("callocz() cannot allocate %zu members of %zu bytes.", nmemb, size);
+
     struct malloc_trace *p = malloc_trace_find_or_create(file, function, line);
     size = nmemb * size;
 
@@ -298,6 +307,8 @@ void *callocz_int(size_t nmemb, size_t size, const char *file, const char *funct
 char *strdupz_int(const char *s, const char *file, const char *function, size_t line) {
     struct malloc_trace *p = malloc_trace_find_or_create(file, function, line);
     size_t size = strlen(s) + 1;
+    if(unlikely(size > SIZE_MAX - malloc_header_size))
+        fatal("strdupz() cannot allocate %zu bytes of memory.", size);
 
     size_t_atomic_count(add, p->strdup_calls, 1);
     size_t_atomic_count(add, p->allocations, 1);
@@ -362,6 +373,9 @@ void *reallocz_int(void *ptr, size_t size, const char *file, const char *functio
         return libc_realloc(ptr, size);
 
     if(t->signature.size == size) return ptr;
+    if(unlikely(size > SIZE_MAX - malloc_header_size))
+        fatal("reallocz() cannot allocate %zu bytes of memory.", size);
+
     size_t_atomic_count(add, t->signature.trace->free_calls, 1);
     size_t_atomic_count(sub, t->signature.trace->allocations, 1);
     size_t_atomic_bytes(sub, t->signature.trace->bytes, t->signature.size);

--- a/src/libnetdata/memory/nd-mmap.c
+++ b/src/libnetdata/memory/nd-mmap.c
@@ -152,7 +152,7 @@ void *nd_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t offset)
         __atomic_add_fetch(&nd_mmap_size, len, __ATOMIC_RELAXED);
 
 #ifdef NETDATA_TRACE_ALLOCATIONS
-        malloc_trace_mmap(size);
+        malloc_trace_mmap(len);
 #endif
     }
 

--- a/src/libnetdata/memory/nd-mmap.c
+++ b/src/libnetdata/memory/nd-mmap.c
@@ -42,11 +42,15 @@ static int memory_file_open(const char *filename, size_t size) {
     return fd;
 }
 
+static inline bool madvise_log_first_failure(int *logger) {
+    return __atomic_exchange_n(logger, 0, __ATOMIC_RELAXED) > 0;
+}
+
 inline int madvise_sequential(void *mem, size_t len) {
     static int logger = 1;
     int ret = madvise(mem, len, MADV_SEQUENTIAL);
 
-    if (ret != 0 && logger-- > 0)
+    if (ret != 0 && madvise_log_first_failure(&logger))
         netdata_log_error("madvise(MADV_SEQUENTIAL) of size %zu, failed.", len);
     return ret;
 }
@@ -55,7 +59,7 @@ inline int madvise_random(void *mem, size_t len) {
     static int logger = 1;
     int ret = madvise(mem, len, MADV_RANDOM);
 
-    if (ret != 0 && logger-- > 0)
+    if (ret != 0 && madvise_log_first_failure(&logger))
         netdata_log_error("madvise(MADV_RANDOM) of size %zu, failed.", len);
     return ret;
 }
@@ -64,7 +68,7 @@ inline int madvise_dontfork(void *mem, size_t len) {
     static int logger = 1;
     int ret = madvise(mem, len, MADV_DONTFORK);
 
-    if (ret != 0 && logger-- > 0)
+    if (ret != 0 && madvise_log_first_failure(&logger))
         netdata_log_error("madvise(MADV_DONTFORK) of size %zu, failed.", len);
     return ret;
 }
@@ -73,7 +77,7 @@ inline int madvise_willneed(void *mem, size_t len) {
     static int logger = 1;
     int ret = madvise(mem, len, MADV_WILLNEED);
 
-    if (ret != 0 && logger-- > 0)
+    if (ret != 0 && madvise_log_first_failure(&logger))
         netdata_log_error("madvise(MADV_WILLNEED) of size %zu, failed.", len);
     return ret;
 }
@@ -82,7 +86,7 @@ inline int madvise_dontneed(void *mem, size_t len) {
     static int logger = 1;
     int ret = madvise(mem, len, MADV_DONTNEED);
 
-    if (ret != 0 && logger-- > 0)
+    if (ret != 0 && madvise_log_first_failure(&logger))
         netdata_log_error("madvise(MADV_DONTNEED) of size %zu, failed.", len);
     return ret;
 }
@@ -92,7 +96,7 @@ inline int madvise_dontdump(void *mem __maybe_unused, size_t len __maybe_unused)
     static int logger = 1;
     int ret = madvise(mem, len, MADV_DONTDUMP);
 
-    if (ret != 0 && logger-- > 0)
+    if (ret != 0 && madvise_log_first_failure(&logger))
         netdata_log_error("madvise(MADV_DONTDUMP) of size %zu, failed.", len);
     return ret;
 #else
@@ -105,7 +109,7 @@ inline int madvise_mergeable(void *mem __maybe_unused, size_t len __maybe_unused
     static int logger = 1;
     int ret = madvise(mem, len, MADV_MERGEABLE);
 
-    if (ret != 0 && logger-- > 0)
+    if (ret != 0 && madvise_log_first_failure(&logger))
         netdata_log_error("madvise(MADV_MERGEABLE) of size %zu, failed.", len);
     return ret;
 #else


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens memory allocation and mmap helpers without changing normal-build behavior. Adds overflow checks to traced allocators, fixes `unlink()` error handling, makes `madvise` failure logging thread-safe, and uses the correct length for mmap trace accounting.

- **Bug Fixes**
  - Fix `unlink()` check in ARAL page cleanup (compare against `-1`; log on failure).
  - Guard size arithmetic in traced allocators (`reallocarray()`, `mallocz_int()`, `callocz_int()`, `strdupz_int()`, `reallocz_int()`) to prevent overflow and abort unrepresentable requests.
  - Atomically gate first-failure logging in `madvise_*` helpers to remove a data race.
  - Pass `len` to `malloc_trace_mmap()` in `nd_mmap()` for correct trace accounting.

<sup>Written for commit 091b94ea156a09f493d544469952c583c872d31b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

