### PR TITLE
docs(agents): workflow lessons + SOW friction-tracking

### DIFF
--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -135,6 +135,16 @@ Open decisions:
 
 - <files touched, decisions, deviations, reviewers>
 
+## Workflow Friction & Rule Gaps
+
+Running capture of anything that suggests a rule or workflow change: a rule that
+was missing, ambiguous, or slowed the work; a practice worth codifying; a review
+pattern that helped. Jot entries as they happen — do not reconstruct them from
+memory at close. Every entry is triaged before completion (see the Artifact
+Maintenance Gate).
+
+- <observation + which artifact it may touch (AGENTS.md / project skill / spec / SOW template)>
+
 ## Validation
 
 Acceptance criteria evidence:
@@ -169,6 +179,7 @@ Sensitive data gate:
 - End-user/operator docs: <updated docs/runbooks/help paths or evidence-backed reason none were affected>
 - End-user/operator skills: <updated output/reference skill paths or evidence-backed reason none were affected>
 - SOW lifecycle: <durable knowledge transferred to skills/docs/code/tests; follow-ups moved to GitHub issues or rejected; `Status: completed` set; SOW working file is local-only under .agents/sow/q/ and never committed; regression-as-new-SOW handling recorded>
+- Workflow friction triaged: <each `Workflow Friction & Rule Gaps` entry resolved to a rule update (file + change), an evidence-backed rejection, or a tracked follow-up; "no workflow friction arose" if the section is empty>
 
 Specs update:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,11 @@ and edge cases):**
      evidence, or a linked GitHub issue) before an earlier stage merges. A
      self-certified "a later stage will finish it" with no tracked item is not
      acceptable.
+   - Re-ground staged designs: a design recorded during planning or an earlier
+     stage MAY have drifted from the code a previous stage produced (a removed
+     structure, an obsoleted mechanism). Before implementing a later stage you
+     MUST re-verify its recorded design against the current code and record the
+     correction in the SOW; never implement against stale assumptions.
    - Deferral check: before recommending deferral, check the issue, SOW,
      acceptance criteria, and affected migration scope. Silence or ambiguity MUST
      NOT be read as permission to defer; if those sources do not clearly place

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -707,6 +707,7 @@ A SOW cannot be completed until Validation records:
 - end-user/operator docs update or evidence-backed reason none were affected;
 - end-user/operator skill update or evidence-backed reason none were affected by docs/spec changes;
 - lessons extracted or specific reason there were none;
+- workflow-friction triage: each recorded `Workflow Friction & Rule Gaps` note resolved to a rule update (`AGENTS.md`, project skill, spec, or SOW template), an evidence-backed rejection, or a tracked follow-up (or an explicit "none arose");
 - follow-up mapping.
 
 Generic "N/A" is invalid.

--- a/src/go/AGENTS.md
+++ b/src/go/AGENTS.md
@@ -91,15 +91,60 @@ topology, tests, specs, or skills.
 
 ## Core Framework Change Gate
 
-Changes to shared Go framework code are high-blast-radius work. Before changing
-these areas, read `src/go/plugin/framework/docs/changing-framework-code.md`.
-That guide is the canonical owner of the framework-change scope list, required
-design note, validation expectations, and artifact checks.
+Changes to shared Go framework code (`metrix`, `chartengine`, `charttpl`, the job
+runtime, `collectorapi`) are high-blast-radius: this code runs in EVERY collector,
+most of it on the per-cycle hot path. Before changing these areas, read
+`src/go/plugin/framework/docs/changing-framework-code.md` — the canonical owner of
+the framework-change scope list, required design note, validation expectations, and
+artifact checks. Implementation MUST NOT begin until that guide's applicable
+approval tier is satisfied.
 
