### PR TITLE
Netdata fixes part 51

### DIFF
--- a/src/libnetdata/onewayalloc/onewayalloc.c
+++ b/src/libnetdata/onewayalloc/onewayalloc.c
@@ -25,11 +25,16 @@ static size_t onewayalloc_add_or_fatal(size_t size, size_t add, const char *cont
     return size + add;
 }
 
-static size_t onewayalloc_mul_or_fatal(size_t nmemb, size_t size, const char *context) {
+size_t onewayalloc_mul_or_fatal(size_t nmemb, size_t size, const char *context) {
     if(unlikely(size && nmemb > SIZE_MAX / size))
         fatal("ONEWAYALLOC: cannot allocate %s size %zu * %zu.", context, nmemb, size);
 
     return nmemb * size;
+}
+
+size_t onewayalloc_mul3_or_fatal(size_t nmemb1, size_t nmemb2, size_t size, const char *context) {
+    size_t nmemb = onewayalloc_mul_or_fatal(nmemb1, nmemb2, context);
+    return onewayalloc_mul_or_fatal(nmemb, size, context);
 }
 
 static size_t onewayalloc_natural_alignment_or_fatal(size_t size) {

--- a/src/libnetdata/onewayalloc/onewayalloc.h
+++ b/src/libnetdata/onewayalloc/onewayalloc.h
@@ -23,6 +23,9 @@ void onewayalloc_destroy(ONEWAYALLOC *owa);
 // freshly-created arena; the reset path does not relax that contract.
 void onewayalloc_reset(ONEWAYALLOC *owa);
 
+size_t onewayalloc_mul_or_fatal(size_t nmemb, size_t size, const char *context);
+size_t onewayalloc_mul3_or_fatal(size_t nmemb1, size_t nmemb2, size_t size, const char *context);
+
 void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size);
 void *onewayalloc_callocz(ONEWAYALLOC *owa, size_t nmemb, size_t size);
 char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s);

