### PR TITLE
Netdata fixes part 31

### DIFF
--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -173,24 +173,38 @@ static int netdata_claim_prepare_strings()
 
 static void netdata_claim_exit_callback(int signal)
 {
-    (void)signal;
-    if (aToken)
+    if (aToken) {
         free(aToken);
+        aToken = NULL;
+    }
 
-    if (aRoom)
+    if (aRoom) {
         free(aRoom);
+        aRoom = NULL;
+    }
 
-    if (aProxy)
+    if (aProxy) {
         free(aProxy);
+        aProxy = NULL;
+    }
 
-    if (aURL)
+    if (aURL) {
         free(aURL);
+        aURL = NULL;
+    }
 
-    if (argv)
+    if (argv) {
         LocalFree(argv);
+        argv = NULL;
+        token = NULL;
+        room = NULL;
+        proxy = NULL;
+        url = NULL;
+        extPath = NULL;
+    }
 
-    if (extPath)
-        LocalFree(extPath);
+    if (signal)
+        ExitProcess((UINT)signal);
 }
 
 static inline int netdata_claim_prepare_data(char *out, size_t length)
@@ -279,7 +293,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     signal(SIGTERM, netdata_claim_exit_callback);
 
     int argc;
-    LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    argv = CommandLineToArgvW(GetCommandLineW(), &argc);
     if (argc)
         argc = nd_claim_parse_args(argc, argv);
 

--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -292,8 +292,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     signal(SIGINT, netdata_claim_exit_callback);
     signal(SIGTERM, netdata_claim_exit_callback);
 
-    int argc;
+    int argc = 0;
     argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (!argv)
+        netdata_claim_error_exit(L"CommandLineToArgvW");
+
     if (argc)
         argc = nd_claim_parse_args(argc, argv);
 

--- a/src/collectors/apps.plugin/apps_os_windows.c
+++ b/src/collectors/apps.plugin/apps_os_windows.c
@@ -605,19 +605,23 @@ static void GetServiceNames(void) {
         CloseServiceHandle(hSCManager);
         return;
     }
+    DWORD dwAllocatedBytes = dwBytesNeeded;
 
     // Allocate memory to hold the services
-    pServiceStatus = mallocz(dwBytesNeeded);
+    pServiceStatus = mallocz(dwAllocatedBytes);
 
     // Now, retrieve the list of services
     if (!EnumServicesStatusEx(
             hSCManager, SC_ENUM_PROCESS_INFO, SERVICE_WIN32, SERVICE_STATE_ALL,
-            (LPBYTE)pServiceStatus, dwBytesNeeded, &dwBytesNeeded, &dwServicesReturned,
+            (LPBYTE)pServiceStatus, dwAllocatedBytes, &dwBytesNeeded, &dwServicesReturned,
             &dwResumeHandle, NULL)) {
         freez(pServiceStatus);
         CloseServiceHandle(hSCManager);
         return;
     }
+    DWORD dwServicesCapacity = (DWORD)(dwAllocatedBytes / sizeof(*pServiceStatus));
+    if (dwServicesReturned > dwServicesCapacity)
+        dwServicesReturned = dwServicesCapacity;
 
     // Loop through the services
     for (DWORD i = 0; i < dwServicesReturned; i++) {

--- a/src/collectors/windows-events.plugin/windows-events-unicode.c
+++ b/src/collectors/windows-events.plugin/windows-events-unicode.c
@@ -3,16 +3,26 @@
 #include "windows-events-unicode.h"
 
 inline void utf82unicode(wchar_t *dst, size_t dst_size, const char *src) {
+    if (unlikely(!dst || !dst_size))
+        return;
+
     if (src) {
         // Convert from UTF-8 to wide char (UTF-16)
-        if (utf8_to_utf16(dst, dst_size, src, -1) == 0)
+        if (utf8_to_utf16(dst, dst_size, src, -1) == 0) {
             wcsncpy(dst, L"[failed conv.]", dst_size - 1);
+            dst[dst_size - 1] = L'\0';
+        }
     }
-    else
+    else {
         wcsncpy(dst, L"[null]", dst_size - 1);
+        dst[dst_size - 1] = L'\0';
+    }
 }
 
 inline void unicode2utf8(char *dst, size_t dst_size, const wchar_t *src) {
+    if (unlikely(!dst || !dst_size))
+        return;
+
     if (src) {
         if(WideCharToMultiByte(CP_UTF8, 0, src, -1, dst, (int)dst_size, NULL, NULL) == 0)
             strncpyz(dst, "[failed conv.]", dst_size - 1);

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -93,8 +93,8 @@ void cancel_main_threads(void) {
     }
     netdata_log_info("All threads finished.");
 
-    freez(static_threads);
-    static_threads = NULL;
+    // Static threads receive pointers into this array and may still run cleanup
+    // handlers after cancellation. Keep it alive until process exit.
 }
 
 #ifdef ENABLE_DBENGINE

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -91,7 +91,9 @@ void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused)
                 len = strcatz(b, len, ")", sizeof(b));
             }
             len = strcatz(b, len, " in thread ", sizeof(b));
