### PR TITLE
Fix DBEngine retention accounting underflow

### DIFF
--- a/src/database/engine/mrg-internals.h
+++ b/src/database/engine/mrg-internals.h
@@ -81,7 +81,7 @@ static inline void MRG_STATS_DELETED_METRIC(MRG *mrg, size_t partition, Word_t s
     mrg->index[partition].stats.size -= sizeof(METRIC);
     mrg->index[partition].stats.deletions++;
     struct rrdengine_instance *ctx = (struct rrdengine_instance *) section;
-    __atomic_sub_fetch(&ctx->atomic.metrics, 1, __ATOMIC_RELAXED);
+    rrdeng_atomic_uint64_sub_saturating(ctx, &ctx->atomic.metrics, 1, "metrics", "deleting an MRG metric");
 }
 
 static inline void MRG_STATS_SEARCH_HIT(MRG *mrg, size_t partition) {

--- a/src/database/engine/mrg-unittest.c
+++ b/src/database/engine/mrg-unittest.c
@@ -51,9 +51,152 @@ static void mrg_stress(void *ptr) {
     }
 }
 
+static int mrg_unittest_expect_samples_delta(
+    struct rrdengine_instance *ctx,
+    time_t first_time_s,
+    time_t last_time_s,
+    uint32_t update_every_s,
+    bool expected_rc,
+    uint64_t expected_samples,
+    const char *name)
+{
+    uint64_t samples = UINT64_MAX;
+    bool rc = rrdeng_retention_samples_delta(ctx, first_time_s, last_time_s, update_every_s, name, &samples);
+
+    if(rc == expected_rc && samples == expected_samples)
+        return 0;
+
+    fprintf(stderr,
+            "DBENGINE METRIC: samples delta test '%s' failed, expected rc=%s samples=%"PRIu64
+            ", got rc=%s samples=%"PRIu64"\n",
+            name,
+            expected_rc ? "true" : "false",
+            expected_samples,
+            rc ? "true" : "false",
+            samples);
+    return 1;
+}
+
+static int mrg_unittest_expect_counter_sub(
+    struct rrdengine_instance *ctx,
+    uint64_t initial,
+    uint64_t decrement,
+    bool expected_rc,
+    uint64_t expected_value,
+    const char *name)
+{
+    uint64_t counter = initial;
+    bool rc = rrdeng_atomic_uint64_sub_saturating(ctx, &counter, decrement, "unittest", name);
+
+    if(rc == expected_rc && counter == expected_value)
+        return 0;
+
+    fprintf(stderr,
+            "DBENGINE METRIC: counter subtraction test '%s' failed, expected rc=%s value=%"PRIu64
+            ", got rc=%s value=%"PRIu64"\n",
+            name,
+            expected_rc ? "true" : "false",
+            expected_value,
+            rc ? "true" : "false",
+            counter);
+    return 1;
+}
+
+static int dbengine_accounting_helpers_unittest(void) {
+    int errors = 0;
+    struct rrdengine_instance ctx = {0};
+    ctx.config.tier = 1;
+
+    errors += mrg_unittest_expect_samples_delta(&ctx, 10, 70, 10, true, 6, "normal positive interval");
+    errors += mrg_unittest_expect_samples_delta(&ctx, 10, 10, 10, false, 0, "equal timestamps");
+    errors += mrg_unittest_expect_samples_delta(&ctx, 0, 10, 10, false, 0, "missing first timestamp");
+    errors += mrg_unittest_expect_samples_delta(&ctx, 10, 70, 0, false, 0, "missing update every");
+
+#ifndef NETDATA_INTERNAL_CHECKS
+    errors += mrg_unittest_expect_samples_delta(&ctx, 70, 10, 10, false, 0, "reversed interval");
+#endif
+
+    errors += mrg_unittest_expect_counter_sub(&ctx, 9, 4, true, 5, "normal decrement");
+    errors += mrg_unittest_expect_counter_sub(&ctx, 9, 0, true, 9, "zero decrement");
+
+#ifndef NETDATA_INTERNAL_CHECKS
+    errors += mrg_unittest_expect_counter_sub(&ctx, 3, 9, false, 0, "underflow saturation");
+#endif
+
+    ctx.atomic.metrics = 11;
+    ctx.atomic.samples = 22;
+    rrdeng_reset_accounting_if_fresh(&ctx, false);
+    if(ctx.atomic.metrics != 11 || ctx.atomic.samples != 22) {
+        fprintf(stderr,
+                "DBENGINE METRIC: global-context accounting reset policy failed, expected 11/22 got %"PRIu64"/%"PRIu64"\n",
+                ctx.atomic.metrics,
+                ctx.atomic.samples);
+        errors++;
+    }
+
+    rrdeng_reset_accounting_if_fresh(&ctx, true);
+    if(ctx.atomic.metrics != 0 || ctx.atomic.samples != 0) {
+        fprintf(stderr,
+                "DBENGINE METRIC: fresh-context accounting reset policy failed, expected 0/0 got %"PRIu64"/%"PRIu64"\n",
+                ctx.atomic.metrics,
+                ctx.atomic.samples);
+        errors++;
+    }
+
+    return errors;
+}
+
+#ifndef NETDATA_INTERNAL_CHECKS
+static int mrg_metrics_delete_underflow_unittest(MRG *mrg) {
+    nd_uuid_t uuid;
+    uuid_generate(uuid);
+
+    MRG_ENTRY entry = {
+        .uuid = &uuid,
+        .section = (Word_t)&test_ctx_0,
+        .first_time_s = 0,
+        .last_time_s = 0,
+        .latest_update_every_s = 1,
+    };
+
+    bool added = false;
+    METRIC *metric = mrg_metric_add_and_acquire(mrg, entry, &added);
+    if(!metric || !added) {
+        fprintf(stderr, "DBENGINE METRIC: failed to add no-retention metric for delete-underflow test\n");
+        return 1;
+    }
+
+    __atomic_store_n(&test_ctx_0.atomic.metrics, 0, __ATOMIC_RELAXED);
+
+    bool deleted = mrg_metric_release_and_delete(mrg, metric);
+    uint64_t metrics = __atomic_load_n(&test_ctx_0.atomic.metrics, __ATOMIC_RELAXED);
+
+    if(!deleted || metrics != 0) {
+        fprintf(stderr,
+                "DBENGINE METRIC: delete-underflow test failed, expected deleted=true metrics=0, got deleted=%s metrics=%"PRIu64"\n",
+                deleted ? "true" : "false",
+                metrics);
+        return 1;
+    }
+
+    return 0;
+}
+#endif
+
 int mrg_unittest(void) {
     // Use mrg_create_for_unittest to avoid pre-loaded metrics that block deletion
     MRG *mrg = mrg_create_for_unittest();
+    int errors = dbengine_accounting_helpers_unittest();
+
+#ifndef NETDATA_INTERNAL_CHECKS
+    errors += mrg_metrics_delete_underflow_unittest(mrg);
+#endif
+
+    if(errors) {
+        mrg_destroy(mrg);
+        return errors;
+    }
+
     METRIC *m1_t0, *m2_t0, *m3_t0, *m4_t0;
     METRIC *m1_t1, *m2_t1, *m3_t1, *m4_t1;
     bool ret;

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1531,10 +1531,20 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
             bool changed = mrg_metric_set_first_time_s_if_bigger(main_mrg, uuid_first_t_entry->metric, uuid_first_t_entry->first_time_s);
             if (changed) {
                 uint32_t update_every_s = mrg_metric_get_update_every_s(main_mrg, uuid_first_t_entry->metric);
-                if (update_every_s && old_first_time_s && uuid_first_t_entry->first_time_s > old_first_time_s) {
-                    uint64_t remove_samples = (uuid_first_t_entry->first_time_s - old_first_time_s) / update_every_s;
-                    __atomic_sub_fetch(&ctx->atomic.samples, remove_samples, __ATOMIC_RELAXED);
-                }
+                uint64_t remove_samples;
+                if (rrdeng_retention_samples_delta(
+                        ctx,
+                        old_first_time_s,
+                        uuid_first_t_entry->first_time_s,
+                        update_every_s,
+                        "advancing metric first retention time",
+                        &remove_samples))
+                    rrdeng_atomic_uint64_sub_saturating(
+                        ctx,
+                        &ctx->atomic.samples,
+                        remove_samples,
+                        "samples",
+                        "advancing metric first retention time");
             }
             mrg_metric_release(main_mrg, uuid_first_t_entry->metric);
         }
