### PR TITLE
Netdata fixes part 4

### DIFF
--- a/src/daemon/pulse/pulse.h
+++ b/src/daemon/pulse/pulse.h
@@ -40,7 +40,7 @@ void pulse_thread_memory_extended_main(void *ptr);
 #define p1_fetch_sub(variable, value) __atomic_fetch_sub(variable, value, __ATOMIC_RELAXED)
 
 #define p1_store(variable, value) __atomic_store_n(variable, value, __ATOMIC_RELAXED)
-#define p1_load(variable) __atomic_load_n(variable, value, __ATOMIC_RELAXED)
+#define p1_load(variable) __atomic_load_n(variable, __ATOMIC_RELAXED)
 
 #define p2_add_fetch(variable, value) __atomic_add_fetch(variable, value, __ATOMIC_RELAXED)
 #define p2_sub_fetch(variable, value) __atomic_sub_fetch(variable, value, __ATOMIC_RELAXED)
@@ -49,6 +49,6 @@ void pulse_thread_memory_extended_main(void *ptr);
 #define p2_fetch_sub(variable, value) __atomic_fetch_sub(variable, value, __ATOMIC_RELAXED)
 
 #define p2_store(variable, value) __atomic_store_n(variable, value, __ATOMIC_RELAXED)
-#define p2_load(variable) __atomic_load_n(variable, value, __ATOMIC_RELAXED)
+#define p2_load(variable) __atomic_load_n(variable, __ATOMIC_RELAXED)
 
 #endif /* NETDATA_PULSE_H */

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -58,11 +58,6 @@ void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused)
 
         signals_waiting[i].count++;
 
-#if defined(FSANITIZE_ADDRESS)
-        if(signals_waiting[i].action == NETDATA_SIGNAL_EXIT_NOW)
-            exit(1);
-#endif
-
         if(signals_waiting[i].action == NETDATA_SIGNAL_DEADLY) {
             bool chained_handler = original_sigactions[signo] || (original_handlers[signo] && original_handlers[signo] != SIG_IGN && original_handlers[signo] != SIG_DFL);
 
@@ -256,6 +251,12 @@ static void process_triggered_signals(void) {
                     commands_exit();
                     netdata_exit_gracefully(signals_waiting[i].reason, true);
                     break;
+
+#if defined(FSANITIZE_ADDRESS)
+                case NETDATA_SIGNAL_EXIT_NOW:
+                    exit(1);
+                    break;
+#endif
 
                 case NETDATA_SIGNAL_DEADLY:
                     _exit(1);

--- a/src/libnetdata/stacktrace/stacktrace-libbacktrace.c
+++ b/src/libnetdata/stacktrace/stacktrace-libbacktrace.c
@@ -39,6 +39,8 @@ static int bt_collect_frames_callback(void *data, uintptr_t pc) {
     return 0;
 }
 
+static void bt_collect_frames_error_handler(void *data __maybe_unused, const char *msg __maybe_unused, int errnum __maybe_unused) {}
+
 // Common function to format and add a stack frame to the buffer
 static void add_stack_frame(backtrace_data_t *bt_data, uintptr_t pc, const char *function,
                           const char *filename, int lineno) {
@@ -249,7 +251,7 @@ int impl_stacktrace_get_frames(void **frames, int max_frames, int skip_frames) {
     };
     
     // Pass 0 as skip_frames to backtrace_simple and let the callback handle skipping
-    backtrace_simple(backtrace_state, 0, bt_collect_frames_callback, bt_error_handler, &data);
+    backtrace_simple(backtrace_state, 0, bt_collect_frames_callback, bt_collect_frames_error_handler, &data);
     
     return data.num_frames;
 }

--- a/src/libnetdata/stacktrace/stacktrace-libunwind.c
+++ b/src/libnetdata/stacktrace/stacktrace-libunwind.c
@@ -163,17 +163,16 @@ void impl_stacktrace_to_buffer(STACKTRACE trace, BUFFER *wb) {
         // Try to resolve symbol name
         unw_cursor_t cursor;
         unw_context_t context;
-        char sym[256] = "<unknown>";
+        Dl_info info;
         unw_word_t offset = 0;
         
         // We don't have the context anymore, so do the best we can
         // Try to resolve the address to a symbol name
-        if (dladdr(st->frames[i], (Dl_info *)sym) == 0) {
+        if (dladdr(st->frames[i], &info) == 0) {
             buffer_strcat(wb, "<unknown>");
         } else {
-            Dl_info *info = (Dl_info *)sym;
-            if (info->dli_sname)
-                buffer_strcat(wb, info->dli_sname);
+            if (info.dli_sname)
+                buffer_strcat(wb, info.dli_sname);
             else
                 buffer_strcat(wb, "<unknown>");
         }


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unsafe signal handling and stacktrace edge cases, and corrects atomic load macros to prevent future build issues. Improves stability under `FSANITIZE_ADDRESS` and removes undefined behavior in stack frame resolution.

- **Bug Fixes**
  - Stacktrace (libbacktrace): add a dedicated no-op error callback for raw frame collection to prevent wrong-typed callback usage and potential memory corruption on errors.
  - Stacktrace (libunwind): use real `Dl_info` with `dladdr()` instead of a casted buffer to remove undefined behavior.
  - Signals: move sanitizer-only `exit(1)` out of the sigaction handler into the normal dispatch path, keeping LSAN hooks and avoiding non-async-signal-safe calls in the handler.
  - Pulse: fix `p1_load`/`p2_load` to call `__atomic_load_n(variable, __ATOMIC_RELAXED)` with the correct signature.

<sup>Written for commit 134f10f2cfb607a92b8ce03d87c123b9dba8f385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

