### PR TITLE
refactor(go.d): route jobmgr commands through an executor seam

### DIFF
--- a/src/go/plugin/agent/jobmgr/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg.go
@@ -3,8 +3,6 @@
 package jobmgr
 
 import (
-	"strings"
-
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 )
 
@@ -26,27 +24,18 @@ func (m *Manager) dyncfgConfig(fn dyncfg.Function) {
 }
 
 func (m *Manager) dyncfgQueuedExec(fn dyncfg.Function) {
-	switch {
-	case strings.HasPrefix(fn.ID(), m.dyncfgSecretStorePrefixValue()):
+	switch m.dyncfgDomain(fn) {
+	case domainSecretStore:
 		m.dyncfgSecretStoreExec(fn)
-	case strings.HasPrefix(fn.ID(), m.dyncfgCollectorPrefixValue()):
+	case domainCollector:
 		m.dyncfgCollectorExec(fn)
-	case strings.HasPrefix(fn.ID(), m.dyncfgVnodePrefixValue()):
+	case domainVnode:
 		m.dyncfgVnodeExec(fn)
 	default:
-		m.dyncfgResponder.SendCodef(fn, 503, "unknown function '%s' (%s).", fn.Fn().Name, fn.ID())
+		m.dyncfgRespondUnknown(fn)
 	}
 }
 
-func (m *Manager) dyncfgSeqExec(fn dyncfg.Function) {
-	switch {
-	case strings.HasPrefix(fn.ID(), m.dyncfgSecretStorePrefixValue()):
-		m.dyncfgSecretStoreSeqExec(fn)
-	case strings.HasPrefix(fn.ID(), m.dyncfgCollectorPrefixValue()):
-		m.dyncfgCollectorSeqExec(fn)
-	case strings.HasPrefix(fn.ID(), m.dyncfgVnodePrefixValue()):
-		m.dyncfgVnodeSeqExec(fn)
-	default:
-		m.dyncfgResponder.SendCodef(fn, 503, "unknown function '%s' (%s).", fn.Fn().Name, fn.ID())
-	}
+func (m *Manager) dyncfgRespondUnknown(fn dyncfg.Function) {
+	m.dyncfgResponder.SendCodef(fn, 503, "unknown function '%s' (%s).", fn.Fn().Name, fn.ID())
 }

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -32,51 +32,61 @@ type collectorCallbacks struct {
 }
 
 func (cb *collectorCallbacks) ExtractKey(fn dyncfg.Function) (key, name string, ok bool) {
+	key, name, warnErr, ok := cb.mgr.collectorCommandKey(fn)
+	if warnErr != nil {
+		cb.mgr.Warningf("dyncfg: %s: %v", fn.Command(), warnErr)
+	}
+	return key, name, ok
+}
+
+// collectorCommandKey derives the exposed-cache key a collector dyncfg
+// command addresses. It never logs so the executor can derive keys at event
+// construction without duplicating ExtractKey's execution-time warnings:
+// warnErr, when non-nil, is the warning ExtractKey reports; malformed IDs
+// that ExtractKey rejects silently fail with a nil warnErr.
+func (m *Manager) collectorCommandKey(fn dyncfg.Function) (key, name string, warnErr error, ok bool) {
 	var mn, jn string
 
 	if fn.Command() == dyncfg.CommandAdd {
 		// For add: ID is module template, job name is in Args[2].
-		mn, ok = cb.mgr.extractModuleName(fn.ID())
+		mn, ok = m.extractModuleName(fn.ID())
 		if !ok {
-			return "", "", false
+			return "", "", nil, false
 		}
-		if cb.mgr.isSingleInstanceCollector(mn) {
-			cb.mgr.Warningf("dyncfg: %s: single-instance collector %s does not support add", fn.Command(), mn)
-			return "", "", false
+		if m.isSingleInstanceCollector(mn) {
+			return "", "", fmt.Errorf("single-instance collector %s does not support add", mn), false
 		}
 		jn = fn.JobName()
 		if jn == "" {
-			return "", "", false
+			return "", "", nil, false
 		}
 	} else {
-		mn, ok = cb.mgr.extractModuleName(fn.ID())
+		mn, ok = m.extractModuleName(fn.ID())
 		if !ok {
-			return "", "", false
+			return "", "", nil, false
 		}
-		if cb.mgr.isSingleInstanceCollector(mn) {
-			if fn.ID() != cb.mgr.dyncfgModID(mn) {
-				cb.mgr.Warningf("dyncfg: %s: single-instance collector %s must use config ID %s", fn.Command(), mn, cb.mgr.dyncfgModID(mn))
-				return "", "", false
+		if m.isSingleInstanceCollector(mn) {
+			if fn.ID() != m.dyncfgModID(mn) {
+				return "", "", fmt.Errorf("single-instance collector %s must use config ID %s", mn, m.dyncfgModID(mn)), false
 			}
 			jn = mn
 		} else {
 			// For per-job commands: ID contains module:job.
-			mn, jn, ok = cb.mgr.extractModuleJobName(fn.ID())
+			mn, jn, ok = m.extractModuleJobName(fn.ID())
 			if !ok {
-				return "", "", false
+				return "", "", nil, false
 			}
 		}
 	}
-	if err := cb.mgr.validateDyncfgCollectorIdentity(mn, jn); err != nil {
-		cb.mgr.Warningf("dyncfg: %s: %v", fn.Command(), err)
-		return "", "", false
+	if err := m.validateDyncfgCollectorIdentity(mn, jn); err != nil {
+		return "", "", err, false
 	}
 
 	key = mn + "_" + jn
 	if mn == jn {
 		key = jn
 	}
-	return key, jn, true
+	return key, jn, nil, true
 }
 
 func (cb *collectorCallbacks) ValidateConfigName(name string) error {

--- a/src/go/plugin/agent/jobmgr/executor.go
+++ b/src/go/plugin/agent/jobmgr/executor.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+)
+
+// The executor is the single dispatch seam between the run loop and the
+// command handlers: every discovery and dyncfg event is classified into an
+// event (kind, domain, derived key) and executed through dispatch, so
+// execution policy can change without touching the handlers or the loop's
+// select structure.
+//
+// The current policy is one global lane: dispatch runs every event inline on
+// the caller goroutine, with no queuing, preserving the run loop's serialized
+// semantics. The derived key identifies the config an event addresses and is
+// inert routing metadata under this policy.
+
+type eventKind int8
+
+const (
+	eventDiscoveryAdd eventKind = iota + 1
+	eventDiscoveryRemove
+	eventDyncfgCommand
+)
+
+type eventDomain int8
+
+const (
+	domainUnknown eventDomain = iota
+	domainCollector
+	domainSecretStore
+	domainVnode
+)
+
+// event is one unit of work for the executor. Discovery events carry cfg;
+// dyncfg command events carry fn.
+type event struct {
+	kind   eventKind
+	domain eventDomain
+	key    string
+	cfg    confgroup.Config
+	fn     dyncfg.Function
+}
+
+type executor struct {
+	mgr *Manager
+}
+
+func newExecutor(mgr *Manager) *executor {
+	return &executor{mgr: mgr}
+}
+
+// dispatch executes ev synchronously on the caller goroutine.
+func (e *executor) dispatch(ev event) {
+	switch ev.kind {
+	case eventDiscoveryAdd:
+		e.mgr.addConfig(ev.cfg)
+	case eventDiscoveryRemove:
+		e.mgr.removeConfig(ev.cfg)
+	case eventDyncfgCommand:
+		e.dispatchDyncfg(ev)
+	}
+}
+
+func (e *executor) dispatchDyncfg(ev event) {
+	switch ev.domain {
+	case domainSecretStore:
+		e.mgr.dyncfgSecretStoreSeqExec(ev.fn)
+	case domainCollector:
+		e.mgr.dyncfgCollectorSeqExec(ev.fn)
+	case domainVnode:
+		e.mgr.dyncfgVnodeSeqExec(ev.fn)
+	default:
+		e.mgr.dyncfgRespondUnknown(ev.fn)
+	}
+}
+
+func (m *Manager) newDiscoveryAddEvent(cfg confgroup.Config) event {
+	return event{kind: eventDiscoveryAdd, domain: domainCollector, key: cfg.ExposedKey(), cfg: cfg}
+}
+
+func (m *Manager) newDiscoveryRemoveEvent(cfg confgroup.Config) event {
+	return event{kind: eventDiscoveryRemove, domain: domainCollector, key: cfg.ExposedKey(), cfg: cfg}
+}
+
+// newDyncfgEvent classifies a dyncfg command by ID prefix and derives its
+// key. Underivable input keeps the domain's fallback key and still executes,
+// so it reaches the handler's existing rejection paths unchanged.
+func (m *Manager) newDyncfgEvent(fn dyncfg.Function) event {
+	ev := event{kind: eventDyncfgCommand, domain: m.dyncfgDomain(fn), fn: fn}
+
+	var key string
+	var ok bool
+	switch ev.domain {
+	case domainSecretStore:
+		key, ok = m.secretsCtl.DeriveKey(fn)
+	case domainCollector:
+		key, _, _, ok = m.collectorCommandKey(fn)
+	case domainVnode:
+		key, ok = m.vnodesCtl.DeriveKey(fn)
+	}
+	if !ok {
+		key = m.dyncfgFallbackKey(ev.domain)
+	}
+	ev.key = key
+	return ev
+}
+
+func (m *Manager) dyncfgDomain(fn dyncfg.Function) eventDomain {
+	switch {
+	case strings.HasPrefix(fn.ID(), m.dyncfgSecretStorePrefixValue()):
+		return domainSecretStore
+	case strings.HasPrefix(fn.ID(), m.dyncfgCollectorPrefixValue()):
+		return domainCollector
+	case strings.HasPrefix(fn.ID(), m.dyncfgVnodePrefixValue()):
+		return domainVnode
+	default:
+		return domainUnknown
+	}
+}
+
+// dyncfgFallbackKey is the registration-wide key for commands whose config
+// identity cannot be derived; unknown-prefix commands are rejected at
+// dispatch and get no domain key.
+func (m *Manager) dyncfgFallbackKey(domain eventDomain) string {
+	switch domain {
+	case domainSecretStore:
+		return m.dyncfgSecretStorePrefixValue()
+	case domainCollector:
+		return m.dyncfgCollectorPrefixValue()
+	case domainVnode:
+		return m.dyncfgVnodePrefixValue()
+	default:
+		return ""
+	}
+}

--- a/src/go/plugin/agent/jobmgr/executor_test.go
+++ b/src/go/plugin/agent/jobmgr/executor_test.go
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
+	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newExecutorTestManager() (*Manager, *bytes.Buffer) {
+	mgr := newCollectorTestManagerWithService(newTestSecretStoreService())
+	mgr.modules.Register("single", collectorapi.Creator{
+		InstancePolicy: collectorapi.InstancePolicySingle,
+		Create:         func() collectorapi.CollectorV1 { return &collectorapi.MockCollectorV1{} },
+	})
+
+	var buf bytes.Buffer
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&buf))))
+	return mgr, &buf
+}
+
+func newExecutorTestFn(uid string, args []string, payload []byte) dyncfg.Function {
+	fn := functions.Function{UID: uid, Args: args}
+	if payload != nil {
+		fn.Payload = payload
+		fn.ContentType = "application/json"
+	}
+	return dyncfg.NewFunction(fn)
+}
+
+func TestExecutor_KeyDerivation(t *testing.T) {
+	tests := map[string]struct {
+		event      func(mgr *Manager) event
+		wantDomain eventDomain
+		wantKey    string
+	}{
+		// Collector discovery events key by the config's exposed key.
+		"collector discovery add keys by exposed key": {
+			event: func(mgr *Manager) event {
+				return mgr.newDiscoveryAddEvent(prepareUserCfg("success", "a"))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "success_a",
+		},
+		"collector discovery remove keys by exposed key": {
+			event: func(mgr *Manager) event {
+				return mgr.newDiscoveryRemoveEvent(prepareUserCfg("success", "a"))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "success_a",
+		},
+
+		// Collector commands mirror the handler callbacks' ExtractKey.
+		"collector add keys by module plus job name from args": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:success", "add", "a"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "success_a",
+		},
+		"collector add sanitizes the job name like JobName": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:success", "add", "a b"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "success_a_b",
+		},
+		"collector per-job command keys by module and job from ID": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:success:a", "enable"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "success_a",
+		},
+		"collector per-job command with job equal to module collapses the key": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:success:success", "get"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "success",
+		},
+		"collector unregistered module still derives a per-job key": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:ghost:j", "enable"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "ghost_j",
+		},
+		"single-instance collector keys by module": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:single", "enable"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "single",
+		},
+		"single-instance add is underivable": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:single", "add", "x"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "test:collector:",
+		},
+		"single-instance per-job ID is underivable": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:single:x", "disable"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "test:collector:",
+		},
+		"collector add without job name is underivable": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:success", "add"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "test:collector:",
+		},
+		"collector empty module is underivable": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:collector:", "enable"}, nil))
+			},
+			wantDomain: domainCollector,
+			wantKey:    "test:collector:",
+		},
+
+		// Secretstore commands key by store key (kind:name).
+		"secretstore command keys by store key": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:secretstore:vault:prod", "update"}, nil))
+			},
+			wantDomain: domainSecretStore,
+			wantKey:    "vault:prod",
+		},
+		"secretstore template add keys by kind and name from args": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:secretstore:vault", "add", "prod"}, nil))
+			},
+			wantDomain: domainSecretStore,
+			wantKey:    "vault:prod",
+		},
+		"secretstore invalid kind is underivable": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:secretstore:bogus:x", "update"}, nil))
+			},
+			wantDomain: domainSecretStore,
+			wantKey:    "test:secretstore:",
+		},
+		"secretstore template add without name is underivable": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:secretstore:vault", "add"}, nil))
+			},
+			wantDomain: domainSecretStore,
+			wantKey:    "test:secretstore:",
+		},
+
+		// Vnode commands key by vnode name.
+		"vnode job command keys by name from ID": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:vnode:myhost", "update"}, nil))
+			},
+			wantDomain: domainVnode,
+			wantKey:    "myhost",
+		},
+		"vnode add keys by name from args": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:vnode", "add", "myhost"}, nil))
+			},
+			wantDomain: domainVnode,
+			wantKey:    "myhost",
+		},
+		"vnode template schema is underivable": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:vnode", "schema"}, nil))
+			},
+			wantDomain: domainVnode,
+			wantKey:    "test:vnode",
+		},
+		"vnode empty name is underivable": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"test:vnode:", "get"}, nil))
+			},
+			wantDomain: domainVnode,
+			wantKey:    "test:vnode",
+		},
+
+		// Unknown prefixes have no domain and no domain key.
+		"unknown prefix has no domain key": {
+			event: func(mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("uid", []string{"bogus:thing:x", "enable"}, nil))
+			},
+			wantDomain: domainUnknown,
+			wantKey:    "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr, _ := newExecutorTestManager()
+
+			ev := tc.event(mgr)
+
+			assert.Equal(t, tc.wantDomain, ev.domain)
+			assert.Equal(t, tc.wantKey, ev.key)
+		})
+	}
+}
+
+func TestExecutor_DispatchOrder(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T, mgr *Manager, buf *bytes.Buffer)
+	}{
+		"dyncfg commands emit terminals in dispatch order": {
+			run: func(t *testing.T, mgr *Manager, buf *bytes.Buffer) {
+				var wants []wireRecordWant
+				for i := 1; i <= 3; i++ {
+					uid := fmt.Sprintf("order-%d", i)
+					fn := newExecutorTestFn(uid, []string{fmt.Sprintf("test:collector:success:missing%d", i), "get"}, nil)
+					mgr.executor.dispatch(mgr.newDyncfgEvent(fn))
+					wants = append(wants, wireRecordWant{
+						name:     uid + " terminal",
+						contains: []string{"FUNCTION_RESULT_BEGIN " + uid},
+					})
+				}
+
+				requireWireRecordSubsequence(t, buf.String(), wants)
+			},
+		},
+		"discovery and dyncfg events execute in dispatch order": {
+			run: func(t *testing.T, mgr *Manager, buf *bytes.Buffer) {
+				cfg := prepareUserCfg("success", "o1")
+
+				mgr.executor.dispatch(mgr.newDiscoveryAddEvent(cfg))
+				mgr.executor.dispatch(mgr.newDyncfgEvent(newExecutorTestFn("mid-get", []string{mgr.dyncfgJobID(cfg), "get"}, nil)))
+				mgr.executor.dispatch(mgr.newDiscoveryRemoveEvent(cfg))
+
+				requireWireRecordSubsequence(t, buf.String(), []wireRecordWant{
+					{
+						name:     "discovery add config create",
+						contains: []string{"CONFIG test:collector:success:o1 create"},
+					},
+					{
+						name:     "get terminal",
+						contains: []string{"FUNCTION_RESULT_BEGIN mid-get"},
+					},
+					{
+						name:     "discovery remove config delete",
+						contains: []string{"CONFIG test:collector:success:o1 delete"},
+					},
+				})
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr, buf := newExecutorTestManager()
+			tc.run(t, mgr, buf)
+		})
+	}
+}
+
+// Underivable events take the fallback key and must still execute, reaching
+// each domain's existing rejection (or template-scope success) paths.
+func TestExecutor_UnderivableEventExecution(t *testing.T) {
+	tests := map[string]struct {
+		fn       dyncfg.Function
+		wantCode int
+		wantMsg  string
+	}{
+		"single-instance add answers 400": {
+			fn:       newExecutorTestFn("si-add", []string{"test:collector:single", "add", "x"}, []byte("{}")),
+			wantCode: 400,
+			wantMsg:  "invalid config ID format",
+		},
+		"single-instance per-job enable answers 400": {
+			fn:       newExecutorTestFn("si-enable", []string{"test:collector:single:x", "enable"}, nil),
+			wantCode: 400,
+			wantMsg:  "invalid config ID format",
+		},
+		"collector add without job name answers 400": {
+			fn:       newExecutorTestFn("no-name-add", []string{"test:collector:success", "add"}, []byte("{}")),
+			wantCode: 400,
+		},
+		"secretstore malformed store key answers 400": {
+			fn:       newExecutorTestFn("ss-bad-update", []string{"test:secretstore:", "update"}, nil),
+			wantCode: 400,
+			wantMsg:  "invalid config ID format",
+		},
+		"vnode empty name answers 404": {
+			fn:       newExecutorTestFn("vn-bad-get", []string{"test:vnode:", "get"}, nil),
+			wantCode: 404,
+			wantMsg:  "is not registered",
+		},
+		"vnode template schema still succeeds": {
+			fn:       newExecutorTestFn("vn-schema", []string{"test:vnode", "schema"}, nil),
+			wantCode: 200,
+		},
+		"unknown prefix answers 503": {
+			fn:       newExecutorTestFn("unknown-fn", []string{"bogus:thing:x", "enable"}, nil),
+			wantCode: 503,
+			wantMsg:  "unknown function",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr, buf := newExecutorTestManager()
+
+			mgr.executor.dispatch(mgr.newDyncfgEvent(tc.fn))
+
+			output := buf.String()
+			require.Contains(t, output,
+				fmt.Sprintf("FUNCTION_RESULT_BEGIN %s %d", tc.fn.UID(), tc.wantCode),
+				"expected a terminal response with the pinned code")
+			if tc.wantMsg != "" {
+				assert.True(t, strings.Contains(output, tc.wantMsg),
+					"expected output to contain %q, got:\n%s", tc.wantMsg, output)
+			}
+		})
+	}
+}

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -168,6 +168,7 @@ func New(cfg Config) *Manager {
 		RestartableAffectedJobs: mgr.restartableAffectedJobs,
 		RestartDependentJobs:    mgr.restartDependentJobs,
 	})
