### PR TITLE
Remove RHEL 7.x and Amazon Linux 2 from CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -92,49 +92,18 @@ include:
 
   - &amzn
     distro: amazonlinux
-    version: "2"
+    version: "2023"
     support_type: Core
     notes: ''
     eol_check: 'amazon-linux'
     bundle_sentry: *default_sentry
     packages: &amzn_packages
       type: rpm
-      repo_distro: amazonlinux/2
+      repo_distro: amazonlinux/2023
       builder_rev: *def_builder_rev
       arches:
         - x86_64
         - aarch64
-    test: &amzn_test
-      ebpf-core: false
-      skip-local-build: true
-  - <<: *amzn
-    version: "2023"
-    packages:
-      <<: *amzn_packages
-      repo_distro: amazonlinux/2023
-    test:
-      <<: *amzn_test
-      skip-local-build: false
-
-  - distro: centos
-    version: "7"
-    base_image: "netdata/legacy:centos7"
-    support_type: Core
-    notes: ''
-    eol_check: false
-    bundle_sentry: *default_sentry
-    packages:
-      type: rpm
-      repo_distro: el/7
-      builder_rev: *def_builder_rev
-      alt_links:
-        - el/7Server
-        - el/7Client
-      arches:
-        - x86_64
-    test:
-      ebpf-core: false
-      skip-local-build: true
 
   - &centos_stream
     distro: centos-stream
@@ -386,6 +355,27 @@ include:
       <<: *ubuntu_packages
       repo_distro: ubuntu/jammy
 legacy: # Info for platforms we used to support and still need to handle packages for
+  - <<: *amzn
+    version: "2"
+    packages:
+      <<: *amzn_packages
+      repo_distro: amazonlinux/2
+  - distro: centos
+    version: "7"
+    base_image: "netdata/legacy:centos7"
+    support_type: Core
+    notes: ''
+    eol_check: false
+    bundle_sentry: *default_sentry
+    packages:
+      type: rpm
+      repo_distro: el/7
+      builder_rev: *def_builder_rev
+      alt_links:
+        - el/7Server
+        - el/7Client
+      arches:
+        - x86_64
   - <<: *debian
     version: "10"
     packages:
@@ -503,11 +493,6 @@ no_include: # Info for platforms not covered in CI
     version: "9.x"
   - <<: *rhel
     version: "8.x"
-  - <<: *rhel
-    version: "7.x"
-    packages:
-      arches:
-        - x86_64
 
   - &freebsd
     distro: freebsd

--- a/.github/scripts/gen-matrix-build.py
+++ b/.github/scripts/gen-matrix-build.py
@@ -11,7 +11,7 @@ with open('.github/data/distros.yml') as f:
     data = yaml.load(f)
 
 for i, v in enumerate(data['include']):
-    if v['test'].get('skip-local-build', False):
+    if v.get('test', dict()).get('skip-local-build', False):
         continue
 
     e = {

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -69,8 +69,6 @@ Our [static builds](#static-builds) are expected to work on these platforms if a
 | Alma Linux               | 9.x            | x86\_64, AArch64              | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives                                |
 | Alma Linux               | 8.x            | x86\_64, AArch64              | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives                                |
 | Amazon Linux             | 2023           | x86\_64, AArch64              |                                                                                                                |
-| Amazon Linux             | 2              | x86\_64, AArch64              |                                                                                                                |
-| CentOS                   | 7.x            | x86\_64                       |                                                                                                                |
 | Docker                   | 19.03 or newer | x86\_64, ARMv7, AArch64       | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker           |
 | Debian                   | 13.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
 | Debian                   | 12.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
@@ -82,9 +80,9 @@ Our [static builds](#static-builds) are expected to work on these platforms if a
 | Oracle Linux             | 10.x           | x86\_64, AArch64              |                                                                                                                |
 | Oracle Linux             | 9.x            | x86\_64, AArch64              |                                                                                                                |
 | Oracle Linux             | 8.x            | x86\_64, AArch64              |                                                                                                                |
+| Red Hat Enterprise Linux | 10.x           | x86\_64, AArch64              |                                                                                                                |
 | Red Hat Enterprise Linux | 9.x            | x86\_64, AArch64              |                                                                                                                |
 | Red Hat Enterprise Linux | 8.x            | x86\_64, AArch64              |                                                                                                                |
-| Red Hat Enterprise Linux | 7.x            | x86\_64                       |                                                                                                                |
 | Rocky Linux              | 10.x           | x86\_64, AArch64              | Also includes support for Alma Linux and other ABI compatible RHEL derivatives                                 |
 | Rocky Linux              | 9.x            | x86\_64, AArch64              | Also includes support for Alma Linux and other ABI compatible RHEL derivatives                                 |
 | Rocky Linux              | 8.x            | x86\_64, AArch64              | Also includes support for Alma Linux and other ABI compatible RHEL derivatives                                 |
@@ -173,15 +171,18 @@ Platforms that meet these criteria will be immediately transitioned to the **Pre
 
 This is a list of platforms that we have supported in the recent past but no longer officially support:
 
-| Platform | Version   | Notes                |
-|----------|-----------|----------------------|
-| Debian   | 10.x      | EOL as of 2024-07-01 |
-| Fedora   | 42        | EOL as of 2026-05-13 |
-| Fedora   | 41        | EOL as of 2025-12-15 |
-| openSUSE | Leap 15.6 | EOL as of 2026-04-30 |
-| Ubuntu   | 25.04     | EOL as of 2026-01-17 |
-| Ubuntu   | 20.04     | EOL as of 2025-05-31 |
-| Ubuntu   | 18.04     | EOL as of 2023-04-02 |
+| Platform                 | Version   | Notes                |
+|--------------------------|-----------|----------------------|
+| Amazon Linux             | 2         | EOL as of 2026-06-30 |
+| CentOS                   | 7.x       | EOL as of 2026-06-30 |
+| Debian                   | 10.x      | EOL as of 2024-07-01 |
+| Fedora                   | 42        | EOL as of 2026-05-13 |
+| Fedora                   | 41        | EOL as of 2025-12-15 |
+| openSUSE                 | Leap 15.5 | EOL as of 2024-12-31 |
+| Red Hat Enterprise Linux | 7.x       | EOL as of 2026-06-30 |
+| Ubuntu                   | 25.04     | EOL as of 2026-01-17 |
+| Ubuntu                   | 20.04     | EOL as of 2025-05-31 |
+| Ubuntu                   | 18.04     | EOL as of 2023-04-02 |
 
 ## Static builds
 


### PR DESCRIPTION
##### Summary

AL 2 went EOL upstream on 2026-06-30.

RHEL 7.x went EOL upstream on 2024-06-30, and our end of support was delayed due to the number of customers still using the platform.

##### Test Plan

n/a

##### Additional Information

Closes: #21261 
Closes: #22595

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove Amazon Linux 2, RHEL 7.x, and CentOS 7 from active CI and package builds and move them to legacy-only. Update docs (mark EOL, add RHEL 10.x, confirm AL2023 and RHEL 8+/9+/10) and harden the build matrix generator.

- **Migration**
  - No new CI builds or tests for AL2, RHEL 7, or CentOS 7; legacy repos keep existing packages (`amazonlinux/2`, `el/7`) without updates.
  - Upgrade to Amazon Linux 2023 or RHEL 8+ (Alma/Rocky supported).
  - Static builds may still run on these OSes but are not supported.

<sup>Written for commit 8e2c859ab6c8c78cab60f95e1fe7f05161478aef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

