### PR TITLE
NetFlow: restore sFlow visibility and listener docs

### DIFF
--- a/docs/npm/network-flows/README.md
+++ b/docs/npm/network-flows/README.md
@@ -71,7 +71,7 @@ The Netdata netflow plugin decodes:
 - **IPFIX** (RFC 7011, the IETF-standardised successor to NetFlow v9)
 - **sFlow v5** (the packet-sampling protocol most switches use)
 
-A single UDP listener (default `0.0.0.0:2055`) accepts all five. The plugin auto-detects each datagram's protocol from its header.
+By default, the plugin opens UDP listeners on `0.0.0.0:2055` for NetFlow/IPFIX exporters and `0.0.0.0:6343` for sFlow exporters. The plugin auto-detects each datagram's protocol from its header, so users do not need configuration to start receiving flows on the stock ports.
 
 Each flow record is enriched at ingestion with:
 

--- a/docs/npm/network-flows/configuration.md
+++ b/docs/npm/network-flows/configuration.md
@@ -35,7 +35,7 @@ sudo cp /usr/lib/netdata/conf.d/netflow.yaml /etc/netdata/netflow.yaml
 
 ```yaml
 enabled: true               # global on/off
-listener: { ... }           # UDP socket and journal sync
+listener: { ... }           # UDP listener sockets and journal sync
 protocols: { ... }          # which protocols to accept; decapsulation; timestamps
 journal: { ... }            # tier directories, retention, query guardrails
 enrichment: { ... }         # GeoIP, classifiers, ASN, BMP, BioRIS, network sources
@@ -53,11 +53,13 @@ Set to `false` to turn the entire flow plugin off. The plugin still loads but do
 
 ## `listener`
 
-Controls the UDP socket and the journal write cadence.
+Controls the UDP listener sockets and the journal write cadence.
 
 ```yaml
 listener:
-  listen: "0.0.0.0:2055"
+  listen:
+    - "0.0.0.0:2055"
+    - "0.0.0.0:6343"
   max_packet_size: 9216
   sync_every_entries: 0
   sync_interval: "1s"
@@ -65,14 +67,14 @@ listener:
 
 | Key | CLI flag | Default | Notes |
 |---|---|---|---|
-| `listen` | `--netflow-listen` | `0.0.0.0:2055` | Address and port for the UDP socket. Same socket handles NetFlow v5/v7/v9, IPFIX, and sFlow. |
+| `listen` | `--netflow-listen` | `0.0.0.0:2055`, `0.0.0.0:6343` | UDP listener endpoints. Stock config needs no user edits: NetFlow/IPFIX exporters can send to `2055`, and sFlow exporters can send to `6343`. YAML accepts the preferred list form shown above and the legacy scalar form (`listen: "0.0.0.0:2055"`). CLI usage accepts repeated `--netflow-listen` flags or comma-delimited values. |
 | `max_packet_size` | `--netflow-max-packet-size` | `9216` | Maximum UDP datagram in bytes. Increase for jumbo sFlow datagrams or routers that send oversized IPFIX. |
 | `sync_every_entries` | `--netflow-sync-every-entries` | `0` | Periodic fsync of the active raw journal. `0` (default) disables it: data reaches disk via kernel writeback, and every journal file is fully synced when rotated and at shutdown. Values > 0 fsync after that many records (and at least once per `sync_interval`); at high flow rates the fsync stalls the receive path and can cause UDP drops. |
 | `sync_interval` | `--netflow-sync-interval` | `1s` | Maximum time between forced fsyncs when `sync_every_entries` > 0. Also the cadence for facet-state persistence and tier maintenance. |
 
 ### UDP buffer tuning is not in this file
 
-If you receive a high flow rate, the kernel UDP receive buffer matters more than `max_packet_size`. The plugin requests a large buffer (64 MiB) at startup via `setsockopt(SO_RCVBUF)`, but the kernel silently caps unprivileged requests at `net.core.rmem_max`, and distribution defaults are tiny (~208 KiB). Raise the cap at the kernel level:
+If you receive a high flow rate, the kernel UDP receive buffer matters more than `max_packet_size`. The plugin requests a large buffer (64 MiB) for each configured UDP listener socket at startup via `setsockopt(SO_RCVBUF)`, but the kernel silently caps unprivileged requests at `net.core.rmem_max`, and distribution defaults are tiny (~208 KiB). Raise the cap at the kernel level:
 
 ```bash
 sudo sysctl -w net.core.rmem_max=67108864

--- a/docs/npm/network-flows/configuration.md
+++ b/docs/npm/network-flows/configuration.md
@@ -171,11 +171,11 @@ Per-tier values:
 | Key | Default per tier | Notes |
 |---|---|---|
 | `size_of_journal_files` | `10GB` | Disk budget for this tier. Minimum `100MB`. Set to `null` to disable size-based retention on this tier. |
-| `duration_of_journal_files` | `7d` | Time budget for this tier. Set to `null` to disable time-based retention on this tier. |
+| `duration_of_journal_files` | `null` | Optional time budget for this tier. The default disables time-based eviction; set a duration such as `24h` or `14d` to add an age cap. |
 
-Either limit triggers rotation. The tier expires whichever is hit first. At least one of the two must be set per tier (validation enforces this).
+Either configured limit can evict old files. The tier expires whichever configured limit is hit first. At least one of the two must be set per tier (validation enforces this).
 
-If you omit a tier entry entirely, that tier uses the built-in defaults (`10GB` / `7d`). If you provide a tier entry but omit one of the two knobs, the omitted knob falls back to its built-in default. Setting either to `null` explicitly disables that limit on that tier.
+If you omit a tier entry entirely, that tier uses the built-in defaults (`10GB` / no time limit). If you provide a tier entry but omit one of the two knobs, the omitted knob falls back to its built-in default. Setting either to `null` explicitly disables that limit on that tier.
 
 Standalone CLI runs still accept the legacy uniform retention flags:
 `--netflow-retention-size-of-journal-files` and
@@ -297,7 +297,7 @@ journal:
       duration_of_journal_files: 365d
 ```
 
-The built-in defaults (10GB / 7d on every tier) are intended for first validation and small deployments. Most production deployments should size retention from observed flow rate. This profile gives you 24 hours of full-detail forensics, 14 days of 1-minute trends, 30 days of 5-minute snapshots, and a year of hourly aggregates. Storage required scales with your flow rate — see [Sizing and Capacity Planning](/docs/npm/network-flows/sizing-capacity.md).
+The built-in defaults (10GB and no time limit on every tier) are intended for first validation and small deployments. Most production deployments should size retention from observed flow rate and add explicit time caps when they need a fixed investigation window. This profile gives you 24 hours of full-detail forensics, 14 days of 1-minute trends, 30 days of 5-minute snapshots, and a year of hourly aggregates. Storage required scales with your flow rate — see [Sizing and Capacity Planning](/docs/npm/network-flows/sizing-capacity.md).
 
 ## Things that go wrong
 

--- a/docs/npm/network-flows/installation.md
+++ b/docs/npm/network-flows/installation.md
@@ -19,7 +19,7 @@ The static install (the kickstart `--static-only` path) bundles the plugin autom
 ## Prerequisites
 
 - A working Netdata Agent on the host that will receive flow data.
-- That host must be reachable on UDP from your routers and switches (default port `2055`).
+- That host must be reachable on UDP from your routers and switches. The stock plugin listens on UDP `2055` for NetFlow/IPFIX and UDP `6343` for sFlow.
 - A Netdata installation that includes `netdata-plugin-netflow`. Native Linux packages install it as a separate package; static installs bundle it automatically (except the ARMv6 build — Raspberry Pi 1 / Zero); source builds need a Rust toolchain.
 
 ## Install on Debian / Ubuntu / Mint
@@ -111,15 +111,15 @@ After installation and restart:
 sudo journalctl --namespace netdata --since "5 minutes ago" | grep -E 'netflow|listener'
 ```
 
-You should see entries indicating that the plugin loaded its config and that the UDP listener bound to its port.
+You should see entries indicating that the plugin loaded its config and that the UDP listeners bound to their ports.
 
 Quick sanity check:
 
 ```bash
-sudo ss -unlp | grep 2055
+sudo ss -unlp | grep -E ':(2055|6343)([[:space:]]|$)'
 ```
 
-A line for `netflow-plugin` confirms the listener is up.
+Lines for `netflow-plugin` confirm the stock listeners are up.
 
 ## Open Netdata to confirm
 
@@ -133,7 +133,7 @@ If Network Flows doesn't appear under Live, or the view is empty:
 
 ## Configuring flow sources
 
-Installing the plugin enables it. To actually see flow data, you need to configure a router, switch, or software exporter to send NetFlow / IPFIX / sFlow datagrams to this host's UDP port 2055.
+Installing the plugin enables it and opens the stock listener ports. To actually see flow data, configure a router, switch, or software exporter to send NetFlow/IPFIX datagrams to this host's UDP port `2055` or sFlow datagrams to UDP port `6343`.
 
 That's the next step:
 

--- a/docs/npm/network-flows/quick-start.md
+++ b/docs/npm/network-flows/quick-start.md
@@ -17,7 +17,7 @@ Get flow monitoring running in 15 minutes. The path: install the plugin, configu
 - The Netdata Agent is running on the host that will collect flow data.
 - The [netflow plugin is installed](/docs/npm/network-flows/installation.md) on that host.
 - You can configure flow export on at least one router or switch.
-- The router can reach the agent's IP on UDP port 2055.
+- The router can reach the agent's IP on the matching UDP listener port: `2055` for NetFlow/IPFIX, or `6343` for sFlow.
 
 If the plugin isn't installed yet, follow the [Installation page](/docs/npm/network-flows/installation.md) first.
 
@@ -84,7 +84,7 @@ Notes:
 ```
 sflow run
 sflow source-interface Loopback0
-sflow destination 10.0.0.10 2055
+sflow destination 10.0.0.10 6343
 sflow polling-interval 30
 sflow sample dangerous 2000
 !
@@ -151,7 +151,7 @@ If the Sankey is empty after 60-90 seconds, work through this:
 1. **Datagrams arriving at the host.**
 
    ```bash
-   sudo tcpdump -i any -nn -c 20 'udp port 2055'
+   sudo tcpdump -i any -nn -c 20 'udp port 2055 or udp port 6343'
    ```
 
    If you see packets, the network path is fine. If not, check the router's exporter status, the firewall, and the source IP the router uses.
@@ -159,7 +159,7 @@ If the Sankey is empty after 60-90 seconds, work through this:
 2. **Listener bound on the host.**
 
    ```bash
-   sudo ss -unlp | grep 2055
+   sudo ss -unlp | grep -E ':(2055|6343)([[:space:]]|$)'
    ```
 
    Should show `netflow-plugin` listening. If not, see [Troubleshooting](/docs/npm/network-flows/troubleshooting.md).

--- a/docs/npm/network-flows/retention-querying.md
+++ b/docs/npm/network-flows/retention-querying.md
@@ -98,7 +98,7 @@ If you see the time depth in your dashboard suddenly shrink after you applied a 
 
 ## Default retention and the most common misconfiguration
 
-Each tier has its own `size_of_journal_files` and `duration_of_journal_files`. The built-in defaults are uniform — `10GB` and `7d` on every tier. That is rarely what you want; the whole point of having rollup tiers is to keep them around longer than raw.
+Each tier has its own `size_of_journal_files` and `duration_of_journal_files`. The built-in defaults are uniform: `10GB` on every tier with no time-based age limit. That is safe for first validation because disk is still capped, but production deployments should usually set tier-specific size and duration budgets; the whole point of having rollup tiers is to keep them around longer than raw.
 
 A more useful production profile:
 

