### PR TITLE
Netdata fixes part 5

### DIFF
--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -539,13 +539,17 @@ int ws_client_process_rx_ws(ws_client *client)
         case WS_PAYLOAD_EXTENDED_16:
             BUF_READ_CHECK_AT_LEAST(2);
             rbuf_pop(client->buf_read, buf, 2);
-            client->rx.payload_length = be16toh(*((uint16_t *)buf));
+            uint16_t payload_length16;
+            memcpy(&payload_length16, buf, sizeof(payload_length16));
+            client->rx.payload_length = be16toh(payload_length16);
             ws_client_rx_post_hdr_state(client);
             break;
         case WS_PAYLOAD_EXTENDED_64:
             BUF_READ_CHECK_AT_LEAST(LONGEST_POSSIBLE_HDR_PART);
             rbuf_pop(client->buf_read, buf, LONGEST_POSSIBLE_HDR_PART);
-            client->rx.payload_length = be64toh(*((uint64_t *)buf));
+            uint64_t payload_length64;
+            memcpy(&payload_length64, buf, sizeof(payload_length64));
+            client->rx.payload_length = be64toh(payload_length64);
             ws_client_rx_post_hdr_state(client);
             break;
         case WS_PAYLOAD_DATA:
@@ -591,7 +595,9 @@ int ws_client_process_rx_ws(ws_client *client)
             BUF_READ_CHECK_AT_LEAST(sizeof(uint16_t));
 
             rbuf_pop(client->buf_read, buf, sizeof(uint16_t));
-            client->rx.specific_data.op_close.ec = be16toh(*((uint16_t *)buf));
+            uint16_t close_code;
+            memcpy(&close_code, buf, sizeof(close_code));
+            client->rx.specific_data.op_close.ec = be16toh(close_code);
             client->rx.payload_processed += sizeof(uint16_t);
 
             client->rx.remote_closed = true;

