### PR TITLE
Netdata fixes part 41

### DIFF
--- a/src/daemon/status-file-dedup.c
+++ b/src/daemon/status-file-dedup.c
@@ -137,11 +137,10 @@ failed:
     return false;
 }
 
-bool daemon_status_dedup_load(void) {
-    // IMPORTANT: NO LOCKS OR ALLOCATIONS HERE, THIS FUNCTION IS CALLED FROM SIGNAL HANDLERS
-    // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS
+bool daemon_status_dedup_load(bool log) {
+    // Do not call this from signal handlers; they use the already-loaded dedup table.
 
-    return status_file_io_load(DEDUP_FILENAME, status_file_dedup_load_and_parse, NULL);
+    return status_file_io_load(DEDUP_FILENAME, status_file_dedup_load_and_parse, NULL, log);
 }
 
 static bool daemon_status_dedup_save(void) {
@@ -157,11 +156,12 @@ static bool daemon_status_dedup_save(void) {
 // --------------------------------------------------------------------------------------------------------------------
 // deduplication hashes management
 
-bool dedup_already_posted(DAEMON_STATUS_FILE *ds __maybe_unused, uint64_t hash, bool sentry) {
+bool dedup_already_posted(DAEMON_STATUS_FILE *ds __maybe_unused, uint64_t hash, bool sentry, DEDUP_LOAD_MODE load_mode) {
     // IMPORTANT: NO LOCKS OR ALLOCATIONS HERE, THIS FUNCTION IS CALLED FROM SIGNAL HANDLERS
     // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS
 
-    daemon_status_dedup_load();
+    if(load_mode == DEDUP_RELOAD_FROM_DISK)
+        daemon_status_dedup_load(true);
 
     usec_t now_ut = now_realtime_usec();
 
@@ -180,11 +180,12 @@ bool dedup_already_posted(DAEMON_STATUS_FILE *ds __maybe_unused, uint64_t hash, 
     return false;
 }
 
-void dedup_keep_hash(DAEMON_STATUS_FILE *ds __maybe_unused, uint64_t hash, bool sentry) {
+void dedup_keep_hash(DAEMON_STATUS_FILE *ds __maybe_unused, uint64_t hash, bool sentry, DEDUP_LOAD_MODE load_mode) {
     // IMPORTANT: NO LOCKS OR ALLOCATIONS HERE, THIS FUNCTION IS CALLED FROM SIGNAL HANDLERS
     // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS
 
-    daemon_status_dedup_load();
+    if(load_mode == DEDUP_RELOAD_FROM_DISK)
+        daemon_status_dedup_load(true);
 
     // find the same hash
     for(size_t i = 0; i < _countof(dedup.slot); i++) {

--- a/src/daemon/status-file-dedup.h
+++ b/src/daemon/status-file-dedup.h
@@ -8,7 +8,13 @@
 
 uint64_t daemon_status_file_hash(DAEMON_STATUS_FILE *ds, const char *msg, const char *cause);
 
-bool dedup_already_posted(DAEMON_STATUS_FILE *ds, uint64_t hash, bool sentry);
-void dedup_keep_hash(DAEMON_STATUS_FILE *ds, uint64_t hash, bool sentry);
+typedef enum {
+    DEDUP_USE_LOADED,
+    DEDUP_RELOAD_FROM_DISK,
+} DEDUP_LOAD_MODE;
+
+bool daemon_status_dedup_load(bool log);
+bool dedup_already_posted(DAEMON_STATUS_FILE *ds, uint64_t hash, bool sentry, DEDUP_LOAD_MODE load_mode);
+void dedup_keep_hash(DAEMON_STATUS_FILE *ds, uint64_t hash, bool sentry, DEDUP_LOAD_MODE load_mode);
 
 #endif //NETDATA_STATUS_FILE_DEDUP_H

--- a/src/daemon/status-file-io.c
+++ b/src/daemon/status-file-io.c
@@ -17,8 +17,7 @@ static void status_file_io_fallback_dirs_update(void) {
 }
 
 static bool status_file_io_check(const char *directory, const char *filename, char *dst, size_t dst_size, time_t *mtime) {
-    // IMPORTANT: NO LOCKS OR ALLOCATIONS HERE, THIS FUNCTION IS CALLED FROM SIGNAL HANDLERS
-    // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS
+    // Used by the non-signal load path; it may probe filesystem metadata.
 
     if(!directory || !*directory || !filename || !*filename || !dst || !dst_size || !mtime)
         return false;
@@ -65,9 +64,8 @@ static void status_file_io_remove_obsolete(const char *protected_dir, const char
     errno_clear();
 }
 
-bool status_file_io_load(const char *filename, bool (*cb)(const char *, void *), void *data) {
-    // IMPORTANT: NO LOCKS OR ALLOCATIONS HERE, THIS FUNCTION IS CALLED FROM SIGNAL HANDLERS
-    // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS
+bool status_file_io_load(const char *filename, bool (*cb)(const char *, void *), void *data, bool log) {
+    // Do not call this from signal handlers; it probes filesystem metadata and may log.
 
     char newest[FILENAME_MAX] = "";
     char current[FILENAME_MAX];
@@ -93,7 +91,9 @@ bool status_file_io_load(const char *filename, bool (*cb)(const char *, void *),
     if(*newest && cb(newest, data))
         return true;
 
-    nd_log(NDLS_DAEMON, NDLP_ERR, "Cannot find a status file in any location");
+    if(log)
+        nd_log(NDLS_DAEMON, NDLP_ERR, "Cannot find a status file in any location");
+
     return false;
 }
 

--- a/src/daemon/status-file-io.h
+++ b/src/daemon/status-file-io.h
@@ -6,7 +6,7 @@
 #include "libnetdata/libnetdata.h"
 #include "status-file.h"
 
-bool status_file_io_load(const char *filename, bool (*cb)(const char *, void *), void *data);
+bool status_file_io_load(const char *filename, bool (*cb)(const char *, void *), void *data, bool log);
 bool status_file_io_save(const char *filename, const void *data, size_t size, bool log);
 
 #endif //NETDATA_STATUS_FILE_IO_H

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -1008,7 +1008,7 @@ static void post_status_file(struct post_status_file_thread_data *d) {
         session_status.posts++;
         nd_log(NDLS_DAEMON, NDLP_INFO, "Posted last status to agent-events successfully.");
         uint64_t hash = daemon_status_file_hash(d->status, d->msg, d->cause);
-        dedup_keep_hash(&session_status, hash, false);
+        dedup_keep_hash(&session_status, hash, false, DEDUP_RELOAD_FROM_DISK);
         daemon_status_file_save(wb, &session_status, true);
     }
     else
@@ -1064,7 +1064,8 @@ void daemon_status_file_init(void) {
     static_save_buffer_init();
     mallocz_register_out_of_memory_cb(daemon_status_file_out_of_memory);
 
-    status_file_io_load(STATUS_FILENAME, status_file_load_and_parse, &last_session_status);
+    status_file_io_load(STATUS_FILENAME, status_file_load_and_parse, &last_session_status, true);
+    daemon_status_dedup_load(false);
 
     // fill missing information on older versions of the status file
 
@@ -1315,7 +1316,7 @@ void daemon_status_file_check_crash(void) {
         (last_session_status.restarts > 1 || !nd_is_running_under_ci()) &&
 
         // we have not reported this
-        !dedup_already_posted(&session_status, daemon_status_file_hash(&last_session_status, msg, cause), false)
+        !dedup_already_posted(&session_status, daemon_status_file_hash(&last_session_status, msg, cause), false, DEDUP_RELOAD_FROM_DISK)
 
         ) {
         daemon_status_file_startup_step("startup(crash reports prep)");
@@ -1512,10 +1513,11 @@ bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE c
     bool duplicate = false;
     if(chained_handler) {
         uint64_t hash = daemon_status_file_hash(&session_status, NULL, NULL);
-        duplicate = dedup_already_posted(&session_status, hash, true);
+        // Loading from disk is not async-signal-safe; use the table loaded during normal startup.
+        duplicate = dedup_already_posted(&session_status, hash, true, DEDUP_USE_LOADED);
         if (!duplicate) {
             // save this hash, so that we won't post it again to sentry
-            dedup_keep_hash(&session_status, hash, true);
+            dedup_keep_hash(&session_status, hash, true, DEDUP_USE_LOADED);
         }
     }
 

--- a/src/libnetdata/buffer/buffer.c
+++ b/src/libnetdata/buffer/buffer.c
@@ -107,8 +107,16 @@ void buffer_vsprintf(BUFFER *wb, const char *fmt, va_list args) {
         va_list args_copy;
         va_copy(args_copy, args);
         // vsnprintf() returns the number of bytes required, even if bigger than the buffer provided
-        full_size_bytes = (size_t) vsnprintf(&wb->buffer[wb->len], space_remaining, fmt, args_copy);
+        int ret = vsnprintf(&wb->buffer[wb->len], space_remaining, fmt, args_copy);
         va_end(args_copy);
+
+        if(unlikely(ret < 0)) {
+            wb->buffer[wb->len] = '\0';
+            buffer_overflow_check(wb);
+            return;
+        }
+
+        full_size_bytes = (size_t)ret;
 
     } while(full_size_bytes >= space_remaining);
 
@@ -531,6 +539,19 @@ int buffer_unittest(void) {
     buffer_double_roundtrip(wb, NUMBER_ENCODING_DECIMAL, 9.12345678901234567890123456789e+45, "9.123456789012346128e+45");
     buffer_double_roundtrip(wb, NUMBER_ENCODING_HEX, 9.12345678901234567890123456789e+45, "%497991C25C9E4309");
     buffer_double_roundtrip(wb, NUMBER_ENCODING_BASE64, 9.12345678901234567890123456789e+45, "@El5kcJcnkMJ");
+
+    buffer_flush(wb);
+
+    {
+        char tmp[32];
+        const wchar_t invalid_wide[] = { (wchar_t)0xd800, 0 };
+
+        if(snprintf(tmp, sizeof(tmp), "%ls", invalid_wide) < 0) {
+            buffer_strcat(wb, "prefix");
+            buffer_sprintf(wb, "%ls", invalid_wide);
+            errors += buffer_expect(wb, "prefix");
+        }
+    }
 
     buffer_flush(wb);
 

--- a/src/libnetdata/locks/waitq.c
+++ b/src/libnetdata/locks/waitq.c
@@ -4,11 +4,28 @@
 
 #define MAX_USEC 512 // Maximum backoff limit in microseconds
 
-#define PRIORITY_SHIFT 32
-#define NO_PRIORITY 0
+#define WAITQ_PRIORITY_BITS 3
+#define WAITQ_SEQUENCE_BITS (64 - WAITQ_PRIORITY_BITS)
+#define WAITQ_SEQUENCE_MASK ((UINT64_C(1) << WAITQ_SEQUENCE_BITS) - 1)
+#define WAITQ_SEQUENCE_WRAP_HALF (UINT64_C(1) << (WAITQ_SEQUENCE_BITS - 1))
+#define NO_PRIORITY WAITQ_NO_PRIORITY
+
+_Static_assert(WAITQ_PRIO_MAX < (UINT64_C(1) << WAITQ_PRIORITY_BITS),
+               "WAITQ priority bits must leave room for the no-priority sentinel");
 
 static ALWAYS_INLINE uint64_t make_order(WAITQ_PRIORITY priority, uint64_t seqno) {
-    return ((uint64_t)priority << PRIORITY_SHIFT) + seqno;
+    return ((uint64_t)priority << WAITQ_SEQUENCE_BITS) | (seqno & WAITQ_SEQUENCE_MASK);
+}
+
+static ALWAYS_INLINE bool order_is_before(uint64_t current, uint64_t candidate) {
+    uint64_t current_priority = current >> WAITQ_SEQUENCE_BITS;
+    uint64_t candidate_priority = candidate >> WAITQ_SEQUENCE_BITS;
+
+    if(current_priority != candidate_priority)
+        return current_priority < candidate_priority;
+
+    uint64_t diff = (current - candidate) & WAITQ_SEQUENCE_MASK;
+    return diff != 0 && (diff & WAITQ_SEQUENCE_WRAP_HALF);
 }
 
 static ALWAYS_INLINE uint64_t get_our_order(WAITQ *waitq, WAITQ_PRIORITY priority) {
@@ -18,7 +35,7 @@ static ALWAYS_INLINE uint64_t get_our_order(WAITQ *waitq, WAITQ_PRIORITY priorit
 
 ALWAYS_INLINE void waitq_init(WAITQ *waitq) {
     spinlock_init(&waitq->spinlock);
-    waitq->current_priority = 0;
+    waitq->current_priority = NO_PRIORITY;
     waitq->last_seqno = 0;
 }
 
@@ -30,7 +47,7 @@ static ALWAYS_INLINE bool write_our_priority(WAITQ *waitq, uint64_t our_order) {
 
     do {
 
-        if(current != NO_PRIORITY && current < our_order)
+        if(current != NO_PRIORITY && order_is_before(current, our_order))
             return false;
 
     } while(!__atomic_compare_exchange_n(
@@ -125,6 +142,13 @@ ALWAYS_INLINE void waitq_release(WAITQ *waitq) {
 #define THREADS_PER_PRIORITY 2
 #define TEST_DURATION_SEC 2
 
+#define WAITQ_TEST(condition, message) do {        \
+    if(!(condition)) {                             \
+        fprintf(stderr, "WAITQ TEST FAILED: %s\n", message); \
+        errors++;                                  \
+    }                                              \
+} while(0)
+
 // For stress test statistics
 typedef struct thread_stats {
     WAITQ_PRIORITY priority;
@@ -148,6 +172,34 @@ static const char *priority_to_string(WAITQ_PRIORITY p) {
         case WAITQ_PRIO_LOW:    return "LOW";
         default:                        return "UNKNOWN";
     }
+}
+
+static int unittest_order_wrap(void) {
+    int errors = 0;
+
+    uint64_t normal_before_u32_wrap = make_order(WAITQ_PRIO_NORMAL, UINT32_MAX);
+    uint64_t normal_after_u32_wrap = make_order(WAITQ_PRIO_NORMAL, (uint64_t)UINT32_MAX + 1);
+
+    WAITQ_TEST(order_is_before(normal_before_u32_wrap, normal_after_u32_wrap),
+               "same-priority order survives the old uint32 sequence boundary");
+    WAITQ_TEST(!order_is_before(normal_after_u32_wrap, normal_before_u32_wrap),
+               "newer same-priority order is not selected before older order at uint32 boundary");
+
+    uint64_t normal_before_sequence_wrap = make_order(WAITQ_PRIO_NORMAL, WAITQ_SEQUENCE_MASK);
+    uint64_t normal_after_sequence_wrap = make_order(WAITQ_PRIO_NORMAL, WAITQ_SEQUENCE_MASK + 1);
+
+    WAITQ_TEST(order_is_before(normal_before_sequence_wrap, normal_after_sequence_wrap),
+               "same-priority order survives the packed sequence field boundary");
+    WAITQ_TEST(!order_is_before(normal_after_sequence_wrap, normal_before_sequence_wrap),
+               "newer same-priority order is not selected before older order at packed sequence boundary");
+
+    WAITQ_TEST(order_is_before(make_order(WAITQ_PRIO_URGENT, normal_after_u32_wrap),
+                               make_order(WAITQ_PRIO_NORMAL, normal_before_u32_wrap)),
+               "priority ordering remains stronger than FIFO ordering");
+    WAITQ_TEST(make_order(WAITQ_PRIO_LOW, WAITQ_SEQUENCE_MASK) != NO_PRIORITY,
+               "valid waitq orders cannot collide with the no-priority sentinel");
+
+    return errors;
 }
 
 static void stress_thread(void *arg) {
@@ -279,6 +331,7 @@ static int unittest_stress(void) {
 }
 
 int unittest_waiting_queue(void) {
-   int errors = unittest_stress();
+   int errors = unittest_order_wrap();
+   errors += unittest_stress();
    return errors;
 }

--- a/src/libnetdata/locks/waitq.h
+++ b/src/libnetdata/locks/waitq.h
@@ -5,6 +5,8 @@
 
 #include "libnetdata/libnetdata.h"
 
+#define WAITQ_NO_PRIORITY UINT64_MAX
+
 /*
  * WAITING QUEUE
  * Like a spinlock, but:
@@ -35,11 +37,11 @@ typedef enum __attribute__((packed)) {
 typedef struct waiting_queue {
     SPINLOCK spinlock;          // protects the actual resource
     pid_t writer;               // the pid the thread currently holding the lock
-    uint64_t current_priority;  // current highest priority attempting to acquire
-    uint32_t last_seqno;        // for FIFO ordering within same priority
+    uint64_t current_priority;  // current highest priority/order attempting to acquire
+    uint64_t last_seqno;        // for FIFO ordering within same priority
 } WAITQ;
 
-#define WAITQ_INITIALIZER (WAITQ){ .spinlock = SPINLOCK_INITIALIZER, .current_priority = 0, .last_seqno = 0, }
+#define WAITQ_INITIALIZER (WAITQ){ .spinlock = SPINLOCK_INITIALIZER, .current_priority = WAITQ_NO_PRIORITY, .last_seqno = 0, }
 
 // Initialize a waiting queue
 void waitq_init(WAITQ *waitq);

--- a/src/libnetdata/ringbuffer/ringbuffer.c
+++ b/src/libnetdata/ringbuffer/ringbuffer.c
@@ -205,7 +205,7 @@ int rbuf_memcmp(rbuf_t buffer, const char *haystack, const char *needle, size_t 
     const char *end = needle + needle_bytes;
 
     // as head==tail can mean 2 things here
-    if (haystack == buffer->head && buffer->size_data) {
+    if (haystack == buffer->head && buffer->size_data && needle != end) {
         if (*haystack != *needle)
             return (*haystack - *needle);
         rbuf_ptr_inc(buffer, &haystack);
@@ -218,7 +218,7 @@ int rbuf_memcmp(rbuf_t buffer, const char *haystack, const char *needle, size_t 
         rbuf_ptr_inc(buffer, &haystack);
         needle++;
     }
-    return 0;
+    return (needle == end) ? 0 : -1;
 }
 
 int rbuf_memcmp_n(rbuf_t buffer, const char *to_cmp, size_t to_cmp_bytes)

--- a/src/libnetdata/socket/nd-poll.c
+++ b/src/libnetdata/socket/nd-poll.c
@@ -48,7 +48,7 @@ nd_poll_t *nd_poll_create() {
 }
 
 static inline uint32_t nd_poll_events_to_epoll_events(nd_poll_event_t events) {
-    uint32_t pevents = EPOLLERR | EPOLLHUP;
+    uint32_t pevents = EPOLLERR | EPOLLHUP | EPOLLRDHUP;
     if (events & ND_POLL_READ) pevents |= EPOLLIN;
     if (events & ND_POLL_WRITE) pevents |= EPOLLOUT;
     return pevents;
@@ -238,6 +238,10 @@ int nd_poll_wait(nd_poll_t *ndpl, int timeout_ms, nd_poll_result_t *result) {
             return 1;
 
         internal_fatal(true, "nd_poll_get_next_event() should have 1 event!");
+        errno = EIO;
+        result->events = ND_POLL_POLL_FAILED;
+        result->data = NULL;
+        return -1;
     } while(true);
 }
 
@@ -291,7 +295,7 @@ static void ensure_capacity(nd_poll_t *ndpl) {
 }
 
 static inline short int nd_poll_events_to_poll_events(nd_poll_event_t events) {
-    short int pevents = POLLERR | POLLHUP | POLLNVAL;
+    short int pevents = POLLERR | POLLHUP | POLLNVAL | POLLRDHUP;
     if (events & ND_POLL_READ) pevents |= POLLIN;
     if (events & ND_POLL_WRITE) pevents |= POLLOUT;
     return pevents;
@@ -373,17 +377,17 @@ bool nd_poll_upd(nd_poll_t *ndpl, int fd, nd_poll_event_t events) {
 static inline bool nd_poll_get_next_event(nd_poll_t *ndpl, nd_poll_result_t *result) {
     for (nfds_t i = ndpl->last_pos; i < ndpl->nfds; i++) {
         if (ndpl->fds[i].revents != 0) {
+            short int revents = ndpl->fds[i].revents;
+            ndpl->fds[i].revents = 0;
 
             result->data = POINTERS_GET(&ndpl->pointers, ndpl->fds[i].fd);
             if(!result->data)
                 continue;
 
-            result->events = nd_poll_events_from_poll_revents(ndpl->fds[i].revents & ndpl->fds[i].events);
+            result->events = nd_poll_events_from_poll_revents(revents & ndpl->fds[i].events);
             if(!result->events)
                 // nd_poll_upd() may have removed some flags since we got this
                 continue;
-
-            ndpl->fds[i].revents = 0;
 
             ndpl->last_pos = i + 1;
             return true;
@@ -436,6 +440,10 @@ int nd_poll_wait(nd_poll_t *ndpl, int timeout_ms, nd_poll_result_t *result) {
             return 1;
 
         internal_fatal(true, "nd_poll_get_next_event() should have 1 event!");
+        errno = EIO;
+        result->events = ND_POLL_POLL_FAILED;
+        result->data = NULL;
+        return -1;
     } while (true);
 }
 

--- a/src/web/server/static/static-threaded.c
+++ b/src/web/server/static/static-threaded.c
@@ -216,6 +216,12 @@ static int web_server_rcv_callback(POLLINFO *pi, nd_poll_event_t *events) {
         if(unlikely(w->fd == fd && web_client_has_wait_send(w)))
             *events |= ND_POLL_WRITE;
 
+        if(unlikely(w->fd == fd && web_client_has_ssl_wait_receive(w)))
+            *events |= ND_POLL_READ;
+
+        if(unlikely(w->fd == fd && web_client_has_ssl_wait_send(w)))
+            *events |= ND_POLL_WRITE;
+
     } else if(unlikely(bytes < 0)) {
         ret = -1;
         goto cleanup;
@@ -260,6 +266,12 @@ static int web_server_snd_callback(POLLINFO *pi, nd_poll_event_t *events) {
         *events |= ND_POLL_READ;
 
     if(unlikely(w->fd == fd && web_client_has_wait_send(w)))
+        *events |= ND_POLL_WRITE;
+
+    if(unlikely(w->fd == fd && web_client_has_ssl_wait_receive(w)))
+        *events |= ND_POLL_READ;
+
+    if(unlikely(w->fd == fd && web_client_has_ssl_wait_send(w)))
         *events |= ND_POLL_WRITE;
 
     retval = web_server_check_client_status(w);

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -96,6 +96,14 @@ static inline void web_client_enable_wait_from_ssl(struct web_client *w) {
     }
 }
 
+static inline void web_client_reset_zchunk_send_state(struct web_client *w) {
+    w->response.zchunk_header_len = 0;
+    w->response.zchunk_header_sent = 0;
+    w->response.zchunk_suffix_sent = 0;
+    w->response.zchunk_finalize_sent = 0;
+    w->response.zchunk_header[0] = '\0';
+}
+
 static inline char *strip_control_characters(char *url) {
     if(!url) return "";
 
@@ -180,6 +188,7 @@ static void web_client_reset_allocations(struct web_client *w, bool free_all) {
         deflateEnd(&w->response.zstream);
         w->response.zsent = 0;
         w->response.zhave = 0;
+        web_client_reset_zchunk_send_state(w);
         w->response.zstream.avail_in = 0;
         w->response.zstream.avail_out = 0;
         w->response.zstream.total_in = 0;
@@ -802,28 +811,26 @@ HTTP_VALIDATION http_request_validate(struct web_client *w) {
 
 static inline ssize_t web_client_send_data(struct web_client *w,const void *buf,size_t len, int flags)
 {
-    do {
-        errno_clear();
+    errno_clear();
 
-        ssize_t bytes;
-        if ((web_client_check_conn_tcp(w)) && (netdata_ssl_web_server_ctx)) {
-            if (SSL_connection(&w->ssl)) {
-                bytes = netdata_ssl_write(&w->ssl, buf, len);
-                web_client_enable_wait_from_ssl(w);
-            } else
-                bytes = send(w->fd, buf, len, flags);
-        } else if (web_client_check_conn_tcp(w) || web_client_check_conn_unix(w))
+    ssize_t bytes;
+    if ((web_client_check_conn_tcp(w)) && (netdata_ssl_web_server_ctx)) {
+        if (SSL_connection(&w->ssl)) {
+            bytes = netdata_ssl_write(&w->ssl, buf, len);
+            web_client_enable_wait_from_ssl(w);
+        } else
             bytes = send(w->fd, buf, len, flags);
-        else
-            bytes = -999;
+    } else if (web_client_check_conn_tcp(w) || web_client_check_conn_unix(w))
+        bytes = send(w->fd, buf, len, flags);
+    else
+        bytes = -999;
 
-        if(bytes < 0 && errno == EAGAIN) {
-            tinysleep();
-            continue;
-        }
+    if(bytes < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        web_client_enable_wait_send(w);
+        return 0;
+    }
 
-        return bytes;
-    } while(true);
+    return bytes;
 }
 
 void web_client_build_http_header(struct web_client *w) {
@@ -1592,18 +1599,51 @@ void web_client_process_request_from_web_server(struct web_client *w) {
     }
 }
 
+static inline ssize_t web_client_send_chunk_frame(struct web_client *w, const char *buf, size_t len, size_t *sent)
+{
+    ssize_t total = 0;
+
+    while(*sent < len) {
+        ssize_t bytes = web_client_send_data(w, &buf[*sent], len - *sent, 0);
+        if(bytes > 0) {
+            *sent += bytes;
+            total += bytes;
+            w->statistics.sent_bytes += bytes;
+        }
+        else if(bytes == 0) {
+            web_client_enable_wait_send(w);
+            return total;
+        }
+        else
+            return bytes;
+    }
+
+    return total;
+}
+
 ssize_t web_client_send_chunk_header(struct web_client *w, size_t len)
 {
     netdata_log_debug(D_DEFLATE, "%llu: OPEN CHUNK of %zu bytes (hex: %zx).", w->id, len, len);
-    char buf[24];
-    ssize_t bytes;
-    bytes = (ssize_t)sprintf(buf, "%zX\r\n", len);
-    buf[bytes] = 0x00;
+    if(w->response.zchunk_header_len == 0) {
+        int bytes = snprintf(w->response.zchunk_header, sizeof(w->response.zchunk_header), "%zX\r\n", len);
+        if(bytes < 0 || (size_t)bytes >= sizeof(w->response.zchunk_header)) {
+            netdata_log_debug(D_WEB_CLIENT, "%llu: Failed to prepare chunk header.", w->id);
+            WEB_CLIENT_IS_DEAD(w);
+            return -1;
+        }
+        w->response.zchunk_header_len = (size_t)bytes;
+        w->response.zchunk_header_sent = 0;
+    }
 
-    bytes = web_client_send_data(w,buf,strlen(buf),0);
+    ssize_t bytes = web_client_send_chunk_frame(
+        w, w->response.zchunk_header, w->response.zchunk_header_len, &w->response.zchunk_header_sent);
     if(bytes > 0) {
         netdata_log_debug(D_DEFLATE, "%llu: Sent chunk header %zd bytes.", w->id, bytes);
-        w->statistics.sent_bytes += bytes;
+        if(w->response.zchunk_header_sent == w->response.zchunk_header_len) {
+            w->response.zchunk_header_len = 0;
+            w->response.zchunk_header_sent = 0;
+            w->response.zchunk_header[0] = '\0';
+        }
     }
 
     else if(bytes == 0) {
@@ -1622,10 +1662,11 @@ ssize_t web_client_send_chunk_close(struct web_client *w)
     //debug(D_DEFLATE, "%llu: CLOSE CHUNK.", w->id);
 
     ssize_t bytes;
-    bytes = web_client_send_data(w,"\r\n",2,0);
+    bytes = web_client_send_chunk_frame(w, "\r\n", 2, &w->response.zchunk_suffix_sent);
     if(bytes > 0) {
         netdata_log_debug(D_DEFLATE, "%llu: Sent chunk suffix %zd bytes.", w->id, bytes);
-        w->statistics.sent_bytes += bytes;
+        if(w->response.zchunk_suffix_sent == 2)
+            w->response.zchunk_suffix_sent = 0;
     }
 
     else if(bytes == 0) {
@@ -1644,10 +1685,11 @@ ssize_t web_client_send_chunk_finalize(struct web_client *w)
     //debug(D_DEFLATE, "%llu: FINALIZE CHUNK.", w->id);
 
     ssize_t bytes;
-    bytes = web_client_send_data(w,"\r\n0\r\n\r\n",7,0);
+    bytes = web_client_send_chunk_frame(w, "\r\n0\r\n\r\n", 7, &w->response.zchunk_finalize_sent);
     if(bytes > 0) {
         netdata_log_debug(D_DEFLATE, "%llu: Sent chunk suffix %zd bytes.", w->id, bytes);
-        w->statistics.sent_bytes += bytes;
+        if(w->response.zchunk_finalize_sent == 7)
+            w->response.zchunk_finalize_sent = 0;
     }
 
     else if(bytes == 0) {
@@ -1664,6 +1706,7 @@ ssize_t web_client_send_chunk_finalize(struct web_client *w)
 ssize_t web_client_send_deflate(struct web_client *w)
 {
     ssize_t len = 0, t = 0;
+    bool completed_pending_suffix = false;
 
     // when using compression,
     // w->response.sent is the amount of bytes passed through compression
@@ -1672,6 +1715,20 @@ ssize_t web_client_send_deflate(struct web_client *w)
         "%llu: web_client_send_deflate(): w->response.data->len = %zu, w->response.sent = %zu, w->response.zhave = %zu, w->response.zsent = %zu, w->response.zstream.avail_in = %u, w->response.zstream.avail_out = %u, w->response.zstream.total_in = %lu, w->response.zstream.total_out = %lu.",
         w->id, (size_t)w->response.data->len, w->response.sent, w->response.zhave, w->response.zsent, w->response.zstream.avail_in, w->response.zstream.avail_out, w->response.zstream.total_in, w->response.zstream.total_out);
 
+    if(w->response.zchunk_suffix_sent) {
+        t = web_client_send_chunk_close(w);
+        if(t <= 0 || w->response.zchunk_suffix_sent)
+            return t;
+
+        completed_pending_suffix = true;
+    }
+
+    if(w->response.zchunk_header_len) {
+        t = web_client_send_chunk_header(w, w->response.zhave);
+        if(t < 0 || w->response.zchunk_header_len)
+            return t;
+    }
+
     if(w->response.data->len - w->response.sent == 0 && w->response.zstream.avail_in == 0 && w->response.zhave == w->response.zsent && w->response.zstream.avail_out != 0) {
         // there is nothing to send
 
@@ -1679,8 +1736,17 @@ ssize_t web_client_send_deflate(struct web_client *w)
 
         // finalize the chunk
         if(w->response.sent != 0) {
-            t = web_client_send_chunk_finalize(w);
-            if(t < 0) return t;
+            // A pending inter-chunk suffix is also the prefix of the final marker.
+            if(completed_pending_suffix && w->response.zchunk_finalize_sent == 0)
+                w->response.zchunk_finalize_sent = 2;
+
+            ssize_t t2 = web_client_send_chunk_finalize(w);
+            if(t2 < 0)
+                return t2;
+
+            t += t2;
+            if(t2 == 0 || w->response.zchunk_finalize_sent)
+                return t;
         }
 
         if(unlikely(!web_client_has_keepalive(w))) {
@@ -1699,9 +1765,11 @@ ssize_t web_client_send_deflate(struct web_client *w)
         // compress more input data
 
         // close the previous open chunk
-        if(w->response.sent != 0) {
+        // Skip this if the pending suffix was completed at function entry.
+        if(w->response.sent != 0 && !completed_pending_suffix) {
             t = web_client_send_chunk_close(w);
-            if(t < 0) return t;
+            if(t <= 0 || w->response.zchunk_suffix_sent)
+                return t;
         }
 
         netdata_log_debug(D_DEFLATE, "%llu: Compressing %zu new bytes starting from %zu (and %u left behind).", w->id, (w->response.data->len - w->response.sent), w->response.sent, w->response.zstream.avail_in);
@@ -1748,6 +1816,8 @@ ssize_t web_client_send_deflate(struct web_client *w)
         ssize_t t2 = web_client_send_chunk_header(w, w->response.zhave);
         if(t2 < 0) return t2;
         t += t2;
+        if(w->response.zchunk_header_len)
+            return t;
     }
 
     netdata_log_debug(D_WEB_CLIENT, "%llu: Sending %zu bytes of data (+%zd of chunk header).", w->id, w->response.zhave - w->response.zsent, t);
@@ -1763,6 +1833,7 @@ ssize_t web_client_send_deflate(struct web_client *w)
         netdata_log_debug(D_WEB_CLIENT, "%llu: Did not send any bytes to the client (zhave = %zu, zsent = %zu, need to send = %zu).",
             w->id, w->response.zhave, w->response.zsent, w->response.zhave - w->response.zsent);
 
+        len += t;
     }
     else {
         netdata_log_debug(D_WEB_CLIENT, "%llu: Failed to send data to client.", w->id);

--- a/src/web/server/web_client.h
+++ b/src/web/server/web_client.h
@@ -163,6 +163,11 @@ struct response {
     z_stream zstream;                                    // zlib stream for sending compressed output to client
     size_t zsent;                                        // the compressed bytes we have sent to the client
     size_t zhave;                                        // the compressed bytes that we have received from zlib
+    size_t zchunk_header_len;                            // bytes in zchunk_header pending before zbuffer
+    size_t zchunk_header_sent;                           // chunk header bytes already sent
+    size_t zchunk_suffix_sent;                           // chunk suffix bytes already sent
+    size_t zchunk_finalize_sent;                         // final chunk marker bytes already sent
+    char zchunk_header[24];                              // hex chunk-size header plus CRLF
     Bytef zbuffer[NETDATA_WEB_RESPONSE_ZLIB_CHUNK_SIZE]; // temporary buffer for storing compressed output
 };
 

--- a/src/web/websocket/websocket-handshake.c
+++ b/src/web/websocket/websocket-handshake.c
@@ -27,6 +27,9 @@ void websocket_threads_init(void) {
         websocket_threads[i].cmd.pipe[PIPE_WRITE] = -1;
         websocket_threads[i].cmd.buffer = NULL;
         websocket_threads[i].cmd.buffer_size = 0;
+        websocket_threads[i].cmd.broadcast_pending = false;
+        websocket_threads[i].cmd.broadcast_payload_size = 0;
+        websocket_threads[i].cmd.broadcast_payload_read = 0;
     }
 }
 

--- a/src/web/websocket/websocket-internal.h
+++ b/src/web/websocket/websocket-internal.h
@@ -178,6 +178,9 @@ typedef struct websocket_thread {
         int pipe[2];                 // Command pipe [0] = read, [1] = write
         char *buffer;                // Reusable scratch buffer for command payloads
         size_t buffer_size;
+        bool broadcast_pending;
+        uint32_t broadcast_payload_size;
+        uint32_t broadcast_payload_read;
     } cmd;
 
 } WEBSOCKET_THREAD;

--- a/src/web/websocket/websocket-thread.c
+++ b/src/web/websocket/websocket-thread.c
@@ -105,6 +105,25 @@ struct pipe_header {
     };
 };
 
+static void websocket_thread_close_command_pipe(WEBSOCKET_THREAD *wth) {
+    if(wth->cmd.pipe[PIPE_READ] != -1) {
+        close(wth->cmd.pipe[PIPE_READ]);
+        wth->cmd.pipe[PIPE_READ] = -1;
+    }
+
+    if(wth->cmd.pipe[PIPE_WRITE] != -1) {
+        close(wth->cmd.pipe[PIPE_WRITE]);
+        wth->cmd.pipe[PIPE_WRITE] = -1;
+    }
+}
+
+static void websocket_thread_close_command_pipe_write(WEBSOCKET_THREAD *wth) {
+    if(wth->cmd.pipe[PIPE_WRITE] != -1) {
+        close(wth->cmd.pipe[PIPE_WRITE]);
+        wth->cmd.pipe[PIPE_WRITE] = -1;
+    }
+}
+
 static ssize_t write_pipe_block(int fd, const void *buffer, size_t size) {
     const char *buf = buffer;
     ssize_t total_written = 0;
@@ -184,6 +203,8 @@ bool websocket_thread_send_broadcast(WEBSOCKET_THREAD *wth, WEBSOCKET_OPCODE opc
     ssize_t bytes = write_pipe_block(wth->cmd.pipe[PIPE_WRITE], &header, sizeof(header));
     if(bytes != (ssize_t)sizeof(header)) {
         netdata_log_error("WEBSOCKET[%zu]: Failed to write command header to pipe", wth->id);
+        if(bytes > 0)
+            websocket_thread_close_command_pipe_write(wth);
         spinlock_unlock(&wth->spinlock);
         return false;
     }
@@ -192,6 +213,7 @@ bool websocket_thread_send_broadcast(WEBSOCKET_THREAD *wth, WEBSOCKET_OPCODE opc
     bytes = write_pipe_block(wth->cmd.pipe[PIPE_WRITE], &opcode, sizeof(opcode));
     if(bytes != (ssize_t)sizeof(opcode)) {
         netdata_log_error("WEBSOCKET[%zu]: Failed to write broadcast opcode to pipe", wth->id);
+        websocket_thread_close_command_pipe_write(wth);
         spinlock_unlock(&wth->spinlock);
         return false;
     }
@@ -200,6 +222,7 @@ bool websocket_thread_send_broadcast(WEBSOCKET_THREAD *wth, WEBSOCKET_OPCODE opc
     bytes = write_pipe_block(wth->cmd.pipe[PIPE_WRITE], message, message_len);
     if(bytes != (ssize_t)message_len) {
         netdata_log_error("WEBSOCKET[%zu]: Failed to write broadcast message to pipe", wth->id);
+        websocket_thread_close_command_pipe_write(wth);
         spinlock_unlock(&wth->spinlock);
         return false;
     }
@@ -236,6 +259,99 @@ static ssize_t read_pipe_block(int fd, void *buffer, size_t size) {
     return total_read;
 }
 
+static ssize_t read_pipe_available(int fd, void *buffer, size_t size) {
+    for(;;) {
+        ssize_t bytes = read(fd, buffer, size);
+        if(bytes < 0 && errno == EINTR)
+            continue;
+
+        return bytes;
+    }
+}
+
+static void websocket_thread_reset_pending_broadcast(WEBSOCKET_THREAD *wth) {
+    wth->cmd.broadcast_pending = false;
+    wth->cmd.broadcast_payload_size = 0;
+    wth->cmd.broadcast_payload_read = 0;
+}
+
+static bool websocket_thread_drain_command_payload(WEBSOCKET_THREAD *wth, uint32_t payload_size) {
+    char drain_buf[4096];
+    uint32_t remaining = payload_size;
+
+    while(remaining > 0) {
+        size_t chunk = (remaining < sizeof(drain_buf)) ? remaining : sizeof(drain_buf);
+        ssize_t drained = read_pipe_block(wth->cmd.pipe[PIPE_READ], drain_buf, chunk);
+        if(drained <= 0) {
+            netdata_log_error(
+                "WEBSOCKET[%zu]: Failed to fully drain invalid command payload, closing command pipe to avoid desynchronization",
+                wth->id);
+            websocket_thread_close_command_pipe(wth);
+            return false;
+        }
+
+        remaining -= (uint32_t)drained;
+    }
+
+    return true;
+}
+
+static bool websocket_thread_process_pending_broadcast(WEBSOCKET_THREAD *wth) {
+    while(wth->cmd.broadcast_payload_read < wth->cmd.broadcast_payload_size) {
+        ssize_t bytes = read_pipe_available(
+            wth->cmd.pipe[PIPE_READ],
+            wth->cmd.buffer + wth->cmd.broadcast_payload_read,
+            wth->cmd.broadcast_payload_size - wth->cmd.broadcast_payload_read);
+
+        if(bytes < 0) {
+            if(errno == EAGAIN || errno == EWOULDBLOCK)
+                return false;
+
+            netdata_log_error(
+                "WEBSOCKET[%zu]: Failed to read broadcast payload from pipe: %s",
+                wth->id, strerror(errno));
+            websocket_thread_reset_pending_broadcast(wth);
+            websocket_thread_close_command_pipe(wth);
+            return false;
+        }
+
+        if(bytes == 0) {
+            netdata_log_error(
+                "WEBSOCKET[%zu]: Command pipe closed while reading broadcast payload (%u/%u bytes)",
+                wth->id, wth->cmd.broadcast_payload_read, wth->cmd.broadcast_payload_size);
+            websocket_thread_reset_pending_broadcast(wth);
+            websocket_thread_close_command_pipe(wth);
+            return false;
+        }
+
+        wth->cmd.broadcast_payload_read += (uint32_t)bytes;
+    }
+
+    WEBSOCKET_OPCODE opcode;
+    memcpy(&opcode, wth->cmd.buffer, sizeof(opcode));
+
+    uint32_t message_len = wth->cmd.broadcast_payload_size - sizeof(opcode);
+    char *message = wth->cmd.buffer + sizeof(opcode);
+    message[message_len] = '\0';
+
+    websocket_thread_reset_pending_broadcast(wth);
+
+    // Send to all clients in this thread
+    spinlock_lock(&wth->clients_spinlock);
+
+    WS_CLIENT *wsc = wth->clients;
+    while(wsc) {
+        if(wsc->state == WS_STATE_OPEN) {
+            websocket_send_message(wsc, message, message_len, opcode);
+        }
+        wsc = wsc->next;
+    }
+
+    spinlock_unlock(&wth->clients_spinlock);
+
+    return true;
+}
+
 // Process a thread's command pipe
 static void websocket_thread_process_commands(WEBSOCKET_THREAD *wth) {
     internal_fatal(wth->tid != gettid_cached(), "Function %s() should only be used by the websocket thread", __FUNCTION__ );
@@ -244,6 +360,13 @@ static void websocket_thread_process_commands(WEBSOCKET_THREAD *wth) {
 
     // Read all available commands
     for(;;) {
+        if(wth->cmd.broadcast_pending) {
+            if(websocket_thread_process_pending_broadcast(wth))
+                continue;
+
+            break;
+        }
+
         // Read command header
 
         worker_is_busy(WORKERS_WEBSOCKET_CMD_READ);
@@ -302,70 +425,29 @@ static void websocket_thread_process_commands(WEBSOCKET_THREAD *wth) {
             case WEBSOCKET_THREAD_CMD_BROADCAST: {
                 worker_is_busy(WORKERS_WEBSOCKET_CMD_BROADCAST);
 
-                WEBSOCKET_OPCODE opcode;
-                bytes = read_pipe_block(wth->cmd.pipe[PIPE_READ], &opcode, sizeof(opcode));
-                if(bytes != sizeof(opcode)) {
-                    netdata_log_error("WEBSOCKET[%zu]: Failed to read broadcast opcode from pipe", wth->id);
-                    continue;
-                }
-
-                if(header.len < sizeof(opcode)) {
+                if(header.len < sizeof(WEBSOCKET_OPCODE)) {
                     netdata_log_error("WEBSOCKET[%zu]: Broadcast command header.len %u is too small", wth->id, header.len);
-                    continue;
+                    websocket_thread_close_command_pipe(wth);
+                    return;
                 }
-                uint32_t message_len = header.len - sizeof(opcode);
+                uint32_t message_len = header.len - sizeof(WEBSOCKET_OPCODE);
                 if(message_len > WS_MAX_OUTGOING_FRAME_SIZE) {
                     netdata_log_error("WEBSOCKET[%zu]: Broadcast message too large: %u bytes", wth->id, message_len);
-                    // Drain the payload to keep the pipe synchronized for subsequent commands.
-                    char drain_buf[4096];
-                    uint32_t remaining = message_len;
-                    while(remaining > 0) {
-                        size_t chunk = (remaining < sizeof(drain_buf)) ? remaining : sizeof(drain_buf);
-                        ssize_t drained = read_pipe_block(wth->cmd.pipe[PIPE_READ], drain_buf, chunk);
-                        if(drained <= 0) {
-                            // Cannot complete drain: close both pipe ends so the next poll cycle does not
-                            // try to parse the leftover payload bytes as a new pipe_header, and so that
-                            // future write attempts fail the FD guard rather than hitting EPIPE.
-                            netdata_log_error("WEBSOCKET[%zu]: Failed to fully drain oversized broadcast payload, closing command pipe to avoid desynchronization", wth->id);
-                            if(wth->cmd.pipe[PIPE_READ] != -1) {
-                                close(wth->cmd.pipe[PIPE_READ]);
-                                wth->cmd.pipe[PIPE_READ] = -1;
-                            }
-                            if(wth->cmd.pipe[PIPE_WRITE] != -1) {
-                                close(wth->cmd.pipe[PIPE_WRITE]);
-                                wth->cmd.pipe[PIPE_WRITE] = -1;
-                            }
-                            return;
-                        }
-                        remaining -= (uint32_t)drained;
-                    }
+                    websocket_thread_drain_command_payload(wth, header.len);
                     continue;
                 }
-                if(message_len + 1 > wth->cmd.buffer_size) {
-                    wth->cmd.buffer = reallocz(wth->cmd.buffer, message_len + 1);
-                    wth->cmd.buffer_size = message_len + 1;
+                if(header.len + 1 > wth->cmd.buffer_size) {
+                    wth->cmd.buffer = reallocz(wth->cmd.buffer, header.len + 1);
+                    wth->cmd.buffer_size = header.len + 1;
                 }
 
-                char *message = wth->cmd.buffer;
-                bytes = read_pipe_block(wth->cmd.pipe[PIPE_READ], message, message_len);
-                if(bytes != message_len) {
-                    netdata_log_error("WEBSOCKET[%zu]: Failed to read broadcast message from pipe", wth->id);
-                    continue;
-                }
-                message[message_len] = '\0';
-                
-                // Send to all clients in this thread
-                spinlock_lock(&wth->clients_spinlock);
+                wth->cmd.broadcast_pending = true;
+                wth->cmd.broadcast_payload_size = header.len;
+                wth->cmd.broadcast_payload_read = 0;
 
-                WS_CLIENT *wsc = wth->clients;
-                while(wsc) {
-                    if(wsc->state == WS_STATE_OPEN) {
-                        websocket_send_message(wsc, message, message_len, opcode);
-                    }
-                    wsc = wsc->next;
-                }
-                
-                spinlock_unlock(&wth->clients_spinlock);
+                if(!websocket_thread_process_pending_broadcast(wth))
+                    return;
+
                 break;
             }
 
@@ -617,19 +699,12 @@ void websocket_thread(void *ptr) {
     }
 
     // Cleanup command pipe
-    if(wth->cmd.pipe[PIPE_READ] != -1) {
-        close(wth->cmd.pipe[PIPE_READ]);
-        wth->cmd.pipe[PIPE_READ] = -1;
-    }
-
-    if(wth->cmd.pipe[PIPE_WRITE] != -1) {
-        close(wth->cmd.pipe[PIPE_WRITE]);
-        wth->cmd.pipe[PIPE_WRITE] = -1;
-    }
+    websocket_thread_close_command_pipe(wth);
 
     freez(wth->cmd.buffer);
     wth->cmd.buffer = NULL;
     wth->cmd.buffer_size = 0;
+    websocket_thread_reset_pending_broadcast(wth);
 
     // Mark thread as not running
     spinlock_lock(&wth->spinlock);


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves reliability across web I/O, websocket broadcast, and crash-report dedup. Fixes busy-loop and ordering bugs, makes dedup signal-safe, preserves gzip chunking under backpressure, and hardens poll/half-close handling.

- **Bug Fixes**
  - Dedup crash reports: preload table on startup and avoid disk/log calls in signal handlers; normal paths can reload from disk as needed.
  - Web send path: stop retry loops on EAGAIN/EWOULDBLOCK, set WAIT_SEND, and resume via poll; keep gzip chunk headers/suffix/final markers across partial writes; propagate SSL read/write waits; web worker now exposes SSL waits to the poller.
  - Polling: return ND_POLL_POLL_FAILED instead of spinning on undeliverable readiness; consume and clear stale `revents`; subscribe to `EPOLLRDHUP` on epoll for consistent half-close detection.
  - WebSocket broadcast: handle non-blocking pipe bodies across wakeups; detect oversize/invalid payloads, drain safely, and close pipe on errors to avoid stream desync.
  - Buffer formatting: guard negative `vsnprintf()` results to avoid infinite retry and preserve existing buffer contents; add unit test.
  - Ringbuffer compare: reject partial needle matches at buffer head to prevent premature delimiter detection.
  - Wait queue: preserve FIFO across sequence wrap with 64-bit sequence, wrap-aware comparisons, and a no-priority sentinel; add unit test.

- **Refactors**
  - API updates to avoid signal-unsafe paths: `status_file_io_load(..., bool log)` adds a log flag; dedup helpers take `DEDUP_LOAD_MODE` to choose in-memory vs disk reload.

<sup>Written for commit 7a00707736c90cefbe92779bd4bb6371e77b86b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

