### PR TITLE
Netdata fixes part 19

### DIFF
--- a/src/database/contexts/api_v2_contexts.c
+++ b/src/database/contexts/api_v2_contexts.c
@@ -210,7 +210,7 @@ static void rrdcontext_to_json_v2_full_text_search(struct rrdcontext_to_json_v2_
     
     RRDINSTANCE *ri;
     dfe_start_read(rc->rrdinstances, ri) {
-        if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, ri->first_time_s, (ri->flags & RRD_FLAG_COLLECTED) ? ctl->now : ri->last_time_s, 0))
+        if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, ri->first_time_s, rrd_flag_is_collected(ri) ? ctl->now : ri->last_time_s, 0))
             continue;
 
         // Check instance name match only if instances option is enabled
@@ -227,7 +227,7 @@ static void rrdcontext_to_json_v2_full_text_search(struct rrdcontext_to_json_v2_
         if(ctl->options & CONTEXTS_OPTION_DIMENSIONS) {
             RRDMETRIC *rm;
             dfe_start_read(ri->rrdmetrics, rm) {
-                if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, rm->first_time_s, (rm->flags & RRD_FLAG_COLLECTED) ? ctl->now : rm->last_time_s, 0))
+                if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, rm->first_time_s, rrd_flag_is_collected(rm) ? ctl->now : rm->last_time_s, 0))
                     continue;
 
                 if(unlikely(full_text_search_string(&ctl->q.fts, q, rm->id)) ||
@@ -267,7 +267,7 @@ static ssize_t rrdcontext_to_json_v2_add_context(void *data, RRDCONTEXT_ACQUIRED
 
     RRDCONTEXT *rc = rrdcontext_acquired_value(rca);
 
-    if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, rc->first_time_s, (rc->flags & RRD_FLAG_COLLECTED) ? ctl->now : rc->last_time_s, 0))
+    if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, rc->first_time_s, rrd_flag_is_collected(rc) ? ctl->now : rc->last_time_s, 0))
         return 0; // continue to next context
 
     struct fts_search_results search_results = {0};
@@ -294,7 +294,7 @@ static ssize_t rrdcontext_to_json_v2_add_context(void *data, RRDCONTEXT_ACQUIRED
             .priority = rc->priority,
             .first_time_s = rc->first_time_s,
             .last_time_s = rc->last_time_s,
-            .flags = rc->flags,
+            .flags = rrd_flags_get(rc),
             .nodes = 1,
             .instances = dictionary_entries(rc->rrdinstances),
             .instances_dict = NULL,
@@ -972,7 +972,7 @@ static void contexts_react_callback(const DICTIONARY_ITEM *item __maybe_unused, 
     // Collect instances, dimensions, and labels if requested
     RRDINSTANCE *ri;
     dfe_start_read(rc->rrdinstances, ri) {
-        if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, ri->first_time_s, (ri->flags & RRD_FLAG_COLLECTED) ? ctl->now : ri->last_time_s, (time_t)ri->update_every_s))
+        if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, ri->first_time_s, rrd_flag_is_collected(ri) ? ctl->now : ri->last_time_s, (time_t)ri->update_every_s))
             continue;
 
         // Add instance name to instances dictionary
