### PR TITLE
Netdata fixes part 35

### DIFF
--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -511,8 +511,13 @@ void analytics_alarms(void)
     char b[21];
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(localhost, rc) {
-        if (unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+        RRDSET *st = rrdcalc_rrdset_read_lock(rc);
+        if (unlikely(!st))
             continue;
+        if (unlikely(!st->last_collected_time.tv_sec)) {
+            rrdcalc_rrdset_read_unlock(st);
+            continue;
+        }
 
         switch (rc->status) {
             case RRDCALC_STATUS_WARNING:
@@ -524,6 +529,7 @@ void analytics_alarms(void)
             default:
                 alarm_normal++;
         }
+        rrdcalc_rrdset_read_unlock(st);
     }
     foreach_rrdcalc_in_rrdhost_done(rc);
 

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -75,7 +75,7 @@ static inline size_t svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all
 }
 
 static bool svc_rrdset_lock_for_deletion(RRDSET *st, time_t now) {
-    if(st->last_accessed_time_s + rrdset_free_obsolete_time_s < now &&
+    if(rrdset_last_accessed_time_s(st) + rrdset_free_obsolete_time_s < now &&
         st->last_updated.tv_sec + rrdset_free_obsolete_time_s < now &&
         st->last_collected_time.tv_sec + rrdset_free_obsolete_time_s < now &&
         spinlock_trylock(&st->destroy_lock)) {

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -330,7 +330,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
 
     if(timeframe_matches) {
         if(ri->rrdset)
-            ri->rrdset->last_accessed_time_s = qtl->start_s;
+            rrdset_set_last_accessed_time_s(ri->rrdset, qtl->start_s);
 
         if (qt->query.used == qt->query.size) {
             size_t old_mem = qt->query.size * sizeof(*qt->query.array);

--- a/src/database/ram/rrddim_mem.c
+++ b/src/database/ram/rrddim_mem.c
@@ -31,6 +31,10 @@ void rrddim_metrics_group_release(STORAGE_INSTANCE *si __maybe_unused, STORAGE_M
 
 struct mem_metric_handle {
     RRDDIM *rd;
+    storage_number *data;
+    size_t memsize;
+    RRD_DB_MODE memory_mode;
+    bool indexed;
 
     size_t counter;
     size_t entries;
@@ -43,6 +47,9 @@ struct mem_metric_handle {
 };
 
 static void update_metric_handle_from_rrddim(struct mem_metric_handle *mh, RRDDIM *rd) {
+    mh->data           = rd->db.data;
+    mh->memsize        = rd->db.memsize;
+    mh->memory_mode    = rd->rrd_memory_mode;
     mh->counter        = rd->rrdset->counter;
     mh->entries        = rd->rrdset->db.entries;
     mh->current_entry  = rd->rrdset->db.current_entry;
@@ -52,43 +59,107 @@ static void update_metric_handle_from_rrddim(struct mem_metric_handle *mh, RRDDI
 
 static void check_metric_handle_from_rrddim(struct mem_metric_handle *mh) {
     RRDDIM *rd = mh->rd; (void)rd;
+    if(!rd)
+        return;
+
     internal_fatal(mh->entries != (size_t)rd->rrdset->db.entries, "RRDDIM: entries do not match");
     internal_fatal(mh->update_every_s != rd->rrdset->update_every, "RRDDIM: update every does not match");
 }
 
-STORAGE_METRIC_HANDLE *rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *si) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)rrddim_metric_get_by_id(si, rd->uuid);
-    while(!mh) {
-        netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
+static int64_t rrddim_metric_remove_from_index(struct mem_metric_handle *mh) {
+    int64_t judy_mem = 0;
+
+    netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
+    if(mh->indexed) {
         JudyAllocThreadPulseReset();
-        Pvoid_t *PValue = JudyLIns(&rrddim_Judy_array, rd->uuid, PJE0);
-        int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
-        mh = *PValue;
-        if(!mh) {
-            mh = callocz(1, sizeof(struct mem_metric_handle));
-            mh->rd = rd;
-            mh->uuid_id = rd->uuid;
-            mh->refcount = 1;
-            update_metric_handle_from_rrddim(mh, rd);
-            *PValue = mh;
-            pulse_db_rrd_memory_change(judy_mem + (int64_t)sizeof(struct mem_metric_handle));
-        }
-        else {
-            if(!refcount_acquire(&mh->refcount))
-                mh = NULL;
-        }
-        netdata_rwlock_wrunlock(&rrddim_Judy_rwlock);
+        JudyLDel(&rrddim_Judy_array, mh->uuid_id, PJE0);
+        judy_mem = JudyAllocThreadPulseGetAndReset();
+        mh->indexed = false;
     }
+    netdata_rwlock_wrunlock(&rrddim_Judy_rwlock);
 
-    if(unlikely(mh->rd != rd)) {
-        // this can happen when the old RRDDIM is being deleted,
-        // but the dictionary has not yet run the destructors
-        netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
-        mh->rd = rd;
-        netdata_rwlock_wrunlock(&rrddim_Judy_rwlock);
+    return judy_mem;
+}
+
+static void rrddim_metric_free_data(struct mem_metric_handle *mh) {
+    if(!mh->data)
+        return;
+
+    pulse_db_rrd_memory_sub(mh->memsize);
+
+    if(mh->memory_mode == RRD_DB_MODE_RAM)
+        nd_munmap(mh->data, mh->memsize);
+    else
+        freez(mh->data);
+
+    mh->data = NULL;
+    mh->memsize = 0;
+}
+
+static void rrddim_metric_free_handle(struct mem_metric_handle *mh) {
+    int64_t judy_mem = rrddim_metric_remove_from_index(mh);
+
+    rrddim_metric_free_data(mh);
+    freez(mh);
+    pulse_db_rrd_memory_change(judy_mem - (int64_t)sizeof(struct mem_metric_handle));
+}
+
+STORAGE_METRIC_HANDLE *rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *si) {
+    while(true) {
+        struct mem_metric_handle *mh;
+
+        while((mh = (struct mem_metric_handle *)rrddim_metric_get_by_id(si, rd->uuid)) == NULL) {
+            netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
+            JudyAllocThreadPulseReset();
+            Pvoid_t *PValue = JudyLIns(&rrddim_Judy_array, rd->uuid, PJE0);
+            int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
+            mh = *PValue;
+            if(!mh) {
+                mh = callocz(1, sizeof(struct mem_metric_handle));
+                mh->rd = rd;
+                mh->uuid_id = rd->uuid;
+                mh->refcount = 1;
+                mh->indexed = true;
+                update_metric_handle_from_rrddim(mh, rd);
+                *PValue = mh;
+                pulse_db_rrd_memory_change(judy_mem + (int64_t)sizeof(struct mem_metric_handle));
+            }
+            else {
+                if(!refcount_acquire(&mh->refcount))
+                    mh = NULL;
+            }
+            netdata_rwlock_wrunlock(&rrddim_Judy_rwlock);
+        }
+
+        if(unlikely(mh->rd != rd)) {
+            bool retry = false;
+            int64_t judy_mem = 0;
+
+            netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
+            if(mh->rd != rd) {
+                // this can happen when the old RRDDIM is being deleted,
+                // but the dictionary has not yet run the destructors
+                if(mh->indexed) {
+                    JudyAllocThreadPulseReset();
+                    JudyLDel(&rrddim_Judy_array, mh->uuid_id, PJE0);
+                    judy_mem = JudyAllocThreadPulseGetAndReset();
+                    mh->indexed = false;
+                }
+                retry = true;
+            }
+            netdata_rwlock_wrunlock(&rrddim_Judy_rwlock);
+
+            if(judy_mem)
+                pulse_db_rrd_memory_change(judy_mem);
+
+            if(retry) {
+                rrddim_metric_release((STORAGE_METRIC_HANDLE *)mh);
+                continue;
+            }
+        }
+
+        return (STORAGE_METRIC_HANDLE *)mh;
     }
-
-    return (STORAGE_METRIC_HANDLE *)mh;
 }
 
 STORAGE_METRIC_HANDLE *rrddim_metric_get_by_id(STORAGE_INSTANCE *si __maybe_unused, UUIDMAP_ID id) {
@@ -130,21 +201,36 @@ STORAGE_METRIC_HANDLE *rrddim_metric_dup(STORAGE_METRIC_HANDLE *smh) {
 void rrddim_metric_release(STORAGE_METRIC_HANDLE *smh) {
     struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
 
-    if(refcount_release_and_acquire_for_deletion(&mh->refcount)) {
-        // we can delete it
+    if(refcount_release_and_acquire_for_deletion(&mh->refcount))
+        rrddim_metric_free_handle(mh);
+}
 
-        int64_t judy_mem = 0;
-        netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
-        {
+bool rrddim_metric_release_from_rrddim(STORAGE_METRIC_HANDLE *smh, RRDDIM *rd) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
+    bool data_transferred = false;
+    int64_t judy_mem = 0;
+
+    netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
+    if(mh->rd == rd) {
+        mh->rd = NULL;
+        data_transferred = (mh->data == rd->db.data);
+
+        if(mh->indexed) {
             JudyAllocThreadPulseReset();
             JudyLDel(&rrddim_Judy_array, mh->uuid_id, PJE0);
             judy_mem = JudyAllocThreadPulseGetAndReset();
+            mh->indexed = false;
         }
-        netdata_rwlock_wrunlock(&rrddim_Judy_rwlock);
-
-        freez(mh);
-        pulse_db_rrd_memory_change(judy_mem - (int64_t)sizeof(struct mem_metric_handle));
     }
+    netdata_rwlock_wrunlock(&rrddim_Judy_rwlock);
+
+    if(judy_mem)
+        pulse_db_rrd_memory_change(judy_mem);
+
+    if(refcount_release_and_acquire_for_deletion(&mh->refcount))
+        rrddim_metric_free_handle(mh);
+
+    return data_transferred;
 }
 
 bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *si __maybe_unused, nd_uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s) {
@@ -204,12 +290,11 @@ void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *sch) {
     struct mem_collect_handle *ch = (struct mem_collect_handle *)sch;
     struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->smh;
 
-    RRDDIM *rd = mh->rd;
     size_t entries = mh->entries;
     storage_number empty = pack_storage_number(NAN, SN_FLAG_NONE);
 
     for(size_t i = 0; i < entries ;i++)
-        rd->db.data[i] = empty;
+        mh->data[i] = empty;
 
     mh->counter = 0;
     mh->last_updated_s = 0;
@@ -219,8 +304,6 @@ void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *sch) {
 static inline void rrddim_fill_the_gap(STORAGE_COLLECT_HANDLE *sch, time_t now_collect_s) {
     struct mem_collect_handle *ch = (struct mem_collect_handle *)sch;
     struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->smh;
-
-    RRDDIM *rd = mh->rd;
 
     internal_fatal(ch->rd != mh->rd, "RRDDIM: dimensions do not match");
     check_metric_handle_from_rrddim(mh);
@@ -240,7 +323,7 @@ static inline void rrddim_fill_the_gap(STORAGE_COLLECT_HANDLE *sch, time_t now_c
         // fill the dimension
         size_t c;
         for(c = 0; c < entries && now_store_s <= now_collect_s ; now_store_s += update_every_s, c++) {
-            rd->db.data[current_entry++] = empty;
+            mh->data[current_entry++] = empty;
 
             if(unlikely(current_entry >= entries))
                 current_entry = 0;
@@ -263,7 +346,6 @@ void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *sch,
     struct mem_collect_handle *ch = (struct mem_collect_handle *)sch;
     struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->smh;
 
-    RRDDIM *rd = ch->rd;
     time_t point_in_time_s = (time_t)(point_in_time_ut / USEC_PER_SEC);
 
     internal_fatal(ch->rd != mh->rd, "RRDDIM: dimensions do not match");
@@ -275,7 +357,7 @@ void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *sch,
     if(unlikely(mh->last_updated_s && point_in_time_s - mh->update_every_s > mh->last_updated_s))
         rrddim_fill_the_gap(sch, point_in_time_s);
 
-    rd->db.data[mh->current_entry] = pack_storage_number(n, flags);
+    mh->data[mh->current_entry] = pack_storage_number(n, flags);
     mh->counter++;
     mh->current_entry = (mh->current_entry + 1) >= mh->entries ? 0 : mh->current_entry + 1;
     mh->last_updated_s = point_in_time_s;
@@ -303,7 +385,6 @@ int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *sch) {
 // only valid when not using dbengine
 static inline size_t rrddim_time2slot(STORAGE_METRIC_HANDLE *smh, time_t t) {
     struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
-    RRDDIM *rd = mh->rd;
 
     size_t ret = 0;
     time_t last_entry_s  = rrddim_query_latest_time_s(smh);
@@ -331,7 +412,7 @@ static inline size_t rrddim_time2slot(STORAGE_METRIC_HANDLE *smh, time_t t) {
     }
 
     if(unlikely(ret >= entries)) {
-        netdata_log_error("INTERNAL ERROR: rrddim_time2slot() on %s returns values outside entries", rrddim_name(rd));
+        netdata_log_error("INTERNAL ERROR: rrddim_time2slot() returns values outside entries");
         ret = entries - 1;
     }
 
@@ -342,7 +423,6 @@ static inline size_t rrddim_time2slot(STORAGE_METRIC_HANDLE *smh, time_t t) {
 // only valid when not using dbengine
 static inline time_t rrddim_slot2time(STORAGE_METRIC_HANDLE *smh, size_t slot) {
     struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
-    RRDDIM *rd = mh->rd;
 
     time_t ret;
     time_t last_entry_s  = rrddim_query_latest_time_s(smh);
@@ -362,15 +442,15 @@ static inline time_t rrddim_slot2time(STORAGE_METRIC_HANDLE *smh, size_t slot) {
         ret = last_entry_s - (time_t)(update_every * (last_slot - slot));
 
     if(unlikely(ret < first_entry_s)) {
-        netdata_log_error("INTERNAL ERROR: rrddim_slot2time() on dimension '%s' of chart '%s' returned time (%ld) too far in the past (before first_entry_s %ld) for slot %zu",
-              rrddim_name(rd), rrdset_id(rd->rrdset), ret, first_entry_s, slot);
+        netdata_log_error("INTERNAL ERROR: rrddim_slot2time() returned time (%ld) too far in the past (before first_entry_s %ld) for slot %zu",
+              ret, first_entry_s, slot);
 
         ret = first_entry_s;
     }
 
     if(unlikely(ret > last_entry_s)) {
-        netdata_log_error("INTERNAL ERROR: rrddim_slot2time() on dimension '%s' of chart '%s' returned time (%ld) too far into the future (after last_entry_s %ld) for slot %zu",
-              rrddim_name(rd), rrdset_id(rd->rrdset), ret, last_entry_s, slot);
+        netdata_log_error("INTERNAL ERROR: rrddim_slot2time() returned time (%ld) too far into the future (after last_entry_s %ld) for slot %zu",
+              ret, last_entry_s, slot);
 
         ret = last_entry_s;
     }
@@ -383,8 +463,6 @@ static inline time_t rrddim_slot2time(STORAGE_METRIC_HANDLE *smh, size_t slot) {
 
 void rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *seqh, time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority __maybe_unused) {
     struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
-
-    check_metric_handle_from_rrddim(mh);
 
     seqh->start_time_s = start_time_s;
     seqh->end_time_s = end_time_s;
@@ -413,7 +491,6 @@ void rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_h
 ALWAYS_INLINE STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *seqh) {
     struct mem_query_handle* h = (struct mem_query_handle*)seqh->handle;
     struct mem_metric_handle *mh = (struct mem_metric_handle *)h->smh;
-    RRDDIM *rd = mh->rd;
 
     size_t entries = mh->entries;
     size_t slot = h->slot;
@@ -438,7 +515,7 @@ ALWAYS_INLINE STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query
         return sp;
     }
 
-    storage_number n = rd->db.data[slot++];
+    storage_number n = mh->data[slot++];
     if(unlikely(slot >= entries)) slot = 0;
 
     h->slot = slot;
@@ -458,12 +535,8 @@ int rrddim_query_is_finished(struct storage_engine_query_handle *seqh) {
 
 void rrddim_query_finalize(struct storage_engine_query_handle *seqh) {
 #ifdef NETDATA_INTERNAL_CHECKS
-    struct mem_query_handle *h = (struct mem_query_handle*)seqh->handle;
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)h->smh;
-
     internal_error(!rrddim_query_is_finished(seqh),
-                   "QUERY: query for chart '%s' dimension '%s' has been stopped unfinished",
-                   rrdset_id(mh->rd->rrdset), rrddim_name(mh->rd));
+                   "QUERY: query for RRDDIM storage has been stopped unfinished");
 
 #endif
     freez(seqh->handle);

--- a/src/database/ram/rrddim_mem.c
+++ b/src/database/ram/rrddim_mem.c
@@ -46,6 +46,14 @@ struct mem_metric_handle {
     REFCOUNT refcount;
 };
 
+static RRDDIM *rrddim_metric_handle_rrddim_load(struct mem_metric_handle *mh) {
+    return __atomic_load_n(&mh->rd, __ATOMIC_ACQUIRE);
+}
+
+static void rrddim_metric_handle_rrddim_store(struct mem_metric_handle *mh, RRDDIM *rd) {
+    __atomic_store_n(&mh->rd, rd, __ATOMIC_RELEASE);
+}
+
 static void update_metric_handle_from_rrddim(struct mem_metric_handle *mh, RRDDIM *rd) {
     mh->data           = rd->db.data;
     mh->memsize        = rd->db.memsize;
@@ -58,7 +66,7 @@ static void update_metric_handle_from_rrddim(struct mem_metric_handle *mh, RRDDI
 }
 
 static void check_metric_handle_from_rrddim(struct mem_metric_handle *mh) {
-    RRDDIM *rd = mh->rd; (void)rd;
+    RRDDIM *rd = rrddim_metric_handle_rrddim_load(mh); (void)rd;
     if(!rd)
         return;
 
@@ -116,7 +124,7 @@ STORAGE_METRIC_HANDLE *rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE 
             mh = *PValue;
             if(!mh) {
                 mh = callocz(1, sizeof(struct mem_metric_handle));
-                mh->rd = rd;
+                rrddim_metric_handle_rrddim_store(mh, rd);
                 mh->uuid_id = rd->uuid;
                 mh->refcount = 1;
                 mh->indexed = true;
@@ -131,12 +139,12 @@ STORAGE_METRIC_HANDLE *rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE 
             netdata_rwlock_wrunlock(&rrddim_Judy_rwlock);
         }
 
-        if(unlikely(mh->rd != rd)) {
+        if(unlikely(rrddim_metric_handle_rrddim_load(mh) != rd)) {
             bool retry = false;
             int64_t judy_mem = 0;
 
             netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
-            if(mh->rd != rd) {
+            if(rrddim_metric_handle_rrddim_load(mh) != rd) {
                 // this can happen when the old RRDDIM is being deleted,
                 // but the dictionary has not yet run the destructors
                 if(mh->indexed) {
@@ -211,8 +219,8 @@ bool rrddim_metric_release_from_rrddim(STORAGE_METRIC_HANDLE *smh, RRDDIM *rd) {
     int64_t judy_mem = 0;
 
     netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
-    if(mh->rd == rd) {
-        mh->rd = NULL;
+    if(rrddim_metric_handle_rrddim_load(mh) == rd) {
+        rrddim_metric_handle_rrddim_store(mh, NULL);
         data_transferred = (mh->data == rd->db.data);
 
         if(mh->indexed) {
@@ -271,7 +279,7 @@ void rrddim_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *sch
 
 STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *smh, uint32_t update_every __maybe_unused, STORAGE_METRICS_GROUP *smg __maybe_unused) {
     struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
-    RRDDIM *rd = mh->rd;
+    RRDDIM *rd = rrddim_metric_handle_rrddim_load(mh);
 
     update_metric_handle_from_rrddim(mh, rd);
     internal_fatal((uint32_t)mh->update_every_s != update_every, "RRDDIM: update requested does not match the dimension");
@@ -305,7 +313,7 @@ static inline void rrddim_fill_the_gap(STORAGE_COLLECT_HANDLE *sch, time_t now_c
     struct mem_collect_handle *ch = (struct mem_collect_handle *)sch;
     struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->smh;
 
-    internal_fatal(ch->rd != mh->rd, "RRDDIM: dimensions do not match");
+    internal_fatal(ch->rd != rrddim_metric_handle_rrddim_load(mh), "RRDDIM: dimensions do not match");
     check_metric_handle_from_rrddim(mh);
 
     size_t entries = mh->entries;
@@ -348,7 +356,7 @@ void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *sch,
 
     time_t point_in_time_s = (time_t)(point_in_time_ut / USEC_PER_SEC);
 
-    internal_fatal(ch->rd != mh->rd, "RRDDIM: dimensions do not match");
+    internal_fatal(ch->rd != rrddim_metric_handle_rrddim_load(mh), "RRDDIM: dimensions do not match");
     check_metric_handle_from_rrddim(mh);
 
     if(unlikely(point_in_time_s <= mh->last_updated_s))

--- a/src/database/ram/rrddim_mem.h
+++ b/src/database/ram/rrddim_mem.h
@@ -27,6 +27,7 @@ STORAGE_METRIC_HANDLE *rrddim_metric_get_by_id(STORAGE_INSTANCE *si, UUIDMAP_ID 
 STORAGE_METRIC_HANDLE *rrddim_metric_get_by_uuid(STORAGE_INSTANCE *si, nd_uuid_t *uuid);
 STORAGE_METRIC_HANDLE *rrddim_metric_dup(STORAGE_METRIC_HANDLE *smh);
 void rrddim_metric_release(STORAGE_METRIC_HANDLE *smh);
+bool rrddim_metric_release_from_rrddim(STORAGE_METRIC_HANDLE *smh, RRDDIM *rd);
 
 bool rrddim_metric_retention_by_id(STORAGE_INSTANCE *si, UUIDMAP_ID id, time_t *first_entry_s, time_t *last_entry_s);
 bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *si, nd_uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s);

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -520,17 +520,20 @@ RRDDIM *rrddim_add_custom(RRDSET *st
 
     RRDDIM *rd = NULL;
     while(!rd) {
-        rd = rrddim_index_find(st, id);
-        if(rd) {
-            if(spinlock_trylock(&rd->destroy_lock)) {
-                rrddim_isnot_obsolete___safe_from_collector_thread(st, rd);
-                spinlock_unlock(&rd->destroy_lock);
+        const DICTIONARY_ITEM *item = dictionary_get_and_acquire_item(st->rrddim_root_index, id);
+        if(item) {
+            RRDDIM *existing_rd = dictionary_acquired_item_value(item);
+            if(spinlock_trylock(&existing_rd->destroy_lock)) {
+                rrddim_isnot_obsolete___safe_from_collector_thread(st, existing_rd);
+                spinlock_unlock(&existing_rd->destroy_lock);
             }
             else {
-                rd = NULL;
+                dictionary_acquired_item_release(st->rrddim_root_index, item);
                 microsleep(1 * USEC_PER_MS);
                 continue;
             }
+
+            dictionary_acquired_item_release(st->rrddim_root_index, item);
         }
 
         struct rrddim_constructor tmp = {

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -360,7 +360,7 @@ inline RRDDIM *rrddim_find(RRDSET *st, const char *id, bool include_obsolete) {
         if(!include_obsolete && rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE) && !rrdset_is_discoverable(st))
             rd = NULL;
         else
-            rd->rrdset->last_accessed_time_s = now_realtime_sec();
+            rrdset_touch_last_accessed_time_s(rd->rrdset);
     }
 
     dictionary_acquired_item_release(st->rrddim_root_index, rd_item);
@@ -379,7 +379,7 @@ inline RRDDIM_ACQUIRED *rrddim_find_and_acquire(RRDSET *st, const char *id, bool
             return NULL;
         }
 
-        rd->rrdset->last_accessed_time_s = now_realtime_sec();
+        rrdset_touch_last_accessed_time_s(rd->rrdset);
     }
 
     return rda;

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -344,8 +344,8 @@ void rrddim_index_destroy(RRDSET *st) {
     st->rrddim_root_index = NULL;
 }
 
-static inline RRDDIM *rrddim_index_find(RRDSET *st, const char *id) {
-    return dictionary_get(st->rrddim_root_index, id);
+static inline const DICTIONARY_ITEM *rrddim_index_find_and_acquire(RRDSET *st, const char *id) {
+    return dictionary_get_and_acquire_item(st->rrddim_root_index, id);
 }
 
 // ----------------------------------------------------------------------------
@@ -354,13 +354,16 @@ static inline RRDDIM *rrddim_index_find(RRDSET *st, const char *id) {
 inline RRDDIM *rrddim_find(RRDSET *st, const char *id, bool include_obsolete) {
     netdata_log_debug(D_RRD_CALLS, "rrddim_find() for chart %s, dimension %s", rrdset_name(st), id);
 
-    RRDDIM *rd = rrddim_index_find(st, id);
+    const DICTIONARY_ITEM *rd_item = rrddim_index_find_and_acquire(st, id);
+    RRDDIM *rd = dictionary_acquired_item_value(rd_item);
     if(rd) {
         if(!include_obsolete && rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE) && !rrdset_is_discoverable(st))
-            return NULL;
-
-        rd->rrdset->last_accessed_time_s = now_realtime_sec();
+            rd = NULL;
+        else
+            rd->rrdset->last_accessed_time_s = now_realtime_sec();
     }
+
+    dictionary_acquired_item_release(st->rrddim_root_index, rd_item);
 
     return rd;
 }

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -3,6 +3,7 @@
 #include "rrd.h"
 #include "storage-engine.h"
 #include "rrddim-collection.h"
+#include "ram/rrddim_mem.h"
 
 void rrddim_metadata_updated(RRDDIM *rd) {
     rrdcontext_updated_rrddim(rd);
@@ -214,17 +215,22 @@ static void rrddim_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         metaqueue_delete_dimension_uuid(uuidmap_uuid_ptr(rd->uuid));
     }
 
+    bool db_data_lifetime_transferred = false;
+
     for(size_t tier = 0; tier < nd_profile.storage_tiers;tier++) {
         spinlock_lock(&rd->tiers[tier].spinlock);
         if(rd->tiers[tier].smh) {
             STORAGE_ENGINE *eng = host->db[tier].eng;
-            eng->api.metric_release(rd->tiers[tier].smh);
+            if(rd->tiers[tier].seb == STORAGE_ENGINE_BACKEND_RRDDIM)
+                db_data_lifetime_transferred |= rrddim_metric_release_from_rrddim(rd->tiers[tier].smh, rd);
+            else
+                eng->api.metric_release(rd->tiers[tier].smh);
             rd->tiers[tier].smh = NULL;
         }
         spinlock_unlock(&rd->tiers[tier].spinlock);
     }
 
-    if(rd->db.data) {
+    if(rd->db.data && !db_data_lifetime_transferred) {
         pulse_db_rrd_memory_sub(rd->db.memsize);
 
         if(rd->rrd_memory_mode == RRD_DB_MODE_RAM)

--- a/src/database/rrdhost-status.c
+++ b/src/database/rrdhost-status.c
@@ -317,8 +317,13 @@ static void rrdhost_status_health_internal(RRDHOST_STATUS *s, RRDHOST_FLAGS flag
 
         RRDCALC *rc;
         foreach_rrdcalc_in_rrdhost_read(host, rc) {
-            if (unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+            RRDSET *st = rrdcalc_rrdset_read_lock(rc);
+            if (unlikely(!st))
                 continue;
+            if (unlikely(!st->last_collected_time.tv_sec)) {
+                rrdcalc_rrdset_read_unlock(st);
+                continue;
+            }
 
             switch (rc->status) {
                 default:
@@ -345,6 +350,7 @@ static void rrdhost_status_health_internal(RRDHOST_STATUS *s, RRDHOST_FLAGS flag
                     s->health.alerts.uninitialized++;
                     break;
             }
+            rrdcalc_rrdset_read_unlock(st);
         }
         foreach_rrdcalc_in_rrdhost_done(rc);
     }

--- a/src/database/rrdset-index-id.c
+++ b/src/database/rrdset-index-id.c
@@ -320,8 +320,8 @@ void rrdset_index_destroy(RRDHOST *host) {
     host->rrdset_root_index = NULL;
 }
 
-static inline RRDSET *rrdset_index_add(RRDHOST *host, const char *id, struct rrdset_constructor *st_ctr) {
-    return dictionary_set_advanced(host->rrdset_root_index, id, -1, NULL, sizeof(RRDSET), st_ctr);
+static inline const DICTIONARY_ITEM *rrdset_index_add_and_acquire(RRDHOST *host, const char *id, struct rrdset_constructor *st_ctr) {
+    return dictionary_set_and_acquire_item_advanced(host->rrdset_root_index, id, -1, NULL, sizeof(RRDSET), st_ctr);
 }
 
 static inline void rrdset_index_del(RRDHOST *host, RRDSET *st) {
@@ -451,23 +451,26 @@ RRDSET *rrdset_create_custom(
 
     struct rrdset_constructor ctr;
 
-    RRDSET *st = NULL;
-    while(!st) {
-        st = rrdset_index_find(host, chart_full_id);
-        if(st) {
-            if(spinlock_trylock(&st->destroy_lock)) {
-                rrdset_isnot_obsolete___safe_from_collector_thread(st);
-                spinlock_unlock(&st->destroy_lock);
+    const DICTIONARY_ITEM *st_item = NULL;
+    while(!st_item) {
+        const DICTIONARY_ITEM *existing_item = dictionary_get_and_acquire_item(host->rrdset_root_index, chart_full_id);
+        if(existing_item) {
+            RRDSET *existing_st = dictionary_acquired_item_value(existing_item);
+            if(spinlock_trylock(&existing_st->destroy_lock)) {
+                rrdset_isnot_obsolete___safe_from_collector_thread(existing_st);
+                spinlock_unlock(&existing_st->destroy_lock);
             }
             else {
 #ifdef FSANITIZE_ADDRESS
                 fprintf(stderr, "rrdset_create_custom() - chart '%s' of host '%s' is being deleted but we need it. Retrying...\n",
                         chart_full_id, rrdhost_hostname(host));
 #endif
-                st = NULL;
+                dictionary_acquired_item_release(host->rrdset_root_index, existing_item);
                 microsleep(1 * USEC_PER_MS);
                 continue;
             }
+
+            dictionary_acquired_item_release(host->rrdset_root_index, existing_item);
         }
 
         ctr = (struct rrdset_constructor){
@@ -488,8 +491,10 @@ RRDSET *rrdset_create_custom(
             .history_entries = history_entries,
         };
 
-        st = rrdset_index_add(host, chart_full_id, &ctr);
+        st_item = rrdset_index_add_and_acquire(host, chart_full_id, &ctr);
     }
+
+    RRDSET *st = dictionary_acquired_item_value(st_item);
 
     bool name_updated = false;
     if(!st->name) {
@@ -511,6 +516,7 @@ RRDSET *rrdset_create_custom(
         rrdset_metadata_updated(st);
     }
 
+    dictionary_acquired_item_release(host->rrdset_root_index, st_item);
     return st;
 }
 

--- a/src/database/rrdset-index-id.c
+++ b/src/database/rrdset-index-id.c
@@ -282,7 +282,7 @@ static void rrdset_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
     RRDHOST *host = st->rrdhost;
 
     st->collector_tid = gettid_cached();
-    st->last_accessed_time_s = now_realtime_sec();
+    rrdset_touch_last_accessed_time_s(st);
 
     if(ctr->react_action & (RRDSET_REACT_NEW | RRDSET_REACT_PLUGIN_UPDATED | RRDSET_REACT_MODULE_UPDATED)) {
         if (ctr->react_action & RRDSET_REACT_NEW) {
@@ -344,7 +344,7 @@ RRDSET *rrdset_find(RRDHOST *host, const char *id, bool include_obsolete) {
         if(!include_obsolete && !rrdset_is_discoverable(st))
             return NULL;
 
-        st->last_accessed_time_s = now_realtime_sec();
+        rrdset_touch_last_accessed_time_s(st);
     }
 
     return(st);
@@ -374,7 +374,7 @@ RRDSET_ACQUIRED *rrdset_find_and_acquire(RRDHOST *host, const char *id, bool inc
                 return NULL;
             }
 
-            st->last_accessed_time_s = now_realtime_sec();
+            rrdset_touch_last_accessed_time_s(st);
         }
     }
 

--- a/src/database/rrdset-index-name.c
+++ b/src/database/rrdset-index-name.c
@@ -114,7 +114,7 @@ RRDSET *rrdset_find_byname(RRDHOST *host, const char *name) {
         if(!rrdset_is_discoverable(st))
             return NULL;
 
-        st->last_accessed_time_s = now_realtime_sec();
+        rrdset_touch_last_accessed_time_s(st);
     }
 
     return(st);

--- a/src/database/rrdset.c
+++ b/src/database/rrdset.c
@@ -125,7 +125,7 @@ void rrdset_is_obsolete___safe_from_collector_thread(RRDSET *st) {
         rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE);
         rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_OBSOLETE_CHARTS);
 
-        st->last_accessed_time_s = now_realtime_sec();
+        rrdset_touch_last_accessed_time_s(st);
 
         // The parent skips replication for obsolete charts, so the natural
         // "replication finished" decrement at stream-replication-sender.c will
@@ -159,7 +159,7 @@ void rrdset_isnot_obsolete___safe_from_collector_thread(RRDSET *st) {
 //                rrdhost_hostname(st->rrdhost), rrdset_id(st));
 
         rrdset_flag_clear(st, RRDSET_FLAG_OBSOLETE);
-        st->last_accessed_time_s = now_realtime_sec();
+        rrdset_touch_last_accessed_time_s(st);
 
         rrdset_metadata_updated(st);
 

--- a/src/database/rrdset.h
+++ b/src/database/rrdset.h
@@ -258,6 +258,18 @@ static inline uint32_t rrdset_metadata_version(RRDSET *st) {
     return __atomic_load_n(&st->version, __ATOMIC_RELAXED);
 }
 
+static inline time_t rrdset_last_accessed_time_s(RRDSET *st) {
+    return __atomic_load_n(&st->last_accessed_time_s, __ATOMIC_RELAXED);
+}
+
+static inline void rrdset_set_last_accessed_time_s(RRDSET *st, time_t last_accessed_time_s) {
+    __atomic_store_n(&st->last_accessed_time_s, last_accessed_time_s, __ATOMIC_RELAXED);
+}
+
+static inline void rrdset_touch_last_accessed_time_s(RRDSET *st) {
+    rrdset_set_last_accessed_time_s(st, now_realtime_sec());
+}
+
 static inline uint32_t rrdset_metadata_upstream_version(RRDSET *st) {
     return __atomic_load_n(&st->stream.snd.sent_version, __ATOMIC_RELAXED);
 }

--- a/src/health/health_json.c
+++ b/src/health/health_json.c
@@ -181,14 +181,21 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
             STRING *tok_string = string_strdupz(tok);
 
             foreach_rrdcalc_in_rrdhost_read(host, rc) {
-                if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+                RRDSET *st = rrdcalc_rrdset_read_lock(rc);
+                if(unlikely(!st))
                     continue;
-                if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
+                if(unlikely(!st->last_collected_time.tv_sec)) {
+                    rrdcalc_rrdset_read_unlock(st);
                     continue;
-                if(unlikely(rc->rrdset
-                             && rc->rrdset->context == tok_string
+                }
+                if (unlikely(!rrdset_is_available_for_exporting_and_alarms(st))) {
+                    rrdcalc_rrdset_read_unlock(st);
+                    continue;
+                }
+                if(unlikely(st->context == tok_string
                              && ((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status)))
                     numberOfAlarms++;
+                rrdcalc_rrdset_read_unlock(st);
             }
             foreach_rrdcalc_in_rrdhost_done(rc);
 
@@ -197,12 +204,20 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
     }
     else {
         foreach_rrdcalc_in_rrdhost_read(host, rc) {
-            if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+            RRDSET *st = rrdcalc_rrdset_read_lock(rc);
+            if(unlikely(!st))
                 continue;
-            if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
+            if(unlikely(!st->last_collected_time.tv_sec)) {
+                rrdcalc_rrdset_read_unlock(st);
                 continue;
+            }
+            if (unlikely(!rrdset_is_available_for_exporting_and_alarms(st))) {
+                rrdcalc_rrdset_read_unlock(st);
+                continue;
+            }
             if(unlikely((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status))
                 numberOfAlarms++;
+            rrdcalc_rrdset_read_unlock(st);
         }
         foreach_rrdcalc_in_rrdhost_done(rc);
     }
@@ -214,18 +229,28 @@ static void health_alarms2json_fill_alarms(RRDHOST *host, BUFFER *wb, int all, v
     RRDCALC *rc;
     int i = 0;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
-        if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+        RRDSET *st = rrdcalc_rrdset_read_lock(rc);
+        if(unlikely(!st))
             continue;
+        if(unlikely(!st->last_collected_time.tv_sec)) {
+            rrdcalc_rrdset_read_unlock(st);
+            continue;
+        }
 
-        if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
+        if (unlikely(!rrdset_is_available_for_exporting_and_alarms(st))) {
+            rrdcalc_rrdset_read_unlock(st);
             continue;
+        }
 
-        if(likely(!all && !(rc->status == RRDCALC_STATUS_WARNING || rc->status == RRDCALC_STATUS_CRITICAL)))
+        if(likely(!all && !(rc->status == RRDCALC_STATUS_WARNING || rc->status == RRDCALC_STATUS_CRITICAL))) {
+            rrdcalc_rrdset_read_unlock(st);
             continue;
+        }
 
         if(likely(i)) buffer_strcat(wb, ",\n");
         fp(host, wb, rc);
         i++;
+        rrdcalc_rrdset_read_unlock(st);
     }
     foreach_rrdcalc_in_rrdhost_done(rc);
 }

--- a/src/health/health_notifications.c
+++ b/src/health/health_notifications.c
@@ -305,7 +305,11 @@ struct health_raised_summary *alerts_raised_summary_create(RRDHOST *host) {
 void alerts_raised_summary_populate(struct health_raised_summary *hrm) {
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(hrm->host, rc) {
-        if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec)) continue;
+        RRDSET *st = rrdcalc_rrdset_read_lock(rc);
+        if(unlikely(!st)) continue;
+        bool collected = st->last_collected_time.tv_sec;
+        rrdcalc_rrdset_read_unlock(st);
+        if(unlikely(!collected)) continue;
         health_raised_summary_add_alert(hrm, rc_dfe.item);
     }
     foreach_rrdcalc_in_rrdhost_done(rc);

--- a/src/health/health_variable.c
+++ b/src/health/health_variable.c
@@ -36,9 +36,13 @@ struct variable_lookup_job {
 };
 
 static void variable_lookup_add_result_with_score(struct variable_lookup_job *vbd, NETDATA_DOUBLE n, RRDSET *st, const char *source __maybe_unused) {
-    if(vbd->score.last_rrdset != st && vbd->rc->rrdset) {
-        vbd->score.last_rrdset = st;
-        vbd->score.last_score = rrdlabels_common_count(vbd->rc->rrdset->rrdlabels, st->rrdlabels);
+    if(vbd->score.last_rrdset != st) {
+        RRDSET *alert_st = rrdcalc_rrdset_read_lock(vbd->rc);
+        if(alert_st) {
+            vbd->score.last_rrdset = st;
+            vbd->score.last_score = rrdlabels_common_count(alert_st->rrdlabels, st->rrdlabels);
+            rrdcalc_rrdset_read_unlock(alert_st);
+        }
     }
 
     if(vbd->result.used >= vbd->result.size) {

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -113,6 +113,25 @@ struct rrdcalc {
 #define foreach_rrdcalc_in_rrdhost_done(rc) \
     dfe_done(rc)
 
+static inline RRDSET *rrdcalc_rrdset_read_lock(RRDCALC *rc) {
+    RRDSET *st = rc->rrdset;
+    if(unlikely(!st))
+        return NULL;
+
+    rw_spinlock_read_lock(&st->alerts.spinlock);
+    // cppcheck-suppress knownConditionTrueFalse
+    if(unlikely(rc->rrdset != st)) {
+        rw_spinlock_read_unlock(&st->alerts.spinlock);
+        return NULL;
+    }
+
+    return st;
+}
+
+static inline void rrdcalc_rrdset_read_unlock(RRDSET *st) {
+    rw_spinlock_read_unlock(&st->alerts.spinlock);
+}
+
 #define RRDCALC_HAS_DB_LOOKUP(rc) ((rc)->config.after)
 
 void rrdcalc_update_info_using_rrdset_labels(RRDCALC *rc);

--- a/src/health/rrdvar.c
+++ b/src/health/rrdvar.c
@@ -269,13 +269,18 @@ void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *wb) {
 
         RRDCALC *rc;
         dfe_start_read(st->rrdhost->rrdcalc_root_index, rc) {
+            RRDSET *alert_st = rrdcalc_rrdset_read_lock(rc);
+            if(unlikely(!alert_st))
+                continue;
+
             tmp = (struct scored) {
                 .existing = false,
-                .chart = string_dup(rc->rrdset->id),
-                .context = string_dup(rc->rrdset->context),
+                .chart = string_dup(alert_st->id),
+                .context = string_dup(alert_st->context),
                 .value = rc->value,
-                .score = rrdlabels_common_count(rc->rrdset->rrdlabels, st->rrdlabels),
+                .score = rrdlabels_common_count(alert_st->rrdlabels, st->rrdlabels),
             };
+            rrdcalc_rrdset_read_unlock(alert_st);
             z = dictionary_set(dict, string2str(rc->config.name), &tmp, sizeof(tmp));
 
             if(z->existing) {

--- a/src/web/api/formatters/charts2json.c
+++ b/src/web/api/formatters/charts2json.c
@@ -69,7 +69,7 @@ void charts2json(RRDHOST *host, BUFFER *wb) {
             buffer_json_member_add_object(wb, rrdset_id(st));
             rrdset2json(st, wb, &dimensions, &memory);
             buffer_json_object_close(wb);
-            st->last_accessed_time_s = now;
+            rrdset_set_last_accessed_time_s(st, now);
             c++;
         }
     }

--- a/src/web/api/v1/api_v1_alarms.c
+++ b/src/web/api/v1/api_v1_alarms.c
@@ -138,7 +138,7 @@ int api_v1_variable(RRDHOST *host, struct web_client *w, char *url) {
     }
 
     w->response.data->content_type = CT_APPLICATION_JSON;
-    st->last_accessed_time_s = now_realtime_sec();
+    rrdset_touch_last_accessed_time_s(st);
     alert_variable_lookup_trace(host, st, variable, w->response.data);
 
     return HTTP_RESP_OK;

--- a/src/web/api/v1/api_v1_badge/web_buffer_svg.c
+++ b/src/web/api/v1/api_v1_badge/web_buffer_svg.c
@@ -361,6 +361,12 @@ static struct units_formatter {
         { NULL,          0, UNITS_FORMAT_NONE }
 };
 
+static inline bool badge_time_value_is_undefined(NETDATA_DOUBLE value) {
+    // The exclusive upper bound avoids rejecting exactly SIZE_MAX on long-double builds.
+    return isless(value, 0.0) || isnan(value) || isinf(value) ||
+           isgreaterequal(value, (NETDATA_DOUBLE)SIZE_MAX + (NETDATA_DOUBLE)1.0);
+}
+
 char *format_value_and_unit(char *value_string, size_t value_string_len,
     NETDATA_DOUBLE value, const char *units, int precision) {
     static int max = -1;
@@ -391,7 +397,7 @@ char *format_value_and_unit(char *value_string, size_t value_string_len,
             snprintfz(value_string, value_string_len, "%s", "now");
             return value_string;
         }
-        else if(isless(value, 0.0) || isnan(value) || isinf(value)) {
+        else if(badge_time_value_is_undefined(value)) {
             snprintfz(value_string, value_string_len, "%s", "undefined");
             return value_string;
         }
@@ -421,7 +427,7 @@ char *format_value_and_unit(char *value_string, size_t value_string_len,
             snprintfz(value_string, value_string_len, "%s", "now");
             return value_string;
         }
-        else if(isless(value, 0.0) || isnan(value) || isinf(value)) {
+        else if(badge_time_value_is_undefined(value)) {
             snprintfz(value_string, value_string_len, "%s", "undefined");
             return value_string;
         }
@@ -448,7 +454,7 @@ char *format_value_and_unit(char *value_string, size_t value_string_len,
             snprintfz(value_string, value_string_len, "%s", "now");
             return value_string;
         }
-        else if(isless(value, 0.0) || isnan(value) || isinf(value)) {
+        else if(badge_time_value_is_undefined(value)) {
             snprintfz(value_string, value_string_len, "%s", "undefined");
             return value_string;
         }

--- a/src/web/api/v1/api_v1_badge/web_buffer_svg.c
+++ b/src/web/api/v1/api_v1_badge/web_buffer_svg.c
@@ -391,7 +391,7 @@ char *format_value_and_unit(char *value_string, size_t value_string_len,
             snprintfz(value_string, value_string_len, "%s", "now");
             return value_string;
         }
-        else if(isnan(value) || isinf(value)) {
+        else if(isless(value, 0.0) || isnan(value) || isinf(value)) {
             snprintfz(value_string, value_string_len, "%s", "undefined");
             return value_string;
         }
@@ -421,7 +421,7 @@ char *format_value_and_unit(char *value_string, size_t value_string_len,
             snprintfz(value_string, value_string_len, "%s", "now");
             return value_string;
         }
-        else if(isnan(value) || isinf(value)) {
+        else if(isless(value, 0.0) || isnan(value) || isinf(value)) {
             snprintfz(value_string, value_string_len, "%s", "undefined");
             return value_string;
         }
@@ -448,7 +448,7 @@ char *format_value_and_unit(char *value_string, size_t value_string_len,
             snprintfz(value_string, value_string_len, "%s", "now");
             return value_string;
         }
-        else if(isnan(value) || isinf(value)) {
+        else if(isless(value, 0.0) || isnan(value) || isinf(value)) {
             snprintfz(value_string, value_string_len, "%s", "undefined");
             return value_string;
         }

--- a/src/web/api/v1/api_v1_badge/web_buffer_svg.c
+++ b/src/web/api/v1/api_v1_badge/web_buffer_svg.c
@@ -976,7 +976,7 @@ int api_v1_badge(RRDHOST *host, struct web_client *w, char *url) {
         ret = HTTP_RESP_OK;
         goto cleanup;
     }
-    st->last_accessed_time_s = now_realtime_sec();
+    rrdset_touch_last_accessed_time_s(st);
 
     if(alarm) {
         rca = rrdcalc_from_rrdset_get(st, alarm);

--- a/src/web/api/v1/api_v1_charts.c
+++ b/src/web/api/v1/api_v1_charts.c
@@ -41,7 +41,7 @@ int api_v1_single_chart_helper(RRDHOST *host, struct web_client *w, char *url, v
     }
 
     w->response.data->content_type = CT_APPLICATION_JSON;
-    st->last_accessed_time_s = now_realtime_sec();
+    rrdset_touch_last_accessed_time_s(st);
     callback(st, w->response.data);
     return HTTP_RESP_OK;
 

--- a/src/web/api/v1/api_v1_info.c
+++ b/src/web/api/v1/api_v1_info.c
@@ -81,8 +81,13 @@ static void web_client_api_request_v1_info_summary_alarm_statuses(RRDHOST *host,
     size_t normal = 0, warning = 0, critical = 0;
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
-        if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+        RRDSET *st = rrdcalc_rrdset_read_lock(rc);
+        if(unlikely(!st))
             continue;
+        if(unlikely(!st->last_collected_time.tv_sec)) {
+            rrdcalc_rrdset_read_unlock(st);
+            continue;
+        }
 
         switch(rc->status) {
             case RRDCALC_STATUS_WARNING:
@@ -94,6 +99,7 @@ static void web_client_api_request_v1_info_summary_alarm_statuses(RRDHOST *host,
             default:
                 normal++;
         }
+        rrdcalc_rrdset_read_unlock(st);
     }
     foreach_rrdcalc_in_rrdhost_done(rc);
 

--- a/src/web/api/v1/api_v1_info.c
+++ b/src/web/api/v1/api_v1_info.c
@@ -21,7 +21,7 @@ static void host_collectors(RRDHOST *host, BUFFER *wb) {
         bool *set = dictionary_set(dict, name, &old, sizeof(bool));
         if(!*set) {
             *set = true;
-            st->last_accessed_time_s = now;
+            rrdset_set_last_accessed_time_s(st, now);
             buffer_json_add_array_item_object(wb);
             buffer_json_member_add_string(wb, "plugin", rrdset_plugin_name(st));
             buffer_json_member_add_string(wb, "module", rrdset_module_name(st));


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes concurrency and lifetime issues in RAM-backed dimensions and alert readers, and makes chart last-access timestamps atomic. Prevents use-after-free and undefined casts without changing metric or API behavior.

- **Bug Fixes**
  - RAM storage: cache `data`, `memsize`, and mode in the refcounted metric handle; detach stale handles from the Judy index on RRDDIM delete/replace; free buffers on final release; publish `mh->rd` with acquire/release.
  - Lookups/creation: acquire dictionary items while checking flags and `destroy_lock` in `rrddim_find()` and `rrdset_create_custom()` to avoid races with deletion.
  - Alerts: add `rrdcalc_rrdset_read_lock()`/unlock and use it in analytics, host status, health JSON, notifications, info API, health variable scoring, and chart variables API to guard `rc->rrdset` reads.
  - Badges: reject negative or oversized time values before size_t casts; render “undefined” instead of triggering undefined behavior.

- **Refactors**
  - Add atomic helpers for `RRDSET.last_accessed_time_s` and replace all direct reads/writes (service cleanup, queries, API endpoints, obsolete/revive paths).
  - Update collectors/queries to read/write via the cached metric-handle buffer (`mh->data`) and tighten internal checks/log messages.

<sup>Written for commit b627b28d01a01c9b756ecd872b3d463d50ac92c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

