### PR TITLE
Netdata fixes part 9

### DIFF
--- a/src/libnetdata/libjudy/judyl-typed.h
+++ b/src/libnetdata/libjudy/judyl-typed.h
@@ -36,7 +36,7 @@
     ALWAYS_INLINE                                                                                       \
     static TYPE __attribute__((unused)) NAME##_GET(NAME##_JudyLSet *set, Word_t index) {                \
         Pvoid_t *pValue = JudyLGet(set->judyl, index, PJE0);                                            \
-        return (pValue != NULL) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};                              \
+        return (pValue != NULL && pValue != PJERR) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};           \
     }                                                                                                   \
                                                                                                         \
     ALWAYS_INLINE                                                                                       \
@@ -47,25 +47,25 @@
     ALWAYS_INLINE                                                                                       \
     static TYPE __attribute__((unused)) NAME##_FIRST(NAME##_JudyLSet *set, Word_t *index) {             \
         Pvoid_t *pValue = JudyLFirst(set->judyl, index, PJE0);                                          \
-        return (pValue != NULL) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};                              \
+        return (pValue != NULL && pValue != PJERR) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};           \
     }                                                                                                   \
                                                                                                         \
     ALWAYS_INLINE                                                                                       \
     static TYPE __attribute__((unused)) NAME##_NEXT(NAME##_JudyLSet *set, Word_t *index) {              \
         Pvoid_t *pValue = JudyLNext(set->judyl, index, PJE0);                                           \
-        return (pValue != NULL) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};                              \
+        return (pValue != NULL && pValue != PJERR) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};           \
     }                                                                                                   \
                                                                                                         \
     ALWAYS_INLINE                                                                                       \
     static TYPE __attribute__((unused)) NAME##_LAST(NAME##_JudyLSet *set, Word_t *index) {              \
         Pvoid_t *pValue = JudyLLast(set->judyl, index, PJE0);                                           \
-        return (pValue != NULL) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};                              \
+        return (pValue != NULL && pValue != PJERR) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};           \
     }                                                                                                   \
                                                                                                         \
     ALWAYS_INLINE                                                                                       \
     static TYPE __attribute__((unused)) NAME##_PREV(NAME##_JudyLSet *set, Word_t *index) {              \
         Pvoid_t *pValue = JudyLPrev(set->judyl, index, PJE0);                                           \
-        return (pValue != NULL) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};                              \
+        return (pValue != NULL && pValue != PJERR) ? (TYPE)UNPACK_MACRO(*pValue) : (TYPE){0};           \
     }                                                                                                   \
                                                                                                         \
     ALWAYS_INLINE                                                                                       \
@@ -74,7 +74,7 @@
         Pvoid_t *pValue;                                                                                \
         if (callback) {                                                                                 \
             for (pValue = JudyLFirst(set->judyl, &index, PJE0);                                         \
-                 pValue != NULL;                                                                        \
+                 pValue != NULL && pValue != PJERR;                                                     \
                  pValue = JudyLNext(set->judyl, &index, PJE0)) {                                        \
                 callback(index, (TYPE)UNPACK_MACRO(*pValue), data);                                     \
             }                                                                                           \

--- a/src/libnetdata/line_splitter/line_splitter.h
+++ b/src/libnetdata/line_splitter/line_splitter.h
@@ -32,6 +32,13 @@ extern bool isspace_map_group_by_label[256];
 extern bool isspace_dyncfg_id_map[256];
 
 static ALWAYS_INLINE size_t quoted_strings_splitter(char *str, char **words, size_t max_words, bool *isspace_map) {
+    if (unlikely(!str)) {
+        if (likely(max_words))
+            words[0] = NULL;
+
+        return 0;
+    }
+
     char *s = str, quote = 0;
     size_t i = 0;
 
@@ -40,7 +47,9 @@ static ALWAYS_INLINE size_t quoted_strings_splitter(char *str, char **words, siz
         s++;
 
     if(unlikely(!*s)) {
-        words[i] = NULL;
+        if (likely(max_words))
+            words[i] = NULL;
+
         return 0;
     }
 

--- a/src/libnetdata/socket/poll-events.c
+++ b/src/libnetdata/socket/poll-events.c
@@ -367,6 +367,11 @@ void poll_events(LISTEN_SOCKETS *sockets
         .tmr_callback = tmr_callback?tmr_callback:poll_default_tmr_callback
     };
 
+    if(unlikely(!p.ndpl)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "POLLFD: failed to create nd_poll");
+        return;
+    }
+
     size_t i;
     for(i = 0; i < sockets->opened ;i++) {
 

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -190,6 +190,9 @@ unsigned char *utf8_check(unsigned char *s)
 }
 
 char *url_decode_r(char *to, const char *url, size_t size) {
+    if(unlikely(!size))
+        return NULL;
+
     const char *s = url;     // source
     char *d = to,            // destination
          *e = &to[size - 1]; // destination end

--- a/src/libnetdata/user-auth/http-access.c
+++ b/src/libnetdata/user-auth/http-access.c
@@ -118,6 +118,8 @@ void http_access2buffer_json_array(BUFFER *wb, const char *key, HTTP_ACCESS acce
 }
 
 void http_access2txt(char *buf, size_t size, const char *separator, HTTP_ACCESS access) {
+    if(unlikely(!buf || !size)) return;
+
     char *write = buf;
     char *end = &buf[size - 1];
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened several core paths with defensive guards to prevent NULL dereferences and invalid writes in rare error cases. Improves stability in JudyL lookups, line splitting, poll startup, URL decoding, and HTTP access formatting.

- **Bug Fixes**
  - JudyL typed wrappers: treat PJERR as an error for GET/FIRST/NEXT/LAST/PREV and iteration; return default or stop.
  - Line splitter: handle NULL input; only set words[0] when capacity exists.
  - Socket poll: on nd_poll_create() failure, log and exit early before registering fds.
  - URL decode: return NULL when output size is 0 before computing bounds.
  - HTTP access formatter: return early on NULL buffer or size 0 to avoid invalid pointer arithmetic.

<sup>Written for commit 828774400bca53a091417b68f57f7628691e6a45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

