### PR TITLE
percentage group-by: per-row anomaly rate and zero-denominator guard

### DIFF
--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -135,8 +135,11 @@ void rrdr2rrdr_group_by_calculate_percentage_of_group(RRDR *r) {
             else if(isnan(h))
                 cn[d] = 100.0;
 
-            else
-                cn[d] = n * 100.0 / (n + h);
+            else {
+                // all series collected zeros (or cancel out): report 0%, not a gap
+                NETDATA_DOUBLE t = n + h;
+                cn[d] = (t != 0.0) ? (n * 100.0 / t) : 0.0;
+            }
         }
     }
 }
@@ -322,7 +325,10 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
                 NETDATA_DOUBLE n;
 
                 sum += *cn;
-                ars += *ar;
+
+                // when the sts pair is per-row (percentage), the anomaly rate must
+                // also be accumulated per-row (the row mean), not per-contribution
+                ars += percentage_stats_by_rows ? (*ar / (NETDATA_DOUBLE)gbc) : *ar;
 
                 if(aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE && !query_target_aggregatable(qt))
                     n = (*cn /= gbc);


### PR DESCRIPTION
##### Summary

Two follow-ups to #23035 (`view.dimensions.sts` for group-by `aggregation=percentage`):

**1. Anomaly rate regression fix.** #23035 switched the statistics pair to per-row accounting, but the anomaly-rate accumulator kept summing the per-contribution anomaly rates (`ars += *ar` runs before the `*ar /= gbc` normalization). With `count` now counting rows, `sts.arp` was over-reported by roughly the number of source series — observed **13.2 vs 0.08** for `avg` on the same window (162 series). The accumulator now takes the row mean when the pair is per-row, so `arp` is the mean row anomaly rate, consistent with the row-based pair. (The original validation window had zero anomalies, which masked this.)

**2. Zero-denominator guard (0/0 → 0%).** `rrdr2rrdr_group_by_calculate_percentage_of_group()` divided by `(selected + hidden)` unguarded. Windows where every series collected zeros returned NaN — rendered as chart gaps — although the data exists (verifiable with `aggregation=sum`: zero values, no EMPTY annotations). Such windows now report **0%**, matching the zero-total behavior of the `options=percentage` path (`rrd2rrdr_convert_values_to_percentage_of_total()` guards `total==0`). The guard also covers sign-cancelling denominators, which previously produced infinities.

##### Validation

- `net.net` over 6h (real anomalies): percentage `sts.arp` 13.2 → **0.075**, vs 0.0798 for `avg` on the same window (same scale; row-mean vs contribution-mean weighting).
- Idle block device, `dimensions=reads`, `aggregation=percentage`: 12×`null` → 12×`0`; `aggregation=sum` on the same window shows collected zeros with `pa=0`, proving the points are real data, not gaps.
- `sts.avg` remains exact: percentage on `system.cpu`, `sts.avg` 22.7210308 == mean of the result rows.
- Controls on a fixed absolute window: `avg`/`sum` non-raw and `sum` with `options=raw` produce byte-identical `result` before/after.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated anomaly rates and chart gaps in percentage group-by by switching to per-row `arp` accumulation and guarding zero denominators to return 0% instead of NaN/∞.

- **Bug Fixes**
  - Anomaly rate: when `aggregation=percentage`, accumulate the row mean for `sts.arp` instead of summing per-contribution values, fixing over-reported rates.
  - Percentage-of-group: in `rrdr2rrdr_group_by_calculate_percentage_of_group()`, return 0% when `(selected + hidden) == 0` (or cancels to 0), preventing gaps and matching `rrd2rrdr_convert_values_to_percentage_of_total()`.

<sup>Written for commit 8f60a64977716f909fcc5059f27dfa4a9ab4026f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

