### PR TITLE
Netdata fixes part 11

### DIFF
--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -712,7 +712,7 @@ static inline bool local_sockets_find_all_sockets_in_proc(LS_STATE *ls, const ch
                         local_sockets_log(ls, "cannot open file: %s\n", filename);
                     else {
                         size_t clen = strlen(comm);
-                        if(comm[clen - 1] == '\n')
+                        if(clen > 0 && comm[clen - 1] == '\n')
                             comm[clen - 1] = '\0';
                     }
                 }

--- a/src/libnetdata/stacktrace/stacktrace-array.c
+++ b/src/libnetdata/stacktrace/stacktrace-array.c
@@ -19,6 +19,9 @@ bool stacktrace_array_add(STACKTRACE_ARRAY *array, int skip_frames) {
     if (unlikely(!array))
         return false;
 
+    if (unlikely(skip_frames < 0 || skip_frames > INT_MAX - 3))
+        return false;
+
     // Get current stacktrace
     STACKTRACE current = stacktrace_get(skip_frames + 1);  // +1 to skip this function
     if (!current)

--- a/src/libnetdata/stacktrace/stacktrace-common.c
+++ b/src/libnetdata/stacktrace/stacktrace-common.c
@@ -63,7 +63,14 @@ void stacktrace_init(void) {
 
 // Allocate a new stacktrace structure with the given number of frames
 struct stacktrace *stacktrace_create(int num_frames) {
-    size_t size = sizeof(struct stacktrace) + ((num_frames - 1) * sizeof(void *));
+    if (unlikely(num_frames <= 0))
+        return NULL;
+
+    size_t extra_frames = (size_t)num_frames - 1;
+    if (unlikely(extra_frames > (SIZE_MAX - sizeof(struct stacktrace)) / sizeof(void *)))
+        return NULL;
+
+    size_t size = sizeof(struct stacktrace) + extra_frames * sizeof(void *);
     struct stacktrace *trace = callocz(1, size);
     trace->frame_count = num_frames;
     return trace;
@@ -155,7 +162,7 @@ STACKTRACE stacktrace_get(int skip_frames) {
     // Add 1 to skip_frames to also skip stacktrace_get() itself
     int num_frames = impl_stacktrace_get_frames(frames, 50, skip_frames + 1);
     
-    if (num_frames <= 0)
+    if (num_frames <= 0 || num_frames > (int)_countof(frames))
         return NULL;
     
     // Calculate hash

--- a/src/libnetdata/stacktrace/stacktrace-common.c
+++ b/src/libnetdata/stacktrace/stacktrace-common.c
@@ -144,6 +144,9 @@ void stacktrace_keep_first_root_cause_function(const char *function) {
 // Get the current stacktrace - public API
 NEVER_INLINE
 STACKTRACE stacktrace_get(int skip_frames) {
+    if (unlikely(skip_frames < 0 || skip_frames > INT_MAX - 2))
+        return NULL;
+
     // Make sure cache is initialized
     stacktrace_cache_init();
     


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens stacktrace capture and /proc parsing to prevent edge-case overflows and out-of-bounds reads. Behavior for valid inputs is unchanged.

- **Bug Fixes**
  - Stacktrace: Reject negative or too-large skip counts in `stacktrace_get()` and `stacktrace_array_add()`; validate frame counts against local buffer; check allocation math and reject non-positive frame counts.
  - Local sockets: Guard newline trimming of `/proc/<pid>/comm` by checking length before indexing to avoid underflow on empty strings.

<sup>Written for commit 838e61aad553c2410c3a61fb7a9a622d8ac78185. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

