### PR TITLE
Netdata fixes part 58

### DIFF
--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -488,7 +488,7 @@ bool claim_agent_from_environment(void) {
 
     bool insecure = CONFIG_BOOLEAN_NO;
     const char *from_env = getenv("NETDATA_EXTRA_CLAIM_OPTS");
-    if(from_env && *from_env && strstr(from_env, "-insecure") == 0)
+    if(from_env && *from_env && strstr(from_env, "-insecure") != NULL)
         insecure = CONFIG_BOOLEAN_YES;
 
     return claim_agent(url, token, rooms, proxy, insecure);

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -467,6 +467,24 @@ bool claim_agent(const char *url, const char *token, const char *rooms, const ch
     return done;
 }
 
+static bool claim_extra_opts_has_token(const char *opts, const char *token, size_t token_len) {
+    while(opts && *opts) {
+        while(isspace((uint8_t)*opts))
+            opts++;
+
+        const char *end = opts;
+        while(*end && !isspace((uint8_t)*end))
+            end++;
+
+        if((size_t)(end - opts) == token_len && memcmp(opts, token, token_len) == 0)
+            return true;
+
+        opts = end;
+    }
+
+    return false;
+}
+
 bool claim_agent_from_environment(void) {
     const char *url = getenv("NETDATA_CLAIM_URL");
     if(!url || !*url) {
@@ -488,7 +506,7 @@ bool claim_agent_from_environment(void) {
 
     bool insecure = CONFIG_BOOLEAN_NO;
     const char *from_env = getenv("NETDATA_EXTRA_CLAIM_OPTS");
-    if(from_env && *from_env && strstr(from_env, "-insecure") != NULL)
+    if(claim_extra_opts_has_token(from_env, "-insecure", sizeof("-insecure") - 1))
         insecure = CONFIG_BOOLEAN_YES;
 
     return claim_agent(url, token, rooms, proxy, insecure);

--- a/src/collectors/windows.plugin/GetHardwareInfo.c
+++ b/src/collectors/windows.plugin/GetHardwareInfo.c
@@ -527,14 +527,11 @@ void do_GetHardwareInfo_cleanup()
 {
     if (hardware_info_thread) {
         if (nd_thread_join(hardware_info_thread)) {
-            // nd_thread_join() frees the ND_THREAD object even on failure,
-            // so we cannot retry. The Windows/MSYS2 UV_EINVAL fast-exit case
-            // is already handled inside nd_thread_join(). For any other error,
-            // wait for up to one heartbeat interval plus slack for the worker
-            // to report completion before tearing down local resources it may
-            // still be touching. If it never does, abort cleanup: leaking here
-            // is safer than racing a live worker or hanging plugin shutdown
-            // indefinitely.
+            // nd_thread_join() keeps the ND_THREAD wrapper alive if the worker
+            // is not proven finished. Wait for the worker to report completion
+            // before tearing down local resources it may still be touching. If
+            // it never does, abort cleanup: leaking here is safer than racing a
+            // live worker or hanging plugin shutdown indefinitely.
             nd_log_daemon(NDLP_ERR, "Failed to join Get Hardware Info thread");
 
             size_t retries = 0;

--- a/src/libnetdata/log/nd_log.c
+++ b/src/libnetdata/log/nd_log.c
@@ -354,10 +354,12 @@ static void nd_logger(const char *file, const char *function, const unsigned lon
     nd_logger_log_fields(fp, fd, mutex, limit, priority, output, &nd_log.sources[source],
                          thread_log_fields, THREAD_FIELDS_MAX);
 
-    if(nd_log.sources[source].pending_msg && spinlock_trylock(&nd_log.sources[source].limits.spinlock)) {
+    const char *pending_msg = NULL;
+
+    if(spinlock_trylock(&nd_log.sources[source].limits.spinlock)) {
         // we have to check again if the pending message is still there
 
-        const char *pending_msg = nd_log.sources[source].pending_msg;
+        pending_msg = nd_log.sources[source].pending_msg;
 
         if(pending_msg) {
             nd_logger_unset_all_thread_fields();
@@ -397,13 +399,13 @@ static void nd_logger(const char *file, const char *function, const unsigned lon
         }
 
         spinlock_unlock(&nd_log.sources[source].limits.spinlock);
-
-        if(pending_msg)
-            nd_logger_log_fields(fp, fd, mutex, false, priority, output, &nd_log.sources[source],
-                                 thread_log_fields, THREAD_FIELDS_MAX);
-
-        freez((void *)pending_msg);
     }
+
+    if(pending_msg)
+        nd_logger_log_fields(fp, fd, mutex, false, priority, output, &nd_log.sources[source],
+                             thread_log_fields, THREAD_FIELDS_MAX);
+
+    freez((void *)pending_msg);
 
     errno_clear();
 }

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -28,6 +28,8 @@ static volatile bool spawn_server_exit = false;
 static volatile bool spawn_server_sigchld = false;
 static SPAWN_REQUEST *spawn_server_requests = NULL;
 
+#define SPAWN_SERVER_IOV_MAX 10
+
 static size_t spawn_server_max_unix_socket_path_length(void) {
     struct sockaddr_un server_addr = { 0 };
     return sizeof(server_addr.sun_path) - 1;
@@ -114,25 +116,46 @@ static void* argv_encode(const char **argv, size_t *out_size) {
     return buffer;
 }
 
+static const char *argv_find_next(const char *ptr, const char *end) {
+    return memchr(ptr, '\0', (size_t)(end - ptr));
+}
+
 // Function to decode argv or envp
 static const char** argv_decode(const char *buffer, size_t size) {
+    if(!buffer || !size || buffer[size - 1] != '\0')
+        return NULL;
+
     size_t count = 0;
     const char *ptr = buffer;
-    while (ptr < buffer + size) {
-        if(ptr && *ptr) {
+    const char *end = buffer + size;
+    bool found_final_empty_string = false;
+    while (ptr < end) {
+        if(*ptr) {
+            const char *next = argv_find_next(ptr, end);
+            if(!next)
+                return NULL;
+
             count++;
-            ptr += strlen(ptr) + 1;
+            ptr = next + 1;
         }
-        else
+        else {
+            if(ptr != end - 1)
+                return NULL;
+
+            found_final_empty_string = true;
             break;
+        }
     }
+
+    if(!found_final_empty_string)
+        return NULL;
 
     const char **argv = mallocz((count + 1) * sizeof(char *));
 
     ptr = buffer;
     for (size_t i = 0; i < count; i++) {
         argv[i] = ptr;
-        ptr += strlen(ptr) + 1;
+        ptr = argv_find_next(ptr, end) + 1;
     }
     argv[count] = NULL; // Null-terminate the array
 
@@ -459,14 +482,239 @@ typedef enum __attribute__((packed)) {
     SPAWN_SERVER_MSG_PING,
 } SPAWN_SERVER_MSG;
 
+static void spawn_server_close_received_fds(void *control, size_t controllen) {
+    const size_t header_len = CMSG_LEN(0);
+
+    if(!control || controllen < header_len)
+        return;
+
+    unsigned char *current = control;
+    size_t remaining = controllen;
+
+    while(remaining >= header_len) {
+        struct cmsghdr *cmsg = (struct cmsghdr *)current;
+        if(cmsg->cmsg_len < header_len)
+            break;
+
+        if(cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS ||
+           cmsg->cmsg_len < CMSG_LEN(sizeof(int)))
+            goto next_cmsg;
+
+        uintptr_t data_start = (uintptr_t)CMSG_DATA(cmsg);
+        uintptr_t control_end = (uintptr_t)current + remaining;
+        if(data_start < (uintptr_t)current || data_start >= control_end)
+            goto next_cmsg;
+
+        size_t fd_bytes = cmsg->cmsg_len - CMSG_LEN(0);
+        size_t available_bytes = control_end - data_start;
+        if(fd_bytes > available_bytes)
+            fd_bytes = available_bytes;
+
+        int *fds = (int *)(void *)data_start;
+        for(size_t i = 0; i < fd_bytes / sizeof(int); i++)
+            close(fds[i]);
+
+next_cmsg:
+        if(cmsg->cmsg_len > remaining)
+            break;
+
+        size_t next_cmsg_len = CMSG_SPACE(cmsg->cmsg_len - header_len);
+        if(!next_cmsg_len || next_cmsg_len > remaining)
+            break;
+
+        current += next_cmsg_len;
+        remaining -= next_cmsg_len;
+    }
+}
+
+static bool spawn_server_iov_total_size(const struct iovec *iov, size_t iovlen, size_t *total) {
+    size_t bytes = 0;
+
+    for(size_t i = 0; i < iovlen; i++) {
+        if(unlikely(iov[i].iov_len > SIZE_MAX - bytes))
+            return false;
+
+        bytes += iov[i].iov_len;
+    }
+
+    *total = bytes;
+    return true;
+}
+
+static void spawn_server_iov_advance(struct iovec *iov, size_t iovlen, size_t *first, size_t bytes) {
+    while(bytes && *first < iovlen) {
+        if(bytes < iov[*first].iov_len) {
+            iov[*first].iov_base = (char *)iov[*first].iov_base + bytes;
+            iov[*first].iov_len -= bytes;
+            return;
+        }
+
+        bytes -= iov[*first].iov_len;
+        (*first)++;
+    }
+}
+
+static bool spawn_server_recvmsg_fully(int sock, const struct iovec *iov, size_t iovlen,
+                                       void *control, size_t controllen, size_t *received_controllen,
+                                       const char *description) {
+    if(received_controllen)
+        *received_controllen = 0;
+
+    if(unlikely(iovlen > SPAWN_SERVER_IOV_MAX)) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: cannot recvmsg() %s: too many iovecs (%zu)",
+               description, iovlen);
+        return false;
+    }
+
+    struct iovec pending[SPAWN_SERVER_IOV_MAX];
+    memcpy(pending, iov, sizeof(*iov) * iovlen);
+
+    size_t remaining;
+    if(unlikely(!spawn_server_iov_total_size(pending, iovlen, &remaining))) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: cannot recvmsg() %s: iovec byte count overflows",
+               description);
+        return false;
+    }
+
+    size_t first = 0;
+    size_t control_received = 0;
+
+    while(remaining) {
+        struct msghdr msg = {
+            .msg_iov = &pending[first],
+            .msg_iovlen = iovlen - first,
+        };
+
+        if(control && !control_received) {
+            msg.msg_control = control;
+            msg.msg_controllen = controllen;
+        }
+
+        ssize_t bytes = recvmsg(sock, &msg, 0);
+        if(bytes < 0) {
+            if(errno == EINTR)
+                continue;
+
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN SERVER: failed to recvmsg() %s.",
+                   description);
+            spawn_server_close_received_fds(control, control_received);
+            return false;
+        }
+
+        if(bytes == 0) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN SERVER: peer closed socket while receiving %s.",
+                   description);
+            spawn_server_close_received_fds(control, control_received);
+            return false;
+        }
+
+        if(msg.msg_flags & MSG_CTRUNC) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN SERVER: received truncated control message while receiving %s.",
+                   description);
+            spawn_server_close_received_fds(control, msg.msg_controllen);
+            return false;
+        }
+
+        if(control && !control_received && msg.msg_controllen)
+            control_received = msg.msg_controllen;
+
+        if(unlikely((size_t)bytes > remaining)) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN SERVER: recvmsg() returned more bytes than requested while receiving %s.",
+                   description);
+            spawn_server_close_received_fds(control, control_received);
+            return false;
+        }
+
+        spawn_server_iov_advance(pending, iovlen, &first, (size_t)bytes);
+        remaining -= (size_t)bytes;
+    }
+
+    if(received_controllen)
+        *received_controllen = control_received;
+
+    return true;
+}
+
+static bool spawn_server_sendmsg_fully(int sock, const struct iovec *iov, size_t iovlen,
+                                       void *control, size_t controllen, const char *description) {
+    if(unlikely(iovlen > SPAWN_SERVER_IOV_MAX)) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN PARENT: cannot sendmsg() %s: too many iovecs (%zu)",
+               description, iovlen);
+        return false;
+    }
+
+    struct iovec pending[SPAWN_SERVER_IOV_MAX];
+    memcpy(pending, iov, sizeof(*iov) * iovlen);
+
+    size_t remaining;
+    if(unlikely(!spawn_server_iov_total_size(pending, iovlen, &remaining))) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN PARENT: cannot sendmsg() %s: iovec byte count overflows",
+               description);
+        return false;
+    }
+
+    size_t first = 0;
+    bool control_sent = !control || !controllen;
+
+    while(remaining) {
+        struct msghdr msg = {
+            .msg_iov = &pending[first],
+            .msg_iovlen = iovlen - first,
+        };
+
+        if(!control_sent) {
+            msg.msg_control = control;
+            msg.msg_controllen = controllen;
+        }
+
+        ssize_t bytes = sendmsg(sock, &msg, 0);
+        if(bytes < 0) {
+            if(errno == EINTR)
+                continue;
+
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN PARENT: failed to sendmsg() %s.",
+                   description);
+            return false;
+        }
+
+        if(bytes == 0) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN PARENT: sendmsg() made no progress while sending %s.",
+                   description);
+            return false;
+        }
+
+        control_sent = true;
+
+        if(unlikely((size_t)bytes > remaining)) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN PARENT: sendmsg() returned more bytes than requested while sending %s.",
+                   description);
+            return false;
+        }
+
+        spawn_server_iov_advance(pending, iovlen, &first, (size_t)bytes);
+        remaining -= (size_t)bytes;
+    }
+
+    return true;
+}
+
 static bool spawn_server_is_running(const char *path) {
-    struct msghdr msg = {0};
     struct iovec iov[7];
     SPAWN_SERVER_MSG msg_type = SPAWN_SERVER_MSG_PING;
     size_t dummy_size = 0;
     SPAWN_INSTANCE_TYPE dummy_type = 0;
     ND_UUID magic = UUID_ZERO;
-    char cmsgbuf[CMSG_SPACE(sizeof(int))] __attribute__((aligned(sizeof(size_t))));
 
     iov[0].iov_base = &msg_type;
     iov[0].iov_len = sizeof(msg_type);
@@ -489,18 +737,11 @@ static bool spawn_server_is_running(const char *path) {
     iov[6].iov_base = &dummy_type;
     iov[6].iov_len = sizeof(dummy_type);
 
-    msg.msg_iov = iov;
-    msg.msg_iovlen = 7;
-    msg.msg_control = cmsgbuf;
-    msg.msg_controllen = sizeof(cmsgbuf);
-
     int sock = connect_to_spawn_server(path, false);
     if(sock == -1)
         return false;
 
-    int rc = sendmsg(sock, &msg, 0);
-    if (rc < 0) {
-        // cannot send the message
+    if(!spawn_server_sendmsg_fully(sock, iov, 7, NULL, 0, "spawn server ping")) {
         close(sock);
         return false;
     }
@@ -530,7 +771,7 @@ static bool spawn_server_send_request(ND_UUID *magic, SPAWN_REQUEST *request) {
     struct cmsghdr *cmsg;
     SPAWN_SERVER_MSG msg_type = SPAWN_SERVER_MSG_REQUEST;
     char cmsgbuf[CMSG_SPACE(sizeof(int) * SPAWN_SERVER_TRANSFER_FDS)] __attribute__((aligned(sizeof(size_t))));
-    struct iovec iov[11];
+    struct iovec iov[SPAWN_SERVER_IOV_MAX];
 
     // We send 1 request with 10 iovec in it
     // The request will be received in 2 parts
@@ -567,11 +808,6 @@ static bool spawn_server_send_request(ND_UUID *magic, SPAWN_REQUEST *request) {
     iov[9].iov_base = (char *)request->data;
     iov[9].iov_len = request->data_size;
 
-    iov[10].iov_base = NULL;
-    iov[10].iov_len = 0;
-
-    msg.msg_iov = iov;
-    msg.msg_iovlen = 11;
     msg.msg_control = cmsgbuf;
     msg.msg_controllen = CMSG_SPACE(sizeof(int) * SPAWN_SERVER_TRANSFER_FDS);
 
@@ -582,17 +818,13 @@ static bool spawn_server_send_request(ND_UUID *magic, SPAWN_REQUEST *request) {
 
     memcpy(CMSG_DATA(cmsg), request->fds, sizeof(int) * SPAWN_SERVER_TRANSFER_FDS);
 
-    int rc = sendmsg(request->sock, &msg, 0);
-
-    if (rc < 0) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: Failed to sendmsg() request to spawn server using socket %d.", request->sock);
+    if(!spawn_server_sendmsg_fully(request->sock, iov, 10, cmsgbuf, CMSG_SPACE(sizeof(int) * SPAWN_SERVER_TRANSFER_FDS),
+                                   "request to spawn server"))
         goto cleanup;
-    }
-    else {
-        ret = true;
-        // fprintf(stderr, "PARENT: sent request %zu on socket %d (fds: %d, %d, %d, %d) from tid %d\n",
-        //     request->request_id, request->socket, request->fds[0], request->fds[1], request->fds[2], request->fds[3], os_gettid());
-    }
+
+    ret = true;
+    // fprintf(stderr, "PARENT: sent request %zu on socket %d (fds: %d, %d, %d, %d) from tid %d\n",
+    //     request->request_id, request->socket, request->fds[0], request->fds[1], request->fds[2], request->fds[3], os_gettid());
 
 cleanup:
     freez(encoded_env);
@@ -612,6 +844,7 @@ static void spawn_server_receive_request(int sock, SPAWN_SERVER *server) {
     SPAWN_INSTANCE_TYPE type;
     char cmsgbuf[CMSG_SPACE(sizeof(int) * SPAWN_SERVER_TRANSFER_FDS)] __attribute__((aligned(sizeof(size_t))));
     char *envp_encoded = NULL, *argv_encoded = NULL, *data = NULL;
+    const char **envp_decoded = NULL, **argv_decoded = NULL;
     int stdin_fd = -1, stdout_fd = -1, stderr_fd = -1, custom_fd = -1;
 
     // First recvmsg() to read sizes and control message
@@ -641,45 +874,31 @@ static void spawn_server_receive_request(int sock, SPAWN_SERVER *server) {
     msg.msg_control = cmsgbuf;
     msg.msg_controllen = sizeof(cmsgbuf);
 
-    if (recvmsg(sock, &msg, 0) < 0) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR,
-            "SPAWN SERVER: failed to recvmsg() the first part of the request.");
+    memset(cmsgbuf, 0, sizeof(cmsgbuf));
+    size_t received_controllen = 0;
+    if(!spawn_server_recvmsg_fully(sock, iov, 7, cmsgbuf, sizeof(cmsgbuf), &received_controllen,
+                                   "the first part of the request")) {
         close(sock);
         return;
     }
 
     if(msg_type == SPAWN_SERVER_MSG_PING) {
+        spawn_server_close_received_fds(cmsgbuf, received_controllen);
         spawn_server_send_status_ping(sock);
         close(sock);
         return;
     }
 
-    if(!UUIDeq(magic, server->magic)) {
+    if(msg_type != SPAWN_SERVER_MSG_REQUEST) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
-            "SPAWN SERVER: Invalid authorization key for request %zu. "
-            "Rejecting request.",
-            request_id);
+               "SPAWN SERVER: invalid request message type %u. Rejecting request.",
+               (unsigned)msg_type);
+        spawn_server_close_received_fds(cmsgbuf, received_controllen);
         close(sock);
         return;
     }
 
-    if(type == SPAWN_INSTANCE_TYPE_EXEC && !(server->options & SPAWN_SERVER_OPTION_EXEC)) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR,
-            "SPAWN SERVER: Request %zu wants to exec, but exec is not allowed for this spawn server. "
-            "Rejecting request.",
-            request_id);
-        close(sock);
-        return;
-    }
-
-    if(type == SPAWN_INSTANCE_TYPE_CALLBACK && !(server->options & SPAWN_SERVER_OPTION_CALLBACK)) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR,
-            "SPAWN SERVER: Request %zu wants to run a callback, but callbacks are not allowed for this spawn server. "
-            "Rejecting request.",
-            request_id);
-        close(sock);
-        return;
-    }
+    msg.msg_controllen = received_controllen;
 
     // Extract file descriptors from control message
     struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
