### PR TITLE
Netdata fixes part 42

### DIFF
--- a/src/collectors/log2journal/log2journal-yaml.c
+++ b/src/collectors/log2journal/log2journal-yaml.c
@@ -197,9 +197,27 @@ bool yaml_parse_file(const char *config_file_path, LOG_JOB *jb) {
 }
 
 bool yaml_parse_config(const char *config_name, LOG_JOB *jb) {
+    if(!config_name || !*config_name) {
+        l2j_log("yaml configuration name cannot be empty.");
+        return false;
+    }
+
     char filename[FILENAME_MAX + 1];
 
-    snprintf(filename, sizeof(filename), "%s/%s.yaml", LOG2JOURNAL_CONFIG_PATH, config_name);
+    int length = snprintf(filename, sizeof(filename), "%s/%s.yaml", LOG2JOURNAL_CONFIG_PATH, config_name);
+    if(length < 0) {
+        l2j_log("failed to generate yaml configuration filename.");
+        return false;
+    }
+
+    if((size_t)length >= sizeof(filename)) {
+        l2j_log(
+            "yaml configuration filename is too long (needed %d bytes plus NUL, buffer is %zu bytes).",
+            length,
+            sizeof(filename));
+        return false;
+    }
+
     return yaml_parse_file(filename, jb);
 }
 

--- a/src/collectors/log2journal/tests.d/error-config-name-too-long.cmd
+++ b/src/collectors/log2journal/tests.d/error-config-name-too-long.cmd
@@ -1,0 +1,1 @@
+${TESTED_LOG2JOURNAL_BIN} -c "$(printf 'a%.0s' {1..10000})"

--- a/src/collectors/log2journal/tests.d/error-config-name-too-long.fail
+++ b/src/collectors/log2journal/tests.d/error-config-name-too-long.fail
@@ -1,0 +1,1 @@
+yaml configuration filename is too long

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -139,16 +139,30 @@ static inline int health_parse_repeat(
             return 1;
         }
         if(!strcasecmp(key, "warning")) {
-            if (!duration_parse_seconds(value, (int *)warn_repeat_every)) {
+            int repeat_every;
+            if (!duration_parse_seconds(value, &repeat_every)) {
                 netdata_log_error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
                                   line, file, value, key);
             }
+            else if (repeat_every < 0) {
+                netdata_log_error("Health configuration at line %zu of file '%s': negative value '%s' for '%s' keyword",
+                                  line, file, value, key);
+            }
+            else
+                *warn_repeat_every = (uint32_t)repeat_every;
         }
         else if(!strcasecmp(key, "critical")) {
-            if (!duration_parse_seconds(value, (int *)crit_repeat_every)) {
+            int repeat_every;
+            if (!duration_parse_seconds(value, &repeat_every)) {
                 netdata_log_error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
                                   line, file, value, key);
             }
+            else if (repeat_every < 0) {
+                netdata_log_error("Health configuration at line %zu of file '%s': negative value '%s' for '%s' keyword",
+                                  line, file, value, key);
+            }
+            else
+                *crit_repeat_every = (uint32_t)repeat_every;
         }
     }
 

