### PR TITLE
Update vendored NetIPC to 98ec474

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/src/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -197,6 +197,22 @@ static inline void ebpf_cgroup_set_target_data(ebpf_cgroup_target_t *out, const 
     out->updated = 1;
 }
 
+static inline bool ebpf_cgroup_target_matches_item(const ebpf_cgroup_target_t *target, const nipc_cgroups_item_view_t *item)
+{
+    size_t name_len = item->name.len;
+
+    if (name_len >= sizeof(target->name) || target->name[name_len] != '\0')
+        return false;
+
+    if (name_len == 0)
+        return true;
+
+    if (!item->name.ptr)
+        return false;
+
+    return memcmp(target->name, item->name.ptr, name_len) == 0;
+}
+
 /**
  * Find or create
  *
@@ -209,9 +225,7 @@ static inline void ebpf_cgroup_set_target_data(ebpf_cgroup_target_t *out, const 
 static ebpf_cgroup_target_t *ebpf_cgroup_find_or_create(const nipc_cgroups_item_view_t *item)
 {
     for (ebpf_cgroup_target_t *ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (ect->hash == item->hash &&
-            strlen(ect->name) == item->name.len &&
-            memcmp(ect->name, item->name.ptr, item->name.len) == 0) {
+        if (ect->hash == item->hash && ebpf_cgroup_target_matches_item(ect, item)) {
             ect->updated = 1;
             return ect;
         }

--- a/src/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/src/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -12,17 +12,17 @@ _Atomic int send_cgroup_chart = 0;
 #ifdef OS_LINUX
 #define EBPF_CGROUP_NETIPC_CALL_TIMEOUT_MS 5000u
 
-static nipc_cgroups_cache_t ebpf_cgroup_cache;
-static bool ebpf_cgroup_cache_initialized = false;
+static nipc_client_ctx_t ebpf_cgroup_client;
+static bool ebpf_cgroup_client_initialized = false;
 
 static bool ebpf_cgroup_cache_is_initialized(void)
 {
-    return __atomic_load_n(&ebpf_cgroup_cache_initialized, __ATOMIC_ACQUIRE);
+    return __atomic_load_n(&ebpf_cgroup_client_initialized, __ATOMIC_ACQUIRE);
 }
 
 static void ebpf_cgroup_cache_set_initialized(bool initialized)
 {
-    __atomic_store_n(&ebpf_cgroup_cache_initialized, initialized, __ATOMIC_RELEASE);
+    __atomic_store_n(&ebpf_cgroup_client_initialized, initialized, __ATOMIC_RELEASE);
 }
 
 static const char *ebpf_netipc_client_state_name(nipc_client_state_t state)
@@ -69,11 +69,11 @@ static void ebpf_log_cgroup_transport_state(uint64_t generation, uint32_t count,
     static bool previous_using_shm = false;
     static uint64_t previous_session_id = 0;
 
-    nipc_client_state_t state = ebpf_cgroup_cache.client.state;
-    bool session_valid = ebpf_cgroup_cache.client.session_valid;
-    uint32_t profile = session_valid ? ebpf_cgroup_cache.client.session.selected_profile : 0;
-    bool using_shm = session_valid && ebpf_cgroup_cache.client.shm != NULL;
-    uint64_t session_id = session_valid ? ebpf_cgroup_cache.client.session.session_id : 0;
+    nipc_client_state_t state = ebpf_cgroup_client.state;
+    bool session_valid = ebpf_cgroup_client.session_valid;
+    uint32_t profile = session_valid ? ebpf_cgroup_client.session.selected_profile : 0;
+    bool using_shm = session_valid && ebpf_cgroup_client.shm != NULL;
+    uint64_t session_id = session_valid ? ebpf_cgroup_client.session.session_id : 0;
 
     if (previous_state == state &&
         previous_session_valid == session_valid &&
@@ -179,15 +179,20 @@ static size_t ebpf_count_cgroup_pids_unsafe(void)
 /**
  * Set Target Data
  *
- * Set local variable values from a netipc cache item.
+ * Set local variable values from a netipc cgroups-snapshot item.
  *
  * @param out  local output variable.
- * @param item netipc cache item.
+ * @param item netipc cgroups-snapshot item.
  */
-static inline void ebpf_cgroup_set_target_data(ebpf_cgroup_target_t *out, const nipc_cgroups_cache_item_t *item)
+static inline void ebpf_cgroup_set_target_data(ebpf_cgroup_target_t *out, const nipc_cgroups_item_view_t *item)
 {
+    size_t name_len = item->name.len;
+    if (name_len >= sizeof(out->name))
+        name_len = sizeof(out->name) - 1;
+
     out->hash = item->hash;
-    snprintfz(out->name, 255, "%s", item->name);
+    memcpy(out->name, item->name.ptr, name_len);
+    out->name[name_len] = '\0';
     out->systemd = item->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE;
     out->updated = 1;
 }
