### PR TITLE
Validate NETDATA_HOST_PREFIX in local_listeners

### DIFF
--- a/src/collectors/utils/local_listeners.c
+++ b/src/collectors/utils/local_listeners.c
@@ -68,7 +68,8 @@ int main(int argc, char **argv) {
     if(!netdata_configured_host_prefix) netdata_configured_host_prefix = "";
 
     // Validate host prefix (must be a real procfs/sysfs mount)
-    verify_netdata_host_prefix(true);
+    if(verify_netdata_host_prefix(true) == -1)
+        exit(1);
 
     for (int i = 1; i < argc; i++) {
         char *s = argv[i];

--- a/src/collectors/utils/local_listeners.c
+++ b/src/collectors/utils/local_listeners.c
@@ -67,6 +67,9 @@ int main(int argc, char **argv) {
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
     if(!netdata_configured_host_prefix) netdata_configured_host_prefix = "";
 
+    // Validate host prefix (must be a real procfs/sysfs mount)
+    verify_netdata_host_prefix(true);
+
     for (int i = 1; i < argc; i++) {
         char *s = argv[i];
         bool positive = true;

--- a/src/libnetdata/common.h
+++ b/src/libnetdata/common.h
@@ -254,6 +254,10 @@ typedef uint32_t uid_t;
 #define O_CLOEXEC (0)
 #endif
 
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW (0)
+#endif
+
 // --------------------------------------------------------------------------------------------------------------------
 // fix for alpine linux
 

--- a/src/libnetdata/common.h
+++ b/src/libnetdata/common.h
@@ -254,10 +254,6 @@ typedef uint32_t uid_t;
 #define O_CLOEXEC (0)
 #endif
 
-#ifndef O_NOFOLLOW
-#define O_NOFOLLOW (0)
-#endif
-
 // --------------------------------------------------------------------------------------------------------------------
 // fix for alpine linux
 

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -662,16 +662,13 @@ ALWAYS_INLINE
 static int read_proc_cmdline(const char *filename, char *buffer, size_t size) {
     if (unlikely(!size)) return 3;
 
-    // O_NOFOLLOW: a real /proc/<pid>/cmdline is never a symlink. Refusing to
-    // follow one closes a symlink-based arbitrary-file-read primitive when this
-    // is reached through an untrusted /proc path. Guard the flag locally for
-    // platforms that lack it (e.g. some Windows toolchains), matching the
-    // pattern in api_v1_manage.c -- a global fallback define would defeat the
-    // #ifdef O_NOFOLLOW guards those callers rely on for their safe fallbacks.
+    // O_NOFOLLOW closes a symlink-based arbitrary-file-read primitive: a real
+    // /proc/<pid>/cmdline is never a symlink
 #ifdef O_NOFOLLOW
     int fd = open(filename, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
 #else
-    int fd = open(filename, O_RDONLY | O_CLOEXEC);
+    errno = ENOSYS;
+    int fd = -1;
 #endif
     if (unlikely(fd == -1)) {
         buffer[0] = '\0';

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -664,8 +664,15 @@ static int read_proc_cmdline(const char *filename, char *buffer, size_t size) {
 
     // O_NOFOLLOW: a real /proc/<pid>/cmdline is never a symlink. Refusing to
     // follow one closes a symlink-based arbitrary-file-read primitive when this
-    // is reached through an untrusted /proc path.
-    int fd = open(filename, O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0666);
+    // is reached through an untrusted /proc path. Guard the flag locally for
+    // platforms that lack it (e.g. some Windows toolchains), matching the
+    // pattern in api_v1_manage.c -- a global fallback define would defeat the
+    // #ifdef O_NOFOLLOW guards those callers rely on for their safe fallbacks.
+#ifdef O_NOFOLLOW
+    int fd = open(filename, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+#else
+    int fd = open(filename, O_RDONLY | O_CLOEXEC);
+#endif
     if (unlikely(fd == -1)) {
         buffer[0] = '\0';
         return 1;

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -662,7 +662,10 @@ ALWAYS_INLINE
 static int read_proc_cmdline(const char *filename, char *buffer, size_t size) {
     if (unlikely(!size)) return 3;
 
-    int fd = open(filename, O_RDONLY | O_CLOEXEC, 0666);
+    // O_NOFOLLOW: a real /proc/<pid>/cmdline is never a symlink. Refusing to
+    // follow one closes a symlink-based arbitrary-file-read primitive when this
+    // is reached through an untrusted /proc path.
+    int fd = open(filename, O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0666);
     if (unlikely(fd == -1)) {
         buffer[0] = '\0';
         return 1;


### PR DESCRIPTION
##### Summary
- Add `verify_netdata_host_prefix(true)` to ensure the provided `NETDATA_HOST_PREFIX` is a valid procfs/sysfs mount.
- Use `O_NOFOLLOW` in `read_proc_cmdline` to prevent unsafe symlink traversal in `/proc/<pid>/cmdline` file access.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `NETDATA_HOST_PREFIX` on startup and harden `/proc/<pid>/cmdline` reads by refusing symlinks; if `O_NOFOLLOW` isn’t supported, fail safely with `ENOSYS`. This blocks arbitrary file reads and exits on invalid host prefixes.

- **Bug Fixes**
  - Enforce `verify_netdata_host_prefix(true)` in `local_listeners`; exit if it’s not a real procfs/sysfs mount.
  - In `read_proc_cmdline()`, use `O_NOFOLLOW` when available; otherwise set `errno = ENOSYS` and fail (no fallback) to avoid unsafe symlink traversal.

<sup>Written for commit 9dec4b0f5ce6c7d98a96dddebcfa3c5ef2a99abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