+	mgr.executor = newExecutor(mgr)
 
 	return mgr
 }
@@ -217,6 +218,7 @@ type Manager struct {
 	collectorCallbacks *collectorCallbacks
 	secretsCtl         *secretsctl.Controller
 	vnodesCtl          *vnodectl.Controller
+	executor           *executor
 
 	// Runtime loop state.
 	ctx              context.Context
@@ -342,11 +344,11 @@ func (m *Manager) run() {
 			case <-m.ctx.Done():
 				return
 			case cfg := <-m.addCh:
-				m.addConfig(cfg)
+				m.executor.dispatch(m.newDiscoveryAddEvent(cfg))
 			case cfg := <-m.rmCh:
-				m.removeConfig(cfg)
+				m.executor.dispatch(m.newDiscoveryRemoveEvent(cfg))
 			case fn := <-m.dyncfgCh:
-				m.dyncfgSeqExec(fn)
+				m.executor.dispatch(m.newDyncfgEvent(fn))
 			}
 		}
 	}
@@ -398,7 +400,7 @@ func (m *Manager) runWaitDecisionStep() bool {
 		case <-m.ctx.Done():
 			return false
 		case fn := <-m.dyncfgCh:
-			m.dyncfgSeqExec(fn)
+			m.executor.dispatch(m.newDyncfgEvent(fn))
 		}
 		return true
 	}
