### PR TITLE
feat(go.d/cloudwatch): add opt-in resource tag labels

### DIFF
--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.26
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.61.1
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.33.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.5
 	github.com/catonetworks/cato-go-sdk v0.2.6
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -81,6 +81,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 h1:mbRIur
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13/go.mod h1:ITg9em2KbJx1s0y4aqRX5OYWG6HBZ5TVR//OdpEZ2CQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.30 h1:/Z5jmNrKsSD7EmDjzAPsm/3L9IuOkzaynklJZ1qX7S4=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.30/go.mod h1:lEzEZnOosE7zi8Z6royW1cFJTD9fpab4Ul1SBrllewk=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.33.5 h1:cd2vmT/Cc9/ZzmuY0XM2YKA5tgkp2Jyv5Ia35ENsW5I=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.33.5/go.mod h1:1N13ke5qTtwOiBPXfPtH+MmG5Jo0UAfKnp+OZ2bQahI=
 github.com/aws/aws-sdk-go-v2/service/signin v1.2.2 h1:69JEZSDTQ+UNbTWQJCZMmbpQb5sfc79KUt0O7Pyfjmo=
 github.com/aws/aws-sdk-go-v2/service/signin v1.2.2/go.mod h1:mxC0nT/C8wMMS97DemZPzvUZxvIt+2Iq+eS3JdFZGgg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.31.5 h1:xlK3Tdc8FO7Tq1k0+hL+otF33glj+dE+qeM5iINiDvU=

--- a/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
@@ -250,6 +250,48 @@ Discovery then finds which *instances* of those profiles exist per account and r
   stop being re-emitted and a group that later reappears is queried on its first cycle
   back rather than waiting for a stale schedule entry to expire.
 
+## Tag Enrichment (`tags.go`, `tagjoin.go`, `tagresolve.go`)
+
+Opt-in (`tags` config, empty by default). When set, the collector attaches selected
+AWS resource tags as **non-identity** chart labels, so `i-0abc123` also carries
+`owner`/`project`/`name`/… without changing series identity. It slots into the cycle
+between discovery and query planning:
+
+```text
+refreshDiscovery → refreshTags → buildQueryPlan → … → observe
+```
+
+- **Client + cache.** A Resource Groups Tagging API (RGTA) client is built per
+  `{account, region}` (the same generic `clientCache[T]` as the CloudWatch client).
+  `refreshTags` runs on the discovery TTL and is best-effort: a per-`{account, region}`
+  failure keeps that scope's **last-known** tags (a first-run failure yields none) and
+  never fails the cycle. With no tags configured, no RGTA client is ever built.
+- **Resolution (`tagresolve.go`).** `resolveTagPlan` turns the allowlist into a
+  per-profile `awsKey → label` plan, once. It is **non-fatal**: an entry whose label is
+  empty/invalid, collides with a reserved (`account_id`/`region`) or dimension label, or
+  duplicates another tag is **skipped with a warning** — never a config error, never an
+  emitted duplicate key (which would panic `metrix`). `rename` resolves collisions; the
+  default label is the sanitized key (`Name` → `name`).
+- **ARN↔dimension join (`tagjoin.go`).** RGTA returns ARN + tags; the cache is keyed by
+  the profile's ARN-projectable `joinKey`. A per-profile mapper (a default
+  last-resource-segment extractor plus overrides for ALB/NLB/target-group/ECS/OpenSearch/
+  Step-Functions) derives the `joinKey` from the ARN, and the instance side projects its
+  dimension values onto the same key. **Safe failure mode:** a wrong ARN assumption is a
+  cache *miss* (no tags), never *wrong* tags, because the instance side uses real
+  dimension values. Parent-resource profiles (S3, DynamoDB-operation, ALB-target) key on
+  the parent dimension so children inherit its tags. Unregistered profiles
+  (auto_scaling, bedrock, and the ambiguous cloudfront/api_gateway/msk/elasticache) carry
+  no tags.
+- **Emission split.** Identity `labels` (`{account_id, region, <dims>}`) and `tagLabels`
+  travel separately through `plannedQuery`/`querySample`/`observedSeries`. `writeSample`
+  emits `labels + tagLabels` in a fresh slice; `observedKey` (the retention/scheduling
+  identity) uses **identity labels only**, so a tag change never churns scheduling, and
+  retention re-emit carries the last-known `tagLabels`. `chartengine` `auto_intersection`
+  then promotes the tag labels as non-identity chart labels — no template change.
+- **INV.2.** Tags only ADD labels; they never gate series existence. A custom profile
+  that names a tag in `instances.by_labels` (or uses `["*"]`) is out of scope — that is
+  the operator's own chart-identity choice.
+
 ## Dynamic Charts
 
 `chart.go`, built once by `ensureProfiles` and cached in `chartTemplateYAML`.
@@ -395,9 +437,13 @@ verify current per-region prices on the CloudWatch pricing page.)
   failure is fatal.
 - **Single node** — AWS resources are chart instances via `by_labels`, not
   vnodes.
+- **Tags are additive** — the opt-in `tags` allowlist adds non-identity labels
+  only; it never gates series existence and never overwrites an identity label
+  (a colliding tag is skipped with a warning).
 - **Config minimalism** — only `regions`, `auth`, `profiles`, `discovery`
