### PR TITLE
build(rust): keep line tables instead of full debuginfo 

### DIFF
--- a/src/crates/Cargo.toml
+++ b/src/crates/Cargo.toml
@@ -192,8 +192,9 @@ debug = true
 debug-assertions = true
 
 [profile.release]
-# Keep debuginfo in packaged release builds so production crashes remain symbolizable.
-debug = true
+# Keep line tables in packaged release builds so production crash backtraces stay
+# symbolizable (function + file:line) without the size cost of full DWARF debuginfo.
+debug = "line-tables-only"
 opt-level = 3
 lto = "fat"
 codegen-units = 1


### PR DESCRIPTION
##### Summary

The workspace release profile shipped full DWARF (debug = true), bloating the netflow, otel, and otel-signal-viewer plugin binaries. Switch to debug = "line-tables-only" so crash backtraces stay symbolizable (function + file:line) without the size cost of type/variable debuginfo.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Rust plugin binary size by setting `[profile.release].debug` to `line-tables-only` in `Cargo.toml`. Backtraces remain symbolizable (function + file:line) in production without the size cost of full debug info; affects netflow, otel, and otel-signal-viewer.

<sup>Written for commit 723887e93b1fbd443f9c3bb1e3f709edb235d5d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

