### PR TITLE
feat(go.d): chart histogram buckets as range heatmaps

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -115,6 +115,9 @@ source files for evidence.
 - Do NOT rely on chartengine's metric-name suffix inference for generated
   Netdata metrics. Suffix inference is only a fallback and MUST NOT be used as
   the correctness mechanism for V2 collector charts.
+- Histogram bucket charts use range bucket values from `metrix.ReadFlatten()`
+  and chartengine forces them to `heatmap`. Do NOT add collector-local
+  cumulative-bucket workaround metrics or a bucket-mode option for V2 charts.
 - Put multipliers, divisors, hidden flags, and float formatting in the chart
   template, not ad hoc chart-emission code.
 - `metrix` registers a descriptor per metric NAME permanently (no unregister), so

--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -116,7 +116,8 @@ source files for evidence.
   Netdata metrics. Suffix inference is only a fallback and MUST NOT be used as
   the correctness mechanism for V2 collector charts.
 - Histogram bucket charts use range bucket values from `metrix.ReadFlatten()`
-  and chartengine forces them to `heatmap`. Do NOT add collector-local
+  and chartengine forces them to `heatmap`. Bucket dimensions are ordered by
+  numeric upper bound with `+Inf` last. Do NOT add collector-local
   cumulative-bucket workaround metrics or a bucket-mode option for V2 charts.
 - Put multipliers, divisors, hidden flags, and float formatting in the chart
   template, not ad hoc chart-emission code.

--- a/src/go/pkg/metrix/README.md
+++ b/src/go/pkg/metrix/README.md
@@ -192,6 +192,12 @@ metrix.MeasureSetPoint{Values: []metrix.SampleValue{15, 23}}
 | StateSet    | `<name>{<name>=state}` with scalar 0/1 values                                                                    |
 | MeasureSet  | `<name>_<field>{measure_field=field}`; flattened kind follows family semantics (`Gauge` or `Counter`)            |
 
+Histogram bucket flattening emits non-overlapping range bucket totals while
+keeping the `le` label as the bucket upper bound. The first finite bucket is
+`<= le[0]`; each later finite bucket is `(previous le, current le]`; `+Inf` is
+`count - last finite cumulative bucket`. Typed `Histogram()` reads remain
+canonical cumulative histogram points.
+
 Flatten metadata is exposed via `SeriesMeta.Kind`, `SeriesMeta.SourceKind`, and `SeriesMeta.FlattenRole`.
 
 `MeasureSet` flattening keeps per-field metric names for `MetricMeta(name)` compatibility and also adds a synthetic `measure_field=<field>` label. This gives chartengine explicit field identity without widening the reader metadata API.

--- a/src/go/pkg/metrix/histogram_store_test.go
+++ b/src/go/pkg/metrix/histogram_store_test.go
@@ -198,6 +198,9 @@ func TestHistogramStoreScenarios(t *testing.T) {
 						{UpperBound: 2, CumulativeCount: 1},
 					},
 				})
+				mustValue(t, s.Read(ReadFlatten()), "svc.latency_bucket", Labels{HistogramBucketLabel: "1"}, 0)
+				mustValue(t, s.Read(ReadFlatten()), "svc.latency_bucket", Labels{HistogramBucketLabel: "2"}, 1)
+				mustValue(t, s.Read(ReadFlatten()), "svc.latency_bucket", Labels{HistogramBucketLabel: "+Inf"}, 0)
 
 				cc.BeginCycle()
 				cc.CommitCycleSuccess()
