### PR TITLE
Netdata fixes part 26

### DIFF
--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -96,7 +96,7 @@ void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused)
             len = strcatz(b, len, nd_thread_tag_async_safe(), sizeof(b));
             len = strcatz(b, len, "!\n", sizeof(b));
 
-            if(write(STDERR_FILENO, b, strlen(b)) == -1) {
+            if(write(STDERR_FILENO, b, len) == -1) {
                 // nothing to do - we cannot write but there is no way to complain about it
                 ;
             }

--- a/src/database/rrdfunctions-exporters.c
+++ b/src/database/rrdfunctions-exporters.c
@@ -165,8 +165,13 @@ void host_functions_to_dict(RRDHOST *host, DICTIONARY *dst, void *value, size_t 
         if(version)
             *version = t->version;
 
-        char key[UINT64_MAX_LENGTH + sizeof(RRDFUNCTIONS_VERSION_SEPARATOR) + strlen(t_dfe.name)];
-        snprintfz(key, sizeof(key), "%"PRIu32 RRDFUNCTIONS_VERSION_SEPARATOR "%s",
+        size_t function_name_len = strlen(t_dfe.name);
+        if(unlikely(function_name_len > SIZE_MAX - UINT64_MAX_LENGTH - sizeof(RRDFUNCTIONS_VERSION_SEPARATOR)))
+            fatal("RRDFUNCTIONS: function key is too large.");
+
+        size_t key_size = UINT64_MAX_LENGTH + sizeof(RRDFUNCTIONS_VERSION_SEPARATOR) + function_name_len;
+        CLEAN_CHAR_P *key = mallocz(key_size);
+        snprintfz(key, key_size, "%"PRIu32 RRDFUNCTIONS_VERSION_SEPARATOR "%s",
                   t->version, t_dfe.name);
 
         dictionary_set(dst, key, value, value_size);

--- a/src/database/rrdfunctions-inflight.c
+++ b/src/database/rrdfunctions-inflight.c
@@ -394,8 +394,10 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
     char sanitized_cmd[PLUGINSD_LINE_MAX + 1];
     const DICTIONARY_ITEM *host_function_acquired = NULL;
 
-    char sanitized_source[(source ? strlen(source) : 0) + 1];
-    rrd_functions_sanitize(sanitized_source, source ? source : "", sizeof(sanitized_source));
+    const char *source_to_sanitize = source ? source : "";
+    size_t sanitized_source_size = strlen(source_to_sanitize) + 1;
+    CLEAN_CHAR_P *sanitized_source = mallocz(sanitized_source_size);
+    rrd_functions_sanitize(sanitized_source, source_to_sanitize, sanitized_source_size);
 
     // ------------------------------------------------------------------------
     // check for the host
@@ -507,7 +509,7 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
         .sanitized_cmd_length = sanitized_cmd_length,
         .transaction = strdupz(transaction),
         .user_access = user_access,
-        .source = strdupz(sanitized_source),
+        .source = sanitized_source,
         .payload = buffer_dup(payload),
         .timeout = timeout_s,
         .cancelled = false,
@@ -528,6 +530,7 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
             .data = progress_cb_data,
         },
     };
+    sanitized_source = NULL;
     uuid_copy(t.transaction_uuid, uuid);
 
     struct rrd_function_inflight *r = dictionary_set(rrd_functions_inflight_requests, transaction, &t, sizeof(t));

--- a/src/database/rrdfunctions.c
+++ b/src/database/rrdfunctions.c
@@ -234,8 +234,9 @@ void rrd_function_add(RRDHOST *host, RRDSET *st, const char *name, int timeout, 
     if(st && !st->functions_view)
         st->functions_view = dictionary_create_view(host->functions);
 
-    char key[strlen(name) + 1];
-    rrd_functions_sanitize(key, name, sizeof(key));
+    size_t key_size = strlen(name) + 1;
+    CLEAN_CHAR_P *key = mallocz(key_size);
+    rrd_functions_sanitize(key, name, key_size);
 
     struct rrd_host_function tmp = {
         .collector = NULL,
@@ -264,8 +265,9 @@ bool rrd_function_del(RRDHOST *host, RRDSET *st, const char *name, bool from_str
     if(unlikely(!name || !*name))
         return false;
 
-    char key[strlen(name) + 1];
-    rrd_functions_sanitize(key, name, sizeof(key));
+    size_t key_size = strlen(name) + 1;
+    CLEAN_CHAR_P *key = mallocz(key_size);
+    rrd_functions_sanitize(key, name, key_size);
 
     const DICTIONARY_ITEM *item = dictionary_get_and_acquire_item(host->functions, key);
     if(!item)

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -255,8 +255,9 @@ struct rrdhost {
 
                 // single-writer (the receiver thread), relaxed-atomic; read lock-free by the
                 // pulse traversal. Cumulative over the host's lifetime, never reset.
-                uint64_t bytes_in;                  // raw socket bytes received from this child (all connections)
-                uint64_t bytes_out;                 // raw socket bytes sent to this child (all connections)
+                // Keep these 8-byte aligned: 32-bit GCC may inline relaxed 64-bit access.
+                uint64_t bytes_in __attribute__((aligned(8)));  // raw socket bytes received from this child
+                uint64_t bytes_out __attribute__((aligned(8))); // raw socket bytes sent to this child
 
                 // realtime second the current inbound (receiver) state was entered; reset by
                 // pulse_host_status() on every inbound state change, read by the pulse traversal

--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -700,10 +700,10 @@ static ARAL_PAGE *aral_create_page___no_lock_needed(ARAL *ar, size_t size TRACE_
 
     if(ar->config.mmap.enabled) {
         page = callocz(1, sizeof(ARAL_PAGE));
-        ar->aral_lock.file_number++;
+        size_t file_number = __atomic_add_fetch(&ar->aral_lock.file_number, 1, __ATOMIC_RELAXED);
 
         char filename[FILENAME_MAX + 1];
-        snprintfz(filename, FILENAME_MAX, "%s/array_alloc.mmap/%s.%zu", *ar->config.mmap.cache_dir, ar->config.mmap.filename, ar->aral_lock.file_number);
+        snprintfz(filename, FILENAME_MAX, "%s/array_alloc.mmap/%s.%zu", *ar->config.mmap.cache_dir, ar->config.mmap.filename, file_number);
         page->filename = strdupz(filename);
         page->mapped = true;
 

--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -802,7 +802,7 @@ static void aral_del_page___no_lock_needed(ARAL *ar, ARAL_PAGE *page TRACE_ALLOC
         nd_munmap(page->data, page->size);
 
         if (unlikely(unlink(page->filename) == -1))
-            netdata_log_error("Cannot delete file '%s'", page->filename);
+            netdata_log_error("ARAL: '%s' cannot delete file '%s'", ar->config.name, page->filename);
 
         freez((void *)page->filename);
         freez(page);

--- a/src/libnetdata/atomics/single_writer.h
+++ b/src/libnetdata/atomics/single_writer.h
@@ -28,9 +28,9 @@
 // atomic load): for them there IS a concurrent writer.
 //
 // MUST NOT be used when more than one thread writes the same counter. For
-// genuinely multi-writer counters use __atomic_fetch_add(). On 32-bit platforms
-// a 64-bit relaxed store is not a single instruction; this is the same trade-off
-// Netdata's other 64-bit atomics already make.
+// genuinely multi-writer counters use __atomic_fetch_add(). 64-bit counters
+// using this helper MUST be 8-byte aligned; some 32-bit compilers inline
+// relaxed 64-bit access when they can prove the target is lock-free.
 
 // add n to a single-writer counter (writer thread only)
 #define single_writer_atomic_add(ptr, n) do {                           \

--- a/src/libnetdata/datetime/rfc3339.c
+++ b/src/libnetdata/datetime/rfc3339.c
@@ -74,7 +74,7 @@ static inline size_t print_fraction(char *buffer, size_t size, usec_t fraction, 
 }
 
 size_t rfc3339_datetime_ut(char *buffer, size_t len, usec_t now_ut, size_t fractional_digits, bool utc) {
-    if (!buffer || len < 20) // Minimum size for YYYY-MM-DDThh:mm:ssZ
+    if (!buffer || len < 20) // Minimum size for YYYY-MM-DDThh:mm:ss plus terminator
         return 0;
 
     time_t t = (time_t)(now_ut / USEC_PER_SEC);
@@ -93,47 +93,47 @@ size_t rfc3339_datetime_ut(char *buffer, size_t len, usec_t now_ut, size_t fract
     size_t pos = 0;
 
     // Year (4 digits)
-    if (len - pos < 4) goto finish;
+    if (len - pos <= 4) goto finish;
     pos += print_4digit_year(&buffer[pos], len - pos, tmp->tm_year + 1900);
 
     // Month separator
-    if (len - pos < 1) goto finish;
+    if (len - pos <= 1) goto finish;
     buffer[pos++] = '-';
 
     // Month (2 digits)
-    if (len - pos < 2) goto finish;
+    if (len - pos <= 2) goto finish;
     pos += print_2digit(&buffer[pos], len - pos, tmp->tm_mon + 1);
 
     // Day separator
-    if (len - pos < 1) goto finish;
+    if (len - pos <= 1) goto finish;
     buffer[pos++] = '-';
 
     // Day (2 digits)
-    if (len - pos < 2) goto finish;
+    if (len - pos <= 2) goto finish;
     pos += print_2digit(&buffer[pos], len - pos, tmp->tm_mday);
 
     // T separator
-    if (len - pos < 1) goto finish;
+    if (len - pos <= 1) goto finish;
     buffer[pos++] = 'T';
 
     // Hour (2 digits)
-    if (len - pos < 2) goto finish;
+    if (len - pos <= 2) goto finish;
     pos += print_2digit(&buffer[pos], len - pos, tmp->tm_hour);
 
     // Minute separator
-    if (len - pos < 1) goto finish;
+    if (len - pos <= 1) goto finish;
     buffer[pos++] = ':';
 
     // Minute (2 digits)
-    if (len - pos < 2) goto finish;
+    if (len - pos <= 2) goto finish;
     pos += print_2digit(&buffer[pos], len - pos, tmp->tm_min);
 
     // Second separator
-    if (len - pos < 1) goto finish;
+    if (len - pos <= 1) goto finish;
     buffer[pos++] = ':';
 
     // Second (2 digits)
-    if (len - pos < 2) goto finish;
+    if (len - pos <= 2) goto finish;
     pos += print_2digit(&buffer[pos], len - pos, tmp->tm_sec);
 
     // Add fractional part if requested
@@ -143,7 +143,7 @@ size_t rfc3339_datetime_ut(char *buffer, size_t len, usec_t now_ut, size_t fract
 
         if (fractional_part > 0) {
             // Need space for decimal point and digits
-            if (len - pos < fractional_digits + 1) goto finish;
+            if (len - pos <= fractional_digits + 1) goto finish;
 
             buffer[pos++] = '.';
             pos += print_fraction(&buffer[pos], len - pos, fractional_part, fractional_digits);
@@ -152,7 +152,7 @@ size_t rfc3339_datetime_ut(char *buffer, size_t len, usec_t now_ut, size_t fract
 
     // Add timezone information
     if (utc) {
-        if (len - pos < 1) goto finish;
+        if (len - pos <= 1) goto finish;
         buffer[pos++] = 'Z';
     }
     else {
@@ -162,12 +162,12 @@ size_t rfc3339_datetime_ut(char *buffer, size_t len, usec_t now_ut, size_t fract
 
         // Check if timezone is UTC
         if (hours == 0 && minutes == 0) {
-            if (len - pos < 1) goto finish;
+            if (len - pos <= 1) goto finish;
             buffer[pos++] = 'Z';
         }
         else {
             // Need space for sign, hours, colon, minutes (6 chars total)
-            if (len - pos < 6) goto finish;
+            if (len - pos <= 6) goto finish;
 
             // Add timezone offset
             buffer[pos++] = (hours >= 0) ? '+' : '-';
@@ -185,11 +185,7 @@ size_t rfc3339_datetime_ut(char *buffer, size_t len, usec_t now_ut, size_t fract
     }
 
 finish:
-    // Ensure null termination
-    if (pos < len)
-        buffer[pos] = '\0';
-    else
-        buffer[len - 1] = '\0';
+    buffer[pos] = '\0';
 
     return pos;
 }

--- a/src/libnetdata/json/json-c-parser-unittest.c
+++ b/src/libnetdata/json/json-c-parser-unittest.c
@@ -1461,6 +1461,12 @@ static int test_format_rfc3339(void) {
     usec_t parsed;
     size_t len;
 
+    char exact_fit[sizeof("1970-01-01T00:00:00Z") - 1];
+    memset(exact_fit, 'x', sizeof(exact_fit));
+    len = rfc3339_datetime_ut(exact_fit, sizeof(exact_fit), 0, 0, true);
+    T(len == strlen("1970-01-01T00:00:00") && strcmp(exact_fit, "1970-01-01T00:00:00") == 0,
+      "format_rfc3339: exact-fit buffer reserves terminator and returns visible length");
+
     len = rfc3339_datetime_ut(buffer, sizeof(buffer), 123456, 3, true);
     T(len == strlen("1970-01-01T00:00:00.123Z") && strcmp(buffer, "1970-01-01T00:00:00.123Z") == 0,
       "format_rfc3339: 3 digits truncate microseconds");

--- a/src/libnetdata/parsers/duration-unittest.c
+++ b/src/libnetdata/parsers/duration-unittest.c
@@ -276,8 +276,16 @@ static int test_duration_generation(void) {
         { 31536000, "s", "1y" },
         { 9000, "s", "2h30m" },
         { 129600, "s", "1d12h" },
+#if defined(__SIZEOF_INT128__)
+        { INT64_MAX, "y", "9223372036854775807y" },
+#endif
+        { 2372, "q", "584y4q" },
         { 0, "s", "off" },
         { -300, "s", "-5m" },
+#if defined(__SIZEOF_INT128__)
+        { INT64_MIN, "y", "-9223372036854775808y" },
+#endif
+        { INT64_MIN, "ns", "-292y5mo21d23h47m16s854ms775us808ns" },
         { 0, NULL, NULL }
     };
     

--- a/src/libnetdata/parsers/duration.c
+++ b/src/libnetdata/parsers/duration.c
@@ -116,6 +116,21 @@ inline int64_t duration_round_to_resolution(int64_t value, int64_t resolution) {
     return 0;
 }
 
+#if defined(__SIZEOF_INT128__)
+typedef unsigned __int128 duration_snprintf_uint_t;
+#else
+typedef uint64_t duration_snprintf_uint_t;
+#endif
+
+static inline duration_snprintf_uint_t duration_round_to_resolution_u(
+    duration_snprintf_uint_t value,
+    duration_snprintf_uint_t resolution) {
+    duration_snprintf_uint_t quotient = value / resolution;
+    duration_snprintf_uint_t remainder = value % resolution;
+
+    return quotient + (remainder > resolution / 2);
+}
+
 // -------------------------------------------------------------------------------------------------------------------
 // parse a duration string
 
@@ -317,15 +332,21 @@ ssize_t duration_snprintf(char *dst, size_t dst_size, int64_t value, const char 
         return snprintfz(dst, dst_size, "off");
 
     const char *sign = "";
+    uint64_t magnitude = (uint64_t)value;
     if(value < 0) {
         sign = "-";
-        value = -value;
+        magnitude = (uint64_t)(-(value + 1)) + 1;
     }
 
     const struct duration_unit *du_min = duration_find_unit(unit);
     size_t offset = 0;
 
-    int64_t nsec = value * du_min->multiplier;
+#if !defined(__SIZEOF_INT128__)
+    if(unlikely(magnitude > UINT64_MAX / (uint64_t)du_min->multiplier))
+        return -3;
+#endif
+
+    duration_snprintf_uint_t nsec = (duration_snprintf_uint_t)magnitude * (duration_snprintf_uint_t)du_min->multiplier;
 
     // Iterate through units from largest to smallest
     for (ssize_t i = (ssize_t)(sizeof(units) / sizeof(units[0])) - 1; i >= 0 && nsec > 0; i--) {
@@ -339,14 +360,20 @@ ssize_t duration_snprintf(char *dst, size_t dst_size, int64_t value, const char 
         // we have to round the value per unit (inside this loop), not globally.
         // Otherwise, we have to make sure that all larger units are integer multiples of the smaller ones.
 
-        int64_t multiplier = units[i].multiplier;
-        int64_t rounded = (du == du_min) ? (duration_round_to_resolution(nsec, multiplier) * multiplier) : nsec;
+        duration_snprintf_uint_t multiplier = (duration_snprintf_uint_t)units[i].multiplier;
+        duration_snprintf_uint_t rounded =
+            (du == du_min) ? (duration_round_to_resolution_u(nsec, multiplier) * multiplier) : nsec;
 
-        int64_t unit_count = rounded / multiplier;
+        duration_snprintf_uint_t unit_count = rounded / multiplier;
         if (unit_count > 0) {
+#if defined(__SIZEOF_INT128__)
+            if(unlikely(unit_count > UINT64_MAX))
+                return -3;
+#endif
+
             const char *space = (add_spaces && offset) ? " " : "";
             int written = snprintfz(dst + offset, dst_size - offset,
-                                    "%s%s%" PRIi64 "%s", space, sign, unit_count, units[i].unit);
+                                    "%s%s%" PRIu64 "%s", space, sign, (uint64_t)unit_count, units[i].unit);
 
             if (written < 0)
                 return -3;
@@ -359,10 +386,11 @@ ssize_t duration_snprintf(char *dst, size_t dst_size, int64_t value, const char 
                 return (ssize_t)offset;
             }
 
-            if(unit_count * multiplier >= nsec)
+            duration_snprintf_uint_t unit_nsec = unit_count * multiplier;
+            if(unit_nsec >= nsec)
                 break;
             else
-                nsec -= unit_count * multiplier;
+                nsec -= unit_nsec;
         }
 
         if(du == du_min)

--- a/src/libnetdata/signals/signal-code.c
+++ b/src/libnetdata/signals/signal-code.c
@@ -222,8 +222,7 @@ void SIGNAL_CODE_2str_h(SIGNAL_CODE code, char *buf, size_t size) {
     // now we have to concatenate the two strings
     // with a slash in between
 
-    strncpyz(buf, signo_str, size - 1);
-    size_t len = strlen(buf);
+    size_t len = strcatz(buf, 0, signo_str, size);
 
     if(size - 1 > len)
         buf[len++] = '/';

--- a/src/libnetdata/stacktrace/stacktrace-none.c
+++ b/src/libnetdata/stacktrace/stacktrace-none.c
@@ -38,21 +38,10 @@ void stacktrace_capture(BUFFER *wb) {
 
 // Simple dummy implementation for platforms without stack trace support
 int impl_stacktrace_get_frames(void **frames, int max_frames, int skip_frames) {
-    if (!frames || max_frames <= 0)
-        return 0;
-    
-    // No need to adjust skip_frames here as we're just creating a dummy frame
-    // but we include the comment for consistency with other implementations
-    // skip_frames += 1; // Skip this function itself
-    
-    // Just use a counter to create a unique "frame"
-    static uint64_t counter = 0;
-    uint64_t id = __atomic_fetch_add(&counter, 1, __ATOMIC_SEQ_CST);
-    
-    // Store one dummy frame
-    frames[0] = (void *)(uintptr_t)id;
-    
-    return 1;
+    (void)frames;
+    (void)max_frames;
+    (void)skip_frames;
+    return 0;
 }
 
 void impl_stacktrace_to_buffer(STACKTRACE trace, BUFFER *wb) {

--- a/src/streaming/stream-circular-buffer.h
+++ b/src/streaming/stream-circular-buffer.h
@@ -26,10 +26,10 @@ typedef struct stream_circular_buffer_stats {
     size_t bytes_uncompressed;
     size_t bytes_sent;
 
-    uint32_t bytes_size;
-    uint32_t bytes_max_size;
-    uint32_t bytes_outstanding;
-    uint32_t bytes_available;
+    size_t bytes_size;
+    size_t bytes_max_size;
+    size_t bytes_outstanding;
+    size_t bytes_available;
 
     double buffer_ratio;
 

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -325,7 +325,7 @@ void stream_receiver_handle_op(struct stream_thread *sth, struct receiver_state 
         STREAM_CIRCULAR_BUFFER_STATS stats = *stream_circular_buffer_stats_unsafe(rpt->thread.send_to_child.scb);
         spinlock_unlock(&rpt->thread.send_to_child.spinlock);
         nd_log(NDLS_DAEMON, NDLP_ERR,
-               "STREAM RCV[%zu] '%s' [from [%s]:%s]: send buffer is full (buffer size %u, max %u, used %u, available %u). "
+               "STREAM RCV[%zu] '%s' [from [%s]:%s]: send buffer is full (buffer size %zu, max %zu, used %zu, available %zu). "
                "Restarting connection.",
                sth->id, rrdhost_hostname(rpt->host), rpt->remote_ip, rpt->remote_port,
                stats.bytes_size, stats.bytes_max_size, stats.bytes_outstanding, stats.bytes_available);

--- a/src/streaming/stream-sender-commit.c
+++ b/src/streaming/stream-sender-commit.c
@@ -99,7 +99,7 @@ void sender_buffer_commit(struct sender_state *s, BUFFER *wb, struct sender_buff
             s->scb, src_len * STREAM_CIRCULAR_BUFFER_ADAPT_TO_TIMES_MAX_SIZE, false))) {
         // adaptive sizing of the circular buffer
         nd_log(NDLS_DAEMON, NDLP_NOTICE,
-               "STREAM SND '%s' [to %s]: Increased max buffer size to %u (message size %zu).",
+               "STREAM SND '%s' [to %s]: Increased max buffer size to %zu (message size %zu).",
                rrdhost_hostname(s->host), s->remote_ip, stats->bytes_max_size, src_len + 1);
     }
 
@@ -198,6 +198,7 @@ void sender_buffer_commit(struct sender_state *s, BUFFER *wb, struct sender_buff
     return;
 
 overflow_with_lock: {
+        STREAM_CIRCULAR_BUFFER_STATS stats_snapshot = *stats;
         msg = s->thread.msg;
         stream_sender_unlock(s);
         waitq_release(&s->waitq);
@@ -206,10 +207,10 @@ overflow_with_lock: {
         stream_sender_send_opcode(s, msg);
         nd_log_limit_static_global_var(erl, 1, 0);
         nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
-                     "STREAM SND '%s' [to %s]: buffer overflow (buffer size %u, max size %u, available %u). "
+                     "STREAM SND '%s' [to %s]: buffer overflow (buffer size %zu, max size %zu, available %zu). "
                      "Restarting connection.",
                      rrdhost_hostname(s->host), s->remote_ip,
-                     stats->bytes_size, stats->bytes_max_size, stats->bytes_available);
+                     stats_snapshot.bytes_size, stats_snapshot.bytes_max_size, stats_snapshot.bytes_available);
         return;
     }
 

--- a/src/streaming/stream-sender.c
+++ b/src/streaming/stream-sender.c
@@ -283,7 +283,7 @@ void stream_sender_handle_op(struct stream_thread *sth, struct sender_state *s, 
         STREAM_CIRCULAR_BUFFER_STATS stats = *stream_circular_buffer_stats_unsafe(s->scb);
         stream_sender_unlock(s);
         nd_log(NDLS_DAEMON, NDLP_ERR,
-               "STREAM SND[%zu] '%s' [to %s]: send buffer is full (buffer size %u, max %u, used %u, available %u). "
+               "STREAM SND[%zu] '%s' [to %s]: send buffer is full (buffer size %zu, max %zu, used %zu, available %zu). "
                "Restarting connection.",
                sth->id, rrdhost_hostname(s->host), s->remote_ip,
                stats.bytes_size, stats.bytes_max_size, stats.bytes_outstanding, stats.bytes_available);


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened core paths and streaming by fixing memory growth, integer/buffer edge cases, and unsafe signal/stacktrace code. Improves correctness on 32-bit builds and large streams without changing normal behavior.

- **Bug Fixes**
  - Stacktrace: none backend now returns 0 frames to stop unbounded cache growth.
  - Signals: avoid strlen in the crash path; write() uses known length; `SIGNAL_CODE_2str_h()` uses `strcatz()` to get length safely.
  - Date/time: RFC3339 formatter reserves space for the terminator; exact-fit buffers now produce a correct, terminated prefix; added unit test.
  - Durations: eliminate signed overflow and INT64_MIN negate; format via unsigned math (uses `__int128` when available) and guard fallback; added unit tests.
  - Streaming: widen circular buffer stat fields to `size_t` and switch logs to `%zu`; take a stats snapshot before unlocking in overflow logs; updated sender/receiver messages.
  - Concurrency/alignment: enforce 8-byte alignment for 64-bit single-writer counters; clarify macro contract.
  - ARAL: atomically increment mmap page file numbers to avoid filename races; include allocator name in unlink error logs.
  - RRD functions: replace runtime-sized stack buffers with exact-size heap allocations for keys/sources; bound-check function key sizing; pass sanitized source without extra strdup.

<sup>Written for commit c8181267178c53a75530e684175d46473ff6b1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