@@ -197,14 +202,16 @@ static inline void ebpf_cgroup_set_target_data(ebpf_cgroup_target_t *out, const 
  *
  * Find the structure inside the link list or allocate and link when it is not present.
  *
- * @param item netipc cache item.
+ * @param item netipc cgroups-snapshot item.
  *
  * @return It returns a pointer for the structure associated with the input.
  */
-static ebpf_cgroup_target_t *ebpf_cgroup_find_or_create(const nipc_cgroups_cache_item_t *item)
+static ebpf_cgroup_target_t *ebpf_cgroup_find_or_create(const nipc_cgroups_item_view_t *item)
 {
     for (ebpf_cgroup_target_t *ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (ect->hash == item->hash && !strcmp(ect->name, item->name)) {
+        if (ect->hash == item->hash &&
+            strlen(ect->name) == item->name.len &&
+            memcmp(ect->name, item->name.ptr, item->name.len) == 0) {
             ect->updated = 1;
             return ect;
         }
@@ -288,7 +295,7 @@ void ebpf_reset_updated_var()
 }
 
 /**
- * Initialize netipc cgroup cache
+ * Initialize netipc cgroups-snapshot client
  *
  * Connect to the cgroups-snapshot service via netipc.
  */
@@ -307,10 +314,10 @@ static void ebpf_cgroup_cache_init(void)
         .call_timeout_ms = EBPF_CGROUP_NETIPC_CALL_TIMEOUT_MS,
     };
 
-    nipc_cgroups_cache_init(&ebpf_cgroup_cache,
-                             os_run_dir(false),
-                             "cgroups-snapshot",
-                             &config);
+    nipc_client_init(&ebpf_cgroup_client,
+                     os_run_dir(false),
+                     "cgroups-snapshot",
+                     &config);
 
     ebpf_cgroup_cache_set_initialized(true);
 #endif
@@ -320,26 +327,26 @@ void ebpf_cgroup_cache_abort(void)
 {
 #ifdef OS_LINUX
     if (ebpf_cgroup_cache_is_initialized())
-        nipc_client_abort(&ebpf_cgroup_cache.client);
+        nipc_client_abort(&ebpf_cgroup_client);
 #endif
 }
 
 /**
- * Close the netipc cgroup cache and release resources.
+ * Close the netipc cgroups-snapshot client and release resources.
  */
 void ebpf_cgroup_cache_cleanup(void)
 {
 #ifdef OS_LINUX
     if (ebpf_cgroup_cache_is_initialized()) {
-        nipc_client_abort(&ebpf_cgroup_cache.client);
-        nipc_cgroups_cache_close(&ebpf_cgroup_cache);
+        nipc_client_abort(&ebpf_cgroup_client);
+        nipc_client_close(&ebpf_cgroup_client);
         ebpf_cgroup_cache_set_initialized(false);
     }
 #endif
 }
 
 /**
- * Refresh cgroup data from netipc cache
+ * Refresh cgroup data from netipc cgroups-snapshot
  *
  * Replaces the legacy SHM parse function.
  */
@@ -357,26 +364,48 @@ static void ebpf_parse_cgroup_netipc_data(void)
         return;
 
     static int refresh_fail_count = 0;
-    if (!nipc_cgroups_cache_refresh(&ebpf_cgroup_cache)) {
+    nipc_client_refresh(&ebpf_cgroup_client);
+
+    nipc_cgroups_resp_view_t view;
+    nipc_error_t err = nipc_client_call_cgroups_snapshot_timeout(
+        &ebpf_cgroup_client,
+        &view,
+        EBPF_CGROUP_NETIPC_CALL_TIMEOUT_MS);
+    if (err != NIPC_OK) {
         if (++refresh_fail_count % 10 == 1)
-            collector_error("EBPF CGROUP: netipc refresh failed (%d consecutive failures)", refresh_fail_count);
+            collector_error(
+                "EBPF CGROUP: netipc cgroups-snapshot call failed err=%d (%d consecutive failures)",
+                err,
+                refresh_fail_count);
         return;
     }
-    refresh_fail_count = 0;
 
     uint32_t last_count = previous_count;
-    uint32_t count = ebpf_cgroup_cache.item_count;
-    uint64_t generation = ebpf_cgroup_cache.generation;
+    uint32_t count = view.item_count;
+    uint64_t generation = view.generation;
     uint32_t enabled_count = 0;
 
-    int systemd_enabled = (int)ebpf_cgroup_cache.systemd_enabled;
+    int systemd_enabled = (int)view.systemd_enabled;
     int integration_active = (count > 0) ? 1 : 0;
 
     for (uint32_t i = 0; i < count; i++) {
-        const nipc_cgroups_cache_item_t *item = &ebpf_cgroup_cache.items[i];
-        if (item->enabled)
+        nipc_cgroups_item_view_t item;
+        err = nipc_cgroups_resp_item(&view, i, &item);
+        if (err != NIPC_OK) {
+            if (++refresh_fail_count % 10 == 1)
+                collector_error(
+                    "EBPF CGROUP: netipc cgroups-snapshot item decode failed index=%u err=%d "
+                    "(%d consecutive failures)",
+                    i,
+                    err,
+                    refresh_fail_count);
+            return;
+        }
+
+        if (item.enabled)
             enabled_count++;
     }
+    refresh_fail_count = 0;
 
     ebpf_log_cgroup_transport_state(generation, count, enabled_count);
 
@@ -425,11 +454,12 @@ static void ebpf_parse_cgroup_netipc_data(void)
     ebpf_remove_cgroup_target_update_list();
     ebpf_reset_updated_var();
 
+    // The validation pass above already decoded every item in this immutable response buffer.
     for (uint32_t i = 0; i < count; i++) {
-        const nipc_cgroups_cache_item_t *item = &ebpf_cgroup_cache.items[i];
-        if (item->enabled) {
-            ebpf_cgroup_target_t *ect = ebpf_cgroup_find_or_create(item);
-            ebpf_update_pid_link_list(ect, item->path);
+        nipc_cgroups_item_view_t item;
+        if (nipc_cgroups_resp_item(&view, i, &item) == NIPC_OK && item.enabled) {
+            ebpf_cgroup_target_t *ect = ebpf_cgroup_find_or_create(&item);
+            ebpf_update_pid_link_list(ect, item.path.ptr);
         }
     }
 

--- a/src/crates/netipc/src/protocol/string_reverse.rs
+++ b/src/crates/netipc/src/protocol/string_reverse.rs
@@ -44,7 +44,7 @@ pub fn string_reverse_decode(buf: &[u8]) -> Result<StringReverseView<'_>, NipcEr
         return Err(NipcError::Truncated);
     }
     let str_offset = u32::from_ne_bytes(buf[0..4].try_into().unwrap()) as usize;
-    if str_offset < STRING_REVERSE_HDR_SIZE {
+    if str_offset != STRING_REVERSE_HDR_SIZE {
         return Err(NipcError::BadLayout);
     }
     let str_length = u32::from_ne_bytes(buf[4..8].try_into().unwrap()) as usize;
@@ -142,6 +142,19 @@ mod tests {
         assert!(matches!(
             string_reverse_decode(&buf),
             Err(NipcError::MissingNul)
+        ));
+    }
+
+    #[test]
+    fn decode_bad_offset() {
+        let mut buf = [0u8; 16];
+        buf[0..4].copy_from_slice(&9u32.to_ne_bytes());
+        buf[4..8].copy_from_slice(&1u32.to_ne_bytes());
+        buf[9] = b'x';
+        buf[10] = 0;
+        assert!(matches!(
+            string_reverse_decode(&buf),
+            Err(NipcError::BadLayout)
         ));
     }
 

--- a/src/crates/netipc/src/service/cgroups_snapshot.rs
+++ b/src/crates/netipc/src/service/cgroups_snapshot.rs
@@ -21,8 +21,8 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 pub use raw::{
-    CgroupsCacheItem, CgroupsCacheStatus, ClientAbortHandle, ClientState, ClientStatus,
-    SnapshotHandler,
+    CgroupsCacheItem, CgroupsCacheItemView, CgroupsCacheReadGuard, CgroupsCacheStatus,
+    ClientAbortHandle, ClientState, ClientStatus, SnapshotHandler,
 };
 
 /// Public L2/L3 client configuration for the cgroups-snapshot service.
@@ -262,7 +262,7 @@ impl CgroupsCache {
     }
 
     /// Refresh the cache. Returns true if the cache was updated.
-    pub fn refresh(&mut self) -> bool {
+    pub fn refresh(&self) -> bool {
         self.inner.refresh()
     }
 
@@ -272,9 +272,14 @@ impl CgroupsCache {
         self.inner.ready()
     }
 
-    /// Look up a cached item by hash + name. O(1), no I/O.
-    pub fn lookup(&self, hash: u32, name: &str) -> Option<&CgroupsCacheItem> {
-        self.inner.lookup(hash, name)
+    /// Acquire a read guard for borrowed cache access.
+    pub fn read_lock(&self) -> CgroupsCacheReadGuard<'_> {
+        self.inner.read_lock()
+    }
+
+    /// Duplicate a borrowed view into an owned item.
+    pub fn item_dup(&self, view: CgroupsCacheItemView<'_>) -> CgroupsCacheItem {
+        self.inner.item_dup(view)
     }
 
     /// Fill a status snapshot for diagnostics.
@@ -283,7 +288,7 @@ impl CgroupsCache {
     }
 
     /// Set the context-level default timeout for blocking refresh calls.
-    pub fn set_call_timeout(&mut self, timeout_ms: u32) {
+    pub fn set_call_timeout(&self, timeout_ms: u32) {
         self.inner.set_call_timeout(timeout_ms);
     }
 
@@ -303,7 +308,7 @@ impl CgroupsCache {
     }
 
     /// Close the cache and underlying L2 client.
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         self.inner.close();
     }
 }

--- a/src/crates/netipc/src/service/cgroups_unix_tests.rs
+++ b/src/crates/netipc/src/service/cgroups_unix_tests.rs
@@ -232,7 +232,7 @@ fn test_cache_round_trip_unix() {
     let service = unique_service("cache");
     let _server = TestServer::start(&service, server_config());
 
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, &service, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, &service, client_config());
     let mut updated = false;
     for _ in 0..200 {
         if cache.refresh() {
@@ -244,7 +244,10 @@ fn test_cache_round_trip_unix() {
     assert!(updated);
     assert!(cache.ready());
 
-    let item = cache.lookup(1001, "docker-abc123").expect("lookup");
+    let item = {
+        let guard = cache.read_lock();
+        guard.get(1001, "docker-abc123").expect("lookup").dup()
+    };
     assert_eq!(item.path, "/sys/fs/cgroup/docker/abc123");
 
     let status = cache.status();

--- a/src/crates/netipc/src/service/cgroups_windows_tests.rs
+++ b/src/crates/netipc/src/service/cgroups_windows_tests.rs
@@ -197,7 +197,7 @@ fn test_cache_round_trip_windows() {
     let service = unique_service("cache");
     let _server = TestServer::start(&service, server_config());
 
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, &service, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, &service, client_config());
     let mut updated = false;
     for _ in 0..200 {
         if cache.refresh() {
@@ -209,7 +209,10 @@ fn test_cache_round_trip_windows() {
     assert!(updated);
     assert!(cache.ready());
 
-    let item = cache.lookup(1001, "docker-abc123").expect("lookup");
+    let item = {
+        let guard = cache.read_lock();
+        guard.get(1001, "docker-abc123").expect("lookup").dup()
+    };
     assert_eq!(item.path, "/sys/fs/cgroup/docker/abc123");
 
     let status = cache.status();
@@ -228,7 +231,10 @@ fn test_cache_round_trip_windows() {
     abort.clear();
     cache.close();
     assert!(!cache.ready());
-    assert!(cache.lookup(1001, "docker-abc123").is_none());
+    {
+        let guard = cache.read_lock();
+        assert!(guard.get(1001, "docker-abc123").is_none());
+    }
 }
 
 #[test]
@@ -277,10 +283,13 @@ fn test_client_facade_controls_windows() {
 fn test_cache_facade_controls_windows() {
     ensure_run_dir();
     let service = unique_service("cache_controls");
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, &service, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, &service, client_config());
 
     assert!(!cache.ready());
-    assert!(cache.lookup(1001, "docker-abc123").is_none());
+    {
+        let guard = cache.read_lock();
+        assert!(guard.get(1001, "docker-abc123").is_none());
+    }
     let initial = cache.status();
     assert!(!initial.populated);
     assert_eq!(initial.item_count, 0);

--- a/src/crates/netipc/src/service/raw.rs
+++ b/src/crates/netipc/src/service/raw.rs
@@ -29,7 +29,9 @@ mod server_windows;
 mod string_reverse;
 
 pub use apps_lookup::{apps_lookup_dispatch, AppsLookupHandler};
-pub use cgroups_cache::{CgroupsCache, CgroupsCacheItem, CgroupsCacheStatus};
+pub use cgroups_cache::{
+    CgroupsCache, CgroupsCacheItem, CgroupsCacheItemView, CgroupsCacheReadGuard, CgroupsCacheStatus,
+};
 pub use cgroups_lookup::{cgroups_lookup_dispatch, CgroupsLookupHandler};
 pub use cgroups_snapshot::{snapshot_dispatch, snapshot_max_items, SnapshotHandler};
 pub use client::{ClientAbortHandle, ClientState, ClientStatus, RawClient};

--- a/src/crates/netipc/src/service/raw/cgroups_cache.rs
+++ b/src/crates/netipc/src/service/raw/cgroups_cache.rs
@@ -1,8 +1,8 @@
 use super::client::{ClientAbortHandle, ClientConfig, ClientState, RawClient};
 use super::common::next_power_of_2_u32;
+use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard};
 
-/// Cached copy of a single cgroup item. Owns its strings.
-/// Built from ephemeral L2 views during cache construction.
+/// Owned copy of a single cgroup item.
 #[derive(Debug, Clone)]
 pub struct CgroupsCacheItem {
     pub hash: u32,
@@ -10,6 +10,31 @@ pub struct CgroupsCacheItem {
     pub enabled: u32,
     pub name: String,
     pub path: String,
+}
+
+/// Borrowed immutable cgroup item view.
+///
+/// The view is valid only while the read guard that produced it is alive.
+#[derive(Debug, Clone, Copy)]
+pub struct CgroupsCacheItemView<'a> {
+    pub hash: u32,
+    pub options: u32,
+    pub enabled: u32,
+    pub name: &'a str,
+    pub path: &'a str,
+}
+
+impl<'a> CgroupsCacheItemView<'a> {
+    /// Duplicate this borrowed view into an owned item that survives unlock.
+    pub fn dup(self) -> CgroupsCacheItem {
+        CgroupsCacheItem {
+            hash: self.hash,
+            options: self.options,
+            enabled: self.enabled,
+            name: self.name.to_string(),
+            path: self.path.to_string(),
+        }
+    }
 }
 
 /// L3 cache status snapshot (for diagnostics, not hot path).
@@ -32,6 +57,45 @@ struct CgroupsHashBucket {
     used: bool,
 }
 
+#[derive(Debug, Default)]
+struct CgroupsCacheSnapshot {
+    items: Vec<CgroupsCacheItem>,
+    buckets: Vec<CgroupsHashBucket>,
+    systemd_enabled: u32,
+    generation: u64,
+    populated: bool,
+}
+
+struct CgroupsCacheState {
+    snapshot: CgroupsCacheSnapshot,
+    refresh_success_count: u32,
+    refresh_failure_count: u32,
+    epoch: std::time::Instant,
+    last_refresh_ts: u64,
+}
+
+impl CgroupsCacheState {
+    fn new() -> Self {
+        Self {
+            snapshot: CgroupsCacheSnapshot::default(),
+            refresh_success_count: 0,
+            refresh_failure_count: 0,
+            epoch: std::time::Instant::now(),
+            last_refresh_ts: 0,
+        }
+    }
+}
+
+fn lock_mutex<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn read_lock<T>(lock: &RwLock<T>) -> RwLockReadGuard<'_, T> {
+    lock.read().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 fn cache_hash_name(name: &str) -> u32 {
     let mut h: u32 = 5381;
     for b in name.as_bytes() {
@@ -40,140 +104,55 @@ fn cache_hash_name(name: &str) -> u32 {
     h
 }
 
-/// L3 client-side cgroups snapshot cache.
-///
-/// Wraps an L2 client and maintains a local owned copy of the most
-/// recent successful snapshot. Lookup by hash+name is O(1) via HashMap.
-///
-/// On refresh failure, the previous cache is preserved. The cache
-/// is empty only if no successful refresh has ever occurred.
-pub struct CgroupsCache {
-    pub(super) client: RawClient,
-    items: Vec<CgroupsCacheItem>,
-    /// Open-addressing hash table: (hash ^ djb2(name)) -> index into items vec
-    buckets: Vec<CgroupsHashBucket>,
-    systemd_enabled: u32,
-    generation: u64,
-    populated: bool,
-    refresh_success_count: u32,
-    refresh_failure_count: u32,
-    /// Monotonic reference point for timestamp calculation
-    epoch: std::time::Instant,
-    /// Monotonic ms of last successful refresh (0 if never)
-    pub last_refresh_ts: u64,
+fn cache_build_buckets(items: &[CgroupsCacheItem]) -> Vec<CgroupsHashBucket> {
+    if items.is_empty() || items.len() > (u32::MAX as usize / 2) {
+        return Vec::new();
+    }
+
+    let bcount = next_power_of_2_u32((items.len() as u32) * 2) as usize;
+    if bcount == 0 {
+        return Vec::new();
+    }
+
+    let mut buckets = vec![CgroupsHashBucket::default(); bcount];
+    let mask = (bcount - 1) as u32;
+    for (i, item) in items.iter().enumerate() {
+        let mut slot = (item.hash ^ cache_hash_name(&item.name)) & mask;
+        while buckets[slot as usize].used {
+            slot = (slot + 1) & mask;
+        }
+        buckets[slot as usize] = CgroupsHashBucket {
+            index: i as u32,
+            used: true,
+        };
+    }
+    buckets
 }
 
-impl CgroupsCache {
-    /// Create a new L3 cache. Creates the underlying L2 client context.
-    /// Does NOT connect. Does NOT require the server to be running.
-    /// Cache starts empty (populated == false).
-    pub fn new(run_dir: &str, service_name: &str, config: ClientConfig) -> Self {
-        CgroupsCache {
-            client: RawClient::new_snapshot(run_dir, service_name, config),
-            items: Vec::new(),
-            buckets: Vec::new(),
-            systemd_enabled: 0,
-            generation: 0,
-            populated: false,
-            refresh_success_count: 0,
-            refresh_failure_count: 0,
-            epoch: std::time::Instant::now(),
-            last_refresh_ts: 0,
+impl CgroupsCacheSnapshot {
+    fn from_items(items: Vec<CgroupsCacheItem>, systemd_enabled: u32, generation: u64) -> Self {
+        let buckets = cache_build_buckets(&items);
+        Self {
+            items,
+            buckets,
+            systemd_enabled,
+            generation,
+            populated: true,
         }
     }
 
-    /// Refresh the cache. Drives the L2 client (connect/reconnect as
-    /// needed) and requests a fresh snapshot. On success, rebuilds the
-    /// local cache. On failure, preserves the previous cache.
-    ///
-    /// Returns true if the cache was updated.
-    pub fn refresh(&mut self) -> bool {
-        self.client.refresh();
-
-        match self.client.call_snapshot() {
-            Ok(view) => {
-                let mut new_items = Vec::with_capacity(view.item_count as usize);
-                for i in 0..view.item_count {
-                    match view.item(i) {
-                        Ok(iv) => {
-                            let name = match iv.name.as_str() {
-                                Ok(s) => s.to_string(),
-                                Err(_) => String::from_utf8_lossy(iv.name.as_bytes()).into_owned(),
-                            };
-                            let path = match iv.path.as_str() {
-                                Ok(s) => s.to_string(),
-                                Err(_) => String::from_utf8_lossy(iv.path.as_bytes()).into_owned(),
-                            };
-                            new_items.push(CgroupsCacheItem {
-                                hash: iv.hash,
-                                options: iv.options,
-                                enabled: iv.enabled,
-                                name,
-                                path,
-                            });
-                        }
-                        Err(_) => {
-                            self.refresh_failure_count += 1;
-                            return false;
-                        }
-                    }
-                }
-
-                let mut buckets = Vec::new();
-                if !new_items.is_empty() {
-                    let bcount = next_power_of_2_u32((new_items.len() as u32) * 2) as usize;
-                    buckets.resize(bcount, CgroupsHashBucket::default());
-                    let mask = (bcount - 1) as u32;
-                    for (i, item) in new_items.iter().enumerate() {
-                        let mut slot = (item.hash ^ cache_hash_name(&item.name)) & mask;
-                        while buckets[slot as usize].used {
-                            slot = (slot + 1) & mask;
-                        }
-                        buckets[slot as usize] = CgroupsHashBucket {
-                            index: i as u32,
-                            used: true,
-                        };
-                    }
-                }
-
-                self.items = new_items;
-                self.buckets = buckets;
-                self.systemd_enabled = view.systemd_enabled;
-                self.generation = view.generation;
-                self.populated = true;
-                self.refresh_success_count += 1;
-                self.last_refresh_ts = self.epoch.elapsed().as_millis() as u64;
-                true
-            }
-            Err(_) => {
-                self.refresh_failure_count += 1;
-                false
-            }
-        }
-    }
-
-    /// Returns true if at least one successful refresh has occurred.
-    /// Cheap cached boolean. No I/O, no syscalls.
-    ///
-    /// Note: ready means "has cached data", not "is connected."
-    #[inline]
-    pub fn ready(&self) -> bool {
-        self.populated
-    }
-
-    /// Look up a cached item by hash + name. O(1) via open-addressing hash
-    /// table. No I/O.
-    pub fn lookup(&self, hash: u32, name: &str) -> Option<&CgroupsCacheItem> {
+    fn get(&self, hash: u32, name: &str) -> Option<CgroupsCacheItemView<'_>> {
         if !self.populated {
             return None;
         }
+
         if !self.buckets.is_empty() {
             let mask = (self.buckets.len() - 1) as u32;
             let mut slot = (hash ^ cache_hash_name(name)) & mask;
             while self.buckets[slot as usize].used {
                 let item = &self.items[self.buckets[slot as usize].index as usize];
                 if item.hash == hash && item.name == name {
-                    return Some(item);
+                    return Some(item.as_view());
                 }
                 slot = (slot + 1) & mask;
             }
@@ -183,48 +162,211 @@ impl CgroupsCache {
         self.items
             .iter()
             .find(|item| item.hash == hash && item.name == name)
+            .map(CgroupsCacheItem::as_view)
+    }
+}
+
+impl CgroupsCacheItem {
+    fn as_view(&self) -> CgroupsCacheItemView<'_> {
+        CgroupsCacheItemView {
+            hash: self.hash,
+            options: self.options,
+            enabled: self.enabled,
+            name: &self.name,
+            path: &self.path,
+        }
+    }
+}
+
+/// Read guard for borrowed L3 cache access.
+pub struct CgroupsCacheReadGuard<'a> {
+    state: RwLockReadGuard<'a, CgroupsCacheState>,
+}
+
+impl<'a> CgroupsCacheReadGuard<'a> {
+    /// Look up a cached item by hash + name. No I/O.
+    pub fn get(&self, hash: u32, name: &str) -> Option<CgroupsCacheItemView<'_>> {
+        self.state.snapshot.get(hash, name)
+    }
+
+    /// Duplicate a borrowed view into an owned item that survives unlock.
+    pub fn dup(&self, view: CgroupsCacheItemView<'_>) -> CgroupsCacheItem {
+        view.dup()
+    }
+}
+
+/// L3 client-side cgroups snapshot cache.
+///
+/// Refresh serializes L2 client use, builds a new immutable snapshot privately,
+/// then swaps it under a write lock. Readers hold read guards while using
+/// borrowed views and do not block snapshot construction.
+pub struct CgroupsCache {
+    client: Mutex<RawClient>,
+    abort_handle: ClientAbortHandle,
+    state: RwLock<CgroupsCacheState>,
+}
+
+impl CgroupsCache {
+    /// Create a new L3 cache. Creates the underlying L2 client context.
+    /// Does NOT connect. Does NOT require the server to be running.
+    /// Cache starts empty (populated == false).
+    pub fn new(run_dir: &str, service_name: &str, config: ClientConfig) -> Self {
+        let client = RawClient::new_snapshot(run_dir, service_name, config);
+        let abort_handle = client.abort_handle();
+        CgroupsCache {
+            client: Mutex::new(client),
+            abort_handle,
+            state: RwLock::new(CgroupsCacheState::new()),
+        }
+    }
+
+    /// Refresh the cache. Drives the L2 client and requests a fresh snapshot.
+    /// On success, swaps in a new immutable snapshot. On failure, preserves the
+    /// previous snapshot.
+    pub fn refresh(&self) -> bool {
+        let mut client = lock_mutex(&self.client);
+        client.refresh();
+
+        let view = match client.call_snapshot() {
+            Ok(view) => view,
+            Err(_) => {
+                let mut state = self
+                    .state
+                    .write()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                state.refresh_failure_count += 1;
+                return false;
+            }
+        };
+
+        let mut new_items = Vec::with_capacity(view.item_count as usize);
+        for i in 0..view.item_count {
+            let iv = match view.item(i) {
+                Ok(iv) => iv,
+                Err(_) => {
+                    let mut state = self
+                        .state
+                        .write()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    state.refresh_failure_count += 1;
+                    return false;
+                }
+            };
+            let name = match iv.name.as_str() {
+                Ok(s) => s.to_string(),
+                Err(_) => String::from_utf8_lossy(iv.name.as_bytes()).into_owned(),
+            };
+            let path = match iv.path.as_str() {
+                Ok(s) => s.to_string(),
+                Err(_) => String::from_utf8_lossy(iv.path.as_bytes()).into_owned(),
+            };
+            new_items.push(CgroupsCacheItem {
+                hash: iv.hash,
+                options: iv.options,
+                enabled: iv.enabled,
+                name,
+                path,
+            });
+        }
+
+        let snapshot =
+            CgroupsCacheSnapshot::from_items(new_items, view.systemd_enabled, view.generation);
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.snapshot = snapshot;
+        state.refresh_success_count += 1;
+        state.last_refresh_ts = state.epoch.elapsed().as_millis() as u64;
+        true
+    }
+
+    /// Returns true if at least one successful refresh has occurred.
+    #[inline]
+    pub fn ready(&self) -> bool {
+        read_lock(&self.state).snapshot.populated
+    }
+
+    /// Acquire a read guard for borrowed cache access.
+    pub fn read_lock(&self) -> CgroupsCacheReadGuard<'_> {
+        CgroupsCacheReadGuard {
+            state: read_lock(&self.state),
+        }
+    }
+
+    /// Duplicate a borrowed view into an owned item.
+    pub fn item_dup(&self, view: CgroupsCacheItemView<'_>) -> CgroupsCacheItem {
+        view.dup()
+    }
+
+    #[doc(hidden)]
+    pub fn seed_for_tests(
+        &self,
+        items: Vec<CgroupsCacheItem>,
+        systemd_enabled: u32,
+        generation: u64,
+    ) {
+        let snapshot = CgroupsCacheSnapshot::from_items(items, systemd_enabled, generation);
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.snapshot = snapshot;
+        state.refresh_success_count += 1;
+        state.last_refresh_ts = state.epoch.elapsed().as_millis() as u64;
     }
 
     /// Fill a status snapshot for diagnostics.
     pub fn status(&self) -> CgroupsCacheStatus {
+        let connection_state = lock_mutex(&self.client).status().state;
+        let state = read_lock(&self.state);
         CgroupsCacheStatus {
-            populated: self.populated,
-            item_count: self.items.len() as u32,
-            systemd_enabled: self.systemd_enabled,
-            generation: self.generation,
-            refresh_success_count: self.refresh_success_count,
-            refresh_failure_count: self.refresh_failure_count,
-            connection_state: self.client.status().state,
-            last_refresh_ts: self.last_refresh_ts,
+            populated: state.snapshot.populated,
+            item_count: state.snapshot.items.len() as u32,
+            systemd_enabled: state.snapshot.systemd_enabled,
+            generation: state.snapshot.generation,
+            refresh_success_count: state.refresh_success_count,
+            refresh_failure_count: state.refresh_failure_count,
+            connection_state,
+            last_refresh_ts: state.last_refresh_ts,
         }
     }
 
     /// Set the context-level default timeout for blocking refresh calls.
-    pub fn set_call_timeout(&mut self, timeout_ms: u32) {
-        self.client.set_call_timeout(timeout_ms);
+    pub fn set_call_timeout(&self, timeout_ms: u32) {
+        lock_mutex(&self.client).set_call_timeout(timeout_ms);
     }
 
     /// Return a cloneable handle that can abort refresh calls from another thread.
     pub fn abort_handle(&self) -> ClientAbortHandle {
-        self.client.abort_handle()
+        self.abort_handle.clone()
     }
 
     /// Request abort of an in-flight or future refresh call.
     pub fn abort(&self) {
-        self.client.abort();
+        self.abort_handle.abort();
     }
 
     /// Clear a previous abort request so the cache client can be reused.
     pub fn clear_abort(&self) {
-        self.client.clear_abort();
+        self.abort_handle.clear();
     }
 
-    /// Close the cache: free all cached items, close the L2 client.
-    pub fn close(&mut self) {
-        self.items.clear();
-        self.buckets.clear();
-        self.populated = false;
-        self.client.close();
+    #[cfg(test)]
+    pub fn max_receive_message_bytes(&self) -> usize {
+        lock_mutex(&self.client).max_receive_message_bytes()
+    }
+
+    /// Close the cache and underlying L2 client.
+    pub fn close(&self) {
+        {
+            let mut state = self
+                .state
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.snapshot = CgroupsCacheSnapshot::default();
+        }
+        lock_mutex(&self.client).close();
     }
 }
 

--- a/src/crates/netipc/src/service/raw_unix_tests.rs
+++ b/src/crates/netipc/src/service/raw_unix_tests.rs
@@ -4506,7 +4506,7 @@ fn test_cache_full_round_trip() {
 
     let mut server = TestServer::start(svc, METHOD_CGROUPS_SNAPSHOT, Some(test_cgroups_dispatch()));
 
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
     assert!(!cache.ready());
 
     // Ensure monotonic epoch advances past 0ms before refresh
@@ -4518,7 +4518,7 @@ fn test_cache_full_round_trip() {
     assert!(cache.ready());
 
     // Lookup by hash + name
-    let item = cache.lookup(1001, "docker-abc123");
+    let item = cache_dup(&cache, 1001, "docker-abc123");
     assert!(item.is_some());
     let item = item.unwrap();
     assert_eq!(item.hash, 1001);
@@ -4527,7 +4527,7 @@ fn test_cache_full_round_trip() {
     assert_eq!(item.name, "docker-abc123");
     assert_eq!(item.path, "/sys/fs/cgroup/docker/abc123");
 
-    let item2 = cache.lookup(3003, "systemd-user");
+    let item2 = cache_dup(&cache, 3003, "systemd-user");
     assert!(item2.is_some());
     assert_eq!(item2.unwrap().enabled, 0);
 
@@ -4555,12 +4555,12 @@ fn test_cache_refresh_failure_preserves() {
 
     let mut server = TestServer::start(svc, METHOD_CGROUPS_SNAPSHOT, Some(test_cgroups_dispatch()));
 
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
 
     // First refresh populates cache
     assert!(cache.refresh());
     assert!(cache.ready());
-    assert!(cache.lookup(1001, "docker-abc123").is_some());
+    assert!(cache_has(&cache, 1001, "docker-abc123"));
 
     // Kill server
     server.stop();
@@ -4571,13 +4571,73 @@ fn test_cache_refresh_failure_preserves() {
     let updated = cache.refresh();
     assert!(!updated);
     assert!(cache.ready()); // still has cached data
-    assert!(cache.lookup(1001, "docker-abc123").is_some());
+    assert!(cache_has(&cache, 1001, "docker-abc123"));
 
     let status = cache.status();
     assert_eq!(status.refresh_success_count, 1);
     assert!(status.refresh_failure_count >= 1);
 
     cache.close();
+    cleanup_all(svc);
+}
+
+#[test]
+fn test_cache_concurrent_readers_refresh() {
+    let svc = "rs_cache_concurrent";
+    ensure_run_dir();
+    cleanup_all(svc);
+
+    let mut server = TestServer::start(svc, METHOD_CGROUPS_SNAPSHOT, Some(test_cgroups_dispatch()));
+    let cache = Arc::new(CgroupsCache::new(TEST_RUN_DIR, svc, client_config()));
+    assert!(cache.refresh());
+
+    const READER_COUNT: usize = 4;
+    const READER_ITERS: usize = 500;
+    const WRITER_ITERS: usize = 100;
+
+    let mut handles = Vec::new();
+    for _ in 0..READER_COUNT {
+        let cache = Arc::clone(&cache);
+        handles.push(thread::spawn(move || {
+            let mut failures = 0usize;
+            for _ in 0..READER_ITERS {
+                let guard = cache.read_lock();
+                match guard.get(1001, "docker-abc123") {
+                    Some(view)
+                        if view.hash == 1001 && view.path == "/sys/fs/cgroup/docker/abc123" =>
+                    {
+                        let copy = guard.dup(view);
+                        if copy.hash != view.hash || copy.name != view.name {
+                            failures += 1;
+                        }
+                    }
+                    _ => failures += 1,
+                }
+                thread::sleep(Duration::from_micros(100));
+            }
+            failures
+        }));
+    }
+
+    let mut writer_failures = 0usize;
+    for _ in 0..WRITER_ITERS {
+        if !cache.refresh() {
+            writer_failures += 1;
+        }
+    }
+
+    let reader_failures: usize = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("reader thread"))
+        .sum();
+
+    let status = cache.status();
+    assert_eq!(writer_failures, 0);
+    assert_eq!(reader_failures, 0);
+    assert_eq!(status.refresh_success_count, 1 + WRITER_ITERS as u32);
+
+    cache.close();
+    server.stop();
     cleanup_all(svc);
 }
 
@@ -4590,7 +4650,7 @@ fn test_cache_reconnect_rebuilds() {
     let mut server1 =
         TestServer::start(svc, METHOD_CGROUPS_SNAPSHOT, Some(test_cgroups_dispatch()));
 
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
     assert!(cache.refresh());
     assert_eq!(cache.status().item_count, 3);
 
@@ -4622,17 +4682,17 @@ fn test_cache_lookup_not_found() {
 
     let mut server = TestServer::start(svc, METHOD_CGROUPS_SNAPSHOT, Some(test_cgroups_dispatch()));
 
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
     assert!(cache.refresh());
 
     // Non-existent hash
-    assert!(cache.lookup(9999, "nonexistent").is_none());
+    assert!(!cache_has(&cache, 9999, "nonexistent"));
 
     // Correct hash, wrong name
-    assert!(cache.lookup(1001, "wrong-name").is_none());
+    assert!(!cache_has(&cache, 1001, "wrong-name"));
 
     // Correct name, wrong hash
-    assert!(cache.lookup(9999, "docker-abc123").is_none());
+    assert!(!cache_has(&cache, 9999, "docker-abc123"));
 
     cache.close();
     server.stop();
@@ -4651,7 +4711,7 @@ fn test_cache_empty() {
     assert!(!cache.ready());
 
     // Lookup on empty cache returns None
-    assert!(cache.lookup(1001, "docker-abc123").is_none());
+    assert!(!cache_has(&cache, 1001, "docker-abc123"));
 
     let status = cache.status();
     assert!(!status.populated);
@@ -4713,7 +4773,7 @@ fn test_cache_large_dataset() {
         256 * N as usize,
     );
 
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, svc, cfg);
+    let cache = CgroupsCache::new(TEST_RUN_DIR, svc, cfg);
 
     assert!(cache.refresh());
     assert_eq!(cache.status().item_count, N);
@@ -4721,7 +4781,7 @@ fn test_cache_large_dataset() {
     // Verify all lookups
     for i in 0..N {
         let name = format!("cgroup-{i}");
-        let item = cache.lookup(i + 1000, &name);
+        let item = cache_dup(&cache, i + 1000, &name);
         assert!(item.is_some(), "item {i} not found");
         let item = item.unwrap();
         assert_eq!(item.hash, i + 1000);
@@ -4751,12 +4811,10 @@ fn test_cache_refresh_lossy_utf8() {
     );
 
     let mut server = TestServer::start(svc, METHOD_CGROUPS_SNAPSHOT, Some(handler));
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
 
     assert!(cache.refresh(), "cache refresh should succeed");
-    let item = cache
-        .lookup(1001, "bad-\u{FFFD}-name")
-        .expect("lossy lookup");
+    let item = cache_dup(&cache, 1001, "bad-\u{FFFD}-name").expect("lossy lookup");
     assert_eq!(item.name, "bad-\u{FFFD}-name");
     assert_eq!(item.path, "/bad/\u{FFFD}/path");
 
@@ -4772,14 +4830,11 @@ fn test_cache_refresh_preserves_old_cache_on_malformed_snapshot_item() {
     cleanup_all(svc);
 
     let mut server = TestServer::start(svc, METHOD_CGROUPS_SNAPSHOT, Some(test_cgroups_dispatch()));
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
 
     assert!(cache.refresh(), "initial refresh should succeed");
     let old_status = cache.status();
-    let old_item = cache
-        .lookup(1001, "docker-abc123")
-        .expect("existing cache item")
-        .clone();
+    let old_item = cache_dup(&cache, 1001, "docker-abc123").expect("existing cache item");
 
     server.stop();
     cleanup_all(svc);
@@ -4838,13 +4893,11 @@ fn test_cache_refresh_preserves_old_cache_on_malformed_snapshot_item() {
         status.refresh_failure_count,
         old_status.refresh_failure_count + 1
     );
-    let preserved = cache
-        .lookup(1001, "docker-abc123")
-        .expect("old cache item should remain");
+    let preserved = cache_dup(&cache, 1001, "docker-abc123").expect("old cache item should remain");
     assert_eq!(preserved.hash, old_item.hash);
     assert_eq!(preserved.path, old_item.path);
     assert!(
-        cache.lookup(9999, "new-item").is_none(),
+        !cache_has(&cache, 9999, "new-item"),
         "bad refresh must not replace the old cache"
     );
 
@@ -4867,6 +4920,16 @@ fn simple_hash(s: &str) -> u32 {
             .wrapping_add(c as u32);
     }
     hash
+}
+
+fn cache_has(cache: &CgroupsCache, hash: u32, name: &str) -> bool {
+    let guard = cache.read_lock();
+    guard.get(hash, name).is_some()
+}
+
+fn cache_dup(cache: &CgroupsCache, hash: u32, name: &str) -> Option<CgroupsCacheItem> {
+    let guard = cache.read_lock();
+    guard.get(hash, name).map(|view| guard.dup(view))
 }
 
 struct StressTestServer {
@@ -5214,7 +5277,7 @@ fn test_stress_cache_concurrent() {
     for _ in 0..NUM_CLIENTS {
         let svc_name = svc.to_string();
         let handle = thread::spawn(move || {
-            let mut cache = CgroupsCache::new(TEST_RUN_DIR, &svc_name, client_config());
+            let cache = CgroupsCache::new(TEST_RUN_DIR, &svc_name, client_config());
             let mut successes = 0usize;
 
             for _ in 0..REQUESTS_PER {
@@ -5224,7 +5287,7 @@ fn test_stress_cache_concurrent() {
                     if status.item_count != 3 {
                         continue;
                     }
-                    let item = cache.lookup(1001, "docker-abc123");
+                    let item = cache_dup(&cache, 1001, "docker-abc123");
                     if item.is_some() && item.unwrap().hash == 1001 {
                         successes += 1;
                     }
@@ -5272,7 +5335,7 @@ fn test_stress_long_running() {
         let svc_name = svc.to_string();
         let r = running.clone();
         let handle = thread::spawn(move || {
-            let mut cache = CgroupsCache::new(TEST_RUN_DIR, &svc_name, client_config());
+            let cache = CgroupsCache::new(TEST_RUN_DIR, &svc_name, client_config());
             let mut refreshes = 0u64;
             let mut errors = 0u64;
 
@@ -5685,14 +5748,14 @@ fn test_cache_close_resets() {
 
     let mut server = TestServer::start(svc, METHOD_CGROUPS_SNAPSHOT, Some(test_cgroups_dispatch()));
 
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
     assert!(cache.refresh());
     assert!(cache.ready());
     assert_eq!(cache.status().item_count, 3);
 
     cache.close();
     assert!(!cache.ready());
-    assert!(cache.lookup(1001, "docker-abc123").is_none());
+    assert!(!cache_has(&cache, 1001, "docker-abc123"));
     assert_eq!(cache.status().item_count, 0);
 
     server.stop();
@@ -5715,7 +5778,7 @@ fn test_cache_default_buf_size() {
 
     let cache = CgroupsCache::new(TEST_RUN_DIR, svc, cfg);
     assert_eq!(
-        cache.client.max_receive_message_bytes(),
+        cache.max_receive_message_bytes(),
         HEADER_SIZE + CACHE_RESPONSE_BUF_SIZE
     );
 

--- a/src/crates/netipc/src/service/raw_windows_tests.rs
+++ b/src/crates/netipc/src/service/raw_windows_tests.rs
@@ -3021,7 +3021,7 @@ fn test_cache_full_round_trip_windows() {
     let svc = "rs_win_cache_roundtrip";
     let mut server = TestServer::start(svc, METHOD_CGROUPS_SNAPSHOT, test_cgroups_dispatch());
 
-    let mut cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
+    let cache = CgroupsCache::new(TEST_RUN_DIR, svc, client_config());
     assert!(!cache.ready());
 
     thread::sleep(Duration::from_millis(2));
@@ -3030,7 +3030,10 @@ fn test_cache_full_round_trip_windows() {
     assert!(updated);
     assert!(cache.ready());
 
-    let item = cache.lookup(1001, "docker-abc123").expect("lookup");
+    let item = {
+        let guard = cache.read_lock();
+        guard.get(1001, "docker-abc123").expect("lookup").dup()
+    };
     assert_eq!(item.hash, 1001);
     assert_eq!(item.path, "/sys/fs/cgroup/docker/abc123");
 

--- a/src/crates/netipc/src/transport/win_shm.rs
+++ b/src/crates/netipc/src/transport/win_shm.rs
@@ -588,17 +588,20 @@ impl WinShmContext {
         let spin = read_u32(base, OFF_SPIN_TRIES);
 
         // Validate header fields from shared memory
+        let req_end = req_off.checked_add(req_cap);
+        let resp_end = resp_off.checked_add(resp_cap);
         if req_off == 0
             || req_cap == 0
             || resp_off == 0
             || resp_cap == 0
-            || req_off % 64 != 0
-            || req_cap % 64 != 0
-            || resp_off % 64 != 0
-            || resp_cap % 64 != 0
-            || req_off
-                .checked_add(req_cap)
-                .map_or(true, |end| resp_off < end)
+            || req_off < HEADER_LEN
+            || resp_off < HEADER_LEN
+            || req_off % CACHELINE_SIZE != 0
+            || req_cap % CACHELINE_SIZE != 0
+            || resp_off % CACHELINE_SIZE != 0
+            || resp_cap % CACHELINE_SIZE != 0
+            || req_end.map_or(true, |end| resp_off < end)
+            || resp_end.is_none()
         {
             unsafe {
                 ffi::UnmapViewOfFile(base as *const _);
@@ -607,7 +610,7 @@ impl WinShmContext {
             return Err(WinShmError::BadHeader);
         }
 
-        let region_size = (resp_off as usize) + (resp_cap as usize);
+        let region_size = resp_end.unwrap() as usize;
 
         // Read current sequence numbers via interlocked
         let cur_req_seq = interlocked_read_i64(base, OFF_REQ_SEQ);
@@ -784,18 +787,10 @@ impl WinShmContext {
         let mut observed = false;
         let mut mlen: i32 = 0;
         for _ in 0..self.spin_tries {
-            let cur = interlocked_read_i64(self.base, seq_off);
-            if cur >= expected_seq {
-                mlen = interlocked_read_i32(self.base, len_off);
-                if mlen > 0 && (mlen as usize) <= max_copy {
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(
-                            self.base.add(area_off as usize),
-                            buf.as_mut_ptr(),
-                            mlen as usize,
-                        );
-                    }
-                }
+            if let Some(observed_len) =
+                self.copy_observed_message(buf, seq_off, len_off, expected_seq, area_off, max_copy)?
+            {
+                mlen = observed_len;
                 observed = true;
                 break;
             }
@@ -817,8 +812,15 @@ impl WinShmContext {
                     interlocked_exchange_i32(self.base, self_waiting_off, 1);
                     std::sync::atomic::fence(std::sync::atomic::Ordering::SeqCst);
 
-                    let cur = interlocked_read_i64(self.base, seq_off);
-                    if cur >= expected_seq {
+                    if let Some(observed_len) = self.copy_observed_message(
+                        buf,
+                        seq_off,
+                        len_off,
+                        expected_seq,
+                        area_off,
+                        max_copy,
+                    )? {
+                        mlen = observed_len;
                         interlocked_exchange_i32(self.base, self_waiting_off, 0);
                         break; // data available
                     }
@@ -839,15 +841,29 @@ impl WinShmContext {
                     interlocked_exchange_i32(self.base, self_waiting_off, 0);
 
                     // Check sequence — data may have arrived
-                    let cur = interlocked_read_i64(self.base, seq_off);
-                    if cur >= expected_seq {
+                    if let Some(observed_len) = self.copy_observed_message(
+                        buf,
+                        seq_off,
+                        len_off,
+                        expected_seq,
+                        area_off,
+                        max_copy,
+                    )? {
+                        mlen = observed_len;
                         break; // data available
                     }
 
                     // No data — check peer close
                     if interlocked_read_i32(self.base, peer_closed_off) != 0 {
-                        let cur = interlocked_read_i64(self.base, seq_off);
-                        if cur >= expected_seq {
+                        if let Some(observed_len) = self.copy_observed_message(
+                            buf,
+                            seq_off,
+                            len_off,
+                            expected_seq,
+                            area_off,
+                            max_copy,
+                        )? {
+                            mlen = observed_len;
                             break;
                         }
                         self.advance_seq(expected_seq);
@@ -861,34 +877,20 @@ impl WinShmContext {
 
                     // Spurious wake — retry with remaining deadline
                 }
-
-                // Copy after waking
-                mlen = interlocked_read_i32(self.base, len_off);
-                if mlen > 0 && (mlen as usize) <= max_copy {
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(
-                            self.base.add(area_off as usize),
-                            buf.as_mut_ptr(),
-                            mlen as usize,
-                        );
-                    }
-                }
             } else {
                 // BUSYWAIT
                 let start = unsafe { ffi::GetTickCount() };
+                let mut polls = 0;
                 loop {
-                    let cur = interlocked_read_i64(self.base, seq_off);
-                    if cur >= expected_seq {
-                        mlen = interlocked_read_i32(self.base, len_off);
-                        if mlen > 0 && (mlen as usize) <= max_copy {
-                            unsafe {
-                                std::ptr::copy_nonoverlapping(
-                                    self.base.add(area_off as usize),
-                                    buf.as_mut_ptr(),
-                                    mlen as usize,
-                                );
-                            }
-                        }
+                    if let Some(observed_len) = self.copy_observed_message(
+                        buf,
+                        seq_off,
+                        len_off,
+                        expected_seq,
+                        area_off,
+                        max_copy,
+                    )? {
+                        mlen = observed_len;
                         break;
                     }
 
@@ -900,25 +902,22 @@ impl WinShmContext {
                     }
 
                     if interlocked_read_i32(self.base, peer_closed_off) != 0 {
-                        let cur = interlocked_read_i64(self.base, seq_off);
-                        if cur >= expected_seq {
-                            mlen = interlocked_read_i32(self.base, len_off);
-                            if mlen > 0 && (mlen as usize) <= max_copy {
-                                unsafe {
-                                    std::ptr::copy_nonoverlapping(
-                                        self.base.add(area_off as usize),
-                                        buf.as_mut_ptr(),
-                                        mlen as usize,
-                                    );
-                                }
-                            }
+                        if let Some(observed_len) = self.copy_observed_message(
+                            buf,
+                            seq_off,
+                            len_off,
+                            expected_seq,
+                            area_off,
+                            max_copy,
+                        )? {
+                            mlen = observed_len;
                             break;
                         }
                         self.advance_seq(expected_seq);
                         return Err(WinShmError::Disconnected);
                     }
 
-                    cpu_relax();
+                    busywait_relax(&mut polls);
                 }
             }
         }
@@ -966,22 +965,18 @@ impl WinShmContext {
         let max_copy = std::cmp::min(buf.len(), area_cap as usize);
 
         for _ in 0..self.spin_tries {
-            let cur = interlocked_read_i64(self.base, seq_off);
-            if cur < expected_seq {
+            let Some(mlen) = self.copy_observed_message(
+                buf,
+                seq_off,
+                len_off,
+                expected_seq,
+                area_off,
+                max_copy,
+            )?
+            else {
                 cpu_relax();
                 continue;
-            }
-
-            let mlen = interlocked_read_i32(self.base, len_off);
-            if mlen > 0 && (mlen as usize) <= max_copy {
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        self.base.add(area_off as usize),
-                        buf.as_mut_ptr(),
-                        mlen as usize,
-                    );
-                }
-            }
+            };
 
             // Match receive(): consume the observed sequence before reporting
             // malformed or oversized messages.
@@ -996,6 +991,43 @@ impl WinShmContext {
         }
 
         Ok(None)
+    }
+
+    fn copy_observed_message(
+        &self,
+        buf: &mut [u8],
+        seq_off: usize,
+        len_off: usize,
+        expected_seq: i64,
+        area_off: u32,
+        max_copy: usize,
+    ) -> Result<Option<i32>, WinShmError> {
+        let seq_before = interlocked_read_i64(self.base, seq_off);
+        if seq_before < expected_seq {
+            return Ok(None);
+        }
+
+        let mlen = interlocked_read_i32(self.base, len_off);
+        if mlen < 0 {
+            return Err(WinShmError::BadHeader);
+        }
+        if mlen > 0 && (mlen as usize) <= max_copy {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    self.base.add(area_off as usize),
+                    buf.as_mut_ptr(),
+                    mlen as usize,
+                );
+            }
+        }
+
+        let len_after = interlocked_read_i32(self.base, len_off);
+        let seq_after = interlocked_read_i64(self.base, seq_off);
+        if seq_before != seq_after || mlen != len_after {
+            return Err(WinShmError::BadHeader);
+        }
+
+        Ok(Some(mlen))
     }
 
     fn advance_seq(&mut self, expected_seq: i64) {
@@ -1204,6 +1236,17 @@ fn cpu_relax() {
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))]
     {
         std::sync::atomic::fence(std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[cfg(windows)]
+#[inline]
+fn busywait_relax(polls: &mut u32) {
+    *polls = polls.wrapping_add(1);
+    if (*polls & BUSYWAIT_POLL_MASK) == 0 {
+        std::thread::yield_now();
+    } else {
+        cpu_relax();
     }
 }
 

--- a/src/go/pkg/netipc/protocol/cgroups_lookup.go
+++ b/src/go/pkg/netipc/protocol/cgroups_lookup.go
@@ -183,21 +183,24 @@ func (v *CgroupsLookupRequestView) itemBytes(index uint32) ([]byte, []byte, erro
 			return nil, nil, ErrOverflow
 		}
 	}
-	dirOff64 := uint64(index) * uint64(LookupDirEntrySize)
-	if dirOff64 > uint64(maxIntValue()) || CgroupsLookupReqHdr > maxIntValue()-int(dirOff64) {
+	dirOff, ok := checkedInt(uint64(index) * uint64(LookupDirEntrySize))
+	if !ok || CgroupsLookupReqHdr > maxIntValue()-dirOff {
 		return nil, nil, ErrOverflow
 	}
-	base := CgroupsLookupReqHdr + int(dirOff64) // #nosec G115 -- bounded by maxIntValue above.
+	base := CgroupsLookupReqHdr + dirOff
 	if base > len(v.payload)-LookupDirEntrySize {
 		return nil, nil, ErrOutOfBounds
 	}
 	off32 := ne.Uint32(v.payload[base : base+4])
 	length32 := ne.Uint32(v.payload[base+4 : base+8])
-	if uint64(off32) > uint64(maxIntValue()) || uint64(length32) > uint64(maxIntValue()) {
+	off, ok := checkedInt(uint64(off32))
+	if !ok {
 		return nil, nil, ErrOutOfBounds
 	}
-	length := int(length32) // #nosec G115 -- bounded by maxIntValue above.
-	off := int(off32)       // #nosec G115 -- bounded by maxIntValue above.
+	length, ok := checkedInt(uint64(length32))
+	if !ok {
+		return nil, nil, ErrOutOfBounds
+	}
 	item, err := lookupPayloadSlice(v.payload, dirEnd, off, length)
 	if err != nil {
 		return nil, nil, err

--- a/src/go/pkg/netipc/protocol/cgroups_lookup.go
+++ b/src/go/pkg/netipc/protocol/cgroups_lookup.go
@@ -40,6 +40,16 @@ type CgroupsLookupItemView struct {
 	labelTableOffset int
 }
 
+type cgroupsLookupItemHeader struct {
+	status       uint16
+	orchestrator uint16
+	pathOff      int
+	pathLen      int
+	nameOff      int
+	nameLen      int
+	labelCount   uint16
+}
+
 func validateCgroupsLookupSemantics(status, orchestrator uint16, pathLen, nameLen, labelCount int) error {
 	if status != CgroupLookupKnown && status != CgroupLookupUnknownRetryLater &&
 		status != CgroupLookupUnknownPermanent && status != CgroupLookupPayloadExceeded &&
@@ -53,6 +63,38 @@ func validateCgroupsLookupSemantics(status, orchestrator uint16, pathLen, nameLe
 		return ErrBadLayout
 	}
 	return nil
+}
+
+func readCgroupsLookupItemHeader(item []byte) (cgroupsLookupItemHeader, error) {
+	var header cgroupsLookupItemHeader
+	if len(item) < CgroupsLookupItemHdr {
+		return header, ErrTruncated
+	}
+
+	header.status = ne.Uint16(item[2:4])
+	header.orchestrator = ne.Uint16(item[4:6])
+	var err error
+	header.pathOff, err = checkedWireU32Int(item, 8)
+	if err != nil {
+		return header, err
+	}
+	header.pathLen, err = checkedWireU32Int(item, 12)
+	if err != nil {
+		return header, err
+	}
+	header.nameOff, err = checkedWireU32Int(item, 16)
+	if err != nil {
+		return header, err
+	}
+	header.nameLen, err = checkedWireU32Int(item, 20)
+	if err != nil {
+		return header, err
+	}
+	header.labelCount = ne.Uint16(item[24:26])
+	if ne.Uint16(item[0:2]) != 1 || ne.Uint16(item[6:8]) != 0 || ne.Uint16(item[26:28]) != 0 {
+		return header, ErrBadLayout
+	}
+	return header, nil
 }
 
 func EncodeCgroupsLookupRequest(paths [][]byte, buf []byte) (int, error) {
@@ -310,49 +352,33 @@ func EncodeCgroupsLookupRawResponse(items [][]byte, generation uint64, buf []byt
 }
 
 func validateCgroupsLookupItem(item []byte) error {
-	if len(item) < CgroupsLookupItemHdr {
-		return ErrTruncated
-	}
-	status := ne.Uint16(item[2:4])
-	orchestrator := ne.Uint16(item[4:6])
-	pathOff, err := checkedWireU32Int(item, 8)
+	header, err := readCgroupsLookupItemHeader(item)
 	if err != nil {
 		return err
 	}
-	pathLen, err := checkedWireU32Int(item, 12)
+	if err := validateCgroupsLookupSemantics(
+		header.status,
+		header.orchestrator,
+		header.pathLen,
+		header.nameLen,
+		int(header.labelCount)); err != nil {
+		return err
+	}
+	if header.status != CgroupLookupKnown {
+		return validateCgroupsLookupUnknownItem(item, header.pathOff, header.pathLen, header.nameOff)
+	}
+	pathEnd, err := lookupStringInto(item, CgroupsLookupItemHdr, header.pathOff, header.pathLen, nil)
 	if err != nil {
 		return err
 	}
-	nameOff, err := checkedWireU32Int(item, 16)
+	nameEnd, err := lookupStringInto(item, CgroupsLookupItemHdr, header.nameOff, header.nameLen, nil)
 	if err != nil {
 		return err
 	}
-	nameLen, err := checkedWireU32Int(item, 20)
-	if err != nil {
-		return err
-	}
-	labelCount := ne.Uint16(item[24:26])
-	if ne.Uint16(item[0:2]) != 1 || ne.Uint16(item[6:8]) != 0 || ne.Uint16(item[26:28]) != 0 {
+	if overlap(header.pathOff, pathEnd, header.nameOff, nameEnd) {
 		return ErrBadLayout
 	}
-	if err := validateCgroupsLookupSemantics(status, orchestrator, pathLen, nameLen, int(labelCount)); err != nil {
-		return err
-	}
-	if status != CgroupLookupKnown {
-		return validateCgroupsLookupUnknownItem(item, pathOff, pathLen, nameOff)
-	}
-	pathEnd, err := lookupStringInto(item, CgroupsLookupItemHdr, pathOff, pathLen, nil)
-	if err != nil {
-		return err
-	}
-	nameEnd, err := lookupStringInto(item, CgroupsLookupItemHdr, nameOff, nameLen, nil)
-	if err != nil {
-		return err
-	}
-	if overlap(pathOff, pathEnd, nameOff, nameEnd) {
-		return ErrBadLayout
-	}
-	_, err = validateLabels(item, CgroupsLookupItemHdr, labelCount, max(pathEnd, nameEnd))
+	_, err = validateLabels(item, CgroupsLookupItemHdr, header.labelCount, max(pathEnd, nameEnd))
 	return err
 }
 
@@ -383,61 +409,51 @@ func decodeCgroupsLookupItem(item []byte) (*CgroupsLookupItemView, error) {
 }
 
 func decodeCgroupsLookupItemInto(item []byte, out *CgroupsLookupItemView) error {
-	if len(item) < CgroupsLookupItemHdr {
-		return ErrTruncated
-	}
-	status := ne.Uint16(item[2:4])
-	orchestrator := ne.Uint16(item[4:6])
-	pathOff, err := checkedWireU32Int(item, 8)
+	header, err := readCgroupsLookupItemHeader(item)
 	if err != nil {
 		return err
 	}
-	pathLen, err := checkedWireU32Int(item, 12)
-	if err != nil {
+	if err := validateCgroupsLookupSemantics(
+		header.status,
+		header.orchestrator,
+		header.pathLen,
+		header.nameLen,
+		int(header.labelCount)); err != nil {
 		return err
 	}
-	nameOff, err := checkedWireU32Int(item, 16)
-	if err != nil {
-		return err
-	}
-	nameLen, err := checkedWireU32Int(item, 20)
-	if err != nil {
-		return err
-	}
-	labelCount := ne.Uint16(item[24:26])
-	if ne.Uint16(item[0:2]) != 1 || ne.Uint16(item[6:8]) != 0 || ne.Uint16(item[26:28]) != 0 {
-		return ErrBadLayout
-	}
-	if err := validateCgroupsLookupSemantics(status, orchestrator, pathLen, nameLen, int(labelCount)); err != nil {
-		return err
-	}
-	if status != CgroupLookupKnown {
-		return decodeCgroupsLookupUnknownItemInto(item, status, pathOff, pathLen, nameOff, out)
+	if header.status != CgroupLookupKnown {
+		return decodeCgroupsLookupUnknownItemInto(
+			item,
+			header.status,
+			header.pathOff,
+			header.pathLen,
+			header.nameOff,
+			out)
 	}
 	var path CStringView
-	pathEnd, err := lookupStringInto(item, CgroupsLookupItemHdr, pathOff, pathLen, viewOut(out, &path))
+	pathEnd, err := lookupStringInto(item, CgroupsLookupItemHdr, header.pathOff, header.pathLen, viewOut(out, &path))
 	if err != nil {
 		return err
 	}
 	var name CStringView
-	nameEnd, err := lookupStringInto(item, CgroupsLookupItemHdr, nameOff, nameLen, viewOut(out, &name))
+	nameEnd, err := lookupStringInto(item, CgroupsLookupItemHdr, header.nameOff, header.nameLen, viewOut(out, &name))
 	if err != nil {
 		return err
 	}
-	if overlap(pathOff, pathEnd, nameOff, nameEnd) {
+	if overlap(header.pathOff, pathEnd, header.nameOff, nameEnd) {
 		return ErrBadLayout
 	}
-	table, err := validateLabels(item, CgroupsLookupItemHdr, labelCount, max(pathEnd, nameEnd))
+	table, err := validateLabels(item, CgroupsLookupItemHdr, header.labelCount, max(pathEnd, nameEnd))
 	if err != nil {
 		return err
 	}
 	if out != nil {
 		*out = CgroupsLookupItemView{
-			Status:           status,
-			Orchestrator:     orchestrator,
+			Status:           header.status,
+			Orchestrator:     header.orchestrator,
 			Path:             path,
 			Name:             name,
-			LabelCount:       labelCount,
+			LabelCount:       header.labelCount,
 			item:             item,
 			labelTableOffset: table,
 		}

--- a/src/go/pkg/netipc/protocol/codec_edge_test.go
+++ b/src/go/pkg/netipc/protocol/codec_edge_test.go
@@ -607,6 +607,19 @@ func TestStringReverseDecodeMissingNul(t *testing.T) {
 	}
 }
 
+func TestStringReverseDecodeBadOffset(t *testing.T) {
+	buf := make([]byte, StringReverseHdrSize+3)
+	ne.PutUint32(buf[0:4], uint32(StringReverseHdrSize+1))
+	ne.PutUint32(buf[4:8], 1)
+	buf[StringReverseHdrSize+1] = 'x'
+	buf[StringReverseHdrSize+2] = 0
+
+	_, err := StringReverseDecode(buf)
+	if err != ErrBadLayout {
+		t.Fatalf("expected ErrBadLayout, got %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 //  DispatchStringReverse
 // ---------------------------------------------------------------------------

--- a/src/go/pkg/netipc/protocol/frame.go
+++ b/src/go/pkg/netipc/protocol/frame.go
@@ -301,7 +301,7 @@ func BatchDirDecode(buf []byte, itemCount uint32, packedAreaLen uint32) ([]Batch
 // Checks alignment and that each entry falls within packedAreaLen.
 func BatchDirValidate(buf []byte, itemCount uint32, packedAreaLen uint32) error {
 	dirSize64 := uint64(itemCount) * 8
-	if dirSize64 > uint64(maxIntValue()) {
+	if dirSize64 > maxIntUint64() {
 		return ErrBadItemCount
 	}
 	dirSize := int(dirSize64) // #nosec G115 -- bounded by maxIntValue above.
@@ -331,7 +331,7 @@ func BatchItemGet(payload []byte, itemCount uint32, index uint32) ([]byte, error
 	}
 
 	dirSize64 := uint64(itemCount) * 8
-	if dirSize64 > uint64(maxIntValue()) {
+	if dirSize64 > maxIntUint64() {
 		return nil, ErrBadItemCount
 	}
 	dirSize := int(dirSize64) // #nosec G115 -- bounded by maxIntValue above.
@@ -348,7 +348,7 @@ func BatchItemGet(payload []byte, itemCount uint32, index uint32) ([]byte, error
 	if off%uint32(Alignment) != 0 {
 		return nil, ErrBadAlignment
 	}
-	if uint64(off)+uint64(length) > uint64(packedAreaLen) {
+	if !uint32RangeWithinInt(off, length, packedAreaLen) {
 		return nil, ErrOutOfBounds
 	}
 
@@ -404,30 +404,31 @@ func NewBatchBuilder(buf []byte, maxItems uint32) *BatchBuilder {
 // Add appends an item payload. Handles alignment padding.
 func (b *BatchBuilder) Add(item []byte) error {
 	maxInt := maxIntValue()
+	itemLen32, itemLenFitsU32 := checkedU32Int(len(item))
 	// Inline the common case; addSlow preserves the precise error returns for
 	// overflow and unusual bounds.
 	if b.itemCount < b.maxItems &&
 		b.dirEnd >= 0 &&
 		b.dataOffset >= 0 &&
 		b.dataOffset <= maxInt-7 &&
-		uint64(len(item)) <= uint64(^uint32(0)) {
+		itemLenFitsU32 {
 		alignedOff := Align8(b.dataOffset)
-		if uint64(alignedOff) <= uint64(^uint32(0)) &&
+		alignedOff32, alignedOffFitsU32 := checkedU32Int(alignedOff)
+		if alignedOffFitsU32 &&
 			alignedOff <= maxInt-b.dirEnd &&
 			len(item) <= maxInt-alignedOff {
 			absPos := b.dirEnd + alignedOff
 			if len(item) <= maxInt-absPos {
 				itemEnd := absPos + len(item)
-				idx64 := uint64(b.itemCount) * 8
-				if idx64 <= uint64(maxInt) {
-					idx := int(idx64) // #nosec G115 -- bounded by maxInt above.
+				idx, ok := checkedInt(uint64(b.itemCount) * 8)
+				if ok {
 					if itemEnd <= len(b.buf) && idx <= len(b.buf)-8 {
 						if alignedOff > b.dataOffset {
 							clear(b.buf[b.dirEnd+b.dataOffset : b.dirEnd+alignedOff])
 						}
 						copy(b.buf[absPos:], item)
-						ne.PutUint32(b.buf[idx:idx+4], uint32(alignedOff))  // #nosec G115 -- bounded above.
-						ne.PutUint32(b.buf[idx+4:idx+8], uint32(len(item))) // #nosec G115 -- bounded above.
+						ne.PutUint32(b.buf[idx:idx+4], alignedOff32)
+						ne.PutUint32(b.buf[idx+4:idx+8], itemLen32)
 						b.dataOffset = alignedOff + len(item)
 						b.itemCount++
 						return nil
@@ -447,10 +448,12 @@ func (b *BatchBuilder) addSlow(item []byte) error {
 		return ErrOverflow
 	}
 	alignedOff := Align8(b.dataOffset)
-	if uint64(alignedOff) > uint64(^uint32(0)) {
+	alignedOff32, ok := checkedU32Int(alignedOff)
+	if !ok {
 		return ErrOverflow
 	}
-	if uint64(len(item)) > uint64(^uint32(0)) {
+	itemLen32, ok := checkedU32Int(len(item))
+	if !ok {
 		return ErrOverflow
 	}
 	if alignedOff > maxIntValue()-b.dirEnd {
@@ -481,16 +484,13 @@ func (b *BatchBuilder) addSlow(item []byte) error {
 	copy(b.buf[absPos:], item)
 
 	// Write directory entry.
-	idx64 := uint64(b.itemCount) * 8
-	if idx64 > uint64(maxIntValue()) {
+	idx, ok := checkedInt(uint64(b.itemCount) * 8)
+	if !ok {
 		return ErrOverflow
 	}
-	idx := int(idx64) // #nosec G115 -- bounded by maxIntValue above.
 	if idx > len(b.buf)-8 {
 		return ErrOverflow
 	}
-	alignedOff32 := uint32(alignedOff) // #nosec G115 -- bounded by uint32 max above.
-	itemLen32 := uint32(len(item))     // #nosec G115 -- bounded by uint32 max above.
 	ne.PutUint32(b.buf[idx:idx+4], alignedOff32)
 	ne.PutUint32(b.buf[idx+4:idx+8], itemLen32)
 

--- a/src/go/pkg/netipc/protocol/lookup_common.go
+++ b/src/go/pkg/netipc/protocol/lookup_common.go
@@ -31,11 +31,23 @@ func maxIntValue() int {
 	return int(^uint(0) >> 1)
 }
 
-func checkedU32Int(value int) (uint32, bool) {
-	if value < 0 || uint64(value) > uint64(^uint32(0)) {
+func maxIntUint64() uint64 {
+	return uint64(^uint(0) >> 1)
+}
+
+func nonNegativeIntUint64(value int) (uint64, bool) {
+	if value < 0 {
 		return 0, false
 	}
-	return uint32(value), true
+	return uint64(value), true // #nosec G115 -- value is checked non-negative before widening.
+}
+
+func checkedU32Int(value int) (uint32, bool) {
+	value64, ok := nonNegativeIntUint64(value)
+	if !ok || value64 > uint64(^uint32(0)) {
+		return 0, false
+	}
+	return uint32(value), true // #nosec G115 -- value is bounded by uint32 max above.
 }
 
 func checkedU16Int(value int) (uint16, bool) {
@@ -94,8 +106,7 @@ func lookupDirOffset(hdrSize int, index uint32) (int, bool) {
 }
 
 func checkedInt(value uint64) (int, bool) {
-	maxInt := uint64(maxIntValue()) // #nosec G115 -- maxIntValue is non-negative and intentionally widened for the bounds check.
-	if value > maxInt {
+	if value > maxIntUint64() {
 		return 0, false
 	}
 	return int(value), true // #nosec G115 -- value is bounded by maxInt above.
@@ -139,6 +150,11 @@ func checkedAddU32(a, b uint32) (uint32, bool) {
 		return 0, false
 	}
 	return a + b, true
+}
+
+func uint32RangeWithinInt(off, length uint32, limit int) bool {
+	limit64, ok := nonNegativeIntUint64(limit)
+	return ok && uint64(off)+uint64(length) <= limit64
 }
 
 func checkedAlign8U32(v uint32) (uint32, bool) {
@@ -198,14 +214,14 @@ func finishPayloadExceededSuffixBytes(suffixBytes []uint32) bool {
 
 func payloadExceededSuffixFits(bufLen, dataOffset int, suffixBytes []uint32, first, maxItems uint32) bool {
 	maxInt := maxIntValue()
-	if uint64(maxItems) > uint64(maxInt) {
+	if uint64(maxItems) > maxIntUint64() {
 		return true
 	}
 	maxItemsInt := int(maxItems) // #nosec G115 -- maxItems is bounded by maxInt above.
 	if maxItemsInt == maxInt || len(suffixBytes) != maxItemsInt+1 {
 		return true
 	}
-	if uint64(first) > uint64(maxInt) {
+	if uint64(first) > maxIntUint64() {
 		return false
 	}
 	if first > maxItems {
@@ -220,15 +236,16 @@ func payloadExceededSuffixFits(bufLen, dataOffset int, suffixBytes []uint32, fir
 		return false
 	}
 	suffixBytesNeeded := uint64(suffixBytes[firstInt])
-	return suffixBytesNeeded <= uint64(bufLen-itemStart)
+	remainingBytes, ok := nonNegativeIntUint64(bufLen - itemStart)
+	return ok && suffixBytesNeeded <= remainingBytes
 }
 
 func payloadExceededFixedSuffixFits(bufLen, dataOffset, itemLen int, first, maxItems uint32) bool {
 	maxInt := maxIntValue()
-	if uint64(maxItems) > uint64(maxInt) {
+	if uint64(maxItems) > maxIntUint64() {
 		return true
 	}
-	if uint64(first) > uint64(maxInt) {
+	if uint64(first) > maxIntUint64() {
 		return false
 	}
 	if first > maxItems {
@@ -249,14 +266,21 @@ func payloadExceededFixedSuffixFits(bufLen, dataOffset, itemLen int, first, maxI
 	if !ok {
 		return false
 	}
-	itemLenBytes := uint64(itemLen)
-	alignedItemBytes := uint64(alignedItemLen)
+	itemLenBytes, ok := nonNegativeIntUint64(itemLen)
+	if !ok {
+		return false
+	}
+	alignedItemBytes, ok := nonNegativeIntUint64(alignedItemLen)
+	if !ok {
+		return false
+	}
 	tailItems := remaining - 1
 	if alignedItemBytes != 0 && tailItems > (^uint64(0)-itemLenBytes)/alignedItemBytes {
 		return false
 	}
 	needed := itemLenBytes + tailItems*alignedItemBytes
-	return needed <= uint64(bufLen-itemStart)
+	remainingBytes, ok := nonNegativeIntUint64(bufLen - itemStart)
+	return ok && needed <= remainingBytes
 }
 
 func validateLookupDir(buf []byte, dirStart int, itemCount uint32, packedAreaLen int, minLen int, exactLen int) error {
@@ -284,7 +308,7 @@ func validateLookupDir(buf []byte, dirStart int, itemCount uint32, packedAreaLen
 	}
 
 	dirSize64 := uint64(itemCount) * uint64(LookupDirEntrySize)
-	if dirSize64 > uint64(maxIntValue()) {
+	if dirSize64 > maxIntUint64() {
 		return ErrBadItemCount
 	}
 	dirSize := int(dirSize64) // #nosec G115 -- bounded by maxIntValue above.
@@ -610,11 +634,10 @@ func labelLayoutPrefix(fixedEnd, labelCount int) (int, int, int, error) {
 		return 0, 0, 0, ErrOverflow
 	}
 	tableStart := Align8(fixedEnd)
-	tableBytes64 := uint64(labelCount) * uint64(LookupLabelEntrySize)
-	if tableBytes64 > uint64(maxIntValue()) {
+	tableBytes, ok := checkedMulInt(labelCount, LookupLabelEntrySize)
+	if !ok {
 		return 0, 0, 0, ErrOverflow
 	}
-	tableBytes := int(tableBytes64) // #nosec G115 -- bounded by maxIntValue above.
 	if tableStart > maxIntValue()-tableBytes {
 		return 0, 0, 0, ErrOverflow
 	}

--- a/src/go/pkg/netipc/protocol/lookup_guard_test.go
+++ b/src/go/pkg/netipc/protocol/lookup_guard_test.go
@@ -1530,6 +1530,90 @@ func TestCgroupsSnapshotAdditionalGuardCoverage(t *testing.T) {
 		t.Fatalf("zero-item snapshot view = count/generation %d/%d", zeroView.ItemCount, zeroView.Generation)
 	}
 
+	decodeOverflowDir := func(name string, off uint32, length uint32) {
+		t.Helper()
+		buf := make([]byte, cgroupsRespHdr+cgroupsDirEntry+cgroupsItemHdr)
+		ne.PutUint16(buf[0:2], 1)
+		ne.PutUint32(buf[4:8], 1)
+		ne.PutUint32(buf[cgroupsRespHdr:cgroupsRespHdr+4], off)
+		ne.PutUint32(buf[cgroupsRespHdr+4:cgroupsRespHdr+8], length)
+		if _, err := DecodeCgroupsResponse(buf); !errors.Is(err, ErrOutOfBounds) {
+			t.Fatalf("%s = %v, want ErrOutOfBounds", name, err)
+		}
+	}
+	highAlignedU32 := ^uint32(0) - uint32(Alignment-1)
+	decodeOverflowDir("snapshot directory offset above int", highAlignedU32, cgroupsItemHdr)
+	decodeOverflowDir("snapshot directory length above int", 0, ^uint32(0))
+
+	itemView := func(item []byte) CgroupsResponseView {
+		payload := make([]byte, cgroupsRespHdr+cgroupsDirEntry+len(item))
+		ne.PutUint32(payload[cgroupsRespHdr:cgroupsRespHdr+4], 0)
+		ne.PutUint32(payload[cgroupsRespHdr+4:cgroupsRespHdr+8], uint32(len(item)))
+		copy(payload[cgroupsRespHdr+cgroupsDirEntry:], item)
+		return CgroupsResponseView{ItemCount: 1, payload: payload}
+	}
+	baseItem := func(itemLen int) []byte {
+		item := make([]byte, itemLen)
+		ne.PutUint16(item[0:2], 1)
+		return item
+	}
+	expectBadItem := func(name string, item []byte) {
+		t.Helper()
+		view := itemView(item)
+		if _, err := view.Item(0); !errors.Is(err, ErrOutOfBounds) {
+			t.Fatalf("%s = %v, want ErrOutOfBounds", name, err)
+		}
+	}
+
+	dirOffset := itemView(baseItem(cgroupsItemHdr))
+	ne.PutUint32(dirOffset.payload[cgroupsRespHdr:cgroupsRespHdr+4], highAlignedU32)
+	if _, err := dirOffset.Item(0); !errors.Is(err, ErrOutOfBounds) {
+		t.Fatalf("snapshot item directory offset above int = %v, want ErrOutOfBounds", err)
+	}
+
+	dirLength := itemView(baseItem(cgroupsItemHdr))
+	ne.PutUint32(dirLength.payload[cgroupsRespHdr+4:cgroupsRespHdr+8], ^uint32(0))
+	if _, err := dirLength.Item(0); !errors.Is(err, ErrOutOfBounds) {
+		t.Fatalf("snapshot item directory length above int = %v, want ErrOutOfBounds", err)
+	}
+
+	item := baseItem(cgroupsItemHdr)
+	ne.PutUint32(item[16:20], ^uint32(0))
+	expectBadItem("snapshot name offset above int", item)
+
+	item = baseItem(cgroupsItemHdr)
+	ne.PutUint32(item[16:20], cgroupsItemHdr)
+	ne.PutUint32(item[20:24], ^uint32(0))
+	expectBadItem("snapshot name length above int", item)
+
+	item = baseItem(cgroupsItemHdr + 1)
+	item[cgroupsItemHdr] = 0
+	ne.PutUint32(item[16:20], cgroupsItemHdr)
+	ne.PutUint32(item[20:24], 0)
+	ne.PutUint32(item[24:28], ^uint32(0))
+	expectBadItem("snapshot path offset above int", item)
+
+	item = baseItem(cgroupsItemHdr + 2)
+	item[cgroupsItemHdr] = 0
+	ne.PutUint32(item[16:20], cgroupsItemHdr)
+	ne.PutUint32(item[20:24], 0)
+	ne.PutUint32(item[24:28], cgroupsItemHdr+1)
+	ne.PutUint32(item[28:32], ^uint32(0))
+	expectBadItem("snapshot path length above int", item)
+
+	item = baseItem(cgroupsItemHdr)
+	ne.PutUint32(item[16:20], uint32(maxIntValue()))
+	ne.PutUint32(item[20:24], 1)
+	expectBadItem("snapshot name length overflow", item)
+
+	item = baseItem(cgroupsItemHdr + 1)
+	item[cgroupsItemHdr] = 0
+	ne.PutUint32(item[16:20], cgroupsItemHdr)
+	ne.PutUint32(item[20:24], 0)
+	ne.PutUint32(item[24:28], uint32(maxIntValue()))
+	ne.PutUint32(item[28:32], 1)
+	expectBadItem("snapshot path length overflow", item)
+
 	if strconv.IntSize < 64 {
 		t.Skip("synthetic snapshot overflow guards require 64-bit int")
 	}

--- a/src/go/pkg/netipc/protocol/string_reverse.go
+++ b/src/go/pkg/netipc/protocol/string_reverse.go
@@ -57,6 +57,9 @@ func StringReverseDecode(buf []byte) (StringReverseView, error) {
 	if err != nil {
 		return StringReverseView{}, err
 	}
+	if strOffset != StringReverseHdrSize {
+		return StringReverseView{}, ErrBadLayout
+	}
 	strLength, err := checkedWireU32Int(buf, 4)
 	if err != nil {
 		return StringReverseView{}, err

--- a/src/go/pkg/netipc/service/cgroups_snapshot/cache_common.go
+++ b/src/go/pkg/netipc/service/cgroups_snapshot/cache_common.go
@@ -19,9 +19,9 @@ func (c *Cache) Ready() bool {
 	return c.inner.Ready()
 }
 
-// Lookup finds a cached item by hash + name. O(1), no I/O.
-func (c *Cache) Lookup(hash uint32, name string) (CacheItem, bool) {
-	return c.inner.Lookup(hash, name)
+// ReadLock acquires a read guard for borrowed cache access.
+func (c *Cache) ReadLock() CacheReadGuard {
+	return c.inner.ReadLock()
 }
 
 // Status returns a diagnostic snapshot for the L3 cache.

--- a/src/go/pkg/netipc/service/cgroups_snapshot/cgroups_unix_test.go
+++ b/src/go/pkg/netipc/service/cgroups_snapshot/cgroups_unix_test.go
@@ -182,10 +182,14 @@ func TestCacheRoundTripUnix(t *testing.T) {
 		t.Fatal("cache not ready after refresh")
 	}
 
-	item, ok := cache.Lookup(1001, "docker-abc123")
-	if !ok {
+	guard := cache.ReadLock()
+	itemView := guard.Get(1001, "docker-abc123")
+	if itemView == nil {
+		guard.Unlock()
 		t.Fatal("lookup failed")
 	}
+	item := guard.Dup(itemView)
+	guard.Unlock()
 	if item.Path != "/sys/fs/cgroup/docker/abc123" {
 		t.Fatalf("unexpected path: %q", item.Path)
 	}

--- a/src/go/pkg/netipc/service/cgroups_snapshot/cgroups_windows_test.go
+++ b/src/go/pkg/netipc/service/cgroups_snapshot/cgroups_windows_test.go
@@ -164,9 +164,16 @@ func TestCacheRoundTripWindows(t *testing.T) {
 	if !cache.Ready() {
 		t.Fatal("cache not ready after refresh")
 	}
-	item, ok := cache.Lookup(1001, "docker-abc123")
-	if !ok || item.Path != "/sys/fs/cgroup/docker/abc123" {
-		t.Fatalf("unexpected cache item: %+v ok=%v", item, ok)
+	guard := cache.ReadLock()
+	itemView := guard.Get(1001, "docker-abc123")
+	if itemView == nil {
+		guard.Unlock()
+		t.Fatal("lookup failed")
+	}
+	item := guard.Dup(itemView)
+	guard.Unlock()
+	if item.Path != "/sys/fs/cgroup/docker/abc123" {
+		t.Fatalf("unexpected cache item: %+v", item)
 	}
 	status1 := cache.Status()
 	if !status1.Populated || status1.ItemCount != 3 || status1.SystemdEnabled != 1 || status1.Generation != 42 || status1.RefreshSuccessCount != 1 || status1.RefreshFailureCount != 0 || status1.ConnectionState != StateReady || status1.LastRefreshTs < 0 {

--- a/src/go/pkg/netipc/service/cgroups_snapshot/control_windows_test.go
+++ b/src/go/pkg/netipc/service/cgroups_snapshot/control_windows_test.go
@@ -41,9 +41,12 @@ func TestClientAndCacheControlMethodsWindows(t *testing.T) {
 	if cache.Ready() {
 		t.Fatal("cache unexpectedly ready without a successful refresh")
 	}
-	if item, ok := cache.Lookup(123, "missing"); ok || item.Name != "" {
-		t.Fatalf("cache lookup without refresh = %+v/%v, want empty/false", item, ok)
+	guard := cache.ReadLock()
+	if item := guard.Get(123, "missing"); item != nil {
+		guard.Unlock()
+		t.Fatalf("cache lookup without refresh = %+v, want nil", item)
 	}
+	guard.Unlock()
 	cacheStatus := cache.Status()
 	if cacheStatus.Populated || cacheStatus.RefreshFailureCount != 1 ||
 		cacheStatus.ConnectionState != StateNotFound {

--- a/src/go/pkg/netipc/service/cgroups_snapshot/types.go
+++ b/src/go/pkg/netipc/service/cgroups_snapshot/types.go
@@ -57,5 +57,11 @@ type Handler struct {
 // CacheItem is an owned copy of a single cgroup item.
 type CacheItem = raw.CacheItem
 
+// CacheItemView is a borrowed immutable view into a locked cache snapshot.
+type CacheItemView = raw.CacheItemView
+
+// CacheReadGuard protects borrowed cache views.
+type CacheReadGuard = raw.CacheReadGuard
+
 // CacheStatus is a diagnostic snapshot for the L3 cache.
 type CacheStatus = raw.CacheStatus

--- a/src/go/pkg/netipc/service/raw/cache_common_test.go
+++ b/src/go/pkg/netipc/service/raw/cache_common_test.go
@@ -2,22 +2,54 @@ package raw
 
 import "testing"
 
+func cacheDupForTest(cache *Cache, hash uint32, name string) (CacheItem, bool) {
+	guard := cache.ReadLock()
+	defer guard.Unlock()
+
+	view := guard.Get(hash, name)
+	if view == nil {
+		return CacheItem{}, false
+	}
+	return guard.Dup(view), true
+}
+
+func cacheHasForTest(cache *Cache, hash uint32, name string) bool {
+	_, found := cacheDupForTest(cache, hash, name)
+	return found
+}
+
+func cacheSetLinearSnapshotForTest(cache *Cache, items []CacheItem) {
+	views := make([]CacheItemView, len(items))
+	for i := range items {
+		views[i] = CacheItemView{
+			Hash:    items[i].Hash,
+			Options: items[i].Options,
+			Enabled: items[i].Enabled,
+			Name:    items[i].Name,
+			Path:    items[i].Path,
+		}
+	}
+	cache.snapshot = &cacheSnapshot{
+		items: items,
+		views: views,
+	}
+}
+
 func TestCacheDirectFallbackAndControlsCommon(t *testing.T) {
 	cache := newCache(&Client{state: StateReady, abortCh: make(chan struct{})})
-	cache.populated = true
-	cache.items = []CacheItem{
+	cacheSetLinearSnapshotForTest(cache, []CacheItem{
 		{Hash: 100, Name: "alpha", Path: "/alpha"},
 		{Hash: 200, Name: "beta", Path: "/beta"},
-	}
+	})
 
-	item, found := cache.Lookup(200, "beta")
+	item, found := cacheDupForTest(cache, 200, "beta")
 	if !found || item.Path != "/beta" {
 		t.Fatalf("fallback lookup = %+v found %v", item, found)
 	}
-	if _, found := cache.Lookup(200, "missing"); found {
+	if cacheHasForTest(cache, 200, "missing") {
 		t.Fatal("fallback lookup should reject wrong name")
 	}
-	if _, found := cache.Lookup(999, "beta"); found {
+	if cacheHasForTest(cache, 999, "beta") {
 		t.Fatal("fallback lookup should reject wrong hash")
 	}
 
@@ -34,7 +66,76 @@ func TestCacheDirectFallbackAndControlsCommon(t *testing.T) {
 		t.Fatal("cache clear abort did not reset client abort state")
 	}
 	cache.Close()
-	if cache.Ready() || cache.items != nil || cache.buckets != nil {
-		t.Fatalf("closed cache retained state: ready=%v items=%v buckets=%v", cache.Ready(), cache.items, cache.buckets)
+	if cache.Ready() || cache.snapshot != nil {
+		t.Fatalf("closed cache retained state: ready=%v snapshot=%v", cache.Ready(), cache.snapshot)
+	}
+}
+
+func TestCacheGuardAndSeedForTestsCommon(t *testing.T) {
+	var nilView *CacheItemView
+	if got := nilView.Dup(); got != (CacheItem{}) {
+		t.Fatalf("nil view dup = %+v, want zero item", got)
+	}
+
+	var nilGuard *CacheReadGuard
+	nilGuard.Unlock()
+	if got := nilGuard.Get(1, "missing"); got != nil {
+		t.Fatalf("nil guard get = %+v, want nil", got)
+	}
+	if got := nilGuard.Dup(&CacheItemView{Hash: 1, Name: "x"}); got != (CacheItem{}) {
+		t.Fatalf("nil guard dup = %+v, want zero item", got)
+	}
+
+	guard := CacheReadGuard{}
+	guard.Unlock()
+	if got := guard.Get(1, "missing"); got != nil {
+		t.Fatalf("unlocked guard get = %+v, want nil", got)
+	}
+	if got := guard.Dup(&CacheItemView{Hash: 1, Name: "x"}); got != (CacheItem{}) {
+		t.Fatalf("unlocked guard dup = %+v, want zero item", got)
+	}
+
+	cache := newCache(&Client{state: StateReady, abortCh: make(chan struct{})})
+	if !cache.SeedForTests(nil, 7, 9) {
+		t.Fatal("empty seed should succeed")
+	}
+	status := cache.Status()
+	if !status.Populated || status.ItemCount != 0 ||
+		status.SystemdEnabled != 7 || status.Generation != 9 ||
+		status.RefreshSuccessCount != 1 {
+		t.Fatalf("empty seed status = %+v", status)
+	}
+
+	seed := []CacheItem{
+		{Hash: 10, Enabled: 1, Name: "alpha", Path: "/alpha"},
+		{Hash: 20, Enabled: 0, Name: "beta", Path: "/beta"},
+	}
+	if !cache.SeedForTests(seed, 3, 11) {
+		t.Fatal("seed should succeed")
+	}
+	seed[0].Path = "/mutated"
+
+	read := cache.ReadLock()
+	view := read.Get(10, "alpha")
+	if view == nil {
+		t.Fatal("seeded item should be found")
+	}
+	owned := read.Dup(view)
+	if owned.Path != "/alpha" {
+		t.Fatalf("owned seeded item path = %q, want /alpha", owned.Path)
+	}
+	if got := read.Dup(nil); got != (CacheItem{}) {
+		t.Fatalf("guard dup nil view = %+v, want zero item", got)
+	}
+	read.Unlock()
+	read.Unlock()
+	if got := read.Get(10, "alpha"); got != nil {
+		t.Fatalf("unlocked read guard get = %+v, want nil", got)
+	}
+
+	status = cache.Status()
+	if status.ItemCount != 2 || status.SystemdEnabled != 3 ||
+		status.Generation != 11 || status.RefreshSuccessCount != 2 {
+		t.Fatalf("seed status = %+v", status)
 	}
 }

--- a/src/go/pkg/netipc/service/raw/cache_test.go
+++ b/src/go/pkg/netipc/service/raw/cache_test.go
@@ -170,13 +170,11 @@ func TestCacheConcurrentReadersRefresh(t *testing.T) {
 
 	var wg sync.WaitGroup
 	failures := make(chan int, readerCount)
-	for i := 0; i < readerCount; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range readerCount {
+		wg.Go(func() {
 
 			localFailures := 0
-			for j := 0; j < readerIters; j++ {
+			for range readerIters {
 				guard := cache.ReadLock()
 				view := guard.Get(1001, "docker-abc123")
 				if view == nil ||
@@ -194,11 +192,11 @@ func TestCacheConcurrentReadersRefresh(t *testing.T) {
 				guard.Unlock()
 			}
 			failures <- localFailures
-		}()
+		})
 	}
 
 	writerFailures := 0
-	for i := 0; i < writerIters; i++ {
+	for range writerIters {
 		if !cache.Refresh() {
 			writerFailures++
 		}
@@ -365,42 +363,6 @@ func TestCacheEmpty(t *testing.T) {
 	}
 
 	cleanupAll(svc)
-}
-
-func TestCacheDirectFallbackAndControls(t *testing.T) {
-	cache := newCache(&Client{state: StateReady, abortCh: make(chan struct{})})
-	cacheSetLinearSnapshotForTest(cache, []CacheItem{
-		{Hash: 100, Name: "alpha", Path: "/alpha"},
-		{Hash: 200, Name: "beta", Path: "/beta"},
-	})
-
-	item, found := cacheDupForTest(cache, 200, "beta")
-	if !found || item.Path != "/beta" {
-		t.Fatalf("fallback lookup = %+v found %v", item, found)
-	}
-	if cacheHasForTest(cache, 200, "missing") {
-		t.Fatal("fallback lookup should reject wrong name")
-	}
-	if cacheHasForTest(cache, 999, "beta") {
-		t.Fatal("fallback lookup should reject wrong hash")
-	}
-
-	cache.SetCallTimeout(123)
-	if cache.client.callTimeoutMs != 123 {
-		t.Fatalf("cache call timeout = %d, want 123", cache.client.callTimeoutMs)
-	}
-	cache.Abort()
-	if !cache.client.abortRequested.Load() {
-		t.Fatal("cache abort did not mark client aborted")
-	}
-	cache.ClearAbort()
-	if cache.client.abortRequested.Load() {
-		t.Fatal("cache clear abort did not reset client abort state")
-	}
-	cache.Close()
-	if cache.Ready() || cache.snapshot != nil {
-		t.Fatalf("closed cache retained state: ready=%v snapshot=%v", cache.Ready(), cache.snapshot)
-	}
 }
 
 func TestCacheOverflowGuards(t *testing.T) {

--- a/src/go/pkg/netipc/service/raw/cache_test.go
+++ b/src/go/pkg/netipc/service/raw/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,7 +41,7 @@ func TestCacheFullRoundTrip(t *testing.T) {
 	}
 
 	// Lookup by hash + name
-	item, found := cache.Lookup(1001, "docker-abc123")
+	item, found := cacheDupForTest(cache, 1001, "docker-abc123")
 	if !found {
 		t.Fatal("item should be found")
 	}
@@ -60,7 +61,7 @@ func TestCacheFullRoundTrip(t *testing.T) {
 		t.Fatalf("expected path=/sys/fs/cgroup/docker/abc123, got %q", item.Path)
 	}
 
-	item2, found2 := cache.Lookup(3003, "systemd-user")
+	item2, found2 := cacheDupForTest(cache, 3003, "systemd-user")
 	if !found2 {
 		t.Fatal("item 2 should be found")
 	}
@@ -115,8 +116,7 @@ func TestCacheRefreshFailurePreserves(t *testing.T) {
 	if !cache.Ready() {
 		t.Fatal("should be ready")
 	}
-	_, found := cache.Lookup(1001, "docker-abc123")
-	if !found {
+	if !cacheHasForTest(cache, 1001, "docker-abc123") {
 		t.Fatal("item should be found after first refresh")
 	}
 
@@ -133,8 +133,7 @@ func TestCacheRefreshFailurePreserves(t *testing.T) {
 	if !cache.Ready() {
 		t.Fatal("should still be ready (old cache preserved)")
 	}
-	_, found = cache.Lookup(1001, "docker-abc123")
-	if !found {
+	if !cacheHasForTest(cache, 1001, "docker-abc123") {
 		t.Fatal("item should still be found (old cache preserved)")
 	}
 
@@ -148,6 +147,80 @@ func TestCacheRefreshFailurePreserves(t *testing.T) {
 
 	cache.Close()
 	cleanupAll(svc)
+}
+
+func TestCacheConcurrentReadersRefresh(t *testing.T) {
+	svc := "go_cache_concurrent"
+	ensureRunDir()
+	cleanupAll(svc)
+
+	ts := startTestServer(svc, testSnapshotDispatch())
+	defer ts.stop()
+
+	cache := NewCache(testRunDir, svc, testClientConfig())
+	defer cache.Close()
+
+	if !cache.Refresh() {
+		t.Fatal("initial refresh should succeed")
+	}
+
+	const readerCount = 4
+	const readerIters = 500
+	const writerIters = 100
+
+	var wg sync.WaitGroup
+	failures := make(chan int, readerCount)
+	for i := 0; i < readerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			localFailures := 0
+			for j := 0; j < readerIters; j++ {
+				guard := cache.ReadLock()
+				view := guard.Get(1001, "docker-abc123")
+				if view == nil ||
+					view.Hash != 1001 ||
+					view.Path != "/sys/fs/cgroup/docker/abc123" {
+					localFailures++
+					guard.Unlock()
+					continue
+				}
+				copy := guard.Dup(view)
+				if copy.Hash != view.Hash || copy.Name != view.Name {
+					localFailures++
+				}
+				time.Sleep(100 * time.Microsecond)
+				guard.Unlock()
+			}
+			failures <- localFailures
+		}()
+	}
+
+	writerFailures := 0
+	for i := 0; i < writerIters; i++ {
+		if !cache.Refresh() {
+			writerFailures++
+		}
+	}
+
+	wg.Wait()
+	close(failures)
+
+	readerFailures := 0
+	for count := range failures {
+		readerFailures += count
+	}
+
+	if writerFailures != 0 {
+		t.Fatalf("writer failures = %d", writerFailures)
+	}
+	if readerFailures != 0 {
+		t.Fatalf("reader failures = %d", readerFailures)
+	}
+	if got := cache.Status().RefreshSuccessCount; got != 1+writerIters {
+		t.Fatalf("refresh success count = %d, want %d", got, 1+writerIters)
+	}
 }
 
 func TestCacheRefreshRejectsMalformedSnapshotItem(t *testing.T) {
@@ -242,20 +315,17 @@ func TestCacheLookupNotFound(t *testing.T) {
 	}
 
 	// Non-existent hash
-	_, found := cache.Lookup(9999, "nonexistent")
-	if found {
+	if cacheHasForTest(cache, 9999, "nonexistent") {
 		t.Fatal("should not find nonexistent item")
 	}
 
 	// Correct hash, wrong name
-	_, found = cache.Lookup(1001, "wrong-name")
-	if found {
+	if cacheHasForTest(cache, 1001, "wrong-name") {
 		t.Fatal("should not find with wrong name")
 	}
 
 	// Correct name, wrong hash
-	_, found = cache.Lookup(9999, "docker-abc123")
-	if found {
+	if cacheHasForTest(cache, 9999, "docker-abc123") {
 		t.Fatal("should not find with wrong hash")
 	}
 
@@ -276,8 +346,7 @@ func TestCacheEmpty(t *testing.T) {
 	}
 
 	// Lookup on empty cache returns not-found
-	_, found := cache.Lookup(1001, "docker-abc123")
-	if found {
+	if cacheHasForTest(cache, 1001, "docker-abc123") {
 		t.Fatal("should not find in empty cache")
 	}
 
@@ -300,20 +369,19 @@ func TestCacheEmpty(t *testing.T) {
 
 func TestCacheDirectFallbackAndControls(t *testing.T) {
 	cache := newCache(&Client{state: StateReady, abortCh: make(chan struct{})})
-	cache.populated = true
-	cache.items = []CacheItem{
+	cacheSetLinearSnapshotForTest(cache, []CacheItem{
 		{Hash: 100, Name: "alpha", Path: "/alpha"},
 		{Hash: 200, Name: "beta", Path: "/beta"},
-	}
+	})
 
-	item, found := cache.Lookup(200, "beta")
+	item, found := cacheDupForTest(cache, 200, "beta")
 	if !found || item.Path != "/beta" {
 		t.Fatalf("fallback lookup = %+v found %v", item, found)
 	}
-	if _, found := cache.Lookup(200, "missing"); found {
+	if cacheHasForTest(cache, 200, "missing") {
 		t.Fatal("fallback lookup should reject wrong name")
 	}
-	if _, found := cache.Lookup(999, "beta"); found {
+	if cacheHasForTest(cache, 999, "beta") {
 		t.Fatal("fallback lookup should reject wrong hash")
 	}
 
@@ -330,8 +398,8 @@ func TestCacheDirectFallbackAndControls(t *testing.T) {
 		t.Fatal("cache clear abort did not reset client abort state")
 	}
 	cache.Close()
-	if cache.Ready() || cache.items != nil || cache.buckets != nil {
-		t.Fatalf("closed cache retained state: ready=%v items=%v buckets=%v", cache.Ready(), cache.items, cache.buckets)
+	if cache.Ready() || cache.snapshot != nil {
+		t.Fatalf("closed cache retained state: ready=%v snapshot=%v", cache.Ready(), cache.snapshot)
 	}
 }
 
@@ -414,7 +482,7 @@ func TestCacheLargeDataset(t *testing.T) {
 	// Verify all lookups
 	for i := range uint32(N) {
 		name := fmt.Sprintf("cgroup-%d", i)
-		item, found := cache.Lookup(i+1000, name)
+		item, found := cacheDupForTest(cache, i+1000, name)
 		if !found {
 			t.Fatalf("item %d not found", i)
 		}

--- a/src/go/pkg/netipc/service/raw/cgroups_cache.go
+++ b/src/go/pkg/netipc/service/raw/cgroups_cache.go
@@ -1,6 +1,7 @@
 package raw
 
 import (
+	"sync"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/netipc/protocol"
@@ -10,13 +11,38 @@ import (
 const cacheResponseBufSize = 65536
 
 // CacheItem is an owned copy of a single cgroup item.
-// Built from ephemeral L2 views during cache construction.
 type CacheItem struct {
 	Hash    uint32
 	Options uint32
 	Enabled uint32
-	Name    string // owned copy
-	Path    string // owned copy
+	Name    string
+	Path    string
+}
+
+// CacheItemView is a borrowed immutable view into a cache snapshot.
+//
+// The view is valid only while the CacheReadGuard that returned it remains
+// locked.
+type CacheItemView struct {
+	Hash    uint32
+	Options uint32
+	Enabled uint32
+	Name    string
+	Path    string
+}
+
+// Dup duplicates a borrowed view into an owned item that survives unlock.
+func (v *CacheItemView) Dup() CacheItem {
+	if v == nil {
+		return CacheItem{}
+	}
+	return CacheItem{
+		Hash:    v.Hash,
+		Options: v.Options,
+		Enabled: v.Enabled,
+		Name:    v.Name,
+		Path:    v.Path,
+	}
 }
 
 // CacheStatus is a diagnostic snapshot for the L3 cache.
@@ -27,14 +53,21 @@ type CacheStatus struct {
 	Generation          uint64
 	RefreshSuccessCount uint32
 	RefreshFailureCount uint32
-	ConnectionState     ClientState // underlying L2 client state
-	LastRefreshTs       int64       // monotonic timestamp (ms) of last successful refresh, 0 if never
+	ConnectionState     ClientState
+	LastRefreshTs       int64
 }
 
-// cacheBucket is one open-addressing bucket for hash+name lookup.
 type cacheBucket struct {
 	index int
 	used  bool
+}
+
+type cacheSnapshot struct {
+	items          []CacheItem
+	views          []CacheItemView
+	buckets        []cacheBucket
+	systemdEnabled uint32
+	generation     uint64
 }
 
 func cacheHashName(name string) uint32 {
@@ -45,20 +78,93 @@ func cacheHashName(name string) uint32 {
 	return h
 }
 
+func buildCacheSnapshot(items []CacheItem, systemdEnabled uint32, generation uint64) (*cacheSnapshot, error) {
+	copiedItems := append([]CacheItem(nil), items...)
+	snapshot := &cacheSnapshot{
+		items:          copiedItems,
+		views:          make([]CacheItemView, len(copiedItems)),
+		systemdEnabled: systemdEnabled,
+		generation:     generation,
+	}
+
+	for i := range copiedItems {
+		snapshot.views[i] = CacheItemView{
+			Hash:    copiedItems[i].Hash,
+			Options: copiedItems[i].Options,
+			Enabled: copiedItems[i].Enabled,
+			Name:    copiedItems[i].Name,
+			Path:    copiedItems[i].Path,
+		}
+	}
+
+	if len(copiedItems) == 0 {
+		return snapshot, nil
+	}
+
+	itemCount, err := checkedLookupU32(len(copiedItems))
+	if err != nil {
+		return nil, err
+	}
+	bcount, err := cacheBucketCountForItemCount(itemCount)
+	if err != nil {
+		return nil, err
+	}
+
+	buckets := make([]cacheBucket, bcount)
+	mask := bcount - 1
+	for i := range copiedItems {
+		slot := (copiedItems[i].Hash ^ cacheHashName(copiedItems[i].Name)) & mask
+		for buckets[slot].used {
+			slot = (slot + 1) & mask
+		}
+		buckets[slot].index = i
+		buckets[slot].used = true
+	}
+	snapshot.buckets = buckets
+	return snapshot, nil
+}
+
+func (s *cacheSnapshot) get(hash uint32, name string) *CacheItemView {
+	if s == nil {
+		return nil
+	}
+
+	if len(s.buckets) > 0 {
+		mask, err := cacheBucketMaskForLen(len(s.buckets))
+		if err != nil {
+			return nil
+		}
+		slot := (hash ^ cacheHashName(name)) & mask
+		for s.buckets[slot].used {
+			idx := s.buckets[slot].index
+			if s.views[idx].Hash == hash && s.views[idx].Name == name {
+				return &s.views[idx]
+			}
+			slot = (slot + 1) & mask
+		}
+		return nil
+	}
+
+	for i := range s.views {
+		if s.views[i].Hash == hash && s.views[i].Name == name {
+			return &s.views[i]
+		}
+	}
+	return nil
+}
+
 // Cache is an L3 client-side cgroups snapshot cache.
 type Cache struct {
-	client *Client
-	items  []CacheItem
-	// Open-addressing hash table: (hash ^ djb2(name)) -> index into items slice.
-	buckets []cacheBucket
+	writerMu sync.Mutex
+	mu       sync.RWMutex
 
-	systemdEnabled      uint32
-	generation          uint64
-	populated           bool
+	client   *Client
+	snapshot *cacheSnapshot
+
 	refreshSuccessCount uint32
 	refreshFailureCount uint32
-	epoch               time.Time // monotonic reference point
-	lastRefreshTs       int64     // elapsed ms since epoch
+	epoch               time.Time
+	lastRefreshTs       int64
 }
 
 func newCache(client *Client) *Cache {
@@ -69,13 +175,18 @@ func newCache(client *Client) *Cache {
 }
 
 // Refresh drives the L2 client and requests a fresh snapshot. On success,
-// it rebuilds the local cache. On failure, it preserves the previous cache.
+// it swaps in a new immutable snapshot. On failure, it preserves the previous
+// snapshot.
 func (c *Cache) Refresh() bool {
-	c.client.Refresh()
+	c.writerMu.Lock()
+	defer c.writerMu.Unlock()
 
+	c.client.Refresh()
 	view, err := c.client.CallSnapshot()
 	if err != nil {
+		c.mu.Lock()
 		c.refreshFailureCount++
+		c.mu.Unlock()
 		return false
 	}
 
@@ -83,7 +194,9 @@ func (c *Cache) Refresh() bool {
 	for i := uint32(0); i < view.ItemCount; i++ {
 		iv, ierr := view.Item(i)
 		if ierr != nil {
+			c.mu.Lock()
 			c.refreshFailureCount++
+			c.mu.Unlock()
 			return false
 		}
 		newItems = append(newItems, CacheItem{
@@ -95,37 +208,19 @@ func (c *Cache) Refresh() bool {
 		})
 	}
 
-	var buckets []cacheBucket
-	if len(newItems) > 0 {
-		itemCount, err := checkedLookupU32(len(newItems))
-		if err != nil {
-			c.refreshFailureCount++
-			return false
-		}
-		bcount, err := cacheBucketCountForItemCount(itemCount)
-		if err != nil {
-			c.refreshFailureCount++
-			return false
-		}
-		buckets = make([]cacheBucket, bcount)
-		mask := bcount - 1
-		for i := range newItems {
-			slot := (newItems[i].Hash ^ cacheHashName(newItems[i].Name)) & mask
-			for buckets[slot].used {
-				slot = (slot + 1) & mask
-			}
-			buckets[slot].index = i
-			buckets[slot].used = true
-		}
+	snapshot, err := buildCacheSnapshot(newItems, view.SystemdEnabled, view.Generation)
+	if err != nil {
+		c.mu.Lock()
+		c.refreshFailureCount++
+		c.mu.Unlock()
+		return false
 	}
 
-	c.items = newItems
-	c.buckets = buckets
-	c.systemdEnabled = view.SystemdEnabled
-	c.generation = view.Generation
-	c.populated = true
+	c.mu.Lock()
+	c.snapshot = snapshot
 	c.refreshSuccessCount++
 	c.lastRefreshTs = time.Since(c.epoch).Milliseconds()
+	c.mu.Unlock()
 
 	return true
 }
@@ -146,52 +241,98 @@ func cacheBucketCountForItemCount(itemCount uint32) (uint32, error) {
 
 // Ready returns true if at least one successful refresh has occurred.
 func (c *Cache) Ready() bool {
-	return c.populated
+	c.mu.RLock()
+	ready := c.snapshot != nil
+	c.mu.RUnlock()
+	return ready
 }
 
-// Lookup finds a cached item by hash + name. O(1) via open-addressing hash
-// table. No I/O.
-func (c *Cache) Lookup(hash uint32, name string) (CacheItem, bool) {
-	if !c.populated {
-		return CacheItem{}, false
+// CacheReadGuard protects borrowed cache views.
+type CacheReadGuard struct {
+	cache    *Cache
+	snapshot *cacheSnapshot
+	locked   bool
+}
+
+// ReadLock acquires a read guard for borrowed cache access.
+func (c *Cache) ReadLock() CacheReadGuard {
+	c.mu.RLock()
+	return CacheReadGuard{
+		cache:    c,
+		snapshot: c.snapshot,
+		locked:   true,
+	}
+}
+
+// Unlock releases a read guard.
+func (g *CacheReadGuard) Unlock() {
+	if g == nil || !g.locked {
+		return
+	}
+	cache := g.cache
+	g.cache = nil
+	g.snapshot = nil
+	g.locked = false
+	cache.mu.RUnlock()
+}
+
+// Get looks up a borrowed item view by hash + name. No I/O.
+func (g *CacheReadGuard) Get(hash uint32, name string) *CacheItemView {
+	if g == nil || !g.locked {
+		return nil
+	}
+	return g.snapshot.get(hash, name)
+}
+
+// Dup duplicates a borrowed view into an owned item that survives unlock.
+func (g *CacheReadGuard) Dup(view *CacheItemView) CacheItem {
+	if g == nil || !g.locked || view == nil {
+		return CacheItem{}
+	}
+	return view.Dup()
+}
+
+// SeedForTests publishes a synthetic immutable snapshot through the cache
+// write lock. It is for repository tests and benchmarks.
+func (c *Cache) SeedForTests(items []CacheItem, systemdEnabled uint32, generation uint64) bool {
+	snapshot, err := buildCacheSnapshot(items, systemdEnabled, generation)
+	if err != nil {
+		return false
 	}
 
-	if len(c.buckets) > 0 {
-		mask, err := cacheBucketMaskForLen(len(c.buckets))
-		if err != nil {
-			return CacheItem{}, false
-		}
-		slot := (hash ^ cacheHashName(name)) & mask
-		for c.buckets[slot].used {
-			item := &c.items[c.buckets[slot].index]
-			if item.Hash == hash && item.Name == name {
-				return *item, true
-			}
-			slot = (slot + 1) & mask
-		}
-		return CacheItem{}, false
-	}
+	c.writerMu.Lock()
+	defer c.writerMu.Unlock()
 
-	for i := range c.items {
-		if c.items[i].Hash == hash && c.items[i].Name == name {
-			return c.items[i], true
-		}
-	}
-	return CacheItem{}, false
+	c.mu.Lock()
+	c.snapshot = snapshot
+	c.refreshSuccessCount++
+	c.lastRefreshTs = time.Since(c.epoch).Milliseconds()
+	c.mu.Unlock()
+	return true
 }
 
 // Status returns a diagnostic snapshot for the L3 cache.
 func (c *Cache) Status() CacheStatus {
-	return CacheStatus{
-		Populated:           c.populated,
-		ItemCount:           cacheStatusItemCountForLen(len(c.items)),
-		SystemdEnabled:      c.systemdEnabled,
-		Generation:          c.generation,
+	c.writerMu.Lock()
+	connectionState := c.client.state
+	c.writerMu.Unlock()
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	status := CacheStatus{
 		RefreshSuccessCount: c.refreshSuccessCount,
 		RefreshFailureCount: c.refreshFailureCount,
-		ConnectionState:     c.client.state,
+		ConnectionState:     connectionState,
 		LastRefreshTs:       c.lastRefreshTs,
 	}
+	if c.snapshot != nil {
+		status.Populated = true
+		status.ItemCount = cacheStatusItemCountForLen(len(c.snapshot.items))
+		status.SystemdEnabled = c.snapshot.systemdEnabled
+		status.Generation = c.snapshot.generation
+	}
+	return status
 }
 
 func cacheBucketMaskForLen(bucketLen int) (uint32, error) {
@@ -208,7 +349,9 @@ func cacheStatusItemCountForLen(itemLen int) uint32 {
 
 // SetCallTimeout sets the context-level default timeout for refresh calls.
 func (c *Cache) SetCallTimeout(timeoutMs uint32) {
+	c.writerMu.Lock()
 	c.client.SetCallTimeout(timeoutMs)
+	c.writerMu.Unlock()
 }
 
 // Abort unblocks an in-flight refresh call.
@@ -223,8 +366,12 @@ func (c *Cache) ClearAbort() {
 
 // Close frees all cached items and closes the L2 client.
 func (c *Cache) Close() {
-	c.items = nil
-	c.buckets = nil
-	c.populated = false
+	c.writerMu.Lock()
+	defer c.writerMu.Unlock()
+
+	c.mu.Lock()
+	c.snapshot = nil
+	c.mu.Unlock()
+
 	c.client.Close()
 }

--- a/src/go/pkg/netipc/service/raw/edge_test.go
+++ b/src/go/pkg/netipc/service/raw/edge_test.go
@@ -276,8 +276,7 @@ func TestCacheLookupBeforeRefresh(t *testing.T) {
 		t.Fatal("should not be ready")
 	}
 
-	_, found := cache.Lookup(123, "anything")
-	if found {
+	if cacheHasForTest(cache, 123, "anything") {
 		t.Fatal("should not find items in empty cache")
 	}
 }
@@ -361,8 +360,7 @@ func TestCacheCloseResetsState(t *testing.T) {
 	if cache.Ready() {
 		t.Fatal("should not be ready after close")
 	}
-	_, found := cache.Lookup(1001, "docker-abc123")
-	if found {
+	if cacheHasForTest(cache, 1001, "docker-abc123") {
 		t.Fatal("should not find items after close")
 	}
 
@@ -419,19 +417,17 @@ func TestCacheLookupHashNameMismatch(t *testing.T) {
 	}
 
 	// Correct hash (1001), wrong name
-	_, found := cache.Lookup(1001, "wrong-name")
-	if found {
+	if cacheHasForTest(cache, 1001, "wrong-name") {
 		t.Fatal("should not find with wrong name")
 	}
 
 	// Wrong hash, correct name
-	_, found = cache.Lookup(9999, "docker-abc123")
-	if found {
+	if cacheHasForTest(cache, 9999, "docker-abc123") {
 		t.Fatal("should not find with wrong hash")
 	}
 
 	// Both correct
-	item, found := cache.Lookup(1001, "docker-abc123")
+	item, found := cacheDupForTest(cache, 1001, "docker-abc123")
 	if !found {
 		t.Fatal("should find with correct hash+name")
 	}

--- a/src/go/pkg/netipc/service/raw/more_windows_test.go
+++ b/src/go/pkg/netipc/service/raw/more_windows_test.go
@@ -883,7 +883,7 @@ func TestWinCacheLookupBeforeRefresh(t *testing.T) {
 	if cache.Ready() {
 		t.Fatal("cache should not be ready")
 	}
-	if _, found := cache.Lookup(123, "anything"); found {
+	if cacheHasForTest(cache, 123, "anything") {
 		t.Fatal("lookup before refresh should miss")
 	}
 }
@@ -916,7 +916,7 @@ func TestWinCacheFullRoundTrip(t *testing.T) {
 		t.Fatal("cache should be ready after refresh")
 	}
 
-	item, found := cache.Lookup(1001, "docker-abc123")
+	item, found := cacheDupForTest(cache, 1001, "docker-abc123")
 	if !found {
 		t.Fatal("expected cached item")
 	}
@@ -959,7 +959,7 @@ func TestWinCacheRefreshFailurePreserves(t *testing.T) {
 	if !cache.Ready() {
 		t.Fatal("cache should be ready")
 	}
-	if _, found := cache.Lookup(1001, "docker-abc123"); !found {
+	if !cacheHasForTest(cache, 1001, "docker-abc123") {
 		t.Fatal("expected first cached item")
 	}
 
@@ -972,7 +972,7 @@ func TestWinCacheRefreshFailurePreserves(t *testing.T) {
 	if !cache.Ready() {
 		t.Fatal("cache should preserve readiness")
 	}
-	if _, found := cache.Lookup(1001, "docker-abc123"); !found {
+	if !cacheHasForTest(cache, 1001, "docker-abc123") {
 		t.Fatal("old cache data should be preserved")
 	}
 
@@ -1018,13 +1018,13 @@ func TestWinCacheLookupHashNameMismatch(t *testing.T) {
 		t.Fatal("refresh should succeed")
 	}
 
-	if _, found := cache.Lookup(1001, "wrong-name"); found {
+	if cacheHasForTest(cache, 1001, "wrong-name") {
 		t.Fatal("lookup with wrong name should miss")
 	}
-	if _, found := cache.Lookup(9999, "docker-abc123"); found {
+	if cacheHasForTest(cache, 9999, "docker-abc123") {
 		t.Fatal("lookup with wrong hash should miss")
 	}
-	if item, found := cache.Lookup(1001, "docker-abc123"); !found || item.Hash != 1001 {
+	if item, found := cacheDupForTest(cache, 1001, "docker-abc123"); !found || item.Hash != 1001 {
 		t.Fatalf("expected exact hash+name match, got found=%v item=%+v", found, item)
 	}
 }
@@ -1042,7 +1042,7 @@ func TestWinCacheCloseResetsState(t *testing.T) {
 	if cache.Ready() {
 		t.Fatal("cache should not be ready after close")
 	}
-	if _, found := cache.Lookup(1001, "docker-abc123"); found {
+	if cacheHasForTest(cache, 1001, "docker-abc123") {
 		t.Fatal("lookup after close should miss")
 	}
 
@@ -1111,7 +1111,7 @@ func TestWinCacheLargeDataset(t *testing.T) {
 
 	for i := uint32(0); i < itemCount; i++ {
 		name := fmt.Sprintf("cgroup-%d", i)
-		item, found := cache.Lookup(i+1000, name)
+		item, found := cacheDupForTest(cache, i+1000, name)
 		if !found {
 			t.Fatalf("item %d not found", i)
 		}

--- a/src/go/pkg/netipc/service/raw/stress_test.go
+++ b/src/go/pkg/netipc/service/raw/stress_test.go
@@ -368,8 +368,8 @@ func TestStressConcurrentCacheClients(t *testing.T) {
 						r.failures++
 						continue
 					}
-					// Verify a lookup
-					item, found := cache.Lookup(1001, "docker-abc123")
+					// Verify a guarded lookup.
+					item, found := cacheDupForTest(cache, 1001, "docker-abc123")
 					if !found || item.Hash != 1001 ||
 						item.Path != "/sys/fs/cgroup/docker/abc123" {
 						r.failures++

--- a/src/go/pkg/netipc/transport/windows/shm.go
+++ b/src/go/pkg/netipc/transport/windows/shm.go
@@ -21,11 +21,12 @@ import (
 // ---------------------------------------------------------------------------
 
 const (
-	winShmMagic         uint32 = 0x4e535748 // "NSWH"
-	winShmVersion       uint32 = 3
-	winShmHeaderLen     uint32 = 128
-	winShmCachelineSize uint32 = 64
-	winShmDefaultSpin   uint32 = 1024
+	winShmMagic            uint32 = 0x4e535748 // "NSWH"
+	winShmVersion          uint32 = 3
+	winShmHeaderLen        uint32 = 128
+	winShmCachelineSize    uint32 = 64
+	winShmDefaultSpin      uint32 = 1024
+	winShmBusywaitPollMask uint32 = 1023
 
 	WinShmProfileHybrid   uint32 = 0x02
 	WinShmProfileBusywait uint32 = 0x04
@@ -407,7 +408,30 @@ func WinShmClientAttach(runDir, serviceName string, authToken, sessionID uint64,
 	respOff := binary.NativeEndian.Uint32(data[wshOFFRespOffset:])
 	respCap := binary.NativeEndian.Uint32(data[wshOFFRespCapacity:])
 	spin := binary.NativeEndian.Uint32(data[wshOFFSpinTries:])
-	regionSize := uintptr(respOff + respCap)
+	if reqOff == 0 || reqCap == 0 || respOff == 0 || respCap == 0 ||
+		reqOff < winShmHeaderLen || respOff < winShmHeaderLen ||
+		reqOff%winShmCachelineSize != 0 || reqCap%winShmCachelineSize != 0 ||
+		respOff%winShmCachelineSize != 0 || respCap%winShmCachelineSize != 0 ||
+		reqOff > ^uint32(0)-reqCap ||
+		respOff > ^uint32(0)-respCap {
+		procUnmapViewOfFile.Call(base)
+		syscall.CloseHandle(mapping)
+		return nil, ErrWinShmBadHeader
+	}
+	reqEnd := reqOff + reqCap
+	respEnd := respOff + respCap
+	if respOff < reqEnd {
+		procUnmapViewOfFile.Call(base)
+		syscall.CloseHandle(mapping)
+		return nil, ErrWinShmBadHeader
+	}
+	regionSize64 := uint64(respEnd)
+	regionSize := uintptr(regionSize64)
+	if uint64(regionSize) != regionSize64 {
+		procUnmapViewOfFile.Call(base)
+		syscall.CloseHandle(mapping)
+		return nil, ErrWinShmBadHeader
+	}
 
 	// Now reslice to full region
 	fullData := unsafe.Slice((*byte)(unsafe.Pointer(base)), regionSize)
@@ -624,12 +648,13 @@ func (c *WinShmContext) WinShmReceive(buf []byte, timeoutMs uint32) (int, error)
 	observed := false
 	var mlen int32
 	for i := uint32(0); i < c.SpinTries; i++ {
-		cur := atomic.LoadInt64((*int64)(unsafe.Pointer(&data[seqOff])))
-		if cur >= expectedSeq {
-			mlen = atomic.LoadInt32((*int32)(unsafe.Pointer(&data[lenOff])))
-			if mlen > 0 && int(mlen) <= maxCopy {
-				copy(buf[:mlen], data[areaOff:areaOff+uint32(mlen)])
-			}
+		var ok bool
+		var err error
+		mlen, ok, err = winShmCopyObserved(data, seqOff, lenOff, expectedSeq, areaOff, maxCopy, buf)
+		if err != nil {
+			return 0, err
+		}
+		if ok {
 			observed = true
 			break
 		}
@@ -649,9 +674,16 @@ func (c *WinShmContext) WinShmReceive(buf []byte, timeoutMs uint32) (int, error)
 				atomic.StoreInt32((*int32)(unsafe.Pointer(&data[selfWaitingOff])), 1)
 				atomic.LoadInt32((*int32)(unsafe.Pointer(&data[selfWaitingOff])))
 
-				cur := atomic.LoadInt64((*int64)(unsafe.Pointer(&data[seqOff])))
-				if cur >= expectedSeq {
+				var ok bool
+				var err error
+				mlen, ok, err = winShmCopyObserved(data, seqOff, lenOff, expectedSeq, areaOff, maxCopy, buf)
+				if err != nil {
 					atomic.StoreInt32((*int32)(unsafe.Pointer(&data[selfWaitingOff])), 0)
+					return 0, err
+				}
+				if ok {
+					atomic.StoreInt32((*int32)(unsafe.Pointer(&data[selfWaitingOff])), 0)
+					observed = true
 					break
 				}
 
@@ -669,14 +701,22 @@ func (c *WinShmContext) WinShmReceive(buf []byte, timeoutMs uint32) (int, error)
 				ret, _, _ := procWaitForSingleObj.Call(uintptr(waitEvent), waitMs)
 				atomic.StoreInt32((*int32)(unsafe.Pointer(&data[selfWaitingOff])), 0)
 
-				cur = atomic.LoadInt64((*int64)(unsafe.Pointer(&data[seqOff])))
-				if cur >= expectedSeq {
+				mlen, ok, err = winShmCopyObserved(data, seqOff, lenOff, expectedSeq, areaOff, maxCopy, buf)
+				if err != nil {
+					return 0, err
+				}
+				if ok {
+					observed = true
 					break
 				}
 
 				if atomic.LoadInt32((*int32)(unsafe.Pointer(&data[peerClosedOff]))) != 0 {
-					cur = atomic.LoadInt64((*int64)(unsafe.Pointer(&data[seqOff])))
-					if cur >= expectedSeq {
+					mlen, ok, err = winShmCopyObserved(data, seqOff, lenOff, expectedSeq, areaOff, maxCopy, buf)
+					if err != nil {
+						return 0, err
+					}
+					if ok {
+						observed = true
 						break
 					}
 					c.advanceSeq(expectedSeq)
@@ -688,20 +728,19 @@ func (c *WinShmContext) WinShmReceive(buf []byte, timeoutMs uint32) (int, error)
 				}
 			}
 
-			mlen = atomic.LoadInt32((*int32)(unsafe.Pointer(&data[lenOff])))
-			if mlen > 0 && int(mlen) <= maxCopy {
-				copy(buf[:mlen], data[areaOff:areaOff+uint32(mlen)])
-			}
 		} else {
 			// BUSYWAIT
 			start, _, _ := procGetTickCount64.Call()
+			var polls uint32
 			for {
-				cur := atomic.LoadInt64((*int64)(unsafe.Pointer(&data[seqOff])))
-				if cur >= expectedSeq {
-					mlen = atomic.LoadInt32((*int32)(unsafe.Pointer(&data[lenOff])))
-					if mlen > 0 && int(mlen) <= maxCopy {
-						copy(buf[:mlen], data[areaOff:areaOff+uint32(mlen)])
-					}
+				var ok bool
+				var err error
+				mlen, ok, err = winShmCopyObserved(data, seqOff, lenOff, expectedSeq, areaOff, maxCopy, buf)
+				if err != nil {
+					return 0, err
+				}
+				if ok {
+					observed = true
 					break
 				}
 
@@ -714,19 +753,24 @@ func (c *WinShmContext) WinShmReceive(buf []byte, timeoutMs uint32) (int, error)
 				}
 
 				if atomic.LoadInt32((*int32)(unsafe.Pointer(&data[peerClosedOff]))) != 0 {
-					cur := atomic.LoadInt64((*int64)(unsafe.Pointer(&data[seqOff])))
-					if cur >= expectedSeq {
-						mlen = atomic.LoadInt32((*int32)(unsafe.Pointer(&data[lenOff])))
-						if mlen > 0 && int(mlen) <= maxCopy {
-							copy(buf[:mlen], data[areaOff:areaOff+uint32(mlen)])
-						}
+					mlen, ok, err = winShmCopyObserved(data, seqOff, lenOff, expectedSeq, areaOff, maxCopy, buf)
+					if err != nil {
+						return 0, err
+					}
+					if ok {
+						observed = true
 						break
 					}
 					c.advanceSeq(expectedSeq)
 					return 0, ErrWinShmDisconnected
 				}
 
-				spinPause()
+				polls++
+				if polls&winShmBusywaitPollMask == 0 {
+					procSwitchToThread.Call()
+				} else {
+					spinPause()
+				}
 			}
 		}
 	}
@@ -738,6 +782,30 @@ func (c *WinShmContext) WinShmReceive(buf []byte, timeoutMs uint32) (int, error)
 	}
 
 	return int(mlen), nil
+}
+
+func winShmCopyObserved(data []byte, seqOff, lenOff int, expectedSeq int64, areaOff uint32, maxCopy int, buf []byte) (int32, bool, error) {
+	seqBefore := atomic.LoadInt64((*int64)(unsafe.Pointer(&data[seqOff])))
+	if seqBefore < expectedSeq {
+		return 0, false, nil
+	}
+
+	mlen := atomic.LoadInt32((*int32)(unsafe.Pointer(&data[lenOff])))
+	if mlen < 0 {
+		return 0, false, ErrWinShmBadHeader
+	}
+	if mlen > 0 && int(mlen) <= maxCopy {
+		off := int(areaOff)
+		copy(buf[:int(mlen)], data[off:off+int(mlen)])
+	}
+
+	lenAfter := atomic.LoadInt32((*int32)(unsafe.Pointer(&data[lenOff])))
+	seqAfter := atomic.LoadInt64((*int64)(unsafe.Pointer(&data[seqOff])))
+	if seqBefore != seqAfter || mlen != lenAfter {
+		return 0, false, ErrWinShmBadHeader
+	}
+
+	return mlen, true, nil
 }
 
 func (c *WinShmContext) advanceSeq(expectedSeq int64) {

--- a/src/libnetdata/netipc/include/netipc/netipc_named_pipe.h
+++ b/src/libnetdata/netipc/include/netipc/netipc_named_pipe.h
@@ -40,8 +40,8 @@ extern "C" {
 #define NIPC_NP_MAX_INSTANCES PIPE_UNLIMITED_INSTANCES
 
 /* FNV-1a 64-bit constants */
-#define NIPC_FNV1A_OFFSET_BASIS 0xcbf29ce484222325ull
-#define NIPC_FNV1A_PRIME        0x00000100000001B3ull
+#define NIPC_FNV1A_OFFSET_BASIS 0xcbf29ce484222325ULL
+#define NIPC_FNV1A_PRIME        0x00000100000001B3ULL
 
 /* ------------------------------------------------------------------ */
 /*  Error codes (transport-level)                                      */

--- a/src/libnetdata/netipc/include/netipc/netipc_service.h
+++ b/src/libnetdata/netipc/include/netipc/netipc_service.h
@@ -146,6 +146,8 @@ typedef struct {
   nipc_shm_ctx_t *shm; /* non-NULL if SHM profile negotiated */
   int abort_pipe[2];
   bool abort_pipe_valid;
+  pthread_mutex_t abort_pipe_lock;
+  bool abort_pipe_lock_initialized;
 #endif
 
   uint32_t call_timeout_ms;
@@ -325,7 +327,11 @@ typedef struct nipc_session_ctx {
   pthread_t thread;
 #endif
   uint64_t id;
+#if defined(_WIN32) || defined(__MSYS__)
+  volatile LONG active; /* use Interlocked* for cross-thread access */
+#else
   bool active; /* use __atomic builtins for cross-thread access */
+#endif
 } nipc_session_ctx_t;
 
 struct nipc_managed_server {
@@ -355,6 +361,7 @@ struct nipc_managed_server {
 #if defined(_WIN32) || defined(__MSYS__)
   volatile LONG running;
   volatile LONG accept_loop_active;
+  volatile LONG accept_loop_thread_id;
 #else
   bool running;
 #endif
@@ -422,6 +429,11 @@ nipc_server_init_raw_for_tests(nipc_managed_server_t *server,
 #endif
                                int worker_count, uint16_t expected_method_code,
                                nipc_server_handler_fn handler, void *user);
+
+nipc_error_t nipc_apps_lookup_remaining_timeout_for_tests(
+    nipc_client_ctx_t *ctx, uint64_t deadline_ms, uint32_t *timeout_out);
+nipc_error_t nipc_cgroups_lookup_remaining_timeout_for_tests(
+    nipc_client_ctx_t *ctx, uint64_t deadline_ms, uint32_t *timeout_out);
 
 #if defined(_WIN32) || defined(__MSYS__)
 typedef enum {
@@ -504,8 +516,25 @@ void nipc_server_destroy(nipc_managed_server_t *server);
 #define NIPC_CGROUPS_CACHE_BUF_SIZE_DEFAULT 65536
 
 /*
- * Cached copy of a single cgroup item. Owns its strings.
- * Built from ephemeral L2 views during cache construction.
+ * Borrowed view of a cached cgroup item.
+ *
+ * Returned by nipc_cgroups_cache_get() and valid only while the caller holds
+ * the read guard used for that lookup. Do not store this pointer, free it, or
+ * use it after nipc_cgroups_cache_read_unlock().
+ */
+typedef struct {
+  uint32_t hash;
+  uint32_t options;
+  uint32_t enabled;
+  const char *name; /* borrowed NUL-terminated string */
+  const char *path; /* borrowed NUL-terminated string */
+} nipc_cgroups_cache_item_view_t;
+
+/*
+ * Owned copy of a single cgroup item.
+ *
+ * Returned by nipc_cgroups_cache_item_dup(). The caller owns the returned item
+ * and must release it with nipc_cgroups_cache_item_free().
  */
 typedef struct {
   uint32_t hash;
@@ -541,25 +570,17 @@ typedef struct {
  * becomes empty only if no successful refresh has ever occurred.
  */
 
-/* Hash table bucket for O(1) cache lookup */
-typedef struct {
-  uint32_t index; /* index into items[] array */
-  bool used;      /* true if this bucket is occupied */
-} nipc_cgroups_hash_bucket_t;
+typedef struct nipc_cgroups_cache_snapshot nipc_cgroups_cache_snapshot_t;
 
 typedef struct {
   nipc_client_ctx_t client;
 
-  /* Cache data (owned) */
-  nipc_cgroups_cache_item_t *items;
-  uint32_t item_count;
-  uint32_t systemd_enabled;
-  uint64_t generation;
-  bool populated;
-
-  /* Hash table for O(1) lookup (open addressing, rebuilt on refresh) */
-  nipc_cgroups_hash_bucket_t *buckets;
-  uint32_t bucket_count; /* always a power of 2 */
+  /*
+   * Opaque immutable snapshot protected by cache_lock. Readers must acquire a
+   * read guard before accessing borrowed item views. Refresh builds a new
+   * snapshot privately and swaps it under the write lock.
+   */
+  nipc_cgroups_cache_snapshot_t *snapshot;
 
   /* Counters */
   uint32_t refresh_success_count;
@@ -569,7 +590,23 @@ typedef struct {
   /* Internal: response buffer for L2 calls */
   uint8_t *response_buf;
   size_t response_buf_size;
+
+#if defined(_WIN32) || defined(__MSYS__)
+  SRWLOCK cache_lock;
+  CRITICAL_SECTION writer_lock;
+#else
+  pthread_rwlock_t cache_lock;
+  pthread_mutex_t writer_lock;
+#endif
+  bool cache_lock_initialized;
+  bool writer_lock_initialized;
 } nipc_cgroups_cache_t;
+
+typedef struct {
+  nipc_cgroups_cache_t *cache;
+  const nipc_cgroups_cache_snapshot_t *snapshot;
+  bool locked;
+} nipc_cgroups_cache_read_guard_t;
 
 /*
  * Initialize an L3 cache. Creates the underlying L2 client context.
@@ -597,26 +634,60 @@ bool nipc_cgroups_cache_refresh(nipc_cgroups_cache_t *cache);
  *
  * Note: ready means "has cached data", not "is connected."
  */
-static inline bool nipc_cgroups_cache_ready(const nipc_cgroups_cache_t *cache) {
-  return cache->populated;
-}
+bool nipc_cgroups_cache_ready(nipc_cgroups_cache_t *cache);
+
+/*
+ * Acquire a read guard for borrowed cache access.
+ *
+ * While the guard is held, refresh can build a new snapshot in the background
+ * but cannot publish and retire the current snapshot. Always release a
+ * successful guard with nipc_cgroups_cache_read_unlock().
+ */
+bool nipc_cgroups_cache_read_lock(nipc_cgroups_cache_t *cache,
+                                  nipc_cgroups_cache_read_guard_t *guard);
+
+void nipc_cgroups_cache_read_unlock(nipc_cgroups_cache_read_guard_t *guard);
 
 /*
  * Look up a cached item by hash + name. Pure in-memory, no I/O.
  *
- * Returns a pointer to the cached item, or NULL if not found or
- * cache is empty. The returned pointer is valid until the next
- * successful refresh.
+ * Returns a borrowed immutable view, or NULL if not found or cache is empty.
+ * The returned view is valid only until nipc_cgroups_cache_read_unlock() is
+ * called on the guard.
  */
-const nipc_cgroups_cache_item_t *
-nipc_cgroups_cache_lookup(const nipc_cgroups_cache_t *cache, uint32_t hash,
-                          const char *name);
+const nipc_cgroups_cache_item_view_t *
+nipc_cgroups_cache_get(const nipc_cgroups_cache_read_guard_t *guard,
+                       uint32_t hash, const char *name);
+
+/*
+ * Duplicate a borrowed view into an owned item. The caller must hold the same
+ * read guard that protected the view. The returned item survives unlock and
+ * must be freed with nipc_cgroups_cache_item_free().
+ */
+nipc_cgroups_cache_item_t *
+nipc_cgroups_cache_item_dup(const nipc_cgroups_cache_read_guard_t *guard,
+                            const nipc_cgroups_cache_item_view_t *view);
+
+void nipc_cgroups_cache_item_free(nipc_cgroups_cache_item_t *item);
 
 /*
  * Fill a status snapshot for diagnostics.
  */
-void nipc_cgroups_cache_status(const nipc_cgroups_cache_t *cache,
+void nipc_cgroups_cache_status(nipc_cgroups_cache_t *cache,
                                nipc_cgroups_cache_status_t *out);
+
+#ifdef NIPC_INTERNAL_TESTING
+/*
+ * Internal test/benchmark helper. Seeds the cache from owned copies of the
+ * supplied items and publishes the snapshot through the same write lock used by
+ * refresh. Not part of the public L3 cache contract.
+ */
+bool nipc_cgroups_cache_seed_for_tests(nipc_cgroups_cache_t *cache,
+                                       const nipc_cgroups_cache_item_t *items,
+                                       uint32_t item_count,
+                                       uint32_t systemd_enabled,
+                                       uint64_t generation);
+#endif
 
 /*
  * Close the cache: free all cached items, close the L2 client.

--- a/src/libnetdata/netipc/src/protocol/netipc_protocol.c
+++ b/src/libnetdata/netipc/src/protocol/netipc_protocol.c
@@ -325,6 +325,7 @@ nipc_error_t nipc_hello_decode(const void *buf, size_t buf_len,
     if (buf_len < NIPC_HELLO_WIRE_SIZE)
         return NIPC_ERR_TRUNCATED;
 
+    memset(out, 0, sizeof(*out));
     memcpy(out, buf, NIPC_HELLO_WIRE_SIZE);
 
     if (out->layout_version != 1)

--- a/src/libnetdata/netipc/src/protocol/netipc_protocol_apps_lookup.c
+++ b/src/libnetdata/netipc/src/protocol/netipc_protocol_apps_lookup.c
@@ -222,24 +222,42 @@ nipc_error_t nipc_apps_lookup_req_decode(const void *buf, size_t buf_len,
 nipc_error_t nipc_apps_lookup_req_item(const nipc_apps_lookup_req_view_t *view,
                                        uint32_t index,
                                        nipc_apps_lookup_req_item_t *out) {
+  if (!view || !out || !view->_payload)
+    return NIPC_ERR_BAD_LAYOUT;
   if (index >= view->item_count)
     return NIPC_ERR_OUT_OF_BOUNDS;
 
   /* Decode validates this, but item accessors are public and may be
    * called with manually constructed views. */
-  if (mul_would_overflow((size_t)view->item_count, NIPC_LOOKUP_DIR_ENTRY_SIZE))
+  if (mul_would_overflow((size_t)view->item_count, NIPC_LOOKUP_DIR_ENTRY_SIZE) ||
+      mul_would_overflow((size_t)view->item_count, NIPC_APPS_LOOKUP_KEY_SIZE))
     return NIPC_ERR_BAD_ITEM_COUNT;
 
   size_t dir_size = (size_t)view->item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+#if SIZE_MAX <= UINT32_MAX
+  if (NIPC_APPS_LOOKUP_REQ_HDR_SIZE > SIZE_MAX - dir_size)
+    return NIPC_ERR_BAD_ITEM_COUNT;
+#endif
   size_t dir_end = NIPC_APPS_LOOKUP_REQ_HDR_SIZE + dir_size;
+  if (dir_end > view->_payload_len)
+    return NIPC_ERR_TRUNCATED;
+  size_t packed_area_len = view->_payload_len - dir_end;
   const uint8_t *dir = view->_payload + NIPC_APPS_LOOKUP_REQ_HDR_SIZE;
   const uint8_t *packed = view->_payload + dir_end;
 
   nipc_lookup_dir_entry_t entry;
   memcpy(&entry, dir + (size_t)index * NIPC_LOOKUP_DIR_ENTRY_SIZE,
          sizeof(entry));
+  if (entry.offset % NIPC_ALIGNMENT != 0)
+    return NIPC_ERR_BAD_ALIGNMENT;
+  if (entry.length != NIPC_APPS_LOOKUP_KEY_SIZE)
+    return NIPC_ERR_BAD_LAYOUT;
+  if ((uint64_t)entry.offset + entry.length > packed_area_len)
+    return NIPC_ERR_OUT_OF_BOUNDS;
   nipc_apps_lookup_key_wire_t key;
   memcpy(&key, packed + entry.offset, sizeof(key));
+  if (key.reserved != 0)
+    return NIPC_ERR_BAD_LAYOUT;
   out->pid = key.pid;
   return NIPC_OK;
 }
@@ -373,6 +391,8 @@ nipc_error_t nipc_apps_lookup_resp_decode(const void *buf, size_t buf_len,
 nipc_error_t
 nipc_apps_lookup_resp_item(const nipc_apps_lookup_resp_view_t *view,
                            uint32_t index, nipc_apps_lookup_item_view_t *out) {
+  if (!view || !out || !view->_payload)
+    return NIPC_ERR_BAD_LAYOUT;
   if (index >= view->item_count)
     return NIPC_ERR_OUT_OF_BOUNDS;
 
@@ -382,14 +402,23 @@ nipc_apps_lookup_resp_item(const nipc_apps_lookup_resp_view_t *view,
     return NIPC_ERR_BAD_ITEM_COUNT;
 
   size_t dir_size = (size_t)view->item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+#if SIZE_MAX <= UINT32_MAX
   if (NIPC_APPS_LOOKUP_RESP_HDR_SIZE > SIZE_MAX - dir_size)
     return NIPC_ERR_BAD_ITEM_COUNT;
+#endif
   size_t dir_end = NIPC_APPS_LOOKUP_RESP_HDR_SIZE + dir_size;
+  if (dir_end > view->_payload_len)
+    return NIPC_ERR_TRUNCATED;
+  size_t packed_area_len = view->_payload_len - dir_end;
   const uint8_t *dir = view->_payload + NIPC_APPS_LOOKUP_RESP_HDR_SIZE;
   const uint8_t *packed = view->_payload + dir_end;
   nipc_lookup_dir_entry_t entry;
   memcpy(&entry, dir + (size_t)index * NIPC_LOOKUP_DIR_ENTRY_SIZE,
          sizeof(entry));
+  if (entry.offset % NIPC_ALIGNMENT != 0)
+    return NIPC_ERR_BAD_ALIGNMENT;
+  if ((uint64_t)entry.offset + entry.length > packed_area_len)
+    return NIPC_ERR_OUT_OF_BOUNDS;
   return apps_lookup_decode_item_bytes(packed + entry.offset, entry.length,
                                        out);
 }
@@ -398,12 +427,18 @@ nipc_error_t
 nipc_apps_lookup_resp_raw_item(const nipc_apps_lookup_resp_view_t *view,
                                uint32_t index, const uint8_t **item_out,
                                uint32_t *item_len_out) {
+  if (!view || !item_out || !item_len_out || !view->_payload)
+    return NIPC_ERR_BAD_LAYOUT;
   if (index >= view->item_count)
     return NIPC_ERR_OUT_OF_BOUNDS;
   if (mul_would_overflow((size_t)view->item_count, NIPC_LOOKUP_DIR_ENTRY_SIZE))
     return NIPC_ERR_BAD_ITEM_COUNT;
 
   size_t dir_size = (size_t)view->item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+#if SIZE_MAX <= UINT32_MAX
+  if (NIPC_APPS_LOOKUP_RESP_HDR_SIZE > SIZE_MAX - dir_size)
+    return NIPC_ERR_BAD_ITEM_COUNT;
+#endif
   size_t dir_end = NIPC_APPS_LOOKUP_RESP_HDR_SIZE + dir_size;
   if (dir_end > view->_payload_len)
     return NIPC_ERR_TRUNCATED;
@@ -413,6 +448,8 @@ nipc_apps_lookup_resp_raw_item(const nipc_apps_lookup_resp_view_t *view,
   nipc_lookup_dir_entry_t entry;
   memcpy(&entry, dir + (size_t)index * NIPC_LOOKUP_DIR_ENTRY_SIZE,
          sizeof(entry));
+  if (entry.offset % NIPC_ALIGNMENT != 0)
+    return NIPC_ERR_BAD_ALIGNMENT;
   uint64_t end;
   if (nipc_lookup_add_u64_over_limit(entry.offset, entry.length,
                                      view->_payload_len - dir_end, &end))
@@ -432,8 +469,10 @@ nipc_error_t nipc_apps_lookup_raw_resp_encode(
 
   uint8_t *out = (uint8_t *)buf;
   size_t dir_size = (size_t)item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+#if SIZE_MAX <= UINT32_MAX
   if (NIPC_APPS_LOOKUP_RESP_HDR_SIZE > SIZE_MAX - dir_size)
     return NIPC_ERR_OVERFLOW;
+#endif
   size_t data_offset = NIPC_APPS_LOOKUP_RESP_HDR_SIZE + dir_size;
   if (data_offset > buf_len)
     return NIPC_ERR_OVERFLOW;
@@ -708,9 +747,11 @@ nipc_error_t nipc_dispatch_apps_lookup(const uint8_t *req, size_t req_len,
 
   uint32_t *payload_exceeded_suffix_bytes = NULL;
   if (request.item_count > 0) {
+#if SIZE_MAX <= UINT32_MAX
     if ((size_t)request.item_count >=
         ((size_t)-1) / sizeof(*payload_exceeded_suffix_bytes))
       return NIPC_ERR_OVERFLOW;
+#endif
     payload_exceeded_suffix_bytes =
         (uint32_t *)malloc(((size_t)request.item_count + 1u) *
                            sizeof(*payload_exceeded_suffix_bytes));

--- a/src/libnetdata/netipc/src/protocol/netipc_protocol_cgroups_lookup.c
+++ b/src/libnetdata/netipc/src/protocol/netipc_protocol_cgroups_lookup.c
@@ -156,6 +156,8 @@ nipc_error_t
 nipc_cgroups_lookup_req_item(const nipc_cgroups_lookup_req_view_t *view,
                              uint32_t index,
                              nipc_cgroups_lookup_req_item_t *out) {
+  if (!view || !out || !view->_payload)
+    return NIPC_ERR_BAD_LAYOUT;
   if (index >= view->item_count)
     return NIPC_ERR_OUT_OF_BOUNDS;
 
@@ -165,14 +167,33 @@ nipc_cgroups_lookup_req_item(const nipc_cgroups_lookup_req_view_t *view,
     return NIPC_ERR_BAD_ITEM_COUNT;
 
   size_t dir_size = (size_t)view->item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+#if SIZE_MAX <= UINT32_MAX
+  if (NIPC_CGROUPS_LOOKUP_REQ_HDR_SIZE > SIZE_MAX - dir_size)
+    return NIPC_ERR_BAD_ITEM_COUNT;
+#endif
   size_t dir_end = NIPC_CGROUPS_LOOKUP_REQ_HDR_SIZE + dir_size;
+  if (dir_end > view->_payload_len)
+    return NIPC_ERR_TRUNCATED;
+  size_t packed_area_len = view->_payload_len - dir_end;
   const uint8_t *dir = view->_payload + NIPC_CGROUPS_LOOKUP_REQ_HDR_SIZE;
   const uint8_t *packed = view->_payload + dir_end;
 
   nipc_lookup_dir_entry_t entry;
   memcpy(&entry, dir + (size_t)index * NIPC_LOOKUP_DIR_ENTRY_SIZE,
          sizeof(entry));
-  out->path.ptr = (const char *)(packed + entry.offset);
+  if (entry.offset % NIPC_ALIGNMENT != 0)
+    return NIPC_ERR_BAD_ALIGNMENT;
+  if ((uint64_t)entry.offset + entry.length > packed_area_len)
+    return NIPC_ERR_OUT_OF_BOUNDS;
+  if (entry.length < 2)
+    return NIPC_ERR_TRUNCATED;
+  const uint8_t *key = packed + entry.offset;
+  if (key[entry.length - 1] != '\0')
+    return NIPC_ERR_MISSING_NUL;
+  if (nipc_lookup_bytes_have_nul(key, entry.length - 1))
+    return NIPC_ERR_BAD_LAYOUT;
+
+  out->path.ptr = (const char *)key;
   out->path.len = entry.length - 1;
   return NIPC_OK;
 }
@@ -288,6 +309,8 @@ nipc_error_t
 nipc_cgroups_lookup_resp_item(const nipc_cgroups_lookup_resp_view_t *view,
                               uint32_t index,
                               nipc_cgroups_lookup_item_view_t *out) {
+  if (!view || !out || !view->_payload)
+    return NIPC_ERR_BAD_LAYOUT;
   if (index >= view->item_count)
     return NIPC_ERR_OUT_OF_BOUNDS;
 
@@ -297,14 +320,23 @@ nipc_cgroups_lookup_resp_item(const nipc_cgroups_lookup_resp_view_t *view,
     return NIPC_ERR_BAD_ITEM_COUNT;
 
   size_t dir_size = (size_t)view->item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+#if SIZE_MAX <= UINT32_MAX
   if (NIPC_CGROUPS_LOOKUP_RESP_HDR_SIZE > SIZE_MAX - dir_size)
     return NIPC_ERR_BAD_ITEM_COUNT;
+#endif
   size_t dir_end = NIPC_CGROUPS_LOOKUP_RESP_HDR_SIZE + dir_size;
+  if (dir_end > view->_payload_len)
+    return NIPC_ERR_TRUNCATED;
+  size_t packed_area_len = view->_payload_len - dir_end;
   const uint8_t *dir = view->_payload + NIPC_CGROUPS_LOOKUP_RESP_HDR_SIZE;
   const uint8_t *packed = view->_payload + dir_end;
   nipc_lookup_dir_entry_t entry;
   memcpy(&entry, dir + (size_t)index * NIPC_LOOKUP_DIR_ENTRY_SIZE,
          sizeof(entry));
+  if (entry.offset % NIPC_ALIGNMENT != 0)
+    return NIPC_ERR_BAD_ALIGNMENT;
+  if ((uint64_t)entry.offset + entry.length > packed_area_len)
+    return NIPC_ERR_OUT_OF_BOUNDS;
   return cgroups_lookup_decode_item_bytes(packed + entry.offset, entry.length,
                                           out);
 }
@@ -313,12 +345,18 @@ nipc_error_t
 nipc_cgroups_lookup_resp_raw_item(const nipc_cgroups_lookup_resp_view_t *view,
                                   uint32_t index, const uint8_t **item_out,
                                   uint32_t *item_len_out) {
+  if (!view || !item_out || !item_len_out || !view->_payload)
+    return NIPC_ERR_BAD_LAYOUT;
   if (index >= view->item_count)
     return NIPC_ERR_OUT_OF_BOUNDS;
   if (mul_would_overflow((size_t)view->item_count, NIPC_LOOKUP_DIR_ENTRY_SIZE))
     return NIPC_ERR_BAD_ITEM_COUNT;
 
   size_t dir_size = (size_t)view->item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+#if SIZE_MAX <= UINT32_MAX
+  if (NIPC_CGROUPS_LOOKUP_RESP_HDR_SIZE > SIZE_MAX - dir_size)
+    return NIPC_ERR_BAD_ITEM_COUNT;
+#endif
   size_t dir_end = NIPC_CGROUPS_LOOKUP_RESP_HDR_SIZE + dir_size;
   if (dir_end > view->_payload_len)
     return NIPC_ERR_TRUNCATED;
@@ -328,6 +366,8 @@ nipc_cgroups_lookup_resp_raw_item(const nipc_cgroups_lookup_resp_view_t *view,
   nipc_lookup_dir_entry_t entry;
   memcpy(&entry, dir + (size_t)index * NIPC_LOOKUP_DIR_ENTRY_SIZE,
          sizeof(entry));
+  if (entry.offset % NIPC_ALIGNMENT != 0)
+    return NIPC_ERR_BAD_ALIGNMENT;
   uint64_t end;
   if (nipc_lookup_add_u64_over_limit(entry.offset, entry.length,
                                      view->_payload_len - dir_end, &end))
@@ -347,8 +387,10 @@ nipc_error_t nipc_cgroups_lookup_raw_resp_encode(
 
   uint8_t *out = (uint8_t *)buf;
   size_t dir_size = (size_t)item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+#if SIZE_MAX <= UINT32_MAX
   if (NIPC_CGROUPS_LOOKUP_RESP_HDR_SIZE > SIZE_MAX - dir_size)
     return NIPC_ERR_OVERFLOW;
+#endif
   size_t data_offset = NIPC_CGROUPS_LOOKUP_RESP_HDR_SIZE + dir_size;
   if (data_offset > buf_len)
     return NIPC_ERR_OVERFLOW;
@@ -634,9 +676,11 @@ nipc_error_t nipc_dispatch_cgroups_lookup(
 
   uint32_t *payload_exceeded_suffix_bytes = NULL;
   if (request.item_count > 0) {
+#if SIZE_MAX <= UINT32_MAX
     if ((size_t)request.item_count >=
         ((size_t)-1) / sizeof(*payload_exceeded_suffix_bytes))
       return NIPC_ERR_OVERFLOW;
+#endif
     payload_exceeded_suffix_bytes =
         (uint32_t *)malloc(((size_t)request.item_count + 1u) *
                            sizeof(*payload_exceeded_suffix_bytes));

--- a/src/libnetdata/netipc/src/protocol/netipc_protocol_cgroups_snapshot.c
+++ b/src/libnetdata/netipc/src/protocol/netipc_protocol_cgroups_snapshot.c
@@ -102,6 +102,8 @@ nipc_error_t nipc_cgroups_resp_decode(const void *buf, size_t buf_len,
 nipc_error_t nipc_cgroups_resp_item(const nipc_cgroups_resp_view_t *view,
                                     uint32_t index,
                                     nipc_cgroups_item_view_t *out) {
+    if (!view || !out || !view->_payload)
+        return NIPC_ERR_BAD_LAYOUT;
     if (index >= view->item_count)
         return NIPC_ERR_OUT_OF_BOUNDS;
 
@@ -112,13 +114,26 @@ nipc_error_t nipc_cgroups_resp_item(const nipc_cgroups_resp_view_t *view,
 
     size_t dir_start = NIPC_CGROUPS_RESP_HDR_SIZE;
     size_t dir_size  = (size_t)view->item_count * NIPC_CGROUPS_DIR_ENTRY_SIZE;
+#if SIZE_MAX <= UINT32_MAX
+    if (dir_start > SIZE_MAX - dir_size)
+        return NIPC_ERR_BAD_ITEM_COUNT;
+#endif
     size_t packed_area_start = dir_start + dir_size;
+    if (packed_area_start > view->_payload_len)
+        return NIPC_ERR_TRUNCATED;
+    size_t packed_area_len = view->_payload_len - packed_area_start;
 
     /* Read directory entry */
     nipc_batch_entry_t dir_entry;
     memcpy(&dir_entry,
            view->_payload + dir_start + index * sizeof(dir_entry),
            sizeof(dir_entry));
+    if (dir_entry.offset % NIPC_ALIGNMENT != 0)
+        return NIPC_ERR_BAD_ALIGNMENT;
+    if ((uint64_t)dir_entry.offset + dir_entry.length > packed_area_len)
+        return NIPC_ERR_OUT_OF_BOUNDS;
+    if (dir_entry.length < NIPC_CGROUPS_ITEM_HDR_SIZE)
+        return NIPC_ERR_TRUNCATED;
 
     const uint8_t *item = view->_payload + packed_area_start + dir_entry.offset;
     uint32_t item_len = dir_entry.length;

--- a/src/libnetdata/netipc/src/protocol/netipc_protocol_string_reverse.c
+++ b/src/libnetdata/netipc/src/protocol/netipc_protocol_string_reverse.c
@@ -36,6 +36,8 @@ nipc_error_t nipc_string_reverse_decode(const void *buf, size_t buf_len,
     memcpy(&str_offset, p + 0, 4);
     memcpy(&str_length, p + 4, 4);
 
+    if (str_offset != NIPC_STRING_REVERSE_HDR_SIZE)
+        return NIPC_ERR_BAD_LAYOUT;
     if ((uint64_t)str_offset + str_length + 1 > buf_len)
         return NIPC_ERR_OUT_OF_BOUNDS;
 

--- a/src/libnetdata/netipc/src/service/netipc_service_apps_lookup.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_apps_lookup.c
@@ -100,12 +100,16 @@ static nipc_error_t apps_lookup_remaining_timeout(nipc_client_ctx_t *ctx,
   return NIPC_OK;
 }
 
+nipc_error_t nipc_apps_lookup_remaining_timeout_for_tests(
+    nipc_client_ctx_t *ctx, uint64_t deadline_ms, uint32_t *timeout_out) {
+  return apps_lookup_remaining_timeout(ctx, deadline_ms, timeout_out);
+}
+
 static nipc_error_t
 apps_lookup_next_request_count(nipc_client_ctx_t *ctx, uint32_t remaining,
                                uint32_t *count_out, size_t *size_out) {
   if (remaining == 0) {
-    if (!apps_lookup_request_size(0, size_out))
-      return NIPC_ERR_OVERFLOW;
+    *size_out = NIPC_APPS_LOOKUP_REQ_HDR_SIZE;
     *count_out = 0;
     return NIPC_OK;
   }

--- a/src/libnetdata/netipc/src/service/netipc_service_cgroups_cache.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_cgroups_cache.c
@@ -28,18 +28,57 @@ bool nipc_cgroups_cache_refresh(nipc_cgroups_cache_t *cache)
     return nipc_service_common_cgroups_cache_refresh(cache, &cgroups_cache_ops);
 }
 
-const nipc_cgroups_cache_item_t *nipc_cgroups_cache_lookup(
-    const nipc_cgroups_cache_t *cache,
-    uint32_t hash,
-    const char *name)
+bool nipc_cgroups_cache_ready(nipc_cgroups_cache_t *cache)
 {
-    return nipc_service_common_cgroups_cache_lookup(cache, hash, name);
+    return nipc_service_common_cgroups_cache_ready(cache);
 }
 
-void nipc_cgroups_cache_status(const nipc_cgroups_cache_t *cache,
+bool nipc_cgroups_cache_read_lock(nipc_cgroups_cache_t *cache,
+                                  nipc_cgroups_cache_read_guard_t *guard)
+{
+    return nipc_service_common_cgroups_cache_read_lock(cache, guard);
+}
+
+void nipc_cgroups_cache_read_unlock(nipc_cgroups_cache_read_guard_t *guard)
+{
+    nipc_service_common_cgroups_cache_read_unlock(guard);
+}
+
+const nipc_cgroups_cache_item_view_t *
+nipc_cgroups_cache_get(const nipc_cgroups_cache_read_guard_t *guard,
+                       uint32_t hash,
+                       const char *name)
+{
+    return nipc_service_common_cgroups_cache_get(guard, hash, name);
+}
+
+nipc_cgroups_cache_item_t *
+nipc_cgroups_cache_item_dup(const nipc_cgroups_cache_read_guard_t *guard,
+                            const nipc_cgroups_cache_item_view_t *view)
+{
+    return nipc_service_common_cgroups_cache_item_dup(guard, view);
+}
+
+void nipc_cgroups_cache_item_free(nipc_cgroups_cache_item_t *item)
+{
+    nipc_service_common_cgroups_cache_item_free(item);
+}
+
+void nipc_cgroups_cache_status(nipc_cgroups_cache_t *cache,
                                nipc_cgroups_cache_status_t *out)
 {
     nipc_service_common_cgroups_cache_status(cache, out);
+}
+
+bool nipc_cgroups_cache_seed_for_tests(nipc_cgroups_cache_t *cache,
+                                       const nipc_cgroups_cache_item_t *items,
+                                       uint32_t item_count,
+                                       uint32_t systemd_enabled,
+                                       uint64_t generation)
+{
+    return nipc_service_common_cgroups_cache_seed_for_tests(
+        cache, items, item_count, systemd_enabled, generation,
+        &cgroups_cache_ops);
 }
 
 void nipc_cgroups_cache_close(nipc_cgroups_cache_t *cache)

--- a/src/libnetdata/netipc/src/service/netipc_service_cgroups_cache_common.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_cgroups_cache_common.c
@@ -5,6 +5,29 @@
 #include <stdlib.h>
 #include <string.h>
 
+typedef struct {
+    uint32_t index; /* index into items[] and views[] */
+    bool used;
+} nipc_cgroups_cache_bucket_t;
+
+struct nipc_cgroups_cache_snapshot {
+    nipc_cgroups_cache_item_t *items;
+    nipc_cgroups_cache_item_view_t *views;
+    uint32_t item_count;
+    uint32_t systemd_enabled;
+    uint64_t generation;
+    nipc_cgroups_cache_bucket_t *buckets;
+    uint32_t bucket_count; /* always a power of 2 when non-zero */
+};
+
+static uint32_t cache_hash_name(const char *name)
+{
+    uint32_t h = 5381;
+    for (const unsigned char *p = (const unsigned char *)name; *p; p++)
+        h = ((h << 5) + h) + *p;
+    return h;
+}
+
 static void cache_free_items(nipc_cgroups_cache_item_t *items, uint32_t count)
 {
     if (!items)
@@ -17,34 +40,41 @@ static void cache_free_items(nipc_cgroups_cache_item_t *items, uint32_t count)
     free(items);
 }
 
-static uint32_t cache_hash_name(const char *name)
+static void cache_snapshot_free(nipc_cgroups_cache_snapshot_t *snapshot)
 {
-    uint32_t h = 5381;
-    for (const unsigned char *p = (const unsigned char *)name; *p; p++)
-        h = ((h << 5) + h) + *p;
-    return h;
+    if (!snapshot)
+        return;
+
+    cache_free_items(snapshot->items, snapshot->item_count);
+    free(snapshot->views);
+    free(snapshot->buckets);
+    free(snapshot);
 }
 
-static bool cache_build_hashtable(nipc_cgroups_cache_t *cache,
+static bool cache_build_hashtable(nipc_cgroups_cache_snapshot_t *snapshot,
                                   const nipc_service_common_cache_ops_t *ops)
 {
-    free(cache->buckets);
-    cache->buckets = NULL;
-    cache->bucket_count = 0;
-
-    if (cache->item_count == 0)
+    if (snapshot->item_count == 0)
         return true;
 
-    uint32_t bcount = nipc_service_common_next_power_of_2_u32(cache->item_count * 2);
-    nipc_cgroups_hash_bucket_t *buckets = ops->calloc_fn(
-        bcount, sizeof(nipc_cgroups_hash_bucket_t),
+    if (snapshot->item_count > UINT32_MAX / 2)
+        return false;
+
+    uint32_t bcount =
+        nipc_service_common_next_power_of_2_u32(snapshot->item_count * 2);
+    if (bcount == 0)
+        return false;
+
+    nipc_cgroups_cache_bucket_t *buckets = ops->calloc_fn(
+        bcount, sizeof(nipc_cgroups_cache_bucket_t),
         ops->cache_buckets_fault_site);
     if (!buckets)
         return false;
 
     uint32_t mask = bcount - 1;
-    for (uint32_t i = 0; i < cache->item_count; i++) {
-        uint32_t key = cache->items[i].hash ^ cache_hash_name(cache->items[i].name);
+    for (uint32_t i = 0; i < snapshot->item_count; i++) {
+        uint32_t key = snapshot->items[i].hash ^
+                       cache_hash_name(snapshot->items[i].name);
         uint32_t slot = key & mask;
 
         while (buckets[slot].used)
@@ -54,64 +84,279 @@ static bool cache_build_hashtable(nipc_cgroups_cache_t *cache,
         buckets[slot].used = true;
     }
 
-    cache->buckets = buckets;
-    cache->bucket_count = bcount;
+    snapshot->buckets = buckets;
+    snapshot->bucket_count = bcount;
     return true;
 }
 
-static nipc_cgroups_cache_item_t *cache_build_items(
-    const nipc_cgroups_resp_view_t *view,
-    const nipc_service_common_cache_ops_t *ops,
-    uint32_t *count_out)
+static bool cache_copy_str(char **dst,
+                           const char *src,
+                           size_t len,
+                           const nipc_service_common_cache_ops_t *ops,
+                           int fault_site)
 {
-    uint32_t n = view->item_count;
-    *count_out = 0;
+    *dst = ops->malloc_fn(len + 1, fault_site);
+    if (!*dst)
+        return false;
+    if (len > 0)
+        memcpy(*dst, src, len);
+    (*dst)[len] = '\0';
+    return true;
+}
 
-    if (n == 0)
+static nipc_cgroups_cache_snapshot_t *cache_snapshot_build(
+    const nipc_cgroups_resp_view_t *view,
+    const nipc_service_common_cache_ops_t *ops)
+{
+    nipc_cgroups_cache_snapshot_t *snapshot =
+        calloc(1, sizeof(nipc_cgroups_cache_snapshot_t));
+    if (!snapshot)
         return NULL;
 
-    nipc_cgroups_cache_item_t *items = ops->calloc_fn(
-        n, sizeof(nipc_cgroups_cache_item_t),
-        ops->cache_items_fault_site);
-    if (!items)
-        return NULL;
+    snapshot->item_count = view->item_count;
+    snapshot->systemd_enabled = view->systemd_enabled;
+    snapshot->generation = view->generation;
 
-    for (uint32_t i = 0; i < n; i++) {
+    if (view->item_count == 0)
+        return snapshot;
+
+    snapshot->items = ops->calloc_fn(view->item_count,
+                                     sizeof(nipc_cgroups_cache_item_t),
+                                     ops->cache_items_fault_site);
+    if (!snapshot->items) {
+        cache_snapshot_free(snapshot);
+        return NULL;
+    }
+
+    snapshot->views = calloc(view->item_count,
+                             sizeof(nipc_cgroups_cache_item_view_t));
+    if (!snapshot->views) {
+        cache_snapshot_free(snapshot);
+        return NULL;
+    }
+
+    for (uint32_t i = 0; i < view->item_count; i++) {
         nipc_cgroups_item_view_t iv;
         nipc_error_t err = nipc_cgroups_resp_item(view, i, &iv);
         if (err != NIPC_OK) {
-            cache_free_items(items, i);
+            cache_snapshot_free(snapshot);
             return NULL;
         }
 
-        items[i].hash = iv.hash;
-        items[i].options = iv.options;
-        items[i].enabled = iv.enabled;
+        snapshot->items[i].hash = iv.hash;
+        snapshot->items[i].options = iv.options;
+        snapshot->items[i].enabled = iv.enabled;
 
-        items[i].name = ops->malloc_fn(
-            iv.name.len + 1, ops->cache_item_name_fault_site);
-        if (!items[i].name) {
-            cache_free_items(items, i);
+        if (!cache_copy_str(&snapshot->items[i].name, iv.name.ptr, iv.name.len,
+                            ops, ops->cache_item_name_fault_site) ||
+            !cache_copy_str(&snapshot->items[i].path, iv.path.ptr, iv.path.len,
+                            ops, ops->cache_item_path_fault_site)) {
+            cache_snapshot_free(snapshot);
             return NULL;
         }
-        if (iv.name.len > 0)
-            memcpy(items[i].name, iv.name.ptr, iv.name.len);
-        items[i].name[iv.name.len] = '\0';
 
-        items[i].path = ops->malloc_fn(
-            iv.path.len + 1, ops->cache_item_path_fault_site);
-        if (!items[i].path) {
-            free(items[i].name);
-            cache_free_items(items, i);
-            return NULL;
-        }
-        if (iv.path.len > 0)
-            memcpy(items[i].path, iv.path.ptr, iv.path.len);
-        items[i].path[iv.path.len] = '\0';
+        snapshot->views[i].hash = snapshot->items[i].hash;
+        snapshot->views[i].options = snapshot->items[i].options;
+        snapshot->views[i].enabled = snapshot->items[i].enabled;
+        snapshot->views[i].name = snapshot->items[i].name;
+        snapshot->views[i].path = snapshot->items[i].path;
     }
 
-    *count_out = n;
-    return items;
+    if (!cache_build_hashtable(snapshot, ops)) {
+        /*
+         * Hashtable construction is an optimization. Keep the snapshot usable
+         * through linear lookup if the bucket allocation fails.
+         */
+        free(snapshot->buckets);
+        snapshot->buckets = NULL;
+        snapshot->bucket_count = 0;
+    }
+
+    return snapshot;
+}
+
+static nipc_cgroups_cache_snapshot_t *cache_snapshot_build_from_items(
+    const nipc_cgroups_cache_item_t *items,
+    uint32_t item_count,
+    uint32_t systemd_enabled,
+    uint64_t generation,
+    const nipc_service_common_cache_ops_t *ops)
+{
+    nipc_cgroups_cache_snapshot_t *snapshot =
+        calloc(1, sizeof(nipc_cgroups_cache_snapshot_t));
+    if (!snapshot)
+        return NULL;
+
+    snapshot->item_count = item_count;
+    snapshot->systemd_enabled = systemd_enabled;
+    snapshot->generation = generation;
+
+    if (item_count == 0)
+        return snapshot;
+
+    snapshot->items = ops->calloc_fn(item_count,
+                                     sizeof(nipc_cgroups_cache_item_t),
+                                     ops->cache_items_fault_site);
+    if (!snapshot->items) {
+        cache_snapshot_free(snapshot);
+        return NULL;
+    }
+
+    snapshot->views = calloc(item_count,
+                             sizeof(nipc_cgroups_cache_item_view_t));
+    if (!snapshot->views) {
+        cache_snapshot_free(snapshot);
+        return NULL;
+    }
+
+    for (uint32_t i = 0; i < item_count; i++) {
+        const char *name = items[i].name ? items[i].name : "";
+        const char *path = items[i].path ? items[i].path : "";
+
+        snapshot->items[i].hash = items[i].hash;
+        snapshot->items[i].options = items[i].options;
+        snapshot->items[i].enabled = items[i].enabled;
+
+        if (!cache_copy_str(&snapshot->items[i].name, name, strlen(name),
+                            ops, ops->cache_item_name_fault_site) ||
+            !cache_copy_str(&snapshot->items[i].path, path, strlen(path),
+                            ops, ops->cache_item_path_fault_site)) {
+            cache_snapshot_free(snapshot);
+            return NULL;
+        }
+
+        snapshot->views[i].hash = snapshot->items[i].hash;
+        snapshot->views[i].options = snapshot->items[i].options;
+        snapshot->views[i].enabled = snapshot->items[i].enabled;
+        snapshot->views[i].name = snapshot->items[i].name;
+        snapshot->views[i].path = snapshot->items[i].path;
+    }
+
+    if (!cache_build_hashtable(snapshot, ops)) {
+        free(snapshot->buckets);
+        snapshot->buckets = NULL;
+        snapshot->bucket_count = 0;
+    }
+
+    return snapshot;
+}
+
+static bool cache_read_lock(nipc_cgroups_cache_t *cache)
+{
+    if (!cache || !cache->cache_lock_initialized)
+        return false;
+
+#if defined(_WIN32) || defined(__MSYS__)
+    AcquireSRWLockShared(&cache->cache_lock);
+    return true;
+#else
+    return pthread_rwlock_rdlock(&cache->cache_lock) == 0;
+#endif
+}
+
+static void cache_read_unlock(nipc_cgroups_cache_t *cache)
+{
+    if (!cache || !cache->cache_lock_initialized)
+        return;
+
+#if defined(_WIN32) || defined(__MSYS__)
+    ReleaseSRWLockShared(&cache->cache_lock);
+#else
+    pthread_rwlock_unlock(&cache->cache_lock);
+#endif
+}
+
+static bool cache_write_lock(nipc_cgroups_cache_t *cache)
+{
+    if (!cache || !cache->cache_lock_initialized)
+        return false;
+
+#if defined(_WIN32) || defined(__MSYS__)
+    AcquireSRWLockExclusive(&cache->cache_lock);
+    return true;
+#else
+    return pthread_rwlock_wrlock(&cache->cache_lock) == 0;
+#endif
+}
+
+static void cache_write_unlock(nipc_cgroups_cache_t *cache)
+{
+    if (!cache || !cache->cache_lock_initialized)
+        return;
+
+#if defined(_WIN32) || defined(__MSYS__)
+    ReleaseSRWLockExclusive(&cache->cache_lock);
+#else
+    pthread_rwlock_unlock(&cache->cache_lock);
+#endif
+}
+
+static bool cache_writer_lock(nipc_cgroups_cache_t *cache)
+{
+    if (!cache || !cache->writer_lock_initialized)
+        return false;
+
+#if defined(_WIN32) || defined(__MSYS__)
+    EnterCriticalSection(&cache->writer_lock);
+    return true;
+#else
+    return pthread_mutex_lock(&cache->writer_lock) == 0;
+#endif
+}
+
+static void cache_writer_unlock(nipc_cgroups_cache_t *cache)
+{
+    if (!cache || !cache->writer_lock_initialized)
+        return;
+
+#if defined(_WIN32) || defined(__MSYS__)
+    LeaveCriticalSection(&cache->writer_lock);
+#else
+    pthread_mutex_unlock(&cache->writer_lock);
+#endif
+}
+
+static bool cache_init_locks(nipc_cgroups_cache_t *cache)
+{
+#if defined(_WIN32) || defined(__MSYS__)
+    InitializeSRWLock(&cache->cache_lock);
+    cache->cache_lock_initialized = true;
+    InitializeCriticalSection(&cache->writer_lock);
+    cache->writer_lock_initialized = true;
+    return true;
+#else
+    if (pthread_rwlock_init(&cache->cache_lock, NULL) != 0)
+        return false;
+    cache->cache_lock_initialized = true;
+
+    if (pthread_mutex_init(&cache->writer_lock, NULL) != 0) {
+        pthread_rwlock_destroy(&cache->cache_lock);
+        cache->cache_lock_initialized = false;
+        return false;
+    }
+    cache->writer_lock_initialized = true;
+    return true;
+#endif
+}
+
+static void cache_destroy_locks(nipc_cgroups_cache_t *cache)
+{
+#if defined(_WIN32) || defined(__MSYS__)
+    if (cache->writer_lock_initialized) {
+        DeleteCriticalSection(&cache->writer_lock);
+        cache->writer_lock_initialized = false;
+    }
+    cache->cache_lock_initialized = false;
+#else
+    if (cache->writer_lock_initialized) {
+        pthread_mutex_destroy(&cache->writer_lock);
+        cache->writer_lock_initialized = false;
+    }
+    if (cache->cache_lock_initialized) {
+        pthread_rwlock_destroy(&cache->cache_lock);
+        cache->cache_lock_initialized = false;
+    }
+#endif
 }
 
 void nipc_service_common_cgroups_cache_init(nipc_cgroups_cache_t *cache,
@@ -120,6 +365,7 @@ void nipc_service_common_cgroups_cache_init(nipc_cgroups_cache_t *cache,
                                             const nipc_client_config_t *config)
 {
     memset(cache, 0, sizeof(*cache));
+    cache_init_locks(cache);
     nipc_client_init(&cache->client, run_dir, service_name, config);
 }
 
@@ -127,97 +373,262 @@ bool nipc_service_common_cgroups_cache_refresh(
     nipc_cgroups_cache_t *cache,
     const nipc_service_common_cache_ops_t *ops)
 {
+    if (!cache_writer_lock(cache))
+        return false;
+
     nipc_client_refresh(&cache->client);
 
     nipc_cgroups_resp_view_t view;
     nipc_error_t err = nipc_client_call_cgroups_snapshot(&cache->client, &view);
     if (err != NIPC_OK) {
         cache->refresh_failure_count++;
+        cache_writer_unlock(cache);
         return false;
     }
 
-    uint32_t new_count = 0;
-    nipc_cgroups_cache_item_t *new_items = NULL;
-    if (view.item_count > 0) {
-        new_items = cache_build_items(&view, ops, &new_count);
-        if (!new_items) {
-            cache->refresh_failure_count++;
-            return false;
-        }
+    nipc_cgroups_cache_snapshot_t *new_snapshot =
+        cache_snapshot_build(&view, ops);
+    if (!new_snapshot) {
+        cache->refresh_failure_count++;
+        cache_writer_unlock(cache);
+        return false;
     }
 
-    cache_free_items(cache->items, cache->item_count);
-    cache->items = new_items;
-    cache->item_count = new_count;
-    cache->systemd_enabled = view.systemd_enabled;
-    cache->generation = view.generation;
-    cache->populated = true;
+    nipc_cgroups_cache_snapshot_t *old_snapshot = NULL;
+    if (!cache_write_lock(cache)) {
+        cache_snapshot_free(new_snapshot);
+        cache->refresh_failure_count++;
+        cache_writer_unlock(cache);
+        return false;
+    }
+
+    old_snapshot = cache->snapshot;
+    cache->snapshot = new_snapshot;
     cache->refresh_success_count++;
     cache->last_refresh_ts = ops->monotonic_ms_fn();
-    cache_build_hashtable(cache, ops);
+
+    cache_write_unlock(cache);
+    cache_snapshot_free(old_snapshot);
+    cache_writer_unlock(cache);
 
     return true;
 }
 
-const nipc_cgroups_cache_item_t *nipc_service_common_cgroups_cache_lookup(
-    const nipc_cgroups_cache_t *cache,
+bool nipc_service_common_cgroups_cache_ready(nipc_cgroups_cache_t *cache)
+{
+    if (!cache_read_lock(cache))
+        return false;
+    bool ready = cache->snapshot != NULL;
+    cache_read_unlock(cache);
+    return ready;
+}
+
+bool nipc_service_common_cgroups_cache_read_lock(
+    nipc_cgroups_cache_t *cache,
+    nipc_cgroups_cache_read_guard_t *guard)
+{
+    if (!guard)
+        return false;
+
+    memset(guard, 0, sizeof(*guard));
+
+    if (!cache_read_lock(cache))
+        return false;
+
+    guard->cache = cache;
+    guard->snapshot = cache->snapshot;
+    guard->locked = true;
+    return true;
+}
+
+void nipc_service_common_cgroups_cache_read_unlock(
+    nipc_cgroups_cache_read_guard_t *guard)
+{
+    if (!guard || !guard->locked)
+        return;
+
+    nipc_cgroups_cache_t *cache = guard->cache;
+    guard->cache = NULL;
+    guard->snapshot = NULL;
+    guard->locked = false;
+    cache_read_unlock(cache);
+}
+
+const nipc_cgroups_cache_item_view_t *nipc_service_common_cgroups_cache_get(
+    const nipc_cgroups_cache_read_guard_t *guard,
     uint32_t hash,
     const char *name)
 {
-    if (!cache->populated || !cache->items || !name)
+    if (!guard || !guard->locked || !guard->snapshot || !name)
         return NULL;
 
-    if (cache->buckets && cache->bucket_count > 0) {
+    const nipc_cgroups_cache_snapshot_t *snapshot = guard->snapshot;
+    if (snapshot->item_count == 0 || !snapshot->views)
+        return NULL;
+
+    if (snapshot->buckets && snapshot->bucket_count > 0) {
         uint32_t key = hash ^ cache_hash_name(name);
-        uint32_t mask = cache->bucket_count - 1;
+        uint32_t mask = snapshot->bucket_count - 1;
         uint32_t slot = key & mask;
 
-        while (cache->buckets[slot].used) {
-            uint32_t idx = cache->buckets[slot].index;
-            if (cache->items[idx].hash == hash &&
-                strcmp(cache->items[idx].name, name) == 0)
-                return &cache->items[idx];
+        while (snapshot->buckets[slot].used) {
+            uint32_t idx = snapshot->buckets[slot].index;
+            if (snapshot->views[idx].hash == hash &&
+                strcmp(snapshot->views[idx].name, name) == 0)
+                return &snapshot->views[idx];
             slot = (slot + 1) & mask;
         }
         return NULL;
     }
 
-    for (uint32_t i = 0; i < cache->item_count; i++) {
-        if (cache->items[i].hash == hash &&
-            strcmp(cache->items[i].name, name) == 0)
-            return &cache->items[i];
+    for (uint32_t i = 0; i < snapshot->item_count; i++) {
+        if (snapshot->views[i].hash == hash &&
+            strcmp(snapshot->views[i].name, name) == 0)
+            return &snapshot->views[i];
     }
 
     return NULL;
 }
 
-void nipc_service_common_cgroups_cache_status(const nipc_cgroups_cache_t *cache,
+static char *cache_strdup_owned(const char *src)
+{
+    if (!src)
+        src = "";
+    size_t len = strlen(src);
+    char *dst = malloc(len + 1);
+    if (!dst)
+        return NULL;
+    memcpy(dst, src, len + 1);
+    return dst;
+}
+
+nipc_cgroups_cache_item_t *nipc_service_common_cgroups_cache_item_dup(
+    const nipc_cgroups_cache_read_guard_t *guard,
+    const nipc_cgroups_cache_item_view_t *view)
+{
+    if (!guard || !guard->locked || !view)
+        return NULL;
+
+    nipc_cgroups_cache_item_t *item = calloc(1, sizeof(*item));
+    if (!item)
+        return NULL;
+
+    item->hash = view->hash;
+    item->options = view->options;
+    item->enabled = view->enabled;
+    item->name = cache_strdup_owned(view->name);
+    item->path = cache_strdup_owned(view->path);
+    if (!item->name || !item->path) {
+        nipc_service_common_cgroups_cache_item_free(item);
+        return NULL;
+    }
+
+    return item;
+}
+
+void nipc_service_common_cgroups_cache_item_free(nipc_cgroups_cache_item_t *item)
+{
+    if (!item)
+        return;
+
+    free(item->name);
+    free(item->path);
+    free(item);
+}
+
+void nipc_service_common_cgroups_cache_status(nipc_cgroups_cache_t *cache,
                                               nipc_cgroups_cache_status_t *out)
 {
-    out->populated = cache->populated;
-    out->item_count = cache->item_count;
-    out->systemd_enabled = cache->systemd_enabled;
-    out->generation = cache->generation;
+    if (!out)
+        return;
+
+    memset(out, 0, sizeof(*out));
+
+    if (!cache_writer_lock(cache))
+        return;
+    if (!cache_read_lock(cache)) {
+        cache_writer_unlock(cache);
+        return;
+    }
+
+    const nipc_cgroups_cache_snapshot_t *snapshot = cache->snapshot;
+    out->populated = snapshot != NULL;
+    if (snapshot) {
+        out->item_count = snapshot->item_count;
+        out->systemd_enabled = snapshot->systemd_enabled;
+        out->generation = snapshot->generation;
+    }
     out->refresh_success_count = cache->refresh_success_count;
     out->refresh_failure_count = cache->refresh_failure_count;
     out->connection_state = cache->client.state;
     out->last_refresh_ts = cache->last_refresh_ts;
+
+    cache_read_unlock(cache);
+    cache_writer_unlock(cache);
+}
+
+bool nipc_service_common_cgroups_cache_seed_for_tests(
+    nipc_cgroups_cache_t *cache,
+    const nipc_cgroups_cache_item_t *items,
+    uint32_t item_count,
+    uint32_t systemd_enabled,
+    uint64_t generation,
+    const nipc_service_common_cache_ops_t *ops)
+{
+    if (!cache || !ops || (!items && item_count > 0))
+        return false;
+
+    nipc_cgroups_cache_snapshot_t *new_snapshot =
+        cache_snapshot_build_from_items(items, item_count,
+                                        systemd_enabled, generation, ops);
+    if (!new_snapshot)
+        return false;
+
+    if (!cache_writer_lock(cache)) {
+        cache_snapshot_free(new_snapshot);
+        return false;
+    }
+
+    nipc_cgroups_cache_snapshot_t *old_snapshot = NULL;
+    if (!cache_write_lock(cache)) {
+        cache_writer_unlock(cache);
+        cache_snapshot_free(new_snapshot);
+        return false;
+    }
+
+    old_snapshot = cache->snapshot;
+    cache->snapshot = new_snapshot;
+    cache->refresh_success_count++;
+    cache->last_refresh_ts = ops->monotonic_ms_fn();
+
+    cache_write_unlock(cache);
+    cache_writer_unlock(cache);
+    cache_snapshot_free(old_snapshot);
+
+    return true;
 }
 
 void nipc_service_common_cgroups_cache_close(nipc_cgroups_cache_t *cache)
 {
-    cache_free_items(cache->items, cache->item_count);
-    cache->items = NULL;
-    cache->item_count = 0;
-    cache->populated = false;
+    if (!cache)
+        return;
 
-    free(cache->buckets);
-    cache->buckets = NULL;
-    cache->bucket_count = 0;
+    if (cache_writer_lock(cache)) {
+        nipc_cgroups_cache_snapshot_t *old_snapshot = NULL;
+        if (cache_write_lock(cache)) {
+            old_snapshot = cache->snapshot;
+            cache->snapshot = NULL;
+            cache_write_unlock(cache);
+        }
+        cache_snapshot_free(old_snapshot);
 
-    free(cache->response_buf);
-    cache->response_buf = NULL;
-    cache->response_buf_size = 0;
+        free(cache->response_buf);
+        cache->response_buf = NULL;
+        cache->response_buf_size = 0;
 
-    nipc_client_close(&cache->client);
+        nipc_client_close(&cache->client);
+        cache_writer_unlock(cache);
+    }
+
+    cache_destroy_locks(cache);
 }

--- a/src/libnetdata/netipc/src/service/netipc_service_cgroups_cache_common.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_cgroups_cache_common.c
@@ -104,6 +104,17 @@ static bool cache_copy_str(char **dst,
     return true;
 }
 
+static size_t cache_cstr_len(const char *src)
+{
+    if (!src)
+        return 0;
+
+    const char *p = src;
+    while (*p)
+        p++;
+    return (size_t)(p - src);
+}
+
 static nipc_cgroups_cache_snapshot_t *cache_snapshot_build(
     const nipc_cgroups_resp_view_t *view,
     const nipc_service_common_cache_ops_t *ops)
@@ -217,9 +228,12 @@ static nipc_cgroups_cache_snapshot_t *cache_snapshot_build_from_items(
         snapshot->items[i].options = items[i].options;
         snapshot->items[i].enabled = items[i].enabled;
 
-        if (!cache_copy_str(&snapshot->items[i].name, name, strlen(name),
+        size_t name_len = cache_cstr_len(name);
+        size_t path_len = cache_cstr_len(path);
+
+        if (!cache_copy_str(&snapshot->items[i].name, name, name_len,
                             ops, ops->cache_item_name_fault_site) ||
-            !cache_copy_str(&snapshot->items[i].path, path, strlen(path),
+            !cache_copy_str(&snapshot->items[i].path, path, path_len,
                             ops, ops->cache_item_path_fault_site)) {
             cache_snapshot_free(snapshot);
             return NULL;
@@ -494,7 +508,7 @@ static char *cache_strdup_owned(const char *src)
 {
     if (!src)
         src = "";
-    size_t len = strlen(src);
+    size_t len = cache_cstr_len(src);
     char *dst = malloc(len + 1);
     if (!dst)
         return NULL;

--- a/src/libnetdata/netipc/src/service/netipc_service_cgroups_cache_common.h
+++ b/src/libnetdata/netipc/src/service/netipc_service_cgroups_cache_common.h
@@ -14,12 +14,29 @@ void nipc_service_common_cgroups_cache_init(nipc_cgroups_cache_t *cache,
 bool nipc_service_common_cgroups_cache_refresh(
     nipc_cgroups_cache_t *cache,
     const nipc_service_common_cache_ops_t *ops);
-const nipc_cgroups_cache_item_t *nipc_service_common_cgroups_cache_lookup(
-    const nipc_cgroups_cache_t *cache,
+bool nipc_service_common_cgroups_cache_ready(nipc_cgroups_cache_t *cache);
+bool nipc_service_common_cgroups_cache_read_lock(
+    nipc_cgroups_cache_t *cache,
+    nipc_cgroups_cache_read_guard_t *guard);
+void nipc_service_common_cgroups_cache_read_unlock(
+    nipc_cgroups_cache_read_guard_t *guard);
+const nipc_cgroups_cache_item_view_t *nipc_service_common_cgroups_cache_get(
+    const nipc_cgroups_cache_read_guard_t *guard,
     uint32_t hash,
     const char *name);
-void nipc_service_common_cgroups_cache_status(const nipc_cgroups_cache_t *cache,
+nipc_cgroups_cache_item_t *nipc_service_common_cgroups_cache_item_dup(
+    const nipc_cgroups_cache_read_guard_t *guard,
+    const nipc_cgroups_cache_item_view_t *view);
+void nipc_service_common_cgroups_cache_item_free(nipc_cgroups_cache_item_t *item);
+void nipc_service_common_cgroups_cache_status(nipc_cgroups_cache_t *cache,
                                               nipc_cgroups_cache_status_t *out);
+bool nipc_service_common_cgroups_cache_seed_for_tests(
+    nipc_cgroups_cache_t *cache,
+    const nipc_cgroups_cache_item_t *items,
+    uint32_t item_count,
+    uint32_t systemd_enabled,
+    uint64_t generation,
+    const nipc_service_common_cache_ops_t *ops);
 void nipc_service_common_cgroups_cache_close(nipc_cgroups_cache_t *cache);
 
 #ifdef __cplusplus

--- a/src/libnetdata/netipc/src/service/netipc_service_cgroups_lookup.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_cgroups_lookup.c
@@ -104,14 +104,18 @@ static nipc_error_t cgroups_lookup_remaining_timeout(nipc_client_ctx_t *ctx,
   return NIPC_OK;
 }
 
+nipc_error_t nipc_cgroups_lookup_remaining_timeout_for_tests(
+    nipc_client_ctx_t *ctx, uint64_t deadline_ms, uint32_t *timeout_out) {
+  return cgroups_lookup_remaining_timeout(ctx, deadline_ms, timeout_out);
+}
+
 static nipc_error_t
 cgroups_lookup_next_request_count(nipc_client_ctx_t *ctx,
                                   const nipc_str_view_t *paths,
                                   uint32_t remaining, uint32_t *count_out,
                                   size_t *size_out) {
   if (remaining == 0) {
-    if (!cgroups_lookup_request_size(NULL, 0, size_out))
-      return NIPC_ERR_OVERFLOW;
+    *size_out = NIPC_CGROUPS_LOOKUP_REQ_HDR_SIZE;
     *count_out = 0;
     return NIPC_OK;
   }
@@ -190,8 +194,10 @@ cgroups_lookup_clone_oversized_request_item(const nipc_str_view_t *path,
   size_t item_start = nipc_align8(data);
   if (item_start < data)
     return NIPC_ERR_OVERFLOW;
+#if SIZE_MAX <= UINT32_MAX
   if ((size_t)path->len > SIZE_MAX - NIPC_CGROUPS_LOOKUP_ITEM_HDR_SIZE - 2u)
     return NIPC_ERR_OVERFLOW;
+#endif
 
   size_t item_size =
       NIPC_CGROUPS_LOOKUP_ITEM_HDR_SIZE + (size_t)path->len + 2u;

--- a/src/libnetdata/netipc/src/service/netipc_service_posix_client.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_posix_client.c
@@ -37,9 +37,10 @@ static void client_sleep_ms(uint32_t ms)
 
 static void close_abort_pipe(nipc_client_ctx_t *ctx)
 {
-    if (!ctx->abort_pipe_valid)
+    if (!ctx->abort_pipe_lock_initialized)
         return;
 
+    pthread_mutex_lock(&ctx->abort_pipe_lock);
     if (ctx->abort_pipe[0] >= 0) {
         close(ctx->abort_pipe[0]);
         ctx->abort_pipe[0] = -1;
@@ -49,12 +50,19 @@ static void close_abort_pipe(nipc_client_ctx_t *ctx)
         ctx->abort_pipe[1] = -1;
     }
     ctx->abort_pipe_valid = false;
+    pthread_mutex_unlock(&ctx->abort_pipe_lock);
+
+    pthread_mutex_destroy(&ctx->abort_pipe_lock);
+    ctx->abort_pipe_lock_initialized = false;
 }
 
 static void drain_abort_pipe(nipc_client_ctx_t *ctx)
 {
-    if (!ctx->abort_pipe_valid || ctx->abort_pipe[0] < 0)
+    if (!ctx->abort_pipe_lock_initialized)
         return;
+    pthread_mutex_lock(&ctx->abort_pipe_lock);
+    if (!ctx->abort_pipe_valid || ctx->abort_pipe[0] < 0)
+        goto done;
 
     char buf[64];
     for (;;) {
@@ -65,6 +73,9 @@ static void drain_abort_pipe(nipc_client_ctx_t *ctx)
             continue;
         break;
     }
+
+done:
+    pthread_mutex_unlock(&ctx->abort_pipe_lock);
 }
 
 static void init_abort_pipe(nipc_client_ctx_t *ctx)
@@ -72,10 +83,18 @@ static void init_abort_pipe(nipc_client_ctx_t *ctx)
     ctx->abort_pipe[0] = -1;
     ctx->abort_pipe[1] = -1;
     ctx->abort_pipe_valid = false;
+    ctx->abort_pipe_lock_initialized = false;
+
+    if (pthread_mutex_init(&ctx->abort_pipe_lock, NULL) != 0)
+        return;
+    ctx->abort_pipe_lock_initialized = true;
 
     int fds[2];
-    if (pipe(fds) != 0)
+    if (pipe(fds) != 0) {
+        pthread_mutex_destroy(&ctx->abort_pipe_lock);
+        ctx->abort_pipe_lock_initialized = false;
         return;
+    }
 
     for (int i = 0; i < 2; i++) {
         int flags = fcntl(fds[i], F_GETFL, 0);
@@ -166,6 +185,10 @@ void nipc_client_abort(nipc_client_ctx_t *ctx)
         return;
 
     __atomic_store_n(&ctx->abort_requested, 1u, __ATOMIC_RELEASE);
+    if (!ctx->abort_pipe_lock_initialized)
+        return;
+
+    pthread_mutex_lock(&ctx->abort_pipe_lock);
     if (ctx->abort_pipe_valid && ctx->abort_pipe[1] >= 0) {
         const char b = 1;
         ssize_t n;
@@ -173,6 +196,7 @@ void nipc_client_abort(nipc_client_ctx_t *ctx)
             n = write(ctx->abort_pipe[1], &b, 1);
         } while (n < 0 && errno == EINTR);
     }
+    pthread_mutex_unlock(&ctx->abort_pipe_lock);
 }
 
 void nipc_client_clear_abort(nipc_client_ctx_t *ctx)

--- a/src/libnetdata/netipc/src/service/netipc_service_posix_internal.h
+++ b/src/libnetdata/netipc/src/service/netipc_service_posix_internal.h
@@ -15,6 +15,14 @@
 #define CLIENT_CALL_RECONNECT_DRAIN_MS (SERVER_POLL_TIMEOUT_MS + 50u)
 #define CLIENT_CALL_RECONNECT_RETRIES 20u
 
+typedef struct {
+    pthread_mutex_t lock;
+    pthread_cond_t copied_cond;
+    bool copied;
+    nipc_managed_server_t *server;
+    nipc_session_ctx_t *session;
+} nipc_posix_session_start_arg_t;
+
 enum {
     NIPC_POSIX_SERVICE_TEST_FAULT_CLIENT_RESPONSE_BUF_REALLOC_INTERNAL = 1,
     NIPC_POSIX_SERVICE_TEST_FAULT_CLIENT_SEND_BUF_REALLOC_INTERNAL,

--- a/src/libnetdata/netipc/src/service/netipc_service_posix_server.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_posix_server.c
@@ -86,6 +86,42 @@ static bool server_prepare_accept_config(nipc_managed_server_t *server,
   return cfg_out->supported_profiles != 0;
 }
 
+static void server_accept_loop_mark_active(nipc_managed_server_t *server) {
+  if (!server || !server->sessions)
+    return;
+
+  pthread_mutex_lock(&server->sessions_lock);
+  server->acceptor_thread = pthread_self();
+  server->acceptor_started = true;
+  pthread_mutex_unlock(&server->sessions_lock);
+}
+
+static void server_accept_loop_mark_inactive(nipc_managed_server_t *server) {
+  if (!server || !server->sessions)
+    return;
+
+  pthread_mutex_lock(&server->sessions_lock);
+  server->acceptor_started = false;
+  pthread_mutex_unlock(&server->sessions_lock);
+}
+
+static void server_wait_accept_loop_inactive(nipc_managed_server_t *server) {
+  if (!server || !server->sessions)
+    return;
+
+  for (;;) {
+    pthread_mutex_lock(&server->sessions_lock);
+    bool active = server->acceptor_started;
+    bool current_thread =
+        active && pthread_equal(server->acceptor_thread, pthread_self());
+    pthread_mutex_unlock(&server->sessions_lock);
+
+    if (!active || current_thread)
+      return;
+    nipc_service_posix_sleep_us(1000);
+  }
+}
+
 /* ------------------------------------------------------------------ */
 /*  Public API: managed server                                         */
 /* ------------------------------------------------------------------ */
@@ -150,6 +186,7 @@ nipc_server_init_raw_for_tests(nipc_managed_server_t *server,
 
 void nipc_server_run(nipc_managed_server_t *server) {
   __atomic_store_n(&server->running, true, __ATOMIC_RELEASE);
+  server_accept_loop_mark_active(server);
 
   while (__atomic_load_n(&server->running, __ATOMIC_RELAXED)) {
     /* Poll the listener fd before blocking on accept */
@@ -228,10 +265,6 @@ void nipc_server_run(nipc_managed_server_t *server) {
       continue;
     }
 
-    /* The caller-owned server object stays live until destroy joins sessions.
-     */
-    // codeql[cpp/stack-address-escape]
-    sctx->server = server;
     sctx->session = session;
     sctx->shm = shm;
     sctx->id = sid;
@@ -241,9 +274,33 @@ void nipc_server_run(nipc_managed_server_t *server) {
     pthread_mutex_unlock(&server->sessions_lock);
 
     /* Spawn handler thread for this session */
-    int rc = nipc_service_posix_pthread_create(
-        &sctx->thread, NULL, nipc_service_posix_session_handler_thread, sctx);
-    if (rc != 0) {
+    nipc_posix_session_start_arg_t start_arg = {
+        .copied = false,
+        .server = server,
+        .session = sctx,
+    };
+    int start_mutex_rc = pthread_mutex_init(&start_arg.lock, NULL);
+    int start_cond_rc = start_mutex_rc == 0
+                            ? pthread_cond_init(&start_arg.copied_cond, NULL)
+                            : -1;
+    int rc = -1;
+    if (start_mutex_rc == 0 && start_cond_rc == 0) {
+      rc = nipc_service_posix_pthread_create(
+          &sctx->thread, NULL, nipc_service_posix_session_handler_thread,
+          &start_arg);
+    }
+    if (rc == 0) {
+      pthread_mutex_lock(&start_arg.lock);
+      while (!start_arg.copied)
+        pthread_cond_wait(&start_arg.copied_cond, &start_arg.lock);
+      pthread_mutex_unlock(&start_arg.lock);
+    }
+    if (start_cond_rc == 0)
+      pthread_cond_destroy(&start_arg.copied_cond);
+    if (start_mutex_rc == 0)
+      pthread_mutex_destroy(&start_arg.lock);
+
+    if (start_mutex_rc != 0 || start_cond_rc != 0 || rc != 0) {
       /* Thread creation failed: clean up */
       pthread_mutex_lock(&server->sessions_lock);
       /* Remove the sctx we just added */
@@ -264,6 +321,8 @@ void nipc_server_run(nipc_managed_server_t *server) {
       free(sctx);
     }
   }
+
+  server_accept_loop_mark_inactive(server);
 }
 
 void nipc_server_stop(nipc_managed_server_t *server) {
@@ -277,6 +336,7 @@ bool nipc_server_drain(nipc_managed_server_t *server, uint32_t timeout_ms) {
    * loop will exit on its next poll timeout (100ms). The listener
    * is closed later by nipc_server_destroy(). */
   __atomic_store_n(&server->running, false, __ATOMIC_RELEASE);
+  server_wait_accept_loop_inactive(server);
 
   /* 2. Wait for in-flight sessions to complete */
   bool all_drained = true;
@@ -352,6 +412,7 @@ bool nipc_server_drain(nipc_managed_server_t *server, uint32_t timeout_ms) {
 void nipc_server_destroy(nipc_managed_server_t *server) {
   __atomic_store_n(&server->running, false, __ATOMIC_RELEASE);
   nipc_uds_close_listener(&server->listener);
+  server_wait_accept_loop_inactive(server);
 
   /* Join all active session threads */
   if (server->sessions) {

--- a/src/libnetdata/netipc/src/service/netipc_service_posix_server_session.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_posix_server_session.c
@@ -273,8 +273,13 @@ static void server_handle_session(nipc_managed_server_t *server,
 /* Thread function: handles one client session from accept to disconnect. */
 void *nipc_service_posix_session_handler_thread(void *arg)
 {
-    nipc_session_ctx_t *sctx = (nipc_session_ctx_t *)arg;
-    nipc_managed_server_t *server = sctx->server;
+    nipc_posix_session_start_arg_t *start = (nipc_posix_session_start_arg_t *)arg;
+    pthread_mutex_lock(&start->lock);
+    nipc_session_ctx_t *sctx = start->session;
+    nipc_managed_server_t *server = start->server;
+    start->copied = true;
+    pthread_cond_signal(&start->copied_cond);
+    pthread_mutex_unlock(&start->lock);
 
     /* Allocate a per-session response buffer */
     size_t resp_size = (size_t)sctx->session.max_response_payload_bytes;

--- a/src/libnetdata/netipc/src/service/netipc_service_win_server.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_win_server.c
@@ -146,11 +146,22 @@ server_cancel_active_session_io_locked(nipc_managed_server_t *server) {
     nipc_session_ctx_t *s = server->sessions[i];
     if (!s)
       continue;
-    if (!InterlockedCompareExchange((volatile LONG *)&s->active, 0, 0))
+    if (!InterlockedCompareExchange(&s->active, 0, 0))
       continue;
     if (s->thread == NULL || s->thread == INVALID_HANDLE_VALUE)
       continue;
     CancelSynchronousIo(s->thread);
+  }
+}
+
+static void server_wait_accept_loop_inactive(nipc_managed_server_t *server) {
+  LONG current_thread_id = (LONG)GetCurrentThreadId();
+
+  while (InterlockedCompareExchange(&server->accept_loop_active, 0, 0)) {
+    LONG owner = InterlockedCompareExchange(&server->accept_loop_thread_id, 0, 0);
+    if (owner == current_thread_id)
+      return;
+    Sleep(1);
   }
 }
 
@@ -217,6 +228,7 @@ nipc_server_init_raw_for_tests(nipc_managed_server_t *server,
 }
 
 void nipc_server_run(nipc_managed_server_t *server) {
+  InterlockedExchange(&server->accept_loop_thread_id, (LONG)GetCurrentThreadId());
   InterlockedExchange(&server->accept_loop_active, 1);
   InterlockedExchange(&server->running, 1);
 
@@ -298,7 +310,7 @@ void nipc_server_run(nipc_managed_server_t *server) {
     sctx->session = session;
     sctx->shm = shm;
     sctx->id = sid;
-    InterlockedExchange((volatile LONG *)&sctx->active, 1);
+    InterlockedExchange(&sctx->active, 1);
 
     server->sessions[server->session_count++] = sctx;
     LeaveCriticalSection(&server->sessions_lock);
@@ -329,6 +341,7 @@ void nipc_server_run(nipc_managed_server_t *server) {
   }
 
   InterlockedExchange(&server->accept_loop_active, 0);
+  InterlockedExchange(&server->accept_loop_thread_id, 0);
   nipc_np_close_listener(&server->listener);
 }
 
@@ -353,6 +366,7 @@ bool nipc_server_drain(nipc_managed_server_t *server, uint32_t timeout_ms) {
     server_wake_listener(server);
   else
     nipc_np_close_listener(&server->listener);
+  server_wait_accept_loop_inactive(server);
 
   /* 2. Wait for in-flight sessions to complete */
   bool all_drained = true;
@@ -364,8 +378,7 @@ bool nipc_server_drain(nipc_managed_server_t *server, uint32_t timeout_ms) {
       EnterCriticalSection(&server->sessions_lock);
       int active_count = 0;
       for (int i = 0; i < server->session_count; i++) {
-        if (InterlockedCompareExchange(
-                (volatile LONG *)&server->sessions[i]->active, 0, 0))
+        if (InterlockedCompareExchange(&server->sessions[i]->active, 0, 0))
           active_count++;
       }
       LeaveCriticalSection(&server->sessions_lock);
@@ -415,6 +428,7 @@ void nipc_server_destroy(nipc_managed_server_t *server) {
     server_wake_listener(server);
   else
     nipc_np_close_listener(&server->listener);
+  server_wait_accept_loop_inactive(server);
 
   /* Join all active session threads */
   if (server->sessions) {

--- a/src/libnetdata/netipc/src/service/netipc_service_win_server_session.c
+++ b/src/libnetdata/netipc/src/service/netipc_service_win_server_session.c
@@ -224,7 +224,7 @@ unsigned __stdcall nipc_service_win_session_handler_thread(void *arg)
     nipc_np_close_session(&sctx->session);
 
     /* Mark inactive; the reap/destroy path owns removal from the array */
-    InterlockedExchange((volatile LONG *)&sctx->active, 0);
+    InterlockedExchange(&sctx->active, 0);
     return 0;
 }
 
@@ -238,7 +238,7 @@ void nipc_service_win_server_reap_sessions_locked(nipc_managed_server_t *server)
     int i = 0;
     while (i < server->session_count) {
         nipc_session_ctx_t *s = server->sessions[i];
-        if (!InterlockedCompareExchange((volatile LONG *)&s->active, 0, 0)) {
+        if (!InterlockedCompareExchange(&s->active, 0, 0)) {
             WaitForSingleObject(s->thread, INFINITE);
             CloseHandle(s->thread);
             /* Swap with last, free */

--- a/src/libnetdata/netipc/src/transport/posix/netipc_shm.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_shm.c
@@ -766,9 +766,9 @@ nipc_shm_error_t nipc_shm_receive(nipc_shm_ctx_t *ctx,
         if (timeout_ms > 0) {
             struct timespec now_ts;
             clock_gettime(CLOCK_MONOTONIC, &now_ts);
-            deadline_ns = (uint64_t)now_ts.tv_sec * 1000000000ull
+            deadline_ns = (uint64_t)now_ts.tv_sec * 1000000000ULL
                         + (uint64_t)now_ts.tv_nsec
-                        + (uint64_t)timeout_ms * 1000000ull;
+                        + (uint64_t)timeout_ms * 1000000ULL;
         }
 
         for (;;) {
@@ -784,14 +784,14 @@ nipc_shm_error_t nipc_shm_receive(nipc_shm_ctx_t *ctx,
             if (deadline_ns > 0) {
                 struct timespec now_ts;
                 clock_gettime(CLOCK_MONOTONIC, &now_ts);
-                uint64_t now_val = (uint64_t)now_ts.tv_sec * 1000000000ull
+                uint64_t now_val = (uint64_t)now_ts.tv_sec * 1000000000ULL
                                  + (uint64_t)now_ts.tv_nsec;
                 if (now_val >= deadline_ns)
                     return NIPC_SHM_ERR_TIMEOUT;
 
                 uint64_t remain = deadline_ns - now_val;
-                ts.tv_sec  = (time_t)(remain / 1000000000ull);
-                ts.tv_nsec = (long)(remain % 1000000000ull);
+                ts.tv_sec  = (time_t)(remain / 1000000000ULL);
+                ts.tv_nsec = (long)(remain % 1000000000ULL);
                 tsp = &ts;
             }
 

--- a/src/libnetdata/netipc/src/transport/posix/netipc_uds_inflight.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_uds_inflight.c
@@ -10,7 +10,13 @@ int nipc_uds_inflight_add(nipc_uds_session_t *s, uint64_t id)
     }
 
     if (s->inflight_count >= s->inflight_capacity) {
+        if (s->inflight_capacity > UINT32_MAX / 2)
+            return -2;
         uint32_t new_cap = s->inflight_capacity ? s->inflight_capacity * 2 : 16;
+#if SIZE_MAX <= UINT32_MAX
+        if ((size_t)new_cap > SIZE_MAX / sizeof(uint64_t))
+            return -2;
+#endif
         uint64_t *new_ids = realloc(s->inflight_ids,
                                     (size_t)new_cap * sizeof(uint64_t));
         if (!new_ids)

--- a/src/libnetdata/netipc/src/transport/posix/netipc_uds_lifecycle.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_uds_lifecycle.c
@@ -3,6 +3,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -11,6 +12,34 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+
+static pthread_mutex_t bind_umask_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static int bind_owner_only_socket(int fd, const struct sockaddr_un *addr)
+{
+    int rc = pthread_mutex_lock(&bind_umask_lock);
+    if (rc != 0) {
+        errno = rc;
+        return -1;
+    }
+
+    /* Bind path sockets as 0600 without a post-bind permission window. */
+    mode_t old_mask = umask(S_IXUSR | S_IRWXG | S_IRWXO); // nosemgrep
+    int bind_rc = bind(fd, (const struct sockaddr *)addr, sizeof(*addr));
+    int saved_errno = errno;
+    umask(old_mask); // nosemgrep
+
+    rc = pthread_mutex_unlock(&bind_umask_lock);
+    if (bind_rc < 0) {
+        errno = saved_errno;
+        return -1;
+    }
+    if (rc != 0) {
+        errno = rc;
+        return -1;
+    }
+    return 0;
+}
 
 static int copy_cstr_checked(char *dst, size_t dst_size, const char *src)
 {
@@ -178,14 +207,8 @@ nipc_uds_error_t nipc_uds_listen(const char *run_dir,
         return NIPC_UDS_ERR_PATH_TOO_LONG;
     }
 
-    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    if (bind_owner_only_socket(fd, &addr) < 0) {
         close(fd);
-        return NIPC_UDS_ERR_SOCKET;
-    }
-
-    if (chmod(path, S_IRUSR | S_IWUSR) < 0) {
-        close(fd);
-        unlink(path);
         return NIPC_UDS_ERR_SOCKET;
     }
 

--- a/src/libnetdata/netipc/src/transport/posix/netipc_uds_lifecycle.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_uds_lifecycle.c
@@ -24,10 +24,12 @@ static int bind_owner_only_socket(int fd, const struct sockaddr_un *addr)
     }
 
     /* Bind path sockets as 0600 without a post-bind permission window. */
-    mode_t old_mask = umask(S_IXUSR | S_IRWXG | S_IRWXO); // nosemgrep
+    // Flawfinder: ignore
+    mode_t old_mask = umask(S_IXUSR | S_IRWXG | S_IRWXO); // nosemgrep // NOSONAR
     int bind_rc = bind(fd, (const struct sockaddr *)addr, sizeof(*addr));
     int saved_errno = errno;
-    umask(old_mask); // nosemgrep
+    // Flawfinder: ignore
+    umask(old_mask); // nosemgrep // NOSONAR
 
     rc = pthread_mutex_unlock(&bind_umask_lock);
     if (bind_rc < 0) {

--- a/src/libnetdata/netipc/src/transport/posix/netipc_uds_receive.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_uds_receive.c
@@ -107,9 +107,13 @@ static nipc_uds_error_t validate_batch(const nipc_header_t *hdr,
     if (!(hdr->flags & NIPC_FLAG_BATCH) || hdr->item_count <= 1)
         return NIPC_UDS_OK;
 
-    uint32_t dir_bytes = hdr->item_count * 8;
-    uint32_t dir_aligned = (uint32_t)nipc_align8(dir_bytes);
-    if (payload_len < dir_aligned)
+    if (hdr->item_count > UINT32_MAX / NIPC_LOOKUP_DIR_ENTRY_SIZE)
+        return NIPC_UDS_ERR_PROTOCOL;
+    uint32_t dir_bytes = hdr->item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+    size_t dir_aligned = nipc_align8((size_t)dir_bytes);
+    if (dir_aligned < (size_t)dir_bytes || dir_aligned > UINT32_MAX)
+        return NIPC_UDS_ERR_PROTOCOL;
+    if (payload_len < dir_aligned || payload_len - dir_aligned > UINT32_MAX)
         return NIPC_UDS_ERR_PROTOCOL;
 
     uint32_t packed_area_len = (uint32_t)(payload_len - dir_aligned);

--- a/src/libnetdata/netipc/src/transport/windows/netipc_named_pipe.c
+++ b/src/libnetdata/netipc/src/transport/windows/netipc_named_pipe.c
@@ -488,7 +488,11 @@ static int inflight_add(nipc_np_session_t *s, uint64_t id) {
       return -1; /* duplicate */
   }
   if (s->inflight_count >= s->inflight_capacity) {
+    if (s->inflight_capacity > UINT32_MAX / 2)
+      return -2; /* allocation failure */
     uint32_t new_cap = s->inflight_capacity ? s->inflight_capacity * 2 : 16;
+    if ((size_t)new_cap > SIZE_MAX / sizeof(uint64_t))
+      return -2; /* allocation failure */
     uint64_t *new_ids =
         realloc(s->inflight_ids, (size_t)new_cap * sizeof(uint64_t));
     if (!new_ids)
@@ -1148,9 +1152,13 @@ static nipc_np_error_t validate_batch(const nipc_header_t *hdr,
   if (!(hdr->flags & NIPC_FLAG_BATCH) || hdr->item_count <= 1)
     return NIPC_NP_OK;
 
-  uint32_t dir_bytes = hdr->item_count * 8;
-  uint32_t dir_aligned = (uint32_t)nipc_align8(dir_bytes);
-  if (payload_len < dir_aligned)
+  if (hdr->item_count > UINT32_MAX / NIPC_LOOKUP_DIR_ENTRY_SIZE)
+    return NIPC_NP_ERR_PROTOCOL;
+  uint32_t dir_bytes = hdr->item_count * NIPC_LOOKUP_DIR_ENTRY_SIZE;
+  size_t dir_aligned = nipc_align8((size_t)dir_bytes);
+  if (dir_aligned < (size_t)dir_bytes || dir_aligned > UINT32_MAX)
+    return NIPC_NP_ERR_PROTOCOL;
+  if (payload_len < dir_aligned || payload_len - dir_aligned > UINT32_MAX)
     return NIPC_NP_ERR_PROTOCOL;
 
   uint32_t packed_area_len = (uint32_t)(payload_len - dir_aligned);

--- a/src/libnetdata/netipc/src/transport/windows/netipc_win_shm.c
+++ b/src/libnetdata/netipc/src/transport/windows/netipc_win_shm.c
@@ -857,7 +857,6 @@ nipc_win_shm_error_t nipc_win_shm_receive(
                     &mlen);
                 if (copy_rc > 0) {
                     InterlockedExchange(self_waiting_ptr, 0);
-                    observed = true;
                     break; /* data available */
                 }
                 if (copy_rc < 0) {
@@ -885,7 +884,6 @@ nipc_win_shm_error_t nipc_win_shm_receive(
                 copy_rc = copy_observed_message(seq_ptr, len_ptr, expected_seq,
                                                 buf, data_ptr, max_copy, &mlen);
                 if (copy_rc > 0) {
-                    observed = true;
                     break; /* data available */
                 }
                 if (copy_rc < 0)
@@ -897,7 +895,6 @@ nipc_win_shm_error_t nipc_win_shm_receive(
                         seq_ptr, len_ptr, expected_seq, buf, data_ptr, max_copy,
                         &mlen);
                     if (copy_rc > 0) {
-                        observed = true;
                         break;
                     }
                     if (copy_rc < 0)
@@ -925,7 +922,6 @@ nipc_win_shm_error_t nipc_win_shm_receive(
                     seq_ptr, len_ptr, expected_seq, buf, data_ptr, max_copy,
                     &mlen);
                 if (copy_rc > 0) {
-                    observed = true;
                     break;
                 }
                 if (copy_rc < 0)
@@ -944,7 +940,6 @@ nipc_win_shm_error_t nipc_win_shm_receive(
                         seq_ptr, len_ptr, expected_seq, buf, data_ptr, max_copy,
                         &mlen);
                     if (copy_rc > 0) {
-                        observed = true;
                         break;
                     }
                     if (copy_rc < 0)

--- a/src/libnetdata/netipc/src/transport/windows/netipc_win_shm.c
+++ b/src/libnetdata/netipc/src/transport/windows/netipc_win_shm.c
@@ -188,6 +188,15 @@ static inline void cpu_relax(void)
 #endif
 }
 
+static inline void busywait_relax(uint32_t *polls)
+{
+    (*polls)++;
+    if ((*polls & NIPC_WIN_SHM_BUSYWAIT_POLL_MASK) == 0)
+        SwitchToThread();
+    else
+        cpu_relax();
+}
+
 /* Pointer into the mapped region at a byte offset. */
 static inline void *region_ptr(const nipc_win_shm_ctx_t *ctx, uint32_t offset)
 {
@@ -198,6 +207,33 @@ static inline void *region_ptr(const nipc_win_shm_ctx_t *ctx, uint32_t offset)
 static inline nipc_win_shm_region_header_t *region_hdr(const nipc_win_shm_ctx_t *ctx)
 {
     return (nipc_win_shm_region_header_t *)ctx->base;
+}
+
+static int copy_observed_message(volatile LONG64 *seq_ptr,
+                                 volatile LONG *len_ptr,
+                                 LONG64 expected_seq,
+                                 void *buf,
+                                 const void *data_ptr,
+                                 uint32_t max_copy,
+                                 LONG *mlen_out)
+{
+    LONG64 seq_before = atomic_load_64(seq_ptr);
+    if (seq_before < expected_seq)
+        return 0;
+
+    LONG len_before = atomic_load_32(len_ptr);
+    if (len_before < 0)
+        return -1;
+    if (len_before > 0 && (size_t)len_before <= max_copy)
+        memcpy(buf, data_ptr, (size_t)len_before);
+
+    LONG len_after = atomic_load_32(len_ptr);
+    LONG64 seq_after = atomic_load_64(seq_ptr);
+    if (seq_before != seq_after || len_before != len_after)
+        return -1;
+
+    *mlen_out = len_before;
+    return 1;
 }
 
 /* ------------------------------------------------------------------ */
@@ -554,10 +590,13 @@ nipc_win_shm_error_t nipc_win_shm_client_attach(
 
     /* Validate offsets and capacities from shared memory */
     if (req_off == 0 || req_cap == 0 || resp_off == 0 || resp_cap == 0 ||
+        req_off < NIPC_WIN_SHM_HEADER_LEN || resp_off < NIPC_WIN_SHM_HEADER_LEN ||
         req_off % 64 != 0 || req_cap % 64 != 0 ||
         resp_off % 64 != 0 || resp_cap % 64 != 0 ||
         req_off > UINT32_MAX - req_cap ||
-        resp_off < req_off + req_cap) {
+        resp_off > UINT32_MAX - resp_cap ||
+        resp_off < req_off + req_cap ||
+        (size_t)resp_off > SIZE_MAX - (size_t)resp_cap) {
         UnmapViewOfFile(base);
         CloseHandle(mapping);
         return NIPC_WIN_SHM_ERR_BAD_HEADER;
@@ -790,14 +829,14 @@ nipc_win_shm_error_t nipc_win_shm_receive(
     bool observed = false;
     LONG mlen = 0;
     for (uint32_t i = 0; i < ctx->spin_tries; i++) {
-        LONG64 cur = atomic_load_64(seq_ptr);
-        if (cur >= expected_seq) {
-            mlen = atomic_load_32(len_ptr);
-            if (mlen > 0 && (size_t)mlen <= max_copy)
-                memcpy(buf, data_ptr, (size_t)mlen);
+        int copy_rc = copy_observed_message(seq_ptr, len_ptr, expected_seq,
+                                            buf, data_ptr, max_copy, &mlen);
+        if (copy_rc > 0) {
             observed = true;
             break;
         }
+        if (copy_rc < 0)
+            return NIPC_WIN_SHM_ERR_BAD_HEADER;
         cpu_relax();
     }
 
@@ -813,10 +852,17 @@ nipc_win_shm_error_t nipc_win_shm_receive(
                 MemoryBarrier();
 
                 /* Recheck after setting flag to avoid race */
-                LONG64 cur = atomic_load_64(seq_ptr);
-                if (cur >= expected_seq) {
+                int copy_rc = copy_observed_message(
+                    seq_ptr, len_ptr, expected_seq, buf, data_ptr, max_copy,
+                    &mlen);
+                if (copy_rc > 0) {
                     InterlockedExchange(self_waiting_ptr, 0);
+                    observed = true;
                     break; /* data available */
+                }
+                if (copy_rc < 0) {
+                    InterlockedExchange(self_waiting_ptr, 0);
+                    return NIPC_WIN_SHM_ERR_BAD_HEADER;
                 }
 
                 /* Compute remaining wait time */
@@ -836,15 +882,26 @@ nipc_win_shm_error_t nipc_win_shm_receive(
                 InterlockedExchange(self_waiting_ptr, 0);
 
                 /* Check sequence — data may have arrived */
-                cur = atomic_load_64(seq_ptr);
-                if (cur >= expected_seq)
+                copy_rc = copy_observed_message(seq_ptr, len_ptr, expected_seq,
+                                                buf, data_ptr, max_copy, &mlen);
+                if (copy_rc > 0) {
+                    observed = true;
                     break; /* data available */
+                }
+                if (copy_rc < 0)
+                    return NIPC_WIN_SHM_ERR_BAD_HEADER;
 
                 /* No data — check peer close */
                 if (atomic_load_32(peer_closed_ptr) != 0) {
-                    cur = atomic_load_64(seq_ptr);
-                    if (cur >= expected_seq)
+                    copy_rc = copy_observed_message(
+                        seq_ptr, len_ptr, expected_seq, buf, data_ptr, max_copy,
+                        &mlen);
+                    if (copy_rc > 0) {
+                        observed = true;
                         break;
+                    }
+                    if (copy_rc < 0)
+                        return NIPC_WIN_SHM_ERR_BAD_HEADER;
                     if (ctx->role == NIPC_WIN_SHM_ROLE_SERVER)
                         ctx->local_req_seq = expected_seq;
                     else
@@ -859,22 +916,20 @@ nipc_win_shm_error_t nipc_win_shm_receive(
                 /* Spurious wake — retry with remaining deadline */
             }
 
-            /* Copy immediately after waking */
-            mlen = atomic_load_32(len_ptr);
-            if (mlen > 0 && (size_t)mlen <= max_copy)
-                memcpy(buf, data_ptr, (size_t)mlen);
-
         } else {
             /* SHM_BUSYWAIT: spin indefinitely with periodic deadline checks */
             ULONGLONG start = GetTickCount64();
+            uint32_t polls = 0;
             for (;;) {
-                LONG64 cur = atomic_load_64(seq_ptr);
-                if (cur >= expected_seq) {
-                    mlen = atomic_load_32(len_ptr);
-                    if (mlen > 0 && (size_t)mlen <= max_copy)
-                        memcpy(buf, data_ptr, (size_t)mlen);
+                int copy_rc = copy_observed_message(
+                    seq_ptr, len_ptr, expected_seq, buf, data_ptr, max_copy,
+                    &mlen);
+                if (copy_rc > 0) {
+                    observed = true;
                     break;
                 }
+                if (copy_rc < 0)
+                    return NIPC_WIN_SHM_ERR_BAD_HEADER;
 
                 /* Periodic timeout check */
                 if (timeout_ms > 0) {
@@ -885,13 +940,15 @@ nipc_win_shm_error_t nipc_win_shm_receive(
 
                 /* Check peer close */
                 if (atomic_load_32(peer_closed_ptr) != 0) {
-                    cur = atomic_load_64(seq_ptr);
-                    if (cur >= expected_seq) {
-                        mlen = atomic_load_32(len_ptr);
-                        if (mlen > 0 && (size_t)mlen <= max_copy)
-                            memcpy(buf, data_ptr, (size_t)mlen);
+                    copy_rc = copy_observed_message(
+                        seq_ptr, len_ptr, expected_seq, buf, data_ptr, max_copy,
+                        &mlen);
+                    if (copy_rc > 0) {
+                        observed = true;
                         break;
                     }
+                    if (copy_rc < 0)
+                        return NIPC_WIN_SHM_ERR_BAD_HEADER;
                     if (ctx->role == NIPC_WIN_SHM_ROLE_SERVER)
                         ctx->local_req_seq = expected_seq;
                     else
@@ -899,7 +956,7 @@ nipc_win_shm_error_t nipc_win_shm_receive(
                     return NIPC_WIN_SHM_ERR_DISCONNECTED;
                 }
 
-                cpu_relax();
+                busywait_relax(&polls);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Vendor plugin-ipc commit `98ec474d103ab2a7ed150f88c37225b74e1a9d27` into Netdata.
- Bring the C, Rust, and Go NetIPC vendored trees forward, preserving Netdata-local wrappers and Go import paths.
- Adapt `ebpf.plugin` cgroup integration to use the existing L2 `cgroups-snapshot` client API instead of reading L3 cache internals.
- Fix PR CI/scanner findings from the first pushed vendor commit.

## Why

The vendored NetIPC cache API now keeps L3 cache internals opaque. Netdata `ebpf.plugin` was directly reading fields from the old cache struct, so it no longer built after vendoring. The eBPF consumer is a periodic importer that publishes its own protected derived table, so direct L2 fetch/process is enough and avoids adding an unnecessary L3 enumeration API.

## CI Repair

- Applied the Go 1.26 `go fix` rewrite in the vendored raw cache test and removed a duplicate test block that Sonar counted as new duplication.
- Replaced scanner-flagged vendored cgroups-cache `strlen()` calls with a local bounded length helper.
- Kept owner-only UDS socket creation behavior and added scanner suppressions for the intentionally guarded `umask()` calls.
- Removed unread Windows SHM `observed` assignments.
- Replaced the Netdata-only eBPF `strlen()` lookup with a bounded fixed-buffer comparison helper.
- Reduced cgroups-lookup protocol duplication by sharing private Go item-header parsing between validation and decode paths.

## Validation

- Source plugin-ipc preflight for `e2bd45254b9f7182692fda8ed7c811d57fd03397`: GitHub checks/actions passed, Dependabot and secret scanning had no open alerts.
- Source commit `98ec474d103ab2a7ed150f88c37225b74e1a9d27`: local `go test -count=1 ./pkg/netipc/protocol` and `go test -count=1 ./pkg/netipc/...` passed before vendoring; GitHub checks were still queued when the Go-only duplication repair was re-vendored.
- Source code scanning still has one stale open Semgrep alert from old commit `b4dfe405e1f99be417c21a9c0478aba2f64facaa`; current source no longer contains the flagged `chmod()` call and fresh Codacy/CodeQL checks passed on the preceding source preflight.
- Netdata vendor drift check: `diff-netdata-vendor.sh` reported no C/Rust/Go source drift after expected wrapper/workspace/import-path normalization.
- Netdata Go validation: `go fix ./pkg/netipc/service/raw` was idempotent; `go test -count=1 ./pkg/netipc/protocol` and `go test -count=1 ./pkg/netipc/...` passed under `src/go`.
- Netdata C validation: CMake build targets `netipc`, `ebpf.plugin`, `apps-lookup-netipc-lock-test`, `apps-cgroups-lookup-client-abort-test`, and `cgroup-lookup-netipc-test` passed.
- Direct runs of `apps-lookup-netipc-lock-test`, `apps-cgroups-lookup-client-abort-test`, and `cgroup-lookup-netipc-test` passed.
- Scanner checks: `git diff --check` passed, stale-pattern scan passed, Flawfinder reported no level-5 hits in the touched UDS lifecycle file, and Cppcheck no longer reported the unread Windows SHM assignment.

## Notes

- Existing Codacy Go standard-library dependency findings are intentionally left open because Netdata needs Go `1.26.0` compatibility.