--- a/src/libnetdata/c_rhash/c_rhash.c
+++ b/src/libnetdata/c_rhash/c_rhash.c
@@ -115,7 +115,7 @@ int c_rhash_get_uint8_by_str(c_rhash hash, const char *key, uint8_t *ret_val) {
     struct bin_item *bin = hash->bins[nhash];
 
     while (bin) {
-        if (bin->key_type == ITEMTYPE_STRING) {
+        if (bin->key_type == ITEMTYPE_STRING && bin->value_type == ITEMTYPE_UINT8) {
             if (!strcmp(bin->key, key)) {
                 *ret_val = *(uint8_t*)bin->value;
                 return 0;

--- a/src/libnetdata/c_rhash/tests.c
+++ b/src/libnetdata/c_rhash/tests.c
@@ -70,6 +70,15 @@ int test_str_uint8() {
     ASSERT_RETVAL(c_rhash_get_uint8_by_str, ==, 0, hash, KEY_1, &val);
     ASSERT_VAL_UINT8(100, val);
 
+    ASSERT_RETVAL(c_rhash_insert_str_ptr, ==, 0, hash, KEY_1, &hash);
+    val = 123;
+    ASSERT_RETVAL(c_rhash_get_uint8_by_str, !=, 0, hash, KEY_1, &val);
+    ASSERT_VAL_UINT8(0, val);
+
+    ASSERT_RETVAL(c_rhash_insert_str_uint8, ==, 0, hash, KEY_1, 42);
+    ASSERT_RETVAL(c_rhash_get_uint8_by_str, ==, 0, hash, KEY_1, &val);
+    ASSERT_VAL_UINT8(42, val);
+
     ALL_SUBTESTS_PASS();
 test_cleanup:
     c_rhash_destroy(hash);

--- a/src/libnetdata/completion/completion.c
+++ b/src/libnetdata/completion/completion.c
@@ -6,8 +6,11 @@ ALWAYS_INLINE void completion_reset(struct completion *p)
 {
     if (!p)
         return;
+
+    netdata_mutex_lock(&p->mutex);
     p->completed = 0;
     p->completed_jobs = 0;
+    netdata_mutex_unlock(&p->mutex);
 }
 
 ALWAYS_INLINE void completion_init(struct completion *p)

--- a/src/libnetdata/json/json-c-parser-unittest.c
+++ b/src/libnetdata/json/json-c-parser-unittest.c
@@ -2044,6 +2044,52 @@ static int test_parse_function_payload_empty_error_fallback(void) {
     return failed;
 }
 
+struct json_walk_boolean_names_capture {
+    size_t root_true;
+    size_t root_false;
+    size_t array_true;
+    size_t array_false;
+    size_t unexpected;
+};
+
+static int json_walk_boolean_names_callback(JSON_ENTRY *e) {
+    struct json_walk_boolean_names_capture *capture = e->callback_data;
+
+    if(e->type != JSON_BOOLEAN)
+        return 0;
+
+    if(!strcmp(e->name, "enabled") && e->data.boolean)
+        capture->root_true++;
+    else if(!strcmp(e->name, "disabled") && !e->data.boolean)
+        capture->root_false++;
+    else if(!strcmp(e->name, "array_enabled") && e->data.boolean)
+        capture->array_true++;
+    else if(!strcmp(e->name, "array_disabled") && !e->data.boolean)
+        capture->array_false++;
+    else
+        capture->unexpected++;
+
+    return 0;
+}
+
+static int test_json_walk_boolean_names(void) {
+    int failed = 0;
+    char payload[] =
+        "{\"text\":\"root\",\"enabled\":true,\"count\":1,\"disabled\":false,"
+        "\"items\":[{\"text\":\"array\",\"array_enabled\":true,\"count\":2,\"array_disabled\":false}]}";
+    struct json_walk_boolean_names_capture capture = { 0 };
+
+    int rc = json_parse(payload, &capture, json_walk_boolean_names_callback);
+    T(rc == JSON_OK, "json_walk_boolean_names: parse succeeds");
+    T(capture.root_true == 1, "json_walk_boolean_names: root true boolean keeps key");
+    T(capture.root_false == 1, "json_walk_boolean_names: root false boolean keeps key");
+    T(capture.array_true == 1, "json_walk_boolean_names: array true boolean keeps key");
+    T(capture.array_false == 1, "json_walk_boolean_names: array false boolean keeps key");
+    T(capture.unexpected == 0, "json_walk_boolean_names: no stale boolean keys");
+
+    return failed;
+}
+
 // ============================================================================
 // Entry point
 // ============================================================================
@@ -2076,6 +2122,7 @@ int json_c_parser_unittest(void) {
         { "ARRAY_ITEM_OBJECT",  test_parse_array_item_object },
         { "FUNCTION_PAYLOAD_ERROR_CAP", test_parse_function_payload_error_cap },
         { "FUNCTION_PAYLOAD_EMPTY_ERROR_FALLBACK", test_parse_function_payload_empty_error_fallback },
+        { "JSON_WALK_BOOLEAN_NAMES", test_json_walk_boolean_names },
         { NULL, NULL }
     };
 

--- a/src/libnetdata/json/json.c
+++ b/src/libnetdata/json/json.c
@@ -159,8 +159,12 @@ static inline void json_jsonc_set_string(JSON_ENTRY *e,char *key,const char *val
  * @param e the output structure
  * @param value the input value
  */
-static inline void json_jsonc_set_boolean(JSON_ENTRY *e,int value) {
+static inline void json_jsonc_set_boolean(JSON_ENTRY *e,char *key,int value) {
+    size_t len = key ? strnlen(key, JSON_NAME_LEN) : 0;
     e->type = JSON_BOOLEAN;
+    if(len)
+        memcpy(e->name,key,len);
+    e->name[len] = 0x00;
     e->data.boolean = value;
 }
 
@@ -207,7 +211,7 @@ static inline void json_jsonc_parse_array(json_object *ptr, void *callback_data,
                         json_jsonc_set_string(&e,key,json_object_get_string(val));
                         callback_function(&e);
                     } else if (type == json_type_boolean) {
-                        json_jsonc_set_boolean(&e,json_object_get_boolean(val));
+                        json_jsonc_set_boolean(&e,key,json_object_get_boolean(val));
                         callback_function(&e);
                     }
                 }
@@ -461,7 +465,7 @@ size_t json_walk(json_object *t, void *callback_data, int (*callback_function)(s
             json_jsonc_set_string(&e,key,json_object_get_string(val));
             callback_function(&e);
         } else if (type == json_type_boolean) {
-            json_jsonc_set_boolean(&e,json_object_get_boolean(val));
+            json_jsonc_set_boolean(&e,key,json_object_get_boolean(val));
             callback_function(&e);
         } else if (type == json_type_int) {
             json_jsonc_set_integer(&e,key,json_object_get_int64(val));

--- a/src/libnetdata/os/windows-wmi/windows-wmi-GetDiskDriveInfo.c
+++ b/src/libnetdata/os/windows-wmi/windows-wmi-GetDiskDriveInfo.c
@@ -4,6 +4,22 @@
 
 #if defined(OS_WINDOWS)
 
+static void wmi_bstr_to_multibyte(char *dst, size_t dst_size, BSTR src)
+{
+    if (!dst_size)
+        return;
+
+    dst[0] = '\0';
+
+    if (!src)
+        return;
+
+    if (!utf16_to_utf8(dst, dst_size, src, -1, NULL)) {
+        dst[0] = '\0';
+        return;
+    }
+}
+
 size_t GetDiskDriveInfo(DiskDriveInfoWMI *diskInfoArray, size_t array_size) {
     if (InitializeWMI() != S_OK) return 0;
 
@@ -42,28 +58,40 @@ size_t GetDiskDriveInfo(DiskDriveInfoWMI *diskInfoArray, size_t array_size) {
         // Extract DeviceID
         hr = pclsObj->lpVtbl->Get(pclsObj, L"DeviceID", 0, &vtProp, 0, 0);
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
-            wcstombs(diskInfoArray[index].DeviceID, vtProp.bstrVal, sizeof(diskInfoArray[index].DeviceID));
+            wmi_bstr_to_multibyte(
+                diskInfoArray[index].DeviceID,
+                sizeof(diskInfoArray[index].DeviceID),
+                vtProp.bstrVal);
         }
         VariantClear(&vtProp);
 
         // Extract Model
         hr = pclsObj->lpVtbl->Get(pclsObj, L"Model", 0, &vtProp, 0, 0);
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
-            wcstombs(diskInfoArray[index].Model, vtProp.bstrVal, sizeof(diskInfoArray[index].Model));
+            wmi_bstr_to_multibyte(
+                diskInfoArray[index].Model,
+                sizeof(diskInfoArray[index].Model),
+                vtProp.bstrVal);
         }
         VariantClear(&vtProp);
 
         // Extract Caption
         hr = pclsObj->lpVtbl->Get(pclsObj, L"Caption", 0, &vtProp, 0, 0);
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
-            wcstombs(diskInfoArray[index].Caption, vtProp.bstrVal, sizeof(diskInfoArray[index].Caption));
+            wmi_bstr_to_multibyte(
+                diskInfoArray[index].Caption,
+                sizeof(diskInfoArray[index].Caption),
+                vtProp.bstrVal);
         }
         VariantClear(&vtProp);
 
         // Extract Name
         hr = pclsObj->lpVtbl->Get(pclsObj, L"Name", 0, &vtProp, 0, 0);
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
-            wcstombs(diskInfoArray[index].Name, vtProp.bstrVal, sizeof(diskInfoArray[index].Name));
+            wmi_bstr_to_multibyte(
+                diskInfoArray[index].Name,
+                sizeof(diskInfoArray[index].Name),
+                vtProp.bstrVal);
         }
         VariantClear(&vtProp);
 
@@ -78,7 +106,7 @@ size_t GetDiskDriveInfo(DiskDriveInfoWMI *diskInfoArray, size_t array_size) {
         hr = pclsObj->lpVtbl->Get(pclsObj, L"Size", 0, &vtProp, 0, 0);
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
             char sizeStr[64];
-            wcstombs(sizeStr, vtProp.bstrVal, sizeof(sizeStr));
+            wmi_bstr_to_multibyte(sizeStr, sizeof(sizeStr), vtProp.bstrVal);
             diskInfoArray[index].Size = strtoull(sizeStr, NULL, 10);
         }
         VariantClear(&vtProp);
@@ -86,7 +114,10 @@ size_t GetDiskDriveInfo(DiskDriveInfoWMI *diskInfoArray, size_t array_size) {
         // Extract Status
         hr = pclsObj->lpVtbl->Get(pclsObj, L"Status", 0, &vtProp, 0, 0);
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
-            wcstombs(diskInfoArray[index].Status, vtProp.bstrVal, sizeof(diskInfoArray[index].Status));
+            wmi_bstr_to_multibyte(
+                diskInfoArray[index].Status,
+                sizeof(diskInfoArray[index].Status),
+                vtProp.bstrVal);
         }
         VariantClear(&vtProp);
 
@@ -107,21 +138,30 @@ size_t GetDiskDriveInfo(DiskDriveInfoWMI *diskInfoArray, size_t array_size) {
         // Extract Manufacturer
         hr = pclsObj->lpVtbl->Get(pclsObj, L"Manufacturer", 0, &vtProp, 0, 0);
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
-            wcstombs(diskInfoArray[index].Manufacturer, vtProp.bstrVal, sizeof(diskInfoArray[index].Manufacturer));
+            wmi_bstr_to_multibyte(
+                diskInfoArray[index].Manufacturer,
+                sizeof(diskInfoArray[index].Manufacturer),
+                vtProp.bstrVal);
         }
         VariantClear(&vtProp);
 
         // Extract InstallDate
         hr = pclsObj->lpVtbl->Get(pclsObj, L"InstallDate", 0, &vtProp, 0, 0);
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
-            wcstombs(diskInfoArray[index].InstallDate, vtProp.bstrVal, sizeof(diskInfoArray[index].InstallDate));
+            wmi_bstr_to_multibyte(
+                diskInfoArray[index].InstallDate,
+                sizeof(diskInfoArray[index].InstallDate),
+                vtProp.bstrVal);
         }
         VariantClear(&vtProp);
 
         // Extract MediaType
         hr = pclsObj->lpVtbl->Get(pclsObj, L"MediaType", 0, &vtProp, 0, 0);
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
-            wcstombs(diskInfoArray[index].MediaType, vtProp.bstrVal, sizeof(diskInfoArray[index].MediaType));
+            wmi_bstr_to_multibyte(
+                diskInfoArray[index].MediaType,
+                sizeof(diskInfoArray[index].MediaType),
+                vtProp.bstrVal);
         }
         VariantClear(&vtProp);
 

--- a/src/libnetdata/parsers/duration-unittest.c
+++ b/src/libnetdata/parsers/duration-unittest.c
@@ -385,6 +385,72 @@ static int test_parse_and_format_roundtrip(void) {
     return failed;
 }
 
+static int test_duration_parse_seconds_int_range(void) {
+    int failed = 0;
+    char max_int_seconds[64];
+    char min_int_seconds[64];
+    char above_max_int_seconds[64];
+    char below_min_int_seconds[64];
+
+    snprintfz(max_int_seconds, sizeof(max_int_seconds), "%ds", INT_MAX);
+    snprintfz(min_int_seconds, sizeof(min_int_seconds), "%ds", INT_MIN);
+#if INT_MAX < INTMAX_MAX
+    snprintfz(above_max_int_seconds, sizeof(above_max_int_seconds), "%" PRIdMAX "s", (intmax_t)INT_MAX + 1);
+#else
+    snprintfz(above_max_int_seconds, sizeof(above_max_int_seconds), "999999999999999999999999999999s");
+#endif
+#if INT_MIN > INTMAX_MIN
+    snprintfz(below_min_int_seconds, sizeof(below_min_int_seconds), "%" PRIdMAX "s", (intmax_t)INT_MIN - 1);
+#else
+    snprintfz(below_min_int_seconds, sizeof(below_min_int_seconds), "-999999999999999999999999999999s");
+#endif
+
+    struct {
+        const char *input;
+        bool should_succeed;
+        int expected;
+        const char *description;
+    } range_tests[] = {
+        { max_int_seconds, true, INT_MAX, "max int seconds succeeds" },
+        { min_int_seconds, true, INT_MIN, "min int seconds succeeds" },
+        { above_max_int_seconds, false, 0, "above max int seconds fails" },
+        { below_min_int_seconds, false, 0, "below min int seconds fails" },
+        { NULL, false, 0, NULL }
+    };
+
+    for (int i = 0; range_tests[i].input != NULL; i++) {
+        int result = 12345;
+        bool success = duration_parse_seconds(range_tests[i].input, &result);
+
+        if (success != range_tests[i].should_succeed) {
+            fprintf(stderr, "FAILED: %s\n", range_tests[i].description);
+            fprintf(stderr, "  Input: '%s'\n", range_tests[i].input);
+            fprintf(stderr, "  Expected to %s but %s\n",
+                    range_tests[i].should_succeed ? "succeed" : "fail",
+                    success ? "succeeded" : "failed");
+            failed++;
+            continue;
+        }
+
+        if (success && result != range_tests[i].expected) {
+            fprintf(stderr, "FAILED: %s\n", range_tests[i].description);
+            fprintf(stderr, "  Input: '%s'\n", range_tests[i].input);
+            fprintf(stderr, "  Expected: %d seconds\n", range_tests[i].expected);
+            fprintf(stderr, "  Got: %d seconds\n", result);
+            failed++;
+        }
+
+        if (!success && result != 12345) {
+            fprintf(stderr, "FAILED: %s modified result on failure\n", range_tests[i].description);
+            fprintf(stderr, "  Input: '%s'\n", range_tests[i].input);
+            fprintf(stderr, "  Got: %d seconds\n", result);
+            failed++;
+        }
+    }
+
+    return failed;
+}
+
 int duration_unittest(void) {
     int passed = 0;
     int failed = 0;
@@ -417,7 +483,15 @@ int duration_unittest(void) {
     } else {
         failed += roundtrip_failed;
     }
-    
+
+    printf("\nRunning int range tests...\n");
+    int range_failed = test_duration_parse_seconds_int_range();
+    if (range_failed == 0) {
+        printf("All int range tests passed\n");
+    } else {
+        failed += range_failed;
+    }
+
     printf("\n===============================================================\n");
     printf("Duration parser tests completed: %d passed, %d failed\n", passed, failed);
     

--- a/src/libnetdata/parsers/duration.c
+++ b/src/libnetdata/parsers/duration.c
@@ -384,6 +384,9 @@ bool duration_parse_seconds(const char *str, int *result) {
     int64_t v;
 
     if(duration_parse_time_t(str, &v)) {
+        if(v < INT_MIN || v > INT_MAX)
+            return false;
+
         *result = (int)v;
         return true;
     }

--- a/src/libnetdata/stacktrace/stacktrace-common.c
+++ b/src/libnetdata/stacktrace/stacktrace-common.c
@@ -219,13 +219,17 @@ void stacktrace_to_buffer(STACKTRACE trace, BUFFER *wb) {
     }
     
     struct stacktrace *st = (struct stacktrace *)trace;
-    
+
     // If we already have cached text representation, use it
-    if (st->text) {
-        buffer_strcat(wb, st->text);
+    spinlock_lock(&stacktrace_lock);
+    const char *text = st->text;
+    spinlock_unlock(&stacktrace_lock);
+
+    if (text) {
+        buffer_strcat(wb, text);
         return;
     }
-    
+
     // Use the implementation-specific function for conversion
     impl_stacktrace_to_buffer(trace, wb);
     

--- a/src/libnetdata/stacktrace/stacktrace-libunwind.c
+++ b/src/libnetdata/stacktrace/stacktrace-libunwind.c
@@ -22,11 +22,8 @@ void stacktrace_flush(void) {
 }
 
 bool stacktrace_capture_is_async_signal_safe(void) {
-#if defined(STATIC_BUILD)
+    // libunwind's default program-header iterator uses dl_iterate_phdr(), which is not async-signal-safe.
     return false;
-#else
-    return true;
-#endif
 }
 
 bool stacktrace_available(void) {
@@ -35,8 +32,6 @@ bool stacktrace_available(void) {
 
 NEVER_INLINE
 void stacktrace_capture(BUFFER *wb) {
-    // this function is async-signal-safe, if the buffer has enough space to hold the stack trace
-
     root_cause_function[0] = '\0';
 
     unw_cursor_t cursor;

--- a/src/libnetdata/statistical/statistical.c
+++ b/src/libnetdata/statistical/statistical.c
@@ -309,7 +309,8 @@ NETDATA_DOUBLE single_exponential_smoothing_reverse(const NETDATA_DOUBLE *series
     const NETDATA_DOUBLE *value = &series[entries -1];
     NETDATA_DOUBLE level = (1.0 - alpha) * (*value);
 
-    for(value++ ; value >= series; value--) {
+    while(value > series) {
+        value--;
         if(likely(netdata_double_isnumber(*value)))
             level = alpha * (*value) + (1.0 - alpha) * level;
     }

--- a/src/streaming/stream-circular-buffer.c
+++ b/src/streaming/stream-circular-buffer.c
@@ -113,8 +113,13 @@ bool stream_circular_buffer_add_unsafe(
     scb->stats.bytes_uncompressed += bytes_uncompressed;
     scb->stats.bytes_sent_by_type[type] += bytes_actual;
 
-    if(unlikely(autoscale && cbuffer_available_size_unsafe(scb->cb) < bytes_actual))
-        stream_circular_buffer_set_max_size_unsafe(scb, scb->cb->max_size * 2, true);
+    if(unlikely(autoscale && cbuffer_available_size_unsafe(scb->cb) < bytes_actual)) {
+        size_t max_size = scb->cb->max_size;
+        max_size = (max_size > SIZE_MAX / 2) ? SIZE_MAX : max_size * 2;
+
+        if(max_size > scb->cb->max_size)
+            stream_circular_buffer_set_max_size_unsafe(scb, max_size, true);
+    }
 
     if(unlikely(cbuffer_add_unsafe(scb->cb, data, bytes_actual) != 0))
         return false;

--- a/src/web/api/formatters/charts2json.c
+++ b/src/web/api/formatters/charts2json.c
@@ -6,34 +6,46 @@
 
 const char* get_release_channel() {
     static int use_stable = -1;
+    static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
-    if (use_stable == -1) {
-        char filename[FILENAME_MAX + 1];
-        snprintfz(filename, FILENAME_MAX, "%s/.environment", netdata_configured_user_config_dir);
-        procfile *ff = procfile_open(filename, "=", PROCFILE_FLAG_NO_ERROR_ON_FILE_IO);
-        if (ff) {
-            procfile_set_quotes(ff, "'\"");
-            ff = procfile_readall(ff);
+    int stable = __atomic_load_n(&use_stable, __ATOMIC_ACQUIRE);
+
+    if (unlikely(stable == -1)) {
+        spinlock_lock(&spinlock);
+
+        stable = __atomic_load_n(&use_stable, __ATOMIC_RELAXED);
+        if (stable == -1) {
+            char filename[FILENAME_MAX + 1];
+            snprintfz(filename, FILENAME_MAX, "%s/.environment", netdata_configured_user_config_dir);
+            procfile *ff = procfile_open(filename, "=", PROCFILE_FLAG_NO_ERROR_ON_FILE_IO);
             if (ff) {
-                unsigned int i;
-                for (i = 0; i < procfile_lines(ff); i++) {
-                    if (!procfile_linewords(ff, i))
-                        continue;
-                    if (!strcmp(procfile_lineword(ff, i, 0), "RELEASE_CHANNEL")) {
-                        if (!strcmp(procfile_lineword(ff, i, 1), "stable"))
-                            use_stable = 1;
-                        else if (!strcmp(procfile_lineword(ff, i, 1), "nightly"))
-                            use_stable = 0;
-                        break;
+                procfile_set_quotes(ff, "'\"");
+                ff = procfile_readall(ff);
+                if (ff) {
+                    unsigned int i;
+                    for (i = 0; i < procfile_lines(ff); i++) {
+                        if (!procfile_linewords(ff, i))
+                            continue;
+                        if (!strcmp(procfile_lineword(ff, i, 0), "RELEASE_CHANNEL")) {
+                            if (!strcmp(procfile_lineword(ff, i, 1), "stable"))
+                                stable = 1;
+                            else if (!strcmp(procfile_lineword(ff, i, 1), "nightly"))
+                                stable = 0;
+                            break;
+                        }
                     }
+                    procfile_close(ff);
                 }
-                procfile_close(ff);
             }
+            if (stable == -1)
+                stable = strchr(NETDATA_VERSION, '-') ? 0 : 1;
+
+            __atomic_store_n(&use_stable, stable, __ATOMIC_RELEASE);
         }
-        if (use_stable == -1)
-            use_stable = strchr(NETDATA_VERSION, '-') ? 0 : 1;
+
+        spinlock_unlock(&spinlock);
     }
-    return (use_stable)?"stable":"nightly";
+    return stable ? "stable" : "nightly";
 }
 
 void charts2json(RRDHOST *host, BUFFER *wb) {

--- a/src/web/api/v3/api_v3_settings.c
+++ b/src/web/api/v3/api_v3_settings.c
@@ -277,6 +277,12 @@ int api_v3_settings(RRDHOST *host, struct web_client *w, char *url) {
                     "Settings API PUT action requires a payload.",
                     HTTP_RESP_BAD_REQUEST);
 
+            if(buffer_strlen(w->payload) > MAX_SETTINGS_SIZE_BYTES)
+                return rrd_call_function_error(
+                    w->response.data,
+                    "Settings API PUT payload exceeds the maximum allowed size.",
+                    HTTP_RESP_CONTENT_TOO_LONG);
+
             return settings_put(w, file);
 
         default:

--- a/src/web/mcp/adapters/mcp-websocket.c
+++ b/src/web/mcp/adapters/mcp-websocket.c
@@ -18,6 +18,16 @@ MCP_CLIENT *mcp_websocket_get_context(struct websocket_server_client *wsc) {
     return (MCP_CLIENT *)wsc->user_data;
 }
 
+static void mcp_websocket_release_context(struct websocket_server_client *wsc) {
+    MCP_CLIENT *ctx = mcp_websocket_get_context(wsc);
+    if (!ctx)
+        return;
+
+    // Detach before freeing so repeated lifecycle callbacks never observe a stale pointer.
+    mcp_websocket_set_context(wsc, NULL);
+    mcp_free_client(ctx);
+}
+
 // Create a response context for a WebSocket client
 static MCP_CLIENT *mcp_websocket_create_context(struct websocket_server_client *wsc) {
     if (!wsc) return NULL;
@@ -163,12 +173,7 @@ void mcp_websocket_on_close(struct websocket_server_client *wsc, WEBSOCKET_CLOSE
     
     websocket_debug(wsc, "MCP client closing (code: %d, reason: %s)", code, reason ? reason : "none");
     
-    // Clean up the MCP context
-    MCP_CLIENT *ctx = mcp_websocket_get_context(wsc);
-    if (ctx) {
-        mcp_free_client(ctx);
-        mcp_websocket_set_context(wsc, NULL);
-    }
+    mcp_websocket_release_context(wsc);
 }
 
 // WebSocket disconnect handler for MCP
@@ -177,12 +182,7 @@ void mcp_websocket_on_disconnect(struct websocket_server_client *wsc) {
     
     websocket_debug(wsc, "MCP client disconnected");
     
-    // Clean up the MCP context
-    MCP_CLIENT *ctx = mcp_websocket_get_context(wsc);
-    if (ctx) {
-        mcp_free_client(ctx);
-        mcp_websocket_set_context(wsc, NULL);
-    }
+    mcp_websocket_release_context(wsc);
 }
 
 // Register WebSocket callbacks for MCP


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens safety and correctness across config parsing, JSON handling, Windows WMI, streaming buffers, and concurrency. Adds bounds checks, proper locking, and focused tests; enforces settings payload limits and fixes boolean key propagation.

- **Bug Fixes**
  - Config parsing: reject empty/overlong `--config` in log2journal; reject out‑of‑int‑range durations and negative health repeats.
  - JSON: boolean callbacks now carry their key names; adds unit test to catch regressions.
  - Windows WMI: convert BSTRs to UTF‑8 with bounded writes to preserve non‑ASCII disk metadata.
  - Streaming/statistics: guard autoscale against size_t overflow; fix reverse smoothing loop bounds.
  - Concurrency: lock `completion_reset`, synchronize stacktrace cached text reads, and make release channel cache thread‑safe.
  - API: cap settings PUT payloads (HTTP 413 on oversize).
  - MCP websocket: clear `user_data` before freeing client and centralize cleanup.
  - Hash map: enforce `uint8` value type in lookups; adds regression test.

<sup>Written for commit db31341b9dc7fdaf7e331bf679d3060f8ea2a1aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

