### PR TITLE
avoid out-of-bounds read in url_percent_escape_decode

### DIFF
--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -57,7 +57,7 @@ char *url_encode(const char *str) {
  *  @return The character decoded on success and 0 otherwise
  */
 char url_percent_escape_decode(const char *s) {
-    if(likely(s[1] && s[2]))
+    if(likely(s[0] && s[1] && s[2]))
         return (char)(((uint8_t)from_hex(s[1]) << 4) | (uint8_t)from_hex(s[2]));
     return 0;
 }


### PR DESCRIPTION
##### Summary

`url_percent_escape_decode()` reads `s[1]` and `s[2]` after checking only that they are non-zero, without first checking `s[0]`:

- `url_decode_multibyte_utf8()` walks a percent-encoded UTF-8 sequence by advancing `s += 3` per continuation byte, with no check that another `%XX` triplet is actually present
- a truncated trailing escape (a URL ending in `%C3`, `%F0%80%80`, ...) leaves `s` on the terminating NUL, so the next `url_percent_escape_decode(s)` reads 1-2 bytes past the string end
- reached from `url_decode_r()` in web and ACLK URL decoding, the same path hardened for signed-char/shift UB in #22921

Added the missing `s[0]` term so the guard short-circuits on the NUL before it dereferences `s[1]`/`s[2]`. Valid input is unchanged, since `s[0]` is always the `%` there.

##### Test Plan

Decoded a heap-allocated URL ending in `%C3` (NUL on the last byte of the allocation) through `url_decode_r()` under AddressSanitizer:

- before: `heap-buffer-overflow READ of size 1`, 0 bytes after the allocation, at the `url_percent_escape_decode` call
- after: clean, and the malformed URL is rejected (`url_decode_r` returns NULL)

Valid percent-encoded UTF-8 decodes identically because the added term is always true when `s[0] == '%'`. Built the `libnetdata` target; `url.c` compiles without new warnings.

##### Additional Information

The three call sites (`url.c:105`, `:117`, `:205`) all reach the read through this one helper, so the single guard covers them. `url_utf8_get_byte_length()` caps the run at 4 bytes, so the over-read is at most 1-2 bytes.

<details> <summary>For users: How does this change affect me?</summary>
Affects URL decoding at the web and ACLK request boundary. No change for well-formed requests. A malformed percent-escaped URL that could previously read past the request buffer is now rejected during decode.
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent out-of-bounds reads in URL percent-decoding by checking s[0] before accessing s[1] and s[2], so truncated “%XX” sequences don’t read past the string. Malformed URLs like “%C3” are now rejected (url_decode_r returns NULL); valid percent-encoded UTF-8 is unchanged and web/ACLK decode paths are safe.

<sup>Written for commit 7082507cf5dd16072cc6413b9c7ca694da37b1e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

