### PR TITLE
Netdata fixes part 32

### DIFF
--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1973,6 +1973,8 @@ static int rrdlabels_unittest_host_chart_labels() {
     errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=*name* _hostname=*", true);
     errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=*name* _os=l*", true);
     errors += rrdlabels_unittest_check_pattern_list(labels, "_os=l* _hostname=*name*", true);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "=_hostname", false);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=", true);
 
     rrdlabels_destroy(labels);
 

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -286,8 +286,14 @@ static inline int check_if_resumed_from_suspension(void) {
     // detect if monotonic and realtime have twice the difference
     // in which case we assume the system was just waken from hibernation
 
-    if(last_realtime && last_monotonic && realtime - last_realtime > 2 * (monotonic - last_monotonic))
-        ret = 1;
+    if(last_realtime && last_monotonic && realtime > last_realtime && monotonic >= last_monotonic) {
+        usec_t realtime_delta = realtime - last_realtime;
+        usec_t monotonic_delta = monotonic - last_monotonic;
+
+        // Equivalent to realtime_delta > 2 * monotonic_delta, without unsigned overflow.
+        if(realtime_delta > monotonic_delta && realtime_delta - monotonic_delta > monotonic_delta)
+            ret = 1;
+    }
 
     last_realtime = realtime;
     last_monotonic = monotonic;

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -354,12 +354,15 @@ static char *simple_pattern_trim_around_equal(const char *src) {
     char *dst = store;
     while (*src) {
         if (*src == '=') {
-            if (*(dst -1) == ' ')
+            if (dst > store && *(dst - 1) == ' ')
                 dst--;
 
             *dst++ = *src++;
             if (*src == ' ')
                 src++;
+
+            if (!*src)
+                break;
         }
 
         *dst++ = *src++;

--- a/src/libnetdata/facets/facets.c
+++ b/src/libnetdata/facets/facets.c
@@ -2246,6 +2246,10 @@ static inline void facets_reset_key(FACET_KEY *k) {
     k->key_values_selected_in_row = 0;
     k->current_value.flags = FACET_KEY_VALUE_NONE;
     k->current_value.hash = FACETS_HASH_ZERO;
+    k->current_value.raw = NULL;
+    k->current_value.raw_len = 0;
+    k->current_value.b->len = 0;
+    k->current_value.v = NULL;
 }
 
 static void facets_reset_keys_with_value_and_row(FACETS *facets) {

--- a/src/libnetdata/facets/facets.c
+++ b/src/libnetdata/facets/facets.c
@@ -55,6 +55,12 @@ static inline void facets_hash_to_str(FACETS_HASH num, char *out) {
 }
 
 static inline FACETS_HASH str_to_facets_hash(const char *str) {
+    if(unlikely(!str))
+        return FACETS_HASH_ZERO;
+
+    if(unlikely(strnlen(str, FACET_STRING_HASH_SIZE) != FACET_STRING_HASH_SIZE - 1))
+        return FACETS_HASH_ZERO;
+
     FACETS_HASH num = 0;
     int shifts = 6 * (FACET_STRING_HASH_SIZE - 2);
 

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -308,7 +308,7 @@ static inline PARSER_RC pluginsd_host(char **words, size_t num_words, PARSER *pa
                 min_check_interval = MIN(min_check_interval, stale_after_seconds);
                 if (rrdhost_option_check(virtual_host, RRDHOST_OPTION_VIRTUAL_HOST)) {
                     time_t last_seen = (*Pvalue + VNODE_BASE_EPOCH);
-                    uint32_t seen_seconds_ago = (uint32_t) (now - last_seen);
+                    uint32_t seen_seconds_ago = (now > last_seen) ? (uint32_t)(now - last_seen) : 0;
 
                     if (seen_seconds_ago >= stale_after_seconds) {
                         rrdhost_option_clear(virtual_host, RRDHOST_OPTION_VIRTUAL_HOST);

--- a/src/registry/registry_internals.c
+++ b/src/registry/registry_internals.c
@@ -47,13 +47,12 @@ static inline char *registry_fix_machine_name(char *name, size_t *len) {
     }
 
     // remove trailing spaces
-    while(--t >= s) {
-        if(*t == ' ')
-            *t = '\0';
+    while(t > s) {
+        if(t[-1] == ' ')
+            *--t = '\0';
         else
             break;
     }
-    t++;
 
     if(likely(len))
         *len = (t - s);


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes edge cases in time and string handling to prevent false hibernation/stale states and remove undefined behavior across health, pluginsd, facets, registry, and label parsing. Adds label matcher tests for '=' edge cases.

- **Bug Fixes**
  - Health: compute deltas only when clocks move forward and compare without overflow to avoid false hibernation detection.
  - Pluginsd: clamp vnode age when `now <= last_seen` to prevent false stale transitions on clock rollback.
  - Facets: reject invalid facet hash strings and clear transient current-value fields on reset to avoid stale reads.
  - Registry: trim trailing spaces without forming a pointer before the string start.
  - Labels: guard pattern trimming around '=' and stop on terminal '='; add unit tests for empty-value and malformed '=' matchers.

<sup>Written for commit 5b682c674f6b8ee4ac1b1d928a2a1f2cc5db157c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

