### PR TITLE
cgroups: make netdata.cloud/ignore work for Kubernetes pod annotations

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -192,14 +192,21 @@ static char *cgroup_parse_resolved_name_and_labels(struct cgroup *cg, char *data
     while(data) {
         char *pair = strsep_skip_consecutive_separators(&data, ",");
 
-        if(strncmp(pair, CGROUP_NETDATA_CLOUD_LABEL_PREFIX, sizeof(CGROUP_NETDATA_CLOUD_LABEL_PREFIX) - 1) == 0) {
+        // the kubernetes resolver prefixes every label with "k8s_", including
+        // the netdata.cloud/* pod annotations, so accept the directives with
+        // and without that prefix
+        char *directive = pair;
+        if(strncmp(directive, "k8s_", sizeof("k8s_") - 1) == 0)
+            directive = &directive[sizeof("k8s_") - 1];
+
+        if(strncmp(directive, CGROUP_NETDATA_CLOUD_LABEL_PREFIX, sizeof(CGROUP_NETDATA_CLOUD_LABEL_PREFIX) - 1) == 0) {
             // a netdata.cloud label
-            char *key = &pair[sizeof(CGROUP_NETDATA_CLOUD_LABEL_PREFIX) - 1];
+            char *key = &directive[sizeof(CGROUP_NETDATA_CLOUD_LABEL_PREFIX) - 1];
 
             if(strncmp(key, CGROUP_RENAME_LABEL, sizeof(CGROUP_RENAME_LABEL) - 1) == 0) {
                 char *n = &key[sizeof(CGROUP_RENAME_LABEL) - 1];
                 size_t len = strlen(n);
-                if(n[0] == '"' && n[len - 1] == '"') {
+                if(len > 0 && n[0] == '"' && n[len - 1] == '"') {
                     n[len - 1] = '\0';
                     n++;
                 }


### PR DESCRIPTION
##### Summary

`netdata.cloud/ignore` has never worked as a Kubernetes pod annotation (and neither has `netdata.cloud/cgroup.name`).

The kubernetes leg of the `cgroup-name.sh` helper prefixes every label it emits with `k8s_` — including the `netdata.cloud/*` pod annotations (`cgroup-name.sh.in` lines 508/524). The parser in `cgroup-discovery.c` only recognizes pairs starting exactly with `netdata.cloud/` as directives, so a pod annotation arrives as `k8s_netdata.cloud/ignore="true"`, misses the check, and is added as a useless chart label instead of excluding the cgroup. Docker/Podman container labels are forwarded unprefixed, so the container-label path always worked — only the pod-annotation path was broken. Both halves shipped together in #19315 / #19316.

This change makes the parser accept the directives with and without the `k8s_` prefix, so `netdata.cloud/ignore` pod annotations work without changing the helper output contract. `netdata.cloud/cgroup.name` annotations start matching too, since both directives share the same prefix check. A matched prefixed directive is consumed like the unprefixed form instead of becoming a chart label. The rename-value quote check is also guarded against an empty value, which the annotation path makes reachable.

##### Test Plan

- Compiled `cgroup-discovery.c` with the change (no new warnings).
- Exercised the parser logic with a unit-level harness driving the function with:
  - an unprefixed rename directive (container-label path — unchanged behavior);
  - `k8s_`-prefixed rename and ignore directives (now applied and consumed; sibling `k8s_*` labels untouched);
  - an empty rename value (no rename, no out-of-bounds read);
  - a plain `k8s_*` label (still added as a chart label as-is).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Kubernetes pod annotations `netdata.cloud/ignore` and `netdata.cloud/cgroup.name` by accepting `k8s_`-prefixed directives in the cgroup label parser. This fixes pods not being excluded/renamed and prevents prefixed directives from leaking as chart labels.

- **Bug Fixes**
  - Treat `k8s_netdata.cloud/*` the same as unprefixed directives; consume them instead of adding labels.
  - Apply `netdata.cloud/ignore` and `netdata.cloud/cgroup.name` from pod annotations; container label handling unchanged.
  - Safeguard rename quote stripping when the value is empty to avoid out-of-bounds access.

<sup>Written for commit d90869f74a703e43d7fd20e22ef53c44fa5278c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