--- a/src/database/engine/dbengine-compression.c
+++ b/src/database/engine/dbengine-compression.c
@@ -135,7 +135,7 @@ size_t dbengine_decompress(void *dst, void *src, size_t dst_size, size_t src_siz
         case RRDENG_COMPRESSION_LZ4: {
             int rc = LZ4_decompress_safe(src, dst, (int)src_size, (int)dst_size);
             if(rc < 0) {
-                nd_log(NDLS_DAEMON, NDLP_ERR, "DBENGINE: ZSTD decompression error %d", rc);
+                nd_log(NDLS_DAEMON, NDLP_ERR, "DBENGINE: LZ4 decompression error %d", rc);
                 rc = 0;
             }
 

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -695,7 +695,7 @@ static int journalfile_check_superblock(uv_file file)
 
 static void journalfile_restore_extent_metadata(struct rrdengine_instance *ctx, struct rrdengine_journalfile *journalfile, void *buf, unsigned max_size)
 {
-    static bitmap64_t page_error_map = BITMAP64_INITIALIZER;
+    static bool page_error_map[UINT8_MAX + 1];
     unsigned i, count, payload_length, descr_size;
     struct rrdeng_jf_store_data *jf_metric_data;
 
@@ -716,9 +716,9 @@ static void journalfile_restore_extent_metadata(struct rrdengine_instance *ctx, 
         uint8_t page_type = jf_metric_data->descr[i].type;
 
         if (page_type > RRDENG_PAGE_TYPE_MAX) {
-            if (!bitmap64_get(&page_error_map, page_type)) {
+            if (!page_error_map[page_type]) {
                 netdata_log_error("DBENGINE: unknown page type %d encountered.", page_type);
-                bitmap64_set(&page_error_map, page_type);
+                page_error_map[page_type] = true;
             }
             continue;
         }

--- a/src/web/api/v2/api_v2_progress.c
+++ b/src/web/api/v2/api_v2_progress.c
@@ -19,7 +19,7 @@ int api_v2_progress(RRDHOST *host __maybe_unused, struct web_client *w, char *ur
         if(!strcmp(name, "transaction")) transaction = value;
     }
 
-    nd_uuid_t tr;
+    nd_uuid_t tr = {0};
     uuid_parse_flexi(transaction, tr);
 
     rrd_function_call_progresser(&tr);

--- a/src/web/mcp/adapters/mcp-websocket.c
+++ b/src/web/mcp/adapters/mcp-websocket.c
@@ -64,14 +64,14 @@ void mcp_websocket_on_message(struct websocket_server_client *wsc, const char *m
     if (!wsc || !message || length == 0)
         return;
     
-    // Log the raw incoming message
-    netdata_log_debug(D_MCP, "RCV: %s", message);
-    
     // Only handle text messages
     if (opcode != WS_OPCODE_TEXT) {
         websocket_error(wsc, "Ignoring binary message - mcp supports only TEXT messages");
         return;
     }
+
+    // Log the raw incoming message
+    netdata_log_debug(D_MCP, "RCV: %s", message);
     
     // Silently ignore standalone "PING" messages (legacy MCP client behavior)
     if (length == 4 && strncmp(message, "PING", 4) == 0) {

--- a/src/web/rtc/webrtc.c
+++ b/src/web/rtc/webrtc.c
@@ -377,16 +377,21 @@ static void myClosedCallback(int id __maybe_unused, void *user_ptr) {
     webrtc_set_thread_name();
 
     WEBRTC_DC *chan = user_ptr;
-    internal_fatal(chan->dc != id, "WEBRTC[%d],DC[%d]: dc mismatch, expected %d, got %d", chan->conn->pc, chan->dc, chan->dc, id);
+    WEBRTC_CONN *conn = chan->conn;
+    int pc = conn->pc;
+    int dc = chan->dc;
+    const char *label = chan->label;
+
+    internal_fatal(dc != id, "WEBRTC[%d],DC[%d]: dc mismatch, expected %d, got %d", pc, dc, dc, id);
 
     __atomic_store_n(&chan->open, false, __ATOMIC_RELAXED);
-    internal_error(true, "WEBRTC[%d],DC[%d]: data channel closed.", chan->conn->pc, chan->dc);
+    internal_error(true, "WEBRTC[%d],DC[%d]: data channel closed.", pc, dc);
 
-    spinlock_lock(&chan->conn->channels.spinlock);
-    DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(chan->conn->channels.head, chan, link.prev, link.next);
-    spinlock_unlock(&chan->conn->channels.spinlock);
+    spinlock_lock(&conn->channels.spinlock);
+    DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(conn->channels.head, chan, link.prev, link.next);
+    spinlock_unlock(&conn->channels.spinlock);
 
-    nd_log(NDLS_ACCESS, NDLP_DEBUG, "WEBRTC[%d],DC[%d]: %d DATA CHANNEL '%s' CLOSED", chan->conn->pc, chan->dc, gettid_cached(), chan->label);
+    nd_log(NDLS_ACCESS, NDLP_DEBUG, "WEBRTC[%d],DC[%d]: %d DATA CHANNEL '%s' CLOSED", pc, dc, gettid_cached(), label);
 
     freez(chan->label);
     freez(chan);


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves safety and correctness across WebSocket, WebRTC, API, and DB engine paths by removing undefined behavior, fixing a close-path race, and correcting logs. Hardens behavior under malformed input and edge cases with negligible performance impact.

- **Bug Fixes**
  - ACLK WebSocket: avoid unaligned header reads by copying to aligned `uint16_t`/`uint64_t` locals before endian conversion.
  - MCP WebSocket: reject non-text frames before debug logging to prevent out-of-bounds `%s` reads.
  - API v2 progress: initialize `nd_uuid_t` to zero before parsing to avoid using uninitialized stack data.
  - DB engine journal replay: replace 64-bit bitmap with `bool[256]` to safely track and log unknown page types.
  - DB engine compression: correct LZ4 failure log label (was mistakenly labeled as ZSTD).
  - WebRTC: cache connection/channel info before unlinking to avoid a close-path use-after-free read.

<sup>Written for commit a8a7bc8a21e3209400e671465467bdb48397927e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

