### PR TITLE
Netdata fixes part 38

### DIFF
--- a/src/daemon/config/netdata-conf-global.c
+++ b/src/daemon/config/netdata-conf-global.c
@@ -5,15 +5,17 @@
 
 size_t netdata_conf_cpus(void) {
     static size_t processors = 0;
+    static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
-    if(processors)
-        return processors;
+    size_t cached_processors = __atomic_load_n(&processors, __ATOMIC_ACQUIRE);
+    if(cached_processors)
+        return cached_processors;
 
-    SPINLOCK spinlock = SPINLOCK_INITIALIZER;
     spinlock_lock(&spinlock);
     size_t p = 0;
 
-    if(processors)
+    cached_processors = __atomic_load_n(&processors, __ATOMIC_ACQUIRE);
+    if(cached_processors)
         goto skip;
 
 #if defined(OS_LINUX)
@@ -29,15 +31,16 @@ size_t netdata_conf_cpus(void) {
     if(p < 1)
         p = 1;
 
-    processors = p;
+    cached_processors = p;
 
     char buf[24];
-    snprintfz(buf, sizeof(buf), "%zu", processors);
+    snprintfz(buf, sizeof(buf), "%zu", cached_processors);
     nd_setenv("NETDATA_CONF_CPUS", buf, 1);
+    __atomic_store_n(&processors, cached_processors, __ATOMIC_RELEASE);
 
 skip:
     spinlock_unlock(&spinlock);
-    return processors;
+    return cached_processors;
 }
 
 void netdata_conf_glibc_malloc_initialize(size_t wanted_arenas, size_t trim_threshold __maybe_unused) {

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -56,7 +56,7 @@ void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused)
         if(signals_waiting[i].signo != signo)
             continue;
 
-        signals_waiting[i].count++;
+        __atomic_fetch_add(&signals_waiting[i].count, 1, __ATOMIC_RELAXED);
 
         if(signals_waiting[i].action == NETDATA_SIGNAL_DEADLY) {
             bool chained_handler = original_sigactions[signo] || (original_handlers[signo] && original_handlers[signo] != SIG_IGN && original_handlers[signo] != SIG_DFL);
@@ -215,11 +215,10 @@ static void process_triggered_signals(void) {
     do {
         found = 0;
         for (size_t i = 0; i < _countof(signals_waiting) ; i++) {
-            if (!signals_waiting[i].count)
+            if (!__atomic_exchange_n(&signals_waiting[i].count, 0, __ATOMIC_RELAXED))
                 continue;
 
             found++;
-            signals_waiting[i].count = 0;
             const char *name = signals_waiting[i].name;
 
             switch (signals_waiting[i].action) {

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -58,7 +58,72 @@ static DAEMON_STATUS_FILE session_status = {
     },
 };
 
+typedef struct daemon_status_fatal_snapshot {
+    char filename[sizeof(session_status.fatal.filename)];
+    char function[sizeof(session_status.fatal.function)];
+    char errno_str[sizeof(session_status.fatal.errno_str)];
+    char message[sizeof(session_status.fatal.message)];
+    char stack_trace[sizeof(session_status.fatal.stack_trace)];
+    char thread[sizeof(session_status.fatal.thread)];
+    pid_t thread_id;
+    long line;
+    uint32_t worker_job_id;
+} DAEMON_STATUS_FATAL_SNAPSHOT;
+
+static DAEMON_STATUS_FATAL_SNAPSHOT fatal_snapshot = { 0 };
+
 static void daemon_status_file_out_of_memory(void);
+
+static void fatal_snapshot_store_string(char *dst, const char *src, size_t size) {
+    if(!size)
+        return;
+
+    __atomic_store_n(&dst[0], '\0', __ATOMIC_RELEASE);
+
+    if(!src)
+        return;
+
+    size_t i = 0;
+    for(; i < size - 1 && src[i] ; i++)
+        __atomic_store_n(&dst[i], src[i], __ATOMIC_RELEASE);
+
+    __atomic_store_n(&dst[i], '\0', __ATOMIC_RELEASE);
+}
+
+static const char *fatal_snapshot_load_string(const char *src, char *dst, size_t size) {
+    if(!size)
+        return "";
+
+    size_t i = 0;
+    for(; i < size - 1 ; i++) {
+        char c = __atomic_load_n(&src[i], __ATOMIC_ACQUIRE);
+        dst[i] = c;
+
+        if(!c)
+            return dst;
+    }
+
+    dst[i] = '\0';
+    return dst;
+}
+
+static void daemon_status_file_publish_fatal_snapshot(void) {
+    fatal_snapshot_store_string(
+        fatal_snapshot.filename, session_status.fatal.filename, sizeof(fatal_snapshot.filename));
+    fatal_snapshot_store_string(
+        fatal_snapshot.function, session_status.fatal.function, sizeof(fatal_snapshot.function));
+    fatal_snapshot_store_string(
+        fatal_snapshot.message, session_status.fatal.message, sizeof(fatal_snapshot.message));
+    fatal_snapshot_store_string(
+        fatal_snapshot.errno_str, session_status.fatal.errno_str, sizeof(fatal_snapshot.errno_str));
+    fatal_snapshot_store_string(
+        fatal_snapshot.stack_trace, session_status.fatal.stack_trace, sizeof(fatal_snapshot.stack_trace));
+    fatal_snapshot_store_string(fatal_snapshot.thread, session_status.fatal.thread, sizeof(fatal_snapshot.thread));
+
+    __atomic_store_n(&fatal_snapshot.thread_id, session_status.fatal.thread_id, __ATOMIC_RELEASE);
+    __atomic_store_n(&fatal_snapshot.line, session_status.fatal.line, __ATOMIC_RELEASE);
+    __atomic_store_n(&fatal_snapshot.worker_job_id, session_status.fatal.worker_job_id, __ATOMIC_RELEASE);
+}
 
 static void copy_and_clean_thread_name_if_empty(DAEMON_STATUS_FILE *ds, const char *name) {
     if(ds->fatal.thread[0] && strcmp(ds->fatal.thread, "NO_NAME") != 0)
@@ -1354,6 +1419,7 @@ static void daemon_status_file_save_twice_if_we_can_get_stack_trace(BUFFER *wb, 
     else
 #endif
         set_stack_trace_message_if_empty(&session_status, STACK_TRACE_INFO_PREFIX "no stack trace backend available");
+    daemon_status_file_publish_fatal_snapshot();
 
     // save it without a stack trace to be sure we will have the event
     daemon_status_file_save(wb, ds, false);
@@ -1372,9 +1438,11 @@ static void daemon_status_file_save_twice_if_we_can_get_stack_trace(BUFFER *wb, 
         (!ds->fatal.function[0] || strncmp(ds->fatal.function, "thread:", 7) == 0))
         safecpy(ds->fatal.function, first_nd_fn);
 #endif
+    daemon_status_file_publish_fatal_snapshot();
 
     if(buffer_strlen(wb) > 0) {
         safecpy(ds->fatal.stack_trace, buffer_tostring(wb));
+        daemon_status_file_publish_fatal_snapshot();
 
         daemon_status_file_save(wb, ds, false);
     }
@@ -1420,6 +1488,8 @@ void daemon_status_file_register_fatal(const char *filename, const char *functio
 
     if(line)
         session_status.fatal.line = line;
+
+    daemon_status_file_publish_fatal_snapshot();
 
     spinlock_unlock(&session_status.fatal.spinlock);
     dsf_release(session_status);
@@ -1503,6 +1573,8 @@ bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE c
         }
     }
 
+    daemon_status_file_publish_fatal_snapshot();
+
     dsf_release(session_status);
 
     // the buffer should already be allocated, so this should normally do nothing
@@ -1564,6 +1636,7 @@ void daemon_status_file_shutdown_timeout(BUFFER *trace) {
     dsf_release(session_status);
 
     safecpy(session_status.fatal.function, "shutdown_timeout");
+    daemon_status_file_publish_fatal_snapshot();
 
     static_save_buffer_init();
     daemon_status_file_save(static_save_buffer, &session_status, false);
@@ -1583,6 +1656,8 @@ void daemon_status_file_shutdown_step(const char *step, const char *step_timings
 
     if(step_timings && *step_timings && stack_trace_is_empty(&session_status))
         safecpy(session_status.fatal.stack_trace, step_timings);
+
+    daemon_status_file_publish_fatal_snapshot();
 
     daemon_status_file_update_status(DAEMON_STATUS_EXITING);
 
@@ -1614,6 +1689,8 @@ void daemon_status_file_startup_step(const char *step) {
         safecpy(session_status.fatal.function, step);
     else
         session_status.fatal.function[0] = '\0';
+
+    daemon_status_file_publish_fatal_snapshot();
 
     daemon_status_file_update_status(DAEMON_STATUS_INITIALIZING);
 }
@@ -1670,23 +1747,28 @@ const char *daemon_status_file_get_timezone(void) {
 }
 
 const char *daemon_status_file_get_fatal_filename(void) {
-    return session_status.fatal.filename;
+    static __thread char filename[sizeof(fatal_snapshot.filename)];
+    return fatal_snapshot_load_string(fatal_snapshot.filename, filename, sizeof(filename));
 }
 
 const char *daemon_status_file_get_fatal_function(void) {
-    return session_status.fatal.function;
+    static __thread char function[sizeof(fatal_snapshot.function)];
+    return fatal_snapshot_load_string(fatal_snapshot.function, function, sizeof(function));
 }
 
 const char *daemon_status_file_get_fatal_message(void) {
-    return session_status.fatal.message;
+    static __thread char message[sizeof(fatal_snapshot.message)];
+    return fatal_snapshot_load_string(fatal_snapshot.message, message, sizeof(message));
 }
 
 const char *daemon_status_file_get_fatal_errno(void) {
-    return session_status.fatal.errno_str;
+    static __thread char errno_str[sizeof(fatal_snapshot.errno_str)];
+    return fatal_snapshot_load_string(fatal_snapshot.errno_str, errno_str, sizeof(errno_str));
 }
 
 const char *daemon_status_file_get_fatal_stack_trace(void) {
-    return session_status.fatal.stack_trace;
+    static __thread char stack_trace[sizeof(fatal_snapshot.stack_trace)];
+    return fatal_snapshot_load_string(fatal_snapshot.stack_trace, stack_trace, sizeof(stack_trace));
 }
 
 const char *daemon_status_file_get_stack_trace_backend(void) {
@@ -1694,7 +1776,8 @@ const char *daemon_status_file_get_stack_trace_backend(void) {
 }
 
 const char *daemon_status_file_get_fatal_thread(void) {
-    return session_status.fatal.thread;
+    static __thread char thread[sizeof(fatal_snapshot.thread)];
+    return fatal_snapshot_load_string(fatal_snapshot.thread, thread, sizeof(thread));
 }
 
 const char *daemon_status_file_get_sys_vendor(void) {
@@ -1710,11 +1793,11 @@ const char *daemon_status_file_get_product_type(void) {
 }
 
 pid_t daemon_status_file_get_fatal_thread_id(void) {
-    return session_status.fatal.thread_id;
+    return __atomic_load_n(&fatal_snapshot.thread_id, __ATOMIC_ACQUIRE);
 }
 
 long daemon_status_file_get_fatal_line(void) {
-    return session_status.fatal.line;
+    return __atomic_load_n(&fatal_snapshot.line, __ATOMIC_ACQUIRE);
 }
 
 DAEMON_STATUS daemon_status_file_get_status(void) {
@@ -1734,5 +1817,5 @@ ND_MACHINE_GUID daemon_status_file_get_host_id(void) {
 }
 
 size_t daemon_status_file_get_fatal_worker_job_id(void) {
-    return session_status.fatal.worker_job_id;
+    return __atomic_load_n(&fatal_snapshot.worker_job_id, __ATOMIC_ACQUIRE);
 }

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -592,6 +592,23 @@ static inline void atomic_set_max_int64_t(int64_t *max, int64_t desired) {
                                          false, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
 }
 
+static ALWAYS_INLINE uint16_t page_accesses_get(PGC_PAGE *page) {
+    return __atomic_load_n(&page->accesses, __ATOMIC_RELAXED);
+}
+
+static ALWAYS_INLINE void page_accesses_increment(PGC_PAGE *page) {
+    uint16_t accesses = page_accesses_get(page);
+
+    // This is a queue-placement hint; wrapping to zero makes a hot page look cold.
+    while(accesses != UINT16_MAX) {
+        uint16_t wanted = accesses + 1;
+
+        if(__atomic_compare_exchange_n(&page->accesses, &accesses, wanted,
+                                       false, __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+            return;
+    }
+}
+
 struct section_pages {
     SPINLOCK migration_to_v2_spinlock;
     size_t entries;
@@ -674,7 +691,8 @@ static ALWAYS_INLINE void pgc_queue_add(PGC *cache __maybe_unused, struct pgc_qu
         // - New pages created as CLEAN, always have 1 access.
         // - DIRTY pages made CLEAN, depending on their accesses may be appended (accesses > 0) or prepended (accesses = 0).
 
-        if(page->accesses || page_flag_check(page, PGC_PAGE_HAS_BEEN_ACCESSED | PGC_PAGE_HAS_NO_DATA_IGNORE_ACCESSES) == PGC_PAGE_HAS_BEEN_ACCESSED) {
+        if(page_accesses_get(page) ||
+            page_flag_check(page, PGC_PAGE_HAS_BEEN_ACCESSED | PGC_PAGE_HAS_NO_DATA_IGNORE_ACCESSES) == PGC_PAGE_HAS_BEEN_ACCESSED) {
             DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(q->base, page, link.prev, link.next);
             page_flag_clear(page, PGC_PAGE_HAS_BEEN_ACCESSED);
         }
@@ -774,7 +792,7 @@ static ALWAYS_INLINE void page_has_been_accessed(PGC *cache, PGC_PAGE *page) {
     PGC_PAGE_FLAGS flags = page_flag_check(page, PGC_PAGE_CLEAN | PGC_PAGE_HAS_NO_DATA_IGNORE_ACCESSES);
 
     if (!(flags & PGC_PAGE_HAS_NO_DATA_IGNORE_ACCESSES)) {
-        __atomic_add_fetch(&page->accesses, 1, __ATOMIC_RELAXED);
+        page_accesses_increment(page);
 
         if (flags & PGC_PAGE_CLEAN) {
             if(pgc_queue_trylock(cache, &cache->clean, PGC_QUEUE_LOCK_PRIO_EVICTORS)) {
@@ -1911,7 +1929,7 @@ static bool flush_pages(PGC *cache, size_t max_flushes, Word_t section, bool wai
             pages_made_clean_size += tpg->assumed_size;
             pages_made_clean++;
 
-            if(!tpg->accesses)
+            if(!page_accesses_get(tpg))
                 pages_to_evict++;
 
             page_set_clean(cache, tpg, true, false, PGC_QUEUE_LOCK_PRIO_FLUSHERS);

--- a/src/libnetdata/os/boot_id.c
+++ b/src/libnetdata/os/boot_id.c
@@ -4,6 +4,7 @@
 #include "libnetdata/libnetdata.h"
 
 static ND_UUID cached_boot_id = { 0 };
+static bool cached_boot_id_available = false;
 static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
 #if defined(OS_LINUX)
@@ -49,19 +50,22 @@ static ND_UUID get_boot_id(void) {
 #endif // OS_LINUX
 
 ND_UUID os_boot_id(void) {
-    // Fast path - return cached value if available
-    if(!UUIDiszero(cached_boot_id))
+    if(__atomic_load_n(&cached_boot_id_available, __ATOMIC_ACQUIRE))
         return cached_boot_id;
 
     spinlock_lock(&spinlock);
 
-    // Check again under lock in case another thread set it
-    if(UUIDiszero(cached_boot_id)) {
-        cached_boot_id = get_boot_id();
+    ND_UUID boot_id = cached_boot_id;
+    if(UUIDiszero(boot_id)) {
+        boot_id = get_boot_id();
+        cached_boot_id = boot_id;
+
+        if(!UUIDiszero(boot_id))
+            __atomic_store_n(&cached_boot_id_available, true, __ATOMIC_RELEASE);
     }
 
     spinlock_unlock(&spinlock);
-    return cached_boot_id;
+    return boot_id;
 }
 
 bool os_boot_ids_match(ND_UUID a, ND_UUID b) {

--- a/src/libnetdata/os/boottime.c
+++ b/src/libnetdata/os/boottime.c
@@ -3,6 +3,7 @@
 #include "libnetdata/libnetdata.h"
 
 static time_t cached_boottime = 0;
+static bool cached_boottime_available = false;
 static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
 #if defined(OS_LINUX)
@@ -110,16 +111,20 @@ static time_t get_stable_boottime(void) {
 }
 
 time_t os_boottime(void) {
-    // Fast path - return cached value if available
-    if(cached_boottime > 0)
+    if(__atomic_load_n(&cached_boottime_available, __ATOMIC_ACQUIRE))
         return cached_boottime;
 
     spinlock_lock(&spinlock);
 
-    // Check again under lock in case another thread set it
-    if(cached_boottime == 0)
-        cached_boottime = get_stable_boottime();
+    time_t boottime = cached_boottime;
+    if(boottime == 0) {
+        boottime = get_stable_boottime();
+        cached_boottime = boottime;
+
+        if(boottime > 0)
+            __atomic_store_n(&cached_boottime_available, true, __ATOMIC_RELEASE);
+    }
 
     spinlock_unlock(&spinlock);
-    return cached_boottime;
+    return boottime;
 }

--- a/src/libnetdata/os/get_system_cpus.c
+++ b/src/libnetdata/os/get_system_cpus.c
@@ -4,12 +4,19 @@
 
 size_t os_get_system_cpus_cached(bool cache) {
     static size_t processors = 0;
+    static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
-    if(likely(cache && processors > 0))
-        return processors;
+    size_t cached_processors = __atomic_load_n(&processors, __ATOMIC_ACQUIRE);
+    if(likely(cache && cached_processors > 0))
+        return cached_processors;
 
-    SPINLOCK spinlock = SPINLOCK_INITIALIZER;
     spinlock_lock(&spinlock);
+
+    cached_processors = __atomic_load_n(&processors, __ATOMIC_RELAXED);
+    if(likely(cache && cached_processors > 0)) {
+        spinlock_unlock(&spinlock);
+        return cached_processors;
+    }
 
     long p = 0;
 
@@ -71,15 +78,17 @@ size_t os_get_system_cpus_cached(bool cache) {
 #endif
 
 done:
-    processors = (size_t)p;
+    cached_processors = (size_t)p;
+    __atomic_store_n(&processors, cached_processors, __ATOMIC_RELEASE);
     spinlock_unlock(&spinlock);
-    return processors;
+    return cached_processors;
 
 error:
+    cached_processors = 1;
+    __atomic_store_n(&processors, cached_processors, __ATOMIC_RELEASE);
     spinlock_unlock(&spinlock);
-    processors = 1;
-    netdata_log_error("Cannot detect number of CPU cores. Assuming the system has %zu processors.", processors);
-    return processors;
+    netdata_log_error("Cannot detect number of CPU cores. Assuming the system has %zu processors.", cached_processors);
+    return cached_processors;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/libnetdata/os/machine_id.c
+++ b/src/libnetdata/os/machine_id.c
@@ -4,6 +4,7 @@
 #include "libnetdata/libnetdata.h"
 
 static ND_UUID cached_machine_id = { 0 };
+static bool cached_machine_id_available = false;
 static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
 #if defined(OS_LINUX)
@@ -171,26 +172,29 @@ static ND_UUID get_machine_id(void) {
 #endif // OS_WINDOWS
 
 ND_UUID os_machine_id(void) {
-    // Fast path - return cached value if available
-    if(!UUIDiszero(cached_machine_id))
+    if(__atomic_load_n(&cached_machine_id_available, __ATOMIC_ACQUIRE))
         return cached_machine_id;
 
     spinlock_lock(&spinlock);
 
-    // Check again under lock in case another thread set it
-    if(UUIDiszero(cached_machine_id)) {
-        cached_machine_id = get_machine_id();
+    ND_UUID machine_id = cached_machine_id;
+    if(UUIDiszero(machine_id)) {
+        machine_id = get_machine_id();
+        cached_machine_id = machine_id;
 
         // Log the result if debugging is enabled
-        if(UUIDeq(cached_machine_id, NO_MACHINE_ID))
+        if(UUIDeq(machine_id, NO_MACHINE_ID))
             nd_log(NDLS_DAEMON, NDLP_WARNING, "OS_MACHINE_ID: Could not detect a reliable machine ID");
         else {
             char buf[UUID_STR_LEN];
-            uuid_unparse_lower(cached_machine_id.uuid, buf);
+            uuid_unparse_lower(machine_id.uuid, buf);
             nd_log(NDLS_DAEMON, NDLP_NOTICE, "OS_MACHINE_ID: machine ID found '%s'", buf);
         }
+
+        if(!UUIDiszero(machine_id))
+            __atomic_store_n(&cached_machine_id_available, true, __ATOMIC_RELEASE);
     }
 
     spinlock_unlock(&spinlock);
-    return cached_machine_id;
+    return machine_id;
 }

--- a/src/libnetdata/os/mmap_limit.c
+++ b/src/libnetdata/os/mmap_limit.c
@@ -3,19 +3,32 @@
 #include "mmap_limit.h"
 #include "libnetdata/libnetdata.h"
 
-unsigned long long os_mmap_limit(void) {
-    static unsigned long long cached_limit = 0;
+static unsigned long long cached_limit = 0;
+static bool cached_limit_available = false;
+static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
-    if (cached_limit)
+unsigned long long os_mmap_limit(void) {
+    if (__atomic_load_n(&cached_limit_available, __ATOMIC_ACQUIRE))
         return cached_limit;
 
-#if defined(OS_LINUX)
-    if(read_single_number_file("/proc/sys/vm/max_map_count", &cached_limit) != 0)
-        cached_limit = 65536;
-#else
-    // For other operating systems, assume no limit.
-    cached_limit = UINT32_MAX;
-#endif
+    spinlock_lock(&spinlock);
 
-    return cached_limit;
+    unsigned long long limit = cached_limit;
+    if (!limit) {
+#if defined(OS_LINUX)
+        if(read_single_number_file("/proc/sys/vm/max_map_count", &limit) != 0)
+            limit = 65536;
+#else
+        // For other operating systems, assume no limit.
+        limit = UINT32_MAX;
+#endif
+        cached_limit = limit;
+
+        bool limit_available = (bool)limit;
+        __atomic_store_n(&cached_limit_available, limit_available, __ATOMIC_RELEASE);
+    }
+
+    spinlock_unlock(&spinlock);
+
+    return limit;
 }

--- a/src/libnetdata/os/run_dir.c
+++ b/src/libnetdata/os/run_dir.c
@@ -4,6 +4,7 @@
 #include "libnetdata/libnetdata.h"
 
 static char *cached_run_dir = NULL;
+static bool cached_run_dir_available = false;
 static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
 static inline bool is_dir_accessible(const char *dir, bool rw) {
@@ -116,17 +117,23 @@ success:
 
 const char *os_run_dir(bool rw) {
     // Fast path - return cached directory if available
-    if(cached_run_dir)
+    if(__atomic_load_n(&cached_run_dir_available, __ATOMIC_ACQUIRE))
         return cached_run_dir;
 
     spinlock_lock(&spinlock);
 
     // Check again under lock in case another thread set it
-    if(!cached_run_dir)
-        cached_run_dir = detect_run_dir(rw);
+    char *run_dir = cached_run_dir;
+    if(!run_dir) {
+        run_dir = detect_run_dir(rw);
+        cached_run_dir = run_dir;
+
+        if(run_dir)
+            __atomic_store_n(&cached_run_dir_available, true, __ATOMIC_RELEASE);
+    }
 
     spinlock_unlock(&spinlock);
 
     errno_clear();
-    return cached_run_dir;
+    return run_dir;
 }

--- a/src/libnetdata/procfile/procfile.c
+++ b/src/libnetdata/procfile/procfile.c
@@ -17,15 +17,45 @@ static size_t procfile_max_lines = PFLINES_INCREASE_STEP;
 static size_t procfile_max_words = PFWORDS_INCREASE_STEP;
 static size_t procfile_max_allocation = PROCFILE_INCREMENT_BUFFER;
 
-void procfile_set_adaptive_allocation(bool enable, size_t bytes, size_t lines, size_t words) {
-    procfile_adaptive_initial_allocation = enable;
+struct procfile_adaptive_allocation {
+    size_t bytes;
+    size_t lines;
+    size_t words;
+};
 
-    if(bytes > procfile_max_allocation)
-        procfile_max_allocation = bytes;
-    if(lines > procfile_max_lines)
-        procfile_max_lines = lines;
-    if(words > procfile_max_words)
-        procfile_max_words = words;
+static inline bool procfile_adaptive_allocation_enabled(void) {
+    return __atomic_load_n(&procfile_adaptive_initial_allocation, __ATOMIC_ACQUIRE);
+}
+
+static inline struct procfile_adaptive_allocation procfile_adaptive_allocation_snapshot(void) {
+    if(!procfile_adaptive_allocation_enabled())
+        return (struct procfile_adaptive_allocation) {
+            .bytes = PROCFILE_INCREMENT_BUFFER,
+            .lines = PFLINES_INCREASE_STEP,
+            .words = PFWORDS_INCREASE_STEP,
+        };
+
+    return (struct procfile_adaptive_allocation) {
+        .bytes = __atomic_load_n(&procfile_max_allocation, __ATOMIC_RELAXED),
+        .lines = __atomic_load_n(&procfile_max_lines, __ATOMIC_RELAXED),
+        .words = __atomic_load_n(&procfile_max_words, __ATOMIC_RELAXED),
+    };
+}
+
+static inline void procfile_adaptive_allocation_update_max(size_t *max, size_t value) {
+    size_t current = __atomic_load_n(max, __ATOMIC_RELAXED);
+
+    while(value > current &&
+          !__atomic_compare_exchange_n(max, &current, value, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED))
+        ;
+}
+
+void procfile_set_adaptive_allocation(bool enable, size_t bytes, size_t lines, size_t words) {
+    procfile_adaptive_allocation_update_max(&procfile_max_allocation, bytes);
+    procfile_adaptive_allocation_update_max(&procfile_max_lines, lines);
+    procfile_adaptive_allocation_update_max(&procfile_max_words, words);
+
+    __atomic_store_n(&procfile_adaptive_initial_allocation, enable, __ATOMIC_RELEASE);
 }
 
 // ----------------------------------------------------------------------------
@@ -76,10 +106,8 @@ static inline void procfile_words_add(procfile *ff, char *str) {
 }
 
 NEVERNULL
-static inline pfwords *procfile_words_create(void) {
+static inline pfwords *procfile_words_create(size_t size) {
     // netdata_log_debug(D_PROCFILE, PF_PREFIX ":   initializing words");
-
-    size_t size = (procfile_adaptive_initial_allocation) ? procfile_max_words : PFWORDS_INCREASE_STEP;
 
     pfwords *new = mallocz(sizeof(pfwords) + size * sizeof(char *));
     new->len = 0;
@@ -127,10 +155,8 @@ static inline uint32_t *procfile_lines_add(procfile *ff) {
 }
 
 NEVERNULL
-static inline pflines *procfile_lines_create(void) {
+static inline pflines *procfile_lines_create(size_t size) {
     // netdata_log_debug(D_PROCFILE, PF_PREFIX ":   initializing lines");
-
-    size_t size = (unlikely(procfile_adaptive_initial_allocation)) ? procfile_max_words : PFLINES_INCREASE_STEP;
 
     pflines *new = mallocz(sizeof(pflines) + size * sizeof(ffline));
     new->len = 0;
@@ -359,10 +385,10 @@ procfile *procfile_readall(procfile *ff) {
     procfile_words_reset(ff->words);
     procfile_parser(ff);
 
-    if(unlikely(procfile_adaptive_initial_allocation)) {
-        if(unlikely(ff->len > procfile_max_allocation)) procfile_max_allocation = ff->len;
-        if(unlikely(ff->lines->len > procfile_max_lines)) procfile_max_lines = ff->lines->len;
-        if(unlikely(ff->words->len > procfile_max_words)) procfile_max_words = ff->words->len;
+    if(unlikely(procfile_adaptive_allocation_enabled())) {
+        procfile_adaptive_allocation_update_max(&procfile_max_allocation, ff->len);
+        procfile_adaptive_allocation_update_max(&procfile_max_lines, ff->lines->len);
+        procfile_adaptive_allocation_update_max(&procfile_max_words, ff->words->len);
     }
 
     if(ff->stats.max_source_bytes < ff->len)
@@ -471,7 +497,8 @@ procfile *procfile_open(const char *filename, const char *separators, uint32_t f
 
     // netdata_log_info("PROCFILE: opened '%s' on fd %d", filename, fd);
 
-    size_t size = (unlikely(procfile_adaptive_initial_allocation)) ? procfile_max_allocation : PROCFILE_INCREMENT_BUFFER;
+    struct procfile_adaptive_allocation adaptive = procfile_adaptive_allocation_snapshot();
+    size_t size = adaptive.bytes;
     procfile *ff = mallocz(sizeof(procfile) + size);
 
     //strncpyz(ff->filename, filename, FILENAME_MAX);
@@ -485,8 +512,8 @@ procfile *procfile_open(const char *filename, const char *separators, uint32_t f
     ff->stats.max_lines = ff->stats.max_words = ff->stats.max_source_bytes = 0;
     ff->stats.total_read_bytes = ff->stats.max_read_size = 0;
 
-    ff->lines = procfile_lines_create();
-    ff->words = procfile_words_create();
+    ff->lines = procfile_lines_create(adaptive.lines);
+    ff->words = procfile_words_create(adaptive.words);
 
     ff->stats.memory = sizeof(procfile) + size +
                        (sizeof(pflines) + ff->lines->size * sizeof(ffline)) +


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened concurrency across daemon, OS helpers, DB engine, and procfile by removing data races and publishing cached values atomically. Improves stability in signal handling, fatal reporting, and cache behavior without changing public behavior.

- **Bug Fixes**
  - Serialized cached CPU count init in `netdata_conf_cpus()` and `os_get_system_cpus_cached()` using a static spinlock and acquire/release atomics.
  - Published cached identity/system values safely (`os_boot_id()`, `os_boottime()`, `os_machine_id()`, `os_mmap_limit()`, `os_run_dir()`), using an availability flag and lock-protected writes.
  - Made signal counters atomic: handler uses relaxed fetch-add; drain loop uses relaxed exchange to avoid losing signals.
  - Snapshotted fatal status fields and served getters from a per-thread buffer, preventing races with Sentry/breadcrumb reads.
  - Saturated DB engine page access counter to `UINT16_MAX` and used atomic reads to prevent wrap-around misclassification.
  - Serialized procfile adaptive allocation: atomic enable flag and maxima, snapshot sizes at open, and correct line/word sizing.

<sup>Written for commit 6404977253fed08babd1a4c56a37ab4ed99e39d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/22999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