@@ -984,7 +984,7 @@ static void contexts_react_callback(const DICTIONARY_ITEM *item __maybe_unused, 
         if(t->dimensions_dict) {
             RRDMETRIC *rm;
             dfe_start_read(ri->rrdmetrics, rm) {
-                if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, rm->first_time_s, (rm->flags & RRD_FLAG_COLLECTED) ? ctl->now : rm->last_time_s, (time_t)ri->update_every_s))
+                if(ctl->window.enabled && !query_matches_retention(ctl->window.after, ctl->window.before, rm->first_time_s, rrd_flag_is_collected(rm) ? ctl->now : rm->last_time_s, (time_t)ri->update_every_s))
                     continue;
 
                 dictionary_set(t->dimensions_dict, string2str(rm->name), NULL, 0);

--- a/src/database/contexts/rrdcontext-context.c
+++ b/src/database/contexts/rrdcontext-context.c
@@ -235,7 +235,7 @@ static void rrdcontext_react_callback(const DICTIONARY_ITEM *item __maybe_unused
 
 void rrdcontext_trigger_updates(RRDCONTEXT *rc, const char *function) {
     if(rrd_flag_is_updated(rc) || !rrd_flag_check(rc, RRD_FLAG_LIVE_RETENTION))
-        rrdcontext_queue_for_post_processing(rc, function, rc->flags);
+        rrdcontext_queue_for_post_processing(rc, function, rrd_flags_get(rc));
 }
 
 void rrdhost_create_rrdcontexts(RRDHOST *host) {

--- a/src/database/contexts/rrdcontext-instance.c
+++ b/src/database/contexts/rrdcontext-instance.c
@@ -263,7 +263,7 @@ void rrdinstances_destroy_from_rrdcontext(RRDCONTEXT *rc) {
 void rrdinstance_trigger_updates(RRDINSTANCE *ri, const char *function) {
     RRDSET *st = ri->rrdset;
 
-    if(likely(st)) {
+    if(st != NULL) {
         if(unlikely((unsigned int) st->priority != ri->priority)) {
             ri->priority = st->priority;
             rrd_flag_set_updated(ri, RRD_FLAG_UPDATE_REASON_CHANGED_METADATA);
@@ -282,7 +282,7 @@ void rrdinstance_trigger_updates(RRDINSTANCE *ri, const char *function) {
 
     if(rrd_flag_is_updated(ri) || !rrd_flag_check(ri, RRD_FLAG_LIVE_RETENTION)) {
         rrd_flag_set_updated(ri->rc, RRD_FLAG_UPDATE_REASON_TRIGGERED);
-        rrdcontext_queue_for_post_processing(ri->rc, function, ri->flags);
+        rrdcontext_queue_for_post_processing(ri->rc, function, rrd_flags_get(ri));
     }
 }
 

--- a/src/database/contexts/rrdcontext-internal.h
+++ b/src/database/contexts/rrdcontext-internal.h
@@ -132,7 +132,7 @@ rrd_flag_add_remove_atomic(RRD_FLAGS *flags, RRD_FLAGS check, RRD_FLAGS conditio
     RRD_FLAGS expected, desired;
 
     do {
-        expected = *flags;
+        expected = __atomic_load_n(flags, __ATOMIC_SEQ_CST);
 
         desired = expected;
         desired &= ~(always_remove);
@@ -150,7 +150,7 @@ rrd_flags_replace_atomic(RRD_FLAGS *flags, RRD_FLAGS desired) {
     RRD_FLAGS expected;
     
     do {
-        expected = *flags;
+        expected = __atomic_load_n(flags, __ATOMIC_SEQ_CST);
     } while(!__atomic_compare_exchange_n(flags, &expected, desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST));
 
     return expected;

--- a/src/database/contexts/rrdcontext-metric.c
+++ b/src/database/contexts/rrdcontext-metric.c
@@ -232,7 +232,7 @@ void rrdmetric_trigger_updates(RRDMETRIC *rm, const char *function) {
 
     if(rrd_flag_is_updated(rm) || !rrd_flag_check(rm, RRD_FLAG_LIVE_RETENTION)) {
         rrd_flag_set_updated(rm->ri, RRD_FLAG_UPDATE_REASON_TRIGGERED);
-        rrdcontext_queue_for_post_processing(rm->ri->rc, function, rm->flags);
+        rrdcontext_queue_for_post_processing(rm->ri->rc, function, rrd_flags_get(rm));
     }
 }
 

--- a/src/database/contexts/rrdcontext-queues.c
+++ b/src/database/contexts/rrdcontext-queues.c
@@ -152,12 +152,12 @@ void rrdcontext_add_to_pp_queue(RRDCONTEXT *rc) {
 
     if(ret == RRDCONTEXT_QUEUE_ADDED) {
         rrd_flag_set(rc, RRD_FLAG_QUEUED_FOR_PP);
-        rc->pp.queued_flags = rc->flags;
+        rc->pp.queued_flags = rrd_flags_get(rc);
         rc->pp.queued_ut = now_realtime_usec();
     }
     else if(ret == RRDCONTEXT_QUEUE_FOUND) {
         rrd_flag_set(rc, RRD_FLAG_QUEUED_FOR_PP);
-        rc->pp.queued_flags |= rc->flags;
+        rc->pp.queued_flags |= rrd_flags_get(rc);
     }
 
     spinlock_unlock(&rc->rrdhost->rrdctx.pp_queue.spinlock);

--- a/src/libnetdata/os/get_system_cpus.c
+++ b/src/libnetdata/os/get_system_cpus.c
@@ -97,8 +97,8 @@ static inline unsigned long cpuset_str2ul(char **s) {
 
 #if defined(OS_LINUX)
 size_t os_read_cpuset_cpus(const char *filename, size_t system_cpus) {
-    static char *buf = NULL;
-    static size_t buf_size = 0;
+    static __thread char *buf = NULL;
+    static __thread size_t buf_size = 0;
 
     if(unlikely(!system_cpus))
         system_cpus = os_get_system_cpus_uncached();

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -8,7 +8,8 @@
 
 /* Converts a hex character to its integer value */
 char from_hex(char ch) {
-    return (char)(isdigit(ch) ? ch - '0' : tolower(ch) - 'a' + 10);
+    uint8_t uch = (uint8_t)ch;
+    return (char)(isdigit(uch) ? uch - '0' : tolower(uch) - 'a' + 10);
 }
 
 /* Converts an integer value to its hex character*/
@@ -57,7 +58,7 @@ char *url_encode(const char *str) {
  */
 char url_percent_escape_decode(const char *s) {
     if(likely(s[1] && s[2]))
-        return (char)(from_hex(s[1]) << 4 | from_hex(s[2]));
+        return (char)(((uint8_t)from_hex(s[1]) << 4) | (uint8_t)from_hex(s[2]));
     return 0;
 }
 

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -72,13 +72,15 @@ char url_percent_escape_decode(const char *s) {
  * @return It returns the length of the specific character.
  */
 char url_utf8_get_byte_length(char c) {
-    if(!IS_UTF8_BYTE(c))
+    uint8_t byte = (uint8_t)c;
+
+    if(!IS_UTF8_BYTE(byte))
         return 1;
 
     char length = 0;
-    while(likely(c & 0x80)) {
+    while(likely(byte & 0x80)) {
         length++;
-        c <<= 1;
+        byte <<= 1;
     }
     //4 byte is max size for UTF-8 char
     //10XX XXXX is not valid character -> check length == 1

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -16,12 +16,19 @@ static NETDATA_DOUBLE *UNUSED_FUNCTION(rrdr_line_values)(RRDR *r, long rrdr_line
 }
 
 ALWAYS_INLINE
-static long rrdr_line_init(RRDR *r __maybe_unused, time_t t __maybe_unused, long rrdr_line) {
+static long rrdr_line_next(RRDR *r __maybe_unused, long rrdr_line) {
     rrdr_line++;
 
     internal_fatal(rrdr_line >= (long)r->n,
                    "QUERY: requested to step above RRDR size for query '%s'",
                    r->internal.qt->id);
+
+    return rrdr_line;
+}
+
+ALWAYS_INLINE
+static long rrdr_line_init(RRDR *r __maybe_unused, time_t t __maybe_unused, long rrdr_line) {
+    rrdr_line = rrdr_line_next(r, rrdr_line);
 
     internal_fatal(r->t[rrdr_line] != t,
                    "QUERY: wrong timestamp at RRDR line %ld, expected %ld, got %ld, of query '%s'",
@@ -450,7 +457,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
 
     // fill the rest of the points with empty values
     while (points_added < points_wanted) {
-        rrdr_line++;
+        rrdr_line = rrdr_line_next(r, rrdr_line);
         size_t rrdr_o_v_index = rrdr_line * r->d + dim_id_in_rrdr;
         r->o[rrdr_o_v_index] = RRDR_VALUE_EMPTY;
         r->v[rrdr_o_v_index] = 0.0;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened flag handling, URL decoding, and query tail-fill to remove undefined behavior and data races without changing behavior. Improves safety in multi-threaded paths and malformed input handling.

- **Bug Fixes**
  - Read and snapshot rrdcontext/instance/metric flags atomically; use rrd_flags_get()/rrd_flag_is_collected() in triggers, queues, and API v2; queue stores queued_flags from atomic snapshots.
  - Seed compare-exchange helpers with __atomic_load_n to avoid racy plain loads.
  - URL percent-decoding: use unsigned bytes with ctype and bit shifts; fix UTF‑8 byte-length counting to shift an unsigned copy.
  - Queries: add a guarded rrdr_line_next() and use it for tail-fill to keep bounds checks consistent.
  - OS cpuset parsing: make the scratch buffer thread-local to prevent cross‑thread races.

<sup>Written for commit cc0b3e16674f2c6709b36b9a9cca31e306600b69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

