### PR TITLE
refactor(go.d/jobmgr): move effect lifecycle routing into transition kernel

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -152,6 +152,10 @@ Wait-park is special: it applies to discovery events for a config awaiting
 the user's enable/disable decision. DynCfg commands against the same key do
 not wait-park; they execute and answer the state machine's current outcome.
 
+Effect completion, deadline abandon, and late-return ordering are planned in
+`executor_transition.go` and pinned by `executor_transition_test.go`. The
+diagram below is the conceptual lane shape, not the policy table.
+
 ```mermaid
 stateDiagram-v2
     [*] --> Idle
@@ -378,6 +382,11 @@ loop. If the deadline fires first, the worker commits the deadline outcome
 and the leaked call keeps running in the background. The key is then wedged
 until the leaked call returns.
 
+`executor_transition.go` is the loop-side owner for completion, abandon, late
+return, warm continuation, late replay, and shutdown-late ordering. The prose
+below records the cross-file invariants that stay with the manager, effect
+worker, claim table, and domain controllers.
+
 While wedged:
 
 - the lane remains busy;
@@ -410,10 +419,10 @@ sequenceDiagram
         L->>L: commit, release claims, settle lane
     else deadline fires first
         E-->>L: abandoned result
-        L->>L: commit deadline outcome, wedge key
+        L->>L: abandon transition, wedge key
         M-->>E: late result
         E-->>L: late completion
-        L->>L: resolve wedge, release writes, settle lane
+        L->>L: late-return transition, release writes, settle lane
     end
 ```
 
@@ -499,7 +508,7 @@ tests that fail when a command gate moves without updating the command plan.
 | Secretstore flow and conversion | `secretstore_flow_test.go` |
 | Secretstore effects and dependent restart edge cases | `secretstore_effect_test.go`, `effect_deadline_test.go` |
 | Vnode and cross-domain claim interactions | `vnode_claims_test.go`, `dyncfg_vnode_test.go` |
-| Deadline, wedge, shutdown one-rule | `effect_deadline_test.go`, `effect_test.go`, `executor_test.go` |
+| Deadline, wedge, shutdown one-rule | `effect_deadline_test.go`, `effect_test.go`, `executor_test.go`, `executor_transition_test.go` |
 | Function publication timing | `manager_process_test.go`, `funcdispatch_test.go`, `funcctl/*_test.go` |
 | Command-plan parity | `handler_test.go`, `secretsctl/commandplan_test.go`, `vnodectl/commandplan_test.go`, `executor_test.go` |
 

--- a/src/go/plugin/agent/jobmgr/claims_test.go
+++ b/src/go/plugin/agent/jobmgr/claims_test.go
@@ -290,6 +290,43 @@ func TestClaimTable_ReleasedHookWaitsForGrantedReaders(t *testing.T) {
 	assert.Equal(t, []string{"store"}, released)
 }
 
+// TestClaimTable_WakeReattemptsWaitersWithoutRelease pins the wedge wake
+// seam: waiters parked at a wedged key must recompute without a holder change.
+// A waiter whose recomputed set drops the wedged key proceeds; one that still
+// needs it re-parks at the FIFO front.
+func TestClaimTable_WakeReattemptsWaitersWithoutRelease(t *testing.T) {
+	ct := newClaimTable()
+
+	holder := &claimProbe{label: "wedged-holder"}
+	ct.acquire(holder.request(staticClaims(claim{"wedged", claimWrite})))
+	require.True(t, holder.granted())
+
+	waiterSet := []claim{{"wedged", claimWrite}}
+	waiter := &claimProbe{label: "store-update"}
+	ct.acquire(waiter.request(func() []claim { return waiterSet }))
+	require.False(t, waiter.granted(), "the waiter starts parked at the wedged key")
+
+	stillNeedsWedged := &claimProbe{label: "still-needs-wedged"}
+	ct.acquire(stillNeedsWedged.request(staticClaims(claim{"wedged", claimWrite})))
+	require.False(t, stillNeedsWedged.granted(), "a later waiter parks behind the first")
+	require.Equal(t, 2, ct.parkedCount())
+
+	waiterSet = []claim{{"other", claimWrite}}
+	ct.wake("wedged")
+
+	require.True(t, waiter.granted(), "wake must reattempt the head and grant after recompute drops the wedged key")
+	assert.Equal(t, []string{"other"}, heldKeys(waiter.grant))
+	require.False(t, stillNeedsWedged.granted(), "the next waiter still needs the wedged key and must re-park")
+	assert.Equal(t, 1, ct.parkedCount())
+
+	ct.release(holder.grant)
+	require.True(t, stillNeedsWedged.granted(), "the re-parked waiter must keep FIFO position when the key releases")
+
+	ct.release(waiter.grant)
+	ct.release(stillNeedsWedged.grant)
+	assert.Equal(t, 0, ct.parkedCount())
+}
+
 // TestClaimTable_RecomputeAtRestage pins the stale-set rule: a parked
 // acquisition recomputes its claim set when it wakes; a changed set releases
 // EVERYTHING held and reacquires under the new set, so keys dropped from the

--- a/src/go/plugin/agent/jobmgr/doc.go
+++ b/src/go/plugin/agent/jobmgr/doc.go
@@ -77,18 +77,18 @@
 //
 //   - An abandoned effect (deadline exceeded) frees its pool slot and commits
 //     its deadline outcome, but the key stays busy until the leaked module
-//     call returns; the late outcome (warm start, retry eligibility, plain
-//     release) is decided then, on the loop. The wedge re-attempts claim
-//     waiters parked at the key, so commands that exclude wedged keys on
-//     recompute (store mutations skip-and-report wedged dependents) proceed
-//     instead of waiting out the leaked call. A late warm start additionally
-//     requires the job's store dependencies unchanged since the abandon
-//     (their identities are captured when the read claims release; a store
-//     mutation committed or in flight at the late return drops the warm job,
-//     matching the mutation's skip-and-report of the wedged dependent).
-//     Dropped continuations dispose SILENTLY: the job's emission gate closes
-//     before its cleanup, which would otherwise emit HOST/HOSTINFO lines for
-//     a job that never started.
+//     call returns. Loop-side abandon and late-return ordering is planned by
+//     executor_transition.go and pinned by executor_transition_test.go. The
+//     wedge re-attempts claim waiters parked at the key, so commands that
+//     exclude wedged keys on recompute (store mutations skip-and-report wedged
+//     dependents) proceed instead of waiting out the leaked call. A late warm
+//     start additionally requires the job's store dependencies unchanged since
+//     the abandon (their identities are captured when the read claims release;
+//     a store mutation committed or in flight at the late return drops the
+//     warm job, matching the mutation's skip-and-report of the wedged
+//     dependent). Dropped continuations dispose SILENTLY: the job's emission
+//     gate closes before its cleanup, which would otherwise emit HOST/HOSTINFO
+//     lines for a job that never started.
 //
 //   - Every job registration (startRunningJob) reconciles the job's vnode
 //     against the store before Start: a job created before a vnode update but

