### PR TITLE
refactor(go.d): route jobmgr scheduling through command plans

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -219,12 +219,27 @@ disable can answer from `Entry.Status`, and that status is mutated by
 secretstore dependent restart plans. When the collector key is
 foreign-write-held, these commands park and answer after the hold resolves.
 
-The predicates that decide this are colocated with the command gates:
+Command planning rules:
 
-- collector: `dyncfg.Handler.CommandActs` and
-  `RejectionDependsOnStatus`;
-- secretstore: `secretsctl.Controller.CommandActs`;
-- vnode: `vnodectl.Controller.CommandActs`.
+- Domain ownership:
+  - collector commands use `dyncfg.Handler.CommandPlan`;
+  - secretstore commands use `secretsctl.Controller.CommandPlan`;
+  - vnode commands use `vnodectl.Controller.CommandPlan`.
+- Plan classes:
+  - claimless commands answer without claim-table serialization;
+  - hold-aware claimless commands normally answer without claims, but park
+    behind a foreign write hold;
+  - claimed commands acquire their claim set before the first claim-protected
+    access.
+- Executor ownership:
+  - wraps the domain command plan in a jobmgr-local event plan;
+  - owns event-level routing and claim-key computation;
+  - uses `CommandPlan.NeedsClaims(false)` for intrinsic claim acquisition;
+  - uses `CommandPlan.NeedsClaims(true)` to decide foreign write-hold bypass;
+  - re-runs claim computation at every claim-table restage.
+
+Because claim computation is dynamic, a parked command can become claimless or
+change dependencies before it acts.
 
 ## Domain Flows
 
@@ -447,8 +462,7 @@ The test suite should be read as a set of matrices, not as isolated tests.
 
 Do not try to test the full Cartesian product. The useful target is
 equivalence-class coverage: one test per behavior boundary, plus parity
-tests that fail when a command gate moves without updating the scheduler
-predicate.
+tests that fail when a command gate moves without updating the command plan.
 
 ### Existing Coverage Anchors
 
@@ -464,7 +478,7 @@ predicate.
 | Vnode and cross-domain claim interactions | `vnode_claims_test.go`, `dyncfg_vnode_test.go` |
 | Deadline, wedge, shutdown one-rule | `effect_deadline_test.go`, `effect_test.go`, `executor_test.go` |
 | Function publication timing | `manager_process_test.go`, `funcdispatch_test.go`, `funcctl/*_test.go` |
-| CommandActs parity | `handler_test.go`, `secretsctl/commandacts_test.go`, `vnodectl/commandacts_test.go` |
+| Command-plan parity | `handler_test.go`, `secretsctl/commandplan_test.go`, `vnodectl/commandplan_test.go`, `executor_test.go` |
 
 ### Known Test-Gap Classes
 
@@ -474,14 +488,13 @@ hardening should focus.
 | Gap class | Current state | Suggested next test shape |
 | --- | --- | --- |
 | Human-readable matrix | Coverage exists but is spread across many files. | Keep this section current when adding a command or state. |
-| Integrated hold-aware status commands | End-to-end pin covers enable during a dependent restart; handler unit tests classify enable/restart/disable. | Add table-driven end-to-end rows for restart and disable under a foreign dependent write hold if more pre-PR hardening is requested. |
 | Unsupported/inline command parity | End-to-end rejection pins exist for representative unsupported store/vnode commands; per-domain parity tables are not a full unsupported-command census. | Extend parity tables when command support changes, especially for unsupported commands that should remain claimless. |
 | Pairwise cross-domain interleavings | Representative read/write conflicts are pinned; every command pair is not enumerated. | Add pairwise tests only when a new claim mode or new cross-key writer is introduced. |
 | Shutdown matrix by every command | Shutdown one-rule is pinned at the main chokepoints and representative commands. | Add command-specific shutdown rows only when a command adds a new effect phase or publication path. |
 
 When adding tests, prefer:
 
-- table-driven gate parity tests for deterministic command predicates;
+- table-driven gate parity tests for deterministic command plans;
 - property tests for claim-table ordering rules;
 - end-to-end choreography only for cross-domain ordering or publication
-  outcomes that cannot be proven at the predicate/unit layer.
+  outcomes that cannot be proven at the plan/unit layer.

--- a/src/go/plugin/agent/jobmgr/command_plan.go
+++ b/src/go/plugin/agent/jobmgr/command_plan.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import "github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+
+// eventPlan is the executor-local scheduling plan for one event. Domain
+// controllers describe command shape; jobmgr attaches claim computation because
+// claim keys and modes are executor-owned.
+type eventPlan struct {
+	command dyncfg.CommandPlan
+	claims  func() []claim
+}
+
+func newClaimlessEventPlan() eventPlan {
+	return eventPlan{command: dyncfg.CommandPlanClaimless()}
+}
+
+func newClaimedEventPlan(claims func() []claim) eventPlan {
+	return eventPlan{command: dyncfg.CommandPlanClaims(), claims: claims}
+}
+
+func newDyncfgEventPlan(command dyncfg.CommandPlan, claims func() []claim) eventPlan {
+	return eventPlan{command: command, claims: claims}
+}
+
+func (p eventPlan) needsClaims() bool {
+	return p.command.NeedsClaims(false)
+}
+
+func (p eventPlan) bypassesForeignWriteHold() bool {
+	return !p.command.NeedsClaims(true)
+}
+
+func (p eventPlan) computeClaims() []claim {
+	if !p.needsClaims() || p.claims == nil {
+		return nil
+	}
+	return p.claims()
+}
+
+func (e *executor) planEvent(ev event) eventPlan {
+	switch ev.kind {
+	case eventDiscoveryAdd, eventDiscoveryRemove:
+		return newClaimedEventPlan(func() []claim { return e.eventClaims(ev) })
+	case eventDyncfgCommand:
+		return e.planDyncfgCommand(ev)
+	default:
+		return newClaimlessEventPlan()
+	}
+}
+
+func (e *executor) planDyncfgCommand(ev event) eventPlan {
+	if ev.underivable {
+		return newClaimlessEventPlan()
+	}
+
+	var plan dyncfg.CommandPlan
+	switch ev.domain {
+	case domainSecretStore:
+		plan = e.mgr.secretsCtl.CommandPlan(ev.fn)
+	case domainVnode:
+		plan = e.mgr.vnodesCtl.CommandPlan(ev.fn)
+	case domainCollector:
+		entry, ok := e.mgr.collectorExposed.LookupByKey(ev.key)
+		if !ok {
+			entry = nil
+		}
+		plan = e.mgr.collectorHandler.CommandPlan(ev.fn, entry)
+	default:
+		return newClaimlessEventPlan()
+	}
+
+	return newDyncfgEventPlan(plan, func() []claim { return e.eventClaims(ev) })
+}

--- a/src/go/plugin/agent/jobmgr/doc.go
+++ b/src/go/plugin/agent/jobmgr/doc.go
@@ -29,21 +29,20 @@
 //     rejection or no-op BEFORE its first claim-protected access (identity,
 //     existence, state, source/type, payload-presence, and command-support
 //     gates) executes claimless-inline instead of parking behind held keys
