### PR TITLE
feat(go.d/cloudwatch): add stock health alerts

### DIFF
--- a/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
@@ -371,7 +371,39 @@ jobs:
 
 ## Alerts
 
-There are no alerts configured by default for this integration.
+
+The following alerts are available:
+
+| Alert name  | On metric | Description |
+|:------------|:----------|:------------|
+| [ cw_ec2_status_check_failed ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.ec2.status_check_failed | EC2 status check failed on ${label:instance_id} |
+| [ cw_ec2_attached_ebs_status_check_failed ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.ec2.status_check_failed | EC2 attached EBS status check failed on ${label:instance_id} |
+| [ cw_nat_gateway_port_allocation_errors ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.nat_gateway.errors | NAT Gateway port allocation errors on ${label:nat_gateway_id} |
+| [ cw_efs_io_limit_reached ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.efs.io_limit | EFS I/O limit reached on ${label:file_system_id} |
+| [ cw_efs_burst_credits_exhausted ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.efs.burst_credit | EFS burst credits exhausted on ${label:file_system_id} |
+| [ cw_ecs_cpu_utilization ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.ecs.utilization | ECS service CPU utilization high on ${label:cluster_name}/${label:service_name} |
+| [ cw_ecs_memory_utilization ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.ecs.utilization | ECS service memory utilization high on ${label:cluster_name}/${label:service_name} |
+| [ cw_ecs_ebs_filesystem_utilization ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.ecs.ebs_filesystem_utilization | ECS EBS filesystem utilization high on ${label:cluster_name}/${label:service_name} |
+| [ cw_opensearch_cluster_status_red ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.opensearch.cluster_status | OpenSearch cluster red on ${label:domain_name} |
+| [ cw_opensearch_cluster_status_yellow ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.opensearch.cluster_status | OpenSearch cluster yellow on ${label:domain_name} |
+| [ cw_opensearch_index_writes_blocked ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.opensearch.index_writes_blocked | OpenSearch index writes blocked on ${label:domain_name} |
+| [ cw_opensearch_jvm_memory_pressure ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.opensearch.jvm_memory_pressure | OpenSearch JVM memory pressure high on ${label:domain_name} |
+| [ cw_opensearch_cpu_utilization ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.opensearch.cpu | OpenSearch CPU utilization high on ${label:domain_name} |
+| [ cw_opensearch_automated_snapshot_failure ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.opensearch.automated_snapshot_failure | OpenSearch automated snapshot failed on ${label:domain_name} |
+| [ cw_opensearch_old_gen_jvm_memory_pressure ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.opensearch.old_gen_jvm_memory_pressure | OpenSearch old-gen JVM memory pressure high on ${label:domain_name} |
+| [ cw_elasticache_engine_cpu_utilization ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.elasticache.cpu | ElastiCache engine CPU utilization high on ${label:cache_cluster_id}/${label:cache_node_id} |
+| [ cw_msk_cpu_utilization ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.msk.cpu | MSK broker CPU utilization high on ${label:cluster_name}/${label:broker_id} |
+| [ cw_msk_data_logs_disk_used ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.msk.disk_used | MSK broker data-log disk utilization high on ${label:cluster_name}/${label:broker_id} |
+| [ cw_msk_heap_memory_after_gc ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.msk.heap_memory_after_gc | MSK broker heap memory after GC high on ${label:cluster_name}/${label:broker_id} |
+| [ cw_rds_replica_lag ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.rds.replica_lag | RDS replica lag high on ${label:db_instance_identifier} |
+| [ cw_rds_maximum_used_transaction_ids ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.rds.maximum_used_transaction_ids | RDS transaction ID usage high on ${label:db_instance_identifier} |
+| [ cw_rds_ebs_byte_balance ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.rds.ebs_balance | RDS EBS byte balance low on ${label:db_instance_identifier} |
+| [ cw_rds_ebs_io_balance ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.rds.ebs_balance | RDS EBS I/O balance low on ${label:db_instance_identifier} |
+| [ cw_vpn_tunnel_down ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.vpn.tunnel_state | VPN tunnel down on ${label:vpn_id} |
+| [ cw_sns_invalid_notification_attributes ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.sns.invalid_notifications | SNS invalid notification attributes on ${label:topic_name} |
+| [ cw_sns_invalid_notification_body ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.sns.invalid_notifications | SNS invalid notification message body on ${label:topic_name} |
+| [ cw_sns_notifications_redriven_to_dlq ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.sns.dlq_redrive | SNS notifications redriven to DLQ on ${label:topic_name} |
+| [ cw_sns_notifications_failed_to_redrive_to_dlq ](https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf) | cloudwatch.sns.dlq_redrive | SNS notifications failed to redrive to DLQ on ${label:topic_name} |
 
 
 ## Metrics
@@ -390,8 +422,8 @@ The built-in profiles ship the following charts by default. Each service links t
 
 | Profile | Metric prefix | Description |
 |:--------|:--------------|:------------|
-| [Amazon EC2](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ec2.yaml) | `cloudwatch.ec2.*` | CPU utilization, network traffic, disk operations, status-check failures |
-| [Amazon RDS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/rds.yaml) | `cloudwatch.rds.*` | CPU utilization, database connections, freeable memory, free storage space, disk throughput, IOPS, latency |
+| [Amazon EC2](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ec2.yaml) | `cloudwatch.ec2.*` | CPU utilization, network traffic, disk operations, status-check failures, attached-EBS status-check failures |
+| [Amazon RDS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/rds.yaml) | `cloudwatch.rds.*` | CPU utilization, database connections, freeable memory, free storage space, disk throughput, IOPS, latency, replica lag, PostgreSQL transaction ID usage, EBS credit balance |
 | [Classic Load Balancer (ELB)](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/elb.yaml) | `cloudwatch.elb.*` | request count, backend and load-balancer response codes, backend connection errors, latency, host count, spillover count |
 | [Application Load Balancer (ALB)](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/alb.yaml) | `cloudwatch.alb.*` | request count, target and load-balancer response codes, connection rate, active connections, processed traffic, target response time, consumed LCUs |
 | [Network Load Balancer (NLB)](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/nlb.yaml) | `cloudwatch.nlb.*` | active and new flow counts, processed bytes and packets, consumed LCUs, TCP resets |
@@ -404,15 +436,15 @@ The built-in profiles ship the following charts by default. Each service links t
 | [NAT Gateway](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/nat_gateway.yaml) | `cloudwatch.nat_gateway.*` | traffic, active connections, connection rate, errors, idle timeouts |
 | [Amazon Kinesis Data Streams](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/kinesis.yaml) | `cloudwatch.kinesis.*` | data throughput, records, GetRecords iterator age, operation latency, throughput exceeded, PutRecords rejected |
 | [Amazon Data Firehose](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/firehose.yaml) | `cloudwatch.firehose.*` | records, throughput, put requests, throttled records, S3 delivery freshness and success |
-| [Amazon SNS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/sns.yaml) | `cloudwatch.sns.*` | messages published, notifications, published message size |
+| [Amazon SNS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/sns.yaml) | `cloudwatch.sns.*` | messages published, notifications, invalid notification filters, DLQ redrive, published message size |
 | [Amazon EBS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ebs.yaml) | `cloudwatch.ebs.*` | volume throughput, IOPS, queue length, idle time, burst balance |
 | [Amazon EFS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/efs.yaml) | `cloudwatch.efs.*` | I/O throughput, metered vs permitted throughput, percent I/O limit, burst credit balance, client connections |
 | [Amazon ECS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ecs.yaml) | `cloudwatch.ecs.*` | service utilization, EBS filesystem utilization, live task count |
 | [Amazon ElastiCache](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/elasticache.yaml) | `cloudwatch.elasticache.*` | CPU utilization, memory, database memory usage, current and new connections, cache hits and misses, evictions, network traffic |
-| [Amazon OpenSearch Service](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/opensearch.yaml) | `cloudwatch.opensearch.*` | cluster status, index writes blocked, nodes, CPU utilization, JVM memory pressure, free storage space, search and indexing rate, search and indexing latency |
+| [Amazon OpenSearch Service](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/opensearch.yaml) | `cloudwatch.opensearch.*` | cluster status, index writes blocked, automated snapshot failures, nodes, CPU utilization, JVM memory pressure, old-gen JVM memory pressure, free storage space, search and indexing rate, search and indexing latency |
 | [Amazon DocumentDB](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/docdb.yaml) | `cloudwatch.docdb.*` | CPU utilization, freeable memory, connections, buffer cache hit ratio, disk IOPS, latency, throughput, replica lag, cursors timed out |
 | [Amazon Redshift](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/redshift.yaml) | `cloudwatch.redshift.*` | health, CPU utilization, disk space used, database connections, disk IOPS, throughput, network throughput |
-| [Amazon MSK](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/msk.yaml) | `cloudwatch.msk.*` | broker throughput, messages in, CPU, disk used, memory, partitions, connections |
+| [Amazon MSK](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/msk.yaml) | `cloudwatch.msk.*` | broker throughput, messages in, CPU, disk used, memory, heap memory after GC, partitions, connections |
 | [Amazon CloudFront](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/cloudfront.yaml) | `cloudwatch.cloudfront.*` | requests, downloaded and uploaded traffic, total/4xx/5xx error rates |
 | [AWS Auto Scaling](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/auto_scaling.yaml) | `cloudwatch.auto_scaling.*` | group sizing (min/max/desired/total) and instances by state (in-service, pending, standby, terminating) |
 | [Amazon Bedrock](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/bedrock.yaml) | `cloudwatch.bedrock.*` | invocations, invocation errors, token throughput, invocation and time-to-first-token latency |

--- a/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
@@ -389,7 +389,119 @@ modules:
               - Verify the credentials selected by `auth.mode` are valid and not expired.
               - For `assume_role`, confirm the base identity is allowed to `sts:AssumeRole` the target role and that the role's trust policy permits it.
               - For AWS GovCloud or China partitions, ensure every region in `regions` belongs to the same partition.
-    alerts: []
+    alerts:
+      - name: cw_ec2_status_check_failed
+        metric: cloudwatch.ec2.status_check_failed
+        info: "EC2 status check failed on ${label:instance_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_ec2_attached_ebs_status_check_failed
+        metric: cloudwatch.ec2.status_check_failed
+        info: "EC2 attached EBS status check failed on ${label:instance_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_nat_gateway_port_allocation_errors
+        metric: cloudwatch.nat_gateway.errors
+        info: "NAT Gateway port allocation errors on ${label:nat_gateway_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_efs_io_limit_reached
+        metric: cloudwatch.efs.io_limit
+        info: "EFS I/O limit reached on ${label:file_system_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_efs_burst_credits_exhausted
+        metric: cloudwatch.efs.burst_credit
+        info: "EFS burst credits exhausted on ${label:file_system_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_ecs_cpu_utilization
+        metric: cloudwatch.ecs.utilization
+        info: "ECS service CPU utilization high on ${label:cluster_name}/${label:service_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_ecs_memory_utilization
+        metric: cloudwatch.ecs.utilization
+        info: "ECS service memory utilization high on ${label:cluster_name}/${label:service_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_ecs_ebs_filesystem_utilization
+        metric: cloudwatch.ecs.ebs_filesystem_utilization
+        info: "ECS EBS filesystem utilization high on ${label:cluster_name}/${label:service_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_opensearch_cluster_status_red
+        metric: cloudwatch.opensearch.cluster_status
+        info: "OpenSearch cluster red on ${label:domain_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_opensearch_cluster_status_yellow
+        metric: cloudwatch.opensearch.cluster_status
+        info: "OpenSearch cluster yellow on ${label:domain_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_opensearch_index_writes_blocked
+        metric: cloudwatch.opensearch.index_writes_blocked
+        info: "OpenSearch index writes blocked on ${label:domain_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_opensearch_jvm_memory_pressure
+        metric: cloudwatch.opensearch.jvm_memory_pressure
+        info: "OpenSearch JVM memory pressure high on ${label:domain_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_opensearch_cpu_utilization
+        metric: cloudwatch.opensearch.cpu
+        info: "OpenSearch CPU utilization high on ${label:domain_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_opensearch_automated_snapshot_failure
+        metric: cloudwatch.opensearch.automated_snapshot_failure
+        info: "OpenSearch automated snapshot failed on ${label:domain_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_opensearch_old_gen_jvm_memory_pressure
+        metric: cloudwatch.opensearch.old_gen_jvm_memory_pressure
+        info: "OpenSearch old-gen JVM memory pressure high on ${label:domain_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_elasticache_engine_cpu_utilization
+        metric: cloudwatch.elasticache.cpu
+        info: "ElastiCache engine CPU utilization high on ${label:cache_cluster_id}/${label:cache_node_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_msk_cpu_utilization
+        metric: cloudwatch.msk.cpu
+        info: "MSK broker CPU utilization high on ${label:cluster_name}/${label:broker_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_msk_data_logs_disk_used
+        metric: cloudwatch.msk.disk_used
+        info: "MSK broker data-log disk utilization high on ${label:cluster_name}/${label:broker_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_msk_heap_memory_after_gc
+        metric: cloudwatch.msk.heap_memory_after_gc
+        info: "MSK broker heap memory after GC high on ${label:cluster_name}/${label:broker_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_rds_replica_lag
+        metric: cloudwatch.rds.replica_lag
+        info: "RDS replica lag high on ${label:db_instance_identifier}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_rds_maximum_used_transaction_ids
+        metric: cloudwatch.rds.maximum_used_transaction_ids
+        info: "RDS transaction ID usage high on ${label:db_instance_identifier}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_rds_ebs_byte_balance
+        metric: cloudwatch.rds.ebs_balance
+        info: "RDS EBS byte balance low on ${label:db_instance_identifier}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_rds_ebs_io_balance
+        metric: cloudwatch.rds.ebs_balance
+        info: "RDS EBS I/O balance low on ${label:db_instance_identifier}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_vpn_tunnel_down
+        metric: cloudwatch.vpn.tunnel_state
+        info: "VPN tunnel down on ${label:vpn_id}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_sns_invalid_notification_attributes
+        metric: cloudwatch.sns.invalid_notifications
+        info: "SNS invalid notification attributes on ${label:topic_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_sns_invalid_notification_body
+        metric: cloudwatch.sns.invalid_notifications
+        info: "SNS invalid notification message body on ${label:topic_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_sns_notifications_redriven_to_dlq
+        metric: cloudwatch.sns.dlq_redrive
+        info: "SNS notifications redriven to DLQ on ${label:topic_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
+      - name: cw_sns_notifications_failed_to_redrive_to_dlq
+        metric: cloudwatch.sns.dlq_redrive
+        info: "SNS notifications failed to redrive to DLQ on ${label:topic_name}"
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cloudwatch.conf
     metrics:
       folding:
         title: Metrics
@@ -409,8 +521,8 @@ modules:
 
         | Profile | Metric prefix | Description |
         |:--------|:--------------|:------------|
-        | [Amazon EC2](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ec2.yaml) | `cloudwatch.ec2.*` | CPU utilization, network traffic, disk operations, status-check failures |
-        | [Amazon RDS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/rds.yaml) | `cloudwatch.rds.*` | CPU utilization, database connections, freeable memory, free storage space, disk throughput, IOPS, latency |
+        | [Amazon EC2](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ec2.yaml) | `cloudwatch.ec2.*` | CPU utilization, network traffic, disk operations, status-check failures, attached-EBS status-check failures |
+        | [Amazon RDS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/rds.yaml) | `cloudwatch.rds.*` | CPU utilization, database connections, freeable memory, free storage space, disk throughput, IOPS, latency, replica lag, PostgreSQL transaction ID usage, EBS credit balance |
         | [Classic Load Balancer (ELB)](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/elb.yaml) | `cloudwatch.elb.*` | request count, backend and load-balancer response codes, backend connection errors, latency, host count, spillover count |
         | [Application Load Balancer (ALB)](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/alb.yaml) | `cloudwatch.alb.*` | request count, target and load-balancer response codes, connection rate, active connections, processed traffic, target response time, consumed LCUs |
         | [Network Load Balancer (NLB)](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/nlb.yaml) | `cloudwatch.nlb.*` | active and new flow counts, processed bytes and packets, consumed LCUs, TCP resets |
@@ -423,15 +535,15 @@ modules:
         | [NAT Gateway](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/nat_gateway.yaml) | `cloudwatch.nat_gateway.*` | traffic, active connections, connection rate, errors, idle timeouts |
         | [Amazon Kinesis Data Streams](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/kinesis.yaml) | `cloudwatch.kinesis.*` | data throughput, records, GetRecords iterator age, operation latency, throughput exceeded, PutRecords rejected |
         | [Amazon Data Firehose](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/firehose.yaml) | `cloudwatch.firehose.*` | records, throughput, put requests, throttled records, S3 delivery freshness and success |
-        | [Amazon SNS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/sns.yaml) | `cloudwatch.sns.*` | messages published, notifications, published message size |
+        | [Amazon SNS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/sns.yaml) | `cloudwatch.sns.*` | messages published, notifications, invalid notification filters, DLQ redrive, published message size |
         | [Amazon EBS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ebs.yaml) | `cloudwatch.ebs.*` | volume throughput, IOPS, queue length, idle time, burst balance |
         | [Amazon EFS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/efs.yaml) | `cloudwatch.efs.*` | I/O throughput, metered vs permitted throughput, percent I/O limit, burst credit balance, client connections |
         | [Amazon ECS](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ecs.yaml) | `cloudwatch.ecs.*` | service utilization, EBS filesystem utilization, live task count |
         | [Amazon ElastiCache](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/elasticache.yaml) | `cloudwatch.elasticache.*` | CPU utilization, memory, database memory usage, current and new connections, cache hits and misses, evictions, network traffic |
-        | [Amazon OpenSearch Service](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/opensearch.yaml) | `cloudwatch.opensearch.*` | cluster status, index writes blocked, nodes, CPU utilization, JVM memory pressure, free storage space, search and indexing rate, search and indexing latency |
+        | [Amazon OpenSearch Service](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/opensearch.yaml) | `cloudwatch.opensearch.*` | cluster status, index writes blocked, automated snapshot failures, nodes, CPU utilization, JVM memory pressure, old-gen JVM memory pressure, free storage space, search and indexing rate, search and indexing latency |
         | [Amazon DocumentDB](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/docdb.yaml) | `cloudwatch.docdb.*` | CPU utilization, freeable memory, connections, buffer cache hit ratio, disk IOPS, latency, throughput, replica lag, cursors timed out |
         | [Amazon Redshift](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/redshift.yaml) | `cloudwatch.redshift.*` | health, CPU utilization, disk space used, database connections, disk IOPS, throughput, network throughput |
-        | [Amazon MSK](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/msk.yaml) | `cloudwatch.msk.*` | broker throughput, messages in, CPU, disk used, memory, partitions, connections |
+        | [Amazon MSK](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/msk.yaml) | `cloudwatch.msk.*` | broker throughput, messages in, CPU, disk used, memory, heap memory after GC, partitions, connections |
         | [Amazon CloudFront](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/cloudfront.yaml) | `cloudwatch.cloudfront.*` | requests, downloaded and uploaded traffic, total/4xx/5xx error rates |
         | [AWS Auto Scaling](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/auto_scaling.yaml) | `cloudwatch.auto_scaling.*` | group sizing (min/max/desired/total) and instances by state (in-service, pending, standby, terminating) |
         | [Amazon Bedrock](https://github.com/netdata/netdata/blob/master/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/bedrock.yaml) | `cloudwatch.bedrock.*` | invocations, invocation errors, token throughput, invocation and time-to-first-token latency |

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ec2.yaml
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/ec2.yaml
@@ -30,6 +30,9 @@ metrics:
   - id: status_check_failed
     metric_name: StatusCheckFailed
     statistics: [maximum]
+  - id: status_check_failed_attached_ebs
+    metric_name: StatusCheckFailed_AttachedEBS
+    statistics: [maximum]
   # ----------------------------------------------------------------------------------------
   # Optional metrics (disabled by default). To enable one, uncomment its block here AND the
   # matching chart in the charts: section below, then restart the go.d process. All are
@@ -129,6 +132,8 @@ template:
       dimensions:
         - selector: status_check_failed_maximum
           name: failed
+        - selector: status_check_failed_attached_ebs_maximum
+          name: attached_ebs
     # ----------------------------------------------------------------------------------------
     # Charts for the optional metrics above. Uncomment a chart together with its metric.
     # ----------------------------------------------------------------------------------------

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/msk.yaml
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/msk.yaml
@@ -43,6 +43,9 @@ metrics:
   - id: memory_free
     metric_name: MemoryFree
     statistics: [average]
+  - id: heap_memory_after_gc
+    metric_name: HeapMemoryAfterGC
+    statistics: [average]
   - id: under_replicated_partitions
     metric_name: UnderReplicatedPartitions
     statistics: [maximum]
@@ -134,6 +137,15 @@ template:
           name: used
         - selector: memory_free_average
           name: free
+    - id: cw_msk_heap_memory_after_gc
+      context: heap_memory_after_gc
+      title: MSK Broker Heap Memory After GC
+      family: Memory
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: heap_memory_after_gc_average
+          name: used
     - id: cw_msk_partitions
       context: partitions
       title: MSK Broker Partitions

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/opensearch.yaml
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/opensearch.yaml
@@ -24,7 +24,7 @@ metrics:
     statistics: [maximum]
   - id: cpu_utilization
     metric_name: CPUUtilization
-    statistics: [average]
+    statistics: [average, maximum]
   - id: jvm_memory_pressure
     metric_name: JVMMemoryPressure
     statistics: [maximum]
@@ -46,6 +46,12 @@ metrics:
   - id: indexing_latency
     metric_name: IndexingLatency
     statistics: [average]
+  - id: old_gen_jvm_memory_pressure
+    metric_name: OldGenJVMMemoryPressure
+    statistics: [maximum]
+  - id: automated_snapshot_failure
+    metric_name: AutomatedSnapshotFailure
+    statistics: [maximum]
   # ----------------------------------------------------------------------------------------
   # Optional metrics (disabled by default). To enable one, uncomment its block here AND the
   # matching chart in the charts: section below. All are published at the {ClientId, DomainName}
@@ -57,17 +63,11 @@ metrics:
   # - id: deleted_documents
   #   metric_name: DeletedDocuments
   #   statistics: [maximum]
-  # - id: old_gen_jvm_memory_pressure
-  #   metric_name: OldGenJVMMemoryPressure
-  #   statistics: [maximum]
   # - id: shards_active
   #   metric_name: Shards.active
   #   statistics: [maximum]
   # - id: shards_unassigned
   #   metric_name: Shards.unassigned
-  #   statistics: [maximum]
-  # - id: automated_snapshot_failure
-  #   metric_name: AutomatedSnapshotFailure
   #   statistics: [maximum]
   # Thread-pool queues/rejections (ThreadpoolSearchQueue/Rejected, ...), EBS I/O metrics (ReadLatency,
   # WriteThroughput, ...), and dedicated-master (Master*), UltraWarm (Warm*), cold-storage (Cold*) and
@@ -120,6 +120,8 @@ template:
       dimensions:
         - selector: cpu_utilization_average
           name: cpu
+        - selector: cpu_utilization_maximum
+          name: maximum
     - id: cw_os_jvm_pressure
       context: jvm_memory_pressure
       title: OpenSearch JVM Memory Pressure
@@ -160,6 +162,24 @@ template:
           name: search
         - selector: indexing_latency_average
           name: indexing
+    - id: cw_os_old_gen_jvm_pressure
+      context: old_gen_jvm_memory_pressure
+      title: OpenSearch Old-Gen JVM Memory Pressure
+      family: JVM
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: old_gen_jvm_memory_pressure_maximum
+          name: pressure
+    - id: cw_os_snapshot_failure
+      context: automated_snapshot_failure
+      title: OpenSearch Automated Snapshot Failure
+      family: Health
+      units: status
+      algorithm: absolute
+      dimensions:
+        - selector: automated_snapshot_failure_maximum
+          name: failure
     # ----------------------------------------------------------------------------------------
     # Charts for the optional metrics above. Uncomment a chart together with its metric.
     # ----------------------------------------------------------------------------------------
@@ -185,21 +205,3 @@ template:
     #       name: active
     #     - selector: shards_unassigned_maximum
     #       name: unassigned
-    # - id: cw_os_old_gen_jvm_pressure
-    #   context: old_gen_jvm_memory_pressure
-    #   title: OpenSearch Old-Gen JVM Memory Pressure
-    #   family: JVM
-    #   units: percentage
-    #   algorithm: absolute
-    #   dimensions:
-    #     - selector: old_gen_jvm_memory_pressure_maximum
-    #       name: pressure
-    # - id: cw_os_snapshot_failure
-    #   context: automated_snapshot_failure
-    #   title: OpenSearch Automated Snapshot Failure
-    #   family: Health
-    #   units: status
-    #   algorithm: absolute
-    #   dimensions:
-    #     - selector: automated_snapshot_failure_maximum
-    #       name: failure

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/rds.yaml
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/rds.yaml
@@ -38,6 +38,18 @@ metrics:
   - id: write_latency
     metric_name: WriteLatency
     statistics: [average]
+  - id: replica_lag               # read replicas only, seconds
+    metric_name: ReplicaLag
+    statistics: [maximum]
+  - id: maximum_used_transaction_ids  # PostgreSQL only
+    metric_name: MaximumUsedTransactionIDs
+    statistics: [average]
+  - id: ebs_byte_balance          # RDS storage throughput credits, percent
+    metric_name: EBSByteBalance%
+    statistics: [average]
+  - id: ebs_io_balance            # RDS storage I/O credits, percent
+    metric_name: EBSIOBalance%
+    statistics: [average]
   # ----------------------------------------------------------------------------------------
   # Optional metrics (disabled by default). To enable one, uncomment its block here AND the
   # matching chart in the charts: section below, then restart the go.d process. All are
@@ -58,9 +70,6 @@ metrics:
   # - id: burst_balance             # gp2 storage burst credits, percent
   #   metric_name: BurstBalance
   #   statistics: [average]
-  # - id: replica_lag               # read replicas only, seconds
-  #   metric_name: ReplicaLag
-  #   statistics: [average]
   # - id: cpu_credit_usage          # burstable (db.t*) instances only
   #   metric_name: CPUCreditUsage
   #   statistics: [average]
@@ -69,8 +78,8 @@ metrics:
   #   statistics: [average]
   # Engine- and storage-specific metrics are also published at {DBInstanceIdentifier} and can be
   # added the same way: BinLogDiskUsage (MySQL/MariaDB); TempDb* and FailedSQLServerAgentJobsCount
-  # (SQL Server); MaximumUsedTransactionIDs, *ReplicationSlot*, TransactionLogs* (PostgreSQL); and
-  # the *LogVolume / *LocalStorage families. See:
+  # (SQL Server); *ReplicationSlot*, TransactionLogs* (PostgreSQL); and the *LogVolume /
+  # *LocalStorage families. See:
   # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-metrics.html
 template:
   family: RDS
@@ -148,6 +157,35 @@ template:
           name: read
         - selector: write_latency_average
           name: write
+    - id: cw_rds_replica_lag
+      context: replica_lag
+      title: RDS Replica Lag
+      family: Replication
+      units: seconds
+      algorithm: absolute
+      dimensions:
+        - selector: replica_lag_maximum
+          name: lag
+    - id: cw_rds_transaction_ids
+      context: maximum_used_transaction_ids
+      title: RDS Maximum Used Transaction IDs
+      family: Transactions
+      units: transactions
+      algorithm: absolute
+      dimensions:
+        - selector: maximum_used_transaction_ids_average
+          name: used
+    - id: cw_rds_ebs_balance
+      context: ebs_balance
+      title: RDS EBS Credit Balance
+      family: Credits
+      units: percentage
+      algorithm: absolute
+      dimensions:
+        - selector: ebs_byte_balance_average
+          name: byte
+        - selector: ebs_io_balance_average
+          name: io
     # ----------------------------------------------------------------------------------------
     # Charts for the optional metrics above. Uncomment a chart together with its metric.
     # ----------------------------------------------------------------------------------------
@@ -189,15 +227,6 @@ template:
     #   dimensions:
     #     - selector: burst_balance_average
     #       name: balance
-    # - id: cw_rds_replica_lag
-    #   context: replica_lag
-    #   title: RDS Replica Lag
-    #   family: Replication
-    #   units: seconds
-    #   algorithm: absolute
-    #   dimensions:
-    #     - selector: replica_lag_average
-    #       name: lag
     # - id: cw_rds_cpu_credits
     #   context: cpu_credits
     #   title: RDS CPU Credits

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/sns.yaml
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/sns.yaml
@@ -24,23 +24,30 @@ metrics:
     metric_name: NumberOfNotificationsFilteredOut
     statistics: [sum]
     rate: true
+  - id: number_of_notifications_filtered_out_invalid_attributes
+    metric_name: NumberOfNotificationsFilteredOut-InvalidAttributes
+    statistics: [sum]
+    rate: true
+  - id: number_of_notifications_filtered_out_invalid_message_body
+    metric_name: NumberOfNotificationsFilteredOut-InvalidMessageBody
+    statistics: [sum]
+    rate: true
+  - id: number_of_notifications_redriven_to_dlq
+    metric_name: NumberOfNotificationsRedrivenToDlq
+    statistics: [sum]
+    rate: true
+  - id: number_of_notifications_failed_to_redrive_to_dlq
+    metric_name: NumberOfNotificationsFailedToRedriveToDlq
+    statistics: [sum]
+    rate: true
   - id: publish_size
     metric_name: PublishSize
     statistics: [average]
   # ----------------------------------------------------------------------------------------
-  # Optional metrics (disabled by default). To enable one, uncomment its block here AND the
-  # matching chart in the charts: section below. All are published at the {TopicName} grain.
+  # Additional filtered-out breakdown metrics at the {TopicName} grain can be added the same way.
   # ----------------------------------------------------------------------------------------
-  # - id: number_of_notifications_redriven_to_dlq
-  #   metric_name: NumberOfNotificationsRedrivenToDlq
-  #   statistics: [sum]
-  #   rate: true
-  # - id: number_of_notifications_failed_to_redrive_to_dlq
-  #   metric_name: NumberOfNotificationsFailedToRedriveToDlq
-  #   statistics: [sum]
-  #   rate: true
   # Filtered-out breakdowns (NumberOfNotificationsFilteredOut-MessageAttributes / -MessageBody /
-  # -InvalidAttributes / -NoMessageAttributes) are also at {TopicName}. SMS (PhoneNumber grain),
+  # -NoMessageAttributes) are also at {TopicName}. SMS (PhoneNumber grain),
   # mobile-push (Application/Platform grains), and account-level SMS spend need their own profiles.
   # See: https://docs.aws.amazon.com/sns/latest/dg/sns-monitoring-using-cloudwatch.html
 template:
@@ -81,17 +88,25 @@ template:
       dimensions:
         - selector: publish_size_average
           name: size
-    # ----------------------------------------------------------------------------------------
-    # Charts for the optional metrics above. Uncomment a chart together with its metric.
-    # ----------------------------------------------------------------------------------------
-    # - id: cw_sns_dlq
-    #   context: dlq_redrive
-    #   title: SNS Dead-Letter Queue Redrive
-    #   family: Notifications
-    #   units: notifications/s
-    #   algorithm: absolute
-    #   dimensions:
-    #     - selector: number_of_notifications_redriven_to_dlq_sum
-    #       name: redriven
-    #     - selector: number_of_notifications_failed_to_redrive_to_dlq_sum
-    #       name: failed_redrive
+    - id: cw_sns_invalid_notifications
+      context: invalid_notifications
+      title: SNS Invalid Notifications
+      family: Notifications
+      units: notifications/s
+      algorithm: absolute
+      dimensions:
+        - selector: number_of_notifications_filtered_out_invalid_attributes_sum
+          name: invalid_attributes
+        - selector: number_of_notifications_filtered_out_invalid_message_body_sum
+          name: invalid_message_body
+    - id: cw_sns_dlq
+      context: dlq_redrive
+      title: SNS Dead-Letter Queue Redrive
+      family: Notifications
+      units: notifications/s
+      algorithm: absolute
+      dimensions:
+        - selector: number_of_notifications_redriven_to_dlq_sum
+          name: redriven
+        - selector: number_of_notifications_failed_to_redrive_to_dlq_sum
+          name: failed_redrive

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/vpn.yaml
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.profiles/default/vpn.yaml
@@ -25,7 +25,7 @@ metrics:
     rate: true
   - id: tunnel_state
     metric_name: TunnelState
-    statistics: [average]
+    statistics: [average, minimum]
 template:
   family: VPN
   context_namespace: vpn
@@ -53,3 +53,5 @@ template:
       dimensions:
         - selector: tunnel_state_average
           name: up
+        - selector: tunnel_state_minimum
+          name: minimum

--- a/src/health/health.d/cloudwatch.conf
+++ b/src/health/health.d/cloudwatch.conf
@@ -1,0 +1,479 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+# AWS CloudWatch metrics are delayed. These alerts use sustained lookups against
+# the currently shipped stock profile periods instead of lowering collection
+# periods and increasing CloudWatch query cost.
+
+# --- EC2 ---
+
+# AWS recommended: StatusCheckFailed Maximum >= 1, 300s period, 2/2 datapoints.
+
+ template: cw_ec2_status_check_failed
+       on: cloudwatch.ec2.status_check_failed
+    class: Availability
+     type: Other
+component: AWS EC2
+   lookup: min -10m unaligned of failed
+    units: status
+    every: 1m
+     crit: $this != nan AND $this >= 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: EC2 status check failed on ${label:instance_id}
+     info: EC2 instance ${label:instance_id} in ${label:region} has failed AWS status checks.
+       to: sysadmin
+
+# AWS recommended: StatusCheckFailed_AttachedEBS Maximum >= 1, 60s period, 10/10 datapoints.
+# Current stock profile period is 300s, so this preserves 10 datapoints as a 50m window.
+
+ template: cw_ec2_attached_ebs_status_check_failed
+       on: cloudwatch.ec2.status_check_failed
+    class: Availability
+     type: Other
+component: AWS EC2
+   lookup: min -50m unaligned of attached_ebs
+    units: status
+    every: 1m
+     crit: $this != nan AND $this >= 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: EC2 attached EBS status check failed on ${label:instance_id}
+     info: EC2 instance ${label:instance_id} in ${label:region} has an attached EBS volume failing AWS status checks.
+       to: sysadmin
+
+# --- NAT Gateway ---
+
+# AWS recommended: ErrorPortAllocation Sum > 0, 60s period, 15/15 datapoints.
+# The profile stores CloudWatch sums as rates; any sustained non-zero rate means errors occurred.
+
+ template: cw_nat_gateway_port_allocation_errors
+       on: cloudwatch.nat_gateway.errors
+    class: Errors
+     type: Other
+component: AWS NAT Gateway
+   lookup: min -15m unaligned of port_allocation
+    units: errors/s
+    every: 1m
+     crit: $this != nan AND $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: NAT Gateway port allocation errors on ${label:nat_gateway_id}
+     info: NAT Gateway ${label:nat_gateway_id} in ${label:region} is reporting source-port allocation failures.
+       to: sysadmin
+
+# --- EFS ---
+
+# AWS recommended: PercentIOLimit Average >= 100, 60s period, 15/15 datapoints.
+
+ template: cw_efs_io_limit_reached
+       on: cloudwatch.efs.io_limit
+    class: Utilization
+     type: Other
+component: AWS EFS
+   lookup: min -15m unaligned of io_limit
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this >= 100
+    delay: down 5m multiplier 1.5 max 1h
+  summary: EFS I/O limit reached on ${label:file_system_id}
+     info: EFS file system ${label:file_system_id} in ${label:region} is at its AWS PercentIOLimit threshold.
+       to: sysadmin
+
+# AWS recommended: BurstCreditBalance Average <= 0, 60s period, 15/15 datapoints.
+
+ template: cw_efs_burst_credits_exhausted
+       on: cloudwatch.efs.burst_credit
+    class: Utilization
+     type: Other
+component: AWS EFS
+   lookup: max -15m unaligned of balance
+    units: bytes
+    every: 1m
+     warn: $this != nan AND $this <= 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: EFS burst credits exhausted on ${label:file_system_id}
+     info: EFS file system ${label:file_system_id} in ${label:region} has exhausted burst credits.
+       to: sysadmin
+
+# --- ECS ---
+
+# AWS recommended: CPUUtilization Average > 80, 60s period, 5/5 datapoints.
+# Current stock profile period is 300s, so this preserves 5 datapoints as a 25m window.
+
+ template: cw_ecs_cpu_utilization
+       on: cloudwatch.ecs.utilization
+    class: Utilization
+     type: Other
+component: AWS ECS
+   lookup: min -25m unaligned of cpu
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > 80
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ECS service CPU utilization high on ${label:cluster_name}/${label:service_name}
+     info: ECS service ${label:service_name} in cluster ${label:cluster_name} (${label:region}) has sustained CPU utilization above the AWS recommended alarm threshold.
+       to: sysadmin
+
+# AWS recommended: MemoryUtilization Average > 80, 60s period, 5/5 datapoints.
+
+ template: cw_ecs_memory_utilization
+       on: cloudwatch.ecs.utilization
+    class: Utilization
+     type: Other
+component: AWS ECS
+   lookup: min -25m unaligned of memory
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > 80
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ECS service memory utilization high on ${label:cluster_name}/${label:service_name}
+     info: ECS service ${label:service_name} in cluster ${label:cluster_name} (${label:region}) has sustained memory utilization above the AWS recommended alarm threshold.
+       to: sysadmin
+
+# AWS recommended: EBSFilesystemUtilization Average > 80, 60s period, 5/5 datapoints.
+
+ template: cw_ecs_ebs_filesystem_utilization
+       on: cloudwatch.ecs.ebs_filesystem_utilization
+    class: Utilization
+     type: Other
+component: AWS ECS
+   lookup: min -25m unaligned of ebs_filesystem
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > 80
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ECS EBS filesystem utilization high on ${label:cluster_name}/${label:service_name}
+     info: ECS service ${label:service_name} in cluster ${label:cluster_name} (${label:region}) has sustained EBS filesystem utilization above the AWS recommended alarm threshold.
+       to: sysadmin
+
+# --- OpenSearch ---
+
+# AWS recommended: ClusterStatus.red Maximum >= 1, 1 datapoint.
+
+ template: cw_opensearch_cluster_status_red
+       on: cloudwatch.opensearch.cluster_status
+    class: Availability
+     type: Other
+component: AWS OpenSearch
+   lookup: max -5m unaligned of red
+    units: status
+    every: 1m
+     crit: $this != nan AND $this >= 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: OpenSearch cluster red on ${label:domain_name}
+     info: OpenSearch domain ${label:domain_name} in ${label:region} is reporting red cluster status.
+       to: sysadmin
+
+# AWS recommended: ClusterStatus.yellow Maximum >= 1 for sustained datapoints.
+
+ template: cw_opensearch_cluster_status_yellow
+       on: cloudwatch.opensearch.cluster_status
+    class: Availability
+     type: Other
+component: AWS OpenSearch
+   lookup: min -15m unaligned of yellow
+    units: status
+    every: 1m
+     warn: $this != nan AND $this >= 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: OpenSearch cluster yellow on ${label:domain_name}
+     info: OpenSearch domain ${label:domain_name} in ${label:region} is reporting yellow cluster status.
+       to: sysadmin
+
+# AWS recommended: ClusterIndexWritesBlocked Maximum >= 1.
+
+ template: cw_opensearch_index_writes_blocked
+       on: cloudwatch.opensearch.index_writes_blocked
+    class: Errors
+     type: Other
+component: AWS OpenSearch
+   lookup: max -5m unaligned of blocked
+    units: status
+    every: 1m
+     crit: $this != nan AND $this >= 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: OpenSearch index writes blocked on ${label:domain_name}
+     info: OpenSearch domain ${label:domain_name} in ${label:region} is blocking index write requests.
+       to: sysadmin
+
+# AWS recommended: JVMMemoryPressure Maximum >= 95, 60s period, 3/3 datapoints.
+
+ template: cw_opensearch_jvm_memory_pressure
+       on: cloudwatch.opensearch.jvm_memory_pressure
+    class: Utilization
+     type: Other
+component: AWS OpenSearch
+   lookup: min -15m unaligned of pressure
+    units: percentage
+    every: 1m
+     crit: $this != nan AND $this >= 95
+    delay: down 5m multiplier 1.5 max 1h
+  summary: OpenSearch JVM memory pressure high on ${label:domain_name}
+     info: OpenSearch domain ${label:domain_name} in ${label:region} has sustained JVM memory pressure above the AWS recommended alarm threshold.
+       to: sysadmin
+
+# AWS recommended: CPUUtilization Maximum >= 80, sustained 15m.
+
+ template: cw_opensearch_cpu_utilization
+       on: cloudwatch.opensearch.cpu
+    class: Utilization
+     type: Other
+component: AWS OpenSearch
+   lookup: min -15m unaligned of maximum
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this >= 80
+    delay: down 5m multiplier 1.5 max 1h
+  summary: OpenSearch CPU utilization high on ${label:domain_name}
+     info: OpenSearch domain ${label:domain_name} in ${label:region} has sustained maximum CPU utilization above the AWS recommended alarm threshold.
+       to: sysadmin
+
+# AWS recommended: AutomatedSnapshotFailure Maximum >= 1, 1 datapoint.
+
+ template: cw_opensearch_automated_snapshot_failure
+       on: cloudwatch.opensearch.automated_snapshot_failure
+    class: Errors
+     type: Other
+component: AWS OpenSearch
+   lookup: max -5m unaligned of failure
+    units: status
+    every: 1m
+     warn: $this != nan AND $this >= 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: OpenSearch automated snapshot failed on ${label:domain_name}
+     info: OpenSearch domain ${label:domain_name} in ${label:region} has a failed automated snapshot.
+       to: sysadmin
+
+# AWS recommended: OldGenJVMMemoryPressure Maximum >= 80, 60s period, 3/3 datapoints.
+
+ template: cw_opensearch_old_gen_jvm_memory_pressure
+       on: cloudwatch.opensearch.old_gen_jvm_memory_pressure
+    class: Utilization
+     type: Other
+component: AWS OpenSearch
+   lookup: min -15m unaligned of pressure
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this >= 80
+    delay: down 5m multiplier 1.5 max 1h
+  summary: OpenSearch old-gen JVM memory pressure high on ${label:domain_name}
+     info: OpenSearch domain ${label:domain_name} in ${label:region} has sustained old-generation JVM memory pressure above the AWS recommended alarm threshold.
+       to: sysadmin
+
+# --- ElastiCache ---
+
+# AWS recommended: EngineCPUUtilization Average > 90, 60s period, 5/5 datapoints.
+# Current stock profile period is 300s, so this preserves 5 datapoints as a 25m window.
+
+ template: cw_elasticache_engine_cpu_utilization
+       on: cloudwatch.elasticache.cpu
+    class: Utilization
+     type: Other
+component: AWS ElastiCache
+   lookup: min -25m unaligned of engine
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > 90
+    delay: down 5m multiplier 1.5 max 1h
+  summary: ElastiCache engine CPU utilization high on ${label:cache_cluster_id}/${label:cache_node_id}
+     info: ElastiCache node ${label:cache_cluster_id}/${label:cache_node_id} in ${label:region} has sustained engine CPU utilization above the AWS recommended alarm threshold.
+       to: sysadmin
+
+# --- MSK ---
+
+# AWS best practice: keep broker CpuUser + CpuSystem under 60%.
+
+ template: cw_msk_cpu_utilization
+       on: cloudwatch.msk.cpu
+    class: Utilization
+     type: Other
+component: AWS MSK
+   lookup: min -15m unaligned of user,system
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > 60
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MSK broker CPU utilization high on ${label:cluster_name}/${label:broker_id}
+     info: MSK broker ${label:broker_id} in cluster ${label:cluster_name} (${label:region}) has sustained CpuUser plus CpuSystem above the AWS best-practice threshold.
+       to: sysadmin
+
+# AWS best practice: create an alarm when KafkaDataLogsDiskUsed reaches 85%.
+
+ template: cw_msk_data_logs_disk_used
+       on: cloudwatch.msk.disk_used
+    class: Utilization
+     type: Other
+component: AWS MSK
+   lookup: min -15m unaligned of data_logs
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this >= 85
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MSK broker data-log disk utilization high on ${label:cluster_name}/${label:broker_id}
+     info: MSK broker ${label:broker_id} in cluster ${label:cluster_name} (${label:region}) has sustained data-log disk utilization above the AWS best-practice threshold.
+       to: sysadmin
+
+# AWS best practice: alarm when HeapMemoryAfterGC is above 60%.
+
+ template: cw_msk_heap_memory_after_gc
+       on: cloudwatch.msk.heap_memory_after_gc
+    class: Utilization
+     type: Other
+component: AWS MSK
+   lookup: min -15m unaligned of used
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this > 60
+    delay: down 5m multiplier 1.5 max 1h
+  summary: MSK broker heap memory after GC high on ${label:cluster_name}/${label:broker_id}
+     info: MSK broker ${label:broker_id} in cluster ${label:cluster_name} (${label:region}) has sustained heap memory after GC above the AWS best-practice threshold.
+       to: sysadmin
+
+# --- RDS ---
+
+# AWS recommended: ReplicaLag Maximum > 60s, 60s period, 10/10 datapoints.
+# Current stock profile period is 300s, so this preserves 10 datapoints as a 50m window.
+
+ template: cw_rds_replica_lag
+       on: cloudwatch.rds.replica_lag
+    class: Latency
+     type: Other
+component: AWS RDS
+   lookup: min -50m unaligned of lag
+    units: seconds
+    every: 1m
+     warn: $this != nan AND $this > 60
+    delay: down 5m multiplier 1.5 max 1h
+  summary: RDS replica lag high on ${label:db_instance_identifier}
+     info: RDS instance ${label:db_instance_identifier} in ${label:region} has sustained replica lag above the AWS recommended alarm threshold.
+       to: sysadmin
+
+# AWS recommended: MaximumUsedTransactionIDs Average > 1e9, 60s period, 1 datapoint.
+
+ template: cw_rds_maximum_used_transaction_ids
+       on: cloudwatch.rds.maximum_used_transaction_ids
+    class: Errors
+     type: Other
+component: AWS RDS
+   lookup: max -5m unaligned of used
+    units: transactions
+    every: 1m
+     crit: $this != nan AND $this > 1000000000
+    delay: down 5m multiplier 1.5 max 1h
+  summary: RDS transaction ID usage high on ${label:db_instance_identifier}
+     info: RDS instance ${label:db_instance_identifier} in ${label:region} is above the AWS recommended transaction ID alarm threshold.
+       to: sysadmin
+
+# AWS recommended: EBSByteBalance% Average < 10, 60s period, 3/3 datapoints.
+
+ template: cw_rds_ebs_byte_balance
+       on: cloudwatch.rds.ebs_balance
+    class: Utilization
+     type: Other
+component: AWS RDS
+   lookup: max -15m unaligned of byte
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this < 10
+    delay: down 5m multiplier 1.5 max 1h
+  summary: RDS EBS byte balance low on ${label:db_instance_identifier}
+     info: RDS instance ${label:db_instance_identifier} in ${label:region} has sustained EBS byte balance below the AWS recommended alarm threshold.
+       to: sysadmin
+
+# AWS recommended: EBSIOBalance% Average < 10, 60s period, 3/3 datapoints.
+
+ template: cw_rds_ebs_io_balance
+       on: cloudwatch.rds.ebs_balance
+    class: Utilization
+     type: Other
+component: AWS RDS
+   lookup: max -15m unaligned of io
+    units: percentage
+    every: 1m
+     warn: $this != nan AND $this < 10
+    delay: down 5m multiplier 1.5 max 1h
+  summary: RDS EBS I/O balance low on ${label:db_instance_identifier}
+     info: RDS instance ${label:db_instance_identifier} in ${label:region} has sustained EBS I/O balance below the AWS recommended alarm threshold.
+       to: sysadmin
+
+# --- VPN ---
+
+# AWS recommended: TunnelState Minimum < 1, 300s period, 3/3 datapoints.
+
+ template: cw_vpn_tunnel_down
+       on: cloudwatch.vpn.tunnel_state
+    class: Availability
+     type: Other
+component: AWS Site-to-Site VPN
+   lookup: max -15m unaligned of minimum
+    units: status
+    every: 1m
+     crit: $this != nan AND $this < 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: VPN tunnel down on ${label:vpn_id}
+     info: Site-to-Site VPN ${label:vpn_id} in ${label:region} has one or more tunnels down.
+       to: sysadmin
+
+# --- SNS ---
+
+# AWS recommended: NumberOfNotificationsFilteredOut-InvalidAttributes Sum > 0, 60s period, 5/5 datapoints.
+# The profile stores CloudWatch sums as rates; any sustained non-zero rate means filtered notifications occurred.
+
+ template: cw_sns_invalid_notification_attributes
+       on: cloudwatch.sns.invalid_notifications
+    class: Errors
+     type: Other
+component: AWS SNS
+   lookup: min -25m unaligned of invalid_attributes
+    units: notifications/s
+    every: 1m
+     warn: $this != nan AND $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SNS invalid notification attributes on ${label:topic_name}
+     info: SNS topic ${label:topic_name} in ${label:region} has sustained notifications filtered out because of invalid attributes.
+       to: sysadmin
+
+# AWS recommended: NumberOfNotificationsFilteredOut-InvalidMessageBody Sum > 0, 60s period, 5/5 datapoints.
+
+ template: cw_sns_invalid_notification_body
+       on: cloudwatch.sns.invalid_notifications
+    class: Errors
+     type: Other
+component: AWS SNS
+   lookup: min -25m unaligned of invalid_message_body
+    units: notifications/s
+    every: 1m
+     warn: $this != nan AND $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SNS invalid notification message body on ${label:topic_name}
+     info: SNS topic ${label:topic_name} in ${label:region} has sustained notifications filtered out because of invalid message bodies.
+       to: sysadmin
+
+# AWS recommended: NumberOfNotificationsRedrivenToDlq Sum > 0, 60s period, 5/5 datapoints.
+
+ template: cw_sns_notifications_redriven_to_dlq
+       on: cloudwatch.sns.dlq_redrive
+    class: Errors
+     type: Other
+component: AWS SNS
+   lookup: min -25m unaligned of redriven
+    units: notifications/s
+    every: 1m
+     crit: $this != nan AND $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SNS notifications redriven to DLQ on ${label:topic_name}
+     info: SNS topic ${label:topic_name} in ${label:region} has sustained notifications moved to a dead-letter queue.
+       to: sysadmin
+
+# AWS recommended: NumberOfNotificationsFailedToRedriveToDlq Sum > 0, 60s period, 5/5 datapoints.
+
+ template: cw_sns_notifications_failed_to_redrive_to_dlq
+       on: cloudwatch.sns.dlq_redrive
+    class: Errors
+     type: Other
+component: AWS SNS
+   lookup: min -25m unaligned of failed_redrive
+    units: notifications/s
+    every: 1m
+     crit: $this != nan AND $this > 0
+    delay: down 5m multiplier 1.5 max 1h
+  summary: SNS notifications failed to redrive to DLQ on ${label:topic_name}
+     info: SNS topic ${label:topic_name} in ${label:region} has sustained notifications that could not be moved to a dead-letter queue.
+       to: sysadmin


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stock health alerts to the CloudWatch `go.d` integration, covering major AWS services with sane defaults. Expands built-in profiles and docs so users get actionable alerts without extra CloudWatch cost.

- **New Features**
  - Adds preconfigured alerts (health.d/cloudwatch.conf) for EC2, NAT Gateway, EFS, ECS, OpenSearch, ElastiCache, MSK, RDS, VPN, and SNS using sustained windows aligned to shipped collection periods.
  - Extends profiles and charts:
    - EC2: `StatusCheckFailed_AttachedEBS`
    - OpenSearch: `OldGenJVMMemoryPressure`, `AutomatedSnapshotFailure`, CPU maximum dim
    - RDS: `ReplicaLag`, `MaximumUsedTransactionIDs`, `EBSByteBalance%`, `EBSIOBalance%`
    - MSK: `HeapMemoryAfterGC`
    - SNS: invalid notification breakdowns and DLQ redrive metrics
    - VPN: `TunnelState` minimum dim
  - Updates docs and `metadata.yaml` to list the new alerts and enhanced metric coverage.

<sup>Written for commit 9257f8d83a7f87590a7e888d6070f6f2aa8d3e84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

