### PR TITLE
refactor(go.d/jobmgr): pull vnode snapshots at runtime boundaries

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -327,11 +327,34 @@ write claim.
 
 | Command | Main flow |
 | --- | --- |
-| `add` | Validate name, payload, GUID, and uniqueness; add vnode. |
-| `update` | Validate payload/GUID/uniqueness; update vnode and notify running jobs. |
+| `add` | Validate name, payload, GUID, and uniqueness; commit a versioned vnode snapshot. |
+| `update` | Validate payload/GUID/uniqueness; commit a new versioned vnode snapshot. |
 | `remove` | Reject if missing, non-dyncfg, or referenced; otherwise remove and publish delete. |
 | `test` | Validate candidate inline, no claim. |
 | `get` / `schema` / `userconfig` | Cheap response paths. |
+
+The vnode store is the authoritative config source. Lookups return cloned
+snapshots with:
+
+- a store revision that advances on every committed vnode config write;
+- a metadata revision that advances only when runtime-visible vnode metadata
+  changes.
+
+Jobs bind to an explicit vnode name and consume snapshots from the store:
+
+- job creation gets the current snapshot from the factory;
+- job registration reconciles the current snapshot before `Start`;
+- V1 jobs refresh after collection and before emission;
+- V2 jobs refresh before collection and emission;
+- cleanup never re-reads the live vnode store:
+  - V1 cleanup uses the job's committed local snapshot;
+  - V2 module-owned cleanup samples `VirtualNode()` before module cleanup;
+  - V2 jobmgr-owned cleanup uses the last successfully emitted HOST_DEFINE
+    cleanup info for owner and stale-suppression metadata.
+
+Runtime-equivalent vnode commits are still consumed by revision, but do not
+force redundant HOSTINFO/HOST_DEFINE output. Module-owned vnodes keep their
+runtime-specific precedence and are not overwritten by jobmgr snapshots.
 
 Collector commands that reference a vnode hold a read claim on the vnode.
 That prevents vnode removal/update from racing a collector stop/start window.

--- a/src/go/plugin/agent/jobmgr/doc.go
+++ b/src/go/plugin/agent/jobmgr/doc.go
@@ -91,15 +91,14 @@
 //     a job that never started.
 //
 //   - Every job registration (startRunningJob) reconciles the job's vnode
-//     against the store before Start: vnode updates propagate to registered
-//     jobs only, so a job created before an update but registered after it
-//     (a dependent restart's stop/start gap, a warm continuation) receives
-//     the current config at registration instead of running on its stale
-//     creation-time snapshot. The reconcile COMMITS a baseline into the job
-//     (SetVnodeBaseline) rather than queueing a delivery: the baseline is
-//     visible to cleanup even when the job never collects, and a
-//     concurrently queued live update stays queued and still wins at
-//     collection.
+//     against the store before Start: a job created before a vnode update but
+//     registered after it (a dependent restart's stop/start gap, a warm
+//     continuation) receives the current config at registration instead of
+//     running on its stale creation-time snapshot. The reconcile commits a
+//     versioned snapshot into the job (SetVnodeSnapshot) so cleanup can use the
+//     committed vnode even when the job never collects;
+//     later running jobs refresh from the versioned vnode lookup at their
+//     runtime-defined collection boundary.
 //
 //   - Discovery ingestion (runProcessConfGroups) does not mutate manager
 //     state directly. It publishes add/remove intents through channels

--- a/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_collector_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/jobruntime"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
 
@@ -1892,13 +1893,12 @@ func (*blockingSecretStoreService) Update(context.Context, string, secretstore.C
 	return nil
 }
 
-func (*blockingSecretStoreService) Remove(string) error           { return nil }
-func (j *collectorProbeJob) Cleanup()                             {}
-func (j *collectorProbeJob) IsRunning() bool                      { return true }
-func (j *collectorProbeJob) Panicked() bool                       { return false }
-func (j *collectorProbeJob) Vnode() vnodes.VirtualNode            { return vnodes.VirtualNode{} }
-func (j *collectorProbeJob) UpdateVnode(*vnodes.VirtualNode)      {}
-func (j *collectorProbeJob) SetVnodeBaseline(*vnodes.VirtualNode) {}
+func (*blockingSecretStoreService) Remove(string) error                { return nil }
+func (j *collectorProbeJob) Cleanup()                                  {}
+func (j *collectorProbeJob) IsRunning() bool                           { return true }
+func (j *collectorProbeJob) Panicked() bool                            { return false }
+func (j *collectorProbeJob) Vnode() vnodes.VirtualNode                 { return vnodes.VirtualNode{} }
+func (j *collectorProbeJob) SetVnodeSnapshot(jobruntime.VnodeSnapshot) {}
 
 type auditAnalyzerSpy struct {
 	registered []string

--- a/src/go/plugin/agent/jobmgr/dyncfg_vnode.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_vnode.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
 
 func (m *Manager) dyncfgVnodePrefixValue() string {
@@ -36,12 +35,4 @@ func (m *Manager) affectedVnodeJobs(vnode string) []string {
 		return true
 	})
 	return jobs
-}
-
-func (m *Manager) applyVnodeUpdate(name string, cfg *vnodes.VirtualNode) {
-	for _, job := range m.runningJobs.snapshot() {
-		if job.Vnode().Name == name {
-			job.UpdateVnode(cfg)
-		}
-	}
 }

--- a/src/go/plugin/agent/jobmgr/dyncfg_vnode_test.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_vnode_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/safewriter"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/vnodectl"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
@@ -265,79 +267,66 @@ func TestDyncfgCmdTest_ValidatesVnodeThroughControllerLookup(t *testing.T) {
 	}
 }
 
-func TestApplyVnodeUpdate_UpdatesMatchingRunningJobs(t *testing.T) {
-	mgr := New(Config{PluginName: testPluginName})
+func TestRunningJobPullsVnodeUpdateFromStore(t *testing.T) {
+	reg := collectorapi.Registry{}
+	reg.Register("gated", collectorapi.Creator{
+		JobConfigSchema: collectorapi.MockConfigSchema,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				ChartsFunc: func() *collectorapi.Charts {
+					return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+				},
+				CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+			}
+		},
+	})
 
-	dbJob := &vnodeUpdateProbeJob{
-		fullName: "success_db",
-		module:   "success",
-		name:     "db",
-		vnode:    vnodes.VirtualNode{Name: "db"},
-	}
-	otherJob := &vnodeUpdateProbeJob{
-		fullName: "success_other",
-		module:   "success",
-		name:     "other",
-		vnode:    vnodes.VirtualNode{Name: "other"},
-	}
+	var out, jobOut simOutput
+	mgr := New(Config{PluginName: testPluginName, Out: &jobOut})
+	mgr.SetDyncfgResponder(dyncfg.NewResponder(netdataapi.New(safewriter.New(&out))))
+	mgr.modules = reg
+	mgr.vnodesCtl = vnodectl.New(vnodectl.Options{
+		Logger:       mgr.Logger,
+		API:          mgr.dyncfgResponder,
+		Plugin:       testPluginName,
+		AffectedJobs: mgr.affectedVnodeJobs,
+	})
 
-	mgr.runningJobs.lock()
-	mgr.runningJobs.add(dbJob.FullName(), dbJob)
-	mgr.runningJobs.add(otherJob.FullName(), otherJob)
-	mgr.runningJobs.unlock()
+	ctx, cancel := context.WithCancel(context.Background())
+	in := make(chan []*confgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(in)
+		mgr.Run(ctx, in)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), charWait)
+	defer waitCancel()
+	require.True(t, mgr.WaitStarted(waitCtx))
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(charWait):
+			t.Errorf("manager did not stop after cancel")
+		}
+	})
+	h := &charHarness{mgr: mgr, out: &out, in: in}
 
-	next := &vnodes.VirtualNode{
-		Name:       "db",
-		Hostname:   "db-new",
-		GUID:       "11111111-1111-1111-1111-111111111111",
-		SourceType: confgroup.TypeDyncfg,
-		Source:     confgroup.TypeDyncfg,
-	}
+	const guid = "b0b0b0b0-0000-4000-8000-000000000055"
+	h.dyncfg("vn-add", []string{h.mgr.dyncfgVnodePrefixValue(), "add", "v-pull"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-one"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-add 202"), charWait, charTick)
 
-	mgr.applyVnodeUpdate("db", next)
+	cfg := prepareDyncfgCfg("gated", "mysql").Set("vnode", "v-pull")
+	h.dyncfg("1-add", []string{h.mgr.dyncfgModID("gated"), "add", "mysql"},
+		mustJSON(t, map[string]any{"vnode": "v-pull", "update_every": 1}))
+	h.dyncfg("2-enable", []string{h.mgr.dyncfgJobID(cfg), "enable"}, nil)
+	require.Eventually(t, func() bool { return strings.Contains(jobOut.String(), "host-one") }, charWait, charTick)
 
