### PR TITLE
Netdata fixes part 47

### DIFF
--- a/src/libnetdata/libnetdata.h
+++ b/src/libnetdata/libnetdata.h
@@ -51,6 +51,8 @@ char *find_and_replace(const char *src, const char *find, const char *replace, c
 #define COMPRESSION_MAX_OVERHEAD 128
 #define COMPRESSION_MAX_MSG_SIZE (COMPRESSION_MAX_CHUNK - COMPRESSION_MAX_OVERHEAD - 1)
 #define PLUGINSD_LINE_MAX (COMPRESSION_MAX_MSG_SIZE - 768)
+// This controls the max response size of a deferred function payload.
+#define PLUGINSD_MAX_DEFERRED_SIZE (100 * 1024 * 1024)
 
 bool run_command_and_copy_output_to_stdout(const char *command, int max_line_length);
 struct web_buffer *run_command_and_get_output_to_buffer(const char *command, int max_line_length);

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -255,7 +255,25 @@ url_is_request_complete_and_extract_payload(const char *begin, const char *end, 
         if(!cl) return false;
         cl = &cl[16];
 
-        size_t content_length = str2ul(cl);
+        while(*cl == ' ' || *cl == '\t')
+            cl++;
+
+        if(!isdigit((uint8_t)*cl))
+            return false;
+
+        char *content_length_end;
+        errno_clear();
+        unsigned long long parsed_content_length = strtoull(cl, &content_length_end, 10);
+        if(errno != 0 || parsed_content_length > SIZE_MAX)
+            return false;
+
+        while(*content_length_end == ' ' || *content_length_end == '\t')
+            content_length_end++;
+
+        if(content_length_end[0] != '\r' || content_length_end[1] != '\n')
+            return false;
+
+        size_t content_length = (size_t)parsed_content_length;
 
         const char *payload = strstr(cl, "\r\n\r\n");
         if(!payload) return false;

--- a/src/plugins.d/pluginsd_parser.h
+++ b/src/plugins.d/pluginsd_parser.h
@@ -14,9 +14,6 @@
 // this has to be in-sync with the same at stream-thread.c
 #define WORKER_RECEIVER_JOB_REPLICATION_COMPLETION 24
 
-// this controls the max response size of a function
-#define PLUGINSD_MAX_DEFERRED_SIZE (100 * 1024 * 1024)
-
 #define PLUGINSD_MIN_RRDSET_POINTERS_CACHE 1024
 // Slots are cache indexes. Larger values are treated as uncached input to avoid sparse cache allocations.
 #define PLUGINSD_CHART_SLOT_MAX 1000000

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -143,16 +143,40 @@ static ssize_t read_stream(struct receiver_state *r, char* buffer, size_t size) 
 
 ALWAYS_INLINE
 static ssize_t receiver_read_uncompressed(struct receiver_state *r) {
-    internal_fatal(r->thread.uncompressed.read_buffer[r->thread.uncompressed.read_len] != '\0',
+    ssize_t read_len = r->thread.uncompressed.read_len;
+    if(unlikely(read_len < 0)) {
+        internal_fatal(true, "The line to read is too big! Already have %zd bytes in read_buffer.", read_len);
+        errno_clear();
+        return -2;
+    }
+
+    size_t read_offset = (size_t)read_len;
+    if(unlikely(read_offset >= sizeof(r->thread.uncompressed.read_buffer) - 1)) {
+        internal_fatal(true, "The line to read is too big! Already have %zd bytes in read_buffer.", read_len);
+        errno_clear();
+        return -2;
+    }
+
+    internal_fatal(r->thread.uncompressed.read_buffer[read_offset] != '\0',
                    "%s: read_buffer does not start with zero #2", __FUNCTION__ );
 
-    ssize_t bytes = read_stream(r, r->thread.uncompressed.read_buffer + r->thread.uncompressed.read_len, sizeof(r->thread.uncompressed.read_buffer) - r->thread.uncompressed.read_len - 1);
+    size_t available = sizeof(r->thread.uncompressed.read_buffer) - read_offset - 1;
+    char *dst = r->thread.uncompressed.read_buffer + read_offset;
+    ssize_t bytes = read_stream(r, dst, available);
     if(bytes > 0) {
+        size_t bytes_read = (size_t)bytes;
+        if(unlikely(bytes_read > available)) {
+            internal_fatal(true, "read_stream() returned %zd bytes with only %zu bytes available", bytes, available);
+            errno_clear();
+            return -2;
+        }
+
+        size_t new_read_len = read_offset + bytes_read;
         worker_set_metric(WORKER_RECEIVER_JOB_BYTES_READ, (NETDATA_DOUBLE)bytes);
         worker_set_metric(WORKER_RECEIVER_JOB_BYTES_UNCOMPRESSED, (NETDATA_DOUBLE)bytes);
 
-        r->thread.uncompressed.read_len += bytes;
-        r->thread.uncompressed.read_buffer[r->thread.uncompressed.read_len] = '\0';
+        r->thread.uncompressed.read_len = (ssize_t)new_read_len;
+        dst[bytes_read] = '\0';
         r->thread.bytes_received += bytes;
         if(likely(r->host))
             single_writer_atomic_add(&r->host->stream.rcv.status.bytes_in, (uint64_t)bytes);
@@ -243,30 +267,56 @@ static decompressor_status_t receiver_get_decompressed(struct receiver_state *r)
     if (unlikely(!stream_decompressed_bytes_in_buffer(&r->thread.compressed.decompressor)))
         return DECOMPRESS_NEED_MORE_DATA;
 
-    size_t available = sizeof(r->thread.uncompressed.read_buffer) - r->thread.uncompressed.read_len - 1;
-    if (likely(available)) {
-        size_t len = stream_decompressor_get(
-            &r->thread.compressed.decompressor, r->thread.uncompressed.read_buffer + r->thread.uncompressed.read_len, available);
-        if (unlikely(!len)) {
-            internal_error(true, "decompressor returned zero length #1");
-            return DECOMPRESS_FAILED;
-        }
-
-        r->thread.uncompressed.read_len += (int)len;
-        r->thread.uncompressed.read_buffer[r->thread.uncompressed.read_len] = '\0';
-    }
-    else {
-        internal_fatal(true, "The line to read is too big! Already have %zd bytes in read_buffer.", r->thread.uncompressed.read_len);
+    ssize_t read_len = r->thread.uncompressed.read_len;
+    if(unlikely(read_len < 0)) {
+        internal_fatal(true, "The line to read is too big! Already have %zd bytes in read_buffer.", read_len);
         return DECOMPRESS_FAILED;
     }
+
+    size_t read_offset = (size_t)read_len;
+    if(unlikely(read_offset >= sizeof(r->thread.uncompressed.read_buffer) - 1)) {
+        internal_fatal(true, "The line to read is too big! Already have %zd bytes in read_buffer.", read_len);
+        return DECOMPRESS_FAILED;
+    }
+
+    size_t available = sizeof(r->thread.uncompressed.read_buffer) - read_offset - 1;
+    char *dst = r->thread.uncompressed.read_buffer + read_offset;
+    size_t len = stream_decompressor_get(
+        &r->thread.compressed.decompressor, dst, available);
+    if (unlikely(!len)) {
+        internal_error(true, "decompressor returned zero length #1");
+        return DECOMPRESS_FAILED;
+    }
+
+    if(unlikely(len > available)) {
+        internal_fatal(true, "decompressor returned %zu bytes with only %zu bytes available", len, available);
+        return DECOMPRESS_FAILED;
+    }
+
+    size_t new_read_len = read_offset + len;
+    r->thread.uncompressed.read_len = (ssize_t)new_read_len;
+    dst[len] = '\0';
 
     return DECOMPRESS_OK;
 }
 
 ALWAYS_INLINE_HOT_FLATTEN
 static ssize_t receiver_read_compressed(struct receiver_state *r) {
+    ssize_t read_len = r->thread.uncompressed.read_len;
+    if(unlikely(read_len < 0)) {
+        internal_fatal(true, "The line to read is too big! Already have %zd bytes in read_buffer.", read_len);
+        errno_clear();
+        return -2;
+    }
 
-    internal_fatal(r->thread.uncompressed.read_buffer[r->thread.uncompressed.read_len] != '\0',
+    size_t read_offset = (size_t)read_len;
+    if(unlikely(read_offset >= sizeof(r->thread.uncompressed.read_buffer) - 1)) {
+        internal_fatal(true, "The line to read is too big! Already have %zd bytes in read_buffer.", read_len);
+        errno_clear();
+        return -2;
+    }
+
+    internal_fatal(r->thread.uncompressed.read_buffer[read_offset] != '\0',
                    "%s: read_buffer does not start with zero #2", __FUNCTION__ );
 
     ssize_t bytes = read_stream(r, r->thread.compressed.buf + r->thread.compressed.used,

--- a/src/streaming/stream-sender-execute.c
+++ b/src/streaming/stream-sender-execute.c
@@ -142,12 +142,56 @@ static void cleanup_deferred_data(struct sender_state *s) {
     s->thread.defer.action_data = NULL;
 }
 
+static bool stream_sender_defer_is_end_keyword_prefix(struct sender_state *s, const char *line, size_t line_len) {
+    const char *end_keyword = s->thread.defer.end_keyword;
+    if(unlikely(!end_keyword))
+        return false;
+
+    size_t keyword_len = strlen(end_keyword);
+
+    return line_len <= keyword_len && memcmp(line, end_keyword, line_len) == 0;
+}
+
+static bool stream_sender_defer_is_end_keyword(struct sender_state *s, const char *line, size_t line_len) {
+    const char *end_keyword = s->thread.defer.end_keyword;
+    if(unlikely(!end_keyword))
+        return false;
+
+    size_t keyword_len = strlen(end_keyword);
+
+    return line_len == keyword_len && memcmp(line, end_keyword, line_len) == 0;
+}
+
+static bool stream_sender_defer_payload_append(struct sender_state *s, const char *line, size_t line_len, bool add_newline) {
+    size_t add_len = line_len + (add_newline ? 1 : 0);
+    size_t current_len = buffer_strlen(s->thread.defer.payload);
+
+    if(add_len > PLUGINSD_MAX_DEFERRED_SIZE || current_len > PLUGINSD_MAX_DEFERRED_SIZE - add_len) {
+        size_t attempted_len = current_len > SIZE_MAX - add_len ? SIZE_MAX : current_len + add_len;
+
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "STREAM SND '%s' [to %s]: deferred payload is too big (%zu bytes, limit %zu bytes) "
+               "while waiting for keyword '%s'. Restarting sender connection.",
+               rrdhost_hostname(s->host), s->remote_ip,
+               attempted_len,
+               (size_t)PLUGINSD_MAX_DEFERRED_SIZE,
+               s->thread.defer.end_keyword ? s->thread.defer.end_keyword : "unknown");
+        return false;
+    }
+
+    buffer_fast_strcat(s->thread.defer.payload, line, line_len);
+    if(add_newline)
+        buffer_putc(s->thread.defer.payload, '\n');
+
+    return true;
+}
+
 void stream_sender_execute_commands_cleanup(struct sender_state *s) {
     cleanup_deferred_data(s);
 }
 
 // This is just a placeholder until the gap filling state machine is inserted
-void stream_sender_execute_commands(struct sender_state *s) {
+bool stream_sender_execute_commands(struct sender_state *s) {
     ND_LOG_STACK lgs[] = {
         ND_LOG_FIELD_CB(NDF_REQUEST, line_splitter_reconstruct_line, &s->thread.rbuf.line),
         ND_LOG_FIELD_END(),
@@ -166,7 +210,13 @@ void stream_sender_execute_commands(struct sender_state *s) {
 
         if(!newline) {
             if(s->thread.defer.end_keyword) {
-                buffer_strcat(s->thread.defer.payload, start);
+                size_t line_len = end - start;
+                if(stream_sender_defer_is_end_keyword_prefix(s, start, line_len))
+                    break;
+
+                if(!stream_sender_defer_payload_append(s, start, line_len, false))
+                    return false;
+
                 start = end;
             }
             break;
@@ -176,7 +226,7 @@ void stream_sender_execute_commands(struct sender_state *s) {
         s->thread.rbuf.line.count++;
 
         if(s->thread.defer.end_keyword) {
-            if(strcmp(start, s->thread.defer.end_keyword) == 0) {
+            if(stream_sender_defer_is_end_keyword(s, start, newline - start)) {
 #ifdef NETDATA_LOG_STREAM_SENDER
                 buffer_strcat(s->log.received, buffer_tostring(s->thread.defer.payload));
                 buffer_strcat(s->log.received, "\n");
@@ -188,8 +238,8 @@ void stream_sender_execute_commands(struct sender_state *s) {
                 cleanup_deferred_data(s);
             }
             else {
-                buffer_strcat(s->thread.defer.payload, start);
-                buffer_putc(s->thread.defer.payload, '\n');
+                if(!stream_sender_defer_payload_append(s, start, newline - start, true))
+                    return false;
             }
 
             continue;
@@ -340,4 +390,6 @@ void stream_sender_execute_commands(struct sender_state *s) {
         s->thread.rbuf.b[0] = '\0';
         s->thread.rbuf.read_len = 0;
     }
+
+    return true;
 }

--- a/src/streaming/stream-sender-internals.h
+++ b/src/streaming/stream-sender-internals.h
@@ -130,7 +130,7 @@ struct sender_state {
 void stream_sender_add_to_connector_queue(RRDHOST *host);
 
 void stream_sender_execute_commands_cleanup(struct sender_state *s);
-void stream_sender_execute_commands(struct sender_state *s);
+bool stream_sender_execute_commands(struct sender_state *s);
 
 bool stream_connect(struct sender_state *s, uint16_t default_port, time_t timeout);
 

--- a/src/streaming/stream-sender.c
+++ b/src/streaming/stream-sender.c
@@ -793,25 +793,36 @@ bool stream_sender_send_data(struct stream_thread *sth, struct sender_state *s, 
 bool stream_sender_receive_data(struct stream_thread *sth, struct sender_state *s, usec_t now_ut, bool process_opcodes) {
     EVLOOP_STATUS status = EVLOOP_STATUS_CONTINUE;
     while(status == EVLOOP_STATUS_CONTINUE) {
-        ssize_t rc = nd_sock_revc_nowait(&s->sock, s->thread.rbuf.b + s->thread.rbuf.read_len, s->thread.rbuf.size - s->thread.rbuf.read_len - 1);
-        if (likely(rc > 0)) {
-            s->thread.rbuf.read_len += rc;
-
-            s->thread.last_traffic_ut = now_ut;
-            sth->snd.bytes_received += rc;
-            pulse_stream_received_bytes(rc);
-
-            worker_is_busy(WORKER_SENDER_JOB_EXECUTE);
-            stream_sender_execute_commands(s);
+        ssize_t read_len = s->thread.rbuf.read_len;
+        if(unlikely(!s->thread.rbuf.b || !s->thread.rbuf.size || read_len < 0 ||
+                    (size_t)read_len >= s->thread.rbuf.size - 1)) {
+            internal_fatal(true, "The line to read is too big! Already have %zd bytes in read_buffer.", read_len);
+            errno_clear();
+            status = EVLOOP_STATUS_SOCKET_ERROR;
         }
-        else if (rc == 0 || errno == ECONNRESET)
-            status = EVLOOP_STATUS_SOCKET_CLOSED;
+        else {
+            size_t available = s->thread.rbuf.size - (size_t)read_len - 1;
+            ssize_t rc = nd_sock_revc_nowait(&s->sock, s->thread.rbuf.b + read_len, available);
 
-        else if (rc < 0) {
-            if(errno == EWOULDBLOCK || errno == EAGAIN || errno == EINTR)
-                status = EVLOOP_STATUS_SOCKET_FULL;
-            else
-                status = EVLOOP_STATUS_SOCKET_ERROR;
+            if (likely(rc > 0)) {
+                s->thread.rbuf.read_len = read_len + rc;
+
+                s->thread.last_traffic_ut = now_ut;
+                sth->snd.bytes_received += rc;
+                pulse_stream_received_bytes(rc);
+
+                worker_is_busy(WORKER_SENDER_JOB_EXECUTE);
+                stream_sender_execute_commands(s);
+            }
+            else if (rc == 0 || errno == ECONNRESET)
+                status = EVLOOP_STATUS_SOCKET_CLOSED;
+
+            else if (rc < 0) {
+                if(errno == EWOULDBLOCK || errno == EAGAIN || errno == EINTR)
+                    status = EVLOOP_STATUS_SOCKET_FULL;
+                else
+                    status = EVLOOP_STATUS_SOCKET_ERROR;
+            }
         }
 
         if(status == EVLOOP_STATUS_SOCKET_ERROR || status == EVLOOP_STATUS_SOCKET_CLOSED) {

--- a/src/streaming/stream-sender.c
+++ b/src/streaming/stream-sender.c
@@ -812,7 +812,8 @@ bool stream_sender_receive_data(struct stream_thread *sth, struct sender_state *
                 pulse_stream_received_bytes(rc);
 
                 worker_is_busy(WORKER_SENDER_JOB_EXECUTE);
-                stream_sender_execute_commands(s);
+                if(!stream_sender_execute_commands(s))
+                    status = EVLOOP_STATUS_SOCKET_ERROR;
             }
             else if (rc == 0 || errno == ECONNRESET)
                 status = EVLOOP_STATUS_SOCKET_CLOSED;

--- a/src/web/websocket/websocket-receive.c
+++ b/src/web/websocket/websocket-receive.c
@@ -57,14 +57,12 @@ ssize_t websocket_receive_data(WS_CLIENT *wsc) {
     if (!wsc->in_buffer.data || wsc->sock.fd < 0)
         return -1;
 
-    size_t available_space = WEBSOCKET_RECEIVE_BUFFER_SIZE;
-    if(wsc->next_frame_size > 0) {
-        size_t used_space = cbuffer_used_size_unsafe(&wsc->in_buffer);
-        if(used_space < wsc->next_frame_size) {
-            size_t missing_for_next_frame = wsc->next_frame_size - used_space;
-            available_space = MAX(missing_for_next_frame, WEBSOCKET_RECEIVE_BUFFER_SIZE);
-        }
+    size_t available_space = cbuffer_available_size_unsafe(&wsc->in_buffer);
+    if(available_space <= 1) {
+        websocket_error(wsc, "Not enough space in input buffer to read from client");
+        return -1;
     }
+    available_space = MIN(available_space - 1, (size_t)WEBSOCKET_RECEIVE_BUFFER_SIZE);
 
     char *buffer = cbuffer_reserve_unsafe(&wsc->in_buffer, available_space);
     if(!buffer) {
@@ -279,7 +277,7 @@ bool websocket_protocol_parse_header_from_buffer(const char *buffer, size_t leng
             return false; // Not enough data
         }
         
-        header->payload_length =
+        uint64_t payload_length =
             ((uint64_t)((unsigned char)buffer[2]) << 56) | 
             ((uint64_t)((unsigned char)buffer[3]) << 48) | 
             ((uint64_t)((unsigned char)buffer[4]) << 40) | 
@@ -288,6 +286,8 @@ bool websocket_protocol_parse_header_from_buffer(const char *buffer, size_t leng
             ((uint64_t)((unsigned char)buffer[7]) << 16) | 
             ((uint64_t)((unsigned char)buffer[8]) << 8) | 
             ((uint64_t)((unsigned char)buffer[9]));
+
+        header->payload_length = payload_length > SIZE_MAX ? SIZE_MAX : (size_t)payload_length;
         header->header_size += 8;
     }
     
@@ -304,7 +304,8 @@ bool websocket_protocol_parse_header_from_buffer(const char *buffer, size_t leng
     }
 
     header->payload = (void *)&buffer[header->header_size];
-    header->frame_size = header->header_size + header->payload_length;
+    header->frame_size = header->payload_length > SIZE_MAX - header->header_size ?
+        SIZE_MAX : header->header_size + header->payload_length;
     
     return true;
 }
@@ -577,6 +578,14 @@ websocket_protocol_consume_frame(WS_CLIENT *wsc, char *data, size_t length, ssiz
         websocket_debug(wsc, "Not enough data to parse a complete header: bytes available = %zu",
                         length);
         return WS_FRAME_NEED_MORE_DATA;
+    }
+
+    if (header.payload_length > (uint64_t)WS_MAX_INCOMING_FRAME_SIZE ||
+        header.frame_size >= WEBSOCKET_IN_BUFFER_MAX_SIZE) {
+        websocket_error(wsc, "Invalid frame: Frame too large (payload=%zu bytes, frame=%zu bytes)",
+                        header.payload_length, header.frame_size);
+        websocket_protocol_exception(wsc, WS_CLOSE_MESSAGE_TOO_BIG, "Frame too large");
+        return WS_FRAME_ERROR;
     }
     
     // Check if we have enough data for the complete frame (header + payload)


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens streaming, URL, and WebSocket paths with strict bounds and parsing checks to prevent memory-safety issues and unbounded buffer growth. Valid traffic stays unchanged; malformed or oversized inputs now fail fast and cleanly.

- **Bug Fixes**
  - Streaming receiver: validate `read_len` before any pointer math; bound available space; guard decompressor output; fail early on invalid states.
  - Streaming sender: enforce `PLUGINSD_MAX_DEFERRED_SIZE` during deferred payload accumulation; add exact/prefix end-keyword checks across reads; `stream_sender_execute_commands()` now returns `bool` so callers can disconnect on errors.
  - WebSocket: reserve only actual free buffer space (capped by receive chunk); saturate 64-bit payload lengths to `size_t`; guard `frame_size` addition; reject frames exceeding limits with “message too big”.
  - URL parsing: parse `Content-Length` with `strtoull()`, require digits, reject overflow/garbage, and enforce CRLF termination and optional SP/HTAB only.
  - Constants: move `PLUGINSD_MAX_DEFERRED_SIZE` to `libnetdata.h` and remove the duplicate define.

<sup>Written for commit fa94a3b2d929683f2189919454a825f8d3535428. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

