### PR TITLE
Netdata fixes part 23

### DIFF
--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -516,7 +516,15 @@ ALWAYS_INLINE PGD *pgd_create_from_disk_data(uint8_t type, void *base, uint32_t 
 
             memcpy(pg->raw.data, base, pg->raw.size);
 
-            uint32_t total_entries = gorilla_buffer_patch((void *) pg->raw.data);
+            uint32_t total_entries = 0;
+            if(unlikely(!gorilla_buffer_patch((void *) pg->raw.data,
+                                              size / RRDENG_GORILLA_32BIT_BUFFER_SIZE,
+                                              &total_entries))) {
+                netdata_log_error("DBENGINE: invalid gorilla disk page chain.");
+                pgd_free(pg);
+                pg = PGD_EMPTY;
+                break;
+            }
             pg->used = total_entries;
             pg->slots = pg->used;
             break;

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -377,6 +377,28 @@ TEST(PGD, Roundtrip) {
     pgd_free(pg_collector);
 }
 
+TEST(PGD, RejectCorruptGorillaDiskChain) {
+    size_t slots = slots_for_page(16);
+    PGD *pg_collector = pgd_create(page_type, slots);
+
+    for (size_t i = 0; i != slots; i++)
+        pgd_append_point(pg_collector, i, i, 0, 0, 1, 1, SN_DEFAULT_FLAGS, i);
+
+    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    uint32_t size_in_words = size_in_bytes / sizeof(uint32_t);
+
+    alignas(sizeof(uintptr_t)) uint32_t disk_buffer[size_in_words];
+    pgd_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
+
+    void *last_gbuf = &disk_buffer[size_in_words - RRDENG_GORILLA_32BIT_BUFFER_SLOTS];
+    memcpy(last_gbuf, &last_gbuf, sizeof(last_gbuf));
+
+    PGD *pg_disk = pgd_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
+    EXPECT_EQ(pg_disk, PGD_EMPTY);
+
+    pgd_free(pg_collector);
+}
+
 int pgd_test(int argc, char *argv[])
 {
     // Dummy/necessary initialization stuff

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -399,6 +399,56 @@ TEST(PGD, RejectCorruptGorillaDiskChain) {
     pgd_free(pg_collector);
 }
 
+TEST(PGD, StopCorruptGorillaDiskEntriesAtEncodedBits) {
+    PGD *pg_collector = pgd_create(page_type, slots_for_page(1));
+
+    uint32_t value = 666;
+    pgd_append_point(pg_collector, 0, value, 0, 0, 1, 1, SN_DEFAULT_FLAGS, 0);
+
+    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    uint32_t size_in_words = size_in_bytes / sizeof(uint32_t);
+
+    alignas(sizeof(uintptr_t)) uint32_t disk_buffer[size_in_words];
+    pgd_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
+
+    auto *gbuf = static_cast<gorilla_buffer_t *>(static_cast<void *>(&disk_buffer[0]));
+    gbuf->header.entries++;
+
+    PGD *pg_disk = pgd_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
+    EXPECT_EQ(pgd_slots_used(pg_disk), 2);
+
+    PGDC cursor;
+    pgdc_reset(&cursor, pg_disk, 0);
+
+    STORAGE_POINT sp = {};
+    EXPECT_TRUE(pgdc_get_next_point(&cursor, 0, &sp));
+    EXPECT_EQ(value, static_cast<uint32_t>(sp.min));
+    EXPECT_FALSE(pgdc_get_next_point(&cursor, 1, &sp));
+
+    pgd_free(pg_disk);
+    pgd_free(pg_collector);
+}
+
+TEST(PGD, RejectCorruptGorillaDiskNbits) {
+    PGD *pg_collector = pgd_create(page_type, slots_for_page(1));
+
+    pgd_append_point(pg_collector, 0, 666, 0, 0, 1, 1, SN_DEFAULT_FLAGS, 0);
+
+    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    uint32_t size_in_words = size_in_bytes / sizeof(uint32_t);
+
+    alignas(sizeof(uintptr_t)) uint32_t disk_buffer[size_in_words];
+    pgd_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
+
+    auto *gbuf = static_cast<gorilla_buffer_t *>(static_cast<void *>(&disk_buffer[0]));
+    gbuf->header.nbits = RRDENG_GORILLA_32BIT_BUFFER_SIZE * CHAR_BIT;
+
+    PGD *pg_disk = pgd_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
+    EXPECT_EQ(pg_disk, PGD_EMPTY);
+
+    pgd_free(pg_collector);
+}
+
 int pgd_test(int argc, char *argv[])
 {
     // Dummy/necessary initialization stuff

--- a/src/libnetdata/avl/avl.c
+++ b/src/libnetdata/avl/avl.c
@@ -381,8 +381,7 @@ void avl_init_lock(avl_tree_lock *tree, int (*compar)(void * /*a*/, void * /*b*/
 
 void avl_destroy_lock(avl_tree_lock *tree __maybe_unused) {
 #if defined(AVL_LOCK_WITH_RWLOCK)
-    if(netdata_rwlock_destroy(&tree->rwlock) != 0)
-        fatal("Failed to destroy AVL rwlock");
+    netdata_rwlock_destroy(&tree->rwlock);
 #endif
 }
 

--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -37,6 +37,21 @@ static bool gorilla_disk_buffer_has_valid_nbits(const gorilla_buffer_t *gbuf) {
     return gbuf->header.nbits < gorilla_buffer_data_bits(RRDENG_GORILLA_32BIT_BUFFER_SLOTS);
 }
 
+static uint32_t gorilla_data_word_load(const uint32_t *word)
+{
+    return __atomic_load_n(word, __ATOMIC_RELAXED);
+}
+
+static void gorilla_data_word_store(uint32_t *word, uint32_t value)
+{
+    __atomic_store_n(word, value, __ATOMIC_RELAXED);
+}
+
+static void gorilla_data_word_or(uint32_t *word, uint32_t value)
+{
+    __atomic_fetch_or(word, value, __ATOMIC_RELAXED);
+}
+
 static void bit_buffer_write(uint32_t *buf, size_t pos, uint32_t v, size_t nbits)
 {
     assert(nbits > 0 && nbits <= bit_size<uint32_t>());
@@ -47,20 +62,20 @@ static void bit_buffer_write(uint32_t *buf, size_t pos, uint32_t v, size_t nbits
     pos += nbits;
 
     if (offset == 0) {
-        buf[index] = v;
+        gorilla_data_word_store(&buf[index], v);
     } else {
         const size_t remaining_bits = bit_size<uint32_t>() - offset;
 
         // write the lower part of the value
         const uint32_t low_bits_mask = ((uint32_t) 1 << remaining_bits) - 1;
         const uint32_t lowest_bits_in_value = v & low_bits_mask;
-        buf[index] |= (lowest_bits_in_value << offset);
+        gorilla_data_word_or(&buf[index], lowest_bits_in_value << offset);
 
         if (nbits > remaining_bits) {
             // write the upper part of the value
             const uint32_t high_bits_mask = ~low_bits_mask;
             const uint32_t highest_bits_in_value = (v & high_bits_mask) >> (remaining_bits);
-            buf[index + 1] = highest_bits_in_value;
+            gorilla_data_word_store(&buf[index + 1], highest_bits_in_value);
         }
     }
 }
@@ -75,19 +90,22 @@ static void bit_buffer_read(const uint32_t *buf, size_t pos, uint32_t *v, size_t
     pos += nbits;
 
     if (offset == 0) {
+        uint32_t word = gorilla_data_word_load(&buf[index]);
         *v = (nbits == bit_size<uint32_t>()) ?
-                    buf[index] :
-                    buf[index] & (((uint32_t) 1 << nbits) - 1);
+                    word :
+                    word & (((uint32_t) 1 << nbits) - 1);
     } else {
         const size_t remaining_bits = bit_size<uint32_t>() - offset;
 
         // extract the lower part of the value
+        uint32_t word = gorilla_data_word_load(&buf[index]);
         if (nbits < remaining_bits) {
-            *v = (buf[index] >> offset) & (((uint32_t) 1 << nbits) - 1);
+            *v = (word >> offset) & (((uint32_t) 1 << nbits) - 1);
         } else {
-            *v = (buf[index] >> offset) & (((uint32_t) 1 << remaining_bits) - 1);
+            *v = (word >> offset) & (((uint32_t) 1 << remaining_bits) - 1);
             nbits -= remaining_bits;
-            *v |= (buf[index + 1] & (((uint32_t) 1 << nbits) - 1)) << remaining_bits;
+            word = gorilla_data_word_load(&buf[index + 1]);
+            *v |= (word & (((uint32_t) 1 << nbits) - 1)) << remaining_bits;
         }
     }
 }

--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -260,24 +260,30 @@ bool gorilla_writer_serialize(const gorilla_writer_t *gw, uint8_t *dst, uint32_t
     return true;
 }
 
-uint32_t gorilla_buffer_patch(gorilla_buffer_t *gbuf) {
+bool gorilla_buffer_patch(gorilla_buffer_t *gbuf, size_t nbuffers, uint32_t *entries) {
     gorilla_buffer_t *curr_gbuf = gbuf;
     uint32_t n = curr_gbuf->header.entries;
+    size_t buffers = 1;
 
     while (curr_gbuf->header.next) {
-        uint32_t *buf = reinterpret_cast<uint32_t *>(gbuf);
-        gbuf = reinterpret_cast<gorilla_buffer_t *>(&buf[RRDENG_GORILLA_32BIT_BUFFER_SLOTS]);
+        if(unlikely(buffers == nbuffers))
+            return false;
 
-        assert(((uintptr_t) (gbuf) % sizeof(uintptr_t)) == 0 &&
+        auto *buf = static_cast<unsigned char *>(static_cast<void *>(curr_gbuf));
+        auto *next_gbuf = static_cast<gorilla_buffer_t *>(static_cast<void *>(buf + RRDENG_GORILLA_32BIT_BUFFER_SIZE));
+
+        assert(((uintptr_t) (next_gbuf) % sizeof(uintptr_t)) == 0 &&
                "Gorilla buffer not aligned to uintptr_t");
 
-        curr_gbuf->header.next = gbuf;
+        curr_gbuf->header.next = next_gbuf;
         curr_gbuf = curr_gbuf->header.next;
+        buffers++;
 
         n += curr_gbuf->header.entries;
     }
 
-    return n;
+    *entries = n;
+    return true;
 }
 
 size_t gorilla_buffer_unpatched_nbuffers(const gorilla_buffer_t *gbuf) {
@@ -286,8 +292,8 @@ size_t gorilla_buffer_unpatched_nbuffers(const gorilla_buffer_t *gbuf) {
         nbuffers++;
 
         if(gbuf->header.next) {
-            const auto *buf = reinterpret_cast<const uint32_t *>(gbuf);
-            gbuf = reinterpret_cast<const gorilla_buffer_t *>(&buf[RRDENG_GORILLA_32BIT_BUFFER_SLOTS]);
+            const auto *buf = static_cast<const unsigned char *>(static_cast<const void *>(gbuf));
+            gbuf = static_cast<const gorilla_buffer_t *>(static_cast<const void *>(buf + RRDENG_GORILLA_32BIT_BUFFER_SIZE));
         }
         else
             break;
@@ -301,8 +307,8 @@ size_t gorilla_buffer_unpatched_nbytes(const gorilla_buffer_t *gbuf) {
     while(gbuf) {
         if(gbuf->header.next) {
             nbytes += RRDENG_GORILLA_32BIT_BUFFER_SIZE;
-            const auto *buf = reinterpret_cast<const uint32_t *>(gbuf);
-            gbuf = reinterpret_cast<const gorilla_buffer_t *>(&buf[RRDENG_GORILLA_32BIT_BUFFER_SLOTS]);
+            const auto *buf = static_cast<const unsigned char *>(static_cast<const void *>(gbuf));
+            gbuf = static_cast<const gorilla_buffer_t *>(static_cast<const void *>(buf + RRDENG_GORILLA_32BIT_BUFFER_SIZE));
         }
         else {
             nbytes += gorilla_buffer_nbytes(gbuf->header.nbits);

--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -29,6 +29,14 @@ static uint32_t gorilla_buffer_nbytes(uint32_t nbits) {
     return slots * RRDENG_GORILLA_32BIT_SLOT_BYTES;
 }
 
+static constexpr size_t gorilla_buffer_data_bits(size_t n) {
+    return (n * bit_size<uint32_t>()) - (sizeof(gorilla_header_t) * CHAR_BIT);
+}
+
+static bool gorilla_disk_buffer_has_valid_nbits(const gorilla_buffer_t *gbuf) {
+    return gbuf->header.nbits < gorilla_buffer_data_bits(RRDENG_GORILLA_32BIT_BUFFER_SLOTS);
+}
+
 static void bit_buffer_write(uint32_t *buf, size_t pos, uint32_t v, size_t nbits)
 {
     assert(nbits > 0 && nbits <= bit_size<uint32_t>());
@@ -104,7 +112,7 @@ void gorilla_writer_add_buffer(gorilla_writer_t *gw, gorilla_buffer_t *gbuf, siz
     gbuf->header.entries = 0;
     gbuf->header.nbits = 0;
 
-    uint32_t capacity = (n * bit_size<uint32_t>()) - (sizeof(gorilla_header_t) * CHAR_BIT);
+    uint32_t capacity = gorilla_buffer_data_bits(n);
 
     gw->prev_number = 0;
     gw->prev_xor_lzc = 0;
@@ -265,6 +273,9 @@ bool gorilla_buffer_patch(gorilla_buffer_t *gbuf, size_t nbuffers, uint32_t *ent
     uint32_t n = curr_gbuf->header.entries;
     size_t buffers = 1;
 
+    if(unlikely(!gorilla_disk_buffer_has_valid_nbits(curr_gbuf)))
+        return false;
+
     while (curr_gbuf->header.next) {
         if(unlikely(buffers == nbuffers))
             return false;
@@ -278,6 +289,9 @@ bool gorilla_buffer_patch(gorilla_buffer_t *gbuf, size_t nbuffers, uint32_t *ent
         curr_gbuf->header.next = next_gbuf;
         curr_gbuf = curr_gbuf->header.next;
         buffers++;
+
+        if(unlikely(!gorilla_disk_buffer_has_valid_nbits(curr_gbuf)))
+            return false;
 
         n += curr_gbuf->header.entries;
     }
@@ -355,6 +369,16 @@ gorilla_reader_t gorilla_reader_init(gorilla_buffer_t *gbuf)
     };
 }
 
+static bool gorilla_reader_read_bits(gorilla_reader_t *gr, const uint32_t *data, uint32_t *number, size_t nbits)
+{
+    if (unlikely(gr->position > gr->capacity || nbits > gr->capacity - gr->position))
+        return false;
+
+    bit_buffer_read(data, gr->position, number, nbits);
+    gr->position += nbits;
+    return true;
+}
+
 extern "C" {
     ALWAYS_INLINE_ONLY bool gorilla_reader_read(gorilla_reader_t *gr, uint32_t *number)
     {
@@ -387,18 +411,17 @@ extern "C" {
 
         // read the first number
         if (gr->index == 0) {
-            bit_buffer_read(data, gr->position, number, bit_size<uint32_t>());
-
+            if (unlikely(!gorilla_reader_read_bits(gr, data, number, bit_size<uint32_t>())))
+                return false;
             gr->index++;
-            gr->position += bit_size<uint32_t>();
             gr->prev_number = *number;
             return true;
         }
 
         // process same-number bit
         uint32_t is_same_number;
-        bit_buffer_read(data, gr->position, &is_same_number, 1);
-        gr->position++;
+        if (unlikely(!gorilla_reader_read_bits(gr, data, &is_same_number, 1)))
+            return false;
 
         if (is_same_number) {
             *number = gr->prev_number;
@@ -410,18 +433,19 @@ extern "C" {
         uint32_t xor_lzc = gr->prev_xor_lzc;
 
         uint32_t same_xor_lzc;
-        bit_buffer_read(data, gr->position, &same_xor_lzc, 1);
-        gr->position++;
+        if (unlikely(!gorilla_reader_read_bits(gr, data, &same_xor_lzc, 1)))
+            return false;
 
         if (!same_xor_lzc) {
-            bit_buffer_read(data, gr->position, &xor_lzc, (bit_size<uint32_t>() == 32) ? 5 : 6);
-            gr->position += (bit_size<uint32_t>() == 32) ? 5 : 6;
+            size_t xor_lzc_bits = (bit_size<uint32_t>() == 32) ? 5 : 6;
+            if (unlikely(!gorilla_reader_read_bits(gr, data, &xor_lzc, xor_lzc_bits)))
+                return false;
         }
 
         // process the non-lzc suffix
         uint32_t xor_value = 0;
-        bit_buffer_read(data, gr->position, &xor_value, bit_size<uint32_t>() - xor_lzc);
-        gr->position += bit_size<uint32_t>() - xor_lzc;
+        if (unlikely(!gorilla_reader_read_bits(gr, data, &xor_value, bit_size<uint32_t>() - xor_lzc)))
+            return false;
 
         *number = (gr->prev_number ^ xor_value);
 

--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -495,7 +495,44 @@ private:
     std::vector<uint32_t *> Buffers;
 };
 
+static void fuzz_disk_buffer_patch(const uint8_t *data, size_t size) {
+    if (size == 0)
+        return;
+
+    const size_t buffer_size = RRDENG_GORILLA_32BIT_BUFFER_SIZE;
+    if (size > SIZE_MAX - (buffer_size - 1))
+        return;
+
+    const size_t disk_size = ((size + buffer_size - 1) / buffer_size) * buffer_size;
+    const size_t nbuffers = disk_size / buffer_size;
+    const size_t words = disk_size / sizeof(uint32_t);
+
+    Storage S;
+    gorilla_buffer_t *disk_buffer = S.alloc_buffer(words);
+    memcpy(disk_buffer, data, size);
+
+    uint32_t entries = 0;
+    if (gorilla_buffer_patch(disk_buffer, nbuffers, &entries)) {
+        gorilla_reader_t gr = gorilla_reader_init(disk_buffer);
+
+        // entries is fuzzer-controlled, so keep this path bounded.
+        constexpr uint32_t max_reads = 16384;
+        if (entries > max_reads)
+            entries = max_reads;
+
+        for (uint32_t i = 0; i != entries; i++) {
+            uint32_t number = 0;
+            if (!gorilla_reader_read(&gr, &number))
+                break;
+        }
+    }
+
+    S.free_buffers();
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    fuzz_disk_buffer_patch(Data, Size);
+
     if (Size < 4)
         return 0;
 

--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -300,39 +300,6 @@ bool gorilla_buffer_patch(gorilla_buffer_t *gbuf, size_t nbuffers, uint32_t *ent
     return true;
 }
 
-size_t gorilla_buffer_unpatched_nbuffers(const gorilla_buffer_t *gbuf) {
-    size_t nbuffers = 0;
-    while(gbuf) {
-        nbuffers++;
-
-        if(gbuf->header.next) {
-            const auto *buf = static_cast<const unsigned char *>(static_cast<const void *>(gbuf));
-            gbuf = static_cast<const gorilla_buffer_t *>(static_cast<const void *>(buf + RRDENG_GORILLA_32BIT_BUFFER_SIZE));
-        }
-        else
-            break;
-    }
-
-    return nbuffers;
-}
-
-size_t gorilla_buffer_unpatched_nbytes(const gorilla_buffer_t *gbuf) {
-    size_t nbytes = sizeof(gorilla_buffer_t);
-    while(gbuf) {
-        if(gbuf->header.next) {
-            nbytes += RRDENG_GORILLA_32BIT_BUFFER_SIZE;
-            const auto *buf = static_cast<const unsigned char *>(static_cast<const void *>(gbuf));
-            gbuf = static_cast<const gorilla_buffer_t *>(static_cast<const void *>(buf + RRDENG_GORILLA_32BIT_BUFFER_SIZE));
-        }
-        else {
-            nbytes += gorilla_buffer_nbytes(gbuf->header.nbits);
-            break;
-        }
-    }
-
-    return nbytes;
-}
-
 gorilla_reader_t gorilla_writer_get_reader(const gorilla_writer_t *gw)
 {
     const gorilla_buffer_t *buffer = __atomic_load_n(&gw->head_buffer, __ATOMIC_ACQUIRE);

--- a/src/libnetdata/gorilla/gorilla.h
+++ b/src/libnetdata/gorilla/gorilla.h
@@ -67,7 +67,7 @@ uint32_t gorilla_writer_actual_nbytes(const gorilla_writer_t *gw);
 uint32_t gorilla_writer_optimal_nbytes(const gorilla_writer_t *gw);
 bool gorilla_writer_serialize(const gorilla_writer_t *gw, uint8_t *dst, uint32_t dst_size);
 
-uint32_t gorilla_buffer_patch(gorilla_buffer_t *buf);
+bool gorilla_buffer_patch(gorilla_buffer_t *buf, size_t nbuffers, uint32_t *entries);
 size_t gorilla_buffer_unpatched_nbuffers(const gorilla_buffer_t *gbuf);
 size_t gorilla_buffer_unpatched_nbytes(const gorilla_buffer_t *gbuf);
 gorilla_reader_t gorilla_reader_init(gorilla_buffer_t *buf);

--- a/src/libnetdata/gorilla/gorilla.h
+++ b/src/libnetdata/gorilla/gorilla.h
@@ -43,7 +43,7 @@ typedef struct {
     size_t index;
 
     // in bits
-    size_t capacity; // FIXME: this not needed on the reader's side
+    size_t capacity;
     size_t position;
 
     uint32_t prev_number;

--- a/src/libnetdata/gorilla/gorilla.h
+++ b/src/libnetdata/gorilla/gorilla.h
@@ -68,8 +68,6 @@ uint32_t gorilla_writer_optimal_nbytes(const gorilla_writer_t *gw);
 bool gorilla_writer_serialize(const gorilla_writer_t *gw, uint8_t *dst, uint32_t dst_size);
 
 bool gorilla_buffer_patch(gorilla_buffer_t *buf, size_t nbuffers, uint32_t *entries);
-size_t gorilla_buffer_unpatched_nbuffers(const gorilla_buffer_t *gbuf);
-size_t gorilla_buffer_unpatched_nbytes(const gorilla_buffer_t *gbuf);
 gorilla_reader_t gorilla_reader_init(gorilla_buffer_t *buf);
 bool gorilla_reader_read(gorilla_reader_t *gr, uint32_t *number);
 

--- a/src/libnetdata/locks/locks.c
+++ b/src/libnetdata/locks/locks.c
@@ -232,16 +232,20 @@ static netdata_rwlock_locker *find_rwlock_locker(const char *file __maybe_unused
 }
 
 static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, LOCKER_REQUEST lock_type) {
-    netdata_rwlock_locker *locker;
+    pid_t pid = gettid();
+    netdata_rwlock_locker *locker = NULL;
 
-    locker = find_rwlock_locker(file, function, line, rwlock);
-    if(locker) {
+    __netdata_mutex_lock(&rwlock->lockers_mutex);
+
+    Pvoid_t *PValue = JudyLGet(rwlock->lockers_pid_JudyL, pid, PJE0);
+    if(PValue && *PValue) {
+        locker = *PValue;
         locker->lock |= lock_type;
         locker->refcount++;
     }
     else {
         locker = mallocz(sizeof(netdata_rwlock_locker));
-        locker->pid = gettid();
+        locker->pid = pid;
         locker->tag = netdata_thread_tag();
         locker->refcount = 1;
         locker->lock = lock_type;
@@ -250,14 +254,13 @@ static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *fu
         locker->function = function;
         locker->line = line;
 
-        __netdata_mutex_lock(&rwlock->lockers_mutex);
         DOUBLE_LINKED_LIST_APPEND_UNSAFE(rwlock->lockers, locker, prev, next);
-        Pvoid_t *PValue = JudyLIns(&rwlock->lockers_pid_JudyL, locker->pid, PJE0);
+        PValue = JudyLIns(&rwlock->lockers_pid_JudyL, locker->pid, PJE0);
         *PValue = locker;
         if (lock_type == RWLOCK_REQUEST_READ || lock_type == RWLOCK_REQUEST_TRYREAD) rwlock->readers++;
         if (lock_type == RWLOCK_REQUEST_WRITE || lock_type == RWLOCK_REQUEST_TRYWRITE) rwlock->writers++;
-        __netdata_mutex_unlock(&rwlock->lockers_mutex);
     }
+    __netdata_mutex_unlock(&rwlock->lockers_mutex);
 
     return locker;
 }

--- a/src/libnetdata/locks/locks.c
+++ b/src/libnetdata/locks/locks.c
@@ -95,32 +95,28 @@ int netdata_mutex_init_debug(const char *file __maybe_unused, const char *functi
     return ret;
 }
 
-int netdata_mutex_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+void netdata_mutex_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                              const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
     netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(%p) from %lu@%s, %s()", mutex, line, file, function);
 
-    int ret = __netdata_mutex_destroy(mutex);
+    __netdata_mutex_destroy(mutex);
 
-    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(%p) = %d, from %lu@%s, %s()", mutex, ret, line, file, function);
-
-    return ret;
+    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(%p), from %lu@%s, %s()", mutex, line, file, function);
 }
 
-int netdata_mutex_lock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+void netdata_mutex_lock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                              const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
     netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     usec_t start_s = now_monotonic_high_precision_usec();
-    int ret = __netdata_mutex_lock(mutex);
+    __netdata_mutex_lock(mutex);
     usec_t end_s = now_monotonic_high_precision_usec();
 
     // remove compiler unused variables warning
     (void)start_s;
     (void)end_s;
 
-    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
-
-    return ret;
+    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(%p) in %llu usec, from %lu@%s, %s()", mutex, end_s - start_s, line, file, function);
 }
 
 int netdata_mutex_trylock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
@@ -140,21 +136,19 @@ int netdata_mutex_trylock_debug(const char *file __maybe_unused, const char *fun
     return ret;
 }
 
-int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+void netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
     netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     usec_t start_s = now_monotonic_high_precision_usec();
-    int ret = __netdata_mutex_unlock(mutex);
+    __netdata_mutex_unlock(mutex);
     usec_t end_s = now_monotonic_high_precision_usec();
 
     // remove compiler unused variables warning
     (void)start_s;
     (void)end_s;
 
-    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
-
-    return ret;
+    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(%p) in %llu usec, from %lu@%s, %s()", mutex, end_s - start_s, line, file, function);
 }
 
 #endif // NETDATA_TRACE_RWLOCKS
@@ -246,7 +240,7 @@ static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *fu
     else {
         locker = mallocz(sizeof(netdata_rwlock_locker));
         locker->pid = pid;
-        locker->tag = netdata_thread_tag();
+        locker->tag = nd_thread_tag();
         locker->refcount = 1;
         locker->lock = lock_type;
         locker->got_it = false;
@@ -254,7 +248,7 @@ static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *fu
         locker->function = function;
         locker->line = line;
 
-        DOUBLE_LINKED_LIST_APPEND_UNSAFE(rwlock->lockers, locker, prev, next);
+        DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(rwlock->lockers, locker, prev, next);
         PValue = JudyLIns(&rwlock->lockers_pid_JudyL, locker->pid, PJE0);
         *PValue = locker;
         if (lock_type == RWLOCK_REQUEST_READ || lock_type == RWLOCK_REQUEST_TRYREAD) rwlock->readers++;
@@ -269,7 +263,7 @@ static void remove_rwlock_locker(const char *file __maybe_unused, const char *fu
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     locker->refcount--;
     if(!locker->refcount) {
-        DOUBLE_LINKED_LIST_REMOVE_UNSAFE(rwlock->lockers, locker, prev, next);
+        DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(rwlock->lockers, locker, prev, next);
         JudyLDel(&rwlock->lockers_pid_JudyL, locker->pid, PJE0);
         if (locker->lock == RWLOCK_REQUEST_READ || locker->lock == RWLOCK_REQUEST_TRYREAD) rwlock->readers--;
         else if (locker->lock == RWLOCK_REQUEST_WRITE || locker->lock == RWLOCK_REQUEST_TRYWRITE) rwlock->writers--;
@@ -281,16 +275,12 @@ static void remove_rwlock_locker(const char *file __maybe_unused, const char *fu
 // ----------------------------------------------------------------------------
 // debug versions of rwlock
 
-int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+void netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                  const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
 
-    int ret = __netdata_rwlock_destroy(rwlock);
-    if(!ret) {
-        while (rwlock->lockers)
-            remove_rwlock_locker(file, function, line, rwlock, rwlock->lockers);
-    }
-
-    return ret;
+    __netdata_rwlock_destroy(rwlock);
+    while (rwlock->lockers)
+        remove_rwlock_locker(file, function, line, rwlock, rwlock->lockers);
 }
 
 int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
@@ -308,35 +298,25 @@ int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *funct
     return ret;
 }
 
-int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+void netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
 
     netdata_rwlock_locker *locker = add_rwlock_locker(file, function, line, rwlock, RWLOCK_REQUEST_READ);
 
-    int ret = __netdata_rwlock_rdlock(rwlock);
-    if(!ret)
-        locker->got_it = true;
-    else
-        remove_rwlock_locker(file, function, line, rwlock, locker);
-
-    return ret;
+    __netdata_rwlock_rdlock(rwlock);
+    locker->got_it = true;
 }
 
-int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+void netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
 
     netdata_rwlock_locker *locker = add_rwlock_locker(file, function, line, rwlock, RWLOCK_REQUEST_WRITE);
 
-    int ret = __netdata_rwlock_wrlock(rwlock);
-    if(!ret)
-        locker->got_it = true;
-    else
-        remove_rwlock_locker(file, function, line, rwlock, locker);
-
-    return ret;
+    __netdata_rwlock_wrlock(rwlock);
+    locker->got_it = true;
 }
 
-int netdata_rwlock_rdunlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+void netdata_rwlock_rdunlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
@@ -344,14 +324,11 @@ int netdata_rwlock_rdunlock_debug(const char *file __maybe_unused, const char *f
     if(unlikely(!locker))
         fatal("UNLOCK WITHOUT LOCK");
 
-    int ret = __netdata_rwlock_rdunlock(rwlock);
-    if(likely(!ret))
-        remove_rwlock_locker(file, function, line, rwlock, locker);
-
-    return ret;
+    __netdata_rwlock_rdunlock(rwlock);
+    remove_rwlock_locker(file, function, line, rwlock, locker);
 }
 
-int netdata_rwlock_wrunlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+void netdata_rwlock_wrunlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
@@ -359,11 +336,8 @@ int netdata_rwlock_wrunlock_debug(const char *file __maybe_unused, const char *f
     if(unlikely(!locker))
         fatal("UNLOCK WITHOUT LOCK");
 
-    int ret = __netdata_rwlock_wrunlock(rwlock);
-    if(likely(!ret))
-        remove_rwlock_locker(file, function, line, rwlock, locker);
-
-    return ret;
+    __netdata_rwlock_wrunlock(rwlock);
+    remove_rwlock_locker(file, function, line, rwlock, locker);
 }
 
 int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,

--- a/src/libnetdata/locks/locks.h
+++ b/src/libnetdata/locks/locks.h
@@ -85,17 +85,17 @@ void __netdata_cond_broadcast(netdata_cond_t *cond);
 #ifdef NETDATA_TRACE_RWLOCKS
 
 int netdata_mutex_init_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
-int netdata_mutex_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
-int netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+void netdata_mutex_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+void netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
 int netdata_mutex_trylock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
-int netdata_mutex_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+void netdata_mutex_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
 
-int netdata_rwlock_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+void netdata_rwlock_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
 int netdata_rwlock_init_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-int netdata_rwlock_rdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-int netdata_rwlock_wrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-int netdata_rwlock_rdunlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-int netdata_rwlock_wrunlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+void netdata_rwlock_rdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+void netdata_rwlock_wrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+void netdata_rwlock_rdunlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+void netdata_rwlock_wrunlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
 int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
 int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
 

--- a/src/libnetdata/memory/nd-mallocz.c
+++ b/src/libnetdata/memory/nd-mallocz.c
@@ -223,11 +223,22 @@ static void link_system_library_function(libc_function_t *func_pptr, const char 
     libc_function_t func = dlsym(RTLD_NEXT, name);
     dlsym_bootstrap_depth--;
 
-    *func_pptr = func;
-    if(!*func_pptr && required) {
-        fprintf(stderr, "FATAL: Cannot find system's %s() function.\n", name);
+    if(!func && required) {
+        // Report without allocating, then abort. fprintf() may call malloc(),
+        // which at this point (bootstrap inactive, libc allocator still
+        // unresolved and *func_pptr about to be NULL) would recurse into the
+        // first-run resolver or dereference a NULL libc function pointer.
+        // Mirror dlsym_bootstrap_abort() and use write(2). name is always a
+        // string literal, so strlen() is safe and allocation-free here.
+        static const char pre[] = "FATAL: Cannot find system's ";
+        static const char post[] = "() function.\n";
+        if(write(STDERR_FILENO, pre, sizeof(pre) - 1) < 0) { /* best effort */ }
+        if(write(STDERR_FILENO, name, strlen(name)) < 0) { /* best effort */ }
+        if(write(STDERR_FILENO, post, sizeof(post) - 1) < 0) { /* best effort */ }
         abort();
     }
+
+    *func_pptr = func;
 }
 
 static void *malloc_first_run(size_t size) {

--- a/src/libnetdata/memory/nd-mallocz.c
+++ b/src/libnetdata/memory/nd-mallocz.c
@@ -193,6 +193,20 @@ struct malloc_header {
     uint8_t data[];
 };
 
+#define MALLOC_HEADER_MAGIC 0x0BADCAFEU
+
+static const uint8_t malloc_header_magic_salt;
+
+static uint32_t malloc_header_magic(const struct malloc_header *t) {
+    uintptr_t value = (uintptr_t)t ^ (uintptr_t)&malloc_header_magic_salt;
+
+#if UINTPTR_MAX > UINT32_MAX
+    value ^= value >> 32;
+#endif
+
+    return (uint32_t)value ^ MALLOC_HEADER_MAGIC;
+}
+
 static size_t malloc_header_size = sizeof(struct malloc_header);
 
 int malloc_trace_compare(void *A, void *B) {
@@ -267,9 +281,9 @@ void *mallocz_int(size_t size, const char *file, const char *function, size_t li
 
     struct malloc_header *t = (struct malloc_header *)libc_malloc(malloc_header_size + size);
     if (unlikely(!t)) fatal("mallocz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
-    t->signature.magic = 0x0BADCAFE;
     t->signature.trace = p;
     t->signature.size = size;
+    t->signature.magic = malloc_header_magic(t);
 
 #ifdef NETDATA_INTERNAL_CHECKS
     for(ssize_t i = 0; i < (ssize_t)sizeof(t->padding) ;i++) // signed to avoid compiler warning when zero-padded
@@ -292,9 +306,9 @@ void *callocz_int(size_t nmemb, size_t size, const char *file, const char *funct
 
     struct malloc_header *t = (struct malloc_header *)libc_calloc(1, malloc_header_size + size);
     if (unlikely(!t)) fatal("mallocz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
-    t->signature.magic = 0x0BADCAFE;
     t->signature.trace = p;
     t->signature.size = size;
+    t->signature.magic = malloc_header_magic(t);
 
 #ifdef NETDATA_INTERNAL_CHECKS
     for(ssize_t i = 0; i < (ssize_t)sizeof(t->padding) ;i++) // signed to avoid compiler warning when zero-padded
@@ -316,9 +330,9 @@ char *strdupz_int(const char *s, const char *file, const char *function, size_t 
 
     struct malloc_header *t = (struct malloc_header *)libc_malloc(malloc_header_size + size);
     if (unlikely(!t)) fatal("strdupz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
-    t->signature.magic = 0x0BADCAFE;
     t->signature.trace = p;
     t->signature.size = size;
+    t->signature.magic = malloc_header_magic(t);
 
 #ifdef NETDATA_INTERNAL_CHECKS
     for(ssize_t i = 0; i < (ssize_t)sizeof(t->padding) ;i++) // signed to avoid compiler warning when zero-padded
@@ -339,9 +353,9 @@ char *strndupz_int(const char *s, size_t len, const char *file, const char *func
 
     struct malloc_header *t = (struct malloc_header *)libc_malloc(malloc_header_size + size);
     if (unlikely(!t)) fatal("strndupz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
-    t->signature.magic = 0x0BADCAFE;
     t->signature.trace = p;
     t->signature.size = size;
+    t->signature.magic = malloc_header_magic(t);
 
 #ifdef NETDATA_INTERNAL_CHECKS
     for(ssize_t i = 0; i < (ssize_t)sizeof(t->padding) ;i++) // signed to avoid compiler warning when zero-padded
@@ -354,10 +368,13 @@ char *strndupz_int(const char *s, size_t len, const char *file, const char *func
 }
 
 static struct malloc_header *malloc_get_header(void *ptr, const char *caller, const char *file, const char *function, size_t line) {
+    if(!ptr)
+        return NULL;
+
     uint8_t *ret = (uint8_t *)ptr - malloc_header_size;
     struct malloc_header *t = (struct malloc_header *)ret;
 
-    if(t->signature.magic != 0x0BADCAFE) {
+    if(t->signature.magic != malloc_header_magic(t)) {
         netdata_log_error("pointer %p is not our pointer (called %s() from %zu@%s, %s()).", ptr, caller, line, file, function);
         return NULL;
     }
@@ -387,9 +404,9 @@ void *reallocz_int(void *ptr, size_t size, const char *file, const char *functio
 
     t = (struct malloc_header *)libc_realloc(t, malloc_header_size + size);
     if (unlikely(!t)) fatal("reallocz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
-    t->signature.magic = 0x0BADCAFE;
     t->signature.trace = p;
     t->signature.size = size;
+    t->signature.magic = malloc_header_magic(t);
 
 #ifdef NETDATA_INTERNAL_CHECKS
     for(ssize_t i = 0; i < (ssize_t)sizeof(t->padding) ;i++) // signed to avoid compiler warning when zero-padded

--- a/src/libnetdata/memory/nd-mallocz.c
+++ b/src/libnetdata/memory/nd-mallocz.c
@@ -53,6 +53,10 @@ void out_of_memory(const char *call, size_t size, const char *details) {
 #if defined(HAVE_DLSYM) && defined(ENABLE_DLSYM)
 #include <dlfcn.h>
 
+#ifndef MALLOC_ALIGNMENT
+#define MALLOC_ALIGNMENT (sizeof(uintptr_t) * 2)
+#endif
+
 typedef void (*libc_function_t)(void);
 
 static void *malloc_first_run(size_t size);
@@ -80,8 +84,146 @@ static size_t (*libc_malloc_usable_size)(void *) = malloc_usable_size_first_run;
 static size_t (*libc_malloc_usable_size)(void *) = NULL;
 #endif
 
+#define DLSYM_BOOTSTRAP_BUFFER_SIZE (1024 * 1024)
+#define DLSYM_BOOTSTRAP_MAGIC 0xD157B007U
+
+struct dlsym_bootstrap_header {
+    size_t size;
+    uint32_t magic;
+};
+
+#define DLSYM_BOOTSTRAP_HEADER_SIZE \
+    (((sizeof(struct dlsym_bootstrap_header) + MALLOC_ALIGNMENT - 1) / MALLOC_ALIGNMENT) * MALLOC_ALIGNMENT)
+
+static uint8_t dlsym_bootstrap_buffer[DLSYM_BOOTSTRAP_BUFFER_SIZE]
+    __attribute__((aligned(sizeof(uintptr_t) * 2)));
+static size_t dlsym_bootstrap_used = 0;
+static __thread size_t dlsym_bootstrap_depth = 0;
+
+static size_t dlsym_bootstrap_align_size(size_t size) {
+    size_t rem = size % MALLOC_ALIGNMENT;
+    return rem ? size + MALLOC_ALIGNMENT - rem : size;
+}
+
+static bool dlsym_bootstrap_active(void) {
+    return dlsym_bootstrap_depth != 0;
+}
+
+static void dlsym_bootstrap_abort(void) {
+    static const char msg[] = "FATAL: dlsym() bootstrap allocator exhausted.\n";
+    if(write(STDERR_FILENO, msg, sizeof(msg) - 1) < 0) {
+        // best effort
+    }
+    abort();
+}
+
+static bool dlsym_bootstrap_contains(const void *ptr) {
+    uintptr_t addr = (uintptr_t)ptr;
+    uintptr_t base = (uintptr_t)dlsym_bootstrap_buffer;
+    return addr >= base + DLSYM_BOOTSTRAP_HEADER_SIZE && addr < base + sizeof(dlsym_bootstrap_buffer);
+}
+
+static struct dlsym_bootstrap_header *dlsym_bootstrap_header(void *ptr) {
+    if(!dlsym_bootstrap_contains(ptr))
+        return NULL;
+
+    struct dlsym_bootstrap_header *hdr =
+        (struct dlsym_bootstrap_header *)((uint8_t *)ptr - DLSYM_BOOTSTRAP_HEADER_SIZE);
+
+    return hdr->magic == DLSYM_BOOTSTRAP_MAGIC ? hdr : NULL;
+}
+
+static void *dlsym_bootstrap_malloc(size_t size) {
+    if(!size)
+        size = 1;
+
+    if(size > SIZE_MAX - DLSYM_BOOTSTRAP_HEADER_SIZE)
+        dlsym_bootstrap_abort();
+
+    size_t requested = DLSYM_BOOTSTRAP_HEADER_SIZE + size;
+    if(requested > SIZE_MAX - MALLOC_ALIGNMENT)
+        dlsym_bootstrap_abort();
+
+    size_t total = dlsym_bootstrap_align_size(requested);
+
+    while(true) {
+        size_t used = __atomic_load_n(&dlsym_bootstrap_used, __ATOMIC_RELAXED);
+        size_t aligned_used = dlsym_bootstrap_align_size(used);
+
+        if(aligned_used > DLSYM_BOOTSTRAP_BUFFER_SIZE || total > DLSYM_BOOTSTRAP_BUFFER_SIZE - aligned_used)
+            dlsym_bootstrap_abort();
+
+        size_t next = aligned_used + total;
+        if(__atomic_compare_exchange_n(&dlsym_bootstrap_used, &used, next, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+            struct dlsym_bootstrap_header *hdr =
+                (struct dlsym_bootstrap_header *)&dlsym_bootstrap_buffer[aligned_used];
+            hdr->size = size;
+            hdr->magic = DLSYM_BOOTSTRAP_MAGIC;
+            return &dlsym_bootstrap_buffer[aligned_used + DLSYM_BOOTSTRAP_HEADER_SIZE];
+        }
+    }
+}
+
+static void *dlsym_bootstrap_calloc(size_t n, size_t size) {
+    if(size && n > SIZE_MAX / size)
+        dlsym_bootstrap_abort();
+
+    size_t bytes = n * size;
+    void *ptr = dlsym_bootstrap_malloc(bytes);
+    memset(ptr, 0, bytes);
+    return ptr;
+}
+
+static void *dlsym_bootstrap_realloc(void *ptr, size_t size) {
+    if(!ptr)
+        return dlsym_bootstrap_malloc(size);
+
+    struct dlsym_bootstrap_header *hdr = dlsym_bootstrap_header(ptr);
+    if(!hdr)
+        dlsym_bootstrap_abort();
+
+    void *new_ptr = dlsym_bootstrap_malloc(size);
+    memcpy(new_ptr, ptr, MIN(hdr->size, size));
+    return new_ptr;
+}
+
+static char *dlsym_bootstrap_strdup(const char *s) {
+    size_t len = strnlen(s, SIZE_MAX - 1);
+    if(unlikely(len == SIZE_MAX - 1))
+        dlsym_bootstrap_abort();
+
+    size_t size = len + 1;
+    char *ptr = dlsym_bootstrap_malloc(size);
+    memcpy(ptr, s, size);
+    return ptr;
+}
+
+static char *dlsym_bootstrap_strndup(const char *s, size_t len) {
+    size_t bytes = strnlen(s, len);
+    if(unlikely(bytes == SIZE_MAX))
+        dlsym_bootstrap_abort();
+
+    char *ptr = dlsym_bootstrap_malloc(bytes + 1);
+    memcpy(ptr, s, bytes);
+    ptr[bytes] = '\0';
+    return ptr;
+}
+
+static bool dlsym_bootstrap_free(void *ptr) {
+    return dlsym_bootstrap_header(ptr) != NULL;
+}
+
+static size_t dlsym_bootstrap_usable_size(void *ptr) {
+    struct dlsym_bootstrap_header *hdr = dlsym_bootstrap_header(ptr);
+    return hdr ? hdr->size : 0;
+}
+
 static void link_system_library_function(libc_function_t *func_pptr, const char *name, bool required) {
-    *func_pptr = dlsym(RTLD_NEXT, name);
+    dlsym_bootstrap_depth++;
+    libc_function_t func = dlsym(RTLD_NEXT, name);
+    dlsym_bootstrap_depth--;
+
+    *func_pptr = func;
     if(!*func_pptr && required) {
         fprintf(stderr, "FATAL: Cannot find system's %s() function.\n", name);
         abort();
@@ -128,37 +270,97 @@ static size_t malloc_usable_size_first_run(void *ptr) {
 }
 
 void *malloc(size_t size) {
+    if(unlikely(dlsym_bootstrap_active()))
+        return dlsym_bootstrap_malloc(size);
+
     return mallocz(size);
 }
 
 void *calloc(size_t n, size_t size) {
+    if(unlikely(dlsym_bootstrap_active()))
+        return dlsym_bootstrap_calloc(n, size);
+
     return callocz(n, size);
 }
 
 void *realloc(void *ptr, size_t size) {
+    if(unlikely(dlsym_bootstrap_contains(ptr)))
+        return dlsym_bootstrap_realloc(ptr, size);
+
+    if(unlikely(dlsym_bootstrap_active())) {
+        if(!ptr)
+            return dlsym_bootstrap_realloc(ptr, size);
+
+        if(libc_realloc != realloc_first_run)
+            return libc_realloc(ptr, size);
+
+        dlsym_bootstrap_abort();
+    }
+
     return reallocz(ptr, size);
 }
 
 void *reallocarray(void *ptr, size_t n, size_t size) {
-    if(unlikely(size && n > SIZE_MAX / size))
-        fatal("reallocarray() cannot allocate %zu members of %zu bytes.", n, size);
+    if(unlikely(size && n > SIZE_MAX / size)) {
+        if(unlikely(dlsym_bootstrap_active()))
+            dlsym_bootstrap_abort();
 
-    return reallocz(ptr, n * size);
+        fatal("reallocarray() cannot allocate %zu members of %zu bytes.", n, size);
+    }
+
+    size_t bytes = n * size;
+
+    if(unlikely(dlsym_bootstrap_contains(ptr)))
+        return dlsym_bootstrap_realloc(ptr, bytes);
+
+    if(unlikely(dlsym_bootstrap_active())) {
+        if(!ptr)
+            return dlsym_bootstrap_realloc(ptr, bytes);
+
+        if(libc_realloc != realloc_first_run)
+            return libc_realloc(ptr, bytes);
+
+        dlsym_bootstrap_abort();
+    }
+
+    return reallocz(ptr, bytes);
 }
 
 void free(void *ptr) {
+    if(unlikely(dlsym_bootstrap_free(ptr)))
+        return;
+
+    if(unlikely(dlsym_bootstrap_active())) {
+        if(libc_free != free_first_run)
+            libc_free(ptr);
+
+        return;
+    }
+
     freez(ptr);
 }
 
 char *strdup(const char *s) {
+    if(unlikely(dlsym_bootstrap_active()))
+        return dlsym_bootstrap_strdup(s);
+
     return strdupz(s);
 }
 
 char *strndup(const char *s, size_t len) {
+    if(unlikely(dlsym_bootstrap_active()))
+        return dlsym_bootstrap_strndup(s, len);
+
     return strndupz(s, len);
 }
 
 size_t malloc_usable_size(void *ptr) {
+    if(unlikely(dlsym_bootstrap_contains(ptr)))
+        return dlsym_bootstrap_usable_size(ptr);
+
+    if(unlikely(dlsym_bootstrap_active()))
+        return 0;
+
     return mallocz_usable_size(ptr);
 }
 #else // !HAVE_DLSYM


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Gorilla disk page load/read paths and tightens trace/debug infrastructure. Prevents out‑of‑bounds reads and data races, fixes rwlock trace bookkeeping, and adds a reentrancy‑safe `dlsym` bootstrap with allocation ownership checks.

- **Bug Fixes**
  - `NETDATA_TRACE_RWLOCKS`: hold `lockers_mutex` during lookup/update/insert; switch to `nd_thread_tag` and `*_ITEM_UNSAFE` list macros.
  - Align debug wrappers: make destroy/lock/unlock wrappers `void` (trylocks stay `int`); drop impossible return checks, including in `avl_destroy_lock`.
  - Trace allocator: add per‑allocation header magic to validate ownership; add a `dlsym` bootstrap allocator to avoid recursion; use `write()` for fatal messages during unresolved `dlsym` to avoid allocator reentry.
  - Gorilla disk pages: bound buffer‑chain patching with `gorilla_buffer_patch(buf, nbuffers, &entries)`; reject malformed chains and invalid `nbits`; stop reads at encoded bit capacity; make payload word access atomic to avoid reader/writer races; remove unused unbounded helpers; add regression tests.

- **New Features**
  - Fuzzing: add disk‑page patch/read path coverage (`gorilla_buffer_patch` → `gorilla_reader_init`) with bounded reads.

<sup>Written for commit 9d29323532e119e67e626f93d39be487e6001e3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

