### PR TITLE
Netdata fixes part 48

### DIFF
--- a/src/claim/claim.c
+++ b/src/claim/claim.c
@@ -126,11 +126,11 @@ bool claim_id_matches_any(const char *claim_id) {
     if(!UUIDiszero(having) && UUIDeq(having, this_one))
         return true;
 
-    having = localhost->aclk.claim_id_of_parent;
+    having = rrdhost_claim_id_of_parent_get(localhost);
     if(!UUIDiszero(having) && UUIDeq(having, this_one))
         return true;
 
-    having = localhost->aclk.claim_id_of_origin;
+    having = rrdhost_claim_id_of_origin_get(localhost);
     if(!UUIDiszero(having) && UUIDeq(having, this_one))
         return true;
 

--- a/src/claim/claim_id.c
+++ b/src/claim/claim_id.c
@@ -10,6 +10,63 @@ static struct {
     .spinlock = SPINLOCK_INITIALIZER,
 };
 
+static ND_UUID rrdhost_claim_id_field_get(RRDHOST *host, bool parent) {
+    ND_UUID uuid = UUID_ZERO;
+
+    if(unlikely(!host))
+        return uuid;
+
+    spinlock_lock(&host->aclk.spinlock);
+    uuid = parent ? host->aclk.claim_id_of_parent : host->aclk.claim_id_of_origin;
+    spinlock_unlock(&host->aclk.spinlock);
+
+    return uuid;
+}
+
+static void rrdhost_claim_id_field_set(RRDHOST *host, ND_UUID claim_id, bool parent) {
+    if(unlikely(!host))
+        return;
+
+    spinlock_lock(&host->aclk.spinlock);
+    if(parent)
+        host->aclk.claim_id_of_parent = claim_id;
+    else
+        host->aclk.claim_id_of_origin = claim_id;
+    spinlock_unlock(&host->aclk.spinlock);
+}
+
+ND_UUID rrdhost_claim_id_of_origin_get(RRDHOST *host) {
+    return rrdhost_claim_id_field_get(host, false);
+}
+
+void rrdhost_claim_id_of_origin_set(RRDHOST *host, ND_UUID claim_id) {
+    rrdhost_claim_id_field_set(host, claim_id, false);
+}
+
+ND_UUID rrdhost_claim_id_of_parent_get(RRDHOST *host) {
+    return rrdhost_claim_id_field_get(host, true);
+}
+
+bool rrdhost_claim_id_of_parent_update(RRDHOST *host, ND_UUID claim_id, ND_UUID *previous_claim_id) {
+    ND_UUID previous = UUID_ZERO;
+    bool changed = false;
+
+    if(likely(host)) {
+        spinlock_lock(&host->aclk.spinlock);
+        previous = host->aclk.claim_id_of_parent;
+        if(!UUIDeq(previous, claim_id)) {
+            host->aclk.claim_id_of_parent = claim_id;
+            changed = true;
+        }
+        spinlock_unlock(&host->aclk.spinlock);
+    }
+
+    if(previous_claim_id)
+        *previous_claim_id = previous;
+
+    return changed;
+}
+
 void claim_id_clear_previous_working(void) {
     spinlock_lock(&claim.spinlock);
     claim.claim_uuid_saved = UUID_ZERO;
@@ -27,7 +84,7 @@ void claim_id_set(ND_UUID new_claim_id) {
 
     claim.claim_uuid = new_claim_id;
     if(localhost)
-        localhost->aclk.claim_id_of_origin = claim.claim_uuid;
+        rrdhost_claim_id_of_origin_set(localhost, claim.claim_uuid);
 
     spinlock_unlock(&claim.spinlock);
 }
@@ -106,14 +163,16 @@ CLAIM_ID rrdhost_claim_id_get(RRDHOST *host) {
 
     if(host == localhost) {
         ret.uuid = claim_id_get_uuid();
-        if(UUIDiszero(ret.uuid) || (!aclk_online() && !UUIDiszero(host->aclk.claim_id_of_parent)))
-            ret.uuid = host->aclk.claim_id_of_parent;
+        ND_UUID parent_claim_id = rrdhost_claim_id_of_parent_get(host);
+        if(UUIDiszero(ret.uuid) || (!aclk_online() && !UUIDiszero(parent_claim_id)))
+            ret.uuid = parent_claim_id;
     }
     else {
-        if (!UUIDiszero(host->aclk.claim_id_of_origin))
-            ret.uuid = host->aclk.claim_id_of_origin;
+        ND_UUID origin_claim_id = rrdhost_claim_id_of_origin_get(host);
+        if (!UUIDiszero(origin_claim_id))
+            ret.uuid = origin_claim_id;
         else
-            ret.uuid = host->aclk.claim_id_of_parent;
+            ret.uuid = rrdhost_claim_id_of_parent_get(host);
     }
 
     if(claim_id_is_set(ret))

--- a/src/claim/claim_id.h
+++ b/src/claim/claim_id.h
@@ -24,5 +24,9 @@ typedef struct {
 CLAIM_ID claim_id_get(void);
 CLAIM_ID claim_id_get_last_working(void);
 CLAIM_ID rrdhost_claim_id_get(RRDHOST *host);
+ND_UUID rrdhost_claim_id_of_origin_get(RRDHOST *host);
+void rrdhost_claim_id_of_origin_set(RRDHOST *host, ND_UUID claim_id);
+ND_UUID rrdhost_claim_id_of_parent_get(RRDHOST *host);
+bool rrdhost_claim_id_of_parent_update(RRDHOST *host, ND_UUID claim_id, ND_UUID *previous_claim_id);
 
 #endif //NETDATA_CLAIM_ID_H

--- a/src/claim/cloud-status.c
+++ b/src/claim/cloud-status.c
@@ -26,7 +26,7 @@ CLOUD_STATUS cloud_status(void) {
         rrdhost_flag_check(localhost, RRDHOST_FLAG_STREAM_SENDER_READY_4_METRICS) &&
         stream_sender_has_capabilities(localhost, STREAM_CAP_NODE_ID) &&
         !UUIDiszero(localhost->node_id) &&
-        !UUIDiszero(localhost->aclk.claim_id_of_parent))
+        !UUIDiszero(rrdhost_claim_id_of_parent_get(localhost)))
         return CLOUD_STATUS_INDIRECT;
 
     if(is_agent_claimed())

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -358,6 +358,7 @@ RRDHOST *rrdhost_create(
 
     spinlock_init(&host->receiver_lock);
     spinlock_init(&host->rrdhost_update_lock);
+    spinlock_init(&host->aclk.spinlock);
 
     if (likely(!archived)) {
         rrd_functions_host_init(host);

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -373,6 +373,7 @@ struct rrdhost {
     ND_UUID node_id;                                // Cloud node_id
 
     struct {
+        SPINLOCK spinlock;
         ND_UUID claim_id_of_origin;
         ND_UUID claim_id_of_parent;
     } aclk;

--- a/src/health/health.h
+++ b/src/health/health.h
@@ -86,6 +86,7 @@ void health_alarm_entry_aral_init(void);
 struct aral_statistics *health_alarm_entry_aral_stats(void);
 ALARM_ENTRY *health_alarm_entry_create(void);
 void health_alarm_entry_destroy(ALARM_ENTRY *ae);
+void health_alarm_entry_assign_unique_id(RRDHOST *host, ALARM_ENTRY *ae);
 
 void *health_cmdapi_thread(void *ptr);
 

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -451,8 +451,8 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                         rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0);
 
                 if (ae) {
-                    health_log_alert(host, ae);
                     health_alarm_log_add_entry(host, ae, false);
+                    health_log_alert(host, ae);
                     health_alert_status_counts_sub(&status_counts, rc->status);
                     rc->old_status = rc->status;
                     rc->status = RRDCALC_STATUS_REMOVED;
@@ -655,11 +655,11 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                             ((rc->config.alert_action_options & ALERT_ACTION_OPTION_NO_CLEAR_NOTIFICATION)? HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION : 0) |
                             ((rc->run_flags & RRDCALC_FLAG_SILENCED)? HEALTH_ENTRY_FLAG_SILENCED : 0) |
                             (rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0)
-                                )
+                        )
                     );
 
-                health_log_alert(host, ae);
                 health_alarm_log_add_entry(host, ae, false);
+                health_log_alert(host, ae);
 
                 nd_log(NDLS_DAEMON, NDLP_DEBUG,
                        "[%s]: Alert event for [%s.%s], value [%s], status [%s].",
@@ -734,9 +734,10 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                             ((rc->config.alert_action_options & ALERT_ACTION_OPTION_NO_CLEAR_NOTIFICATION)? HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION : 0) |
                             ((rc->run_flags & RRDCALC_FLAG_SILENCED)? HEALTH_ENTRY_FLAG_SILENCED : 0) |
                             (rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0)
-                                )
+                        )
                     );
 
+                health_alarm_entry_assign_unique_id(host, ae);
                 health_log_alert(host, ae);
                 ae->last_repeat = rc->last_repeat;
                 if (!(rc->run_flags & RRDCALC_FLAG_RUN_ONCE) && rc->status == RRDCALC_STATUS_CLEAR) {

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -812,7 +812,7 @@ static void health_event_loop(void) {
             schedule_node_state_update(localhost, 10);
         }
 
-        if (unlikely(silencers->all_alarms && silencers->stype == STYPE_DISABLE_ALARMS)) {
+        if (unlikely(health_silencers_all_alarms_disabled())) {
             static int logged=0;
             if (!logged) {
                 nd_log(NDLS_DAEMON, NDLP_DEBUG,

--- a/src/health/health_json.c
+++ b/src/health/health_json.c
@@ -231,13 +231,17 @@ static void health_alarms2json_fill_alarms(RRDHOST *host, BUFFER *wb, int all, v
 }
 
 void health_alarms2json(RRDHOST *host, BUFFER *wb, int all) {
+    rw_spinlock_read_lock(&host->health_log.spinlock);
+    uint32_t latest_alarm_log_unique_id = (host->health_log.next_log_id > 0) ? (host->health_log.next_log_id - 1) : 0;
+    rw_spinlock_read_unlock(&host->health_log.spinlock);
+
     buffer_sprintf(wb, "{\n\t\"hostname\": \"%s\","
                     "\n\t\"latest_alarm_log_unique_id\": %u,"
                     "\n\t\"status\": %s,"
                     "\n\t\"now\": %lu,"
                     "\n\t\"alarms\": {\n",
                    rrdhost_hostname(host),
-                   (host->health_log.next_log_id > 0)?(host->health_log.next_log_id - 1):0,
+                   latest_alarm_log_unique_id,
                    host->health.enabled ?"true":"false",
                    (unsigned long)now_realtime_sec());
 

--- a/src/health/health_log.c
+++ b/src/health/health_log.c
@@ -42,6 +42,29 @@ void health_alarm_entry_destroy(ALARM_ENTRY *ae) {
 // ----------------------------------------------------------------------------
 extern __thread bool is_health_thread;
 
+static inline void health_alarm_entry_assign_unique_id_unsafe(RRDHOST *host, ALARM_ENTRY *ae) {
+    if(unlikely(!ae->unique_id))
+        ae->unique_id = host->health_log.next_log_id++;
+}
+
+void health_alarm_entry_assign_unique_id(RRDHOST *host, ALARM_ENTRY *ae) {
+    if(!host || !ae)
+        return;
+
+    rw_spinlock_write_lock(&host->health_log.spinlock);
+    health_alarm_entry_assign_unique_id_unsafe(host, ae);
+    rw_spinlock_write_unlock(&host->health_log.spinlock);
+}
+
+static inline void health_alarm_log_insert_entry_unsafe(RRDHOST *host, ALARM_ENTRY *ae) {
+    ALARM_ENTRY *t;
+
+    for(t = host->health_log.alarms ; t && t->unique_id > ae->unique_id ; t = t->next)
+        ;
+
+    DOUBLE_LINKED_LIST_INSERT_ITEM_BEFORE_UNSAFE(host->health_log.alarms, t, ae, prev, next);
+}
+
 inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae, bool async)
 {
     if (async) {
@@ -209,12 +232,6 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     ae->source = string_dup(source);
     ae->units = string_dup(units);
 
-    rw_spinlock_write_lock(&host->health_log.spinlock);
-    ae->unique_id = host->health_log.next_log_id++;
-    rw_spinlock_write_unlock(&host->health_log.spinlock);
-
-    netdata_log_debug(D_HEALTH, "Health adding alarm log entry with id: %u", ae->unique_id);
-
     ae->alarm_id = alarm_id;
     ae->alarm_event_id = alarm_event_id;
     ae->when = when;
@@ -245,20 +262,20 @@ inline ALARM_ENTRY* health_create_alarm_entry(
 
 inline void health_alarm_log_add_entry(RRDHOST *host, ALARM_ENTRY *ae, bool async)
 {
-    netdata_log_debug(D_HEALTH, "Health adding alarm log entry with id: %u", ae->unique_id);
-
     __atomic_add_fetch(&host->health_transitions, 1, __ATOMIC_RELAXED);
 
-    // link it
-    rw_spinlock_write_lock(&host->health_log.spinlock);
-    DOUBLE_LINKED_LIST_PREPEND_ITEM_UNSAFE(host->health_log.alarms, ae, prev, next);
-    rw_spinlock_write_unlock(&host->health_log.spinlock);
-
-    // match previous alarms
-    rw_spinlock_read_lock(&host->health_log.spinlock);
     ALARM_ENTRY *update_ae = NULL;
-    for(ALARM_ENTRY *t = host->health_log.alarms ; t ; t = t->next) {
-        if(t != ae && t->alarm_id == ae->alarm_id) {
+
+    rw_spinlock_write_lock(&host->health_log.spinlock);
+
+    health_alarm_entry_assign_unique_id_unsafe(host, ae);
+    health_alarm_log_insert_entry_unsafe(host, ae);
+
+    // Match the previous older entry for this alert. The list is ordered by
+    // descending unique_id, so entries before ae are newer and must not be
+    // marked as updated by ae.
+    for(ALARM_ENTRY *t = ae->next ; t ; t = t->next) {
+        if(t->alarm_id == ae->alarm_id) {
             if(!(t->flags & HEALTH_ENTRY_FLAG_UPDATED) && !t->updated_by_id) {
                 t->flags |= HEALTH_ENTRY_FLAG_UPDATED;
                 t->updated_by_id = ae->unique_id;
@@ -275,7 +292,11 @@ inline void health_alarm_log_add_entry(RRDHOST *host, ALARM_ENTRY *ae, bool asyn
             break;
         }
     }
-    rw_spinlock_read_unlock(&host->health_log.spinlock);
+
+    rw_spinlock_write_unlock(&host->health_log.spinlock);
+
+    netdata_log_debug(D_HEALTH, "Health adding alarm log entry with id: %u", ae->unique_id);
+
     if (update_ae)
         health_alarm_log_save(host, update_ae, async);
 

--- a/src/health/health_log.c
+++ b/src/health/health_log.c
@@ -190,8 +190,6 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     if (duration < 0)
         duration = 0;
 
-    netdata_log_debug(D_HEALTH, "Health adding alarm log entry with id: %u", host->health_log.next_log_id);
-
     ALARM_ENTRY *ae = health_alarm_entry_create();
     ae->name = string_dup(name);
     ae->chart = string_dup(chart);
@@ -211,7 +209,12 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     ae->source = string_dup(source);
     ae->units = string_dup(units);
 
+    rw_spinlock_write_lock(&host->health_log.spinlock);
     ae->unique_id = host->health_log.next_log_id++;
+    rw_spinlock_write_unlock(&host->health_log.spinlock);
+
+    netdata_log_debug(D_HEALTH, "Health adding alarm log entry with id: %u", ae->unique_id);
+
     ae->alarm_id = alarm_id;
     ae->alarm_event_id = alarm_event_id;
     ae->when = when;

--- a/src/health/health_silencers.c
+++ b/src/health/health_silencers.c
@@ -21,6 +21,8 @@
 
 SILENCERS *silencers;
 
+static RW_SPINLOCK silencers_rw_spinlock = RW_SPINLOCK_INITIALIZER;
+
 /**
  * Create Silencer
  *
@@ -42,7 +44,7 @@ SILENCER *create_silencer(void) {
  *
  * @param silencer
  */
-void health_silencers_add(SILENCER *silencer) {
+static void health_silencers_add_unsafe(SILENCER *silencer) {
     // Add the created instance to the linked list in silencers
     silencer->next = silencers->silencers;
     silencers->silencers = silencer;
@@ -53,6 +55,12 @@ void health_silencers_add(SILENCER *silencer) {
         silencer->charts,
         silencer->contexts,
         silencer->hosts);
+}
+
+void health_silencers_add(SILENCER *silencer) {
+    rw_spinlock_write_lock(&silencers_rw_spinlock);
+    health_silencers_add_unsafe(silencer);
+    rw_spinlock_write_unlock(&silencers_rw_spinlock);
 }
 
 /**
@@ -67,20 +75,12 @@ void health_silencers_add(SILENCER *silencer) {
  * @return It returns the silencer configured on success and NULL otherwise
  */
 SILENCER *health_silencers_addparam(SILENCER *silencer, char *key, char *value) {
-    static uint32_t
-        hash_alarm = 0,
-        hash_template = 0,
-        hash_chart = 0,
-        hash_context = 0,
-        hash_host = 0;
-
-    if (unlikely(!hash_alarm)) {
-        hash_alarm = simple_uhash(HEALTH_ALARM_KEY);
-        hash_template = simple_uhash(HEALTH_TEMPLATE_KEY);
-        hash_chart = simple_uhash(HEALTH_CHART_KEY);
-        hash_context = simple_uhash(HEALTH_CONTEXT_KEY);
+    uint32_t
+        hash_alarm = simple_uhash(HEALTH_ALARM_KEY),
+        hash_template = simple_uhash(HEALTH_TEMPLATE_KEY),
+        hash_chart = simple_uhash(HEALTH_CHART_KEY),
+        hash_context = simple_uhash(HEALTH_CONTEXT_KEY),
         hash_host = simple_uhash(HEALTH_HOST_KEY);
-    }
 
     uint32_t hash = simple_uhash(key);
     if (unlikely(silencer == NULL)) {
@@ -121,7 +121,7 @@ SILENCER *health_silencers_addparam(SILENCER *silencer, char *key, char *value) 
  *
  * @return It always return 0.
  */
-int health_silencers_json_read_callback(JSON_ENTRY *e)
+static int health_silencers_json_read_callback(JSON_ENTRY *e)
 {
     switch(e->type) {
         case JSON_OBJECT:
@@ -133,7 +133,7 @@ int health_silencers_json_read_callback(JSON_ENTRY *e)
 #endif
                 e->callback_data = create_silencer();
                 if(e->callback_data) {
-                    health_silencers_add(e->callback_data);
+                    health_silencers_add_unsafe(e->callback_data);
                 }
 #ifndef ENABLE_JSONC
             }
@@ -177,10 +177,12 @@ int health_silencers_json_read_callback(JSON_ENTRY *e)
  * @return It returns 0 on success and -1 otherwise
  */
 int health_initialize_global_silencers() {
+    rw_spinlock_write_lock(&silencers_rw_spinlock);
     silencers = mallocz(sizeof(SILENCERS));
     silencers->all_alarms = 0;
     silencers->stype = STYPE_NONE;
     silencers->silencers = NULL;
+    rw_spinlock_write_unlock(&silencers_rw_spinlock);
 
     return 0;
 }
@@ -194,7 +196,7 @@ int health_initialize_global_silencers() {
  *
  * @param t is the structure that will be cleaned.
  */
-void free_silencers(SILENCER *t) {
+static void free_silencers_unsafe(SILENCER *t) {
     if (!t) return;
 
     while(t) {
@@ -212,6 +214,12 @@ void free_silencers(SILENCER *t) {
 
         t = next;
     }
+}
+
+void free_silencers(SILENCER *t) {
+    rw_spinlock_write_lock(&silencers_rw_spinlock);
+    free_silencers_unsafe(t);
+    rw_spinlock_write_unlock(&silencers_rw_spinlock);
 }
 
 /**
@@ -242,7 +250,7 @@ int health_silencers2json_entry(BUFFER *wb, char* var, char* val, int hasprev) {
  *
  * @param wb is the buffer to write the silencers.
  */
-void health_silencers2json(BUFFER *wb) {
+static void health_silencers2json_unsafe(BUFFER *wb) {
     buffer_sprintf(wb, "{\n\t\"all\": %s,"
                        "\n\t\"type\": \"%s\","
                        "\n\t\"silencers\": [",
@@ -264,6 +272,12 @@ void health_silencers2json(BUFFER *wb) {
     }
     if(likely(i)) buffer_strcat(wb, "\n\t");
     buffer_strcat(wb, "]\n}\n");
+}
+
+void health_silencers2json(BUFFER *wb) {
+    rw_spinlock_read_lock(&silencers_rw_spinlock);
+    health_silencers2json_unsafe(wb);
+    rw_spinlock_read_unlock(&silencers_rw_spinlock);
 }
 
 
@@ -304,6 +318,7 @@ int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, c
     (void) host;
 
     BUFFER *wb = w->response.data;
+    BUFFER *jsonb = NULL;
     buffer_flush(wb);
     wb->content_type = CT_TEXT_PLAIN;
 
@@ -322,6 +337,7 @@ int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, c
             buffer_strcat(wb, HEALTH_CMDAPI_MSG_AUTHERROR);
             ret = HTTP_RESP_FORBIDDEN;
         } else {
+            rw_spinlock_write_lock(&silencers_rw_spinlock);
             while (url) {
                 char *value = strsep_skip_consecutive_separators(&url, "&");
                 if (!value || !*value) continue;
@@ -351,12 +367,12 @@ int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, c
                     } else if (!strcmp(value, HEALTH_CMDAPI_CMD_RESET)) {
                         silencers->all_alarms = 0;
                         silencers->stype = STYPE_NONE;
-                        free_silencers(silencers->silencers);
+                        free_silencers_unsafe(silencers->silencers);
                         silencers->silencers = NULL;
                         buffer_strcat(wb, HEALTH_CMDAPI_MSG_RESET);
                     } else if (!strcmp(value, HEALTH_CMDAPI_CMD_LIST)) {
                         w->response.data->content_type = CT_APPLICATION_JSON;
-                        health_silencers2json(wb);
+                        health_silencers2json_unsafe(wb);
                         config_changed=0;
                     }
                 } else {
@@ -365,7 +381,7 @@ int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, c
             }
 
             if (likely(silencer)) {
-                health_silencers_add(silencer);
+                health_silencers_add_unsafe(silencer);
                 buffer_strcat(wb, HEALTH_CMDAPI_MSG_ADDED);
                 if (silencers->stype == STYPE_NONE) {
                     buffer_strcat(wb, HEALTH_CMDAPI_MSG_STYPEWARNING);
@@ -375,13 +391,16 @@ int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, c
                 buffer_strcat(wb, HEALTH_CMDAPI_MSG_NOSELECTORWARNING);
             }
             ret = HTTP_RESP_OK;
+            if (config_changed) {
+                jsonb = buffer_create(200, &netdata_buffers_statistics.buffers_health);
+                health_silencers2json_unsafe(jsonb);
+            }
+            rw_spinlock_write_unlock(&silencers_rw_spinlock);
         }
     }
     w->response.data = wb;
     buffer_no_cacheable(w->response.data);
-    if (ret == HTTP_RESP_OK && config_changed) {
-        BUFFER *jsonb = buffer_create(200, &netdata_buffers_statistics.buffers_health);
-        health_silencers2json(jsonb);
+    if (ret == HTTP_RESP_OK && jsonb) {
         health_silencers2file(jsonb);
         buffer_free(jsonb);
     }
@@ -417,7 +436,9 @@ void health_silencers_init(void) {
                 copied = fread(str, sizeof(char), length, fd);
                 if (copied == (length* sizeof(char))) {
                     str[length] = 0x00;
+                    rw_spinlock_write_lock(&silencers_rw_spinlock);
                     json_parse(str, NULL, health_silencers_json_read_callback);
+                    rw_spinlock_write_unlock(&silencers_rw_spinlock);
                     netdata_log_info("Parsed health silencers file %s", health_silencers_filename());
                 } else {
                     netdata_log_error("Cannot read the data from health silencers file %s", health_silencers_filename());
@@ -437,7 +458,7 @@ void health_silencers_init(void) {
     }
 }
 
-SILENCE_TYPE health_silencers_check_silenced(RRDCALC *rc, const char *host) {
+static SILENCE_TYPE health_silencers_check_silenced_unsafe(RRDCALC *rc, const char *host) {
     SILENCER *s;
 
     for (s = silencers->silencers; s!=NULL; s=s->next){
@@ -465,18 +486,26 @@ SILENCE_TYPE health_silencers_check_silenced(RRDCALC *rc, const char *host) {
     return STYPE_NONE;
 }
 
+SILENCE_TYPE health_silencers_check_silenced(RRDCALC *rc, const char *host) {
+    rw_spinlock_read_lock(&silencers_rw_spinlock);
+    SILENCE_TYPE st = health_silencers_check_silenced_unsafe(rc, host);
+    rw_spinlock_read_unlock(&silencers_rw_spinlock);
+
+    return st;
+}
+
 int health_silencers_update_disabled_silenced(RRDHOST *host, RRDCALC *rc) {
     uint32_t rrdcalc_flags_old = rc->run_flags;
     // Clear the flags
     rc->run_flags &= ~(RRDCALC_FLAG_DISABLED | RRDCALC_FLAG_SILENCED);
-    if (unlikely(silencers->all_alarms)) {
-        if (silencers->stype == STYPE_DISABLE_ALARMS) rc->run_flags |= RRDCALC_FLAG_DISABLED;
-        else if (silencers->stype == STYPE_SILENCE_NOTIFICATIONS) rc->run_flags |= RRDCALC_FLAG_SILENCED;
-    } else {
-        SILENCE_TYPE st = health_silencers_check_silenced(rc, rrdhost_hostname(host));
-        if (st == STYPE_DISABLE_ALARMS) rc->run_flags |= RRDCALC_FLAG_DISABLED;
-        else if (st == STYPE_SILENCE_NOTIFICATIONS) rc->run_flags |= RRDCALC_FLAG_SILENCED;
-    }
+
+    rw_spinlock_read_lock(&silencers_rw_spinlock);
+    SILENCE_TYPE st =
+        silencers->all_alarms ? silencers->stype : health_silencers_check_silenced_unsafe(rc, rrdhost_hostname(host));
+    rw_spinlock_read_unlock(&silencers_rw_spinlock);
+
+    if (st == STYPE_DISABLE_ALARMS) rc->run_flags |= RRDCALC_FLAG_DISABLED;
+    else if (st == STYPE_SILENCE_NOTIFICATIONS) rc->run_flags |= RRDCALC_FLAG_SILENCED;
 
     if (rrdcalc_flags_old != rc->run_flags) {
         netdata_log_info(
@@ -492,4 +521,12 @@ int health_silencers_update_disabled_silenced(RRDHOST *host, RRDCALC *rc) {
         return 1;
     else
         return 0;
+}
+
+bool health_silencers_all_alarms_disabled(void) {
+    rw_spinlock_read_lock(&silencers_rw_spinlock);
+    bool ret = silencers->all_alarms && silencers->stype == STYPE_DISABLE_ALARMS;
+    rw_spinlock_read_unlock(&silencers_rw_spinlock);
+
+    return ret;
 }

--- a/src/health/health_silencers.h
+++ b/src/health/health_silencers.h
@@ -36,7 +36,6 @@ typedef struct silencers {
 extern SILENCERS *silencers;
 
 SILENCER *create_silencer(void);
-int health_silencers_json_read_callback(JSON_ENTRY *e);
 void health_silencers_add(SILENCER *silencer);
 SILENCER * health_silencers_addparam(SILENCER *silencer, char *key, char *value);
 int health_initialize_global_silencers();
@@ -51,5 +50,6 @@ void health_set_silencers_filename(void);
 void health_silencers_init(void);
 SILENCE_TYPE health_silencers_check_silenced(RRDCALC *rc, const char *host);
 int health_silencers_update_disabled_silenced(RRDHOST *host, RRDCALC *rc);
+bool health_silencers_all_alarms_disabled(void);
 
 #endif //NETDATA_HEALTH_SILENCERS_H

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -264,8 +264,8 @@ static void rrdcalc_link_to_rrdset(RRDCALC *rc) {
         0,
         rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0);
 
-    health_log_alert(host, ae);
     health_alarm_log_add_entry(host, ae, true);
+    health_log_alert(host, ae);
     rrdset_flag_set(st, RRDSET_FLAG_HAS_RRDCALC_LINKED);
 }
 
@@ -287,11 +287,11 @@ static void rrdcalc_unlink_from_rrdset(RRDCALC *rc, bool having_ll_wrlock) {
                 rc->value,
                 rc->status,
                 RRDCALC_STATUS_REMOVED,
-                0,
-                0);
+                    0,
+                    0);
 
-            health_log_alert(host, ae);
             health_alarm_log_add_entry(host, ae, true);
+            health_log_alert(host, ae);
         }
     }
 

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -61,32 +61,53 @@ inline const char *rrdcalc_status2string(RRDCALC_STATUS status) {
     }
 }
 
+static ALARM_ENTRY *rrdcalc_find_alarm_entry(RRDHOST *host, STRING *chart, STRING *name, nd_uuid_t *config_hash_id) {
+    for(ALARM_ENTRY *ae = host->health_log.alarms; ae ;ae = ae->next) {
+        if(unlikely(name == ae->name && chart == ae->chart && uuid_eq(ae->config_hash_id, *config_hash_id)))
+            return ae;
+    }
+
+    return NULL;
+}
+
 uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id, nd_uuid_t *config_hash_id) {
     rw_spinlock_read_lock(&host->health_log.spinlock);
 
     // re-use old IDs, by looking them up in the alarm log
-    ALARM_ENTRY *ae = NULL;
-    for(ae = host->health_log.alarms; ae ;ae = ae->next) {
-        if(unlikely(name == ae->name && chart == ae->chart && uuid_eq(ae->config_hash_id, *config_hash_id))) {
-            if(next_event_id) *next_event_id = ae->alarm_event_id + 1;
-            break;
-        }
-    }
+    ALARM_ENTRY *ae = rrdcalc_find_alarm_entry(host, chart, name, config_hash_id);
 
-    uint32_t alarm_id;
-
-    if(ae)
-        alarm_id = ae->alarm_id;
-    else {
-        alarm_id = sql_get_alarm_id(host, chart, name, next_event_id);
-        if (!alarm_id) {
-            if (unlikely(!host->health_log.next_alarm_id))
-                host->health_log.next_alarm_id = get_uint32_id();
-            alarm_id = host->health_log.next_alarm_id++;
-        }
+    if(ae) {
+        uint32_t alarm_id = ae->alarm_id;
+        if(next_event_id) *next_event_id = ae->alarm_event_id + 1;
+        rw_spinlock_read_unlock(&host->health_log.spinlock);
+        return alarm_id;
     }
 
     rw_spinlock_read_unlock(&host->health_log.spinlock);
+
+    uint32_t sql_next_event_id = next_event_id ? *next_event_id : 0;
+    uint32_t sql_alarm_id = sql_get_alarm_id(host, chart, name, &sql_next_event_id);
+
+    rw_spinlock_write_lock(&host->health_log.spinlock);
+
+    ae = rrdcalc_find_alarm_entry(host, chart, name, config_hash_id);
+
+    uint32_t alarm_id;
+    if(ae) {
+        alarm_id = ae->alarm_id;
+        if(next_event_id) *next_event_id = ae->alarm_event_id + 1;
+    }
+    else if(sql_alarm_id) {
+        alarm_id = sql_alarm_id;
+        if(next_event_id) *next_event_id = sql_next_event_id;
+    }
+    else {
+        if (unlikely(!host->health_log.next_alarm_id))
+            host->health_log.next_alarm_id = get_uint32_id();
+        alarm_id = host->health_log.next_alarm_id++;
+    }
+
+    rw_spinlock_write_unlock(&host->health_log.spinlock);
     return alarm_id;
 }
 

--- a/src/libnetdata/log/nd_log-init.c
+++ b/src/libnetdata/log/nd_log-init.c
@@ -307,7 +307,7 @@ void nd_log_reopen_log_files(bool log) {
 }
 
 int nd_log_systemd_journal_fd(void) {
-    return nd_log.journal.fd;
+    return __atomic_load_n(&nd_log.journal.fd, __ATOMIC_ACQUIRE);
 }
 
 void nd_log_reopen_log_files_for_spawn_server(const char *name) {

--- a/src/libnetdata/log/nd_log-to-systemd-journal.c
+++ b/src/libnetdata/log/nd_log-to-systemd-journal.c
@@ -154,28 +154,49 @@ bool nd_logger_journal_libsystemd(struct log_field *fields __maybe_unused, size_
         }
     }
 
-    static bool sockets_before[1024];
-    bool detect_systemd_socket = __atomic_load_n(&nd_log.journal.first_msg, __ATOMIC_RELAXED) == false;
+    static SPINLOCK first_msg_spinlock = SPINLOCK_INITIALIZER;
+    bool detection_lock_acquired = false;
+    bool detect_systemd_socket = __atomic_load_n(&nd_log.journal.first_msg, __ATOMIC_ACQUIRE) == false;
+
     if(detect_systemd_socket) {
-        for(int i = 3 ; (size_t)i < _countof(sockets_before); i++)
-            sockets_before[i] = fd_is_socket(i);
-    }
+        spinlock_lock(&first_msg_spinlock);
+        detection_lock_acquired = true;
 
-    int r = sd_journal_sendv(iov, iov_count);
-
-    if(r == 0 && detect_systemd_socket) {
-        __atomic_store_n(&nd_log.journal.first_msg, true, __ATOMIC_RELAXED);
-
-        // this is the first successful libsystemd log
-        // let's detect its fd number (we need it for the spawn server)
-
-        for(int i = 3 ; (size_t)i < _countof(sockets_before); i++) {
-            if (!sockets_before[i] && fd_is_socket(i)) {
-                nd_log.journal.fd = i;
-                break;
-            }
+        detect_systemd_socket = __atomic_load_n(&nd_log.journal.first_msg, __ATOMIC_ACQUIRE) == false;
+        if(!detect_systemd_socket) {
+            spinlock_unlock(&first_msg_spinlock);
+            detection_lock_acquired = false;
         }
     }
+
+    int r;
+    if(detect_systemd_socket) {
+        bool sockets_before[1024] = { 0 };
+
+        for(int i = 3 ; (size_t)i < _countof(sockets_before); i++)
+            sockets_before[i] = fd_is_socket(i);
+
+        r = sd_journal_sendv(iov, iov_count);
+
+        if(r == 0) {
+            // this is the first successful libsystemd log
+            // let's detect its fd number (we need it for the spawn server)
+
+            for(int i = 3 ; (size_t)i < _countof(sockets_before); i++) {
+                if (!sockets_before[i] && fd_is_socket(i)) {
+                    __atomic_store_n(&nd_log.journal.fd, i, __ATOMIC_RELEASE);
+                    break;
+                }
+            }
+
+            __atomic_store_n(&nd_log.journal.first_msg, true, __ATOMIC_RELEASE);
+        }
+    }
+    else
+        r = sd_journal_sendv(iov, iov_count);
+
+    if(detection_lock_acquired)
+        spinlock_unlock(&first_msg_spinlock);
 
     for (int i = 0; i < iov_count; i++)
         free(iov[i].iov_base);

--- a/src/streaming/protocol/command-claimed_id.c
+++ b/src/streaming/protocol/command-claimed_id.c
@@ -45,10 +45,8 @@ PARSER_RC stream_receiver_pluginsd_claimed_id(char **words, size_t num_words, PA
         return PARSER_RC_OK;
     }
 
-    if(!uuid_is_null(claim_uuid)) {
-        uuid_copy(host->aclk.claim_id_of_origin.uuid, claim_uuid);
-        stream_sender_send_claimed_id(host);
-    }
+    rrdhost_claim_id_of_origin_set(host, uuid2UUID(claim_uuid));
+    stream_sender_send_claimed_id(host);
 
     return PARSER_RC_OK;
 }
@@ -63,7 +61,7 @@ void stream_sender_send_claimed_id(RRDHOST *host) {
     CLEAN_BUFFER *wb = buffer_create(0, NULL);
 
     char str[UUID_STR_LEN] = "";
-    ND_UUID uuid = host->aclk.claim_id_of_origin;
+    ND_UUID uuid = rrdhost_claim_id_of_origin_get(host);
     if(!UUIDiszero(uuid))
         uuid_unparse_lower(uuid.uuid, str);
     else

--- a/src/streaming/protocol/command-nodeid.c
+++ b/src/streaming/protocol/command-nodeid.c
@@ -7,12 +7,11 @@
 
 // the child disconnected from the parent, and it has to clear the parent's claim id
 void stream_sender_clear_parent_claim_id(RRDHOST *host) {
-    if (!UUIDiszero(host->aclk.claim_id_of_parent)) {
+    ND_UUID previous_claim_id;
+    if (rrdhost_claim_id_of_parent_update(host, UUID_ZERO, &previous_claim_id) && !UUIDiszero(previous_claim_id)) {
         nd_log(NDLS_DAEMON, NDLP_INFO,
                "Host '%s' [PCLAIMID] cleared parent's claim id",
                rrdhost_hostname(host));
-
-        host->aclk.claim_id_of_parent = UUID_ZERO;
     }
 }
 
@@ -31,7 +30,7 @@ void stream_receiver_send_node_and_claim_id_to_child(RRDHOST *host) {
             // the agent is not claimed or not connected, just use parent claim id
             // to allow the connection flow.
             // this may be zero and it is ok.
-            claim_id.uuid = host->aclk.claim_id_of_parent;
+            claim_id.uuid = rrdhost_claim_id_of_parent_get(host);
             uuid_unparse_lower(claim_id.uuid.uuid, claim_id.str);
         }
 
@@ -100,8 +99,9 @@ void stream_sender_get_node_and_claim_id_from_parent(struct sender_state *s, con
     // the parameters are ok
     // apply the changes
 
-    if (!UUIDeq(s->host->aclk.claim_id_of_parent, claim_id)) {
-        if(UUIDiszero(s->host->aclk.claim_id_of_parent))
+    ND_UUID previous_claim_id;
+    if (rrdhost_claim_id_of_parent_update(s->host, claim_id, &previous_claim_id)) {
+        if(UUIDiszero(previous_claim_id))
             nd_log(NDLS_DAEMON, NDLP_INFO,
                    "STREAM SND '%s' [to %s] [PCLAIMID] set parent's claim id to %s (was empty)",
                    rrdhost_hostname(s->host), s->remote_ip,
@@ -111,8 +111,6 @@ void stream_sender_get_node_and_claim_id_from_parent(struct sender_state *s, con
                    "STREAM SND '%s' [to %s] [PCLAIMID] changed parent's claim id to %s (was set)",
                    rrdhost_hostname(s->host), s->remote_ip,
                    claim_id_str ? claim_id_str : "(unset)");
-
-        s->host->aclk.claim_id_of_parent = claim_id;
     }
 
     if(!UUIDiszero(s->host->node_id) && !UUIDeq(s->host->node_id, node_id)) {

--- a/src/web/api/http_auth.c
+++ b/src/web/api/http_auth.c
@@ -52,7 +52,7 @@ static void bearer_token_cleanup(bool force) {
     time_t now_s = now_realtime_sec();
 
     struct bearer_token *z;
-    dfe_start_read(netdata_authorized_bearers, z) {
+    dfe_start_write(netdata_authorized_bearers, z) {
         if(z->expires_s < now_s) {
             nd_uuid_t uuid;
             if(uuid_parse_flexi(z_dfe.name, uuid) == 0)

--- a/src/web/api/v1/api_v1_allmetrics.c
+++ b/src/web/api/v1/api_v1_allmetrics.c
@@ -93,10 +93,17 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, const char *filter_
 
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
-        if(!rc->rrdset) continue;
+        RRDSET *alert_st = rc->rrdset;
+        if(!alert_st) continue;
+
+        rw_spinlock_read_lock(&alert_st->alerts.spinlock);
+        if(unlikely(rc->rrdset != alert_st)) {
+            rw_spinlock_read_unlock(&alert_st->alerts.spinlock);
+            continue;
+        }
 
         char chart[SHELL_ELEMENT_MAX + 1];
-        shell_name_copy(chart, rc->rrdset->name?rrdset_name(rc->rrdset):rrdset_id(rc->rrdset), SHELL_ELEMENT_MAX);
+        shell_name_copy(chart, alert_st->name?rrdset_name(alert_st):rrdset_id(alert_st), SHELL_ELEMENT_MAX);
 
         char alarm[SHELL_ELEMENT_MAX + 1];
         shell_name_copy(alarm, rrdcalc_name(rc), SHELL_ELEMENT_MAX);
@@ -111,6 +118,7 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, const char *filter_
         }
 
         buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_STATUS=\"%s\"\n", chart, alarm, rrdcalc_status2string(rc->status));
+        rw_spinlock_read_unlock(&alert_st->alerts.spinlock);
     }
     foreach_rrdcalc_in_rrdhost_done(rc);
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple concurrency issues across claim IDs, health silencers/alarms, logging, and API paths to remove races, stale state, and a crash without changing intended behavior.

- **Bug Fixes**
  - Claim IDs: added per-host ACLK spinlock with getters/setters; unified parent update; propagate `NULL` from `CLAIMED_ID` receiver; initialize lock in `rrdhost_create`; updated `cloud-status`, streaming, and claim paths to use accessors.
  - Health silencers: introduced RW spinlock; serialize add/list/reset/free and file load; build JSON snapshot under the write lock and write to disk after; added `health_silencers_all_alarms_disabled()`; health evaluation now reads silencer state under a read lock (prevents UAF/data races).
  - Health alarms/log: serialized `next_alarm_id` and `next_log_id`; assign `unique_id` and insert entries in order under the same write lock; update the previous same-alert entry while locked; added `health_alarm_entry_assign_unique_id()` and used it for repeat notifications; snapshot `latest_alarm_log_unique_id` under a read lock; event loop logs now add the entry before sending alerts.
  - rrdcalc IDs: reworked `rrdcalc_get_unique_id()` to scan under read lock, query SQL outside locks, then recheck under write lock to avoid duplicate IDs; adjusted link/unlink to log after adding the entry.
  - API stability: guarded shell allmetrics alert chart lookups with the chart alerts read lock and pointer recheck to avoid a NULL dereference.
  - Systemd journal logging: serialized first-message fd detection with a private spinlock; moved socket snapshot to stack; published fd with release ordering; `nd_log_systemd_journal_fd()` now uses an acquire load.
  - Auth cleanup: switched bearer cleanup to a write iterator so deletions happen under the correct mutation-capable traversal.

<sup>Written for commit f4624845895326d551f57319aee77f4cb2de08a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

