### PR TITLE
Netdata fixes part 50

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,6 +966,7 @@ set(LIBNETDATA_FILES
         src/libnetdata/aral/aral.h
         src/libnetdata/avl/avl.c
         src/libnetdata/avl/avl.h
+        src/libnetdata/avl/avl-types.h
         src/libnetdata/buffer/buffer.c
         src/libnetdata/buffer/buffer.h
         src/libnetdata/buffer/functions_fields.c

--- a/src/database/rrdfunctions-exporters.c
+++ b/src/database/rrdfunctions-exporters.c
@@ -165,7 +165,7 @@ void host_functions_to_dict(RRDHOST *host, DICTIONARY *dst, void *value, size_t 
         if(version)
             *version = t->version;
 
-        size_t function_name_len = strlen(t_dfe.name);
+        size_t function_name_len = rrd_functions_strlen_bounded(t_dfe.name, PLUGINSD_LINE_MAX);
         if(unlikely(function_name_len > SIZE_MAX - UINT64_MAX_LENGTH - sizeof(RRDFUNCTIONS_VERSION_SEPARATOR)))
             fatal("RRDFUNCTIONS: function key is too large.");
 

--- a/src/database/rrdfunctions-inflight.c
+++ b/src/database/rrdfunctions-inflight.c
@@ -411,7 +411,7 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
     const DICTIONARY_ITEM *host_function_acquired = NULL;
 
     const char *source_to_sanitize = source ? source : "";
-    size_t sanitized_source_size = strlen(source_to_sanitize) + 1;
+    size_t sanitized_source_size = rrd_functions_strlen_bounded(source_to_sanitize, PLUGINSD_LINE_MAX) + 1;
     CLEAN_CHAR_P *sanitized_source = mallocz(sanitized_source_size);
     rrd_functions_sanitize(sanitized_source, source_to_sanitize, sanitized_source_size);
 

--- a/src/database/rrdfunctions-internals.h
+++ b/src/database/rrdfunctions-internals.h
@@ -34,6 +34,14 @@ struct rrd_host_function {
     struct rrd_collector *collector;
 };
 
+static inline size_t rrd_functions_strlen_bounded(const char *s, size_t max) {
+    size_t len = strnlen(s, max + 1);
+    if(unlikely(len > max))
+        fatal("RRDFUNCTIONS: string exceeds maximum supported length.");
+
+    return len;
+}
+
 bool rrd_function_is_available(struct rrd_host_function *rdcf, RRDHOST *host);
 int rrd_functions_find_by_name(RRDHOST *host, BUFFER *wb, const char *name, size_t key_length, const DICTIONARY_ITEM **item);
 

--- a/src/database/rrdfunctions.c
+++ b/src/database/rrdfunctions.c
@@ -234,7 +234,7 @@ void rrd_function_add(RRDHOST *host, RRDSET *st, const char *name, int timeout, 
     if(st && !st->functions_view)
         st->functions_view = dictionary_create_view(host->functions);
 
-    size_t key_size = strlen(name) + 1;
+    size_t key_size = rrd_functions_strlen_bounded(name, PLUGINSD_LINE_MAX) + 1;
     CLEAN_CHAR_P *key = mallocz(key_size);
     rrd_functions_sanitize(key, name, key_size);
 
@@ -265,7 +265,7 @@ bool rrd_function_del(RRDHOST *host, RRDSET *st, const char *name, bool from_str
     if(unlikely(!name || !*name))
         return false;
 
-    size_t key_size = strlen(name) + 1;
+    size_t key_size = rrd_functions_strlen_bounded(name, PLUGINSD_LINE_MAX) + 1;
     CLEAN_CHAR_P *key = mallocz(key_size);
     rrd_functions_sanitize(key, name, key_size);
 

--- a/src/libnetdata/avl/avl-types.h
+++ b/src/libnetdata/avl/avl-types.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef NETDATA_AVL_TYPES_H
+#define NETDATA_AVL_TYPES_H 1
+
+/* One element of the AVL tree */
+typedef struct avl_element {
+    struct avl_element *avl_link[2];  /* Subtrees. */
+    signed char avl_balance;       /* Balance factor. */
+} avl_t;
+
+typedef struct __attribute__((packed)) avl_element_packed {
+    struct avl_element *avl_link[2];  /* Subtrees. */
+    signed char avl_balance;       /* Balance factor. */
+} avl_t_packed;
+
+#endif /* avl-types.h */

--- a/src/libnetdata/avl/avl.h
+++ b/src/libnetdata/avl/avl.h
@@ -4,6 +4,7 @@
 #define _AVL_H 1
 
 #include "../libnetdata.h"
+#include "avl-types.h"
 
 /* Maximum AVL tree height. */
 #ifndef AVL_MAX_HEIGHT
@@ -15,19 +16,6 @@
 #else
 #define AVL_LOCK_INITIALIZER RW_SPINLOCK_INITIALIZER
 #endif
-
-/* Data structures */
-
-/* One element of the AVL tree */
-typedef struct avl_element {
-    struct avl_element *avl_link[2];  /* Subtrees. */
-    signed char avl_balance;       /* Balance factor. */
-} avl_t;
-
-typedef struct __attribute__((packed)) avl_element_packed {
-    struct avl_element *avl_link[2];  /* Subtrees. */
-    signed char avl_balance;       /* Balance factor. */
-} avl_t_packed;
 
 /* An AVL tree */
 typedef struct avl_tree_type {

--- a/src/libnetdata/memory/nd-mallocz.h
+++ b/src/libnetdata/memory/nd-mallocz.h
@@ -7,6 +7,8 @@
 
 // memory allocation functions that handle failures
 #ifdef NETDATA_TRACE_ALLOCATIONS
+#include "../avl/avl-types.h"
+
 struct malloc_trace {
     avl_t avl;
 
@@ -33,6 +35,8 @@ struct malloc_trace {
 };
 
 int malloc_trace_walkthrough(int (*callback)(void *item, void *data), void *data);
+void malloc_trace_mmap(size_t size);
+void malloc_trace_munmap(size_t size);
 
 #define strdupz(s) strdupz_int(s, __FILE__, __FUNCTION__, __LINE__)
 #define strndupz(s, len) strndupz_int(s, len, __FILE__, __FUNCTION__, __LINE__)


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes NETDATA_TRACE_ALLOCATIONS build failures by separating AVL typedefs and adding missing mmap trace prototypes. Also bounds RRD function temporary string sizes to PLUGINSD_LINE_MAX to prevent unbounded scans and allocations.

- **Bug Fixes**
  - Introduced `avl-types.h` with `avl_t`/`avl_t_packed`, included from `avl.h` and the trace-only block in `nd-mallocz.h`; declared `malloc_trace_mmap()` and `malloc_trace_munmap()`; added the new header to CMake.
  - Added `rrd_functions_strlen_bounded()` and replaced strlen-based sizing in function add/del/export/inflight paths; inputs over `PLUGINSD_LINE_MAX` now fail early; valid callers behave the same.

<sup>Written for commit a00c9962d12c7847331fe39fb1e94ded444c6238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