-Framework-change implementation MUST NOT begin until the applicable approval
-tier in that guide is satisfied. You SHOULD prefer a clean framework extension
-over collector-local glue, global variables, or private package coupling when
-the problem is general.
+- Clean extension over glue: prefer a clean framework extension over
+  collector-local globals, singletons, adapters, or private-package coupling when
+  the problem is general.
+- Behavior preservation: when a framework change also touches shipped collectors,
+  preserve their observable behavior (chart IDs, contexts, dimensions, config keys,
+  defaults) and validate representative consumers, not only the framework package
+  (see "Validation For Go Changes").
+- metrix contract: `metrix` keeps one descriptor per metric NAME, resolved
+  atomically at commit and bounded — a name idle past `expireAfterSuccessCycles +
+  descriptorGraceCycles` is evicted, and re-registers cleanly afterward. A consumer
+  that caches per-name state across cycles MUST couple its lifetime to the optional
+  `metrix.DescriptorRetention` accessor. See `src/go/pkg/metrix/README.md`
+  ("Descriptor Lifecycle and Retention").
+
+## Hot-Path And Benchmark Discipline
+
+metrix commit/collect, per-sample/per-write, and per-cycle code are hot paths that
+run for every collector on every cycle.
+
+- Before/after REQUIRED: a hot-path change MUST include before/after
+  `go test -bench` numbers (use `git stash` for the "before" baseline), not just
+  "tests pass".
+- Allocation count is the gate: assert allocs stay within the intended envelope
+  (e.g. a sparse commit stays ~O(touched), never O(retained)). `ns/op` is a
+  dev-machine trend indicator, NOT a CI gate — label it as such inline, and never
+  record a personal name in the file.
+- State the complexity envelope explicitly (e.g. "commit is O(live-series +
+  touched + distinct-names)") and prove the change did not introduce an
+  O(samples)/O(retained)/O(n^2) regression.
+- Keep bench comments in sync with the code they measure, in the same change, with
+  self-contained wording (no round/session references).
+
+## Validation For Go Changes
+
+Run the narrowest command that actually exercises the change; do not claim
+full-project validation from a narrow one.
+
+- Always: `gofmt` clean and `go vet ./<pkg>/` clean.
+- Unit: `go test -count=1 ./<pkg>/...` for every package you touched.
+- Concurrency: add `-race` for concurrency-sensitive packages (`metrix`, the job
+  runtime, `plugin/agent/jobmgr`).
+- Shared framework code: ALSO build and test representative consumers (a couple of
+  real collectors) plus `-race ./plugin/agent/jobmgr/`, so a framework change is
+  proven against real users, not just its own package.
+- Reproduce a reviewer-reported bug as a FAILING test first, then fix to green
+  (repo-wide working-style rule).
 
 ## Batching And Review
 
@@ -111,4 +156,7 @@ the problem is general.
 - Changes MUST NOT mix framework changes, collector migrations, and
   integration-doc regeneration unless they are required for one coherent
   behavior change.
+- Multi-round review: checkpoint-commit each validated change before its review and
+  squash at PR time; if findings keep clustering in one subsystem (~2-3 rounds),
+  stop patching and fix the class (repo-wide review rules).
 - For Go test style, follow the repo-root `AGENTS.md` "Go test style" section.


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a running “Workflow Friction & Rule Gaps” log to SOWs and requires triage before close. Tightens Go framework-change rules with hot-path benchmarks, validation steps, and behavior preservation for shipped collectors.

- New Features
  - SOW template: added “Workflow Friction & Rule Gaps” section; each entry must be resolved (rule update, evidence-backed rejection, or tracked follow-up) before completion.
  - AGENTS.md: added workflow-friction triage to the Validation Gate; new “Re-ground staged designs” rule to prevent building against stale plans.
  - src/go/AGENTS.md: expanded Core Framework Change Gate, naming hot-path packages (`metrix`, `chartengine`, `charttpl`, job runtime, `collectorapi`) and requiring preserved behavior for existing collectors.
  - Hot-path discipline: require before/after `go test -bench` numbers, allocations as the gating metric, explicit complexity envelopes, and in-sync bench comments; checkpoint-commit validated changes and prefer class fixes when review findings cluster.
  - Validation steps for Go: `gofmt`/`go vet`, `go test -count=1`, `-race` for concurrency-sensitive packages, build/test representative consumers for framework changes, and reproduce reported bugs as failing tests first.

<sup>Written for commit bff5b63ad1c96524427c2980414b15a40bad9783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

