### PR TITLE
Netdata fixes part 56

### DIFF
--- a/src/collectors/windows.plugin/GetSensors.c
+++ b/src/collectors/windows.plugin/GetSensors.c
@@ -439,9 +439,9 @@ static inline char *netdata_pvar_to_char(const PROPERTYKEY *key, ISensor *pSenso
     HRESULT hr = pSensor->lpVtbl->GetProperty(pSensor, key, &pv);
     if (SUCCEEDED(hr) && pv.vt == VT_LPWSTR) {
         char value[8192];
-        int len = wcslen(pv.pwszVal);
-        len = wcstombs(value, pv.pwszVal, len);
-        if (len < 0) {
+        size_t len = wcstombs(value, pv.pwszVal, sizeof(value) - 1);
+        if (len == (size_t)-1) {
+            PropVariantClear(&pv);
             return NULL;
         }
         value[len] = '\0';

--- a/src/libnetdata/os/windows-perflib/perflib-dump.c
+++ b/src/libnetdata/os/windows-perflib/perflib-dump.c
@@ -448,8 +448,13 @@ bool dumpInstanceCb(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE *pObjectType, 
         if(pInstance->ParentObjectTitleIndex) {
             PERF_INSTANCE_DEFINITION *pi = pInstance;
             while(pi->ParentObjectTitleIndex) {
-                PERF_OBJECT_TYPE *po = getObjectTypeByIndex(pDataBlock, pInstance->ParentObjectTitleIndex);
+                PERF_OBJECT_TYPE *po = getObjectTypeByIndex(pDataBlock, pi->ParentObjectTitleIndex);
+                if(!po)
+                    break;
+
                 pi = getInstanceByPosition(pDataBlock, po, pi->ParentObjectInstance);
+                if(!pi)
+                    break;
 
                 if(!getInstanceName(pDataBlock, po, pi, name, sizeof(name)))
                     strncpyz(name, "[failed]", sizeof(name) - 1);

--- a/src/libnetdata/os/windows-perflib/perflib.c
+++ b/src/libnetdata/os/windows-perflib/perflib.c
@@ -629,7 +629,15 @@ PERF_INSTANCE_DEFINITION *getInstanceByPosition(PERF_DATA_BLOCK *pDataBlock, PER
     PERF_COUNTER_BLOCK *pc = NULL;
     for(DWORD i = 0; i <= instancePosition ;i++) {
         pi = getInstance(pDataBlock, pObjectType, pc);
+        if(!pi)
+            return NULL;
+
+        if(i == instancePosition)
+            return pi;
+
         pc = getInstanceCounterBlock(pDataBlock, pObjectType, pi);
+        if(!pc)
+            return NULL;
     }
     return pi;
 }

--- a/src/libnetdata/os/windows-perflib/perflib.c
+++ b/src/libnetdata/os/windows-perflib/perflib.c
@@ -459,6 +459,12 @@ static BOOL isValidInstanceDefinition(
                 pInstance->NameOffset > byte_length - pInstance->NameLength))
         return FALSE;
 
+    // when a name exists, it must live after the fixed header - otherwise
+    // header bytes would be decoded as the instance name
+    // (NameLength == 0 with NameOffset == 0 is valid for unnamed instances)
+    if(unlikely(pInstance->NameLength && pInstance->NameOffset < sizeof(*pInstance)))
+        return FALSE;
+
     return TRUE;
 }
 

--- a/src/libnetdata/os/windows-perflib/perflib.c
+++ b/src/libnetdata/os/windows-perflib/perflib.c
@@ -12,9 +12,12 @@
 // and the RegQueryValueEx will set your size variable to the required buffer size. However,
 // if the source is "Global" or one or more object index values, you will need to increment
 // the buffer size in a loop until RegQueryValueEx does not return ERROR_MORE_DATA.
-static LPBYTE getPerformanceData(const char *pwszSource) {
+static LPBYTE getPerformanceData(const char *pwszSource, DWORD *bytes_used) {
     static __thread DWORD size = 0;
     static __thread LPBYTE buffer = NULL;
+
+    if(bytes_used)
+        *bytes_used = 0;
 
     if(pwszSource == (const char *)0x01) {
         freez(buffer);
@@ -40,11 +43,14 @@ static LPBYTE getPerformanceData(const char *pwszSource) {
         return NULL;
     }
 
+    if(bytes_used)
+        *bytes_used = size;
+
     return buffer;
 }
 
 void perflibFreePerformanceData(void) {
-    getPerformanceData((const char *)0x01);
+    getPerformanceData((const char *)0x01, NULL);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -449,6 +455,10 @@ static BOOL isValidInstanceDefinition(
     if(unlikely(pObjectType && !isObjectSpanValid(pObjectType, pInstance, byte_length)))
         return FALSE;
 
+    if(unlikely(pInstance->NameLength > byte_length ||
+                pInstance->NameOffset > byte_length - pInstance->NameLength))
+        return FALSE;
+
     return TRUE;
 }
 
@@ -486,10 +496,25 @@ static BOOL isValidCounterDefinition(
     return TRUE;
 }
 
-static inline PERF_DATA_BLOCK *getDataBlock(BYTE *pBuffer) {
+static inline PERF_DATA_BLOCK *getDataBlock(BYTE *pBuffer, DWORD bytes_used) {
+    if(unlikely(!pBuffer || bytes_used < sizeof(PERF_DATA_BLOCK))) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "WINDOWS: PERFLIB: Performance data block is too small.");
+        return NULL;
+    }
+
     PERF_DATA_BLOCK *pDataBlock = (PERF_DATA_BLOCK *)pBuffer;
 
     static WCHAR signature[] = { 'P', 'E', 'R', 'F' };
+
+    if(unlikely(pDataBlock->TotalByteLength > bytes_used))
+        pDataBlock->TotalByteLength = bytes_used;
+
+    if(unlikely(pDataBlock->TotalByteLength < sizeof(*pDataBlock))) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "WINDOWS: PERFLIB: Invalid data block length.");
+        return NULL;
+    }
 
     if(memcmp(pDataBlock->Signature, signature, sizeof(signature)) != 0) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
@@ -637,6 +662,9 @@ static BOOL getEncodedStringToUTF8(char *dst, size_t dst_len, DWORD CodePage, ch
     WCHAR *tempBuffer;  // Temporary buffer for Unicode data
     DWORD charsCopied = 0;
 
+    if(unlikely(!dst || !dst_len || dst_len > INT_MAX || length > INT_MAX))
+        return FALSE;
+
     if (CodePage == 0) {
         // Input is already Unicode (UTF-16)
         tempBuffer = (WCHAR *)start;
@@ -649,6 +677,9 @@ static BOOL getEncodedStringToUTF8(char *dst, size_t dst_len, DWORD CodePage, ch
     }
 
     // Now convert from Unicode (UTF-16) to UTF-8
+    if(unlikely(charsCopied > INT_MAX))
+        return FALSE;
+
     int bytesCopied = WideCharToMultiByte(CP_UTF8, 0, tempBuffer, (int)charsCopied, dst, (int)dst_len, NULL, NULL);
     if (bytesCopied == 0) {
         dst[0] = '\0'; // Ensure the buffer is null-terminated even on failure
@@ -662,8 +693,10 @@ static BOOL getEncodedStringToUTF8(char *dst, size_t dst_len, DWORD CodePage, ch
 ALWAYS_INLINE
 BOOL getInstanceName(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE *pObjectType, PERF_INSTANCE_DEFINITION *pInstance,
                      char *buffer, size_t bufferLen) {
-    (void)pDataBlock;
     if (!pObjectType || !pInstance || !buffer || !bufferLen)
+        return FALSE;
+
+    if(!isValidInstanceDefinition(pDataBlock, pObjectType, pInstance))
         return FALSE;
 
     return getEncodedStringToUTF8(buffer, bufferLen, pObjectType->CodePage,
@@ -811,10 +844,11 @@ PERF_DATA_BLOCK *perflibGetPerformanceData(DWORD id) {
     char source[24];
     snprintfz(source, sizeof(source), "%u", id);
 
-    LPBYTE pData = (LPBYTE)getPerformanceData((id > 0) ? source : NULL);
+    DWORD bytes_used = 0;
+    LPBYTE pData = (LPBYTE)getPerformanceData((id > 0) ? source : NULL, &bytes_used);
     if (!pData) return NULL;
 
-    PERF_DATA_BLOCK *pDataBlock = getDataBlock(pData);
+    PERF_DATA_BLOCK *pDataBlock = getDataBlock(pData, bytes_used);
     if(!pDataBlock) return NULL;
 
     return pDataBlock;

--- a/src/libnetdata/spawn_server/log-forwarder.c
+++ b/src/libnetdata/spawn_server/log-forwarder.c
@@ -221,27 +221,31 @@ bool log_forwarder_del_and_close_token(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN to
 }
 
 void log_forwarder_annotate_token_name(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token, const char *cmd) {
-    if(!lf || !lf->running || token == LOG_FORWARDER_TOKEN_NONE || !cmd || !*cmd) return;
+    if(!lf || token == LOG_FORWARDER_TOKEN_NONE || !cmd || !*cmd) return;
 
     spinlock_lock(&lf->spinlock);
 
-    LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, token);
-    if (entry) {
-        freez(entry->cmd);
-        entry->cmd = strdupz(cmd);
+    if(lf->running) {
+        LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, token);
+        if (entry) {
+            freez(entry->cmd);
+            entry->cmd = strdupz(cmd);
+        }
     }
 
     spinlock_unlock(&lf->spinlock);
 }
 
 void log_forwarder_annotate_token_pid(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token, pid_t pid) {
-    if(!lf || !lf->running || token == LOG_FORWARDER_TOKEN_NONE) return;
+    if(!lf || token == LOG_FORWARDER_TOKEN_NONE) return;
 
     spinlock_lock(&lf->spinlock);
 
-    LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, token);
-    if (entry)
-        entry->pid = pid;
+    if(lf->running) {
+        LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, token);
+        if (entry)
+            entry->pid = pid;
+    }
 
     spinlock_unlock(&lf->spinlock);
 }

--- a/src/libnetdata/spawn_server/log-forwarder.c
+++ b/src/libnetdata/spawn_server/log-forwarder.c
@@ -197,20 +197,22 @@ LOG_FORWARDER_TOKEN log_forwarder_add_fd(LOG_FORWARDER *lf, int fd) {
 }
 
 bool log_forwarder_del_and_close_token(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token) {
-    if(!lf || !lf->running || token == LOG_FORWARDER_TOKEN_NONE) return false;
+    if(!lf || token == LOG_FORWARDER_TOKEN_NONE) return false;
 
     bool ret = false;
 
     spinlock_lock(&lf->spinlock);
 
-    LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, token);
-    if(entry) {
-        entry->delete = true;
+    if(lf->running) {
+        LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, token);
+        if(entry) {
+            entry->delete = true;
 
-        // Send a byte to the pipe to wake up the thread
-        log_forwarder_wake_up_worker(lf);
+            // Send a byte to the pipe to wake up the thread
+            log_forwarder_wake_up_worker(lf);
 
-        ret = true;
+            ret = true;
+        }
     }
 
     spinlock_unlock(&lf->spinlock);

--- a/src/libnetdata/spawn_server/log-forwarder.c
+++ b/src/libnetdata/spawn_server/log-forwarder.c
@@ -5,6 +5,7 @@
 
 typedef struct LOG_FORWARDER_ENTRY {
     int fd;
+    LOG_FORWARDER_TOKEN token;
     char *cmd;
     pid_t pid;
     BUFFER *wb;
@@ -20,6 +21,7 @@ typedef struct LOG_FORWARDER {
     ND_THREAD *thread;
     SPINLOCK spinlock;
     int pipe_fds[2]; // Pipe for notifications
+    LOG_FORWARDER_TOKEN next_token;
     bool running;
     volatile bool initialized; // Thread has fully initialized (atomic)
 } LOG_FORWARDER;
@@ -39,13 +41,21 @@ static inline size_t log_forwarder_max_pfds(void) {
 // --------------------------------------------------------------------------------------------------------------------
 // helper functions
 
-static inline LOG_FORWARDER_ENTRY *log_forwarder_find_entry_unsafe(LOG_FORWARDER *lf, int fd) {
+static inline LOG_FORWARDER_ENTRY *log_forwarder_find_entry_unsafe(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token) {
     for (LOG_FORWARDER_ENTRY *entry = lf->entries; entry; entry = entry->next) {
-        if (entry->fd == fd)
+        if (entry->token == token)
             return entry;
     }
 
     return NULL;
+}
+
+static inline LOG_FORWARDER_TOKEN log_forwarder_next_token_unsafe(LOG_FORWARDER *lf) {
+    LOG_FORWARDER_TOKEN token = lf->next_token++;
+    if(unlikely(token == LOG_FORWARDER_TOKEN_NONE))
+        token = lf->next_token++;
+
+    return token;
 }
 
 static inline void log_forwarder_del_entry_unsafe(LOG_FORWARDER *lf, LOG_FORWARDER_ENTRY *entry) {
@@ -82,6 +92,7 @@ LOG_FORWARDER *log_forwarder_start(void) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "Log forwarder: Failed to set non-blocking mode");
 
     lf->running = true;
+    lf->next_token = LOG_FORWARDER_TOKEN_NONE + 1;
     __atomic_store_n(&lf->initialized, false, __ATOMIC_RELEASE);
 
     lf->thread = nd_thread_create("log-fw", NETDATA_THREAD_OPTION_DEFAULT, log_forwarder_thread_func, lf);
@@ -151,8 +162,8 @@ void log_forwarder_stop(LOG_FORWARDER *lf) {
 // --------------------------------------------------------------------------------------------------------------------
 // managing entries
 
-void log_forwarder_add_fd(LOG_FORWARDER *lf, int fd) {
-    if(!lf || !lf->running || fd < 0) return;
+LOG_FORWARDER_TOKEN log_forwarder_add_fd(LOG_FORWARDER *lf, int fd) {
+    if(!lf || fd < 0) return LOG_FORWARDER_TOKEN_NONE;
 
     LOG_FORWARDER_ENTRY *entry = callocz(1, sizeof(LOG_FORWARDER_ENTRY));
     entry->fd = fd;
@@ -164,6 +175,16 @@ void log_forwarder_add_fd(LOG_FORWARDER *lf, int fd) {
 
     spinlock_lock(&lf->spinlock);
 
+    if(!lf->running) {
+        spinlock_unlock(&lf->spinlock);
+        buffer_free(entry->wb);
+        freez(entry);
+        return LOG_FORWARDER_TOKEN_NONE;
+    }
+
+    LOG_FORWARDER_TOKEN token = log_forwarder_next_token_unsafe(lf);
+    entry->token = token;
+
     // Append to the entries list
     DOUBLE_LINKED_LIST_PREPEND_ITEM_UNSAFE(lf->entries, entry, prev, next);
 
@@ -171,16 +192,18 @@ void log_forwarder_add_fd(LOG_FORWARDER *lf, int fd) {
     log_forwarder_wake_up_worker(lf);
 
     spinlock_unlock(&lf->spinlock);
+
+    return token;
 }
 
-bool log_forwarder_del_and_close_fd(LOG_FORWARDER *lf, int fd) {
-    if(!lf || !lf->running || fd < 0) return false;
+bool log_forwarder_del_and_close_token(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token) {
+    if(!lf || !lf->running || token == LOG_FORWARDER_TOKEN_NONE) return false;
 
     bool ret = false;
 
     spinlock_lock(&lf->spinlock);
 
-    LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, fd);
+    LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, token);
     if(entry) {
         entry->delete = true;
 
@@ -195,12 +218,12 @@ bool log_forwarder_del_and_close_fd(LOG_FORWARDER *lf, int fd) {
     return ret;
 }
 
-void log_forwarder_annotate_fd_name(LOG_FORWARDER *lf, int fd, const char *cmd) {
-    if(!lf || !lf->running || fd < 0 || !cmd || !*cmd) return;
+void log_forwarder_annotate_token_name(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token, const char *cmd) {
+    if(!lf || !lf->running || token == LOG_FORWARDER_TOKEN_NONE || !cmd || !*cmd) return;
 
     spinlock_lock(&lf->spinlock);
 
-    LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, fd);
+    LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, token);
     if (entry) {
         freez(entry->cmd);
         entry->cmd = strdupz(cmd);
@@ -209,12 +232,12 @@ void log_forwarder_annotate_fd_name(LOG_FORWARDER *lf, int fd, const char *cmd) 
     spinlock_unlock(&lf->spinlock);
 }
 
-void log_forwarder_annotate_fd_pid(LOG_FORWARDER *lf, int fd, pid_t pid) {
-    if(!lf || !lf->running || fd < 0) return;
+void log_forwarder_annotate_token_pid(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token, pid_t pid) {
+    if(!lf || !lf->running || token == LOG_FORWARDER_TOKEN_NONE) return;
 
     spinlock_lock(&lf->spinlock);
 
-    LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, fd);
+    LOG_FORWARDER_ENTRY *entry = log_forwarder_find_entry_unsafe(lf, token);
     if (entry)
         entry->pid = pid;
 

--- a/src/libnetdata/spawn_server/log-forwarder.h
+++ b/src/libnetdata/spawn_server/log-forwarder.h
@@ -6,12 +6,15 @@
 #include "../common.h"
 
 typedef struct LOG_FORWARDER LOG_FORWARDER;
+typedef uint64_t LOG_FORWARDER_TOKEN;
+
+#define LOG_FORWARDER_TOKEN_NONE 0
 
 LOG_FORWARDER *log_forwarder_start(void); // done once, at spawn_server_create()
-void log_forwarder_add_fd(LOG_FORWARDER *lf, int fd); // to add a new fd
-void log_forwarder_annotate_fd_name(LOG_FORWARDER *lf, int fd, const char *cmd); // set the syslog identifier
-void log_forwarder_annotate_fd_pid(LOG_FORWARDER *lf, int fd, pid_t pid); // set the pid of the child process
-bool log_forwarder_del_and_close_fd(LOG_FORWARDER *lf, int fd); // to remove an fd
+LOG_FORWARDER_TOKEN log_forwarder_add_fd(LOG_FORWARDER *lf, int fd); // to add a new fd
+void log_forwarder_annotate_token_name(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token, const char *cmd); // set the syslog identifier
+void log_forwarder_annotate_token_pid(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token, pid_t pid); // set the pid of the child process
+bool log_forwarder_del_and_close_token(LOG_FORWARDER *lf, LOG_FORWARDER_TOKEN token); // to remove an fd
 void log_forwarder_stop(LOG_FORWARDER *lf); // done once, at spawn_server_destroy()
 
 #endif //NETDATA_LOG_FORWARDER_H

--- a/src/libnetdata/spawn_server/spawn_server_internals.h
+++ b/src/libnetdata/spawn_server/spawn_server_internals.h
@@ -88,6 +88,7 @@ struct spawn_instance {
 #if defined(SPAWN_SERVER_VERSION_WINDOWS)
     HANDLE process_handle;
     DWORD dwProcessId;
+    LOG_FORWARDER_TOKEN stderr_log_token;
 #endif
 };
 

--- a/src/libnetdata/spawn_server/spawn_server_windows.c
+++ b/src/libnetdata/spawn_server/spawn_server_windows.c
@@ -135,6 +135,20 @@ int set_fd_blocking(int fd) {
     return 0;
 }
 
+static void spawn_server_release_stderr_fd(SPAWN_SERVER *server, SPAWN_INSTANCE *si) {
+    if(si->stderr_fd == -1)
+        return;
+
+    if(si->stderr_log_token != LOG_FORWARDER_TOKEN_NONE) {
+        log_forwarder_del_and_close_token(server->log_forwarder, si->stderr_log_token);
+        si->stderr_log_token = LOG_FORWARDER_TOKEN_NONE;
+    }
+    else
+        close(si->stderr_fd);
+
+    si->stderr_fd = -1;
+}
+
 //static void print_environment_block(char *env_block) {
 //    if (env_block == NULL) {
 //        fprintf(stderr, "Environment block is NULL\n");
@@ -294,9 +308,9 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_un
     instance->stderr_fd = pipe_stderr[PIPE_READ];
 
     // Add stderr_fd to the log forwarder
-    log_forwarder_add_fd(server->log_forwarder, instance->stderr_fd);
-    log_forwarder_annotate_fd_name(server->log_forwarder, instance->stderr_fd, command);
-    log_forwarder_annotate_fd_pid(server->log_forwarder, instance->stderr_fd, spawn_server_instance_pid(instance));
+    instance->stderr_log_token = log_forwarder_add_fd(server->log_forwarder, instance->stderr_fd);
+    log_forwarder_annotate_token_name(server->log_forwarder, instance->stderr_log_token, command);
+    log_forwarder_annotate_token_pid(server->log_forwarder, instance->stderr_log_token, spawn_server_instance_pid(instance));
 
     errno_clear();
     nd_log(NDLS_COLLECTORS, NDLP_INFO,
@@ -435,12 +449,7 @@ int spawn_server_exec_kill(SPAWN_SERVER *server __maybe_unused, SPAWN_INSTANCE *
     errno_clear();
     TerminateChildProcesses(si);
 
-    if(si->stderr_fd != -1) {
-        if(!log_forwarder_del_and_close_fd(server->log_forwarder, si->stderr_fd))
-            close(si->stderr_fd);
-
-        si->stderr_fd = -1;
-    }
+    spawn_server_release_stderr_fd(server, si);
 
     return spawn_server_exec_wait(server, si);
 }
@@ -497,12 +506,7 @@ int spawn_server_exec_wait(SPAWN_SERVER *server __maybe_unused, SPAWN_INSTANCE *
     if(err)
         LocalFree(err);
 
-    if(si->stderr_fd != -1) {
-        if(!log_forwarder_del_and_close_fd(server->log_forwarder, si->stderr_fd))
-            close(si->stderr_fd);
-
-        si->stderr_fd = -1;
-    }
+    spawn_server_release_stderr_fd(server, si);
 
     freez(si);
     return map_status_code_to_signal(exit_code);

--- a/src/libnetdata/spawn_server/spawn_server_windows.c
+++ b/src/libnetdata/spawn_server/spawn_server_windows.c
@@ -140,6 +140,10 @@ static void spawn_server_release_stderr_fd(SPAWN_SERVER *server, SPAWN_INSTANCE 
         return;
 
     if(si->stderr_log_token != LOG_FORWARDER_TOKEN_NONE) {
+        // a valid token means the forwarder adopted the fd and closes it on
+        // every path (worker delete, or thread-exit cleanup); a false return
+        // means it is already closed or about to be - raw-closing the number
+        // here could close an unrelated, recycled descriptor
         log_forwarder_del_and_close_token(server->log_forwarder, si->stderr_log_token);
         si->stderr_log_token = LOG_FORWARDER_TOKEN_NONE;
     }


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Windows perflib and sensor parsing and fixes Windows spawn log forwarding by moving from fd-based tracking to stable tokens. Prevents crashes, buffer overflows, and wrong-descriptor closes under reuse.

- **Bug Fixes**
  - Perflib: pass the actual byte count from `RegQueryValueEx`, clamp `TotalByteLength`, reject too-small blocks, and validate instance `NameOffset/NameLength` (reject names overlapping the instance header). Make `getInstanceByPosition()` and parent traversal in `perflib-dump` stop on NULLs and use the current parent pointer. Add bounds checks in string encoding and validate the instance before `getInstanceName()`.
  - Sensors: bound `wcstombs()` by `sizeof(value) - 1`, handle `(size_t)-1`, and clear `PROPVARIANT` on failure to avoid overflow and leaks.
  - Log forwarder/spawn (Windows): introduce `LOG_FORWARDER_TOKEN` to identify entries. Replace fd-based lookup/teardown with token-based APIs, store the token in `SPAWN_INSTANCE`, and retire tokens on teardown. Read `running` under lock in deletion and annotate helpers to avoid races.

- **Migration**
  - Update users of the log forwarder API:
    - `log_forwarder_add_fd()` now returns a `LOG_FORWARDER_TOKEN`; store it.
    - Use `log_forwarder_annotate_token_name()` and `log_forwarder_annotate_token_pid()`.
    - Replace `log_forwarder_del_and_close_fd()` with `log_forwarder_del_and_close_token()`.

<sup>Written for commit 38c11b7bfa1e5ef04cd3c941fb1e132d92fc21c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

