### PR TITLE
Netdata fixes part 21

### DIFF
--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -992,7 +992,7 @@ static inline void free_this_page(PGC *cache, PGC_PAGE *page, size_t partition _
             .metric_id = page->metric_id,
             .start_time_s = page->start_time_s,
             .end_time_s = __atomic_load_n(&page->end_time_s, __ATOMIC_RELAXED),
-            .update_every_s = page->update_every_s,
+            .update_every_s = pgc_page_update_every_s(page),
             .size = size,
             .hot = (is_page_hot(page)) ? true : false,
             .data = page->data,
@@ -1816,7 +1816,7 @@ static bool flush_pages(PGC *cache, size_t max_flushes, Word_t section, bool wai
                             .metric_id = page->metric_id,
                             .start_time_s = page->start_time_s,
                             .end_time_s = __atomic_load_n(&page->end_time_s, __ATOMIC_RELAXED),
-                            .update_every_s = page->update_every_s,
+                            .update_every_s = pgc_page_update_every_s(page),
                             .size = page_size_from_assumed_size(cache, page->assumed_size),
                             .data = page->data,
                             .custom_data = (cache->config.additional_bytes_per_page) ? page->custom_data : NULL,
@@ -2261,14 +2261,15 @@ time_t pgc_page_end_time_s(PGC_PAGE *page) {
 }
 
 uint32_t pgc_page_update_every_s(PGC_PAGE *page) {
-    return page->update_every_s;
+    return __atomic_load_n(&page->update_every_s, __ATOMIC_RELAXED);
 }
 
 uint32_t pgc_page_fix_update_every(PGC_PAGE *page, uint32_t update_every_s) {
-    if(page->update_every_s == 0)
-        page->update_every_s = update_every_s;
+    uint32_t expected = 0;
+    __atomic_compare_exchange_n(&page->update_every_s, &expected, update_every_s,
+                                false, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
 
-    return page->update_every_s;
+    return __atomic_load_n(&page->update_every_s, __ATOMIC_RELAXED);
 }
 
 time_t pgc_page_fix_end_time_s(PGC_PAGE *page, time_t end_time_s) {
@@ -2594,7 +2595,7 @@ void pgc_open_cache_to_journal_v2(
             struct jv2_page_info *pi = aral_mallocz(ar_pi);
             pi->start_time_s = page->start_time_s;
             pi->end_time_s = page->end_time_s;
-            pi->update_every_s = page->update_every_s;
+            pi->update_every_s = pgc_page_update_every_s(page);
             pi->page_length = page_size_from_assumed_size(cache, page->assumed_size);
             pi->page = page;
             pi->extent_index = current_extent_index_id;

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -716,9 +716,8 @@ static void journalfile_restore_extent_metadata(struct rrdengine_instance *ctx, 
         uint8_t page_type = jf_metric_data->descr[i].type;
 
         if (page_type > RRDENG_PAGE_TYPE_MAX) {
-            if (!page_error_map[page_type]) {
+            if (!__atomic_exchange_n(&page_error_map[page_type], true, __ATOMIC_RELAXED)) {
                 netdata_log_error("DBENGINE: unknown page type %d encountered.", page_type);
-                page_error_map[page_type] = true;
             }
             continue;
         }

--- a/src/database/engine/mrg-internals.h
+++ b/src/database/engine/mrg-internals.h
@@ -224,24 +224,22 @@ ALWAYS_INLINE
 static bool metric_release(MRG *mrg, METRIC *metric) {
     size_t partition = metric->partition;
 
-    if (refcount_release(&metric->refcount) == 0) {
+    if (refcount_release_and_acquire_for_deletion_advanced(&metric->refcount) == REFCOUNT_DELETED) {
         // we are the last user
         if (!acquired_metric_has_retention(mrg, metric)) {
-            // This metric is eligible for deletion.
-            // Atomically check and set the 'deleted' flag.
-            // If __atomic_test_and_set returns 'true', it means the flag was already set.
-            if (!__atomic_test_and_set(&metric->deleted, __ATOMIC_ACQ_REL)) {
-                // We won the race. The flag was 'false' and we set it to 'true'.
-                // We are now responsible for deletion.
-                acquired_for_deletion_metric_delete(mrg, metric);
-                uuidmap_free(metric->uuid);
-                aral_freez(mrg->index[partition].aral, metric);
-                __atomic_sub_fetch(&mrg->index[partition].stats.entries_acquired, 1, __ATOMIC_RELAXED);
-                __atomic_sub_fetch(&mrg->index[partition].stats.current_references, 1, __ATOMIC_RELAXED);
-                return true;
-            }
-            // Another thread is already deleting it. nothing to do
+            // We claimed the last reference for deletion, so no new acquire can resurrect it.
+            acquired_for_deletion_metric_delete(mrg, metric);
+            uuidmap_free(metric->uuid);
+            aral_freez(mrg->index[partition].aral, metric);
+            __atomic_sub_fetch(&mrg->index[partition].stats.entries_acquired, 1, __ATOMIC_RELAXED);
+            __atomic_sub_fetch(&mrg->index[partition].stats.current_references, 1, __ATOMIC_RELAXED);
+            return true;
         }
+
+        REFCOUNT expected = REFCOUNT_DELETED;
+        bool restored = __atomic_compare_exchange_n(&metric->refcount, &expected, 0,
+                                                    false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+        internal_fatal(!restored, "DBENGINE METRIC: cannot restore retained metric refcount from deletion state");
     }
 
     __atomic_sub_fetch(&mrg->index[partition].stats.current_references, 1, __ATOMIC_RELAXED);

--- a/src/database/engine/mrg-internals.h
+++ b/src/database/engine/mrg-internals.h
@@ -240,6 +240,7 @@ static bool metric_release(MRG *mrg, METRIC *metric) {
         bool restored = __atomic_compare_exchange_n(&metric->refcount, &expected, 0,
                                                     false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
         internal_fatal(!restored, "DBENGINE METRIC: cannot restore retained metric refcount from deletion state");
+        __atomic_sub_fetch(&mrg->index[partition].stats.entries_acquired, 1, __ATOMIC_RELAXED);
     }
 
     __atomic_sub_fetch(&mrg->index[partition].stats.current_references, 1, __ATOMIC_RELAXED);

--- a/src/database/engine/mrg-internals.h
+++ b/src/database/engine/mrg-internals.h
@@ -14,7 +14,6 @@ struct metric {
 
     REFCOUNT refcount;
     uint8_t partition;
-    bool deleted;
 
     uint32_t latest_update_every_s; // the latest data collection frequency
 
@@ -202,8 +201,6 @@ static void acquired_for_deletion_metric_delete(MRG *mrg, METRIC *metric) {
 
     mrg_index_write_unlock(mrg, partition);
 
-    __atomic_store_n(&metric->deleted, true, __ATOMIC_RELEASE);
-
     mrg_stats_judy_mem(mrg, partition, JudyAllocThreadPulseGetAndReset());
 }
 
@@ -212,11 +209,6 @@ static bool metric_acquire(MRG *mrg, METRIC *metric) {
     REFCOUNT rc = refcount_acquire_advanced(&metric->refcount);
     if(!REFCOUNT_ACQUIRED(rc))
         return false;
-
-    if (__atomic_load_n(&metric->deleted, __ATOMIC_ACQUIRE)) {
-        refcount_release(&metric->refcount);
-        return false;
-    }
 
     size_t partition = metric->partition;
 
@@ -309,7 +301,6 @@ static METRIC *metric_add_and_acquire(MRG *mrg, MRG_ENTRY *entry, bool *ret) {
     metric->latest_time_s_clean = MAX(0, entry->last_time_s);
     metric->latest_time_s_hot = 0;
     metric->latest_update_every_s = entry->latest_update_every_s;
-    metric->deleted = false;
 #ifdef NETDATA_INTERNAL_CHECKS
     metric->writer = 0;
 #endif

--- a/src/database/engine/mrg-internals.h
+++ b/src/database/engine/mrg-internals.h
@@ -64,21 +64,21 @@ struct mrg {
 };
 
 static inline void MRG_STATS_DUPLICATE_ADD(MRG *mrg, size_t partition) {
-    mrg->index[partition].stats.additions_duplicate++;
+    __atomic_add_fetch(&mrg->index[partition].stats.additions_duplicate, 1, __ATOMIC_RELAXED);
 }
 
 static inline void MRG_STATS_ADDED_METRIC(MRG *mrg, size_t partition, Word_t section) {
-    mrg->index[partition].stats.entries++;
-    mrg->index[partition].stats.additions++;
-    mrg->index[partition].stats.size += sizeof(METRIC);
+    __atomic_add_fetch(&mrg->index[partition].stats.entries, 1, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&mrg->index[partition].stats.additions, 1, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&mrg->index[partition].stats.size, (int64_t)sizeof(METRIC), __ATOMIC_RELAXED);
     struct rrdengine_instance *ctx = (struct rrdengine_instance *) section;
     __atomic_add_fetch(&ctx->atomic.metrics, 1, __ATOMIC_RELAXED);
 }
 
 static inline void MRG_STATS_DELETED_METRIC(MRG *mrg, size_t partition, Word_t section) {
-    mrg->index[partition].stats.entries--;
-    mrg->index[partition].stats.size -= sizeof(METRIC);
-    mrg->index[partition].stats.deletions++;
+    __atomic_sub_fetch(&mrg->index[partition].stats.entries, 1, __ATOMIC_RELAXED);
+    __atomic_sub_fetch(&mrg->index[partition].stats.size, (int64_t)sizeof(METRIC), __ATOMIC_RELAXED);
+    __atomic_add_fetch(&mrg->index[partition].stats.deletions, 1, __ATOMIC_RELAXED);
     struct rrdengine_instance *ctx = (struct rrdengine_instance *) section;
     rrdeng_atomic_uint64_sub_saturating(ctx, &ctx->atomic.metrics, 1, "metrics", "deleting an MRG metric");
 }
@@ -92,7 +92,7 @@ static inline void MRG_STATS_SEARCH_MISS(MRG *mrg, size_t partition) {
 }
 
 static inline void MRG_STATS_DELETE_MISS(MRG *mrg, size_t partition) {
-    mrg->index[partition].stats.delete_misses++;
+    __atomic_add_fetch(&mrg->index[partition].stats.delete_misses, 1, __ATOMIC_RELAXED);
 }
 
 #define mrg_index_read_lock(mrg, partition) rw_spinlock_read_lock(&(mrg)->index[partition].rw_spinlock)

--- a/src/database/engine/mrg-unittest.c
+++ b/src/database/engine/mrg-unittest.c
@@ -183,6 +183,131 @@ static int mrg_metrics_delete_underflow_unittest(MRG *mrg) {
 }
 #endif
 
+static int mrg_entries_acquired_counter_unittest(MRG *mrg) {
+    int errors = 0;
+
+    nd_uuid_t uuid;
+    uuid_generate(uuid);
+
+    struct mrg_statistics baseline;
+    mrg_get_statistics(mrg, &baseline);
+
+    MRG_ENTRY entry = {
+        .uuid = &uuid,
+        .section = (Word_t)&test_ctx_0,
+        .first_time_s = 10,
+        .last_time_s = 20,
+        .latest_update_every_s = 1,
+    };
+
+    bool added = false;
+    METRIC *metric = mrg_metric_add_and_acquire(mrg, entry, &added);
+    if(!metric || !added) {
+        fprintf(stderr, "DBENGINE METRIC: failed to add retained metric for acquired-counter test\n");
+        return 1;
+    }
+
+    struct mrg_statistics stats;
+    mrg_get_statistics(mrg, &stats);
+    if(stats.entries != baseline.entries + 1 ||
+       stats.entries_acquired != baseline.entries_acquired + 1 ||
+       stats.current_references != baseline.current_references + 1) {
+        fprintf(stderr,
+                "DBENGINE METRIC: acquired-counter add failed, expected entries/acquired/references %zu/%zd/%zd, got %zu/%zd/%zd\n",
+                baseline.entries + 1,
+                baseline.entries_acquired + 1,
+                baseline.current_references + 1,
+                stats.entries,
+                stats.entries_acquired,
+                stats.current_references);
+        errors++;
+    }
+
+    bool deleted = mrg_metric_release(mrg, metric);
+    if(deleted) {
+        fprintf(stderr, "DBENGINE METRIC: acquired-counter retained metric was deleted on release\n");
+        errors++;
+    }
+
+    mrg_get_statistics(mrg, &stats);
+    if(stats.entries_acquired != baseline.entries_acquired ||
+       stats.current_references != baseline.current_references) {
+        fprintf(stderr,
+                "DBENGINE METRIC: acquired-counter release failed, expected acquired/references %zd/%zd, got %zd/%zd\n",
+                baseline.entries_acquired,
+                baseline.current_references,
+                stats.entries_acquired,
+                stats.current_references);
+        errors++;
+    }
+
+    metric = mrg_metric_get_and_acquire_by_uuid(mrg, &uuid, entry.section);
+    if(!metric) {
+        fprintf(stderr, "DBENGINE METRIC: acquired-counter retained metric not found after release\n");
+        return errors + 1;
+    }
+
+    mrg_get_statistics(mrg, &stats);
+    if(stats.entries_acquired != baseline.entries_acquired + 1 ||
+       stats.current_references != baseline.current_references + 1) {
+        fprintf(stderr,
+                "DBENGINE METRIC: acquired-counter reacquire failed, expected acquired/references %zd/%zd, got %zd/%zd\n",
+                baseline.entries_acquired + 1,
+                baseline.current_references + 1,
+                stats.entries_acquired,
+                stats.current_references);
+        errors++;
+    }
+
+    deleted = mrg_metric_release(mrg, metric);
+    if(deleted) {
+        fprintf(stderr, "DBENGINE METRIC: acquired-counter reacquired retained metric was deleted on release\n");
+        errors++;
+    }
+
+    mrg_get_statistics(mrg, &stats);
+    if(stats.entries_acquired != baseline.entries_acquired ||
+       stats.current_references != baseline.current_references) {
+        fprintf(stderr,
+                "DBENGINE METRIC: acquired-counter second release failed, expected acquired/references %zd/%zd, got %zd/%zd\n",
+                baseline.entries_acquired,
+                baseline.current_references,
+                stats.entries_acquired,
+                stats.current_references);
+        errors++;
+    }
+
+    metric = mrg_metric_get_and_acquire_by_uuid(mrg, &uuid, entry.section);
+    if(!metric) {
+        fprintf(stderr, "DBENGINE METRIC: acquired-counter retained metric not found for cleanup\n");
+        return errors + 1;
+    }
+
+    mrg_metric_clear_retention(mrg, metric);
+    deleted = mrg_metric_release_and_delete(mrg, metric);
+    if(!deleted) {
+        fprintf(stderr, "DBENGINE METRIC: acquired-counter cleanup did not delete metric\n");
+        errors++;
+    }
+
+    mrg_get_statistics(mrg, &stats);
+    if(stats.entries != baseline.entries ||
+       stats.entries_acquired != baseline.entries_acquired ||
+       stats.current_references != baseline.current_references) {
+        fprintf(stderr,
+                "DBENGINE METRIC: acquired-counter cleanup failed, expected entries/acquired/references %zu/%zd/%zd, got %zu/%zd/%zd\n",
+                baseline.entries,
+                baseline.entries_acquired,
+                baseline.current_references,
+                stats.entries,
+                stats.entries_acquired,
+                stats.current_references);
+        errors++;
+    }
+
+    return errors;
+}
+
 int mrg_unittest(void) {
     // Use mrg_create_for_unittest to avoid pre-loaded metrics that block deletion
     MRG *mrg = mrg_create_for_unittest();
@@ -191,6 +316,7 @@ int mrg_unittest(void) {
 #ifndef NETDATA_INTERNAL_CHECKS
     errors += mrg_metrics_delete_underflow_unittest(mrg);
 #endif
+    errors += mrg_entries_acquired_counter_unittest(mrg);
 
     if(errors) {
         mrg_destroy(mrg);

--- a/src/database/engine/mrg.c
+++ b/src/database/engine/mrg.c
@@ -306,6 +306,21 @@ bool mrg_metric_has_zero_disk_retention(MRG *mrg __maybe_unused, METRIC *metric)
     return (first && last && first < last);
 }
 
+static inline bool mrg_metric_clean_samples_from_snapshot(
+    time_t first_time_s,
+    time_t latest_time_s_clean,
+    uint32_t update_every_s,
+    uint64_t *samples)
+{
+    *samples = 0;
+
+    if (!update_every_s || first_time_s <= 0 || latest_time_s_clean <= 0 || first_time_s >= latest_time_s_clean)
+        return false;
+
+    *samples = (uint64_t)(latest_time_s_clean - first_time_s) / update_every_s;
+    return *samples > 0;
+}
+
 ALWAYS_INLINE_HOT
 bool mrg_metric_set_hot_latest_time_s(MRG *mrg __maybe_unused, METRIC *metric, time_t latest_time_s) {
     internal_fatal(latest_time_s < 0, "DBENGINE METRIC: timestamp is negative");
@@ -454,8 +469,12 @@ inline void mrg_update_metric_retention_and_granularity_by_uuid(
         uint32_t latest_update_every_s = __atomic_load_n(&metric->latest_update_every_s, __ATOMIC_RELAXED);
         time_t latest_time_s_clean = __atomic_load_n(&metric->latest_time_s_clean, __ATOMIC_RELAXED);
         time_t metric_first_time_s = __atomic_load_n(&metric->first_time_s, __ATOMIC_RELAXED);
-        if (update_every_s && latest_update_every_s && latest_time_s_clean)
-            old_samples = (latest_time_s_clean - metric_first_time_s) / latest_update_every_s;
+        if (update_every_s)
+            mrg_metric_clean_samples_from_snapshot(
+                metric_first_time_s,
+                latest_time_s_clean,
+                latest_update_every_s,
+                &old_samples);
 
         mrg_metric_expand_retention(mrg, metric, first_time_s, last_time_s, update_every_s);
 
@@ -463,10 +482,14 @@ inline void mrg_update_metric_retention_and_granularity_by_uuid(
         latest_update_every_s = __atomic_load_n(&metric->latest_update_every_s, __ATOMIC_RELAXED);
         latest_time_s_clean = __atomic_load_n(&metric->latest_time_s_clean, __ATOMIC_RELAXED);
         metric_first_time_s = __atomic_load_n(&metric->first_time_s, __ATOMIC_RELAXED);
-        if (update_every_s && latest_update_every_s && latest_time_s_clean)
-            new_samples = (latest_time_s_clean - metric_first_time_s) / latest_update_every_s;
+        if (update_every_s)
+            mrg_metric_clean_samples_from_snapshot(
+                metric_first_time_s,
+                latest_time_s_clean,
+                latest_update_every_s,
+                &new_samples);
 
-        if (journal_samples)
+        if (journal_samples && new_samples > old_samples)
             *journal_samples += (new_samples - old_samples);
     }
     else {

--- a/src/database/engine/mrg.c
+++ b/src/database/engine/mrg.c
@@ -451,14 +451,20 @@ inline void mrg_update_metric_retention_and_granularity_by_uuid(
     if (likely(!added)) {
         uint64_t old_samples = 0;
 
-        if (update_every_s && metric->latest_update_every_s && metric->latest_time_s_clean)
-            old_samples = (metric->latest_time_s_clean - metric->first_time_s) / metric->latest_update_every_s;
+        uint32_t latest_update_every_s = __atomic_load_n(&metric->latest_update_every_s, __ATOMIC_RELAXED);
+        time_t latest_time_s_clean = __atomic_load_n(&metric->latest_time_s_clean, __ATOMIC_RELAXED);
+        time_t metric_first_time_s = __atomic_load_n(&metric->first_time_s, __ATOMIC_RELAXED);
+        if (update_every_s && latest_update_every_s && latest_time_s_clean)
+            old_samples = (latest_time_s_clean - metric_first_time_s) / latest_update_every_s;
 
         mrg_metric_expand_retention(mrg, metric, first_time_s, last_time_s, update_every_s);
 
         uint64_t new_samples = 0;
-        if (update_every_s && metric->latest_update_every_s && metric->latest_time_s_clean)
-            new_samples = (metric->latest_time_s_clean - metric->first_time_s) / metric->latest_update_every_s;
+        latest_update_every_s = __atomic_load_n(&metric->latest_update_every_s, __ATOMIC_RELAXED);
+        latest_time_s_clean = __atomic_load_n(&metric->latest_time_s_clean, __ATOMIC_RELAXED);
+        metric_first_time_s = __atomic_load_n(&metric->first_time_s, __ATOMIC_RELAXED);
+        if (update_every_s && latest_update_every_s && latest_time_s_clean)
+            new_samples = (latest_time_s_clean - metric_first_time_s) / latest_update_every_s;
 
         if (journal_samples)
             *journal_samples += (new_samples - old_samples);

--- a/src/database/engine/mrg.h
+++ b/src/database/engine/mrg.h
@@ -16,7 +16,8 @@ typedef struct mrg_entry {
 } MRG_ENTRY;
 
 struct mrg_statistics {
-    // --- non-atomic --- under a write lock
+    // --- sampled lock-free by mrg_get_statistics() ---
+    // Writers use relaxed atomics. The padded fields below are updated on hotter reader/writer paths.
 
     size_t entries;
     int64_t size;    // total memory used, with indexing
@@ -28,7 +29,7 @@ struct mrg_statistics {
     size_t delete_having_retention_or_referenced;
     size_t delete_misses;
 
-    // --- atomic --- multiple readers / writers
+    // --- hot counters --- multiple readers / writers
 
     PAD64(ssize_t) entries_acquired;
     PAD64(ssize_t) current_references;

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -177,7 +177,7 @@ struct page_details *page_details_get(void);
 
 #define pdc_page_status_check(pd, flag) (__atomic_load_n(&((pd)->status), __ATOMIC_ACQUIRE) & (flag))
 #define pdc_page_status_set(pd, flag)   __atomic_or_fetch(&((pd)->status), flag, __ATOMIC_RELEASE)
-#define pdc_page_status_clear(pd, flag) __atomic_and_fetch(&((od)->status), ~(flag), __ATOMIC_RELEASE)
+#define pdc_page_status_clear(pd, flag) __atomic_and_fetch(&((pd)->status), ~(flag), __ATOMIC_RELEASE)
 
 struct jv2_extents_info {
     uint32_t index;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens dbengine concurrency and correctness by making metadata and stats updates atomic, guarding journal sample deltas, fixing a potential use‑after‑free in MRG metric release, and correcting a status‑clear macro. Reduces data‑race risk in journal restore, page cache, and MRG paths.

- **Bug Fixes**
  - Page cache: repair and read `update_every_s` with relaxed atomics; updated snapshot callers.
  - Journal restore: log‑once map for unknown page types uses a relaxed atomic exchange to avoid races.
  - MRG: compute journal sample deltas from atomic snapshots and ignore non‑positive intervals to prevent bogus additions.
  - MRG: prevent metric resurrection by moving the last release directly to DELETED and restoring to 0 when retained; remove the redundant `deleted` flag.
  - MRG statistics: writers use relaxed atomic RMW; fix `entries_acquired` on retained final release and add a unittest.
  - Fix `pdc_page_status_clear()` to clear `pd->status` instead of a non‑existent `od->status`.

<sup>Written for commit 3741e3741438a2299de293e9ff14f71cf4ae4d52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

