### PR TITLE
Netdata fixes part 57

### DIFF
--- a/src/database/rrdfunctions-inflight.c
+++ b/src/database/rrdfunctions-inflight.c
@@ -5,8 +5,6 @@
 #include "rrdfunctions-inflight.h"
 
 struct rrd_function_inflight {
-    bool used;
-
     RRDHOST *host;
     nd_uuid_t transaction_uuid;
     const char *transaction;
@@ -104,6 +102,17 @@ static void rrd_functions_inflight_insert_cb(const DICTIONARY_ITEM *item __maybe
     spinlock_init(&r->callbacks.spinlock);
 }
 
+static bool rrd_functions_inflight_conflict_cb(const DICTIONARY_ITEM *item __maybe_unused,
+                                               void *old_value __maybe_unused,
+                                               void *new_value __maybe_unused,
+                                               void *data) {
+    bool *duplicate_transaction = data;
+    if(duplicate_transaction)
+        *duplicate_transaction = true;
+
+    return false;
+}
+
 void rrd_functions_inflight_init(void) {
     if(rrd_functions_inflight_requests)
         return;
@@ -112,6 +121,7 @@ void rrd_functions_inflight_init(void) {
 
     dictionary_register_insert_callback(rrd_functions_inflight_requests, rrd_functions_inflight_insert_cb, NULL);
     dictionary_register_delete_callback(rrd_functions_inflight_requests, rrd_functions_inflight_delete_cb, NULL);
+    dictionary_register_conflict_callback(rrd_functions_inflight_requests, rrd_functions_inflight_conflict_cb, NULL);
 }
 
 void rrd_functions_inflight_destroy(void) {
@@ -518,7 +528,6 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
     // put the function into the inflight requests
 
     struct rrd_function_inflight t = {
-        .used = false,
         .host = host,
         .cmd = strdupz(cmd),
         .sanitized_cmd = strdupz(sanitized_cmd),
@@ -549,7 +558,9 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
     sanitized_source = NULL;
     uuid_copy(t.transaction_uuid, uuid);
 
-    struct rrd_function_inflight *r = dictionary_set(rrd_functions_inflight_requests, transaction, &t, sizeof(t));
+    bool duplicate_transaction = false;
+    struct rrd_function_inflight *r = dictionary_set_advanced(
+        rrd_functions_inflight_requests, transaction, -1, &t, sizeof(t), &duplicate_transaction);
     if(!r) {
         // dictionary_set() returns NULL when the dictionary is destroyed (shutdown in progress)
         code = rrd_call_function_error(result_wb, "Service is shutting down.", HTTP_RESP_SERVICE_UNAVAILABLE);
@@ -563,7 +574,7 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
         return code;
     }
 
-    if(r->used) {
+    if(duplicate_transaction) {
         nd_log(NDLS_DAEMON, NDLP_NOTICE,
                "FUNCTIONS: duplicate transaction '%s', function: '%s'",
                t.transaction, t.cmd);
@@ -571,14 +582,13 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
         code = rrd_call_function_error(result_wb, "Duplicate transaction.", HTTP_RESP_BAD_REQUEST);
 
         rrd_functions_inflight_cleanup(&t);
-        dictionary_acquired_item_release(r->host->functions, t.host_function_acquired);
+        dictionary_acquired_item_release(host->functions, t.host_function_acquired);
 
         if(result_cb)
             result_cb(result_wb, code, result_cb_data);
 
         return code;
     }
-    r->used = true;
     // internal_error(true, "FUNCTIONS: transaction '%s' started", r->transaction);
 
     if(r->rdcf->sync) {

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -2215,8 +2215,15 @@ static ssize_t weights_count_node_callback(void *data, RRDHOST *host, bool query
 
     struct query_weights_data *qwd = data;
     if (qwd->total_hosts >= qwd->hosts_array_capacity) {
-        qwd->hosts_array_capacity = qwd->hosts_array_capacity ? qwd->hosts_array_capacity * 2 : 1;
-        qwd->hosts_array = reallocz(qwd->hosts_array, sizeof(RRDHOST *) * qwd->hosts_array_capacity);
+        if(unlikely(qwd->hosts_array_capacity > SIZE_MAX / 2))
+            fatal("QUERY WEIGHTS: too many hosts to allocate");
+
+        size_t new_capacity = qwd->hosts_array_capacity ? qwd->hosts_array_capacity * 2 : 1;
+        if(unlikely(new_capacity > SIZE_MAX / sizeof(*qwd->hosts_array)))
+            fatal("QUERY WEIGHTS: too many hosts to allocate");
+
+        qwd->hosts_array = reallocz(qwd->hosts_array, new_capacity * sizeof(*qwd->hosts_array));
+        qwd->hosts_array_capacity = new_capacity;
     }
     qwd->hosts_array[qwd->total_hosts++] = host;
 
@@ -2281,7 +2288,10 @@ static ssize_t query_scope_foreach_host_parallel(SIMPLE_PATTERN *scope_hosts_sp,
 #else
     size_t host_count = dictionary_entries(rrdhost_root_index);
     qwd->hosts_array_capacity = host_count ? host_count : 1;
-    qwd->hosts_array = mallocz(sizeof(RRDHOST *) * qwd->hosts_array_capacity);
+    if(unlikely(qwd->hosts_array_capacity > SIZE_MAX / sizeof(*qwd->hosts_array)))
+        fatal("QUERY WEIGHTS: too many hosts to allocate");
+
+    qwd->hosts_array = mallocz(qwd->hosts_array_capacity * sizeof(*qwd->hosts_array));
     qwd->total_hosts = 0;
 
     (void) query_scope_foreach_host(scope_hosts_sp, hosts_sp, weights_count_node_callback, qwd, &qwd->versions, NULL);

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -344,6 +344,7 @@ struct workload_stats {
 
 struct query_weights_data {
     QUERY_WEIGHTS_REQUEST *qwr;
+    struct query_weights_data *shared_qwd;
 
     SIMPLE_PATTERN *scope_nodes_sp;
     SIMPLE_PATTERN *scope_contexts_sp;
@@ -394,6 +395,25 @@ struct query_weights_thread_data {
     size_t thread_id;
 };
 
+static inline struct query_weights_data *query_weights_status_qwd(struct query_weights_data *qwd) {
+    return qwd->shared_qwd ? qwd->shared_qwd : qwd;
+}
+
+static inline bool query_weights_is_stopped(struct query_weights_data *qwd) {
+    struct query_weights_data *status_qwd = query_weights_status_qwd(qwd);
+
+    return __atomic_load_n(&status_qwd->timed_out, __ATOMIC_RELAXED) ||
+           __atomic_load_n(&status_qwd->interrupted, __ATOMIC_RELAXED);
+}
+
+static inline void query_weights_set_timed_out(struct query_weights_data *qwd) {
+    __atomic_store_n(&query_weights_status_qwd(qwd)->timed_out, true, __ATOMIC_RELAXED);
+}
+
+static inline void query_weights_set_interrupted(struct query_weights_data *qwd) {
+    __atomic_store_n(&query_weights_status_qwd(qwd)->interrupted, true, __ATOMIC_RELAXED);
+}
+
 // Worker thread function for parallel host processing
 void query_weights_worker_thread(void *arg)
 {
@@ -431,6 +451,7 @@ void query_weights_worker_thread(void *arg)
 
         // Create a local query_weights_data for this thread
         struct query_weights_data local_qwd = *main_qwd;
+        local_qwd.shared_qwd = main_qwd;
         local_qwd.results = thread_data->local_results;
         local_qwd.stats = thread_data->local_stats;
         local_qwd.examined_dimensions = thread_data->local_examined_dimensions;
@@ -2079,8 +2100,11 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
     struct query_weights_data *qwd = data;
     QUERY_WEIGHTS_REQUEST *qwr = qwd->qwr;
 
+    if(query_weights_is_stopped(qwd))
+        return -1;
+
     if(qwd->qwr->interrupt_callback && qwd->qwr->interrupt_callback(qwd->qwr->interrupt_callback_data)) {
-        __atomic_store_n(&qwd->interrupted, true, __ATOMIC_RELAXED);
+        query_weights_set_interrupted(qwd);
         return -1;
     }
 
@@ -2134,7 +2158,7 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
 
     qwd->timings.executed_ut = now_monotonic_usec();
     if(qwd->timings.executed_ut - qwd->timings.received_ut > qwd->timeout_us) {
-        qwd->timed_out = true;
+        query_weights_set_timed_out(qwd);
         return -1;
     }
 
@@ -2239,6 +2263,9 @@ static ssize_t weights_do_context_callback(void *data, RRDCONTEXT_ACQUIRED *rca,
                                             qwd->dimensions_sp,
                                             true, true, qwd->qwr->version,
                                             weights_for_rrdmetric, qwd);
+    if(query_weights_is_stopped(qwd))
+        return -1;
+
     return ret;
 }
 

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -2215,7 +2215,7 @@ static ssize_t weights_count_node_callback(void *data, RRDHOST *host, bool query
 
     struct query_weights_data *qwd = data;
     if (qwd->total_hosts >= qwd->hosts_array_capacity) {
-        qwd->hosts_array_capacity *= 2;
+        qwd->hosts_array_capacity = qwd->hosts_array_capacity ? qwd->hosts_array_capacity * 2 : 1;
         qwd->hosts_array = reallocz(qwd->hosts_array, sizeof(RRDHOST *) * qwd->hosts_array_capacity);
     }
     qwd->hosts_array[qwd->total_hosts++] = host;
@@ -2280,8 +2280,8 @@ static ssize_t query_scope_foreach_host_parallel(SIMPLE_PATTERN *scope_hosts_sp,
 
 #else
     size_t host_count = dictionary_entries(rrdhost_root_index);
-    qwd->hosts_array = mallocz(sizeof(RRDHOST *) * host_count);
-    qwd->hosts_array_capacity = host_count;
+    qwd->hosts_array_capacity = host_count ? host_count : 1;
+    qwd->hosts_array = mallocz(sizeof(RRDHOST *) * qwd->hosts_array_capacity);
     qwd->total_hosts = 0;
 
     (void) query_scope_foreach_host(scope_hosts_sp, hosts_sp, weights_count_node_callback, qwd, &qwd->versions, NULL);


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate inflight function transactions, preserves RRDR metadata when limiting cardinality, and makes parallel weights queries stop correctly and allocate safely. Adds overflow-guarded allocation helpers for the cardinality limiter; no behavior change for successful queries.

- **Bug Fixes**
  - rrdfunctions: serialize duplicate keys via dictionary conflict callback; drop the shared flag; release acquisitions on the correct host; still returns HTTP 400 Duplicate transaction.
  - Cardinality limit: keep side arrays and label dictionaries when rebuilding RRDR; move label dictionary ownership; aggregate counts/hidden values for the “remaining” bucket; create empty dictionaries only when needed.
  - Weights stop/cancel: route timeout/interrupt checks and sets through a shared parent `query_weights_data` so all workers see cancellations; context callback returns -1 when the shared stop flag is set.
  - Weights host collection: prevent zero-capacity growth and allocation overflow; start with at least capacity 1, double safely with bounds checks, and resize using `sizeof(*hosts_array)`.

- **Refactors**
  - `onewayalloc`: add overflow-guarded multipliers (`onewayalloc_mul_or_fatal`, `onewayalloc_mul3_or_fatal`) and use them for cardinality limiter sizing.

<sup>Written for commit f4413c5f4fe8fa815a1c1b19915dc67a5c32d0e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

