### PR TITLE
cgroups: collect cgroup v2 memory.events and memory.swap.events

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-charts.c
+++ b/src/collectors/cgroups.plugin/cgroup-charts.c
@@ -559,6 +559,146 @@ void update_mem_failcnt_chart(struct cgroup *cg) {
     rrdset_done(chart);
 }
 
+void update_mem_events_chart(struct cgroup *cg) {
+    RRDSET *chart = cg->st_mem_events;
+
+    if (unlikely(!cg->st_mem_events)) {
+        char *title;
+        char *context;
+        int prio;
+        if (is_cgroup_systemd_service(cg)) {
+            title = "Systemd Services Memory Usage Events";
+            context = "systemd.service.memory.events";
+            prio = NETDATA_CHART_PRIO_CGROUPS_SYSTEMD + 12;
+        } else {
+            title = "Memory Usage Events";
+            context = k8s_is_kubepod(cg) ? "k8s.cgroup.mem_events" : "cgroup.mem_events";
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 260;
+        }
+
+        char buff[RRD_ID_LENGTH_MAX + 1];
+        chart = cg->st_mem_events = rrdset_create_localhost(
+            cgroup_chart_type(buff, cg),
+            "mem_events",
+            NULL,
+            "mem",
+            context,
+            title,
+            "events/s",
+            PLUGIN_CGROUPS_NAME,
+            is_cgroup_systemd_service(cg) ? PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME : PLUGIN_CGROUPS_MODULE_CGROUPS_NAME,
+            prio,
+            cgroup_update_every,
+            RRDSET_TYPE_LINE);
+
+        rrdset_update_rrdlabels(chart, cg->chart_labels);
+        rrddim_add(chart, "low", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rrddim_add(chart, "high", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rrddim_add(chart, "max", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        if (cg->memory.events_has_sock_throttled)
+            rrddim_add(chart, "sock_throttled", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+    }
+
+    rrddim_set(chart, "low", (collected_number)cg->memory.events_low);
+    rrddim_set(chart, "high", (collected_number)cg->memory.events_high);
+    rrddim_set(chart, "max", (collected_number)cg->memory.events_max);
+    if (cg->memory.events_has_sock_throttled)
+        rrddim_set(chart, "sock_throttled", (collected_number)cg->memory.events_sock_throttled);
+    rrdset_done(chart);
+}
+
+void update_mem_events_oom_chart(struct cgroup *cg) {
+    RRDSET *chart = cg->st_mem_events_oom;
+
+    if (unlikely(!cg->st_mem_events_oom)) {
+        char *title;
+        char *context;
+        int prio;
+        if (is_cgroup_systemd_service(cg)) {
+            title = "Systemd Services Out of Memory Events";
+            context = "systemd.service.memory.oom_events";
+            prio = NETDATA_CHART_PRIO_CGROUPS_SYSTEMD + 11;
+        } else {
+            title = "Out of Memory Events";
+            context = k8s_is_kubepod(cg) ? "k8s.cgroup.mem_events_oom" : "cgroup.mem_events_oom";
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 255;
+        }
+
+        char buff[RRD_ID_LENGTH_MAX + 1];
+        chart = cg->st_mem_events_oom = rrdset_create_localhost(
+            cgroup_chart_type(buff, cg),
+            "mem_events_oom",
+            NULL,
+            "mem",
+            context,
+            title,
+            "events/s",
+            PLUGIN_CGROUPS_NAME,
+            is_cgroup_systemd_service(cg) ? PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME : PLUGIN_CGROUPS_MODULE_CGROUPS_NAME,
+            prio,
+            cgroup_update_every,
+            RRDSET_TYPE_LINE);
+
+        rrdset_update_rrdlabels(chart, cg->chart_labels);
+        rrddim_add(chart, "oom", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rrddim_add(chart, "oom_kill", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        if (cg->memory.events_has_oom_group_kill)
+            rrddim_add(chart, "oom_group_kill", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+    }
+
+    rrddim_set(chart, "oom", (collected_number)cg->memory.events_oom);
+    rrddim_set(chart, "oom_kill", (collected_number)cg->memory.events_oom_kill);
+    if (cg->memory.events_has_oom_group_kill)
+        rrddim_set(chart, "oom_group_kill", (collected_number)cg->memory.events_oom_group_kill);
+    rrdset_done(chart);
+}
+
+void update_mem_events_swap_chart(struct cgroup *cg) {
+    RRDSET *chart = cg->st_mem_events_swap;
+
+    if (unlikely(!cg->st_mem_events_swap)) {
+        char *title;
+        char *context;
+        int prio;
+        if (is_cgroup_systemd_service(cg)) {
+            title = "Systemd Services Swap Usage Events";
+            context = "systemd.service.memory.swap_events";
+            prio = NETDATA_CHART_PRIO_CGROUPS_SYSTEMD + 13;
+        } else {
+            title = "Swap Usage Events";
+            context = k8s_is_kubepod(cg) ? "k8s.cgroup.mem_events_swap" : "cgroup.mem_events_swap";
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 265;
+        }
+
+        char buff[RRD_ID_LENGTH_MAX + 1];
+        chart = cg->st_mem_events_swap = rrdset_create_localhost(
+            cgroup_chart_type(buff, cg),
+            "mem_events_swap",
+            NULL,
+            "mem",
+            context,
+            title,
+            "events/s",
+            PLUGIN_CGROUPS_NAME,
+            is_cgroup_systemd_service(cg) ? PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME : PLUGIN_CGROUPS_MODULE_CGROUPS_NAME,
+            prio,
+            cgroup_update_every,
+            RRDSET_TYPE_LINE);
+
+        rrdset_update_rrdlabels(chart, cg->chart_labels);
+        if (cg->memory.swap_events_has_high)
+            rrddim_add(chart, "high", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rrddim_add(chart, "max", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rrddim_add(chart, "fail", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+    }
+
+    if (cg->memory.swap_events_has_high)
+        rrddim_set(chart, "high", (collected_number)cg->memory.swap_events_high);
+    rrddim_set(chart, "max", (collected_number)cg->memory.swap_events_max);
+    rrddim_set(chart, "fail", (collected_number)cg->memory.swap_events_fail);
+    rrdset_done(chart);
+}
+
 void update_mem_usage_chart(struct cgroup *cg) {
     RRDSET *chart = cg->st_mem_usage;
 

--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -89,6 +89,9 @@ static inline void cgroup_free(struct cgroup *cg) {
     if(cg->st_mem_usage_limit) rrdset_is_obsolete___safe_from_collector_thread(cg->st_mem_usage_limit);
     if(cg->st_mem_utilization) rrdset_is_obsolete___safe_from_collector_thread(cg->st_mem_utilization);
     if(cg->st_mem_failcnt) rrdset_is_obsolete___safe_from_collector_thread(cg->st_mem_failcnt);
+    if(cg->st_mem_events) rrdset_is_obsolete___safe_from_collector_thread(cg->st_mem_events);
+    if(cg->st_mem_events_oom) rrdset_is_obsolete___safe_from_collector_thread(cg->st_mem_events_oom);
+    if(cg->st_mem_events_swap) rrdset_is_obsolete___safe_from_collector_thread(cg->st_mem_events_swap);
     if(cg->st_io) rrdset_is_obsolete___safe_from_collector_thread(cg->st_io);
     if(cg->st_serviced_ops) rrdset_is_obsolete___safe_from_collector_thread(cg->st_serviced_ops);
     if(cg->st_throttle_io) rrdset_is_obsolete___safe_from_collector_thread(cg->st_throttle_io);
@@ -112,10 +115,14 @@ static inline void cgroup_free(struct cgroup *cg) {
     freez(cg->cpuacct_cpu_shares.filename);
 
     arl_free(cg->memory.arl_base);
+    arl_free(cg->memory.arl_events);
+    arl_free(cg->memory.arl_swap_events);
     freez(cg->memory.filename_detailed);
     freez(cg->memory.filename_failcnt);
     freez(cg->memory.filename_usage_in_bytes);
     freez(cg->memory.filename_msw_usage_in_bytes);
+    freez(cg->memory.filename_events);
+    freez(cg->memory.filename_swap_events);
 
     freez(cg->io_service_bytes.filename);
     freez(cg->io_serviced.filename);
@@ -715,6 +722,20 @@ static inline void discovery_update_filenames_cgroup_v2(struct cgroup *cg) {
         snprintfz(filename, FILENAME_MAX, "%s%s/memory.stat", cgroup_unified_base, cg->id);
         if (!(cg->memory.staterr_mem_stat = stat(filename, &buf) != 0)) {
             cg->memory.filename_detailed = strdupz(filename);
+        }
+    }
+
+    if (unlikely(!cg->memory.staterr_events && !cg->memory.filename_events)) {
+        snprintfz(filename, FILENAME_MAX, "%s%s/memory.events", cgroup_unified_base, cg->id);
+        if (!(cg->memory.staterr_events = stat(filename, &buf) != 0)) {
+            cg->memory.filename_events = strdupz(filename);
+        }
+    }
+
+    if (unlikely(!cg->memory.staterr_swap_events && !cg->memory.filename_swap_events)) {
+        snprintfz(filename, FILENAME_MAX, "%s%s/memory.swap.events", cgroup_unified_base, cg->id);
+        if (!(cg->memory.staterr_swap_events = stat(filename, &buf) != 0)) {
+            cg->memory.filename_swap_events = strdupz(filename);
         }
     }
 

--- a/src/collectors/cgroups.plugin/cgroup-internals.h
+++ b/src/collectors/cgroups.plugin/cgroup-internals.h
@@ -99,6 +99,41 @@ struct memory {
     unsigned long long usage_in_bytes;
     unsigned long long msw_usage_in_bytes;
     unsigned long long failcnt;
+
+    // memory.events and memory.swap.events (cgroup v2 only)
+    // counters are hierarchical: they include events from descendant cgroups
+    // and survive the removal of the descendant that triggered them
+    ARL_BASE *arl_events;
+    ARL_ENTRY *arl_events_oom_group_kill;
+    ARL_ENTRY *arl_events_sock_throttled;
+    ARL_BASE *arl_swap_events;
+    ARL_ENTRY *arl_swap_events_high;
+
+    char *filename_events;
+    char *filename_swap_events;
+
+    bool staterr_events;
+    bool staterr_swap_events;
+
+    int updated_events;
+    int updated_swap_events;
+
+    // kernel-version dependent keys: oom_group_kill 5.17+, sock_throttled 6.19+, swap high 5.8+
+    int events_has_oom_group_kill;
+    int events_has_sock_throttled;
+    int swap_events_has_high;
+
+    unsigned long long events_low;
+    unsigned long long events_high;
+    unsigned long long events_max;
+    unsigned long long events_oom;
+    unsigned long long events_oom_kill;
+    unsigned long long events_oom_group_kill;
+    unsigned long long events_sock_throttled;
+
+    unsigned long long swap_events_high;
+    unsigned long long swap_events_max;
+    unsigned long long swap_events_fail;
 };
 
 // https://www.kernel.org/doc/Documentation/cgroup-v1/cpuacct.txt
@@ -263,6 +298,9 @@ struct cgroup {
     RRDSET *st_mem_usage;
     RRDSET *st_mem_usage_limit;
     RRDSET *st_mem_failcnt;
+    RRDSET *st_mem_events;
+    RRDSET *st_mem_events_oom;
+    RRDSET *st_mem_events_swap;
 
     // Blkio
     RRDSET *st_io;
@@ -473,6 +511,9 @@ void update_mem_writeback_chart(struct cgroup *cg);
 void update_mem_activity_chart(struct cgroup *cg);
 void update_mem_pgfaults_chart(struct cgroup *cg);
 void update_mem_failcnt_chart(struct cgroup *cg);
+void update_mem_events_chart(struct cgroup *cg);
+void update_mem_events_oom_chart(struct cgroup *cg);
+void update_mem_events_swap_chart(struct cgroup *cg);
 void update_mem_usage_chart(struct cgroup *cg);
 
 void update_io_serviced_bytes_chart(struct cgroup *cg);

--- a/src/collectors/cgroups.plugin/metadata.yaml
+++ b/src/collectors/cgroups.plugin/metadata.yaml
@@ -78,6 +78,10 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cgroups.conf
         metric: cgroup.mem_usage
         info: cgroup memory utilization
+      - name: cgroup_memory_limit_pressure
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cgroups.conf
+        metric: cgroup.mem_events
+        info: number of times the cgroup hit its memory limit (memory.max) in the last 10 minutes, forcing reclaim (OOM risk)
       - name: cgroup_1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cgroups.conf
         metric: cgroup.net_packets
@@ -197,6 +201,31 @@ modules:
               chart_type: line
               dimensions:
                 - name: failures
+            - name: cgroup.mem_events_oom
+              description: Out of Memory Events
+              unit: "events/s"
+              chart_type: line
+              dimensions:
+                - name: oom
+                - name: oom_kill
+                - name: oom_group_kill
+            - name: cgroup.mem_events
+              description: Memory Usage Events
+              unit: "events/s"
+              chart_type: line
+              dimensions:
+                - name: low
+                - name: high
+                - name: max
+                - name: sock_throttled
+            - name: cgroup.mem_events_swap
+              description: Swap Usage Events
+              unit: "events/s"
+              chart_type: line
+              dimensions:
+                - name: high
+                - name: max
+                - name: fail
             - name: cgroup.io
               description: I/O Bandwidth (all disks)
               unit: "KiB/s"
@@ -501,6 +530,10 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cgroups.conf
         metric: k8s.cgroup.mem_usage
         info: cgroup memory utilization
+      - name: k8s_cgroup_memory_limit_pressure
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cgroups.conf
+        metric: k8s.cgroup.mem_events
+        info: number of times the container hit its memory limit (memory.max) in the last 10 minutes, forcing reclaim (OOM risk)
       - name: k8s_cgroup_1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/cgroups.conf
         metric: k8s.cgroup.net_packets
@@ -634,6 +667,31 @@ modules:
               chart_type: line
               dimensions:
                 - name: failures
+            - name: k8s.cgroup.mem_events_oom
+              description: Out of Memory Events
+              unit: "events/s"
+              chart_type: line
+              dimensions:
+                - name: oom
+                - name: oom_kill
+                - name: oom_group_kill
+            - name: k8s.cgroup.mem_events
+              description: Memory Usage Events
+              unit: "events/s"
+              chart_type: line
+              dimensions:
+                - name: low
+                - name: high
+                - name: max
+                - name: sock_throttled
+            - name: k8s.cgroup.mem_events_swap
+              description: Swap Usage Events
+              unit: "events/s"
+              chart_type: line
+              dimensions:
+                - name: high
+                - name: max
+                - name: fail
             - name: k8s.cgroup.io
               description: I/O Bandwidth (all disks)
               unit: "KiB/s"
@@ -957,6 +1015,31 @@ modules:
               unit: failures/s
               chart_type: line
               dimensions:
+                - name: fail
+            - name: systemd.service.memory.oom_events
+              description: Systemd Services Out of Memory Events
+              unit: events/s
+              chart_type: line
+              dimensions:
+                - name: oom
+                - name: oom_kill
+                - name: oom_group_kill
+            - name: systemd.service.memory.events
+              description: Systemd Services Memory Usage Events
+              unit: events/s
+              chart_type: line
+              dimensions:
+                - name: low
+                - name: high
+                - name: max
+                - name: sock_throttled
+            - name: systemd.service.memory.swap_events
+              description: Systemd Services Swap Usage Events
+              unit: events/s
+              chart_type: line
+              dimensions:
+                - name: high
+                - name: max
                 - name: fail
             - name: systemd.service.memory.ram.usage
               description: Systemd Services Memory

--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -785,6 +785,8 @@ static inline void cgroup2_read_pressure(struct pressure *res) {
 
 static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unified) {
     static procfile *ff = NULL;
+    static procfile *ff_events = NULL;
+    static procfile *ff_swap_events = NULL;
 
     if(likely(mem->filename_detailed)) {
         ff = procfile_reopen(ff, mem->filename_detailed, NULL, CGROUP_PROCFILE_FLAG);
@@ -877,6 +879,80 @@ memory_next:
 
     if (likely(mem->filename_failcnt)) {
         mem->updated_failcnt = !read_single_number_file(mem->filename_failcnt, &mem->failcnt);
+    }
+
+    // memory.events and memory.swap.events are discovered only on cgroup v2
+    if (likely(mem->filename_events)) {
+        mem->updated_events = 0;
+
+        ff_events = procfile_reopen(ff_events, mem->filename_events, NULL, CGROUP_PROCFILE_FLAG);
+        if (likely(ff_events && (ff_events = procfile_readall(ff_events)))) {
+            if (unlikely(!mem->arl_events)) {
+                mem->arl_events = arl_create("cgroup/memory.events", NULL, 60);
+
+                arl_expect(mem->arl_events, "low", &mem->events_low);
+                arl_expect(mem->arl_events, "high", &mem->events_high);
+                arl_expect(mem->arl_events, "max", &mem->events_max);
+                arl_expect(mem->arl_events, "oom", &mem->events_oom);
+                arl_expect(mem->arl_events, "oom_kill", &mem->events_oom_kill);
+                mem->arl_events_oom_group_kill =
+                    arl_expect(mem->arl_events, "oom_group_kill", &mem->events_oom_group_kill);
+                mem->arl_events_sock_throttled =
+                    arl_expect(mem->arl_events, "sock_throttled", &mem->events_sock_throttled);
+            }
+
+            arl_begin(mem->arl_events);
+
+            unsigned long i, lines = procfile_lines(ff_events);
+            for (i = 0; i < lines; i++) {
+                if (arl_check(mem->arl_events, procfile_lineword(ff_events, i, 0), procfile_lineword(ff_events, i, 1)))
+                    break;
+            }
+
+            if (unlikely(!mem->events_has_oom_group_kill &&
+                         (mem->arl_events_oom_group_kill->flags & ARL_ENTRY_FLAG_FOUND)))
+                mem->events_has_oom_group_kill = 1;
+
+            if (unlikely(!mem->events_has_sock_throttled &&
+                         (mem->arl_events_sock_throttled->flags & ARL_ENTRY_FLAG_FOUND)))
+                mem->events_has_sock_throttled = 1;
+
+            mem->updated_events = 1;
+        }
+        else
+            cgroups_check = 1;
+    }
+
+    if (likely(mem->filename_swap_events)) {
+        mem->updated_swap_events = 0;
+
+        ff_swap_events = procfile_reopen(ff_swap_events, mem->filename_swap_events, NULL, CGROUP_PROCFILE_FLAG);
+        if (likely(ff_swap_events && (ff_swap_events = procfile_readall(ff_swap_events)))) {
+            if (unlikely(!mem->arl_swap_events)) {
+                mem->arl_swap_events = arl_create("cgroup/memory.swap.events", NULL, 60);
+
+                mem->arl_swap_events_high = arl_expect(mem->arl_swap_events, "high", &mem->swap_events_high);
+                arl_expect(mem->arl_swap_events, "max", &mem->swap_events_max);
+                arl_expect(mem->arl_swap_events, "fail", &mem->swap_events_fail);
+            }
+
+            arl_begin(mem->arl_swap_events);
+
+            unsigned long i, lines = procfile_lines(ff_swap_events);
+            for (i = 0; i < lines; i++) {
+                if (arl_check(
+                        mem->arl_swap_events, procfile_lineword(ff_swap_events, i, 0),
+                        procfile_lineword(ff_swap_events, i, 1)))
+                    break;
+            }
+
+            if (unlikely(!mem->swap_events_has_high && (mem->arl_swap_events_high->flags & ARL_ENTRY_FLAG_FOUND)))
+                mem->swap_events_has_high = 1;
+
+            mem->updated_swap_events = 1;
+        }
+        else
+            cgroups_check = 1;
     }
 }
 
@@ -1081,6 +1157,13 @@ void update_cgroup_systemd_services_charts() {
         if (likely(cg->memory.updated_failcnt)) {
             update_mem_failcnt_chart(cg);
         }
+        if (likely(cg->memory.updated_events)) {
+            update_mem_events_chart(cg);
+            update_mem_events_oom_chart(cg);
+        }
+        if (likely(cg->memory.updated_swap_events)) {
+            update_mem_events_swap_chart(cg);
+        }
         if (likely(cg->memory.updated_detailed)) {
             update_mem_usage_detailed_chart(cg);
             update_mem_writeback_chart(cg);
@@ -1210,6 +1293,15 @@ void update_cgroup_charts() {
 
         if (likely(cg->memory.updated_failcnt)) {
             update_mem_failcnt_chart(cg);
+        }
+
+        if (likely(cg->memory.updated_events)) {
+            update_mem_events_chart(cg);
+            update_mem_events_oom_chart(cg);
+        }
+
+        if (likely(cg->memory.updated_swap_events)) {
+            update_mem_events_swap_chart(cg);
         }
 
         cgroup_update_io_pids_charts(cg);

--- a/src/health/health.d/cgroups.conf
+++ b/src/health/health.d/cgroups.conf
@@ -31,6 +31,28 @@ host labels: _os=linux
        info: Cgroup ${label:cgroup_name} memory utilization
          to: silent
 
+# A cgroup's own oom_kill counter is NOT reliably alertable: on OOM the leaf
+# cgroup is usually torn down (single-process containers, k8s memory.oom.group,
+# systemd OOMPolicy=stop) before the next collection, so the increment and the
+# chart vanish. Reliable OOM-kill alerting is delivered by kmsg-plugin, which
+# records the event durably regardless of the cgroup's lifetime. Here we alert
+# on the reliable, observable-while-alive signal: the cgroup repeatedly hitting
+# its hard memory limit (memory.max), which forces reclaim and precedes an OOM.
+   template: cgroup_memory_limit_pressure
+         on: cgroup.mem_events
+      class: Utilization
+       type: Cgroups
+  component: Memory
+host labels: _os=linux
+     lookup: sum -10m unaligned of max
+      units: events
+      every: 1m
+       warn: $this > 0
+      delay: down 10m
+    summary: Cgroup ${label:cgroup_name} memory limit pressure
+       info: Cgroup ${label:cgroup_name} hit its memory limit (memory.max) ${this} times in the last 10 minutes, forcing reclaim (OOM risk)
+         to: silent
+
 # ---------------------------------K8s containers--------------------------------------------
 
    template: k8s_cgroup_10min_cpu_usage
@@ -64,4 +86,20 @@ host labels: _os=linux
     summary: Container ${label:k8s_container_name} pod ${label:k8s_pod_name} memory utilization
        info: container ${label:k8s_container_name} of pod ${label:k8s_pod_name} of namespace ${label:k8s_namespace}, \
              memory utilization
+         to: silent
+
+   template: k8s_cgroup_memory_limit_pressure
+         on: k8s.cgroup.mem_events
+      class: Utilization
+       type: Cgroups
+  component: Memory
+host labels: _os=linux
+     lookup: sum -10m unaligned of max
+      units: events
+      every: 1m
+       warn: $this > 0
+      delay: down 10m
+    summary: Container ${label:k8s_container_name} pod ${label:k8s_pod_name} memory limit pressure
+       info: Container ${label:k8s_container_name} of pod ${label:k8s_pod_name} of namespace ${label:k8s_namespace}, \
+             hit its memory limit (memory.max) ${this} times in the last 10 minutes, forcing reclaim (OOM risk)
          to: silent


### PR DESCRIPTION
## Summary

On cgroup v2, Netdata previously read none of the kernel's per-cgroup memory
pressure and OOM signals — only the v1 `memory.failcnt` exists, and v1 is
disappearing. This adds collection of `memory.events` and `memory.swap.events`
for every monitored cgroup (container, systemd service, k8s pod/container), so
DevOps/SREs can answer "is my service being memory-throttled?", "is this
workload pinned at its limit?", and see OOM activity where the kernel keeps it.

## What it collects

For each monitored cgroup on cgroup v2:

- **`memory.events`**: `low`, `high`, `max`, `oom`, `oom_kill`,
  `oom_group_kill` (kernel 5.17+), `sock_throttled` (kernel 6.19+)
- **`memory.swap.events`**: `high`, `max`, `fail`

## Charts

Three new charts per cgroup, in all three context families (`cgroup.*`,
`k8s.cgroup.*`, `systemd.service.*`):

- **Memory usage events** — `low` / `high` / `max`, plus `sock_throttled`
  where the kernel exposes the key
- **Out of memory events** — `oom` / `oom_kill`, plus `oom_group_kill` on 5.17+
- **Swap events** — `high` / `max` / `fail`, where `memory.swap.events` exists

All dimensions are incremental (events/s).

## Alerting

A leaf cgroup's `oom_kill` counter is **not** reliably alertable: on OOM the
cgroup is usually torn down before the next collection (single-process
containers, k8s `memory.oom.group`, systemd `OOMPolicy=stop`), so the increment
and its chart vanish and an alert on it can never fire. Rather than ship an
alert that structurally cannot fire, this adds a warning on the reliable,
observable-while-alive signal:

- **`cgroup_memory_limit_pressure`** / **`k8s_cgroup_memory_limit_pressure`** —
  fires when a cgroup repeatedly hits its hard memory limit (`memory.max`,
  the `max` dimension), which forces reclaim and precedes an OOM. Complements
  the existing `cgroup_ram_in_use` utilization alert.

The OOM charts are still collected and visualized. **Reliable OOM-kill
alerting** — recording *which* container/pod/service/process was killed,
durably, even after the cgroup vanishes — needs a durable record independent of
the cgroup's lifetime and is a deliberate follow-up (a dedicated kernel-log
plugin), intentionally out of scope here.

## Implementation notes

- Parsing follows the existing ARL pattern used for `memory.stat` and tolerates
  unknown/future kernel keys.
- Conditional dimensions are added only when the kernel exposes the key
  (following the existing `detailed_has_*` convention), so gaps stay data.
- Missing files (v1 systems, root cgroup) use the existing staterr-once
  discovery guard — no per-iteration log noise and no per-iteration allocation.

## Testing

- Verified against live `/sys/fs/cgroup` values on a Linux 7.0.10 host (docker
  containers, systemd services, real historical OOM counts in `system.slice`);
  conditional dimensions (`sock_throttled`, `oom_group_kill`, swap `high`)
  present and correct on that kernel.
- OOM churn test: chart-captured `oom_kill` matched the kernel file exactly for
  a container whose PID 1 survives its kill; the pressure chart captured the
  `max` reclaim storm. A single-process container removed within <1s of its
  kill confirmed the leaf-cgroup race — the motivation for the alerting choice
  above.
- Missing-file / v1 path: no error-log noise.