--- a/src/libnetdata/string/string.c
+++ b/src/libnetdata/string/string.c
@@ -341,11 +341,14 @@ STRING *string_strndupz(const char *str, size_t len) {
     if(unlikely(len > STRING_MAX_LENGTH))
         fatal("STRING: cannot index string length %zu, maximum is %zu", len, STRING_MAX_LENGTH);
 
+    size_t length = strnlen(str, len);
+    if(unlikely(!length)) return NULL;
+
     uint8_t partition = string_partition_str(str);
 
-    STRING *string = string_index_search(str, len + 1, partition);
+    STRING *string = string_index_search(str, length + 1, partition);
     while(!string)
-        string = string_index_insert(str, len + 1, partition);
+        string = string_index_insert(str, length + 1, partition);
 
     string_stats_atomic_increment(partition, active_references);
 
@@ -751,6 +754,25 @@ int string_unittest(size_t entries) {
 
     // check string
     {
+        char short_bound[100] = "short";
+        STRING *s_short_bound = string_strndupz(short_bound, sizeof(short_bound));
+        if(!s_short_bound || string_strlen(s_short_bound) != 5 || strcmp(string2str(s_short_bound), "short") != 0) {
+            errors++;
+            fprintf(stderr, "ERROR: strndup string input should stop at NUL before the bound\n");
+        }
+        else
+            fprintf(stderr, "OK: strndup string input stops at NUL before the bound\n");
+        string_freez(s_short_bound);
+
+        STRING *s_substring = string_strndupz("prefix:suffix", 6);
+        if(!s_substring || string_strlen(s_substring) != 6 || strcmp(string2str(s_substring), "prefix") != 0) {
+            errors++;
+            fprintf(stderr, "ERROR: strndup string input should preserve bounded substrings\n");
+        }
+        else
+            fprintf(stderr, "OK: strndup string input preserves bounded substrings\n");
+        string_freez(s_substring);
+
         long entries_starting = unittest_string_entries();
 
         fprintf(stderr, "\nChecking strings...\n");

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -310,14 +310,16 @@ url_is_request_complete_and_extract_payload(const char *begin, const char *end, 
  * @param s is the start of the user request.
  * @return
  */
-inline char *url_find_protocol(char *s) {
-    while(*s) {
+inline char *url_find_protocol(char *s, const char *end) {
+    while(s < end && *s) {
         // find the next space
-        while (*s && *s != ' ') s++;
+        while (s < end && *s && *s != ' ') s++;
+
+        if(s >= end || !*s) break;
 
         // is it SPACE + "HTTP/" ?
-        if(!*s || !strncmp(s, " HTTP/", 6)) break;
-        else s++;
+        if((size_t)(end - s) >= 6 && !strncmp(s, " HTTP/", 6)) break;
+        s++;
     }
 
     return s;

--- a/src/libnetdata/url/url.h
+++ b/src/libnetdata/url/url.h
@@ -22,6 +22,6 @@ char *url_encode(const char *str);
 char *url_decode_r(char *to, const char *url, size_t size);
 
 bool url_is_request_complete_and_extract_payload(const char *begin, const char *end, size_t length, BUFFER **post_payload);
-char *url_find_protocol(char *s);
+char *url_find_protocol(char *s, const char *end);
 
 #endif /* NETDATA_URL_H */

--- a/src/web/api/queries/median/median.h
+++ b/src/web/api/queries/median/median.h
@@ -15,12 +15,13 @@ struct tg_median {
 };
 
 static inline void tg_median_create_internal(RRDR *r, const char *options, NETDATA_DOUBLE def) {
-    long entries = r->view.group;
+    size_t entries = r->view.group;
     if(entries < 10) entries = 10;
 
     struct tg_median *g = (struct tg_median *)onewayalloc_callocz(r->internal.owa, 1, sizeof(struct tg_median));
-    g->series = onewayalloc_mallocz(r->internal.owa, entries * sizeof(NETDATA_DOUBLE));
-    g->series_size = (size_t)entries;
+    g->series = onewayalloc_mallocz(
+        r->internal.owa, onewayalloc_mul_or_fatal(entries, sizeof(*g->series), "median series"));
+    g->series_size = entries;
 
     g->percent = def;
     if(options && *options) {
@@ -81,7 +82,10 @@ static inline void tg_median_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_median *g = (struct tg_median *)r->time_grouping.data;
 
     if(unlikely(g->next_pos >= g->series_size)) {
-        g->series = onewayalloc_doublesize( r->internal.owa, g->series, g->series_size * sizeof(NETDATA_DOUBLE));
+        g->series = onewayalloc_doublesize(
+            r->internal.owa,
+            g->series,
+            onewayalloc_mul_or_fatal(g->series_size, sizeof(*g->series), "median series"));
         g->series_size *= 2;
     }
 

--- a/src/web/api/queries/percentile/percentile.h
+++ b/src/web/api/queries/percentile/percentile.h
@@ -15,12 +15,13 @@ struct tg_percentile {
 };
 
 static inline void tg_percentile_create_internal(RRDR *r, const char *options, NETDATA_DOUBLE def) {
-    long entries = r->view.group;
+    size_t entries = r->view.group;
     if(entries < 10) entries = 10;
 
     struct tg_percentile *g = (struct tg_percentile *)onewayalloc_callocz(r->internal.owa, 1, sizeof(struct tg_percentile));
-    g->series = onewayalloc_mallocz(r->internal.owa, entries * sizeof(NETDATA_DOUBLE));
-    g->series_size = (size_t)entries;
+    g->series = onewayalloc_mallocz(
+        r->internal.owa, onewayalloc_mul_or_fatal(entries, sizeof(*g->series), "percentile series"));
+    g->series_size = entries;
 
     g->percent = def;
     if(options && *options) {
@@ -81,7 +82,10 @@ static inline void tg_percentile_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_percentile *g = (struct tg_percentile *)r->time_grouping.data;
 
     if(unlikely(g->next_pos >= g->series_size)) {
-        g->series = onewayalloc_doublesize( r->internal.owa, g->series, g->series_size * sizeof(NETDATA_DOUBLE));
+        g->series = onewayalloc_doublesize(
+            r->internal.owa,
+            g->series,
+            onewayalloc_mul_or_fatal(g->series_size, sizeof(*g->series), "percentile series"));
         g->series_size *= 2;
     }
 

--- a/src/web/api/queries/query-cardinality-limit.c
+++ b/src/web/api/queries/query-cardinality-limit.c
@@ -20,7 +20,8 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
     ONEWAYALLOC *owa = r->internal.owa;
     
     // Calculate contribution of each dimension using dview statistics (sum of values)
-    NETDATA_DOUBLE *contributions = onewayalloc_mallocz(owa, r->d * sizeof(NETDATA_DOUBLE));
+    NETDATA_DOUBLE *contributions = onewayalloc_mallocz(
+        owa, onewayalloc_mul_or_fatal(r->d, sizeof(*contributions), "RRDR cardinality contributions"));
     
     // Count queried dimensions and get their contributions from dview
     size_t queried_count = 0;
@@ -60,7 +61,8 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
     struct {
         size_t dim_idx;
         NETDATA_DOUBLE contribution;
-    } *sorted_dims = onewayalloc_mallocz(owa, queried_count * sizeof(*sorted_dims));
+    } *sorted_dims = onewayalloc_mallocz(
+        owa, onewayalloc_mul_or_fatal(queried_count, sizeof(*sorted_dims), "RRDR cardinality dimensions"));
     
     size_t sorted_idx = 0;
     for (size_t d = 0; d < r->d; d++) {

--- a/src/web/api/queries/query-group-by-init.c
+++ b/src/web/api/queries/query-group-by-init.c
@@ -253,10 +253,12 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
         }
     }
 
-    int added = 0;
+    size_t added = 0;
     RRDR *first_r = NULL, *last_r = NULL;
     BUFFER *key = buffer_create(0, NULL);
-    struct rrdr_group_by_entry *entries = onewayalloc_mallocz(owa, qt->query.used * sizeof(struct rrdr_group_by_entry));
+    size_t entries_size =
+        onewayalloc_mul_or_fatal(qt->query.used, sizeof(struct rrdr_group_by_entry), "RRDR group-by entries");
+    struct rrdr_group_by_entry *entries = onewayalloc_mallocz(owa, entries_size);
     DICTIONARY *groups = dictionary_create(DICT_OPTION_SINGLE_THREADED | DICT_OPTION_DONT_OVERWRITE_VALUE);
     DICTIONARY *label_keys = NULL;
 
@@ -267,7 +269,7 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
         if(group_by == RRDR_GROUP_BY_NONE)
             break;
 
-        memset(entries, 0, qt->query.used * sizeof(struct rrdr_group_by_entry));
+        memset(entries, 0, entries_size);
         dictionary_flush(groups);
         added = 0;
 
@@ -307,9 +309,9 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
 
             // lookup the key in the dictionary
 
-            int pos = -1;
-            int *set = dictionary_set(groups, buffer_tostring(key), &pos, sizeof(pos));
-            if (*set == -1) {
+            size_t pos = SIZE_MAX;
+            size_t *set = dictionary_set(groups, buffer_tostring(key), &pos, sizeof(pos));
+            if (*set == SIZE_MAX) {
                 // the key just added to the dictionary
 
                 *set = pos = added++;
@@ -378,7 +380,7 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
         RRDR *r = rrdr_create(owa, qt, added, qt->window.points);
         if (!r) {
             internal_error(true,
-                           "QUERY: cannot create group by RRDR for %s, after=%ld, before=%ld, dimensions=%d, points=%zu",
+                           "QUERY: cannot create group by RRDR for %s, after=%ld, before=%ld, dimensions=%zu, points=%zu",
                            qt->id, qt->window.after, qt->window.before, added, qt->window.points);
             goto cleanup;
         }
@@ -413,11 +415,13 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             }
 
             if(r->n) {
-                r->gbc = onewayalloc_callocz(owa, r->n * r->d, sizeof(*r->gbc));
+                r->gbc = onewayalloc_callocz(
+                    owa, onewayalloc_mul_or_fatal(r->n, r->d, "RRDR group-by counts"), sizeof(*r->gbc));
 
                 if(hidden_dimensions && ((group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) || (aggregation_method == RRDR_GROUP_BY_FUNCTION_PERCENTAGE)))
                     // this is where we are going to group the hidden dimensions
-                    r->vh = onewayalloc_mallocz(owa, r->n * r->d * sizeof(*r->vh));
+                    r->vh = onewayalloc_mallocz(
+                        owa, onewayalloc_mul3_or_fatal(r->n, r->d, sizeof(*r->vh), "RRDR hidden values"));
             }
         }
 
@@ -496,7 +500,7 @@ cleanup:
         }
 
         if(entries && added) {
-            for (int d = 0; d < added; d++) {
+            for (size_t d = 0; d < added; d++) {
                 string_freez(entries[d].id);
                 string_freez(entries[d].name);
                 string_freez(entries[d].units);
@@ -514,4 +518,3 @@ cleanup:
 
     return r_tmp;
 }
-

--- a/src/web/api/queries/rrdr.c
+++ b/src/web/api/queries/rrdr.c
@@ -119,13 +119,16 @@ RRDR *rrdr_create(ONEWAYALLOC *owa, QUERY_TARGET *qt, size_t dimensions, size_t 
     r->view.before = qt->window.before;
     r->view.after = qt->window.after;
     r->time_grouping.points_wanted = points;
-    r->d = (int)dimensions;
-    r->n = (int)points;
+    r->d = dimensions;
+    r->n = points;
 
     if(points && dimensions) {
-        r->v = onewayalloc_mallocz(owa, points * dimensions * sizeof(NETDATA_DOUBLE));
-        r->o = onewayalloc_mallocz(owa, points * dimensions * sizeof(RRDR_VALUE_FLAGS));
-        r->ar = onewayalloc_mallocz(owa, points * dimensions * sizeof(NETDATA_DOUBLE));
+        r->v = onewayalloc_mallocz(
+            owa, onewayalloc_mul3_or_fatal(points, dimensions, sizeof(*r->v), "RRDR values"));
+        r->o = onewayalloc_mallocz(
+            owa, onewayalloc_mul3_or_fatal(points, dimensions, sizeof(*r->o), "RRDR value flags"));
+        r->ar = onewayalloc_mallocz(
+            owa, onewayalloc_mul3_or_fatal(points, dimensions, sizeof(*r->ar), "RRDR anomaly rates"));
     }
 
     if(points) {
@@ -133,7 +136,7 @@ RRDR *rrdr_create(ONEWAYALLOC *owa, QUERY_TARGET *qt, size_t dimensions, size_t 
     }
 
     if(dimensions) {
-        r->od = onewayalloc_mallocz(owa, dimensions * sizeof(RRDR_DIMENSION_FLAGS));
+        r->od = onewayalloc_mallocz(owa, onewayalloc_mul_or_fatal(dimensions, sizeof(*r->od), "RRDR dimension flags"));
         r->di = onewayalloc_callocz(owa, dimensions, sizeof(STRING *));
         r->dn = onewayalloc_callocz(owa, dimensions, sizeof(STRING *));
         r->du = onewayalloc_callocz(owa, dimensions, sizeof(STRING *));

--- a/src/web/api/queries/trimmed_mean/trimmed_mean.h
+++ b/src/web/api/queries/trimmed_mean/trimmed_mean.h
@@ -15,12 +15,13 @@ struct tg_trimmed_mean {
 };
 
 static inline void tg_trimmed_mean_create_internal(RRDR *r, const char *options, NETDATA_DOUBLE def) {
-    long entries = r->view.group;
+    size_t entries = r->view.group;
     if(entries < 10) entries = 10;
 
     struct tg_trimmed_mean *g = (struct tg_trimmed_mean *)onewayalloc_callocz(r->internal.owa, 1, sizeof(struct tg_trimmed_mean));
-    g->series = onewayalloc_mallocz(r->internal.owa, entries * sizeof(NETDATA_DOUBLE));
-    g->series_size = (size_t)entries;
+    g->series = onewayalloc_mallocz(
+        r->internal.owa, onewayalloc_mul_or_fatal(entries, sizeof(*g->series), "trimmed mean series"));
+    g->series_size = entries;
 
     g->percent = def;
     if(options && *options) {
@@ -78,7 +79,10 @@ static inline void tg_trimmed_mean_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_trimmed_mean *g = (struct tg_trimmed_mean *)r->time_grouping.data;
 
     if(unlikely(g->next_pos >= g->series_size)) {
-        g->series = onewayalloc_doublesize( r->internal.owa, g->series, g->series_size * sizeof(NETDATA_DOUBLE));
+        g->series = onewayalloc_doublesize(
+            r->internal.owa,
+            g->series,
+            onewayalloc_mul_or_fatal(g->series_size, sizeof(*g->series), "trimmed mean series"));
         g->series_size *= 2;
     }
 

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -1423,8 +1423,10 @@ static double kstwo(
         return NAN;
 
     // -1 in size, since the calculate_pairs_diffs() returns one less point
-    DIFFS_NUMBERS *baseline_diffs = onewayalloc_mallocz(owa, (size_t)(baseline_points - 1) * sizeof(*baseline_diffs));
-    DIFFS_NUMBERS *highlight_diffs = onewayalloc_mallocz(owa, (size_t)(highlight_points - 1) * sizeof(*highlight_diffs));
+    DIFFS_NUMBERS *baseline_diffs = onewayalloc_mallocz(
+        owa, onewayalloc_mul_or_fatal((size_t)(baseline_points - 1), sizeof(*baseline_diffs), "baseline diffs"));
+    DIFFS_NUMBERS *highlight_diffs = onewayalloc_mallocz(
+        owa, onewayalloc_mul_or_fatal((size_t)(highlight_points - 1), sizeof(*highlight_diffs), "highlight diffs"));
 
     int base_size = (int)calculate_pairs_diff(baseline_diffs, baseline, baseline_points);
     int high_size = (int)calculate_pairs_diff(highlight_diffs, highlight, highlight_points);
@@ -1507,7 +1509,8 @@ NETDATA_DOUBLE *rrd2rrdr_ks2(
         goto cleanup;
 
     *entries = rrdr_rows(r);
-    ret = onewayalloc_mallocz(owa, sizeof(NETDATA_DOUBLE) * rrdr_rows(r));
+    size_t ret_size = onewayalloc_mul_or_fatal(rrdr_rows(r), sizeof(*ret), "weight values");
+    ret = onewayalloc_mallocz(owa, ret_size);
 
     if(sp)
         *sp = r->internal.qt->query.array[0].query_points;
@@ -1515,7 +1518,7 @@ NETDATA_DOUBLE *rrd2rrdr_ks2(
     // copy the points of the dimension to a contiguous array
     // there is no need to check for empty values, since empty values are already zero
     // https://github.com/netdata/netdata/blob/6e3144683a73a2024d51425b20ecfd569034c858/web/api/queries/average/average.c#L41-L43
-    memcpy(ret, r->v, rrdr_rows(r) * sizeof(NETDATA_DOUBLE));
+    memcpy(ret, r->v, ret_size);
 
 cleanup:
     rrdr_free(owa, r);

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -690,12 +690,13 @@ static inline char *web_client_valid_method(struct web_client *w, char *s) {
  *          in the enum HTTP_VALIDATION otherwise.
  */
 HTTP_VALIDATION http_request_validate(struct web_client *w) {
-    char *s = (char *)buffer_tostring(w->response.data), *encoded_url = NULL;
+    char *request = (char *)buffer_tostring(w->response.data), *s = request, *encoded_url = NULL;
 
     size_t last_pos = w->header_parse_last_size;
 
     w->header_parse_tries++;
     w->header_parse_last_size = buffer_strlen(w->response.data);
+    char *request_end = request + w->header_parse_last_size;
 
     int is_it_valid;
     if(w->header_parse_tries > 1) {
@@ -743,10 +744,14 @@ HTTP_VALIDATION http_request_validate(struct web_client *w) {
     encoded_url = s;
 
     //we search for the position where we have " HTTP/", because it finishes the user request
-    s = url_find_protocol(s);
+    char *request_line_end = s;
+    while(request_line_end < request_end && *request_line_end && *request_line_end != '\r')
+        request_line_end++;
+
+    s = url_find_protocol(s, request_line_end);
 
     // incomplete requests
-    if(unlikely(!*s)) {
+    if(unlikely(s >= request_line_end || !*s)) {
         web_client_enable_wait_receive(w);
         return HTTP_VALIDATION_INCOMPLETE;
     }


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened string interning, HTTP request parsing, and allocation size math to prevent overreads, mis-parses, and integer overflows. No behavior change for valid inputs; unsafe cases now fail fast.

- **Bug Fixes**
  - Bounded `string_strndupz()` with `strnlen()`; stops at NUL before bound and preserves exact substrings; added unit tests.
  - Bounded `url_find_protocol()` with an explicit end pointer and scan only within the request line; updated web client to pass the correct line end to avoid matching headers; incomplete lines are handled correctly.
  - Exposed `onewayalloc_mul_or_fatal()` and added `onewayalloc_mul3_or_fatal()`; replaced raw size products to catch overflow at:
    - RRDR allocations (values, flags, anomaly rates, dimension flags).
    - Group-by entries, counts, and hidden values.
    - Cardinality-limit contributions and sorted dimensions.
    - Time-grouping series for median, percentile, and trimmed mean, including growth paths.
    - Weights: pair-diff buffers and result array.
  - Converted RRDR points/dimensions and related counters to `size_t` to remove narrowing.

<sup>Written for commit e57f32a79a782d2eea9c0583883a9c1f88108b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

