### PR TITLE
Netdata fixes part 52

### DIFF
--- a/src/aclk/aclk_alarm_api.c
+++ b/src/aclk/aclk_alarm_api.c
@@ -13,6 +13,11 @@ void aclk_send_alarm_log_entry(struct alarm_log_entry *log_entry)
     size_t payload_size;
     char *payload = generate_alarm_log_entry(&payload_size, log_entry);
 
+    if (!payload) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "Failed to generate payload");
+        return;
+    }
+
     aclk_send_bin_msg(payload, payload_size, ACLK_TOPICID_ALARM_LOG, "AlarmLogEntry");
 }
 

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -4,6 +4,7 @@
 #include "daemon/common.h"
 
 static uv_pipe_t client_pipe;
+static bool client_pipe_close_requested;
 static uv_write_t write_req;
 static uv_shutdown_t shutdown_req;
 
@@ -11,6 +12,14 @@ static char command_string[MAX_COMMAND_LENGTH];
 static unsigned command_string_size;
 
 static int exit_status;
+
+static void close_client_pipe(void)
+{
+    if (!client_pipe_close_requested) {
+        client_pipe_close_requested = true;
+        uv_close((uv_handle_t *)&client_pipe, NULL);
+    }
+}
 
 struct command_context {
     uv_work_t work;
@@ -114,7 +123,7 @@ static void shutdown_cb(uv_shutdown_t* req, int status)
     ret = uv_read_start((uv_stream_t *)&client_pipe, alloc_cb, pipe_read_cb);
     if (ret) {
         fprintf(stderr, "uv_read_start(): %s\n", uv_strerror(ret));
-        uv_close((uv_handle_t *)&client_pipe, NULL);
+        close_client_pipe();
         return;
     }
 }
@@ -131,7 +140,7 @@ static void pipe_write_cb(uv_write_t* req, int status)
     ret = uv_shutdown(&shutdown_req, (uv_stream_t *)&client_pipe, shutdown_cb);
     if (ret) {
         fprintf(stderr, "uv_shutdown(): %s\n", uv_strerror(ret));
-        uv_close((uv_handle_t *)&client_pipe, NULL);
+        close_client_pipe();
         return;
     }
 }
@@ -205,7 +214,7 @@ int main(int argc, char **argv)
 
     uv_run(loop, UV_RUN_DEFAULT);
 
-    uv_close((uv_handle_t *)&client_pipe, NULL);
+    close_client_pipe();
     buffer_free(client_pipe.data);
 
     return exit_status;

