### PR TITLE
Netdata fixes part 34

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -971,6 +971,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/circular_buffer/circular_buffer.h
         src/libnetdata/clocks/clocks.c
         src/libnetdata/clocks/clocks.h
+        src/libnetdata/clocks/clocks-internals.h
+        src/libnetdata/clocks/clocks-unittest.c
         src/libnetdata/completion/completion.c
         src/libnetdata/completion/completion.h
         src/libnetdata/datetime/iso8601.c

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -211,6 +211,7 @@ int help(int exitcode) {
 
 int buffer_unittest(void);
 int ringbuffer_unittest(void);
+int log_stack_unittest(void);
 int clocks_unittest(void);
 int ws_client_unittest(void);
 int mqtt_ng_unittest(void);
@@ -441,6 +442,7 @@ int netdata_main(int argc, char **argv) {
                             if (unit_test_str2ld()) return 1;
                             if (buffer_unittest()) return 1;
                             if (ringbuffer_unittest()) return 1;
+                            if (log_stack_unittest()) return 1;
                             if (clocks_unittest()) return 1;
                             if (ws_client_unittest()) return 1;
                             if (mqtt_ng_unittest()) return 1;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -211,6 +211,7 @@ int help(int exitcode) {
 
 int buffer_unittest(void);
 int ringbuffer_unittest(void);
+int clocks_unittest(void);
 int ws_client_unittest(void);
 int mqtt_ng_unittest(void);
 int pgc_unittest(void);
@@ -440,6 +441,7 @@ int netdata_main(int argc, char **argv) {
                             if (unit_test_str2ld()) return 1;
                             if (buffer_unittest()) return 1;
                             if (ringbuffer_unittest()) return 1;
+                            if (clocks_unittest()) return 1;
                             if (ws_client_unittest()) return 1;
                             if (mqtt_ng_unittest()) return 1;
 

--- a/src/libnetdata/clocks/clocks-internals.h
+++ b/src/libnetdata/clocks/clocks-internals.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_CLOCKS_INTERNALS_H
+#define NETDATA_CLOCKS_INTERNALS_H 1
+
+#include "clocks.h"
+
+static inline bool sleep_usec_prepare_retry_after_eintr(
+        usec_t usec,
+        usec_t started_monotonic_ut,
+        usec_t now_monotonic_ut,
+        struct timespec *req) {
+    usec_t elapsed_ut = now_monotonic_ut > started_monotonic_ut ? now_monotonic_ut - started_monotonic_ut : 0;
+    if(elapsed_ut >= usec)
+        return false;
+
+    usec_t remaining_ut = (usec_t)req->tv_sec * USEC_PER_SEC + (usec_t)req->tv_nsec / NSEC_PER_USEC;
+    usec_t check_ut = usec - elapsed_ut;
+    if(remaining_ut > check_ut) {
+        *req = (struct timespec) {
+            .tv_sec = (time_t)(check_ut / USEC_PER_SEC),
+            .tv_nsec = (long)((check_ut % USEC_PER_SEC) * NSEC_PER_USEC),
+        };
+    }
+
+    return true;
+}
+
+#endif /* NETDATA_CLOCKS_INTERNALS_H */

--- a/src/libnetdata/clocks/clocks-unittest.c
+++ b/src/libnetdata/clocks/clocks-unittest.c
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../libnetdata.h"
+#include "clocks-internals.h"
+
+#define CLOCKS_TEST(condition, msg) do {                                         \
+        if(!(condition)) {                                                       \
+            fprintf(stderr, "clocks unittest FAILED: %s (%s:%d)\n",             \
+                    (msg), __FUNCTION__, __LINE__);                              \
+            errors++;                                                            \
+        }                                                                        \
+    } while(0)
+
+static int clocks_retry_keeps_valid_remaining_time(void) {
+    int errors = 0;
+    struct timespec req = {
+        .tv_sec = 0,
+        .tv_nsec = 123 * NSEC_PER_MSEC,
+    };
+
+    bool retry = sleep_usec_prepare_retry_after_eintr(
+            1 * USEC_PER_SEC,
+            100 * USEC_PER_MS,
+            250 * USEC_PER_MS,
+            &req);
+
+    CLOCKS_TEST(retry, "retry continues while monotonic budget remains");
+    CLOCKS_TEST(req.tv_sec == 0, "valid remaining seconds are preserved");
+    CLOCKS_TEST(req.tv_nsec == (long)(123 * NSEC_PER_MSEC), "valid remaining nanoseconds are preserved");
+
+    return errors;
+}
+
+static int clocks_retry_clamps_inflated_remaining_time(void) {
+    int errors = 0;
+    struct timespec req = {
+        .tv_sec = 0,
+        .tv_nsec = 300 * NSEC_PER_MSEC,
+    };
+
+    bool retry = sleep_usec_prepare_retry_after_eintr(
+            200 * USEC_PER_MS,
+            1 * USEC_PER_SEC,
+            1 * USEC_PER_SEC + 150 * USEC_PER_MS,
+            &req);
+
+    CLOCKS_TEST(retry, "retry continues after clamp when budget remains");
+    CLOCKS_TEST(req.tv_sec == 0, "clamped seconds stay below one second");
+    CLOCKS_TEST(req.tv_nsec == (long)(50 * NSEC_PER_MSEC), "remaining time is clamped to monotonic budget");
+
+    return errors;
+}
+
+static int clocks_retry_stops_when_budget_is_exhausted(void) {
+    int errors = 0;
+    struct timespec req = {
+        .tv_sec = 0,
+        .tv_nsec = 100 * NSEC_PER_MSEC,
+    };
+
+    bool retry = sleep_usec_prepare_retry_after_eintr(
+            200 * USEC_PER_MS,
+            1 * USEC_PER_SEC,
+            1 * USEC_PER_SEC + 200 * USEC_PER_MS,
+            &req);
+
+    CLOCKS_TEST(!retry, "retry stops once monotonic budget is exhausted");
+
+    return errors;
+}
+
+static int clocks_retry_treats_backward_monotonic_sample_as_no_elapsed_time(void) {
+    int errors = 0;
+    struct timespec req = {
+        .tv_sec = 2,
+        .tv_nsec = 0,
+    };
+
+    bool retry = sleep_usec_prepare_retry_after_eintr(
+            1 * USEC_PER_SEC,
+            2 * USEC_PER_SEC,
+            1 * USEC_PER_SEC,
+            &req);
+
+    CLOCKS_TEST(retry, "retry continues when elapsed time is clamped to zero");
+    CLOCKS_TEST(req.tv_sec == 1, "backward monotonic sample clamps to full budget seconds");
+    CLOCKS_TEST(req.tv_nsec == 0, "backward monotonic sample clamps to full budget nanoseconds");
+
+    return errors;
+}
+
+int clocks_unittest(void) {
+    int errors = 0;
+
+    fprintf(stderr, "\nrunning clocks unittest\n");
+
+    errors += clocks_retry_keeps_valid_remaining_time();
+    errors += clocks_retry_clamps_inflated_remaining_time();
+    errors += clocks_retry_stops_when_budget_is_exhausted();
+    errors += clocks_retry_treats_backward_monotonic_sample_as_no_elapsed_time();
+
+    if(errors)
+        fprintf(stderr, "clocks unittest: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "clocks unittest: OK\n");
+
+    return errors;
+}

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -446,7 +446,7 @@ void sleep_usec_with_now(usec_t usec, usec_t started_ut __maybe_unused) {
     Sleep(sleep_ms);
 }
 #else
-void sleep_usec_with_now(usec_t usec, usec_t started_ut) {
+void sleep_usec_with_now(usec_t usec, usec_t started_ut __maybe_unused) {
     // we expect microseconds (1.000.000 per second)
     // but timespec is nanoseconds (1.000.000.000 per second)
     struct timespec rem = { 0, 0 }, req = {
@@ -457,10 +457,7 @@ void sleep_usec_with_now(usec_t usec, usec_t started_ut) {
     // make sure errno is not EINTR
     errno_clear();
 
-    if(!started_ut)
-        started_ut = now_realtime_usec();
-
-    usec_t end_ut = started_ut + usec;
+    usec_t started_monotonic_ut = now_monotonic_usec();
 
     while (nanosleep(&req, &rem) != 0) {
         if (likely(errno == EINTR && (rem.tv_sec || rem.tv_nsec))) {
@@ -470,12 +467,13 @@ void sleep_usec_with_now(usec_t usec, usec_t started_ut) {
             // break an infinite loop
             errno_clear();
 
-            usec_t now_ut = now_realtime_usec();
-            if(now_ut >= end_ut)
+            usec_t now_ut = now_monotonic_usec();
+            usec_t elapsed_ut = now_ut > started_monotonic_ut ? now_ut - started_monotonic_ut : 0;
+            if(elapsed_ut >= usec)
                 break;
 
-            usec_t remaining_ut = (usec_t)req.tv_sec * USEC_PER_SEC + (usec_t)req.tv_nsec * NSEC_PER_USEC > usec;
-            usec_t check_ut = now_ut - started_ut;
+            usec_t remaining_ut = (usec_t)req.tv_sec * USEC_PER_SEC + (usec_t)req.tv_nsec / NSEC_PER_USEC;
+            usec_t check_ut = usec - elapsed_ut;
             if(remaining_ut > check_ut) {
                 req = (struct timespec){
                     .tv_sec = (time_t) ( check_ut / USEC_PER_SEC),

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "../libnetdata.h"
+#include "clocks-internals.h"
 
 // defaults are for compatibility
 // call clocks_init() once, to optimize these default settings
@@ -472,18 +473,8 @@ void sleep_usec_with_now(usec_t usec, usec_t started_ut __maybe_unused) {
             errno_clear();
 
             usec_t now_ut = now_monotonic_usec();
-            usec_t elapsed_ut = now_ut > started_monotonic_ut ? now_ut - started_monotonic_ut : 0;
-            if(elapsed_ut >= usec)
+            if(!sleep_usec_prepare_retry_after_eintr(usec, started_monotonic_ut, now_ut, &req))
                 break;
-
-            usec_t remaining_ut = (usec_t)req.tv_sec * USEC_PER_SEC + (usec_t)req.tv_nsec / NSEC_PER_USEC;
-            usec_t check_ut = usec - elapsed_ut;
-            if(remaining_ut > check_ut) {
-                req = (struct timespec){
-                    .tv_sec = (time_t) ( check_ut / USEC_PER_SEC),
-                    .tv_nsec = (suseconds_t) ((check_ut % USEC_PER_SEC) * NSEC_PER_USEC)
-                };
-            }
         }
         else {
             netdata_log_error("Cannot nanosleep() for %"PRIu64" microseconds.", usec);

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -279,7 +279,9 @@ void heartbeat_statistics(usec_t *min_ptr, usec_t *max_ptr, usec_t *average_ptr,
     struct heartbeat_thread_statistics current[HEARTBEAT_ALIGNMENT_STATISTICS_SIZE];
     static struct heartbeat_thread_statistics old[HEARTBEAT_ALIGNMENT_STATISTICS_SIZE] = { 0 };
 
+    spinlock_lock(&heartbeat_alignment_spinlock);
     memcpy(current, heartbeat_alignment_values, sizeof(struct heartbeat_thread_statistics) * HEARTBEAT_ALIGNMENT_STATISTICS_SIZE);
+    spinlock_unlock(&heartbeat_alignment_spinlock);
 
     usec_t min = 0, max = 0, total = 0, average = 0;
     size_t i, count = 0;
@@ -362,10 +364,12 @@ inline void heartbeat_init(heartbeat_t *hb, usec_t step) {
     hb->randomness = heartbeat_randomness(hb->hash);
 
     if(hb->statistics_id < HEARTBEAT_ALIGNMENT_STATISTICS_SIZE) {
+        spinlock_lock(&heartbeat_alignment_spinlock);
         heartbeat_alignment_values[hb->statistics_id].dt = 0;
         heartbeat_alignment_values[hb->statistics_id].sequence = 0;
         heartbeat_alignment_values[hb->statistics_id].randomness = hb->randomness;
         heartbeat_alignment_values[hb->statistics_id].tid = os_gettid();
+        spinlock_unlock(&heartbeat_alignment_spinlock);
     }
 }
 
@@ -390,7 +394,6 @@ usec_t heartbeat_next(heartbeat_t *hb) {
     sleep_usec_with_now(next - now, now);
     spinlock_lock(&heartbeat_alignment_spinlock);
     now = now_realtime_usec();
-    spinlock_unlock(&heartbeat_alignment_spinlock);
 
     dt = now - hb->realtime;
 
@@ -398,6 +401,7 @@ usec_t heartbeat_next(heartbeat_t *hb) {
         heartbeat_alignment_values[hb->statistics_id].dt += now - next;
         heartbeat_alignment_values[hb->statistics_id].sequence++;
     }
+    spinlock_unlock(&heartbeat_alignment_spinlock);
 
     if(unlikely(now < next)) {
         errno_clear();

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -254,7 +254,7 @@ void sleep_to_absolute_time(usec_t usec) {
                                       req.tv_nsec);
                 }
             }
-            sleep_usec(usec);
+            break;
         }
     }
 }

--- a/src/libnetdata/log/nd_log-internals.c
+++ b/src/libnetdata/log/nd_log-internals.c
@@ -385,6 +385,7 @@ struct nd_log nd_log = {
 
 __thread struct log_stack_entry *thread_log_stack_base[THREAD_LOG_STACK_MAX];
 __thread size_t thread_log_stack_next = 0;
+static __thread size_t thread_log_stack_dropped = 0;
 __thread struct log_field thread_log_fields[_NDF_MAX] = {
     // THE ORDER HERE IS IRRELEVANT (but keep them sorted by their number)
 
@@ -732,6 +733,12 @@ void log_stack_pop(void *ptr) {
 
     struct log_stack_entry *lgs = *(struct log_stack_entry (*)[])ptr;
 
+    // Dropped frames unwind before older pushed frames; consume them before pointer matching.
+    if(unlikely(thread_log_stack_dropped)) {
+        thread_log_stack_dropped--;
+        return;
+    }
+
     if(unlikely(!thread_log_stack_next || lgs != thread_log_stack_base[thread_log_stack_next - 1])) {
         fatal("You cannot pop in the middle of the stack, or an item not in the stack");
         return;
@@ -741,9 +748,104 @@ void log_stack_pop(void *ptr) {
 }
 
 void log_stack_push(struct log_stack_entry *lgs) {
-    if(!lgs || thread_log_stack_next >= THREAD_LOG_STACK_MAX) return;
+    if(!lgs) return;
+
+    if(unlikely(thread_log_stack_next >= THREAD_LOG_STACK_MAX)) {
+        thread_log_stack_dropped++;
+        return;
+    }
+
     thread_log_stack_base[thread_log_stack_next++] = lgs;
 }
+
+#define LOG_STACK_TEST(condition, msg) do {                                      \
+        if(!(condition)) {                                                       \
+            fprintf(stderr, "log stack unittest FAILED: %s (%s:%d)\n",          \
+                    (msg), __FUNCTION__, __LINE__);                              \
+            errors++;                                                            \
+        }                                                                        \
+    } while(0)
+
+int log_stack_unittest(void) {
+    int errors = 0;
+
+    fprintf(stderr, "\nrunning log stack unittest\n");
+
+    struct log_stack_entry lgs[THREAD_LOG_STACK_MAX + 2][2];
+    for(size_t i = 0; i < THREAD_LOG_STACK_MAX + 2; i++) {
+        lgs[i][0] = ND_LOG_FIELD_TXT(NDF_MESSAGE, "log-stack-unittest");
+        lgs[i][1] = ND_LOG_FIELD_END();
+    }
+
+    memset(thread_log_stack_base, 0, sizeof(thread_log_stack_base));
+    thread_log_stack_next = 0;
+    thread_log_stack_dropped = 0;
+
+    for(size_t i = 0; i < THREAD_LOG_STACK_MAX; i++)
+        log_stack_push(lgs[i]);
+
+    LOG_STACK_TEST(thread_log_stack_next == THREAD_LOG_STACK_MAX, "stack fills to maximum depth");
+    LOG_STACK_TEST(thread_log_stack_dropped == 0, "no dropped pushes before overflow");
+
+    log_stack_push(lgs[THREAD_LOG_STACK_MAX]);
+    log_stack_push(lgs[THREAD_LOG_STACK_MAX + 1]);
+
+    LOG_STACK_TEST(thread_log_stack_next == THREAD_LOG_STACK_MAX, "overflow does not grow stack");
+    LOG_STACK_TEST(thread_log_stack_dropped == 2, "overflow records dropped pushes");
+
+    log_stack_pop(&lgs[THREAD_LOG_STACK_MAX + 1]);
+    LOG_STACK_TEST(thread_log_stack_next == THREAD_LOG_STACK_MAX, "dropped cleanup leaves stack depth unchanged");
+    LOG_STACK_TEST(thread_log_stack_dropped == 1, "dropped cleanup consumes one dropped push");
+
+    log_stack_pop(&lgs[THREAD_LOG_STACK_MAX]);
+    LOG_STACK_TEST(thread_log_stack_next == THREAD_LOG_STACK_MAX, "second dropped cleanup leaves stack depth unchanged");
+    LOG_STACK_TEST(thread_log_stack_dropped == 0, "second dropped cleanup consumes final dropped push");
+
+    for(size_t i = THREAD_LOG_STACK_MAX; i > 0; i--)
+        log_stack_pop(&lgs[i - 1]);
+
+    LOG_STACK_TEST(thread_log_stack_next == 0, "successful pushes still pop in LIFO order");
+    LOG_STACK_TEST(thread_log_stack_dropped == 0, "dropped counter is clear after cleanup");
+
+    struct log_stack_entry repeated_lgs[] = {
+        ND_LOG_FIELD_TXT(NDF_MESSAGE, "log-stack-repeated-pointer"),
+        ND_LOG_FIELD_END(),
+    };
+
+    memset(thread_log_stack_base, 0, sizeof(thread_log_stack_base));
+    thread_log_stack_next = 0;
+    thread_log_stack_dropped = 0;
+
+    for(size_t i = 0; i < THREAD_LOG_STACK_MAX; i++)
+        log_stack_push(repeated_lgs);
+
+    log_stack_push(repeated_lgs);
+    LOG_STACK_TEST(thread_log_stack_next == THREAD_LOG_STACK_MAX, "same-pointer overflow leaves previous stack entries");
+    LOG_STACK_TEST(thread_log_stack_dropped == 1, "same-pointer overflow records dropped push");
+
+    log_stack_pop(&repeated_lgs);
+    LOG_STACK_TEST(thread_log_stack_next == THREAD_LOG_STACK_MAX, "same-pointer dropped cleanup does not pop older entry");
+    LOG_STACK_TEST(thread_log_stack_dropped == 0, "same-pointer dropped cleanup consumes dropped push");
+
+    for(size_t i = THREAD_LOG_STACK_MAX; i > 0; i--)
+        log_stack_pop(&repeated_lgs);
+
+    LOG_STACK_TEST(thread_log_stack_next == 0, "same-pointer successful entries still pop");
+    LOG_STACK_TEST(thread_log_stack_dropped == 0, "same-pointer dropped counter is clear after cleanup");
+
+    memset(thread_log_stack_base, 0, sizeof(thread_log_stack_base));
+    thread_log_stack_next = 0;
+    thread_log_stack_dropped = 0;
+
+    if(errors)
+        fprintf(stderr, "log stack unittest: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "log stack unittest: OK\n");
+
+    return errors;
+}
+
+#undef LOG_STACK_TEST
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/src/libnetdata/memory/nd-mallocz.c
+++ b/src/libnetdata/memory/nd-mallocz.c
@@ -331,7 +331,11 @@ char *strdupz_int(const char *s, const char *file, const char *function, size_t 
 
 char *strndupz_int(const char *s, size_t len, const char *file, const char *function, size_t line) {
     struct malloc_trace *p = malloc_trace_find_or_create(file, function, line);
-    size_t size = len + 1;
+    size_t bytes = strnlen(s, len);
+    if (unlikely(bytes >= SIZE_MAX - malloc_header_size))
+        fatal("strndupz() cannot allocate %zu bytes of memory.", bytes);
+
+    size_t size = bytes + 1;
 
     size_t_atomic_count(add, p->strdup_calls, 1);
     size_t_atomic_count(add, p->allocations, 1);
@@ -348,8 +352,8 @@ char *strndupz_int(const char *s, size_t len, const char *file, const char *func
         t->padding[i] = 0xFF;
 #endif
 
-    memcpy(&t->data, s, size);
-    t->data[len] = '\0';
+    memcpy(&t->data, s, bytes);
+    t->data[bytes] = '\0';
     return (char *)&t->data;
 }
 

--- a/src/libnetdata/os/os.h
+++ b/src/libnetdata/os/os.h
@@ -23,6 +23,7 @@
 #include "sleep.h"
 #include "uuid_generate.h"
 #include "setenv.h"
+#include "strndup.h"
 #include "hostname.h"
 #include "socket_egress_interface.h"
 #include "os-freebsd-wrappers.h"

--- a/src/libnetdata/os/strndup.c
+++ b/src/libnetdata/os/strndup.c
@@ -1,17 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#ifndef HAVE_STRNDUP
+#if !defined(HAVE_STRNDUP) && !(defined(NETDATA_TRACE_ALLOCATIONS) && defined(HAVE_DLSYM) && defined(ENABLE_DLSYM))
 #include "../libnetdata.h"
 
-static inline char *os_strndup( const char *s1, size_t n)
-{
+char *strndup(const char *s1, size_t n) {
     size_t bytes = strnlen(s1, n);
-    if (unlikely(bytes == SIZE_MAX))
+    if (unlikely(bytes == SIZE_MAX)) {
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    // cppcheck-suppress memleak
+    char *copy = malloc(bytes + 1);
+    if (!copy)
         return NULL;
 
-    char *copy= (char*)malloc( bytes+1 );
-    memcpy( copy, s1, bytes );
+    memcpy(copy, s1, bytes);
     copy[bytes] = 0;
     return copy;
-};
+}
 #endif

--- a/src/libnetdata/os/strndup.c
+++ b/src/libnetdata/os/strndup.c
@@ -5,9 +5,13 @@
 
 static inline char *os_strndup( const char *s1, size_t n)
 {
-    char *copy= (char*)malloc( n+1 );
-    memcpy( copy, s1, n );
-    copy[n] = 0;
+    size_t bytes = strnlen(s1, n);
+    if (unlikely(bytes == SIZE_MAX))
+        return NULL;
+
+    char *copy= (char*)malloc( bytes+1 );
+    memcpy( copy, s1, bytes );
+    copy[bytes] = 0;
     return copy;
 };
 #endif

--- a/src/libnetdata/os/strndup.c
+++ b/src/libnetdata/os/strndup.c
@@ -3,7 +3,7 @@
 #if !defined(HAVE_STRNDUP) && !(defined(NETDATA_TRACE_ALLOCATIONS) && defined(HAVE_DLSYM) && defined(ENABLE_DLSYM))
 #include "../libnetdata.h"
 
-char *strndup(const char *s1, size_t n) {
+char *os_strndup(const char *s1, size_t n) {
     size_t bytes = strnlen(s1, n);
     if (unlikely(bytes == SIZE_MAX)) {
         errno = ENOMEM;

--- a/src/libnetdata/os/strndup.h
+++ b/src/libnetdata/os/strndup.h
@@ -5,8 +5,10 @@
 
 #include "config.h"
 
+#include <stddef.h>
+
 #ifndef HAVE_STRNDUP
-#define strndup(s, n) os_strndup(s, n)
+char *strndup(const char *s, size_t n);
 #endif
 
 #endif //STRNDUP_H

--- a/src/libnetdata/os/strndup.h
+++ b/src/libnetdata/os/strndup.h
@@ -7,8 +7,10 @@
 
 #include <stddef.h>
 
-#ifndef HAVE_STRNDUP
-char *strndup(const char *s, size_t n);
+#if !defined(HAVE_STRNDUP) && !(defined(NETDATA_TRACE_ALLOCATIONS) && defined(HAVE_DLSYM) && defined(ENABLE_DLSYM))
+char *os_strndup(const char *s, size_t n);
+#undef strndup
+#define strndup(s, n) os_strndup(s, n)
 #endif
 
 #endif //STRNDUP_H


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sleep reliability, log stack overflow handling, and strndup portability/sizing across the codebase. Adds focused unit tests and minor build wiring to prevent regressions.

- **Bug Fixes**
  - Clocks: stop retrying on non-EINTR errors in absolute sleep; clamp interrupted nanosleep retries using monotonic time; serialize heartbeat statistics reads/writes with the existing spinlock.
  - Logging: track and unwind dropped log stack pushes when the thread-local stack overflows to avoid fatal pops; normal LIFO behavior unchanged.
  - Memory/OS: size `strndupz`/fallback allocations from bounded `strnlen()` bytes, guard against size wrap, and provide `os_strndup` mapped via `strndup.h` only when libc lacks `strndup` and tracing interposition is off; include `strndup.h` from `os.h`.

- **Refactors**
  - Extracted EINTR retry clamp into a static inline helper in `clocks-internals.h`.
  - Added `clocks-unittest.c` and a log stack unittest; hooked both into the existing unittest path via `CMakeLists.txt` and `src/daemon/main.c`.

<sup>Written for commit 5fe29ede9c07ccf6546e42c67dd5a60aaa784872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

