### PR TITLE
Netdata fixes part 17

### DIFF
--- a/src/libnetdata/facets/facets.c
+++ b/src/libnetdata/facets/facets.c
@@ -80,6 +80,11 @@ static const char *hash_to_static_string(FACETS_HASH hash) {
 }
 
 static inline bool is_valid_string_hash(const char *s) {
+    if(!s) {
+        netdata_log_error("The user supplied key is NULL for a facets hash.");
+        return false;
+    }
+
     if(strlen(s) != FACET_STRING_HASH_SIZE - 1) {
         netdata_log_error("The user supplied key '%s' does not have the right length for a facets hash.", s);
         return false;

--- a/src/libnetdata/ringbuffer/ringbuffer-unittest.c
+++ b/src/libnetdata/ringbuffer/ringbuffer-unittest.c
@@ -33,6 +33,12 @@ static int ringbuffer_fixed_size_unittest(void)
     return errors;
 }
 
+static int ringbuffer_null_free_unittest(void)
+{
+    rbuf_free(NULL);
+    return 0;
+}
+
 static int ringbuffer_linear_growth_unittest(void)
 {
     int errors = 0;
@@ -136,6 +142,7 @@ int ringbuffer_unittest(void)
     fprintf(stderr, "\nrunning ringbuffer unittest\n");
 
     errors += ringbuffer_fixed_size_unittest();
+    errors += ringbuffer_null_free_unittest();
     errors += ringbuffer_linear_growth_unittest();
     errors += ringbuffer_wrapped_growth_unittest();
     errors += ringbuffer_cap_unittest();

--- a/src/libnetdata/ringbuffer/ringbuffer.c
+++ b/src/libnetdata/ringbuffer/ringbuffer.c
@@ -21,6 +21,9 @@ rbuf_t rbuf_create(size_t size, size_t max_size)
 
 void rbuf_free(rbuf_t buffer)
 {
+    if (!buffer)
+        return;
+
     freez(buffer->data);
     freez(buffer);
 }

--- a/src/libnetdata/sanitizers/utf8-sanitizer-unittest.c
+++ b/src/libnetdata/sanitizers/utf8-sanitizer-unittest.c
@@ -1036,6 +1036,47 @@ static void test_empty_and_special(void) {
         run_sanitize_test(&t);
     }
 
+    // NULL default is equivalent to empty fallback
+    {
+        sanitize_test_t t = {
+            .name = "null_input_with_null_default",
+            .input = NULL,
+            .dst_size = 32, .char_map = identity_char_map, .utf = true, .empty = NULL,
+            .expected_output = "", .expected_len = 0, .expected_mblen = 0
+        };
+        run_sanitize_test(&t);
+    }
+
+    {
+        sanitize_test_t t = {
+            .name = "empty_input_with_null_default",
+            .input = (unsigned char *)"",
+            .dst_size = 32, .char_map = identity_char_map, .utf = true, .empty = NULL,
+            .expected_output = "", .expected_len = 0, .expected_mblen = 0
+        };
+        run_sanitize_test(&t);
+    }
+
+    {
+        sanitize_test_t t = {
+            .name = "control_chars_with_null_default",
+            .input = (unsigned char *)"\t\n\r\v",
+            .dst_size = 32, .char_map = test_rrd_char_map, .utf = true, .empty = NULL,
+            .expected_output = "", .expected_len = 0, .expected_mblen = 0
+        };
+        run_sanitize_test(&t);
+    }
+
+    {
+        sanitize_test_t t = {
+            .name = "all_underscores_with_null_default",
+            .input = (unsigned char *)"___",
+            .dst_size = 32, .char_map = identity_char_map, .utf = true, .empty = NULL,
+            .expected_output = "", .expected_len = 0, .expected_mblen = 0
+        };
+        run_sanitize_test(&t);
+    }
+
     // Single character
     {
         sanitize_test_t t = {

--- a/src/libnetdata/sanitizers/utf8-sanitizer.c
+++ b/src/libnetdata/sanitizers/utf8-sanitizer.c
@@ -4,6 +4,7 @@
 
 size_t text_sanitize(unsigned char *dst, const unsigned char *src, size_t dst_size, const unsigned char *char_map, bool utf, const char *empty, size_t *multibyte_length) {
     if(unlikely(!dst || !dst_size)) return 0;
+    if(unlikely(!empty)) empty = "";
 
     // skip leading spaces and invalid characters
     while(src && *src && !IS_UTF8_BYTE(*src) && (isspace(*src) || iscntrl(*src) || !isprint(*src)))

--- a/src/libnetdata/simple_pattern/simple_pattern.c
+++ b/src/libnetdata/simple_pattern/simple_pattern.c
@@ -288,7 +288,10 @@ static SIMPLE_PATTERN_RESULT simple_pattern_matches_extract_with_length(SIMPLE_P
     for(m = root; m ; m = m->next) {
         char *ws = wildcarded;
         size_t wss = wildcarded_size;
-        if(unlikely(ws)) *ws = '\0';
+        if(unlikely(wss)) {
+            if(unlikely(ws))
+                *ws = '\0';
+        }
 
         if (match_pattern(m, str, len, ws, &wss)) {
             if (m->negative) return SP_MATCHED_NEGATIVE;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened libnetdata to prevent NULL-pointer crashes and a potential one-byte overflow in facets, ringbuffer, UTF-8 sanitizer, and simple pattern matching. No change for valid inputs; invalid or NULL inputs now safely fail or no-op.

- **Bug Fixes**
  - Facets: check for NULL before strlen() in hash validator; log and reject NULL IDs.
  - Ringbuffer: make rbuf_free(NULL) a no-op.
  - UTF-8 sanitizer: treat NULL empty fallback as "" to avoid crash.
  - Simple pattern: only write initial terminator when wildcard buffer capacity > 0.

- **Tests**
  - Added rbuf_free(NULL) unit test.
  - Added UTF-8 sanitizer tests for NULL fallback, empty input, control chars, and underscore-only output.

<sup>Written for commit 03659ddf763df565e6438252f553a693e387f66e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

