### PR TITLE
fix view.dimensions.sts.avg for group-by aggregation percentage

### DIFF
--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -285,6 +285,14 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
     if(!query_target_aggregatable(qt) && r->partial_data_trimming.expected_after < qt->window.before)
         rrdr2rrdr_group_by_partial_trimming(r);
 
+    // percentage points are already normalized (0-100), so their sts pair must
+    // average over the view rows to stay consistent with min/max (row extremes),
+    // not over the per-point source contributions (gbc); in aggregatable (raw)
+    // mode the values are not percentaged and the cloud derives the statistics,
+    // so the (sum, gbc) pair is kept as-is
+    bool percentage_stats_by_rows =
+        aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE && !query_target_aggregatable(qt);
+
     // apply averaging, remove RRDR_VALUE_EMPTY, find the non-zero dimensions, min and max
     size_t global_min_max_values = 0;
     size_t dimensions_nonzero = 0;
@@ -347,7 +355,7 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
                         global_max = n;
                 }
 
-                count += gbc;
+                count += percentage_stats_by_rows ? 1 : gbc;
             }
         }
 


### PR DESCRIPTION
##### Summary

`view.dimensions.sts.avg` is wrong for queries using the group-by aggregation `percentage`: it can land far outside `[sts.min, sts.max]` (e.g. values 22.4-23.6 returning `min=22.4, avg=0.18, max=23.6`).

**Root cause.** The final statistics pass in `rrd2rrdr_group_by_finalize()` accumulates the pair `(sum += value, count += gbc)` per dimension, and the formatter derives `avg = sum/count` (`storage_point_average_value()`, `jsonwrap-v2.c`). For `average` this is correct by construction: `sum` accumulates the pre-division group sums, so `Σsums/Σgbc` is the weighted mean of the plotted points. For `percentage`, however, the values are already normalized (0-100) by the percentage-of-group calculation that ran earlier, so dividing their sum by the number of per-point source contributions (`gbc`) averages percentages over a population they do not describe.

**Fix.** When the final group-by aggregation is `percentage` (the last active pass) and the response is not aggregatable (`raw`), accumulate `count` per non-empty view row instead of per source contribution. `sts.avg` becomes the mean of the plotted points, consistent with `sts.min`/`sts.max` which are row extremes. The anomaly rate stays consistent automatically (`arp = ars/count` = mean row anomaly rate).

`gbc` itself is untouched — its meaning (contributing source series per view point) and all its uses (average division, PARTIAL flagging, partial-data trimming, raw-mode `count` emission) are unchanged.

##### Scope / what is intentionally NOT affected

- **Aggregatable (`raw`) responses are byte-identical.** In raw mode the values are not converted to percentages and the statistics pair is derived by the consumer (Netdata Cloud), so the existing `(sum, gbc)` pair is kept as-is.
- v1 endpoints have no `view.dimensions.sts` (no `dview`) and are unaffected.
- All other aggregations (`avg`, `sum`, `min`, `max`) are unaffected.

##### Validation

Before/after on the same absolute time window (10 points, `system.cpu`, a parent with 15 nodes / ~140 source series), responses canonicalized (volatile fields removed, summary arrays identity-sorted):

| query | sts.avg before | sts.avg after | mean of result rows |
|---|---|---|---|
| `group_by=selected&aggregation=percentage&dimensions=user` | 0.5993144 | **8.3904014** | 8.39040137 |
| `group_by=selected&aggregation=percentage` | 0.1815282 | **22.8725521** | 22.87255207 |
| `group_by=dimension&aggregation=sum` + `group_by=selected&aggregation=percentage` (2 passes, percentage last) | 2.5413947 | **22.8725521** | 22.87255207 |

- the three percentage queries differ **only** in `view.dimensions.sts.avg`; `result` is byte-identical;
- `avg`/`sum`/`min`/`max` (non-raw) and `percentage`/`sum` with `options=raw`: fully identical before/after.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect `view.dimensions.sts.avg` for `group_by=percentage` by averaging over view rows in non-raw responses. This keeps `avg` aligned with `min`/`max` and the plotted percentages.

- **Bug Fixes**
  - For final `aggregation=percentage` and non-aggregatable responses, increment stats count per non-empty row instead of `gbc`.
  - `gbc` semantics remain unchanged; only `avg` derivation changes.
  - Raw responses and other aggregations (`avg`, `sum`, `min`, `max`) are unchanged.

<sup>Written for commit 981fd4e82291f9472c4b1a128754d5ecdcc0466c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

