### PR TITLE
Netdata fixes part 37

### DIFF
--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -174,18 +174,23 @@ UUIDMAP_ID uuidmap_create(const nd_uuid_t uuid) {
     return id;
 }
 
-static struct uuidmap_entry *get_entry_by_id(UUIDMAP_ID id) {
-    if(id == 0) return NULL;
-
-    uint8_t partition = uuidmap_id_to_partition(id);
-
-    rw_spinlock_read_lock(&uuid_map.p[partition].spinlock);
-
+static struct uuidmap_entry *get_entry_by_id_locked(UUIDMAP_ID id, uint8_t partition) {
     Pvoid_t *PValue = JudyLGet(uuid_map.p[partition].id_to_uuid, id, PJE0);
     if (PValue == PJERR)
         fatal("UUIDMAP: corrupted JudyL array");
 
-    struct uuidmap_entry *ue = PValue ? *PValue : NULL;
+    return PValue ? *PValue : NULL;
+}
+
+static struct uuidmap_entry *get_entry_by_id_and_acquire(UUIDMAP_ID id) {
+    if(id == 0) return NULL;
+
+    uint8_t partition = uuidmap_id_to_partition(id);
+    rw_spinlock_read_lock(&uuid_map.p[partition].spinlock);
+
+    struct uuidmap_entry *ue = get_entry_by_id_locked(id, partition);
+    if(ue && !refcount_acquire(&ue->refcount))
+        ue = NULL;
 
     rw_spinlock_read_unlock(&uuid_map.p[partition].spinlock);
 
@@ -193,12 +198,17 @@ static struct uuidmap_entry *get_entry_by_id(UUIDMAP_ID id) {
 }
 
 void uuidmap_free(UUIDMAP_ID id) {
-    struct uuidmap_entry *ue = get_entry_by_id(id);
+    if(id == 0) return;
 
+    uint8_t partition = uuidmap_id_to_partition(id);
+    struct uuidmap_entry *ue = NULL;
+    bool should_delete = false;
+
+    rw_spinlock_write_lock(&uuid_map.p[partition].spinlock);
+
+    ue = get_entry_by_id_locked(id, partition);
     if(ue && refcount_release_and_acquire_for_deletion(&ue->refcount)) {
         JudyAllocThreadPulseReset();
-        uint8_t partition = uuidmap_id_to_partition(id);
-        rw_spinlock_write_lock(&uuid_map.p[partition].spinlock);
 
         int rc;
         rc = JudyHSDel(&uuid_map.p[partition].uuid_to_id, (void *)ue->uuid, sizeof(nd_uuid_t), PJE0);
@@ -213,35 +223,53 @@ void uuidmap_free(UUIDMAP_ID id) {
         uuid_map.p[partition].entries--;
 
         uuid_map.p[partition].memory += JudyAllocThreadPulseGetAndReset();
-        rw_spinlock_write_unlock(&uuid_map.p[partition].spinlock);
-
-        aral_freez(uuid_map.ar, ue);
+        should_delete = true;
     }
+
+    rw_spinlock_write_unlock(&uuid_map.p[partition].spinlock);
+
+    if(should_delete)
+        aral_freez(uuid_map.ar, ue);
 }
 
 nd_uuid_t *uuidmap_uuid_ptr(UUIDMAP_ID id) {
-    struct uuidmap_entry *ue = get_entry_by_id(id);
-    return ue ? &ue->uuid : NULL;
+    if(id == 0) return NULL;
+
+    uint8_t partition = uuidmap_id_to_partition(id);
+    rw_spinlock_read_lock(&uuid_map.p[partition].spinlock);
+
+    struct uuidmap_entry *ue = get_entry_by_id_locked(id, partition);
+    nd_uuid_t *uuid = ue ? &ue->uuid : NULL;
+
+    rw_spinlock_read_unlock(&uuid_map.p[partition].spinlock);
+
+    return uuid;
 }
 
 nd_uuid_t *uuidmap_uuid_ptr_and_dup(UUIDMAP_ID id) {
-    struct uuidmap_entry *ue = get_entry_by_id(id);
-
-    if(ue && refcount_acquire(&ue->refcount))
-        return &ue->uuid;
-
-    return NULL;
+    struct uuidmap_entry *ue = get_entry_by_id_and_acquire(id);
+    return ue ? &ue->uuid : NULL;
 }
 
 bool uuidmap_uuid(UUIDMAP_ID id, nd_uuid_t out_uuid) {
-    nd_uuid_t *uuid = uuidmap_uuid_ptr(id);
-
-    if(!uuid) {
+    if(id == 0) {
         nd_uuid_clear(out_uuid);
         return false;
     }
 
-    uuid_copy(out_uuid, *uuid);
+    uint8_t partition = uuidmap_id_to_partition(id);
+    rw_spinlock_read_lock(&uuid_map.p[partition].spinlock);
+
+    struct uuidmap_entry *ue = get_entry_by_id_locked(id, partition);
+    if(!ue) {
+        nd_uuid_clear(out_uuid);
+        rw_spinlock_read_unlock(&uuid_map.p[partition].spinlock);
+        return false;
+    }
+
+    uuid_copy(out_uuid, ue->uuid);
+    rw_spinlock_read_unlock(&uuid_map.p[partition].spinlock);
+
     return true;
 }
 
@@ -252,9 +280,9 @@ ND_UUID uuidmap_get(UUIDMAP_ID id) {
 }
 
 UUIDMAP_ID uuidmap_dup(UUIDMAP_ID id) {
-    struct uuidmap_entry *ue = get_entry_by_id(id);
+    struct uuidmap_entry *ue = get_entry_by_id_and_acquire(id);
 
-    if(!ue || !refcount_acquire(&ue->refcount))
+    if(!ue)
         fatal("UUIDMAP: id %u does not exist, or cannot be acquired, in %s", id, __FUNCTION__ );
 
     return id;

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -182,15 +182,21 @@ static struct uuidmap_entry *get_entry_by_id_locked(UUIDMAP_ID id, uint8_t parti
     return PValue ? *PValue : NULL;
 }
 
+static ALWAYS_INLINE struct uuidmap_entry *get_entry_by_id_locked_and_acquire(UUIDMAP_ID id, uint8_t partition) {
+    struct uuidmap_entry *ue = get_entry_by_id_locked(id, partition);
+    if(ue && !refcount_acquire(&ue->refcount))
+        ue = NULL;
+
+    return ue;
+}
+
 static struct uuidmap_entry *get_entry_by_id_and_acquire(UUIDMAP_ID id) {
     if(id == 0) return NULL;
 
     uint8_t partition = uuidmap_id_to_partition(id);
     rw_spinlock_read_lock(&uuid_map.p[partition].spinlock);
 
-    struct uuidmap_entry *ue = get_entry_by_id_locked(id, partition);
-    if(ue && !refcount_acquire(&ue->refcount))
-        ue = NULL;
+    struct uuidmap_entry *ue = get_entry_by_id_locked_and_acquire(id, partition);
 
     rw_spinlock_read_unlock(&uuid_map.p[partition].spinlock);
 
@@ -351,6 +357,135 @@ typedef struct thread_stats {
     size_t cycles;
 } THREAD_STATS;
 
+typedef struct uuidmap_delete_gate {
+    UUIDMAP_ID id;
+    uint8_t partition;
+    bool writer_blocked;
+    bool writer_unexpectedly_acquired;
+    bool allow_delete;
+    bool delete_done;
+} UUIDMAP_DELETE_GATE;
+
+static void uuidmap_deferred_free_thread(void *arg) {
+    UUIDMAP_DELETE_GATE *gate = arg;
+
+    if(rw_spinlock_trywrite_lock(&uuid_map.p[gate->partition].spinlock)) {
+        __atomic_store_n(&gate->writer_unexpectedly_acquired, true, __ATOMIC_RELEASE);
+        rw_spinlock_write_unlock(&uuid_map.p[gate->partition].spinlock);
+    }
+    else
+        __atomic_store_n(&gate->writer_blocked, true, __ATOMIC_RELEASE);
+
+    while(!__atomic_load_n(&gate->allow_delete, __ATOMIC_ACQUIRE))
+        tinysleep();
+
+    uuidmap_free(gate->id);
+    __atomic_store_n(&gate->delete_done, true, __ATOMIC_RELEASE);
+}
+
+static int uuidmap_locked_lookup_delete_interleaving_unittest(void) {
+    fprintf(stderr, "\nTesting UUID Map locked lookup/delete interleaving...\n");
+
+    nd_uuid_t test_uuid = {
+        0xf0, 0xde, 0xbc, 0x9a,
+        0x78, 0x56, 0x34, 0x12,
+        0xf0, 0xde, 0xbc, 0x9a,
+        0x78, 0x56, 0x34, 0x11
+    };
+
+    int errors = 0;
+    UUIDMAP_ID id = uuidmap_create(test_uuid);
+    if(!id) {
+        fprintf(stderr, "ERROR: Cannot create UUID for locked lookup/delete interleaving test\n");
+        return 1;
+    }
+
+    uint8_t partition = uuidmap_id_to_partition(id);
+    UUIDMAP_DELETE_GATE gate = {
+        .id = id,
+        .partition = partition,
+    };
+
+    rw_spinlock_read_lock(&uuid_map.p[partition].spinlock);
+
+    struct uuidmap_entry *ue = get_entry_by_id_locked(id, partition);
+    if(!ue) {
+        fprintf(stderr, "ERROR: Cannot find UUID after create in locked lookup/delete interleaving test\n");
+        errors++;
+    }
+
+    ND_THREAD *thread = nd_thread_create(
+        "UUID-DELETE-GATE",
+        NETDATA_THREAD_OPTION_DONT_LOG,
+        uuidmap_deferred_free_thread,
+        &gate);
+
+    usec_t deadline = now_monotonic_usec() + 5 * USEC_PER_SEC;
+    while(!__atomic_load_n(&gate.writer_blocked, __ATOMIC_ACQUIRE) &&
+          !__atomic_load_n(&gate.writer_unexpectedly_acquired, __ATOMIC_ACQUIRE) &&
+          now_monotonic_usec() < deadline)
+        tinysleep();
+
+    if(__atomic_load_n(&gate.writer_unexpectedly_acquired, __ATOMIC_ACQUIRE)) {
+        fprintf(stderr, "ERROR: UUID delete writer entered while lookup reader was locked\n");
+        errors++;
+    }
+
+    if(!__atomic_load_n(&gate.writer_blocked, __ATOMIC_ACQUIRE)) {
+        fprintf(stderr, "ERROR: UUID delete writer did not reach the blocked interleaving window\n");
+        errors++;
+    }
+
+    bool acquired_ref = false;
+    if(ue) {
+        struct uuidmap_entry *acquired = get_entry_by_id_locked_and_acquire(id, partition);
+        if(acquired != ue) {
+            fprintf(stderr, "ERROR: Locked lookup/acquire returned unexpected UUID entry\n");
+            errors++;
+        }
+        else
+            acquired_ref = true;
+    }
+
+    rw_spinlock_read_unlock(&uuid_map.p[partition].spinlock);
+
+    __atomic_store_n(&gate.allow_delete, true, __ATOMIC_RELEASE);
+    nd_thread_join(thread);
+
+    if(!__atomic_load_n(&gate.delete_done, __ATOMIC_ACQUIRE)) {
+        fprintf(stderr, "ERROR: UUID delete helper did not complete\n");
+        errors++;
+    }
+
+    if(acquired_ref) {
+        nd_uuid_t found_uuid;
+        if(!uuidmap_uuid(id, found_uuid)) {
+            fprintf(stderr, "ERROR: UUID disappeared despite locked refcount acquire\n");
+            errors++;
+        }
+        else if(uuid_compare(found_uuid, test_uuid) != 0) {
+            fprintf(stderr, "ERROR: UUID changed after locked lookup/delete interleaving\n");
+            errors++;
+        }
+
+        uuidmap_free(id);
+    }
+
+    nd_uuid_t found_uuid;
+    if(uuidmap_uuid(id, found_uuid)) {
+        fprintf(stderr, "ERROR: UUID still exists after releasing locked interleaving reference\n");
+        errors++;
+        uuidmap_free(id);
+    }
+
+    if(errors)
+        fprintf(stderr, "UUID Map locked lookup/delete interleaving test: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "UUID Map locked lookup/delete interleaving test: OK\n");
+
+    return errors;
+}
+
 static void concurrent_test_thread(void *arg) {
     THREAD_STATS *stats = arg;
     nd_uuid_t test_uuid = {
@@ -465,7 +600,8 @@ int uuidmap_unittest(void) {
     fprintf(stderr, "\nTesting UUID Map...\n");
 
     const size_t ENTRIES = 100000;
-    int errors = uuidmap_concurrent_unittest();
+    int errors = uuidmap_locked_lookup_delete_interleaving_unittest();
+    errors += uuidmap_concurrent_unittest();
 
     struct test_entry {
         nd_uuid_t uuid;

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -419,6 +419,12 @@ static int uuidmap_locked_lookup_delete_interleaving_unittest(void) {
         NETDATA_THREAD_OPTION_DONT_LOG,
         uuidmap_deferred_free_thread,
         &gate);
+    if(!thread) {
+        fprintf(stderr, "ERROR: Cannot create delete helper thread in locked lookup/delete interleaving test\n");
+        rw_spinlock_read_unlock(&uuid_map.p[partition].spinlock);
+        uuidmap_free(id);
+        return errors + 1;
+    }
 
     usec_t deadline = now_monotonic_usec() + 5 * USEC_PER_SEC;
     while(!__atomic_load_n(&gate.writer_blocked, __ATOMIC_ACQUIRE) &&

--- a/src/web/mcp/bridges/stdio-golang/nd-mcp.go
+++ b/src/web/mcp/bridges/stdio-golang/nd-mcp.go
@@ -290,11 +290,10 @@ func main() {
 	maxDelay := 60 * time.Second
 	attempt := 0
 
-	// Timer for reconnection backoff
-	var timer *time.Timer
 	stdinClosedNotify := (<-chan struct{})(stdinClosedCh)
 
 	// Main connection loop
+connectionLoop:
 	for {
 		select {
 		case <-doneCh:
@@ -305,49 +304,43 @@ func main() {
 			// and then exit on the next reconnection attempt
 			stdinClosedNotify = nil // Prevent duplicate handling
 		case <-reconnectCh:
-			// Immediate reconnection requested (e.g. from stdin activity)
-			if timer != nil {
-				timer.Stop()
-			}
-
+			// Stdin activity may wake an idle disconnected bridge.
 			// Only proceed with immediate reconnection if we're not already connecting/connected
 			stateMu.Lock()
 			currentState := state
 			stateMu.Unlock()
 
-			if currentState == stateDisconnected {
-				// Reset the reconnection timer
-				attempt = 0
-				// Fall through to connection attempt
-			} else {
+			if currentState != stateDisconnected {
 				// Already connecting or connected
 				continue
 			}
 		default:
-			// Calculate backoff delay with jitter
-			if attempt > 0 {
-				// Check if stdin is closed and we're disconnected - if so, exit
-				if !stdinActive {
-					fmt.Fprintf(os.Stderr, "%s: Stdin closed and disconnected, exiting\n", programName)
-					return
-				}
+		}
 
-				delaySeconds := math.Min(float64(maxDelay.Seconds()),
-					float64(baseDelay.Seconds())*math.Pow(2, float64(attempt-1))*(0.5+jitter()))
-				delay := time.Duration(delaySeconds * float64(time.Second))
+		// Calculate backoff delay with jitter
+		if attempt > 0 {
+			// Check if stdin is closed and we're disconnected - if so, exit
+			if !stdinActive {
+				fmt.Fprintf(os.Stderr, "%s: Stdin closed and disconnected, exiting\n", programName)
+				return
+			}
 
-				fmt.Fprintf(os.Stderr, "%s: Reconnecting in %.1f seconds (attempt %d)...\n",
-					programName, delaySeconds, attempt)
+			delaySeconds := math.Min(float64(maxDelay.Seconds()),
+				float64(baseDelay.Seconds())*math.Pow(2, float64(attempt-1))*(0.5+jitter()))
+			delay := time.Duration(delaySeconds * float64(time.Second))
 
-				// Create timer and wait for it to expire, or for signals
-				timer = time.NewTimer(delay)
+			fmt.Fprintf(os.Stderr, "%s: Reconnecting in %.1f seconds (attempt %d)...\n",
+				programName, delaySeconds, attempt)
 
+			// Create timer and wait for it to expire, or for shutdown signals.
+			timer := time.NewTimer(delay)
+
+		backoffWait:
+			for {
 				select {
 				case <-timer.C:
 					// Timer expired, continue to connection attempt
-				case <-reconnectCh:
-					// Immediate reconnection requested
-					timer.Stop()
+					break backoffWait
 				case <-doneCh:
 					// Program termination requested
 					timer.Stop()
@@ -356,7 +349,7 @@ func main() {
 					// Stdin closed
 					timer.Stop()
 					stdinClosedNotify = nil
-					continue
+					continue connectionLoop
 				}
 			}
 		}
@@ -469,9 +462,6 @@ func main() {
 				// Clean up the connection
 				conn.Close(websocket.StatusNormalClosure, "Shutdown requested")
 				cancel()
-				return
-			case <-stdinClosedCh:
-				// Stdin closed, but keep connection active
 				return
 			}
 		}()

--- a/src/web/mcp/bridges/stdio-golang/nd-mcp.go
+++ b/src/web/mcp/bridges/stdio-golang/nd-mcp.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -127,7 +128,8 @@ func main() {
 	var stateMu sync.Mutex
 	var messageQueueMu sync.Mutex
 	messageQueue := []string{}
-	stdinActive := true
+	var stdinActive atomic.Bool
+	stdinActive.Store(true)
 
 	// Pending requests that are waiting for connection to be established
 	var pendingMu sync.Mutex
@@ -281,7 +283,7 @@ func main() {
 		}
 
 		// Signal that stdin is closed
-		stdinActive = false
+		stdinActive.Store(false)
 		close(stdinClosedCh)
 	}()
 
@@ -320,7 +322,7 @@ connectionLoop:
 		// Calculate backoff delay with jitter
 		if attempt > 0 {
 			// Check if stdin is closed and we're disconnected - if so, exit
-			if !stdinActive {
+			if !stdinActive.Load() {
 				fmt.Fprintf(os.Stderr, "%s: Stdin closed and disconnected, exiting\n", programName)
 				return
 			}
@@ -626,7 +628,7 @@ connectionLoop:
 		hasMessages := len(messageQueue) > 0
 		messageQueueMu.Unlock()
 
-		if !stdinActive && !hasMessages {
+		if !stdinActive.Load() && !hasMessages {
 			fmt.Fprintf(os.Stderr, "%s: Stdin closed and no pending messages, exiting\n", programName)
 			return
 		}

--- a/src/web/mcp/bridges/stdio-golang/nd-mcp.go
+++ b/src/web/mcp/bridges/stdio-golang/nd-mcp.go
@@ -316,6 +316,10 @@ connectionLoop:
 				// Already connecting or connected
 				continue
 			}
+			// Disconnected: fall through to the backoff block below. We
+			// intentionally do NOT reset attempt here -- reconnect
+			// notifications are wakeups only, so stdin activity cannot bypass
+			// exponential backoff and cause a reconnect storm.
 		default:
 		}
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory-safety race in the UUID map and restores reliable reconnect/backoff and shutdown behavior in the Go MCP stdio bridge. No API or functional changes for normal operation.

- **Bug Fixes**
  - UUID map (C): perform lookup and refcount acquire under the partition read lock; free/delete under the write lock; copy UUID bytes while holding the read lock; handle id==0 early. Removes a use-after-free window during concurrent free/dup/copy.
  - UUID map tests: add a deterministic locked lookup/delete interleaving test that proves a ref acquired under the read lock keeps the entry alive through delete; handle helper thread creation failure and clean up safely.
  - MCP stdio bridge (Go): keep exponential backoff intact—stdin activity wakes a disconnected bridge but no longer cancels or resets the delay; during backoff, only the timer, shutdown, or stdin close end the wait; the session watcher stays until ctx.Done() or global shutdown so the websocket closes on shutdown even after stdin closes; make stdin lifecycle flag `sync/atomic.Bool` to remove a data race.

<sup>Written for commit bd7c4f7b541b11f4944553b4a6246107c0206336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