--- a/src/go/plugin/agent/jobmgr/dyncfg_secretstore.go
+++ b/src/go/plugin/agent/jobmgr/dyncfg_secretstore.go
@@ -205,7 +205,7 @@ func (m *Manager) lookupExposedByFullName(fullName string) (*dyncfg.Entry[confgr
 // observed on the loop: exposed status plus config content hash, "" when the
 // store is not exposed. Captured at a collector command's deadline abandon
 // and compared at its late return - any store mutation committed in between
-// changes it and invalidates the warm continuation (executor.staleWarmDep).
+// changes it and invalidates the warm continuation (executor.staleWarmDepStatus).
 // A re-apply of identical content (the handler's no-op path) leaves it
 // unchanged by design.
 func (m *Manager) secretStoreDepIdentity(storeKey string) string {

--- a/src/go/plugin/agent/jobmgr/effect.go
+++ b/src/go/plugin/agent/jobmgr/effect.go
@@ -151,16 +151,20 @@ func effectControlFrom(ctx context.Context) *effectControl {
 	return ctl
 }
 
+type effectOutcome uint8
+
+const (
+	effectOutcomeCompleted effectOutcome = iota
+	effectOutcomeAbandoned
+	effectOutcomeLateReturn
+	effectOutcomeShutdownNeverRan
+)
+
 type effectResult struct {
-	key string
-	err error
-	// abandoned: the deadline fired; the key must stay busy (wedged) until
-	// the late completion arrives.
-	abandoned bool
-	// late: the leaked child returned; the key unwedges and resume (if any
-	// and still valid) starts the warm job.
-	late   bool
-	resume *warmResume
+	key     string
+	outcome effectOutcome
+	err     error
+	resume  *warmResume
 	// lateWork is loop-side work delivered with a late completion (replay
 	// of dependent restarts that completed after the abandon); it runs
 	// before the command's remaining claims release.
@@ -187,7 +191,7 @@ func (m *Manager) runEffectWorker() {
 				// must NOT start (no new module calls at shutdown) - it
 				// resolves never-ran, same as the drain resolves the rest of
 				// the queue.
-				res = effectResult{key: t.key, err: dyncfg.ErrPhaseNeverRan}
+				res = effectResult{key: t.key, outcome: effectOutcomeShutdownNeverRan, err: dyncfg.ErrPhaseNeverRan}
 			} else {
 				res = m.superviseEffect(t)
 			}
@@ -236,14 +240,14 @@ func (m *Manager) superviseEffect(t effectTask) effectResult {
 	select {
 	case err := <-done:
 		cancel()
-		return effectResult{key: t.key, err: err, busyFor: time.Since(started)}
+		return effectResult{key: t.key, outcome: effectOutcomeCompleted, err: err, busyFor: time.Since(started)}
 	case <-ctx.Done():
 		if !ctl.claimAbandon() {
 			// The closure claimed completion first: its in-process post-work
 			// is finishing - wait it out and report a normal completion.
 			err := <-done
 			cancel()
-			return effectResult{key: t.key, err: err}
+			return effectResult{key: t.key, outcome: effectOutcomeCompleted, err: err}
 		}
 		// Quarantine the stopping job's output BEFORE the deadline outcome
 		// commits (the commit happens after this result reaches the loop).
@@ -278,7 +282,13 @@ func (m *Manager) superviseEffect(t effectTask) effectResult {
 			case <-abandonDelivered:
 			case <-m.lateDrop:
 			}
-			res := effectResult{key: t.key, err: err, late: true, resume: ctl.resume.Load(), lateWork: ctl.takeLateWork()}
+			res := effectResult{
+				key:      t.key,
+				outcome:  effectOutcomeLateReturn,
+				err:      err,
+				resume:   ctl.resume.Load(),
+				lateWork: ctl.takeLateWork(),
+			}
 			if r := res.resume; r != nil && m.ctx.Err() != nil {
 				// Shutdown is in effect: no warm job will ever start, and a
 				// buffered send can win the race against the closed lateDrop
@@ -322,8 +332,8 @@ func (m *Manager) superviseEffect(t effectTask) effectResult {
 		}
 		return effectResult{
 			key:       t.key,
+			outcome:   effectOutcomeAbandoned,
 			err:       abandonErr,
-			abandoned: true,
 			delivered: abandonDelivered,
 			busyFor:   time.Since(started),
 		}

--- a/src/go/plugin/agent/jobmgr/executor.go
+++ b/src/go/plugin/agent/jobmgr/executor.go
@@ -533,7 +533,7 @@ func (e *executor) snapshotWedgedDeps(g *claimGrant) []wedgedDep {
 	return deps
 }
 
-// staleWarmDep reports why a warm continuation's store dependencies are no
+// staleWarmDepStatus reports why a warm continuation's store dependencies are no
 // longer trustworthy: a store the warm job resolved its secrets from whose
 // committed identity changed since the abandon (a rotation committed while
 // the key was wedged - that rotation reported this dependent as skipped, so
@@ -542,7 +542,8 @@ func (e *executor) snapshotWedgedDeps(g *claimGrant) []wedgedDep {
 // have activated a new value off-loop; dropping is the safe direction - if
 // that mutation ultimately fails, only this warm start is lost, never
 // credential freshness). Union-claimed dependencies the warm config no
-// longer references are ignored. Empty means the continuation is safe.
+// longer references are ignored. staleWarmDepNone means the continuation is
+// safe; the accompanying message is empty in that case.
 func (e *executor) staleWarmDepStatus(deps []wedgedDep, cfg confgroup.Config) (staleWarmDepKind, string) {
 	if len(deps) == 0 {
 		return staleWarmDepNone, ""

--- a/src/go/plugin/agent/jobmgr/executor.go
+++ b/src/go/plugin/agent/jobmgr/executor.go
@@ -88,8 +88,8 @@ type keyState struct {
 	grant     *claimGrant
 	// wedge, when non-nil, IS the wedged state: the lane's command was
 	// abandoned at its deadline and the leaked call has not returned (busy
-	// stays true for the whole window). Constructed only by wedgeKey at the
-	// abandon commit; consumed only by the late return.
+	// stays true for the whole window). Constructed only by the enter-wedged
+	// transition action; consumed only by the late return.
 	wedge *wedge
 }
 
@@ -457,11 +457,12 @@ func (e *executor) eventClaims(ev event) []claim {
 // leaked module call still running) is the one state where the normal
 // invariants are asymmetric; every site touching it MUST preserve all of
 // the following, and a change to any point updates this block. Structural
-// owners: points 2-5 are the ordered body of wedgeKey (the only place a
-// wedge is created); points 8-10 and 13 the ordered body of resolveWedge
-// (the only place one is resolved); point 6 the effect worker; point 7 the
-// restart buffer plus lateWork; points 11-12 the registration reconcile and
-// the late retry evaluation; point 14 the effect closures' obligation:
+// owners: points 2-5 are the ordered abandon transition actions (the only
+// place a wedge is created); points 8-10 and 13 are the ordered late-return
+// transition actions (the only place one is resolved); point 6 the effect
+// worker; point 7 the restart buffer plus lateWork; points 11-12 the
+// registration reconcile and the late retry evaluation; point 14 the effect
+// closures' obligation:
 //
 // While wedged (from the abandon commit to the late return):
 //
@@ -535,9 +536,10 @@ func (e *executor) eventClaims(ev event) []claim {
 
 // wedge is the loop-owned record of one abandoned command, from its abandon
 // commit to its late return. keyState.wedge != nil IS the wedged state:
-// wedgeKey (the abandon commit) is the only constructor and resolveWedge
-// (the late return) the only consumer, so the wedged window's distributed
-// invariants live in two ordered bodies instead of scattered sites.
+// the enter-wedged transition action is the only constructor and the
+// leave-wedged transition action is the only consumer, so the wedged window's
+// distributed invariants live in the transition table instead of scattered
+// sites.
 type wedge struct {
 	// gen is the key's generation at the abandon commit: a mismatch at the
 	// late return means a newer command committed on the key (assert-only -
@@ -555,34 +557,6 @@ type wedge struct {
 type wedgedDep struct {
 	stateKey string
 	identity string
-}
-
-// wedgeKey performs the abandon-commit half of the wedge lifecycle, in
-// order: mark the key wedged FIRST (the commit's chained phases must refuse
-// and claim recomputes must already exclude this key), commit the deadline
-// outcome and advance the generation, run the command's after-idle hooks
-// (loop-owned side effects such as the store-dependency sync finalize
-// BEFORE any claim release - contract point 4), capture the read-claimed
-// store dependency identities (the last moment the read claims still
-// exclude mutations - point 3), release those read claims (they must not
-// outlive the commit, or a wedged dependent's store read would block every
-// rotation of that store - point 2), and re-attempt the claim waiters
-// parked at the key (the retained write claim has no bounded release;
-// recompute lets store mutations skip-and-report this key instead of
-// waiting out the leaked call - point 5). The command's WRITE claims - this
-// key and any keys the leaked work may still mutate - stay held on ks.grant
-// until the late return settles the lane (point 2).
-func (e *executor) wedgeKey(sk string, ks *keyState, commit func(error), err error) {
-	ks.wedge = &wedge{}
-	commit(err)
-	ks.generation++
-	ks.wedge.gen = ks.generation
-	e.runAfterIdleHooks(ks)
-	if ks.grant != nil {
-		ks.wedge.deps = e.snapshotWedgedDeps(ks.grant)
-		e.claims.releaseReadClaims(ks.grant)
-	}
-	e.claims.wake(sk)
 }
 
 // snapshotWedgedDeps captures the wedging command's store dependencies from
@@ -615,9 +589,9 @@ func (e *executor) snapshotWedgedDeps(g *claimGrant) []wedgedDep {
 // that mutation ultimately fails, only this warm start is lost, never
 // credential freshness). Union-claimed dependencies the warm config no
 // longer references are ignored. Empty means the continuation is safe.
-func (e *executor) staleWarmDep(deps []wedgedDep, cfg confgroup.Config) string {
+func (e *executor) staleWarmDepStatus(deps []wedgedDep, cfg confgroup.Config) (staleWarmDepKind, string) {
 	if len(deps) == 0 {
-		return ""
+		return staleWarmDepNone, ""
 	}
 	referenced := make(map[string]bool, len(deps))
 	for _, key := range extractSecretStoreKeys(cfg) {
@@ -628,14 +602,14 @@ func (e *executor) staleWarmDep(deps []wedgedDep, cfg confgroup.Config) string {
 			continue
 		}
 		if e.claims.heldForWrite(dep.stateKey) {
-			return fmt.Sprintf("a mutation of store dependency '%s' is in flight", dep.stateKey)
+			return staleWarmDepWriteHeld, fmt.Sprintf("a mutation of store dependency '%s' is in flight", dep.stateKey)
 		}
 		key, _ := strings.CutPrefix(dep.stateKey, secretStoreStateKey(""))
 		if e.mgr.secretStoreDepIdentity(key) != dep.identity {
-			return fmt.Sprintf("store dependency '%s' changed while the key was wedged", dep.stateKey)
+			return staleWarmDepChanged, fmt.Sprintf("store dependency '%s' changed while the key was wedged", dep.stateKey)
 		}
 	}
-	return ""
+	return staleWarmDepNone, ""
 }
 
 func (e *executor) executeCollectorCommand(sk string, ks *keyState, fn dyncfg.Function) {
@@ -776,139 +750,13 @@ func (e *executor) onEffectDoneShutdown(res effectResult) {
 	// parked events) must already see the shutdown mode, or a woken command
 	// would execute - and publish - through the normal path.
 	e.draining = true
-	if res.outcome != effectOutcomeLateReturn {
-		res.err = fmt.Errorf("interrupted by shutdown: %w", dyncfg.ErrPhaseNeverRan)
-	}
 	e.onEffectDone(res)
 }
 
 // onEffectDone resumes a completed blocking phase's commit on the run loop.
 func (e *executor) onEffectDone(res effectResult) {
 	ks := e.keys[res.key]
-	if res.outcome == effectOutcomeLateReturn {
-		e.onLateReturn(res, ks)
-		return
-	}
-	if ks == nil || !ks.busy || ks.pendingCommit == nil {
-		e.mgr.Errorf("BUG: stray effect completion for key '%s' (err: %v)", res.key, res.err)
-		return
-	}
-	commit := ks.pendingCommit
-	ks.pendingCommit = nil
-	e.inflight--
-	if mx := e.mgr.executorMetrics; mx != nil && res.busyFor > 0 {
-		mx.effectBusySeconds.Add(res.busyFor.Seconds())
-	}
-	if res.outcome == effectOutcomeAbandoned {
-		// The deadline outcome commits now, but the key stays busy (wedged)
-		// until the leaked module call returns; no retry and no follow-up
-		// work is scheduled here - the late outcome decides. The whole
-		// transition, including the commit, is wedgeKey's ordered body.
-		e.wedgeKey(res.key, ks, commit, res.err)
-		e.flushPendingEffects()
-		e.observeState()
-		return
-	}
-	ks.busy = false
-	commit(res.err) // may chain the next phase, re-marking the key busy
-	ks.generation++
-	if !ks.busy {
-		// The command's final commit ran: finalize its loop-owned side
-		// effects BEFORE the claim release wakes commands that read them.
-		e.runAfterIdleHooks(ks)
-	}
-	e.finishIfSettled(res.key, ks)
-	e.settle(res.key, ks)
-	e.maybeDelete(res.key, ks)
-	e.flushPendingEffects()
-	e.observeState()
-}
-
-// onLateReturn unwedges a key whose abandoned effect finally returned:
-// resolveWedge decides the late outcome, then the lane settles.
-func (e *executor) onLateReturn(res effectResult, ks *keyState) {
-	if ks == nil || ks.wedge == nil {
-		e.mgr.Errorf("BUG: late completion for a key that is not wedged ('%s')", res.key)
-		if res.resume != nil {
-			e.mgr.disposeWarmResume(res.resume)
-		}
-		return
-	}
-	w := ks.wedge
-	ks.wedge = nil
-	ks.busy = false
-	e.mgr.Infof("abandoned operation for key '%s' returned (err: %v)", res.key, res.err)
-	e.resolveWedge(w, res, ks)
-	e.finishIfSettled(res.key, ks)
-	e.settle(res.key, ks)
-	e.maybeDelete(res.key, ks)
-	e.observeState()
-}
-
-// resolveWedge is the late-return half of the wedge lifecycle, in order:
-// replay the late work while the command's write claims still hold (dropped
-// when draining - one rule; contract points 8 and 13), then start the warm
-// continuation ONLY while every validity condition holds - not draining,
-// generation unchanged (assert - the lane parks everything while wedged),
-// no stop intent queued, and the warm config's store dependencies unchanged
-// since the abandon and not currently write-held (their read claims were
-// released with the abandon commit, so a rotation may have committed - or
-// be in flight - underneath the wedge; point 9). Every dropped continuation
-// disposes silently (point 10).
-func (e *executor) resolveWedge(w *wedge, res effectResult, ks *keyState) {
-	if res.lateWork != nil {
-		if e.draining {
-			// A late result queued just before cancellation can carry replay
-			// work: one rule - nothing publishes at shutdown; state
-			// reconverges on restart.
-			e.mgr.Infof("dropping late replay for key '%s': shutting down", res.key)
-		} else {
-			// Replay loop-side work for pieces that completed only after the
-			// abandon (dependent restarts): the command's write claims are
-			// still held, so no newer command has touched the affected keys
-			// and the replay is truthful.
-			res.lateWork()
-		}
-	}
-
-	if res.resume == nil {
-		return
-	}
-	staleDep := e.staleWarmDep(w.deps, res.resume.cfg)
-	switch {
-	case e.draining:
-		// Shutdown never starts fresh collector work: a warm job that
-		// arrives during the drain is dropped, not resumed (no late
-		// re-enables and no running publish after shutdown began).
-		e.mgr.Infof("dropping late detection success for key '%s': shutting down", res.key)
-		e.mgr.disposeWarmResume(res.resume)
-	case ks.generation != w.gen:
-		if mx := e.mgr.executorMetrics; mx != nil {
-			mx.staleCommits.Add(1)
-		}
-		e.mgr.Warningf("dropping late detection success for key '%s': config changed during operation", res.key)
-		e.mgr.disposeWarmResume(res.resume)
-	case keyFIFOHasStopIntent(ks):
-		// A disable/remove is already queued behind the wedge: the user's
-		// intent wins over the continuation - the warm job is dropped and
-		// the queued command executes against the failed entry.
-		e.mgr.Infof("dropping late detection success for key '%s': a stop command is queued", res.key)
-		e.mgr.disposeWarmResume(res.resume)
-	case staleDep != "":
-		// The warm job resolved its secrets from a store that changed (or
-		// is being changed) while the key was wedged: starting it would
-		// resurrect pre-rotation credentials that the store command
-		// deliberately skipped restarting (skip-and-report on wedged
-		// dependents), with nothing left to ever refresh them.
-		if mx := e.mgr.executorMetrics; mx != nil {
-			mx.staleCommits.Add(1)
-		}
-		e.mgr.Warningf("dropping late detection success for key '%s': %s", res.key, staleDep)
-		e.mgr.disposeWarmResume(res.resume)
-	default:
-		e.mgr.resumeWarmJob(res.resume)
-		ks.generation++
-	}
+	e.executeEffectTransition(res, ks)
 }
 
 // settle drains a key's after-idle hooks and parked events until the key

--- a/src/go/plugin/agent/jobmgr/executor.go
+++ b/src/go/plugin/agent/jobmgr/executor.go
@@ -776,7 +776,7 @@ func (e *executor) onEffectDoneShutdown(res effectResult) {
 	// parked events) must already see the shutdown mode, or a woken command
 	// would execute - and publish - through the normal path.
 	e.draining = true
-	if !res.late {
+	if res.outcome != effectOutcomeLateReturn {
 		res.err = fmt.Errorf("interrupted by shutdown: %w", dyncfg.ErrPhaseNeverRan)
 	}
 	e.onEffectDone(res)
@@ -785,7 +785,7 @@ func (e *executor) onEffectDoneShutdown(res effectResult) {
 // onEffectDone resumes a completed blocking phase's commit on the run loop.
 func (e *executor) onEffectDone(res effectResult) {
 	ks := e.keys[res.key]
-	if res.late {
+	if res.outcome == effectOutcomeLateReturn {
 		e.onLateReturn(res, ks)
 		return
 	}
@@ -799,7 +799,7 @@ func (e *executor) onEffectDone(res effectResult) {
 	if mx := e.mgr.executorMetrics; mx != nil && res.busyFor > 0 {
 		mx.effectBusySeconds.Add(res.busyFor.Seconds())
 	}
-	if res.abandoned {
+	if res.outcome == effectOutcomeAbandoned {
 		// The deadline outcome commits now, but the key stays busy (wedged)
 		// until the leaked module call returns; no retry and no follow-up
 		// work is scheduled here - the late outcome decides. The whole

--- a/src/go/plugin/agent/jobmgr/executor.go
+++ b/src/go/plugin/agent/jobmgr/executor.go
@@ -453,92 +453,46 @@ func (e *executor) eventClaims(ev event) []claim {
 	return set
 }
 
-// THE WEDGE LIFECYCLE CONTRACT. A wedged key (deadline-abandoned effect,
-// leaked module call still running) is the one state where the normal
-// invariants are asymmetric; every site touching it MUST preserve all of
-// the following, and a change to any point updates this block. Structural
-// owners: points 2-5 are the ordered abandon transition actions (the only
-// place a wedge is created); points 8-10 and 13 are the ordered late-return
-// transition actions (the only place one is resolved); point 6 the effect
-// worker; point 7 the restart buffer plus lateWork; points 11-12 the
-// registration reconcile and the late retry evaluation; point 14 the effect
-// closures' obligation:
+// WEDGE LIFECYCLE NOTES. A wedged key (deadline-abandoned effect, leaked
+// module call still running) is the one state where normal settle rules are
+// asymmetric. Loop-side abandon and late-return ordering is owned by
+// planLaneEffectTransition and pinned by executor_transition_test.go:
+// writes stay held until late return, reads release at abandon, read-claimed
+// store identities are snapshotted before release, late replay runs before
+// final release, and shutdown late returns only dispose/drop and release.
 //
-// While wedged (from the abandon commit to the late return):
+// Cross-file invariants still live with their mechanism owners:
 //
-//  1. The lane stays busy: all its events park in the lane FIFO, so no
-//     command for the key can run or commit (generation mismatch at the
-//     late return is an assert, not a working path).
-//  2. The command's WRITE claims - its own key plus any keys the leaked
-//     work may still MUTATE (a store command's dependent job keys) - stay
-//     held until the late return; its READ claims release at the abandon
-//     commit. Dependency mutations CAN therefore commit during the wedge.
-//  3. Because reads release, the abandon commit snapshots the read-claimed
-//     store identities (wedgedDeps) - the last moment mutations were still
-//     excluded, hence exactly what the leaked work resolved.
-//  4. Store-dependency index maintenance happens at the abandon commit
-//     BEFORE any claim release, so commands woken by the release never
-//     read a stale index: the after-idle hooks (the dyncfg-command deps
-//     sync) and the discovery-removal path's commit-side RemoveActiveJob
-//     (stagedRemoveConfig) - cleanup MUST NOT sit in an effect closure
-//     after the blocking wait, where an abandon defers it to the leaked
-//     stop's return while the removal publish already happened.
-//  5. Claim waiters parked at the wedged key are re-attempted at the wedge
-//     (claims.wake): recompute excludes wedged keys, so store mutations
-//     skip-and-report the dependent instead of waiting out the leaked
-//     call; a waiter whose set still needs the key re-parks at the front.
-//  6. The abandoned result reaches the loop before the child's late
-//     completion (the delivered gate): an instantly-returning leaked call
-//     must not wedge the key with nothing left to release it.
-//  7. Store commands buffer completed dependent restarts as they finish:
-//     the buffer flushes at the abandon commit AND is registered as
-//     lateWork for restarts completing after it.
-//
-// At the late return:
-//
-//  8. lateWork runs BEFORE the remaining claims release (the replay is
-//     truthful while the write claims still exclude newer commands) -
-//     unless draining, where it is dropped (one rule).
-//  9. A warm resume starts ONLY if: not draining; the generation matches;
-//     no stop intent is queued in the lane FIFO; every store dependency
-//     the warm config references has an unchanged committed identity and
-//     no in-flight write hold (staleWarmDep); and the exposed entry is
-//     still this config in its abandoned-failed state (resumeWarmJob).
-// 10. Every DROPPED resume disposes silently: disposeWarmResume closes the
-//     job's emission gate by captured handle before Cleanup (V1 Cleanup
-//     emits HOST/HOSTINFO lines even for a never-started job).
-// 11. A STARTED warm job receives the current vnode config at registration
-//     (startRunningJob's reconcile), like every other start path - as a
-//     COMMITTED baseline: it must be visible to cleanup even if the job never
-//     collects; later running updates are pulled at the job's runtime-defined
-//     collection boundary.
-// 12. A late FAILURE evaluates retry eligibility under today's rules at
-//     the return; nothing was scheduled at the abandon (a provisional
-//     retry could race the continuation).
-// 13. Shutdown: late results consumed while draining only release keys -
-//     the resume is disposed, lateWork dropped; the child gates its send
-//     on lateDrop so it never blocks after the drain.
-//
-// Entering the wedge (the deadline race):
-//
-// 14. Classification is race-independent: an effect that DEGRADED its work
-//     because the deadline fired (a store command's restart sequence cut
-//     mid-way) returns a non-nil error, so the command reaches its timeout
-//     outcome whether the closure's return or the worker's abandon wins
-//     their select race - message text alone cannot carry the degradation.
-//     ENFORCED AS A SEAM POST-CONDITION, not per-checkpoint discipline:
-//     runStagedRestarts reclassifies any nil-error restart sequence whose
-//     command window has expired (a deadline firing DURING a restart or
-//     after the last one is invisible to in-loop checkpoints), so the
-//     pipeline cannot under-report degradation. Skip-and-report on WEDGED
-//     dependents is not degradation; it is the command's successful outcome
-//     for wedged keys.
+// - The lane remains occupied while wedged; route/settle must park same-key
+//   events until the late return.
+// - Commit-side dependency cleanup must happen before claim release wakes
+//   waiters. Do not move discovery removal or dependency-index cleanup into
+//   an effect closure after the blocking wait; abandon would defer cleanup
+//   until the leaked call returns while publication already happened.
+// - Claim wake at the wedge lets commands whose recomputed claim set
+//   excludes wedged keys proceed. Store mutations skip-and-report wedged
+//   dependents instead of waiting for an unbounded leaked call.
+// - The effect worker's delivered gate must deliver abandon before the
+//   child's late result, even when the leaked call returns immediately.
+// - Store commands buffer completed dependent restarts as they finish; the
+//   buffer flushes at normal/abandon commit and is also registered as
+//   lateWork for restarts completing after abandon.
+// - resumeWarmJob still verifies the exposed entry before a warm start.
+//   disposeWarmResume closes the captured emission gate before Cleanup, and
+//   startRunningJob reconciles the current vnode baseline at registration.
+// - Late failures evaluate retry eligibility at late return; no provisional
+//   retry is scheduled at abandon.
+// - Late children gate their sends on lateDrop so shutdown drain cannot
+//   block after the bounded wait.
+// - Deadline classification is race-independent: runStagedRestarts
+//   reclassifies an expired restart sequence as a timeout even if the
+//   closure returns after the deadline checkpoint.
 
 // wedge is the loop-owned record of one abandoned command, from its abandon
 // commit to its late return. keyState.wedge != nil IS the wedged state:
 // the enter-wedged transition action is the only constructor and the
 // leave-wedged transition action is the only consumer, so the wedged window's
-// distributed invariants live in the transition table instead of scattered
+// loop-side ordering lives in the transition table instead of scattered
 // sites.
 type wedge struct {
 	// gen is the key's generation at the abandon commit: a mismatch at the
@@ -546,7 +500,7 @@ type wedge struct {
 	// the lane parks everything while wedged).
 	gen uint64
 	// deps are the read-claimed store dependencies' identities at the
-	// abandon commit (contract point 3).
+	// abandon commit.
 	deps []wedgedDep
 }
 

--- a/src/go/plugin/agent/jobmgr/executor_test.go
+++ b/src/go/plugin/agent/jobmgr/executor_test.go
@@ -351,6 +351,187 @@ func TestExecutor_CommandPlanClaims(t *testing.T) {
 	}
 }
 
+func TestExecutor_SnapshotWedgedDepsCapturesReadStoreClaims(t *testing.T) {
+	mgr, _ := newExecutorTestManager()
+	storeA := secretstore.StoreKey(secretstore.KindVault, "vault_a")
+	storeB := secretstore.StoreKey(secretstore.KindVault, "vault_b")
+	seedSecretStore(t, mgr, secretstore.KindVault, "vault_a", map[string]any{"value": "a"}, dyncfg.StatusAccepted)
+	seedSecretStore(t, mgr, secretstore.KindVault, "vault_b", map[string]any{"value": "b"}, dyncfg.StatusAccepted)
+
+	got := mgr.executor.snapshotWedgedDeps(&claimGrant{held: []claim{
+		{key: secretStoreStateKey(storeA), mode: claimRead},
+		{key: vnodeStateKey("vnode"), mode: claimRead},
+		{key: secretStoreStateKey("vault:write"), mode: claimWrite},
+		{key: collectorStateKey("success_job"), mode: claimRead},
+		{key: secretStoreStateKey(storeB), mode: claimRead},
+	}})
+
+	assert.Equal(t, []wedgedDep{
+		{stateKey: secretStoreStateKey(storeA), identity: mgr.secretStoreDepIdentity(storeA)},
+		{stateKey: secretStoreStateKey(storeB), identity: mgr.secretStoreDepIdentity(storeB)},
+	}, got)
+}
+
+func TestExecutor_StaleWarmDep(t *testing.T) {
+	storeKey := secretstore.StoreKey(secretstore.KindVault, "vault_prod")
+	stateKey := secretStoreStateKey(storeKey)
+	referencingCfg := prepareDyncfgCfg("success", "job").
+		Set("password", "${store:vault:vault_prod:secret/data/mysql#password}")
+	unreferencedCfg := prepareDyncfgCfg("success", "job")
+
+	tests := map[string]struct {
+		deps      func(*Manager) []wedgedDep
+		cfg       confgroup.Config
+		writeHold bool
+		wantEmpty bool
+		wantText  string
+	}{
+		"no deps is fresh": {
+			cfg:       referencingCfg,
+			wantEmpty: true,
+		},
+		"unreferenced dep is ignored": {
+			deps: func(mgr *Manager) []wedgedDep {
+				return []wedgedDep{{stateKey: stateKey, identity: "stale"}}
+			},
+			cfg:       unreferencedCfg,
+			wantEmpty: true,
+		},
+		"matching identity is fresh": {
+			deps: func(mgr *Manager) []wedgedDep {
+				return []wedgedDep{{stateKey: stateKey, identity: mgr.secretStoreDepIdentity(storeKey)}}
+			},
+			cfg:       referencingCfg,
+			wantEmpty: true,
+		},
+		"changed identity is stale": {
+			deps: func(mgr *Manager) []wedgedDep {
+				return []wedgedDep{{stateKey: stateKey, identity: "old-identity"}}
+			},
+			cfg:      referencingCfg,
+			wantText: "changed while the key was wedged",
+		},
+		"write-held dependency is stale": {
+			deps: func(mgr *Manager) []wedgedDep {
+				return []wedgedDep{{stateKey: stateKey, identity: mgr.secretStoreDepIdentity(storeKey)}}
+			},
+			cfg:       referencingCfg,
+			writeHold: true,
+			wantText:  "is in flight",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr, _ := newExecutorTestManager()
+			seedSecretStore(t, mgr, secretstore.KindVault, "vault_prod", map[string]any{"value": "secret"}, dyncfg.StatusAccepted)
+			e := newExecutor(mgr)
+			if tc.writeHold {
+				holder := &claimProbe{label: "store-mutation"}
+				e.claims.acquire(holder.request(staticClaims(claim{stateKey, claimWrite})))
+				require.True(t, holder.granted())
+			}
+			var deps []wedgedDep
+			if tc.deps != nil {
+				deps = tc.deps(mgr)
+			}
+
+			got := e.staleWarmDep(deps, tc.cfg)
+			if tc.wantEmpty {
+				assert.Empty(t, got)
+			} else {
+				assert.Contains(t, got, tc.wantText)
+			}
+		})
+	}
+}
+
+func TestKeyFIFOHasStopIntent(t *testing.T) {
+	fn := func(cmd dyncfg.Command) dyncfg.Function {
+		return newExecutorTestFn("uid-"+string(cmd), []string{"test:collector:success:job", string(cmd)}, nil)
+	}
+
+	tests := map[string]struct {
+		fifo []event
+		want bool
+	}{
+		"empty fifo": {},
+		"discovery add is not stop intent": {
+			fifo: []event{{kind: eventDiscoveryAdd}},
+		},
+		"discovery remove is stop intent": {
+			fifo: []event{{kind: eventDiscoveryRemove}},
+			want: true,
+		},
+		"dyncfg disable is stop intent": {
+			fifo: []event{{kind: eventDyncfgCommand, fn: fn(dyncfg.CommandDisable)}},
+			want: true,
+		},
+		"dyncfg remove is stop intent": {
+			fifo: []event{{kind: eventDyncfgCommand, fn: fn(dyncfg.CommandRemove)}},
+			want: true,
+		},
+		"dyncfg restart is not stop intent": {
+			fifo: []event{{kind: eventDyncfgCommand, fn: fn(dyncfg.CommandRestart)}},
+		},
+		"later stop intent is detected": {
+			fifo: []event{
+				{kind: eventDyncfgCommand, fn: fn(dyncfg.CommandGet)},
+				{kind: eventDyncfgCommand, fn: fn(dyncfg.CommandDisable)},
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, keyFIFOHasStopIntent(&keyState{fifo: tc.fifo}))
+		})
+	}
+}
+
+func TestExecutor_ShutdownAbandonKeepsWedgeUntilLateReturn(t *testing.T) {
+	mgr, _ := newExecutorTestManager()
+	e := newExecutor(mgr)
+	const key = "shutdown-abandon"
+
+	holder := &claimProbe{label: "running-command"}
+	e.claims.acquire(holder.request(staticClaims(claim{key: key, mode: claimWrite})))
+	require.True(t, holder.granted())
+
+	var committed error
+	ks := &keyState{
+		busy:  true,
+		grant: holder.grant,
+		pendingCommit: func(err error) {
+			committed = err
+		},
+	}
+	e.keys[key] = ks
+	e.inflight = 1
+
+	e.onEffectDoneShutdown(effectResult{
+		key:     key,
+		outcome: effectOutcomeAbandoned,
+		err:     errors.New("deadline"),
+	})
+
+	require.True(t, e.draining)
+	require.ErrorIs(t, committed, dyncfg.ErrPhaseNeverRan)
+	require.NotNil(t, ks.wedge, "shutdown rewrites the committed error, not the abandon lifecycle outcome")
+	assert.True(t, ks.busy, "the lane stays wedged until the leaked child returns")
+	assert.True(t, e.claims.heldForWrite(key), "write claims stay held while wedged")
+	assert.Equal(t, 0, e.inflight)
+
+	e.onEffectDone(effectResult{key: key, outcome: effectOutcomeLateReturn})
+
+	assert.False(t, e.claims.heldForWrite(key), "late return releases the retained write claim")
+	if ks := e.keys[key]; ks != nil {
+		assert.False(t, ks.busy)
+		assert.Nil(t, ks.wedge)
+	}
+}
+
 // Per-key FIFO pin: events for ONE key execute and emit in arrival order
 // through the running manager (cross-key order is unconstrained by design).
 func TestExecutor_DispatchOrder(t *testing.T) {
@@ -535,7 +716,7 @@ func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
 		}})
 		defer drainAbandonedEffect(mgr, res, block)
 
-		require.True(t, res.abandoned)
+		require.Equal(t, effectOutcomeAbandoned, res.outcome)
 		assert.False(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned),
 			"an abandon with no fence installed must not claim the fenced outcome")
 	})
@@ -552,7 +733,7 @@ func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
 		}})
 		defer drainAbandonedEffect(mgr, res, block)
 
-		require.True(t, res.abandoned)
+		require.Equal(t, effectOutcomeAbandoned, res.outcome)
 		assert.True(t, fenceRan.Load(), "the worker must run the fence before reporting the abandon")
 		assert.True(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned))
 	})
@@ -570,7 +751,7 @@ func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
 		}})
 		defer drainAbandonedEffect(mgr, res, block)
 
-		require.True(t, res.abandoned)
+		require.Equal(t, effectOutcomeAbandoned, res.outcome)
 		assert.True(t, errors.Is(res.err, dyncfg.ErrPhaseNeverRan),
 			"a shutdown interruption must answer retryably no matter which side wins the claim")
 	})
@@ -601,7 +782,7 @@ func TestSuperviseEffect_AbandonFenceClassification(t *testing.T) {
 		}})
 		defer drainAbandonedEffect(mgr, res, block)
 
-		require.True(t, res.abandoned)
+		require.Equal(t, effectOutcomeAbandoned, res.outcome)
 		assert.True(t, errors.Is(res.err, dyncfg.ErrPhaseNeverRan),
 			"a shutdown interruption answers retryably even when the stop's fence ran")
 		assert.False(t, errors.Is(res.err, dyncfg.ErrPhaseAbandoned),
@@ -818,7 +999,7 @@ func TestSuperviseEffect_LateCompletionWaitsForAbandonDelivery(t *testing.T) {
 		<-ctx.Done() // returns the instant the deadline fires
 		return ctx.Err()
 	}})
-	require.True(t, res.abandoned)
+	require.Equal(t, effectOutcomeAbandoned, res.outcome)
 	require.NotNil(t, res.delivered, "abandoned results carry the delivery gate")
 
 	// The leaked child has already returned, but its late result must wait
@@ -830,7 +1011,7 @@ func TestSuperviseEffect_LateCompletionWaitsForAbandonDelivery(t *testing.T) {
 	require.Eventually(t, func() bool { return len(mgr.effectDoneCh) == 1 }, charWait, charTick,
 		"the late completion must flow once the abandon was delivered")
 	late := <-mgr.effectDoneCh
-	assert.True(t, late.late)
+	assert.Equal(t, effectOutcomeLateReturn, late.outcome)
 }
 
 // TestResumeWarmJob_IneligibleDropDisposesGate pins that a warm job dropped

--- a/src/go/plugin/agent/jobmgr/executor_test.go
+++ b/src/go/plugin/agent/jobmgr/executor_test.go
@@ -383,32 +383,33 @@ func TestExecutor_StaleWarmDep(t *testing.T) {
 		deps      func(*Manager) []wedgedDep
 		cfg       confgroup.Config
 		writeHold bool
-		wantEmpty bool
+		wantKind  staleWarmDepKind
 		wantText  string
 	}{
 		"no deps is fresh": {
-			cfg:       referencingCfg,
-			wantEmpty: true,
+			cfg:      referencingCfg,
+			wantKind: staleWarmDepNone,
 		},
 		"unreferenced dep is ignored": {
 			deps: func(mgr *Manager) []wedgedDep {
 				return []wedgedDep{{stateKey: stateKey, identity: "stale"}}
 			},
-			cfg:       unreferencedCfg,
-			wantEmpty: true,
+			cfg:      unreferencedCfg,
+			wantKind: staleWarmDepNone,
 		},
 		"matching identity is fresh": {
 			deps: func(mgr *Manager) []wedgedDep {
 				return []wedgedDep{{stateKey: stateKey, identity: mgr.secretStoreDepIdentity(storeKey)}}
 			},
-			cfg:       referencingCfg,
-			wantEmpty: true,
+			cfg:      referencingCfg,
+			wantKind: staleWarmDepNone,
 		},
 		"changed identity is stale": {
 			deps: func(mgr *Manager) []wedgedDep {
 				return []wedgedDep{{stateKey: stateKey, identity: "old-identity"}}
 			},
 			cfg:      referencingCfg,
+			wantKind: staleWarmDepChanged,
 			wantText: "changed while the key was wedged",
 		},
 		"write-held dependency is stale": {
@@ -417,6 +418,7 @@ func TestExecutor_StaleWarmDep(t *testing.T) {
 			},
 			cfg:       referencingCfg,
 			writeHold: true,
+			wantKind:  staleWarmDepWriteHeld,
 			wantText:  "is in flight",
 		},
 	}
@@ -436,11 +438,12 @@ func TestExecutor_StaleWarmDep(t *testing.T) {
 				deps = tc.deps(mgr)
 			}
 
-			got := e.staleWarmDep(deps, tc.cfg)
-			if tc.wantEmpty {
-				assert.Empty(t, got)
+			gotKind, gotText := e.staleWarmDepStatus(deps, tc.cfg)
+			assert.Equal(t, tc.wantKind, gotKind)
+			if tc.wantKind == staleWarmDepNone {
+				assert.Empty(t, gotText)
 			} else {
-				assert.Contains(t, got, tc.wantText)
+				assert.Contains(t, gotText, tc.wantText)
 			}
 		})
 	}
@@ -530,6 +533,73 @@ func TestExecutor_ShutdownAbandonKeepsWedgeUntilLateReturn(t *testing.T) {
 		assert.False(t, ks.busy)
 		assert.Nil(t, ks.wedge)
 	}
+}
+
+func TestExecutor_CompletedTransitionChainedCommitKeepsLaneOccupied(t *testing.T) {
+	mgr, _ := newExecutorTestManager()
+	e := newExecutor(mgr)
+	const key = "completed-chain"
+
+	holder := &claimProbe{label: "running-command"}
+	e.claims.acquire(holder.request(staticClaims(claim{key: key, mode: claimWrite})))
+	require.True(t, holder.granted())
+
+	var committed error
+	hookRan := false
+	ks := &keyState{
+		busy:  true,
+		grant: holder.grant,
+		pendingCommit: func(err error) {
+			committed = err
+			ks := e.keys[key]
+			ks.busy = true
+		},
+	}
+	e.keys[key] = ks
+	e.inflight = 1
+	e.afterIdleHook(ks, func() { hookRan = true })
+
+	e.onEffectDone(effectResult{key: key, outcome: effectOutcomeCompleted})
+
+	require.NoError(t, committed)
+	assert.True(t, ks.busy, "the chained phase keeps the lane occupied")
+	assert.False(t, hookRan, "after-idle hooks wait for the chained phase's final commit")
+	assert.True(t, e.claims.heldForWrite(key), "the grant stays held while the chained phase is busy")
+	assert.Equal(t, 0, e.inflight)
+}
+
+func TestExecutor_AbandonTransitionRefusesChainedPhaseAfterEnterWedge(t *testing.T) {
+	mgr, _ := newExecutorTestManager()
+	e := newExecutor(mgr)
+	const key = "abandon-chain"
+
+	deadlineErr := errors.New("deadline")
+	var committed error
+	var chainedErr error
+	chainedRan := false
+	ks := &keyState{
+		busy: true,
+		pendingCommit: func(err error) {
+			committed = err
+			e.runnerFor(key)(func(context.Context) error {
+				chainedRan = true
+				return nil
+			}, func(err error) {
+				chainedErr = err
+			})
+		},
+	}
+	e.keys[key] = ks
+	e.inflight = 1
+
+	e.onEffectDone(effectResult{key: key, outcome: effectOutcomeAbandoned, err: deadlineErr})
+
+	require.ErrorIs(t, committed, deadlineErr)
+	require.ErrorIs(t, chainedErr, dyncfg.ErrPhaseNeverRan)
+	assert.False(t, chainedRan, "the chained effect must not dispatch once the key is wedged")
+	require.NotNil(t, ks.wedge)
+	assert.True(t, ks.busy)
+	assert.Equal(t, 0, e.inflight)
 }
 
 // Per-key FIFO pin: events for ONE key execute and emit in arrival order

--- a/src/go/plugin/agent/jobmgr/executor_transition.go
+++ b/src/go/plugin/agent/jobmgr/executor_transition.go
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"fmt"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+)
+
+type lanePhase uint8
+
+const (
+	lanePhaseIdle lanePhase = iota
+	lanePhaseRunning
+	lanePhaseWedged
+)
+
+type laneEffectEvent uint8
+
+const (
+	laneEffectCompleted laneEffectEvent = iota
+	laneEffectAbandoned
+	laneEffectLateReturn
+)
+
+type staleWarmDepKind uint8
+
+const (
+	staleWarmDepNone staleWarmDepKind = iota
+	staleWarmDepChanged
+	staleWarmDepWriteHeld
+)
+
+type warmDropReason uint8
+
+const (
+	warmDropNone warmDropReason = iota
+	warmDropGenerationMismatch
+	warmDropStopIntentQueued
+	warmDropStaleDepChanged
+	warmDropStaleDepWriteHeld
+	warmDropDraining
+)
+
+type lateDropReason uint8
+
+const (
+	lateDropNone lateDropReason = iota
+	lateDropDraining
+)
+
+type commitErrSource uint8
+
+const (
+	commitErrResult commitErrSource = iota
+	commitErrShutdownNeverRan
+)
+
+type laneActionKind uint8
+
+const (
+	laneActionDiagnosticStrayCompletion laneActionKind = iota
+	laneActionDiagnosticLateNotWedged
+	laneActionDisposeWarmResume
+	laneActionTakePendingCommit
+	laneActionLeaveRunning
+	laneActionEnterWedged
+	laneActionLeaveWedged
+	laneActionLogLateReturn
+	laneActionCommit
+	laneActionBumpGeneration
+	laneActionCaptureWedgeGeneration
+	laneActionRunAfterIdle
+	laneActionRunAfterIdleIfIdle
+	laneActionSnapshotReadDeps
+	laneActionReleaseReadClaims
+	laneActionWakeClaimWaiters
+	laneActionRunLateWork
+	laneActionDropLateWork
+	laneActionStartWarm
+	laneActionDropWarm
+	laneActionFinishIfSettled
+	laneActionSettle
+	laneActionMaybeDelete
+	laneActionFlushPendingEffects
+	laneActionObserveState
+)
+
+type laneAction struct {
+	kind      laneActionKind
+	commitErr commitErrSource
+	warmDrop  warmDropReason
+	lateDrop  lateDropReason
+}
+
+type laneTransitionInput struct {
+	phase             lanePhase
+	event             laneEffectEvent
+	draining          bool
+	hasPendingCommit  bool
+	hasLateWork       bool
+	hasWarmResume     bool
+	generationMatches bool
+	stopIntentQueued  bool
+	staleDep          staleWarmDepKind
+}
+
+func planLaneEffectTransition(in laneTransitionInput) []laneAction {
+	switch in.event {
+	case laneEffectCompleted:
+		return planRunningCompletion(in, laneEffectCompleted)
+	case laneEffectAbandoned:
+		return planRunningCompletion(in, laneEffectAbandoned)
+	case laneEffectLateReturn:
+		return planLateReturn(in)
+	default:
+		return []laneAction{{kind: laneActionDiagnosticStrayCompletion}}
+	}
+}
+
+func planRunningCompletion(in laneTransitionInput, ev laneEffectEvent) []laneAction {
+	if in.phase != lanePhaseRunning || !in.hasPendingCommit {
+		return []laneAction{{kind: laneActionDiagnosticStrayCompletion}}
+	}
+
+	commit := laneAction{kind: laneActionCommit, commitErr: commitErrResult}
+	if in.draining {
+		commit.commitErr = commitErrShutdownNeverRan
+	}
+
+	if ev == laneEffectAbandoned {
+		return []laneAction{
+			{kind: laneActionTakePendingCommit},
+			{kind: laneActionEnterWedged},
+			commit,
+			{kind: laneActionBumpGeneration},
+			{kind: laneActionCaptureWedgeGeneration},
+			{kind: laneActionRunAfterIdle},
+			{kind: laneActionSnapshotReadDeps},
+			{kind: laneActionReleaseReadClaims},
+			{kind: laneActionWakeClaimWaiters},
+			{kind: laneActionFlushPendingEffects},
+			{kind: laneActionObserveState},
+		}
+	}
+
+	return []laneAction{
+		{kind: laneActionTakePendingCommit},
+		{kind: laneActionLeaveRunning},
+		commit,
+		{kind: laneActionBumpGeneration},
+		{kind: laneActionRunAfterIdleIfIdle},
+		{kind: laneActionFinishIfSettled},
+		{kind: laneActionSettle},
+		{kind: laneActionMaybeDelete},
+		{kind: laneActionFlushPendingEffects},
+		{kind: laneActionObserveState},
+	}
+}
+
+func planLateReturn(in laneTransitionInput) []laneAction {
+	if in.phase != lanePhaseWedged {
+		actions := []laneAction{{kind: laneActionDiagnosticLateNotWedged}}
+		if in.hasWarmResume {
+			actions = append(actions, laneAction{kind: laneActionDisposeWarmResume})
+		}
+		return actions
+	}
+
+	actions := []laneAction{
+		{kind: laneActionLeaveWedged},
+		{kind: laneActionLogLateReturn},
+	}
+	if in.hasLateWork {
+		if in.draining {
+			actions = append(actions, laneAction{kind: laneActionDropLateWork, lateDrop: lateDropDraining})
+		} else {
+			actions = append(actions, laneAction{kind: laneActionRunLateWork})
+		}
+	}
+	if in.hasWarmResume {
+		actions = append(actions, planWarmResume(in)...)
+	}
+	actions = append(actions,
+		laneAction{kind: laneActionFinishIfSettled},
+		laneAction{kind: laneActionSettle},
+		laneAction{kind: laneActionMaybeDelete},
+		laneAction{kind: laneActionObserveState},
+	)
+	return actions
+}
+
+func planWarmResume(in laneTransitionInput) []laneAction {
+	switch {
+	case in.draining:
+		return []laneAction{{kind: laneActionDropWarm, warmDrop: warmDropDraining}}
+	case !in.generationMatches:
+		return []laneAction{{kind: laneActionDropWarm, warmDrop: warmDropGenerationMismatch}}
+	case in.stopIntentQueued:
+		return []laneAction{{kind: laneActionDropWarm, warmDrop: warmDropStopIntentQueued}}
+	case in.staleDep == staleWarmDepChanged:
+		return []laneAction{{kind: laneActionDropWarm, warmDrop: warmDropStaleDepChanged}}
+	case in.staleDep == staleWarmDepWriteHeld:
+		return []laneAction{{kind: laneActionDropWarm, warmDrop: warmDropStaleDepWriteHeld}}
+	default:
+		return []laneAction{
+			{kind: laneActionStartWarm},
+			{kind: laneActionBumpGeneration},
+		}
+	}
+}
+
+type laneEffectActionContext struct {
+	res         effectResult
+	ks          *keyState
+	commit      func(error)
+	wedge       *wedge
+	staleDepMsg string
+}
+
+func (e *executor) effectTransitionInput(res effectResult, ks *keyState) (laneTransitionInput, string) {
+	in := laneTransitionInput{
+		phase:             lanePhaseForKey(ks),
+		event:             laneEffectEventFromOutcome(res.outcome),
+		draining:          e.draining,
+		hasPendingCommit:  ks != nil && ks.pendingCommit != nil,
+		hasLateWork:       res.lateWork != nil,
+		hasWarmResume:     res.resume != nil,
+		generationMatches: true,
+		stopIntentQueued:  ks != nil && keyFIFOHasStopIntent(ks),
+	}
+	if ks != nil && ks.wedge != nil {
+		in.generationMatches = ks.generation == ks.wedge.gen
+	}
+	var staleDepMsg string
+	if res.resume != nil && ks != nil && ks.wedge != nil {
+		in.staleDep, staleDepMsg = e.staleWarmDepStatus(ks.wedge.deps, res.resume.cfg)
+	}
+	return in, staleDepMsg
+}
+
+func lanePhaseForKey(ks *keyState) lanePhase {
+	switch {
+	case ks == nil:
+		return lanePhaseIdle
+	case ks.wedge != nil:
+		return lanePhaseWedged
+	case ks.busy:
+		return lanePhaseRunning
+	default:
+		return lanePhaseIdle
+	}
+}
+
+func laneEffectEventFromOutcome(out effectOutcome) laneEffectEvent {
+	switch out {
+	case effectOutcomeAbandoned:
+		return laneEffectAbandoned
+	case effectOutcomeLateReturn:
+		return laneEffectLateReturn
+	default:
+		return laneEffectCompleted
+	}
+}
+
+func (e *executor) executeEffectTransition(res effectResult, ks *keyState) {
+	in, staleDepMsg := e.effectTransitionInput(res, ks)
+	ctx := laneEffectActionContext{res: res, ks: ks, staleDepMsg: staleDepMsg}
+	for _, action := range planLaneEffectTransition(in) {
+		e.executeLaneAction(&ctx, action)
+	}
+}
+
+func (e *executor) executeLaneAction(ctx *laneEffectActionContext, action laneAction) {
+	switch action.kind {
+	case laneActionDiagnosticStrayCompletion:
+		e.mgr.Errorf("BUG: stray effect completion for key '%s' (err: %v)", ctx.res.key, ctx.res.err)
+	case laneActionDiagnosticLateNotWedged:
+		e.mgr.Errorf("BUG: late completion for a key that is not wedged ('%s')", ctx.res.key)
+	case laneActionDisposeWarmResume:
+		if ctx.res.resume != nil {
+			e.mgr.disposeWarmResume(ctx.res.resume)
+		}
+	case laneActionTakePendingCommit:
+		if ctx.ks == nil {
+			return
+		}
+		ctx.commit = ctx.ks.pendingCommit
+		ctx.ks.pendingCommit = nil
+		e.inflight--
+		if mx := e.mgr.executorMetrics; mx != nil && ctx.res.busyFor > 0 {
+			mx.effectBusySeconds.Add(ctx.res.busyFor.Seconds())
+		}
+	case laneActionLeaveRunning:
+		if ctx.ks != nil {
+			ctx.ks.busy = false
+		}
+	case laneActionEnterWedged:
+		if ctx.ks != nil {
+			ctx.ks.wedge = &wedge{}
+		}
+	case laneActionLeaveWedged:
+		if ctx.ks != nil {
+			ctx.wedge = ctx.ks.wedge
+			ctx.ks.wedge = nil
+			ctx.ks.busy = false
+		}
+	case laneActionLogLateReturn:
+		e.mgr.Infof("abandoned operation for key '%s' returned (err: %v)", ctx.res.key, ctx.res.err)
+	case laneActionCommit:
+		if ctx.commit == nil {
+			return
+		}
+		err := ctx.res.err
+		if action.commitErr == commitErrShutdownNeverRan {
+			err = fmt.Errorf("interrupted by shutdown: %w", dyncfg.ErrPhaseNeverRan)
+		}
+		ctx.commit(err)
+	case laneActionBumpGeneration:
+		if ctx.ks != nil {
+			ctx.ks.generation++
+		}
+	case laneActionCaptureWedgeGeneration:
+		if ctx.ks != nil && ctx.ks.wedge != nil {
+			ctx.ks.wedge.gen = ctx.ks.generation
+		}
+	case laneActionRunAfterIdle:
+		if ctx.ks != nil {
+			e.runAfterIdleHooks(ctx.ks)
+		}
+	case laneActionRunAfterIdleIfIdle:
+		if ctx.ks != nil && !ctx.ks.busy {
+			e.runAfterIdleHooks(ctx.ks)
+		}
+	case laneActionSnapshotReadDeps:
+		if ctx.ks != nil && ctx.ks.wedge != nil && ctx.ks.grant != nil {
+			ctx.ks.wedge.deps = e.snapshotWedgedDeps(ctx.ks.grant)
+		}
+	case laneActionReleaseReadClaims:
+		if ctx.ks != nil && ctx.ks.grant != nil {
+			e.claims.releaseReadClaims(ctx.ks.grant)
+		}
+	case laneActionWakeClaimWaiters:
+		e.claims.wake(ctx.res.key)
+	case laneActionRunLateWork:
+		if ctx.res.lateWork != nil {
+			ctx.res.lateWork()
+		}
+	case laneActionDropLateWork:
+		e.dropLateWork(ctx.res, action.lateDrop)
+	case laneActionStartWarm:
+		if ctx.res.resume != nil {
+			e.mgr.resumeWarmJob(ctx.res.resume)
+		}
+	case laneActionDropWarm:
+		e.dropWarmResume(ctx.res, action.warmDrop, ctx.staleDepMsg)
+	case laneActionFinishIfSettled:
+		if ctx.ks != nil {
+			e.finishIfSettled(ctx.res.key, ctx.ks)
+		}
+	case laneActionSettle:
+		if ctx.ks != nil {
+			e.settle(ctx.res.key, ctx.ks)
+		}
+	case laneActionMaybeDelete:
+		if ctx.ks != nil {
+			e.maybeDelete(ctx.res.key, ctx.ks)
+		}
+	case laneActionFlushPendingEffects:
+		e.flushPendingEffects()
+	case laneActionObserveState:
+		e.observeState()
+	}
+}
+
+func (e *executor) dropLateWork(res effectResult, reason lateDropReason) {
+	if reason == lateDropDraining {
+		e.mgr.Infof("dropping late replay for key '%s': shutting down", res.key)
+	}
+}
+
+func (e *executor) dropWarmResume(res effectResult, reason warmDropReason, staleDepMsg string) {
+	if res.resume == nil {
+		return
+	}
+	switch reason {
+	case warmDropDraining:
+		e.mgr.Infof("dropping late detection success for key '%s': shutting down", res.key)
+	case warmDropGenerationMismatch:
+		if mx := e.mgr.executorMetrics; mx != nil {
+			mx.staleCommits.Add(1)
+		}
+		e.mgr.Warningf("dropping late detection success for key '%s': config changed during operation", res.key)
+	case warmDropStopIntentQueued:
+		e.mgr.Infof("dropping late detection success for key '%s': a stop command is queued", res.key)
+	case warmDropStaleDepChanged, warmDropStaleDepWriteHeld:
+		if mx := e.mgr.executorMetrics; mx != nil {
+			mx.staleCommits.Add(1)
+		}
+		e.mgr.Warningf("dropping late detection success for key '%s': %s", res.key, staleDepMsg)
+	}
+	e.mgr.disposeWarmResume(res.resume)
+}

