### PR TITLE
Netdata fixes part 43

### DIFF
--- a/src/aclk/aclk_proxy.c
+++ b/src/aclk/aclk_proxy.c
@@ -88,6 +88,17 @@ void aclk_proxy_get_display(char *buf, size_t buflen, const char *proxy, ACLK_PR
 }
 
 static const char *proxy_source = NULL;
+static netdata_mutex_t aclk_proxy_mutex;
+
+static void __attribute__((constructor)) aclk_proxy_mutex_init(void)
+{
+    netdata_mutex_init(&aclk_proxy_mutex);
+}
+
+static void __attribute__((destructor)) aclk_proxy_mutex_destroy(void)
+{
+    netdata_mutex_destroy(&aclk_proxy_mutex);
+}
 
 static inline int check_environment_proxy(const char **proxy, ACLK_PROXY_TYPE *type)
 {
@@ -193,6 +204,8 @@ const char *aclk_get_proxy(ACLK_PROXY_TYPE *return_type, bool for_logging)
     static const char *safe_proxy = NULL;
     static ACLK_PROXY_TYPE proxy_type = PROXY_NOT_SET;
 
+    netdata_mutex_lock(&aclk_proxy_mutex);
+
     if (proxy_type == PROXY_NOT_SET) {
         proxy = aclk_lws_wss_get_proxy_setting(&proxy_type);
         char *log = NULL;
@@ -205,7 +218,12 @@ const char *aclk_get_proxy(ACLK_PROXY_TYPE *return_type, bool for_logging)
 
     if (return_type)
         *return_type = proxy_type;
-    return for_logging ? safe_proxy : proxy;
+
+    const char *ret = for_logging ? safe_proxy : proxy;
+
+    netdata_mutex_unlock(&aclk_proxy_mutex);
+
+    return ret;
 }
 
 const char *aclk_get_proxy_source(void) {

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -1845,7 +1845,7 @@ static int parse_puback_varhdr(struct mqtt_ng_client *client)
 static int parse_suback_varhdr(struct mqtt_ng_client *client)
 {
     int rc;
-    size_t avail;
+    size_t avail, stored;
     struct mqtt_ng_parser *parser = &client->parser;
     struct mqtt_suback *suback = &client->parser.mqtt_packet.suback;
     switch (parser->varhdr_state) {
@@ -1873,7 +1873,11 @@ static int parse_suback_varhdr(struct mqtt_ng_client *client)
             if (avail < 1)
                 return MQTT_NG_CLIENT_NEED_MORE_BYTES;
 
-            suback->reason_codes_pending -= rbuf_pop(parser->received_data, (char*)suback->reason_codes, MIN(suback->reason_codes_pending, avail));
+            stored = suback->reason_code_count - suback->reason_codes_pending;
+            suback->reason_codes_pending -= rbuf_pop(
+                parser->received_data,
+                (char *)&suback->reason_codes[stored],
+                MIN(suback->reason_codes_pending, avail));
 
             if (!suback->reason_codes_pending)
                 return MQTT_NG_CLIENT_PARSE_DONE;
@@ -2399,6 +2403,68 @@ static int mqtt_ng_unittest_reset_after_partial_publish(void)
     return errors;
 }
 
+static int mqtt_ng_unittest_partial_suback_reason_codes(void)
+{
+    int errors = 0;
+    rbuf_t input = rbuf_create(128, 128);
+    struct mqtt_ng_init settings = {
+        .data_in = input,
+        .data_out_fnc = NULL,
+        .user_ctx = NULL,
+        .connack_callback = NULL,
+        .puback_callback = NULL,
+        .msg_callback = NULL,
+    };
+    struct mqtt_ng_client *client = mqtt_ng_init(&settings);
+
+    const char partial_suback[] = {
+        (char)(MQTT_CPT_SUBACK << 4), 5,
+        0, 1,
+        0,
+        0,
+    };
+    const char remaining_suback[] = {
+        (char)0x80,
+    };
+
+    MQTT_NG_TEST(client != NULL, "mqtt_ng_init succeeds for SUBACK parser test");
+    if (!client) {
+        rbuf_free(input);
+        return errors;
+    }
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, partial_suback, sizeof(partial_suback)),
+                 "push partial SUBACK");
+
+    int rc = handle_incoming_traffic(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_NEED_MORE_BYTES, "partial SUBACK needs more bytes");
+    MQTT_NG_TEST(client->parser.state == MQTT_PARSE_VARIABLE_HEADER, "partial SUBACK stays in variable-header parser");
+    MQTT_NG_TEST(client->parser.varhdr_state == MQTT_PARSE_REASONCODES, "partial SUBACK waits for reason codes");
+    MQTT_NG_TEST(client->parser.mqtt_packet.suback.reason_code_count == 2, "partial SUBACK reason-code count");
+    MQTT_NG_TEST(client->parser.mqtt_packet.suback.reason_codes_pending == 1, "partial SUBACK pending reason code");
+    uint8_t *reason_codes = client->parser.mqtt_packet.suback.reason_codes;
+    MQTT_NG_TEST(reason_codes != NULL, "partial SUBACK owns reason-code buffer");
+    if (reason_codes)
+        MQTT_NG_TEST(reason_codes[0] == 0, "partial SUBACK stores first reason code");
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, remaining_suback, sizeof(remaining_suback)),
+                 "push remaining SUBACK reason code");
+
+    rc = parse_suback_varhdr(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_PARSE_DONE, "fragmented SUBACK reason codes parse done");
+    if (reason_codes) {
+        MQTT_NG_TEST(reason_codes[0] == 0, "fragmented SUBACK preserves first reason code");
+        MQTT_NG_TEST(reason_codes[1] == 0x80, "fragmented SUBACK appends second reason code");
+    }
+    MQTT_NG_TEST(client->parser.mqtt_packet.suback.reason_codes_pending == 0, "fragmented SUBACK consumes all reason codes");
+
+    freez(client->parser.mqtt_packet.suback.reason_codes);
+    client->parser.mqtt_packet.suback.reason_codes = NULL;
+    mqtt_ng_destroy(client);
+    rbuf_free(input);
+    return errors;
+}
+
 int mqtt_ng_unittest(void)
 {
     int errors = 0;
@@ -2406,6 +2472,7 @@ int mqtt_ng_unittest(void)
     fprintf(stderr, "\nrunning mqtt_ng unittest\n");
 
     errors += mqtt_ng_unittest_reset_after_partial_publish();
+    errors += mqtt_ng_unittest_partial_suback_reason_codes();
 
     if (errors)
         fprintf(stderr, "mqtt_ng unittest: %d ERROR(S)\n", errors);

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -146,6 +146,7 @@ struct mqtt_properties_parser_ctx {
     struct mqtt_property *tail;
     uint32_t properties_length;
     uint32_t vbi_length;
+    size_t max_bytes;
     struct mqtt_vbi_parser_ctx vbi_parser_ctx;
     size_t bytes_consumed;
     int str_idx;
@@ -1496,6 +1497,28 @@ int mqtt_ng_ping(struct mqtt_ng_client *client)
     if (rbuf_bytes_available(buf) < (x))                                                                               \
         return MQTT_NG_CLIENT_NEED_MORE_BYTES;
 
+static int mqtt_properties_read_check(struct mqtt_properties_parser_ctx *ctx, rbuf_t data, size_t bytes)
+{
+    size_t consumed = ctx->bytes_consumed;
+    if (ctx->state == PROPERTIES_LENGTH || ctx->state == PROPERTY_TYPE_VBI)
+        consumed += ctx->vbi_parser_ctx.bytes;
+
+    if (consumed > ctx->max_bytes || bytes > ctx->max_bytes - consumed) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MQTT properties exceed packet boundary.");
+        return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+    }
+    if (rbuf_bytes_available(data) < bytes)
+        return MQTT_NG_CLIENT_NEED_MORE_BYTES;
+
+    return MQTT_NG_CLIENT_PARSE_DONE;
+}
+
+#define PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, x) do {                                                              \
+        int read_check_rc = mqtt_properties_read_check((ctx), (data), (x));                                            \
+        if (read_check_rc != MQTT_NG_CLIENT_PARSE_DONE)                                                               \
+            return read_check_rc;                                                                                     \
+    } while(0)
+
 #define vbi_parser_reset_ctx(ctx) memset(ctx, 0, sizeof(struct mqtt_vbi_parser_ctx))
 
 static int vbi_parser_parse(struct mqtt_vbi_parser_ctx *ctx, rbuf_t data)
