### PR TITLE
Netdata fixes part 22

### DIFF
--- a/src/daemon/config/netdata-conf-profile.c
+++ b/src/daemon/config/netdata-conf-profile.c
@@ -26,8 +26,9 @@ static inline ND_PROFILE prefer_profile(ND_PROFILE setting, ND_PROFILE preferred
 
 ND_PROFILE nd_profile_detect_and_configure(bool recheck) {
     static ND_PROFILE profile = ND_PROFILE_NONE;
-    if(!recheck && profile != ND_PROFILE_NONE)
-        return profile;
+    ND_PROFILE cached_profile = __atomic_load_n(&profile, __ATOMIC_ACQUIRE);
+    if(!recheck && cached_profile != ND_PROFILE_NONE)
+        return cached_profile;
 
     // required for detecting the profile
     stream_conf_load();
@@ -88,8 +89,8 @@ ND_PROFILE nd_profile_detect_and_configure(bool recheck) {
                buffer_tostring(wb));
     }
 
-    profile = pt;
-    return profile;
+    __atomic_store_n(&profile, pt, __ATOMIC_RELEASE);
+    return pt;
 }
 
 struct nd_profile_t nd_profile = { 0 };

--- a/src/daemon/pulse/pulse-daemon-memory.c
+++ b/src/daemon/pulse/pulse-daemon-memory.c
@@ -125,7 +125,9 @@ void pulse_daemon_memory_do(bool extended __maybe_unused) {
         size_t health_log_memory = aral_used_bytes_from_stats(health_alarm_entry_aral_stats());
 
         rrddim_set_by_pointer(st_memory, rd_db_dbengine, (collected_number)pulse_dbengine_total_memory);
-        rrddim_set_by_pointer(st_memory, rd_db_rrd, (collected_number)pulse_rrd_memory_size);
+        rrddim_set_by_pointer(
+            st_memory, rd_db_rrd,
+            (collected_number)__atomic_load_n(&pulse_rrd_memory_size, __ATOMIC_RELAXED));
         rrddim_set_by_pointer(st_memory, rd_db_sqlite3, (collected_number)sqlite3_memory_used_highwater);
 
 #ifdef DICT_WITH_STATS

--- a/src/daemon/pulse/pulse-http-api.c
+++ b/src/daemon/pulse/pulse-http-api.c
@@ -31,7 +31,7 @@ void pulse_web_request_completed(uint64_t dt,
                                              uint64_t bytes_sent __maybe_unused,
                                              uint64_t content_size,
                                              uint64_t compressed_content_size) {
-    uint64_t old_web_usec_max = live_stats.web_usec_max;
+    uint64_t old_web_usec_max = __atomic_load_n(&live_stats.web_usec_max, __ATOMIC_RELAXED);
     while(dt > old_web_usec_max)
         __atomic_compare_exchange(&live_stats.web_usec_max, &old_web_usec_max, &dt, 1, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
 

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -294,7 +294,7 @@ static bool labels_add_already_sanitized(RRDLABELS *labels, const char *key, con
         changed = true;
     }
 
-    labels->version++;
+    __atomic_add_fetch(&labels->version, 1, __ATOMIC_RELAXED);
 
 //    judy_mem = JudyAllocThreadPulseGetAndReset();
 //    RRDLABELS_MEMORY_DELTA(&dictionary_stats_category_rrdlabels, judy_mem, 0);
@@ -762,7 +762,8 @@ bool rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src) {
     lfe_done_nolock();
 
     size_t removed = rrdlabels_remove_all_unmarked_unsafe(dst);
-    dst->version = src->version;
+    uint32_t src_version = __atomic_load_n(&src->version, __ATOMIC_RELAXED);
+    __atomic_store_n(&dst->version, src_version, __ATOMIC_RELAXED);
 
     spinlock_unlock(&src->spinlock);
     spinlock_unlock(&dst->spinlock);
@@ -834,7 +835,7 @@ void rrdlabels_copy(RRDLABELS *dst, RRDLABELS *src)
             // is modified. Same ordering as labels_add_already_sanitized().
             *((RRDLABEL_SRC *)PValue) = (ls & ~(RRDLABEL_FLAG_OLD)) | RRDLABEL_FLAG_NEW;
             dup_label(label);
-            dst->version++;
+            __atomic_add_fetch(&dst->version, 1, __ATOMIC_RELAXED);
             update_statistics = true;
         }
         else
@@ -857,7 +858,7 @@ void rrdlabels_copy(RRDLABELS *dst, RRDLABELS *src)
             // Cleanup is itself a state mutation: bump version and request
             // tail-stats accounting so version-based consumers and the
             // memory pulse stay correct even when no new insert happened.
-            dst->version++;
+            __atomic_add_fetch(&dst->version, 1, __ATOMIC_RELAXED);
             update_statistics = true;
         }
     }
@@ -1092,7 +1093,7 @@ uint32_t rrdlabels_version(RRDLABELS *labels __maybe_unused)
     if (unlikely(!labels))
         return 0;
 
-    return labels->version;
+    return __atomic_load_n(&labels->version, __ATOMIC_RELAXED);
 }
 
 void rrdset_update_rrdlabels(RRDSET *st, RRDLABELS *new_rrdlabels) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several data races by using atomic loads/stores for the profile cache, pulse metrics, and RRD labels versioning. No behavior or performance changes expected.

- **Bug Fixes**
  - Cache: `nd_profile_detect_and_configure()` now uses acquire/release atomics for the cached profile.
  - Pulse memory: sample `pulse_rrd_memory_size` with a relaxed atomic load when updating the `netdata.memory` RRD.
  - Pulse HTTP: initialize the max-latency CAS loop with a relaxed atomic load of `live_stats.web_usec_max`.
  - RRD labels: make `version` counter atomic (add/load/store) across add, copy, migrate, and read paths.

<sup>Written for commit 50b2f369310c2a159c1277a78881670ec409d23c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