-//     with no bounded release. Each DOMAIN owns its acts-predicate,
-//     colocated with the gates it mirrors and enforced by that domain's
-//     parity test: dyncfg.Handler.CommandActs (collector), secretsctl and
-//     vnodectl Controller.CommandActs. Execution order is the criterion,
-//     not the eventual outcome: gates that need the claim's exclusion - and
-//     every gate execution orders BEHIND them - answer inline under the
-//     granted claim (the store remove's affected-jobs 409 plus its trailing
-//     source/type 405s; the vnode remove's referenced-by-configs 409). The
-//     STATUS axis is HOLD-AWARE: enable/restart/disable rejections and
-//     no-ops derive from entry.Status, the one input a foreign write-claim
-//     holder (a store command's dependent-restart plan) mutates - while
-//     the command's key is foreign-write-held they are treated as ACTING,
-//     park, and answer truthfully after the hold resolves. Same-key order
-//     is preserved: the route bypass fires only on an unoccupied lane with
-//     an empty FIFO.
+//     with no bounded release. Each DOMAIN owns its CommandPlan, colocated
+//     with the command gates and pinned by parity tests; the executor wraps it
+//     in a jobmgr-local event plan that attaches claim computation. Execution
+//     order is the criterion, not the eventual outcome: gates that need the
+//     claim's exclusion - and every gate execution orders BEHIND them - answer
+//     inline under the granted claim (the store remove's affected-jobs 409
+//     plus its trailing source/type 405s; the vnode remove's
+//     referenced-by-configs 409). The STATUS axis is HOLD-AWARE:
+//     enable/restart/disable rejections and no-ops derive from entry.Status,
+//     the one input a foreign write-claim holder (a store command's
+//     dependent-restart plan) mutates - while the command's key is
+//     foreign-write-held they park and answer truthfully after the hold
+//     resolves. Same-key order is preserved: the route bypass fires only on
+//     an unoccupied lane with an empty FIFO.
 //
 //   - Blocking module work (validation, job creation, detection, stop waits,
 //     secretstore backend I/O, dependent-job restarts) runs on the effect