@@ -687,12 +906,14 @@ static void spawn_server_receive_request(int sock, SPAWN_SERVER *server) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "SPAWN SERVER: Received invalid control message (expected %zu bytes, received %zu bytes)",
                (size_t)(CMSG_LEN(sizeof(int) * SPAWN_SERVER_TRANSFER_FDS)), (size_t)(cmsg?cmsg->cmsg_len:0));
+        spawn_server_close_received_fds(cmsgbuf, received_controllen);
         close(sock);
         return;
     }
 
     if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Received unexpected control message type.");
+        spawn_server_close_received_fds(cmsgbuf, received_controllen);
         close(sock);
         return;
     }
@@ -710,6 +931,37 @@ static void spawn_server_receive_request(int sock, SPAWN_SERVER *server) {
         goto cleanup;
     }
 
+    if(!UUIDeq(magic, server->magic)) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+            "SPAWN SERVER: Invalid authorization key for request %zu. "
+            "Rejecting request.",
+            request_id);
+        goto cleanup;
+    }
+
+    if(type == SPAWN_INSTANCE_TYPE_EXEC && !(server->options & SPAWN_SERVER_OPTION_EXEC)) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+            "SPAWN SERVER: Request %zu wants to exec, but exec is not allowed for this spawn server. "
+            "Rejecting request.",
+            request_id);
+        goto cleanup;
+    }
+
+    if(type == SPAWN_INSTANCE_TYPE_CALLBACK && !(server->options & SPAWN_SERVER_OPTION_CALLBACK)) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+            "SPAWN SERVER: Request %zu wants to run a callback, but callbacks are not allowed for this spawn server. "
+            "Rejecting request.",
+            request_id);
+        goto cleanup;
+    }
+
+    if(env_size == 0 || argv_size == 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: invalid encoded request sizes, env = %zu, argv = %zu",
+               env_size, argv_size);
+        goto cleanup;
+    }
+
     // Second recvmsg() to read buffer contents
     iov[0].iov_base = envp_encoded = mallocz(env_size);
     iov[0].iov_len = env_size;
