### PR TITLE
docs(mcp): document MCP Connections (Netdata Cloud as MCP client)

### DIFF
--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -899,7 +899,7 @@ sidebar:
               label: Chat with Netdata
               edit_url: https://github.com/netdata/netdata/edit/master/docs/netdata-ai/mcp/ai-chat-netdata.md
           - meta:
-              label: MCP Clients
+              label: Supported AI Clients
               edit_url: https://github.com/netdata/netdata/edit/master/docs/netdata-ai/mcp/mcp-clients/ai-devops-copilot.md
             items:
               - meta:
@@ -929,6 +929,9 @@ sidebar:
               - meta:
                   label: OpenCode
                   edit_url: https://github.com/netdata/netdata/edit/master/docs/netdata-ai/mcp/mcp-clients/opencode.md
+          - meta:
+              label: MCP Connections
+              edit_url: https://github.com/netdata/netdata/edit/master/docs/netdata-ai/mcp/mcp-connections.md
   # Dashboards and Charts
   - meta:
       label: Dashboards and Charts

--- a/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md
+++ b/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md
@@ -50,7 +50,7 @@ Local, unsupervised ML runs on every agent, learning normal behavior and scoring
 
 ### 7) MCP (Model Context Protocol)
 
-Connect AI clients to Netdata’s MCP server to bring live observability into natural‑language workflows and optional automation. Options include [MCP](/docs/netdata-ai/mcp/README.md), [Chat with Netdata](/docs/netdata-ai/mcp/ai-chat-netdata.md), and [MCP Clients](/docs/netdata-ai/mcp/mcp-clients/ai-devops-copilot.md) like Claude Desktop, Cursor, VS Code, JetBrains IDEs, Claude Code, Gemini CLI, and the Netdata Web Client.
+Connect AI clients to Netdata’s MCP server to bring live observability into natural‑language workflows and optional automation. Options include [MCP](/docs/netdata-ai/mcp/README.md), [Chat with Netdata](/docs/netdata-ai/mcp/ai-chat-netdata.md), and [Supported AI Clients](/docs/netdata-ai/mcp/mcp-clients/ai-devops-copilot.md) like Claude Desktop, Cursor, VS Code, JetBrains IDEs, Claude Code, Gemini CLI, and the Netdata Web Client. Netdata Cloud can also act as an MCP client that connects to your own tools — see [MCP Connections](/docs/netdata-ai/mcp/mcp-connections.md).
 
 ## Usage and credits
 

--- a/docs/netdata-ai/mcp/README.md
+++ b/docs/netdata-ai/mcp/README.md
@@ -1,6 +1,13 @@
 # Netdata MCP
 