@@ -1537,6 +1560,7 @@ static void mqtt_properties_parser_ctx_reset(struct mqtt_properties_parser_ctx *
     ctx->tail = NULL;
     ctx->properties_length = 0;
     ctx->bytes_consumed = 0;
+    ctx->max_bytes = SIZE_MAX;
     vbi_parser_reset_ctx(&ctx->vbi_parser_ctx);
 }
 
@@ -1628,11 +1652,16 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
     int rc;
     switch (ctx->state) {
         case PROPERTIES_LENGTH:
+            PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, 1);
             rc = vbi_parser_parse(&ctx->vbi_parser_ctx, data);
             if (rc == MQTT_NG_CLIENT_PARSE_DONE) {
                 ctx->properties_length = ctx->vbi_parser_ctx.result;
                 ctx->bytes_consumed += ctx->vbi_parser_ctx.bytes;
                 ctx->vbi_length = ctx->vbi_parser_ctx.bytes;
+                if (ctx->vbi_length > ctx->max_bytes || ctx->properties_length > ctx->max_bytes - ctx->vbi_length) {
+                    nd_log(NDLS_DAEMON, NDLP_ERR, "MQTT properties exceed packet boundary.");
+                    return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+                }
                 if (!ctx->properties_length)
                     return MQTT_NG_CLIENT_PARSE_DONE;
                 ctx->state = PROPERTY_CREATE;
@@ -1640,7 +1669,7 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
             }
             return rc;
         case PROPERTY_CREATE:
-            BUF_READ_CHECK_AT_LEAST(data, 1)
+            PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, 1);
             struct mqtt_property *prop = callocz(1, sizeof(struct mqtt_property));
             if (ctx->head == NULL) {
                 ctx->head = prop;
@@ -1682,7 +1711,7 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
             }
             break;
         case PROPERTY_TYPE_STR_BIN_LEN:
-            BUF_READ_CHECK_AT_LEAST(data, sizeof(uint16_t))
+            PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, sizeof(uint16_t));
             rbuf_pop(data, (char*)&ctx->tail->bindata_len, sizeof(uint16_t));
             ctx->tail->bindata_len = be16toh(ctx->tail->bindata_len);
             ctx->bytes_consumed += 2;
@@ -1700,7 +1729,7 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
             }
             break;
         case PROPERTY_TYPE_STR:
-            BUF_READ_CHECK_AT_LEAST(data, ctx->tail->bindata_len)
+            PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, ctx->tail->bindata_len);
             ctx->tail->data.strings[ctx->str_idx] = mallocz(ctx->tail->bindata_len + 1);
             rbuf_pop(data, ctx->tail->data.strings[ctx->str_idx], ctx->tail->bindata_len);
             ctx->tail->data.strings[ctx->str_idx][ctx->tail->bindata_len] = 0;
@@ -1713,13 +1742,14 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
             ctx->state = PROPERTY_NEXT;
             break;
         case PROPERTY_TYPE_BIN:
-            BUF_READ_CHECK_AT_LEAST(data, ctx->tail->bindata_len)
+            PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, ctx->tail->bindata_len);
             ctx->tail->data.bindata = mallocz(ctx->tail->bindata_len);
             rbuf_pop(data, ctx->tail->data.bindata, ctx->tail->bindata_len);
             ctx->bytes_consumed += ctx->tail->bindata_len;
             ctx->state = PROPERTY_NEXT;
             break;
         case PROPERTY_TYPE_VBI:
+            PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, 1);
             rc = vbi_parser_parse(&ctx->vbi_parser_ctx, data);
             if (rc == MQTT_NG_CLIENT_PARSE_DONE) {
                 ctx->tail->data.uint32 = ctx->vbi_parser_ctx.result;
@@ -1729,20 +1759,20 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
             }
             return rc;
         case PROPERTY_TYPE_UINT8:
-            BUF_READ_CHECK_AT_LEAST(data, sizeof(uint8_t))
+            PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, sizeof(uint8_t));
             rbuf_pop(data, (char*)&ctx->tail->data.uint8, sizeof(uint8_t));
             ctx->bytes_consumed += sizeof(uint8_t);
             ctx->state = PROPERTY_NEXT;
             break;
         case PROPERTY_TYPE_UINT32:
-            BUF_READ_CHECK_AT_LEAST(data, sizeof(uint32_t))
+            PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, sizeof(uint32_t));
             rbuf_pop(data, (char*)&ctx->tail->data.uint32, sizeof(uint32_t));
             ctx->tail->data.uint32 = be32toh(ctx->tail->data.uint32);
             ctx->bytes_consumed += sizeof(uint32_t);
             ctx->state = PROPERTY_NEXT;
             break;
         case PROPERTY_TYPE_UINT16:
-            BUF_READ_CHECK_AT_LEAST(data, sizeof(uint16_t))
+            PROPERTIES_READ_CHECK_AT_LEAST(ctx, data, sizeof(uint16_t));
             rbuf_pop(data, (char*)&ctx->tail->data.uint16, sizeof(uint16_t));
             ctx->tail->data.uint16 = be16toh(ctx->tail->data.uint16);
             ctx->bytes_consumed += sizeof(uint16_t);
@@ -1752,7 +1782,11 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
             if (ctx->properties_length > ctx->bytes_consumed - ctx->vbi_length) {
                 ctx->state = PROPERTY_CREATE;
                 break;
-            } else
+            }
+            if (ctx->properties_length < ctx->bytes_consumed - ctx->vbi_length) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "MQTT property exceeds properties length.");
+                return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+            }
             return MQTT_NG_CLIENT_PARSE_DONE;
     }
     return MQTT_NG_CLIENT_OK_CALL_AGAIN;
@@ -1760,17 +1794,30 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
 
 static int parse_connack_varhdr(struct mqtt_ng_client *client)
 {
+    int rc;
     struct mqtt_ng_parser *parser = &client->parser;
     switch (parser->varhdr_state) {
         case MQTT_PARSE_VARHDR_INITIAL:
+            if (parser->mqtt_fixed_hdr_remaining_length < 3) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "Error parsing CONNACK message");
+                return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+            }
             BUF_READ_CHECK_AT_LEAST(parser->received_data, 2)
             rbuf_pop(parser->received_data, (char*)&parser->mqtt_packet.connack.flags, 1);
             rbuf_pop(parser->received_data, (char*)&parser->mqtt_packet.connack.reason_code, 1);
             parser->varhdr_state = MQTT_PARSE_VARHDR_PROPS;
             mqtt_properties_parser_ctx_reset(&parser->properties_parser);
+            parser->properties_parser.max_bytes = parser->mqtt_fixed_hdr_remaining_length - 2;
             break;
         case MQTT_PARSE_VARHDR_PROPS:
-            return parse_properties_array(&parser->properties_parser, parser->received_data);
+            rc = parse_properties_array(&parser->properties_parser, parser->received_data);
+            if (rc != MQTT_NG_CLIENT_PARSE_DONE)
+                return rc;
+            if (parser->properties_parser.bytes_consumed != parser->properties_parser.max_bytes) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "Error parsing CONNACK message");
+                return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+            }
+            return MQTT_NG_CLIENT_PARSE_DONE;
         default:
             nd_log(NDLS_DAEMON, NDLP_ERR, "invalid state for connack varhdr parser");
             return MQTT_NG_CLIENT_INTERNAL_ERROR;
