### PR TITLE
feat(go.d): move jobmgr dyncfg domains onto claimed executor

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -1,0 +1,487 @@
+# Job Manager Architecture
+
+This document describes the current `jobmgr` architecture for maintainers.
+It is intentionally human-oriented: it explains the moving parts, command
+flows, state ownership, and test model without requiring the reader to
+reconstruct the system from individual review notes.
+
+## Mental Model
+
+`jobmgr` owns collector jobs at runtime. It accepts configuration changes
+from discovery and Dynamic Configuration (DynCfg), starts and stops jobs,
+coordinates secret stores and virtual nodes, and publishes Function routes.
+
+The central rule is simple:
+
+> The manager loop owns orchestration state. Blocking module work runs
+> outside the loop, then returns to the loop to commit.
+
+The architecture has four layers:
+
+1. Inputs:
+   discovery add/remove, DynCfg functions, effect completions, shutdown.
+2. Manager loop:
+   the single goroutine that owns executor state, claim state, and commits.
+3. Executor:
+   per-key lanes plus a multi-key claim table.
+4. Effects:
+   blocking work on a bounded worker pool, with deadline abandon and late
+   return handling.
+
+```mermaid
+flowchart TD
+    discovery("Discovery add/remove") --> loop("Manager.run")
+    dyncfg("DynCfg function") --> loop
+    done("Effect completion") --> loop
+    stop("Shutdown") --> loop
+
+    loop --> exec("Executor")
+    exec --> lanes("Per-key lanes")
+    exec --> claims("Claim table")
+    exec --> domains("Domain handlers")
+
+    domains --> collector("Collector config/job handler")
+    domains --> stores("Secretstore controller")
+    domains --> vnodes("Vnode controller")
+
+    collector --> effects("Effect pool")
+    stores --> effects
+    effects --> done
+
+    collector --> commit("Loop-side commit")
+    stores --> commit
+    vnodes --> commit
+    commit --> wire("DynCfg output and CONFIG records")
+    commit --> jobs("runningJobs / deps / funcctl / fileStatus")
+```
+
+## Main Objects
+
+| Object | Owner | Purpose |
+| --- | --- | --- |
+| `Manager.run` | One goroutine | Routes every accepted event and executes commits. |
+| `executor` | Manager loop | Serializes same-key work, manages effects, shutdown drain, and wedged keys. |
+| `keyState` | Manager loop | State for one domain key: FIFO, wait park, busy phase, grant, wedge. |
+| `claimTable` | Manager loop | Reserves cross-key dependencies before work can run. |
+| `dyncfg.Handler` | Manager loop plus callbacks | Generic collector config state machine. |
+| `secretsctl.Controller` | Manager loop plus effects | Secret store CRUD, validation, and dependent restarts. |
+| `vnodectl.Controller` | Manager loop | Vnode CRUD and validation. |
+| `runningJobs` | Locked helper | Registered runtime jobs. |
+| `secretStoreDeps` | Locked helper | Mapping from stores to dependent collector configs. |
+| `funcctl.Controller` | Locked helper plus reconciler | Function route publication. |
+| `emissionGates` | Locked helper | Output gate used to quarantine stopping or dropped jobs. |
+| `fileStatus` | Locked helper | File status persistence for dyncfg-managed jobs. |
+
+The loop owns orchestration decisions, but several helpers are locked
+because effects and auxiliary goroutines also need safe access.
+
+## Event Domains And Keys
+
+Every executor event has:
+
+- kind: discovery add, discovery remove, or DynCfg command;
+- domain: collector, secretstore, vnode, or unknown;
+- key: the object identity inside the domain.
+
+The lane key is domain-namespaced as `<domain>|<key>`, so collector job
+keys, store keys, and vnode names cannot collide.
+
+| Domain | Key | Examples |
+| --- | --- | --- |
+| Collector | Exposed config key | `mysql_local`, `go.d_job` |
+| Secretstore | Store key | `vault:vault_prod` |
+| Vnode | Vnode name | `db-primary` |
+| Unknown | none | Rejected immediately. |
+
+Underivable commands keep a domain fallback key and execute the existing
+handler rejection path. They are rejection-only by construction and do not
+claim dependencies.
+
+## Manager Loop
+
+`Manager.run` is the only consumer of:
+
+- discovery add/remove channels;
+- DynCfg command channel;
+- effect completion channel.
+
+It checks shutdown before every normal receive and again after the select
+chooses a work item. That bounds the shutdown race to the single event
+already being handled.
+
+```mermaid
+flowchart TD
+    start("Loop tick") --> pre("Check manager context")
+    pre -->|done| drain("Executor shutdown drain")
+    pre -->|active| receive("Receive one event")
+    receive --> add("Discovery add")
+    receive --> remove("Discovery remove")
+    receive --> fn("DynCfg command")
+    receive --> result("Effect result")
+
+    add --> activeCheck("Context still active?")
+    remove --> activeCheck
+    fn --> activeCheck
+    result --> resultCheck("Context still active?")
+
+    activeCheck -->|yes| dispatch("executor.dispatch")
+    activeCheck -->|no| reject("drop discovery or answer DynCfg 503")
+    resultCheck -->|yes| commit("executor.onEffectDone")
+    resultCheck -->|no| shutdownResult("executor.onEffectDoneShutdown")
+```
+
+The loop must not block on module code, external I/O, or unbounded channel
+sends. Blocking work must go through a `StepRunner` and return to the loop
+for commit.
+
+## Executor Lanes
+
+Each key has a lane. A lane may be:
+
+- idle;
+- occupied by claim acquisition;
+- occupied by an effect;
+- occupied by a held claim after inline work;
+- wait-parked awaiting an enable/disable decision;
+- wedged after a deadline abandon.
+
+Same-key events never overtake each other. Different keys can run
+concurrently unless the claim table finds a dependency conflict.
+
+Wait-park is special: it applies to discovery events for a config awaiting
+the user's enable/disable decision. DynCfg commands against the same key do
+not wait-park; they execute and answer the state machine's current outcome.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> AcquiringClaims: mutating event
+    Idle --> InlineCommit: claimless event
+    Idle --> WaitParked: discovered config awaiting decision
+    WaitParked --> AcquiringClaims: enable or disable decision
+    AcquiringClaims --> BusyEffect: grant plus blocking phase
+    AcquiringClaims --> InlineCommit: grant plus inline command
+    BusyEffect --> Commit: effect completion
+    BusyEffect --> Wedged: deadline abandon
+    Wedged --> Commit: late return
+    InlineCommit --> Idle
+    Commit --> Idle
+```
+
+## Claim Table
+
+Claims reserve cross-key dependencies before work runs.
+
+| Command class | Claims |
+| --- | --- |
+| Collector mutation | Own collector key as write; referenced stores as read; referenced vnode as read. |
+| Collector update/replace | Union of old and new store/vnode references. |
+| Collector disable/remove | Old store/vnode references from the exposed config. |
+| Secretstore mutation | Store key as write; restartable dependent jobs as write. |
+| Secretstore test | Store key as read. |
+| Vnode mutation | Vnode name as write. |
+| Rejection-only command | No claims. |
+
+Claim rules:
+
+- reads share;
+- writes exclude;
+- acquisition walks one global lexicographic order, including the primary;
+- a request holds the acquired prefix and parks at the first blocked key;
+- per-key waiter FIFO prevents barging;
+- claim sets recompute at every restage;
+- if the recomputed set changes, the old prefix is released and the new set
+  is acquired from the start;
+- claim waiters are pumped before lane release hooks can settle parked lane
+  events.
+
+This is the deadlock-avoidance core: no command waits for a later key while
+holding keys in an order that another command can invert.
+
+## Rejection-Only Commands
+
+A rejection-only command is one that answers before its first
+claim-protected access. It should not claim anything and should not park
+behind a foreign write hold.
+
+Examples:
+
+- invalid identity;
+- unknown command;
+- missing object;
+- missing payload;
+- unsupported command;
+- most source/type gates;
+- parse gates that happen before state access.
+
+Status-derived collector gates are the exception. Enable, restart, and
+disable can answer from `Entry.Status`, and that status is mutated by
+secretstore dependent restart plans. When the collector key is
+foreign-write-held, these commands park and answer after the hold resolves.
+
+The predicates that decide this are colocated with the command gates:
+
+- collector: `dyncfg.Handler.CommandActs` and
+  `RejectionDependsOnStatus`;
+- secretstore: `secretsctl.Controller.CommandActs`;
+- vnode: `vnodectl.Controller.CommandActs`.
+
+## Domain Flows
+
+### Collector Configs And Jobs
+
+Collector commands use the generic DynCfg handler plus jobmgr callbacks.
+
+| Command | Main flow |
+| --- | --- |
+| `add` | Validate payload, expose config, optionally replace old job, publish create/status. |
+| `enable` | Start an accepted/failed/disabled config and publish running or failed. |
+| `disable` | Stage stop, wait in effect, publish disabled. |
+| `remove` | Stage stop if needed, remove exposed/seen state, publish delete. |
+| `update` | For same-source update: stop old job, start replacement. For conversion: activate dyncfg config over file/user config. |
+| `restart` | Stop then start the same config. |
+| `get` / `schema` / `userconfig` | Read-only or cheap response paths. |
+| `test` | Keyless interactive validation on its own bounded pool. |
+
+Collector mutations claim their own key and referenced store/vnode keys.
+Update-shaped commands claim both old and new references.
+
+Function routing follows committed state:
+
+- stop withdrawal happens at stage time, before the stop effect reaches a
+  worker;
+- start publication happens at commit time, when the config is running.
+
+### Discovery
+
+Discovery does not mutate manager state directly. It sends add/remove
+intents to the loop.
+
+Discovery add:
+
+1. Validate identity.
+2. Remember the discovered config.
+3. If replacing an exposed config, stage the old stop.
+4. Publish create/status.
+5. If auto-enable applies, chain an enable command through the lane.
+6. Otherwise wait-park the key for an enable/disable decision.
+
+Discovery remove:
+
+1. Stage stop if a matching exposed job exists.
+2. Remove active job state and exposed config at commit.
+3. Publish delete.
+
+Discovery replace/remove stops are final-phase staged stops. Their stop wait
+claims completion before disarming the deadline fence, so a completed stop
+cannot be misclassified as an unfenced timeout.
+
+### Secretstores
+
+Secretstore commands run through `secretsctl.Controller.StepExec`.
+
+| Command | Main flow |
+| --- | --- |
+| `add` | Validate/activate store in effect, publish store config, restart dependents if needed. |
+| `update` | Validate/activate replacement, restart dependents. |
+| file/user conversion `update` | Activate dyncfg override in place, then restart dependents. |
+| `remove` | Reject if referenced; otherwise remove store. |
+| `test` | Validate candidate or stored config; read claim only. |
+| `get` / `schema` / `userconfig` | Cheap response paths. |
+
+Dependent restarts are one multi-key effect:
+
+1. The loop snapshots the restart plan after the store command has its
+   grant.
+2. The effect restarts dependents sequentially.
+3. Each completed dependent restart buffers a loop-side CONFIG STATUS replay.
+4. The store command flushes completed replay work before its terminal
+   response at normal commit or deadline-abandon commit.
+5. Restarts that finish only after a deadline abandon are replayed at the
+   late return, before the remaining write claims release.
+6. Wedged dependents are excluded from the claim set and reported as
+   skipped.
+
+The terminal message belongs to the command's own effect context, so
+overlapping store commands cannot cross-attribute messages.
+
+### Vnodes
+
+Vnode commands are loop-synchronous stage+commit operations under a vnode
+write claim.
+
+| Command | Main flow |
+| --- | --- |
+| `add` | Validate name, payload, GUID, and uniqueness; add vnode. |
+| `update` | Validate payload/GUID/uniqueness; update vnode and notify running jobs. |
+| `remove` | Reject if missing, non-dyncfg, or referenced; otherwise remove and publish delete. |
+| `test` | Validate candidate inline, no claim. |
+| `get` / `schema` / `userconfig` | Cheap response paths. |
+
+Collector commands that reference a vnode hold a read claim on the vnode.
+That prevents vnode removal/update from racing a collector stop/start window.
+
+Every job registration reconciles the job's vnode baseline before `Start`.
+This covers dependent restarts and warm resumes that were created before a
+vnode update but registered after it.
+
+## Effects, Deadlines, And Wedges
+
+Blocking work runs as an effect with the manager context plus a flat
+deadline. Blocking work includes:
+
+- collector validation and detection;
+- job stop waits;
+- secretstore backend validation and activation;
+- dependent restarts.
+
+If an effect returns before the deadline, the result is committed on the
+loop. If the deadline fires first, the worker commits the deadline outcome
+and the leaked call keeps running in the background. The key is then wedged
+until the leaked call returns.
+
+While wedged:
+
+- the lane remains busy;
+- same-key events park;
+- read claims release at the abandon commit;
+- write claims remain held until late return;
+- claim waiters at the wedged key are re-attempted so commands that can
+  skip wedged keys do not wait for an unbounded leaked call.
+
+At late return:
+
+- late replay work runs before remaining write claims release;
+- a warm start resumes only if the config is still current, no stop intent
+  is queued, the manager is not shutting down, and referenced stores are
+  unchanged/not write-held;
+- dropped warm starts dispose silently behind a closed emission gate;
+- shutdown late returns only release state and publish nothing.
+
+```mermaid
+sequenceDiagram
+    participant L as Manager loop
+    participant E as Effect worker
+    participant M as Module call
+
+    L->>E: dispatch effect
+    E->>M: run blocking work
+    alt returns before deadline
+        M-->>E: result
+        E-->>L: normal completion
+        L->>L: commit, release claims, settle lane
+    else deadline fires first
+        E-->>L: abandoned result
+        L->>L: commit deadline outcome, wedge key
+        M-->>E: late result
+        E-->>L: late completion
+        L->>L: resolve wedge, release writes, settle lane
+    end
+```
+
+## Shutdown
+
+Shutdown has one rule:
+
+> Every non-terminal DynCfg command answers 503, publishes nothing, and
+> disposes everything.
+
+Shutdown drain handles all places work can be stuck:
+
+- commands still in `dyncfgCh`;
+- pending effects that were not picked by a worker;
+- effect tasks sitting in the worker channel;
+- claim-parked commands;
+- in-flight effects that finish inside the bounded drain window;
+- still-busy keys after the drain window expires;
+- lane FIFO and wait FIFO entries.
+
+Late completions after the drain window are dropped through `lateDrop`.
+They must not publish state.
+
+## Function Publication
+
+Function publication is separate from job start/stop mechanics.
+
+- Stop withdrawal happens when a stop stages.
+- Start publication happens when a running status commits.
+- A reconciler goroutine performs publication work outside the manager loop.
+- The manager loop may request reconciliation, but it must not publish
+  directly.
+
+This keeps Function routing aligned to committed state while preventing the
+manager loop from blocking on publication work.
+
+## Output Ordering Rules
+
+Important ordering contracts:
+
+- Collector shared-handler commands emit the terminal result before their
+  same-command CONFIG records.
+- Secretstore dependent restart CONFIG STATUS records that completed by the
+  command commit are replayed before the store command terminal. Restarts
+  completing after deadline abandon are replayed at the late return, before
+  the remaining write claims release.
+- Vnode remove emits CONFIG delete before its terminal.
+- Shutdown publishes no CONFIG records for non-terminal work.
+- Deadline abandon keeps the permanent deadline classification, not the
+  shutdown one-rule.
+
+These contracts are pinned by characterization and flow tests.
+
+## Testing Model
+
+The test suite should be read as a set of matrices, not as isolated tests.
+
+### Matrix Axes
+
+| Axis | Values to cover |
+| --- | --- |
+| Domain | collector, secretstore, vnode |
+| Object state | missing, accepted, running, failed, disabled, dyncfg, file/user, stock/internal |
+| Command class | read-only, rejection-only, stage+commit, effect, chained effect, keyless test |
+| Dependencies | no refs, store refs, vnode refs, dependent jobs, busy dependent, wedged dependent |
+| Ordering | same-key FIFO, wait-parked discovery, foreign write hold, read/read sharing, read/write conflict |
+| Failure boundary | validation failure, start failure, stop timeout, effect deadline, late return, shutdown |
+| Expected result | terminal code, CONFIG records, claim behavior, publication timing, retry behavior |
+
+Do not try to test the full Cartesian product. The useful target is
+equivalence-class coverage: one test per behavior boundary, plus parity
+tests that fail when a command gate moves without updating the scheduler
+predicate.
+
+### Existing Coverage Anchors
+
+| Area | Primary tests |
+| --- | --- |
+| Claim table ordering and fairness | `claims_test.go` |
+| Per-key dispatch, derivation, keyless collector test | `executor_test.go` |
+| Generic DynCfg command state machine | `plugin/framework/dyncfg/handler_test.go` |
+| Collector callbacks and command basics | `dyncfg_collector_test.go`, `manager_test.go` |
+| Discovery wait parking and wire order | `characterization_test.go` |
+| Secretstore flow and conversion | `secretstore_flow_test.go` |
+| Secretstore effects and dependent restart edge cases | `secretstore_effect_test.go`, `effect_deadline_test.go` |
+| Vnode and cross-domain claim interactions | `vnode_claims_test.go`, `dyncfg_vnode_test.go` |
+| Deadline, wedge, shutdown one-rule | `effect_deadline_test.go`, `effect_test.go`, `executor_test.go` |
+| Function publication timing | `manager_process_test.go`, `funcdispatch_test.go`, `funcctl/*_test.go` |
+| CommandActs parity | `handler_test.go`, `secretsctl/commandacts_test.go`, `vnodectl/commandacts_test.go` |
+
+### Known Test-Gap Classes
+
+These are not known runtime defects. They are places where future test
+hardening should focus.
+
+| Gap class | Current state | Suggested next test shape |
+| --- | --- | --- |
+| Human-readable matrix | Coverage exists but is spread across many files. | Keep this section current when adding a command or state. |
+| Integrated hold-aware status commands | End-to-end pin covers enable during a dependent restart; handler unit tests classify enable/restart/disable. | Add table-driven end-to-end rows for restart and disable under a foreign dependent write hold if more pre-PR hardening is requested. |
+| Unsupported/inline command parity | End-to-end rejection pins exist for representative unsupported store/vnode commands; per-domain parity tables are not a full unsupported-command census. | Extend parity tables when command support changes, especially for unsupported commands that should remain claimless. |
+| Pairwise cross-domain interleavings | Representative read/write conflicts are pinned; every command pair is not enumerated. | Add pairwise tests only when a new claim mode or new cross-key writer is introduced. |
+| Shutdown matrix by every command | Shutdown one-rule is pinned at the main chokepoints and representative commands. | Add command-specific shutdown rows only when a command adds a new effect phase or publication path. |
+
+When adding tests, prefer:
+
+- table-driven gate parity tests for deterministic command predicates;
+- property tests for claim-table ordering rules;
+- end-to-end choreography only for cross-domain ordering or publication
+  outcomes that cannot be proven at the predicate/unit layer.

--- a/src/go/plugin/agent/jobmgr/characterization_test.go
+++ b/src/go/plugin/agent/jobmgr/characterization_test.go
@@ -375,6 +375,60 @@ func TestCharacterization_WireOrderByDomain(t *testing.T) {
 				assert.Contains(t, resp["message"], "gated:mysql")
 			},
 		},
+		"secretstore multi-dependent CONFIG STATUS replay follows sorted job order": {
+			run: func(t *testing.T) {
+				mgr, out := newDyncfgSecretStoreTestManagerWithService(newTestSecretStoreService())
+				mgr.modules["gated"] = collectorapi.Creator{
+					Create: func() collectorapi.CollectorV1 { return &secretAwareCollector{} },
+				}
+
+				key := secretstore.StoreKey(secretstore.KindVault, "vault_prod")
+				seedSecretStore(t, mgr, secretstore.KindVault, "vault_prod", map[string]any{"value": "good"}, dyncfg.StatusRunning)
+
+				// Registered in reverse name order on purpose: the restart
+				// sequence follows the dependency index's sorted job order,
+				// not registration order.
+				for _, name := range []string{"beta", "alpha"} {
+					cfg := prepareDyncfgCfg("gated", name).
+						Set("option_str", "${store:vault:vault_prod:value}").
+						Set("option_int", 1)
+					mgr.collectorExposed.Add(&dyncfg.Entry[confgroup.Config]{Cfg: cfg, Status: dyncfg.StatusRunning})
+					mgr.syncSecretStoreDepsForConfig(cfg)
+					require.NoError(t, mgr.collectorCallbacks.Start(context.Background(), cfg))
+				}
+
+				badFn := dyncfg.NewFunction(functions.Function{
+					UID:         "ss-update-bad",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"value": "bad"}),
+					Args:        []string{mgr.dyncfgSecretStoreID(key), string(dyncfg.CommandUpdate)},
+				})
+				mgr.dyncfgSecretStoreSeqExec(badFn)
+
+				output := out.String()
+				wiretest.RequireSubsequence(t, output, []wiretest.RecordWant{
+					{
+						Name:     "first dependent in sorted order fails",
+						Contains: []string{"CONFIG test:collector:gated:alpha status failed"},
+					},
+					{
+						Name:     "second dependent in sorted order fails",
+						Contains: []string{"CONFIG test:collector:gated:beta status failed"},
+					},
+					{
+						Name:     "store update terminal",
+						Contains: []string{"FUNCTION_RESULT_BEGIN ss-update-bad"},
+					},
+				})
+
+				var resp map[string]any
+				mustDecodeFunctionPayload(t, output, "ss-update-bad", &resp)
+				msg, _ := resp["message"].(string)
+				assert.Regexp(t,
+					`^Secretstore change applied, but dependent collector restarts failed: gated:alpha \(.+\); gated:beta \(.+\)\.$`,
+					msg, "per-job failures must join in sorted job order with the pinned format")
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/src/go/plugin/agent/jobmgr/claims.go
+++ b/src/go/plugin/agent/jobmgr/claims.go
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"cmp"
+	"slices"
+	"time"
+)
+
+// The claim table is the loop-owned multi-key reservation layer over the
+// executor's namespaced keys. A command that touches keys beyond its own
+// lane (a store update restarting dependent jobs, a collector command
+// resolving secrets from a store, a command bound to a vnode) reserves ALL
+// of them before its blocking work ships, under these rules:
+//
+//   - Read claims share a key; a write claim is exclusive. Read and write
+//     conflict - the later arrival parks.
+//   - ALL of a command's keys - including its primary - are acquired in ONE
+//     global lexicographic key order, waiting at each. A single total order
+//     makes circular waits structurally impossible; grabbing the primary
+//     first and then the rest would deadlock two overlapping multi-key
+//     commands.
+//   - Waiters at a key are strictly FIFO: a new acquisition parks behind
+//     existing waiters even when it would be compatible with the current
+//     holders, so writers can never starve behind a stream of readers.
+//   - The claim set is recomputed at EVERY (re-)stage attempt: when a parked
+//     acquisition wakes, its dependency set may have changed while another
+//     command's effect was in flight (stage-time sets go stale). If the set
+//     changed, everything held is released and the walk restarts under the
+//     new set - a parked command never acts on a stale dependency set.
+//   - An acquisition that cannot proceed holds only the lexicographic
+//     prefix it already acquired and parks at the blocking key; commands
+//     that have not begun acquiring hold nothing.
+//
+// The table is loop-owned state: every method must be called on the run-loop
+// goroutine. Grant callbacks run synchronously on the caller (acquire or the
+// release that unblocked them). The table is the single source of key
+// exclusivity: every command occupying a lane holds a claim on its own key
+// here, so no out-of-band occupancy veto exists.
+
+// claimMode distinguishes shared readers from exclusive writers.
+type claimMode int8
+
+const (
+	claimRead claimMode = iota + 1
+	claimWrite
+)
+
+// claim is one key of a command's reservation set. Keys use the executor's
+// domain-namespaced form (event.stateKey) so keys from different domains can
+// never collide.
+type claim struct {
+	key  string
+	mode claimMode
+}
+
+// claimRequest is one command's multi-key reservation.
+type claimRequest struct {
+	// label identifies the command in logs and metrics.
+	label string
+	// compute returns the current claim set. It is called at the initial
+	// attempt and again at every unpark; duplicate keys are normalized to
+	// the strongest mode.
+	compute func() []claim
+	// granted runs synchronously once every claim is held. The command's
+	// blocking work may then ship; the grant must be released at commit.
+	granted func(*claimGrant)
+}
+
+// claimGrant is a completed acquisition: proof that all claims of the last
+// computed set are held, and the handle to release them.
+type claimGrant struct {
+	held  []claim
+	owner *claimAcquisition
+}
+
+// claimTable tracks holders and FIFO waiters per key.
+type claimTable struct {
+	keys map[string]*claimKeyState
+	// released, when set, runs after a key loses its last holder so the
+	// owner can settle work parked behind the claim.
+	released func(key string)
+
+	// wakeQueue defers waiter processing to a single flat pump at the
+	// outermost entry point, so releases performed inside an attempt (a
+	// recomputed set dropping keys) never recurse.
+	wakeQueue     []string
+	releasedQueue []string
+	pumping       bool
+	parked        int
+}
+
+type claimKeyState struct {
+	writer  *claimAcquisition
+	readers map[*claimAcquisition]struct{}
+	waiters []*claimAcquisition
+}
+
+func (ks *claimKeyState) unused() bool {
+	return ks.writer == nil && len(ks.readers) == 0 && len(ks.waiters) == 0
+}
+
+// claimAcquisition is one in-progress ordered walk over a normalized set.
+type claimAcquisition struct {
+	req      *claimRequest
+	set      []claim // sorted by key, deduped to the strongest mode
+	next     int     // index into set of the key being acquired
+	parkedAt time.Time
+}
+
+func newClaimTable() *claimTable {
+	return &claimTable{keys: make(map[string]*claimKeyState)}
+}
+
+// normalizeClaims sorts by key and collapses duplicates to the strongest
+// mode, giving every acquisition the same global walk order.
+func normalizeClaims(set []claim) []claim {
+	if len(set) == 0 {
+		return nil
+	}
+	modes := make(map[string]claimMode, len(set))
+	for _, c := range set {
+		if c.mode == claimWrite || modes[c.key] == 0 {
+			modes[c.key] = max(modes[c.key], c.mode)
+		}
+	}
+	out := make([]claim, 0, len(modes))
+	for key, mode := range modes {
+		out = append(out, claim{key: key, mode: mode})
+	}
+	slices.SortFunc(out, func(a, b claim) int { return cmp.Compare(a.key, b.key) })
+	return out
+}
+
+// acquire starts an ordered acquisition for req. When every key is free it
+// completes synchronously (req.granted runs before acquire returns);
+// otherwise the acquisition holds its lexicographic prefix and parks at the
+// blocking key until releases resume it.
+func (ct *claimTable) acquire(req *claimRequest) {
+	ct.attempt(&claimAcquisition{req: req}, "")
+	ct.pump()
+}
+
+// attempt (re)runs an acquisition: recompute the set, release everything on
+// a set change, then walk the remaining keys in order. When the walk blocks
+// at reparkFront, the acquisition re-enters that queue at the FRONT (it was
+// just popped as its head and must not lose its position).
+func (ct *claimTable) attempt(a *claimAcquisition, reparkFront string) {
+	set := normalizeClaims(a.req.compute())
+	if !slices.Equal(set, a.set) {
+		ct.releaseHeld(a)
+		a.set = set
+		a.next = 0
+	}
+	ct.walk(a, reparkFront)
+}
+
+// walk acquires a.set[a.next:] in order, parking at the first unavailable
+// key; on full acquisition the request is granted.
+func (ct *claimTable) walk(a *claimAcquisition, reparkFront string) {
+	for a.next < len(a.set) {
+		c := a.set[a.next]
+		ks := ct.keys[c.key]
+		if ks == nil {
+			ks = &claimKeyState{}
+			ct.keys[c.key] = ks
+		}
+		// FIFO fairness: park behind existing waiters even when compatible
+		// with the current holders - except at the key this acquisition was
+		// just woken from (any waiters there arrived behind it).
+		barged := len(ks.waiters) > 0 && c.key != reparkFront
+		if barged || !ct.canHold(ks, c) {
+			a.parkedAt = time.Now()
+			ct.parked++
+			if c.key == reparkFront {
+				ks.waiters = append([]*claimAcquisition{a}, ks.waiters...)
+			} else {
+				ks.waiters = append(ks.waiters, a)
+			}
+			return
+		}
+		if c.mode == claimWrite {
+			ks.writer = a
+		} else {
+			if ks.readers == nil {
+				ks.readers = make(map[*claimAcquisition]struct{})
+			}
+			ks.readers[a] = struct{}{}
+		}
+		a.next++
+	}
+	a.parkedAt = time.Time{}
+	a.req.granted(&claimGrant{held: a.set, owner: a})
+}
+
+func (ct *claimTable) canHold(ks *claimKeyState, c claim) bool {
+	if ks.writer != nil {
+		return false
+	}
+	if c.mode == claimWrite && len(ks.readers) > 0 {
+		return false
+	}
+	return true
+}
+
+// release frees every key of a completed grant and resumes parked
+// acquisitions that can now proceed (their granted callbacks may run
+// synchronously inside this call).
+func (ct *claimTable) release(g *claimGrant) {
+	if g == nil || g.owner == nil {
+		return
+	}
+	a := g.owner
+	g.owner = nil
+	a.next = len(a.set)
+	ct.releaseHeld(a)
+	ct.pump()
+}
+
+// releaseReadClaims frees the grant's READ claims and keeps its writes.
+// Used at a deadline-abandon commit: the command has committed its outcome,
+// so its read reservations (referenced stores, vnodes - keys its leaked
+// work only LOOKED at) must not outlive it. Its write claims - the
+// command's own key and any keys the leaked work may still MUTATE, such as
+// a store command's dependent job keys - stay held until the late return.
+func (ct *claimTable) releaseReadClaims(g *claimGrant) {
+	if g == nil || g.owner == nil {
+		return
+	}
+	a := g.owner
+	var kept []claim
+	for _, c := range a.set {
+		if c.mode == claimWrite {
+			kept = append(kept, c)
+			continue
+		}
+		ks := ct.keys[c.key]
+		if ks == nil {
+			continue
+		}
+		delete(ks.readers, a)
+		ct.wakeQueue = append(ct.wakeQueue, c.key)
+		if ks.writer == nil && len(ks.readers) == 0 {
+			ct.releasedQueue = append(ct.releasedQueue, c.key)
+		}
+	}
+	a.set = kept
+	a.next = len(kept)
+	g.held = kept
+	ct.pump()
+}
+
+// releaseHeld drops the acquisition's held prefix (set[:next]) and queues
+// wakes for the freed keys.
+func (ct *claimTable) releaseHeld(a *claimAcquisition) {
+	for i := range a.next {
+		c := a.set[i]
+		ks := ct.keys[c.key]
+		if ks == nil {
+			continue
+		}
+		if c.mode == claimWrite {
+			if ks.writer == a {
+				ks.writer = nil
+			}
+		} else {
+			delete(ks.readers, a)
+		}
+		ct.wakeQueue = append(ct.wakeQueue, c.key)
+		if ks.writer == nil && len(ks.readers) == 0 {
+			ct.releasedQueue = append(ct.releasedQueue, c.key)
+		}
+	}
+	a.next = 0
+}
+
+// heldForWrite reports whether an acquisition holds the key EXCLUSIVELY.
+// Lane owners park events for a write-held key until the release hook
+// settles them; read holds never park lane events - read-shaped inline
+// commands share safely, and claim-acquiring events arbitrate their modes in
+// the table itself (read/read shares, write parks fairly in the FIFO).
+func (ct *claimTable) heldForWrite(key string) bool {
+	ks := ct.keys[key]
+	return ks != nil && ks.writer != nil
+}
+
+// wake re-attempts the FIFO waiters parked at key even though its holders
+// did not change. Used when a key WEDGES: its retained write claim now has
+// no bounded release, and waiters whose recomputed sets exclude wedged keys
+// (store mutations skip-and-report wedged dependents) must proceed instead
+// of waiting out the leaked call. A waiter whose recomputed set still needs
+// the key simply re-parks at the front.
+func (ct *claimTable) wake(key string) {
+	ct.wakeQueue = append(ct.wakeQueue, key)
+	ct.pump()
+}
+
+// pump processes deferred wakes until quiescence. Only the outermost caller
+// pumps; attempts running inside it queue further wakes instead of
+// recursing.
+func (ct *claimTable) pump() {
+	if ct.pumping {
+		return
+	}
+	ct.pumping = true
+	defer func() { ct.pumping = false }()
+	for {
+		for len(ct.wakeQueue) > 0 {
+			key := ct.wakeQueue[0]
+			ct.wakeQueue = ct.wakeQueue[1:]
+			ct.processWaiters(key)
+		}
+		if len(ct.releasedQueue) == 0 {
+			return
+		}
+		keys := ct.releasedQueue
+		ct.releasedQueue = nil
+		seen := make(map[string]bool, len(keys))
+		for _, key := range keys {
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			ct.notifyReleased(key)
+		}
+	}
+}
+
+func (ct *claimTable) notifyReleased(key string) {
+	ks := ct.keys[key]
+	if ks != nil && (ks.writer != nil || len(ks.readers) > 0 || len(ks.waiters) > 0) {
+		return
+	}
+	if ct.released != nil {
+		ct.released(key)
+	}
+	if ks != nil && ks.unused() {
+		delete(ct.keys, key)
+	}
+}
+
+// processWaiters resumes the FIFO head of a key's waiter queue until the
+// head cannot proceed (it re-parked at this key) or the queue empties.
+func (ct *claimTable) processWaiters(key string) {
+	for {
+		ks := ct.keys[key]
+		if ks == nil || len(ks.waiters) == 0 {
+			return
+		}
+		head := ks.waiters[0]
+		ks.waiters = ks.waiters[1:]
+		ct.parked--
+		head.parkedAt = time.Time{}
+		ct.attempt(head, key)
+		ksNow := ct.keys[key]
+		if ksNow != nil && len(ksNow.waiters) > 0 && ksNow.waiters[0] == head {
+			// The head is still blocked here: everyone behind it stays
+			// queued (strict FIFO, no barging past a blocked head).
+			return
+		}
+	}
+}
+
+// drainParked fails every parked acquisition: each is reported through fail,
+// its held prefix is released, and it will never be granted. Used by the
+// shutdown drain so parked commands reach a terminal outcome.
+func (ct *claimTable) drainParked(fail func(*claimRequest)) {
+	var drained []*claimAcquisition
+	for _, ks := range ct.keys {
+		drained = append(drained, ks.waiters...)
+		ct.parked -= len(ks.waiters)
+		ks.waiters = nil
+	}
+	for _, a := range drained {
+		ct.releaseHeld(a)
+		fail(a.req)
+	}
+	for key, ks := range ct.keys {
+		if ks.unused() {
+			delete(ct.keys, key)
+		}
+	}
+	// No waiters remain, so queued wakes cannot grant anything; drop them.
+	ct.wakeQueue = nil
+	ct.releasedQueue = nil
+}
+
+// parkedCount reports how many acquisitions are currently parked.
+func (ct *claimTable) parkedCount() int {
+	return ct.parked
+}
+
+// oldestParkedSince reports the park time of the longest-parked acquisition
+// and false when nothing is parked.
+func (ct *claimTable) oldestParkedSince() (time.Time, bool) {
+	var oldest time.Time
+	for _, ks := range ct.keys {
+		for _, a := range ks.waiters {
+			if !a.parkedAt.IsZero() && (oldest.IsZero() || a.parkedAt.Before(oldest)) {
+				oldest = a.parkedAt
+			}
+		}
+	}
+	return oldest, !oldest.IsZero()
+}

--- a/src/go/plugin/agent/jobmgr/claims_test.go
+++ b/src/go/plugin/agent/jobmgr/claims_test.go
@@ -1,0 +1,517 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"fmt"
+	"math/rand"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// claimProbe records a request's grant lifecycle for assertions.
+type claimProbe struct {
+	label  string
+	grants int
+	grant  *claimGrant
+}
+
+func (p *claimProbe) granted() bool { return p.grants > 0 }
+
+func (p *claimProbe) request(compute func() []claim) *claimRequest {
+	return &claimRequest{
+		label:   p.label,
+		compute: compute,
+		granted: func(g *claimGrant) {
+			p.grants++
+			p.grant = g
+		},
+	}
+}
+
+func staticClaims(claims ...claim) func() []claim {
+	return func() []claim { return claims }
+}
+
+func heldKeys(g *claimGrant) []string {
+	keys := make([]string, 0, len(g.held))
+	for _, c := range g.held {
+		keys = append(keys, c.key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// TestClaimTable_BothOrdersNoDeadlock is the binding overlap scenario: a
+// collector command (write on its job key, read on a store) against a store
+// update (write on the store, write on that collector's job key), staggered
+// through a pre-existing store holder so both end up mid-acquisition, in
+// BOTH arrival orders and BOTH lexicographic key directions. Single global
+// acquisition order must resolve every variant; a primary-first
+// implementation deadlocks the second-arrival variants (one command holding
+// its primary while waiting for the other's).
+func TestClaimTable_BothOrdersNoDeadlock(t *testing.T) {
+	tests := map[string]struct {
+		jobKey, storeKey string
+		collectorFirst   bool
+	}{
+		"job key sorts first, collector arrives first":   {jobKey: "a|job", storeKey: "s|store", collectorFirst: true},
+		"job key sorts first, store arrives first":       {jobKey: "a|job", storeKey: "s|store", collectorFirst: false},
+		"store key sorts first, collector arrives first": {jobKey: "t|job", storeKey: "s|store", collectorFirst: true},
+		"store key sorts first, store arrives first":     {jobKey: "t|job", storeKey: "s|store", collectorFirst: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ct := newClaimTable()
+
+			blocker := &claimProbe{label: "blocker"}
+			ct.acquire(blocker.request(staticClaims(claim{tc.storeKey, claimWrite})))
+			require.True(t, blocker.granted(), "the blocker must acquire the free store immediately")
+
+			collector := &claimProbe{label: "collector"}
+			store := &claimProbe{label: "store-update"}
+			collectorReq := collector.request(staticClaims(
+				claim{tc.jobKey, claimWrite},  // primary
+				claim{tc.storeKey, claimRead}, // referenced store
+			))
+			storeReq := store.request(staticClaims(
+				claim{tc.storeKey, claimWrite}, // primary
+				claim{tc.jobKey, claimWrite},   // dependent job restart
+			))
+
+			first, second := collector, store
+			if tc.collectorFirst {
+				ct.acquire(collectorReq)
+				ct.acquire(storeReq)
+			} else {
+				ct.acquire(storeReq)
+				ct.acquire(collectorReq)
+				first, second = store, collector
+			}
+
+			assert.False(t, collector.granted(), "the collector command must park behind the blocked store")
+			assert.False(t, store.granted(), "the store update must park behind the blocked store")
+
+			ct.release(blocker.grant)
+			require.True(t, first.granted(),
+				"releasing the blocker must grant the first arrival (%s)", first.label)
+			require.False(t, second.granted(),
+				"the second arrival (%s) must wait for the first's conflicting holds", second.label)
+
+			ct.release(first.grant)
+			require.True(t, second.granted(),
+				"releasing the first grant must grant the second arrival (%s) - a deadlock here means acquisition is not a single global order", second.label)
+
+			ct.release(second.grant)
+			assert.Equal(t, 0, ct.parkedCount(), "nothing may stay parked after all grants release")
+		})
+	}
+}
+
+// TestClaimTable_OrderedAcquisitionProperties is a randomized sweep:
+// many requests with random claim sets acquired and released in random
+// interleavings. Invariants: reader/writer exclusion holds at every grant,
+// every request is granted exactly once, and nothing stays parked once all
+// grants are released.
+func TestClaimTable_OrderedAcquisitionProperties(t *testing.T) {
+	for seed := int64(1); seed <= 8; seed++ {
+		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(seed))
+			ct := newClaimTable()
+
+			keys := make([]string, 10)
+			for i := range keys {
+				keys[i] = fmt.Sprintf("k%02d", i)
+			}
+
+			type holdState struct{ readers, writers int }
+			holds := map[string]*holdState{}
+			holdOf := func(key string) *holdState {
+				if holds[key] == nil {
+					holds[key] = &holdState{}
+				}
+				return holds[key]
+			}
+
+			const requests = 40
+			var outstanding []*claimGrant
+			grantsSeen := 0
+
+			newRequest := func(i int) *claimRequest {
+				n := 1 + rng.Intn(4)
+				perm := rng.Perm(len(keys))[:n]
+				set := make([]claim, 0, n)
+				for _, ki := range perm {
+					mode := claimRead
+					if rng.Intn(2) == 0 {
+						mode = claimWrite
+					}
+					set = append(set, claim{keys[ki], mode})
+				}
+				req := &claimRequest{
+					label:   fmt.Sprintf("req-%d", i),
+					compute: staticClaims(set...),
+				}
+				req.granted = func(g *claimGrant) {
+					grantsSeen++
+					for _, c := range g.held {
+						hs := holdOf(c.key)
+						switch c.mode {
+						case claimWrite:
+							require.Zero(t, hs.readers, "write grant on %s with readers held", c.key)
+							require.Zero(t, hs.writers, "write grant on %s with a writer held", c.key)
+							hs.writers++
+						case claimRead:
+							require.Zero(t, hs.writers, "read grant on %s with a writer held", c.key)
+							hs.readers++
+						}
+					}
+					outstanding = append(outstanding, g)
+				}
+				return req
+			}
+
+			releaseRandom := func() {
+				i := rng.Intn(len(outstanding))
+				g := outstanding[i]
+				outstanding = slices.Delete(outstanding, i, i+1)
+				for _, c := range g.held {
+					hs := holdOf(c.key)
+					if c.mode == claimWrite {
+						hs.writers--
+					} else {
+						hs.readers--
+					}
+				}
+				ct.release(g)
+			}
+
+			for i := range requests {
+				ct.acquire(newRequest(i))
+				// Release with 50% probability per outstanding grant to keep
+				// a healthy mix of holds and parks.
+				for len(outstanding) > 0 && rng.Intn(2) == 0 {
+					releaseRandom()
+				}
+			}
+			for len(outstanding) > 0 {
+				releaseRandom()
+			}
+
+			assert.Equal(t, requests, grantsSeen, "every request must be granted exactly once")
+			assert.Equal(t, 0, ct.parkedCount(), "nothing may stay parked after all releases")
+		})
+	}
+}
+
+// TestClaimTable_WaiterFIFOPreventsWriterStarvation pins fair per-key
+// queuing: a later reader parks BEHIND an already-parked writer instead of
+// joining the current readers, so a stream of readers can never starve a
+// writer.
+func TestClaimTable_WaiterFIFOPreventsWriterStarvation(t *testing.T) {
+	ct := newClaimTable()
+	const k = "k"
+
+	reader1 := &claimProbe{label: "reader-1"}
+	ct.acquire(reader1.request(staticClaims(claim{k, claimRead})))
+	require.True(t, reader1.granted())
+
+	writer := &claimProbe{label: "writer"}
+	ct.acquire(writer.request(staticClaims(claim{k, claimWrite})))
+	require.False(t, writer.granted(), "the writer must park behind the held read claim")
+
+	reader2 := &claimProbe{label: "reader-2"}
+	ct.acquire(reader2.request(staticClaims(claim{k, claimRead})))
+	require.False(t, reader2.granted(),
+		"a later reader must park behind the waiting writer, not join the current readers")
+
+	ct.release(reader1.grant)
+	require.True(t, writer.granted(), "the writer is first in the FIFO")
+	require.False(t, reader2.granted(), "the reader waits out the writer's exclusive hold")
+
+	ct.release(writer.grant)
+	require.True(t, reader2.granted())
+	ct.release(reader2.grant)
+	assert.Equal(t, 0, ct.parkedCount())
+}
+
+// TestClaimTable_ReleasePumpsWaitersBeforeReleasedHook pins the lane/claim
+// ordering seam: executor lane FIFO work parked behind a foreign write hold
+// must not settle until same-key claim waiters had the first chance to acquire
+// the key. Otherwise a later status no-op could run before an older store
+// update waiter gets its dependent write claim.
+func TestClaimTable_ReleasePumpsWaitersBeforeReleasedHook(t *testing.T) {
+	ct := newClaimTable()
+	var released []string
+	ct.released = func(key string) {
+		released = append(released, key)
+	}
+
+	holder := &claimProbe{label: "holder"}
+	ct.acquire(holder.request(staticClaims(claim{"job", claimWrite})))
+	require.True(t, holder.granted())
+
+	waiter := &claimProbe{label: "store-update"}
+	ct.acquire(waiter.request(staticClaims(claim{"job", claimWrite})))
+	require.False(t, waiter.granted(), "the store update must park behind the held job key")
+
+	ct.release(holder.grant)
+	require.True(t, waiter.granted(), "the claim waiter must acquire before lane FIFO settlement")
+	assert.Empty(t, released, "the executor release hook must not run while the waiter now holds the key")
+
+	ct.release(waiter.grant)
+	assert.Equal(t, []string{"job"}, released)
+}
+
+func TestClaimTable_ReleasedHookWaitsForGrantedReaders(t *testing.T) {
+	ct := newClaimTable()
+	var released []string
+	ct.released = func(key string) {
+		released = append(released, key)
+	}
+
+	holder := &claimProbe{label: "holder"}
+	ct.acquire(holder.request(staticClaims(claim{"store", claimWrite})))
+	require.True(t, holder.granted())
+
+	reader := &claimProbe{label: "collector"}
+	ct.acquire(reader.request(staticClaims(claim{"store", claimRead})))
+	require.False(t, reader.granted(), "the reader must park behind the writer")
+
+	ct.release(holder.grant)
+	require.True(t, reader.granted(), "the reader must acquire before release hooks run")
+	assert.Empty(t, released, "the release hook must not run while a reader holds the key")
+
+	ct.release(reader.grant)
+	assert.Equal(t, []string{"store"}, released)
+}
+
+// TestClaimTable_RecomputeAtRestage pins the stale-set rule: a parked
+// acquisition recomputes its claim set when it wakes; a changed set releases
+// EVERYTHING held and reacquires under the new set, so keys dropped from the
+// set free immediately and newly-added dependencies are respected.
+func TestClaimTable_RecomputeAtRestage(t *testing.T) {
+	t.Run("changed set releases the held prefix and reacquires", func(t *testing.T) {
+		ct := newClaimTable()
+
+		blocker := &claimProbe{label: "blocker"}
+		ct.acquire(blocker.request(staticClaims(claim{"k3", claimWrite})))
+		require.True(t, blocker.granted())
+
+		set := []claim{{"k1", claimWrite}, {"k3", claimWrite}}
+		parked := &claimProbe{label: "parked"}
+		ct.acquire(parked.request(func() []claim { return set }))
+		require.False(t, parked.granted(), "the acquisition must park at the blocked k3 holding k1")
+
+		probe := &claimProbe{label: "k1-probe"}
+		ct.acquire(probe.request(staticClaims(claim{"k1", claimWrite})))
+		require.False(t, probe.granted(), "k1 must be held by the parked acquisition's prefix")
+
+		// The dependency set changes while the acquisition is parked (the
+		// stale-credential class: another command's commit altered it).
+		set = []claim{{"k2", claimWrite}, {"k3", claimWrite}}
+
+		ct.release(blocker.grant)
+		require.True(t, parked.granted(), "the woken acquisition must complete under the new set")
+		assert.Equal(t, []string{"k2", "k3"}, heldKeys(parked.grant),
+			"the grant must reflect the RECOMPUTED set, not the stale one")
+		require.True(t, probe.granted(),
+			"k1 was dropped from the set - the stale prefix hold must have been released")
+
+		ct.release(parked.grant)
+		ct.release(probe.grant)
+		assert.Equal(t, 0, ct.parkedCount())
+	})
+
+	t.Run("unchanged set keeps the held prefix", func(t *testing.T) {
+		ct := newClaimTable()
+
+		blocker := &claimProbe{label: "blocker"}
+		ct.acquire(blocker.request(staticClaims(claim{"k3", claimWrite})))
+		require.True(t, blocker.granted())
+
+		parked := &claimProbe{label: "parked"}
+		ct.acquire(parked.request(staticClaims(claim{"k1", claimWrite}, claim{"k3", claimWrite})))
+		require.False(t, parked.granted())
+
+		probe := &claimProbe{label: "k1-probe"}
+		ct.acquire(probe.request(staticClaims(claim{"k1", claimWrite})))
+		require.False(t, probe.granted())
+
+		ct.release(blocker.grant)
+		require.True(t, parked.granted())
+		assert.Equal(t, []string{"k1", "k3"}, heldKeys(parked.grant))
+		require.False(t, probe.granted(), "k1 stays held until the grant releases")
+
+		ct.release(parked.grant)
+		require.True(t, probe.granted())
+		ct.release(probe.grant)
+	})
+}
+
+// TestClaimTable_ClaimSetNormalization pins that duplicate keys collapse to
+// the strongest mode (union claim sets legitimately produce the same key as
+// both read and write).
+func TestClaimTable_ClaimSetNormalization(t *testing.T) {
+	ct := newClaimTable()
+
+	p := &claimProbe{label: "dup"}
+	ct.acquire(p.request(staticClaims(
+		claim{"k", claimRead},
+		claim{"k", claimWrite},
+		claim{"k", claimRead},
+	)))
+	require.True(t, p.granted())
+	require.Len(t, p.grant.held, 1, "duplicate keys must collapse to one claim")
+	assert.Equal(t, claimWrite, p.grant.held[0].mode, "write is the strongest mode")
+
+	reader := &claimProbe{label: "reader"}
+	ct.acquire(reader.request(staticClaims(claim{"k", claimRead})))
+	assert.False(t, reader.granted(), "the collapsed claim must be exclusive")
+
+	ct.release(p.grant)
+	assert.True(t, reader.granted())
+	ct.release(reader.grant)
+}
+
+// TestClaimTable_EmptySetGrantsImmediately pins the degenerate case: a
+// command with no claims runs immediately and its release is a no-op.
+func TestClaimTable_EmptySetGrantsImmediately(t *testing.T) {
+	ct := newClaimTable()
+	p := &claimProbe{label: "empty"}
+	ct.acquire(p.request(staticClaims()))
+	require.True(t, p.granted())
+	ct.release(p.grant)
+	assert.Equal(t, 0, ct.parkedCount())
+}
+
+// TestClaimTable_FairnessSweep is the N-parked-keys starvation property:
+// many contenders with random modes and multi-key sets, all overlapping on
+// one shared key, released in random order - grants on the shared key must
+// follow arrival order exactly (strict per-key FIFO admits no barging in
+// either direction), and nobody starves.
+func TestClaimTable_FairnessSweep(t *testing.T) {
+	for seed := int64(1); seed <= 8; seed++ {
+		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(seed))
+			ct := newClaimTable()
+
+			const shared = "kshared"
+			const contenders = 25
+
+			// A pre-existing holder guarantees every contender parks, so the
+			// recorded grant order is decided by the waiter FIFO alone.
+			blocker := &claimProbe{label: "blocker"}
+			ct.acquire(blocker.request(staticClaims(claim{shared, claimWrite})))
+			require.True(t, blocker.granted())
+
+			var grantOrder []int
+			var outstanding []*claimGrant
+			for i := range contenders {
+				mode := claimRead
+				if rng.Intn(2) == 0 {
+					mode = claimWrite
+				}
+				set := []claim{{shared, mode}}
+				if rng.Intn(2) == 0 {
+					set = append(set, claim{fmt.Sprintf("own-%02d", i), claimWrite})
+				}
+				req := &claimRequest{
+					label:   fmt.Sprintf("contender-%d", i),
+					compute: staticClaims(set...),
+				}
+				req.granted = func(g *claimGrant) {
+					grantOrder = append(grantOrder, i)
+					outstanding = append(outstanding, g)
+				}
+				ct.acquire(req)
+			}
+			require.Empty(t, grantOrder, "every contender must park behind the blocker")
+
+			ct.release(blocker.grant)
+			for len(outstanding) > 0 {
+				i := rng.Intn(len(outstanding))
+				g := outstanding[i]
+				outstanding = slices.Delete(outstanding, i, i+1)
+				ct.release(g)
+			}
+
+			require.Len(t, grantOrder, contenders, "nobody may starve")
+			assert.True(t, slices.IsSorted(grantOrder),
+				"grants on the shared key must follow arrival order, got %v", grantOrder)
+			assert.Equal(t, 0, ct.parkedCount())
+		})
+	}
+}
+
+// TestClaimTable_DrainParked pins the shutdown path: draining fails every
+// parked acquisition through the supplied callback, releases their held
+// prefixes, and leaves the table empty; granted never fires for them.
+func TestClaimTable_DrainParked(t *testing.T) {
+	ct := newClaimTable()
+
+	holder := &claimProbe{label: "holder"}
+	ct.acquire(holder.request(staticClaims(claim{"k2", claimWrite})))
+	require.True(t, holder.granted())
+
+	parked := &claimProbe{label: "parked"}
+	ct.acquire(parked.request(staticClaims(claim{"k1", claimWrite}, claim{"k2", claimWrite})))
+	require.False(t, parked.granted())
+
+	probe := &claimProbe{label: "k1-probe"}
+	ct.acquire(probe.request(staticClaims(claim{"k1", claimWrite})))
+	require.False(t, probe.granted(), "k1 must be held by the parked acquisition's prefix")
+
+	var drained []string
+	ct.drainParked(func(req *claimRequest) { drained = append(drained, req.label) })
+
+	assert.ElementsMatch(t, []string{"parked", "k1-probe"}, drained,
+		"every parked acquisition must be reported to the drain callback")
+	assert.False(t, parked.granted(), "a drained acquisition is never granted")
+	assert.Equal(t, 0, ct.parkedCount())
+
+	free := &claimProbe{label: "k1-after-drain"}
+	ct.acquire(free.request(staticClaims(claim{"k1", claimWrite})))
+	assert.True(t, free.granted(), "the drained acquisition's prefix holds must be released")
+
+	ct.release(holder.grant)
+	ct.release(free.grant)
+}
+
+// TestClaimTable_ParkedMetrics pins the aging signal: parkedCount and
+// oldestParkedSince track park/grant transitions.
+func TestClaimTable_ParkedMetrics(t *testing.T) {
+	ct := newClaimTable()
+
+	_, ok := ct.oldestParkedSince()
+	assert.False(t, ok, "no parked acquisitions yet")
+
+	holder := &claimProbe{label: "holder"}
+	ct.acquire(holder.request(staticClaims(claim{"k", claimWrite})))
+	require.True(t, holder.granted())
+	assert.Equal(t, 0, ct.parkedCount())
+
+	waiter1 := &claimProbe{label: "waiter-1"}
+	ct.acquire(waiter1.request(staticClaims(claim{"k", claimWrite})))
+	waiter2 := &claimProbe{label: "waiter-2"}
+	ct.acquire(waiter2.request(staticClaims(claim{"k", claimWrite})))
+	assert.Equal(t, 2, ct.parkedCount())
+	since, ok := ct.oldestParkedSince()
+	require.True(t, ok)
+	assert.False(t, since.IsZero())
+
+	ct.release(holder.grant)
+	require.True(t, waiter1.granted())
+	assert.Equal(t, 1, ct.parkedCount(), "waiter-2 stays parked behind waiter-1's hold")
+
+	ct.release(waiter1.grant)
+	require.True(t, waiter2.granted())
+	assert.Equal(t, 0, ct.parkedCount())
+	_, ok = ct.oldestParkedSince()
+	assert.False(t, ok)
+	ct.release(waiter2.grant)
+}

--- a/src/go/plugin/agent/jobmgr/doc.go
+++ b/src/go/plugin/agent/jobmgr/doc.go
@@ -6,17 +6,66 @@
 //
 //   - Manager.run() is the single dispatcher: it routes every discovery and
 //     dyncfg event into the executor's per-key lanes and executes ALL commits
-//     on its goroutine. Executor lane state (keyState) is loop-owned and
-//     lock-free; nothing outside the run loop may touch it, except through
-//     the loop-synchronous tryLockIdleKey/unlockIdleKey seam.
+//     on its goroutine. Executor lane state (keyState) and the claim table
+//     are loop-owned and lock-free; nothing outside the run loop may touch
+//     them.
 //
-//   - Blocking module work (validation, job creation, detection, stop waits)
-//     runs on the effect pool under a flat internal deadline. Effects for one
-//     key never overlap (key busy stage-to-commit; all its events park in
-//     arrival order); effects for different keys run concurrently. State an
-//     effect may reach carries its own synchronization: retryingTasks, the
-//     vnode store, runningJobs, emissionGates, fileStatus, secretStoreDeps,
-//     and funcctl are all internally locked.
+//   - Cross-key dependencies are reserved through the claim table BEFORE a
+//     command's blocking work ships: every mutating event holds a write
+//     claim on its own key; collector commands add read claims on their
+//     referenced secret stores and vnode (the UNION of old and new for
+//     update-shaped commands); secretstore mutations add write claims on
+//     their restartable dependent job keys. Acquisition follows ONE global
+//     lexicographic key order (prefix held, park at the blocking key, strict
+//     per-key waiter FIFO), and claim sets are recomputed at every re-stage
+//     attempt. Claims release when the command fully settles; at a
+//     deadline abandon the command's READ claims release with its commit,
+//     while its WRITE claims - the wedged key and any keys the leaked work
+//     may still mutate, such as a store command's dependent job keys - stay
+//     held until the leaked call returns.
+//
+//   - REJECTION-ONLY dyncfg commands claim NOTHING and bypass foreign-hold
+//     lane parking: a command whose execution answers a deterministic
+//     rejection or no-op BEFORE its first claim-protected access (identity,
+//     existence, state, source/type, payload-presence, and command-support
+//     gates) executes claimless-inline instead of parking behind held keys
+//     with no bounded release. Each DOMAIN owns its acts-predicate,
+//     colocated with the gates it mirrors and enforced by that domain's
+//     parity test: dyncfg.Handler.CommandActs (collector), secretsctl and
+//     vnodectl Controller.CommandActs. Execution order is the criterion,
+//     not the eventual outcome: gates that need the claim's exclusion - and
+//     every gate execution orders BEHIND them - answer inline under the
+//     granted claim (the store remove's affected-jobs 409 plus its trailing
+//     source/type 405s; the vnode remove's referenced-by-configs 409). The
+//     STATUS axis is HOLD-AWARE: enable/restart/disable rejections and
+//     no-ops derive from entry.Status, the one input a foreign write-claim
+//     holder (a store command's dependent-restart plan) mutates - while
+//     the command's key is foreign-write-held they are treated as ACTING,
+//     park, and answer truthfully after the hold resolves. Same-key order
+//     is preserved: the route bypass fires only on an unoccupied lane with
+//     an empty FIFO.
+//
+//   - Blocking module work (validation, job creation, detection, stop waits,
+//     secretstore backend I/O, dependent-job restarts) runs on the effect
+//     pool under a flat internal deadline. Effects for one key never overlap
+//     (key occupied stage-to-commit; all its events park in arrival order);
+//     effects for different keys run concurrently. State an effect may reach
+//     carries its own synchronization: retryingTasks, the vnode store,
+//     runningJobs, emissionGates, fileStatus, secretStoreDeps, and funcctl
+//     are all internally locked.
+//
+//   - Function routing to a stopping job is withdrawn when its stop command
+//     STAGES (before the effect reaches a pool worker); a started job's
+//     functions publish at COMMIT (OnStatusChange on the running
+//     transition), never from inside the effect. A staged stop whose wait
+//     never ran (shutdown) is undone so the still-running job stays visible
+//     to routing and cleanup.
+//
+//   - At shutdown ONE RULE holds: every non-terminal dyncfg command answers
+//     503, publishes nothing, and everything is disposed - regardless of
+//     which phase was running or how far it got. Only the deadline path
+//     keeps its classification (fenced abandon publishes stop success;
+//     restart/update stop timeouts fail).
 //
 //   - effectDoneCh has exactly one reader: the run loop. Effect completions
 //     and late returns of abandoned effects resume there; per-call channels
@@ -30,7 +79,28 @@
 //   - An abandoned effect (deadline exceeded) frees its pool slot and commits
 //     its deadline outcome, but the key stays busy until the leaked module
 //     call returns; the late outcome (warm start, retry eligibility, plain
-//     release) is decided then, on the loop.
+//     release) is decided then, on the loop. The wedge re-attempts claim
+//     waiters parked at the key, so commands that exclude wedged keys on
+//     recompute (store mutations skip-and-report wedged dependents) proceed
+//     instead of waiting out the leaked call. A late warm start additionally
+//     requires the job's store dependencies unchanged since the abandon
+//     (their identities are captured when the read claims release; a store
+//     mutation committed or in flight at the late return drops the warm job,
+//     matching the mutation's skip-and-report of the wedged dependent).
+//     Dropped continuations dispose SILENTLY: the job's emission gate closes
+//     before its cleanup, which would otherwise emit HOST/HOSTINFO lines for
+//     a job that never started.
+//
+//   - Every job registration (startRunningJob) reconciles the job's vnode
+//     against the store before Start: vnode updates propagate to registered
+//     jobs only, so a job created before an update but registered after it
+//     (a dependent restart's stop/start gap, a warm continuation) receives
+//     the current config at registration instead of running on its stale
+//     creation-time snapshot. The reconcile COMMITS a baseline into the job
+//     (SetVnodeBaseline) rather than queueing a delivery: the baseline is
+//     visible to cleanup even when the job never collects, and a
+//     concurrently queued live update stays queued and still wins at
+//     collection.
 //
 //   - Discovery ingestion (runProcessConfGroups) does not mutate manager
 //     state directly. It publishes add/remove intents through channels
@@ -50,7 +120,16 @@
 //     work uses manager-rooted contexts and bounded worker limits where
 //     required.
 //
-//   - Secretstore and vnode dyncfg commands execute loop-synchronously; the
-//     secretstore dependent-restart bridge claims idle collector keys and
-//     skips busy ones - it never waits on effect completions.
+//   - Secretstore commands run on the executor lanes with claims: dependent
+//     restarts execute inside the store command's single multi-key effect
+//     (per-job entry state and CONFIG STATUS replay at commit, in restart
+//     order; terminal messages ride the command's own effect contexts, so
+//     concurrent store commands cannot cross-attribute them). A dependent
+//     with work in flight parks the store command until that work commits;
+//     only WEDGED dependents are skipped and reported.
+//
+//   - Vnode commands run on the executor lanes as stage+commit events under
+//     a write claim on the vnode name (conflicting with collector commands'
+//     vnode read claims); the commands themselves execute inline on the
+//     loop, so the cross-vnode uniqueness scan needs no extra claims.
 package jobmgr

--- a/src/go/plugin/agent/jobmgr/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg.go
@@ -7,17 +7,20 @@ import (
 )
 
 func (m *Manager) dyncfgConfig(fn dyncfg.Function) {
-	if err := fn.ValidateArgs(2); err != nil {
-		m.Warningf("dyncfg: %v", err)
-		m.dyncfgResponder.SendCodef(fn, 400, "%v", err)
-		return
-	}
-
+	// The shutdown check precedes even argument validation: once shutdown
+	// begins EVERY non-terminal command answers 503-publish-nothing (one
+	// rule), malformed ones included.
 	select {
 	case <-m.ctx.Done():
 		m.dyncfgResponder.SendCodef(fn, 503, "Job manager is shutting down.")
 		return
 	default:
+	}
+
+	if err := fn.ValidateArgs(2); err != nil {
+		m.Warningf("dyncfg: %v", err)
+		m.dyncfgResponder.SendCodef(fn, 400, "%v", err)
+		return
 	}
 
 	m.dyncfgQueuedExec(fn)

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go
@@ -26,17 +26,61 @@ func (m *Manager) scheduleRetryTask(cfg confgroup.Config, job runtimeJob) {
 	go runRetryTask(ctx, m.addCh, cfg)
 }
 
+// disposeWarmResume disposes a warm job that will never start, SILENTLY:
+// its emission gate is closed first (by captured handle), because V1
+// Cleanup emits HOST/HOSTINFO lines even for a never-started job, and a
+// dropped continuation must publish nothing - at shutdown that is the one
+// rule, and on stale drops the identity of a job whose start was suppressed
+// must not reach the wire. The gate is then deregistered matched by handle
+// (a same-name replacement's gate must survive).
+func (m *Manager) disposeWarmResume(r *warmResume) {
+	if r.gate != nil {
+		r.gate.Close()
+	}
+	r.job.Cleanup()
+	m.emissionGates.removeMatching(r.cfg.FullName(), r.gate)
+}
+
+// disposeUnstartedJob cleans up a job that never started. When silent (the
+// command's outcome publishes nothing - the shutdown paths), the job's
+// emission gate closes first: V1 Cleanup emits HOST/HOSTINFO lines even for
+// a never-started job, and identity output for a suppressed start must not
+// reach the wire after a 503. The looked-up gate is this job's own - the
+// key stays busy (or wedged) for the whole effect and its late window, so
+// no same-name replacement can interleave.
+func (m *Manager) disposeUnstartedJob(name string, job runtimeJob, silent bool) {
+	if silent {
+		if gate, ok := m.emissionGates.lookup(name); ok {
+			gate.Close()
+		}
+	}
+	job.Cleanup()
+	m.emissionGates.remove(name)
+}
+
+// shutdownDisposal reports whether a never-started job's disposal must be
+// silent because its command's outcome publishes nothing at shutdown:
+// either shutdown cancelled the effect context, or the manager is shutting
+// down (the manager check covers control-free restarts whose context cause
+// stays pinned to the deadline). Outside shutdown, failure disposals keep
+// today's cleanup emission - they accompany a published failure terminal.
+func shutdownDisposal(ctx context.Context, m *Manager) bool {
+	return errors.Is(context.Cause(ctx), context.Canceled) || m.baseContext().Err() != nil
+}
+
 // resumeWarmJob starts an already-detected job whose detection was abandoned
 // at its deadline but succeeded late. The caller (run loop) has already
-// validated the continuation (no commits on the key since the abandon); here
-// the exposed entry must still be this config in its abandoned-failed state,
-// else the warm job is disposed (module cleanup + gate deregistration).
+// validated the continuation (no commits on the key since the abandon and
+// store dependencies unchanged); here the exposed entry must still be this
+// config in its abandoned-failed state, else the warm job is disposed
+// silently. The vnode config the job snapshotted at creation is reconciled
+// at registration (startRunningJob), covering updates that committed while
+// the key was wedged.
 func (m *Manager) resumeWarmJob(r *warmResume) {
 	entry, ok := m.collectorExposed.LookupByKey(r.cfg.ExposedKey())
 	if !ok || entry.Cfg.UID() != r.cfg.UID() || entry.Status != dyncfg.StatusFailed {
 		m.Infof("dropping late detection success for '%s': config no longer eligible", r.cfg.FullName())
-		r.job.Cleanup()
-		m.emissionGates.removeMatching(r.cfg.FullName(), r.gate)
+		m.disposeWarmResume(r)
 		return
 	}
 	m.retryingTasks.remove(r.cfg)
@@ -116,7 +160,11 @@ func (cb *collectorCallbacks) ValidateConfigName(name string) error {
 	return dyncfg.JobNameRuleStrict(name)
 }
 
-func (cb *collectorCallbacks) ParseAndValidate(ctx context.Context, fn dyncfg.Function, name string) (confgroup.Config, error) {
+// parseCollectorPayload is the CHEAP, deterministic parse prefix of
+// ParseAndValidate (no I/O, no module instantiation), shared with
+// ParsePayload so the stage gate and the effect produce identical outcomes
+// for identical inputs.
+func (cb *collectorCallbacks) parseCollectorPayload(fn dyncfg.Function, name string) (confgroup.Config, error) {
 	mn, ok := cb.mgr.extractModuleName(fn.ID())
 	if !ok {
 		return nil, fmt.Errorf("could not extract module name from ID: %s", fn.ID())
@@ -128,6 +176,21 @@ func (cb *collectorCallbacks) ParseAndValidate(ctx context.Context, fn dyncfg.Fu
 	}
 
 	cb.mgr.dyncfgSetConfigMeta(cfg, mn, name, fn)
+	return cfg, nil
+}
+
+// ParsePayload implements dyncfg.PayloadParser: malformed payloads answer
+// their 400 at stage, before any claim or effect.
+func (cb *collectorCallbacks) ParsePayload(fn dyncfg.Function, name string) error {
+	_, err := cb.parseCollectorPayload(fn, name)
+	return err
+}
+
+func (cb *collectorCallbacks) ParseAndValidate(ctx context.Context, fn dyncfg.Function, name string) (confgroup.Config, error) {
+	cfg, err := cb.parseCollectorPayload(fn, name)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := cb.mgr.validateCollectorJob(ctx, cfg); err != nil {
 		if errors.Is(context.Cause(ctx), context.Canceled) {
@@ -174,8 +237,10 @@ func (cb *collectorCallbacks) Start(ctx context.Context, cfg confgroup.Config) e
 			effectControlFrom(ctx).setResume(&warmResume{cfg: cfg, job: job, gate: gate})
 			return nil
 		}
-		job.Cleanup()
-		cb.mgr.emissionGates.remove(cfg.FullName())
+		// A late failure after a shutdown-finalized 503 must dispose
+		// silently; outside shutdown the cleanup emission accompanies the
+		// published timeout terminal, as today.
+		cb.mgr.disposeUnstartedJob(cfg.FullName(), job, shutdownDisposal(ctx, cb.mgr))
 		if _, ok := errors.AsType[dyncfg.CodedError](detErr); ok {
 			if dyncfg.IsRetryableError(detErr) {
 				cb.mgr.scheduleRetryTask(cfg, job)
@@ -187,11 +252,10 @@ func (cb *collectorCallbacks) Start(ctx context.Context, cfg confgroup.Config) e
 	}
 
 	if detErr != nil {
-		job.Cleanup()
-		// Tracking removal only. The gate itself stays open by contract -
-		// closing is reserved for abandoning a wedged stop - and no writer
-		// survives here anyway: the job never started.
-		cb.mgr.emissionGates.remove(cfg.FullName())
+		// Silent when shutdown owns the outcome (503-publish-nothing);
+		// otherwise the cleanup emission accompanies the published failure
+		// terminal, as today.
+		cb.mgr.disposeUnstartedJob(cfg.FullName(), job, shutdownDisposal(ctx, cb.mgr))
 		if errors.Is(context.Cause(ctx), context.Canceled) {
 			// Shutdown interrupted the detection (a ctx-honoring module
 			// returned early): not a detection failure - answer retryably,
@@ -208,12 +272,19 @@ func (cb *collectorCallbacks) Start(ctx context.Context, cfg confgroup.Config) e
 		return fmt.Errorf("job enable failed: %w", detErr)
 	}
 
-	if errors.Is(context.Cause(ctx), context.Canceled) {
-		// Shutdown began while the detection was finishing (the child won
-		// the completion claim against the cancelled context): never start
-		// fresh collector work - the enable answers retryably instead.
-		job.Cleanup()
-		cb.mgr.emissionGates.remove(cfg.FullName())
+	if errors.Is(context.Cause(ctx), context.Canceled) || cb.mgr.baseContext().Err() != nil {
+		// Shutdown began while the detection was finishing: never start
+		// fresh collector work. The manager-context check matters for
+		// restarts running inside another command's effect (a store
+		// command's dependent restart runs control-free, and its context
+		// cause stays DeadlineExceeded once that effect's deadline fired -
+		// it can never read Canceled, yet its late success must not start a
+		// job after cleanup snapshotted the running set). The command
+		// answers 503-publish-nothing, so the never-started job disposes
+		// silently: the gate closes (this job's own - the key stays busy
+		// for the whole effect, no same-name replacement can interleave)
+		// before Cleanup can emit HOST/HOSTINFO lines.
+		cb.mgr.disposeUnstartedJob(cfg.FullName(), job, true)
 		return fmt.Errorf("job not started: %w", dyncfg.ErrPhaseNeverRan)
 	}
 
@@ -221,19 +292,31 @@ func (cb *collectorCallbacks) Start(ctx context.Context, cfg confgroup.Config) e
 	return nil
 }
 
-func (cb *collectorCallbacks) Update(ctx context.Context, oldCfg, newCfg confgroup.Config) error {
+// StageUpdate splits the update at the stop seam: the old instance's routing
+// removal happens on the staging goroutine (function routing to the job
+// being replaced ends immediately), the blocking wait plus the replacement's
+// creation/detection/start run in the effect. Undo reverts the routing
+// removal when the effect never ran.
+func (cb *collectorCallbacks) StageUpdate(oldCfg, newCfg confgroup.Config) dyncfg.StagedUpdate {
+	staged := cb.mgr.newStagedJobStop(oldCfg.FullName())
 	cb.mgr.retryingTasks.remove(oldCfg)
-	cb.mgr.fileStatus.remove(oldCfg)
-	stopped := cb.mgr.stopRunningJob(ctx, oldCfg.FullName())
-	if stopped {
-		// Point of no return: the old instance is stopped. A shutdown
-		// interruption from here on must commit as a disruptive failure - a
-		// never-ran rollback would resurrect a state that no longer exists.
-		// A no-op stop (the old config was not running) tears nothing down,
-		// so never-ran (and its rollback) stays the truthful outcome.
-		effectControlFrom(ctx).markDisruptive()
+	return dyncfg.StagedUpdate{
+		Run: func(ctx context.Context) error {
+			cb.mgr.fileStatus.remove(oldCfg)
+			staged.wait(ctx)
+			return cb.startUpdatedJob(ctx, newCfg)
+		},
+		Undo: staged.undo,
 	}
+}
 
+func (cb *collectorCallbacks) Update(ctx context.Context, oldCfg, newCfg confgroup.Config) error {
+	return cb.StageUpdate(oldCfg, newCfg).Run(ctx)
+}
+
+// startUpdatedJob is the update effect's post-stop half: creation, detection
+// and start of the replacement instance.
+func (cb *collectorCallbacks) startUpdatedJob(ctx context.Context, newCfg confgroup.Config) error {
 	// A stop phase that exceeded its deadline fails the update here: the
 	// replacement's start phase never begins (no second instance).
 	if effectControlFrom(ctx).abandonedNow() {
@@ -244,14 +327,10 @@ func (cb *collectorCallbacks) Update(ctx context.Context, oldCfg, newCfg confgro
 	if err != nil {
 		effectControlFrom(ctx).claimCompletion()
 		if errors.Is(context.Cause(ctx), context.Canceled) {
-			if !stopped {
-				// Nothing was torn down: answer retryably with rollback.
-				return fmt.Errorf("job not created: %w", dyncfg.ErrPhaseNeverRan)
-			}
-			// Shutdown interrupted the replacement's creation. The old
-			// instance is already stopped: a disruptive failure, not a
-			// rollback.
-			return fmt.Errorf("job update failed: the manager is shutting down; the replacement was not created")
+			// Shutdown interrupted the update: one rule - answer 503 and
+			// publish nothing, whether or not the old instance was already
+			// torn down.
+			return fmt.Errorf("job not created: %w", dyncfg.ErrPhaseNeverRan)
 		}
 		var ce dyncfg.CodedError
 		if errors.As(err, &ce) {
@@ -268,8 +347,8 @@ func (cb *collectorCallbacks) Update(ctx context.Context, oldCfg, newCfg confgro
 			effectControlFrom(ctx).setResume(&warmResume{cfg: newCfg, job: job, gate: gate})
 			return nil
 		}
-		job.Cleanup()
-		cb.mgr.emissionGates.remove(newCfg.FullName())
+		// Same silence rule as Start's late-failure arm.
+		cb.mgr.disposeUnstartedJob(newCfg.FullName(), job, shutdownDisposal(ctx, cb.mgr))
 		if _, ok := errors.AsType[dyncfg.CodedError](detErr); ok {
 			if dyncfg.IsRetryableError(detErr) {
 				cb.mgr.scheduleRetryTask(newCfg, job)
@@ -281,16 +360,12 @@ func (cb *collectorCallbacks) Update(ctx context.Context, oldCfg, newCfg confgro
 	}
 
 	if detErr != nil {
-		job.Cleanup()
-		// Tracking removal only; see the identical note in Start.
-		cb.mgr.emissionGates.remove(newCfg.FullName())
+		// Same silence rule as Start's claimed-failure arm.
+		cb.mgr.disposeUnstartedJob(newCfg.FullName(), job, shutdownDisposal(ctx, cb.mgr))
 		if errors.Is(context.Cause(ctx), context.Canceled) {
-			if !stopped {
-				return fmt.Errorf("job not started: %w", dyncfg.ErrPhaseNeverRan)
-			}
-			// Shutdown interrupted the replacement's detection: disruptive
-			// failure (the old instance is already stopped), no retry.
-			return fmt.Errorf("job update failed: the manager is shutting down; the replacement was not started")
+			// Shutdown interrupted the replacement's detection: one rule -
+			// answer 503, publish nothing, schedule nothing.
+			return fmt.Errorf("detection interrupted: %w", dyncfg.ErrPhaseNeverRan)
 		}
 		var ce dyncfg.CodedError
 		if errors.As(detErr, &ce) {
@@ -303,37 +378,54 @@ func (cb *collectorCallbacks) Update(ctx context.Context, oldCfg, newCfg confgro
 		return fmt.Errorf("job update failed: %w", detErr)
 	}
 
-	if errors.Is(context.Cause(ctx), context.Canceled) {
+	if errors.Is(context.Cause(ctx), context.Canceled) || cb.mgr.baseContext().Err() != nil {
 		// Shutdown began while the replacement's detection was finishing:
-		// never start fresh collector work.
-		job.Cleanup()
-		cb.mgr.emissionGates.remove(newCfg.FullName())
-		if !stopped {
-			// Nothing was torn down: answer retryably with rollback.
-			return fmt.Errorf("job not started: %w", dyncfg.ErrPhaseNeverRan)
-		}
-		// The old instance is already stopped, so this is a disruptive
-		// failure (status failed), not a rollback - unlike the never-ran
-		// phase, half the update happened.
-		return fmt.Errorf("job update failed: the manager is shutting down; the replacement was not started")
+		// never start fresh collector work - one rule, answer 503. (The
+		// manager-context check covers control-free restarts whose context
+		// cause is pinned to DeadlineExceeded; see Start.) Publish-nothing
+		// extends to the never-started replacement's disposal: close its
+		// gate (its own - the key is busy for the whole effect) before
+		// Cleanup can emit HOST/HOSTINFO lines.
+		cb.mgr.disposeUnstartedJob(newCfg.FullName(), job, true)
+		return fmt.Errorf("job not started: %w", dyncfg.ErrPhaseNeverRan)
 	}
 
 	cb.mgr.startRunningJob(job)
 	return nil
 }
 
-func (cb *collectorCallbacks) Stop(ctx context.Context, cfg confgroup.Config) {
+// StageStop splits the stop at its blocking wait: routing removal happens on
+// the staging goroutine, the wait runs in the effect. Undo reverts the
+// routing removal when the wait never ran.
+func (cb *collectorCallbacks) StageStop(cfg confgroup.Config) dyncfg.StagedStop {
+	staged := cb.mgr.newFinalPhaseStagedJobStop(cfg.FullName())
 	cb.mgr.retryingTasks.remove(cfg)
-	// Persisted-status removal precedes the blocking wait so the deadline
-	// path (which commits disable/remove while the stop is still wedged)
-	// observes it done.
-	cb.mgr.fileStatus.remove(cfg)
-	cb.mgr.stopRunningJob(ctx, cfg.FullName())
-	effectControlFrom(ctx).claimCompletion()
+	return dyncfg.StagedStop{
+		Wait: func(ctx context.Context) {
+			// Persisted-status removal precedes the blocking wait so the
+			// deadline path (which commits disable/remove while the stop is
+			// still wedged) observes it done.
+			cb.mgr.fileStatus.remove(cfg)
+			staged.wait(ctx)
+		},
+		Undo: staged.undo,
+	}
+}
+
+func (cb *collectorCallbacks) Stop(ctx context.Context, cfg confgroup.Config) {
+	cb.StageStop(cfg).Wait(ctx)
 }
 
 func (cb *collectorCallbacks) OnStatusChange(entry *dyncfg.Entry[confgroup.Config], _ dyncfg.Status, _ dyncfg.Function) {
-	if entry.Status == dyncfg.StatusRunning && isDyncfg(entry.Cfg) {
+	if entry.Status != dyncfg.StatusRunning {
+		return
+	}
+	// Function publication follows COMMITTED state: the effect started the
+	// job and registered it in the running set; the commit that publishes
+	// the running status publishes its functions (warm-start continuations
+	// and dependent restarts commit through here too).
+	cb.mgr.publishRunningJobFunctions(entry.Cfg.FullName())
+	if isDyncfg(entry.Cfg) {
 		cb.mgr.fileStatus.add(entry.Cfg, entry.Status.String())
 	}
 }

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_cmds.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_cmds.go
@@ -228,7 +228,7 @@ func (m *Manager) runDyncfgCmdTest(task dyncfgCmdTestTask) {
 	job, err := newConfigModule(task.creator)
 	if err != nil {
 		m.Warningf("dyncfg: test: module %s: failed to create module: %v", task.moduleName, err)
-		m.dyncfgResponder.SendCodef(task.fn, 500, "Module %s instantiation failed: %v.", task.moduleName, err)
+		m.sendDyncfgCmdTestResult(task.fn, 500, "Module %s instantiation failed: %v.", task.moduleName, err)
 		return
 	}
 	if named, ok := job.(jobNameSetter); ok {
@@ -247,7 +247,7 @@ func (m *Manager) runDyncfgCmdTest(task dyncfgCmdTestTask) {
 	resolveCtx := collectorSecretResolveContext(ctx, m.Logger, task.cfg)
 	if err := applyConfig(resolveCtx, task.cfg, job, m.secretResolver, secretStoreSvc, storeSnapshot); err != nil {
 		m.Warningf("dyncfg: test: module %s job %s: failed to apply config: %v", task.moduleName, task.cfg.Name(), err)
-		m.dyncfgResponder.SendCodef(task.fn, 400, "Invalid configuration. Failed to apply configuration: %v.", err)
+		m.sendDyncfgCmdTestResult(task.fn, 400, "Invalid configuration. Failed to apply configuration: %v.", err)
 		return
 	}
 
@@ -265,7 +265,7 @@ func (m *Manager) runDyncfgCmdTest(task dyncfgCmdTestTask) {
 		return
 	}
 
-	m.dyncfgResponder.SendCodef(task.fn, 200, "")
+	m.sendDyncfgCmdTestResult(task.fn, 200, "")
 }
 
 func (m *Manager) sendDyncfgCmdTestError(fn dyncfg.Function, defaultCode int, format string, err error) {
@@ -274,7 +274,22 @@ func (m *Manager) sendDyncfgCmdTestError(fn dyncfg.Function, defaultCode int, fo
 	if errors.As(err, &coded) {
 		code = coded.DyncfgCode()
 	}
-	m.dyncfgResponder.SendCodef(fn, code, format, err)
+	m.sendDyncfgCmdTestResult(fn, code, format, err)
+}
+
+// sendDyncfgCmdTestResult delivers a test worker's terminal, overridden with
+// 503 once shutdown began: the keyless test path bypasses the executor's
+// receive-time one-rule choke points (it responds directly from its own
+// worker goroutine), so the boundary lives at its own send seam. A
+// shutdown-canceled Init/Check must not classify as a 422 module failure,
+// and even a test completing during the drain answers 503 - matching the
+// stop-completing-during-drain contract.
+func (m *Manager) sendDyncfgCmdTestResult(fn dyncfg.Function, code int, format string, args ...any) {
+	if m.baseContext().Err() != nil {
+		m.dyncfgResponder.SendCodef(fn, 503, "Job manager is shutting down.")
+		return
+	}
+	m.dyncfgResponder.SendCodef(fn, code, format, args...)
 }
 
 func (m *Manager) dyncfgCmdTestTimeout(fn dyncfg.Function) time.Duration {

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_helpers.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_helpers.go
@@ -4,6 +4,7 @@ package jobmgr
 
 import (
 	"encoding/json"
+	"errors"
 	"slices"
 	"strings"
 
@@ -57,11 +58,25 @@ func configFromPayload(fn dyncfg.Function) (confgroup.Config, error) {
 			return nil, err
 		}
 
-		return cfg.Clone()
+		cloned, err := cfg.Clone()
+		if err != nil {
+			return nil, err
+		}
+		cfg = cloned
+	} else if err := yaml.Unmarshal(fn.Payload(), &cfg); err != nil {
+		return nil, err
 	}
 
-	if err := yaml.Unmarshal(fn.Payload(), &cfg); err != nil {
-		return nil, err
+	if cfg == nil {
+		// Only the YAML path can get here: a "null" (or whitespace-only)
+		// document unmarshals to a nil map with no error. The JSON path
+		// never yields nil - Clone's yaml round-trip marshals a nil map as
+		// {} and materializes an empty config (pre-existing behavior,
+		// deliberately preserved). Callers write config metadata into the
+		// map, and the stage parse gate runs on the manager loop, which has
+		// no recover: an unguarded nil map is a plugin-killing panic, not a
+		// malformed config error.
+		return nil, errors.New("payload contains no configuration object")
 	}
 
 	return cfg, nil

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_helpers_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_helpers_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A "null" (or whitespace-only) document unmarshals to a NIL map with no
+// error on both content paths; downstream metadata writes into that map
+// would panic on the manager loop, so the parse layer must reject it.
+func TestConfigFromPayload_RejectsNullDocuments(t *testing.T) {
+	tests := map[string]struct {
+		payload     []byte
+		contentType string
+		wantErr     bool
+	}{
+		"json object": {payload: []byte(`{"option_str":"x"}`), contentType: "application/json"},
+		"yaml object": {payload: []byte("option_str: x")},
+		// JSON null is materialized as an empty object by Clone's yaml
+		// round-trip (a nil map marshals as {}) - pre-existing behavior,
+		// deliberately unchanged: only the YAML path can return nil.
+		"json null":  {payload: []byte("null"), contentType: "application/json"},
+		"yaml null":  {payload: []byte("null"), wantErr: true},
+		"yaml empty": {payload: []byte("   "), wantErr: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fn := dyncfg.NewFunction(functions.Function{
+				UID:         "u",
+				Args:        []string{"test:collector:gated", "add", "j"},
+				Payload:     tc.payload,
+				ContentType: tc.contentType,
+			})
+
+			cfg, err := configFromPayload(fn)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, cfg)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, cfg)
+		})
+	}
+}

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
@@ -1473,6 +1473,41 @@ func TestCollectorCallbacks_Stop(t *testing.T) {
 	}
 }
 
+func TestCollectorCallbacks_StagedStopCancelsRetryBeforeWait(t *testing.T) {
+	tests := map[string]struct {
+		stage func(*collectorCallbacks, confgroup.Config, confgroup.Config)
+	}{
+		"stop": {
+			stage: func(cb *collectorCallbacks, cfg, _ confgroup.Config) {
+				cb.StageStop(cfg)
+			},
+		},
+		"update": {
+			stage: func(cb *collectorCallbacks, cfg, newCfg confgroup.Config) {
+				cb.StageUpdate(cfg, newCfg)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr := newCollectorTestManager()
+			cb := &collectorCallbacks{mgr: mgr}
+			cfg := prepareDyncfgCfg("success", "job").Set("autodetection_retry", 1)
+			newCfg := prepareDyncfgCfg("success", "job").Set("autodetection_retry", 1).Set("option_str", "changed")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			mgr.retryingTasks.add(cfg, &retryTask{cancel: cancel})
+
+			tc.stage(cb, cfg, newCfg)
+
+			_, retryPending := mgr.retryingTasks.lookup(cfg)
+			assert.False(t, retryPending, "retry must be canceled at stage time, before the stop effect can wait in the pool")
+			assert.ErrorIs(t, ctx.Err(), context.Canceled)
+		})
+	}
+}
+
 func TestCollectorCallbacks_OnStatusChange(t *testing.T) {
 	tests := map[string]struct {
 		cfg      confgroup.Config
@@ -1857,12 +1892,13 @@ func (*blockingSecretStoreService) Update(context.Context, string, secretstore.C
 	return nil
 }
 
-func (*blockingSecretStoreService) Remove(string) error      { return nil }
-func (j *collectorProbeJob) Cleanup()                        {}
-func (j *collectorProbeJob) IsRunning() bool                 { return true }
-func (j *collectorProbeJob) Panicked() bool                  { return false }
-func (j *collectorProbeJob) Vnode() vnodes.VirtualNode       { return vnodes.VirtualNode{} }
-func (j *collectorProbeJob) UpdateVnode(*vnodes.VirtualNode) {}
+func (*blockingSecretStoreService) Remove(string) error           { return nil }
+func (j *collectorProbeJob) Cleanup()                             {}
+func (j *collectorProbeJob) IsRunning() bool                      { return true }
+func (j *collectorProbeJob) Panicked() bool                       { return false }
+func (j *collectorProbeJob) Vnode() vnodes.VirtualNode            { return vnodes.VirtualNode{} }
+func (j *collectorProbeJob) UpdateVnode(*vnodes.VirtualNode)      {}
+func (j *collectorProbeJob) SetVnodeBaseline(*vnodes.VirtualNode) {}
 
 type auditAnalyzerSpy struct {
 	registered []string

--- a/src/go/plugin/agent/jobmgr/dyncfg_secretstore.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_secretstore.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/secretsctl"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
@@ -28,45 +30,167 @@ func (m *Manager) dyncfgSecretStoreSeqExec(fn dyncfg.Function) {
 	m.secretsCtl.SeqExec(fn)
 }
 
-func (m *Manager) restartDependentCollectorJob(fullName string) error {
-	entry, ok := m.lookupExposedByFullName(fullName)
-	if !ok {
-		return fmt.Errorf("job '%s' is not exposed", fullName)
+// secretStoreDependentPlan is one dependent job's restart order, snapshotted
+// on the run loop while the store command holds the dependent's write claim
+// (so the entry cannot change until the command commits).
+type secretStoreDependentPlan struct {
+	name    string
+	display string
+	cfg     confgroup.Config
+	// wedged dependents are never restarted (their key is held by an
+	// abandoned effect with no bounded release); they are skipped and
+	// reported in the terminal message.
+	wedged bool
+}
+
+// restartReplayBuffer collects completed dependent restarts' loop-side
+// commits AS THEY COMPLETE, so a command abandoned at its deadline still
+// replays the restarts that did happen. The mutex covers effect-goroutine
+// appends vs loop-side drains; drain-on-flush makes every commit replay
+// exactly once (at the command's commit, or at the late return for restarts
+// that completed after the abandon).
+type restartReplayBuffer struct {
+	mu      sync.Mutex
+	commits []func()
+}
+
+func (b *restartReplayBuffer) add(fn func()) {
+	b.mu.Lock()
+	b.commits = append(b.commits, fn)
+	b.mu.Unlock()
+}
+
+// flush drains and runs the buffered commits in order. Loop-side only.
+func (b *restartReplayBuffer) flush() {
+	b.mu.Lock()
+	commits := b.commits
+	b.commits = nil
+	b.mu.Unlock()
+	for _, fn := range commits {
+		fn()
+	}
+}
+
+// stageDependentRestarts snapshots the store's dependent-restart plan on the
+// run loop; the returned Run restarts the planned dependents sequentially
+// inside the effect, and Flush replays the completed restarts' entry-state
+// and CONFIG STATUS transitions on the loop.
+func (m *Manager) stageDependentRestarts(storeKey string) *secretsctl.StagedRestarts {
+	plan := m.secretStoreRestartPlan(storeKey)
+	buf := &restartReplayBuffer{}
+	return &secretsctl.StagedRestarts{
+		Run: func(ctx context.Context) (string, error) {
+			return m.runDependentRestarts(ctx, storeKey, plan, buf)
+		},
+		Flush: buf.flush,
+	}
+}
+
+// secretStoreRestartPlan selects the store's restartable dependents (running
+// or failed jobs referencing it) and marks the wedged ones for
+// skip-and-report. Loop-owned state: call only on the run-loop goroutine.
+func (m *Manager) secretStoreRestartPlan(storeKey string) []secretStoreDependentPlan {
+	var plan []secretStoreDependentPlan
+	for _, ref := range m.restartableAffectedJobs(storeKey) {
+		entry, ok := m.lookupExposedByFullName(ref.ID)
+		if !ok {
+			continue
+		}
+		plan = append(plan, secretStoreDependentPlan{
+			name:    ref.ID,
+			display: ref.Display,
+			cfg:     entry.Cfg,
+			wedged:  m.executor.collectorKeyWedged(entry.Cfg.ExposedKey()),
+		})
+	}
+	return plan
+}
+
+// runDependentRestarts executes a staged restart plan inside a store
+// command's effect. Restarts run sequentially in plan order; the deadline
+// (and the command's abandonment) is checked before EACH restart, so a store
+// command that runs out of time launches no new restarts and reports the
+// remainder as skipped. Failures use the terminal message's existing per-job
+// format. Every completed restart's replay lands in the buffer as it
+// completes: the command's commit flushes it, and a restart completing only
+// after a deadline abandon replays at the late return (the buffer flush is
+// registered as the effect's late work; the dependents' write claims are
+// held until then, so the late replay stays truthful).
+//
+// A deadline-cut sequence returns a non-nil error alongside the message:
+// the classification must not depend on whether the effect's return or the
+// worker's abandon wins their select race, so a command whose restarts were
+// cut reaches the timeout failure even when its closure completes first.
+// Wedged-dependent skips do NOT set the error - skip-and-report is the
+// command's normal successful outcome for wedged keys.
+func (m *Manager) runDependentRestarts(ctx context.Context, storeKey string, plan []secretStoreDependentPlan, buf *restartReplayBuffer) (string, error) {
+	type failure struct {
+		display string
+		err     error
+	}
+	var failures []failure
+	var cutErr error
+	ctl := effectControlFrom(ctx)
+	ctl.setLateWork(buf.flush)
+	// Inner restarts must never claim the STORE command's completion or
+	// register fences on it: they run under a control-free context that
+	// still carries the deadline and cancellation.
+	depCtx := context.WithValue(ctx, effectControlKey{}, (*effectControl)(nil))
+
+	for _, dep := range plan {
+		fail := func(err error) {
+			m.Warningf("dyncfg: secretstore: failed to restart dependent job '%s' after store '%s' change: %v", dep.name, storeKey, err)
+			failures = append(failures, failure{display: dep.display, err: err})
+		}
+		if dep.wedged {
+			fail(fmt.Errorf("skipped: operation in progress"))
+			continue
+		}
+		if ctx.Err() != nil || ctl.abandonedNow() {
+			if cutErr == nil {
+				cutErr = fmt.Errorf("the store operation timed out before all dependent restarts started")
+			}
+			fail(fmt.Errorf("skipped: the store operation timed out before this restart started"))
+			continue
+		}
+
+		m.collectorCallbacks.Stop(depCtx, dep.cfg)
+		status := dyncfg.StatusRunning
+		if err := m.collectorCallbacks.Start(depCtx, dep.cfg); err != nil {
+			fail(fmt.Errorf("job '%s' restart failed: %w", dep.name, err))
+			status = dyncfg.StatusFailed
+		}
+		buf.add(m.commitDependentRestart(dep, status))
 	}
 
-	// Secretstore commands run loop-synchronously; a dependent whose key has
-	// work in flight is SKIPPED and reported (waiting would self-deadlock:
-	// effect completions arrive via this loop) - the report format is the
-	// terminal message's existing per-job failure entry. The busy check
-	// precedes the status check: a dependent whose enable is still in
-	// flight reads accepted but must report as in-progress, not as a state
-	// rejection.
-	sk := collectorStateKey(entry.Cfg.ExposedKey())
-	if !m.executor.tryLockIdleKey(sk) {
-		return fmt.Errorf("skipped: operation in progress")
+	if len(failures) == 0 {
+		return "", nil
 	}
-	defer m.executor.unlockIdleKey(sk)
-
-	oldStatus := entry.Status
-	switch oldStatus {
-	case dyncfg.StatusRunning, dyncfg.StatusFailed:
-	default:
-		return fmt.Errorf("job '%s' restart is not allowed in '%s' state", fullName, oldStatus)
+	parts := make([]string, 0, len(failures))
+	for _, f := range failures {
+		name := f.display
+		if name == "" {
+			name = "unknown"
+		}
+		parts = append(parts, fmt.Sprintf("%s (%v)", name, f.err))
 	}
+	return fmt.Sprintf("Secretstore change applied, but dependent collector restarts failed: %s.", strings.Join(parts, "; ")), cutErr
+}
 
-	m.collectorCallbacks.Stop(context.Background(), entry.Cfg)
-
-	if err := m.collectorCallbacks.Start(context.Background(), entry.Cfg); err != nil {
-		entry.Status = dyncfg.StatusFailed
-		m.collectorHandler.NotifyConfigStatus(entry.Cfg, dyncfg.StatusFailed)
+// commitDependentRestart is the loop-side half of one dependent restart: the
+// entry-state transition, its CONFIG STATUS line, and the status-change hook
+// (which publishes the restarted job's functions).
+func (m *Manager) commitDependentRestart(dep secretStoreDependentPlan, status dyncfg.Status) func() {
+	return func() {
+		entry, ok := m.lookupExposedByFullName(dep.name)
+		if !ok || entry.Cfg.UID() != dep.cfg.UID() {
+			return
+		}
+		oldStatus := entry.Status
+		entry.Status = status
+		m.collectorHandler.NotifyConfigStatus(entry.Cfg, status)
 		m.collectorCallbacks.OnStatusChange(entry, oldStatus, dyncfg.NewFunction(functions.Function{}))
-		return fmt.Errorf("job '%s' restart failed: %w", fullName, err)
 	}
-
-	entry.Status = dyncfg.StatusRunning
-	m.collectorHandler.NotifyConfigStatus(entry.Cfg, dyncfg.StatusRunning)
-	m.collectorCallbacks.OnStatusChange(entry, oldStatus, dyncfg.NewFunction(functions.Function{}))
-	return nil
 }
 
 func (m *Manager) lookupExposedByFullName(fullName string) (*dyncfg.Entry[confgroup.Config], bool) {
@@ -75,4 +199,19 @@ func (m *Manager) lookupExposedByFullName(fullName string) (*dyncfg.Entry[confgr
 		return nil, false
 	}
 	return m.collectorExposed.LookupByKey(fullName)
+}
+
+// secretStoreDepIdentity is the committed identity of a store dependency as
+// observed on the loop: exposed status plus config content hash, "" when the
+// store is not exposed. Captured at a collector command's deadline abandon
+// and compared at its late return - any store mutation committed in between
+// changes it and invalidates the warm continuation (executor.staleWarmDep).
+// A re-apply of identical content (the handler's no-op path) leaves it
+// unchanged by design.
+func (m *Manager) secretStoreDepIdentity(storeKey string) string {
+	entry, ok := m.secretsCtl.Lookup(storeKey)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%s|%d", entry.Status, entry.Cfg.Hash())
 }

--- a/src/go/plugin/agent/jobmgr/dyncfg_secretstore_cache.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_secretstore_cache.go
@@ -3,9 +3,6 @@
 package jobmgr
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 )
@@ -19,6 +16,12 @@ func (m *Manager) affectedJobs(key string) []secretstore.JobRef {
 	return exposed
 }
 
+// restartableAffectedJobs selects the store's dependents that a store change
+// restarts: running or failed jobs referencing it. A dependent whose command
+// is in flight is not a special case here - the store command's write claim
+// on the dependent's key parks the store command until that work commits,
+// and the claim-set recomputation re-selects dependents at that point.
+// Loop-owned state (entry status): call only on the run-loop goroutine.
 func (m *Manager) restartableAffectedJobs(key string) []secretstore.JobRef {
 	if m == nil || m.secretStoreDeps == nil {
 		return nil
@@ -34,54 +37,7 @@ func (m *Manager) restartableAffectedJobs(key string) []secretstore.JobRef {
 		switch entry.Status {
 		case dyncfg.StatusRunning, dyncfg.StatusFailed:
 			refs = append(refs, job)
-		default:
-			// The exposed status lags the effect: an enable in flight may
-			// already have started the job (with the OLD resolved secret)
-			// while the entry still reads accepted. A dependent whose key
-			// has work in flight MUST be selected so the bridge reports it
-			// as skipped instead of silently missing it.
-			if m.executor.collectorKeyHasWork(entry.Cfg.ExposedKey()) {
-				refs = append(refs, job)
-			}
 		}
 	}
 	return refs
-}
-
-type secretStoreRestartFailure struct {
-	ref secretstore.JobRef
-	err error
-}
-
-func (m *Manager) restartDependentJobs(key string) string {
-	failures := m.restartDependentJobsBestEffort(key)
-	if len(failures) == 0 {
-		return ""
-	}
-
-	parts := make([]string, 0, len(failures))
-	for _, failure := range failures {
-		name := failure.ref.Display
-		if name == "" {
-			name = failure.ref.ID
-		}
-		parts = append(parts, fmt.Sprintf("%s (%v)", name, failure.err))
-	}
-
-	return fmt.Sprintf("Secretstore change applied, but dependent collector restarts failed: %s.", strings.Join(parts, "; "))
-}
-
-func (m *Manager) restartDependentJobsBestEffort(key string) []secretStoreRestartFailure {
-	if m == nil {
-		return nil
-	}
-
-	var failures []secretStoreRestartFailure
-	for _, job := range m.restartableAffectedJobs(key) {
-		if err := m.restartDependentCollectorJob(job.ID); err != nil {
-			m.Warningf("dyncfg: secretstore: failed to restart dependent job '%s' after store '%s' change: %v", job.ID, key, err)
-			failures = append(failures, secretStoreRestartFailure{ref: job, err: err})
-		}
-	}
-	return failures
 }

--- a/src/go/plugin/agent/jobmgr/dyncfg_vnode_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_vnode_test.go
@@ -336,3 +336,8 @@ func (j *vnodeUpdateProbeJob) UpdateVnode(vnode *vnodes.VirtualNode) {
 	j.updated = &copy
 	j.vnode = copy
 }
+func (j *vnodeUpdateProbeJob) SetVnodeBaseline(vnode *vnodes.VirtualNode) {
+	if vnode != nil {
+		j.vnode = *vnode
+	}
+}

--- a/src/go/plugin/agent/jobmgr/effect.go
+++ b/src/go/plugin/agent/jobmgr/effect.go
@@ -61,19 +61,12 @@ type effectControl struct {
 	// BEFORE the deadline outcome commits.
 	quarantine atomic.Pointer[func()]
 
-	// disruptive, set by a multi-phase closure once it has irreversibly
-	// mutated state (an update's old instance is stopped): a shutdown
-	// interruption after this point must commit as a failure, never as
-	// never-ran - a never-ran outcome would roll caches back to a state
-	// that no longer exists.
-	disruptive atomic.Bool
-}
-
-// markDisruptive records the point of no return for the running phase.
-func (c *effectControl) markDisruptive() {
-	if c != nil {
-		c.disruptive.Store(true)
-	}
+	// lateWork, set by a closure with loop-side work that must still run
+	// when the effect is abandoned (a store command's dependent-restart
+	// replay for restarts that complete only after the deadline), is
+	// delivered on the late completion and executed by the loop while the
+	// command's write claims are still held.
+	lateWork atomic.Pointer[func()]
 }
 
 // warmResume is a late-detection success: the already-detected job, started
@@ -108,7 +101,27 @@ func (c *effectControl) claimAbandon() bool {
 
 func (c *effectControl) setResume(r *warmResume) { c.resume.Store(r) }
 
-func (c *effectControl) setQuarantine(fn func()) { c.quarantine.Store(&fn) }
+func (c *effectControl) setLateWork(fn func()) {
+	if c != nil {
+		c.lateWork.Store(&fn)
+	}
+}
+
+func (c *effectControl) takeLateWork() func() {
+	if c == nil {
+		return nil
+	}
+	if p := c.lateWork.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+func (c *effectControl) setQuarantine(fn func()) {
+	if c != nil {
+		c.quarantine.Store(&fn)
+	}
+}
 
 // clearQuarantine disarms the fence once the guarded blocking wait finished
 // normally, so a deadline in a LATER phase of the same effect cannot fence a
@@ -146,9 +159,20 @@ type effectResult struct {
 	abandoned bool
 	// late: the leaked child returned; the key unwedges and resume (if any
 	// and still valid) starts the warm job.
-	late    bool
-	resume  *warmResume
-	busyFor time.Duration
+	late   bool
+	resume *warmResume
+	// lateWork is loop-side work delivered with a late completion (replay
+	// of dependent restarts that completed after the abandon); it runs
+	// before the command's remaining claims release.
+	lateWork func()
+	// delivered, set on abandoned results, is closed by the worker AFTER
+	// the result reaches the loop (or is dropped): the leaked child's late
+	// completion gates on it, so a call that returns instantly at
+	// cancellation can never overtake the abandon - an overtaken late
+	// result would be dropped as not-wedged and the key would wedge with
+	// nothing left to release it.
+	delivered chan struct{}
+	busyFor   time.Duration
 }
 
 func (m *Manager) runEffectWorker() {
@@ -173,6 +197,9 @@ func (m *Manager) runEffectWorker() {
 				// The drain window expired with the results channel full; the
 				// force pass already committed this command's terminal.
 				m.Warningf("dropping effect completion for key '%s' after shutdown (err: %v)", t.key, res.err)
+			}
+			if res.delivered != nil {
+				close(res.delivered)
 			}
 		}
 	}
@@ -238,20 +265,33 @@ func (m *Manager) superviseEffect(t effectTask) effectResult {
 
 		m.leakedChildren.Add(1)
 		m.leakedNow.Add(1)
+		abandonDelivered := make(chan struct{})
 		go func() {
 			defer m.leakedChildren.Done()
 			err := <-done
 			cancel()
 			m.leakedNow.Add(-1)
-			res := effectResult{key: t.key, err: err, late: true, resume: ctl.resume.Load()}
+			// The abandoned result must reach the loop first: an instantly
+			// returning leaked call would otherwise race its late completion
+			// ahead of the abandon.
+			select {
+			case <-abandonDelivered:
+			case <-m.lateDrop:
+			}
+			res := effectResult{key: t.key, err: err, late: true, resume: ctl.resume.Load(), lateWork: ctl.takeLateWork()}
 			if r := res.resume; r != nil && m.ctx.Err() != nil {
 				// Shutdown is in effect: no warm job will ever start, and a
 				// buffered send can win the race against the closed lateDrop
-				// and strand the result unread - dispose here, deliver a
-				// resume-less completion (a consumer just unwedges the key).
-				r.job.Cleanup()
-				m.emissionGates.removeMatching(r.cfg.FullName(), r.gate)
+				// and strand the result unread - dispose here (silently, one
+				// rule), deliver a resume-less completion (a consumer just
+				// unwedges the key).
+				m.disposeWarmResume(r)
 				res.resume = nil
+			}
+			if res.lateWork != nil && m.ctx.Err() != nil {
+				// One rule at shutdown: nothing publishes after the drain -
+				// the late replay is dropped, not run.
+				res.lateWork = nil
 			}
 			select {
 			case m.effectDoneCh <- res:
@@ -260,31 +300,20 @@ func (m *Manager) superviseEffect(t effectTask) effectResult {
 				if r := res.resume; r != nil {
 					// Unreachable once the pre-send disposal ran (shutdown
 					// precedes lateDrop's close); kept as a safety net.
-					r.job.Cleanup()
-					m.emissionGates.removeMatching(r.cfg.FullName(), r.gate)
+					m.disposeWarmResume(r)
 				}
 			}
 		}()
 		var abandonErr error
-		shutdown := errors.Is(context.Cause(ctx), context.Canceled)
 		switch {
-		case shutdown && fenced:
-			// Shutdown cancelled the effect context; same abandon mechanics
-			// (the worker must never block at shutdown), different cause.
-			abandonErr = fmt.Errorf("%w: job manager is shutting down", dyncfg.ErrPhaseAbandoned)
-		case shutdown && ctl.disruptive.Load():
-			// Shutdown after the phase's point of no return (the update's
-			// old instance is already stopped): a never-ran rollback would
-			// resurrect caches for a state that no longer exists - commit
-			// as a plain disruptive failure instead.
-			abandonErr = fmt.Errorf("interrupted by shutdown after the operation began: the previous state was already torn down")
-		case shutdown:
-			// Unfenced shutdown interruption: no matter which side wins the
-			// completion claim, the command's outcome is "interrupted, retry
-			// after restart" - the never-ran shape (503, nothing published,
-			// caches untouched/restored). This is the single choke point:
-			// callback-side conversions cover the child winning the claim,
-			// this branch covers the worker winning it.
+		case errors.Is(context.Cause(ctx), context.Canceled):
+			// Shutdown cancelled the effect context (dyncfg deadlines carry a
+			// timeout cause; commands are never cancelled individually). ONE
+			// RULE: every non-terminal command at shutdown answers 503,
+			// publishes nothing, and disposes everything - regardless of
+			// which phase was running, how far it got, or whether a fence
+			// ran. This is the worker-side choke point; the callback-side
+			// conversions cover the child winning the completion claim.
 			abandonErr = fmt.Errorf("interrupted by shutdown: %w", dyncfg.ErrPhaseNeverRan)
 		case fenced:
 			abandonErr = fmt.Errorf("%w: timed out after %s (the collector call is still running)", dyncfg.ErrPhaseAbandoned, m.effectDeadline)
@@ -295,6 +324,7 @@ func (m *Manager) superviseEffect(t effectTask) effectResult {
 			key:       t.key,
 			err:       abandonErr,
 			abandoned: true,
+			delivered: abandonDelivered,
 			busyFor:   time.Since(started),
 		}
 	}

--- a/src/go/plugin/agent/jobmgr/effect_deadline_test.go
+++ b/src/go/plugin/agent/jobmgr/effect_deadline_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -388,14 +390,17 @@ func TestEffect_StopDeadline(t *testing.T) {
 	}
 }
 
-// Bridge pin: secretstore dependent restarts run loop-synchronously and
-// SKIP-AND-REPORT dependents whose collector key has work in flight; idle
-// dependents restart inline exactly as before.
-func TestSecretstoreBridge_SkipsBusyDependents(t *testing.T) {
+// Secretstore dependent restarts run as ONE claimed multi-key effect: a
+// dependent with work in flight PARKS the store command (write claim on the
+// dependent's key) until that work commits, and the recomputed plan then
+// restarts it against the new store. Only a WEDGED dependent - held by an
+// abandoned effect with no bounded release - is skipped and reported in the
+// terminal message's existing per-job format.
+func TestSecretstoreDependentClaims(t *testing.T) {
 	tests := map[string]struct {
 		run func(t *testing.T)
 	}{
-		"busy-key dependent is skipped and reported in the terminal message": {
+		"a busy dependent parks the store update until its work commits, then restarts": {
 			run: func(t *testing.T) {
 				release := make(chan struct{})
 				var inits atomic.Int32
@@ -406,8 +411,8 @@ func TestSecretstoreBridge_SkipsBusyDependents(t *testing.T) {
 					Create: func() collectorapi.CollectorV1 {
 						return &collectorapi.MockCollectorV1{
 							InitFunc: func(context.Context) error {
-								if inits.Add(1) > 1 {
-									<-release // the update's detection blocks: key busy
+								if inits.Add(1) == 2 {
+									<-release // the restart's detection blocks: key busy
 								}
 								return nil
 							},
@@ -436,6 +441,11 @@ func TestSecretstoreBridge_SkipsBusyDependents(t *testing.T) {
 				defer waitCancel()
 				require.True(t, mgr.WaitStarted(waitCtx))
 				t.Cleanup(func() {
+					select {
+					case <-release:
+					default:
+						close(release)
+					}
 					cancel()
 					select {
 					case <-done:
@@ -455,34 +465,40 @@ func TestSecretstoreBridge_SkipsBusyDependents(t *testing.T) {
 				cfg := prepareDyncfgCfg("gated", "mysql")
 				h.dyncfg("2-enable", []string{mgr.dyncfgJobID(cfg), "enable"}, nil)
 				require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
-				require.Eventually(t, func() bool {
-					return len(mgr.restartableAffectedJobs("vault:vault_prod")) == 1
-				}, charWait, charTick, "the job must be registered as a restartable store dependent")
 
-				// Make the dependent's key busy without leaving Running state
-				// (which would drop it from the restartable set): a restart
-				// whose detection blocks.
+				// The dependent's key goes busy: a restart whose detection
+				// blocks.
 				h.dyncfg("3-restart", []string{mgr.dyncfgJobID(cfg), "restart"}, nil)
 				require.Eventually(t, func() bool { return inits.Load() >= 2 }, charWait, charTick,
 					"the restart's detection did not start")
 
-				// The store update must NOT wait on the busy dependent.
+				// The store update write-claims the busy dependent's key: it
+				// must PARK until the restart commits, never skip it.
 				h.dyncfg("ss-update", []string{mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
 					mustJSON(t, map[string]any{"value": "rotated"}))
-				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick,
-					"the store update must complete while its dependent is busy")
-
-				var resp map[string]any
-				mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
-				assert.Contains(t, resp["message"], "dependent collector restarts failed")
-				assert.Contains(t, resp["message"], "skipped: operation in progress")
+				require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update"), charNeverWait, charTick,
+					"the store update must wait for the busy dependent, not complete around it")
 
 				close(release)
 				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-restart 200"), charWait, charTick,
 					"the blocked restart must complete after release")
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick,
+					"the parked store update must proceed once the dependent frees")
+
+				var resp map[string]any
+				mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
+				msg, _ := resp["message"].(string)
+				assert.Empty(t, msg, "the unparked update restarts the dependent cleanly - nothing to report")
+				assert.GreaterOrEqual(t, inits.Load(), int32(3),
+					"the dependent must be restarted against the rotated store")
+
+				wiretest.RequireSubsequence(t, h.out.String(), []wiretest.RecordWant{
+					{Name: "restart terminal", Contains: []string{"FUNCTION_RESULT_BEGIN 3-restart 200"}},
+					{Name: "store update terminal", Contains: []string{"FUNCTION_RESULT_BEGIN ss-update 200"}},
+				})
 			},
 		},
-		"a dependent with an enable in flight is reported, never silently missed": {
+		"an in-flight enable parks the rotation via its store read claim, then the recomputed plan restarts the job": {
 			run: func(t *testing.T) {
 				gate := make(chan struct{})
 				var inits atomic.Int32
@@ -493,8 +509,9 @@ func TestSecretstoreBridge_SkipsBusyDependents(t *testing.T) {
 					Create: func() collectorapi.CollectorV1 {
 						return &collectorapi.MockCollectorV1{
 							InitFunc: func(context.Context) error {
-								inits.Add(1)
-								<-gate // the enable's detection holds the key busy
+								if inits.Add(1) == 1 {
+									<-gate // the enable's detection holds the key busy
+								}
 								return nil
 							},
 							ChartsFunc: func() *collectorapi.Charts {
@@ -522,6 +539,11 @@ func TestSecretstoreBridge_SkipsBusyDependents(t *testing.T) {
 				defer waitCancel()
 				require.True(t, mgr.WaitStarted(waitCtx))
 				t.Cleanup(func() {
+					select {
+					case <-gate:
+					default:
+						close(gate)
+					}
 					cancel()
 					select {
 					case <-done:
@@ -537,32 +559,116 @@ func TestSecretstoreBridge_SkipsBusyDependents(t *testing.T) {
 				h.dyncfg("1-add", []string{mgr.dyncfgModID("gated"), "add", "mysql"},
 					mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
 				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 1-add"), charWait, charTick)
-				require.Eventually(t, func() bool {
-					return len(mgr.affectedJobs("vault:vault_prod")) == 1
-				}, charWait, charTick, "the job must be registered as a store dependent")
 
-				// The enable's effect starts (it resolved the OLD secret) but
-				// its commit is pending: the exposed status still reads
-				// accepted while the key is busy.
+				// The enable's effect starts against the OLD secret and holds
+				// a READ claim on the store while its detection runs.
 				cfg := prepareDyncfgCfg("gated", "mysql")
 				h.dyncfg("2-enable", []string{mgr.dyncfgJobID(cfg), "enable"}, nil)
 				require.Eventually(t, func() bool { return inits.Load() >= 1 }, charWait, charTick,
 					"the enable's detection did not start")
 
-				// The store update must not silently miss the in-flight
-				// dependent: it is selected and reported as skipped.
+				// The store rotation's WRITE claim conflicts with the enable's
+				// READ claim: it parks instead of racing the in-flight
+				// detection (the stale-credential window is structurally
+				// closed).
 				h.dyncfg("ss-update", []string{mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
 					mustJSON(t, map[string]any{"value": "rotated"}))
-				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick)
+				require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update"), charNeverWait, charTick,
+					"the rotation must wait out the in-flight enable's store read claim")
+
+				close(gate)
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick,
+					"the parked rotation must proceed once the enable commits")
 
 				var resp map[string]any
 				mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
-				assert.Contains(t, resp["message"], "skipped: operation in progress",
-					"an in-flight dependent must be reported, not silently missed")
+				msg, _ := resp["message"].(string)
+				assert.Empty(t, msg,
+					"the recomputed plan restarts the now-running dependent cleanly")
+				assert.GreaterOrEqual(t, inits.Load(), int32(2),
+					"the dependent that went running during the park must be restarted with the new secret")
+			},
+		},
+		"a wedged dependent is skipped and reported in the terminal message": {
+			run: func(t *testing.T) {
+				release := make(chan struct{})
+				var inits atomic.Int32
 
-				close(gate)
-				require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick,
-					"the enable must complete after release")
+				reg := collectorapi.Registry{}
+				reg.Register("gated", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							InitFunc: func(context.Context) error {
+								inits.Add(1)
+								<-release // ignores the deadline: the key wedges
+								return nil
+							},
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService()})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+				mgr.effectDeadline = testEffectDeadline
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				t.Cleanup(func() {
+					select {
+					case <-release:
+					default:
+						close(release)
+					}
+					cancel()
+					select {
+					case <-done:
+					case <-time.After(charWait):
+						t.Errorf("manager did not stop after cancel")
+					}
+				})
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				h.dyncfg("ss-add", []string{mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+					mustJSON(t, map[string]any{"value": "good"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+				h.dyncfg("1-add", []string{mgr.dyncfgModID("gated"), "add", "mysql"},
+					mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 1-add"), charWait, charTick)
+
+				// The enable's detection ignores its deadline: the command
+				// commits failed and the key WEDGES until the leaked call
+				// returns.
+				cfg := prepareDyncfgCfg("gated", "mysql")
+				h.dyncfg("2-enable", []string{mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status failed"), charWait, charTick,
+					"the enable must commit its deadline failure")
+
+				// A wedged key has no bounded release: the rotation must NOT
+				// wait for it - it completes and reports the skip in the
+				// existing per-job failure format.
+				h.dyncfg("ss-update", []string{mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+					mustJSON(t, map[string]any{"value": "rotated"}))
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick,
+					"the store update must complete while its dependent is wedged")
+
+				var resp map[string]any
+				mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
+				assert.Contains(t, resp["message"], "dependent collector restarts failed")
+				assert.Contains(t, resp["message"], "skipped: operation in progress")
+				assert.Equal(t, int32(1), inits.Load(),
+					"a wedged dependent is never restarted")
 			},
 		},
 		"a wait-parked accepted dependent stays ignored": {
@@ -1137,6 +1243,190 @@ func TestEffect_Shutdown(t *testing.T) {
 					"no disabled status may be published for a stop that never ran")
 			},
 		},
+		"in-flight stop at shutdown answers 503 and publishes nothing": {
+			// ONE RULE at shutdown: every non-terminal command answers 503,
+			// publishes nothing, and disposes everything. This is a deliberate
+			// wire contract: a stop that in fact completes during the drain
+			// still answers 503 instead of 200 - no matter which side wins the
+			// completion claim, the outcome is identical.
+			run: func(t *testing.T) {
+				defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+				entered := make(chan struct{}, 1)
+				release := make(chan struct{})
+
+				reg := collectorapi.Registry{}
+				reg.Register("stuck", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					// Declared functions let the registry track the job, so the
+					// test can observe that the stop effect is in its blocking
+					// wait (routing already withdrawn) before shutdown begins.
+					InstanceFunctions: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "details"}}
+					},
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 {
+								select {
+								case entered <- struct{}{}:
+								default:
+								}
+								<-release
+								return map[string]int64{"d1": 1}
+							},
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+				mgr.drainWait = time.Second
+				mgr.effectDeadline = time.Hour // nothing may abandon before shutdown
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				cfg := prepareDyncfgCfg("stuck", "s")
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("stuck"), "add", "s"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+				select {
+				case <-entered:
+				case <-time.After(charWait):
+					t.Fatal("no collection started")
+				}
+
+				// The stop effect must be in its blocking wait before shutdown:
+				// routing withdrawal happens just ahead of it.
+				h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+				require.Eventually(t, func() bool {
+					return !slices.Contains(h.mgr.GetJobNames("stuck"), "s")
+				}, charWait, charTick, "the stop effect did not start")
+
+				cancel()
+				// The stop completes during the drain window.
+				close(release)
+				select {
+				case <-done:
+				case <-time.After(charWait):
+					t.Fatal("shutdown did not complete")
+				}
+
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable 503"), charWait, charTick,
+					"an in-flight stop at shutdown must answer 503, even if it completes during the drain")
+				assert.False(t, h.outputContains("CONFIG test:collector:stuck:s status disabled")(),
+					"no disabled status may be published at shutdown")
+			},
+		},
+		"a stop in flight at shutdown never re-registers its job and never hangs cleanup": {
+			// The abandoned stop commits never-ran (one rule), but its
+			// blocking wait STARTED: the undo must not fire - re-adding the
+			// still-stopping job would hand cleanup a second unbounded
+			// job.Stop on the same instance, hanging shutdown until the
+			// wedged collector unblocks.
+			run: func(t *testing.T) {
+				entered := make(chan struct{}, 1)
+				release := make(chan struct{})
+
+				reg := collectorapi.Registry{}
+				reg.Register("stuck", collectorapi.Creator{
+					JobConfigSchema: collectorapi.MockConfigSchema,
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							ChartsFunc: func() *collectorapi.Charts {
+								return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+							},
+							CollectFunc: func(context.Context) map[string]int64 {
+								select {
+								case entered <- struct{}{}:
+								default:
+								}
+								<-release
+								return map[string]int64{"d1": 1}
+							},
+						}
+					},
+				})
+
+				var out simOutput
+				mgr := New(Config{PluginName: testPluginName})
+				mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+				mgr.modules = reg
+				mgr.drainWait = 300 * time.Millisecond
+				mgr.effectDeadline = time.Hour // only shutdown may abandon
+
+				ctx, cancel := context.WithCancel(context.Background())
+				in := make(chan []*confgroup.Group)
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					defer close(in)
+					mgr.Run(ctx, in)
+				}()
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+				defer waitCancel()
+				require.True(t, mgr.WaitStarted(waitCtx))
+				t.Cleanup(func() {
+					select {
+					case <-release:
+					default:
+						close(release)
+					}
+					cancel()
+				})
+				h := &charHarness{mgr: mgr, out: &out, in: in}
+
+				cfg := prepareDyncfgCfg("stuck", "s")
+				h.dyncfg("1-add", []string{h.mgr.dyncfgModID("stuck"), "add", "s"}, []byte("{}"))
+				h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+				require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+				select {
+				case <-entered:
+				case <-time.After(charWait):
+					t.Fatal("no collection started")
+				}
+
+				// The stop blocks in the wedged collection.
+				h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+				require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable"), charNeverWait, charTick,
+					"the stop must be blocked in its final collection")
+
+				// Shutdown WITHOUT unblocking the collector: the manager must
+				// still stop (the wedged job is owned by the leaked stop, not
+				// re-registered for cleanup to block on).
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(charWait):
+					t.Fatal("shutdown hung: the still-stopping job must not be re-registered for cleanup")
+				}
+
+				require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable 503"), charWait, charTick,
+					"the abandoned stop answers 503 at shutdown")
+				assert.False(t, h.outputContains("CONFIG test:collector:stuck:s status disabled")(),
+					"nothing publishes at shutdown")
+				mgr.runningJobs.lock()
+				_, running := mgr.runningJobs.lookup(cfg.FullName())
+				mgr.runningJobs.unlock()
+				assert.False(t, running,
+					"a job whose stop wait started must never be re-registered by the never-ran undo")
+			},
+		},
 		"late detection success during the drain is dropped, never started": {
 			run: func(t *testing.T) {
 				defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
@@ -1410,7 +1700,8 @@ func TestEffect_Shutdown(t *testing.T) {
 // TestCallbacks_NoFreshWorkAfterShutdown pins the success-tail shutdown
 // guard: a detection that finishes normally against a shutdown-cancelled
 // context must not start the job - the enable answers retryably (never-ran)
-// and an update fails disruptively, and neither leaves a gate registered.
+// and updates answer retryably under the shutdown one-rule, and neither
+// leaves a gate registered.
 func TestCallbacks_NoFreshWorkAfterShutdown(t *testing.T) {
 	newMgr := func(cleanups *atomic.Int32, initFn func(context.Context) error) *Manager {
 		reg := collectorapi.Registry{}
@@ -1498,7 +1789,11 @@ func TestCallbacks_NoFreshWorkAfterShutdown(t *testing.T) {
 		assert.False(t, running)
 	})
 
-	t.Run("update fails disruptively and starts nothing", func(t *testing.T) {
+	t.Run("update of a running config answers never-ran and starts nothing", func(t *testing.T) {
+		// ONE RULE at shutdown: even though the old instance was already
+		// stopped (half the update happened), the command answers 503 and
+		// publishes nothing - the daemon retries after restart against a
+		// freshly rebuilt state.
 		mgr := newMgr(nil, nil)
 		oldCfg := prepareDyncfgCfg("quick", "q")
 		require.NoError(t, mgr.collectorCallbacks.Start(context.Background(), oldCfg))
@@ -1507,9 +1802,8 @@ func TestCallbacks_NoFreshWorkAfterShutdown(t *testing.T) {
 		err := mgr.collectorCallbacks.Update(cancelled(), oldCfg, newCfg)
 
 		require.Error(t, err)
-		assert.False(t, errors.Is(err, dyncfg.ErrPhaseNeverRan),
-			"half the update happened (the old instance stopped) - it must fail, not roll back")
-		assert.Contains(t, err.Error(), "shutting down")
+		assert.True(t, errors.Is(err, dyncfg.ErrPhaseNeverRan),
+			"a shutdown-interrupted update answers retryably regardless of how far it got")
 		mgr.runningJobs.lock()
 		_, running := mgr.runningJobs.lookup(newCfg.FullName())
 		mgr.runningJobs.unlock()
@@ -1609,4 +1903,124 @@ func TestWaitUnparkReplayOrder(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return strings.Count(h.out.String(), "CONFIG test:collector:gated:g create accepted") >= 2
 	}, charWait, charTick, "discovery events must not reorder across the wait-unpark replay")
+}
+
+// A discovery removal whose stop ABANDONS at the deadline publishes the
+// removal (fenced-abandon success) while the leaked stop still runs; the
+// store-dependency index must be cleaned at that commit - not at the leaked
+// stop's eventual return - or a store remove granted after the abandon's
+// claim release answers a false 409 naming a config whose delete is already
+// on the wire.
+func TestDiscoveryRemove_CleansDepsIndexAtAbandonCommit(t *testing.T) {
+	release := make(chan struct{})
+	collecting := make(chan struct{}, 1)
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 {
+					select {
+					case collecting <- struct{}{}:
+					default:
+					}
+					<-release // the removal's stop blocks on this collection
+					return map[string]int64{"d1": 1}
+				},
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, func(m *Manager) { m.effectDeadline = testEffectDeadline })
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	cfg := prepareUserCfg("gated", "legacy").Set("option_str", "${store:vault:vault_prod:value}")
+	h.in <- prepareCfgGroups(cfg.Source(), cfg)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:legacy create accepted"), charWait, charTick)
+	h.dyncfg("leg-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN leg-enable 200"), charWait, charTick)
+	select {
+	case <-collecting:
+	case <-time.After(charWait):
+		t.Fatal("no collection started")
+	}
+
+	// Discovery removes the config; its stop blocks in the in-flight
+	// collection past the deadline and ABANDONS - the removal publishes.
+	h.in <- prepareCfgGroups(cfg.Source())
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:legacy delete"), charWait, charTick,
+		"the abandoned removal must still publish the config delete")
+
+	// The store remove is granted once the abandon commit released the
+	// removal's read claim; the dependency index must no longer list the
+	// removed config.
+	h.dyncfg("ss-remove", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "remove"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-remove 200"), charWait, charTick,
+		"the store remove must not answer a false 409 from the stale dependency index")
+
+	close(release)
+}
+
+// A YAML "null" payload document (the default content type) unmarshals to
+// a NIL confgroup.Config with no error, and the parse prefix then writes
+// config metadata into that map. The stage parse gate (PayloadParser) runs
+// the prefix ON THE MANAGER LOOP, which has no recover - an unguarded nil
+// map is a plugin-killing panic, not a recovered effect failure. YAML null
+// documents must reject as 400 at the parse layer. (JSON null never yields
+// nil: Clone's yaml round-trip materializes it as an empty object -
+// pre-existing behavior, deliberately unchanged; the pin holds it to a
+// non-panic terminal.)
+func TestDyncfgNullPayload_Answers400(t *testing.T) {
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, nil)
+
+	// An exposed config for the update path.
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"}, mustJSON(t, map[string]any{}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 1-add 202"), charWait, charTick)
+
+	// YAML path: no content type set.
+	h.mgr.dyncfgConfig(dyncfg.NewFunction(functions.Function{
+		UID:     "add-null-yaml",
+		Args:    []string{h.mgr.dyncfgModID("gated"), "add", "pg"},
+		Payload: []byte("null"),
+	}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN add-null-yaml 400"), charWait, charTick,
+		"a YAML null payload must answer 400, not panic the manager loop")
+
+	// JSON path: materialized as an empty object, answers its normal
+	// terminal without panicking.
+	h.dyncfg("update-null-json", []string{h.mgr.dyncfgJobID(cfg), "update"}, []byte("null"))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN update-null-json"), charWait, charTick,
+		"a JSON null payload must reach a terminal, not panic the manager loop")
+
+	// The loop survived: a later command still answers.
+	h.dyncfg("2-get", []string{h.mgr.dyncfgJobID(cfg), "get"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 2-get"), charWait, charTick)
 }

--- a/src/go/plugin/agent/jobmgr/executor.go
+++ b/src/go/plugin/agent/jobmgr/executor.go
@@ -4,6 +4,7 @@ package jobmgr
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -16,17 +17,20 @@ import (
 // command handlers: every discovery and dyncfg event is classified into an
 // event (kind, domain, derived key) and executed through dispatch.
 //
-// Collector-domain events run under PER-KEY lanes: each key is idle, busy
-// (a blocking phase in flight on the effect pool), or wait-parked (a
-// discovered config awaiting its enable/disable decision). While a key is
-// busy ALL of its events park in arrival order; while it is wait-parked only
-// discovery events park - inbound dyncfg commands execute immediately with
-// the state machine's outcomes, and an enable/disable decision unparks the
-// key. Events for different keys never wait on each other. Commits always
-// run on the run-loop goroutine; blocking work runs on the pool.
-//
-// Secretstore and vnode commands stay loop-synchronous: their domains are
-// not on the executor lanes and their keys never go busy.
+// All three dyncfg domains run under PER-KEY lanes: each key is idle,
+// occupied (a command anywhere between claim acquisition and its last
+// commit, including a blocking phase in flight on the effect pool), or
+// wait-parked (a discovered config awaiting its enable/disable decision).
+// While a key is occupied ALL of its events park in arrival order; while it
+// is wait-parked only discovery events park - inbound dyncfg commands
+// execute immediately with the state machine's outcomes, and an
+// enable/disable decision unparks the key. Events for different keys never
+// wait on each other; cross-key dependencies (a collector command reading a
+// store or vnode, a store command restarting dependent jobs) are reserved
+// through the claim table before blocking work ships. Commits always run on
+// the run-loop goroutine; blocking work runs on the pool. Vnode commands
+// are stage+commit only: they execute inline on the loop under their
+// vnode-name write claim and their keys never go busy.
 
 type eventKind int8
 
@@ -53,6 +57,12 @@ type event struct {
 	key    string
 	cfg    confgroup.Config
 	fn     dyncfg.Function
+	// underivable marks a dyncfg command whose config identity could not be
+	// derived (key is the domain fallback): it can only ever reach the
+	// handler's rejection paths, so it executes claimless-inline - claiming
+	// payload refs for it could park an invalid command behind a held key
+	// instead of answering 400 immediately.
+	underivable bool
 }
 
 // effectPoolSize bounds concurrently executing blocking phases. Internal
@@ -62,21 +72,36 @@ const effectPoolSize = 4
 // keyState is the loop-owned lane state of one key.
 type keyState struct {
 	busy          bool
-	wedged        bool
 	waiting       bool
 	generation    uint64
-	wedgedGen     uint64
 	fifo          []event
 	waitFIFO      []event
 	pendingCommit func(error)
 	afterIdle     []func()
 	firstParkedAt time.Time
 	waitSince     time.Time
+	// acquiring is the lane's current command while its claim set is being
+	// acquired (parked in the claim table); grant is its completed
+	// acquisition while the command runs. Together with busy they keep the
+	// lane occupied stage-to-commit so same-key events never reorder.
+	acquiring *claimRequest
+	grant     *claimGrant
+	// wedge, when non-nil, IS the wedged state: the lane's command was
+	// abandoned at its deadline and the leaked call has not returned (busy
+	// stays true for the whole window). Constructed only by wedgeKey at the
+	// abandon commit; consumed only by the late return.
+	wedge *wedge
 }
 
 func (ks *keyState) empty() bool {
-	return !ks.busy && !ks.wedged && !ks.waiting && ks.pendingCommit == nil &&
+	return !ks.occupied() && ks.wedge == nil && !ks.waiting && ks.pendingCommit == nil &&
 		len(ks.fifo) == 0 && len(ks.waitFIFO) == 0 && len(ks.afterIdle) == 0
+}
+
+// occupied reports whether the lane's current command is anywhere between
+// stage (claim acquisition) and commit.
+func (ks *keyState) occupied() bool {
+	return ks.busy || ks.acquiring != nil || ks.grant != nil
 }
 
 // effectTask is one blocking phase handed to the effect pool.
@@ -96,10 +121,29 @@ type executor struct {
 	// draining flips at shutdown: chained blocking phases then run inline so
 	// pending commits complete without pool workers.
 	draining bool
+	// claims is the multi-key reservation table; claimWork maps in-flight
+	// acquisitions back to their events so the shutdown drain can answer
+	// claim-parked commands.
+	claims    *claimTable
+	claimWork map[*claimRequest]event
 }
 
 func newExecutor(mgr *Manager) *executor {
-	return &executor{mgr: mgr, keys: make(map[string]*keyState)}
+	e := &executor{
+		mgr:       mgr,
+		keys:      make(map[string]*keyState),
+		claims:    newClaimTable(),
+		claimWork: make(map[*claimRequest]event),
+	}
+	// A key freed of its last foreign claim may have lane events parked
+	// behind it.
+	e.claims.released = func(key string) {
+		if ks := e.keys[key]; ks != nil {
+			e.settle(key, ks)
+			e.maybeDelete(key, ks)
+		}
+	}
+	return e
 }
 
 // stateKey namespaces lane state by domain so key strings from different
@@ -110,16 +154,20 @@ func (ev event) stateKey() string {
 
 // dispatch routes ev into its key's lane on the run-loop goroutine.
 func (e *executor) dispatch(ev event) {
-	if ev.kind == eventDyncfgCommand && ev.domain != domainCollector {
-		e.dispatchDyncfg(ev)
-		return
-	}
-	if ev.kind == eventDyncfgCommand && ev.fn.Command() == dyncfg.CommandTest {
-		// Collector test is KEYLESS by contract: it runs in its own capped
-		// off-loop pool and must never park behind a busy key (a wedged
-		// 120s detection would block an interactive test).
-		e.mgr.dyncfgCmdTest(ev.fn)
-		return
+	if ev.kind == eventDyncfgCommand {
+		switch ev.domain {
+		case domainUnknown:
+			e.mgr.dyncfgRespondUnknown(ev.fn)
+			return
+		case domainCollector:
+			if ev.fn.Command() == dyncfg.CommandTest {
+				// Collector test is KEYLESS by contract: it runs in its own
+				// capped off-loop pool and must never park behind a busy key
+				// (a wedged 120s detection would block an interactive test).
+				e.mgr.dyncfgCmdTest(ev.fn)
+				return
+			}
+		}
 	}
 	sk := ev.stateKey()
 	ks := e.keys[sk]
@@ -133,7 +181,20 @@ func (e *executor) dispatch(ev event) {
 }
 
 func (e *executor) route(sk string, ks *keyState, ev event) {
-	if ks.busy {
+	if ks.occupied() || e.claims.heldForWrite(sk) {
+		if !ks.occupied() && len(ks.fifo) == 0 &&
+			ev.kind == eventDyncfgCommand && !e.dyncfgCommandActs(ev) {
+			// A deterministic rejection/no-op arriving under a FOREIGN write
+			// hold (a store command's claim on this dependent job key):
+			// answer it claimless-inline instead of parking it behind a hold
+			// with no bounded release - a wedged store command's dependent
+			// write claims release only at its late return. Same-key order
+			// is preserved: the bypass requires an unoccupied lane and an
+			// empty lane FIFO, so no earlier same-key event is overtaken
+			// (wait-parked discovery events may legitimately be preceded).
+			e.execute(sk, ks, ev)
+			return
+		}
 		if len(ks.fifo) == 0 {
 			ks.firstParkedAt = time.Now()
 		}
@@ -164,7 +225,7 @@ func (e *executor) route(sk string, ks *keyState, ev event) {
 			parked := ks.waitFIFO
 			ks.waitFIFO = nil
 			for i, pev := range parked {
-				if ks.busy {
+				if ks.occupied() {
 					rest := append([]event(nil), parked[i:]...)
 					ks.fifo = append(rest, ks.fifo...)
 					if ks.firstParkedAt.IsZero() {
@@ -185,6 +246,57 @@ func (e *executor) route(sk string, ks *keyState, ev event) {
 }
 
 func (e *executor) execute(sk string, ks *keyState, ev event) {
+	if e.draining {
+		// ONE RULE at shutdown - enforced BEFORE claim acquisition so a
+		// command popped from a settling FIFO during the drain can never
+		// park in the claim table without a terminal.
+		e.refuseAtShutdown(ev)
+		return
+	}
+	if !e.eventNeedsClaims(ev) {
+		e.executeEvent(sk, ks, ev)
+		return
+	}
+	// Mutating events reserve their full claim set - the lane key plus the
+	// referenced stores and vnode - before any work runs. The lane stays
+	// occupied through the acquisition so same-key events keep their order.
+	req := &claimRequest{
+		label:   claimLabel(ev),
+		compute: func() []claim { return e.collectorEventClaims(ev) },
+	}
+	req.granted = func(g *claimGrant) {
+		delete(e.claimWork, req)
+		ks.acquiring = nil
+		ks.grant = g
+		e.executeEvent(sk, ks, ev)
+		e.finishIfSettled(sk, ks)
+	}
+	ks.acquiring = req
+	e.claimWork[req] = ev
+	e.claims.acquire(req)
+}
+
+// refuseAtShutdown resolves an event under the one rule: dyncfg commands
+// answer 503, discovery events are dropped - nothing executes, nothing
+// publishes.
+func (e *executor) refuseAtShutdown(ev event) {
+	if ev.kind != eventDyncfgCommand {
+		return
+	}
+	e.mgr.dyncfgResponder.SendCodef(ev.fn, 503, dyncfgShuttingDownMsg)
+	if mx := e.mgr.executorMetrics; mx != nil {
+		mx.shutdownRejected.Add(1)
+	}
+}
+
+// executeEvent runs an event's body; for claimed events this happens once
+// the claim grant is held. The draining re-check covers grants that fire
+// during the drain (a release waking a parked acquisition).
+func (e *executor) executeEvent(sk string, ks *keyState, ev event) {
+	if e.draining {
+		e.refuseAtShutdown(ev)
+		return
+	}
 	switch ev.kind {
 	case eventDiscoveryAdd:
 		e.mgr.stagedAddConfig(ev.cfg, e.runnerFor(sk), func() {
@@ -196,8 +308,411 @@ func (e *executor) execute(sk string, ks *keyState, ev event) {
 	case eventDiscoveryRemove:
 		e.mgr.stagedRemoveConfig(ev.cfg, e.runnerFor(sk))
 	case eventDyncfgCommand:
-		e.executeCollectorCommand(sk, ks, ev.fn)
+		switch ev.domain {
+		case domainSecretStore:
+			e.executeSecretStoreCommand(sk, ev.fn)
+		case domainVnode:
+			e.executeVnodeCommand(ev.fn)
+		default:
+			e.executeCollectorCommand(sk, ks, ev.fn)
+		}
 	}
+}
+
+// executeVnodeCommand runs a vnode command inline: the domain is
+// stage+commit only (no blocking work, no effects), so the command completes
+// on the loop while its write claim conflicts with collector commands'
+// vnode read claims. The cross-vnode uniqueness scan needs no extra claims
+// because vnode mutations never leave the loop.
+func (e *executor) executeVnodeCommand(fn dyncfg.Function) {
+	e.mgr.dyncfgVnodeSeqExec(fn)
+}
+
+// executeSecretStoreCommand routes a store command through the controller's
+// step API. Note on the remove path's deadline exposure: a store remove
+// cannot carry dependent restarts into its effect - removal is 409-refused
+// while ANY job references the store (dyncfgCmdRemoveStep's affected-jobs
+// guard, checked under the remove's granted store write claim, so no new
+// reference can appear before the effect) - and the remaining effect body
+// (service.Remove) is in-memory, so a remove effect cannot outlive the
+// deadline.
+func (e *executor) executeSecretStoreCommand(sk string, fn dyncfg.Function) {
+	e.mgr.secretsCtl.StepExec(fn, e.runnerFor(sk))
+}
+
+// finishIfSettled releases a claimed command's grant once no blocking phase
+// is in flight (the command completed inline or its last commit ran). A
+// wedged key keeps its grant until the late return.
+func (e *executor) finishIfSettled(sk string, ks *keyState) {
+	if ks.busy || ks.grant == nil {
+		return
+	}
+	g := ks.grant
+	ks.grant = nil
+	e.claims.release(g)
+}
+
+// eventNeedsClaims reports whether the event reaches a phase that mutates
+// state or runs blocking work: those events reserve claims. Discovery
+// events always act; dyncfg commands consult their domain's acts predicate
+// - rejection-only commands (and cheap read commands: get, schema,
+// userconfig) run claimless-inline against loop-owned state.
+func (e *executor) eventNeedsClaims(ev event) bool {
+	switch ev.kind {
+	case eventDiscoveryAdd, eventDiscoveryRemove:
+		return true
+	case eventDyncfgCommand:
+		return e.dyncfgCommandActs(ev)
+	}
+	return false
+}
+
+// dyncfgCommandActs reports whether a dyncfg command reaches a phase that
+// mutates state or runs blocking work, per its DOMAIN's own predicate -
+// each colocated with the gates it mirrors and enforced by that domain's
+// parity test (Handler.CommandActs for collector commands incl. the
+// payload axis; the secretsctl and vnodectl Controller.CommandActs for
+// their stage gates and 501 arms). Rejection-only commands claim NOTHING
+// and bypass foreign-hold lane parking: a rejection execution reaches
+// BEFORE its first claim-protected access (identity/underivable,
+// existence, payload, command-support, and most source/type gates) answers
+// immediately instead of parking behind held dependencies, where a wedged
+// store's write claim has no bounded release. STATUS-derived
+// rejections/no-ops are immediate only when this key is not foreign
+// write-held; under a foreign write hold the status is being mutated, so
+// the command parks and answers after the hold resolves. Gates execution
+// orders BEHIND a claim-protected read answer under the granted claim
+// instead - the store remove's source/type 405s sit behind its
+// affected-jobs read. Evaluated on the loop and re-evaluated at every
+// (re-)stage attempt.
+func (e *executor) dyncfgCommandActs(ev event) bool {
+	if ev.underivable {
+		// Rejection-only by construction: the handler answers 400/404/405
+		// without touching state.
+		return false
+	}
+	m := e.mgr
+	switch ev.domain {
+	case domainSecretStore:
+		return m.secretsCtl.CommandActs(ev.fn)
+	case domainVnode:
+		return m.vnodesCtl.CommandActs(ev.fn)
+	default:
+		// Collector test never reaches the lanes (keyless, diverted at
+		// dispatch); get/schema report false from the handler predicate.
+		entry, ok := m.collectorExposed.LookupByKey(ev.key)
+		if !ok {
+			entry = nil
+		}
+		if m.collectorHandler.CommandActs(ev.fn, entry) {
+			return true
+		}
+		// HOLD-AWARE STATUS GATES: a STATUS-derived rejection/no-op is
+		// deterministic only while no foreign write claim holds this key -
+		// the only cross-key write claimer (a store command's
+		// dependent-restart plan) mutates exactly entry.Status, so an
+		// answer minted from it mid-hold can be falsified by the holder's
+		// outcome (a false-success enable during a failing restart). Such
+		// commands are treated as ACTING while held: they park and answer
+		// truthfully after the hold resolves - under a wedged holder that
+		// is the late return, per key-held-until-return. Every immutable
+		// rejection axis keeps the bypass.
+		return m.collectorHandler.RejectionDependsOnStatus(ev.fn, entry) &&
+			e.claims.heldForWrite(ev.stateKey())
+	}
+}
+
+func claimLabel(ev event) string {
+	if ev.kind == eventDyncfgCommand {
+		return string(ev.fn.Command()) + " " + ev.key
+	}
+	return "discovery " + ev.key
+}
+
+// collectorEventClaims computes an event's reservation set.
+//
+// Collector events: a write claim on their own lane key plus read claims on
+// every referenced secret store and the referenced vnode. Update-shaped
+// events (dyncfg update, add over an existing config, discovery replace)
+// take the UNION of the old and new dependencies - old and new stores/vnodes
+// can differ, and claiming only the new set would let commands on the old
+// dependencies interleave with the teardown half.
+//
+// Secretstore events: a write claim on the store key plus write claims on
+// every restartable dependent job key (wedged dependents are excluded - they
+// are skipped and reported, never waited on); the advisory test takes only a
+// read claim on the store.
+//
+// Recomputed at every (re-)stage attempt by contract; a command that became
+// rejection-only while parked (its entry removed, its store deleted)
+// recomputes to the EMPTY set, which grants immediately and lets it answer
+// its rejection inline.
+func (e *executor) collectorEventClaims(ev event) []claim {
+	m := e.mgr
+
+	if ev.kind == eventDyncfgCommand && !e.dyncfgCommandActs(ev) {
+		// Rejection-only commands claim NOTHING - not even their lane key
+		// (see dyncfgCommandActs; arrival-time rejections never reach this
+		// compute, eventNeedsClaims filters them to claimless-inline).
+		return nil
+	}
+
+	if ev.kind == eventDyncfgCommand && ev.domain == domainSecretStore {
+		if ev.fn.Command() == dyncfg.CommandTest {
+			return []claim{{key: ev.stateKey(), mode: claimRead}}
+		}
+		set := []claim{{key: ev.stateKey(), mode: claimWrite}}
+		for _, dep := range m.secretStoreRestartPlan(ev.key) {
+			if dep.wedged {
+				continue
+			}
+			set = append(set, claim{key: collectorStateKey(dep.cfg.ExposedKey()), mode: claimWrite})
+		}
+		return set
+	}
+
+	if ev.kind == eventDyncfgCommand && ev.domain == domainVnode {
+		// Vnode mutations claim only the vnode name: the write conflicts
+		// with collector commands' read claims on the same vnode, and the
+		// commands themselves are loop-synchronous stage+commit.
+		return []claim{{key: ev.stateKey(), mode: claimWrite}}
+	}
+
+	set := []claim{{key: ev.stateKey(), mode: claimWrite}}
+
+	addCfgRefs := func(cfg confgroup.Config) {
+		for _, storeKey := range extractSecretStoreKeys(cfg) {
+			set = append(set, claim{key: secretStoreStateKey(storeKey), mode: claimRead})
+		}
+		if vnode := cfg.Vnode(); vnode != "" {
+			set = append(set, claim{key: vnodeStateKey(vnode), mode: claimRead})
+		}
+	}
+	addExposedRefs := func() {
+		if entry, ok := m.collectorExposed.LookupByKey(ev.key); ok {
+			addCfgRefs(entry.Cfg)
+		}
+	}
+	addPayloadRefs := func() {
+		// Cheap parse only (no I/O). An unparsable payload never reaches
+		// this compute - the PayloadParser stage gate classifies it as
+		// rejection-only - so the error branch is defensive.
+		if cfg, err := configFromPayload(ev.fn); err == nil {
+			addCfgRefs(cfg)
+		}
+	}
+
+	switch ev.kind {
+	case eventDiscoveryAdd:
+		addCfgRefs(ev.cfg)
+		addExposedRefs() // replace of an existing config: union old + new
+	case eventDiscoveryRemove:
+		// Stop-shaped events hold their OLD references too: the stopping
+		// job remains a dependent of its stores and vnode until the stop
+		// commits, so store/vnode mutations - and their affected-job gates,
+		// which read the exposed cache the stop already cleared at stage -
+		// must wait the stop out instead of racing it.
+		addExposedRefs()
+	case eventDyncfgCommand:
+		// Only ACTING commands reach here (the rejection-only guard above,
+		// backed by the per-domain CommandActs predicates and their parity
+		// tests, filtered the rest): every acting mutation claims its
+		// config's references - old and new where both exist.
+		switch ev.fn.Command() {
+		case dyncfg.CommandAdd, dyncfg.CommandUpdate:
+			addPayloadRefs()
+			addExposedRefs() // union old + new (add over an existing config replaces it)
+		case dyncfg.CommandEnable, dyncfg.CommandRestart,
+			dyncfg.CommandDisable, dyncfg.CommandRemove:
+			addExposedRefs()
+		}
+	}
+	return set
+}
+
+// THE WEDGE LIFECYCLE CONTRACT. A wedged key (deadline-abandoned effect,
+// leaked module call still running) is the one state where the normal
+// invariants are asymmetric; every site touching it MUST preserve all of
+// the following, and a change to any point updates this block. Structural
+// owners: points 2-5 are the ordered body of wedgeKey (the only place a
+// wedge is created); points 8-10 and 13 the ordered body of resolveWedge
+// (the only place one is resolved); point 6 the effect worker; point 7 the
+// restart buffer plus lateWork; points 11-12 the registration reconcile and
+// the late retry evaluation; point 14 the effect closures' obligation:
+//
+// While wedged (from the abandon commit to the late return):
+//
+//  1. The lane stays busy: all its events park in the lane FIFO, so no
+//     command for the key can run or commit (generation mismatch at the
+//     late return is an assert, not a working path).
+//  2. The command's WRITE claims - its own key plus any keys the leaked
+//     work may still MUTATE (a store command's dependent job keys) - stay
+//     held until the late return; its READ claims release at the abandon
+//     commit. Dependency mutations CAN therefore commit during the wedge.
+//  3. Because reads release, the abandon commit snapshots the read-claimed
+//     store identities (wedgedDeps) - the last moment mutations were still
+//     excluded, hence exactly what the leaked work resolved.
+//  4. Store-dependency index maintenance happens at the abandon commit
+//     BEFORE any claim release, so commands woken by the release never
+//     read a stale index: the after-idle hooks (the dyncfg-command deps
+//     sync) and the discovery-removal path's commit-side RemoveActiveJob
+//     (stagedRemoveConfig) - cleanup MUST NOT sit in an effect closure
+//     after the blocking wait, where an abandon defers it to the leaked
+//     stop's return while the removal publish already happened.
+//  5. Claim waiters parked at the wedged key are re-attempted at the wedge
+//     (claims.wake): recompute excludes wedged keys, so store mutations
+//     skip-and-report the dependent instead of waiting out the leaked
+//     call; a waiter whose set still needs the key re-parks at the front.
+//  6. The abandoned result reaches the loop before the child's late
+//     completion (the delivered gate): an instantly-returning leaked call
+//     must not wedge the key with nothing left to release it.
+//  7. Store commands buffer completed dependent restarts as they finish:
+//     the buffer flushes at the abandon commit AND is registered as
+//     lateWork for restarts completing after it.
+//
+// At the late return:
+//
+//  8. lateWork runs BEFORE the remaining claims release (the replay is
+//     truthful while the write claims still exclude newer commands) -
+//     unless draining, where it is dropped (one rule).
+//  9. A warm resume starts ONLY if: not draining; the generation matches;
+//     no stop intent is queued in the lane FIFO; every store dependency
+//     the warm config references has an unchanged committed identity and
+//     no in-flight write hold (staleWarmDep); and the exposed entry is
+//     still this config in its abandoned-failed state (resumeWarmJob).
+// 10. Every DROPPED resume disposes silently: disposeWarmResume closes the
+//     job's emission gate by captured handle before Cleanup (V1 Cleanup
+//     emits HOST/HOSTINFO lines even for a never-started job).
+// 11. A STARTED warm job receives the current vnode config at registration
+//     (startRunningJob's reconcile), like every other start path - as a
+//     COMMITTED baseline, not a queued delivery: it must be visible to
+//     cleanup even if the job never collects, and it must not evict a
+//     newer live update from the one-slot queue.
+// 12. A late FAILURE evaluates retry eligibility under today's rules at
+//     the return; nothing was scheduled at the abandon (a provisional
+//     retry could race the continuation).
+// 13. Shutdown: late results consumed while draining only release keys -
+//     the resume is disposed, lateWork dropped; the child gates its send
+//     on lateDrop so it never blocks after the drain.
+//
+// Entering the wedge (the deadline race):
+//
+// 14. Classification is race-independent: an effect that DEGRADED its work
+//     because the deadline fired (a store command's restart sequence cut
+//     mid-way) returns a non-nil error, so the command reaches its timeout
+//     outcome whether the closure's return or the worker's abandon wins
+//     their select race - message text alone cannot carry the degradation.
+//     ENFORCED AS A SEAM POST-CONDITION, not per-checkpoint discipline:
+//     runStagedRestarts reclassifies any nil-error restart sequence whose
+//     command window has expired (a deadline firing DURING a restart or
+//     after the last one is invisible to in-loop checkpoints), so the
+//     pipeline cannot under-report degradation. Skip-and-report on WEDGED
+//     dependents is not degradation; it is the command's successful outcome
+//     for wedged keys.
+
+// wedge is the loop-owned record of one abandoned command, from its abandon
+// commit to its late return. keyState.wedge != nil IS the wedged state:
+// wedgeKey (the abandon commit) is the only constructor and resolveWedge
+// (the late return) the only consumer, so the wedged window's distributed
+// invariants live in two ordered bodies instead of scattered sites.
+type wedge struct {
+	// gen is the key's generation at the abandon commit: a mismatch at the
+	// late return means a newer command committed on the key (assert-only -
+	// the lane parks everything while wedged).
+	gen uint64
+	// deps are the read-claimed store dependencies' identities at the
+	// abandon commit (contract point 3).
+	deps []wedgedDep
+}
+
+// wedgedDep is one read-claimed secret-store dependency of a wedged
+// command: its committed identity at the abandon commit. Up to that moment
+// the command's read claim excluded store mutations, so the identity pins
+// the value its leaked detection actually resolved.
+type wedgedDep struct {
+	stateKey string
+	identity string
+}
+
+// wedgeKey performs the abandon-commit half of the wedge lifecycle, in
+// order: mark the key wedged FIRST (the commit's chained phases must refuse
+// and claim recomputes must already exclude this key), commit the deadline
+// outcome and advance the generation, run the command's after-idle hooks
+// (loop-owned side effects such as the store-dependency sync finalize
+// BEFORE any claim release - contract point 4), capture the read-claimed
+// store dependency identities (the last moment the read claims still
+// exclude mutations - point 3), release those read claims (they must not
+// outlive the commit, or a wedged dependent's store read would block every
+// rotation of that store - point 2), and re-attempt the claim waiters
+// parked at the key (the retained write claim has no bounded release;
+// recompute lets store mutations skip-and-report this key instead of
+// waiting out the leaked call - point 5). The command's WRITE claims - this
+// key and any keys the leaked work may still mutate - stay held on ks.grant
+// until the late return settles the lane (point 2).
+func (e *executor) wedgeKey(sk string, ks *keyState, commit func(error), err error) {
+	ks.wedge = &wedge{}
+	commit(err)
+	ks.generation++
+	ks.wedge.gen = ks.generation
+	e.runAfterIdleHooks(ks)
+	if ks.grant != nil {
+		ks.wedge.deps = e.snapshotWedgedDeps(ks.grant)
+		e.claims.releaseReadClaims(ks.grant)
+	}
+	e.claims.wake(sk)
+}
+
+// snapshotWedgedDeps captures the wedging command's store dependencies from
+// its grant's read claims, just before those claims release at the abandon
+// commit. Vnode reads are not captured: a warm job's vnode is refreshed at
+// resume instead (resumeWarmJob), matching the live-update semantics a
+// running job gets.
+func (e *executor) snapshotWedgedDeps(g *claimGrant) []wedgedDep {
+	var deps []wedgedDep
+	for _, c := range g.held {
+		if c.mode != claimRead {
+			continue
+		}
+		key, ok := strings.CutPrefix(c.key, secretStoreStateKey(""))
+		if !ok {
+			continue
+		}
+		deps = append(deps, wedgedDep{stateKey: c.key, identity: e.mgr.secretStoreDepIdentity(key)})
+	}
+	return deps
+}
+
+// staleWarmDep reports why a warm continuation's store dependencies are no
+// longer trustworthy: a store the warm job resolved its secrets from whose
+// committed identity changed since the abandon (a rotation committed while
+// the key was wedged - that rotation reported this dependent as skipped, so
+// nothing would ever refresh a job started on the old value), or one
+// currently write-held (a granted store mutation whose effect may already
+// have activated a new value off-loop; dropping is the safe direction - if
+// that mutation ultimately fails, only this warm start is lost, never
+// credential freshness). Union-claimed dependencies the warm config no
+// longer references are ignored. Empty means the continuation is safe.
+func (e *executor) staleWarmDep(deps []wedgedDep, cfg confgroup.Config) string {
+	if len(deps) == 0 {
+		return ""
+	}
+	referenced := make(map[string]bool, len(deps))
+	for _, key := range extractSecretStoreKeys(cfg) {
+		referenced[secretStoreStateKey(key)] = true
+	}
+	for _, dep := range deps {
+		if !referenced[dep.stateKey] {
+			continue
+		}
+		if e.claims.heldForWrite(dep.stateKey) {
+			return fmt.Sprintf("a mutation of store dependency '%s' is in flight", dep.stateKey)
+		}
+		key, _ := strings.CutPrefix(dep.stateKey, secretStoreStateKey(""))
+		if e.mgr.secretStoreDepIdentity(key) != dep.identity {
+			return fmt.Sprintf("store dependency '%s' changed while the key was wedged", dep.stateKey)
+		}
+	}
+	return ""
 }
 
 func (e *executor) executeCollectorCommand(sk string, ks *keyState, fn dyncfg.Function) {
@@ -234,14 +749,28 @@ func (e *executor) executeCollectorCommand(sk string, ks *keyState, fn dyncfg.Fu
 	}
 }
 
-// afterIdleHook runs h when the key's current command fully settles (all
-// chained phases committed); immediately when it never went busy.
+// afterIdleHook runs h when the key's current command fully commits (all
+// chained phases done); immediately when it never went busy. Hooks run
+// BEFORE the command's claims release: they finalize loop-owned state (the
+// store-dependency index) that commands unparked by the release recompute
+// from - releasing first would hand those commands a stale view.
 func (e *executor) afterIdleHook(ks *keyState, h func()) {
 	if ks.busy {
 		ks.afterIdle = append(ks.afterIdle, h)
 		return
 	}
 	h()
+}
+
+// runAfterIdleHooks drains and runs the key's pending after-commit hooks.
+func (e *executor) runAfterIdleHooks(ks *keyState) {
+	for len(ks.afterIdle) > 0 {
+		hooks := ks.afterIdle
+		ks.afterIdle = nil
+		for _, h := range hooks {
+			h()
+		}
+	}
 }
 
 // runnerFor is the executor's asynchronous StepRunner: it marks the key
@@ -258,7 +787,7 @@ func (e *executor) runnerFor(sk string) dyncfg.StepRunner {
 			return
 		}
 		ks := e.keys[sk]
-		if ks.wedged {
+		if ks.wedge != nil {
 			// Reachable when a commit chains a phase after its own stop was
 			// abandoned: the key is held by the leaked call, so the chained
 			// phase never runs (never-ran keeps the commit truthful).
@@ -312,6 +841,24 @@ func (e *executor) failPendingPhase(sk string) {
 	commit(dyncfg.ErrPhaseNeverRan)
 }
 
+// onEffectDoneShutdown handles a completion under the ONE RULE at shutdown:
+// a phase completing after cancellation - success, failure, or
+// deadline-abandon - still answers 503 and publishes nothing (a stop
+// finishing here would otherwise publish state for a plugin that is
+// exiting). Late completions are not command outcomes (their commands
+// already committed at the abandon) and only release keys.
+func (e *executor) onEffectDoneShutdown(res effectResult) {
+	// Draining engages HERE, not just in shutdownDrain: the commit's cascade
+	// (claim releases waking parked acquisitions, lane settles popping
+	// parked events) must already see the shutdown mode, or a woken command
+	// would execute - and publish - through the normal path.
+	e.draining = true
+	if !res.late {
+		res.err = fmt.Errorf("interrupted by shutdown: %w", dyncfg.ErrPhaseNeverRan)
+	}
+	e.onEffectDone(res)
+}
+
 // onEffectDone resumes a completed blocking phase's commit on the run loop.
 func (e *executor) onEffectDone(res effectResult) {
 	ks := e.keys[res.key]
@@ -331,12 +878,10 @@ func (e *executor) onEffectDone(res effectResult) {
 	}
 	if res.abandoned {
 		// The deadline outcome commits now, but the key stays busy (wedged)
-		// until the leaked module call returns. No retry and no follow-up
-		// work is scheduled here; the late outcome decides.
-		ks.wedged = true
-		commit(res.err)
-		ks.generation++
-		ks.wedgedGen = ks.generation
+		// until the leaked module call returns; no retry and no follow-up
+		// work is scheduled here - the late outcome decides. The whole
+		// transition, including the commit, is wedgeKey's ordered body.
+		e.wedgeKey(res.key, ks, commit, res.err)
 		e.flushPendingEffects()
 		e.observeState()
 		return
@@ -344,77 +889,111 @@ func (e *executor) onEffectDone(res effectResult) {
 	ks.busy = false
 	commit(res.err) // may chain the next phase, re-marking the key busy
 	ks.generation++
+	if !ks.busy {
+		// The command's final commit ran: finalize its loop-owned side
+		// effects BEFORE the claim release wakes commands that read them.
+		e.runAfterIdleHooks(ks)
+	}
+	e.finishIfSettled(res.key, ks)
 	e.settle(res.key, ks)
 	e.maybeDelete(res.key, ks)
 	e.flushPendingEffects()
 	e.observeState()
 }
 
-// onLateReturn unwedges a key whose abandoned effect finally returned. A
-// warm detection success starts through the normal start path when the
-// continuation is still valid (nothing committed on the key since the
-// abandon - structurally guaranteed while wedged, asserted here); anything
-// else was already handled by the late protocol inside the closure.
+// onLateReturn unwedges a key whose abandoned effect finally returned:
+// resolveWedge decides the late outcome, then the lane settles.
 func (e *executor) onLateReturn(res effectResult, ks *keyState) {
-	if ks == nil || !ks.wedged {
+	if ks == nil || ks.wedge == nil {
 		e.mgr.Errorf("BUG: late completion for a key that is not wedged ('%s')", res.key)
 		if res.resume != nil {
-			e.dropWarmResume(res.resume)
+			e.mgr.disposeWarmResume(res.resume)
 		}
 		return
 	}
-	ks.wedged = false
+	w := ks.wedge
+	ks.wedge = nil
 	ks.busy = false
 	e.mgr.Infof("abandoned operation for key '%s' returned (err: %v)", res.key, res.err)
-
-	if res.resume != nil {
-		switch {
-		case e.draining:
-			// Shutdown never starts fresh collector work: a warm job that
-			// arrives during the drain is dropped, not resumed (no late
-			// re-enables and no running publish after shutdown began).
-			e.mgr.Infof("dropping late detection success for key '%s': shutting down", res.key)
-			e.dropWarmResume(res.resume)
-		case ks.generation != ks.wedgedGen:
-			if mx := e.mgr.executorMetrics; mx != nil {
-				mx.staleCommits.Add(1)
-			}
-			e.mgr.Warningf("dropping late detection success for key '%s': config changed during operation", res.key)
-			e.dropWarmResume(res.resume)
-		case keyFIFOHasStopIntent(ks):
-			// A disable/remove is already queued behind the wedge: the user's
-			// intent wins over the continuation - the warm job is dropped and
-			// the queued command executes against the failed entry.
-			e.mgr.Infof("dropping late detection success for key '%s': a stop command is queued", res.key)
-			e.dropWarmResume(res.resume)
-		default:
-			e.mgr.resumeWarmJob(res.resume)
-			ks.generation++
-		}
-	}
+	e.resolveWedge(w, res, ks)
+	e.finishIfSettled(res.key, ks)
 	e.settle(res.key, ks)
 	e.maybeDelete(res.key, ks)
 	e.observeState()
 }
 
-// dropWarmResume disposes a warm job that will never start: module cleanup
-// plus deregistering its own emission gate (matched by handle - a same-name
-// replacement's gate must survive).
-func (e *executor) dropWarmResume(r *warmResume) {
-	r.job.Cleanup()
-	e.mgr.emissionGates.removeMatching(r.cfg.FullName(), r.gate)
+// resolveWedge is the late-return half of the wedge lifecycle, in order:
+// replay the late work while the command's write claims still hold (dropped
+// when draining - one rule; contract points 8 and 13), then start the warm
+// continuation ONLY while every validity condition holds - not draining,
+// generation unchanged (assert - the lane parks everything while wedged),
+// no stop intent queued, and the warm config's store dependencies unchanged
+// since the abandon and not currently write-held (their read claims were
+// released with the abandon commit, so a rotation may have committed - or
+// be in flight - underneath the wedge; point 9). Every dropped continuation
+// disposes silently (point 10).
+func (e *executor) resolveWedge(w *wedge, res effectResult, ks *keyState) {
+	if res.lateWork != nil {
+		if e.draining {
+			// A late result queued just before cancellation can carry replay
+			// work: one rule - nothing publishes at shutdown; state
+			// reconverges on restart.
+			e.mgr.Infof("dropping late replay for key '%s': shutting down", res.key)
+		} else {
+			// Replay loop-side work for pieces that completed only after the
+			// abandon (dependent restarts): the command's write claims are
+			// still held, so no newer command has touched the affected keys
+			// and the replay is truthful.
+			res.lateWork()
+		}
+	}
+
+	if res.resume == nil {
+		return
+	}
+	staleDep := e.staleWarmDep(w.deps, res.resume.cfg)
+	switch {
+	case e.draining:
+		// Shutdown never starts fresh collector work: a warm job that
+		// arrives during the drain is dropped, not resumed (no late
+		// re-enables and no running publish after shutdown began).
+		e.mgr.Infof("dropping late detection success for key '%s': shutting down", res.key)
+		e.mgr.disposeWarmResume(res.resume)
+	case ks.generation != w.gen:
+		if mx := e.mgr.executorMetrics; mx != nil {
+			mx.staleCommits.Add(1)
+		}
+		e.mgr.Warningf("dropping late detection success for key '%s': config changed during operation", res.key)
+		e.mgr.disposeWarmResume(res.resume)
+	case keyFIFOHasStopIntent(ks):
+		// A disable/remove is already queued behind the wedge: the user's
+		// intent wins over the continuation - the warm job is dropped and
+		// the queued command executes against the failed entry.
+		e.mgr.Infof("dropping late detection success for key '%s': a stop command is queued", res.key)
+		e.mgr.disposeWarmResume(res.resume)
+	case staleDep != "":
+		// The warm job resolved its secrets from a store that changed (or
+		// is being changed) while the key was wedged: starting it would
+		// resurrect pre-rotation credentials that the store command
+		// deliberately skipped restarting (skip-and-report on wedged
+		// dependents), with nothing left to ever refresh them.
+		if mx := e.mgr.executorMetrics; mx != nil {
+			mx.staleCommits.Add(1)
+		}
+		e.mgr.Warningf("dropping late detection success for key '%s': %s", res.key, staleDep)
+		e.mgr.disposeWarmResume(res.resume)
+	default:
+		e.mgr.resumeWarmJob(res.resume)
+		ks.generation++
+	}
 }
 
 // settle drains a key's after-idle hooks and parked events until the key
-// goes busy again or nothing is left.
+// goes occupied again (or a foreign claim holds it) or nothing is left.
 func (e *executor) settle(sk string, ks *keyState) {
-	for !ks.busy {
+	for !ks.occupied() && !e.claims.heldForWrite(sk) {
 		if len(ks.afterIdle) > 0 {
-			hooks := ks.afterIdle
-			ks.afterIdle = nil
-			for _, h := range hooks {
-				h()
-			}
+			e.runAfterIdleHooks(ks)
 			continue
 		}
 		if len(ks.fifo) == 0 {
@@ -456,7 +1035,7 @@ func (e *executor) maybeDelete(sk string, ks *keyState) {
 func (e *executor) busyCount() int {
 	n := 0
 	for _, ks := range e.keys {
-		if ks.busy || ks.wedged {
+		if ks.busy || ks.wedge != nil {
 			n++
 		}
 	}
@@ -506,12 +1085,31 @@ dyncfgDrained:
 	}
 drained:
 
+	// Claim-parked commands hold no effects and will never be granted:
+	// answer them retryably now (one rule).
+	e.claims.drainParked(func(req *claimRequest) {
+		ev, ok := e.claimWork[req]
+		if !ok {
+			return
+		}
+		delete(e.claimWork, req)
+		if ks := e.keys[ev.stateKey()]; ks != nil && ks.acquiring == req {
+			ks.acquiring = nil
+		}
+		if ev.kind == eventDyncfgCommand {
+			e.mgr.dyncfgResponder.SendCodef(ev.fn, 503, dyncfgShuttingDownMsg)
+			if mx := e.mgr.executorMetrics; mx != nil {
+				mx.shutdownRejected.Add(1)
+			}
+		}
+	})
+
 	deadline := time.NewTimer(e.mgr.drainWait)
 	defer deadline.Stop()
 	for e.busyCount() > 0 {
 		select {
 		case res := <-e.mgr.effectDoneCh:
-			e.onEffectDone(res)
+			e.onEffectDoneShutdown(res)
 		case <-deadline.C:
 			e.mgr.Warningf("executor: timeout waiting %s for in-flight effects to drain", e.mgr.drainWait)
 			goto force
@@ -523,6 +1121,10 @@ force:
 		// after the window expired) must not leave its command silent: fail
 		// the still-pending commit with the never-ran outcome.
 		e.failPendingPhase(sk)
+		if g := ks.grant; g != nil {
+			ks.grant = nil
+			e.claims.release(g)
+		}
 		parked := append(append([]event(nil), ks.fifo...), ks.waitFIFO...)
 		ks.fifo, ks.waitFIFO = nil, nil
 		for _, ev := range parked {
@@ -549,47 +1151,23 @@ func collectorStateKey(key string) string {
 	return event{domain: domainCollector, key: key}.stateKey()
 }
 
-// collectorKeyHasWork reports whether the collector key has a blocking
-// phase in flight (busy or wedged). Wait-parking is NOT work: a config
-// awaiting its enable/disable decision has no job and no resolved secret,
-// so store rotations must keep ignoring it. Loop-owned state: call only on
-// the run-loop goroutine.
-func (e *executor) collectorKeyHasWork(key string) bool {
+// secretStoreStateKey is the claim key for a secret-store key.
+func secretStoreStateKey(key string) string {
+	return event{domain: domainSecretStore, key: key}.stateKey()
+}
+
+// vnodeStateKey is the claim key for a vnode name.
+func vnodeStateKey(name string) string {
+	return event{domain: domainVnode, key: name}.stateKey()
+}
+
+// collectorKeyWedged reports whether the collector key is held by an
+// abandoned effect awaiting its late return. A wedged key has no bounded
+// release, so store rotations skip-and-report its job instead of claiming
+// it. Loop-owned state: call only on the run-loop goroutine.
+func (e *executor) collectorKeyWedged(key string) bool {
 	ks := e.keys[collectorStateKey(key)]
-	return ks != nil && (ks.busy || ks.wedged)
-}
-
-// tryLockIdleKey claims a collector key for a LOOP-SYNCHRONOUS inline
-// operation (the secretstore dependent-restart bridge). It succeeds only for
-// a fully idle key - any in-flight effect, wedge, wait-park, or parked work
-// means the caller must skip, never wait: effect completions arrive via this
-// same loop, so waiting here would self-deadlock.
-func (e *executor) tryLockIdleKey(sk string) bool {
-	ks := e.keys[sk]
-	if ks == nil {
-		ks = &keyState{}
-		e.keys[sk] = ks
-	}
-	if !ks.empty() {
-		return false
-	}
-	ks.busy = true
-	e.observeState()
-	return true
-}
-
-// unlockIdleKey releases a tryLockIdleKey claim and drains anything that
-// parked behind it meanwhile.
-func (e *executor) unlockIdleKey(sk string) {
-	ks := e.keys[sk]
-	if ks == nil || !ks.busy {
-		e.mgr.Errorf("BUG: unlock of a key that is not held ('%s')", sk)
-		return
-	}
-	ks.busy = false
-	e.settle(sk, ks)
-	e.maybeDelete(sk, ks)
-	e.observeState()
+	return ks != nil && ks.wedge != nil
 }
 
 // observePark counts one parked event.
@@ -627,10 +1205,13 @@ func (e *executor) observeState() {
 	mx.busyKeys.Set(float64(busy))
 	mx.waitParkedKeys.Set(float64(waiting))
 	mx.parkedEvents.Set(float64(parked))
+	mx.claimParked.Set(float64(e.claims.parkedCount()))
 	mx.poolInflight.Set(float64(e.inflight))
 	mx.poolQueued.Set(float64(len(e.pending) + len(e.mgr.effectCh)))
 	mx.oldestParkedSince.Store(unixNanosOrZero(oldestParked))
 	mx.oldestWaitSince.Store(unixNanosOrZero(oldestWait))
+	oldestClaim, _ := e.claims.oldestParkedSince()
+	mx.oldestClaimParkedSince.Store(unixNanosOrZero(oldestClaim))
 }
 
 func unixNanosOrZero(t time.Time) int64 {
@@ -638,17 +1219,6 @@ func unixNanosOrZero(t time.Time) int64 {
 		return 0
 	}
 	return t.UnixNano()
-}
-
-func (e *executor) dispatchDyncfg(ev event) {
-	switch ev.domain {
-	case domainSecretStore:
-		e.mgr.dyncfgSecretStoreSeqExec(ev.fn)
-	case domainVnode:
-		e.mgr.dyncfgVnodeSeqExec(ev.fn)
-	default:
-		e.mgr.dyncfgRespondUnknown(ev.fn)
-	}
 }
 
 func (m *Manager) newDiscoveryAddEvent(cfg confgroup.Config) event {
@@ -677,6 +1247,7 @@ func (m *Manager) newDyncfgEvent(fn dyncfg.Function) event {
 	}
 	if !ok {
 		key = m.dyncfgFallbackKey(ev.domain)
+		ev.underivable = true
 	}
 	ev.key = key
 	return ev

--- a/src/go/plugin/agent/jobmgr/executor_metrics.go
+++ b/src/go/plugin/agent/jobmgr/executor_metrics.go
@@ -25,11 +25,13 @@ type executorRuntimeMetrics struct {
 	busyKeys       metrix.StatefulGauge
 	waitParkedKeys metrix.StatefulGauge
 	parkedEvents   metrix.StatefulGauge
+	claimParked    metrix.StatefulGauge
 	poolInflight   metrix.StatefulGauge
 	poolQueued     metrix.StatefulGauge
 
-	oldestParkedAge metrix.StatefulGauge
-	oldestWaitAge   metrix.StatefulGauge
+	oldestParkedAge      metrix.StatefulGauge
+	oldestWaitAge        metrix.StatefulGauge
+	oldestClaimParkedAge metrix.StatefulGauge
 
 	effectsStarted       metrix.StatefulCounter
 	effectPanics         metrix.StatefulCounter
@@ -42,10 +44,12 @@ type executorRuntimeMetrics struct {
 	suppressedLateOutput metrix.StatefulCounter
 	barrierWaitSeconds   metrix.StatefulCounter
 
-	// Unix nanos of the oldest currently parked event / wait-parked key;
-	// 0 when none. Written on the run loop, read by the producer tick.
-	oldestParkedSince atomic.Int64
-	oldestWaitSince   atomic.Int64
+	// Unix nanos of the oldest currently parked event / wait-parked key /
+	// claim-parked acquisition; 0 when none. Written on the run loop, read
+	// by the producer tick.
+	oldestParkedSince      atomic.Int64
+	oldestWaitSince        atomic.Int64
+	oldestClaimParkedSince atomic.Int64
 }
 
 func newExecutorRuntimeMetrics(store metrix.RuntimeStore) *executorRuntimeMetrics {
@@ -70,6 +74,11 @@ func newExecutorRuntimeMetrics(store metrix.RuntimeStore) *executorRuntimeMetric
 			metrix.WithChartFamily("Agent/JobMgr/Executor"),
 			metrix.WithUnit("events"),
 		),
+		claimParked: metrix.SeededGauge(meter, "claim_parked",
+			metrix.WithDescription("Commands parked in the claim table awaiting conflicting keys"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("commands"),
+		),
 		poolInflight: metrix.SeededGauge(meter, "pool_inflight",
 			metrix.WithDescription("Blocking phases in flight: executing on the effect pool or awaiting a slot"),
 			metrix.WithChartFamily("Agent/JobMgr/Executor"),
@@ -87,6 +96,11 @@ func newExecutorRuntimeMetrics(store metrix.RuntimeStore) *executorRuntimeMetric
 		),
 		oldestWaitAge: metrix.SeededGauge(meter, "oldest_wait_age",
 			metrix.WithDescription("Age of the oldest wait-parked key"),
+			metrix.WithChartFamily("Agent/JobMgr/Executor"),
+			metrix.WithUnit("seconds"),
+		),
+		oldestClaimParkedAge: metrix.SeededGauge(meter, "oldest_claim_parked_age",
+			metrix.WithDescription("Age of the oldest claim-parked command"),
 			metrix.WithChartFamily("Agent/JobMgr/Executor"),
 			metrix.WithUnit("seconds"),
 		),
@@ -150,6 +164,7 @@ func (m *executorRuntimeMetrics) refreshAges() error {
 	}
 	m.oldestParkedAge.Set(ageSeconds(m.oldestParkedSince.Load()))
 	m.oldestWaitAge.Set(ageSeconds(m.oldestWaitSince.Load()))
+	m.oldestClaimParkedAge.Set(ageSeconds(m.oldestClaimParkedSince.Load()))
 	return nil
 }
 

--- a/src/go/plugin/agent/jobmgr/executor_test.go
+++ b/src/go/plugin/agent/jobmgr/executor_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 func newExecutorTestManager() (*Manager, *bytes.Buffer) {
@@ -386,6 +388,8 @@ func TestDyncfgLaneDerivers_TestIsKeyless(t *testing.T) {
 // that sentinel, so an abandon that wins before the stop registered its
 // quarantine must classify as a plain failure instead.
 func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
 	newMgr := func() *Manager {
 		mgr := New(Config{PluginName: testPluginName})
 		mgr.effectDeadline = 50 * time.Millisecond
@@ -395,12 +399,12 @@ func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
 	t.Run("unfenced abandon is a plain failure", func(t *testing.T) {
 		mgr := newMgr()
 		block := make(chan struct{})
-		defer close(block)
 
 		res := mgr.superviseEffect(effectTask{key: "k", effect: func(context.Context) error {
 			<-block
 			return nil
 		}})
+		defer drainAbandonedEffect(mgr, res, block)
 
 		require.True(t, res.abandoned)
 		assert.False(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned),
@@ -410,7 +414,6 @@ func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
 	t.Run("fenced abandon carries ErrPhaseAbandoned", func(t *testing.T) {
 		mgr := newMgr()
 		block := make(chan struct{})
-		defer close(block)
 		var fenceRan atomic.Bool
 
 		res := mgr.superviseEffect(effectTask{key: "k", effect: func(ctx context.Context) error {
@@ -418,6 +421,7 @@ func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
 			<-block
 			return nil
 		}})
+		defer drainAbandonedEffect(mgr, res, block)
 
 		require.True(t, res.abandoned)
 		assert.True(t, fenceRan.Load(), "the worker must run the fence before reporting the abandon")
@@ -430,55 +434,29 @@ func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
 		cancel()
 		mgr.ctx = ctx // shutdown already began
 		block := make(chan struct{})
-		defer close(block)
 
 		res := mgr.superviseEffect(effectTask{key: "k", effect: func(context.Context) error {
 			<-block
 			return nil
 		}})
+		defer drainAbandonedEffect(mgr, res, block)
 
 		require.True(t, res.abandoned)
 		assert.True(t, errors.Is(res.err, dyncfg.ErrPhaseNeverRan),
 			"a shutdown interruption must answer retryably no matter which side wins the claim")
 	})
 
-	t.Run("disruptive shutdown abandon is a plain failure, never never-ran", func(t *testing.T) {
+	t.Run("fenced shutdown abandon is never-ran too", func(t *testing.T) {
+		// ONE RULE at shutdown: every non-terminal command answers 503 and
+		// publishes nothing - a fence changes nothing about the outcome (it
+		// still runs mechanically to suppress late output). Only a
+		// DEADLINE-caused fenced abandon may publish success.
 		mgr := newMgr()
 		mgr.effectDeadline = time.Hour // only the cancellation may abandon
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		mgr.ctx = ctx
 		block := make(chan struct{})
-		defer close(block)
-		marked := make(chan struct{})
-		go func() {
-			// Shutdown lands strictly AFTER the point of no return.
-			<-marked
-			cancel()
-		}()
-
-		res := mgr.superviseEffect(effectTask{key: "k", effect: func(ctx context.Context) error {
-			effectControlFrom(ctx).markDisruptive()
-			close(marked)
-			<-block
-			return nil
-		}})
-
-		require.True(t, res.abandoned)
-		assert.False(t, errors.Is(res.err, dyncfg.ErrPhaseNeverRan),
-			"a never-ran outcome would roll back caches for a state that no longer exists")
-		assert.False(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned),
-			"no fence ran - success must not be published")
-	})
-
-	t.Run("fenced shutdown abandon carries ErrPhaseAbandoned", func(t *testing.T) {
-		mgr := newMgr()
-		mgr.effectDeadline = time.Hour // only the cancellation may abandon
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		mgr.ctx = ctx
-		block := make(chan struct{})
-		defer close(block)
 		fenceSet := make(chan struct{})
 		go func() {
 			// Shutdown lands strictly AFTER the stop registered its fence.
@@ -492,11 +470,238 @@ func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
 			<-block
 			return nil
 		}})
+		defer drainAbandonedEffect(mgr, res, block)
 
 		require.True(t, res.abandoned)
-		assert.True(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned),
-			"a fenced stop may publish success even when shutdown is the cause")
+		assert.True(t, errors.Is(res.err, dyncfg.ErrPhaseNeverRan),
+			"a shutdown interruption answers retryably even when the stop's fence ran")
+		assert.False(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned),
+			"no stop-shaped success may be published at shutdown")
 	})
+}
+
+// The fence disarm after a completed stop is gated on WINNING the effect's
+// completion claim: a worker that abandoned during the stop - or wins the
+// CAS between Stop returning and the claim - must find the fence STILL
+// ARMED, so its abandon classifies as the fenced stop success
+// (ErrPhaseAbandoned) instead of an unfenced plain timeout that would take
+// the broken-stop 500 + cache-restore branch for a cleanly completed stop.
+func TestWaitStoppedJob_ClaimGatesTheFenceDisarm(t *testing.T) {
+	newCase := func() (*Manager, *effectControl, context.Context, runtimeJob) {
+		mgr := New(Config{PluginName: testPluginName})
+		ctl := &effectControl{}
+		ctx := context.WithValue(context.Background(), effectControlKey{}, ctl)
+		return mgr, ctl, ctx, &tickProbeJob{}
+	}
+
+	t.Run("winning the claim disarms the fence", func(t *testing.T) {
+		mgr, ctl, ctx, job := newCase()
+		mgr.waitStoppedJob(ctx, "j", job, true)
+		assert.False(t, ctl.claimCompletion(), "the wait must have claimed the completion itself")
+		assert.Nil(t, ctl.takeQuarantine(), "a won claim disarms the fence")
+	})
+
+	t.Run("losing the claim leaves the fence armed for the worker", func(t *testing.T) {
+		mgr, ctl, ctx, job := newCase()
+		require.True(t, ctl.claimAbandon(), "the worker wins the race in this scenario")
+		mgr.waitStoppedJob(ctx, "j", job, true)
+		assert.NotNil(t, ctl.takeQuarantine(),
+			"a lost claim must leave the fence for the abandoning worker - its abandon then publishes the fenced stop success")
+	})
+
+	t.Run("an inner-phase stop never claims and always disarms", func(t *testing.T) {
+		mgr, ctl, ctx, job := newCase()
+		mgr.waitStoppedJob(ctx, "j", job, false)
+		assert.True(t, ctl.claimCompletion(), "the outermost closure still owns the completion")
+		assert.Nil(t, ctl.takeQuarantine(), "the inner-phase disarm keeps today's semantics")
+	})
+}
+
+func TestDiscoveryStagedStopsAreFinalPhase(t *testing.T) {
+	runWithAbandonedStop := func(t *testing.T, action func(*Manager, dyncfg.StepRunner)) {
+		t.Helper()
+		mgr, _ := newExecutorTestManager()
+		cfg := prepareDiscoveredCfg("success", "disc")
+		mgr.collectorHandler.AddDiscoveredConfig(cfg, dyncfg.StatusRunning)
+		mgr.runningJobs.lock()
+		mgr.runningJobs.add(cfg.FullName(), &tickProbeJob{
+			fullName:   cfg.FullName(),
+			moduleName: cfg.Module(),
+			name:       cfg.Name(),
+		})
+		mgr.runningJobs.unlock()
+
+		var ran bool
+		run := func(effect func(context.Context) error, commit func(error)) {
+			ran = true
+			ctl := &effectControl{}
+			require.True(t, ctl.claimAbandon(), "the worker wins the deadline race")
+			ctx := context.WithValue(context.Background(), effectControlKey{}, ctl)
+			require.NoError(t, effect(ctx))
+			assert.NotNil(t, ctl.takeQuarantine(),
+				"discovery one-phase stops must leave the fence armed when the worker won the race")
+			commit(dyncfg.ErrPhaseAbandoned)
+		}
+
+		action(mgr, run)
+		require.True(t, ran)
+	}
+
+	t.Run("replace", func(t *testing.T) {
+		runWithAbandonedStop(t, func(mgr *Manager, run dyncfg.StepRunner) {
+			replacement := prepareUserCfg("success", "disc")
+			mgr.stagedAddConfig(replacement, run, func() {}, func(dyncfg.Function) {})
+		})
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		runWithAbandonedStop(t, func(mgr *Manager, run dyncfg.StepRunner) {
+			cfg := prepareDiscoveredCfg("success", "disc")
+			mgr.stagedRemoveConfig(cfg, run)
+		})
+	})
+}
+
+// A collector test completing DURING the shutdown drain answers 503, never
+// its natural 200/422: the keyless test path bypasses the executor's
+// receive-time one-rule choke points (its worker responds directly), so the
+// boundary lives at the worker's send seam - and the drain WAITS for test
+// workers, making this window deterministic, not a race.
+func TestCollectorTest_AnswersShutdown503(t *testing.T) {
+	gate := make(chan struct{})
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					<-gate // the test's Init outlives the shutdown start
+					return nil
+				},
+			}
+		},
+	})
+
+	var out simOutput
+	mgr := New(Config{PluginName: testPluginName})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	h.dyncfg("t1", []string{mgr.dyncfgModID("gated"), "test", "probe"}, []byte("{}"))
+	require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN t1"), charNeverWait, charTick,
+		"the test worker must be in flight")
+
+	// Shutdown begins while the test's Init is blocked; the drain waits for
+	// test workers, so the worker completes DURING shutdown - with a module
+	// SUCCESS that must still answer 503.
+	cancel()
+	close(gate)
+	select {
+	case <-done:
+	case <-time.After(2 * cmdTestWorkerDrainWait):
+		t.Fatal("shutdown did not complete")
+	}
+
+	require.True(t, h.outputContains("FUNCTION_RESULT_BEGIN t1 503")(),
+		"a test completing during the drain must answer 503")
+	assert.NotContains(t, out.String(), "FUNCTION_RESULT_BEGIN t1 200",
+		"the module's success must not reach the wire after shutdown began")
+}
+
+// Once shutdown begins EVERY non-terminal command answers 503 - malformed
+// ones included: the shutdown check precedes even argument validation, so a
+// too-few-args request cannot answer 400 after the one-rule boundary.
+func TestDyncfgConfig_MalformedAnswers503AtShutdown(t *testing.T) {
+	var out simOutput
+	mgr := New(Config{PluginName: testPluginName})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = collectorapi.Registry{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(charWait):
+		t.Fatal("shutdown did not complete")
+	}
+
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+	h.dyncfg("bad-args", []string{"test:collector:success"}, nil) // one arg only: malformed
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN bad-args 503"), charWait, charTick,
+		"a malformed command after shutdown must answer 503, not 400")
+	assert.NotContains(t, out.String(), "FUNCTION_RESULT_BEGIN bad-args 400")
+}
+
+// drainAbandonedEffect releases a directly-supervised abandoned effect the
+// way the production worker and loop would: unblock the leaked module call,
+// acknowledge the delivery gate (the worker closes it after its send
+// reaches the loop), and wait the leaked child out - its late completion
+// lands in the buffered effectDoneCh. Without this, the child parks at the
+// delivery gate forever and the goroutine leaks into later tests.
+func drainAbandonedEffect(mgr *Manager, res effectResult, release chan struct{}) {
+	select {
+	case <-release:
+	default:
+		close(release)
+	}
+	if res.delivered != nil {
+		close(res.delivered)
+	}
+	mgr.leakedChildren.Wait()
+}
+
+// TestSuperviseEffect_LateCompletionWaitsForAbandonDelivery pins the late
+// protocol's delivery order: a leaked call that returns INSTANTLY at
+// cancellation (a ctx-honoring backend) must not push its late completion
+// into effectDoneCh before the abandoned result reaches the loop - an
+// overtaken late result would be dropped as not-wedged and the key would
+// wedge with nothing left to release it.
+func TestSuperviseEffect_LateCompletionWaitsForAbandonDelivery(t *testing.T) {
+	mgr := New(Config{PluginName: testPluginName})
+	mgr.effectDeadline = 30 * time.Millisecond
+
+	res := mgr.superviseEffect(effectTask{key: "k", effect: func(ctx context.Context) error {
+		<-ctx.Done() // returns the instant the deadline fires
+		return ctx.Err()
+	}})
+	require.True(t, res.abandoned)
+	require.NotNil(t, res.delivered, "abandoned results carry the delivery gate")
+
+	// The leaked child has already returned, but its late result must wait
+	// for the abandon's delivery.
+	require.Never(t, func() bool { return len(mgr.effectDoneCh) > 0 }, charNeverWait, charTick,
+		"the late completion must not overtake the undelivered abandon")
+
+	close(res.delivered) // what the worker does after its send reaches the loop
+	require.Eventually(t, func() bool { return len(mgr.effectDoneCh) == 1 }, charWait, charTick,
+		"the late completion must flow once the abandon was delivered")
+	late := <-mgr.effectDoneCh
+	assert.True(t, late.late)
 }
 
 // TestResumeWarmJob_IneligibleDropDisposesGate pins that a warm job dropped

--- a/src/go/plugin/agent/jobmgr/funcdispatch_test.go
+++ b/src/go/plugin/agent/jobmgr/funcdispatch_test.go
@@ -577,8 +577,10 @@ func TestCleanup_UnregistersStaticFunctionsBeforeStoppingJobs(t *testing.T) {
 	mgr.funcCtl.RegisterModules(mgr.modules)
 
 	mgr.startRunningJob(&lockProbeJob{fullName: "staticmod_job1", moduleName: "staticmod", name: "job1"})
+	mgr.publishRunningJobFunctions("staticmod_job1")
 	mgr.funcCtl.ReconcileModuleMethods("staticmod")
 	mgr.startRunningJob(&lockProbeJob{fullName: "jobmod_job1", moduleName: "jobmod", name: "job1"})
+	mgr.publishRunningJobFunctions("jobmod_job1")
 	mgr.funcCtl.ReconcileModuleMethods("jobmod")
 
 	mgr.cleanup()
@@ -713,6 +715,7 @@ func newInstanceFunctionDispatchTestManager(
 	mgr.modules = collectorapi.Registry{"mod": creator}
 	mgr.funcCtl.RegisterModules(mgr.modules)
 	mgr.startRunningJob(&lockProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"})
+	mgr.publishRunningJobFunctions("mod_job1") // publication happens at commit, not inside the start
 	mgr.funcCtl.ReconcileModuleMethods("mod")
 
 	return mgr

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -179,7 +179,7 @@ func New(cfg Config) *Manager {
 		Initial:                 mgr.initialSecretStores,
 		AffectedJobs:            mgr.affectedJobs,
 		RestartableAffectedJobs: mgr.restartableAffectedJobs,
-		RestartDependentJobs:    mgr.restartDependentJobs,
+		StageDependentRestarts:  mgr.stageDependentRestarts,
 	})
 	mgr.executor = newExecutor(mgr)
 
@@ -370,17 +370,53 @@ func (m *Manager) runProcessConfGroups(in chan []*confgroup.Group) {
 
 func (m *Manager) run() {
 	for {
+		// Shutdown is checked FIRST every iteration: a plain select picks
+		// uniformly among ready cases, so after cancellation it could keep
+		// choosing ready work and commit it through the normal path -
+		// publishing state the one-rule shutdown contract says must not be
+		// published. The priority check bounds post-cancel normal
+		// processing to the event already being handled when cancellation
+		// landed.
+		select {
+		case <-m.ctx.Done():
+			m.executor.shutdownDrain()
+			return
+		default:
+		}
+		// Each work arm re-checks cancellation at receive time: the select
+		// picks uniformly among ready cases, so cancellation landing after
+		// the pre-check could still hand us work - it is then handled under
+		// the shutdown rule instead of the normal path. (A cancellation
+		// landing after this second check while the commit runs is the
+		// irreducible atomicity window every shutdown guard shares.)
 		select {
 		case <-m.ctx.Done():
 			m.executor.shutdownDrain()
 			return
 		case cfg := <-m.addCh:
+			if m.ctx.Err() != nil {
+				continue // discovery publishes nothing at shutdown
+			}
 			m.executor.dispatch(m.newDiscoveryAddEvent(cfg))
 		case cfg := <-m.rmCh:
+			if m.ctx.Err() != nil {
+				continue
+			}
 			m.executor.dispatch(m.newDiscoveryRemoveEvent(cfg))
 		case fn := <-m.dyncfgCh:
+			if m.ctx.Err() != nil {
+				m.dyncfgResponder.SendCodef(fn, 503, dyncfgShuttingDownMsg)
+				if mx := m.executorMetrics; mx != nil {
+					mx.shutdownRejected.Add(1)
+				}
+				continue
+			}
 			m.executor.dispatch(m.newDyncfgEvent(fn))
 		case res := <-m.effectDoneCh:
+			if m.ctx.Err() != nil {
+				m.executor.onEffectDoneShutdown(res)
+				continue
+			}
 			m.executor.onEffectDone(res)
 		}
 	}
@@ -444,15 +480,25 @@ func (m *Manager) stagedAddConfig(cfg confgroup.Config, run dyncfg.StepRunner, m
 	}
 	if entry.Status == dyncfg.StatusRunning {
 		old := entry.Cfg
+		staged := m.newFinalPhaseStagedJobStop(old.FullName())
 		run(func(ctx context.Context) error {
-			m.stopRunningJob(ctx, old.FullName())
-			m.fileStatus.remove(old)
+			staged.wait(ctx)
 			return nil
 		}, func(stopErr error) {
+			if stopErr == nil || errors.Is(stopErr, dyncfg.ErrPhaseAbandoned) {
+				// At COMMIT, not in the effect closure: on the abandon arm
+				// the closure body runs only at the leaked stop's eventual
+				// return, which would leave the replaced config's stale file
+				// status lingering long past the replacement's publish.
+				m.fileStatus.remove(old)
+			}
 			if stopErr != nil && !errors.Is(stopErr, dyncfg.ErrPhaseAbandoned) {
 				// The stop never ran (shutdown) or broke (recovered panic):
 				// the old instance's state is not settled - do not create the
 				// replacement next to it.
+				if errors.Is(stopErr, dyncfg.ErrPhaseNeverRan) {
+					staged.undo()
+				}
 				m.Warningf("skipping replacement of %s[%s]: stop of the previous instance did not complete: %v", cfg.Module(), cfg.Name(), stopErr)
 				return
 			}
@@ -496,20 +542,30 @@ func (m *Manager) stagedRemoveConfig(cfg confgroup.Config, run dyncfg.StepRunner
 	if !ok {
 		return
 	}
+	// Routing removal at stage time; dependency-state cleanup at COMMIT, on
+	// the arms that treat the removal as done. The abandon arm publishes the
+	// removal while the leaked stop still runs, so cleaning in the effect
+	// closure (at the leaked stop's eventual return) would leave the
+	// store-dependency index listing a config whose delete is already on the
+	// wire - a store remove granted after the abandon's claim release would
+	// answer a false 409 from that stale index.
+	staged := m.newFinalPhaseStagedJobStop(cfg.FullName())
 	run(func(ctx context.Context) error {
-		// Stop first so running-state cleanup is applied against existing dependency state.
-		m.stopRunningJob(ctx, cfg.FullName())
-		m.secretStoreDeps.RemoveActiveJob(entry.Cfg.FullName())
-		m.fileStatus.remove(cfg)
+		staged.wait(ctx)
 		return nil
 	}, func(stopErr error) {
 		if stopErr != nil && !errors.Is(stopErr, dyncfg.ErrPhaseAbandoned) {
 			// The stop never ran (shutdown) or broke (recovered panic): the
 			// job may still be emitting - publishing the removal would
 			// violate no-output-after-publish.
+			if errors.Is(stopErr, dyncfg.ErrPhaseNeverRan) {
+				staged.undo()
+			}
 			m.Warningf("suppressing config removal publish for %s[%s]: stop did not complete: %v", cfg.Module(), cfg.Name(), stopErr)
 			return
 		}
+		m.secretStoreDeps.RemoveActiveJob(entry.Cfg.FullName())
+		m.fileStatus.remove(cfg)
 		if !isStock(cfg) || entry.Status == dyncfg.StatusRunning {
 			m.collectorHandler.NotifyConfigRemove(cfg)
 		}
@@ -603,21 +659,68 @@ func (m *Manager) startRunningJob(job runtimeJob) {
 		m.requestFunctionReconcile(stale.ModuleName())
 	}
 
-	go job.Start()
-
+	// Registration precedes the vnode reconcile, which precedes Start: a
+	// vnode update committing concurrently either sees the registered job
+	// (applyVnodeUpdate queues it live) or committed before the reconcile's
+	// lookup (the baseline carries it). The baseline is COMMITTED into the
+	// job, not queued: a queued delivery could evict a newer live update
+	// from the one-slot channel, and V1 applies queued updates only during
+	// collection - a job stopped before its first tick would clean up with
+	// the stale creation-time vnode. Ticks to a registered but
+	// not-yet-started job are non-blocking sends; a stop racing this window
+	// unblocks because Start launches unconditionally below.
 	m.runningJobs.lock()
 	m.runningJobs.add(job.FullName(), job)
 	m.runningJobs.unlock()
 	m.secretStoreDeps.setRunning(job.FullName(), true)
+	m.reconcileJobVnode(job)
+	go job.Start()
+	// Function publication is NOT registered here: it follows COMMITTED
+	// state - the commit that publishes the running status also publishes
+	// the job's functions (collectorCallbacks.OnStatusChange).
+}
 
+// reconcileJobVnode delivers the current vnode config to a job being
+// registered. Vnode updates propagate to REGISTERED jobs only
+// (applyVnodeUpdate): a job created before an update committed but
+// registered after it would run on its stale creation-time snapshot - the
+// stop/start gap of a store command's dependent restart, or a warm
+// continuation resumed after a wedge. Vnode removal cannot leave a dangling
+// reference here: it is 409-refused while the job's exposed entry
+// references the vnode.
+func (m *Manager) reconcileJobVnode(job runtimeJob) {
+	cur := job.Vnode()
+	if cur.Name == "" {
+		return
+	}
+	vn, ok := m.vnodesCtl.Lookup(cur.Name)
+	if !ok || cur.Equal(vn) {
+		return
+	}
+	m.Infof("delivering updated vnode '%s' config to job '%s' at registration", cur.Name, job.FullName())
+	job.SetVnodeBaseline(vn)
+}
+
+// publishRunningJobFunctions registers a committed-live job with the
+// function registry and requests publication. Runs at COMMIT (on the loop):
+// publication follows committed state, never a still-uncommitted effect.
+func (m *Manager) publishRunningJobFunctions(name string) {
+	m.runningJobs.lock()
+	job, ok := m.runningJobs.lookup(name)
+	m.runningJobs.unlock()
+	if !ok {
+		return
+	}
 	m.funcCtl.OnJobStart(job)
 	m.requestFunctionReconcile(job.ModuleName())
 }
 
-// stopRunningJob stops the named job if it is running; it reports whether
-// THIS call found and stopped one (callers use it as the point-of-no-return
-// signal - a no-op stop tears nothing down).
-func (m *Manager) stopRunningJob(ctx context.Context, name string) bool {
+// stageStopRunningJob deregisters the named job from routing (running set,
+// store-dependency index, function registry) and returns its handle for the
+// blocking wait. Runs on the STAGING goroutine - before the stop effect is
+// even scheduled - so function routing to a stopping job ends immediately,
+// no matter how long the effect waits for a pool slot or blocks.
+func (m *Manager) stageStopRunningJob(name string) (runtimeJob, bool) {
 	m.runningJobs.lock()
 	job, ok := m.runningJobs.lookup(name)
 	if ok {
@@ -625,12 +728,91 @@ func (m *Manager) stopRunningJob(ctx context.Context, name string) bool {
 	}
 	m.runningJobs.unlock()
 	if !ok {
-		return false
+		return nil, false
 	}
 	m.secretStoreDeps.setRunning(name, false)
 	m.funcCtl.OnJobStop(job)
 	m.requestFunctionReconcile(job.ModuleName())
+	return job, true
+}
 
+// undoStagedStop reverts a staged stop whose blocking wait NEVER RAN: the
+// job is still running, so it must be visible to routing and to cleanup
+// again (a de-routed running job would collect forever, invisible and
+// unstoppable).
+func (m *Manager) undoStagedStop(name string, job runtimeJob) {
+	m.runningJobs.lock()
+	m.runningJobs.add(name, job)
+	m.runningJobs.unlock()
+	m.secretStoreDeps.setRunning(name, true)
+	m.funcCtl.OnJobStart(job)
+	m.requestFunctionReconcile(job.ModuleName())
+}
+
+const (
+	stagedStopPending int32 = iota
+	stagedStopWaiting
+	stagedStopUndone
+)
+
+// stagedJobStop is one command's staged stop of a running job with
+// EXACTLY-ONE-OWNER semantics between its blocking wait and its never-ran
+// undo. At shutdown a stop whose wait already STARTED commits never-ran
+// (one rule), but its job must NOT be re-registered: the in-flight wait
+// owns it, and re-adding it would hand cleanup a second unbounded
+// job.Stop() on the same instance (a hang for a wedged collector).
+// Conversely, once undone the wait becomes a no-op, so a command that
+// rolled back can never stop the job it just restored. The CAS makes the
+// two outcomes mutually exclusive across the effect and loop goroutines.
+type stagedJobStop struct {
+	// finalPhase marks a stop that is its effect's ONLY blocking phase
+	// (dyncfg disable/remove/restart-stop): its wait claims the effect
+	// completion before disarming the fence, making the stop-vs-deadline
+	// classification race-independent. An inner-phase stop (update's stop
+	// half runs in the same effect as the replacement's start) must NOT
+	// claim - the outermost closure owns completion.
+	finalPhase bool
+
+	m     *Manager
+	name  string
+	job   runtimeJob
+	had   bool
+	state atomic.Int32
+}
+
+func (m *Manager) newStagedJobStop(name string) *stagedJobStop {
+	s := &stagedJobStop{m: m, name: name}
+	s.job, s.had = m.stageStopRunningJob(name)
+	return s
+}
+
+func (m *Manager) newFinalPhaseStagedJobStop(name string) *stagedJobStop {
+	s := m.newStagedJobStop(name)
+	s.finalPhase = true
+	return s
+}
+
+// wait performs the blocking stop; a no-op when the command already undid
+// the stage (nothing may be stopped by a rolled-back command).
+func (s *stagedJobStop) wait(ctx context.Context) {
+	if !s.had || !s.state.CompareAndSwap(stagedStopPending, stagedStopWaiting) {
+		return
+	}
+	s.m.waitStoppedJob(ctx, s.name, s.job, s.finalPhase)
+}
+
+// undo re-registers the job when - and only when - the wait never started.
+func (s *stagedJobStop) undo() {
+	if !s.had || !s.state.CompareAndSwap(stagedStopPending, stagedStopUndone) {
+		return
+	}
+	s.m.undoStagedStop(s.name, s.job)
+}
+
+// waitStoppedJob is the blocking half of a staged stop: it fences the job's
+// output for the deadline path, waits out job.Stop, and drops the emission
+// gate on the normal path.
+func (m *Manager) waitStoppedJob(ctx context.Context, name string, job runtimeJob, finalPhase bool) {
 	// If this stop's deadline fires, the worker fences the job's output
 	// BEFORE the command's deadline outcome publishes: the gate captured
 	// HERE is the stopping job's own (never a by-name lookup - a same-name
@@ -652,17 +834,44 @@ func (m *Manager) stopRunningJob(ctx context.Context, name string) bool {
 		})
 	}
 
-	// Registry removals above happen before the blocking wait so function
-	// routing to the job ends as soon as the stop begins.
+	// Routing removal happened at stage time; only the blocking wait runs
+	// here.
 	job.Stop()
-	// The wait finished normally: disarm the fence. Completion claiming is
-	// the OUTERMOST closure's job - a stop may be an inner phase of a
-	// larger effect (update stops the old job before detecting the new).
-	effectControlFrom(ctx).clearQuarantine()
+	ctl := effectControlFrom(ctx)
+	if !finalPhase {
+		// Inner phase of a larger effect (update's stop half): completion
+		// claiming belongs to the outermost closure; disarm so a LATER
+		// phase's deadline cannot fence the cleanly stopped job.
+		ctl.clearQuarantine()
+	} else if ctl.claimCompletion() {
+		// The stop is its effect's only blocking phase: claim completion
+		// BEFORE disarming, so the classification cannot depend on the
+		// completion-vs-deadline race - a worker that abandoned during the
+		// stop, or wins between Stop returning and this claim, takes the
+		// STILL-ARMED fence and publishes the same stop success via
+		// ErrPhaseAbandoned. A completed stop classifying as an unfenced
+		// plain timeout (the broken-stop 500 + cache restore) is
+		// structurally impossible.
+		ctl.clearQuarantine()
+	}
 	// Tracking removal only on the normal path: the gate is never closed
 	// here, because a stopping job's in-flight flush and cleanup/obsoletion
-	// output must reach the wire.
+	// output must reach the wire. (On a lost claim the abandoning worker
+	// owns the captured gate handle; removing the registry entry does not
+	// affect it.)
 	m.emissionGates.remove(name)
+}
+
+// stopRunningJob stops the named job if it is running; it reports whether
+// THIS call found and stopped one (callers use it as the point-of-no-return
+// signal - a no-op stop tears nothing down). Stage and wait run inline on
+// the caller - the synchronous composition of the staged split.
+func (m *Manager) stopRunningJob(ctx context.Context, name string) bool {
+	job, ok := m.stageStopRunningJob(name)
+	if !ok {
+		return false
+	}
+	m.waitStoppedJob(ctx, name, job, false)
 	return true
 }
 

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -468,6 +468,7 @@ func TestFunctionReconcileFunnelConcurrentLifecycle(t *testing.T) {
 
 	stable := &tickProbeJob{fullName: "mod_stable", moduleName: "mod", name: "stable", collector: availability}
 	mgr.startRunningJob(stable)
+	mgr.publishRunningJobFunctions(stable.FullName())
 	available.Store(true)
 
 	var wg sync.WaitGroup
@@ -480,6 +481,7 @@ func TestFunctionReconcileFunnelConcurrentLifecycle(t *testing.T) {
 				fullName := fmt.Sprintf("mod_%s", name)
 				job := &tickProbeJob{fullName: fullName, moduleName: "mod", name: name, collector: availability}
 				mgr.startRunningJob(job)
+				mgr.publishRunningJobFunctions(fullName)
 				mgr.stopRunningJob(context.Background(), fullName)
 			}
 		}(worker)
@@ -544,7 +546,7 @@ func TestFunctionReconcileFunnelWithdrawsStoppedInstanceAfterInFlightPublish(t *
 		collector:  availability,
 	}
 	mgr.startRunningJob(job)
-	mgr.requestFunctionReconcile("mod")
+	mgr.publishRunningJobFunctions(job.FullName())
 
 	select {
 	case <-availabilityEntered:
@@ -568,6 +570,160 @@ func TestFunctionReconcileFunnelWithdrawsStoppedInstanceAfterInFlightPublish(t *
 	case <-time.After(2 * time.Second):
 		t.Fatal("runFunctionReconciler did not stop")
 	}
+}
+
+// MUST-NOT-FLIP: function routing to a stopping job is withdrawn BEFORE the
+// stop's blocking wait completes - the registry removal happens ahead of
+// job.Stop(), so a job wedged in its final collection cannot keep receiving
+// function dispatches while its stop is pending. The withdrawal must never
+// move behind the blocking wait.
+func TestFuncRoutingWithdrawal_PrecedesBlockingStopWait(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	reg := collectorapi.Registry{}
+	reg.Register("stuck", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		// The function registry tracks jobs only for modules that declare
+		// functions; routing withdrawal is observable through it.
+		InstanceFunctions: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "details"}}
+		},
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 {
+					select {
+					case entered <- struct{}{}:
+					default:
+					}
+					<-release
+					return map[string]int64{"d1": 1}
+				},
+			}
+		},
+	})
+
+	// The default effect deadline applies: the blocked stop must not abandon
+	// within the test window, so the pin observes a stop that is genuinely in
+	// its blocking wait.
+	h := startCharManager(t, reg)
+	t.Cleanup(func() { close(release) })
+
+	cfg := prepareDyncfgCfg("stuck", "s")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("stuck"), "add", "s"}, []byte("{}"))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+	require.Eventually(t, func() bool {
+		return slices.Contains(h.mgr.GetJobNames("stuck"), "s")
+	}, charWait, charTick, "the running job must be routable")
+
+	select {
+	case <-entered:
+	case <-time.After(charWait):
+		t.Fatal("no collection started")
+	}
+
+	h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+
+	require.Eventually(t, func() bool {
+		return !slices.Contains(h.mgr.GetJobNames("stuck"), "s")
+	}, charWait, charTick, "routing must be withdrawn while the stop is still blocked")
+	assert.False(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable")(),
+		"the withdrawal must precede the stop's completion, not follow its terminal")
+
+	release <- struct{}{}
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable 200"), charWait, charTick,
+		"the released stop must complete normally")
+}
+
+// MUST-NOT-FLIP: function-routing withdrawal happens when the stop command
+// STAGES, not when its effect reaches a pool worker - a saturated effect
+// pool must not extend routing to a job the user asked to stop. The blocking
+// wait itself may then run (or wedge) arbitrarily late.
+func TestFuncRoutingWithdrawal_ProceedsWhilePoolSaturated(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAll := func() { releaseOnce.Do(func() { close(release) }) }
+
+	var detStarted atomic.Int32
+	reg := collectorapi.Registry{}
+	reg.Register("stuck", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		InstanceFunctions: func(collectorapi.RuntimeJob) []funcapi.FunctionConfig {
+			return []funcapi.FunctionConfig{{ID: "details"}}
+		},
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 {
+					select {
+					case entered <- struct{}{}:
+					default:
+					}
+					<-release
+					return map[string]int64{"d1": 1}
+				},
+			}
+		},
+	})
+	reg.Register("wedge", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					detStarted.Add(1)
+					<-release
+					return nil
+				},
+			}
+		},
+	})
+
+	h := startCharManager(t, reg)
+	t.Cleanup(releaseAll)
+
+	cfg := prepareDyncfgCfg("stuck", "s")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("stuck"), "add", "s"}, []byte("{}"))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:stuck:s status running"), charWait, charTick)
+	require.Eventually(t, func() bool {
+		return slices.Contains(h.mgr.GetJobNames("stuck"), "s")
+	}, charWait, charTick, "the running job must be routable")
+	select {
+	case <-entered:
+	case <-time.After(charWait):
+		t.Fatal("no collection started")
+	}
+
+	// Pin every pool worker inside a blocked detection: detection i can only
+	// dispatch after validate i completed, so every validate finds a free
+	// slot and the detections then occupy all workers.
+	for i := range effectPoolSize {
+		name := string(rune('a' + i))
+		h.dyncfg("w-add-"+name, []string{h.mgr.dyncfgModID("wedge"), "add", name}, []byte("{}"))
+		h.dyncfg("w-en-"+name, []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("wedge", name)), "enable"}, nil)
+	}
+	require.Eventually(t, func() bool { return detStarted.Load() == int32(effectPoolSize) }, charWait, charTick,
+		"every pool worker must be inside a blocked detection")
+
+	// The disable's stop effect cannot reach a worker; the stage must still
+	// withdraw routing immediately.
+	h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+	require.Eventually(t, func() bool {
+		return !slices.Contains(h.mgr.GetJobNames("stuck"), "s")
+	}, charWait, charTick, "routing must be withdrawn while the stop effect is starved of a pool slot")
+	assert.False(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable")(),
+		"the stop effect must not have run yet - withdrawal happened at stage time")
+
+	releaseAll()
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable 200"), charWait, charTick,
+		"the released stop must complete normally")
 }
 
 func TestManagerAddConfigSingleInstancePolicy(t *testing.T) {
@@ -728,7 +884,7 @@ func TestRun_RegistersAgentScopeModuleMethodsBeforeAnyJobStarts(t *testing.T) {
 	assert.Equal(t, []string{"mod:a"}, fnReg.registeredNames())
 }
 
-func TestStartRunningJob_RegistersModuleMethodsAfterReconcile(t *testing.T) {
+func TestPublishRunningJobFunctions_RegistersModuleMethodsAfterReconcile(t *testing.T) {
 	fnReg := &recordingFunctionRegistry{}
 	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
 	creator := collectorapi.Creator{
@@ -741,6 +897,7 @@ func TestStartRunningJob_RegistersModuleMethodsAfterReconcile(t *testing.T) {
 
 	job := &lockProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"}
 	mgr.startRunningJob(job)
+	mgr.publishRunningJobFunctions(job.FullName())
 
 	assert.Empty(t, fnReg.registeredNames())
 
@@ -749,7 +906,7 @@ func TestStartRunningJob_RegistersModuleMethodsAfterReconcile(t *testing.T) {
 	assert.ElementsMatch(t, []string{"mod:a", "mod:b"}, fnReg.registeredNames())
 }
 
-func TestStartRunningJob_ReconcileDoesNotReregisterModuleMethods(t *testing.T) {
+func TestPublishRunningJobFunctions_ReconcileDoesNotReregisterModuleMethods(t *testing.T) {
 	fnReg := &recordingFunctionRegistry{}
 	mgr := New(Config{PluginName: testPluginName, FnReg: fnReg})
 	creator := collectorapi.Creator{
@@ -762,10 +919,12 @@ func TestStartRunningJob_ReconcileDoesNotReregisterModuleMethods(t *testing.T) {
 
 	job1 := &lockProbeJob{fullName: "mod_job1", moduleName: "mod", name: "job1"}
 	mgr.startRunningJob(job1)
+	mgr.publishRunningJobFunctions(job1.FullName())
 	mgr.funcCtl.ReconcileModuleMethods("mod")
 
 	job2 := &lockProbeJob{fullName: "mod_job2", moduleName: "mod", name: "job2"}
 	mgr.startRunningJob(job2)
+	mgr.publishRunningJobFunctions(job2.FullName())
 	mgr.funcCtl.ReconcileModuleMethods("mod")
 
 	registered := fnReg.registeredNames()
@@ -922,14 +1081,15 @@ func (j *lockProbeJob) Tick(_ int) {
 		<-j.tickRelease
 	})
 }
-func (j *lockProbeJob) AutoDetection(context.Context) error { return nil }
-func (j *lockProbeJob) AutoDetectionEvery() int             { return 0 }
-func (j *lockProbeJob) RetryAutoDetection() bool            { return false }
-func (j *lockProbeJob) Cleanup()                            {}
-func (j *lockProbeJob) IsRunning() bool                     { return true }
-func (j *lockProbeJob) Panicked() bool                      { return false }
-func (j *lockProbeJob) Vnode() vnodes.VirtualNode           { return vnodes.VirtualNode{} }
-func (j *lockProbeJob) UpdateVnode(_ *vnodes.VirtualNode)   {}
+func (j *lockProbeJob) AutoDetection(context.Context) error    { return nil }
+func (j *lockProbeJob) AutoDetectionEvery() int                { return 0 }
+func (j *lockProbeJob) RetryAutoDetection() bool               { return false }
+func (j *lockProbeJob) Cleanup()                               {}
+func (j *lockProbeJob) IsRunning() bool                        { return true }
+func (j *lockProbeJob) Panicked() bool                         { return false }
+func (j *lockProbeJob) Vnode() vnodes.VirtualNode              { return vnodes.VirtualNode{} }
+func (j *lockProbeJob) UpdateVnode(_ *vnodes.VirtualNode)      {}
+func (j *lockProbeJob) SetVnodeBaseline(_ *vnodes.VirtualNode) {}
 
 type tickProbeJob struct {
 	fullName   string
@@ -938,21 +1098,22 @@ type tickProbeJob struct {
 	collector  any
 }
 
-func (j *tickProbeJob) FullName() string                    { return j.fullName }
-func (j *tickProbeJob) ModuleName() string                  { return j.moduleName }
-func (j *tickProbeJob) Name() string                        { return j.name }
-func (j *tickProbeJob) Collector() any                      { return j.collector }
-func (j *tickProbeJob) Start()                              {}
-func (j *tickProbeJob) Stop()                               {}
-func (j *tickProbeJob) Tick(int)                            {}
-func (j *tickProbeJob) AutoDetection(context.Context) error { return nil }
-func (j *tickProbeJob) AutoDetectionEvery() int             { return 0 }
-func (j *tickProbeJob) RetryAutoDetection() bool            { return false }
-func (j *tickProbeJob) Cleanup()                            {}
-func (j *tickProbeJob) IsRunning() bool                     { return true }
-func (j *tickProbeJob) Panicked() bool                      { return false }
-func (j *tickProbeJob) Vnode() vnodes.VirtualNode           { return vnodes.VirtualNode{} }
-func (j *tickProbeJob) UpdateVnode(_ *vnodes.VirtualNode)   {}
+func (j *tickProbeJob) FullName() string                       { return j.fullName }
+func (j *tickProbeJob) ModuleName() string                     { return j.moduleName }
+func (j *tickProbeJob) Name() string                           { return j.name }
+func (j *tickProbeJob) Collector() any                         { return j.collector }
+func (j *tickProbeJob) Start()                                 {}
+func (j *tickProbeJob) Stop()                                  {}
+func (j *tickProbeJob) Tick(int)                               {}
+func (j *tickProbeJob) AutoDetection(context.Context) error    { return nil }
+func (j *tickProbeJob) AutoDetectionEvery() int                { return 0 }
+func (j *tickProbeJob) RetryAutoDetection() bool               { return false }
+func (j *tickProbeJob) Cleanup()                               {}
+func (j *tickProbeJob) IsRunning() bool                        { return true }
+func (j *tickProbeJob) Panicked() bool                         { return false }
+func (j *tickProbeJob) Vnode() vnodes.VirtualNode              { return vnodes.VirtualNode{} }
+func (j *tickProbeJob) UpdateVnode(_ *vnodes.VirtualNode)      {}
+func (j *tickProbeJob) SetVnodeBaseline(_ *vnodes.VirtualNode) {}
 
 type managerFunctionAvailability struct {
 	fn func(string) bool

--- a/src/go/plugin/agent/jobmgr/runtime_job.go
+++ b/src/go/plugin/agent/jobmgr/runtime_job.go
@@ -31,6 +31,10 @@ type runtimeJob interface {
 
 	Vnode() vnodes.VirtualNode
 	UpdateVnode(vnode *vnodes.VirtualNode)
+	// SetVnodeBaseline commits a vnode config into the job pre-Start
+	// (visible to cleanup without a collection; never drains a queued
+	// live update). Callers must not use it on a started job.
+	SetVnodeBaseline(vnode *vnodes.VirtualNode)
 }
 
 // configModule is the shared Init/Check/config contract for dyncfg config test/get

--- a/src/go/plugin/agent/jobmgr/secretsctl/cache.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/cache.go
@@ -43,7 +43,7 @@ func (c *Controller) RememberDiscoveredConfig(cfg secretstore.Config) (Entry, bo
 }
 
 func (c *Controller) rememberDiscoveredConfig(cfg secretstore.Config) (*dyncfg.Entry[secretstore.Config], bool, error) {
-	if err := c.validateConfig(cfg); err != nil {
+	if err := c.validateConfig(context.Background(), cfg); err != nil {
 		return nil, false, err
 	}
 
@@ -63,7 +63,6 @@ func (c *Controller) rememberDiscoveredConfig(cfg secretstore.Config) (*dyncfg.E
 
 	if entry.Status == dyncfg.StatusRunning || entry.Status == dyncfg.StatusFailed {
 		c.cb.Stop(context.Background(), entry.Cfg)
-		c.cb.TakeCommandMessage()
 	}
 
 	entry = c.handler.AddDiscoveredConfig(cfg, dyncfg.StatusAccepted)
@@ -86,22 +85,24 @@ func (c *Controller) removeDiscoveredConfig(cfg secretstore.Config) (*dyncfg.Ent
 	}
 
 	c.cb.Stop(context.Background(), entry.Cfg)
-	c.cb.TakeCommandMessage()
 	c.handler.NotifyConfigRemove(entry.Cfg)
 	return entry, true
 }
 
-func (c *Controller) validateConfig(cfg secretstore.Config) error {
+// validateConfig validates against the backend under the caller's context:
+// effect callers thread the executor's deadline/cancellation so backend I/O
+// never outlives its command.
+func (c *Controller) validateConfig(ctx context.Context, cfg secretstore.Config) error {
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
 	if c.service == nil {
 		return fmt.Errorf("secretstore service is not available")
 	}
-	return c.service.Validate(secretStoreResolveContext(context.Background(), c.Logger, cfg), cfg)
+	return c.service.Validate(secretStoreResolveContext(ctx, c.Logger, cfg), cfg)
 }
 
-func (c *Controller) validateStored(key string) error {
+func (c *Controller) validateStored(ctx context.Context, key string) error {
 	entry, ok := c.lookupInternal(key)
 	if !ok {
 		return secretstore.ErrStoreNotFound
@@ -111,10 +112,10 @@ func (c *Controller) validateStored(key string) error {
 	}
 
 	if _, ok := c.service.GetStatus(key); ok {
-		return c.service.ValidateStored(secretStoreResolveContextForKey(context.Background(), c.Logger, key, entry.Cfg.Kind(), entry.Cfg.Name()), key)
+		return c.service.ValidateStored(secretStoreResolveContextForKey(ctx, c.Logger, key, entry.Cfg.Kind(), entry.Cfg.Name()), key)
 	}
 
-	return c.validateConfig(entry.Cfg)
+	return c.validateConfig(ctx, entry.Cfg)
 }
 
 func (c *Controller) affectedJobsFor(storeKey string) []secretstore.JobRef {

--- a/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/callbacks.go
@@ -4,7 +4,6 @@ package secretsctl
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -16,17 +15,12 @@ import (
 
 type secretStoreCallbacks struct {
 	deps secretStoreCallbackDeps
-	// commandMessage is written by Start/Update/Stop and consumed by
-	// TakeCommandMessage. Safety relies on callbacks remaining serialized by
-	// the jobmgr dyncfg command flow.
-	commandMessage string
 }
 
 type secretStoreCallbackDeps struct {
-	pluginName           string
-	log                  *logger.Logger
-	service              secretstore.Service
-	restartDependentJobs func(string) string
+	pluginName string
+	log        *logger.Logger
+	service    secretstore.Service
 }
 
 type codedError struct {
@@ -42,11 +36,30 @@ func newSecretStoreCallbacks(deps secretStoreCallbackDeps) *secretStoreCallbacks
 	return &secretStoreCallbacks{deps: deps}
 }
 
-func (d secretStoreCallbackDeps) restartDependentJobsMessage(storeKey string) string {
-	if d.restartDependentJobs == nil {
-		return ""
+// runStagedRestarts executes the command's staged dependent-restart plan (if
+// any rides the effect context): the message goes to the command's terminal,
+// the buffered per-job state/status commits replay on the loop before it.
+// The returned error is non-nil when the deadline cut the sequence short -
+// mutating callbacks MUST return it, so the command classifies as the
+// timeout failure regardless of whether the effect's return or the worker's
+// abandon wins their select race. That guarantee is enforced HERE as a
+// TOTAL post-condition, not only by the plan's own checkpoints: a sequence
+// returning success while the command's window has already expired (the
+// deadline fired DURING a restart, or after the last one - a per-checkpoint
+// cut check cannot see either) is reclassified as the timeout failure, so
+// no restart pipeline can under-report deadline degradation.
+func runStagedRestarts(ctx context.Context) error {
+	r := storeCommandRunFrom(ctx)
+	if r == nil || r.staged == nil {
+		return nil
 	}
-	return d.restartDependentJobs(storeKey)
+	msg, err := r.staged.Run(ctx)
+	r.setMessage(msg)
+	dyncfg.SetCommandMessage(ctx, msg)
+	if err == nil && ctx.Err() != nil {
+		err = fmt.Errorf("the store operation timed out during the dependent restarts")
+	}
+	return err
 }
 
 func (d secretStoreCallbackDeps) extractSecretStoreKindFromTemplateID(id string) (secretstore.StoreKind, bool) {
@@ -139,7 +152,10 @@ func (cb *secretStoreCallbacks) ValidateConfigName(name string) error {
 	return dyncfg.JobNameRuleAllowDots(name)
 }
 
-func (cb *secretStoreCallbacks) ParseAndValidate(ctx context.Context, fn dyncfg.Function, name string) (secretstore.Config, error) {
+// parseStorePayload is the CHEAP, deterministic parse prefix of
+// ParseAndValidate (no backend I/O), shared with ParsePayload so the stage
+// gate and the effect produce identical outcomes for identical inputs.
+func (cb *secretStoreCallbacks) parseStorePayload(fn dyncfg.Function, name string) (secretstore.Config, error) {
 	var kind secretstore.StoreKind
 	if fn.Command() == dyncfg.CommandAdd {
 		var ok bool
@@ -159,7 +175,18 @@ func (cb *secretStoreCallbacks) ParseAndValidate(ctx context.Context, fn dyncfg.
 		}
 	}
 
-	cfg, err := cb.deps.secretStoreConfigFromPayload(fn, name, kind)
+	return cb.deps.secretStoreConfigFromPayload(fn, name, kind)
+}
+
+// ParsePayload implements dyncfg.PayloadParser: malformed payloads answer
+// their 400 at stage, before any claim or effect.
+func (cb *secretStoreCallbacks) ParsePayload(fn dyncfg.Function, name string) error {
+	_, err := cb.parseStorePayload(fn, name)
+	return err
+}
+
+func (cb *secretStoreCallbacks) ParseAndValidate(ctx context.Context, fn dyncfg.Function, name string) (secretstore.Config, error) {
+	cfg, err := cb.parseStorePayload(fn, name)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +197,6 @@ func (cb *secretStoreCallbacks) ParseAndValidate(ctx context.Context, fn dyncfg.
 }
 
 func (cb *secretStoreCallbacks) Start(ctx context.Context, cfg secretstore.Config) error {
-	cb.commandMessage = ""
 	key := cfg.ExposedKey()
 	if cb.deps.service == nil {
 		return &codedError{err: fmt.Errorf("secretstore service is not available"), code: 400}
@@ -183,13 +209,21 @@ func (cb *secretStoreCallbacks) Start(ctx context.Context, cfg secretstore.Confi
 	} else if err := cb.deps.service.Add(cb.deps.resolveContext(ctx, cfg), cfg); err != nil {
 		return &codedError{err: err, code: secretStoreErrorCode(err)}
 	}
+	markCommandActivated(ctx)
 
-	cb.commandMessage = cb.deps.restartDependentJobsMessage(key)
-	return nil
+	return runStagedRestarts(ctx)
+}
+
+// markCommandActivated flips the command run's activation marker (when one
+// rides the context): failures from here on are applied-but-degraded, not
+// validation-class.
+func markCommandActivated(ctx context.Context) {
+	if r := storeCommandRunFrom(ctx); r != nil {
+		r.markActivated()
+	}
 }
 
 func (cb *secretStoreCallbacks) Update(ctx context.Context, oldCfg, newCfg secretstore.Config) error {
-	cb.commandMessage = ""
 	key := oldCfg.ExposedKey()
 	if cb.deps.service == nil {
 		return &codedError{err: fmt.Errorf("secretstore service is not available"), code: 400}
@@ -202,34 +236,26 @@ func (cb *secretStoreCallbacks) Update(ctx context.Context, oldCfg, newCfg secre
 	} else if err := cb.deps.service.Add(cb.deps.resolveContext(ctx, newCfg), newCfg); err != nil {
 		return &codedError{err: err, code: secretStoreErrorCode(err)}
 	}
+	markCommandActivated(ctx)
 
-	cb.commandMessage = cb.deps.restartDependentJobsMessage(key)
-	return nil
+	return runStagedRestarts(ctx)
 }
 
-func (cb *secretStoreCallbacks) Stop(_ context.Context, cfg secretstore.Config) {
-	cb.commandMessage = ""
+func (cb *secretStoreCallbacks) Stop(ctx context.Context, cfg secretstore.Config) {
 	key := cfg.ExposedKey()
 	if cb.deps.service == nil {
 		return
 	}
 
 	if err := cb.deps.service.Remove(key); err != nil {
-		if errors.Is(err, secretstore.ErrStoreNotFound) {
-			return
-		}
 		return
 	}
-	cb.commandMessage = cb.deps.restartDependentJobsMessage(key)
+	// Stop has no error return by the handler contract: a deadline-cut
+	// sequence still reports the skipped dependents through the message.
+	_ = runStagedRestarts(ctx)
 }
 
 func (*secretStoreCallbacks) OnStatusChange(*dyncfg.Entry[secretstore.Config], dyncfg.Status, dyncfg.Function) {
-}
-
-func (cb *secretStoreCallbacks) TakeCommandMessage() string {
-	msg := strings.TrimSpace(cb.commandMessage)
-	cb.commandMessage = ""
-	return msg
 }
 
 func (cb *secretStoreCallbacks) ConfigID(cfg secretstore.Config) string {

--- a/src/go/plugin/agent/jobmgr/secretsctl/callbacks_test.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/callbacks_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
@@ -29,14 +30,13 @@ func TestSecretStoreCallbacks(t *testing.T) {
 				assert.Equal(t, secretstore.StoreKey(secretstore.KindVault, "vault_prod"), key)
 				assert.Equal(t, "vault_prod", name)
 
-				cfg, err := cb.ParseAndValidate(context.Background(), addFn, name)
+				cfg, err := cb.ParseAndValidate(restart.ctx(key), addFn, name)
 				require.NoError(t, err)
 				assert.Empty(t, restart.calls)
-				assert.Equal(t, "", cb.TakeCommandMessage())
 
-				require.NoError(t, cb.Start(context.Background(), cfg))
+				require.NoError(t, cb.Start(restart.ctx(key), cfg))
 				assert.Equal(t, []string{key}, restart.calls)
-				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
+				assert.Equal(t, "restart:"+key, restart.takeMessage())
 				assert.Equal(t, testSecretStoreConfigID(key), cb.ConfigID(cfg))
 
 				status, ok := svc.GetStatus(key)
@@ -51,18 +51,18 @@ func TestSecretStoreCallbacks(t *testing.T) {
 				assert.Equal(t, key, updateKey)
 				assert.Equal(t, name, updateName)
 
-				updatedCfg, err := cb.ParseAndValidate(context.Background(), updateFn, "")
+				updatedCfg, err := cb.ParseAndValidate(restart.ctx(key), updateFn, "")
 				require.NoError(t, err)
 				assert.Len(t, restart.calls, 1)
 
-				require.NoError(t, cb.Update(context.Background(), cfg, updatedCfg))
+				require.NoError(t, cb.Update(restart.ctx(key), cfg, updatedCfg))
 				assert.Equal(t, []string{key, key}, restart.calls)
-				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
+				assert.Equal(t, "restart:"+key, restart.takeMessage())
 				assert.Equal(t, "two", resolveTestStoreValue(t, svc, key))
 
-				cb.Stop(context.Background(), updatedCfg)
+				cb.Stop(restart.ctx(key), updatedCfg)
 				assert.Equal(t, []string{key, key, key}, restart.calls)
-				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
+				assert.Equal(t, "restart:"+key, restart.takeMessage())
 				_, ok = svc.GetStatus(key)
 				assert.False(t, ok)
 			},
@@ -73,31 +73,30 @@ func TestSecretStoreCallbacks(t *testing.T) {
 				key, name, ok := cb.ExtractKey(addFn)
 				require.True(t, ok)
 
-				cfg, err := cb.ParseAndValidate(context.Background(), addFn, name)
+				cfg, err := cb.ParseAndValidate(restart.ctx(key), addFn, name)
 				require.NoError(t, err)
 				assert.Empty(t, restart.calls)
 
 				assert.Equal(t, testSecretStoreConfigID(key), cb.ConfigID(cfg))
-				assert.Equal(t, "", cb.TakeCommandMessage())
 				cb.OnStatusChange(nil, dyncfg.StatusAccepted, addFn)
 				assert.Empty(t, restart.calls)
 
-				require.NoError(t, cb.Start(context.Background(), cfg))
+				require.NoError(t, cb.Start(restart.ctx(key), cfg))
 				assert.Equal(t, []string{key}, restart.calls)
-				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
+				assert.Equal(t, "restart:"+key, restart.takeMessage())
 
 				updateFn := newSecretStoreCallbackFunction(t, "ss-mutate-update", testSecretStoreConfigID(key), dyncfg.CommandUpdate, "", map[string]any{"value": "two"})
-				updatedCfg, err := cb.ParseAndValidate(context.Background(), updateFn, "")
+				updatedCfg, err := cb.ParseAndValidate(restart.ctx(key), updateFn, "")
 				require.NoError(t, err)
 				assert.Len(t, restart.calls, 1)
 
-				require.NoError(t, cb.Update(context.Background(), cfg, updatedCfg))
+				require.NoError(t, cb.Update(restart.ctx(key), cfg, updatedCfg))
 				assert.Equal(t, []string{key, key}, restart.calls)
-				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
+				assert.Equal(t, "restart:"+key, restart.takeMessage())
 
-				cb.Stop(context.Background(), updatedCfg)
+				cb.Stop(restart.ctx(key), updatedCfg)
 				assert.Equal(t, []string{key, key, key}, restart.calls)
-				assert.Equal(t, "restart:"+key, cb.TakeCommandMessage())
+				assert.Equal(t, "restart:"+key, restart.takeMessage())
 			},
 		},
 	}
@@ -110,8 +109,148 @@ func TestSecretStoreCallbacks(t *testing.T) {
 	}
 }
 
+// A deadline-cut restart sequence must fail the mutating callbacks: the
+// commands' classification cannot depend on whether the effect's return or
+// the worker's abandon wins their select race, so the cut error is returned
+// (Start/Update), never swallowed into the message alone. Stop keeps the
+// handler's void contract - the message still reports the skips.
+func TestSecretStoreCallbacks_DeadlineCutRestartsFailMutations(t *testing.T) {
+	cb, _, restart := newSecretStoreCallbacksTestSubject()
+	cutErr := fmt.Errorf("the store operation timed out before all dependent restarts started")
+	restart.runErr = cutErr
+
+	addFn := newSecretStoreCallbackFunction(t, "ss-add", testSecretStoreTemplateID(secretstore.KindVault), dyncfg.CommandAdd, "vault_prod", map[string]any{"value": "one"})
+	key, name, ok := cb.ExtractKey(addFn)
+	require.True(t, ok)
+	cfg, err := cb.ParseAndValidate(restart.ctx(key), addFn, name)
+	require.NoError(t, err)
+
+	err = cb.Start(restart.ctx(key), cfg)
+	assert.ErrorIs(t, err, cutErr, "Start must return the cut error, not swallow it into the message")
+	assert.Equal(t, "restart:"+key, restart.takeMessage(), "the skip report still reaches the terminal message")
+
+	updateFn := newSecretStoreCallbackFunction(t, "ss-update", testSecretStoreConfigID(key), dyncfg.CommandUpdate, "", map[string]any{"value": "two"})
+	updatedCfg, err := cb.ParseAndValidate(restart.ctx(key), updateFn, "")
+	require.NoError(t, err)
+	err = cb.Update(restart.ctx(key), cfg, updatedCfg)
+	assert.ErrorIs(t, err, cutErr, "Update must return the cut error, not swallow it into the message")
+
+	cb.Stop(restart.ctx(key), updatedCfg)
+	assert.Equal(t, "restart:"+key, restart.takeMessage(), "Stop keeps its void contract but still reports through the message")
+}
+
+// The custom commit paths (add, conversion) classify plain failures by
+// PHASE via the run box's activation marker: coded errors keep their codes;
+// a plain error AFTER activation is the applied-but-degraded partial
+// outcome (200, like the shared update path - 400 would misreport an
+// applied mutation as a bad request); a plain error BEFORE activation is
+// validation-class.
+func TestStoreCommandRun_CommandCodeByPhase(t *testing.T) {
+	tests := map[string]struct {
+		err       error
+		activated bool
+		want      int
+	}{
+		"coded error keeps its code regardless of phase": {
+			err:       &codedError{err: fmt.Errorf("nope"), code: 409},
+			activated: true,
+			want:      409,
+		},
+		"plain error after activation is the applied-but-degraded 200": {
+			err:       fmt.Errorf("the store operation timed out during the dependent restarts"),
+			activated: true,
+			want:      200,
+		},
+		"plain error before activation is validation-class 400": {
+			err:       fmt.Errorf("value is required"),
+			activated: false,
+			want:      400,
+		},
+		"store-not-found before activation maps to 404": {
+			err:       secretstore.ErrStoreNotFound,
+			activated: false,
+			want:      404,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := &storeCommandRun{}
+			if tc.activated {
+				r.markActivated()
+			}
+			assert.Equal(t, tc.want, r.commandCode(tc.err))
+		})
+	}
+}
+
+// The race-independent classification is a TOTAL post-condition at the
+// restart seam, not only a per-checkpoint duty inside the plan: a restart
+// sequence reporting NO error while the command's window has expired (the
+// deadline fired DURING a restart, or right after the last one - shapes the
+// plan's own cut checkpoints cannot see) must still fail the mutating
+// callbacks, or the closure-wins arm of the completion race would classify
+// the same physical timeout as success.
+func TestSecretStoreCallbacks_ExpiredWindowFailsMutationsWithoutRunError(t *testing.T) {
+	cb, _, restart := newSecretStoreCallbacksTestSubject()
+
+	expired, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	addFn := newSecretStoreCallbackFunction(t, "ss-add", testSecretStoreTemplateID(secretstore.KindVault), dyncfg.CommandAdd, "vault_prod", map[string]any{"value": "one"})
+	key, name, ok := cb.ExtractKey(addFn)
+	require.True(t, ok)
+	cfg, err := cb.ParseAndValidate(restart.ctx(key), addFn, name)
+	require.NoError(t, err)
+
+	err = cb.Start(restart.ctxOn(expired, key), cfg)
+	require.Error(t, err, "an expired command window must fail the mutation even when the restart run reports no error")
+	assert.Contains(t, err.Error(), "timed out")
+	assert.Equal(t, "restart:"+key, restart.takeMessage(), "the per-dependent report still reaches the terminal message")
+
+	updateFn := newSecretStoreCallbackFunction(t, "ss-update", testSecretStoreConfigID(key), dyncfg.CommandUpdate, "", map[string]any{"value": "two"})
+	updatedCfg, err := cb.ParseAndValidate(restart.ctx(key), updateFn, "")
+	require.NoError(t, err)
+	err = cb.Update(restart.ctxOn(expired, key), cfg, updatedCfg)
+	require.Error(t, err, "Update must reclassify an expired-window success the same way")
+	assert.Contains(t, err.Error(), "timed out")
+}
+
+// secretStoreCallbackRestartRecorder plays the command-run box: it records
+// restart-seam invocations and captures the message the callbacks store for
+// the terminal. runErr, when set, plays a deadline-cut restart sequence.
 type secretStoreCallbackRestartRecorder struct {
-	calls []string
+	calls  []string
+	box    *storeCommandRun
+	runErr error
+}
+
+// ctx returns an effect context carrying a command run whose staged restart
+// records the given store key.
+func (r *secretStoreCallbackRestartRecorder) ctx(storeKey string) context.Context {
+	return r.ctxOn(context.Background(), storeKey)
+}
+
+// ctxOn is ctx on an arbitrary parent (an expired one plays a command whose
+// deadline fired during the restart sequence).
+func (r *secretStoreCallbackRestartRecorder) ctxOn(parent context.Context, storeKey string) context.Context {
+	r.box = &storeCommandRun{
+		staged: &StagedRestarts{
+			Run: func(context.Context) (string, error) {
+				r.calls = append(r.calls, storeKey)
+				return "restart:" + storeKey, r.runErr
+			},
+			Flush: func() {},
+		},
+	}
+	return withStoreCommandRun(parent, r.box)
+}
+
+func (r *secretStoreCallbackRestartRecorder) takeMessage() string {
+	if r.box == nil {
+		return ""
+	}
+	return r.box.takeMessage()
 }
 
 func newSecretStoreCallbacksTestSubject() (*secretStoreCallbacks, secretstore.Service, *secretStoreCallbackRestartRecorder) {
@@ -120,10 +259,6 @@ func newSecretStoreCallbacksTestSubject() (*secretStoreCallbacks, secretstore.Se
 	cb := newSecretStoreCallbacks(secretStoreCallbackDeps{
 		pluginName: testPluginName,
 		service:    svc,
-		restartDependentJobs: func(storeKey string) string {
-			restart.calls = append(restart.calls, storeKey)
-			return "restart:" + storeKey
-		},
 	})
 	return cb, svc, restart
 }

--- a/src/go/plugin/agent/jobmgr/secretsctl/commandacts_test.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/commandacts_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package secretsctl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestControllerCommandActsParity drives StepExec across the deterministic
+// stage-gate matrix and asserts CommandActs agrees: blocking work runs (the
+// step runner is invoked) exactly when CommandActs reports true. Claim
+// scheduling relies on this predicate to skip claims for rejection-only
+// store commands - a stage-gate change without a matching CommandActs update
+// fails here as the starvation bug it would be. The deliberate exception
+// class: remove of any EXISTING store "acts" even when it will reject -
+// its affected-jobs check reads the dependency index, which must be
+// excluded by the granted store write claim, so that 409 AND the handler's
+// source/type 405s ordered behind it answer under the claim without
+// blocking work - those cells assert the exception explicitly via wantRan.
+func TestControllerCommandActsParity(t *testing.T) {
+	const storeName = "vault_prod"
+	storeKey := secretstore.StoreKey(secretstore.KindVault, storeName)
+	garbagePayload := []byte(`{"value": `)
+
+	newFn := func(t *testing.T, ctl *Controller, cmd dyncfg.Command, id string, name string, payload []byte) dyncfg.Function {
+		t.Helper()
+		args := []string{id, string(cmd)}
+		if name != "" {
+			args = append(args, name)
+		}
+		f := functions.Function{UID: "parity", Args: args, Payload: payload}
+		if payload != nil {
+			f.ContentType = "application/json"
+		}
+		return dyncfg.NewFunction(f)
+	}
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := map[string]struct {
+		seedDyncfg bool // seed a dyncfg-sourced store via the custom add
+		seedFile   bool // seed a file-sourced store (the conversion source)
+		affected   bool // seed dependent refs (the remove 409 arm)
+		fn         func(t *testing.T, ctl *Controller) dyncfg.Function
+		wantActs   bool
+		wantRan    *bool // nil: strict parity (ran == wantActs); non-nil: documented exception
+	}{
+		"enable is unsupported and rejection-only": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandEnable, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: false,
+		},
+		"restart is unsupported and rejection-only": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandRestart, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: false,
+		},
+		"disable is unsupported and rejection-only": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandDisable, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: false,
+		},
+		"add of a new store acts": {
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandAdd, ctl.templateID(secretstore.KindVault), storeName, mustJSON(t, map[string]any{"value": "good"}))
+			},
+			wantActs: true,
+		},
+		"add of an existing store is rejection-only": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandAdd, ctl.templateID(secretstore.KindVault), storeName, mustJSON(t, map[string]any{"value": "good"}))
+			},
+			wantActs: false,
+		},
+		"add without payload is rejection-only": {
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandAdd, ctl.templateID(secretstore.KindVault), storeName, nil)
+			},
+			wantActs: false,
+		},
+		"add with unparsable payload is rejection-only": {
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandAdd, ctl.templateID(secretstore.KindVault), storeName, garbagePayload)
+			},
+			wantActs: false,
+		},
+		"update of a dyncfg store acts": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandUpdate, ctl.configID(storeKey), "", mustJSON(t, map[string]any{"value": "rotated"}))
+			},
+			wantActs: true,
+		},
+		"update of a missing store is rejection-only": {
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandUpdate, ctl.configID(storeKey), "", mustJSON(t, map[string]any{"value": "rotated"}))
+			},
+			wantActs: false,
+		},
+		"update without payload is rejection-only": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandUpdate, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: false,
+		},
+		"update of a dyncfg store with unparsable payload is rejection-only": {
+			// The PayloadParser stage gate in the shared handler's
+			// updateRejection: the parse prefix answers 400 before any claim
+			// or effect.
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandUpdate, ctl.configID(storeKey), "", garbagePayload)
+			},
+			wantActs: false,
+		},
+		"conversion update of a file store acts": {
+			seedFile: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandUpdate, ctl.configID(storeKey), "", mustJSON(t, map[string]any{"value": "override"}))
+			},
+			wantActs: true,
+		},
+		"conversion update without payload is rejection-only": {
+			seedFile: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandUpdate, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: false,
+		},
+		"conversion update with unparsable payload is rejection-only": {
+			seedFile: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandUpdate, ctl.configID(storeKey), "", garbagePayload)
+			},
+			wantActs: false,
+		},
+		"remove of an unreferenced store acts": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandRemove, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: true,
+		},
+		"remove of a missing store is rejection-only": {
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandRemove, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: false,
+		},
+		"remove of a referenced store acts but answers 409 under the claim": {
+			seedDyncfg: true,
+			affected:   true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandRemove, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: true,
+			wantRan:  boolPtr(false),
+		},
+		"remove of a file store acts but answers 405 under the claim": {
+			// The source gate sits BEHIND the affected-jobs read in the
+			// remove's execution order, so it cannot be answered claimlessly.
+			seedFile: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandRemove, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: true,
+			wantRan:  boolPtr(false),
+		},
+		"remove of a referenced file store acts but answers 409 under the claim": {
+			seedFile: true,
+			affected: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandRemove, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: true,
+			wantRan:  boolPtr(false),
+		},
+		"payloadless test of an existing store acts": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandTest, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: true,
+		},
+		"payloadless test of a missing store is rejection-only": {
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandTest, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: false,
+		},
+		"payload test of an existing store acts": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandTest, ctl.configID(storeKey), "", mustJSON(t, map[string]any{"value": "candidate"}))
+			},
+			wantActs: true,
+		},
+		"payload test of a missing store is rejection-only": {
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandTest, ctl.configID(storeKey), "", mustJSON(t, map[string]any{"value": "candidate"}))
+			},
+			wantActs: false,
+		},
+		"payload test with unparsable payload is rejection-only": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandTest, ctl.configID(storeKey), "", garbagePayload)
+			},
+			wantActs: false,
+		},
+		"schema answers inline and never claims": {
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandSchema, ctl.templateID(secretstore.KindVault), "", nil)
+			},
+			wantActs: false,
+		},
+		"get answers inline and never claims": {
+			seedDyncfg: true,
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandGet, ctl.configID(storeKey), "", nil)
+			},
+			wantActs: false,
+		},
+		"userconfig answers inline and never claims": {
+			fn: func(t *testing.T, ctl *Controller) dyncfg.Function {
+				return newFn(t, ctl, dyncfg.CommandUserconfig, ctl.templateID(secretstore.KindVault), "", mustJSON(t, map[string]any{"value": "good"}))
+			},
+			wantActs: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var opts Options
+			if tc.seedFile {
+				opts.Initial = []secretstore.Config{
+					newSecretStoreConfigWithSource(t, secretstore.KindVault, storeName, map[string]any{"value": "one"}, "file=/etc/netdata/go.d/ss/vault.conf", confgroup.TypeUser),
+				}
+			}
+			ctl, _, seams := newControllerTestSubjectWithOptions(opts)
+			if tc.seedFile {
+				ctl.PublishExisting()
+				_, ok := ctl.Lookup(storeKey)
+				require.True(t, ok, "seeding the file store failed")
+			}
+			if tc.seedDyncfg {
+				ctl.SeqExec(dyncfg.NewFunction(functions.Function{
+					UID:         "seed-add",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"value": "good"}),
+					Args:        []string{ctl.templateID(secretstore.KindVault), string(dyncfg.CommandAdd), storeName},
+				}))
+				_, ok := ctl.Lookup(storeKey)
+				require.True(t, ok, "seeding the dyncfg store failed")
+			}
+			if tc.affected {
+				seams.affectedJobs[storeKey] = []secretstore.JobRef{{ID: "mysql:prod", Display: "mysql:prod"}}
+			}
+
+			fn := tc.fn(t, ctl)
+
+			// Capture the predicate BEFORE running: execution mutates the
+			// caches, and the executor consults the predicate pre-execution.
+			acts := ctl.CommandActs(fn)
+			assert.Equal(t, tc.wantActs, acts, "CommandActs")
+
+			ran := false
+			ctl.StepExec(fn, func(effect func(context.Context) error, commit func(error)) {
+				ran = true
+				dyncfg.RunStepSync(effect, commit)
+			})
+
+			wantRan := acts
+			if tc.wantRan != nil {
+				wantRan = *tc.wantRan
+			}
+			assert.Equal(t, wantRan, ran, "blocking work must run exactly when the command acts")
+		})
+	}
+}

--- a/src/go/plugin/agent/jobmgr/secretsctl/controller.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/controller.go
@@ -27,7 +27,9 @@ type Options struct {
 
 	AffectedJobs            func(string) []secretstore.JobRef
 	RestartableAffectedJobs func(string) []secretstore.JobRef
-	RestartDependentJobs    func(string) string
+	// StageDependentRestarts snapshots the store's dependent-restart plan on
+	// the caller's goroutine (the run loop).
+	StageDependentRestarts func(storeKey string) *StagedRestarts
 }
 
 type Entry struct {
@@ -47,7 +49,7 @@ type Controller struct {
 
 	affectedJobs            func(string) []secretstore.JobRef
 	restartableAffectedJobs func(string) []secretstore.JobRef
-	restartDependentJobs    func(string) string
+	stageDependentRestarts  func(string) *StagedRestarts
 
 	handler *dyncfg.Handler[secretstore.Config]
 	cb      *secretStoreCallbacks
@@ -73,13 +75,12 @@ func New(opts Options) *Controller {
 		initial:                 append([]secretstore.Config(nil), opts.Initial...),
 		affectedJobs:            opts.AffectedJobs,
 		restartableAffectedJobs: opts.RestartableAffectedJobs,
-		restartDependentJobs:    opts.RestartDependentJobs,
+		stageDependentRestarts:  opts.StageDependentRestarts,
 	}
 	c.cb = newSecretStoreCallbacks(secretStoreCallbackDeps{
-		pluginName:           c.pluginName,
-		log:                  c.Logger,
-		service:              c.service,
-		restartDependentJobs: c.restartDependentJobs,
+		pluginName: c.pluginName,
+		log:        c.Logger,
+		service:    c.service,
 	})
 	c.handler = dyncfg.NewHandler(dyncfg.HandlerOpts[secretstore.Config]{
 		Logger:    c.Logger,

--- a/src/go/plugin/agent/jobmgr/secretsctl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/controller_test.go
@@ -171,7 +171,11 @@ func TestControllerSeqExec_TestStoredWithoutService_Returns400(t *testing.T) {
 	}
 }
 
-func TestRememberDiscoveredConfig_DrainsRestartFailureMessageFromNonHandlerStop(t *testing.T) {
+// A non-command stop (discovered-config replacement, boot publishing) carries
+// no command run: it must not execute dependent restarts and cannot leave a
+// message behind - restart execution and terminal messages exist only inside
+// a dyncfg command's effect.
+func TestRememberDiscoveredConfig_ReplacementStopRunsNoRestarts(t *testing.T) {
 	ctl, _, seams := newControllerTestSubject()
 	existing := newSecretStoreConfigWithSource(t, secretstore.KindVault, "vault_prod", map[string]any{"value": "one"}, "/etc/netdata/secretstores.yaml", confgroup.TypeUser)
 	require.NoError(t, ctl.Service().Add(context.Background(), existing))
@@ -189,10 +193,10 @@ func TestRememberDiscoveredConfig_DrainsRestartFailureMessageFromNonHandlerStop(
 	require.NoError(t, err)
 	require.True(t, changed)
 	assert.Equal(t, dyncfg.StatusAccepted, entry.Status)
-	assert.Equal(t, []string{key}, seams.restartCalls)
+	assert.Empty(t, seams.restartCalls,
+		"a replacement stop outside a dyncfg command must not restart dependents")
 	_, ok := ctl.Service().GetStatus(key)
 	assert.False(t, ok)
-	assert.Equal(t, "", ctl.cb.TakeCommandMessage())
 }
 
 func TestControllerPublishExisting(t *testing.T) {
@@ -321,11 +325,16 @@ func newControllerTestSubjectWithOptions(opts Options) (*Controller, *bytes.Buff
 			return seams.restartableJobs[storeKey]
 		}
 	}
-	restartDependentJobs := opts.RestartDependentJobs
-	if restartDependentJobs == nil {
-		restartDependentJobs = func(storeKey string) string {
-			seams.restartCalls = append(seams.restartCalls, storeKey)
-			return seams.restartMessages[storeKey]
+	stageRestarts := opts.StageDependentRestarts
+	if stageRestarts == nil {
+		stageRestarts = func(storeKey string) *StagedRestarts {
+			return &StagedRestarts{
+				Run: func(context.Context) (string, error) {
+					seams.restartCalls = append(seams.restartCalls, storeKey)
+					return seams.restartMessages[storeKey], nil
+				},
+				Flush: func() {},
+			}
 		}
 	}
 	ctl := New(Options{
@@ -335,7 +344,7 @@ func newControllerTestSubjectWithOptions(opts Options) (*Controller, *bytes.Buff
 		Service:                 svc,
 		AffectedJobs:            affectedJobs,
 		RestartableAffectedJobs: restartableJobs,
-		RestartDependentJobs:    restartDependentJobs,
+		StageDependentRestarts:  stageRestarts,
 		Initial:                 opts.Initial,
 		Seen:                    opts.Seen,
 		Exposed:                 opts.Exposed,

--- a/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"gopkg.in/yaml.v2"
 )
@@ -27,31 +28,136 @@ func (c *Controller) DeriveKey(fn dyncfg.Function) (string, bool) {
 	return key, ok
 }
 
+// SeqExec executes a command synchronously (legacy inline path, kept for
+// direct callers and tests; production routes through StepExec on the
+// executor).
 func (c *Controller) SeqExec(fn dyncfg.Function) {
+	c.StepExec(fn, dyncfg.RunStepSync)
+}
+
+// StepExec executes a command with its blocking pieces (backend validation
+// and I/O, dependent-job restarts) behind run. Cheap read commands answer
+// inline.
+func (c *Controller) StepExec(fn dyncfg.Function, run dyncfg.StepRunner) {
 	switch fn.Command() {
 	case dyncfg.CommandSchema:
 		c.dyncfgCmdSchema(fn)
 	case dyncfg.CommandGet:
 		c.dyncfgCmdGet(fn)
 	case dyncfg.CommandAdd:
-		c.dyncfgCmdAdd(fn)
+		c.dyncfgCmdAddStep(fn, run)
 	case dyncfg.CommandUpdate:
-		// TODO: file/user -> dyncfg conversion currently reuses generic update ordering,
-		// which can tear down the old live store before the override is active.
-		c.handler.CmdUpdate(fn)
+		c.dyncfgCmdUpdateStep(fn, run)
 	case dyncfg.CommandTest:
-		c.dyncfgCmdTest(fn)
+		c.dyncfgCmdTestStep(fn, run)
 	case dyncfg.CommandUserconfig:
 		c.dyncfgCmdUserconfig(fn)
 	case dyncfg.CommandRemove:
-		c.dyncfgCmdRemove(fn)
+		c.dyncfgCmdRemoveStep(fn, run)
 	default:
 		c.Warningf("dyncfg: function '%s' command '%s' not implemented", fn.Fn().Name, fn.Command())
 		c.api.SendCodef(fn, 501, "Function '%s' command '%s' is not implemented.", fn.Fn().Name, fn.Command())
 	}
 }
 
-func (c *Controller) dyncfgCmdAdd(fn dyncfg.Function) {
+// CommandActs reports whether fn may execute CLAIMLESSLY: false only when
+// execution answers a deterministic rejection BEFORE its first
+// claim-protected access - an unsupported command (the 501 arm above), a
+// missing store, an existing store on add, or a missing/unparsable
+// payload. Claim scheduling consults it so rejection-only store commands
+// claim nothing instead of parking behind held keys with no bounded
+// release; it mirrors the stage gates of the Step functions in this file
+// plus the shared handler's gates (via handler.CommandActs), and the
+// parity test drives StepExec against it. The remove arm consults ONLY the
+// shared pre-claim gate prefix (removeRejection): its affected-jobs check
+// reads the dependency index, which must be excluded by the granted store
+// write claim (no new reference can appear once the claim is held), so
+// EVERY remove gate from that read onward - the 409 and the handler's
+// source/type 405s ordered behind it - answers under the claim, and a
+// remove of any EXISTING store "acts" even when it will answer a rejection
+// inline.
+func (c *Controller) CommandActs(fn dyncfg.Function) bool {
+	switch fn.Command() {
+	case dyncfg.CommandAdd:
+		if fn.ValidateArgs(3) != nil {
+			return false
+		}
+		key, name, ok := c.cb.ExtractKey(fn)
+		if !ok {
+			return false
+		}
+		if _, exists := c.lookup(key); exists {
+			return false
+		}
+		if fn.ValidateHasPayload() != nil {
+			return false
+		}
+		if dyncfg.JobNameRuleAllowDots(name) != nil {
+			return false
+		}
+		kind, ok := c.dyncfgExtractSecretStoreKindFromTemplateID(fn.ID())
+		if !ok {
+			return false
+		}
+		cfg, err := c.dyncfgSecretStoreConfigFromPayload(fn, name, kind)
+		return err == nil && cfg.Validate() == nil
+	case dyncfg.CommandUpdate:
+		if key, ok := c.dyncfgExtractSecretStoreKey(fn.ID()); ok {
+			if entry, exists := c.lookupInternal(key); exists && entry.Cfg.SourceType() != confgroup.TypeDyncfg {
+				// Conversion path: payload gates at stage, validation in the
+				// effect.
+				if fn.ValidateHasPayload() != nil {
+					return false
+				}
+				_, err := c.dyncfgSecretStoreConfigFromPayload(fn, entry.Cfg.Name(), entry.Cfg.Kind())
+				return err == nil
+			}
+		}
+		return c.handler.CommandActs(fn, c.handlerEntry(fn.ID()))
+	case dyncfg.CommandRemove:
+		_, code, _ := c.removeRejection(fn)
+		return code == 0
+	case dyncfg.CommandTest:
+		storeKey, ok := c.dyncfgExtractSecretStoreKey(fn.ID())
+		if !ok {
+			return false
+		}
+		entry, exists := c.lookupInternal(storeKey)
+		if !exists {
+			return false
+		}
+		if !fn.HasPayload() {
+			return true
+		}
+		_, err := c.dyncfgSecretStoreConfigFromPayload(fn, entry.Cfg.Name(), entry.Cfg.Kind())
+		return err == nil
+	default:
+		// schema/get/userconfig answer inline and never claim; everything
+		// else is the 501 arm.
+		return false
+	}
+}
+
+// handlerEntry resolves the shared handler's exposed entry for a command's
+// config ID (nil when the store is not exposed), for handler.CommandActs
+// delegation.
+func (c *Controller) handlerEntry(id string) *dyncfg.Entry[secretstore.Config] {
+	key, ok := c.dyncfgExtractSecretStoreKey(id)
+	if !ok {
+		return nil
+	}
+	entry, ok := c.lookupInternal(key)
+	if !ok {
+		return nil
+	}
+	return entry
+}
+
+// dyncfgCmdAddStep is the secretstore custom add split at its blocking
+// pieces: cheap ID/payload validation and cache seeding at stage, backend
+// validation plus store activation plus dependent restarts in the effect,
+// terminal and CONFIG emission at commit.
+func (c *Controller) dyncfgCmdAddStep(fn dyncfg.Function, run dyncfg.StepRunner) {
 	if err := fn.ValidateArgs(3); err != nil {
 		c.api.SendCodef(fn, 400, "%v", err)
 		return
@@ -81,38 +187,129 @@ func (c *Controller) dyncfgCmdAdd(fn dyncfg.Function) {
 		return
 	}
 
-	rawCfg, err := c.dyncfgSecretStoreConfigFromPayload(fn, name, kind)
+	cfg, err := c.dyncfgSecretStoreConfigFromPayload(fn, name, kind)
 	if err != nil {
 		c.api.SendCodef(fn, 400, "%v", err)
 		return
 	}
-	if err := rawCfg.Validate(); err != nil {
+	if err := cfg.Validate(); err != nil {
 		c.api.SendCodef(fn, 400, "%v", err)
 		return
 	}
 
-	cfg, prepErr := c.prepareConfigCandidate(rawCfg)
 	c.seen.Add(cfg)
 	entry := &dyncfg.Entry[secretstore.Config]{Cfg: cfg, Status: dyncfg.StatusFailed}
 	c.exposed.Add(entry)
 
-	code := 200
-	msg := ""
-	if prepErr == nil {
-		if err := c.cb.Start(context.Background(), cfg); err == nil {
-			entry.Status = dyncfg.StatusRunning
-			msg = c.cb.TakeCommandMessage()
+	r := c.newStoreCommandRun(fn)
+	c.storeStepRunner(run, r)(func(ctx context.Context) error {
+		if err := c.validateConfig(ctx, cfg); err != nil {
+			return err
+		}
+		return c.cb.Start(ctx, cfg)
+	}, func(err error) {
+		if errors.Is(err, dyncfg.ErrPhaseNeverRan) {
+			// Shutdown: undo the stage-time seeding, answer retryably,
+			// publish nothing.
+			c.seen.Remove(cfg)
+			c.exposed.Remove(cfg)
+			c.api.SendCodef(fn, 503, "%v", err)
+			return
+		}
+		code := 200
+		msg := r.takeMessage()
+		if err != nil {
+			code = r.commandCode(err)
+			msg = err.Error()
 		} else {
-			prepErr = err
+			entry.Status = dyncfg.StatusRunning
+		}
+		c.api.SendCodef(fn, code, "%s", msg)
+		c.handler.NotifyConfigCreate(cfg, entry.Status)
+	})
+}
+
+// dyncfgCmdUpdateStep routes a dyncfg-sourced update through the shared
+// handler state machine; a file/user-sourced entry takes the custom
+// conversion path, which activates the override IN PLACE instead of tearing
+// down the live store first.
+func (c *Controller) dyncfgCmdUpdateStep(fn dyncfg.Function, run dyncfg.StepRunner) {
+	r := c.newStoreCommandRun(fn)
+	if key, ok := c.dyncfgExtractSecretStoreKey(fn.ID()); ok {
+		if entry, exists := c.lookupInternal(key); exists && entry.Cfg.SourceType() != confgroup.TypeDyncfg {
+			c.dyncfgCmdConvertStep(fn, run, r, entry)
+			return
 		}
 	}
-	if prepErr != nil {
-		code = secretStoreCommandCode(prepErr)
-		msg = prepErr.Error()
+	c.handler.CmdUpdateStep(fn, c.storeStepRunner(run, r))
+}
+
+// dyncfgCmdConvertStep converts a file/user-sourced live store to dyncfg
+// ownership: the new configuration is validated and swapped in place
+// (service update, not remove-then-add), dependents restart exactly once
+// against the new store, and the caches then expose the dyncfg-sourced
+// config. Validation errors win over state rejections (400 beats 403),
+// mirroring the shared handler's update precedence.
+func (c *Controller) dyncfgCmdConvertStep(fn dyncfg.Function, run dyncfg.StepRunner, r *storeCommandRun, entry *dyncfg.Entry[secretstore.Config]) {
+	if err := fn.ValidateHasPayload(); err != nil {
+		c.api.SendCodef(fn, 400, "%v", err)
+		return
 	}
 
-	c.api.SendCodef(fn, code, "%s", msg)
-	c.handler.NotifyConfigCreate(cfg, entry.Status)
+	newCfg, err := c.dyncfgSecretStoreConfigFromPayload(fn, entry.Cfg.Name(), entry.Cfg.Kind())
+	if err != nil {
+		c.api.SendCodef(fn, 400, "%v", err)
+		return
+	}
+
+	wrapped := c.storeStepRunner(run, r)
+	wrapped(func(ctx context.Context) error {
+		return c.validateConfig(ctx, newCfg)
+	}, func(err error) {
+		if errors.Is(err, dyncfg.ErrPhaseNeverRan) {
+			c.api.SendCodef(fn, 503, "%v", err)
+			return
+		}
+		if err != nil {
+			c.api.SendCodef(fn, 400, "%v", err)
+			c.handler.NotifyConfigStatus(entry.Cfg, entry.Status)
+			return
+		}
+		if entry.Status == dyncfg.StatusAccepted {
+			c.api.SendCodef(fn, 403, "updating is not allowed in '%s' state.", entry.Status)
+			c.handler.NotifyConfigStatus(entry.Cfg, entry.Status)
+			return
+		}
+
+		oldStatus := entry.Status
+		wrapped(func(ctx context.Context) error {
+			return c.cb.Start(ctx, newCfg)
+		}, func(startErr error) {
+			if errors.Is(startErr, dyncfg.ErrPhaseNeverRan) {
+				c.api.SendCodef(fn, 503, "%v", startErr)
+				return
+			}
+			if startErr != nil && !r.activatedNow() {
+				c.api.SendCodef(fn, r.commandCode(startErr), "%v", startErr)
+				c.handler.NotifyConfigStatus(entry.Cfg, entry.Status)
+				return
+			}
+			c.seen.Add(newCfg)
+			newEntry := &dyncfg.Entry[secretstore.Config]{Cfg: newCfg, Status: dyncfg.StatusRunning}
+			if startErr != nil {
+				newEntry.Status = dyncfg.StatusFailed
+			}
+			c.exposed.Add(newEntry)
+			c.handler.NotifyConfigCreate(newCfg, newEntry.Status)
+			if startErr != nil {
+				c.api.SendCodef(fn, r.commandCode(startErr), "%v", startErr)
+			} else {
+				c.api.SendCodef(fn, 200, "%s", r.takeMessage())
+			}
+			c.handler.NotifyConfigStatus(newCfg, newEntry.Status)
+			c.cb.OnStatusChange(newEntry, oldStatus, fn)
+		})
+	})
 }
 
 func (c *Controller) dyncfgCmdSchema(fn dyncfg.Function) {
@@ -159,7 +356,11 @@ func (c *Controller) dyncfgCmdGet(fn dyncfg.Function) {
 	c.api.SendJSON(fn, string(bs))
 }
 
-func (c *Controller) dyncfgCmdTest(fn dyncfg.Function) {
+// dyncfgCmdTestStep validates in the effect (backend I/O) and answers with
+// impact lists RECOMPUTED AT COMMIT on the loop: the lists are point-in-time
+// advisory - a dependency change during the validation is reflected, and no
+// dependent job keys are reserved for an advisory command.
+func (c *Controller) dyncfgCmdTestStep(fn dyncfg.Function, run dyncfg.StepRunner) {
 	storeKey, ok := c.dyncfgExtractSecretStoreKey(fn.ID())
 	if !ok {
 		c.api.SendCodef(fn, 400, "Invalid ID format for secretstore test: %s.", fn.ID())
@@ -167,11 +368,26 @@ func (c *Controller) dyncfgCmdTest(fn dyncfg.Function) {
 	}
 
 	if !fn.HasPayload() {
-		if err := c.validateStored(storeKey); err != nil {
-			c.api.SendCodef(fn, secretStoreErrorCode(err), "%v", err)
+		if _, ok := c.lookupInternal(storeKey); !ok {
+			// Stage-side mirror of validateStored's not-found answer (same
+			// error, same formatting - byte-identical on the wire) so a
+			// doomed test never reserves the store's read claim.
+			c.api.SendCodef(fn, secretStoreErrorCode(secretstore.ErrStoreNotFound), "%v", secretstore.ErrStoreNotFound)
 			return
 		}
-		c.dyncfgSendSecretStoreTestImpactMessage(fn, c.affectedJobsFor(storeKey), c.restartableAffectedJobsFor(storeKey), true)
+		run(func(ctx context.Context) error {
+			return c.validateStored(ctx, storeKey)
+		}, func(err error) {
+			if errors.Is(err, dyncfg.ErrPhaseNeverRan) {
+				c.api.SendCodef(fn, 503, "%v", err)
+				return
+			}
+			if err != nil {
+				c.api.SendCodef(fn, secretStoreErrorCode(err), "%v", err)
+				return
+			}
+			c.dyncfgSendSecretStoreTestImpactMessage(fn, c.affectedJobsFor(storeKey), c.restartableAffectedJobsFor(storeKey), true)
+		})
 		return
 	}
 
@@ -187,18 +403,23 @@ func (c *Controller) dyncfgCmdTest(fn dyncfg.Function) {
 		return
 	}
 
-	cfg, err = c.prepareConfigCandidate(cfg)
-	if err != nil {
-		c.api.SendCodef(fn, 400, "%v", err)
-		return
-	}
-
-	if cfg.Hash() == entry.Cfg.Hash() {
-		c.api.SendCodef(fn, 202, "Submitted configuration does not change the active secretstore.")
-		return
-	}
-
-	c.dyncfgSendSecretStoreTestImpactMessage(fn, c.affectedJobsFor(storeKey), c.restartableAffectedJobsFor(storeKey), false)
+	run(func(ctx context.Context) error {
+		return c.validateConfig(ctx, cfg)
+	}, func(err error) {
+		if errors.Is(err, dyncfg.ErrPhaseNeverRan) {
+			c.api.SendCodef(fn, 503, "%v", err)
+			return
+		}
+		if err != nil {
+			c.api.SendCodef(fn, 400, "%v", err)
+			return
+		}
+		if cfg.Hash() == entry.Cfg.Hash() {
+			c.api.SendCodef(fn, 202, "Submitted configuration does not change the active secretstore.")
+			return
+		}
+		c.dyncfgSendSecretStoreTestImpactMessage(fn, c.affectedJobsFor(storeKey), c.restartableAffectedJobsFor(storeKey), false)
+	})
 }
 
 func (c *Controller) dyncfgCmdUserconfig(fn dyncfg.Function) {
@@ -227,15 +448,10 @@ func (c *Controller) dyncfgCmdUserconfig(fn dyncfg.Function) {
 	c.api.SendYAML(fn, string(bs))
 }
 
-func (c *Controller) dyncfgCmdRemove(fn dyncfg.Function) {
-	storeKey, ok := c.dyncfgExtractSecretStoreKey(fn.ID())
-	if !ok {
-		c.api.SendCodef(fn, 400, "Invalid ID format for secretstore remove: %s.", fn.ID())
-		return
-	}
-
-	if _, ok := c.lookup(storeKey); !ok {
-		c.api.SendCodef(fn, 404, "The specified secretstore '%s' is not configured.", storeKey)
+func (c *Controller) dyncfgCmdRemoveStep(fn dyncfg.Function, run dyncfg.StepRunner) {
+	storeKey, code, msg := c.removeRejection(fn)
+	if code != 0 {
+		c.api.SendCodef(fn, code, "%s", msg)
 		return
 	}
 
@@ -244,7 +460,25 @@ func (c *Controller) dyncfgCmdRemove(fn dyncfg.Function) {
 		return
 	}
 
-	c.handler.CmdRemove(fn)
+	c.handler.CmdRemoveStep(fn, c.storeStepRunner(run, c.newStoreCommandRun(fn)))
+}
+
+// removeRejection runs the remove path's PRE-CLAIM gates - the gates that
+// precede its first claim-protected read, the affected-jobs check - and
+// reports the rejection they produce (code 0 = the command must claim). It
+// is the SINGLE SOURCE for dyncfgCmdRemoveStep and CommandActs; add a
+// pre-claim gate here, never in either caller. Every gate ordered after
+// these - the affected-jobs 409 AND the shared handler's source/type 405s
+// behind it - answers UNDER the granted store write claim.
+func (c *Controller) removeRejection(fn dyncfg.Function) (storeKey string, code int, msg string) {
+	storeKey, ok := c.dyncfgExtractSecretStoreKey(fn.ID())
+	if !ok {
+		return "", 400, fmt.Sprintf("Invalid ID format for secretstore remove: %s.", fn.ID())
+	}
+	if _, exists := c.lookup(storeKey); !exists {
+		return "", 404, fmt.Sprintf("The specified secretstore '%s' is not configured.", storeKey)
+	}
+	return storeKey, 0, ""
 }
 
 func (c *Controller) dyncfgTypedConfigFromPayload(fn dyncfg.Function, kind secretstore.StoreKind) (any, error) {
@@ -373,12 +607,4 @@ func secretStoreErrorCode(err error) int {
 	default:
 		return 400
 	}
-}
-
-func secretStoreCommandCode(err error) int {
-	var ce interface{ DyncfgCode() int }
-	if errors.As(err, &ce) {
-		return ce.DyncfgCode()
-	}
-	return secretStoreErrorCode(err)
 }

--- a/src/go/plugin/agent/jobmgr/secretsctl/initial.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/initial.go
@@ -17,8 +17,9 @@ func (c *Controller) publishInitialConfig(rawCfg secretstore.Config) {
 			return
 		}
 		if existing.Status == dyncfg.StatusRunning || existing.Status == dyncfg.StatusFailed {
+			// Boot publishing carries no command run: no restart stage, no
+			// terminal message.
 			c.cb.Stop(context.Background(), existing.Cfg)
-			c.cb.TakeCommandMessage()
 		}
 	}
 
@@ -34,7 +35,7 @@ func (c *Controller) publishInitialConfig(rawCfg secretstore.Config) {
 }
 
 func (c *Controller) prepareConfigCandidate(cfg secretstore.Config) (secretstore.Config, error) {
-	return cfg, c.validateConfig(cfg)
+	return cfg, c.validateConfig(context.Background(), cfg)
 }
 
 func shouldKeepExisting(cfg secretstore.Config, existing *dyncfg.Entry[secretstore.Config]) bool {

--- a/src/go/plugin/agent/jobmgr/secretsctl/steprun.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/steprun.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package secretsctl
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+)
+
+// StagedRestarts is one store command's dependent-restart plan, staged by
+// the manager on the run loop before the effect ships:
+//
+//   - Run executes the restarts inside the effect and returns the terminal
+//     message plus a non-nil error when the DEADLINE cut the sequence short
+//     (dependents skipped because the command's time ran out). The error
+//     makes the classification race-independent: a cut sequence must reach
+//     the command's failure outcome even when the effect returns before
+//     the worker observes the expired deadline - a nil return would let
+//     the completion-vs-abandon select race decide between success and
+//     the timeout failure for the same physical state.
+//   - Flush replays the completed restarts' loop-side entry-state and
+//     CONFIG STATUS transitions, in restart order, draining as it goes.
+//     Each completed restart replays exactly once: at the command's commit,
+//     or - for restarts that complete only after a deadline abandon - at
+//     the late return, while the dependents' claims are still held.
+type StagedRestarts struct {
+	Run   func(ctx context.Context) (string, error)
+	Flush func()
+}
+
+// storeCommandRun is one secretstore command's effect-to-commit carrier. It
+// rides the command's effect contexts, so concurrent store commands can
+// never cross-attribute restart messages or replay buffers. The mutex
+// covers effect-goroutine writes vs loop-side reads.
+type storeCommandRun struct {
+	staged *StagedRestarts
+
+	mu      sync.Mutex
+	message string
+	// activated flips when the service took the new value: the custom
+	// commit paths (add, conversion) use it to classify a plain failure by
+	// PHASE - pre-activation (validation-class, coded fallbacks apply) vs
+	// applied-but-degraded (the restart sequence was cut or failed after
+	// activation, which answers 200 with the failure text like the shared
+	// update path). The shared handler needs no marker - its phases commit
+	// separately.
+	activated bool
+}
+
+func (r *storeCommandRun) setMessage(msg string) {
+	r.mu.Lock()
+	r.message = msg
+	r.mu.Unlock()
+}
+
+// markActivated records that the service holds the new value; called by the
+// mutating callbacks on the effect goroutine right after service.Update/Add
+// succeed.
+func (r *storeCommandRun) markActivated() {
+	r.mu.Lock()
+	r.activated = true
+	r.mu.Unlock()
+}
+
+func (r *storeCommandRun) activatedNow() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.activated
+}
+
+// commandCode maps a store mutation's failure to its terminal code with
+// phase awareness, mirroring the shared handler's update mapping: coded
+// errors keep their codes; a plain error AFTER activation is the
+// applied-but-degraded partial outcome and answers 200 with the failure
+// text (terminal 400 would misreport an applied mutation as a bad
+// request); a plain error before activation falls back to the
+// validation-class codes.
+func (r *storeCommandRun) commandCode(err error) int {
+	var ce interface{ DyncfgCode() int }
+	if errors.As(err, &ce) {
+		return ce.DyncfgCode()
+	}
+	if r.activatedNow() {
+		return 200
+	}
+	return secretStoreErrorCode(err)
+}
+
+func (r *storeCommandRun) takeMessage() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	msg := strings.TrimSpace(r.message)
+	r.message = ""
+	return msg
+}
+
+// flush replays the completed dependent restarts. Loop-side only.
+func (r *storeCommandRun) flush() {
+	if r.staged != nil {
+		r.staged.Flush()
+	}
+}
+
+type storeCommandRunKey struct{}
+
+func withStoreCommandRun(ctx context.Context, r *storeCommandRun) context.Context {
+	return context.WithValue(ctx, storeCommandRunKey{}, r)
+}
+
+func storeCommandRunFrom(ctx context.Context) *storeCommandRun {
+	r, _ := ctx.Value(storeCommandRunKey{}).(*storeCommandRun)
+	return r
+}
+
+// newStoreCommandRun builds the command's carrier and stages its
+// dependent-restart plan (on the caller's goroutine - the run loop) when the
+// command addresses a derivable store key.
+func (c *Controller) newStoreCommandRun(fn dyncfg.Function) *storeCommandRun {
+	r := &storeCommandRun{}
+	if c.stageDependentRestarts == nil {
+		return r
+	}
+	if key, _, ok := c.cb.ExtractKey(fn); ok {
+		r.staged = c.stageDependentRestarts(key)
+	}
+	return r
+}
+
+// storeStepRunner wraps a StepRunner so every effect of the command carries
+// its run box and every commit first replays the buffered per-job work -
+// except never-ran commits, which publish nothing by the shutdown rule.
+func (c *Controller) storeStepRunner(run dyncfg.StepRunner, r *storeCommandRun) dyncfg.StepRunner {
+	return func(effect func(context.Context) error, commit func(error)) {
+		run(func(ctx context.Context) error {
+			return effect(withStoreCommandRun(ctx, r))
+		}, func(err error) {
+			if !errors.Is(err, dyncfg.ErrPhaseNeverRan) {
+				r.flush()
+			}
+			commit(err)
+		})
+	}
+}

--- a/src/go/plugin/agent/jobmgr/secretstore_effect_test.go
+++ b/src/go/plugin/agent/jobmgr/secretstore_effect_test.go
@@ -1,0 +1,1141 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
+	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// startSecretStoreEffectHarness builds a running manager with the given
+// registry and the vault test-store service.
+func startSecretStoreEffectHarness(t *testing.T, reg collectorapi.Registry, tune func(*Manager)) *charHarness {
+	t.Helper()
+
+	var out simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService()})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+	if tune != nil {
+		tune(mgr)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	return &charHarness{mgr: mgr, out: &out, in: in}
+}
+
+// Two store commands whose effects overlap must never cross-attribute their
+// terminal messages: each command's message rides its own effect contexts.
+func TestSecretStoreCommands_ConcurrentMessagesStayPerCommand(t *testing.T) {
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			c := &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+			c.InitFunc = func(context.Context) error {
+				inits.Add(1)
+				if c.Config.OptionStr == "good" {
+					return nil
+				}
+				// A rotated (bad) secret: hold the restart so both store
+				// commands' effects overlap, then fail with the resolved
+				// value so each terminal identifies its own dependent.
+				<-release
+				return fmt.Errorf("secret is not usable: %s", c.Config.OptionStr)
+			}
+			return c
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, nil)
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	for _, store := range []string{"store_a", "store_b"} {
+		h.dyncfg("ss-add-"+store, []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", store},
+			mustJSON(t, map[string]any{"value": "good"}))
+		require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add-"+store+" 200"), charWait, charTick)
+	}
+	for job, store := range map[string]string{"a1": "store_a", "b1": "store_b"} {
+		h.dyncfg("add-"+job, []string{h.mgr.dyncfgModID("gated"), "add", job},
+			mustJSON(t, map[string]any{"option_str": fmt.Sprintf("${store:vault:%s:value}", store)}))
+		h.dyncfg("en-"+job, []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("gated", job)), "enable"}, nil)
+		require.Eventually(t, h.outputContains("CONFIG test:collector:gated:"+job+" status running"), charWait, charTick)
+	}
+
+	// Rotate both stores to bad values: the dependent restarts block, so both
+	// store effects are in flight at once.
+	h.dyncfg("ss-update-a", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:store_a", "update"},
+		mustJSON(t, map[string]any{"value": "bad-a"}))
+	h.dyncfg("ss-update-b", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:store_b", "update"},
+		mustJSON(t, map[string]any{"value": "bad-b"}))
+	require.Eventually(t, func() bool { return inits.Load() >= 4 }, charWait, charTick,
+		"both dependents' restarts must be in flight concurrently")
+
+	close(release)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update-a 200"), charWait, charTick)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update-b 200"), charWait, charTick)
+
+	var respA, respB map[string]any
+	mustDecodeFunctionPayload(t, h.out.String(), "ss-update-a", &respA)
+	mustDecodeFunctionPayload(t, h.out.String(), "ss-update-b", &respB)
+	msgA, _ := respA["message"].(string)
+	msgB, _ := respB["message"].(string)
+	assert.Contains(t, msgA, "gated:a1", "store_a's terminal must report its own dependent")
+	assert.NotContains(t, msgA, "gated:b1", "store_a's terminal must not carry store_b's dependent")
+	assert.Contains(t, msgB, "gated:b1", "store_b's terminal must report its own dependent")
+	assert.NotContains(t, msgB, "gated:a1", "store_b's terminal must not carry store_a's dependent")
+}
+
+// The store test's affected/restartable impact lists are point-in-time
+// advisory, recomputed AT COMMIT: a dependency that appears while the test's
+// validation runs shows up in the answer (the test holds only a read claim,
+// so collector work on the store proceeds).
+func TestSecretStoreTest_AdvisoryListsRecomputedAtCommit(t *testing.T) {
+	validateGate := make(chan struct{})
+
+	// A dedicated service whose store Init blocks on the marker value: the
+	// test command's validation effect parks on it deterministically.
+	svc := secretstore.NewService(secretstore.Creator{
+		Kind:        secretstore.KindVault,
+		DisplayName: "Vault",
+		Schema:      `{"jsonSchema":{"type":"object","properties":{"value":{"type":"string"}}},"uiSchema":[]}`,
+		Create: func() secretstore.Store {
+			return &gatedValidateStore{gate: validateGate}
+		},
+	})
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	var out simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: svc})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		select {
+		case <-validateGate:
+		default:
+			close(validateGate)
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	// The test's validation effect blocks on the marker value.
+	h.dyncfg("ss-test", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "test"},
+		mustJSON(t, map[string]any{"value": "slow-validate"}))
+	require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-test"), charNeverWait, charTick,
+		"the test's validation must be in flight")
+
+	// A dependency change during the validation window: a collector job
+	// referencing the store goes running (its store READ claim shares the
+	// test's read claim).
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick,
+		"collector work on the store must proceed during the advisory test")
+
+	close(validateGate)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-test 202"), charWait, charTick)
+
+	var resp map[string]any
+	mustDecodeFunctionPayload(t, h.out.String(), "ss-test", &resp)
+	msg, _ := resp["message"].(string)
+	assert.Contains(t, msg, "gated:mysql",
+		"the impact lists must be recomputed at commit and include the dependency added during validation")
+}
+
+// gatedValidateStore blocks Init while validating the marker value, so a
+// store test's validation effect can be held open deterministically.
+type gatedValidateStore struct {
+	testStoreConfig struct {
+		Value string `yaml:"value" json:"value"`
+	}
+	gate <-chan struct{}
+}
+
+func (s *gatedValidateStore) Configuration() any { return &s.testStoreConfig }
+
+func (s *gatedValidateStore) Init(context.Context) error {
+	if s.testStoreConfig.Value == "slow-validate" {
+		<-s.gate
+	}
+	if s.testStoreConfig.Value == "" {
+		return fmt.Errorf("value is required")
+	}
+	return nil
+}
+
+func (s *gatedValidateStore) Publish() secretstore.PublishedStore {
+	return &gatedValidatePublished{value: s.testStoreConfig.Value}
+}
+
+type gatedValidatePublished struct{ value string }
+
+func (s *gatedValidatePublished) Resolve(_ context.Context, req secretstore.ResolveRequest) (string, error) {
+	if req.Operand != "value" {
+		return "", fmt.Errorf("unexpected operand %q", req.Operand)
+	}
+	return s.value, nil
+}
+
+// A restart sequence cut by the deadline reports a non-nil error alongside
+// the message, and wedged-only skips do not: the error is what makes the
+// command's classification race-independent - without it, an effect
+// returning just as the deadline fires could classify as SUCCESS (store
+// running) or the timeout failure depending on which select arm the worker
+// happens to pick for the same physical state.
+func TestRunDependentRestarts_DeadlineCutReturnsError(t *testing.T) {
+	mgr := New(Config{PluginName: testPluginName})
+
+	plan := []secretStoreDependentPlan{
+		{name: "gated:alpha", display: "gated:alpha", cfg: prepareDyncfgCfg("gated", "alpha")},
+		{name: "gated:beta", display: "gated:beta", cfg: prepareDyncfgCfg("gated", "beta")},
+	}
+
+	t.Run("expired deadline cuts the sequence with an error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // the deadline has already fired when the loop checks
+
+		msg, err := mgr.runDependentRestarts(ctx, "vault:vault_prod", plan, &restartReplayBuffer{})
+		require.Error(t, err, "a deadline-cut sequence must return an error, not just message text")
+		assert.Contains(t, err.Error(), "timed out")
+		assert.Contains(t, msg, "gated:alpha (skipped: the store operation timed out before this restart started)")
+		assert.Contains(t, msg, "gated:beta (skipped: the store operation timed out before this restart started)")
+	})
+
+	t.Run("wedged-only skips stay a successful outcome", func(t *testing.T) {
+		wedgedPlan := []secretStoreDependentPlan{
+			{name: "gated:alpha", display: "gated:alpha", cfg: plan[0].cfg, wedged: true},
+		}
+		msg, err := mgr.runDependentRestarts(context.Background(), "vault:vault_prod", wedgedPlan, &restartReplayBuffer{})
+		require.NoError(t, err, "skip-and-report on wedged dependents is the command's normal outcome")
+		assert.Contains(t, msg, "gated:alpha (skipped: operation in progress)")
+	})
+}
+
+// A store command abandoned at its deadline mid-restart-sequence: dependents
+// already restarted still commit (their CONFIG STATUS replays before the
+// terminal), no new restarts launch after the deadline, and the terminal
+// carries the timeout failure.
+func TestSecretStoreUpdate_DeadlineMidSequencePartialOutcome(t *testing.T) {
+	release := make(chan struct{})
+	var inits atomic.Int32
+	var gammaRestarts atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			c := &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+			c.InitFunc = func(context.Context) error {
+				inits.Add(1)
+				switch c.Config.OptionStr {
+				case "rotated":
+					switch c.Config.OptionInt {
+					case 2: // beta: wedges the restart sequence past the deadline
+						<-release
+					case 3: // gamma: must never restart
+						gammaRestarts.Add(1)
+					}
+				}
+				return nil
+			}
+			return c
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	// Three dependents; restart order is the sorted job order:
+	// alpha, beta, gamma.
+	for job, idx := range map[string]int{"alpha": 1, "beta": 2, "gamma": 3} {
+		h.dyncfg("add-"+job, []string{h.mgr.dyncfgModID("gated"), "add", job},
+			mustJSON(t, map[string]any{
+				"option_str": "${store:vault:vault_prod:value}",
+				"option_int": idx,
+			}))
+		h.dyncfg("en-"+job, []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("gated", job)), "enable"}, nil)
+		require.Eventually(t, h.outputContains("CONFIG test:collector:gated:"+job+" status running"), charWait, charTick)
+	}
+
+	h.dyncfg("ss-update", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+
+	// The sequence wedges inside beta's restart and the command commits its
+	// deadline outcome: alpha's completed restart still replays before the
+	// terminal, the store goes failed.
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick,
+		"the update must commit its deadline outcome while beta's restart is wedged")
+
+	var resp map[string]any
+	mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
+	msg, _ := resp["message"].(string)
+	assert.Contains(t, msg, "timed out", "the terminal must carry the abandonment")
+
+	output := h.out.String()
+	wiretest.RequireSubsequence(t, output, []wiretest.RecordWant{
+		{
+			Name:     "alpha's completed restart replays",
+			Contains: []string{"CONFIG test:collector:gated:alpha status running"},
+		},
+		{
+			Name:     "store update terminal",
+			Contains: []string{"FUNCTION_RESULT_BEGIN ss-update 200"},
+		},
+		{
+			Name:     "store failed status",
+			Contains: []string{"CONFIG " + h.mgr.dyncfgSecretStoreID(secretstore.StoreKey(secretstore.KindVault, "vault_prod")) + " status failed"},
+		},
+	})
+	assert.Equal(t, 2, strings.Count(output, "CONFIG test:collector:gated:alpha status running"),
+		"alpha: one enable line plus one replayed restart line")
+
+	// Unwedge: beta's leaked restart returns; gamma must never have been
+	// launched (no new restarts after the deadline).
+	close(release)
+	require.Eventually(t, func() bool { return h.mgr.leakedNow.Load() == 0 }, charWait, charTick,
+		"the leaked store effect must return after release")
+	assert.Zero(t, gammaRestarts.Load(), "no new dependent restarts may launch after the deadline")
+}
+
+// A collector update that changes the job's store reference must finalize
+// the dependency index when its outcome commits - INCLUDING the
+// deadline-abandon commit, where the job's key stays wedged and no settle
+// runs: a later rotation of the NEW store must see the job as a dependent
+// (and report it as skipped while it is wedged), never silently miss it.
+func TestSecretStoreRotation_SeesDependentRereferencedByAbandonedUpdate(t *testing.T) {
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 2 {
+						<-release // the re-reference update's detection wedges
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	for _, store := range []string{"store_a", "store_b"} {
+		h.dyncfg("ss-add-"+store, []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", store},
+			mustJSON(t, map[string]any{"value": "good"}))
+		require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add-"+store+" 200"), charWait, charTick)
+	}
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:store_a:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+
+	// The job update re-references store_b; its detection wedges past the
+	// deadline. The update commits FAILED with the store_b config exposed,
+	// releases its READ claim on store_b, and the job's key stays wedged.
+	h.dyncfg("3-update", []string{h.mgr.dyncfgJobID(cfg), "update"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:store_b:value}"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-update 200"), charWait, charTick,
+		"the update must commit its deadline outcome while its detection is wedged")
+
+	// The store_b rotation proceeds (the read claim was released at the
+	// abandon) and must SEE the failed job as a store_b dependent: wedged,
+	// so skipped-and-reported - a stale dependency index would silently
+	// miss it.
+	h.dyncfg("ss-update-b", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:store_b", "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update-b 200"), charWait, charTick,
+		"the rotation must not wait on the wedged dependent")
+
+	var resp map[string]any
+	mustDecodeFunctionPayload(t, h.out.String(), "ss-update-b", &resp)
+	msg, _ := resp["message"].(string)
+	assert.Contains(t, msg, "gated:mysql",
+		"the dependency index must reflect the abandoned update's re-reference before its claims release")
+	assert.Contains(t, msg, "skipped: operation in progress")
+}
+
+// A store command abandoned mid-restart keeps its WRITE claims on the
+// dependents until the leaked restart returns: a newer command on the
+// dependent must wait it out (no resurrection of just-disabled work), and
+// the leaked restart's status replay is delivered late, before the claims
+// release.
+func TestSecretStoreUpdate_AbandonedRestartHoldsDependentClaim(t *testing.T) {
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 2 {
+						<-release // the rotation's dependent restart wedges
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+
+	// The rotation's dependent restart wedges past the deadline: the store
+	// command commits its timeout outcome while the leaked restart runs on.
+	h.dyncfg("ss-update", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick,
+		"the rotation must commit its deadline outcome while the restart is wedged")
+
+	// The dependent's write claim is still held by the leaked restart: a
+	// user disable must WAIT, not run concurrently with (or be resurrected
+	// over by) the leaked Stop/Start.
+	h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+	require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable"), charNeverWait, charTick,
+		"the disable must wait out the leaked restart's write claim on the dependent")
+
+	close(release)
+	// The leaked restart finishes: its status replay is delivered late
+	// (while the claim is still held), then the claims release and the
+	// parked disable executes against the settled state.
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable 200"), charWait, charTick,
+		"the parked disable must proceed once the leaked restart returns")
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status disabled"), charWait, charTick)
+
+	wiretest.RequireSubsequence(t, h.out.String(), []wiretest.RecordWant{
+		{Name: "rotation deadline terminal", Contains: []string{"FUNCTION_RESULT_BEGIN ss-update 200"}},
+		{Name: "late restart replay", Contains: []string{"CONFIG test:collector:gated:mysql status running"}},
+		{Name: "parked disable terminal", Contains: []string{"FUNCTION_RESULT_BEGIN 3-disable 200"}},
+		{Name: "dependent disabled", Contains: []string{"CONFIG test:collector:gated:mysql status disabled"}},
+	})
+
+	h.mgr.runningJobs.lock()
+	_, running := h.mgr.runningJobs.lookup(cfg.FullName())
+	h.mgr.runningJobs.unlock()
+	assert.False(t, running, "no resurrected instance may survive the disable")
+}
+
+// A store mutation parked behind a BUSY dependent must be re-attempted when
+// that dependent WEDGES: the wedged key's write claim has no bounded
+// release, so the parked command's recompute (which excludes wedged keys)
+// must run at the wedge transition - skip-and-reporting the dependent -
+// instead of waiting out the leaked collector call.
+func TestSecretStoreUpdate_UnparksWhenParkedDependentWedges(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 2 {
+						// The user restart's detection wedges past the deadline.
+						select {
+						case entered <- struct{}{}:
+						default:
+						}
+						<-release
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+
+	// A user restart occupies the dependent's key (its detection is in
+	// flight, the key merely BUSY); the rotation sent now claims the RUNNING
+	// dependent for restart and parks behind that write claim.
+	h.dyncfg("3-restart", []string{h.mgr.dyncfgJobID(cfg), "restart"}, nil)
+	select {
+	case <-entered:
+	case <-time.After(charWait):
+		t.Fatal("the restart's detection did not start")
+	}
+	h.dyncfg("ss-update", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+
+	// The restart wedges at its deadline WITHOUT the leaked call returning:
+	// the parked rotation must be re-attempted at the wedge transition,
+	// exclude the now-wedged dependent, and commit with the skip report.
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick,
+		"the parked rotation must proceed once the dependent wedges, not wait out the leaked call")
+	var resp map[string]any
+	mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
+	msg, _ := resp["message"].(string)
+	assert.Contains(t, msg, "gated:mysql (skipped: operation in progress)",
+		"the rotation must report the wedged dependent as skipped")
+
+	// Late success after the committed rotation: the warm replacement carries
+	// pre-rotation credentials and is dropped, never started.
+	close(release)
+	h.dyncfg("4-get", []string{h.mgr.dyncfgJobID(cfg), "get"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 4-get"), charWait, charTick,
+		"the key must unwedge and settle after the late return")
+	assert.Equal(t, 1, strings.Count(h.out.String(), "CONFIG test:collector:gated:mysql status running"),
+		"the stale warm replacement must not publish a second running transition")
+	h.mgr.runningJobs.lock()
+	_, running := h.mgr.runningJobs.lookup(cfg.FullName())
+	h.mgr.runningJobs.unlock()
+	assert.False(t, running, "the stale warm replacement must be dropped, not registered")
+}
+
+// A store rotation that commits while a dependent's key is wedged reports
+// that dependent as skipped ("skipped: operation in progress"); the
+// dependent's late detection success must then be DROPPED, never started:
+// the warm job resolved its secrets from the pre-rotation store, and with
+// the rotation already committed nothing would ever restart it onto the new
+// value.
+func TestWarmResume_DroppedAfterStoreRotationCommitted(t *testing.T) {
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 1 {
+						<-release // the enable's detection wedges past the deadline
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, func(mgr *Manager) { mgr.effectDeadline = testEffectDeadline })
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status failed"), charWait, charTick,
+		"the enable must commit its deadline outcome while the detection is wedged")
+
+	// The rotation commits fully: the wedged dependent is skipped-and-reported
+	// and the store now holds the rotated value.
+	h.dyncfg("ss-update", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick)
+	var resp map[string]any
+	mustDecodeFunctionPayload(t, h.out.String(), "ss-update", &resp)
+	msg, _ := resp["message"].(string)
+	assert.Contains(t, msg, "gated:mysql (skipped: operation in progress)",
+		"the rotation must report the wedged dependent as skipped")
+
+	// Late success: the store changed while the key was wedged - the warm job
+	// carries pre-rotation credentials and must be dropped, not started.
+	close(release)
+	h.dyncfg("3-get", []string{h.mgr.dyncfgJobID(cfg), "get"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-get"), charWait, charTick,
+		"the key must unwedge and settle after the late return")
+	assert.NotContains(t, h.out.String(), "CONFIG test:collector:gated:mysql status running",
+		"a warm job resolved from the pre-rotation store must never start")
+	h.mgr.runningJobs.lock()
+	_, running := h.mgr.runningJobs.lookup(cfg.FullName())
+	h.mgr.runningJobs.unlock()
+	assert.False(t, running, "the stale warm job must be dropped, not registered")
+}
+
+// A store mutation IN FLIGHT at the late return (granted, its effect
+// possibly past activation but its loop-side commit not yet run) must also
+// drop the warm continuation: here the mutation is wedged inside backend
+// validation - the store's committed identity is provably unchanged, so the
+// write-hold check is the only guard standing between the warm job and a
+// start that could race the activation.
+func TestWarmResume_DroppedWhileStoreMutationInFlight(t *testing.T) {
+	wedgeGate := make(chan struct{})
+	validateGate := make(chan struct{})
+	var inits atomic.Int32
+
+	svc := secretstore.NewService(secretstore.Creator{
+		Kind:        secretstore.KindVault,
+		DisplayName: "Vault",
+		Schema:      `{"jsonSchema":{"type":"object","properties":{"value":{"type":"string"}}},"uiSchema":[]}`,
+		Create: func() secretstore.Store {
+			return &gatedValidateStore{gate: validateGate}
+		},
+	})
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 1 {
+						<-wedgeGate // the enable's detection wedges past the deadline
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	var out simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: svc})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+	mgr.effectDeadline = testEffectDeadline
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		for _, gate := range []chan struct{}{wedgeGate, validateGate} {
+			select {
+			case <-gate:
+			default:
+				close(gate)
+			}
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	h.dyncfg("ss-add", []string{mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status failed"), charWait, charTick,
+		"the enable must commit its deadline outcome while the detection is wedged")
+
+	// The store update's backend validation wedges past the deadline: the
+	// command commits 400, its loop-side entry stays UNCHANGED, and its write
+	// claim on the store key is held until the leaked validation returns.
+	h.dyncfg("ss-update", []string{mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+		mustJSON(t, map[string]any{"value": "slow-validate"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 400"), charWait, charTick,
+		"the store update must commit its deadline outcome while its validation is wedged")
+
+	// Late success under the in-flight mutation: identity is unchanged, so
+	// only the write-hold check can (and must) drop the warm job.
+	close(wedgeGate)
+	h.dyncfg("3-get", []string{mgr.dyncfgJobID(cfg), "get"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-get"), charWait, charTick,
+		"the key must unwedge and settle after the late return")
+	assert.NotContains(t, h.out.String(), "CONFIG test:collector:gated:mysql status running",
+		"a warm job must not start while a mutation of its store is in flight")
+	h.mgr.runningJobs.lock()
+	_, running := h.mgr.runningJobs.lookup(cfg.FullName())
+	h.mgr.runningJobs.unlock()
+	assert.False(t, running, "the warm job must be dropped, not registered")
+
+	// Unwedge the store: its leaked validation returns and everything drains.
+	close(validateGate)
+	require.Eventually(t, func() bool { return mgr.leakedNow.Load() == 0 }, charWait, charTick,
+		"the leaked store validation must return after release")
+}
+
+// A conversion whose dependent restarts are cut by the deadline is
+// APPLIED-BUT-DEGRADED and must answer 200 with the failure text - exactly
+// like the dyncfg-sourced update's partial outcome - never 400: the
+// override was activated in place (activation failures are coded), so a
+// bad-request terminal would misreport an applied mutation.
+func TestDyncfgSecretStoreConversion_DeadlineCutAnswersAppliedOutcome(t *testing.T) {
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 2 {
+						<-release // the conversion's dependent restart wedges
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	initial := newSecretStoreConfigWithSource(t, secretstore.KindVault, "vault_prod",
+		map[string]any{"value": "good"}, "file=/etc/netdata/go.d/ss/vault.conf", "user")
+
+	var out simOutput
+	mgr := New(Config{
+		PluginName:         testPluginName,
+		SecretStores:       []secretstore.Config{initial},
+		SecretStoreService: newTestSecretStoreService(),
+	})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+	mgr.effectDeadline = testEffectDeadline
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	storeID := h.mgr.dyncfgSecretStoreID(secretstore.StoreKey(secretstore.KindVault, "vault_prod"))
+	require.Eventually(t, h.outputContains("CONFIG "+storeID+" create"), charWait, charTick,
+		"the file-sourced store must publish at startup")
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+
+	// The update of a file/user-sourced store takes the CONVERSION path: it
+	// activates the override in place, then the dependent restart wedges
+	// past the deadline.
+	h.dyncfg("ss-convert", []string{storeID, "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-convert 200"), charWait, charTick,
+		"an applied-but-degraded conversion must answer the 200 partial outcome, not 400")
+	assert.NotContains(t, h.out.String(), "FUNCTION_RESULT_BEGIN ss-convert 400",
+		"a bad-request terminal would misreport an applied conversion")
+
+	var resp map[string]any
+	mustDecodeFunctionPayload(t, h.out.String(), "ss-convert", &resp)
+	msg, _ := resp["message"].(string)
+	assert.Contains(t, msg, "timed out", "the terminal must carry the degradation")
+	require.Eventually(t, h.outputContains("CONFIG "+storeID+" status failed"), charWait, charTick,
+		"the applied-but-degraded store commits failed")
+
+	close(release)
+	require.Eventually(t, func() bool { return h.mgr.leakedNow.Load() == 0 }, charWait, charTick,
+		"the leaked conversion effect must drain after release")
+}
+
+// A store test shares the store's read claim with in-flight collector
+// commands in EITHER arrival order: here the collector enable holds the
+// read first and the advisory test must still complete alongside it.
+func TestSecretStoreTest_SharesReadClaimWithInFlightCollector(t *testing.T) {
+	gate := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					inits.Add(1)
+					<-gate // the enable's detection holds the store read claim
+					return nil
+				},
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, nil)
+	t.Cleanup(func() {
+		select {
+		case <-gate:
+		default:
+			close(gate)
+		}
+	})
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, func() bool { return inits.Load() >= 1 }, charWait, charTick,
+		"the enable's detection did not start")
+
+	// Read/read shares: the advisory test must complete while the enable is
+	// still in flight.
+	h.dyncfg("ss-test", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "test"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-test 202"), charWait, charTick,
+		"the advisory test must share the store read claim with the in-flight enable")
+
+	close(gate)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 2-enable"), charWait, charTick)
+}
+
+// Secretstore backend validation runs under the effect's context: a backend
+// that honors cancellation returns at the deadline, so the leaked call
+// drains instead of wedging the store key forever.
+func TestSecretStoreAdd_ValidationHonorsEffectContext(t *testing.T) {
+	svc := secretstore.NewService(secretstore.Creator{
+		Kind:        secretstore.KindVault,
+		DisplayName: "Vault",
+		Schema:      `{"jsonSchema":{"type":"object","properties":{"value":{"type":"string"}}},"uiSchema":[]}`,
+		Create: func() secretstore.Store {
+			return &ctxBlockingStore{}
+		},
+	})
+
+	var out simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: svc})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = collectorapi.Registry{}
+	mgr.effectDeadline = testEffectDeadline
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	// The backend blocks until its context ends: with the effect context
+	// threaded through, the deadline both abandons the command AND unblocks
+	// the leaked call, so the store key drains instead of wedging forever.
+	h.dyncfg("ss-add", []string{mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "ctx-block"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add"), charWait, charTick,
+		"the add must reach a terminal at the deadline")
+	require.Eventually(t, func() bool { return mgr.leakedNow.Load() == 0 }, charWait, charTick,
+		"the ctx-honoring backend call must return once the effect context ends")
+}
+
+// ctxBlockingStore blocks Init until its context ends when validating the
+// marker value.
+type ctxBlockingStore struct {
+	cfg struct {
+		Value string `yaml:"value" json:"value"`
+	}
+}
+
+func (s *ctxBlockingStore) Configuration() any { return &s.cfg }
+
+func (s *ctxBlockingStore) Init(ctx context.Context) error {
+	if s.cfg.Value == "ctx-block" {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if s.cfg.Value == "" {
+		return fmt.Errorf("value is required")
+	}
+	return nil
+}
+
+func (s *ctxBlockingStore) Publish() secretstore.PublishedStore {
+	return &gatedValidatePublished{value: s.cfg.Value}
+}
+
+// A dependent restart running inside a store command's effect is
+// control-free and its context cause pins to DeadlineExceeded once that
+// effect's deadline fires - its late detection success must still never
+// start a job once the manager is shutting down (cleanup has already
+// snapshotted the running set; a start here would leak a running collector).
+func TestSecretStoreDependentRestart_LateSuccessNeverStartsAfterShutdown(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 2 {
+						<-release // the rotation's dependent restart wedges
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	var out simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService()})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+	mgr.effectDeadline = testEffectDeadline
+	mgr.drainWait = 300 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	h.dyncfg("ss-add", []string{mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+
+	// The rotation's dependent restart wedges past the deadline: the store
+	// command commits its timeout outcome while the restart runs on leaked.
+	h.dyncfg("ss-update", []string{mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick,
+		"the rotation must commit its deadline outcome while the restart is wedged")
+
+	// Shutdown completes without unblocking the restart.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(charWait):
+		t.Fatal("shutdown did not complete")
+	}
+
+	// The leaked restart's detection now succeeds - after cleanup. The
+	// start guard must drop it (cleanup, no start): a started job here
+	// would run unmanaged forever.
+	close(release)
+	require.Eventually(t, func() bool { return mgr.leakedNow.Load() == 0 }, charWait, charTick,
+		"the leaked store effect must drain after release")
+	mgr.runningJobs.lock()
+	_, running := mgr.runningJobs.lookup(cfg.FullName())
+	mgr.runningJobs.unlock()
+	assert.False(t, running, "no job may register after shutdown cleanup")
+}

--- a/src/go/plugin/agent/jobmgr/secretstore_flow_test.go
+++ b/src/go/plugin/agent/jobmgr/secretstore_flow_test.go
@@ -6,11 +6,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
@@ -82,6 +84,15 @@ func newTestSecretStoreService() secretstore.Service {
 			return &testStore{}
 		},
 	})
+}
+
+type updateFailingSecretStoreService struct {
+	secretstore.Service
+	err error
+}
+
+func (s *updateFailingSecretStoreService) Update(context.Context, string, secretstore.Config) error {
+	return s.err
 }
 
 func TestApplyConfig_ResolvesStoreReferenceWithKindAndName(t *testing.T) {
@@ -289,6 +300,143 @@ func TestDyncfgSecretStoreUpdate_DependentRestartBehavior(t *testing.T) {
 			tc.run(t, mgr, out)
 		})
 	}
+}
+
+// MUST-NOT-FLIP: the file/user -> dyncfg conversion of a LIVE secretstore
+// activates the override IN PLACE - the old live store is never torn down,
+// so a running dependent is restarted exactly ONCE against the new store and
+// never passes through a failed round. (The generic conversion ordering used
+// to stop the old store first; the dependent visibly failed against the
+// missing store and recovered only after the new store started.)
+func TestDyncfgSecretStoreConversion_FileToDyncfgUpdate(t *testing.T) {
+	initial := newSecretStoreConfigWithSource(t, secretstore.KindVault, "vault_prod",
+		map[string]any{"value": "good"}, "file=/etc/netdata/go.d/ss/vault.conf", confgroup.TypeUser)
+
+	var out bytes.Buffer
+	mgr := New(Config{
+		PluginName:         testPluginName,
+		SecretStores:       []secretstore.Config{initial},
+		SecretStoreService: newTestSecretStoreService(),
+	})
+	mgr.ctx = context.Background()
+	mgr.modules = prepareMockRegistry()
+	mgr.fileStatus = newFileStatus()
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules["gated"] = collectorapi.Creator{
+		Create: func() collectorapi.CollectorV1 { return &secretAwareCollector{} },
+	}
+	mgr.secretsCtl.PublishExisting()
+
+	key := secretstore.StoreKey(secretstore.KindVault, "vault_prod")
+	entry, ok := mgr.lookupSecretStoreEntry(key)
+	require.True(t, ok)
+	require.Equal(t, dyncfg.StatusRunning, entry.Status)
+	require.Equal(t, confgroup.TypeUser, entry.Cfg.SourceType())
+
+	cfg := prepareDyncfgCfg("gated", "mysql").
+		Set("option_str", "${store:vault:vault_prod:value}").
+		Set("option_int", 1)
+	mgr.collectorExposed.Add(&dyncfg.Entry[confgroup.Config]{Cfg: cfg, Status: dyncfg.StatusRunning})
+	mgr.syncSecretStoreDepsForConfig(cfg)
+	require.NoError(t, mgr.collectorCallbacks.Start(context.Background(), cfg))
+
+	convertFn := dyncfg.NewFunction(functions.Function{
+		UID:         "ss-convert",
+		ContentType: "application/json",
+		Payload:     mustJSON(t, map[string]any{"value": "good"}),
+		Args:        []string{mgr.dyncfgSecretStoreID(key), string(dyncfg.CommandUpdate)},
+	})
+	mgr.dyncfgSecretStoreSeqExec(convertFn)
+
+	output := out.String()
+	wiretest.RequireSubsequence(t, output, []wiretest.RecordWant{
+		{
+			Name:     "dependent restarted once against the new store",
+			Contains: []string{"CONFIG test:collector:gated:mysql status running"},
+		},
+		{
+			Name:     "converted store create",
+			Contains: []string{"CONFIG " + mgr.dyncfgSecretStoreID(key) + " create", "dyncfg"},
+		},
+		{
+			Name:     "conversion terminal",
+			Contains: []string{"FUNCTION_RESULT_BEGIN ss-convert 200"},
+		},
+		{
+			Name:     "converted store status",
+			Contains: []string{"CONFIG " + mgr.dyncfgSecretStoreID(key) + " status running"},
+		},
+	})
+	assert.NotContains(t, output, "CONFIG test:collector:gated:mysql status failed",
+		"the in-place conversion must never tear the dependent down against a missing store")
+	assert.Equal(t, 1, strings.Count(output, "CONFIG test:collector:gated:mysql status running"),
+		"the dependent restarts exactly once")
+
+	var resp map[string]any
+	mustDecodeFunctionPayload(t, output, "ss-convert", &resp)
+	assert.Equal(t, float64(200), resp["status"])
+	assert.Equal(t, "", resp["message"], "a clean single-round restart reports no failures")
+
+	entry, ok = mgr.lookupSecretStoreEntry(key)
+	require.True(t, ok)
+	assert.Equal(t, dyncfg.StatusRunning, entry.Status)
+	assert.Equal(t, confgroup.TypeDyncfg, entry.Cfg.SourceType())
+
+	depEntry, ok := mgr.lookupExposedByFullName(cfg.FullName())
+	require.True(t, ok)
+	assert.Equal(t, dyncfg.StatusRunning, depEntry.Status)
+}
+
+func TestDyncfgSecretStoreConversion_PreActivationFailureKeepsExistingEntry(t *testing.T) {
+	initial := newSecretStoreConfigWithSource(t, secretstore.KindVault, "vault_prod",
+		map[string]any{"value": "good"}, "file=/etc/netdata/go.d/ss/vault.conf", confgroup.TypeUser)
+	svc := &updateFailingSecretStoreService{
+		Service: newTestSecretStoreService(),
+		err:     fmt.Errorf("backend refused update"),
+	}
+
+	var out bytes.Buffer
+	mgr := New(Config{
+		PluginName:         testPluginName,
+		SecretStores:       []secretstore.Config{initial},
+		SecretStoreService: svc,
+	})
+	mgr.ctx = context.Background()
+	mgr.modules = prepareMockRegistry()
+	mgr.fileStatus = newFileStatus()
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.secretsCtl.PublishExisting()
+
+	key := secretstore.StoreKey(secretstore.KindVault, "vault_prod")
+	storeID := mgr.dyncfgSecretStoreID(key)
+	entry, ok := mgr.lookupSecretStoreEntry(key)
+	require.True(t, ok)
+	require.Equal(t, dyncfg.StatusRunning, entry.Status)
+	require.Equal(t, confgroup.TypeUser, entry.Cfg.SourceType())
+
+	convertFn := dyncfg.NewFunction(functions.Function{
+		UID:         "ss-convert-fails",
+		ContentType: "application/json",
+		Payload:     mustJSON(t, map[string]any{"value": "rotated"}),
+		Args:        []string{storeID, string(dyncfg.CommandUpdate)},
+	})
+	mgr.dyncfgSecretStoreSeqExec(convertFn)
+
+	output := out.String()
+	require.Contains(t, output, "FUNCTION_RESULT_BEGIN ss-convert-fails 400")
+	assert.Contains(t, output, "backend refused update")
+	assert.NotContains(t, output, "CONFIG "+storeID+" status failed",
+		"a pre-activation conversion failure must not expose a failed replacement")
+
+	entry, ok = mgr.lookupSecretStoreEntry(key)
+	require.True(t, ok)
+	assert.Equal(t, dyncfg.StatusRunning, entry.Status)
+	assert.Equal(t, confgroup.TypeUser, entry.Cfg.SourceType())
+	assert.Equal(t, "good", entry.Cfg["value"])
+
+	value, err := svc.Resolve(context.Background(), svc.Capture(), key+":value", "${store:"+key+":value}")
+	require.NoError(t, err)
+	assert.Equal(t, "good", value)
 }
 
 func TestDyncfgSecretStoreGet_CanonicalJSONDoesNotExposeUnknownFields(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/vnode_claims_test.go
+++ b/src/go/plugin/agent/jobmgr/vnode_claims_test.go
@@ -1,0 +1,1038 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
+	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// A vnode mutation write-claims the vnode name: it must park behind an
+// in-flight collector effect holding a read claim on the same vnode, and
+// proceed once that command commits. Vnode wire output is otherwise
+// unchanged (the commands stay stage+commit on the loop).
+func TestVnodeClaims_WriteConflictsWithCollectorReadClaim(t *testing.T) {
+	gate := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 1 {
+						<-gate // the enable's detection holds its claims
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, nil)
+	t.Cleanup(func() {
+		select {
+		case <-gate:
+		default:
+			close(gate)
+		}
+	})
+
+	const guid = "b0b0b0b0-0000-4000-8000-000000000001"
+	h.dyncfg("vn-add", []string{h.mgr.dyncfgVnodePrefixValue(), "add", "v1"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-one"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-add 202"), charWait, charTick)
+
+	// A collector job bound to the vnode: its enable holds a READ claim on
+	// the vnode while the detection runs.
+	cfg := prepareDyncfgCfg("gated", "mysql").Set("vnode", "v1")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"vnode": "v1"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 1-add"), charWait, charTick)
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, func() bool { return inits.Load() >= 1 }, charWait, charTick,
+		"the enable's detection did not start")
+
+	// The vnode update's WRITE claim conflicts with the enable's READ claim:
+	// it parks until the enable commits.
+	h.dyncfg("vn-update", []string{h.mgr.dyncfgVnodePrefixValue() + ":v1", "update"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-two"}))
+	require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-update"), charNeverWait, charTick,
+		"the vnode update must wait out the in-flight collector effect's vnode read claim")
+
+	close(gate)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick,
+		"the enable must commit after release")
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-update 202"), charWait, charTick,
+		"the parked vnode update must proceed once the collector command commits")
+
+	vnode, ok := h.mgr.vnodesCtl.Lookup("v1")
+	require.True(t, ok)
+	assert.Equal(t, "host-two", vnode.Hostname, "the parked update must apply after unparking")
+}
+
+// A stop-shaped collector command holds its OLD vnode reference: a vnode
+// remove must wait out the dependent job's in-flight stop instead of racing
+// its affected-job gate against the exposed-cache removal the stop already
+// performed at stage.
+func TestVnodeRemove_WaitsForDependentStopInFlight(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 {
+					select {
+					case entered <- struct{}{}:
+					default:
+					}
+					<-release
+					return map[string]int64{"d1": 1}
+				},
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, nil)
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	const guid = "b0b0b0b0-0000-4000-8000-000000000002"
+	h.dyncfg("vn-add", []string{h.mgr.dyncfgVnodePrefixValue(), "add", "v2"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-two"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-add 202"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql").Set("vnode", "v2")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"vnode": "v2"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+	select {
+	case <-entered:
+	case <-time.After(charWait):
+		t.Fatal("no collection started")
+	}
+
+	// The job's removal clears the exposed entry at stage and blocks in its
+	// stop; its vnode read claim keeps the dependency visible as "in flight".
+	h.dyncfg("3-remove", []string{h.mgr.dyncfgJobID(cfg), "remove"}, nil)
+	require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-remove"), charNeverWait, charTick,
+		"the job's stop must be blocked in its final collection")
+
+	// The vnode remove's write claim conflicts with the stopping job's read
+	// claim: it must wait, not act on the already-cleared exposed cache.
+	h.dyncfg("vn-remove", []string{h.mgr.dyncfgVnodePrefixValue() + ":v2", "remove"}, nil)
+	require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-remove"), charNeverWait, charTick,
+		"the vnode remove must wait out the dependent's in-flight stop")
+
+	close(release)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-remove 200"), charWait, charTick)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-remove 200"), charWait, charTick,
+		"the vnode remove proceeds once the dependent's removal committed")
+	_, ok := h.mgr.vnodesCtl.Lookup("v2")
+	assert.False(t, ok, "the vnode is removed once no dependent remains")
+}
+
+// An underivable command (here: an add without a job name) is
+// rejection-only: it must answer 400 immediately even when its payload
+// references a store whose key is write-held - claiming payload refs for it
+// would park an invalid command behind that hold instead.
+func TestUnderivableCommand_RejectsWithoutClaiming(t *testing.T) {
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 2 {
+						<-release // the rotation's dependent restart blocks
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, nil)
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+
+	// pg stays ACCEPTED (added, never enabled) and references the store: its
+	// exposed refs exist for a later restart's claim compute, but Accepted is
+	// not restartable - the plan below must not claim it either.
+	h.dyncfg("pg-add", []string{h.mgr.dyncfgModID("gated"), "add", "pg"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN pg-add"), charWait, charTick)
+
+	// legacy is USER-SOURCED (discovered) and references the store: its
+	// remove is source-rejected (405, only dyncfg configs can be removed).
+	legacyCfg := prepareUserCfg("gated", "legacy").Set("option_str", "${store:vault:vault_prod:value}")
+	h.in <- prepareCfgGroups(legacyCfg.Source(), legacyCfg)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:legacy create accepted"), charWait, charTick)
+
+	// The rotation holds the store's WRITE claim while its dependent
+	// restart blocks.
+	h.dyncfg("ss-update", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+	require.Eventually(t, func() bool { return inits.Load() >= 2 }, charWait, charTick,
+		"the rotation's dependent restart did not start")
+
+	// An add with NO job name is underivable; its payload references the
+	// write-held store. It must be rejected immediately, not parked.
+	h.dyncfg("bad-add", []string{h.mgr.dyncfgModID("gated"), "add"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN bad-add 400"), charWait, charTick,
+		"an underivable command must reach its 400 rejection while the store is held")
+
+	// A DERIVABLE update addressed to a config that is not exposed is
+	// rejection-only too (the handler answers 404 before any effect): its
+	// payload refs must not be claimed, or the doomed command would park
+	// behind the write-held store instead of answering immediately.
+	h.dyncfg("ghost-update", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("gated", "ghost")), "update"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ghost-update 404"), charWait, charTick,
+		"an update of an unknown config must reach its 404 rejection while the store is held")
+
+	// A STATE-rejected command is rejection-only as well: restart of an
+	// Accepted config answers 405 before any work, so its exposed refs must
+	// not be claimed either - pg was added (Accepted) before the rotation
+	// took the store's write claim.
+	h.dyncfg("pg-restart", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("gated", "pg")), "restart"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN pg-restart 405"), charWait, charTick,
+		"a restart of an Accepted config must reach its 405 rejection while the store is held")
+
+	// A SOURCE-rejected command too: remove of a user-sourced config answers
+	// 405 before any stop work, so its exposed refs must not be claimed.
+	h.dyncfg("legacy-remove", []string{h.mgr.dyncfgJobID(legacyCfg), "remove"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN legacy-remove 405"), charWait, charTick,
+		"a remove of a non-dyncfg config must reach its 405 rejection while the store is held")
+
+	// The PAYLOAD axis: update without a payload answers 400 before any
+	// blocking work, so it must not claim its exposed refs - pg references
+	// the write-held store and would otherwise park on the store's read
+	// claim.
+	h.dyncfg("pg-nopayload", []string{h.mgr.dyncfgJobID(prepareDyncfgCfg("gated", "pg")), "update"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN pg-nopayload 400"), charWait, charTick,
+		"an update without a payload must reach its 400 rejection while the store is held")
+
+	// The NAME-POLICY axis, a CALLBACK gate (ValidateConfigName /
+	// JobNameRuleStrict): a dotted job name is derivable (non-empty) yet
+	// answers 400 before any blocking work, so its payload refs - which
+	// reference the write-held store - must not be claimed. The predicate
+	// runs the handler's own addRejection gates, so callback gates cannot
+	// drift out of it.
+	h.dyncfg("bad-name-add", []string{h.mgr.dyncfgModID("gated"), "add", "bad.name"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN bad-name-add 400"), charWait, charTick,
+		"an add with an invalid strict name must reach its 400 rejection while the store is held")
+
+	// The PAYLOAD-PARSE axis (the PayloadParser stage gate): a present but
+	// unparsable payload answers 400 from the cheap parse prefix, before
+	// any claim or effect. An update of mysql would otherwise park at the
+	// LANE (its job key is write-held by the rotation's plan), and an
+	// add-over-pg would otherwise claim pg's exposed refs - the write-held
+	// store - and park in the claim table.
+	h.dyncfg("mysql-badpayload", []string{h.mgr.dyncfgJobID(cfg), "update"}, []byte("{ not json"))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN mysql-badpayload 400"), charWait, charTick,
+		"an update with an unparsable payload must reach its 400 rejection while its job key is write-held")
+	h.dyncfg("pg-badpayload", []string{h.mgr.dyncfgModID("gated"), "add", "pg"}, []byte("{ not json"))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN pg-badpayload 400"), charWait, charTick,
+		"an add with an unparsable payload must reach its 400 rejection while the store is held")
+
+	// The STATUS axis is HOLD-AWARE (user decision 1A): enable of a Running
+	// config is a no-op only while its status is stable - mysql's key is
+	// write-held by the rotation whose blocked restart is mid-mutating that
+	// very status, so the enable must PARK and answer truthfully after the
+	// hold resolves, not mint a 200 from mid-mutation state. Sent LAST so
+	// the parked command does not block the same-key bypass pins above.
+	h.dyncfg("mysql-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN mysql-enable"), charNeverWait, charTick,
+		"a status-gated no-op must park while its job key is write-held")
+
+	close(release)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN mysql-enable 200"), charWait, charTick,
+		"the parked enable answers truthfully once the restart committed")
+}
+
+// Status commands that arrive while a store-driven dependent restart owns
+// the job key's foreign write claim must park until the holder commits,
+// then answer from the settled state. The table keeps the original
+// false-success enable pin and adds restart/disable coverage for the same
+// foreign-hold choreography.
+func startDependentRestartHold(t *testing.T) (*charHarness, confgroup.Config, *atomic.Int32, func()) {
+	t.Helper()
+
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 2 {
+						<-release // the rotation's dependent restart blocks, then FAILS
+						return errors.New("rotated secret rejected")
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, nil)
+	closeRelease := func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}
+	t.Cleanup(closeRelease)
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+
+	h.dyncfg("ss-update", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+	require.Eventually(t, func() bool { return inits.Load() >= 2 }, charWait, charTick,
+		"the rotation's dependent restart did not start")
+
+	return h, cfg, &inits, closeRelease
+}
+
+func TestStatusCommandsDuringDependentRestart_AnswerTruthfully(t *testing.T) {
+	tests := map[string]struct {
+		command string
+		check   func(t *testing.T, h *charHarness, inits *atomic.Int32)
+	}{
+		"enable": {
+			command: string(dyncfg.CommandEnable),
+			check: func(t *testing.T, h *charHarness, inits *atomic.Int32) {
+				t.Helper()
+				require.Eventually(t, func() bool { return inits.Load() >= 3 }, charWait, charTick,
+					"enable must run its own detection instead of answering a stale no-op")
+				require.Eventually(t, func() bool {
+					return strings.Count(h.out.String(), "CONFIG test:collector:gated:mysql status running") >= 2
+				}, charWait, charTick, "enable must recover the job to running")
+			},
+		},
+		"restart": {
+			command: string(dyncfg.CommandRestart),
+			check: func(t *testing.T, h *charHarness, inits *atomic.Int32) {
+				t.Helper()
+				require.Eventually(t, func() bool { return inits.Load() >= 3 }, charWait, charTick,
+					"restart must run its own detection against the post-restart failed state")
+				require.Eventually(t, func() bool {
+					return strings.Count(h.out.String(), "CONFIG test:collector:gated:mysql status running") >= 2
+				}, charWait, charTick, "restart must recover the job to running")
+			},
+		},
+		"disable": {
+			command: string(dyncfg.CommandDisable),
+			check: func(t *testing.T, h *charHarness, inits *atomic.Int32) {
+				t.Helper()
+				require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status disabled"), charWait, charTick,
+					"disable must act on the post-restart failed state")
+				require.Never(t, func() bool { return inits.Load() >= 3 }, charNeverWait, charTick,
+					"disable must not start a fresh detection")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			h, cfg, inits, release := startDependentRestartHold(t)
+
+			uid := "mysql-" + tc.command
+			h.dyncfg(uid, []string{h.mgr.dyncfgJobID(cfg), tc.command}, nil)
+			require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN "+uid), charNeverWait, charTick,
+				"the command must park while the store restart owns the dependent write claim")
+
+			release()
+
+			require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status failed"), charWait, charTick,
+				"the failed store-driven restart must commit the dependent as failed")
+			require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick)
+			require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN "+uid+" 200"), charWait, charTick,
+				"the parked command must answer after the store-held mutation settles")
+			tc.check(t, h, inits)
+		})
+	}
+}
+
+// Unsupported store/vnode commands (enable/disable/restart - the 501 arms)
+// are rejection-only: they must answer immediately instead of reserving
+// their domain claims first - a store restart would park its write claim
+// behind an in-flight enable's store read claim, and a vnode restart would
+// park behind the same enable's vnode read claim, both for the full effect
+// window.
+func TestUnsupportedDomainCommands_RejectWithoutClaiming(t *testing.T) {
+	release := make(chan struct{})
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					<-release // the enable holds its claims for the whole detection
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	h := startSecretStoreEffectHarness(t, reg, nil)
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	const guid = "b0b0b0b0-0000-4000-8000-0000000000bb"
+	h.dyncfg("vn-add", []string{h.mgr.dyncfgVnodePrefixValue(), "add", "v9"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-nine"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-add 202"), charWait, charTick)
+
+	// The enable blocks in its detection holding {job WRITE, store READ,
+	// vnode READ}.
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}", "vnode": "v9"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN 2-enable"), charNeverWait, charTick,
+		"the enable must be blocked in its detection")
+
+	h.dyncfg("ss-restart", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "restart"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-restart 501"), charWait, charTick,
+		"an unsupported store command must answer 501 while a collector holds the store's read claim")
+
+	h.dyncfg("vn-restart", []string{h.mgr.dyncfgVnodePrefixValue() + ":v9", "restart"}, nil)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-restart 501"), charWait, charTick,
+		"an unsupported vnode command must answer 501 while a collector holds the vnode's read claim")
+
+	close(release)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 2-enable 200"), charWait, charTick)
+}
+
+// The store remove's affected-jobs gate reads the dependency index, which
+// the granted store write claim must exclude - and the handler's
+// source/type gates sit BEHIND that read in the remove's execution order.
+// A remove of a FILE-sourced store (whose eventual answer is a rejection
+// either way: 409 while referenced, 405 otherwise) must therefore wait out
+// an in-flight collector effect holding the store's read claim rather than
+// answer claimlessly from an index snapshot that effect is about to
+// change.
+func TestStoreRemove_AffectedGateWaitsForStoreClaim(t *testing.T) {
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					inits.Add(1)
+					<-release // the enable holds its claims for the whole detection
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	fileStore := newSecretStoreConfigWithSource(t, secretstore.KindVault, "vault_prod",
+		map[string]any{"value": "good"}, "file=/etc/netdata/go.d/ss/vault.conf", confgroup.TypeUser)
+
+	var out simOutput
+	mgr := New(Config{
+		PluginName:         testPluginName,
+		SecretStores:       []secretstore.Config{fileStore},
+		SecretStoreService: newTestSecretStoreService(),
+	})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	cfg := prepareDyncfgCfg("gated", "mysql")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, func() bool { return inits.Load() >= 1 }, charWait, charTick,
+		"the enable's detection did not start")
+
+	h.dyncfg("ss-remove", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "remove"}, nil)
+	require.Never(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-remove"), charNeverWait, charTick,
+		"the remove must park behind the in-flight enable's store read claim")
+
+	close(release)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 2-enable 200"), charWait, charTick)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-remove 409"), charWait, charTick,
+		"the remove answers its 409 under the granted claim once the reference settles")
+}
+
+// The registration-time vnode reconcile is COMMITTED into the job, not
+// queued: V1 applies queued updates only during collection, so a job
+// stopped before its first tick would otherwise clean up with the stale
+// creation-time vnode - HOST/HOSTINFO lines for a hostname the store no
+// longer holds.
+func TestWarmResume_CleanupEmitsReconciledVnodeBeforeFirstCollection(t *testing.T) {
+	gate := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 1 {
+						<-gate // the enable's detection wedges past the deadline
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	var out, jobOut simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService(), Out: &jobOut})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+	mgr.effectDeadline = testEffectDeadline
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		select {
+		case <-gate:
+		default:
+			close(gate)
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	const guid = "b0b0b0b0-0000-4000-8000-000000000006"
+	h.dyncfg("vn-add", []string{h.mgr.dyncfgVnodePrefixValue(), "add", "v7"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-one"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-add 202"), charWait, charTick)
+
+	// update_every keeps the warm job from collecting inside the test
+	// window: only Cleanup can reveal which vnode the job carries.
+	cfg := prepareDyncfgCfg("gated", "mysql").Set("vnode", "v7")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"vnode": "v7", "update_every": 3600}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status failed"), charWait, charTick,
+		"the enable must commit its deadline outcome while the detection is wedged")
+
+	h.dyncfg("vn-update", []string{h.mgr.dyncfgVnodePrefixValue() + ":v7", "update"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-two"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-update 202"), charWait, charTick)
+
+	close(gate)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick,
+		"the late detection success must start the warm job")
+
+	// Stop before any collection: Cleanup's HOST/HOSTINFO output must carry
+	// the reconciled vnode, which only a COMMITTED baseline makes visible.
+	h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status disabled"), charWait, charTick)
+	require.Eventually(t, func() bool { return strings.Contains(jobOut.String(), "host-two") }, charWait, charTick,
+		"cleanup must emit the vnode config reconciled at registration")
+	assert.NotContains(t, jobOut.String(), "host-one",
+		"the stale creation-time vnode must never reach the wire")
+}
+
+// A leaked detection that FAILS after shutdown finalized its command as
+// 503-publish-nothing must dispose silently: the never-started vnode-bound
+// job's Cleanup would otherwise emit HOST/HOSTINFO through the open gate -
+// identity output on the wire after the one rule said nothing publishes.
+func TestLateDetectionFailure_DisposesSilentlyAfterShutdown(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	gate := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 1 {
+						<-gate // the enable's detection wedges past the deadline
+						return fmt.Errorf("late detection failure")
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	var out, jobOut simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService(), Out: &jobOut})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+	mgr.effectDeadline = testEffectDeadline
+	mgr.drainWait = 300 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	const guid = "b0b0b0b0-0000-4000-8000-000000000007"
+	h.dyncfg("vn-add", []string{h.mgr.dyncfgVnodePrefixValue(), "add", "v8"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-silent"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-add 202"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql").Set("vnode", "v8")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"vnode": "v8"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status failed"), charWait, charTick,
+		"the enable must commit its deadline outcome while the detection is wedged")
+
+	// Shutdown completes without unblocking the leaked detection.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(charWait):
+		t.Fatal("shutdown did not complete")
+	}
+
+	// The leaked detection now FAILS - after cleanup. Its disposal must be
+	// silent: nothing of the never-started job may reach the wire.
+	close(gate)
+	require.Eventually(t, func() bool { return mgr.leakedNow.Load() == 0 }, charWait, charTick,
+		"the leaked detection must drain after release")
+	assert.Empty(t, jobOut.String(),
+		"a never-started job disposed after shutdown must not emit - its command answered 503-publish-nothing")
+}
+
+// A dropped warm continuation must dispose SILENTLY: V1 Cleanup emits
+// HOST/HOSTINFO lines even for a job that never started, and publishing
+// identity output for a suppressed start would mark its vnode active and
+// leak stale job output (at shutdown it would breach the one rule). The
+// disposal closes the job's emission gate before cleanup.
+func TestWarmResume_DropDisposesSilently(t *testing.T) {
+	gate := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 1 {
+						<-gate // the enable's detection wedges past the deadline
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	var out, jobOut simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService(), Out: &jobOut})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+	mgr.effectDeadline = testEffectDeadline
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		select {
+		case <-gate:
+		default:
+			close(gate)
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	const guid = "b0b0b0b0-0000-4000-8000-000000000005"
+	h.dyncfg("vn-add", []string{h.mgr.dyncfgVnodePrefixValue(), "add", "v6"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-silent"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-add 202"), charWait, charTick)
+
+	// The vnode-bound job's detection wedges past the deadline; a disable
+	// queued behind the wedge makes the eventual late success a DROP
+	// (stop intent wins over the continuation).
+	cfg := prepareDyncfgCfg("gated", "mysql").Set("vnode", "v6")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"vnode": "v6"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status failed"), charWait, charTick,
+		"the enable must commit its deadline outcome while the detection is wedged")
+	h.dyncfg("3-disable", []string{h.mgr.dyncfgJobID(cfg), "disable"}, nil)
+
+	// Late success: the warm job is dropped for the queued disable, which
+	// then executes; the never-started job's disposal must reach the wire
+	// with NOTHING (no HOSTINFO, no HOST lines).
+	close(gate)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 3-disable 200"), charWait, charTick,
+		"the queued disable must execute after the drop")
+	assert.Empty(t, jobOut.String(),
+		"a dropped warm job must dispose silently - its cleanup output is suppressed by the closed gate")
+}
+
+// A vnode update that commits inside a dependent restart's stop/start gap
+// reaches no job (the dependent left runningJobs at its restart's stage, and
+// the replacement is not registered yet): the replacement must still start
+// on the CURRENT vnode config - registration reconciles the job's
+// creation-time snapshot against the store.
+func TestDependentRestart_ReceivesVnodeUpdatedDuringRestartGap(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			c := &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+			c.InitFunc = func(context.Context) error {
+				inits.Add(1)
+				if c.Config.OptionStr == "rotated" {
+					// The dependent restart's detection: the replacement is
+					// created (vnode snapshotted) but not yet registered.
+					select {
+					case entered <- struct{}{}:
+					default:
+					}
+					<-release
+				}
+				return nil
+			}
+			return c
+		},
+	})
+
+	var out, jobOut simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService(), Out: &jobOut})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	const guid = "b0b0b0b0-0000-4000-8000-000000000004"
+	h.dyncfg("vn-add", []string{h.mgr.dyncfgVnodePrefixValue(), "add", "v5"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-one"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-add 202"), charWait, charTick)
+	h.dyncfg("ss-add", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault", "add", "vault_prod"},
+		mustJSON(t, map[string]any{"value": "good"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-add 200"), charWait, charTick)
+
+	cfg := prepareDyncfgCfg("gated", "mysql").Set("vnode", "v5")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"vnode": "v5", "option_str": "${store:vault:vault_prod:value}"}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick)
+
+	// The rotation restarts the dependent; the replacement blocks in its
+	// detection with the OLD vnode snapshot already taken at creation.
+	h.dyncfg("ss-update", []string{h.mgr.dyncfgSecretStorePrefixValue() + "vault:vault_prod", "update"},
+		mustJSON(t, map[string]any{"value": "rotated"}))
+	select {
+	case <-entered:
+	case <-time.After(charWait):
+		t.Fatal("the dependent restart's detection did not start")
+	}
+
+	// Mid-gap vnode update: the store command holds no vnode claim, and
+	// applyVnodeUpdate reaches no job (the dependent is between instances).
+	h.dyncfg("vn-update", []string{h.mgr.dyncfgVnodePrefixValue() + ":v5", "update"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-two"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-update 202"), charWait, charTick,
+		"the vnode update must proceed during the restart gap")
+
+	// The replacement registers AFTER the vnode update committed: it must
+	// receive the current config at registration, not run on host-one.
+	close(release)
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN ss-update 200"), charWait, charTick)
+	require.Eventually(t, func() bool { return strings.Contains(jobOut.String(), "host-two") }, charWait, charTick,
+		"the restarted dependent's vnode host info must carry the config updated during the restart gap")
+}
+
+// A vnode update that commits while a dependent's key is wedged reaches only
+// RUNNING jobs (applyVnodeUpdate): the dependent's late detection success
+// must still start with the CURRENT vnode config - the resume re-delivers
+// the update the warm job missed, exactly as the live update would have.
+func TestWarmResume_RefreshesVnodeUpdatedWhileWedged(t *testing.T) {
+	gate := make(chan struct{})
+	var inits atomic.Int32
+
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				InitFunc: func(context.Context) error {
+					if inits.Add(1) == 1 {
+						<-gate // the enable's detection wedges past the deadline
+					}
+					return nil
+				},
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
+
+	// The job's chart/host wire output is observed separately from the dyncfg
+	// responder output: the refreshed vnode identity shows up as HOSTINFO on
+	// the job writer.
+	var out, jobOut simOutput
+	mgr := New(Config{PluginName: testPluginName, SecretStoreService: newTestSecretStoreService(), Out: &jobOut})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+	mgr.effectDeadline = testEffectDeadline
+
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		select {
+		case <-gate:
+		default:
+			close(gate)
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
+
+	const guid = "b0b0b0b0-0000-4000-8000-000000000003"
+	h.dyncfg("vn-add", []string{h.mgr.dyncfgVnodePrefixValue(), "add", "v3"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-one"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-add 202"), charWait, charTick)
+
+	// The job binds the vnode at creation (host-one) and its detection wedges
+	// past the deadline; the abandon releases the vnode read claim.
+	cfg := prepareDyncfgCfg("gated", "mysql").Set("vnode", "v3")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"vnode": "v3"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN 1-add"), charWait, charTick)
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status failed"), charWait, charTick,
+		"the enable must commit its deadline outcome while the detection is wedged")
+
+	// The vnode update proceeds (the read claim was released at the abandon)
+	// and reaches no jobs: the warm job is not running yet.
+	h.dyncfg("vn-update", []string{h.mgr.dyncfgVnodePrefixValue() + ":v3", "update"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-two"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-update 202"), charWait, charTick,
+		"the vnode update must proceed once the wedged dependent's read claim released")
+
+	// Late success: the warm job starts (no re-detection) and its first
+	// emission carries the UPDATED vnode identity, not the stale snapshot.
+	close(gate)
+	require.Eventually(t, h.outputContains("CONFIG test:collector:gated:mysql status running"), charWait, charTick,
+		"the late detection success must start the warm job")
+	require.Eventually(t, func() bool { return strings.Contains(jobOut.String(), "host-two") }, charWait, charTick,
+		"the warm job's vnode host info must carry the config updated during the wedge")
+	assert.NotContains(t, jobOut.String(), "host-one",
+		"the stale vnode snapshot must never reach the wire")
+	assert.Equal(t, int32(1), inits.Load(), "the warm start must not re-run detection")
+}

--- a/src/go/plugin/agent/jobmgr/vnodectl/commandacts_test.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/commandacts_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package vnodectl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestControllerCommandActsParity drives SeqExec across the deterministic
+// stage-gate matrix and asserts CommandActs agrees: a command mutates the
+// vnode store (or reaches its claim-protected gates) exactly when
+// CommandActs reports true, and every wantActs=false cell answers its
+// rejection without touching the store. Claim scheduling relies on this
+// predicate to skip the vnode write claim for rejection-only commands - a
+// stage-gate change without a matching CommandActs update fails here as the
+// starvation bug it would be. Two documented acts-but-rejects cells answer
+// inline UNDER the claim by design: payload parse/GUID/uniqueness rejections
+// (bounded by one effect window) and the remove path's referenced-by-configs
+// 409 (a stopping dependent's read claim must be waited out, not answered
+// around).
+func TestControllerCommandActsParity(t *testing.T) {
+	const guid = "b0b0b0b0-0000-4000-8000-0000000000aa"
+
+	tests := map[string]struct {
+		initial  map[string]*vnodes.VirtualNode
+		affected []string
+		fn       func(ctl *Controller) dyncfg.Function
+		wantActs bool
+		wantCode int
+	}{
+		"enable is unsupported and rejection-only": {
+			initial: map[string]*vnodes.VirtualNode{"db": testVnode("db", "h1", guid, "dyncfg")},
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.configID("db"), string(dyncfg.CommandEnable)}})
+			},
+			wantActs: false,
+			wantCode: 501,
+		},
+		"restart is unsupported and rejection-only": {
+			initial: map[string]*vnodes.VirtualNode{"db": testVnode("db", "h1", guid, "dyncfg")},
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.configID("db"), string(dyncfg.CommandRestart)}})
+			},
+			wantActs: false,
+			wantCode: 501,
+		},
+		"disable is unsupported and rejection-only": {
+			initial: map[string]*vnodes.VirtualNode{"db": testVnode("db", "h1", guid, "dyncfg")},
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.configID("db"), string(dyncfg.CommandDisable)}})
+			},
+			wantActs: false,
+			wantCode: 501,
+		},
+		"add with payload and name acts": {
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{
+					UID:         "parity",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"guid": guid, "hostname": "h1"}),
+					Args:        []string{ctl.Prefix(), string(dyncfg.CommandAdd), "db"},
+				})
+			},
+			wantActs: true,
+			wantCode: 202,
+		},
+		"add without payload is rejection-only": {
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.Prefix(), string(dyncfg.CommandAdd), "db"}})
+			},
+			wantActs: false,
+			wantCode: 400,
+		},
+		"add without a name is rejection-only": {
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{
+					UID:         "parity",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"guid": guid, "hostname": "h1"}),
+					Args:        []string{ctl.Prefix(), string(dyncfg.CommandAdd)},
+				})
+			},
+			wantActs: false,
+			wantCode: 400,
+		},
+		"add with an unacceptable name is rejection-only": {
+			// JobName() normalizes plain spaces and colons to underscores;
+			// a tab survives normalization and fails the name rule.
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{
+					UID:         "parity",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"guid": guid, "hostname": "h1"}),
+					Args:        []string{ctl.Prefix(), string(dyncfg.CommandAdd), "bad\tname"},
+				})
+			},
+			wantActs: false,
+			wantCode: 400,
+		},
+		"add with an invalid guid acts and rejects inline under the claim": {
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{
+					UID:         "parity",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"guid": "not-a-guid", "hostname": "h1"}),
+					Args:        []string{ctl.Prefix(), string(dyncfg.CommandAdd), "db"},
+				})
+			},
+			wantActs: true,
+			wantCode: 400,
+		},
+		"update of an existing vnode acts": {
+			initial: map[string]*vnodes.VirtualNode{"db": testVnode("db", "h1", guid, "dyncfg")},
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{
+					UID:         "parity",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"guid": guid, "hostname": "h2"}),
+					Args:        []string{ctl.configID("db"), string(dyncfg.CommandUpdate)},
+				})
+			},
+			wantActs: true,
+			wantCode: 202,
+		},
+		"update of a missing vnode is rejection-only": {
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{
+					UID:         "parity",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"guid": guid, "hostname": "h2"}),
+					Args:        []string{ctl.configID("db"), string(dyncfg.CommandUpdate)},
+				})
+			},
+			wantActs: false,
+			wantCode: 404,
+		},
+		"remove of a dyncfg vnode acts": {
+			initial: map[string]*vnodes.VirtualNode{"db": testVnode("db", "h1", guid, "dyncfg")},
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.configID("db"), string(dyncfg.CommandRemove)}})
+			},
+			wantActs: true,
+			wantCode: 200,
+		},
+		"remove of a missing vnode is rejection-only": {
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.configID("db"), string(dyncfg.CommandRemove)}})
+			},
+			wantActs: false,
+			wantCode: 404,
+		},
+		"remove of a non-dyncfg vnode is rejection-only": {
+			initial: map[string]*vnodes.VirtualNode{"db": testVnode("db", "h1", guid, "stock")},
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.configID("db"), string(dyncfg.CommandRemove)}})
+			},
+			wantActs: false,
+			wantCode: 405,
+		},
+		"remove of a referenced vnode acts but answers 409 under the claim": {
+			initial:  map[string]*vnodes.VirtualNode{"db": testVnode("db", "h1", guid, "dyncfg")},
+			affected: []string{"mysql:prod"},
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.configID("db"), string(dyncfg.CommandRemove)}})
+			},
+			wantActs: true,
+			wantCode: 409,
+		},
+		"test answers inline and never claims": {
+			initial: map[string]*vnodes.VirtualNode{"db": testVnode("db", "h1", guid, "dyncfg")},
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{
+					UID:         "parity",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"guid": guid, "hostname": "h2"}),
+					Args:        []string{ctl.Prefix(), string(dyncfg.CommandTest), "db"},
+				})
+			},
+			wantActs: false,
+			wantCode: 202,
+		},
+		"get answers inline and never claims": {
+			initial: map[string]*vnodes.VirtualNode{"db": testVnode("db", "h1", guid, "dyncfg")},
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.configID("db"), string(dyncfg.CommandGet)}})
+			},
+			wantActs: false,
+			wantCode: 200,
+		},
+		"schema answers inline and never claims": {
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{UID: "parity", Args: []string{ctl.Prefix(), string(dyncfg.CommandSchema)}})
+			},
+			wantActs: false,
+			wantCode: 200,
+		},
+		"userconfig answers inline and never claims": {
+			fn: func(ctl *Controller) dyncfg.Function {
+				return dyncfg.NewFunction(functions.Function{
+					UID:         "parity",
+					ContentType: "application/json",
+					Payload:     mustJSON(t, map[string]any{"guid": guid, "hostname": "h1"}),
+					Args:        []string{ctl.Prefix(), string(dyncfg.CommandUserconfig), "db"},
+				})
+			},
+			wantActs: false,
+			wantCode: 200,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctl, out, seams := newControllerTestSubject(tc.initial)
+			for _, ref := range tc.affected {
+				seams.affectedJobs["db"] = append(seams.affectedJobs["db"], ref)
+			}
+
+			fn := tc.fn(ctl)
+
+			// Capture the predicate BEFORE running: execution mutates the
+			// store, and the executor consults the predicate pre-execution.
+			acts := ctl.CommandActs(fn)
+			assert.Equal(t, tc.wantActs, acts, "CommandActs")
+
+			ctl.SeqExec(fn)
+			assert.Contains(t, out.String(), fmt.Sprintf("FUNCTION_RESULT_BEGIN parity %d", tc.wantCode),
+				"the command must answer its expected outcome, output:\n%s", out.String())
+
+			if !tc.wantActs {
+				if tc.initial == nil {
+					_, ok := ctl.Lookup("db")
+					assert.False(t, ok, "a rejection-only command must not create store state")
+				} else if orig := tc.initial["db"]; orig != nil {
+					got, ok := ctl.Lookup("db")
+					assert.True(t, ok, "a rejection-only command must not remove store state")
+					assert.Equal(t, orig.Hostname, got.Hostname, "a rejection-only command must not mutate store state")
+				}
+			}
+		})
+	}
+}

--- a/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
@@ -77,6 +77,41 @@ func (c *Controller) SeqExec(fn dyncfg.Function) {
 	}
 }
 
+// CommandActs reports whether fn may execute CLAIMLESSLY: false only when
+// execution answers a deterministic rejection BEFORE its first
+// claim-protected access - an unsupported command (the 501 arm above), a
+// missing vnode on update/remove, a non-dyncfg vnode on remove, or a
+// missing payload/name on add. The remove SOURCE gate belongs here only
+// because dyncfgCmdRemove orders it BEFORE the referenced-by-configs read
+// (unlike the store domain, whose remove reads its dependency index
+// first). Claim scheduling consults it so rejection-only vnode commands
+// claim nothing instead of parking behind collector read claims held
+// across effects; the parity test drives SeqExec against it. Deliberately
+// NOT mirrored here: payload parse/GUID/uniqueness rejections (answered
+// inline under the claim, bounded by one effect window) and the remove
+// path's referenced-by-configs 409, which must be evaluated under the
+// granted write claim (a stopping dependent's read claim must be waited
+// out, not answered around). schema/get/userconfig/test answer inline and
+// never claim.
+func (c *Controller) CommandActs(fn dyncfg.Function) bool {
+	switch fn.Command() {
+	case dyncfg.CommandAdd:
+		if fn.ValidateArgs(3) != nil || !fn.HasPayload() {
+			return false
+		}
+		name := fn.JobName()
+		return name != "" && dyncfg.JobNameRuleAllowDots(name) == nil
+	case dyncfg.CommandUpdate:
+		_, ok := c.Lookup(strings.TrimPrefix(fn.ID(), c.Prefix()+":"))
+		return ok
+	case dyncfg.CommandRemove:
+		vnode, ok := c.Lookup(strings.TrimPrefix(fn.ID(), c.Prefix()+":"))
+		return ok && vnode.SourceType == confgroup.TypeDyncfg
+	default:
+		return false
+	}
+}
+
 func (c *Controller) dyncfgCmdSchema(fn dyncfg.Function) {
 	c.api.SendJSON(fn, vnodes.ConfigSchema)
 }

--- a/src/go/plugin/framework/dyncfg/handler.go
+++ b/src/go/plugin/framework/dyncfg/handler.go
@@ -5,6 +5,8 @@ package dyncfg
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -70,10 +72,42 @@ func IsRetryableError(err error) bool {
 	return errors.As(err, &re) && re.DyncfgRetryable()
 }
 
-// CommandMessageSource optionally provides a success/warning message
-// for the command that just completed.
-type CommandMessageSource interface {
-	TakeCommandMessage() string
+// commandMessageBox carries a command's success/warning message from its
+// effect to its commit. One box exists per command invocation and rides the
+// effect contexts, so concurrent commands can never cross-attribute
+// messages; the mutex covers the effect-goroutine write vs the commit read.
+type commandMessageBox struct {
+	mu  sync.Mutex
+	msg string
+}
+
+func (b *commandMessageBox) set(msg string) {
+	b.mu.Lock()
+	b.msg = msg
+	b.mu.Unlock()
+}
+
+func (b *commandMessageBox) take() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	msg := strings.TrimSpace(b.msg)
+	b.msg = ""
+	return msg
+}
+
+type commandMessageKey struct{}
+
+func withCommandMessage(ctx context.Context, box *commandMessageBox) context.Context {
+	return context.WithValue(ctx, commandMessageKey{}, box)
+}
+
+// SetCommandMessage records a success/warning message for the running
+// command; the commit emits it in the terminal response. No-op outside a
+// command effect.
+func SetCommandMessage(ctx context.Context, msg string) {
+	if box, ok := ctx.Value(commandMessageKey{}).(*commandMessageBox); ok {
+		box.set(msg)
+	}
 }
 
 // HandlerOpts configures the handler with component-specific settings.
@@ -106,14 +140,6 @@ type Handler[C Config] struct {
 	removeStockOnEnableFail bool
 	configCommands          []Command
 	waitGate                *waitGate[C]
-}
-
-func takeCommandMessage[C Config](cb Callbacks[C]) string {
-	msgSrc, ok := any(cb).(CommandMessageSource)
-	if !ok {
-		return ""
-	}
-	return msgSrc.TakeCommandMessage()
 }
 
 // WaitTimeoutEvent describes a wait gate timeout transition.
@@ -453,6 +479,81 @@ func (h *Handler[C]) configSupportedCommands(cfg C, isDyncfg bool) string {
 // another blocking phase of the same command.
 type StepRunner func(effect func(context.Context) error, commit func(error))
 
+// StagedStop is a stop split in two: the routing removal already happened on
+// the goroutine that called StageStop (the command-staging goroutine), and
+// Wait performs the blocking half inside the effect. Undo restores routing
+// when the wait NEVER RAN (the commit received ErrPhaseNeverRan): nothing
+// was stopped, so the stage-time removal would otherwise leave live work
+// invisible to routing and cleanup.
+type StagedStop struct {
+	Wait func(ctx context.Context)
+	Undo func()
+}
+
+// StagedUpdate is the update-shaped counterpart: Run embeds an
+// already-staged stop of the old config's work followed by the replacement's
+// start. Undo reverts the staged routing removal when Run never executed, or
+// when it reports a non-disruptive failure (the old work was not touched).
+type StagedUpdate struct {
+	Run  func(ctx context.Context) error
+	Undo func()
+}
+
+// StopStager is an optional Callbacks extension: components whose Stop has a
+// blocking wait implement it so routing removal happens when the command
+// stages instead of when the effect reaches a pool worker. Components
+// without it keep the single-phase Stop/Update semantics.
+type StopStager[C Config] interface {
+	StageStop(cfg C) StagedStop
+}
+
+// UpdateStager is the Update-shaped staging extension; see StopStager.
+type UpdateStager[C Config] interface {
+	StageUpdate(oldCfg, newCfg C) StagedUpdate
+}
+
+// PayloadParser is an optional Callbacks extension: ParsePayload runs the
+// CHEAP, deterministic parse prefix of ParseAndValidate (no I/O, no module
+// instantiation, no store access - it MUST stay pure in fn AND total on
+// arbitrary payloads: it runs on the caller's dispatch loop, which has no
+// recover, so a panic here - e.g. writing into a map a "null" document
+// left nil - kills the plugin) and returns the same error
+// ParseAndValidate's parse step would return for the same input.
+// When implemented, add and update answer a malformed payload's 400 at
+// STAGE - before any claim or effect - and the acts predicate classifies
+// the command as rejection-only instead of letting it park behind held
+// dependency claims. Components without it keep the parse-in-effect
+// semantics.
+type PayloadParser interface {
+	ParsePayload(fn Function, name string) error
+}
+
+// stagedStopFor stages the config's stop through the callbacks' StopStager
+// when implemented; otherwise it degrades to the single-phase cb.Stop with a
+// no-op Undo.
+func (h *Handler[C]) stagedStopFor(cfg C) StagedStop {
+	if ss, ok := any(h.cb).(StopStager[C]); ok {
+		return ss.StageStop(cfg)
+	}
+	return StagedStop{
+		Wait: func(ctx context.Context) { h.cb.Stop(ctx, cfg) },
+		Undo: func() {},
+	}
+}
+
+// stagedUpdateFor stages the update through the callbacks' UpdateStager when
+// implemented; otherwise it degrades to the single-phase cb.Update with a
+// no-op Undo.
+func (h *Handler[C]) stagedUpdateFor(oldCfg, newCfg C) StagedUpdate {
+	if us, ok := any(h.cb).(UpdateStager[C]); ok {
+		return us.StageUpdate(oldCfg, newCfg)
+	}
+	return StagedUpdate{
+		Run:  func(ctx context.Context) error { return h.cb.Update(ctx, oldCfg, newCfg) },
+		Undo: func() {},
+	}
+}
+
 // RunStepSync is the synchronous StepRunner used by the legacy Cmd* methods.
 func RunStepSync(effect func(context.Context) error, commit func(error)) {
 	commit(effect(context.Background()))
@@ -465,11 +566,12 @@ func RunStepSync(effect func(context.Context) error, commit func(error)) {
 var ErrPhaseNeverRan = errors.New("the operation did not run: shutting down")
 
 // ErrPhaseAbandoned is committed for a blocking phase that ran past its
-// deadline (or into shutdown) and was abandoned with the job's output
-// fenced. Stop-shaped commits publish success on it by contract - the
-// stop is guaranteed to be effective even though the call has not
-// returned. Any other stop error (e.g. a recovered panic) proves nothing
-// about the job's state and MUST commit as failed.
+// DEADLINE and was abandoned with the job's output fenced. Stop-shaped
+// commits publish success on it by contract - the stop is guaranteed to be
+// effective even though the call has not returned. Shutdown interruptions
+// never carry it (they map to ErrPhaseNeverRan: 503, publish nothing). Any
+// other stop error (e.g. a recovered panic) proves nothing about the job's
+// state and MUST commit as failed.
 var ErrPhaseAbandoned = errors.New("the operation was abandoned")
 
 // CmdAddStep is CmdAdd with a caller-supplied StepRunner.
@@ -496,24 +598,9 @@ func (h *Handler[C]) CmdAdd(fn Function) {
 }
 
 func (h *Handler[C]) cmdAdd(fn Function, run StepRunner) {
-	if err := fn.ValidateArgs(3); err != nil {
-		h.api.SendCodef(fn, 400, "%v", err)
-		return
-	}
-
-	key, name, ok := h.cb.ExtractKey(fn)
-	if !ok {
-		h.api.SendCodef(fn, 400, "invalid config ID format.")
-		return
-	}
-
-	if err := fn.ValidateHasPayload(); err != nil {
-		h.api.SendCodef(fn, 400, "%v", err)
-		return
-	}
-
-	if err := h.cb.ValidateConfigName(name); err != nil {
-		h.api.SendCodef(fn, 400, "invalid config name '%s': %v.", name, err)
+	key, name, code, msg := h.addRejection(fn)
+	if code != 0 {
+		h.api.SendCodef(fn, code, "%s", msg)
 		return
 	}
 
@@ -555,11 +642,13 @@ func (h *Handler[C]) cmdAdd(fn Function, run StepRunner) {
 			}
 			existingEntry := existing
 			h.exposed.Remove(existing.Cfg)
+			staged := h.stagedStopFor(existing.Cfg)
 			run(func(ctx context.Context) error {
-				h.cb.Stop(ctx, existing.Cfg)
+				staged.Wait(ctx)
 				return nil
 			}, func(stopErr error) {
 				if errors.Is(stopErr, ErrPhaseNeverRan) {
+					staged.Undo()
 					if wasSeen {
 						h.seen.Add(existingEntry.Cfg)
 					}
@@ -618,8 +707,9 @@ func (h *Handler[C]) cmdEnable(fn Function, run StepRunner) {
 		return
 	}
 
+	box := &commandMessageBox{}
 	run(func(ctx context.Context) error {
-		return h.cb.Start(ctx, entry.Cfg)
+		return h.cb.Start(withCommandMessage(ctx, box), entry.Cfg)
 	}, func(err error) {
 		if errors.Is(err, ErrPhaseNeverRan) {
 			// The start never executed (shutdown): the config is untouched -
@@ -652,7 +742,7 @@ func (h *Handler[C]) cmdEnable(fn Function, run StepRunner) {
 		}
 
 		entry.Status = StatusRunning
-		h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+		h.api.SendCodef(fn, 200, "%s", box.take())
 		h.NotifyConfigStatus(entry.Cfg, StatusRunning)
 		h.cb.OnStatusChange(entry, oldStatus, fn)
 	})
@@ -685,11 +775,14 @@ func (h *Handler[C]) cmdDisable(fn Function, run StepRunner) {
 	}
 
 	// Unconditional for all non-Disabled statuses.
+	box := &commandMessageBox{}
+	staged := h.stagedStopFor(entry.Cfg)
 	run(func(ctx context.Context) error {
-		h.cb.Stop(ctx, entry.Cfg)
+		staged.Wait(withCommandMessage(ctx, box))
 		return nil
 	}, func(stopErr error) {
 		if errors.Is(stopErr, ErrPhaseNeverRan) {
+			staged.Undo()
 			h.api.SendCodef(fn, 503, "%v", stopErr)
 			return
 		}
@@ -703,7 +796,7 @@ func (h *Handler[C]) cmdDisable(fn Function, run StepRunner) {
 			return
 		}
 		entry.Status = StatusDisabled
-		h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+		h.api.SendCodef(fn, 200, "%s", box.take())
 		h.NotifyConfigStatus(entry.Cfg, StatusDisabled)
 		h.cb.OnStatusChange(entry, oldStatus, fn)
 	})
@@ -712,6 +805,138 @@ func (h *Handler[C]) cmdDisable(fn Function, run StepRunner) {
 // CmdRemove handles the "remove" command.
 func (h *Handler[C]) CmdRemove(fn Function) {
 	h.cmdRemove(fn, RunStepSync)
+}
+
+// CommandActs reports whether fn against entry reaches a phase that stops
+// or starts work - where dependency reservations are load-bearing - as
+// opposed to answering a deterministic rejection or no-op. Claim scheduling
+// uses it so "rejection-only commands claim nothing" cannot drift from the
+// Cmd* gates in this file. The criterion is EXECUTION ORDER, not the
+// eventual outcome: false is returned only when the command's execution
+// answers BEFORE its first claim-protected access - a rejection that
+// execution reaches only after such an access (a domain gate ordered
+// behind a dependency-index read) must claim first and answer under the
+// claim.
+//
+// Add and update do not mirror their gates AT ALL: the predicate runs the
+// SAME addRejection/updateRejection functions their Cmd* bodies answer
+// from, so a gate added there - including callback gates like
+// ValidateConfigName, which a mirror in this file cannot see - is
+// automatically rejection-only (eight starvation findings proved that
+// mirroring the parse-shaped gate chains does not converge). The
+// stop/start-shaped commands keep the explicit state predicate below
+// (enable no-ops on Running; restart rejects Accepted/Disabled; disable
+// no-ops on Disabled; remove rejects non-dyncfg sources and non-job types;
+// a nil entry never acts); their pre-effect sections mutate caches, so
+// they cannot share a rejection function, and the parity test drives every
+// command against every gate combination to hold them to this predicate.
+// Identity gates (argument count, config ID format) are also the caller's
+// underivable axis.
+func (h *Handler[C]) CommandActs(fn Function, entry *Entry[C]) bool {
+	switch cmd := fn.Command(); cmd {
+	case CommandAdd:
+		_, _, code, _ := h.addRejection(fn)
+		return code == 0
+	case CommandUpdate:
+		_, _, code, _ := h.updateRejection(fn)
+		return code == 0
+	default:
+		if entry == nil {
+			return false
+		}
+		switch cmd {
+		case CommandEnable:
+			return entry.Status == StatusAccepted || entry.Status == StatusDisabled || entry.Status == StatusFailed
+		case CommandRestart:
+			return entry.Status == StatusRunning || entry.Status == StatusFailed
+		case CommandDisable:
+			return entry.Status != StatusDisabled
+		case CommandRemove:
+			return entry.Cfg.SourceType() == "dyncfg" && h.cb.ConfigType(entry.Cfg) == ConfigTypeJob
+		}
+		return false
+	}
+}
+
+// RejectionDependsOnStatus reports whether fn's rejection-only
+// classification against entry is derived from entry.Status - the one
+// input a FOREIGN write-claim holder (a store command's dependent-restart
+// plan) mutates from another key. A status-derived rejection is
+// deterministic only while no foreign write claim holds the command's key:
+// under a hold the status is mid-mutation, and an answer minted from it
+// can be falsified by the holder's outcome (an enable answering the
+// Running no-op 200 while the dependent restart it cannot see is stopping
+// - and may fail - that very job). Claim scheduling treats such commands
+// as ACTING while their key is write-held, so they park and answer
+// truthfully after the hold resolves. Meaningful only when CommandActs
+// reported false; every other rejection axis (identity, existence,
+// source/type, payload, command support) depends on state no foreign
+// holder mutates.
+func (h *Handler[C]) RejectionDependsOnStatus(fn Function, entry *Entry[C]) bool {
+	if entry == nil {
+		return false
+	}
+	switch fn.Command() {
+	case CommandEnable, CommandRestart, CommandDisable:
+		return true
+	}
+	return false
+}
+
+// addRejection runs cmdAdd's deterministic pre-effect gates and reports the
+// rejection they produce (code 0 = the command acts). It is the SINGLE
+// SOURCE for both cmdAdd and CommandActs; add a gate here, never in either
+// caller.
+func (h *Handler[C]) addRejection(fn Function) (key, name string, code int, msg string) {
+	if err := fn.ValidateArgs(3); err != nil {
+		return "", "", 400, fmt.Sprintf("%v", err)
+	}
+	key, name, ok := h.cb.ExtractKey(fn)
+	if !ok {
+		return "", "", 400, "invalid config ID format."
+	}
+	if err := fn.ValidateHasPayload(); err != nil {
+		return "", "", 400, fmt.Sprintf("%v", err)
+	}
+	if err := h.cb.ValidateConfigName(name); err != nil {
+		return "", "", 400, fmt.Sprintf("invalid config name '%s': %v.", name, err)
+	}
+	if err := h.parsePayload(fn, name); err != nil {
+		return "", "", 400, fmt.Sprintf("%v", err)
+	}
+	return key, name, 0, ""
+}
+
+// updateRejection runs cmdUpdate's deterministic pre-effect gates and
+// reports the rejection they produce (code 0 = the command acts, and the
+// exposed entry is returned). It is the SINGLE SOURCE for both cmdUpdate
+// and CommandActs; add a gate here, never in either caller.
+func (h *Handler[C]) updateRejection(fn Function) (name string, entry *Entry[C], code int, msg string) {
+	key, name, ok := h.cb.ExtractKey(fn)
+	if !ok {
+		return "", nil, 400, "invalid config ID format."
+	}
+	entry, ok = h.exposed.LookupByKey(key)
+	if !ok {
+		return "", nil, 404, "config not found."
+	}
+	if err := fn.ValidateHasPayload(); err != nil {
+		return "", nil, 400, fmt.Sprintf("%v", err)
+	}
+	if err := h.parsePayload(fn, name); err != nil {
+		return "", nil, 400, fmt.Sprintf("%v", err)
+	}
+	return name, entry, 0, ""
+}
+
+// parsePayload runs the callbacks' cheap parse prefix when they implement
+// PayloadParser; components without it defer payload-format rejection to
+// ParseAndValidate in the effect.
+func (h *Handler[C]) parsePayload(fn Function, name string) error {
+	if p, ok := any(h.cb).(PayloadParser); ok {
+		return p.ParsePayload(fn, name)
+	}
+	return nil
 }
 
 func (h *Handler[C]) cmdRemove(fn Function, run StepRunner) {
@@ -739,13 +964,16 @@ func (h *Handler[C]) cmdRemove(fn Function, run StepRunner) {
 	// Cache removal precedes the blocking stop (remove-before-block).
 	h.seen.Remove(entry.Cfg)
 	h.exposed.Remove(entry.Cfg)
+	box := &commandMessageBox{}
+	staged := h.stagedStopFor(entry.Cfg)
 	run(func(ctx context.Context) error {
-		h.cb.Stop(ctx, entry.Cfg)
+		staged.Wait(withCommandMessage(ctx, box))
 		return nil
 	}, func(stopErr error) {
 		if errors.Is(stopErr, ErrPhaseNeverRan) {
 			// Nothing was stopped: restore the stage-time cache removals and
 			// answer retryably instead of publishing a delete that is a lie.
+			staged.Undo()
 			h.seen.Add(entry.Cfg)
 			h.exposed.Add(entry)
 			h.api.SendCodef(fn, 503, "%v", stopErr)
@@ -764,7 +992,7 @@ func (h *Handler[C]) cmdRemove(fn Function, run StepRunner) {
 			h.cb.OnStatusChange(entry, oldStatus, fn)
 			return
 		}
-		h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+		h.api.SendCodef(fn, 200, "%s", box.take())
 		h.NotifyConfigRemove(entry.Cfg)
 	})
 }
@@ -775,27 +1003,17 @@ func (h *Handler[C]) CmdUpdate(fn Function) {
 }
 
 func (h *Handler[C]) cmdUpdate(fn Function, run StepRunner) {
-	key, name, ok := h.cb.ExtractKey(fn)
-	if !ok {
-		h.api.SendCodef(fn, 400, "invalid config ID format.")
+	name, entry, code, msg := h.updateRejection(fn)
+	if code != 0 {
+		h.api.SendCodef(fn, code, "%s", msg)
 		return
 	}
 
-	entry, ok := h.exposed.LookupByKey(key)
-	if !ok {
-		h.api.SendCodef(fn, 404, "config not found.")
-		return
-	}
-
-	if err := fn.ValidateHasPayload(); err != nil {
-		h.api.SendCodef(fn, 400, "%v", err)
-		return
-	}
-
+	box := &commandMessageBox{}
 	var newCfg C
 	run(func(ctx context.Context) error {
 		var err error
-		newCfg, err = h.cb.ParseAndValidate(ctx, fn, name)
+		newCfg, err = h.cb.ParseAndValidate(withCommandMessage(ctx, box), fn, name)
 		return err
 	}, func(err error) {
 		if errors.Is(err, ErrPhaseNeverRan) {
@@ -843,33 +1061,43 @@ func (h *Handler[C]) cmdUpdate(fn Function, run StepRunner) {
 				if isConversion {
 					h.NotifyConfigCreate(newCfg, StatusDisabled)
 				}
-				h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+				h.api.SendCodef(fn, 200, "%s", box.take())
 				h.NotifyConfigStatus(newCfg, StatusDisabled)
 				h.cb.OnStatusChange(newEntry, oldStatus, fn)
 				return
 			}
 
-			// Start or update.
+			// Start or update. The non-conversion update stages its old
+			// instance's stop NOW (on the staging goroutine): routing to the
+			// job being replaced ends immediately, the blocking wait runs in
+			// the effect.
+			effect := func(ctx context.Context) error { return h.cb.Start(ctx, newCfg) }
+			undo := func() {}
+			if !isConversion {
+				upd := h.stagedUpdateFor(oldCfg, newCfg)
+				effect, undo = upd.Run, upd.Undo
+			}
 			run(func(ctx context.Context) error {
-				if isConversion {
-					return h.cb.Start(ctx, newCfg)
-				}
-				return h.cb.Update(ctx, oldCfg, newCfg)
+				return effect(withCommandMessage(ctx, box))
 			}, func(err error) {
-				if !isConversion && errors.Is(err, ErrPhaseNeverRan) {
-					// The update phase never executed (shutdown): the old
-					// instance is untouched - roll back to the old cache state
-					// and answer retryably instead of publishing failed.
+				if errors.Is(err, ErrPhaseNeverRan) {
+					// The update was interrupted by shutdown: roll back to the
+					// old cache state and answer retryably, publishing nothing
+					// (at shutdown every non-terminal command answers 503 and
+					// emits no CONFIG lines).
+					undo()
 					h.seen.Remove(newCfg)
-					h.seen.Add(oldCfg)
+					if !isConversion {
+						h.seen.Add(oldCfg)
+					}
 					h.exposed.Add(entry)
 					h.api.SendCodef(fn, 503, "%v", err)
-					h.NotifyConfigStatus(oldCfg, oldStatus)
 					return
 				}
 				if err != nil {
 					if !isConversion && errors.Is(err, ErrNonDisruptiveUpdate) {
 						// Update failed before runtime disruption; rollback to old cache state.
+						undo()
 						h.seen.Remove(newCfg)
 						h.seen.Add(oldCfg)
 						h.exposed.Add(entry)
@@ -898,7 +1126,7 @@ func (h *Handler[C]) cmdUpdate(fn Function, run StepRunner) {
 				if isConversion {
 					h.NotifyConfigCreate(newCfg, StatusRunning)
 				}
-				h.api.SendCodef(fn, 200, "%s", takeCommandMessage(h.cb))
+				h.api.SendCodef(fn, 200, "%s", box.take())
 				h.NotifyConfigStatus(newCfg, StatusRunning)
 				h.cb.OnStatusChange(newEntry, oldStatus, fn)
 			})
@@ -906,14 +1134,16 @@ func (h *Handler[C]) cmdUpdate(fn Function, run StepRunner) {
 
 		// For conversion, stop the old work before publishing replacement config state.
 		if isConversion {
+			staged := h.stagedStopFor(oldCfg)
 			run(func(ctx context.Context) error {
-				h.cb.Stop(ctx, oldCfg)
+				staged.Wait(withCommandMessage(ctx, box))
 				return nil
 			}, func(stopErr error) {
 				if errors.Is(stopErr, ErrPhaseNeverRan) {
 					// Nothing happened at all: the old job is untouched and
 					// the caches were not swapped yet - answer retryably
 					// without marking anything failed.
+					staged.Undo()
 					h.api.SendCodef(fn, 503, "%v", stopErr)
 					return
 				}
@@ -974,13 +1204,15 @@ func (h *Handler[C]) cmdRestart(fn Function, run StepRunner) {
 
 	oldStatus := entry.Status
 
+	staged := h.stagedStopFor(entry.Cfg)
 	run(func(ctx context.Context) error {
-		h.cb.Stop(ctx, entry.Cfg)
+		staged.Wait(ctx)
 		return nil
 	}, func(stopErr error) {
 		if errors.Is(stopErr, ErrPhaseNeverRan) {
 			// Nothing happened at all: answer retryably without publishing a
 			// failed status for a job that is in fact untouched.
+			staged.Undo()
 			h.api.SendCodef(fn, 503, "%v", stopErr)
 			return
 		}
@@ -1000,6 +1232,13 @@ func (h *Handler[C]) cmdRestart(fn Function, run StepRunner) {
 		run(func(ctx context.Context) error {
 			return h.cb.Start(ctx, entry.Cfg)
 		}, func(err error) {
+			if errors.Is(err, ErrPhaseNeverRan) {
+				// The start phase was interrupted by shutdown: answer 503 and
+				// publish nothing (at shutdown every non-terminal command
+				// answers retryably and emits no CONFIG lines).
+				h.api.SendCodef(fn, 503, "%v", err)
+				return
+			}
 			if err != nil {
 				entry.Status = StatusFailed
 				code := 422

--- a/src/go/plugin/framework/dyncfg/handler_test.go
+++ b/src/go/plugin/framework/dyncfg/handler_test.go
@@ -32,6 +32,7 @@ func (e *codedErr) DyncfgCode() int { return e.code }
 // mockCallbacks records all callback invocations for verification.
 type mockCallbacks struct {
 	extractKeyFn       func(fn Function) (string, string, bool)
+	parsePayloadFn     func(fn Function, name string) error
 	parseAndValidateFn func(fn Function, name string) (testConfig, error)
 	startFn            func(cfg testConfig) error
 	updateFn           func(oldCfg, newCfg testConfig) error
@@ -65,6 +66,13 @@ func (m *mockCallbacks) ExtractKey(fn Function) (string, string, bool) {
 		return "", "", false
 	}
 	return parts[1], parts[1], true
+}
+
+func (m *mockCallbacks) ParsePayload(fn Function, name string) error {
+	if m.parsePayloadFn != nil {
+		return m.parsePayloadFn(fn, name)
+	}
+	return nil
 }
 
 func (m *mockCallbacks) ParseAndValidate(_ context.Context, fn Function, name string) (testConfig, error) {
@@ -1634,5 +1642,155 @@ func TestStopCommitOutcomeMapping(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, tc.run)
+	}
+}
+
+// TestHandler_RejectionDependsOnStatus pins the status-axis classification
+// consumed by hold-aware claim scheduling: exactly the enable/restart/
+// disable arms against an EXISTING entry are status-derived (their
+// rejection-only outcome can be falsified by a foreign write-claim holder
+// mutating entry.Status); every other command - and every command against
+// a nil entry - rejects on state no foreign holder mutates.
+func TestHandler_RejectionDependsOnStatus(t *testing.T) {
+	cb := &mockCallbacks{}
+	h := newTestHandler(cb)
+	cfg := testConfig{uid: "uid-j", key: "j", sourceType: "dyncfg", source: "test"}
+	entry := &Entry[testConfig]{Cfg: cfg, Status: StatusRunning}
+
+	commands := []Command{CommandAdd, CommandUpdate, CommandEnable, CommandRestart,
+		CommandDisable, CommandRemove, CommandGet, CommandSchema}
+	for _, cmd := range commands {
+		fn := newTestFn("test:j", string(cmd), "", nil)
+		want := cmd == CommandEnable || cmd == CommandRestart || cmd == CommandDisable
+		assert.Equal(t, want, h.RejectionDependsOnStatus(fn, entry), "command %s with an entry", cmd)
+		assert.False(t, h.RejectionDependsOnStatus(fn, nil), "command %s with a nil entry", cmd)
+	}
+}
+
+// TestHandler_CommandActsParity drives every state-gated command against
+// every gate combination and asserts CommandActs agrees with the Cmd*
+// implementations: blocking work runs (the step runner is invoked) exactly
+// when CommandActs reports true. Claim scheduling relies on this predicate
+// to skip dependency reservations for rejection-only commands - a gate
+// change in a Cmd* body without a matching CommandActs update fails here
+// as the starvation bug it would be. The payload axis is part of the
+// matrix: add and update answer 400 before any blocking work when the
+// payload is missing.
+func TestHandler_CommandActsParity(t *testing.T) {
+	type gate struct {
+		sourceType string
+		configType ConfigType
+	}
+	statuses := []Status{StatusAccepted, StatusRunning, StatusFailed, StatusDisabled}
+	gates := []gate{
+		{"dyncfg", ConfigTypeJob},
+		{"user", ConfigTypeJob},
+		{"stock", ConfigTypeJob},
+		{"dyncfg", ConfigTypeSingle},
+	}
+	commands := []Command{CommandUpdate, CommandEnable, CommandRestart, CommandDisable, CommandRemove}
+	payloads := []struct {
+		name    string
+		payload []byte
+	}{
+		{"with payload", []byte(`{}`)},
+		{"without payload", nil},
+		{"with unparsable payload", []byte("garbage")},
+	}
+	// The PayloadParser stage gate: "garbage" fails the cheap parse, so
+	// add/update with it are rejection-only before any blocking work.
+	parsePayload := func(fn Function, _ string) error {
+		if string(fn.Fn().Payload) == "garbage" {
+			return errors.New("unparsable payload")
+		}
+		return nil
+	}
+
+	driveWithSpy := func(h *Handler[testConfig], cmd Command, fn Function) bool {
+		ran := false
+		spy := func(effect func(context.Context) error, commit func(error)) {
+			ran = true
+			RunStepSync(effect, commit)
+		}
+		switch cmd {
+		case CommandAdd:
+			h.cmdAdd(fn, spy)
+		case CommandUpdate:
+			h.cmdUpdate(fn, spy)
+		case CommandEnable:
+			h.cmdEnable(fn, spy)
+		case CommandRestart:
+			h.cmdRestart(fn, spy)
+		case CommandDisable:
+			h.cmdDisable(fn, spy)
+		case CommandRemove:
+			h.cmdRemove(fn, spy)
+		}
+		return ran
+	}
+
+	for _, cmd := range commands {
+		for _, st := range statuses {
+			for _, g := range gates {
+				for _, pl := range payloads {
+					name := fmt.Sprintf("%s on %s %s %s %s", cmd, st, g.sourceType, g.configType, pl.name)
+					t.Run(name, func(t *testing.T) {
+						cb := &mockCallbacks{
+							configTypeFn:   func(testConfig) ConfigType { return g.configType },
+							parsePayloadFn: parsePayload,
+						}
+						h := newTestHandler(cb)
+						cfg := testConfig{uid: "uid-j", key: "j", sourceType: g.sourceType, source: "test"}
+						entry := &Entry[testConfig]{Cfg: cfg, Status: st}
+						h.seen.Add(cfg)
+						h.exposed.Add(entry)
+
+						fn := newTestFn("test:j", string(cmd), "", pl.payload)
+
+						// Capture the predicate BEFORE running: the command's
+						// commit mutates entry.Status (that is its job), and the
+						// executor consults the predicate pre-execution.
+						acts := h.CommandActs(fn, entry)
+
+						ran := driveWithSpy(h, cmd, fn)
+
+						assert.Equal(t, acts, ran,
+							"CommandActs must mirror whether the handler runs blocking work")
+					})
+				}
+			}
+		}
+	}
+
+	// Add cells: a nil entry acts only for add, an existing entry takes the
+	// replace path - both gated on payload presence AND the callback name
+	// policy (the mock uses JobNameRuleStrict, so a dotted name answers 400
+	// before any blocking work).
+	for _, pl := range payloads {
+		for _, existing := range []bool{false, true} {
+			for _, jobName := range []string{"j", "bad.name"} {
+				name := fmt.Sprintf("add %s existing=%v name=%s", pl.name, existing, jobName)
+				t.Run(name, func(t *testing.T) {
+					cb := &mockCallbacks{parsePayloadFn: parsePayload}
+					h := newTestHandler(cb)
+					var entry *Entry[testConfig]
+					if existing {
+						cfg := testConfig{uid: "uid-" + jobName, key: jobName, sourceType: "dyncfg", source: "test"}
+						entry = &Entry[testConfig]{Cfg: cfg, Status: StatusRunning}
+						h.seen.Add(cfg)
+						h.exposed.Add(entry)
+					}
+
+					fn := newTestFn("test:"+jobName, string(CommandAdd), jobName, pl.payload)
+
+					acts := h.CommandActs(fn, entry)
+
+					ran := driveWithSpy(h, CommandAdd, fn)
+
+					assert.Equal(t, acts, ran,
+						"CommandActs must mirror whether the handler runs blocking work")
+				})
+			}
+		}
 	}
 }

--- a/src/go/plugin/framework/jobruntime/job_v1.go
+++ b/src/go/plugin/framework/jobruntime/job_v1.go
@@ -154,8 +154,12 @@ type Job struct {
 	api                  *netdataapi.API
 
 	vnodeCreated bool
-	vnode        vnodes.VirtualNode
-	updVnode     chan *vnodes.VirtualNode
+	// vnodeMu covers j.vnode against off-goroutine readers (Vnode is
+	// called from the manager loop on registered jobs) racing the job
+	// goroutine's writes and the pre-Start baseline write.
+	vnodeMu  sync.RWMutex
+	vnode    vnodes.VirtualNode
+	updVnode chan *vnodes.VirtualNode
 
 	retries atomic.Int64
 	prevRun time.Time
@@ -224,7 +228,9 @@ func (j *Job) Configuration() any {
 }
 
 func (j *Job) Vnode() vnodes.VirtualNode {
-	return j.vnode
+	j.vnodeMu.RLock()
+	defer j.vnodeMu.RUnlock()
+	return *j.vnode.Copy()
 }
 
 // AutoDetection invokes init, check and postCheck. It handles panic.
@@ -291,6 +297,22 @@ func (j *Job) UpdateVnode(vnode *vnodes.VirtualNode) {
 	default:
 	}
 	j.updVnode <- vnode
+}
+
+// SetVnodeBaseline commits the vnode config directly into the job BEFORE
+// Start: registration-time freshness must be visible to Cleanup even when
+// the job never collects, and it must NOT drain a concurrently queued live
+// update - UpdateVnode's slot keeps the newest committed value, which still
+// applies at collection. Pre-Start only: the job goroutine does not exist
+// yet, and the write is published to it by the Start goroutine launch.
+// Module-owned vnode state is never overridden.
+func (j *Job) SetVnodeBaseline(vnode *vnodes.VirtualNode) {
+	if vnode == nil || (j.module != nil && j.module.VirtualNode() != nil) {
+		return
+	}
+	j.vnodeMu.Lock()
+	j.vnode = *vnode.Copy()
+	j.vnodeMu.Unlock()
 }
 
 // Tick Tick.
@@ -506,7 +528,9 @@ func (j *Job) processMetrics(mx collectedMetrics, startTime time.Time, sinceLast
 		case vnode := <-j.updVnode:
 			j.vnodeCreated = false
 			createChart = j.vnode.GUID != vnode.GUID
+			j.vnodeMu.Lock()
 			j.vnode = *vnode.Copy()
+			j.vnodeMu.Unlock()
 		default:
 		}
 	}
@@ -514,7 +538,9 @@ func (j *Job) processMetrics(mx collectedMetrics, startTime time.Time, sinceLast
 	if !j.vnodeCreated {
 		if j.vnode.GUID == "" {
 			if v := j.module.VirtualNode(); v != nil && v.GUID != "" && v.Hostname != "" {
+				j.vnodeMu.Lock()
 				j.vnode = *v
+				j.vnodeMu.Unlock()
 			}
 		}
 		if j.vnode.GUID != "" {
@@ -599,8 +625,10 @@ func (j *Job) sendVnodeHostInfo() {
 		return
 	}
 
+	j.vnodeMu.Lock()
 	j.vnode.Hostname = info.Hostname
 	j.vnode.Labels = info.Labels
+	j.vnodeMu.Unlock()
 	j.api.HOSTINFO(info)
 }
 

--- a/src/go/plugin/framework/jobruntime/job_v1_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v1_test.go
@@ -79,6 +79,51 @@ func TestJob_Panicked(t *testing.T) {
 	assert.Equal(t, job.Panicked(), job.panicked.Load())
 }
 
+// Vnode() is read off-goroutine (the manager loop reads registered jobs'
+// vnodes) while the pre-Start baseline write may still be in flight on the
+// starting goroutine: the accesses must be synchronized. This test fails
+// under -race without vnodeMu.
+func TestJob_VnodeAccessIsSynchronized(t *testing.T) {
+	job := newTestJob()
+	baseline := &vnodes.VirtualNode{Name: "v", Hostname: "baseline", GUID: "guid-b"}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 200 {
+			_ = job.Vnode()
+		}
+	}()
+	for range 200 {
+		job.SetVnodeBaseline(baseline)
+	}
+	<-done
+}
+
+// The pre-Start baseline commits into the job WITHOUT draining the live
+// update queue: a concurrently queued newer update must survive the
+// baseline and still apply at collection - a queued (UpdateVnode) baseline
+// would evict it from the one-slot channel, and a job stopped before its
+// first collection would clean up on the stale creation-time vnode.
+func TestJob_SetVnodeBaselineDoesNotDrainQueuedUpdate(t *testing.T) {
+	job := newTestJob()
+	queued := &vnodes.VirtualNode{Name: "v", Hostname: "queued", GUID: "guid-q"}
+	baseline := &vnodes.VirtualNode{Name: "v", Hostname: "baseline", GUID: "guid-b"}
+
+	job.UpdateVnode(queued)
+	job.SetVnodeBaseline(baseline)
+
+	assert.Equal(t, "baseline", job.vnode.Hostname,
+		"the baseline must be committed into the job, visible without a collection")
+	select {
+	case v := <-job.updVnode:
+		assert.Equal(t, "queued", v.Hostname,
+			"the queued live update must survive the baseline and still apply at collection")
+	default:
+		t.Fatal("the baseline must not drain the queued live update")
+	}
+}
+
 func TestJob_AutoDetectionEvery(t *testing.T) {
 	job := newTestJob()
 

--- a/src/go/plugin/framework/jobruntime/job_v2.go
+++ b/src/go/plugin/framework/jobruntime/job_v2.go
@@ -206,6 +206,26 @@ func (j *JobV2) UpdateVnode(vnode *vnodes.VirtualNode) {
 	}
 	j.updVnode <- vnode
 }
+
+// SetVnodeBaseline commits the vnode config into the job BEFORE Start -
+// same contract as the V1 method: visible to cleanup without a collection,
+// never drains a concurrently queued live update, never overrides
+// module-owned vnode state, pre-Start callers only.
+func (j *JobV2) SetVnodeBaseline(vnode *vnodes.VirtualNode) {
+	if vnode == nil {
+		return
+	}
+	if j.module != nil && j.module.VirtualNode() != nil {
+		return
+	}
+	next := vnode.Copy()
+	j.vnodeMu.Lock()
+	j.vnode = *next
+	j.vnodeMu.Unlock()
+	if state := j.scopeStates[defaultHostScopeKey]; state != nil {
+		state.host.invalidateDefine()
+	}
+}
 func (j *JobV2) Cleanup() {
 	j.buf.Reset()
 	snapshots := j.captureScopeCleanupSnapshots()

--- a/src/go/plugin/framework/jobruntime/job_v2_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_test.go
@@ -244,6 +244,29 @@ groups:
 `
 }
 
+// Same contract as the V1 variant: the pre-Start baseline commits into the
+// job without draining the live update queue, so a concurrently queued
+// newer update still applies at collection.
+func TestJobV2_SetVnodeBaselineDoesNotDrainQueuedUpdate(t *testing.T) {
+	mod := &mockModuleV2{store: metrix.NewCollectorStore(), template: chartTemplateV2()}
+	job := newTestJobV2(mod, &bytes.Buffer{})
+	queued := &vnodes.VirtualNode{Name: "v", Hostname: "queued", GUID: "guid-q"}
+	baseline := &vnodes.VirtualNode{Name: "v", Hostname: "baseline", GUID: "guid-b"}
+
+	job.UpdateVnode(queued)
+	job.SetVnodeBaseline(baseline)
+
+	assert.Equal(t, "baseline", job.Vnode().Hostname,
+		"the baseline must be committed into the job, visible without a collection")
+	select {
+	case v := <-job.updVnode:
+		assert.Equal(t, "queued", v.Hostname,
+			"the queued live update must survive the baseline and still apply at collection")
+	default:
+		t.Fatal("the baseline must not drain the queued live update")
+	}
+}
+
 func TestJobV2RunnerDoesNotRunDuringAutoDetection(t *testing.T) {
 	started := make(chan struct{})
 	mod := &mockRunnerModuleV2{


### PR DESCRIPTION
##### Summary

Move secretstore and vnode dynamic configuration onto the job manager executor, add loop-owned multi-key claims for store and vnode dependencies, flatten shutdown handling, preserve dependent restart ordering, and document the resulting job manager architecture.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `secretstore` and `vnode` dynamic configuration onto the `jobmgr` executor behind a loop-owned multi-key claim system to serialize cross-domain work, keep dependent restarts ordered, and make shutdown consistent. Adds an architecture doc and tightens payload, vnode, and function-publication safety.

- New Features
  - Route `secretstore` and `vnode` dyncfg through the executor with a multi-key claim table (global key order, FIFO, read/write) to serialize overlapping work.
  - Run `secretstore` dependent restarts as one claimed effect with a staged plan and late replay on timeout; preserves sorted job order across dependents.
  - Add `StepExec` plus `CommandActs` in `secretsctl`/`vnodectl` so rejection-only commands skip claims and never starve claimed work.
  - Add `SetVnodeBaseline` and synchronize `Vnode()` reads; vnode write claims now park behind collector read claims.
  - Replace shared command message plumbing with a per-command message box in `dyncfg.Handler` and add `ParsePayload`; add `jobmgr/ARCHITECTURE.md`.

- Bug Fixes
  - Deterministic dependent restart ordering; no deadlocks/starvation across `secretstore`/`vnode`/collector operations via claims.
  - Safer shutdown: priority cancel check, consistent 503 responses, no late wire publications; never-started jobs are cleaned silently via closed emission gates.
  - Reject null/whitespace YAML payloads in dyncfg to prevent nil-map panics.
  - Converting a live secret store (file/user → dyncfg) no longer tears the store down first; dependents restart once without transient failures.
  - Publish running job functions at commit time (not inside start) to avoid racey exposure during lifecycle churn.

<sup>Written for commit 7240a6ea2d439290d23102c5efdd36dde8e3caed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

