### PR TITLE
fix(database): keep rrdset indexes allocated while host is archived

### DIFF
--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -808,7 +808,12 @@ void rrdhost_cleanup_data_collection_and_health(RRDHOST *host) {
     rrdhost_pluginsd_receive_chart_slots_free(host);
 
     rrdcalc_delete_all(host);
-    rrdset_index_destroy(host);
+
+    // flush, not destroy: this runs when the host transitions to archived
+    // (service.c) while queries may still hold acquired charts; the indexes
+    // must stay allocated until rrdhost_free_unlinked() destroys them
+    rrdset_index_flush(host);
+
     rrdcalc_rrdhost_index_destroy(host);
     health_alarm_log_free(host);
 
@@ -841,6 +846,10 @@ static void rrdhost_unlink___while_having_rrd_wrlock(RRDHOST *host) {
 
 static void rrdhost_free_unlinked(RRDHOST *host) {
     rrdhost_cleanup_data_collection_and_health(host);
+
+    // the host is already unlinked, so no new queries can find it;
+    // now it is safe to destroy the chart indexes the archive path only flushed
+    rrdset_index_destroy(host);
 
     // ------------------------------------------------------------------------
     // free it

--- a/src/database/rrdset-index-id.c
+++ b/src/database/rrdset-index-id.c
@@ -310,6 +310,20 @@ void rrdset_index_init(RRDHOST *host) {
     rrdset_index_byname_init(host);
 }
 
+void rrdset_index_flush(RRDHOST *host) {
+    // empty the indexes but keep them allocated and the host pointers valid,
+    // so that in-flight queries holding acquired charts can still release them
+    // through rrdset_acquired_release() after the host is archived;
+    // the indexes are destroyed only in rrdhost_free_unlinked(), after the
+    // host has been removed from the indexes and cannot be found by new queries
+
+    // flush the name index first (it is a view of the id index)
+    dictionary_flush(host->rrdset_root_index_name);
+
+    // then flush the id index
+    dictionary_flush(host->rrdset_root_index);
+}
+
 void rrdset_index_destroy(RRDHOST *host) {
     // destroy the name index first
     dictionary_destroy(host->rrdset_root_index_name);
@@ -365,6 +379,9 @@ RRDSET *rrdset_find_bytype(RRDHOST *host, const char *type, const char *id, bool
 RRDSET_ACQUIRED *rrdset_find_and_acquire(RRDHOST *host, const char *id, bool include_obsolete) {
     netdata_log_debug(D_RRD_CALLS, "rrdset_find_and_acquire() for host %s, chart %s", rrdhost_hostname(host), id);
 
+    // the index stays allocated for the whole life of the host (archiving only
+    // flushes it); this guard is defense-in-depth for callers racing with
+    // rrdhost_free_unlinked()
     if (unlikely(!host->rrdset_root_index))
         return NULL;
 

--- a/src/database/rrdset-index-id.h
+++ b/src/database/rrdset-index-id.h
@@ -61,6 +61,7 @@ static inline
 }
 
 void rrdset_index_init(RRDHOST *host);
+void rrdset_index_flush(RRDHOST *host);
 void rrdset_index_destroy(RRDHOST *host);
 
 void rrdset_free(RRDSET *st);


### PR DESCRIPTION
##### Summary
Follow-up to #23056, which guarded the lookup side of the same problem.

The orphan→archived transition destroys the host's rrdset indexes and nulls
the pointers while queries may still be in flight, leaving two windows:

1. A query that acquired a chart before the archive crashes on release:
   `dictionary_destroy()` defers destruction (referenced items), but
   `rrdset_index_destroy()` nulls `host->rrdset_root_index` anyway, so
   `rrdset_acquired_release()` dereferences NULL. Every data query holds
   acquired charts for its full duration (`query_target.c`), so on parents
   archiving hosts under constant query load this eventually fires.
2. The fix in (#23056) guard itself is a TOCTOU: if the archive runs entirely between
   the pointer check and its use, and nothing holds a reference, the dict is
   freed immediately and the lookup calls into freed memory.

Fix: on archive, flush the indexes (name view first, then the id index) but
keep them allocated — lookups return NULL naturally, releases always see a
valid dictionary, and a lookup racing with the archive now races with a
normal locked flush instead of destruction. The indexes are destroyed only in
`rrdhost_free_unlinked()`, after the host is unlinked and unreachable.

Semantics are unchanged: flush is exactly what `dictionary_destroy()` already
did internally when deferring, so charts held by queries are still freed when
the last reference drains. Host reactivation (archived→live) now reuses the
surviving index instead of recreating it (`rrdhost.c` already guards init
with `if (!host->rrdset_root_index)`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes during host archival by flushing RRD set indexes instead of destroying them. This removes a null-deref and TOCTOU window for in-flight queries and lets reactivated hosts reuse the same indexes.

- **Bug Fixes**
  - Introduced `rrdset_index_flush()` and use it on archive; flushes name, then id index, but keeps them allocated.
  - Destroy indexes only in `rrdhost_free_unlinked()`, after the host is unreachable.
  - Added a defensive guard in `rrdset_find_and_acquire()` to avoid accessing a freed index.

<sup>Written for commit 7efe32c9d0bbc372c15ca8409e896e1ba850ef7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

