### PR TITLE
docs: remove cloudwatch from Prometheus metadata

### DIFF
--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -536,35 +536,6 @@ modules:
               Install [Cilium Proxy](https://github.com/cilium/proxy) by following the instructions mentioned in the exporter README.
   - <<: *module
     meta:
-      id: collector-go.d.plugin-prometheus-aws_cloudwatch
-      <<: *meta
-      community: true
-      monitored_instance:
-        name: CloudWatch
-        link: https://github.com/prometheus/cloudwatch_exporter
-        icon_filename: aws-cloudwatch.png
-        categories:
-          - data-collection.cloud-and-devops
-      keywords:
-        - cloud services
-        - cloud computing
-        - scalability
-    overview:
-      <<: *overview
-      data_collection:
-        metrics_description: |
-          Monitor AWS CloudWatch metrics for comprehensive AWS resource management and performance optimization.
-        method_description: |
-          Metrics are gathered by periodically sending HTTP requests to [CloudWatch exporter](https://github.com/prometheus/cloudwatch_exporter).
-    setup:
-      <<: *setup
-      prerequisites:
-        list:
-          - title: Install Exporter
-            description: |
-              Install [CloudWatch exporter](https://github.com/prometheus/cloudwatch_exporter) by following the instructions mentioned in the exporter README.
-  - <<: *module
-    meta:
       <<: *meta
       id: collector-go.d.plugin-prometheus-concourse
       community: true


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the AWS CloudWatch exporter entry from the Prometheus collector metadata so docs no longer list it as a supported integration.

<sup>Written for commit d6799550219d497506201c361bff660b23e27bd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