@@ -723,9 +975,16 @@ static void spawn_server_receive_request(int sock, SPAWN_SERVER *server) {
     msg.msg_control = NULL;
     msg.msg_controllen = 0;
 
-    ssize_t total_bytes_received = recvmsg(sock, &msg, 0);
-    if (total_bytes_received < 0) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: failed to recvmsg() the second part of the request.");
+    if(!spawn_server_recvmsg_fully(sock, iov, msg.msg_iovlen, NULL, 0, NULL,
+                                   "the second part of the request"))
+        goto cleanup;
+
+    envp_decoded = argv_decode(envp_encoded, env_size);
+    argv_decoded = argv_decode(argv_encoded, argv_size);
+    if(!envp_decoded || !argv_decoded) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: received malformed encoded argv/envp buffers for request %zu",
+               request_id);
         goto cleanup;
     }
 
@@ -743,12 +1002,14 @@ static void spawn_server_receive_request(int sock, SPAWN_SERVER *server) {
             [2] = stderr_fd,
             [3] = custom_fd,
         },
-        .envp = argv_decode(envp_encoded, env_size),
-        .argv = argv_decode(argv_encoded, argv_size),
+        .envp = envp_decoded,
+        .argv = argv_decoded,
         .data = data,
         .data_size = data_size,
         .type = type
     };