-            len += print_uint64(&b[len], gettid_cached());
+            char tid[UINT64_MAX_LENGTH];
+            print_uint64(tid, gettid_cached());
+            len = strcatz(b, len, tid, sizeof(b));
             len = strcatz(b, len, " ", sizeof(b));
             len = strcatz(b, len, nd_thread_tag_async_safe(), sizeof(b));
             len = strcatz(b, len, "!\n", sizeof(b));

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -1499,7 +1499,9 @@ bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE c
         len = strcatz(session_status.fatal.function, len, session_status.fatal.thread, sizeof(session_status.fatal.function));
         if(session_status.fatal.worker_job_id <= WORKER_UTILIZATION_MAX_JOB_TYPES) {
             len = strcatz(session_status.fatal.function, len, ":", sizeof(session_status.fatal.function));
-            len += print_uint64(&session_status.fatal.function[len], session_status.fatal.worker_job_id);
+            char worker_job_id[UINT64_MAX_LENGTH];
+            print_uint64(worker_job_id, session_status.fatal.worker_job_id);
+            len = strcatz(session_status.fatal.function, len, worker_job_id, sizeof(session_status.fatal.function));
         }
     }
 

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -63,7 +63,12 @@ static usec_t get_clock_resolution(clockid_t clock) {
         if(!ret && ts.tv_nsec > 0 && ts.tv_nsec < (long int)NSEC_PER_USEC)
             return (usec_t)1;
 
-        else if(!ret || ret > MAX_CLOCK_RESOLUTION_UT) {
+        else if(!ret) {
+            nd_log(NDLS_DAEMON, NDLP_ERR, "clock_getres(%d) returned zero usec resolution, using defaults for clock resolution.", (int)clock);
+            return DEFAULT_CLOCK_RESOLUTION_UT;
+        }
+
+        else if(ret > MAX_CLOCK_RESOLUTION_UT) {
             nd_log(NDLS_DAEMON, NDLP_ERR, "clock_getres(%d) returned %"PRIu64" usec is out of range, using defaults for clock resolution.", (int)clock, ret);
             return DEFAULT_CLOCK_RESOLUTION_UT;
         }

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -63,7 +63,7 @@ static usec_t get_clock_resolution(clockid_t clock) {
         if(!ret && ts.tv_nsec > 0 && ts.tv_nsec < (long int)NSEC_PER_USEC)
             return (usec_t)1;
 
-        else if(ret > MAX_CLOCK_RESOLUTION_UT) {
+        else if(!ret || ret > MAX_CLOCK_RESOLUTION_UT) {
             nd_log(NDLS_DAEMON, NDLP_ERR, "clock_getres(%d) returned %"PRIu64" usec is out of range, using defaults for clock resolution.", (int)clock, ret);
             return DEFAULT_CLOCK_RESOLUTION_UT;
         }

--- a/src/libnetdata/locks/waitq.c
+++ b/src/libnetdata/locks/waitq.c
@@ -100,6 +100,11 @@ ALWAYS_INLINE void waitq_acquire_with_trace(WAITQ *waitq, WAITQ_PRIORITY priorit
                 worker_spinlock_contention(func, spins);
                 return;
             }
+
+            spins++;
+            if ((spins % SPINS_BEFORE_DEADLOCK_CHECK) == 0)
+                spinlock_deadlock_detect(&deadlock_timestamp, "waitq", func);
+
             yield_the_processor();
         }
 

--- a/src/libnetdata/log/nd_log-init.c
+++ b/src/libnetdata/log/nd_log-init.c
@@ -311,8 +311,8 @@ int nd_log_systemd_journal_fd(void) {
 }
 
 void nd_log_reopen_log_files_for_spawn_server(const char *name) {
-    nd_log.fatal_hook_cb = NULL;
-    nd_log.fatal_final_cb = NULL;
+    __atomic_store_n(&nd_log.fatal_hook_cb, (log_event_t)NULL, __ATOMIC_RELEASE);
+    __atomic_store_n(&nd_log.fatal_final_cb, (fatal_event_t)NULL, __ATOMIC_RELEASE);
     nd_log.single_threaded_child = true;
 
     gettid_uncached();

--- a/src/libnetdata/log/nd_log.c
+++ b/src/libnetdata/log/nd_log.c
@@ -150,7 +150,8 @@ static void nd_log_fatal_hook(struct log_field *fields, size_t fields_max __mayb
 
     nd_log_fatal_event = false;
 
-    if(!nd_log.fatal_hook_cb)
+    log_event_t fatal_hook_cb = __atomic_load_n(&nd_log.fatal_hook_cb, __ATOMIC_ACQUIRE);
+    if(!fatal_hook_cb)
         return;
 
     const char *filename = log_field_strdupz(&fields[NDF_FILE]);
@@ -160,17 +161,17 @@ static void nd_log_fatal_hook(struct log_field *fields, size_t fields_max __mayb
     const char *errno_str = log_field_strdupz(&fields[NDF_ERRNO]);
     long line = log_field_to_int64(&fields[NDF_LINE]);
 
-    nd_log.fatal_hook_cb(filename, function, message, errno_str, stack_trace, line);
+    fatal_hook_cb(filename, function, message, errno_str, stack_trace, line);
 }
 
 void nd_log_register_fatal_hook_cb(log_event_t cb) {
-    nd_log.fatal_hook_cb = cb;
+    __atomic_store_n(&nd_log.fatal_hook_cb, cb, __ATOMIC_RELEASE);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
 
 void nd_log_register_fatal_final_cb(fatal_event_t cb) {
-    nd_log.fatal_final_cb = cb;
+    __atomic_store_n(&nd_log.fatal_final_cb, cb, __ATOMIC_RELEASE);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -585,8 +586,9 @@ void netdata_logger_fatal(const char *file, const char *function, const unsigned
     fatal_abort_internal_checks();
 #endif
 
-    if(nd_log.fatal_final_cb)
-        nd_log.fatal_final_cb();
+    fatal_event_t fatal_final_cb = __atomic_load_n(&nd_log.fatal_final_cb, __ATOMIC_ACQUIRE);
+    if(fatal_final_cb)
+        fatal_final_cb();
 
     exit(1);
 }

--- a/src/libnetdata/memory/nd-mallocz.c
+++ b/src/libnetdata/memory/nd-mallocz.c
@@ -7,10 +7,22 @@ void mallocz_register_out_of_memory_cb(out_of_memory_cb cb) {
     out_of_memory_callback = cb;
 }
 
+static __thread bool out_of_memory_running = false;
 
 ALWAYS_INLINE NORETURN
 void out_of_memory(const char *call, size_t size, const char *details) {
     int errno_saved = errno;
+
+    if(unlikely(out_of_memory_running)) {
+        errno = errno_saved;
+        fatal("Out of memory on %s(%zu bytes) while already handling out-of-memory.\n"
+              "Additional details: %s",
+              call, size,
+              details ? details : "none");
+    }
+
+    out_of_memory_running = true;
+
     exit_initiated_add(EXIT_REASON_OUT_OF_MEMORY);
 
     if(out_of_memory_callback)

--- a/src/libnetdata/os/dir_size.c
+++ b/src/libnetdata/os/dir_size.c
@@ -56,8 +56,8 @@ static void calc_dir_size_recursive(const char *base_path, const char *rel_path,
     };
 
     // Use string representation as the dictionary name
-    char name[sizeof(INODE_DEVICE_PAIR) * 2 + 1];
-    snprintfz(name, sizeof(name), "%lu_%lu", (unsigned long)id_pair.inode, (unsigned long)id_pair.device);
+    char name[UINT64_MAX_LENGTH * 2 + 1];
+    snprintfz(name, sizeof(name), "%" PRIu64 "_%" PRIu64, (uint64_t)id_pair.inode, (uint64_t)id_pair.device);
 
     // Check if we've seen this inode-device pair before (for symlink loop detection)
     if (dictionary_get(visited_inodes, name))

--- a/src/libnetdata/os/get_system_cpus.c
+++ b/src/libnetdata/os/get_system_cpus.c
@@ -130,6 +130,9 @@ size_t os_read_cpuset_cpus(const char *filename, size_t system_cpus) {
             if(*s == '-') {
                 s++;
                 unsigned long m = cpuset_str2ul(&s);
+                if(unlikely(m < n))
+                    return 0;
+
                 ncpus += m - n; // calculate the number of cpus in the region
             }
             s++;

--- a/src/libnetdata/os/hostname.c
+++ b/src/libnetdata/os/hostname.c
@@ -145,7 +145,7 @@ bool os_hostname(char *dst, size_t dst_size, const char *filesystem_root) {
 
 #ifdef HAVE_LIBICONV
     const char *locale = get_current_locale();
-    if (locale && *locale) {
+    if (original_hostname && locale && *locale) {
         char utf8_output[HOST_NAME_MAX * 4 + 1] = "";
         if(iconv_convert_to_utf8(original_hostname, get_encoding_from_locale(locale), utf8_output, sizeof(utf8_output))) {
             rrdlabels_sanitize_value(dst, trim(utf8_output), dst_size);

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -5,7 +5,7 @@
 #if defined(OS_WINDOWS)
 long netdata_registry_get_dword_from_open_key(unsigned int *out, void *lKey, char *name)
 {
-    DWORD length = 260;
+    DWORD length = sizeof(*out);
     return RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) out, &length);
 }
 

--- a/src/libnetdata/os/windows-api/windows_api.c
+++ b/src/libnetdata/os/windows-api/windows_api.c
@@ -49,10 +49,21 @@ int netdata_fill_default_ip()
     PIP_ADAPTER_ADDRESSES aa = adapters;
     while (aa) {
         if (aa->IfIndex == ifIndex) {
-            char iface[1024];
-            size_t required_size = wcstombs(NULL , aa->FriendlyName, 0) + 1;
-            wcstombs(iface, aa->FriendlyName, required_size);
-            default_ip.local_iface = strdup(iface);
+            if (aa->FriendlyName) {
+                size_t required_size = wcstombs(NULL, aa->FriendlyName, 0);
+                if (required_size != (size_t)-1) {
+                    char *iface = malloc(required_size + 1);
+                    if (iface) {
+                        size_t converted = wcstombs(iface, aa->FriendlyName, required_size + 1);
+                        if (converted != (size_t)-1 && converted <= required_size) {
+                            iface[converted] = '\0';
+                            default_ip.local_iface = iface;
+                        }
+                        else
+                            free(iface);
+                    }
+                }
+            }
 
             PIP_ADAPTER_UNICAST_ADDRESS ua = aa->FirstUnicastAddress;
             while (ua) {

--- a/src/libnetdata/procfile/procfile.c
+++ b/src/libnetdata/procfile/procfile.c
@@ -103,7 +103,7 @@ static inline void procfile_words_free(pfwords *fw) {
 // An array of lines
 
 NEVERNULL
-static inline uint32_t *procfile_lines_add(procfile *ff) {
+static inline size_t *procfile_lines_add(procfile *ff) {
     // netdata_log_debug(D_PROCFILE, PF_PREFIX ":   adding line %d at word %d", fl->len, first_word);
 
     pflines *fl = ff->lines;
@@ -181,7 +181,7 @@ static void procfile_parser(procfile *ff) {
     char quote = 0;                     // the quote character - only when in quoted string
     size_t opened = 0;                  // counts the number of open parenthesis
 
-    uint32_t *line_words = procfile_lines_add(ff);
+    size_t *line_words = procfile_lines_add(ff);
 
     while(s < e) {
         PF_CHAR_TYPE ct = separators[(unsigned char)(*s)];

--- a/src/libnetdata/procfile/procfile.h
+++ b/src/libnetdata/procfile/procfile.h
@@ -19,8 +19,8 @@ typedef struct {
 // An array of lines
 
 typedef struct {
-    uint32_t words; // how many words this line has
-    uint32_t first; // the id of the first word of this line in the words array
+    size_t words;   // how many words this line has
+    size_t first;   // the id of the first word of this line in the words array
 } ffline;
 
 typedef struct {

--- a/src/libnetdata/spawn_server/spawn_server_windows.c
+++ b/src/libnetdata/spawn_server/spawn_server_windows.c
@@ -58,12 +58,17 @@ void spawn_server_destroy(SPAWN_SERVER *server) {
 }
 
 static BUFFER *argv_to_windows(const char **argv) {
-    BUFFER *wb = buffer_create(0, NULL);
-
     // argv[0] is the path
-    size_t b_size = strlen(argv[0]) * 2 + FILENAME_MAX;
+    ssize_t converted_size = cygwin_conv_path(CCP_POSIX_TO_WIN_A | CCP_ABSOLUTE, argv[0], NULL, 0);
+    if(converted_size <= 0)
+        return NULL;
+
+    size_t b_size = (size_t)converted_size;
     CLEAN_CHAR_P *b = mallocz(b_size);
-    cygwin_conv_path(CCP_POSIX_TO_WIN_A | CCP_ABSOLUTE, argv[0], b, b_size);
+    if(cygwin_conv_path(CCP_POSIX_TO_WIN_A | CCP_ABSOLUTE, argv[0], b, b_size) != 0)
+        return NULL;
+
+    BUFFER *wb = buffer_create(0, NULL);
 
     for(size_t i = 0; argv[i] ;i++) {
         const char *s = (i == 0) ? b : argv[i];
@@ -161,6 +166,13 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_un
     instance->request_id = __atomic_add_fetch(&server->request_id, 1, __ATOMIC_RELAXED);
 
     CLEAN_BUFFER *wb = argv_to_windows(argv);
+    if(!wb) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN PARENT: Cannot convert command path for request No %zu, command: %s",
+               instance->request_id, argv[0]);
+        goto cleanup;
+    }
+
     char *command = (char *)buffer_tostring(wb);
 
     if (pipe(pipe_stdin) == -1) {

--- a/src/libnetdata/stacktrace/stacktrace-common.c
+++ b/src/libnetdata/stacktrace/stacktrace-common.c
@@ -41,13 +41,13 @@ const char *stacktrace_root_cause_function(void) {
 
 // Initialize the stacktrace cache
 void stacktrace_cache_init(void) {
-    if (cache_initialized)
+    if (likely(__atomic_load_n(&cache_initialized, __ATOMIC_ACQUIRE)))
         return;
 
     spinlock_lock(&stacktrace_lock);
-    if (!cache_initialized) {
+    if (unlikely(!__atomic_load_n(&cache_initialized, __ATOMIC_ACQUIRE))) {
         STACKTRACE_INIT(&stacktrace_cache);
-        cache_initialized = true;
+        __atomic_store_n(&cache_initialized, true, __ATOMIC_RELEASE);
     }
     spinlock_unlock(&stacktrace_lock);
 }


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Netdata on Windows and core paths by fixing memory-safety bugs, crash handling, and edge‑case parsing. Reliability improves without changing normal behavior.

- **Bug Fixes**
  - Windows: safe argv cleanup and error handling in the claim tool; cap service enumeration to the allocated buffer; bound `RegQueryValueEx` for DWORD reads; validate and fail fast on `cygwin_conv_path` conversion; guard Unicode helpers on zero-size buffers; allocate interface-name buffers from probed size.
  - Crash/diagnostics: make fatal callbacks atomic; publish stacktrace cache init atomically; append numeric fields safely in signal/status paths; prevent recursive OOM prelude reentry; add waitq deadlock checks in the contended loop; keep static thread descriptors alive through shutdown.
  - Parsing/OS: use size_t for procfile line metadata; avoid dir_size inode key truncation; reject reversed CPU ranges in cpuset parsing; treat zero clock resolutions as invalid and fall back to defaults.

<sup>Written for commit b6075e3a93ec3290a34d05be27a9eba6f014cbfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

