### PR TITLE
Netdata fixes part 54

### DIFF
--- a/src/database/contexts/api_v2_contexts_agents.c
+++ b/src/database/contexts/api_v2_contexts_agents.c
@@ -4,6 +4,7 @@
 #include "aclk/aclk_capas.h"
 #include "database/rrd-metadata.h"
 #include "database/rrd-retention.h"
+#include "web/api/http_auth.h"
 
 void build_info_to_json_object(BUFFER *b);
 
@@ -72,7 +73,7 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
         buffer_json_member_add_object(wb, "api");
         {
             buffer_json_member_add_uint64(wb, "version", aclk_get_http_api_version());
-            buffer_json_member_add_boolean(wb, "bearer_protection", netdata_is_protected_by_bearer);
+            buffer_json_member_add_boolean(wb, "bearer_protection", netdata_bearer_protection_is_enabled());
         }
         buffer_json_object_close(wb); // api
 

--- a/src/database/rrdset-index-name.c
+++ b/src/database/rrdset-index-name.c
@@ -119,3 +119,22 @@ RRDSET *rrdset_find_byname(RRDHOST *host, const char *name) {
 
     return(st);
 }
+
+RRDSET_ACQUIRED *rrdset_find_byname_and_acquire(RRDHOST *host, const char *name) {
+    if (unlikely(!host->rrdset_root_index_name))
+        return NULL;
+
+    const DICTIONARY_ITEM *name_item = dictionary_get_and_acquire_item(host->rrdset_root_index_name, name);
+    if (!name_item)
+        return NULL;
+
+    RRDSET *st = dictionary_acquired_item_value(name_item);
+    RRDSET_ACQUIRED *rsa = NULL;
+
+    if (st && rrdset_is_discoverable(st))
+        rsa = rrdset_find_and_acquire(host, rrdset_id(st), false);
+
+    dictionary_acquired_item_release(host->rrdset_root_index_name, name_item);
+
+    return rsa;
+}

--- a/src/database/rrdset-index-name.h
+++ b/src/database/rrdset-index-name.h
@@ -13,6 +13,7 @@ void rrdset_index_del_name(RRDHOST *host, RRDSET *st);
 
 extern RRDHOST *localhost;
 RRDSET *rrdset_find_byname(RRDHOST *host, const char *name);
+RRDSET_ACQUIRED *rrdset_find_byname_and_acquire(RRDHOST *host, const char *name);
 #define rrdset_find_byname_localhost(name)  rrdset_find_byname(localhost, name)
 
 /* This will not return charts that are archived */

--- a/src/libnetdata/socket/security.c
+++ b/src/libnetdata/socket/security.c
@@ -549,7 +549,9 @@ NETDATA_SSL_HANDSHAKE_RESULT netdata_ssl_accept_nonblocking(NETDATA_SSL *ssl) {
         return NETDATA_SSL_HANDSHAKE_PENDING;
     }
 
+    int saved_errno = errno;
     netdata_ssl_log_error_queue("SSL_accept", ssl, err);
+    errno = saved_errno;
     ssl->state = NETDATA_SSL_STATE_FAILED;
     return NETDATA_SSL_HANDSHAKE_FAILED;
 }

--- a/src/libnetdata/socket/security.c
+++ b/src/libnetdata/socket/security.c
@@ -529,6 +529,31 @@ bool netdata_ssl_accept(NETDATA_SSL *ssl) {
     return true;
 }
 
