### PR TITLE
Update systemd journal SDK to 0.7.8

### DIFF
--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -4284,9 +4284,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-common"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8640d72b0782a35e6d24bd66c65a1fd5a1d50e08251f568fc6ed2b9f467d01"
+checksum = "26dffb78c54dd0878c122705a5e285cac0b45f4d449a2345fe339994fa3d6dec"
 dependencies = [
  "libc",
  "rustc-hash",
@@ -4297,9 +4297,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-core"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4051721ee09f72c2db014766cc958d80a92a9f06dfd55d233a42c80bd9bfbe1e"
+checksum = "cb19cb9e5b94468937d7a3558f795f33913d190517d217313d493f827a37e5e9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4338,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-engine"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d7ab6d801daf4209c4c628f3abbcb982516595fbd8cf92ce5f4c36094455ae"
+checksum = "2737251973f2264ed314d349a4978b9d86ebafca785a170b0733852073478524"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4364,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-host"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e079375d0b7d55eaaeefa781aea9af90e17bc75253f6d16b08f372054e558f"
+checksum = "f0b8f13e0d446f8f8aea1184bef404d93d4de5e5c98db15f95a4d2b8204cb105"
 dependencies = [
  "libc",
  "systemd-journal-sdk-common",
@@ -4376,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-index"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949f5042aaa0ab9c9315c1fc2f65af632eec253bd2b933b34ac9f074a41a5f6d"
+checksum = "eaf050f2b2d60f7659a51cf2f31f9d2213b7932c5492675f1bce71974ec6568c"
 dependencies = [
  "regex",
  "roaring 0.11.4",
@@ -4393,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-log-writer"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196f8a6481821c8bca7df266782e6312d9ef94609b9f4530284d857e81f10f97"
+checksum = "91abdafd3a2616fd61118a4136c8f087562ebb2242fea8a0f54e458c71bcfbff"
 dependencies = [
  "itoa",
  "systemd-journal-sdk-common",
@@ -4408,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-registry"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05117db6540add123383eb9f288c7ee8c4ef08cb3f192c1cfa046658dbf0a1"
+checksum = "440268acc39fb032477bbb714a80a7e2b16ae226a81c6222332406e16c5144a5"
 dependencies = [
  "notify",
  "parking_lot",

--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -4284,9 +4284,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-common"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d1e8982e662302ab942d72c86cada4a01a069012a1b6aea3802fc83619041c"
+checksum = "ee8640d72b0782a35e6d24bd66c65a1fd5a1d50e08251f568fc6ed2b9f467d01"
 dependencies = [
  "libc",
  "rustc-hash",
@@ -4297,9 +4297,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-core"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7ebd119a8c9e30b33faba9acbb84dbe3d1b0d601d497aebca48b399955dbb8"
+checksum = "4051721ee09f72c2db014766cc958d80a92a9f06dfd55d233a42c80bd9bfbe1e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4338,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-engine"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b521b001ca842805380a07db7c8b64924b4bfbe83ccb1cfa8c181e2c33b9e5"
+checksum = "93d7ab6d801daf4209c4c628f3abbcb982516595fbd8cf92ce5f4c36094455ae"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4364,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-host"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47facaccf9fcaf588c3ed2cc189427728935560fe1b5139a3609a59033c9af8"
+checksum = "f2e079375d0b7d55eaaeefa781aea9af90e17bc75253f6d16b08f372054e558f"
 dependencies = [
  "libc",
  "systemd-journal-sdk-common",
@@ -4376,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-index"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52f574dd822d3663dd0dea8ac63d7f7fb63269c571ff155b68586e679207a81"
+checksum = "949f5042aaa0ab9c9315c1fc2f65af632eec253bd2b933b34ac9f074a41a5f6d"
 dependencies = [
  "regex",
  "roaring 0.11.4",
@@ -4393,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-log-writer"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3cc1fa4f01832641f30d80a5669749f46c9ae2601514d1aed90137bd112357"
+checksum = "196f8a6481821c8bca7df266782e6312d9ef94609b9f4530284d857e81f10f97"
 dependencies = [
  "itoa",
  "systemd-journal-sdk-common",
@@ -4408,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-registry"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2739f7d0d149aa01129077496f1941d10d1ee3e3737b542123ffde03de47e"
+checksum = "8f05117db6540add123383eb9f288c7ee8c4ef08cb3f192c1cfa046658dbf0a1"
 dependencies = [
  "notify",
  "parking_lot",

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -24,13 +24,13 @@ clap = { workspace = true, features = ["derive"] }
 # crates). Aliased to the historical names so call sites keep `use journal_*`.
 # Scope: netflow-plugin only; log-viewer/otel still use the vendored workspace
 # crates (tracked as a follow-up). One source of journal-core in this binary.
-journal-common = { package = "systemd-journal-sdk-common", version = "0.7.7" }
-journal-core = { package = "systemd-journal-sdk-core", version = "0.7.7" }
-journal-engine = { package = "systemd-journal-sdk-engine", version = "0.7.7" }
-journal-host = { package = "systemd-journal-sdk-host", version = "0.7.7" }
-journal-index = { package = "systemd-journal-sdk-index", version = "0.7.7" }
-journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.7.7" }
-journal-registry = { package = "systemd-journal-sdk-registry", version = "0.7.7" }
+journal-common = { package = "systemd-journal-sdk-common", version = "0.7.8" }
+journal-core = { package = "systemd-journal-sdk-core", version = "0.7.8" }
+journal-engine = { package = "systemd-journal-sdk-engine", version = "0.7.8" }
+journal-host = { package = "systemd-journal-sdk-host", version = "0.7.8" }
+journal-index = { package = "systemd-journal-sdk-index", version = "0.7.8" }
+journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.7.8" }
+journal-registry = { package = "systemd-journal-sdk-registry", version = "0.7.8" }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 hashbrown = { workspace = true }

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -24,13 +24,13 @@ clap = { workspace = true, features = ["derive"] }
 # crates). Aliased to the historical names so call sites keep `use journal_*`.
 # Scope: netflow-plugin only; log-viewer/otel still use the vendored workspace
 # crates (tracked as a follow-up). One source of journal-core in this binary.
-journal-common = { package = "systemd-journal-sdk-common", version = "0.7.6" }
-journal-core = { package = "systemd-journal-sdk-core", version = "0.7.6" }
-journal-engine = { package = "systemd-journal-sdk-engine", version = "0.7.6" }
-journal-host = { package = "systemd-journal-sdk-host", version = "0.7.6" }
-journal-index = { package = "systemd-journal-sdk-index", version = "0.7.6" }
-journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.7.6" }
-journal-registry = { package = "systemd-journal-sdk-registry", version = "0.7.6" }
+journal-common = { package = "systemd-journal-sdk-common", version = "0.7.7" }
+journal-core = { package = "systemd-journal-sdk-core", version = "0.7.7" }
+journal-engine = { package = "systemd-journal-sdk-engine", version = "0.7.7" }
+journal-host = { package = "systemd-journal-sdk-host", version = "0.7.7" }
+journal-index = { package = "systemd-journal-sdk-index", version = "0.7.7" }
+journal-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.7.7" }
+journal-registry = { package = "systemd-journal-sdk-registry", version = "0.7.7" }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 hashbrown = { workspace = true }

--- a/src/crates/netflow-plugin/src/local_journal_host.rs
+++ b/src/crates/netflow-plugin/src/local_journal_host.rs
@@ -4,12 +4,48 @@ use journal_host::{LoadOptions, LocalJournalProvider};
 
 pub(crate) fn load_local_journal_provider(cfg: &PluginConfig) -> Result<LocalJournalProvider> {
     let state_dir = cfg.journal_host_state_dir();
-    LocalJournalProvider::load(LoadOptions::default().with_state_dir(&state_dir)).with_context(
-        || {
-            format!(
-                "failed to load local journal host identity using state directory {}",
-                state_dir.display()
-            )
-        },
-    )
+    LocalJournalProvider::load(local_journal_load_options(cfg, &state_dir)).with_context(|| {
+        format!(
+            "failed to load local journal host identity using state directory {}",
+            state_dir.display()
+        )
+    })
+}
+
+fn local_journal_load_options(cfg: &PluginConfig, state_dir: &std::path::Path) -> LoadOptions {
+    let mut options = LoadOptions::default().with_state_dir(state_dir);
+    if let Some(prefix) = cfg.journal_host_filesystem_prefix() {
+        options = options.with_host_filesystem_prefix(prefix);
+    }
+    options
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn local_journal_load_options_forwards_host_filesystem_prefix() {
+        let state_dir = PathBuf::from("/tmp/netdata-state");
+        let mut cfg = PluginConfig::default();
+        cfg._netdata_env.host_prefix = Some("/host".to_string());
+
+        let options = local_journal_load_options(&cfg, &state_dir);
+
+        assert_eq!(options.state_dir, Some(state_dir));
+        assert_eq!(options.host_filesystem_prefix, Some(PathBuf::from("/host")));
+    }
+
+    #[test]
+    fn local_journal_load_options_ignores_empty_host_filesystem_prefix() {
+        let state_dir = PathBuf::from("/tmp/netdata-state");
+        let mut cfg = PluginConfig::default();
+        cfg._netdata_env.host_prefix = Some("  ".to_string());
+
+        let options = local_journal_load_options(&cfg, &state_dir);
+
+        assert_eq!(options.state_dir, Some(state_dir));
+        assert_eq!(options.host_filesystem_prefix, None);
+    }
 }

--- a/src/crates/netflow-plugin/src/plugin_config/runtime.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/runtime.rs
@@ -108,6 +108,15 @@ impl PluginConfig {
             .join("systemd-journal-sdk")
     }
 
+    pub(crate) fn journal_host_filesystem_prefix(&self) -> Option<&Path> {
+        self._netdata_env
+            .host_prefix
+            .as_deref()
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(Path::new)
+    }
+
     fn load_from_netdata_config(netdata_env: &NetdataEnv) -> Result<Self> {
         let candidates = [
             netdata_env

--- a/src/crates/netflow-plugin/src/plugin_config_tests.rs
+++ b/src/crates/netflow-plugin/src/plugin_config_tests.rs
@@ -699,6 +699,25 @@ fn journal_host_state_dir_falls_back_to_build_default() {
 }
 
 #[test]
+fn journal_host_filesystem_prefix_uses_configured_host_prefix() {
+    let mut cfg = PluginConfig::default();
+    cfg._netdata_env.host_prefix = Some("/host".to_string());
+
+    assert_eq!(
+        cfg.journal_host_filesystem_prefix(),
+        Some(std::path::Path::new("/host"))
+    );
+}
+
+#[test]
+fn journal_host_filesystem_prefix_ignores_empty_host_prefix() {
+    let mut cfg = PluginConfig::default();
+    cfg._netdata_env.host_prefix = Some("  ".to_string());
+
+    assert_eq!(cfg.journal_host_filesystem_prefix(), None);
+}
+
+#[test]
 fn auto_detect_geoip_databases_uses_absolute_journal_parent() {
     let dir = tempdir().expect("create tempdir");
     let cache_dir = dir.path();

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/microsoft/go-mssqldb v1.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0
-	github.com/netdata/systemd-journal-sdk/go v0.7.7
+	github.com/netdata/systemd-journal-sdk/go v0.7.8
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	go.mongodb.org/mongo-driver/v2 v2.7.0

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/microsoft/go-mssqldb v1.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0
-	github.com/netdata/systemd-journal-sdk/go v0.7.6
+	github.com/netdata/systemd-journal-sdk/go v0.7.7
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	go.mongodb.org/mongo-driver/v2 v2.7.0

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -354,8 +354,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netdata/systemd-journal-sdk/go v0.7.7 h1:cZXIl/l7DSU/xokxIBPg+ihLb+as8qOhzg5wdCZBYy0=
-github.com/netdata/systemd-journal-sdk/go v0.7.7/go.mod h1:A03ryRKYt5zrAhxx81HTbnwZ1W8uLq13N1VWXJvO5Zc=
+github.com/netdata/systemd-journal-sdk/go v0.7.8 h1:kDHKpQv6ZNajcF0abQyfrG0JRka1asSrERvDrs8QIbc=
+github.com/netdata/systemd-journal-sdk/go v0.7.8/go.mod h1:A03ryRKYt5zrAhxx81HTbnwZ1W8uLq13N1VWXJvO5Zc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -354,8 +354,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netdata/systemd-journal-sdk/go v0.7.6 h1:TB4BeVU47e6g6tum70aJ2uuZaWxrqPCAgLrOOt8ajbA=
-github.com/netdata/systemd-journal-sdk/go v0.7.6/go.mod h1:A03ryRKYt5zrAhxx81HTbnwZ1W8uLq13N1VWXJvO5Zc=
+github.com/netdata/systemd-journal-sdk/go v0.7.7 h1:cZXIl/l7DSU/xokxIBPg+ihLb+as8qOhzg5wdCZBYy0=
+github.com/netdata/systemd-journal-sdk/go v0.7.7/go.mod h1:A03ryRKYt5zrAhxx81HTbnwZ1W8uLq13N1VWXJvO5Zc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=

--- a/src/go/pkg/pluginconfig/pluginconfig.go
+++ b/src/go/pkg/pluginconfig/pluginconfig.go
@@ -29,6 +29,7 @@ var (
 
 type envData struct {
 	cygwinBase string
+	hostPrefix string
 	userDir    string
 	stockDir   string
 	varLibDir  string
@@ -84,6 +85,7 @@ func MustInit(input InitInput) {
 }
 
 func EnvLogLevel() string      { return env.logLevel }
+func HostPrefix() string       { return hostPrefix() }
 func RegistryUniqueID() string { return readRegistryUniqueID(registryUniqueIDVarLibDir()) }
 
 func UserConfigDirs() multipath.MultiPath { return dirs.userConfigDirsClone() }
@@ -274,12 +276,14 @@ var isTerm = terminal.IsTerminal()
 func readEnvFromOS(execDir string) envData {
 	e := envData{
 		cygwinBase: os.Getenv("NETDATA_CYGWIN_BASE_PATH"),
+		hostPrefix: os.Getenv("NETDATA_HOST_PREFIX"),
 		userDir:    os.Getenv("NETDATA_USER_CONFIG_DIR"),
 		stockDir:   os.Getenv("NETDATA_STOCK_CONFIG_DIR"),
 		watchPath:  os.Getenv("NETDATA_PLUGINS_GOD_WATCH_PATH"),
 		varLibDir:  os.Getenv("NETDATA_LIB_DIR"),
 		logLevel:   os.Getenv("NETDATA_LOG_LEVEL"),
 	}
+	e.hostPrefix = handleDirOnWin(e.cygwinBase, safePathClean(e.hostPrefix), execDir)
 	e.userDir = handleDirOnWin(e.cygwinBase, safePathClean(e.userDir), execDir)
 	e.stockDir = handleDirOnWin(e.cygwinBase, safePathClean(e.stockDir), execDir)
 	e.varLibDir = handleDirOnWin(e.cygwinBase, safePathClean(e.varLibDir), execDir)
@@ -292,6 +296,13 @@ func readEnvFromOS(execDir string) envData {
 	}
 
 	return e
+}
+
+func hostPrefix() string {
+	if env.hostPrefix != "" {
+		return env.hostPrefix
+	}
+	return safePathClean(os.Getenv("NETDATA_HOST_PREFIX"))
 }
 
 // Convert a POSIX absolute (/foo) to Windows under base (e.g., C:\msys64\foo).

--- a/src/go/pkg/pluginconfig/pluginconfig_test.go
+++ b/src/go/pkg/pluginconfig/pluginconfig_test.go
@@ -27,6 +27,17 @@ func TestReadRegistryUniqueID(t *testing.T) {
 	assert.Empty(t, readRegistryUniqueID(filepath.Join(tmp, "missing")))
 }
 
+func TestHostPrefixReadsNetdataHostPrefix(t *testing.T) {
+	orig := env
+	t.Cleanup(func() { env = orig })
+	env.hostPrefix = ""
+
+	prefix := filepath.Join(t.TempDir(), "host", "..", "host")
+	t.Setenv("NETDATA_HOST_PREFIX", prefix)
+
+	assert.Equal(t, filepath.Clean(prefix), HostPrefix())
+}
+
 func TestDirectoriesBuild(t *testing.T) {
 	tmp := t.TempDir()
 	execDir := filepath.Join(tmp, "root", "opt", "netdata", "bin")

--- a/src/go/plugin/agent/jobmgr/sim_test.go
+++ b/src/go/plugin/agent/jobmgr/sim_test.go
@@ -130,7 +130,8 @@ func (s *runSim) run(t *testing.T) {
 			mgr.collectorSeen.Count() == len(s.wantSeen) &&
 			mgr.collectorExposed.Count() == len(s.wantExposed) &&
 			runningSetMatches(mgr.runningJobs.snapshot(), s.wantRunning) &&
-			out.FuncResultCount() >= expectedResults
+			out.FuncResultCount() >= expectedResults &&
+			s.dyncfgTranscriptSettled(out.String())
 	}, timeout, 10*time.Millisecond, "manager state did not settle before shutdown")
 	if t.Failed() {
 		t.Logf("settle state: discovered %d/%d seen %d/%d exposed %d/%d results %d/%d",
@@ -151,29 +152,7 @@ func (s *runSim) run(t *testing.T) {
 		t.Errorf("failed to finish work in %s", timeout)
 	}
 
-	var lines []string
-	skipNextEmpty := false
-	for s := range strings.SplitSeq(out.String(), "\n") {
-		if strings.HasPrefix(s, "CONFIG") && strings.Contains(s, " template ") {
-			skipNextEmpty = false
-			continue
-		}
-		if strings.HasPrefix(s, "FUNCTION GLOBAL") || strings.HasPrefix(s, "FUNCTION_DEL") {
-			skipNextEmpty = true
-			continue
-		}
-		if skipNextEmpty && s == "" {
-			skipNextEmpty = false
-			continue
-		}
-		skipNextEmpty = false
-		if strings.HasPrefix(s, "FUNCTION_RESULT_BEGIN") {
-			parts := strings.Fields(s)
-			s = strings.Join(parts[:len(parts)-1], " ") // remove timestamp
-		}
-		lines = append(lines, s)
-	}
-	wantDyncfg, gotDyncfg := strings.TrimSpace(s.wantDyncfg), strings.TrimSpace(strings.Join(lines, "\n"))
+	wantDyncfg, gotDyncfg := strings.TrimSpace(s.wantDyncfg), normalizeDyncfgTranscript(out.String())
 
 	//fmt.Println(gotDyncfg)
 
@@ -228,6 +207,44 @@ func (s *runSim) run(t *testing.T) {
 		_, ok := runningBeforeShutdown[name]
 		require.Truef(t, ok, "runningJobs: job '%s' is not found", name)
 	}
+}
+
+func normalizeDyncfgTranscript(output string) string {
+	var lines []string
+	skipNextEmpty := false
+	for s := range strings.SplitSeq(output, "\n") {
+		if strings.HasPrefix(s, "CONFIG") && strings.Contains(s, " template ") {
+			skipNextEmpty = false
+			continue
+		}
+		if strings.HasPrefix(s, "FUNCTION GLOBAL") || strings.HasPrefix(s, "FUNCTION_DEL") {
+			skipNextEmpty = true
+			continue
+		}
+		if skipNextEmpty && s == "" {
+			skipNextEmpty = false
+			continue
+		}
+		skipNextEmpty = false
+		if strings.HasPrefix(s, "FUNCTION_RESULT_BEGIN") {
+			parts := strings.Fields(s)
+			s = strings.Join(parts[:len(parts)-1], " ") // remove timestamp
+		}
+		lines = append(lines, s)
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+func (s *runSim) dyncfgTranscriptSettled(output string) bool {
+	got := normalizeDyncfgTranscript(output)
+	if len(s.wantDyncfgRecords) > 0 {
+		total := 0
+		for _, wants := range s.wantDyncfgRecords {
+			total += len(wants)
+		}
+		return len(wiretest.AtomicRecords(got)) >= total
+	}
+	return got == strings.TrimSpace(s.wantDyncfg)
 }
 
 func prepareMockRegistry() collectorapi.Registry {

--- a/src/go/plugin/go.d/collector/snmp_traps/journal_host.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/journal_host.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	netdataLibDirEnv        = "NETDATA_LIB_DIR"
+	netdataHostPrefixEnv    = "NETDATA_HOST_PREFIX"
 	journalHostStateDirName = "systemd-journal-sdk"
 )
 
@@ -34,25 +35,37 @@ var defaultJournalHost struct {
 }
 
 func loadJournalHostProvider() (journalHostProvider, error) {
-	stateDir := netdataJournalHostStateDir()
-	provider, err := journalhost.Load(journalhost.LoadOptions{StateDir: stateDir})
+	opts := journalHostLoadOptions()
+	provider, err := journalhost.Load(opts)
 	if err != nil {
-		return nil, fmt.Errorf("load local journal host identity using state directory %s: %w", stateDir, err)
+		return nil, fmt.Errorf("load local journal host identity using state directory %s: %w", opts.StateDir, err)
 	}
 	return provider, nil
 }
 
 func defaultJournalHostProvider() (journalHostProvider, error) {
 	defaultJournalHost.once.Do(func() {
-		defaultJournalHost.provider, defaultJournalHost.err = journalhost.Load(journalhost.LoadOptions{
-			StateDir: netdataJournalHostStateDir(),
-		})
+		defaultJournalHost.provider, defaultJournalHost.err = journalhost.Load(journalHostLoadOptions())
 	})
 	return defaultJournalHost.provider, defaultJournalHost.err
 }
 
+func journalHostLoadOptions() journalhost.LoadOptions {
+	return journalhost.LoadOptions{
+		StateDir:             netdataJournalHostStateDir(),
+		HostFilesystemPrefix: netdataHostFilesystemPrefix(),
+	}
+}
+
 func netdataJournalHostStateDir() string {
 	return filepath.Join(netdataLibDir(), journalHostStateDirName)
+}
+
+func netdataHostFilesystemPrefix() string {
+	if dir := strings.TrimSpace(os.Getenv(netdataHostPrefixEnv)); dir != "" {
+		return filepath.Clean(dir)
+	}
+	return ""
 }
 
 func netdataLibDir() string {

--- a/src/go/plugin/go.d/collector/snmp_traps/journal_host.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/journal_host.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	netdataLibDirEnv        = "NETDATA_LIB_DIR"
-	netdataHostPrefixEnv    = "NETDATA_HOST_PREFIX"
 	journalHostStateDirName = "systemd-journal-sdk"
 )
 
@@ -62,7 +61,7 @@ func netdataJournalHostStateDir() string {
 }
 
 func netdataHostFilesystemPrefix() string {
-	if dir := strings.TrimSpace(os.Getenv(netdataHostPrefixEnv)); dir != "" {
+	if dir := strings.TrimSpace(pluginconfig.HostPrefix()); dir != "" {
 		return filepath.Clean(dir)
 	}
 	return ""

--- a/src/go/plugin/go.d/collector/snmp_traps/journal_host_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/journal_host_test.go
@@ -3,6 +3,7 @@
 package snmp_traps
 
 import (
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -88,6 +89,44 @@ func TestNetdataJournalHostStateDirUsesBuildinfoVarLibDir(t *testing.T) {
 	want := filepath.Join(libDir, journalHostStateDirName)
 	if got := netdataJournalHostStateDir(); got != want {
 		t.Fatalf("netdataJournalHostStateDir() = %q, want %q", got, want)
+	}
+}
+
+func TestNetdataHostFilesystemPrefixUsesNetdataHostPrefix(t *testing.T) {
+	prefix := filepath.Join(t.TempDir(), "host", "..", "host")
+	t.Setenv(netdataHostPrefixEnv, prefix)
+
+	want := filepath.Clean(os.Getenv(netdataHostPrefixEnv))
+	if got := netdataHostFilesystemPrefix(); got != want {
+		t.Fatalf("netdataHostFilesystemPrefix() = %q, want %q", got, want)
+	}
+}
+
+func TestNetdataHostFilesystemPrefixIgnoresEmptyNetdataHostPrefix(t *testing.T) {
+	t.Setenv(netdataHostPrefixEnv, "  ")
+
+	if got := netdataHostFilesystemPrefix(); got != "" {
+		t.Fatalf("netdataHostFilesystemPrefix() = %q, want empty", got)
+	}
+}
+
+func TestJournalHostLoadOptionsIncludesHostFilesystemPrefix(t *testing.T) {
+	if pluginconfig.VarLibDir() != "" {
+		t.Skip("pluginconfig VarLibDir is already initialized")
+	}
+
+	t.Setenv(netdataHostPrefixEnv, "/host")
+	t.Setenv(netdataLibDirEnv, "")
+	libDir := filepath.Join(t.TempDir(), "opt", "netdata", "var", "lib", "netdata")
+	withTestBuildinfoVarLibDir(t, libDir)
+
+	opts := journalHostLoadOptions()
+
+	if got, want := opts.StateDir, filepath.Join(libDir, journalHostStateDirName); got != want {
+		t.Fatalf("StateDir = %q, want %q", got, want)
+	}
+	if got, want := opts.HostFilesystemPrefix, "/host"; got != want {
+		t.Fatalf("HostFilesystemPrefix = %q, want %q", got, want)
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_traps/journal_host_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/journal_host_test.go
@@ -94,16 +94,16 @@ func TestNetdataJournalHostStateDirUsesBuildinfoVarLibDir(t *testing.T) {
 
 func TestNetdataHostFilesystemPrefixUsesNetdataHostPrefix(t *testing.T) {
 	prefix := filepath.Join(t.TempDir(), "host", "..", "host")
-	t.Setenv(netdataHostPrefixEnv, prefix)
+	t.Setenv("NETDATA_HOST_PREFIX", prefix)
 
-	want := filepath.Clean(os.Getenv(netdataHostPrefixEnv))
+	want := filepath.Clean(os.Getenv("NETDATA_HOST_PREFIX"))
 	if got := netdataHostFilesystemPrefix(); got != want {
 		t.Fatalf("netdataHostFilesystemPrefix() = %q, want %q", got, want)
 	}
 }
 
 func TestNetdataHostFilesystemPrefixIgnoresEmptyNetdataHostPrefix(t *testing.T) {
-	t.Setenv(netdataHostPrefixEnv, "  ")
+	t.Setenv("NETDATA_HOST_PREFIX", "  ")
 
 	if got := netdataHostFilesystemPrefix(); got != "" {
 		t.Fatalf("netdataHostFilesystemPrefix() = %q, want empty", got)
@@ -115,7 +115,7 @@ func TestJournalHostLoadOptionsIncludesHostFilesystemPrefix(t *testing.T) {
 		t.Skip("pluginconfig VarLibDir is already initialized")
 	}
 
-	t.Setenv(netdataHostPrefixEnv, "/host")
+	t.Setenv("NETDATA_HOST_PREFIX", "/host")
 	t.Setenv(netdataLibDirEnv, "")
 	libDir := filepath.Join(t.TempDir(), "opt", "netdata", "var", "lib", "netdata")
 	withTestBuildinfoVarLibDir(t, libDir)


### PR DESCRIPTION
## Summary

- Bump NetFlow Rust `systemd-journal-sdk-*` crates and SNMP traps Go module to `0.7.8`.
- Keep the existing `NETDATA_HOST_PREFIX` plumbing into NetFlow and SNMP trap SDK host identity load options.
- Preserve the existing jobmgr race-test stabilization already included in this PR branch.

## Why

SDK `0.7.8` applies the explicit host filesystem prefix to Linux boot-id lookup as well as machine-id lookup. With the existing Netdata integration, containerized agents that set `NETDATA_HOST_PREFIX` now write SDK journals using host machine-id and host boot-id instead of container identity.

This PR intentionally does not migrate any additional journal readers/writers or remove vendored journal crates.

## Release Evidence

- SDK root tag `v0.7.8` and Go submodule tag `go/v0.7.8` both peel to `6705aee5c0fa22f58deacc0b33a5ee60f2b7bac6`.
- Rust SDK crates `systemd-journal-sdk-*` are published at `0.7.8`.
- `go list -m github.com/netdata/systemd-journal-sdk/go@v0.7.8` resolves.

## Validation

- `cargo test --manifest-path src/crates/Cargo.toml --locked -p netflow-plugin`
  - Passed: 573 tests passed, 26 ignored; `tests/grpc_build.rs` passed.
  - Existing warning: dead-code warning in `netflow-plugin/src/tiering/model.rs`.
- `go test ./plugin/go.d/collector/snmp_traps/...`
  - Passed.
- `go test -race ./pkg/pluginconfig ./plugin/go.d/collector/snmp_traps/... ./plugin/agent/jobmgr`
  - Passed.
- `rg -n "github.com/netdata/systemd-journal-sdk/go v0\\.7\\.7|systemd-journal-sdk-(common|core|engine|host|index|log-writer|registry).*0\\.7\\.7" src/crates/netflow-plugin/Cargo.toml src/crates/Cargo.lock src/go/go.mod src/go/go.sum -S`
  - No matches.
- `git diff --check`
  - Passed.
