### PR TITLE
Netdata fixes part 13

### DIFF
--- a/src/libnetdata/paths/paths.c
+++ b/src/libnetdata/paths/paths.c
@@ -138,35 +138,13 @@ char *filename_from_path_entry_strdupz(const char *path, const char *entry) {
 }
 
 bool filename_is_dir(const char *filename, bool create_it) {
-    CLEAN_CHAR_P *buffer = NULL;
-
-    size_t max_links = 100;
-
     bool is_dir = false;
     struct stat st;
-    while(max_links && stat(filename, &st) == 0) {
-        if ((st.st_mode & S_IFMT) == S_IFDIR)
-            is_dir = true;
-        else if ((st.st_mode & S_IFMT) == S_IFLNK) {
-            max_links--;
 
-            if(!buffer)
-                buffer = mallocz(FILENAME_MAX);
+    if(stat(filename, &st) == 0 && (st.st_mode & S_IFMT) == S_IFDIR)
+        is_dir = true;
 
-            char link_dst[FILENAME_MAX];
-            ssize_t l = readlink(filename, link_dst, FILENAME_MAX - 1);
-            if (l > 0) {
-                link_dst[l] = '\0';
-                strncpyz(buffer, link_dst, FILENAME_MAX - 1);
-                filename = buffer;
-                continue;
-            }
-        }
-
-        break;
-    }
-
-    if(!is_dir && create_it && max_links == 100 && mkdir(filename, 0750) == 0)
+    if(!is_dir && create_it && mkdir(filename, 0750) == 0)
         is_dir = true;
 
     return is_dir;
@@ -179,33 +157,11 @@ bool path_entry_is_dir(const char *path, const char *entry, bool create_it) {
 }
 
 bool filename_is_file(const char *filename) {
-    CLEAN_CHAR_P *buffer = NULL;
-
-    size_t max_links = 100;
-
     bool is_file = false;
     struct stat st;
-    while(max_links && stat(filename, &st) == 0) {
-        if((st.st_mode & S_IFMT) == S_IFREG)
-            is_file = true;
-        else if((st.st_mode & S_IFMT) == S_IFLNK) {
-            max_links--;
 
-            if(!buffer)
-                buffer = mallocz(FILENAME_MAX);
-
-            char link_dst[FILENAME_MAX];
-            ssize_t l = readlink(filename, link_dst, FILENAME_MAX - 1);
-            if(l > 0) {
-                link_dst[l] = '\0';
-                strncpyz(buffer, link_dst, FILENAME_MAX - 1);
-                filename = buffer;
-                continue;
-            }
-        }
-
-        break;
-    }
+    if(stat(filename, &st) == 0 && (st.st_mode & S_IFMT) == S_IFREG)
+        is_file = true;
 
     return is_file;
 }


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unreachable symlink resolution in path helpers and simplified them to direct stat() checks. Optional directory creation is unchanged; behavior for symlinks and missing paths is preserved.

- **Refactors**
  - Simplified `filename_is_dir()` and `filename_is_file()` to a single stat() classification.
  - Deleted readlink/max_links loop and temporary buffer.
  - Retained mkdir when create_it is true.

<sup>Written for commit e234fdd51077b783ef1c6a9badf5593b521bd0ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

