### PR TITLE
fix(database): guard null root index in rrdset_find_and_acquire

### DIFF
--- a/src/database/rrdset-index-id.c
+++ b/src/database/rrdset-index-id.c
@@ -365,6 +365,9 @@ RRDSET *rrdset_find_bytype(RRDHOST *host, const char *type, const char *id, bool
 RRDSET_ACQUIRED *rrdset_find_and_acquire(RRDHOST *host, const char *id, bool include_obsolete) {
     netdata_log_debug(D_RRD_CALLS, "rrdset_find_and_acquire() for host %s, chart %s", rrdhost_hostname(host), id);
 
+    if (unlikely(!host->rrdset_root_index))
+        return NULL;
+
     RRDSET_ACQUIRED *sta = (RRDSET_ACQUIRED *)dictionary_get_and_acquire_item(host->rrdset_root_index, id);
     if(sta) {
         RRDSET *st = dictionary_acquired_item_value((const DICTIONARY_ITEM *)sta);


### PR DESCRIPTION
##### Summary
- Add NULL check to prevent potential crash on archived hosts


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash when acquiring a chart on archived or uninitialized hosts. `rrdset_find_and_acquire` now returns NULL if `host->rrdset_root_index` is missing.

<sup>Written for commit dc666f55bb343bcc893295e775ad397da6b47a01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

