### PR TITLE
Netdata fixes part 39

### DIFF
--- a/src/collectors/log2journal/log2journal-yaml.c
+++ b/src/collectors/log2journal/log2journal-yaml.c
@@ -252,23 +252,43 @@ static bool needs_quotes_in_yaml(const char *str) {
     return false;
 }
 
+static void yaml_print_single_quoted_value(const char *value) {
+    fputc('\'', stderr);
+
+    while(*value) {
+        if(*value == '\'')
+            fputc('\'', stderr);
+
+        fputc(*value, stderr);
+        value++;
+    }
+
+    fputc('\'', stderr);
+}
+
 static void yaml_print_node(const char *key, const char *value, size_t depth, bool dash) {
     if(depth > 10) depth = 10;
-    const char *quote = "'";
+    bool quote = true;
 
     const char *second_line = NULL;
     if(value && strchr(value, '\n')) {
         second_line = value;
         value = "|";
-        quote = "";
+        quote = false;
     }
     else if(!value || !needs_quotes_in_yaml(value))
-        quote = "";
+        quote = false;
 
-    fprintf(stderr, "%.*s%s%s%s%s%s%s\n",
+    fprintf(stderr, "%.*s%s%s%s",
             (int)(depth * 2), "                    ", dash ? "- ": "",
-            key ? key : "", key ? ": " : "",
-            quote, value ? value : "", quote);
+            key ? key : "", key ? ": " : "");
+
+    if(quote)
+        yaml_print_single_quoted_value(value ? value : "");
+    else
+        fputs(value ? value : "", stderr);
+
+    fputc('\n', stderr);
 
     if(second_line) {
         yaml_print_multiline_value(second_line, depth + 1);

--- a/src/collectors/log2journal/tests.d/yaml-single-quote-show-config-final-config.yaml
+++ b/src/collectors/log2journal/tests.d/yaml-single-quote-show-config-final-config.yaml
@@ -1,0 +1,3 @@
+pattern: message
+
+prefix: 'Bob''s host'

--- a/src/collectors/log2journal/tests.d/yaml-single-quote-show-config.cmd
+++ b/src/collectors/log2journal/tests.d/yaml-single-quote-show-config.cmd
@@ -1,0 +1,1 @@
+sh -c 'printf "show-config\n\n"; ${TESTED_LOG2JOURNAL_BIN} -f tests.d/yaml-single-quote-show-config.yaml --show-config 2>&1'

--- a/src/collectors/log2journal/tests.d/yaml-single-quote-show-config.yaml
+++ b/src/collectors/log2journal/tests.d/yaml-single-quote-show-config.yaml
@@ -1,0 +1,3 @@
+pattern: message
+
+prefix: "Bob's host"

--- a/src/daemon/buildinfo.c
+++ b/src/daemon/buildinfo.c
@@ -1425,7 +1425,7 @@ static void populate_system_info(void) {
     build_info_set_value_strdupz(BIB_OS_ID, system_info->host_os_id);
     build_info_set_value_strdupz(BIB_OS_ID_LIKE, system_info->host_os_id_like);
     build_info_set_value_strdupz(BIB_OS_VERSION, system_info->host_os_version);
-    build_info_set_value_strdupz(BIB_OS_VERSION_ID, system_info->container_os_version_id);
+    build_info_set_value_strdupz(BIB_OS_VERSION_ID, system_info->host_os_version_id);
     build_info_set_value_strdupz(BIB_OS_DETECTION, system_info->host_os_detection);
     build_info_set_value_strdupz(BIB_HW_CPU_CORES, system_info->host_cores);
     build_info_set_value_strdupz(BIB_HW_CPU_FREQUENCY, system_info->host_cpu_freq);

--- a/src/daemon/pulse/pulse-db-dbengine-retention.c
+++ b/src/daemon/pulse/pulse-db-dbengine-retention.c
@@ -6,7 +6,6 @@
 
 void dbengine_retention_statistics(bool extended __maybe_unused) {
 
-    static bool init = false;
     static DBENGINE_TIER_STATS stats[RRD_STORAGE_TIERS];
 
     if (!localhost)
@@ -19,7 +18,7 @@ void dbengine_retention_statistics(bool extended __maybe_unused) {
         if (!eng || eng->seb != STORAGE_ENGINE_BACKEND_DBENGINE)
             continue;
 
-        if (init == false) {
+        if (unlikely(!stats[tier].st)) {
             char id[200];
             snprintfz(id, sizeof(id) - 1, "dbengine_retention_tier%zu", tier);
             stats[tier].st = rrdset_create_localhost(
@@ -79,6 +78,5 @@ void dbengine_retention_statistics(bool extended __maybe_unused) {
 
         rrdset_done(stats[tier].st);
     }
-    init = true;
 }
 #endif

--- a/src/daemon/pulse/pulse-db-dbengine.c
+++ b/src/daemon/pulse/pulse-db-dbengine.c
@@ -309,7 +309,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
             priority++;
         }
 
-        for(size_t i = 0; i < _countof(ptrs->queues[q].rd_pgc_page_size_x) - 1 ;i++)
+        for(size_t i = 0; i < _countof(ptrs->queues[q].rd_pgc_page_size_x) ;i++)
             rrddim_set_by_pointer(ptrs->queues[q].st_pgc_page_size_heatmap, ptrs->queues[q].rd_pgc_page_size_x[i], (collected_number)pgc_stats->queues[q].size_histogram.array[i].count);
 
         rrdset_done(ptrs->queues[q].st_pgc_page_size_heatmap);

--- a/src/daemon/pulse/pulse-network.c
+++ b/src/daemon/pulse/pulse-network.c
@@ -155,7 +155,7 @@ static void pulse_aclk_time_heatmap(void) {
         rds[_countof(rds) - 1] = rrddim_add(st, "+inf", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
 
-    for(size_t i = 0; i < _countof(rds) - 1 ;i++) {
+    for(size_t i = 0; i < _countof(rds) ;i++) {
         size_t old_value = 0, new_value = 0;
         __atomic_exchange(&aclk_time_heatmap.array[i].count, &new_value, &old_value, __ATOMIC_RELAXED);
         rrddim_set_by_pointer(st, rds[i], (collected_number)old_value);

--- a/src/daemon/status-file-dedup.c
+++ b/src/daemon/status-file-dedup.c
@@ -84,7 +84,7 @@ uint64_t daemon_status_file_hash(DAEMON_STATUS_FILE *ds, const char *msg, const 
 
     safecpy(to_hash.version, ds->version);
     safecpy(to_hash.filename, ds->fatal.filename);
-    safecpy(to_hash.filename, ds->fatal.function);
+    safecpy(to_hash.function, ds->fatal.function);
     safecpy(to_hash.stack_trace, ds->fatal.stack_trace);
     safecpy(to_hash.thread, ds->fatal.thread);
 

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -1038,7 +1038,7 @@ struct pgc_page *pg_cache_lookup_next(
 
     if(gaps && !pdc->executed_with_gaps)
         __atomic_add_fetch(&rrdeng_cache_efficiency_stats.queries_executed_with_gaps, 1, __ATOMIC_RELAXED);
-    pdc->executed_with_gaps = +gaps;
+    pdc->executed_with_gaps += gaps;
 
     if(page) {
         if(waited)

--- a/src/database/rrdhost-system-info.c
+++ b/src/database/rrdhost-system-info.c
@@ -557,7 +557,7 @@ int rrdhost_system_info_foreach(struct rrdhost_system_info *system_info, add_hos
     ret += cb("NETDATA_CONTAINER_OS_ID_LIKE", system_info->container_os_id_like, uuid);
     ret += cb("NETDATA_CONTAINER_OS_VERSION", system_info->container_os_version, uuid);
     ret += cb("NETDATA_CONTAINER_OS_VERSION_ID", system_info->container_os_version_id, uuid);
-    ret += cb("NETDATA_CONTAINER_OS_DETECTION", system_info->host_os_detection, uuid);
+    ret += cb("NETDATA_CONTAINER_OS_DETECTION", system_info->container_os_detection, uuid);
     ret += cb("NETDATA_HOST_OS_NAME", system_info->host_os_name, uuid);
     ret += cb("NETDATA_HOST_OS_ID", system_info->host_os_id, uuid);
     ret += cb("NETDATA_HOST_OS_ID_LIKE", system_info->host_os_id_like, uuid);

--- a/src/exporting/prometheus/remote_write/remote_write.c
+++ b/src/exporting/prometheus/remote_write/remote_write.c
@@ -61,9 +61,10 @@ int process_prometheus_remote_write_response(BUFFER *buffer, struct instance *in
     s++;
     len--;
 
-    if (likely(len > 4 && (!strncmp(s, "200 ", 4) || !strncmp(s, "204 ", 4))))
+    if (likely(len > 4 && (!strncmp(s, "200 ", 4) || !strncmp(s, "204 ", 4)))) {
+        buffer_flush(buffer);
         return 0;
-    else
+    } else
         return exporting_discard_response(buffer, instance);
 }
 

--- a/src/exporting/send_data.c
+++ b/src/exporting/send_data.c
@@ -78,6 +78,8 @@ void simple_connector_receive_response(int *sock, struct instance *instance)
     // loop through to collect all data
     while (*sock != -1 && errno != EWOULDBLOCK) {
         ssize_t r;
+        buffer_need_bytes(response, 1);
+
         if (SSL_connection(&connector_specific_data->ssl))
             r = netdata_ssl_read(&connector_specific_data->ssl, &response->buffer[response->len],
                                  (int) (response->size - response->len));

--- a/src/libnetdata/c_rhash/c_rhash.c
+++ b/src/libnetdata/c_rhash/c_rhash.c
@@ -123,6 +123,7 @@ int c_rhash_get_uint8_by_str(c_rhash hash, const char *key, uint8_t *ret_val) {
         }
         bin = bin->next;
     }
+    *ret_val = 0;
     return 1;
 }
 

--- a/src/libnetdata/c_rhash/tests.c
+++ b/src/libnetdata/c_rhash/tests.c
@@ -52,7 +52,9 @@ int test_str_uint8() {
 
     TEST_START();
     // function should fail on empty hash
+    val = 123;
     ASSERT_RETVAL(c_rhash_get_uint8_by_str, !=, 0, hash, KEY_1, &val);
+    ASSERT_VAL_UINT8(0, val);
 
     ASSERT_RETVAL(c_rhash_insert_str_uint8, ==, 0, hash, KEY_1, 5);
     ASSERT_RETVAL(c_rhash_get_uint8_by_str, ==, 0, hash, KEY_1, &val);
@@ -63,7 +65,9 @@ int test_str_uint8() {
     ASSERT_VAL_UINT8(5, val);
     ASSERT_RETVAL(c_rhash_get_uint8_by_str, ==, 0, hash, KEY_2, &val);
     ASSERT_VAL_UINT8(8, val);
+    val = 123;
     ASSERT_RETVAL(c_rhash_get_uint8_by_str, !=, 0, hash, "sndnskjdf", &val);
+    ASSERT_VAL_UINT8(0, val);
 
     // test update of key
     ASSERT_RETVAL(c_rhash_insert_str_uint8, ==, 0, hash, KEY_1, 100);

--- a/src/libnetdata/os/hostname.c
+++ b/src/libnetdata/os/hostname.c
@@ -132,7 +132,7 @@ bool os_hostname(char *dst, size_t dst_size, const char *filesystem_root) {
 
     if (filesystem_root && *filesystem_root) {
         char filename[FILENAME_MAX + 1];
-        snprintfz(filename, FILENAME_MAX, "%s/etc/hostname", netdata_configured_host_prefix);
+        snprintfz(filename, FILENAME_MAX, "%s/etc/hostname", filesystem_root);
 
         if (read_txt_file(filename, buf, sizeof(buf)))
             *buf = '\0';

--- a/src/libnetdata/socket/connect-to.c
+++ b/src/libnetdata/socket/connect-to.c
@@ -424,7 +424,7 @@ static bool connect_to_one_of_callback(char *entry, void *data) {
     struct connect_to_one_of_data *t = data;
 
     if(t->reconnects_counter)
-        t->reconnects_counter++;
+        (*t->reconnects_counter)++;
 
     t->sock = connect_to_this(entry, t->default_port, t->timeout);
     if(t->sock != -1) {

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -715,11 +715,11 @@ static void spawn_server_receive_request(int sock, SPAWN_SERVER *server) {
     iov[0].iov_len = env_size;
     iov[1].iov_base = argv_encoded = mallocz(argv_size);
     iov[1].iov_len = argv_size;
-    iov[2].iov_base = data = mallocz(data_size);
+    iov[2].iov_base = data = data_size ? mallocz(data_size) : NULL;
     iov[2].iov_len = data_size;
 
     msg.msg_iov = iov;
-    msg.msg_iovlen = 3;
+    msg.msg_iovlen = data_size ? 3 : 2;
     msg.msg_control = NULL;
     msg.msg_controllen = 0;
 

--- a/src/libnetdata/statistical/statistical.c
+++ b/src/libnetdata/statistical/statistical.c
@@ -342,8 +342,8 @@ NETDATA_DOUBLE double_exponential_smoothing(const NETDATA_DOUBLE *series, size_t
     else
         trend = 0;
 
-    const NETDATA_DOUBLE *value = series;
-    for(value++ ; value >= series; value--) {
+    const NETDATA_DOUBLE *value = series, *end = &series[entries];
+    for(value++ ; value < end; value++) {
         if(likely(netdata_double_isnumber(*value))) {
             NETDATA_DOUBLE last_level = level;
             level = alpha * *value + (1.0 - alpha) * (level + trend);

--- a/src/registry/registry_person.c
+++ b/src/registry/registry_person.c
@@ -208,6 +208,7 @@ REGISTRY_PERSON_URL *registry_person_link_to_url(REGISTRY_PERSON *p, REGISTRY_MA
 
             pu->machine->links--;
             pu->machine = m;
+            m->links++;
         }
 
         if(strcmp(string2str(pu->machine_name), machine_name) != 0) {

--- a/src/web/api/formatters/jsonwrap-summary-contexts.c
+++ b/src/web/api/formatters/jsonwrap-summary-contexts.c
@@ -29,9 +29,7 @@ size_t query_target_summary_contexts_v2(BUFFER *wb, QUERY_TARGET *qt, const char
         z->metrics.queried += qc->metrics.queried;
         z->metrics.failed += qc->metrics.failed;
 
-        z->alerts.clear += qc->alerts.clear;
-        z->alerts.warning += qc->alerts.warning;
-        z->alerts.critical += qc->alerts.critical;
+        aggregate_alerts_counts(&z->alerts, &qc->alerts);
 
         storage_point_merge_to(z->query_points, qc->query_points);
     }

--- a/src/web/api/formatters/jsonwrap-summary-contexts.c
+++ b/src/web/api/formatters/jsonwrap-summary-contexts.c
@@ -20,7 +20,7 @@ size_t query_target_summary_contexts_v2(BUFFER *wb, QUERY_TARGET *qt, const char
         z = dictionary_set(dict, rrdcontext_acquired_id(qc->rca), NULL, sizeof(*z));
 
         z->instances.selected += qc->instances.selected;
-        z->instances.excluded += qc->instances.selected;
+        z->instances.excluded += qc->instances.excluded;
         z->instances.queried += qc->instances.queried;
         z->instances.failed += qc->instances.failed;
 

--- a/src/web/websocket/websocket.c
+++ b/src/web/websocket/websocket.c
@@ -185,9 +185,9 @@ bool websocket_client_register(WS_CLIENT *wsc) {
     spinlock_lock(&ws_server.spinlock);
     
     int added = WS_CLIENTS_SET(&ws_server.clients, wsc->id, wsc);
-    if (!added) {
+    if (added) {
         ws_server.active_clients++;
-        websocket_debug(wsc, "WebSocket client registered, total clients: %u", ws_server.active_clients);
+        websocket_debug(wsc, "WebSocket client registered, total clients: %zu", ws_server.active_clients);
     }
     
     spinlock_unlock(&ws_server.spinlock);


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes across Netdata to correct YAML output, metrics accounting, exporting buffers, and system metadata. Improves correctness and stability without changing external APIs.

- **Bug Fixes**
  - Correct YAML single-quote escaping in `log2journal --show-config`; added a focused regression test.
  - Metrics heatmaps and stats: export the final +inf buckets in pulse/dbengine; iterate full arrays; make the gap-query latch cumulative; initialize dbengine retention charts per tier.
  - API summaries: use instances.excluded (not selected) and aggregate alerts via the helper to include all buckets.
  - Build info and metadata: use host_os_version_id for BIB_OS_VERSION_ID; use container_os_detection for NETDATA_CONTAINER_OS_DETECTION.
  - Exporting: flush success on Prometheus remote_write; ensure read buffer growth to avoid zero-length reads and spurious socket closes.
  - Connections: increment reconnect attempts by dereferencing the counter; fix WebSocket active client count and log format.
  - Reliability: include fatal function in crash dedup hash; avoid malloc(0) for empty spawn-server payloads.
  - Misc: c_rhash uint8 miss now zeros the output (with tests); fix double exponential smoothing to walk forward; honor filesystem_root in os_hostname().

<sup>Written for commit 89b6c57e2f13b9fe52c4be8617ee8c56456c15b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

