### PR TITLE
feat(go.d/metrix): transactional, bounded descriptor lifecycle

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -122,10 +122,21 @@ source files for evidence.
   option for V2 charts.
 - Put multipliers, divisors, hidden flags, and float formatting in the chart
   template, not ad hoc chart-emission code.
-- `metrix` registers a descriptor per metric NAME permanently (no unregister), so
-  re-registering a name with a changed kind, summary quantile set, or histogram
-  bounds PANICS. When a name's contract can drift across cycles, keep the per-name
-  handle for the job lifetime and SKIP a drifted series instead of re-registering.
+- `metrix` keeps ONE descriptor per metric NAME, resolved atomically at commit and
+  BOUNDED: a name idle past its retention window (`expireAfterSuccessCycles +
+  descriptorGraceCycles`, both configurable on `NewCollectorStore(...)`) is evicted
+  and can then re-register with a changed contract. Within that window the
+  descriptor is authoritative — re-registering a TRULY-LIVE name with a changed
+  kind / summary quantiles / histogram bounds fails the commit (loud), an idle name
+  is superseded, and Init-time (out-of-cycle) registration still panics
+  synchronously on conflict.
+- If a collector caches per-name handles ACROSS cycles, it MUST NOT keep them for
+  the job lifetime: couple their lifetime to the descriptor window via the optional
+  `metrix.DescriptorRetention` accessor (`DescriptorRetentionWindow()`,
+  `SuccessfulCommits()`), or a stale handle drift-skips a changed-contract name
+  forever after `metrix` evicts the descriptor. The prometheus writer
+  (`collector/prometheus/writer.go`) is the reference; see
+  `src/go/pkg/metrix/README.md` ("Descriptor Lifecycle and Retention").
 - To reproduce a V1 chart context in a migration, inject `context_namespace` (the
   fixed prefix, or `prefix.<app>` per job) so autogen rebuilds `prefix.<metric>` /
   `prefix.<app>.<metric>` without hand-built chart IDs.

--- a/src/go/pkg/metrix/README.md
+++ b/src/go/pkg/metrix/README.md
@@ -1,76 +1,268 @@
 # metrix
 
-`metrix` is the metrics storage and read API used by go.d `ModuleV2` collectors and runtime/internal components.
+`metrix` is the metrics storage and read API used by go.d `ModuleV2` collectors
+and runtime/internal components. A collector writes metrics into a store each
+collect cycle; readers (chart planning, tooling) see a consistent, immutable
+snapshot of the last successful cycle.
+
+This document is human-oriented. Read it top to bottom as a journey: the
+plain-language model first, then the collect cycle, then the part that makes
+metrix safe for unbounded metric streams — **descriptor identity and
+retention** — and finally the precise API reference, contracts, and pitfalls.
 
 **Audience**: `ModuleV2` collector authors and framework contributors.
 
 **See also**: [charttpl](/src/go/plugin/framework/charttpl/README.md) (template DSL),
-[chartengine](/src/go/plugin/framework/chartengine/README.md) (compile + plan).
+[chartengine](/src/go/plugin/framework/chartengine/README.md) (compile + plan),
+[how-to-write-a-collector.md](/src/go/plugin/go.d/docs/how-to-write-a-collector.md)
+(end-to-end integration).
 
-## Purpose
+## What metrix Does
+
+A collector does not build charts or hold metric state itself. It **observes
+values into a store**, and the store owns everything else: series identity,
+per-name descriptors, snapshot publication, and lifecycle.
+
+The central rule is simple:
+
+> One metric **name** has exactly one **descriptor**. The store resolves and
+> publishes that descriptor atomically at commit, keeps it while the name is in
+> use, and **evicts it after the name goes idle** — so an unbounded stream of
+> metric names (statsd, push, client-driven names) cannot grow the store without
+> bound.
+
+Two store flavors exist for two kinds of producer:
 
 | Consumer                         | Store type       | Typical usage                                              |
 |----------------------------------|------------------|------------------------------------------------------------|
 | Collector jobs (`ModuleV2`)      | `CollectorStore` | Cycle-scoped writes, snapshot reads, chart planning input  |
 | Internal/runtime instrumentation | `RuntimeStore`   | Stateful immediate-commit writes, runtime metrics planning |
 
-## Core Concepts
+The rest of this document is mostly about `CollectorStore` (the cycle model and
+the descriptor lifecycle). `RuntimeStore` differences are called out where they
+matter.
 
-- **Immutable reads** — Readers observe immutable snapshots that are swapped atomically on commit. Multiple goroutines can read concurrently without locking.
-- **Cycle-scoped collector writes** — `CollectorStore` writes are staged between `BeginCycle` and `CommitCycleSuccess`. Nothing is visible to readers until commit.
-- **Stateful runtime writes** — `RuntimeStore` writes are committed immediately (no cycle API). Each write produces a new overlay snapshot.
-- **Label canonicalization** — Label maps (`map[string]string`) are sorted and encoded into a canonical key that uniquely identifies a series (metric name + labels).
-- **Typed + flattened views** — Reader supports canonical typed families (Histogram, Summary, StateSet, MeasureSet) and a flattened scalar view where complex types are projected into individual scalar series.
+## The Big Picture
 
-## Key Definitions
+A few words carry the whole model. This table is the vocabulary the rest of the
+document uses; later sections make each part precise.
 
-- **Freshness** controls which series appear in non-raw reads.
-  `FreshnessCycle` = series must be observed in the latest successful cycle to be visible.
-  `FreshnessCommitted` = series is visible as long as it's committed, even if not re-observed.
-- **Window** controls how stateful histogram/summary instruments accumulate observations.
-  `WindowCumulative` = observations accumulate across cycles.
-  `WindowCycle` = observations reset each cycle.
+| Term | Plain meaning |
+| --- | --- |
+| **Series** | One time series: a metric **name** plus a canonical **label set**. |
+| **Descriptor** | The per-**name** contract: kind (gauge/counter/…), mode, freshness, window, type schema (histogram bounds / summary quantiles), and metadata. One per name. |
+| **Cycle** | One collect round. Collector writes are **staged**, then published all-at-once on success. |
+| **Snapshot** | The immutable published view readers see. Swapped atomically at commit. |
+| **Freshness** | Whether a not-recently-observed series is still visible to normal reads. |
+| **Window** | Whether a stateful histogram/summary accumulates across cycles or resets each cycle. |
+| **Retention** | How long an idle series, then its descriptor, are kept before eviction. |
 
-## Stores and Interfaces
+The flow from a collector write to a reader read:
 
-| Interface           | Key methods                                             | Notes                                   |
-|---------------------|---------------------------------------------------------|-----------------------------------------|
-| `CollectorStore`    | `Read(...)`, `Write()`                                  | Default collector-facing store          |
-| `RuntimeStore`      | `Read(...)`, `Write()`                                  | Stateful-only writes                    |
-| `CycleManagedStore` | `CycleController()`                                     | Runtime/orchestrator-only cycle control |
-| `Reader`            | `Value/Delta/Histogram/Summary/StateSet/MeasureSet/...` | Immutable snapshot read API             |
+```mermaid
+flowchart LR
+    collector("Collector<br/>Observe values") --> staged("Staged frame<br/>this cycle's writes")
+    staged --> resolve("Commit: resolve descriptors<br/>fail / supersede / drop")
+    resolve --> retain("Apply retention<br/>+ descriptor sweep")
+    retain --> publish("Publish snapshot<br/>atomic swap")
+    publish --> snap("Immutable snapshot")
+    snap --> reader("Readers<br/>chart planning / tooling")
 
-## Write Model
+    abort("AbortCycle<br/>scrape failed") -. discard staged .-> staged
 
-### Collector store
+    classDef input fill:#eef1f4,stroke:#8b949e,color:#24292f;
+    classDef sched fill:#ece2ff,stroke:#8250df,color:#3b1f6b;
+    classDef commit fill:#d8f3e0,stroke:#2da44e,color:#0b3d1f;
+    classDef hard fill:#ffdcdc,stroke:#cf222e,color:#5a0b0b;
 
-| Phase   | Action                                                                                        |
-|---------|-----------------------------------------------------------------------------------------------|
-| Begin   | Open staged frame (`BeginCycle`)                                                              |
-| Collect | Collector writes metrics through `Write().SnapshotMeter(...)` or `Write().StatefulMeter(...)` |
-| Success | `CommitCycleSuccess` publishes new snapshot and advances success sequence                     |
-| Failure | `AbortCycle` drops staged writes                                                              |
+    class collector,reader input;
+    class staged,resolve,retain sched;
+    class publish,snap commit;
+    class abort hard;
+```
 
-`ModuleV2` collectors should write metrics only; cycle control is handled by job runtime.
+Key properties that fall out of this shape:
 
-### Runtime store
+- **Reads are lock-free.** A reader holds an immutable snapshot; commits swap in
+  a new one. Any number of goroutines read concurrently.
+- **Writes are invisible until commit.** A half-collected or failed cycle never
+  leaks partial data to readers.
+- **Commit is transactional.** Either the whole cycle publishes, or (on
+  `AbortCycle` / an unresolvable conflict) nothing changes.
 
-- **No cycle API** — writes commit immediately.
-- **Stateful only** — snapshot-mode instrument registration returns an error.
+## The Collect Cycle
 
-> [!CAUTION]
-> Calling snapshot-mode record methods (`ObserveTotal`, `ObservePoint`) on a `RuntimeStore` **panics**.
+A `CollectorStore` write only exists inside a cycle. The job runtime drives the
+cycle around the collector's `Collect`; `ModuleV2` collectors just write.
 
-- **Fixed freshness** — runtime store enforces `FreshnessCommitted` semantics; other freshness policies are rejected.
+| Phase   | Action                                                                                         |
+|---------|------------------------------------------------------------------------------------------------|
+| Begin   | Open a staged frame (`BeginCycle`).                                                             |
+| Collect | Collector writes via `Write().SnapshotMeter(...)` or `Write().StatefulMeter(...)`.             |
+| Success | `CommitCycleSuccess` resolves descriptors, applies retention, and publishes a new snapshot.     |
+| Failure | `AbortCycle` discards all staged writes and staged registrations — the committed state is untouched. |
 
-## Instrument Modes and Defaults
+`RuntimeStore` has **no cycle API**: writes commit immediately, each producing a
+new overlay snapshot, and it is **stateful-only** (snapshot-mode registration
+returns an error; calling snapshot record methods panics).
 
-| Mode     | Typical meter        | Freshness default    | Window default     |
+## Metric Identity: Names, Series, and Descriptors
+
+Every write resolves to a **series** — the metric name plus a canonical key
+built from its sorted labels. Many series can share one name (same metric,
+different label values).
+
+All series of a name share **one descriptor**. The descriptor is the name's
+contract and is the thing whose growth metrix bounds:
+
+- **Authority** — kind, mode, freshness, window, and the type schema (histogram
+  bounds / summary quantiles). Two writes with different authority for one name
+  are a conflict.
+- **Declaration** — metadata (description, unit, chart family/priority, float).
+  Compatible declarations for one authority are **merged** into a single
+  canonical descriptor; a genuine conflict (e.g. two different units) fails.
+
+At commit the store computes exactly **one canonical descriptor per accepted
+name** and stamps every surviving series of that name with it, so readers,
+the registry, and every series agree regardless of write or label order.
+
+## Descriptor Lifecycle and Retention
+
+This is the core of why metrix is safe for push-style, client-driven metric
+names. It applies to `CollectorStore` (`RuntimeStore` has its own bounded
+retention path).
+
+### Two coupled retentions
+
+Two things age out, on the **successful-commit clock** (only successful commits
+advance it; aborted cycles do not):
+
+1. **Series retention** — a series not observed for `expireAfterSuccessCycles`
+   successful commits is evicted. `maxSeries` optionally caps the total series
+   count, evicting the oldest first.
+2. **Descriptor grace** — after a name's *last* series is gone, its descriptor is
+   kept for `descriptorGraceCycles` more successful commits (in case the name
+   returns), then swept from the registry.
+
+So a fully idle name's descriptor lives `expire + grace` successful commits past
+its last observation. Defaults: `expire = 10`, `maxSeries = 0` (disabled),
+`grace = expire` (so grace ≥ expire holds by construction).
+
+### The descriptor state machine
+
+```mermaid
+flowchart LR
+    new("New name observed") --> live
+
+    live("LIVE<br/>has ≥1 live series")
+    grace("ZERO-LIVE-IN-GRACE<br/>no series, within grace")
+    evicted("EVICTED<br/>removed from the registry")
+
+    live -->|last series evicted by retention| grace
+    grace -->|observed again| live
+    grace -->|grace elapsed → universe sweep| evicted
+    evicted -->|name reappears| live
+
+    classDef commit fill:#d8f3e0,stroke:#2da44e,color:#0b3d1f;
+    classDef effect fill:#ffe6cc,stroke:#e36209,color:#5a2a00;
+    classDef hard fill:#ffdcdc,stroke:#cf222e,color:#5a0b0b;
+    classDef input fill:#eef1f4,stroke:#8b949e,color:#24292f;
+
+    class new input;
+    class live commit;
+    class grace effect;
+    class evicted hard;
+```
+
+- **LIVE** — at least one series exists. The descriptor is authoritative; a
+  conflicting re-registration of a truly-live name fails loud.
+- **ZERO-LIVE-IN-GRACE** — the series aged out but the descriptor lingers, so a
+  briefly-absent name resumes without re-registration churn.
+- **EVICTED** — swept from the registry. The name is a clean slate: it may
+  reappear with the **same or a changed** contract and re-register without error.
+
+The sweep runs at commit, after retention, over the whole descriptor universe
+(the names in the registry) in one pass — bounded work, no per-series refcounts.
+
+### Conflict resolution at commit
+
+Because registration is staged and resolved at commit (never a mid-cycle panic
+for collector code), a name observed with an incompatible authority is resolved
+by state:
+
+| Situation | Outcome |
+| --- | --- |
+| New name, one authority | **Accept**. |
+| Incompatible kind, old kind **not** observed this cycle (idle/in-grace) | **Supersede** — drop the old series + descriptor, install the new. |
+| Incompatible kinds both observed this cycle (a truly-live conflict) | **Fail** the whole commit (loud; transactional — nothing published). |
+| Multiple incompatible kinds, none established | **Drop** this name for the cycle; other names still commit. |
+
+### Consumers that cache per-name state
+
+A consumer that caches handles keyed off a metric name (the prometheus writer)
+must keep its cache alive at least as long as metrix keeps the descriptor, or it
+would re-register a name metrix still holds. The store exposes this via an
+**optional** interface (type assertion; not part of `CollectorStore`, so
+existing implementations and fakes keep compiling):
+
+```go
+type DescriptorRetention interface {
+    DescriptorRetentionWindow() uint64 // expire+grace; DescriptorRetentionUnbounded if expiry is disabled
+    SuccessfulCommits() uint64         // the successful-commit clock the window is measured in
+}
+```
+
+`DescriptorRetentionWindow()` returns `DescriptorRetentionUnbounded`
+(`math.MaxUint64`) when series expiry is disabled (`WithExpireAfterSuccessCycles(0)`),
+meaning descriptors can live indefinitely — a consumer must then never age out
+its cached state for that name.
+
+## Reading
+
+`Read(...)` returns an immutable `Reader` over the latest published snapshot.
+Two independent axes control what and how it reads:
+
+- **Raw** (`ReadRaw()`) — bypass freshness filtering; return all committed series
+  regardless of when last observed.
+- **Flatten** (`ReadFlatten()`) — project complex types (Histogram, Summary,
+  StateSet, MeasureSet) into individual scalar series.
+
+| Read options                     | Visibility           | Shape                    |
+|----------------------------------|----------------------|--------------------------|
+| `Read()`                         | Freshness-filtered   | Canonical typed families |
+| `Read(ReadRaw())`                | All committed series | Canonical typed families |
+| `Read(ReadFlatten())`            | Freshness-filtered   | Flattened scalar view    |
+| `Read(ReadRaw(), ReadFlatten())` | All committed series | Flattened scalar view    |
+
+**Freshness** decides visibility for non-raw reads:
+
+- `FreshnessCycle` — the series must have been observed in the latest successful
+  cycle to be visible.
+- `FreshnessCommitted` — the series stays visible as long as it is committed,
+  even if not re-observed this cycle.
+
+**Window** decides how stateful histogram/summary instruments accumulate:
+
+- `WindowCumulative` — observations accumulate across cycles.
+- `WindowCycle` — observations reset each cycle.
+
+The `Reader` interface exposes typed getters
+(`Value/Delta/Histogram/Summary/StateSet/MeasureSet`), metadata
+(`SeriesMeta/MetricMeta/CollectMeta`), host scopes, and iteration helpers
+(`ForEachByName/ForEachSeries/ForEachMatch`).
+
+## Instruments
+
+An instrument is declared on a meter and identified by its name; observing
+through it writes a series.
+
+| Mode     | Meter                | Freshness default    | Window default     |
 |----------|----------------------|----------------------|--------------------|
 | Snapshot | `SnapshotMeter(...)` | `FreshnessCycle`     | `WindowCumulative` |
 | Stateful | `StatefulMeter(...)` | `FreshnessCommitted` | `WindowCumulative` |
 
-## Instrument Options
+Kinds: **Gauge**, **Counter**, **Histogram**, **Summary**, **StateSet**, and
+**MeasureSet** (below). Instruments accept options:
 
 | Option                                                                            | Scope                                                                                          |
 |-----------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
@@ -82,15 +274,19 @@
 | `WithStateSetStates(...)`                                                         | StateSet allowed states                                                                        |
 | `WithStateSetMode(...)`                                                           | `ModeBitSet` (multiple simultaneous active states) or `ModeEnum` (exactly one active state)    |
 | `WithMeasureSetFields(...)`                                                       | MeasureSet fixed ordered field schema (required for MeasureSet instruments)                    |
-| `WithDescription(...)`, `WithChartFamily(...)`, `WithUnit(...)`, `WithFloat(...)` | Metric metadata hints for downstream consumers (e.g., autogen chart identity + float SET mode) |
+| `WithDescription(...)`, `WithChartFamily(...)`, `WithChartPriority(...)`, `WithUnit(...)`, `WithFloat(...)` | Metadata hints for downstream consumers (chart identity, units, float SET mode) |
 
 ## MeasureSet
 
-- **Structured numeric family** — `MeasureSet` stores one logical metric family with a fixed ordered list of named numeric fields.
-- **Family-level semantics** — one `MeasureSet` family is either gauge-like or counter-like; semantics are never mixed per field.
-- **Family-level metadata** — `Description`, `ChartFamily`, and `Unit` apply to the whole family.
-- **Field-level schema** — `MeasureFieldSpec` declares per-field `Name` and `Float`.
-- **Chartengine integration** — chart autogen treats `MeasureSet` as a structured family, similar to `StateSet`; flatten remains the generic reader/tooling path.
+`MeasureSet` stores one logical metric family with a fixed ordered list of named
+numeric fields — a structured family, similar to `StateSet` for chart autogen.
+
+- **Family-level semantics** — a family is either gauge-like or counter-like;
+  never mixed per field.
+- **Family-level metadata** — `Description`, `ChartFamily`, and `Unit` apply to
+  the whole family.
+- **Field-level schema** — `MeasureFieldSpec` declares per-field `Name` and
+  `Float`.
 
 ### Writers
 
@@ -99,25 +295,17 @@
 | Snapshot | `MeasureSetGauge(...).ObservePoint(...)` or preferred `ObserveFields(...)`                                                  | `MeasureSetCounter(...).ObserveTotalPoint(...)` or preferred `ObserveTotalFields(...)` |
 | Stateful | `MeasureSetGauge(...).SetPoint(...)`, `AddPoint(...)`, `SetFields(...)`, `AddFields(...)`, `SetField(...)`, `AddField(...)` | `MeasureSetCounter(...).AddPoint(...)`, `AddFields(...)`, `AddField(...)`              |
 
-### Phase-1 write contract
+### Write contract
 
-- **Preferred collector-facing API** — use named write helpers instead of raw positional `MeasureSetPoint` values whenever practical.
-- **Snapshot handles** support:
-  - full-family positional writes (`ObservePoint(...)`, `ObserveTotalPoint(...)`)
-  - full-family named writes (`ObserveFields(...)`, `ObserveTotalFields(...)`)
-- **Stateful handles** support:
-  - full-family positional writes
-  - full-family named writes
-  - singular field writes (`SetField(...)`, `AddField(...)`)
-- **Snapshot singular field writes do not exist in phase 1.**
-  - `MeasureSet` still models one sampled family point per collect cycle in snapshot mode.
-  - Partial snapshot field visibility/completeness semantics are intentionally deferred.
-- **Named full-family writes require the exact declared field set.**
-  - Missing fields panic.
-  - Unknown extra fields panic.
-- **Stateful singular field writes update only the addressed field.**
-  - Gauge-like `SetField(...)` overwrites one field on top of the committed/staged family.
-  - Gauge-like `AddField(...)` and counter-like `AddField(...)` apply a delta to one field.
+- **Prefer named write helpers** over raw positional `MeasureSetPoint` values.
+- **Snapshot handles** support full-family positional and named writes.
+- **Stateful handles** additionally support singular field writes
+  (`SetField`/`AddField`), which update only the addressed field on top of the
+  committed/staged family.
+- **Snapshot singular field writes do not exist** (phase 1): snapshot mode models
+  one sampled family point per cycle; partial field visibility is deferred.
+- **Named full-family writes require the exact declared field set** — missing or
+  unknown fields panic.
 
 ### Schema example
 
@@ -138,8 +326,6 @@ latency.ObserveFields(map[string]metrix.SampleValue{
 })
 ```
 
-Re-registering the same metric name with a different `MeasureSet` schema is rejected like other structured families.
-
 ### Stateful singular-write example
 
 ```go
@@ -153,33 +339,11 @@ usage := meter.MeasureSetGauge(
 	),
 )
 
-usage.SetFields(map[string]metrix.SampleValue{
-	"value": 10,
-	"limit": 20,
-})
+usage.SetFields(map[string]metrix.SampleValue{"value": 10, "limit": 20})
 usage.SetField("value", 15)
 usage.AddField("limit", 3)
