### PR TITLE
Netdata fixes part 10

### DIFF
--- a/src/libnetdata/adaptive_resortable_list/adaptive_resortable_list.c
+++ b/src/libnetdata/adaptive_resortable_list/adaptive_resortable_list.c
@@ -33,6 +33,9 @@ inline void arl_callback_ssize_t(const char *name, uint32_t hash, const char *va
 
 // create a new ARL
 ARL_BASE *arl_create(const char *name, void (*processor)(const char *, uint32_t, const char *, void *), size_t rechecks) {
+    if(unlikely(!rechecks))
+        fatal("ARL: rechecks cannot be zero");
+
     ARL_BASE *base = callocz(1, sizeof(ARL_BASE));
 
     base->name = strdupz(name);

--- a/src/libnetdata/c_rhash/c_rhash.c
+++ b/src/libnetdata/c_rhash/c_rhash.c
@@ -7,6 +7,9 @@ c_rhash c_rhash_new(size_t bin_count) {
     if (!bin_count)
         bin_count = 1000;
 
+    if (unlikely(bin_count > (SIZE_MAX - sizeof(struct c_rhash_s)) / sizeof(c_rhash_bin)))
+        fatal("C_RHASH: bin count is too large.");
+
     c_rhash hash = callocz(1, sizeof(struct c_rhash_s) + (bin_count * sizeof(struct bin_ll*)) );
     hash->bin_count = bin_count;
     hash->bins = (c_rhash_bin *)((char*)hash + sizeof(struct c_rhash_s));

--- a/src/libnetdata/simple_hashtable/simple_hashtable.h
+++ b/src/libnetdata/simple_hashtable/simple_hashtable.h
@@ -383,7 +383,7 @@ static inline SIMPLE_HASHTABLE_SLOT_NAMED *simple_hashtable_get_slot_named(
             else {
                 // the hashtable is full, but resize is false.
                 // this should never happen.
-                assert(sl != sl_started);
+                fatal("SIMPLE_HASHTABLE: lookup without resize reached a full table");
             }
         }
     }

--- a/src/libnetdata/simple_hashtable/simple_hashtable.h
+++ b/src/libnetdata/simple_hashtable/simple_hashtable.h
@@ -174,7 +174,10 @@ static inline void simple_hashtable_del_value_sorted_named(SIMPLE_HASHTABLE_NAME
     size_t index = simple_hashtable_sorted_binary_search_named(ht, value);
 
     // Check if the value exists at the found index
-    assert(index < ht->sorted.used && ht->sorted.array[index] == value);
+    bool found = index < ht->sorted.used && ht->sorted.array[index] == value;
+    assert(found);
+    if(unlikely(!found))
+        return;
 
     // Use memmove to shift elements and close the gap
     memmove(&ht->sorted.array[index], &ht->sorted.array[index + 1], (ht->sorted.used - index - 1) * sizeof(SIMPLE_HASHTABLE_VALUE_TYPE));
@@ -186,7 +189,10 @@ static inline void simple_hashtable_replace_value_sorted_named(SIMPLE_HASHTABLE_
         return;
 
     size_t old_value_index = simple_hashtable_sorted_binary_search_named(ht, old_value);
-    assert(old_value_index < ht->sorted.used && ht->sorted.array[old_value_index] == old_value);
+    bool old_value_found = old_value_index < ht->sorted.used && ht->sorted.array[old_value_index] == old_value;
+    assert(old_value_found);
+    if(unlikely(!old_value_found))
+        return;
 
     int r = SIMPLE_HASHTABLE_SORT_FUNCTION(old_value, new_value);
     if(r == 0) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `libnetdata` structures to prevent invalid states and memory errors. Adds guards and fatal diagnostics without changing behavior for valid callers.

- **Bug Fixes**
  - `arl_create`: reject zero `rechecks` to avoid divide-by-zero in the iterator path.
  - `c_rhash_new`: validate `bin_count` fits allocation; fatal on overflow-risk to prevent OOB access.
  - `simple_hashtable`: guard sorted delete/replace when value is absent (no-op instead of OOB), and fatal on impossible full-table lookup without resize to avoid hangs.

<sup>Written for commit 45ca8ee8b18cf1533daa251af18deb7d9d135c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

