### PR TITLE
docs: clarify Dovecot 2.3 old_stats setup

### DIFF
--- a/src/go/plugin/go.d/collector/dovecot/config_schema.json
+++ b/src/go/plugin/go.d/collector/dovecot/config_schema.json
@@ -20,7 +20,7 @@
       },
       "address": {
         "title": "Address",
-        "description": "The Unix or TCP socket address where the Dovecot [old_stats](https://doc.dovecot.org/configuration_manual/stats/old_statistics/#old-statistics) plugin listens for connections.",
+        "description": "The Unix or TCP socket address where the Dovecot old_stats interface listens for connections. On Dovecot 2.3 and newer, expose this through service old-stats.",
         "type": "string",
         "default": "127.0.0.1:24242"
       },
@@ -56,7 +56,7 @@
       "ui:placeholder": "To use this option, first create a Virtual Node and then reference its name here."
     },
     "address": {
-      "ui:help": "Use `unix://{path_to_socket}` for Unix socket or `{ip}:{port}` for TCP socket."
+      "ui:help": "Use `unix://{path_to_socket}` for a Unix socket or `{ip}:{port}` for TCP. For Dovecot 2.3+, this should point to the old-stats socket."
     },
     "timeout": {
       "ui:help": "Accepts decimals for precise control (e.g., type 1.5 for 1.5 seconds)."

--- a/src/go/plugin/go.d/collector/dovecot/integrations/dovecot.md
+++ b/src/go/plugin/go.d/collector/dovecot/integrations/dovecot.md
@@ -24,7 +24,7 @@ Module: dovecot
 This collector monitors Dovecot metrics about sessions, logins, commands, page faults and more.
 
 
-It reads the server's response to the `EXPORT\tglobal\n` command.
+It reads the server's response to the `EXPORT\tglobal\n` command from Dovecot's `old_stats` interface.
 
 
 This collector is supported on all platforms.
@@ -69,9 +69,31 @@ UI configuration requires paid Netdata Cloud plan.
 
 ### Prerequisites
 
-#### Enable old_stats plugin
+#### Enable old_stats-compatible statistics
 
-To enable `old_stats` plugin, see [Old Statistics](https://doc.dovecot.org/configuration_manual/stats/old_statistics/#old-statistics).
+This collector uses Dovecot's `old_stats` interface. On Dovecot 2.3 and newer, enable the
+`old_stats` plugin and expose an `old-stats` socket that matches the collector `address`.
+
+Example Dovecot 2.3+ configuration:
+
+```text
+mail_plugins = $mail_plugins old_stats
+
+service old-stats {
+  unix_listener old-stats {
+    user = netdata
+    group = netdata
+    mode = 0660
+  }
+}
+```
+
+With the socket above, set `address` to `unix:///var/run/dovecot/old-stats`.
+
+The newer Dovecot statistics/OpenMetrics interface is not collected by this integration.
+If you expose Dovecot metrics through OpenMetrics instead, configure Netdata's
+Prometheus/OpenMetrics collector for that endpoint.
+
 
 
 
@@ -90,7 +112,7 @@ The following options can be defined globally: update_every, autodetection_retry
 |:------|:-----|:------------|:--------|:---------:|
 | **Collection** | update_every | Data collection interval (seconds). | 1 | no |
 |  | autodetection_retry | Autodetection retry interval (seconds). Set 0 to disable. | 0 | no |
-| **Target** | address | Dovecot socket address (Unix or TCP). Used by the [old_stats](https://doc.dovecot.org/configuration_manual/stats/old_statistics/#old-statistics) plugin. | 127.0.0.1:24242 | yes |
+| **Target** | address | Dovecot socket address (Unix or TCP). This collector expects the `old_stats` interface; on Dovecot 2.3+, expose it through `service old-stats`. | 127.0.0.1:24242 | yes |
 |  | timeout | Connection, read, write, and name resolution timeout (seconds). | 1 | no |
 | **Virtual Node** | vnode | Associates this data collection job with a [Virtual Node](https://learn.netdata.cloud/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts#virtual-nodes). |  | no |
 

--- a/src/go/plugin/go.d/collector/dovecot/metadata.yaml
+++ b/src/go/plugin/go.d/collector/dovecot/metadata.yaml
@@ -24,7 +24,7 @@ modules:
         metrics_description: |
           This collector monitors Dovecot metrics about sessions, logins, commands, page faults and more.
         method_description: |
-          It reads the server's response to the `EXPORT\tglobal\n` command.
+          It reads the server's response to the `EXPORT\tglobal\n` command from Dovecot's `old_stats` interface.
       supported_platforms:
         include: []
         exclude: []
@@ -45,9 +45,30 @@ modules:
     setup:
       prerequisites:
         list:
-          - title: Enable old_stats plugin
+          - title: Enable old_stats-compatible statistics
             description: |
-              To enable `old_stats` plugin, see [Old Statistics](https://doc.dovecot.org/configuration_manual/stats/old_statistics/#old-statistics).
+              This collector uses Dovecot's `old_stats` interface. On Dovecot 2.3 and newer, enable the
+              `old_stats` plugin and expose an `old-stats` socket that matches the collector `address`.
+
+              Example Dovecot 2.3+ configuration:
+
+              ```text
+              mail_plugins = $mail_plugins old_stats
+
+              service old-stats {
+                unix_listener old-stats {
+                  user = netdata
+                  group = netdata
+                  mode = 0660
+                }
+              }
+              ```
+
+              With the socket above, set `address` to `unix:///var/run/dovecot/old-stats`.
+
+              The newer Dovecot statistics/OpenMetrics interface is not collected by this integration.
+              If you expose Dovecot metrics through OpenMetrics instead, configure Netdata's
+              Prometheus/OpenMetrics collector for that endpoint.
       configuration:
         file:
           name: go.d/dovecot.conf
@@ -70,7 +91,7 @@ modules:
               group: Collection
 
             - name: address
-              description: "Dovecot socket address (Unix or TCP). Used by the [old_stats](https://doc.dovecot.org/configuration_manual/stats/old_statistics/#old-statistics) plugin."
+              description: "Dovecot socket address (Unix or TCP). This collector expects the `old_stats` interface; on Dovecot 2.3+, expose it through `service old-stats`."
               default_value: 127.0.0.1:24242
               required: true
               group: Target

--- a/src/go/plugin/go.d/config/go.d/dovecot.conf
+++ b/src/go/plugin/go.d/config/go.d/dovecot.conf
@@ -1,5 +1,8 @@
 ## All available configuration options, their descriptions and default values:
 ## https://github.com/netdata/netdata/tree/master/src/go/plugin/go.d/collector/dovecot#readme
+##
+## This collector uses Dovecot's old_stats interface. On Dovecot 2.3 and newer,
+## expose an old-stats socket and keep the address below in sync with it.
 
 jobs:
   - name: local


### PR DESCRIPTION
Fixes #4392

## Summary
- clarify that the Dovecot collector queries the old_stats interface with EXPORT global
- document the Dovecot 2.3+ old-stats socket setup expected by the collector
- update the address help text and shipped sample config comment to match the documented setup

## Collector consistency
- Runtime collector code: unchanged; it already uses the old_stats EXPORT global path.
- metadata.yaml and generated integration README: updated and regenerated with integrations/gen_integrations.py.
- config_schema.json: updated address description and UI help.
- stock go.d/dovecot.conf: updated comment for the shipped example address.
- taxonomy.yaml and health.d: not changed; this PR does not add, remove, or rename metrics, chart contexts, dimensions, labels, or alerts.

## Testing
- `python integrations/gen_integrations.py`
- `python3 -m json.tool src/go/plugin/go.d/collector/dovecot/config_schema.json >/tmp/dovecot-config-schema.json`
- `python - <<PY ... ruamel.yaml safe-load metadata.yaml ... PY`
- `git diff --check`
