### PR TITLE
Netdata fixes part 3

### DIFF
--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -1171,6 +1171,13 @@ static inline bool local_sockets_read_proc_net_x_procfile(LS_STATE *ls, const ch
     return true;
 }
 
+static inline bool local_sockets_read_proc_net_x(LS_STATE *ls, const char *filename, uint16_t family, uint16_t protocol) {
+    if(ls->config.procfile)
+        return local_sockets_read_proc_net_x_procfile(ls, filename, family, protocol);
+
+    return local_sockets_read_proc_net_x_getline(ls, filename, family, protocol);
+}
+
 #endif // !OS_FREEBSD
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -1401,10 +1408,7 @@ static inline void local_sockets_do_family_protocol(LS_STATE *ls, const char *fi
 
     local_sockets_track_time_by_protocol(ls, false, family, protocol);
 
-    if(ls->config.procfile)
-        local_sockets_read_proc_net_x_procfile(ls, filename, family, protocol);
-    else
-        local_sockets_read_proc_net_x_getline(ls, filename, family, protocol);
+    local_sockets_read_proc_net_x(ls, filename, family, protocol);
 }
 
 static inline void local_sockets_read_all_system_sockets(LS_STATE *ls) {

--- a/src/libnetdata/os/setenv.c
+++ b/src/libnetdata/os/setenv.c
@@ -38,6 +38,6 @@ void nd_setenv(const char *name, const char *value, int overwrite) {
 #ifdef HAVE_SETENV
     setenv(name, value, overwrite);
 #else
-    os_setenv(name, value, overwite);
+    os_setenv(name, value, overwrite);
 #endif
 }

--- a/src/libnetdata/procfile/procfile.c
+++ b/src/libnetdata/procfile/procfile.c
@@ -407,7 +407,7 @@ static void procfile_set_separators(procfile *ff, const char *separators) {
     PF_CHAR_TYPE *ffs = ff->separators;
     const char *s = separators;
     while(*s)
-        ffs[(int)*s++] = PF_CHAR_IS_SEPARATOR;
+        ffs[(unsigned char)*s++] = PF_CHAR_IS_SEPARATOR;
 }
 
 void procfile_set_quotes(procfile *ff, const char *quotes) {
@@ -426,7 +426,7 @@ void procfile_set_quotes(procfile *ff, const char *quotes) {
     // set the quotes
     const char *s = quotes;
     while(*s)
-        ffs[(int)*s++] = PF_CHAR_IS_QUOTE;
+        ffs[(unsigned char)*s++] = PF_CHAR_IS_QUOTE;
 }
 
 void procfile_set_open_close(procfile *ff, const char *open, const char *close) {
@@ -445,12 +445,12 @@ void procfile_set_open_close(procfile *ff, const char *open, const char *close) 
     // set the openings
     const char *s = open;
     while(*s)
-        ffs[(int)*s++] = PF_CHAR_IS_OPEN;
+        ffs[(unsigned char)*s++] = PF_CHAR_IS_OPEN;
 
     // set the closings
     s = close;
     while(*s)
-        ffs[(int)*s++] = PF_CHAR_IS_CLOSE;
+        ffs[(unsigned char)*s++] = PF_CHAR_IS_CLOSE;
 }
 
 procfile *procfile_open(const char *filename, const char *separators, uint32_t flags) {

--- a/src/libnetdata/socket/connect-to.c
+++ b/src/libnetdata/socket/connect-to.c
@@ -429,7 +429,7 @@ static bool connect_to_one_of_callback(char *entry, void *data) {
     t->sock = connect_to_this(entry, t->default_port, t->timeout);
     if(t->sock != -1) {
         if(t->connected_to && t->connected_to_size) {
-            strncpyz(t->connected_to, entry, t->connected_to_size);
+            strncpyz(t->connected_to, entry, t->connected_to_size - 1);
             t->connected_to[t->connected_to_size - 1] = '\0';
         }
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several libnetdata issues to improve safety and portability. Prevents a buffer overrun, corrects procfile byte indexing, restores the `setenv` fallback, and adds a missing proc-net reader dispatcher.

- **Bug Fixes**
  - Bound `strncpyz` in connect path (`connected_to_size - 1`) to avoid an out-of-bounds terminator write.
  - Index character-class tables with `(unsigned char)` in procfile setters to prevent negative indexes and OOB writes on signed-char platforms.
  - Fix `nd_setenv()` fallback to pass the correct `overwrite` argument.
  - Add `local_sockets_read_proc_net_x()` dispatcher and use it in the proc-net reader path; fixes fallback build without changing Linux/FreeBSD behavior.

<sup>Written for commit 7bf208086d6d317b7acd544bb549fdde31b71f05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

