### PR TITLE
Netdata fixes part 29

### DIFF
--- a/src/collectors/systemd-journal.plugin/systemd-journal-function.h
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-function.h
@@ -30,7 +30,7 @@ struct lqs_extension {
         uint32_t slots;
         uint32_t sampled;
         uint32_t unsampled;
-        uint32_t estimated;
+        size_t estimated;
     } samples;
 
     struct {
@@ -40,7 +40,7 @@ struct lqs_extension {
         uint32_t recalibrate;
         uint32_t sampled;
         uint32_t unsampled;
-        uint32_t estimated;
+        size_t estimated;
     } samples_per_file;
 
     struct {

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -204,12 +204,44 @@ static inline void pointer_del(PGC *cache __maybe_unused, PGC_PAGE *page __maybe
 // ----------------------------------------------------------------------------
 // helpers
 
+static inline size_t page_assumed_size_overhead(PGC *cache) {
+    size_t overhead = sizeof(PGC_PAGE);
+
+    if(unlikely(__builtin_add_overflow(overhead, cache->config.additional_bytes_per_page, &overhead) ||
+                __builtin_add_overflow(overhead, sizeof(Word_t) * 3, &overhead)))
+        fatal("DBENGINE CACHE: page assumed size overhead overflow for cache '%s' (additional_bytes_per_page=%zu)",
+              cache->config.name, cache->config.additional_bytes_per_page);
+
+    if(unlikely(overhead > UINT32_MAX))
+        fatal("DBENGINE CACHE: page assumed size overhead %zu exceeds uint32_t accounting for cache '%s'",
+              overhead, cache->config.name);
+
+    return overhead;
+}
+
 static inline size_t page_assumed_size(PGC *cache, size_t size) {
-    return size + (sizeof(PGC_PAGE) + cache->config.additional_bytes_per_page + sizeof(Word_t) * 3);
+    size_t overhead = page_assumed_size_overhead(cache);
+    size_t assumed_size;
+
+    if(unlikely(__builtin_add_overflow(size, overhead, &assumed_size)))
+        fatal("DBENGINE CACHE: page assumed size overflow for cache '%s' (size=%zu, overhead=%zu)",
+              cache->config.name, size, overhead);
+
+    if(unlikely(assumed_size > UINT32_MAX))
+        fatal("DBENGINE CACHE: page assumed size %zu exceeds uint32_t accounting for cache '%s'",
+              assumed_size, cache->config.name);
+
+    return assumed_size;
 }
 
 static inline size_t page_size_from_assumed_size(PGC *cache, size_t assumed_size) {
-    return assumed_size - (sizeof(PGC_PAGE) + cache->config.additional_bytes_per_page + sizeof(Word_t) * 3);
+    size_t overhead = page_assumed_size_overhead(cache);
+
+    if(unlikely(assumed_size < overhead))
+        fatal("DBENGINE CACHE: page assumed size %zu is smaller than overhead %zu for cache '%s'",
+              assumed_size, overhead, cache->config.name);
+
+    return assumed_size - overhead;
 }
 
 // ----------------------------------------------------------------------------
@@ -2375,7 +2407,11 @@ void pgc_page_hot_set_end_time_s(PGC *cache __maybe_unused, PGC_PAGE *page, time
         int64_t old_assumed_size = page->assumed_size;
 
         size_t old_size = page_size_from_assumed_size(cache, old_assumed_size);
-        size_t size = old_size + additional_bytes;
+        size_t size;
+        if(unlikely(__builtin_add_overflow(old_size, additional_bytes, &size)))
+            fatal("DBENGINE CACHE: page size growth overflow for cache '%s' (old_size=%zu, additional_bytes=%zu)",
+                  cache->config.name, old_size, additional_bytes);
+
         page->assumed_size = page_assumed_size(cache, size);
 
         int64_t delta = page->assumed_size - old_assumed_size;

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -2590,6 +2590,7 @@ void pgc_open_cache_to_journal_v2(
             fatal("CACHE: JudyLIns(JudyL_pages_by_start_time, %ld) failed, JudyL_pages_by_start_time = %p, result = %p",
                   (long)page->start_time_s, mi->JudyL_pages_by_start_time, PValue);
 
+        bool page_queued_for_jv2_cleanup = false;
         if(!*PValue) {
             struct jv2_page_info *pi = aral_mallocz(ar_pi);
             pi->start_time_s = page->start_time_s;
@@ -2601,19 +2602,25 @@ void pgc_open_cache_to_journal_v2(
             pi->custom_data = (cache->config.additional_bytes_per_page) ? page->custom_data : NULL;
             *PValue = pi;
 
+            page_queued_for_jv2_cleanup = true;
             count_of_unique_pages++;
         }
         else {
             // impossible situation
             internal_fatal(true, "Page is already in JudyL metric pages");
-            page_flag_clear(page, PGC_PAGE_IS_BEING_MIGRATED_TO_V2);
-            page_transition_unlock(cache, page);
-            page_release(cache, page, false);
         }
 
         if (likely(false == startup))
             yield_the_processor(); // do not lock too aggressively
         pgc_queue_lock(cache, &cache->hot, PGC_QUEUE_LOCK_PRIO_LOW);
+
+        if(unlikely(!page_queued_for_jv2_cleanup)) {
+            // The loop advances through page->link.next; keep the page pinned
+            // until the hot lock protects the cursor again.
+            page_flag_clear(page, PGC_PAGE_IS_BEING_MIGRATED_TO_V2);
+            page_transition_unlock(cache, page);
+            page_release(cache, page, false);
+        }
     }
 
     spinlock_unlock(&sp->migration_to_v2_spinlock);

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -170,28 +170,35 @@ static void njfv2idx_add(struct rrdengine_datafile *datafile) {
         fatal("DBENGINE: NJFV2IDX trying to index a journal file with no datafile");
 
     struct rrdengine_instance *ctx = datafile_ctx(datafile);
+    time_t last_time_s = datafile->journalfile->v2.last_time_s;
 
-    internal_fatal(datafile->journalfile->v2.last_time_s <= 0, "DBENGINE: NJFV2IDX trying to index a journal file with invalid first_time_s");
+    if(unlikely(last_time_s <= 0))
+        fatal("DBENGINE: NJFV2IDX trying to index a journal file with invalid last_time_s");
+
+    if(unlikely((uintmax_t)last_time_s > (uintmax_t)(Word_t)~0UL))
+        fatal("DBENGINE: NJFV2IDX trying to index a journal file with last_time_s outside Judy word range");
+
+    Word_t indexed_as = (Word_t)last_time_s;
 
     rw_spinlock_write_lock(&ctx->njfv2idx.spinlock);
-    datafile->journalfile->njfv2idx.indexed_as = datafile->journalfile->v2.last_time_s;
 
-    do {
-        internal_fatal(datafile->journalfile->njfv2idx.indexed_as <= 0, "DBENGINE: NJFV2IDX journalfile is already indexed");
+    // Ask Judy for the empty slot so collision probing is bounded and cannot wrap.
+    int rc = JudyLFirstEmpty(ctx->njfv2idx.JudyL, &indexed_as, PJE0);
+    if(unlikely(rc == JERR))
+        fatal("DBENGINE: NJFV2IDX corrupted judy array");
 
-        Pvoid_t *PValue = JudyLIns(&ctx->njfv2idx.JudyL, datafile->journalfile->njfv2idx.indexed_as, PJE0);
-        if (!PValue || PValue == PJERR)
-            fatal("DBENGINE: NJFV2IDX corrupted judy array");
+    if(unlikely(!rc))
+        fatal("DBENGINE: NJFV2IDX cannot find an empty journal file index slot");
 
-        if (unlikely(*PValue)) {
-            // already there
-            datafile->journalfile->njfv2idx.indexed_as++;
-        }
-        else {
-            *PValue = datafile;
-            break;
-        }
-    } while(1);
+    Pvoid_t *PValue = JudyLIns(&ctx->njfv2idx.JudyL, indexed_as, PJE0);
+    if (!PValue || PValue == PJERR)
+        fatal("DBENGINE: NJFV2IDX corrupted judy array");
+
+    if(unlikely(*PValue))
+        fatal("DBENGINE: NJFV2IDX selected an occupied journal file index slot");
+
+    *PValue = datafile;
+    datafile->journalfile->njfv2idx.indexed_as = indexed_as;
 
     rw_spinlock_write_unlock(&ctx->njfv2idx.spinlock);
 }

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -36,6 +36,9 @@ RRDHOST *rrdhost_find_by_node_id(const char *node_id) {
 }
 
 RRDHOST *rrdhost_find_by_hostname(const char *hostname) {
+    if(unlikely(!hostname))
+        return NULL;
+
     if(strcmp(hostname, "localhost") == 0)
         return localhost;
 

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -174,7 +174,7 @@ static void finalize_and_free_stmt_list(struct stmt_pool_s *stmt_list)
     if (!stmt_list)
         return;
 
-    int max_keys = stmt_list->count;
+    int max_keys = MIN(stmt_list->count, MAX_PREPARED_THREAD_STATEMENTS);
     for (int i = 0; i < max_keys; i++) {
         if (!stmt_list->stmt[i])
             continue;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens DB engine cache sizing and journal v2 indexing, and fixes edge cases in hostname lookup, journal sampling, and SQLite cleanup. Prevents overflows, crashes, and invalid memory accesses.

- **Bug Fixes**
  - DBEngine cache: overflow-checked page size accounting and centralized overhead math; fail fast on invalid sizes.
  - Journal v2 index: use JudyLFirstEmpty() to pick a bounded empty key; validate timestamps and store the exact inserted key.
  - Journal migration: keep the page pinned until the hot lock is re-acquired to avoid skipping or mis-traversing pages.
  - systemd-journal plugin: widen estimated counters from uint32_t to size_t to avoid wrap on large result sets.
  - Host lookup: return NULL on NULL hostname in rrdhost_find_by_hostname() instead of calling strcmp().
  - SQLite: cap statement-pool finalizer loop to MIN(count, `MAX_PREPARED_THREAD_STATEMENTS`) to avoid out-of-bounds access.

<sup>Written for commit ac20d99bab429c9f97608f38ad650bc4b29dd84b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