@@ -205,6 +208,8 @@ func TestHistogramStoreScenarios(t *testing.T) {
 				require.False(t, ok, "expected stale cycle-window histogram hidden from Read")
 				_, ok = s.Read(ReadRaw()).Histogram("svc.latency", nil)
 				require.True(t, ok, "expected raw histogram to remain visible")
+				_, ok = s.Read(ReadFlatten()).Value("svc.latency_bucket", Labels{HistogramBucketLabel: "1"})
+				require.False(t, ok, "expected stale cycle-window flattened histogram hidden from Read(ReadFlatten())")
 			},
 		},
 		"window option on snapshot histogram panics": {

--- a/src/go/pkg/metrix/histogram_store_test.go
+++ b/src/go/pkg/metrix/histogram_store_test.go
@@ -44,11 +44,36 @@ func TestHistogramStoreScenarios(t *testing.T) {
 
 				fr := s.Read(ReadFlatten())
 				mustValue(t, fr, "svc.request_duration_seconds_bucket", Labels{"le": "0.1"}, 1)
-				mustValue(t, fr, "svc.request_duration_seconds_bucket", Labels{"le": "0.5"}, 2)
-				mustValue(t, fr, "svc.request_duration_seconds_bucket", Labels{"le": "1"}, 3)
-				mustValue(t, fr, "svc.request_duration_seconds_bucket", Labels{"le": "+Inf"}, 3)
+				mustValue(t, fr, "svc.request_duration_seconds_bucket", Labels{"le": "0.5"}, 1)
+				mustValue(t, fr, "svc.request_duration_seconds_bucket", Labels{"le": "1"}, 1)
+				mustValue(t, fr, "svc.request_duration_seconds_bucket", Labels{"le": "+Inf"}, 0)
 				mustValue(t, fr, "svc.request_duration_seconds_count", nil, 3)
 				mustValue(t, fr, "svc.request_duration_seconds_sum", nil, 1.2)
+			},
+		},
+		"snapshot histogram without finite bounds flattens count into +Inf range bucket": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				h := s.Write().SnapshotMeter("svc").Histogram("latency")
+
+				cc.BeginCycle()
+				h.ObservePoint(HistogramPoint{
+					Count: 4,
+					Sum:   12,
+				})
+				cc.CommitCycleSuccess()
+
+				mustHistogram(t, s.Read(), "svc.latency", nil, HistogramPoint{
+					Count:   4,
+					Sum:     12,
+					Buckets: []BucketPoint{},
+				})
+
+				fr := s.Read(ReadFlatten())
+				mustValue(t, fr, "svc.latency_bucket", Labels{"le": "+Inf"}, 4)
+				mustValue(t, fr, "svc.latency_count", nil, 4)
+				mustValue(t, fr, "svc.latency_sum", nil, 12)
 			},
 		},
 		"snapshot histogram without bounds captures schema after successful cycle": {

--- a/src/go/pkg/metrix/host_scope_test.go
+++ b/src/go/pkg/metrix/host_scope_test.go
@@ -162,7 +162,7 @@ func TestHostScopeFlattenPreservesScopeScenarios(t *testing.T) {
 				mustValue(t, scopedReader, "svc.latency_count", Labels{"route": "/api"}, 3)
 				mustValue(t, scopedReader, "svc.latency_sum", Labels{"route": "/api"}, 6)
 				mustValue(t, scopedReader, "svc.latency_bucket", Labels{"route": "/api", HistogramBucketLabel: "1"}, 1)
-				mustValue(t, scopedReader, "svc.latency_bucket", Labels{"route": "/api", HistogramBucketLabel: "5"}, 3)
+				mustValue(t, scopedReader, "svc.latency_bucket", Labels{"route": "/api", HistogramBucketLabel: "5"}, 2)
 			},
 		},
 		"composite instruments": {

--- a/src/go/pkg/metrix/reader.go
+++ b/src/go/pkg/metrix/reader.go
@@ -241,7 +241,12 @@ func appendFlattenedHistogramSeries(dst *readSnapshot, src *committedSeries) {
 		return
 	}
 
+	prevCumulative := SampleValue(0)
 	for i, ub := range schema.bounds {
+		cumulative := src.histogramCumulative[i]
+		bucketValue := cumulative - prevCumulative
+		prevCumulative = cumulative
+
 		labelsMap := make(map[string]string, len(src.labels)+1)
 		for _, lbl := range src.labels {
 			labelsMap[lbl.Key] = lbl.Value
@@ -272,7 +277,7 @@ func appendFlattenedHistogramSeries(dst *readSnapshot, src *committedSeries) {
 				window:    src.desc.window,
 				meta:      src.desc.meta,
 			},
-			value: src.histogramCumulative[i],
+			value: bucketValue,
 			meta: flattenedSeriesMeta(
 				src.meta,
 				MetricKindCounter,
@@ -308,7 +313,7 @@ func appendFlattenedHistogramSeries(dst *readSnapshot, src *committedSeries) {
 				window:    src.desc.window,
 				meta:      src.desc.meta,
 			},
-			value: src.histogramCount,
+			value: src.histogramCount - prevCumulative,
 			meta: flattenedSeriesMeta(
 				src.meta,
 				MetricKindCounter,

--- a/src/go/pkg/metrix/runtime_store_test.go
+++ b/src/go/pkg/metrix/runtime_store_test.go
@@ -103,8 +103,8 @@ func TestRuntimeStoreScenarios(t *testing.T) {
 
 				fr := s.Read(ReadFlatten())
 				mustValue(t, fr, "runtime.req_duration_bucket", Labels{"le": "1"}, 1)
-				mustValue(t, fr, "runtime.req_duration_bucket", Labels{"le": "2"}, 1)
-				mustValue(t, fr, "runtime.req_duration_bucket", Labels{"le": "+Inf"}, 2)
+				mustValue(t, fr, "runtime.req_duration_bucket", Labels{"le": "2"}, 0)
+				mustValue(t, fr, "runtime.req_duration_bucket", Labels{"le": "+Inf"}, 1)
 				mustValue(t, fr, "runtime.mode", Labels{"runtime.mode": "maintenance"}, 0)
 				mustValue(t, fr, "runtime.mode", Labels{"runtime.mode": "operational"}, 1)
 			},

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -174,6 +174,11 @@ Default lifecycle policy when template omits lifecycle:
 | Type ID budget        | Enforced via `AutogenPolicy.MaxTypeIDLen` + effective emit type-id prefix (`WithEmitTypeIDBudgetPrefix(...)`)                                  |
 | Lifecycle             | Autogen applies `ExpireAfterSuccessCycles` to **both** chart and dimension expiry (unlike template lifecycle where they default independently) |
 
+Histogram bucket charts use non-overlapping range bucket totals from
+`metrix.ReadFlatten()` and are emitted as `heatmap` charts in both autogen and
+template-driven paths. The `le` label remains the upper-bound identity for the
+bucket dimension.
+
 `MeasureSet` autogen specifics:
 
 - chartengine treats `MeasureSet` as a structured family, similar to `StateSet`, not as grouped scalar coincidence
@@ -191,7 +196,7 @@ These label keys are treated specially by chartengine when consuming flattened s
 
 | Key / Pattern   | Meaning                                                                                                                |
 |-----------------|------------------------------------------------------------------------------------------------------------------------|
-| `le`            | Histogram bucket bound label                                                                                           |
+| `le`            | Histogram range bucket upper-bound label                                                                               |
 | `quantile`      | Summary quantile label                                                                                                 |
 | `measure_field` | `MeasureSet` field identity label                                                                                      |
 | `<metric-name>` | `StateSet` special case: the flattened state name is carried under a synthetic label whose key is the base metric name |

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -177,7 +177,8 @@ Default lifecycle policy when template omits lifecycle:
 Histogram bucket charts use non-overlapping range bucket totals from
 `metrix.ReadFlatten()` and are emitted as `heatmap` charts in both autogen and
 template-driven paths. The `le` label remains the upper-bound identity for the
-bucket dimension.
+bucket dimension. Bucket dimensions are ordered by numeric upper bound with
+`+Inf` last, not by lexical dimension name.
 
 `MeasureSet` autogen specifics:
 

--- a/src/go/plugin/framework/chartengine/autogen.go
+++ b/src/go/plugin/framework/chartengine/autogen.go
@@ -292,7 +292,7 @@ func buildHistogramBucketAutogenRoute(
 		dimensionKeyLabel: metrix.HistogramBucketLabel,
 		algorithm:         program.AlgorithmIncremental,
 		units:             "observations/s",
-		chartType:         program.ChartTypeLine,
+		chartType:         program.ChartTypeHeatmap,
 		family:            getAutogenChartFamily(baseName),
 		contextName:       baseName,
 		staticDimension:   false,

--- a/src/go/plugin/framework/chartengine/autogen_test.go
+++ b/src/go/plugin/framework/chartengine/autogen_test.go
@@ -129,6 +129,7 @@ func runTestBuildHistogramBucketAutogenRoute(t *testing.T) {
 			assert.Equal(t, tc.wantDim, route.dimensionName)
 			assert.Equal(t, metrix.HistogramBucketLabel, route.dimensionKeyLabel)
 			assert.Equal(t, program.AlgorithmIncremental, route.algorithm)
+			assert.Equal(t, program.ChartTypeHeatmap, route.chartType)
 			assert.False(t, route.staticDimension)
 		})
 	}

--- a/src/go/plugin/framework/chartengine/lifecycle.go
+++ b/src/go/plugin/framework/chartengine/lifecycle.go
@@ -29,6 +29,7 @@ type materializedDimensionState struct {
 	float              bool
 	static             bool
 	order              int
+	sortKey            dimensionSortKey
 	algorithm          program.Algorithm
 	multiplier         int
 	divisor            int
@@ -128,13 +129,14 @@ func (s *materializedState) ensureChart(
 func (c *materializedChartState) ensureDimension(name string, state dimensionState) (*materializedDimensionState, bool) {
 	dim, ok := c.dimensions[name]
 	if ok {
-		if dim.static != state.static || dim.order != state.order {
+		if dim.static != state.static || dim.order != state.order || dim.sortKey != state.sortKey {
 			c.orderedDimsDirty = true
 		}
 		dim.hidden = state.hidden
 		dim.float = state.float
 		dim.static = state.static
 		dim.order = state.order
+		dim.sortKey = state.sortKey
 		dim.algorithm = state.algorithm
 		dim.multiplier = state.multiplier
 		dim.divisor = state.divisor
@@ -145,6 +147,7 @@ func (c *materializedChartState) ensureDimension(name string, state dimensionSta
 		float:      state.float,
 		static:     state.static,
 		order:      state.order,
+		sortKey:    state.sortKey,
 		algorithm:  state.algorithm,
 		multiplier: state.multiplier,
 		divisor:    state.divisor,

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -117,6 +117,18 @@ type flattenedReadChecker interface {
 	FlattenedRead() bool
 }
 
+func isHistogramBucketSeries(meta metrix.SeriesMeta) bool {
+	return meta.SourceKind == metrix.MetricKindHistogram &&
+		meta.FlattenRole == metrix.FlattenRoleHistogramBucket
+}
+
+func forceHistogramBucketChartType(meta program.ChartMeta, seriesMeta metrix.SeriesMeta) program.ChartMeta {
+	if isHistogramBucketSeries(seriesMeta) {
+		meta.Type = program.ChartTypeHeatmap
+	}
+	return meta
+}
+
 func (e *Engine) preparePlan(reader metrix.Reader) (Plan, materializedState, uint64, uint64, uint64, bool, error) {
 	if e == nil {
 		return Plan{}, materializedState{}, 0, 0, 0, false, fmt.Errorf("chartengine: nil engine")
@@ -405,7 +417,7 @@ func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 		}
 
 		for _, route := range routes {
-			if err := ctx.accumulateRoute(ctx.index, route, labels, v); err != nil {
+			if err := ctx.accumulateRoute(ctx.index, route, meta, labels, v); err != nil {
 				firstErr = err
 				return
 			}
@@ -430,9 +442,12 @@ func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 func (ctx *planBuildContext) accumulateRoute(
 	index matchIndex,
 	route routeBinding,
+	seriesMeta metrix.SeriesMeta,
 	labels metrix.LabelView,
 	value metrix.SampleValue,
 ) error {
+	route.Meta = forceHistogramBucketChartType(route.Meta, seriesMeta)
+
 	cs, exists := ctx.chartsByID[route.ChartID]
 	if exists && cs.templateID != route.ChartTemplateID {
 		if !route.Autogen && isAutogenTemplateID(cs.templateID) {
@@ -492,6 +507,9 @@ func (ctx *planBuildContext) accumulateRoute(
 			currentBuildSeq: ctx.buildCycle,
 		}
 		ctx.chartsByID[route.ChartID] = cs
+	}
+	if isHistogramBucketSeries(seriesMeta) {
+		cs.meta.Type = program.ChartTypeHeatmap
 	}
 
 	entry, exists := cs.entries[route.DimensionName]

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -71,9 +72,22 @@ type dimensionState struct {
 	float      bool
 	static     bool
 	order      int
+	sortKey    dimensionSortKey
 	algorithm  program.Algorithm
 	multiplier int
 	divisor    int
+}
+
+type dimensionSortKind uint8
+
+const (
+	dimensionSortDefault dimensionSortKind = iota
+	dimensionSortHistogramBucket
+)
+
+type dimensionSortKey struct {
+	kind       dimensionSortKind
+	upperBound float64
 }
 
 type dimBuildEntry struct {
@@ -120,13 +134,6 @@ type flattenedReadChecker interface {
 func isHistogramBucketSeries(meta metrix.SeriesMeta) bool {
 	return meta.SourceKind == metrix.MetricKindHistogram &&
 		meta.FlattenRole == metrix.FlattenRoleHistogramBucket
-}
-
-func forceHistogramBucketChartType(meta program.ChartMeta, seriesMeta metrix.SeriesMeta) program.ChartMeta {
-	if isHistogramBucketSeries(seriesMeta) {
-		meta.Type = program.ChartTypeHeatmap
-	}
-	return meta
 }
 
 func (e *Engine) preparePlan(reader metrix.Reader) (Plan, materializedState, uint64, uint64, uint64, bool, error) {
@@ -446,8 +453,6 @@ func (ctx *planBuildContext) accumulateRoute(
 	labels metrix.LabelView,
 	value metrix.SampleValue,
 ) error {
-	route.Meta = forceHistogramBucketChartType(route.Meta, seriesMeta)
-
 	cs, exists := ctx.chartsByID[route.ChartID]
 	if exists && cs.templateID != route.ChartTemplateID {
 		if !route.Autogen && isAutogenTemplateID(cs.templateID) {
@@ -511,6 +516,7 @@ func (ctx *planBuildContext) accumulateRoute(
 	if isHistogramBucketSeries(seriesMeta) {
 		cs.meta.Type = program.ChartTypeHeatmap
 	}
+	sortKey := histogramBucketDimensionSortKey(route, seriesMeta, labels)
 
 	entry, exists := cs.entries[route.DimensionName]
 	if !exists {
@@ -525,6 +531,7 @@ func (ctx *planBuildContext) accumulateRoute(
 			float:      route.Float,
 			static:     route.Static,
 			order:      route.DimensionIndex,
+			sortKey:    sortKey,
 			algorithm:  route.Algorithm,
 			multiplier: route.Multiplier,
 			divisor:    route.Divisor,
@@ -667,14 +674,49 @@ func observedDimensionNames(cs *chartState, matChart *materializedChartState) []
 			return orderedObservedDimensionNames(cs.entries, cs.currentBuildSeq)
 		}
 		existing := matChart.dimensions[name]
-		if existing == nil || existing.static != entry.static || existing.order != entry.order {
+		if existing == nil || existing.static != entry.static || existing.order != entry.order || existing.sortKey != entry.sortKey {
 			return orderedObservedDimensionNames(cs.entries, cs.currentBuildSeq)
 		}
 	}
 	return prev
 }
 
+func histogramBucketDimensionSortKey(route routeBinding, meta metrix.SeriesMeta, labels metrix.LabelView) dimensionSortKey {
+	if !isHistogramBucketSeries(meta) || route.DimensionKeyLabel != metrix.HistogramBucketLabel || labels == nil {
+		return dimensionSortKey{}
+	}
+	upperBound, ok := labels.Get(metrix.HistogramBucketLabel)
+	if !ok {
+		return dimensionSortKey{}
+	}
+	return histogramBucketSortKey(upperBound)
+}
+
+func histogramBucketSortKey(upperBound string) dimensionSortKey {
+	value, ok := parseHistogramBucketUpperBound(upperBound)
+	if !ok {
+		return dimensionSortKey{}
+	}
+	return dimensionSortKey{
+		kind:       dimensionSortHistogramBucket,
+		upperBound: value,
+	}
+}
+
+func parseHistogramBucketUpperBound(upperBound string) (float64, bool) {
+	upperBound = strings.TrimSpace(upperBound)
+	if upperBound == "" {
+		return 0, false
+	}
+	value, err := strconv.ParseFloat(upperBound, 64)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, -1) {
+		return 0, false
+	}
+	return value, true
+}
+
 func sortInferredDimensions(in []InferredDimension) {
+	histogramGroups := inferredHistogramBucketGroups(in)
 	sort.Slice(in, func(i, j int) bool {
 		lhs := in[i]
 		rhs := in[j]
@@ -684,8 +726,49 @@ func sortInferredDimensions(in []InferredDimension) {
 		if lhs.DimensionIndex != rhs.DimensionIndex {
 			return lhs.DimensionIndex < rhs.DimensionIndex
 		}
+		if histogramGroups[inferredDimensionGroup{chartTemplateID: lhs.ChartTemplateID, dimensionIndex: lhs.DimensionIndex}] {
+			lhsBound, lhsOK := parseHistogramBucketUpperBound(lhs.Name)
+			rhsBound, rhsOK := parseHistogramBucketUpperBound(rhs.Name)
+			if lhsOK && rhsOK && lhsBound != rhsBound {
+				return lhsBound < rhsBound
+			}
+		}
 		return lhs.Name < rhs.Name
 	})
+}
+
+type inferredDimensionGroup struct {
+	chartTemplateID string
+	dimensionIndex  int
+}
+
+type inferredHistogramGroupStats struct {
+	total     int
+	parseable int
+	hasInf    bool
+}
+
+func inferredHistogramBucketGroups(in []InferredDimension) map[inferredDimensionGroup]bool {
+	stats := make(map[inferredDimensionGroup]inferredHistogramGroupStats)
+	for _, dim := range in {
+		group := inferredDimensionGroup{
+			chartTemplateID: dim.ChartTemplateID,
+			dimensionIndex:  dim.DimensionIndex,
+		}
+		item := stats[group]
+		item.total++
+		if upperBound, ok := parseHistogramBucketUpperBound(dim.Name); ok {
+			item.parseable++
+			item.hasInf = item.hasInf || math.IsInf(upperBound, 1)
+		}
+		stats[group] = item
+	}
+
+	out := make(map[inferredDimensionGroup]bool, len(stats))
+	for group, item := range stats {
+		out[group] = item.total > 0 && item.parseable == item.total && item.hasInf
+	}
+	return out
 }
 
 func isAutogenTemplateID(templateID string) bool {

--- a/src/go/plugin/framework/chartengine/planner_lifecycle.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle.go
@@ -9,35 +9,61 @@ import (
 )
 
 func orderedMaterializedDimensionNames(dimensions map[string]*materializedDimensionState) []string {
-	type staticEntry struct {
-		name  string
-		order int
-	}
-	staticEntries := make([]staticEntry, 0, len(dimensions))
-	dynamicNames := make([]string, 0, len(dimensions))
+	staticEntries := make([]staticDimensionOrderEntry, 0, len(dimensions))
+	dynamicEntries := make([]dynamicDimensionOrderEntry, 0, len(dimensions))
 	for name, dim := range dimensions {
 		if dim.static {
-			staticEntries = append(staticEntries, staticEntry{
+			staticEntries = append(staticEntries, staticDimensionOrderEntry{
 				name:  name,
 				order: dim.order,
 			})
 			continue
 		}
-		dynamicNames = append(dynamicNames, name)
+		dynamicEntries = append(dynamicEntries, dynamicDimensionOrderEntry{
+			name:    name,
+			sortKey: dim.sortKey,
+		})
 	}
+	return orderedDimensionNames(staticEntries, dynamicEntries)
+}
+
+type staticDimensionOrderEntry struct {
+	name  string
+	order int
+}
+
+type dynamicDimensionOrderEntry struct {
+	name    string
+	sortKey dimensionSortKey
+}
+
+func orderedDimensionNames(staticEntries []staticDimensionOrderEntry, dynamicEntries []dynamicDimensionOrderEntry) []string {
 	sort.Slice(staticEntries, func(i, j int) bool {
 		if staticEntries[i].order != staticEntries[j].order {
 			return staticEntries[i].order < staticEntries[j].order
 		}
 		return staticEntries[i].name < staticEntries[j].name
 	})
-	sort.Strings(dynamicNames)
-	out := make([]string, 0, len(staticEntries)+len(dynamicNames))
+	sort.Slice(dynamicEntries, func(i, j int) bool {
+		return lessDynamicDimension(dynamicEntries[i], dynamicEntries[j])
+	})
+	out := make([]string, 0, len(staticEntries)+len(dynamicEntries))
 	for _, item := range staticEntries {
 		out = append(out, item.name)
 	}
-	out = append(out, dynamicNames...)
+	for _, item := range dynamicEntries {
+		out = append(out, item.name)
+	}
 	return out
+}
+
+func lessDynamicDimension(lhs, rhs dynamicDimensionOrderEntry) bool {
+	if lhs.sortKey.kind == dimensionSortHistogramBucket && rhs.sortKey.kind == dimensionSortHistogramBucket {
+		if lhs.sortKey.upperBound != rhs.sortKey.upperBound {
+			return lhs.sortKey.upperBound < rhs.sortKey.upperBound
+		}
+	}
+	return lhs.name < rhs.name
 }
 
 func enforceLifecycleCaps(
@@ -348,36 +374,23 @@ func collectExpiryRemovals(
 }
 
 func orderedObservedDimensionNames(entries map[string]*dimBuildEntry, seenSeq uint64) []string {
-	type staticEntry struct {
-		name  string
-		order int
-	}
-	staticEntries := make([]staticEntry, 0, len(entries))
-	dynamicNames := make([]string, 0, len(entries))
+	staticEntries := make([]staticDimensionOrderEntry, 0, len(entries))
+	dynamicEntries := make([]dynamicDimensionOrderEntry, 0, len(entries))
 	for name, entry := range entries {
 		if entry == nil || entry.seenSeq != seenSeq {
 			continue
 		}
 		if entry.static {
-			staticEntries = append(staticEntries, staticEntry{
+			staticEntries = append(staticEntries, staticDimensionOrderEntry{
 				name:  name,
 				order: entry.order,
 			})
 			continue
 		}
-		dynamicNames = append(dynamicNames, name)
+		dynamicEntries = append(dynamicEntries, dynamicDimensionOrderEntry{
+			name:    name,
+			sortKey: entry.sortKey,
+		})
 	}
-	sort.Slice(staticEntries, func(i, j int) bool {
-		if staticEntries[i].order != staticEntries[j].order {
-			return staticEntries[i].order < staticEntries[j].order
-		}
-		return staticEntries[i].name < staticEntries[j].name
-	})
-	sort.Strings(dynamicNames)
-	out := make([]string, 0, len(staticEntries)+len(dynamicNames))
-	for _, entry := range staticEntries {
-		out = append(out, entry.name)
-	}
-	out = append(out, dynamicNames...)
-	return out
+	return orderedDimensionNames(staticEntries, dynamicEntries)
 }

--- a/src/go/plugin/framework/chartengine/planner_lifecycle.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle.go
@@ -58,7 +58,10 @@ func orderedDimensionNames(staticEntries []staticDimensionOrderEntry, dynamicEnt
 }
 
 func lessDynamicDimension(lhs, rhs dynamicDimensionOrderEntry) bool {
-	if lhs.sortKey.kind == dimensionSortHistogramBucket && rhs.sortKey.kind == dimensionSortHistogramBucket {
+	if lhs.sortKey.kind != rhs.sortKey.kind {
+		return lhs.sortKey.kind < rhs.sortKey.kind
+	}
+	if lhs.sortKey.kind == dimensionSortHistogramBucket {
 		if lhs.sortKey.upperBound != rhs.sortKey.upperBound {
 			return lhs.sortKey.upperBound < rhs.sortKey.upperBound
 		}

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -234,6 +234,7 @@ func TestBuildPlanLegacySingleScenarioCases(t *testing.T) {
 		"BuildPlanTemplatePrecedenceOverAutogen":                       {run: runTestBuildPlanTemplatePrecedenceOverAutogen},
 		"BuildPlanAutogenStrictOverflowDrop":                           {run: runTestBuildPlanAutogenStrictOverflowDrop},
 		"BuildPlanAutogenUsesFlattenMetadataForHistogramBuckets":       {run: runTestBuildPlanAutogenUsesFlattenMetadataForHistogramBuckets},
+		"BuildPlanOrdersMixedHistogramAndDefaultDynamicDimensions":     {run: runTestBuildPlanOrdersMixedHistogramAndDefaultDynamicDimensions},
 		"BuildPlanAutogenCreatesChartForUnmatchedGauge":                {run: runTestBuildPlanAutogenCreatesChartForUnmatchedGauge},
 		"BuildPlanAutogenCreatesChartForUnmatchedStateSet":             {run: runTestBuildPlanAutogenCreatesChartForUnmatchedStateSet},
 		"BuildPlanAutogenKeepsStateSetUnitsWhenMetricMetaUnitIsSet":    {run: runTestBuildPlanAutogenKeepsStateSetUnitsWhenMetricMetaUnitIsSet},
@@ -252,6 +253,70 @@ func TestBuildPlanLegacySingleScenarioCases(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, tc.run)
 	}
+}
+
+func runTestBuildPlanOrdersMixedHistogramAndDefaultDynamicDimensions(t *testing.T) {
+	e, err := New()
+	require.NoError(t, err)
+
+	yaml := `
+version: v1
+groups:
+  - family: Mixed
+    metrics:
+      - svc.latency_seconds_bucket
+      - svc.status
+    charts:
+      - title: Mixed Dynamic Dimensions
+        context: mixed_dynamic_dimensions
+        units: values
+        algorithm: incremental
+        dimensions:
+          - selector: svc.latency_seconds_bucket
+          - selector: svc.status
+`
+	require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	sm := store.Write().SnapshotMeter("svc")
+	h := sm.Histogram("latency_seconds", metrix.WithHistogramBounds(2, 10))
+	ss := sm.StateSet("status", metrix.WithStateSetStates("15", "3"), metrix.WithStateSetMode(metrix.ModeEnum))
+
+	cc.BeginCycle()
+	h.ObservePoint(metrix.HistogramPoint{
+		Count: 3,
+		Sum:   13,
+		Buckets: []metrix.BucketPoint{
+			{UpperBound: 2, CumulativeCount: 1},
+			{UpperBound: 10, CumulativeCount: 2},
+		},
+	})
+	ss.Enable("3")
+	cc.CommitCycleSuccess()
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	create := findCreateChartAction(plan)
+	require.NotNil(t, create)
+	assert.Equal(t, program.ChartTypeHeatmap, create.Meta.Type)
+
+	var createDims []string
+	var updateDims []string
+	for _, action := range plan.Actions {
+		switch action := action.(type) {
+		case CreateDimensionAction:
+			createDims = append(createDims, action.Name)
+		case UpdateChartAction:
+			for _, value := range action.Values {
+				updateDims = append(updateDims, value.Name)
+			}
+		}
+	}
+	want := []string{"15", "3", "2", "10", "+Inf"}
+	assert.Equal(t, want, createDims)
+	assert.Equal(t, want, updateDims)
 }
 
 func runTestBuildPlanRequiresFlattenedReaderForInference(t *testing.T) {

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -74,10 +74,11 @@ func TestInferDimensionLabelKeyScenarios(t *testing.T) {
 
 func TestBuildPlanResolvesInferDimensionNames(t *testing.T) {
 	tests := map[string]struct {
-		yaml      string
-		setup     func(t *testing.T, s metrix.CollectorStore)
-		wantNames []string
-		wantKinds []ActionKind
+		yaml           string
+		setup          func(t *testing.T, s metrix.CollectorStore)
+		wantNames      []string
+		wantKinds      []ActionKind
+		wantCreateType program.ChartType
 	}{
 		"histogram bucket inference resolves bucket names from le": {
 			yaml: `
@@ -89,6 +90,7 @@ groups:
     charts:
       - title: Latency buckets
         context: latency_bucket
+        type: stacked
         units: observations
         dimensions:
           - selector: svc.latency_seconds_bucket
@@ -108,8 +110,9 @@ groups:
 				})
 				cc.CommitCycleSuccess()
 			},
-			wantNames: []string{"+Inf", "1", "2"},
-			wantKinds: []ActionKind{ActionCreateChart, ActionCreateDimension, ActionCreateDimension, ActionCreateDimension, ActionUpdateChart},
+			wantNames:      []string{"+Inf", "1", "2"},
+			wantKinds:      []ActionKind{ActionCreateChart, ActionCreateDimension, ActionCreateDimension, ActionCreateDimension, ActionUpdateChart},
+			wantCreateType: program.ChartTypeHeatmap,
 		},
 		"summary quantile inference resolves quantile labels": {
 			yaml: `
@@ -194,6 +197,11 @@ groups:
 			}
 			assert.Equal(t, tc.wantNames, got)
 			assert.Equal(t, tc.wantKinds, actionKinds(plan.Actions))
+			if tc.wantCreateType != "" {
+				create := findCreateChartAction(plan)
+				require.NotNil(t, create)
+				assert.Equal(t, tc.wantCreateType, create.Meta.Type)
+			}
 		})
 	}
 }
@@ -1213,6 +1221,7 @@ groups:
 	assert.Equal(t, "Request duration", buckets.Meta.Title)
 	assert.Equal(t, "Latency", buckets.Meta.Family)
 	assert.Equal(t, "observations/s", buckets.Meta.Units)
+	assert.Equal(t, program.ChartTypeHeatmap, buckets.Meta.Type)
 
 	sum := findCreateChartActionByID(plan, "svc.request_duration_ms_sum")
 	require.NotNil(t, sum)
@@ -1525,6 +1534,7 @@ groups:
 		}
 	}
 	require.NotNil(t, bucketChart)
+	assert.Equal(t, program.ChartTypeHeatmap, bucketChart.Meta.Type)
 	assert.Equal(t, "GET", bucketChart.Labels["method"])
 	_, hasLE := bucketChart.Labels["le"]
 	assert.False(t, hasLE)

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -98,20 +98,21 @@ groups:
 			setup: func(t *testing.T, s metrix.CollectorStore) {
 				t.Helper()
 				cc := mustCycleController(t, s)
-				h := s.Write().SnapshotMeter("svc").Histogram("latency_seconds", metrix.WithHistogramBounds(1, 2))
+				h := s.Write().SnapshotMeter("svc").Histogram("latency_seconds", metrix.WithHistogramBounds(1, 2, 10))
 				cc.BeginCycle()
 				h.ObservePoint(metrix.HistogramPoint{
-					Count: 2,
-					Sum:   3,
+					Count: 4,
+					Sum:   13,
 					Buckets: []metrix.BucketPoint{
 						{UpperBound: 1, CumulativeCount: 1},
 						{UpperBound: 2, CumulativeCount: 2},
+						{UpperBound: 10, CumulativeCount: 3},
 					},
 				})
 				cc.CommitCycleSuccess()
 			},
-			wantNames:      []string{"+Inf", "1", "2"},
-			wantKinds:      []ActionKind{ActionCreateChart, ActionCreateDimension, ActionCreateDimension, ActionCreateDimension, ActionUpdateChart},
+			wantNames:      []string{"1", "2", "10", "+Inf"},
+			wantKinds:      []ActionKind{ActionCreateChart, ActionCreateDimension, ActionCreateDimension, ActionCreateDimension, ActionCreateDimension, ActionUpdateChart},
 			wantCreateType: program.ChartTypeHeatmap,
 		},
 		"summary quantile inference resolves quantile labels": {
@@ -1505,16 +1506,17 @@ groups:
 	store := metrix.NewCollectorStore()
 	cc := mustCycleController(t, store)
 	sm := store.Write().SnapshotMeter("svc")
-	h := sm.Histogram("latency_seconds", metrix.WithHistogramBounds(1, 2))
+	h := sm.Histogram("latency_seconds", metrix.WithHistogramBounds(1, 2, 10))
 	method := sm.LabelSet(metrix.Label{Key: "method", Value: "GET"})
 
 	cc.BeginCycle()
 	h.ObservePoint(metrix.HistogramPoint{
-		Count: 3,
-		Sum:   4,
+		Count: 4,
+		Sum:   13,
 		Buckets: []metrix.BucketPoint{
 			{UpperBound: 1, CumulativeCount: 1},
-			{UpperBound: 2, CumulativeCount: 3},
+			{UpperBound: 2, CumulativeCount: 2},
+			{UpperBound: 10, CumulativeCount: 3},
 		},
 	}, method)
 	cc.CommitCycleSuccess()
@@ -1539,17 +1541,26 @@ groups:
 	_, hasLE := bucketChart.Labels["le"]
 	assert.False(t, hasLE)
 
-	dims := map[string]struct{}{}
+	var dims []string
+	var updateDims []string
 	for _, action := range plan.Actions {
-		create, ok := action.(CreateDimensionAction)
-		if !ok || create.ChartID != "svc.latency_seconds-method=GET" {
-			continue
+		switch action := action.(type) {
+		case CreateDimensionAction:
+			if action.ChartID != "svc.latency_seconds-method=GET" {
+				continue
+			}
+			dims = append(dims, action.Name)
+		case UpdateChartAction:
+			if action.ChartID != "svc.latency_seconds-method=GET" {
+				continue
+			}
+			for _, value := range action.Values {
+				updateDims = append(updateDims, value.Name)
+			}
 		}
-		dims[create.Name] = struct{}{}
 	}
-	assert.Contains(t, dims, "bucket_1")
-	assert.Contains(t, dims, "bucket_2")
-	assert.Contains(t, dims, "bucket_+Inf")
+	assert.Equal(t, []string{"bucket_1", "bucket_2", "bucket_10", "bucket_+Inf"}, dims)
+	assert.Equal(t, []string{"bucket_1", "bucket_2", "bucket_10", "bucket_+Inf"}, updateDims)
 }
 
 func runTestBuildPlanAutogenCreatesChartForUnmatchedGauge(t *testing.T) {

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -531,7 +531,8 @@ charts:
 
 Histogram `_bucket` dimensions receive non-overlapping range bucket totals from
 `metrix.ReadFlatten()`. The `le` label remains the bucket upper bound, but the
-value is no longer cumulative with earlier buckets.
+value is no longer cumulative with earlier buckets. Histogram bucket dimensions
+are ordered by numeric `le` value with `+Inf` last.
 
 > [!WARNING]
 > If a chart's dimensions mix counter-like metrics (e.g., `requests_total`) with gauge-like metrics (e.g., `temperature`) and `algorithm` is omitted, the engine fails with a compile error: _"algorithm inference is ambiguous for mixed metric kinds; set algorithm explicitly"_. Set `algorithm` on the chart to resolve this.

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -146,8 +146,8 @@ groups:
         title: Request Duration Buckets
         context: request_duration_buckets
         units: observations/s
-        type: stacked
-        algorithm: incremental        # histogram buckets are counters
+        type: heatmap                 # histogram bucket charts are forced to heatmap
+        algorithm: incremental        # histogram range buckets are counter-like totals
         instances:
           by_labels: [host]
         dimensions:
@@ -207,7 +207,7 @@ groups:
             # service_status="ready" → dim "ready", service_status="degraded" → dim "degraded", etc.
 ```
 
-**What this template produces** — if the collector reports metrics for 2 hosts (`host="web-1"`, `host="web-2"`), the engine creates **2 instances of every chart** (one per host). The histogram bucket chart gets one dimension per `le` boundary, the summary chart gets one per quantile, and the stateset chart gets one per state — all named automatically by the engine.
+**What this template produces** — if the collector reports metrics for 2 hosts (`host="web-1"`, `host="web-2"`), the engine creates **2 instances of every chart** (one per host). The histogram bucket chart is a heatmap with one non-overlapping range dimension per `le` boundary, the summary chart gets one per quantile, and the stateset chart gets one per state — all named automatically by the engine.
 
 ## Template Structure
 
@@ -514,7 +514,7 @@ charts:
 | `context`         | string        | **yes**  |                        | Chart context leaf. Combined with context namespaces.                        |
 | `units`           | string        | **yes**  |                        | Chart units (e.g., `queries/s`, `bytes`, `percentage`).                      |
 | `algorithm`       | string        | no       | inferred from metrics  | `absolute` or `incremental`. If omitted, inferred from metric suffixes.      |
-| `type`            | string        | no       | `line`                 | `line`, `area`, `stacked`, or `heatmap`.                                     |
+| `type`            | string        | no       | `line`                 | `line`, `area`, `stacked`, or `heatmap`. Histogram bucket charts are forced to `heatmap`. |
 | `priority`        | int           | no       | `70000`                | Chart ordering priority in the dashboard (`0` = use engine default `70000`). |
 | `label_promotion` | array[string] | no       | from `chart_defaults`  | Labels to promote as chart labels (for filtering/grouping in UI). Entries must be non-empty label keys. |
 | `instances`       | object        | no       | from `chart_defaults`  | Instance identity policy (see [instances](#instances)).                      |
@@ -528,6 +528,10 @@ charts:
 |-------------------------------------------|--------------------|
 | `*_total`, `*_count`, `*_sum`, `*_bucket` | `incremental`      |
 | Everything else                           | `absolute`         |
+
+Histogram `_bucket` dimensions receive non-overlapping range bucket totals from
+`metrix.ReadFlatten()`. The `le` label remains the bucket upper bound, but the
+value is no longer cumulative with earlier buckets.
 
 > [!WARNING]
 > If a chart's dimensions mix counter-like metrics (e.g., `requests_total`) with gauge-like metrics (e.g., `temperature`) and `algorithm` is omitted, the engine fails with a compile error: _"algorithm inference is ambiguous for mixed metric kinds; set algorithm explicitly"_. Set `algorithm` on the chart to resolve this.

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -387,7 +387,7 @@ test_dur_count 6
 `,
 			want: func(t *testing.T, fr metrix.Reader) {
 				assert.InDelta(t, 4, value(t, fr, "test_dur_bucket", metrix.Labels{"le": "0.1"}), 1e-9)
-				assert.InDelta(t, 6, value(t, fr, "test_dur_bucket", metrix.Labels{"le": "+Inf"}), 1e-9)
+				assert.InDelta(t, 2, value(t, fr, "test_dur_bucket", metrix.Labels{"le": "+Inf"}), 1e-9)
 				assert.InDelta(t, 2.5, value(t, fr, "test_dur_sum", nil), 1e-9)
 				assert.InDelta(t, 6, value(t, fr, "test_dur_count", nil), 1e-9)
 			},

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/histogram.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/histogram.json
@@ -8,7 +8,7 @@
       {
         "name": "bucket_+Inf",
         "algo": "incremental",
-        "value": 6
+        "value": 2
       },
       {
         "name": "bucket_0.1",
@@ -19,7 +19,7 @@
     "soft": {
       "units": "observations/s",
       "family": "test_histogram",
-      "type": ""
+      "type": "heatmap"
     }
   },
   {

--- a/src/go/plugin/go.d/collector/prometheus/writer_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_test.go
@@ -103,7 +103,8 @@ app_dur_count 4
 			assert: func(t *testing.T, fr metrix.Reader, written int) {
 				assert.Equal(t, 1, written)
 				assert.InDelta(t, 1, value(t, fr, "app_dur_bucket", metrix.Labels{"le": "0.1"}), 1e-9)
-				assert.InDelta(t, 3, value(t, fr, "app_dur_bucket", metrix.Labels{"le": "0.5"}), 1e-9)
+				assert.InDelta(t, 2, value(t, fr, "app_dur_bucket", metrix.Labels{"le": "0.5"}), 1e-9)
+				assert.InDelta(t, 1, value(t, fr, "app_dur_bucket", metrix.Labels{"le": "+Inf"}), 1e-9)
 				assert.InDelta(t, 4, value(t, fr, "app_dur_count", nil), 1e-9)
 				assert.InDelta(t, 0.9, value(t, fr, "app_dur_sum", nil), 1e-9)
 			},
@@ -119,6 +120,7 @@ app_hist_count 5
 			assert: func(t *testing.T, fr metrix.Reader, written int) {
 				assert.Equal(t, 1, written, "a malformed +Inf count must not skip the whole histogram (Count supersedes +Inf)")
 				assert.InDelta(t, 5, value(t, fr, "app_hist_bucket", metrix.Labels{"le": "1"}), 1e-9)
+				assert.InDelta(t, 0, value(t, fr, "app_hist_bucket", metrix.Labels{"le": "+Inf"}), 1e-9)
 				assert.InDelta(t, 5, value(t, fr, "app_hist_count", nil), 1e-9)
 			},
 		},


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Histogram bucket metrics are flattened into non-overlapping range totals and rendered as heatmaps by `chartengine` (autogen and templates), with buckets ordered numerically and `+Inf` last. This replaces cumulative buckets and removes collector-local workarounds.

- **New Features**
  - `metrix.ReadFlatten()` emits range bucket totals; `+Inf` is `count - last finite bucket`. Typed `Histogram()` reads remain cumulative.
  - `chartengine` forces `_bucket` series to `heatmap` and keeps `algorithm: incremental`; `le` remains the upper-bound label. Planner orders bucket dimensions numerically with `+Inf` last, applies this in inference and lifecycle, and sorts histogram dims after other dynamic dims when mixed.
  - Autogen emits heatmaps; planner enforces heatmap for bucket charts; docs and tests updated across `metrix`, `chartengine`, and `go.d/prometheus`.

- **Migration**
  - No config changes. Histogram bucket charts display as heatmaps even if templates specify another type.
  - Remove any collector-local cumulative-to-range logic. If dashboards expected cumulative bucket values, update to per-range totals.
  - Histograms without finite bounds flatten all observations into the `+Inf` range bucket.

<sup>Written for commit 98d06e2b6443b72ff2f0de8174a3616e503ccb65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