@@ -1780,6 +1827,7 @@ static int parse_connack_varhdr(struct mqtt_ng_client *client)
 
 static int parse_disconnect_varhdr(struct mqtt_ng_client *client)
 {
+    int rc;
     struct mqtt_ng_parser *parser = &client->parser;
     switch (parser->varhdr_state) {
         case MQTT_PARSE_VARHDR_INITIAL:
@@ -1794,9 +1842,17 @@ static int parse_disconnect_varhdr(struct mqtt_ng_client *client)
                 return MQTT_NG_CLIENT_PARSE_DONE;
             parser->varhdr_state = MQTT_PARSE_VARHDR_PROPS;
             mqtt_properties_parser_ctx_reset(&parser->properties_parser);
+            parser->properties_parser.max_bytes = parser->mqtt_fixed_hdr_remaining_length - 1;
             break;
         case MQTT_PARSE_VARHDR_PROPS:
-            return parse_properties_array(&parser->properties_parser, parser->received_data);
+            rc = parse_properties_array(&parser->properties_parser, parser->received_data);
+            if (rc != MQTT_NG_CLIENT_PARSE_DONE)
+                return rc;
+            if (parser->properties_parser.bytes_consumed != parser->properties_parser.max_bytes) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "Error parsing DISCONNECT message");
+                return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+            }
+            return MQTT_NG_CLIENT_PARSE_DONE;
         default:
             nd_log(NDLS_DAEMON, NDLP_ERR, "invalid state for connack varhdr parser");
             return MQTT_NG_CLIENT_INTERNAL_ERROR;
@@ -1806,9 +1862,14 @@ static int parse_disconnect_varhdr(struct mqtt_ng_client *client)
 
 static int parse_puback_varhdr(struct mqtt_ng_client *client)
 {
+    int rc;
     struct mqtt_ng_parser *parser = &client->parser;
     switch (parser->varhdr_state) {
         case MQTT_PARSE_VARHDR_INITIAL:
+            if (parser->mqtt_fixed_hdr_remaining_length < 2) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "Error parsing PUBACK message");
+                return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+            }
             BUF_READ_CHECK_AT_LEAST(parser->received_data, 2)
             rbuf_pop(parser->received_data, (char*)&parser->mqtt_packet.puback.packet_id, 2);
             parser->mqtt_packet.puback.packet_id = be16toh(parser->mqtt_packet.puback.packet_id);
@@ -1832,9 +1893,17 @@ static int parse_puback_varhdr(struct mqtt_ng_client *client)
 
             parser->varhdr_state = MQTT_PARSE_VARHDR_PROPS;
             mqtt_properties_parser_ctx_reset(&parser->properties_parser);
+            parser->properties_parser.max_bytes = parser->mqtt_fixed_hdr_remaining_length - 3;
             /* FALLTHROUGH */
         case MQTT_PARSE_VARHDR_PROPS:
-            return parse_properties_array(&parser->properties_parser, parser->received_data);
+            rc = parse_properties_array(&parser->properties_parser, parser->received_data);
+            if (rc != MQTT_NG_CLIENT_PARSE_DONE)
+                return rc;
+            if (parser->properties_parser.bytes_consumed != parser->properties_parser.max_bytes) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "Error parsing PUBACK message");
+                return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+            }
+            return MQTT_NG_CLIENT_PARSE_DONE;
         default:
             nd_log(NDLS_DAEMON, NDLP_ERR, "invalid state for puback varhdr parser");
             return MQTT_NG_CLIENT_INTERNAL_ERROR;
@@ -1851,19 +1920,28 @@ static int parse_suback_varhdr(struct mqtt_ng_client *client)
     switch (parser->varhdr_state) {
         case MQTT_PARSE_VARHDR_INITIAL:
             suback->reason_codes = NULL;
+            if (parser->mqtt_fixed_hdr_remaining_length < 4) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "Error parsing SUBACK message");
+                return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+            }
             BUF_READ_CHECK_AT_LEAST(parser->received_data, 2)
             rbuf_pop(parser->received_data, (char*)&suback->packet_id, 2);
             suback->packet_id = be16toh(suback->packet_id);
             parser->varhdr_state = MQTT_PARSE_VARHDR_PROPS;
             parser->mqtt_parsed_len = 2;
             mqtt_properties_parser_ctx_reset(&parser->properties_parser);
+            parser->properties_parser.max_bytes = parser->mqtt_fixed_hdr_remaining_length - parser->mqtt_parsed_len - 1;
             /* FALLTHROUGH */
         case MQTT_PARSE_VARHDR_PROPS:
-           rc = parse_properties_array(&parser->properties_parser, parser->received_data);
+            rc = parse_properties_array(&parser->properties_parser, parser->received_data);
             if (rc != MQTT_NG_CLIENT_PARSE_DONE) 
                 return rc;
             parser->mqtt_parsed_len += parser->properties_parser.bytes_consumed;
             suback->reason_code_count = parser->mqtt_fixed_hdr_remaining_length - parser->mqtt_parsed_len;
+            if (!suback->reason_code_count) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "Error parsing SUBACK message");
+                return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+            }
             suback->reason_codes = callocz(suback->reason_code_count, sizeof(*suback->reason_codes));
             suback->reason_codes_pending = suback->reason_code_count;
             parser->varhdr_state = MQTT_PARSE_REASONCODES;
@@ -1904,6 +1982,10 @@ static int parse_publish_varhdr(struct mqtt_ng_client *client)
             rbuf_pop(parser->received_data, (char*)&publish->topic_len, 2);
             publish->topic_len = be16toh(publish->topic_len);
             parser->mqtt_parsed_len = 2;
+            if (parser->mqtt_fixed_hdr_remaining_length < parser->mqtt_parsed_len + publish->topic_len + (publish->qos ? 2 : 0) + 1) {
+                nd_log(NDLS_DAEMON, NDLP_ERR, "Error parsing PUBLISH message");
+                return MQTT_NG_CLIENT_PROTOCOL_ERROR;
+            }
             if (!publish->topic_len) {
                 parser->varhdr_state = MQTT_PARSE_VARHDR_POST_TOPICNAME;
                 break;
@@ -1934,6 +2016,7 @@ static int parse_publish_varhdr(struct mqtt_ng_client *client)
             parser->mqtt_parsed_len += 2;
             /* FALLTHROUGH */
         case MQTT_PARSE_VARHDR_PROPS:
+            parser->properties_parser.max_bytes = parser->mqtt_fixed_hdr_remaining_length - parser->mqtt_parsed_len;
             rc = parse_properties_array(&parser->properties_parser, parser->received_data);
             if (rc != MQTT_NG_CLIENT_PARSE_DONE) 
                 return rc;
@@ -2340,6 +2423,41 @@ static int mqtt_ng_unittest_push_bytes(rbuf_t buffer, const char *data, size_t l
         }                                                                      \
     } while(0)
 
+static int mqtt_ng_unittest_reject_malformed_properties_packet(
+    const char *packet_name,
+    const char *packet,
+    size_t packet_len,
+    size_t expected_unread)
+{
+    int errors = 0;
+    rbuf_t input = rbuf_create(128, 128);
+    struct mqtt_ng_init settings = {
+        .data_in = input,
+        .data_out_fnc = NULL,
+        .user_ctx = NULL,
+        .connack_callback = NULL,
+        .puback_callback = NULL,
+        .msg_callback = NULL,
+    };
+    struct mqtt_ng_client *client = mqtt_ng_init(&settings);
+
+    MQTT_NG_TEST(client != NULL, packet_name);
+    if (!client) {
+        rbuf_free(input);
+        return errors;
+    }
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, packet, packet_len), packet_name);
+
+    int rc = handle_incoming_traffic(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_PROTOCOL_ERROR, packet_name);
+    MQTT_NG_TEST(rbuf_bytes_available(input) == expected_unread, packet_name);
+
+    mqtt_ng_destroy(client);
+    rbuf_free(input);
+    return errors;
+}
+
 static int mqtt_ng_unittest_reset_after_partial_publish(void)
 {
     int errors = 0;
@@ -2465,6 +2583,94 @@ static int mqtt_ng_unittest_partial_suback_reason_codes(void)
     return errors;
 }
 
