### PR TITLE
Netdata fixes part 12

### DIFF
--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -116,7 +116,7 @@ int nd_claim_parse_args(int argc, LPWSTR *argv)
             if (!tmp)
                 ExitProcess(1);
 
-            netdata_claim_convert_str(tmp, argv[i], length - 1);
+            netdata_claim_convert_str(tmp, argv[i], length);
             if (i < argc)
                 insecure = atoi(tmp);
             else
@@ -142,14 +142,14 @@ static int netdata_claim_prepare_strings()
     if (!aToken)
         return -1;
 
-    netdata_claim_convert_str(aToken, token, length - 1);
+    netdata_claim_convert_str(aToken, token, length);
 
     length = wcslen(room) + 1;
     aRoom = calloc(sizeof(char), length);
     if (!aRoom)
         return -1;
 
-    netdata_claim_convert_str(aRoom, room, length - 1);
+    netdata_claim_convert_str(aRoom, room, length);
 
     if (proxy) {
         length = wcslen(proxy) + 1;
@@ -157,7 +157,7 @@ static int netdata_claim_prepare_strings()
         if (!aProxy)
             return -1;
 
-        netdata_claim_convert_str(aProxy, proxy, length - 1);
+        netdata_claim_convert_str(aProxy, proxy, length);
     }
 
     if (url) {
@@ -166,7 +166,7 @@ static int netdata_claim_prepare_strings()
         if (!aURL)
             return -1;
 
-        netdata_claim_convert_str(aURL, url, length - 1);
+        netdata_claim_convert_str(aURL, url, length);
     }
     return 0;
 }
@@ -218,7 +218,7 @@ static int netdata_claim_get_path(char *path)
 	if (length >= WINDOWS_MAX_PATH) 
             return -1;
 
-        netdata_claim_convert_str(path, extPath, length - 1);
+        netdata_claim_convert_str(path, extPath, length);
 	return 0;
     }
 

--- a/src/claim/main.h
+++ b/src/claim/main.h
@@ -13,6 +13,7 @@ extern LPWSTR proxy;
 void netdata_claim_error_exit(wchar_t *function);
 static inline void netdata_claim_convert_str(char *dst, wchar_t *src, size_t len) {
     size_t copied = wcstombs(dst, src, len);
+    if (copied == (size_t)-1) copied = 0;
     dst[copied] = '\0';
 }
 

--- a/src/claim/main.h
+++ b/src/claim/main.h
@@ -11,8 +11,11 @@ extern LPWSTR room;
 extern LPWSTR proxy;
 
 void netdata_claim_error_exit(wchar_t *function);