+    envp_decoded = NULL;
+    argv_decoded = NULL;
 
     // all allocations given to the request are now handled by this
     spawn_server_execute_request(server, rq);
@@ -765,6 +1026,8 @@ cleanup:
     if(stdout_fd != -1) close(stdout_fd);
     if(stderr_fd != -1) close(stderr_fd);
     if(custom_fd != -1) close(custom_fd);
+    freez((void *)envp_decoded);
+    freez((void *)argv_decoded);
     freez(envp_encoded);
     freez(argv_encoded);
     freez(data);

--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -309,8 +309,12 @@ static void nd_thread_run_cleanup_callbacks(void) {
 
 // ----------------------------------------------------------------------------
 
+static int nd_thread_join_internal(ND_THREAD *nti, bool *wrapper_released);
+
 void nd_thread_join_threads()
 {
+    ND_THREAD *retained = NULL;
+
     ND_THREAD *nti;
     do {
         spinlock_lock(&threads_globals.exited.spinlock);
@@ -324,11 +328,33 @@ void nd_thread_join_threads()
         }
         spinlock_unlock(&threads_globals.exited.spinlock);
 
-        // nd_thread_join() handles NULL and will skip list removal since we already did it
-        // The atomic CAS in nd_thread_join() still protects against direct callers racing with us
-        nd_thread_join(nti);
+        // nd_thread_join_internal() handles NULL and will skip list removal since we already did it
+        // The atomic CAS in nd_thread_join_internal() still protects against direct callers racing with us
+        bool wrapper_released = true;
+        nd_thread_join_internal(nti, &wrapper_released);
+
+        // a failed join keeps the wrapper alive; we already unlinked it from the
+        // exited list, so keep it aside (the loop keeps draining) and restore it
+        // below where a later cleanup pass can find it
+        if(nti && !wrapper_released)
+            DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(retained, nti, prev, next);
 
     } while (nti);
+
+    if(retained) {
+        spinlock_lock(&threads_globals.exited.spinlock);
+        while(retained) {
+            ND_THREAD *t = retained;
+            DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(retained, t, prev, next);
+            DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(threads_globals.exited.list, t, prev, next);
+            t->list = ND_THREAD_LIST_EXITED;
+
+            // it is discoverable again - release our CAS ownership so a
+            // later join can retry it
+            nd_thread_status_clear(t, NETDATA_THREAD_STATUS_JOINED);
+        }
+        spinlock_unlock(&threads_globals.exited.spinlock);
+    }
 }
 
 static void nd_thread_exit(ND_THREAD *nti) {
@@ -498,7 +524,13 @@ bool nd_thread_signaled_to_cancel(void) {
 // ----------------------------------------------------------------------------
 // nd_thread_join
 
-int nd_thread_join(ND_THREAD *nti) {
+// returns the join result; sets *wrapper_released to false when the ND_THREAD
+// wrapper is intentionally kept alive (failed join with the worker not proven
+// finished), so nd_thread_join_threads() can make it discoverable again after
+// having unlinked it from the exited list
+static int nd_thread_join_internal(ND_THREAD *nti, bool *wrapper_released) {
+    *wrapper_released = true;
+
     if(!nti)
         return ESRCH;
 
@@ -548,7 +580,10 @@ int nd_thread_join(ND_THREAD *nti) {
     // Only release the wrapper once the OS join succeeded, or Netdata's thread
     // exit path has finished and can no longer use the thread-local pointer.
     if(ret != 0 && !nd_thread_status_check(nti, NETDATA_THREAD_STATUS_FINISHED)) {
-        nd_thread_status_clear(nti, NETDATA_THREAD_STATUS_JOINED);
+        // JOINED stays set: the wrapper remains CAS-owned by this caller, so
+        // no other joiner can free it while the caller decides how to make it
+        // joinable again (see nd_thread_join() and nd_thread_join_threads())
+        *wrapper_released = false;
         return ret;
     }
 
@@ -567,6 +602,18 @@ int nd_thread_join(ND_THREAD *nti) {
     spinlock_unlock(&threads_globals.exited.spinlock);
 
     freez(nti);
+
+    return ret;
+}
+
+int nd_thread_join(ND_THREAD *nti) {
+    bool wrapper_released;
+    int ret = nd_thread_join_internal(nti, &wrapper_released);
+
+    // release our CAS ownership of the retained wrapper, so the caller
+    // (which still holds the pointer) can retry the join
+    if(nti && !wrapper_released)
+        nd_thread_status_clear(nti, NETDATA_THREAD_STATUS_JOINED);
 
     return ret;
 }

--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -522,10 +522,10 @@ int nd_thread_join(ND_THREAD *nti) {
                "cannot join thread. uv_thread_join() failed with code %d. (tag=%s)",
                ret, nti->tag);
 
-        // On Windows/MSYS2, if the thread exited very quickly, uv_thread_join() can fail with EINVAL (-22)
+        // On Windows/MSYS2, if the thread exited very quickly, uv_thread_join() can fail with UV_EINVAL
         // because the thread handle becomes invalid before the join executes. However, the thread may
         // still be finishing its cleanup. Wait for it to reach FINISHED state before cleaning up.
-        if(ret == -22) { // UV_EINVAL
+        if(ret == UV_EINVAL) {
             nd_log(NDLS_DAEMON, NDLP_INFO,
                    "thread '%s' join returned EINVAL, waiting for thread to finish...", nti->tag);
 
@@ -545,9 +545,12 @@ int nd_thread_join(ND_THREAD *nti) {
         }
     }
 
-    // Always clean up the thread structure - if uv_thread_join() failed,
-    // retrying won't help (thread doesn't exist, not joinable, or logic error)
-    // JOINED flag was already set atomically at the start of this function
+    // Only release the wrapper once the OS join succeeded, or Netdata's thread
+    // exit path has finished and can no longer use the thread-local pointer.
+    if(ret != 0 && !nd_thread_status_check(nti, NETDATA_THREAD_STATUS_FINISHED)) {
+        nd_thread_status_clear(nti, NETDATA_THREAD_STATUS_JOINED);
+        return ret;
+    }
 
     spinlock_lock(&threads_globals.running.spinlock);
     if(nti->list == ND_THREAD_LIST_RUNNING) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves reliability and safety across spawn-server, logging, threads, and claiming. Fixes races and parsing bugs, and hardens message framing to prevent partial or invalid request handling.

- **Bug Fixes**
  - Spawn server (nofork): added full send/receive loops with bounded iovecs, strict argv/envp decoding, message-type and size validation, and guaranteed SCM_RIGHTS FD cleanup on all reject paths; valid requests remain unchanged.
  - Logging: drains deferred flood-protection messages under the source spinlock, then logs/frees after unlock, removing a pending_msg data race.
  - Claim: recognizes `-insecure` only as a standalone token in `NETDATA_EXTRA_CLAIM_OPTS` and fixes the inverted check that could disable TLS by mistake.
  - Threads: `nd_thread_join()` retains the wrapper on failed joins and frees it only after a successful OS join or when the worker is FINISHED; the reaper restores retained wrappers to the exited list and clears JOINED so later joins can succeed; keeps Windows `UV_EINVAL` fast-finish handling.

<sup>Written for commit 5b711dfddc9bea051aae3a23b82c15414ab8008d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