--- a/docs/npm/network-flows/troubleshooting.md
+++ b/docs/npm/network-flows/troubleshooting.md
@@ -27,7 +27,7 @@ The plugin won't come up at all, or starts and immediately exits.
 |---|---|
 | YAML typo or unknown key | `journalctl --namespace netdata --since "5 minutes ago" \| grep -E 'failed to load configuration\|netflow'`. The plugin uses strict YAML — any unknown key fails parsing. |
 | Required GeoIP DB missing (`optional: false`) | Same log search. Look for `failed to load database`. Either fix the path or set `optional: true`. |
-| Listen address conflict | Look for `failed to bind`. Another process is on the configured port (default 2055). |
+| Listen address conflict | Look for `failed to bind`. Another process is on one of the configured ports (stock defaults: `2055` and `6343`). |
 | Validation error | Look for `must be greater than 0` and similar. The plugin validates the full config at startup. |
 | `enabled: false` was set | Look for `netflow plugin disabled by config`. The plugin honours this and shuts down cleanly — looks like "not running" if you don't read the log. |
 
@@ -51,7 +51,7 @@ The plugin is running, but the Network Flows view is empty.
 **First check:** is anything reaching the plugin?
 
 ```bash
-sudo tcpdump -i any -nn -c 50 'udp port 2055'
+sudo tcpdump -i any -nn -c 50 'udp port 2055 or udp port 6343'
 ```
 
 - **No packets in 30 seconds** — exporter not sending, or firewall blocking. Check the exporter's status (`show flow exporter` on Cisco, equivalents elsewhere) and the network path. The plugin can't help here; the data isn't reaching it.
@@ -60,7 +60,7 @@ sudo tcpdump -i any -nn -c 50 'udp port 2055'
 **Second check:** is the listener bound?
 
 ```bash
-sudo ss -unlp | grep -E ':2055|netflow'
+sudo ss -unlp | grep -E ':(2055|6343)([[:space:]]|$)|netflow'
 ```
 
 If nothing matches, the plugin isn't listening. See "doesn't start" above.
@@ -72,6 +72,23 @@ Open `netflow.input_packets` on the standard Netdata charts page. The dimensions
 - `udp_received > 0`, `parsed_packets == 0` — datagrams arriving, none decoding successfully. Wrong protocol on the listener, or all datagrams malformed.
 - `udp_received > 0`, `parsed_packets > 0`, but no per-protocol counter (`netflow_v9`, `ipfix`, etc.) is moving — the protocol you're sending may be disabled in the plugin config. Check `protocols.v9`, `protocols.ipfix`, etc. in `netflow.yaml`.
 - `parse_errors` rising in lockstep with `udp_received` — datagrams aren't valid for the protocols the plugin supports. Capture a small UDP sample with `tcpdump -w` and inspect it with Wireshark.
+
+### sFlow packets arrive, but no sFlow rows appear
+
+sFlow datagrams can carry flow samples, counter samples, or both. Netdata's Network Flows view creates flow rows from sFlow flow samples only. Counter-only sFlow traffic is valid sFlow traffic, and `netflow.input_packets` can show `sflow` increasing, but there are no source/destination flow rows to display.
+
+Capture a small sample and check the sFlow sample types:
+
+```bash
+sudo tcpdump -i any -s 0 -w /tmp/sflow-check.cap -c 50 'udp port 6343 or udp port 2055'
+tshark -r /tmp/sflow-check.cap \
+  -d udp.port==6343,sflow -d udp.port==2055,sflow \
+  -T fields -e sflow_245.sampletype -e sflow_245.flow_record_format | sort | uniq -c
+```
+
+- Sample type `1` (`flow_sample`) and `3` (`expanded_flow_sample`) can produce Network Flow rows.
+- Sample type `2` (`counters_sample`) and `4` (`expanded_counters_sample`) do not contain endpoint-level flow records.
+- If you only see sample types `2` or `4`, configure the exporter or generator to send flow samples, or both flow and counter samples. For MIMIC, select `Flow` or `All`/`Both` samples and make sure the loaded SFLOW configuration file actually contains flow sample blocks.
 
 ## Partial data — some flows are dropped
 
@@ -96,6 +113,7 @@ The plugin doesn't count these. Check at the OS level:
 
 ```bash
 sudo ss -uamn sport = :2055        # inspect the d<N> field inside skmem:(...)
+sudo ss -uamn sport = :6343        # repeat for the stock sFlow listener
 grep ^Udp: /proc/net/snmp          # RcvbufErrors counter (system-wide)
 ```
 
@@ -213,13 +231,14 @@ Default retention is `10GB / 7d` per tier. The default is applied separately to 
 sudo journalctl --namespace netdata --since "10 minutes ago" | grep -iE 'netflow|geoip|bmp|bioris|network-sources'
 
 # What's arriving on the wire
-sudo tcpdump -i any -nn -c 50 'udp port 2055'
+sudo tcpdump -i any -nn -c 50 'udp port 2055 or udp port 6343'
 
 # Is the listener bound
-sudo ss -unlp | grep 2055
+sudo ss -unlp | grep -E ':(2055|6343)([[:space:]]|$)'
 
 # UDP kernel drops
 sudo ss -uamn sport = :2055
+sudo ss -uamn sport = :6343
 grep ^Udp: /proc/net/snmp
 
 # Disk usage by tier
