### PR TITLE
Netdata fixes part 36

### DIFF
--- a/src/database/rrdfunctions-inflight.c
+++ b/src/database/rrdfunctions-inflight.c
@@ -39,6 +39,10 @@ struct rrd_function_inflight {
     } result;
 
     struct {
+        SPINLOCK spinlock;
+    } callbacks;
+
+    struct {
         // to be called in sync mode
         // while the function is running
         // to check if the function has been canceled
@@ -95,12 +99,18 @@ static void rrd_functions_inflight_delete_cb(const DICTIONARY_ITEM *item __maybe
     dictionary_acquired_item_release(r->host->functions, r->host_function_acquired);
 }
 
+static void rrd_functions_inflight_insert_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused) {
+    struct rrd_function_inflight *r = value;
+    spinlock_init(&r->callbacks.spinlock);
+}
+
 void rrd_functions_inflight_init(void) {
     if(rrd_functions_inflight_requests)
         return;
 
     rrd_functions_inflight_requests = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE, NULL, sizeof(struct rrd_function_inflight));
 
+    dictionary_register_insert_callback(rrd_functions_inflight_requests, rrd_functions_inflight_insert_cb, NULL);
     dictionary_register_delete_callback(rrd_functions_inflight_requests, rrd_functions_inflight_delete_cb, NULL);
 }
 
@@ -114,14 +124,20 @@ void rrd_functions_inflight_destroy(void) {
 
 static void rrd_inflight_async_function_register_canceller_cb(void *register_canceller_cb_data, rrd_function_cancel_cb_t canceller_cb, void *canceller_cb_data) {
     struct rrd_function_inflight *r = register_canceller_cb_data;
+
+    spinlock_lock(&r->callbacks.spinlock);
     r->canceller.cb = canceller_cb;
     r->canceller.data = canceller_cb_data;
+    spinlock_unlock(&r->callbacks.spinlock);
 }
 
 static void rrd_inflight_async_function_register_progresser_cb(void *register_progresser_cb_data, rrd_function_progresser_cb_t progresser_cb, void *progresser_cb_data) {
     struct rrd_function_inflight *r = register_progresser_cb_data;
+
+    spinlock_lock(&r->callbacks.spinlock);
     r->progresser.cb = progresser_cb;
     r->progresser.data = progresser_cb_data;
+    spinlock_unlock(&r->callbacks.spinlock);
 }
 
 // ----------------------------------------------------------------------------
@@ -642,8 +658,16 @@ static void rrd_function_cancel_inflight(struct rrd_function_inflight *r) {
         return;
     }
 
-    if(r->canceller.cb)
-        r->canceller.cb(r->canceller.data);
+    rrd_function_cancel_cb_t canceller_cb;
+    void *canceller_cb_data;
+
+    spinlock_lock(&r->callbacks.spinlock);
+    canceller_cb = r->canceller.cb;
+    canceller_cb_data = r->canceller.data;
+    spinlock_unlock(&r->callbacks.spinlock);
+
+    if(canceller_cb)
+        canceller_cb(canceller_cb_data);
 
     rrd_collector_dispatcher_release(r->rdcf->collector);
 }
@@ -684,8 +708,16 @@ void rrd_function_progress(const char *transaction) {
 
     functions_stop_monotonic_update_on_progress(&r->stop_monotonic_ut);
 
-    if(r->progresser.cb)
-        r->progresser.cb(transaction, r->progresser.data);
+    rrd_function_progresser_cb_t progresser_cb;
+    void *progresser_cb_data;
+
+    spinlock_lock(&r->callbacks.spinlock);
+    progresser_cb = r->progresser.cb;
+    progresser_cb_data = r->progresser.data;
+    spinlock_unlock(&r->callbacks.spinlock);
+
+    if(progresser_cb)
+        progresser_cb(transaction, progresser_cb_data);
 
     rrd_collector_dispatcher_release(r->rdcf->collector);
 

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -470,6 +470,74 @@ static void test_dimension_finalize_constant_state()
     ML_TEST_ASSERT(dim.suppression_window_counter == 0, "window counter must reset");
 }
 
