### PR TITLE
Netdata fixes part 15

### DIFF
--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -217,7 +217,7 @@ static void netdata_windows_discover_os_version(char *os, size_t length, DWORD b
     }
 
 #define ND_WIN_VER_LENGTH 16
-    char version[ND_WIN_VER_LENGTH + 1];
+    char version[ND_WIN_VER_LENGTH + 1] = NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN;
     if (IsWindows10OrGreater()) {
         // https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
         (void)snprintf(version, ND_WIN_VER_LENGTH, (build < 22000) ? "10" : "11");

--- a/src/daemon/winsvc.cc
+++ b/src/daemon/winsvc.cc
@@ -39,6 +39,7 @@ static SERVICE_STATUS_HANDLE svc_status_handle = nullptr;
 static SERVICE_STATUS svc_status = {};
 
 static HANDLE svc_stop_event_handle = nullptr;
+static DWORD svc_stop_control_code = SERVICE_CONTROL_STOP;
 
 static ND_THREAD *cleanup_thread = nullptr;
 
@@ -88,7 +89,7 @@ static HANDLE CreateEventHandle(const char *msg)
 
 static void call_netdata_cleanup(void *arg)
 {
-    DWORD controlCode = *((DWORD *)arg);
+    UNUSED(arg);
 
     // Wait until we have to stop the service
     netdata_service_log("Cleanup thread waiting for stop event...");
@@ -97,6 +98,7 @@ static void call_netdata_cleanup(void *arg)
     // Stop the agent
     netdata_service_log("Running netdata cleanup...");
     EXIT_REASON reason;
+    DWORD controlCode = __atomic_load_n(&svc_stop_control_code, __ATOMIC_ACQUIRE);
     switch(controlCode) {
         case SERVICE_CONTROL_SHUTDOWN:
             reason = (EXIT_REASON)(EXIT_REASON_SERVICE_STOP|EXIT_REASON_SYSTEM_SHUTDOWN);
@@ -135,11 +137,13 @@ static void WINAPI ServiceControlHandler(DWORD controlCode)
             if (!ReportSvcStatus(SERVICE_STOP_PENDING, 0, 5000, 0))
                 return;
 
+            __atomic_store_n(&svc_stop_control_code, controlCode, __ATOMIC_RELEASE);
+
             // Create cleanup thread
             netdata_service_log("Creating cleanup thread...");
             char tag[NETDATA_THREAD_TAG_MAX + 1];
             snprintfz(tag, NETDATA_THREAD_TAG_MAX, "%s", "CLEANUP");
-            cleanup_thread = nd_thread_create(tag, NETDATA_THREAD_OPTION_DEFAULT, call_netdata_cleanup, &controlCode);
+            cleanup_thread = nd_thread_create(tag, NETDATA_THREAD_OPTION_DEFAULT, call_netdata_cleanup, NULL);
 
             // Signal the stop request
             netdata_service_log("Signalling the cleanup thread...");

--- a/src/web/mcp/bridges/stdio-golang/nd-mcp.go
+++ b/src/web/mcp/bridges/stdio-golang/nd-mcp.go
@@ -292,6 +292,7 @@ func main() {
 
 	// Timer for reconnection backoff
 	var timer *time.Timer
+	stdinClosedNotify := (<-chan struct{})(stdinClosedCh)
 
 	// Main connection loop
 	for {
@@ -299,10 +300,10 @@ func main() {
 		case <-doneCh:
 			// Program termination requested
 			return
-		case <-stdinClosedCh:
+		case <-stdinClosedNotify:
 			// Stdin closed, continue running until websocket disconnects
 			// and then exit on the next reconnection attempt
-			stdinClosedCh = nil // Prevent duplicate handling
+			stdinClosedNotify = nil // Prevent duplicate handling
 		case <-reconnectCh:
 			// Immediate reconnection requested (e.g. from stdin activity)
 			if timer != nil {
@@ -351,10 +352,10 @@ func main() {
 					// Program termination requested
 					timer.Stop()
 					return
-				case <-stdinClosedCh:
+				case <-stdinClosedNotify:
 					// Stdin closed
 					timer.Stop()
-					stdinClosedCh = nil
+					stdinClosedNotify = nil
 					continue
 				}
 			}
@@ -471,7 +472,6 @@ func main() {
 				return
 			case <-stdinClosedCh:
 				// Stdin closed, but keep connection active
-				stdinClosedCh = nil
 				return
 			}
 		}()


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Windows service shutdown and OS version reporting, and removes a Go race on stdin close in the MCP stdio bridge. Prevents a dangling-pointer read, uninitialized buffer use, and a shared-channel race.

- **Bug Fixes**
  - Windows service: store stop/shutdown control code in a static atomic and pass NULL to the cleanup thread; load it safely inside the thread (behavior unchanged).
  - Windows system info: initialize the `version` buffer to `NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN` to avoid fallback using uninitialized memory.
  - MCP stdio bridge (Go): keep `stdinClosedCh` immutable and use a local receive-only `stdinClosedNotify` to suppress duplicates; remove nil assignments to the shared channel.

<sup>Written for commit a324a00641628ac92602fd3420dabd2555c636c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

