### PR TITLE
Netdata fixes part 45

### DIFF
--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -253,20 +253,25 @@ static void netdata_claim_write_config(char *path)
         filename = path;
     }
 
+    int length = netdata_claim_prepare_data(data, WINDOWS_MAX_PATH);
+    if (length < 0 || length >= WINDOWS_MAX_PATH) {
+        MessageBoxW(NULL, L"Cannot write claim.conf.", L"Error", MB_OK|MB_ICONERROR);
+        return;
+    }
+
     HANDLE hf = CreateFileA(filename, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hf == INVALID_HANDLE_VALUE)
         netdata_claim_error_exit(L"CreateFileA");
 
-    DWORD length = netdata_claim_prepare_data(data, WINDOWS_MAX_PATH);
     DWORD written = 0;
 
-    BOOL ret = WriteFile(hf, data, length, &written, NULL);
+    BOOL ret = WriteFile(hf, data, (DWORD)length, &written, NULL);
     if (!ret) {
         CloseHandle(hf);
         netdata_claim_error_exit(L"WriteFileA");
     }
 
-    if (length != written)
+    if ((DWORD)length != written)
         MessageBoxW(NULL, L"Cannot write claim.conf.", L"Error", MB_OK|MB_ICONERROR);
 
     CloseHandle(hf);

--- a/src/collectors/windows.plugin/GetSensors.c
+++ b/src/collectors/windows.plugin/GetSensors.c
@@ -14,6 +14,8 @@
 static ISensorManager *pSensorManager = NULL;
 static ND_THREAD *sensors_thread_update = NULL;
 static netdata_mutex_t sensors_mutex;
+static volatile LONG sensors_thread_finished = 0;
+static const int SENSORS_THREAD_JOIN_FALLBACK_WAIT_MS = 2000;
 
 #define NETDATA_WIN_SENSOR_STATES (6)
 #define NETDATA_WIN_VECTOR_POS (3)
@@ -695,7 +697,7 @@ static void netdata_sensors_monitor(void *ptr __maybe_unused)
     if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "Sensor thread: cannot initialize COM interface (error 0x%lX)", (unsigned long)hr);
-        return;
+        goto done;
     }
 
     // Create sensor manager instance for this thread
@@ -704,10 +706,7 @@ static void netdata_sensors_monitor(void *ptr __maybe_unused)
     if (FAILED(hr)) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "Sensor thread: cannot create ISensorManager (error 0x%lX)", (unsigned long)hr);
-        // Only uninitialize if we successfully initialized COM ourselves
-        if (com_initialized)
-            CoUninitialize();
-        return;
+        goto done;
     }
 
     heartbeat_t hb;
@@ -722,6 +721,7 @@ static void netdata_sensors_monitor(void *ptr __maybe_unused)
         netdata_get_sensors();
     }
 
+done:
     // Thread cleanup - release sensor manager and uninitialize COM
     if (pSensorManager) {
         pSensorManager->lpVtbl->Release(pSensorManager);
@@ -731,6 +731,8 @@ static void netdata_sensors_monitor(void *ptr __maybe_unused)
     // Only uninitialize if we successfully initialized COM ourselves
     if (com_initialized)
         CoUninitialize();
+
+    InterlockedExchange(&sensors_thread_finished, 1);
 }
 
 void dict_sensor_insert(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
@@ -765,8 +767,11 @@ static int initialize(int update_every)
     dictionary_register_insert_callback(sensors, dict_sensor_insert, NULL);
     dictionary_register_delete_callback(sensors, dict_sensor_delete, NULL);
 
+    InterlockedExchange(&sensors_thread_finished, 0);
     sensors_thread_update =
         nd_thread_create("sensors_upd", NETDATA_THREAD_OPTION_DEFAULT, netdata_sensors_monitor, &update_every);
+    if (!sensors_thread_update)
+        InterlockedExchange(&sensors_thread_finished, 1);
 
     return 0;
 }