-  (`refresh_every`, `recently_active_only`), `query_offset`, and `timeout` (plus
-  the framework's `update_every` / `autodetection_retry`) are operator-facing.
+  (`refresh_every`, `recently_active_only`), `query_offset`, `timeout`, and the
+  opt-in `tags` allowlist (plus the framework's `update_every` /
+  `autodetection_retry`) are operator-facing.
   Concurrency, batch size, and the recently-active period bound are internal
   constants.
 

--- a/src/go/plugin/go.d/collector/cloudwatch/clients.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/clients.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/awsauth"
@@ -26,6 +27,13 @@ type stsClient interface {
 	GetCallerIdentity(ctx context.Context, in *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
 }
 
+// rgtaClient is the narrow Resource Groups Tagging API surface used for tag
+// enrichment (Phase 2b). GetResources is the only call: it lists tagged resources
+// (ARN + tags) per region so the collector can join tags onto discovered series.
+type rgtaClient interface {
+	GetResources(ctx context.Context, in *resourcegroupstaggingapi.GetResourcesInput, optFns ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error)
+}
+
 func defaultNewCloudWatchClient(cfg aws.Config) cloudwatchClient {
 	return cloudwatch.NewFromConfig(cfg)
 }
@@ -34,38 +42,43 @@ func defaultNewSTSClient(cfg aws.Config) stsClient {
 	return sts.NewFromConfig(cfg)
 }
 
+func defaultNewRGTAClient(cfg aws.Config) rgtaClient {
+	return resourcegroupstaggingapi.NewFromConfig(cfg)
+}
+
 func defaultNewAWSConfig(ctx context.Context, id awsauth.Identity, region string) (aws.Config, error) {
 	return id.NewConfig(ctx, awsauth.ConfigOptions{Region: region})
 }
 
-// clientKey identifies a CloudWatch client by the account it authenticates as and
-// the region it targets. Multi-account jobs need a distinct client per
-// (account, region): the same region is queried under each account's own
-// credentials.
+// clientKey identifies a client by the account it authenticates as and the region
+// it targets. Multi-account jobs need a distinct client per (account, region): the
+// same region is queried under each account's own credentials.
 type clientKey struct {
 	account string
 	region  string
 }
 
-// clientCache builds and caches one CloudWatch client per (account, region).
+// clientCache builds and caches one client of type T per (account, region). It is
+// generic so the CloudWatch and Resource Groups Tagging API clients (identical
+// per-(account, region) lifecycle, different API surface) share one implementation.
 // forAccountRegion is safe for concurrent use, so callers need not pre-resolve
 // clients to avoid racing a shared cache. A client is built at most once per
 // (account, region); only successes are cached, so a transient credential error is
 // retried next call.
-type clientCache struct {
+type clientCache[T any] struct {
 	mu      sync.Mutex
-	clients map[clientKey]cloudwatchClient
-	build   func(ctx context.Context, account, region string) (cloudwatchClient, error)
+	clients map[clientKey]T
+	build   func(ctx context.Context, account, region string) (T, error)
 }
 
-func newClientCache(build func(ctx context.Context, account, region string) (cloudwatchClient, error)) *clientCache {
-	return &clientCache{
-		clients: make(map[clientKey]cloudwatchClient),
+func newClientCache[T any](build func(ctx context.Context, account, region string) (T, error)) *clientCache[T] {
+	return &clientCache[T]{
+		clients: make(map[clientKey]T),
 		build:   build,
 	}
 }
 
-func (cc *clientCache) forAccountRegion(ctx context.Context, account, region string) (cloudwatchClient, error) {
+func (cc *clientCache[T]) forAccountRegion(ctx context.Context, account, region string) (T, error) {
 	key := clientKey{account: account, region: region}
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
@@ -74,16 +87,17 @@ func (cc *clientCache) forAccountRegion(ctx context.Context, account, region str
 	}
 	client, err := cc.build(ctx, account, region)
 	if err != nil {
-		return nil, err
+		var zero T
+		return zero, err
 	}
 	cc.clients[key] = client
 	return client, nil
 }
 
-func (cc *clientCache) reset() {
+func (cc *clientCache[T]) reset() {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
-	cc.clients = make(map[clientKey]cloudwatchClient)
+	cc.clients = make(map[clientKey]T)
 }
 
 // buildAccountRegionClient constructs a CloudWatch client for one (account, region)
@@ -100,4 +114,19 @@ func (c *Collector) buildAccountRegionClient(ctx context.Context, account, regio
 		return nil, err
 	}
 	return c.newCloudWatchClient(cfg), nil
+}
+
+// buildAccountRegionRGTAClient constructs a Resource Groups Tagging API client for
+// one (account, region), mirroring buildAccountRegionClient. RGTA is regional, so
+// the tag lookup for a series uses the client for that series' (account, region).
+func (c *Collector) buildAccountRegionRGTAClient(ctx context.Context, account, region string) (rgtaClient, error) {
+	id, ok := c.identityForAccount(account)
+	if !ok {
+		return nil, fmt.Errorf("no resolved identity for account %q", account)
+	}
+	cfg, err := c.newAWSConfig(ctx, id, region)
+	if err != nil {
+		return nil, err
+	}
+	return c.newRGTAClient(cfg), nil
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/clients_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/clients_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The cache is generic over the client type; these tests exercise it with a
+// trivial T=string fake so the memoize/distinct-key/reset/error semantics are
+// verified independently of the CloudWatch and RGTA client surfaces.
+
+func TestClientCache_MemoizesPerAccountRegion(t *testing.T) {
+	var builds int
+	cache := newClientCache(func(_ context.Context, account, region string) (string, error) {
+		builds++
+		return account + "/" + region, nil
+	})
+
+	c1, err := cache.forAccountRegion(context.Background(), "a1", "us-east-1")
+	require.NoError(t, err)
+	assert.Equal(t, "a1/us-east-1", c1)
+
+	c2, err := cache.forAccountRegion(context.Background(), "a1", "us-east-1")
+	require.NoError(t, err)
+	assert.Equal(t, c1, c2)
+	assert.Equal(t, 1, builds, "same (account, region) is built once")
+
+	_, err = cache.forAccountRegion(context.Background(), "a2", "us-east-1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, builds, "a distinct account rebuilds")
+
+	cache.reset()
+	_, err = cache.forAccountRegion(context.Background(), "a1", "us-east-1")
+	require.NoError(t, err)
+	assert.Equal(t, 3, builds, "reset clears the cache")
+}
+
+func TestClientCache_BuildErrorNotCached(t *testing.T) {
+	var builds int
+	cache := newClientCache(func(_ context.Context, _, _ string) (string, error) {
+		builds++
+		return "", errors.New("boom")
+	})
+
+	_, err := cache.forAccountRegion(context.Background(), "a1", "r1")
+	require.Error(t, err)
+	_, err = cache.forAccountRegion(context.Background(), "a1", "r1")
+	require.Error(t, err)
+	assert.Equal(t, 2, builds, "a failed build is retried, not cached")
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/collect.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/collect.go
@@ -14,6 +14,7 @@ func (c *Collector) collect(ctx context.Context) error {
 	if err := c.refreshDiscovery(ctx); err != nil {
 		return err
 	}
+	c.refreshTags(ctx) // best-effort tag enrichment; never gates collection (INV.2)
 
 	plan := c.buildQueryPlan()
 	c.observations.pruneObserved(plan)

--- a/src/go/plugin/go.d/collector/cloudwatch/collector.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/collector.go
@@ -26,6 +26,8 @@ const (
 	logKeyGetMetricDataFailed    = "getmetricdata_failed"
 	logKeyGetMetricDataForbidden = "getmetricdata_forbidden"
 	logKeyAccountResolveFailed   = "account_resolve_failed"
+	logKeyTagPlanWarn            = "tag_plan_warn"
+	logKeyTagRefreshFailed       = "tag_refresh_failed"
 )
 
 //go:embed "config_schema.json"
@@ -58,9 +60,11 @@ func New() *Collector {
 		newAWSConfig:        defaultNewAWSConfig,
 		newCloudWatchClient: defaultNewCloudWatchClient,
 		newSTSClient:        defaultNewSTSClient,
+		newRGTAClient:       defaultNewRGTAClient,
 	}
 	c.observations = newObservationStore(c.store)
 	c.clients = newClientCache(c.buildAccountRegionClient)
+	c.rgtaClients = newClientCache(c.buildAccountRegionRGTAClient)
 	return c
 }
 
@@ -75,6 +79,7 @@ type Collector struct {
 	newAWSConfig        func(ctx context.Context, id awsauth.Identity, region string) (aws.Config, error)
 	newCloudWatchClient func(cfg aws.Config) cloudwatchClient
 	newSTSClient        func(cfg aws.Config) stsClient
+	newRGTAClient       func(cfg aws.Config) rgtaClient
 	newCatalog          func() (cwprofiles.Catalog, error) // nil => cwprofiles.DefaultCatalog
 
 	accounts          []cwAccount         // resolved AWS accounts (one per auth identity, deduped by account id)
@@ -82,13 +87,17 @@ type Collector struct {
 	seenAccountID     map[string]string   // account id -> first identity Ref, for cross-cycle dedup
 	chartTemplateYAML string
 
-	profiles  []cwprofiles.ResolvedProfile // candidate profiles selected per profiles.mode
-	clients   *clientCache                 // CloudWatch client cache, one per (account, region)
-	discovery discoverySnapshot
+	profiles    []cwprofiles.ResolvedProfile   // candidate profiles selected per profiles.mode
+	clients     *clientCache[cloudwatchClient] // CloudWatch client cache, one per (account, region)
+	rgtaClients *clientCache[rgtaClient]       // RGTA (tag) client cache, one per (account, region)
+	discovery   discoverySnapshot
 
 	discoverySig string // last-logged discovered-resources summary; Info re-logs only when it changes
 
 	observations *observationStore // retention cache + per-(account, region, period) query schedule
+
+	tags     tagSnapshot              // resource tag cache, refreshed with discovery (empty when tags unconfigured)
+	tagPlans map[string][]resolvedTag // per-profile resolved tag->label plans (nil when tags unconfigured)
 }
 
 func (c *Collector) Init(context.Context) error {
@@ -122,7 +131,10 @@ func (c *Collector) Cleanup(context.Context) {
 	c.discovery = discoverySnapshot{}
 	c.discoverySig = ""
 	c.clients.reset()
+	c.rgtaClients.reset()
 	c.observations.reset()
+	c.tags = tagSnapshot{}
+	c.tagPlans = nil
 }
 
 func (c *Collector) Configuration() any { return c.Config }

--- a/src/go/plugin/go.d/collector/cloudwatch/config.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Auth               awsauth.Config   `yaml:"auth" json:"auth"`
 	Profiles           ProfilesConfig   `yaml:"profiles" json:"profiles"`
 	Discovery          DiscoveryConfig  `yaml:"discovery" json:"discovery"`
+	Tags               []TagConfig      `yaml:"tags,omitempty" json:"tags,omitempty"`
 	QueryOffset        int              `yaml:"query_offset,omitempty" json:"query_offset"`
 	Timeout            confopt.Duration `yaml:"timeout,omitempty" json:"timeout"`
 }
@@ -58,6 +59,17 @@ type ProfilesExactConfig struct {
 // ProfileEntry names one profile (by basename) to collect in exact mode.
 type ProfileEntry struct {
 	Name string `yaml:"name" json:"name"`
+}
+
+// TagConfig selects one AWS resource tag to emit as an additional label. Name is
+// the AWS tag key (case-sensitive). Rename optionally sets the Netdata label name;
+// without it the label is the sanitized tag key. An empty allowlist disables tag
+// enrichment entirely (no RGTA calls, no extra IAM). Tag resolution -- sanitize,
+// collision skip-and-warn, per-service ARN join -- is non-fatal and runs after
+// profile selection, never in config validation.
+type TagConfig struct {
+	Name   string `yaml:"name" json:"name"`
+	Rename string `yaml:"rename,omitempty" json:"rename,omitempty"`
 }
 
 type DiscoveryConfig struct {

--- a/src/go/plugin/go.d/collector/cloudwatch/config_schema.json
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_schema.json
@@ -241,6 +241,30 @@
           }
         }
       },
+      "tags": {
+        "title": "Resource tags",
+        "description": "AWS resource tags to attach as labels on collected metrics, looked up via the Resource Groups Tagging API. Empty by default; listing any tag enables tag lookup and requires the tag:GetResources IAM permission. Tag values may contain personal data (e.g. owner emails) -- only list tags you want exposed as labels.",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Tag key",
+              "description": "AWS tag key to collect (case-sensitive), e.g. owner. Becomes the sanitized label (e.g. owner) unless renamed.",
+              "type": "string"
+            },
+            "rename": {
+              "title": "Label name",
+              "description": "Optional Netdata label name to use instead of the sanitized tag key. Use it when the sanitized key would be invalid (for example an aws:-prefixed key) or collides with a built-in label such as region.",
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*$"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      },
       "query_offset": {
         "title": "Query offset",
         "description": "Seconds subtracted from now when querying, to account for CloudWatch publish latency.",
@@ -335,6 +359,20 @@
         }
       }
     },
+    "tags": {
+      "ui:listFlavour": "list",
+      "ui:help": "AWS resource tags to attach as labels. Add one row per tag. Leave empty to disable tag enrichment (no extra IAM or API calls). Tag values may contain personal data (e.g. owner emails) -- only list tags you want exposed.",
+      "items": {
+        "name": {
+          "ui:help": "AWS tag key (case-sensitive).",
+          "ui:placeholder": "owner"
+        },
+        "rename": {
+          "ui:help": "Optional label name; defaults to the sanitized tag key. Use it to rename or to resolve a collision (e.g. the tag 'region' -> 'aws_region').",
+          "ui:placeholder": "aws_region"
+        }
+      }
+    },
     "discovery": {
       "refresh_every": {
         "ui:help": "How often to re-run metric discovery (ListMetrics). Discovery is cheap; raise this only to cut API load on very large accounts."
@@ -382,6 +420,12 @@
           "title": "Discovery",
           "fields": [
             "discovery"
+          ]
+        },
+        {
+          "title": "Tags",
+          "fields": [
+            "tags"
           ]
         },
         {

--- a/src/go/plugin/go.d/collector/cloudwatch/config_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func validBaseConfig() Config {
@@ -86,13 +87,39 @@ func TestConfigSchema_RuntimeContract(t *testing.T) {
 	// Every public Config key must have a schema property (drift guard).
 	for _, key := range []string{
 		"update_every", "autodetection_retry", "vnode", "regions", "auth", "profiles",
-		"discovery", "query_offset", "timeout",
+		"discovery", "tags", "query_offset", "timeout",
 	} {
 		assert.Contains(t, doc.JSONSchema.Properties, key, "schema property for %q", key)
 	}
 
 	// Credential fields must be marked sensitive (secret_access_key, session_token, external_id).
 	assert.Equal(t, 3, strings.Count(string(data), `"sensitive": true`), "credential fields marked sensitive")
+}
+
+func TestConfig_TagsDecode(t *testing.T) {
+	// Structural decode only: tag semantics (sanitize, collision skip-and-warn, rename
+	// validation) are resolved non-fatally after profile selection, not in config
+	// decoding or validation. An empty allowlist disables tag enrichment (opt-in).
+	tests := map[string]struct {
+		yaml string
+		want []TagConfig
+	}{
+		"a list of tag specs decodes (optional rename)": {
+			yaml: "regions: [us-east-1]\ntags:\n  - name: owner\n  - name: Name\n    rename: instance_name\n",
+			want: []TagConfig{{Name: "owner"}, {Name: "Name", Rename: "instance_name"}},
+		},
+		"absent tags decodes to nil (opt-in disabled)": {
+			yaml: "regions: [us-east-1]\n",
+			want: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var c Config
+			require.NoError(t, yaml.Unmarshal([]byte(tc.yaml), &c))
+			assert.Equal(t, tc.want, c.Tags)
+		})
+	}
 }
 
 func TestRegionPartition(t *testing.T) {

--- a/src/go/plugin/go.d/collector/cloudwatch/identity.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/identity.go
@@ -76,6 +76,7 @@ func (c *Collector) ensureAccounts(ctx context.Context) error {
 		c.seenAccountID[acctID] = id.Ref
 		c.accounts = append(c.accounts, cwAccount{identity: id, accountID: acctID})
 		c.markDiscoveryStale() // discover the newly-resolved account this cycle, not after refresh_every
+		c.markTagsStale()      // and fetch its tags this cycle, so its first charts are created tagged
 		c.Infof("CloudWatch: monitoring %d AWS account(s): %s", len(c.accounts), strings.Join(c.accountIDs(), ", "))
 	}
 

--- a/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
@@ -76,7 +76,7 @@ This collector is supported on all platforms.
 
 This collector supports collecting metrics from multiple instances of this integration, including remote instances.
 
-The configured IAM identity requires `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and `sts:GetCallerIdentity`. When `auth.mode` is `assume_role`, it also requires `sts:AssumeRole`.
+The configured IAM identity requires `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and `sts:GetCallerIdentity`. When `auth.mode` is `assume_role`, it also requires `sts:AssumeRole`. Resource tag enrichment (the optional `tags` option) additionally requires `tag:GetResources`.
 
 
 ### Default Behavior
@@ -91,7 +91,7 @@ With `profiles.mode: auto` (default), the collector discovers metrics for all bu
 - Minimum collection interval is 60 seconds (CloudWatch's minimum metric period).
 - CloudWatch publishes metrics with a delay; the effective query offset is `max(query_offset, period)`, so long-period metrics (such as the daily S3 storage metrics) are inherently about one period behind.
 - There is no cap on discovered resources; a warning is logged at 1000 or more discovered instances (collection is never truncated).
-- Resources are labeled by their identifying CloudWatch dimensions (for example EC2 `instance_id`), not by their `Name` tag or other resource tags; tag-based naming and filtering are not currently supported. (A dimension that is constant across resources, such as CloudFront's `Region=Global`, is used to match and query metrics but is not turned into a label.)
+- Resources are labeled by their identifying CloudWatch dimensions (for example EC2 `instance_id`). Selected resource tags can additionally be attached as labels via the opt-in `tags` option (using the Resource Groups Tagging API); tags are enrichment only and never change a resource's identity. (A dimension that is constant across resources, such as CloudFront's `Region=Global`, is used to match and query metrics but is not turned into a label.)
 
 
 #### Performance Impact
@@ -141,7 +141,7 @@ Attach a policy such as:
 }
 ```
 
-`cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and `sts:GetCallerIdentity` do not support resource-level permissions, so `"Resource": "*"` is required -- this is already least-privilege for these read actions. In `assume_role` mode, scope `sts:AssumeRole` to the specific role ARN(s) rather than `*`.
+`cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and `sts:GetCallerIdentity` do not support resource-level permissions, so `"Resource": "*"` is required -- this is already least-privilege for these read actions. In `assume_role` mode, scope `sts:AssumeRole` to the specific role ARN(s) rather than `*`. To enable resource tag enrichment (the optional `tags` option), also grant `tag:GetResources` (it likewise requires `"Resource": "*"`).
 
 Then provide credentials with one of the `auth.mode` options:
 
@@ -188,6 +188,7 @@ A user profile file with the same basename as a stock profile overrides it.
 |  | profiles.mode_exact.entries | List of profiles to collect by basename (required when `profiles.mode` is `exact`). Each entry has a `name`, e.g. `ec2` or `alb_target`. |  | no |
 | **Discovery** | discovery.refresh_every | How often (seconds) to re-discover metrics. Minimum 60. | 300 | no |
 |  | discovery.recently_active_only | List only metrics active in the last 3 hours. Automatically disabled for metrics whose period exceeds 3 hours (such as the daily S3 storage metrics). | yes | no |
+| **Tags** | tags | Optional allowlist of AWS resource tags to attach as extra labels on collected metrics, looked up via the Resource Groups Tagging API. Empty by default -- with no tags listed, no tag lookup runs and no extra IAM is needed. Each entry has a `name` (the AWS tag key, case-sensitive) and an optional `rename` (the Netdata label name; the default is the sanitized key, so `Name` becomes `name`). Use `rename` when the key is not a valid label (for example an `aws:`-prefixed key) or collides with a built-in label such as `region`. Enabling tags requires the `tag:GetResources` IAM permission. Note: tag values become label values and may contain personal data (such as owner emails), so list only tags you want exposed as labels. Tags apply only to profiles with a supported resource-ARN join; some services are not tag-enriched: Auto Scaling and Bedrock (not taggable via the Resource Groups Tagging API), and -- pending a reliable ARN join -- API Gateway, CloudFront, MSK, and ElastiCache. Tags behave as create-time chart labels: a tag that first appears or changes value after a chart already exists is reflected only when that chart is next recreated. |  | no |
 | **Virtual Node** | vnode | Associates this data collection job with a [Virtual Node](https://learn.netdata.cloud/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts#virtual-nodes). |  | no |
 
 <a id="option-authentication-auth-mode"></a>

--- a/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
@@ -114,7 +114,7 @@ modules:
       multi_instance: true
       additional_permissions:
         description: |
-          The configured IAM identity requires `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and `sts:GetCallerIdentity`. When `auth.mode` is `assume_role`, it also requires `sts:AssumeRole`.
+          The configured IAM identity requires `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and `sts:GetCallerIdentity`. When `auth.mode` is `assume_role`, it also requires `sts:AssumeRole`. Resource tag enrichment (the optional `tags` option) additionally requires `tag:GetResources`.
       default_behavior:
         auto_detection:
           description: |
@@ -124,7 +124,7 @@ modules:
             - Minimum collection interval is 60 seconds (CloudWatch's minimum metric period).
             - CloudWatch publishes metrics with a delay; the effective query offset is `max(query_offset, period)`, so long-period metrics (such as the daily S3 storage metrics) are inherently about one period behind.
             - There is no cap on discovered resources; a warning is logged at 1000 or more discovered instances (collection is never truncated).
-            - Resources are labeled by their identifying CloudWatch dimensions (for example EC2 `instance_id`), not by their `Name` tag or other resource tags; tag-based naming and filtering are not currently supported. (A dimension that is constant across resources, such as CloudFront's `Region=Global`, is used to match and query metrics but is not turned into a label.)
+            - Resources are labeled by their identifying CloudWatch dimensions (for example EC2 `instance_id`). Selected resource tags can additionally be attached as labels via the opt-in `tags` option (using the Resource Groups Tagging API); tags are enrichment only and never change a resource's identity. (A dimension that is constant across resources, such as CloudFront's `Region=Global`, is used to match and query metrics but is not turned into a label.)
         performance_impact:
           description: |
             AWS bills CloudWatch API usage. `GetMetricData` (the metric queries) is the cost driver, billed per metric requested; `ListMetrics` discovery falls under the free tier and then costs a fraction as much. As a rough anchor, `GetMetricData` is billed at roughly $0.01 per 1,000 metrics requested -- confirm current [CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/) for your region. Each combination of instance, metric, and statistic is one billed query, run once per its own period (not once per collection cycle), so cost scales with discovered instances, metrics, statistics, and their periods -- not with `update_every`. The collector already minimizes it with curated per-service profiles, single-statistic defaults, exact dimension filtering, cached discovery, and `recently_active_only`. To reduce it further, restrict services with `profiles.mode: exact` or narrow `regions`.
@@ -154,7 +154,7 @@ modules:
               }
               ```
 
-              `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and `sts:GetCallerIdentity` do not support resource-level permissions, so `"Resource": "*"` is required -- this is already least-privilege for these read actions. In `assume_role` mode, scope `sts:AssumeRole` to the specific role ARN(s) rather than `*`.
+              `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and `sts:GetCallerIdentity` do not support resource-level permissions, so `"Resource": "*"` is required -- this is already least-privilege for these read actions. In `assume_role` mode, scope `sts:AssumeRole` to the specific role ARN(s) rather than `*`. To enable resource tag enrichment (the optional `tags` option), also grant `tag:GetResources` (it likewise requires `"Resource": "*"`).
 
               Then provide credentials with one of the `auth.mode` options:
 
@@ -263,6 +263,12 @@ modules:
               default_value: true
               required: false
               group: Discovery
+            - name: tags
+              description: |
+                Optional allowlist of AWS resource tags to attach as extra labels on collected metrics, looked up via the Resource Groups Tagging API. Empty by default -- with no tags listed, no tag lookup runs and no extra IAM is needed. Each entry has a `name` (the AWS tag key, case-sensitive) and an optional `rename` (the Netdata label name; the default is the sanitized key, so `Name` becomes `name`). Use `rename` when the key is not a valid label (for example an `aws:`-prefixed key) or collides with a built-in label such as `region`. Enabling tags requires the `tag:GetResources` IAM permission. Note: tag values become label values and may contain personal data (such as owner emails), so list only tags you want exposed as labels. Tags apply only to profiles with a supported resource-ARN join; some services are not tag-enriched: Auto Scaling and Bedrock (not taggable via the Resource Groups Tagging API), and -- pending a reliable ARN join -- API Gateway, CloudFront, MSK, and ElastiCache. Tags behave as create-time chart labels: a tag that first appears or changes value after a chart already exists is reflected only when that chart is next recreated.
+              default_value: ""
+              required: false
+              group: Tags
             - name: vnode
               description: Associates this data collection job with a [Virtual Node](https://learn.netdata.cloud/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts#virtual-nodes).
               default_value: ""

--- a/src/go/plugin/go.d/collector/cloudwatch/observe.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/observe.go
@@ -15,6 +15,7 @@ import (
 type observedSeries struct {
 	seriesName string
 	labels     []metrix.Label
+	tagLabels  []metrix.Label // non-identity enrichment; re-emitted with the series, not in observedKey
 	value      float64
 	groupKey   queryGroupKey // (account, region, effective period) — the scheduling unit
 }
@@ -103,10 +104,11 @@ func (o *observationStore) observe(dueQueries []plannedQuery, samples []querySam
 	observedThisCycle := make(map[string]bool, len(samples))
 	for _, s := range samples {
 		key := observedKey(s.seriesName, s.labels)
-		writeSample(meter, s.seriesName, s.labels, s.value)
+		writeSample(meter, s.seriesName, s.labels, s.tagLabels, s.value)
 		o.lastObserved[key] = observedSeries{
 			seriesName: s.seriesName,
 			labels:     s.labels,
+			tagLabels:  s.tagLabels,
 			value:      s.value,
 			groupKey:   s.groupKey(),
 		}
@@ -126,10 +128,11 @@ func (o *observationStore) observe(dueQueries []plannedQuery, samples []querySam
 			continue // had a datapoint
 		}
 		if pq.nilAsZero && noData[pq.id] {
-			writeSample(meter, pq.seriesName, pq.labels, 0)
+			writeSample(meter, pq.seriesName, pq.labels, pq.tagLabels, 0)
 			o.lastObserved[key] = observedSeries{
 				seriesName: pq.seriesName,
 				labels:     pq.labels,
+				tagLabels:  pq.tagLabels,
 				value:      0,
 				groupKey:   pq.groupKey(),
 			}
@@ -143,15 +146,25 @@ func (o *observationStore) observe(dueQueries []plannedQuery, samples []querySam
 		if observedThisCycle[key] || queried[obs.groupKey] {
 			continue
 		}
-		writeSample(meter, obs.seriesName, obs.labels, obs.value)
+		writeSample(meter, obs.seriesName, obs.labels, obs.tagLabels, obs.value)
 	}
 }
 
-func writeSample(meter metrix.SnapshotMeter, seriesName string, labels []metrix.Label, value float64) {
+func writeSample(meter metrix.SnapshotMeter, seriesName string, labels, tagLabels []metrix.Label, value float64) {
+	// Identity labels are shared read-only across an instance's queries, so tag
+	// enrichment is concatenated into a FRESH slice, never appended onto labels.
+	// tagLabels are non-identity (not part of observedKey), so a tag change never
+	// churns retention/scheduling.
+	all := labels
+	if len(tagLabels) > 0 {
+		all = make([]metrix.Label, 0, len(labels)+len(tagLabels))
+		all = append(all, labels...)
+		all = append(all, tagLabels...)
+	}
 	// WithFloat marks the metric float-native; chartengine inherits that onto the
 	// chart dimension, so CloudWatch's fractional values render at full precision
 	// without injecting options.float per dimension.
-	meter.WithLabels(labels...).Gauge(seriesName, metrix.WithFloat(true)).Observe(value)
+	meter.WithLabels(all...).Gauge(seriesName, metrix.WithFloat(true)).Observe(value)
 }
 
 // pruneObserved drops both the retention-cache entries and the per-(account, region,

--- a/src/go/plugin/go.d/collector/cloudwatch/query_executor.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/query_executor.go
@@ -238,7 +238,7 @@ func (c *Collector) runGetMetricData(ctx context.Context, client cloudwatchClien
 		id := aws.ToString(q.Id)
 		if value, ok := valueByID[id]; ok {
 			pq := byID[id]
-			samples = append(samples, querySample{seriesName: pq.seriesName, labels: pq.labels, value: value, account: pq.account, region: pq.region, period: pq.period})
+			samples = append(samples, querySample{seriesName: pq.seriesName, labels: pq.labels, tagLabels: pq.tagLabels, value: value, account: pq.account, region: pq.region, period: pq.period})
 			continue
 		}
 		if usableByID[id] {

--- a/src/go/plugin/go.d/collector/cloudwatch/query_plan.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/query_plan.go
@@ -18,6 +18,7 @@ import (
 type querySample struct {
 	seriesName string
 	labels     []metrix.Label
+	tagLabels  []metrix.Label // non-identity enrichment labels; emitted but not in observedKey
 	value      float64
 	account    string
 	region     string
@@ -33,7 +34,8 @@ type plannedQuery struct {
 	period     int
 	seriesName string
 	labels     []metrix.Label
-	nilAsZero  bool // record 0 (vs a gap) when the query returns no datapoint
+	tagLabels  []metrix.Label // non-identity enrichment labels; emitted but not in observedKey
+	nilAsZero  bool           // record 0 (vs a gap) when the query returns no datapoint
 	query      cwtypes.MetricDataQuery
 }
 
@@ -86,7 +88,8 @@ func (c *Collector) buildQueryPlan() []plannedQuery {
 						continue // defensive: snapshot/profile mismatch
 					}
 					labels, dims := c.instanceLabelsAndDims(acct.accountID, prof, region, inst)
-					plan = append(plan, c.metricQueries(acct.accountID, prof, region, labels, dims, &idx)...)
+					tagLabels := c.tagLabelsFor(acct.accountID, region, prof, inst.DimensionValues)
+					plan = append(plan, c.metricQueries(acct.accountID, prof, region, labels, tagLabels, dims, &idx)...)
 				}
 			}
 		}
@@ -120,7 +123,7 @@ func (c *Collector) instanceLabelsAndDims(accountID string, prof cwprofiles.Reso
 
 // metricQueries builds the planned queries for one instance: one per
 // (metric × statistic), allocating sequential q<idx> ids through idx.
-func (c *Collector) metricQueries(accountID string, prof cwprofiles.ResolvedProfile, region string, labels []metrix.Label, dims []cwtypes.Dimension, idx *int) []plannedQuery {
+func (c *Collector) metricQueries(accountID string, prof cwprofiles.ResolvedProfile, region string, labels, tagLabels []metrix.Label, dims []cwtypes.Dimension, idx *int) []plannedQuery {
 	var out []plannedQuery
 	for _, m := range prof.Config.Metrics {
 		period := prof.Config.EffectivePeriod(m)
@@ -135,6 +138,7 @@ func (c *Collector) metricQueries(accountID string, prof cwprofiles.ResolvedProf
 				period:     period,
 				seriesName: cwprofiles.ExportedSeriesName(prof.Name, m.ID, token),
 				labels:     labels,
+				tagLabels:  tagLabels,
 				nilAsZero:  m.EmitZeroOnNoData(token),
 				query: cwtypes.MetricDataQuery{
 					Id: aws.String(id),

--- a/src/go/plugin/go.d/collector/cloudwatch/tagjoin.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagjoin.go
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/cwprofiles"
+)
+
+// tagJoin describes, for one profile, how to project BOTH a discovered instance and
+// an RGTA-returned resource ARN onto a common "join key", so a resource's tags
+// attach to the right series.
+//
+//   - resourceTypes are the RGTA GetResources ResourceTypeFilters that narrow the
+//     scan to this profile's resources, and (reversed) map an ARN's service[:type]
+//     back to the profile.
+//   - joinDims names the profile dimensions that form the key, in order. For a
+//     single-resource profile it is the one identifying dimension; for a
+//     parent-resource profile (e.g. S3 across storage_type) it is only the parent
+//     dimension, so every child instance inherits the parent's tags.
+//   - arnValues extracts the joinDims values from an ARN (nil => defaultARNValues,
+//     the resource-id after the last '/' or ':'). It returns ok=false when the ARN
+//     is not this profile's flavour (e.g. a classic-ELB extractor rejects an ALB
+//     ARN), so a shared resource type can fan out to the right profile.
+//
+// Safety: a wrong extraction can only MISS (the arn-side key won't equal any
+// instance-side key, so that resource contributes no tags) — it can never mislabel,
+// because the instance side always uses the real discovered dimension values.
+type tagJoin struct {
+	resourceTypes []string
+	joinDims      []string
+	arnValues     func(a arn.ARN) ([]string, bool)
+}
+
+// tagJoins is the per-profile (by basename) join registry. Only profiles listed
+// here are tag-enriched; a profile with no entry (risky/ambiguous joins like
+// cloudfront/api_gateway/msk/elasticache, or non-taggable auto_scaling/bedrock)
+// simply carries no tags — graceful under INV.2.
+var tagJoins = map[string]tagJoin{
+	// Sound single-dimension joins: default extractor (resource-id = last segment).
+	"ec2":         {resourceTypes: []string{"ec2:instance"}, joinDims: []string{"InstanceId"}},
+	"ebs":         {resourceTypes: []string{"ec2:volume"}, joinDims: []string{"VolumeId"}},
+	"efs":         {resourceTypes: []string{"elasticfilesystem:file-system"}, joinDims: []string{"FileSystemId"}},
+	"nat_gateway": {resourceTypes: []string{"ec2:natgateway"}, joinDims: []string{"NatGatewayId"}},
+	"vpn":         {resourceTypes: []string{"ec2:vpn-connection"}, joinDims: []string{"VpnId"}},
+	// rds and docdb share the rds:db ARN type. The join is unambiguous because a
+	// DBInstanceIdentifier is unique per account+region across the rds:db family
+	// (RDS/DocDB/Neptune), so an ARN matches at most one discovered instance and
+	// cross-family entries are inert. (Confirmed in live smoke.)
+	"rds":      {resourceTypes: []string{"rds:db"}, joinDims: []string{"DBInstanceIdentifier"}},
+	"docdb":    {resourceTypes: []string{"rds:db"}, joinDims: []string{"DBInstanceIdentifier"}},
+	"lambda":   {resourceTypes: []string{"lambda:function"}, joinDims: []string{"FunctionName"}},
+	"sqs":      {resourceTypes: []string{"sqs"}, joinDims: []string{"QueueName"}},
+	"sns":      {resourceTypes: []string{"sns"}, joinDims: []string{"TopicName"}},
+	"eks":      {resourceTypes: []string{"eks:cluster"}, joinDims: []string{"ClusterName"}},
+	"kinesis":  {resourceTypes: []string{"kinesis:stream"}, joinDims: []string{"StreamName"}},
+	"firehose": {resourceTypes: []string{"firehose:deliverystream"}, joinDims: []string{"DeliveryStreamName"}},
+	"redshift": {resourceTypes: []string{"redshift:cluster"}, joinDims: []string{"ClusterIdentifier"}},
+	"dynamodb": {resourceTypes: []string{"dynamodb:table"}, joinDims: []string{"TableName"}},
+
+	// Parent-resource joins: joinDims is the parent dimension only, so children
+	// (across storage_type / filter_id / operation) inherit the parent's tags.
+	"s3":                 {resourceTypes: []string{"s3"}, joinDims: []string{"BucketName"}},
+	"s3_requests":        {resourceTypes: []string{"s3"}, joinDims: []string{"BucketName"}},
+	"dynamodb_operation": {resourceTypes: []string{"dynamodb:table"}, joinDims: []string{"TableName"}},
+
+	// Overrides: shared/quirky ARN shapes.
+	"elb":            {resourceTypes: []string{"elasticloadbalancing:loadbalancer"}, joinDims: []string{"LoadBalancerName"}, arnValues: elbClassicARNValues},
+	"alb":            {resourceTypes: []string{"elasticloadbalancing:loadbalancer"}, joinDims: []string{"LoadBalancer"}, arnValues: albARNValues},
+	"nlb":            {resourceTypes: []string{"elasticloadbalancing:loadbalancer"}, joinDims: []string{"LoadBalancer"}, arnValues: nlbARNValues},
+	"alb_target":     {resourceTypes: []string{"elasticloadbalancing:targetgroup"}, joinDims: []string{"TargetGroup"}, arnValues: albTargetARNValues},
+	"ecs":            {resourceTypes: []string{"ecs:service"}, joinDims: []string{"ClusterName", "ServiceName"}, arnValues: ecsARNValues},
+	"opensearch":     {resourceTypes: []string{"es:domain"}, joinDims: []string{"ClientId", "DomainName"}, arnValues: opensearchARNValues},
+	"step_functions": {resourceTypes: []string{"states:stateMachine"}, joinDims: []string{"StateMachineArn"}, arnValues: stepFunctionsARNValues},
+	// eventbridge is default-bus-only ({RuleName}); its override rejects custom-bus
+	// rule ARNs so a custom-bus rule cannot mis-tag a same-named default-bus rule.
+	"eventbridge": {resourceTypes: []string{"events:rule"}, joinDims: []string{"RuleName"}, arnValues: eventbridgeARNValues},
+}
+
+// defaultARNValues extracts a single-segment resource id: the part after the FIRST
+// '/' or ':' (e.g. "instance/i-abc" -> "i-abc", "db:name" -> "name"), or the whole
+// resource when it has no separator (e.g. an SQS queue name or an S3 bucket). It
+// REJECTS a resource whose id part carries a further '/' or ':' (a sub-resource or
+// qualifier, e.g. "instance/foo/i-1" or "function:name:version") so an unexpected
+// ARN misses rather than mis-tagging via a coincidental trailing segment.
+func defaultARNValues(a arn.ARN) ([]string, bool) {
+	res := a.Resource
+	i := strings.IndexAny(res, "/:")
+	if i < 0 {
+		if res == "" {
+			return nil, false
+		}
+		return []string{res}, true
+	}
+	id := res[i+1:]
+	if id == "" || strings.ContainsAny(id, "/:") {
+		return nil, false
+	}
+	return []string{id}, true
+}
+
+// elbClassicARNValues matches a classic ELB (loadbalancer/<name>); it rejects the
+// ALB/NLB shape (loadbalancer/app|net/...), which shares the resource type.
+func elbClassicARNValues(a arn.ARN) ([]string, bool) {
+	const p = "loadbalancer/"
+	if !strings.HasPrefix(a.Resource, p) {
+		return nil, false
+	}
+	name := strings.TrimPrefix(a.Resource, p)
+	if name == "" || strings.Contains(name, "/") {
+		return nil, false // "app/..."/"net/..." => v2 load balancer, not classic
+	}
+	return []string{name}, true
+}
+
+func albARNValues(a arn.ARN) ([]string, bool) { return elbV2Values(a, "app/") }
+func nlbARNValues(a arn.ARN) ([]string, bool) { return elbV2Values(a, "net/") }
+
+// elbV2Values matches an ALB/NLB whose CloudWatch LoadBalancer dimension is the ARN
+// suffix after "loadbalancer/" (e.g. "app/name/hash").
+func elbV2Values(a arn.ARN, kind string) ([]string, bool) {
+	const p = "loadbalancer/"
+	if !strings.HasPrefix(a.Resource, p) {
+		return nil, false
+	}
+	lb := strings.TrimPrefix(a.Resource, p)
+	if !strings.HasPrefix(lb, kind) {
+		return nil, false
+	}
+	return []string{lb}, true
+}
+
+// albTargetARNValues: the TargetGroup dimension value is the full "targetgroup/..."
+// resource, so the join key keeps the prefix.
+func albTargetARNValues(a arn.ARN) ([]string, bool) {
+	if !strings.HasPrefix(a.Resource, "targetgroup/") {
+		return nil, false
+	}
+	return []string{a.Resource}, true
+}
+
+// ecsARNValues: an ECS service ARN is "service/<cluster>/<service>".
+func ecsARNValues(a arn.ARN) ([]string, bool) {
+	if !strings.HasPrefix(a.Resource, "service/") {
+		return nil, false
+	}
+	parts := strings.Split(a.Resource, "/")
+	if len(parts) != 3 || parts[1] == "" || parts[2] == "" {
+		return nil, false
+	}
+	return []string{parts[1], parts[2]}, true
+}
+
+// opensearchARNValues: OpenSearch's ClientId dimension is the AWS account id and
+// DomainName is the domain ("domain/<name>" resource).
+func opensearchARNValues(a arn.ARN) ([]string, bool) {
+	const p = "domain/"
+	if a.AccountID == "" || !strings.HasPrefix(a.Resource, p) {
+		return nil, false
+	}
+	name := strings.TrimPrefix(a.Resource, p)
+	if name == "" {
+		return nil, false
+	}
+	return []string{a.AccountID, name}, true
+}
+
+// stepFunctionsARNValues: the StateMachineArn dimension value IS the full ARN.
+func stepFunctionsARNValues(a arn.ARN) ([]string, bool) {
+	if a.Resource == "" {
+		return nil, false
+	}
+	return []string{a.String()}, true
+}
+
+// eventbridgeARNValues matches only a DEFAULT-bus rule ("rule/<RuleName>"). It
+// rejects a custom-bus rule ("rule/<EventBusName>/<RuleName>"): the {RuleName}-only
+// profile represents default-bus rules, so a custom-bus rule of the same name must
+// not join (miss, never mis-tag).
+func eventbridgeARNValues(a arn.ARN) ([]string, bool) {
+	const p = "rule/"
+	if !strings.HasPrefix(a.Resource, p) {
+		return nil, false
+	}
+	name := strings.TrimPrefix(a.Resource, p)
+	if name == "" || strings.Contains(name, "/") {
+		return nil, false
+	}
+	return []string{name}, true
+}
+
+// arnJoinKey computes this profile's join key from a resource ARN, or ok=false when
+// the ARN is not this profile's flavour.
+func (tj tagJoin) arnJoinKey(a arn.ARN) (string, bool) {
+	fn := tj.arnValues
+	if fn == nil {
+		fn = defaultARNValues
+	}
+	vals, ok := fn(a)
+	if !ok || len(vals) != len(tj.joinDims) {
+		return "", false
+	}
+	return strings.Join(vals, instanceKeySep), true
+}
+
+// instanceJoinKey computes this profile's join key from a discovered instance's
+// dimension values (ordered by dimNames = Profile.DimensionNames()).
+func (tj tagJoin) instanceJoinKey(dimNames, values []string) (string, bool) {
+	parts := make([]string, len(tj.joinDims))
+	for i, jd := range tj.joinDims {
+		idx := indexOfString(dimNames, jd)
+		if idx < 0 || idx >= len(values) {
+			return "", false
+		}
+		parts[i] = values[idx]
+	}
+	return strings.Join(parts, instanceKeySep), true
+}
+
+func indexOfString(ss []string, s string) int {
+	for i, v := range ss {
+		if v == s {
+			return i
+		}
+	}
+	return -1
+}
+
+// deriveResourceType maps an ARN to the "service[:type]" key used to look a profile
+// up in the resource-type index (and matching the ResourceTypeFilters strings).
+func deriveResourceType(a arn.ARN) string {
+	if i := strings.IndexAny(a.Resource, "/:"); i >= 0 {
+		return a.Service + ":" + a.Resource[:i]
+	}
+	return a.Service
+}
+
+// selectedTagJoins returns the registered joins for the given selected profiles,
+// keyed by profile basename. Profiles with no registered join are omitted (no tags).
+func selectedTagJoins(profiles []cwprofiles.ResolvedProfile) map[string]tagJoin {
+	out := make(map[string]tagJoin)
+	for _, p := range profiles {
+		if tj, ok := tagJoins[p.Name]; ok {
+			out[p.Name] = tj
+		}
+	}
+	return out
+}
+
+// resourceTypeFilters is the deduped union of ResourceTypeFilters across the given
+// joins, to narrow the RGTA GetResources scan.
+func resourceTypeFilters(joins map[string]tagJoin) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, tj := range joins {
+		for _, rt := range tj.resourceTypes {
+			if _, dup := seen[rt]; dup {
+				continue
+			}
+			seen[rt] = struct{}{}
+			out = append(out, rt)
+		}
+	}
+	return out
+}
+
+// resourceTypeIndex maps each resource-type to the profile basenames that claim it
+// (a shared type like elasticloadbalancing:loadbalancer fans out to elb/alb/nlb,
+// disambiguated by each join's arnValues).
+func resourceTypeIndex(joins map[string]tagJoin) map[string][]string {
+	out := make(map[string][]string)
+	for name, tj := range joins {
+		for _, rt := range tj.resourceTypes {
+			out[rt] = append(out[rt], name)
+		}
+	}
+	return out
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/tagjoin_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagjoin_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/cwprofiles"
+)
+
+// TestTagJoin_RoundTrip is the load-bearing check: for a representative resource
+// ARN and the matching discovered instance's dimension values, the arn-derived and
+// instance-derived join keys must be equal (both non-empty). If they diverge, the
+// resource's tags would silently not attach.
+func TestTagJoin_RoundTrip(t *testing.T) {
+	const acct = "111122223333"
+	tests := map[string]struct {
+		profile  string
+		dimNames []string
+		values   []string
+		arnStr   string
+	}{
+		"ec2":         {"ec2", []string{"InstanceId"}, []string{"i-0abc123"}, "arn:aws:ec2:us-east-1:" + acct + ":instance/i-0abc123"},
+		"ebs":         {"ebs", []string{"VolumeId"}, []string{"vol-0abc123"}, "arn:aws:ec2:us-east-1:" + acct + ":volume/vol-0abc123"},
+		"efs":         {"efs", []string{"FileSystemId"}, []string{"fs-0abc123"}, "arn:aws:elasticfilesystem:us-east-1:" + acct + ":file-system/fs-0abc123"},
+		"nat_gateway": {"nat_gateway", []string{"NatGatewayId"}, []string{"nat-0abc123"}, "arn:aws:ec2:us-east-1:" + acct + ":natgateway/nat-0abc123"},
+		"vpn":         {"vpn", []string{"VpnId"}, []string{"vpn-0abc123"}, "arn:aws:ec2:us-east-1:" + acct + ":vpn-connection/vpn-0abc123"},
+		"rds":         {"rds", []string{"DBInstanceIdentifier"}, []string{"mydb"}, "arn:aws:rds:us-east-1:" + acct + ":db:mydb"},
+		"docdb":       {"docdb", []string{"DBInstanceIdentifier"}, []string{"mydocdb"}, "arn:aws:rds:us-east-1:" + acct + ":db:mydocdb"},
+		"lambda":      {"lambda", []string{"FunctionName"}, []string{"myfn"}, "arn:aws:lambda:us-east-1:" + acct + ":function:myfn"},
+		"sqs":         {"sqs", []string{"QueueName"}, []string{"myqueue"}, "arn:aws:sqs:us-east-1:" + acct + ":myqueue"},
+		"sns":         {"sns", []string{"TopicName"}, []string{"mytopic"}, "arn:aws:sns:us-east-1:" + acct + ":mytopic"},
+		"eks":         {"eks", []string{"ClusterName"}, []string{"mycluster"}, "arn:aws:eks:us-east-1:" + acct + ":cluster/mycluster"},
+		"kinesis":     {"kinesis", []string{"StreamName"}, []string{"mystream"}, "arn:aws:kinesis:us-east-1:" + acct + ":stream/mystream"},
+		"firehose":    {"firehose", []string{"DeliveryStreamName"}, []string{"mystream"}, "arn:aws:firehose:us-east-1:" + acct + ":deliverystream/mystream"},
+		"redshift":    {"redshift", []string{"ClusterIdentifier"}, []string{"mycluster"}, "arn:aws:redshift:us-east-1:" + acct + ":cluster:mycluster"},
+		"dynamodb":    {"dynamodb", []string{"TableName"}, []string{"mytable"}, "arn:aws:dynamodb:us-east-1:" + acct + ":table/mytable"},
+		"eventbridge": {"eventbridge", []string{"RuleName"}, []string{"myrule"}, "arn:aws:events:us-east-1:" + acct + ":rule/myrule"},
+
+		// Parent-resource: the child dimension (storage_type/filter_id/operation) is
+		// not in the ARN; the join key is the parent, so the child inherits its tags.
+		"s3 (parent bucket, ignores storage_type)": {"s3", []string{"BucketName", "StorageType"}, []string{"mybucket", "StandardStorage"}, "arn:aws:s3:::mybucket"},
+		"s3_requests (parent bucket)":              {"s3_requests", []string{"BucketName", "FilterId"}, []string{"mybucket", "myfilter"}, "arn:aws:s3:::mybucket"},
+		"dynamodb_operation (parent table)":        {"dynamodb_operation", []string{"TableName", "Operation"}, []string{"mytable", "GetItem"}, "arn:aws:dynamodb:us-east-1:" + acct + ":table/mytable"},
+
+		// ELB family shares the loadbalancer resource type; each flavour extracts differently.
+		"elb classic (name)":       {"elb", []string{"LoadBalancerName"}, []string{"my-elb"}, "arn:aws:elasticloadbalancing:us-east-1:" + acct + ":loadbalancer/my-elb"},
+		"alb (app/name/hash)":      {"alb", []string{"LoadBalancer"}, []string{"app/my-alb/50dc6c495c0c9188"}, "arn:aws:elasticloadbalancing:us-east-1:" + acct + ":loadbalancer/app/my-alb/50dc6c495c0c9188"},
+		"nlb (net/name/hash)":      {"nlb", []string{"LoadBalancer"}, []string{"net/my-nlb/50dc6c495c0c9188"}, "arn:aws:elasticloadbalancing:us-east-1:" + acct + ":loadbalancer/net/my-nlb/50dc6c495c0c9188"},
+		"alb_target (full prefix)": {"alb_target", []string{"LoadBalancer", "TargetGroup"}, []string{"app/my-alb/50dc6c495c0c9188", "targetgroup/my-tg/73e2d6bc24d8a067"}, "arn:aws:elasticloadbalancing:us-east-1:" + acct + ":targetgroup/my-tg/73e2d6bc24d8a067"},
+
+		// Multi-dimension joins fully derivable from the ARN.
+		"ecs (cluster+service)":    {"ecs", []string{"ClusterName", "ServiceName"}, []string{"mycluster", "mysvc"}, "arn:aws:ecs:us-east-1:" + acct + ":service/mycluster/mysvc"},
+		"opensearch (account+dom)": {"opensearch", []string{"ClientId", "DomainName"}, []string{acct, "mydomain"}, "arn:aws:es:us-east-1:" + acct + ":domain/mydomain"},
+
+		// StateMachineArn dimension value IS the ARN.
+		"step_functions (arn-as-dim)": {"step_functions", []string{"StateMachineArn"}, []string{"arn:aws:states:us-east-1:" + acct + ":stateMachine:mysm"}, "arn:aws:states:us-east-1:" + acct + ":stateMachine:mysm"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tj, ok := tagJoins[tc.profile]
+			require.Truef(t, ok, "no tagJoin for profile %q", tc.profile)
+
+			a, err := arn.Parse(tc.arnStr)
+			require.NoError(t, err)
+
+			ak, aok := tj.arnJoinKey(a)
+			require.Truef(t, aok, "arnJoinKey failed for %q", tc.arnStr)
+
+			ik, iok := tj.instanceJoinKey(tc.dimNames, tc.values)
+			require.True(t, iok, "instanceJoinKey failed")
+
+			assert.Equal(t, ik, ak, "arn-derived and instance-derived join keys must match")
+		})
+	}
+}
+
+func TestTagJoin_ArnJoinKeyCases(t *testing.T) {
+	// arnJoinKey acceptance/rejection. An unexpected shape (foreign load-balancer
+	// flavour on the shared type, a custom-bus rule, or a sub-segment id) must MISS
+	// (never mis-tag). wantKey == "" means "expect a miss (ok == false)".
+	tests := map[string]struct {
+		profile string
+		arn     string
+		wantKey string
+	}{
+		"classic elb accepts loadbalancer/<name>":    {"elb", "arn:aws:elasticloadbalancing:us-east-1:111122223333:loadbalancer/my-elb", "my-elb"},
+		"classic elb rejects an ALB arn":             {"elb", "arn:aws:elasticloadbalancing:us-east-1:111122223333:loadbalancer/app/my-alb/hash", ""},
+		"classic elb rejects an NLB arn":             {"elb", "arn:aws:elasticloadbalancing:us-east-1:111122223333:loadbalancer/net/my-nlb/hash", ""},
+		"alb rejects a classic elb arn":              {"alb", "arn:aws:elasticloadbalancing:us-east-1:111122223333:loadbalancer/my-elb", ""},
+		"alb rejects an NLB arn":                     {"alb", "arn:aws:elasticloadbalancing:us-east-1:111122223333:loadbalancer/net/my-nlb/hash", ""},
+		"nlb rejects an ALB arn":                     {"nlb", "arn:aws:elasticloadbalancing:us-east-1:111122223333:loadbalancer/app/my-alb/hash", ""},
+		"eventbridge accepts a default-bus rule":     {"eventbridge", "arn:aws:events:us-east-1:111122223333:rule/myrule", "myrule"},
+		"eventbridge rejects a custom-bus rule":      {"eventbridge", "arn:aws:events:us-east-1:111122223333:rule/mybus/myrule", ""},
+		"default extractor accepts instance/<id>":    {"ec2", "arn:aws:ec2:us-east-1:111122223333:instance/i-1", "i-1"},
+		"default extractor rejects a sub-segment id": {"ec2", "arn:aws:ec2:us-east-1:111122223333:instance/foo/i-1", ""},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, ok := tagJoins[tc.profile].arnJoinKey(mustParseARN(t, tc.arn))
+			if tc.wantKey == "" {
+				assert.False(t, ok, "expected a miss")
+				return
+			}
+			require.True(t, ok)
+			assert.Equal(t, tc.wantKey, got)
+		})
+	}
+}
+
+func TestDeriveResourceType(t *testing.T) {
+	tests := map[string]string{
+		"arn:aws:ec2:us-east-1:111122223333:instance/i-0abc":                  "ec2:instance",
+		"arn:aws:rds:us-east-1:111122223333:db:mydb":                          "rds:db",
+		"arn:aws:sqs:us-east-1:111122223333:myqueue":                          "sqs",
+		"arn:aws:s3:::mybucket":                                               "s3",
+		"arn:aws:elasticloadbalancing:us-east-1:111122223333:loadbalancer/x":  "elasticloadbalancing:loadbalancer",
+		"arn:aws:elasticloadbalancing:us-east-1:111122223333:targetgroup/x/y": "elasticloadbalancing:targetgroup",
+		"arn:aws:es:us-east-1:111122223333:domain/mydomain":                   "es:domain",
+		"arn:aws:states:us-east-1:111122223333:stateMachine:mysm":             "states:stateMachine",
+	}
+	for arnStr, want := range tests {
+		t.Run(want, func(t *testing.T) {
+			assert.Equal(t, want, deriveResourceType(mustParseARN(t, arnStr)))
+		})
+	}
+}
+
+// TestTagJoins_DimsExistInProfiles is a drift guard: every registered join must
+// reference dimensions that actually exist in its stock profile, and the profile
+// must exist. Catches a profile rename/removal silently disabling a tag join.
+func TestTagJoins_DimsExistInProfiles(t *testing.T) {
+	cat, err := cwprofiles.DefaultCatalog()
+	require.NoError(t, err)
+
+	byName := make(map[string]cwprofiles.ResolvedProfile)
+	for _, p := range cat.AllProfiles() {
+		byName[p.Name] = p
+	}
+
+	for name, tj := range tagJoins {
+		p, ok := byName[name]
+		require.Truef(t, ok, "tagJoins references unknown profile %q", name)
+		dims := p.Config.DimensionNames()
+		for _, jd := range tj.joinDims {
+			assert.Containsf(t, dims, jd, "profile %q joinDim %q missing from dimensions %v", name, jd, dims)
+		}
+	}
+}
+
+func TestResourceTypeFiltersAndIndex(t *testing.T) {
+	joins := map[string]tagJoin{
+		"ec2": tagJoins["ec2"],
+		"elb": tagJoins["elb"],
+		"alb": tagJoins["alb"],
+		"nlb": tagJoins["nlb"],
+	}
+	assert.ElementsMatch(t, []string{"ec2:instance", "elasticloadbalancing:loadbalancer"}, resourceTypeFilters(joins))
+
+	idx := resourceTypeIndex(joins)
+	assert.ElementsMatch(t, []string{"ec2"}, idx["ec2:instance"])
+	assert.ElementsMatch(t, []string{"elb", "alb", "nlb"}, idx["elasticloadbalancing:loadbalancer"])
+}
+
+func mustParseARN(t *testing.T, s string) arn.ARN {
+	t.Helper()
+	a, err := arn.Parse(s)
+	require.NoError(t, err)
+	return a
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/tagresolve.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagresolve.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// labelKeyRe is the Netdata label-key contract (matches cwprofiles' identity-id
+// rule): lowercase start, then lowercase alphanumerics/underscore.
+var labelKeyRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// resolvedTag maps one surviving AWS tag key to the Netdata label it emits.
+type resolvedTag struct {
+	awsKey string // exact AWS tag key (case-sensitive)
+	label  string // Netdata label key (valid, collision-free)
+}
+
+// sanitizeLabel derives a default label from an AWS tag key: lowercase, with every
+// character outside [a-z0-9_] replaced by '_'. The result may still be invalid
+// (e.g. a leading digit); resolveTagPlan validates it and skips on failure.
+func sanitizeLabel(key string) string {
+	var b strings.Builder
+	b.Grow(len(key))
+	for _, r := range strings.ToLower(key) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// resolveTagPlan turns the job's tag allowlist into the ordered set of
+// (AWS key -> label) that survive for a profile whose identity dimension labels are
+// dimLabels. It is NON-FATAL: a bad or colliding entry is skipped and described in
+// warnings, never an error (tags are optional enrichment).
+//
+// An entry is skipped when its target label:
+//   - is empty or fails the label-key regex (after sanitize, when not renamed);
+//   - equals a reserved identity label (account_id, region) or one of the profile's
+//     dimension labels — which would duplicate an emitted label key and panic metrix;
+//   - duplicates an already-surviving tag's label; or
+//   - repeats an AWS key already seen in this allowlist.
+//
+// The surviving plan is the same for every instance of the profile; only the tag
+// VALUES differ per resource, applied at cache-build time.
+func resolveTagPlan(tags []TagConfig, dimLabels []string) (plan []resolvedTag, warnings []string) {
+	if len(tags) == 0 {
+		return nil, nil
+	}
+
+	reserved := map[string]string{"account_id": "reserved", "region": "reserved"}
+	for _, d := range dimLabels {
+		reserved[d] = "dimension"
+	}
+
+	seenAWS := make(map[string]struct{}, len(tags))
+	seenLabel := make(map[string]struct{}, len(tags))
+
+	for _, t := range tags {
+		awsKey := t.Name
+		if strings.TrimSpace(awsKey) == "" {
+			warnings = append(warnings, "skipped a tag entry with an empty name")
+			continue
+		}
+		if _, dup := seenAWS[awsKey]; dup {
+			warnings = append(warnings, fmt.Sprintf("skipped duplicate tag %q", awsKey))
+			continue
+		}
+		seenAWS[awsKey] = struct{}{}
+
+		label := t.Rename
+		if label == "" {
+			label = sanitizeLabel(awsKey)
+		}
+		if !labelKeyRe.MatchString(label) {
+			warnings = append(warnings, fmt.Sprintf("skipped tag %q: label %q is not a valid label key (rename it)", awsKey, label))
+			continue
+		}
+		if kind, ok := reserved[label]; ok {
+			warnings = append(warnings, fmt.Sprintf("skipped tag %q: label %q collides with a %s label (rename it)", awsKey, label, kind))
+			continue
+		}
+		if _, dup := seenLabel[label]; dup {
+			warnings = append(warnings, fmt.Sprintf("skipped tag %q: label %q duplicates another tag's label (rename it)", awsKey, label))
+			continue
+		}
+		seenLabel[label] = struct{}{}
+
+		plan = append(plan, resolvedTag{awsKey: awsKey, label: label})
+	}
+	return plan, warnings
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/tagresolve_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagresolve_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeLabel(t *testing.T) {
+	tests := map[string]string{
+		"owner":                     "owner",
+		"Name":                      "name",
+		"Environment":               "environment",
+		"aws:autoscaling:groupName": "aws_autoscaling_groupname",
+		"app.kubernetes.io/team":    "app_kubernetes_io_team",
+		"123abc":                    "123abc", // stays invalid (leading digit); resolveTagPlan skips it
+	}
+	for in, want := range tests {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, sanitizeLabel(in))
+		})
+	}
+}
+
+func TestResolveTagPlan(t *testing.T) {
+	tests := map[string]struct {
+		tags      []TagConfig
+		dimLabels []string
+		wantPlan  []resolvedTag
+		wantWarn  int
+	}{
+		"empty allowlist disables": {
+			tags:     nil,
+			wantPlan: nil,
+			wantWarn: 0,
+		},
+		"plain keys pass through": {
+			tags:     []TagConfig{{Name: "owner"}, {Name: "project"}},
+			wantPlan: []resolvedTag{{"owner", "owner"}, {"project", "project"}},
+		},
+		"Name sanitizes to name": {
+			tags:     []TagConfig{{Name: "Name"}},
+			wantPlan: []resolvedTag{{"Name", "name"}},
+		},
+		"rename overrides default": {
+			tags:     []TagConfig{{Name: "Name", Rename: "instance_name"}},
+			wantPlan: []resolvedTag{{"Name", "instance_name"}},
+		},
+		"region tag collides with reserved -> skipped": {
+			tags:     []TagConfig{{Name: "region"}},
+			wantPlan: nil,
+			wantWarn: 1,
+		},
+		"region tag renamed -> kept": {
+			tags:     []TagConfig{{Name: "region", Rename: "aws_region"}},
+			wantPlan: []resolvedTag{{"region", "aws_region"}},
+		},
+		"collision with a profile dimension label -> skipped": {
+			tags:      []TagConfig{{Name: "instance_id"}},
+			dimLabels: []string{"instance_id"},
+			wantPlan:  nil,
+			wantWarn:  1,
+		},
+		"duplicate AWS key -> one kept": {
+			tags:     []TagConfig{{Name: "owner"}, {Name: "owner"}},
+			wantPlan: []resolvedTag{{"owner", "owner"}},
+			wantWarn: 1,
+		},
+		"two keys sanitizing to the same label -> second skipped": {
+			tags:     []TagConfig{{Name: "Name"}, {Name: "name"}},
+			wantPlan: []resolvedTag{{"Name", "name"}},
+			wantWarn: 1,
+		},
+		"invalid rename -> skipped": {
+			tags:     []TagConfig{{Name: "foo", Rename: "Bad-Name"}},
+			wantPlan: nil,
+			wantWarn: 1,
+		},
+		"key sanitizing to an invalid label -> skipped": {
+			tags:     []TagConfig{{Name: "123abc"}},
+			wantPlan: nil,
+			wantWarn: 1,
+		},
+		"empty name -> skipped": {
+			tags:     []TagConfig{{Name: "  "}},
+			wantPlan: nil,
+			wantWarn: 1,
+		},
+		"survivors kept when mixed with skips": {
+			tags:      []TagConfig{{Name: "owner"}, {Name: "region"}, {Name: "project"}},
+			dimLabels: []string{"instance_id"},
+			wantPlan:  []resolvedTag{{"owner", "owner"}, {"project", "project"}},
+			wantWarn:  1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			plan, warnings := resolveTagPlan(tc.tags, tc.dimLabels)
+			assert.Equal(t, tc.wantPlan, plan)
+			assert.Len(t, warnings, tc.wantWarn)
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/tags.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags.go
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgtatypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+	"github.com/sourcegraph/conc/pool"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/cwprofiles"
+)
+
+// tagCacheKey identifies a resource's resolved tag labels by account, region, the
+// profile they enrich, and the profile's ARN-projectable join key.
+type tagCacheKey struct {
+	account string
+	region  string
+	profile string
+	joinKey string
+}
+
+// tagSnapshot is the cached result of one tag refresh: resolved labels per resource,
+// with a TTL. On a per-(account, region) RGTA failure the previous snapshot's entries
+// for that (account, region) are carried forward (last-known); a first-run failure
+// simply yields no tags. Never gates series existence (INV.2).
+type tagSnapshot struct {
+	labels    map[tagCacheKey][]metrix.Label
+	fetchedAt time.Time
+	expiresAt time.Time
+}
+
+func (s tagSnapshot) expired(now time.Time) bool {
+	return s.fetchedAt.IsZero() || !now.Before(s.expiresAt)
+}
+
+// markTagsStale forces the next refreshTags to re-fetch even within the TTL. Called
+// when a new account resolves: its tags must be fetched this cycle, before its charts
+// are created, because chart labels are set only at chart creation.
+func (c *Collector) markTagsStale() {
+	c.tags.expiresAt = time.Time{}
+}
+
+// profileDimLabels returns a profile's identifying (non-constant) dimension labels —
+// the labels a tag must not collide with (else metrix would panic on a duplicate key).
+func profileDimLabels(prof cwprofiles.Profile) []string {
+	var out []string
+	for _, d := range prof.Instance.Dimensions {
+		if !d.IsConstant() {
+			out = append(out, d.Label)
+		}
+	}
+	return out
+}
+
+// computeTagPlans resolves the per-profile tag-label plan once (the allowlist and
+// profiles are fixed per job) and logs each skip once. Profiles with no registered
+// ARN join or an empty resolved plan are omitted, so they carry no tags.
+func (c *Collector) computeTagPlans() {
+	if len(c.Tags) == 0 {
+		return
+	}
+	plans := make(map[string][]resolvedTag)
+	for _, p := range c.profiles {
+		if _, ok := tagJoins[p.Name]; !ok {
+			continue
+		}
+		plan, warnings := resolveTagPlan(c.Tags, profileDimLabels(p.Config))
+		for _, w := range warnings {
+			c.Limit(logKeyTagPlanWarn+":"+p.Name+":"+w, 1, recurringLogEvery).
+				Warningf("CloudWatch tags (profile %q): %s", p.Name, w)
+		}
+		if len(plan) > 0 {
+			plans[p.Name] = plan
+		}
+	}
+	c.tagPlans = plans
+}
+
+// refreshTags rebuilds the tag cache when its TTL has expired. It is best-effort and
+// NEVER gates collection: a per-(account, region) failure carries last-known tags
+// forward (or yields none on the first pass). Opt-in: with no configured tags (so no
+// resolved plans) it is a no-op and no RGTA client is ever built.
+func (c *Collector) refreshTags(ctx context.Context) {
+	if len(c.Tags) == 0 {
+		return // opt-in: no tags configured, so never build an RGTA client
+	}
+	if c.tagPlans == nil {
+		c.computeTagPlans() // resolve per-profile plans once (allowlist + profiles are fixed)
+	}
+	if len(c.tagPlans) == 0 {
+		return // every configured tag was skipped, or no selected profile has an ARN join
+	}
+	now := c.now()
+	if !c.tags.expired(now) {
+		return
+	}
+
+	joins := selectedTagJoins(c.profiles)
+	filters := resourceTypeFilters(joins)
+	rtIndex := resourceTypeIndex(joins)
+	ttl := time.Duration(c.Discovery.RefreshEvery) * time.Second
+
+	next := tagSnapshot{
+		labels:    make(map[tagCacheKey][]metrix.Label),
+		fetchedAt: now,
+		expiresAt: now.Add(ttl),
+	}
+
+	// Fetch each (account, region) concurrently (bounded), so a slow or hung RGTA
+	// endpoint cannot serialize into an accounts x regions x timeout collection stall;
+	// the per-call timeout bounds each fetch. Indexing into the shared map is done
+	// serially afterwards to avoid a data race. Mirrors discovery's fan-out.
+	type tagFetch struct {
+		account, region string
+		resources       []rgtatypes.ResourceTagMapping
+		err             error
+	}
+	var targets []tagFetch
+	for _, account := range c.accountIDs() {
+		for _, region := range c.regions() {
+			targets = append(targets, tagFetch{account: account, region: region})
+		}
+	}
+
+	p := pool.New().WithMaxGoroutines(max(1, apiConcurrency))
+	for i := range targets {
+		t := &targets[i]
+		p.Go(func() {
+			client, err := c.rgtaClients.forAccountRegion(ctx, t.account, t.region)
+			if err != nil {
+				t.err = fmt.Errorf("build client: %w", err)
+				return
+			}
+			t.resources, t.err = getAllResources(ctx, client, filters, c.Timeout.Duration())
+		})
+	}
+	p.Wait()
+
+	// If the parent collect context was canceled or timed out during the fan-out, do
+	// NOT commit next or advance the TTL: that would suppress tag retries until the next
+	// TTL expiry (and risk creating charts untagged). Keeping the previous snapshot (its
+	// TTL is already expired, which is why we ran) makes the next cycle retry. Per-call
+	// timeouts use derived contexts and do not trip this, so they stay fail-soft.
+	if ctx.Err() != nil {
+		return
+	}
+
+	for _, t := range targets {
+		if t.err != nil {
+			c.carryForwardTags(next.labels, t.account, t.region)
+			c.Limit(logKeyTagRefreshFailed+":"+t.account+"/"+t.region, 1, recurringLogEvery).
+				Warningf("CloudWatch tag lookup for account %q region %q failed: %v (using last-known tags)", t.account, t.region, t.err)
+			continue
+		}
+		indexResourceTags(next.labels, t.account, t.region, t.resources, rtIndex, joins, c.tagPlans)
+	}
+
+	c.tags = next
+}
+
+// carryForwardTags copies the previous snapshot's entries for one (account, region)
+// into dst, so a transient RGTA failure keeps that scope's last-known tags.
+func (c *Collector) carryForwardTags(dst map[tagCacheKey][]metrix.Label, account, region string) {
+	for k, v := range c.tags.labels {
+		if k.account == account && k.region == region {
+			dst[k] = v
+		}
+	}
+}
+
+// getAllResources pages through RGTA GetResources, narrowed to the given resource
+// types, and returns every tagged resource mapping.
+func getAllResources(ctx context.Context, client rgtaClient, filters []string, timeout time.Duration) ([]rgtatypes.ResourceTagMapping, error) {
+	cctx, cancel := withTimeout(ctx, timeout)
+	defer cancel()
+
+	var out []rgtatypes.ResourceTagMapping
+	var token *string
+	for {
+		in := &resourcegroupstaggingapi.GetResourcesInput{PaginationToken: token}
+		if len(filters) > 0 {
+			in.ResourceTypeFilters = filters
+		}
+		resp, err := client.GetResources(cctx, in)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, resp.ResourceTagMappingList...)
+		if resp.PaginationToken == nil || *resp.PaginationToken == "" {
+			break
+		}
+		token = resp.PaginationToken
+	}
+	return out, nil
+}
+
+// indexResourceTags resolves each tagged resource to its (profile, joinKey) and
+// stores the resolved tag labels. A resource whose ARN does not parse, whose type
+// no selected profile claims, or whose join key cannot be built is skipped.
+func indexResourceTags(
+	dst map[tagCacheKey][]metrix.Label,
+	account, region string,
+	resources []rgtatypes.ResourceTagMapping,
+	rtIndex map[string][]string,
+	joins map[string]tagJoin,
+	plans map[string][]resolvedTag,
+) {
+	for _, res := range resources {
+		if res.ResourceARN == nil {
+			continue
+		}
+		a, err := arn.Parse(*res.ResourceARN)
+		if err != nil {
+			continue
+		}
+		// RGTA is queried per (account, region), so a resource whose ARN names a
+		// different account or region should not appear; skip it if it does, so tags
+		// are never cached against the wrong target. Empty ARN fields (e.g. S3, which
+		// carries no account/region) are allowed.
+		if (a.AccountID != "" && a.AccountID != account) || (a.Region != "" && a.Region != region) {
+			continue
+		}
+		profNames := rtIndex[deriveResourceType(a)]
+		if len(profNames) == 0 {
+			continue
+		}
+		tags := tagMap(res.Tags)
+		for _, profName := range profNames {
+			plan := plans[profName]
+			if len(plan) == 0 {
+				continue
+			}
+			jk, ok := joins[profName].arnJoinKey(a)
+			if !ok {
+				continue
+			}
+			labels := applyTagPlan(plan, tags)
+			if len(labels) == 0 {
+				continue
+			}
+			dst[tagCacheKey{account: account, region: region, profile: profName, joinKey: jk}] = labels
+		}
+	}
+}
+
+func tagMap(tags []rgtatypes.Tag) map[string]string {
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		if t.Key != nil && t.Value != nil {
+			out[*t.Key] = *t.Value
+		}
+	}
+	return out
+}
+
+// applyTagPlan produces the emitted tag labels for a resource: for each surviving
+// (awsKey -> label) in plan, the label if the resource carries that tag. The result
+// is a fresh slice stored read-only in the cache; the write path concatenates it
+// into a new slice, so it is never mutated.
+func applyTagPlan(plan []resolvedTag, tags map[string]string) []metrix.Label {
+	var out []metrix.Label
+	for _, rt := range plan {
+		if v, ok := tags[rt.awsKey]; ok {
+			out = append(out, metrix.Label{Key: rt.label, Value: v})
+		}
+	}
+	return out
+}
+
+// tagLabelsFor returns the cached, non-identity tag labels for one discovered
+// instance, or nil when tags are off, the profile has no join, or none are cached.
+func (c *Collector) tagLabelsFor(account, region string, prof cwprofiles.ResolvedProfile, values []string) []metrix.Label {
+	if len(c.tags.labels) == 0 {
+		return nil
+	}
+	tj, ok := tagJoins[prof.Name]
+	if !ok {
+		return nil
+	}
+	jk, ok := tj.instanceJoinKey(prof.Config.DimensionNames(), values)
+	if !ok {
+		return nil
+	}
+	return c.tags.labels[tagCacheKey{account: account, region: region, profile: prof.Name, joinKey: jk}]
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgtatypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/awsauth"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/cwprofiles"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRGTA is a Resource Groups Tagging API stub returning canned resources, or an
+// error when err is set. calls counts GetResources invocations across pages/cycles.
+type fakeRGTA struct {
+	resources  []rgtatypes.ResourceTagMapping   // single page (used when pages is nil)
+	pages      [][]rgtatypes.ResourceTagMapping // multi-page: call N returns page N, with a token until the last
+	err        error
+	calls      int
+	gotFilters []string // ResourceTypeFilters seen on the most recent request
+}
+
+func (f *fakeRGTA) GetResources(_ context.Context, in *resourcegroupstaggingapi.GetResourcesInput, _ ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	f.calls++
+	f.gotFilters = in.ResourceTypeFilters
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.pages != nil {
+		idx := f.calls - 1
+		out := &resourcegroupstaggingapi.GetResourcesOutput{}
+		if idx < len(f.pages) {
+			out.ResourceTagMappingList = f.pages[idx]
+		}
+		if idx < len(f.pages)-1 {
+			out.PaginationToken = aws.String("next")
+		}
+		return out, nil
+	}
+	return &resourcegroupstaggingapi.GetResourcesOutput{ResourceTagMappingList: f.resources}, nil
+}
+
+func rgtaResource(arn string, kv ...string) rgtatypes.ResourceTagMapping {
+	m := rgtatypes.ResourceTagMapping{ResourceARN: aws.String(arn)}
+	for i := 0; i+1 < len(kv); i += 2 {
+		m.Tags = append(m.Tags, rgtatypes.Tag{Key: aws.String(kv[i]), Value: aws.String(kv[i+1])})
+	}
+	return m
+}
+
+// seriesLabels returns the label set of the single emitted series whose name has the
+// given prefix (fails if not exactly one), read from the collector's metric store.
+func seriesLabels(t *testing.T, c *Collector, namePrefix string) map[string]string {
+	t.Helper()
+	out := make(map[string]string)
+	found := 0
+	c.MetricStore().Read().ForEachSeries(func(name string, labels metrix.LabelView, _ metrix.SampleValue) {
+		if len(name) < len(namePrefix) || name[:len(namePrefix)] != namePrefix {
+			return
+		}
+		found++
+		labels.Range(func(k, v string) bool {
+			out[k] = v
+			return true
+		})
+	})
+	require.Equalf(t, 1, found, "exactly one series with name prefix %q", namePrefix)
+	return out
+}
+
+// ec2TagCollector wires the end-to-end EC2 collector with a fake RGTA client and the
+// given tag allowlist. The instance is i-1 in account 000000000000, region us-east-1.
+func ec2TagCollector(t *testing.T, tags []TagConfig, rgta rgtaClient) *Collector {
+	t.Helper()
+	c, _ := endToEndCollector(10)
+	c.Config.Tags = tags
+	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
+	c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
+	return c
+}
+
+func TestCollect_TagEnrichment(t *testing.T) {
+	tests := map[string]struct {
+		tags  []TagConfig
+		rgta  *fakeRGTA
+		check func(t *testing.T, labels map[string]string)
+	}{
+		"attaches allowlisted tags as non-identity labels (with rename)": {
+			tags: []TagConfig{{Name: "owner"}, {Name: "team", Rename: "squad"}},
+			rgta: &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
+				rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "alice", "team", "sre"),
+			}},
+			check: func(t *testing.T, labels map[string]string) {
+				assert.Equal(t, "alice", labels["owner"])
+				assert.Equal(t, "sre", labels["squad"])
+				// identity labels intact and untouched
+				assert.Equal(t, "i-1", labels["instance_id"])
+				assert.Equal(t, "000000000000", labels["account_id"])
+				assert.Equal(t, "us-east-1", labels["region"])
+			},
+		},
+		"INV.2: an untagged instance still collects, without tag labels": {
+			tags: []TagConfig{{Name: "owner"}},
+			rgta: &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
+				rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-999", "owner", "bob"),
+			}},
+			check: func(t *testing.T, labels map[string]string) {
+				assert.Equal(t, "i-1", labels["instance_id"], "untagged instance still collects")
+				_, ok := labels["owner"]
+				assert.False(t, ok, "no tag label for an untagged instance")
+			},
+		},
+		"INV.2: an RGTA failure leaves the series (no tags, no panic)": {
+			tags: []TagConfig{{Name: "owner"}},
+			rgta: &fakeRGTA{err: errors.New("access denied")},
+			check: func(t *testing.T, labels map[string]string) {
+				assert.Equal(t, "i-1", labels["instance_id"], "series survives an RGTA failure")
+				_, ok := labels["owner"]
+				assert.False(t, ok)
+			},
+		},
+		"a tag colliding with a reserved label is skipped, not overwriting it": {
+			tags: []TagConfig{{Name: "region"}, {Name: "owner"}},
+			rgta: &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
+				rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "region", "bogus", "owner", "alice"),
+			}},
+			check: func(t *testing.T, labels map[string]string) {
+				assert.Equal(t, "us-east-1", labels["region"], "reserved region label is never overwritten by a tag")
+				assert.Equal(t, "alice", labels["owner"], "the valid sibling tag still attaches")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := ec2TagCollector(t, tc.tags, tc.rgta)
+			_, err := collecttest.CollectScalarSeries(c)
+			require.NoError(t, err)
+			tc.check(t, seriesLabels(t, c, "ec2.cpu_utilization_average"))
+		})
+	}
+}
+
+func TestCollect_TagRetentionReEmitCarriesTags(t *testing.T) {
+	// A not-due series is re-emitted from cache every cycle; its tag labels must ride
+	// along (they are cached with the series, not re-resolved).
+	rgta := &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "alice"),
+	}}
+	c := ec2TagCollector(t, []TagConfig{{Name: "owner"}}, rgta)
+	base := time.Unix(1_000_000_000, 0)
+
+	// Cycle 1: queried + tagged.
+	c.now = func() time.Time { return base }
+	_, err := collecttest.CollectScalarSeries(c)
+	require.NoError(t, err)
+	require.Equal(t, "alice", seriesLabels(t, c, "ec2.cpu_utilization_average")["owner"])
+
+	// Cycle 2 at +60s: the 300s period is not due -> re-emit. Tags must persist.
+	c.now = func() time.Time { return base.Add(60 * time.Second) }
+	_, err = collecttest.CollectScalarSeries(c)
+	require.NoError(t, err)
+	assert.Equal(t, "alice", seriesLabels(t, c, "ec2.cpu_utilization_average")["owner"],
+		"re-emitted (not-due) series keeps its tag labels")
+}
+
+func TestRefreshTags_FirstFailureNoneThenSuccessThenCarryForward(t *testing.T) {
+	rgta := &fakeRGTA{
+		err: errors.New("throttled"),
+		resources: []rgtatypes.ResourceTagMapping{
+			rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "alice"),
+		},
+	}
+	c := New()
+	c.Config.Regions = []string{"us-east-1"}
+	c.Config.Tags = []TagConfig{{Name: "owner"}}
+	c.applyDefaults()
+	c.accounts = []cwAccount{{accountID: "000000000000"}}
+	c.profiles = []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}}
+	c.newAWSConfig = func(context.Context, awsauth.Identity, string) (aws.Config, error) { return aws.Config{}, nil }
+	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
+	c.computeTagPlans()
+	require.NotEmpty(t, c.tagPlans, "owner resolves to a plan for ec2")
+
+	key := tagCacheKey{account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-1"}
+	base := time.Unix(1_000_000_000, 0)
+	ttl := time.Duration(c.Discovery.RefreshEvery) * time.Second
+
+	// First refresh fails with no prior cache -> no tags (not last-known, none exists).
+	c.now = func() time.Time { return base }
+	c.refreshTags(context.Background())
+	assert.NotContains(t, c.tags.labels, key, "first-run RGTA failure yields no tags")
+
+	// TTL expires and RGTA succeeds -> tags cached.
+	rgta.err = nil
+	c.now = func() time.Time { return base.Add(ttl) }
+	c.refreshTags(context.Background())
+	require.Contains(t, c.tags.labels, key)
+	assert.Equal(t, []metrix.Label{{Key: "owner", Value: "alice"}}, c.tags.labels[key])
+
+	// TTL expires and RGTA fails again -> last-known tags carried forward.
+	rgta.err = errors.New("throttled again")
+	c.now = func() time.Time { return base.Add(2 * ttl) }
+	c.refreshTags(context.Background())
+	assert.Equal(t, []metrix.Label{{Key: "owner", Value: "alice"}}, c.tags.labels[key],
+		"a later RGTA failure keeps the last-known tags")
+}
+
+func TestGetAllResources_PaginatesAndFiltersByType(t *testing.T) {
+	fake := &fakeRGTA{pages: [][]rgtatypes.ResourceTagMapping{
+		{rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "a")},
+		{rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-2", "owner", "b")},
+	}}
+
+	got, err := getAllResources(context.Background(), fake, []string{"ec2:instance"}, 0)
+	require.NoError(t, err)
+	assert.Len(t, got, 2, "both pages are fetched")
+	assert.Equal(t, 2, fake.calls, "the pagination token is followed")
+	assert.Equal(t, []string{"ec2:instance"}, fake.gotFilters, "ResourceTypeFilters is passed through to RGTA")
+}
+
+func tagUnitCollector(t *testing.T, rgta rgtaClient) *Collector {
+	t.Helper()
+	c := New()
+	c.Config.Regions = []string{"us-east-1"}
+	c.Config.Tags = []TagConfig{{Name: "owner"}}
+	c.applyDefaults()
+	c.accounts = []cwAccount{{accountID: "000000000000"}}
+	c.profiles = []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}}
+	c.newAWSConfig = func(context.Context, awsauth.Identity, string) (aws.Config, error) { return aws.Config{}, nil }
+	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
+	return c
+}
+
+func TestRefreshTags_MarkStaleForcesRefetchWithinTTL(t *testing.T) {
+	// A newly-resolved account marks tags stale so its tags are fetched the same cycle
+	// (before its charts are created), even though the global TTL is still valid.
+	rgta := &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "alice"),
+	}}
+	c := tagUnitCollector(t, rgta)
+
+	base := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return base }
+	c.refreshTags(context.Background())
+	require.Equal(t, 1, rgta.calls)
+
+	c.now = func() time.Time { return base.Add(30 * time.Second) }
+	c.refreshTags(context.Background())
+	require.Equal(t, 1, rgta.calls, "within the TTL there is no re-fetch")
+
+	c.markTagsStale()
+	c.refreshTags(context.Background())
+	assert.Equal(t, 2, rgta.calls, "markTagsStale forces a re-fetch within the TTL")
+}
+
+func TestRefreshTags_CanceledContextDoesNotAdvanceTTL(t *testing.T) {
+	// A collect context canceled during the RGTA fan-out must not commit a snapshot or
+	// advance the TTL, so the next cycle retries instead of suppressing tags.
+	rgta := &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "alice"),
+	}}
+	c := tagUnitCollector(t, rgta)
+	c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.refreshTags(ctx)
+
+	assert.True(t, c.tags.expired(c.now()), "a canceled refresh must not advance the TTL")
+	assert.Empty(t, c.tags.labels, "a canceled refresh must not commit a snapshot")
+}
+
+func TestIndexResourceTags_SkipsForeignAccountRegion(t *testing.T) {
+	// RGTA is queried per (account, region); a resource whose ARN names a different
+	// account or region must not be cached against the queried target.
+	joins := selectedTagJoins([]cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
+	rtIndex := resourceTypeIndex(joins)
+	plans := map[string][]resolvedTag{"ec2": {{awsKey: "owner", label: "owner"}}}
+	dst := map[tagCacheKey][]metrix.Label{}
+
+	resources := []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-ok", "owner", "a"),
+		rgtaResource("arn:aws:ec2:us-east-1:999999999999:instance/i-acct", "owner", "b"),   // wrong account
+		rgtaResource("arn:aws:ec2:eu-west-1:000000000000:instance/i-region", "owner", "c"), // wrong region
+	}
+	indexResourceTags(dst, "000000000000", "us-east-1", resources, rtIndex, joins, plans)
+
+	require.Len(t, dst, 1, "only the same-account, same-region resource is cached")
+	assert.Contains(t, dst, tagCacheKey{account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-ok"})
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
+++ b/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
@@ -35,6 +35,12 @@
     "refresh_every": 123,
     "recently_active_only": true
   },
+  "tags": [
+    {
+      "name": "ok",
+      "rename": "ok"
+    }
+  ],
   "query_offset": 123,
   "timeout": 123.123
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/cloudwatch/testdata/config.yaml
@@ -21,5 +21,8 @@ profiles:
 discovery:
   refresh_every: 123
   recently_active_only: true
+tags:
+  - name: "ok"
+    rename: "ok"
 query_offset: 123
 timeout: 123.123

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.conf
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.conf
@@ -12,6 +12,15 @@
 ## Required IAM permissions:
 ##   cloudwatch:ListMetrics, cloudwatch:GetMetricData, sts:GetCallerIdentity
 ##   (plus sts:AssumeRole when auth.mode is assume_role)
+##   (plus tag:GetResources when the 'tags' option is set)
+##
+## Resource tag enrichment (optional, off by default):
+##   Set 'tags' to attach AWS resource tags as extra chart labels. Each entry has a
+##   'name' (the AWS tag key, case-sensitive) and an optional 'rename' (the Netdata
+##   label; default is the sanitized key, e.g. Name -> name). Use 'rename' for keys
+##   that are not valid labels or that collide with a built-in label such as region.
+##   Tag values may contain personal data (e.g. owner emails) -- list only tags you
+##   want exposed as labels.
 ##
 ## Authentication modes:
 ##   default     - AWS SDK default credential chain (env vars, shared config,
@@ -77,3 +86,15 @@
 #          - name: rds
 #    auth:
 #      mode: default
+#
+#  - name: with_tags
+#    regions:
+#      - us-east-1
+#    auth:
+#      mode: default
+#    tags:
+#      - name: Name          # AWS 'Name' tag -> label 'name'
+#      - name: owner         # -> label 'owner'
+#      - name: environment   # -> label 'environment'
+#      - name: region        # collides with the built-in 'region' label -> rename
+#        rename: aws_region


### PR DESCRIPTION
##### Summary

Part of netdata/product#3369

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opt-in resource tag enrichment to the CloudWatch collector. Selected AWS tags are attached as extra, non-identity labels; off by default and requires `tag:GetResources` only when tags are configured.

- **New Features**
  - New `tags: [{name, rename?}]` config to allowlist tag keys; empty disables tag lookup.
  - Per-account/region RGTA client and cached tag lookup; refresh on discovery TTL; failures use last-known tags and never block collection.
  - Safe per-profile ARN↔dimension joins; parent-resource profiles inherit tags; ambiguous or non-taggable services are skipped (no wrong tags, just no tags).
  - Collision guard and defaults: invalid or colliding tag labels (incl. `account_id`, `region`, or dimension labels) are skipped with warnings and never override identity labels.
  - Tags don’t affect series identity; scheduling/retention unchanged, and re-emits keep tag labels.

- **Dependencies**
  - Added `github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi`.

<sup>Written for commit 255f3e50a3eb52f9cfbe6a06d084ce9829fac7eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



