### PR TITLE
Netdata fixes part 30

### DIFF
--- a/src/aclk/aclk_otp.c
+++ b/src/aclk/aclk_otp.c
@@ -428,16 +428,16 @@ static int private_decrypt(RSA *p_key, unsigned char * enc_data, int data_len, u
     size_t outlen = EVP_PKEY_size(p_key);
     EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(p_key, NULL);
     if (!ctx)
-        return 1;
+        return -1;
 
     if (EVP_PKEY_decrypt_init(ctx) <= 0) {
         EVP_PKEY_CTX_free(ctx);
-        return 1;
+        return -1;
     }
 
     if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0) {
         EVP_PKEY_CTX_free(ctx);
-        return 1;
+        return -1;
     }
 
     *decrypted = mallocz(outlen);

--- a/src/aclk/aclk_rx_msgs.c
+++ b/src/aclk/aclk_rx_msgs.c
@@ -347,7 +347,7 @@ int send_alarm_configuration(const char *msg, size_t msg_len)
 int send_alarm_snapshot(const char *msg, size_t msg_len)
 {
     struct send_alarm_snapshot *sas = parse_send_alarm_snapshot(msg, msg_len);
-    if (!sas->node_id || !sas->claim_id || !sas->snapshot_uuid) {
+    if (!sas || !sas->node_id || !sas->claim_id || !sas->snapshot_uuid) {
         netdata_log_error("Error parsing SendAlarmSnapshot");
         destroy_send_alarm_snapshot(sas);
         return 1;
@@ -355,6 +355,8 @@ int send_alarm_snapshot(const char *msg, size_t msg_len)
     aclk_query_t *query = aclk_query_new(ALERT_CHECKPOINT);
     query->data.node_id = sas->node_id;     // Will be freed on query free
     query->claim_id = sas->claim_id;        // Will be freed on query free
+    sas->node_id = NULL;
+    sas->claim_id = NULL;
     query->version = 0; // force snapshot
     aclk_add_job(query);
     destroy_send_alarm_snapshot(sas);

--- a/src/aclk/https_client.c
+++ b/src/aclk/https_client.c
@@ -252,7 +252,7 @@ static int parse_http_hdr(rbuf_t buf, http_parse_ctx *parse_ctx)
     }
 
     char *separator = rbuf_find_bytes(buf, HTTP_KEYVAL_SEPARATOR, strlen(HTTP_KEYVAL_SEPARATOR), &idx);
-    if (!separator) {
+    if (!separator || idx >= idx_end) {
         netdata_log_error("ACLK: Missing Key/Value separator");
         return 1;
     }

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -642,6 +642,11 @@ int ws_client_process_rx_ws(ws_client *client)
             client->rx.parse_state = WS_PACKET_DONE;
             return WS_CLIENT_PARSING_DONE;
         case WS_PAYLOAD_PING_REQ_PAYLOAD:
+            if (client->rx.payload_length > 125) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: WebSocket PING payload too big! Received %"PRIu64" bytes, maximum allowed 125 bytes",
+                       client->rx.payload_length);
+                return WS_CLIENT_PROTOCOL_ERROR;
+            }
             if (client->rx.payload_length > rbuf_get_capacity(client->buf_read) / 2) {
                 nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: Ping payload too big! Received %"PRIu64" bytes, maximum allowed %zu bytes (buffer capacity: %zu bytes)",
                        client->rx.payload_length, rbuf_get_capacity(client->buf_read) / 2, rbuf_get_capacity(client->buf_read));

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -579,6 +579,11 @@ int ws_client_process_rx_ws(ws_client *client)
             // a) empty payload
             // b) 2byte reason code
             // c) 2byte reason code followed by message
+            if (client->rx.payload_length > 125) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: WebSocket CONNECTION_CLOSE payload too big! Received %"PRIu64" bytes, maximum allowed 125 bytes",
+                       client->rx.payload_length);
+                return WS_CLIENT_PROTOCOL_ERROR;
+            }
             if (client->rx.payload_length == 1) {
                 nd_log(NDLS_DAEMON, NDLP_ERR, "ACLK: WebScoket CONNECTION_CLOSE can't have payload of size 1");
                 return WS_CLIENT_PROTOCOL_ERROR;

--- a/src/aclk/schema-wrappers/alarm_config.cc
+++ b/src/aclk/schema-wrappers/alarm_config.cc
@@ -122,8 +122,10 @@ char *generate_provide_alarm_configuration(size_t *len, struct provide_alarm_con
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);
     char *bin = (char*)mallocz(*len);
-    if (!msg.SerializeToArray(bin, *len))
+    if (!msg.SerializeToArray(bin, *len)) {
+        freez(bin);
         return NULL;
+    }
 
     return bin;
 }