--- a/src/collectors/log2journal/log2journal-params.c
+++ b/src/collectors/log2journal/log2journal-params.c
@@ -196,7 +196,7 @@ RW_FLAGS parse_rewrite_flags(const char *options) {
 
     // Tokenize the input options using ","
     char *token;
-    char *optionsCopy = strdup(options); // Make a copy to avoid modifying the original
+    char *optionsCopy = strdupz(options); // Make a copy to avoid modifying the original
     token = strtok(optionsCopy, ",");
 
     while (token != NULL) {
@@ -222,7 +222,7 @@ RW_FLAGS parse_rewrite_flags(const char *options) {
         token = strtok(NULL, ",");
     }
 
-    free(optionsCopy); // Free the copied string
+    freez(optionsCopy); // Free the copied string
 
     return flags;
 }
@@ -270,7 +270,7 @@ static bool parse_rewrite(LOG_JOB *jb, const char *param) {
     // Extract key, search pattern, and replacement pattern
     char *key = strndupz(param, equal_sign - param);
     char *search_pattern = strndupz(equal_sign + 2, second_separator - (equal_sign + 2));
-    char *replace_pattern = third_separator ? strndup(second_separator + 1, third_separator - (second_separator + 1)) : strdupz(second_separator + 1);
+    char *replace_pattern = third_separator ? strndupz(second_separator + 1, third_separator - (second_separator + 1)) : strdupz(second_separator + 1);
 
     if(!*search_pattern)
         flags &= ~RW_MATCH_PCRE2;

--- a/src/libnetdata/atomics/atomic_flags.h
+++ b/src/libnetdata/atomics/atomic_flags.h
@@ -17,7 +17,8 @@
 
 // returns the old flags (before applying the changes)
 #define atomic_flags_set_and_clear(pvalue, set, clear) ({                    \
-    __typeof__(*pvalue) __old = *(pvalue), __new;                            \
+    __typeof__(*pvalue) __old =                                             \
+        __atomic_load_n((pvalue), __ATOMIC_RELAXED), __new;                  \
     do {                                                                     \
         __new = (__old | (set)) & ~(clear);                                  \
     } while(!__atomic_compare_exchange_n((pvalue), &__old, __new,            \

--- a/src/libnetdata/buffer/buffer.h
+++ b/src/libnetdata/buffer/buffer.h
@@ -158,10 +158,13 @@ static const char *buffer_tostring(BUFFER *wb)
 
 ALWAYS_INLINE
 static void _buffer_json_depth_push(BUFFER *wb, BUFFER_JSON_NODE_TYPE type) {
-#ifdef NETDATA_INTERNAL_CHECKS
-    assert(wb->json.depth <= BUFFER_JSON_MAX_DEPTH && "BUFFER JSON: max nesting reached");
-#endif
-    wb->json.depth++;
+    int next_depth = wb->json.depth + 1;
+
+    if(unlikely(next_depth < 0 || next_depth >= BUFFER_JSON_MAX_DEPTH))
+        fatal("BUFFER JSON: invalid nesting depth %d (next %d, max %d)",
+              wb->json.depth, next_depth, BUFFER_JSON_MAX_DEPTH - 1);
+
+    wb->json.depth = (int8_t)next_depth;
 #ifdef NETDATA_INTERNAL_CHECKS
     assert(wb->json.depth >= 0 && "Depth wrapped around and is negative");
 #endif

--- a/src/libnetdata/c_rhash/c_rhash.c
+++ b/src/libnetdata/c_rhash/c_rhash.c
@@ -10,7 +10,7 @@ c_rhash c_rhash_new(size_t bin_count) {
     if (unlikely(bin_count > (SIZE_MAX - sizeof(struct c_rhash_s)) / sizeof(c_rhash_bin)))
         fatal("C_RHASH: bin count is too large.");
 
-    c_rhash hash = callocz(1, sizeof(struct c_rhash_s) + (bin_count * sizeof(struct bin_ll*)) );
+    c_rhash hash = callocz(1, sizeof(struct c_rhash_s) + (bin_count * sizeof(c_rhash_bin)) );
     hash->bin_count = bin_count;
     hash->bins = (c_rhash_bin *)((char*)hash + sizeof(struct c_rhash_s));
 

--- a/src/libnetdata/os/windows-perflib/perflib-names.c
+++ b/src/libnetdata/os/windows-perflib/perflib-names.c
@@ -144,22 +144,34 @@ const char *RegistryFindHelpByID(DWORD id) {
 
 // ----------------------------------------------------------
 
+static inline bool registry_multi_sz_strlen(const char *ptr, const char *end, size_t *len) {
+    if(ptr >= end)
+        return false;
+
+    const char *nul = memchr(ptr, '\0', (size_t)(end - ptr));
+    if(!nul)
+        return false;
+
+    *len = (size_t)(nul - ptr);
+    return true;
+}
+
 static inline void readRegistryKeys_unsafe(BOOL helps) {
-    TCHAR *pData = NULL;
+    char *pData = NULL;
 
     HKEY hKey;
     DWORD dwType;
     DWORD dwSize = 0;
     LONG lStatus;
 
-    LPCSTR valueName;
+    const char *valueName;
     if(helps)
-        valueName = TEXT("help");
+        valueName = "help";
     else
-        valueName = TEXT("CounterDefinition");
+        valueName = "CounterDefinition";
 
     // Open the key for the English counters
-    lStatus = RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT(REGISTRY_KEY), 0, KEY_READ, &hKey);
+    lStatus = RegOpenKeyExA(HKEY_LOCAL_MACHINE, REGISTRY_KEY, 0, KEY_READ, &hKey);
     if (lStatus != ERROR_SUCCESS) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "Failed to open registry key HKEY_LOCAL_MACHINE, subkey '%s', error %ld\n", REGISTRY_KEY, (long)lStatus);
@@ -167,7 +179,7 @@ static inline void readRegistryKeys_unsafe(BOOL helps) {
     }
 
     // Get the size of the 'Counters' data
-    lStatus = RegQueryValueEx(hKey, valueName, NULL, &dwType, NULL, &dwSize);
+    lStatus = RegQueryValueExA(hKey, valueName, NULL, &dwType, NULL, &dwSize);
     if (lStatus != ERROR_SUCCESS) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "Failed to get registry key HKEY_LOCAL_MACHINE, subkey '%s', value '%s', size of data, error %ld\n",
@@ -179,7 +191,7 @@ static inline void readRegistryKeys_unsafe(BOOL helps) {
     pData = mallocz(dwSize);
 
     // Read the 'Counters' data
-    lStatus = RegQueryValueEx(hKey, valueName, NULL, &dwType, (LPBYTE)pData, &dwSize);
+    lStatus = RegQueryValueExA(hKey, valueName, NULL, &dwType, (LPBYTE)pData, &dwSize);
     if (lStatus != ERROR_SUCCESS || dwType != REG_MULTI_SZ) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "Failed to get registry key HKEY_LOCAL_MACHINE, subkey '%s', value '%s', data, error %ld\n",
@@ -188,11 +200,15 @@ static inline void readRegistryKeys_unsafe(BOOL helps) {
     }
 
     // Process the counter data
-    TCHAR *ptr = pData;
-    TCHAR *end_ptr = pData + dwSize;
-    while (*ptr && ptr < end_ptr - 1) {
-        TCHAR *sid = ptr;  // First string is the ID
-        size_t sid_len = lstrlen(ptr);
+    char *ptr = pData;
+    char *end_ptr = pData + dwSize;
+    while (ptr < end_ptr && *ptr) {
+        char *sid = ptr;  // First string is the ID
+        size_t sid_len;
+        if(!registry_multi_sz_strlen(ptr, end_ptr, &sid_len)) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR, "Registry data truncated while reading ID, aborting");
+            break;
+        }
         
         // Check for valid ID string
         if (sid_len == 0) {
@@ -200,16 +216,19 @@ static inline void readRegistryKeys_unsafe(BOOL helps) {
             break;
         }
         
-        // Check for buffer overrun
-        if (ptr + sid_len + 1 >= end_ptr) {
+        ptr += sid_len + 1; // Move to the next string
+
+        if (ptr >= end_ptr) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "Registry data truncated after ID, aborting");
             break;
         }
-        
-        ptr += sid_len + 1; // Move to the next string
-        
-        TCHAR *name = ptr;  // Second string is the name
-        size_t name_len = lstrlen(ptr);
+
+        char *name = ptr;  // Second string is the name
+        size_t name_len;
+        if(!registry_multi_sz_strlen(ptr, end_ptr, &name_len)) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR, "Registry data truncated while reading name, aborting");
+            break;
+        }
         
         // Check for empty name
         if (name_len == 0) {
@@ -218,13 +237,7 @@ static inline void readRegistryKeys_unsafe(BOOL helps) {
             ptr += 1;
             continue;
         }
-        
-        // Check for buffer overrun
-        if (ptr + name_len + 1 > end_ptr) {
-            nd_log(NDLS_COLLECTORS, NDLP_ERR, "Registry data truncated after name, aborting");
-            break;
-        }
-        
+
         ptr += name_len + 1; // Move to the next pair
         
         // Convert ID to number with validation

--- a/src/libnetdata/spawn_server/spawn_server_windows.c
+++ b/src/libnetdata/spawn_server/spawn_server_windows.c
@@ -25,7 +25,11 @@ static void update_cygpath_env(void) {
     char win_path[MAX_PATH];
 
     // Convert Cygwin root path to Windows path
-    cygwin_conv_path(CCP_POSIX_TO_WIN_A, "/", win_path, sizeof(win_path));
+    errno_clear();
+    if(cygwin_conv_path(CCP_POSIX_TO_WIN_A, "/", win_path, sizeof(win_path)) != 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot convert Cygwin/MSYS2 base path to Windows path: %s", strerror(errno));
+        return;
+    }
 
     nd_setenv("NETDATA_CYGWIN_BASE_PATH", win_path, 1);
 

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -323,6 +323,7 @@ static int append_slash_to_url_and_redirect(struct web_client *w) {
 
     buffer_strcat(w->response.header, "Location: ");
     const char *b = buffer_tostring(w->url_as_received);
+    size_t url_len = buffer_strlen(w->url_as_received);
     const char *q = strchr(b, '?');
     if(q && q > b) {
         const char *e = q - 1;
@@ -335,7 +336,8 @@ static int append_slash_to_url_and_redirect(struct web_client *w) {
         buffer_strcat(w->response.header, q);
     }
     else {
-        const char *e = &b[buffer_strlen(w->url_as_received) - 1];
+        const char *e = b + url_len;
+        if(e > b) e--;
         while(e > b && *e != '/') e--;
         if(*e == '/') e++;
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened error paths and bounds checks across ACLK, CLI, JSON buffer, Windows perflib, and web redirect code. Prevents crashes, out‑of‑bounds reads, and undefined behavior without changing normal behavior.

- **Bug Fixes**
  - ACLK: check `generate_alarm_log_entry()` result before send; log and return on failure.
  - CLI: gate `uv_close()` with a single close helper to avoid double-closing the client pipe.
  - log2journal: use `strdupz/strndupz/freez` in rewrite parsing to follow fatal-on-OOM behavior.
  - Atomics: seed CAS with `__atomic_load_n` in `atomic_flags_set_and_clear()` to avoid data races.
  - Buffer JSON: validate next depth; `fatal` on overflow/underflow to prevent stack overrun.
  - c_rhash: allocate bins with `sizeof(c_rhash_bin)` to match the guard and element type.
  - Windows: make perflib REG_MULTI_SZ parsing byte-safe (`Reg*ExA` + bounded `memchr`); guard truncation. Check Cygwin path conversion and skip export on failure.
  - Web: handle empty URL in slash-redirect to avoid underflow; emit "/" when empty.

<sup>Written for commit ea263d5e1b28fe93e551d357a0299128b805bc7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

