### PR TITLE
Netdata fixes part 20

### DIFF
--- a/src/libnetdata/inicfg/inicfg_sections.c
+++ b/src/libnetdata/inicfg/inicfg_sections.c
@@ -36,6 +36,8 @@ void inicfg_section_remove_and_delete(struct config *root, struct config_section
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "INTERNAL ERROR: Cannot remove section '%s', it was not inserted before.",
                string2str(sect->name));
+        if(have_sect_lock)
+            SECTION_UNLOCK(sect);
         return;
     }
 

--- a/src/libnetdata/json/json.c
+++ b/src/libnetdata/json/json.c
@@ -415,6 +415,7 @@ size_t json_walk_object(char *js, jsmntok_t *t, size_t nest, size_t start, JSON_
                     sprintf(c,"%s%s%s", e->fullname, e->fullname[0]?".":"", ne.name);
                     if (unlikely(len>JSON_FULLNAME_LEN)) len=JSON_FULLNAME_LEN;
                     strncpy(ne.fullname, c, len);
+                    ne.fullname[len] = '\0';
                     freez(c);
                     start++;
                     key = 0;

--- a/src/libnetdata/simple_hashtable/simple_hashtable.h
+++ b/src/libnetdata/simple_hashtable/simple_hashtable.h
@@ -485,7 +485,14 @@ static inline void simple_hashtable_resize_named(SIMPLE_HASHTABLE_NAMED *ht) {
         used++;
     }
 
-    assert(used == ht->used - ht->deleted);
+    if(unlikely(ht->deleted > ht->used))
+        fatal("SIMPLE_HASHTABLE: resize accounting invalid, deleted slots %zu exceed used slots %zu",
+              ht->deleted, ht->used);
+
+    size_t expected_used = ht->used - ht->deleted;
+    if(unlikely(used != expected_used))
+        fatal("SIMPLE_HASHTABLE: resize accounting mismatch, rehashed %zu slots, expected %zu slots (used %zu, deleted %zu)",
+              used, expected_used, ht->used, ht->deleted);
 
     ht->used = used;
     ht->deleted = 0;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a section-lock leak on an error path, ensures JSON walker full names are NUL-terminated, and adds fail-fast checks to hashtable resize. Improves stability and prevents hidden corruption or wedged locks.

- Bug Fixes
  - inicfg: release `SECTION_LOCK` on remove mismatch when the caller held the lock.
  - json: NUL-terminate `JSON_ENTRY.fullname` after bounded copy in `json_walk_object`.
  - simple_hashtable: replace assert-only check with fatal guards during resize; validate `deleted <= used` and rehashed count matches expectations.

<sup>Written for commit cd47dd46e8943b3885a4316c9732a3c4b41129ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