+// committed point == metrix.MeasureSetPoint{Values: []metrix.SampleValue{15, 23}}
 ```
-
-This yields a committed `MeasureSet` point equivalent to:
-
-```go
-metrix.MeasureSetPoint{Values: []metrix.SampleValue{15, 23}}
-```
-
-## Read Modes
-
-`Read(...)` accepts option functions that control two independent axes:
-
-- **Raw** (`ReadRaw()`) — bypasses freshness filtering, returning all committed series regardless of when they were last observed.
-- **Flatten** (`ReadFlatten()`) — projects complex types (Histogram, Summary, StateSet, MeasureSet) into individual scalar series.
-
-| Read options                     | Visibility           | Shape                    |
-|----------------------------------|----------------------|--------------------------|
-| `Read()`                         | Freshness-filtered   | Canonical typed families |
-| `Read(ReadRaw())`                | All committed series | Canonical typed families |
-| `Read(ReadFlatten())`            | Freshness-filtered   | Flattened scalar view    |
-| `Read(ReadRaw(), ReadFlatten())` | All committed series | Flattened scalar view    |
 
 ## Flattened View Mapping
 
@@ -193,16 +357,37 @@ metrix.MeasureSetPoint{Values: []metrix.SampleValue{15, 23}}
 | MeasureSet  | `<name>_<field>{measure_field=field}`; flattened kind follows family semantics (`Gauge` or `Counter`)            |
 
 Histogram bucket flattening emits non-overlapping range bucket totals while
-keeping the `le` label as the bucket upper bound. The first finite bucket is
+keeping the `le` label as the bucket upper bound: the first finite bucket is
 `<= le[0]`; each later finite bucket is `(previous le, current le]`; `+Inf` is
-`count - last finite cumulative bucket`. Typed `Histogram()` reads remain
-canonical cumulative histogram points.
+`count - last finite cumulative bucket`. Typed `Histogram()` reads stay canonical
+cumulative points.
 
-Flatten metadata is exposed via `SeriesMeta.Kind`, `SeriesMeta.SourceKind`, and `SeriesMeta.FlattenRole`.
+Flatten metadata is exposed via `SeriesMeta.Kind`, `SeriesMeta.SourceKind`, and
+`SeriesMeta.FlattenRole`. `MeasureSet` flattening keeps per-field metric names
+for `MetricMeta(name)` compatibility and adds a synthetic `measure_field=<field>`
+label for explicit field identity.
 
-`MeasureSet` flattening keeps per-field metric names for `MetricMeta(name)` compatibility and also adds a synthetic `measure_field=<field>` label. This gives chartengine explicit field identity without widening the reader metadata API.
+## Configuration
 
-## Minimal Usage Snippets
+`NewCollectorStore(opts ...CollectorStoreOption)` is variadic and additive;
+existing callers keep working. The options tune the retention model above:
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `WithExpireAfterSuccessCycles(n)` | `10` | Successful commits an unobserved series is kept (`0` disables series expiry → unbounded descriptor window). |
+| `WithMaxSeries(n)` | `0` (off) | Hard cap on total committed series; oldest evicted past the cap. |
+| `WithDescriptorGraceCycles(n)` | `= expire` | Successful commits a descriptor is kept after its last series is gone, before the sweep removes it. |
+
+Eviction and drop activity is exposed as cumulative counters on the per-snapshot
+`CollectMeta` (read via `Reader.CollectMeta()`); metrix itself never logs:
+
+| Field | Meaning |
+| --- | --- |
+| `EvictedDescriptors` | Descriptors removed by the universe sweep (idle past grace). |
+| `DroppedNames` | Names dropped for a cycle as ambiguous multi-kind conflicts. |
+| `LastAttemptSeq` / `LastAttemptStatus` / `LastSuccessSeq` | Last cycle attempt sequence, status, and last success. |
+
+## Usage Snippets
 
 ### Collector write path
 
@@ -236,28 +421,43 @@ see [how-to-write-a-collector.md](/src/go/plugin/go.d/docs/how-to-write-a-collec
 
 ## Contracts and Pitfalls
 
-- **Label sets** — `LabelSet` is store-owned; do not share between different stores.
-- **Counter deltas** — `Delta()` requires contiguous sequence (N, N+1).
-  In `CollectorStore` this is per-cycle: missing one successful cycle breaks the delta.
-  In `RuntimeStore` this is per-series per-write: the sequence always increments on each write, so skipping a write cycle does not break deltas.
-- **Snapshot freshness** — Snapshot-mode instruments cannot use `FreshnessCommitted`.
-- **Runtime writes** — `RuntimeStore` rejects snapshot-mode instrument registration with an error.
-  Calling snapshot-mode record methods (`ObserveTotal`, `ObservePoint`) **panics**.
-- **MeasureSet runtime writes** — `RuntimeStore` supports both gauge-like and counter-like `MeasureSet` families, but only through `StatefulMeter(...)`.
-- **MeasureSet named writes** — `ObserveFields(...)`, `ObserveTotalFields(...)`, `SetFields(...)`, and `AddFields(...)` require the exact declared field set. Snapshot singular field writes are intentionally absent in phase 1.
-- **Window/freshness coupling** — Stateful histogram/summary with `WindowCycle` requires (and silently forces) `FreshnessCycle`. Setting an explicit non-Cycle freshness with `WindowCycle` returns an error.
-- **Schema stability** — Re-registering an existing metric name with different kind/mode/schema returns an error (or panics in strict runtime paths).
-- **MeasureSet flatten naming** — Flattened `MeasureSet` series use per-field metric names like `<name>_<field>` and also carry a synthetic `measure_field=<field>` label.
-- **MeasureSet counter semantics** — Stateful counter-like `MeasureSet` families reject negative `AddPoint(...)` deltas, just like scalar counters.
-- **Summary NaN quantiles** — a summary point may carry NaN quantile *values* (e.g. an empty observation window); they are stored (only Inf is rejected) and render as a chart gap downstream (chartengine emits `SETEMPTY`). Count and Sum must still be finite.
-- **Collector retention** — `CollectorStore` evicts series not seen for 10 successful cycles by default.
+- **Descriptor lifetime is not permanent.** A fully idle name evicts after
+  `expire + grace` successful commits and can then be re-registered with a
+  changed contract. Consumers that cache per-name handles must read
+  `DescriptorRetention` and not outlive the window.
+- **Aborted cycles freeze the clocks.** Retention, grace, and the sweep advance
+  only on successful commits, so endpoint downtime does not age anything out.
+- **Label sets** — `LabelSet` is store-owned; do not share between stores.
+- **Counter deltas** — `Delta()` requires a contiguous sequence (N, N+1). In
+  `CollectorStore` this is per-cycle (a missed successful cycle breaks the delta);
+  in `RuntimeStore` it is per-series per-write (skipping a write does not break it).
+- **Snapshot freshness** — snapshot-mode instruments cannot use
+  `FreshnessCommitted`.
+- **Runtime writes** — `RuntimeStore` rejects snapshot-mode registration with an
+  error; calling snapshot record methods (`ObserveTotal`, `ObservePoint`) panics.
+  MeasureSet families work only through `StatefulMeter(...)`.
+- **MeasureSet named writes** require the exact declared field set; snapshot
+  singular field writes are absent in phase 1.
+- **MeasureSet counter semantics** — stateful counter-like families reject
+  negative `AddPoint(...)` deltas, like scalar counters.
+- **Window/freshness coupling** — stateful histogram/summary with `WindowCycle`
+  requires (and silently forces) `FreshnessCycle`; an explicit non-Cycle freshness
+  with `WindowCycle` is an error.
+- **Truly-live schema conflicts fail the commit.** Re-registering an
+  actively-observed name with a different kind/mode/schema fails loud (transactional);
+  an idle name is superseded instead. Init-time registration keeps a synchronous panic.
+- **Summary NaN quantiles** — a summary point may carry NaN quantile *values*
+  (e.g. an empty window); they are stored (only Inf is rejected) and render as a
+  chart gap downstream. Count and Sum must be finite.
 
 ## Internal Architecture Notes
 
-| Area             | Implementation pattern                                           |
-|------------------|------------------------------------------------------------------|
-| Snapshot publish | Read snapshots are immutable and atomically swapped              |
-| Collector commit | Staged frame merges into new snapshot on successful cycle commit |
-| Runtime commit   | Overlay/compaction strategy with retention pruning               |
-| Iteration        | Name-indexed deterministic iteration for reader traversal        |
-| Identity         | Canonical metric+labels key with stable `SeriesIdentity` hash    |
+| Area | Implementation pattern |
+|------|------------------------|
+| Snapshot publish | Read snapshots are immutable and atomically swapped. |
+| Collector commit | Staged frame → descriptor resolution → retention → single canonical pass → publish, all success-path; abort discards staged state. |
+| Descriptor resolution | Observed authorities per name are grouped in a fingerprint-indexed map (no cap); one canonical descriptor per accepted name. |
+| Descriptor eviction | One O(descriptor-universe) sweep at commit, after retention; `instrumentZeroSince` tracks idle-since on the successful-commit clock. |
+| Runtime commit | Overlay/compaction strategy with its own retention pruning. |
+| Iteration | Name-indexed deterministic iteration for reader traversal. |
+| Identity | Canonical metric+labels key with a stable `SeriesIdentity` hash. |

--- a/src/go/pkg/metrix/collector_store.go
+++ b/src/go/pkg/metrix/collector_store.go
@@ -42,6 +42,19 @@ type instrumentDescriptor struct {
 	stateSet   *stateSetSchema   // set for kindStateSet only
 	measureSet *measureSetSchema // set for kindMeasureSet only
 	meta       MetricMeta
+	// metaSet records which optional metadata fields were explicitly declared, so
+	// declaration compatibility preserves registration's "compare only if set" rule.
+	metaSet metricMetaSet
+}
+
+// metricMetaSet records which optional family-metadata fields a registration
+// explicitly set. It gates declaration-compatibility checks (preserve-first).
+type metricMetaSet struct {
+	description   bool
+	chartFamily   bool
+	chartPriority bool
+	unit          bool
+	float         bool
 }
 
 type histogramSchema struct {
@@ -135,6 +148,176 @@ type cycleFrame struct {
 	stateSet           map[string]*stagedStateSet
 	measureSetGauges   map[string]*stagedMeasureSet
 	measureSetCounters map[string]*stagedMeasureSet
+	// pendingInstruments holds the descriptors registered during this cycle, grouped
+	// per name. A name may carry several mutually-incompatible authorities in one
+	// cycle (e.g. a kind that supersedes the committed one), so each name maps to a
+	// list of authority representatives. They drive registration dedup within the
+	// cycle and are discarded when it ends; they are NOT merged into the committed
+	// registry (only observed series install a committed descriptor, see
+	// CommitCycleSuccess).
+	pendingInstruments map[string][]*instrumentDescriptor
+	// conflicts records same-key writes whose authority is INCOMPATIBLE with the staged entry
+	// (a different kind/mode/schema, or a conflicting declaration). A compatible same-key write
+	// is instead merged into the staged entry's running-canonical descriptor and never recorded
+	// here. Commit-time resolution folds these in so the name fails or drops rather than silently
+	// keeping one arbitrary authority. Deduped by full descriptor identity (key, authority
+	// fingerprint, declaration fingerprint) via recordedConflict, so many handles or samples that
+	// share a full descriptor record once (evidence stays O(distinct full descriptors), not
+	// O(handles)/O(samples)), while each distinct authority OR declaration is recorded.
+	conflicts []stagedDescConflict
+	// recordedConflict buckets recorded conflict evidence by full descriptor identity (series key,
+	// authority fingerprint, declaration fingerprint) for O(1) dedup. Each bucket holds the evidence
+	// descriptors for that identity - normally one; more than one only on a fingerprint collision,
+	// which verify-on-hit (descriptorsFullyEqual, or effective-bounds plus declaration compare for
+	// histograms) resolves so distinct descriptors are never silently merged. Lazily allocated.
+	recordedConflict map[sameKeyConflictID][]*instrumentDescriptor
+}
+
+// stagedDescConflict is a same-key write whose authority is incompatible with the staged entry
+// for that key. desc is the descriptor the resolver reconciles: the effective, bounds-filled
+// descriptor for a histogram; the handle itself otherwise.
+type stagedDescConflict struct {
+	name string
+	desc *instrumentDescriptor
+}
+
+// sameKeyConflictID keys recorded same-key conflict evidence by series key, authority IDENTITY
+// (fingerprint), and a DECLARATION fingerprint, so distinct FULL descriptors (authority AND declared
+// metadata) each get their own O(1) bucket: many handles/samples sharing a full descriptor dedup to
+// one record, while a same-authority write with a different declaration (a distinct conflict) still
+// records without scanning a growing per-authority bucket. declFP collisions (or authority-fp
+// collisions) put >1 entry in a bucket, which the *Recorded checks separate with descriptorsFullyEqual.
+type sameKeyConflictID struct {
+	key    string
+	fp     authorityFingerprint
+	declFP uint64
+}
+
+// authorityFingerprint is a comparable identity for a series authority: two descriptors that are
+// series-authority-compatible share a fingerprint (kind/mode/freshness/window/schema). It keys the
+// conflict-evidence map so dedup is O(1) and bounded by DISTINCT authorities rather than by handle
+// pointer or sample count. It EXCLUDES declaration metadata (unit, description, ...), which is
+// reconciled by mergeInstrumentMetadata, not authority identity. schemaHash is a stable hash of the
+// type-specific schema; a collision only puts two distinct authorities in one bucket, and the
+// bucket is verified with descriptorSeriesAuthoritiesEqual (or a direct bounds compare) so distinct
+// authorities are never silently merged.
+//
+// NOTE on the histogram nil-bounds wildcard: a nil-bounds snapshot histogram is compatible with ANY
+// concrete-bounds histogram, so it has no single equal fingerprint. Fingerprints are only taken of
+// CONCRETE descriptors (the conflict evidence is the effective, bounds-filled descriptor); the
+// committed-vs-wildcard comparison keeps using seriesAuthoritiesCompatible.
+type authorityFingerprint struct {
+	kind       metricKind
+	mode       metricMode
+	freshness  FreshnessPolicy
+	window     MetricWindow
+	schemaHash uint64
+}
+
+func authorityFingerprintOf(d *instrumentDescriptor) authorityFingerprint {
+	return authorityFingerprint{
+		kind:       d.kind,
+		mode:       d.mode,
+		freshness:  d.freshness,
+		window:     d.window,
+		schemaHash: d.authoritySchemaHash(),
+	}
+}
+
+// histogramAuthorityFingerprint fingerprints a histogram write by its EFFECTIVE (observed) bounds
+// without cloning: a nil-bounds snapshot descriptor carries no bounds, so the observed bounds are
+// hashed directly. It matches authorityFingerprintOf(effectiveHistogramDescriptor(d, bounds)).
+func histogramAuthorityFingerprint(d *instrumentDescriptor, bounds []float64) authorityFingerprint {
+	return authorityFingerprint{
+		kind:       d.kind,
+		mode:       d.mode,
+		freshness:  d.freshness,
+		window:     d.window,
+		schemaHash: hashFloat64s(fnvOffset64, bounds),
+	}
+}
+
+// authoritySchemaHash hashes exactly the type-specific schema fields that
+// descriptorSeriesAuthoritiesEqual compares, so equal authorities hash equally. Scalar kinds
+// (gauge/counter) have no schema and hash to 0.
+func (d *instrumentDescriptor) authoritySchemaHash() uint64 {
+	switch d.kind {
+	case kindHistogram:
+		if d.histogram == nil {
+			return 0
+		}
+		return hashFloat64s(fnvOffset64, d.histogram.bounds)
+	case kindSummary:
+		if d.summary == nil {
+			return 0
+		}
+		h := hashUint64(fnvOffset64, uint64(d.summary.reservoirSize))
+		return hashFloat64s(h, d.summary.quantiles)
+	case kindStateSet:
+		if d.stateSet == nil {
+			return 0
+		}
+		h := hashUint64(fnvOffset64, uint64(d.stateSet.mode))
+		return hashStrings(h, d.stateSet.states)
+	case kindMeasureSet:
+		if d.measureSet == nil {
+			return 0
+		}
+		h := hashUint64(fnvOffset64, uint64(d.measureSet.semantics))
+		for _, f := range d.measureSet.fields {
+			h = hashString(h, f.Name)
+			if f.Float {
+				h = hashUint64(h, 1)
+			} else {
+				h = hashUint64(h, 0)
+			}
+		}
+		return h
+	}
+	return 0
+}
+
+// FNV-1a helpers (allocation-free) for authority schema hashing. Lengths are folded in so distinct
+// groupings (e.g. ["ab","c"] vs ["a","bc"]) do not collide.
+const (
+	fnvOffset64 uint64 = 14695981039346656037
+	fnvPrime64  uint64 = 1099511628211
+)
+
+func hashUint64(h, v uint64) uint64 {
+	for i := 0; i < 8; i++ {
+		h ^= (v >> (uint(i) * 8)) & 0xff
+		h *= fnvPrime64
+	}
+	return h
+}
+
+func hashFloat64s(h uint64, xs []float64) uint64 {
+	h = hashUint64(h, uint64(len(xs)))
+	for _, x := range xs {
+		if x == 0 {
+			x = 0 // canonicalize -0.0 to +0.0 so signed zero hashes as it compares (-0.0 == +0.0)
+		}
+		h = hashUint64(h, math.Float64bits(x))
+	}
+	return h
+}
+
+func hashString(h uint64, s string) uint64 {
+	h = hashUint64(h, uint64(len(s)))
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= fnvPrime64
+	}
+	return h
+}
+
+func hashStrings(h uint64, xs []string) uint64 {
+	h = hashUint64(h, uint64(len(xs)))
+	for _, s := range xs {
+		h = hashString(h, s)
+	}
+	return h
 }
 
 type storeCore struct {
@@ -144,10 +327,12 @@ type storeCore struct {
 	successSeq  uint64
 	active      *cycleFrame
 	instruments map[string]*instrumentDescriptor // metric name => descriptor (mode/kind locked)
-	// Captured schema for snapshot histograms declared without explicit bounds.
-	// Accessed only under c.mu during cycle commit.
-	snapshotHistogramSchema map[string]*histogramSchema // metric name => captured bounds
-	retention               collectorRetentionPolicy
+	// instrumentZeroSince records, per name, the successful-commit seq at which the name
+	// last went idle (no live series). The descriptor-universe sweep uses it to age idle
+	// descriptors out of instruments after descriptorGraceCycles. Lazily allocated; a name
+	// with a live series has no entry.
+	instrumentZeroSince map[string]uint64
+	retention           collectorRetentionPolicy
 
 	snapshot atomic.Pointer[readSnapshot] // atomically swapped immutable read view
 }
@@ -155,6 +340,10 @@ type storeCore struct {
 type collectorRetentionPolicy struct {
 	expireAfterSuccessCycles uint64
 	maxSeries                int
+	// descriptorGraceCycles is how many successful commits a descriptor is kept in
+	// instruments after its last series is evicted, before the descriptor-universe
+	// sweep removes it. Defaults to expireAfterSuccessCycles (see NewCollectorStore).
+	descriptorGraceCycles uint64
 }
 
 const (
@@ -175,13 +364,28 @@ type storeCycleController struct {
 }
 
 // NewCollectorStore creates a collection store with staged writes and immutable read snapshots.
-func NewCollectorStore() CollectorStore {
+func NewCollectorStore(opts ...CollectorStoreOption) CollectorStore {
+	cfg := collectorStoreConfig{
+		expireAfterSuccessCycles: defaultCollectorExpireAfterSuccessCycles,
+		maxSeries:                defaultCollectorMaxSeries,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt.apply(&cfg)
+		}
+	}
+	// Grace defaults to the (possibly overridden) expire so the invariant grace >= expire
+	// holds by construction; an explicit WithDescriptorGraceCycles decouples them.
+	grace := cfg.expireAfterSuccessCycles
+	if cfg.graceSet {
+		grace = cfg.graceCycles
+	}
 	core := &storeCore{
-		instruments:             make(map[string]*instrumentDescriptor),
-		snapshotHistogramSchema: make(map[string]*histogramSchema),
+		instruments: make(map[string]*instrumentDescriptor),
 		retention: collectorRetentionPolicy{
-			expireAfterSuccessCycles: defaultCollectorExpireAfterSuccessCycles,
-			maxSeries:                defaultCollectorMaxSeries,
+			expireAfterSuccessCycles: cfg.expireAfterSuccessCycles,
+			maxSeries:                cfg.maxSeries,
+			descriptorGraceCycles:    grace,
 		},
 	}
 	core.snapshot.Store(&readSnapshot{
@@ -230,6 +434,44 @@ func (s *managedStore) CycleController() CycleController {
 	return &storeCycleController{core: s.core}
 }
 
+// DescriptorRetention (optional interface) - both store facades delegate to storeCore.
+
+func (s *storeView) DescriptorRetentionWindow() uint64 { return s.core.descriptorRetentionWindow() }
+func (s *storeView) SuccessfulCommits() uint64         { return s.core.successfulCommits() }
+
+func (s *managedStore) DescriptorRetentionWindow() uint64 { return s.core.descriptorRetentionWindow() }
+func (s *managedStore) SuccessfulCommits() uint64         { return s.core.successfulCommits() }
+
+// DescriptorRetentionUnbounded is the DescriptorRetentionWindow() value when series age-expiry
+// is disabled (WithExpireAfterSuccessCycles(0)): a name's series - and thus its descriptor - can
+// live indefinitely, so a consumer must retain its cached state for that name indefinitely too
+// rather than aging it out on a finite window.
+const DescriptorRetentionUnbounded uint64 = math.MaxUint64
+
+// descriptorRetentionWindow is the number of successful commits a descriptor can outlive its
+// last series: expire+grace. With age-expiry disabled (expire==0) a series - and thus its
+// descriptor - can live indefinitely, so the window is unbounded; a grace so large that
+// expire+grace overflows uint64 also saturates to unbounded. Both fields are fixed at
+// construction, so no lock.
+func (c *storeCore) descriptorRetentionWindow() uint64 {
+	expire := c.retention.expireAfterSuccessCycles
+	if expire == 0 {
+		return DescriptorRetentionUnbounded
+	}
+	window := expire + c.retention.descriptorGraceCycles
+	if window < expire { // uint64 overflow
+		return DescriptorRetentionUnbounded
+	}
+	return window
+}
+
+// successfulCommits reads the success clock advanced under c.mu at commit.
+func (c *storeCore) successfulCommits() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.successSeq
+}
+
 // BeginCycle opens a new staged frame for collection writes.
 func (c *storeCycleController) BeginCycle() {
 	c.core.mu.Lock()
@@ -250,6 +492,344 @@ func (c *storeCycleController) BeginCycle() {
 		stateSet:           make(map[string]*stagedStateSet),
 		measureSetGauges:   make(map[string]*stagedMeasureSet),
 		measureSetCounters: make(map[string]*stagedMeasureSet),
+		pendingInstruments: make(map[string][]*instrumentDescriptor),
+	}
+}
+
+// abortWithError republishes the previously committed series as a failed attempt,
+// clears the active cycle, and returns err. All staged writes and staged
+// registrations from the aborted cycle are discarded (never merged).
+func (c *storeCycleController) abortWithError(oldSnap *readSnapshot, err error) error {
+	abortSnap := &readSnapshot{
+		collectMeta: oldSnap.collectMeta,
+		series:      oldSnap.series,
+		byName:      oldSnap.byName,
+	}
+	abortSnap.collectMeta.LastAttemptSeq = c.core.active.seq
+	abortSnap.collectMeta.LastAttemptStatus = CollectStatusFailed
+	c.core.snapshot.Store(abortSnap)
+	c.core.active = nil
+	return err
+}
+
+// descriptorResolution is the outcome of reconciling a cycle's observed instrument
+// descriptors against the committed registry.
+type descriptorResolution struct {
+	failErr   error
+	supersede []string                         // committed names whose (unobserved) kind is replaced by the observed one
+	drop      []string                         // names with ambiguous multi-kind writes and no established authority
+	canonical map[string]*instrumentDescriptor // accepted name => the single descriptor to publish for all its series
+}
+
+// observedAuthority accumulates one series authority observed for a name this cycle,
+// canonicalizing the declared metadata of every compatible write into a single
+// descriptor so the name publishes one descriptor rather than a raw per-write one.
+type observedAuthority struct {
+	canonical *instrumentDescriptor
+}
+
+// nameAuthorities holds every distinct series authority observed for one name this cycle. `all` is
+// the flat list the resolution loop walks; `byFP` indexes it by authority fingerprint so grouping a
+// new write is O(1) with no cap (a bucket per fingerprint, length 1 except on a hash collision).
+type nameAuthorities struct {
+	all  []*observedAuthority
+	byFP map[authorityFingerprint][]*observedAuthority
+}
+
+// reconcileStagedDesc reconciles a same-key write against the staged entry's running-canonical
+// descriptor. On a compatible write it returns the metadata-merged canonical (so the staged
+// entry always carries the complete declaration for its authority - later writes reconcile
+// against the growing canonical, not just the first descriptor). It returns an error when the
+// authority is incompatible or a declaration conflicts. Pure (no side effects).
+func reconcileStagedDesc(existing, incoming *instrumentDescriptor) (*instrumentDescriptor, error) {
+	if err := descriptorSeriesAuthorityCompat(existing, incoming); err != nil {
+		return nil, err
+	}
+	return mergeInstrumentMetadata(existing, incoming)
+}
+
+// reconcileSameKeyDesc merges a compatible same-key write into the staged entry's canonical and
+// returns (canonical, true); on an incompatible one it records the conflicting DESCRIPTOR and
+// returns (nil, false) so the caller drops the write. Conflicts are deduped by FULL descriptor
+// identity (authority + declaration), so many handles or repeats of the same descriptor record once
+// (evidence stays O(distinct descriptors), not O(handles)/O(samples)), while a same-authority write
+// with a DIFFERENT declaration (e.g. a conflicting unit) is a distinct descriptor and IS recorded -
+// so the resolver still sees and fails on that declaration conflict, and a committed-matching
+// authority observed only as a same-key conflict still reaches the resolver. The identity check
+// runs BEFORE reconcileStagedDesc, so a repeated known conflict is dropped without re-deriving (and
+// allocating) its mismatch error. Non-histogram record paths call it under c.mu; histograms use
+// reconcileSameKeyHistogram.
+func (c *storeCore) reconcileSameKeyDesc(key string, existing, incoming *instrumentDescriptor) (*instrumentDescriptor, bool) {
+	fp := authorityFingerprintOf(incoming)
+	if c.sameKeyConflictRecorded(key, fp, incoming) {
+		return nil, false // this exact descriptor already conflicts on this key
+	}
+	merged, err := reconcileStagedDesc(existing, incoming)
+	if err != nil {
+		c.recordSameKeyConflict(key, fp, incoming)
+		return nil, false
+	}
+	return merged, true
+}
+
+// reconcileSameKeyHistogram reconciles a differing same-key histogram write. It compares EFFECTIVE
+// (bounds-filled) descriptors so a different observed bucket schema is a conflict, and on a
+// compatible write returns the metadata-merged staged descriptor - keeping its bounds-nature (a
+// nil-bounds snapshot stays nil) so point normalization stays crash-safe for client-driven bounds.
+// A histogram authority already recorded for this key is dropped BEFORE the effective clone (via a
+// no-clone identity+bounds check), so a repeat of the same conflicting schema stays O(1). A DIFFERENT
+// observed schema is a distinct authority and IS recorded (reaching the resolver), which is what lets
+// a committed-matching observation still fail loud. Under c.mu.
+func (c *storeCore) reconcileSameKeyHistogram(key string, entry *stagedHistogram, incomingDesc *instrumentDescriptor, incomingBounds []float64) (*instrumentDescriptor, bool) {
+	fp := histogramAuthorityFingerprint(incomingDesc, incomingBounds)
+	if c.histogramConflictRecorded(key, fp, incomingDesc, incomingBounds) {
+		return nil, false
+	}
+	incomingEff := effectiveHistogramDescriptor(incomingDesc, incomingBounds)
+	if !descriptorSeriesAuthoritiesEqual(effectiveHistogramDescriptor(entry.desc, entry.bounds), incomingEff) {
+		c.recordSameKeyConflict(key, fp, incomingEff)
+		return nil, false
+	}
+	merged, err := mergeInstrumentMetadata(entry.desc, incomingDesc)
+	if err != nil {
+		c.recordSameKeyConflict(key, fp, incomingEff)
+		return nil, false
+	}
+	return merged, true
+}
+
+// recordSameKeyConflict records an incompatible same-key write as commit-time conflict evidence so
+// the resolver fails/drops the name. Deduped by (key, authority fp, declaration fp) with
+// verify-on-hit: each distinct FULL descriptor gets its own O(1) bucket, and the caller's *Recorded
+// check confirms full equality so a fp collision records a distinct entry rather than dropping one.
+// evidence is the descriptor the resolver reconciles (the effective histogram descriptor, or the
+// handle itself). Under c.mu.
+func (c *storeCore) recordSameKeyConflict(key string, fp authorityFingerprint, evidence *instrumentDescriptor) {
+	id := sameKeyConflictID{key: key, fp: fp, declFP: declarationFingerprint(evidence)}
+	if c.active.recordedConflict == nil {
+		c.active.recordedConflict = make(map[sameKeyConflictID][]*instrumentDescriptor)
+	}
+	c.active.recordedConflict[id] = append(c.active.recordedConflict[id], evidence)
+	c.active.conflicts = append(c.active.conflicts, stagedDescConflict{name: evidence.name, desc: evidence})
+}
+
+// sameKeyConflictRecorded reports whether a FULLY-equal conflict (same authority AND declaration)
+// is already recorded for key. incoming is concrete (a non-histogram handle or an effective
+// histogram descriptor). Keying by declaration fingerprint keeps this O(1) even for many distinct
+// declarations of one authority; the bucket is normally length 1 (longer only on a fingerprint
+// collision, separated by descriptorsFullyEqual). Under c.mu.
+func (c *storeCore) sameKeyConflictRecorded(key string, fp authorityFingerprint, incoming *instrumentDescriptor) bool {
+	id := sameKeyConflictID{key: key, fp: fp, declFP: declarationFingerprint(incoming)}
+	for _, rec := range c.active.recordedConflict[id] {
+		if descriptorsFullyEqual(rec, incoming) {
+			return true
+		}
+	}
+	return false
+}
+
+// histogramConflictRecorded reports whether a fully-equal histogram conflict (same observed bounds
+// AND declaration) is already recorded for key. It compares the recorded effective bounds to the
+// observed bounds directly, so the incoming effective descriptor need not be cloned to detect a
+// repeat. Under c.mu.
+func (c *storeCore) histogramConflictRecorded(key string, fp authorityFingerprint, d *instrumentDescriptor, bounds []float64) bool {
+	id := sameKeyConflictID{key: key, fp: fp, declFP: declarationFingerprint(d)}
+	for _, rec := range c.active.recordedConflict[id] {
+		if rec.kind == kindHistogram && rec.histogram != nil &&
+			rec.mode == d.mode && rec.freshness == d.freshness && rec.window == d.window &&
+			equalHistogramBounds(rec.histogram.bounds, bounds) && descriptorDeclarationsEqual(rec, d) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveObservedDescriptors groups this cycle's staged writes by metric name and
+// reconciles each name against its committed descriptor. Per name:
+//   - a single observed kind that matches the committed authority (or a new name) -> ok;
+//   - a single observed kind incompatible with a committed kind that was NOT observed
+//     this cycle -> supersede the committed kind;
+//   - multiple incompatible kinds observed, one of which is the committed (established)
+//     kind that is actively observed -> unresolvable, fail the whole cycle;
+//   - multiple incompatible kinds observed with no established/observed authority ->
+//     ambiguous, drop this name's writes for the cycle (other names still commit).
+//
+// It only reads state; the caller applies the supersessions, drops, and failure.
+func (c *storeCore) resolveObservedDescriptors() descriptorResolution {
+	// authorities[name] holds the distinct (mutually incompatible) series authorities observed for
+	// name this cycle. Each accumulates a CANONICAL descriptor: the declared metadata of every
+	// compatible write is merged into it (order-independent), so the name publishes one descriptor
+	// rather than whichever raw write landed first. Grouping is indexed by authority fingerprint,
+	// so it is O(1) per write with NO cap: every distinct authority is kept, so a declaration
+	// conflict on ANY of them is merged and detected (fixing the class of bug where a capped-out
+	// authority silently hid a conflict), and the fail-vs-drop decision sees the true count. For a
+	// pathological many-schema name this is O(distinct authorities) memory - transient, bounded by
+	// the cycle's write count, and the name fails/drops anyway.
+	authorities := make(map[string]*nameAuthorities)
+	// declErrs collects declaration (metadata) conflicts between series-authority-
+	// compatible descriptors observed this cycle; they fail the cycle at the end.
+	var declErrs []error
+	// committedObservedNames marks names whose live committed authority is actively observed this
+	// cycle. It drives the multi-authority fail-vs-drop decision below and is computed over EVERY
+	// observed authority. Because each distinct same-key authority is recorded as a conflict
+	// (deduped by full descriptor identity), a committed-matching write observed only as a same-key
+	// conflict still reaches this loop.
+	committedObservedNames := make(map[string]bool)
+	// Descriptors reach record already reduced to their effective authority (histograms carry their
+	// observed bounds), so no wildcard remains and series-authority compatibility is a symmetric
+	// equivalence. Compatible authorities are canonicalized by merging their declared metadata; a
+	// metadata conflict fails the cycle.
+	record := func(name string, desc *instrumentDescriptor) {
+		if !committedObservedNames[name] {
+			if committed := realCommittedAuthority(c.instruments[name]); committed != nil &&
+				seriesAuthoritiesCompatible(committed, desc) {
+				committedObservedNames[name] = true
+			}
+		}
+		na := authorities[name]
+		if na == nil {
+			na = &nameAuthorities{byFP: make(map[authorityFingerprint][]*observedAuthority)}
+			authorities[name] = na
+		}
+		fp := authorityFingerprintOf(desc)
+		// The bucket is normally length 1 (distinct authorities have distinct fingerprints); a
+		// length > 1 bucket only arises on a hash collision, which descriptorSeriesAuthoritiesEqual
+		// separates so distinct authorities are never merged.
+		for _, auth := range na.byFP[fp] {
+			if descriptorSeriesAuthoritiesEqual(auth.canonical, desc) {
+				merged, err := mergeDeclarations(auth.canonical, desc)
+				if err != nil {
+					declErrs = append(declErrs, err)
+					return
+				}
+				auth.canonical = merged
+				return // same authority already recorded
+			}
+		}
+		auth := &observedAuthority{canonical: desc}
+		na.byFP[fp] = append(na.byFP[fp], auth)
+		na.all = append(na.all, auth)
+	}
+	for _, s := range c.active.gauges {
+		record(s.name, s.desc)
+	}
+	for _, s := range c.active.counters {
+		record(s.name, s.desc)
+	}
+	for _, s := range c.active.histograms {
+		record(s.name, effectiveHistogramDescriptor(s.desc, s.bounds))
+	}
+	for _, s := range c.active.summaries {
+		record(s.name, s.desc)
+	}
+	for _, s := range c.active.stateSet {
+		record(s.name, s.desc)
+	}
+	for _, s := range c.active.measureSetGauges {
+		record(s.name, s.desc)
+	}
+	for _, s := range c.active.measureSetCounters {
+		record(s.name, s.desc)
+	}
+	// Fold in observed same-key descriptors that differed from their staged entry, so an
+	// incompatible second write fails/drops the name and a compatible one is merged.
+	for _, cc := range c.active.conflicts {
+		record(cc.name, cc.desc)
+	}
+
+	res := descriptorResolution{canonical: make(map[string]*instrumentDescriptor)}
+	var failNames []string
+	for name, na := range authorities {
+		auths := na.all
+		// The raw committed descriptor supplies the canonical DECLARATION base (its declared
+		// metadata is preserved) even when it is a never-observed nil-bounds histogram
+		// wildcard. realCommittedAuthority is the live AUTHORITY (nil for such a wildcard)
+		// and drives only the supersede/fail decision.
+		rawCommitted := c.instruments[name]
+		committed := realCommittedAuthority(rawCommitted)
+		if len(auths) < 2 {
+			observed := auths[0].canonical
+			switch {
+			case committed != nil && !seriesAuthoritiesCompatible(committed, observed):
+				// A live committed authority of a different kind was not observed: supersede it.
+				res.supersede = append(res.supersede, name)
+				res.canonical[name] = observed
+			case rawCommitted != nil && seriesAuthoritiesCompatible(rawCommitted, observed):
+				// Committed authority (live, or a wildcard registration) is compatible: its
+				// declared metadata is the canonical base, merged with the observed one.
+				merged, err := mergeDeclarations(rawCommitted, observed)
+				if err != nil {
+					declErrs = append(declErrs, err)
+					continue
+				}
+				res.canonical[name] = merged
+			default:
+				// New name (no committed registration), or an incompatible wildcard.
+				res.canonical[name] = observed
+			}
+			continue
+		}
+		// Multiple incompatible authorities observed for one name this cycle. A committed
+		// declaration must still be honored: an observed authority that is series-authority-
+		// compatible with the committed descriptor but declares conflicting metadata is a fail-loud
+		// bug, independent of whether the committed kind is a LIVE authority (realCommittedAuthority
+		// classifies fail-vs-drop; declaration compatibility does not depend on it). Without this,
+		// e.g. a committed nil-bounds histogram unit=bytes vs an observed unit=seconds would silently
+		// drop instead of failing. The single-authority branch already merges against rawCommitted.
+		if rawCommitted != nil {
+			for _, auth := range auths {
+				if seriesAuthoritiesCompatible(rawCommitted, auth.canonical) {
+					if _, err := mergeDeclarations(rawCommitted, auth.canonical); err != nil {
+						declErrs = append(declErrs, err)
+					}
+				}
+			}
+		}
+		// committedObserved was computed over every observed authority, so the fail-vs-drop decision
+		// is complete.
+		if committedObservedNames[name] {
+			// An established authority is actively written alongside an incompatible one:
+			// unresolvable, fail loud (never silent data loss).
+			failNames = append(failNames, name)
+		} else {
+			// Ambiguous with no established authority: drop this name, commit the rest.
+			res.drop = append(res.drop, name)
+		}
+	}
+	var joinErrs []error
+	if len(failNames) > 0 {
+		sort.Strings(failNames)
+		joinErrs = append(joinErrs, fmt.Errorf("metrix: conflicting instrument kinds actively observed in one cycle for %v", failNames))
+	}
+	if len(declErrs) > 0 {
+		// Deterministic order + dedup so the cycle error is stable across map iteration.
+		sort.Slice(declErrs, func(i, j int) bool { return declErrs[i].Error() < declErrs[j].Error() })
+		last := ""
+		for _, err := range declErrs {
+			if msg := err.Error(); msg != last {
+				joinErrs = append(joinErrs, err)
+				last = msg
+			}
+		}
+	}
+	res.failErr = errors.Join(joinErrs...)
+	return res
+}
+
+// dropStagedNames removes all staged writes and staged registrations for the given set
+// of names from the frame in a single pass per staged map, so ambiguous multi-kind names
+// are ignored for the cycle without failing the commit - O(touched), not O(dropped*touched).
+func (f *cycleFrame) dropStagedNames(names map[string]struct{}) {
+	in := func(name string) bool { _, ok := names[name]; return ok }
+	maps.DeleteFunc(f.gauges, func(_ string, s *stagedGauge) bool { return in(s.name) })
+	maps.DeleteFunc(f.counters, func(_ string, s *stagedCounter) bool { return in(s.name) })
+	maps.DeleteFunc(f.histograms, func(_ string, s *stagedHistogram) bool { return in(s.name) })
+	maps.DeleteFunc(f.summaries, func(_ string, s *stagedSummary) bool { return in(s.name) })
+	maps.DeleteFunc(f.stateSet, func(_ string, s *stagedStateSet) bool { return in(s.name) })
+	maps.DeleteFunc(f.measureSetGauges, func(_ string, s *stagedMeasureSet) bool { return in(s.name) })
+	maps.DeleteFunc(f.measureSetCounters, func(_ string, s *stagedMeasureSet) bool { return in(s.name) })
+	for name := range names {
+		delete(f.pendingInstruments, name)
 	}
 }
 
@@ -264,17 +844,16 @@ func (c *storeCycleController) CommitCycleSuccess() error {
 
 	oldSnap := c.core.snapshot.Load()
 	if c.core.active.err != nil {
-		abortSnap := &readSnapshot{
-			collectMeta: oldSnap.collectMeta,
-			series:      oldSnap.series,
-			byName:      oldSnap.byName,
-		}
-		abortSnap.collectMeta.LastAttemptSeq = c.core.active.seq
-		abortSnap.collectMeta.LastAttemptStatus = CollectStatusFailed
-		c.core.snapshot.Store(abortSnap)
-		err := c.core.active.err
-		c.core.active = nil
-		return err
+		return c.abortWithError(oldSnap, c.core.active.err)
+	}
+
+	// Reconcile this cycle's observed descriptors against the committed registry
+	// before publishing anything. Two incompatible kinds observed for one name in
+	// the same cycle is unresolvable and fails the whole commit; because no committed
+	// state has been mutated yet, that failure is transactional.
+	resolution := c.core.resolveObservedDescriptors()
+	if resolution.failErr != nil {
+		return c.abortWithError(oldSnap, resolution.failErr)
 	}
 	successSeq := c.core.successSeq + 1
 	next := &readSnapshot{
@@ -285,6 +864,39 @@ func (c *storeCycleController) CommitCycleSuccess() error {
 	commitHostScopes := make(map[string]HostScope)
 
 	maps.Copy(next.series, oldSnap.series)
+
+	// Apply supersessions: a name whose committed kind was not observed this cycle is
+	// replaced by the newly observed kind. Drop its carried-forward series and its
+	// committed descriptor so the staged loops create fresh series for the new kind
+	// (rather than mutating a series that still carries the old descriptor). One pass over
+	// next.series regardless of how many names supersede - O(live), not O(superseded*live).
+	if len(resolution.supersede) > 0 {
+		supersedeSet := make(map[string]struct{}, len(resolution.supersede))
+		for _, name := range resolution.supersede {
+			supersedeSet[name] = struct{}{}
+			delete(c.core.instruments, name)
+			// Keep instrumentZeroSince a subset of instruments: if the new kind's series does
+			// not survive this commit (e.g. maxSeries-evicted before canonicalization), the
+			// name never re-enters instruments, so the sweep would never revisit and clear a
+			// leftover idle stamp.
+			delete(c.core.instrumentZeroSince, name)
+		}
+		maps.DeleteFunc(next.series, func(_ string, series *committedSeries) bool {
+			_, ok := supersedeSet[series.name]
+			return ok
+		})
+	}
+
+	// Drop ambiguous multi-kind names: remove their staged writes and staged registration
+	// so they are ignored this cycle (prior committed series carry forward untouched). One
+	// pass per staged map - O(touched), not O(dropped*touched).
+	if len(resolution.drop) > 0 {
+		dropSet := make(map[string]struct{}, len(resolution.drop))
+		for _, name := range resolution.drop {
+			dropSet[name] = struct{}{}
+		}
+		c.core.active.dropStagedNames(dropSet)
+	}
 
 	for key, staged := range c.core.active.gauges {
 		commitHostScopes[staged.hostScopeKey] = staged.hostScope
@@ -316,26 +928,11 @@ func (c *storeCycleController) CommitCycleSuccess() error {
 
 	for key, staged := range c.core.active.histograms {
 		commitHostScopes[staged.hostScopeKey] = staged.hostScope
+		// The canonical descriptor already carries concrete bounds (the resolver reduces a
+		// nil-bounds observation to its observed bounds), and the resolver groups a name's
+		// writes by effective bounds, so every staged write of an accepted name shares the
+		// canonical bounds - no per-series schema capture or drift check is needed here.
 		series := getOrCreateCommitSeries(oldSnap, next, key, staged.name, staged.hostScopeKey, staged.hostScope, staged.labels, staged.labelsKey, staged.desc)
-
-		if series.desc == nil {
-			panic("metrix: missing histogram descriptor")
-		}
-		if series.desc.histogram == nil {
-			schema := c.core.snapshotHistogramSchema[series.name]
-			if schema == nil {
-				schema = &histogramSchema{bounds: append([]float64(nil), staged.bounds...)}
-				c.core.snapshotHistogramSchema[series.name] = schema
-			} else if !equalHistogramBounds(schema.bounds, staged.bounds) {
-				panic("metrix: histogram schema drift detected")
-			}
-			// Descriptor pointers can be shared across published snapshots.
-			// Never mutate shared descriptor state in-place; attach schema via a cloned descriptor.
-			series.desc = cloneInstrumentDescriptorWithHistogram(series.desc, schema.bounds)
-		} else if !equalHistogramBounds(series.desc.histogram.bounds, staged.bounds) {
-			panic("metrix: histogram schema drift detected")
-		}
-
 		series.histogramCount = staged.count
 		series.histogramSum = staged.sum
 		series.histogramCumulative = append(series.histogramCumulative[:0], staged.cumulative...)
@@ -406,9 +1003,49 @@ func (c *storeCycleController) CommitCycleSuccess() error {
 
 	refreshCommittedHostScopes(oldSnap, next, commitHostScopes)
 	applyCollectorRetention(next.series, c.core.retention, successSeq)
+
+	// Canonicalize the published snapshot in one pass, after retention: every surviving
+	// series of a name observed this cycle gets the single canonical descriptor, and the
+	// registry is set to match. This is the sole place descriptors are canonicalized, so
+	// instruments[name], every series.desc (including carried, unobserved series of an
+	// observed name), and the reader all agree regardless of label or iteration order.
+	// Running after retention means an evicted-this-cycle name leaves no orphan entry.
+	// Names with only carried series keep their committed entry; a defensive fill covers
+	// any surviving series whose name somehow lacks one.
+	// liveNames is collected here (folded into the existing scan) and consumed by the
+	// descriptor-universe sweep below, so the sweep needs no separate pass over next.series.
+	liveNames := make(map[string]struct{})
+	for key := range next.series {
+		series := next.series[key]
+		liveNames[series.name] = struct{}{}
+		canonical, ok := resolution.canonical[series.name]
+		if !ok {
+			if _, exists := c.core.instruments[series.name]; !exists {
+				c.core.instruments[series.name] = series.desc
+			}
+			continue
+		}
+		// This pass scans every live series (O(live-series)), but only clones/rewrites a
+		// series whose descriptor actually changes. With a no-op merge canonical == the
+		// committed descriptor, so unchanged retained series are skipped: the clone/allocation
+		// work stays O(touched), not O(retained).
+		if series.desc != canonical {
+			ensureCommitSeriesMutable(oldSnap, next, key).desc = canonical
+		}
+		if c.core.instruments[series.name] != canonical {
+			c.core.instruments[series.name] = canonical
+		}
+	}
+
+	// Bound descriptor growth: evict descriptors whose series are gone and whose grace has
+	// elapsed. Runs after canonicalization so the live-name set is final.
+	evicted := c.core.sweepDescriptorUniverse(liveNames, successSeq)
+
 	next.collectMeta.LastAttemptSeq = c.core.active.seq
 	next.collectMeta.LastAttemptStatus = CollectStatusSuccess
 	next.collectMeta.LastSuccessSeq = c.core.active.seq
+	next.collectMeta.EvictedDescriptors += evicted
+	next.collectMeta.DroppedNames += uint64(len(resolution.drop))
 
 	c.core.snapshot.Store(next)
 	c.core.successSeq = successSeq
@@ -539,6 +1176,42 @@ func applyCollectorRetention(series map[string]*committedSeries, policy collecto
 	}, nil)
 }
 
+// sweepDescriptorUniverse bounds instruments growth. The descriptor universe is exactly
+// the names in instruments (post-canonicalization every live name has an entry, and idle
+// names linger there until swept). For each name:
+//   - a live series clears any idle stamp;
+//   - an idle name is stamped with successSeq the first cycle it goes idle, then evicted
+//     once it has been idle for descriptorGraceCycles successful commits.
+//
+// It runs under c.mu at commit, after retention and canonicalization. Cost is O(universe) -
+// one pass over instruments, within the commit envelope. Returns the number of descriptors
+// evicted this cycle. instrumentZeroSince is lazily allocated (a store that never idles a
+// name never allocates it). Deleting the current key while ranging a map is defined in Go.
+func (c *storeCore) sweepDescriptorUniverse(liveNames map[string]struct{}, successSeq uint64) uint64 {
+	grace := c.retention.descriptorGraceCycles
+	var evicted uint64
+	for name := range c.instruments {
+		if _, live := liveNames[name]; live {
+			delete(c.instrumentZeroSince, name) // no-op on a nil map
+			continue
+		}
+		since, stamped := c.instrumentZeroSince[name]
+		if !stamped {
+			if c.instrumentZeroSince == nil {
+				c.instrumentZeroSince = make(map[string]uint64)
+			}
+			c.instrumentZeroSince[name] = successSeq
+			since = successSeq
+		}
+		if successSeq-since >= grace {
+			delete(c.instruments, name)
+			delete(c.instrumentZeroSince, name)
+			evicted++
+		}
+	}
+	return evicted
+}
+
 func defaultFreshness(mode metricMode) FreshnessPolicy {
 	if mode == modeSnapshot {
 		return FreshnessCycle
@@ -639,52 +1312,7 @@ func (c *storeCore) registerInstrument(name string, kind metricKind, mode metric
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if d, ok := c.instruments[name]; ok {
-		if d.kind != kind {
-			return nil, fmt.Errorf("metrix: instrument kind mismatch for %s", name)
-		}
-		if d.mode != mode {
-			return nil, fmt.Errorf("metrix: instrument mode mismatch for %s", name)
-		}
-		if d.freshness != fresh {
-			return nil, fmt.Errorf("metrix: instrument freshness mismatch for %s", name)
-		}
-		if d.window != window {
-			return nil, fmt.Errorf("metrix: instrument window mismatch for %s", name)
-		}
-		if kind == kindHistogram {
-			if !(mode == modeSnapshot && histogram == nil) && !equalHistogramSchema(d.histogram, histogram) {
-				return nil, fmt.Errorf("metrix: histogram schema mismatch for %s", name)
-			}
-		}
-		if kind == kindSummary && !equalSummarySchema(d.summary, summary) {
-			return nil, fmt.Errorf("metrix: summary schema mismatch for %s", name)
-		}
-		if kind == kindStateSet && !equalStateSetSchema(d.stateSet, schema) {
-			return nil, fmt.Errorf("metrix: stateset schema mismatch for %s", name)
-		}
-		if kind == kindMeasureSet && !equalMeasureSetSchema(d.measureSet, measureSet) {
-			return nil, fmt.Errorf("metrix: measureset schema mismatch for %s", name)
-		}
-		if cfg.descriptionSet && d.meta.Description != metricMeta.Description {
-			return nil, fmt.Errorf("metrix: metric description mismatch for %s", name)
-		}
-		if cfg.chartFamilySet && d.meta.ChartFamily != metricMeta.ChartFamily {
-			return nil, fmt.Errorf("metrix: metric chart family mismatch for %s", name)
-		}
-		if cfg.chartPrioritySet && d.meta.ChartPriority != metricMeta.ChartPriority {
-			return nil, fmt.Errorf("metrix: metric chart priority mismatch for %s", name)
-		}
-		if cfg.unitSet && d.meta.Unit != metricMeta.Unit {
-			return nil, fmt.Errorf("metrix: metric unit mismatch for %s", name)
-		}
-		if cfg.floatSet && d.meta.Float != metricMeta.Float {
-			return nil, fmt.Errorf("metrix: metric float mismatch for %s", name)
-		}
-		return d, nil
-	}
-
-	d := &instrumentDescriptor{
+	candidate := &instrumentDescriptor{
 		name:       name,
 		kind:       kind,
 		mode:       mode,
@@ -695,9 +1323,350 @@ func (c *storeCore) registerInstrument(name string, kind metricKind, mode metric
 		stateSet:   schema,
 		measureSet: measureSet,
 		meta:       metricMeta,
+		metaSet: metricMetaSet{
+			description:   cfg.descriptionSet,
+			chartFamily:   cfg.chartFamilySet,
+			chartPriority: cfg.chartPrioritySet,
+			unit:          cfg.unitSet,
+			float:         cfg.floatSet,
+		},
 	}
-	c.instruments[name] = d
-	return d, nil
+
+	// Resolve the candidate against any existing authority for this name. Registration
+	// is transactional: during an active cycle a new authority is staged into
+	// pendingInstruments and installed into the committed registry only on
+	// CommitCycleSuccess (from observed series); an aborted cycle discards it. A name
+	// may carry several mutually-incompatible pending authorities in one cycle (a
+	// superseding kind), so pending is a per-name list. A metadata mismatch against a
+	// series-authority-compatible descriptor is always a declaration bug and stays
+	// fail-loud regardless of cycle state.
+	if committed, ok := c.instruments[name]; ok {
+		// A nil-bounds histogram (a fresh registration or a never-observed committed
+		// descriptor) is an as-yet-unbounded wildcard, so compare via the symmetric
+		// helper. Once observed, the committed descriptor carries concrete bounds (the
+		// registry is converged at commit), so no schema lookup is needed here.
+		if seriesAuthoritiesCompatible(committed, candidate) {
+			if err := descriptorDeclarationCompat(committed, candidate); err != nil {
+				return nil, err
+			}
+			return dedupDescriptor(committed, candidate), nil
+		}
+		// The committed authority is incompatible. Outside a cycle there is nothing to
+		// reconcile, so fail loud; during a cycle, defer to commit (the committed kind
+		// is superseded if unobserved, or the cycle fails if both are observed) after
+		// checking the candidate against any compatible pending authority below.
+		if c.active == nil {
+			return nil, descriptorSeriesAuthorityCompat(committed, candidate)
+		}
+	} else if c.active == nil {
+		c.instruments[name] = candidate
+		return candidate, nil
+	}
+
+	// Active cycle: dedup against a compatible pending authority (declaration must
+	// still match), otherwise stage the candidate as a new pending authority.
+	for _, pending := range c.active.pendingInstruments[name] {
+		if seriesAuthoritiesCompatible(pending, candidate) {
+			if err := descriptorDeclarationCompat(pending, candidate); err != nil {
+				return nil, err
+			}
+			return dedupDescriptor(pending, candidate), nil
+		}
+	}
+	c.active.pendingInstruments[name] = append(c.active.pendingInstruments[name], candidate)
+	return candidate, nil
+}
+
+// descriptorSeriesAuthoritiesEqual reports whether the incoming descriptor may back the same
+// series as the existing one for a shared name: kind, mode, freshness, window, and the
+// type-specific schema all agree. A snapshot histogram registered with nil bounds is a wildcard
+// that adopts any existing bounds. It ALLOCATES NOTHING, so hot paths that only need the yes/no
+// answer (the resolver's authority grouping over many distinct schemas) use it directly rather
+// than allocating and discarding a descriptive error via descriptorSeriesAuthorityCompat.
+func descriptorSeriesAuthoritiesEqual(existing, incoming *instrumentDescriptor) bool {
+	if existing.kind != incoming.kind || existing.mode != incoming.mode ||
+		existing.freshness != incoming.freshness || existing.window != incoming.window {
+		return false
+	}
+	switch incoming.kind {
+	case kindHistogram:
+		return (incoming.mode == modeSnapshot && incoming.histogram == nil) || equalHistogramSchema(existing.histogram, incoming.histogram)
+	case kindSummary:
+		return equalSummarySchema(existing.summary, incoming.summary)
+	case kindStateSet:
+		return equalStateSetSchema(existing.stateSet, incoming.stateSet)
+	case kindMeasureSet:
+		return equalMeasureSetSchema(existing.measureSet, incoming.measureSet)
+	}
+	return true
+}
+
+// descriptorDeclarationsEqual reports whether two descriptors declare identical family metadata:
+// the same fields were set (metaSet) and to the same values. Allocation-free. The conflict-evidence
+// dedup uses it (with descriptorsFullyEqual) so a same-authority write with a DIFFERENT declaration
+// is recorded rather than collapsed, keeping its declaration conflict visible to the resolver.
+func descriptorDeclarationsEqual(a, b *instrumentDescriptor) bool {
+	return a.metaSet == b.metaSet &&
+		a.meta.Description == b.meta.Description &&
+		a.meta.ChartFamily == b.meta.ChartFamily &&
+		a.meta.ChartPriority == b.meta.ChartPriority &&
+		a.meta.Unit == b.meta.Unit &&
+		a.meta.Float == b.meta.Float
+}
+
+// declarationFingerprint hashes exactly the fields descriptorDeclarationsEqual compares (which
+// metadata was set, and its values), so equal declarations hash equally. It keys the same-key
+// conflict dedup by full descriptor identity, keeping that dedup O(1) even when one authority sees
+// many distinct declarations. Allocation-free.
+func declarationFingerprint(d *instrumentDescriptor) uint64 {
+	var bits uint64
+	if d.metaSet.description {
+		bits |= 1 << 0
+	}
+	if d.metaSet.chartFamily {
+		bits |= 1 << 1
+	}
+	if d.metaSet.chartPriority {
+		bits |= 1 << 2
+	}
+	if d.metaSet.unit {
+		bits |= 1 << 3
+	}
+	if d.metaSet.float {
+		bits |= 1 << 4
+	}
+	if d.meta.Float {
+		bits |= 1 << 5
+	}
+	h := hashUint64(fnvOffset64, bits)
+	h = hashUint64(h, uint64(d.meta.ChartPriority))
+	h = hashString(h, d.meta.Description)
+	h = hashString(h, d.meta.ChartFamily)
+	h = hashString(h, d.meta.Unit)
+	return h
+}
+
+// descriptorsFullyEqual reports whether two descriptors are identical in BOTH series authority and
+// declared metadata - i.e. the same instrument in every respect the resolver reconciles.
+func descriptorsFullyEqual(a, b *instrumentDescriptor) bool {
+	return descriptorSeriesAuthoritiesEqual(a, b) && descriptorDeclarationsEqual(a, b)
+}
+
+// descriptorSeriesAuthorityCompat reports the same relation as descriptorSeriesAuthoritiesEqual,
+// but returns the first field mismatch as a descriptive error (nil when compatible) for the
+// fail-loud paths (registration, commit-time declaration failure). It re-derives the specific
+// mismatch only when the fast equality check already said "not equal", so the happy path stays
+// allocation-free and the error paths keep their exact messages.
+func descriptorSeriesAuthorityCompat(existing, incoming *instrumentDescriptor) error {
+	if descriptorSeriesAuthoritiesEqual(existing, incoming) {
+		return nil
+	}
+	name := incoming.name
+	switch {
+	case existing.kind != incoming.kind:
+		return fmt.Errorf("metrix: instrument kind mismatch for %s", name)
+	case existing.mode != incoming.mode:
+		return fmt.Errorf("metrix: instrument mode mismatch for %s", name)
+	case existing.freshness != incoming.freshness:
+		return fmt.Errorf("metrix: instrument freshness mismatch for %s", name)
+	case existing.window != incoming.window:
+		return fmt.Errorf("metrix: instrument window mismatch for %s", name)
+	}
+	switch incoming.kind {
+	case kindHistogram:
+		return fmt.Errorf("metrix: histogram schema mismatch for %s", name)
+	case kindSummary:
+		return fmt.Errorf("metrix: summary schema mismatch for %s", name)
+	case kindStateSet:
+		return fmt.Errorf("metrix: stateset schema mismatch for %s", name)
+	case kindMeasureSet:
+		return fmt.Errorf("metrix: measureset schema mismatch for %s", name)
+	}
+	return fmt.Errorf("metrix: instrument authority mismatch for %s", name) // unreachable: not equal, no field differs
+}
+
+// descriptorDeclarationCompat reports whether the incoming descriptor's explicitly
+// declared family metadata conflicts with the existing (first) descriptor. Fields
+// the incoming did not set are ignored (preserve-first). It returns the first
+// conflict as an error, or nil when compatible.
+func descriptorDeclarationCompat(existing, incoming *instrumentDescriptor) error {
+	name := incoming.name
+	if incoming.metaSet.description && existing.meta.Description != incoming.meta.Description {
+		return fmt.Errorf("metrix: metric description mismatch for %s", name)
+	}
+	if incoming.metaSet.chartFamily && existing.meta.ChartFamily != incoming.meta.ChartFamily {
+		return fmt.Errorf("metrix: metric chart family mismatch for %s", name)
+	}
+	if incoming.metaSet.chartPriority && existing.meta.ChartPriority != incoming.meta.ChartPriority {
+		return fmt.Errorf("metrix: metric chart priority mismatch for %s", name)
+	}
+	if incoming.metaSet.unit && existing.meta.Unit != incoming.meta.Unit {
+		return fmt.Errorf("metrix: metric unit mismatch for %s", name)
+	}
+	if incoming.metaSet.float && existing.meta.Float != incoming.meta.Float {
+		return fmt.Errorf("metrix: metric float mismatch for %s", name)
+	}
+	return nil
+}
+
+// baselineSeriesForWrite returns the previously committed series for key only when its
+// descriptor is series-authority-compatible with desc. Accumulating writes (stateful
+// Add and cumulative windows) seed their baseline from the prior committed value;
+// without this guard a write whose name was just superseded by a different kind would
+// seed its baseline from the incompatible old series. Callers hold c.mu.
+func (c *storeCore) baselineSeriesForWrite(key string, desc *instrumentDescriptor) *committedSeries {
+	existing := c.snapshot.Load().series[key]
+	if existing == nil || existing.desc == nil {
+		return nil
+	}
+	if descriptorSeriesAuthorityCompat(existing.desc, desc) != nil {
+		return nil
+	}
+	return existing
+}
+
+// effectiveHistogramDescriptor returns a descriptor whose histogram bounds reflect the
+// bounds observed this cycle. A snapshot histogram registered with nil bounds is a
+// wildcard descriptor; comparing two such writes by descriptor alone hides genuinely
+// different observed bucket schemas, so authority resolution compares the observed
+// bounds instead. Non-histogram or explicit-bounds descriptors are returned unchanged.
+func effectiveHistogramDescriptor(desc *instrumentDescriptor, observedBounds []float64) *instrumentDescriptor {
+	if desc.kind != kindHistogram || desc.histogram != nil {
+		return desc
+	}
+	return cloneInstrumentDescriptorWithHistogram(desc, observedBounds)
+}
+
+// realCommittedAuthority returns the committed descriptor only when it is a live
+// authority. A never-observed nil-bounds snapshot histogram is a registration wildcard
+// (its bounds are established only by observation, at which point convergence installs a
+// concrete descriptor), so it does not count as a committed authority in resolution.
+func realCommittedAuthority(committed *instrumentDescriptor) *instrumentDescriptor {
+	if committed == nil {
+		return nil
+	}
+	if committed.kind == kindHistogram && committed.histogram == nil {
+		return nil
+	}
+	return committed
+}
+
+// mergeInstrumentMetadata unions ONLY the declared meta fields (description, chartFamily,
+// chartPriority, unit, float) of two series-authority-compatible descriptors into a canonical
+// one: a field declared on either side wins, and a field declared on BOTH sides with different
+// values is a conflict (returned as an error). It never touches instrument SCHEMA (histogram
+// bounds, summary quantiles, ...) - that authority is fixed by the series-authority check and,
+// for histograms, by the staged entry's observed bounds; so a running-canonical staged entry
+// keeps its bounds-nature (a nil-bounds snapshot stays nil, crash-safe for client-driven bounds).
+// Order-independent. Lazy: a semantic no-op returns a's pointer so the canonical pass skips
+// re-cloning unchanged series, keeping the commit's clone/allocation work O(touched), not
+// O(retained) (the pass itself still scans every live series).
+func mergeInstrumentMetadata(a, b *instrumentDescriptor) (*instrumentDescriptor, error) {
+	merged := a
+	ensureCopy := func() {
+		if merged == a {
+			cp := *a
+			merged = &cp
+		}
+	}
+	if b.metaSet.description {
+		switch {
+		case !merged.metaSet.description:
+			ensureCopy()
+			merged.meta.Description = b.meta.Description
+			merged.metaSet.description = true
+		case merged.meta.Description != b.meta.Description:
+			return nil, fmt.Errorf("metrix: metric description mismatch for %s", a.name)
+		}
+	}
+	if b.metaSet.chartFamily {
+		switch {
+		case !merged.metaSet.chartFamily:
+			ensureCopy()
+			merged.meta.ChartFamily = b.meta.ChartFamily
+			merged.metaSet.chartFamily = true
+		case merged.meta.ChartFamily != b.meta.ChartFamily:
+			return nil, fmt.Errorf("metrix: metric chart family mismatch for %s", a.name)
+		}
+	}
+	if b.metaSet.chartPriority {
+		switch {
+		case !merged.metaSet.chartPriority:
+			ensureCopy()
+			merged.meta.ChartPriority = b.meta.ChartPriority
+			merged.metaSet.chartPriority = true
+		case merged.meta.ChartPriority != b.meta.ChartPriority:
+			return nil, fmt.Errorf("metrix: metric chart priority mismatch for %s", a.name)
+		}
+	}
+	if b.metaSet.unit {
+		switch {
+		case !merged.metaSet.unit:
+			ensureCopy()
+			merged.meta.Unit = b.meta.Unit
+			merged.metaSet.unit = true
+		case merged.meta.Unit != b.meta.Unit:
+			return nil, fmt.Errorf("metrix: metric unit mismatch for %s", a.name)
+		}
+	}
+	if b.metaSet.float {
+		switch {
+		case !merged.metaSet.float:
+			ensureCopy()
+			merged.meta.Float = b.meta.Float
+			merged.metaSet.float = true
+		case merged.meta.Float != b.meta.Float:
+			return nil, fmt.Errorf("metrix: metric float mismatch for %s", a.name)
+		}
+	}
+	return merged, nil
+}
+
+// mergeDeclarations unions the declared metadata (mergeInstrumentMetadata) AND carries concrete
+// histogram bounds when one side is a nil-bounds wildcard, producing the canonical descriptor the
+// resolver publishes. Used by the resolver, where a nil-bounds committed/observed descriptor must
+// adopt the concrete observed bounds. `a` provides the base (authority fields); pass the
+// committed/first descriptor as `a` where one exists. Order-independent; lazy (see
+// mergeInstrumentMetadata).
+func mergeDeclarations(a, b *instrumentDescriptor) (*instrumentDescriptor, error) {
+	merged, err := mergeInstrumentMetadata(a, b)
+	if err != nil {
+		return nil, err
+	}
+	if merged.kind == kindHistogram && merged.histogram == nil && b.histogram != nil {
+		if merged == a { // still the shared base; copy before adding bounds
+			cp := *a
+			merged = &cp
+		}
+		merged.histogram = b.histogram
+	}
+	return merged, nil
+}
+
+// seriesAuthoritiesCompatible reports series-authority compatibility treating a
+// nil-bounds snapshot histogram as a wildcard on EITHER side. It is used only for
+// single-pair comparisons where one side may be an as-yet-unbounded histogram (a
+// fresh registration, or a never-observed committed descriptor). The resolver's
+// observed grouping does NOT use it - it reduces observed histograms to concrete
+// effective bounds first, keeping grouping transitive with a single directional check.
+func seriesAuthoritiesCompatible(a, b *instrumentDescriptor) bool {
+	return descriptorSeriesAuthoritiesEqual(a, b) || descriptorSeriesAuthoritiesEqual(b, a)
+}
+
+// dedupDescriptor is the descriptor a handle receives when its registration dedups to
+// an existing compatible authority. For histograms it keeps the CANDIDATE's bounds
+// shape while preserving the existing (first) declared metadata: a nil-bounds
+// registration must stay nil so its record path normalizes from the observed point
+// (crash-safe for client-driven bounds), and an explicit registration keeps its
+// declared bounds (validated at record). Non-histogram handles reuse the existing
+// descriptor unchanged.
+func dedupDescriptor(existing, candidate *instrumentDescriptor) *instrumentDescriptor {
+	if candidate.kind != kindHistogram {
+		return existing
+	}
+	merged := *existing
+	merged.histogram = candidate.histogram
+	return &merged
 }
 
 func (c *storeCore) prepareHostScopeForWriteLocked(scope HostScope) (HostScope, bool) {

--- a/src/go/pkg/metrix/collector_store.go
+++ b/src/go/pkg/metrix/collector_store.go
@@ -285,7 +285,7 @@ const (
 )
 
 func hashUint64(h, v uint64) uint64 {
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		h ^= (v >> (uint(i) * 8)) & 0xff
 		h *= fnvPrime64
 	}

--- a/src/go/pkg/metrix/collector_store_options_test.go
+++ b/src/go/pkg/metrix/collector_store_options_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCollectorStoreOptions pins the constructor option contract: the retention
+// knobs are configurable, and descriptorGraceCycles defaults to the (possibly
+// overridden) expireAfterSuccessCycles unless set explicitly.
+func TestCollectorStoreOptions(t *testing.T) {
+	tests := map[string]struct {
+		opts       []CollectorStoreOption
+		wantExpire uint64
+		wantMax    int
+		wantGrace  uint64
+	}{
+		"defaults couple grace to the default expire": {
+			opts:       nil,
+			wantExpire: defaultCollectorExpireAfterSuccessCycles,
+			wantMax:    defaultCollectorMaxSeries,
+			wantGrace:  defaultCollectorExpireAfterSuccessCycles,
+		},
+		"overriding expire carries into the grace default": {
+			opts:       []CollectorStoreOption{WithExpireAfterSuccessCycles(5)},
+			wantExpire: 5,
+			wantMax:    defaultCollectorMaxSeries,
+			wantGrace:  5,
+		},
+		"explicit grace overrides the coupled default": {
+			opts:       []CollectorStoreOption{WithExpireAfterSuccessCycles(5), WithDescriptorGraceCycles(3)},
+			wantExpire: 5,
+			wantMax:    defaultCollectorMaxSeries,
+			wantGrace:  3,
+		},
+		"explicit zero grace is honored, not treated as unset": {
+			opts:       []CollectorStoreOption{WithDescriptorGraceCycles(0)},
+			wantExpire: defaultCollectorExpireAfterSuccessCycles,
+			wantMax:    defaultCollectorMaxSeries,
+			wantGrace:  0,
+		},
+		"max series is configurable": {
+			opts:       []CollectorStoreOption{WithMaxSeries(100)},
+			wantExpire: defaultCollectorExpireAfterSuccessCycles,
+			wantMax:    100,
+			wantGrace:  defaultCollectorExpireAfterSuccessCycles,
+		},
+		"a nil option is ignored": {
+			opts:       []CollectorStoreOption{nil, WithMaxSeries(7)},
+			wantExpire: defaultCollectorExpireAfterSuccessCycles,
+			wantMax:    7,
+			wantGrace:  defaultCollectorExpireAfterSuccessCycles,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := NewCollectorStore(tc.opts...)
+			sv := collectorStoreViewForTest(t, s)
+			require.Equal(t, tc.wantExpire, sv.core.retention.expireAfterSuccessCycles, "expireAfterSuccessCycles")
+			require.Equal(t, tc.wantMax, sv.core.retention.maxSeries, "maxSeries")
+			require.Equal(t, tc.wantGrace, sv.core.retention.descriptorGraceCycles, "descriptorGraceCycles")
+		})
+	}
+}

--- a/src/go/pkg/metrix/counter.go
+++ b/src/go/pkg/metrix/counter.go
@@ -90,6 +90,13 @@ func (c *storeCore) recordCounterObserveTotal(desc *instrumentDescriptor, scope 
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.counters[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		entry = &stagedCounter{
 			key:          key,
@@ -131,9 +138,16 @@ func (c *storeCore) recordCounterAdd(desc *instrumentDescriptor, scope HostScope
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.counters[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		baseline := SampleValue(0)
-		if existing := c.snapshot.Load().series[key]; existing != nil && existing.desc != nil && existing.desc.kind == kindCounter {
+		if existing := c.baselineSeriesForWrite(key, desc); existing != nil {
 			baseline = existing.counterCurrent
 		}
 		entry = &stagedCounter{

--- a/src/go/pkg/metrix/descriptor_authority_store_test.go
+++ b/src/go/pkg/metrix/descriptor_authority_store_test.go
@@ -714,13 +714,13 @@ func TestCommitCostGuards(t *testing.T) {
 		cc.BeginCycle()
 		// Stateful: 1000 Observe on one handle.
 		hs := s.Write().StatefulMeter("svc").Histogram("hs", WithHistogramBounds(1, 2))
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			hs.Observe(1)
 		}
 		// Snapshot: 1000 ObservePoint with the same bounds on one handle.
 		hp := s.Write().SnapshotMeter("svc").Histogram("hp")
 		pt := HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 1, CumulativeCount: 1}, {UpperBound: 2, CumulativeCount: 1}}}
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			hp.ObservePoint(pt)
 		}
 		require.Empty(t, sv.core.active.conflicts, "same-handle repeats must not append descriptor evidence")
@@ -737,7 +737,7 @@ func TestCommitCostGuards(t *testing.T) {
 		}
 
 		cc.BeginCycle()
-		for i := 0; i < retained; i++ {
+		for i := range retained {
 			s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: labels[i]}).Gauge("m").Observe(SampleValue(i))
 		}
 		require.NoError(t, cc.CommitCycleSuccess())
@@ -745,7 +745,7 @@ func TestCommitCostGuards(t *testing.T) {
 		// A cycle touching only 5 of the retained series must not clone all of them.
 		allocs := testing.AllocsPerRun(2, func() {
 			cc.BeginCycle()
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: labels[i]}).Gauge("m").Observe(SampleValue(i))
 			}
 			_ = cc.CommitCycleSuccess()
@@ -814,7 +814,7 @@ func TestMultiAuthorityCommittedObserved(t *testing.T) {
 				// authority (no cap), so the bytes-vs-seconds declaration conflict is caught
 				// regardless of map-iteration order -> FAIL every time, never an order-dependent DROP.
 				// Repeat to exercise staged-map order.
-				for i := 0; i < 64; i++ {
+				for i := range 64 {
 					s := NewCollectorStore()
 					cc := cycleController(t, s)
 

--- a/src/go/pkg/metrix/descriptor_authority_store_test.go
+++ b/src/go/pkg/metrix/descriptor_authority_store_test.go
@@ -1,0 +1,877 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthorityFingerprintSignedZero pins that the authority fingerprint matches series-authority
+// equality for signed zero: -0.0 and +0.0 compare equal, so equal authorities must share a
+// fingerprint (else a semantic authority over-records as two conflict buckets).
+func TestAuthorityFingerprintSignedZero(t *testing.T) {
+	negZero := math.Copysign(0, -1)
+	a := &instrumentDescriptor{kind: kindHistogram, histogram: &histogramSchema{bounds: []float64{0, 1}}}
+	b := &instrumentDescriptor{kind: kindHistogram, histogram: &histogramSchema{bounds: []float64{negZero, 1}}}
+	require.True(t, descriptorSeriesAuthoritiesEqual(a, b), "+0.0 and -0.0 bounds are authority-equal")
+	require.Equal(t, authorityFingerprintOf(a), authorityFingerprintOf(b), "equal authorities must share a fingerprint")
+}
+
+// TestBaselineSeriesAuthority pins that accumulating writes (stateful Add and
+// cumulative windows) never seed their baseline from a series whose descriptor is
+// series-authority-incompatible - e.g. a name whose kind was just superseded. A
+// single helper (baselineSeriesForWrite) guards every additive baseline read, so
+// gauge and measureset (which previously read any kind) and the kind-checked
+// counter/histogram/summary paths all share the same authority check.
+func TestBaselineSeriesAuthority(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"gauge superseding a counter does not inherit the counter's value": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Cycle 1: svc.m is a snapshot counter at 100.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Counter("m").ObserveTotal(100)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: svc.m is written only as a stateful gauge Add(5). The counter is
+				// superseded, so the gauge must start fresh (5), not from the counter (105).
+				cc.BeginCycle()
+				s.Write().StatefulMeter("svc").Gauge("m").Add(5)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				mustValue(t, s.Read(), "svc.m", nil, 5)
+			},
+		},
+		"measureset-counter superseding a measureset-gauge does not inherit the gauge's value": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Cycle 1: svc.lat is a stateful measureset gauge, field value = 100.
+				cc.BeginCycle()
+				s.Write().StatefulMeter("svc").MeasureSetGauge("lat",
+					WithMeasureSetFields(MeasureFieldSpec{Name: "value"}),
+				).AddField("value", 100)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: svc.lat is written only as a measureset COUNTER (incompatible
+				// semantics). It must start fresh (5), not from the superseded gauge (105).
+				cc.BeginCycle()
+				s.Write().StatefulMeter("svc").MeasureSetCounter("lat",
+					WithMeasureSetFields(MeasureFieldSpec{Name: "value"}),
+				).AddField("value", 5)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				mustValue(t, s.Read(ReadFlatten()), "svc.lat_value", measureSetFieldLabels("value"), 5)
+			},
+		},
+		"compatible stateful gauge still carries its baseline across cycles": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				cc.BeginCycle()
+				s.Write().StatefulMeter("svc").Gauge("m").Add(10)
+				require.NoError(t, cc.CommitCycleSuccess())
+				mustValue(t, s.Read(), "svc.m", nil, 10)
+
+				// Same authority next cycle -> baseline carries (10 + 5 = 15).
+				cc.BeginCycle()
+				s.Write().StatefulMeter("svc").Gauge("m").Add(5)
+				require.NoError(t, cc.CommitCycleSuccess())
+				mustValue(t, s.Read(), "svc.m", nil, 15)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// TestSameKeyAuthorityConflict pins that two writes to the SAME series key with
+// incompatible authorities (e.g. snapshot vs stateful mode) no longer collapse into
+// one staged entry: the second write records a conflict so commit-time resolution
+// drops the name. Previously only summary/stateset/measureset guarded this; the guard
+// now covers gauge, counter, and histogram too.
+func TestSameKeyAuthorityConflict(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"gauge snapshot vs stateful on one key is dropped": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				s.Write().StatefulMeter("svc").Gauge("m").Add(2) // same key, incompatible mode
+				s.Write().SnapshotMeter("svc").Gauge("ok").Observe(9)
+
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read()
+				mustNoValue(t, r, "svc.m", nil)
+				mustValue(t, r, "svc.ok", nil, 9)
+			},
+		},
+		"counter snapshot vs stateful on one key is dropped": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Counter("m").ObserveTotal(1)
+				s.Write().StatefulMeter("svc").Counter("m").Add(2) // same key, incompatible mode
+				s.Write().SnapshotMeter("svc").Counter("ok").ObserveTotal(9)
+
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read()
+				mustNoValue(t, r, "svc.m", nil)
+				mustValue(t, r, "svc.ok", nil, 9)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// TestHistogramEffectiveBoundsAuthority pins that histogram authority is resolved by
+// the bounds actually OBSERVED this cycle, not by the descriptor alone. A nil-bounds
+// snapshot histogram is a wildcard descriptor, so comparing descriptors would let
+// genuinely different bucket schemas collapse (silent mixed schemas) or drift-panic at
+// commit. Same-observed-bounds writes still dedup; different observed bounds drop.
+func TestHistogramEffectiveBoundsAuthority(t *testing.T) {
+	pt := func(uppers ...float64) HistogramPoint {
+		buckets := make([]BucketPoint, len(uppers))
+		for i, ub := range uppers {
+			buckets[i] = BucketPoint{UpperBound: ub, CumulativeCount: 1}
+		}
+		return HistogramPoint{Count: 1, Sum: 1, Buckets: buckets}
+	}
+
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"nil-bounds and explicit-bounds with different observed bounds are dropped": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).
+					Histogram("h").ObservePoint(pt(1, 2))
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).
+					Histogram("h", WithHistogramBounds(5, 6)).ObservePoint(pt(5, 6))
+				s.Write().SnapshotMeter("svc").Gauge("ok").Observe(9)
+
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read(ReadFlatten())
+				mustNoValue(t, r, "svc.h_count", Labels{"id": "a"})
+				mustNoValue(t, r, "svc.h_count", Labels{"id": "b"})
+				mustValue(t, r, "svc.ok", nil, 9)
+			},
+		},
+		"two nil-bounds with different observed bounds are dropped, not panicked": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				require.NotPanics(t, func() {
+					s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).
+						Histogram("h").ObservePoint(pt(1, 2))
+					s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).
+						Histogram("h").ObservePoint(pt(5, 6))
+				})
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read(ReadFlatten())
+				mustNoValue(t, r, "svc.h_count", Labels{"id": "a"})
+				mustNoValue(t, r, "svc.h_count", Labels{"id": "b"})
+			},
+		},
+		"nil-bounds and explicit-bounds with the same observed bounds both commit": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).
+					Histogram("h").ObservePoint(pt(1, 2))
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).
+					Histogram("h", WithHistogramBounds(1, 2)).ObservePoint(pt(1, 2))
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read(ReadFlatten())
+				mustValue(t, r, "svc.h_count", Labels{"id": "a"}, 1)
+				mustValue(t, r, "svc.h_count", Labels{"id": "b"}, 1)
+			},
+		},
+		"same-key histogram with different observed bounds is dropped, not panicked": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				h := s.Write().SnapshotMeter("svc").Histogram("h")
+				require.NotPanics(t, func() {
+					h.ObservePoint(pt(1, 2))
+					h.ObservePoint(pt(5, 6)) // same key, different observed bounds
+				})
+				s.Write().SnapshotMeter("svc").Gauge("ok").Observe(9)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read(ReadFlatten())
+				mustNoValue(t, r, "svc.h_count", nil)
+				mustValue(t, r, "svc.ok", nil, 9)
+			},
+		},
+		"nil-bounds histogram observing different bounds next cycle supersedes without panic": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Histogram("h").ObservePoint(pt(1, 2))
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// The committed registry now holds explicit bounds (installed from the
+				// published series). A next-cycle nil-bounds handle observing different
+				// bounds must not panic; the captured schema is superseded at commit.
+				newPoint := HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 5, CumulativeCount: 1}, {UpperBound: 6, CumulativeCount: 1}}}
+				cc.BeginCycle()
+				require.NotPanics(t, func() {
+					s.Write().SnapshotMeter("svc").Histogram("h").ObservePoint(newPoint)
+				})
+				require.NoError(t, cc.CommitCycleSuccess())
+				mustHistogram(t, s.Read(), "svc.h", nil, newPoint)
+			},
+		},
+		"nil-bounds histogram observing the same bounds next cycle is stable": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Histogram("h").ObservePoint(pt(1, 2))
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Same effective bounds must NOT false-supersede (the P1-a regression):
+				// the value updates in place across cycles.
+				samePoint := HistogramPoint{Count: 5, Sum: 5, Buckets: []BucketPoint{{UpperBound: 1, CumulativeCount: 5}, {UpperBound: 2, CumulativeCount: 5}}}
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Histogram("h").ObservePoint(samePoint)
+				require.NoError(t, cc.CommitCycleSuccess())
+				mustHistogram(t, s.Read(), "svc.h", nil, samePoint)
+			},
+		},
+		"nil-then-explicit registration with the same bounds both commit": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				// Register nil-bounds FIRST, then explicit (reverse order), same bounds.
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Histogram("h").ObservePoint(pt(1, 2))
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Histogram("h", WithHistogramBounds(1, 2)).ObservePoint(pt(1, 2))
+				require.NoError(t, cc.CommitCycleSuccess())
+				r := s.Read(ReadFlatten())
+				mustValue(t, r, "svc.h_count", Labels{"id": "a"}, 1)
+				mustValue(t, r, "svc.h_count", Labels{"id": "b"}, 1)
+			},
+		},
+		"init nil then explicit-committed then nil different bounds supersedes without panic": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				// Init-register nil-bounds (no active cycle): instruments[name] is nil-bounds.
+				_ = s.Write().SnapshotMeter("svc").Histogram("h")
+
+				// Cycle 1: commit EXPLICIT bounds [1,2]. Explicit series capture no persistent
+				// schema (the round-4 divergence); install-from-accepted converges the registry.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Histogram("h", WithHistogramBounds(1, 2)).ObservePoint(pt(1, 2))
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: a nil-bounds handle observing different bounds must not panic; the
+				// converged committed authority supersedes.
+				newPoint := HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 5, CumulativeCount: 1}, {UpperBound: 6, CumulativeCount: 1}}}
+				cc.BeginCycle()
+				require.NotPanics(t, func() {
+					s.Write().SnapshotMeter("svc").Histogram("h").ObservePoint(newPoint)
+				})
+				require.NoError(t, cc.CommitCycleSuccess())
+				mustHistogram(t, s.Read(), "svc.h", nil, newPoint)
+			},
+		},
+		"evicted nil-bounds histogram leaves no orphaned schema": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				sv.core.retention = collectorRetentionPolicy{maxSeries: 1}
+				cc := cycleController(t, s)
+
+				// Cycle 1: nil-bounds histogram svc.a[1,2] + gauge svc.z. maxSeries=1 evicts
+				// the lower-keyed series (svc.a) after its bounds were captured this cycle.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Histogram("a").ObservePoint(pt(1, 2))
+				s.Write().SnapshotMeter("svc").Gauge("z").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: svc.a with DIFFERENT bounds must not panic against a stale orphaned
+				// schema - per-cycle schema means no persistent orphan can exist.
+				other := HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 5, CumulativeCount: 1}, {UpperBound: 6, CumulativeCount: 1}}}
+				cc.BeginCycle()
+				require.NotPanics(t, func() {
+					s.Write().SnapshotMeter("svc").Histogram("a").ObservePoint(other)
+				})
+				require.NoError(t, cc.CommitCycleSuccess())
+			},
+		},
+		"init nil-bounds histogram with conflicting first observations drops only that name": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				// Init-register nil-bounds svc.h (no active cycle): a wildcard registration
+				// with no live series - NOT an established authority.
+				_ = s.Write().SnapshotMeter("svc").Histogram("h")
+
+				// First observed cycle: two conflicting bounds for svc.h + an unrelated gauge.
+				// With no live committed authority, svc.h is ambiguous and must be DROPPED,
+				// not fail the whole cycle - the unrelated gauge still commits.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Histogram("h").ObservePoint(pt(1, 2))
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Histogram("h").ObservePoint(HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 5, CumulativeCount: 1}, {UpperBound: 6, CumulativeCount: 1}}})
+				s.Write().SnapshotMeter("svc").Gauge("ok").Observe(9)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read(ReadFlatten())
+				mustNoValue(t, r, "svc.h_count", Labels{"id": "a"})
+				mustNoValue(t, r, "svc.h_count", Labels{"id": "b"})
+				mustValue(t, r, "svc.ok", nil, 9)
+			},
+		},
+		"init nil-bounds histogram declaration survives a stale-handle first observation": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				cc := cycleController(t, s)
+				// Stale nil-bounds handle with NO unit, from an aborted cycle (before init reg).
+				cc.BeginCycle()
+				stale := s.Write().SnapshotMeter("svc").Histogram("h")
+				cc.AbortCycle()
+
+				// Init-register svc.h nil-bounds WITH unit=bytes (no active cycle).
+				_ = s.Write().SnapshotMeter("svc").Histogram("h", WithUnit("bytes"))
+
+				// First observation uses the stale NO-unit handle. The committed declaration
+				// (unit=bytes) is a wildcard registration but its metadata must be preserved.
+				cc.BeginCycle()
+				stale.ObservePoint(pt(1, 2))
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				require.NotNil(t, sv.core.instruments["svc.h"])
+				require.Equal(t, "bytes", sv.core.instruments["svc.h"].meta.Unit, "committed nil-bounds declaration must be preserved")
+				for _, series := range sv.core.snapshot.Load().series {
+					if series.name == "svc.h" {
+						require.Equal(t, "bytes", series.desc.meta.Unit)
+					}
+				}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// TestCanonicalDescriptorMetadata pins that commit publishes a single CANONICAL
+// descriptor per name: compatible-but-divergent metadata (a cached handle that sets
+// fewer fields, or complementary fields across labels) is reconciled deterministically
+// so every series - and the reader - sees the same metadata, independent of label/order.
+func TestCanonicalDescriptorMetadata(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"cached unset-metadata handle does not erase committed metadata on a new label": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// A cached no-unit handle (label b) from an aborted cycle, before any commit.
+				cc.BeginCycle()
+				stale := s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Gauge("m")
+				cc.AbortCycle()
+
+				// Commit svc.m{id=a} with unit=bytes.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Gauge("m", WithUnit("bytes")).Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// The stale no-unit handle observes its new label. Canonicalization must
+				// publish the committed (bytes) metadata for it, not empty metadata.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Gauge("m", WithUnit("bytes")).Observe(2)
+				stale.Observe(3)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				meta, ok := s.Read().MetricMeta("svc.m")
+				require.True(t, ok)
+				require.Equal(t, "bytes", meta.Unit, "metadata must be canonical across labels")
+			},
+		},
+		"new name merges explicit and unset handles deterministically": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// A stale explicit (unit=bytes) handle for a NEW name, from an aborted cycle.
+				cc.BeginCycle()
+				explicit := s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Gauge("m", WithUnit("bytes"))
+				cc.AbortCycle()
+
+				// A fresh unset handle + the stale explicit handle both observe the new name
+				// in one cycle. Canonicalization is order-independent: unit=bytes wins
+				// (unset never conflicts).
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Gauge("m").Observe(2)
+				explicit.Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				meta, ok := s.Read().MetricMeta("svc.m")
+				require.True(t, ok)
+				require.Equal(t, "bytes", meta.Unit)
+			},
+		},
+		"complementary metadata across labels is unioned": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Two stale handles for a NEW name: one sets unit, the other description.
+				cc.BeginCycle()
+				hUnit := s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Gauge("m", WithUnit("bytes"))
+				cc.AbortCycle()
+				cc.BeginCycle()
+				hDesc := s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Gauge("m", WithDescription("d"))
+				cc.AbortCycle()
+
+				cc.BeginCycle()
+				hUnit.Observe(1)
+				hDesc.Observe(2)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				meta, ok := s.Read().MetricMeta("svc.m")
+				require.True(t, ok)
+				require.Equal(t, "bytes", meta.Unit)
+				require.Equal(t, "d", meta.Description)
+			},
+		},
+		"carried unobserved series of an observed name is canonicalized": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				cc := cycleController(t, s)
+				// A cached bytes-unit handle (label b) from an aborted cycle, before any commit.
+				cc.BeginCycle()
+				bytesHandle := s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Gauge("m", WithUnit("bytes"))
+				cc.AbortCycle()
+
+				// Cycle 1: commit svc.m{id=a} and svc.m{id=b}, both WITHOUT a unit.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Gauge("m").Observe(1)
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Gauge("m").Observe(2)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: only id=b is observed (unit=bytes). The canonical becomes bytes;
+				// the carried, unobserved id=a series must be canonicalized to bytes too, so
+				// every series and the registry agree (not just the observed one).
+				cc.BeginCycle()
+				bytesHandle.Observe(3)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				for _, series := range sv.core.snapshot.Load().series {
+					if series.name == "svc.m" {
+						require.Equal(t, "bytes", series.desc.meta.Unit, "every svc.m series must carry the canonical unit")
+					}
+				}
+				require.Equal(t, "bytes", sv.core.instruments["svc.m"].meta.Unit)
+			},
+		},
+		"same-key complementary metadata is unioned regardless of write order": {
+			run: func(t *testing.T) {
+				for _, reversed := range []bool{false, true} {
+					s := NewCollectorStore()
+					cc := cycleController(t, s)
+					// Two cached handles for the SAME key (no labels): complementary metadata.
+					cc.BeginCycle()
+					hUnit := s.Write().SnapshotMeter("svc").Gauge("m", WithUnit("bytes"))
+					cc.AbortCycle()
+					cc.BeginCycle()
+					hDesc := s.Write().SnapshotMeter("svc").Gauge("m", WithDescription("d"))
+					cc.AbortCycle()
+
+					cc.BeginCycle()
+					if reversed {
+						hDesc.Observe(2)
+						hUnit.Observe(1)
+					} else {
+						hUnit.Observe(1)
+						hDesc.Observe(2)
+					}
+					require.NoError(t, cc.CommitCycleSuccess())
+
+					meta, ok := s.Read().MetricMeta("svc.m")
+					require.Truef(t, ok, "reversed=%v", reversed)
+					require.Equalf(t, "bytes", meta.Unit, "reversed=%v", reversed)
+					require.Equalf(t, "d", meta.Description, "reversed=%v", reversed)
+				}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// TestCommitTimeDeclarationConflict pins that a declaration (metadata) conflict between
+// series-authority-compatible descriptors is caught at commit even when a cached handle
+// bypasses registration - a reused handle from an aborted cycle carries a stale unit
+// that conflicts with the committed declaration, so the cycle must fail transactionally.
+func TestCommitTimeDeclarationConflict(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"cached handle with a conflicting unit fails the commit": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// A gauge registered with unit=seconds in a cycle that aborts: the handle
+				// survives, but the registration is discarded (never committed).
+				cc.BeginCycle()
+				stale := s.Write().SnapshotMeter("svc").Gauge("m", WithUnit("seconds"))
+				cc.AbortCycle()
+
+				// Commit the same name with unit=bytes.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m", WithUnit("bytes")).Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Reusing the stale handle bypasses registration (no re-check), so the
+				// unit conflict must be caught at commit -> the cycle fails, transactionally.
+				cc.BeginCycle()
+				stale.Observe(2)
+				err := cc.CommitCycleSuccess()
+				require.Error(t, err)
+				require.ErrorContains(t, err, "unit mismatch")
+
+				// The failed cycle did not corrupt the committed gauge: it can still be
+				// observed (with the committed unit) and read back in a fresh cycle.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m", WithUnit("bytes")).Observe(7)
+				require.NoError(t, cc.CommitCycleSuccess())
+				mustValue(t, s.Read(), "svc.m", nil, 7)
+			},
+		},
+		"same-key stale metadata conflict fails the commit": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// A stale unit=seconds handle, created before any commit (so registration
+				// does not yet conflict).
+				cc.BeginCycle()
+				stale := s.Write().SnapshotMeter("svc").Gauge("m", WithUnit("seconds"))
+				cc.AbortCycle()
+
+				// Commit svc.m with unit=bytes.
+				cc.BeginCycle()
+				valid := s.Write().SnapshotMeter("svc").Gauge("m", WithUnit("bytes"))
+				valid.Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Same cycle, SAME key: valid (bytes) then stale (seconds). The stale write
+				// must be recorded as a conflict (not silently applied under bytes metadata),
+				// failing the cycle.
+				cc.BeginCycle()
+				valid.Observe(2)
+				stale.Observe(3)
+				err := cc.CommitCycleSuccess()
+				require.Error(t, err)
+				require.ErrorContains(t, err, "unit mismatch")
+			},
+		},
+		"different-label explicit and unset metadata both commit (preserve-first)": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				// Same name, different labels: one sets unit, the other leaves it unset.
+				// Preserve-first makes this compatible - it must NOT be wrongly failed.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Gauge("m", WithUnit("bytes")).Observe(1)
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Gauge("m").Observe(2)
+				require.NoError(t, cc.CommitCycleSuccess())
+				r := s.Read()
+				mustValue(t, r, "svc.m", Labels{"id": "a"}, 1)
+				mustValue(t, r, "svc.m", Labels{"id": "b"}, 2)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// TestPendingMetadataConflict pins that a metadata (declaration) conflict between two
+// series-authority-compatible registrations stays fail-loud even when the committed
+// authority for that name is incompatible - the per-name pending authority list is
+// consulted so the second declaration is compared against the first.
+func TestPendingMetadataConflict(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"conflicting units fail even under an incompatible committed authority": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Establish an incompatible committed authority (gauge) for svc.m.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Two counter declarations share an authority; their unit conflict is a bug.
+				cc.BeginCycle()
+				_ = s.Write().SnapshotMeter("svc").Counter("m", WithUnit("bytes"))
+				expectPanic(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Counter("m", WithUnit("seconds"))
+				})
+			},
+		},
+		"matching units dedup even under an incompatible committed authority": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				cc.BeginCycle()
+				require.NotPanics(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Counter("m", WithUnit("bytes"))
+					_ = s.Write().SnapshotMeter("svc").Counter("m", WithUnit("bytes"))
+				})
+				cc.AbortCycle()
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// TestInstallDescriptorAfterRetention pins that committed descriptors are installed
+// only for series that SURVIVE retention: a series evicted in the same cycle it is
+// first observed must not leave an orphan descriptor behind.
+func TestInstallDescriptorAfterRetention(t *testing.T) {
+	s := NewCollectorStore()
+	sv := collectorStoreViewForTest(t, s)
+	sv.core.retention = collectorRetentionPolicy{maxSeries: 1}
+	cc := cycleController(t, s)
+
+	cc.BeginCycle()
+	s.Write().SnapshotMeter("svc").Gauge("a").Observe(1)
+	s.Write().SnapshotMeter("svc").Gauge("b").Observe(2)
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	series := sv.core.snapshot.Load().series
+	require.Len(t, series, 1, "maxSeries=1 must evict one of the two new series")
+	require.Len(t, sv.core.instruments, 1, "an evicted series must not leave an orphan descriptor")
+	for _, srv := range series {
+		_, ok := sv.core.instruments[srv.name]
+		require.True(t, ok, "the surviving series must have its descriptor installed")
+	}
+}
+
+// TestCommitCostGuards pins the commit-cost envelope for the canonicalization work:
+// repeated same-handle writes must not accumulate per-write descriptor evidence, and a
+// sparse commit over a large retained name must not clone every retained series.
+func TestCommitCostGuards(t *testing.T) {
+	t.Run("repeated same-handle histogram writes do not grow conflict evidence", func(t *testing.T) {
+		s := NewCollectorStore()
+		sv := collectorStoreViewForTest(t, s)
+		cc := cycleController(t, s)
+		cc.BeginCycle()
+		// Stateful: 1000 Observe on one handle.
+		hs := s.Write().StatefulMeter("svc").Histogram("hs", WithHistogramBounds(1, 2))
+		for i := 0; i < 1000; i++ {
+			hs.Observe(1)
+		}
+		// Snapshot: 1000 ObservePoint with the same bounds on one handle.
+		hp := s.Write().SnapshotMeter("svc").Histogram("hp")
+		pt := HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 1, CumulativeCount: 1}, {UpperBound: 2, CumulativeCount: 1}}}
+		for i := 0; i < 1000; i++ {
+			hp.ObservePoint(pt)
+		}
+		require.Empty(t, sv.core.active.conflicts, "same-handle repeats must not append descriptor evidence")
+		require.NoError(t, cc.CommitCycleSuccess())
+	})
+
+	t.Run("sparse commit over a large retained name is O(touched) allocations", func(t *testing.T) {
+		const retained = 2000
+		s := NewCollectorStore()
+		cc := cycleController(t, s)
+		labels := make([]string, retained)
+		for i := range labels {
+			labels[i] = strconv.Itoa(i)
+		}
+
+		cc.BeginCycle()
+		for i := 0; i < retained; i++ {
+			s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: labels[i]}).Gauge("m").Observe(SampleValue(i))
+		}
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		// A cycle touching only 5 of the retained series must not clone all of them.
+		allocs := testing.AllocsPerRun(2, func() {
+			cc.BeginCycle()
+			for i := 0; i < 5; i++ {
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: labels[i]}).Gauge("m").Observe(SampleValue(i))
+			}
+			_ = cc.CommitCycleSuccess()
+		})
+		require.Lessf(t, allocs, float64(retained/4), "sparse commit allocs must be O(touched), not O(retained) (got %.0f allocs)", allocs)
+	})
+}
+
+// TestMultiAuthorityCommittedObserved pins the multi-authority fail-vs-drop decision: the resolver
+// keeps EVERY distinct observed authority (fingerprint-indexed, no cap) and tracks committed-observed
+// over all of them, so an established authority actively written alongside incompatible ones FAILs
+// loud (never a silent gap on an established series), while an ambiguous NEW name with no committed
+// authority DROPs - regardless of how many authorities are observed or in what order.
+func TestMultiAuthorityCommittedObserved(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"committed histogram observed alongside two incompatible kinds fails, not drops": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Cycle 1: establish svc.m as a stateful histogram.
+				cc.BeginCycle()
+				s.Write().StatefulMeter("svc").Histogram("m", WithHistogramBounds(1, 2)).Observe(0.5)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: svc.m is observed as a gauge, a counter, AND the established histogram
+				// (matching bounds). The committed authority IS actively observed among the three ->
+				// fail loud (never a silent gap on an established series).
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				s.Write().SnapshotMeter("svc").Counter("m").ObserveTotal(2)
+				s.Write().StatefulMeter("svc").Histogram("m", WithHistogramBounds(1, 2)).Observe(0.7)
+				err := cc.CommitCycleSuccess()
+				require.Error(t, err)
+				require.ErrorContains(t, err, "conflicting instrument kinds")
+			},
+		},
+		"ambiguous multi-kind on a new name drops (no committed authority)": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Three incompatible kinds for a NEW name, none committed: still ambiguous ->
+				// drop this name (the resolver must not turn drop into fail when nothing is
+				// established). An unrelated metric must still commit.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				s.Write().SnapshotMeter("svc").Counter("m").ObserveTotal(2)
+				s.Write().StatefulMeter("svc").Histogram("m", WithHistogramBounds(1, 2)).Observe(0.7)
+				s.Write().SnapshotMeter("svc").Gauge("ok").Observe(9)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read()
+				_, ok := r.Value("svc.m", nil)
+				require.False(t, ok, "ambiguous new name must be dropped")
+				mustValue(t, r, "svc.ok", nil, 9)
+			},
+		},
+		"a declaration conflict on a third authority fails deterministically across map orders": {
+			run: func(t *testing.T) {
+				// Same name, three authorities via STALE handles (aborted cycles bypass
+				// registration's declaration check): a bytes gauge, a stateful (additive) gauge, and
+				// a seconds gauge, each on a distinct label. The resolver keeps every distinct
+				// authority (no cap), so the bytes-vs-seconds declaration conflict is caught
+				// regardless of map-iteration order -> FAIL every time, never an order-dependent DROP.
+				// Repeat to exercise staged-map order.
+				for i := 0; i < 64; i++ {
+					s := NewCollectorStore()
+					cc := cycleController(t, s)
+
+					cc.BeginCycle()
+					hBytes := s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Gauge("m", WithUnit("bytes"))
+					cc.AbortCycle()
+					cc.BeginCycle()
+					hStateful := s.Write().StatefulMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Gauge("m")
+					cc.AbortCycle()
+					cc.BeginCycle()
+					hSeconds := s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "c"}).Gauge("m", WithUnit("seconds"))
+					cc.AbortCycle()
+
+					cc.BeginCycle()
+					hBytes.Observe(1)
+					hStateful.Add(2)
+					hSeconds.Observe(3)
+					err := cc.CommitCycleSuccess()
+					require.Errorf(t, err, "iteration %d", i)
+					require.ErrorContainsf(t, err, "unit mismatch", "iteration %d", i)
+				}
+			},
+		},
+		"committed declaration conflict is caught even when the name is multi-authority": {
+			run: func(t *testing.T) {
+				pt := func(uppers ...float64) HistogramPoint {
+					b := make([]BucketPoint, len(uppers))
+					for i, ub := range uppers {
+						b[i] = BucketPoint{UpperBound: ub, CumulativeCount: 1}
+					}
+					return HistogramPoint{Count: 1, Sum: 1, Buckets: b}
+				}
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				// A stale unit=seconds histogram handle from an aborted cycle (created before any
+				// committed authority, so its registration is not rejected).
+				cc.BeginCycle()
+				stale := s.Write().SnapshotMeter("svc").Histogram("m", WithUnit("seconds"))
+				cc.AbortCycle()
+				// Init-register a committed nil-bounds histogram with unit=bytes (never observed -> a
+				// wildcard committed authority, so realCommittedAuthority returns nil).
+				_ = s.Write().SnapshotMeter("svc").Histogram("m", WithUnit("bytes"))
+
+				// The stale handle observes two different bounds (multi-authority). The committed
+				// bytes vs observed seconds is a declaration conflict that must FAIL loud even though
+				// the multi-authority name would otherwise DROP.
+				cc.BeginCycle()
+				stale.ObservePoint(pt(1, 2))
+				stale.ObservePoint(pt(5, 6))
+				err := cc.CommitCycleSuccess()
+				require.Error(t, err)
+				require.ErrorContains(t, err, "unit mismatch")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}

--- a/src/go/pkg/metrix/descriptor_compat_test.go
+++ b/src/go/pkg/metrix/descriptor_compat_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestDescriptor builds an instrumentDescriptor directly (bypassing registration)
+// so the compatibility helpers can be exercised with same-name incompatible pairs
+// that registration itself would never produce.
+func newTestDescriptor(name string, kind metricKind, mode metricMode, mutate ...func(*instrumentDescriptor)) *instrumentDescriptor {
+	d := &instrumentDescriptor{
+		name:      name,
+		kind:      kind,
+		mode:      mode,
+		freshness: defaultFreshness(mode),
+	}
+	for _, m := range mutate {
+		m(d)
+	}
+	return d
+}
+
+// descWithMeta builds a scalar descriptor carrying family metadata and the
+// option-set bits that record which of those fields were explicitly declared.
+func descWithMeta(meta MetricMeta, set metricMetaSet) *instrumentDescriptor {
+	return &instrumentDescriptor{name: "m", kind: kindGauge, mode: modeSnapshot, meta: meta, metaSet: set}
+}
+
+// TestDescriptorSeriesAuthorityCompat pins the series-identity contract: two
+// descriptors for the same name may back the same series only when their kind,
+// mode, freshness, window, and type schema agree. Each case isolates one
+// dimension so the first-mismatch error is deterministic.
+func TestDescriptorSeriesAuthorityCompat(t *testing.T) {
+	tests := map[string]struct {
+		existing *instrumentDescriptor
+		incoming *instrumentDescriptor
+		wantErr  string // "" = compatible; otherwise required error substring
+	}{
+		"identical snapshot gauge is compatible": {
+			existing: newTestDescriptor("m", kindGauge, modeSnapshot),
+			incoming: newTestDescriptor("m", kindGauge, modeSnapshot),
+		},
+		"kind mismatch": {
+			existing: newTestDescriptor("m", kindGauge, modeSnapshot),
+			incoming: newTestDescriptor("m", kindCounter, modeSnapshot),
+			wantErr:  "instrument kind mismatch for m",
+		},
+		"mode mismatch": {
+			existing: newTestDescriptor("m", kindGauge, modeSnapshot),
+			incoming: newTestDescriptor("m", kindGauge, modeStateful),
+			wantErr:  "instrument mode mismatch for m",
+		},
+		"freshness mismatch (kind+mode equal)": {
+			existing: newTestDescriptor("m", kindCounter, modeStateful, func(d *instrumentDescriptor) { d.freshness = FreshnessCommitted }),
+			incoming: newTestDescriptor("m", kindCounter, modeStateful, func(d *instrumentDescriptor) { d.freshness = FreshnessCycle }),
+			wantErr:  "instrument freshness mismatch for m",
+		},
+		"window mismatch (kind+mode+freshness equal)": {
+			existing: newTestDescriptor("m", kindCounter, modeStateful, func(d *instrumentDescriptor) { d.freshness = FreshnessCommitted; d.window = WindowCumulative }),
+			incoming: newTestDescriptor("m", kindCounter, modeStateful, func(d *instrumentDescriptor) { d.freshness = FreshnessCommitted; d.window = WindowCycle }),
+			wantErr:  "instrument window mismatch for m",
+		},
+		"histogram bounds mismatch": {
+			existing: newTestDescriptor("m", kindHistogram, modeSnapshot, func(d *instrumentDescriptor) { d.histogram = &histogramSchema{bounds: []float64{1, 2}} }),
+			incoming: newTestDescriptor("m", kindHistogram, modeSnapshot, func(d *instrumentDescriptor) { d.histogram = &histogramSchema{bounds: []float64{1, 3}} }),
+			wantErr:  "histogram schema mismatch for m",
+		},
+		"histogram nil-bounds snapshot is a wildcard (adopts existing)": {
+			existing: newTestDescriptor("m", kindHistogram, modeSnapshot, func(d *instrumentDescriptor) { d.histogram = &histogramSchema{bounds: []float64{1, 2}} }),
+			incoming: newTestDescriptor("m", kindHistogram, modeSnapshot, func(d *instrumentDescriptor) { d.histogram = nil }),
+		},
+		"histogram non-nil incoming against nil-bounds existing is a mismatch (wildcard is only for nil incoming)": {
+			// incoming carries explicit bounds; existing has nil -> equalHistogramSchema(nil, x) is false,
+			// and the wildcard only fires for a nil INCOMING, so this must be a mismatch.
+			existing: newTestDescriptor("m", kindHistogram, modeSnapshot, func(d *instrumentDescriptor) { d.histogram = nil }),
+			incoming: newTestDescriptor("m", kindHistogram, modeSnapshot, func(d *instrumentDescriptor) { d.histogram = &histogramSchema{bounds: []float64{1, 2}} }),
+			wantErr:  "histogram schema mismatch for m",
+		},
+		"summary quantiles mismatch": {
+			existing: newTestDescriptor("m", kindSummary, modeStateful, func(d *instrumentDescriptor) {
+				d.freshness = FreshnessCommitted
+				d.summary = &summarySchema{quantiles: []float64{0.5}}
+			}),
+			incoming: newTestDescriptor("m", kindSummary, modeStateful, func(d *instrumentDescriptor) {
+				d.freshness = FreshnessCommitted
+				d.summary = &summarySchema{quantiles: []float64{0.9}}
+			}),
+			wantErr: "summary schema mismatch for m",
+		},
+		"stateset states mismatch": {
+			existing: newTestDescriptor("m", kindStateSet, modeSnapshot, func(d *instrumentDescriptor) { d.stateSet = &stateSetSchema{states: []string{"a"}} }),
+			incoming: newTestDescriptor("m", kindStateSet, modeSnapshot, func(d *instrumentDescriptor) { d.stateSet = &stateSetSchema{states: []string{"b"}} }),
+			wantErr:  "stateset schema mismatch for m",
+		},
+		"measureset fields mismatch": {
+			existing: newTestDescriptor("m", kindMeasureSet, modeSnapshot, func(d *instrumentDescriptor) {
+				d.measureSet = &measureSetSchema{fields: []MeasureFieldSpec{{Name: "a"}}}
+			}),
+			incoming: newTestDescriptor("m", kindMeasureSet, modeSnapshot, func(d *instrumentDescriptor) {
+				d.measureSet = &measureSetSchema{fields: []MeasureFieldSpec{{Name: "b"}}}
+			}),
+			wantErr: "measureset schema mismatch for m",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := descriptorSeriesAuthorityCompat(tc.existing, tc.incoming)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			// Exact match: step 1 must preserve the full registration error strings verbatim.
+			require.EqualError(t, err, "metrix: "+tc.wantErr)
+		})
+	}
+}
+
+// TestDescriptorDeclarationCompat pins the metadata contract: a field conflicts
+// only when the incoming registration EXPLICITLY set it to a value differing
+// from the first (preserve-first). Fields the incoming did not set are ignored,
+// even if their values differ.
+func TestDescriptorDeclarationCompat(t *testing.T) {
+	base := MetricMeta{Description: "A", ChartFamily: "F", ChartPriority: 100, Unit: "u", Float: true}
+	allSet := metricMetaSet{description: true, chartFamily: true, chartPriority: true, unit: true, float: true}
+
+	tests := map[string]struct {
+		existing *instrumentDescriptor
+		incoming *instrumentDescriptor
+		wantErr  string
+	}{
+		"incoming sets nothing keeps existing (preserve-first)": {
+			existing: descWithMeta(base, metricMetaSet{}),
+			incoming: descWithMeta(MetricMeta{Description: "different", ChartFamily: "other", ChartPriority: 999, Unit: "x", Float: false}, metricMetaSet{}),
+		},
+		"incoming re-declares identical values": {
+			existing: descWithMeta(base, allSet),
+			incoming: descWithMeta(base, allSet),
+		},
+		"description conflict": {
+			existing: descWithMeta(base, metricMetaSet{}),
+			incoming: descWithMeta(MetricMeta{Description: "B"}, metricMetaSet{description: true}),
+			wantErr:  "metric description mismatch for m",
+		},
+		"description differs but unset is ignored": {
+			existing: descWithMeta(base, metricMetaSet{}),
+			incoming: descWithMeta(MetricMeta{Description: "B"}, metricMetaSet{}),
+		},
+		"chart family conflict": {
+			existing: descWithMeta(base, metricMetaSet{}),
+			incoming: descWithMeta(MetricMeta{ChartFamily: "G"}, metricMetaSet{chartFamily: true}),
+			wantErr:  "metric chart family mismatch for m",
+		},
+		"chart priority conflict": {
+			existing: descWithMeta(base, metricMetaSet{}),
+			incoming: descWithMeta(MetricMeta{ChartPriority: 200}, metricMetaSet{chartPriority: true}),
+			wantErr:  "metric chart priority mismatch for m",
+		},
+		"unit conflict": {
+			existing: descWithMeta(base, metricMetaSet{}),
+			incoming: descWithMeta(MetricMeta{Unit: "v"}, metricMetaSet{unit: true}),
+			wantErr:  "metric unit mismatch for m",
+		},
+		"float conflict": {
+			existing: descWithMeta(base, metricMetaSet{}),
+			incoming: descWithMeta(MetricMeta{Float: false}, metricMetaSet{float: true}),
+			wantErr:  "metric float mismatch for m",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := descriptorDeclarationCompat(tc.existing, tc.incoming)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			// Exact match: step 1 must preserve the full registration error strings verbatim.
+			require.EqualError(t, err, "metrix: "+tc.wantErr)
+		})
+	}
+}

--- a/src/go/pkg/metrix/descriptor_conflict_store_test.go
+++ b/src/go/pkg/metrix/descriptor_conflict_store_test.go
@@ -163,7 +163,7 @@ func TestDescriptorConflictResolution(t *testing.T) {
 				pt := HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 1, CumulativeCount: 1}, {UpperBound: 2, CumulativeCount: 1}}}
 				// Repeat: staged-map iteration order is nondeterministic, so a directional
 				// wildcard would sometimes wrongly split these into two authorities and drop them.
-				for i := 0; i < 64; i++ {
+				for i := range 64 {
 					s := NewCollectorStore()
 					cc := cycleController(t, s)
 					cc.BeginCycle()
@@ -284,7 +284,7 @@ func TestSameKeyEvidenceRetainsDistinctDescriptors(t *testing.T) {
 				// no-clone identity check (evidence stays O(1)).
 				h := s.Write().SnapshotMeter("svc").Histogram("h")
 				h.ObservePoint(HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 1, CumulativeCount: 1}, {UpperBound: 2, CumulativeCount: 1}}})
-				for i := 0; i < 1000; i++ {
+				for range 1000 {
 					h.ObservePoint(HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 5, CumulativeCount: 1}, {UpperBound: 6, CumulativeCount: 1}}})
 				}
 				require.Len(t, sv.core.active.conflicts, 1, "a repeated same-authority conflict must record once")
@@ -305,7 +305,7 @@ func TestSameKeyEvidenceRetainsDistinctDescriptors(t *testing.T) {
 				// and the rest dedup -> evidence stays O(1), not O(handles).
 				entry := stale(t, s, cc, WithUnit("bytes"))
 				var dups []SnapshotGauge
-				for i := 0; i < 8; i++ {
+				for range 8 {
 					dups = append(dups, stale(t, s, cc, WithUnit("seconds")))
 				}
 				cc.BeginCycle()

--- a/src/go/pkg/metrix/descriptor_conflict_store_test.go
+++ b/src/go/pkg/metrix/descriptor_conflict_store_test.go
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDescriptorConflictResolution pins the commit-time state model (step 2b-1):
+//   - an incompatible registration during a cycle no longer panics; it is deferred.
+//   - two incompatible kinds OBSERVED for one name in the same cycle is an
+//     unresolvable conflict that fails the whole commit (nothing published).
+//   - a committed kind that is NOT observed this cycle is superseded by the newly
+//     observed kind, and the old kind's carried-forward series are removed by name.
+func TestDescriptorConflictResolution(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"incompatible in-cycle registration is deferred, not panicked": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				_ = s.Write().SnapshotMeter("svc").Gauge("m")
+				require.NotPanics(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Counter("m")
+				})
+				// Neither kind was observed, so there is nothing to reconcile.
+				require.NoError(t, cc.CommitCycleSuccess())
+			},
+		},
+		"ambiguous multi-kind on a new name is dropped, not failed (other metrics still commit)": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				// svc.m is written as two incompatible kinds with no established authority.
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				s.Write().SnapshotMeter("svc").Counter("m").ObserveTotal(2)
+				// An unrelated metric in the same cycle must still commit.
+				s.Write().SnapshotMeter("svc").Gauge("ok").Observe(9)
+
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read()
+				_, ok := r.Value("svc.m", nil)
+				require.False(t, ok, "ambiguous multi-kind name must be dropped for the cycle")
+				mustValue(t, r, "svc.ok", nil, 9)
+			},
+		},
+		"conflict with an established committed kind fails the commit": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Cycle 1: establish svc.m as a gauge.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: the established gauge is actively observed AND a conflicting
+				// counter is observed for the same name -> unresolvable, fail the cycle.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(2)
+				s.Write().SnapshotMeter("svc").Counter("m").ObserveTotal(3)
+				err := cc.CommitCycleSuccess()
+				require.Error(t, err)
+				require.ErrorContains(t, err, "conflicting instrument kinds")
+
+				// Transactional: the failed cycle did not mutate the committed gauge, so
+				// declaring svc.m as a counter (outside a cycle) still conflicts.
+				expectPanic(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Counter("m")
+				})
+			},
+		},
+		"unobserved committed kind is superseded by a newly observed kind": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Cycle 1: svc.m is a gauge.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: svc.m is written only as a counter (the gauge is not observed).
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Counter("m").ObserveTotal(5)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// svc.m is now a counter; re-declaring it as a gauge conflicts.
+				mustValue(t, s.Read(), "svc.m", nil, 5)
+				expectPanic(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Gauge("m")
+				})
+			},
+		},
+		"supersede removes the old kind's carried-forward series by name": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Cycle 1: gauge svc.m{id=old}.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "old"}).Gauge("m").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+				mustValue(t, s.Read(), "svc.m", Labels{"id": "old"}, 1)
+
+				// Cycle 2: counter svc.m{id=new} only -> supersede removes ALL svc.m series.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "new"}).Counter("m").ObserveTotal(5)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				r := s.Read()
+				mustValue(t, r, "svc.m", Labels{"id": "new"}, 5)
+				_, ok := r.Value("svc.m", Labels{"id": "old"})
+				require.False(t, ok, "old gauge series must be removed when the name is superseded")
+			},
+		},
+		"an unobserved in-cycle registration does not overwrite the committed registry": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				// Observe a gauge, and separately DECLARE (never observe) a conflicting counter.
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				_ = s.Write().SnapshotMeter("svc").Counter("m")
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Only the observed gauge is committed; the unobserved counter registration
+				// must NOT be installed. Declaring a counter (outside a cycle) still conflicts.
+				expectPanic(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Counter("m")
+				})
+			},
+		},
+		"same-key summary with a different schema is caught, not silently kept": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				// Two summary handles for the SAME name+labels but different quantile schemas,
+				// both observed. The second write must not silently apply under the first schema.
+				s.Write().SnapshotMeter("svc").Summary("lat", WithSummaryQuantiles(0.5)).
+					ObservePoint(SummaryPoint{Count: 1, Sum: 1, Quantiles: []QuantilePoint{{Quantile: 0.5, Value: 1}}})
+				s.Write().SnapshotMeter("svc").Summary("lat", WithSummaryQuantiles(0.9)).
+					ObservePoint(SummaryPoint{Count: 1, Sum: 1, Quantiles: []QuantilePoint{{Quantile: 0.9, Value: 1}}})
+				// An unrelated metric must still commit.
+				s.Write().SnapshotMeter("svc").Gauge("ok").Observe(9)
+
+				require.NoError(t, cc.CommitCycleSuccess())
+				r := s.Read()
+				_, ok := r.Value("svc.lat", nil)
+				require.False(t, ok, "conflicting-schema summary must be dropped, not silently committed")
+				mustValue(t, r, "svc.ok", nil, 9)
+			},
+		},
+		"histogram nil-bounds vs explicit-bounds grouping is order-independent": {
+			run: func(t *testing.T) {
+				pt := HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 1, CumulativeCount: 1}, {UpperBound: 2, CumulativeCount: 1}}}
+				// Repeat: staged-map iteration order is nondeterministic, so a directional
+				// wildcard would sometimes wrongly split these into two authorities and drop them.
+				for i := 0; i < 64; i++ {
+					s := NewCollectorStore()
+					cc := cycleController(t, s)
+					cc.BeginCycle()
+					// Same name, different labels: one nil-bounds snapshot histogram, one explicit.
+					s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "a"}).Histogram("h").ObservePoint(pt)
+					s.Write().SnapshotMeter("svc").WithLabels(Label{Key: "id", Value: "b"}).Histogram("h", WithHistogramBounds(1, 2)).ObservePoint(pt)
+					require.NoError(t, cc.CommitCycleSuccess())
+
+					r := s.Read(ReadFlatten())
+					_, okA := r.Value("svc.h_count", Labels{"id": "a"})
+					_, okB := r.Value("svc.h_count", Labels{"id": "b"})
+					require.Truef(t, okA && okB, "both histograms must commit regardless of iteration order (i=%d)", i)
+				}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}
+
+// TestSameKeyEvidenceRetainsDistinctDescriptors pins that same-key reconciliation records EVERY
+// distinct authority/declaration, not just the first differing one. The staged entry carries the
+// running-canonical merge of compatible writes; an incompatible one is recorded as conflict
+// evidence, deduped by FULL descriptor identity (authority fingerprint + declaration fingerprint)
+// within its bucket. A distinct descriptor on one key must not be lost, or a real conflict would be
+// silently published under the first authority's metadata.
+func TestSameKeyEvidenceRetainsDistinctDescriptors(t *testing.T) {
+	// stale builds a cached handle for svc.m in its own aborted cycle, so reusing it later
+	// bypasses registration's conflict check and exercises the commit-time resolver directly.
+	stale := func(t *testing.T, s CollectorStore, cc CycleController, opts ...InstrumentOption) SnapshotGauge {
+		t.Helper()
+		cc.BeginCycle()
+		h := s.Write().SnapshotMeter("svc").Gauge("m", opts...)
+		cc.AbortCycle()
+		return h
+	}
+
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"a third same-key declaration conflict is not lost to dedup": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				hUnset := stale(t, s, cc)
+				hBytes := stale(t, s, cc, WithUnit("bytes"))
+				hSeconds := stale(t, s, cc, WithUnit("seconds"))
+
+				// unset merges, bytes merges into the canonical, seconds conflicts. The seconds
+				// declaration must reach the resolver -> unit conflict -> fail the cycle.
+				cc.BeginCycle()
+				hUnset.Observe(1)
+				hBytes.Observe(2)
+				hSeconds.Observe(3)
+				err := cc.CommitCycleSuccess()
+				require.Error(t, err)
+				require.ErrorContains(t, err, "unit mismatch")
+
+				// Transactional: nothing published for the new name.
+				_, ok := s.Read().Value("svc.m", nil)
+				require.False(t, ok, "a same-key conflict must not publish a value under the first authority")
+			},
+		},
+		"three complementary same-key declarations all survive the merge": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				hUnset := stale(t, s, cc)
+				hBytes := stale(t, s, cc, WithUnit("bytes"))
+				hDesc := stale(t, s, cc, WithDescription("d"))
+
+				// All three are compatible; the running canonical must union every field, not
+				// keep only the first differing one (which dedup-by-key would have dropped).
+				cc.BeginCycle()
+				hUnset.Observe(1)
+				hBytes.Observe(2)
+				hDesc.Observe(3)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				meta, ok := s.Read().MetricMeta("svc.m")
+				require.True(t, ok)
+				require.Equal(t, "bytes", meta.Unit)
+				require.Equal(t, "d", meta.Description)
+			},
+		},
+		"a later same-key mode conflict is not hidden by dedup": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				hUnset := stale(t, s, cc)
+				hBytes := stale(t, s, cc, WithUnit("bytes"))
+				// A stateful (additive) gauge handle on the SAME key: an incompatible mode.
+				cc.BeginCycle()
+				hStateful := s.Write().StatefulMeter("svc").Gauge("m")
+				cc.AbortCycle()
+
+				cc.BeginCycle()
+				hUnset.Observe(1)
+				hBytes.Observe(2)
+				hStateful.Add(5)
+				// Two incompatible modes, no established authority -> ambiguous -> drop the name.
+				require.NoError(t, cc.CommitCycleSuccess())
+				_, ok := s.Read().Value("svc.m", nil)
+				require.False(t, ok, "a mode conflict must drop the name, not publish under one mode")
+			},
+		},
+		"a repeated same-authority histogram conflict records once": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				// One nil-bounds snapshot histogram handle: entry bounds [1,2], then the SAME
+				// conflicting bounds [5,6] flooded 1000 times. All 1000 share one authority
+				// (fingerprint), so the conflict is recorded once and later repeats are dropped by a
+				// no-clone identity check (evidence stays O(1)).
+				h := s.Write().SnapshotMeter("svc").Histogram("h")
+				h.ObservePoint(HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 1, CumulativeCount: 1}, {UpperBound: 2, CumulativeCount: 1}}})
+				for i := 0; i < 1000; i++ {
+					h.ObservePoint(HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: 5, CumulativeCount: 1}, {UpperBound: 6, CumulativeCount: 1}}})
+				}
+				require.Len(t, sv.core.active.conflicts, 1, "a repeated same-authority conflict must record once")
+				// The name is unresolvable (two effective schemas) -> dropped, cycle commits.
+				require.NoError(t, cc.CommitCycleSuccess())
+				_, ok := s.Read(ReadFlatten()).Value("svc.h_count", nil)
+				require.False(t, ok)
+			},
+		},
+		"many distinct same-key handles sharing an authority record one conflict": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				cc := cycleController(t, s)
+				// Distinct stale handles (each from its own aborted cycle) for one key: a unit=bytes
+				// gauge entry plus several unit=seconds gauges (all the gauge authority, conflicting
+				// declaration). All conflicts share one authority fingerprint, so the first records
+				// and the rest dedup -> evidence stays O(1), not O(handles).
+				entry := stale(t, s, cc, WithUnit("bytes"))
+				var dups []SnapshotGauge
+				for i := 0; i < 8; i++ {
+					dups = append(dups, stale(t, s, cc, WithUnit("seconds")))
+				}
+				cc.BeginCycle()
+				entry.Observe(1)
+				for _, h := range dups {
+					h.Observe(2)
+				}
+				require.Len(t, sv.core.active.conflicts, 1, "distinct handles sharing an authority must record one conflict")
+				err := cc.CommitCycleSuccess()
+				require.Error(t, err)
+				require.ErrorContains(t, err, "unit mismatch")
+			},
+		},
+		"histogram: committed bounds observed as a same-key conflict still fails loud": {
+			run: func(t *testing.T) {
+				histPoint := func(uppers ...float64) HistogramPoint {
+					b := make([]BucketPoint, len(uppers))
+					for i, ub := range uppers {
+						b[i] = BucketPoint{UpperBound: ub, CumulativeCount: 1}
+					}
+					return HistogramPoint{Count: 1, Sum: 1, Buckets: b}
+				}
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				// Cycle 1: establish svc.h with bounds [7,8].
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Histogram("h").ObservePoint(histPoint(7, 8))
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: one handle observes [1,2] (entry), [5,6] (a distinct authority -> conflict),
+				// then the committed [7,8] (another distinct authority -> its own conflict). Because
+				// each distinct authority is recorded (not collapsed), the committed-matching [7,8]
+				// reaches the resolver, so the cycle FAILs loud rather than silently DROPping.
+				cc.BeginCycle()
+				h := s.Write().SnapshotMeter("svc").Histogram("h")
+				h.ObservePoint(histPoint(1, 2))
+				h.ObservePoint(histPoint(5, 6))
+				h.ObservePoint(histPoint(7, 8))
+				err := cc.CommitCycleSuccess()
+				require.Error(t, err)
+				require.ErrorContains(t, err, "conflicting instrument kinds")
+			},
+		},
+		"declaration conflict within a conflict authority fails deterministically across orders": {
+			run: func(t *testing.T) {
+				// Same key via stale handles (bypass registration): a snapshot gauge, plus two
+				// STATEFUL gauges sharing the stateful-gauge authority but declaring conflicting
+				// units (bytes vs seconds). Whichever authority becomes the staged entry, the
+				// bytes-vs-seconds declaration conflict WITHIN the stateful authority must be recorded
+				// and caught -> FAIL every time, not an order-dependent DROP.
+				writes := []func(snap SnapshotGauge, b, sc StatefulGauge){
+					func(snap SnapshotGauge, b, sc StatefulGauge) { snap.Observe(1); b.Add(2); sc.Add(3) },
+					func(snap SnapshotGauge, b, sc StatefulGauge) { b.Add(2); snap.Observe(1); sc.Add(3) },
+					func(snap SnapshotGauge, b, sc StatefulGauge) { sc.Add(3); b.Add(2); snap.Observe(1) },
+				}
+				for i, w := range writes {
+					s := NewCollectorStore()
+					cc := cycleController(t, s)
+					cc.BeginCycle()
+					snap := s.Write().SnapshotMeter("svc").Gauge("m")
+					cc.AbortCycle()
+					cc.BeginCycle()
+					b := s.Write().StatefulMeter("svc").Gauge("m", WithUnit("bytes"))
+					cc.AbortCycle()
+					cc.BeginCycle()
+					sc := s.Write().StatefulMeter("svc").Gauge("m", WithUnit("seconds"))
+					cc.AbortCycle()
+
+					cc.BeginCycle()
+					w(snap, b, sc)
+					err := cc.CommitCycleSuccess()
+					require.Errorf(t, err, "order %d", i)
+					require.ErrorContainsf(t, err, "unit mismatch", "order %d", i)
+				}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}

--- a/src/go/pkg/metrix/descriptor_retention_accessor_test.go
+++ b/src/go/pkg/metrix/descriptor_retention_accessor_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDescriptorRetentionAccessor pins the optional-interface contract a descriptor-caching
+// consumer (the prometheus writer) uses to keep its per-name state alive at least as long as
+// metrix keeps the descriptor: the window is expire+grace, the clock advances only on
+// successful commits, and both the view and the managed store expose it.
+func TestDescriptorRetentionAccessor(t *testing.T) {
+	t.Run("window is expire+grace", func(t *testing.T) {
+		s := NewCollectorStore(WithExpireAfterSuccessCycles(4), WithDescriptorGraceCycles(6))
+		dr, ok := s.(DescriptorRetention)
+		require.True(t, ok, "collector store must expose DescriptorRetention")
+		require.Equal(t, uint64(10), dr.DescriptorRetentionWindow())
+		require.Equal(t, uint64(0), dr.SuccessfulCommits())
+	})
+
+	t.Run("default window couples grace to the default expire", func(t *testing.T) {
+		s := NewCollectorStore() // expire=10, grace defaults to expire=10
+		require.Equal(t, uint64(20), s.(DescriptorRetention).DescriptorRetentionWindow())
+	})
+
+	t.Run("disabled series expiry reports an unbounded window", func(t *testing.T) {
+		s := NewCollectorStore(WithExpireAfterSuccessCycles(0))
+		require.Equal(t, DescriptorRetentionUnbounded, s.(DescriptorRetention).DescriptorRetentionWindow())
+	})
+
+	t.Run("disabled series expiry is unbounded even with an explicit grace", func(t *testing.T) {
+		s := NewCollectorStore(WithExpireAfterSuccessCycles(0), WithDescriptorGraceCycles(5))
+		require.Equal(t, DescriptorRetentionUnbounded, s.(DescriptorRetention).DescriptorRetentionWindow())
+	})
+
+	t.Run("an overflowing expire+grace saturates to unbounded", func(t *testing.T) {
+		s := NewCollectorStore(WithExpireAfterSuccessCycles(10), WithDescriptorGraceCycles(math.MaxUint64-5))
+		require.Equal(t, DescriptorRetentionUnbounded, s.(DescriptorRetention).DescriptorRetentionWindow())
+	})
+
+	t.Run("the clock advances only on successful commits", func(t *testing.T) {
+		s := NewCollectorStore()
+		cc := cycleController(t, s)
+
+		cc.BeginCycle()
+		require.NoError(t, cc.CommitCycleSuccess())
+		cc.BeginCycle()
+		require.NoError(t, cc.CommitCycleSuccess())
+		cc.BeginCycle()
+		cc.AbortCycle() // an aborted cycle must not advance the clock
+
+		require.Equal(t, uint64(2), s.(DescriptorRetention).SuccessfulCommits())
+	})
+
+	t.Run("the managed store also exposes it", func(t *testing.T) {
+		s := NewCollectorStore()
+		m, ok := AsCycleManagedStore(s)
+		require.True(t, ok)
+		_, ok = m.(DescriptorRetention)
+		require.True(t, ok, "the managed store must also expose DescriptorRetention")
+	})
+}

--- a/src/go/pkg/metrix/descriptor_universe_sweep_store_test.go
+++ b/src/go/pkg/metrix/descriptor_universe_sweep_store_test.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDescriptorUniverseSweep pins the bounded-growth contract: a descriptor is kept
+// while its name has a live series and for descriptorGraceCycles successful commits
+// after its last series is evicted, then swept from instruments. A continuously
+// observed name is never swept; a swept name re-establishes when observed again.
+func TestDescriptorUniverseSweep(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"last-series eviction sweeps the descriptor after grace, keeps it during grace": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				sv.core.retention = collectorRetentionPolicy{expireAfterSuccessCycles: 1, descriptorGraceCycles: 2}
+				cc := cycleController(t, s)
+
+				// Cycle 1 (successSeq=1): observe -> live.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("g").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.g", true)
+
+				// Cycle 2 (successSeq=2): not observed -> series expires (expire=1); descriptor
+				// goes idle at 2 and is kept (grace not elapsed).
+				cc.BeginCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.g", true)
+				_, ok := s.Read(ReadRaw()).Value("svc.g", nil)
+				require.False(t, ok, "the series must be evicted by retention")
+
+				// Cycle 3 (successSeq=3): 3-2=1 < grace(2) -> still kept.
+				cc.BeginCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.g", true)
+
+				// Cycle 4 (successSeq=4): 4-2=2 >= grace(2) -> swept.
+				cc.BeginCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.g", false)
+				require.Equal(t, uint64(1), s.Read().CollectMeta().EvictedDescriptors)
+			},
+		},
+		"a continuously observed name is never swept": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				sv.core.retention = collectorRetentionPolicy{expireAfterSuccessCycles: 1, descriptorGraceCycles: 1}
+				cc := cycleController(t, s)
+
+				for i := 0; i < 10; i++ {
+					cc.BeginCycle()
+					s.Write().SnapshotMeter("svc").Gauge("g").Observe(SampleValue(i))
+					require.NoError(t, cc.CommitCycleSuccess())
+				}
+				requireInstrument(t, sv, "svc.g", true)
+				require.Equal(t, uint64(0), s.Read().CollectMeta().EvictedDescriptors)
+			},
+		},
+		"a registered-but-never-published descriptor is swept after grace": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore(WithExpireAfterSuccessCycles(1), WithDescriptorGraceCycles(2))
+				sv := collectorStoreViewForTest(t, s)
+
+				// Declared outside a cycle -> Init-time eager install, never observed.
+				s.Write().SnapshotMeter("svc").Gauge("x")
+				requireInstrument(t, sv, "svc.x", true)
+
+				cc := cycleController(t, s)
+				// Cycle 1 (successSeq=1): idle at 1, kept.
+				cc.BeginCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.x", true)
+				// Cycle 2 (successSeq=2): 2-1=1 < grace(2) -> kept.
+				cc.BeginCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.x", true)
+				// Cycle 3 (successSeq=3): 3-1=2 >= grace(2) -> swept.
+				cc.BeginCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.x", false)
+				require.Equal(t, uint64(1), s.Read().CollectMeta().EvictedDescriptors)
+			},
+		},
+		"grace zero sweeps the descriptor the cycle its last series is evicted": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				sv.core.retention = collectorRetentionPolicy{expireAfterSuccessCycles: 1, descriptorGraceCycles: 0}
+				cc := cycleController(t, s)
+
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("g").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Series evicted this cycle; grace=0 -> descriptor swept the same cycle.
+				cc.BeginCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.g", false)
+				require.Equal(t, uint64(1), s.Read().CollectMeta().EvictedDescriptors)
+			},
+		},
+		"a swept name re-establishes when observed again": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				sv.core.retention = collectorRetentionPolicy{expireAfterSuccessCycles: 1, descriptorGraceCycles: 0}
+				cc := cycleController(t, s)
+
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("g").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				cc.BeginCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.g", false)
+
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("g").Observe(5)
+				require.NoError(t, cc.CommitCycleSuccess())
+				requireInstrument(t, sv, "svc.g", true)
+				mustValue(t, s.Read(ReadRaw()), "svc.g", nil, 5)
+			},
+		},
+		"supersede of an idle-stamped name whose replacement is evicted leaves no zeroSince orphan": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				sv := collectorStoreViewForTest(t, s)
+				sv.core.retention = collectorRetentionPolicy{expireAfterSuccessCycles: 1, maxSeries: 1, descriptorGraceCycles: 100}
+				cc := cycleController(t, s)
+
+				// Cycle 1: observe svc.a (gauge) -> committed, live.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("a").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// Cycle 2: not observed -> series expires (expire=1); svc.a goes idle (grace=100).
+				cc.BeginCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				require.Contains(t, sv.core.instrumentZeroSince, "svc.a", "an idle name must be stamped")
+
+				// Cycle 3: supersede svc.a with a new kind AND observe svc.z. maxSeries=1 evicts
+				// the new svc.a series (smaller key) before canonicalization, so svc.a never
+				// re-enters instruments. Its idle stamp must be cleared, not orphaned forever.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Counter("a").ObserveTotal(2)
+				s.Write().SnapshotMeter("svc").Gauge("z").Observe(3)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				requireInstrument(t, sv, "svc.a", false)
+				require.NotContains(t, sv.core.instrumentZeroSince, "svc.a", "no orphan idle stamp after supersede")
+				// The invariant the fix maintains: instrumentZeroSince is a subset of instruments.
+				for name := range sv.core.instrumentZeroSince {
+					require.Contains(t, sv.core.instruments, name, "instrumentZeroSince must stay a subset of instruments")
+				}
+			},
+		},
+		"dropped-name and eviction counters accumulate and survive abort": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+
+				// Ambiguous multi-kind name is dropped; an unrelated name still commits.
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				s.Write().SnapshotMeter("svc").Counter("m").ObserveTotal(2)
+				s.Write().SnapshotMeter("svc").Gauge("ok").Observe(9)
+				require.NoError(t, cc.CommitCycleSuccess())
+				require.Equal(t, uint64(1), s.Read().CollectMeta().DroppedNames)
+				require.Equal(t, uint64(0), s.Read().CollectMeta().EvictedDescriptors)
+
+				// An aborted cycle must not change the counters.
+				cc.BeginCycle()
+				cc.AbortCycle()
+				require.Equal(t, uint64(1), s.Read().CollectMeta().DroppedNames)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) { tc.run(t) })
+	}
+}
+
+func requireInstrument(t *testing.T, sv *storeView, name string, want bool) {
+	t.Helper()
+	_, ok := sv.core.instruments[name]
+	require.Equalf(t, want, ok, "instruments[%q] present=%v, want %v", name, ok, want)
+}

--- a/src/go/pkg/metrix/descriptor_universe_sweep_store_test.go
+++ b/src/go/pkg/metrix/descriptor_universe_sweep_store_test.go
@@ -56,7 +56,7 @@ func TestDescriptorUniverseSweep(t *testing.T) {
 				sv.core.retention = collectorRetentionPolicy{expireAfterSuccessCycles: 1, descriptorGraceCycles: 1}
 				cc := cycleController(t, s)
 
-				for i := 0; i < 10; i++ {
+				for i := range 10 {
 					cc.BeginCycle()
 					s.Write().SnapshotMeter("svc").Gauge("g").Observe(SampleValue(i))
 					require.NoError(t, cc.CommitCycleSuccess())

--- a/src/go/pkg/metrix/gauge.go
+++ b/src/go/pkg/metrix/gauge.go
@@ -95,6 +95,13 @@ func (c *storeCore) recordGaugeSet(desc *instrumentDescriptor, scope HostScope, 
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.gauges[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		entry = &stagedGauge{
 			key:          key,
@@ -132,9 +139,16 @@ func (c *storeCore) recordGaugeAdd(desc *instrumentDescriptor, scope HostScope, 
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.gauges[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		baseline := SampleValue(0)
-		if existing := c.snapshot.Load().series[key]; existing != nil {
+		if existing := c.baselineSeriesForWrite(key, desc); existing != nil {
 			baseline = existing.value
 		}
 		entry = &stagedGauge{

--- a/src/go/pkg/metrix/histogram.go
+++ b/src/go/pkg/metrix/histogram.go
@@ -101,16 +101,27 @@ func (c *storeCore) recordHistogramObservePoint(desc *instrumentDescriptor, scop
 		return
 	}
 
-	schema := desc.histogram
-	if schema == nil {
-		// For snapshot histograms without explicit bounds, validate against
-		// previously captured family schema (if available).
-		schema = c.snapshotHistogramSchema[desc.name]
-	}
-	bounds, count, sum, cumulative := normalizeHistogramPoint(point, schema)
+	// A nil-bounds snapshot histogram adopts the bounds of the observed point; it is
+	// NOT validated against the committed schema here, because client-driven bounds
+	// must never panic the record path. Bounds consistency for nil-bounds histograms
+	// is resolved at commit via the effective-authority path (drop/fail). Explicit-
+	// bounds histograms still validate against their declared schema (fail-loud).
+	bounds, count, sum, cumulative := normalizeHistogramPoint(point, desc.histogram)
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.histograms[key]
+	// Reconcile a same-key write only when it DIFFERS from the staged entry (a different
+	// handle, or the same handle with different observed bounds); a repeated same-handle
+	// write with the same bounds is a canonicalization no-op and must not grow evidence.
+	// A nil-bounds snapshot descriptor is a wildcard, so compare by observed bounds: two
+	// same-key writes with different effective schemas must not silently collapse.
+	if ok && (entry.desc != desc || !equalHistogramBounds(entry.bounds, bounds)) {
+		canonical, proceed := c.reconcileSameKeyHistogram(key, entry, desc, bounds)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		entry = &stagedHistogram{
 			key:          key,
@@ -122,9 +133,6 @@ func (c *storeCore) recordHistogramObservePoint(desc *instrumentDescriptor, scop
 			desc:         desc,
 		}
 		c.active.histograms[key] = entry
-	}
-	if len(entry.bounds) > 0 && !equalHistogramBounds(entry.bounds, bounds) {
-		panic("metrix: histogram point schema mismatch within cycle")
 	}
 	entry.bounds = append(entry.bounds[:0], bounds...)
 	entry.count = count
@@ -162,6 +170,16 @@ func (c *storeCore) recordHistogramObserve(desc *instrumentDescriptor, scope Hos
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.histograms[key]
+	// A stateful histogram's descriptor fully determines its effective authority (bounds
+	// are declared, not per-write), so a repeated same-handle write is a no-op; reconcile
+	// only when the descriptor differs.
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyHistogram(key, entry, desc, desc.histogram.bounds)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		entry = &stagedHistogram{
 			key:          key,
@@ -175,7 +193,7 @@ func (c *storeCore) recordHistogramObserve(desc *instrumentDescriptor, scope Hos
 			cumulative:   make([]SampleValue, len(schema.bounds)),
 		}
 		if desc.window == WindowCumulative {
-			if existing := c.snapshot.Load().series[key]; existing != nil && existing.desc != nil && existing.desc.kind == kindHistogram {
+			if existing := c.baselineSeriesForWrite(key, desc); existing != nil {
 				entry.count = existing.histogramCount
 				entry.sum = existing.histogramSum
 				entry.cumulative = append(entry.cumulative[:0], existing.histogramCumulative...)

--- a/src/go/pkg/metrix/histogram_store_test.go
+++ b/src/go/pkg/metrix/histogram_store_test.go
@@ -118,8 +118,12 @@ func TestHistogramStoreScenarios(t *testing.T) {
 					},
 				})
 
+				// A nil-bounds histogram observing bounds different from the captured
+				// schema must NOT panic (client-driven bounds must be crash-safe). The
+				// mismatch is resolved at commit: the captured schema was not observed
+				// this cycle, so the new bounds supersede it.
 				cc.BeginCycle()
-				expectPanic(t, func() {
+				require.NotPanics(t, func() {
 					h.ObservePoint(HistogramPoint{
 						Count: 2, Sum: 0.8,
 						Buckets: []BucketPoint{
@@ -128,7 +132,14 @@ func TestHistogramStoreScenarios(t *testing.T) {
 						},
 					})
 				})
-				cc.AbortCycle()
+				require.NoError(t, cc.CommitCycleSuccess())
+				mustHistogram(t, s.Read(), "svc.latency", nil, HistogramPoint{
+					Count: 2, Sum: 0.8,
+					Buckets: []BucketPoint{
+						{UpperBound: 0.5, CumulativeCount: 2},
+						{UpperBound: 1, CumulativeCount: 2},
+					},
+				})
 			},
 		},
 		"stateful histogram requires bounds": {

--- a/src/go/pkg/metrix/hotpath_bench_test.go
+++ b/src/go/pkg/metrix/hotpath_bench_test.go
@@ -7,7 +7,12 @@ import (
 	"testing"
 )
 
-// Baseline results (to be updated before/after hot-path refactors):
+// Hot-path benchmarks for the collector store commit/record path. Every number in this
+// file - this header's history and the "Latest" comment above each benchmark - was
+// measured on a developer laptop, NOT CI. Treat them as relative/trend indicators for
+// before/after comparisons, not absolute gates.
+//
+// Baseline results (historical; each benchmark's latest numbers are inline above its func):
 // Command:
 //
 //	go test ./pkg/metrix -run '^$' -bench 'RuntimeStoreSingleWriteAtCardinality|CollectorCommitSparseAtCardinality' -benchmem
@@ -34,6 +39,8 @@ import (
 //
 // BenchmarkCollectorCommitSparseAtCardinality/series_50000_touched_10-14  978680      2471 ns/op     5697 B/op  45 allocs/op
 // BenchmarkCollectorCommitSparseAtCardinality/series_100000_touched_20-14 511872      4346 ns/op    11316 B/op  77 allocs/op
+// Latest (developer laptop, -benchtime=200x): series_1 625ns/5allocs, series_10 990ns/5,
+// series_100 1.0us/5, series_1000 2.0us/5. Per-write cost is ~flat across cardinality.
 func BenchmarkRuntimeStoreSingleWriteAtCardinality(b *testing.B) {
 	tests := map[string]struct {
 		totalSeries int
@@ -71,6 +78,17 @@ func BenchmarkRuntimeStoreSingleWriteAtCardinality(b *testing.B) {
 	}
 }
 
+// This guards the ALLOCATION envelope of a sparse commit: only touched/changed series are
+// cloned, so allocs stay ~O(touched) and never O(retained). Commit TIME is intentionally
+// O(live-series + touched + distinct-authorities) - every commit copies the series map and
+// scans live series for retention, host-scope refresh, canonicalization, and the
+// descriptor-universe sweep - so the timings scale with live series (same touched, more
+// retained = slower), which is expected; the invariant this bench pins is that allocs do not.
+// Latest (developer laptop, -benchtime=300x): s100/t5 2.2us/38allocs, s1000/t5 11us/38,
+// s5000/t10 23us/58, s50000/t10 198us/62, s100000/t20 543us/98 (the descriptor-universe sweep
+// added no allocs: it is O(distinct-names) and its live-name set does not escape the commit).
+// Before the canonicalization-clone fix the s100000/t20 case cloned every retained descriptor:
+// 43.7ms / 100340 allocs.
 func BenchmarkCollectorCommitSparseAtCardinality(b *testing.B) {
 	tests := map[string]struct {
 		totalSeries int
@@ -114,6 +132,162 @@ func BenchmarkCollectorCommitSparseAtCardinality(b *testing.B) {
 					h.Observe(SampleValue(i + j))
 				}
 				cc.CommitCycleSuccess()
+			}
+		})
+	}
+}
+
+// BenchmarkCollectorCommitManySuperseded exercises commit when many distinct names each
+// change kind (supersede) in one cycle. Must be O(live), not O(superseded*live).
+// Round-8 set-based supersede, before -> after (developer laptop): names_100 304us -> 91us;
+// names_1000 4.87ms -> 1.10ms; names_5000 91.1ms -> 5.68ms. O(N^2) -> O(N).
+func BenchmarkCollectorCommitManySuperseded(b *testing.B) {
+	for _, n := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("names_%d", n), func(b *testing.B) {
+			s := NewCollectorStore()
+			cc := benchmarkCycleController(b, s)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				// Alternate each name's kind every cycle so each name supersedes the other.
+				cc.BeginCycle()
+				meter := s.Write().SnapshotMeter("svc")
+				for i := 0; i < n; i++ {
+					name := fmt.Sprintf("m%d", i)
+					if iter%2 == 0 {
+						meter.Counter(name).ObserveTotal(1)
+					} else {
+						meter.Gauge(name).Observe(1)
+					}
+				}
+				cc.CommitCycleSuccess()
+			}
+		})
+	}
+}
+
+// BenchmarkCollectorCommitManyDropped exercises commit when many distinct names are
+// ambiguous (two incompatible kinds, no committed authority) and dropped. Must be
+// O(touched), not O(dropped*touched).
+// Round-8 set-based drop, before -> after (developer laptop): names_100 177us -> 96us;
+// names_1000 8.58ms -> 1.15ms; names_5000 196ms -> 6.03ms. O(N^2) -> O(N).
+func BenchmarkCollectorCommitManyDropped(b *testing.B) {
+	for _, n := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("names_%d", n), func(b *testing.B) {
+			s := NewCollectorStore()
+			cc := benchmarkCycleController(b, s)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				cc.BeginCycle()
+				meter := s.Write().SnapshotMeter("svc")
+				for i := 0; i < n; i++ {
+					name := fmt.Sprintf("m%d", i)
+					meter.Gauge(name).Observe(1)
+					meter.Counter(name).ObserveTotal(1)
+				}
+				cc.CommitCycleSuccess()
+			}
+		})
+	}
+}
+
+// BenchmarkCollectorSameKeyRepeatedWrites exercises repeated same-key writes whose observed
+// schema differs from the staged entry but is otherwise identical (the same conflicting bounds
+// every time). They share one authority fingerprint, so the conflict is recorded once and every
+// later repeat is dropped by a no-clone identity check - both the descriptor evidence AND the
+// effective-descriptor clones stay O(1), not O(samples) (the residual per-sample cost is inherent
+// point normalization).
+// Fingerprint dedup with no-clone repeat check, before -> after (developer laptop): samples_10000
+// 1.81ms / 100045 allocs -> 0.97ms / 20044 allocs (the residual allocs are inherent point
+// normalization; the per-sample effective clone and evidence growth are gone once the conflicting
+// authority is recorded). This is the pathological conflict-flood path; a healthy same-schema
+// repeat never enters here.
+func BenchmarkCollectorSameKeyRepeatedWrites(b *testing.B) {
+	pt := func(uppers ...float64) HistogramPoint {
+		buckets := make([]BucketPoint, len(uppers))
+		for i, ub := range uppers {
+			buckets[i] = BucketPoint{UpperBound: ub, CumulativeCount: 1}
+		}
+		return HistogramPoint{Count: 1, Sum: 1, Buckets: buckets}
+	}
+	for _, k := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("samples_%d", k), func(b *testing.B) {
+			s := NewCollectorStore()
+			cc := benchmarkCycleController(b, s)
+			pt12, pt56 := pt(1, 2), pt(5, 6)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				cc.BeginCycle()
+				h := s.Write().SnapshotMeter("svc").Histogram("h")
+				h.ObservePoint(pt12)
+				for j := 0; j < k; j++ {
+					h.ObservePoint(pt56) // differs from the staged entry every time
+				}
+				cc.CommitCycleSuccess()
+			}
+		})
+	}
+}
+
+// BenchmarkCollectorCommitManySchemasPerName exercises one histogram name whose labels
+// carry many distinct bucket schemas (distinct authorities). Authority grouping is
+// fingerprint-indexed, so it is O(distinct) time, not O(distinct^2).
+// History (developer laptop): pre-hardening O(N^2) (schemas_1000 29.8ms / 1.52M allocs); a
+// cap-at-2 made it O(N) time / O(1) memory but LOSSILY hid declaration conflicts past the cap; the
+// fingerprint index restores losslessness at O(distinct) memory - schemas_1000 ~688us / ~25k allocs
+// (every distinct authority is kept so any declaration conflict is caught). This is the pathological
+// many-schema-per-name case (a broken collector); a healthy 1-authority name is unaffected.
+func BenchmarkCollectorCommitManySchemasPerName(b *testing.B) {
+	for _, n := range []int{100, 500, 1000} {
+		b.Run(fmt.Sprintf("schemas_%d", n), func(b *testing.B) {
+			s := NewCollectorStore()
+			cc := benchmarkCycleController(b, s)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				cc.BeginCycle()
+				meter := s.Write().SnapshotMeter("svc")
+				for i := 0; i < n; i++ {
+					pt := HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: float64(i + 1), CumulativeCount: 1}}}
+					meter.WithLabels(Label{Key: "id", Value: fmt.Sprintf("s%d", i)}).Histogram("h").ObservePoint(pt)
+				}
+				cc.CommitCycleSuccess()
+			}
+		})
+	}
+}
+
+// BenchmarkCollectorSameKeyManyDeclarations exercises one series key written by many handles that
+// share an authority but declare DISTINCT metadata (unique units). Conflict evidence is keyed by
+// full descriptor identity (authority fingerprint + declaration fingerprint), so recording each
+// distinct declaration is O(1) and the total stays O(distinct), not O(distinct^2) (a per-authority
+// bucket rescanned before every append).
+// Full-descriptor conflict key, before -> after (developer laptop): declarations_1000 2.76ms ->
+// 0.39ms (allocs stay O(N): 6.1k -> 7.1k). The win is TIME: the per-append bucket scan (O(N^2)) is
+// replaced by an O(1) keyed lookup.
+func BenchmarkCollectorSameKeyManyDeclarations(b *testing.B) {
+	for _, n := range []int{100, 1000} {
+		b.Run(fmt.Sprintf("declarations_%d", n), func(b *testing.B) {
+			s := NewCollectorStore()
+			cc := benchmarkCycleController(b, s)
+			// N stale same-key gauge handles, same authority, distinct units (each from its own
+			// aborted cycle so registration does not reject the declaration conflict).
+			handles := make([]SnapshotGauge, n)
+			for i := range handles {
+				cc.BeginCycle()
+				handles[i] = s.Write().SnapshotMeter("svc").Gauge("m", WithUnit(fmt.Sprintf("u%d", i)))
+				cc.AbortCycle()
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				cc.BeginCycle()
+				for _, h := range handles {
+					h.Observe(1)
+				}
+				cc.CommitCycleSuccess() // fails on the declaration conflicts; measures conflict recording + resolution
 			}
 		})
 	}

--- a/src/go/pkg/metrix/hotpath_bench_test.go
+++ b/src/go/pkg/metrix/hotpath_bench_test.go
@@ -152,7 +152,7 @@ func BenchmarkCollectorCommitManySuperseded(b *testing.B) {
 				// Alternate each name's kind every cycle so each name supersedes the other.
 				cc.BeginCycle()
 				meter := s.Write().SnapshotMeter("svc")
-				for i := 0; i < n; i++ {
+				for i := range n {
 					name := fmt.Sprintf("m%d", i)
 					if iter%2 == 0 {
 						meter.Counter(name).ObserveTotal(1)
@@ -181,7 +181,7 @@ func BenchmarkCollectorCommitManyDropped(b *testing.B) {
 			for iter := 0; iter < b.N; iter++ {
 				cc.BeginCycle()
 				meter := s.Write().SnapshotMeter("svc")
-				for i := 0; i < n; i++ {
+				for i := range n {
 					name := fmt.Sprintf("m%d", i)
 					meter.Gauge(name).Observe(1)
 					meter.Counter(name).ObserveTotal(1)
@@ -222,7 +222,7 @@ func BenchmarkCollectorSameKeyRepeatedWrites(b *testing.B) {
 				cc.BeginCycle()
 				h := s.Write().SnapshotMeter("svc").Histogram("h")
 				h.ObservePoint(pt12)
-				for j := 0; j < k; j++ {
+				for range k {
 					h.ObservePoint(pt56) // differs from the staged entry every time
 				}
 				cc.CommitCycleSuccess()
@@ -249,7 +249,7 @@ func BenchmarkCollectorCommitManySchemasPerName(b *testing.B) {
 			for iter := 0; iter < b.N; iter++ {
 				cc.BeginCycle()
 				meter := s.Write().SnapshotMeter("svc")
-				for i := 0; i < n; i++ {
+				for i := range n {
 					pt := HistogramPoint{Count: 1, Sum: 1, Buckets: []BucketPoint{{UpperBound: float64(i + 1), CumulativeCount: 1}}}
 					meter.WithLabels(Label{Key: "id", Value: fmt.Sprintf("s%d", i)}).Histogram("h").ObservePoint(pt)
 				}

--- a/src/go/pkg/metrix/interfaces.go
+++ b/src/go/pkg/metrix/interfaces.go
@@ -16,6 +16,24 @@ type RuntimeStore interface {
 	Write() RuntimeWriter
 }
 
+// DescriptorRetention is an OPTIONAL interface a CollectorStore may implement to expose how
+// long it keeps a descriptor and the clock that lifetime is measured in. A consumer that
+// caches per-name state keyed off metrix descriptors (e.g. the prometheus writer) obtains it
+// via a type assertion and keeps its state alive at least DescriptorRetentionWindow successful
+// commits, so it never re-registers a name while metrix still holds the descriptor. It is
+// deliberately NOT part of CollectorStore so existing implementations and test fakes keep
+// compiling.
+type DescriptorRetention interface {
+	// DescriptorRetentionWindow is the number of successful commits a descriptor can outlive
+	// its last series: expireAfterSuccessCycles + descriptorGraceCycles. It is
+	// DescriptorRetentionUnbounded when series age-expiry is disabled (the descriptor can then
+	// live indefinitely); a consumer MUST treat that as "never age out my cached state".
+	DescriptorRetentionWindow() uint64
+	// SuccessfulCommits is the number of successful commits so far - the clock the retention
+	// window is measured against.
+	SuccessfulCommits() uint64
+}
+
 // CycleController owns collect-cycle transitions for a cycle-managed store.
 // Collector code does not call these methods directly.
 type CycleController interface {

--- a/src/go/pkg/metrix/measureset.go
+++ b/src/go/pkg/metrix/measureset.go
@@ -265,6 +265,13 @@ func (c *storeCore) recordMeasureSetGaugeSetPoint(desc *instrumentDescriptor, sc
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.measureSetGauges[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		entry = &stagedMeasureSet{
 			key:          key,
@@ -309,9 +316,16 @@ func (c *storeCore) recordMeasureSetGaugeAddPoint(desc *instrumentDescriptor, sc
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.measureSetGauges[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		baseline := make([]SampleValue, len(schema.fields))
-		if existing := c.snapshot.Load().series[key]; existing != nil {
+		if existing := c.baselineSeriesForWrite(key, desc); existing != nil {
 			baseline = append(baseline[:0], existing.measureSetValues...)
 			if len(baseline) != len(schema.fields) {
 				baseline = make([]SampleValue, len(schema.fields))
@@ -364,9 +378,16 @@ func (c *storeCore) recordMeasureSetGaugeSetField(desc *instrumentDescriptor, sc
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.measureSetGauges[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		baseline := make([]SampleValue, len(schema.fields))
-		if existing := c.snapshot.Load().series[key]; existing != nil {
+		if existing := c.baselineSeriesForWrite(key, desc); existing != nil {
 			baseline = append(baseline[:0], existing.measureSetValues...)
 			if len(baseline) != len(schema.fields) {
 				baseline = make([]SampleValue, len(schema.fields))
@@ -418,6 +439,13 @@ func (c *storeCore) recordMeasureSetCounterObserveTotalPoint(desc *instrumentDes
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.measureSetCounters[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		entry = &stagedMeasureSet{
 			key:          key,
@@ -462,9 +490,16 @@ func (c *storeCore) recordMeasureSetCounterAddPoint(desc *instrumentDescriptor, 
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.measureSetCounters[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		baseline := make([]SampleValue, len(schema.fields))
-		if existing := c.snapshot.Load().series[key]; existing != nil {
+		if existing := c.baselineSeriesForWrite(key, desc); existing != nil {
 			baseline = append(baseline[:0], existing.measureSetValues...)
 			if len(baseline) != len(schema.fields) {
 				baseline = make([]SampleValue, len(schema.fields))

--- a/src/go/pkg/metrix/options.go
+++ b/src/go/pkg/metrix/options.go
@@ -10,6 +10,49 @@ type optionFunc func(*instrumentConfig)
 
 func (f optionFunc) apply(cfg *instrumentConfig) { f(cfg) }
 
+// CollectorStoreOption configures a collector store at construction time.
+type CollectorStoreOption interface {
+	apply(*collectorStoreConfig)
+}
+
+type collectorStoreConfig struct {
+	expireAfterSuccessCycles uint64
+	maxSeries                int
+	graceCycles              uint64
+	graceSet                 bool
+}
+
+type collectorStoreOptionFunc func(*collectorStoreConfig)
+
+func (f collectorStoreOptionFunc) apply(cfg *collectorStoreConfig) { f(cfg) }
+
+// WithExpireAfterSuccessCycles sets how many successful commits an unobserved series
+// is retained before eviction (0 disables series expiry).
+func WithExpireAfterSuccessCycles(cycles uint64) CollectorStoreOption {
+	return collectorStoreOptionFunc(func(cfg *collectorStoreConfig) {
+		cfg.expireAfterSuccessCycles = cycles
+	})
+}
+
+// WithMaxSeries caps the number of committed series; the oldest are evicted past the
+// cap (0 disables the cap).
+func WithMaxSeries(max int) CollectorStoreOption {
+	return collectorStoreOptionFunc(func(cfg *collectorStoreConfig) {
+		cfg.maxSeries = max
+	})
+}
+
+// WithDescriptorGraceCycles sets how many successful commits a descriptor is kept after
+// its last series is evicted, before the descriptor itself is swept. It defaults to
+// expireAfterSuccessCycles, so the effective descriptor lifetime after a name goes idle
+// is expire+grace; set it explicitly (including 0) to decouple the two.
+func WithDescriptorGraceCycles(cycles uint64) CollectorStoreOption {
+	return collectorStoreOptionFunc(func(cfg *collectorStoreConfig) {
+		cfg.graceCycles = cycles
+		cfg.graceSet = true
+	})
+}
+
 type instrumentConfig struct {
 	freshnessSet bool
 	freshness    FreshnessPolicy

--- a/src/go/pkg/metrix/register_txn_store_test.go
+++ b/src/go/pkg/metrix/register_txn_store_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegistrationTransactionality pins the staged-registration contract:
+// a registration made during an active cycle is provisional - it joins the
+// committed registry only when the cycle commits, and is discarded if the cycle
+// aborts. Conflict handling is unchanged at this step (fail-loud); the
+// commit-time state model arrives in a later step.
+func TestRegistrationTransactionality(t *testing.T) {
+	tests := map[string]struct {
+		run func(t *testing.T)
+	}{
+		"registration in a committed cycle persists (later incompatible re-declare conflicts)": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				// svc.m is now a committed gauge; re-declaring it as a counter must conflict.
+				expectPanic(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Counter("m")
+				})
+			},
+		},
+		"registration in an aborted cycle is discarded (later different-kind re-declare is clean)": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				_ = s.Write().SnapshotMeter("svc").Gauge("m")
+				cc.AbortCycle()
+
+				// The gauge registration was never committed, so svc.m is free to be
+				// declared as a different kind without conflict.
+				require.NotPanics(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Counter("m")
+				})
+			},
+		},
+		"duplicate compatible registration within a cycle dedups": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				require.NotPanics(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Gauge("m")
+					_ = s.Write().SnapshotMeter("svc").Gauge("m")
+				})
+				cc.AbortCycle()
+			},
+		},
+		"re-declare compatible in a later cycle dedups against the committed registry": {
+			run: func(t *testing.T) {
+				s := NewCollectorStore()
+				cc := cycleController(t, s)
+				cc.BeginCycle()
+				s.Write().SnapshotMeter("svc").Gauge("m").Observe(1)
+				require.NoError(t, cc.CommitCycleSuccess())
+
+				cc.BeginCycle()
+				require.NotPanics(t, func() {
+					_ = s.Write().SnapshotMeter("svc").Gauge("m")
+				})
+				cc.AbortCycle()
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc.run)
+	}
+}

--- a/src/go/pkg/metrix/stateset.go
+++ b/src/go/pkg/metrix/stateset.go
@@ -133,6 +133,13 @@ func (c *storeCore) recordStateSetObserve(desc *instrumentDescriptor, scope Host
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.stateSet[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		entry = &stagedStateSet{
 			key:          key,

--- a/src/go/pkg/metrix/summary.go
+++ b/src/go/pkg/metrix/summary.go
@@ -109,6 +109,13 @@ func (c *storeCore) recordSummaryObservePoint(desc *instrumentDescriptor, scope 
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.summaries[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		entry = &stagedSummary{
 			key:          key,
@@ -153,6 +160,13 @@ func (c *storeCore) recordSummaryObserve(desc *instrumentDescriptor, scope HostS
 
 	key := makeSeriesKey(scope.ScopeKey, desc.name, labelsKey)
 	entry, ok := c.active.summaries[key]
+	if ok && entry.desc != desc {
+		canonical, proceed := c.reconcileSameKeyDesc(key, entry.desc, desc)
+		if !proceed {
+			return
+		}
+		entry.desc = canonical
+	}
 	if !ok {
 		entry = &stagedSummary{
 			key:          key,
@@ -164,7 +178,7 @@ func (c *storeCore) recordSummaryObserve(desc *instrumentDescriptor, scope HostS
 			desc:         desc,
 		}
 		if desc.window == WindowCumulative {
-			if existing := c.snapshot.Load().series[key]; existing != nil && existing.desc != nil && existing.desc.kind == kindSummary {
+			if existing := c.baselineSeriesForWrite(key, desc); existing != nil {
 				entry.count = existing.summaryCount
 				entry.sum = existing.summarySum
 				if len(desc.summaryQuantiles()) > 0 && existing.summarySketch != nil {

--- a/src/go/pkg/metrix/types.go
+++ b/src/go/pkg/metrix/types.go
@@ -93,6 +93,12 @@ type CollectMeta struct {
 	LastAttemptSeq    uint64
 	LastAttemptStatus CollectStatus
 	LastSuccessSeq    uint64
+	// EvictedDescriptors is the cumulative count of descriptors removed by the
+	// descriptor-universe sweep (a name whose series are gone and whose grace elapsed).
+	EvictedDescriptors uint64
+	// DroppedNames is the cumulative count of names dropped for a cycle because their
+	// writes were an ambiguous multi-kind conflict with no established authority.
+	DroppedNames uint64
 }
 
 type QuantilePoint struct {

--- a/src/go/plugin/go.d/collector/prometheus/writer.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer.go
@@ -3,6 +3,7 @@
 package prometheus
 
 import (
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -32,6 +33,16 @@ type metricFamilyWriter struct {
 	policy  metricFamilyWriterPolicy
 	handles map[string]*metricFamilyHandle
 	cycle   uint64
+
+	// Family-handle lifetime is coupled to the metrix descriptor lifetime (see metricFamilyHandle):
+	// retention is the store's descriptor-retention accessor, nil only if the store does not expose
+	// it (then handles are kept, the pre-coupling behavior); window is the descriptor retention
+	// window (expire+grace), MaxUint64 meaning unbounded; lastReconcileSuccess is the successful-commit
+	// count observed at the previous scrape, used to detect whether the previous cycle committed.
+	retention            metrix.DescriptorRetention
+	window               uint64
+	lastReconcileSuccess uint64
+
 	*logger.Logger
 }
 
@@ -43,25 +54,32 @@ type cachedInstrument[T any] struct {
 }
 
 // metricFamilyHandle caches, per metric name, the canonical distribution schema, instrument options,
-// and the per-series instrument handles. The family handle is created once per name and KEPT for the
-// job's lifetime on purpose: metrix registers an instrument descriptor per name permanently (no
-// unregister API), so if a name reappeared with a changed contract (kind, summary quantiles, or
-// histogram bounds) and the writer re-registered it, metrix would panic on the mismatch. Keeping the
-// handle lets ensureHandle detect that drift and skip it instead of re-registering.
+// and the per-series instrument handles. The handle exists for as long as metrix keeps the name's
+// descriptor: while the descriptor is live, keeping the handle lets ensureHandle detect a changed
+// contract (kind, summary quantiles, or histogram bounds) and skip it rather than write a conflicting
+// kind; once the name is idle past the metrix descriptor window (expire+grace) metrix evicts the
+// descriptor and reconcileHandles evicts this handle in lockstep, so a name that later reappears with
+// a changed contract re-registers cleanly instead of being drift-skipped forever. staged marks the
+// handle as touched this scrape (awaiting the framework commit); accepted/acceptedSuccess record the
+// last successful commit that accepted it, the clock reconcileHandles ages it by.
 //
-// The per-series instrument handles inside ARE evicted: they are reused across cycles (skipping
-// per-series instrument re-resolution) and dropped once a series goes unobserved for
+// The per-series instrument handles inside ARE evicted separately: they are reused across cycles
+// (skipping per-series instrument re-resolution) and dropped once a series goes unobserved for
 // seriesCacheRetentionCycles, so the cache stays bounded under label-value churn — unlike a metrix
 // vec, whose internal handle cache is unbounded. A family may mix label-key sets; each series is
 // cached and written by its own full label tuple. Per-name state (this handle plus the metrix
 // descriptor) is bounded by metric-name cardinality; metric-NAME churn (a Prometheus anti-pattern)
-// grows it — an accepted metrix-store limit.
+// grows it only within the retention window — a now-bounded limit.
 type metricFamilyHandle struct {
 	name             string
 	typ              commonmodel.MetricType
 	summaryQuantiles []float64
 	histogramBounds  []float64
 	opts             []metrix.InstrumentOption
+
+	staged          bool
+	accepted        bool
+	acceptedSuccess uint64
 
 	gauges     map[string]*cachedInstrument[metrix.SnapshotGauge]
 	counters   map[string]*cachedInstrument[metrix.SnapshotCounter]
@@ -78,12 +96,19 @@ func newMetricFamilyWriter(store metrix.CollectorStore, policy metricFamilyWrite
 	if policy.isFallbackTypeCounter == nil {
 		policy.isFallbackTypeCounter = matcher.FALSE()
 	}
-	return &metricFamilyWriter{
+	w := &metricFamilyWriter{
 		store:   store,
 		policy:  policy,
 		handles: make(map[string]*metricFamilyHandle),
+		window:  math.MaxUint64, // no accessor -> keep family handles (pre-coupling behavior)
 		Logger:  log,
 	}
+	// Couple family-handle lifetime to the metrix descriptor window when the store exposes it.
+	if dr, ok := store.(metrix.DescriptorRetention); ok {
+		w.retention = dr
+		w.window = dr.DescriptorRetentionWindow()
+	}
+	return w
 }
 
 // countWritable reports how many series across all families could be written. Used at Check to
@@ -116,6 +141,7 @@ func (w *metricFamilyWriter) countWritable(mfs prompkg.MetricFamilies) int {
 
 func (w *metricFamilyWriter) writeMetricFamilies(mfs prompkg.MetricFamilies) int {
 	w.cycle++
+	w.reconcileHandles()
 
 	written := 0
 	for _, mf := range mfs {
@@ -133,15 +159,61 @@ func (w *metricFamilyWriter) writeMetricFamilies(mfs prompkg.MetricFamilies) int
 			continue
 		}
 
+		// Stage the handle only when at least one compatible series actually writes. A family whose
+		// type matches but whose series all drift (changed summary quantiles / histogram bounds)
+		// writes nothing, so it must NOT refresh its lifetime - otherwise it would never age out to
+		// re-adopt the new schema after metrix evicts the descriptor. Partial drift (some canonical
+		// series still write) does refresh, keeping the live family.
 		for _, metric := range mf.Metrics() {
 			if w.observeMetric(handle, metric) {
 				written++
+				handle.staged = true
 			}
 		}
 	}
 
 	w.evictStaleSeries()
 	return written
+}
+
+// reconcileHandles couples the family-handle cache to the metrix descriptor lifetime. It runs at the
+// start of each scrape, before handles are (re)touched, on the metrix successful-commit clock:
+//   - a handle staged in the previous scrape is PROMOTED to accepted if that scrape's cycle committed;
+//     if it did not commit (aborted) and the handle had never been accepted, it is dropped so a bogus
+//     handle from a failed commit cannot drift-skip this scrape;
+//   - an accepted handle idle for the descriptor window (expire+grace) is evicted, matching metrix's
+//     own descriptor eviction, so a name that reappears with a changed contract re-registers cleanly.
+//
+// Both clocks advance only on successful commits, so writer and store stay in lockstep across endpoint
+// downtime (aborted cycles advance neither). With no accessor (window == MaxUint64) handles are kept,
+// the pre-coupling behavior.
+func (w *metricFamilyWriter) reconcileHandles() {
+	if w.retention == nil {
+		return
+	}
+	success := w.retention.SuccessfulCommits()
+	committed := success > w.lastReconcileSuccess
+	for name, h := range w.handles {
+		if h.staged {
+			h.staged = false
+			switch {
+			case committed:
+				h.accepted = true
+				h.acceptedSuccess = success
+			case !h.accepted:
+				delete(w.handles, name) // never accepted and the staging cycle aborted -> bogus
+				continue
+			}
+		}
+		// Age out an accepted handle once idle for the descriptor window. Skip when the window is
+		// unbounded (series expiry disabled), and guard the subtraction against a non-monotonic
+		// clock so it can never underflow-wrap into a spurious eviction.
+		if h.accepted && w.window != metrix.DescriptorRetentionUnbounded &&
+			success >= h.acceptedSuccess && success-h.acceptedSuccess >= w.window {
+			delete(w.handles, name) // metrix has evicted the descriptor; drop the handle in step
+		}
+	}
+	w.lastReconcileSuccess = success
 }
 
 func (w *metricFamilyWriter) skipMetricFamily(mf *prompkg.MetricFamily) bool {

--- a/src/go/plugin/go.d/collector/prometheus/writer_lifecycle_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_lifecycle_test.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetricFamilyWriterHandleLifecycle pins the family-handle lifetime coupling to metrix's
+// descriptor lifetime: handles are aged on the successful-commit clock to the descriptor window
+// (expire+grace), so a name idle past the window is evicted and re-registers cleanly, a bogus
+// handle from an aborted commit does not drift-skip, and a previously accepted handle survives an
+// aborted re-touch.
+func TestMetricFamilyWriterHandleLifecycle(t *testing.T) {
+	t.Run("the writer couples its family-handle window to the metrix descriptor window", func(t *testing.T) {
+		store := metrix.NewCollectorStore() // expire=10, grace=10 -> window=20
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		require.NotNil(t, w.retention, "a metrix store must expose DescriptorRetention")
+		require.Equal(t, uint64(20), w.window)
+	})
+
+	t.Run("a name idle past the descriptor window is evicted and re-registers with a changed type", func(t *testing.T) {
+		store := metrix.NewCollectorStore()
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		cc := cycle(t, store)
+		window := int(store.(metrix.DescriptorRetention).DescriptorRetentionWindow())
+
+		cc.BeginCycle()
+		require.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 1\n")))
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		// foo absent for longer than the descriptor window while the endpoint stays up (keepalive
+		// keeps the writer reconciling); metrix evicts foo's gauge descriptor and the writer evicts
+		// its family handle in lockstep.
+		for range window + 2 {
+			cc.BeginCycle()
+			w.writeMetricFamilies(scrape(t, "# TYPE ka gauge\nka 1\n"))
+			require.NoError(t, cc.CommitCycleSuccess())
+		}
+		require.NotContains(t, w.handles, "foo", "the family handle must be evicted after the descriptor window")
+
+		// foo reappears as a counter; both the metrix descriptor and the writer handle are gone, so
+		// it re-registers cleanly instead of being drift-skipped forever.
+		cc.BeginCycle()
+		assert.NotPanics(t, func() {
+			assert.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo counter\nfoo 5\n")),
+				"a name idle past the window must re-register with its new type")
+		})
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		v, ok := store.Read(metrix.ReadRaw()).Value("foo", nil)
+		require.True(t, ok, "the re-registered counter must be readable")
+		require.Equal(t, metrix.SampleValue(5), v)
+	})
+
+	t.Run("a never-accepted handle from an aborted commit does not drift-skip the next scrape", func(t *testing.T) {
+		store := metrix.NewCollectorStore()
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		cc := cycle(t, store)
+
+		// foo scraped as a gauge but the cycle ABORTS: metrix never commits the descriptor and the
+		// staged family handle was never accepted.
+		cc.BeginCycle()
+		w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 1\n"))
+		cc.AbortCycle()
+
+		// foo reappears as a counter; the bogus never-accepted gauge handle must be cleared, not used
+		// to drift-skip the counter.
+		cc.BeginCycle()
+		assert.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo counter\nfoo 5\n")),
+			"a bogus handle from an aborted commit must not drift-skip the next scrape")
+		require.NoError(t, cc.CommitCycleSuccess())
+	})
+
+	t.Run("a previously accepted handle survives an aborted re-touch", func(t *testing.T) {
+		store := metrix.NewCollectorStore()
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		cc := cycle(t, store)
+
+		cc.BeginCycle()
+		require.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 1\n")))
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		// foo re-scraped but the cycle aborts; foo was already accepted, so its handle must survive.
+		cc.BeginCycle()
+		w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 2\n"))
+		cc.AbortCycle()
+
+		cc.BeginCycle()
+		assert.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 3\n")),
+			"a previously accepted handle must survive an aborted re-touch")
+		require.NoError(t, cc.CommitCycleSuccess())
+		require.Contains(t, w.handles, "foo")
+	})
+
+	t.Run("a summary whose series all drift is not refreshed forever and re-adopts the new quantiles", func(t *testing.T) {
+		store := metrix.NewCollectorStore()
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		cc := cycle(t, store)
+		window := int(store.(metrix.DescriptorRetention).DescriptorRetentionWindow())
+
+		cc.BeginCycle()
+		require.Equal(t, 1, w.writeMetricFamilies(scrape(t,
+			"# TYPE app_lat summary\napp_lat{quantile=\"0.5\"} 1\napp_lat_sum 1\napp_lat_count 1\n")))
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		// app_lat now only ever exposes {0.5,0.9}: every series is schema-drift-skipped while the old
+		// {0.5} descriptor is live. The bug was that staging on type-match kept the handle alive forever;
+		// with the fix the zero-writing family ages out and re-adopts the new quantile set.
+		drift := "# TYPE app_lat summary\napp_lat{quantile=\"0.5\"} 1\napp_lat{quantile=\"0.9\"} 2\napp_lat_sum 3\napp_lat_count 2\n"
+		reAdopted := false
+		for range window * 2 {
+			cc.BeginCycle()
+			if w.writeMetricFamilies(scrape(t, drift)) > 0 {
+				reAdopted = true
+			}
+			require.NoError(t, cc.CommitCycleSuccess())
+		}
+		require.True(t, reAdopted, "a fully-drifting family must re-adopt its new schema after the window, not drift-skip forever")
+		require.Contains(t, w.handles, "app_lat")
+		require.Equal(t, []float64{0.5, 0.9}, w.handles["app_lat"].summaryQuantiles, "the handle now carries the new quantile set")
+	})
+
+	t.Run("a histogram whose series all drift is not refreshed forever and re-adopts the new bounds", func(t *testing.T) {
+		store := metrix.NewCollectorStore()
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		cc := cycle(t, store)
+		window := int(store.(metrix.DescriptorRetention).DescriptorRetentionWindow())
+
+		cc.BeginCycle()
+		require.Equal(t, 1, w.writeMetricFamilies(scrape(t,
+			"# TYPE app_lat histogram\napp_lat_bucket{le=\"0.1\"} 1\napp_lat_bucket{le=\"0.5\"} 2\napp_lat_bucket{le=\"+Inf\"} 2\napp_lat_sum 1\napp_lat_count 2\n")))
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		// app_lat now only ever exposes a different bucket schema: skipped while the old descriptor is
+		// live, then aged out and re-adopted with the new bounds.
+		drift := "# TYPE app_lat histogram\napp_lat_bucket{le=\"0.1\"} 1\napp_lat_bucket{le=\"0.5\"} 2\napp_lat_bucket{le=\"1\"} 3\napp_lat_bucket{le=\"+Inf\"} 3\napp_lat_sum 5\napp_lat_count 3\n"
+		reAdopted := false
+		for range window * 2 {
+			cc.BeginCycle()
+			if w.writeMetricFamilies(scrape(t, drift)) > 0 {
+				reAdopted = true
+			}
+			require.NoError(t, cc.CommitCycleSuccess())
+		}
+		require.True(t, reAdopted, "a fully-drifting histogram must re-adopt its new schema after the window, not drift-skip forever")
+		require.Contains(t, w.handles, "app_lat")
+		require.Equal(t, []float64{0.1, 0.5, 1}, w.handles["app_lat"].histogramBounds, "the handle now carries the new bucket bounds")
+	})
+
+	t.Run("with series expiry disabled the window is unbounded and handles are never evicted", func(t *testing.T) {
+		store := metrix.NewCollectorStore(metrix.WithExpireAfterSuccessCycles(0))
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		require.Equal(t, metrix.DescriptorRetentionUnbounded, w.window)
+		cc := cycle(t, store)
+
+		cc.BeginCycle()
+		require.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 1\n")))
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		for range 50 {
+			cc.BeginCycle()
+			w.writeMetricFamilies(scrape(t, "# TYPE ka gauge\nka 1\n"))
+			require.NoError(t, cc.CommitCycleSuccess())
+		}
+		require.Contains(t, w.handles, "foo", "an unbounded window must never evict the family handle")
+	})
+
+	t.Run("at a tight window a drifting name is kept until the boundary then re-registers", func(t *testing.T) {
+		store := metrix.NewCollectorStore(metrix.WithExpireAfterSuccessCycles(2), metrix.WithDescriptorGraceCycles(0))
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		require.Equal(t, uint64(2), w.window)
+		cc := cycle(t, store)
+
+		cc.BeginCycle()
+		require.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 1\n")))
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		// foo now drifts to a counter every cycle. While the gauge descriptor is within its window the
+		// counter is drift-skipped (0); once the handle ages out at the boundary it re-registers (1),
+		// then stays. This pins the exact >= window boundary, not just eventual re-adoption.
+		drift := "# TYPE foo counter\nfoo 5\n"
+		var writtenPerCycle []int
+		for range 4 {
+			cc.BeginCycle()
+			writtenPerCycle = append(writtenPerCycle, w.writeMetricFamilies(scrape(t, drift)))
+			require.NoError(t, cc.CommitCycleSuccess())
+		}
+		require.Equal(t, []int{0, 0, 1, 1}, writtenPerCycle,
+			"drift-skipped within the window, re-registered at the boundary, then stable")
+	})
+
+	t.Run("a scalar family that becomes all-unwritable ages out instead of refreshing", func(t *testing.T) {
+		store := metrix.NewCollectorStore()
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		cc := cycle(t, store)
+		window := int(store.(metrix.DescriptorRetention).DescriptorRetentionWindow())
+
+		cc.BeginCycle()
+		require.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 1\n")))
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		// foo keeps appearing but only ever as NaN, which is not a writable scalar: zero series write,
+		// so the handle must not refresh and must age out (a keepalive family keeps the endpoint up).
+		nan := "# TYPE foo gauge\nfoo NaN\n# TYPE ka gauge\nka 1\n"
+		for range window + 2 {
+			cc.BeginCycle()
+			w.writeMetricFamilies(scrape(t, nan))
+			require.NoError(t, cc.CommitCycleSuccess())
+		}
+		require.NotContains(t, w.handles, "foo", "an all-unwritable family must age out, not refresh forever")
+	})
+
+	t.Run("with no descriptor-retention accessor, family handles are kept (fallback)", func(t *testing.T) {
+		store := metrix.NewCollectorStore()
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		w.retention = nil // simulate a store that does not expose the optional accessor
+		cc := cycle(t, store)
+
+		cc.BeginCycle()
+		require.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 1\n")))
+		require.NoError(t, cc.CommitCycleSuccess())
+
+		for range 50 {
+			cc.BeginCycle()
+			w.writeMetricFamilies(scrape(t, "# TYPE ka gauge\nka 1\n"))
+			require.NoError(t, cc.CommitCycleSuccess())
+		}
+		require.Contains(t, w.handles, "foo", "with no accessor, reconcile must keep handles")
+	})
+}

--- a/src/go/plugin/go.d/collector/prometheus/writer_lifecycle_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_lifecycle_test.go
@@ -218,10 +218,15 @@ func TestMetricFamilyWriterHandleLifecycle(t *testing.T) {
 	})
 
 	t.Run("with no descriptor-retention accessor, family handles are kept (fallback)", func(t *testing.T) {
-		store := metrix.NewCollectorStore()
+		// A CollectorStore that genuinely does not expose DescriptorRetention, so this exercises
+		// newMetricFamilyWriter's real constructor fallback rather than mutating the writer after.
+		real := metrix.NewCollectorStore()
+		store := &noRetentionStore{CollectorStore: real}
 		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
-		w.retention = nil // simulate a store that does not expose the optional accessor
-		cc := cycle(t, store)
+		require.Nil(t, w.retention, "constructor must not resolve the optional accessor")
+		require.Equal(t, metrix.DescriptorRetentionUnbounded, w.window, "fallback window must be unbounded")
+
+		cc := cycle(t, real) // controls the same core the wrapper's Write() delegates to
 
 		cc.BeginCycle()
 		require.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 1\n")))
@@ -234,4 +239,11 @@ func TestMetricFamilyWriterHandleLifecycle(t *testing.T) {
 		}
 		require.Contains(t, w.handles, "foo", "with no accessor, reconcile must keep handles")
 	})
+}
+
+// noRetentionStore is a metrix.CollectorStore that deliberately does NOT expose the optional
+// DescriptorRetention accessor: embedding the interface promotes only Read/Write, so a type
+// assertion to DescriptorRetention fails. It exercises the writer's no-accessor fallback path.
+type noRetentionStore struct {
+	metrix.CollectorStore
 }

--- a/src/go/plugin/go.d/collector/prometheus/writer_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_test.go
@@ -419,7 +419,7 @@ app_lat_count{id="b"} 3
 		assert.Len(t, w.handles["app_g"].gauges, 1, "stale series handle must be evicted, leaving only the active one")
 	})
 
-	t.Run("reappearing metric name with a changed type is skipped, never re-registered (no panic)", func(t *testing.T) {
+	t.Run("a reappearing name within the descriptor window with a changed type is drift-skipped (no panic)", func(t *testing.T) {
 		store := metrix.NewCollectorStore()
 		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
 		cc := cycle(t, store)
@@ -428,24 +428,25 @@ app_lat_count{id="b"} 3
 		require.Equal(t, 1, w.writeMetricFamilies(scrape(t, "# TYPE foo gauge\nfoo 1\n")))
 		require.NoError(t, cc.CommitCycleSuccess())
 
-		// foo is absent well beyond the per-series retention window; its series handle is evicted, but
-		// the family handle is kept.
-		for range seriesCacheRetentionCycles + 5 {
+		// foo is absent but the endpoint stays up (a keepalive family keeps the writer reconciling)
+		// for fewer cycles than the descriptor window, so metrix still holds foo's gauge descriptor.
+		for range seriesCacheRetentionCycles {
 			cc.BeginCycle()
+			w.writeMetricFamilies(scrape(t, "# TYPE ka gauge\nka 1\n"))
 			require.NoError(t, cc.CommitCycleSuccess())
 		}
 
-		// foo reappears as a counter. metrix's descriptor for "foo" is a permanent gauge, so
-		// re-registering it as a counter would panic; the kept handle must detect the drift and skip.
+		// foo reappears as a counter while its gauge descriptor is still live: writing a conflicting
+		// kind would fail the metrix commit, so the kept handle must detect the drift and skip.
 		cc.BeginCycle()
 		assert.NotPanics(t, func() {
 			assert.Equal(t, 0, w.writeMetricFamilies(scrape(t, "# TYPE foo counter\nfoo 5\n")),
-				"a reappearing name with a changed type must be skipped")
+				"a reappearing name whose descriptor is still live must be drift-skipped")
 		})
 		require.NoError(t, cc.CommitCycleSuccess())
 	})
 
-	t.Run("reappearing metric name with changed summary quantiles is skipped (no panic)", func(t *testing.T) {
+	t.Run("a reappearing name within the descriptor window with changed summary quantiles is drift-skipped (no panic)", func(t *testing.T) {
 		store := metrix.NewCollectorStore()
 		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
 		cc := cycle(t, store)
@@ -455,19 +456,21 @@ app_lat_count{id="b"} 3
 			"# TYPE app_lat summary\napp_lat{quantile=\"0.5\"} 1\napp_lat_sum 1\napp_lat_count 1\n")))
 		require.NoError(t, cc.CommitCycleSuccess())
 
-		// app_lat absent beyond the per-series retention window (series handle evicted, family handle kept).
-		for range seriesCacheRetentionCycles + 5 {
+		// app_lat absent for fewer cycles than the descriptor window (keepalive keeps the writer
+		// reconciling), so metrix still holds its summary descriptor fixed to {0.5}.
+		for range seriesCacheRetentionCycles {
 			cc.BeginCycle()
+			w.writeMetricFamilies(scrape(t, "# TYPE ka gauge\nka 1\n"))
 			require.NoError(t, cc.CommitCycleSuccess())
 		}
 
-		// app_lat reappears with a different quantile set. metrix's summary descriptor for "app_lat" is
-		// fixed to {0.5}; observing {0.5,0.9} would panic, so the kept handle must skip the drifted series.
+		// app_lat reappears with a different quantile set while its descriptor is still live; the
+		// off-schema series must be drift-skipped rather than fail the commit.
 		cc.BeginCycle()
 		assert.NotPanics(t, func() {
 			assert.Equal(t, 0, w.writeMetricFamilies(scrape(t,
 				"# TYPE app_lat summary\napp_lat{quantile=\"0.5\"} 1\napp_lat{quantile=\"0.9\"} 2\napp_lat_sum 3\napp_lat_count 2\n")),
-				"a reappearing summary with a changed quantile set must be skipped")
+				"a reappearing summary with a changed quantile set must be drift-skipped while live")
 		})
 		require.NoError(t, cc.CommitCycleSuccess())
 	})


### PR DESCRIPTION
##### Summary

Closes #22648.

`metrix` stores one descriptor per metric name. Until now, those descriptors have been kept for the entire life of the process. Fine for fixed collectors, but unbounded for push/client-driven metric names (statsd). This makes the descriptor lifecycle bounded, the prerequisite for a push-based statsd collector.

| | Before | After |
|---|---|---|
| Descriptor lifetime | Kept forever, even after the metric stops being collected | Kept while in use, evicted after the metric goes idle |
| Unbounded metric-name streams | Grew memory without limit | Stay bounded |
| A name that changes shape (e.g. gauge → counter) | Could conflict permanently | Handled cleanly once the old one goes idle |
| Existing collectors | — | Unaffected: API is backward-compatible; only long-idle metrics change behavior |

After:

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded, transactional descriptor lifecycle in `metrix` with commit-time resolution, plus Prometheus writer handles coupled to the descriptor window. Prevents unbounded growth for push/client-driven names and allows clean re-register when a name’s contract changes after going idle.

- **New Features**
  - Per-name descriptors are transactional and bounded: staged per cycle, resolved at commit, kept while used, swept after expire+grace successful commits.
  - Commit-time conflict policy: live conflicts fail the commit; idle/in-grace kinds are superseded; ambiguous new names are dropped for the cycle (no partial publish).
  - `NewCollectorStore(...)` adds `WithExpireAfterSuccessCycles`, `WithMaxSeries`, `WithDescriptorGraceCycles` (grace defaults to expire).
  - Optional `DescriptorRetention` exposes the retention window and successful-commit clock; the Prometheus writer now ages its family handles to that window, only promotes handles on successful commits, and falls back to keep handles if the accessor isn’t available.
  - Snapshot histograms with nil bounds adopt observed bounds on write; consistency is enforced at commit.
  - New `CollectMeta` counters: `EvictedDescriptors`, `DroppedNames`.

- **Migration**
  - No API changes required; existing collectors keep working. Descriptors are no longer permanent: a fully idle name evicts after expire+grace and can re-register with a new contract.
  - Consumers that cache per-name state can optionally assert `DescriptorRetention` and align their cache window to `expire+grace` for fewer drift-skips and clean re-registers.

<sup>Written for commit e1948d787753406b0250a00962cc7a73e27dadd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

