### PR TITLE
Netdata fixes part 46

### DIFF
--- a/src/daemon/dyncfg/dyncfg-tree.c
+++ b/src/daemon/dyncfg/dyncfg-tree.c
@@ -224,11 +224,11 @@ static int dyncfg_config_execute_cb(struct rrd_function_execute *rfe, void *data
 
             if(cmd == DYNCFG_CMD_REMOVE) {
                 bool delete = (df->current.status == DYNCFG_STATUS_ORPHAN);
-                dictionary_acquired_item_release(dyncfg_globals.nodes, item);
-                item = NULL;
 
                 if(delete) {
                     if(!http_access_user_has_enough_access_level_for_endpoint(rfe->user_access, df->edit_access)) {
+                        dictionary_acquired_item_release(dyncfg_globals.nodes, item);
+                        item = NULL;
                         code = dyncfg_default_response(
                             rfe->result.wb, HTTP_RESP_FORBIDDEN,
                             "dyncfg: you don't have enough edit permissions to execute this command");
@@ -236,6 +236,9 @@ static int dyncfg_config_execute_cb(struct rrd_function_execute *rfe, void *data
                     }
 
                     dictionary_del(dyncfg_globals.nodes, id);
+                    dictionary_acquired_item_release(dyncfg_globals.nodes, item);
+                    item = NULL;
+                    dictionary_garbage_collect(dyncfg_globals.nodes);
                     dyncfg_file_delete(id);
                     code = dyncfg_default_response(rfe->result.wb, 200, "");
                     goto cleanup;

--- a/src/health/health_notifications.c
+++ b/src/health/health_notifications.c
@@ -538,10 +538,11 @@ bool health_alarm_log_get_global_id_and_transition_id_for_rrdcalc(RRDCALC *rc, u
 }
 
 void health_alarm_log_process_to_send_notifications(RRDHOST *host, struct health_raised_summary *hrm) {
-    uint32_t first_waiting = (host->health_log.alarms)?host->health_log.alarms->unique_id:0;
     time_t now = now_realtime_sec();
 
     rw_spinlock_read_lock(&host->health_log.spinlock);
+
+    uint32_t first_waiting = (host->health_log.alarms)?host->health_log.alarms->unique_id:0;
 
     for(ALARM_ENTRY *ae = host->health_log.alarms; ae && ae->unique_id >= host->health_last_processed_id; ae = ae->next) {
         if(unlikely(

--- a/src/libnetdata/datetime/rfc3339.c
+++ b/src/libnetdata/datetime/rfc3339.c
@@ -194,16 +194,22 @@ finish:
     return pos;
 }
 
-usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
+bool rfc3339_parse_ut(const char *rfc3339, usec_t *timestamp_ut, char **endptr) {
     struct tm tm = { 0 };
     int tz_hours = 0, tz_mins = 0;
     char *s;
     usec_t timestamp, usec = 0;
 
+    if (endptr)
+        *endptr = NULL;
+
+    if (!rfc3339 || !timestamp_ut)
+        return false;
+
     // Parse date and time (up to seconds)
     s = strptime(rfc3339, "%Y-%m-%dT%H:%M:%S", &tm);
     if (!s)
-        return 0; // Parsing error
+        return false; // Parsing error
 
     // Parse fractional seconds if present
     if (*s == '.') {
@@ -212,7 +218,7 @@ usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
 
         while (isdigit((uint8_t)*next)) {
             if (digits_parsed == 9)
-                return 0; // Parsing error
+                return false; // Parsing error
 
             usec = usec * 10 + (*next - '0');
             digits_parsed++;
@@ -220,7 +226,7 @@ usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
         }
 
         if (digits_parsed < 1)
-            return 0; // Parsing error
+            return false; // Parsing error
 
         static const usec_t fix_usec[] = {
             1000000, // 0 digits (not used)
@@ -250,7 +256,7 @@ usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
 
         if (!isdigit((uint8_t)s[1]) || !isdigit((uint8_t)s[2]) || s[3] != ':' ||
             !isdigit((uint8_t)s[4]) || !isdigit((uint8_t)s[5]))
-            return 0; // Parsing error
+            return false; // Parsing error
 
         char tz_sign = *s;
         tz_hours = (s[1] - '0') * 10 + (s[2] - '0');
@@ -263,7 +269,7 @@ usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
     else if (*s == 'Z')
         s++;
     else
-        return 0; // Invalid RFC 3339 timezone specification
+        return false; // Invalid RFC 3339 timezone specification
 
     // Convert struct tm to time_t in UTC
     time_t epoch_s;
@@ -275,7 +281,7 @@ usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
     // Use mktime(), which assumes tm is local time, then adjust.
     epoch_s = mktime(&tm);
     if (epoch_s == -1)
-        return 0; // Error in time conversion
+        return false; // Error in time conversion
 
 #  if defined(HAVE_TM_GMTOFF)
     // tm.tm_gmtoff is the offset (in seconds) of local time from UTC.
@@ -295,14 +301,14 @@ usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
         struct tm *lt = localtime(&epoch_s);
         if (!lt) {
             spinlock_unlock(&time_static_buffer_spinlock);
-            return 0;
+            return false;
         }
         local_tm = *lt;
 
         struct tm *gt = gmtime(&epoch_s);
         if (!gt) {
             spinlock_unlock(&time_static_buffer_spinlock);
-            return 0;
+            return false;
         }
         utc_tm   = *gt;
 
@@ -324,5 +330,6 @@ usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
     if (endptr)
         *endptr = s;
 
-    return timestamp;
+    *timestamp_ut = timestamp;
+    return true;
 }

--- a/src/libnetdata/datetime/rfc3339.c
+++ b/src/libnetdata/datetime/rfc3339.c
@@ -207,11 +207,19 @@ usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
 
     // Parse fractional seconds if present
     if (*s == '.') {
-        char *next;
-        usec = strtoul(s + 1, &next, 10);
-        int digits_parsed = (int)(next - (s + 1));
+        char *next = s + 1;
+        int digits_parsed = 0;
 
-        if (digits_parsed < 1 || digits_parsed > 9)
+        while (isdigit((uint8_t)*next)) {
+            if (digits_parsed == 9)
+                return 0; // Parsing error
+
+            usec = usec * 10 + (*next - '0');
+            digits_parsed++;
+            next++;
+        }
+
+        if (digits_parsed < 1)
             return 0; // Parsing error
 
         static const usec_t fix_usec[] = {

--- a/src/libnetdata/datetime/rfc3339.h
+++ b/src/libnetdata/datetime/rfc3339.h
@@ -7,6 +7,6 @@
 
 #define RFC3339_MAX_LENGTH 36
 size_t rfc3339_datetime_ut(char *buffer, size_t len, usec_t now_ut, size_t fractional_digits, bool utc);
-usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr);
+bool rfc3339_parse_ut(const char *rfc3339, usec_t *timestamp_ut, char **endptr);
 
 #endif //NETDATA_RFC3339_H

--- a/src/libnetdata/inicfg/inicfg_cleanup.c
+++ b/src/libnetdata/inicfg/inicfg_cleanup.c
@@ -9,8 +9,10 @@ void inicfg_section_destroy_non_loaded(struct config *root, const char *section)
 
     netdata_log_debug(D_CONFIG, "Destroying section '%s'.", section);
 
+    APPCONFIG_LOCK(root);
     sect = inicfg_section_find(root, section);
     if(!sect) {
+        APPCONFIG_UNLOCK(root);
         netdata_log_error("Could not destroy section '%s'. Not found.", section);
         return;
     }
@@ -22,23 +24,28 @@ void inicfg_section_destroy_non_loaded(struct config *root, const char *section)
         if (opt->flags & CONFIG_VALUE_LOADED) {
             // do not destroy values that were loaded from the configuration files.
             SECTION_UNLOCK(sect);
+            APPCONFIG_UNLOCK(root);
             return;
         }
     }
 
     // no option is loaded, free them all
-    inicfg_section_remove_and_delete(root, sect, false, true);
+    inicfg_section_remove_and_delete(root, sect, true, true);
+    APPCONFIG_UNLOCK(root);
 }
 
 void inicfg_section_option_destroy_non_loaded(struct config *root, const char *section, const char *name) {
     struct config_section *sect;
+    APPCONFIG_LOCK(root);
     sect = inicfg_section_find(root, section);
     if (!sect) {
+        APPCONFIG_UNLOCK(root);
         netdata_log_error("Could not destroy section option '%s -> %s'. The section not found.", section, name);
         return;
     }
 
     SECTION_LOCK(sect);
+    APPCONFIG_UNLOCK(root);
 
     struct config_option *opt = inicfg_option_find(sect, name);
     if (opt && opt->flags & CONFIG_VALUE_LOADED) {

--- a/src/libnetdata/json/json-c-parser-inline.h
+++ b/src/libnetdata/json/json-c-parser-inline.h
@@ -135,7 +135,16 @@
         if (json_object_is_type(_j, json_type_string)) {                                                        \
             char _datetime[RFC3339_MAX_LENGTH]; _datetime[0] = '\0';                                            \
             strncpyz(_datetime, json_object_get_string(_j), sizeof(_datetime) - 1);                             \
-            dst = rfc3339_parse_ut(_datetime, NULL);                                                            \
+            usec_t _timestamp_ut = 0;                                                                           \
+            if (rfc3339_parse_ut(_datetime, &_timestamp_ut, NULL))                                               \
+                dst = _timestamp_ut;                                                                            \
+            else {                                                                                              \
+                dst = 0;                                                                                        \
+                if ((flags) & (JSONC_REQUIRED | JSONC_STRICT)) {                                                \
+                    buffer_sprintf(error, "invalid RFC3339 datetime for '%s.%s'", path, member);                \
+                    return false;                                                                               \
+                }                                                                                               \
+            }                                                                                                   \
         }                                                                                                       \
         else {                                                                                                  \
             dst = 0;                                                                                            \

--- a/src/libnetdata/json/json-c-parser-unittest.c
+++ b/src/libnetdata/json/json-c-parser-unittest.c
@@ -1401,6 +1401,26 @@ static int test_parse_txt2rfc3339(void) {
     T(ok && dst != 0, "txt2rfc3339: valid RFC3339");
     json_object_put(root);
 
+    root = json_object_new_object();
+    json_object_object_add(root, "k", json_object_new_string("1970-01-01T00:00:00Z"));
+    dst = 999; R(); ok = wrap_parse_txt2rfc3339(root, "k", &dst, error, JSONC_REQUIRED);
+    T(ok && dst == 0, "txt2rfc3339: valid epoch-zero RFC3339");
+    json_object_put(root);
+
+    root = json_object_new_object();
+    json_object_object_add(root, "k", json_object_new_string("not-rfc3339"));
+
+    dst = 999; R(); ok = wrap_parse_txt2rfc3339(root, "k", &dst, error, JSONC_OPTIONAL);
+    T(ok && dst == 0, "txt2rfc3339: invalid string+OPT->dst=0,ok");
+
+    dst = 999; R(); ok = wrap_parse_txt2rfc3339(root, "k", &dst, error, JSONC_REQUIRED);
+    T(!ok && dst == 0, "txt2rfc3339: invalid string+REQ->error");
+
+    dst = 999; R(); ok = wrap_parse_txt2rfc3339(root, "k", &dst, error, JSONC_STRICT);
+    T(!ok && dst == 0, "txt2rfc3339: invalid string+STRICT->error");
+
+    json_object_put(root);
+
     // --- non-string types → dst=0, flag check ---
     {
         struct { const char *name; int type_id; } types[] = {
@@ -1459,6 +1479,7 @@ static int test_format_rfc3339(void) {
     int failed = 0;
     char buffer[RFC3339_MAX_LENGTH];
     usec_t parsed;
+    bool parsed_ok;
     size_t len;
 
     len = rfc3339_datetime_ut(buffer, sizeof(buffer), 123456, 3, true);
@@ -1468,38 +1489,62 @@ static int test_format_rfc3339(void) {
     len = rfc3339_datetime_ut(buffer, sizeof(buffer), 123456, 7, true);
     T(len == strlen("1970-01-01T00:00:00.1234560Z") && strcmp(buffer, "1970-01-01T00:00:00.1234560Z") == 0,
       "format_rfc3339: 7 digits keep microseconds and pad trailing zero");
-    parsed = rfc3339_parse_ut(buffer, NULL);
-    T(parsed == 123456, "format_rfc3339: 7-digit output parses back to the same microseconds");
+    parsed = 0;
+    parsed_ok = rfc3339_parse_ut(buffer, &parsed, NULL);
+    T(parsed_ok && parsed == 123456, "format_rfc3339: 7-digit output parses back to the same microseconds");
 
     len = rfc3339_datetime_ut(buffer, sizeof(buffer), 1, 9, true);
     T(len == strlen("1970-01-01T00:00:00.000001000Z") && strcmp(buffer, "1970-01-01T00:00:00.000001000Z") == 0,
       "format_rfc3339: 9 digits preserve leading zeros and pad nanoseconds");
-    parsed = rfc3339_parse_ut(buffer, NULL);
-    T(parsed == 1, "format_rfc3339: 9-digit output parses back to the same microseconds");
+    parsed = 0;
+    parsed_ok = rfc3339_parse_ut(buffer, &parsed, NULL);
+    T(parsed_ok && parsed == 1, "format_rfc3339: 9-digit output parses back to the same microseconds");
 
-    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.1Z", NULL);
-    T(parsed == 100000, "parse_rfc3339: 1 fractional digit scales to microseconds");
+    len = rfc3339_datetime_ut(buffer, sizeof(buffer), 0, 0, true);
+    T(len == strlen("1970-01-01T00:00:00Z") && strcmp(buffer, "1970-01-01T00:00:00Z") == 0,
+      "format_rfc3339: epoch zero formats without fractional seconds");
+    parsed = 999;
+    parsed_ok = rfc3339_parse_ut(buffer, &parsed, NULL);
+    T(parsed_ok && parsed == 0, "format_rfc3339: epoch-zero output parses successfully");
 
-    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.999999999Z", NULL);
-    T(parsed == 999999, "parse_rfc3339: 9 fractional digits truncate to microseconds");
+    parsed = 0;
+    parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00.1Z", &parsed, NULL);
+    T(parsed_ok && parsed == 100000, "parse_rfc3339: 1 fractional digit scales to microseconds");
 
-    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.Z", NULL);
-    T(parsed == 0, "parse_rfc3339: missing fractional digits fail");
+    parsed = 0;
+    parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00.999999999Z", &parsed, NULL);
+    T(parsed_ok && parsed == 999999, "parse_rfc3339: 9 fractional digits truncate to microseconds");
 
-    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.1234567890Z", NULL);
-    T(parsed == 0, "parse_rfc3339: more than 9 fractional digits fail");
+    parsed = 999;
+    parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00.Z", &parsed, NULL);
+    T(!parsed_ok && parsed == 999, "parse_rfc3339: missing fractional digits fail without overwriting output");
 
-    parsed = rfc3339_parse_ut("1970-01-01T00:00:00. 123Z", NULL);
-    T(parsed == 0, "parse_rfc3339: fractional whitespace fails");
+    parsed = 999;
+    parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00.1234567890Z", &parsed, NULL);
+    T(!parsed_ok && parsed == 999, "parse_rfc3339: more than 9 fractional digits fail without overwriting output");
 
-    parsed = rfc3339_parse_ut("1970-01-01T00:00:00. +1Z", NULL);
-    T(parsed == 0, "parse_rfc3339: fractional whitespace plus sign fails");
+    parsed = 999;
+    parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00. 123Z", &parsed, NULL);
+    T(!parsed_ok && parsed == 999, "parse_rfc3339: fractional whitespace fails without overwriting output");
 
-    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.+1Z", NULL);
-    T(parsed == 0, "parse_rfc3339: fractional plus sign fails");
+    parsed = 999;
+    parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00. +1Z", &parsed, NULL);
+    T(!parsed_ok && parsed == 999, "parse_rfc3339: fractional whitespace plus sign fails without overwriting output");
 
-    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.-1Z", NULL);
-    T(parsed == 0, "parse_rfc3339: fractional minus sign fails");
+    parsed = 999;
+    parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00.+1Z", &parsed, NULL);
+    T(!parsed_ok && parsed == 999, "parse_rfc3339: fractional plus sign fails without overwriting output");
+
+    parsed = 999;
+    parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00.-1Z", &parsed, NULL);
+    T(!parsed_ok && parsed == 999, "parse_rfc3339: fractional minus sign fails without overwriting output");
+
+    parsed = 999;
+    parsed_ok = rfc3339_parse_ut("not-rfc3339", &parsed, NULL);
+    T(!parsed_ok && parsed == 999, "parse_rfc3339: invalid input fails without overwriting output");
+
+    parsed_ok = rfc3339_parse_ut(buffer, NULL, NULL);
+    T(!parsed_ok, "parse_rfc3339: NULL output pointer is rejected");
 
     return failed;
 }

--- a/src/libnetdata/json/json-c-parser-unittest.c
+++ b/src/libnetdata/json/json-c-parser-unittest.c
@@ -1477,6 +1477,30 @@ static int test_format_rfc3339(void) {
     parsed = rfc3339_parse_ut(buffer, NULL);
     T(parsed == 1, "format_rfc3339: 9-digit output parses back to the same microseconds");
 
+    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.1Z", NULL);
+    T(parsed == 100000, "parse_rfc3339: 1 fractional digit scales to microseconds");
+
+    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.999999999Z", NULL);
+    T(parsed == 999999, "parse_rfc3339: 9 fractional digits truncate to microseconds");
+
+    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.Z", NULL);
+    T(parsed == 0, "parse_rfc3339: missing fractional digits fail");
+
+    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.1234567890Z", NULL);
+    T(parsed == 0, "parse_rfc3339: more than 9 fractional digits fail");
+
+    parsed = rfc3339_parse_ut("1970-01-01T00:00:00. 123Z", NULL);
+    T(parsed == 0, "parse_rfc3339: fractional whitespace fails");
+
+    parsed = rfc3339_parse_ut("1970-01-01T00:00:00. +1Z", NULL);
+    T(parsed == 0, "parse_rfc3339: fractional whitespace plus sign fails");
+
+    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.+1Z", NULL);
+    T(parsed == 0, "parse_rfc3339: fractional plus sign fails");
+
+    parsed = rfc3339_parse_ut("1970-01-01T00:00:00.-1Z", NULL);
+    T(parsed == 0, "parse_rfc3339: fractional minus sign fails");
+
     return failed;
 }
 

--- a/src/libnetdata/string/string.c
+++ b/src/libnetdata/string/string.c
@@ -81,17 +81,34 @@ void string_statistics(size_t *inserts, size_t *deletes, size_t *searches, size_
     if (releases) *releases = 0;
 
     for(size_t i = 0; i < STRING_PARTITIONS ;i++) {
-        if (inserts)        *inserts        += string_base[i].inserts;
-        if (deletes)        *deletes        += string_base[i].deletes;
-        if (entries)        *entries        += (size_t) string_base[i].entries;
-        if (memory)         *memory         += (size_t) string_base[i].memory;
-        if (memory_index)   *memory_index   += (string_base[i].memory_index > 0) ? string_base[i].memory_index : 0;
+        rw_spinlock_read_lock(&string_base[i].spinlock);
+
+        size_t partition_inserts = string_base[i].inserts;
+        size_t partition_deletes = string_base[i].deletes;
+        long int partition_entries = string_base[i].entries;
+        long int partition_memory = string_base[i].memory;
+        long int partition_memory_index = string_base[i].memory_index;
 
 #ifdef NETDATA_INTERNAL_CHECKS
-        if (searches)       *searches       += string_base[i].atomic.searches;
-        if (references)     *references     += (size_t) string_base[i].atomic.active_references;
-        if (duplications)   *duplications   += string_base[i].atomic.duplications;
-        if (releases)       *releases       += string_base[i].atomic.releases;
+        size_t partition_searches = __atomic_load_n(&string_base[i].atomic.searches, __ATOMIC_RELAXED);
+        long int partition_references = __atomic_load_n(&string_base[i].atomic.active_references, __ATOMIC_RELAXED);
+        size_t partition_duplications = __atomic_load_n(&string_base[i].atomic.duplications, __ATOMIC_RELAXED);
+        size_t partition_releases = __atomic_load_n(&string_base[i].atomic.releases, __ATOMIC_RELAXED);
+#endif
+
+        rw_spinlock_read_unlock(&string_base[i].spinlock);
+
+        if (inserts)        *inserts        += partition_inserts;
+        if (deletes)        *deletes        += partition_deletes;
+        if (entries)        *entries        += (size_t) partition_entries;
+        if (memory)         *memory         += (size_t) partition_memory;
+        if (memory_index)   *memory_index   += (partition_memory_index > 0) ? (size_t) partition_memory_index : 0;
+
+#ifdef NETDATA_INTERNAL_CHECKS
+        if (searches)       *searches       += partition_searches;
+        if (references)     *references     += (size_t) partition_references;
+        if (duplications)   *duplications   += partition_duplications;
+        if (releases)       *releases       += partition_releases;
 #endif
     }
 }

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -287,7 +287,6 @@ static inline PARSER_RC pluginsd_host_define_end(char **words __maybe_unused, si
 
 static inline PARSER_RC pluginsd_host(char **words, size_t num_words, PARSER *parser)
 {
-    static time_t last_host_stale_check = 0;
     char *guid = get_word(words, num_words, 1);
 
     if(!guid || !*guid || strcmp(guid, "localhost") == 0) {
@@ -295,7 +294,7 @@ static inline PARSER_RC pluginsd_host(char **words, size_t num_words, PARSER *pa
         // Check if we need to switch any nodes to stale
         uint32_t min_check_interval = UINT_MAX;
         time_t now = now_realtime_sec();
-        if (last_host_stale_check < now) {
+        if (parser->user.vnodes.last_host_stale_check < now) {
             Word_t Index = 0;
             bool first_then_next = true;
             uint32_t *Pvalue;
@@ -322,7 +321,7 @@ static inline PARSER_RC pluginsd_host(char **words, size_t num_words, PARSER *pa
             if (min_check_interval == UINT_MAX)
                 min_check_interval = 60;
 
-            last_host_stale_check = now_realtime_sec() + min_check_interval;
+            parser->user.vnodes.last_host_stale_check = now_realtime_sec() + min_check_interval;
         }
         return PARSER_RC_OK;
     }

--- a/src/plugins.d/pluginsd_parser.h
+++ b/src/plugins.d/pluginsd_parser.h
@@ -102,6 +102,7 @@ typedef struct parser_user_object {
 
     struct {
         Pvoid_t JudyL;
+        time_t last_host_stale_check;
     } vnodes;
 
 } PARSER_USER_OBJECT;

--- a/src/web/mcp/mcp-params.c
+++ b/src/web/mcp/mcp-params.c
@@ -610,12 +610,13 @@ time_t mcp_params_parse_time(struct json_object *params, const char *name, time_
 
         // Try to parse as RFC3339 first
         char *endptr = NULL;
-        usec_t timestamp_ut = rfc3339_parse_ut(val_str, &endptr);
+        usec_t timestamp_ut = 0;
+        bool parsed_rfc3339 = rfc3339_parse_ut(val_str, &timestamp_ut, &endptr);
 
         // Check if RFC3339 parsing was successful
         // Note: We check endptr to see if the entire string was consumed
         // We don't check timestamp_ut > 0 because dates before 1970 are valid
-        if (endptr && (*endptr == '\0' || isspace((unsigned char)*endptr))) {
+        if (parsed_rfc3339 && endptr && (*endptr == '\0' || isspace((unsigned char)*endptr))) {
             // Successfully parsed as RFC3339, convert to seconds
             return (time_t)(timestamp_ut / USEC_PER_SEC);
         }


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens concurrency and parsing across the codebase: fixes several races (dyncfg delete, health notifications, string stats, pluginsd stale checks) and hardens RFC3339 parsing. RFC3339 parsing now returns status and treats epoch zero correctly.

- **Bug Fixes**
  - Dynamic config: keep acquired node through permission check and `dictionary_del()`, then release and garbage collect to avoid use-after-free on orphaned REMOVE.
  - Health notifications: read the alarm-list head under the existing read lock to remove a race.
  - String stats: snapshot per-partition counters under a read lock; load internal counters atomically.
  - `pluginsd`: move `last_host_stale_check` from a function-static to `parser->user.vnodes` to remove a cross-thread data race.
  - INI cleanup: fix lock order (root before section) and pass `have_root_lock=true` to avoid a potential deadlock.
  - RFC3339: reject malformed fractional seconds (whitespace/signs/overlong), cap at 9 digits, and update `json-c` parser macro and MCP time parsing; add tests (incl. epoch zero).

- **Migration**
  - `rfc3339_parse_ut` changed to `bool rfc3339_parse_ut(const char *s, usec_t *timestamp_ut, char **endptr)`.
    - Update callers to check the boolean result and read the timestamp via the out parameter.
    - Epoch zero (1970-01-01T00:00:00Z) is now a valid parse result instead of being indistinguishable from failure.

<sup>Written for commit 5438dc1f6cd0c0e9e1c776bb937d2c3c98be1865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