-	require.NotNil(t, dbJob.updated)
-	assert.Equal(t, "db-new", dbJob.updated.Hostname)
-	assert.Nil(t, otherJob.updated)
-}
-
-type vnodeUpdateProbeJob struct {
-	fullName string
-	module   string
-	name     string
-	vnode    vnodes.VirtualNode
-	updated  *vnodes.VirtualNode
-}
-
-func (j *vnodeUpdateProbeJob) FullName() string   { return j.fullName }
-func (j *vnodeUpdateProbeJob) ModuleName() string { return j.module }
-func (j *vnodeUpdateProbeJob) Name() string       { return j.name }
-func (j *vnodeUpdateProbeJob) Collector() any     { return nil }
-func (j *vnodeUpdateProbeJob) Start()             {}
-func (j *vnodeUpdateProbeJob) Stop()              {}
-func (j *vnodeUpdateProbeJob) Tick(int)           {}
-func (j *vnodeUpdateProbeJob) AutoDetection(context.Context) error {
-	return nil
-}
-func (j *vnodeUpdateProbeJob) AutoDetectionEvery() int { return 0 }
-func (j *vnodeUpdateProbeJob) RetryAutoDetection() bool {
-	return false
-}
-func (j *vnodeUpdateProbeJob) Cleanup()                  {}
-func (j *vnodeUpdateProbeJob) IsRunning() bool           { return true }
-func (j *vnodeUpdateProbeJob) Panicked() bool            { return false }
-func (j *vnodeUpdateProbeJob) Vnode() vnodes.VirtualNode { return j.vnode }
-func (j *vnodeUpdateProbeJob) UpdateVnode(vnode *vnodes.VirtualNode) {
-	if vnode == nil {
-		j.updated = nil
-		return
-	}
-	copy := *vnode
-	j.updated = &copy
-	j.vnode = copy
-}
-func (j *vnodeUpdateProbeJob) SetVnodeBaseline(vnode *vnodes.VirtualNode) {
-	if vnode != nil {
-		j.vnode = *vnode
-	}
+	h.dyncfg("vn-update", []string{h.mgr.dyncfgVnodePrefixValue() + ":v-pull", "update"},
+		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-two"}))
+	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-update 202"), charWait, charTick)
+	require.Eventually(t, func() bool { return strings.Contains(jobOut.String(), "host-two") }, charWait, charTick,
+		"running job must refresh from the vnode store")
 }

--- a/src/go/plugin/agent/jobmgr/executor.go
+++ b/src/go/plugin/agent/jobmgr/executor.go
@@ -508,9 +508,9 @@ func (e *executor) eventClaims(ev event) []claim {
 //     emits HOST/HOSTINFO lines even for a never-started job).
 // 11. A STARTED warm job receives the current vnode config at registration
 //     (startRunningJob's reconcile), like every other start path - as a
-//     COMMITTED baseline, not a queued delivery: it must be visible to
-//     cleanup even if the job never collects, and it must not evict a
-//     newer live update from the one-slot queue.
+//     COMMITTED baseline: it must be visible to cleanup even if the job never
+//     collects; later running updates are pulled at the job's runtime-defined
+//     collection boundary.
 // 12. A late FAILURE evaluates retry eligibility under today's rules at
 //     the return; nothing was scheduled at the abandon (a provisional
 //     retry could race the continuation).

--- a/src/go/plugin/agent/jobmgr/job_factory.go
+++ b/src/go/plugin/agent/jobmgr/job_factory.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/internal/naming"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/vnodectl"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
@@ -73,11 +74,7 @@ func newJobFactory(m *Manager) *jobFactory {
 			if !ok {
 				return jobruntime.VnodeSnapshot{}, false
 			}
-			return jobruntime.VnodeSnapshot{
-				Vnode:            snapshot.Vnode,
-				Revision:         snapshot.Revision,
-				MetadataRevision: snapshot.MetadataRevision,
-			}, true
+			return toRuntimeVnodeSnapshot(snapshot), true
 		},
 		out:               m.out,
 		gates:             m.emissionGates,
@@ -92,6 +89,14 @@ func newJobFactory(m *Manager) *jobFactory {
 		secretResolver: m.secretResolver,
 		secretStoreSvc: m.secretsCtl.Service(),
 		ctx:            m.baseContext(),
+	}
+}
+
+func toRuntimeVnodeSnapshot(snapshot vnodectl.Snapshot) jobruntime.VnodeSnapshot {
+	return jobruntime.VnodeSnapshot{
+		Vnode:            snapshot.Vnode,
+		Revision:         snapshot.Revision,
+		MetadataRevision: snapshot.MetadataRevision,
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/job_factory.go
+++ b/src/go/plugin/agent/jobmgr/job_factory.go
@@ -19,7 +19,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/metricsaudit"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/runtimecomp"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnoderegistry"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
 
 func jobLogSource(cfg confgroup.Config) string {
@@ -38,12 +37,12 @@ func jobLogSource(cfg confgroup.Config) string {
 type jobFactory struct {
 	logger *logger.Logger
 
-	pluginName        string
-	modules           collectorapi.Registry
-	vnodeLookup       func(string) (*vnodes.VirtualNode, bool)
-	out               io.Writer
-	gates             *emissionGates
-	onSuppressedWrite func()
+	pluginName          string
+	modules             collectorapi.Registry
+	vnodeSnapshotLookup func(string) (jobruntime.VnodeSnapshot, bool)
+	out                 io.Writer
+	gates               *emissionGates
+	onSuppressedWrite   func()
 
 	validationOnly bool
 
@@ -67,9 +66,19 @@ func newJobFactory(m *Manager) *jobFactory {
 	return &jobFactory{
 		logger: m.Logger,
 
-		pluginName:        m.pluginName,
-		modules:           m.modules,
-		vnodeLookup:       m.vnodesCtl.Lookup,
+		pluginName: m.pluginName,
+		modules:    m.modules,
+		vnodeSnapshotLookup: func(name string) (jobruntime.VnodeSnapshot, bool) {
+			snapshot, ok := m.vnodesCtl.LookupSnapshot(name)
+			if !ok {
+				return jobruntime.VnodeSnapshot{}, false
+			}
+			return jobruntime.VnodeSnapshot{
+				Vnode:            snapshot.Vnode,
+				Revision:         snapshot.Revision,
+				MetadataRevision: snapshot.MetadataRevision,
+			}, true
+		},
 		out:               m.out,
 		gates:             m.emissionGates,
 		onSuppressedWrite: m.observeSuppressedWrite,
@@ -107,13 +116,13 @@ func (f *jobFactory) create(cfg confgroup.Config) (runtimeJob, error) {
 		return nil, fmt.Errorf("function_only is set but %s module has no functions defined", cfg.Module())
 	}
 
-	var vnode *vnodes.VirtualNode
+	var vnode jobruntime.VnodeSnapshot
 	if cfg.Vnode() != "" {
-		if f.vnodeLookup == nil {
+		if f.vnodeSnapshotLookup == nil {
 			return nil, fmt.Errorf("vnode '%s' is not found", cfg.Vnode())
 		}
-		n, ok := f.vnodeLookup(cfg.Vnode())
-		if !ok || n == nil {
+		n, ok := f.vnodeSnapshotLookup(cfg.Vnode())
+		if !ok || n.Vnode == nil {
 			return nil, fmt.Errorf("vnode '%s' is not found", cfg.Vnode())
 		}
 		vnode = n
@@ -159,7 +168,7 @@ func (f *jobFactory) logApplyConfigError(cfg confgroup.Config, err error) {
 	f.logger.Errorf("failed to apply config for %s[%s] job: %v", cfg.Module(), cfg.Name(), err)
 }
 
-func (f *jobFactory) createV2(cfg confgroup.Config, creator collectorapi.Creator, functionOnly bool, vnode *vnodes.VirtualNode) (runtimeJob, error) {
+func (f *jobFactory) createV2(cfg confgroup.Config, creator collectorapi.Creator, functionOnly bool, vnode jobruntime.VnodeSnapshot) (runtimeJob, error) {
 	mod := creator.CreateV2()
 	if mod == nil {
 		return nil, fmt.Errorf("module %s CreateV2 returned nil", cfg.Module())
@@ -190,13 +199,17 @@ func (f *jobFactory) createV2(cfg confgroup.Config, creator collectorapi.Creator
 		RuntimeService:  f.runtimeService,
 		VnodeRegistry:   f.vnodeRegistry,
 	}
-	if vnode != nil {
-		jobCfg.Vnode = *vnode.Copy()
+	if vnode.Vnode != nil {
+		jobCfg.Vnode = *vnode.Vnode.Copy()
+		jobCfg.VnodeName = cfg.Vnode()
+		jobCfg.VnodeRevision = vnode.Revision
+		jobCfg.VnodeMetadataRevision = vnode.MetadataRevision
+		jobCfg.VnodeLookup = f.vnodeSnapshotLookup
 	}
 	return jobruntime.NewJobV2(jobCfg), nil
 }
 
-func (f *jobFactory) createV1(cfg confgroup.Config, creator collectorapi.Creator, functionOnly bool, vnode *vnodes.VirtualNode) (runtimeJob, error) {
+func (f *jobFactory) createV1(cfg confgroup.Config, creator collectorapi.Creator, functionOnly bool, vnode jobruntime.VnodeSnapshot) (runtimeJob, error) {
 	if creator.Create == nil {
 		return nil, fmt.Errorf("module %s has no compatible creator", cfg.Module())
 	}
@@ -243,8 +256,12 @@ func (f *jobFactory) createV1(cfg confgroup.Config, creator collectorapi.Creator
 		AuditAnalyzer:   f.auditAnalyzer,
 		FunctionOnly:    functionOnly,
 	}
-	if vnode != nil {
-		jobCfg.Vnode = *vnode.Copy()
+	if vnode.Vnode != nil {
+		jobCfg.Vnode = *vnode.Vnode.Copy()
+		jobCfg.VnodeName = cfg.Vnode()
+		jobCfg.VnodeRevision = vnode.Revision
+		jobCfg.VnodeMetadataRevision = vnode.MetadataRevision
+		jobCfg.VnodeLookup = f.vnodeSnapshotLookup
 	}
 
 	return jobruntime.NewJob(jobCfg), nil

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/jobruntime"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/metricsaudit"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/runtimecomp"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnoderegistry"
@@ -164,12 +165,11 @@ func New(cfg Config) *Manager {
 		ConfigCommands:          dyncfgCollectorConfigCmds(),
 	})
 	mgr.vnodesCtl = vnodectl.New(vnodectl.Options{
-		Logger:           mgr.Logger,
-		API:              api,
-		Plugin:           cfg.PluginName,
-		Initial:          vnodesReg,
-		AffectedJobs:     mgr.affectedVnodeJobs,
-		ApplyVnodeUpdate: mgr.applyVnodeUpdate,
+		Logger:       mgr.Logger,
+		API:          api,
+		Plugin:       cfg.PluginName,
+		Initial:      vnodesReg,
+		AffectedJobs: mgr.affectedVnodeJobs,
 	})
 	mgr.secretsCtl = secretsctl.New(secretsctl.Options{
 		Logger:                  mgr.Logger,
@@ -660,15 +660,14 @@ func (m *Manager) startRunningJob(job runtimeJob) {
 	}
 
 	// Registration precedes the vnode reconcile, which precedes Start: a
-	// vnode update committing concurrently either sees the registered job
-	// (applyVnodeUpdate queues it live) or committed before the reconcile's
-	// lookup (the baseline carries it). The baseline is COMMITTED into the
-	// job, not queued: a queued delivery could evict a newer live update
-	// from the one-slot channel, and V1 applies queued updates only during
-	// collection - a job stopped before its first tick would clean up with
-	// the stale creation-time vnode. Ticks to a registered but
-	// not-yet-started job are non-blocking sends; a stop racing this window
-	// unblocks because Start launches unconditionally below.
+	// vnode update committing concurrently either is pulled at the job's
+	// next collection boundary or committed before the reconcile's lookup
+	// (the baseline carries it). The baseline is COMMITTED into the job:
+	// V1 refreshes only during collection, so a job stopped before its first
+	// tick would otherwise clean up with the stale creation-time vnode.
+	// Ticks to a registered but not-yet-started job are non-blocking sends;
+	// a stop racing this window unblocks because Start launches
+	// unconditionally below.
 	m.runningJobs.lock()
 	m.runningJobs.add(job.FullName(), job)
 	m.runningJobs.unlock()
@@ -680,25 +679,37 @@ func (m *Manager) startRunningJob(job runtimeJob) {
 	// the job's functions (collectorCallbacks.OnStatusChange).
 }
 
-// reconcileJobVnode delivers the current vnode config to a job being
-// registered. Vnode updates propagate to REGISTERED jobs only
-// (applyVnodeUpdate): a job created before an update committed but
-// registered after it would run on its stale creation-time snapshot - the
-// stop/start gap of a store command's dependent restart, or a warm
-// continuation resumed after a wedge. Vnode removal cannot leave a dangling
-// reference here: it is 409-refused while the job's exposed entry
-// references the vnode.
+// reconcileJobVnode commits the current vnode snapshot to a job being
+// registered. A job created before an update committed but registered after it
+// must not clean up on its stale creation-time snapshot - the stop/start gap of
+// a store command's dependent restart, or a warm continuation resumed after a
+// wedge. Runtime-equivalent store commits are still consumed here so jobs start
+// with the current store revision even when HOSTINFO/HOST_DEFINE metadata did
+// not change. Vnode removal cannot leave a dangling reference here: it is
+// 409-refused while the job's exposed entry references the vnode.
 func (m *Manager) reconcileJobVnode(job runtimeJob) {
 	cur := job.Vnode()
 	if cur.Name == "" {
 		return
 	}
-	vn, ok := m.vnodesCtl.Lookup(cur.Name)
-	if !ok || cur.Equal(vn) {
+	snapshot, ok := m.vnodesCtl.LookupSnapshot(cur.Name)
+	if !ok || snapshot.Vnode == nil {
+		return
+	}
+	if cur.Equal(snapshot.Vnode) {
+		commitJobVnodeSnapshot(job, snapshot)
 		return
 	}
 	m.Infof("delivering updated vnode '%s' config to job '%s' at registration", cur.Name, job.FullName())
-	job.SetVnodeBaseline(vn)
+	commitJobVnodeSnapshot(job, snapshot)
+}
+
+func commitJobVnodeSnapshot(job runtimeJob, snapshot vnodectl.Snapshot) {
+	job.SetVnodeSnapshot(jobruntime.VnodeSnapshot{
+		Vnode:            snapshot.Vnode,
+		Revision:         snapshot.Revision,
+		MetadataRevision: snapshot.MetadataRevision,
+	})
 }
 
 // publishRunningJobFunctions registers a committed-live job with the

--- a/src/go/plugin/agent/jobmgr/manager.go
+++ b/src/go/plugin/agent/jobmgr/manager.go
@@ -28,7 +28,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/jobruntime"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/metricsaudit"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/runtimecomp"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnoderegistry"
@@ -705,11 +704,7 @@ func (m *Manager) reconcileJobVnode(job runtimeJob) {
 }
 
 func commitJobVnodeSnapshot(job runtimeJob, snapshot vnodectl.Snapshot) {
-	job.SetVnodeSnapshot(jobruntime.VnodeSnapshot{
-		Vnode:            snapshot.Vnode,
-		Revision:         snapshot.Revision,
-		MetadataRevision: snapshot.MetadataRevision,
-	})
+	job.SetVnodeSnapshot(toRuntimeVnodeSnapshot(snapshot))
 }
 
 // publishRunningJobFunctions registers a committed-live job with the

--- a/src/go/plugin/agent/jobmgr/manager_process_test.go
+++ b/src/go/plugin/agent/jobmgr/manager_process_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/functions"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/jobruntime"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
 
@@ -1057,6 +1058,39 @@ func TestRun_DoesNotPublishCollectorTemplateForSingleInstanceModules(t *testing.
 	assert.NotContains(t, output, "CONFIG "+mgr.dyncfgModID("single")+" create accepted template /collectors/"+testPluginName+"/Jobs")
 }
 
+func TestReconcileJobVnodeCommitsRuntimeEquivalentSnapshotRevision(t *testing.T) {
+	mgr := New(Config{
+		PluginName: testPluginName,
+		Vnodes: map[string]*vnodes.VirtualNode{
+			"db": {
+				Name:       "db",
+				Hostname:   "db-host",
+				GUID:       "db-guid",
+				SourceType: confgroup.TypeDyncfg,
+				Source:     "dyncfg",
+			},
+		},
+	})
+	job := &vnodeReconcileProbeJob{
+		tickProbeJob: tickProbeJob{fullName: "module_job", moduleName: "module", name: "job"},
+		vnode: vnodes.VirtualNode{
+			Name:       "db",
+			Hostname:   "db-host",
+			GUID:       "db-guid",
+			SourceType: confgroup.TypeUser,
+			Source:     "file",
+		},
+	}
+
+	mgr.reconcileJobVnode(job)
+
+	require.Equal(t, 1, job.snapshotCalls)
+	require.NotNil(t, job.snapshot.Vnode)
+	assert.Equal(t, confgroup.TypeDyncfg, job.snapshot.Vnode.SourceType)
+	assert.Equal(t, uint64(1), job.snapshot.Revision)
+	assert.Equal(t, uint64(1), job.snapshot.MetadataRevision)
+}
+
 type lockProbeJob struct {
 	fullName   string
 	moduleName string
@@ -1081,15 +1115,14 @@ func (j *lockProbeJob) Tick(_ int) {
 		<-j.tickRelease
 	})
 }
-func (j *lockProbeJob) AutoDetection(context.Context) error    { return nil }
-func (j *lockProbeJob) AutoDetectionEvery() int                { return 0 }
-func (j *lockProbeJob) RetryAutoDetection() bool               { return false }
-func (j *lockProbeJob) Cleanup()                               {}
-func (j *lockProbeJob) IsRunning() bool                        { return true }
-func (j *lockProbeJob) Panicked() bool                         { return false }
-func (j *lockProbeJob) Vnode() vnodes.VirtualNode              { return vnodes.VirtualNode{} }
-func (j *lockProbeJob) UpdateVnode(_ *vnodes.VirtualNode)      {}
-func (j *lockProbeJob) SetVnodeBaseline(_ *vnodes.VirtualNode) {}
+func (j *lockProbeJob) AutoDetection(context.Context) error       { return nil }
+func (j *lockProbeJob) AutoDetectionEvery() int                   { return 0 }
+func (j *lockProbeJob) RetryAutoDetection() bool                  { return false }
+func (j *lockProbeJob) Cleanup()                                  {}
+func (j *lockProbeJob) IsRunning() bool                           { return true }
+func (j *lockProbeJob) Panicked() bool                            { return false }
+func (j *lockProbeJob) Vnode() vnodes.VirtualNode                 { return vnodes.VirtualNode{} }
+func (j *lockProbeJob) SetVnodeSnapshot(jobruntime.VnodeSnapshot) {}
 
 type tickProbeJob struct {
 	fullName   string
@@ -1098,22 +1131,37 @@ type tickProbeJob struct {
 	collector  any
 }
 
-func (j *tickProbeJob) FullName() string                       { return j.fullName }
-func (j *tickProbeJob) ModuleName() string                     { return j.moduleName }
-func (j *tickProbeJob) Name() string                           { return j.name }
-func (j *tickProbeJob) Collector() any                         { return j.collector }
-func (j *tickProbeJob) Start()                                 {}
-func (j *tickProbeJob) Stop()                                  {}
-func (j *tickProbeJob) Tick(int)                               {}
-func (j *tickProbeJob) AutoDetection(context.Context) error    { return nil }
-func (j *tickProbeJob) AutoDetectionEvery() int                { return 0 }
-func (j *tickProbeJob) RetryAutoDetection() bool               { return false }
-func (j *tickProbeJob) Cleanup()                               {}
-func (j *tickProbeJob) IsRunning() bool                        { return true }
-func (j *tickProbeJob) Panicked() bool                         { return false }
-func (j *tickProbeJob) Vnode() vnodes.VirtualNode              { return vnodes.VirtualNode{} }
-func (j *tickProbeJob) UpdateVnode(_ *vnodes.VirtualNode)      {}
-func (j *tickProbeJob) SetVnodeBaseline(_ *vnodes.VirtualNode) {}
+func (j *tickProbeJob) FullName() string                          { return j.fullName }
+func (j *tickProbeJob) ModuleName() string                        { return j.moduleName }
+func (j *tickProbeJob) Name() string                              { return j.name }
+func (j *tickProbeJob) Collector() any                            { return j.collector }
+func (j *tickProbeJob) Start()                                    {}
+func (j *tickProbeJob) Stop()                                     {}
+func (j *tickProbeJob) Tick(int)                                  {}
+func (j *tickProbeJob) AutoDetection(context.Context) error       { return nil }
+func (j *tickProbeJob) AutoDetectionEvery() int                   { return 0 }
+func (j *tickProbeJob) RetryAutoDetection() bool                  { return false }
+func (j *tickProbeJob) Cleanup()                                  {}
+func (j *tickProbeJob) IsRunning() bool                           { return true }
+func (j *tickProbeJob) Panicked() bool                            { return false }
+func (j *tickProbeJob) Vnode() vnodes.VirtualNode                 { return vnodes.VirtualNode{} }
+func (j *tickProbeJob) SetVnodeSnapshot(jobruntime.VnodeSnapshot) {}
+
+type vnodeReconcileProbeJob struct {
+	tickProbeJob
+	vnode         vnodes.VirtualNode
+	snapshot      jobruntime.VnodeSnapshot
+	snapshotCalls int
+}
+
+func (j *vnodeReconcileProbeJob) Vnode() vnodes.VirtualNode { return *j.vnode.Copy() }
+func (j *vnodeReconcileProbeJob) SetVnodeSnapshot(snapshot jobruntime.VnodeSnapshot) {
+	j.snapshotCalls++
+	j.snapshot = snapshot.Copy()
+	if snapshot.Vnode != nil {
+		j.vnode = *snapshot.Vnode.Copy()
+	}
+}
 
 type managerFunctionAvailability struct {
 	fn func(string) bool

--- a/src/go/plugin/agent/jobmgr/runtime_job.go
+++ b/src/go/plugin/agent/jobmgr/runtime_job.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/jobruntime"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
 
@@ -30,11 +31,10 @@ type runtimeJob interface {
 	Panicked() bool
 
 	Vnode() vnodes.VirtualNode
-	UpdateVnode(vnode *vnodes.VirtualNode)
-	// SetVnodeBaseline commits a vnode config into the job pre-Start
-	// (visible to cleanup without a collection; never drains a queued
-	// live update). Callers must not use it on a started job.
-	SetVnodeBaseline(vnode *vnodes.VirtualNode)
+	// SetVnodeSnapshot commits a versioned vnode config into the job pre-Start
+	// (visible to cleanup without a collection). Callers must not use it on a
+	// started job.
+	SetVnodeSnapshot(snapshot jobruntime.VnodeSnapshot)
 }
 
 // configModule is the shared Init/Check/config contract for dyncfg config test/get

--- a/src/go/plugin/agent/jobmgr/vnode_claims_test.go
+++ b/src/go/plugin/agent/jobmgr/vnode_claims_test.go
@@ -577,11 +577,10 @@ func TestStoreRemove_AffectedGateWaitsForStoreClaim(t *testing.T) {
 		"the remove answers its 409 under the granted claim once the reference settles")
 }
 
-// The registration-time vnode reconcile is COMMITTED into the job, not
-// queued: V1 applies queued updates only during collection, so a job
-// stopped before its first tick would otherwise clean up with the stale
-// creation-time vnode - HOST/HOSTINFO lines for a hostname the store no
-// longer holds.
+// The registration-time vnode reconcile is COMMITTED into the job: V1 pulls
+// later vnode changes only during collection, so a job stopped before its
+// first tick would otherwise clean up with the stale creation-time vnode -
+// HOST/HOSTINFO lines for a hostname the store no longer holds.
 func TestWarmResume_CleanupEmitsReconciledVnodeBeforeFirstCollection(t *testing.T) {
 	gate := make(chan struct{})
 	var inits atomic.Int32
@@ -927,7 +926,7 @@ func TestDependentRestart_ReceivesVnodeUpdatedDuringRestartGap(t *testing.T) {
 	}
 
 	// Mid-gap vnode update: the store command holds no vnode claim, and
-	// applyVnodeUpdate reaches no job (the dependent is between instances).
+	// No running job exists to refresh yet (the dependent is between instances).
 	h.dyncfg("vn-update", []string{h.mgr.dyncfgVnodePrefixValue() + ":v5", "update"},
 		mustJSON(t, map[string]any{"guid": guid, "hostname": "host-two"}))
 	require.Eventually(t, h.outputContains("FUNCTION_RESULT_BEGIN vn-update 202"), charWait, charTick,
@@ -941,10 +940,10 @@ func TestDependentRestart_ReceivesVnodeUpdatedDuringRestartGap(t *testing.T) {
 		"the restarted dependent's vnode host info must carry the config updated during the restart gap")
 }
 
-// A vnode update that commits while a dependent's key is wedged reaches only
-// RUNNING jobs (applyVnodeUpdate): the dependent's late detection success
-// must still start with the CURRENT vnode config - the resume re-delivers
-// the update the warm job missed, exactly as the live update would have.
+// A vnode update that commits while a dependent's key is wedged reaches no
+// running instance of that dependent: the dependent's late detection success
+// must still start with the CURRENT vnode config - the resume commits the
+// update the warm job missed.
 func TestWarmResume_RefreshesVnodeUpdatedWhileWedged(t *testing.T) {
 	gate := make(chan struct{})
 	var inits atomic.Int32

--- a/src/go/plugin/agent/jobmgr/vnodectl/controller.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/controller.go
@@ -23,8 +23,7 @@ type Options struct {
 	Plugin  string
 	Initial map[string]*vnodes.VirtualNode
 
-	AffectedJobs     func(string) []string
-	ApplyVnodeUpdate func(string, *vnodes.VirtualNode)
+	AffectedJobs func(string) []string
 }
 
 type Controller struct {
@@ -34,8 +33,7 @@ type Controller struct {
 	pluginName string
 	store      *vnodeStore
 
-	affectedJobs     func(string) []string
-	applyVnodeUpdate func(string, *vnodes.VirtualNode)
+	affectedJobs func(string) []string
 }
 
 func New(opts Options) *Controller {
@@ -45,12 +43,11 @@ func New(opts Options) *Controller {
 	}
 
 	return &Controller{
-		Logger:           log,
-		api:              opts.API,
-		pluginName:       opts.Plugin,
-		store:            newVnodeStore(opts.Initial),
-		affectedJobs:     opts.AffectedJobs,
-		applyVnodeUpdate: opts.ApplyVnodeUpdate,
+		Logger:       log,
+		api:          opts.API,
+		pluginName:   opts.Plugin,
+		store:        newVnodeStore(opts.Initial),
+		affectedJobs: opts.AffectedJobs,
 	}
 }
 
@@ -71,6 +68,13 @@ func (c *Controller) Lookup(name string) (*vnodes.VirtualNode, bool) {
 		return nil, false
 	}
 	return c.store.Lookup(name)
+}
+
+func (c *Controller) LookupSnapshot(name string) (Snapshot, bool) {
+	if c.store == nil {
+		return Snapshot{}, false
+	}
+	return c.store.LookupSnapshot(name)
 }
 
 func (c *Controller) CreateTemplates() {

--- a/src/go/plugin/agent/jobmgr/vnodectl/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/controller_test.go
@@ -35,7 +35,6 @@ func TestControllerSeqExec(t *testing.T) {
 
 				assert.Contains(t, out.String(), "FUNCTION_RESULT_BEGIN vn-schema 200 application/json")
 				assert.Empty(t, seams.affectedJobsCalls)
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
 		"userconfig generation": {
@@ -56,7 +55,6 @@ func TestControllerSeqExec(t *testing.T) {
 				assert.Contains(t, body, "name: db")
 				assert.Contains(t, body, "hostname: db")
 				assert.Empty(t, seams.affectedJobsCalls)
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
 		"get returns stored config": {
@@ -72,10 +70,9 @@ func TestControllerSeqExec(t *testing.T) {
 				assert.Equal(t, "db", payload["name"])
 				assert.Equal(t, "11111111-1111-1111-1111-111111111111", payload["guid"])
 				assert.Empty(t, seams.affectedJobsCalls)
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
-		"add applies vnode update seam": {
+		"add stores versioned vnode snapshot": {
 			run: func(t *testing.T, ctl *Controller, out *bytes.Buffer, seams *controllerSeams) {
 				fn := dyncfg.NewFunction(functions.Function{
 					UID:         "vn-add",
@@ -91,13 +88,14 @@ func TestControllerSeqExec(t *testing.T) {
 				var payload map[string]any
 				mustDecodeFunctionPayload(t, out.String(), "vn-add", &payload)
 				assert.Equal(t, float64(202), payload["status"])
-				assert.Equal(t, []string{"db"}, seams.applyCalls)
-				cfg, ok := ctl.Lookup("db")
+				snapshot, ok := ctl.LookupSnapshot("db")
 				require.True(t, ok)
-				assert.Equal(t, confgroup.TypeDyncfg, cfg.SourceType)
+				assert.Equal(t, confgroup.TypeDyncfg, snapshot.Vnode.SourceType)
+				assert.NotZero(t, snapshot.Revision)
+				assert.Equal(t, snapshot.Revision, snapshot.MetadataRevision)
 			},
 		},
-		"add no-op keeps apply seam unused": {
+		"add no-op leaves store unchanged": {
 			initial: map[string]*vnodes.VirtualNode{
 				"db": testVnode("db", "db", "11111111-1111-1111-1111-111111111111", confgroup.TypeDyncfg),
 			},
@@ -113,7 +111,6 @@ func TestControllerSeqExec(t *testing.T) {
 				var payload map[string]any
 				mustDecodeFunctionPayload(t, out.String(), "vn-add-noop", &payload)
 				assert.Equal(t, float64(202), payload["status"])
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
 		"add equal user vnode rewrites stored source metadata to dyncfg": {
@@ -133,12 +130,11 @@ func TestControllerSeqExec(t *testing.T) {
 				var payload map[string]any
 				mustDecodeFunctionPayload(t, out.String(), "vn-add-promote-user", &payload)
 				assert.Equal(t, float64(202), payload["status"])
-				assert.Equal(t, []string{"db"}, seams.applyCalls)
 
-				cfg, ok := ctl.Lookup("db")
+				snapshot, ok := ctl.LookupSnapshot("db")
 				require.True(t, ok)
-				assert.Equal(t, confgroup.TypeDyncfg, cfg.SourceType)
-				assert.Equal(t, "user=alice", cfg.Source)
+				assert.Equal(t, confgroup.TypeDyncfg, snapshot.Vnode.SourceType)
+				assert.Equal(t, "user=alice", snapshot.Vnode.Source)
 			},
 		},
 		"duplicate hostname is rejected": {
@@ -161,10 +157,9 @@ func TestControllerSeqExec(t *testing.T) {
 				mustDecodeFunctionPayload(t, out.String(), "vn-add-dup-host", &payload)
 				assert.Equal(t, float64(400), payload["status"])
 				assert.Contains(t, fmt.Sprint(payload["errorMessage"]), "duplicate virtual node hostname")
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
-		"update applies vnode update seam": {
+		"update stores versioned vnode snapshot": {
 			initial: map[string]*vnodes.VirtualNode{
 				"db": testVnode("db", "db", "11111111-1111-1111-1111-111111111111", confgroup.TypeDyncfg),
 			},
@@ -183,10 +178,13 @@ func TestControllerSeqExec(t *testing.T) {
 				var payload map[string]any
 				mustDecodeFunctionPayload(t, out.String(), "vn-update", &payload)
 				assert.Equal(t, float64(202), payload["status"])
-				assert.Equal(t, []string{"db"}, seams.applyCalls)
+				snapshot, ok := ctl.LookupSnapshot("db")
+				require.True(t, ok)
+				assert.Equal(t, map[string]string{"team": "db"}, snapshot.Vnode.Labels)
+				assert.Greater(t, snapshot.Revision, uint64(0))
 			},
 		},
-		"update no-op keeps apply seam unused": {
+		"update no-op leaves store unchanged": {
 			initial: map[string]*vnodes.VirtualNode{
 				"db": testVnode("db", "db", "11111111-1111-1111-1111-111111111111", confgroup.TypeDyncfg),
 			},
@@ -202,7 +200,6 @@ func TestControllerSeqExec(t *testing.T) {
 				var payload map[string]any
 				mustDecodeFunctionPayload(t, out.String(), "vn-update-noop", &payload)
 				assert.Equal(t, float64(202), payload["status"])
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
 		"update equal user vnode rewrites stored source metadata to dyncfg": {
@@ -222,12 +219,11 @@ func TestControllerSeqExec(t *testing.T) {
 				var payload map[string]any
 				mustDecodeFunctionPayload(t, out.String(), "vn-update-promote-user", &payload)
 				assert.Equal(t, float64(202), payload["status"])
-				assert.Equal(t, []string{"db"}, seams.applyCalls)
 
-				cfg, ok := ctl.Lookup("db")
+				snapshot, ok := ctl.LookupSnapshot("db")
 				require.True(t, ok)
-				assert.Equal(t, confgroup.TypeDyncfg, cfg.SourceType)
-				assert.Equal(t, "user=alice", cfg.Source)
+				assert.Equal(t, confgroup.TypeDyncfg, snapshot.Vnode.SourceType)
+				assert.Equal(t, "user=alice", snapshot.Vnode.Source)
 			},
 		},
 		"update rejects duplicate hostname": {
@@ -251,7 +247,6 @@ func TestControllerSeqExec(t *testing.T) {
 				mustDecodeFunctionPayload(t, out.String(), "vn-update-dup-host", &payload)
 				assert.Equal(t, float64(400), payload["status"])
 				assert.Contains(t, fmt.Sprint(payload["errorMessage"]), "duplicate virtual node hostname")
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
 		"update rejects duplicate guid": {
@@ -274,7 +269,6 @@ func TestControllerSeqExec(t *testing.T) {
 				mustDecodeFunctionPayload(t, out.String(), "vn-update-dup-guid", &payload)
 				assert.Equal(t, float64(400), payload["status"])
 				assert.Contains(t, fmt.Sprint(payload["errorMessage"]), "duplicate virtual node guid")
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
 		"invalid guid is rejected": {
@@ -290,7 +284,6 @@ func TestControllerSeqExec(t *testing.T) {
 				var payload map[string]any
 				mustDecodeFunctionPayload(t, out.String(), "vn-invalid-guid", &payload)
 				assert.Equal(t, float64(400), payload["status"])
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
 		"empty vnode name is rejected": {
@@ -307,7 +300,6 @@ func TestControllerSeqExec(t *testing.T) {
 				mustDecodeFunctionPayload(t, out.String(), "vn-empty-name", &payload)
 				assert.Equal(t, float64(400), payload["status"])
 				assert.Contains(t, fmt.Sprint(payload["errorMessage"]), "Missing vnode name")
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
 		"remove rejects non dyncfg source": {
@@ -383,7 +375,6 @@ func TestControllerSeqExec(t *testing.T) {
 				assert.Equal(t, float64(202), payload["status"])
 				assert.Equal(t, "Updated configuration will affect configs: mysql:prod.", payload["message"])
 				assert.Equal(t, []string{"db"}, seams.affectedJobsCalls)
-				assert.Empty(t, seams.applyCalls)
 			},
 		},
 	}
@@ -450,10 +441,72 @@ func TestControllerSetAPI_NilPreservesResponder(t *testing.T) {
 	}
 }
 
+func TestControllerLookupSnapshot_ReturnsImmutableVersionedCopies(t *testing.T) {
+	initial := map[string]*vnodes.VirtualNode{
+		"db": {
+			Name:       "db",
+			Hostname:   "db",
+			GUID:       "11111111-1111-1111-1111-111111111111",
+			SourceType: confgroup.TypeUser,
+			Source:     "file",
+			Labels:     map[string]string{"env": "prod"},
+		},
+	}
+	ctl, _, _ := newControllerTestSubject(initial)
+
+	initial["db"].Hostname = "mutated-original"
+	initial["db"].Labels["env"] = "mutated-original"
+
+	snap, ok := ctl.LookupSnapshot("db")
+	require.True(t, ok)
+	assert.Equal(t, "db", snap.Vnode.Hostname)
+	assert.Equal(t, "prod", snap.Vnode.Labels["env"])
+	assert.NotZero(t, snap.Revision)
+	assert.Equal(t, snap.Revision, snap.MetadataRevision)
+
+	snap.Vnode.Hostname = "mutated-lookup"
+	snap.Vnode.Labels["env"] = "mutated-lookup"
+
+	next, ok := ctl.LookupSnapshot("db")
+	require.True(t, ok)
+	assert.Equal(t, "db", next.Vnode.Hostname)
+	assert.Equal(t, "prod", next.Vnode.Labels["env"])
+
+	changed, err := ctl.store.Upsert(&vnodes.VirtualNode{
+		Name:       "db",
+		Hostname:   "db",
+		GUID:       "11111111-1111-1111-1111-111111111111",
+		SourceType: confgroup.TypeDyncfg,
+		Source:     "dyncfg",
+		Labels:     map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	sourceOnly, ok := ctl.LookupSnapshot("db")
+	require.True(t, ok)
+	assert.Greater(t, sourceOnly.Revision, next.Revision)
+	assert.Equal(t, next.MetadataRevision, sourceOnly.MetadataRevision,
+		"source-only commits are consumed without marking runtime-visible metadata dirty")
+
+	changed, err = ctl.store.Upsert(&vnodes.VirtualNode{
+		Name:       "db",
+		Hostname:   "db-new",
+		GUID:       "11111111-1111-1111-1111-111111111111",
+		SourceType: confgroup.TypeDyncfg,
+		Source:     "dyncfg",
+		Labels:     map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	metadataChanged, ok := ctl.LookupSnapshot("db")
+	require.True(t, ok)
+	assert.Greater(t, metadataChanged.Revision, sourceOnly.Revision)
+	assert.Greater(t, metadataChanged.MetadataRevision, sourceOnly.MetadataRevision)
+}
+
 type controllerSeams struct {
 	affectedJobs      map[string][]string
 	affectedJobsCalls []string
-	applyCalls        []string
 }
 
 func newControllerTestSubject(initial map[string]*vnodes.VirtualNode) (*Controller, *bytes.Buffer, *controllerSeams) {
@@ -467,9 +520,6 @@ func newControllerTestSubject(initial map[string]*vnodes.VirtualNode) (*Controll
 		AffectedJobs: func(vnode string) []string {
 			seams.affectedJobsCalls = append(seams.affectedJobsCalls, vnode)
 			return seams.affectedJobs[vnode]
-		},
-		ApplyVnodeUpdate: func(name string, _ *vnodes.VirtualNode) {
-			seams.applyCalls = append(seams.applyCalls, name)
 		},
 	})
 	return ctl, &out, seams

--- a/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/dyncfg.go
@@ -198,7 +198,6 @@ func (c *Controller) dyncfgCmdAdd(fn dyncfg.Function) {
 		return
 	}
 
-	c.applyUpdate(name, cfg)
 	c.api.SendCodef(fn, 202, "")
 	c.createJob(cfg, dyncfg.StatusRunning)
 }
@@ -241,7 +240,6 @@ func (c *Controller) dyncfgCmdUpdate(fn dyncfg.Function) {
 		return
 	}
 
-	c.applyUpdate(name, cfg)
 	c.api.SendCodef(fn, 202, "")
 	c.createJob(cfg, dyncfg.StatusRunning)
 }
@@ -310,12 +308,6 @@ func (c *Controller) affectedJobsFor(vnode string) string {
 		return ""
 	}
 	return strings.Join(c.affectedJobs(vnode), ", ")
-}
-
-func (c *Controller) applyUpdate(name string, cfg *vnodes.VirtualNode) {
-	if c.applyVnodeUpdate != nil {
-		c.applyVnodeUpdate(name, cfg)
-	}
 }
 
 func (c *Controller) verifyVnodeUnique(newCfg *vnodes.VirtualNode) error {

--- a/src/go/plugin/agent/jobmgr/vnodectl/store.go
+++ b/src/go/plugin/agent/jobmgr/vnodectl/store.go
@@ -9,25 +9,62 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
 
-// vnodeStore is read from collector command effects running off the jobmgr
-// loop while vnode mutations stay loop-serialized, so access is guarded by mu.
+// vnodeStore is read from collector command effects and running job goroutines
+// while vnode mutations stay loop-serialized, so access is guarded by mu.
 type vnodeStore struct {
-	mu    sync.RWMutex
-	items map[string]*vnodes.VirtualNode
+	mu           sync.RWMutex
+	items        map[string]*vnodeEntry
+	nextRevision uint64
+}
+
+type vnodeEntry struct {
+	cfg              *vnodes.VirtualNode
+	revision         uint64
+	metadataRevision uint64
+}
+
+type Snapshot struct {
+	Vnode            *vnodes.VirtualNode
+	Revision         uint64
+	MetadataRevision uint64
 }
 
 func newVnodeStore(items map[string]*vnodes.VirtualNode) *vnodeStore {
-	if items == nil {
-		items = make(map[string]*vnodes.VirtualNode)
+	s := &vnodeStore{items: make(map[string]*vnodeEntry)}
+	for name, cfg := range items {
+		if cfg == nil {
+			continue
+		}
+		cp := cfg.Copy()
+		if cp.Name == "" {
+			cp.Name = name
+		}
+		s.nextRevision++
+		s.items[name] = &vnodeEntry{
+			cfg:              cp,
+			revision:         s.nextRevision,
+			metadataRevision: s.nextRevision,
+		}
 	}
-	return &vnodeStore{items: items}
+	return s
 }
 
 func (s *vnodeStore) Lookup(name string) (*vnodes.VirtualNode, bool) {
+	snap, ok := s.LookupSnapshot(name)
+	if !ok {
+		return nil, false
+	}
+	return snap.Vnode, true
+}
+
+func (s *vnodeStore) LookupSnapshot(name string) (Snapshot, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	cfg, ok := s.items[name]
-	return cfg, ok
+	ent, ok := s.items[name]
+	if !ok {
+		return Snapshot{}, false
+	}
+	return ent.snapshot(), true
 }
 
 func (s *vnodeStore) Upsert(cfg *vnodes.VirtualNode) (bool, error) {
@@ -36,10 +73,20 @@ func (s *vnodeStore) Upsert(cfg *vnodes.VirtualNode) (bool, error) {
 	if cfg == nil {
 		return false, fmt.Errorf("nil vnode config")
 	}
-	if orig, ok := s.items[cfg.Name]; ok && sameStoredVnode(orig, cfg) {
+	if orig, ok := s.items[cfg.Name]; ok && sameStoredVnode(orig.cfg, cfg) {
 		return false, nil
 	}
-	s.items[cfg.Name] = cfg
+	next := cfg.Copy()
+	s.nextRevision++
+	metadataRevision := s.nextRevision
+	if orig, ok := s.items[cfg.Name]; ok && orig.cfg.Equal(next) {
+		metadataRevision = orig.metadataRevision
+	}
+	s.items[cfg.Name] = &vnodeEntry{
+		cfg:              next,
+		revision:         s.nextRevision,
+		metadataRevision: metadataRevision,
+	}
 	return true, nil
 }
 
@@ -56,10 +103,18 @@ func (s *vnodeStore) Remove(name string) bool {
 func (s *vnodeStore) ForEach(fn func(cfg *vnodes.VirtualNode) bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	for _, cfg := range s.items {
-		if !fn(cfg) {
+	for _, ent := range s.items {
+		if !fn(ent.cfg.Copy()) {
 			return
 		}
+	}
+}
+
+func (e *vnodeEntry) snapshot() Snapshot {
+	return Snapshot{
+		Vnode:            e.cfg.Copy(),
+		Revision:         e.revision,
+		MetadataRevision: e.metadataRevision,
 	}
 }
 

--- a/src/go/plugin/framework/jobruntime/job_v1.go
+++ b/src/go/plugin/framework/jobruntime/job_v1.go
@@ -307,15 +307,16 @@ func (j *Job) SetVnodeSnapshot(snapshot VnodeSnapshot) {
 	if snapshot.Vnode == nil || (j.module != nil && j.module.VirtualNode() != nil) {
 		return
 	}
+	next := snapshot.Vnode.Copy()
 	j.vnodeMu.Lock()
-	j.vnode = *snapshot.Vnode.Copy()
-	j.vnodeMu.Unlock()
+	j.vnode = *next
 	if snapshot.Revision != 0 {
 		j.vnodeRevision = snapshot.Revision
 	}
 	if snapshot.MetadataRevision != 0 {
 		j.vnodeMetadataRevision = snapshot.MetadataRevision
 	}
+	j.vnodeMu.Unlock()
 }
 
 func (j *Job) refreshVnodeSnapshot() bool {
@@ -333,6 +334,11 @@ func (j *Job) applyVnodeSnapshot(snapshot VnodeSnapshot) bool {
 	if snapshot.Vnode == nil {
 		return false
 	}
+	next := snapshot.Vnode.Copy()
+
+	j.vnodeMu.Lock()
+	defer j.vnodeMu.Unlock()
+
 	if snapshot.Revision != 0 && snapshot.Revision <= j.vnodeRevision {
 		return false
 	}
@@ -340,11 +346,9 @@ func (j *Job) applyVnodeSnapshot(snapshot VnodeSnapshot) bool {
 	createChart := false
 	if metadataChanged {
 		j.vnodeCreated = false
-		createChart = j.vnode.GUID != snapshot.Vnode.GUID
+		createChart = j.vnode.GUID != next.GUID
 	}
-	j.vnodeMu.Lock()
-	j.vnode = *snapshot.Vnode.Copy()
-	j.vnodeMu.Unlock()
+	j.vnode = *next
 	if snapshot.Revision != 0 {
 		j.vnodeRevision = snapshot.Revision
 	}

--- a/src/go/plugin/framework/jobruntime/job_v1.go
+++ b/src/go/plugin/framework/jobruntime/job_v1.go
@@ -57,22 +57,26 @@ func newCollectDurationChart(pluginName string) *collectorapi.Chart {
 }
 
 type JobConfig struct {
-	PluginName      string
-	Name            string
-	ModuleName      string
-	FullName        string
-	Source          string
-	Module          collectorapi.CollectorV1
-	Labels          map[string]string
-	Out             io.Writer
-	UpdateEvery     int
-	AutoDetectEvery int
-	Priority        int
-	IsStock         bool
-	Vnode           vnodes.VirtualNode
-	AuditMode       bool
-	AuditAnalyzer   metricsaudit.Analyzer
-	FunctionOnly    bool
+	PluginName            string
+	Name                  string
+	ModuleName            string
+	FullName              string
+	Source                string
+	Module                collectorapi.CollectorV1
+	Labels                map[string]string
+	Out                   io.Writer
+	UpdateEvery           int
+	AutoDetectEvery       int
+	Priority              int
+	IsStock               bool
+	Vnode                 vnodes.VirtualNode
+	VnodeName             string
+	VnodeRevision         uint64
+	VnodeMetadataRevision uint64
+	VnodeLookup           VnodeLookup
+	AuditMode             bool
+	AuditAnalyzer         metricsaudit.Analyzer
+	FunctionOnly          bool
 }
 
 func NewJob(cfg JobConfig) *Job {
@@ -86,27 +90,30 @@ func NewJob(cfg JobConfig) *Job {
 		AutoDetectEvery: cfg.AutoDetectEvery,
 		AutoDetectTries: infTries,
 
-		pluginName:           cfg.PluginName,
-		name:                 cfg.Name,
-		moduleName:           cfg.ModuleName,
-		fullName:             cfg.FullName,
-		updateEvery:          cfg.UpdateEvery,
-		priority:             cfg.Priority,
-		isStock:              cfg.IsStock,
-		functionOnly:         cfg.FunctionOnly,
-		module:               cfg.Module,
-		labels:               cfg.Labels,
-		out:                  cfg.Out,
-		collectStatusChart:   newCollectStatusChart(cfg.PluginName),
-		collectDurationChart: newCollectDurationChart(cfg.PluginName),
-		stopCtrl:             newStopController(),
-		tick:                 make(chan int),
-		buf:                  &buf,
-		api:                  netdataapi.New(&buf),
-		vnode:                cfg.Vnode,
-		updVnode:             make(chan *vnodes.VirtualNode, 1),
-		auditMode:            cfg.AuditMode,
-		auditAnalyzer:        cfg.AuditAnalyzer,
+		pluginName:            cfg.PluginName,
+		name:                  cfg.Name,
+		moduleName:            cfg.ModuleName,
+		fullName:              cfg.FullName,
+		updateEvery:           cfg.UpdateEvery,
+		priority:              cfg.Priority,
+		isStock:               cfg.IsStock,
+		functionOnly:          cfg.FunctionOnly,
+		module:                cfg.Module,
+		labels:                cfg.Labels,
+		out:                   cfg.Out,
+		collectStatusChart:    newCollectStatusChart(cfg.PluginName),
+		collectDurationChart:  newCollectDurationChart(cfg.PluginName),
+		stopCtrl:              newStopController(),
+		tick:                  make(chan int),
+		buf:                   &buf,
+		api:                   netdataapi.New(&buf),
+		vnode:                 cfg.Vnode,
+		vnodeName:             cfg.VnodeName,
+		vnodeRevision:         cfg.VnodeRevision,
+		vnodeMetadataRevision: cfg.VnodeMetadataRevision,
+		vnodeLookup:           cfg.VnodeLookup,
+		auditMode:             cfg.AuditMode,
+		auditAnalyzer:         cfg.AuditAnalyzer,
 	}
 
 	log := logger.New().With(jobLoggerAttrs(j.ModuleName(), j.Name(), cfg.Source)...)
@@ -157,9 +164,12 @@ type Job struct {
 	// vnodeMu covers j.vnode against off-goroutine readers (Vnode is
 	// called from the manager loop on registered jobs) racing the job
 	// goroutine's writes and the pre-Start baseline write.
-	vnodeMu  sync.RWMutex
-	vnode    vnodes.VirtualNode
-	updVnode chan *vnodes.VirtualNode
+	vnodeMu               sync.RWMutex
+	vnode                 vnodes.VirtualNode
+	vnodeName             string
+	vnodeRevision         uint64
+	vnodeMetadataRevision uint64
+	vnodeLookup           VnodeLookup
 
 	retries atomic.Int64
 	prevRun time.Time
@@ -288,31 +298,60 @@ func (j *Job) AutoDetection(ctx context.Context) (err error) {
 	return nil
 }
 
-func (j *Job) UpdateVnode(vnode *vnodes.VirtualNode) {
-	if vnode == nil {
-		return
-	}
-	select {
-	case <-j.updVnode:
-	default:
-	}
-	j.updVnode <- vnode
-}
-
-// SetVnodeBaseline commits the vnode config directly into the job BEFORE
-// Start: registration-time freshness must be visible to Cleanup even when
-// the job never collects, and it must NOT drain a concurrently queued live
-// update - UpdateVnode's slot keeps the newest committed value, which still
-// applies at collection. Pre-Start only: the job goroutine does not exist
-// yet, and the write is published to it by the Start goroutine launch.
-// Module-owned vnode state is never overridden.
-func (j *Job) SetVnodeBaseline(vnode *vnodes.VirtualNode) {
-	if vnode == nil || (j.module != nil && j.module.VirtualNode() != nil) {
+// SetVnodeSnapshot commits the vnode config directly into the job BEFORE Start:
+// registration-time freshness must be visible to Cleanup even when the job
+// never collects. Pre-Start only: the job goroutine does not exist yet, and the
+// write is published to it by the Start goroutine launch. Module-owned vnode
+// state is never overridden.
+func (j *Job) SetVnodeSnapshot(snapshot VnodeSnapshot) {
+	if snapshot.Vnode == nil || (j.module != nil && j.module.VirtualNode() != nil) {
 		return
 	}
 	j.vnodeMu.Lock()
-	j.vnode = *vnode.Copy()
+	j.vnode = *snapshot.Vnode.Copy()
 	j.vnodeMu.Unlock()
+	if snapshot.Revision != 0 {
+		j.vnodeRevision = snapshot.Revision
+	}
+	if snapshot.MetadataRevision != 0 {
+		j.vnodeMetadataRevision = snapshot.MetadataRevision
+	}
+}
+
+func (j *Job) refreshVnodeSnapshot() bool {
+	if j.vnodeName == "" || j.vnodeLookup == nil {
+		return false
+	}
+	snapshot, ok := j.vnodeLookup(j.vnodeName)
+	if !ok {
+		return false
+	}
+	return j.applyVnodeSnapshot(snapshot)
+}
+
+func (j *Job) applyVnodeSnapshot(snapshot VnodeSnapshot) bool {
+	if snapshot.Vnode == nil {
+		return false
+	}
+	if snapshot.Revision != 0 && snapshot.Revision <= j.vnodeRevision {
+		return false
+	}
+	metadataChanged := snapshot.MetadataRevision == 0 || snapshot.MetadataRevision != j.vnodeMetadataRevision
+	createChart := false
+	if metadataChanged {
+		j.vnodeCreated = false
+		createChart = j.vnode.GUID != snapshot.Vnode.GUID
+	}
+	j.vnodeMu.Lock()
+	j.vnode = *snapshot.Vnode.Copy()
+	j.vnodeMu.Unlock()
+	if snapshot.Revision != 0 {
+		j.vnodeRevision = snapshot.Revision
+	}
+	if snapshot.MetadataRevision != 0 {
+		j.vnodeMetadataRevision = snapshot.MetadataRevision
+	}
+	return createChart
 }
 
 // Tick Tick.
@@ -524,15 +563,7 @@ func (j *Job) collect() collectedMetrics {
 func (j *Job) processMetrics(mx collectedMetrics, startTime time.Time, sinceLastRun int) bool {
 	var createChart bool
 	if j.module.VirtualNode() == nil {
-		select {
-		case vnode := <-j.updVnode:
-			j.vnodeCreated = false
-			createChart = j.vnode.GUID != vnode.GUID
-			j.vnodeMu.Lock()
-			j.vnode = *vnode.Copy()
-			j.vnodeMu.Unlock()
-		default:
-		}
+		createChart = j.refreshVnodeSnapshot()
 	}
 
 	if !j.vnodeCreated {

--- a/src/go/plugin/framework/jobruntime/job_v1_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v1_test.go
@@ -3,16 +3,19 @@
 package jobruntime
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -80,7 +83,7 @@ func TestJob_Panicked(t *testing.T) {
 }
 
 // Vnode() is read off-goroutine (the manager loop reads registered jobs'
-// vnodes) while the pre-Start baseline write may still be in flight on the
+// vnodes) while the pre-Start snapshot write may still be in flight on the
 // starting goroutine: the accesses must be synchronized. This test fails
 // under -race without vnodeMu.
 func TestJob_VnodeAccessIsSynchronized(t *testing.T) {
@@ -95,33 +98,27 @@ func TestJob_VnodeAccessIsSynchronized(t *testing.T) {
 		}
 	}()
 	for range 200 {
-		job.SetVnodeBaseline(baseline)
+		job.SetVnodeSnapshot(VnodeSnapshot{Vnode: baseline})
 	}
 	<-done
 }
 
-// The pre-Start baseline commits into the job WITHOUT draining the live
-// update queue: a concurrently queued newer update must survive the
-// baseline and still apply at collection - a queued (UpdateVnode) baseline
-// would evict it from the one-slot channel, and a job stopped before its
-// first collection would clean up on the stale creation-time vnode.
-func TestJob_SetVnodeBaselineDoesNotDrainQueuedUpdate(t *testing.T) {
+// The pre-Start snapshot commit is visible without a collection: a job stopped
+// before its first tick must clean up on the reconciled vnode, not the stale
+// creation-time vnode.
+func TestJob_SetVnodeSnapshotCommitsRevisionBeforeStart(t *testing.T) {
 	job := newTestJob()
-	queued := &vnodes.VirtualNode{Name: "v", Hostname: "queued", GUID: "guid-q"}
-	baseline := &vnodes.VirtualNode{Name: "v", Hostname: "baseline", GUID: "guid-b"}
-
-	job.UpdateVnode(queued)
-	job.SetVnodeBaseline(baseline)
-
-	assert.Equal(t, "baseline", job.vnode.Hostname,
-		"the baseline must be committed into the job, visible without a collection")
-	select {
-	case v := <-job.updVnode:
-		assert.Equal(t, "queued", v.Hostname,
-			"the queued live update must survive the baseline and still apply at collection")
-	default:
-		t.Fatal("the baseline must not drain the queued live update")
+	snapshot := VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "v", Hostname: "baseline", GUID: "guid-b"},
+		Revision:         7,
+		MetadataRevision: 5,
 	}
+
+	job.SetVnodeSnapshot(snapshot)
+	assert.Equal(t, "baseline", job.vnode.Hostname,
+		"the snapshot must be committed into the job, visible without a collection")
+	assert.Equal(t, uint64(7), job.vnodeRevision)
+	assert.Equal(t, uint64(5), job.vnodeMetadataRevision)
 }
 
 func TestJob_AutoDetectionEvery(t *testing.T) {
@@ -398,35 +395,169 @@ func TestJob_Tick(t *testing.T) {
 	}
 }
 
-func TestJob_UpdateVnode_NilIgnored(t *testing.T) {
-	tests := map[string]struct {
-		update *vnodes.VirtualNode
-	}{
-		"nil vnode update is ignored": {
-			update: nil,
+func TestJob_PullVnodeUpdateDuringCollectAppliesBeforeSameCycleEmission(t *testing.T) {
+	var out bytes.Buffer
+	current := newSnapshotHolder(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "host-one", GUID: "node-guid"},
+		Revision:         1,
+		MetadataRevision: 1,
+	})
+	collectStarted := make(chan struct{})
+	collectRelease := make(chan struct{})
+
+	mod := &collectorapi.MockCollectorV1{
+		ChartsFunc: func() *collectorapi.Charts {
+			return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+		},
+		CollectFunc: func(context.Context) map[string]int64 {
+			close(collectStarted)
+			<-collectRelease
+			return map[string]int64{"d1": 1}
 		},
 	}
+	job := NewJob(JobConfig{
+		PluginName:            pluginName,
+		Name:                  jobName,
+		ModuleName:            modName,
+		FullName:              modName + "_" + jobName,
+		Module:                mod,
+		Out:                   &out,
+		Vnode:                 *current.snapshot().Vnode.Copy(),
+		VnodeName:             "db",
+		VnodeRevision:         1,
+		VnodeMetadataRevision: 1,
+		VnodeLookup:           current.lookup,
+	})
+	require.NoError(t, job.AutoDetection(context.Background()))
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			job := newTestJob()
-			job.module = &collectorapi.MockCollectorV1{}
-			job.charts = &collectorapi.Charts{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		job.runOnce()
+	}()
+	<-collectStarted
+	current.set(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "host-two", GUID: "node-guid"},
+		Revision:         2,
+		MetadataRevision: 2,
+	})
+	close(collectRelease)
+	<-done
 
-			job.UpdateVnode(tc.update)
+	assert.Contains(t, out.String(), "HOST_DEFINE 'node-guid' 'host-two'")
+	assert.NotContains(t, out.String(), "HOST_DEFINE 'node-guid' 'host-one'")
+}
 
-			assert.NotPanics(t, func() {
-				_ = job.processMetrics(
-					collectedMetrics{
-						intMetrics:   map[string]int64{},
-						floatMetrics: map[string]float64{},
-					},
-					time.Now(),
-					1,
-				)
-			})
-		})
+func TestJob_PullSourceOnlyUpdateDoesNotResendHostInfo(t *testing.T) {
+	var out bytes.Buffer
+	current := newSnapshotHolder(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "host-one", GUID: "node-guid", SourceType: "user"},
+		Revision:         1,
+		MetadataRevision: 1,
+	})
+	mod := &collectorapi.MockCollectorV1{
+		ChartsFunc: func() *collectorapi.Charts {
+			return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+		},
+		CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
 	}
+	job := NewJob(JobConfig{
+		PluginName:            pluginName,
+		Name:                  jobName,
+		ModuleName:            modName,
+		FullName:              modName + "_" + jobName,
+		Module:                mod,
+		Out:                   &out,
+		Vnode:                 *current.snapshot().Vnode.Copy(),
+		VnodeName:             "db",
+		VnodeRevision:         1,
+		VnodeMetadataRevision: 1,
+		VnodeLookup:           current.lookup,
+	})
+	require.NoError(t, job.AutoDetection(context.Background()))
+	job.runOnce()
+
+	out.Reset()
+	current.set(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "host-one", GUID: "node-guid", SourceType: "dyncfg"},
+		Revision:         2,
+		MetadataRevision: 1,
+	})
+	job.runOnce()
+
+	assert.NotContains(t, out.String(), "HOST_DEFINE 'node-guid' 'host-one'")
+}
+
+func TestJob_ModuleOwnedVnodeDoesNotOverrideConfiguredJobVnode(t *testing.T) {
+	var out bytes.Buffer
+	mod := &v1ModuleOwnedVnodeCollector{
+		MockCollectorV1: collectorapi.MockCollectorV1{
+			ChartsFunc: func() *collectorapi.Charts {
+				return &collectorapi.Charts{&collectorapi.Chart{ID: "id", Title: "t", Units: "u", Dims: collectorapi.Dims{{ID: "d1"}}}}
+			},
+			CollectFunc: func(context.Context) map[string]int64 { return map[string]int64{"d1": 1} },
+		},
+		vnode: &vnodes.VirtualNode{Name: "module", Hostname: "module-host", GUID: "module-guid"},
+	}
+	current := newSnapshotHolder(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "pulled-host", GUID: "pulled-guid"},
+		Revision:         2,
+		MetadataRevision: 2,
+	})
+	job := NewJob(JobConfig{
+		PluginName:            pluginName,
+		Name:                  jobName,
+		ModuleName:            modName,
+		FullName:              modName + "_" + jobName,
+		Module:                mod,
+		Out:                   &out,
+		Vnode:                 vnodes.VirtualNode{Name: "db", Hostname: "job-host", GUID: "job-guid"},
+		VnodeName:             "db",
+		VnodeRevision:         1,
+		VnodeMetadataRevision: 1,
+		VnodeLookup:           current.lookup,
+	})
+	require.NoError(t, job.AutoDetection(context.Background()))
+
+	job.runOnce()
+
+	assert.Contains(t, out.String(), "HOST_DEFINE 'job-guid' 'job-host'")
+	assert.NotContains(t, out.String(), "module-host")
+	assert.NotContains(t, out.String(), "pulled-host")
+}
+
+type v1ModuleOwnedVnodeCollector struct {
+	collectorapi.MockCollectorV1
+	vnode *vnodes.VirtualNode
+}
+
+func (c *v1ModuleOwnedVnodeCollector) VirtualNode() *vnodes.VirtualNode {
+	return c.vnode
+}
+
+type vnodeSnapshotHolder struct {
+	mu      sync.Mutex
+	current VnodeSnapshot
+}
+
+func newSnapshotHolder(snapshot VnodeSnapshot) *vnodeSnapshotHolder {
+	return &vnodeSnapshotHolder{current: snapshot.Copy()}
+}
+
+func (h *vnodeSnapshotHolder) set(snapshot VnodeSnapshot) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.current = snapshot.Copy()
+}
+
+func (h *vnodeSnapshotHolder) snapshot() VnodeSnapshot {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.current.Copy()
+}
+
+func (h *vnodeSnapshotHolder) lookup(string) (VnodeSnapshot, bool) {
+	return h.snapshot(), true
 }
 
 func newTestFunctionOnlyJob() *Job {

--- a/src/go/plugin/framework/jobruntime/job_v2.go
+++ b/src/go/plugin/framework/jobruntime/job_v2.go
@@ -220,16 +220,17 @@ func (j *JobV2) SetVnodeSnapshot(snapshot VnodeSnapshot) {
 		return
 	}
 	next := snapshot.Vnode.Copy()
+	var metadataChanged bool
 	j.vnodeMu.Lock()
 	j.vnode = *next
-	j.vnodeMu.Unlock()
 	if snapshot.Revision != 0 {
 		j.vnodeRevision = snapshot.Revision
 	}
-	metadataChanged := snapshot.MetadataRevision == 0 || snapshot.MetadataRevision != j.vnodeMetadataRevision
+	metadataChanged = snapshot.MetadataRevision == 0 || snapshot.MetadataRevision != j.vnodeMetadataRevision
 	if snapshot.MetadataRevision != 0 {
 		j.vnodeMetadataRevision = snapshot.MetadataRevision
 	}
+	j.vnodeMu.Unlock()
 	if metadataChanged {
 		if state := j.scopeStates[defaultHostScopeKey]; state != nil {
 			state.host.invalidateDefine()
@@ -253,31 +254,39 @@ func (j *JobV2) applyVnodeSnapshot(snapshot VnodeSnapshot) {
 		return
 	}
 	if j.module != nil && j.module.VirtualNode() != nil {
+		advanced := false
+		j.vnodeMu.Lock()
 		if snapshot.Revision != 0 && snapshot.Revision > j.vnodeRevision {
 			j.vnodeRevision = snapshot.Revision
 			if snapshot.MetadataRevision != 0 {
 				j.vnodeMetadataRevision = snapshot.MetadataRevision
 			}
+			advanced = true
+		}
+		j.vnodeMu.Unlock()
+		if advanced {
 			j.Debugf("ignoring vnode update for module-owned vnode")
 		}
-		return
-	}
-	if snapshot.Revision != 0 && snapshot.Revision <= j.vnodeRevision {
 		return
 	}
 
 	next := snapshot.Vnode.Copy()
 
+	var metadataChanged bool
 	j.vnodeMu.Lock()
+	if snapshot.Revision != 0 && snapshot.Revision <= j.vnodeRevision {
+		j.vnodeMu.Unlock()
+		return
+	}
 	j.vnode = *next
-	j.vnodeMu.Unlock()
 	if snapshot.Revision != 0 {
 		j.vnodeRevision = snapshot.Revision
 	}
-	metadataChanged := snapshot.MetadataRevision == 0 || snapshot.MetadataRevision != j.vnodeMetadataRevision
+	metadataChanged = snapshot.MetadataRevision == 0 || snapshot.MetadataRevision != j.vnodeMetadataRevision
 	if snapshot.MetadataRevision != 0 {
 		j.vnodeMetadataRevision = snapshot.MetadataRevision
 	}
+	j.vnodeMu.Unlock()
 	if metadataChanged {
 		// Registry owner release is intentionally tied to the next successful
 		// emission or cleanup, so obsolete emission can still select the old host.

--- a/src/go/plugin/framework/jobruntime/job_v2.go
+++ b/src/go/plugin/framework/jobruntime/job_v2.go
@@ -28,21 +28,25 @@ import (
 )
 
 type JobV2Config struct {
-	PluginName      string
-	Name            string
-	ModuleName      string
-	FullName        string
-	Source          string
-	Module          collectorapi.CollectorV2
-	Labels          map[string]string
-	Out             io.Writer
-	UpdateEvery     int
-	AutoDetectEvery int
-	IsStock         bool
-	Vnode           vnodes.VirtualNode
-	VnodeRegistry   *vnoderegistry.Registry
-	FunctionOnly    bool
-	RuntimeService  runtimecomp.Service
+	PluginName            string
+	Name                  string
+	ModuleName            string
+	FullName              string
+	Source                string
+	Module                collectorapi.CollectorV2
+	Labels                map[string]string
+	Out                   io.Writer
+	UpdateEvery           int
+	AutoDetectEvery       int
+	IsStock               bool
+	Vnode                 vnodes.VirtualNode
+	VnodeName             string
+	VnodeRevision         uint64
+	VnodeMetadataRevision uint64
+	VnodeLookup           VnodeLookup
+	VnodeRegistry         *vnoderegistry.Registry
+	FunctionOnly          bool
+	RuntimeService        runtimecomp.Service
 }
 
 func NewJobV2(cfg JobV2Config) *JobV2 {
@@ -56,26 +60,29 @@ func NewJobV2(cfg JobV2Config) *JobV2 {
 	}
 
 	j := &JobV2{
-		pluginName:      cfg.PluginName,
-		name:            cfg.Name,
-		moduleName:      cfg.ModuleName,
-		fullName:        cfg.FullName,
-		updateEvery:     cfg.UpdateEvery,
-		autoDetectEvery: cfg.AutoDetectEvery,
-		autoDetectTries: infTries,
-		isStock:         cfg.IsStock,
-		functionOnly:    cfg.FunctionOnly,
-		module:          cfg.Module,
-		labels:          cloneLabels(cfg.Labels),
-		out:             cfg.Out,
-		stopCtrl:        newStopController(),
-		tick:            make(chan int),
-		updVnode:        make(chan *vnodes.VirtualNode, 1),
-		buf:             &buf,
-		api:             netdataapi.New(&buf),
-		vnode:           cfg.Vnode,
-		vnodeRegistry:   registry,
-		runtimeService:  cfg.RuntimeService,
+		pluginName:            cfg.PluginName,
+		name:                  cfg.Name,
+		moduleName:            cfg.ModuleName,
+		fullName:              cfg.FullName,
+		updateEvery:           cfg.UpdateEvery,
+		autoDetectEvery:       cfg.AutoDetectEvery,
+		autoDetectTries:       infTries,
+		isStock:               cfg.IsStock,
+		functionOnly:          cfg.FunctionOnly,
+		module:                cfg.Module,
+		labels:                cloneLabels(cfg.Labels),
+		out:                   cfg.Out,
+		stopCtrl:              newStopController(),
+		tick:                  make(chan int),
+		buf:                   &buf,
+		api:                   netdataapi.New(&buf),
+		vnode:                 cfg.Vnode,
+		vnodeName:             cfg.VnodeName,
+		vnodeRevision:         cfg.VnodeRevision,
+		vnodeMetadataRevision: cfg.VnodeMetadataRevision,
+		vnodeLookup:           cfg.VnodeLookup,
+		vnodeRegistry:         registry,
+		runtimeService:        cfg.RuntimeService,
 	}
 	if j.out == nil {
 		j.out = io.Discard
@@ -126,9 +133,12 @@ type JobV2 struct {
 	prevRun time.Time
 	retries atomic.Int64
 
-	vnodeMu  sync.RWMutex
-	vnode    vnodes.VirtualNode
-	updVnode chan *vnodes.VirtualNode
+	vnodeMu               sync.RWMutex
+	vnode                 vnodes.VirtualNode
+	vnodeName             string
+	vnodeRevision         uint64
+	vnodeMetadataRevision uint64
+	vnodeLookup           VnodeLookup
 
 	vnodeRegistry *vnoderegistry.Registry
 
@@ -196,36 +206,87 @@ func (j *JobV2) Vnode() vnodes.VirtualNode {
 	defer j.vnodeMu.RUnlock()
 	return *j.vnode.Copy()
 }
-func (j *JobV2) UpdateVnode(vnode *vnodes.VirtualNode) {
-	if vnode == nil {
-		return
-	}
-	select {
-	case <-j.updVnode:
-	default:
-	}
-	j.updVnode <- vnode
-}
 
-// SetVnodeBaseline commits the vnode config into the job BEFORE Start -
-// same contract as the V1 method: visible to cleanup without a collection,
-// never drains a concurrently queued live update, never overrides
-// module-owned vnode state, pre-Start callers only.
-func (j *JobV2) SetVnodeBaseline(vnode *vnodes.VirtualNode) {
-	if vnode == nil {
+// SetVnodeSnapshot commits the vnode config directly into the job BEFORE Start:
+// registration-time freshness must be visible to Cleanup even when the job
+// never collects. Pre-Start only: the job goroutine does not exist yet, and the
+// write is published to it by the Start goroutine launch. Module-owned vnode
+// state is never overridden.
+func (j *JobV2) SetVnodeSnapshot(snapshot VnodeSnapshot) {
+	if snapshot.Vnode == nil {
 		return
 	}
 	if j.module != nil && j.module.VirtualNode() != nil {
 		return
 	}
-	next := vnode.Copy()
+	next := snapshot.Vnode.Copy()
 	j.vnodeMu.Lock()
 	j.vnode = *next
 	j.vnodeMu.Unlock()
-	if state := j.scopeStates[defaultHostScopeKey]; state != nil {
-		state.host.invalidateDefine()
+	if snapshot.Revision != 0 {
+		j.vnodeRevision = snapshot.Revision
+	}
+	metadataChanged := snapshot.MetadataRevision == 0 || snapshot.MetadataRevision != j.vnodeMetadataRevision
+	if snapshot.MetadataRevision != 0 {
+		j.vnodeMetadataRevision = snapshot.MetadataRevision
+	}
+	if metadataChanged {
+		if state := j.scopeStates[defaultHostScopeKey]; state != nil {
+			state.host.invalidateDefine()
+		}
 	}
 }
+
+func (j *JobV2) refreshVnodeSnapshot() {
+	if j.vnodeName == "" || j.vnodeLookup == nil {
+		return
+	}
+	snapshot, ok := j.vnodeLookup(j.vnodeName)
+	if !ok {
+		return
+	}
+	j.applyVnodeSnapshot(snapshot)
+}
+
+func (j *JobV2) applyVnodeSnapshot(snapshot VnodeSnapshot) {
+	if snapshot.Vnode == nil {
+		return
+	}
+	if j.module != nil && j.module.VirtualNode() != nil {
+		if snapshot.Revision != 0 && snapshot.Revision > j.vnodeRevision {
+			j.vnodeRevision = snapshot.Revision
+			if snapshot.MetadataRevision != 0 {
+				j.vnodeMetadataRevision = snapshot.MetadataRevision
+			}
+			j.Debugf("ignoring vnode update for module-owned vnode")
+		}
+		return
+	}
+	if snapshot.Revision != 0 && snapshot.Revision <= j.vnodeRevision {
+		return
+	}
+
+	next := snapshot.Vnode.Copy()
+
+	j.vnodeMu.Lock()
+	j.vnode = *next
+	j.vnodeMu.Unlock()
+	if snapshot.Revision != 0 {
+		j.vnodeRevision = snapshot.Revision
+	}
+	metadataChanged := snapshot.MetadataRevision == 0 || snapshot.MetadataRevision != j.vnodeMetadataRevision
+	if snapshot.MetadataRevision != 0 {
+		j.vnodeMetadataRevision = snapshot.MetadataRevision
+	}
+	if metadataChanged {
+		// Registry owner release is intentionally tied to the next successful
+		// emission or cleanup, so obsolete emission can still select the old host.
+		if state := j.scopeStates[defaultHostScopeKey]; state != nil {
+			state.host.invalidateDefine()
+		}
+	}
+}
+
 func (j *JobV2) Cleanup() {
 	j.buf.Reset()
 	snapshots := j.captureScopeCleanupSnapshots()
@@ -493,7 +554,7 @@ func (j *JobV2) runOnce() {
 	defer j.ResetAllOnce()
 	defer j.flushRuntimeAggregator()
 
-	j.applyPendingVnodeUpdate()
+	j.refreshVnodeSnapshot()
 
 	curTime := time.Now()
 	sinceLastRun := calcSinceLastRun(curTime, j.prevRun)
@@ -517,32 +578,6 @@ func (j *JobV2) runOnce() {
 func (j *JobV2) flushRuntimeAggregator() {
 	if j != nil && j.runtimeAggregator != nil {
 		j.runtimeAggregator.Flush()
-	}
-}
-
-func (j *JobV2) applyPendingVnodeUpdate() {
-	select {
-	case vnode := <-j.updVnode:
-		if vnode == nil {
-			return
-		}
-		if j.module != nil && j.module.VirtualNode() != nil {
-			// Match v1 ownership model: do not override module-owned vnode state.
-			j.Debugf("ignoring vnode update for module-owned vnode")
-			return
-		}
-
-		next := vnode.Copy()
-
-		j.vnodeMu.Lock()
-		j.vnode = *next
-		j.vnodeMu.Unlock()
-		// Registry owner release is intentionally tied to the next successful
-		// emission or cleanup, so obsolete emission can still select the old host.
-		if state := j.scopeStates[defaultHostScopeKey]; state != nil {
-			state.host.invalidateDefine()
-		}
-	default:
 	}
 }
 

--- a/src/go/plugin/framework/jobruntime/job_v2_cleanup.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_cleanup.go
@@ -52,18 +52,20 @@ func (j *JobV2) cleanupHostInfo(state *jobV2ScopeState) netdataapi.HostInfo {
 	if state == nil {
 		return netdataapi.HostInfo{}
 	}
+	// The returned HostInfo is consumed immediately for read-only
+	// stale-suppression checks; callers must not mutate Labels.
 	if state.scopeKey == defaultHostScopeKey && j.module != nil && j.module.VirtualNode() != nil {
 		vnode := j.currentVnode()
 		return netdataapi.HostInfo{
 			GUID:     vnode.GUID,
 			Hostname: vnode.Hostname,
-			Labels:   maps.Clone(vnode.Labels),
+			Labels:   vnode.Labels,
 		}
 	}
 	return netdataapi.HostInfo{
 		GUID:     state.host.cleanupInfo.GUID,
 		Hostname: state.host.cleanupInfo.Hostname,
-		Labels:   maps.Clone(state.host.cleanupInfo.Labels),
+		Labels:   state.host.cleanupInfo.Labels,
 	}
 }
 

--- a/src/go/plugin/framework/jobruntime/job_v2_cleanup.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_cleanup.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
 
 type jobV2CleanupSnapshot struct {
@@ -18,7 +17,7 @@ type jobV2CleanupSnapshot struct {
 	staleVnodeSuppressed bool
 }
 
-func (s *jobV2HostState) captureCleanupSnapshot(vnode vnodes.VirtualNode, allowStaleVnodeSuppression bool) jobV2CleanupSnapshot {
+func (s *jobV2HostState) captureCleanupSnapshot(info netdataapi.HostInfo, allowStaleVnodeSuppression bool) jobV2CleanupSnapshot {
 	if s == nil {
 		return jobV2CleanupSnapshot{}
 	}
@@ -26,7 +25,7 @@ func (s *jobV2HostState) captureCleanupSnapshot(vnode vnodes.VirtualNode, allowS
 	return jobV2CleanupSnapshot{
 		charts:               maps.Clone(s.cleanupCharts),
 		host:                 host,
-		staleVnodeSuppressed: allowStaleVnodeSuppression && shouldSuppressCleanupForStaleVnode(host, vnode),
+		staleVnodeSuppressed: allowStaleVnodeSuppression && shouldSuppressCleanupForStaleVnode(host, info),
 	}
 }
 
@@ -34,7 +33,6 @@ func (j *JobV2) captureScopeCleanupSnapshots() []jobV2CleanupSnapshot {
 	if j == nil || len(j.scopeStates) == 0 {
 		return nil
 	}
-	vnode := j.currentVnode()
 	keys := sortedScopeStateKeys(j.scopeStates)
 
 	snapshots := make([]jobV2CleanupSnapshot, 0, len(keys))
@@ -43,11 +41,30 @@ func (j *JobV2) captureScopeCleanupSnapshots() []jobV2CleanupSnapshot {
 		if state == nil {
 			continue
 		}
-		snapshot := state.host.captureCleanupSnapshot(vnode, key == defaultHostScopeKey)
+		snapshot := state.host.captureCleanupSnapshot(j.cleanupHostInfo(state), key == defaultHostScopeKey)
 		snapshot.scopeKey = key
 		snapshots = append(snapshots, snapshot)
 	}
 	return snapshots
+}
+
+func (j *JobV2) cleanupHostInfo(state *jobV2ScopeState) netdataapi.HostInfo {
+	if state == nil {
+		return netdataapi.HostInfo{}
+	}
+	if state.scopeKey == defaultHostScopeKey && j.module != nil && j.module.VirtualNode() != nil {
+		vnode := j.currentVnode()
+		return netdataapi.HostInfo{
+			GUID:     vnode.GUID,
+			Hostname: vnode.Hostname,
+			Labels:   maps.Clone(vnode.Labels),
+		}
+	}
+	return netdataapi.HostInfo{
+		GUID:     state.host.cleanupInfo.GUID,
+		Hostname: state.host.cleanupInfo.Hostname,
+		Labels:   maps.Clone(state.host.cleanupInfo.Labels),
+	}
 }
 
 func (j *JobV2) releaseAllScopeRegistryOwners() {
@@ -82,6 +99,7 @@ func (s *jobV2HostState) clearAfterCleanup() {
 	s.definedInfo = netdataapi.HostInfo{}
 	s.engineHost = jobV2HostRef{}
 	s.cleanupOwner = jobV2HostRef{}
+	s.cleanupInfo = netdataapi.HostInfo{}
 }
 
 func buildJobV2CleanupPlan(charts map[string]chartengine.ChartMeta) chartengine.Plan {
@@ -105,8 +123,8 @@ func buildJobV2CleanupPlan(charts map[string]chartengine.ChartMeta) chartengine.
 	return chartengine.Plan{Actions: actions}
 }
 
-func shouldSuppressCleanupForStaleVnode(cleanupHost jobV2HostRef, vnode vnodes.VirtualNode) bool {
+func shouldSuppressCleanupForStaleVnode(cleanupHost jobV2HostRef, info netdataapi.HostInfo) bool {
 	return cleanupHost.isVnode() &&
-		vnode.GUID == cleanupHost.guid &&
-		vnode.Labels["_node_stale_after_seconds"] != ""
+		info.GUID == cleanupHost.guid &&
+		info.Labels["_node_stale_after_seconds"] != ""
 }

--- a/src/go/plugin/framework/jobruntime/job_v2_host_state.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_host_state.go
@@ -53,6 +53,7 @@ type jobV2HostState struct {
 	definedInfo   netdataapi.HostInfo
 	engineHost    jobV2HostRef
 	cleanupOwner  jobV2HostRef
+	cleanupInfo   netdataapi.HostInfo
 	cleanupCharts map[string]chartengine.ChartMeta
 	// registryOwners tracks successfully emitted vnode owners so cleanup can
 	// release them after obsolete-chart emission.
@@ -150,6 +151,11 @@ func (s *jobV2HostState) commitSuccessfulEmission(plan chartengine.Plan, decisio
 	}
 
 	s.cleanupOwner = decision.targetHost
+	s.cleanupInfo = netdataapi.HostInfo{
+		GUID:     decision.defineInfo.GUID,
+		Hostname: decision.defineInfo.Hostname,
+		Labels:   maps.Clone(decision.defineInfo.Labels),
+	}
 }
 
 func (s *jobV2HostState) releaseRegistryOwners(registry *vnoderegistry.Registry) {

--- a/src/go/plugin/framework/jobruntime/job_v2_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_test.go
@@ -150,6 +150,15 @@ func newTestJobV2WithVnode(mod collectorapi.CollectorV2, out *bytes.Buffer, vnod
 	})
 }
 
+func bindJobV2VnodeLookup(job *JobV2, name string, snapshot VnodeSnapshot) *vnodeSnapshotHolder {
+	holder := newSnapshotHolder(snapshot)
+	job.vnodeName = name
+	job.vnodeRevision = snapshot.Revision
+	job.vnodeMetadataRevision = snapshot.MetadataRevision
+	job.vnodeLookup = holder.lookup
+	return holder
+}
+
 func newRegistryTestJobV2(t *testing.T, fullName string, registry *vnoderegistry.Registry, out *bytes.Buffer, vnode vnodes.VirtualNode) *JobV2 {
 	t.Helper()
 	store := metrix.NewCollectorStore()
@@ -244,27 +253,24 @@ groups:
 `
 }
 
-// Same contract as the V1 variant: the pre-Start baseline commits into the
-// job without draining the live update queue, so a concurrently queued
-// newer update still applies at collection.
-func TestJobV2_SetVnodeBaselineDoesNotDrainQueuedUpdate(t *testing.T) {
+// The pre-Start snapshot commit is visible without a collection: a job stopped
+// before its first tick must clean up on the reconciled vnode, not the stale
+// creation-time vnode.
+func TestJobV2_SetVnodeSnapshotCommitsRevisionBeforeStart(t *testing.T) {
 	mod := &mockModuleV2{store: metrix.NewCollectorStore(), template: chartTemplateV2()}
 	job := newTestJobV2(mod, &bytes.Buffer{})
-	queued := &vnodes.VirtualNode{Name: "v", Hostname: "queued", GUID: "guid-q"}
-	baseline := &vnodes.VirtualNode{Name: "v", Hostname: "baseline", GUID: "guid-b"}
+	snapshot := VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "v", Hostname: "baseline", GUID: "guid-b"},
+		Revision:         7,
+		MetadataRevision: 5,
+	}
 
-	job.UpdateVnode(queued)
-	job.SetVnodeBaseline(baseline)
+	job.SetVnodeSnapshot(snapshot)
 
 	assert.Equal(t, "baseline", job.Vnode().Hostname,
-		"the baseline must be committed into the job, visible without a collection")
-	select {
-	case v := <-job.updVnode:
-		assert.Equal(t, "queued", v.Hostname,
-			"the queued live update must survive the baseline and still apply at collection")
-	default:
-		t.Fatal("the baseline must not drain the queued live update")
-	}
+		"the snapshot must be committed into the job, visible without a collection")
+	assert.Equal(t, uint64(7), job.vnodeRevision)
+	assert.Equal(t, uint64(5), job.vnodeMetadataRevision)
 }
 
 func TestJobV2RunnerDoesNotRunDuringAutoDetection(t *testing.T) {
@@ -749,7 +755,7 @@ END`, chartengine.Priority, chartengine.Priority))
 				assert.Zero(t, job.buf.Len())
 			},
 		},
-		"module-owned vnode is not overridden by queued job vnode updates": {
+		"module-owned vnode is not overridden by pulled job vnode updates": {
 			run: func(t *testing.T) {
 				store := metrix.NewCollectorStore()
 				mod := &mockModuleV2{
@@ -782,6 +788,11 @@ END`, chartengine.Priority, chartengine.Priority))
 				}
 
 				job := newTestJobV2WithVnode(mod, &bytes.Buffer{}, *mod.vnode.Copy())
+				current := bindJobV2VnodeLookup(job, "db", VnodeSnapshot{
+					Vnode:            &vnodes.VirtualNode{Name: "old", Hostname: "old-host", GUID: "old-guid"},
+					Revision:         1,
+					MetadataRevision: 1,
+				})
 				require.NoError(t, job.AutoDetection(context.Background()))
 
 				runDone := make(chan struct{})
@@ -791,10 +802,10 @@ END`, chartengine.Priority, chartengine.Priority))
 				}()
 
 				<-collectStarted
-				job.UpdateVnode(&vnodes.VirtualNode{
-					Name:     "new",
-					Hostname: "new-host",
-					GUID:     "new-guid",
+				current.set(VnodeSnapshot{
+					Vnode:            &vnodes.VirtualNode{Name: "new", Hostname: "new-host", GUID: "new-guid"},
+					Revision:         2,
+					MetadataRevision: 2,
 				})
 				assert.Equal(t, "old-guid", mod.vnode.GUID)
 
@@ -1118,12 +1129,19 @@ func TestJobV2VnodeEmissionLifecycle(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	job := newTestJobV2WithVnode(mod, &out, vnodes.VirtualNode{
+	initial := vnodes.VirtualNode{
+		Name:     "db",
 		Hostname: "node-host",
 		GUID:     "node-guid",
 		Labels: map[string]string{
 			"region": "eu'\n",
 		},
+	}
+	job := newTestJobV2WithVnode(mod, &out, initial)
+	snapshot := bindJobV2VnodeLookup(job, "db", VnodeSnapshot{
+		Vnode:            &initial,
+		Revision:         1,
+		MetadataRevision: 1,
 	})
 	require.NoError(t, job.AutoDetection(context.Background()))
 
@@ -1149,9 +1167,10 @@ BEGIN 'module_job.workers_busy'`)
 	assert.NotContains(t, wire, "HOST_DEFINE 'node-guid' 'node-host'")
 
 	out.Reset()
-	job.UpdateVnode(&vnodes.VirtualNode{
-		Hostname: "node-host-2",
-		GUID:     "node-guid-2",
+	snapshot.set(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "node-host-2", GUID: "node-guid-2"},
+		Revision:         2,
+		MetadataRevision: 2,
 	})
 	current = 3
 	job.runOnce()
@@ -1163,6 +1182,114 @@ HOST_DEFINE_END
 HOST 'node-guid-2'
 
 CHART 'module_job.workers_busy'`)
+}
+
+func TestJobV2_PullVnodeUpdateDuringCollectAppliesOnNextCycle(t *testing.T) {
+	store := metrix.NewCollectorStore()
+	current := newSnapshotHolder(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "host-one", GUID: "node-guid"},
+		Revision:         1,
+		MetadataRevision: 1,
+	})
+	collectStarted := make(chan struct{})
+	collectRelease := make(chan struct{})
+	collectCalls := 0
+	mod := &mockModuleV2{
+		store:    store,
+		template: chartTemplateV2(),
+		collectFunc: func(context.Context) error {
+			collectCalls++
+			if collectCalls == 1 {
+				close(collectStarted)
+				<-collectRelease
+			}
+			store.Write().SnapshotMeter("apache").Gauge("workers_busy").Observe(float64(collectCalls))
+			return nil
+		},
+	}
+	var out bytes.Buffer
+	job := NewJobV2(JobV2Config{
+		PluginName:            pluginName,
+		Name:                  jobName,
+		ModuleName:            modName,
+		FullName:              modName + "_" + jobName,
+		Module:                mod,
+		Out:                   &out,
+		UpdateEvery:           1,
+		Vnode:                 *current.snapshot().Vnode.Copy(),
+		VnodeName:             "db",
+		VnodeRevision:         1,
+		VnodeMetadataRevision: 1,
+		VnodeLookup:           current.lookup,
+	})
+	require.NoError(t, job.AutoDetection(context.Background()))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		job.runOnce()
+	}()
+	<-collectStarted
+	current.set(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "host-two", GUID: "node-guid"},
+		Revision:         2,
+		MetadataRevision: 2,
+	})
+	close(collectRelease)
+	<-done
+
+	first := out.String()
+	assert.Contains(t, first, "HOST_DEFINE 'node-guid' 'host-one'")
+	assert.NotContains(t, first, "HOST_DEFINE 'node-guid' 'host-two'")
+
+	out.Reset()
+	job.runOnce()
+	second := out.String()
+	assert.Contains(t, second, "HOST_DEFINE 'node-guid' 'host-two'")
+}
+
+func TestJobV2_PullSourceOnlyUpdateDoesNotRedefineHost(t *testing.T) {
+	store := metrix.NewCollectorStore()
+	current := newSnapshotHolder(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "host-one", GUID: "node-guid", SourceType: "user"},
+		Revision:         1,
+		MetadataRevision: 1,
+	})
+	mod := &mockModuleV2{
+		store:    store,
+		template: chartTemplateV2(),
+		collectFunc: func(context.Context) error {
+			store.Write().SnapshotMeter("apache").Gauge("workers_busy").Observe(1)
+			return nil
+		},
+	}
+	var out bytes.Buffer
+	job := NewJobV2(JobV2Config{
+		PluginName:            pluginName,
+		Name:                  jobName,
+		ModuleName:            modName,
+		FullName:              modName + "_" + jobName,
+		Module:                mod,
+		Out:                   &out,
+		UpdateEvery:           1,
+		Vnode:                 *current.snapshot().Vnode.Copy(),
+		VnodeName:             "db",
+		VnodeRevision:         1,
+		VnodeMetadataRevision: 1,
+		VnodeLookup:           current.lookup,
+	})
+	require.NoError(t, job.AutoDetection(context.Background()))
+	job.runOnce()
+
+	out.Reset()
+	current.set(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "host-one", GUID: "node-guid", SourceType: "dyncfg"},
+		Revision:         2,
+		MetadataRevision: 1,
+	})
+	job.runOnce()
+
+	assert.NotContains(t, out.String(), "HOST_DEFINE 'node-guid' 'host-one'")
 }
 
 func TestJobV2ModuleOwnedVnodeSameGUIDMetadataRefresh(t *testing.T) {
@@ -1453,6 +1580,11 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 				}
 
 				var out bytes.Buffer
+				initial := vnodes.VirtualNode{
+					Name:     "db",
+					Hostname: "node-host-a",
+					GUID:     "node-guid-a",
+				}
 				job := NewJobV2(JobV2Config{
 					PluginName:    pluginName,
 					Name:          jobName,
@@ -1462,10 +1594,12 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 					Out:           &out,
 					UpdateEvery:   1,
 					VnodeRegistry: registry,
-					Vnode: vnodes.VirtualNode{
-						Hostname: "node-host-a",
-						GUID:     "node-guid-a",
-					},
+					Vnode:         initial,
+				})
+				currentVnode := bindJobV2VnodeLookup(job, "db", VnodeSnapshot{
+					Vnode:            &initial,
+					Revision:         1,
+					MetadataRevision: 1,
 				})
 				require.NoError(t, job.AutoDetection(context.Background()))
 
@@ -1474,9 +1608,10 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 
 				out.Reset()
 				current = 2
-				job.UpdateVnode(&vnodes.VirtualNode{
-					Hostname: "node-host-b",
-					GUID:     "node-guid-b",
+				currentVnode.set(VnodeSnapshot{
+					Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "node-host-b", GUID: "node-guid-b"},
+					Revision:         2,
+					MetadataRevision: 2,
 				})
 				job.runOnce()
 
@@ -1499,6 +1634,11 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 				}
 
 				var out bytes.Buffer
+				initial := vnodes.VirtualNode{
+					Name:     "db",
+					Hostname: "node-host",
+					GUID:     "node-guid",
+				}
 				job := NewJobV2(JobV2Config{
 					PluginName:    pluginName,
 					Name:          jobName,
@@ -1508,10 +1648,12 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 					Out:           &out,
 					UpdateEvery:   1,
 					VnodeRegistry: registry,
-					Vnode: vnodes.VirtualNode{
-						Hostname: "node-host",
-						GUID:     "node-guid",
-					},
+					Vnode:         initial,
+				})
+				currentVnode := bindJobV2VnodeLookup(job, "db", VnodeSnapshot{
+					Vnode:            &initial,
+					Revision:         1,
+					MetadataRevision: 1,
 				})
 				require.NoError(t, job.AutoDetection(context.Background()))
 
@@ -1520,7 +1662,11 @@ func TestJobV2VnodeRegistryScenarios(t *testing.T) {
 
 				out.Reset()
 				current = 2
-				job.UpdateVnode(&vnodes.VirtualNode{})
+				currentVnode.set(VnodeSnapshot{
+					Vnode:            &vnodes.VirtualNode{Name: "db"},
+					Revision:         2,
+					MetadataRevision: 2,
+				})
 				job.runOnce()
 
 				assert.Empty(t, registry.Owners("node-guid"))
@@ -2094,9 +2240,16 @@ func TestJobV2CleanupUsesLastSuccessfulHostAfterFailedHostSwitch(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	job := newTestJobV2WithVnode(mod, &out, vnodes.VirtualNode{
+	initial := vnodes.VirtualNode{
+		Name:     "db",
 		Hostname: "node-host-a",
 		GUID:     "node-guid-a",
+	}
+	job := newTestJobV2WithVnode(mod, &out, initial)
+	currentVnode := bindJobV2VnodeLookup(job, "db", VnodeSnapshot{
+		Vnode:            &initial,
+		Revision:         1,
+		MetadataRevision: 1,
 	})
 	require.NoError(t, job.AutoDetection(context.Background()))
 
@@ -2104,9 +2257,10 @@ func TestJobV2CleanupUsesLastSuccessfulHostAfterFailedHostSwitch(t *testing.T) {
 	out.Reset()
 
 	failCollect = true
-	job.UpdateVnode(&vnodes.VirtualNode{
-		Hostname: "node-host-b",
-		GUID:     "node-guid-b",
+	currentVnode.set(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "node-host-b", GUID: "node-guid-b"},
+		Revision:         2,
+		MetadataRevision: 2,
 	})
 	job.runOnce()
 	assert.Equal(t, "", out.String())
@@ -2118,6 +2272,56 @@ func TestJobV2CleanupUsesLastSuccessfulHostAfterFailedHostSwitch(t *testing.T) {
 
 CHART 'module_job.workers_busy' '' 'Workers Busy' 'workers' 'Workers' 'workers_busy' 'line' '%d' '1' 'obsolete' 'plugin' 'module'`, chartengine.Priority))
 	assert.NotContains(t, wire, "HOST 'node-guid-b'")
+	assert.Empty(t, job.scopeStates)
+}
+
+func TestJobV2CleanupUsesLastSuccessfulVnodeForStaleSuppressionAfterFailedHostSwitch(t *testing.T) {
+	store := metrix.NewCollectorStore()
+	failCollect := false
+	mod := &mockModuleV2{
+		store:    store,
+		template: chartTemplateV2(),
+		collectFunc: func(context.Context) error {
+			if failCollect {
+				return errors.New("collect failed")
+			}
+			store.Write().SnapshotMeter("apache").Gauge("workers_busy").Observe(1)
+			return nil
+		},
+	}
+
+	var out bytes.Buffer
+	initial := vnodes.VirtualNode{
+		Name:     "db",
+		Hostname: "node-host-a",
+		GUID:     "node-guid-a",
+		Labels: map[string]string{
+			"_node_stale_after_seconds": "60",
+		},
+	}
+	job := newTestJobV2WithVnode(mod, &out, initial)
+	currentVnode := bindJobV2VnodeLookup(job, "db", VnodeSnapshot{
+		Vnode:            &initial,
+		Revision:         1,
+		MetadataRevision: 1,
+	})
+	require.NoError(t, job.AutoDetection(context.Background()))
+
+	job.runOnce()
+	out.Reset()
+
+	failCollect = true
+	currentVnode.set(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "node-host-b", GUID: "node-guid-b"},
+		Revision:         2,
+		MetadataRevision: 2,
+	})
+	job.runOnce()
+	require.Empty(t, out.String())
+
+	job.Cleanup()
+
+	assert.Empty(t, out.String())
 	assert.Empty(t, job.scopeStates)
 }
 
@@ -2136,9 +2340,16 @@ func TestJobV2EmptyHostSwitchDoesNotKeepReloadingEngine(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	job := newTestJobV2WithVnode(mod, &out, vnodes.VirtualNode{
+	initial := vnodes.VirtualNode{
+		Name:     "db",
 		Hostname: "node-host-a",
 		GUID:     "node-guid-a",
+	}
+	job := newTestJobV2WithVnode(mod, &out, initial)
+	currentVnode := bindJobV2VnodeLookup(job, "db", VnodeSnapshot{
+		Vnode:            &initial,
+		Revision:         1,
+		MetadataRevision: 1,
 	})
 	require.NoError(t, job.AutoDetection(context.Background()))
 	require.Equal(t, 1, mod.templateCalls)
@@ -2150,9 +2361,10 @@ func TestJobV2EmptyHostSwitchDoesNotKeepReloadingEngine(t *testing.T) {
 
 	out.Reset()
 	emitValue = false
-	job.UpdateVnode(&vnodes.VirtualNode{
-		Hostname: "node-host-b",
-		GUID:     "node-guid-b",
+	currentVnode.set(VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db", Hostname: "node-host-b", GUID: "node-guid-b"},
+		Revision:         2,
+		MetadataRevision: 2,
 	})
 	job.runOnce()
 	assert.Equal(t, "", out.String())
@@ -2185,18 +2397,28 @@ func TestJobV2CleanupDoesNotSuppressGlobalCleanupForDifferentStaleVnode(t *testi
 
 	var out bytes.Buffer
 	job := newTestJobV2(mod, &out)
+	currentVnode := bindJobV2VnodeLookup(job, "db", VnodeSnapshot{
+		Vnode:            &vnodes.VirtualNode{Name: "db"},
+		Revision:         1,
+		MetadataRevision: 1,
+	})
 	require.NoError(t, job.AutoDetection(context.Background()))
 
 	job.runOnce()
 	out.Reset()
 
 	failCollect = true
-	job.UpdateVnode(&vnodes.VirtualNode{
-		Hostname: "node-host-b",
-		GUID:     "node-guid-b",
-		Labels: map[string]string{
-			"_node_stale_after_seconds": "60",
+	currentVnode.set(VnodeSnapshot{
+		Vnode: &vnodes.VirtualNode{
+			Name:     "db",
+			Hostname: "node-host-b",
+			GUID:     "node-guid-b",
+			Labels: map[string]string{
+				"_node_stale_after_seconds": "60",
+			},
 		},
+		Revision:         2,
+		MetadataRevision: 2,
 	})
 	job.runOnce()
 	assert.Equal(t, "", out.String())

--- a/src/go/plugin/framework/jobruntime/vnode_snapshot.go
+++ b/src/go/plugin/framework/jobruntime/vnode_snapshot.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobruntime
+
+import "github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+
+type VnodeLookup func(name string) (VnodeSnapshot, bool)
+
+// VnodeSnapshot is an immutable view of one committed jobmgr vnode store entry.
+//
+// Revision changes on every stored vnode commit. MetadataRevision changes only
+// when runtime-visible HOSTINFO/HOST_DEFINE metadata changes.
+type VnodeSnapshot struct {
+	Vnode            *vnodes.VirtualNode
+	Revision         uint64
+	MetadataRevision uint64
+}
+
+func (s VnodeSnapshot) Copy() VnodeSnapshot {
+	var vnode *vnodes.VirtualNode
+	if s.Vnode != nil {
+		vnode = s.Vnode.Copy()
+	}
+	return VnodeSnapshot{
+		Vnode:            vnode,
+		Revision:         s.Revision,
+		MetadataRevision: s.MetadataRevision,
+	}
+}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `jobmgr` to a pull model for virtual node configs: jobs read versioned vnode snapshots from the store at runtime boundaries instead of receiving push updates. Adds revision-aware snapshot handling to avoid redundant HOSTINFO/HOST_DEFINE and improve registration/cleanup correctness while preserving module-owned vnode precedence.

- **Refactors**
  - Added versioned vnode snapshots with `Revision` and `MetadataRevision`; `vnodectl` now exposes `LookupSnapshot` that returns immutable copies. `Revision` advances on every commit; `MetadataRevision` only when runtime-visible metadata changes.
  - Registration commits the current snapshot via `SetVnodeSnapshot` (even if content is equal) to carry revisions; removed live fan-out of updates to running jobs.
  - `jobruntime` V1/V2 now pull snapshots with `VnodeLookup` and track `VnodeRevision`/`VnodeMetadataRevision`:
    - V1 refreshes after collect and before emit; applies newer revisions only; recreates charts when metadata changes.
    - V2 refreshes before collect/emit; applies newer revisions only; ignores source-only changes; module-owned vnodes are not overridden (revision still advances and is logged).
  - Cleanup never re-reads the live store:
    - V1 uses the job’s committed snapshot.
    - V2 uses the last successfully emitted HOST_DEFINE info for owner and stale-suppression checks.
  - Updated docs and tests to reflect the pull model, revision semantics, and snapshot immutability.

- **Migration**
  - Replace uses of `UpdateVnode`/`SetVnodeBaseline` with `SetVnodeSnapshot` (pre-Start only).
  - Use `vnodectl.LookupSnapshot` instead of `Lookup` when vnode revision data is required.

<sup>Written for commit 5a246ac8259bd7cfc8323be0c36ed20c27cdf209. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