@@ -1546,11 +1556,21 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
             if (!has_retention) {
                 time_t first_time_s = mrg_metric_get_first_time_s(main_mrg, uuid_first_t_entry->metric);
                 time_t last_time_s = mrg_metric_get_latest_time_s(main_mrg, uuid_first_t_entry->metric);
-                time_t update_every_s = mrg_metric_get_update_every_s(main_mrg, uuid_first_t_entry->metric);
-                if (update_every_s && first_time_s && last_time_s) {
-                    uint64_t remove_samples = (first_time_s - last_time_s) / update_every_s;
-                    __atomic_sub_fetch(&ctx->atomic.samples, remove_samples, __ATOMIC_RELAXED);
-                }
+                uint32_t update_every_s = mrg_metric_get_update_every_s(main_mrg, uuid_first_t_entry->metric);
+                uint64_t remove_samples;
+                if (rrdeng_retention_samples_delta(
+                        ctx,
+                        first_time_s,
+                        last_time_s,
+                        update_every_s,
+                        "deleting a metric with zero disk retention",
+                        &remove_samples))
+                    rrdeng_atomic_uint64_sub_saturating(
+                        ctx,
+                        &ctx->atomic.samples,
+                        remove_samples,
+                        "samples",
+                        "deleting a metric with zero disk retention");
 
                 bool deleted = mrg_metric_release_and_delete(main_mrg, uuid_first_t_entry->metric);
                 if(deleted)

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -483,6 +483,106 @@ static inline void ctx_fs_error(struct rrdengine_instance *ctx) {
     rrd_stat_atomic_add(&global_stats.global_fs_errors, 1);
 }
 
+static inline bool rrdeng_retention_samples_delta(
+    struct rrdengine_instance *ctx,
+    time_t first_time_s,
+    time_t last_time_s,
+    uint32_t update_every_s,
+    const char *reason,
+    uint64_t *samples)
+{
+    *samples = 0;
+
+    if(!update_every_s || !first_time_s || !last_time_s || first_time_s == last_time_s)
+        return false;
+
+    if(unlikely(first_time_s > last_time_s)) {
+        int tier = ctx ? ctx->config.tier : -1;
+
+        internal_fatal(
+            true,
+            "DBENGINE: tier %d: invalid retention interval while %s (first=%ld, last=%ld, update_every=%u)",
+            tier,
+            reason,
+            (long)first_time_s,
+            (long)last_time_s,
+            update_every_s);
+
+        nd_log_limit_static_global_var(erl, 60, 0);
+        nd_log_limit(
+            &erl,
+            NDLS_DAEMON,
+            NDLP_ERR,
+            "DBENGINE: tier %d: invalid retention interval while %s (first=%ld, last=%ld, update_every=%u); not updating sample counter",
+            tier,
+            reason,
+            (long)first_time_s,
+            (long)last_time_s,
+            update_every_s);
+
+        return false;
+    }
+
+    *samples = (last_time_s - first_time_s) / update_every_s;
+    return *samples > 0;
+}
+
+static inline bool rrdeng_atomic_uint64_sub_saturating(
+    struct rrdengine_instance *ctx,
+    uint64_t *counter,
+    uint64_t value,
+    const char *counter_name,
+    const char *reason)
+{
+    if(!value)
+        return true;
+
+    uint64_t old = __atomic_load_n(counter, __ATOMIC_RELAXED);
+    while(true) {
+        if(unlikely(old < value)) {
+            int tier = ctx ? ctx->config.tier : -1;
+
+            internal_fatal(
+                true,
+                "DBENGINE: tier %d: %s counter underflow while %s (current=%" PRIu64 ", subtract=%" PRIu64 ")",
+                tier,
+                counter_name,
+                reason,
+                old,
+                value);
+
+            nd_log_limit_static_global_var(erl, 60, 0);
+            nd_log_limit(
+                &erl,
+                NDLS_DAEMON,
+                NDLP_ERR,
+                "DBENGINE: tier %d: %s counter underflow while %s (current=%" PRIu64 ", subtract=%" PRIu64 "); saturating to zero",
+                tier,
+                counter_name,
+                reason,
+                old,
+                value);
+
+            if(__atomic_compare_exchange_n(counter, &old, 0, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+                return false;
+
+            continue;
+        }
+
+        uint64_t wanted = old - value;
+        if(__atomic_compare_exchange_n(counter, &old, wanted, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+            return true;
+    }
+}
+
+static inline void rrdeng_reset_accounting_if_fresh(struct rrdengine_instance *ctx, bool freshly_initialized_ctx) {
+    if(!freshly_initialized_ctx)
+        return;
+
+    ctx->atomic.metrics = 0;
+    ctx->atomic.samples = 0;
+}
+
 #define ctx_last_fileno_get(ctx) __atomic_load_n(&(ctx)->atomic.last_fileno, __ATOMIC_RELAXED)
 #define ctx_last_fileno_increment(ctx) __atomic_add_fetch(&(ctx)->atomic.last_fileno, 1, __ATOMIC_RELAXED)
 

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -1162,6 +1162,7 @@ int rrdeng_init(
 {
     struct rrdengine_instance *ctx;
     uint32_t max_open_files;
+    bool freshly_initialized_ctx = false;
 
     max_open_files = rlimit_nofile.rlim_cur / 4;
 
@@ -1181,6 +1182,7 @@ int rrdeng_init(
     if(ctxp) {
         *ctxp = ctx = mallocz(sizeof(*ctx));
         initialize_single_ctx(ctx);
+        freshly_initialized_ctx = true;
     }
     else
         ctx = multidb_ctx[tier];
@@ -1203,8 +1205,8 @@ int rrdeng_init(
     ctx->quiesce.enabled = false;
 
     ctx->atomic.first_time_s = LONG_MAX;
-    ctx->atomic.metrics = 0;
-    ctx->atomic.samples = 0;
+    // Global contexts may already have MRG prepopulation accounting from the first DBEngine spawn.
+    rrdeng_reset_accounting_if_fresh(ctx, freshly_initialized_ctx);
 
     if (rrdeng_dbengine_spawn(ctx) && !init_rrd_files(ctx)) {
         // success - we run this ctx too

--- a/src/database/rrd-retention.h
+++ b/src/database/rrd-retention.h
@@ -13,8 +13,8 @@ typedef struct rrd_storage_tier {
     size_t group_seconds;             // Granularity in seconds
     char granularity_human[32];       // Human-readable granularity string
 
-    size_t metrics;                   // Number of metrics in this tier
-    size_t samples;                   // Number of samples in this tier
+    uint64_t metrics;                 // Number of metrics in this tier
+    uint64_t samples;                 // Number of samples in this tier
 
     uint64_t disk_used;               // Disk space used in bytes
     uint64_t disk_max;                // Maximum available disk space in bytes


### PR DESCRIPTION
## Summary

- Fix DBEngine sample removal accounting to use positive retention deltas and non-wrapping counter subtraction.
- Preserve MRG-prepopulated DBEngine metric/sample counters on reused global tier contexts.
- Widen retention API metric/sample fields to `uint64_t` and add focused MRG accounting tests.

## Root cause

The zero-disk-retention delete path could compute `(first_time_s - last_time_s) / update_every_s`, which is negative for valid retention intervals and can become a huge unsigned decrement. Separately, reused global `multidb_ctx[tier]` contexts could have MRG prepopulation accounting erased by later tier initialization, letting normal metric deletes decrement from zero. On 32-bit builds, the retention API struct used `size_t`, hiding 64-bit counter wrap as low-32-bit values near `UINT32_MAX`.

## Validation

- `git diff --check`
- affected DBEngine object compile for `rrdengine.c`, `rrdengineapi.c`, `mrg.c`, `mrg-load.c`, `mrg-unittest.c`, and `rrd-retention.c`
- affected internal-check object compile with `-DNETDATA_INTERNAL_CHECKS=1`
- `.agents/sow/audit.sh` passed locally with only unrelated pre-existing local SOW warnings

Full local `netdata` target link was blocked by an unrelated missing checkout artifact: `src/aclk/aclk-schemas/proto/aclk/v1/lib.proto`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DBEngine retention counter underflows by using safe sample-delta math and saturating counter subtraction. Preserves prepopulated counters on reused contexts and widens retention counters to `uint64_t`.

- **Bug Fixes**
  - Compute positive sample deltas with validation and use them when advancing first_time_s and deleting zero-retention metrics.
  - Add saturating `uint64_t` counter subtraction and apply it to metrics/samples updates, including MRG metric deletion.
  - Keep MRG prepopulation counters when reusing global contexts; reset only on freshly created contexts.
  - Widen retention `metrics`/`samples` to `uint64_t` and add targeted unit tests for deltas, underflow, and reset policy.

<sup>Written for commit c28ba1f1921e5ed5ae8c4511c567d0ca4636d37d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