@@ -942,11 +947,29 @@ int do_GetSensors(int update_every, usec_t dt __maybe_unused)
 
 void do_Sensors_cleanup()
 {
-    // Wait for sensor thread to finish
-    // The thread handles its own COM cleanup (CoUninitialize) and pSensorManager release
-    if (nd_thread_join(sensors_thread_update))
-        nd_log_daemon(NDLP_ERR, "Failed to join sensors thread update");
-    sensors_thread_update = NULL;
+    if (sensors_thread_update) {
+        int join_result = nd_thread_join(sensors_thread_update);
+        sensors_thread_update = NULL;
+
+        if (join_result) {
+            nd_log_daemon(NDLP_ERR, "Failed to join sensors thread update");
+
+            size_t retries = 0;
+            while (!InterlockedCompareExchange(&sensors_thread_finished, 1, 1) &&
+                   retries < (size_t)SENSORS_THREAD_JOIN_FALLBACK_WAIT_MS) {
+                Sleep(1);
+                retries++;
+            }
+
+            if (!InterlockedCompareExchange(&sensors_thread_finished, 1, 1))
+                return;
+        }
+    } else if (sensors && !InterlockedCompareExchange(&sensors_thread_finished, 1, 1)) {
+        return;
+    }
+
+    if (!sensors)
+        return;
 
     __netdata_mutex_destroy(&sensors_mutex);
     dictionary_destroy(sensors);

--- a/src/daemon/pipename.c
+++ b/src/daemon/pipename.c
@@ -5,24 +5,35 @@
 #include "libnetdata/libnetdata.h"
 
 static const char *cached_pipename = NULL;
+static bool cached_pipename_available = false;
+static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
 const char *daemon_pipename(void) {
-    if(cached_pipename)
+    if(__atomic_load_n(&cached_pipename_available, __ATOMIC_ACQUIRE))
         return cached_pipename;
 
-    const char *pipename = getenv("NETDATA_PIPENAME");
-    if (pipename) {
-        cached_pipename = strdupz(pipename);
-        return pipename;
+    spinlock_lock(&spinlock);
+
+    const char *pipename = cached_pipename;
+    if(!pipename) {
+        const char *env_pipename = getenv("NETDATA_PIPENAME");
+        if (env_pipename)
+            cached_pipename = strdupz(env_pipename);
+        else {
+            //#if defined(OS_WINDOWS)
+            // cached_pipename = strdupz("\\\\?\\pipe\\netdata-cli");
+            //#else
+            char filename[FILENAME_MAX + 1];
+            snprintfz(filename, FILENAME_MAX, "%s/netdata.pipe", os_run_dir(false));
+            cached_pipename = strdupz(filename);
+            //#endif
+        }
+
+        pipename = cached_pipename;
+        __atomic_store_n(&cached_pipename_available, true, __ATOMIC_RELEASE);
     }
 
-//#if defined(OS_WINDOWS)
-//    cached_pipename = strdupz("\\\\?\\pipe\\netdata-cli");
-//    return cached_pipename;
-//#else
-    char filename[FILENAME_MAX + 1];
-    snprintfz(filename, FILENAME_MAX, "%s/netdata.pipe", os_run_dir(false));
-    cached_pipename = strdupz(filename);
-    return cached_pipename;
-//#endif
+    spinlock_unlock(&spinlock);
+
+    return pipename;
 }

--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -1060,19 +1060,25 @@ static inline void aral_add_free_slot___no_lock_required(ARAL *ar, ARAL_PAGE *pa
     // use the slot id of the item to be freed to determine the partition number
     size_t start = (((uint8_t *)ptr - page->data) / ar->config.element_size) % ARAL_PAGE_INCOMING_PARTITIONS;
 
-    while (true) {
-        for (size_t partition = start; partition < ARAL_PAGE_INCOMING_PARTITIONS; partition++) {
-            if (aral_page_incoming_trylock(ar, page, partition)) {
-                fr->next = page->incoming[partition].list;
-                page->incoming[partition].list = fr;
-                __atomic_fetch_or(&page->incoming_partition_bitmap, 1U << partition, __ATOMIC_RELEASE);
-                aral_page_incoming_unlock(ar, page, partition);
-                return;
-            }
+    size_t partition = start;
+    bool locked = false;
+    for(size_t offset = 0; offset < ARAL_PAGE_INCOMING_PARTITIONS; offset++) {
+        partition = (start + offset) % ARAL_PAGE_INCOMING_PARTITIONS;
+        if(aral_page_incoming_trylock(ar, page, partition)) {
+            locked = true;
+            break;
         }
-
-        start = 0;
     }
+
+    if(!locked) {
+        partition = start;
+        aral_page_incoming_lock(ar, page, partition);
+    }
+
+    fr->next = page->incoming[partition].list;
+    page->incoming[partition].list = fr;
+    __atomic_fetch_or(&page->incoming_partition_bitmap, 1U << partition, __ATOMIC_RELEASE);
+    aral_page_incoming_unlock(ar, page, partition);
 }
 
 ALWAYS_INLINE void *aral_callocz_internal(ARAL *ar, bool marked TRACE_ALLOCATIONS_FUNCTION_DEFINITION_PARAMS) {

--- a/src/libnetdata/os/get_pid_max.c
+++ b/src/libnetdata/os/get_pid_max.c
@@ -5,9 +5,19 @@
 pid_t pid_max = 4194304;
 
 pid_t os_get_system_pid_max(void) {
-    static bool read = false;
-    if(read) return pid_max;
-    read = true;
+    static bool cached = false;
+    static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
+
+    if(__atomic_load_n(&cached, __ATOMIC_ACQUIRE))
+        return pid_max;
+
+    spinlock_lock(&spinlock);
+
+    if(__atomic_load_n(&cached, __ATOMIC_RELAXED)) {
+        pid_t cached_pid_max = pid_max;
+        spinlock_unlock(&spinlock);
+        return cached_pid_max;
+    }
 
 #if defined(OS_MACOS)
     int mib[2];
@@ -23,8 +33,6 @@ pid_t os_get_system_pid_max(void) {
     }
     else pid_max = (pid_t)maxproc;
 
-    return pid_max;
-
 #elif defined(OS_FREEBSD)
 
     int32_t tmp_pid_max;
@@ -36,8 +44,6 @@ pid_t os_get_system_pid_max(void) {
     else
         pid_max = tmp_pid_max;
 
-    return pid_max;
-
 #elif defined(OS_LINUX)
 
     char filename[FILENAME_MAX + 1];
@@ -46,26 +52,26 @@ pid_t os_get_system_pid_max(void) {
     unsigned long long max = 0;
     if(read_single_number_file(filename, &max) != 0) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Cannot open file '%s'. Assuming system supports %d pids.", filename, pid_max);
-        return pid_max;
     }
-
-    if(!max) {
+    else if(!max) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Cannot parse file '%s'. Assuming system supports %d pids.", filename, pid_max);
-        return pid_max;
     }
-
-    pid_max = (pid_t) max;
-    return pid_max;
+    else
+        pid_max = (pid_t) max;
 
 #elif defined(OS_WINDOWS)
 
     pid_max = (pid_t)0x7FFFFFFF;
-    return pid_max;
 
 #else
 
     // return the default
-    return pid_max;
 
 #endif
+
+    __atomic_store_n(&cached, true, __ATOMIC_RELEASE);
+
+    pid_t cached_pid_max = pid_max;
+    spinlock_unlock(&spinlock);
+    return cached_pid_max;
 }

--- a/src/libnetdata/os/windows-perflib/perflib.c
+++ b/src/libnetdata/os/windows-perflib/perflib.c
@@ -53,6 +53,112 @@ void perflibFreePerformanceData(void) {
 // a displayable counter value. Use the counter type to determine the information
 // needed to calculate the value.
 
+ALWAYS_INLINE
+static size_t getCounterDataSize(PERF_COUNTER_DEFINITION* pCounter)
+{
+    switch (pCounter->CounterType) {
+        case PERF_COUNTER_COUNTER:
+        case PERF_COUNTER_QUEUELEN_TYPE:
+        case PERF_SAMPLE_COUNTER:
+        case PERF_OBJ_TIME_TIMER:
+        case PERF_COUNTER_RAWCOUNT:
+        case PERF_COUNTER_RAWCOUNT_HEX:
+        case PERF_COUNTER_DELTA:
+        case PERF_SAMPLE_FRACTION:
+        case PERF_RAW_FRACTION:
+            return sizeof(DWORD);
+
+        case PERF_COUNTER_MULTI_TIMER:
+        case PERF_COUNTER_MULTI_TIMER_INV:
+        case PERF_100NSEC_MULTI_TIMER:
+        case PERF_100NSEC_MULTI_TIMER_INV:
+            return sizeof(ULONGLONG) +
+                ((pCounter->CounterType & PERF_MULTI_COUNTER) == PERF_MULTI_COUNTER ? sizeof(DWORD) : 0);
+
+        case PERF_COUNTER_100NS_QUEUELEN_TYPE:
+        case PERF_COUNTER_OBJ_TIME_QUEUELEN_TYPE:
+        case PERF_COUNTER_TIMER:
+        case PERF_COUNTER_TIMER_INV:
+        case PERF_COUNTER_BULK_COUNT:
+        case PERF_COUNTER_LARGE_QUEUELEN_TYPE:
+        case PERF_COUNTER_LARGE_RAWCOUNT:
+        case PERF_COUNTER_LARGE_RAWCOUNT_HEX:
+        case PERF_COUNTER_LARGE_DELTA:
+        case PERF_100NSEC_TIMER:
+        case PERF_100NSEC_TIMER_INV:
+        case PERF_LARGE_RAW_FRACTION:
+        case PERF_PRECISION_SYSTEM_TIMER:
+        case PERF_PRECISION_100NS_TIMER:
+        case PERF_PRECISION_OBJECT_TIMER:
+        case PERF_AVERAGE_TIMER:
+        case PERF_AVERAGE_BULK:
+        case PERF_ELAPSED_TIME:
+            return sizeof(ULONGLONG);
+
+        default:
+            return 0;
+    }
+}
+
+ALWAYS_INLINE
+static PVOID getCounterBlockData(
+    PERF_COUNTER_BLOCK* pCounterDataBlock,
+    PERF_COUNTER_DEFINITION* pCounter,
+    size_t size)
+{
+    if(unlikely(!pCounterDataBlock || !pCounter || !size ||
+                 size > pCounterDataBlock->ByteLength ||
+                 pCounter->CounterOffset > pCounterDataBlock->ByteLength - size))
+        return NULL;
+
+    return (PVOID)((LPBYTE)pCounterDataBlock + pCounter->CounterOffset);
+}
+
+ALWAYS_INLINE
+static PERF_COUNTER_DEFINITION *getFollowingCounterDefinition(
+    PERF_OBJECT_TYPE* pObject,
+    PERF_COUNTER_DEFINITION* pCounter)
+{
+    if(unlikely(!pObject || !pCounter ||
+                 pObject->HeaderLength > pObject->DefinitionLength ||
+                 pObject->DefinitionLength > pObject->TotalByteLength))
+        return NULL;
+
+    PBYTE object = (PBYTE)pObject;
+    PBYTE counters = object + pObject->HeaderLength;
+    PBYTE end = object + pObject->DefinitionLength;
+    PBYTE counter = (PBYTE)pCounter;
+
+    if(unlikely(counter < counters ||
+                 counter > end ||
+                 sizeof(*pCounter) > (size_t)(end - counter)))
+        return NULL;
+
+    PBYTE next = counter + sizeof(*pCounter);
+    if(unlikely(sizeof(*pCounter) > (size_t)(end - next)))
+        return NULL;
+
+    PERF_COUNTER_DEFINITION *pBaseCounter = (PERF_COUNTER_DEFINITION *)next;
+    if(unlikely(!pBaseCounter->ByteLength || pBaseCounter->ByteLength > (DWORD)(end - next)))
+        return NULL;
+
+    return pBaseCounter;
+}
+
+ALWAYS_INLINE
+static PVOID getBaseCounterBlockData(
+    PERF_OBJECT_TYPE* pObject,
+    PERF_COUNTER_BLOCK* pCounterDataBlock,
+    PERF_COUNTER_DEFINITION* pCounter,
+    size_t size)
+{
+    PERF_COUNTER_DEFINITION* pBaseCounter = getFollowingCounterDefinition(pObject, pCounter);
+    if(!pBaseCounter || (pBaseCounter->CounterType & PERF_COUNTER_BASE) != PERF_COUNTER_BASE)
+        return NULL;
+
+    return getCounterBlockData(pCounterDataBlock, pBaseCounter, size);
+}
+
 static BOOL getCounterData(
     PERF_DATA_BLOCK *pDataBlock,
     PERF_OBJECT_TYPE* pObject,
@@ -62,14 +168,20 @@ static BOOL getCounterData(
 {
     PVOID pData = NULL;
     UNALIGNED ULONGLONG* pullData = NULL;
-    PERF_COUNTER_DEFINITION* pBaseCounter = NULL;
     BOOL fSuccess = TRUE;
 
     if(!pCounterDataBlock)
         return FALSE;
 
-    //Point to the raw counter data.
-    pData = (PVOID)((LPBYTE)pCounterDataBlock + pCounter->CounterOffset);
+    size_t size = getCounterDataSize(pCounter);
+    if(size) {
+        pData = getCounterBlockData(pCounterDataBlock, pCounter, size);
+        if(!pData) {
+            pRawData->Data = 0;
+            pRawData->Time = 0;
+            return FALSE;
+        }
+    }
 
     //Now use the PERF_COUNTER_DEFINITION.CounterType value to figure out what
     //other information you need to calculate a displayable value.
@@ -167,11 +279,9 @@ static BOOL getCounterData(
         case PERF_SAMPLE_FRACTION:
         case PERF_RAW_FRACTION:
             pRawData->Data = (ULONGLONG)(*(DWORD*)pData);
-            pBaseCounter = pCounter + 1;  //Get base counter
-            if ((pBaseCounter->CounterType & PERF_COUNTER_BASE) == PERF_COUNTER_BASE) {
-                pData = (PVOID)((LPBYTE)pCounterDataBlock + pBaseCounter->CounterOffset);
+            pData = getBaseCounterBlockData(pObject, pCounterDataBlock, pCounter, sizeof(DWORD));
+            if (pData)
                 pRawData->Time = (LONGLONG)(*(DWORD*)pData);
-            }
             else
                 fSuccess = FALSE;
             break;
@@ -181,11 +291,9 @@ static BOOL getCounterData(
         case PERF_PRECISION_100NS_TIMER:
         case PERF_PRECISION_OBJECT_TIMER:
             pRawData->Data = *(UNALIGNED ULONGLONG*)pData;
-            pBaseCounter = pCounter + 1;
-            if ((pBaseCounter->CounterType & PERF_COUNTER_BASE) == PERF_COUNTER_BASE) {
-                pData = (PVOID)((LPBYTE)pCounterDataBlock + pBaseCounter->CounterOffset);
+            pData = getBaseCounterBlockData(pObject, pCounterDataBlock, pCounter, sizeof(LONGLONG));
+            if (pData)
                 pRawData->Time = *(LONGLONG*)pData;
-            }
             else
                 fSuccess = FALSE;
             break;
@@ -193,11 +301,9 @@ static BOOL getCounterData(
         case PERF_AVERAGE_TIMER:
         case PERF_AVERAGE_BULK:
             pRawData->Data = *(UNALIGNED ULONGLONG*)pData;
-            pBaseCounter = pCounter+1;
-            if ((pBaseCounter->CounterType & PERF_COUNTER_BASE) == PERF_COUNTER_BASE) {
-                pData = (PVOID)((LPBYTE)pCounterDataBlock + pBaseCounter->CounterOffset);
+            pData = getBaseCounterBlockData(pObject, pCounterDataBlock, pCounter, sizeof(DWORD));
+            if (pData)
                 pRawData->Time = *(DWORD*)pData;
-            }
             else
                 fSuccess = FALSE;
 

--- a/src/libnetdata/os/windows-perflib/perflib.c
+++ b/src/libnetdata/os/windows-perflib/perflib.c
@@ -115,31 +115,67 @@ static PVOID getCounterBlockData(
 }
 
 ALWAYS_INLINE
+static BOOL isObjectSpanValid(PERF_OBJECT_TYPE* pObject, void *ptr, size_t length)
+{
+    if(!pObject || !ptr || !length)
+        return FALSE;
+
+    size_t total_length = pObject->TotalByteLength;
+    if(unlikely(length > total_length))
+        return FALSE;
+
+    uintptr_t object = (uintptr_t)pObject;
+    uintptr_t start = (uintptr_t)ptr;
+    if(unlikely(start < object))
+        return FALSE;
+
+    size_t offset = start - object;
+    return offset <= total_length && length <= total_length - offset;
+}
+
+ALWAYS_INLINE
+static BOOL isObjectCounterDefinitionValid(PERF_OBJECT_TYPE* pObject, PERF_COUNTER_DEFINITION* pCounter)
+{
+    if(!pObject || !pCounter)
+        return FALSE;
+
+    size_t header_length = pObject->HeaderLength;
+    size_t definition_length = pObject->DefinitionLength;
+    size_t total_length = pObject->TotalByteLength;
+    if(unlikely(header_length > definition_length || definition_length > total_length))
+        return FALSE;
+
+    uintptr_t object = (uintptr_t)pObject;
+    uintptr_t counter = (uintptr_t)pCounter;
+    if(unlikely(counter < object))
+        return FALSE;
+
+    size_t counter_offset = counter - object;
+    if(unlikely(counter_offset < header_length || counter_offset > definition_length))
+        return FALSE;
+
+    size_t remaining = definition_length - counter_offset;
+    return sizeof(*pCounter) <= remaining &&
+           pCounter->ByteLength >= sizeof(*pCounter) &&
+           pCounter->ByteLength <= remaining;
+}
+
+ALWAYS_INLINE
 static PERF_COUNTER_DEFINITION *getFollowingCounterDefinition(
     PERF_OBJECT_TYPE* pObject,
     PERF_COUNTER_DEFINITION* pCounter)
 {
-    if(unlikely(!pObject || !pCounter ||
-                 pObject->HeaderLength > pObject->DefinitionLength ||
-                 pObject->DefinitionLength > pObject->TotalByteLength))
+    if(unlikely(!isObjectCounterDefinitionValid(pObject, pCounter)))
         return NULL;
 
     PBYTE object = (PBYTE)pObject;
-    PBYTE counters = object + pObject->HeaderLength;
     PBYTE end = object + pObject->DefinitionLength;
-    PBYTE counter = (PBYTE)pCounter;
-
-    if(unlikely(counter < counters ||
-                 counter > end ||
-                 sizeof(*pCounter) > (size_t)(end - counter)))
-        return NULL;
-
-    PBYTE next = counter + sizeof(*pCounter);
+    PBYTE next = (PBYTE)pCounter + pCounter->ByteLength;
     if(unlikely(sizeof(*pCounter) > (size_t)(end - next)))
         return NULL;
 
     PERF_COUNTER_DEFINITION *pBaseCounter = (PERF_COUNTER_DEFINITION *)next;
-    if(unlikely(!pBaseCounter->ByteLength || pBaseCounter->ByteLength > (DWORD)(end - next)))
+    if(unlikely(!isObjectCounterDefinitionValid(pObject, pBaseCounter)))
         return NULL;
 
     return pBaseCounter;
@@ -363,6 +399,93 @@ static BOOL isValidStructure(PERF_DATA_BLOCK *pDataBlock, void *ptr, size_t leng
         (PBYTE)ptr + length > (PBYTE)pDataBlock + pDataBlock->TotalByteLength ? FALSE : TRUE;
 }
 
+ALWAYS_INLINE
+static BOOL isValidVariableStructure(
+    PERF_DATA_BLOCK *pDataBlock,
+    void *ptr,
+    size_t minimum_length,
+    DWORD *length)
+{
+    DWORD byte_length;
+
+    if(!length)
+        return FALSE;
+
+    if(unlikely(!isValidStructure(pDataBlock, ptr, sizeof(byte_length))))
+        return FALSE;
+
+    memcpy(&byte_length, ptr, sizeof(byte_length));
+    if(unlikely(byte_length < minimum_length || !isValidStructure(pDataBlock, ptr, byte_length)))
+        return FALSE;
+
+    *length = byte_length;
+    return TRUE;
+}
+
+ALWAYS_INLINE
+static BOOL isValidObjectType(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE *pObjectType) {
+    DWORD total_byte_length;
+
+    if(unlikely(!isValidVariableStructure(pDataBlock, pObjectType, sizeof(*pObjectType), &total_byte_length) ||
+                 pObjectType->HeaderLength < sizeof(*pObjectType) ||
+                 pObjectType->HeaderLength > pObjectType->DefinitionLength ||
+                 pObjectType->DefinitionLength > total_byte_length))
+        return FALSE;
+
+    return TRUE;
+}
+
+ALWAYS_INLINE
+static BOOL isValidInstanceDefinition(
+    PERF_DATA_BLOCK *pDataBlock,
+    PERF_OBJECT_TYPE *pObjectType,
+    PERF_INSTANCE_DEFINITION *pInstance)
+{
+    DWORD byte_length = 0;
+
+    if(unlikely(!isValidVariableStructure(pDataBlock, pInstance, sizeof(*pInstance), &byte_length)))
+        return FALSE;
+
+    if(unlikely(pObjectType && !isObjectSpanValid(pObjectType, pInstance, byte_length)))
+        return FALSE;
+
+    return TRUE;
+}
+
+ALWAYS_INLINE
+static BOOL isValidCounterBlock(
+    PERF_DATA_BLOCK *pDataBlock,
+    PERF_OBJECT_TYPE *pObjectType,
+    PERF_COUNTER_BLOCK *pCounterBlock)
+{
+    DWORD byte_length = 0;
+
+    if(unlikely(!isValidVariableStructure(pDataBlock, pCounterBlock, sizeof(*pCounterBlock), &byte_length)))
+        return FALSE;
+
+    if(unlikely(pObjectType && !isObjectSpanValid(pObjectType, pCounterBlock, byte_length)))
+        return FALSE;
+
+    return TRUE;
+}
+
+ALWAYS_INLINE
+static BOOL isValidCounterDefinition(
+    PERF_DATA_BLOCK *pDataBlock,
+    PERF_OBJECT_TYPE *pObjectType,
+    PERF_COUNTER_DEFINITION *pCounterDefinition)
+{
+    DWORD byte_length = 0;
+
+    if(unlikely(!isValidVariableStructure(pDataBlock, pCounterDefinition, sizeof(*pCounterDefinition), &byte_length)))
+        return FALSE;
+
+    if(unlikely(pObjectType && !isObjectCounterDefinitionValid(pObjectType, pCounterDefinition)))
+        return FALSE;
+
+    return TRUE;
+}
+
 static inline PERF_DATA_BLOCK *getDataBlock(BYTE *pBuffer) {
     PERF_DATA_BLOCK *pDataBlock = (PERF_DATA_BLOCK *)pBuffer;
 
@@ -393,7 +516,7 @@ static PERF_OBJECT_TYPE *getObjectType(PERF_DATA_BLOCK* pDataBlock, PERF_OBJECT_
     else if (lastObjectType->TotalByteLength != 0)
         pObjectType = (PERF_OBJECT_TYPE *)((PBYTE)lastObjectType + lastObjectType->TotalByteLength);
 
-    if(pObjectType && (!isValidPointer(pDataBlock, pObjectType) || !isValidStructure(pDataBlock, pObjectType, pObjectType->TotalByteLength))) {
+    if(pObjectType && (!isValidPointer(pDataBlock, pObjectType) || !isValidObjectType(pDataBlock, pObjectType))) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "WINDOWS: PERFLIB: %s(): Invalid ObjectType!", __FUNCTION__);
         pObjectType = NULL;
     }
@@ -430,7 +553,7 @@ static PERF_INSTANCE_DEFINITION *getInstance(
     else
         pInstance = (PERF_INSTANCE_DEFINITION *)((PBYTE)lastCounterBlock + lastCounterBlock->ByteLength);
 
-    if(pInstance && (!isValidPointer(pDataBlock, pInstance) || !isValidStructure(pDataBlock, pInstance, pInstance->ByteLength))) {
+    if(pInstance && (!isValidPointer(pDataBlock, pInstance) || !isValidInstanceDefinition(pDataBlock, pObjectType, pInstance))) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "WINDOWS: PERFLIB: %s(): Invalid Instance Definition!", __FUNCTION__);
         pInstance = NULL;
     }
@@ -448,7 +571,7 @@ static PERF_COUNTER_BLOCK *getObjectTypeCounterBlock(
 
     PERF_COUNTER_BLOCK *pCounterBlock = (PERF_COUNTER_BLOCK *)((PBYTE)pObjectType + pObjectType->DefinitionLength);
 
-    if(pCounterBlock && (!isValidPointer(pDataBlock, pCounterBlock) || !isValidStructure(pDataBlock, pCounterBlock, pCounterBlock->ByteLength))) {
+    if(pCounterBlock && (!isValidPointer(pDataBlock, pCounterBlock) || !isValidCounterBlock(pDataBlock, pObjectType, pCounterBlock))) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "WINDOWS: PERFLIB: %s(): Invalid ObjectType CounterBlock!", __FUNCTION__);
         pCounterBlock = NULL;
     }
@@ -467,7 +590,7 @@ static PERF_COUNTER_BLOCK *getInstanceCounterBlock(
 
     PERF_COUNTER_BLOCK *pCounterBlock = (PERF_COUNTER_BLOCK *)((PBYTE)pInstance + pInstance->ByteLength);
 
-    if(pCounterBlock && (!isValidPointer(pDataBlock, pCounterBlock) || !isValidStructure(pDataBlock, pCounterBlock, pCounterBlock->ByteLength))) {
+    if(pCounterBlock && (!isValidPointer(pDataBlock, pCounterBlock) || !isValidCounterBlock(pDataBlock, pObjectType, pCounterBlock))) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "WINDOWS: PERFLIB: %s(): Invalid Instance CounterBlock!", __FUNCTION__);
         pCounterBlock = NULL;
     }
@@ -497,7 +620,7 @@ static PERF_COUNTER_DEFINITION *getCounterDefinition(PERF_DATA_BLOCK *pDataBlock
     else
         pCounterDefinition = (PERF_COUNTER_DEFINITION *)((PBYTE)lastCounterDefinition +	lastCounterDefinition->ByteLength);
 
-    if(pCounterDefinition && (!isValidPointer(pDataBlock, pCounterDefinition) || !isValidStructure(pDataBlock, pCounterDefinition, pCounterDefinition->ByteLength))) {
+    if(pCounterDefinition && (!isValidPointer(pDataBlock, pCounterDefinition) || !isValidCounterDefinition(pDataBlock, pObjectType, pCounterDefinition))) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "WINDOWS: PERFLIB: %s(): Invalid Counter Definition!", __FUNCTION__);
         pCounterDefinition = NULL;
     }

--- a/src/libnetdata/spawn_server/log-forwarder.c
+++ b/src/libnetdata/spawn_server/log-forwarder.c
@@ -136,13 +136,14 @@ void log_forwarder_stop(LOG_FORWARDER *lf) {
     // Wait for the thread to finish
     // Note: nd_thread_join() handles the Windows/MSYS2 EINVAL case internally
     int join_result = nd_thread_join(lf->thread);
+    lf->thread = NULL;
     if(join_result != 0) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
-               "Log forwarder: nd_thread_join() failed with error %d", join_result);
+               "Log forwarder: nd_thread_join() failed with error %d; leaking state to avoid racing a live worker",
+               join_result);
+        return;
     }
 
-    // Always clean up - if join failed, the thread has still exited
-    lf->thread = NULL;
     close(lf->pipe_fds[PIPE_WRITE]);
     freez(lf);
 }

--- a/src/libnetdata/spawn_server/spawn_server_posix.c
+++ b/src/libnetdata/spawn_server/spawn_server_posix.c
@@ -11,6 +11,8 @@
 extern char **environ;
 #endif
 
+#define SPAWN_SERVER_MAX_DEFERRED_REAPERS 1
+
 int spawn_server_instance_read_fd(SPAWN_INSTANCE *si) { return si->read_fd; }
 int spawn_server_instance_write_fd(SPAWN_INSTANCE *si) { return si->write_fd; }
 void spawn_server_instance_read_fd_unset(SPAWN_INSTANCE *si) { si->read_fd = -1; }
@@ -21,6 +23,7 @@ static struct {
     bool sigchld_initialized;
     SPINLOCK spinlock;
     SPAWN_INSTANCE *instances;
+    uint32_t deferred_reapers;
 } spawn_globals = {
     .spinlock = SPINLOCK_INITIALIZER,
     .instances = NULL,
@@ -208,6 +211,66 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd, int custo
     return si;
 }
 
+static int spawn_server_waitpid(SPAWN_INSTANCE *si);
+
+static void spawn_server_instance_cleanup(SPAWN_INSTANCE *si) {
+    spinlock_lock(&spawn_globals.spinlock);
+    DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(spawn_globals.instances, si, prev, next);
+    spinlock_unlock(&spawn_globals.spinlock);
+
+    freez((void *)si->cmdline);
+    freez(si);
+}
+
+static void *spawn_server_detached_waitpid_cleanup(void *ptr) {
+    SPAWN_INSTANCE *si = ptr;
+
+    (void)spawn_server_waitpid(si);
+    spawn_server_instance_cleanup(si);
+    __atomic_sub_fetch(&spawn_globals.deferred_reapers, 1, __ATOMIC_RELAXED);
+
+    return NULL;
+}
+
+static bool spawn_server_defer_waitpid_cleanup(SPAWN_INSTANCE *si) {
+    pthread_t thread;
+    pthread_attr_t attr;
+    pid_t child_pid = si->child_pid;
+    size_t request_id = si->request_id;
+
+    if(__atomic_add_fetch(&spawn_globals.deferred_reapers, 1, __ATOMIC_RELAXED) >
+        SPAWN_SERVER_MAX_DEFERRED_REAPERS) {
+        __atomic_sub_fetch(&spawn_globals.deferred_reapers, 1, __ATOMIC_RELAXED);
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN PARENT: deferred reaper limit reached for pid %d (request No %zu): %s",
+               child_pid, request_id, si->cmdline);
+        return false;
+    }
+
+    int rc = pthread_attr_init(&attr);
+    bool attr_initialized = rc == 0;
+    if(attr_initialized)
+        rc = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+    if(rc == 0)
+        rc = pthread_create(&thread, &attr, spawn_server_detached_waitpid_cleanup, si);
+
+    if(attr_initialized && pthread_attr_destroy(&attr) != 0 && rc == 0)
+        nd_log(NDLS_COLLECTORS, NDLP_WARNING,
+               "SPAWN PARENT: failed to destroy detached reaper attributes for pid %d (request No %zu)",
+               child_pid, request_id);
+
+    if(rc != 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN PARENT: failed to start detached reaper for pid %d: %s",
+               si->child_pid, si->cmdline);
+        __atomic_sub_fetch(&spawn_globals.deferred_reapers, 1, __ATOMIC_RELAXED);
+        return false;
+    }
+
+    return true;
+}
+
 int spawn_server_exec_kill(SPAWN_SERVER *server, SPAWN_INSTANCE *si, int timeout_ms) {
     if (!si) return -1;
 
@@ -232,6 +295,16 @@ int spawn_server_exec_kill(SPAWN_SERVER *server, SPAWN_INSTANCE *si, int timeout
     }
     else
         return status;
+
+    if(spawn_server_exec_timedwait(server, si, SPAWN_KILL_DEFAULT_GRACE_MS, &status) == SPAWN_TIMEDWAIT_EXITED)
+        return status;
+
+    nd_log(NDLS_COLLECTORS, NDLP_ERR,
+           "SPAWN PARENT: giving up waiting for pid %d after SIGKILL (request No %zu) - cleanup deferred",
+           si->child_pid, si->request_id);
+
+    if(spawn_server_defer_waitpid_cleanup(si))
+        return -1;
 
     return spawn_server_exec_wait(server, si);
 }
@@ -343,12 +416,7 @@ int spawn_server_exec_wait(SPAWN_SERVER *server __maybe_unused, SPAWN_INSTANCE *
                "SPAWN PARENT: child with pid %d exited with status %d (sighandler): %s",
                si->child_pid, status, si->cmdline);
 
-    spinlock_lock(&spawn_globals.spinlock);
-    DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(spawn_globals.instances, si, prev, next);
-    spinlock_unlock(&spawn_globals.spinlock);
-
-    freez((void *)si->cmdline);
-    freez(si);
+    spawn_server_instance_cleanup(si);
     return status;
 }
 

--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -375,8 +375,6 @@ static void nd_thread_exit(ND_THREAD *nti) {
     thread_cache_destroy();
     worker_unregister();
 
-    nd_thread_status_set(nti, NETDATA_THREAD_STATUS_FINISHED);
-
     spinlock_lock(&threads_globals.running.spinlock);
     if(nti->list == ND_THREAD_LIST_RUNNING) {
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(threads_globals.running.list, nti, prev, next);
@@ -388,6 +386,8 @@ static void nd_thread_exit(ND_THREAD *nti) {
     DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(threads_globals.exited.list, nti, prev, next);
     nti->list = ND_THREAD_LIST_EXITED;
     spinlock_unlock(&threads_globals.exited.spinlock);
+
+    nd_thread_status_set(nti, NETDATA_THREAD_STATUS_FINISHED);
 }
 
 static void nd_thread_starting_point(void *ptr) {

--- a/src/registry/registry.c
+++ b/src/registry/registry.c
@@ -8,6 +8,8 @@
 #define REGISTRY_STATUS_FAILED "failed"
 #define REGISTRY_STATUS_DISABLED "disabled"
 
+static SPINLOCK registry_cloud_base_url_spinlock = SPINLOCK_INITIALIZER;
+
 bool registry_is_valid_url(const char *url) {
     return url && (*url == 'h' || *url == '*');
 }
@@ -150,12 +152,23 @@ static inline int registry_person_url_callback_verify_machine_exists(REGISTRY_PE
 
 // ----------------------------------------------------------------------------
 // dynamic update of the configuration
-// The registry does not seem to be designed to support this and I cannot see any concurrency protection
-// that could make this safe, so try to be as atomic as possible.
+// This may run before registry.lock is initialized, so protect the owned snapshot with a dedicated lock.
 
 void registry_update_cloud_base_url() {
-    registry.cloud_base_url = cloud_config_url_get();
+    char *cloud_base_url = strdupz(cloud_config_url_get());
+
+    spinlock_lock(&registry_cloud_base_url_spinlock);
+    freez(registry.cloud_base_url);
+    registry.cloud_base_url = cloud_base_url;
     nd_setenv("NETDATA_REGISTRY_CLOUD_BASE_URL", registry.cloud_base_url, 1);
+    spinlock_unlock(&registry_cloud_base_url_spinlock);
+}
+
+void registry_cloud_base_url_free(void) {
+    spinlock_lock(&registry_cloud_base_url_spinlock);
+    freez(registry.cloud_base_url);
+    registry.cloud_base_url = NULL;
+    spinlock_unlock(&registry_cloud_base_url_spinlock);
 }
 
 // ----------------------------------------------------------------------------
@@ -184,7 +197,9 @@ int registry_request_hello_json(RRDHOST *host, struct web_client *w, bool do_not
 
     CLOUD_STATUS status = cloud_status();
     buffer_json_member_add_string(w->response.data, "cloud_status", CLOUD_STATUS_2str(status));
+    spinlock_lock(&registry_cloud_base_url_spinlock);
     buffer_json_member_add_string(w->response.data, "cloud_base_url", registry.cloud_base_url);
+    spinlock_unlock(&registry_cloud_base_url_spinlock);
 
     buffer_json_member_add_string(w->response.data, "registry", registry.registry_to_announce);
     buffer_json_member_add_boolean(w->response.data, "anonymous_statistics", do_not_track ? false : netdata_anonymous_statistics_enabled);

--- a/src/registry/registry.c
+++ b/src/registry/registry.c
@@ -460,11 +460,6 @@ void registry_statistics(void) {
         rrddim_add(sts, "sessions",  NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
 
-    rrddim_set(sts, "sessions", (collected_number)registry.usages_count);
-    rrdset_done(sts);
-
-    // ------------------------------------------------------------------------
-
     if(unlikely(!stc)) {
         stc = rrdset_create_localhost(
                 "netdata"
@@ -486,14 +481,6 @@ void registry_statistics(void) {
         rrddim_add(stc, "persons_urls",   NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
         rrddim_add(stc, "machines_urls",  NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
-
-    rrddim_set(stc, "persons",       (collected_number)registry.persons_count);
-    rrddim_set(stc, "machines",      (collected_number)registry.machines_count);
-    rrddim_set(stc, "persons_urls",  (collected_number)registry.persons_urls_count);
-    rrddim_set(stc, "machines_urls", (collected_number)registry.machines_urls_count);
-    rrdset_done(stc);
-
-    // ------------------------------------------------------------------------
 
     if(unlikely(!stm)) {
         stm = rrdset_create_localhost(
@@ -517,17 +504,57 @@ void registry_statistics(void) {
         rrddim_add(stm, "machines_urls",  NULL,  1, 1024, RRD_ALGORITHM_ABSOLUTE);
     }
 
+    collected_number usages_count;
+    collected_number persons_count, machines_count, persons_urls_count, machines_urls_count;
+    collected_number persons_memory, machines_memory, persons_urls_memory, machines_urls_memory;
+
+    registry_lock();
+
+    usages_count = (collected_number)registry.usages_count;
+    persons_count = (collected_number)registry.persons_count;
+    machines_count = (collected_number)registry.machines_count;
+    persons_urls_count = (collected_number)registry.persons_urls_count;
+    machines_urls_count = (collected_number)registry.machines_urls_count;
+
     struct aral_statistics *p_aral_stats = aral_get_statistics(registry.persons_aral);
-    rrddim_set(stm, "persons",       (collected_number)p_aral_stats->structures.allocated_bytes + (collected_number)p_aral_stats->malloc.allocated_bytes + (collected_number)p_aral_stats->mmap.allocated_bytes);
+    persons_memory = (collected_number)aral_structures_bytes_from_stats(p_aral_stats) +
+                     (collected_number)aral_used_bytes_from_stats(p_aral_stats) +
+                     (collected_number)aral_free_bytes_from_stats(p_aral_stats);
 
     struct aral_statistics *m_aral_stats = aral_get_statistics(registry.machines_aral);
-    rrddim_set(stm, "machines",      (collected_number)m_aral_stats->structures.allocated_bytes + (collected_number)m_aral_stats->malloc.allocated_bytes + (collected_number)m_aral_stats->mmap.allocated_bytes);
+    machines_memory = (collected_number)aral_structures_bytes_from_stats(m_aral_stats) +
+                      (collected_number)aral_used_bytes_from_stats(m_aral_stats) +
+                      (collected_number)aral_free_bytes_from_stats(m_aral_stats);
 
     struct aral_statistics *pu_aral_stats = aral_get_statistics(registry.person_urls_aral);
-    rrddim_set(stm, "persons_urls",  (collected_number)pu_aral_stats->structures.allocated_bytes + (collected_number)pu_aral_stats->malloc.allocated_bytes + (collected_number)pu_aral_stats->mmap.allocated_bytes);
+    persons_urls_memory = (collected_number)aral_structures_bytes_from_stats(pu_aral_stats) +
+                          (collected_number)aral_used_bytes_from_stats(pu_aral_stats) +
+                          (collected_number)aral_free_bytes_from_stats(pu_aral_stats);
 
     struct aral_statistics *mu_aral_stats = aral_get_statistics(registry.machine_urls_aral);
-    rrddim_set(stm, "machines_urls", (collected_number)mu_aral_stats->structures.allocated_bytes + (collected_number)mu_aral_stats->malloc.allocated_bytes + (collected_number)mu_aral_stats->mmap.allocated_bytes);
+    machines_urls_memory = (collected_number)aral_structures_bytes_from_stats(mu_aral_stats) +
+                           (collected_number)aral_used_bytes_from_stats(mu_aral_stats) +
+                           (collected_number)aral_free_bytes_from_stats(mu_aral_stats);
+
+    registry_unlock();
+
+    rrddim_set(sts, "sessions", usages_count);
+    rrdset_done(sts);
+
+    // ------------------------------------------------------------------------
+
+    rrddim_set(stc, "persons",       persons_count);
+    rrddim_set(stc, "machines",      machines_count);
+    rrddim_set(stc, "persons_urls",  persons_urls_count);
+    rrddim_set(stc, "machines_urls", machines_urls_count);
+    rrdset_done(stc);
+
+    // ------------------------------------------------------------------------
+
+    rrddim_set(stm, "persons",       persons_memory);
+    rrddim_set(stm, "machines",      machines_memory);
+    rrddim_set(stm, "persons_urls",  persons_urls_memory);
+    rrddim_set(stm, "machines_urls", machines_urls_memory);
 
     rrdset_done(stm);
 }

--- a/src/registry/registry_init.c
+++ b/src/registry/registry_init.c
@@ -231,6 +231,8 @@ static int registry_person_del_callback(const DICTIONARY_ITEM *item __maybe_unus
 }
 
 void registry_free(void) {
+    registry_cloud_base_url_free();
+
     if(!registry.enabled) return;
     registry.enabled = false;
 

--- a/src/registry/registry_internals.h
+++ b/src/registry/registry_internals.h
@@ -33,7 +33,7 @@ struct registry {
     const char *registry_domain;
     const char *hostname;
     const char *registry_to_announce;
-    const char *cloud_base_url;
+    char *cloud_base_url;
     time_t persons_expiration; // seconds to expire idle persons
     int verify_cookies_redirects;
     int enable_cookies_samesite_secure;
@@ -76,6 +76,7 @@ extern struct registry registry;
 REGISTRY_PERSON *registry_request_access(const char *person_guid, char *machine_guid, char *url, char *name, time_t when);
 REGISTRY_PERSON *registry_request_delete(const char *person_guid, char *machine_guid, char *url, char *delete_url, time_t when);
 REGISTRY_MACHINE *registry_request_machine(const char *person_guid, char *request_machine, STRING **hostname);
+void registry_cloud_base_url_free(void);
 
 // REGISTRY LOG (in registry_log.c)
 void registry_log(char action, REGISTRY_PERSON *p, REGISTRY_MACHINE *m, STRING *u, const char *name);

--- a/src/web/api/v2/api_v2_claim.c
+++ b/src/web/api/v2/api_v2_claim.c
@@ -5,9 +5,10 @@
 
 static char *netdata_random_session_id_filename = NULL;
 static nd_uuid_t netdata_random_session_id = { 0 };
+static SPINLOCK netdata_random_session_id_spinlock = SPINLOCK_INITIALIZER;
 
-bool netdata_random_session_id_generate(void) {
-    static char guid[UUID_STR_LEN] = "";
+static bool netdata_random_session_id_generate_unlocked(void) {
+    char guid[UUID_STR_LEN] = "";
 
     uuid_generate_random(netdata_random_session_id);
     uuid_unparse_lower(netdata_random_session_id, guid);
@@ -44,26 +45,38 @@ bool netdata_random_session_id_generate(void) {
     return ret;
 }
 
-static const char *netdata_random_session_id_get_filename(void) {
-    if(!netdata_random_session_id_filename)
-        netdata_random_session_id_generate();
+bool netdata_random_session_id_generate(void) {
+    spinlock_lock(&netdata_random_session_id_spinlock);
+    bool ret = netdata_random_session_id_generate_unlocked();
+    spinlock_unlock(&netdata_random_session_id_spinlock);
 
-    return netdata_random_session_id_filename;
+    return ret;
+}
+
+static const char *netdata_random_session_id_get_filename(void) {
+    spinlock_lock(&netdata_random_session_id_spinlock);
+
+    if(!netdata_random_session_id_filename)
+        netdata_random_session_id_generate_unlocked();
+
+    const char *filename = netdata_random_session_id_filename;
+    spinlock_unlock(&netdata_random_session_id_spinlock);
+
+    return filename;
 }
 
 static bool netdata_random_session_id_matches(const char *guid) {
-    if(uuid_is_null(netdata_random_session_id))
-        return false;
-
     nd_uuid_t uuid;
 
     if(uuid_parse(guid, uuid))
         return false;
 
-    if(uuid_compare(netdata_random_session_id, uuid) == 0)
-        return true;
+    spinlock_lock(&netdata_random_session_id_spinlock);
+    bool ret = !uuid_is_null(netdata_random_session_id) &&
+               uuid_compare(netdata_random_session_id, uuid) == 0;
+    spinlock_unlock(&netdata_random_session_id_spinlock);
 
-    return false;
+    return ret;
 }
 
 static bool check_claim_param(const char *s) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Windows performance data handling, claim config writes, and thread/process shutdown paths to prevent races and out-of-bounds reads. Added synchronized caches and safer registry/allocator behavior for more stable runtime.

- **Bug Fixes**
  - Windows perflib: bound counter reads and validate variable-length records (object/instance/counter/block) to avoid OOB; verify adjacent base counters before use.
  - Windows claim helper: format and validate into the stack buffer before opening the file; reject truncation; use correct WriteFile length.
  - Windows sensors: unify cleanup path, track thread completion with an Interlocked flag, and skip teardown after failed join to avoid races.
  - Spawn server (POSIX): bound post-SIGKILL wait and defer reaping via a capped detached helper; if start fails or cap reached, fall back to blocking wait.
  - Log forwarder: on failed join, keep state allocated and return to avoid racing a live worker.
  - Threads: publish FINISHED after list updates so joiners don’t free a thread still touching list pointers.
  - Registry: own and synchronize `cloud_base_url` updates and reads; snapshot registry counters/ARAL memory under lock for charts; free snapshot on shutdown.
  - Caches: serialize first-init for `pid_max` and daemon pipe name; publish with acquire/release semantics for consistent reads.
  - Claim API: serialize random session-id generation, filename init, and comparisons to prevent torn reads.
  - ARAL: replace unbounded free-slot trylock spin with one sweep + locked fallback on the home partition.

<sup>Written for commit c6917968042564c72860ddda6c1821128739ba27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

