### PR TITLE
Netdata fixes part 40

### DIFF
--- a/src/daemon/dyncfg/dyncfg-files.c
+++ b/src/daemon/dyncfg/dyncfg-files.c
@@ -271,15 +271,37 @@ static bool dyncfg_read_file_to_buffer(const char *filename, BUFFER *dst) {
         return false;
     }
 
-    buffer_flush(dst);
-    buffer_need_bytes(dst, st.st_size + 1); // +1 for the terminating zero
-
-    ssize_t r = read(fd, (char*)dst->buffer, st.st_size);
-    if(unlikely(r == -1)) {
+    if(unlikely(st.st_size < 0 || (uintmax_t)st.st_size > UINT32_MAX - 2)) {
         close(fd);
         return false;
     }
-    dst->len = r;
+
+    size_t file_size = (size_t)st.st_size;
+
+    buffer_flush(dst);
+    buffer_need_bytes(dst, file_size + 1); // +1 for the terminating zero
+
+    size_t bytes_read = 0;
+    while(bytes_read < file_size) {
+        size_t bytes_to_read = file_size - bytes_read;
+        if(bytes_to_read > (size_t)SSIZE_MAX)
+            bytes_to_read = (size_t)SSIZE_MAX;
+
+        ssize_t r = read(fd, &dst->buffer[bytes_read], bytes_to_read);
+        if(likely(r > 0)) {
+            bytes_read += (size_t)r;
+            continue;
+        }
+
+        if(unlikely(r == -1 && errno == EINTR))
+            continue;
+
+        buffer_flush(dst);
+        close(fd);
+        return false;
+    }
+
+    dst->len = bytes_read;
     dst->buffer[dst->len] = '\0';
 
     close(fd);

--- a/src/daemon/status-file-dmi.c
+++ b/src/daemon/status-file-dmi.c
@@ -1011,7 +1011,7 @@ static void parse_smbios_structures(const smbios_data_t smbios, DMI_INFO *dmi) {
             
             if (found_terminator) {
                 // Advance to next structure
-                current = (const BYTE *)(str_end + 1);
+                current = (const BYTE *)(str_end + 2);
                 continue;
             } else {
                 break; // Corrupt data
@@ -1052,7 +1052,7 @@ static void parse_smbios_structures(const smbios_data_t smbios, DMI_INFO *dmi) {
         }
         
         // Move to the next structure
-        current = (const BYTE *)(str_end + 1);
+        current = (const BYTE *)(str_end + 2);
         
         // Check for end marker or out of bounds
         if (current >= end || *current == 127)

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -1525,7 +1525,7 @@ bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE c
     // This can cause a deadlock when a signal is received while the lock is held.
     // The code is commented out to prevent the deadlock, at the cost of not saving the status file on a crash.
 #else
-    bool safe_to_get_stack_trace = reason != EXIT_REASON_SIGABRT || stacktrace_capture_is_async_signal_safe();
+    bool safe_to_get_stack_trace = reason != EXIT_REASON_SIGABRT && stacktrace_capture_is_async_signal_safe();
     bool get_stack_trace = stacktrace_available() && safe_to_get_stack_trace && stack_trace_is_empty(&session_status);
 
     // save it
@@ -1534,6 +1534,8 @@ bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE c
     else {
         if (!stacktrace_available())
             set_stack_trace_message_if_empty(&session_status, STACK_TRACE_INFO_PREFIX "no stack trace backend available");
+        else if(reason == EXIT_REASON_SIGABRT)
+            set_stack_trace_message_if_empty(&session_status, STACK_TRACE_INFO_PREFIX "fatal handler already captured the stack trace");
         else
             set_stack_trace_message_if_empty(&session_status, STACK_TRACE_INFO_PREFIX "not safe to get a stack trace for this signal using this backend");
 

--- a/src/daemon/winsvc.cc
+++ b/src/daemon/winsvc.cc
@@ -120,6 +120,10 @@ static void call_netdata_cleanup(void *arg)
     // Set status to stopped
     netdata_service_log("Reporting the service as stopped...");
     ReportSvcStatus(SERVICE_STOPPED, 0, 0, 0);
+
+    // SERVICE_STOPPED closes the SCM context; terminate instead of returning to
+    // stale service code.
+    exit(0);
 }
 
 static void WINAPI ServiceControlHandler(DWORD controlCode)

--- a/src/database/contexts/rrdcontext-queues.c
+++ b/src/database/contexts/rrdcontext-queues.c
@@ -23,7 +23,7 @@ static inline RRDCONTEXT_QUEUE_STATUS rrdcontext_queue_add(RRDCONTEXT_QUEUE_Judy
         ret = RRDCONTEXT_QUEUE_FOUND;
     }
     else {
-        *idx = queue->id++;
+        *idx = ++queue->id;
         RRDCONTEXT_QUEUE_SET(queue, *idx, rc);
         __atomic_add_fetch(&queue->version, 1, __ATOMIC_RELAXED);
         __atomic_add_fetch(&queue->entries, 1, __ATOMIC_RELAXED);

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -531,9 +531,17 @@ done:
 
 void sql_check_removed_alerts_state(RRDHOST *host)
 {
-    uint32_t max_unique_id = 0;
     sqlite3_stmt *res = NULL;
     nd_uuid_t transition_id;
+
+    struct removed_alert_candidate {
+        uint32_t unique_id;
+        uint32_t alarm_id;
+        uint32_t alarm_event_id;
+        nd_uuid_t transition_id;
+    } *candidates = NULL;
+    size_t candidates_used = 0;
+    size_t candidates_size = 0;
 
     if (!PREPARE_STATEMENT(db_meta, SQL_SELECT_LAST_STATUSES, &res))
         return;
@@ -559,10 +567,29 @@ void sql_check_removed_alerts_state(RRDHOST *host)
         uuid_copy(transition_id, *transition_uuid);
 
         if (unlikely(status != RRDCALC_STATUS_REMOVED)) {
-           if (unlikely(!max_unique_id))
-               max_unique_id = sql_get_max_unique_id(host);
+            if (unlikely(candidates_used == candidates_size)) {
+                if (unlikely(candidates_size > SIZE_MAX / 2)) {
+                    error_report("HEALTH [%s]: Too many removed alert candidates. Stopping removed alert check.",
+                                 rrdhost_hostname(host));
+                    break;
+                }
 
-           sql_inject_removed_status(host, alarm_id, alarm_event_id, unique_id, ++max_unique_id, &transition_id);
+                size_t new_size = candidates_size ? candidates_size * 2 : 16;
+                if (unlikely(new_size > SIZE_MAX / sizeof(*candidates))) {
+                    error_report("HEALTH [%s]: Too many removed alert candidates. Stopping removed alert check.",
+                                 rrdhost_hostname(host));
+                    break;
+                }
+
+                candidates = reallocz(candidates, new_size * sizeof(*candidates));
+                candidates_size = new_size;
+            }
+
+            candidates[candidates_used].unique_id = unique_id;
+            candidates[candidates_used].alarm_id = alarm_id;
+            candidates[candidates_used].alarm_event_id = alarm_event_id;
+            uuid_copy(candidates[candidates_used].transition_id, transition_id);
+            candidates_used++;
         }
         if (!service_running(SERVICE_HEALTH))
             break;
@@ -570,6 +597,21 @@ void sql_check_removed_alerts_state(RRDHOST *host)
 done:
     REPORT_BIND_FAIL(res, param);
     SQLITE_FINALIZE(res);
+
+    if (candidates_used) {
+        uint32_t max_unique_id = sql_get_max_unique_id(host);
+        for (size_t i = 0; i < candidates_used; i++) {
+            sql_inject_removed_status(
+                host,
+                candidates[i].alarm_id,
+                candidates[i].alarm_event_id,
+                candidates[i].unique_id,
+                ++max_unique_id,
+                &candidates[i].transition_id);
+        }
+    }
+
+    freez(candidates);
 }
 
 #define SQL_DELETE_MISSING_CHART_ALERT                                                                                 \

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -1080,7 +1080,7 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, time_t after, const ch
      buffer_json_initialize(wb, "\"", "\"", 0, false, BUFFER_JSON_OPTIONS_DEFAULT);
      buffer_json_member_add_array(wb, NULL);
 
-     while (sqlite3_step(stmt_query) == SQLITE_ROW) {
+     while (sqlite3_step_monitored(stmt_query) == SQLITE_ROW) {
          char old_value_string[100 + 1];
          char new_value_string[100 + 1];
 
@@ -1540,7 +1540,7 @@ run_query:;
     size_t invalid_transition_ids = 0;
 
     param = 0;
-    while (sqlite3_step(res) == SQLITE_ROW) {
+    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         if (unlikely(!sqlite3_column_uuid_copy(res, 0, host_id))) {
             invalid_host_ids++;
             continue;
@@ -1684,7 +1684,7 @@ int sql_get_alert_configuration(
 
     added = 0;
     int param;
-    while (sqlite3_step(res) == SQLITE_ROW) {
+    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         param = 0;
         if (unlikely(!sqlite3_column_uuid_copy(res, param++, config_hash_id))) {
             invalid_config_hash_ids++;

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2097,7 +2097,7 @@ size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, 
     size_t count = 0;
 
     usec_t started_ut = now_monotonic_usec();
-    while (sqlite3_step(res) == SQLITE_ROW) {
+    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         nd_uuid_t uuid;
         if (!sqlite3_column_uuid_copy(res, 0, uuid))
             continue;

--- a/src/exporting/aws_kinesis/aws_kinesis.c
+++ b/src/exporting/aws_kinesis/aws_kinesis.c
@@ -137,18 +137,23 @@ void aws_kinesis_connector_worker(void *instance_p)
             char partition_key[KINESIS_PARTITION_KEY_MAX + 1];
             snprintf(partition_key, KINESIS_PARTITION_KEY_MAX, "netdata_%llu", partition_key_seq++);
             size_t partition_key_len = strnlen(partition_key, KINESIS_PARTITION_KEY_MAX);
+            size_t max_record_len = KINESIS_RECORD_MAX - partition_key_len;
 
             const char *first_char = buffer_tostring(buffer) + sent;
 
             size_t record_len = 0;
 
             // split buffer into chunks of maximum allowed size
-            if (buffer_len - sent < KINESIS_RECORD_MAX - partition_key_len) {
+            if (buffer_len - sent < max_record_len) {
                 record_len = buffer_len - sent;
             } else {
-                record_len = KINESIS_RECORD_MAX - partition_key_len;
+                record_len = max_record_len;
                 while (record_len && *(first_char + record_len - 1) != '\n')
                     record_len--;
+
+                // Oversized single records cannot stay newline-bounded; split at the payload limit.
+                if (unlikely(!record_len))
+                    record_len = max_record_len;
             }
             char error_message[ERROR_LINE_MAX + 1] = "";
 

--- a/src/libnetdata/buffered_reader/buffered_reader.h
+++ b/src/libnetdata/buffered_reader/buffered_reader.h
@@ -42,7 +42,11 @@ static inline buffered_reader_ret_t buffered_reader_read(struct buffered_reader 
     if(unlikely(remaining <= 0))
         return BUFFERED_READER_READ_BUFFER_FULL;
 
-    ssize_t bytes_read = read(fd, read_at, remaining);
+    ssize_t bytes_read;
+    do {
+        bytes_read = read(fd, read_at, remaining);
+    } while(unlikely(bytes_read < 0 && errno == EINTR));
+
     if(unlikely(bytes_read <= 0))
         return BUFFERED_READER_READ_FAILED;
 

--- a/src/libnetdata/inicfg/inicfg_conf_file.c
+++ b/src/libnetdata/inicfg/inicfg_conf_file.c
@@ -238,8 +238,7 @@ int inicfg_load(struct config *root, char *filename, int overwrite_used, const c
             if(sect && section_string && overwrite_used && section_string == sect->name) {
                 SECTION_LOCK(sect);
 
-                while(sect->values)
-                    inicfg_option_remove_and_delete(sect, sect->values, true);
+                inicfg_option_remove_and_delete_all(sect, true);
 
                 SECTION_UNLOCK(sect);
             }

--- a/src/libnetdata/inicfg/inicfg_options.c
+++ b/src/libnetdata/inicfg/inicfg_options.c
@@ -93,8 +93,12 @@ void inicfg_option_remove_and_delete_all(struct config_section *sect, bool have_
     if(!have_sect_lock)
         SECTION_LOCK(sect);
 
-    while(sect->values)
-        inicfg_option_remove_and_delete(sect, sect->values, true);
+    struct config_option *opt = sect->values;
+    while(opt) {
+        struct config_option *next = opt->next;
+        inicfg_option_remove_and_delete(sect, opt, true);
+        opt = next;
+    }
 
     if(!have_sect_lock)
         SECTION_UNLOCK(sect);

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -624,12 +624,23 @@ static bool read_txt_file_to_buffer(const char *filename, BUFFER *wb, size_t max
     buffer_need_bytes(wb, file_size + 1);
 
     // Read the file contents into the buffer
-    ssize_t r = read(fd, &wb->buffer[wb->len], file_size);
-    if (r != (ssize_t)file_size) {
+    size_t original_len = wb->len;
+    size_t bytes_read = 0;
+    while(bytes_read < file_size) {
+        ssize_t r = read(fd, &wb->buffer[original_len + bytes_read], file_size - bytes_read);
+        if (r > 0) {
+            bytes_read += (size_t)r;
+            continue;
+        }
+
+        if (r == -1 && errno == EINTR)
+            continue;
+
         close(fd);
-        return false; // Read error
+        return false; // Read error or unexpected end of file
     }
-    wb->len = r;
+    wb->len = original_len + bytes_read;
+    wb->buffer[wb->len] = '\0';
 
     // Close the file descriptor
     close(fd);

--- a/src/libnetdata/json/json.c
+++ b/src/libnetdata/json/json.c
@@ -288,6 +288,26 @@ size_t json_walk_primitive(char *js, jsmntok_t *t, size_t start, JSON_ENTRY *e)
     return 1;
 }
 
+static size_t json_walk_token_span(jsmntok_t *t, size_t start)
+{
+    size_t span = 1;
+
+    switch(t[start].type) {
+        case JSMN_OBJECT:
+        case JSMN_ARRAY:
+            for(int i = 0; i < t[start].size; i++)
+                span += json_walk_token_span(t, start + span);
+            break;
+
+        case JSMN_PRIMITIVE:
+        case JSMN_STRING:
+        default:
+            break;
+    }
+
+    return span;
+}
+
 /**
  * Array
  *
@@ -325,6 +345,7 @@ size_t json_walk_array(char *js, jsmntok_t *t, size_t nest, size_t start, JSON_E
         ne.pos = i;
         if (strlen(e->name) > JSON_NAME_LEN  - 24 || strlen(e->fullname) > JSON_FULLNAME_LEN -24) {
             netdata_log_info("JSON: JSON walk_array ignoring element with name:%s fullname:%s",e->name, e->fullname);
+            start += json_walk_token_span(t, start);
             continue;
         }
         snprintfz(ne.name, JSON_NAME_LEN, "%s[%lu]", e->name, i);

--- a/src/libnetdata/json/json.c
+++ b/src/libnetdata/json/json.c
@@ -454,7 +454,7 @@ size_t json_walk(json_object *t, void *callback_data, int (*callback_function)(s
         type = json_object_get_type(val);
         if (type == json_type_array) {
             e.type = JSON_ARRAY;
-            json_jsonc_parse_array(val,NULL,callback_function);
+            json_jsonc_parse_array(val,callback_data,callback_function);
         } else if (type == json_type_object) {
             e.type = JSON_OBJECT;
         } else if (type == json_type_string) {

--- a/src/libnetdata/sanitizers/utf8-sanitizer-unittest.c
+++ b/src/libnetdata/sanitizers/utf8-sanitizer-unittest.c
@@ -1505,6 +1505,20 @@ static void test_regression_fixed_bugs(void) {
         run_sanitize_test(&t);
     }
 
+    // REGRESSION: In-place hex expansion must not overwrite unread source bytes.
+    {
+        const unsigned char input[] = "\xC2" "AB";
+        unsigned char separate[sizeof(input)];
+        unsigned char in_place[] = "\xC2" "AB";
+
+        size_t separate_len = text_sanitize(separate, input, sizeof(separate), identity_char_map, true, "", NULL);
+        size_t in_place_len = text_sanitize(in_place, in_place, sizeof(in_place), identity_char_map, true, "", NULL);
+
+        TEST_ASSERT("regression_in_place_hex_alias",
+            in_place_len == separate_len && strcmp((char *)in_place, (char *)separate) == 0,
+            "In-place result '%s' does not match separate result '%s'", in_place, separate);
+    }
+
     // Test truncated sequence that would overflow if not properly bounded
     {
         sanitize_test_t t = {

--- a/src/libnetdata/sanitizers/utf8-sanitizer.c
+++ b/src/libnetdata/sanitizers/utf8-sanitizer.c
@@ -6,6 +6,17 @@ size_t text_sanitize(unsigned char *dst, const unsigned char *src, size_t dst_si
     if(unlikely(!dst || !dst_size)) return 0;
     if(unlikely(!empty)) empty = "";
 
+    char *src_to_free = NULL;
+    if(unlikely(utf && src == dst)) {
+        for(const unsigned char *s = src; *s ;s++) {
+            if(IS_UTF8_STARTBYTE(*s)) {
+                src_to_free = strdupz((const char *)src);
+                src = (const unsigned char *)src_to_free;
+                break;
+            }
+        }
+    }
+
     // skip leading spaces and invalid characters
     while(src && *src && !IS_UTF8_BYTE(*src) && (isspace(*src) || iscntrl(*src) || !isprint(*src)))
         src++;
@@ -138,10 +149,13 @@ size_t text_sanitize(unsigned char *dst, const unsigned char *src, size_t dst_si
         dst[dst_size - 1] = '\0';
         mblen = strlen((char *)dst);
         if(multibyte_length) *multibyte_length = mblen;
+        freez(src_to_free);
         return mblen;
     }
 
     if(multibyte_length) *multibyte_length = mblen;
 
-    return d - dst;
+    size_t len = d - dst;
+    freez(src_to_free);
+    return len;
 }

--- a/src/libnetdata/simple_pattern/simple_pattern.c
+++ b/src/libnetdata/simple_pattern/simple_pattern.c
@@ -388,8 +388,8 @@ static void scan_is_potential_name(struct simple_pattern *p, int *alpha, int *co
             }
             if (p->mode != SIMPLE_PATTERN_EXACT)
                 *wildcards = 1;
-            p = p->child;
         }
+        p = p->child;
     }
 }
 

--- a/src/libnetdata/socket/poll-events.c
+++ b/src/libnetdata/socket/poll-events.c
@@ -140,7 +140,9 @@ int poll_default_rcv_callback(POLLINFO *pi, nd_poll_event_t *events) {
 
                 return -1;
             }
-        } else if (rc) {
+        } else if (!rc) {
+            return -1;
+        } else {
             // data received
             nd_log(NDLS_DAEMON, NDLP_WARNING,
                    "POLLFD: internal error: poll_default_rcv_callback() is discarding %zd bytes received on socket %d",

--- a/src/libnetdata/spawn_server/log-forwarder.c
+++ b/src/libnetdata/spawn_server/log-forwarder.c
@@ -359,8 +359,16 @@ static void log_forwarder_thread_func(void *arg) {
 
             // read or mark them for deletion
             for(LOG_FORWARDER_ENTRY *entry = lf->entries; entry ; entry = entry->next) {
-                if (entry->pfds_idx < 1 || entry->pfds_idx >= nfds || !(pfds[entry->pfds_idx].revents & POLLIN) || entry->delete || !entry->wb)
+                if (entry->pfds_idx < 1 || entry->pfds_idx >= nfds || entry->delete || !entry->wb)
                     continue;
+
+                short revents = pfds[entry->pfds_idx].revents;
+                if (!(revents & POLLIN)) {
+                    if (revents & (POLLERR | POLLHUP | POLLNVAL))
+                        entry->delete = true;
+
+                    continue;
+                }
 
                 BUFFER *wb = entry->wb;
                 buffer_need_bytes(wb, 1024);

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -853,6 +853,32 @@ static void spawn_server_process_sigchld(void) {
     }
 }
 
+static void spawn_server_signal_all_children(int signo) {
+    for(SPAWN_REQUEST *rq = spawn_server_requests; rq ; rq = rq->next) {
+        if(kill(rq->pid, signo) != 0)
+            nd_log(NDLS_COLLECTORS, signo == SIGKILL ? NDLP_ERR : NDLP_WARNING,
+                   "SPAWN SERVER: failed to send signal %d to child pid %d (request %zu): %s",
+                   signo, rq->pid, rq->request_id, strerror(errno));
+    }
+}
+
+static bool spawn_server_wait_for_children_to_exit(usec_t timeout_ut) {
+    usec_t deadline_ut = now_monotonic_usec() + timeout_ut;
+
+    while(spawn_server_requests) {
+        spawn_server_process_sigchld();
+        if(!spawn_server_requests)
+            return true;
+
+        if(now_monotonic_usec() >= deadline_ut)
+            return false;
+
+        sleep_usec(10 * USEC_PER_MS);
+    }
+
+    return true;
+}
+
 static int spawn_server_event_loop(SPAWN_SERVER *server) {
     int pipe_fd = server->pipe[1];
     close(server->pipe[0]); server->pipe[0] = -1;
@@ -935,17 +961,18 @@ static int spawn_server_event_loop(SPAWN_SERVER *server) {
 
     // stop all children
     if(spawn_server_requests) {
-        // nd_log(NDLS_COLLECTORS, NDLP_INFO, "SPAWN SERVER: killing all children...");
-        size_t killed = 0;
-        for(SPAWN_REQUEST *rq = spawn_server_requests; rq ; rq = rq->next) {
-            kill(rq->pid, SIGTERM);
-            killed++;
+        spawn_server_signal_all_children(SIGTERM);
+
+        if(!spawn_server_wait_for_children_to_exit((usec_t)SPAWN_KILL_DEFAULT_GRACE_MS * USEC_PER_MS)) {
+            nd_log(NDLS_COLLECTORS, NDLP_WARNING,
+                   "SPAWN SERVER: children did not exit after SIGTERM; sending SIGKILL");
+
+            spawn_server_signal_all_children(SIGKILL);
+
+            if(!spawn_server_wait_for_children_to_exit((usec_t)SPAWN_KILL_DEFAULT_GRACE_MS * USEC_PER_MS))
+                nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                       "SPAWN SERVER: giving up waiting for children after SIGKILL");
         }
-        while(spawn_server_requests) {
-            spawn_server_process_sigchld();
-            tinysleep();
-        }
-        // nd_log(NDLS_COLLECTORS, NDLP_INFO, "SPAWN SERVER: all %zu children finished", killed);
     }
 
     return 0;

--- a/src/libnetdata/stacktrace/stacktrace-common.c
+++ b/src/libnetdata/stacktrace/stacktrace-common.c
@@ -76,6 +76,87 @@ struct stacktrace *stacktrace_create(int num_frames) {
     return trace;
 }
 
+static bool stacktrace_frames_equal(const struct stacktrace *trace, const void *frames, int num_frames) {
+    return trace && trace->frame_count == num_frames &&
+           memcmp(trace->frames, frames, (size_t)num_frames * sizeof(void *)) == 0;
+}
+
+// The global cache caller holds stacktrace_lock; unit tests use a private cache.
+static struct stacktrace *stacktrace_cache_get_or_create(
+    STACKTRACE_JudyLSet *cache,
+    uint64_t hash,
+    const void *frames,
+    int num_frames)
+{
+    if (unlikely(!cache || !frames || num_frames <= 0))
+        return NULL;
+
+    Word_t key = (Word_t)hash;
+    struct stacktrace *last = NULL;
+
+    for (struct stacktrace *trace = STACKTRACE_GET(cache, key); trace; trace = trace->hash_next) {
+        if (stacktrace_frames_equal(trace, frames, num_frames))
+            return trace;
+
+        last = trace;
+    }
+
+    struct stacktrace *trace = stacktrace_create(num_frames);
+    if (unlikely(!trace))
+        return NULL;
+
+    trace->hash = hash;
+    memcpy(trace->frames, frames, (size_t)num_frames * sizeof(void *));
+
+    if (last)
+        last->hash_next = trace;
+    else if (!STACKTRACE_SET(cache, key, trace)) {
+        freez(trace);
+        return NULL;
+    }
+
+    return trace;
+}
+
+static void stacktrace_free_chain(Word_t index __maybe_unused, struct stacktrace *trace, void *data __maybe_unused) {
+    while (trace) {
+        struct stacktrace *next = trace->hash_next;
+        freez(trace->text);
+        freez(trace);
+        trace = next;
+    }
+}
+
+int stacktrace_cache_unittest(void) {
+    STACKTRACE_JudyLSet cache;
+    STACKTRACE_INIT(&cache);
+
+    int frame_a0, frame_a1, frame_b1;
+    void *frames_a[] = { &frame_a0, &frame_a1 };
+    void *frames_a_again[] = { &frame_a0, &frame_a1 };
+    void *frames_b[] = { &frame_a0, &frame_b1 };
+    uint64_t hash = UINT64_C(0x1122334455667788);
+
+    struct stacktrace *first = stacktrace_cache_get_or_create(&cache, hash, frames_a, _countof(frames_a));
+    struct stacktrace *second = stacktrace_cache_get_or_create(&cache, hash, frames_b, _countof(frames_b));
+    struct stacktrace *first_again = stacktrace_cache_get_or_create(&cache, hash, frames_a_again, _countof(frames_a_again));
+
+    size_t chain_length = 0;
+    for (struct stacktrace *trace = STACKTRACE_GET(&cache, (Word_t)hash); trace; trace = trace->hash_next)
+        chain_length++;
+
+    bool success = first && second &&
+                   first != second &&
+                   first_again == first &&
+                   first->hash == hash &&
+                   second->hash == hash &&
+                   chain_length == 2;
+
+    STACKTRACE_FREE(&cache, stacktrace_free_chain, NULL);
+
+    return success ? 0 : 1;
+}
+
 // Exact match check if a function is in the auxiliary list (strcmp)
 bool stacktrace_is_auxiliary_function(const char *function) {
     if (!function || !*function)
@@ -168,43 +249,8 @@ STACKTRACE stacktrace_get(int skip_frames) {
     // Calculate hash
     uint64_t hash = XXH3_64bits(frames, num_frames * sizeof(void *));
     
-    // Look up in cache first
     spinlock_lock(&stacktrace_lock);
-    
-    struct stacktrace *trace = STACKTRACE_GET(&stacktrace_cache, hash);
-    
-    // If existing trace found, verify it's the same frames
-    // This handles hash collisions
-    if (trace) {
-        if (trace->frame_count != num_frames || 
-            memcmp(trace->frames, frames, num_frames * sizeof(void *)) != 0) {
-            // Hash collision - use linear probing
-            int i = 1;
-            uint64_t new_hash = hash;
-            do {
-                new_hash = hash + i;
-                trace = STACKTRACE_GET(&stacktrace_cache, new_hash);
-                
-                if (!trace || 
-                    (trace->frame_count == num_frames && 
-                     memcmp(trace->frames, frames, num_frames * sizeof(void *)) == 0)) {
-                    break; // Either found a match or empty slot
-                }
-                i++;
-            } while (i < 10);  // Limit search to avoid infinite loops
-            
-            hash = new_hash;
-        }
-    }
-    
-    // If not found or hash collision, create new entry
-    if (!trace) {
-        trace = stacktrace_create(num_frames);
-        trace->hash = hash;
-        memcpy(trace->frames, frames, num_frames * sizeof(void *));
-        STACKTRACE_SET(&stacktrace_cache, hash, trace);
-    }
-    
+    struct stacktrace *trace = stacktrace_cache_get_or_create(&stacktrace_cache, hash, frames, num_frames);
     spinlock_unlock(&stacktrace_lock);
     
     return trace;

--- a/src/libnetdata/stacktrace/stacktrace-common.h
+++ b/src/libnetdata/stacktrace/stacktrace-common.h
@@ -31,6 +31,7 @@
 // The structure for stacktrace storage
 struct stacktrace {
     uint64_t hash;          // Hash of the stack trace
+    struct stacktrace *hash_next; // Next trace with the same JudyL key
     char *text;             // Text representation (cached, lazy-initialized)
     int frame_count;        // Number of frames
     void *frames[1];        // Variable-length array of frame pointers
@@ -60,6 +61,7 @@ bool stacktrace_is_netdata_function(const char *function, const char *filename);
 bool stacktrace_is_signal_handler_function(const char *function);
 bool stacktrace_contains_signal_handler_function(const char *text);
 void stacktrace_keep_first_root_cause_function(const char *function);
+int stacktrace_cache_unittest(void);
 
 // Implementation-specific declarations
 void impl_stacktrace_init(void);

--- a/src/libnetdata/stacktrace/stacktrace-unittest.c
+++ b/src/libnetdata/stacktrace/stacktrace-unittest.c
@@ -2,6 +2,7 @@
 
 #include "libnetdata/libnetdata.h"
 #include "stacktrace.h"
+#include "stacktrace-common.h"
 
 // Structure to hold all test data
 typedef struct {
@@ -92,6 +93,9 @@ static void inline_function_to_capture_stack_trace(stacktrace_test_data_t *test_
 int stacktrace_unittest(void) {
     // Initialize stacktrace subsystem
     stacktrace_init();
+
+    bool cache_collision_test = stacktrace_cache_unittest() == 0;
+    fprintf(stderr, "\nSTACKTRACE CACHE COLLISION TEST: %s\n", cache_collision_test ? "SUCCESS" : "FAILURE");
     
     // Setup test data structure
     stacktrace_test_data_t test_data = {
@@ -133,7 +137,7 @@ int stacktrace_unittest(void) {
     buffer_free(test_data.indirect_root_cause);
     
     // Report overall test status - success if both analyses succeed
-    bool test_success = direct_analysis && indirect_analysis;
+    bool test_success = cache_collision_test && direct_analysis && indirect_analysis;
     fprintf(stderr, "\nSTACKTRACE TEST: Overall result: %s\n",
             test_success ? "SUCCESS" : "FAILURE");
     

--- a/src/registry/registry_db.c
+++ b/src/registry/registry_db.c
@@ -127,9 +127,11 @@ int registry_db_save(void) {
 
     char tmp_filename[FILENAME_MAX + 1];
     char old_filename[FILENAME_MAX + 1];
+    char old_tmp_filename[FILENAME_MAX + 1];
 
     snprintfz(old_filename, FILENAME_MAX, "%s.old", registry.db_filename);
     snprintfz(tmp_filename, FILENAME_MAX, "%s.tmp", registry.db_filename);
+    snprintfz(old_tmp_filename, FILENAME_MAX, "%s.old.tmp", registry.db_filename);
 
     netdata_log_debug(D_REGISTRY, "REGISTRY: Creating file '%s'", tmp_filename);
     FILE *fp = fopen(tmp_filename, "w");
@@ -181,48 +183,67 @@ int registry_db_save(void) {
 
     errno_clear();
 
-    // remove the .old db
-    netdata_log_debug(D_REGISTRY, "REGISTRY: Removing old db '%s'", old_filename);
-    if(unlink(old_filename) == -1 && errno != ENOENT)
-        netdata_log_error("REGISTRY: cannot remove old registry file '%s'", old_filename);
+    netdata_log_debug(D_REGISTRY, "REGISTRY: Removing stale old tmp db '%s'", old_tmp_filename);
+    if(unlink(old_tmp_filename) == -1 && errno != ENOENT) {
+        netdata_log_error("REGISTRY: cannot remove stale temporary old registry file '%s'", old_tmp_filename);
+        unlink(tmp_filename);
+        nd_log_limits_reset();
+        registry.consecutive_save_failures++;
+        registry.last_save_failure = now_realtime_sec();
+        return -1;
+    }
 
-    // rename the db to .old
-    netdata_log_debug(D_REGISTRY, "REGISTRY: Link current db '%s' to .old: '%s'", registry.db_filename, old_filename);
-    if(link(registry.db_filename, old_filename) == -1 && errno != ENOENT)
-        netdata_log_error("REGISTRY: cannot move file '%s' to '%s'. Saving registry DB failed!", registry.db_filename, old_filename);
-
-    else {
-        // remove the database (it is saved in .old)
-        netdata_log_debug(D_REGISTRY, "REGISTRY: removing db '%s'", registry.db_filename);
-        if (unlink(registry.db_filename) == -1 && errno != ENOENT)
-            netdata_log_error("REGISTRY: cannot remove old registry file '%s'", registry.db_filename);
-
-        // move the .tmp to make it active
-        netdata_log_debug(D_REGISTRY, "REGISTRY: linking tmp db '%s' to active db '%s'", tmp_filename, registry.db_filename);
-        if (link(tmp_filename, registry.db_filename) == -1) {
-            netdata_log_error("REGISTRY: cannot move file '%s' to '%s'. Saving registry DB failed!", tmp_filename,
-                    registry.db_filename);
-
-            // move the .old back
-            netdata_log_debug(D_REGISTRY, "REGISTRY: linking old db '%s' to active db '%s'", old_filename, registry.db_filename);
-            if(link(old_filename, registry.db_filename) == -1)
-                netdata_log_error("REGISTRY: cannot move file '%s' to '%s'. Recovering the old registry DB failed!", old_filename, registry.db_filename);
-        }
-        else {
-            netdata_log_debug(D_REGISTRY, "REGISTRY: removing tmp db '%s'", tmp_filename);
-            if(unlink(tmp_filename) == -1)
-                netdata_log_error("REGISTRY: cannot remove tmp registry file '%s'", tmp_filename);
-
-            // it has been moved successfully
-            // discard the current registry log
-            registry_log_recreate();
-            registry.log_count = 0;
-            
-            // Reset failure tracking on success
-            registry.consecutive_save_failures = 0;
-            registry.last_save_failure = 0;
+    // Keep a backup of the current DB, but do not remove the active DB before publishing the new one.
+    netdata_log_debug(D_REGISTRY, "REGISTRY: Link current db '%s' to temporary old db '%s'", registry.db_filename, old_tmp_filename);
+    if(link(registry.db_filename, old_tmp_filename) == -1) {
+        if(errno != ENOENT) {
+            netdata_log_error("REGISTRY: cannot move file '%s' to '%s'. Saving registry DB failed!", registry.db_filename,
+                              old_tmp_filename);
+            unlink(tmp_filename);
+            nd_log_limits_reset();
+            registry.consecutive_save_failures++;
+            registry.last_save_failure = now_realtime_sec();
+            return -1;
         }
     }
+    else {
+        netdata_log_debug(D_REGISTRY, "REGISTRY: renaming temporary old db '%s' to old db '%s'", old_tmp_filename,
+                          old_filename);
+        if(rename(old_tmp_filename, old_filename) == -1) {
+            netdata_log_error("REGISTRY: cannot move file '%s' to '%s'. Saving registry DB failed!", old_tmp_filename,
+                              old_filename);
+            unlink(old_tmp_filename);
+            unlink(tmp_filename);
+            nd_log_limits_reset();
+            registry.consecutive_save_failures++;
+            registry.last_save_failure = now_realtime_sec();
+            return -1;
+        }
+
+        if(unlink(old_tmp_filename) == -1 && errno != ENOENT)
+            netdata_log_error("REGISTRY: cannot remove temporary old registry file '%s'", old_tmp_filename);
+    }
+
+    // Publish the new DB atomically. If rename fails, the active DB remains untouched.
+    netdata_log_debug(D_REGISTRY, "REGISTRY: renaming tmp db '%s' to active db '%s'", tmp_filename, registry.db_filename);
+    if(rename(tmp_filename, registry.db_filename) == -1) {
+        netdata_log_error("REGISTRY: cannot move file '%s' to '%s'. Saving registry DB failed!", tmp_filename,
+                          registry.db_filename);
+        unlink(tmp_filename);
+        nd_log_limits_reset();
+        registry.consecutive_save_failures++;
+        registry.last_save_failure = now_realtime_sec();
+        return -1;
+    }
+
+    // it has been moved successfully
+    // discard the current registry log
+    registry_log_recreate();
+    registry.log_count = 0;
+
+    // Reset failure tracking on success
+    registry.consecutive_save_failures = 0;
+    registry.last_save_failure = 0;
 
     // continue operations
     nd_log_limits_reset();

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -961,7 +961,7 @@ void stream_receiver_check_all_nodes_from_poll(struct stream_thread *sth, usec_t
             stream_receiver_remove(sth, rpt, STREAM_HANDSHAKE_DISCONNECT_SOCKET_CLOSED_BY_REMOTE);
             continue;
         }
-        if (probe_rc < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+        if (probe_rc < 0 && errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
             // Socket error detected (keepalive timeout, etc.)
             // Save errno immediately as subsequent calls may modify it
             int saved_errno = errno;
@@ -985,7 +985,7 @@ void stream_receiver_check_all_nodes_from_poll(struct stream_thread *sth, usec_t
             continue;
         }
         // probe_rc > 0: data available (normal)
-        // probe_rc < 0 with EAGAIN/EWOULDBLOCK: no data but connection alive
+        // probe_rc < 0 with EAGAIN/EWOULDBLOCK/EINTR: no data but connection alive
 
         spinlock_lock(&rpt->thread.send_to_child.spinlock);
         STREAM_CIRCULAR_BUFFER_STATS stats = *stream_circular_buffer_stats_unsafe(rpt->thread.send_to_child.scb);

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -495,19 +495,59 @@ static int web_server_static_file(struct web_client *w, char *filename) {
     if(is_dir && !web_client_flag_check(w, WEB_CLIENT_FLAG_PATH_HAS_TRAILING_SLASH))
         return append_slash_to_url_and_redirect(w);
 
-    buffer_flush(w->response.data);
-    buffer_need_bytes(w->response.data, (size_t)statbuf.st_size);
-    w->response.data->len = (size_t)statbuf.st_size;
-
     // open the file
     int fd = open(web_filename, O_RDONLY | O_CLOEXEC);
 
-    // read the file
-    if(fd != -1 && read(fd, w->response.data->buffer, statbuf.st_size) != statbuf.st_size) {
-        // cannot read the whole file
-        nd_log(NDLS_DAEMON, NDLP_ERR, "Web server failed to read file '%s'", web_filename);
+    if(fd != -1 && fstat(fd, &statbuf) != 0) {
+        int saved_errno = errno;
         close(fd);
+        errno = saved_errno;
         fd = -1;
+    }
+
+    if(fd != -1 && unlikely(statbuf.st_size < 0 || (uintmax_t)statbuf.st_size > UINT32_MAX - 2)) {
+        close(fd);
+        errno = EFBIG;
+        fd = -1;
+    }
+
+    if(fd != -1) {
+        size_t file_size = (size_t)statbuf.st_size;
+
+        buffer_flush(w->response.data);
+        buffer_need_bytes(w->response.data, file_size + 1);
+
+        size_t bytes_read = 0;
+        while(bytes_read < file_size) {
+            size_t bytes_to_read = file_size - bytes_read;
+            if(bytes_to_read > (size_t)SSIZE_MAX)
+                bytes_to_read = (size_t)SSIZE_MAX;
+
+            ssize_t r = read(fd, &w->response.data->buffer[bytes_read], bytes_to_read);
+            if(likely(r > 0)) {
+                bytes_read += (size_t)r;
+                continue;
+            }
+
+            if(unlikely(r == -1 && errno == EINTR))
+                continue;
+
+            if(r == 0)
+                errno = EIO;
+
+            // cannot read the whole file
+            nd_log(NDLS_DAEMON, NDLP_ERR, "Web server failed to read file '%s'", web_filename);
+            int saved_errno = errno;
+            close(fd);
+            errno = saved_errno;
+            fd = -1;
+            break;
+        }
+
+        if(fd != -1) {
+            w->response.data->len = bytes_read;
+            w->response.data->buffer[w->response.data->len] = '\0';
+        }
     }
 
     // check for failures

--- a/src/web/websocket/websocket-receive.c
+++ b/src/web/websocket/websocket-receive.c
@@ -629,6 +629,7 @@ websocket_protocol_consume_frame(WS_CLIENT *wsc, char *data, size_t length, ssiz
 
         case WS_ALLOW_DISCARD:
             // we have already logged in websocket_is_frame_allowed()
+            *bytes_processed = header.frame_size;
             return WS_FRAME_COMPLETE;
 
         default:


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves robustness and correctness across the Agent: safer file reads, resilient SQLite/stream/socket handling, atomic registry saves, and reliable shutdown/crash paths. Fixes edge cases in Kinesis batching, WebSocket teardown, Windows SMBIOS/service stop, and JSON walking to prevent stalls and data loss.

- **Bug Fixes**
  - File I/O: dyncfg schema, text-file helper, and web static files now read to completion with EINTR retry and size checks; `buffered_reader` retries on EINTR.
  - Networking/protocols: treat recv EOF as close to avoid spins; keep EINTR stream-receiver probes alive; consume discarded WebSocket teardown frames; remove errored/hung log-forwarder fds from poll.
  - Exporting: split oversized newline-free AWS Kinesis records at the payload limit so workers advance.
  - Storage: use `sqlite3_step_monitored()` in key readers; buffer removed-alert repairs and run after SELECT finalization; publish registry DB with atomic `rename()` and safe backup staging.
  - Crashes/stacktraces: only capture crash stack traces when the backend is async-signal-safe; fix cache collision by chaining same-hash entries; add a cache unit test; preserve in-place UTF-8 sanitize behavior with a temporary copy and add a regression test.
  - Windows: advance SMBIOS parser past the double-NUL terminator; exit the process after reporting `SERVICE_STOPPED`.
  - Config/runtime: bound INI option removal loops; fix `simple_pattern` scan to always advance; allocate nonzero RRDCONTEXT queue IDs.
  - JSON: pass callback context into `json-c` array parsing; skip ignored `jsmn` array token spans to keep traversal state correct.

<sup>Written for commit 295c9733a397f23158eb30e2b79476101325a7ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

