### PR TITLE
Netdata fixes part 55

### DIFF
--- a/src/libnetdata/clocks/clocks-internals.h
+++ b/src/libnetdata/clocks/clocks-internals.h
@@ -5,12 +5,16 @@
 
 #include "clocks.h"
 
+static inline usec_t clocks_usec_delta_or_zero(usec_t now_ut, usec_t old_ut) {
+    return now_ut >= old_ut ? now_ut - old_ut : 0;
+}
+
 static inline bool sleep_usec_prepare_retry_after_eintr(
         usec_t usec,
         usec_t started_monotonic_ut,
         usec_t now_monotonic_ut,
         struct timespec *req) {
-    usec_t elapsed_ut = now_monotonic_ut > started_monotonic_ut ? now_monotonic_ut - started_monotonic_ut : 0;
+    usec_t elapsed_ut = clocks_usec_delta_or_zero(now_monotonic_ut, started_monotonic_ut);
     if(elapsed_ut >= usec)
         return false;
 

--- a/src/libnetdata/clocks/clocks-unittest.c
+++ b/src/libnetdata/clocks/clocks-unittest.c
@@ -89,6 +89,19 @@ static int clocks_retry_treats_backward_monotonic_sample_as_no_elapsed_time(void
     return errors;
 }
 
+static int clocks_usec_delta_or_zero_saturates_backward_samples(void) {
+    int errors = 0;
+
+    CLOCKS_TEST(clocks_usec_delta_or_zero(250 * USEC_PER_MS, 100 * USEC_PER_MS) == 150 * USEC_PER_MS,
+                "normal unsigned microsecond delta is preserved");
+    CLOCKS_TEST(clocks_usec_delta_or_zero(100 * USEC_PER_MS, 100 * USEC_PER_MS) == 0,
+                "equal unsigned microsecond samples produce zero delta");
+    CLOCKS_TEST(clocks_usec_delta_or_zero(100 * USEC_PER_MS, 250 * USEC_PER_MS) == 0,
+                "backward unsigned microsecond sample saturates to zero");
+
+    return errors;
+}
+
 int clocks_unittest(void) {
     int errors = 0;
 
@@ -98,6 +111,7 @@ int clocks_unittest(void) {
     errors += clocks_retry_clamps_inflated_remaining_time();
     errors += clocks_retry_stops_when_budget_is_exhausted();
     errors += clocks_retry_treats_backward_monotonic_sample_as_no_elapsed_time();
+    errors += clocks_usec_delta_or_zero_saturates_backward_samples();
 
     if(errors)
         fprintf(stderr, "clocks unittest: %d ERROR(S)\n", errors);

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -401,10 +401,10 @@ usec_t heartbeat_next(heartbeat_t *hb) {
     spinlock_lock(&heartbeat_alignment_spinlock);
     now = now_realtime_usec();
 
-    dt = now - hb->realtime;
+    dt = clocks_usec_delta_or_zero(now, hb->realtime);
 
     if(hb->statistics_id < HEARTBEAT_ALIGNMENT_STATISTICS_SIZE) {
-        heartbeat_alignment_values[hb->statistics_id].dt += now - next;
+        heartbeat_alignment_values[hb->statistics_id].dt += clocks_usec_delta_or_zero(now, next);
         heartbeat_alignment_values[hb->statistics_id].sequence++;
     }
     spinlock_unlock(&heartbeat_alignment_spinlock);

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -36,6 +36,7 @@ typedef enum __attribute__ ((__packed__)) item_flags {
     ITEM_FLAG_NONE              = 0,
     ITEM_FLAG_DELETED           = (1 << 0), // this item is marked deleted, so it is not available for traversal (deleted from the index too)
     ITEM_FLAG_BEING_CREATED     = (1 << 1), // this item is currently being created - this flag is removed when construction finishes
+    ITEM_FLAG_PENDING_DELETION  = (1 << 2), // this deleted item is counted in pending_deletion_items
 
     // IMPORTANT: This is 8-bit
 } ITEM_FLAGS;
@@ -151,6 +152,7 @@ struct dictionary {
     struct {
         DICTIONARY_ITEM *list;          // the double linked list of all items in the dictionary
         RW_SPINLOCK rw_spinlock;        // protect the linked-list
+        SPINLOCK pending_deletion_spinlock; // protect delete flag / last-reference accounting
         pid_t writer_pid;               // the gettid() of the writer
         uint32_t writer_depth;          // nesting of write locks
     } items;

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -305,18 +305,30 @@ static inline void dict_item_shared_set_deleted(DICTIONARY *dict, DICTIONARY_ITE
 static inline bool dict_item_set_deleted(DICTIONARY *dict, DICTIONARY_ITEM *item) {
     ITEM_FLAGS expected, desired;
 
+    if(likely(!is_dictionary_single_threaded(dict)))
+        spinlock_lock(&dict->items.pending_deletion_spinlock);
+
     expected = __atomic_load_n(&item->flags, __ATOMIC_RELAXED);
 
     do {
 
-        if (expected & ITEM_FLAG_DELETED)
+        if (expected & ITEM_FLAG_DELETED) {
+            if(likely(!is_dictionary_single_threaded(dict)))
+                spinlock_unlock(&dict->items.pending_deletion_spinlock);
             return false;
+        }
 
         desired = expected | ITEM_FLAG_DELETED;
 
     } while(!__atomic_compare_exchange_n(&item->flags, &expected, desired, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED));
 
     DICTIONARY_ENTRIES_MINUS1(dict);
+
+    if(DICTIONARY_ITEM_REFCOUNT_GET(dict, item) == 0)
+        item_pending_deletion_set_unsafe(dict, item);
+
+    if(likely(!is_dictionary_single_threaded(dict)))
+        spinlock_unlock(&dict->items.pending_deletion_spinlock);
     return true;
 }
 
@@ -362,7 +374,7 @@ static inline void dict_item_release_and_check_if_it_is_deleted_and_can_be_remov
         if(should_be_deleted && item_is_not_referenced_and_can_be_removed(dict, item)) {
             // this has to be before removing from the linked list,
             // otherwise the garbage collector will also kick in!
-            DICTIONARY_PENDING_DELETES_MINUS1(dict);
+            item_pending_deletion_clear(dict, item);
 
             item_linked_list_remove(dict, item);
             dict_item_free_with_hooks(dict, item);

--- a/src/libnetdata/dictionary/dictionary-locks.h
+++ b/src/libnetdata/dictionary/dictionary-locks.h
@@ -12,6 +12,7 @@ static inline size_t dictionary_locks_init(DICTIONARY *dict) {
     if(likely(!is_dictionary_single_threaded(dict))) {
         rw_spinlock_init(&dict->index.rw_spinlock);
         rw_spinlock_init(&dict->items.rw_spinlock);
+        spinlock_init(&dict->items.pending_deletion_spinlock);
     }
 
     return 0;

--- a/src/libnetdata/dictionary/dictionary-refcount.h
+++ b/src/libnetdata/dictionary/dictionary-refcount.h
@@ -20,6 +20,35 @@ static inline size_t reference_counter_free(DICTIONARY *dict __maybe_unused) {
     return 0;
 }
 
+static inline bool item_pending_deletion_set_unsafe(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    if(item_flag_check(item, ITEM_FLAG_PENDING_DELETION))
+        return false;
+
+    item_flag_set(item, ITEM_FLAG_PENDING_DELETION);
+    DICTIONARY_PENDING_DELETES_PLUS1(dict);
+    return true;
+}
+
+static inline long int item_pending_deletion_clear_unsafe(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    if(!item_flag_check(item, ITEM_FLAG_PENDING_DELETION))
+        return DICTIONARY_PENDING_DELETES_GET(dict);
+
+    item_flag_clear(item, ITEM_FLAG_PENDING_DELETION);
+    return DICTIONARY_PENDING_DELETES_MINUS1(dict);
+}
+
+static inline long int item_pending_deletion_clear(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    if(likely(!is_dictionary_single_threaded(dict)))
+        spinlock_lock(&dict->items.pending_deletion_spinlock);
+
+    long int pending = item_pending_deletion_clear_unsafe(dict, item);
+
+    if(likely(!is_dictionary_single_threaded(dict)))
+        spinlock_unlock(&dict->items.pending_deletion_spinlock);
+
+    return pending;
+}
+
 static inline void item_acquire(DICTIONARY *dict, DICTIONARY_ITEM *item) {
     REFCOUNT refcount;
 
@@ -51,7 +80,7 @@ static inline void item_acquire(DICTIONARY *dict, DICTIONARY_ITEM *item) {
         // if this is a deleted item, but the counter increased to 1
         // we need to remove it from the pending items to delete
         if(item_flag_check(item, ITEM_FLAG_DELETED))
-            DICTIONARY_PENDING_DELETES_MINUS1(dict);
+            item_pending_deletion_clear(dict, item);
     }
     
 #ifdef FSANITIZE_ADDRESS
@@ -60,11 +89,11 @@ static inline void item_acquire(DICTIONARY *dict, DICTIONARY_ITEM *item) {
 #endif
 }
 
-static inline void item_release(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+static inline void item_release_counted_reference(DICTIONARY *dict, DICTIONARY_ITEM *item, bool referenced_item_is_counted) {
     // this function may be called without any lock on the dictionary
     // or even when someone else has 'write' lock on the dictionary
 
-    bool is_deleted;
+    bool is_deleted = false, pending_delete_recorded = false;
     REFCOUNT refcount;
 
     if(unlikely(is_dictionary_single_threaded(dict))) {
@@ -72,14 +101,30 @@ static inline void item_release(DICTIONARY *dict, DICTIONARY_ITEM *item) {
         refcount = --item->refcount;
     }
     else {
-        // get the flags before decrementing any reference counters
-        // (the other way around may lead to use-after-free)
-        is_deleted = item_flag_check(item, ITEM_FLAG_DELETED);
+        REFCOUNT expected = DICTIONARY_ITEM_REFCOUNT_GET(dict, item);
 
-        // decrement the refcount
+        while(expected > 1) {
+            REFCOUNT desired = expected - 1;
+            if(__atomic_compare_exchange_n(&item->refcount, &expected, desired, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED)) {
+                refcount = desired;
+                goto released;
+            }
+        }
+
+        spinlock_lock(&dict->items.pending_deletion_spinlock);
+
+        is_deleted = item_flag_check(item, ITEM_FLAG_DELETED);
         refcount = __atomic_sub_fetch(&item->refcount, 1, __ATOMIC_RELEASE);
+
+        if(refcount == 0 && is_deleted) {
+            item_pending_deletion_set_unsafe(dict, item);
+            pending_delete_recorded = true;
+        }
+
+        spinlock_unlock(&dict->items.pending_deletion_spinlock);
     }
 
+released:
     if(refcount < 0) {
         dictionary_internal_error(true, dict,
             "DICTIONARY: attempted to release item without references (refcount = %d): '%s'",
@@ -94,13 +139,18 @@ static inline void item_release(DICTIONARY *dict, DICTIONARY_ITEM *item) {
 
     if(refcount == 0) {
 
-        if(is_deleted)
-            DICTIONARY_PENDING_DELETES_PLUS1(dict);
+        if(is_deleted && !pending_delete_recorded)
+            item_pending_deletion_set_unsafe(dict, item);
 
         // referenced items counts number of unique items referenced
         // so, we decrease it only when refcount == 0
-        DICTIONARY_REFERENCED_ITEMS_MINUS1(dict);
+        if(referenced_item_is_counted)
+            DICTIONARY_REFERENCED_ITEMS_MINUS1(dict);
     }
+}
+
+static inline void item_release(DICTIONARY *dict, DICTIONARY_ITEM *item) {
+    item_release_counted_reference(dict, item, true);
 }
 
 static inline int item_check_and_acquire_advanced(DICTIONARY *dict, DICTIONARY_ITEM *item, bool having_index_lock) {
@@ -153,23 +203,24 @@ static inline int item_check_and_acquire_advanced(DICTIONARY *dict, DICTIONARY_I
                 dict_item_set_deleted(dict, item);
 
                 // decrement the refcount we incremented above
-                if (__atomic_sub_fetch(&item->refcount, 1, __ATOMIC_RELEASE) == 0) {
-                    // this is a deleted item, and we are the last one
-                    DICTIONARY_PENDING_DELETES_PLUS1(dict);
-                }
+                item_release_counted_reference(dict, item, false);
 
                 // do not touch the item below this point
             } else {
                 // this is traversal / walkthrough
                 // decrement the refcount we incremented above
-                __atomic_sub_fetch(&item->refcount, 1, __ATOMIC_RELEASE);
+                item_release_counted_reference(dict, item, false);
             }
 
             return RC_ITEM_MARKED_FOR_DELETION;
         }
 
-        if(desired == 1)
+        if(desired == 1) {
+            if(item_flag_check(item, ITEM_FLAG_DELETED))
+                item_pending_deletion_clear(dict, item);
+
             DICTIONARY_REFERENCED_ITEMS_PLUS1(dict);
+        }
             
 #ifdef FSANITIZE_ADDRESS
         // Add a stacktrace for this acquisition point

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -530,6 +530,41 @@ static size_t unittest_check_dictionary(const char *label, DICTIONARY *dict, siz
     return errors;
 }
 
+static size_t dictionary_unittest_last_release_before_delete_mark(void) {
+    size_t errors = 0;
+    const char *name = "pending-delete-race";
+
+    fprintf(stderr, "\nTesting last-release/delete-mark race accounting:\n");
+
+    DICTIONARY *dict = dictionary_create(DICT_OPTION_NONE | DICT_OPTION_NAME_LINK_DONT_CLONE);
+    dictionary_set(dict, name, "VALUE", 6);
+    DICTIONARY_ITEM *item = (DICTIONARY_ITEM *)dictionary_get_and_acquire_item(dict, name);
+
+    errors += unittest_check_dictionary("pre-race", dict, 1, 1, 0, 1, 0);
+
+    dictionary_index_lock_wrlock(dict);
+    if(hashtable_delete_unsafe(dict, item_get_name(item), item_get_name_len(item), item) == 0) {
+        fprintf(stderr, "failed to remove race item from index\n");
+        errors++;
+    }
+    else
+        pointer_del(dict, item);
+    dictionary_index_wrlock_unlock(dict);
+
+    dict_item_shared_set_deleted(dict, item);
+    item_release(dict, item);
+    dict_item_set_deleted(dict, item);
+
+    errors += unittest_check_dictionary("post-race", dict, 0, 0, 1, 0, 1);
+
+    dictionary_garbage_collect(dict);
+    errors += unittest_check_dictionary("post-gc", dict, 0, 0, 0, 0, 0);
+
+    dictionary_destroy(dict);
+
+    return errors;
+}
+
 static int check_item_callback(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data) {
     return value == data;
 }
@@ -1893,6 +1928,8 @@ int dictionary_unittest(size_t entries) {
     // check reference counters
     {
         fprintf(stderr, "\nTesting reference counters:\n");
+        errors += dictionary_unittest_last_release_before_delete_mark();
+
         dict = dictionary_create(DICT_OPTION_NONE | DICT_OPTION_NAME_LINK_DONT_CLONE);
         errors += unittest_check_dictionary("", dict, 0, 0, 0, 0, 0);
 

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -192,10 +192,10 @@ void garbage_collect_pending_deletes(DICTIONARY *dict) {
 
             if(item_is_not_referenced_and_can_be_removed(dict, item)) {
                 DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(dict->items.list, item, prev, next);
+                pending = item_pending_deletion_clear(dict, item);
                 dict_item_free_with_hooks(dict, item);
                 deleted++;
 
-                pending = DICTIONARY_PENDING_DELETES_MINUS1(dict);
                 if (!pending)
                     break;
             }

--- a/src/libnetdata/eval/eval-unittest-hardcoding.c
+++ b/src/libnetdata/eval/eval-unittest-hardcoding.c
@@ -69,6 +69,16 @@ int eval_hardcode_unittest(void) {
             66.0,
             EVAL_ERROR_OK
         },
+        // Raw source contains more $test prefixes than parsed test variables
+        {
+            "Prefix variable no-progress guard",
+            "$test_var + $test_var + $test",
+            "test",
+            123456789.0,
+            "$test_var + $test_var + $test",
+            0.0,
+            EVAL_ERROR_UNKNOWN_VARIABLE
+        },
         // Hardcoding negative value
         {
             "Negative value",

--- a/src/libnetdata/eval/eval-utils.c
+++ b/src/libnetdata/eval/eval-utils.c
@@ -365,6 +365,7 @@ void expression_hardcode_variable(EVAL_EXPRESSION *expression, STRING *variable,
         const char *src = string2str(expression->source);
         size_t slot = 0;
         while(matches) {
+            size_t matches_before = matches;
             size_t matched = 0;
 
             matched = str_replace_cpy(dst[slot], max_buf_size, src, find1, find1_len, replace, replace_len);
@@ -382,6 +383,9 @@ void expression_hardcode_variable(EVAL_EXPRESSION *expression, STRING *variable,
                     matches -= MIN(matches, matched);
                 }
             }
+
+            if(matches == matches_before)
+                return;
         }
 
         // Update the expression source with the new string.

--- a/src/libnetdata/procfile/procfile.c
+++ b/src/libnetdata/procfile/procfile.c
@@ -7,6 +7,7 @@
 #define PFWORDS_INCREASE_STEP 2000
 #define PFLINES_INCREASE_STEP 200
 #define PROCFILE_INCREMENT_BUFFER 4096
+#define PROCFILE_MAX_SOURCE_SIZE ((size_t)128 * 1024 * 1024)
 
 int procfile_open_flags = O_RDONLY | O_CLOEXEC;
 
@@ -176,6 +177,19 @@ static inline void procfile_lines_free(pflines *fl) {
     freez(fl);
 }
 
+static procfile *procfile_readall_file_too_large(procfile *ff) {
+    if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO)))
+        collector_error(PF_PREFIX ": Refusing to read more than %zu bytes from file '%s' on fd %d.",
+                        (size_t)PROCFILE_MAX_SOURCE_SIZE, procfile_filename(ff), ff->fd);
+    else if(unlikely(ff->flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG))
+        netdata_log_error(PF_PREFIX ": Refusing to read more than %zu bytes from file '%s' on fd %d.",
+                          (size_t)PROCFILE_MAX_SOURCE_SIZE, procfile_filename(ff), ff->fd);
+
+    procfile_close(ff);
+    errno = EFBIG;
+    return NULL;
+}
+
 
 // ----------------------------------------------------------------------------
 // The procfile
@@ -325,24 +339,39 @@ procfile *procfile_readall(procfile *ff) {
     ff->len = 0;    // zero the used size
     ssize_t r = 1;  // read at least once
     while(r > 0) {
-        ssize_t s = ff->len;
-        ssize_t x = ff->size - s;
+        size_t s = ff->len;
+        size_t x = ff->size - s;
+
+        if(unlikely(s >= PROCFILE_MAX_SOURCE_SIZE))
+            return procfile_readall_file_too_large(ff);
 
         if(unlikely(!x)) {
+            if(unlikely(ff->size >= PROCFILE_MAX_SOURCE_SIZE))
+                return procfile_readall_file_too_large(ff);
+
             size_t minimum = PROCFILE_INCREMENT_BUFFER;
             size_t optimal = ff->size / 2;
             size_t wanted = (optimal > minimum)?optimal:minimum;
+            size_t available = PROCFILE_MAX_SOURCE_SIZE - ff->size;
+            if(unlikely(wanted > available))
+                wanted = available;
 
             netdata_log_debug(D_PROCFILE, PF_PREFIX ": Expanding data buffer for file '%s' by %zu bytes.", procfile_filename(ff), wanted);
             ff = reallocz(ff, sizeof(procfile) + ff->size + wanted);
             ff->size += wanted;
             ff->stats.memory += wanted;
             ff->stats.resizes++;
+
+            x = ff->size - s;
         }
+
+        size_t remaining = PROCFILE_MAX_SOURCE_SIZE - s;
+        if(unlikely(x > remaining))
+            x = remaining;
 
         // netdata_log_info("Reading file '%s', from position %zd with length %zd", procfile_filename(ff), s, (ssize_t)(ff->size - s));
         ff->stats.reads++;
-        r = read(ff->fd, &ff->data[s], ff->size - s);
+        r = read(ff->fd, &ff->data[s], x);
         if(unlikely(r == -1)) {
             if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) collector_error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
             else if(unlikely(ff->flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG))

--- a/src/libnetdata/procfile/procfile.c
+++ b/src/libnetdata/procfile/procfile.c
@@ -342,8 +342,26 @@ procfile *procfile_readall(procfile *ff) {
         size_t s = ff->len;
         size_t x = ff->size - s;
 
-        if(unlikely(s >= PROCFILE_MAX_SOURCE_SIZE))
+        if(unlikely(s > PROCFILE_MAX_SOURCE_SIZE))
             return procfile_readall_file_too_large(ff);
+
+        if(unlikely(s == PROCFILE_MAX_SOURCE_SIZE)) {
+            char extra;
+            ff->stats.reads++;
+            r = read(ff->fd, &extra, 1);
+            if(unlikely(r == -1)) {
+                if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) collector_error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
+                else if(unlikely(ff->flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG))
+                    netdata_log_error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
+                procfile_close(ff);
+                return NULL;
+            }
+
+            if(likely(!r))
+                break;
+
+            return procfile_readall_file_too_large(ff);
+        }
 
         if(unlikely(!x)) {
             if(unlikely(ff->size >= PROCFILE_MAX_SOURCE_SIZE))

--- a/src/libnetdata/procfile/procfile.c
+++ b/src/libnetdata/procfile/procfile.c
@@ -357,8 +357,18 @@ procfile *procfile_readall(procfile *ff) {
                 return NULL;
             }
 
-            if(likely(!r))
+            if(likely(!r)) {
+                // the buffer is full to the last byte; procfile_parser() needs
+                // one spare byte to '\0'-terminate the last word without
+                // overwriting the last data byte
+                if(unlikely(ff->len >= ff->size)) {
+                    ff = reallocz(ff, sizeof(procfile) + ff->size + 1);
+                    ff->size++;
+                    ff->stats.memory++;
+                    ff->stats.resizes++;
+                }
                 break;
+            }
 
             return procfile_readall_file_too_large(ff);
         }

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -115,8 +115,6 @@ UUIDMAP_ID uuidmap_create(const nd_uuid_t uuid) {
     UUIDMAP_ID id = uuidmap_acquire_by_uuid(uuid);
     if(id != 0) return id;
 
-    uuidmap_init_aral();
-
     // we didn't find it - let's add it
 
     uint8_t partition = uuid_to_uuidmap_partition(uuid);
@@ -160,6 +158,11 @@ UUIDMAP_ID uuidmap_create(const nd_uuid_t uuid) {
     PValue = JudyLIns(&uuid_map.p[partition].id_to_uuid, id, PJE0);
     if (!PValue || PValue == PJERR)
         fatal("UUIDMAP: corrupted JudyL array");
+
+    // initialize the ARAL at its point of use: a concurrent uuidmap_destroy()
+    // may have destroyed it after any earlier check, but it needs all
+    // partition locks, so the write lock we hold here excludes it
+    uuidmap_init_aral();
 
     struct uuidmap_entry *ue = aral_mallocz(uuid_map.ar);
     nd_uuid_copy(ue->uuid, uuid);

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -432,6 +432,11 @@ static int uuidmap_destroy_referenced_entry_unittest(void) {
     };
 
     int errors = 0;
+
+    // in the full unittest sequence, earlier tests may still hold referenced
+    // entries in the global map - the expectations below are relative to them
+    size_t baseline = uuidmap_destroy();
+
     UUIDMAP_ID id = uuidmap_create(test_uuid);
     if(!id) {
         fprintf(stderr, "ERROR: Cannot create UUID for referenced destroy test\n");
@@ -439,8 +444,9 @@ static int uuidmap_destroy_referenced_entry_unittest(void) {
     }
 
     size_t referenced = uuidmap_destroy();
-    if(referenced != 1) {
-        fprintf(stderr, "ERROR: UUID destroy returned %zu referenced entries, expected 1\n", referenced);
+    if(referenced != baseline + 1) {
+        fprintf(stderr, "ERROR: UUID destroy returned %zu referenced entries, expected %zu\n",
+                referenced, baseline + 1);
         errors++;
     }
 
@@ -457,8 +463,9 @@ static int uuidmap_destroy_referenced_entry_unittest(void) {
     uuidmap_free(id);
 
     referenced = uuidmap_destroy();
-    if(referenced != 0) {
-        fprintf(stderr, "ERROR: UUID destroy returned %zu referenced entries after release, expected 0\n", referenced);
+    if(referenced != baseline) {
+        fprintf(stderr, "ERROR: UUID destroy returned %zu referenced entries after release, expected %zu\n",
+                referenced, baseline);
         errors++;
     }
 

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -390,15 +390,13 @@ size_t uuidmap_destroy(void) {
         uuid_map.p[partition].entries = 0;
     }
 
-    uuidmap_unlock_all_partitions();
-
     // Destroy ARAL
     if (uuid_map.ar) {
         aral_destroy(uuid_map.ar);
         uuid_map.ar = NULL;
     }
 
-    memset(&uuid_map, 0, sizeof(uuid_map));
+    uuidmap_unlock_all_partitions();
     return referenced;
 }
 

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -294,15 +294,54 @@ UUIDMAP_ID uuidmap_dup(UUIDMAP_ID id) {
     return id;
 }
 
+static void uuidmap_lock_all_partitions(void) {
+    for(size_t partition = 0; partition < UUIDMAP_PARTITIONS; partition++)
+        rw_spinlock_write_lock(&uuid_map.p[partition].spinlock);
+}
+
+static void uuidmap_unlock_all_partitions(void) {
+    for(size_t partition = UUIDMAP_PARTITIONS; partition > 0; partition--)
+        rw_spinlock_write_unlock(&uuid_map.p[partition - 1].spinlock);
+}
+
+static void uuidmap_destroy_restore_claimed_entries(struct uuidmap_entry **claimed, size_t used) {
+    for(size_t i = 0; i < used; i++) {
+        REFCOUNT expected = REFCOUNT_DELETED;
+        bool restored = __atomic_compare_exchange_n(&claimed[i]->refcount, &expected, 0,
+                                                    false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+        internal_fatal(!restored, "UUIDMAP: cannot restore destroy-claimed UUID entry refcount");
+    }
+}
+
+static bool uuidmap_destroy_claim_entry(struct uuidmap_entry *ue, struct uuidmap_entry ***claimed, size_t *used,
+                                        size_t *size) {
+    if(!refcount_acquire_for_deletion(&ue->refcount))
+        return false;
+
+    if(*used == *size) {
+        internal_fatal(*size > SIZE_MAX / 2, "UUIDMAP: too many UUID entries to claim during destroy");
+
+        size_t new_size = *size ? *size * 2 : 1024;
+        internal_fatal(new_size > SIZE_MAX / sizeof(**claimed),
+                       "UUIDMAP: too many UUID entries to claim during destroy");
+
+        *claimed = reallocz(*claimed, new_size * sizeof(**claimed));
+        *size = new_size;
+    }
+
+    (*claimed)[(*used)++] = ue;
+    return true;
+}
+
 size_t uuidmap_destroy(void) {
     size_t referenced = 0;
+    size_t claimed_used = 0, claimed_size = 0;
+    struct uuidmap_entry **claimed = NULL;
+
+    uuidmap_lock_all_partitions();
 
     // Traverse all partitions
     for (size_t partition = 0; partition < UUIDMAP_PARTITIONS; partition++) {
-        // Lock the partition to prevent new entries while we're cleaning up
-        rw_spinlock_write_lock(&uuid_map.p[partition].spinlock);
-
-        Pvoid_t uuid_to_id = uuid_map.p[partition].uuid_to_id;
         Pvoid_t id_to_uuid = uuid_map.p[partition].id_to_uuid;
 
         // Process all entries in the id_to_uuid map
@@ -318,22 +357,40 @@ size_t uuidmap_destroy(void) {
 
             struct uuidmap_entry *ue = *id_pvalue;
 
-            // Try to acquire for deletion
-            if (!refcount_acquire_for_deletion(&ue->refcount))
+            // Try to acquire for deletion.
+            if (!uuidmap_destroy_claim_entry(ue, &claimed, &claimed_used, &claimed_size))
                 referenced++;
-
-            aral_freez(uuid_map.ar, ue);
         }
+    }
+
+    if(referenced) {
+        uuidmap_destroy_restore_claimed_entries(claimed, claimed_used);
+        freez(claimed);
+        uuidmap_unlock_all_partitions();
+        return referenced;
+    }
+
+    for(size_t i = 0; i < claimed_used; i++)
+        aral_freez(uuid_map.ar, claimed[i]);
+    freez(claimed);
+
+    // Traverse all partitions
+    for (size_t partition = 0; partition < UUIDMAP_PARTITIONS; partition++) {
+        Pvoid_t uuid_to_id = uuid_map.p[partition].uuid_to_id;
+        Pvoid_t id_to_uuid = uuid_map.p[partition].id_to_uuid;
 
         // Free all Judy arrays
         JudyHSFreeArray(&uuid_to_id, PJE0);
         JudyLFreeArray(&id_to_uuid, PJE0);
 
-        // Reset partition data
-        memset(&uuid_map.p[partition], 0, sizeof(uuid_map.p[partition]));
-
-        rw_spinlock_write_unlock(&uuid_map.p[partition].spinlock);
+        uuid_map.p[partition].uuid_to_id = NULL;
+        uuid_map.p[partition].id_to_uuid = NULL;
+        uuid_map.p[partition].next_id = 0;
+        uuid_map.p[partition].memory = 0;
+        uuid_map.p[partition].entries = 0;
     }
+
+    uuidmap_unlock_all_partitions();
 
     // Destroy ARAL
     if (uuid_map.ar) {
@@ -365,6 +422,55 @@ typedef struct uuidmap_delete_gate {
     bool allow_delete;
     bool delete_done;
 } UUIDMAP_DELETE_GATE;
+
+static int uuidmap_destroy_referenced_entry_unittest(void) {
+    fprintf(stderr, "\nTesting UUID Map destroy with referenced entry...\n");
+
+    nd_uuid_t test_uuid = {
+        0x6d, 0x0f, 0x8b, 0x2a,
+        0x48, 0x57, 0x4c, 0x2e,
+        0x9a, 0x6f, 0x8a, 0x63,
+        0x01, 0x7e, 0x2d, 0x19
+    };
+
+    int errors = 0;
+    UUIDMAP_ID id = uuidmap_create(test_uuid);
+    if(!id) {
+        fprintf(stderr, "ERROR: Cannot create UUID for referenced destroy test\n");
+        return 1;
+    }
+
+    size_t referenced = uuidmap_destroy();
+    if(referenced != 1) {
+        fprintf(stderr, "ERROR: UUID destroy returned %zu referenced entries, expected 1\n", referenced);
+        errors++;
+    }
+
+    nd_uuid_t found_uuid;
+    if(!uuidmap_uuid(id, found_uuid)) {
+        fprintf(stderr, "ERROR: UUID disappeared after referenced destroy returned non-zero\n");
+        errors++;
+    }
+    else if(uuid_compare(found_uuid, test_uuid) != 0) {
+        fprintf(stderr, "ERROR: UUID changed after referenced destroy returned non-zero\n");
+        errors++;
+    }
+
+    uuidmap_free(id);
+
+    referenced = uuidmap_destroy();
+    if(referenced != 0) {
+        fprintf(stderr, "ERROR: UUID destroy returned %zu referenced entries after release, expected 0\n", referenced);
+        errors++;
+    }
+
+    if(errors)
+        fprintf(stderr, "UUID Map destroy referenced entry test: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "UUID Map destroy referenced entry test: OK\n");
+
+    return errors;
+}
 
 static void uuidmap_deferred_free_thread(void *arg) {
     UUIDMAP_DELETE_GATE *gate = arg;
@@ -606,7 +712,8 @@ int uuidmap_unittest(void) {
     fprintf(stderr, "\nTesting UUID Map...\n");
 
     const size_t ENTRIES = 100000;
-    int errors = uuidmap_locked_lookup_delete_interleaving_unittest();
+    int errors = uuidmap_destroy_referenced_entry_unittest();
+    errors += uuidmap_locked_lookup_delete_interleaving_unittest();
     errors += uuidmap_concurrent_unittest();
 
     struct test_entry {

--- a/src/libnetdata/uuid/uuidmap.h
+++ b/src/libnetdata/uuid/uuidmap.h
@@ -37,7 +37,7 @@ static inline UUIDMAP_ID uuidmap_make_id(uint8_t partition, uint32_t id) {
 // returns ID, or zero on error
 UUIDMAP_ID uuidmap_create(const nd_uuid_t uuid);
 
-// returns the number of entries still referenced (although freed)
+// returns the number of entries still referenced; non-zero leaves UUIDMap intact
 size_t uuidmap_destroy(void);
 
 // delete a uuid from the map

--- a/src/libnetdata/xxHash/xxhash.h
+++ b/src/libnetdata/xxHash/xxhash.h
@@ -5888,9 +5888,9 @@ XXH_PUBLIC_API XXH_errorcode
 XXH3_64bits_reset_withSecret(XXH_NOESCAPE XXH3_state_t* statePtr, XXH_NOESCAPE const void* secret, size_t secretSize)
 {
     if (statePtr == NULL) return XXH_ERROR;
-    XXH3_reset_internal(statePtr, 0, secret, secretSize);
     if (secret == NULL) return XXH_ERROR;
     if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_ERROR;
+    XXH3_reset_internal(statePtr, 0, secret, secretSize);
     return XXH_OK;
 }
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several high-priority runtime issues across clocks, dictionary GC, eval hardcoding, procfile reads, UUID map create/destroy, and `xxhash`. Improves safety under races, prevents livelocks and unbounded memory growth, and tightens error handling, with new tests.

- **Bug Fixes**
  - Clocks: added unsigned delta helper that saturates at zero; used in `heartbeat_next()` and EINTR retry; new unit tests.
  - Dictionary: introduced `ITEM_FLAG_PENDING_DELETION` and a small spinlock to serialize delete-mark/final-release; refcount paths now set/clear pending deletion consistently; GC counter stays correct; added race regression test.
  - Eval: guarded hardcode loop to bail out on no-progress replacements (prefix variable case); added regression test.
  - Procfile: bounded `procfile_readall()` to 128 MiB, clamped growth/read sizes, accepted exact-limit files via EOF probe, and reserved a spare byte for `'\0'` on exact-limit acceptance; oversize sources now fail with `errno=EFBIG`.
  - UUID Map: initialized ARAL under the partition write lock in `uuidmap_create()` to avoid destroy races; held all partition locks through destroy, claimed/freed only zero-ref entries, and left the map intact when references remain; referenced-destroy unittest made baseline-relative; header comment clarifies return contract.
  - `xxhash`: validated secret inputs before state reset in `XXH3_64bits_reset_withSecret()` to avoid partial mutation on error.

<sup>Written for commit 557df3c195bc1e4beb94223ed1a93dab7e017c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