--- a/src/go/plugin/agent/jobmgr/executor.go
+++ b/src/go/plugin/agent/jobmgr/executor.go
@@ -183,7 +183,7 @@ func (e *executor) dispatch(ev event) {
 func (e *executor) route(sk string, ks *keyState, ev event) {
 	if ks.occupied() || e.claims.heldForWrite(sk) {
 		if !ks.occupied() && len(ks.fifo) == 0 &&
-			ev.kind == eventDyncfgCommand && !e.dyncfgCommandActs(ev) {
+			ev.kind == eventDyncfgCommand && e.planEvent(ev).bypassesForeignWriteHold() {
 			// A deterministic rejection/no-op arriving under a FOREIGN write
 			// hold (a store command's claim on this dependent job key):
 			// answer it claimless-inline instead of parking it behind a hold
@@ -253,7 +253,8 @@ func (e *executor) execute(sk string, ks *keyState, ev event) {
 		e.refuseAtShutdown(ev)
 		return
 	}
-	if !e.eventNeedsClaims(ev) {
+	plan := e.planEvent(ev)
+	if !plan.needsClaims() {
 		e.executeEvent(sk, ks, ev)
 		return
 	}
@@ -262,7 +263,7 @@ func (e *executor) execute(sk string, ks *keyState, ev event) {
 	// occupied through the acquisition so same-key events keep their order.
 	req := &claimRequest{
 		label:   claimLabel(ev),
-		compute: func() []claim { return e.collectorEventClaims(ev) },
+		compute: func() []claim { return e.planEvent(ev).computeClaims() },
 	}
 	req.granted = func(g *claimGrant) {
 		delete(e.claimWork, req)
@@ -352,76 +353,6 @@ func (e *executor) finishIfSettled(sk string, ks *keyState) {
 	e.claims.release(g)
 }
 
-// eventNeedsClaims reports whether the event reaches a phase that mutates
-// state or runs blocking work: those events reserve claims. Discovery
-// events always act; dyncfg commands consult their domain's acts predicate
-// - rejection-only commands (and cheap read commands: get, schema,
-// userconfig) run claimless-inline against loop-owned state.
-func (e *executor) eventNeedsClaims(ev event) bool {
-	switch ev.kind {
-	case eventDiscoveryAdd, eventDiscoveryRemove:
-		return true
-	case eventDyncfgCommand:
-		return e.dyncfgCommandActs(ev)
-	}
-	return false
-}
-
-// dyncfgCommandActs reports whether a dyncfg command reaches a phase that
-// mutates state or runs blocking work, per its DOMAIN's own predicate -
-// each colocated with the gates it mirrors and enforced by that domain's
-// parity test (Handler.CommandActs for collector commands incl. the
-// payload axis; the secretsctl and vnodectl Controller.CommandActs for
-// their stage gates and 501 arms). Rejection-only commands claim NOTHING
-// and bypass foreign-hold lane parking: a rejection execution reaches
-// BEFORE its first claim-protected access (identity/underivable,
-// existence, payload, command-support, and most source/type gates) answers
-// immediately instead of parking behind held dependencies, where a wedged
-// store's write claim has no bounded release. STATUS-derived
-// rejections/no-ops are immediate only when this key is not foreign
-// write-held; under a foreign write hold the status is being mutated, so
-// the command parks and answers after the hold resolves. Gates execution
-// orders BEHIND a claim-protected read answer under the granted claim
-// instead - the store remove's source/type 405s sit behind its
-// affected-jobs read. Evaluated on the loop and re-evaluated at every
-// (re-)stage attempt.
-func (e *executor) dyncfgCommandActs(ev event) bool {
-	if ev.underivable {
-		// Rejection-only by construction: the handler answers 400/404/405
-		// without touching state.
-		return false
-	}
-	m := e.mgr
-	switch ev.domain {
-	case domainSecretStore:
-		return m.secretsCtl.CommandActs(ev.fn)
-	case domainVnode:
-		return m.vnodesCtl.CommandActs(ev.fn)
-	default:
-		// Collector test never reaches the lanes (keyless, diverted at
-		// dispatch); get/schema report false from the handler predicate.
-		entry, ok := m.collectorExposed.LookupByKey(ev.key)
-		if !ok {
-			entry = nil
-		}
-		if m.collectorHandler.CommandActs(ev.fn, entry) {
-			return true
-		}
-		// HOLD-AWARE STATUS GATES: a STATUS-derived rejection/no-op is
-		// deterministic only while no foreign write claim holds this key -
-		// the only cross-key write claimer (a store command's
-		// dependent-restart plan) mutates exactly entry.Status, so an
-		// answer minted from it mid-hold can be falsified by the holder's
-		// outcome (a false-success enable during a failing restart). Such
-		// commands are treated as ACTING while held: they park and answer
-		// truthfully after the hold resolves - under a wedged holder that
-		// is the late return, per key-held-until-return. Every immutable
-		// rejection axis keeps the bypass.
-		return m.collectorHandler.RejectionDependsOnStatus(ev.fn, entry) &&
-			e.claims.heldForWrite(ev.stateKey())
-	}
-}
-
 func claimLabel(ev event) string {
 	if ev.kind == eventDyncfgCommand {
 		return string(ev.fn.Command()) + " " + ev.key
@@ -429,7 +360,7 @@ func claimLabel(ev event) string {
 	return "discovery " + ev.key
 }
 
-// collectorEventClaims computes an event's reservation set.
+// eventClaims computes an event's reservation set.
 //
 // Collector events: a write claim on their own lane key plus read claims on
 // every referenced secret store and the referenced vnode. Update-shaped
@@ -447,15 +378,8 @@ func claimLabel(ev event) string {
 // rejection-only while parked (its entry removed, its store deleted)
 // recomputes to the EMPTY set, which grants immediately and lets it answer
 // its rejection inline.
-func (e *executor) collectorEventClaims(ev event) []claim {
+func (e *executor) eventClaims(ev event) []claim {
 	m := e.mgr
-
-	if ev.kind == eventDyncfgCommand && !e.dyncfgCommandActs(ev) {
-		// Rejection-only commands claim NOTHING - not even their lane key
-		// (see dyncfgCommandActs; arrival-time rejections never reach this
-		// compute, eventNeedsClaims filters them to claimless-inline).
-		return nil
-	}
 
 	if ev.kind == eventDyncfgCommand && ev.domain == domainSecretStore {
 		if ev.fn.Command() == dyncfg.CommandTest {
@@ -514,10 +438,9 @@ func (e *executor) collectorEventClaims(ev event) []claim {
 		// must wait the stop out instead of racing it.
 		addExposedRefs()
 	case eventDyncfgCommand:
-		// Only ACTING commands reach here (the rejection-only guard above,
-		// backed by the per-domain CommandActs predicates and their parity
-		// tests, filtered the rest): every acting mutation claims its
-		// config's references - old and new where both exist.
+		// Only claim-bearing commands reach here (the event plan filtered the
+		// rest): every acting collector mutation claims its config's
+		// references - old and new where both exist.
 		switch ev.fn.Command() {
 		case dyncfg.CommandAdd, dyncfg.CommandUpdate:
 			addPayloadRefs()

--- a/src/go/plugin/agent/jobmgr/executor_test.go
+++ b/src/go/plugin/agent/jobmgr/executor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/internal/wiretest"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
@@ -218,6 +219,134 @@ func TestExecutor_KeyDerivation(t *testing.T) {
 
 			assert.Equal(t, tc.wantDomain, ev.domain)
 			assert.Equal(t, tc.wantKey, ev.key)
+		})
+	}
+}
+
+func TestExecutor_CommandPlanClaims(t *testing.T) {
+	storeKey := secretstore.StoreKey(secretstore.KindVault, "vault_prod")
+	seedStore := func(t *testing.T, mgr *Manager) {
+		t.Helper()
+		mgr.dyncfgSecretStoreSeqExec(newExecutorTestFn("seed-store",
+			[]string{"test:secretstore:vault", "add", "vault_prod"},
+			mustJSON(t, map[string]any{"value": "secret"})))
+	}
+	claimSet := func(plan eventPlan) []claim {
+		return normalizeClaims(plan.computeClaims())
+	}
+
+	tests := map[string]struct {
+		setup func(t *testing.T, mgr *Manager)
+		event func(t *testing.T, mgr *Manager) event
+		check func(t *testing.T, plan eventPlan, claims []claim)
+	}{
+		"collector update claims old and new refs": {
+			setup: func(t *testing.T, mgr *Manager) {
+				oldCfg := prepareDyncfgCfg("success", "job").
+					Set("password", "${store:vault:vault_old:secret/data/mysql#password}").
+					Set("vnode", "oldvn")
+				mgr.collectorExposed.Add(&dyncfg.Entry[confgroup.Config]{Cfg: oldCfg, Status: dyncfg.StatusRunning})
+			},
+			event: func(t *testing.T, mgr *Manager) event {
+				newCfg := prepareDyncfgCfg("success", "job").
+					Set("password", "${store:vault:vault_new:secret/data/mysql#password}").
+					Set("vnode", "newvn")
+				return mgr.newDyncfgEvent(newExecutorTestFn("collector-update",
+					[]string{"test:collector:success:job", "update"},
+					mustJSON(t, newCfg)))
+			},
+			check: func(t *testing.T, plan eventPlan, claims []claim) {
+				assert.True(t, plan.needsClaims())
+				assert.Equal(t, normalizeClaims([]claim{
+					{key: collectorStateKey("success_job"), mode: claimWrite},
+					{key: secretStoreStateKey("vault:vault_old"), mode: claimRead},
+					{key: secretStoreStateKey("vault:vault_new"), mode: claimRead},
+					{key: vnodeStateKey("oldvn"), mode: claimRead},
+					{key: vnodeStateKey("newvn"), mode: claimRead},
+				}), claims)
+			},
+		},
+		"collector status no-op is hold-aware claimless": {
+			setup: func(t *testing.T, mgr *Manager) {
+				cfg := prepareDyncfgCfg("success", "job")
+				mgr.collectorExposed.Add(&dyncfg.Entry[confgroup.Config]{Cfg: cfg, Status: dyncfg.StatusRunning})
+			},
+			event: func(t *testing.T, mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("collector-enable",
+					[]string{"test:collector:success:job", "enable"}, nil))
+			},
+			check: func(t *testing.T, plan eventPlan, claims []claim) {
+				assert.False(t, plan.needsClaims())
+				assert.False(t, plan.bypassesForeignWriteHold())
+				assert.Empty(t, claims)
+			},
+		},
+		"secretstore test claims store read": {
+			setup: seedStore,
+			event: func(t *testing.T, mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("store-test",
+					[]string{"test:secretstore:vault:vault_prod", "test"}, nil))
+			},
+			check: func(t *testing.T, plan eventPlan, claims []claim) {
+				assert.True(t, plan.needsClaims())
+				assert.Equal(t, []claim{{key: secretStoreStateKey(storeKey), mode: claimRead}}, claims)
+			},
+		},
+		"secretstore update claims store write and dependent writes": {
+			setup: func(t *testing.T, mgr *Manager) {
+				seedStore(t, mgr)
+				cfg := prepareDyncfgCfg("success", "dep").
+					Set("password", "${store:vault:vault_prod:secret/data/mysql#password}")
+				mgr.collectorExposed.Add(&dyncfg.Entry[confgroup.Config]{Cfg: cfg, Status: dyncfg.StatusRunning})
+				mgr.secretStoreDeps.SetActiveJobStores(cfg.FullName(), cfg.ExposedKey(), []string{storeKey})
+			},
+			event: func(t *testing.T, mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("store-update",
+					[]string{"test:secretstore:vault:vault_prod", "update"},
+					mustJSON(t, map[string]any{"value": "rotated"})))
+			},
+			check: func(t *testing.T, plan eventPlan, claims []claim) {
+				assert.True(t, plan.needsClaims())
+				assert.Equal(t, normalizeClaims([]claim{
+					{key: secretStoreStateKey(storeKey), mode: claimWrite},
+					{key: collectorStateKey("success_dep"), mode: claimWrite},
+				}), claims)
+			},
+		},
+		"vnode mutation claims vnode write": {
+			event: func(t *testing.T, mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("vnode-add",
+					[]string{"test:vnode", "add", "db"},
+					mustJSON(t, map[string]any{"guid": "b0b0b0b0-0000-4000-8000-0000000000aa", "hostname": "db"})))
+			},
+			check: func(t *testing.T, plan eventPlan, claims []claim) {
+				assert.True(t, plan.needsClaims())
+				assert.Equal(t, []claim{{key: vnodeStateKey("db"), mode: claimWrite}}, claims)
+			},
+		},
+		"underivable command is claimless": {
+			event: func(t *testing.T, mgr *Manager) event {
+				return mgr.newDyncfgEvent(newExecutorTestFn("bad",
+					[]string{"test:collector:success", "add"}, nil))
+			},
+			check: func(t *testing.T, plan eventPlan, claims []claim) {
+				assert.False(t, plan.needsClaims())
+				assert.True(t, plan.bypassesForeignWriteHold())
+				assert.Empty(t, claims)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr, _ := newExecutorTestManager()
+			if tc.setup != nil {
+				tc.setup(t, mgr)
+			}
+
+			ev := tc.event(t, mgr)
+			plan := mgr.executor.planEvent(ev)
+			tc.check(t, plan, claimSet(plan))
 		})
 	}
 }

--- a/src/go/plugin/agent/jobmgr/secretsctl/commandplan_test.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/commandplan_test.go
@@ -15,18 +15,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestControllerCommandActsParity drives StepExec across the deterministic
-// stage-gate matrix and asserts CommandActs agrees: blocking work runs (the
-// step runner is invoked) exactly when CommandActs reports true. Claim
-// scheduling relies on this predicate to skip claims for rejection-only
-// store commands - a stage-gate change without a matching CommandActs update
-// fails here as the starvation bug it would be. The deliberate exception
-// class: remove of any EXISTING store "acts" even when it will reject -
-// its affected-jobs check reads the dependency index, which must be
-// excluded by the granted store write claim, so that 409 AND the handler's
-// source/type 405s ordered behind it answer under the claim without
-// blocking work - those cells assert the exception explicitly via wantRan.
-func TestControllerCommandActsParity(t *testing.T) {
+// TestControllerCommandPlanParity drives StepExec across the deterministic
+// stage-gate matrix and asserts CommandPlan agrees: blocking work runs (the
+// step runner is invoked) exactly when the plan reports intrinsic claims. The
+// deliberate exception class: remove of any EXISTING store "acts" even when it
+// will reject - its affected-jobs check reads the dependency index, which must
+// be excluded by the granted store write claim, so that 409 AND the handler's
+// source/type 405s ordered behind it answer under the claim without blocking
+// work - those cells assert the exception explicitly via wantRan.
+func TestControllerCommandPlanParity(t *testing.T) {
 	const storeName = "vault_prod"
 	storeKey := secretstore.StoreKey(secretstore.KindVault, storeName)
 	garbagePayload := []byte(`{"value": `)
@@ -275,10 +272,12 @@ func TestControllerCommandActsParity(t *testing.T) {
 
 			fn := tc.fn(t, ctl)
 
-			// Capture the predicate BEFORE running: execution mutates the
-			// caches, and the executor consults the predicate pre-execution.
-			acts := ctl.CommandActs(fn)
-			assert.Equal(t, tc.wantActs, acts, "CommandActs")
+			// Capture the plan BEFORE running: execution mutates the caches,
+			// and the executor consults the plan pre-execution.
+			plan := ctl.CommandPlan(fn)
+			assert.Equal(t, tc.wantActs, plan.NeedsClaims(false), "CommandPlan")
+			assert.Equal(t, tc.wantActs, plan.NeedsClaims(true),
+				"store commands have no status-hold-aware axis")
 
 			ran := false
 			ctl.StepExec(fn, func(effect func(context.Context) error, commit func(error)) {
@@ -286,7 +285,7 @@ func TestControllerCommandActsParity(t *testing.T) {
 				dyncfg.RunStepSync(effect, commit)
 			})
 
-			wantRan := acts
+			wantRan := plan.NeedsClaims(false)
 			if tc.wantRan != nil {
 				wantRan = *tc.wantRan
 			}

--- a/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/secretsctl/dyncfg.go
@@ -60,87 +60,87 @@ func (c *Controller) StepExec(fn dyncfg.Function, run dyncfg.StepRunner) {
 	}
 }
 
-// CommandActs reports whether fn may execute CLAIMLESSLY: false only when
-// execution answers a deterministic rejection BEFORE its first
-// claim-protected access - an unsupported command (the 501 arm above), a
-// missing store, an existing store on add, or a missing/unparsable
-// payload. Claim scheduling consults it so rejection-only store commands
-// claim nothing instead of parking behind held keys with no bounded
-// release; it mirrors the stage gates of the Step functions in this file
-// plus the shared handler's gates (via handler.CommandActs), and the
-// parity test drives StepExec against it. The remove arm consults ONLY the
-// shared pre-claim gate prefix (removeRejection): its affected-jobs check
-// reads the dependency index, which must be excluded by the granted store
-// write claim (no new reference can appear once the claim is held), so
-// EVERY remove gate from that read onward - the 409 and the handler's
-// source/type 405s ordered behind it - answers under the claim, and a
-// remove of any EXISTING store "acts" even when it will answer a rejection
-// inline.
-func (c *Controller) CommandActs(fn dyncfg.Function) bool {
+// CommandPlan reports how fn must be scheduled. Claimless means execution
+// answers a deterministic rejection before its first claim-protected access.
+// The remove arm consults only the pre-claim gate prefix (removeRejection):
+// its affected-jobs check reads the dependency index, so every gate from that
+// read onward answers under the granted store write claim.
+func (c *Controller) CommandPlan(fn dyncfg.Function) dyncfg.CommandPlan {
 	switch fn.Command() {
 	case dyncfg.CommandAdd:
 		if fn.ValidateArgs(3) != nil {
-			return false
+			return dyncfg.CommandPlanClaimless()
 		}
 		key, name, ok := c.cb.ExtractKey(fn)
 		if !ok {
-			return false
+			return dyncfg.CommandPlanClaimless()
 		}
 		if _, exists := c.lookup(key); exists {
-			return false
+			return dyncfg.CommandPlanClaimless()
 		}
 		if fn.ValidateHasPayload() != nil {
-			return false
+			return dyncfg.CommandPlanClaimless()
 		}
 		if dyncfg.JobNameRuleAllowDots(name) != nil {
-			return false
+			return dyncfg.CommandPlanClaimless()
 		}
 		kind, ok := c.dyncfgExtractSecretStoreKindFromTemplateID(fn.ID())
 		if !ok {
-			return false
+			return dyncfg.CommandPlanClaimless()
 		}
 		cfg, err := c.dyncfgSecretStoreConfigFromPayload(fn, name, kind)
-		return err == nil && cfg.Validate() == nil
+		if err == nil && cfg.Validate() == nil {
+			return dyncfg.CommandPlanClaims()
+		}
+		return dyncfg.CommandPlanClaimless()
 	case dyncfg.CommandUpdate:
 		if key, ok := c.dyncfgExtractSecretStoreKey(fn.ID()); ok {
 			if entry, exists := c.lookupInternal(key); exists && entry.Cfg.SourceType() != confgroup.TypeDyncfg {
 				// Conversion path: payload gates at stage, validation in the
 				// effect.
 				if fn.ValidateHasPayload() != nil {
-					return false
+					return dyncfg.CommandPlanClaimless()
 				}
 				_, err := c.dyncfgSecretStoreConfigFromPayload(fn, entry.Cfg.Name(), entry.Cfg.Kind())
-				return err == nil
+				if err == nil {
+					return dyncfg.CommandPlanClaims()
+				}
+				return dyncfg.CommandPlanClaimless()
 			}
 		}
-		return c.handler.CommandActs(fn, c.handlerEntry(fn.ID()))
+		return c.handler.CommandPlan(fn, c.handlerEntry(fn.ID()))
 	case dyncfg.CommandRemove:
 		_, code, _ := c.removeRejection(fn)
-		return code == 0
+		if code == 0 {
+			return dyncfg.CommandPlanClaims()
+		}
+		return dyncfg.CommandPlanClaimless()
 	case dyncfg.CommandTest:
 		storeKey, ok := c.dyncfgExtractSecretStoreKey(fn.ID())
 		if !ok {
-			return false
+			return dyncfg.CommandPlanClaimless()
 		}
 		entry, exists := c.lookupInternal(storeKey)
 		if !exists {
-			return false
+			return dyncfg.CommandPlanClaimless()
 		}
 		if !fn.HasPayload() {
-			return true
+			return dyncfg.CommandPlanClaims()
 		}
 		_, err := c.dyncfgSecretStoreConfigFromPayload(fn, entry.Cfg.Name(), entry.Cfg.Kind())
-		return err == nil
+		if err == nil {
+			return dyncfg.CommandPlanClaims()
+		}
+		return dyncfg.CommandPlanClaimless()
 	default:
 		// schema/get/userconfig answer inline and never claim; everything
 		// else is the 501 arm.
-		return false
+		return dyncfg.CommandPlanClaimless()
 	}
 }
 
 // handlerEntry resolves the shared handler's exposed entry for a command's
-// config ID (nil when the store is not exposed), for handler.CommandActs
-// delegation.
+// config ID (nil when the store is not exposed), for handler command planning.
 func (c *Controller) handlerEntry(id string) *dyncfg.Entry[secretstore.Config] {
 	key, ok := c.dyncfgExtractSecretStoreKey(id)
 	if !ok {
@@ -466,7 +466,7 @@ func (c *Controller) dyncfgCmdRemoveStep(fn dyncfg.Function, run dyncfg.StepRunn
 // removeRejection runs the remove path's PRE-CLAIM gates - the gates that
 // precede its first claim-protected read, the affected-jobs check - and
 // reports the rejection they produce (code 0 = the command must claim). It
-// is the SINGLE SOURCE for dyncfgCmdRemoveStep and CommandActs; add a
+// is the SINGLE SOURCE for dyncfgCmdRemoveStep and CommandPlan; add a
 // pre-claim gate here, never in either caller. Every gate ordered after
 // these - the affected-jobs 409 AND the shared handler's source/type 405s
 // behind it - answers UNDER the granted store write claim.

--- a/src/go/plugin/agent/jobmgr/vnode_claims_test.go
+++ b/src/go/plugin/agent/jobmgr/vnode_claims_test.go
@@ -271,7 +271,7 @@ func TestUnderivableCommand_RejectsWithoutClaiming(t *testing.T) {
 	// The NAME-POLICY axis, a CALLBACK gate (ValidateConfigName /
 	// JobNameRuleStrict): a dotted job name is derivable (non-empty) yet
 	// answers 400 before any blocking work, so its payload refs - which
-	// reference the write-held store - must not be claimed. The predicate
+	// reference the write-held store - must not be claimed. The command plan
 	// runs the handler's own addRejection gates, so callback gates cannot
 	// drift out of it.
 	h.dyncfg("bad-name-add", []string{h.mgr.dyncfgModID("gated"), "add", "bad.name"},

--- a/src/go/plugin/agent/jobmgr/vnodectl/commandplan_test.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/commandplan_test.go
@@ -13,19 +13,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestControllerCommandActsParity drives SeqExec across the deterministic
-// stage-gate matrix and asserts CommandActs agrees: a command mutates the
-// vnode store (or reaches its claim-protected gates) exactly when
-// CommandActs reports true, and every wantActs=false cell answers its
-// rejection without touching the store. Claim scheduling relies on this
-// predicate to skip the vnode write claim for rejection-only commands - a
-// stage-gate change without a matching CommandActs update fails here as the
-// starvation bug it would be. Two documented acts-but-rejects cells answer
-// inline UNDER the claim by design: payload parse/GUID/uniqueness rejections
-// (bounded by one effect window) and the remove path's referenced-by-configs
-// 409 (a stopping dependent's read claim must be waited out, not answered
-// around).
-func TestControllerCommandActsParity(t *testing.T) {
+// TestControllerCommandPlanParity drives SeqExec across the deterministic
+// stage-gate matrix and asserts CommandPlan agrees: a command mutates the vnode
+// store (or reaches its claim-protected gates) exactly when the plan reports
+// claims, and every claimless cell answers its rejection without touching the
+// store. Two documented acts-but-rejects cells answer inline UNDER the claim by
+// design:
+// payload parse/GUID/uniqueness rejections (bounded by one effect window) and
+// the remove path's referenced-by-configs 409 (a stopping dependent's read
+// claim must be waited out, not answered around).
+func TestControllerCommandPlanParity(t *testing.T) {
 	const guid = "b0b0b0b0-0000-4000-8000-0000000000aa"
 
 	tests := map[string]struct {
@@ -224,10 +221,12 @@ func TestControllerCommandActsParity(t *testing.T) {
 
 			fn := tc.fn(ctl)
 
-			// Capture the predicate BEFORE running: execution mutates the
-			// store, and the executor consults the predicate pre-execution.
-			acts := ctl.CommandActs(fn)
-			assert.Equal(t, tc.wantActs, acts, "CommandActs")
+			// Capture the plan BEFORE running: execution mutates the store, and
+			// the executor consults the plan pre-execution.
+			plan := ctl.CommandPlan(fn)
+			assert.Equal(t, tc.wantActs, plan.NeedsClaims(false), "CommandPlan")
+			assert.Equal(t, tc.wantActs, plan.NeedsClaims(true),
+				"vnode commands have no status-hold-aware axis")
 
 			ctl.SeqExec(fn)
 			assert.Contains(t, out.String(), fmt.Sprintf("FUNCTION_RESULT_BEGIN parity %d", tc.wantCode),

--- a/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
@@ -77,38 +77,36 @@ func (c *Controller) SeqExec(fn dyncfg.Function) {
 	}
 }
 
-// CommandActs reports whether fn may execute CLAIMLESSLY: false only when
-// execution answers a deterministic rejection BEFORE its first
-// claim-protected access - an unsupported command (the 501 arm above), a
-// missing vnode on update/remove, a non-dyncfg vnode on remove, or a
-// missing payload/name on add. The remove SOURCE gate belongs here only
-// because dyncfgCmdRemove orders it BEFORE the referenced-by-configs read
-// (unlike the store domain, whose remove reads its dependency index
-// first). Claim scheduling consults it so rejection-only vnode commands
-// claim nothing instead of parking behind collector read claims held
-// across effects; the parity test drives SeqExec against it. Deliberately
-// NOT mirrored here: payload parse/GUID/uniqueness rejections (answered
-// inline under the claim, bounded by one effect window) and the remove
-// path's referenced-by-configs 409, which must be evaluated under the
-// granted write claim (a stopping dependent's read claim must be waited
-// out, not answered around). schema/get/userconfig/test answer inline and
-// never claim.
-func (c *Controller) CommandActs(fn dyncfg.Function) bool {
+// CommandPlan reports how fn must be scheduled. Claimless means execution
+// answers a deterministic rejection before its first claim-protected access.
+// The remove SOURCE gate belongs here only because dyncfgCmdRemove orders it
+// before the referenced-by-configs read. Payload parse/GUID/uniqueness
+// rejections and referenced-by-configs 409 answer under the vnode write claim.
+func (c *Controller) CommandPlan(fn dyncfg.Function) dyncfg.CommandPlan {
 	switch fn.Command() {
 	case dyncfg.CommandAdd:
 		if fn.ValidateArgs(3) != nil || !fn.HasPayload() {
-			return false
+			return dyncfg.CommandPlanClaimless()
 		}
 		name := fn.JobName()
-		return name != "" && dyncfg.JobNameRuleAllowDots(name) == nil
+		if name != "" && dyncfg.JobNameRuleAllowDots(name) == nil {
+			return dyncfg.CommandPlanClaims()
+		}
+		return dyncfg.CommandPlanClaimless()
 	case dyncfg.CommandUpdate:
 		_, ok := c.Lookup(strings.TrimPrefix(fn.ID(), c.Prefix()+":"))
-		return ok
+		if ok {
+			return dyncfg.CommandPlanClaims()
+		}
+		return dyncfg.CommandPlanClaimless()
 	case dyncfg.CommandRemove:
 		vnode, ok := c.Lookup(strings.TrimPrefix(fn.ID(), c.Prefix()+":"))
-		return ok && vnode.SourceType == confgroup.TypeDyncfg
+		if ok && vnode.SourceType == confgroup.TypeDyncfg {
+			return dyncfg.CommandPlanClaims()
+		}
+		return dyncfg.CommandPlanClaimless()
 	default:
-		return false
+		return dyncfg.CommandPlanClaimless()
 	}
 }
 

--- a/src/go/plugin/framework/dyncfg/handler.go
+++ b/src/go/plugin/framework/dyncfg/handler.go
@@ -479,6 +479,35 @@ func (h *Handler[C]) configSupportedCommands(cfg C, isDyncfg bool) string {
 // another blocking phase of the same command.
 type StepRunner func(effect func(context.Context) error, commit func(error))
 
+// CommandPlan describes the scheduling shape of one command at the point where
+// a caller is deciding whether dependency claims are needed. It is deliberately
+// narrower than command execution: handlers still own responses and mutations.
+type CommandPlan struct {
+	needsClaims     bool
+	statusHoldAware bool
+}
+
+// CommandPlanClaimless is for commands that answer before any claim-protected
+// access and therefore must not park behind dependency claims.
+func CommandPlanClaimless() CommandPlan { return CommandPlan{} }
+
+// CommandPlanClaims is for commands that reach claim-protected state or
+// blocking work.
+func CommandPlanClaims() CommandPlan { return CommandPlan{needsClaims: true} }
+
+// CommandPlanStatusGate is for collector status-derived rejections/no-ops:
+// claimless normally, but held behind a foreign write claim because that holder
+// is mutating the status the response would be derived from.
+func CommandPlanStatusGate() CommandPlan { return CommandPlan{statusHoldAware: true} }
+
+// NeedsClaims reports whether the command should reserve dependencies or wait
+// under a current write hold. Callers use writeHeld=false for the intrinsic
+// claim decision, and writeHeld=true when checking whether a claimless command
+// can bypass a foreign write hold.
+func (p CommandPlan) NeedsClaims(writeHeld bool) bool {
+	return p.needsClaims || (p.statusHoldAware && writeHeld)
+}
+
 // StagedStop is a stop split in two: the routing removal already happened on
 // the goroutine that called StageStop (the command-staging goroutine), and
 // Wait performs the blocking half inside the effect. Undo restores routing
@@ -520,10 +549,9 @@ type UpdateStager[C Config] interface {
 // left nil - kills the plugin) and returns the same error
 // ParseAndValidate's parse step would return for the same input.
 // When implemented, add and update answer a malformed payload's 400 at
-// STAGE - before any claim or effect - and the acts predicate classifies
-// the command as rejection-only instead of letting it park behind held
-// dependency claims. Components without it keep the parse-in-effect
-// semantics.
+// STAGE - before any claim or effect - and the command plan classifies the
+// command as rejection-only instead of letting it park behind held dependency
+// claims. Components without it keep the parse-in-effect semantics.
 type PayloadParser interface {
 	ParsePayload(fn Function, name string) error
 }
@@ -807,85 +835,63 @@ func (h *Handler[C]) CmdRemove(fn Function) {
 	h.cmdRemove(fn, RunStepSync)
 }
 
-// CommandActs reports whether fn against entry reaches a phase that stops
-// or starts work - where dependency reservations are load-bearing - as
-// opposed to answering a deterministic rejection or no-op. Claim scheduling
-// uses it so "rejection-only commands claim nothing" cannot drift from the
-// Cmd* gates in this file. The criterion is EXECUTION ORDER, not the
-// eventual outcome: false is returned only when the command's execution
-// answers BEFORE its first claim-protected access - a rejection that
-// execution reaches only after such an access (a domain gate ordered
-// behind a dependency-index read) must claim first and answer under the
-// claim.
+// CommandPlan reports how fn against entry must be scheduled. The criterion is
+// EXECUTION ORDER, not the eventual outcome: a command is claimless only when
+// execution answers BEFORE its first claim-protected access. A rejection reached
+// after such an access must claim first and answer under the claim.
 //
-// Add and update do not mirror their gates AT ALL: the predicate runs the
-// SAME addRejection/updateRejection functions their Cmd* bodies answer
-// from, so a gate added there - including callback gates like
-// ValidateConfigName, which a mirror in this file cannot see - is
-// automatically rejection-only (eight starvation findings proved that
-// mirroring the parse-shaped gate chains does not converge). The
-// stop/start-shaped commands keep the explicit state predicate below
-// (enable no-ops on Running; restart rejects Accepted/Disabled; disable
-// no-ops on Disabled; remove rejects non-dyncfg sources and non-job types;
-// a nil entry never acts); their pre-effect sections mutate caches, so
-// they cannot share a rejection function, and the parity test drives every
-// command against every gate combination to hold them to this predicate.
-// Identity gates (argument count, config ID format) are also the caller's
-// underivable axis.
-func (h *Handler[C]) CommandActs(fn Function, entry *Entry[C]) bool {
+// Add and update do not mirror their gates: this runs the SAME
+// addRejection/updateRejection helpers their Cmd* bodies answer from, so a gate
+// added there remains single-source. Stop/start-shaped commands keep the
+// explicit state predicate below because their pre-effect sections mutate
+// caches. Identity gates (argument count, config ID format) are still the
+// caller's underivable axis.
+func (h *Handler[C]) CommandPlan(fn Function, entry *Entry[C]) CommandPlan {
 	switch cmd := fn.Command(); cmd {
 	case CommandAdd:
 		_, _, code, _ := h.addRejection(fn)
-		return code == 0
+		if code == 0 {
+			return CommandPlanClaims()
+		}
+		return CommandPlanClaimless()
 	case CommandUpdate:
 		_, _, code, _ := h.updateRejection(fn)
-		return code == 0
+		if code == 0 {
+			return CommandPlanClaims()
+		}
+		return CommandPlanClaimless()
 	default:
 		if entry == nil {
-			return false
+			return CommandPlanClaimless()
 		}
 		switch cmd {
 		case CommandEnable:
-			return entry.Status == StatusAccepted || entry.Status == StatusDisabled || entry.Status == StatusFailed
+			if entry.Status == StatusAccepted || entry.Status == StatusDisabled || entry.Status == StatusFailed {
+				return CommandPlanClaims()
+			}
+			return CommandPlanStatusGate()
 		case CommandRestart:
-			return entry.Status == StatusRunning || entry.Status == StatusFailed
+			if entry.Status == StatusRunning || entry.Status == StatusFailed {
+				return CommandPlanClaims()
+			}
+			return CommandPlanStatusGate()
 		case CommandDisable:
-			return entry.Status != StatusDisabled
+			if entry.Status != StatusDisabled {
+				return CommandPlanClaims()
+			}
+			return CommandPlanStatusGate()
 		case CommandRemove:
-			return entry.Cfg.SourceType() == "dyncfg" && h.cb.ConfigType(entry.Cfg) == ConfigTypeJob
+			if entry.Cfg.SourceType() == "dyncfg" && h.cb.ConfigType(entry.Cfg) == ConfigTypeJob {
+				return CommandPlanClaims()
+			}
 		}
-		return false
+		return CommandPlanClaimless()
 	}
-}
-
-// RejectionDependsOnStatus reports whether fn's rejection-only
-// classification against entry is derived from entry.Status - the one
-// input a FOREIGN write-claim holder (a store command's dependent-restart
-// plan) mutates from another key. A status-derived rejection is
-// deterministic only while no foreign write claim holds the command's key:
-// under a hold the status is mid-mutation, and an answer minted from it
-// can be falsified by the holder's outcome (an enable answering the
-// Running no-op 200 while the dependent restart it cannot see is stopping
-// - and may fail - that very job). Claim scheduling treats such commands
-// as ACTING while their key is write-held, so they park and answer
-// truthfully after the hold resolves. Meaningful only when CommandActs
-// reported false; every other rejection axis (identity, existence,
-// source/type, payload, command support) depends on state no foreign
-// holder mutates.
-func (h *Handler[C]) RejectionDependsOnStatus(fn Function, entry *Entry[C]) bool {
-	if entry == nil {
-		return false
-	}
-	switch fn.Command() {
-	case CommandEnable, CommandRestart, CommandDisable:
-		return true
-	}
-	return false
 }
 
 // addRejection runs cmdAdd's deterministic pre-effect gates and reports the
 // rejection they produce (code 0 = the command acts). It is the SINGLE
-// SOURCE for both cmdAdd and CommandActs; add a gate here, never in either
+// SOURCE for both cmdAdd and CommandPlan; add a gate here, never in either
 // caller.
 func (h *Handler[C]) addRejection(fn Function) (key, name string, code int, msg string) {
 	if err := fn.ValidateArgs(3); err != nil {
@@ -910,7 +916,7 @@ func (h *Handler[C]) addRejection(fn Function) (key, name string, code int, msg 
 // updateRejection runs cmdUpdate's deterministic pre-effect gates and
 // reports the rejection they produce (code 0 = the command acts, and the
 // exposed entry is returned). It is the SINGLE SOURCE for both cmdUpdate
-// and CommandActs; add a gate here, never in either caller.
+// and CommandPlan; add a gate here, never in either caller.
 func (h *Handler[C]) updateRejection(fn Function) (name string, entry *Entry[C], code int, msg string) {
 	key, name, ok := h.cb.ExtractKey(fn)
 	if !ok {

--- a/src/go/plugin/framework/dyncfg/handler_test.go
+++ b/src/go/plugin/framework/dyncfg/handler_test.go
@@ -1645,38 +1645,63 @@ func TestStopCommitOutcomeMapping(t *testing.T) {
 	}
 }
 
-// TestHandler_RejectionDependsOnStatus pins the status-axis classification
-// consumed by hold-aware claim scheduling: exactly the enable/restart/
-// disable arms against an EXISTING entry are status-derived (their
-// rejection-only outcome can be falsified by a foreign write-claim holder
-// mutating entry.Status); every other command - and every command against
-// a nil entry - rejects on state no foreign holder mutates.
-func TestHandler_RejectionDependsOnStatus(t *testing.T) {
+// TestHandler_CommandPlanForeignHoldStatusGates pins the status-axis scheduling
+// class consumed by foreign-hold claim routing.
+func TestHandler_CommandPlanForeignHoldStatusGates(t *testing.T) {
 	cb := &mockCallbacks{}
 	h := newTestHandler(cb)
-	cfg := testConfig{uid: "uid-j", key: "j", sourceType: "dyncfg", source: "test"}
-	entry := &Entry[testConfig]{Cfg: cfg, Status: StatusRunning}
 
-	commands := []Command{CommandAdd, CommandUpdate, CommandEnable, CommandRestart,
-		CommandDisable, CommandRemove, CommandGet, CommandSchema}
-	for _, cmd := range commands {
-		fn := newTestFn("test:j", string(cmd), "", nil)
-		want := cmd == CommandEnable || cmd == CommandRestart || cmd == CommandDisable
-		assert.Equal(t, want, h.RejectionDependsOnStatus(fn, entry), "command %s with an entry", cmd)
-		assert.False(t, h.RejectionDependsOnStatus(fn, nil), "command %s with a nil entry", cmd)
+	tests := []struct {
+		cmd      Command
+		status   Status
+		wantFree bool
+		wantHeld bool
+	}{
+		{CommandEnable, StatusAccepted, true, true},
+		{CommandEnable, StatusRunning, false, true},
+		{CommandEnable, StatusFailed, true, true},
+		{CommandEnable, StatusDisabled, true, true},
+		{CommandRestart, StatusAccepted, false, true},
+		{CommandRestart, StatusRunning, true, true},
+		{CommandRestart, StatusFailed, true, true},
+		{CommandRestart, StatusDisabled, false, true},
+		{CommandDisable, StatusAccepted, true, true},
+		{CommandDisable, StatusRunning, true, true},
+		{CommandDisable, StatusFailed, true, true},
+		{CommandDisable, StatusDisabled, false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s %s", tc.cmd, tc.status), func(t *testing.T) {
+			cfg := testConfig{uid: "uid-j", key: "j", sourceType: "dyncfg", source: "test"}
+			entry := &Entry[testConfig]{Cfg: cfg, Status: tc.status}
+			fn := newTestFn("test:j", string(tc.cmd), "", nil)
+
+			plan := h.CommandPlan(fn, entry)
+			assert.Equal(t, tc.wantFree, plan.NeedsClaims(false),
+				"free lane intrinsic claim decision")
+			assert.Equal(t, tc.wantHeld, plan.NeedsClaims(true),
+				"foreign write hold must promote status-derived no-ops")
+		})
+	}
+
+	for _, cmd := range []Command{CommandEnable, CommandRestart, CommandDisable} {
+		t.Run(fmt.Sprintf("%s missing entry", cmd), func(t *testing.T) {
+			fn := newTestFn("test:j", string(cmd), "", nil)
+			plan := h.CommandPlan(fn, nil)
+			assert.False(t, plan.NeedsClaims(false), "missing entry rejects claimless")
+			assert.False(t, plan.NeedsClaims(true), "missing entry bypasses foreign holds")
+		})
 	}
 }
 
-// TestHandler_CommandActsParity drives every state-gated command against
-// every gate combination and asserts CommandActs agrees with the Cmd*
+// TestHandler_CommandPlanParity drives every state-gated command against
+// every gate combination and asserts CommandPlan agrees with the Cmd*
 // implementations: blocking work runs (the step runner is invoked) exactly
-// when CommandActs reports true. Claim scheduling relies on this predicate
-// to skip dependency reservations for rejection-only commands - a gate
-// change in a Cmd* body without a matching CommandActs update fails here
-// as the starvation bug it would be. The payload axis is part of the
-// matrix: add and update answer 400 before any blocking work when the
-// payload is missing.
-func TestHandler_CommandActsParity(t *testing.T) {
+// when the plan reports intrinsic claims. The payload axis is part of the
+// matrix: add and update answer 400 before any blocking work when the payload
+// is missing.
+func TestHandler_CommandPlanParity(t *testing.T) {
 	type gate struct {
 		sourceType string
 		configType ConfigType
@@ -1747,15 +1772,23 @@ func TestHandler_CommandActsParity(t *testing.T) {
 
 						fn := newTestFn("test:j", string(cmd), "", pl.payload)
 
-						// Capture the predicate BEFORE running: the command's
+						// Capture the plan BEFORE running: the command's
 						// commit mutates entry.Status (that is its job), and the
-						// executor consults the predicate pre-execution.
-						acts := h.CommandActs(fn, entry)
+						// executor consults the plan pre-execution.
+						plan := h.CommandPlan(fn, entry)
+						claims := plan.NeedsClaims(false)
+						if !claims && (cmd == CommandEnable || cmd == CommandRestart || cmd == CommandDisable) {
+							assert.True(t, plan.NeedsClaims(true),
+								"claimless status-derived gates must wait under foreign holds")
+						} else {
+							assert.Equal(t, claims, plan.NeedsClaims(true),
+								"non-status gates must not change under foreign holds")
+						}
 
 						ran := driveWithSpy(h, cmd, fn)
 
-						assert.Equal(t, acts, ran,
-							"CommandActs must mirror whether the handler runs blocking work")
+						assert.Equal(t, claims, ran,
+							"CommandPlan must mirror whether the handler runs blocking work")
 					})
 				}
 			}
@@ -1783,12 +1816,15 @@ func TestHandler_CommandActsParity(t *testing.T) {
 
 					fn := newTestFn("test:"+jobName, string(CommandAdd), jobName, pl.payload)
 
-					acts := h.CommandActs(fn, entry)
+					plan := h.CommandPlan(fn, entry)
+					claims := plan.NeedsClaims(false)
+					assert.Equal(t, claims, plan.NeedsClaims(true),
+						"add gates are not status-derived")
 
 					ran := driveWithSpy(h, CommandAdd, fn)
 
-					assert.Equal(t, acts, ran,
-						"CommandActs must mirror whether the handler runs blocking work")
+					assert.Equal(t, claims, ran,
+						"CommandPlan must mirror whether the handler runs blocking work")
 				})
 			}
 		}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored job manager scheduling to use domain-owned command plans, improving hold-aware routing and preventing starvation under foreign write holds. No user-facing behavior changes; this is an internal scheduling and testing cleanup.

- **Refactors**
  - Added `dyncfg.CommandPlan` with claimless/claims/status-hold-aware modes and `NeedsClaims(writeHeld)`.
  - Executor now wraps domain plans in a local `eventPlan`, computes claims, and re-computes them on restage; uses the plan to bypass or wait under foreign write holds.
  - Replaced `Handler.CommandActs` and `RejectionDependsOnStatus` with `Handler.CommandPlan` and `CommandPlanStatusGate`; updated `secretsctl.Controller` and `vnodectl.Controller` to `CommandPlan`.
  - Updated architecture docs to describe command-plan ownership and scheduling rules.
  - Expanded tests: parity tests now validate `CommandPlan` across collector, `secretsctl`, and `vnodectl`; added executor tests for claim sets and hold-aware routing.

- **Migration**
  - Replace `Handler.CommandActs(...)` with `Handler.CommandPlan(...).NeedsClaims(false)`.
  - Replace `secretsctl.Controller.CommandActs(...)` and `vnodectl.Controller.CommandActs(...)` with `CommandPlan(...).NeedsClaims(false)`.
  - Replace `Handler.RejectionDependsOnStatus(...)` with `Handler.CommandPlan(...).NeedsClaims(true)` for foreign write-hold checks; use `CommandPlanStatusGate()` in handlers where applicable.

<sup>Written for commit b5aac0c165a5d38dd03c2e356e9f5695bb212480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

