### PR TITLE
refactor(go.d): run blocking jobmgr collector work as supervised effects

### DIFF
--- a/.agents/skills/project-snmp-trap-profiles-authoring/decisions/0001-go-process-and-trapwriter.md
+++ b/.agents/skills/project-snmp-trap-profiles-authoring/decisions/0001-go-process-and-trapwriter.md
@@ -60,8 +60,8 @@ The implementation language is **Go** (user decision, 2026-05-25). The journal w
 | Pattern | Source | Lines |
 |---|---|---|
 | go.d V2 collector registration + lifecycle | `src/go/plugin/go.d/collector/ping/collector.go:25-34` | `collectorapi.Register("ping", ...)` + `CreateV2` |
-| DynCfg job orchestration | `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go:85-121` | `Start()` preflight + coded errors |
-| codedError for HTTP-422 | `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go:140-147` | `type codedError struct` with `DyncfgCode() int` |
+| DynCfg job orchestration | `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go` (`collectorCallbacks.Start`) | `Start()` preflight + coded errors |
+| codedError for HTTP-422 | `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go` (`codedError`) | `type codedError struct` with `DyncfgCode() int` |
 | SNMP profile multipath+dedup loader | `src/go/plugin/go.d/collector/snmp/ddsnmp/load.go:270-286` | `multipath.MultiPath` + filename dedup |
 | chart templates (V2) | `src/go/plugin/go.d/collector/ping/charts.yaml` | YAML-driven chart definitions |
 
@@ -415,21 +415,21 @@ All job resources are validated synchronously in the go.d framework's job `Start
 
 These errors must flow through DynCfg as coded errors with the resource-specific code above. Non-retryable configuration/profile errors use HTTP-422; retryable startup/environment errors use HTTP-503 and implement `DyncfgRetryable() bool` so file-configured jobs can retry after the transient condition clears.
 
-- `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go:88-90` wraps `Start()` `createCollectorJob()` failures as `codedError{code: 400}`, hiding any inner 422.
-- `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go:93-96` schedules retry and returns a plain error for `Start()` `AutoDetection()` failures.
-- `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go:108-116` returns plain errors for both `Update()` `createCollectorJob()` and `AutoDetection()` failures.
+- `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go` (`collectorCallbacks.Start`) wraps `createCollectorJob()` failures as `codedError{code: 400}`, hiding any inner 422.
+- `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go` (`collectorCallbacks.Start`) schedules retry and returns a plain error for `AutoDetection(ctx)` failures.
+- `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go` (`collectorCallbacks.Update`) returns plain errors for both `createCollectorJob()` and `AutoDetection(ctx)` failures.
 - `src/go/plugin/framework/dyncfg/handler.go:506-509` honors `CodedError` for `CmdEnable`, but `CmdUpdate` callback failures currently send HTTP 200 at `handler.go:683`. Update payload parse/validation failures already return HTTP 400 before the callback path.
 
 **Framework change needed** (small jobmgr + DynCfg handler edit, scoped to SOW-0035 M2):
 
 1. Preserve an inner `CodedError` from `createCollectorJob()` instead of replacing it with hardcoded HTTP 400.
-2. If `AutoDetection()` returns a `CodedError`, call `Cleanup()` and return that error. Schedule a retry only when the error also implements `DyncfgRetryable() bool` and returns `true`; plain non-coded `AutoDetection()` errors keep the existing retry behavior for other collectors.
+2. If `AutoDetection(ctx)` returns a `CodedError`, call `Cleanup()` and return that error. Schedule a retry only when the error also implements `DyncfgRetryable() bool` and returns `true`; plain non-coded `AutoDetection(ctx)` errors keep the existing retry behavior for other collectors.
 3. Make `Update()` mirror `Start()` for both `createCollectorJob()` and `AutoDetection()` coded errors.
 4. Make the `CmdUpdate` callback error path at `src/go/plugin/framework/dyncfg/handler.go:683` honor `CodedError` response codes like `CmdEnable` does, instead of always sending HTTP 200 for `cb.Start()` / `cb.Update()` failure. Preserve the existing `ErrNonDisruptiveUpdate` rollback path at `handler.go:667-677` as HTTP 200 because the old config remains effective and runtime state did not change; trap creation-time failures must not use `ErrNonDisruptiveUpdate`.
 
 Before changing shared DynCfg behavior, M2 must run a same-failure scan (`rg 'CodedError|codedError|MarkNonDisruptiveUpdate' src/go/plugin`) and add handler/jobmgr tests proving existing plain-error retry behavior remains unchanged while coded trap creation failures surface their HTTP status.
 
-The trap plugin must still preflight all resources before it reports successful startup. `AutoDetection()` should be a no-op for traps unless a future SOW proves a cheap consistency check is needed; bind/profile/journal/writer/retention failures must be creation-time coded errors, not retry-loop events.
+The trap plugin must still preflight all resources before it reports successful startup. `AutoDetection(ctx)` should be a no-op for traps unless a future SOW proves a cheap consistency check is needed; bind/profile/journal/writer/retention failures must be creation-time coded errors, not retry-loop events.
 
 **Partial resource cleanup**: if endpoint 3 of 5 fails to bind after endpoints 1-2 succeeded, the previously bound endpoints are closed before returning the error. The job never enters the running state.
 

--- a/.agents/skills/project-snmp-trap-profiles-authoring/decisions/0001-go-process-and-trapwriter.md
+++ b/.agents/skills/project-snmp-trap-profiles-authoring/decisions/0001-go-process-and-trapwriter.md
@@ -424,7 +424,7 @@ These errors must flow through DynCfg as coded errors with the resource-specific
 
 1. Preserve an inner `CodedError` from `createCollectorJob()` instead of replacing it with hardcoded HTTP 400.
 2. If `AutoDetection(ctx)` returns a `CodedError`, call `Cleanup()` and return that error. Schedule a retry only when the error also implements `DyncfgRetryable() bool` and returns `true`; plain non-coded `AutoDetection(ctx)` errors keep the existing retry behavior for other collectors.
-3. Make `Update()` mirror `Start()` for both `createCollectorJob()` and `AutoDetection()` coded errors.
+3. Make `Update()` mirror `Start()` for both `createCollectorJob()` and `AutoDetection(ctx)` coded errors.
 4. Make the `CmdUpdate` callback error path at `src/go/plugin/framework/dyncfg/handler.go:683` honor `CodedError` response codes like `CmdEnable` does, instead of always sending HTTP 200 for `cb.Start()` / `cb.Update()` failure. Preserve the existing `ErrNonDisruptiveUpdate` rollback path at `handler.go:667-677` as HTTP 200 because the old config remains effective and runtime state did not change; trap creation-time failures must not use `ErrNonDisruptiveUpdate`.
 
 Before changing shared DynCfg behavior, M2 must run a same-failure scan (`rg 'CodedError|codedError|MarkNonDisruptiveUpdate' src/go/plugin`) and add handler/jobmgr tests proving existing plain-error retry behavior remains unchanged while coded trap creation failures surface their HTTP status.
@@ -486,7 +486,7 @@ On `Update()`, current jobmgr behavior stops the old running job before creating
 - Existing Rust journal-log-writer: `src/crates/journal-log-writer/src/log/mod.rs`
 - Existing NetFlow journal retention: `src/crates/netflow-plugin/src/plugin_config/types/journal.rs`
 - go.d DynCfg callbacks: `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go`