@@ -417,7 +419,7 @@ func (m *Manager) runWaitDecisionStep() bool {
 	case <-m.ctx.Done():
 		return false
 	case fn := <-m.dyncfgCh:
-		m.dyncfgSeqExec(fn)
+		m.executor.dispatch(m.newDyncfgEvent(fn))
 	case <-timer.C:
 		m.collectorHandler.ExpireWaitDecision()
 	}

--- a/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
@@ -17,6 +17,15 @@ func dyncfgSecretStoreTemplateCmds() string {
 	return dyncfg.JoinCommands(dyncfg.CommandAdd, dyncfg.CommandSchema, dyncfg.CommandUserconfig)
 }
 
+// DeriveKey returns the store key a dyncfg command addresses, mirroring the
+// handler callbacks' ExtractKey: template `add` keys by kind plus the name in
+// Args[2], other commands parse the store key from the config ID. It never
+// logs and has no side effects, so callers can derive keys before execution.
+func (c *Controller) DeriveKey(fn dyncfg.Function) (string, bool) {
+	key, _, ok := c.cb.ExtractKey(fn)
+	return key, ok
+}
+
 func (c *Controller) SeqExec(fn dyncfg.Function) {
 	switch fn.Command() {
 	case dyncfg.CommandSchema:

--- a/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
@@ -37,6 +37,24 @@ func dyncfgVnodeJobCmds(isDyncfgJob bool) string {
 	return dyncfg.JoinCommands(cmds...)
 }
 
+// DeriveKey returns the vnode name a dyncfg command addresses. Job-scope
+// commands carry it in the config ID (`<prefix>:<name>`, the same extraction
+// the command handlers use); template-scope add/test carry it in Args[2].
+// Template-scope commands without a name (schema, userconfig) are not
+// addressable to a vnode and report !ok. It never logs and has no side
+// effects, so callers can derive keys before execution.
+func (c *Controller) DeriveKey(fn dyncfg.Function) (string, bool) {
+	if name, ok := strings.CutPrefix(fn.ID(), c.Prefix()+":"); ok && name != "" {
+		return name, true
+	}
+	if fn.ID() == c.Prefix() {
+		if name := fn.JobName(); name != "" {
+			return name, true
+		}
+	}
+	return "", false
+}
+
 func (c *Controller) SeqExec(fn dyncfg.Function) {
 	switch fn.Command() {
 	case dyncfg.CommandSchema:

--- a/src/go/plugin/framework/functions/characterization_test.go
+++ b/src/go/plugin/framework/functions/characterization_test.go
@@ -16,6 +16,7 @@ package functions
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -48,12 +49,7 @@ func TestCharacterization_PrefixLaneHeldUntilTerminalFinalize(t *testing.T) {
 				}
 				hasHandled := func(uid string) func() bool {
 					return func() bool {
-						for _, got := range handledUIDs() {
-							if got == uid {
-								return true
-							}
-						}
-						return false
+						return slices.Contains(handledUIDs(), uid)
 					}
 				}
 


### PR DESCRIPTION
Introduce a single dispatch seam between the jobmgr run loop and the command handlers. Every discovery and dyncfg event is classified into an event (kind, domain, derived key) and executed through executor.dispatch; the loop's select arms and the wait-decision step no longer call handlers directly, and the old dyncfgSeqExec prefix switch is removed.

Execution is unchanged: dispatch runs every event inline on the loop goroutine in one global lane, with no queuing and no new goroutines.

Key derivation identifies the config an event addresses per domain: collector discovery by cfg.ExposedKey(); collector commands per the handler callbacks' ExtractKey semantics (add keys by module plus the job name in Args[2]; single-instance by module), via a silent core shared with ExtractKey so derivation never duplicates execution-time warnings; secretstore commands by store key (template add by kind:name); vnode commands by vnode name. Underivable input takes the domain's registration-prefix fallback key and still reaches the existing rejection paths.

New tests: key-derivation matrix across all domains, dispatch-order pin, and underivable-input execution pins. No existing test file is modified; the characterization pins and golden sims pass unchanged.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all `jobmgr` discovery and dyncfg commands through a single `executor` that classifies events and derives per-domain keys, while keeping execution inline, single-lane, and ordered. This simplifies the run loop and isolates execution policy.

- **Refactors**
  - Added `executor` with event classification (kind, domain, key) and `dispatch`; run loop and wait-decision now call `executor.dispatch`.
  - Execution unchanged: one global lane, no queues, no new goroutines.
  - Key derivation:
    - Collector discovery via `Config.ExposedKey()`; collector commands via `collectorCommandKey` shared with callbacks’ `ExtractKey`.
    - Secret store via `secretsctl.DeriveKey` (kind:name; template `add` reads `Args[2]`).
    - Vnode via `vnodectl.DeriveKey` (name from ID or `Args[2]`; template commands without a name are not addressable).
    - Underivable input uses the domain’s registration prefix; unknown prefixes rejected with `dyncfgRespondUnknown`.
  - Removed the old `dyncfgSeqExec` prefix switch.
  - Added tests: key-derivation matrix, dispatch-order pin, and underivable-input execution pins.
  - Small go fix: use `slices.Contains` in `functions/characterization_test.go`.

<sup>Written for commit 8f831bd98bac93a33ba5484bc15b856f5b6afa81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

