### PR TITLE
Netdata fixes part 27

### DIFF
--- a/src/aclk/https_client.c
+++ b/src/aclk/https_client.c
@@ -241,7 +241,7 @@ const char *get_http_header_by_name(http_parse_ctx *ctx, const char *name)
 
 static int parse_http_hdr(rbuf_t buf, http_parse_ctx *parse_ctx)
 {
-    int idx, idx_end;
+    size_t idx, idx_end;
     char buf_key[HTTP_HDR_BUFFER_SIZE];
     char buf_val[HTTP_HDR_BUFFER_SIZE];
     char *ptr;
@@ -296,7 +296,7 @@ static inline void chunked_response_buffer_grow_by(http_parse_ctx *parse_ctx, si
 
 static int process_chunked_content(rbuf_t buf, http_parse_ctx *parse_ctx)
 {
-    int idx;
+    size_t idx;
     size_t bytes_to_copy;
 
     do {
@@ -378,7 +378,7 @@ static int process_chunked_content(rbuf_t buf, http_parse_ctx *parse_ctx)
 
 http_parse_rc parse_http_response(rbuf_t buf, http_parse_ctx *parse_ctx)
 {
-    int idx;
+    size_t idx;
     char rc[4];
 
     do {

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -245,14 +245,14 @@ exit_with_error:
 
 #define HTTP_HDR_LINE_CHECK_LIMIT(x)                                                                                   \
     if ((x) >= MAX_HTTP_LINE_LENGTH) {                                                                                 \
-        nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: HTTP line received is too long. Maximum is %d", MAX_HTTP_LINE_LENGTH);                                  \
+        nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: HTTP line received is too long. Maximum is %zu", (size_t)MAX_HTTP_LINE_LENGTH);                         \
         return WS_CLIENT_PROTOCOL_ERROR;                                                                               \
     }
 
 int ws_client_parse_handshake_resp(ws_client *client)
 {
     char buf[HTTP_SC_LENGTH];
-    int idx_crlf, idx_sep;
+    size_t idx_crlf, idx_sep;
     char *ptr;
     size_t bytes;
 
@@ -316,13 +316,13 @@ int ws_client_parse_handshake_resp(ws_client *client)
                 nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: Expected HTTP hdr field key/value separator \": \" before endline in non empty HTTP header line");
                 return WS_CLIENT_PROTOCOL_ERROR;
             }
-            if (idx_crlf == idx_sep + (int)strlen(HTTP_HDR_SEPARATOR)) {
+            if (idx_crlf == idx_sep + strlen(HTTP_HDR_SEPARATOR)) {
                 nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: HTTP Header value cannot be empty");
                 return WS_CLIENT_PROTOCOL_ERROR;
             }
 
             if (idx_sep > HTTP_HEADER_NAME_MAX_LEN) {
-                nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: HTTP header too long (%d)", idx_sep);
+                nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: HTTP header too long (%zu)", idx_sep);
                 return WS_CLIENT_PROTOCOL_ERROR;
             }
 

--- a/src/collectors/tc.plugin/plugin_tc.c
+++ b/src/collectors/tc.plugin/plugin_tc.c
@@ -800,6 +800,9 @@ static inline int tc_space(char c) {
 }
 
 static inline void tc_split_words(char *str, char **words, int max_words) {
+    if(unlikely(max_words <= 0))
+        return;
+
     char *s = str;
     int i = 0;
 

--- a/src/database/rrdfunctions.c
+++ b/src/database/rrdfunctions.c
@@ -346,7 +346,7 @@ bool rrd_function_is_available(struct rrd_host_function *rdcf, RRDHOST *host) {
 int rrd_functions_find_by_name(RRDHOST *host, BUFFER *wb, const char *name, size_t key_length, const DICTIONARY_ITEM **item) {
     char buffer[MAX_FUNCTION_LENGTH + 1];
     strncpyz(buffer, name, sizeof(buffer) - 1);
-    key_length = strlen(buffer);
+    key_length = strnlen(buffer, sizeof(buffer));
     char *s = NULL;
 
     OBJECT_STATE_ID state_id = object_state_id(&host->state_id);

--- a/src/database/rrdfunctions.c
+++ b/src/database/rrdfunctions.c
@@ -346,6 +346,7 @@ bool rrd_function_is_available(struct rrd_host_function *rdcf, RRDHOST *host) {
 int rrd_functions_find_by_name(RRDHOST *host, BUFFER *wb, const char *name, size_t key_length, const DICTIONARY_ITEM **item) {
     char buffer[MAX_FUNCTION_LENGTH + 1];
     strncpyz(buffer, name, sizeof(buffer) - 1);
+    key_length = strlen(buffer);
     char *s = NULL;
 
     OBJECT_STATE_ID state_id = object_state_id(&host->state_id);

--- a/src/libnetdata/atomics/refcount.h
+++ b/src/libnetdata/atomics/refcount.h
@@ -76,9 +76,8 @@ static REFCOUNT refcount_release_with_trace(REFCOUNT *refcount, const char *func
         if(!REFCOUNT_VALID(expected))
             fatal("REFCOUNT %d is invalid (detected at %s(), called from %s())", expected, __FUNCTION__, func);
 
-//        // the following is a valid case when using refcount_acquire_for_deletion_and_wait_with_trace()
-//        if(expected <= 0)
-//            fatal("REFCOUNT cannot release a refcount of %d (detected at %s(), called from %s())", expected, __FUNCTION__, func);
+        if(unlikely(expected == 0 || expected == REFCOUNT_DELETED))
+            fatal("REFCOUNT cannot release a refcount of %d (detected at %s(), called from %s())", expected, __FUNCTION__, func);
 
         desired = expected - 1;
     } while(!__atomic_compare_exchange_n(refcount, &expected, desired, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED));
@@ -109,6 +108,9 @@ static REFCOUNT refcount_release_and_acquire_for_deletion_advanced_with_trace(RE
         expected = refcount_references(refcount);
         if (!REFCOUNT_VALID(expected))
             fatal("REFCOUNT %d is invalid (detected at %s(), called from %s())", expected, __FUNCTION__, func);
+
+        if (unlikely(expected == 0 || expected == REFCOUNT_DELETED))
+            fatal("REFCOUNT cannot release a refcount of %d (detected at %s(), called from %s())", expected, __FUNCTION__, func);
 
         if (expected == 1) {
             // we can get it for deletion

--- a/src/libnetdata/c_rhash/c_rhash.c
+++ b/src/libnetdata/c_rhash/c_rhash.c
@@ -132,7 +132,7 @@ int c_rhash_get_ptr_by_str(c_rhash hash, const char *key, void **ret_val) {
     struct bin_item *bin = hash->bins[nhash];
 
     while (bin) {
-        if (bin->key_type == ITEMTYPE_STRING) {
+        if (bin->key_type == ITEMTYPE_STRING && bin->value_type == ITEMTYPE_OPAQUE_PTR) {
             if (!strcmp(bin->key, key)) {
                 *ret_val = *((void**)bin->value);
                 return 0;
@@ -150,7 +150,7 @@ int c_rhash_get_ptr_by_uint64(c_rhash hash, uint64_t key, void **ret_val) {
     struct bin_item *bin = hash->bins[nhash];
 
     while (bin) {
-        if (bin->key_type == ITEMTYPE_UINT64) {
+        if (bin->key_type == ITEMTYPE_UINT64 && bin->value_type == ITEMTYPE_OPAQUE_PTR) {
             if (*((uint64_t *)bin->key) == key) {
                 *ret_val = *((void**)bin->value);
                 return 0;

--- a/src/libnetdata/circular_buffer/circular_buffer.c
+++ b/src/libnetdata/circular_buffer/circular_buffer.c
@@ -122,11 +122,14 @@ int cbuffer_add_unsafe(struct circular_buffer *buf, const char *d, size_t d_len)
     return 0;
 }
 
-// Assume caller does not remove too many bytes (i.e. read will jump over write)
 ALWAYS_INLINE
 void cbuffer_remove_unsafe(struct circular_buffer *buf, size_t num) {
+    size_t used = cbuffer_used_size_unsafe(buf);
+    if (unlikely(num > used))
+        num = used;
+
     buf->read += num;
-    // Assume num < size (i.e. caller cannot remove more bytes than are in the buffer)
+    // num is now bounded by the used bytes, which cannot exceed the ring capacity.
     if (buf->read >= buf->size)
         buf->read -= buf->size;
 }

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -242,6 +242,80 @@ static size_t dictionary_unittest_foreach_delete_this(DICTIONARY *dict, char **n
     return entries - count;
 }
 
+static size_t dictionary_unittest_reject_unrepresentable_lengths(void) {
+    size_t errors = 0;
+
+    DICTIONARY *dict = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+    int value = 1;
+    if(dictionary_set_advanced(dict, "key-too-long", (ssize_t)KEY_LEN_MAX + 1, &value, sizeof(value), NULL)) {
+        fprintf(stderr, ">>> %s() accepted an unrepresentable key length\n", __FUNCTION__);
+        errors++;
+    }
+    if(dictionary_entries(dict) != 0) {
+        fprintf(stderr, ">>> %s() added an item with an unrepresentable key length\n", __FUNCTION__);
+        errors++;
+    }
+    dictionary_destroy(dict);
+
+    DICTIONARY *master = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+    DICTIONARY *view = dictionary_create_view(master);
+    DICT_ITEM_CONST DICTIONARY_ITEM *master_item = dictionary_set_and_acquire_item(master, "master", &value, sizeof(value));
+    if(!master_item) {
+        fprintf(stderr, ">>> %s() failed to add the master item\n", __FUNCTION__);
+        errors++;
+    }
+    else {
+        if(dictionary_view_set_advanced(view, "view-key-too-long", (ssize_t)KEY_LEN_MAX + 1, master_item)) {
+            fprintf(stderr, ">>> %s() accepted an unrepresentable view key length\n", __FUNCTION__);
+            errors++;
+        }
+        if(dictionary_entries(view) != 0) {
+            fprintf(stderr, ">>> %s() added a view item with an unrepresentable key length\n", __FUNCTION__);
+            errors++;
+        }
+        dictionary_acquired_item_release(master, master_item);
+    }
+    dictionary_destroy(view);
+    dictionary_destroy(master);
+
+    dict = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+    if(dictionary_set(dict, "value-too-large", NULL, (size_t)VALUE_LEN_MAX + 1)) {
+        fprintf(stderr, ">>> %s() accepted an unrepresentable value length\n", __FUNCTION__);
+        errors++;
+    }
+    if(dictionary_entries(dict) != 0) {
+        fprintf(stderr, ">>> %s() added an item with an unrepresentable value length\n", __FUNCTION__);
+        errors++;
+    }
+    dictionary_destroy(dict);
+
+    dict = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+    int original = 1234;
+    int *stored = dictionary_set(dict, "existing", &original, sizeof(original));
+    if(!stored || *stored != original) {
+        fprintf(stderr, ">>> %s() failed to add the baseline item\n", __FUNCTION__);
+        errors++;
+    }
+
+    if(dictionary_set(dict, "existing", NULL, (size_t)VALUE_LEN_MAX + 1)) {
+        fprintf(stderr, ">>> %s() reset an item with an unrepresentable value length\n", __FUNCTION__);
+        errors++;
+    }
+
+    stored = dictionary_get(dict, "existing");
+    if(!stored || *stored != original) {
+        fprintf(stderr, ">>> %s() changed the baseline item after rejected reset\n", __FUNCTION__);
+        errors++;
+    }
+    if(dictionary_entries(dict) != 1) {
+        fprintf(stderr, ">>> %s() changed dictionary entries after rejected reset\n", __FUNCTION__);
+        errors++;
+    }
+    dictionary_destroy(dict);
+
+    return errors;
+}
+
 static size_t dictionary_unittest_destroy(DICTIONARY *dict, char **names, char **values, size_t entries) {
     (void)names;
     (void)values;
@@ -1891,6 +1965,9 @@ int dictionary_unittest(size_t entries) {
 
     dictionary_unittest_free_char_pp(names, entries);
     dictionary_unittest_free_char_pp(values, entries);
+
+    fprintf(stderr, "\nTesting dictionary packed length bounds\n");
+    errors += dictionary_unittest_reject_unrepresentable_lengths();
 
     errors += dictionary_unittest_views();
     errors += dictionary_unittest_threads();

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -528,13 +528,21 @@ static bool api_is_name_good_with_trace(DICTIONARY *dict __maybe_unused, const c
         return false;
     }
 
+    size_t real_name_len = strnlen(name, KEY_LEN_MAX + 1);
+    if(unlikely(real_name_len > KEY_LEN_MAX)) {
+        dictionary_internal_error(true, dict,
+            "DICTIONARY: attempted to %s() with a name longer than the maximum acceptable size %zu",
+            function, (size_t)KEY_LEN_MAX);
+        return false;
+    }
+
     dictionary_internal_error(
-        name_len > 0 && name_len != (ssize_t)strlen(name), dict,
+        name_len > 0 && name_len != (ssize_t)real_name_len, dict,
         "DICTIONARY: attempted to %s() with a name of '%s', having length of %zu, "
         "but the supplied name_len = %ld",
         function,
         name,
-        strlen(name),
+        real_name_len,
         (long int) name_len);
 
     dictionary_internal_error(
@@ -543,7 +551,7 @@ static bool api_is_name_good_with_trace(DICTIONARY *dict __maybe_unused, const c
         "but the supplied name_len = %ld",
         function,
         name,
-        strlen(name),
+        real_name_len,
         (long int) name_len);
 
     return true;
@@ -724,6 +732,23 @@ DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_set_and_acquire_item_advanced(DICTIO
     if(unlikely(!api_is_name_good(dict, name, name_len)))
         return NULL;
 
+    if(name_len == -1)
+        name_len = (ssize_t)strnlen(name, KEY_LEN_MAX + 1);
+
+    if(unlikely((size_t)name_len > KEY_LEN_MAX)) {
+        dictionary_internal_error(true, dict,
+                                  "DICTIONARY: tried to index a key of size %zu, but the maximum acceptable is %zu",
+                                  (size_t)name_len, (size_t)KEY_LEN_MAX);
+        return NULL;
+    }
+
+    if(unlikely(value_len > VALUE_LEN_MAX)) {
+        dictionary_internal_error(true, dict,
+                                  "DICTIONARY: tried to add an item of size %zu, but the maximum acceptable is %zu",
+                                  value_len, (size_t)VALUE_LEN_MAX);
+        return NULL;
+    }
+
     api_internal_check(dict, NULL, false, true);
 
     if(unlikely(is_view_dictionary(dict)))
@@ -750,6 +775,16 @@ void *dictionary_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_l
 DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_view_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, DICTIONARY_ITEM *master_item) {
     if(unlikely(!api_is_name_good(dict, name, name_len)))
         return NULL;
+
+    if(name_len == -1)
+        name_len = (ssize_t)strnlen(name, KEY_LEN_MAX + 1);
+
+    if(unlikely((size_t)name_len > KEY_LEN_MAX)) {
+        dictionary_internal_error(true, dict,
+                                  "DICTIONARY: tried to index a key of size %zu, but the maximum acceptable is %zu",
+                                  (size_t)name_len, (size_t)KEY_LEN_MAX);
+        return NULL;
+    }
 
     api_internal_check(dict, NULL, false, true);
 

--- a/src/libnetdata/eval/eval-utils.c
+++ b/src/libnetdata/eval/eval-utils.c
@@ -7,11 +7,11 @@
 // memory management
 
 EVAL_NODE *eval_node_alloc(int count) {
-    static int id = 1;
+    static int id = 0;
 
     EVAL_NODE *op = callocz(1, sizeof(EVAL_NODE) + (sizeof(EVAL_VALUE) * count));
 
-    op->id = id++;
+    op->id = __atomic_add_fetch(&id, 1, __ATOMIC_RELAXED);
     op->operator = EVAL_OPERATOR_NOP;
     op->precedence = 0;  // Will be set based on the operator
     op->count = count;

--- a/src/libnetdata/inicfg/dyncfg.c
+++ b/src/libnetdata/inicfg/dyncfg.c
@@ -231,8 +231,13 @@ static inline bool is_forbidden_filename_char(char c) {
 char *dyncfg_escape_id_for_filename(const char *id) {
     if (id == NULL) return NULL;
 
+    size_t max_len = (SIZE_MAX - 1) / 3;
+    size_t len = strnlen(id, max_len + 1);
+    if(unlikely(len > (SIZE_MAX - 1) / 3))
+        fatal("dyncfg_escape_id_for_filename() cannot allocate escaped id for %zu bytes.", len);
+
     // Allocate memory for the worst case, where every character is escaped.
-    char *escaped = mallocz(strlen(id) * 3 + 1); // Each char can become '%XX', plus '\0'
+    char *escaped = mallocz(len * 3 + 1); // Each char can become '%XX', plus '\0'
     if (!escaped) return NULL;
 
     const char *src = id;

--- a/src/libnetdata/line_splitter/line_splitter.h
+++ b/src/libnetdata/line_splitter/line_splitter.h
@@ -32,6 +32,9 @@ extern bool isspace_map_group_by_label[256];
 extern bool isspace_dyncfg_id_map[256];
 
 static ALWAYS_INLINE size_t quoted_strings_splitter(char *str, char **words, size_t max_words, bool *isspace_map) {
+    if (unlikely(!max_words))
+        return 0;
+
     if (unlikely(!str)) {
         if (likely(max_words))
             words[0] = NULL;

--- a/src/libnetdata/linked_lists/linked_lists.h
+++ b/src/libnetdata/linked_lists/linked_lists.h
@@ -110,17 +110,18 @@
 
 #define DOUBLE_LINKED_LIST_APPEND_LIST_UNSAFE(head, head2, prev, next)                         \
     do {                                                                                       \
-        if (head2) {                                                                           \
+        __typeof(head2) _head2 = (head2);                                                      \
+        if (_head2 && _head2 != (head)) {                                                       \
             if (head) {                                                                        \
-                __typeof(head2) _head2_last_item = (head2)->prev;                              \
-                                                                                               \
-                (head2)->prev = (head)->prev;                                                  \
-                (head)->prev->next = (head2);                                                  \
-                                                                                               \
+                __typeof(_head2) _head2_last_item = _head2->prev;                              \
+                                                                                                \
+                _head2->prev = (head)->prev;                                                   \
+                (head)->prev->next = _head2;                                                   \
+                                                                                                \
                 (head)->prev = _head2_last_item;                                               \
             }                                                                                  \
             else                                                                               \
-                (head) = (head2);                                                              \
+                (head) = _head2;                                                               \
         }                                                                                      \
     } while (0)
 

--- a/src/libnetdata/object-state/object-state.c
+++ b/src/libnetdata/object-state/object-state.c
@@ -61,8 +61,15 @@ void object_state_deactivate(OBJECT_STATE *os) {
         &os->state_refcount, &expected, desired, false, __ATOMIC_SEQ_CST, __ATOMIC_RELAXED));
 
     // Now wait for all holders to release
-    while(__atomic_load_n(&os->state_refcount, __ATOMIC_ACQUIRE) != OBJECT_STATE_DEACTIVATED)
+    REFCOUNT refcount;
+    while((refcount = __atomic_load_n(&os->state_refcount, __ATOMIC_ACQUIRE)) != OBJECT_STATE_DEACTIVATED) {
+        if(refcount < OBJECT_STATE_DEACTIVATED) {
+            fatal("OBJECT_STATE: object state refcount underflowed while deactivating (state refcount %d)", refcount);
+            return;
+        }
+
         tinysleep();   // Busy wait until all holders are gone
+    }
 }
 
 bool object_state_acquire(OBJECT_STATE *os, OBJECT_STATE_ID wanted_state_id) {
@@ -88,5 +95,17 @@ bool object_state_acquire(OBJECT_STATE *os, OBJECT_STATE_ID wanted_state_id) {
 }
 
 void object_state_release(OBJECT_STATE *os) {
-    __atomic_sub_fetch(&os->state_refcount, 1, __ATOMIC_RELEASE);
+    REFCOUNT expected = __atomic_load_n(&os->state_refcount, __ATOMIC_RELAXED);
+    REFCOUNT desired;
+
+    do {
+        if(expected <= OBJECT_STATE_DEACTIVATED) {
+            fatal("OBJECT_STATE: attempt to release object with no holders (state refcount %d)", expected);
+            return;
+        }
+
+        desired = expected - 1;
+
+    } while(!__atomic_compare_exchange_n(
+        &os->state_refcount, &expected, desired, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED));
 }

--- a/src/libnetdata/onewayalloc/onewayalloc.c
+++ b/src/libnetdata/onewayalloc/onewayalloc.c
@@ -18,6 +18,36 @@ size_t onewayalloc_allocated_memory(void) {
     return __atomic_load_n(&onewayalloc_total_memory, __ATOMIC_RELAXED);
 }
 
+static size_t onewayalloc_add_or_fatal(size_t size, size_t add, const char *context) {
+    if(unlikely(add > SIZE_MAX - size))
+        fatal("ONEWAYALLOC: cannot allocate %s size %zu with %zu additional bytes.", context, size, add);
+
+    return size + add;
+}
+
+static size_t onewayalloc_mul_or_fatal(size_t nmemb, size_t size, const char *context) {
+    if(unlikely(size && nmemb > SIZE_MAX / size))
+        fatal("ONEWAYALLOC: cannot allocate %s size %zu * %zu.", context, nmemb, size);
+
+    return nmemb * size;
+}
+
+static size_t onewayalloc_natural_alignment_or_fatal(size_t size) {
+    if(unlikely(size > SIZE_MAX - (SYSTEM_REQUIRED_ALIGNMENT - 1)))
+        fatal("ONEWAYALLOC: cannot naturally align allocation size %zu.", size);
+
+    return natural_alignment(size);
+}
+
+static size_t onewayalloc_page_alignment_or_fatal(size_t size, size_t page_size) {
+    size_t remainder = size % page_size;
+
+    if(remainder)
+        size = onewayalloc_add_or_fatal(size, page_size - remainder, "page aligned");
+
+    return size;
+}
+
 // Create an OWA
 // Once it is created, the caller may call the onewayalloc_mallocz()
 // any number of times, for any amount of memory.
@@ -30,7 +60,7 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
 
     // make sure the new page will fit both the requested size
     // and the OWA_PAGE structure at its beginning
-    size_hint += natural_alignment(sizeof(OWA_PAGE));
+    size_hint = onewayalloc_add_or_fatal(size_hint, natural_alignment(sizeof(OWA_PAGE)), "page");
 
     // prefer the user size if it is bigger than our size
     if(size_hint > size)
@@ -50,8 +80,7 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     }
 
     // Make sure our allocations are always a multiple of the hardware page size
-    if(size % OWA_NATURAL_PAGE_SIZE)
-        size = size + OWA_NATURAL_PAGE_SIZE - (size % OWA_NATURAL_PAGE_SIZE);
+    size = onewayalloc_page_alignment_or_fatal(size, OWA_NATURAL_PAGE_SIZE);
 
     // Use netdata_mmap instead of mallocz
     OWA_PAGE *page = (OWA_PAGE *)nd_mmap_advanced(NULL, size, MAP_ANONYMOUS | MAP_PRIVATE, 0, false, false, NULL);
@@ -105,7 +134,7 @@ void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {
     head->stats_mallocs_size += size;
 
     // make sure the size is aligned
-    size = natural_alignment(size);
+    size = onewayalloc_natural_alignment_or_fatal(size);
 
     if(unlikely(page->size - page->offset < size)) {
         // we don't have enough space to fit the data
@@ -121,7 +150,7 @@ void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {
 }
 
 void *onewayalloc_callocz(ONEWAYALLOC *owa, size_t nmemb, size_t size) {
-    size_t total = nmemb * size;
+    size_t total = onewayalloc_mul_or_fatal(nmemb, size, "calloc");
     void *mem = onewayalloc_mallocz(owa, total);
     memset(mem, 0, total);
     return mem;
@@ -177,7 +206,7 @@ void onewayalloc_freez(ONEWAYALLOC *owa __maybe_unused, const void *ptr __maybe_
 }
 
 void *onewayalloc_doublesize(ONEWAYALLOC *owa, const void *src, size_t oldsize) {
-    size_t newsize = oldsize * 2;
+    size_t newsize = onewayalloc_mul_or_fatal(oldsize, 2, "doubled");
     void *dst = onewayalloc_mallocz(owa, newsize);
     memcpy(dst, src, oldsize);
     onewayalloc_freez(owa, src);

--- a/src/libnetdata/parsers/duration.c
+++ b/src/libnetdata/parsers/duration.c
@@ -323,6 +323,8 @@ ssize_t duration_snprintf(char *dst, size_t dst_size, int64_t value, const char 
     }
 
     const struct duration_unit *du_min = duration_find_unit(unit);
+    if(!du_min) return -3;
+
     size_t offset = 0;
 
     int64_t nsec = value * du_min->multiplier;

--- a/src/libnetdata/ringbuffer/ringbuffer-unittest.c
+++ b/src/libnetdata/ringbuffer/ringbuffer-unittest.c
@@ -135,6 +135,25 @@ static int ringbuffer_flush_keeps_capacity_unittest(void)
     return errors;
 }
 
+static int ringbuffer_find_bytes_unittest(void)
+{
+    int errors = 0;
+    rbuf_t buffer = rbuf_create(8, 8);
+    size_t idx = (size_t)-1;
+    char *found;
+
+    RB_TEST(rbuf_push(buffer, "abcdefgh", 8) == 8, "find setup fill");
+    found = rbuf_find_bytes(buffer, "ef", 2, &idx);
+    RB_TEST(found && !memcmp(found, "ef", 2), "find bytes returns matching pointer");
+    RB_TEST(idx == 4, "find bytes reports size_t offset");
+
+    RB_TEST(rbuf_find_bytes(buffer, "zz", 2, &idx) == NULL, "find bytes reports no match");
+    RB_TEST(idx == 8, "find bytes reports scanned size on no match");
+
+    rbuf_free(buffer);
+    return errors;
+}
+
 int ringbuffer_unittest(void)
 {
     int errors = 0;
@@ -147,6 +166,7 @@ int ringbuffer_unittest(void)
     errors += ringbuffer_wrapped_growth_unittest();
     errors += ringbuffer_cap_unittest();
     errors += ringbuffer_flush_keeps_capacity_unittest();
+    errors += ringbuffer_find_bytes_unittest();
 
     if (errors)
         fprintf(stderr, "ringbuffer unittest: %d ERROR(S)\n", errors);

--- a/src/libnetdata/ringbuffer/ringbuffer.c
+++ b/src/libnetdata/ringbuffer/ringbuffer.c
@@ -226,7 +226,7 @@ int rbuf_memcmp_n(rbuf_t buffer, const char *to_cmp, size_t to_cmp_bytes)
     return rbuf_memcmp(buffer, buffer->tail, to_cmp, to_cmp_bytes);
 }
 
-char *rbuf_find_bytes(rbuf_t buffer, const char *needle, size_t needle_bytes, int *found_idx)
+char *rbuf_find_bytes(rbuf_t buffer, const char *needle, size_t needle_bytes, size_t *found_idx)
 {
     const char *ptr = buffer->tail;
     *found_idx = 0;

--- a/src/libnetdata/ringbuffer/ringbuffer.h
+++ b/src/libnetdata/ringbuffer/ringbuffer.h
@@ -41,7 +41,7 @@ size_t rbuf_bytes_free(rbuf_t buffer);
 size_t rbuf_push(rbuf_t buffer, const char *data, size_t len);
 size_t rbuf_pop(rbuf_t buffer, char *data, size_t len);
 
-char *rbuf_find_bytes(rbuf_t buffer, const char *needle, size_t needle_bytes, int *found_idx);
+char *rbuf_find_bytes(rbuf_t buffer, const char *needle, size_t needle_bytes, size_t *found_idx);
 int rbuf_memcmp_n(rbuf_t buffer, const char *to_cmp, size_t to_cmp_bytes);
 
 int ringbuffer_unittest(void);

--- a/src/libnetdata/statistical/statistical.c
+++ b/src/libnetdata/statistical/statistical.c
@@ -466,6 +466,9 @@ NETDATA_DOUBLE holtwinters(const NETDATA_DOUBLE *series, size_t entries,
     NETDATA_DOUBLE beta,
     NETDATA_DOUBLE gamma,
     NETDATA_DOUBLE *forecast) {
+    if(unlikely(entries == 0))
+        return NAN;
+
     if(unlikely(isnan(alpha)))
         alpha = 0.3;
 

--- a/src/libnetdata/string/string.c
+++ b/src/libnetdata/string/string.c
@@ -25,6 +25,8 @@ struct netdata_string {
     const char str[];   // the string itself, is appended to this structure
 };
 
+#define STRING_MAX_LENGTH (MIN((size_t)UINT32_MAX, (size_t)LONG_MAX - sizeof(STRING)) - 1)
+
 static struct string_partition {
     RW_SPINLOCK spinlock;       // the R/W spinlock to protect the Judy array
 
@@ -306,6 +308,9 @@ STRING *string_strdupz(const char *str) {
 
     if(unlikely(!length)) return NULL;
 
+    if(unlikely(length > STRING_MAX_LENGTH))
+        fatal("STRING: cannot index string length %zu, maximum is %zu", length, STRING_MAX_LENGTH);
+
     length++;
     uint8_t partition = string_partition_str(str);
     STRING *string = string_index_search(str, length, partition);
@@ -332,6 +337,9 @@ STRING *string_strdupz(const char *str) {
 ALWAYS_INLINE
 STRING *string_strndupz(const char *str, size_t len) {
     if(unlikely(!str || !*str || !len)) return NULL;
+
+    if(unlikely(len > STRING_MAX_LENGTH))
+        fatal("STRING: cannot index string length %zu, maximum is %zu", len, STRING_MAX_LENGTH);
 
     uint8_t partition = string_partition_str(str);
 

--- a/src/libnetdata/string/string.c
+++ b/src/libnetdata/string/string.c
@@ -437,9 +437,6 @@ bool string_equals_string_nocase(const STRING *a, const STRING *b) {
 static STRING *string_2way_merge_X = NULL;
 
 STRING *string_2way_merge(STRING *a, STRING *b) {
-    if(unlikely(!string_2way_merge_X))
-        string_2way_merge_X = string_strdupz("[x]");
-
     if(unlikely(a == b)) return string_dup(a);
     if(unlikely(a == string_2way_merge_X)) return string_dup(a);
     if(unlikely(b == string_2way_merge_X)) return string_dup(b);
@@ -978,4 +975,6 @@ void string_init(void) {
         string_base[i].JudyLPointers = NULL;
 #endif
     }
+
+    string_2way_merge_X = string_strdupz("[x]");
 }

--- a/src/libnetdata/string/string.c
+++ b/src/libnetdata/string/string.c
@@ -453,18 +453,19 @@ STRING *string_2way_merge(STRING *a, STRING *b) {
         *dst1++ = *s1;
 
     *dst1 = '\0';
+    const char *prefix_end1 = s1, *prefix_end2 = s2;
 
     if(*s1 != '\0' || *s2 != '\0') {
         *dst1++ = '[';
         *dst1++ = 'x';
         *dst1++ = ']';
 
-        s1 = &(string2str(a))[alen - 1];
-        s2 = &(string2str(b))[blen - 1];
+        s1 = string2str(a) + alen;
+        s2 = string2str(b) + blen;
         char *dst2 = &buf2[length];
         *dst2 = '\0';
-        for (; *s1 && *s2 && *s1 == *s2; s1--, s2--)
-            *(--dst2) = *s1;
+        for (; s1 > prefix_end1 && s2 > prefix_end2 && s1[-1] == s2[-1]; s1--, s2--)
+            *(--dst2) = s1[-1];
 
         strcpy(dst1, dst2);
     }

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -22,8 +22,13 @@ char to_hex(char code) {
 /* IMPORTANT: be sure to free() the returned string after use */
 char *url_encode(const char *str) {
     char *buf, *pbuf;
+    size_t max_len = (SIZE_MAX - 1) / 3;
+    size_t len = strnlen(str, max_len + 1);
 
-    pbuf = buf = mallocz(strlen(str) * 3 + 1);
+    if(unlikely(len > (SIZE_MAX - 1) / 3))
+        fatal("url_encode() cannot allocate encoded string for %zu bytes.", len);
+
+    pbuf = buf = mallocz(len * 3 + 1);
 
     while (*str) {
         if (isalnum((uint8_t)*str) || *str == '-' || *str == '_' || *str == '.' || *str == '~')

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -311,7 +311,7 @@ inline char *url_find_protocol(char *s) {
         while (*s && *s != ' ') s++;
 
         // is it SPACE + "HTTP/" ?
-        if(*s && !strncmp(s, " HTTP/", 6)) break;
+        if(!*s || !strncmp(s, " HTTP/", 6)) break;
         else s++;
     }
 

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -1304,6 +1304,15 @@ static double ks_2samp(
         DIFFS_NUMBERS highlight_diffs[], int high_size,
         uint32_t base_shifts) {
 
+    // high_idx is bounded by high_size; keep the scaled comparison representable.
+    if(unlikely(base_shifts >= sizeof(int64_t) * CHAR_BIT - 1))
+        return NAN;
+    int64_t high_multiplier = 1;
+    for(uint32_t shift = 0; shift < base_shifts; shift++)
+        high_multiplier *= 2;
+    if(unlikely((int64_t)high_size > INT64_MAX / high_multiplier))
+        return NAN;
+
     qsort(baseline_diffs, base_size, sizeof(DIFFS_NUMBERS), compare_diffs);
     qsort(highlight_diffs, high_size, sizeof(DIFFS_NUMBERS), compare_diffs);
 
@@ -1335,8 +1344,8 @@ static double ks_2samp(
     DIFFS_NUMBERS K = baseline_diffs[0];
     int base_idx = binary_search_bigger_than(baseline_diffs, 1, base_size, K);
     int high_idx = binary_search_bigger_than(highlight_diffs, 0, high_size, K);
-    int delta = base_idx - (high_idx << base_shifts);
-    int min = delta, max = delta;
+    int64_t delta = (int64_t)base_idx - (int64_t)high_idx * high_multiplier;
+    int64_t min = delta, max = delta;
     int base_min_idx = base_idx;
     int base_max_idx = base_idx;
     int high_min_idx = high_idx;
@@ -1348,7 +1357,7 @@ static double ks_2samp(
         base_idx = binary_search_bigger_than(baseline_diffs, i + 1, base_size, K); // starting from i, since data1 is sorted
         high_idx = binary_search_bigger_than(highlight_diffs, 0, high_size, K);
 
-        delta = base_idx - (high_idx << base_shifts);
+        delta = (int64_t)base_idx - (int64_t)high_idx * high_multiplier;
         if(delta < min) {
             min = delta;
             base_min_idx = base_idx;
@@ -1367,7 +1376,7 @@ static double ks_2samp(
         base_idx = binary_search_bigger_than(baseline_diffs, 0, base_size, K);
         high_idx = binary_search_bigger_than(highlight_diffs, i + 1, high_size, K); // starting from i, since data2 is sorted
 
-        delta = base_idx - (high_idx << base_shifts);
+        delta = (int64_t)base_idx - (int64_t)high_idx * high_multiplier;
         if(delta < min) {
             min = delta;
             base_min_idx = base_idx;
@@ -2686,7 +2695,15 @@ static int mc_unittest4(void) {
     DIFFS_NUMBERS high[3] = { 365, -123, 0 };
 
     double prob = ks_2samp(base, bs, high, hs, 2);
-    return double_expect(prob, "0.777778", "12x3");
+    int errors = double_expect(prob, "0.777778", "12x3");
+
+    DIFFS_NUMBERS invalid_base[1] = { 1 };
+    DIFFS_NUMBERS invalid_high[1] = { 1 };
+    prob = ks_2samp(invalid_base, 1, invalid_high, 1, (uint32_t)(sizeof(int64_t) * CHAR_BIT));
+    int ret = isnan(prob) ? 0 : 1;
+
+    fprintf(stderr, "%s invalid shift, expected NAN, got %f\n", ret ? "FAILED" : "OK", prob);
+    return errors + ret;
 }
 
 int mc_unittest(void) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened memory safety and correctness across core paths with bounds checks, safer arithmetic, and type fixes; added unit tests to cover edge cases. No behavior changes for valid inputs; prevents rare crashes, hangs, and overflows.

- **Bug Fixes**
  - Bounds and types: switched HTTP/WebSocket/ringbuffer indexes to size_t; updated logs and tests; `rbuf_find_bytes()` now returns offsets via size_t*.
  - Memory safety: clamped circular-buffer removals; guarded URL/DynCfg escape allocations against overflow; added overflow-safe math in `onewayalloc`; enforced dictionary key/value length bounds; validated interned string length; fixed two-way merge suffix bounds and initialized the “[x]” sentinel at startup.
  - Concurrency/lifecycle: made eval node IDs atomic; rejected invalid refcount releases from 0/DELETED; added CAS and underflow guards to object-state release/deactivation.
  - Parsers/algorithms: `holtwinters()` returns NAN on empty input; `duration_snprintf()` returns -3 on invalid unit; guarded KS2 index scaling and widened deltas to int64_t.
  - Data structures/utils: prevented double-linked-list self-append; early-return for zero-capacity splitters; `c_rhash` pointer getters now require pointer value type; bounded function-name scan with strnlen.
  - Tests: added dictionary length-bound tests and ringbuffer find-bytes tests.

<sup>Written for commit d27a3aa325440852cae1554bdd183cbcf0dc3df2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

