### PR TITLE
fix(go.d): unify histogram bucket dimension names

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -116,9 +116,10 @@ source files for evidence.
   Netdata metrics. Suffix inference is only a fallback and MUST NOT be used as
   the correctness mechanism for V2 collector charts.
 - Histogram bucket charts use range bucket values from `metrix.ReadFlatten()`
-  and chartengine forces them to `heatmap`. Bucket dimensions are ordered by
-  numeric upper bound with `+Inf` last. Do NOT add collector-local
-  cumulative-bucket workaround metrics or a bucket-mode option for V2 charts.
+  and chartengine forces them to `heatmap`. Bucket dimensions are named by the
+  bare `le` upper-bound value and ordered numerically with `+Inf` last. Do NOT
+  add collector-local cumulative-bucket workaround metrics or a bucket-mode
+  option for V2 charts.
 - Put multipliers, divisors, hidden flags, and float formatting in the chart
   template, not ad hoc chart-emission code.
 - `metrix` registers a descriptor per metric NAME permanently (no unregister), so

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -177,8 +177,10 @@ Default lifecycle policy when template omits lifecycle:
 Histogram bucket charts use non-overlapping range bucket totals from
 `metrix.ReadFlatten()` and are emitted as `heatmap` charts in both autogen and
 template-driven paths. The `le` label remains the upper-bound identity for the
-bucket dimension. Bucket dimensions are ordered by numeric upper bound with
-`+Inf` last, not by lexical dimension name.
+bucket dimension. Autogen and template-inferred bucket dimensions are named by
+the bare `le` value (for example `0.005`, `0.025`, `+Inf`). Bucket dimensions
+are ordered by numeric upper bound with `+Inf` last, not by lexical dimension
+name.
 
 `MeasureSet` autogen specifics:
 

--- a/src/go/plugin/framework/chartengine/autogen.go
+++ b/src/go/plugin/framework/chartengine/autogen.go
@@ -288,7 +288,7 @@ func buildHistogramBucketAutogenRoute(
 	return autogenRoute{
 		chartID:           chartID,
 		chartName:         baseName,
-		dimensionName:     "bucket_" + upperBound,
+		dimensionName:     upperBound,
 		dimensionKeyLabel: metrix.HistogramBucketLabel,
 		algorithm:         program.AlgorithmIncremental,
 		units:             "observations/s",

--- a/src/go/plugin/framework/chartengine/autogen_test.go
+++ b/src/go/plugin/framework/chartengine/autogen_test.go
@@ -102,7 +102,7 @@ func runTestBuildHistogramBucketAutogenRoute(t *testing.T) {
 		wantID     string
 		wantDim    string
 	}{
-		"histogram bucket excludes le from chart id and uses bucket dimension": {
+		"histogram bucket excludes le from chart id and uses upper-bound dimension": {
 			metricName: "svc.latency_seconds_bucket",
 			labels: map[string]string{
 				"instance": "db1",
@@ -110,7 +110,7 @@ func runTestBuildHistogramBucketAutogenRoute(t *testing.T) {
 				"method":   "GET",
 			},
 			wantID:  "svc.latency_seconds-instance=db1-method=GET",
-			wantDim: "bucket_0.5",
+			wantDim: "0.5",
 		},
 	}
 

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -1624,8 +1624,8 @@ groups:
 			}
 		}
 	}
-	assert.Equal(t, []string{"bucket_1", "bucket_2", "bucket_10", "bucket_+Inf"}, dims)
-	assert.Equal(t, []string{"bucket_1", "bucket_2", "bucket_10", "bucket_+Inf"}, updateDims)
+	assert.Equal(t, []string{"1", "2", "10", "+Inf"}, dims)
+	assert.Equal(t, []string{"1", "2", "10", "+Inf"}, updateDims)
 }
 
 func runTestBuildPlanAutogenCreatesChartForUnmatchedGauge(t *testing.T) {

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -532,7 +532,7 @@ charts:
 Histogram `_bucket` dimensions receive non-overlapping range bucket totals from
 `metrix.ReadFlatten()`. The `le` label remains the bucket upper bound, but the
 value is no longer cumulative with earlier buckets. Histogram bucket dimensions
-are ordered by numeric `le` value with `+Inf` last.
+are named by the bare `le` value and ordered numerically, with `+Inf` last.
 
 > [!WARNING]
 > If a chart's dimensions mix counter-like metrics (e.g., `requests_total`) with gauge-like metrics (e.g., `temperature`) and `algorithm` is omitted, the engine fails with a compile error: _"algorithm inference is ambiguous for mixed metric kinds; set algorithm explicitly"_. Set `algorithm` on the chart to resolve this.

--- a/src/go/plugin/go.d/collector/prometheus/testdata/golden/histogram.json
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/golden/histogram.json
@@ -6,12 +6,12 @@
     },
     "dims": [
       {
-        "name": "bucket_+Inf",
+        "name": "+Inf",
         "algo": "incremental",
         "value": 2
       },
       {
-        "name": "bucket_0.1",
+        "name": "0.1",
         "algo": "incremental",
         "value": 4
       }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies histogram bucket dimension names to the bare `le` value (e.g., `0.1`, `+Inf`) across `chartengine` autogen and template paths, ordered numerically with `+Inf` last. Removes the `bucket_` prefix for consistent heatmap dimensions and clearer docs/tests.

- **Refactors**
  - `chartengine` autogen sets `dimensionName` to the `le` value; tests and Prometheus histogram golden updated.
  - Docs updated in `chartengine/README.md`, `charttpl/README.md`, and SKILL to describe naming and ordering.

- **Migration**
  - If you reference bucket dimension names (dashboards, alerts, overrides), replace `bucket_<value>` with `<value>`.

<sup>Written for commit 834547d9f7e965e59866bf123836cc8c69f52c8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

