### PR TITLE
feat(go.d): run collector dyncfg commands concurrently on per-key lanes

### DIFF
--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	go.mongodb.org/mongo-driver/v2 v2.7.0
+	go.uber.org/goleak v1.3.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/src/go/pkg/ticker/ticker.go
+++ b/src/go/pkg/ticker/ticker.go
@@ -31,16 +31,24 @@ func (t *Ticker) start() {
 	ch := make(chan int)
 	t.C = ch
 	go func() {
-	LOOP:
 		for {
 			now := time.Now()
 			nextRun := now.Truncate(t.interval).Add(t.interval)
 
-			time.Sleep(nextRun.Sub(now))
+			// The wait must be interruptible: Stop releases this goroutine
+			// promptly, not after the current interval elapses.
+			timer := time.NewTimer(nextRun.Sub(now))
+			select {
+			case <-t.done:
+				timer.Stop()
+				close(ch)
+				return
+			case <-timer.C:
+			}
 			select {
 			case <-t.done:
 				close(ch)
-				break LOOP
+				return
 			case ch <- t.loops:
 				t.loops++
 			}
@@ -48,8 +56,9 @@ func (t *Ticker) start() {
 	}()
 }
 
-// Stop turns off a Ticker. After Stop, no more ticks will be sent.
-// Stop does not close the channel, to prevent a read from the channel succeeding incorrectly.
+// Stop turns off a Ticker and promptly releases its goroutine. After Stop,
+// no more ticks are sent and the channel is closed once the goroutine
+// observes the stop; do not read C after Stop.
 func (t *Ticker) Stop() {
 	t.done <- struct{}{}
 }

--- a/src/go/pkg/ticker/ticker.go
+++ b/src/go/pkg/ticker/ticker.go
@@ -2,7 +2,10 @@
 
 package ticker
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 type (
 	// Ticker holds a channel that delivers ticks of a clock at intervals.
@@ -10,6 +13,7 @@ type (
 	Ticker struct {
 		C        <-chan int
 		done     chan struct{}
+		stopOnce sync.Once
 		loops    int
 		interval time.Duration
 	}
@@ -21,7 +25,7 @@ type (
 func New(interval time.Duration) *Ticker {
 	ticker := &Ticker{
 		interval: interval,
-		done:     make(chan struct{}, 1),
+		done:     make(chan struct{}),
 	}
 	ticker.start()
 	return ticker
@@ -58,7 +62,8 @@ func (t *Ticker) start() {
 
 // Stop turns off a Ticker and promptly releases its goroutine. After Stop,
 // no more ticks are sent and the channel is closed once the goroutine
-// observes the stop; do not read C after Stop.
+// observes the stop; do not read C after Stop. Stop is idempotent: repeated
+// calls are safe and never block.
 func (t *Ticker) Stop() {
-	t.done <- struct{}{}
+	t.stopOnce.Do(func() { close(t.done) })
 }

--- a/src/go/pkg/ticker/ticket_test.go
+++ b/src/go/pkg/ticker/ticket_test.go
@@ -41,6 +41,19 @@ func TestTicker(t *testing.T) {
 	}
 }
 
+func TestTickerStopReleasesPromptly(t *testing.T) {
+	tk := New(time.Hour)
+	tk.Stop()
+	select {
+	case _, ok := <-tk.C:
+		if ok {
+			t.Error("expected the tick channel to be closed after Stop")
+		}
+	case <-time.After(time.Second):
+		t.Error("Stop must release the ticker goroutine promptly, not after the current interval")
+	}
+}
+
 func abs(a time.Duration) time.Duration {
 	if a < 0 {
 		return -a

--- a/src/go/pkg/ticker/ticket_test.go
+++ b/src/go/pkg/ticker/ticket_test.go
@@ -60,3 +60,19 @@ func abs(a time.Duration) time.Duration {
 	}
 	return a
 }
+
+func TestTickerStopIsIdempotent(t *testing.T) {
+	tk := New(time.Hour)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tk.Stop()
+		tk.Stop() // repeated Stop must never block
+		tk.Stop()
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Error("repeated Stop must not block")
+	}
+}

--- a/src/go/plugin/agent/discovery/sd/dyncfg.go
+++ b/src/go/plugin/agent/discovery/sd/dyncfg.go
@@ -87,7 +87,7 @@ func (cb *sdCallbacks) ValidateConfigName(name string) error {
 	return dyncfg.JobNameRuleAllowDots(name)
 }
 
-func (cb *sdCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (sdConfig, error) {
+func (cb *sdCallbacks) ParseAndValidate(_ context.Context, fn dyncfg.Function, name string) (sdConfig, error) {
 	dt, _, _ := cb.sd.extractDiscovererAndName(fn.ID())
 	if _, err := parseDyncfgPayload(fn.Payload(), dt, name, cb.sd.configDefaults, cb.sd.discovererRegistry(), true); err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (cb *sdCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (sdConf
 	return cfg, nil
 }
 
-func (cb *sdCallbacks) Start(cfg sdConfig) error {
+func (cb *sdCallbacks) Start(_ context.Context, cfg sdConfig) error {
 	pipelineCfg, err := cfg.ToPipelineConfig(cb.sd.configDefaults)
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (cb *sdCallbacks) Start(cfg sdConfig) error {
 	return cb.sd.mgr.Start(cb.sd.ctx, cfg.PipelineKey(), pipelineCfg)
 }
 
-func (cb *sdCallbacks) Update(oldCfg, newCfg sdConfig) error {
+func (cb *sdCallbacks) Update(_ context.Context, oldCfg, newCfg sdConfig) error {
 	pipelineCfg, err := newCfg.ToPipelineConfig(cb.sd.configDefaults)
 	if err != nil {
 		return dyncfg.MarkNonDisruptiveUpdate(err)
@@ -116,7 +116,7 @@ func (cb *sdCallbacks) Update(oldCfg, newCfg sdConfig) error {
 	return cb.sd.mgr.Restart(cb.sd.ctx, newCfg.PipelineKey(), pipelineCfg)
 }
 
-func (cb *sdCallbacks) Stop(cfg sdConfig) {
+func (cb *sdCallbacks) Stop(_ context.Context, cfg sdConfig) {
 	cb.sd.mgr.Stop(cfg.PipelineKey())
 }
 

--- a/src/go/plugin/agent/jobmgr/cache.go
+++ b/src/go/plugin/agent/jobmgr/cache.go
@@ -41,8 +41,10 @@ type (
 	}
 
 	retryingTasks struct {
-		// retryingTasks is intentionally lock-free. All access must remain serialized
-		// through manager-owned command flow and synchronous dyncfg handler callbacks.
+		// Guarded by mu: retry scheduling and cancellation run from command
+		// effects executing off the manager loop as well as from the loop
+		// itself; per-config ordering comes from the executor's key FIFO.
+		mu sync.Mutex
 		// [cfg.UID()]
 		items map[string]*retryTask
 	}
@@ -117,15 +119,21 @@ func (c *runningJobs) snapshot() []runtimeJob {
 }
 
 func (c *retryingTasks) add(cfg confgroup.Config, retry *retryTask) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.items[cfg.UID()] = retry
 }
 func (c *retryingTasks) remove(cfg confgroup.Config) {
-	if v, ok := c.lookup(cfg); ok {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if v, ok := c.items[cfg.UID()]; ok {
 		v.cancel()
 	}
 	delete(c.items, cfg.UID())
 }
 func (c *retryingTasks) lookup(cfg confgroup.Config) (*retryTask, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	v, ok := c.items[cfg.UID()]
 	return v, ok
 }

--- a/src/go/plugin/agent/jobmgr/characterization_test.go
+++ b/src/go/plugin/agent/jobmgr/characterization_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
@@ -95,69 +96,6 @@ func (h *charHarness) outputContains(substr string) func() bool {
 	return func() bool { return strings.Contains(h.out.String(), substr) }
 }
 
-type wireRecordWant struct {
-	name     string
-	contains []string
-}
-
-func atomicWireRecords(output string) []string {
-	var records []string
-	lines := strings.Split(output, "\n")
-	for i := 0; i < len(lines); {
-		line := lines[i]
-		if line == "" {
-			i++
-			continue
-		}
-		if !strings.HasPrefix(line, "FUNCTION_RESULT_BEGIN ") {
-			records = append(records, line)
-			i++
-			continue
-		}
-
-		var b strings.Builder
-		b.WriteString(line)
-		i++
-		for i < len(lines) {
-			b.WriteByte('\n')
-			b.WriteString(lines[i])
-			if lines[i] == "FUNCTION_RESULT_END" {
-				i++
-				break
-			}
-			i++
-		}
-		records = append(records, b.String())
-	}
-	return records
-}
-
-func requireWireRecordSubsequence(t *testing.T, output string, wants []wireRecordWant) {
-	t.Helper()
-
-	records := atomicWireRecords(output)
-	next := 0
-	for _, want := range wants {
-		found := -1
-		for i := next; i < len(records); i++ {
-			matched := true
-			for _, substr := range want.contains {
-				if !strings.Contains(records[i], substr) {
-					matched = false
-					break
-				}
-			}
-			if matched {
-				found = i
-				break
-			}
-		}
-		require.NotEqualf(t, -1, found, "wire record %q not found after index %d in records:\n%s",
-			want.name, next, strings.Join(records, "\n---\n"))
-		next = found + 1
-	}
-}
-
 func charSuccessCreator() collectorapi.Creator {
 	return collectorapi.Creator{
 		JobConfigSchema: collectorapi.MockConfigSchema,
@@ -172,10 +110,10 @@ func charSuccessCreator() collectorapi.Creator {
 	}
 }
 
-// FLIPS-BY-DESIGN: today one slow enable (synchronous AutoDetection on the
-// single run loop) blocks every other dyncfg command, including commands for
-// unrelated configs. The per-key concurrency redesign inverts this: an
-// unrelated config's commands must complete while another config detects.
+// INVERTED FLIPS-BY-DESIGN pin (previously pinned global serialization):
+// with per-key lanes an unrelated config's commands MUST complete while
+// another config's slow detection is in flight. Regressing this back to
+// cross-key blocking is a defect.
 func TestCharacterization_RunLoopSerialization(t *testing.T) {
 	tests := map[string]struct {
 		run func(t *testing.T)
@@ -220,18 +158,19 @@ func TestCharacterization_RunLoopSerialization(t *testing.T) {
 					t.Fatal("slow module Init did not start")
 				}
 
-				// Queued behind the blocked enable: even the unrelated add's terminal
-				// response cannot be emitted while the loop is inside AutoDetection.
+				// The unrelated add runs on its own key lane: its terminal must
+				// arrive while the slow enable is still blocked in AutoDetection.
 				h.dyncfg("3-add-b", []string{h.mgr.dyncfgModID("success"), "add", "b"}, []byte("{}"))
 
-				require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-add-b"), charNeverWait, charTick,
-					"unrelated command completed while another config's enable was blocked in AutoDetection; "+
-						"global serialization no longer holds - update this FLIPS-BY-DESIGN pin deliberately")
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-add-b"), charWait, charTick,
+					"unrelated command did not complete while another config's enable was blocked in AutoDetection; "+
+						"per-key concurrency regressed to cross-key blocking")
+				assert.False(t, h.outputContains("FUNCTION_RESULT_BEGIN 2-enable-a")(),
+					"the slow enable must still be in flight")
 
 				release <- struct{}{}
 
 				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 2-enable-a"), charWait, charTick)
-				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-add-b"), charWait, charTick)
 			},
 		},
 	}
@@ -242,104 +181,100 @@ func TestCharacterization_RunLoopSerialization(t *testing.T) {
 }
 
 // Mixed classes, marked per case:
-//   - FLIPS-BY-DESIGN: the gate is global today - while one discovered config
-//     awaits its enable/disable decision, discovery processing (addCh AND
-//     rmCh) freezes for ALL other configs; the redesign scopes waiting to the
-//     affected key only, so unrelated adds/removals proceed.
-//   - MUST-NOT-FLIP: dyncfg commands execute immediately while the gate is
-//     armed, with state-machine outcomes - load-bearing in the redesign too
-//     (a parked command would deadlock its functions lane against the
-//     gate-clearing enable).
+//   - INVERTED FLIPS-BY-DESIGN: waiting is scoped to the affected key -
+//     while one discovered config awaits its enable/disable decision,
+//     unrelated adds AND removals MUST proceed (previously the global gate
+//     froze all discovery).
+//   - MUST-NOT-FLIP: dyncfg commands execute immediately while a key is
+//     wait-parked, with state-machine outcomes - load-bearing under per-key
+//     lanes too (a parked command would deadlock its functions lane against
+//     the gate-clearing enable).
 func TestCharacterization_WaitGateBehavior(t *testing.T) {
 	tests := map[string]struct {
 		run func(t *testing.T, h *charHarness)
 	}{
-		"global wait gate freezes unrelated discovery": {
+		"wait-parked key does not block unrelated discovery": {
 			run: func(t *testing.T, h *charHarness) {
 				cfgA := prepareUserCfg("success", "a")
 				cfgB := prepareUserCfg("success", "b")
 
 				h.in <- prepareCfgGroups(cfgA.Source(), cfgA)
-				require.Eventually(t, func() bool { return h.mgr.collectorHandler.WaitingForDecision() }, charWait, charTick,
-					"wait gate did not arm for the first discovered config")
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:a create accepted"), charWait, charTick,
+					"first discovered config was not exposed")
 
-				go func() { h.in <- prepareCfgGroups(cfgB.Source(), cfgB) }()
-
-				require.Never(t, func() bool {
-					_, ok := h.mgr.collectorExposed.LookupByKey(cfgB.ExposedKey())
-					return ok
-				}, charNeverWait, charTick,
-					"second discovered config was exposed while the first awaited a decision; "+
-						"the global wait gate no longer freezes discovery - update this FLIPS-BY-DESIGN pin deliberately")
-
-				h.dyncfg("1-enable-a", []string{h.mgr.dyncfgJobID(cfgA), "enable"}, nil)
+				h.in <- prepareCfgGroups(cfgB.Source(), cfgB)
 
 				require.Eventually(t, func() bool {
 					_, ok := h.mgr.collectorExposed.LookupByKey(cfgB.ExposedKey())
 					return ok
-				}, charWait, charTick, "second config was not processed after the first received its decision")
+				}, charWait, charTick,
+					"second discovered config was not exposed while the first awaited its decision; "+
+						"waiting regressed to a global freeze")
+
+				// The parked key still takes its decision.
+				h.dyncfg("1-enable-a", []string{h.mgr.dyncfgJobID(cfgA), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:a status running"), charWait, charTick)
 			},
 		},
-		"global wait gate freezes unrelated removal": {
+		"wait-parked key does not block unrelated removal": {
 			run: func(t *testing.T, h *charHarness) {
 				cfgA := prepareUserCfg("success", "a")
 				cfgB := prepareUserCfg("success", "b")
 
-				// Establish B as a running job first, then arm the gate with A.
+				// Establish B as a running job first, then park A awaiting its decision.
 				h.in <- prepareCfgGroups(cfgB.Source(), cfgB)
-				require.Eventually(t, func() bool { return h.mgr.collectorHandler.WaitingForDecision() }, charWait, charTick)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:b create accepted"), charWait, charTick)
 				h.dyncfg("1-enable-b", []string{h.mgr.dyncfgJobID(cfgB), "enable"}, nil)
 				// Entry.Status is loop-owned (dyncfg cache contract) - observe the
 				// transition through the wire output instead of reading the field.
 				require.Eventually(t, h.outputContains("CONFIG test:collector:success:b status running"), charWait, charTick)
 
 				h.in <- prepareCfgGroups(cfgA.Source(), cfgA)
-				require.Eventually(t, func() bool { return h.mgr.collectorHandler.WaitingForDecision() }, charWait, charTick,
-					"wait gate did not arm for the second discovered config")
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:a create accepted"), charWait, charTick,
+					"second discovered config was not exposed")
 
 				// B vanishes from discovery while A awaits its decision: the
-				// removal must NOT be consumed (rmCh is frozen by the gate).
+				// removal MUST be consumed (waiting is per-key).
 				h.in <- prepareCfgGroups(cfgB.Source())
-
-				require.Never(t, func() bool {
-					_, ok := h.mgr.collectorExposed.LookupByKey(cfgB.ExposedKey())
-					return !ok
-				}, charNeverWait, charTick,
-					"unrelated config's removal was processed while another config awaited a decision; "+
-						"the global wait gate no longer freezes rmCh - update this FLIPS-BY-DESIGN pin deliberately")
-
-				h.dyncfg("2-enable-a", []string{h.mgr.dyncfgJobID(cfgA), "enable"}, nil)
 
 				require.Eventually(t, func() bool {
 					_, ok := h.mgr.collectorExposed.LookupByKey(cfgB.ExposedKey())
 					return !ok
-				}, charWait, charTick, "pending removal was not processed after the decision cleared the gate")
+				}, charWait, charTick,
+					"unrelated config's removal was not processed while another key awaited a decision; "+
+						"waiting regressed to a global freeze")
+
+				// A's decision still lands.
+				h.dyncfg("2-enable-a", []string{h.mgr.dyncfgJobID(cfgA), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:a status running"), charWait, charTick)
 			},
 		},
-		"dyncfg commands execute while wait gate is armed": {
+		"dyncfg commands execute while a key is wait-parked": {
 			run: func(t *testing.T, h *charHarness) {
 				cfg := prepareUserCfg("success", "waity")
 				h.in <- prepareCfgGroups(cfg.Source(), cfg)
-				require.Eventually(t, func() bool { return h.mgr.collectorHandler.WaitingForDecision() }, charWait, charTick)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:waity create accepted"), charWait, charTick)
 
 				h.dyncfg("1-update", []string{h.mgr.dyncfgJobID(cfg), "update"}, []byte("{}"))
 				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 1-update"), charWait, charTick)
 				var updateResp map[string]any
 				mustDecodeFunctionPayload(t, h.out.String(), "1-update", &updateResp)
 				assert.Equal(t, float64(403), updateResp["status"], "premature update must be rejected with 403")
-				assert.True(t, h.mgr.collectorHandler.WaitingForDecision(), "non-decision command must not clear the wait gate")
 
 				h.dyncfg("2-restart", []string{h.mgr.dyncfgJobID(cfg), "restart"}, nil)
 				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 2-restart"), charWait, charTick)
 				var restartResp map[string]any
 				mustDecodeFunctionPayload(t, h.out.String(), "2-restart", &restartResp)
 				assert.Equal(t, float64(405), restartResp["status"], "premature restart must be rejected with 405")
-				assert.True(t, h.mgr.collectorHandler.WaitingForDecision())
 
+				// Non-decision commands must not have cleared the wait park: the
+				// key still takes its decision and only then starts.
+				assert.False(t, h.outputContains("CONFIG test:collector:success:waity status running")(),
+					"job started before its enable decision")
 				h.dyncfg("3-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
-				require.Eventually(t, func() bool { return !h.mgr.collectorHandler.WaitingForDecision() }, charWait, charTick,
-					"matching enable did not clear the wait gate")
 				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-enable"), charWait, charTick)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:waity status running"), charWait, charTick,
+					"matching enable did not unpark the key")
 			},
 		},
 	}
@@ -376,22 +311,22 @@ func TestCharacterization_WireOrderByDomain(t *testing.T) {
 
 				require.Eventually(t, h.outputContains("CONFIG test:collector:success:ord status running"), charWait, charTick)
 
-				requireWireRecordSubsequence(t, h.out.String(), []wireRecordWant{
+				wiretest.RequireSubsequence(t, h.out.String(), []wiretest.RecordWant{
 					{
-						name:     "add terminal",
-						contains: []string{"FUNCTION_RESULT_BEGIN 1-add"},
+						Name:     "add terminal",
+						Contains: []string{"FUNCTION_RESULT_BEGIN 1-add"},
 					},
 					{
-						name:     "add config create",
-						contains: []string{"CONFIG test:collector:success:ord create"},
+						Name:     "add config create",
+						Contains: []string{"CONFIG test:collector:success:ord create"},
 					},
 					{
-						name:     "enable terminal",
-						contains: []string{"FUNCTION_RESULT_BEGIN 2-enable"},
+						Name:     "enable terminal",
+						Contains: []string{"FUNCTION_RESULT_BEGIN 2-enable"},
 					},
 					{
-						name:     "enable config status",
-						contains: []string{"CONFIG test:collector:success:ord status running"},
+						Name:     "enable config status",
+						Contains: []string{"CONFIG test:collector:success:ord status running"},
 					},
 				})
 			},
@@ -411,7 +346,7 @@ func TestCharacterization_WireOrderByDomain(t *testing.T) {
 					Set("option_int", 1)
 				mgr.collectorExposed.Add(&dyncfg.Entry[confgroup.Config]{Cfg: cfg, Status: dyncfg.StatusRunning})
 				mgr.syncSecretStoreDepsForConfig(cfg)
-				require.NoError(t, mgr.collectorCallbacks.Start(cfg))
+				require.NoError(t, mgr.collectorCallbacks.Start(context.Background(), cfg))
 
 				badFn := dyncfg.NewFunction(functions.Function{
 					UID:         "ss-update-bad",
@@ -422,14 +357,14 @@ func TestCharacterization_WireOrderByDomain(t *testing.T) {
 				mgr.dyncfgSecretStoreSeqExec(badFn)
 
 				output := out.String()
-				requireWireRecordSubsequence(t, output, []wireRecordWant{
+				wiretest.RequireSubsequence(t, output, []wiretest.RecordWant{
 					{
-						name:     "dependent job failed status",
-						contains: []string{"CONFIG test:collector:gated:mysql status failed"},
+						Name:     "dependent job failed status",
+						Contains: []string{"CONFIG test:collector:gated:mysql status failed"},
 					},
 					{
-						name:     "store update terminal",
-						contains: []string{"FUNCTION_RESULT_BEGIN ss-update-bad"},
+						Name:     "store update terminal",
+						Contains: []string{"FUNCTION_RESULT_BEGIN ss-update-bad"},
 					},
 				})
 
@@ -529,7 +464,7 @@ func TestCharacterization_RetryTasks(t *testing.T) {
 
 				cfg := prepareUserCfg("flaky", "r1").Set("autodetection_retry", 1)
 				h.in <- prepareCfgGroups(cfg.Source(), cfg)
-				require.Eventually(t, func() bool { return h.mgr.collectorHandler.WaitingForDecision() }, charWait, charTick)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:flaky:r1 create accepted"), charWait, charTick)
 
 				h.dyncfg("1-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
 				require.Eventually(t, h.outputContains("job enable failed"), charWait, charTick)
@@ -570,8 +505,8 @@ func TestCharacterization_FileStatusHookPoints(t *testing.T) {
 			run: func(t *testing.T, mgr *Manager, cb *collectorCallbacks) {
 				cfg := prepareDyncfgCfg("success", "job")
 
-				require.NoError(t, cb.Start(cfg))
-				t.Cleanup(func() { mgr.stopRunningJob(cfg.FullName()) })
+				require.NoError(t, cb.Start(context.Background(), cfg))
+				t.Cleanup(func() { mgr.stopRunningJob(context.Background(), cfg.FullName()) })
 				_, running := mgr.runningJobs.lookup(cfg.FullName())
 				require.True(t, running)
 
@@ -614,7 +549,7 @@ func TestCharacterization_FileStatusHookPoints(t *testing.T) {
 				mgr.runningJobs.unlock()
 				mgr.fileStatus.add(cfg, dyncfg.StatusRunning.String())
 
-				cb.Stop(cfg)
+				cb.Stop(context.Background(), cfg)
 
 				assert.True(t, job.stopped)
 				_, ok := mgr.fileStatus.lookup(cfg)
@@ -635,8 +570,8 @@ func TestCharacterization_FileStatusHookPoints(t *testing.T) {
 				mgr.runningJobs.unlock()
 				mgr.fileStatus.add(oldCfg, dyncfg.StatusRunning.String())
 
-				require.NoError(t, cb.Update(oldCfg, newCfg))
-				t.Cleanup(func() { mgr.stopRunningJob(newCfg.FullName()) })
+				require.NoError(t, cb.Update(context.Background(), oldCfg, newCfg))
+				t.Cleanup(func() { mgr.stopRunningJob(context.Background(), newCfg.FullName()) })
 
 				assert.True(t, job.stopped)
 				_, oldOK := mgr.fileStatus.lookup(oldCfg)

--- a/src/go/plugin/agent/jobmgr/doc.go
+++ b/src/go/plugin/agent/jobmgr/doc.go
@@ -4,25 +4,53 @@
 //
 // Concurrency contract (must remain true unless this document is updated):
 //
-//   - Manager.run() is the serialized owner of dyncfg state transitions:
-//     exposed configs, vnode map updates, and add/remove command application.
+//   - Manager.run() is the single dispatcher: it routes every discovery and
+//     dyncfg event into the executor's per-key lanes and executes ALL commits
+//     on its goroutine. Executor lane state (keyState) is loop-owned and
+//     lock-free; nothing outside the run loop may touch it, except through
+//     the loop-synchronous tryLockIdleKey/unlockIdleKey seam.
 //
-//   - Discovery ingestion (runProcessConfGroups) does not mutate manager state directly.
-//     It publishes add/remove intents through channels consumed by Manager.run().
+//   - Blocking module work (validation, job creation, detection, stop waits)
+//     runs on the effect pool under a flat internal deadline. Effects for one
+//     key never overlap (key busy stage-to-commit; all its events park in
+//     arrival order); effects for different keys run concurrently. State an
+//     effect may reach carries its own synchronization: retryingTasks, the
+//     vnode store, runningJobs, emissionGates, fileStatus, secretStoreDeps,
+//     and funcctl are all internally locked.
 //
-//   - Tick-triggered Function publication reconcile is manager-run-loop owned.
-//     runNotifyRunningJobs may request module reconcile, but must not perform
-//     Function publication directly.
+//   - effectDoneCh has exactly one reader: the run loop. Effect completions
+//     and late returns of abandoned effects resume there; per-call channels
+//     are used anywhere a non-loop caller awaits.
+//
+//   - A wait-parked key (discovered config awaiting its enable/disable
+//     decision) parks only ITS OWN discovery events; its dyncfg commands
+//     execute immediately with the state machine's outcomes, and unrelated
+//     keys are never affected. There is no global wait freeze.
+//
+//   - An abandoned effect (deadline exceeded) frees its pool slot and commits
+//     its deadline outcome, but the key stays busy until the leaked module
+//     call returns; the late outcome (warm start, retry eligibility, plain
+//     release) is decided then, on the loop.
+//
+//   - Discovery ingestion (runProcessConfGroups) does not mutate manager
+//     state directly. It publishes add/remove intents through channels
+//     consumed by Manager.run().
+//
+//   - Tick-triggered Function publication reconcile is reconciler-goroutine
+//     owned. runNotifyRunningJobs may request module reconcile, but must not
+//     perform Function publication directly.
 //
 //   - runningJobs.items is protected by runningJobs.mux.
-//     All traversals must use runningJobs.snapshot() and execute callbacks outside the lock.
-//     No external API/job callbacks may execute while holding runningJobs.mux.
+//     All traversals must use runningJobs.snapshot() and execute callbacks
+//     outside the lock. No external API/job callbacks may execute while
+//     holding runningJobs.mux.
 //
-//   - Function handlers run on framework/functions manager goroutine(s) and must avoid
-//     cross-goroutine access to manager-owned mutable maps; async work uses manager-rooted
-//     contexts and bounded worker limits where required.
+//   - Function handlers run on framework/functions manager goroutine(s) and
+//     must avoid cross-goroutine access to manager-owned mutable maps; async
+//     work uses manager-rooted contexts and bounded worker limits where
+//     required.
 //
-//   - Wait-for-decision gating for discovered configs is handler-owned. Manager.run()
-//     delegates wait-step orchestration to dyncfg handler and keeps dyncfg command
-//     processing progress even while waiting.
+//   - Secretstore and vnode dyncfg commands execute loop-synchronously; the
+//     secretstore dependent-restart bridge claims idle collector keys and
+//     skips busy ones - it never waits on effect completions.
 package jobmgr

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
 )
 
 // scheduleRetryTask schedules a retry if the job supports auto-detection retry.
@@ -23,6 +24,28 @@ func (m *Manager) scheduleRetryTask(cfg confgroup.Config, job runtimeJob) {
 	m.retryingTasks.add(cfg, &retryTask{cancel: cancel})
 
 	go runRetryTask(ctx, m.addCh, cfg)
+}
+
+// resumeWarmJob starts an already-detected job whose detection was abandoned
+// at its deadline but succeeded late. The caller (run loop) has already
+// validated the continuation (no commits on the key since the abandon); here
+// the exposed entry must still be this config in its abandoned-failed state,
+// else the warm job is disposed (module cleanup + gate deregistration).
+func (m *Manager) resumeWarmJob(r *warmResume) {
+	entry, ok := m.collectorExposed.LookupByKey(r.cfg.ExposedKey())
+	if !ok || entry.Cfg.UID() != r.cfg.UID() || entry.Status != dyncfg.StatusFailed {
+		m.Infof("dropping late detection success for '%s': config no longer eligible", r.cfg.FullName())
+		r.job.Cleanup()
+		m.emissionGates.removeMatching(r.cfg.FullName(), r.gate)
+		return
+	}
+	m.retryingTasks.remove(r.cfg)
+	oldStatus := entry.Status
+	m.startRunningJob(r.job)
+	entry.Status = dyncfg.StatusRunning
+	m.collectorHandler.NotifyConfigStatus(entry.Cfg, dyncfg.StatusRunning)
+	m.collectorCallbacks.OnStatusChange(entry, oldStatus, dyncfg.NewFunction(functions.Function{}))
+	m.Infof("late detection success for '%s': warm job started", r.cfg.FullName())
 }
 
 // --- collectorCallbacks implements dyncfg.Callbacks[confgroup.Config] ---
@@ -93,7 +116,7 @@ func (cb *collectorCallbacks) ValidateConfigName(name string) error {
 	return dyncfg.JobNameRuleStrict(name)
 }
 
-func (cb *collectorCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (confgroup.Config, error) {
+func (cb *collectorCallbacks) ParseAndValidate(ctx context.Context, fn dyncfg.Function, name string) (confgroup.Config, error) {
 	mn, ok := cb.mgr.extractModuleName(fn.ID())
 	if !ok {
 		return nil, fmt.Errorf("could not extract module name from ID: %s", fn.ID())
@@ -106,112 +129,207 @@ func (cb *collectorCallbacks) ParseAndValidate(fn dyncfg.Function, name string) 
 
 	cb.mgr.dyncfgSetConfigMeta(cfg, mn, name, fn)
 
-	// Payload parsing above is cheap and stays with the caller; the full
-	// validation (config apply incl. secret resolution) is blocking module
-	// work and runs as an effect.
-	err = cb.mgr.runEffectSync(cfg.FullName(), func(context.Context) error {
-		return cb.mgr.validateCollectorJob(cfg)
-	})
-	if err != nil {
+	if err := cb.mgr.validateCollectorJob(ctx, cfg); err != nil {
+		if errors.Is(context.Cause(ctx), context.Canceled) {
+			// Shutdown interrupted validation (e.g. a cancelled secret
+			// fetch): the config is not invalid - answer retryably.
+			return nil, fmt.Errorf("validation interrupted: %w", dyncfg.ErrPhaseNeverRan)
+		}
 		return nil, fmt.Errorf("invalid configuration: failed to apply configuration: %v", err)
 	}
 
 	return cfg, nil
 }
 
-func (cb *collectorCallbacks) Start(cfg confgroup.Config) error {
+func (cb *collectorCallbacks) Start(ctx context.Context, cfg confgroup.Config) error {
 	cb.mgr.retryingTasks.remove(cfg)
 
-	// The blocking module work (job creation incl. secret resolution, then
-	// detection) runs as one effect; retry scheduling and the running-job
-	// registration stay with the loop-owned state below.
-	var job runtimeJob
-	var createErr error
-	err := cb.mgr.runEffectSync(cfg.FullName(), func(ctx context.Context) error {
-		job, createErr = cb.mgr.createCollectorJob(cfg)
-		if createErr != nil {
-			return createErr
-		}
-		if err := job.AutoDetection(ctx); err != nil {
-			job.Cleanup()
-			return err
-		}
-		return nil
-	})
-
-	if createErr != nil {
-		if _, ok := errors.AsType[dyncfg.CodedError](createErr); ok {
-			return createErr
-		}
-		return &codedError{err: fmt.Errorf("invalid configuration: failed to apply configuration: %w", createErr), code: 400}
-	}
+	job, err := cb.mgr.createCollectorJob(ctx, cfg)
 	if err != nil {
+		// Creation failures cannot outlive the deadline meaningfully; claim
+		// so a raced abandon does not also expect a late outcome... they can:
+		// the claim decides which side reports.
+		effectControlFrom(ctx).claimCompletion()
+		if errors.Is(context.Cause(ctx), context.Canceled) {
+			return fmt.Errorf("job not created: %w", dyncfg.ErrPhaseNeverRan)
+		}
+		if _, ok := errors.AsType[dyncfg.CodedError](err); !ok {
+			err = &codedError{err: fmt.Errorf("invalid configuration: failed to apply configuration: %w", err), code: 400}
+		}
+		return err
+	}
+
+	detErr := job.AutoDetection(ctx)
+
+	if !effectControlFrom(ctx).claimCompletion() {
+		// Abandoned at the deadline: the command already committed its
+		// failure. SUCCESS becomes a warm-start continuation the loop
+		// validates and starts; FAILURE cleans up and evaluates retry
+		// eligibility now, under the normal rules.
+		if detErr == nil {
+			// The registered gate is this job's own (the key is busy for the
+			// whole effect, so no same-name replacement can interleave); drop
+			// paths deregister exactly it.
+			gate, _ := cb.mgr.emissionGates.lookup(cfg.FullName())
+			effectControlFrom(ctx).setResume(&warmResume{cfg: cfg, job: job, gate: gate})
+			return nil
+		}
+		job.Cleanup()
+		cb.mgr.emissionGates.remove(cfg.FullName())
+		if _, ok := errors.AsType[dyncfg.CodedError](detErr); ok {
+			if dyncfg.IsRetryableError(detErr) {
+				cb.mgr.scheduleRetryTask(cfg, job)
+			}
+		} else {
+			cb.mgr.scheduleRetryTask(cfg, job)
+		}
+		return detErr
+	}
+
+	if detErr != nil {
+		job.Cleanup()
 		// Tracking removal only. The gate itself stays open by contract -
 		// closing is reserved for abandoning a wedged stop - and no writer
 		// survives here anyway: the job never started.
 		cb.mgr.emissionGates.remove(cfg.FullName())
-		if _, ok := errors.AsType[dyncfg.CodedError](err); ok {
-			if dyncfg.IsRetryableError(err) {
+		if errors.Is(context.Cause(ctx), context.Canceled) {
+			// Shutdown interrupted the detection (a ctx-honoring module
+			// returned early): not a detection failure - answer retryably,
+			// publish nothing, schedule nothing.
+			return fmt.Errorf("detection interrupted: %w", dyncfg.ErrPhaseNeverRan)
+		}
+		if _, ok := errors.AsType[dyncfg.CodedError](detErr); ok {
+			if dyncfg.IsRetryableError(detErr) {
 				cb.mgr.scheduleRetryTask(cfg, job)
 			}
-			return err
+			return detErr
 		}
 		cb.mgr.scheduleRetryTask(cfg, job)
-		return fmt.Errorf("job enable failed: %w", err)
+		return fmt.Errorf("job enable failed: %w", detErr)
+	}
+
+	if errors.Is(context.Cause(ctx), context.Canceled) {
+		// Shutdown began while the detection was finishing (the child won
+		// the completion claim against the cancelled context): never start
+		// fresh collector work - the enable answers retryably instead.
+		job.Cleanup()
+		cb.mgr.emissionGates.remove(cfg.FullName())
+		return fmt.Errorf("job not started: %w", dyncfg.ErrPhaseNeverRan)
 	}
 
 	cb.mgr.startRunningJob(job)
 	return nil
 }
 
-func (cb *collectorCallbacks) Update(oldCfg, newCfg confgroup.Config) error {
+func (cb *collectorCallbacks) Update(ctx context.Context, oldCfg, newCfg confgroup.Config) error {
 	cb.mgr.retryingTasks.remove(oldCfg)
-	cb.mgr.stopRunningJob(oldCfg.FullName())
 	cb.mgr.fileStatus.remove(oldCfg)
-
-	var job runtimeJob
-	var createErr error
-	err := cb.mgr.runEffectSync(newCfg.FullName(), func(ctx context.Context) error {
-		job, createErr = cb.mgr.createCollectorJob(newCfg)
-		if createErr != nil {
-			return createErr
-		}
-		if err := job.AutoDetection(ctx); err != nil {
-			job.Cleanup()
-			return err
-		}
-		return nil
-	})
-
-	if createErr != nil {
-		var ce dyncfg.CodedError
-		if errors.As(createErr, &ce) {
-			return createErr
-		}
-		return fmt.Errorf("job update failed: %w", createErr)
+	stopped := cb.mgr.stopRunningJob(ctx, oldCfg.FullName())
+	if stopped {
+		// Point of no return: the old instance is stopped. A shutdown
+		// interruption from here on must commit as a disruptive failure - a
+		// never-ran rollback would resurrect a state that no longer exists.
+		// A no-op stop (the old config was not running) tears nothing down,
+		// so never-ran (and its rollback) stays the truthful outcome.
+		effectControlFrom(ctx).markDisruptive()
 	}
+
+	// A stop phase that exceeded its deadline fails the update here: the
+	// replacement's start phase never begins (no second instance).
+	if effectControlFrom(ctx).abandonedNow() {
+		return fmt.Errorf("job update failed: the previous instance's stop timed out and was abandoned")
+	}
+
+	job, err := cb.mgr.createCollectorJob(ctx, newCfg)
 	if err != nil {
-		// Tracking removal only; see the identical note in Start.
-		cb.mgr.emissionGates.remove(newCfg.FullName())
+		effectControlFrom(ctx).claimCompletion()
+		if errors.Is(context.Cause(ctx), context.Canceled) {
+			if !stopped {
+				// Nothing was torn down: answer retryably with rollback.
+				return fmt.Errorf("job not created: %w", dyncfg.ErrPhaseNeverRan)
+			}
+			// Shutdown interrupted the replacement's creation. The old
+			// instance is already stopped: a disruptive failure, not a
+			// rollback.
+			return fmt.Errorf("job update failed: the manager is shutting down; the replacement was not created")
+		}
 		var ce dyncfg.CodedError
 		if errors.As(err, &ce) {
-			if dyncfg.IsRetryableError(err) {
-				cb.mgr.scheduleRetryTask(newCfg, job)
-			}
 			return err
 		}
-		cb.mgr.scheduleRetryTask(newCfg, job)
 		return fmt.Errorf("job update failed: %w", err)
 	}
 
+	detErr := job.AutoDetection(ctx)
+
+	if !effectControlFrom(ctx).claimCompletion() {
+		if detErr == nil {
+			gate, _ := cb.mgr.emissionGates.lookup(newCfg.FullName())
+			effectControlFrom(ctx).setResume(&warmResume{cfg: newCfg, job: job, gate: gate})
+			return nil
+		}
+		job.Cleanup()
+		cb.mgr.emissionGates.remove(newCfg.FullName())
+		if _, ok := errors.AsType[dyncfg.CodedError](detErr); ok {
+			if dyncfg.IsRetryableError(detErr) {
+				cb.mgr.scheduleRetryTask(newCfg, job)
+			}
+		} else {
+			cb.mgr.scheduleRetryTask(newCfg, job)
+		}
+		return detErr
+	}
+
+	if detErr != nil {
+		job.Cleanup()
+		// Tracking removal only; see the identical note in Start.
+		cb.mgr.emissionGates.remove(newCfg.FullName())
+		if errors.Is(context.Cause(ctx), context.Canceled) {
+			if !stopped {
+				return fmt.Errorf("job not started: %w", dyncfg.ErrPhaseNeverRan)
+			}
+			// Shutdown interrupted the replacement's detection: disruptive
+			// failure (the old instance is already stopped), no retry.
+			return fmt.Errorf("job update failed: the manager is shutting down; the replacement was not started")
+		}
+		var ce dyncfg.CodedError
+		if errors.As(detErr, &ce) {
+			if dyncfg.IsRetryableError(detErr) {
+				cb.mgr.scheduleRetryTask(newCfg, job)
+			}
+			return detErr
+		}
+		cb.mgr.scheduleRetryTask(newCfg, job)
+		return fmt.Errorf("job update failed: %w", detErr)
+	}
+
+	if errors.Is(context.Cause(ctx), context.Canceled) {
+		// Shutdown began while the replacement's detection was finishing:
+		// never start fresh collector work.
+		job.Cleanup()
+		cb.mgr.emissionGates.remove(newCfg.FullName())
+		if !stopped {
+			// Nothing was torn down: answer retryably with rollback.
+			return fmt.Errorf("job not started: %w", dyncfg.ErrPhaseNeverRan)
+		}
+		// The old instance is already stopped, so this is a disruptive
+		// failure (status failed), not a rollback - unlike the never-ran
+		// phase, half the update happened.
+		return fmt.Errorf("job update failed: the manager is shutting down; the replacement was not started")
+	}
+
 	cb.mgr.startRunningJob(job)
 	return nil
 }
 
-func (cb *collectorCallbacks) Stop(cfg confgroup.Config) {
+func (cb *collectorCallbacks) Stop(ctx context.Context, cfg confgroup.Config) {
 	cb.mgr.retryingTasks.remove(cfg)
-	cb.mgr.stopRunningJob(cfg.FullName())
+	// Persisted-status removal precedes the blocking wait so the deadline
+	// path (which commits disable/remove while the stop is still wedged)
+	// observes it done.
 	cb.mgr.fileStatus.remove(cfg)
+	cb.mgr.stopRunningJob(ctx, cfg.FullName())
+	effectControlFrom(ctx).claimCompletion()
 }
 
 func (cb *collectorCallbacks) OnStatusChange(entry *dyncfg.Entry[confgroup.Config], _ dyncfg.Status, _ dyncfg.Function) {

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
@@ -751,7 +751,7 @@ func TestDyncfgCmdUpdate_SingleInstancePolicyReplacesRunningLowerPriority(t *tes
 	mgr.runningJobs.lock()
 	mgr.runningJobs.add(oldJob.FullName(), oldJob)
 	mgr.runningJobs.unlock()
-	t.Cleanup(func() { mgr.stopRunningJob("singleupdate") })
+	t.Cleanup(func() { mgr.stopRunningJob(context.Background(), "singleupdate") })
 
 	newCfg := prepareDyncfgCfg("singleupdate", "singleupdate")
 	fn := dyncfg.NewFunction(functions.Function{
@@ -891,7 +891,7 @@ func TestCollectorCallbacks_ParseAndValidate(t *testing.T) {
 				Args:        collectorTestArgs(mgr, tc.args...),
 			})
 
-			cfg, err := cb.ParseAndValidate(fn, "validated")
+			cfg, err := cb.ParseAndValidate(context.Background(), fn, "validated")
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
@@ -965,7 +965,7 @@ func TestCollectorCallbacks_ParseAndValidate_SuppressesAuditSideEffects(t *testi
 		Args:        collectorTestArgs(mgr, "success", string(dyncfg.CommandAdd), "validated"),
 	})
 
-	_, err := cb.ParseAndValidate(fn, "validated")
+	_, err := cb.ParseAndValidate(context.Background(), fn, "validated")
 	require.NoError(t, err)
 
 	entries, err := os.ReadDir(tempDir)
@@ -990,7 +990,7 @@ func TestCollectorCallbacks_ApplyConfigLoggingHonorsValidationMode(t *testing.T)
 					Args:        collectorTestArgs(mgr, "success", string(dyncfg.CommandAdd), "validated"),
 				})
 
-				_, err := cb.ParseAndValidate(fn, "validated")
+				_, err := cb.ParseAndValidate(context.Background(), fn, "validated")
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to apply configuration")
 			},
@@ -999,7 +999,7 @@ func TestCollectorCallbacks_ApplyConfigLoggingHonorsValidationMode(t *testing.T)
 			run: func(t *testing.T, mgr *Manager, _ *bytes.Buffer) {
 				cfg := prepareDyncfgCfg("success", "runtime-job").Set("option_str", "one").Set("option_int", "bad")
 
-				_, err := mgr.createCollectorJob(cfg)
+				_, err := mgr.createCollectorJob(context.Background(), cfg)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "cannot unmarshal")
 			},
@@ -1054,7 +1054,7 @@ func TestCollectorCallbacks_Start(t *testing.T) {
 			mgr := newCollectorTestManager()
 			cb := &collectorCallbacks{mgr: mgr}
 
-			err := cb.Start(tc.cfg)
+			err := cb.Start(context.Background(), tc.cfg)
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
@@ -1074,7 +1074,7 @@ func TestCollectorCallbacks_Start(t *testing.T) {
 			assert.Equal(t, tc.wantRetryPending, retryPending)
 
 			if tc.wantRunning {
-				mgr.stopRunningJob(tc.cfg.FullName())
+				mgr.stopRunningJob(context.Background(), tc.cfg.FullName())
 			}
 			if tc.wantRetryPending {
 				mgr.retryingTasks.remove(tc.cfg)
@@ -1097,7 +1097,7 @@ func TestCollectorCallbacks_Start_AutodetectionCodedError_PreservedNoRetry(t *te
 	cb := &collectorCallbacks{mgr: mgr}
 
 	cfg := prepareDyncfgCfg("codedcheck", "job")
-	err := cb.Start(cfg)
+	err := cb.Start(context.Background(), cfg)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bind failed")
@@ -1124,7 +1124,7 @@ func TestCollectorCallbacks_Start_InitCodedError_PreservedNoRetry(t *testing.T) 
 	cb := &collectorCallbacks{mgr: mgr}
 
 	cfg := prepareDyncfgCfg("codedinit", "job")
-	err := cb.Start(cfg)
+	err := cb.Start(context.Background(), cfg)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bind failed")
@@ -1151,7 +1151,7 @@ func TestCollectorCallbacks_Start_RetryableInitCodedError_PreservedSchedulesRetr
 	cb := &collectorCallbacks{mgr: mgr}
 
 	cfg := prepareDyncfgCfg("retryableinit", "job").Set("autodetection_retry", 1)
-	err := cb.Start(cfg)
+	err := cb.Start(context.Background(), cfg)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bind failed")
@@ -1179,7 +1179,7 @@ func TestCollectorCallbacks_Start_ForeignCodeRetryableErrorDoesNotSatisfyDyncfgC
 	cb := &collectorCallbacks{mgr: mgr}
 
 	cfg := prepareDyncfgCfg("foreignretryable", "job").Set("autodetection_retry", 1)
-	err := cb.Start(cfg)
+	err := cb.Start(context.Background(), cfg)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "foreign retryable")
@@ -1221,7 +1221,7 @@ func TestCollectorCallbacks_Update_CreateCollectorJobPlainErrorPreserved(t *test
 			mgr.runningJobs.unlock()
 			mgr.fileStatus.add(tc.oldCfg, dyncfg.StatusRunning.String())
 
-			err := cb.Update(tc.oldCfg, tc.newCfg)
+			err := cb.Update(context.Background(), tc.oldCfg, tc.newCfg)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantErr)
 			if tc.wantCode != 0 {
@@ -1268,7 +1268,7 @@ func TestCollectorCallbacks_Update_AutodetectionCodedError_PreservedNoRetry(t *t
 	mgr.runningJobs.unlock()
 	mgr.fileStatus.add(oldCfg, dyncfg.StatusRunning.String())
 
-	err := cb.Update(oldCfg, newCfg)
+	err := cb.Update(context.Background(), oldCfg, newCfg)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bind failed")
@@ -1308,7 +1308,7 @@ func TestCollectorCallbacks_Update_InitCodedError_PreservedNoRetry(t *testing.T)
 	mgr.runningJobs.unlock()
 	mgr.fileStatus.add(oldCfg, dyncfg.StatusRunning.String())
 
-	err := cb.Update(oldCfg, newCfg)
+	err := cb.Update(context.Background(), oldCfg, newCfg)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bind failed")
@@ -1348,7 +1348,7 @@ func TestCollectorCallbacks_Update_RetryableInitCodedError_PreservedSchedulesRet
 	mgr.runningJobs.unlock()
 	mgr.fileStatus.add(oldCfg, dyncfg.StatusRunning.String())
 
-	err := cb.Update(oldCfg, newCfg)
+	err := cb.Update(context.Background(), oldCfg, newCfg)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bind failed")
@@ -1403,7 +1403,7 @@ func TestCollectorCallbacks_Update(t *testing.T) {
 			defer cancel()
 			mgr.retryingTasks.add(tc.oldCfg, &retryTask{cancel: cancel})
 
-			err := cb.Update(tc.oldCfg, tc.newCfg)
+			err := cb.Update(context.Background(), tc.oldCfg, tc.newCfg)
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
@@ -1426,7 +1426,7 @@ func TestCollectorCallbacks_Update(t *testing.T) {
 			assert.Equal(t, tc.wantRetryPending, retryPending)
 
 			if tc.wantRunning {
-				mgr.stopRunningJob(tc.newCfg.FullName())
+				mgr.stopRunningJob(context.Background(), tc.newCfg.FullName())
 			}
 			if tc.wantRetryPending {
 				mgr.retryingTasks.remove(tc.newCfg)
@@ -1460,7 +1460,7 @@ func TestCollectorCallbacks_Stop(t *testing.T) {
 			defer cancel()
 			mgr.retryingTasks.add(cfg, &retryTask{cancel: cancel})
 
-			cb.Stop(cfg)
+			cb.Stop(context.Background(), cfg)
 
 			assert.True(t, job.stopped)
 			_, running := mgr.runningJobs.lookup(cfg.FullName())
@@ -1767,7 +1767,7 @@ func (cb *collectorSeqTestCallbacks) ValidateConfigName(name string) error {
 	return dyncfg.JobNameRuleStrict(name)
 }
 
-func (cb *collectorSeqTestCallbacks) ParseAndValidate(fn dyncfg.Function, _ string) (confgroup.Config, error) {
+func (cb *collectorSeqTestCallbacks) ParseAndValidate(_ context.Context, fn dyncfg.Function, _ string) (confgroup.Config, error) {
 	cfg, ok := cb.parsed[fn.Command()]
 	if !ok {
 		return nil, errors.New("unexpected parse request")
@@ -1775,11 +1775,13 @@ func (cb *collectorSeqTestCallbacks) ParseAndValidate(fn dyncfg.Function, _ stri
 	return cfg, nil
 }
 
-func (cb *collectorSeqTestCallbacks) Start(confgroup.Config) error { return nil }
+func (cb *collectorSeqTestCallbacks) Start(context.Context, confgroup.Config) error { return nil }
 
-func (cb *collectorSeqTestCallbacks) Update(_, _ confgroup.Config) error { return nil }
+func (cb *collectorSeqTestCallbacks) Update(_ context.Context, _, _ confgroup.Config) error {
+	return nil
+}
 
-func (cb *collectorSeqTestCallbacks) Stop(confgroup.Config) {}
+func (cb *collectorSeqTestCallbacks) Stop(context.Context, confgroup.Config) {}
 
 func (cb *collectorSeqTestCallbacks) OnStatusChange(*dyncfg.Entry[confgroup.Config], dyncfg.Status, dyncfg.Function) {
 }

--- a/src/go/plugin/agent/jobmgr/dyncfg_handoff.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_handoff.go
@@ -17,6 +17,14 @@ const dyncfgShuttingDownMsg = "Job manager is shutting down."
 // blocks. This is intentional so awaited state transitions preserve ordering
 // and eventually slow the producer instead of being dropped.
 func (m *Manager) enqueueDyncfgFunction(fn dyncfg.Function) {
+	// Post-shutdown commands are rejected up front: with the run loop gone,
+	// a buffered send would strand the command unread. The executor's
+	// shutdown drain answers what was accepted before cancellation; a send
+	// racing cancellation itself is force-finalized by the functions layer.
+	if m.baseContext().Err() != nil {
+		m.dyncfgResponder.SendCodef(fn, 503, dyncfgShuttingDownMsg)
+		return
+	}
 	select {
 	case m.dyncfgCh <- fn:
 	case <-m.baseContext().Done():

--- a/src/go/plugin/agent/jobmgr/dyncfg_secretstore.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_secretstore.go
@@ -3,6 +3,7 @@
 package jobmgr
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -33,6 +34,19 @@ func (m *Manager) restartDependentCollectorJob(fullName string) error {
 		return fmt.Errorf("job '%s' is not exposed", fullName)
 	}
 
+	// Secretstore commands run loop-synchronously; a dependent whose key has
+	// work in flight is SKIPPED and reported (waiting would self-deadlock:
+	// effect completions arrive via this loop) - the report format is the
+	// terminal message's existing per-job failure entry. The busy check
+	// precedes the status check: a dependent whose enable is still in
+	// flight reads accepted but must report as in-progress, not as a state
+	// rejection.
+	sk := collectorStateKey(entry.Cfg.ExposedKey())
+	if !m.executor.tryLockIdleKey(sk) {
+		return fmt.Errorf("skipped: operation in progress")
+	}
+	defer m.executor.unlockIdleKey(sk)
+
 	oldStatus := entry.Status
 	switch oldStatus {
 	case dyncfg.StatusRunning, dyncfg.StatusFailed:
@@ -40,9 +54,9 @@ func (m *Manager) restartDependentCollectorJob(fullName string) error {
 		return fmt.Errorf("job '%s' restart is not allowed in '%s' state", fullName, oldStatus)
 	}
 
-	m.collectorCallbacks.Stop(entry.Cfg)
+	m.collectorCallbacks.Stop(context.Background(), entry.Cfg)
 
-	if err := m.collectorCallbacks.Start(entry.Cfg); err != nil {
+	if err := m.collectorCallbacks.Start(context.Background(), entry.Cfg); err != nil {
 		entry.Status = dyncfg.StatusFailed
 		m.collectorHandler.NotifyConfigStatus(entry.Cfg, dyncfg.StatusFailed)
 		m.collectorCallbacks.OnStatusChange(entry, oldStatus, dyncfg.NewFunction(functions.Function{}))

--- a/src/go/plugin/agent/jobmgr/dyncfg_secretstore_cache.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_secretstore_cache.go
@@ -34,6 +34,15 @@ func (m *Manager) restartableAffectedJobs(key string) []secretstore.JobRef {
 		switch entry.Status {
 		case dyncfg.StatusRunning, dyncfg.StatusFailed:
 			refs = append(refs, job)
+		default:
+			// The exposed status lags the effect: an enable in flight may
+			// already have started the job (with the OLD resolved secret)
+			// while the entry still reads accepted. A dependent whose key
+			// has work in flight MUST be selected so the bridge reports it
+			// as skipped instead of silently missing it.
+			if m.executor.collectorKeyHasWork(entry.Cfg.ExposedKey()) {
+				refs = append(refs, job)
+			}
 		}
 	}
 	return refs

--- a/src/go/plugin/agent/jobmgr/dyncfg_vnode_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_vnode_test.go
@@ -213,7 +213,7 @@ func TestCreateCollectorJob_UsesVnodeControllerLookup(t *testing.T) {
 			mgr := New(Config{PluginName: testPluginName, Vnodes: tc.vnodes})
 			mgr.modules = prepareMockRegistry()
 
-			job, err := mgr.createCollectorJob(tc.cfg)
+			job, err := mgr.createCollectorJob(context.Background(), tc.cfg)
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)

--- a/src/go/plugin/agent/jobmgr/effect.go
+++ b/src/go/plugin/agent/jobmgr/effect.go
@@ -4,65 +4,298 @@ package jobmgr
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"sync/atomic"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 )
 
-// An effect is a unit of blocking module work (config validation, job
-// creation, detection, stop) executed off the manager loop in a supervised
-// child goroutine. Each dispatcher awaits its own effect over a per-call
-// completion channel; effectDoneCh is armed in every run-loop select as the
-// future asynchronous completion path and carries nothing today.
+// An effect is one blocking phase of a command (config validation, job
+// creation, detection, stop), executed by the effect pool off the run loop
+// under a flat internal deadline. Completions travel over effectDoneCh; THE
+// RUN LOOP IS THE ONLY READER.
 //
-// The current execution policy is fully synchronous: runEffectSync spawns
-// the child and immediately drains its completion, so at most one effect is
-// ever in flight and the observable sequence is identical to calling the
-// closure inline. The effect context carries no deadline and is never
-// cancelled.
+// Deadline protocol: when an effect exceeds the deadline, the WORKER abandons
+// it - the pool slot frees and the command commits its deadline outcome - but
+// the module call keeps running in the supervised child and THE KEY STAYS
+// BUSY until it returns. Exactly one side wins the completion claim (CAS):
+// a child that loses skips its normal post-work and follows the late
+// protocol (publish a warm-start continuation on success, clean up and
+// evaluate retry eligibility on failure); a worker that loses waits out the
+// child's in-process post-work and reports a normal completion. Late
+// completions are delivered to the loop shutdown-safely: after manager
+// shutdown they are dropped with a log instead of blocking forever.
 //
-// Discipline: runEffectSync must be called only from the goroutine that owns
-// manager state - the run loop in production. It preserves panic semantics:
-// a child panic is re-raised on the caller goroutine.
+// A panic inside an effect is contained by the supervised child and converts
+// to a failed completion: the command commits its failure path instead of
+// crashing the plugin, and the key is released.
+
+// defaultEffectDeadline is the flat internal cap on one blocking phase.
+// Internal constant by design; tests may shorten it per manager.
+const defaultEffectDeadline = 120 * time.Second
+
+const (
+	effectStateRunning = iota
+	effectStateCompleted
+	effectStateAbandoned
+)
+
+// effectControl is the abandon-protocol channel between the worker and the
+// effect closure, carried on the effect context.
+type effectControl struct {
+	state atomic.Int32
+
+	// resume, set by a detection closure that lost the completion claim
+	// after a SUCCESSFUL detection, carries the warm job for the loop's
+	// late-start continuation.
+	resume atomic.Pointer[warmResume]
+
+	// quarantine, set by a stop closure before its blocking wait, fences the
+	// stopping job's output; the worker runs it at the abandon moment,
+	// BEFORE the deadline outcome commits.
+	quarantine atomic.Pointer[func()]
+
+	// disruptive, set by a multi-phase closure once it has irreversibly
+	// mutated state (an update's old instance is stopped): a shutdown
+	// interruption after this point must commit as a failure, never as
+	// never-ran - a never-ran outcome would roll caches back to a state
+	// that no longer exists.
+	disruptive atomic.Bool
+}
+
+// markDisruptive records the point of no return for the running phase.
+func (c *effectControl) markDisruptive() {
+	if c != nil {
+		c.disruptive.Store(true)
+	}
+}
+
+// warmResume is a late-detection success: the already-detected job, started
+// directly by the loop when the continuation is still valid. It carries the
+// job's own emission gate so drop paths can deregister exactly it.
+type warmResume struct {
+	cfg  confgroup.Config
+	job  runtimeJob
+	gate *emissionGateway
+}
+
+// claimCompletion is called by closures after their blocking module call:
+// false means the worker abandoned this effect and the closure must follow
+// the late protocol instead of its normal post-work.
+func (c *effectControl) claimCompletion() bool {
+	if c == nil {
+		return true
+	}
+	return c.state.CompareAndSwap(effectStateRunning, effectStateCompleted)
+}
+
+// abandonedNow reports whether the worker has already abandoned this effect
+// (without claiming anything): multi-phase closures check it between phases
+// so an abandoned stop never proceeds into creating a replacement.
+func (c *effectControl) abandonedNow() bool {
+	return c != nil && c.state.Load() == effectStateAbandoned
+}
+
+func (c *effectControl) claimAbandon() bool {
+	return c.state.CompareAndSwap(effectStateRunning, effectStateAbandoned)
+}
+
+func (c *effectControl) setResume(r *warmResume) { c.resume.Store(r) }
+
+func (c *effectControl) setQuarantine(fn func()) { c.quarantine.Store(&fn) }
+
+// clearQuarantine disarms the fence once the guarded blocking wait finished
+// normally, so a deadline in a LATER phase of the same effect cannot fence a
+// job that already stopped cleanly.
+func (c *effectControl) clearQuarantine() {
+	if c != nil {
+		c.quarantine.Store(nil)
+	}
+}
+
+func (c *effectControl) takeQuarantine() func() {
+	if p := c.quarantine.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+type effectControlKey struct{}
+
+// effectControlFrom returns the abandon-protocol handle, nil on synchronous
+// paths (which can never be abandoned).
+func effectControlFrom(ctx context.Context) *effectControl {
+	if ctx == nil {
+		return nil
+	}
+	ctl, _ := ctx.Value(effectControlKey{}).(*effectControl)
+	return ctl
+}
 
 type effectResult struct {
-	key        string
-	err        error
-	panicked   bool
-	panicValue any
+	key string
+	err error
+	// abandoned: the deadline fired; the key must stay busy (wedged) until
+	// the late completion arrives.
+	abandoned bool
+	// late: the leaked child returned; the key unwedges and resume (if any
+	// and still valid) starts the warm job.
+	late    bool
+	resume  *warmResume
+	busyFor time.Duration
 }
 
-// runEffectSync executes run in a supervised child goroutine and waits for
-// its completion. The completion travels over a per-call channel, NOT
-// effectDoneCh: callers are not always the run loop (tests drive manager
-// entry points from other goroutines while the loop runs), and any shared
-// completion channel would race the loop's effectDoneCh select arms.
-func (m *Manager) runEffectSync(key string, run func(ctx context.Context) error) error {
-	// Deadline disabled: the effect context is uncancellable, matching the
-	// blocking behavior of the inline calls it replaces.
-	ctx := context.Background()
+func (m *Manager) runEffectWorker() {
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case t := <-m.effectCh:
+			var res effectResult
+			if m.ctx.Err() != nil {
+				// Shutdown races the pick: a queued phase grabbed after cancel
+				// must NOT start (no new module calls at shutdown) - it
+				// resolves never-ran, same as the drain resolves the rest of
+				// the queue.
+				res = effectResult{key: t.key, err: dyncfg.ErrPhaseNeverRan}
+			} else {
+				res = m.superviseEffect(t)
+			}
+			select {
+			case m.effectDoneCh <- res:
+			case <-m.lateDrop:
+				// The drain window expired with the results channel full; the
+				// force pass already committed this command's terminal.
+				m.Warningf("dropping effect completion for key '%s' after shutdown (err: %v)", t.key, res.err)
+			}
+		}
+	}
+}
 
-	done := make(chan effectResult, 1)
+func (m *Manager) superviseEffect(t effectTask) effectResult {
+	ctl := &effectControl{}
+	// Effects carry the deadline AND the manager lifetime: shutdown cancels
+	// them (dyncfg cancellation never does). Deadline-honoring module calls
+	// then return promptly during the bounded shutdown drain.
+	ctx, cancel := context.WithTimeout(m.baseContext(), m.effectDeadline)
+	ctx = context.WithValue(ctx, effectControlKey{}, ctl)
+
+	done := make(chan error, 1)
 	go func() {
-		res := effectResult{key: key}
+		var err error
 		defer func() {
 			if r := recover(); r != nil {
-				res.panicked = true
-				res.panicValue = r
+				m.Errorf("effect panic (key '%s'): %v", t.key, r)
+				if m.executorMetrics != nil {
+					m.executorMetrics.effectPanics.Add(1)
+				}
+				if logger.Level.Enabled(slog.LevelDebug) {
+					m.Errorf("STACK: %s", debug.Stack())
+				}
+				err = fmt.Errorf("internal error: effect panic: %v", r)
 			}
-			done <- res
+			done <- err
 		}()
-		res.err = run(ctx)
+		err = t.effect(ctx)
 	}()
 
-	res := <-done
-	if res.panicked {
-		// Today a panic on this path crashes the plugin; keep that contract.
-		panic(res.panicValue)
-	}
-	return res.err
-}
+	started := time.Now()
+	select {
+	case err := <-done:
+		cancel()
+		return effectResult{key: t.key, err: err, busyFor: time.Since(started)}
+	case <-ctx.Done():
+		if !ctl.claimAbandon() {
+			// The closure claimed completion first: its in-process post-work
+			// is finishing - wait it out and report a normal completion.
+			err := <-done
+			cancel()
+			return effectResult{key: t.key, err: err}
+		}
+		// Quarantine the stopping job's output BEFORE the deadline outcome
+		// commits (the commit happens after this result reaches the loop).
+		// The classification below depends on it: only a FENCED abandon may
+		// carry ErrPhaseAbandoned - stop-shaped commits publish success on
+		// that sentinel, and success without a fence would break
+		// no-output-after-publish (an abandon can win before the closure
+		// even reaches the stop that registers the fence).
+		fenced := false
+		if q := ctl.takeQuarantine(); q != nil {
+			q()
+			fenced = true
+		}
+		if m.executorMetrics != nil {
+			m.executorMetrics.leakedEffects.Add(1)
+			m.executorMetrics.wedgedKeys.Add(1)
+		}
+		m.Warningf("effect deadline (%s) exceeded for key '%s'; abandoning (the collector call keeps running leaked)", m.effectDeadline, t.key)
 
-// handleUnexpectedEffectDone is the loop-select arm for effect completions.
-// Under the synchronous policy every completion is drained by its
-// dispatcher, so an arrival here is a bug, not an event to act on.
-func (m *Manager) handleUnexpectedEffectDone(res effectResult) {
-	m.Errorf("BUG: unexpected effect completion for key '%s' (err: %v) reached the run loop", res.key, res.err)
+		m.leakedChildren.Add(1)
+		m.leakedNow.Add(1)
+		go func() {
+			defer m.leakedChildren.Done()
+			err := <-done
+			cancel()
+			m.leakedNow.Add(-1)
+			res := effectResult{key: t.key, err: err, late: true, resume: ctl.resume.Load()}
+			if r := res.resume; r != nil && m.ctx.Err() != nil {
+				// Shutdown is in effect: no warm job will ever start, and a
+				// buffered send can win the race against the closed lateDrop
+				// and strand the result unread - dispose here, deliver a
+				// resume-less completion (a consumer just unwedges the key).
+				r.job.Cleanup()
+				m.emissionGates.removeMatching(r.cfg.FullName(), r.gate)
+				res.resume = nil
+			}
+			select {
+			case m.effectDoneCh <- res:
+			case <-m.lateDrop:
+				m.Warningf("dropping late effect completion for key '%s' after shutdown (err: %v)", t.key, err)
+				if r := res.resume; r != nil {
+					// Unreachable once the pre-send disposal ran (shutdown
+					// precedes lateDrop's close); kept as a safety net.
+					r.job.Cleanup()
+					m.emissionGates.removeMatching(r.cfg.FullName(), r.gate)
+				}
+			}
+		}()
+		var abandonErr error
+		shutdown := errors.Is(context.Cause(ctx), context.Canceled)
+		switch {
+		case shutdown && fenced:
+			// Shutdown cancelled the effect context; same abandon mechanics
+			// (the worker must never block at shutdown), different cause.
+			abandonErr = fmt.Errorf("%w: job manager is shutting down", dyncfg.ErrPhaseAbandoned)
+		case shutdown && ctl.disruptive.Load():
+			// Shutdown after the phase's point of no return (the update's
+			// old instance is already stopped): a never-ran rollback would
+			// resurrect caches for a state that no longer exists - commit
+			// as a plain disruptive failure instead.
+			abandonErr = fmt.Errorf("interrupted by shutdown after the operation began: the previous state was already torn down")
+		case shutdown:
+			// Unfenced shutdown interruption: no matter which side wins the
+			// completion claim, the command's outcome is "interrupted, retry
+			// after restart" - the never-ran shape (503, nothing published,
+			// caches untouched/restored). This is the single choke point:
+			// callback-side conversions cover the child winning the claim,
+			// this branch covers the worker winning it.
+			abandonErr = fmt.Errorf("interrupted by shutdown: %w", dyncfg.ErrPhaseNeverRan)
+		case fenced:
+			abandonErr = fmt.Errorf("%w: timed out after %s (the collector call is still running)", dyncfg.ErrPhaseAbandoned, m.effectDeadline)
+		default:
+			abandonErr = fmt.Errorf("operation timed out after %s and was abandoned (the collector call is still running)", m.effectDeadline)
+		}
+		return effectResult{
+			key:       t.key,
+			err:       abandonErr,
+			abandoned: true,
+			busyFor:   time.Since(started),
+		}
+	}
 }

--- a/src/go/plugin/agent/jobmgr/effect_deadline_test.go
+++ b/src/go/plugin/agent/jobmgr/effect_deadline_test.go
@@ -1,0 +1,1612 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
+	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// startTunedCharManager is startCharManager with a pre-Run mutation hook
+// (the deadline battery shortens the effect deadline per manager).
+func startTunedCharManager(t *testing.T, modules collectorapi.Registry, tune func(mgr *Manager)) *charHarness {
+	t.Helper()
+
+	var out simOutput
+	mgr := New(Config{PluginName: testPluginName})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = modules
+	if tune != nil {
+		tune(mgr)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx), "manager did not report started")
+
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+
+	return &charHarness{mgr: mgr, out: &out, in: in}
+}
+
+const testEffectDeadline = 200 * time.Millisecond
+
+func TestEffect_DeadlineAbandon(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"abandoned detection fails, wedges the key, and warm-starts on late success": {
+			run: func(t *testing.T) {
+				release := make(chan struct{})
+				var initCalls atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("wedge", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								initCalls.Add(1)
+								<-release
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+				reg.Register("success", charSuccessCreator())
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("wedge"), "add", "w"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("wedge", "w")), "enable"}, nil)
+
+				// The deadline outcome commits while the module call still runs.
+				require.Eventually(t, h.outputContains("timed out after"), charWait, charTick,
+					"the enable must fail with the abandonment message at the deadline")
+				require.Eventually(t, h.outputContains("CONFIG test:collector:wedge:w status failed"), charWait, charTick)
+
+				// The key is wedged: its own commands park...
+				h.dyncfg("3-get", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("wedge", "w")), "get"}, nil)
+				require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-get"), charNeverWait, charTick,
+					"a wedged key must hold its parked commands until the late return")
+				// ...while unrelated keys proceed.
+				h.dyncfg("4-add-b", []string{h.mgr.dyncfgModID("success"), "add", "b"}, []byte("{}"))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 4-add-b"), charWait, charTick,
+					"unrelated keys must not wait on a wedged key")
+
+				// Late success: the warm job starts once, with no re-detection.
+				close(release)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:wedge:w status running"), charWait, charTick,
+					"the late detection success must start the warm job")
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-get"), charWait, charTick,
+					"the parked command must run after the key unwedges")
+				assert.Equal(t, int32(1), initCalls.Load(), "the warm start must not re-run detection")
+			},
+		},
+		"late retryable failure schedules a retry under the normal rules": {
+			run: func(t *testing.T) {
+				release := make(chan struct{})
+				var initCalls atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("flaky", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							// A plain Init failure disables auto-detection; Check
+							// failures are the retryable class.
+							CheckFunc: func(context.Context) error {
+								if initCalls.Add(1) == 1 {
+									<-release
+									return errors.New("late first failure")
+								}
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+
+				cfg := prepareUserCfg("flaky", "r").Set("autodetection_retry", 1)
+				h.in <- prepareCfgGroups(cfg.Source(), cfg)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:flaky:r create accepted"), charWait, charTick)
+				h.dyncfg("1-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+
+				require.Eventually(t, h.outputContains("timed out after"), charWait, charTick)
+
+				// No retry is scheduled at the abandon moment; the late failure
+				// evaluates retry eligibility, the retry re-adds the config, and
+				// the daemon (played here) echoes the enable for its CREATE.
+				close(release)
+				require.Eventually(t, func() bool { return initCalls.Load() >= 1 && h.outputContains("timed out after")() }, charWait, charTick)
+				require.Eventually(t, func() bool {
+					return strings.Count(h.out.String(), "CONFIG test:collector:flaky:r create accepted") >= 2
+				}, 10*time.Second, charTick, "the retry must re-add the config")
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:flaky:r status running"), charWait, charTick,
+					"the retried detection must succeed")
+				assert.Equal(t, int32(2), initCalls.Load())
+			},
+		},
+		"late non-retryable failure schedules no retry": {
+			run: func(t *testing.T) {
+				release := make(chan struct{})
+				var initCalls atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("dead", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								initCalls.Add(1)
+								<-release
+								return errors.New("late failure")
+							},
+						}
+					},
+				})
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+
+				// No autodetection_retry: today's rules schedule nothing.
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("dead"), "add", "d"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("dead", "d")), "enable"}, nil)
+				require.Eventually(t, h.outputContains("timed out after"), charWait, charTick)
+
+				close(release)
+				require.Never(t, func() bool { return initCalls.Load() > 1 }, 1500*time.Millisecond, 50*time.Millisecond,
+					"a late non-retryable failure must not schedule a retry")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+func TestEffect_StopDeadline(t *testing.T) {
+	newBlockingCollectJob := func(entered chan<- struct{}, release <-chan struct{}) collectorapi.Creator {
+		return collectorapi.Creator{
+			JobConfigSchema: collectorapi.MockConfigSchema,
+			Create: func() collectorapi.CollectorV1 {
+				return &collectorapi.MockCollectorV1{
+					ChartsFunc: func() *collectorapi.Charts {
+						return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+					},
+					CollectFunc: func(context.Context) map[string]int64 {
+						select {
+						case entered <- struct{}{}:
+						default:
+						}
+						<-release
+						return map[string]int64{"d1": 1}
+					},
+				}
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"disable of a wedged stop commits at the deadline and fences late output": {
+			run: func(t *testing.T) {
+				entered := make(chan struct{}, 1)
+				release := make(chan struct{})
+				defer close(release)
+
+				reg := collectorapi.Registry{}
+				reg.Register("stuck", newBlockingCollectJob(entered, release))
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+
+				cfg := prepareDyncfgCfg("stuck", "s")
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("stuck"), "add", "s"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+
+				// Wait for a collection to be in flight so the stop wedges.
+				select {
+				case <-entered:
+				case <-time.After(charWait):
+					t.Fatal("no collection started")
+				}
+				gate, ok := h.mgr.emissionGates.lookup(cfg.FullName())
+				require.True(t, ok)
+
+				h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+
+				// Disable still "always succeeds": terminal 200 and the CONFIG
+				// status publish at the deadline, while the stop stays wedged.
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable 200"), charWait, charTick,
+					"disable must commit successfully at the deadline")
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status disabled"), charWait, charTick)
+
+				// The gate is closed: once the blocked collection unblocks, its
+				// flush after the publish is suppressed, never written.
+				release <- struct{}{}
+				require.Eventually(t, func() bool { return gate.SuppressedWrites() >= 1 }, charWait, charTick,
+					"the late flush must be swallowed by the closed gate")
+			},
+		},
+		"restart of a wedged stop fails 422 and never starts a second instance": {
+			run: func(t *testing.T) {
+				entered := make(chan struct{}, 1)
+				release := make(chan struct{})
+				defer close(release)
+
+				reg := collectorapi.Registry{}
+				reg.Register("stuck", newBlockingCollectJob(entered, release))
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+
+				cfg := prepareDyncfgCfg("stuck", "s")
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("stuck"), "add", "s"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+				select {
+				case <-entered:
+				case <-time.After(charWait):
+					t.Fatal("no collection started")
+				}
+
+				h.dyncfg("3-restart", []string{h.mgr.dyncfgJobID(cfg), "restart"}, nil)
+
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-restart 422"), charWait, charTick,
+					"a restart whose stop wedges must fail 422")
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status failed"), charWait, charTick)
+
+				// The start phase never began: only one instance was ever
+				// created (one running job existed; none is running now and no
+				// new detection started while the key is wedged).
+				require.Never(t, func() bool {
+					h.mgr.runningJobs.lock()
+					_, running := h.mgr.runningJobs.lookup(cfg.FullName())
+					h.mgr.runningJobs.unlock()
+					return running
+				}, charNeverWait, charTick, "no second instance may start after a stop-deadline failure")
+			},
+		},
+		"update of a wedged stop fails at the deadline and never creates the replacement": {
+			run: func(t *testing.T) {
+				entered := make(chan struct{}, 1)
+				release := make(chan struct{})
+				var detections atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("stuck", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								detections.Add(1)
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 {
+								select {
+								case entered <- struct{}{}:
+								default:
+								}
+								<-release
+								return map[string]int64{"d1": 1}
+							},
+						}
+					},
+				})
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+
+				cfg := prepareDyncfgCfg("stuck", "s")
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("stuck"), "add", "s"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+				select {
+				case <-entered:
+				case <-time.After(charWait):
+					t.Fatal("no collection started")
+				}
+
+				h.dyncfg("3-update", []string{h.mgr.dyncfgJobID(cfg), "update"},
+					mustJSON(t, map[string]any{"option_str": "changed"}))
+
+				// The update commits its failure at the deadline via the
+				// existing update-failure mapping (plain error -> 200 with the
+				// message + status failed), while the old stop stays wedged.
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-update 200"), charWait, charTick,
+					"an update whose stop wedges must commit failed at the deadline")
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status failed"), charWait, charTick)
+				assert.True(t, h.outputContains("timed out after")(),
+					"the terminal must carry the abandonment message")
+
+				// Unwedge: the late stop return must release the key only -
+				// the replacement is never created, never detected, never
+				// started (no warm continuation exists for an abandoned stop).
+				release <- struct{}{}
+				close(release)
+				require.Never(t, func() bool {
+					h.mgr.runningJobs.lock()
+					_, running := h.mgr.runningJobs.lookup(cfg.FullName())
+					h.mgr.runningJobs.unlock()
+					return running
+				}, charNeverWait, charTick, "the replacement must never start after an abandoned stop")
+				assert.Equal(t, int32(1), detections.Load(),
+					"only the original instance may ever run detection")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// Bridge pin: secretstore dependent restarts run loop-synchronously and
+// SKIP-AND-REPORT dependents whose collector key has work in flight; idle
+// dependents restart inline exactly as before.
+func TestSecretstoreBridge_SkipsBusyDependents(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"busy-key dependent is skipped and reported in the terminal message": {
+			run: func(t *testing.T) {
+				release := make(chan struct{})
+				var inits atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("gated", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								if inits.Add(1) > 1 {
+									<-release // the update's detection blocks: key busy
+								}
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService()})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				t.Cleanup(func() {
+					cancel()
+					select {
+					case <-done:
+					case <-time.After(charWait):
+						t.Errorf("manager did not stop after cancel")
+					}
+				})
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				// Store, then a running collector job that references it.
+				h.dyncfg("ss-add", []string{mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+					mustJSON(t, map[string]any{"value": "good"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+				h.dyncfg("1-add", []string{mgr.dyncfgModID("gated"), "add", "mysql"},
+					mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+				cfg := prepareDyncfgCfg("gated", "mysql")
+				h.dyncfg("2-enable", []string{mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+				require.Eventually(t, func() bool {
+					return len(mgr.restartableAffectedJobs("vault:vault_prod")) == 1
+				}, charWait, charTick, "the job must be registered as a restartable store dependent")
+
+				// Make the dependent's key busy without leaving Running state
+				// (which would drop it from the restartable set): a restart
+				// whose detection blocks.
+				h.dyncfg("3-restart", []string{mgr.dyncfgJobID(cfg), "restart"}, nil)
+				require.Eventually(t, func() bool { return inits.Load() >= 2 }, charWait, charTick,
+					"the restart's detection did not start")
+
+				// The store update must NOT wait on the busy dependent.
+				h.dyncfg("ss-update", []string{mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+					mustJSON(t, map[string]any{"value": "rotated"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick,
+					"the store update must complete while its dependent is busy")
+
+				var resp map[string]any
+				mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
+				assert.Contains(t, resp["message"], "dependent collector restarts failed")
+				assert.Contains(t, resp["message"], "skipped: operation in progress")
+
+				close(release)
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-restart 200"), charWait, charTick,
+					"the blocked restart must complete after release")
+			},
+		},
+		"a dependent with an enable in flight is reported, never silently missed": {
+			run: func(t *testing.T) {
+				gate := make(chan struct{})
+				var inits atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("gated", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								inits.Add(1)
+								<-gate // the enable's detection holds the key busy
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService()})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				t.Cleanup(func() {
+					cancel()
+					select {
+					case <-done:
+					case <-time.After(charWait):
+						t.Errorf("manager did not stop after cancel")
+					}
+				})
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				h.dyncfg("ss-add", []string{mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+					mustJSON(t, map[string]any{"value": "good"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+				h.dyncfg("1-add", []string{mgr.dyncfgModID("gated"), "add", "mysql"},
+					mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 1-add"), charWait, charTick)
+				require.Eventually(t, func() bool {
+					return len(mgr.affectedJobs("vault:vault_prod")) == 1
+				}, charWait, charTick, "the job must be registered as a store dependent")
+
+				// The enable's effect starts (it resolved the OLD secret) but
+				// its commit is pending: the exposed status still reads
+				// accepted while the key is busy.
+				cfg := prepareDyncfgCfg("gated", "mysql")
+				h.dyncfg("2-enable", []string{mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, func() bool { return inits.Load() >= 1 }, charWait, charTick,
+					"the enable's detection did not start")
+
+				// The store update must not silently miss the in-flight
+				// dependent: it is selected and reported as skipped.
+				h.dyncfg("ss-update", []string{mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+					mustJSON(t, map[string]any{"value": "rotated"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick)
+
+				var resp map[string]any
+				mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
+				assert.Contains(t, resp["message"], "skipped: operation in progress",
+					"an in-flight dependent must be reported, not silently missed")
+
+				close(gate)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick,
+					"the enable must complete after release")
+			},
+		},
+		"a wait-parked accepted dependent stays ignored": {
+			run: func(t *testing.T) {
+				reg := collectorapi.Registry{}
+				reg.Register("gated", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService()})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				t.Cleanup(func() {
+					cancel()
+					select {
+					case <-done:
+					case <-time.After(charWait):
+						t.Errorf("manager did not stop after cancel")
+					}
+				})
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				h.dyncfg("ss-add", []string{mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+					mustJSON(t, map[string]any{"value": "good"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+				// A discovery config referencing the store, wait-parked for a
+				// user decision: no job, no resolved secret - a store change
+				// has nothing to restart and must not report it.
+				cfg := prepareUserCfg("gated", "waiting").Set("option_str", "${store:vault:vault_prod:value}")
+				h.in <- prepareCfgGroups(cfg.Source(), cfg)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:gated:waiting create accepted"), charWait, charTick)
+				require.Eventually(t, func() bool {
+					return len(mgr.affectedJobs("vault:vault_prod")) == 1
+				}, charWait, charTick, "the config must be registered as a store dependent")
+
+				h.dyncfg("ss-update", []string{mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+					mustJSON(t, map[string]any{"value": "rotated"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick)
+
+				var resp map[string]any
+				mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
+				msg, _ := resp["message"].(string)
+				assert.NotContains(t, msg, "restarts failed",
+					"a wait-parked accepted dependent must not surface as a restart failure")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// Pool and FIFO invariants under wedged keys.
+func TestEffect_WedgeInvariants(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"abandoned effects free their pool slots: work proceeds with every slot leaked": {
+			run: func(t *testing.T) {
+				release := make(chan struct{})
+
+				reg := collectorapi.Registry{}
+				reg.Register("wedge", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								<-release
+								return nil
+							},
+						}
+					},
+				})
+				reg.Register("success", charSuccessCreator())
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+				defer close(release)
+
+				// Wedge as many keys as the pool has workers.
+				for i := range effectPoolSize {
+					name := string(rune('a' + i))
+					h.dyncfg("add-"+name, []string{h.mgr.dyncfgModID("wedge"), "add", name}, []byte("{}"))
+					h.dyncfg("enable-"+name, []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("wedge", name)), "enable"}, nil)
+				}
+				for i := range effectPoolSize {
+					name := string(rune('a' + i))
+					require.Eventually(t, h.outputContains("CONFIG test:collector:wedge:"+name+" status failed"), charWait, charTick,
+						"every wedged key must commit its deadline failure")
+				}
+
+				// All four module calls are leaked; the pool slots are free.
+				h.dyncfg("5-add", []string{h.mgr.dyncfgModID("success"), "add", "fresh"}, []byte("{}"))
+				h.dyncfg("6-enable", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("success", "fresh")), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:fresh status running"), charWait, charTick,
+					"a fresh key must get a pool slot while all abandoned calls are still leaked")
+			},
+		},
+		"a disable parked behind the wedge prevents the warm start": {
+			run: func(t *testing.T) {
+				release := make(chan struct{})
+				var initCalls atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("wedge", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								initCalls.Add(1)
+								<-release
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+
+				cfg := prepareDyncfgCfg("wedge", "w")
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("wedge"), "add", "w"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:wedge:w status failed"), charWait, charTick)
+
+				// Parked behind the wedge.
+				h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+				require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable"), charNeverWait, charTick)
+
+				close(release)
+
+				// The user's queued stop intent wins over the continuation: the
+				// warm job is dropped (never started) and the parked disable
+				// executes against the failed entry.
+				require.Eventually(t, h.outputContains("CONFIG test:collector:wedge:w status disabled"), charWait, charTick)
+				wiretest.RequireSubsequence(t, h.out.String(), []wiretest.RecordWant{
+					{Name: "parked disable terminal", Contains: []string{"FUNCTION_RESULT_BEGIN 3-disable 200"}},
+					{Name: "disabled", Contains: []string{"CONFIG test:collector:wedge:w status disabled"}},
+				})
+				assert.False(t, h.outputContains("CONFIG test:collector:wedge:w status running")(),
+					"a queued disable must prevent the warm start entirely")
+				assert.Equal(t, int32(1), initCalls.Load(), "no re-detection may run")
+				_, hasGate := h.mgr.emissionGates.lookup(cfg.FullName())
+				assert.False(t, hasGate, "the dropped warm job's gate must be deregistered")
+			},
+		},
+		"function routing to a wedged-stop job ends at the stop's start, not its return": {
+			run: func(t *testing.T) {
+				entered := make(chan struct{}, 1)
+				release := make(chan struct{})
+				defer close(release)
+
+				reg := collectorapi.Registry{}
+				reg.Register("stuck", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 {
+								select {
+								case entered <- struct{}{}:
+								default:
+								}
+								<-release
+								return map[string]int64{"d1": 1}
+							},
+						}
+					},
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "probe", Name: "Probe"}}
+					},
+				})
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+
+				cfg := prepareDyncfgCfg("stuck", "s")
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("stuck"), "add", "s"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+				require.Eventually(t, func() bool {
+					return len(h.mgr.GetJobNames("stuck")) == 1
+				}, charWait, charTick, "the running job must be routable")
+				select {
+				case <-entered:
+				case <-time.After(charWait):
+					t.Fatal("no collection started")
+				}
+
+				h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status disabled"), charWait, charTick)
+
+				// The stop is still wedged (collect blocked), yet function
+				// routing already ended: the registry removal ran at the
+				// stop's start, before the blocking wait.
+				assert.Empty(t, h.mgr.GetJobNames("stuck"),
+					"function routing must end when the stop begins, not when it returns")
+			},
+		},
+		"auto-enable replacement over a wedged stop starts after the wedge clears": {
+			run: func(t *testing.T) {
+				entered := make(chan struct{}, 1)
+				release := make(chan struct{})
+				var inits atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("stuck", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								inits.Add(1)
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 {
+								select {
+								case entered <- struct{}{}:
+								default:
+								}
+								<-release
+								return map[string]int64{"d1": 1}
+							},
+						}
+					},
+				})
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) {
+					mgr.effectDeadline = testEffectDeadline
+					mgr.runModePolicy.AutoEnableDiscovered = true
+				})
+				defer close(release)
+
+				// The stock config auto-enables and its collection wedges.
+				stockCfg := prepareStockCfg("stuck", "s")
+				h.in <- prepareCfgGroups(stockCfg.Source(), stockCfg)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+				select {
+				case <-entered:
+				case <-time.After(charWait):
+					t.Fatal("no collection started")
+				}
+
+				// A higher-priority config replaces it: the old stop wedges at
+				// the deadline (abandoned, fenced); the auto-enable must park
+				// behind the wedge instead of failing against it.
+				userCfg := prepareUserCfg("stuck", "s")
+				h.in <- prepareCfgGroups(userCfg.Source(), userCfg)
+				require.Eventually(t, func() bool {
+					return strings.Count(h.out.String(), "CONFIG test:collector:stuck:s create accepted") >= 2
+				}, charWait, charTick, "the replacement must commit after the abandoned stop")
+
+				// The leaked stop returns; the parked enable replays and the
+				// replacement starts - it must never have been failed.
+				release <- struct{}{}
+				require.Eventually(t, func() bool {
+					return inits.Load() == 2 &&
+						strings.Count(h.out.String(), "CONFIG test:collector:stuck:s status running") >= 2
+				}, charWait, charTick, "the replacement must start after the wedge clears")
+				assert.False(t, h.outputContains("CONFIG test:collector:stuck:s status failed")(),
+					"a replacement must not fail solely because the old stop wedged")
+			},
+		},
+		"a test command never parks behind a wedged key": {
+			run: func(t *testing.T) {
+				release := make(chan struct{})
+				var initCalls atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("wedge", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								if initCalls.Add(1) == 1 {
+									<-release // only the enable's detection wedges
+								}
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+
+				h := startTunedCharManager(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+				defer close(release)
+
+				cfg := prepareDyncfgCfg("wedge", "w")
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("wedge"), "add", "w"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:wedge:w status failed"), charWait, charTick,
+					"the detection must wedge the key")
+
+				// Test is KEYLESS by contract: it answers while the key is
+				// wedged instead of parking behind the abandoned detection.
+				h.dyncfg("3-test", []string{h.mgr.dyncfgJobID(cfg), "test"}, []byte("{}"))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-test"), charWait, charTick,
+					"a test command must never park behind a busy key")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// Shutdown battery: every admitted command reaches a terminal outcome, no
+// goroutine blocks forever, and late children after shutdown are dropped.
+func TestEffect_Shutdown(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"saturated shutdown answers undispatched commands and returns promptly": {
+			run: func(t *testing.T) {
+				// No goroutine created by this test may survive it: workers
+				// exit on shutdown, and leaked children drain via lateDrop
+				// once released. (IgnoreCurrent is evaluated here, at defer
+				// time, snapshotting pre-test goroutines.)
+				defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+				release := make(chan struct{})
+				var detStarted, cleanups atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("wedge", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								detStarted.Add(1)
+								<-release
+								return nil
+							},
+							CleanupFunc: func(context.Context) {
+								cleanups.Add(1)
+							},
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+				mgr.drainWait = 300 * time.Millisecond
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				// Saturate the pool and its queue with blocking detections on
+				// distinct keys, plus extras that stay undispatched. Whether a
+				// given validate wins a pool slot before the wedged detections
+				// occupy them all is scheduling-dependent - the invariant under
+				// test does not depend on it: every consumed command must reach
+				// a terminal across shutdown, ran or not.
+				total := effectPoolSize*2 + 2
+				for i := range total {
+					name := string(rune('a' + i))
+					h.dyncfg("add-"+name, []string{h.mgr.dyncfgModID("wedge"), "add", name}, []byte("{}"))
+					h.dyncfg("en-"+name, []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("wedge", name)), "enable"}, nil)
+				}
+				require.Eventually(t, func() bool { return len(h.mgr.dyncfgCh) == 0 }, charWait, charTick,
+					"every command must be consumed by the loop (staged, queued, or parked)")
+				// All pool workers end up inside blocked detections (while any
+				// worker is free, validates keep completing and detections
+				// keep starting), making the leaked accounting deterministic.
+				require.Eventually(t, func() bool { return detStarted.Load() == int32(effectPoolSize) }, charWait, charTick,
+					"every pool worker must be inside a blocked detection")
+
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(charWait):
+					t.Fatal("shutdown did not complete with a saturated executor")
+				}
+
+				// The in-flight detections were abandoned at shutdown and are
+				// accounted as leaked until their module calls return.
+				assert.Equal(t, int64(effectPoolSize), h.mgr.leakedNow.Load(),
+					"every abandoned in-flight call must be accounted as leaked")
+
+				// Blocked module calls (ignoring cancellation) are leaked;
+				// their children must not block anything after shutdown.
+				close(release)
+				require.Eventually(t, func() bool { return h.mgr.leakedNow.Load() == 0 }, charWait, charTick,
+					"returned module calls must leave the leaked accounting")
+
+				// The late SUCCESSFUL detections arrive after lateDrop closed:
+				// their warm jobs are disposed in place - modules cleaned and
+				// gates deregistered, nothing started.
+				require.Eventually(t, func() bool { return cleanups.Load() == int32(effectPoolSize) }, charWait, charTick,
+					"every dropped warm job must clean its module exactly once")
+				for i := range total {
+					name := string(rune('a' + i))
+					_, hasGate := h.mgr.emissionGates.lookup("wedge_" + name)
+					assert.False(t, hasGate, "no gate may survive for job %q", name)
+				}
+
+				// Terminals for all: in-flight phases fail via shutdown-abandon,
+				// queued-but-unpicked and pending phases fail never-ran, parked
+				// commands answer 503 - silence for any command is a bug.
+				results := 0
+				for i := range total {
+					name := string(rune('a' + i))
+					if h.outputContains("FUNCTION_RESULT_BEGIN add-" + name)() {
+						results++
+					}
+					if h.outputContains("FUNCTION_RESULT_BEGIN en-" + name)() {
+						results++
+					}
+				}
+				assert.Equal(t, 2*total, results, "every admitted command must reach a terminal outcome across shutdown")
+			},
+		},
+		"queued disable at shutdown answers 503 and publishes nothing": {
+			run: func(t *testing.T) {
+				defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+				entered := make(chan struct{}, 1)
+				release := make(chan struct{})
+
+				reg := collectorapi.Registry{}
+				reg.Register("stuck", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 {
+								select {
+								case entered <- struct{}{}:
+								default:
+								}
+								<-release
+								return map[string]int64{"d1": 1}
+							},
+						}
+					},
+				})
+				var detStarted atomic.Int32
+				reg.Register("wedge", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								detStarted.Add(1)
+								<-release
+								return nil
+							},
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+				mgr.drainWait = 300 * time.Millisecond
+				mgr.effectDeadline = time.Hour // nothing may abandon before shutdown
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				cfg := prepareDyncfgCfg("stuck", "s")
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("stuck"), "add", "s"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+				select {
+				case <-entered:
+				case <-time.After(charWait):
+					t.Fatal("no collection started")
+				}
+
+				// Block every pool worker with an unrelated detection. Exactly
+				// pool-size pairs keep this deterministic: detection i can
+				// only dispatch after validate i completed, so every validate
+				// finds a free slot, and then the detections pin all workers.
+				// Only AFTER that stage the disable: no slot can free before
+				// cancel, and after cancel no worker may start new work - so
+				// its stop phase deterministically never runs.
+				saturate := effectPoolSize
+				for i := range saturate {
+					name := string(rune('a' + i))
+					h.dyncfg("w-add-"+name, []string{h.mgr.dyncfgModID("wedge"), "add", name}, []byte("{}"))
+					h.dyncfg("w-en-"+name, []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("wedge", name)), "enable"}, nil)
+				}
+				for i := range saturate {
+					name := string(rune('a' + i))
+					require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN w-add-"+name), charWait, charTick)
+				}
+				// All validates answered and every pool worker sits in a
+				// blocked detection: no slot can free from here on. (The
+				// remaining detections wait in the pool queue or the
+				// executor's pending list; executor key state is loop-owned
+				// and must not be read from the test goroutine.)
+				require.Eventually(t, func() bool { return detStarted.Load() == int32(effectPoolSize) }, charWait, charTick,
+					"every pool worker must be inside a blocked detection")
+
+				h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+				require.Eventually(t, func() bool { return len(h.mgr.dyncfgCh) == 0 }, charWait, charTick,
+					"the disable must be consumed by the loop (staged as pending)")
+
+				cancel()
+				// Unblock the leaked module calls so cleanup can stop the
+				// still-running job; the disable's 503 was already decided by
+				// the drain, before anything unblocked.
+				close(release)
+				select {
+				case <-done:
+				case <-time.After(charWait):
+					t.Fatal("shutdown did not complete")
+				}
+
+				// The stop NEVER RAN: the disable must answer retryably and
+				// publish nothing - a disabled status would be a lie.
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable 503"), charWait, charTick,
+					"a never-ran disable must answer 503")
+				assert.False(t, h.outputContains("CONFIG test:collector:stuck:s status disabled")(),
+					"no disabled status may be published for a stop that never ran")
+			},
+		},
+		"late detection success during the drain is dropped, never started": {
+			run: func(t *testing.T) {
+				defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+				release := make(chan struct{})
+
+				reg := collectorapi.Registry{}
+				reg.Register("wedge", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								<-release
+								return nil // a SUCCESSFUL late detection
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+				mgr.effectDeadline = testEffectDeadline
+				mgr.drainWait = 2 * time.Second // wide window: the late success arrives DURING the drain
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("wedge"), "add", "w"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("wedge", "w")), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:wedge:w status failed"), charWait, charTick,
+					"the detection must wedge and commit its deadline failure")
+
+				cancel()
+				// The leaked detection succeeds while shutdownDrain is inside
+				// its window: the warm job must be dropped, not started.
+				release <- struct{}{}
+				close(release)
+				select {
+				case <-done:
+				case <-time.After(charWait):
+					t.Fatal("shutdown did not complete")
+				}
+
+				assert.False(t, h.outputContains("CONFIG test:collector:wedge:w status running")(),
+					"shutdown must never start fresh collector work from a late detection success")
+			},
+		},
+		"discovery removal whose stop never ran publishes no delete": {
+			run: func(t *testing.T) {
+				defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+				entered := make(chan struct{}, 1)
+				release := make(chan struct{})
+				var detStarted atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("stuck", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 {
+								select {
+								case entered <- struct{}{}:
+								default:
+								}
+								<-release
+								return map[string]int64{"d1": 1}
+							},
+						}
+					},
+				})
+				reg.Register("wedge", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								detStarted.Add(1)
+								<-release
+								return nil
+							},
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+				mgr.drainWait = 300 * time.Millisecond
+				mgr.effectDeadline = time.Hour // nothing may abandon before shutdown
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				// A discovery-origin config, enabled by the played daemon,
+				// with a collection in flight (so its stop would block).
+				cfg := prepareUserCfg("stuck", "s")
+				h.in <- prepareCfgGroups(cfg.Source(), cfg)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s create accepted"), charWait, charTick)
+				h.dyncfg("1-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+				select {
+				case <-entered:
+				case <-time.After(charWait):
+					t.Fatal("no collection started")
+				}
+
+				// Pin every pool worker (pool-size pairs: deterministic, see
+				// the queued-disable case).
+				for i := range effectPoolSize {
+					name := string(rune('a' + i))
+					h.dyncfg("w-add-"+name, []string{h.mgr.dyncfgModID("wedge"), "add", name}, []byte("{}"))
+					h.dyncfg("w-en-"+name, []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("wedge", name)), "enable"}, nil)
+				}
+				for i := range effectPoolSize {
+					name := string(rune('a' + i))
+					require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN w-add-"+name), charWait, charTick)
+				}
+				require.Eventually(t, func() bool { return detStarted.Load() == int32(effectPoolSize) }, charWait, charTick,
+					"every pool worker must be inside a blocked detection")
+
+				// Remove the config via discovery: its stop phase cannot get
+				// a slot before cancel and may not start after it.
+				h.in <- prepareCfgGroups(cfg.Source())
+				require.Eventually(t, func() bool { return len(h.mgr.rmCh) == 0 }, charWait, charTick,
+					"the removal must be consumed by the loop")
+
+				cancel()
+				close(release)
+				select {
+				case <-done:
+				case <-time.After(charWait):
+					t.Fatal("shutdown did not complete")
+				}
+
+				// The stop never ran: publishing the removal would break
+				// no-output-after-publish for a job that was never stopped.
+				assert.False(t, h.outputContains("CONFIG test:collector:stuck:s delete")(),
+					"no delete may be published for a discovery removal whose stop never ran")
+			},
+		},
+		"commands accepted before shutdown always reach a terminal": {
+			run: func(t *testing.T) {
+				defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+				release := make(chan struct{})
+				var inits atomic.Int32
+
+				reg := collectorapi.Registry{}
+				reg.Register("gated", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								if inits.Add(1) > 1 {
+									<-release // the bridge restart's detection holds the LOOP
+								}
+								return nil
+							},
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService()})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+				mgr.drainWait = 300 * time.Millisecond
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				h.dyncfg("ss-add", []string{mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+					mustJSON(t, map[string]any{"value": "good"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+				h.dyncfg("1-add", []string{mgr.dyncfgModID("gated"), "add", "mysql"},
+					mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+				cfg := prepareDyncfgCfg("gated", "mysql")
+				h.dyncfg("2-enable", []string{mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+				require.Eventually(t, func() bool {
+					return len(mgr.restartableAffectedJobs("vault:vault_prod")) == 1
+				}, charWait, charTick)
+
+				// The store update's inline dependent restart blocks the RUN
+				// LOOP mid-command; commands buffered behind it sit in
+				// dyncfgCh when shutdown starts.
+				h.dyncfg("ss-update", []string{mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+					mustJSON(t, map[string]any{"value": "rotated"}))
+				require.Eventually(t, func() bool { return inits.Load() >= 2 }, charWait, charTick,
+					"the inline restart's detection did not start")
+
+				buffered := 5
+				for i := range buffered {
+					h.dyncfg(fmt.Sprintf("g-%d", i), []string{mgr.dyncfgJobID(cfg), "get"}, nil)
+				}
+
+				cancel()
+				close(release)
+				select {
+				case <-done:
+				case <-time.After(charWait):
+					t.Fatal("shutdown did not complete")
+				}
+
+				// Silence is a bug: the loop-held command finishes, and every
+				// buffered command is either executed or drained with 503.
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update"), charWait, charTick,
+					"the loop-held store update must reach a terminal")
+				for i := range buffered {
+					assert.True(t, h.outputContains(fmt.Sprintf("FUNCTION_RESULT_BEGIN g-%d", i))(),
+						"a command accepted into dyncfgCh must reach a terminal across shutdown")
+				}
+
+				// Post-shutdown commands are rejected up front.
+				h.dyncfg("late", []string{mgr.dyncfgJobID(cfg), "get"}, nil)
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN late 503"), charWait, charTick,
+					"a post-shutdown command must answer 503 immediately")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// TestCallbacks_NoFreshWorkAfterShutdown pins the success-tail shutdown
+// guard: a detection that finishes normally against a shutdown-cancelled
+// context must not start the job - the enable answers retryably (never-ran)
+// and an update fails disruptively, and neither leaves a gate registered.
+func TestCallbacks_NoFreshWorkAfterShutdown(t *testing.T) {
+	newMgr := func(cleanups *atomic.Int32, initFn func(context.Context) error) *Manager {
+		reg := collectorapi.Registry{}
+		reg.Register("quick", collectorapi.Creator{
+			JobConfigSchema: collectorapi.MockConfigSchema,
+			Create: func() collectorapi.CollectorV1 {
+				return &collectorapi.MockCollectorV1{
+					InitFunc: initFn,
+					CleanupFunc: func(context.Context) {
+						if cleanups != nil {
+							cleanups.Add(1)
+						}
+					},
+					ChartsFunc: func() *collectorapi.Charts {
+						return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+					},
+					CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+				}
+			},
+		})
+		var out simOutput
+		mgr := New(Config{PluginName: testPluginName})
+		mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+		mgr.modules = reg
+		mgr.fileStatus = newFileStatus() // Run initializes this; the pin drives callbacks directly
+		return mgr
+	}
+
+	cancelled := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+
+	t.Run("enable answers never-ran and starts nothing", func(t *testing.T) {
+		var cleanups atomic.Int32
+		mgr := newMgr(&cleanups, nil)
+		cfg := prepareDyncfgCfg("quick", "q")
+
+		err := mgr.collectorCallbacks.Start(cancelled(), cfg)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, dyncfg.ErrPhaseNeverRan))
+		mgr.runningJobs.lock()
+		_, running := mgr.runningJobs.lookup(cfg.FullName())
+		mgr.runningJobs.unlock()
+		assert.False(t, running, "shutdown must never start fresh collector work")
+		_, hasGate := mgr.emissionGates.lookup(cfg.FullName())
+		assert.False(t, hasGate, "the unstarted job's gate must be deregistered")
+		assert.Equal(t, int32(1), cleanups.Load(),
+			"a detected-but-never-started module must be cleaned up exactly once")
+	})
+
+	t.Run("interrupted detection answers never-ran, not a failure", func(t *testing.T) {
+		var cleanups atomic.Int32
+		// A ctx-honoring module returns the cancellation as its error.
+		mgr := newMgr(&cleanups, func(ctx context.Context) error { return ctx.Err() })
+		cfg := prepareDyncfgCfg("quick", "q")
+
+		err := mgr.collectorCallbacks.Start(cancelled(), cfg)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, dyncfg.ErrPhaseNeverRan),
+			"a shutdown-interrupted detection is not a detection failure")
+		assert.Equal(t, int32(1), cleanups.Load(),
+			"the module must be cleaned up exactly once (defer + drop paths share the guard)")
+	})
+
+	t.Run("update of a non-running config answers never-ran", func(t *testing.T) {
+		// The old config was never started: the stop is a no-op, nothing is
+		// torn down, so a shutdown interruption must roll back retryably
+		// instead of committing a disruptive failure.
+		mgr := newMgr(nil, nil)
+		oldCfg := prepareDyncfgCfg("quick", "q")
+		newCfg := prepareDyncfgCfg("quick", "q").Set("option_str", "changed")
+
+		err := mgr.collectorCallbacks.Update(cancelled(), oldCfg, newCfg)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, dyncfg.ErrPhaseNeverRan),
+			"a no-op stop tears nothing down - never-ran is the truthful outcome")
+		mgr.runningJobs.lock()
+		_, running := mgr.runningJobs.lookup(newCfg.FullName())
+		mgr.runningJobs.unlock()
+		assert.False(t, running)
+	})
+
+	t.Run("update fails disruptively and starts nothing", func(t *testing.T) {
+		mgr := newMgr(nil, nil)
+		oldCfg := prepareDyncfgCfg("quick", "q")
+		require.NoError(t, mgr.collectorCallbacks.Start(context.Background(), oldCfg))
+
+		newCfg := prepareDyncfgCfg("quick", "q").Set("option_str", "changed")
+		err := mgr.collectorCallbacks.Update(cancelled(), oldCfg, newCfg)
+
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, dyncfg.ErrPhaseNeverRan),
+			"half the update happened (the old instance stopped) - it must fail, not roll back")
+		assert.Contains(t, err.Error(), "shutting down")
+		mgr.runningJobs.lock()
+		_, running := mgr.runningJobs.lookup(newCfg.FullName())
+		mgr.runningJobs.unlock()
+		assert.False(t, running, "shutdown must never start the replacement")
+		_, hasGate := mgr.emissionGates.lookup(newCfg.FullName())
+		assert.False(t, hasGate, "the unstarted replacement's gate must be deregistered")
+	})
+}
+
+// TestWaitUnparkReplayOrder pins same-kind FIFO order across the wait-unpark
+// replay: discovery events must never reorder relative to each other, even
+// when a wait-parked key went busy (an update's validation), collected
+// discovery and decision events in its fifo, and the decision's replay then
+// re-queues wait-parked events while the key is busy again.
+func TestWaitUnparkReplayOrder(t *testing.T) {
+	gate := make(chan struct{})
+	var creates atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			if creates.Add(1) == 1 {
+				<-gate // the update's validation holds the key busy
+			}
+			return &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	var out simOutput
+	mgr := New(Config{PluginName: testPluginName})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		select {
+		case <-gate:
+		default:
+			close(gate)
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	// Discovery config, wait-parked for a decision.
+	cfg := prepareUserCfg("gated", "g")
+	h.in <- prepareCfgGroups(cfg.Source(), cfg)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:g create accepted"), charWait, charTick)
+
+	// A non-decision update executes during the wait; its validation blocks,
+	// so the key is busy AND waiting.
+	h.dyncfg("1-update", []string{mgr.dyncfgJobID(cfg), "update"}, mustJSON(t, map[string]any{"option_str": "x"}))
+	require.Eventually(t, func() bool { return creates.Load() >= 1 }, charWait, charTick,
+		"the update's validation did not start")
+
+	// Arrival order into the busy fifo: discovery REMOVE, then the enable
+	// decision, then discovery re-ADD. Empty same-channel batches fence the
+	// discovery sends (runProcessConfGroups is sequential), and a drained
+	// dyncfgCh fences the enable.
+	h.in <- prepareCfgGroups(cfg.Source()) // A: discovery remove
+	h.in <- prepareCfgGroups("fence-1")
+	h.dyncfg("2-enable", []string{mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, func() bool { return len(mgr.dyncfgCh) == 0 }, charWait, charTick)
+	h.in <- prepareCfgGroups(cfg.Source(), cfg) // B: discovery re-add
+	h.in <- prepareCfgGroups("fence-2")
+
+	// Validation completes: the update answers 403 (Accepted), settle moves
+	// the remove to the wait queue, the enable decision goes busy, and the
+	// replay must put the remove BACK IN FRONT of the re-add.
+	close(gate)
+
+	// Order preserved means: remove runs first (delete), re-add runs last
+	// (the config exists again, accepted). Reordered, the re-add is a no-op
+	// against the running job and the remove then deletes the config for
+	// good - the second create-accepted never appears.
+	require.Eventually(t, func() bool {
+		return strings.Count(h.out.String(), "CONFIG test:collector:gated:g create accepted") >= 2
+	}, charWait, charTick, "discovery events must not reorder across the wait-unpark replay")
+}

--- a/src/go/plugin/agent/jobmgr/effect_test.go
+++ b/src/go/plugin/agent/jobmgr/effect_test.go
@@ -14,15 +14,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Deadline-disabled pin: the effect path applies NO deadline and NO
-// cancellation to detection - a slow detection completes and its job starts.
-// The stage that activates effect deadlines must flip this pin deliberately
-// together with its abandon/late-return semantics, never delete it.
-func TestEffect_DeadlineDisabledPin(t *testing.T) {
+// INVERTED PIN (previously the deadline-disabled pin): detection now runs
+// under the internal effect deadline - the context carries it - and a
+// detection that finishes within the cap starts its job normally with no
+// abandon path fired.
+func TestEffect_DeadlineBehaviorPin(t *testing.T) {
 	tests := map[string]struct {
 		run func(t *testing.T)
 	}{
-		"slow detection sees no deadline, no cancellation, and still starts its job": {
+		"detection under the cap sees the deadline and still starts its job": {
 			run: func(t *testing.T) {
 				var sawDeadline, sawCancel atomic.Bool
 
@@ -35,7 +35,7 @@ func TestEffect_DeadlineDisabledPin(t *testing.T) {
 								if _, ok := ctx.Deadline(); ok {
 									sawDeadline.Store(true)
 								}
-								time.Sleep(500 * time.Millisecond)
+								time.Sleep(300 * time.Millisecond)
 								if ctx.Err() != nil {
 									sawCancel.Store(true)
 								}
@@ -55,9 +55,9 @@ func TestEffect_DeadlineDisabledPin(t *testing.T) {
 				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("slowok", "s")), "enable"}, nil)
 
 				require.Eventually(t, h.outputContains("CONFIG test:collector:slowok:s status running"), charWait, charTick,
-					"slow detection must complete and start the job - no abandon path may fire")
-				assert.False(t, sawDeadline.Load(), "detection effect context must carry no deadline")
-				assert.False(t, sawCancel.Load(), "detection effect context must never be cancelled")
+					"in-deadline detection must complete and start the job")
+				assert.True(t, sawDeadline.Load(), "detection context must carry the effect deadline")
+				assert.False(t, sawCancel.Load(), "an in-deadline detection must not observe cancellation")
 			},
 		},
 	}
@@ -85,22 +85,22 @@ func TestEffect_DoneChannelLoopArms(t *testing.T) {
 					"the run loop stopped serving after draining a completion")
 			},
 		},
-		"wait-mode select drains a completion and keeps serving dyncfg": {
+		"stray completion with a wait-parked key neither wedges nor unparks": {
 			run: func(t *testing.T, h *charHarness) {
 				cfg := prepareUserCfg("success", "waity")
 				h.in <- prepareCfgGroups(cfg.Source(), cfg)
-				require.Eventually(t, func() bool { return h.mgr.collectorHandler.WaitingForDecision() }, charWait, charTick)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:waity create accepted"), charWait, charTick)
 
 				h.mgr.effectDoneCh <- effectResult{key: "stray"}
 
 				require.Eventually(t, func() bool { return len(h.mgr.effectDoneCh) == 0 }, charWait, charTick,
-					"the wait-mode select did not drain the effect completion")
+					"the run loop did not drain the effect completion")
 
 				h.dyncfg("after-wait-drain", []string{h.mgr.dyncfgJobID(cfg), "update"}, []byte("{}"))
 				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN after-wait-drain"), charWait, charTick,
-					"wait mode stopped serving dyncfg after draining a completion")
-				assert.True(t, h.mgr.collectorHandler.WaitingForDecision(),
-					"a stray completion must not clear the wait gate")
+					"the loop stopped serving dyncfg after draining a completion")
+				assert.False(t, h.outputContains("CONFIG test:collector:success:waity status running")(),
+					"a stray completion must not unpark a waiting key")
 			},
 		},
 	}

--- a/src/go/plugin/agent/jobmgr/emission_gateway.go
+++ b/src/go/plugin/agent/jobmgr/emission_gateway.go
@@ -20,22 +20,30 @@ type emissionGateway struct {
 	out        io.Writer
 	closed     bool
 	suppressed int
+	// onSuppressed, when set, is called (outside the lock) for every
+	// swallowed write so the executor metrics can count them fleet-wide.
+	onSuppressed func()
 }
 
-func newEmissionGateway(out io.Writer) *emissionGateway {
+func newEmissionGateway(out io.Writer, onSuppressed func()) *emissionGateway {
 	if out == nil {
 		out = io.Discard
 	}
-	return &emissionGateway{out: out}
+	return &emissionGateway{out: out, onSuppressed: onSuppressed}
 }
 
 func (g *emissionGateway) Write(p []byte) (int, error) {
 	g.mu.Lock()
-	defer g.mu.Unlock()
 	if g.closed {
 		g.suppressed++
+		hook := g.onSuppressed
+		g.mu.Unlock()
+		if hook != nil {
+			hook()
+		}
 		return len(p), nil
 	}
+	defer g.mu.Unlock()
 	return g.out.Write(p)
 }
 
@@ -79,6 +87,20 @@ func (s *emissionGates) remove(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.items, name)
+}
+
+// removeMatching removes the entry only when it still holds the given gate:
+// drop paths that run later on the loop must never evict a same-name
+// replacement's gate.
+func (s *emissionGates) removeMatching(name string, gate *emissionGateway) {
+	if gate == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.items[name] == gate {
+		delete(s.items, name)
+	}
 }
 
 func (s *emissionGates) lookup(name string) (*emissionGateway, bool) {

--- a/src/go/plugin/agent/jobmgr/emission_gateway_test.go
+++ b/src/go/plugin/agent/jobmgr/emission_gateway_test.go
@@ -4,6 +4,7 @@ package jobmgr
 
 import (
 	"bytes"
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -39,7 +40,7 @@ func TestEmissionGateway(t *testing.T) {
 		"open gate passes writes through": {
 			run: func(t *testing.T) {
 				var buf bytes.Buffer
-				gate := newEmissionGateway(&buf)
+				gate := newEmissionGateway(&buf, nil)
 
 				n, err := gate.Write([]byte("payload"))
 
@@ -52,7 +53,7 @@ func TestEmissionGateway(t *testing.T) {
 		"closed gate suppresses and counts writes": {
 			run: func(t *testing.T) {
 				var buf bytes.Buffer
-				gate := newEmissionGateway(&buf)
+				gate := newEmissionGateway(&buf, nil)
 
 				gate.Close()
 				n, err := gate.Write([]byte("late"))
@@ -66,7 +67,7 @@ func TestEmissionGateway(t *testing.T) {
 		"close waits out an in-flight write": {
 			run: func(t *testing.T) {
 				w := &blockingTestWriter{started: make(chan struct{}), release: make(chan struct{})}
-				gate := newEmissionGateway(w)
+				gate := newEmissionGateway(w, nil)
 
 				writeDone := make(chan struct{})
 				go func() {
@@ -107,14 +108,14 @@ func TestEmissionGateway(t *testing.T) {
 				mgr := newCollectorTestManager()
 				cfg := prepareDyncfgCfg("success", "gw")
 
-				job, err := mgr.createCollectorJob(cfg)
+				job, err := mgr.createCollectorJob(context.Background(), cfg)
 				require.NoError(t, err)
 				gate, tracked := mgr.emissionGates.lookup(cfg.FullName())
 				require.True(t, tracked, "creation must register the job's gateway")
 				require.NotNil(t, gate)
 
 				mgr.startRunningJob(job)
-				mgr.stopRunningJob(cfg.FullName())
+				mgr.stopRunningJob(context.Background(), cfg.FullName())
 				_, tracked = mgr.emissionGates.lookup(cfg.FullName())
 				assert.False(t, tracked, "gateway tracking must end when the job stops")
 			},
@@ -124,7 +125,7 @@ func TestEmissionGateway(t *testing.T) {
 				mgr := newCollectorTestManager()
 				cfg := prepareDyncfgCfg("success", "gw-badcfg").Set("vnode", "no-such-vnode")
 
-				_, err := mgr.createCollectorJob(cfg)
+				_, err := mgr.createCollectorJob(context.Background(), cfg)
 
 				require.Error(t, err)
 				_, tracked := mgr.emissionGates.lookup(cfg.FullName())
@@ -137,7 +138,7 @@ func TestEmissionGateway(t *testing.T) {
 				cb := &collectorCallbacks{mgr: mgr}
 				cfg := prepareDyncfgCfg("fail", "gw-detect")
 
-				err := cb.Start(cfg)
+				err := cb.Start(context.Background(), cfg)
 
 				require.Error(t, err)
 				_, tracked := mgr.emissionGates.lookup(cfg.FullName())
@@ -149,11 +150,11 @@ func TestEmissionGateway(t *testing.T) {
 				mgr := newCollectorTestManager()
 				cfg := prepareDyncfgCfg("success", "gw-replace")
 
-				oldJob, err := mgr.createCollectorJob(cfg)
+				oldJob, err := mgr.createCollectorJob(context.Background(), cfg)
 				require.NoError(t, err)
 				mgr.startRunningJob(oldJob)
 
-				newJob, err := mgr.createCollectorJob(cfg)
+				newJob, err := mgr.createCollectorJob(context.Background(), cfg)
 				require.NoError(t, err)
 				newGate, tracked := mgr.emissionGates.lookup(cfg.FullName())
 				require.True(t, tracked)
@@ -161,7 +162,7 @@ func TestEmissionGateway(t *testing.T) {
 				// The defensive stop inside startRunningJob replaces the old
 				// same-name job; the new job's gate must survive it.
 				mgr.startRunningJob(newJob)
-				t.Cleanup(func() { mgr.stopRunningJob(cfg.FullName()) })
+				t.Cleanup(func() { mgr.stopRunningJob(context.Background(), cfg.FullName()) })
 
 				gate, tracked := mgr.emissionGates.lookup(cfg.FullName())
 				require.True(t, tracked, "replacement dropped the new job's gateway tracking")
@@ -173,7 +174,7 @@ func TestEmissionGateway(t *testing.T) {
 				mgr := newCollectorTestManager()
 				cfg := prepareDyncfgCfg("success", "gw-validate")
 
-				require.NoError(t, mgr.validateCollectorJob(cfg))
+				require.NoError(t, mgr.validateCollectorJob(context.Background(), cfg))
 
 				_, tracked := mgr.emissionGates.lookup(cfg.FullName())
 				assert.False(t, tracked, "validation-only creation must not register a gateway")

--- a/src/go/plugin/agent/jobmgr/executor.go
+++ b/src/go/plugin/agent/jobmgr/executor.go
@@ -3,22 +3,30 @@
 package jobmgr
 
 import (
+	"context"
 	"strings"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
 )
 
 // The executor is the single dispatch seam between the run loop and the
 // command handlers: every discovery and dyncfg event is classified into an
-// event (kind, domain, derived key) and executed through dispatch, so
-// execution policy can change without touching the handlers or the loop's
-// select structure.
+// event (kind, domain, derived key) and executed through dispatch.
 //
-// The current policy is one global lane: dispatch runs every event inline on
-// the caller goroutine, with no queuing, preserving the run loop's serialized
-// semantics. The derived key identifies the config an event addresses and is
-// inert routing metadata under this policy.
+// Collector-domain events run under PER-KEY lanes: each key is idle, busy
+// (a blocking phase in flight on the effect pool), or wait-parked (a
+// discovered config awaiting its enable/disable decision). While a key is
+// busy ALL of its events park in arrival order; while it is wait-parked only
+// discovery events park - inbound dyncfg commands execute immediately with
+// the state machine's outcomes, and an enable/disable decision unparks the
+// key. Events for different keys never wait on each other. Commits always
+// run on the run-loop goroutine; blocking work runs on the pool.
+//
+// Secretstore and vnode commands stay loop-synchronous: their domains are
+// not on the executor lanes and their keys never go busy.
 
 type eventKind int8
 
@@ -47,32 +55,595 @@ type event struct {
 	fn     dyncfg.Function
 }
 
+// effectPoolSize bounds concurrently executing blocking phases. Internal
+// constant by design.
+const effectPoolSize = 4
+
+// keyState is the loop-owned lane state of one key.
+type keyState struct {
+	busy          bool
+	wedged        bool
+	waiting       bool
+	generation    uint64
+	wedgedGen     uint64
+	fifo          []event
+	waitFIFO      []event
+	pendingCommit func(error)
+	afterIdle     []func()
+	firstParkedAt time.Time
+	waitSince     time.Time
+}
+
+func (ks *keyState) empty() bool {
+	return !ks.busy && !ks.wedged && !ks.waiting && ks.pendingCommit == nil &&
+		len(ks.fifo) == 0 && len(ks.waitFIFO) == 0 && len(ks.afterIdle) == 0
+}
+
+// effectTask is one blocking phase handed to the effect pool.
+type effectTask struct {
+	key    string
+	effect func(ctx context.Context) error
+}
+
 type executor struct {
-	mgr *Manager
+	mgr      *Manager
+	keys     map[string]*keyState
+	inflight int
+	// pending holds effect tasks awaiting a pool slot: dispatch NEVER blocks
+	// the loop (it must keep draining dyncfgCh and completions even with the
+	// pool saturated); completions flush this queue.
+	pending []effectTask
+	// draining flips at shutdown: chained blocking phases then run inline so
+	// pending commits complete without pool workers.
+	draining bool
 }
 
 func newExecutor(mgr *Manager) *executor {
-	return &executor{mgr: mgr}
+	return &executor{mgr: mgr, keys: make(map[string]*keyState)}
 }
 
-// dispatch executes ev synchronously on the caller goroutine.
+// stateKey namespaces lane state by domain so key strings from different
+// domains can never collide.
+func (ev event) stateKey() string {
+	return string('0'+byte(ev.domain)) + "|" + ev.key
+}
+
+// dispatch routes ev into its key's lane on the run-loop goroutine.
 func (e *executor) dispatch(ev event) {
+	if ev.kind == eventDyncfgCommand && ev.domain != domainCollector {
+		e.dispatchDyncfg(ev)
+		return
+	}
+	if ev.kind == eventDyncfgCommand && ev.fn.Command() == dyncfg.CommandTest {
+		// Collector test is KEYLESS by contract: it runs in its own capped
+		// off-loop pool and must never park behind a busy key (a wedged
+		// 120s detection would block an interactive test).
+		e.mgr.dyncfgCmdTest(ev.fn)
+		return
+	}
+	sk := ev.stateKey()
+	ks := e.keys[sk]
+	if ks == nil {
+		ks = &keyState{}
+		e.keys[sk] = ks
+	}
+	e.route(sk, ks, ev)
+	e.maybeDelete(sk, ks)
+	e.observeState()
+}
+
+func (e *executor) route(sk string, ks *keyState, ev event) {
+	if ks.busy {
+		if len(ks.fifo) == 0 {
+			ks.firstParkedAt = time.Now()
+		}
+		ks.fifo = append(ks.fifo, ev)
+		e.observePark()
+		return
+	}
+	if ks.waiting {
+		if ev.kind != eventDyncfgCommand {
+			if len(ks.waitFIFO) == 0 && len(ks.fifo) == 0 {
+				ks.firstParkedAt = time.Now()
+			}
+			ks.waitFIFO = append(ks.waitFIFO, ev)
+			e.observePark()
+			return
+		}
+		if cmd := ev.fn.Command(); cmd == dyncfg.CommandEnable || cmd == dyncfg.CommandDisable {
+			// The decision unparks the key: it executes first, then the
+			// wait-parked events replay. Wait-parked events always arrived
+			// BEFORE anything still sitting in the fifo (settle moves them
+			// out of earlier fifo positions, and nothing arrives mid-execute
+			// on the single loop goroutine), so once the key goes busy the
+			// remainder must re-enter AT THE FRONT of the fifo - appending
+			// would reorder same-kind events (discovery B before A).
+			ks.waiting = false
+			ks.waitSince = time.Time{}
+			e.execute(sk, ks, ev)
+			parked := ks.waitFIFO
+			ks.waitFIFO = nil
+			for i, pev := range parked {
+				if ks.busy {
+					rest := append([]event(nil), parked[i:]...)
+					ks.fifo = append(rest, ks.fifo...)
+					if ks.firstParkedAt.IsZero() {
+						ks.firstParkedAt = time.Now()
+					}
+					return
+				}
+				e.route(sk, ks, pev)
+			}
+			return
+		}
+		// Non-decision dyncfg commands never wait-park: they execute
+		// immediately with the state machine's outcomes.
+		e.execute(sk, ks, ev)
+		return
+	}
+	e.execute(sk, ks, ev)
+}
+
+func (e *executor) execute(sk string, ks *keyState, ev event) {
 	switch ev.kind {
 	case eventDiscoveryAdd:
-		e.mgr.addConfig(ev.cfg)
+		e.mgr.stagedAddConfig(ev.cfg, e.runnerFor(sk), func() {
+			ks.waiting = true
+			ks.waitSince = time.Now()
+		}, func(fn dyncfg.Function) {
+			e.dispatch(e.mgr.newDyncfgEvent(fn))
+		})
 	case eventDiscoveryRemove:
-		e.mgr.removeConfig(ev.cfg)
+		e.mgr.stagedRemoveConfig(ev.cfg, e.runnerFor(sk))
 	case eventDyncfgCommand:
-		e.dispatchDyncfg(ev)
+		e.executeCollectorCommand(sk, ks, ev.fn)
 	}
+}
+
+func (e *executor) executeCollectorCommand(sk string, ks *keyState, fn dyncfg.Function) {
+	m := e.mgr
+	// jobmgr no longer arms the shared handler's wait gate (waiting lives on
+	// the key lanes); SyncDecision on an unarmed gate is a no-op and stays
+	// for code parity with the service-discovery consumer.
+	m.collectorHandler.SyncDecision(fn)
+
+	run := e.runnerFor(sk)
+	switch cmd := fn.Command(); cmd {
+	case dyncfg.CommandAdd:
+		m.collectorHandler.CmdAddStep(fn, run)
+		e.afterIdleHook(ks, func() { m.syncSecretStoreDepsByFunction(fn) })
+	case dyncfg.CommandUpdate:
+		m.collectorHandler.CmdUpdateStep(fn, run)
+		e.afterIdleHook(ks, func() { m.syncSecretStoreDepsByFunction(fn) })
+	case dyncfg.CommandRemove:
+		m.collectorHandler.CmdRemoveStep(fn, run)
+		e.afterIdleHook(ks, func() { m.syncSecretStoreDepsByFunction(fn) })
+	case dyncfg.CommandEnable:
+		m.collectorHandler.CmdEnableStep(fn, run)
+	case dyncfg.CommandDisable:
+		m.collectorHandler.CmdDisableStep(fn, run)
+	case dyncfg.CommandRestart:
+		m.collectorHandler.CmdRestartStep(fn, run)
+	case dyncfg.CommandSchema:
+		m.dyncfgCmdSchema(fn)
+	case dyncfg.CommandGet:
+		m.dyncfgCmdGet(fn)
+	default:
+		m.Warningf("dyncfg: function '%s' command '%s' not implemented", fn.Fn().Name, cmd)
+		m.dyncfgResponder.SendCodef(fn, 501, "Function '%s' command '%s' is not implemented.", fn.Fn().Name, cmd)
+	}
+}
+
+// afterIdleHook runs h when the key's current command fully settles (all
+// chained phases committed); immediately when it never went busy.
+func (e *executor) afterIdleHook(ks *keyState, h func()) {
+	if ks.busy {
+		ks.afterIdle = append(ks.afterIdle, h)
+		return
+	}
+	h()
+}
+
+// runnerFor is the executor's asynchronous StepRunner: it marks the key
+// busy, ships the blocking phase to the pool, and resumes the commit on the
+// run loop when the completion arrives. During shutdown drain it degrades to
+// inline execution.
+func (e *executor) runnerFor(sk string) dyncfg.StepRunner {
+	return func(effect func(context.Context) error, commit func(error)) {
+		if e.draining {
+			// Shutdown starts no new blocking phases: a chained phase during
+			// the drain is refused with the never-ran outcome (stop-shaped
+			// commits answer 503 instead of publishing untruthful state).
+			commit(dyncfg.ErrPhaseNeverRan)
+			return
+		}
+		ks := e.keys[sk]
+		if ks.wedged {
+			// Reachable when a commit chains a phase after its own stop was
+			// abandoned: the key is held by the leaked call, so the chained
+			// phase never runs (never-ran keeps the commit truthful).
+			e.mgr.Warningf("refusing chained phase on wedged key '%s'", sk)
+			commit(dyncfg.ErrPhaseNeverRan)
+			return
+		}
+		ks.busy = true
+		ks.pendingCommit = commit
+		e.inflight++
+		if mx := e.mgr.executorMetrics; mx != nil {
+			mx.effectsStarted.Add(1)
+		}
+		e.dispatchEffect(effectTask{key: sk, effect: effect})
+	}
+}
+
+// dispatchEffect hands a task to the pool WITHOUT EVER BLOCKING: tasks
+// enter the executor's pending queue and move to free pool slots here and
+// as completions arrive. The loop therefore always keeps draining dyncfgCh,
+// discovery, and completions regardless of pool pressure, and a later
+// dispatch never overtakes an earlier one parked against a full pool.
+func (e *executor) dispatchEffect(t effectTask) {
+	e.pending = append(e.pending, t)
+	e.flushPendingEffects()
+}
+
+// flushPendingEffects moves parked tasks to freed pool slots.
+func (e *executor) flushPendingEffects() {
+	for len(e.pending) > 0 {
+		select {
+		case e.mgr.effectCh <- e.pending[0]:
+			e.pending = e.pending[1:]
+		default:
+			return
+		}
+	}
+}
+
+// failPendingPhase commits the never-ran outcome for a phase that could not
+// be dispatched or executed (shutdown).
+func (e *executor) failPendingPhase(sk string) {
+	ks := e.keys[sk]
+	if ks == nil || ks.pendingCommit == nil {
+		return
+	}
+	commit := ks.pendingCommit
+	ks.pendingCommit = nil
+	ks.busy = false
+	e.inflight--
+	commit(dyncfg.ErrPhaseNeverRan)
+}
+
+// onEffectDone resumes a completed blocking phase's commit on the run loop.
+func (e *executor) onEffectDone(res effectResult) {
+	ks := e.keys[res.key]
+	if res.late {
+		e.onLateReturn(res, ks)
+		return
+	}
+	if ks == nil || !ks.busy || ks.pendingCommit == nil {
+		e.mgr.Errorf("BUG: stray effect completion for key '%s' (err: %v)", res.key, res.err)
+		return
+	}
+	commit := ks.pendingCommit
+	ks.pendingCommit = nil
+	e.inflight--
+	if mx := e.mgr.executorMetrics; mx != nil && res.busyFor > 0 {
+		mx.effectBusySeconds.Add(res.busyFor.Seconds())
+	}
+	if res.abandoned {
+		// The deadline outcome commits now, but the key stays busy (wedged)
+		// until the leaked module call returns. No retry and no follow-up
+		// work is scheduled here; the late outcome decides.
+		ks.wedged = true
+		commit(res.err)
+		ks.generation++
+		ks.wedgedGen = ks.generation
+		e.flushPendingEffects()
+		e.observeState()
+		return
+	}
+	ks.busy = false
+	commit(res.err) // may chain the next phase, re-marking the key busy
+	ks.generation++
+	e.settle(res.key, ks)
+	e.maybeDelete(res.key, ks)
+	e.flushPendingEffects()
+	e.observeState()
+}
+
+// onLateReturn unwedges a key whose abandoned effect finally returned. A
+// warm detection success starts through the normal start path when the
+// continuation is still valid (nothing committed on the key since the
+// abandon - structurally guaranteed while wedged, asserted here); anything
+// else was already handled by the late protocol inside the closure.
+func (e *executor) onLateReturn(res effectResult, ks *keyState) {
+	if ks == nil || !ks.wedged {
+		e.mgr.Errorf("BUG: late completion for a key that is not wedged ('%s')", res.key)
+		if res.resume != nil {
+			e.dropWarmResume(res.resume)
+		}
+		return
+	}
+	ks.wedged = false
+	ks.busy = false
+	e.mgr.Infof("abandoned operation for key '%s' returned (err: %v)", res.key, res.err)
+
+	if res.resume != nil {
+		switch {
+		case e.draining:
+			// Shutdown never starts fresh collector work: a warm job that
+			// arrives during the drain is dropped, not resumed (no late
+			// re-enables and no running publish after shutdown began).
+			e.mgr.Infof("dropping late detection success for key '%s': shutting down", res.key)
+			e.dropWarmResume(res.resume)
+		case ks.generation != ks.wedgedGen:
+			if mx := e.mgr.executorMetrics; mx != nil {
+				mx.staleCommits.Add(1)
+			}
+			e.mgr.Warningf("dropping late detection success for key '%s': config changed during operation", res.key)
+			e.dropWarmResume(res.resume)
+		case keyFIFOHasStopIntent(ks):
+			// A disable/remove is already queued behind the wedge: the user's
+			// intent wins over the continuation - the warm job is dropped and
+			// the queued command executes against the failed entry.
+			e.mgr.Infof("dropping late detection success for key '%s': a stop command is queued", res.key)
+			e.dropWarmResume(res.resume)
+		default:
+			e.mgr.resumeWarmJob(res.resume)
+			ks.generation++
+		}
+	}
+	e.settle(res.key, ks)
+	e.maybeDelete(res.key, ks)
+	e.observeState()
+}
+
+// dropWarmResume disposes a warm job that will never start: module cleanup
+// plus deregistering its own emission gate (matched by handle - a same-name
+// replacement's gate must survive).
+func (e *executor) dropWarmResume(r *warmResume) {
+	r.job.Cleanup()
+	e.mgr.emissionGates.removeMatching(r.cfg.FullName(), r.gate)
+}
+
+// settle drains a key's after-idle hooks and parked events until the key
+// goes busy again or nothing is left.
+func (e *executor) settle(sk string, ks *keyState) {
+	for !ks.busy {
+		if len(ks.afterIdle) > 0 {
+			hooks := ks.afterIdle
+			ks.afterIdle = nil
+			for _, h := range hooks {
+				h()
+			}
+			continue
+		}
+		if len(ks.fifo) == 0 {
+			return
+		}
+		ev := ks.fifo[0]
+		ks.fifo = ks.fifo[1:]
+		if len(ks.fifo) == 0 {
+			ks.firstParkedAt = time.Time{}
+		}
+		// Remaining events keep the popped event's timestamp: overstating the
+		// oldest parked age is the safe direction for an aging alarm.
+		e.route(sk, ks, ev)
+	}
+}
+
+func keyFIFOHasStopIntent(ks *keyState) bool {
+	for _, ev := range ks.fifo {
+		switch ev.kind {
+		case eventDiscoveryRemove:
+			// The config is going away: starting the warm job would be a
+			// transient start immediately torn down by the queued removal.
+			return true
+		case eventDyncfgCommand:
+			if cmd := ev.fn.Command(); cmd == dyncfg.CommandDisable || cmd == dyncfg.CommandRemove {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (e *executor) maybeDelete(sk string, ks *keyState) {
+	if ks.empty() {
+		delete(e.keys, sk)
+	}
+}
+
+func (e *executor) busyCount() int {
+	n := 0
+	for _, ks := range e.keys {
+		if ks.busy || ks.wedged {
+			n++
+		}
+	}
+	return n
+}
+
+// shutdownDrain waits out in-flight blocking phases (running their commits,
+// with chained phases inline) for a bounded window, then answers every still
+// parked dyncfg command with 503.
+func (e *executor) shutdownDrain() {
+	e.draining = true
+	defer close(e.mgr.lateDrop)
+
+	// Commands the handoff accepted into dyncfgCh before cancellation would
+	// otherwise be stranded unread (the run loop has exited): answer them
+	// retryably. A send racing cancellation itself can still land after this
+	// drain; the functions layer's shutdown force-finalize is the terminal
+	// backstop for that window.
+	for {
+		select {
+		case fn := <-e.mgr.dyncfgCh:
+			e.mgr.dyncfgResponder.SendCodef(fn, 503, dyncfgShuttingDownMsg)
+			if mx := e.mgr.executorMetrics; mx != nil {
+				mx.shutdownRejected.Add(1)
+			}
+		default:
+			goto dyncfgDrained
+		}
+	}
+dyncfgDrained:
+
+	// Workers exit on shutdown, so parked and queued-but-unpicked effects
+	// would leave their commands without a terminal outcome: fail their
+	// commits with the never-ran outcome (stop-shaped commits answer 503
+	// rather than publish state for stops that never happened).
+	for _, t := range e.pending {
+		e.failPendingPhase(t.key)
+	}
+	e.pending = nil
+	for {
+		select {
+		case t := <-e.mgr.effectCh:
+			e.failPendingPhase(t.key)
+		default:
+			goto drained
+		}
+	}
+drained:
+
+	deadline := time.NewTimer(e.mgr.drainWait)
+	defer deadline.Stop()
+	for e.busyCount() > 0 {
+		select {
+		case res := <-e.mgr.effectDoneCh:
+			e.onEffectDone(res)
+		case <-deadline.C:
+			e.mgr.Warningf("executor: timeout waiting %s for in-flight effects to drain", e.mgr.drainWait)
+			goto force
+		}
+	}
+force:
+	for sk, ks := range e.keys {
+		// A result that never arrived (or was dropped against a full channel
+		// after the window expired) must not leave its command silent: fail
+		// the still-pending commit with the never-ran outcome.
+		e.failPendingPhase(sk)
+		parked := append(append([]event(nil), ks.fifo...), ks.waitFIFO...)
+		ks.fifo, ks.waitFIFO = nil, nil
+		for _, ev := range parked {
+			if ev.kind == eventDyncfgCommand {
+				e.mgr.dyncfgResponder.SendCodef(ev.fn, 503, dyncfgShuttingDownMsg)
+				if mx := e.mgr.executorMetrics; mx != nil {
+					mx.shutdownRejected.Add(1)
+				}
+			}
+		}
+	}
+
+	// The bounded drain is over: account for abandoned module calls that
+	// still have not returned - their goroutines stay leaked by design
+	// (deadline-ignoring collector calls cannot be cancelled) and their late
+	// completions will be dropped via lateDrop.
+	if n := e.mgr.leakedNow.Load(); n > 0 {
+		e.mgr.Warningf("executor: %d abandoned collector call(s) still running at shutdown (leaked)", n)
+	}
+}
+
+// collectorStateKey is the lane-state key for a collector config key.
+func collectorStateKey(key string) string {
+	return event{domain: domainCollector, key: key}.stateKey()
+}
+
+// collectorKeyHasWork reports whether the collector key has a blocking
+// phase in flight (busy or wedged). Wait-parking is NOT work: a config
+// awaiting its enable/disable decision has no job and no resolved secret,
+// so store rotations must keep ignoring it. Loop-owned state: call only on
+// the run-loop goroutine.
+func (e *executor) collectorKeyHasWork(key string) bool {
+	ks := e.keys[collectorStateKey(key)]
+	return ks != nil && (ks.busy || ks.wedged)
+}
+
+// tryLockIdleKey claims a collector key for a LOOP-SYNCHRONOUS inline
+// operation (the secretstore dependent-restart bridge). It succeeds only for
+// a fully idle key - any in-flight effect, wedge, wait-park, or parked work
+// means the caller must skip, never wait: effect completions arrive via this
+// same loop, so waiting here would self-deadlock.
+func (e *executor) tryLockIdleKey(sk string) bool {
+	ks := e.keys[sk]
+	if ks == nil {
+		ks = &keyState{}
+		e.keys[sk] = ks
+	}
+	if !ks.empty() {
+		return false
+	}
+	ks.busy = true
+	e.observeState()
+	return true
+}
+
+// unlockIdleKey releases a tryLockIdleKey claim and drains anything that
+// parked behind it meanwhile.
+func (e *executor) unlockIdleKey(sk string) {
+	ks := e.keys[sk]
+	if ks == nil || !ks.busy {
+		e.mgr.Errorf("BUG: unlock of a key that is not held ('%s')", sk)
+		return
+	}
+	ks.busy = false
+	e.settle(sk, ks)
+	e.maybeDelete(sk, ks)
+	e.observeState()
+}
+
+// observePark counts one parked event.
+func (e *executor) observePark() {
+	if mx := e.mgr.executorMetrics; mx != nil {
+		mx.parkedTotal.Add(1)
+	}
+}
+
+// observeState recomputes the aggregate lane gauges and the oldest-age
+// atomics after a state transition. Runs on the loop; O(active keys).
+func (e *executor) observeState() {
+	mx := e.mgr.executorMetrics
+	if mx == nil {
+		return
+	}
+	var busy, waiting, parked int
+	var oldestParked, oldestWait time.Time
+	for _, ks := range e.keys {
+		if ks.busy {
+			busy++
+		}
+		if ks.waiting {
+			waiting++
+			if oldestWait.IsZero() || ks.waitSince.Before(oldestWait) {
+				oldestWait = ks.waitSince
+			}
+		}
+		parked += len(ks.fifo) + len(ks.waitFIFO)
+		if len(ks.fifo)+len(ks.waitFIFO) > 0 && !ks.firstParkedAt.IsZero() &&
+			(oldestParked.IsZero() || ks.firstParkedAt.Before(oldestParked)) {
+			oldestParked = ks.firstParkedAt
+		}
+	}
+	mx.busyKeys.Set(float64(busy))
+	mx.waitParkedKeys.Set(float64(waiting))
+	mx.parkedEvents.Set(float64(parked))
+	mx.poolInflight.Set(float64(e.inflight))
+	mx.poolQueued.Set(float64(len(e.pending) + len(e.mgr.effectCh)))
+	mx.oldestParkedSince.Store(unixNanosOrZero(oldestParked))
+	mx.oldestWaitSince.Store(unixNanosOrZero(oldestWait))
+}
+
+func unixNanosOrZero(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
 }
 
 func (e *executor) dispatchDyncfg(ev event) {
 	switch ev.domain {
 	case domainSecretStore:
 		e.mgr.dyncfgSecretStoreSeqExec(ev.fn)
-	case domainCollector:
-		e.mgr.dyncfgCollectorSeqExec(ev.fn)
 	case domainVnode:
 		e.mgr.dyncfgVnodeSeqExec(ev.fn)
 	default:
@@ -138,4 +709,56 @@ func (m *Manager) dyncfgFallbackKey(domain eventDomain) string {
 	default:
 		return ""
 	}
+}
+
+// laneDeriverRegistry is the optional lane-narrowing capability of the
+// functions registry (satisfied by the functions manager; registries without
+// it keep one lane per prefix registration).
+type laneDeriverRegistry interface {
+	RegisterPrefixLaneDeriver(name, prefix string, derive functions.LaneKeyDeriver)
+}
+
+// registerDyncfgLaneDerivers narrows the functions schedule lanes for the
+// dyncfg prefixes to the config identity each command addresses, using the
+// same silent key derivation the executor uses for its events. Underivable
+// requests keep the registration-wide lane and still reach the handlers'
+// rejection paths. Derivers run on the functions manager goroutine: they only
+// read state that is immutable after startup (module registry, controller
+// prefixes) or internally synchronized.
+func (m *Manager) registerDyncfgLaneDerivers() {
+	reg, ok := m.fnReg.(laneDeriverRegistry)
+	if !ok {
+		return
+	}
+	reg.RegisterPrefixLaneDeriver("config", m.dyncfgCollectorPrefixValue(), func(fn functions.Function) (string, any) {
+		dfn := dyncfg.NewFunction(fn)
+		if dfn.Command() == dyncfg.CommandTest {
+			// Test is keyless END-TO-END and for EVERY ID form (job-level
+			// and template-level): a unique lane per request keeps it from
+			// serializing behind the config's mutating lane (held until that
+			// command's terminal), other tests, or the registration-wide
+			// fallback lane; concurrency is capped by the test pool's
+			// cap-and-503 instead.
+			return "test|" + fn.UID, nil
+		}
+		key, _, _, ok := m.collectorCommandKey(dfn)
+		if !ok {
+			return "", nil
+		}
+		return key, nil
+	})
+	reg.RegisterPrefixLaneDeriver("config", m.dyncfgSecretStorePrefixValue(), func(fn functions.Function) (string, any) {
+		key, ok := m.secretsCtl.DeriveKey(dyncfg.NewFunction(fn))
+		if !ok {
+			return "", nil
+		}
+		return key, nil
+	})
+	reg.RegisterPrefixLaneDeriver("config", m.dyncfgVnodePrefixValue(), func(fn functions.Function) (string, any) {
+		key, ok := m.vnodesCtl.DeriveKey(dyncfg.NewFunction(fn))
+		if !ok {
+			return "", nil
+		}
+		return key, nil
+	})
 }

--- a/src/go/plugin/agent/jobmgr/executor_metrics.go
+++ b/src/go/plugin/agent/jobmgr/executor_metrics.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/runtimecomp"
+)
+
+const (
+	executorRuntimeMetricPrefix  = "netdata.go.plugin.agent.jobmgr.executor"
+	executorRuntimeComponentName = "jobmgr.executor"
+	executorRuntimeProducerName  = "jobmgr.executor.ages"
+)
+
+// executorRuntimeMetrics exposes the executor's lane and pool state. Gauges
+// and counters are written from the run loop (and pool workers for effect
+// accounting); the age gauges are computed by a runtimecomp producer tick
+// from atomics the loop maintains, so the ticker never reads loop-owned
+// state.
+type executorRuntimeMetrics struct {
+	busyKeys       metrix.StatefulGauge
+	waitParkedKeys metrix.StatefulGauge
+	parkedEvents   metrix.StatefulGauge
+	poolInflight   metrix.StatefulGauge
+	poolQueued     metrix.StatefulGauge
+
+	oldestParkedAge metrix.StatefulGauge
+	oldestWaitAge   metrix.StatefulGauge
+
+	effectsStarted       metrix.StatefulCounter
+	effectPanics         metrix.StatefulCounter
+	parkedTotal          metrix.StatefulCounter
+	shutdownRejected     metrix.StatefulCounter
+	leakedEffects        metrix.StatefulCounter
+	wedgedKeys           metrix.StatefulCounter
+	staleCommits         metrix.StatefulCounter
+	effectBusySeconds    metrix.StatefulCounter
+	suppressedLateOutput metrix.StatefulCounter
+	barrierWaitSeconds   metrix.StatefulCounter
+
+	// Unix nanos of the oldest currently parked event / wait-parked key;
+	// 0 when none. Written on the run loop, read by the producer tick.
+	oldestParkedSince atomic.Int64
+	oldestWaitSince   atomic.Int64
+}
+
+func newExecutorRuntimeMetrics(store metrix.RuntimeStore) *executorRuntimeMetrics {
+	if store == nil {
+		return nil
+	}
+
+	meter := store.Write().StatefulMeter(executorRuntimeMetricPrefix)
+	return &executorRuntimeMetrics{
+		busyKeys: metrix.SeededGauge(meter, "busy_keys",
+			metrix.WithDescription("Keys with a blocking phase in flight"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("keys"),
+		),
+		waitParkedKeys: metrix.SeededGauge(meter, "wait_parked_keys",
+			metrix.WithDescription("Keys parked awaiting an enable/disable decision"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("keys"),
+		),
+		parkedEvents: metrix.SeededGauge(meter, "parked_events",
+			metrix.WithDescription("Events parked behind busy or wait-parked keys"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("events"),
+		),
+		poolInflight: metrix.SeededGauge(meter, "pool_inflight",
+			metrix.WithDescription("Blocking phases in flight: executing on the effect pool or awaiting a slot"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("effects"),
+		),
+		poolQueued: metrix.SeededGauge(meter, "pool_queued",
+			metrix.WithDescription("Dispatched blocking phases awaiting a pool slot"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("effects"),
+		),
+		oldestParkedAge: metrix.SeededGauge(meter, "oldest_parked_age",
+			metrix.WithDescription("Age of the oldest parked event"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("seconds"),
+		),
+		oldestWaitAge: metrix.SeededGauge(meter, "oldest_wait_age",
+			metrix.WithDescription("Age of the oldest wait-parked key"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("seconds"),
+		),
+		effectsStarted: metrix.SeededCounter(meter, "effects_started",
+			metrix.WithDescription("Blocking phases dispatched to the effect pool"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("effects"),
+		),
+		effectPanics: metrix.SeededCounter(meter, "effect_panics",
+			metrix.WithDescription("Effect panics converted to failed commands"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("panics"),
+		),
+		parkedTotal: metrix.SeededCounter(meter, "parked_events_admitted",
+			metrix.WithDescription("Events that parked behind a busy or wait-parked key"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("events"),
+		),
+		shutdownRejected: metrix.SeededCounter(meter, "shutdown_rejected",
+			metrix.WithDescription("Parked dyncfg commands answered 503 at shutdown"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("commands"),
+		),
+		leakedEffects: metrix.SeededCounter(meter, "leaked_effects",
+			metrix.WithDescription("Effects abandoned at their deadline with the module call still running"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("effects"),
+		),
+		wedgedKeys: metrix.SeededCounter(meter, "wedged_keys",
+			metrix.WithDescription("Keys held busy by an abandoned effect awaiting its late return"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("keys"),
+		),
+		staleCommits: metrix.SeededCounter(meter, "stale_commits",
+			metrix.WithDescription("Commits rejected because the key changed during the operation"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("commits"),
+		),
+		effectBusySeconds: metrix.SeededCounter(meter, "effect_busy_seconds",
+			metrix.WithDescription("Cumulative time blocking phases spent executing"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("seconds"),
+		),
+		suppressedLateOutput: metrix.SeededCounter(meter, "suppressed_late_output",
+			metrix.WithDescription("Writes swallowed by closed emission gates after a quarantine"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("writes"),
+		),
+		barrierWaitSeconds: metrix.SeededCounter(meter, "barrier_wait_seconds",
+			metrix.WithDescription("Cumulative time quarantine fences waited on the runtime emission barrier"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("seconds"),
+		),
+	}
+}
+
+// refreshAges is the runtimecomp producer tick.
+func (m *executorRuntimeMetrics) refreshAges() error {
+	if m == nil {
+		return nil
+	}
+	m.oldestParkedAge.Set(ageSeconds(m.oldestParkedSince.Load()))
+	m.oldestWaitAge.Set(ageSeconds(m.oldestWaitSince.Load()))
+	return nil
+}
+
+func ageSeconds(sinceNanos int64) float64 {
+	if sinceNanos == 0 {
+		return 0
+	}
+	return time.Since(time.Unix(0, sinceNanos)).Seconds()
+}
+
+func (m *Manager) registerExecutorRuntimeComponent() {
+	if m.runtimeService == nil || m.executorMetrics == nil {
+		return
+	}
+	err := m.runtimeService.RegisterComponent(runtimecomp.ComponentConfig{
+		Name:        executorRuntimeComponentName,
+		Store:       m.executorRuntimeStore,
+		UpdateEvery: 1,
+		Autogen:     runtimecomp.AutogenPolicy{Enabled: true},
+		Module:      "jobmgr",
+		JobName:     "executor",
+		JobLabels:   map[string]string{"component": "jobmgr_executor"},
+	})
+	if err != nil {
+		m.Warningf("executor runtime metrics registration failed: %v", err)
+		return
+	}
+	if err := m.runtimeService.RegisterProducer(executorRuntimeProducerName, m.executorMetrics.refreshAges); err != nil {
+		m.Warningf("executor runtime age producer registration failed: %v", err)
+	}
+}
+
+func (m *Manager) unregisterExecutorRuntimeComponent() {
+	if m.runtimeService == nil {
+		return
+	}
+	m.runtimeService.UnregisterProducer(executorRuntimeProducerName)
+	m.runtimeService.UnregisterComponent(executorRuntimeComponentName)
+}

--- a/src/go/plugin/agent/jobmgr/executor_metrics.go
+++ b/src/go/plugin/agent/jobmgr/executor_metrics.go
@@ -157,7 +157,11 @@ func ageSeconds(sinceNanos int64) float64 {
 	if sinceNanos == 0 {
 		return 0
 	}
-	return time.Since(time.Unix(0, sinceNanos)).Seconds()
+	// Clamped: a wall-clock step backwards must not report negative age.
+	if s := time.Since(time.Unix(0, sinceNanos)).Seconds(); s > 0 {
+		return s
+	}
+	return 0
 }
 
 func (m *Manager) registerExecutorRuntimeComponent() {

--- a/src/go/plugin/agent/jobmgr/executor_test.go
+++ b/src/go/plugin/agent/jobmgr/executor_test.go
@@ -4,12 +4,17 @@ package jobmgr
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
@@ -215,47 +220,52 @@ func TestExecutor_KeyDerivation(t *testing.T) {
 	}
 }
 
+// Per-key FIFO pin: events for ONE key execute and emit in arrival order
+// through the running manager (cross-key order is unconstrained by design).
 func TestExecutor_DispatchOrder(t *testing.T) {
 	tests := map[string]struct {
-		run func(t *testing.T, mgr *Manager, buf *bytes.Buffer)
+		run func(t *testing.T, h *charHarness)
 	}{
-		"dyncfg commands emit terminals in dispatch order": {
-			run: func(t *testing.T, mgr *Manager, buf *bytes.Buffer) {
-				var wants []wireRecordWant
+		"same-key dyncfg commands emit terminals in dispatch order": {
+			run: func(t *testing.T, h *charHarness) {
+				var wants []wiretest.RecordWant
 				for i := 1; i <= 3; i++ {
 					uid := fmt.Sprintf("order-%d", i)
-					fn := newExecutorTestFn(uid, []string{fmt.Sprintf("test:collector:success:missing%d", i), "get"}, nil)
-					mgr.executor.dispatch(mgr.newDyncfgEvent(fn))
-					wants = append(wants, wireRecordWant{
-						name:     uid + " terminal",
-						contains: []string{"FUNCTION_RESULT_BEGIN " + uid},
+					h.dyncfg(uid, []string{"test:collector:success:missing", "get"}, nil)
+					wants = append(wants, wiretest.RecordWant{
+						Name:     uid + " terminal",
+						Contains: []string{"FUNCTION_RESULT_BEGIN " + uid},
 					})
 				}
 
-				requireWireRecordSubsequence(t, buf.String(), wants)
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN order-3"), charWait, charTick)
+				wiretest.RequireSubsequence(t, h.out.String(), wants)
 			},
 		},
-		"discovery and dyncfg events execute in dispatch order": {
-			run: func(t *testing.T, mgr *Manager, buf *bytes.Buffer) {
+		"same-key discovery and dyncfg events keep arrival order": {
+			run: func(t *testing.T, h *charHarness) {
 				cfg := prepareUserCfg("success", "o1")
 
-				mgr.executor.dispatch(mgr.newDiscoveryAddEvent(cfg))
-				mgr.executor.dispatch(mgr.newDyncfgEvent(newExecutorTestFn("mid-get", []string{mgr.dyncfgJobID(cfg), "get"}, nil)))
-				mgr.executor.dispatch(mgr.newDiscoveryRemoveEvent(cfg))
+				h.in <- prepareCfgGroups(cfg.Source(), cfg)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:o1 create"), charWait, charTick)
+				h.dyncfg("mid-update", []string{h.mgr.dyncfgJobID(cfg), "update"}, []byte("{}"))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN mid-update"), charWait, charTick)
+				// The decision unparks the key; a wait-parked key's own discovery
+				// events (including its removal) stay parked until it.
+				h.dyncfg("then-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:success:o1 status running"), charWait, charTick)
+				h.in <- prepareCfgGroups(cfg.Source())
+				require.Eventually(t, func() bool {
+					_, ok := h.mgr.collectorExposed.LookupByKey(cfg.ExposedKey())
+					return !ok
+				}, charWait, charTick)
 
-				requireWireRecordSubsequence(t, buf.String(), []wireRecordWant{
-					{
-						name:     "discovery add config create",
-						contains: []string{"CONFIG test:collector:success:o1 create"},
-					},
-					{
-						name:     "get terminal",
-						contains: []string{"FUNCTION_RESULT_BEGIN mid-get"},
-					},
-					{
-						name:     "discovery remove config delete",
-						contains: []string{"CONFIG test:collector:success:o1 delete"},
-					},
+				wiretest.RequireSubsequence(t, h.out.String(), []wiretest.RecordWant{
+					{Name: "discovery add config create", Contains: []string{"CONFIG test:collector:success:o1 create"}},
+					{Name: "premature update terminal", Contains: []string{"FUNCTION_RESULT_BEGIN mid-update"}},
+					{Name: "enable terminal", Contains: []string{"FUNCTION_RESULT_BEGIN then-enable"}},
+					{Name: "running status", Contains: []string{"CONFIG test:collector:success:o1 status running"}},
+					{Name: "discovery remove config delete", Contains: []string{"CONFIG test:collector:success:o1 delete"}},
 				})
 			},
 		},
@@ -263,14 +273,13 @@ func TestExecutor_DispatchOrder(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			mgr, buf := newExecutorTestManager()
-			tc.run(t, mgr, buf)
+			reg := collectorapi.Registry{}
+			reg.Register("success", charSuccessCreator())
+
+			tc.run(t, startCharManager(t, reg))
 		})
 	}
 }
-
-// Underivable events take the fallback key and must still execute, reaching
-// each domain's existing rejection (or template-scope success) paths.
 func TestExecutor_UnderivableEventExecution(t *testing.T) {
 	tests := map[string]struct {
 		fn       dyncfg.Function
@@ -328,4 +337,188 @@ func TestExecutor_UnderivableEventExecution(t *testing.T) {
 			}
 		})
 	}
+}
+
+// captureDeriverRegistry records lane derivers so their key derivation can be
+// pinned without a live functions manager.
+type captureDeriverRegistry struct {
+	noop
+	derivers map[string]functions.LaneKeyDeriver
+}
+
+func (c *captureDeriverRegistry) RegisterPrefixLaneDeriver(_, prefix string, d functions.LaneKeyDeriver) {
+	c.derivers[prefix] = d
+}
+
+// TestDyncfgLaneDerivers_TestIsKeyless pins the functions-lane half of the
+// keyless-test contract: the collector deriver gives every test request its
+// own lane, so a test never serializes behind the config's mutating lane
+// (held until that command's terminal finalize) or behind other tests.
+func TestDyncfgLaneDerivers_TestIsKeyless(t *testing.T) {
+	reg := &captureDeriverRegistry{derivers: map[string]functions.LaneKeyDeriver{}}
+	mgr := newCollectorTestManagerWithService(newTestSecretStoreService())
+	mgr.fnReg = reg
+	mgr.registerDyncfgLaneDerivers()
+
+	derive := reg.derivers[mgr.dyncfgCollectorPrefixValue()]
+	require.NotNil(t, derive, "the collector prefix must have a lane deriver")
+
+	jobID := mgr.dyncfgJobID(prepareDyncfgCfg("success", "web"))
+	enableKey, _ := derive(functions.Function{UID: "u1", Args: []string{jobID, "enable"}})
+	testKey1, _ := derive(functions.Function{UID: "u2", Args: []string{jobID, "test"}})
+	testKey2, _ := derive(functions.Function{UID: "u3", Args: []string{jobID, "test"}})
+	templateTestKey, _ := derive(functions.Function{UID: "u4", Args: []string{mgr.dyncfgModID("success"), "test"}})
+
+	require.NotEmpty(t, enableKey)
+	require.NotEmpty(t, testKey1)
+	assert.NotEqual(t, enableKey, testKey1,
+		"a test must not share the lane of the config's mutating commands")
+	assert.NotEqual(t, testKey1, testKey2,
+		"each test request must get its own lane")
+	require.NotEmpty(t, templateTestKey,
+		"a template-ID test must not fall back to the registration-wide lane")
+	assert.NotEqual(t, testKey1, templateTestKey,
+		"template-ID tests get their own lanes too")
+}
+
+// TestSuperviseEffect_AbandonFenceClassification pins that only a FENCED
+// abandon carries ErrPhaseAbandoned: stop-shaped commits publish success on
+// that sentinel, so an abandon that wins before the stop registered its
+// quarantine must classify as a plain failure instead.
+func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
+	newMgr := func() *Manager {
+		mgr := New(Config{PluginName: testPluginName})
+		mgr.effectDeadline = 50 * time.Millisecond
+		return mgr
+	}
+
+	t.Run("unfenced abandon is a plain failure", func(t *testing.T) {
+		mgr := newMgr()
+		block := make(chan struct{})
+		defer close(block)
+
+		res := mgr.superviseEffect(effectTask{key: "k", effect: func(context.Context) error {
+			<-block
+			return nil
+		}})
+
+		require.True(t, res.abandoned)
+		assert.False(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned),
+			"an abandon with no fence installed must not claim the fenced outcome")
+	})
+
+	t.Run("fenced abandon carries ErrPhaseAbandoned", func(t *testing.T) {
+		mgr := newMgr()
+		block := make(chan struct{})
+		defer close(block)
+		var fenceRan atomic.Bool
+
+		res := mgr.superviseEffect(effectTask{key: "k", effect: func(ctx context.Context) error {
+			effectControlFrom(ctx).setQuarantine(func() { fenceRan.Store(true) })
+			<-block
+			return nil
+		}})
+
+		require.True(t, res.abandoned)
+		assert.True(t, fenceRan.Load(), "the worker must run the fence before reporting the abandon")
+		assert.True(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned))
+	})
+
+	t.Run("unfenced shutdown abandon is never-ran", func(t *testing.T) {
+		mgr := newMgr()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		mgr.ctx = ctx // shutdown already began
+		block := make(chan struct{})
+		defer close(block)
+
+		res := mgr.superviseEffect(effectTask{key: "k", effect: func(context.Context) error {
+			<-block
+			return nil
+		}})
+
+		require.True(t, res.abandoned)
+		assert.True(t, errors.Is(res.err, dyncfg.ErrPhaseNeverRan),
+			"a shutdown interruption must answer retryably no matter which side wins the claim")
+	})
+
+	t.Run("disruptive shutdown abandon is a plain failure, never never-ran", func(t *testing.T) {
+		mgr := newMgr()
+		mgr.effectDeadline = time.Hour // only the cancellation may abandon
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		mgr.ctx = ctx
+		block := make(chan struct{})
+		defer close(block)
+		marked := make(chan struct{})
+		go func() {
+			// Shutdown lands strictly AFTER the point of no return.
+			<-marked
+			cancel()
+		}()
+
+		res := mgr.superviseEffect(effectTask{key: "k", effect: func(ctx context.Context) error {
+			effectControlFrom(ctx).markDisruptive()
+			close(marked)
+			<-block
+			return nil
+		}})
+
+		require.True(t, res.abandoned)
+		assert.False(t, errors.Is(res.err, dyncfg.ErrPhaseNeverRan),
+			"a never-ran outcome would roll back caches for a state that no longer exists")
+		assert.False(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned),
+			"no fence ran - success must not be published")
+	})
+
+	t.Run("fenced shutdown abandon carries ErrPhaseAbandoned", func(t *testing.T) {
+		mgr := newMgr()
+		mgr.effectDeadline = time.Hour // only the cancellation may abandon
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		mgr.ctx = ctx
+		block := make(chan struct{})
+		defer close(block)
+		fenceSet := make(chan struct{})
+		go func() {
+			// Shutdown lands strictly AFTER the stop registered its fence.
+			<-fenceSet
+			cancel()
+		}()
+
+		res := mgr.superviseEffect(effectTask{key: "k", effect: func(ctx context.Context) error {
+			effectControlFrom(ctx).setQuarantine(func() {})
+			close(fenceSet)
+			<-block
+			return nil
+		}})
+
+		require.True(t, res.abandoned)
+		assert.True(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned),
+			"a fenced stop may publish success even when shutdown is the cause")
+	})
+}
+
+// TestResumeWarmJob_IneligibleDropDisposesGate pins that a warm job dropped
+// on the ineligible path (its exposed entry is gone or replaced - reachable
+// when a stock enable failure removed the entry) deregisters its own
+// emission gate along with the module cleanup.
+func TestResumeWarmJob_IneligibleDropDisposesGate(t *testing.T) {
+	mgr, _ := newExecutorTestManager()
+	cfg := prepareDyncfgCfg("success", "gone")
+
+	job, err := mgr.createCollectorJob(context.Background(), cfg)
+	require.NoError(t, err)
+	gate, hasGate := mgr.emissionGates.lookup(cfg.FullName())
+	require.True(t, hasGate, "creation must register the gate")
+
+	// The config is NOT exposed: the continuation is ineligible.
+	mgr.resumeWarmJob(&warmResume{cfg: cfg, job: job, gate: gate})
+
+	_, hasGate = mgr.emissionGates.lookup(cfg.FullName())
+	assert.False(t, hasGate, "the dropped warm job's gate must be deregistered")
+	mgr.runningJobs.lock()
+	_, running := mgr.runningJobs.lookup(cfg.FullName())
+	mgr.runningJobs.unlock()
+	assert.False(t, running, "an ineligible warm job must never start")
 }

--- a/src/go/plugin/agent/jobmgr/funcdispatch_test.go
+++ b/src/go/plugin/agent/jobmgr/funcdispatch_test.go
@@ -409,7 +409,7 @@ func TestInstanceFunctionRegisteredHandlerPaths(t *testing.T) {
 			if tc.wantDataValue != nil {
 				assert.Equal(t, tc.wantDataValue, jsonNestedArrayValue(t, resp["data"], 0, 0))
 			}
-			mgr.stopRunningJob("mod_job1")
+			mgr.stopRunningJob(context.Background(), "mod_job1")
 		})
 	}
 }

--- a/src/go/plugin/agent/jobmgr/internal/wiretest/wiretest.go
+++ b/src/go/plugin/agent/jobmgr/internal/wiretest/wiretest.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package wiretest provides shared test helpers for asserting plugin wire
+// output as atomic protocol records. Multi-line FUNCTION_RESULT blocks are
+// grouped into single records so assertions can never match across a record
+// boundary; subsequence matching pins per-key ordering without constraining
+// cross-key interleaving.
+package wiretest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// RecordWant names one expected wire record and the substrings that identify
+// it.
+type RecordWant struct {
+	Name     string
+	Contains []string
+}
+
+// AtomicRecords splits wire output into atomic protocol records: one line per
+// record, except FUNCTION_RESULT_BEGIN..FUNCTION_RESULT_END blocks, which
+// form a single record.
+func AtomicRecords(output string) []string {
+	var records []string
+	lines := strings.Split(output, "\n")
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		if line == "" {
+			i++
+			continue
+		}
+		if !strings.HasPrefix(line, "FUNCTION_RESULT_BEGIN ") {
+			records = append(records, line)
+			i++
+			continue
+		}
+
+		var b strings.Builder
+		b.WriteString(line)
+		i++
+		for i < len(lines) {
+			b.WriteByte('\n')
+			b.WriteString(lines[i])
+			if lines[i] == "FUNCTION_RESULT_END" {
+				i++
+				break
+			}
+			i++
+		}
+		records = append(records, b.String())
+	}
+	return records
+}
+
+// findSubsequence reports whether wants appear in records in order (as a
+// subsequence); when they do not, it returns the index of the first want
+// that could not be found.
+func findSubsequence(records []string, wants []RecordWant) (missing int, ok bool) {
+	next := 0
+	for wi, want := range wants {
+		found := -1
+		for i := next; i < len(records); i++ {
+			matched := true
+			for _, substr := range want.Contains {
+				if !strings.Contains(records[i], substr) {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				found = i
+				break
+			}
+		}
+		if found == -1 {
+			return wi, false
+		}
+		next = found + 1
+	}
+	return 0, true
+}
+
+// RequireSubsequence asserts that wants appear in output's atomic records in
+// order. Records not named by wants may appear anywhere between them.
+func RequireSubsequence(t testing.TB, output string, wants []RecordWant) {
+	t.Helper()
+
+	records := AtomicRecords(output)
+	missing, ok := findSubsequence(records, wants)
+	if !ok {
+		require.Failf(t, "wire record subsequence mismatch",
+			"record %q (index %d) not found in order in records:\n%s",
+			wants[missing].Name, missing, strings.Join(records, "\n---\n"))
+	}
+}

--- a/src/go/plugin/agent/jobmgr/internal/wiretest/wiretest_test.go
+++ b/src/go/plugin/agent/jobmgr/internal/wiretest/wiretest_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package wiretest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleOutput = `CONFIG a create
+
+FUNCTION_RESULT_BEGIN uid-1 200 application/json
+{"status":200}
+FUNCTION_RESULT_END
+
+CONFIG a status running
+
+CONFIG b create
+
+FUNCTION_RESULT_BEGIN uid-2 200 application/json
+{"status":200}
+FUNCTION_RESULT_END
+`
+
+func TestAtomicRecords(t *testing.T) {
+	tests := map[string]struct {
+		output      string
+		wantRecords int
+	}{
+		"function result blocks group into one record": {
+			output:      sampleOutput,
+			wantRecords: 5,
+		},
+		"empty output yields no records": {
+			output:      "\n\n",
+			wantRecords: 0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			records := AtomicRecords(tc.output)
+			assert.Len(t, records, tc.wantRecords)
+			for _, r := range records {
+				assert.NotContains(t, r[1:], "FUNCTION_RESULT_BEGIN",
+					"a record must never contain a second result block")
+			}
+		})
+	}
+}
+
+// The negative cases prove the harness REJECTS same-key reorderings - a
+// subsequence assertion that cannot fail would let per-key ordering
+// regressions through silently.
+func TestFindSubsequence(t *testing.T) {
+	tests := map[string]struct {
+		wants       []RecordWant
+		wantOK      bool
+		wantMissing int
+	}{
+		"in-order wants match as a subsequence": {
+			wants: []RecordWant{
+				{Name: "a create", Contains: []string{"CONFIG a create"}},
+				{Name: "uid-1", Contains: []string{"FUNCTION_RESULT_BEGIN uid-1"}},
+				{Name: "a running", Contains: []string{"CONFIG a status running"}},
+			},
+			wantOK: true,
+		},
+		"unrelated records may interleave": {
+			wants: []RecordWant{
+				{Name: "a create", Contains: []string{"CONFIG a create"}},
+				{Name: "b create", Contains: []string{"CONFIG b create"}},
+			},
+			wantOK: true,
+		},
+		"reordered wants are rejected": {
+			wants: []RecordWant{
+				{Name: "a running", Contains: []string{"CONFIG a status running"}},
+				{Name: "uid-1", Contains: []string{"FUNCTION_RESULT_BEGIN uid-1"}},
+			},
+			wantOK:      false,
+			wantMissing: 1,
+		},
+		"missing record is rejected": {
+			wants: []RecordWant{
+				{Name: "ghost", Contains: []string{"CONFIG ghost"}},
+			},
+			wantOK:      false,
+			wantMissing: 0,
+		},
+		"multi-substring want must match within ONE record": {
+			wants: []RecordWant{
+				{Name: "cross-record", Contains: []string{"CONFIG a create", "CONFIG b create"}},
+			},
+			wantOK:      false,
+			wantMissing: 0,
+		},
+	}
+
+	records := AtomicRecords(sampleOutput)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			missing, ok := findSubsequence(records, tc.wants)
+			require.Equal(t, tc.wantOK, ok)
+			if !tc.wantOK {
+				assert.Equal(t, tc.wantMissing, missing)
+			}
+		})
+	}
+}

--- a/src/go/plugin/agent/jobmgr/job_factory.go
+++ b/src/go/plugin/agent/jobmgr/job_factory.go
@@ -38,11 +38,12 @@ func jobLogSource(cfg confgroup.Config) string {
 type jobFactory struct {
 	logger *logger.Logger
 
-	pluginName  string
-	modules     collectorapi.Registry
-	vnodeLookup func(string) (*vnodes.VirtualNode, bool)
-	out         io.Writer
-	gates       *emissionGates
+	pluginName        string
+	modules           collectorapi.Registry
+	vnodeLookup       func(string) (*vnodes.VirtualNode, bool)
+	out               io.Writer
+	gates             *emissionGates
+	onSuppressedWrite func()
 
 	validationOnly bool
 
@@ -66,11 +67,12 @@ func newJobFactory(m *Manager) *jobFactory {
 	return &jobFactory{
 		logger: m.Logger,
 
-		pluginName:  m.pluginName,
-		modules:     m.modules,
-		vnodeLookup: m.vnodesCtl.Lookup,
-		out:         m.out,
-		gates:       m.emissionGates,
+		pluginName:        m.pluginName,
+		modules:           m.modules,
+		vnodeLookup:       m.vnodesCtl.Lookup,
+		out:               m.out,
+		gates:             m.emissionGates,
+		onSuppressedWrite: m.observeSuppressedWrite,
 
 		auditMode:     m.auditMode,
 		auditAnalyzer: m.auditAnalyzer,
@@ -130,7 +132,7 @@ func (f *jobFactory) create(cfg confgroup.Config) (runtimeJob, error) {
 	gatedF := *f
 	var gate *emissionGateway
 	if !f.validationOnly {
-		gate = newEmissionGateway(f.out)
+		gate = newEmissionGateway(f.out, f.onSuppressedWrite)
 		gatedF.out = gate
 	}
 

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -4,14 +4,17 @@ package jobmgr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/ticker"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/funcctl"
@@ -52,6 +55,8 @@ type Config struct {
 }
 
 const (
+	defaultExecutorDrainWait = 5 * time.Second
+
 	cmdTestWorkerCap       = 4
 	cmdTestDefaultTimeout  = 60 * time.Second
 	cmdTestWorkerDrainWait = 5 * time.Second
@@ -119,16 +124,22 @@ func New(cfg Config) *Manager {
 		addCh:            make(chan confgroup.Config),
 		rmCh:             make(chan confgroup.Config),
 		dyncfgCh:         make(chan dyncfg.Function, 32),
-		effectDoneCh:     make(chan effectResult, 1),
+		effectCh:         make(chan effectTask, effectPoolSize),
+		effectDeadline:   defaultEffectDeadline,
+		drainWait:        defaultExecutorDrainWait,
+		lateDrop:         make(chan struct{}),
+		effectDoneCh:     make(chan effectResult, effectPoolSize),
 		funcReconPending: make(map[string]struct{}),
 		funcReconWake:    make(chan struct{}, 1),
 		cmdTestSem:       make(chan struct{}, cmdTestWorkerCap),
 
-		dyncfgResponder: api,
-		runtimeService:  cfg.RuntimeService,
-		vnodeRegistry:   vnodeRegistry,
-		secretResolver:  secretresolver.New(),
+		dyncfgResponder:      api,
+		executorRuntimeStore: metrix.NewRuntimeStore(),
+		runtimeService:       cfg.RuntimeService,
+		vnodeRegistry:        vnodeRegistry,
+		secretResolver:       secretresolver.New(),
 	}
+	mgr.executorMetrics = newExecutorRuntimeMetrics(mgr.executorRuntimeStore)
 	mgr.funcCtl = funcctl.New(funcctl.Options{
 		Logger:     mgr.Logger,
 		FnReg:      fnReg,
@@ -224,12 +235,21 @@ type Manager struct {
 	executor           *executor
 
 	// Runtime loop state.
-	ctx              context.Context
-	started          chan struct{}
-	addCh            chan confgroup.Config
-	rmCh             chan confgroup.Config
-	dyncfgCh         chan dyncfg.Function
-	effectDoneCh     chan effectResult
+	ctx            context.Context
+	started        chan struct{}
+	addCh          chan confgroup.Config
+	rmCh           chan confgroup.Config
+	dyncfgCh       chan dyncfg.Function
+	effectCh       chan effectTask
+	effectDoneCh   chan effectResult
+	effectDeadline time.Duration
+	drainWait      time.Duration
+	leakedChildren sync.WaitGroup
+	// leakedNow tracks abandoned module calls that have not returned yet:
+	// incremented at abandon, decremented when the late completion is
+	// delivered or dropped. The shutdown drain reports what remains.
+	leakedNow        atomic.Int64
+	lateDrop         chan struct{}
 	funcReconMu      sync.Mutex
 	funcReconPending map[string]struct{}
 	funcReconWake    chan struct{}
@@ -238,6 +258,10 @@ type Manager struct {
 
 	// Shared service seams.
 	dyncfgResponder *dyncfg.Responder
+
+	// Executor runtime metrics.
+	executorRuntimeStore metrix.RuntimeStore
+	executorMetrics      *executorRuntimeMetrics
 
 	// RuntimeService is an optional runtime/internal metrics registration seam.
 	// When set, V2 jobs may register per-job runtime components.
@@ -264,6 +288,7 @@ func (m *Manager) Run(ctx context.Context, in chan []*confgroup.Group) {
 	m.secretsCtl.PublishExisting()
 
 	m.fnReg.RegisterPrefix("config", m.dyncfgCollectorPrefixValue(), dyncfg.WrapHandler(m.dyncfgConfig))
+	m.registerDyncfgLaneDerivers()
 	for name, creator := range m.modules {
 		if creator.InstancePolicy == collectorapi.InstancePolicySingle {
 			continue
@@ -271,6 +296,9 @@ func (m *Manager) Run(ctx context.Context, in chan []*confgroup.Group) {
 		m.dyncfgCollectorModuleCreate(name)
 	}
 	m.funcCtl.RegisterModules(m.modules)
+
+	m.registerExecutorRuntimeComponent()
+	defer m.unregisterExecutorRuntimeComponent()
 
 	m.loadFileStatus()
 
@@ -281,6 +309,10 @@ func (m *Manager) Run(ctx context.Context, in chan []*confgroup.Group) {
 	wg.Go(func() { m.runProcessConfGroups(in) })
 
 	wg.Go(func() { m.run() })
+
+	for range effectPoolSize {
+		wg.Go(func() { m.runEffectWorker() })
+	}
 
 	wg.Go(func() { m.runNotifyRunningJobs() })
 
@@ -338,29 +370,37 @@ func (m *Manager) runProcessConfGroups(in chan []*confgroup.Group) {
 
 func (m *Manager) run() {
 	for {
-		if m.collectorHandler.WaitingForDecision() {
-			if !m.runWaitDecisionStep() {
-				return
-			}
-			continue
-		} else {
-			select {
-			case <-m.ctx.Done():
-				return
-			case cfg := <-m.addCh:
-				m.executor.dispatch(m.newDiscoveryAddEvent(cfg))
-			case cfg := <-m.rmCh:
-				m.executor.dispatch(m.newDiscoveryRemoveEvent(cfg))
-			case fn := <-m.dyncfgCh:
-				m.executor.dispatch(m.newDyncfgEvent(fn))
-			case res := <-m.effectDoneCh:
-				m.handleUnexpectedEffectDone(res)
-			}
+		select {
+		case <-m.ctx.Done():
+			m.executor.shutdownDrain()
+			return
+		case cfg := <-m.addCh:
+			m.executor.dispatch(m.newDiscoveryAddEvent(cfg))
+		case cfg := <-m.rmCh:
+			m.executor.dispatch(m.newDiscoveryRemoveEvent(cfg))
+		case fn := <-m.dyncfgCh:
+			m.executor.dispatch(m.newDyncfgEvent(fn))
+		case res := <-m.effectDoneCh:
+			m.executor.onEffectDone(res)
 		}
 	}
 }
 
+// addConfig applies a discovered config synchronously (legacy inline path,
+// kept for direct callers and tests; production discovery routes through
+// stagedAddConfig on the executor).
 func (m *Manager) addConfig(cfg confgroup.Config) {
+	m.stagedAddConfig(cfg, dyncfg.RunStepSync,
+		func() { m.collectorHandler.WaitForDecision(cfg) },
+		func(fn dyncfg.Function) { m.collectorHandler.CmdEnable(fn) })
+}
+
+// stagedAddConfig applies a discovered config with its blocking pieces (the
+// replaced job's stop, the auto-enable start) behind run; markWaiting parks
+// the key awaiting an enable/disable decision when discovery is not
+// auto-enabled; enqueueDyncfg routes a command through the key's lane
+// instead of chaining it (used when the key is wedged by an abandoned stop).
+func (m *Manager) stagedAddConfig(cfg confgroup.Config, run dyncfg.StepRunner, markWaiting func(), enqueueDyncfg func(dyncfg.Function)) {
 	creator, ok := m.modules.Lookup(cfg.Module())
 	if !ok {
 		return
@@ -374,66 +414,54 @@ func (m *Manager) addConfig(cfg confgroup.Config) {
 
 	m.collectorHandler.RememberDiscoveredConfig(cfg)
 
-	entry, ok := m.collectorExposed.LookupByKey(cfg.ExposedKey())
-	if !ok {
-		entry = m.collectorHandler.AddDiscoveredConfig(cfg, dyncfg.StatusAccepted)
-	} else {
-		sp, ep := cfg.SourceTypePriority(), entry.Cfg.SourceTypePriority()
-		if ep > sp || (ep == sp && entry.Status == dyncfg.StatusRunning) {
+	proceed := func(entry *dyncfg.Entry[confgroup.Config], viaAbandonedStop bool) {
+		m.syncSecretStoreDepsForConfig(entry.Cfg)
+		m.collectorHandler.NotifyConfigCreate(entry.Cfg, entry.Status)
+
+		if m.runModePolicy.AutoEnableDiscovered {
+			fn := dyncfg.NewFunction(functions.Function{Args: []string{m.dyncfgConfigID(entry.Cfg), "enable"}})
+			if viaAbandonedStop {
+				// The key is wedged by the abandoned stop: a chained enable
+				// would be refused, so route it through the lane - it parks
+				// behind the wedge and replays when the leaked call returns.
+				enqueueDyncfg(fn)
+				return
+			}
+			m.collectorHandler.CmdEnableStep(fn, run)
 			return
 		}
-		if entry.Status == dyncfg.StatusRunning {
-			m.stopRunningJob(entry.Cfg.FullName())
-			m.fileStatus.remove(entry.Cfg)
-		}
-		entry = m.collectorHandler.AddDiscoveredConfig(cfg, dyncfg.StatusAccepted) // replace existing exposed
+		markWaiting()
 	}
 
-	m.syncSecretStoreDepsForConfig(entry.Cfg)
-	m.collectorHandler.NotifyConfigCreate(entry.Cfg, entry.Status)
-
-	if m.runModePolicy.AutoEnableDiscovered {
-		m.collectorHandler.CmdEnable(dyncfg.NewFunction(functions.Function{Args: []string{m.dyncfgConfigID(entry.Cfg), "enable"}}))
-	} else {
-		m.collectorHandler.WaitForDecision(entry.Cfg)
+	entry, ok := m.collectorExposed.LookupByKey(cfg.ExposedKey())
+	if !ok {
+		proceed(m.collectorHandler.AddDiscoveredConfig(cfg, dyncfg.StatusAccepted), false)
+		return
 	}
-}
-
-func (m *Manager) runWaitDecisionStep() bool {
-	waitFor, hasTimeout := m.collectorHandler.WaitDecisionRemaining()
-	if !hasTimeout {
-		select {
-		case <-m.ctx.Done():
-			return false
-		case fn := <-m.dyncfgCh:
-			m.executor.dispatch(m.newDyncfgEvent(fn))
-		case res := <-m.effectDoneCh:
-			m.handleUnexpectedEffectDone(res)
-		}
-		return true
+	sp, ep := cfg.SourceTypePriority(), entry.Cfg.SourceTypePriority()
+	if ep > sp || (ep == sp && entry.Status == dyncfg.StatusRunning) {
+		return
 	}
-
-	timer := time.NewTimer(waitFor)
-	defer func() {
-		if !timer.Stop() {
-			select {
-			case <-timer.C:
-			default:
+	if entry.Status == dyncfg.StatusRunning {
+		old := entry.Cfg
+		run(func(ctx context.Context) error {
+			m.stopRunningJob(ctx, old.FullName())
+			m.fileStatus.remove(old)
+			return nil
+		}, func(stopErr error) {
+			if stopErr != nil && !errors.Is(stopErr, dyncfg.ErrPhaseAbandoned) {
+				// The stop never ran (shutdown) or broke (recovered panic):
+				// the old instance's state is not settled - do not create the
+				// replacement next to it.
+				m.Warningf("skipping replacement of %s[%s]: stop of the previous instance did not complete: %v", cfg.Module(), cfg.Name(), stopErr)
+				return
 			}
-		}
-	}()
-
-	select {
-	case <-m.ctx.Done():
-		return false
-	case fn := <-m.dyncfgCh:
-		m.executor.dispatch(m.newDyncfgEvent(fn))
-	case res := <-m.effectDoneCh:
-		m.handleUnexpectedEffectDone(res)
-	case <-timer.C:
-		m.collectorHandler.ExpireWaitDecision()
+			// replace existing exposed
+			proceed(m.collectorHandler.AddDiscoveredConfig(cfg, dyncfg.StatusAccepted), errors.Is(stopErr, dyncfg.ErrPhaseAbandoned))
+		})
+		return
 	}
-	return true
+	proceed(m.collectorHandler.AddDiscoveredConfig(cfg, dyncfg.StatusAccepted), false) // replace existing exposed
 }
 
 func (m *Manager) runFunctionReconciler() {
@@ -455,21 +483,37 @@ func (m *Manager) runFunctionReconciler() {
 	}
 }
 
+// removeConfig applies a discovery removal synchronously (legacy inline
+// path, kept for direct callers and tests).
 func (m *Manager) removeConfig(cfg confgroup.Config) {
+	m.stagedRemoveConfig(cfg, dyncfg.RunStepSync)
+}
+
+func (m *Manager) stagedRemoveConfig(cfg confgroup.Config, run dyncfg.StepRunner) {
 	m.retryingTasks.remove(cfg)
 
 	entry, ok := m.collectorHandler.RemoveDiscoveredConfig(cfg)
 	if !ok {
 		return
 	}
-	// Stop first so running-state cleanup is applied against existing dependency state.
-	m.stopRunningJob(cfg.FullName())
-	m.secretStoreDeps.RemoveActiveJob(entry.Cfg.FullName())
-	m.fileStatus.remove(cfg)
-
-	if !isStock(cfg) || entry.Status == dyncfg.StatusRunning {
-		m.collectorHandler.NotifyConfigRemove(cfg)
-	}
+	run(func(ctx context.Context) error {
+		// Stop first so running-state cleanup is applied against existing dependency state.
+		m.stopRunningJob(ctx, cfg.FullName())
+		m.secretStoreDeps.RemoveActiveJob(entry.Cfg.FullName())
+		m.fileStatus.remove(cfg)
+		return nil
+	}, func(stopErr error) {
+		if stopErr != nil && !errors.Is(stopErr, dyncfg.ErrPhaseAbandoned) {
+			// The stop never ran (shutdown) or broke (recovered panic): the
+			// job may still be emitting - publishing the removal would
+			// violate no-output-after-publish.
+			m.Warningf("suppressing config removal publish for %s[%s]: stop did not complete: %v", cfg.Module(), cfg.Name(), stopErr)
+			return
+		}
+		if !isStock(cfg) || entry.Status == dyncfg.StatusRunning {
+			m.collectorHandler.NotifyConfigRemove(cfg)
+		}
+	})
 }
 
 func (m *Manager) runNotifyRunningJobs() {
@@ -536,14 +580,27 @@ func (m *Manager) takePendingFunctionReconcileModules() []string {
 }
 
 func (m *Manager) startRunningJob(job runtimeJob) {
-	// The defensive stop removes the gate tracked under this name, but that
-	// entry belongs to the job being started (registered at construction,
-	// after any old same-name job's entry was overwritten) - restore it so
-	// a same-name replacement never leaves the new job untracked.
-	gate, hadGate := m.emissionGates.lookup(job.FullName())
-	m.stopRunningJob(job.FullName())
-	if hadGate {
-		m.emissionGates.add(job.FullName(), gate)
+	// Per-key FIFO makes a still-registered same-name instance structurally
+	// impossible on the start path (the command that starts a job stopped
+	// its predecessor earlier in the same lane). Assert instead of silently
+	// blocking on a defensive stop: the stale instance is deregistered and
+	// leaked (logged), never waited on.
+	if stale, exists := func() (runtimeJob, bool) {
+		m.runningJobs.lock()
+		defer m.runningJobs.unlock()
+		j, ok := m.runningJobs.lookup(job.FullName())
+		if ok {
+			m.runningJobs.remove(job.FullName())
+		}
+		return j, ok
+	}(); exists {
+		m.Errorf("BUG: starting job '%s' while an instance is still registered; leaking the stale instance", job.FullName())
+		if m.executorMetrics != nil {
+			m.executorMetrics.leakedEffects.Add(1)
+		}
+		m.secretStoreDeps.setRunning(job.FullName(), false)
+		m.funcCtl.OnJobStop(stale)
+		m.requestFunctionReconcile(stale.ModuleName())
 	}
 
 	go job.Start()
@@ -557,27 +614,62 @@ func (m *Manager) startRunningJob(job runtimeJob) {
 	m.requestFunctionReconcile(job.ModuleName())
 }
 
-func (m *Manager) stopRunningJob(name string) {
+// stopRunningJob stops the named job if it is running; it reports whether
+// THIS call found and stopped one (callers use it as the point-of-no-return
+// signal - a no-op stop tears nothing down).
+func (m *Manager) stopRunningJob(ctx context.Context, name string) bool {
 	m.runningJobs.lock()
 	job, ok := m.runningJobs.lookup(name)
 	if ok {
 		m.runningJobs.remove(name)
 	}
 	m.runningJobs.unlock()
-	if ok {
-		m.secretStoreDeps.setRunning(name, false)
-		m.funcCtl.OnJobStop(job)
-		m.requestFunctionReconcile(job.ModuleName())
-		// Registry removals above happen before the blocking stop so function
-		// routing to the job ends immediately; only the wait itself is an effect.
-		_ = m.runEffectSync(name, func(context.Context) error {
-			job.Stop()
-			return nil
+	if !ok {
+		return false
+	}
+	m.secretStoreDeps.setRunning(name, false)
+	m.funcCtl.OnJobStop(job)
+	m.requestFunctionReconcile(job.ModuleName())
+
+	// If this stop's deadline fires, the worker fences the job's output
+	// BEFORE the command's deadline outcome publishes: the gate captured
+	// HERE is the stopping job's own (never a by-name lookup - a same-name
+	// replacement may re-register the entry), and the runtime component
+	// barrier waits out any in-progress emission tick.
+	if ctl := effectControlFrom(ctx); ctl != nil {
+		gate, hasGate := m.emissionGates.lookup(name)
+		ctl.setQuarantine(func() {
+			if hasGate {
+				gate.Close()
+			}
+			if rc, ok := job.(interface{ RuntimeComponentName() string }); ok && m.runtimeService != nil {
+				start := time.Now()
+				m.runtimeService.QuarantineComponent(rc.RuntimeComponentName())
+				if m.executorMetrics != nil {
+					m.executorMetrics.barrierWaitSeconds.Add(time.Since(start).Seconds())
+				}
+			}
 		})
-		// Tracking removal only: the gate is never closed on the stop path,
-		// because a stopping job's in-flight flush and cleanup/obsoletion
-		// output must reach the wire.
-		m.emissionGates.remove(name)
+	}
+
+	// Registry removals above happen before the blocking wait so function
+	// routing to the job ends as soon as the stop begins.
+	job.Stop()
+	// The wait finished normally: disarm the fence. Completion claiming is
+	// the OUTERMOST closure's job - a stop may be an inner phase of a
+	// larger effect (update stops the old job before detecting the new).
+	effectControlFrom(ctx).clearQuarantine()
+	// Tracking removal only on the normal path: the gate is never closed
+	// here, because a stopping job's in-flight flush and cleanup/obsoletion
+	// output must reach the wire.
+	m.emissionGates.remove(name)
+	return true
+}
+
+// observeSuppressedWrite counts a write swallowed by a closed emission gate.
+func (m *Manager) observeSuppressedWrite() {
+	if m.executorMetrics != nil {
+		m.executorMetrics.suppressedLateOutput.Add(1)
 	}
 }
 
@@ -588,7 +680,7 @@ func (m *Manager) cleanup() {
 	m.funcCtl.Cleanup()
 
 	for _, job := range m.runningJobs.snapshot() {
-		m.stopRunningJob(job.FullName())
+		m.stopRunningJob(context.Background(), job.FullName())
 	}
 
 	m.waitCmdTestWorkers()
@@ -608,12 +700,20 @@ func (m *Manager) waitCmdTestWorkers() {
 	}
 }
 
-func (m *Manager) createCollectorJob(cfg confgroup.Config) (runtimeJob, error) {
-	return newJobFactory(m).create(cfg)
+func (m *Manager) createCollectorJob(ctx context.Context, cfg confgroup.Config) (runtimeJob, error) {
+	f := newJobFactory(m)
+	if ctx != nil {
+		f.ctx = ctx
+	}
+	return f.create(cfg)
 }
 
-func (m *Manager) validateCollectorJob(cfg confgroup.Config) error {
-	return newJobFactory(m).validate(cfg)
+func (m *Manager) validateCollectorJob(ctx context.Context, cfg confgroup.Config) error {
+	f := newJobFactory(m)
+	if ctx != nil {
+		f.ctx = ctx
+	}
+	return f.validate(cfg)
 }
 
 func (m *Manager) baseContext() context.Context {

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -105,7 +105,7 @@ func TestRunNotifyRunningJobs_TickOutsideLock(t *testing.T) {
 
 	stopDone := make(chan struct{})
 	go func() {
-		mgr.stopRunningJob(job.FullName())
+		mgr.stopRunningJob(context.Background(), job.FullName())
 		close(stopDone)
 	}()
 
@@ -361,59 +361,6 @@ func TestRequestFunctionReconcile_CoalescesPendingModules(t *testing.T) {
 	assert.Equal(t, []string{"mod"}, mgr.takePendingFunctionReconcileModules())
 }
 
-func TestRunWaitDecisionStep(t *testing.T) {
-	tests := map[string]struct {
-		run func(t *testing.T)
-	}{
-		"executes dyncfg command while waiting": {
-			run: func(t *testing.T) {
-				var out bytes.Buffer
-				mgr := New(Config{PluginName: testPluginName, Out: &out})
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				mgr.ctx = ctx
-				mgr.collectorHandler.WaitForDecision(prepareUserCfg("mod", "job"))
-				mgr.dyncfgCh <- dyncfg.NewFunction(functions.Function{
-					UID:  "unknown",
-					Name: "config",
-					Args: []string{"unknown", string(dyncfg.CommandSchema)},
-				})
-
-				require.True(t, mgr.runWaitDecisionStep())
-				assert.Contains(t, out.String(), "unknown function")
-			},
-		},
-		"expires wait decision": {
-			run: func(t *testing.T) {
-				mgr := New(Config{PluginName: testPluginName})
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				mgr.ctx = ctx
-				mgr.collectorHandler = newTestCollectorHandlerWithWaitTimeout(mgr, time.Nanosecond)
-				mgr.collectorHandler.WaitForDecision(prepareUserCfg("mod", "job"))
-
-				require.True(t, mgr.runWaitDecisionStep())
-				assert.False(t, mgr.collectorHandler.WaitingForDecision())
-			},
-		},
-		"context cancel returns false": {
-			run: func(t *testing.T) {
-				mgr := New(Config{PluginName: testPluginName})
-				ctx, cancel := context.WithCancel(context.Background())
-				mgr.ctx = ctx
-				mgr.collectorHandler.WaitForDecision(prepareUserCfg("mod", "job"))
-				cancel()
-
-				assert.False(t, mgr.runWaitDecisionStep())
-			},
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, tc.run)
-	}
-}
-
 func TestRunFunctionReconciler_DoesNotBlockManagerControlLoop(t *testing.T) {
 	reg := &recordingFunctionRegistry{}
 	var out simOutput
@@ -533,7 +480,7 @@ func TestFunctionReconcileFunnelConcurrentLifecycle(t *testing.T) {
 				fullName := fmt.Sprintf("mod_%s", name)
 				job := &tickProbeJob{fullName: fullName, moduleName: "mod", name: name, collector: availability}
 				mgr.startRunningJob(job)
-				mgr.stopRunningJob(fullName)
+				mgr.stopRunningJob(context.Background(), fullName)
 			}
 		}(worker)
 	}
@@ -605,7 +552,7 @@ func TestFunctionReconcileFunnelWithdrawsStoppedInstanceAfterInFlightPublish(t *
 		t.Fatal("reconcile did not check instance Function availability")
 	}
 
-	mgr.stopRunningJob(job.FullName())
+	mgr.stopRunningJob(context.Background(), job.FullName())
 	close(releaseAvailability)
 
 	require.Eventually(t, func() bool {
@@ -1018,6 +965,11 @@ func (a managerFunctionAvailability) FunctionAvailable(functionID string) bool {
 	return a.fn(functionID)
 }
 
+type registeredPrefix struct {
+	name   string
+	prefix string
+}
+
 type recordingFunctionRegistry struct {
 	mu           sync.Mutex
 	registered   []string
@@ -1065,28 +1017,4 @@ func (r *recordingFunctionRegistry) registeredPrefixes() []registeredPrefix {
 	out := make([]registeredPrefix, len(r.prefixes))
 	copy(out, r.prefixes)
 	return out
-}
-
-func newTestCollectorHandlerWithWaitTimeout(mgr *Manager, timeout time.Duration) *dyncfg.Handler[confgroup.Config] {
-	return dyncfg.NewHandler(dyncfg.HandlerOpts[confgroup.Config]{
-		Logger:    mgr.Logger,
-		API:       mgr.dyncfgResponder,
-		Seen:      dyncfg.NewSeenCache[confgroup.Config](),
-		Exposed:   dyncfg.NewExposedCache[confgroup.Config](),
-		Callbacks: mgr.collectorCallbacks,
-		WaitKey: func(cfg confgroup.Config) string {
-			return cfg.FullName()
-		},
-
-		Path:                    fmt.Sprintf(dyncfgCollectorPath, testPluginName),
-		EnableFailCode:          200,
-		RemoveStockOnEnableFail: true,
-		ConfigCommands:          dyncfgCollectorConfigCmds(),
-		WaitTimeout:             timeout,
-	})
-}
-
-type registeredPrefix struct {
-	name   string
-	prefix string
 }

--- a/src/go/plugin/agent/jobmgr/manager_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_test.go
@@ -23,7 +23,7 @@ func TestManager_Run(t *testing.T) {
 				cfg := prepareStockCfg("success", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -55,7 +55,7 @@ CONFIG test:collector:success:name delete
 				cfg := prepareStockCfg("fail", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -85,7 +85,7 @@ CONFIG test:collector:fail:name delete
 				cfg := prepareStockCfg("fail", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -115,7 +115,7 @@ CONFIG test:collector:fail:name delete
 				cfg := prepareUserCfg("success", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -147,7 +147,7 @@ CONFIG test:collector:success:name delete
 				cfg := prepareUserCfg("fail", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -179,7 +179,7 @@ CONFIG test:collector:fail:name delete
 				cfg := prepareDiscoveredCfg("success", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -211,7 +211,7 @@ CONFIG test:collector:success:name delete
 				cfg := prepareDiscoveredCfg("fail", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -245,7 +245,7 @@ CONFIG test:collector:fail:name delete
 				userCfg := prepareUserCfg("fail", "user")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, stockCfg.Source(), stockCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -253,14 +253,14 @@ CONFIG test:collector:fail:name delete
 						}))
 
 						sendConfGroup(in, discCfg.Source(), discCfg)
-						waitSourceExposed(mgr, discCfg)
+						waitSourceExposed(t, mgr, discCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "2-enable",
 							Args: []string{mgr.dyncfgJobID(discCfg), "enable"},
 						}))
 
 						sendConfGroup(in, userCfg.Source(), userCfg)
-						waitSourceExposed(mgr, userCfg)
+						waitSourceExposed(t, mgr, userCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "3-enable",
 							Args: []string{mgr.dyncfgJobID(userCfg), "enable"},
@@ -308,7 +308,7 @@ CONFIG test:collector:fail:name delete
 				userCfg := prepareUserCfg("fail", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, stockCfg.Source(), stockCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -316,14 +316,14 @@ CONFIG test:collector:fail:name delete
 						}))
 
 						sendConfGroup(in, discCfg.Source(), discCfg)
-						waitSourceExposed(mgr, discCfg)
+						waitSourceExposed(t, mgr, discCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "2-enable",
 							Args: []string{mgr.dyncfgJobID(discCfg), "enable"},
 						}))
 
 						sendConfGroup(in, userCfg.Source(), userCfg)
-						waitSourceExposed(mgr, userCfg)
+						waitSourceExposed(t, mgr, userCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "3-enable",
 							Args: []string{mgr.dyncfgJobID(userCfg), "enable"},
@@ -378,7 +378,7 @@ CONFIG test:collector:fail:name status failed
 				userCfg := prepareUserCfg("fail", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, stockCfg.Source(), stockCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -386,14 +386,14 @@ CONFIG test:collector:fail:name status failed
 						}))
 
 						sendConfGroup(in, discCfg.Source(), discCfg)
-						waitSourceExposed(mgr, discCfg)
+						waitSourceExposed(t, mgr, discCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "2-enable",
 							Args: []string{mgr.dyncfgJobID(discCfg), "enable"},
 						}))
 
 						sendConfGroup(in, userCfg.Source(), userCfg)
-						waitSourceExposed(mgr, userCfg)
+						waitSourceExposed(t, mgr, userCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "3-enable",
 							Args: []string{mgr.dyncfgJobID(userCfg), "enable"},
@@ -444,7 +444,7 @@ CONFIG test:collector:fail:name delete
 				stockCfg := prepareStockCfg("fail", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, userCfg.Source(), userCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -487,7 +487,7 @@ CONFIG test:collector:fail:name status failed
 				stockCfg := prepareStockCfg("fail", "name")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, userCfg.Source(), userCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -540,7 +540,7 @@ func TestManager_Run_Dyncfg_Get(t *testing.T) {
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-get",
 							Args: []string{mgr.dyncfgJobID(cfg), "get"},
@@ -567,7 +567,7 @@ FUNCTION_RESULT_END
 				bs, _ := json.Marshal(cfg)
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -609,7 +609,7 @@ FUNCTION_RESULT_END
 				bs, _ := json.Marshal(cfg)
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -663,7 +663,7 @@ func TestManager_Run_Dyncfg_Userconfig(t *testing.T) {
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-userconfig",
 							Args: []string{mgr.dyncfgJobID(cfg), "userconfig"},
@@ -690,7 +690,7 @@ FUNCTION_RESULT_END
 				cfg := prepareDyncfgCfg("success!", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-userconfig",
 							Args: []string{mgr.dyncfgJobID(cfg), "userconfig"},
@@ -727,7 +727,7 @@ func TestManager_Run_Dyncfg_Add(t *testing.T) {
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -759,7 +759,7 @@ CONFIG test:collector:success:test create accepted job /collectors/test/Jobs dyn
 				cfg := prepareDyncfgCfg("fail", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -791,7 +791,7 @@ CONFIG test:collector:fail:test create accepted job /collectors/test/Jobs dyncfg
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -849,7 +849,7 @@ func TestManager_Run_Dyncfg_Enable(t *testing.T) {
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
 							Args: []string{mgr.dyncfgJobID(cfg), "enable"},
@@ -873,7 +873,7 @@ FUNCTION_RESULT_END
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -915,7 +915,7 @@ CONFIG test:collector:success:test status running
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -967,7 +967,7 @@ CONFIG test:collector:success:test status running
 				cfg := prepareDyncfgCfg("fail", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1009,7 +1009,7 @@ CONFIG test:collector:fail:test status failed
 				cfg := prepareDyncfgCfg("fail", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1075,7 +1075,7 @@ func TestManager_Run_Dyncfg_Disable(t *testing.T) {
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-disable",
 							Args: []string{mgr.dyncfgJobID(cfg), "disable"},
@@ -1099,7 +1099,7 @@ FUNCTION_RESULT_END
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1141,7 +1141,7 @@ CONFIG test:collector:success:test status disabled
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1193,7 +1193,7 @@ CONFIG test:collector:success:test status disabled
 				cfg := prepareDyncfgCfg("fail", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1235,7 +1235,7 @@ CONFIG test:collector:fail:test status disabled
 				cfg := prepareDyncfgCfg("fail", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1301,7 +1301,7 @@ func TestManager_Run_Dyncfg_Restart(t *testing.T) {
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-restart",
 							Args: []string{mgr.dyncfgJobID(cfg), "restart"},
@@ -1325,7 +1325,7 @@ FUNCTION_RESULT_END
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1367,7 +1367,7 @@ CONFIG test:collector:success:test status accepted
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1419,7 +1419,7 @@ CONFIG test:collector:success:test status running
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1471,7 +1471,7 @@ CONFIG test:collector:success:test status disabled
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1547,7 +1547,7 @@ func TestManager_Run_Dyncfg_Remove(t *testing.T) {
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-remove",
 							Args: []string{mgr.dyncfgJobID(cfg), "remove"},
@@ -1573,7 +1573,7 @@ FUNCTION_RESULT_END
 				discCfg := prepareDiscoveredCfg("success", "discovered")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, stockCfg.Source(), stockCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -1649,7 +1649,7 @@ FUNCTION_RESULT_END
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1687,7 +1687,7 @@ CONFIG test:collector:success:test delete
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1749,7 +1749,7 @@ func TestManager_Run_Dyncfg_Update(t *testing.T) {
 				cfg := prepareDyncfgCfg("success", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-update",
 							Args:    []string{mgr.dyncfgJobID(cfg), "update"},
@@ -1779,7 +1779,7 @@ FUNCTION_RESULT_END
 				updBs, _ := json.Marshal(updCfg)
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1838,7 +1838,7 @@ CONFIG test:collector:success:test status running
 				updBs, _ := json.Marshal(updCfg)
 
 				return &runSim{
-					do: func(mgr *Manager, _ chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, _ chan []*confgroup.Group) {
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:     "1-add",
 							Source:  "type=dyncfg",
@@ -1902,13 +1902,16 @@ CONFIG test:collector:success:test status disabled
 // config's enable only after receiving that config's CONFIG CREATE, so tests
 // driving multiple same-key configs must not fire an enable before the
 // previous command's effect published the replacement.
-func waitSourceExposed(mgr *Manager, cfg confgroup.Config) {
+func waitSourceExposed(t *testing.T, mgr *Manager, cfg confgroup.Config) {
+	t.Helper()
 	for range 500 {
 		if e, ok := mgr.collectorExposed.LookupByKey(cfg.ExposedKey()); ok && e.Cfg.SourceType() == cfg.SourceType() {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	t.Fatalf("timed out waiting for source type %q to own the exposed entry for %q",
+		cfg.SourceType(), cfg.ExposedKey())
 }
 
 func sendConfGroup(in chan []*confgroup.Group, src string, configs ...confgroup.Config) {
@@ -1975,7 +1978,7 @@ func TestManager_Run_FunctionOnly(t *testing.T) {
 				cfg := prepareFunctionOnlyCfg("nofuncs", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -2007,7 +2010,7 @@ CONFIG test:collector:nofuncs:test status failed
 				cfg := prepareFunctionOnlyCfg("withfuncs", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",
@@ -2039,7 +2042,7 @@ CONFIG test:collector:withfuncs:test status running
 				cfg := prepareUserCfg("funconly", "test")
 
 				return &runSim{
-					do: func(mgr *Manager, in chan []*confgroup.Group) {
+					do: func(t *testing.T, mgr *Manager, in chan []*confgroup.Group) {
 						sendConfGroup(in, cfg.Source(), cfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "1-enable",

--- a/src/go/plugin/agent/jobmgr/manager_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
@@ -251,12 +253,14 @@ CONFIG test:collector:fail:name delete
 						}))
 
 						sendConfGroup(in, discCfg.Source(), discCfg)
+						waitSourceExposed(mgr, discCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "2-enable",
 							Args: []string{mgr.dyncfgJobID(discCfg), "enable"},
 						}))
 
 						sendConfGroup(in, userCfg.Source(), userCfg)
+						waitSourceExposed(mgr, userCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "3-enable",
 							Args: []string{mgr.dyncfgJobID(userCfg), "enable"},
@@ -277,31 +281,23 @@ CONFIG test:collector:fail:name delete
 						{cfg: userCfg, status: dyncfg.StatusFailed},
 					},
 					wantRunning: nil,
-					wantDyncfg: `
-CONFIG test:collector:fail:stock create accepted job /collectors/test/Jobs stock 'type=stock,module=fail,job=stock' 'schema get enable disable update restart test userconfig' 0x0000 0x0000
-
-FUNCTION_RESULT_BEGIN 1-enable 200 application/json
-{"status":200,"message":"job enable failed: mock failed init"}
-FUNCTION_RESULT_END
-
-CONFIG test:collector:fail:stock delete
-
-CONFIG test:collector:fail:discovered create accepted job /collectors/test/Jobs discovered 'type=discovered,module=fail,job=discovered' 'schema get enable disable update restart test userconfig' 0x0000 0x0000
-
-FUNCTION_RESULT_BEGIN 2-enable 200 application/json
-{"status":200,"message":"job enable failed: mock failed init"}
-FUNCTION_RESULT_END
-
-CONFIG test:collector:fail:discovered status failed
-
-CONFIG test:collector:fail:user create accepted job /collectors/test/Jobs user 'type=user,module=fail,job=user' 'schema get enable disable update restart test userconfig' 0x0000 0x0000
-
-FUNCTION_RESULT_BEGIN 3-enable 200 application/json
-{"status":200,"message":"job enable failed: mock failed init"}
-FUNCTION_RESULT_END
-
-CONFIG test:collector:fail:user status failed
-		`,
+					wantDyncfgRecords: [][]wiretest.RecordWant{
+						{
+							{Name: "stock create", Contains: []string{"CONFIG test:collector:fail:stock create accepted job /collectors/test/Jobs stock 'type=stock,module=fail,job=stock'"}},
+							{Name: "stock enable failed", Contains: []string{"FUNCTION_RESULT_BEGIN 1-enable 200", `"message":"job enable failed: mock failed init"`}},
+							{Name: "stock delete", Contains: []string{"CONFIG test:collector:fail:stock delete"}},
+						},
+						{
+							{Name: "discovered create", Contains: []string{"CONFIG test:collector:fail:discovered create accepted job /collectors/test/Jobs discovered 'type=discovered,module=fail,job=discovered'"}},
+							{Name: "discovered enable failed", Contains: []string{"FUNCTION_RESULT_BEGIN 2-enable 200", `"message":"job enable failed: mock failed init"`}},
+							{Name: "discovered status failed", Contains: []string{"CONFIG test:collector:fail:discovered status failed"}},
+						},
+						{
+							{Name: "user create", Contains: []string{"CONFIG test:collector:fail:user create accepted job /collectors/test/Jobs user 'type=user,module=fail,job=user'"}},
+							{Name: "user enable failed", Contains: []string{"FUNCTION_RESULT_BEGIN 3-enable 200", `"message":"job enable failed: mock failed init"`}},
+							{Name: "user status failed", Contains: []string{"CONFIG test:collector:fail:user status failed"}},
+						},
+					},
 				}
 			},
 		},
@@ -320,12 +316,14 @@ CONFIG test:collector:fail:user status failed
 						}))
 
 						sendConfGroup(in, discCfg.Source(), discCfg)
+						waitSourceExposed(mgr, discCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "2-enable",
 							Args: []string{mgr.dyncfgJobID(discCfg), "enable"},
 						}))
 
 						sendConfGroup(in, userCfg.Source(), userCfg)
+						waitSourceExposed(mgr, userCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "3-enable",
 							Args: []string{mgr.dyncfgJobID(userCfg), "enable"},
@@ -388,12 +386,14 @@ CONFIG test:collector:fail:name status failed
 						}))
 
 						sendConfGroup(in, discCfg.Source(), discCfg)
+						waitSourceExposed(mgr, discCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "2-enable",
 							Args: []string{mgr.dyncfgJobID(discCfg), "enable"},
 						}))
 
 						sendConfGroup(in, userCfg.Source(), userCfg)
+						waitSourceExposed(mgr, userCfg)
 						mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
 							UID:  "3-enable",
 							Args: []string{mgr.dyncfgJobID(userCfg), "enable"},
@@ -1621,43 +1621,26 @@ FUNCTION_RESULT_END
 						{cfg: discCfg, status: dyncfg.StatusRunning},
 					},
 					wantRunning: []string{stockCfg.FullName(), userCfg.FullName(), discCfg.FullName()},
-					wantDyncfg: `
-CONFIG test:collector:success:stock create accepted job /collectors/test/Jobs stock 'type=stock,module=success,job=stock' 'schema get enable disable update restart test userconfig' 0x0000 0x0000
-
-FUNCTION_RESULT_BEGIN 1-enable 200 application/json
-{"status":200,"message":""}
-FUNCTION_RESULT_END
-
-CONFIG test:collector:success:stock status running
-
-CONFIG test:collector:success:user create accepted job /collectors/test/Jobs user 'type=user,module=success,job=user' 'schema get enable disable update restart test userconfig' 0x0000 0x0000
-
-FUNCTION_RESULT_BEGIN 2-enable 200 application/json
-{"status":200,"message":""}
-FUNCTION_RESULT_END
-
-CONFIG test:collector:success:user status running
-
-CONFIG test:collector:success:discovered create accepted job /collectors/test/Jobs discovered 'type=discovered,module=success,job=discovered' 'schema get enable disable update restart test userconfig' 0x0000 0x0000
-
-FUNCTION_RESULT_BEGIN 3-enable 200 application/json
-{"status":200,"message":""}
-FUNCTION_RESULT_END
-
-CONFIG test:collector:success:discovered status running
-
-FUNCTION_RESULT_BEGIN 1-remove 405 application/json
-{"status":405,"errorMessage":"removing configurations of source type 'stock' is not supported, only 'dyncfg' configurations can be removed."}
-FUNCTION_RESULT_END
-
-FUNCTION_RESULT_BEGIN 2-remove 405 application/json
-{"status":405,"errorMessage":"removing configurations of source type 'user' is not supported, only 'dyncfg' configurations can be removed."}
-FUNCTION_RESULT_END
-
-FUNCTION_RESULT_BEGIN 3-remove 405 application/json
-{"status":405,"errorMessage":"removing configurations of source type 'discovered' is not supported, only 'dyncfg' configurations can be removed."}
-FUNCTION_RESULT_END
-`,
+					wantDyncfgRecords: [][]wiretest.RecordWant{
+						{
+							{Name: "stock create", Contains: []string{"CONFIG test:collector:success:stock create accepted job /collectors/test/Jobs stock 'type=stock,module=success,job=stock'"}},
+							{Name: "stock enable ok", Contains: []string{"FUNCTION_RESULT_BEGIN 1-enable 200", `"status":200`}},
+							{Name: "stock running", Contains: []string{"CONFIG test:collector:success:stock status running"}},
+							{Name: "stock remove rejected", Contains: []string{"FUNCTION_RESULT_BEGIN 1-remove 405", "source type 'stock' is not supported"}},
+						},
+						{
+							{Name: "user create", Contains: []string{"CONFIG test:collector:success:user create accepted job /collectors/test/Jobs user 'type=user,module=success,job=user'"}},
+							{Name: "user enable ok", Contains: []string{"FUNCTION_RESULT_BEGIN 2-enable 200", `"status":200`}},
+							{Name: "user running", Contains: []string{"CONFIG test:collector:success:user status running"}},
+							{Name: "user remove rejected", Contains: []string{"FUNCTION_RESULT_BEGIN 2-remove 405", "source type 'user' is not supported"}},
+						},
+						{
+							{Name: "discovered create", Contains: []string{"CONFIG test:collector:success:discovered create accepted job /collectors/test/Jobs discovered 'type=discovered,module=success,job=discovered'"}},
+							{Name: "discovered enable ok", Contains: []string{"FUNCTION_RESULT_BEGIN 3-enable 200", `"status":200`}},
+							{Name: "discovered running", Contains: []string{"CONFIG test:collector:success:discovered status running"}},
+							{Name: "discovered remove rejected", Contains: []string{"FUNCTION_RESULT_BEGIN 3-remove 405", "source type 'discovered' is not supported"}},
+						},
+					},
 				}
 			},
 		},
@@ -1911,6 +1894,20 @@ CONFIG test:collector:success:test status disabled
 			sim := test.createSim()
 			sim.run(t)
 		})
+	}
+}
+
+// waitSourceExposed blocks until cfg's source type owns the exposed entry for
+// its key - the daemon-faithful sequencing point: a real daemon sends a
+// config's enable only after receiving that config's CONFIG CREATE, so tests
+// driving multiple same-key configs must not fire an enable before the
+// previous command's effect published the replacement.
+func waitSourceExposed(mgr *Manager, cfg confgroup.Config) {
+	for range 500 {
+		if e, ok := mgr.collectorExposed.LookupByKey(cfg.ExposedKey()); ok && e.Cfg.SourceType() == cfg.SourceType() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/manager_v2_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_v2_test.go
@@ -126,7 +126,7 @@ func TestManagerCreateCollectorJobV2Branching(t *testing.T) {
 				cfg.Set("function_only", true)
 			}
 
-			job, err := mgr.createCollectorJob(cfg)
+			job, err := mgr.createCollectorJob(context.Background(), cfg)
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
@@ -151,7 +151,7 @@ func TestManagerCreateCollectorJobSingleInstancePolicyAllowsV2FunctionOnly(t *te
 		},
 	}
 
-	job, err := mgr.createCollectorJob(prepareFunctionOnlyCfg("testmod", "testmod"))
+	job, err := mgr.createCollectorJob(context.Background(), prepareFunctionOnlyCfg("testmod", "testmod"))
 	require.NoError(t, err)
 	require.NotNil(t, job)
 	require.NoError(t, job.AutoDetection(context.Background()))
@@ -172,7 +172,7 @@ func TestManagerCreateCollectorJobSetsJobNameV2(t *testing.T) {
 		},
 	}
 
-	job, err := mgr.createCollectorJob(prepareUserCfg("testmod", "job1"))
+	job, err := mgr.createCollectorJob(context.Background(), prepareUserCfg("testmod", "job1"))
 	require.NoError(t, err)
 	assert.Same(t, mod, job.Collector())
 	assert.Equal(t, "job1", mod.jobName)
@@ -187,7 +187,7 @@ func TestManagerCreateCollectorJobSetsJobNameV1(t *testing.T) {
 		},
 	}
 
-	job, err := mgr.createCollectorJob(prepareUserCfg("testmod", "job1"))
+	job, err := mgr.createCollectorJob(context.Background(), prepareUserCfg("testmod", "job1"))
 	require.NoError(t, err)
 	assert.Same(t, mod, job.Collector())
 	assert.Equal(t, "job1", mod.jobName)
@@ -247,7 +247,7 @@ func TestManagerCreateCollectorJobSingleInstancePolicyRequiresCanonicalName(t *t
 				"testmod": tc.creator(&created),
 			}
 
-			job, err := mgr.createCollectorJob(prepareUserCfg("testmod", tc.jobName))
+			job, err := mgr.createCollectorJob(context.Background(), prepareUserCfg("testmod", tc.jobName))
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)

--- a/src/go/plugin/agent/jobmgr/secretsctl/cache.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/cache.go
@@ -98,7 +98,7 @@ func (c *Controller) validateConfig(cfg secretstore.Config) error {
 	if c.service == nil {
 		return fmt.Errorf("secretstore service is not available")
 	}
-	return c.service.Validate(secretStoreResolveContext(c.Logger, cfg), cfg)
+	return c.service.Validate(secretStoreResolveContext(context.Background(), c.Logger, cfg), cfg)
 }
 
 func (c *Controller) validateStored(key string) error {
@@ -111,7 +111,7 @@ func (c *Controller) validateStored(key string) error {
 	}
 
 	if _, ok := c.service.GetStatus(key); ok {
-		return c.service.ValidateStored(secretStoreResolveContextForKey(c.Logger, key, entry.Cfg.Kind(), entry.Cfg.Name()), key)
+		return c.service.ValidateStored(secretStoreResolveContextForKey(context.Background(), c.Logger, key, entry.Cfg.Kind(), entry.Cfg.Name()), key)
 	}
 
 	return c.validateConfig(entry.Cfg)

--- a/src/go/plugin/agent/jobmgr/secretsctl/cache.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/cache.go
@@ -3,6 +3,7 @@
 package secretsctl
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -61,7 +62,7 @@ func (c *Controller) rememberDiscoveredConfig(cfg secretstore.Config) (*dyncfg.E
 	}
 
 	if entry.Status == dyncfg.StatusRunning || entry.Status == dyncfg.StatusFailed {
-		c.cb.Stop(entry.Cfg)
+		c.cb.Stop(context.Background(), entry.Cfg)
 		c.cb.TakeCommandMessage()
 	}
 
@@ -84,7 +85,7 @@ func (c *Controller) removeDiscoveredConfig(cfg secretstore.Config) (*dyncfg.Ent
 		return nil, false
 	}
 
-	c.cb.Stop(entry.Cfg)
+	c.cb.Stop(context.Background(), entry.Cfg)
 	c.cb.TakeCommandMessage()
 	c.handler.NotifyConfigRemove(entry.Cfg)
 	return entry, true

--- a/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
@@ -93,18 +93,21 @@ func (d secretStoreCallbackDeps) secretStoreConfigFromPayload(fn dyncfg.Function
 	return payload, nil
 }
 
-func (d secretStoreCallbackDeps) validateSecretStoreConfig(cfg secretstore.Config) error {
+func (d secretStoreCallbackDeps) validateSecretStoreConfig(ctx context.Context, cfg secretstore.Config) error {
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
 	if d.service == nil {
 		return fmt.Errorf("secretstore service is not available")
 	}
-	return d.service.Validate(d.resolveContext(cfg), cfg)
+	return d.service.Validate(d.resolveContext(ctx, cfg), cfg)
 }
 
-func (d secretStoreCallbackDeps) resolveContext(cfg secretstore.Config) context.Context {
-	return secretStoreResolveContext(d.log, cfg)
+// resolveContext derives the service-call context from the caller's: the
+// domain runs loop-synchronously today (ctx is Background), but callers'
+// cancellation propagates once the domain moves onto the executor.
+func (d secretStoreCallbackDeps) resolveContext(ctx context.Context, cfg secretstore.Config) context.Context {
+	return secretStoreResolveContext(ctx, d.log, cfg)
 }
 
 func (d secretStoreCallbackDeps) dyncfgSecretStoreID(id string) string {
@@ -136,7 +139,7 @@ func (cb *secretStoreCallbacks) ValidateConfigName(name string) error {
 	return dyncfg.JobNameRuleAllowDots(name)
 }
 
-func (cb *secretStoreCallbacks) ParseAndValidate(_ context.Context, fn dyncfg.Function, name string) (secretstore.Config, error) {
+func (cb *secretStoreCallbacks) ParseAndValidate(ctx context.Context, fn dyncfg.Function, name string) (secretstore.Config, error) {
 	var kind secretstore.StoreKind
 	if fn.Command() == dyncfg.CommandAdd {
 		var ok bool
@@ -160,13 +163,13 @@ func (cb *secretStoreCallbacks) ParseAndValidate(_ context.Context, fn dyncfg.Fu
 	if err != nil {
 		return nil, err
 	}
-	if err := cb.deps.validateSecretStoreConfig(cfg); err != nil {
+	if err := cb.deps.validateSecretStoreConfig(ctx, cfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil
 }
 
-func (cb *secretStoreCallbacks) Start(_ context.Context, cfg secretstore.Config) error {
+func (cb *secretStoreCallbacks) Start(ctx context.Context, cfg secretstore.Config) error {
 	cb.commandMessage = ""
 	key := cfg.ExposedKey()
 	if cb.deps.service == nil {
@@ -174,10 +177,10 @@ func (cb *secretStoreCallbacks) Start(_ context.Context, cfg secretstore.Config)
 	}
 
 	if _, ok := cb.deps.service.GetStatus(key); ok {
-		if err := cb.deps.service.Update(cb.deps.resolveContext(cfg), key, cfg); err != nil {
+		if err := cb.deps.service.Update(cb.deps.resolveContext(ctx, cfg), key, cfg); err != nil {
 			return &codedError{err: err, code: secretStoreErrorCode(err)}
 		}
-	} else if err := cb.deps.service.Add(cb.deps.resolveContext(cfg), cfg); err != nil {
+	} else if err := cb.deps.service.Add(cb.deps.resolveContext(ctx, cfg), cfg); err != nil {
 		return &codedError{err: err, code: secretStoreErrorCode(err)}
 	}
 
@@ -185,7 +188,7 @@ func (cb *secretStoreCallbacks) Start(_ context.Context, cfg secretstore.Config)
 	return nil
 }
 
-func (cb *secretStoreCallbacks) Update(_ context.Context, oldCfg, newCfg secretstore.Config) error {
+func (cb *secretStoreCallbacks) Update(ctx context.Context, oldCfg, newCfg secretstore.Config) error {
 	cb.commandMessage = ""
 	key := oldCfg.ExposedKey()
 	if cb.deps.service == nil {
@@ -193,10 +196,10 @@ func (cb *secretStoreCallbacks) Update(_ context.Context, oldCfg, newCfg secrets
 	}
 
 	if _, ok := cb.deps.service.GetStatus(key); ok {
-		if err := cb.deps.service.Update(cb.deps.resolveContext(newCfg), key, newCfg); err != nil {
+		if err := cb.deps.service.Update(cb.deps.resolveContext(ctx, newCfg), key, newCfg); err != nil {
 			return &codedError{err: err, code: secretStoreErrorCode(err)}
 		}
-	} else if err := cb.deps.service.Add(cb.deps.resolveContext(newCfg), newCfg); err != nil {
+	} else if err := cb.deps.service.Add(cb.deps.resolveContext(ctx, newCfg), newCfg); err != nil {
 		return &codedError{err: err, code: secretStoreErrorCode(err)}
 	}
 

--- a/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
@@ -136,7 +136,7 @@ func (cb *secretStoreCallbacks) ValidateConfigName(name string) error {
 	return dyncfg.JobNameRuleAllowDots(name)
 }
 
-func (cb *secretStoreCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (secretstore.Config, error) {
+func (cb *secretStoreCallbacks) ParseAndValidate(_ context.Context, fn dyncfg.Function, name string) (secretstore.Config, error) {
 	var kind secretstore.StoreKind
 	if fn.Command() == dyncfg.CommandAdd {
 		var ok bool
@@ -166,7 +166,7 @@ func (cb *secretStoreCallbacks) ParseAndValidate(fn dyncfg.Function, name string
 	return cfg, nil
 }
 
-func (cb *secretStoreCallbacks) Start(cfg secretstore.Config) error {
+func (cb *secretStoreCallbacks) Start(_ context.Context, cfg secretstore.Config) error {
 	cb.commandMessage = ""
 	key := cfg.ExposedKey()
 	if cb.deps.service == nil {
@@ -185,7 +185,7 @@ func (cb *secretStoreCallbacks) Start(cfg secretstore.Config) error {
 	return nil
 }
 
-func (cb *secretStoreCallbacks) Update(oldCfg, newCfg secretstore.Config) error {
+func (cb *secretStoreCallbacks) Update(_ context.Context, oldCfg, newCfg secretstore.Config) error {
 	cb.commandMessage = ""
 	key := oldCfg.ExposedKey()
 	if cb.deps.service == nil {
@@ -204,7 +204,7 @@ func (cb *secretStoreCallbacks) Update(oldCfg, newCfg secretstore.Config) error 
 	return nil
 }
 
-func (cb *secretStoreCallbacks) Stop(cfg secretstore.Config) {
+func (cb *secretStoreCallbacks) Stop(_ context.Context, cfg secretstore.Config) {
 	cb.commandMessage = ""
 	key := cfg.ExposedKey()
 	if cb.deps.service == nil {

--- a/src/go/plugin/agent/jobmgr/secretsctl/callbacks_test.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/callbacks_test.go
@@ -29,12 +29,12 @@ func TestSecretStoreCallbacks(t *testing.T) {
 				assert.Equal(t, secretstore.StoreKey(secretstore.KindVault, "vault_prod"), key)
 				assert.Equal(t, "vault_prod", name)
 
-				cfg, err := cb.ParseAndValidate(addFn, name)
+				cfg, err := cb.ParseAndValidate(context.Background(), addFn, name)
 				require.NoError(t, err)
 				assert.Empty(t, restart.calls)
 				assert.Equal(t, "", cb.TakeCommandMessage())
 
-				require.NoError(t, cb.Start(cfg))
+				require.NoError(t, cb.Start(context.Background(), cfg))
 				assert.Equal(t, []string{key}, restart.calls)
 				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
 				assert.Equal(t, testSecretStoreConfigID(key), cb.ConfigID(cfg))
@@ -51,16 +51,16 @@ func TestSecretStoreCallbacks(t *testing.T) {
 				assert.Equal(t, key, updateKey)
 				assert.Equal(t, name, updateName)
 
-				updatedCfg, err := cb.ParseAndValidate(updateFn, "")
+				updatedCfg, err := cb.ParseAndValidate(context.Background(), updateFn, "")
 				require.NoError(t, err)
 				assert.Len(t, restart.calls, 1)
 
-				require.NoError(t, cb.Update(cfg, updatedCfg))
+				require.NoError(t, cb.Update(context.Background(), cfg, updatedCfg))
 				assert.Equal(t, []string{key, key}, restart.calls)
 				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
 				assert.Equal(t, "two", resolveTestStoreValue(t, svc, key))
 
-				cb.Stop(updatedCfg)
+				cb.Stop(context.Background(), updatedCfg)
 				assert.Equal(t, []string{key, key, key}, restart.calls)
 				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
 				_, ok = svc.GetStatus(key)
@@ -73,7 +73,7 @@ func TestSecretStoreCallbacks(t *testing.T) {
 				key, name, ok := cb.ExtractKey(addFn)
 				require.True(t, ok)
 
-				cfg, err := cb.ParseAndValidate(addFn, name)
+				cfg, err := cb.ParseAndValidate(context.Background(), addFn, name)
 				require.NoError(t, err)
 				assert.Empty(t, restart.calls)
 
@@ -82,20 +82,20 @@ func TestSecretStoreCallbacks(t *testing.T) {
 				cb.OnStatusChange(nil, dyncfg.StatusAccepted, addFn)
 				assert.Empty(t, restart.calls)
 
-				require.NoError(t, cb.Start(cfg))
+				require.NoError(t, cb.Start(context.Background(), cfg))
 				assert.Equal(t, []string{key}, restart.calls)
 				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
 
 				updateFn := newSecretStoreCallbackFunction(t, "ss-mutate-update", testSecretStoreConfigID(key), dyncfg.CommandUpdate, "", map[string]any{"value": "two"})
-				updatedCfg, err := cb.ParseAndValidate(updateFn, "")
+				updatedCfg, err := cb.ParseAndValidate(context.Background(), updateFn, "")
 				require.NoError(t, err)
 				assert.Len(t, restart.calls, 1)
 
-				require.NoError(t, cb.Update(cfg, updatedCfg))
+				require.NoError(t, cb.Update(context.Background(), cfg, updatedCfg))
 				assert.Equal(t, []string{key, key}, restart.calls)
 				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
 
-				cb.Stop(updatedCfg)
+				cb.Stop(context.Background(), updatedCfg)
 				assert.Equal(t, []string{key, key, key}, restart.calls)
 				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
 			},

--- a/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
@@ -3,6 +3,7 @@
 package secretsctl
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -98,7 +99,7 @@ func (c *Controller) dyncfgCmdAdd(fn dyncfg.Function) {
 	code := 200
 	msg := ""
 	if prepErr == nil {
-		if err := c.cb.Start(cfg); err == nil {
+		if err := c.cb.Start(context.Background(), cfg); err == nil {
 			entry.Status = dyncfg.StatusRunning
 			msg = c.cb.TakeCommandMessage()
 		} else {

--- a/src/go/plugin/agent/jobmgr/secretsctl/initial.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/initial.go
@@ -3,6 +3,7 @@
 package secretsctl
 
 import (
+	"context"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 )
@@ -16,14 +17,14 @@ func (c *Controller) publishInitialConfig(rawCfg secretstore.Config) {
 			return
 		}
 		if existing.Status == dyncfg.StatusRunning || existing.Status == dyncfg.StatusFailed {
-			c.cb.Stop(existing.Cfg)
+			c.cb.Stop(context.Background(), existing.Cfg)
 			c.cb.TakeCommandMessage()
 		}
 	}
 
 	entry := &dyncfg.Entry[secretstore.Config]{Cfg: cfg, Status: dyncfg.StatusFailed}
 	if prepErr == nil {
-		if err := c.cb.Start(cfg); err == nil {
+		if err := c.cb.Start(context.Background(), cfg); err == nil {
 			entry.Status = dyncfg.StatusRunning
 		}
 	}

--- a/src/go/plugin/agent/jobmgr/secretsctl/logctx.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/logctx.go
@@ -10,14 +10,14 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 )
 
-func secretStoreResolveContext(log *logger.Logger, cfg secretstore.Config) context.Context {
+func secretStoreResolveContext(ctx context.Context, log *logger.Logger, cfg secretstore.Config) context.Context {
 	if cfg == nil {
-		return logger.ContextWithLogger(context.Background(), log)
+		return logger.ContextWithLogger(ctx, log)
 	}
-	return secretStoreResolveContextForKey(log, cfg.ExposedKey(), cfg.Kind(), cfg.Name())
+	return secretStoreResolveContextForKey(ctx, log, cfg.ExposedKey(), cfg.Kind(), cfg.Name())
 }
 
-func secretStoreResolveContextForKey(log *logger.Logger, key string, kind secretstore.StoreKind, name string) context.Context {
+func secretStoreResolveContextForKey(ctx context.Context, log *logger.Logger, key string, kind secretstore.StoreKind, name string) context.Context {
 	if log != nil {
 		log = log.With(
 			slog.String("secretstore", key),
@@ -25,5 +25,5 @@ func secretStoreResolveContextForKey(log *logger.Logger, key string, kind secret
 			slog.String("secretstore_name", name),
 		)
 	}
-	return logger.ContextWithLogger(context.Background(), log)
+	return logger.ContextWithLogger(ctx, log)
 }

--- a/src/go/plugin/agent/jobmgr/secretstore_flow_test.go
+++ b/src/go/plugin/agent/jobmgr/secretstore_flow_test.go
@@ -179,7 +179,7 @@ func TestDyncfgSecretStoreUpdate_DependentRestartBehavior(t *testing.T) {
 					Status: dyncfg.StatusRunning,
 				})
 				mgr.syncSecretStoreDepsForConfig(cfg)
-				require.NoError(t, mgr.collectorCallbacks.Start(cfg))
+				require.NoError(t, mgr.collectorCallbacks.Start(context.Background(), cfg))
 
 				_, running := mgr.secretStoreDeps.Impacted(key)
 				require.Len(t, running, 1)

--- a/src/go/plugin/agent/jobmgr/sim_test.go
+++ b/src/go/plugin/agent/jobmgr/sim_test.go
@@ -31,7 +31,7 @@ type wantExposedEntry struct {
 }
 
 type runSim struct {
-	do func(mgr *Manager, in chan []*confgroup.Group)
+	do func(t *testing.T, mgr *Manager, in chan []*confgroup.Group)
 
 	wantDiscovered []confgroup.Config
 	wantSeen       []confgroup.Config
@@ -112,7 +112,7 @@ func (s *runSim) run(t *testing.T) {
 		t.Errorf("failed to start work in %s", timeout)
 	}
 
-	s.do(mgr, grpCh)
+	s.do(t, mgr, grpCh)
 
 	expectedResults := strings.Count(s.wantDyncfg, "FUNCTION_RESULT_END")
 	for _, wants := range s.wantDyncfgRecords {

--- a/src/go/plugin/agent/jobmgr/sim_test.go
+++ b/src/go/plugin/agent/jobmgr/sim_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
@@ -37,6 +38,12 @@ type runSim struct {
 	wantExposed    []wantExposedEntry
 	wantRunning    []string
 	wantDyncfg     string
+	// wantDyncfgRecords is the per-key alternative to wantDyncfg for
+	// multi-key scenarios: each element is one key's expected atomic-record
+	// subsequence, asserted independently against the full transcript, plus
+	// a completeness check (total record count must equal the sum of wants),
+	// so only cross-key interleaving is left unconstrained.
+	wantDyncfgRecords [][]wiretest.RecordWant
 }
 
 const funcResultEndMarker = "FUNCTION_RESULT_END\n\n"
@@ -108,6 +115,16 @@ func (s *runSim) run(t *testing.T) {
 	s.do(mgr, grpCh)
 
 	expectedResults := strings.Count(s.wantDyncfg, "FUNCTION_RESULT_END")
+	for _, wants := range s.wantDyncfgRecords {
+		for _, want := range wants {
+			for _, sub := range want.Contains {
+				if strings.HasPrefix(sub, "FUNCTION_RESULT_BEGIN") {
+					expectedResults++
+					break
+				}
+			}
+		}
+	}
 	require.Eventually(t, func() bool {
 		return countDiscovered(mgr) == len(s.wantDiscovered) &&
 			mgr.collectorSeen.Count() == len(s.wantSeen) &&
@@ -115,6 +132,11 @@ func (s *runSim) run(t *testing.T) {
 			runningSetMatches(mgr.runningJobs.snapshot(), s.wantRunning) &&
 			out.FuncResultCount() >= expectedResults
 	}, timeout, 10*time.Millisecond, "manager state did not settle before shutdown")
+	if t.Failed() {
+		t.Logf("settle state: discovered %d/%d seen %d/%d exposed %d/%d results %d/%d",
+			countDiscovered(mgr), len(s.wantDiscovered), mgr.collectorSeen.Count(), len(s.wantSeen),
+			mgr.collectorExposed.Count(), len(s.wantExposed), out.FuncResultCount(), expectedResults)
+	}
 
 	runningBeforeShutdown := make(map[string]struct{})
 	for _, job := range mgr.runningJobs.snapshot() {
@@ -155,7 +177,18 @@ func (s *runSim) run(t *testing.T) {
 
 	//fmt.Println(gotDyncfg)
 
-	assert.Equal(t, wantDyncfg, gotDyncfg, "dyncfg commands")
+	if len(s.wantDyncfgRecords) > 0 {
+		require.Empty(t, s.wantDyncfg, "use either wantDyncfg or wantDyncfgRecords, not both")
+		total := 0
+		for _, wants := range s.wantDyncfgRecords {
+			wiretest.RequireSubsequence(t, gotDyncfg, wants)
+			total += len(wants)
+		}
+		assert.Len(t, wiretest.AtomicRecords(gotDyncfg), total,
+			"transcript must contain exactly the expected records (cross-key order free)")
+	} else {
+		assert.Equal(t, wantDyncfg, gotDyncfg, "dyncfg commands")
+	}
 
 	var n int
 	for _, cfgs := range mgr.discoveredConfigs.items {

--- a/src/go/plugin/agent/jobmgr/vnodectl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/controller_test.go
@@ -6,8 +6,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/logger"
@@ -351,14 +351,14 @@ func TestControllerSeqExec(t *testing.T) {
 				fn := dyncfg.NewFunction(functions.Function{UID: "vn-remove", Args: []string{ctl.configID("db"), string(dyncfg.CommandRemove)}})
 				ctl.SeqExec(fn)
 
-				requireWireRecordSubsequence(t, out.String(), []wireRecordWant{
+				wiretest.RequireSubsequence(t, out.String(), []wiretest.RecordWant{
 					{
-						name:     "vnode config delete",
-						contains: []string{"CONFIG test:vnode:db delete"},
+						Name:     "vnode config delete",
+						Contains: []string{"CONFIG test:vnode:db delete"},
 					},
 					{
-						name:     "vnode remove terminal",
-						contains: []string{"FUNCTION_RESULT_BEGIN vn-remove 200"},
+						Name:     "vnode remove terminal",
+						Contains: []string{"FUNCTION_RESULT_BEGIN vn-remove 200"},
 					},
 				})
 				assert.Equal(t, []string{"db"}, seams.affectedJobsCalls)
@@ -492,69 +492,6 @@ func mustFunctionBody(t *testing.T, output, uid string) string {
 	match := re.FindStringSubmatch(output)
 	require.Len(t, match, 2, "function result for uid '%s' not found in output:\n%s", uid, output)
 	return match[1]
-}
-
-type wireRecordWant struct {
-	name     string
-	contains []string
-}
-
-func atomicWireRecords(output string) []string {
-	var records []string
-	lines := strings.Split(output, "\n")
-	for i := 0; i < len(lines); {
-		line := lines[i]
-		if line == "" {
-			i++
-			continue
-		}
-		if !strings.HasPrefix(line, "FUNCTION_RESULT_BEGIN ") {
-			records = append(records, line)
-			i++
-			continue
-		}
-
-		var b strings.Builder
-		b.WriteString(line)
-		i++
-		for i < len(lines) {
-			b.WriteByte('\n')
-			b.WriteString(lines[i])
-			if lines[i] == "FUNCTION_RESULT_END" {
-				i++
-				break
-			}
-			i++
-		}
-		records = append(records, b.String())
-	}
-	return records
-}
-
-func requireWireRecordSubsequence(t *testing.T, output string, wants []wireRecordWant) {
-	t.Helper()
-
-	records := atomicWireRecords(output)
-	next := 0
-	for _, want := range wants {
-		found := -1
-		for i := next; i < len(records); i++ {
-			matched := true
-			for _, substr := range want.contains {
-				if !strings.Contains(records[i], substr) {
-					matched = false
-					break
-				}
-			}
-			if matched {
-				found = i
-				break
-			}
-		}
-		require.NotEqualf(t, -1, found, "wire record %q not found after index %d in records:\n%s",
-			want.name, next, strings.Join(records, "\n---\n"))
-		next = found + 1
-	}
 }
 
 func mustDecodeFunctionPayload(t *testing.T, output, uid string, dst any) {

--- a/src/go/plugin/agent/jobmgr/vnodectl/store.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/store.go
@@ -4,13 +4,15 @@ package vnodectl
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
 
-// vnodeStore is intentionally lock-free because mutations are serialized by jobmgr.
-// Any caller outside that serialized path must add its own synchronization first.
+// vnodeStore is read from collector command effects running off the jobmgr
+// loop while vnode mutations stay loop-serialized, so access is guarded by mu.
 type vnodeStore struct {
+	mu    sync.RWMutex
 	items map[string]*vnodes.VirtualNode
 }
 
@@ -22,11 +24,15 @@ func newVnodeStore(items map[string]*vnodes.VirtualNode) *vnodeStore {
 }
 
 func (s *vnodeStore) Lookup(name string) (*vnodes.VirtualNode, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	cfg, ok := s.items[name]
 	return cfg, ok
 }
 
 func (s *vnodeStore) Upsert(cfg *vnodes.VirtualNode) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if cfg == nil {
 		return false, fmt.Errorf("nil vnode config")
 	}
@@ -38,6 +44,8 @@ func (s *vnodeStore) Upsert(cfg *vnodes.VirtualNode) (bool, error) {
 }
 
 func (s *vnodeStore) Remove(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if _, ok := s.items[name]; !ok {
 		return false
 	}
@@ -46,6 +54,8 @@ func (s *vnodeStore) Remove(name string) bool {
 }
 
 func (s *vnodeStore) ForEach(fn func(cfg *vnodes.VirtualNode) bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	for _, cfg := range s.items {
 		if !fn(cfg) {
 			return

--- a/src/go/plugin/framework/dyncfg/handler.go
+++ b/src/go/plugin/framework/dyncfg/handler.go
@@ -19,7 +19,7 @@ type Callbacks[C Config] interface {
 
 	// ParseAndValidate parses payload into a config with dyncfg metadata set.
 	// Includes all validation (including heavy checks like module instantiation).
-	ParseAndValidate(fn Function, name string) (C, error)
+	ParseAndValidate(ctx context.Context, fn Function, name string) (C, error)
 
 	// ValidateConfigName enforces the domain's config-name policy. Called before
 	// ParseAndValidate so cheap name-format rejections happen without parsing payload.
@@ -29,16 +29,16 @@ type Callbacks[C Config] interface {
 	// including pre-start cleanup and post-fail retry scheduling.
 	// Return CodedError to override EnableFailCode.
 	// Used by CmdEnable and CmdUpdate (conversion only).
-	Start(cfg C) error
+	Start(ctx context.Context, cfg C) error
 
 	// Update handles non-conversion config updates (dyncfg->dyncfg).
 	// Called after caches are already updated. SD uses mgr.Restart
 	// for graceful transition; jobmgr uses Stop+Start.
-	Update(oldCfg, newCfg C) error
+	Update(ctx context.Context, oldCfg, newCfg C) error
 
 	// Stop stops all work and cleans up all component state for a config.
 	// Safe to call for non-running configs (all ops are no-ops).
-	Stop(cfg C)
+	Stop(ctx context.Context, cfg C)
 
 	// OnStatusChange is called after status transitions in enable/disable/update.
 	// Not called in CmdAdd or CmdRemove.
@@ -444,8 +444,58 @@ func (h *Handler[C]) configSupportedCommands(cfg C, isDyncfg bool) string {
 	return JoinCommands(cmds...)
 }
 
+// StepRunner executes a command's blocking phase (effect) and then its
+// commit. The synchronous runner executes both inline on the caller,
+// preserving the legacy behavior; an asynchronous runner may execute the
+// effect off-thread and the commit later, under this contract: commit runs
+// EXACTLY ONCE after the effect returns, the two closures of one command
+// never run concurrently, and a commit may invoke the runner again to chain
+// another blocking phase of the same command.
+type StepRunner func(effect func(context.Context) error, commit func(error))
+
+// RunStepSync is the synchronous StepRunner used by the legacy Cmd* methods.
+func RunStepSync(effect func(context.Context) error, commit func(error)) {
+	commit(effect(context.Background()))
+}
+
+// ErrPhaseNeverRan is committed for a blocking phase that was never executed
+// (runtime shutting down before it could run). Stop-shaped commits MUST NOT
+// publish success on it: unlike a deadline abandonment - where the stop ran,
+// wedged, and the job's output was fenced - nothing happened at all.
+var ErrPhaseNeverRan = errors.New("the operation did not run: shutting down")
+
+// ErrPhaseAbandoned is committed for a blocking phase that ran past its
+// deadline (or into shutdown) and was abandoned with the job's output
+// fenced. Stop-shaped commits publish success on it by contract - the
+// stop is guaranteed to be effective even though the call has not
+// returned. Any other stop error (e.g. a recovered panic) proves nothing
+// about the job's state and MUST commit as failed.
+var ErrPhaseAbandoned = errors.New("the operation was abandoned")
+
+// CmdAddStep is CmdAdd with a caller-supplied StepRunner.
+func (h *Handler[C]) CmdAddStep(fn Function, run StepRunner) { h.cmdAdd(fn, run) }
+
+// CmdEnableStep is CmdEnable with a caller-supplied StepRunner.
+func (h *Handler[C]) CmdEnableStep(fn Function, run StepRunner) { h.cmdEnable(fn, run) }
+
+// CmdDisableStep is CmdDisable with a caller-supplied StepRunner.
+func (h *Handler[C]) CmdDisableStep(fn Function, run StepRunner) { h.cmdDisable(fn, run) }
+
+// CmdRemoveStep is CmdRemove with a caller-supplied StepRunner.
+func (h *Handler[C]) CmdRemoveStep(fn Function, run StepRunner) { h.cmdRemove(fn, run) }
+
+// CmdUpdateStep is CmdUpdate with a caller-supplied StepRunner.
+func (h *Handler[C]) CmdUpdateStep(fn Function, run StepRunner) { h.cmdUpdate(fn, run) }
+
+// CmdRestartStep is CmdRestart with a caller-supplied StepRunner.
+func (h *Handler[C]) CmdRestartStep(fn Function, run StepRunner) { h.cmdRestart(fn, run) }
+
 // CmdAdd handles the "add" command.
 func (h *Handler[C]) CmdAdd(fn Function) {
+	h.cmdAdd(fn, RunStepSync)
+}
+
+func (h *Handler[C]) cmdAdd(fn Function, run StepRunner) {
 	if err := fn.ValidateArgs(3); err != nil {
 		h.api.SendCodef(fn, 400, "%v", err)
 		return
@@ -467,35 +517,80 @@ func (h *Handler[C]) CmdAdd(fn Function) {
 		return
 	}
 
-	newCfg, err := h.cb.ParseAndValidate(fn, name)
-	if err != nil {
-		h.api.SendCodef(fn, 400, "%v", err)
-		return
-	}
-	if h.cb.ConfigType(newCfg) != ConfigTypeJob {
-		h.api.SendCodef(fn, 405, "adding configurations of type '%s' is not supported, only 'job' configurations can be added.", h.cb.ConfigType(newCfg))
-		return
-	}
-
-	// Replace existing config at the same key, if any.
-	if existing, ok := h.exposed.LookupByKey(key); ok {
-		if _, found := h.seen.Lookup(existing.Cfg); found && existing.Cfg.SourceType() == "dyncfg" {
-			h.seen.Remove(existing.Cfg)
+	var newCfg C
+	run(func(ctx context.Context) error {
+		var err error
+		newCfg, err = h.cb.ParseAndValidate(ctx, fn, name)
+		return err
+	}, func(err error) {
+		if errors.Is(err, ErrPhaseNeverRan) {
+			h.api.SendCodef(fn, 503, "%v", err)
+			return
 		}
-		h.exposed.Remove(existing.Cfg)
-		h.cb.Stop(existing.Cfg)
-	}
+		if err != nil {
+			h.api.SendCodef(fn, 400, "%v", err)
+			return
+		}
+		if h.cb.ConfigType(newCfg) != ConfigTypeJob {
+			h.api.SendCodef(fn, 405, "adding configurations of type '%s' is not supported, only 'job' configurations can be added.", h.cb.ConfigType(newCfg))
+			return
+		}
 
-	h.seen.Add(newCfg)
-	newEntry := &Entry[C]{Cfg: newCfg, Status: StatusAccepted}
-	h.exposed.Add(newEntry)
+		finish := func() {
+			h.seen.Add(newCfg)
+			newEntry := &Entry[C]{Cfg: newCfg, Status: StatusAccepted}
+			h.exposed.Add(newEntry)
 
-	h.api.SendCodef(fn, 202, "")
-	h.NotifyConfigCreate(newCfg, StatusAccepted)
+			h.api.SendCodef(fn, 202, "")
+			h.NotifyConfigCreate(newCfg, StatusAccepted)
+		}
+
+		// Replace existing config at the same key, if any: cache removal
+		// precedes the blocking stop (remove-before-block).
+		if existing, ok := h.exposed.LookupByKey(key); ok {
+			wasSeen := false
+			if _, found := h.seen.Lookup(existing.Cfg); found && existing.Cfg.SourceType() == "dyncfg" {
+				h.seen.Remove(existing.Cfg)
+				wasSeen = true
+			}
+			existingEntry := existing
+			h.exposed.Remove(existing.Cfg)
+			run(func(ctx context.Context) error {
+				h.cb.Stop(ctx, existing.Cfg)
+				return nil
+			}, func(stopErr error) {
+				if errors.Is(stopErr, ErrPhaseNeverRan) {
+					if wasSeen {
+						h.seen.Add(existingEntry.Cfg)
+					}
+					h.exposed.Add(existingEntry)
+					h.api.SendCodef(fn, 503, "%v", stopErr)
+					return
+				}
+				if stopErr != nil && !errors.Is(stopErr, ErrPhaseAbandoned) {
+					// The old instance's stop broke (recovered panic): do not
+					// create a replacement next to a job in an unknown state.
+					if wasSeen {
+						h.seen.Add(existingEntry.Cfg)
+					}
+					h.exposed.Add(existingEntry)
+					h.api.SendCodef(fn, 500, "%v", stopErr)
+					return
+				}
+				finish()
+			})
+			return
+		}
+		finish()
+	})
 }
 
 // CmdEnable handles the "enable" command.
 func (h *Handler[C]) CmdEnable(fn Function) {
+	h.cmdEnable(fn, RunStepSync)
+}
+
+func (h *Handler[C]) cmdEnable(fn Function, run StepRunner) {
 	key, _, ok := h.cb.ExtractKey(fn)
 	if !ok {
 		h.api.SendCodef(fn, 400, "invalid config ID format.")
@@ -523,40 +618,52 @@ func (h *Handler[C]) CmdEnable(fn Function) {
 		return
 	}
 
-	err := h.cb.Start(entry.Cfg)
-
-	if err != nil {
-		entry.Status = StatusFailed
-
-		code := h.enableFailCode
-		var ce CodedError
-		if errors.As(err, &ce) {
-			code = ce.DyncfgCode()
+	run(func(ctx context.Context) error {
+		return h.cb.Start(ctx, entry.Cfg)
+	}, func(err error) {
+		if errors.Is(err, ErrPhaseNeverRan) {
+			// The start never executed (shutdown): the config is untouched -
+			// answer retryably without publishing a failed status (and
+			// without the stock-removal side effect).
+			h.api.SendCodef(fn, 503, "%v", err)
+			return
 		}
-		h.api.SendCodef(fn, code, "%v", err)
+		if err != nil {
+			entry.Status = StatusFailed
 
-		// Stock removal only for plain runtime detection failures.
-		// CodedError carries an explicit status code, so the component owns the
-		// failure semantics and whether the job should be retried.
-		if h.removeStockOnEnableFail && !isCodedError(err) && entry.Cfg.SourceType() == "stock" {
-			h.exposed.Remove(entry.Cfg)
-			h.NotifyConfigRemove(entry.Cfg)
-		} else {
-			h.NotifyConfigStatus(entry.Cfg, StatusFailed)
+			code := h.enableFailCode
+			if ce, ok2 := errors.AsType[CodedError](err); ok2 {
+				code = ce.DyncfgCode()
+			}
+			h.api.SendCodef(fn, code, "%v", err)
+
+			// Stock removal only for plain runtime detection failures.
+			// CodedError carries an explicit status code, so the component owns the
+			// failure semantics and whether the job should be retried.
+			if h.removeStockOnEnableFail && !isCodedError(err) && entry.Cfg.SourceType() == "stock" {
+				h.exposed.Remove(entry.Cfg)
+				h.NotifyConfigRemove(entry.Cfg)
+			} else {
+				h.NotifyConfigStatus(entry.Cfg, StatusFailed)
+			}
+
+			h.cb.OnStatusChange(entry, oldStatus, fn)
+			return
 		}
 
+		entry.Status = StatusRunning
+		h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+		h.NotifyConfigStatus(entry.Cfg, StatusRunning)
 		h.cb.OnStatusChange(entry, oldStatus, fn)
-		return
-	}
-
-	entry.Status = StatusRunning
-	h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
-	h.NotifyConfigStatus(entry.Cfg, StatusRunning)
-	h.cb.OnStatusChange(entry, oldStatus, fn)
+	})
 }
 
 // CmdDisable handles the "disable" command.
 func (h *Handler[C]) CmdDisable(fn Function) {
+	h.cmdDisable(fn, RunStepSync)
+}
+
+func (h *Handler[C]) cmdDisable(fn Function, run StepRunner) {
 	key, _, ok := h.cb.ExtractKey(fn)
 	if !ok {
 		h.api.SendCodef(fn, 400, "invalid config ID format.")
@@ -578,16 +685,36 @@ func (h *Handler[C]) CmdDisable(fn Function) {
 	}
 
 	// Unconditional for all non-Disabled statuses.
-	h.cb.Stop(entry.Cfg)
-
-	entry.Status = StatusDisabled
-	h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
-	h.NotifyConfigStatus(entry.Cfg, StatusDisabled)
-	h.cb.OnStatusChange(entry, oldStatus, fn)
+	run(func(ctx context.Context) error {
+		h.cb.Stop(ctx, entry.Cfg)
+		return nil
+	}, func(stopErr error) {
+		if errors.Is(stopErr, ErrPhaseNeverRan) {
+			h.api.SendCodef(fn, 503, "%v", stopErr)
+			return
+		}
+		if stopErr != nil && !errors.Is(stopErr, ErrPhaseAbandoned) {
+			// The stop broke (recovered panic): the job's state is unknown
+			// and nothing was fenced - publishing disabled would be a lie.
+			entry.Status = StatusFailed
+			h.api.SendCodef(fn, 500, "%v", stopErr)
+			h.NotifyConfigStatus(entry.Cfg, StatusFailed)
+			h.cb.OnStatusChange(entry, oldStatus, fn)
+			return
+		}
+		entry.Status = StatusDisabled
+		h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+		h.NotifyConfigStatus(entry.Cfg, StatusDisabled)
+		h.cb.OnStatusChange(entry, oldStatus, fn)
+	})
 }
 
 // CmdRemove handles the "remove" command.
 func (h *Handler[C]) CmdRemove(fn Function) {
+	h.cmdRemove(fn, RunStepSync)
+}
+
+func (h *Handler[C]) cmdRemove(fn Function, run StepRunner) {
 	key, _, ok := h.cb.ExtractKey(fn)
 	if !ok {
 		h.api.SendCodef(fn, 400, "invalid config ID format.")
@@ -609,16 +736,45 @@ func (h *Handler[C]) CmdRemove(fn Function) {
 		return
 	}
 
+	// Cache removal precedes the blocking stop (remove-before-block).
 	h.seen.Remove(entry.Cfg)
 	h.exposed.Remove(entry.Cfg)
-	h.cb.Stop(entry.Cfg)
-
-	h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
-	h.NotifyConfigRemove(entry.Cfg)
+	run(func(ctx context.Context) error {
+		h.cb.Stop(ctx, entry.Cfg)
+		return nil
+	}, func(stopErr error) {
+		if errors.Is(stopErr, ErrPhaseNeverRan) {
+			// Nothing was stopped: restore the stage-time cache removals and
+			// answer retryably instead of publishing a delete that is a lie.
+			h.seen.Add(entry.Cfg)
+			h.exposed.Add(entry)
+			h.api.SendCodef(fn, 503, "%v", stopErr)
+			return
+		}
+		if stopErr != nil && !errors.Is(stopErr, ErrPhaseAbandoned) {
+			// The stop broke (recovered panic): restore the caches with a
+			// failed status instead of publishing a delete for a job whose
+			// state is unknown and whose output was never fenced.
+			oldStatus := entry.Status
+			entry.Status = StatusFailed
+			h.seen.Add(entry.Cfg)
+			h.exposed.Add(entry)
+			h.api.SendCodef(fn, 500, "%v", stopErr)
+			h.NotifyConfigStatus(entry.Cfg, StatusFailed)
+			h.cb.OnStatusChange(entry, oldStatus, fn)
+			return
+		}
+		h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+		h.NotifyConfigRemove(entry.Cfg)
+	})
 }
 
 // CmdUpdate handles the "update" command.
 func (h *Handler[C]) CmdUpdate(fn Function) {
+	h.cmdUpdate(fn, RunStepSync)
+}
+
+func (h *Handler[C]) cmdUpdate(fn Function, run StepRunner) {
 	key, name, ok := h.cb.ExtractKey(fn)
 	if !ok {
 		h.api.SendCodef(fn, 400, "invalid config ID format.")
@@ -636,104 +792,161 @@ func (h *Handler[C]) CmdUpdate(fn Function) {
 		return
 	}
 
-	newCfg, err := h.cb.ParseAndValidate(fn, name)
-	if err != nil {
-		h.api.SendCodef(fn, 400, "%v", err)
-		h.NotifyConfigStatus(entry.Cfg, entry.Status)
-		return
-	}
-
-	isConversion := entry.Cfg.SourceType() != "dyncfg"
-
-	// No-op: running dyncfg config with same hash.
-	if !isConversion && entry.Status == StatusRunning && entry.Cfg.Hash() == newCfg.Hash() {
-		h.api.SendCodef(fn, 200, "")
-		h.NotifyConfigStatus(entry.Cfg, StatusRunning)
-		return
-	}
-
-	if entry.Status == StatusAccepted {
-		h.api.SendCodef(fn, 403, "updating is not allowed in '%s' state.", entry.Status)
-		h.NotifyConfigStatus(entry.Cfg, StatusAccepted)
-		return
-	}
-
-	oldStatus := entry.Status
-	oldCfg := entry.Cfg
-
-	// For conversion, stop the old work before publishing replacement config state.
-	if isConversion {
-		h.cb.Stop(oldCfg)
-	}
-
-	// Update caches.
-	if !isConversion {
-		h.seen.Remove(oldCfg)
-	}
-	h.seen.Add(newCfg)
-	newEntry := &Entry[C]{Cfg: newCfg, Status: StatusAccepted}
-	h.exposed.Add(newEntry)
-
-	// Preserve Disabled status.
-	if oldStatus == StatusDisabled {
-		newEntry.Status = StatusDisabled
-		if isConversion {
-			h.NotifyConfigCreate(newCfg, StatusDisabled)
+	var newCfg C
+	run(func(ctx context.Context) error {
+		var err error
+		newCfg, err = h.cb.ParseAndValidate(ctx, fn, name)
+		return err
+	}, func(err error) {
+		if errors.Is(err, ErrPhaseNeverRan) {
+			h.api.SendCodef(fn, 503, "%v", err)
+			return
 		}
-		h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
-		h.NotifyConfigStatus(newCfg, StatusDisabled)
-		h.cb.OnStatusChange(newEntry, oldStatus, fn)
-		return
-	}
-
-	// Start or update.
-	if isConversion {
-		err = h.cb.Start(newCfg)
-	} else {
-		err = h.cb.Update(oldCfg, newCfg)
-	}
-
-	if err != nil {
-		if !isConversion && errors.Is(err, ErrNonDisruptiveUpdate) {
-			// Update failed before runtime disruption; rollback to old cache state.
-			h.seen.Remove(newCfg)
-			h.seen.Add(oldCfg)
-			h.exposed.Add(entry)
-
-			h.api.SendCodef(fn, 200, "%v", err)
-			h.NotifyConfigStatus(oldCfg, oldStatus)
-			// No OnStatusChange call here: effective state did not change.
+		// Validation errors win over state rejections (400 beats 403): the
+		// validation effect runs even for Accepted entries.
+		if err != nil {
+			h.api.SendCodef(fn, 400, "%v", err)
+			h.NotifyConfigStatus(entry.Cfg, entry.Status)
 			return
 		}
 
-		newEntry.Status = StatusFailed
-		if isConversion {
-			h.NotifyConfigCreate(newCfg, StatusFailed)
-		}
-		code := 200
-		var ce CodedError
-		if errors.As(err, &ce) {
-			code = ce.DyncfgCode()
-		}
-		h.api.SendCodef(fn, code, "%v", err)
-		h.NotifyConfigStatus(newCfg, StatusFailed)
-		h.cb.OnStatusChange(newEntry, oldStatus, fn)
-		return
-	}
+		isConversion := entry.Cfg.SourceType() != "dyncfg"
 
-	newEntry.Status = StatusRunning
-	if isConversion {
-		h.NotifyConfigCreate(newCfg, StatusRunning)
-	}
-	h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
-	h.NotifyConfigStatus(newCfg, StatusRunning)
-	h.cb.OnStatusChange(newEntry, oldStatus, fn)
+		// No-op: running dyncfg config with same hash.
+		if !isConversion && entry.Status == StatusRunning && entry.Cfg.Hash() == newCfg.Hash() {
+			h.api.SendCodef(fn, 200, "")
+			h.NotifyConfigStatus(entry.Cfg, StatusRunning)
+			return
+		}
+
+		if entry.Status == StatusAccepted {
+			h.api.SendCodef(fn, 403, "updating is not allowed in '%s' state.", entry.Status)
+			h.NotifyConfigStatus(entry.Cfg, StatusAccepted)
+			return
+		}
+
+		oldStatus := entry.Status
+		oldCfg := entry.Cfg
+
+		proceed := func() {
+			// Update caches.
+			if !isConversion {
+				h.seen.Remove(oldCfg)
+			}
+			h.seen.Add(newCfg)
+			newEntry := &Entry[C]{Cfg: newCfg, Status: StatusAccepted}
+			h.exposed.Add(newEntry)
+
+			// Preserve Disabled status.
+			if oldStatus == StatusDisabled {
+				newEntry.Status = StatusDisabled
+				if isConversion {
+					h.NotifyConfigCreate(newCfg, StatusDisabled)
+				}
+				h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+				h.NotifyConfigStatus(newCfg, StatusDisabled)
+				h.cb.OnStatusChange(newEntry, oldStatus, fn)
+				return
+			}
+
+			// Start or update.
+			run(func(ctx context.Context) error {
+				if isConversion {
+					return h.cb.Start(ctx, newCfg)
+				}
+				return h.cb.Update(ctx, oldCfg, newCfg)
+			}, func(err error) {
+				if !isConversion && errors.Is(err, ErrPhaseNeverRan) {
+					// The update phase never executed (shutdown): the old
+					// instance is untouched - roll back to the old cache state
+					// and answer retryably instead of publishing failed.
+					h.seen.Remove(newCfg)
+					h.seen.Add(oldCfg)
+					h.exposed.Add(entry)
+					h.api.SendCodef(fn, 503, "%v", err)
+					h.NotifyConfigStatus(oldCfg, oldStatus)
+					return
+				}
+				if err != nil {
+					if !isConversion && errors.Is(err, ErrNonDisruptiveUpdate) {
+						// Update failed before runtime disruption; rollback to old cache state.
+						h.seen.Remove(newCfg)
+						h.seen.Add(oldCfg)
+						h.exposed.Add(entry)
+
+						h.api.SendCodef(fn, 200, "%v", err)
+						h.NotifyConfigStatus(oldCfg, oldStatus)
+						// No OnStatusChange call here: effective state did not change.
+						return
+					}
+
+					newEntry.Status = StatusFailed
+					if isConversion {
+						h.NotifyConfigCreate(newCfg, StatusFailed)
+					}
+					code := 200
+					if ce, ok2 := errors.AsType[CodedError](err); ok2 {
+						code = ce.DyncfgCode()
+					}
+					h.api.SendCodef(fn, code, "%v", err)
+					h.NotifyConfigStatus(newCfg, StatusFailed)
+					h.cb.OnStatusChange(newEntry, oldStatus, fn)
+					return
+				}
+
+				newEntry.Status = StatusRunning
+				if isConversion {
+					h.NotifyConfigCreate(newCfg, StatusRunning)
+				}
+				h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+				h.NotifyConfigStatus(newCfg, StatusRunning)
+				h.cb.OnStatusChange(newEntry, oldStatus, fn)
+			})
+		}
+
+		// For conversion, stop the old work before publishing replacement config state.
+		if isConversion {
+			run(func(ctx context.Context) error {
+				h.cb.Stop(ctx, oldCfg)
+				return nil
+			}, func(stopErr error) {
+				if errors.Is(stopErr, ErrPhaseNeverRan) {
+					// Nothing happened at all: the old job is untouched and
+					// the caches were not swapped yet - answer retryably
+					// without marking anything failed.
+					h.api.SendCodef(fn, 503, "%v", stopErr)
+					return
+				}
+				// An abandoned or broken stop is a disruptive failure: the
+				// update fails without cache rollback and the start phase
+				// never begins.
+				if stopErr != nil {
+					entry.Status = StatusFailed
+					code := 200
+					if ce, ok2 := errors.AsType[CodedError](stopErr); ok2 {
+						code = ce.DyncfgCode()
+					}
+					h.api.SendCodef(fn, code, "%v", stopErr)
+					h.NotifyConfigStatus(oldCfg, StatusFailed)
+					h.cb.OnStatusChange(entry, oldStatus, fn)
+					return
+				}
+				proceed()
+			})
+			return
+		}
+		proceed()
+	})
 }
 
 // CmdRestart handles the "restart" command.
 // Stops the existing work and starts the same config again.
 // Only allowed for Running/Failed configs (rejects Accepted/Disabled).
 func (h *Handler[C]) CmdRestart(fn Function) {
+	h.cmdRestart(fn, RunStepSync)
+}
+
+func (h *Handler[C]) cmdRestart(fn Function, run StepRunner) {
 	key, _, ok := h.cb.ExtractKey(fn)
 	if !ok {
 		h.api.SendCodef(fn, 400, "invalid config ID format.")
@@ -761,27 +974,50 @@ func (h *Handler[C]) CmdRestart(fn Function) {
 
 	oldStatus := entry.Status
 
-	h.cb.Stop(entry.Cfg)
-
-	err := h.cb.Start(entry.Cfg)
-
-	if err != nil {
-		entry.Status = StatusFailed
-		code := 422
-		var ce CodedError
-		if errors.As(err, &ce) {
-			code = ce.DyncfgCode()
+	run(func(ctx context.Context) error {
+		h.cb.Stop(ctx, entry.Cfg)
+		return nil
+	}, func(stopErr error) {
+		if errors.Is(stopErr, ErrPhaseNeverRan) {
+			// Nothing happened at all: answer retryably without publishing a
+			// failed status for a job that is in fact untouched.
+			h.api.SendCodef(fn, 503, "%v", stopErr)
+			return
 		}
-		h.api.SendCodef(fn, code, "config restart failed: %v", err)
-		h.NotifyConfigStatus(entry.Cfg, StatusFailed)
-		h.cb.OnStatusChange(entry, oldStatus, fn)
-		return
-	}
+		// An abandoned stop (or a broken one) fails the restart and the
+		// start phase never begins (no second instance).
+		if stopErr != nil {
+			entry.Status = StatusFailed
+			code := 422
+			if ce, ok2 := errors.AsType[CodedError](stopErr); ok2 {
+				code = ce.DyncfgCode()
+			}
+			h.api.SendCodef(fn, code, "config restart failed: %v", stopErr)
+			h.NotifyConfigStatus(entry.Cfg, StatusFailed)
+			h.cb.OnStatusChange(entry, oldStatus, fn)
+			return
+		}
+		run(func(ctx context.Context) error {
+			return h.cb.Start(ctx, entry.Cfg)
+		}, func(err error) {
+			if err != nil {
+				entry.Status = StatusFailed
+				code := 422
+				if ce, ok2 := errors.AsType[CodedError](err); ok2 {
+					code = ce.DyncfgCode()
+				}
+				h.api.SendCodef(fn, code, "config restart failed: %v", err)
+				h.NotifyConfigStatus(entry.Cfg, StatusFailed)
+				h.cb.OnStatusChange(entry, oldStatus, fn)
+				return
+			}
 
-	entry.Status = StatusRunning
-	h.api.SendCodef(fn, 200, "")
-	h.NotifyConfigStatus(entry.Cfg, StatusRunning)
-	h.cb.OnStatusChange(entry, oldStatus, fn)
+			entry.Status = StatusRunning
+			h.api.SendCodef(fn, 200, "")
+			h.NotifyConfigStatus(entry.Cfg, StatusRunning)
+			h.cb.OnStatusChange(entry, oldStatus, fn)
+		})
+	})
 }
 
 func isCodedError(err error) bool {

--- a/src/go/plugin/framework/dyncfg/handler_test.go
+++ b/src/go/plugin/framework/dyncfg/handler_test.go
@@ -67,7 +67,7 @@ func (m *mockCallbacks) ExtractKey(fn Function) (string, string, bool) {
 	return parts[1], parts[1], true
 }
 
-func (m *mockCallbacks) ParseAndValidate(fn Function, name string) (testConfig, error) {
+func (m *mockCallbacks) ParseAndValidate(_ context.Context, fn Function, name string) (testConfig, error) {
 	if m.parseAndValidateFn != nil {
 		return m.parseAndValidateFn(fn, name)
 	}
@@ -78,7 +78,7 @@ func (m *mockCallbacks) ValidateConfigName(name string) error {
 	return JobNameRuleStrict(name)
 }
 
-func (m *mockCallbacks) Start(cfg testConfig) error {
+func (m *mockCallbacks) Start(_ context.Context, cfg testConfig) error {
 	m.startCalls = append(m.startCalls, cfg)
 	if m.startFn != nil {
 		return m.startFn(cfg)
@@ -86,7 +86,7 @@ func (m *mockCallbacks) Start(cfg testConfig) error {
 	return nil
 }
 
-func (m *mockCallbacks) Update(oldCfg, newCfg testConfig) error {
+func (m *mockCallbacks) Update(_ context.Context, oldCfg, newCfg testConfig) error {
 	m.updateCalls = append(m.updateCalls, updateCall{oldCfg, newCfg})
 	if m.updateFn != nil {
 		return m.updateFn(oldCfg, newCfg)
@@ -94,7 +94,7 @@ func (m *mockCallbacks) Update(oldCfg, newCfg testConfig) error {
 	return nil
 }
 
-func (m *mockCallbacks) Stop(cfg testConfig) {
+func (m *mockCallbacks) Stop(_ context.Context, cfg testConfig) {
 	m.stopCalls = append(m.stopCalls, cfg)
 	if m.stopFn != nil {
 		m.stopFn(cfg)
@@ -1394,5 +1394,245 @@ func TestJobNameRuleAllowDots(t *testing.T) {
 				assert.NoError(t, err, fmt.Sprintf("JobNameRuleAllowDots(%q) should pass", tt.input))
 			}
 		})
+	}
+}
+
+// --- Stop-commit outcome mapping ---
+
+// commitErrRunner skips the blocking phase and commits err directly: the
+// executor produces these outcomes (never-ran, abandoned, recovered panic)
+// without the closure completing normally.
+func commitErrRunner(err error) StepRunner {
+	return func(_ func(context.Context) error, commit func(error)) {
+		commit(err)
+	}
+}
+
+// chainErrRunner executes the first phase normally (validation) and commits
+// err for every later phase - the shape of a chained stop/update phase that
+// the executor refused or that broke.
+func chainErrRunner(err error) StepRunner {
+	seq := 0
+	return func(effect func(context.Context) error, commit func(error)) {
+		if seq++; seq == 1 {
+			commit(effect(context.Background()))
+			return
+		}
+		commit(err)
+	}
+}
+
+// TestStopCommitOutcomeMapping pins how stop-shaped commits map the three
+// executor outcomes: abandoned (stop ran, wedged, output fenced) publishes
+// success by contract; never-ran answers 503 and restores stage-time cache
+// removals; anything else (a recovered panic) proves nothing about the job's
+// state and must commit failed, never success.
+func TestStopCommitOutcomeMapping(t *testing.T) {
+	abandonedErr := fmt.Errorf("%w: timed out after 1s", ErrPhaseAbandoned)
+	panicErr := errors.New("internal error: effect panic: boom")
+
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"disable abandoned publishes disabled": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				cfg := testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg"}
+				h.exposed.Add(&Entry[testConfig]{Cfg: cfg, Status: StatusRunning})
+
+				h.CmdDisableStep(newTestFn("test:job1", "disable", "", nil), commitErrRunner(abandonedErr))
+
+				entry, _ := h.exposed.LookupByKey("job1")
+				assert.Equal(t, StatusDisabled, entry.Status)
+				assert.Contains(t, out.String(), `"status":200`)
+				assert.Contains(t, out.String(), "status disabled")
+			},
+		},
+		"disable never-ran answers 503 and publishes nothing": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				cfg := testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg"}
+				h.exposed.Add(&Entry[testConfig]{Cfg: cfg, Status: StatusRunning})
+
+				h.CmdDisableStep(newTestFn("test:job1", "disable", "", nil), commitErrRunner(ErrPhaseNeverRan))
+
+				entry, _ := h.exposed.LookupByKey("job1")
+				assert.Equal(t, StatusRunning, entry.Status, "a stop that never ran must not change the status")
+				assert.Contains(t, out.String(), `"status":503`)
+				assert.NotContains(t, out.String(), "status disabled")
+			},
+		},
+		"disable broken stop commits failed, never disabled": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				cfg := testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg"}
+				h.exposed.Add(&Entry[testConfig]{Cfg: cfg, Status: StatusRunning})
+
+				h.CmdDisableStep(newTestFn("test:job1", "disable", "", nil), commitErrRunner(panicErr))
+
+				entry, _ := h.exposed.LookupByKey("job1")
+				assert.Equal(t, StatusFailed, entry.Status)
+				assert.Contains(t, out.String(), `"status":500`)
+				assert.Contains(t, out.String(), "status failed")
+				assert.NotContains(t, out.String(), "status disabled")
+				require.Len(t, cb.statusCalls, 1)
+			},
+		},
+		"remove abandoned publishes delete": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				cfg := testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg"}
+				h.seen.Add(cfg)
+				h.exposed.Add(&Entry[testConfig]{Cfg: cfg, Status: StatusRunning})
+
+				h.CmdRemoveStep(newTestFn("test:job1", "remove", "", nil), commitErrRunner(abandonedErr))
+
+				_, exposed := h.exposed.LookupByKey("job1")
+				assert.False(t, exposed, "the abandoned remove must commit the removal")
+				assert.Contains(t, out.String(), `"status":200`)
+				assert.Contains(t, out.String(), "delete")
+			},
+		},
+		"remove never-ran restores caches and answers 503": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				cfg := testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg"}
+				h.seen.Add(cfg)
+				h.exposed.Add(&Entry[testConfig]{Cfg: cfg, Status: StatusRunning})
+
+				h.CmdRemoveStep(newTestFn("test:job1", "remove", "", nil), commitErrRunner(ErrPhaseNeverRan))
+
+				entry, exposed := h.exposed.LookupByKey("job1")
+				require.True(t, exposed, "the never-ran remove must restore the exposed entry")
+				assert.Equal(t, StatusRunning, entry.Status)
+				_, seen := h.seen.Lookup(cfg)
+				assert.True(t, seen, "the never-ran remove must restore the seen entry")
+				assert.Contains(t, out.String(), `"status":503`)
+				assert.NotContains(t, out.String(), "delete")
+			},
+		},
+		"remove broken stop restores caches with failed status": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				cfg := testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg"}
+				h.seen.Add(cfg)
+				h.exposed.Add(&Entry[testConfig]{Cfg: cfg, Status: StatusRunning})
+
+				h.CmdRemoveStep(newTestFn("test:job1", "remove", "", nil), commitErrRunner(panicErr))
+
+				entry, exposed := h.exposed.LookupByKey("job1")
+				require.True(t, exposed, "the broken remove must restore the exposed entry")
+				assert.Equal(t, StatusFailed, entry.Status)
+				assert.Contains(t, out.String(), `"status":500`)
+				assert.Contains(t, out.String(), "status failed")
+				assert.NotContains(t, out.String(), "delete")
+			},
+		},
+		"enable never-ran answers 503 without failing the entry": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				// Stock source: a failed enable would also trigger stock
+				// removal - never-ran must trigger neither.
+				cfg := testConfig{uid: "stock:job1", key: "job1", sourceType: "stock"}
+				h.exposed.Add(&Entry[testConfig]{Cfg: cfg, Status: StatusAccepted})
+
+				h.CmdEnableStep(newTestFn("test:job1", "enable", "", nil), commitErrRunner(ErrPhaseNeverRan))
+
+				entry, exposed := h.exposed.LookupByKey("job1")
+				require.True(t, exposed, "never-ran must not remove the stock config")
+				assert.Equal(t, StatusAccepted, entry.Status, "an unstarted config must not be marked failed")
+				assert.Contains(t, out.String(), `"status":503`)
+				assert.NotContains(t, out.String(), "status failed")
+			},
+		},
+		"conversion update stop never-ran answers 503 without failing the old job": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				oldCfg := testConfig{uid: "stock:job1", key: "job1", sourceType: "stock", hash: 100}
+				h.seen.Add(oldCfg)
+				h.exposed.Add(&Entry[testConfig]{Cfg: oldCfg, Status: StatusRunning})
+				cb.parseAndValidateFn = func(_ Function, _ string) (testConfig, error) {
+					return testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg", hash: 200}, nil
+				}
+
+				h.CmdUpdateStep(newTestFn("test:job1", "update", "job1", []byte(`{}`)), chainErrRunner(ErrPhaseNeverRan))
+
+				entry, exposed := h.exposed.LookupByKey("job1")
+				require.True(t, exposed)
+				assert.Equal(t, "stock:job1", entry.Cfg.UID(), "the old discovery entry must stay exposed")
+				assert.Equal(t, StatusRunning, entry.Status, "an untouched old job must not be marked failed")
+				assert.Contains(t, out.String(), `"status":503`)
+				assert.NotContains(t, out.String(), "status failed")
+			},
+		},
+		"restart never-ran answers 503 without failing the entry": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				cfg := testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg"}
+				h.exposed.Add(&Entry[testConfig]{Cfg: cfg, Status: StatusRunning})
+
+				h.CmdRestartStep(newTestFn("test:job1", "restart", "", nil), commitErrRunner(ErrPhaseNeverRan))
+
+				entry, _ := h.exposed.LookupByKey("job1")
+				assert.Equal(t, StatusRunning, entry.Status, "an untouched job must not be marked failed")
+				assert.Contains(t, out.String(), `"status":503`)
+				assert.NotContains(t, out.String(), "status failed")
+			},
+		},
+		"add-replace broken stop keeps the old instance": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				oldCfg := testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg", hash: 100}
+				h.seen.Add(oldCfg)
+				h.exposed.Add(&Entry[testConfig]{Cfg: oldCfg, Status: StatusRunning})
+				cb.parseAndValidateFn = func(_ Function, _ string) (testConfig, error) {
+					return testConfig{uid: "dyncfg:job1-new", key: "job1", sourceType: "dyncfg", hash: 200}, nil
+				}
+
+				h.CmdAddStep(newTestFn("test:job1", "add", "job1", []byte(`{}`)), chainErrRunner(panicErr))
+
+				entry, exposed := h.exposed.LookupByKey("job1")
+				require.True(t, exposed, "the old entry must be restored")
+				assert.Equal(t, "dyncfg:job1", entry.Cfg.UID(), "no replacement may be exposed next to a job in an unknown state")
+				assert.Contains(t, out.String(), `"status":500`)
+			},
+		},
+		"update chained never-ran rolls back and answers 503": {
+			run: func(t *testing.T) {
+				cb := &mockCallbacks{}
+				h, out := newTestHandlerWithOutput(cb, 5*time.Second)
+				oldCfg := testConfig{uid: "dyncfg:job1", key: "job1", sourceType: "dyncfg", hash: 100}
+				h.seen.Add(oldCfg)
+				h.exposed.Add(&Entry[testConfig]{Cfg: oldCfg, Status: StatusRunning})
+				cb.parseAndValidateFn = func(_ Function, _ string) (testConfig, error) {
+					return testConfig{uid: "dyncfg:job1-new", key: "job1", sourceType: "dyncfg", hash: 200}, nil
+				}
+
+				h.CmdUpdateStep(newTestFn("test:job1", "update", "job1", []byte(`{}`)), chainErrRunner(ErrPhaseNeverRan))
+
+				entry, exposed := h.exposed.LookupByKey("job1")
+				require.True(t, exposed)
+				assert.Equal(t, "dyncfg:job1", entry.Cfg.UID(), "the never-ran update must roll back to the old config")
+				assert.Equal(t, StatusRunning, entry.Status)
+				_, seenOld := h.seen.Lookup(oldCfg)
+				assert.True(t, seenOld, "the old seen entry must be restored")
+				assert.Contains(t, out.String(), `"status":503`)
+				assert.NotContains(t, out.String(), "status failed")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
 	}
 }

--- a/src/go/plugin/framework/functions/ext.go
+++ b/src/go/plugin/framework/functions/ext.go
@@ -105,6 +105,32 @@ func (m *Manager) RegisterPrefixWithContext(name, prefix string, fn Handler) {
 	fs.prefixes[prefix] = fn
 }
 
+// RegisterPrefixLaneDeriver attaches a lane-key derivation callback to an
+// existing prefix registration. Registering for an unknown name/prefix is a
+// no-op with a warning; passing nil removes the deriver.
+func (m *Manager) RegisterPrefixLaneDeriver(name, prefix string, derive LaneKeyDeriver) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	fs, ok := m.functionRegistry[name]
+	if !ok || fs.prefixes == nil {
+		m.Warningf("not attaching lane deriver to '%s' prefix '%s': not registered", name, prefix)
+		return
+	}
+	if _, exists := fs.prefixes[prefix]; !exists {
+		m.Warningf("not attaching lane deriver to '%s' prefix '%s': prefix not registered", name, prefix)
+		return
+	}
+	if derive == nil {
+		delete(fs.prefixDerivers, prefix)
+		return
+	}
+	if fs.prefixDerivers == nil {
+		fs.prefixDerivers = make(map[string]LaneKeyDeriver)
+	}
+	fs.prefixDerivers[prefix] = derive
+}
+
 func prefixesOverlap(a, b string) bool {
 	if a == "" || b == "" {
 		return false
@@ -125,6 +151,9 @@ func (m *Manager) UnregisterPrefix(name, prefix string) {
 	if _, exists := fs.prefixes[prefix]; exists {
 		m.Debugf("unregistering function '%s' with prefix '%s'", name, prefix)
 		delete(fs.prefixes, prefix)
+		// The deriver belongs to the registration: a later re-register of
+		// the same prefix must not inherit a stale deriver.
+		delete(fs.prefixDerivers, prefix)
 	}
 
 	if fs.direct == nil && len(fs.prefixes) == 0 {

--- a/src/go/plugin/framework/functions/lane.go
+++ b/src/go/plugin/framework/functions/lane.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package functions
+
+import (
+	"context"
+	"runtime/debug"
+)
+
+// LaneKeyDeriver narrows a registration's schedule lane per request. The
+// scheduler serializes requests that share a schedule key until each reaches
+// its terminal finalize; without a deriver every request routed to one
+// registration shares one lane, so an expensive command blocks unrelated ones
+// behind it. A deriver returns the identity the request addresses (for dyncfg,
+// the config a command targets) so only same-identity requests serialize.
+//
+// Returning laneKey == "" selects the registration-wide lane (the behavior
+// without a deriver) - the fallback for requests whose identity cannot be
+// derived; such requests still reach the handler's own rejection paths. meta,
+// when non-nil, travels with the request and is retrievable by the handler
+// via LaneMetaFromContext.
+//
+// Derivers run on the dispatch path and must be side-effect-free and safe to
+// call from the manager goroutine. A panic is contained: the request falls
+// back to the registration-wide lane.
+type LaneKeyDeriver func(fn Function) (laneKey string, meta any)
+
+type laneMetaCtxKey struct{}
+
+// LaneMetaFromContext returns the metadata attached by the registration's
+// LaneKeyDeriver, or nil.
+func LaneMetaFromContext(ctx context.Context) any {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Value(laneMetaCtxKey{})
+}
+
+// deriveLaneKey runs derive with panic containment.
+func (m *Manager) deriveLaneKey(derive LaneKeyDeriver, fn Function) (laneKey string, meta any) {
+	defer func() {
+		if v := recover(); v != nil {
+			m.Errorf("lane key deriver panic (function '%s', uid=%s): %v\n%s", fn.Name, fn.UID, v, string(debug.Stack()))
+			laneKey, meta = "", nil
+		}
+	}()
+	return derive(fn)
+}

--- a/src/go/plugin/framework/functions/lane_deriver_test.go
+++ b/src/go/plugin/framework/functions/lane_deriver_test.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package functions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLaneKeyDerivation(t *testing.T) {
+	noop := func(Function) {}
+
+	tests := map[string]struct {
+		setup    func(mgr *Manager)
+		fn       Function
+		wantKey  string
+		wantMeta any
+	}{
+		"prefix with deriver narrows the lane to the derived identity": {
+			setup: func(mgr *Manager) {
+				mgr.RegisterPrefix("config", "collector:", noop)
+				mgr.RegisterPrefixLaneDeriver("config", "collector:", func(fn Function) (string, any) {
+					return "job-a", "meta-a"
+				})
+			},
+			fn:       Function{Name: "config", Args: []string{"collector:job-a", "enable"}},
+			wantKey:  "config|collector:|job-a",
+			wantMeta: "meta-a",
+		},
+		"underivable request keeps the registration-wide lane": {
+			setup: func(mgr *Manager) {
+				mgr.RegisterPrefix("config", "collector:", noop)
+				mgr.RegisterPrefixLaneDeriver("config", "collector:", func(Function) (string, any) {
+					return "", nil
+				})
+			},
+			fn:      Function{Name: "config", Args: []string{"collector:garbled", "enable"}},
+			wantKey: "config|collector:",
+		},
+		"panicking deriver falls back to the registration-wide lane": {
+			setup: func(mgr *Manager) {
+				mgr.RegisterPrefix("config", "collector:", noop)
+				mgr.RegisterPrefixLaneDeriver("config", "collector:", func(Function) (string, any) {
+					panic("deriver bug")
+				})
+			},
+			fn:      Function{Name: "config", Args: []string{"collector:job-a", "enable"}},
+			wantKey: "config|collector:",
+		},
+		"prefix without deriver keeps the registration-wide lane": {
+			setup: func(mgr *Manager) {
+				mgr.RegisterPrefix("config", "collector:", noop)
+			},
+			fn:      Function{Name: "config", Args: []string{"collector:job-a", "enable"}},
+			wantKey: "config|collector:",
+		},
+		"nil deriver removes a previously attached one": {
+			setup: func(mgr *Manager) {
+				mgr.RegisterPrefix("config", "collector:", noop)
+				mgr.RegisterPrefixLaneDeriver("config", "collector:", func(Function) (string, any) {
+					return "job-a", nil
+				})
+				mgr.RegisterPrefixLaneDeriver("config", "collector:", nil)
+			},
+			fn:      Function{Name: "config", Args: []string{"collector:job-a", "enable"}},
+			wantKey: "config|collector:",
+		},
+		"deriver does not touch other prefixes of the same name": {
+			setup: func(mgr *Manager) {
+				mgr.RegisterPrefix("config", "collector:", noop)
+				mgr.RegisterPrefix("config", "vnode:", noop)
+				mgr.RegisterPrefixLaneDeriver("config", "collector:", func(Function) (string, any) {
+					return "job-a", nil
+				})
+			},
+			fn:      Function{Name: "config", Args: []string{"vnode:myhost", "update"}},
+			wantKey: "config|vnode:",
+		},
+		"unregistering a prefix drops its deriver": {
+			setup: func(mgr *Manager) {
+				// A second prefix keeps the function set alive across the
+				// unregister, so a stale deriver would survive in it.
+				mgr.RegisterPrefix("config", "collector:", noop)
+				mgr.RegisterPrefix("config", "vnode:", noop)
+				mgr.RegisterPrefixLaneDeriver("config", "collector:", func(Function) (string, any) {
+					return "stale", nil
+				})
+				mgr.UnregisterPrefix("config", "collector:")
+				mgr.RegisterPrefix("config", "collector:", noop)
+			},
+			fn:      Function{Name: "config", Args: []string{"collector:job-a", "enable"}},
+			wantKey: "config|collector:",
+		},
+		"deriver registration for an unknown prefix is a no-op": {
+			setup: func(mgr *Manager) {
+				mgr.RegisterPrefix("config", "collector:", noop)
+				mgr.RegisterPrefixLaneDeriver("config", "ghost:", func(Function) (string, any) {
+					return "x", nil
+				})
+			},
+			fn:      Function{Name: "config", Args: []string{"collector:job-a", "enable"}},
+			wantKey: "config|collector:",
+		},
+		"direct registration is unaffected by lane derivation": {
+			setup: func(mgr *Manager) {
+				mgr.Register("plainfn", noop)
+			},
+			fn:      Function{Name: "plainfn"},
+			wantKey: "plainfn",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr := NewManager()
+			tc.setup(mgr)
+
+			handler, key, meta, ok := mgr.lookupFunctionRoute(tc.fn)
+
+			require.True(t, ok)
+			require.NotNil(t, handler)
+			assert.Equal(t, tc.wantKey, key)
+			assert.Equal(t, tc.wantMeta, meta)
+		})
+	}
+}
+
+func TestLaneMetaFromContext(t *testing.T) {
+	tests := map[string]struct {
+		ctx  context.Context
+		want any
+	}{
+		"returns attached meta": {
+			ctx:  context.WithValue(context.Background(), laneMetaCtxKey{}, "meta"),
+			want: "meta",
+		},
+		"nil context yields nil": {
+			ctx:  nil,
+			want: nil,
+		},
+		"context without meta yields nil": {
+			ctx:  context.Background(),
+			want: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, LaneMetaFromContext(tc.ctx))
+		})
+	}
+}
+
+// Derived lanes are real scheduler lanes: same derived key serializes until
+// terminal completion, different derived keys under one registration proceed
+// independently.
+func TestDerivedLaneScheduling(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T, s *keyScheduler)
+	}{
+		"different derived lanes dispatch independently": {
+			run: func(t *testing.T, s *keyScheduler) {
+				require.NoError(t, s.enqueue(&invocationRequest{fn: &Function{UID: "a1"}, scheduleKey: "config|p|a"}))
+				require.NoError(t, s.enqueue(&invocationRequest{fn: &Function{UID: "b1"}, scheduleKey: "config|p|b"}))
+
+				first, ok := s.next()
+				require.True(t, ok)
+				second, ok := s.next()
+				require.True(t, ok)
+				assert.ElementsMatch(t,
+					[]string{"a1", "b1"},
+					[]string{first.fn.UID, second.fn.UID},
+					"requests on distinct derived lanes must both dispatch without a completion in between")
+			},
+		},
+		"same derived lane serializes until completion": {
+			run: func(t *testing.T, s *keyScheduler) {
+				require.NoError(t, s.enqueue(&invocationRequest{fn: &Function{UID: "a1"}, scheduleKey: "config|p|a"}))
+				require.NoError(t, s.enqueue(&invocationRequest{fn: &Function{UID: "a2"}, scheduleKey: "config|p|a"}))
+
+				first, ok := s.next()
+				require.True(t, ok)
+				assert.Equal(t, "a1", first.fn.UID)
+				assert.Equal(t, 1, s.pendingCount(), "the second same-lane request must stay queued")
+
+				s.complete("config|p|a", "a1")
+				second, ok := s.next()
+				require.True(t, ok)
+				assert.Equal(t, "a2", second.fn.UID, "completion must promote the queued same-lane request")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tc.run(t, newKeyScheduler(16))
+		})
+	}
+}

--- a/src/go/plugin/framework/functions/lane_deriver_test.go
+++ b/src/go/plugin/framework/functions/lane_deriver_test.go
@@ -27,7 +27,7 @@ func TestLaneKeyDerivation(t *testing.T) {
 				})
 			},
 			fn:       Function{Name: "config", Args: []string{"collector:job-a", "enable"}},
-			wantKey:  "config|collector:|job-a",
+			wantKey:  "config|collector:\x00job-a",
 			wantMeta: "meta-a",
 		},
 		"underivable request keeps the registration-wide lane": {

--- a/src/go/plugin/framework/functions/manager.go
+++ b/src/go/plugin/framework/functions/manager.go
@@ -752,7 +752,11 @@ func (m *Manager) lookupFunctionRoute(fn Function) (handler Handler, scheduleKey
 					if laneKey, meta := m.deriveLaneKey(derive, fn); laneKey != "" {
 						// Narrow the registration lane to the derived identity;
 						// underivable requests keep the registration-wide lane.
-						return routeHandler, key + "|" + laneKey, meta, true
+						// A NUL byte joins the parts: it cannot appear in the
+						// line-based plugins.d protocol, so two different
+						// (route, lane) pairs can never concatenate into the
+						// same schedule key.
+						return routeHandler, key + "\x00" + laneKey, meta, true
 					}
 				}
 				return routeHandler, key, nil, true

--- a/src/go/plugin/framework/functions/manager.go
+++ b/src/go/plugin/framework/functions/manager.go
@@ -22,8 +22,9 @@ import (
 )
 
 type functionSet struct {
-	direct   Handler            // for globally-unique names
-	prefixes map[string]Handler // for prefix-multiplexed names
+	direct         Handler                   // for globally-unique names
+	prefixes       map[string]Handler        // for prefix-multiplexed names
+	prefixDerivers map[string]LaneKeyDeriver // optional per-prefix lane-key derivation
 }
 
 const (
@@ -34,17 +35,16 @@ const (
 	// TODO: establish and document a MethodHandler goroutine-safety contract
 	// before increasing this default.
 	defaultWorkerCount = 1
-	// defaultQueueSize is intentionally 1 (not removed: the keyed scheduler is
-	// still the dispatch primitive, we just don't want it to absorb bursts).
-	// Rationale: every downstream stage is single-threaded today (1 worker, 1
-	// jobmgr loop, serial Check()), so admitting more than 1 extra request
-	// only buys wedge surface (a queued request that is later cancelled by
-	// netdata cannot reach jobmgr, so the dyncfg wait gate stays in
-	// 'accepted' forever). With queue=1 the stdin reader back-pressures
-	// earlier through the OS pipe instead of
-	// piling up admitted-but-unprocessed work in stateQueued. If/when we add
-	// real downstream concurrency, raise this again.
-	defaultQueueSize            = 1
+	// defaultQueueSize caps the scheduler BACKLOG only (ready-not-picked plus
+	// lane-queued; decremented when a worker picks a request) - it does not
+	// bound dispatched commands awaiting results. The real in-flight bound for
+	// dyncfg is lane ownership: at most one dispatched command per config lane
+	// until terminal finalize, so total in-flight work is O(active lanes) plus
+	// this backlog, mirroring the daemon's own per-config echo bound. Queued
+	// cancels are ignored (see requestCancellation), so a queued dyncfg
+	// command always reaches its handler and its lane always completes -
+	// backlog depth adds latency, never wedges.
+	defaultQueueSize            = 256
 	defaultCancelFallbackDelay  = 5 * time.Second
 	defaultShutdownDrainTimeout = 8 * time.Second
 	defaultTombstoneTTL         = 60 * time.Second
@@ -73,6 +73,7 @@ type invocationRequest struct {
 	handler     Handler
 	ctx         context.Context
 	scheduleKey string
+	laneMeta    any
 }
 
 type invocationRecord struct {
@@ -286,7 +287,7 @@ func (m *Manager) dispatchInvocation(parentCtx context.Context, fn *Function) {
 		return
 	}
 
-	handler, scheduleKey, ok := m.lookupFunctionRoute(*fn)
+	handler, scheduleKey, laneMeta, ok := m.lookupFunctionRoute(*fn)
 	if !ok {
 		m.Infof("skipping execution of '%s': unregistered function", fn.Name)
 		m.respf(fn, 501, "unregistered function: %s", fn.Name)
@@ -329,6 +330,7 @@ func (m *Manager) dispatchInvocation(parentCtx context.Context, fn *Function) {
 		handler:     handler,
 		ctx:         reqCtx,
 		scheduleKey: scheduleKey,
+		laneMeta:    laneMeta,
 	}
 
 	if m.scheduler == nil {
@@ -692,8 +694,9 @@ func (m *Manager) stopTimersLocked(rec *invocationRecord) {
 }
 
 type functionSnapshot struct {
-	direct   Handler
-	prefixes map[string]Handler
+	direct         Handler
+	prefixes       map[string]Handler
+	prefixDerivers map[string]LaneKeyDeriver
 }
 
 func (m *Manager) snapshotFunction(name string) (functionSnapshot, bool) {
@@ -705,6 +708,10 @@ func (m *Manager) snapshotFunction(name string) (functionSnapshot, bool) {
 		if len(fs.prefixes) > 0 {
 			snap.prefixes = make(map[string]Handler, len(fs.prefixes))
 			maps.Copy(snap.prefixes, fs.prefixes)
+		}
+		if len(fs.prefixDerivers) > 0 {
+			snap.prefixDerivers = make(map[string]LaneKeyDeriver, len(fs.prefixDerivers))
+			maps.Copy(snap.prefixDerivers, fs.prefixDerivers)
 		}
 	}
 	m.mux.Unlock()
@@ -729,10 +736,10 @@ func matchPrefix(prefixes map[string]Handler, id string) (string, Handler, bool)
 	return "", nil, false
 }
 
-func (m *Manager) lookupFunctionRoute(fn Function) (handler Handler, scheduleKey string, ok bool) {
+func (m *Manager) lookupFunctionRoute(fn Function) (handler Handler, scheduleKey string, laneMeta any, ok bool) {
 	snap, ok := m.snapshotFunction(fn.Name)
 	if !ok {
-		return nil, "", false
+		return nil, "", nil, false
 	}
 	unknownHandler := m.unknownFunctionHandler()
 
@@ -740,18 +747,26 @@ func (m *Manager) lookupFunctionRoute(fn Function) (handler Handler, scheduleKey
 		if len(fn.Args) > 0 {
 			id := fn.Args[0]
 			if prefix, routeHandler, matched := matchPrefix(snap.prefixes, id); matched && routeHandler != nil {
-				return routeHandler, routeScheduleKey(fn.Name, prefix), true
+				key := routeScheduleKey(fn.Name, prefix)
+				if derive := snap.prefixDerivers[prefix]; derive != nil {
+					if laneKey, meta := m.deriveLaneKey(derive, fn); laneKey != "" {
+						// Narrow the registration lane to the derived identity;
+						// underivable requests keep the registration-wide lane.
+						return routeHandler, key + "|" + laneKey, meta, true
+					}
+				}
+				return routeHandler, key, nil, true
 			}
 		}
 
-		return unknownHandler, routeScheduleKey(fn.Name, scheduleKeyUnmatched), true
+		return unknownHandler, routeScheduleKey(fn.Name, scheduleKeyUnmatched), nil, true
 	}
 
 	if snap.direct != nil {
-		return snap.direct, routeScheduleKey(fn.Name, ""), true
+		return snap.direct, routeScheduleKey(fn.Name, ""), nil, true
 	}
 
-	return unknownHandler, routeScheduleKey(fn.Name, scheduleKeyDirectMissing), true
+	return unknownHandler, routeScheduleKey(fn.Name, scheduleKeyDirectMissing), nil, true
 }
 
 // lookupFunction returns a snapshot handler used by existing tests to verify

--- a/src/go/plugin/framework/functions/manager_test.go
+++ b/src/go/plugin/framework/functions/manager_test.go
@@ -96,7 +96,7 @@ func TestManager_RegisterWithContext(t *testing.T) {
 		gotFn = fn
 	})
 
-	handler, scheduleKey, ok := mgr.lookupFunctionRoute(Function{Name: "fn"})
+	handler, scheduleKey, _, ok := mgr.lookupFunctionRoute(Function{Name: "fn"})
 	if !ok {
 		t.Fatal("expected function route")
 	}
@@ -204,7 +204,7 @@ func TestManager_RegisterPrefixWithContext(t *testing.T) {
 		gotFn = fn
 	})
 
-	handler, scheduleKey, ok := mgr.lookupFunctionRoute(Function{Name: "config", Args: []string{"collector:job"}})
+	handler, scheduleKey, _, ok := mgr.lookupFunctionRoute(Function{Name: "config", Args: []string{"collector:job"}})
 	if !ok {
 		t.Fatal("expected prefix function route")
 	}

--- a/src/go/plugin/framework/functions/manager_worker.go
+++ b/src/go/plugin/framework/functions/manager_worker.go
@@ -42,6 +42,9 @@ func (m *Manager) runWorker() {
 			if ctx == nil {
 				ctx = context.Background()
 			}
+			if req.laneMeta != nil {
+				ctx = context.WithValue(ctx, laneMetaCtxKey{}, req.laneMeta)
+			}
 			req.handler(ctx, fn)
 		}()
 

--- a/src/go/plugin/framework/jobruntime/job_v1.go
+++ b/src/go/plugin/framework/jobruntime/job_v1.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -161,6 +162,11 @@ type Job struct {
 
 	stopCtrl stopController
 
+	// moduleCleanup guards the module's Cleanup to exactly once: it is
+	// reachable from the detection-failure defer, the main loop's tail, and
+	// Cleanup() (detected-but-never-started jobs are disposed through it).
+	moduleCleanup sync.Once
+
 	// Metrics-audit mode support.
 	auditMode     bool
 	auditAnalyzer metricsaudit.Analyzer
@@ -236,7 +242,7 @@ func (j *Job) AutoDetection(ctx context.Context) (err error) {
 			}
 		}
 		if err != nil {
-			j.module.Cleanup(context.TODO())
+			j.cleanupModule()
 		}
 	}()
 
@@ -344,7 +350,6 @@ LOOP:
 			}
 		}
 	}
-	j.module.Cleanup(context.TODO())
 	j.Cleanup()
 }
 
@@ -361,7 +366,12 @@ func (j *Job) disableAutoDetection() {
 	disableAutoDetection(&j.AutoDetectEvery)
 }
 
+func (j *Job) cleanupModule() {
+	j.moduleCleanup.Do(func() { j.module.Cleanup(context.TODO()) })
+}
+
 func (j *Job) Cleanup() {
+	j.cleanupModule()
 	j.buf.Reset()
 	if !collectorapi.ShouldObsoleteCharts() {
 		return

--- a/src/go/plugin/framework/jobruntime/job_v2_runtime.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_runtime.go
@@ -66,6 +66,13 @@ func (j *JobV2) runtimeComponentLabels() map[string]string {
 	return labels
 }
 
+// RuntimeComponentName is the runtime-chart component this job registers;
+// the runtime owner uses it to fence the component's emission when the job's
+// stop is abandoned at its deadline.
+func (j *JobV2) RuntimeComponentName() string {
+	return j.buildRuntimeComponentName()
+}
+
 func (j *JobV2) buildRuntimeComponentName() string {
 	plugin := sanitizeRuntimeComponentPart(firstNonEmpty(j.pluginName, "go.d"))
 	fullName := sanitizeRuntimeComponentPart(firstNonEmpty(j.fullName, j.name, "job"))


### PR DESCRIPTION
##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs collector dyncfg and discovery commands concurrently on per-key lanes with a 4-worker effect pool, so slow work on one config no longer blocks others or the run loop. Activates 120s effect deadlines with safe abandon/resume rules, strict stop fencing, robust shutdown resolution, and new executor runtime metrics.

- New Features
  - Per-key lanes for collector events; 4-worker effect pool; discovery waits are per-key only, dyncfg keeps flowing.
  - Flat 120s effect deadline: frees the pool slot at deadline; late detection success warm-starts once; late failures follow existing retry rules.
  - Stop fencing: per-job emission gateway and runtime barrier fence output before publishing success on abandon; total stop outcome classification.
  - Shutdown resolves every admitted command (buffered, queued, parked, in-flight); workers don’t start new module calls after cancel; leaked calls are tracked and reported.
  - Functions framework: per-prefix lane derivation via `RegisterPrefixLaneDeriver`; collector dyncfg commands lane per config; test requests use unique lanes and bypass busy keys; queue size raised to 256 with backlog-only accounting; derived schedule keys join parts with NUL to avoid collisions.
  - Secretstore bridge: restarts idle dependents inline; skips and reports dependents with work in flight, including enables in progress on old secrets; service calls derive context from the caller.
  - Executor runtime metrics exposed (busy/wedged keys, parked ages, pool depth/queue, leaked effects, suppressed late writes, barrier waits); age gauges clamp at zero.
  - `pkg/ticker` Stop releases promptly and is idempotent; V1 jobs ensure module cleanup runs exactly once.
  - Dependency: add `go.uber.org/goleak` for goroutine leak checks.

- Migration
  - `dyncfg.Callbacks` now carry context:
    - `ParseAndValidate(ctx, fn, name) (C, error)`
    - `Start(ctx, cfg) error`
    - `Update(ctx, oldCfg, newCfg) error`
    - `Stop(ctx, cfg) error`
  - Manager helpers now take context: `createCollectorJob(ctx, cfg)`, `stopRunningJob(ctx, name)`.
  - Secretstore and SD callbacks updated to context-aware forms; adjust callers.
  - If you route commands through `functions.Manager`, you can add per-prefix lane derivation with `RegisterPrefixLaneDeriver("config", "collector:", derive)`.
  - `newEmissionGateway(out, onSuppressed)` now accepts an optional hook to count suppressed writes; pass `nil` to ignore.

<sup>Written for commit 5c83a48a3682aa9dbbfb1eb89b20eb04dc924dbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