-- go.d codedError: `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go:140-147`
+- go.d codedError: `src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go` (`codedError`)
 - go.d V2 collector pattern: `src/go/plugin/go.d/collector/ping/collector.go`
 - SNMP profile loader multipath pattern: `src/go/plugin/go.d/collector/snmp/ddsnmp/load.go:270-286`
 - Design spec: `.agents/skills/project-snmp-trap-profiles-authoring/netdata.md` §5, §11, §19

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -146,6 +146,9 @@ func (cb *collectorCallbacks) Start(cfg confgroup.Config) error {
 		return &codedError{err: fmt.Errorf("invalid configuration: failed to apply configuration: %w", createErr), code: 400}
 	}
 	if err != nil {
+		// Tracking removal only. The gate itself stays open by contract -
+		// closing is reserved for abandoning a wedged stop - and no writer
+		// survives here anyway: the job never started.
 		cb.mgr.emissionGates.remove(cfg.FullName())
 		if _, ok := errors.AsType[dyncfg.CodedError](err); ok {
 			if dyncfg.IsRetryableError(err) {
@@ -188,6 +191,7 @@ func (cb *collectorCallbacks) Update(oldCfg, newCfg confgroup.Config) error {
 		return fmt.Errorf("job update failed: %w", createErr)
 	}
 	if err != nil {
+		// Tracking removal only; see the identical note in Start.
 		cb.mgr.emissionGates.remove(newCfg.FullName())
 		var ce dyncfg.CodedError
 		if errors.As(err, &ce) {

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -116,19 +116,31 @@ func (cb *collectorCallbacks) ParseAndValidate(fn dyncfg.Function, name string) 
 func (cb *collectorCallbacks) Start(cfg confgroup.Config) error {
 	cb.mgr.retryingTasks.remove(cfg)
 
-	job, err := cb.mgr.createCollectorJob(cfg)
-	if err != nil {
-		var ce dyncfg.CodedError
-		if errors.As(err, &ce) {
+	// The blocking module work (job creation incl. secret resolution, then
+	// detection) runs as one effect; retry scheduling and the running-job
+	// registration stay with the loop-owned state below.
+	var job runtimeJob
+	var createErr error
+	err := cb.mgr.runEffectSync(cfg.FullName(), func(ctx context.Context) error {
+		job, createErr = cb.mgr.createCollectorJob(cfg)
+		if createErr != nil {
+			return createErr
+		}
+		if err := job.AutoDetection(ctx); err != nil {
+			job.Cleanup()
 			return err
 		}
-		return &codedError{err: fmt.Errorf("invalid configuration: failed to apply configuration: %w", err), code: 400}
-	}
+		return nil
+	})
 
-	// Detection is uncancellable by contract: Init/Check run to completion
-	// (no deadline or shutdown cancellation is wired into this path).
-	if err := job.AutoDetection(context.Background()); err != nil {
-		job.Cleanup()
+	if createErr != nil {
+		var ce dyncfg.CodedError
+		if errors.As(createErr, &ce) {
+			return createErr
+		}
+		return &codedError{err: fmt.Errorf("invalid configuration: failed to apply configuration: %w", createErr), code: 400}
+	}
+	if err != nil {
 		var ce dyncfg.CodedError
 		if errors.As(err, &ce) {
 			if dyncfg.IsRetryableError(err) {
@@ -149,19 +161,28 @@ func (cb *collectorCallbacks) Update(oldCfg, newCfg confgroup.Config) error {
 	cb.mgr.stopRunningJob(oldCfg.FullName())
 	cb.mgr.fileStatus.remove(oldCfg)
 
-	job, err := cb.mgr.createCollectorJob(newCfg)
-	if err != nil {
-		var ce dyncfg.CodedError
-		if errors.As(err, &ce) {
+	var job runtimeJob
+	var createErr error
+	err := cb.mgr.runEffectSync(newCfg.FullName(), func(ctx context.Context) error {
+		job, createErr = cb.mgr.createCollectorJob(newCfg)
+		if createErr != nil {
+			return createErr
+		}
+		if err := job.AutoDetection(ctx); err != nil {
+			job.Cleanup()
 			return err
 		}
-		return fmt.Errorf("job update failed: %w", err)
-	}
+		return nil
+	})
 
-	// Detection is uncancellable by contract: Init/Check run to completion
-	// (no deadline or shutdown cancellation is wired into this path).
-	if err := job.AutoDetection(context.Background()); err != nil {
-		job.Cleanup()
+	if createErr != nil {
+		var ce dyncfg.CodedError
+		if errors.As(createErr, &ce) {
+			return createErr
+		}
+		return fmt.Errorf("job update failed: %w", createErr)
+	}
+	if err != nil {
 		var ce dyncfg.CodedError
 		if errors.As(err, &ce) {
 			if dyncfg.IsRetryableError(err) {

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -140,16 +140,14 @@ func (cb *collectorCallbacks) Start(cfg confgroup.Config) error {
 	})
 
 	if createErr != nil {
-		var ce dyncfg.CodedError
-		if errors.As(createErr, &ce) {
+		if _, ok := errors.AsType[dyncfg.CodedError](createErr); ok {
 			return createErr
 		}
 		return &codedError{err: fmt.Errorf("invalid configuration: failed to apply configuration: %w", createErr), code: 400}
 	}
 	if err != nil {
 		cb.mgr.emissionGates.remove(cfg.FullName())
-		var ce dyncfg.CodedError
-		if errors.As(err, &ce) {
+		if _, ok := errors.AsType[dyncfg.CodedError](err); ok {
 			if dyncfg.IsRetryableError(err) {
 				cb.mgr.scheduleRetryTask(cfg, job)
 			}

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -125,7 +125,9 @@ func (cb *collectorCallbacks) Start(cfg confgroup.Config) error {
 		return &codedError{err: fmt.Errorf("invalid configuration: failed to apply configuration: %w", err), code: 400}
 	}
 
-	if err := job.AutoDetection(); err != nil {
+	// Detection is uncancellable by contract: Init/Check run to completion
+	// (no deadline or shutdown cancellation is wired into this path).
+	if err := job.AutoDetection(context.Background()); err != nil {
 		job.Cleanup()
 		var ce dyncfg.CodedError
 		if errors.As(err, &ce) {
@@ -156,7 +158,9 @@ func (cb *collectorCallbacks) Update(oldCfg, newCfg confgroup.Config) error {
 		return fmt.Errorf("job update failed: %w", err)
 	}
 
-	if err := job.AutoDetection(); err != nil {
+	// Detection is uncancellable by contract: Init/Check run to completion
+	// (no deadline or shutdown cancellation is wired into this path).
+	if err := job.AutoDetection(context.Background()); err != nil {
 		job.Cleanup()
 		var ce dyncfg.CodedError
 		if errors.As(err, &ce) {

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -106,7 +106,13 @@ func (cb *collectorCallbacks) ParseAndValidate(fn dyncfg.Function, name string) 
 
 	cb.mgr.dyncfgSetConfigMeta(cfg, mn, name, fn)
 
-	if err := cb.mgr.validateCollectorJob(cfg); err != nil {
+	// Payload parsing above is cheap and stays with the caller; the full
+	// validation (config apply incl. secret resolution) is blocking module
+	// work and runs as an effect.
+	err = cb.mgr.runEffectSync(cfg.FullName(), func(context.Context) error {
+		return cb.mgr.validateCollectorJob(cfg)
+	})
+	if err != nil {
 		return nil, fmt.Errorf("invalid configuration: failed to apply configuration: %v", err)
 	}
 
@@ -141,6 +147,7 @@ func (cb *collectorCallbacks) Start(cfg confgroup.Config) error {
 		return &codedError{err: fmt.Errorf("invalid configuration: failed to apply configuration: %w", createErr), code: 400}
 	}
 	if err != nil {
+		cb.mgr.emissionGates.remove(cfg.FullName())
 		var ce dyncfg.CodedError
 		if errors.As(err, &ce) {
 			if dyncfg.IsRetryableError(err) {
@@ -183,6 +190,7 @@ func (cb *collectorCallbacks) Update(oldCfg, newCfg confgroup.Config) error {
 		return fmt.Errorf("job update failed: %w", createErr)
 	}
 	if err != nil {
+		cb.mgr.emissionGates.remove(newCfg.FullName())
 		var ce dyncfg.CodedError
 		if errors.As(err, &ce) {
 			if dyncfg.IsRetryableError(err) {

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
@@ -1806,7 +1806,7 @@ func (j *collectorProbeJob) Collector() any     { return nil }
 func (j *collectorProbeJob) Start()             {}
 func (j *collectorProbeJob) Stop()              { j.stopped = true }
 func (j *collectorProbeJob) Tick(int)           {}
-func (j *collectorProbeJob) AutoDetection() error {
+func (j *collectorProbeJob) AutoDetection(context.Context) error {
 	return nil
 }
 func (j *collectorProbeJob) AutoDetectionEvery() int { return 0 }

--- a/src/go/plugin/agent/jobmgr/dyncfg_vnode_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_vnode_test.go
@@ -316,7 +316,7 @@ func (j *vnodeUpdateProbeJob) Collector() any     { return nil }
 func (j *vnodeUpdateProbeJob) Start()             {}
 func (j *vnodeUpdateProbeJob) Stop()              {}
 func (j *vnodeUpdateProbeJob) Tick(int)           {}
-func (j *vnodeUpdateProbeJob) AutoDetection() error {
+func (j *vnodeUpdateProbeJob) AutoDetection(context.Context) error {
 	return nil
 }
 func (j *vnodeUpdateProbeJob) AutoDetectionEvery() int { return 0 }

--- a/src/go/plugin/agent/jobmgr/effect.go
+++ b/src/go/plugin/agent/jobmgr/effect.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+)
+
+// An effect is a unit of blocking module work (config validation, job
+// creation, detection, stop) executed off the manager loop in a supervised
+// child goroutine. Completions are delivered through effectDoneCh.
+//
+// The current execution policy is fully synchronous: runEffectSync spawns
+// the child and immediately drains its completion, so at most one effect is
+// ever in flight and the observable sequence is identical to calling the
+// closure inline. The effect context carries no deadline and is never
+// cancelled.
+//
+// Discipline: runEffectSync must be called only from the goroutine that owns
+// manager state - the run loop in production. It preserves panic semantics:
+// a child panic is re-raised on the caller goroutine.
+
+type effectResult struct {
+	key        string
+	err        error
+	panicked   bool
+	panicValue any
+}
+
+// runEffectSync executes run in a supervised child goroutine and waits for
+// its completion. The completion travels over a per-call channel, NOT
+// effectDoneCh: callers are not always the run loop (tests drive manager
+// entry points from other goroutines while the loop runs), and any shared
+// completion channel would race the loop's effectDoneCh select arms.
+func (m *Manager) runEffectSync(key string, run func(ctx context.Context) error) error {
+	// Deadline disabled: the effect context is uncancellable, matching the
+	// blocking behavior of the inline calls it replaces.
+	ctx := context.Background()
+
+	done := make(chan effectResult, 1)
+	go func() {
+		res := effectResult{key: key}
+		defer func() {
+			if r := recover(); r != nil {
+				res.panicked = true
+				res.panicValue = r
+			}
+			done <- res
+		}()
+		res.err = run(ctx)
+	}()
+
+	res := <-done
+	if res.panicked {
+		// Today a panic on this path crashes the plugin; keep that contract.
+		panic(res.panicValue)
+	}
+	return res.err
+}
+
+// handleUnexpectedEffectDone is the loop-select arm for effect completions.
+// Under the synchronous policy every completion is drained by its
+// dispatcher, so an arrival here is a bug, not an event to act on.
+func (m *Manager) handleUnexpectedEffectDone(res effectResult) {
+	m.Errorf("BUG: unexpected effect completion for key '%s' (err: %v) reached the run loop", res.key, res.err)
+}

--- a/src/go/plugin/agent/jobmgr/effect.go
+++ b/src/go/plugin/agent/jobmgr/effect.go
@@ -8,7 +8,9 @@ import (
 
 // An effect is a unit of blocking module work (config validation, job
 // creation, detection, stop) executed off the manager loop in a supervised
-// child goroutine. Completions are delivered through effectDoneCh.
+// child goroutine. Each dispatcher awaits its own effect over a per-call
+// completion channel; effectDoneCh is armed in every run-loop select as the
+// future asynchronous completion path and carries nothing today.
 //
 // The current execution policy is fully synchronous: runEffectSync spawns
 // the child and immediately drains its completion, so at most one effect is

--- a/src/go/plugin/agent/jobmgr/effect_test.go
+++ b/src/go/plugin/agent/jobmgr/effect_test.go
@@ -66,3 +66,51 @@ func TestEffect_DeadlineDisabledPin(t *testing.T) {
 		t.Run(name, tc.run)
 	}
 }
+
+// effectDoneCh is armed in every run-loop select state; a stray completion
+// must be drained (bug-detector arm) without wedging the loop.
+func TestEffect_DoneChannelLoopArms(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T, h *charHarness)
+	}{
+		"idle select drains a completion and keeps serving": {
+			run: func(t *testing.T, h *charHarness) {
+				h.mgr.effectDoneCh <- effectResult{key: "stray"}
+
+				require.Eventually(t, func() bool { return len(h.mgr.effectDoneCh) == 0 }, charWait, charTick,
+					"the run loop did not drain the effect completion")
+
+				h.dyncfg("after-idle-drain", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("success", "x")), "get"}, nil)
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN after-idle-drain"), charWait, charTick,
+					"the run loop stopped serving after draining a completion")
+			},
+		},
+		"wait-mode select drains a completion and keeps serving dyncfg": {
+			run: func(t *testing.T, h *charHarness) {
+				cfg := prepareUserCfg("success", "waity")
+				h.in <- prepareCfgGroups(cfg.Source(), cfg)
+				require.Eventually(t, func() bool { return h.mgr.collectorHandler.WaitingForDecision() }, charWait, charTick)
+
+				h.mgr.effectDoneCh <- effectResult{key: "stray"}
+
+				require.Eventually(t, func() bool { return len(h.mgr.effectDoneCh) == 0 }, charWait, charTick,
+					"the wait-mode select did not drain the effect completion")
+
+				h.dyncfg("after-wait-drain", []string{h.mgr.dyncfgJobID(cfg), "update"}, []byte("{}"))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN after-wait-drain"), charWait, charTick,
+					"wait mode stopped serving dyncfg after draining a completion")
+				assert.True(t, h.mgr.collectorHandler.WaitingForDecision(),
+					"a stray completion must not clear the wait gate")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			reg := collectorapi.Registry{}
+			reg.Register("success", charSuccessCreator())
+
+			tc.run(t, startCharManager(t, reg))
+		})
+	}
+}

--- a/src/go/plugin/agent/jobmgr/effect_test.go
+++ b/src/go/plugin/agent/jobmgr/effect_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Deadline-disabled pin: the effect path applies NO deadline and NO
+// cancellation to detection - a slow detection completes and its job starts.
+// The stage that activates effect deadlines must flip this pin deliberately
+// together with its abandon/late-return semantics, never delete it.
+func TestEffect_DeadlineDisabledPin(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"slow detection sees no deadline, no cancellation, and still starts its job": {
+			run: func(t *testing.T) {
+				var sawDeadline, sawCancel atomic.Bool
+
+				reg := collectorapi.Registry{}
+				reg.Register("slowok", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(ctx context.Context) error {
+								if _, ok := ctx.Deadline(); ok {
+									sawDeadline.Store(true)
+								}
+								time.Sleep(500 * time.Millisecond)
+								if ctx.Err() != nil {
+									sawCancel.Store(true)
+								}
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+
+				h := startCharManager(t, reg)
+
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("slowok"), "add", "s"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("slowok", "s")), "enable"}, nil)
+
+				require.Eventually(t, h.outputContains("CONFIG test:collector:slowok:s status running"), charWait, charTick,
+					"slow detection must complete and start the job - no abandon path may fire")
+				assert.False(t, sawDeadline.Load(), "detection effect context must carry no deadline")
+				assert.False(t, sawCancel.Load(), "detection effect context must never be cancelled")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}

--- a/src/go/plugin/agent/jobmgr/emission_gateway.go
+++ b/src/go/plugin/agent/jobmgr/emission_gateway.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"io"
+	"sync"
+)
+
+// emissionGateway wraps a job's output writer so the "is output allowed"
+// check and the write happen under one lock: Close waits out any in-flight
+// write, and no write that starts after Close returns can reach the wire.
+// A plain flag or writer swap cannot give this guarantee - a write that
+// already passed its check could still flush afterwards.
+//
+// The gate is installed on every created job and stays open for the job's
+// whole life on the normal path; nothing closes it in the current runtime.
+type emissionGateway struct {
+	mu         sync.Mutex
+	out        io.Writer
+	closed     bool
+	suppressed int
+}
+
+func newEmissionGateway(out io.Writer) *emissionGateway {
+	if out == nil {
+		out = io.Discard
+	}
+	return &emissionGateway{out: out}
+}
+
+func (g *emissionGateway) Write(p []byte) (int, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.closed {
+		g.suppressed++
+		return len(p), nil
+	}
+	return g.out.Write(p)
+}
+
+// Close shuts the gate. It blocks until any in-flight write completes; every
+// later write is suppressed and counted instead of reaching the writer.
+func (g *emissionGateway) Close() {
+	g.mu.Lock()
+	g.closed = true
+	g.mu.Unlock()
+}
+
+// SuppressedWrites reports how many writes were swallowed after Close.
+func (g *emissionGateway) SuppressedWrites() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.suppressed
+}
+
+// emissionGates tracks the gateway of the most recently created job per full
+// name (jobs are created and stopped on the manager loop; validation-only
+// factory clones register nothing). Entries are removed when the job stops.
+type emissionGates struct {
+	mu    sync.Mutex
+	items map[string]*emissionGateway
+}
+
+func newEmissionGates() *emissionGates {
+	return &emissionGates{items: make(map[string]*emissionGateway)}
+}
+
+func (s *emissionGates) add(name string, gate *emissionGateway) {
+	if gate == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[name] = gate
+}
+
+func (s *emissionGates) remove(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.items, name)
+}
+
+func (s *emissionGates) lookup(name string) (*emissionGateway, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	gate, ok := s.items[name]
+	return gate, ok
+}

--- a/src/go/plugin/agent/jobmgr/emission_gateway_test.go
+++ b/src/go/plugin/agent/jobmgr/emission_gateway_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingTestWriter blocks its first Write until released so tests can hold
+// an in-flight write while probing the gateway lock.
+type blockingTestWriter struct {
+	mu      sync.Mutex
+	buf     bytes.Buffer
+	once    sync.Once
+	started chan struct{}
+	release chan struct{}
+}
+
+func (w *blockingTestWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() {
+		close(w.started)
+		<-w.release
+	})
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func TestEmissionGateway(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"open gate passes writes through": {
+			run: func(t *testing.T) {
+				var buf bytes.Buffer
+				gate := newEmissionGateway(&buf)
+
+				n, err := gate.Write([]byte("payload"))
+
+				require.NoError(t, err)
+				assert.Equal(t, len("payload"), n)
+				assert.Equal(t, "payload", buf.String())
+				assert.Zero(t, gate.SuppressedWrites())
+			},
+		},
+		"closed gate suppresses and counts writes": {
+			run: func(t *testing.T) {
+				var buf bytes.Buffer
+				gate := newEmissionGateway(&buf)
+
+				gate.Close()
+				n, err := gate.Write([]byte("late"))
+
+				require.NoError(t, err, "suppression must not surface as a write error")
+				assert.Equal(t, len("late"), n)
+				assert.Empty(t, buf.String(), "closed gate leaked a write")
+				assert.Equal(t, 1, gate.SuppressedWrites())
+			},
+		},
+		"close waits out an in-flight write": {
+			run: func(t *testing.T) {
+				w := &blockingTestWriter{started: make(chan struct{}), release: make(chan struct{})}
+				gate := newEmissionGateway(w)
+
+				writeDone := make(chan struct{})
+				go func() {
+					_, _ = gate.Write([]byte("in-flight"))
+					close(writeDone)
+				}()
+				select {
+				case <-w.started:
+				case <-time.After(time.Second):
+					t.Fatal("write did not start")
+				}
+
+				closeDone := make(chan struct{})
+				go func() {
+					gate.Close()
+					close(closeDone)
+				}()
+
+				closeReturned := func() bool {
+					select {
+					case <-closeDone:
+						return true
+					default:
+						return false
+					}
+				}
+				require.Never(t, closeReturned, 200*time.Millisecond, 10*time.Millisecond,
+					"Close returned while a write was still in flight")
+
+				close(w.release)
+				require.Eventually(t, closeReturned, time.Second, 10*time.Millisecond)
+				<-writeDone
+				assert.Equal(t, "in-flight", w.buf.String(), "the in-flight write must complete, not be cut")
+			},
+		},
+		"factory-created job gets a tracked gateway until it stops": {
+			run: func(t *testing.T) {
+				mgr := newCollectorTestManager()
+				cfg := prepareDyncfgCfg("success", "gw")
+
+				job, err := mgr.createCollectorJob(cfg)
+				require.NoError(t, err)
+				gate, tracked := mgr.emissionGates.lookup(cfg.FullName())
+				require.True(t, tracked, "creation must register the job's gateway")
+				require.NotNil(t, gate)
+
+				mgr.startRunningJob(job)
+				mgr.stopRunningJob(cfg.FullName())
+				_, tracked = mgr.emissionGates.lookup(cfg.FullName())
+				assert.False(t, tracked, "gateway tracking must end when the job stops")
+			},
+		},
+		"validation-only jobs register no gateway": {
+			run: func(t *testing.T) {
+				mgr := newCollectorTestManager()
+				cfg := prepareDyncfgCfg("success", "gw-validate")
+
+				require.NoError(t, mgr.validateCollectorJob(cfg))
+
+				_, tracked := mgr.emissionGates.lookup(cfg.FullName())
+				assert.False(t, tracked, "validation-only creation must not register a gateway")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}

--- a/src/go/plugin/agent/jobmgr/emission_gateway_test.go
+++ b/src/go/plugin/agent/jobmgr/emission_gateway_test.go
@@ -144,6 +144,30 @@ func TestEmissionGateway(t *testing.T) {
 				assert.False(t, tracked, "a job that failed detection must leave no gateway entry")
 			},
 		},
+		"same-name replacement keeps the new job's gateway tracked": {
+			run: func(t *testing.T) {
+				mgr := newCollectorTestManager()
+				cfg := prepareDyncfgCfg("success", "gw-replace")
+
+				oldJob, err := mgr.createCollectorJob(cfg)
+				require.NoError(t, err)
+				mgr.startRunningJob(oldJob)
+
+				newJob, err := mgr.createCollectorJob(cfg)
+				require.NoError(t, err)
+				newGate, tracked := mgr.emissionGates.lookup(cfg.FullName())
+				require.True(t, tracked)
+
+				// The defensive stop inside startRunningJob replaces the old
+				// same-name job; the new job's gate must survive it.
+				mgr.startRunningJob(newJob)
+				t.Cleanup(func() { mgr.stopRunningJob(cfg.FullName()) })
+
+				gate, tracked := mgr.emissionGates.lookup(cfg.FullName())
+				require.True(t, tracked, "replacement dropped the new job's gateway tracking")
+				assert.Same(t, newGate, gate, "the tracked gate must be the new job's gate")
+			},
+		},
 		"validation-only jobs register no gateway": {
 			run: func(t *testing.T) {
 				mgr := newCollectorTestManager()

--- a/src/go/plugin/agent/jobmgr/emission_gateway_test.go
+++ b/src/go/plugin/agent/jobmgr/emission_gateway_test.go
@@ -119,6 +119,31 @@ func TestEmissionGateway(t *testing.T) {
 				assert.False(t, tracked, "gateway tracking must end when the job stops")
 			},
 		},
+		"failed construction registers no gateway": {
+			run: func(t *testing.T) {
+				mgr := newCollectorTestManager()
+				cfg := prepareDyncfgCfg("success", "gw-badcfg").Set("vnode", "no-such-vnode")
+
+				_, err := mgr.createCollectorJob(cfg)
+
+				require.Error(t, err)
+				_, tracked := mgr.emissionGates.lookup(cfg.FullName())
+				assert.False(t, tracked, "a job that failed to construct must leave no gateway entry")
+			},
+		},
+		"detection failure drops the gateway entry": {
+			run: func(t *testing.T) {
+				mgr := newCollectorTestManager()
+				cb := &collectorCallbacks{mgr: mgr}
+				cfg := prepareDyncfgCfg("fail", "gw-detect")
+
+				err := cb.Start(cfg)
+
+				require.Error(t, err)
+				_, tracked := mgr.emissionGates.lookup(cfg.FullName())
+				assert.False(t, tracked, "a job that failed detection must leave no gateway entry")
+			},
+		},
 		"validation-only jobs register no gateway": {
 			run: func(t *testing.T) {
 				mgr := newCollectorTestManager()

--- a/src/go/plugin/agent/jobmgr/job_factory.go
+++ b/src/go/plugin/agent/jobmgr/job_factory.go
@@ -39,6 +39,7 @@ type jobFactory struct {
 	modules     collectorapi.Registry
 	vnodeLookup func(string) (*vnodes.VirtualNode, bool)
 	out         io.Writer
+	gates       *emissionGates
 
 	validationOnly bool
 
@@ -66,6 +67,7 @@ func newJobFactory(m *Manager) *jobFactory {
 		modules:     m.modules,
 		vnodeLookup: m.vnodesCtl.Lookup,
 		out:         m.out,
+		gates:       m.emissionGates,
 
 		auditMode:     m.auditMode,
 		auditAnalyzer: m.auditAnalyzer,
@@ -114,10 +116,23 @@ func (f *jobFactory) create(cfg confgroup.Config) (runtimeJob, error) {
 
 	f.logger.Debugf("creating %s[%s] job, config: %v", cfg.Module(), cfg.Name(), cfg)
 
-	if creator.CreateV2 != nil {
-		return f.createV2(cfg, creator, functionOnly, vnode)
+	// Every runnable job writes through its own emission gateway so job
+	// output can be provably fenced off; the gate stays open for the job's
+	// whole life on the normal path. Validation-only jobs never run, so they
+	// get no gate registration.
+	gatedF := *f
+	if !f.validationOnly {
+		gate := newEmissionGateway(f.out)
+		gatedF.out = gate
+		if f.gates != nil {
+			f.gates.add(cfg.FullName(), gate)
+		}
 	}
-	return f.createV1(cfg, creator, functionOnly, vnode)
+
+	if creator.CreateV2 != nil {
+		return gatedF.createV2(cfg, creator, functionOnly, vnode)
+	}
+	return gatedF.createV1(cfg, creator, functionOnly, vnode)
 }
 
 func (f *jobFactory) logApplyConfigError(cfg confgroup.Config, err error) {

--- a/src/go/plugin/agent/jobmgr/job_factory.go
+++ b/src/go/plugin/agent/jobmgr/job_factory.go
@@ -31,7 +31,10 @@ func jobLogSource(cfg confgroup.Config) string {
 	return fmt.Sprintf("%s/%s", sourceType, provider)
 }
 
-// jobFactory builds runtime jobs from configs without mutating manager-owned runtime maps.
+// jobFactory builds runtime jobs from configs. It does not mutate
+// manager-owned runtime maps, with one disclosed exception: a successful
+// create registers the job's emission gateway in the manager's gate
+// registry, which carries its own lock.
 type jobFactory struct {
 	logger *logger.Logger
 

--- a/src/go/plugin/agent/jobmgr/job_factory.go
+++ b/src/go/plugin/agent/jobmgr/job_factory.go
@@ -124,7 +124,9 @@ func (f *jobFactory) create(cfg confgroup.Config) (runtimeJob, error) {
 	// whole life on the normal path. Validation-only jobs never run, so they
 	// get no gate. The gate is tracked only for jobs that construct
 	// successfully; the create/detect and stop paths drop the entry when the
-	// job fails or stops.
+	// job fails or stops. A same-name replacement overwrites the previous
+	// entry here, and startRunningJob preserves the tracked gate across its
+	// defensive stop - the entry always belongs to the newest created job.
 	gatedF := *f
 	var gate *emissionGateway
 	if !f.validationOnly {

--- a/src/go/plugin/agent/jobmgr/job_factory.go
+++ b/src/go/plugin/agent/jobmgr/job_factory.go
@@ -119,20 +119,30 @@ func (f *jobFactory) create(cfg confgroup.Config) (runtimeJob, error) {
 	// Every runnable job writes through its own emission gateway so job
 	// output can be provably fenced off; the gate stays open for the job's
 	// whole life on the normal path. Validation-only jobs never run, so they
-	// get no gate registration.
+	// get no gate. The gate is tracked only for jobs that construct
+	// successfully; the create/detect and stop paths drop the entry when the
+	// job fails or stops.
 	gatedF := *f
+	var gate *emissionGateway
 	if !f.validationOnly {
-		gate := newEmissionGateway(f.out)
+		gate = newEmissionGateway(f.out)
 		gatedF.out = gate
-		if f.gates != nil {
-			f.gates.add(cfg.FullName(), gate)
-		}
 	}
 
+	var job runtimeJob
+	var err error
 	if creator.CreateV2 != nil {
-		return gatedF.createV2(cfg, creator, functionOnly, vnode)
+		job, err = gatedF.createV2(cfg, creator, functionOnly, vnode)
+	} else {
+		job, err = gatedF.createV1(cfg, creator, functionOnly, vnode)
 	}
-	return gatedF.createV1(cfg, creator, functionOnly, vnode)
+	if err != nil {
+		return nil, err
+	}
+	if gate != nil && f.gates != nil {
+		f.gates.add(cfg.FullName(), gate)
+	}
+	return job, nil
 }
 
 func (f *jobFactory) logApplyConfigError(cfg confgroup.Config, err error) {

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -112,6 +112,7 @@ func New(cfg Config) *Manager {
 		collectorExposed:  exposed,
 		secretStoreDeps:   newSecretStoreDeps(),
 		runningJobs:       newRunningJobsCache(),
+		emissionGates:     newEmissionGates(),
 		retryingTasks:     newRetryingTasksCache(),
 
 		started:          make(chan struct{}),
@@ -211,6 +212,7 @@ type Manager struct {
 	secretStoreDeps   *secretStoreDeps
 	retryingTasks     *retryingTasks
 	runningJobs       *runningJobs
+	emissionGates     *emissionGates
 
 	// Controllers and handlers.
 	funcCtl            *funcctl.Controller
@@ -551,6 +553,7 @@ func (m *Manager) stopRunningJob(name string) {
 		m.funcCtl.OnJobStop(job)
 		m.requestFunctionReconcile(job.ModuleName())
 		job.Stop()
+		m.emissionGates.remove(name)
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -536,7 +536,15 @@ func (m *Manager) takePendingFunctionReconcileModules() []string {
 }
 
 func (m *Manager) startRunningJob(job runtimeJob) {
+	// The defensive stop removes the gate tracked under this name, but that
+	// entry belongs to the job being started (registered at construction,
+	// after any old same-name job's entry was overwritten) - restore it so
+	// a same-name replacement never leaves the new job untracked.
+	gate, hadGate := m.emissionGates.lookup(job.FullName())
 	m.stopRunningJob(job.FullName())
+	if hadGate {
+		m.emissionGates.add(job.FullName(), gate)
+	}
 
 	go job.Start()
 

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -119,6 +119,7 @@ func New(cfg Config) *Manager {
 		addCh:            make(chan confgroup.Config),
 		rmCh:             make(chan confgroup.Config),
 		dyncfgCh:         make(chan dyncfg.Function, 32),
+		effectDoneCh:     make(chan effectResult, 1),
 		funcReconPending: make(map[string]struct{}),
 		funcReconWake:    make(chan struct{}, 1),
 		cmdTestSem:       make(chan struct{}, cmdTestWorkerCap),
@@ -228,6 +229,7 @@ type Manager struct {
 	addCh            chan confgroup.Config
 	rmCh             chan confgroup.Config
 	dyncfgCh         chan dyncfg.Function
+	effectDoneCh     chan effectResult
 	funcReconMu      sync.Mutex
 	funcReconPending map[string]struct{}
 	funcReconWake    chan struct{}
@@ -351,6 +353,8 @@ func (m *Manager) run() {
 				m.executor.dispatch(m.newDiscoveryRemoveEvent(cfg))
 			case fn := <-m.dyncfgCh:
 				m.executor.dispatch(m.newDyncfgEvent(fn))
+			case res := <-m.effectDoneCh:
+				m.handleUnexpectedEffectDone(res)
 			}
 		}
 	}
@@ -403,6 +407,8 @@ func (m *Manager) runWaitDecisionStep() bool {
 			return false
 		case fn := <-m.dyncfgCh:
 			m.executor.dispatch(m.newDyncfgEvent(fn))
+		case res := <-m.effectDoneCh:
+			m.handleUnexpectedEffectDone(res)
 		}
 		return true
 	}
@@ -422,6 +428,8 @@ func (m *Manager) runWaitDecisionStep() bool {
 		return false
 	case fn := <-m.dyncfgCh:
 		m.executor.dispatch(m.newDyncfgEvent(fn))
+	case res := <-m.effectDoneCh:
+		m.handleUnexpectedEffectDone(res)
 	case <-timer.C:
 		m.collectorHandler.ExpireWaitDecision()
 	}
@@ -552,7 +560,12 @@ func (m *Manager) stopRunningJob(name string) {
 		m.secretStoreDeps.setRunning(name, false)
 		m.funcCtl.OnJobStop(job)
 		m.requestFunctionReconcile(job.ModuleName())
-		job.Stop()
+		// Registry removals above happen before the blocking stop so function
+		// routing to the job ends immediately; only the wait itself is an effect.
+		_ = m.runEffectSync(name, func(context.Context) error {
+			job.Stop()
+			return nil
+		})
 		m.emissionGates.remove(name)
 	}
 }

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -574,6 +574,9 @@ func (m *Manager) stopRunningJob(name string) {
 			job.Stop()
 			return nil
 		})
+		// Tracking removal only: the gate is never closed on the stop path,
+		// because a stopping job's in-flight flush and cleanup/obsoletion
+		// output must reach the wire.
 		m.emissionGates.remove(name)
 	}
 }

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -975,7 +975,7 @@ func (j *lockProbeJob) Tick(_ int) {
 		<-j.tickRelease
 	})
 }
-func (j *lockProbeJob) AutoDetection() error              { return nil }
+func (j *lockProbeJob) AutoDetection(context.Context) error              { return nil }
 func (j *lockProbeJob) AutoDetectionEvery() int           { return 0 }
 func (j *lockProbeJob) RetryAutoDetection() bool          { return false }
 func (j *lockProbeJob) Cleanup()                          {}
@@ -998,7 +998,7 @@ func (j *tickProbeJob) Collector() any                    { return j.collector }
 func (j *tickProbeJob) Start()                            {}
 func (j *tickProbeJob) Stop()                             {}
 func (j *tickProbeJob) Tick(int)                          {}
-func (j *tickProbeJob) AutoDetection() error              { return nil }
+func (j *tickProbeJob) AutoDetection(context.Context) error              { return nil }
 func (j *tickProbeJob) AutoDetectionEvery() int           { return 0 }
 func (j *tickProbeJob) RetryAutoDetection() bool          { return false }
 func (j *tickProbeJob) Cleanup()                          {}

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -975,14 +975,14 @@ func (j *lockProbeJob) Tick(_ int) {
 		<-j.tickRelease
 	})
 }
-func (j *lockProbeJob) AutoDetection(context.Context) error              { return nil }
-func (j *lockProbeJob) AutoDetectionEvery() int           { return 0 }
-func (j *lockProbeJob) RetryAutoDetection() bool          { return false }
-func (j *lockProbeJob) Cleanup()                          {}
-func (j *lockProbeJob) IsRunning() bool                   { return true }
-func (j *lockProbeJob) Panicked() bool                    { return false }
-func (j *lockProbeJob) Vnode() vnodes.VirtualNode         { return vnodes.VirtualNode{} }
-func (j *lockProbeJob) UpdateVnode(_ *vnodes.VirtualNode) {}
+func (j *lockProbeJob) AutoDetection(context.Context) error { return nil }
+func (j *lockProbeJob) AutoDetectionEvery() int             { return 0 }
+func (j *lockProbeJob) RetryAutoDetection() bool            { return false }
+func (j *lockProbeJob) Cleanup()                            {}
+func (j *lockProbeJob) IsRunning() bool                     { return true }
+func (j *lockProbeJob) Panicked() bool                      { return false }
+func (j *lockProbeJob) Vnode() vnodes.VirtualNode           { return vnodes.VirtualNode{} }
+func (j *lockProbeJob) UpdateVnode(_ *vnodes.VirtualNode)   {}
 
 type tickProbeJob struct {
 	fullName   string
@@ -991,21 +991,21 @@ type tickProbeJob struct {
 	collector  any
 }
 
-func (j *tickProbeJob) FullName() string                  { return j.fullName }
-func (j *tickProbeJob) ModuleName() string                { return j.moduleName }
-func (j *tickProbeJob) Name() string                      { return j.name }
-func (j *tickProbeJob) Collector() any                    { return j.collector }
-func (j *tickProbeJob) Start()                            {}
-func (j *tickProbeJob) Stop()                             {}
-func (j *tickProbeJob) Tick(int)                          {}
-func (j *tickProbeJob) AutoDetection(context.Context) error              { return nil }
-func (j *tickProbeJob) AutoDetectionEvery() int           { return 0 }
-func (j *tickProbeJob) RetryAutoDetection() bool          { return false }
-func (j *tickProbeJob) Cleanup()                          {}
-func (j *tickProbeJob) IsRunning() bool                   { return true }
-func (j *tickProbeJob) Panicked() bool                    { return false }
-func (j *tickProbeJob) Vnode() vnodes.VirtualNode         { return vnodes.VirtualNode{} }
-func (j *tickProbeJob) UpdateVnode(_ *vnodes.VirtualNode) {}
+func (j *tickProbeJob) FullName() string                    { return j.fullName }
+func (j *tickProbeJob) ModuleName() string                  { return j.moduleName }
+func (j *tickProbeJob) Name() string                        { return j.name }
+func (j *tickProbeJob) Collector() any                      { return j.collector }
+func (j *tickProbeJob) Start()                              {}
+func (j *tickProbeJob) Stop()                               {}
+func (j *tickProbeJob) Tick(int)                            {}
+func (j *tickProbeJob) AutoDetection(context.Context) error { return nil }
+func (j *tickProbeJob) AutoDetectionEvery() int             { return 0 }
+func (j *tickProbeJob) RetryAutoDetection() bool            { return false }
+func (j *tickProbeJob) Cleanup()                            {}
+func (j *tickProbeJob) IsRunning() bool                     { return true }
+func (j *tickProbeJob) Panicked() bool                      { return false }
+func (j *tickProbeJob) Vnode() vnodes.VirtualNode           { return vnodes.VirtualNode{} }
+func (j *tickProbeJob) UpdateVnode(_ *vnodes.VirtualNode)   {}
 
 type managerFunctionAvailability struct {
 	fn func(string) bool

--- a/src/go/plugin/agent/jobmgr/manager_v2_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_v2_test.go
@@ -154,7 +154,7 @@ func TestManagerCreateCollectorJobSingleInstancePolicyAllowsV2FunctionOnly(t *te
 	job, err := mgr.createCollectorJob(prepareFunctionOnlyCfg("testmod", "testmod"))
 	require.NoError(t, err)
 	require.NotNil(t, job)
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	_, isV2 := job.(*jobruntime.JobV2)
 	assert.True(t, isV2)

--- a/src/go/plugin/agent/jobmgr/runtime_job.go
+++ b/src/go/plugin/agent/jobmgr/runtime_job.go
@@ -21,7 +21,7 @@ type runtimeJob interface {
 	Stop()
 	Tick(clock int)
 
-	AutoDetection() error
+	AutoDetection(ctx context.Context) error
 	AutoDetectionEvery() int
 	RetryAutoDetection() bool
 	Cleanup()

--- a/src/go/plugin/agent/runtimechartemit/job.go
+++ b/src/go/plugin/agent/runtimechartemit/job.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"maps"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -72,6 +73,12 @@ type runtimeMetricsJob struct {
 
 	out      io.Writer
 	registry *componentRegistry
+
+	// tickMu spans runOnce's entire critical section (registry snapshot ->
+	// chart build -> wire write -> state-commit finalizers -> buffer reset)
+	// so quarantineComponent can wait out an in-progress tick. Lock order:
+	// tickMu -> registry.mu; never wait on tickMu while holding Service.mu.
+	tickMu sync.Mutex
 
 	running atomic.Bool
 	stop    chan struct{}
@@ -161,6 +168,9 @@ func (j *runtimeMetricsJob) Stop() {
 }
 
 func (j *runtimeMetricsJob) runOnce(clock int) {
+	j.tickMu.Lock()
+	defer j.tickMu.Unlock()
+
 	specs := j.registry.snapshot()
 	seen := make(map[string]struct{}, len(specs))
 	now := time.Now()
@@ -205,6 +215,18 @@ func (j *runtimeMetricsJob) runOnce(clock int) {
 		j.Warningf("runtime metrics commit failed: %v", err)
 	}
 	j.buf.Reset()
+}
+
+// quarantineComponent deletes the component's registration and emission
+// state without removal output. Holding tickMu waits out any in-progress
+// tick including its finalizers, so after this returns no already-snapshotted
+// sample and no removal-obsolete output for the component can be emitted; a
+// later re-registration of the same name is a fresh component.
+func (j *runtimeMetricsJob) quarantineComponent(name string) {
+	j.tickMu.Lock()
+	defer j.tickMu.Unlock()
+	j.registry.remove(name)
+	delete(j.components, name)
 }
 
 func (j *runtimeMetricsJob) newComponentState(spec componentSpec) (*runtimeComponentState, error) {

--- a/src/go/plugin/agent/runtimechartemit/quarantine_test.go
+++ b/src/go/plugin/agent/runtimechartemit/quarantine_test.go
@@ -107,6 +107,50 @@ func TestRuntimeMetricsJobQuarantineComponent(t *testing.T) {
 					"no output may follow the barrier for a quarantined sole component")
 			},
 		},
+		"tick mutex is held through post-write finalizers and buffer reset": {
+			run: func(t *testing.T) {
+				reg := newComponentRegistry()
+				reg.upsert(newQuarantineTestSpec("component"))
+				out := &gatedWriter{started: make(chan struct{}), release: make(chan struct{})}
+				job := newRuntimeMetricsJob(out, reg, nil)
+
+				tickDone := make(chan struct{})
+				go func() {
+					job.runOnce(1) // first emission: its commit finalizer installs the component state
+					close(tickDone)
+				}()
+
+				select {
+				case <-out.started:
+				case <-time.After(time.Second):
+					t.Fatal("tick did not reach its write")
+				}
+				require.False(t, job.tickMu.TryLock(), "tick mutex must be held while the tick writes")
+
+				close(out.release)
+
+				// The first successful acquisition happens-after runOnce's unlock;
+				// if the mutex is released before the commit finalizer and buffer
+				// reset, the state below would be observed missing.
+				deadline := time.Now().Add(5 * time.Second)
+				for !job.tickMu.TryLock() {
+					if time.Now().After(deadline) {
+						t.Fatal("tick mutex was never released")
+					}
+					time.Sleep(time.Millisecond)
+				}
+				defer job.tickMu.Unlock()
+				_, ok := job.components["component"]
+				assert.True(t, ok, "the post-write commit finalizer must run before the tick mutex is released")
+				assert.Zero(t, job.buf.Len(), "the buffer reset must happen before the tick mutex is released")
+
+				select {
+				case <-tickDone:
+				case <-time.After(time.Second):
+					t.Fatal("tick did not finish")
+				}
+			},
+		},
 		"quarantine removes without obsolete output": {
 			run: func(t *testing.T) {
 				reg := newComponentRegistry()

--- a/src/go/plugin/agent/runtimechartemit/quarantine_test.go
+++ b/src/go/plugin/agent/runtimechartemit/quarantine_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtimechartemit
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartemit"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newQuarantineTestSpec(name string) componentSpec {
+	store := metrix.NewRuntimeStore()
+	store.Write().StatefulMeter(name).Gauge("load").Set(5)
+
+	return componentSpec{
+		Name:         name,
+		Store:        store,
+		TemplateYAML: []byte(runtimeGaugeTemplateYAML()),
+		UpdateEvery:  1,
+		EmitEnv: chartemit.EmitEnv{
+			TypeID:      "netdata.go.d.internal." + name,
+			UpdateEvery: 1,
+			Plugin:      "go.d",
+			Module:      "internal",
+			JobName:     name,
+		},
+	}
+}
+
+// gatedWriter blocks the first Write until released, so a test can hold an
+// in-progress tick inside its write while probing the tick mutex.
+type gatedWriter struct {
+	safeBuffer
+
+	once    sync.Once
+	started chan struct{}
+	release chan struct{}
+}
+
+func (w *gatedWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() {
+		close(w.started)
+		<-w.release
+	})
+	return w.safeBuffer.Write(p)
+}
+
+func TestRuntimeMetricsJobQuarantineComponent(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"quarantine waits out an in-progress tick": {
+			run: func(t *testing.T) {
+				reg := newComponentRegistry()
+				reg.upsert(newQuarantineTestSpec("component"))
+				out := &gatedWriter{started: make(chan struct{}), release: make(chan struct{})}
+				job := newRuntimeMetricsJob(out, reg, nil)
+
+				tickDone := make(chan struct{})
+				go func() {
+					job.runOnce(1)
+					close(tickDone)
+				}()
+
+				select {
+				case <-out.started:
+				case <-time.After(time.Second):
+					t.Fatal("tick did not reach its write")
+				}
+
+				quarantineDone := make(chan struct{})
+				go func() {
+					job.quarantineComponent("component")
+					close(quarantineDone)
+				}()
+
+				quarantineReturned := func() bool {
+					select {
+					case <-quarantineDone:
+						return true
+					default:
+						return false
+					}
+				}
+				require.Never(t, quarantineReturned, 200*time.Millisecond, 10*time.Millisecond,
+					"quarantine returned while a tick was still inside its critical section")
+
+				close(out.release)
+				select {
+				case <-tickDone:
+				case <-time.After(time.Second):
+					t.Fatal("tick did not finish after release")
+				}
+				require.Eventually(t, quarantineReturned, time.Second, 10*time.Millisecond,
+					"quarantine did not return after the in-progress tick completed")
+
+				mark := len(out.String())
+				job.runOnce(2)
+				assert.Equal(t, mark, len(out.String()),
+					"no output may follow the barrier for a quarantined sole component")
+			},
+		},
+		"quarantine removes without obsolete output": {
+			run: func(t *testing.T) {
+				reg := newComponentRegistry()
+				reg.upsert(newQuarantineTestSpec("component"))
+				out := &safeBuffer{}
+				job := newRuntimeMetricsJob(out, reg, nil)
+
+				job.runOnce(1)
+				require.Contains(t, out.String(), "component_load", "component must emit before quarantine")
+
+				job.quarantineComponent("component")
+
+				mark := len(out.String())
+				job.runOnce(2)
+				job.runOnce(3)
+				tail := out.String()[mark:]
+				assert.NotContains(t, tail, "component_load", "quarantined component emitted samples")
+				assert.NotContains(t, tail, "obsolete", "quarantined component emitted removal-obsolete output")
+			},
+		},
+		"re-registration after quarantine emits normally": {
+			run: func(t *testing.T) {
+				reg := newComponentRegistry()
+				reg.upsert(newQuarantineTestSpec("component"))
+				out := &safeBuffer{}
+				job := newRuntimeMetricsJob(out, reg, nil)
+
+				job.runOnce(1)
+				job.quarantineComponent("component")
+
+				reg.upsert(newQuarantineTestSpec("component"))
+				mark := len(out.String())
+				job.runOnce(2)
+				tail := out.String()[mark:]
+				assert.Contains(t, tail, "component_load", "re-registered component must emit again")
+				assert.NotContains(t, tail, "obsolete", "fresh registration must not inherit removal output")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}

--- a/src/go/plugin/agent/runtimechartemit/quarantine_test.go
+++ b/src/go/plugin/agent/runtimechartemit/quarantine_test.go
@@ -151,3 +151,82 @@ func TestRuntimeMetricsJobQuarantineComponent(t *testing.T) {
 		t.Run(name, tc.run)
 	}
 }
+
+func TestServiceQuarantineComponent(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"barrier waits out an in-progress tick even during service Stop": {
+			run: func(t *testing.T) {
+				svc := New(nil)
+				store := metrix.NewRuntimeStore()
+				store.Write().StatefulMeter("component").Gauge("load").Set(5)
+				require.NoError(t, svc.RegisterComponent(ComponentConfig{
+					Name:         "component",
+					Store:        store,
+					TemplateYAML: []byte(runtimeGaugeTemplateYAML()),
+				}))
+
+				out := &gatedWriter{started: make(chan struct{}), release: make(chan struct{})}
+				svc.Start("go.d", out)
+
+				select {
+				case <-out.started:
+				case <-time.After(5 * time.Second):
+					t.Fatal("no tick reached its write")
+				}
+
+				stopDone := make(chan struct{})
+				go func() {
+					svc.Stop()
+					close(stopDone)
+				}()
+
+				quarantineDone := make(chan struct{})
+				go func() {
+					svc.QuarantineComponent("component")
+					close(quarantineDone)
+				}()
+
+				quarantineReturned := func() bool {
+					select {
+					case <-quarantineDone:
+						return true
+					default:
+						return false
+					}
+				}
+				require.Never(t, quarantineReturned, 200*time.Millisecond, 10*time.Millisecond,
+					"quarantine degraded to a plain registry remove while a tick was in flight")
+
+				close(out.release)
+				require.Eventually(t, quarantineReturned, 5*time.Second, 10*time.Millisecond)
+				select {
+				case <-stopDone:
+				case <-time.After(5 * time.Second):
+					t.Fatal("service Stop did not finish")
+				}
+				assert.Empty(t, svc.registry.snapshot(), "registration must be gone after quarantine")
+			},
+		},
+		"quarantine on a never-started service removes the registration": {
+			run: func(t *testing.T) {
+				svc := New(nil)
+				store := metrix.NewRuntimeStore()
+				require.NoError(t, svc.RegisterComponent(ComponentConfig{
+					Name:         "component",
+					Store:        store,
+					TemplateYAML: []byte(runtimeGaugeTemplateYAML()),
+				}))
+
+				svc.QuarantineComponent("component")
+
+				assert.Empty(t, svc.registry.snapshot())
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}

--- a/src/go/plugin/agent/runtimechartemit/quarantine_test.go
+++ b/src/go/plugin/agent/runtimechartemit/quarantine_test.go
@@ -268,6 +268,21 @@ func TestServiceQuarantineComponent(t *testing.T) {
 				assert.Empty(t, svc.registry.snapshot())
 			},
 		},
+		"quarantine normalizes the component name like the other entry points": {
+			run: func(t *testing.T) {
+				svc := New(nil)
+				store := metrix.NewRuntimeStore()
+				require.NoError(t, svc.RegisterComponent(ComponentConfig{
+					Name:         "component",
+					Store:        store,
+					TemplateYAML: []byte(runtimeGaugeTemplateYAML()),
+				}))
+
+				svc.QuarantineComponent("  component  ")
+
+				assert.Empty(t, svc.registry.snapshot(), "a padded name must still hit the registration")
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/src/go/plugin/agent/runtimechartemit/service.go
+++ b/src/go/plugin/agent/runtimechartemit/service.go
@@ -101,6 +101,27 @@ func (s *Service) Start(pluginName string, out io.Writer) {
 	go s.runTicker(interval, stopCh, doneCh)
 }
 
+// QuarantineComponent implements the runtimecomp.Service emission barrier:
+// it snapshots the job pointer under s.mu, releases s.mu, and only then
+// waits on the job's tick mutex (lock order: never wait on the tick mutex
+// while holding s.mu).
+func (s *Service) QuarantineComponent(name string) {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	job := s.job
+	s.mu.Unlock()
+
+	if job != nil {
+		job.quarantineComponent(name)
+		return
+	}
+	// No emitter running: removing the registration is the whole barrier.
+	s.registry.remove(name)
+}
+
 // Stop terminates the runtime emitter job. Calling Stop multiple times is safe.
 func (s *Service) Stop() {
 	if s == nil {

--- a/src/go/plugin/agent/runtimechartemit/service.go
+++ b/src/go/plugin/agent/runtimechartemit/service.go
@@ -136,7 +136,9 @@ func (s *Service) Stop() {
 	job := s.job
 	stopCh := s.tkStop
 	doneCh := s.tkDone
-	s.job = nil
+	// s.job stays set until the emitter has fully stopped: a concurrent
+	// QuarantineComponent must keep finding the job so its barrier waits out
+	// the final in-progress tick instead of degrading to a registry remove.
 	s.tkStop = nil
 	s.tkDone = nil
 	s.started = false
@@ -151,6 +153,12 @@ func (s *Service) Stop() {
 	if job != nil {
 		job.Stop()
 	}
+
+	s.mu.Lock()
+	if s.job == job {
+		s.job = nil
+	}
+	s.mu.Unlock()
 }
 
 // Tick advances runtime producers and runtime emitter job on scheduler cadence.

--- a/src/go/plugin/agent/runtimechartemit/service.go
+++ b/src/go/plugin/agent/runtimechartemit/service.go
@@ -109,6 +109,7 @@ func (s *Service) QuarantineComponent(name string) {
 	if s == nil {
 		return
 	}
+	name = strings.TrimSpace(name)
 
 	s.mu.Lock()
 	job := s.job

--- a/src/go/plugin/framework/functions/runtime_metrics_test.go
+++ b/src/go/plugin/framework/functions/runtime_metrics_test.go
@@ -34,6 +34,8 @@ func (m *runtimeServiceMock) UnregisterComponent(name string) {
 	m.unregistered = append(m.unregistered, name)
 }
 
+func (m *runtimeServiceMock) QuarantineComponent(string) {}
+
 func (m *runtimeServiceMock) RegisterProducer(string, func() error) error { return nil }
 func (m *runtimeServiceMock) UnregisterProducer(string)                   {}
 

--- a/src/go/plugin/framework/jobruntime/job_v1.go
+++ b/src/go/plugin/framework/jobruntime/job_v1.go
@@ -222,7 +222,7 @@ func (j *Job) Vnode() vnodes.VirtualNode {
 }
 
 // AutoDetection invokes init, check and postCheck. It handles panic.
-func (j *Job) AutoDetection() (err error) {
+func (j *Job) AutoDetection(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic %v", r)
@@ -243,7 +243,7 @@ func (j *Job) AutoDetection() (err error) {
 		j.Mute()
 	}
 
-	if err = j.init(); err != nil {
+	if err = j.init(ctx); err != nil {
 		j.Errorf("init failed: %v", err)
 		j.Unmute()
 		if !isRetryableError(err) {
@@ -252,7 +252,7 @@ func (j *Job) AutoDetection() (err error) {
 		return err
 	}
 
-	if err = j.check(); err != nil {
+	if err = j.check(ctx); err != nil {
 		j.Errorf("check failed: %v", err)
 		j.Unmute()
 		return err
@@ -404,12 +404,12 @@ func (j *Job) Cleanup() {
 	}
 }
 
-func (j *Job) init() error {
+func (j *Job) init(ctx context.Context) error {
 	if j.initialized {
 		return nil
 	}
 
-	if err := j.module.Init(context.TODO()); err != nil {
+	if err := j.module.Init(ctx); err != nil {
 		return err
 	}
 
@@ -418,8 +418,8 @@ func (j *Job) init() error {
 	return nil
 }
 
-func (j *Job) check() error {
-	if err := j.module.Check(context.TODO()); err != nil {
+func (j *Job) check(ctx context.Context) error {
+	if err := j.module.Check(ctx); err != nil {
 		consumeAutoDetectTry(&j.AutoDetectTries)
 		return err
 	}

--- a/src/go/plugin/framework/jobruntime/job_v1.go
+++ b/src/go/plugin/framework/jobruntime/job_v1.go
@@ -222,6 +222,7 @@ func (j *Job) Vnode() vnodes.VirtualNode {
 }
 
 // AutoDetection invokes init, check and postCheck. It handles panic.
+// ctx flows into the module's Init/Check calls and must be non-nil.
 func (j *Job) AutoDetection(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/src/go/plugin/framework/jobruntime/job_v1_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v1_test.go
@@ -102,14 +102,14 @@ func TestJob_RetryAutoDetection(t *testing.T) {
 	assert.True(t, job.RetryAutoDetection())
 	assert.Equal(t, infTries, job.AutoDetectTries)
 	for range 1000 {
-		_ = job.check()
+		_ = job.check(context.Background())
 	}
 	assert.True(t, job.RetryAutoDetection())
 	assert.Equal(t, infTries, job.AutoDetectTries)
 
 	job.AutoDetectTries = 10
 	for range 10 {
-		_ = job.check()
+		_ = job.check(context.Background())
 	}
 	assert.False(t, job.RetryAutoDetection())
 	assert.Equal(t, 0, job.AutoDetectTries)
@@ -134,7 +134,7 @@ func TestJob_AutoDetection(t *testing.T) {
 	}
 	job.module = m
 
-	assert.NoError(t, job.AutoDetection())
+	assert.NoError(t, job.AutoDetection(context.Background()))
 	assert.Equal(t, 3, v)
 }
 
@@ -148,7 +148,7 @@ func TestJob_AutoDetection_FailInit(t *testing.T) {
 	}
 	job.module = m
 
-	assert.Error(t, job.AutoDetection())
+	assert.Error(t, job.AutoDetection(context.Background()))
 	assert.False(t, job.RetryAutoDetection())
 	assert.True(t, m.CleanupDone)
 }
@@ -163,7 +163,7 @@ func TestJob_AutoDetection_RetryableFailInitKeepsRetry(t *testing.T) {
 	}
 	job.module = m
 
-	assert.Error(t, job.AutoDetection())
+	assert.Error(t, job.AutoDetection(context.Background()))
 	assert.True(t, job.RetryAutoDetection())
 	assert.True(t, m.CleanupDone)
 }
@@ -178,7 +178,7 @@ func TestJob_AutoDetection_ForeignRetryableFailInitDisablesRetry(t *testing.T) {
 	}
 	job.module = m
 
-	assert.Error(t, job.AutoDetection())
+	assert.Error(t, job.AutoDetection(context.Background()))
 	assert.False(t, job.RetryAutoDetection())
 	assert.True(t, m.CleanupDone)
 }
@@ -195,7 +195,7 @@ func TestJob_AutoDetection_FailCheck(t *testing.T) {
 	}
 	job.module = m
 
-	assert.Error(t, job.AutoDetection())
+	assert.Error(t, job.AutoDetection(context.Background()))
 	assert.True(t, m.CleanupDone)
 }
 
@@ -214,7 +214,7 @@ func TestJob_AutoDetection_FailPostCheck(t *testing.T) {
 	}
 	job.module = m
 
-	assert.Error(t, job.AutoDetection())
+	assert.Error(t, job.AutoDetection(context.Background()))
 	assert.True(t, m.CleanupDone)
 }
 
@@ -227,7 +227,7 @@ func TestJob_AutoDetection_PanicInit(t *testing.T) {
 	}
 	job.module = m
 
-	assert.Error(t, job.AutoDetection())
+	assert.Error(t, job.AutoDetection(context.Background()))
 	assert.True(t, m.CleanupDone)
 }
 
@@ -243,7 +243,7 @@ func TestJob_AutoDetection_PanicCheck(t *testing.T) {
 	}
 	job.module = m
 
-	assert.Error(t, job.AutoDetection())
+	assert.Error(t, job.AutoDetection(context.Background()))
 	assert.True(t, m.CleanupDone)
 }
 
@@ -262,7 +262,7 @@ func TestJob_AutoDetection_PanicPostCheck(t *testing.T) {
 	}
 	job.module = m
 
-	assert.Error(t, job.AutoDetection())
+	assert.Error(t, job.AutoDetection(context.Background()))
 	assert.True(t, m.CleanupDone)
 }
 
@@ -424,7 +424,7 @@ func TestJob_AutoDetection_FunctionOnly_NilCharts(t *testing.T) {
 	}
 	job.module = m
 
-	assert.NoError(t, job.AutoDetection())
+	assert.NoError(t, job.AutoDetection(context.Background()))
 }
 
 func TestJob_AutoDetection_FunctionOnlyFailCheckCleansUp(t *testing.T) {
@@ -443,7 +443,7 @@ func TestJob_AutoDetection_FunctionOnlyFailCheckCleansUp(t *testing.T) {
 	}
 	job.module = m
 
-	assert.Error(t, job.AutoDetection())
+	assert.Error(t, job.AutoDetection(context.Background()))
 	assert.True(t, m.CleanupDone)
 	assert.Equal(t, 1, cleanupCalls)
 }

--- a/src/go/plugin/framework/jobruntime/job_v2.go
+++ b/src/go/plugin/framework/jobruntime/job_v2.go
@@ -248,6 +248,8 @@ func (j *JobV2) Cleanup() {
 	j.clearAllScopeStateAfterCleanup()
 }
 
+// AutoDetection invokes init, check and postCheck. It handles panic.
+// ctx flows into the module's Init/Check calls and must be non-nil.
 func (j *JobV2) AutoDetection(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/src/go/plugin/framework/jobruntime/job_v2.go
+++ b/src/go/plugin/framework/jobruntime/job_v2.go
@@ -248,7 +248,7 @@ func (j *JobV2) Cleanup() {
 	j.clearAllScopeStateAfterCleanup()
 }
 
-func (j *JobV2) AutoDetection() (err error) {
+func (j *JobV2) AutoDetection(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic %v", r)
@@ -267,7 +267,7 @@ func (j *JobV2) AutoDetection() (err error) {
 		j.Mute()
 	}
 
-	if err = j.init(); err != nil {
+	if err = j.init(ctx); err != nil {
 		j.Errorf("init failed: %v", err)
 		j.Unmute()
 		if !isRetryableError(err) {
@@ -275,7 +275,7 @@ func (j *JobV2) AutoDetection() (err error) {
 		}
 		return err
 	}
-	if err = j.check(); err != nil {
+	if err = j.check(ctx); err != nil {
 		j.Errorf("check failed: %v", err)
 		j.Unmute()
 		return err
@@ -396,19 +396,19 @@ func (j *JobV2) shouldCollect(clock int) bool {
 	return shouldCollectWithPenalty(clock, j.updateEvery, int(j.retries.Load()))
 }
 
-func (j *JobV2) init() error {
+func (j *JobV2) init(ctx context.Context) error {
 	if j.initialized {
 		return nil
 	}
-	if err := j.module.Init(j.moduleContext()); err != nil {
+	if err := j.module.Init(j.moduleContextFrom(ctx)); err != nil {
 		return err
 	}
 	j.initialized = true
 	return nil
 }
 
-func (j *JobV2) check() error {
-	if err := j.module.Check(j.moduleContext()); err != nil {
+func (j *JobV2) check(ctx context.Context) error {
+	if err := j.module.Check(j.moduleContextFrom(ctx)); err != nil {
 		consumeAutoDetectTry(&j.autoDetectTries)
 		return err
 	}
@@ -865,6 +865,13 @@ func (j *JobV2) moduleContext() context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	return j.moduleContextFrom(ctx)
+}
+
+// moduleContextFrom attaches the runtime-component service to a
+// caller-supplied context (the detection path receives its context from
+// the caller instead of the run context, which does not exist pre-Start).
+func (j *JobV2) moduleContextFrom(ctx context.Context) context.Context {
 	if j.runtimeService != nil {
 		return runtimecomp.ContextWithService(ctx, j.runtimeService)
 	}

--- a/src/go/plugin/framework/jobruntime/job_v2_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_test.go
@@ -68,6 +68,8 @@ func (m *mockRuntimeComponentService) UnregisterComponent(name string) {
 	m.unregistered = append(m.unregistered, name)
 }
 
+func (m *mockRuntimeComponentService) QuarantineComponent(_ string) {}
+
 func (m *mockRuntimeComponentService) RegisterProducer(_ string, _ func() error) error {
 	return nil
 }

--- a/src/go/plugin/framework/jobruntime/job_v2_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_test.go
@@ -170,7 +170,7 @@ func newRegistryTestJobV2(t *testing.T, fullName string, registry *vnoderegistry
 		Vnode:         vnode,
 		VnodeRegistry: registry,
 	})
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 	return job
 }
 
@@ -256,7 +256,7 @@ func TestJobV2RunnerDoesNotRunDuringAutoDetection(t *testing.T) {
 	}
 	job := newTestJobV2(mod, &bytes.Buffer{})
 
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	require.Never(t, func() bool {
 		select {
@@ -282,7 +282,7 @@ func TestJobV2RunnerDoesNotStartAfterPreStartStop(t *testing.T) {
 		},
 	}
 	job := newTestJobV2(mod, &bytes.Buffer{})
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	job.Stop()
 	go func() {
@@ -326,7 +326,7 @@ func TestJobV2RunnerStopWaitsBeforeCleanup(t *testing.T) {
 		},
 	}
 	job := newTestJobV2(mod, &bytes.Buffer{})
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	go job.Start()
 	select {
@@ -390,7 +390,7 @@ func TestJobV2RunnerPanicRecovered(t *testing.T) {
 		},
 	}
 	job := newTestJobV2(mod, &bytes.Buffer{})
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	go func() {
 		job.Start()
@@ -422,7 +422,7 @@ func TestJobV2Scenarios(t *testing.T) {
 					template: chartTemplateV2(),
 				}
 				job := newTestJobV2(mod, &bytes.Buffer{})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 				require.NotNil(t, job.store)
 				require.NotNil(t, job.cycle)
 				state, err := job.ensureScopeState(metrix.HostScope{})
@@ -442,7 +442,7 @@ func TestJobV2Scenarios(t *testing.T) {
 					template: chartTemplateV2(),
 				}
 				job := newTestJobV2(mod, &bytes.Buffer{})
-				require.ErrorContains(t, job.AutoDetection(), "nil metric store")
+				require.ErrorContains(t, job.AutoDetection(context.Background()), "nil metric store")
 			},
 		},
 		"runOnce collects and emits chart actions": {
@@ -459,7 +459,7 @@ func TestJobV2Scenarios(t *testing.T) {
 
 				var out bytes.Buffer
 				job := newTestJobV2(mod, &out)
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 				job.runOnce()
 
 				wire := out.String()
@@ -489,7 +489,7 @@ END`, chartengine.Priority))
 
 				var out bytes.Buffer
 				job := newTestJobV2(mod, &out)
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 				job.runOnce()
 
 				assert.Equal(t, "", out.String())
@@ -515,7 +515,7 @@ END`, chartengine.Priority))
 
 				var out bytes.Buffer
 				job := newTestJobV2(mod, &out)
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 				assert.True(t, job.Panicked())
@@ -552,7 +552,7 @@ END`, chartengine.Priority))
 
 				var out bytes.Buffer
 				job := newTestJobV2(mod, &out)
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 				job.runOnce()
 
 				wire := out.String()
@@ -601,7 +601,7 @@ END`, chartengine.Priority, chartengine.Priority))
 					RuntimeService: runtimeSvc,
 				})
 
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 				require.Len(t, runtimeSvc.registered, 1)
 				cfg := runtimeSvc.registered[0]
 				assert.Equal(t, job.runtimeComponentName, cfg.Name)
@@ -644,7 +644,7 @@ END`, chartengine.Priority, chartengine.Priority))
 					RuntimeService: runtimeSvc,
 				})
 
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 			},
 		},
 		"runtime registration failure is non-fatal for autodetection": {
@@ -666,7 +666,7 @@ END`, chartengine.Priority, chartengine.Priority))
 					RuntimeService: runtimeSvc,
 				})
 
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 				assert.False(t, job.runtimeComponentRegistered)
 				assert.Empty(t, runtimeSvc.registered)
 			},
@@ -690,7 +690,7 @@ END`, chartengine.Priority, chartengine.Priority))
 					RuntimeService: runtimeSvc,
 				})
 
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 				require.True(t, job.runtimeComponentRegistered)
 				componentName := job.runtimeComponentName
 
@@ -712,7 +712,7 @@ END`, chartengine.Priority, chartengine.Priority))
 
 				var out bytes.Buffer
 				job := newTestJobV2(mod, &out)
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				// Simulate partial protocol bytes already present in the cycle buffer.
 				_, err := job.buf.WriteString("BEGIN 'broken'\nSET 'x' = 1\n")
@@ -757,7 +757,7 @@ END`, chartengine.Priority, chartengine.Priority))
 				}
 
 				job := newTestJobV2WithVnode(mod, &bytes.Buffer{}, *mod.vnode.Copy())
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				runDone := make(chan struct{})
 				go func() {
@@ -797,7 +797,7 @@ END`, chartengine.Priority, chartengine.Priority))
 				}
 
 				job := newTestJobV2(mod, &bytes.Buffer{})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				startDone := make(chan struct{})
 				go func() {
@@ -866,7 +866,7 @@ END`, chartengine.Priority, chartengine.Priority))
 					AutoDetectEvery: 1,
 				})
 
-				require.Error(t, job.AutoDetection())
+				require.Error(t, job.AutoDetection(context.Background()))
 				assert.False(t, job.RetryAutoDetection())
 			},
 		},
@@ -888,7 +888,7 @@ END`, chartengine.Priority, chartengine.Priority))
 					AutoDetectEvery: 1,
 				})
 
-				require.Error(t, job.AutoDetection())
+				require.Error(t, job.AutoDetection(context.Background()))
 				assert.True(t, job.RetryAutoDetection())
 			},
 		},
@@ -908,7 +908,7 @@ END`, chartengine.Priority, chartengine.Priority))
 					AutoDetectEvery: 1,
 				})
 
-				require.Error(t, job.AutoDetection())
+				require.Error(t, job.AutoDetection(context.Background()))
 				assert.False(t, job.RetryAutoDetection())
 			},
 		},
@@ -933,7 +933,7 @@ END`, chartengine.Priority, chartengine.Priority))
 					FunctionOnly:    true,
 				})
 
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				done := make(chan struct{})
 				go func() {
@@ -979,7 +979,7 @@ END`, chartengine.Priority, chartengine.Priority))
 					FunctionOnly:    true,
 				})
 
-				require.Error(t, job.AutoDetection())
+				require.Error(t, job.AutoDetection(context.Background()))
 				assert.True(t, mod.cleaned)
 				assert.Equal(t, 1, cleanupCalls)
 			},
@@ -1035,7 +1035,7 @@ func TestJobV2_StartMarksNotRunningBeforeCleanup(t *testing.T) {
 
 	var out bytes.Buffer
 	job := newTestJobV2(mod, &out)
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	startDone := make(chan struct{})
 	go func() {
@@ -1100,7 +1100,7 @@ func TestJobV2VnodeEmissionLifecycle(t *testing.T) {
 			"region": "eu'\n",
 		},
 	})
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	job.runOnce()
 	wire := out.String()
@@ -1228,7 +1228,7 @@ BEGIN 'module_job.workers_busy'`,
 
 			var out bytes.Buffer
 			job := newTestJobV2WithVnode(mod, &out, *modVnode.Copy())
-			require.NoError(t, job.AutoDetection())
+			require.NoError(t, job.AutoDetection(context.Background()))
 
 			initialInfo, err := chartemit.PrepareHostInfo(netdataapi.HostInfo{
 				GUID:     "node-guid",
@@ -1353,7 +1353,7 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 						GUID:     "node-guid",
 					},
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 
@@ -1393,7 +1393,7 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 						GUID:     "node-guid",
 					},
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				prepared, ok := job.collectAndEmit(0)
 				require.True(t, ok)
@@ -1442,7 +1442,7 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 						GUID:     "node-guid-a",
 					},
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 				assert.Equal(t, []vnoderegistry.Owner{vnoderegistry.Owner("module_job\xffjob\xffnode-guid-a")}, registry.Owners("node-guid-a"))
@@ -1488,7 +1488,7 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 						GUID:     "node-guid",
 					},
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 				require.Equal(t, []vnoderegistry.Owner{vnoderegistry.Owner("module_job\xffjob\xffnode-guid")}, registry.Owners("node-guid"))
@@ -1578,7 +1578,7 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 						GUID:     "node-guid",
 					},
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 
@@ -1617,7 +1617,7 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 						GUID:     "node-guid",
 					},
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 				assert.Equal(t, "", out.String())
@@ -1649,7 +1649,7 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 					Hostname: "node-host",
 					GUID:     "node-guid",
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 				assert.Equal(t, "", out.String())
@@ -1702,7 +1702,7 @@ func TestJobV2HostScopeScenarios(t *testing.T) {
 					UpdateEvery:   1,
 					VnodeRegistry: registry,
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 
@@ -1750,7 +1750,7 @@ CHART 'module_job.workers_busy'`)
 					UpdateEvery:   1,
 					VnodeRegistry: registry,
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 
@@ -1791,7 +1791,7 @@ CHART 'module_job.workers_busy'`)
 					UpdateEvery:   1,
 					VnodeRegistry: registry,
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 				require.Contains(t, out.String(), `HOST_DEFINE 'guid-a' 'host-a'`)
@@ -1836,7 +1836,7 @@ CHART 'module_job.workers_busy'`)
 					UpdateEvery:   1,
 					VnodeRegistry: registry,
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 				assert.Empty(t, out.String())
@@ -1871,7 +1871,7 @@ CHART 'module_job.workers_busy'`)
 
 				var out bytes.Buffer
 				job := newTestJobV2(mod, &out)
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				job.runOnce()
 				require.NotNil(t, job.scopeStates[defaultHostScopeKey])
@@ -1914,7 +1914,7 @@ CHART 'module_job.workers_busy'`)
 					UpdateEvery:   1,
 					VnodeRegistry: registry,
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				prepared, ok := job.collectAndEmit(0)
 				require.True(t, ok)
@@ -1941,7 +1941,7 @@ CHART 'module_job.workers_busy'`)
 				mod := &mockModuleV2{store: store, template: chartTemplateV2()}
 				var out bytes.Buffer
 				job := newTestJobV2(mod, &out)
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 
 				okMeta := chartengine.ChartMeta{
 					Title:    "OK",
@@ -2008,7 +2008,7 @@ CHART 'module_job.workers_busy'`)
 					UpdateEvery:   1,
 					VnodeRegistry: registry,
 				})
-				require.NoError(t, job.AutoDetection())
+				require.NoError(t, job.AutoDetection(context.Background()))
 				job.api = netdataapi.New(writeFunc(func(p []byte) (int, error) {
 					if bytes.Contains(p, []byte("HOST_DEFINE 'guid-a'")) {
 						panic("boom")
@@ -2073,7 +2073,7 @@ func TestJobV2CleanupUsesLastSuccessfulHostAfterFailedHostSwitch(t *testing.T) {
 		Hostname: "node-host-a",
 		GUID:     "node-guid-a",
 	})
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	job.runOnce()
 	out.Reset()
@@ -2115,7 +2115,7 @@ func TestJobV2EmptyHostSwitchDoesNotKeepReloadingEngine(t *testing.T) {
 		Hostname: "node-host-a",
 		GUID:     "node-guid-a",
 	})
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 	require.Equal(t, 1, mod.templateCalls)
 
 	job.runOnce()
@@ -2160,7 +2160,7 @@ func TestJobV2CleanupDoesNotSuppressGlobalCleanupForDifferentStaleVnode(t *testi
 
 	var out bytes.Buffer
 	job := newTestJobV2(mod, &out)
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	job.runOnce()
 	out.Reset()
@@ -2209,7 +2209,7 @@ func TestJobV2CleanupUsesPreModuleCleanupSnapshotForStaleSuppression(t *testing.
 
 	var out bytes.Buffer
 	job := newTestJobV2WithVnode(mod, &out, *modVnode.Copy())
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	job.runOnce()
 	out.Reset()
@@ -2238,7 +2238,7 @@ func TestJobV2CleanupDoesNotSuppressExplicitScopeForStaleJobVnode(t *testing.T) 
 			"_node_stale_after_seconds": "60",
 		},
 	})
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	job.scopeStates = map[string]*jobV2ScopeState{
 		"scope-a": {
@@ -2278,7 +2278,7 @@ func TestJobV2CleanupNoSuccessfulEmissionsIsNoOp(t *testing.T) {
 
 	var out bytes.Buffer
 	job := newTestJobV2(mod, &out)
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 
 	job.Cleanup()
 

--- a/src/go/plugin/framework/runtimecomp/context_test.go
+++ b/src/go/plugin/framework/runtimecomp/context_test.go
@@ -11,6 +11,7 @@ type mockService struct{}
 
 func (mockService) RegisterComponent(ComponentConfig) error { return nil }
 func (mockService) UnregisterComponent(string)              {}
+func (mockService) QuarantineComponent(string)              {}
 func (mockService) RegisterProducer(string, func() error) error {
 	return nil
 }

--- a/src/go/plugin/framework/runtimecomp/types.go
+++ b/src/go/plugin/framework/runtimecomp/types.go
@@ -38,6 +38,14 @@ type ComponentConfig struct {
 type Service interface {
 	RegisterComponent(cfg ComponentConfig) error
 	UnregisterComponent(name string)
+
+	// QuarantineComponent removes a component and its emission state WITHOUT
+	// removal/obsoletion output, returning only after any in-progress emission
+	// tick (including its post-write state finalizers) has completed - after
+	// it returns, no output for the component can reach the wire. Unlike
+	// UnregisterComponent, which stops future snapshots but lets an
+	// in-progress tick finish and later emits removal-obsolete output.
+	QuarantineComponent(name string)
 	RegisterProducer(name string, tickFn func() error) error
 	UnregisterProducer(name string)
 }

--- a/src/go/plugin/scripts.d/collector/nagios/job_v2_integration_test.go
+++ b/src/go/plugin/scripts.d/collector/nagios/job_v2_integration_test.go
@@ -4,6 +4,7 @@ package nagios
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -163,7 +164,7 @@ func newTestJobV2(t *testing.T, name string, coll *Collector, out io.Writer) *jo
 		Out:         out,
 		UpdateEvery: 1,
 	})
-	require.NoError(t, job.AutoDetection())
+	require.NoError(t, job.AutoDetection(context.Background()))
 	return job
 }
 


### PR DESCRIPTION
##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs blocking collector work in `jobmgr` as supervised effects, installs a per‑job emission gateway, and adds a runtime‑component emission barrier. Keeps a new job’s gateway across same‑name replacements, drains stray effect completions, and normalizes component names in the barrier.

- **New Features**
  - Effects: config apply validation, job create + autodetect, and stop‑wait run in supervised child goroutines; execution is synchronous, uncancellable, and preserves panic behavior. The loop now drains stray effect completions.
  - Emission gateway: each runnable job writes through a per‑job gateway that atomically checks‑and‑writes; closing waits out in‑flight writes and suppresses later ones. Gateways are tracked by full name, cleaned on stop and failed create/detect/validation‑only paths, and survive same‑name replacements.
  - Runtime‑component barrier: a tick mutex in `runtimechartemit` spans the entire emit critical section; `runtimecomp.Service.QuarantineComponent` waits out any in‑flight tick, then removes registration and emission state without emitting obsolete output. Re‑registrations emit normally, and the barrier trims the component name like other entry points.

- **Migration**
  - Update `AutoDetection` calls to `AutoDetection(ctx context.Context)` and pass `context.Background()` (detection remains uncancellable).
  - Implement `QuarantineComponent(name string)` on your `runtimecomp.Service` implementations and test mocks.

<sup>Written for commit 741d9094d890a1b1c936d7a3069a5f41c2f65072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