@@ -229,7 +248,7 @@ sudo du -sh /var/cache/netdata/flows/*
 top -p $(pgrep -f netflow-plugin)
 
 # Capture a sample for offline analysis
-sudo tcpdump -w /tmp/netflow-sample.cap -c 200 'udp port 2055'
+sudo tcpdump -w /tmp/flow-sample.cap -c 200 'udp port 2055 or udp port 6343'
 ```
 
 ## When to file an issue

--- a/docs/npm/network-flows/troubleshooting.md
+++ b/docs/npm/network-flows/troubleshooting.md
@@ -212,13 +212,13 @@ Note: the live (open) tier rows shown by queries refresh on a 1-second cadence, 
 sudo du -sh /var/cache/netdata/flows/*
 ```
 
-Default retention is `10GB / 7d` per tier. The default is applied separately to raw, 1m, 5m, and 1h tiers, so total can reach roughly 40 GB plus some. If your config left this default and your collector is busy, expect to hit the size cap before the time cap. See [Configuration](/docs/npm/network-flows/configuration.md) for per-tier overrides — most production deployments need them.
+Default retention is `10GB` per tier with no time-based age limit. The default is applied separately to raw, 1m, 5m, and 1h tiers, so total can reach roughly 40 GB plus some. If your config left this default and your collector is busy, expect to hit the size cap quickly; quiet collectors may keep data for longer than seven days. See [Configuration](/docs/npm/network-flows/configuration.md) for per-tier overrides — most production deployments need them.
 
 ## Things that look like bugs but aren't
 
 - **Traffic appears 2×.** When the router is configured to export both ingress + egress (common, but not universal — vendor best practice is ingress-only), the same packet is recorded once on entry and once on exit on a single router. Filter to one exporter and one interface (`Ingress Interface Name` or `Egress Interface Name`, pick one).
 - **Bidirectional conversations show twice.** A→B and B→A are real, distinct flows representing different packets going each way. Their volumes are usually asymmetric. Filter by `Source AS Name` (your network) for outbound or `Destination AS Name` (your network) for inbound to see one side.
-- **City map empty over long windows.** City + lat/lon are raw-tier-only. Default raw-tier retention is short. Use the country or state map for long ranges.
+- **City map empty over long windows.** City + lat/lon are raw-tier-only. Raw-tier retention is bounded by its size budget, so busy collectors can exhaust raw history quickly. Use the country or state map for long ranges.
 - **`__overflow__` row in results.** Your aggregation produced more groups than `query_max_groups`. Narrow the filter or reduce group-by depth.
 - **30-second query timeout.** Hard limit. Narrow time range, add filters, or reduce group-by depth.
 - **Sampled byte counts not exact.** sFlow is statistical by design; even NetFlow with sampling is an estimate. Cross-check against SNMP for sanity, accept some divergence.

--- a/docs/npm/network-flows/validation.md
+++ b/docs/npm/network-flows/validation.md
@@ -44,7 +44,7 @@ The SNMP-derived bandwidth: from your SNMP monitoring (Netdata's `snmp.d`, your 
 
 **Not acceptable: more than 30% gap.** That indicates one of:
 
-- UDP drops at the kernel. Check the alert mentioned above, or run `sudo ss -uamn sport = :2055` and inspect the `d<N>` value inside the `skmem:(...)` line (the `sock_drop` counter increments on every dropped datagram). The `-n` flag keeps the port numeric in the output.
+- UDP drops at the kernel. Check the alert mentioned above, or run `sudo ss -uamn sport = :2055` / `sudo ss -uamn sport = :6343` and inspect the `d<N>` value inside the `skmem:(...)` line (the `sock_drop` counter increments on every dropped datagram). The `-n` flag keeps the port numeric in the output.
 - Sampling rate not honoured (the exporter is sampling but not communicating the rate). See "Sampling rate verification" below.
 - Wrong interfaces being exported.
 

--- a/docs/npm/network-flows/visualization/dashboard-cards.md
+++ b/docs/npm/network-flows/visualization/dashboard-cards.md
@@ -84,7 +84,7 @@ This one breaks RSS down by what's mapped. Useful when you want to attribute "th
 These charts do not include:
 
 - **Per-exporter ingest counter.** No per-source rate dimension. Decoder-scope cardinality tells you how many sources, not how busy each one is.
-- **UDP socket drops.** Kernel-level drops (full receive buffer, NIC drops) are not surfaced. Use OS-level signals: `sudo ss -uamn sport = :2055` for per-socket drops, or `grep ^Udp: /proc/net/snmp` for the system-wide `RcvbufErrors` counter.
+- **UDP socket drops.** Kernel-level drops (full receive buffer, NIC drops) are not surfaced. Use OS-level signals such as `sudo ss -uamn sport = :2055` and `sudo ss -uamn sport = :6343` for per-socket drops, or `grep ^Udp: /proc/net/snmp` for the system-wide `RcvbufErrors` counter.
 - **Template cache hit ratio.** `template_errors` counts misses; there's no corresponding "hits" counter to form a ratio.
 - **GeoIP staleness signal.** No "MMDB last loaded" timestamp or version. The mapping memory dimensions tell you if a database is loaded, not how old it is.
 - **Per-tier query latency.** These charts cover ingest and storage; query-side performance isn't observable.

--- a/docs/npm/network-flows/visualization/maps-globe.md
+++ b/docs/npm/network-flows/visualization/maps-globe.md
@@ -50,7 +50,7 @@ The country map and state map can use the rollup tiers. They're cheap over long 
 The city map and the globe **need raw-tier data**. City, latitude, and longitude are dropped from the rollup tiers (1m / 5m / 1h) to keep cardinality manageable. So:
 
 - Country / state map over the last 30 days — fine, uses the 1-hour tier.
-- City map over the last 30 days — likely empty. Raw-tier retention defaults to its own 10GB / 7d limits; busy collectors often hit the raw-tier size cap before 7 days.
+- City map over the last 30 days — likely empty on busy collectors. Raw-tier retention defaults to its own 10GB size cap with no time-based age limit, so high flow volume can exhaust raw history quickly.
 
 If your city map looks empty over a long window, try the country map first to confirm data is arriving, then narrow the time range until the city map fills in.
 

--- a/docs/npm/network-flows/visualization/time-series.md
+++ b/docs/npm/network-flows/visualization/time-series.md
@@ -54,7 +54,7 @@ Some queries can't use the rollup tiers. They drop to raw tier and inherit raw-t
 - Filtering or grouping by `SRC_ADDR`, `DST_ADDR`, `SRC_PORT`, `DST_PORT`, or any geo city / latitude / longitude field
 - Any non-empty full-text search
 
-In those cases the 100-bucket rule still applies, but the source tier is raw tier. Time depth is bounded by raw-tier retention (default: the raw tier has its own 10GB / 7d retention limits, and busy collectors often hit the size cap before 7 days).
+In those cases the 100-bucket rule still applies, but the source tier is raw tier. Time depth is bounded by raw-tier retention (default: the raw tier has a 10GB size cap and no time-based age limit, so busy collectors can exhaust raw history quickly).
 
 If you've been working at a higher tier and add an IP filter, the time depth on your chart may suddenly shrink — that's the tier switch.
 

--- a/src/crates/netflow-plugin/README.md
+++ b/src/crates/netflow-plugin/README.md
@@ -362,9 +362,9 @@ traffic, not for billing or hard enforcement decisions.
 - `minute_5` (aliases: `5m`, `minute-5`, `minute5`)
 - `hour_1` (aliases: `1h`, `hour-1`, `hour1`)
 
-If a tier is omitted, it uses the built-in tier default (`10GB / 7d`). There
-are no top-level journal retention knobs; set retention on each tier you want
-to tune.
+If a tier is omitted, it uses the built-in tier default (`10GB` with no
+time-based age limit). There are no top-level journal retention knobs; set
+retention on each tier you want to tune.
 
 To make a tier time-only, set `size_of_journal_files: null`.
 To make a tier size-only, set `duration_of_journal_files: null`.

--- a/src/crates/netflow-plugin/README.md
+++ b/src/crates/netflow-plugin/README.md
@@ -234,7 +234,9 @@ Example:
 enabled: true
 
 listener:
-  listen: "0.0.0.0:2055"
+  listen:
+    - "0.0.0.0:2055"
+    - "0.0.0.0:6343"
 
 protocols:
   v5: true

--- a/src/crates/netflow-plugin/configs/netflow.yaml
+++ b/src/crates/netflow-plugin/configs/netflow.yaml
@@ -14,8 +14,10 @@
 enabled: true
 
 listener:
-  # UDP socket for NetFlow/IPFIX/sFlow exporters.
-  listen: "0.0.0.0:2055"
+  # UDP sockets for NetFlow/IPFIX and sFlow exporters.
+  listen:
+    - "0.0.0.0:2055"
+    - "0.0.0.0:6343"
   max_packet_size: 9216
   # Periodic fsync of the active raw journal. 0 (default) disables it: data
   # reaches disk via kernel writeback, and every journal file is fully synced

--- a/src/crates/netflow-plugin/configs/netflow.yaml
+++ b/src/crates/netflow-plugin/configs/netflow.yaml
@@ -45,8 +45,10 @@ journal:
 
   # Per-tier retention. Each tier has its own size_of_journal_files (hard
   # cap; minimum 100MB; null disables size-based retention) and
-  # duration_of_journal_files (time cap; null disables time-based
-  # retention). Validation requires at least one positive limit per tier.
+  # duration_of_journal_files (optional time cap; null disables time-based
+  # retention). The stock default is size-only retention: 10GB per tier
+  # with no age-based eviction. Validation requires at least one positive
+  # limit per tier.
   # Internal rotation size derives from size_of_journal_files:
   # clamp(size_of_journal_files / 20, 5MB, 200MB). When size is null,
   # internal rotation defaults to 100MB and retention is controlled only
@@ -54,16 +56,16 @@ journal:
   tiers:
     raw:
       size_of_journal_files: 10GB
-      duration_of_journal_files: 7d
+      duration_of_journal_files: null
     minute_1:
       size_of_journal_files: 10GB
-      duration_of_journal_files: 7d
+      duration_of_journal_files: null
     minute_5:
       size_of_journal_files: 10GB
-      duration_of_journal_files: 7d
+      duration_of_journal_files: null
     hour_1:
       size_of_journal_files: 10GB
-      duration_of_journal_files: 7d
+      duration_of_journal_files: null
 
   # Cap on the number of distinct group keys a single aggregation query
   # can build before extra groups are folded into a synthetic

--- a/src/crates/netflow-plugin/integrations/ipfix.md
+++ b/src/crates/netflow-plugin/integrations/ipfix.md
@@ -87,7 +87,7 @@ Enable IPFIX via the `protocols.ipfix` option.
 | protocols.ipfix | Enable IPFIX decoding. | yes | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
 | journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention. | 10GB | no |
-| journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for size-only retention. | 7d | no |
+| journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap. | null | no |
 
 
 </details>

--- a/src/crates/netflow-plugin/integrations/ipfix.md
+++ b/src/crates/netflow-plugin/integrations/ipfix.md
@@ -33,7 +33,7 @@ ASA NSEL), biflow handling, sampling caveats, and verification steps, see the
 [Network Flows Overview](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/).
 
 
-The plugin listens on the same UDP socket as NetFlow. IPFIX messages are identified by
+The plugin uses the same configurable UDP listener set as NetFlow. IPFIX messages are identified by
 version number 10 and decoded using cached templates. Decoded records are enriched and
 appended to disk-backed journal tiers.
 
@@ -47,7 +47,7 @@ This integration runs as a single instance per Netdata Agent.
 
 #### Auto-Detection
 
-The plugin starts when enabled in netflow.yaml and listens on the configured UDP port.
+The stock configuration enables the plugin and listens on the configured UDP ports.
 
 #### Limits
 
@@ -83,7 +83,7 @@ Enable IPFIX via the `protocols.ipfix` option.
 
 | Option | Description | Default | Required |
 |:-----|:------------|:--------|:---------:|
-| listener.listen | UDP endpoint for IPFIX datagrams. | 0.0.0.0:2055 | no |
+| listener.listen | UDP listener endpoints for NetFlow/IPFIX and sFlow datagrams. YAML accepts either a scalar endpoint or a list of endpoints; CLI accepts repeated `--netflow-listen` flags or comma-delimited values. | 0.0.0.0:2055, 0.0.0.0:6343 | no |
 | protocols.ipfix | Enable IPFIX decoding. | yes | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
 | journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention. | 10GB | no |
@@ -111,7 +111,7 @@ sudo ./edit-config netflow.yaml
 
 ###### IPFIX collection
 
-Listen for IPFIX records on Netdata's default flow listener port.
+Listen for IPFIX records on the common NetFlow/IPFIX port.
 
 ```yaml
 enabled: true

--- a/src/crates/netflow-plugin/integrations/netflow.md
+++ b/src/crates/netflow-plugin/integrations/netflow.md
@@ -32,7 +32,7 @@ For full documentation including vendor configuration examples, sampling caveats
 handling and verification steps, see the [Network Flows Overview](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/).
 
 
-The plugin listens on a configurable UDP socket for NetFlow datagrams.
+The plugin listens on configurable UDP listener sockets for NetFlow datagrams.
 NetFlow v5 and v7 records are decoded directly. NetFlow v9 records are decoded using
 dynamic templates cached from the exporter. Decoded records are enriched in-memory
 and appended to disk-backed journal tiers (raw, 1-minute, 5-minute, 1-hour rollups).
@@ -47,7 +47,7 @@ This integration runs as a single instance per Netdata Agent.
 
 #### Auto-Detection
 
-The plugin starts when enabled in netflow.yaml and listens on the configured UDP port.
+The stock configuration enables the plugin and listens on the configured UDP ports.
 
 #### Limits
 
@@ -82,7 +82,7 @@ The plugin is configured via `netflow.yaml` in the Netdata configuration directo
 
 | Option | Description | Default | Required |
 |:-----|:------------|:--------|:---------:|
-| listener.listen | UDP endpoint for NetFlow datagrams. | 0.0.0.0:2055 | no |
+| listener.listen | UDP listener endpoints for NetFlow/IPFIX and sFlow datagrams. YAML accepts either a scalar endpoint or a list of endpoints; CLI accepts repeated `--netflow-listen` flags or comma-delimited values. | 0.0.0.0:2055, 0.0.0.0:6343 | no |
 | protocols.v5 | Enable NetFlow v5 decoding. | yes | no |
 | protocols.v7 | Enable NetFlow v7 decoding. | yes | no |
 | protocols.v9 | Enable NetFlow v9 decoding. | yes | no |
@@ -112,12 +112,14 @@ sudo ./edit-config netflow.yaml
 
 ###### Basic NetFlow v5/v9 collection
 
-Listen on Netdata's default flow listener port for v5 and v9 records.
+Use Netdata's stock listener set for v5 and v9 records.
 
 ```yaml
 enabled: true
 listener:
-  listen: "0.0.0.0:2055"
+  listen:
+    - "0.0.0.0:2055"
+    - "0.0.0.0:6343"
 protocols:
   v5: true
   v9: true

--- a/src/crates/netflow-plugin/integrations/netflow.md
+++ b/src/crates/netflow-plugin/integrations/netflow.md
@@ -88,7 +88,7 @@ The plugin is configured via `netflow.yaml` in the Netdata configuration directo
 | protocols.v9 | Enable NetFlow v9 decoding. | yes | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
 | journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention. | 10GB | no |
-| journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for size-only retention. | 7d | no |
+| journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap. | null | no |
 
 
 </details>

--- a/src/crates/netflow-plugin/integrations/sflow.md
+++ b/src/crates/netflow-plugin/integrations/sflow.md
@@ -88,7 +88,7 @@ Enable sFlow via the `protocols.sflow` option.
 | protocols.sflow | Enable sFlow decoding. | yes | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
 | journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention. | 10GB | no |
-| journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for size-only retention. | 7d | no |
+| journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap. | null | no |
 
 
 </details>

--- a/src/crates/netflow-plugin/integrations/sflow.md
+++ b/src/crates/netflow-plugin/integrations/sflow.md
@@ -34,7 +34,7 @@ Ruckus, hsflowd), and the limits of sampled data, see the
 [Network Flows Overview](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/).
 
 
-The plugin listens on the same UDP socket as NetFlow. sFlow datagrams are identified by
+The plugin uses the same configurable UDP listener set as NetFlow/IPFIX. sFlow datagrams are identified by
 their distinct header format and decoded per the sFlow v5 specification. Decoded records
 are enriched and appended to disk-backed journal tiers.
 
@@ -48,7 +48,7 @@ This integration runs as a single instance per Netdata Agent.
 
 #### Auto-Detection
 
-The plugin starts when enabled in netflow.yaml and listens on the configured UDP port.
+The stock configuration enables the plugin and listens on the configured UDP ports.
 
 #### Limits
 
@@ -84,7 +84,7 @@ Enable sFlow via the `protocols.sflow` option.
 
 | Option | Description | Default | Required |
 |:-----|:------------|:--------|:---------:|
-| listener.listen | UDP endpoint for sFlow datagrams. | 0.0.0.0:2055 | no |
+| listener.listen | UDP listener endpoints for NetFlow/IPFIX and sFlow datagrams. YAML accepts either a scalar endpoint or a list of endpoints; CLI accepts repeated `--netflow-listen` flags or comma-delimited values. | 0.0.0.0:2055, 0.0.0.0:6343 | no |
 | protocols.sflow | Enable sFlow decoding. | yes | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
 | journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention. | 10GB | no |
@@ -112,12 +112,12 @@ sudo ./edit-config netflow.yaml
 
 ###### sFlow collection
 
-Listen for sFlow v5 datagrams on Netdata's default flow listener port.
+Listen for sFlow v5 datagrams on the standard sFlow port.
 
 ```yaml
 enabled: true
 listener:
-  listen: "0.0.0.0:2055"
+  listen: "0.0.0.0:6343"
 protocols:
   v5: false
   v7: false
@@ -131,10 +131,14 @@ protocols:
 ### Verifying sFlow is arriving and diagnosing failures
 
 See [Troubleshooting](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/troubleshooting) for
-the full diagnostic recipe. sFlow-specific gotchas: counter samples are not surfaced
-(only flow samples), bytes/packets are statistical estimates that won't match SNMP
-byte-for-byte, and VLAN information comes from `ExtendedSwitch` records only -- not
-from 802.1Q tags inside the sampled header. See also
+the full diagnostic recipe. sFlow-specific gotchas: Netdata creates Network Flow rows
+from sFlow flow samples (`flow_sample` / `expanded_flow_sample`) only. Counter-only
+streams (`counters_sample` / `expanded_counters_sample`) are valid sFlow and increment
+sFlow packet counters, but they do not contain endpoint-level source/destination flow
+records for the Flow Explorer, Sankey, time-series, or maps. Bytes/packets are
+statistical estimates that won't match SNMP byte-for-byte, and VLAN information comes
+from `ExtendedSwitch` records only -- not from 802.1Q tags inside the sampled header.
+See also
 [Validation and Data Quality](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/validation-and-data-quality)
 and the sFlow section of [Anti-patterns](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/anti-patterns).
 

--- a/src/crates/netflow-plugin/metadata.yaml
+++ b/src/crates/netflow-plugin/metadata.yaml
@@ -38,7 +38,7 @@ modules:
           For full documentation including vendor configuration examples, sampling caveats, template
           handling and verification steps, see the [Network Flows Overview](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/).
         method_description: |
-          The plugin listens on a configurable UDP socket for NetFlow datagrams.
+          The plugin listens on configurable UDP listener sockets for NetFlow datagrams.
           NetFlow v5 and v7 records are decoded directly. NetFlow v9 records are decoded using
           dynamic templates cached from the exporter. Decoded records are enriched in-memory
           and appended to disk-backed journal tiers (raw, 1-minute, 5-minute, 1-hour rollups).
@@ -50,7 +50,7 @@ modules:
         description: ""
       default_behavior:
         auto_detection:
-          description: "The plugin starts when enabled in netflow.yaml and listens on the configured UDP port."
+          description: "The stock configuration enables the plugin and listens on the configured UDP ports."
         limits:
           description: "Operational limits are driven by sustained flow records/s, exporter batching, cardinality, retention, storage speed, and enrichment. On modern hardware with fast storage, plan around 50k-100k sustained flow records/s per well-provisioned agent for the full raw + rollup pipeline, provided the underlying disks can sustain the required journal write activity; use distributed agents for larger deployments."
         performance_impact:
@@ -73,8 +73,8 @@ modules:
             enabled: true
           list:
             - name: listener.listen
-              description: UDP endpoint for NetFlow datagrams.
-              default_value: "0.0.0.0:2055"
+              description: UDP listener endpoints for NetFlow/IPFIX and sFlow datagrams. YAML accepts either a scalar endpoint or a list of endpoints; CLI accepts repeated `--netflow-listen` flags or comma-delimited values.
+              default_value: "0.0.0.0:2055, 0.0.0.0:6343"
               required: false
             - name: protocols.v5
               description: Enable NetFlow v5 decoding.
@@ -108,11 +108,13 @@ modules:
             - name: Basic NetFlow v5/v9 collection
               folding:
                 enabled: false
-              description: Listen on Netdata's default flow listener port for v5 and v9 records.
+              description: Use Netdata's stock listener set for v5 and v9 records.
               config: |
                 enabled: true
                 listener:
-                  listen: "0.0.0.0:2055"
+                  listen:
+                    - "0.0.0.0:2055"
+                    - "0.0.0.0:6343"
                 protocols:
                   v5: true
                   v9: true
@@ -198,7 +200,7 @@ modules:
           ASA NSEL), biflow handling, sampling caveats, and verification steps, see the
           [Network Flows Overview](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/).
         method_description: |
-          The plugin listens on the same UDP socket as NetFlow. IPFIX messages are identified by
+          The plugin uses the same configurable UDP listener set as NetFlow. IPFIX messages are identified by
           version number 10 and decoded using cached templates. Decoded records are enriched and
           appended to disk-backed journal tiers.
       supported_platforms:
@@ -209,7 +211,7 @@ modules:
         description: ""
       default_behavior:
         auto_detection:
-          description: "The plugin starts when enabled in netflow.yaml and listens on the configured UDP port."
+          description: "The stock configuration enables the plugin and listens on the configured UDP ports."
         limits:
           description: "Operational limits are driven by sustained flow records/s, exporter batching, template churn, cardinality, retention, storage speed, and enrichment. On modern hardware with fast storage, plan around 50k-100k sustained flow records/s per well-provisioned agent for the full raw + rollup pipeline, provided the underlying disks can sustain the required journal write activity; use distributed agents for larger deployments."
         performance_impact:
@@ -233,8 +235,8 @@ modules:
             enabled: true
           list:
             - name: listener.listen
-              description: UDP endpoint for IPFIX datagrams.
-              default_value: "0.0.0.0:2055"
+              description: UDP listener endpoints for NetFlow/IPFIX and sFlow datagrams. YAML accepts either a scalar endpoint or a list of endpoints; CLI accepts repeated `--netflow-listen` flags or comma-delimited values.
+              default_value: "0.0.0.0:2055, 0.0.0.0:6343"
               required: false
             - name: protocols.ipfix
               description: Enable IPFIX decoding.
@@ -260,7 +262,7 @@ modules:
             - name: IPFIX collection
               folding:
                 enabled: false
-              description: Listen for IPFIX records on Netdata's default flow listener port.
+              description: Listen for IPFIX records on the common NetFlow/IPFIX port.
               config: |
                 enabled: true
                 listener:
@@ -334,7 +336,7 @@ modules:
           Ruckus, hsflowd), and the limits of sampled data, see the
           [Network Flows Overview](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/).
         method_description: |
-          The plugin listens on the same UDP socket as NetFlow. sFlow datagrams are identified by
+          The plugin uses the same configurable UDP listener set as NetFlow/IPFIX. sFlow datagrams are identified by
           their distinct header format and decoded per the sFlow v5 specification. Decoded records
           are enriched and appended to disk-backed journal tiers.
       supported_platforms:
@@ -345,7 +347,7 @@ modules:
         description: ""
       default_behavior:
         auto_detection:
-          description: "The plugin starts when enabled in netflow.yaml and listens on the configured UDP port."
+          description: "The stock configuration enables the plugin and listens on the configured UDP ports."
         limits:
           description: "Operational limits are driven by sustained samples/s, sampling rate, cardinality, retention, storage speed, and enrichment. Plan capacity from the received sample rate and the expanded byte/packet estimates."
         performance_impact:
@@ -369,8 +371,8 @@ modules:
             enabled: true
           list:
             - name: listener.listen
-              description: UDP endpoint for sFlow datagrams.
-              default_value: "0.0.0.0:2055"
+              description: UDP listener endpoints for NetFlow/IPFIX and sFlow datagrams. YAML accepts either a scalar endpoint or a list of endpoints; CLI accepts repeated `--netflow-listen` flags or comma-delimited values.
+              default_value: "0.0.0.0:2055, 0.0.0.0:6343"
               required: false
             - name: protocols.sflow
               description: Enable sFlow decoding.
@@ -396,11 +398,11 @@ modules:
             - name: sFlow collection
               folding:
                 enabled: false
-              description: Listen for sFlow v5 datagrams on Netdata's default flow listener port.
+              description: Listen for sFlow v5 datagrams on the standard sFlow port.
               config: |
                 enabled: true
                 listener:
-                  listen: "0.0.0.0:2055"
+                  listen: "0.0.0.0:6343"
                 protocols:
                   v5: false
                   v7: false
@@ -413,10 +415,14 @@ modules:
           - name: Verifying sFlow is arriving and diagnosing failures
             description: |
               See [Troubleshooting](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/troubleshooting) for
-              the full diagnostic recipe. sFlow-specific gotchas: counter samples are not surfaced
-              (only flow samples), bytes/packets are statistical estimates that won't match SNMP
-              byte-for-byte, and VLAN information comes from `ExtendedSwitch` records only -- not
-              from 802.1Q tags inside the sampled header. See also
+              the full diagnostic recipe. sFlow-specific gotchas: Netdata creates Network Flow rows
+              from sFlow flow samples (`flow_sample` / `expanded_flow_sample`) only. Counter-only
+              streams (`counters_sample` / `expanded_counters_sample`) are valid sFlow and increment
+              sFlow packet counters, but they do not contain endpoint-level source/destination flow
+              records for the Flow Explorer, Sankey, time-series, or maps. Bytes/packets are
+              statistical estimates that won't match SNMP byte-for-byte, and VLAN information comes
+              from `ExtendedSwitch` records only -- not from 802.1Q tags inside the sampled header.
+              See also
               [Validation and Data Quality](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/validation-and-data-quality)
               and the sFlow section of [Anti-patterns](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/anti-patterns).
     alerts: []

--- a/src/crates/netflow-plugin/metadata.yaml
+++ b/src/crates/netflow-plugin/metadata.yaml
@@ -97,8 +97,8 @@ modules:
               default_value: "10GB"
               required: false
             - name: journal.tiers.&lt;tier&gt;.duration_of_journal_files
-              description: Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for size-only retention.
-              default_value: "7d"
+              description: Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap.
+              default_value: "null"
               required: false
         examples:
           folding:
@@ -251,8 +251,8 @@ modules:
               default_value: "10GB"
               required: false
             - name: journal.tiers.&lt;tier&gt;.duration_of_journal_files
-              description: Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for size-only retention.
-              default_value: "7d"
+              description: Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap.
+              default_value: "null"
               required: false
         examples:
           folding:
@@ -387,8 +387,8 @@ modules:
               default_value: "10GB"
               required: false
             - name: journal.tiers.&lt;tier&gt;.duration_of_journal_files
-              description: Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for size-only retention.
-              default_value: "7d"
+              description: Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap.
+              default_value: "null"
               required: false
         examples:
           folding:

--- a/src/crates/netflow-plugin/src/ingest/metrics.rs
+++ b/src/crates/netflow-plugin/src/ingest/metrics.rs
@@ -240,12 +240,14 @@ impl IngestMetrics {
     pub(super) fn increment_materialized_tier(&self, tier: TierKind, logical_bytes: u64) {
         match tier {
             TierKind::Minute1 => {
-                self.minute_1_entries_written.fetch_add(1, Ordering::Relaxed);
+                self.minute_1_entries_written
+                    .fetch_add(1, Ordering::Relaxed);
                 self.minute_1_logical_bytes
                     .fetch_add(logical_bytes, Ordering::Relaxed);
             }
             TierKind::Minute5 => {
-                self.minute_5_entries_written.fetch_add(1, Ordering::Relaxed);
+                self.minute_5_entries_written
+                    .fetch_add(1, Ordering::Relaxed);
                 self.minute_5_logical_bytes
                     .fetch_add(logical_bytes, Ordering::Relaxed);
             }

--- a/src/crates/netflow-plugin/src/ingest/rebuild.rs
+++ b/src/crates/netflow-plugin/src/ingest/rebuild.rs
@@ -49,9 +49,8 @@ impl IngestService {
                             if let Some(value) =
                                 payload.strip_prefix(b"_SOURCE_REALTIME_TIMESTAMP=")
                             {
-                                source_ts = std::str::from_utf8(value)
-                                    .ok()
-                                    .and_then(|v| v.parse().ok());
+                                source_ts =
+                                    std::str::from_utf8(value).ok().and_then(|v| v.parse().ok());
                             }
                             Ok(())
                         },

--- a/src/crates/netflow-plugin/src/ingest/service/runtime.rs
+++ b/src/crates/netflow-plugin/src/ingest/service/runtime.rs
@@ -1,12 +1,38 @@
 use super::super::*;
 use super::IngestService;
+use std::future::poll_fn;
+use std::task::Poll;
+use tokio::io::ReadBuf;
+
+async fn recv_from_any_listener(
+    sockets: &[UdpSocket],
+    start_index: usize,
+    buffer: &mut [u8],
+) -> std::io::Result<(usize, usize, std::net::SocketAddr)> {
+    poll_fn(|cx| {
+        for offset in 0..sockets.len() {
+            let socket_index = (start_index + offset) % sockets.len();
+            let mut read_buf = ReadBuf::new(buffer);
+            match sockets[socket_index].poll_recv_from(cx, &mut read_buf) {
+                Poll::Ready(Ok(source)) => {
+                    return Poll::Ready(Ok((socket_index, read_buf.filled().len(), source)));
+                }
+                Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                Poll::Pending => {}
+            }
+        }
+        Poll::Pending
+    })
+    .await
+}
 
 impl IngestService {
     pub(crate) async fn run(mut self, shutdown: CancellationToken) -> Result<()> {
         self.rebuild_materialized_from_raw().await?;
 
-        let socket = self.bind_listener_and_start_workers().await?;
+        let sockets = self.bind_listeners_and_start_workers().await?;
         let mut buffer = vec![0_u8; self.cfg.listener.max_packet_size];
+        let mut next_socket_index = 0_usize;
         let mut entries_since_sync = 0_usize;
         let mut sync_tick = tokio::time::interval(self.cfg.listener.sync_interval);
         sync_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -19,14 +45,15 @@ impl IngestService {
                 _ = sync_tick.tick() => {
                     entries_since_sync = self.handle_sync_tick(entries_since_sync);
                 }
-                recv = socket.recv_from(&mut buffer) => {
-                    let (received, source) = match recv {
+                recv = recv_from_any_listener(&sockets, next_socket_index, &mut buffer) => {
+                    let (socket_index, received, source) = match recv {
                         Ok(result) => result,
                         Err(err) => {
                             tracing::warn!("udp recv error: {}", err);
                             continue;
                         }
                     };
+                    next_socket_index = (socket_index + 1) % sockets.len();
 
                     entries_since_sync = self.handle_received_packet(
                         source,
@@ -41,14 +68,22 @@ impl IngestService {
         Ok(())
     }
 
-    async fn bind_listener_and_start_workers(&mut self) -> Result<UdpSocket> {
-        let listen = self.cfg.listener.listen.clone();
-        let socket = UdpSocket::bind(&listen)
-            .await
-            .with_context(|| format!("failed to bind {}", listen))?;
-        Self::expand_receive_buffer(&socket, &listen);
+    async fn bind_listeners_and_start_workers(&mut self) -> Result<Vec<UdpSocket>> {
+        let listens = self.cfg.listener.listen.clone();
+        if listens.is_empty() {
+            anyhow::bail!("listener.listen must contain at least one address");
+        }
+
+        let mut sockets = Vec::with_capacity(listens.len());
+        for listen in listens {
+            let socket = UdpSocket::bind(&listen)
+                .await
+                .with_context(|| format!("failed to bind {}", listen))?;
+            Self::expand_receive_buffer(&socket, &listen);
+            sockets.push(socket);
+        }
         self.spawn_tier_commit_workers();
-        Ok(socket)
+        Ok(sockets)
     }
 
     fn handle_sync_tick(&mut self, entries_since_sync: usize) -> usize {
@@ -431,8 +466,8 @@ impl IngestService {
     }
 
     #[cfg(test)]
-    pub(crate) async fn bind_listener_and_start_workers_for_test(&mut self) -> Result<()> {
-        let _socket = self.bind_listener_and_start_workers().await?;
+    pub(crate) async fn bind_listeners_and_start_workers_for_test(&mut self) -> Result<()> {
+        let _sockets = self.bind_listeners_and_start_workers().await?;
         Ok(())
     }
 

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -530,7 +530,7 @@ async fn e2e_ingest_bind_failure_does_not_start_tier_workers() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn e2e_ingest_partial_bind_failure_does_not_start_tier_workers() {
     let (mut cfg, _tmp) = offline_journal_cfg();
-    let free = reserve_udp_listen_addr();
+    let free = "127.0.0.1:0".to_string();
     let occupied = StdUdpSocket::bind("127.0.0.1:0").expect("bind occupied test socket");
     let occupied_addr = occupied
         .local_addr()

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -131,6 +131,115 @@ async fn e2e_ingest_persists_enriched_fields_and_query_reads_them() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_sflow_fixture_persists_expected_raw_journal_fields_and_query_reads_them() {
+    let (cfg, metrics, _open_tiers, _tier_flow_indexes, _tmp) =
+        ingest_fixture("data-1140.pcap").await;
+
+    assert!(
+        metrics.sflow_datagrams.load(Ordering::Relaxed) > 0,
+        "expected data-1140.pcap to decode as sFlow"
+    );
+
+    let rows = raw_journal_rows(&cfg.journal.raw_tier_dir());
+    let sflow_rows = rows
+        .iter()
+        .filter(|row| row.get("FLOW_VERSION").map(String::as_str) == Some("sflow"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        sflow_rows.len(),
+        5,
+        "expected one persisted raw journal row per decoded sFlow sample"
+    );
+
+    let primary = find_raw_row(
+        &sflow_rows,
+        &[
+            ("SRC_ADDR", "2a0c:8880:2:0:185:21:130:38"),
+            ("DST_ADDR", "2a0c:8880:2:0:185:21:130:39"),
+            ("SRC_PORT", "46026"),
+            ("DST_PORT", "22"),
+        ],
+    );
+    assert_raw_fields(
+        primary,
+        &[
+            ("FLOW_VERSION", "sflow"),
+            ("EXPORTER_IP", "172.16.0.3"),
+            ("SAMPLING_RATE", "1024"),
+            ("IN_IF", "27"),
+            ("OUT_IF", "28"),
+            ("SRC_VLAN", "100"),
+            ("DST_VLAN", "100"),
+            ("PROTOCOL", "6"),
+            ("BYTES", "1536000"),
+            ("PACKETS", "1024"),
+            ("RAW_BYTES", "1500"),
+            ("RAW_PACKETS", "1"),
+        ],
+    );
+
+    let routed = find_raw_row(
+        &sflow_rows,
+        &[
+            ("SRC_ADDR", "45.90.161.148"),
+            ("DST_ADDR", "191.87.91.27"),
+            ("SRC_PORT", "55658"),
+            ("DST_PORT", "5555"),
+        ],
+    );
+    assert_raw_fields(
+        routed,
+        &[
+            ("FLOW_VERSION", "sflow"),
+            ("SAMPLING_RATE", "1024"),
+            ("NEXT_HOP", "31.14.69.110"),
+            ("SRC_AS", "39421"),
+            ("DST_AS", "26615"),
+            ("DST_AS_PATH", "203698,6762,26615"),
+            ("BYTES", "40960"),
+            ("PACKETS", "1024"),
+            ("RAW_BYTES", "40"),
+            ("RAW_PACKETS", "1"),
+        ],
+    );
+
+    let (query_service, _notify_rx) = query::FlowQueryService::new(&cfg)
+        .await
+        .expect("create query service");
+    let before = Utc::now().timestamp().max(1).saturating_add(3600);
+    let output = query_service
+        .query_flows(&query::FlowsRequest {
+            view: query::ViewMode::TableSankey,
+            after: Some(1),
+            before: Some(before),
+            selections: HashMap::from([("FLOW_VERSION".to_string(), vec!["sflow".to_string()])]),
+            group_by: vec![
+                "SRC_ADDR".to_string(),
+                "DST_ADDR".to_string(),
+                "PROTOCOL".to_string(),
+            ],
+            top_n: query::TopN::N100,
+            ..Default::default()
+        })
+        .await
+        .expect("query selected sFlow rows");
+
+    assert_eq!(
+        output.stats.get("query_matched_entries").copied(),
+        Some(5),
+        "expected query to match every persisted sFlow raw row"
+    );
+    assert!(
+        !output.flows.is_empty(),
+        "expected selected FLOW_VERSION=sflow query to return rows"
+    );
+    assert!(
+        output.metrics.get("bytes").copied().unwrap_or(0) > 0,
+        "expected selected FLOW_VERSION=sflow query to aggregate bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn e2e_timestamp_source_first_switched_is_persisted_as_source_timestamp() {
     let (cfg, _metrics, open_tiers, _tier_flow_indexes, _tmp) =
         ingest_fixture_with_timestamp_source(
@@ -386,10 +495,12 @@ async fn e2e_rebuild_tolerates_torn_tier_and_raw_tails() {
 async fn e2e_ingest_bind_failure_does_not_start_tier_workers() {
     let (mut cfg, _tmp) = offline_journal_cfg();
     let occupied = StdUdpSocket::bind("127.0.0.1:0").expect("bind occupied test socket");
-    cfg.listener.listen = occupied
-        .local_addr()
-        .expect("read occupied socket address")
-        .to_string();
+    cfg.listener.listen = vec![
+        occupied
+            .local_addr()
+            .expect("read occupied socket address")
+            .to_string(),
+    ];
 
     let metrics = Arc::new(ingest::IngestMetrics::default());
     let open_tiers = Arc::new(RwLock::new(tiering::OpenTierState::default()));
@@ -403,7 +514,7 @@ async fn e2e_ingest_bind_failure_does_not_start_tier_workers() {
     .expect("create ingest service");
 
     let err = service
-        .bind_listener_and_start_workers_for_test()
+        .bind_listeners_and_start_workers_for_test()
         .await
         .expect_err("occupied UDP address must fail bind");
     assert!(
@@ -413,6 +524,95 @@ async fn e2e_ingest_bind_failure_does_not_start_tier_workers() {
     assert!(
         !service.tier_commit_workers_started_for_test(),
         "tier workers must not start when listener bind fails"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_ingest_partial_bind_failure_does_not_start_tier_workers() {
+    let (mut cfg, _tmp) = offline_journal_cfg();
+    let free = reserve_udp_listen_addr();
+    let occupied = StdUdpSocket::bind("127.0.0.1:0").expect("bind occupied test socket");
+    let occupied_addr = occupied
+        .local_addr()
+        .expect("read occupied socket address")
+        .to_string();
+    cfg.listener.listen = vec![free, occupied_addr.clone()];
+
+    let metrics = Arc::new(ingest::IngestMetrics::default());
+    let open_tiers = Arc::new(RwLock::new(tiering::OpenTierState::default()));
+    let tier_flow_indexes = Arc::new(RwLock::new(tiering::TierFlowIndexStore::default()));
+    let mut service = ingest::IngestService::new(
+        cfg,
+        Arc::clone(&metrics),
+        Arc::clone(&open_tiers),
+        Arc::clone(&tier_flow_indexes),
+    )
+    .expect("create ingest service");
+
+    let err = service
+        .bind_listeners_and_start_workers_for_test()
+        .await
+        .expect_err("occupied UDP address must fail bind");
+    assert!(
+        err.to_string()
+            .contains(&format!("failed to bind {occupied_addr}")),
+        "bind error should identify the failed listener: {err:#}"
+    );
+    assert!(
+        !service.tier_commit_workers_started_for_test(),
+        "tier workers must not start when any listener bind fails"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_ingest_receives_from_multiple_listeners() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let listen_a = reserve_udp_listen_addr();
+    let listen_b = reserve_udp_listen_addr();
+    assert_ne!(
+        listen_a, listen_b,
+        "test listeners must use different ports"
+    );
+
+    let mut cfg = plugin_config::PluginConfig::default();
+    cfg.journal.journal_dir = tmp.path().join("flows").to_string_lossy().to_string();
+    cfg.listener.listen = vec![listen_a.clone(), listen_b.clone()];
+    cfg.listener.sync_interval = Duration::from_millis(50);
+    cfg.listener.sync_every_entries = 1;
+
+    let metrics = Arc::new(ingest::IngestMetrics::default());
+    let open_tiers = Arc::new(RwLock::new(tiering::OpenTierState::default()));
+    let tier_flow_indexes = Arc::new(RwLock::new(tiering::TierFlowIndexStore::default()));
+    let service = ingest::IngestService::new(
+        cfg,
+        Arc::clone(&metrics),
+        Arc::clone(&open_tiers),
+        Arc::clone(&tier_flow_indexes),
+    )
+    .expect("create ingest service");
+
+    let shutdown = CancellationToken::new();
+    let run_shutdown = shutdown.clone();
+    let ingest_task = tokio::spawn(async move { service.run(run_shutdown).await });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let payloads = fixture_udp_payloads("nfv5.pcap");
+    let expected_packets = (payloads.len() * 2) as u64;
+    replay_payloads_udp(&listen_a, &payloads).await;
+    replay_payloads_udp(&listen_b, &payloads).await;
+
+    wait_for_udp_packets(&metrics, expected_packets).await;
+    wait_for_ingest_progress(&metrics).await;
+    shutdown.cancel();
+
+    ingest_task
+        .await
+        .expect("join ingestion task")
+        .expect("ingestion run");
+
+    assert!(
+        metrics.journal_entries_written.load(Ordering::Relaxed) > 0,
+        "expected raw journal entries from multi-listener ingest"
     );
 }
 
@@ -2368,7 +2568,7 @@ async fn ingest_fixture_with_config(
     let listen = reserve_udp_listen_addr();
     let mut cfg = plugin_config::PluginConfig::default();
     cfg.journal.journal_dir = tmp.path().join("flows").to_string_lossy().to_string();
-    cfg.listener.listen = listen.clone();
+    cfg.listener.listen = vec![listen.clone()];
     cfg.listener.sync_interval = Duration::from_millis(50);
     cfg.listener.sync_every_entries = 1;
     cfg.protocols.timestamp_source = timestamp_source;
@@ -2425,16 +2625,32 @@ async fn wait_for_ingest_progress(metrics: &Arc<ingest::IngestMetrics>) {
     .expect("ingest did not write raw entries in time");
 }
 
+async fn wait_for_udp_packets(metrics: &Arc<ingest::IngestMetrics>, expected_packets: u64) {
+    tokio::time::timeout(E2E_INGEST_WAIT_TIMEOUT, async {
+        loop {
+            if metrics.udp_packets_received.load(Ordering::Relaxed) >= expected_packets {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("ingest did not receive expected UDP packets in time");
+}
+
 async fn replay_fixture_udp(listen: &str, fixture_name: &str) {
-    let sender = UdpSocket::bind("127.0.0.1:0")
-        .await
-        .expect("bind udp sender");
     let payloads = fixture_udp_payloads(fixture_name);
     assert!(
         !payloads.is_empty(),
         "fixture {fixture_name} should contain udp payloads"
     );
+    replay_payloads_udp(listen, &payloads).await;
+}
 
+async fn replay_payloads_udp(listen: &str, payloads: &[Vec<u8>]) {
+    let sender = UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("bind udp sender");
     for payload in payloads {
         sender
             .send_to(&payload, listen)
@@ -2554,7 +2770,7 @@ async fn bench_udp_loss_ceiling() {
 
     let mut cfg = plugin_config::PluginConfig::default();
     cfg.journal.journal_dir = tmp.path().join("flows").to_string_lossy().to_string();
-    cfg.listener.listen = listen.clone();
+    cfg.listener.listen = vec![listen.clone()];
     // Production-realistic sync behavior is the default (periodic fsync
     // disabled; files sync on rotation and shutdown). Do NOT force per-entry
     // sync, which would not reflect the real ceiling.
@@ -2716,7 +2932,7 @@ async fn bench_udp_boundary_soak() {
 
     let mut cfg = plugin_config::PluginConfig::default();
     cfg.journal.journal_dir = tmp.path().join("flows").to_string_lossy().to_string();
-    cfg.listener.listen = listen.clone();
+    cfg.listener.listen = vec![listen.clone()];
 
     let metrics = Arc::new(ingest::IngestMetrics::default());
     let open_tiers = Arc::new(RwLock::new(tiering::OpenTierState::default()));
@@ -3057,6 +3273,19 @@ fn assert_tier_dir_exists(path: &Path, tier_name: &str) {
 }
 
 fn first_raw_journal_fields(path: &Path) -> HashMap<String, String> {
+    raw_journal_rows(path)
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| {
+            panic!(
+                "expected at least one raw journal entry in {}",
+                path.display()
+            )
+        })
+}
+
+fn raw_journal_rows(path: &Path) -> Vec<HashMap<String, String>> {
+    let mut rows = Vec::new();
     for file_path in journal_files(path) {
         let repo_file =
             RepoFile::from_path(&file_path).expect("parse raw journal repository metadata");
@@ -3064,41 +3293,64 @@ fn first_raw_journal_fields(path: &Path) -> HashMap<String, String> {
             JournalFile::<Mmap>::open(&repo_file, 8 * 1024 * 1024).expect("open raw journal file");
         let mut reader = JournalReader::default();
         reader.set_location(Location::Head);
-        if !reader
-            .step(&journal, Direction::Forward)
-            .expect("step raw journal reader")
-        {
-            continue;
-        }
-
-        let mut data_offsets = Vec::<NonZeroU64>::new();
-        reader
-            .entry_data_offsets(&journal, &mut data_offsets)
-            .expect("enumerate raw journal data offsets");
-        let mut fields = HashMap::new();
         let mut decompress_buf = Vec::new();
-        query::visit_journal_payloads(
-            &journal,
-            &file_path,
-            &data_offsets,
-            &mut decompress_buf,
-            |payload| {
-                if let Some(eq_pos) = payload.iter().position(|&b| b == b'=') {
-                    let key = String::from_utf8_lossy(&payload[..eq_pos]).into_owned();
-                    let value = String::from_utf8_lossy(&payload[eq_pos + 1..]).into_owned();
-                    fields.insert(key, value);
-                }
-                Ok(())
-            },
-        )
-        .expect("read raw journal payloads");
-        return fields;
+        loop {
+            if !reader
+                .step(&journal, Direction::Forward)
+                .expect("step raw journal reader")
+            {
+                break;
+            }
+
+            let mut data_offsets = Vec::<NonZeroU64>::new();
+            reader
+                .entry_data_offsets(&journal, &mut data_offsets)
+                .expect("enumerate raw journal data offsets");
+            let mut fields = HashMap::new();
+            query::visit_journal_payloads(
+                &journal,
+                &file_path,
+                &data_offsets,
+                &mut decompress_buf,
+                |payload| {
+                    if let Some(eq_pos) = payload.iter().position(|&b| b == b'=') {
+                        let key = String::from_utf8_lossy(&payload[..eq_pos]).into_owned();
+                        let value = String::from_utf8_lossy(&payload[eq_pos + 1..]).into_owned();
+                        fields.insert(key, value);
+                    }
+                    Ok(())
+                },
+            )
+            .expect("read raw journal payloads");
+            rows.push(fields);
+        }
     }
 
-    panic!(
-        "expected at least one raw journal entry in {}",
-        path.display()
-    );
+    rows
+}
+
+fn find_raw_row<'a>(
+    rows: &'a [&HashMap<String, String>],
+    predicates: &[(&str, &str)],
+) -> &'a HashMap<String, String> {
+    rows.iter()
+        .copied()
+        .find(|row| {
+            predicates
+                .iter()
+                .all(|(key, value)| row.get(*key).map(String::as_str) == Some(*value))
+        })
+        .unwrap_or_else(|| panic!("raw journal row not found for predicates {predicates:?}"))
+}
+
+fn assert_raw_fields(row: &HashMap<String, String>, expectations: &[(&str, &str)]) {
+    for (key, expected) in expectations {
+        assert_eq!(
+            row.get(*key).map(String::as_str),
+            Some(*expected),
+            "raw journal field mismatch for {key}"
+        );
+    }
 }
 
 fn first_journal_realtime_usec(path: &Path) -> u64 {

--- a/src/crates/netflow-plugin/src/memory_tests.rs
+++ b/src/crates/netflow-plugin/src/memory_tests.rs
@@ -238,7 +238,7 @@ fn start_ingest_fixture() -> anyhow::Result<(
     let tmp = tempfile::tempdir()?;
     let mut cfg = plugin_config::PluginConfig::default();
     cfg.journal.journal_dir = tmp.path().join("flows").to_string_lossy().to_string();
-    cfg.listener.listen = "127.0.0.1:0".to_string();
+    cfg.listener.listen = vec!["127.0.0.1:0".to_string()];
     cfg.listener.sync_interval = Duration::from_millis(50);
     cfg.listener.sync_every_entries = 256;
     let small_tier = plugin_config::JournalTierRetentionConfig {

--- a/src/crates/netflow-plugin/src/plugin_config/defaults.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/defaults.rs
@@ -107,16 +107,12 @@ pub(super) fn default_retention_size_of_journal_files() -> ByteSize {
     ByteSize::gb(10)
 }
 
-pub(super) fn default_retention_duration_of_journal_files() -> Duration {
-    Duration::from_secs(7 * 24 * 60 * 60)
-}
-
 pub(super) fn default_retention_size_of_journal_files_opt() -> Option<ByteSize> {
     Some(default_retention_size_of_journal_files())
 }
 
 pub(super) fn default_retention_duration_of_journal_files_opt() -> Option<Duration> {
-    Some(default_retention_duration_of_journal_files())
+    None
 }
 
 pub(super) fn default_rotation_duration_of_journal_file() -> Duration {

--- a/src/crates/netflow-plugin/src/plugin_config/defaults.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/defaults.rs
@@ -39,6 +39,10 @@ pub(super) fn default_true() -> bool {
     true
 }
 
+pub(super) fn default_netflow_listen() -> Vec<String> {
+    vec!["0.0.0.0:2055".to_string(), "0.0.0.0:6343".to_string()]
+}
+
 pub(super) fn default_dynamic_bmp_listen() -> String {
     "0.0.0.0:10179".to_string()
 }

--- a/src/crates/netflow-plugin/src/plugin_config/types/journal.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/types/journal.rs
@@ -63,8 +63,8 @@ pub(crate) struct JournalTierRetentionConfig {
     pub(crate) size_of_journal_files: Option<ByteSize>,
 
     /// Maximum age. Unset (`null`) disables the duration limit; the
-    /// tier is then bounded only by `size_of_journal_files`. Defaults
-    /// to the tier-default duration if the field is omitted.
+    /// tier is then bounded only by `size_of_journal_files`. Omitted
+    /// values use the built-in size-only default.
     #[serde(
         default = "default_retention_duration_of_journal_files_opt",
         deserialize_with = "deserialize_opt_duration",
@@ -75,10 +75,10 @@ pub(crate) struct JournalTierRetentionConfig {
 
 impl JournalTierRetentionConfig {
     pub(crate) fn for_tier(_tier: TierKind) -> Self {
-        // Tier-uniform defaults today (10GB, 7d). The shape is per-tier
-        // so each tier can be tuned independently in user config; the
-        // built-in defaults happen to be uniform across tiers but
-        // nothing in the schema enforces that.
+        // Tier-uniform defaults today (10GB, no age cap). The shape is
+        // per-tier so each tier can be tuned independently in user
+        // config; the built-in defaults happen to be uniform across
+        // tiers but nothing in the schema enforces that.
         Self {
             size_of_journal_files: default_retention_size_of_journal_files_opt(),
             duration_of_journal_files: default_retention_duration_of_journal_files_opt(),

--- a/src/crates/netflow-plugin/src/plugin_config/types/listener.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/types/listener.rs
@@ -6,7 +6,9 @@ pub(crate) struct ListenerConfig {
     #[arg(
         long = "netflow-listen",
         value_name = "ADDR",
-        default_values_t = default_netflow_listen()
+        default_values_t = default_netflow_listen(),
+        value_delimiter = ',',
+        value_parser = parse_listener_endpoint,
     )]
     #[serde(default = "default_netflow_listen")]
     #[serde(deserialize_with = "deserialize_listen")]
@@ -56,7 +58,20 @@ where
     }
 
     match ListenValue::deserialize(deserializer)? {
-        ListenValue::Scalar(value) => Ok(vec![value]),
-        ListenValue::List(values) => Ok(values),
+        ListenValue::Scalar(value) => parse_listener_endpoint(&value)
+            .map(|value| vec![value])
+            .map_err(serde::de::Error::custom),
+        ListenValue::List(values) => values
+            .into_iter()
+            .map(|value| parse_listener_endpoint(&value).map_err(serde::de::Error::custom))
+            .collect(),
     }
+}
+
+fn parse_listener_endpoint(value: &str) -> std::result::Result<String, String> {
+    let endpoint = value.trim();
+    if endpoint.is_empty() {
+        return Err("listener address must not be empty".to_string());
+    }
+    Ok(endpoint.to_string())
 }

--- a/src/crates/netflow-plugin/src/plugin_config/types/listener.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/types/listener.rs
@@ -3,8 +3,14 @@ use super::*;
 #[derive(Debug, Parser, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ListenerConfig {
-    #[arg(long = "netflow-listen", default_value = "0.0.0.0:2055")]
-    pub(crate) listen: String,
+    #[arg(
+        long = "netflow-listen",
+        value_name = "ADDR",
+        default_values_t = default_netflow_listen()
+    )]
+    #[serde(default = "default_netflow_listen")]
+    #[serde(deserialize_with = "deserialize_listen")]
+    pub(crate) listen: Vec<String>,
 
     #[arg(long = "netflow-max-packet-size", default_value_t = 9216)]
     pub(crate) max_packet_size: usize,
@@ -30,10 +36,27 @@ pub(crate) struct ListenerConfig {
 impl Default for ListenerConfig {
     fn default() -> Self {
         Self {
-            listen: "0.0.0.0:2055".to_string(),
+            listen: default_netflow_listen(),
             max_packet_size: 9216,
             sync_every_entries: 0,
             sync_interval: Duration::from_secs(1),
         }
+    }
+}
+
+fn deserialize_listen<'de, D>(deserializer: D) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ListenValue {
+        Scalar(String),
+        List(Vec<String>),
+    }
+
+    match ListenValue::deserialize(deserializer)? {
+        ListenValue::Scalar(value) => Ok(vec![value]),
+        ListenValue::List(values) => Ok(values),
     }
 }

--- a/src/crates/netflow-plugin/src/plugin_config/validation/listener.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/validation/listener.rs
@@ -1,5 +1,6 @@
 use crate::plugin_config::PluginConfig;
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 use std::net::SocketAddr;
 
 pub(super) fn validate_listener_and_protocols(cfg: &PluginConfig) -> Result<()> {
@@ -7,10 +8,19 @@ pub(super) fn validate_listener_and_protocols(cfg: &PluginConfig) -> Result<()> 
         anyhow::bail!("listener.max_packet_size must be greater than 0");
     }
 
-    cfg.listener
-        .listen
-        .parse::<SocketAddr>()
-        .with_context(|| format!("invalid listener address: {}", cfg.listener.listen))?;
+    if cfg.listener.listen.is_empty() {
+        anyhow::bail!("listener.listen must contain at least one address");
+    }
+
+    let mut seen = HashSet::new();
+    for listen in &cfg.listener.listen {
+        let addr = listen
+            .parse::<SocketAddr>()
+            .with_context(|| format!("invalid listener address: {}", listen))?;
+        if !seen.insert(addr) {
+            anyhow::bail!("listener.listen contains duplicate address: {}", addr);
+        }
+    }
 
     if !(cfg.protocols.v5
         || cfg.protocols.v7

--- a/src/crates/netflow-plugin/src/plugin_config_tests.rs
+++ b/src/crates/netflow-plugin/src/plugin_config_tests.rs
@@ -247,6 +247,99 @@ fn plugin_enabled_defaults_to_true() {
 }
 
 #[test]
+fn listener_defaults_include_netflow_and_sflow_ports() {
+    let expected = vec!["0.0.0.0:2055".to_string(), "0.0.0.0:6343".to_string()];
+
+    assert_eq!(PluginConfig::default().listener.listen, expected);
+    assert_eq!(
+        PluginConfig::try_parse_from(["netflow-plugin"])
+            .expect("default CLI config should parse")
+            .listener
+            .listen,
+        expected
+    );
+}
+
+#[test]
+fn listener_yaml_accepts_scalar_and_list_forms() {
+    let scalar: ListenerConfig = serde_yaml::from_str(
+        r#"
+listen: "127.0.0.1:2055"
+max_packet_size: 9216
+sync_every_entries: 0
+sync_interval: 1s
+"#,
+    )
+    .expect("scalar listener config should parse");
+    assert_eq!(scalar.listen, vec!["127.0.0.1:2055".to_string()]);
+
+    let list: ListenerConfig = serde_yaml::from_str(
+        r#"
+listen:
+  - "127.0.0.1:2055"
+  - "127.0.0.1:6343"
+max_packet_size: 9216
+sync_every_entries: 0
+sync_interval: 1s
+"#,
+    )
+    .expect("list listener config should parse");
+    assert_eq!(
+        list.listen,
+        vec!["127.0.0.1:2055".to_string(), "127.0.0.1:6343".to_string()]
+    );
+}
+
+#[test]
+fn listener_cli_accepts_repeated_listen_flags() {
+    let cfg = PluginConfig::try_parse_from([
+        "netflow-plugin",
+        "--netflow-listen",
+        "127.0.0.1:2055",
+        "--netflow-listen",
+        "127.0.0.1:6343",
+    ])
+    .expect("repeatable listener CLI should parse");
+
+    assert_eq!(
+        cfg.listener.listen,
+        vec!["127.0.0.1:2055".to_string(), "127.0.0.1:6343".to_string()]
+    );
+    cfg.validate()
+        .expect("repeatable listener CLI should validate");
+}
+
+#[test]
+fn validate_rejects_empty_duplicate_and_invalid_listeners() {
+    let mut empty = PluginConfig::default();
+    empty.listener.listen.clear();
+    let err = empty
+        .validate()
+        .expect_err("empty listener list should fail");
+    assert!(
+        err.to_string()
+            .contains("listener.listen must contain at least one address")
+    );
+
+    let mut duplicate = PluginConfig::default();
+    duplicate.listener.listen = vec!["127.0.0.1:2055".to_string(), "127.0.0.1:2055".to_string()];
+    let err = duplicate
+        .validate()
+        .expect_err("duplicate listener address should fail");
+    assert!(
+        err.to_string()
+            .contains("listener.listen contains duplicate address")
+    );
+
+    let mut invalid = PluginConfig::default();
+    invalid.listener.listen = vec!["not-a-socket".to_string()];
+    let err = invalid
+        .validate()
+        .expect_err("invalid listener address should fail");
+    assert!(err.to_string().contains("invalid listener address"));
+}
+
+#[test]
 fn memory_diagnostics_default_to_disabled_with_bounded_interval() {
     let cfg = PluginConfig::default();
 

--- a/src/crates/netflow-plugin/src/plugin_config_tests.rs
+++ b/src/crates/netflow-plugin/src/plugin_config_tests.rs
@@ -276,7 +276,7 @@ sync_interval: 1s
     let list: ListenerConfig = serde_yaml::from_str(
         r#"
 listen:
-  - "127.0.0.1:2055"
+  - " 127.0.0.1:2055 "
   - "127.0.0.1:6343"
 max_packet_size: 9216
 sync_every_entries: 0
@@ -307,6 +307,44 @@ fn listener_cli_accepts_repeated_listen_flags() {
     );
     cfg.validate()
         .expect("repeatable listener CLI should validate");
+}
+
+#[test]
+fn listener_cli_accepts_comma_delimited_listen_values() {
+    let cfg = PluginConfig::try_parse_from([
+        "netflow-plugin",
+        "--netflow-listen",
+        " 127.0.0.1:2055 , 127.0.0.1:6343 ",
+    ])
+    .expect("comma-delimited listener CLI should parse");
+
+    assert_eq!(
+        cfg.listener.listen,
+        vec!["127.0.0.1:2055".to_string(), "127.0.0.1:6343".to_string()]
+    );
+    cfg.validate()
+        .expect("comma-delimited listener CLI should validate");
+}
+
+#[test]
+fn listener_cli_single_override_replaces_default_list() {
+    let cfg =
+        PluginConfig::try_parse_from(["netflow-plugin", "--netflow-listen", "127.0.0.1:2055"])
+            .expect("single listener CLI override should parse");
+
+    assert_eq!(cfg.listener.listen, vec!["127.0.0.1:2055".to_string()]);
+}
+
+#[test]
+fn listener_cli_rejects_empty_comma_values() {
+    let err = PluginConfig::try_parse_from(["netflow-plugin", "--netflow-listen", " , "])
+        .expect_err("empty comma-delimited listener should fail");
+
+    assert!(
+        err.to_string()
+            .contains("listener address must not be empty"),
+        "unexpected CLI parse error: {err}"
+    );
 }
 
 #[test]

--- a/src/crates/netflow-plugin/src/plugin_config_tests.rs
+++ b/src/crates/netflow-plugin/src/plugin_config_tests.rs
@@ -523,10 +523,7 @@ fn journal_tier_retention_uses_built_in_tier_defaults() {
             retention.size_of_journal_files.unwrap().as_u64(),
             ByteSize::gb(10).as_u64()
         );
-        assert_eq!(
-            retention.duration_of_journal_files.unwrap(),
-            Duration::from_secs(7 * 24 * 60 * 60)
-        );
+        assert_eq!(retention.duration_of_journal_files, None);
     }
 }
 
@@ -554,10 +551,7 @@ fn journal_tier_retention_uses_per_tier_values_when_present() {
         minute_1.size_of_journal_files.unwrap().as_u64(),
         ByteSize::gb(10).as_u64()
     );
-    assert_eq!(
-        minute_1.duration_of_journal_files.unwrap(),
-        Duration::from_secs(7 * 24 * 60 * 60)
-    );
+    assert_eq!(minute_1.duration_of_journal_files, None);
 }
 
 #[test]
@@ -675,12 +669,9 @@ tiers:
         raw.duration_of_journal_files,
         Some(Duration::from_secs(24 * 60 * 60))
     );
-    // Other tiers still at the built-in 10GB / 7d defaults.
+    // Other tiers still at the built-in size-only defaults.
     assert_eq!(minute_1.size_of_journal_files, Some(ByteSize::gb(10)));
-    assert_eq!(
-        minute_1.duration_of_journal_files,
-        Some(Duration::from_secs(7 * 24 * 60 * 60))
-    );
+    assert_eq!(minute_1.duration_of_journal_files, None);
 }
 
 #[test]

--- a/src/crates/netflow-plugin/src/query/scan/direct.rs
+++ b/src/crates/netflow-plugin/src/query/scan/direct.rs
@@ -47,19 +47,19 @@ where
         // turn one damaged file into a startup (rebuild) or query outage.
         // Only caller-side errors (cancellation checkpoints, the on_entry
         // closure) abort the scan.
-        let journal = match JournalFile::<Mmap>::open(&registry_file, FACET_CACHE_JOURNAL_WINDOW_SIZE)
-        {
-            Ok(journal) => journal,
-            Err(err) => {
-                tracing::warn!(
-                    "skipping unreadable journal file {} during {}: {}",
-                    file_path.display(),
-                    purpose,
-                    err
-                );
-                continue;
-            }
-        };
+        let journal =
+            match JournalFile::<Mmap>::open(&registry_file, FACET_CACHE_JOURNAL_WINDOW_SIZE) {
+                Ok(journal) => journal,
+                Err(err) => {
+                    tracing::warn!(
+                        "skipping unreadable journal file {} during {}: {}",
+                        file_path.display(),
+                        purpose,
+                        err
+                    );
+                    continue;
+                }
+            };
 
         let mut reader = JournalReader::default();
         for pair in prefilter_matches {

--- a/src/crates/netflow-plugin/src/query/service.rs
+++ b/src/crates/netflow-plugin/src/query/service.rs
@@ -65,6 +65,9 @@ impl FlowQueryService {
     }
 
     pub(crate) fn process_notify_event(&self, event: Event) -> bool {
+        let Some(event) = journal_registry_event(event) else {
+            return false;
+        };
         let should_reconcile = event_requires_facet_reconcile(&event);
         if let Err(err) = self.registry.process_event(event) {
             tracing::warn!("failed to process netflow journal notify event: {}", err);
@@ -117,6 +120,10 @@ impl FlowQueryService {
 }
 
 fn event_requires_facet_reconcile(event: &Event) -> bool {
+    if !event.paths.iter().any(|path| is_journal_notify_path(path)) {
+        return false;
+    }
+
     matches!(
         event.kind,
         notify::EventKind::Create(_)
@@ -125,15 +132,170 @@ fn event_requires_facet_reconcile(event: &Event) -> bool {
     )
 }
 
+fn journal_registry_event(mut event: Event) -> Option<Event> {
+    match event.kind {
+        notify::EventKind::Create(_) | notify::EventKind::Remove(_) => {
+            event.paths.retain(|path| is_journal_notify_path(path));
+            (!event.paths.is_empty()).then_some(event)
+        }
+        notify::EventKind::Modify(notify::event::ModifyKind::Name(
+            notify::event::RenameMode::Both,
+        )) => event
+            .paths
+            .iter()
+            .all(|path| is_journal_notify_path(path))
+            .then_some(event),
+        notify::EventKind::Modify(notify::event::ModifyKind::Name(_)) => {
+            event.paths.retain(|path| is_journal_notify_path(path));
+            (!event.paths.is_empty()).then_some(event)
+        }
+        _ => None,
+    }
+}
+
+fn is_journal_notify_path(path: &Path) -> bool {
+    path.to_str()
+        .is_some_and(journal_registry::repository::File::is_journal_file)
+}
+
 fn scan_facet_contributions(
     files: &[FileInfo],
 ) -> Result<BTreeMap<String, crate::facet_runtime::FacetFileContribution>> {
     let mut contributions = BTreeMap::new();
     for file_info in files {
         let path = file_info.file.path().to_string();
-        let contribution = crate::facet_runtime::scan_registry_file_contribution(file_info)
-            .with_context(|| format!("failed to build facet contribution for {}", path))?;
+        let contribution = match crate::facet_runtime::scan_registry_file_contribution(file_info) {
+            Ok(contribution) => contribution,
+            Err(err) => {
+                if is_not_found_error(&err) {
+                    tracing::debug!(
+                        "skipping removed journal file {} during netflow facet contribution scan: {}",
+                        path,
+                        err
+                    );
+                } else {
+                    tracing::warn!(
+                        "skipping unreadable journal file {} during netflow facet contribution scan: {}",
+                        path,
+                        err
+                    );
+                }
+                continue;
+            }
+        };
         contributions.insert(path, contribution);
     }
     Ok(contributions)
+}
+
+fn is_not_found_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|err| err.kind() == std::io::ErrorKind::NotFound)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::{
+        Event,
+        event::{CreateKind, EventKind, ModifyKind, RemoveKind, RenameMode},
+    };
+
+    fn path(value: &str) -> PathBuf {
+        PathBuf::from(value)
+    }
+
+    fn create_event(paths: &[&str]) -> Event {
+        let mut event = Event::new(EventKind::Create(CreateKind::File));
+        event.paths = paths.iter().map(|value| path(value)).collect();
+        event
+    }
+
+    fn remove_event(paths: &[&str]) -> Event {
+        let mut event = Event::new(EventKind::Remove(RemoveKind::File));
+        event.paths = paths.iter().map(|value| path(value)).collect();
+        event
+    }
+
+    fn rename_both_event(paths: &[&str]) -> Event {
+        let mut event = Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)));
+        event.paths = paths.iter().map(|value| path(value)).collect();
+        event
+    }
+
+    fn file_info(path: &str) -> FileInfo {
+        FileInfo {
+            file: journal_registry::repository::File::from_path(Path::new(path))
+                .expect("valid journal path"),
+            time_range: journal_registry::TimeRange::Unknown,
+        }
+    }
+
+    #[test]
+    fn facet_sidecar_temp_events_do_not_reach_journal_registry() {
+        let sidecar_tmp =
+            "/var/cache/netdata/flows/raw/system@abc-123.journal.facet.FLOW_VERSION.fst.tmp";
+        let sidecar = "/var/cache/netdata/flows/raw/system@abc-123.journal.facet.FLOW_VERSION.fst";
+
+        assert!(journal_registry_event(create_event(&[sidecar_tmp])).is_none());
+        assert!(journal_registry_event(remove_event(&[sidecar_tmp])).is_none());
+        assert!(journal_registry_event(rename_both_event(&[sidecar_tmp, sidecar])).is_none());
+    }
+
+    #[test]
+    fn journal_lifecycle_events_still_reconcile_facets() {
+        let active = "/var/cache/netdata/flows/raw/system.journal";
+        let archived =
+            "/var/cache/netdata/flows/raw/system@abc-0000000000000001-0000000000000002.journal";
+
+        let create = journal_registry_event(create_event(&[active])).expect("journal create event");
+        assert_eq!(create.paths, vec![path(active)]);
+        assert!(event_requires_facet_reconcile(&create));
+
+        let remove =
+            journal_registry_event(remove_event(&[archived])).expect("journal remove event");
+        assert_eq!(remove.paths, vec![path(archived)]);
+        assert!(event_requires_facet_reconcile(&remove));
+
+        let rename = journal_registry_event(rename_both_event(&[active, archived]))
+            .expect("journal rename event");
+        assert_eq!(rename.paths, vec![path(active), path(archived)]);
+        assert!(event_requires_facet_reconcile(&rename));
+    }
+
+    #[test]
+    fn mixed_create_events_drop_non_journal_paths() {
+        let active = "/var/cache/netdata/flows/raw/system.journal";
+        let sidecar_tmp = "/var/cache/netdata/flows/raw/system.journal.facet.PROTOCOL.fst.tmp";
+
+        let event =
+            journal_registry_event(create_event(&[sidecar_tmp, active])).expect("journal event");
+        assert_eq!(event.paths, vec![path(active)]);
+        assert!(event_requires_facet_reconcile(&event));
+    }
+
+    #[test]
+    fn missing_journal_contribution_is_skipped() {
+        let missing = "/tmp/netflow-missing-facet-test/system.journal";
+
+        let contributions =
+            scan_facet_contributions(&[file_info(missing)]).expect("missing file is skipped");
+
+        assert!(contributions.is_empty());
+    }
+
+    #[test]
+    fn not_found_errors_are_classified_through_context_layers() {
+        let not_found = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::NotFound))
+            .context("outer context");
+        let permission_denied =
+            anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+                .context("outer context");
+
+        assert!(is_not_found_error(&not_found));
+        assert!(!is_not_found_error(&permission_denied));
+    }
 }

--- a/src/crates/netflow-plugin/src/startup_memory_tests.rs
+++ b/src/crates/netflow-plugin/src/startup_memory_tests.rs
@@ -277,8 +277,9 @@ fn profile_config(base_dir: &Path) -> plugin_config::PluginConfig {
     cfg.listener.listen = vec!["127.0.0.1:0".to_string()];
     cfg.listener.sync_every_entries = 1024;
     cfg.listener.sync_interval = std::time::Duration::from_secs(1);
-    // Per-tier defaults (10GB / 7d) already applied by JournalConfig::default;
-    // this call leaves them at the defaults, matching the original test intent.
+    // Per-tier defaults (10GB, no age cap) are already applied by
+    // JournalConfig::default; leave them unchanged to match the original
+    // test intent.
     cfg
 }
 

--- a/src/crates/netflow-plugin/src/startup_memory_tests.rs
+++ b/src/crates/netflow-plugin/src/startup_memory_tests.rs
@@ -274,7 +274,7 @@ async fn profile_live_startup_memory() -> anyhow::Result<StartupMemoryReport> {
 fn profile_config(base_dir: &Path) -> plugin_config::PluginConfig {
     let mut cfg = plugin_config::PluginConfig::default();
     cfg.journal.journal_dir = base_dir.to_string_lossy().to_string();
-    cfg.listener.listen = "127.0.0.1:0".to_string();
+    cfg.listener.listen = vec!["127.0.0.1:0".to_string()];
     cfg.listener.sync_every_entries = 1024;
     cfg.listener.sync_interval = std::time::Duration::from_secs(1);
     // Per-tier defaults (10GB / 7d) already applied by JournalConfig::default;


### PR DESCRIPTION
## Summary

- Filter NetFlow facet watcher file notifications so facet sidecar files are not passed to the journal registry as journal lifecycle events.
- Restore sFlow raw-journal/query E2E coverage and complete listener parser coverage for comma-delimited CLI values and whitespace-normalized YAML listener entries.
- Update Network Flows docs, metadata, and generated flow integration pages for the stock listener contract: NetFlow/IPFIX on UDP 2055 and sFlow on UDP 6343 with no user configuration required.
- Add operator guidance for counter-only sFlow streams: valid sFlow counter samples increment packet counters but do not contain endpoint-level flow records for Sankey, time-series, or maps.

## Root Cause

The facet watcher accepted all create/remove/rename notifications as journal lifecycle signals. Facet sidecar writes use temporary `.fst.tmp` files and renames, so those sidecar events were being sent to the generic journal registry and could trigger invalid-journal warnings or race with rotated journal files during facet reconciliation.

The listener behavior had also drifted from the intended multi-port/default-port contract in documentation and CLI coverage. Stock config already needs to expose both the common NetFlow/IPFIX port and the standard sFlow port, while docs and generated metadata still described a single 2055 listener in several places.

For the live sFlow symptom, packet evidence showed valid sFlow datagrams that carried counter samples only. Those are valid sFlow, but they do not contain source/destination flow records. The PR documents how to verify sample types and how to configure generators/exporters to emit flow samples.

## Validation

- `python3 integrations/gen_integrations.py`
- `python3 integrations/gen_docs_integrations.py`
- `ruby -e 'require "yaml"; YAML.load_file("src/crates/netflow-plugin/metadata.yaml"); puts "metadata yaml ok"'`
- `cargo test -p netflow-plugin listener -- --nocapture`
- `cargo test -p netflow-plugin plugin_config::tests -- --nocapture`
- `cargo test -p netflow-plugin --quiet`
- `git diff --check`

Final rebased validation: `cargo test -p netflow-plugin --quiet` passed with 569 passed, 0 failed, 26 ignored, plus the vendored proto check passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored out-of-the-box sFlow by opening UDP 2055 (NetFlow/IPFIX) and 6343 (sFlow) by default, aligned retention defaults to size-only (10GB per tier), and filtered facet sidecar events to prevent bogus journal lifecycle signals.

- New Features
  - Multi-socket UDP listening: bind all `listener.listen` endpoints; round-robin receive across sockets.
  - Config UX: YAML accepts scalar or list; CLI accepts repeated `--netflow-listen` or comma-delimited values; validation rejects empty/duplicate/invalid addresses.
  - sFlow restored: added raw-journal/query E2E coverage; docs explain counter-only sFlow streams and how to enable flow samples; integration pages updated to `2055`/`6343`.
  - Retention defaults aligned: per-tier default is `10GB` with no time limit; set `duration_of_journal_files` to add an age cap; docs, examples, and metadata updated.

- Bug Fixes
  - Facet watcher filtering: drop `.fst.tmp` and non-journal paths before journal registry processing; ignore transient NotFound during scans; add tests.
  - Safer startup/tests: do not start tier workers if any listener bind fails; clearer errors; tests for partial bind failure and multi-listener ingest; fixed UDP port race in NetFlow tests.

<sup>Written for commit cf53742f09a6950f52372ed87e65b71738d176a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