+static int mqtt_ng_unittest_malformed_suback_properties_length(void)
+{
+    int errors = 0;
+    rbuf_t input = rbuf_create(128, 128);
+    struct mqtt_ng_init settings = {
+        .data_in = input,
+        .data_out_fnc = NULL,
+        .user_ctx = NULL,
+        .connack_callback = NULL,
+        .puback_callback = NULL,
+        .msg_callback = NULL,
+    };
+    struct mqtt_ng_client *client = mqtt_ng_init(&settings);
+
+    const char malformed_suback[] = {
+        (char)(MQTT_CPT_SUBACK << 4), 4,
+        0, 1,
+        2,
+        MQTT_PROP_REQ_PROBLEM_INFO,
+        (char)(MQTT_CPT_PINGRESP << 4), 0,
+    };
+
+    MQTT_NG_TEST(client != NULL, "mqtt_ng_init succeeds for malformed SUBACK parser test");
+    if (!client) {
+        rbuf_free(input);
+        return errors;
+    }
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, malformed_suback, sizeof(malformed_suback)),
+                 "push malformed SUBACK");
+
+    int rc = handle_incoming_traffic(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_PROTOCOL_ERROR, "malformed SUBACK properties length is rejected");
+    MQTT_NG_TEST(client->parser.mqtt_packet.suback.reason_codes == NULL,
+                 "malformed SUBACK does not allocate reason codes");
+    MQTT_NG_TEST(rbuf_bytes_available(input) == 3,
+                 "malformed SUBACK leaves following bytes unread");
+
+    mqtt_ng_destroy(client);
+    rbuf_free(input);
+    return errors;
+}
+
+static int mqtt_ng_unittest_malformed_ack_properties_length(void)
+{
+    int errors = 0;
+    const char malformed_connack[] = {
+        (char)(MQTT_CPT_CONNACK << 4), 4,
+        0, 0,
+        1,
+        MQTT_PROP_REASON_STR,
+        (char)(MQTT_CPT_PINGRESP << 4), 0,
+    };
+    const char malformed_disconnect[] = {
+        (char)(MQTT_CPT_DISCONNECT << 4), 3,
+        0,
+        1,
+        MQTT_PROP_REASON_STR,
+        (char)(MQTT_CPT_PINGRESP << 4), 0,
+    };
+    const char malformed_puback[] = {
+        (char)(MQTT_CPT_PUBACK << 4), 5,
+        0, 1,
+        0,
+        1,
+        MQTT_PROP_REASON_STR,
+        (char)(MQTT_CPT_PINGRESP << 4), 0,
+    };
+
+    errors += mqtt_ng_unittest_reject_malformed_properties_packet(
+        "malformed CONNACK properties do not consume following packet",
+        malformed_connack,
+        sizeof(malformed_connack),
+        2);
+    errors += mqtt_ng_unittest_reject_malformed_properties_packet(
+        "malformed DISCONNECT properties do not consume following packet",
+        malformed_disconnect,
+        sizeof(malformed_disconnect),
+        2);
+    errors += mqtt_ng_unittest_reject_malformed_properties_packet(
+        "malformed PUBACK properties do not consume following packet",
+        malformed_puback,
+        sizeof(malformed_puback),
+        2);
+
+    return errors;
+}
+
 int mqtt_ng_unittest(void)
 {
     int errors = 0;
@@ -2473,6 +2679,8 @@ int mqtt_ng_unittest(void)
 
     errors += mqtt_ng_unittest_reset_after_partial_publish();
     errors += mqtt_ng_unittest_partial_suback_reason_codes();
+    errors += mqtt_ng_unittest_malformed_suback_properties_length();
+    errors += mqtt_ng_unittest_malformed_ack_properties_length();
 
     if (errors)
         fprintf(stderr, "mqtt_ng unittest: %d ERROR(S)\n", errors);

--- a/src/aclk/mqtt_websockets/ws_client-unittest.c
+++ b/src/aclk/mqtt_websockets/ws_client-unittest.c
@@ -205,8 +205,10 @@ static int ws_client_unittest_cap_hit(void)
 static int ws_client_unittest_reset_frees_partial_close_reason(void)
 {
     int errors = 0;
-    char frame[4];
-    size_t header_len = ws_client_unittest_control_header(frame, WS_OP_CONNECTION_CLOSE, 5);
+    const size_t reason_len = 3;
+    const size_t close_payload_len = sizeof(uint16_t) + reason_len;
+    char frame[2 + sizeof(uint16_t)];
+    size_t header_len = ws_client_unittest_control_header(frame, WS_OP_CONNECTION_CLOSE, close_payload_len);
     uint16_t close_code = htobe16(1000);
     memcpy(&frame[header_len], &close_code, sizeof(close_code));
 
@@ -227,6 +229,10 @@ static int ws_client_unittest_reset_frees_partial_close_reason(void)
 
     WS_TEST(ret == WS_CLIENT_NEED_MORE_BYTES, "partial close reason needs more bytes");
     WS_TEST(client.rx.specific_data.op_close.reason != NULL, "partial close reason allocated");
+#ifdef NETDATA_TRACE_ALLOCATIONS
+    WS_TEST(mallocz_usable_size(client.rx.specific_data.op_close.reason) == reason_len + 1,
+            "partial close reason buffer fits reason plus terminator");
+#endif
 
     ws_client_reset(&client);
 

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -609,9 +609,10 @@ int ws_client_process_rx_ws(ws_client *client)
             }
             client->rx.parse_state = WS_PAYLOAD_CONNECTION_CLOSE_MSG;
             break;
-        case WS_PAYLOAD_CONNECTION_CLOSE_MSG:
+        case WS_PAYLOAD_CONNECTION_CLOSE_MSG: {
+            size_t close_reason_length = (size_t)(client->rx.payload_length - sizeof(uint16_t));
             if (!client->rx.specific_data.op_close.reason)
-                client->rx.specific_data.op_close.reason = mallocz(client->rx.payload_length + 1);
+                client->rx.specific_data.op_close.reason = mallocz(close_reason_length + 1);
 
             while (client->rx.payload_processed < client->rx.payload_length) {
                 if (!rbuf_bytes_available(client->buf_read))
@@ -620,7 +621,7 @@ int ws_client_process_rx_ws(ws_client *client)
                                                          &client->rx.specific_data.op_close.reason[client->rx.payload_processed - sizeof(uint16_t)],
                                                          client->rx.payload_length - client->rx.payload_processed);
             }
-            client->rx.specific_data.op_close.reason[client->rx.payload_length] = 0;
+            client->rx.specific_data.op_close.reason[close_reason_length] = 0;
             nd_log(NDLS_DAEMON, NDLP_INFO, "ACLK: WebSocket server closed the connection with EC=%d and reason \"%s\"",
                 client->rx.specific_data.op_close.ec,
                 client->rx.specific_data.op_close.reason);
@@ -629,6 +630,7 @@ int ws_client_process_rx_ws(ws_client *client)
             client->rx.specific_data.op_close.reason = NULL;
             client->rx.parse_state = WS_PACKET_DONE;
             break;
+        }
         case WS_PAYLOAD_SKIP_UNKNOWN_PAYLOAD:
             BUF_READ_CHECK_AT_LEAST(client->rx.payload_length);
             nd_log(NDLS_DAEMON, NDLP_WARNING, "ACLK: Skipping Websocket Packet of unsupported/unknown type");

--- a/src/exporting/mongodb/mongodb.c
+++ b/src/exporting/mongodb/mongodb.c
@@ -182,7 +182,7 @@ int format_batch_mongodb(struct instance *instance)
 
     size_t documents_inserted = 0;
 