-static inline void netdata_claim_convert_str(char *dst, wchar_t *src, size_t len) {
-    size_t copied = wcstombs(dst, src, len);
+static inline void netdata_claim_convert_str(char *dst, wchar_t *src, size_t dst_size) {
+    if (!dst_size)
+        return;
+    // reserve one byte for the NUL: wcstombs() does not terminate when it fills the buffer
+    size_t copied = wcstombs(dst, src, dst_size - 1);
     if (copied == (size_t)-1) copied = 0;
     dst[copied] = '\0';
 }

--- a/src/daemon/daemon-service.c
+++ b/src/daemon/daemon-service.c
@@ -85,9 +85,11 @@ void service_signal_exit(SERVICE_TYPE service) {
         if((sth->services & service)) {
             nd_thread_signal_cancel(sth->netdata_thread);
             nd_log_daemon(NDLP_DEBUG, "SERVICE: Signal to stop : %s", sth->name);
-            if(sth->request_quit_callback) {
+            request_quit_t request_quit_callback = sth->request_quit_callback;
+            void *request_quit_data = sth->data;
+            if(request_quit_callback) {
                 spinlock_unlock(&service_globals.lock);
-                sth->request_quit_callback(sth->data);
+                request_quit_callback(request_quit_data);
                 spinlock_lock(&service_globals.lock);
             }
         }
@@ -153,9 +155,11 @@ bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
                 running++;
                 running_services |= sth->services & service;
 
-                if(sth->force_quit_callback) {
+                force_quit_t force_quit_callback = sth->force_quit_callback;
+                void *force_quit_data = sth->data;
+                if(force_quit_callback) {
                     spinlock_unlock(&service_globals.lock);
-                    sth->force_quit_callback(sth->data);
+                    force_quit_callback(force_quit_data);
                     spinlock_lock(&service_globals.lock);
                     continue;
                 }

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -1057,6 +1057,8 @@ void send_alert_snapshot_to_cloud(RRDHOST *host __maybe_unused)
     }
 
     struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
+    if (unlikely(!aclk_host_config))
+        return;
 
     CLAIM_ID claim_id = claim_id_get();
     if (unlikely(!claim_id_is_set(claim_id)))

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -1051,12 +1051,12 @@ done:
 #define ALARM_EVENTS_PER_CHUNK 1000
 void send_alert_snapshot_to_cloud(RRDHOST *host __maybe_unused)
 {
-    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
-
     if (unlikely(!host)) {
-        nd_log(NDLS_ACCESS, NDLP_WARNING, "AC [%s (N/A)]: Node id not found", aclk_host_config->node_id);
+        nd_log(NDLS_ACCESS, NDLP_WARNING, "AC [N/A (N/A)]: Node id not found");
         return;
     }
+
+    struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
 
     CLAIM_ID claim_id = claim_id_get();
     if (unlikely(!claim_id_is_set(claim_id)))

--- a/src/plugins.d/pluginsd_dyncfg.c
+++ b/src/plugins.d/pluginsd_dyncfg.c
@@ -14,6 +14,7 @@ PARSER_RC pluginsd_config(char **words, size_t num_words, PARSER *parser) {
     char *id     = get_word(words, num_words, i++);
     char *action = get_word(words, num_words, i++);
 
+    if(!action) return PARSER_RC_ERROR;
     if(strcmp(action, PLUGINSD_KEYWORD_CONFIG_ACTION_CREATE) == 0) {
         char *status_str            = get_word(words, num_words, i++);
         char *type_str              = get_word(words, num_words, i++);

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -1239,6 +1239,7 @@ static PARSER_RC pluginsd_json(char **words __maybe_unused, size_t num_words __m
     if(!host) return PLUGINSD_DISABLE_PLUGIN(parser, NULL, NULL);
 
     char *keyword = get_word(words, num_words, 1);
+    if(!keyword) keyword = "";
 
     parser->defer.response = buffer_create(0, NULL);
     parser->defer.end_keyword = PLUGINSD_KEYWORD_JSON_END;

--- a/src/streaming/stream-sender-execute.c
+++ b/src/streaming/stream-sender-execute.c
@@ -316,6 +316,7 @@ void stream_sender_execute_commands(struct sender_state *s) {
             worker_is_busy(WORKER_SENDER_JOB_EXECUTE_META);
 
             char *keyword = get_word(s->thread.rbuf.line.words, s->thread.rbuf.line.num_words, 1);
+            if(!keyword) keyword = "";
 
             s->thread.defer.end_keyword = PLUGINSD_KEYWORD_JSON_END;
             s->thread.defer.payload = buffer_create(0, NULL);

--- a/src/web/api/formatters/jsonwrap-v1.c
+++ b/src/web/api/formatters/jsonwrap-v1.c
@@ -78,10 +78,11 @@ static inline long query_target_metrics_latest_values(BUFFER *wb, const char *ke
 static inline size_t rrdr_dimension_view_latest_values(BUFFER *wb, const char *key, RRDR *r, RRDR_OPTIONS options) {
     buffer_json_member_add_array(wb, key);
 
-    if(!rrdr_rows(r)) {
-        buffer_json_array_close(wb);
-        return 0;
-    }
+    // with zero rows there is no latest row to read; reading it would underflow
+    // (rrdr_rows(r) - 1) on the size_t row index. still emit one empty value per
+    // exposed dimension so this array, latest_values and the dimension metadata
+    // arrays stay parallel and the returned "dimensions" count matches.
+    const bool has_rows = rrdr_rows(r) > 0;
 
     size_t c, i;
     for(c = 0, i = 0; c < r->d ; c++) {
@@ -90,18 +91,20 @@ static inline size_t rrdr_dimension_view_latest_values(BUFFER *wb, const char *k
 
         i++;
 
-        NETDATA_DOUBLE *cn = &r->v[ (rrdr_rows(r) - 1) * r->d ];
-        RRDR_VALUE_FLAGS *co = &r->o[ (rrdr_rows(r) - 1) * r->d ];
-        NETDATA_DOUBLE n = cn[c];
+        if(has_rows) {
+            NETDATA_DOUBLE *cn = &r->v[ (rrdr_rows(r) - 1) * r->d ];
+            RRDR_VALUE_FLAGS *co = &r->o[ (rrdr_rows(r) - 1) * r->d ];
 
-        if(co[c] & RRDR_VALUE_EMPTY) {
-            if(options & RRDR_OPTION_NULL2ZERO)
-                buffer_json_add_array_item_double(wb, 0.0);
-            else
-                buffer_json_add_array_item_double(wb, NAN);
+            if(!(co[c] & RRDR_VALUE_EMPTY)) {
+                buffer_json_add_array_item_double(wb, cn[c]);
+                continue;
+            }
         }
+
+        if(options & RRDR_OPTION_NULL2ZERO)
+            buffer_json_add_array_item_double(wb, 0.0);
         else
-            buffer_json_add_array_item_double(wb, n);
+            buffer_json_add_array_item_double(wb, NAN);
     }
 
     buffer_json_array_close(wb);

--- a/src/web/api/formatters/jsonwrap-v1.c
+++ b/src/web/api/formatters/jsonwrap-v1.c
@@ -78,6 +78,11 @@ static inline long query_target_metrics_latest_values(BUFFER *wb, const char *ke
 static inline size_t rrdr_dimension_view_latest_values(BUFFER *wb, const char *key, RRDR *r, RRDR_OPTIONS options) {
     buffer_json_member_add_array(wb, key);
 
+    if(!rrdr_rows(r)) {
+        buffer_json_array_close(wb);
+        return 0;
+    }
+
     size_t c, i;
     for(c = 0, i = 0; c < r->d ; c++) {
         if(!rrdr_dimension_should_be_exposed(r->od[c], options))

--- a/src/web/api/maps/rrdr_options.c
+++ b/src/web/api/maps/rrdr_options.c
@@ -161,6 +161,8 @@ void rrdr_options_to_buffer(BUFFER *wb, RRDR_OPTIONS options) {
 }
 
 void web_client_api_request_data_vX_options_to_string(char *buf, size_t size, RRDR_OPTIONS options) {
+    if(unlikely(!buf || !size)) return;
+
     char *write = buf;
     char *end = &buf[size - 1];
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardening pass across claim, pluginsd, streaming, API, SQLite alerts, and service shutdown to prevent crashes and out‑of‑bounds writes. Improves robustness by guarding nulls, empty inputs, correct buffer sizing, and rare shutdown races.

- **Bug Fixes**
  - Service shutdown: copy callback pointers/data while holding the lock to avoid a use‑after‑free during exit callbacks.
  - Windows claim: reserve space for the NUL and handle `wcstombs()` failure; pass the full destination size to ensure proper termination and avoid out‑of‑bounds writes.
  - pluginsd CONFIG: return `PARSER_RC_ERROR` when the action word is missing instead of dereferencing NULL.
  - pluginsd JSON and streaming JSON: treat a missing keyword as an empty string to avoid NULL dereferences and follow existing unknown‑keyword paths.
  - SQLite alert snapshot: check `host` and `aclk_host_config` before use; log as N/A when `host` is NULL.
  - API latest values: when RRDR has zero rows, emit per‑dimension placeholders (`NAN` or `0.0` with `RRDR_OPTION_NULL2ZERO`) to keep arrays parallel and avoid underflow.
  - RRDR options string: return early when buffer is NULL or size is zero to avoid invalid pointer arithmetic.

<sup>Written for commit c60ecfb0bdfe90e4d357f53428fc33cd13dc3e33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

