### PR TITLE
Netdata fixes part 8

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -603,6 +603,9 @@ static void send_command_reply(struct command_context *cmd_ctx, cmd_status_t sta
     ret = uv_write(&cmd_ctx->write_req, (uv_stream_t *)client, &write_buf, 1, pipe_write_cb);
     if (ret) {
         netdata_log_error("uv_write(): %s", uv_strerror(ret));
+        buffer_free(reply_string);
+        uv_close((uv_handle_t *)client, pipe_close_cb);
+        --clients;
     }
 }
 

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -138,14 +138,16 @@ static void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)
 static ULONGLONG netdata_windows_get_disk_size(char *cVolume)
 {
     HANDLE disk = CreateFile(cVolume, GENERIC_READ, FILE_SHARE_VALID_FLAGS, 0, OPEN_EXISTING, 0, 0);
-    if (!disk)
+    if (disk == INVALID_HANDLE_VALUE)
         return 0;
 
     GET_LENGTH_INFORMATION length;
     DWORD ret;
 
-    if (!DeviceIoControl(disk, IOCTL_DISK_GET_LENGTH_INFO, 0, 0, &length, sizeof(length), &ret, 0))
+    if (!DeviceIoControl(disk, IOCTL_DISK_GET_LENGTH_INFO, 0, 0, &length, sizeof(length), &ret, 0)) {
+        CloseHandle(disk);
         return 0;
+    }
 
     CloseHandle(disk);
 

--- a/src/health/health_variable.c
+++ b/src/health/health_variable.c
@@ -350,10 +350,12 @@ bool alert_variable_lookup_internal(STRING *variable, void *data, NETDATA_DOUBLE
     if (strendswith_lengths(vbd.dimension, vbd.dimension_length, "_raw", 4)) {
         vbd.dimension_length -= 4;
         vbd.dimension_selection = DIM_SELECT_RAW;
+        string_freez(vbd.dim);
         vbd.dim = string_strndupz(vbd.dimension, vbd.dimension_length);
     } else if (strendswith_lengths(vbd.dimension, vbd.dimension_length, "_last_collected_t", 17)) {
         vbd.dimension_length -= 17;
         vbd.dimension_selection = DIM_SELECT_LAST_COLLECTED;
+        string_freez(vbd.dim);
         vbd.dim = string_strndupz(vbd.dimension, vbd.dimension_length);
     }
 

--- a/src/libnetdata/spawn_server/spawn_server_windows.c
+++ b/src/libnetdata/spawn_server/spawn_server_windows.c
@@ -250,6 +250,8 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_un
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "SPAWN PARENT: cannot CreateProcess() for request No %zu, command: %s",
                instance->request_id, command);
+        if(env_block)
+            FreeEnvironmentStrings(env_block);
         goto cleanup;
     }
 

--- a/src/web/api/v3/api_v3_settings.c
+++ b/src/web/api/v3/api_v3_settings.c
@@ -195,6 +195,8 @@ static inline int settings_put(struct web_client *w, char *file) {
     settings_filename(filename, file, NULL);
 
     bool renamed = rename(tmp_filename, filename) == 0;
+    if(!renamed)
+        unlink(tmp_filename);
 
     rw_spinlock_write_unlock(&settings_spinlock);
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resource-leak and error-path issues across Windows code and the settings API. Prevents leaked buffers/handles and stale temp files; success paths are unchanged.

- **Bug Fixes**
  - Commands: on synchronous uv_write() failure, free the reply buffer, close the client, and decrement the counter.
  - Windows disk size: check for INVALID_HANDLE_VALUE and close the handle on DeviceIoControl() failure.
  - Health variables: release the previous dim before assigning trimmed names for _raw and _last_collected_t.
  - Windows spawn server: free the environment block when CreateProcess() fails.
  - Settings API: unlink the temp file if rename() fails during PUT.

<sup>Written for commit cafa319f719236dac01d1060a32af07a94d25fe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