-    while (*end && documents_inserted <= (size_t)stats->buffered_metrics) {
+    while (*end && documents_inserted < (size_t)stats->buffered_metrics) {
         while (*end && *end != '\n')
             end++;
 

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -83,7 +83,7 @@ inline int can_send_rrdset(struct instance *instance, RRDSET *st, SIMPLE_PATTERN
 static struct prometheus_server {
     const char *server;
     uint32_t hash;
-    RRDHOST *host;
+    char machine_guid[GUID_LEN + 1];
     time_t last_access;
     struct prometheus_server *next;
 } *prometheus_server_root = NULL;
@@ -137,7 +137,9 @@ static inline time_t prometheus_server_last_access(const char *server, RRDHOST *
 
     struct prometheus_server *ps;
     for (ps = prometheus_server_root; ps; ps = ps->next) {
-        if (host == ps->host && hash == ps->hash && !strcmp(server, ps->server)) {
+        if (hash == ps->hash &&
+            !strcmp(server, ps->server) &&
+            !strcmp(host->machine_guid, ps->machine_guid)) {
             time_t last = ps->last_access;
             ps->last_access = now;
             netdata_mutex_unlock(&prometheus_server_root_mutex);
@@ -148,7 +150,7 @@ static inline time_t prometheus_server_last_access(const char *server, RRDHOST *
     ps = callocz(1, sizeof(struct prometheus_server));
     ps->server = strdupz(server);
     ps->hash = hash;
-    ps->host = host;
+    strncpyz(ps->machine_guid, host->machine_guid, sizeof(ps->machine_guid) - 1);
     ps->last_access = now;
     ps->next = prometheus_server_root;
     prometheus_server_root = ps;

--- a/src/exporting/send_data.c
+++ b/src/exporting/send_data.c
@@ -248,25 +248,30 @@ void simple_connector_worker(void *instance_p)
         // detach buffer
 
         size_t buffered_metrics;
+        struct simple_connector_buffer *detached_buffer = NULL;
+        int detached_buffer_used = 0;
 
         if (!connector_specific_data->previous_buffer ||
             (connector_specific_data->previous_buffer == connector_specific_data->first_buffer &&
              connector_specific_data->first_buffer->used == 1)) {
             BUFFER *header, *buffer;
 
-            header = connector_specific_data->first_buffer->header;
-            buffer = connector_specific_data->first_buffer->buffer;
-            connector_specific_data->buffered_metrics = connector_specific_data->first_buffer->buffered_metrics;
-            connector_specific_data->buffered_bytes = connector_specific_data->first_buffer->buffered_bytes;
+            detached_buffer = connector_specific_data->first_buffer;
+            detached_buffer_used = detached_buffer->used;
+
+            header = detached_buffer->header;
+            buffer = detached_buffer->buffer;
+            connector_specific_data->buffered_metrics = detached_buffer->buffered_metrics;
+            connector_specific_data->buffered_bytes = detached_buffer->buffered_bytes;
 
             buffered_metrics = connector_specific_data->buffered_metrics;
 
             buffer_flush(connector_specific_data->header);
-            connector_specific_data->first_buffer->header = connector_specific_data->header;
+            detached_buffer->header = connector_specific_data->header;
             connector_specific_data->header = header;
 
             buffer_flush(connector_specific_data->buffer);
-            connector_specific_data->first_buffer->buffer = connector_specific_data->buffer;
+            detached_buffer->buffer = connector_specific_data->buffer;
             connector_specific_data->buffer = buffer;
         } else {
             buffered_metrics = connector_specific_data->buffered_metrics;
@@ -344,10 +349,15 @@ void simple_connector_worker(void *instance_p)
             failures++;
         }
 
-        if (!failures) {
-            connector_specific_data->first_buffer->buffered_metrics =
-                connector_specific_data->first_buffer->buffered_bytes = connector_specific_data->first_buffer->used = 0;
-            connector_specific_data->first_buffer = connector_specific_data->first_buffer->next;
+        if (!failures && detached_buffer) {
+            netdata_mutex_lock(&instance->mutex);
+
+            if (connector_specific_data->first_buffer == detached_buffer && detached_buffer->used == detached_buffer_used) {
+                detached_buffer->buffered_metrics = detached_buffer->buffered_bytes = detached_buffer->used = 0;
+                connector_specific_data->first_buffer = detached_buffer->next;
+            }
+
+            netdata_mutex_unlock(&instance->mutex);
         }
 
         if (unlikely(instance->engine->exit))

--- a/src/libnetdata/http/http_defs.c
+++ b/src/libnetdata/http/http_defs.c
@@ -203,18 +203,31 @@ static struct {
         , { NULL   , 0    , 0 }
 };
 
+static SPINLOCK mime_types_init_spinlock = SPINLOCK_INITIALIZER;
+static bool mime_types_initialized = false;
+
+static inline void mime_types_init(void) {
+    if(likely(__atomic_load_n(&mime_types_initialized, __ATOMIC_ACQUIRE)))
+        return;
+
+    spinlock_lock(&mime_types_init_spinlock);
+
+    if(unlikely(!__atomic_load_n(&mime_types_initialized, __ATOMIC_ACQUIRE))) {
+        for(int i = 0; mime_types[i].extension; i++)
+            mime_types[i].hash = simple_hash(mime_types[i].extension);
+
+        __atomic_store_n(&mime_types_initialized, true, __ATOMIC_RELEASE);
+    }
+
+    spinlock_unlock(&mime_types_init_spinlock);
+}
+
 HTTP_CONTENT_TYPE contenttype_for_filename(const char *filename) {
     // netdata_log_info("checking filename '%s'", filename);
 
-    static int initialized = 0;
     int i;
 
-    if(unlikely(!initialized)) {
-        for (i = 0; mime_types[i].extension; i++)
-            mime_types[i].hash = simple_hash(mime_types[i].extension);
-
-        initialized = 1;
-    }
+    mime_types_init();
 
     const char *s = filename, *last_dot = NULL;
 

--- a/src/web/api/http_auth.c
+++ b/src/web/api/http_auth.c
@@ -44,9 +44,10 @@ static void bearer_token_delete_from_disk(nd_uuid_t *token) {
 }
 
 static void bearer_token_cleanup(bool force) {
-    static time_t attempts = 0;
+    static uint32_t cleanup_attempts = 0;
 
-    if(++attempts % 1000 != 0 && !force)
+    uint32_t attempts = __atomic_add_fetch(&cleanup_attempts, 1, __ATOMIC_RELAXED);
+    if(attempts % 1000 != 0 && !force)
         return;
 
     time_t now_s = now_realtime_sec();

--- a/src/web/api/http_header.c
+++ b/src/web/api/http_header.c
@@ -378,13 +378,27 @@ struct {
     { .hash = 0, .key = NULL, .cb = NULL }
 };
 
-char *http_header_parse_line(struct web_client *w, char *s) {
-    if(unlikely(!supported_headers[0].hash)) {
-        // initialize the hashes, the first time it runs
+static SPINLOCK supported_headers_init_spinlock = SPINLOCK_INITIALIZER;
+static bool supported_headers_initialized = false;
 
+static inline void supported_headers_init(void) {
+    if(likely(__atomic_load_n(&supported_headers_initialized, __ATOMIC_ACQUIRE)))
+        return;
+
+    spinlock_lock(&supported_headers_init_spinlock);
+
+    if(unlikely(!__atomic_load_n(&supported_headers_initialized, __ATOMIC_ACQUIRE))) {
         for(size_t i = 0; supported_headers[i].key ;i++)
             supported_headers[i].hash = simple_uhash(supported_headers[i].key);
+
+        __atomic_store_n(&supported_headers_initialized, true, __ATOMIC_RELEASE);
     }
+
+    spinlock_unlock(&supported_headers_init_spinlock);
+}
+
+char *http_header_parse_line(struct web_client *w, char *s) {
+    supported_headers_init();
 
     char *e = s;
 

--- a/src/web/mcp/mcp-tools-execute-function.c
+++ b/src/web/mcp/mcp-tools-execute-function.c
@@ -1058,7 +1058,8 @@ static void mcp_process_table_result(MCP_FUNCTION_DATA *data, size_t max_size_th
 
     if (!json_object_object_get_ex(data->input.jobj, "data", &data_obj) ||
         !json_object_is_type(data_obj, json_type_array) ||
-        !json_object_object_get_ex(data->input.jobj, "columns", &columns_obj)) {
+        !json_object_object_get_ex(data->input.jobj, "columns", &columns_obj) ||
+        !json_object_is_type(columns_obj, json_type_object)) {
         buffer_strcat(data->output.result, json_str); // Missing required elements
         return;
     }
@@ -2288,7 +2289,8 @@ static MCP_RETURN_CODE mcp_functions_process_table(MCP_FUNCTION_DATA *data, MCP_
         
         if (!json_object_object_get_ex(data->input.jobj, "data", &data_obj) ||
             !json_object_is_type(data_obj, json_type_array) ||
-            !json_object_object_get_ex(data->input.jobj, "columns", &columns_obj)) {
+            !json_object_object_get_ex(data->input.jobj, "columns", &columns_obj) ||
+            !json_object_is_type(columns_obj, json_type_object)) {
             // Missing required fields, treat as not processable
             data->output.status = MCP_TABLE_NOT_PROCESSABLE;
             buffer_strcat(data->output.result, buffer_tostring(data->input.json));

--- a/src/web/mcp/mcp-tools-execute-function.c
+++ b/src/web/mcp/mcp-tools-execute-function.c
@@ -1057,6 +1057,7 @@ static void mcp_process_table_result(MCP_FUNCTION_DATA *data, size_t max_size_th
     struct json_object *columns_obj = NULL;
 
     if (!json_object_object_get_ex(data->input.jobj, "data", &data_obj) ||
+        !json_object_is_type(data_obj, json_type_array) ||
         !json_object_object_get_ex(data->input.jobj, "columns", &columns_obj)) {
         buffer_strcat(data->output.result, json_str); // Missing required elements
         return;
@@ -2286,6 +2287,7 @@ static MCP_RETURN_CODE mcp_functions_process_table(MCP_FUNCTION_DATA *data, MCP_
         struct json_object *columns_obj = NULL;
         
         if (!json_object_object_get_ex(data->input.jobj, "data", &data_obj) ||
+            !json_object_is_type(data_obj, json_type_array) ||
             !json_object_object_get_ex(data->input.jobj, "columns", &columns_obj)) {
             // Missing required fields, treat as not processable
             data->output.status = MCP_TABLE_NOT_PROCESSABLE;

--- a/src/web/rtc/webrtc.c
+++ b/src/web/rtc/webrtc.c
@@ -9,6 +9,10 @@
 
 #include "rtc/rtc.h"
 
+#if defined(ENABLE_LZ4)
+#include <lz4.h>
+#endif
+
 #define WEBRTC_OUR_MAX_MESSAGE_SIZE (5 * 1024 * 1024)
 #define WEBRTC_DEFAULT_REMOTE_MAX_MESSAGE_SIZE (65536)
 #define WEBRTC_COMPRESSED_HEADER_SIZE 200
@@ -320,7 +324,7 @@ static void webrtc_execute_api_request(WEBRTC_DC *chan, const char *request, siz
     size_t response_size = buffer_strlen(w->response.data);
 
     bool send_plain = true;
-    int max_message_size = (int)chan->conn->max_message_size - WEBRTC_COMPRESSED_HEADER_SIZE;
+    size_t max_message_size = chan->conn->max_message_size - WEBRTC_COMPRESSED_HEADER_SIZE;
 
     if(!webrtc_dc_is_open(chan)) {
         internal_error(true, "WEBRTC[%d],DC[%d]: ignoring API response on closed data channel.", chan->conn->pc, chan->dc);
@@ -332,19 +336,21 @@ static void webrtc_execute_api_request(WEBRTC_DC *chan, const char *request, siz
     }
 
 #if defined(ENABLE_LZ4)
-    int max_compressed_size = LZ4_compressBound((int)response_size);
-    char *compressed = mallocz(max_compressed_size);
+    if(response_size <= LZ4_MAX_INPUT_SIZE) {
+        int max_compressed_size = LZ4_compressBound((int)response_size);
+        char *compressed = mallocz(max_compressed_size);
 
-    int compressed_size = LZ4_compress_default(buffer_tostring(w->response.data), compressed,
-                                               (int)response_size, max_compressed_size);
+        int compressed_size = LZ4_compress_default(buffer_tostring(w->response.data), compressed,
+                                                   (int)response_size, max_compressed_size);
 
-    if(compressed_size > 0) {
-        send_plain = false;
-        sent_bytes = webrtc_send_in_chunks(chan, compressed, compressed_size,
-                                           w->response.code, "LZ4", w->response.data->content_type,
-                                           max_message_size, true);
+        if(compressed_size > 0) {
+            send_plain = false;
+            sent_bytes = webrtc_send_in_chunks(chan, compressed, compressed_size,
+                                               w->response.code, "LZ4", w->response.data->content_type,
+                                               max_message_size, true);
+        }
+        freez(compressed);
     }
-    freez(compressed);
 #endif
 
     if(send_plain)
@@ -711,8 +717,8 @@ int webrtc_new_connection(const char *sdp, BUFFER *wb) {
         internal_error(true, "WEBRTC[%d]: Gathering finished, our answer is ready", conn->pc);
 
     conn->max_message_size = MIN(conn->local_max_message_size, conn->remote_max_message_size);
-    if(conn->max_message_size < WEBRTC_COMPRESSED_HEADER_SIZE)
-        conn->max_message_size = WEBRTC_COMPRESSED_HEADER_SIZE;
+    if(conn->max_message_size <= WEBRTC_COMPRESSED_HEADER_SIZE)
+        conn->max_message_size = WEBRTC_COMPRESSED_HEADER_SIZE + 1;
 
     spinlock_lock(&conn->response.spinlock);
     internal_fatal(!conn->response.sdp, "WEBRTC[%d]: response does not have an SDP: %s", conn->pc, buffer_tostring(conn->response.wb));

--- a/src/web/rtc/webrtc.c
+++ b/src/web/rtc/webrtc.c
@@ -532,7 +532,7 @@ static void myDescriptionCallback(int pc __maybe_unused, const char *sdp, const 
 
     internal_error(true, "WEBRTC[%d]: local description type '%s': %s", conn->pc, type, sdp);
     spinlock_lock(&conn->response.spinlock);
-    if(!conn->response.candidates) {
+    if(conn->response.wb && !conn->response.candidates) {
         buffer_json_member_add_string(conn->response.wb, "sdp", sdp);
         buffer_json_member_add_string(conn->response.wb, "type", type);
         conn->response.sdp = true;
@@ -549,13 +549,15 @@ static void myCandidateCallback(int pc __maybe_unused, const char *cand, const c
     internal_fatal(conn->pc != pc, "WEBRTC[%d]: pc mismatch, expected %d, got %d", conn->pc, conn->pc, pc);
 
     spinlock_lock(&conn->response.spinlock);
-    if(!conn->response.candidates) {
-        buffer_json_member_add_array(conn->response.wb, "candidates");
-        conn->response.candidates = true;
-    }
-
     internal_error(true, "WEBRTC[%d]: local candidate '%s', mid '%s'", conn->pc, cand, mid);
-    buffer_json_add_array_item_string(conn->response.wb, cand);
+    if(conn->response.wb) {
+        if(!conn->response.candidates) {
+            buffer_json_member_add_array(conn->response.wb, "candidates");
+            conn->response.candidates = true;
+        }
+
+        buffer_json_add_array_item_string(conn->response.wb, cand);
+    }
     spinlock_unlock(&conn->response.spinlock);
 }
 
@@ -708,14 +710,16 @@ int webrtc_new_connection(const char *sdp, BUFFER *wb) {
     if(logged)
         internal_error(true, "WEBRTC[%d]: Gathering finished, our answer is ready", conn->pc);
 
-    internal_fatal(!conn->response.sdp, "WEBRTC[%d]: response does not have an SDP: %s", conn->pc, buffer_tostring(conn->response.wb));
-    internal_fatal(!conn->response.candidates, "WEBRTC[%d]: response does not have candidates: %s", conn->pc, buffer_tostring(conn->response.wb));
-
     conn->max_message_size = MIN(conn->local_max_message_size, conn->remote_max_message_size);
     if(conn->max_message_size < WEBRTC_COMPRESSED_HEADER_SIZE)
         conn->max_message_size = WEBRTC_COMPRESSED_HEADER_SIZE;
 
+    spinlock_lock(&conn->response.spinlock);
+    internal_fatal(!conn->response.sdp, "WEBRTC[%d]: response does not have an SDP: %s", conn->pc, buffer_tostring(conn->response.wb));
+    internal_fatal(!conn->response.candidates, "WEBRTC[%d]: response does not have candidates: %s", conn->pc, buffer_tostring(conn->response.wb));
     buffer_json_finalize(wb);
+    conn->response.wb = NULL;
+    spinlock_unlock(&conn->response.spinlock);
 
     return HTTP_RESP_OK;
 }

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -1028,13 +1028,59 @@ static inline void web_client_send_http_header(struct web_client *w) {
         w->statistics.sent_bytes += bytes;
 }
 
-static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, char *url, bool nodeid, int (*func)(RRDHOST *, struct web_client *, char *)) {
-    static uint32_t hash_localhost = 0;
+struct web_client_url_hashes {
+    uint32_t api;
+    uint32_t host;
+    uint32_t node;
+    uint32_t netdata_conf;
+    uint32_t v0;
+    uint32_t v1;
+    uint32_t v2;
+    uint32_t v3;
+    uint32_t mcp;
+    uint32_t sse;
+#ifdef NETDATA_INTERNAL_CHECKS
+    uint32_t exit;
+    uint32_t debug;
+    uint32_t mirror;
+#endif
+};
 
-    if(unlikely(!hash_localhost)) {
-        hash_localhost = simple_hash("localhost");
+static struct web_client_url_hashes web_client_url_hashes = { 0 };
+static SPINLOCK web_client_url_hashes_spinlock = SPINLOCK_INITIALIZER;
+static bool web_client_url_hashes_initialized = false;
+
+static inline const struct web_client_url_hashes *web_client_url_hashes_get(void) {
+    if(likely(__atomic_load_n(&web_client_url_hashes_initialized, __ATOMIC_ACQUIRE)))
+        return &web_client_url_hashes;
+
+    spinlock_lock(&web_client_url_hashes_spinlock);
+
+    if(unlikely(!__atomic_load_n(&web_client_url_hashes_initialized, __ATOMIC_ACQUIRE))) {
+        web_client_url_hashes.api = simple_hash("api");
+        web_client_url_hashes.host = simple_hash("host");
+        web_client_url_hashes.node = simple_hash("node");
+        web_client_url_hashes.netdata_conf = simple_hash("netdata.conf");
+        web_client_url_hashes.v0 = simple_hash("v0");
+        web_client_url_hashes.v1 = simple_hash("v1");
+        web_client_url_hashes.v2 = simple_hash("v2");
+        web_client_url_hashes.v3 = simple_hash("v3");
+        web_client_url_hashes.mcp = simple_hash("mcp");
+        web_client_url_hashes.sse = simple_hash("sse");
+#ifdef NETDATA_INTERNAL_CHECKS
+        web_client_url_hashes.exit = simple_hash("exit");
+        web_client_url_hashes.debug = simple_hash("debug");
+        web_client_url_hashes.mirror = simple_hash("mirror");
+#endif
+        __atomic_store_n(&web_client_url_hashes_initialized, true, __ATOMIC_RELEASE);
     }
 
+    spinlock_unlock(&web_client_url_hashes_spinlock);
+
+    return &web_client_url_hashes;
+}
+
+static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, char *url, bool nodeid, int (*func)(RRDHOST *, struct web_client *, char *)) {
     if(host != localhost) {
         buffer_flush(w->response.data);
         buffer_strcat(w->response.data, "Nesting of hosts is not allowed.");
@@ -1115,30 +1161,21 @@ int web_client_api_request_with_node_selection(RRDHOST *host, struct web_client 
     if(uuid_is_null(w->transaction))
         uuid_generate_random(w->transaction);
 
-    static uint32_t
-            hash_api = 0,
-            hash_host = 0,
-            hash_node = 0;
-
-    if(unlikely(!hash_api)) {
-        hash_api = simple_hash("api");
-        hash_host = simple_hash("host");
-        hash_node = simple_hash("node");
-    }
+    const struct web_client_url_hashes *url_hashes = web_client_url_hashes_get();
 
     char *tok = strsep_skip_consecutive_separators(&decoded_url_path, "/?");
     if(likely(tok && *tok)) {
         uint32_t hash = simple_hash(tok);
 
-        if(unlikely(hash == hash_api && strcmp(tok, "api") == 0)) {
+        if(unlikely(hash == url_hashes->api && strcmp(tok, "api") == 0)) {
             // current API
             netdata_log_debug(D_WEB_CLIENT_ACCESS, "%llu: API request ...", w->id);
             return check_host_and_call(host, w, decoded_url_path, web_client_api_request);
         }
-        else if(unlikely((hash == hash_host && strcmp(tok, "host") == 0) || (hash == hash_node && strcmp(tok, "node") == 0))) {
+        else if(unlikely((hash == url_hashes->host && strcmp(tok, "host") == 0) || (hash == url_hashes->node && strcmp(tok, "node") == 0))) {
             // host switching
             netdata_log_debug(D_WEB_CLIENT_ACCESS, "%llu: host switch request ...", w->id);
-            return web_client_switch_host(host, w, decoded_url_path, hash == hash_node, web_client_api_request_with_node_selection);
+            return web_client_switch_host(host, w, decoded_url_path, hash == url_hashes->node, web_client_api_request_with_node_selection);
         }
     }
 
@@ -1152,39 +1189,7 @@ static inline int web_client_process_url(RRDHOST *host, struct web_client *w, ch
     if(unlikely(!service_running(ABILITY_WEB_REQUESTS)))
         return web_client_service_unavailable(w);
 
-    static uint32_t
-            hash_api = 0,
-            hash_netdata_conf = 0,
-            hash_host = 0,
-            hash_node = 0,
-            hash_v0 = 0,
-            hash_v1 = 0,
-            hash_v2 = 0,
-            hash_v3 = 0,
-            hash_mcp = 0,
-            hash_sse = 0;
-
-#ifdef NETDATA_INTERNAL_CHECKS
-    static uint32_t hash_exit = 0, hash_debug = 0, hash_mirror = 0;
-#endif
-
-    if(unlikely(!hash_api)) {
-        hash_api = simple_hash("api");
-        hash_netdata_conf = simple_hash("netdata.conf");
-        hash_host = simple_hash("host");
-        hash_node = simple_hash("node");
-        hash_v0 = simple_hash("v0");
-        hash_v1 = simple_hash("v1");
-        hash_v2 = simple_hash("v2");
-        hash_v3 = simple_hash("v3");
-        hash_mcp = simple_hash("mcp");
-        hash_sse = simple_hash("sse");
-#ifdef NETDATA_INTERNAL_CHECKS
-        hash_exit = simple_hash("exit");
-        hash_debug = simple_hash("debug");
-        hash_mirror = simple_hash("mirror");
-#endif
-    }
+    const struct web_client_url_hashes *url_hashes = web_client_url_hashes_get();
 
     // keep a copy of the decoded path, in case we need to serve it as a filename
     char filename[FILENAME_MAX + 1];
@@ -1195,49 +1200,49 @@ static inline int web_client_process_url(RRDHOST *host, struct web_client *w, ch
         uint32_t hash = simple_hash(tok);
         netdata_log_debug(D_WEB_CLIENT, "%llu: Processing command '%s'.", w->id, tok);
 
-        if(likely(hash == hash_api && strcmp(tok, "api") == 0)) {                           // current API
+        if(likely(hash == url_hashes->api && strcmp(tok, "api") == 0)) {                           // current API
             netdata_log_debug(D_WEB_CLIENT_ACCESS, "%llu: API request ...", w->id);
             return check_host_and_call(host, w, decoded_url_path, web_client_api_request);
         }
-        else if(likely(hash == hash_mcp && strcmp(tok, "mcp") == 0)) {
+        else if(likely(hash == url_hashes->mcp && strcmp(tok, "mcp") == 0)) {
             if(unlikely(!http_can_access_mcp(w)))
                 return web_client_permission_denied_acl(w);
             return mcp_http_handle_request(host, w);
         }
-        else if(likely(hash == hash_sse && strcmp(tok, "sse") == 0)) {
+        else if(likely(hash == url_hashes->sse && strcmp(tok, "sse") == 0)) {
             if(unlikely(!http_can_access_mcp(w)))
                 return web_client_permission_denied_acl(w);
             return mcp_sse_handle_request(host, w);
         }
-        else if(unlikely((hash == hash_host && strcmp(tok, "host") == 0) || (hash == hash_node && strcmp(tok, "node") == 0))) { // host switching
+        else if(unlikely((hash == url_hashes->host && strcmp(tok, "host") == 0) || (hash == url_hashes->node && strcmp(tok, "node") == 0))) { // host switching
             netdata_log_debug(D_WEB_CLIENT_ACCESS, "%llu: host switch request ...", w->id);
-            return web_client_switch_host(host, w, decoded_url_path, hash == hash_node, web_client_process_url);
+            return web_client_switch_host(host, w, decoded_url_path, hash == url_hashes->node, web_client_process_url);
         }
-        else if(unlikely(hash == hash_v3 && strcmp(tok, "v3") == 0)) {
+        else if(unlikely(hash == url_hashes->v3 && strcmp(tok, "v3") == 0)) {
             if(web_client_flag_check(w, WEB_CLIENT_FLAG_PATH_WITH_VERSION))
                 return bad_request_multiple_dashboard_versions(w);
             web_client_flag_set(w, WEB_CLIENT_FLAG_PATH_IS_V3);
             return web_client_process_url(host, w, decoded_url_path);
         }
-        else if(unlikely(hash == hash_v2 && strcmp(tok, "v2") == 0)) {
+        else if(unlikely(hash == url_hashes->v2 && strcmp(tok, "v2") == 0)) {
             if(web_client_flag_check(w, WEB_CLIENT_FLAG_PATH_WITH_VERSION))
                 return bad_request_multiple_dashboard_versions(w);
             web_client_flag_set(w, WEB_CLIENT_FLAG_PATH_IS_V2);
             return web_client_process_url(host, w, decoded_url_path);
         }
-        else if(unlikely(hash == hash_v1 && strcmp(tok, "v1") == 0)) {
+        else if(unlikely(hash == url_hashes->v1 && strcmp(tok, "v1") == 0)) {
             if(web_client_flag_check(w, WEB_CLIENT_FLAG_PATH_WITH_VERSION))
                 return bad_request_multiple_dashboard_versions(w);
             web_client_flag_set(w, WEB_CLIENT_FLAG_PATH_IS_V1);
             return web_client_process_url(host, w, decoded_url_path);
         }
-        else if(unlikely(hash == hash_v0 && strcmp(tok, "v0") == 0)) {
+        else if(unlikely(hash == url_hashes->v0 && strcmp(tok, "v0") == 0)) {
             if(web_client_flag_check(w, WEB_CLIENT_FLAG_PATH_WITH_VERSION))
                 return bad_request_multiple_dashboard_versions(w);
             web_client_flag_set(w, WEB_CLIENT_FLAG_PATH_IS_V0);
             return web_client_process_url(host, w, decoded_url_path);
         }
-        else if(unlikely(hash == hash_netdata_conf && strcmp(tok, "netdata.conf") == 0)) {    // netdata.conf
+        else if(unlikely(hash == url_hashes->netdata_conf && strcmp(tok, "netdata.conf") == 0)) {    // netdata.conf
             if(unlikely(!http_can_access_netdataconf(w)))
                 return web_client_permission_denied_acl(w);
 
@@ -1249,7 +1254,7 @@ static inline int web_client_process_url(RRDHOST *host, struct web_client *w, ch
             return HTTP_RESP_OK;
         }
 #ifdef NETDATA_INTERNAL_CHECKS
-        else if(unlikely(hash == hash_exit && strcmp(tok, "exit") == 0)) {
+        else if(unlikely(hash == url_hashes->exit && strcmp(tok, "exit") == 0)) {
             if(unlikely(!http_can_access_netdataconf(w)))
                 return web_client_permission_denied_acl(w);
 
@@ -1265,7 +1270,7 @@ static inline int web_client_process_url(RRDHOST *host, struct web_client *w, ch
             netdata_exit_gracefully(EXIT_REASON_API_QUIT, true);
             return HTTP_RESP_OK;
         }
-        else if(unlikely(hash == hash_debug && strcmp(tok, "debug") == 0)) {
+        else if(unlikely(hash == url_hashes->debug && strcmp(tok, "debug") == 0)) {
             if(unlikely(!http_can_access_netdataconf(w)))
                 return web_client_permission_denied_acl(w);
 
@@ -1303,7 +1308,7 @@ static inline int web_client_process_url(RRDHOST *host, struct web_client *w, ch
             buffer_strcat(w->response.data, "debug which chart?\r\n");
             return HTTP_RESP_BAD_REQUEST;
         }
-        else if(unlikely(hash == hash_mirror && strcmp(tok, "mirror") == 0)) {
+        else if(unlikely(hash == url_hashes->mirror && strcmp(tok, "mirror") == 0)) {
             if(unlikely(!http_can_access_netdataconf(w)))
                 return web_client_permission_denied_acl(w);
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens MQTT, WebRTC, HTTP, and exporting paths with bounds checks and thread-safety to prevent packet desync, stale-pointer use, and buffer corruption. Adds focused tests for MQTT and WebSocket edge cases.

- **Bug Fixes**
  - `aclk/mqtt_websockets`: Bound MQTT5 properties by packet Remaining Length for CONNACK/DISCONNECT/PUBACK/PUBLISH/SUBACK; require exact consumption; reject malformed packets without draining next frame; fix fragmented SUBACK reason-code assembly; add regression tests.
  - `aclk`: Serialize proxy cache initialization with a private mutex to remove first-call races.
  - `aclk/mqtt_websockets/ws_client`: Allocate close-reason as payload_len - 2 and NUL-terminate correctly; update unittest to verify buffer size.
  - `exporting/mongodb`: Use strict < bound in batch parse loop to prevent one-past-the-end write.
  - `exporting/send_data`: Synchronize simple connector ring-buffer detach/commit with `instance->mutex` and generation check to avoid clearing producer-owned slots after send.
  - `exporting/prometheus`: Key scrape last-access cache by server + host `machine_guid` instead of an `RRDHOST *` to avoid stale-pointer matches.
  - `libnetdata/http` and `web/api`: Add spinlock-protected one-time init for MIME types and supported-header hashes; make bearer-token cleanup counter atomic.
  - `web/rtc`: Only LZ4-compress when input ≤ `LZ4_MAX_INPUT_SIZE`; use `size_t` for max chunk size; stop late SDP/ICE callbacks from writing to recycled HTTP buffers; ensure `max_message_size` stays > header.
  - `web/server`: Centralize URL routing hash table; initialize once under a spinlock to remove data races.

<sup>Written for commit eb462b6c7a7b352a2d6eaa4e72865b26776ccbba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

