### PR TITLE
Netdata fixes part 53

### DIFF
--- a/src/collectors/apps.plugin/apps_os_freebsd.c
+++ b/src/collectors/apps.plugin/apps_os_freebsd.c
@@ -79,15 +79,20 @@ bool apps_os_read_pid_fds_freebsd(struct pid_stat *p, void *ptr) {
 
     bfdsbuf = fdsbuf;
     efdsbuf = fdsbuf + size;
-    while (bfdsbuf < efdsbuf) {
+    while ((size_t)(efdsbuf - bfdsbuf) >= sizeof(((struct kinfo_file *)0)->kf_structsize)) {
         fds = (struct kinfo_file *)(uintptr_t)bfdsbuf;
-        if (unlikely(fds->kf_structsize == 0))
+        if (unlikely(fds->kf_structsize <= 0))
+            break;
+
+        size_t kf_structsize = (size_t)fds->kf_structsize;
+        if (unlikely(kf_structsize <= offsetof(struct kinfo_file, kf_path) ||
+                     kf_structsize > (size_t)(efdsbuf - bfdsbuf)))
             break;
 
         // do not process file descriptors for current working directory, root directory,
         // jail directory, ktrace vnode, text vnode and controlling terminal
         if (unlikely(fds->kf_fd < 0)) {
-            bfdsbuf += fds->kf_structsize;
+            bfdsbuf += kf_structsize;
             continue;
         }
 
@@ -178,7 +183,7 @@ bool apps_os_read_pid_fds_freebsd(struct pid_stat *p, void *ptr) {
         else
             p->fds[fdid].fd = -p->fds[fdid].fd;
 
-        bfdsbuf += fds->kf_structsize;
+        bfdsbuf += kf_structsize;
     }
 
     return true;

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -2,7 +2,7 @@
 
 #include "windows_plugin.h"
 
-char windows_shared_buffer[8192];
+__thread char windows_shared_buffer[8192];
 
 static struct proc_module {
     const char *name;

--- a/src/collectors/windows.plugin/windows_plugin.h
+++ b/src/collectors/windows.plugin/windows_plugin.h
@@ -21,7 +21,7 @@
 
 void win_plugin_main(void *ptr);
 
-extern char windows_shared_buffer[8192];
+extern __thread char windows_shared_buffer[8192];
 
 // Windows API
 int do_GetSystemUptime(int update_every, usec_t dt);

--- a/src/libnetdata/local-sockets/local-sockets-freebsd.h
+++ b/src/libnetdata/local-sockets/local-sockets-freebsd.h
@@ -336,16 +336,21 @@ static inline void local_sockets_freebsd_enumerate_pids(
         char *p   = fdbuf;
         char *efdbuf = fdbuf + fd_size;
 
-        while (p < efdbuf) {
+        while ((size_t)(efdbuf - p) >= sizeof(((struct kinfo_file *)0)->kf_structsize)) {
             struct kinfo_file *kf = (struct kinfo_file *)p;
-            if (kf->kf_structsize == 0) break;
+            if (kf->kf_structsize <= 0) break;
+
+            size_t kf_structsize = (size_t)kf->kf_structsize;
+            if (kf_structsize < offsetof(struct kinfo_file, kf_path) ||
+                kf_structsize > (size_t)(efdbuf - p))
+                break;
 
             // Only care about internet sockets owned by a FD (fd >= 0).
             if (kf->kf_fd < 0 ||
                 kf->kf_type != KF_TYPE_SOCKET ||
                 (kf->kf_sock_domain != AF_INET && kf->kf_sock_domain != AF_INET6) ||
                 (kf->kf_sock_protocol != IPPROTO_TCP && kf->kf_sock_protocol != IPPROTO_UDP)) {
-                p += kf->kf_structsize;
+                p += kf_structsize;
                 continue;
             }
 
@@ -362,7 +367,7 @@ static inline void local_sockets_freebsd_enumerate_pids(
             };
 
             if (!local_sockets_freebsd_fill_endpoint(&n.local, sa_local, kf->kf_sock_protocol)) {
-                p += kf->kf_structsize;
+                p += kf_structsize;
                 continue;
             }
 
@@ -381,7 +386,7 @@ static inline void local_sockets_freebsd_enumerate_pids(
                 n.inode = KF_SOCK_PCB_UDP(kf);
 
             if (!n.inode) {
-                p += kf->kf_structsize;
+                p += kf_structsize;
                 continue;
             }
 
@@ -448,7 +453,7 @@ static inline void local_sockets_freebsd_enumerate_pids(
 
             local_sockets_add_socket(ls, &n);
 
-            p += kf->kf_structsize;
+            p += kf_structsize;
         }
 
         freez(fdbuf);

--- a/src/libnetdata/os/windows-perflib/perflib-names.c
+++ b/src/libnetdata/os/windows-perflib/perflib-names.c
@@ -12,6 +12,11 @@ typedef struct perflib_registry {
     char *help;
 } perfLibRegistryEntry;
 
+typedef struct perflib_retired_string {
+    char *value;
+    struct perflib_retired_string *next;
+} perfLibRetiredString;
+
 static inline bool compare_perfLibRegistryEntry(const char *k1, const char *k2) {
     return strcmp(k1, k2) == 0;
 }
@@ -35,6 +40,7 @@ static struct {
     struct simple_hashtable_PERFLIB hashtable;
     FILETIME lastWriteTime;
     PERFLIB_ENTRIES_JudyLSet registry_entries;
+    perfLibRetiredString *retired_strings;
 } names_globals = {
     .spinlock = SPINLOCK_INITIALIZER,
 };
@@ -61,6 +67,16 @@ static inline perfLibRegistryEntry* registry_ensure_entry(DWORD id) {
     }
     
     return entry;
+}
+
+static inline void RegistryRetireString_unsafe(char *value) {
+    if(!value)
+        return;
+
+    perfLibRetiredString *retired = mallocz(sizeof(*retired));
+    retired->value = value;
+    retired->next = names_globals.retired_strings;
+    names_globals.retired_strings = retired;
 }
 
 DWORD RegistryFindIDByName(const char *name) {
@@ -95,7 +111,7 @@ static void RegistrySetData_unsafe(DWORD id, const char *key, const char *help) 
         if(entry->key) {
             // Only if the key actually changes, we need to update hash
             if(strcmp(entry->key, key) != 0) {
-                freez(entry->key);
+                RegistryRetireString_unsafe(entry->key);
                 entry->key = strdupz(key);
                 add_to_hash = true;
             }
@@ -107,9 +123,14 @@ static void RegistrySetData_unsafe(DWORD id, const char *key, const char *help) 
     }
 
     if(help) {
-        if(entry->help)
-            freez(entry->help);
-        entry->help = strdupz(help);
+        if(entry->help) {
+            if(strcmp(entry->help, help) != 0) {
+                RegistryRetireString_unsafe(entry->help);
+                entry->help = strdupz(help);
+            }
+        }
+        else
+            entry->help = strdupz(help);
     }
 
     entry->id = id;
@@ -331,6 +352,15 @@ static void free_registry_entry(Word_t idx, perfLibRegistryEntry *entry, void *d
     }
 }
 
+static void free_retired_strings_unsafe(void) {
+    while(names_globals.retired_strings) {
+        perfLibRetiredString *retired = names_globals.retired_strings;
+        names_globals.retired_strings = retired->next;
+        freez(retired->value);
+        freez(retired);
+    }
+}
+
 // Cleanup function to be called during shutdown to free allocated resources
 void PerflibNamesRegistryCleanup(void) {
     spinlock_lock(&names_globals.spinlock);
@@ -340,6 +370,8 @@ void PerflibNamesRegistryCleanup(void) {
     
     // Free the hashtable
     simple_hashtable_destroy_PERFLIB(&names_globals.hashtable);
+
+    free_retired_strings_unsafe();
     
     spinlock_unlock(&names_globals.spinlock);
 }

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -862,6 +862,11 @@ bool stream_receiver_receive_data(struct stream_thread *sth, struct receiver_sta
     internal_fatal(sth->tid != gettid_cached(), "Function %s() should only be used by the dispatcher thread", __FUNCTION__ );
 
     PARSER *parser = __atomic_load_n(&rpt->thread.parser, __ATOMIC_RELAXED);
+    if(unlikely(!parser)) {
+        stream_receiver_remove(sth, rpt, STREAM_HANDSHAKE_RCV_DISCONNECT_PARSER_FAILED);
+        return false;
+    }
+
     ND_LOG_STACK lgs[] = {
         ND_LOG_FIELD_CB(NDF_REQUEST, line_splitter_reconstruct_line, &parser->line),
         ND_LOG_FIELD_CB(NDF_NIDL_NODE, parser_reconstruct_node, parser),


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses memory safety and concurrency issues across FreeBSD, Windows, and streaming to improve stability and prevent rare crashes. Adds bounds checks for FreeBSD walkers, makes a Windows scratch buffer thread-local, defers perflib string frees, and guards a NULL parser in the streaming receiver.

- **Bug Fixes**
  - FreeBSD: validate `kinfo_file` record size and bounds in apps and local-sockets walkers; advance by checked size to prevent over-reads.
  - Windows plugin: make `windows_shared_buffer` thread-local to eliminate cross-thread data races.
  - Windows perflib: retire replaced registry strings and free them during cleanup to avoid use-after-free on refresh.
  - Streaming: NULL-guard the parser after atomic load in `stream_receiver_receive_data()` and remove the receiver if missing.

<sup>Written for commit 69c019f26f94744f660b2bdf9f8d126bf8b4f34a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