--- a/src/go/plugin/agent/jobmgr/executor_transition_test.go
+++ b/src/go/plugin/agent/jobmgr/executor_transition_test.go
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLaneEffectTransition_Table(t *testing.T) {
+	act := func(kind laneActionKind) laneAction {
+		return laneAction{kind: kind}
+	}
+	commit := func(src commitErrSource) laneAction {
+		return laneAction{kind: laneActionCommit, commitErr: src}
+	}
+	dropWarm := func(reason warmDropReason) laneAction {
+		return laneAction{kind: laneActionDropWarm, warmDrop: reason}
+	}
+	dropLate := func(reason lateDropReason) laneAction {
+		return laneAction{kind: laneActionDropLateWork, lateDrop: reason}
+	}
+
+	running := laneTransitionInput{
+		phase:             lanePhaseRunning,
+		hasPendingCommit:  true,
+		generationMatches: true,
+	}
+	wedged := laneTransitionInput{
+		phase:             lanePhaseWedged,
+		generationMatches: true,
+	}
+
+	tests := map[string]struct {
+		in   laneTransitionInput
+		want []laneAction
+	}{
+		"running completed": {
+			in: withEvent(running, laneEffectCompleted),
+			want: []laneAction{
+				act(laneActionTakePendingCommit),
+				act(laneActionLeaveRunning),
+				commit(commitErrResult),
+				act(laneActionBumpGeneration),
+				act(laneActionRunAfterIdleIfIdle),
+				act(laneActionFinishIfSettled),
+				act(laneActionSettle),
+				act(laneActionMaybeDelete),
+				act(laneActionFlushPendingEffects),
+				act(laneActionObserveState),
+			},
+		},
+		"running completed while draining": {
+			in: withDraining(withEvent(running, laneEffectCompleted)),
+			want: []laneAction{
+				act(laneActionTakePendingCommit),
+				act(laneActionLeaveRunning),
+				commit(commitErrShutdownNeverRan),
+				act(laneActionBumpGeneration),
+				act(laneActionRunAfterIdleIfIdle),
+				act(laneActionFinishIfSettled),
+				act(laneActionSettle),
+				act(laneActionMaybeDelete),
+				act(laneActionFlushPendingEffects),
+				act(laneActionObserveState),
+			},
+		},
+		"running abandoned": {
+			in: withEvent(running, laneEffectAbandoned),
+			want: []laneAction{
+				act(laneActionTakePendingCommit),
+				act(laneActionEnterWedged),
+				commit(commitErrResult),
+				act(laneActionBumpGeneration),
+				act(laneActionCaptureWedgeGeneration),
+				act(laneActionRunAfterIdle),
+				act(laneActionSnapshotReadDeps),
+				act(laneActionReleaseReadClaims),
+				act(laneActionWakeClaimWaiters),
+				act(laneActionFlushPendingEffects),
+				act(laneActionObserveState),
+			},
+		},
+		"running abandoned while draining": {
+			in: withDraining(withEvent(running, laneEffectAbandoned)),
+			want: []laneAction{
+				act(laneActionTakePendingCommit),
+				act(laneActionEnterWedged),
+				commit(commitErrShutdownNeverRan),
+				act(laneActionBumpGeneration),
+				act(laneActionCaptureWedgeGeneration),
+				act(laneActionRunAfterIdle),
+				act(laneActionSnapshotReadDeps),
+				act(laneActionReleaseReadClaims),
+				act(laneActionWakeClaimWaiters),
+				act(laneActionFlushPendingEffects),
+				act(laneActionObserveState),
+			},
+		},
+		"wedged late return": {
+			in: withEvent(wedged, laneEffectLateReturn),
+			want: []laneAction{
+				act(laneActionLeaveWedged),
+				act(laneActionLogLateReturn),
+				act(laneActionFinishIfSettled),
+				act(laneActionSettle),
+				act(laneActionMaybeDelete),
+				act(laneActionObserveState),
+			},
+		},
+		"wedged late return runs late work before release tail": {
+			in: withLateWork(withEvent(wedged, laneEffectLateReturn)),
+			want: []laneAction{
+				act(laneActionLeaveWedged),
+				act(laneActionLogLateReturn),
+				act(laneActionRunLateWork),
+				act(laneActionFinishIfSettled),
+				act(laneActionSettle),
+				act(laneActionMaybeDelete),
+				act(laneActionObserveState),
+			},
+		},
+		"wedged late return drops late work while draining": {
+			in: withDraining(withLateWork(withEvent(wedged, laneEffectLateReturn))),
+			want: []laneAction{
+				act(laneActionLeaveWedged),
+				act(laneActionLogLateReturn),
+				dropLate(lateDropDraining),
+				act(laneActionFinishIfSettled),
+				act(laneActionSettle),
+				act(laneActionMaybeDelete),
+				act(laneActionObserveState),
+			},
+		},
+		"wedged late return starts warm continuation": {
+			in: withWarmResume(withEvent(wedged, laneEffectLateReturn)),
+			want: []laneAction{
+				act(laneActionLeaveWedged),
+				act(laneActionLogLateReturn),
+				act(laneActionStartWarm),
+				act(laneActionBumpGeneration),
+				act(laneActionFinishIfSettled),
+				act(laneActionSettle),
+				act(laneActionMaybeDelete),
+				act(laneActionObserveState),
+			},
+		},
+		"wedged late return drops warm continuation on generation mismatch": {
+			in:   withGenerationMismatch(withWarmResume(withEvent(wedged, laneEffectLateReturn))),
+			want: warmDropActions(dropWarm(warmDropGenerationMismatch)),
+		},
+		"wedged late return drops warm continuation on queued stop intent": {
+			in:   withStopIntent(withWarmResume(withEvent(wedged, laneEffectLateReturn))),
+			want: warmDropActions(dropWarm(warmDropStopIntentQueued)),
+		},
+		"wedged late return drops warm continuation on changed dependency": {
+			in:   withStaleDep(withWarmResume(withEvent(wedged, laneEffectLateReturn)), staleWarmDepChanged),
+			want: warmDropActions(dropWarm(warmDropStaleDepChanged)),
+		},
+		"wedged late return drops warm continuation on write-held dependency": {
+			in:   withStaleDep(withWarmResume(withEvent(wedged, laneEffectLateReturn)), staleWarmDepWriteHeld),
+			want: warmDropActions(dropWarm(warmDropStaleDepWriteHeld)),
+		},
+		"wedged late return drops warm continuation while draining": {
+			in:   withDraining(withWarmResume(withEvent(wedged, laneEffectLateReturn))),
+			want: warmDropActions(dropWarm(warmDropDraining)),
+		},
+		"completed while wedged is stray": {
+			in:   withEvent(laneTransitionInput{phase: lanePhaseWedged}, laneEffectCompleted),
+			want: []laneAction{act(laneActionDiagnosticStrayCompletion)},
+		},
+		"abandoned while idle is stray": {
+			in:   withEvent(laneTransitionInput{phase: lanePhaseIdle}, laneEffectAbandoned),
+			want: []laneAction{act(laneActionDiagnosticStrayCompletion)},
+		},
+		"late return while running is not wedged": {
+			in: withWarmResume(withEvent(running, laneEffectLateReturn)),
+			want: []laneAction{
+				act(laneActionDiagnosticLateNotWedged),
+				act(laneActionDisposeWarmResume),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, planLaneEffectTransition(tc.in))
+		})
+	}
+}
+
+func withEvent(in laneTransitionInput, ev laneEffectEvent) laneTransitionInput {
+	in.event = ev
+	return in
+}
+
+func withDraining(in laneTransitionInput) laneTransitionInput {
+	in.draining = true
+	return in
+}
+
+func withLateWork(in laneTransitionInput) laneTransitionInput {
+	in.hasLateWork = true
+	return in
+}
+
+func withWarmResume(in laneTransitionInput) laneTransitionInput {
+	in.hasWarmResume = true
+	return in
+}
+
+func withGenerationMismatch(in laneTransitionInput) laneTransitionInput {
+	in.generationMatches = false
+	return in
+}
+
+func withStopIntent(in laneTransitionInput) laneTransitionInput {
+	in.stopIntentQueued = true
+	return in
+}
+
+func withStaleDep(in laneTransitionInput, kind staleWarmDepKind) laneTransitionInput {
+	in.staleDep = kind
+	return in
+}
+
+func warmDropActions(drop laneAction) []laneAction {
+	return []laneAction{
+		{kind: laneActionLeaveWedged},
+		{kind: laneActionLogLateReturn},
+		drop,
+		{kind: laneActionFinishIfSettled},
+		{kind: laneActionSettle},
+		{kind: laneActionMaybeDelete},
+		{kind: laneActionObserveState},
+	}
+}
+
+func TestExecutor_DropWarmResumeStaleCommitMetricParity(t *testing.T) {
+	tests := map[string]struct {
+		reason warmDropReason
+		want   float64
+	}{
+		"generation mismatch increments stale commits": {
+			reason: warmDropGenerationMismatch,
+			want:   1,
+		},
+		"stale dependency changed increments stale commits": {
+			reason: warmDropStaleDepChanged,
+			want:   1,
+		},
+		"stale dependency write held increments stale commits": {
+			reason: warmDropStaleDepWriteHeld,
+			want:   1,
+		},
+		"draining does not increment stale commits": {
+			reason: warmDropDraining,
+		},
+		"queued stop intent does not increment stale commits": {
+			reason: warmDropStopIntentQueued,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr, _ := newExecutorTestManager()
+			e := newExecutor(mgr)
+			res := effectResult{
+				key: "warm-drop",
+				resume: &warmResume{
+					cfg: prepareDyncfgCfg("success", "warm-drop"),
+					job: &collectorProbeJob{fullName: "success_warm-drop"},
+				},
+			}
+
+			e.dropWarmResume(res, tc.reason, "store dependency changed while the key was wedged")
+
+			got, ok := mgr.executorRuntimeStore.Read(metrix.ReadRaw()).Value(executorRuntimeMetricPrefix+".stale_commits", nil)
+			require.True(t, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved effect lifecycle routing and wedge handling from `executor.go` into a transition kernel to make abandon, late-return, and shutdown ordering explicit and easy to test. This simplifies the executor and tightens stale warm-dependency gating.

- **Refactors**
  - Added `executor_transition.go` with a small planner and actions; `executor_transition_test.go` pins completed/abandon/late-return paths, late-work replay, and shutdown drops.
  - Switched `effectResult` to an `outcome` enum and routed all completions through the transition kernel; preserved metrics when dropping warm resumes (generation mismatch, dependency change, or write-held).
  - Replaced `staleWarmDep` with `staleWarmDepStatus` (typed reason + message) used to gate warm resumes; updated references and comments.
  - Trimmed and clarified wedge lifecycle docs in `ARCHITECTURE.md` and `doc.go` to point to the transition kernel and its tests.
  - Expanded tests to pin read-dependency snapshotting, claim wake/recompute without release, stop-intent detection, shutdown wedge behavior, and chained commits.

<sup>Written for commit 6728bd5f2a967e75a12cc27c5090ef6b78ab96d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