+NETDATA_SSL_HANDSHAKE_RESULT netdata_ssl_accept_nonblocking(NETDATA_SSL *ssl) {
+    errno = 0;
+    ssl->ssl_errno = 0;
+
+    if(unlikely(!is_handshake_initialized(ssl, "accept")))
+        return NETDATA_SSL_HANDSHAKE_FAILED;
+
+    int ret = SSL_accept(ssl->conn);
+    if(ret == 1) {
+        ssl->state = NETDATA_SSL_STATE_COMPLETE;
+        return NETDATA_SSL_HANDSHAKE_COMPLETE;
+    }
+
+    int err = SSL_get_error(ssl->conn, ret);
+    if(err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+        ssl->ssl_errno = err;
+        errno = EWOULDBLOCK;
+        return NETDATA_SSL_HANDSHAKE_PENDING;
+    }
+
+    netdata_ssl_log_error_queue("SSL_accept", ssl, err);
+    ssl->state = NETDATA_SSL_STATE_FAILED;
+    return NETDATA_SSL_HANDSHAKE_FAILED;
+}
+
 /**
  * Info Callback
  *

--- a/src/libnetdata/socket/security.c
+++ b/src/libnetdata/socket/security.c
@@ -503,38 +503,16 @@ bool netdata_ssl_connect(NETDATA_SSL *ssl) {
     return true;
 }
 
-bool netdata_ssl_accept(NETDATA_SSL *ssl) {
-    errno = 0;
-    ssl->ssl_errno = 0;
-
-    if(unlikely(!is_handshake_initialized(ssl, "accept")))
-        return false;
-
-    SSL_set_accept_state(ssl->conn);
-
-    int err;
-    while ((err = SSL_accept(ssl->conn)) != 1) {
-        if(!want_read_write_should_retry(ssl, err))
-            break;
-    }
-
-    if (err != 1) {
-        err = SSL_get_error(ssl->conn, err);
-        netdata_ssl_log_error_queue("SSL_accept", ssl, err);
-        ssl->state = NETDATA_SSL_STATE_FAILED;
-        return false;
-    }
-
-    ssl->state = NETDATA_SSL_STATE_COMPLETE;
-    return true;
-}
-
 NETDATA_SSL_HANDSHAKE_RESULT netdata_ssl_accept_nonblocking(NETDATA_SSL *ssl) {
     errno = 0;
     ssl->ssl_errno = 0;
 
     if(unlikely(!is_handshake_initialized(ssl, "accept")))
         return NETDATA_SSL_HANDSHAKE_FAILED;
+
+    // SSL_get_error() inspects the thread-local error queue, so it must be
+    // empty before the SSL I/O call (see man SSL_get_error).
+    ERR_clear_error();
 
     int ret = SSL_accept(ssl->conn);
     if(ret == 1) {

--- a/src/libnetdata/socket/security.h
+++ b/src/libnetdata/socket/security.h
@@ -47,6 +47,7 @@ SSL_CTX * netdata_ssl_create_client_ctx(unsigned long mode);
 
 bool netdata_ssl_connect(NETDATA_SSL *ssl);
 bool netdata_ssl_accept(NETDATA_SSL *ssl);
+// Tri-state result; compare explicitly with NETDATA_SSL_HANDSHAKE_* constants.
 NETDATA_SSL_HANDSHAKE_RESULT netdata_ssl_accept_nonblocking(NETDATA_SSL *ssl);
 
 bool netdata_ssl_open(NETDATA_SSL *ssl, SSL_CTX *ctx, int fd);

--- a/src/libnetdata/socket/security.h
+++ b/src/libnetdata/socket/security.h
@@ -8,6 +8,12 @@ typedef enum __attribute__((packed)) {
     NETDATA_SSL_STATE_COMPLETE,     // SSL handshake successful
 } NETDATA_SSL_STATE;
 
+typedef enum __attribute__((packed)) {
+    NETDATA_SSL_HANDSHAKE_FAILED = -1,
+    NETDATA_SSL_HANDSHAKE_PENDING = 0,
+    NETDATA_SSL_HANDSHAKE_COMPLETE = 1,
+} NETDATA_SSL_HANDSHAKE_RESULT;
+
 #define NETDATA_SSL_WEB_SERVER_CTX 0
 #define NETDATA_SSL_STREAMING_SENDER_CTX 1
 #define NETDATA_SSL_EXPORTING_CTX 2
@@ -41,6 +47,7 @@ SSL_CTX * netdata_ssl_create_client_ctx(unsigned long mode);
 
 bool netdata_ssl_connect(NETDATA_SSL *ssl);
 bool netdata_ssl_accept(NETDATA_SSL *ssl);
+NETDATA_SSL_HANDSHAKE_RESULT netdata_ssl_accept_nonblocking(NETDATA_SSL *ssl);
 
 bool netdata_ssl_open(NETDATA_SSL *ssl, SSL_CTX *ctx, int fd);
 bool netdata_ssl_open_ext(NETDATA_SSL *ssl, SSL_CTX *ctx, int fd, const unsigned char *alpn_protos, unsigned int alpn_protos_len);

--- a/src/libnetdata/socket/security.h
+++ b/src/libnetdata/socket/security.h
@@ -46,7 +46,6 @@ int security_test_certificate(SSL *ssl);
 SSL_CTX * netdata_ssl_create_client_ctx(unsigned long mode);
 
 bool netdata_ssl_connect(NETDATA_SSL *ssl);
-bool netdata_ssl_accept(NETDATA_SSL *ssl);
 // Tri-state result; compare explicitly with NETDATA_SSL_HANDSHAKE_* constants.
 NETDATA_SSL_HANDSHAKE_RESULT netdata_ssl_accept_nonblocking(NETDATA_SSL *ssl);
 

--- a/src/registry/registry.c
+++ b/src/registry/registry.c
@@ -2,6 +2,7 @@
 
 #include "database/rrd.h"
 #include "registry_internals.h"
+#include "web/api/http_auth.h"
 
 #define REGISTRY_STATUS_OK "ok"
 #define REGISTRY_STATUS_REDIRECT "redirect"
@@ -191,7 +192,7 @@ int registry_request_hello_json(RRDHOST *host, struct web_client *w, bool do_not
         if (claim_id_is_set(claim_id))
             buffer_json_member_add_string(w->response.data, "claim_id", claim_id.str);
 
-        buffer_json_member_add_boolean(w->response.data, "bearer_protection", netdata_is_protected_by_bearer);
+        buffer_json_member_add_boolean(w->response.data, "bearer_protection", netdata_bearer_protection_is_enabled());
     }
     buffer_json_object_close(w->response.data);
 

--- a/src/web/api/http_auth.c
+++ b/src/web/api/http_auth.c
@@ -342,8 +342,11 @@ bool web_client_bearer_token_auth(struct web_client *w, const char *v) {
 }
 
 void bearer_tokens_init(void) {
-    netdata_is_protected_by_bearer =
-        inicfg_get_boolean(&netdata_config, CONFIG_SECTION_WEB, "bearer token protection", netdata_is_protected_by_bearer);
+    netdata_bearer_protection_set_enabled(inicfg_get_boolean(
+        &netdata_config,
+        CONFIG_SECTION_WEB,
+        "bearer token protection",
+        netdata_bearer_protection_is_enabled()));
 
     netdata_authorized_bearers = dictionary_create_advanced(
         DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE,

--- a/src/web/api/http_auth.h
+++ b/src/web/api/http_auth.h
@@ -9,6 +9,14 @@ struct web_client;
 
 extern bool netdata_is_protected_by_bearer;
 
+static inline bool netdata_bearer_protection_is_enabled(void) {
+    return __atomic_load_n(&netdata_is_protected_by_bearer, __ATOMIC_RELAXED);
+}
+
+static inline void netdata_bearer_protection_set_enabled(bool enabled) {
+    __atomic_store_n(&netdata_is_protected_by_bearer, enabled, __ATOMIC_RELAXED);
+}
+
 bool extract_bearer_token_from_request(struct web_client *w, char *dst, size_t dst_len);
 
 time_t bearer_create_token(nd_uuid_t *uuid, HTTP_USER_ROLE user_role, HTTP_ACCESS access, nd_uuid_t cloud_account_id, const char *client_name);

--- a/src/web/api/v1/api_v1_alarms.c
+++ b/src/web/api/v1/api_v1_alarms.c
@@ -105,6 +105,7 @@ int api_v1_variable(RRDHOST *host, struct web_client *w, char *url) {
     int ret = HTTP_RESP_BAD_REQUEST;
     char *chart = NULL;
     char *variable = NULL;
+    RRDSET_ACQUIRED *rsa = NULL;
 
     buffer_flush(w->response.data);
 
@@ -128,8 +129,10 @@ int api_v1_variable(RRDHOST *host, struct web_client *w, char *url) {
         goto cleanup;
     }
 
-    RRDSET *st = rrdset_find(host, chart, false);
-    if(!st) st = rrdset_find_byname(host, chart);
+    rsa = rrdset_find_and_acquire(host, chart, false);
+    if(!rsa) rsa = rrdset_find_byname_and_acquire(host, chart);
+
+    RRDSET *st = rrdset_acquired_to_rrdset(rsa);
     if(!st) {
         buffer_strcat(w->response.data, "Chart is not found: ");
         buffer_strcat_htmlescape(w->response.data, chart);
@@ -141,9 +144,10 @@ int api_v1_variable(RRDHOST *host, struct web_client *w, char *url) {
     rrdset_touch_last_accessed_time_s(st);
     alert_variable_lookup_trace(host, st, variable, w->response.data);
 
-    return HTTP_RESP_OK;
+    ret = HTTP_RESP_OK;
 
 cleanup:
+    rrdset_acquired_release(rsa);
     return ret;
 }
 

--- a/src/web/api/v1/api_v1_badge/web_buffer_svg.c
+++ b/src/web/api/v1/api_v1_badge/web_buffer_svg.c
@@ -902,6 +902,7 @@ int api_v1_badge(RRDHOST *host, struct web_client *w, char *url) {
 
     const RRDCALC_ACQUIRED *rca = NULL;
     RRDCALC *rc = NULL;
+    RRDSET_ACQUIRED *rsa = NULL;
     RRDSET *st = NULL;
 
     while(url) {
@@ -968,8 +969,10 @@ int api_v1_badge(RRDHOST *host, struct web_client *w, char *url) {
 
     int scale = (scale_str && *scale_str)?str2i(scale_str):100;
 
-    st = rrdset_find(host, chart, false);
-    if(!st) st = rrdset_find_byname(host, chart);
+    rsa = rrdset_find_and_acquire(host, chart, false);
+    if(!rsa) rsa = rrdset_find_byname_and_acquire(host, chart);
+
+    st = rrdset_acquired_to_rrdset(rsa);
     if(!st) {
         buffer_no_cacheable(w->response.data);
         buffer_svg(w->response.data, "chart not found", NAN, "", NULL, NULL, -1, scale, 0, -1, -1, NULL, NULL);
@@ -1161,6 +1164,7 @@ int api_v1_badge(RRDHOST *host, struct web_client *w, char *url) {
 
 cleanup:
     rrdcalc_from_rrdset_release(st, rca);
+    rrdset_acquired_release(rsa);
     buffer_free(dimensions);
     return ret;
 }

--- a/src/web/api/v1/api_v1_charts.c
+++ b/src/web/api/v1/api_v1_charts.c
@@ -5,6 +5,7 @@
 int api_v1_single_chart_helper(RRDHOST *host, struct web_client *w, char *url, void callback(RRDSET *st, BUFFER *buf)) {
     int ret = HTTP_RESP_BAD_REQUEST;
     char *chart = NULL;
+    RRDSET_ACQUIRED *rsa = NULL;
 
     buffer_flush(w->response.data);
 
@@ -31,8 +32,10 @@ int api_v1_single_chart_helper(RRDHOST *host, struct web_client *w, char *url, v
         goto cleanup;
     }
 
-    RRDSET *st = rrdset_find(host, chart, false);
-    if(!st) st = rrdset_find_byname(host, chart);
+    rsa = rrdset_find_and_acquire(host, chart, false);
+    if(!rsa) rsa = rrdset_find_byname_and_acquire(host, chart);
+
+    RRDSET *st = rrdset_acquired_to_rrdset(rsa);
     if(!st) {
         buffer_strcat(w->response.data, "Chart is not found: ");
         buffer_strcat_htmlescape(w->response.data, chart);
@@ -43,9 +46,10 @@ int api_v1_single_chart_helper(RRDHOST *host, struct web_client *w, char *url, v
     w->response.data->content_type = CT_APPLICATION_JSON;
     rrdset_touch_last_accessed_time_s(st);
     callback(st, w->response.data);
-    return HTTP_RESP_OK;
+    ret = HTTP_RESP_OK;
 
 cleanup:
+    rrdset_acquired_release(rsa);
     return ret;
 }
 

--- a/src/web/api/v1/api_v1_data.c
+++ b/src/web/api/v1/api_v1_data.c
@@ -130,6 +130,7 @@ int api_v1_data(RRDHOST *host, struct web_client *w, char *url) {
     fix_google_param(outFileName);
 
     RRDSET *st = NULL;
+    RRDSET_ACQUIRED *rsa = NULL;
     ONEWAYALLOC *owa = onewayalloc_create(0);
     QUERY_TARGET *qt = NULL;
 
@@ -140,8 +141,9 @@ int api_v1_data(RRDHOST *host, struct web_client *w, char *url) {
 
     if(chart && !context) {
         // check if this is a specific chart
-        st = rrdset_find(host, chart, false);
-        if (!st) st = rrdset_find_byname(host, chart);
+        rsa = rrdset_find_and_acquire(host, chart, false);
+        if (!rsa) rsa = rrdset_find_byname_and_acquire(host, chart);
+        st = rrdset_acquired_to_rrdset(rsa);
     }
 
     long long before = (before_str && *before_str)?str2l(before_str):0;
@@ -247,6 +249,7 @@ int api_v1_data(RRDHOST *host, struct web_client *w, char *url) {
 
 cleanup:
     query_target_release(qt);
+    rrdset_acquired_release(rsa);
     onewayalloc_destroy(owa);
     buffer_free(dimensions);
     return ret;

--- a/src/web/api/v2/api_v2_bearer.c
+++ b/src/web/api/v2/api_v2_bearer.c
@@ -22,7 +22,7 @@ int api_v2_bearer_protection(RRDHOST *host __maybe_unused, struct web_client *w 
     char *machine_guid = NULL;
     char *claim_id = NULL;
     char *node_id = NULL;
-    bool protection = netdata_is_protected_by_bearer;
+    bool protection = netdata_bearer_protection_is_enabled();
 
     while (url) {
         char *value = strsep_skip_consecutive_separators(&url, "&");
@@ -58,12 +58,12 @@ int api_v2_bearer_protection(RRDHOST *host __maybe_unused, struct web_client *w 
         return HTTP_RESP_BAD_REQUEST;
     }
 
-    netdata_is_protected_by_bearer = protection;
+    netdata_bearer_protection_set_enabled(protection);
 
     BUFFER *wb = w->response.data;
     buffer_reset(wb);
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_DEFAULT);
-    buffer_json_member_add_boolean(wb, "bearer_protection", netdata_is_protected_by_bearer);
+    buffer_json_member_add_boolean(wb, "bearer_protection", netdata_bearer_protection_is_enabled());
     buffer_json_finalize(wb);
 
     return HTTP_RESP_OK;
@@ -83,7 +83,7 @@ int bearer_get_token_json_response(BUFFER *wb, RRDHOST *host, const char *claim_
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_MINIFY);
     buffer_json_member_add_int64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "mg", host->machine_guid);
-    buffer_json_member_add_boolean(wb, "bearer_protection", netdata_is_protected_by_bearer);
+    buffer_json_member_add_boolean(wb, "bearer_protection", netdata_bearer_protection_is_enabled());
     buffer_json_member_add_uuid(wb, "token", uuid);
     buffer_json_member_add_time_t(wb, "expiration", expires_s);
     buffer_json_finalize(wb);

--- a/src/web/api/v2/api_v2_claim.c
+++ b/src/web/api/v2/api_v2_claim.c
@@ -53,13 +53,13 @@ bool netdata_random_session_id_generate(void) {
     return ret;
 }
 
-static const char *netdata_random_session_id_get_filename(void) {
+static char *netdata_random_session_id_filename_strdupz(void) {
     spinlock_lock(&netdata_random_session_id_spinlock);
 
     if(!netdata_random_session_id_filename)
         netdata_random_session_id_generate_unlocked();
 
-    const char *filename = netdata_random_session_id_filename;
+    char *filename = netdata_random_session_id_filename ? strdupz(netdata_random_session_id_filename) : NULL;
     spinlock_unlock(&netdata_random_session_id_spinlock);
 
     return filename;
@@ -117,7 +117,7 @@ typedef enum {
 } CLAIM_RESPONSE;
 
 static void claim_add_user_info_command(BUFFER *wb) {
-    const char *filename = netdata_random_session_id_get_filename();
+    CLEAN_CHAR_P *filename = netdata_random_session_id_filename_strdupz();
     CLEAN_BUFFER *os_cmd = buffer_create(0, NULL);
 
     const char *os_filename;

--- a/src/web/api/web_api.c
+++ b/src/web/api/web_api.c
@@ -29,6 +29,22 @@ void web_client_ensure_proper_authorization(struct web_client *w) {
 #endif
 }
 
+void web_api_command_hashes_init(struct web_api_command *api_commands, SPINLOCK *spinlock, bool *initialized) {
+    if(likely(__atomic_load_n(initialized, __ATOMIC_ACQUIRE)))
+        return;
+
+    spinlock_lock(spinlock);
+
+    if(unlikely(!__atomic_load_n(initialized, __ATOMIC_ACQUIRE))) {
+        for(int i = 0; api_commands[i].api ; i++)
+            api_commands[i].hash = simple_hash(api_commands[i].api);
+
+        __atomic_store_n(initialized, true, __ATOMIC_RELEASE);
+    }
+
+    spinlock_unlock(spinlock);
+}
+
 int web_client_api_request_vX(RRDHOST *host, struct web_client *w, char *url_path_endpoint, struct web_api_command *api_commands) {
     buffer_no_cacheable(w->response.data);
 

--- a/src/web/api/web_api.c
+++ b/src/web/api/web_api.c
@@ -19,10 +19,11 @@ void web_client_ensure_proper_authorization(struct web_client *w) {
     web_client_set_permissions(w, HTTP_ACCESS_ALL, HTTP_USER_ROLE_ADMIN, USER_AUTH_METHOD_GOD);
 #else
     if(w->user_auth.method == USER_AUTH_METHOD_NONE) {
+        bool bearer_protected = netdata_bearer_protection_is_enabled();
         web_client_set_permissions(
             w,
-            (netdata_is_protected_by_bearer) ? HTTP_ACCESS_NONE : HTTP_ACCESS_ANONYMOUS_DATA,
-            (netdata_is_protected_by_bearer) ? HTTP_USER_ROLE_NONE : HTTP_USER_ROLE_ANY,
+            bearer_protected ? HTTP_ACCESS_NONE : HTTP_ACCESS_ANONYMOUS_DATA,
+            bearer_protected ? HTTP_USER_ROLE_NONE : HTTP_USER_ROLE_ANY,
             USER_AUTH_METHOD_NONE);
     }
 #endif

--- a/src/web/api/web_api.h
+++ b/src/web/api/web_api.h
@@ -35,6 +35,8 @@ struct web_api_command {
 
 struct web_client;
 
+void web_api_command_hashes_init(struct web_api_command *api_commands, SPINLOCK *spinlock, bool *initialized);
+
 int web_client_api_request_vX(RRDHOST *host, struct web_client *w, char *url_path_endpoint, struct web_api_command *api_commands);
 
 static inline void fix_google_param(char *s) {

--- a/src/web/api/web_api_v1.c
+++ b/src/web/api/web_api_v1.c
@@ -242,15 +242,11 @@ static struct web_api_command api_commands_v1[] = {
     },
 };
 
+static SPINLOCK api_commands_v1_spinlock = SPINLOCK_INITIALIZER;
+static bool api_commands_v1_initialized = false;
+
 inline int web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *url_path_endpoint) {
-    static int initialized = 0;
-
-    if(unlikely(initialized == 0)) {
-        initialized = 1;
-
-        for(int i = 0; api_commands_v1[i].api ; i++)
-            api_commands_v1[i].hash = simple_hash(api_commands_v1[i].api);
-    }
+    web_api_command_hashes_init(api_commands_v1, &api_commands_v1_spinlock, &api_commands_v1_initialized);
 
     return web_client_api_request_vX(host, w, url_path_endpoint, api_commands_v1);
 }

--- a/src/web/api/web_api_v2.c
+++ b/src/web/api/web_api_v2.c
@@ -170,15 +170,11 @@ static struct web_api_command api_commands_v2[] = {
     },
 };
 
+static SPINLOCK api_commands_v2_spinlock = SPINLOCK_INITIALIZER;
+static bool api_commands_v2_initialized = false;
+
 inline int web_client_api_request_v2(RRDHOST *host, struct web_client *w, char *url_path_endpoint) {
-    static int initialized = 0;
-
-    if(unlikely(initialized == 0)) {
-        initialized = 1;
-
-        for(int i = 0; api_commands_v2[i].api ; i++)
-            api_commands_v2[i].hash = simple_hash(api_commands_v2[i].api);
-    }
+    web_api_command_hashes_init(api_commands_v2, &api_commands_v2_spinlock, &api_commands_v2_initialized);
 
     return web_client_api_request_vX(host, w, url_path_endpoint, api_commands_v2);
 }

--- a/src/web/api/web_api_v3.c
+++ b/src/web/api/web_api_v3.c
@@ -256,15 +256,11 @@ static struct web_api_command api_commands_v3[] = {
     },
 };
 
+static SPINLOCK api_commands_v3_spinlock = SPINLOCK_INITIALIZER;
+static bool api_commands_v3_initialized = false;
+
 inline int web_client_api_request_v3(RRDHOST *host, struct web_client *w, char *url_path_endpoint) {
-    static int initialized = 0;
-
-    if(unlikely(initialized == 0)) {
-        initialized = 1;
-
-        for(int i = 0; api_commands_v3[i].api ; i++)
-            api_commands_v3[i].hash = simple_hash(api_commands_v3[i].api);
-    }
+    web_api_command_hashes_init(api_commands_v3, &api_commands_v3_spinlock, &api_commands_v3_initialized);
 
     return web_client_api_request_vX(host, w, url_path_endpoint, api_commands_v3);
 }

--- a/src/web/mcp/adapters/mcp-http.c
+++ b/src/web/mcp/adapters/mcp-http.c
@@ -119,7 +119,7 @@ int mcp_http_handle_request(struct rrdhost *host __maybe_unused, struct web_clie
 #ifdef NETDATA_MCP_DEV_PREVIEW_API_KEY
     mcp_api_key_verified = mcp_http_apply_api_key(w);
 #endif
-    if (netdata_is_protected_by_bearer && !mcp_api_key_verified) {
+    if (netdata_bearer_protection_is_enabled() && !mcp_api_key_verified) {
         BUFFER *payload = mcp_jsonrpc_build_error_payload(
             NULL, -32600,
             "MCP API key is required when bearer token protection is enabled",

--- a/src/web/mcp/adapters/mcp-sse.c
+++ b/src/web/mcp/adapters/mcp-sse.c
@@ -156,7 +156,7 @@ int mcp_sse_handle_request(struct rrdhost *host __maybe_unused, struct web_clien
 #ifdef NETDATA_MCP_DEV_PREVIEW_API_KEY
     mcp_api_key_verified = mcp_sse_apply_api_key(w);
 #endif
-    if (netdata_is_protected_by_bearer && !mcp_api_key_verified) {
+    if (netdata_bearer_protection_is_enabled() && !mcp_api_key_verified) {
         buffer_flush(w->response.data);
         w->response.data->content_type = CT_TEXT_EVENT_STREAM;
         mcp_http_disable_compression(w);

--- a/src/web/rtc/webrtc.c
+++ b/src/web/rtc/webrtc.c
@@ -467,6 +467,15 @@ static void myMessageCallback(int id __maybe_unused, const char *message, int si
     webrtc_execute_api_request(chan, request, request_size, binary);
 }
 
+static bool webrtc_conn_is_linked_unsafe(WEBRTC_CONN *conn) {
+    for(WEBRTC_CONN *t = webrtc_base.unsafe.head; t ;t = t->link.next) {
+        if(t == conn)
+            return true;
+    }
+
+    return false;
+}
+
 //#define WEBRTC_MAX_REQUEST_SIZE 65536
 //
 //static void myAvailableCallback(int id, void *user_ptr) {
@@ -488,19 +497,32 @@ static void myMessageCallback(int id __maybe_unused, const char *message, int si
 //    }
 //}
 
-static void myDataChannelCallback(int pc __maybe_unused, int dc, void *user_ptr) {
+static void myDataChannelCallback(int pc, int dc, void *user_ptr) {
     webrtc_set_thread_name();
 
     WEBRTC_CONN *conn = user_ptr;
-    internal_fatal(conn->pc != pc, "WEBRTC[%d]: pc mismatch, expected %d, got %d", conn->pc, conn->pc, pc);
-
     WEBRTC_DC *chan = callocz(1, sizeof(WEBRTC_DC));
     chan->dc = dc;
     chan->conn = conn;
 
+    spinlock_lock(&webrtc_base.unsafe.spinlock);
+    if(unlikely(!webrtc_conn_is_linked_unsafe(conn) || webrtc_conn_state(conn) == RTC_CLOSED)) {
+        spinlock_unlock(&webrtc_base.unsafe.spinlock);
+
+        internal_error(true, "WEBRTC[%d],DC[%d]: ignoring data channel for closed connection.", pc, dc);
+        freez(chan);
+        if(rtcDeleteDataChannel(dc) != RTC_ERR_SUCCESS)
+            netdata_log_error("WEBRTC[%d],DC[%d]: rtcDeleteDataChannel() failed.", pc, dc);
+
+        return;
+    }
+
+    internal_fatal(conn->pc != pc, "WEBRTC[%d]: pc mismatch, expected %d, got %d", conn->pc, conn->pc, pc);
+
     spinlock_lock(&conn->channels.spinlock);
     DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(conn->channels.head, chan, link.prev, link.next);
     spinlock_unlock(&conn->channels.spinlock);
+    spinlock_unlock(&webrtc_base.unsafe.spinlock);
 
     rtcSetUserPointer(dc, chan);
 

--- a/src/web/server/static/static-threaded.c
+++ b/src/web/server/static/static-threaded.c
@@ -84,7 +84,9 @@ static __thread struct web_server_static_threaded_worker *worker_private = NULL;
 // ----------------------------------------------------------------------------
 
 static inline int web_server_check_client_status(struct web_client *w) {
-    if(unlikely(web_client_check_dead(w) || (!web_client_has_wait_receive(w) && !web_client_has_wait_send(w))))
+    if(unlikely(web_client_check_dead(w) ||
+                (!web_client_has_wait_receive(w) && !web_client_has_wait_send(w) &&
+                 !web_client_has_ssl_wait_receive(w) && !web_client_has_ssl_wait_send(w))))
         return -1;
 
     return 0;
@@ -92,6 +94,92 @@ static inline int web_server_check_client_status(struct web_client *w) {
 
 // ----------------------------------------------------------------------------
 // web server clients
+
+static void web_server_enable_ssl_wait_from_ssl(struct web_client *w, nd_poll_event_t *events) {
+    if(w->ssl.ssl_errno == SSL_ERROR_WANT_READ) {
+        web_client_disable_ssl_wait_send(w);
+        web_client_enable_ssl_wait_receive(w);
+        *events |= ND_POLL_READ;
+    }
+    else if(w->ssl.ssl_errno == SSL_ERROR_WANT_WRITE) {
+        web_client_disable_ssl_wait_receive(w);
+        web_client_enable_ssl_wait_send(w);
+        *events |= ND_POLL_WRITE;
+    }
+    else {
+        web_client_disable_ssl_wait_receive(w);
+        web_client_disable_ssl_wait_send(w);
+    }
+}
+
+static bool web_server_complete_ssl_handshake(struct web_client *w, nd_poll_event_t *events) {
+    NETDATA_SSL_HANDSHAKE_RESULT rc = netdata_ssl_accept_nonblocking(&w->ssl);
+    if(rc == NETDATA_SSL_HANDSHAKE_COMPLETE) {
+        web_client_disable_ssl_wait_receive(w);
+        web_client_disable_ssl_wait_send(w);
+        return true;
+    }
+
+    if(rc == NETDATA_SSL_HANDSHAKE_PENDING) {
+        web_server_enable_ssl_wait_from_ssl(w, events);
+        return false;
+    }
+
+    WEB_CLIENT_IS_DEAD(w);
+    web_client_disable_ssl_wait_receive(w);
+    web_client_disable_ssl_wait_send(w);
+    return false;
+}
+
+static bool web_server_check_tcp_ssl(struct web_client *w, nd_poll_event_t *events) {
+    if(!web_client_check_conn_tcp(w) || !netdata_ssl_web_server_ctx)
+        return true;
+
+    if(w->ssl.conn) {
+        if(w->ssl.state == NETDATA_SSL_STATE_COMPLETE)
+            return true;
+
+        if(w->ssl.state == NETDATA_SSL_STATE_INIT)
+            return web_server_complete_ssl_handshake(w, events);
+
+        WEB_CLIENT_IS_DEAD(w);
+        return false;
+    }
+
+    if(web_client_has_ssl_checked(w))
+        return true;
+
+    char test;
+    ssize_t bytes = recv(w->fd, &test, 1, MSG_PEEK | MSG_DONTWAIT);
+    if(bytes == 1) {
+        web_client_set_ssl_checked(w);
+
+        if(test > 0x17) {
+            netdata_ssl_close(&w->ssl);
+            return true;
+        }
+
+        if(!netdata_ssl_open(&w->ssl, netdata_ssl_web_server_ctx, w->fd)) {
+            WEB_CLIENT_IS_DEAD(w);
+            return false;
+        }
+
+        return web_server_complete_ssl_handshake(w, events);
+    }
+
+    if(bytes == 0) {
+        WEB_CLIENT_IS_DEAD(w);
+        return false;
+    }
+
+    if(errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+        *events |= ND_POLL_READ;
+        return false;
+    }
+
+    WEB_CLIENT_IS_DEAD(w);
+    return false;
+}
 
 static void *web_server_add_callback(POLLINFO *pi, nd_poll_event_t *events, void *data __maybe_unused) {
     worker_is_busy(WORKER_JOB_ADD_CONNECTION);
@@ -110,34 +198,6 @@ static void *web_server_add_callback(POLLINFO *pi, nd_poll_event_t *events, void
         web_client_set_conn_unix(w);
     } else {
         web_client_set_conn_tcp(w);
-    }
-
-    if ((web_client_check_conn_tcp(w)) && (netdata_ssl_web_server_ctx)) {
-        sock_setnonblock(w->fd, false);
-
-        //Read the first 7 bytes from the message, but the message
-        //is not removed from the queue, because we are using MSG_PEEK
-        char test[8];
-        if ( recv(w->fd,test, 7, MSG_PEEK) == 7 ) {
-            test[7] = '\0';
-        }
-        else {
-            // we couldn't read 7 bytes
-            sock_setnonblock(w->fd, true);
-            goto cleanup;
-        }
-
-        if(test[0] > 0x17) {
-            // no SSL
-            netdata_ssl_close(&w->ssl); // free any previous SSL data
-        }
-        else {
-            // SSL
-            if(!netdata_ssl_open(&w->ssl, netdata_ssl_web_server_ctx, w->fd) || !netdata_ssl_accept(&w->ssl))
-                WEB_CLIENT_IS_DEAD(w);
-        }
-
-        sock_setnonblock(w->fd, true);
     }
 
     netdata_log_debug(D_WEB_CLIENT, "%llu: ADDED CLIENT FD %d", w->id, pi->fd);
@@ -182,6 +242,11 @@ static int web_server_rcv_callback(POLLINFO *pi, nd_poll_event_t *events) {
 
     struct web_client *w = (struct web_client *)pi->data;
     int fd = pi->fd;
+
+    if(!web_server_check_tcp_ssl(w, events)) {
+        ret = web_server_check_client_status(w);
+        goto cleanup;
+    }
 
     ssize_t bytes;
     bytes = web_client_receive(w);
@@ -248,6 +313,19 @@ static int web_server_snd_callback(POLLINFO *pi, nd_poll_event_t *events) {
 
     struct web_client *w = (struct web_client *)pi->data;
     int fd = pi->fd;
+
+    bool completing_ssl_handshake = w->ssl.conn && w->ssl.state == NETDATA_SSL_STATE_INIT;
+    if(!web_server_check_tcp_ssl(w, events)) {
+        retval = web_server_check_client_status(w);
+        goto cleanup;
+    }
+
+    if(completing_ssl_handshake && !web_client_has_wait_send(w)) {
+        web_client_enable_wait_receive(w);
+        *events |= ND_POLL_READ;
+        retval = 0;
+        goto cleanup;
+    }
 
     netdata_log_debug(D_WEB_CLIENT, "%llu: sending data on fd %d.", w->id, fd);
 

--- a/src/web/server/static/static-threaded.c
+++ b/src/web/server/static/static-threaded.c
@@ -202,7 +202,6 @@ static void *web_server_add_callback(POLLINFO *pi, nd_poll_event_t *events, void
 
     netdata_log_debug(D_WEB_CLIENT, "%llu: ADDED CLIENT FD %d", w->id, pi->fd);
 
-cleanup:
     worker_is_idle();
     return w;
 }
@@ -315,6 +314,14 @@ static int web_server_snd_callback(POLLINFO *pi, nd_poll_event_t *events) {
     int fd = pi->fd;
 
     bool completing_ssl_handshake = w->ssl.conn && w->ssl.state == NETDATA_SSL_STATE_INIT;
+
+    // A writable event consumed for TLS handshake progress is not an
+    // application send. Keep it out of send_count, so the first-request
+    // timeout (which is armed only while send_count == 0) still applies
+    // to clients that stall or trickle mid-handshake.
+    if(completing_ssl_handshake && pi->send_count > 0)
+        pi->send_count--;
+
     if(!web_server_check_tcp_ssl(w, events)) {
         retval = web_server_check_client_status(w);
         goto cleanup;

--- a/src/web/server/web_client.h
+++ b/src/web/server/web_client.h
@@ -71,6 +71,7 @@ typedef enum __attribute__((packed)) {
     WEB_CLIENT_FLAG_ACCEPT_TEXT             = (1 << 27),
     WEB_CLIENT_FLAG_MCP_PREVIEW_KEY         = (1 << 28), // Authorization header matched MCP preview key
     WEB_CLIENT_FLAG_PATH_IS_MCP             = (1 << 29), // URL path is /mcp[/...] or /sse[/...] — set during URL decoding so it's also available for OPTIONS preflights (which skip the URL dispatcher)
+    WEB_CLIENT_FLAG_SSL_CHECKED             = (1 << 30), // the initial TCP bytes have been classified as TLS or plain HTTP
 } WEB_CLIENT_FLAGS;
 
 #define WEB_CLIENT_FLAG_PATH_WITH_VERSION (WEB_CLIENT_FLAG_PATH_IS_V0|WEB_CLIENT_FLAG_PATH_IS_V1|WEB_CLIENT_FLAG_PATH_IS_V2|WEB_CLIENT_FLAG_PATH_IS_V3)
@@ -118,6 +119,9 @@ typedef enum __attribute__((packed)) {
 #define web_client_has_mcp_preview_key(w) web_client_flag_check(w, WEB_CLIENT_FLAG_MCP_PREVIEW_KEY)
 #define web_client_set_mcp_preview_key(w) web_client_flag_set(w, WEB_CLIENT_FLAG_MCP_PREVIEW_KEY)
 #define web_client_clear_mcp_preview_key(w) web_client_flag_clear(w, WEB_CLIENT_FLAG_MCP_PREVIEW_KEY)
+
+#define web_client_has_ssl_checked(w) web_client_flag_check(w, WEB_CLIENT_FLAG_SSL_CHECKED)
+#define web_client_set_ssl_checked(w) web_client_flag_set(w, WEB_CLIENT_FLAG_SSL_CHECKED)
 
 #define web_client_check_conn_unix(w) web_client_flag_check(w, WEB_CLIENT_FLAG_CONN_UNIX)
 #define web_client_check_conn_tcp(w) web_client_flag_check(w, WEB_CLIENT_FLAG_CONN_TCP)

--- a/src/web/websocket/websocket-handshake.c
+++ b/src/web/websocket/websocket-handshake.c
@@ -415,7 +415,7 @@ short int websocket_handle_handshake(struct web_client *w) {
             return web_client_permission_denied_acl(w);
         }
 
-        if (netdata_is_protected_by_bearer && !mcp_api_key_verified) {
+        if (netdata_bearer_protection_is_enabled() && !mcp_api_key_verified) {
             w->response.data->content_type = CT_TEXT_PLAIN;
             buffer_flush(w->response.data);
             buffer_strcat(w->response.data,


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes critical races and blocking paths across the web server, API, and WebRTC. Adds a nonblocking TLS handshake and makes bearer protection and API dispatch initialization thread-safe without changing public behavior.

- **Bug Fixes**
  - Web server TLS: implement nonblocking `SSL_accept` with tri-state result and poll-driven handshake; remove blocking recv/temporary blocking mode; add SSL wait flags to event loop; exclude handshake progress from `send_count` to keep first-request timeouts accurate; preserve errno on failures; remove unused blocking accept helper.
  - Authorization: make bearer token protection flag atomic via `netdata_bearer_protection_is_enabled()`/`_set_enabled()`, and use it across APIs, registry, MCP, and websockets for consistent reads.
  - API dispatch: initialize v1/v2/v3 command hashes under a spinlock with release/acquire semantics to remove first-request races.
  - Chart handlers: add `rrdset_find_byname_and_acquire()` and hold/release `RRDSET_ACQUIRED` in v1 endpoints to prevent use-after-free on concurrent chart removal.
  - WebRTC: reject late data channels for closed/unlinked connections under the global lock to prevent use-after-free.
  - Claim flow: duplicate the session filename under the spinlock to avoid races with regeneration; no behavior change in responses.

<sup>Written for commit bdfdbfb5cb7a1b94635081589ea2a2aa93e3cc96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