-Netdata provides [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers that enable AI assistants to interact with your infrastructure monitoring data. You can connect via:
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) works in **two directions** with Netdata:
+
+- **Netdata as an MCP server** — AI assistants and clients (Claude, Cursor, VS Code, CLIs, and more) connect *to* Netdata to query your infrastructure. **This page** covers server setup; for per-client instructions see [Supported AI Clients](/docs/netdata-ai/mcp/mcp-clients/ai-devops-copilot.md).
+- **Netdata as an MCP client** — Netdata Cloud connects *out* to your own MCP servers (GitHub, PagerDuty, Atlassian, or any custom HTTPS MCP server) so Netdata AI can pull your team's institutional context into troubleshooting. See [MCP Connections](/docs/netdata-ai/mcp/mcp-connections.md).
+
+The rest of this page covers **Netdata as an MCP server**.
+
+Netdata provides MCP servers that enable AI assistants to interact with your infrastructure monitoring data. You can connect via:
 
 - **[Netdata Cloud](#netdata-cloud-mcp)** — A single cloud-hosted endpoint at `https://app.netdata.cloud/api/v1/mcp` with full visibility across all your nodes. No bridges, no firewall changes.
 - **[Local Agent or Parent](#local-agent-or-parent-mcp)** —

--- a/docs/netdata-ai/mcp/mcp-clients/ai-devops-copilot.md
+++ b/docs/netdata-ai/mcp/mcp-clients/ai-devops-copilot.md
@@ -1,6 +1,8 @@
-# MCP Clients
+# Supported AI Clients
 
-Model Context Protocol (MCP) clients like **Claude Desktop**, **Cursor**, **Visual Studio Code**, **JetBrains IDEs**, **Netdata Web Client**, **Claude Code**, and **Gemini CLI** can connect to Netdata’s MCP server to bring real observability data into your AI workflows. This enables natural‑language analysis with context from your infrastructure and, for CLI tools, optional automation.
+AI clients like **Claude Desktop**, **Cursor**, **Visual Studio Code**, **JetBrains IDEs**, **Netdata Web Client**, **Claude Code**, and **Gemini CLI** act as Model Context Protocol (MCP) clients that connect to Netdata's MCP server to bring real observability data into your AI workflows. This enables natural‑language analysis with context from your infrastructure and, for CLI tools, optional automation.
+
+> **Looking for the other direction?** To let Netdata Cloud connect *out* to your own MCP servers (GitHub, PagerDuty, Atlassian, custom) and pull that context into Netdata AI, see [MCP Connections](/docs/netdata-ai/mcp/mcp-connections.md).
 
 ## The power of MCP clients
 

--- a/docs/netdata-ai/mcp/mcp-connections.md
+++ b/docs/netdata-ai/mcp/mcp-connections.md
@@ -1,0 +1,74 @@
+# MCP Connections
+
+An alert tells you *what* changed. It rarely tells you *why*. That answer usually lives somewhere else — the pull request that shipped minutes earlier, the incident already open in PagerDuty, the runbook sitting in Confluence.
+
+**MCP Connections** let Netdata AI reach those systems directly. Through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), Netdata Cloud acts as an **MCP client** and connects to the tools your team already runs, reading from them while it investigates. It correlates the metrics and anomalies Netdata detects on every node with the context in your stack — so it can tie a latency spike to the deploy that caused it, link an anomaly to the incident already tracking it, and surface the relevant runbook without you going to look for it.
+
+This is the reverse of connecting an AI client *to* Netdata. Here, **Netdata reaches out to your MCP servers**. To instead connect an AI assistant (Claude, Cursor, a CLI) to Netdata's own MCP server, see [Supported AI Clients](/docs/netdata-ai/mcp/mcp-clients/ai-devops-copilot.md).
+
+![MCP Connections settings](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-settings.png)
+
+## Prerequisites
+
+- A **Netdata Cloud** account on a **Paid plan**.
+- **Space admin** access — MCP Connections are configured per Space, under **Settings → AI → MCP Connections**.
+- A reachable **MCP server** to connect to. Netdata ships built-in integrations for popular providers (GitHub, PagerDuty, Atlassian Cloud for Jira/Confluence/Bitbucket) and a **Custom MCP Server** option for any HTTPS MCP endpoint.
+
+## Configure a new integration
+
+1. Go to **Settings → AI → MCP Connections**.
+2. Select an integration, such as **GitHub**, or choose **Custom MCP Server** to point at your own HTTPS MCP endpoint.
+3. Choose an authentication method (see [Authentication methods](#authentication-methods) below). The available options depend on the integration.
+
+   ![Choose an authentication method](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-auth.png)
+
+4. Provide the required configuration parameters — such as the connection name or account region — then click **Connect & discover tools**.
+
+   ![Connection parameters](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-connection.png)
+
+   For **OAuth** integrations, you'll be redirected to the provider to authorize Netdata. Once you approve, you're sent back and the connection is established automatically.
+
+   ![Authorize Netdata](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-authorize.png)
+
+5. On success, Netdata retrieves the tools the remote MCP server exposes. Select the tools you want to make available for this connection.
+
+   **Netdata only enables read-only tools.** The server may advertise tools that create, modify, or delete data (for example "Create an incident" or "Delete a team") — these appear in the discovered list but **cannot be enabled** from the Netdata UI. Netdata AI reads context; it does not act on your systems.
+
+   ![Select read-only tools](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-tools.png)
+
+6. Click **Save Changes** to complete the configuration. Enabled tools are not active until you save.
+
+## Authentication methods
+
+| Method | Who authenticates | Scope | When to use |
+|--------|-------------------|-------|-------------|
+| **Bearer token** | One shared token, entered once | All users in the Space share this single token | Providers that authenticate with an access token; simplest setup |
+| **OAuth** | Each user authorizes individually with their own credentials | Per user | The standard method for most integrations; keeps per-user access boundaries intact |
+
+For OAuth integrations, enabling a tool does **not** widen access: each user is still restricted by their own permissions on the underlying resource. A user only sees what they're already allowed to see in the connected system.
+
+## Using MCP servers
+
+Once a connection is saved, Netdata AI can use it during investigations. You control which servers are used, per conversation and per report.
+
+### In a conversation
+
+During a conversation you can see all MCP servers enabled for your Space and toggle them on or off for that conversation. The **Connected tools** row shows which servers Netdata AI will draw on as it answers.
+
+![Toggle MCP servers in a conversation](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-conversation.png)
+
+See [Conversations](/docs/netdata-ai/conversations.md) for more on live, interactive troubleshooting.
+
+### In reports and investigations
+
+When generating a report, you can select which MCP servers to include before the report runs — so a scheduled Insight or a Custom Investigation can pull in code changes, incidents, or on-call context alongside the metrics.
+
+![Select MCP servers for a report](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-reports.png)
+
+See [Investigations](/docs/netdata-ai/investigations/index.md) and [Scheduled Reports](/docs/netdata-ai/insights/scheduled-reports.md).
+
+## Security and access
+
+- **Read-only by design.** Only read-only tools can be enabled; mutating actions are never available through Netdata.
+- **OAuth respects your permissions.** With OAuth, each user authenticates individually and is limited to what they can already access in the connected system.
+- **Bearer tokens are Space-wide.** A bearer token is shared by everyone in the Space, so use it for providers where a shared, scoped access token is appropriate.


### PR DESCRIPTION
## What

Documents the new **MCP Connections** feature — Netdata Cloud acting as an **MCP client** that connects to the user's own MCP servers (GitHub, PagerDuty, Atlassian, custom) to bring institutional context (PRs, incidents, runbooks) into Netdata AI investigations.

It also fixes a naming collision: the existing MCP docs only covered the *reverse* direction (Netdata as an MCP **server** that AI clients connect to) and reused the word "client" for that opposite meaning.

## Changes

- **New page** `docs/netdata-ai/mcp/mcp-connections.md` — configuration (auth methods, read-only tool selection) and use in Conversations and Reports, with screenshots.
- **Reframed** the MCP `README.md` intro around the two directions (Netdata as server vs. Netdata as client), linking both subsections.
- **Renamed** the "MCP Clients" subsection → **"Supported AI Clients"** (sidebar label + page H1), with a pointer to the new page. The file name is unchanged, so all inbound links stay valid (no redirects needed).
- Wired the new page into `docs/.map/map.yaml`.
- Updated the stale link text in the ML/troubleshooting category overview.

Resulting sidebar:

```
MCP
├── Chat with Netdata
├── Supported AI Clients   (was "MCP Clients")
│     Claude Desktop · Cursor · VS Code · JetBrains · Claude Code ·
│     Gemini CLI · Codex CLI · Crush · OpenCode
└── MCP Connections        (new)
```

## Notes

- Screenshots live in `netdata/docs-images` (netdata/docs-images#12, merged); image URLs verified `200`.
- Feature is documented as **Paid plan**. Only **read-only** tools can be enabled — write actions the server exposes are shown but cannot be turned on in Netdata (confirmed with the feature owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents MCP Connections, letting Netdata Cloud act as an MCP client to connect to your MCP servers (GitHub, PagerDuty, Atlassian, custom) and bring context into investigations. Clarifies the MCP docs to distinguish server vs. client and updates nav labels.

- **New Features**
  - Added `docs/netdata-ai/mcp/mcp-connections.md` covering setup, auth (OAuth and bearer token), and usage in Conversations and Reports.
  - Only read‑only tools can be enabled; write actions are never available. Feature is for Paid plans.
  - Added “MCP Connections” to the sidebar.

- **Refactors**
  - Reframed `docs/netdata-ai/mcp/README.md` intro around two directions (Netdata as server vs. client) with links.
  - Renamed “MCP Clients” to “Supported AI Clients” (sidebar label and page H1) and added a pointer to MCP Connections; file path unchanged.
  - Updated the ML/troubleshooting category overview link text to match and reference MCP Connections.

<sup>Written for commit 9a54741fd262827d27aea313ca9e818e221c0b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

