### PR TITLE
Netdata fixes part 18

### DIFF
--- a/src/daemon/dyncfg/dyncfg-files.c
+++ b/src/daemon/dyncfg/dyncfg-files.c
@@ -3,6 +3,12 @@
 #include "dyncfg-internals.h"
 #include "dyncfg.h"
 
+// Upper bound for a dyncfg payload loaded from disk. Payloads are configuration
+// documents (normally a few KB); anything beyond this is treated as a corrupt or
+// oversized file. Mirrors MAX_SETTINGS_SIZE_BYTES used for settings payloads, so
+// a bad file cannot force an unbounded heap allocation (mallocz fatals on OOM).
+#define DYNCFG_MAX_PAYLOAD_SIZE (20 * 1024 * 1024)
+
 void dyncfg_file_delete(const char *id) {
     CLEAN_CHAR_P *escaped_id = dyncfg_escape_id_for_filename(id);
     char filename[FILENAME_MAX];
@@ -174,6 +180,15 @@ void dyncfg_file_load(const char *d_name) {
         }
 
         actual_size = (size_t)(total_size - saved_position); // Calculate remaining content size
+
+        if (actual_size > DYNCFG_MAX_PAYLOAD_SIZE) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "DYNCFG: payload size %zu exceeds the maximum allowed %d for file '%s'. Ignoring it.",
+                   actual_size, DYNCFG_MAX_PAYLOAD_SIZE, filename);
+            fclose(fp);
+            dyncfg_cleanup(&tmp);
+            return;
+        }
 
         // Use actual_size instead of content_length to handle the whole remaining file
         tmp.dyncfg.payload = buffer_create(actual_size, NULL);

--- a/src/daemon/dyncfg/dyncfg-files.c
+++ b/src/daemon/dyncfg/dyncfg-files.c
@@ -151,7 +151,6 @@ void dyncfg_file_load(const char *d_name) {
             rc = fseek(fp, 0, SEEK_END);
             if (!rc) {
                 total_size = ftell(fp);                      // Total size of the file
-                actual_size = total_size - saved_position;   // Calculate remaining content size
                 rc = fseek(fp, saved_position, SEEK_SET);    // Reset file pointer to the beginning of the payload
             }
         }
@@ -164,6 +163,18 @@ void dyncfg_file_load(const char *d_name) {
             dyncfg_cleanup(&tmp);
             return;
         }
+
+        if (total_size < saved_position) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "DYNCFG: payload position %ld is beyond file size %ld for file '%s'. Ignoring it.",
+                   saved_position, total_size, filename);
+            fclose(fp);
+            dyncfg_cleanup(&tmp);
+            return;
+        }
+
+        actual_size = (size_t)(total_size - saved_position); // Calculate remaining content size
+
         // Use actual_size instead of content_length to handle the whole remaining file
         tmp.dyncfg.payload = buffer_create(actual_size, NULL);
         tmp.dyncfg.payload->content_type = content_type;

--- a/src/libnetdata/datetime/rfc3339.c
+++ b/src/libnetdata/datetime/rfc3339.c
@@ -280,13 +280,25 @@ usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
         localtime_r(&epoch_s, &local_tm);
         gmtime_r(&epoch_s, &utc_tm);
 #else
-        // If thread-safe functions are not available, use localtime() and gmtime()
+        // localtime() and gmtime() may share static storage; serialize and copy immediately.
+        static SPINLOCK time_static_buffer_spinlock = SPINLOCK_INITIALIZER;
+        spinlock_lock(&time_static_buffer_spinlock);
+
         struct tm *lt = localtime(&epoch_s);
-        struct tm *gt = gmtime(&epoch_s);
-        if (!lt || !gt)
+        if (!lt) {
+            spinlock_unlock(&time_static_buffer_spinlock);
             return 0;
+        }
         local_tm = *lt;
+
+        struct tm *gt = gmtime(&epoch_s);
+        if (!gt) {
+            spinlock_unlock(&time_static_buffer_spinlock);
+            return 0;
+        }
         utc_tm   = *gt;
+
+        spinlock_unlock(&time_static_buffer_spinlock);
 #endif
         int local_offset = (local_tm.tm_hour - utc_tm.tm_hour) * 3600 +
                            (local_tm.tm_min  - utc_tm.tm_min)  * 60;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects invalid payload offsets and caps payload size in the dynamic config loader, and serializes the legacy time fallback in the RFC3339 parser. Prevents oversized allocations and racey timestamp parsing on fallback builds.

- **Bug Fixes**
  - dyncfg: Abort when payload start is past EOF and reject payloads > 20 MiB; compute remaining size only after validation.
  - datetime: In fallback builds, guard `localtime()`/`gmtime()` with a static spinlock and copy results immediately to avoid shared-buffer races.

<sup>Written for commit a11bd639f283f5a7518de36a9aaf4d86acb74554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