+static void test_chart_update_dimension_counts()
+{
+    fprintf(stderr, "  test_chart_update_dimension_counts...\n");
+
+    ml_dimension_t dim = {};
+    spinlock_init(&dim.slock);
+
+    ml_chart_t chart = {};
+
+    dim.mls = MACHINE_LEARNING_STATUS_DISABLED_DUE_TO_EXCLUDED_CHART;
+    dim.mt = METRIC_TYPE_VARIABLE;
+    dim.ts = TRAINING_STATUS_TRAINED;
+    ml_chart_update_dimension(&chart, &dim, true);
+    ML_TEST_ASSERT(chart.mls.num_machine_learning_status_disabled_sp == 1,
+                   "excluded dimensions must increment disabled status");
+    ML_TEST_ASSERT(chart.mls.num_machine_learning_status_enabled == 0,
+                   "excluded dimensions must not increment enabled status");
+
+    chart.mls = {};
+    dim.mls = MACHINE_LEARNING_STATUS_ENABLED;
+    dim.mt = METRIC_TYPE_CONSTANT;
+    dim.ts = TRAINING_STATUS_UNTRAINED;
+    ml_chart_update_dimension(&chart, &dim, true);
+    ML_TEST_ASSERT(chart.mls.num_machine_learning_status_enabled == 1,
+                   "constant dimensions must increment enabled status");
+    ML_TEST_ASSERT(chart.mls.num_metric_type_constant == 1,
+                   "constant dimensions must increment constant metric type");
+    ML_TEST_ASSERT(chart.mls.num_training_status_trained == 1,
+                   "constant dimensions are counted as trained");
+    ML_TEST_ASSERT(chart.mls.num_normal_dimensions == 1,
+                   "constant dimensions are counted as normal");
+    ML_TEST_ASSERT(chart.mls.num_anomalous_dimensions == 0,
+                   "constant dimensions must ignore anomaly input");
+
+    chart.mls = {};
+    dim.mt = METRIC_TYPE_VARIABLE;
+    dim.ts = TRAINING_STATUS_UNTRAINED;
+    ml_chart_update_dimension(&chart, &dim, true);
+    ML_TEST_ASSERT(chart.mls.num_metric_type_variable == 1,
+                   "variable untrained dimensions must increment variable metric type");
+    ML_TEST_ASSERT(chart.mls.num_training_status_untrained == 1,
+                   "variable untrained dimensions must increment untrained status");
+    ML_TEST_ASSERT(chart.mls.num_anomalous_dimensions == 0,
+                   "untrained dimensions must not count anomaly input");
+
+    chart.mls = {};
+    dim.ts = TRAINING_STATUS_TRAINED;
+    ml_chart_update_dimension(&chart, &dim, true);
+    ML_TEST_ASSERT(chart.mls.num_training_status_trained == 1,
+                   "trained dimensions must increment trained status");
+    ML_TEST_ASSERT(chart.mls.num_anomalous_dimensions == 1,
+                   "trained anomalous dimensions must increment anomalous count");
+    ML_TEST_ASSERT(chart.mls.num_normal_dimensions == 0,
+                   "trained anomalous dimensions must not increment normal count");
+
+    chart.mls = {};
+    dim.ts = TRAINING_STATUS_SILENCED;
+    ml_chart_update_dimension(&chart, &dim, false);
+    ML_TEST_ASSERT(chart.mls.num_training_status_silenced == 1,
+                   "silenced dimensions must increment silenced status");
+    ML_TEST_ASSERT(chart.mls.num_training_status_trained == 1,
+                   "silenced dimensions must also increment trained status");
+    ML_TEST_ASSERT(chart.mls.num_normal_dimensions == 1,
+                   "silenced normal dimensions must increment normal count");
+    ML_TEST_ASSERT(chart.mls.num_anomalous_dimensions == 0,
+                   "silenced normal dimensions must not increment anomalous count");
+}
+
 // Test: circular buffer linearization produces the same result as std::rotate
 static void test_circular_buffer_equivalence()
 {
@@ -1068,6 +1136,7 @@ extern "C" int ml_unittest()
     test_kmeans_inlined_empty_source_is_zero_initialized();
     test_features_preprocess_below_min_for_kmeans();
     test_dimension_finalize_constant_state();
+    test_chart_update_dimension_counts();
     test_circular_buffer_equivalence();
     test_same_value_uses_newest_sample();
     test_preprocess_predict_equivalence();

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1179,14 +1179,20 @@ ml_chart_is_available_for_ml(ml_chart_t *chart)
 void
 ml_chart_update_dimension(ml_chart_t *chart, ml_dimension_t *dim, bool is_anomalous)
 {
-    switch (dim->mls) {
+    spinlock_lock(&dim->slock);
+    enum ml_machine_learning_status mls = dim->mls;
+    enum ml_metric_type mt = dim->mt;
+    enum ml_training_status ts = dim->ts;
+    spinlock_unlock(&dim->slock);
+
+    switch (mls) {
         case MACHINE_LEARNING_STATUS_DISABLED_DUE_TO_EXCLUDED_CHART:
             chart->mls.num_machine_learning_status_disabled_sp++;
             return;
         case MACHINE_LEARNING_STATUS_ENABLED: {
             chart->mls.num_machine_learning_status_enabled++;
 
-            switch (dim->mt) {
+            switch (mt) {
                 case METRIC_TYPE_CONSTANT:
                     chart->mls.num_metric_type_constant++;
                     chart->mls.num_training_status_trained++;
@@ -1197,7 +1203,7 @@ ml_chart_update_dimension(ml_chart_t *chart, ml_dimension_t *dim, bool is_anomal
                     break;
             }
 
-            switch (dim->ts) {
+            switch (ts) {
                 case TRAINING_STATUS_UNTRAINED:
                     chart->mls.num_training_status_untrained++;
                     return;

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -549,8 +549,6 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
 
     loaded_km_contexts.reserve(Cfg.num_models_to_use);
     while ((rc = sqlite3_step_monitored(res)) == SQLITE_ROW) {
-        ml_kmeans_t km;
-
         sqlite3_int64 raw_after  = sqlite3_column_int64(res, 0);
         sqlite3_int64 raw_before = sqlite3_column_int64(res, 1);
         // Protect against silent truncation when time_t is narrower than int64_t
@@ -562,13 +560,14 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
             continue;
         }
 
+        loaded_km_contexts.emplace_back();
+        ml_kmeans_inlined_t &km = loaded_km_contexts.back();
+
         km.after  = (time_t) raw_after;
         km.before = (time_t) raw_before;
 
         km.min_dist = sqlite3_column_double(res, 2);
         km.max_dist = sqlite3_column_double(res, 3);
-
-        km.cluster_centers.resize(2);
 
         km.cluster_centers[0].set_size(Cfg.lag_n + 1);
         km.cluster_centers[0](0) = sqlite3_column_double(res, 4);
@@ -585,8 +584,6 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
         km.cluster_centers[1](3) = sqlite3_column_double(res, 13);
         km.cluster_centers[1](4) = sqlite3_column_double(res, 14);
         km.cluster_centers[1](5) = sqlite3_column_double(res, 15);
-
-        loaded_km_contexts.emplace_back(km);
     }
 
     if (rc == SQLITE_DONE && !loaded_km_contexts.empty()) {

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -505,7 +505,7 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     if (!is_empty)
         return 0;
 
-    std::vector<ml_kmeans_t> V;
+    std::vector<ml_kmeans_inlined_t> loaded_km_contexts;
 
     sqlite3_stmt *res = active_stmt ? *active_stmt : NULL;
     int rc = 0;
@@ -547,9 +547,7 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    spinlock_lock(&dim->slock);
-
-    dim->km_contexts.reserve(Cfg.num_models_to_use);
+    loaded_km_contexts.reserve(Cfg.num_models_to_use);
     while ((rc = sqlite3_step_monitored(res)) == SQLITE_ROW) {
         ml_kmeans_t km;
 
@@ -588,14 +586,17 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
         km.cluster_centers[1](4) = sqlite3_column_double(res, 14);
         km.cluster_centers[1](5) = sqlite3_column_double(res, 15);
 
-        dim->km_contexts.emplace_back(km);
+        loaded_km_contexts.emplace_back(km);
     }
 
-    if (!dim->km_contexts.empty()) {
-        dim->ts = TRAINING_STATUS_TRAINED;
+    if (rc == SQLITE_DONE && !loaded_km_contexts.empty()) {
+        spinlock_lock(&dim->slock);
+        if (dim->km_contexts.empty()) {
+            dim->km_contexts.swap(loaded_km_contexts);
+            dim->ts = TRAINING_STATUS_TRAINED;
+        }
+        spinlock_unlock(&dim->slock);
     }
-
-    spinlock_unlock(&dim->slock);
 
     step_rc = rc;
     if (unlikely(step_rc != SQLITE_DONE))
@@ -617,20 +618,13 @@ int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     step_corrupt    = ml_db_mark_if_corrupt(step_rc);
     cleanup_corrupt = ml_db_mark_if_corrupt(rc);
 
-    // Partial step results may be polluting dim state -- roll back whenever
-    // step did NOT cleanly return SQLITE_DONE, not only on CORRUPT/NOTADB.
-    // SQLITE_BUSY-after-retries, SQLITE_IOERR, SQLITE_INTERRUPT etc. all
-    // leave a partial km_contexts behind, and the training-enqueue gate in
-    // ml_public.cc only requeues UNTRAINED dims -- so leaving ts=TRAINED
-    // with a truncated context locks the dim onto stale models until the
-    // next agent restart. Cleanup-only corruption (step=DONE, reset/
-    // finalize=CORRUPT) does NOT trigger this: step returned DONE so the
-    // rows already loaded are structurally valid; only the DB-level flag
-    // needs setting for future calls.
+    // Partial step results stay local. On failure, only repair an otherwise
+    // empty dimension's state; do not clear a model installed concurrently
+    // while SQLite was stepping.
     if (step_rc != SQLITE_DONE) {
         spinlock_lock(&dim->slock);
-        dim->km_contexts.clear();
-        dim->ts = TRAINING_STATUS_UNTRAINED;
+        if (dim->km_contexts.empty())
+            dim->ts = TRAINING_STATUS_UNTRAINED;
         spinlock_unlock(&dim->slock);
     }
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data races in async inflight callbacks and ML chart counters, and reduces ML lock contention during model loading. Also simplifies model loading and adds tests for chart dimension counting.

- **Bug Fixes**
  - Serialize inflight `canceller`/`progresser` registration and use with a per-request spinlock (initialized on dictionary insert); copy under lock, invoke outside.
  - Snapshot `mls/mt/ts` under `dim->slock` in `ml_chart_update_dimension()` to avoid racy reads.
  - Stop holding `dim->slock` during SQLite reads in `ml_dimension_load_models()`; stage rows locally and swap under lock only if still empty. On step failure, keep existing models and set UNTRAINED only when empty.

- **Refactors**
  - Load models directly into `ml_kmeans_inlined_t` (no temporary `ml_kmeans_t` or conversion).
  - Add a unit test for `ml_chart_update_dimension()` counters.

<sup>Written for commit 56d73da377e50fda24f0b6eb874f0f4d07d65450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