--- a/src/aclk/schema-wrappers/alarm_stream.cc
+++ b/src/aclk/schema-wrappers/alarm_stream.cc
@@ -218,6 +218,7 @@ char *generate_alarm_snapshot_bin(size_t *len, alarm_snapshot_proto_ptr_t snapsh
     *len = PROTO_COMPAT_MSG_SIZE_PTR(alarm_snapshot);
     char *bin = (char*)mallocz(*len);
     if (!alarm_snapshot->SerializeToArray(bin, *len)) {
+        freez(bin);
         delete alarm_snapshot;
         return NULL;
     }

--- a/src/aclk/schema-wrappers/alarm_stream.cc
+++ b/src/aclk/schema-wrappers/alarm_stream.cc
@@ -176,6 +176,11 @@ struct send_alarm_snapshot *parse_send_alarm_snapshot(const char *data, size_t l
 
 void destroy_send_alarm_snapshot(struct send_alarm_snapshot *ptr)
 {
+    if (!ptr)
+        return;
+
+    freez(ptr->node_id);
+    freez(ptr->claim_id);
     freez(ptr->snapshot_uuid);
     freez(ptr);
 }

--- a/src/aclk/schema-wrappers/connection.cc
+++ b/src/aclk/schema-wrappers/connection.cc
@@ -15,7 +15,8 @@ char *generate_update_agent_connection(size_t *len, const update_agent_connectio
 {
     UpdateAgentConnection connupd;
 
-    connupd.set_claim_id(data->claim_id);
+    if (data->claim_id)
+        connupd.set_claim_id(data->claim_id);
     connupd.set_reachable(data->reachable);
     connupd.set_session_id(data->session_id);
 

--- a/src/aclk/schema-wrappers/node_creation.cc
+++ b/src/aclk/schema-wrappers/node_creation.cc
@@ -13,8 +13,10 @@ char *generate_node_instance_creation(size_t *len, const node_instance_creation_
 
     if (data->claim_id)
         msg.set_claim_id(data->claim_id);
-    msg.set_machine_guid(data->machine_guid);
-    msg.set_hostname(data->hostname);
+    if (data->machine_guid)
+        msg.set_machine_guid(data->machine_guid);
+    if (data->hostname)
+        msg.set_hostname(data->hostname);
     msg.set_hops(data->hops);
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);

--- a/src/aclk/schema-wrappers/node_info.cc
+++ b/src/aclk/schema-wrappers/node_info.cc
@@ -71,14 +71,17 @@ char *generate_update_node_info_message(size_t *len, struct update_node_info *in
 {
     nodeinstance::info::v1::UpdateNodeInfo msg;
 
-    msg.set_node_id(info->node_id);
-    msg.set_claim_id(info->claim_id);
+    if (info->node_id)
+        msg.set_node_id(info->node_id);
+    if (info->claim_id)
+        msg.set_claim_id(info->claim_id);
 
     if (generate_node_info(msg.mutable_data(), &info->data))
         return NULL;
 
     set_google_timestamp_from_timeval(info->updated_at, msg.mutable_updated_at());
-    msg.set_machine_guid(info->machine_guid);
+    if (info->machine_guid)
+        msg.set_machine_guid(info->machine_guid);
     msg.set_child(info->child);
 
     nodeinstance::info::v1::MachineLearningInfo *ml_info = msg.mutable_ml_info();
@@ -115,15 +118,19 @@ char *generate_update_node_collectors_message(size_t *len, struct update_node_co
 {
     nodeinstance::info::v1::UpdateNodeCollectors msg;
 
-    msg.set_node_id(upd_node_collectors->node_id);
-    msg.set_claim_id(upd_node_collectors->claim_id);
+    if (upd_node_collectors->node_id)
+        msg.set_node_id(upd_node_collectors->node_id);
+    if (upd_node_collectors->claim_id)
+        msg.set_claim_id(upd_node_collectors->claim_id);
 
     void *colls;
     dfe_start_read(upd_node_collectors->node_collectors, colls) {
         struct collector_info *c =(struct collector_info *)colls;
         nodeinstance::info::v1::CollectorInfo *col = msg.add_collectors();
-        col->set_plugin(c->plugin);
-        col->set_module(c->module);
+        if (c->plugin)
+            col->set_plugin(c->plugin);
+        if (c->module)
+            col->set_module(c->module);
     }
     dfe_done(colls);
 

--- a/src/exporting/exporting_engine.c
+++ b/src/exporting/exporting_engine.c
@@ -6,7 +6,7 @@ static struct engine *engine = NULL;
 
 void analytics_exporting_connectors_ssl(BUFFER *b)
 {
-    if (netdata_ssl_exporting_ctx) {
+    if (netdata_ssl_exporting_ctx && engine) {
         for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
             struct simple_connector_data *connector_specific_data = instance->connector_specific_data;
             if (SSL_connection(&connector_specific_data->ssl)) {
@@ -111,6 +111,7 @@ static void exporting_clean_engine()
 
     freez((void *)engine->config.hostname);
     freez(engine);
+    engine = NULL;
 }
 
 /**

--- a/src/web/mcp/bridges/stdio-golang/nd-mcp.go
+++ b/src/web/mcp/bridges/stdio-golang/nd-mcp.go
@@ -371,7 +371,6 @@ func main() {
 
 		// Set up connection timeout
 		connectionCtx, connectionCancel := context.WithTimeout(ctx, 15*time.Second)
-		defer connectionCancel()
 
 		fmt.Fprintf(os.Stderr, "%s: Connecting to %s...\n", programName, targetURL)
 
@@ -388,6 +387,7 @@ func main() {
 			CompressionMode: websocket.CompressionContextTakeover,
 			HTTPHeader:      header,
 		})
+		connectionCancel()
 
 		// Connection failed
 		if err != nil {

--- a/src/web/mcp/mcp-tools-execute-function.c
+++ b/src/web/mcp/mcp-tools-execute-function.c
@@ -1193,8 +1193,12 @@ static void mcp_process_table_result(MCP_FUNCTION_DATA *data, size_t max_size_th
     // Copy rows for filtering/sorting, applying filters if specified
     for (size_t i = 0; i < row_count; i++) {
         struct json_object *row = json_object_array_get_idx(data_obj, i);
-        if (!row)
-            continue;
+        if (!json_object_is_type(row, json_type_array)) {
+            data->output.status = MCP_TABLE_NOT_PROCESSABLE;
+            buffer_strcat(data->output.result, json_str);
+            freez((void *)rows);
+            return;
+        }
 
         bool include_row = true;
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens ACLK networking and MCP tooling against malformed inputs, fixes memory-safety issues, and improves resource cleanup. Prevents crashes, overflows, and leaks across HTTPS, WebSocket, protobuf, and exporting paths.

- **Bug Fixes**
  - Network protocol hardening: reject header separators after CRLF in HTTPS parsing; bound WebSocket `CONNECTION_CLOSE` and `PING` payloads to 125 bytes; return -1 on OpenSSL OTP decrypt setup failures.
  - Memory safety and ownership: free serialization buffers on failure and guard NULL strings in protobuf wrappers; handle NULL and transfer ownership safely in alarm snapshot parsing; require exporting engine before iterating and nullify it on cleanup; cancel per-attempt dial timeout in the Go MCP bridge.
  - MCP robustness: require table rows to be JSON arrays and fall back to NOT_PROCESSABLE with raw output on malformed rows.

<sup>Written for commit 0f1a9c348bb45869029b34459d1d6f91c24ce9be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

