### PR TITLE
Netdata fixes part 6

### DIFF
--- a/src/libnetdata/socket/nd-sock.c
+++ b/src/libnetdata/socket/nd-sock.c
@@ -120,8 +120,11 @@ bool nd_sock_connect_to_this(ND_SOCK *s, const char *definition, int default_por
 
     if(ssl && s->ctx) {
         if (!nd_sock_open_ssl(s)) {
+            netdata_ssl_close(&s->ssl);
             close(s->fd);
             s->fd = -1;
+            freez(s->sni_hostname);
+            s->sni_hostname = NULL;
             return false;
         }
     }

--- a/src/libnetdata/socket/security.c
+++ b/src/libnetdata/socket/security.c
@@ -821,6 +821,7 @@ int security_test_certificate(SSL *ssl) {
         ret = 0;
     }
 
+    X509_free(cert);
     return ret;
 }
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSL/TLS resource leaks and cleanup paths: frees the peer certificate on OpenSSL 3.x and clears SSL/SNI state when TLS setup fails. Behavior is unchanged; reduces memory leaks on failed and verified connections.

- **Bug Fixes**
  - security.c: Free the owned peer certificate with X509_free() after verification to prevent a per-connection X509 leak.
  - nd-sock.c: On TLS setup failure, close the SSL sub-structure and free the SNI hostname before closing the socket.

<sup>Written for commit 5418c023555a8ef02512cfb5406a0277fc3b82cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

