### PR TITLE
Netdata fixes part 7

### DIFF
--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -315,6 +315,7 @@ done:
 static void commit_alert_events(RRDHOST *host)
 {
     sqlite3_stmt *res = NULL;
+    sqlite3_stmt *res_version = NULL;
 
     if (!PREPARE_STATEMENT(db_meta, SQL_SELECT_ALERT_TO_DUMMY, &res))
         return;
@@ -325,7 +326,6 @@ static void commit_alert_events(RRDHOST *host)
     int64_t first_sequence_id = 0;
     int64_t last_sequence_id = 0;
 
-    sqlite3_stmt *res_version = NULL;
     param = 0;
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
 
@@ -349,6 +349,7 @@ static void commit_alert_events(RRDHOST *host)
 done:
     REPORT_BIND_FAIL(res, param);
     SQLITE_FINALIZE(res);
+    SQLITE_FINALIZE(res_version);
 }
 
 typedef enum {

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -1196,6 +1196,7 @@ int health_migrate_old_health_log_table(char *table) {
         freez(uuid_from_table);
         return 0;
     }
+    freez(uuid_from_table);
 
     int rc;
     char command[MAX_HEALTH_SQL_SIZE + 1];
@@ -1204,21 +1205,18 @@ int health_migrate_old_health_log_table(char *table) {
     rc = sqlite3_prepare_v2(db_meta, command, -1, &res, 0);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to prepare statement to copy health log, rc = %d", rc);
-        freez(uuid_from_table);
         return 0;
     }
 
     rc = sqlite3_bind_blob(res, 1, &uuid, sizeof(uuid), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         SQLITE_FINALIZE(res);
-        freez(uuid_from_table);
         return 0;
     }
 
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to execute SQL_COPY_HEALTH_LOG, rc = %d", rc);
-        freez(uuid_from_table);
     }
     SQLITE_FINALIZE(res);
     res = NULL;

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -1218,9 +1218,10 @@ int health_migrate_old_health_log_table(char *table) {
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to execute SQL_COPY_HEALTH_LOG, rc = %d", rc);
-        SQLITE_FINALIZE(res);
         freez(uuid_from_table);
     }
+    SQLITE_FINALIZE(res);
+    res = NULL;
 
     //detail
     snprintfz(command, sizeof(command) - 1, SQL_COPY_HEALTH_LOG_DETAIL(table));
@@ -1242,6 +1243,8 @@ int health_migrate_old_health_log_table(char *table) {
         SQLITE_FINALIZE(res);
         return 0;
     }
+    SQLITE_FINALIZE(res);
+    res = NULL;
 
     //update transition ids
     rc = sqlite3_prepare_v2(db_meta, SQL_UPDATE_HEALTH_LOG_DETAIL_TRANSITION_ID, -1, &res, 0);
@@ -1256,6 +1259,8 @@ int health_migrate_old_health_log_table(char *table) {
         SQLITE_FINALIZE(res);
         return 0;
     }
+    SQLITE_FINALIZE(res);
+    res = NULL;
 
     //update health_log_id
     rc = sqlite3_prepare_v2(db_meta, SQL_UPDATE_HEALTH_LOG_DETAIL_HEALTH_LOG_ID, -1, &res, 0);
@@ -1279,8 +1284,9 @@ int health_migrate_old_health_log_table(char *table) {
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to execute SQL_UPDATE_HEALTH_LOG_DETAIL_HEALTH_LOG_ID, rc = %d", rc);
-        SQLITE_FINALIZE(res);
     }
+    SQLITE_FINALIZE(res);
+    res = NULL;
 
     //update last transition id
     rc = sqlite3_prepare_v2(db_meta, SQL_UPDATE_HEALTH_LOG_LAST_TRANSITION_ID, -1, &res, 0);
@@ -1298,8 +1304,9 @@ int health_migrate_old_health_log_table(char *table) {
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to execute SQL_UPDATE_HEALTH_LOG_LAST_TRANSITION_ID, rc = %d", rc);
-        SQLITE_FINALIZE(res);
     }
+    SQLITE_FINALIZE(res);
+    res = NULL;
 
     return 1;
 }


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SQLite statement and memory leaks in alert commit and health log migration paths. Finalizes prepared statements and frees temporary UUID memory to reduce resource usage without changing behavior.

- **Bug Fixes**
  - Alert commit: initialize and finalize `res_version` to avoid leaking the update statement.
  - Health migration: finalize each prepared statement and clear the pointer before preparing the next.
  - Health migration: free `uuid_from_table` after successful parse.

<sup>Written for commit 02b68ea67959f4323d28e6427d7df83b08bd407f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

