### PR TITLE
Netdata fixes part 16

### DIFF
--- a/src/libnetdata/avl/avl.c
+++ b/src/libnetdata/avl/avl.c
@@ -23,10 +23,12 @@ static inline void avl_check_descent_height(size_t depth, const char *operation)
      Otherwise return |NULL|. */
 avl_t *avl_search(avl_tree_type *tree, avl_t *item) {
     avl_t *p;
+    size_t depth = 0;
 
     // assert (tree != NULL && item != NULL);
 
     for (p = tree->root; p != NULL; ) {
+        avl_check_descent_height(depth++, "search");
         int cmp = tree->compar(item, p);
 
         if (cmp < 0)

--- a/src/libnetdata/avl/avl.c
+++ b/src/libnetdata/avl/avl.c
@@ -14,6 +14,10 @@
  * Foundation, Inc.
 */
 
+static inline void avl_check_descent_height(size_t depth, const char *operation) {
+    if (unlikely(depth >= AVL_MAX_HEIGHT))
+        fatal("AVL: %s descent exceeded maximum height %zu", operation, (size_t)AVL_MAX_HEIGHT);
+}
 
 /* Search |tree| for an item matching |item|, and return it if found.
      Otherwise return |NULL|. */
@@ -62,6 +66,7 @@ avl_t *avl_insert(avl_tree_type *tree, avl_t *item) {
 
         if (p->avl_balance != 0)
             z = q, y = p, k = 0;
+        avl_check_descent_height(k, "insert");
         da[k++] = dir = (unsigned char)(cmp > 0);
     }
 
@@ -152,6 +157,7 @@ avl_t *avl_remove(avl_tree_type *tree, avl_t *item) {
     for(cmp = -1; cmp != 0; cmp = tree->compar(item, p)) {
         unsigned char dir = (unsigned char)(cmp > 0);
 
+        avl_check_descent_height(k, "remove");
         pa[k] = p;
         da[k++] = dir;
 
@@ -169,14 +175,17 @@ avl_t *avl_remove(avl_tree_type *tree, avl_t *item) {
             r->avl_link[0] = p->avl_link[0];
             r->avl_balance = p->avl_balance;
             pa[k - 1]->avl_link[da[k - 1]] = r;
+            avl_check_descent_height(k, "remove");
             da[k] = 1;
             pa[k++] = r;
         }
         else {
             avl_t *s;
+            avl_check_descent_height(k, "remove");
             int j = k++;
 
             for (;;) {
+                avl_check_descent_height(k, "remove");
                 da[k] = 0;
                 pa[k++] = r;
                 s = r->avl_link[0];

--- a/src/libnetdata/avl/avl.c
+++ b/src/libnetdata/avl/avl.c
@@ -293,11 +293,13 @@ avl_t *avl_remove(avl_tree_type *tree, avl_t *item) {
 // ---------------------------
 // traversing
 
-int avl_walker(avl_t *node, int (*callback)(void * /*entry*/, void * /*data*/), void *data) {
+static int avl_walker_depth(avl_t *node, int (*callback)(void * /*entry*/, void * /*data*/), void *data, size_t depth) {
     int total = 0, ret = 0;
 
+    avl_check_descent_height(depth, "traverse");
+
     if(node->avl_link[0]) {
-        ret = avl_walker(node->avl_link[0], callback, data);
+        ret = avl_walker_depth(node->avl_link[0], callback, data, depth + 1);
         if(ret < 0) return ret;
         total += ret;
     }
@@ -307,12 +309,16 @@ int avl_walker(avl_t *node, int (*callback)(void * /*entry*/, void * /*data*/), 
     total += ret;
 
     if(node->avl_link[1]) {
-        ret = avl_walker(node->avl_link[1], callback, data);
+        ret = avl_walker_depth(node->avl_link[1], callback, data, depth + 1);
         if (ret < 0) return ret;
         total += ret;
     }
 
     return total;
+}
+
+int avl_walker(avl_t *node, int (*callback)(void * /*entry*/, void * /*data*/), void *data) {
+    return avl_walker_depth(node, callback, data, 0);
 }
 
 int avl_traverse(avl_tree_type *tree, int (*callback)(void * /*entry*/, void * /*data*/), void *data) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened AVL tree operations by bounding descent depth in search/insert/remove and traversal to prevent stack overwrites and unbounded recursion on corrupted trees. Valid trees behave the same; corrupted trees now fail fast via an invariant check.

- **Bug Fixes**
  - Added `avl_check_descent_height()` and applied it to search, insert, and remove before each descent-stack push.
  - Reworked traversal to `avl_walker_depth()` with depth tracking; public `avl_walker()` now wraps it starting at depth 0.
  - Prevents out-of-bounds writes and stack exhaustion when the tree is over-tall or cyclic.
  - No functional changes for valid trees; adds only an unlikely branch per node.

<sup>Written for commit c8c7523e20ed7429853da4da411f2cfa2397d15b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

