### PR TITLE
Netdata fixes part 44

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -27,6 +27,7 @@ static void parse_command_reply(BUFFER *buf)
     unsigned response_string_size = buffer_strlen(buf);
     FILE *stream = NULL;
     char *pos;
+    char *status_end;
     int syntax_error = 0;
 
     for (pos = response_string ;
@@ -40,7 +41,19 @@ static void parse_command_reply(BUFFER *buf)
 
         switch (*pos) {
         case CMD_PREFIX_EXIT_CODE:
-            exit_status = atoi(++pos);
+            pos++;
+            status_end = pos;
+            while (status_end < response_string + response_string_size && isdigit((uint8_t)*status_end))
+                status_end++;
+
+            if (status_end == pos || status_end >= response_string + response_string_size || *status_end != '\0') {
+                syntax_error = 1;
+                fprintf(stderr, "Syntax error, failed to parse command response.\n");
+            }
+            else {
+                exit_status = atoi(pos);
+                pos = status_end;
+            }
             break;
         case CMD_PREFIX_INFO:
             stream = stdout;

--- a/src/database/contexts/rrdcontext-context-registry.c
+++ b/src/database/contexts/rrdcontext-context-registry.c
@@ -22,11 +22,13 @@ void rrdcontext_context_registry_destroy(void) {
     
     // Free the strings we've held references to
     PValue = JudyLFirst(context_registry_judyl, &index, PJE0);
-    while (PValue) {
+    while (PValue && PValue != PJERR) {
         // Each string has been duplicated when added, so free it
         string_freez((STRING *)index);
         PValue = JudyLNext(context_registry_judyl, &index, PJE0);
     }
+    if (unlikely(PValue == PJERR))
+        fatal("RRDCONTEXT: corrupted context registry JudyL array");
     
     // Free the entire Judy array
     JudyLFreeArray(&context_registry_judyl, PJE0);
@@ -46,12 +48,8 @@ bool rrdcontext_context_registry_add(STRING *context) {
     // Get or insert a slot for this context
     Pvoid_t *PValue = JudyLIns(&context_registry_judyl, (Word_t)context, PJE0);
     
-    if (unlikely(PValue == PJERR)) {
-        // Memory allocation error
-        internal_error(true, "RRDCONTEXT: JudyL memory allocation failed in rrdcontext_context_registry_add()");
-        spinlock_unlock(&context_registry_spinlock);
-        return false;
-    }
+    if (unlikely(!PValue || PValue == PJERR))
+        fatal("RRDCONTEXT: corrupted context registry JudyL array");
     
     size_t count = (size_t)(Word_t)*PValue;
     
@@ -81,6 +79,9 @@ bool rrdcontext_context_registry_remove(STRING *context) {
     // Try to get the value for this context
     Pvoid_t *PValue = JudyLGet(context_registry_judyl, (Word_t)context, PJE0);
     
+    if (unlikely(PValue == PJERR))
+        fatal("RRDCONTEXT: corrupted context registry JudyL array");
+
     if (PValue) {
         size_t count = (size_t)(Word_t)*PValue;
         
@@ -114,10 +115,12 @@ size_t rrdcontext_context_registry_unique_count(void) {
     Word_t index = 0;
     Pvoid_t *PValue = JudyLFirst(context_registry_judyl, &index, PJE0);
     
-    while (PValue) {
+    while (PValue && PValue != PJERR) {
         count++;
         PValue = JudyLNext(context_registry_judyl, &index, PJE0);
     }
+    if (unlikely(PValue == PJERR))
+        fatal("RRDCONTEXT: corrupted context registry JudyL array");
     
     spinlock_unlock(&context_registry_spinlock);
     
@@ -147,7 +150,7 @@ void rrdcontext_context_registry_json_mcp_array(BUFFER *wb, SIMPLE_PATTERN *patt
     Word_t index = 0;
     bool first = true;
     Pvoid_t *PValue;
-    while ((PValue = JudyLFirstThenNext(context_registry_judyl, &index, &first))) {
+    while ((PValue = JudyLFirstThenNext(context_registry_judyl, &index, &first)) && PValue != PJERR) {
         if (!index || !*PValue) continue;
 
         const char *context_name = string2str((STRING *)index);
@@ -161,6 +164,8 @@ void rrdcontext_context_registry_json_mcp_array(BUFFER *wb, SIMPLE_PATTERN *patt
         buffer_json_add_array_item_uint64(wb, *(size_t *)PValue);
         buffer_json_array_close(wb);
     }
+    if (unlikely(PValue == PJERR))
+        fatal("RRDCONTEXT: corrupted context registry JudyL array");
 
     buffer_json_array_close(wb);
 
@@ -179,7 +184,7 @@ void rrdcontext_context_registry_json_mcp_categories_array(BUFFER *wb, SIMPLE_PA
     Word_t index = 0;
     bool first = true;
     Pvoid_t *PValue;
-    while ((PValue = JudyLFirstThenNext(context_registry_judyl, &index, &first))) {
+    while ((PValue = JudyLFirstThenNext(context_registry_judyl, &index, &first)) && PValue != PJERR) {
         if (!index || !*PValue) continue;
         
         const char *context_name = string2str((STRING *)index);
@@ -204,20 +209,20 @@ void rrdcontext_context_registry_json_mcp_categories_array(BUFFER *wb, SIMPLE_PA
         // Get or insert a slot for this category
         Pvoid_t *CategoryValue = JudyLIns(&categories_judyl, (Word_t)category_str, PJE0);
         
-        if (CategoryValue) {
-            // Check if this is a new entry
-            size_t count = (size_t)(Word_t)*CategoryValue;
-            if (count > 0) {
-                // Already exists, free our reference (JudyL already has one)
-                string_freez(category_str);
-            }
-            // Increment the count
-            *CategoryValue = (void *)(Word_t)(count + 1);
-        } else {
-            // Failed to insert, free the STRING
+        if (unlikely(!CategoryValue || CategoryValue == PJERR))
+            fatal("RRDCONTEXT: corrupted category JudyL array");
+
+        // Check if this is a new entry
+        size_t count = (size_t)(Word_t)*CategoryValue;
+        if (count > 0) {
+            // Already exists, free our reference (JudyL already has one)
             string_freez(category_str);
         }
+        // Increment the count
+        *CategoryValue = (void *)(Word_t)(count + 1);
     }
+    if (unlikely(PValue == PJERR))
+        fatal("RRDCONTEXT: corrupted context registry JudyL array");
     
     // Second pass: output the unique categories and their counts
 
@@ -244,7 +249,7 @@ void rrdcontext_context_registry_json_mcp_categories_array(BUFFER *wb, SIMPLE_PA
 
     index = 0;
     first = true;
-    while ((PValue = JudyLFirstThenNext(categories_judyl, &index, &first))) {
+    while ((PValue = JudyLFirstThenNext(categories_judyl, &index, &first)) && PValue != PJERR) {
         if (!index) continue;
         
         STRING *category_str = (STRING *)index;
@@ -263,6 +268,8 @@ void rrdcontext_context_registry_json_mcp_categories_array(BUFFER *wb, SIMPLE_PA
         // Free the STRING object as we go
         string_freez(category_str);
     }
+    if (unlikely(PValue == PJERR))
+        fatal("RRDCONTEXT: corrupted category JudyL array");
     
     buffer_json_array_close(wb);
     

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1032,7 +1032,16 @@ static int journalfile_v2_validate(void *data_start, size_t journal_v2_file_size
 
         char uuid_str[UUID_STR_LEN];
         uuid_unparse_lower(metric->uuid, uuid_str);
-        struct journal_page_header *metric_list_header = (void *) (data_start + metric->page_offset);
+        size_t page_offset = (size_t)metric->page_offset;
+        if (page_offset > journal_v2_file_size ||
+            journal_v2_file_size - page_offset < sizeof(struct journal_page_header)) {
+            netdata_log_info(
+                "DBENGINE: verification failed invalid page list header offset -- index %u at offset %u",
+                entries, metric->page_offset);
+            return 1;
+        }
+
+        struct journal_page_header *metric_list_header = (void *) ((uint8_t *) data_start + page_offset);
         struct journal_page_header local_metric_list_header = *metric_list_header;
 
         local_metric_list_header.crc = JOURVAL_V2_MAGIC;
@@ -1042,8 +1051,17 @@ static int journalfile_v2_validate(void *data_start, size_t journal_v2_file_size
         rc = crc32cmp(metric_list_header->checksum, crc);
 
         if (!rc) {
+            size_t page_list_room = journal_v2_file_size - page_offset - sizeof(struct journal_page_header);
+            if (page_list_room < sizeof(struct journal_v2_block_trailer) ||
+                (size_t)metric_list_header->entries > (page_list_room - sizeof(struct journal_v2_block_trailer)) / sizeof(struct journal_page_list)) {
+                netdata_log_info("DBENGINE: verification failed invalid page list entries -- index %u entries %u at offset %u",
+                                 entries, metric_list_header->entries, metric->page_offset);
+                return 1;
+            }
+
             struct journal_v2_block_trailer *journal_trailer =
-                (void *) data_start + metric->page_offset + sizeof(struct journal_page_header) + (metric_list_header->entries * sizeof(struct journal_page_list));
+                (void *) ((uint8_t *) data_start + page_offset + sizeof(struct journal_page_header) +
+                          (metric_list_header->entries * sizeof(struct journal_page_list)));
 
             crc = crc32(0L, Z_NULL, 0);
             crc = crc32(crc, (uint8_t *) metric_list_header + sizeof(struct journal_page_header), metric_list_header->entries * sizeof(struct journal_page_list));

--- a/src/libnetdata/facets/facets.c
+++ b/src/libnetdata/facets/facets.c
@@ -9,6 +9,7 @@
 #define FACETS_VALUES_HASHTABLE_ENTRIES 15
 
 static inline void facets_reset_key(FACET_KEY *k);
+static inline void facets_track_key_in_current_row(FACETS *facets, FACET_KEY *k);
 
 // ----------------------------------------------------------------------------
 
@@ -257,6 +258,7 @@ struct facets {
     struct {
         // this is like a stack, of the keys that need to clean up between each row
         size_t used;
+        bool overflowed;
         FACET_KEY *array[FACETS_KEYS_IN_ROW_MAX];
     } keys_in_row;
 
@@ -1899,8 +1901,7 @@ void facets_set_additional_options(FACETS *facets, FACETS_OPTIONS options) {
 // ----------------------------------------------------------------------------
 
 static inline void facets_key_set_unsampled_value(FACETS *facets, FACET_KEY *k) {
-    if(likely(!facet_key_value_updated(k) && facets->keys_in_row.used < FACETS_KEYS_IN_ROW_MAX))
-        facets->keys_in_row.array[facets->keys_in_row.used++] = k;
+    facets_track_key_in_current_row(facets, k);
 
     k->current_value.flags |= FACET_KEY_VALUE_UPDATED | FACET_KEY_VALUE_UNSAMPLED;
 
@@ -1923,8 +1924,7 @@ static inline void facets_key_set_unsampled_value(FACETS *facets, FACET_KEY *k) 
 }
 
 static inline void facets_key_set_empty_value(FACETS *facets, FACET_KEY *k) {
-    if(likely(!facet_key_value_updated(k) && facets->keys_in_row.used < FACETS_KEYS_IN_ROW_MAX))
-        facets->keys_in_row.array[facets->keys_in_row.used++] = k;
+    facets_track_key_in_current_row(facets, k);
 
     k->current_value.flags |= FACET_KEY_VALUE_UPDATED | FACET_KEY_VALUE_EMPTY;
 
@@ -1947,8 +1947,7 @@ static inline void facets_key_set_empty_value(FACETS *facets, FACET_KEY *k) {
 }
 
 static inline void facets_key_check_value(FACETS *facets, FACET_KEY *k) {
-    if(likely(!facet_key_value_updated(k) && facets->keys_in_row.used < FACETS_KEYS_IN_ROW_MAX))
-        facets->keys_in_row.array[facets->keys_in_row.used++] = k;
+    facets_track_key_in_current_row(facets, k);
 
     k->current_value.flags |= FACET_KEY_VALUE_UPDATED;
     k->current_value.flags &= ~(FACET_KEY_VALUE_EMPTY|FACET_KEY_VALUE_UNSAMPLED|FACET_KEY_VALUE_ESTIMATED);
@@ -2248,18 +2247,38 @@ static inline void facets_reset_key(FACET_KEY *k) {
     k->current_value.hash = FACETS_HASH_ZERO;
 }
 
-static void facets_reset_keys_with_value_and_row(FACETS *facets) {
-    size_t entries = facets->keys_in_row.used;
+static inline void facets_track_key_in_current_row(FACETS *facets, FACET_KEY *k) {
+    if(unlikely(facet_key_value_updated(k)))
+        return;
 
-    for(size_t p = 0; p < entries ;p++) {
-        FACET_KEY *k = facets->keys_in_row.array[p];
-        facets_reset_key(k);
+    if(likely(facets->keys_in_row.used < FACETS_KEYS_IN_ROW_MAX))
+        facets->keys_in_row.array[facets->keys_in_row.used++] = k;
+    else
+        facets->keys_in_row.overflowed = true;
+}
+
+static void facets_reset_keys_with_value_and_row(FACETS *facets) {
+    if(unlikely(facets->keys_in_row.overflowed)) {
+        FACET_KEY *k;
+        foreach_key_in_facets(facets, k) {
+            facets_reset_key(k);
+        }
+        foreach_key_in_facets_done(k);
+    }
+    else {
+        size_t entries = facets->keys_in_row.used;
+
+        for(size_t p = 0; p < entries ;p++) {
+            FACET_KEY *k = facets->keys_in_row.array[p];
+            facets_reset_key(k);
+        }
     }
 
     facets->current_row.severity = FACET_ROW_SEVERITY_NORMAL;
     facets->current_row.keys_matched_by_query_positive = 0;
     facets->current_row.keys_matched_by_query_negative = 0;
     facets->keys_in_row.used = 0;
+    facets->keys_in_row.overflowed = false;
 
     facets_row_bin_data_cleanup(facets, &facets->bin_data);
 }
@@ -2272,6 +2291,7 @@ void facets_rows_begin(FACETS *facets) {
     foreach_key_in_facets_done(k);
 
     facets->keys_in_row.used = 0;
+    facets->keys_in_row.overflowed = false;
     facets_reset_keys_with_value_and_row(facets);
 }
 

--- a/src/libnetdata/facets/facets.c
+++ b/src/libnetdata/facets/facets.c
@@ -2,7 +2,7 @@
 #include "facets.h"
 
 #define FACETS_HISTOGRAM_COLUMNS 150        // the target number of points in a histogram
-#define FACETS_KEYS_WITH_VALUES_MAX 200     // the max number of keys that can be facets
+#define FACETS_KEYS_WITH_VALUES_INITIAL 200 // embedded capacity for keys that can be facets
 #define FACETS_KEYS_IN_ROW_MAX 500          // the max number of keys in a row
 
 #define FACETS_KEYS_HASHTABLE_ENTRIES 15
@@ -252,7 +252,9 @@ struct facets {
     struct {
         // this is like a stack, of the keys that are used as facets
         size_t used;
-        FACET_KEY *array[FACETS_KEYS_WITH_VALUES_MAX];
+        size_t size;
+        FACET_KEY **array;
+        FACET_KEY *initial_array[FACETS_KEYS_WITH_VALUES_INITIAL];
     } keys_with_values;
 
     struct {
@@ -629,8 +631,32 @@ static inline void facet_key_late_init(FACETS *facets, FACET_KEY *k) {
     if(facets_key_is_facet(facets, k)) {
         FACETS_VALUES_INDEX_CREATE(k);
         k->values.enabled = true;
-        if(facets->keys_with_values.used < FACETS_KEYS_WITH_VALUES_MAX)
-            facets->keys_with_values.array[facets->keys_with_values.used++] = k;
+
+        if(unlikely(facets->keys_with_values.used == facets->keys_with_values.size)) {
+            size_t new_size = facets->keys_with_values.size ?
+                              facets->keys_with_values.size * 2 :
+                              FACETS_KEYS_WITH_VALUES_INITIAL;
+
+            if(unlikely(new_size < facets->keys_with_values.size ||
+                        new_size > SIZE_MAX / sizeof(*facets->keys_with_values.array)))
+                fatal("Cannot grow facets keys_with_values array beyond %zu entries",
+                      facets->keys_with_values.size);
+
+            FACET_KEY **new_array;
+            if(facets->keys_with_values.array == facets->keys_with_values.initial_array) {
+                new_array = mallocz(new_size * sizeof(*new_array));
+                memcpy(new_array,
+                       facets->keys_with_values.initial_array,
+                       facets->keys_with_values.used * sizeof(*new_array));
+            }
+            else
+                new_array = reallocz(facets->keys_with_values.array, new_size * sizeof(*new_array));
+
+            facets->keys_with_values.array = new_array;
+            facets->keys_with_values.size = new_size;
+        }
+
+        facets->keys_with_values.array[facets->keys_with_values.used++] = k;
     }
 }
 
@@ -638,6 +664,8 @@ static inline void FACETS_KEYS_INDEX_CREATE(FACETS *facets) {
     facets->keys.ll = NULL;
     facets->keys.count = 0;
     facets->keys_with_values.used = 0;
+    facets->keys_with_values.size = FACETS_KEYS_WITH_VALUES_INITIAL;
+    facets->keys_with_values.array = facets->keys_with_values.initial_array;
 
     simple_hashtable_init_KEY(&facets->keys.ht, FACETS_KEYS_HASHTABLE_ENTRIES);
 }
@@ -657,6 +685,10 @@ static inline void FACETS_KEYS_INDEX_DESTROY(FACETS *facets) {
     facets->keys.ll = NULL;
     facets->keys.count = 0;
     facets->keys_with_values.used = 0;
+    facets->keys_with_values.size = 0;
+    if(facets->keys_with_values.array != facets->keys_with_values.initial_array)
+        freez(facets->keys_with_values.array);
+    facets->keys_with_values.array = NULL;
 
     simple_hashtable_destroy_KEY(&facets->keys.ht);
 }

--- a/src/libnetdata/simple_hashtable/simple_hashtable.h
+++ b/src/libnetdata/simple_hashtable/simple_hashtable.h
@@ -153,7 +153,13 @@ static inline void simple_hashtable_add_value_sorted_named(SIMPLE_HASHTABLE_NAME
 
     // Ensure there's enough space in the sorted array
     if (ht->sorted.used >= ht->sorted.size) {
+        if(unlikely(ht->sorted.size > SIZE_MAX / 2))
+            fatal("SIMPLE_HASHTABLE: cannot resize sorted array with %zu entries", ht->sorted.size);
+
         size_t size = ht->sorted.size ? ht->sorted.size * 2 : 64;
+        if(unlikely(size > SIZE_MAX / sizeof(SIMPLE_HASHTABLE_VALUE_TYPE)))
+            fatal("SIMPLE_HASHTABLE: cannot allocate sorted array with %zu entries", size);
+
         SIMPLE_HASHTABLE_VALUE_TYPE *array = mallocz(size * sizeof(SIMPLE_HASHTABLE_VALUE_TYPE));
         if(ht->sorted.array) {
             memcpy(array, ht->sorted.array, ht->sorted.size * sizeof(SIMPLE_HASHTABLE_VALUE_TYPE));
@@ -311,7 +317,8 @@ static inline bool simple_hashtable_can_use_slot_named(
     return false;
 }
 
-#define SIMPLE_HASHTABLE_NEEDS_RESIZE(ht) ((ht)->size <= ((ht)->used - (ht)->deleted) << 1 || (ht)->used >= (ht)->size)
+#define SIMPLE_HASHTABLE_NEEDS_RESIZE(ht) \
+    ((ht)->used >= (ht)->size || ((ht)->used - (ht)->deleted) >= ((ht)->size / 2 + ((ht)->size & 1)))
 
 // IMPORTANT: the pointer returned by this call is valid up to the next call of this function (or the resize one).
 // If you need to cache something, cache the hash, not the slot pointer.
@@ -467,8 +474,12 @@ static inline void simple_hashtable_resize_named(SIMPLE_HASHTABLE_NAMED *ht) {
 
     size_t new_size = ht->size;
 
-    if(SIMPLE_HASHTABLE_NEEDS_RESIZE(ht))
-        new_size = (ht->size << 1) - ((ht->size > 16) ? 1 : 0);
+    if(SIMPLE_HASHTABLE_NEEDS_RESIZE(ht)) {
+        if(unlikely(ht->size > SIZE_MAX / 2))
+            fatal("SIMPLE_HASHTABLE: cannot resize table with %zu slots", ht->size);
+
+        new_size = (ht->size * 2) - ((ht->size > 16) ? 1 : 0);
+    }
 
     ht->resizes++;
     ht->size = new_size;

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -81,15 +81,19 @@ typedef struct query_engine_ops {
     struct query_engine_ops *next;
 } QUERY_ENGINE_OPS;
 
+typedef struct query_engine_ops_cache {
+    QUERY_ENGINE_OPS *released_ops;
+} QUERY_ENGINE_OPS_CACHE;
+
 // query planner
 #define query_plan_should_switch_plan(ops, now) ((now) >= (ops)->current_plan_expire_time)
 bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point_end_time);
 void query_planer_finalize_remaining_plans(QUERY_ENGINE_OPS *ops);
-QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, size_t query_metric_id);
-void rrd2rrdr_query_ops_release(QUERY_ENGINE_OPS *ops);
+QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache, size_t query_metric_id);
+void rrd2rrdr_query_ops_release(QUERY_ENGINE_OPS_CACHE *cache, QUERY_ENGINE_OPS *ops);
 time_t query_target_min_update_every_for_tier(QUERY_TARGET *qt, size_t tier);
 int query_plan_unittest(void);
-void rrd2rrdr_query_ops_freeall(RRDR *r);
+void rrd2rrdr_query_ops_freeall(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache);
 
 // query execution
 void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_OPS *ops);

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -9,6 +9,27 @@ static bool query_metric_is_valid_tier(QUERY_METRIC *qm, size_t tier) {
     return true;
 }
 
+static bool query_plan_tier_is_valid(QUERY_METRIC *qm, size_t tier) {
+    if(tier >= nd_profile.storage_tiers || tier >= RRD_STORAGE_TIERS)
+        return false;
+
+    return query_metric_is_valid_tier(qm, tier);
+}
+
+static bool query_plan_entry_is_valid(
+    QUERY_METRIC *qm, const QUERY_PLAN_ENTRY *entry, time_t after_wanted, time_t before_wanted) {
+    if(!entry->after || !entry->before)
+        return false;
+
+    if(entry->after > entry->before)
+        return false;
+
+    if(entry->after < after_wanted || entry->before > before_wanted)
+        return false;
+
+    return query_plan_tier_is_valid(qm, entry->tier);
+}
+
 static size_t query_metric_first_working_tier(QUERY_METRIC *qm) {
     for(size_t tier = 0; tier < nd_profile.storage_tiers; tier++) {
 
@@ -244,14 +265,26 @@ void query_planer_finalize_remaining_plans(QUERY_ENGINE_OPS *ops) {
         query_planer_finalize_plan(ops, p);
 }
 
-static void query_planer_activate_plan(QUERY_ENGINE_OPS *ops, size_t plan_id, time_t overwrite_after __maybe_unused) {
+static bool query_planer_plan_can_be_activated(QUERY_ENGINE_OPS *ops, size_t plan_id) {
     QUERY_METRIC *qm = ops->qm;
 
-    internal_fatal(plan_id >= qm->plan.used, "QUERY: invalid plan_id given");
-    internal_fatal(!ops->plans[plan_id].initialized, "QUERY: plan has not been initialized");
-    internal_fatal(ops->plans[plan_id].finalized, "QUERY: plan has been finalized");
+    if(plan_id >= qm->plan.used)
+        return false;
 
-    internal_fatal(qm->plan.array[plan_id].after > qm->plan.array[plan_id].before, "QUERY: flipped after/before");
+    if(!ops->plans[plan_id].initialized || ops->plans[plan_id].finalized)
+        return false;
+
+    if(!qm->plan.array[plan_id].after || !qm->plan.array[plan_id].before)
+        return false;
+
+    if(qm->plan.array[plan_id].after > qm->plan.array[plan_id].before)
+        return false;
+
+    return query_plan_tier_is_valid(qm, qm->plan.array[plan_id].tier);
+}
+
+static void query_planer_set_active_plan(QUERY_ENGINE_OPS *ops, size_t plan_id, time_t overwrite_after __maybe_unused) {
+    QUERY_METRIC *qm = ops->qm;
 
     ops->tier = qm->plan.array[plan_id].tier;
     ops->tier_ptr = &qm->tiers[ops->tier];
@@ -265,6 +298,14 @@ static void query_planer_activate_plan(QUERY_ENGINE_OPS *ops, size_t plan_id, ti
 
     ops->plan_expanded_after = ops->plans[plan_id].expanded_after;
     ops->plan_expanded_before = ops->plans[plan_id].expanded_before;
+}
+
+static bool query_planer_activate_plan(QUERY_ENGINE_OPS *ops, size_t plan_id, time_t overwrite_after __maybe_unused) {
+    if(!query_planer_plan_can_be_activated(ops, plan_id))
+        return false;
+
+    query_planer_set_active_plan(ops, plan_id, overwrite_after);
+    return true;
 }
 
 bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point_end_time) {
@@ -287,14 +328,14 @@ bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point
         next_plan_before_time = qm->plan.array[ops->current_plan].before;
     } while(now >= next_plan_before_time || last_point_end_time >= next_plan_before_time);
 
-    if(!query_metric_is_valid_tier(qm, qm->plan.array[ops->current_plan].tier)) {
+    if(!query_planer_plan_can_be_activated(ops, ops->current_plan)) {
         ops->current_plan = old_plan;
         ops->current_plan_expire_time = ops->r->internal.qt->window.before;
         return false;
     }
 
     query_planer_finalize_plan(ops, old_plan);
-    query_planer_activate_plan(ops, ops->current_plan, MIN(now, last_point_end_time));
+    query_planer_set_active_plan(ops, ops->current_plan, MIN(now, last_point_end_time));
     return true;
 }
 
@@ -358,11 +399,13 @@ static bool query_plan_build_entries(QUERY_ENGINE_OPS *ops, time_t after_wanted,
                         .after = (tier_first_time_s < after_wanted) ? after_wanted : tier_first_time_s,
                         .before = selected_tier_first_time_s,
                     };
+
+                    if(!query_plan_entry_is_valid(qm, &t, after_wanted, before_wanted))
+                        return false;
+
                     ops->plans[qm->plan.used].initialized = false;
                     ops->plans[qm->plan.used].finalized = false;
                     qm->plan.array[qm->plan.used++] = t;
-
-                    internal_fatal(!t.after || !t.before, "QUERY: invalid plan selected");
 
                     // prepare for the tier
                     selected_tier_first_time_s = t.after;
@@ -394,14 +437,16 @@ static bool query_plan_build_entries(QUERY_ENGINE_OPS *ops, time_t after_wanted,
                         .after = selected_tier_last_time_s,
                         .before = (tier_last_time_s > before_wanted) ? before_wanted : tier_last_time_s,
                     };
+
+                    if(!query_plan_entry_is_valid(qm, &t, after_wanted, before_wanted))
+                        return false;
+
                     ops->plans[qm->plan.used].initialized = false;
                     ops->plans[qm->plan.used].finalized = false;
                     qm->plan.array[qm->plan.used++] = t;
 
                     // prepare for the tier
                     selected_tier_last_time_s = t.before;
-
-                    internal_fatal(!t.after || !t.before, "QUERY: invalid plan selected");
 
                     if (t.before >= before_wanted)
                         break;
@@ -414,16 +459,10 @@ static bool query_plan_build_entries(QUERY_ENGINE_OPS *ops, time_t after_wanted,
     if(qm->plan.used > 1)
         qsort(&qm->plan.array, qm->plan.used, sizeof(QUERY_PLAN_ENTRY), compare_query_plan_entries_on_start_time);
 
-    if(!query_metric_is_valid_tier(qm, qm->plan.array[0].tier))
-        return false;
-
-#ifdef NETDATA_INTERNAL_CHECKS
     for(size_t p = 0; p < qm->plan.used ;p++) {
-        internal_fatal(qm->plan.array[p].after > qm->plan.array[p].before, "QUERY: flipped after/before");
-        internal_fatal(qm->plan.array[p].after < after_wanted, "QUERY: too small plan first time");
-        internal_fatal(qm->plan.array[p].before > before_wanted, "QUERY: too big plan last time");
+        if(!query_plan_entry_is_valid(qm, &qm->plan.array[p], after_wanted, before_wanted))
+            return false;
     }
-#endif
 
     return true;
 }
@@ -433,7 +472,10 @@ static bool query_plan(QUERY_ENGINE_OPS *ops, time_t after_wanted, time_t before
         return false;
 
     query_planer_initialize_plans(ops);
-    query_planer_activate_plan(ops, 0, 0);
+    if(!query_planer_activate_plan(ops, 0, 0)) {
+        query_planer_finalize_remaining_plans(ops);
+        return false;
+    }
 
     return true;
 }
@@ -603,6 +645,36 @@ static int query_plan_unittest_expect_update_every(QUERY_TARGET *qt, size_t tier
     return 1;
 }
 
+static int query_plan_unittest_expect_entry_validity(
+    const char *name, QUERY_METRIC *qm, QUERY_PLAN_ENTRY entry, time_t after, time_t before, bool expected) {
+    bool got = query_plan_entry_is_valid(qm, &entry, after, before);
+    if(got == expected) {
+        fprintf(stderr, "OK query plan entry validation: %s\n", name);
+        return 0;
+    }
+
+    fprintf(stderr,
+            "FAILED query plan entry validation: %s, expected %s, got %s\n",
+            name, expected ? "valid" : "invalid", got ? "valid" : "invalid");
+
+    return 1;
+}
+
+static int query_plan_unittest_expect_activation(
+    const char *name, QUERY_ENGINE_OPS *ops, size_t plan_id, bool expected) {
+    bool got = query_planer_activate_plan(ops, plan_id, 0);
+    if(got == expected) {
+        fprintf(stderr, "OK query plan activation: %s\n", name);
+        return 0;
+    }
+
+    fprintf(stderr,
+            "FAILED query plan activation: %s, expected %s, got %s\n",
+            name, expected ? "success" : "failure", got ? "success" : "failure");
+
+    return 1;
+}
+
 int query_plan_unittest(void) {
     size_t old_storage_tiers = nd_profile.storage_tiers;
     time_t old_update_every = nd_profile.update_every;
@@ -610,6 +682,96 @@ int query_plan_unittest(void) {
 
     nd_profile.storage_tiers = 3;
     nd_profile.update_every = 1;
+
+    {
+        QUERY_METRIC qm = {0};
+        query_plan_unittest_set_tier(&qm, 0, 10, 100, 10);
+
+        errors += query_plan_unittest_expect_entry_validity(
+            "valid in-window entry", &qm, (QUERY_PLAN_ENTRY){ .tier = 0, .after = 20, .before = 80 }, 10, 100, true);
+        errors += query_plan_unittest_expect_entry_validity(
+            "zero start is invalid", &qm, (QUERY_PLAN_ENTRY){ .tier = 0, .after = 0, .before = 80 }, 10, 100, false);
+        errors += query_plan_unittest_expect_entry_validity(
+            "flipped entry is invalid", &qm, (QUERY_PLAN_ENTRY){ .tier = 0, .after = 90, .before = 80 }, 10, 100, false);
+        errors += query_plan_unittest_expect_entry_validity(
+            "entry before requested window is invalid", &qm, (QUERY_PLAN_ENTRY){ .tier = 0, .after = 9, .before = 80 }, 10, 100, false);
+        errors += query_plan_unittest_expect_entry_validity(
+            "entry after requested window is invalid", &qm, (QUERY_PLAN_ENTRY){ .tier = 0, .after = 20, .before = 101 }, 10, 100, false);
+        errors += query_plan_unittest_expect_entry_validity(
+            "out-of-range tier is invalid", &qm, (QUERY_PLAN_ENTRY){ .tier = 3, .after = 20, .before = 80 }, 10, 100, false);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        QUERY_ENGINE_OPS ops = { .qm = &qm };
+
+        query_plan_unittest_set_tier(&qm, 0, 10, 100, 10);
+        qm.plan.used = 1;
+        qm.plan.array[0] = (QUERY_PLAN_ENTRY){ .tier = 0, .after = 10, .before = 100 };
+        ops.plans[0].initialized = true;
+
+        errors += query_plan_unittest_expect_activation("valid initialized plan", &ops, 0, true);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        QUERY_ENGINE_OPS ops = { .qm = &qm };
+
+        query_plan_unittest_set_tier(&qm, 0, 10, 100, 10);
+        qm.plan.used = 1;
+        qm.plan.array[0] = (QUERY_PLAN_ENTRY){ .tier = 0, .after = 10, .before = 100 };
+        ops.plans[0].initialized = true;
+
+        errors += query_plan_unittest_expect_activation("invalid plan id is rejected", &ops, 1, false);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        QUERY_ENGINE_OPS ops = { .qm = &qm };
+
+        query_plan_unittest_set_tier(&qm, 0, 10, 100, 10);
+        qm.plan.used = 1;
+        qm.plan.array[0] = (QUERY_PLAN_ENTRY){ .tier = 0, .after = 10, .before = 100 };
+
+        errors += query_plan_unittest_expect_activation("uninitialized plan is rejected", &ops, 0, false);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        QUERY_ENGINE_OPS ops = { .qm = &qm };
+
+        query_plan_unittest_set_tier(&qm, 0, 10, 100, 10);
+        qm.plan.used = 1;
+        qm.plan.array[0] = (QUERY_PLAN_ENTRY){ .tier = 0, .after = 10, .before = 100 };
+        ops.plans[0].initialized = true;
+        ops.plans[0].finalized = true;
+
+        errors += query_plan_unittest_expect_activation("finalized plan is rejected", &ops, 0, false);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        QUERY_ENGINE_OPS ops = { .qm = &qm };
+
+        query_plan_unittest_set_tier(&qm, 0, 10, 100, 10);
+        qm.plan.used = 1;
+        qm.plan.array[0] = (QUERY_PLAN_ENTRY){ .tier = 0, .after = 100, .before = 10 };
+        ops.plans[0].initialized = true;
+
+        errors += query_plan_unittest_expect_activation("flipped plan is rejected", &ops, 0, false);
+    }
+
+    {
+        QUERY_METRIC qm = {0};
+        QUERY_ENGINE_OPS ops = { .qm = &qm };
+
+        query_plan_unittest_set_tier(&qm, 0, 10, 100, 10);
+        qm.plan.used = 1;
+        qm.plan.array[0] = (QUERY_PLAN_ENTRY){ .tier = 3, .after = 10, .before = 100 };
+        ops.plans[0].initialized = true;
+
+        errors += query_plan_unittest_expect_activation("out-of-range tier is rejected", &ops, 0, false);
+    }
 
     {
         QUERY_METRIC qm = {0};

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -481,29 +481,27 @@ static bool query_plan(QUERY_ENGINE_OPS *ops, time_t after_wanted, time_t before
 }
 
 
-static __thread QUERY_ENGINE_OPS *released_ops = NULL;
-
-void rrd2rrdr_query_ops_freeall(RRDR *r __maybe_unused) {
-    while(released_ops) {
-        QUERY_ENGINE_OPS *ops = released_ops;
-        released_ops = ops->next;
+void rrd2rrdr_query_ops_freeall(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache) {
+    while(cache->released_ops) {
+        QUERY_ENGINE_OPS *ops = cache->released_ops;
+        cache->released_ops = ops->next;
 
         onewayalloc_freez(r->internal.owa, ops);
     }
 }
 
-void rrd2rrdr_query_ops_release(QUERY_ENGINE_OPS *ops) {
+void rrd2rrdr_query_ops_release(QUERY_ENGINE_OPS_CACHE *cache, QUERY_ENGINE_OPS *ops) {
     if(!ops) return;
 
-    ops->next = released_ops;
-    released_ops = ops;
+    ops->next = cache->released_ops;
+    cache->released_ops = ops;
 }
 
-static QUERY_ENGINE_OPS *rrd2rrdr_query_ops_get(RRDR *r) {
+static QUERY_ENGINE_OPS *rrd2rrdr_query_ops_get(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache) {
     QUERY_ENGINE_OPS *ops;
-    if(released_ops) {
-        ops = released_ops;
-        released_ops = ops->next;
+    if(cache->released_ops) {
+        ops = cache->released_ops;
+        cache->released_ops = ops->next;
     }
     else {
         ops = onewayalloc_mallocz(r->internal.owa, sizeof(QUERY_ENGINE_OPS));
@@ -513,10 +511,10 @@ static QUERY_ENGINE_OPS *rrd2rrdr_query_ops_get(RRDR *r) {
     return ops;
 }
 
-QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, size_t query_metric_id) {
+QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache, size_t query_metric_id) {
     QUERY_TARGET *qt = r->internal.qt;
 
-    QUERY_ENGINE_OPS *ops = rrd2rrdr_query_ops_get(r);
+    QUERY_ENGINE_OPS *ops = rrd2rrdr_query_ops_get(r, cache);
     *ops = (QUERY_ENGINE_OPS) {
         .r = r,
         .qm = query_metric(qt, query_metric_id),
@@ -527,7 +525,7 @@ QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, size_t query_metric_id) {
     };
 
     if(!query_plan(ops, qt->window.after, qt->window.before, qt->window.points)) {
-        rrd2rrdr_query_ops_release(ops);
+        rrd2rrdr_query_ops_release(cache, ops);
         return NULL;
     }
 
@@ -672,6 +670,48 @@ static int query_plan_unittest_expect_activation(
             "FAILED query plan activation: %s, expected %s, got %s\n",
             name, expected ? "success" : "failure", got ? "success" : "failure");
 
+    return 1;
+}
+
+static int query_plan_unittest_expect_ops_cache_is_local(void) {
+    ONEWAYALLOC *owa_a = onewayalloc_create(1024);
+    ONEWAYALLOC *owa_b = onewayalloc_create(1024);
+
+    RRDR r_a = {
+        .internal.owa = owa_a,
+    };
+    RRDR r_b = {
+        .internal.owa = owa_b,
+    };
+
+    QUERY_ENGINE_OPS_CACHE cache_a = { 0 };
+    QUERY_ENGINE_OPS_CACHE cache_b = { 0 };
+
+    QUERY_ENGINE_OPS *a = rrd2rrdr_query_ops_get(&r_a, &cache_a);
+    rrd2rrdr_query_ops_release(&cache_a, a);
+
+    QUERY_ENGINE_OPS *a_reused = rrd2rrdr_query_ops_get(&r_a, &cache_a);
+    bool same_cache_reused = (a_reused == a);
+    rrd2rrdr_query_ops_release(&cache_a, a_reused);
+
+    QUERY_ENGINE_OPS *b = rrd2rrdr_query_ops_get(&r_b, &cache_b);
+    bool separate_cache_isolated = (b != a);
+    rrd2rrdr_query_ops_release(&cache_b, b);
+
+    rrd2rrdr_query_ops_freeall(&r_a, &cache_a);
+    rrd2rrdr_query_ops_freeall(&r_b, &cache_b);
+    onewayalloc_destroy(owa_a);
+    onewayalloc_destroy(owa_b);
+
+    if(same_cache_reused && separate_cache_isolated) {
+        fprintf(stderr, "OK query ops cache locality\n");
+        return 0;
+    }
+
+    fprintf(stderr,
+            "FAILED query ops cache locality: same_cache_reused=%s, separate_cache_isolated=%s\n",
+            same_cache_reused ? "true" : "false",
+            separate_cache_isolated ? "true" : "false");
     return 1;
 }
 
@@ -935,6 +975,8 @@ int query_plan_unittest(void) {
 
         errors += query_plan_unittest_expect_update_every(&qt, 1, 300);
     }
+
+    errors += query_plan_unittest_expect_ops_cache_is_local();
 
     nd_profile.storage_tiers = old_storage_tiers;
     nd_profile.update_every = old_update_every;

--- a/src/web/api/queries/query.c
+++ b/src/web/api/queries/query.c
@@ -154,7 +154,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
     size_t last_db_points_read = 0;
     size_t last_result_points_generated = 0;
 
-    // internal_fatal(released_ops, "QUERY: released_ops should be NULL when the query starts");
+    QUERY_ENGINE_OPS_CACHE ops_cache = { 0 };
 
     query_progress_set_finish_line(qt->request.transaction, qt->query.used);
 
@@ -167,7 +167,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
     size_t queries_prepared = 0;
     while(queries_prepared < max_queries_to_prepare) {
         // preload another query
-        ops[queries_prepared] = rrd2rrdr_query_ops_prep(r_tmp, queries_prepared);
+        ops[queries_prepared] = rrd2rrdr_query_ops_prep(r_tmp, &ops_cache, queries_prepared);
         queries_prepared++;
     }
 
@@ -193,7 +193,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
 
         if(queries_prepared < qt->query.used) {
             // preload another query
-            ops[queries_prepared] = rrd2rrdr_query_ops_prep(r_tmp, queries_prepared);
+            ops[queries_prepared] = rrd2rrdr_query_ops_prep(r_tmp, &ops_cache, queries_prepared);
             queries_prepared++;
         }
 
@@ -230,7 +230,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
                                              qt->request.group_by[0].aggregation, &qm->query_points, 0);
             }
 
-            rrd2rrdr_query_ops_release(ops[d]); // reuse this ops allocation
+            rrd2rrdr_query_ops_release(&ops_cache, ops[d]); // reuse this ops allocation
             ops[d] = NULL;
 
             qi->metrics.queried++;
@@ -322,7 +322,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             for(size_t i = d + 1; i < queries_prepared ; i++) {
                 if(ops[i]) {
                     query_planer_finalize_remaining_plans(ops[i]);
-                    rrd2rrdr_query_ops_release(ops[i]);
+                    rrd2rrdr_query_ops_release(&ops_cache, ops[i]);
                     ops[i] = NULL;
                 }
             }
@@ -390,11 +390,10 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
 
     // free the query pipelining ops
     for(size_t d = 0; d < qt->query.used ; d++) {
-        rrd2rrdr_query_ops_release(ops[d]);
+        rrd2rrdr_query_ops_release(&ops_cache, ops[d]);
         ops[d] = NULL;
     }
-    rrd2rrdr_query_ops_freeall(r);
-    // internal_fatal(released_ops, "QUERY: released_ops should be NULL when the query ends");
+    rrd2rrdr_query_ops_freeall(r, &ops_cache);
 
     onewayalloc_freez(owa, ops);
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens safety across facets, queries, hashtables, Judy use, journal validation, and CLI parsing. Prevents stale pointers and out‑of‑bounds reads, and scopes query ops reuse to a single RRDR execution.

- **Bug Fixes**
  - Facets: grow `keys_with_values` beyond 200 using an embedded buffer that expands; track per‑row overflow and, when it happens, reset all keys to avoid stale pointers.
  - CLI: validate exit‑status frames before assignment; reject missing/malformed digits and truncated frames.
  - Simple hashtable: guard doubling math and sorted-array growth against overflow; refine resize predicate to trigger at ≥50% active load.
  - Judy arrays (context registry): check for `PJERR` on insert/get/iterate; treat it as fatal instead of continuing or dereferencing sentinels.
  - DB engine (journal v2): bound page‑list header offsets and entry counts before reading/trailer CRC; fail cleanly on invalid on‑disk data.
  - Query planner: validate tiers and time windows in production; refuse invalid or finalized plans; keep old plan on failed switch; add tests for invalid cases.
  - Query ops cache: replace thread‑local reuse with a per‑RRDR `QUERY_ENGINE_OPS_CACHE`; plumb `prep/release/freeall` to use it and free at query end.

<sup>Written for commit 9e8f9719cf62bb051ab2ae9d24c915fe1f954926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

