### PR TITLE
Netdata fixes part 28

### DIFF
--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -1469,6 +1469,7 @@ static inline void local_sockets_read_all_system_sockets(LS_STATE *ls) {
 struct local_sockets_child_work {
     int fd;
     uint64_t net_ns_inode;
+    bool failed;
 };
 
 #define LOCAL_SOCKET_TERMINATOR (struct local_socket) { \
@@ -1486,9 +1487,68 @@ static inline bool local_socket_is_terminator(const struct local_socket *n) {
             n->net_ns_inode == t.net_ns_inode);
 }
 
+static inline bool local_sockets_write_exact(LS_STATE *ls, int fd, const void *data, size_t len, const char *what) {
+    const uint8_t *p = data;
+    size_t remaining = len;
+
+    while(remaining) {
+        ssize_t rc = write(fd, p, remaining);
+        if(rc > 0) {
+            p += (size_t)rc;
+            remaining -= (size_t)rc;
+            continue;
+        }
+
+        if(rc == -1 && errno == EINTR)
+            continue;
+
+        if(rc == -1) {
+            int err = errno;
+            local_sockets_log(ls, "failed to write %s to pipe: %s", what, strerror(err));
+        }
+        else
+            local_sockets_log(ls, "failed to write %s to pipe: write returned 0", what);
+
+        return false;
+    }
+
+    return true;
+}
+
+static inline bool local_sockets_read_exact(LS_STATE *ls, int fd, void *data, size_t len, const char *what) {
+    uint8_t *p = data;
+    size_t remaining = len;
+
+    while(remaining) {
+        ssize_t rc = read(fd, p, remaining);
+        if(rc > 0) {
+            p += (size_t)rc;
+            remaining -= (size_t)rc;
+            continue;
+        }
+
+        if(rc == -1 && errno == EINTR)
+            continue;
+
+        if(rc == 0)
+            local_sockets_log(ls, "unexpected end of pipe while reading %s", what);
+        else {
+            int err = errno;
+            local_sockets_log(ls, "failed to read %s from pipe: %s", what, strerror(err));
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
 static inline void local_sockets_send_to_parent(struct local_socket_state *ls, const struct local_socket *n, void *data) {
     struct local_sockets_child_work *cw = data;
     int fd = cw->fd;
+
+    if(cw->failed)
+        return;
 
     if(!local_socket_is_terminator(n)) {
         ls->stats.errors_encountered = 0;
@@ -1498,16 +1558,19 @@ static inline void local_sockets_send_to_parent(struct local_socket_state *ls, c
 //            n->inode, n->net_ns_inode, ls->proc_self_net_ns_inode, ls->ns_state.net_ns_pid);
     }
 
-    if(write(fd, n, sizeof(*n)) != sizeof(*n))
-        local_sockets_log(ls, "failed to write local socket to pipe");
+    if(!local_sockets_write_exact(ls, fd, n, sizeof(*n), "local socket")) {
+        cw->failed = true;
+        return;
+    }
 
     size_t len = n->cmdline ? string_strlen(n->cmdline) + 1 : 0;
-    if(write(fd, &len, sizeof(len)) != sizeof(len))
-        local_sockets_log(ls, "failed to write cmdline length to pipe");
+    if(!local_sockets_write_exact(ls, fd, &len, sizeof(len), "cmdline length")) {
+        cw->failed = true;
+        return;
+    }
 
-    if(len)
-        if(write(fd, string2str(n->cmdline), len) != (ssize_t)len)
-            local_sockets_log(ls, "failed to write cmdline to pipe");
+    if(len && !local_sockets_write_exact(ls, fd, string2str(n->cmdline), len, "cmdline"))
+        cw->failed = true;
 }
 
 static inline int local_sockets_spawn_server_callback(SPAWN_REQUEST *request) {
@@ -1628,10 +1691,13 @@ static inline bool local_sockets_get_namespace_sockets_with_pid(LS_STATE *ls, st
 
     size_t received = 0;
     struct local_socket buf;
-    while(read(spawn_server_instance_read_fd(si), &buf, sizeof(buf)) == sizeof(buf)) {
+    int read_fd = spawn_server_instance_read_fd(si);
+    while(local_sockets_read_exact(ls, read_fd, &buf, sizeof(buf), "local socket")) {
+        buf.cmdline = NULL;
+
         size_t len = 0;
-        if(read(spawn_server_instance_read_fd(si), &len, sizeof(len)) != sizeof(len))
-            local_sockets_log(ls, "failed to read cmdline length from pipe");
+        if(!local_sockets_read_exact(ls, read_fd, &len, sizeof(len), "cmdline length"))
+            break;
 
         if(len > LOCAL_SOCKETS_CMDLINE_MAX) {
             // broken pipe protocol: writer caps at LOCAL_SOCKETS_CMDLINE_MAX bytes
@@ -1641,15 +1707,12 @@ static inline bool local_sockets_get_namespace_sockets_with_pid(LS_STATE *ls, st
 
         if(len) {
             CLEAN_CHAR_P *cmdline = mallocz(len + 1);
-            if(read(spawn_server_instance_read_fd(si), cmdline, len) != (ssize_t)len)
-                local_sockets_log(ls, "failed to read cmdline from pipe");
-            else {
-                cmdline[len] = '\0';
-                buf.cmdline = string_strdupz(cmdline);
-            }
+            if(!local_sockets_read_exact(ls, read_fd, cmdline, len, "cmdline"))
+                break;
+
+            cmdline[len] = '\0';
+            buf.cmdline = string_strdupz(cmdline);
         }
-        else
-            buf.cmdline = NULL;
 
         received++;
 

--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -304,13 +304,17 @@ static inline int local_sockets_spawn_server_callback(SPAWN_REQUEST *request);
 
 static inline void local_sockets_log(LS_STATE *ls, const char *format, ...) PRINTFLIKE(2, 3);
 static inline void local_sockets_log(LS_STATE *ls, const char *format, ...) {
-    if(ls && ++ls->stats.errors_encountered == ls->config.max_errors) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "LOCAL-SOCKETS: max number of logs reached. Not logging anymore");
-        return;
-    }
+    if(ls) {
+        size_t errors_encountered = __atomic_add_fetch(&ls->stats.errors_encountered, 1, __ATOMIC_RELAXED);
 
-    if(ls && ls->stats.errors_encountered > ls->config.max_errors)
-        return;
+        if(errors_encountered == ls->config.max_errors) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR, "LOCAL-SOCKETS: max number of logs reached. Not logging anymore");
+            return;
+        }
+
+        if(errors_encountered > ls->config.max_errors)
+            return;
+    }
 
     char buf[16384];
     va_list args;

--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -912,17 +912,26 @@ static inline int local_sockets_libmnl_cb_data(const struct nlmsghdr *nlh, void 
         switch (attr->rta_type) {
             case INET_DIAG_INFO: {
                 if(ls->tmp_protocol == IPPROTO_TCP) {
-                    struct tcp_info *info = (struct tcp_info *)RTA_DATA(attr);
-                    n.info.tcp = *info;
-                    ls->stats.tcp_info_received++;
+                    int payload = RTA_PAYLOAD(attr);
+                    if(payload > 0) {
+                        size_t copy_len = (size_t)payload;
+                        if(copy_len > sizeof(n.info.tcp))
+                            copy_len = sizeof(n.info.tcp);
+
+                        memcpy(&n.info.tcp, RTA_DATA(attr), copy_len);
+                        ls->stats.tcp_info_received++;
+                    }
                 }
             }
             break;
 
             case INET_DIAG_SKV6ONLY: {
-                n.ipv6ony.checked = true;
-                int ipv6only = *(int *)RTA_DATA(attr);
-                n.ipv6ony.ipv46 = !ipv6only;
+                if(RTA_PAYLOAD(attr) >= (int)sizeof(uint8_t)) {
+                    uint8_t ipv6only;
+                    memcpy(&ipv6only, RTA_DATA(attr), sizeof(ipv6only));
+                    n.ipv6ony.checked = true;
+                    n.ipv6ony.ipv46 = !ipv6only;
+                }
             }
             break;
 

--- a/src/libnetdata/socket/connect-to.c
+++ b/src/libnetdata/socket/connect-to.c
@@ -49,6 +49,31 @@ static inline int connect_to_unix(const char *path, struct timeval *timeout) {
     return fd;
 }
 
+static inline int timeval_to_poll_timeout_ms(const struct timeval *timeout) {
+    if(!timeout)
+        return 1000;
+
+    if(timeout->tv_sec <= 0 && timeout->tv_usec <= 0)
+        return 0;
+
+    uint64_t timeout_ms = 0;
+
+    if(timeout->tv_sec > 0) {
+        if((uint64_t)timeout->tv_sec > (uint64_t)INT_MAX / MSEC_PER_SEC)
+            return INT_MAX;
+
+        timeout_ms = (uint64_t)timeout->tv_sec * MSEC_PER_SEC;
+    }
+
+    if(timeout->tv_usec > 0)
+        timeout_ms += (uint64_t)timeout->tv_usec / USEC_PER_MS;
+
+    if(timeout_ms > INT_MAX)
+        return INT_MAX;
+
+    return (int)timeout_ms;
+}
+
 // connect_to_this_ip46()
 // protocol    IPPROTO_TCP, IPPROTO_UDP
 // socktype    SOCK_STREAM, SOCK_DGRAM
@@ -154,8 +179,7 @@ int connect_to_this_ip46(
                            "Waiting for connection to ip %s port %s to be established",
                            hostBfr, servBfr);
 
-                    // Convert 'struct timeval' to milliseconds for poll():
-                    int timeout_ms = timeout ? (timeout->tv_sec * 1000 + timeout->tv_usec / 1000) : 1000;
+                    int timeout_ms = timeval_to_poll_timeout_ms(timeout);
 
                     switch(wait_on_socket_or_cancel_with_timeout(NULL, fd, timeout_ms, POLLOUT, NULL)) {
                         case  0: // proceed

--- a/src/libnetdata/socket/socket.c
+++ b/src/libnetdata/socket/socket.c
@@ -14,8 +14,8 @@ bool ip_to_hostname(const char *ip, char *dst, size_t dst_len) {
     if(!dst || !dst_len)
         return false;
 
-    struct sockaddr_in sa;
-    struct sockaddr_in6 sa6;
+    struct sockaddr_in sa = { 0 };
+    struct sockaddr_in6 sa6 = { 0 };
     struct sockaddr *sa_ptr;
     int sa_len;
 

--- a/src/libnetdata/socket/socket.c
+++ b/src/libnetdata/socket/socket.c
@@ -655,17 +655,17 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
             nd_log(NDLS_DAEMON, NDLP_ERR,
                    "LISTENER: cannot getnameinfo() on received client connection.");
 
-            strncpyz(client_ip, "UNKNOWN", ipsize);
-            strncpyz(client_port, "UNKNOWN", portsize);
+            strncpyz(client_ip, "UNKNOWN", ipsize - 1);
+            strncpyz(client_port, "UNKNOWN", portsize - 1);
         }
         if (!strcmp(client_ip, "127.0.0.1") || !strcmp(client_ip, "::1")) {
-            strncpyz(client_ip, "localhost", ipsize);
+            strncpyz(client_ip, "localhost", ipsize - 1);
         }
         sock_setcloexec(nfd, true);
 
 #ifdef __FreeBSD__
         if(((struct sockaddr *)&sadr)->sa_family == AF_LOCAL)
-            strncpyz(client_ip, "localhost", ipsize);
+            strncpyz(client_ip, "localhost", ipsize - 1);
 #endif
 
         client_ip[ipsize - 1] = '\0';
@@ -675,7 +675,7 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
             case AF_UNIX:
                 // netdata_log_debug(D_LISTENER, "New UNIX domain web client from %s on socket %d.", client_ip, fd);
                 // set the port - certain versions of libc return garbage on unix sockets
-                strncpyz(client_port, "UNIX", portsize);
+                strncpyz(client_port, "UNIX", portsize - 1);
                 break;
 
             case AF_INET:

--- a/src/libnetdata/user-auth/http-access.c
+++ b/src/libnetdata/user-auth/http-access.c
@@ -48,25 +48,24 @@ const char *http_id2user_role(HTTP_USER_ROLE role) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-static struct {
+static const struct {
     const char *name;
-    uint32_t hash;
     HTTP_ACCESS value;
 } http_accesses[] = {
-      {"none"                       , 0    , HTTP_ACCESS_NONE}
-    , {"signed-in"                  , 0    , HTTP_ACCESS_SIGNED_ID}
-    , {"same-space"                 , 0    , HTTP_ACCESS_SAME_SPACE}
-    , {"commercial"                 , 0    , HTTP_ACCESS_COMMERCIAL_SPACE}
-    , {"anonymous-data"             , 0    , HTTP_ACCESS_ANONYMOUS_DATA}
-    , {"sensitive-data"             , 0    , HTTP_ACCESS_SENSITIVE_DATA}
-    , {"view-config"                , 0    , HTTP_ACCESS_VIEW_AGENT_CONFIG}
-    , {"edit-config"                , 0    , HTTP_ACCESS_EDIT_AGENT_CONFIG}
-    , {"view-notifications-config"  , 0    , HTTP_ACCESS_VIEW_NOTIFICATIONS_CONFIG}
-    , {"edit-notifications-config"  , 0    , HTTP_ACCESS_EDIT_NOTIFICATIONS_CONFIG}
-    , {"view-alerts-silencing"      , 0    , HTTP_ACCESS_VIEW_ALERTS_SILENCING}
-    , {"edit-alerts-silencing"     , 0    , HTTP_ACCESS_EDIT_ALERTS_SILENCING}
+      {"none"                       , HTTP_ACCESS_NONE}
+    , {"signed-in"                  , HTTP_ACCESS_SIGNED_ID}
+    , {"same-space"                 , HTTP_ACCESS_SAME_SPACE}
+    , {"commercial"                 , HTTP_ACCESS_COMMERCIAL_SPACE}
+    , {"anonymous-data"             , HTTP_ACCESS_ANONYMOUS_DATA}
+    , {"sensitive-data"             , HTTP_ACCESS_SENSITIVE_DATA}
+    , {"view-config"                , HTTP_ACCESS_VIEW_AGENT_CONFIG}
+    , {"edit-config"                , HTTP_ACCESS_EDIT_AGENT_CONFIG}
+    , {"view-notifications-config"  , HTTP_ACCESS_VIEW_NOTIFICATIONS_CONFIG}
+    , {"edit-notifications-config"  , HTTP_ACCESS_EDIT_NOTIFICATIONS_CONFIG}
+    , {"view-alerts-silencing"      , HTTP_ACCESS_VIEW_ALERTS_SILENCING}
+    , {"edit-alerts-silencing"      , HTTP_ACCESS_EDIT_ALERTS_SILENCING}
 
-    , {NULL                , 0    , 0}
+    , {NULL                         , 0}
 };
 
 inline HTTP_ACCESS http_access2id_one(const char *str) {
@@ -77,10 +76,9 @@ inline HTTP_ACCESS http_access2id_one(const char *str) {
     uint32_t hash = simple_hash(str);
     int i;
     for(i = 0; http_accesses[i].name ; i++) {
-        if(unlikely(!http_accesses[i].hash))
-            http_accesses[i].hash = simple_hash(http_accesses[i].name);
+        uint32_t candidate_hash = simple_hash(http_accesses[i].name);
 
-        if (unlikely(hash == http_accesses[i].hash && !strcmp(str, http_accesses[i].name))) {
+        if (unlikely(hash == candidate_hash && !strcmp(str, http_accesses[i].name))) {
             ret |= http_accesses[i].value;
             break;
         }

--- a/src/streaming/stream-compression/brotli.c
+++ b/src/streaming/stream-compression/brotli.c
@@ -8,8 +8,9 @@
 
 void stream_compressor_init_brotli(struct compressor_state *state) {
     if (!state->initialized) {
-        state->initialized = true;
         state->stream = BrotliEncoderCreateInstance(NULL, NULL, NULL);
+        if (!state->stream)
+            return;
 
         if (state->level < BROTLI_MIN_QUALITY) {
             state->level = BROTLI_MIN_QUALITY;
@@ -17,7 +18,13 @@ void stream_compressor_init_brotli(struct compressor_state *state) {
             state->level = BROTLI_MAX_QUALITY;
         }
 
-        BrotliEncoderSetParameter(state->stream, BROTLI_PARAM_QUALITY, state->level);
+        if (!BrotliEncoderSetParameter(state->stream, BROTLI_PARAM_QUALITY, state->level)) {
+            BrotliEncoderDestroyInstance(state->stream);
+            state->stream = NULL;
+            return;
+        }
+
+        state->initialized = true;
     }
 }
 
@@ -76,10 +83,12 @@ size_t stream_compress_brotli(struct compressor_state *state, const char *data, 
 
 void stream_decompressor_init_brotli(struct decompressor_state *state) {
     if (!state->initialized) {
-        state->initialized = true;
         state->stream = BrotliDecoderCreateInstance(NULL, NULL, NULL);
+        if (!state->stream)
+            return;
 
         simple_ring_buffer_make_room(&state->output, COMPRESSION_MAX_CHUNK);
+        state->initialized = true;
     }
 }
 

--- a/src/streaming/stream-compression/brotli.c
+++ b/src/streaming/stream-compression/brotli.c
@@ -19,6 +19,7 @@ void stream_compressor_init_brotli(struct compressor_state *state) {
         }
 
         if (!BrotliEncoderSetParameter(state->stream, BROTLI_PARAM_QUALITY, state->level)) {
+            netdata_log_error("STREAM_COMPRESS: BrotliEncoderSetParameter() failed to set quality to %d", state->level);
             BrotliEncoderDestroyInstance(state->stream);
             state->stream = NULL;
             return;

--- a/src/streaming/stream-compression/compression.c
+++ b/src/streaming/stream-compression/compression.c
@@ -106,7 +106,7 @@ bool stream_compression_initialize(struct sender_state *s) {
     if(s->thread.compressor.algorithm != COMPRESSION_ALGORITHM_NONE) {
         s->thread.compressor.level = stream_send.compression.levels[s->thread.compressor.algorithm];
         stream_compressor_init(&s->thread.compressor);
-        return true;
+        return s->thread.compressor.initialized;
     }
 
     return false;
@@ -131,7 +131,7 @@ bool stream_decompression_initialize(struct receiver_state *rpt) {
 
     if(rpt->thread.compressed.decompressor.algorithm != COMPRESSION_ALGORITHM_NONE) {
         stream_decompressor_init(&rpt->thread.compressed.decompressor);
-        return true;
+        return rpt->thread.compressed.decompressor.initialized;
     }
 
     return false;

--- a/src/streaming/stream-compression/compression.c
+++ b/src/streaming/stream-compression/compression.c
@@ -269,9 +269,9 @@ size_t stream_compress(struct compressor_state *state, const char *data, size_t 
             break;
     }
 
-    if(unlikely(ret >= COMPRESSION_MAX_CHUNK)) {
-        netdata_log_error("STREAM_COMPRESS: compressed data is %zu bytes, which is >= than the max chunk size %d",
-                ret, COMPRESSION_MAX_CHUNK);
+    if(unlikely(ret >= COMPRESSION_MAX_CHUNK || ret > STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE)) {
+        netdata_log_error("STREAM_COMPRESS: compressed data is %zu bytes, exceeding max chunk size %d or signature capacity %u",
+                ret, COMPRESSION_MAX_CHUNK, STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE);
         return 0;
     }
 
@@ -389,6 +389,48 @@ size_t stream_decompress(struct decompressor_state *state, const char *compresse
 
 // ----------------------------------------------------------------------------
 // unit test
+
+static int unittest_stream_compression_signature(void) {
+    fprintf(stderr, "\nTesting streaming compression signature\n");
+
+    static const size_t lengths[] = {
+        1,
+        STREAM_COMPRESSION_SIGNATURE_7BIT_MASK,
+        STREAM_COMPRESSION_SIGNATURE_7BIT_MASK + 1,
+        STREAM_COMPRESSION_SIGNATURE_HIGH_BITS_MASK,
+        STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE,
+    };
+
+    int errors = 0;
+
+    for(size_t i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+        stream_compression_signature_t signature = stream_compress_encode_signature(lengths[i]);
+        size_t decoded = stream_decompress_decode_signature((const char *)&signature, sizeof(signature));
+
+        if(decoded != lengths[i]) {
+            fprintf(stderr,
+                    "  FAILED: signature length round trip for %zu bytes decoded as %zu bytes\n",
+                    lengths[i], decoded);
+            errors++;
+        }
+    }
+
+    stream_compression_signature_t signature =
+        stream_compress_encode_signature(STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE);
+    if(stream_decompress_decode_signature((const char *)&signature, sizeof(signature) - 1) != 0) {
+        fprintf(stderr, "  FAILED: truncated signature decoded as valid\n");
+        errors++;
+    }
+
+    char invalid_signature[STREAM_COMPRESSION_SIGNATURE_SIZE] = { 0 };
+    if(stream_decompress_decode_signature(invalid_signature, sizeof(invalid_signature)) != 0) {
+        fprintf(stderr, "  FAILED: invalid signature decoded as valid\n");
+        errors++;
+    }
+
+    fprintf(stderr, "Streaming compression signature: %s\n", errors ? "FAILED" : "OK");
+    return errors;
+}
 
 void unittest_generate_random_name(char *dst, size_t size) {
     if(size < 7)
@@ -525,7 +567,7 @@ int unittest_stream_compression_speed(compression_algorithm_t algorithm, const c
             errors++;
             goto cleanup;
         }
-        else if(size >= COMPRESSION_MAX_CHUNK) {
+        else if(size >= COMPRESSION_MAX_CHUNK || size > STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE) {
             fprintf(stderr, "iteration %d: compressed size %zu exceeds max allowed size\n",
                     i, size);
             errors++;
@@ -618,7 +660,7 @@ int unittest_stream_compression(compression_algorithm_t algorithm, const char *n
             errors++;
             goto cleanup;
         }
-        else if(size >= COMPRESSION_MAX_CHUNK) {
+        else if(size >= COMPRESSION_MAX_CHUNK || size > STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE) {
             fprintf(stderr, "iteration %d: compressed size %zu exceeds max allowed size\n",
                     i, size);
             errors++;
@@ -687,6 +729,8 @@ int unittest_stream_decompress_bomb_zstd(void);
 
 int unittest_stream_compressions(void) {
     int ret = 0;
+
+    ret += unittest_stream_compression_signature();
 
 #ifdef ENABLE_ZSTD
     ret += unittest_stream_decompress_bomb_zstd();

--- a/src/streaming/stream-compression/compression.h
+++ b/src/streaming/stream-compression/compression.h
@@ -49,14 +49,34 @@ static inline void simple_ring_buffer_reset(SIMPLE_RING_BUFFER *b) {
 }
 
 static inline void simple_ring_buffer_make_room(SIMPLE_RING_BUFFER *b, size_t size) {
-    if(b->write_pos + size > b->size) {
-        if(!b->size)
-            b->size = COMPRESSION_MAX_CHUNK;
-        else
-            b->size *= 2;
+    if(unlikely(!b))
+        fatal("STREAM_COMPRESSION: NULL simple ring buffer");
 
-        if(b->write_pos + size > b->size)
-            b->size += size;
+    size_t needed_size;
+    if(unlikely(__builtin_add_overflow(b->write_pos, size, &needed_size)))
+        fatal("STREAM_COMPRESSION: simple ring buffer size overflow (write_pos=%zu, size=%zu)",
+              b->write_pos, size);
+
+    if(needed_size > b->size) {
+        size_t new_size;
+        if(!b->size)
+            new_size = COMPRESSION_MAX_CHUNK;
+        else if(b->size > SIZE_MAX / 2)
+            new_size = needed_size;
+        else
+            new_size = b->size * 2;
+
+        if(needed_size > new_size) {
+            if(size > SIZE_MAX - new_size)
+                new_size = needed_size;
+            else
+                new_size += size;
+
+            if(new_size < needed_size)
+                new_size = needed_size;
+        }
+
+        b->size = new_size;
 
         b->data = (const char *)reallocz((void *)b->data, b->size);
     }
@@ -145,6 +165,10 @@ static inline size_t stream_decompressor_start(struct decompressor_state *state,
 static inline size_t stream_decompressed_bytes_in_buffer(struct decompressor_state *state) {
     if(unlikely(state->output.read_pos > state->output.write_pos))
         fatal("STREAM_DECOMPRESS: invalid read/write stream positions");
+    if(unlikely(state->output.write_pos > state->output.size))
+        fatal("STREAM_DECOMPRESS: invalid output buffer size");
+    if(unlikely(state->output.write_pos && !state->output.data))
+        fatal("STREAM_DECOMPRESS: missing output buffer data");
 
     return state->output.write_pos - state->output.read_pos;
 }
@@ -161,6 +185,8 @@ static inline size_t stream_decompressor_get(struct decompressor_state *state, c
     size_t bytes_to_return = size;
     if(bytes_to_return > remaining)
         bytes_to_return = remaining;
+    if(unlikely(bytes_to_return > state->output.size - state->output.read_pos))
+        fatal("STREAM_DECOMPRESS: invalid output buffer read");
 
     memcpy(dst, state->output.data + state->output.read_pos, bytes_to_return);
     state->output.read_pos += bytes_to_return;

--- a/src/streaming/stream-compression/compression.h
+++ b/src/streaming/stream-compression/compression.h
@@ -12,12 +12,27 @@
 #endif
 
 typedef uint32_t stream_compression_signature_t;
+#define STREAM_COMPRESSION_SIGNATURE_LENGTH_BITS 14U
+#define STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE ((1U << STREAM_COMPRESSION_SIGNATURE_LENGTH_BITS) - 1U)
+#define STREAM_COMPRESSION_SIGNATURE_7BIT_MASK ((stream_compression_signature_t)0x7fU)
+#define STREAM_COMPRESSION_SIGNATURE_HIGH_BITS_MASK (STREAM_COMPRESSION_SIGNATURE_7BIT_MASK << 7)
+
+#if COMPRESSION_MAX_CHUNK > (STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE + 1U)
+#error "COMPRESSION_MAX_CHUNK exceeds stream compression signature length capacity"
+#endif
+
 #define STREAM_COMPRESSION_SIGNATURE ((stream_compression_signature_t)('z' | 0x80) | (0x80 << 8) | (0x80 << 16) | ('\n' << 24))
 #define STREAM_COMPRESSION_SIGNATURE_MASK ((stream_compression_signature_t) 0xffU | (0x80U << 8) | (0x80U << 16) | (0xffU << 24))
 #define STREAM_COMPRESSION_SIGNATURE_SIZE sizeof(stream_compression_signature_t)
 
 static inline stream_compression_signature_t stream_compress_encode_signature(size_t compressed_data_size) {
-    stream_compression_signature_t len = ((compressed_data_size & 0x7f) | 0x80 | (((compressed_data_size & (0x7f << 7)) << 1) | 0x8000)) << 8;
+    if(unlikely(compressed_data_size > STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE))
+        fatal("STREAM_COMPRESS: compressed data size %zu exceeds stream compression signature capacity %u",
+              compressed_data_size, STREAM_COMPRESSION_SIGNATURE_MAX_PAYLOAD_SIZE);
+
+    stream_compression_signature_t len =
+        ((((stream_compression_signature_t)compressed_data_size & STREAM_COMPRESSION_SIGNATURE_7BIT_MASK) | 0x80U |
+          ((((stream_compression_signature_t)compressed_data_size & STREAM_COMPRESSION_SIGNATURE_HIGH_BITS_MASK) << 1) | 0x8000U)) << 8);
     return len | STREAM_COMPRESSION_SIGNATURE;
 }
 
@@ -151,7 +166,8 @@ static inline size_t stream_decompress_decode_signature(const char *data, size_t
     if (unlikely((sign & STREAM_COMPRESSION_SIGNATURE_MASK) != STREAM_COMPRESSION_SIGNATURE))
         return 0;
 
-    size_t length = ((sign >> 8) & 0x7f) | ((sign >> 9) & (0x7f << 7));
+    size_t length = ((sign >> 8) & STREAM_COMPRESSION_SIGNATURE_7BIT_MASK) |
+                    ((sign >> 9) & STREAM_COMPRESSION_SIGNATURE_HIGH_BITS_MASK);
     return length;
 }
 

--- a/src/streaming/stream-compression/gzip.c
+++ b/src/streaming/stream-compression/gzip.c
@@ -5,8 +5,6 @@
 
 void stream_compressor_init_gzip(struct compressor_state *state) {
     if (!state->initialized) {
-        state->initialized = true;
-
         // Initialize deflate stream
         z_stream *strm = state->stream = (z_stream *) mallocz(sizeof(z_stream));
         strm->zalloc = Z_NULL;
@@ -24,10 +22,12 @@ void stream_compressor_init_gzip(struct compressor_state *state) {
         if (r != Z_OK) {
             netdata_log_error("STREAM_COMPRESS: Failed to initialize deflate with error: %d", r);
             freez(state->stream);
+            state->stream = NULL;
             state->initialized = false;
             return;
         }
 
+        state->initialized = true;
     }
 }
 
@@ -89,8 +89,6 @@ size_t stream_compress_gzip(struct compressor_state *state, const char *data, si
 
 void stream_decompressor_init_gzip(struct decompressor_state *state) {
     if (!state->initialized) {
-        state->initialized = true;
-
         // Initialize inflate stream
         z_stream *strm = state->stream = (z_stream *)mallocz(sizeof(z_stream));
         strm->zalloc = Z_NULL;
@@ -101,11 +99,13 @@ void stream_decompressor_init_gzip(struct decompressor_state *state) {
         if (r != Z_OK) {
             netdata_log_error("STREAM_DECOMPRESS: Failed to initialize inflateInit2() with error: %d", r);
             freez(state->stream);
+            state->stream = NULL;
             state->initialized = false;
             return;
         }
 
         simple_ring_buffer_make_room(&state->output, COMPRESSION_MAX_CHUNK);
+        state->initialized = true;
     }
 }
 

--- a/src/streaming/stream-compression/lz4.c
+++ b/src/streaming/stream-compression/lz4.c
@@ -11,12 +11,14 @@
 
 void stream_compressor_init_lz4(struct compressor_state *state) {
     if(!state->initialized) {
-        state->initialized = true;
         state->stream = LZ4_createStream();
+        if(!state->stream)
+            return;
 
         // LZ4 needs access to the last 64KB of source data
         // so, we keep twice the size of each message
         simple_ring_buffer_make_room(&state->input, 65536 + COMPRESSION_MAX_CHUNK * 2);
+        state->initialized = true;
     }
 }
 
@@ -78,9 +80,12 @@ size_t stream_compress_lz4(struct compressor_state *state, const char *data, siz
 
 void stream_decompressor_init_lz4(struct decompressor_state *state) {
     if(!state->initialized) {
-        state->initialized = true;
         state->stream = LZ4_createStreamDecode();
+        if(!state->stream)
+            return;
+
         simple_ring_buffer_make_room(&state->output, 65536 + COMPRESSION_MAX_CHUNK * 2);
+        state->initialized = true;
     }
 }
 

--- a/src/streaming/stream-compression/zstd.c
+++ b/src/streaming/stream-compression/zstd.c
@@ -7,8 +7,9 @@
 
 void stream_compressor_init_zstd(struct compressor_state *state) {
     if(!state->initialized) {
-        state->initialized = true;
         state->stream = ZSTD_createCStream();
+        if(!state->stream)
+            return;
 
         if(state->level < 1)
             state->level = 1;
@@ -17,11 +18,16 @@ void stream_compressor_init_zstd(struct compressor_state *state) {
             state->level = ZSTD_maxCLevel();
 
         size_t ret = ZSTD_initCStream(state->stream, state->level);
-        if(ZSTD_isError(ret))
+        if(ZSTD_isError(ret)) {
             netdata_log_error("STREAM_COMPRESS: ZSTD_initCStream() returned error: %s", ZSTD_getErrorName(ret));
+            ZSTD_freeCStream(state->stream);
+            state->stream = NULL;
+            return;
+        }
 
         // ZSTD_CCtx_setParameter(state->stream, ZSTD_c_compressionLevel, 1);
         // ZSTD_CCtx_setParameter(state->stream, ZSTD_c_strategy, ZSTD_fast);
+        state->initialized = true;
     }
 }
 
@@ -94,14 +100,20 @@ size_t stream_compress_zstd(struct compressor_state *state, const char *data, si
 
 void stream_decompressor_init_zstd(struct decompressor_state *state) {
     if(!state->initialized) {
-        state->initialized = true;
         state->stream = ZSTD_createDStream();
+        if(!state->stream)
+            return;
 
         size_t ret = ZSTD_initDStream(state->stream);
-        if(ZSTD_isError(ret))
+        if(ZSTD_isError(ret)) {
             netdata_log_error("STREAM_DECOMPRESS: ZSTD_initDStream() returned error: %s", ZSTD_getErrorName(ret));
+            ZSTD_freeDStream(state->stream);
+            state->stream = NULL;
+            return;
+        }
 
         simple_ring_buffer_make_room(&state->output, MAX(COMPRESSION_MAX_CHUNK, ZSTD_DStreamOutSize()));
+        state->initialized = true;
     }
 }
 

--- a/src/streaming/stream-sender-commit.c
+++ b/src/streaming/stream-sender-commit.c
@@ -144,7 +144,9 @@ void sender_buffer_commit(struct sender_state *s, BUFFER *wb, struct sender_buff
                     "STREAM SND '%s' [to %s]: COMPRESSION failed. Resetting compressor and re-trying",
                     rrdhost_hostname(s->host), s->remote_ip);
 
-                stream_compression_initialize(s);
+                if (!stream_compression_initialize(s))
+                    goto compression_failed_with_lock;
+
                 dst_len = stream_compress(&s->thread.compressor, src, size_to_compress, &dst);
                 if (!dst_len)
                     goto compression_failed_with_lock;

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -16,12 +16,12 @@ static NETDATA_DOUBLE *UNUSED_FUNCTION(rrdr_line_values)(RRDR *r, long rrdr_line
 }
 
 ALWAYS_INLINE
-static long rrdr_line_next(RRDR *r __maybe_unused, long rrdr_line) {
+static long rrdr_line_next(RRDR *r, long rrdr_line) {
     rrdr_line++;
 
-    internal_fatal(rrdr_line >= (long)r->n,
-                   "QUERY: requested to step above RRDR size for query '%s'",
-                   r->internal.qt->id);
+    if(unlikely(rrdr_line < 0 || (size_t)rrdr_line >= r->n))
+        fatal("QUERY: requested to step above RRDR size for query '%s'",
+              r->internal.qt->id);
 
     return rrdr_line;
 }

--- a/src/web/api/v1/api_v1_alarms.c
+++ b/src/web/api/v1/api_v1_alarms.c
@@ -54,7 +54,7 @@ int api_v1_alarm_count(RRDHOST *host, struct web_client *w, char *url) {
 
         char* p = value;
         if(!strcmp(name, "status")) {
-            while ((*p = toupper(*p))) p++;
+            while ((*p = (char)toupper((uint8_t)*p))) p++;
             if (!strcmp("CRITICAL", value)) status = RRDCALC_STATUS_CRITICAL;
             else if (!strcmp("WARNING", value)) status = RRDCALC_STATUS_WARNING;
             else if (!strcmp("UNINITIALIZED", value)) status = RRDCALC_STATUS_UNINITIALIZED;

--- a/src/web/api/v1/api_v1_allmetrics.c
+++ b/src/web/api/v1/api_v1_allmetrics.c
@@ -35,8 +35,8 @@ static inline size_t shell_name_copy(char *d, const char *s, size_t usable) {
     for(n = 0; *s && n < usable ; d++, s++, n++) {
         register char c = *s;
 
-        if(unlikely(!isalnum(c))) *d = '_';
-        else *d = (char)toupper(c);
+        if(unlikely(!isalnum((uint8_t)c))) *d = '_';
+        else *d = (char)toupper((uint8_t)c);
     }
     *d = '\0';
 

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -1708,6 +1708,14 @@ ssize_t web_client_send_deflate(struct web_client *w)
 
         // give the compressor all the data not passed through the compressor yet
         if(w->response.data->len > w->response.sent) {
+            if(unlikely((size_t)w->response.zstream.avail_in > w->response.sent)) {
+                netdata_log_error(
+                    "%llu: Compression input state is inconsistent (sent %zu, avail_in %u). Closing down client.",
+                    w->id, w->response.sent, w->response.zstream.avail_in);
+                web_client_request_done(w);
+                return -1;
+            }
+
             w->response.zstream.next_in = (Bytef *)&w->response.data->buffer[w->response.sent - w->response.zstream.avail_in];
             w->response.zstream.avail_in += (uInt) (w->response.data->len - w->response.sent);
         }

--- a/src/web/websocket/websocket-send.c
+++ b/src/web/websocket/websocket-send.c
@@ -146,17 +146,19 @@ static int websocket_protocol_send_frame(
             header_dst[3] = final_payload_len & 0xFF;
             break;
 
-        case 10:
+        case 10: {
+            uint64_t final_payload_len64 = final_payload_len;
             header_dst[1] = 127;
-            header_dst[2] = (final_payload_len >> 56) & 0xFF;
-            header_dst[3] = (final_payload_len >> 48) & 0xFF;
-            header_dst[4] = (final_payload_len >> 40) & 0xFF;
-            header_dst[5] = (final_payload_len >> 32) & 0xFF;
-            header_dst[6] = (final_payload_len >> 24) & 0xFF;
-            header_dst[7] = (final_payload_len >> 16) & 0xFF;
-            header_dst[8] = (final_payload_len >> 8) & 0xFF;
-            header_dst[9] = final_payload_len & 0xFF;
+            header_dst[2] = (final_payload_len64 >> 56) & 0xFF;
+            header_dst[3] = (final_payload_len64 >> 48) & 0xFF;
+            header_dst[4] = (final_payload_len64 >> 40) & 0xFF;
+            header_dst[5] = (final_payload_len64 >> 32) & 0xFF;
+            header_dst[6] = (final_payload_len64 >> 24) & 0xFF;
+            header_dst[7] = (final_payload_len64 >> 16) & 0xFF;
+            header_dst[8] = (final_payload_len64 >> 8) & 0xFF;
+            header_dst[9] = final_payload_len64 & 0xFF;
             break;
+        }
 
         default:
             // impossible case - added to avoid compiler warning


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens streaming, sockets, and web paths to fix memory-safety issues and make error handling predictable. Covers compression init and limits, netlink/socket I/O, timeout handling, and 32-bit WebSocket encoding.

- **Bug Fixes**
  - Streaming compression: propagate init failures, guard ring buffer growth and decompressor reads, enforce 14-bit signature limits (with tests), reject oversize chunks; sender retry now aborts if re-init fails; log Brotli quality parameter errors.
  - Local sockets: bound `inet_diag` attribute payload reads, use exact read/write for namespace pipe framing, and make the error log counter atomic.
  - Sockets: clamp timeval-to-poll conversion to INT_MAX ms, zero-initialize sockaddr for reverse lookups, and fix `strncpyz()` bounds in accept() fallbacks.
  - Web paths: guard zlib input rewind in deflate, cast bytes to `uint8_t` for `ctype` calls, add always-on RRDR line bounds check, encode 64-bit WebSocket payload length using `uint64_t` for 32-bit builds, and remove the lazy `http_accesses` hash cache to avoid races.

<sup>Written for commit 3cde40ee51b1c1f70ea117f2068ba0299afcc0be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

