### PR TITLE
Netdata fixes part 60

### DIFF
--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -245,7 +245,7 @@ static int wait_till_agent_claim_ready()
 static void msg_callback(const char *topic, const void *msg, size_t msglen, int qos)
 {
     UNUSED(qos);
-    aclk_rcvd_cloud_msgs++;
+    __atomic_add_fetch(&aclk_rcvd_cloud_msgs, 1, __ATOMIC_RELAXED);
 
     netdata_log_debug(D_ACLK, "Got Message From Broker Topic \"%s\" QOS %d", topic, qos);
 
@@ -282,8 +282,8 @@ static void msg_callback(const char *topic, const void *msg, size_t msglen, int 
 
 static void puback_callback(uint16_t packet_id)
 {
-    if (++aclk_pubacks_per_conn == ACLK_PUBACKS_CONN_STABLE) {
-        last_conn_time_appl = now_realtime_sec();
+    if (__atomic_add_fetch(&aclk_pubacks_per_conn, 1, __ATOMIC_RELAXED) == ACLK_PUBACKS_CONN_STABLE) {
+        __atomic_store_n(&last_conn_time_appl, now_realtime_sec(), __ATOMIC_RELAXED);
         aclk_tbeb_reset();
     }
 
@@ -388,9 +388,9 @@ static inline void mqtt_connected_actions(mqtt_wss_client client)
         mqtt_wss_subscribe(client, topic, 1);
 
     aclk_set_connected();
-    aclk_pubacks_per_conn = 0;
-    aclk_rcvd_cloud_msgs = 0;
-    aclk_connection_counter++;
+    __atomic_store_n(&aclk_pubacks_per_conn, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&aclk_rcvd_cloud_msgs, 0, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&aclk_connection_counter, 1, __ATOMIC_RELAXED);
 
     size_t iter = 0;
     while ((topic = (char*)aclk_topic_cache_iterate(&iter)) != NULL)
@@ -422,7 +422,7 @@ void aclk_graceful_disconnect(mqtt_wss_client client)
     nd_log(NDLS_DAEMON, NDLP_WARNING, "ACLK link is down");
     nd_log(NDLS_ACCESS, NDLP_WARNING, "ACLK DISCONNECTED");
 
-    last_disconnect_time = now_realtime_sec();
+    __atomic_store_n(&last_disconnect_time, now_realtime_sec(), __ATOMIC_RELAXED);
     aclk_set_disconnected();
 
     nd_log(NDLS_DAEMON, NDLP_DEBUG,
@@ -466,8 +466,11 @@ static unsigned long aclk_reconnect_delay() {
 static int aclk_block_till_recon_allowed() {
     unsigned long recon_delay = aclk_reconnect_delay();
 
-    next_connection_attempt = now_realtime_sec() + (recon_delay / MSEC_PER_SEC);
-    last_backoff_value = (float)recon_delay / MSEC_PER_SEC;
+    time_t next_attempt = now_realtime_sec() + (time_t)(recon_delay / MSEC_PER_SEC);
+    __atomic_store_n(&next_connection_attempt, next_attempt, __ATOMIC_RELAXED);
+
+    float backoff_value = (float)recon_delay / MSEC_PER_SEC;
+    __atomic_store(&last_backoff_value, &backoff_value, __ATOMIC_RELAXED);
 
     nd_log(NDLS_DAEMON, NDLP_DEBUG,
            "Wait before attempting to reconnect in %.3f seconds", recon_delay / (float)MSEC_PER_SEC);
@@ -774,7 +777,7 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
         aclk_sensitive_free(&proxy_password);
 
         if (!mqtt_rc) {
-            last_conn_time_mqtt = now_realtime_sec();
+            __atomic_store_n(&last_conn_time_mqtt, now_realtime_sec(), __ATOMIC_RELAXED);
             nd_log(NDLS_DAEMON, NDLP_INFO, "ACLK: connection successfully established");
             aclk_status_set(ACLK_STATUS_CONNECTED);
             nd_log(NDLS_ACCESS, NDLP_INFO, "ACLK CONNECTED");
@@ -889,7 +892,7 @@ void aclk_main(void *ptr)
         worker_is_busy(WORKER_ACLK_HANDLE_CONNECTION);
         if (handle_connection(mqttwss_client)) {
             worker_is_busy(WORKER_ACLK_DISCONNECTED);
-            last_disconnect_time = now_realtime_sec();
+            __atomic_store_n(&last_disconnect_time, now_realtime_sec(), __ATOMIC_RELAXED);
             aclk_set_disconnected();
             nd_log(NDLS_ACCESS, NDLP_WARNING, "ACLK DISCONNECTED");
         }
@@ -1105,31 +1108,41 @@ char *aclk_state(void)
     if (aclk_is_online)
         aclk_stats = aclk_statistics();
 
-    buffer_sprintf(wb, "Online: %s\nReconnect count: %d\nBanned By Cloud: %s\n", aclk_is_online ? "Yes" : "No", aclk_connection_counter > 0 ? (aclk_connection_counter - 1) : 0, aclk_disable_runtime ? "Yes" : "No");
-    if (last_conn_time_mqtt && ((tmptr = localtime_r(&last_conn_time_mqtt, &tmbuf))) ) {
+    int connection_counter = __atomic_load_n(&aclk_connection_counter, __ATOMIC_RELAXED);
+    time_t last_conn_time_mqtt_snapshot = __atomic_load_n(&last_conn_time_mqtt, __ATOMIC_RELAXED);
+    time_t last_conn_time_appl_snapshot = __atomic_load_n(&last_conn_time_appl, __ATOMIC_RELAXED);
+    time_t last_disconnect_time_snapshot = __atomic_load_n(&last_disconnect_time, __ATOMIC_RELAXED);
+    time_t next_connection_attempt_snapshot = __atomic_load_n(&next_connection_attempt, __ATOMIC_RELAXED);
+    float last_backoff_value_snapshot;
+    __atomic_load(&last_backoff_value, &last_backoff_value_snapshot, __ATOMIC_RELAXED);
+
+    buffer_sprintf(wb, "Online: %s\nReconnect count: %d\nBanned By Cloud: %s\n", aclk_is_online ? "Yes" : "No", connection_counter > 0 ? (connection_counter - 1) : 0, aclk_disable_runtime ? "Yes" : "No");
+    if (last_conn_time_mqtt_snapshot && ((tmptr = localtime_r(&last_conn_time_mqtt_snapshot, &tmbuf))) ) {
         char timebuf[26];
         strftime(timebuf, 26, "%Y-%m-%d %H:%M:%S", tmptr);
         buffer_sprintf(wb, "Last Connection Time: %s\n", timebuf);
     }
-    if (last_conn_time_appl && ((tmptr = localtime_r(&last_conn_time_appl, &tmbuf))) ) {
+    if (last_conn_time_appl_snapshot && ((tmptr = localtime_r(&last_conn_time_appl_snapshot, &tmbuf))) ) {
         char timebuf[26];
         strftime(timebuf, 26, "%Y-%m-%d %H:%M:%S", tmptr);
         buffer_sprintf(wb, "Last Connection Time + %d PUBACKs received: %s\n", ACLK_PUBACKS_CONN_STABLE, timebuf);
     }
-    if (last_disconnect_time && ((tmptr = localtime_r(&last_disconnect_time, &tmbuf))) ) {
+    if (last_disconnect_time_snapshot && ((tmptr = localtime_r(&last_disconnect_time_snapshot, &tmbuf))) ) {
         char timebuf[26];
         strftime(timebuf, 26, "%Y-%m-%d %H:%M:%S", tmptr);
         buffer_sprintf(wb, "Last Disconnect Time: %s\n", timebuf);
     }
-    if (!aclk_connected && next_connection_attempt && ((tmptr = localtime_r(&next_connection_attempt, &tmbuf))) ) {
+    if (!aclk_is_online && next_connection_attempt_snapshot && ((tmptr = localtime_r(&next_connection_attempt_snapshot, &tmbuf))) ) {
         char timebuf[26];
         strftime(timebuf, 26, "%Y-%m-%d %H:%M:%S", tmptr);
-        buffer_sprintf(wb, "Next Connection Attempt At: %s\nLast Backoff: %.3f", timebuf, last_backoff_value);
+        buffer_sprintf(wb, "Next Connection Attempt At: %s\nLast Backoff: %.3f", timebuf, last_backoff_value_snapshot);
     }
 
     if (aclk_is_online) {
+        int rcvd_cloud_msgs = __atomic_load_n(&aclk_rcvd_cloud_msgs, __ATOMIC_RELAXED);
+        int pubacks_per_conn = __atomic_load_n(&aclk_pubacks_per_conn, __ATOMIC_RELAXED);
         buffer_sprintf(wb, "Received Cloud MQTT Messages: %d\nMQTT Messages Confirmed by Remote Broker (PUBACKs): %d\nPending PUBACKS: %d\nServer Receive Maximum: %u\n",
-                       aclk_rcvd_cloud_msgs, aclk_pubacks_per_conn, aclk_stats.mqtt.packets_waiting_puback,
+                       rcvd_cloud_msgs, pubacks_per_conn, aclk_stats.mqtt.packets_waiting_puback,
                        (unsigned)aclk_stats.mqtt.rx_maximum);
 
         RRDHOST *host;
@@ -1261,10 +1274,10 @@ char *aclk_state_json(void)
     tmp = json_object_new_int(5);
     json_object_object_add(msg, "mqtt-version", tmp);
 
-    tmp = json_object_new_int(aclk_rcvd_cloud_msgs);
+    tmp = json_object_new_int(__atomic_load_n(&aclk_rcvd_cloud_msgs, __ATOMIC_RELAXED));
     json_object_object_add(msg, "received-app-layer-msgs", tmp);
 
-    tmp = json_object_new_int(aclk_pubacks_per_conn);
+    tmp = json_object_new_int(__atomic_load_n(&aclk_pubacks_per_conn, __ATOMIC_RELAXED));
     json_object_object_add(msg, "received-mqtt-pubacks", tmp);
 
     tmp = json_object_new_int((int32_t) aclk_stats.mqtt.packets_waiting_puback);
@@ -1273,16 +1286,23 @@ char *aclk_state_json(void)
     tmp = json_object_new_int((int32_t) aclk_stats.mqtt.rx_maximum);
     json_object_object_add(msg, "server-receive-maximum", tmp);
 
-    tmp = json_object_new_int(aclk_connection_counter > 0 ? (aclk_connection_counter - 1) : 0);
+    int connection_counter = __atomic_load_n(&aclk_connection_counter, __ATOMIC_RELAXED);
+    tmp = json_object_new_int(connection_counter > 0 ? (connection_counter - 1) : 0);
     json_object_object_add(msg, "reconnect-count", tmp);
 
-    json_object_object_add(msg, "last-connect-time-utc", timestamp_to_json(&last_conn_time_mqtt));
-    json_object_object_add(msg, "last-connect-time-puback-utc", timestamp_to_json(&last_conn_time_appl));
-    json_object_object_add(msg, "last-disconnect-time-utc", timestamp_to_json(&last_disconnect_time));
-    json_object_object_add(msg, "next-connection-attempt-utc", !aclk_is_online ? timestamp_to_json(&next_connection_attempt) : NULL);
+    time_t last_conn_time_mqtt_snapshot = __atomic_load_n(&last_conn_time_mqtt, __ATOMIC_RELAXED);
+    time_t last_conn_time_appl_snapshot = __atomic_load_n(&last_conn_time_appl, __ATOMIC_RELAXED);
+    time_t last_disconnect_time_snapshot = __atomic_load_n(&last_disconnect_time, __ATOMIC_RELAXED);
+    time_t next_connection_attempt_snapshot = __atomic_load_n(&next_connection_attempt, __ATOMIC_RELAXED);
+    json_object_object_add(msg, "last-connect-time-utc", timestamp_to_json(&last_conn_time_mqtt_snapshot));
+    json_object_object_add(msg, "last-connect-time-puback-utc", timestamp_to_json(&last_conn_time_appl_snapshot));
+    json_object_object_add(msg, "last-disconnect-time-utc", timestamp_to_json(&last_disconnect_time_snapshot));
+    json_object_object_add(msg, "next-connection-attempt-utc", !aclk_is_online ? timestamp_to_json(&next_connection_attempt_snapshot) : NULL);
     tmp = NULL;
-    if (!aclk_online() && last_backoff_value)
-        tmp = json_object_new_double(last_backoff_value);
+    float last_backoff_value_snapshot;
+    __atomic_load(&last_backoff_value, &last_backoff_value_snapshot, __ATOMIC_RELAXED);
+    if (!aclk_is_online && last_backoff_value_snapshot)
+        tmp = json_object_new_double(last_backoff_value_snapshot);
     json_object_object_add(msg, "last-backoff-value", tmp);
 
     tmp = json_object_new_boolean(aclk_disable_runtime);

--- a/src/aclk/aclk_query_queue.c
+++ b/src/aclk/aclk_query_queue.c
@@ -7,6 +7,7 @@
 struct {
     aclk_query_t query_workers[MAX_QUERY_ENTRIES];
     int free_stack[MAX_QUERY_ENTRIES];
+    bool in_free_stack[MAX_QUERY_ENTRIES];
     int top;
     SPINLOCK spinlock;
 } queryPool;
@@ -17,6 +18,7 @@ __attribute__((constructor)) void init_query_pool()
     spinlock_init(&queryPool.spinlock);
     for (int i = 0; i < MAX_QUERY_ENTRIES; i++) {
         queryPool.free_stack[i] = i;
+        queryPool.in_free_stack[i] = true;
         queryPool.query_workers[i].allocated = false;
     }
     queryPool.top = MAX_QUERY_ENTRIES;
@@ -32,6 +34,7 @@ static aclk_query_t *get_query()
         return query;
     }
     int index = queryPool.free_stack[--queryPool.top];
+    queryPool.in_free_stack[index] = false;
     memset(&queryPool.query_workers[index], 0, sizeof(aclk_query_t));
     spinlock_unlock(&queryPool.spinlock);
     return &queryPool.query_workers[index];
@@ -49,6 +52,11 @@ static void return_query(aclk_query_t *query)
         spinlock_unlock(&queryPool.spinlock);
         return;  // Invalid (should not happen)
     }
+    if (unlikely(queryPool.in_free_stack[index] || queryPool.top < 0 || queryPool.top >= MAX_QUERY_ENTRIES)) {
+        spinlock_unlock(&queryPool.spinlock);
+        return;
+    }
+    queryPool.in_free_stack[index] = true;
     queryPool.free_stack[queryPool.top++] = index;
     memset(query, 0, sizeof(aclk_query_t));
     spinlock_unlock(&queryPool.spinlock);

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -69,17 +69,22 @@ static short aclk_send_message_with_bin_payload(mqtt_wss_client client, json_obj
     str = json_object_to_json_string_ext(msg, JSON_C_TO_STRING_PLAIN);
     len = strlen(str);
 
+    const size_t sep_len = sizeof(V2_BIN_PAYLOAD_SEPARATOR) - 1;
     size_t full_msg_len = len;
-    if (payload_len)
-        full_msg_len += strlen(V2_BIN_PAYLOAD_SEPARATOR) + payload_len;
+    if (payload_len && unlikely(
+            aclk_size_add_overflow(&full_msg_len, sep_len) ||
+            aclk_size_add_overflow(&full_msg_len, payload_len))) {
+        json_object_put(msg);
+        return HTTP_RESP_CONTENT_TOO_LONG;
+    }
 
     full_msg = mallocz(full_msg_len);
     memcpy(full_msg, str, len);
     json_object_put(msg);
 
     if (payload_len) {
-        memcpy(&full_msg[len], V2_BIN_PAYLOAD_SEPARATOR, sizeof(V2_BIN_PAYLOAD_SEPARATOR) - 1);
-        len += strlen(V2_BIN_PAYLOAD_SEPARATOR);
+        memcpy(&full_msg[len], V2_BIN_PAYLOAD_SEPARATOR, sep_len);
+        len += sep_len;
         memcpy(&full_msg[len], payload, payload_len);
     }
 

--- a/src/aclk/aclk_util.c
+++ b/src/aclk/aclk_util.c
@@ -361,12 +361,26 @@ unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int mins_ms
         return 0;
     }
 
-    attempt++;
+    if (attempt < INT_MAX)
+        attempt++;
 
     if (attempt == 0)
         return 0;
 
-    unsigned long int delay = pow(base, attempt - 1);
+    unsigned long int delay = 1;
+    unsigned long int delay_limit = MAX(mins_ms, min_ms);
+    unsigned long int base_ul = (unsigned long int)base;
+
+    // Once the exponential term exceeds both clamp thresholds, the result is clamped.
+    if (base_ul > 1) {
+        for (int i = 0; i < attempt - 1; i++) {
+            if (delay > delay_limit / base_ul)
+                return min_ms;
+
+            delay *= base_ul;
+        }
+    }
+
     delay *= MSEC_PER_SEC;
 
     delay += (os_random32() % (MAX(1000, delay/2)));

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -2329,7 +2329,8 @@ int handle_incoming_traffic(struct mqtt_ng_client *client)
             if ( (prop = get_property_by_id(client->parser.properties_parser.head, MQTT_PROP_TOPIC_ALIAS)) != NULL ) {
                 // Topic Alias property was sent from server
                 void *topic_ptr;
-                if (!c_rhash_get_ptr_by_uint64(client->rx_aliases, prop->data.uint8, &topic_ptr)) {
+                uint16_t topic_alias = prop->data.uint16;
+                if (!c_rhash_get_ptr_by_uint64(client->rx_aliases, topic_alias, &topic_ptr)) {
                     if (pub->topic != NULL) {
                         nd_log(NDLS_DAEMON, NDLP_ERR, "We do not yet support topic alias reassignment");
                         return MQTT_NG_CLIENT_NOT_IMPL_YET;
@@ -2337,10 +2338,10 @@ int handle_incoming_traffic(struct mqtt_ng_client *client)
                     pub->topic = topic_ptr;
                 } else {
                     if (pub->topic == NULL) {
-                        nd_log(NDLS_DAEMON, NDLP_ERR, "Topic alias with id %d unknown and topic not set by server!", prop->data.uint8);
+                        nd_log(NDLS_DAEMON, NDLP_ERR, "Topic alias with id %" PRIu16 " unknown and topic not set by server!", topic_alias);
                         return MQTT_NG_CLIENT_PROTOCOL_ERROR;
                     }
-                    c_rhash_insert_uint64_ptr(client->rx_aliases, prop->data.uint8, pub->topic);
+                    c_rhash_insert_uint64_ptr(client->rx_aliases, topic_alias, pub->topic);
                 }
             }
 
@@ -2432,6 +2433,27 @@ static int mqtt_ng_unittest_push_bytes(rbuf_t buffer, const char *data, size_t l
         }                                                                      \
     } while(0)
 
+static struct {
+    const char *topic;
+    char payload[16];
+    size_t payload_len;
+    int qos;
+    unsigned calls;
+} mqtt_ng_unittest_msg;
+
+static void mqtt_ng_unittest_msg_callback(const char *topic, const void *msg, size_t msglen, int qos)
+{
+    mqtt_ng_unittest_msg.topic = topic;
+    mqtt_ng_unittest_msg.payload_len = msglen;
+    mqtt_ng_unittest_msg.qos = qos;
+    mqtt_ng_unittest_msg.calls++;
+
+    size_t copy_len = MIN(msglen, sizeof(mqtt_ng_unittest_msg.payload) - 1);
+    if (copy_len)
+        memcpy(mqtt_ng_unittest_msg.payload, msg, copy_len);
+    mqtt_ng_unittest_msg.payload[copy_len] = '\0';
+}
+
 static int mqtt_ng_unittest_reject_malformed_properties_packet(
     const char *packet_name,
     const char *packet,
@@ -2461,6 +2483,106 @@ static int mqtt_ng_unittest_reject_malformed_properties_packet(
     int rc = handle_incoming_traffic(client);
     MQTT_NG_TEST(rc == MQTT_NG_CLIENT_PROTOCOL_ERROR, packet_name);
     MQTT_NG_TEST(rbuf_bytes_available(input) == expected_unread, packet_name);
+
+    mqtt_ng_destroy(client);
+    rbuf_free(input);
+    return errors;
+}
+
+static int mqtt_ng_unittest_topic_alias_uint16(void)
+{
+    int errors = 0;
+    rbuf_t input = rbuf_create(128, 128);
+    struct mqtt_ng_init settings = {
+        .data_in = input,
+        .data_out_fnc = NULL,
+        .user_ctx = NULL,
+        .connack_callback = NULL,
+        .puback_callback = NULL,
+        .msg_callback = mqtt_ng_unittest_msg_callback,
+    };
+    struct mqtt_ng_client *client = mqtt_ng_init(&settings);
+
+    const char publish_alias_44[] = {
+        (char)(MQTT_CPT_PUBLISH << 4), 16,
+        0, 7, 'a', 'l', 'i', 'a', 's', '4', '4',
+        3, MQTT_PROP_TOPIC_ALIAS, 0x00, 0x2c,
+        'l', 'o', 'w',
+    };
+    const char publish_alias_256[] = {
+        (char)(MQTT_CPT_PUBLISH << 4), 17,
+        0, 8, 'a', 'l', 'i', 'a', 's', '2', '5', '6',
+        3, MQTT_PROP_TOPIC_ALIAS, 0x01, 0x00,
+        'm', 'i', 'd',
+    };
+    const char publish_alias_300[] = {
+        (char)(MQTT_CPT_PUBLISH << 4), 17,
+        0, 8, 'a', 'l', 'i', 'a', 's', '3', '0', '0',
+        3, MQTT_PROP_TOPIC_ALIAS, 0x01, 0x2c,
+        'b', 'i', 'g',
+    };
+    const char publish_alias_only[] = {
+        (char)(MQTT_CPT_PUBLISH << 4), 9,
+        0, 0,
+        3, MQTT_PROP_TOPIC_ALIAS, 0x01, 0x2c,
+        't', 'w', 'o',
+    };
+
+    memset(&mqtt_ng_unittest_msg, 0, sizeof(mqtt_ng_unittest_msg));
+
+    MQTT_NG_TEST(client != NULL, "mqtt_ng_init succeeds for uint16 topic alias test");
+    if (!client) {
+        rbuf_free(input);
+        return errors;
+    }
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, publish_alias_44, sizeof(publish_alias_44)),
+                 "push PUBLISH with alias 44");
+
+    int rc = handle_incoming_traffic(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_WANT_WRITE, "PUBLISH with alias 44 parses");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.calls == 1, "PUBLISH with alias 44 invokes callback");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.topic && !strcmp(mqtt_ng_unittest_msg.topic, "alias44"),
+                 "PUBLISH with alias 44 callback topic");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.payload_len == 3 && !strcmp(mqtt_ng_unittest_msg.payload, "low"),
+                 "PUBLISH with alias 44 callback payload");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.qos == 0, "PUBLISH with alias 44 callback qos");
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, publish_alias_256, sizeof(publish_alias_256)),
+                 "push PUBLISH with alias 256");
+
+    rc = handle_incoming_traffic(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_WANT_WRITE, "PUBLISH with alias 256 parses");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.calls == 2, "PUBLISH with alias 256 invokes callback");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.topic && !strcmp(mqtt_ng_unittest_msg.topic, "alias256"),
+                 "PUBLISH with alias 256 callback topic");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.payload_len == 3 && !strcmp(mqtt_ng_unittest_msg.payload, "mid"),
+                 "PUBLISH with alias 256 callback payload");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.qos == 0, "PUBLISH with alias 256 callback qos");
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, publish_alias_300, sizeof(publish_alias_300)),
+                 "push PUBLISH with alias 300");
+
+    rc = handle_incoming_traffic(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_WANT_WRITE, "PUBLISH with alias 300 parses");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.calls == 3, "PUBLISH with alias 300 invokes callback");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.topic && !strcmp(mqtt_ng_unittest_msg.topic, "alias300"),
+                 "PUBLISH with alias 300 callback topic");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.payload_len == 3 && !strcmp(mqtt_ng_unittest_msg.payload, "big"),
+                 "PUBLISH with alias 300 callback payload");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.qos == 0, "PUBLISH with alias 300 callback qos");
+
+    MQTT_NG_TEST(!mqtt_ng_unittest_push_bytes(input, publish_alias_only, sizeof(publish_alias_only)),
+                 "push alias-only PUBLISH with alias 300");
+
+    rc = handle_incoming_traffic(client);
+    MQTT_NG_TEST(rc == MQTT_NG_CLIENT_WANT_WRITE, "alias-only PUBLISH with alias 300 parses");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.calls == 4, "alias-only PUBLISH with alias 300 invokes callback");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.topic && !strcmp(mqtt_ng_unittest_msg.topic, "alias300"),
+                 "alias-only PUBLISH with alias 300 callback topic");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.payload_len == 3 && !strcmp(mqtt_ng_unittest_msg.payload, "two"),
+                 "alias-only PUBLISH with alias 300 callback payload");
+    MQTT_NG_TEST(mqtt_ng_unittest_msg.qos == 0, "alias-only PUBLISH with alias 300 callback qos");
 
     mqtt_ng_destroy(client);
     rbuf_free(input);
@@ -2687,6 +2809,7 @@ int mqtt_ng_unittest(void)
     fprintf(stderr, "\nrunning mqtt_ng unittest\n");
 
     errors += mqtt_ng_unittest_reset_after_partial_publish();
+    errors += mqtt_ng_unittest_topic_alias_uint16();
     errors += mqtt_ng_unittest_partial_suback_reason_codes();
     errors += mqtt_ng_unittest_malformed_suback_properties_length();
     errors += mqtt_ng_unittest_malformed_ack_properties_length();

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -744,13 +744,15 @@ int frag_set_external_data(struct buffer_fragment *frag, void *data, size_t data
 static const char mqtt_protocol_name_frag[] =
     { 0x00, 0x04, 'M', 'Q', 'T', 'T', MQTT_VERSION_5_0 };
 
-#define MQTT_UTF8_STRING_SIZE(string) (2 + strlen(string))
-
 // see 1.5.5
 #define MQTT_VARSIZE_INT_BYTES(value) ( value > 2097152 ? 4 : ( value > 16384 ? 3 : ( value > 128 ? 2 : 1 ) ) )
 
 static size_t mqtt_ng_connect_size(struct mqtt_auth_properties *auth,
-                    struct mqtt_lwt_properties *lwt)
+                    struct mqtt_lwt_properties *lwt,
+                    uint16_t client_id_len,
+                    uint16_t will_topic_len,
+                    uint16_t username_len,
+                    uint16_t password_len)
 {
     // First get the size of payload + variable header
     size_t size =
@@ -761,7 +763,7 @@ static size_t mqtt_ng_connect_size(struct mqtt_auth_properties *auth,
 
     // CONNECT payload. 3.1.3
     if (auth->client_id)
-        size += MQTT_UTF8_STRING_SIZE(auth->client_id);
+        size += 2 + client_id_len;
 
     if (lwt) {
         // 3.1.3.2 will properties TODO TODO
@@ -769,7 +771,7 @@ static size_t mqtt_ng_connect_size(struct mqtt_auth_properties *auth,
 
         // 3.1.3.3
         if (lwt->will_topic)
-            size += MQTT_UTF8_STRING_SIZE(lwt->will_topic);
+            size += 2 + will_topic_len;
 
         // 3.1.3.4 will payload
         if (lwt->will_message) {
@@ -779,11 +781,11 @@ static size_t mqtt_ng_connect_size(struct mqtt_auth_properties *auth,
 
     // 3.1.3.5
     if (auth->username)
-        size += MQTT_UTF8_STRING_SIZE(auth->username);
+        size += 2 + username_len;
 
     // 3.1.3.6
     if (auth->password)
-        size += MQTT_UTF8_STRING_SIZE(auth->password);
+        size += 2 + password_len;
 
     return size;
 }
@@ -812,6 +814,18 @@ static size_t mqtt_ng_connect_size(struct mqtt_auth_properties *auth,
         memcpy(WRITE_POS(frag), &temp, sizeof(uint16_t));                                                              \
         DATA_ADVANCE(buffer, sizeof(uint16_t), frag);                                                                  \
     }
+
+static bool mqtt_ng_get_2byte_field_length(const char *field, const char *value, uint16_t *length)
+{
+    size_t len = strnlen(value, (size_t)UINT16_MAX + 1);
+    if (unlikely(len > UINT16_MAX)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MQTT %s exceeds the 65535-byte protocol limit", field);
+        return false;
+    }
+
+    *length = (uint16_t)len;
+    return true;
+}
 
 static int optimized_add(struct header_buffer *buf, void *data, size_t data_len, free_fnc_t data_free_fnc, struct buffer_fragment **frag)
 {
@@ -906,8 +920,11 @@ mqtt_msg_data mqtt_ng_generate_connect(
         return NULL;
     }
 
-    size_t len = strlen(auth->client_id);
-    if (!len) {
+    uint16_t client_id_len;
+    if (!mqtt_ng_get_2byte_field_length("Client ID", auth->client_id, &client_id_len))
+        return NULL;
+
+    if (!client_id_len) {
         // [MQTT-3.1.3-6] server MAY allow empty client_id and treat it
         // as specific client_id (not same as client_id not given)
         // however server MUST allow ClientIDs between 1-23 bytes [MQTT-3.1.3-5]
@@ -915,6 +932,8 @@ mqtt_msg_data mqtt_ng_generate_connect(
         // at his own risk!
         nd_log(NDLS_DAEMON, NDLP_WARNING, "client_id provided is empty string. This might not be allowed by server [MQTT-3.1.3-6]");
     }
+
+    uint16_t will_topic_len = 0;
 
     if (lwt) {
         if (lwt->will_message && lwt->will_message_size > 65535) {
@@ -927,6 +946,9 @@ mqtt_msg_data mqtt_ng_generate_connect(
             return NULL;
         }
 
+        if (!mqtt_ng_get_2byte_field_length("Will Topic", lwt->will_topic, &will_topic_len))
+            return NULL;
+
         if (lwt->will_qos > MQTT_MAX_QOS) {
             // refer to [MQTT-3-1.2-12]
             nd_log(NDLS_DAEMON, NDLP_ERR, "QOS for LWT message is bigger than max");
@@ -934,11 +956,20 @@ mqtt_msg_data mqtt_ng_generate_connect(
         }
     }
 
+    uint16_t username_len = 0;
+    if (auth->username && !mqtt_ng_get_2byte_field_length("User Name", auth->username, &username_len))
+        return NULL;
+
+    uint16_t password_len = 0;
+    if (auth->password && !mqtt_ng_get_2byte_field_length("Password", auth->password, &password_len))
+        return NULL;
+
     // >> START THE RODEO <<
     transaction_buffer_transaction_start(trx_buf)
 
     // Calculate the resulting message size sans fixed MQTT header
-    size_t size = mqtt_ng_connect_size(auth, lwt);
+    size_t size = mqtt_ng_connect_size(
+        auth, lwt, client_id_len, will_topic_len, username_len, password_len);
 
     // Start generating the message
     struct buffer_fragment *frag = NULL;
@@ -989,8 +1020,8 @@ mqtt_msg_data mqtt_ng_generate_connect(
 
     // [MQTT-3.1.3.1] Client identifier
     CHECK_BYTES_AVAILABLE(&trx_buf->hdr_buffer, 2, goto fail_rollback)
-    PACK_2B_INT(&trx_buf->hdr_buffer, strlen(auth->client_id), frag)
-    if (optimized_add(&trx_buf->hdr_buffer, auth->client_id, strlen(auth->client_id), auth->client_id_free, &frag))
+    PACK_2B_INT(&trx_buf->hdr_buffer, client_id_len, frag)
+    if (optimized_add(&trx_buf->hdr_buffer, auth->client_id, client_id_len, auth->client_id_free, &frag))
         goto fail_rollback;
 
     if (lwt != NULL) {
@@ -1003,8 +1034,8 @@ mqtt_msg_data mqtt_ng_generate_connect(
 
         // Will Topic [MQTT-3.1.3.3]
         CHECK_BYTES_AVAILABLE(&trx_buf->hdr_buffer, 2, goto fail_rollback)
-        PACK_2B_INT(&trx_buf->hdr_buffer, strlen(lwt->will_topic), frag)
-        if (optimized_add(&trx_buf->hdr_buffer, lwt->will_topic, strlen(lwt->will_topic), lwt->will_topic_free, &frag))
+        PACK_2B_INT(&trx_buf->hdr_buffer, will_topic_len, frag)
+        if (optimized_add(&trx_buf->hdr_buffer, lwt->will_topic, will_topic_len, lwt->will_topic_free, &frag))
             goto fail_rollback;
 
         // Will Payload [MQTT-3.1.3.4]
@@ -1022,8 +1053,8 @@ mqtt_msg_data mqtt_ng_generate_connect(
     if (auth->username) {
         BUFFER_TRANSACTION_NEW_FRAG(&trx_buf->hdr_buffer, 0, frag, goto fail_rollback)
         CHECK_BYTES_AVAILABLE(&trx_buf->hdr_buffer, 2, goto fail_rollback)
-        PACK_2B_INT(&trx_buf->hdr_buffer, strlen(auth->username), frag)
-        if (optimized_add(&trx_buf->hdr_buffer, auth->username, strlen(auth->username), auth->username_free, &frag))
+        PACK_2B_INT(&trx_buf->hdr_buffer, username_len, frag)
+        if (optimized_add(&trx_buf->hdr_buffer, auth->username, username_len, auth->username_free, &frag))
             goto fail_rollback;
     }
 
@@ -1031,8 +1062,8 @@ mqtt_msg_data mqtt_ng_generate_connect(
     if (auth->password) {
         BUFFER_TRANSACTION_NEW_FRAG(&trx_buf->hdr_buffer, 0, frag, goto fail_rollback)
         CHECK_BYTES_AVAILABLE(&trx_buf->hdr_buffer, 2, goto fail_rollback)
-        PACK_2B_INT(&trx_buf->hdr_buffer, strlen(auth->password), frag)
-        if (optimized_add(&trx_buf->hdr_buffer, auth->password, strlen(auth->password), auth->password_free, &frag))
+        PACK_2B_INT(&trx_buf->hdr_buffer, password_len, frag)
+        if (optimized_add(&trx_buf->hdr_buffer, auth->password, password_len, auth->password_free, &frag))
             goto fail_rollback;
     }
     trx_buf->hdr_buffer.tail_frag->flags |= BUFFER_FRAG_MQTT_PACKET_TAIL;
@@ -1090,12 +1121,12 @@ uint16_t get_unused_packet_id() {
 }
 
 static size_t mqtt_ng_publish_size(
-    const char *topic,
+    uint16_t topic_len,
     size_t msg_len,
     uint16_t topic_id)
 {
     size_t retval = 2
-                    + (topic == NULL ? 0 : strlen(topic)) /* Topic Name Length */
+                    + topic_len                           /* Topic Name Length */
                     + 2                                   /* Packet identifier */
                     + 1                                   /* Properties Length for now fixed to 1 property */
                     + msg_len;
@@ -1114,13 +1145,14 @@ int mqtt_ng_generate_publish(struct transaction_buffer *trx_buf,
                              size_t msg_len,
                              uint8_t publish_flags,
                              uint16_t *packet_id,
-                             uint16_t topic_alias)
+                             uint16_t topic_alias,
+                             uint16_t topic_len)
 {
     // >> START THE RODEO <<
     transaction_buffer_transaction_start(trx_buf)
 
     // Calculate the resulting message size sans fixed MQTT header
-    size_t size = mqtt_ng_publish_size(topic, msg_len, topic_alias);
+    size_t size = mqtt_ng_publish_size(topic_len, msg_len, topic_alias);
 
     // Start generating the message
     struct buffer_fragment *frag = NULL;
@@ -1143,9 +1175,9 @@ int mqtt_ng_generate_publish(struct transaction_buffer *trx_buf,
 
     // MQTT Variable Header
     // [MQTT-3.3.2.1]
-    PACK_2B_INT(&trx_buf->hdr_buffer, topic == NULL ? 0 : strlen(topic), frag)
+    PACK_2B_INT(&trx_buf->hdr_buffer, topic_len, frag)
     if (topic != NULL) {
-        if (optimized_add(&trx_buf->hdr_buffer, topic, strlen(topic), topic_free, &frag))
+        if (optimized_add(&trx_buf->hdr_buffer, topic, topic_len, topic_free, &frag))
             goto fail_rollback;
         BUFFER_TRANSACTION_NEW_FRAG(&trx_buf->hdr_buffer, 0, frag, goto fail_rollback)
     }
@@ -1301,6 +1333,10 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
                     uint8_t publish_flags,
                     uint16_t *packet_id)
 {
+    uint16_t topic_len;
+    if (!mqtt_ng_get_2byte_field_length("Topic Name", topic, &topic_len))
+        return MQTT_NG_MSGGEN_USER_ERROR;
+
     struct topic_alias_data *alias = NULL;
     spinlock_lock(&client->tx_topic_aliases.spinlock);
     c_rhash_get_ptr_by_str(client->tx_topic_aliases.stoi_dict, topic, (void**)&alias);
@@ -1314,10 +1350,11 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
         if (cnt) {
             topic = NULL;
             topic_free = NULL;
+            topic_len = 0;
         }
     }
 
-    if (client->max_msg_size && PUBLISH_SP_SIZE + mqtt_ng_publish_size(topic, msg_len, topic_id) > client->max_msg_size) {
+    if (client->max_msg_size && PUBLISH_SP_SIZE + mqtt_ng_publish_size(topic_len, msg_len, topic_id) > client->max_msg_size) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Message too big for server: %zu", msg_len);
         return MQTT_NG_MSGGEN_MSG_TOO_BIG;
     }
@@ -1327,30 +1364,47 @@ int mqtt_ng_publish(struct mqtt_ng_client *client,
     // On MQTT_NG_MSGGEN_OK, msg is attached to a buffer fragment and freed by
     // the transaction-buffer GC after ack; *packet_id has been written by the
     // generator. See the long comment in mqtt_wss_publish5 for the invariant.
-    int rc = TRY_GENERATE_MESSAGE(mqtt_ng_generate_publish, topic, topic_free, msg, msg_free, msg_len, publish_flags, packet_id, topic_id);
+    int rc = TRY_GENERATE_MESSAGE(
+        mqtt_ng_generate_publish,
+        topic,
+        topic_free,
+        msg,
+        msg_free,
+        msg_len,
+        publish_flags,
+        packet_id,
+        topic_id,
+        topic_len);
     if (rc == MQTT_NG_MSGGEN_OK && packet_id)
         add_packet_to_timeout_monitor_list(client, *packet_id);
     return rc;
 }
 
-static size_t mqtt_ng_subscribe_size(struct mqtt_sub *subs, size_t sub_count)
+static int mqtt_ng_subscribe_size(struct mqtt_sub *subs, size_t sub_count, size_t *size)
 {
     size_t len = 2 /* Packet Identifier */ + 1 /* Properties Length TODO for now fixed 0 */;
     len += sub_count * (2 /* topic filter string length */ + 1 /* [MQTT-3.8.3.1] Subscription Options Byte */);
 
     for (size_t i = 0; i < sub_count; i++) {
-        len += strlen(subs[i].topic);
+        uint16_t topic_len;
+        if (!mqtt_ng_get_2byte_field_length("Topic Filter", subs[i].topic, &topic_len))
+            return MQTT_NG_MSGGEN_USER_ERROR;
+        len += topic_len;
     }
-    return len;
+
+    *size = len;
+    return MQTT_NG_MSGGEN_OK;
 }
 
 int mqtt_ng_generate_subscribe(struct transaction_buffer *trx_buf, struct mqtt_sub *subs, size_t sub_count)
 {
+    size_t size;
+    int rc = mqtt_ng_subscribe_size(subs, sub_count, &size);
+    if (rc != MQTT_NG_MSGGEN_OK)
+        return rc;
+
     // >> START THE RODEO <<
     transaction_buffer_transaction_start(trx_buf)
-
-    // Calculate the resulting message size sans fixed MQTT header
-    size_t size = mqtt_ng_subscribe_size(subs, sub_count);
 
     // Start generating the message
     struct buffer_fragment *frag = NULL;
@@ -1377,9 +1431,12 @@ int mqtt_ng_generate_subscribe(struct transaction_buffer *trx_buf, struct mqtt_s
     DATA_ADVANCE(&trx_buf->hdr_buffer, 1, frag)
 
     for (size_t i = 0; i < sub_count; i++) {
+        uint16_t topic_len;
+        if (!mqtt_ng_get_2byte_field_length("Topic Filter", subs[i].topic, &topic_len))
+            goto fail_user_rollback;
         BUFFER_TRANSACTION_NEW_FRAG(&trx_buf->hdr_buffer, 0, frag, goto fail_rollback)
-        PACK_2B_INT(&trx_buf->hdr_buffer, strlen(subs[i].topic), frag)
-        if (optimized_add(&trx_buf->hdr_buffer, subs[i].topic, strlen(subs[i].topic), subs[i].topic_free, &frag))
+        PACK_2B_INT(&trx_buf->hdr_buffer, topic_len, frag)
+        if (optimized_add(&trx_buf->hdr_buffer, subs[i].topic, topic_len, subs[i].topic_free, &frag))
             goto fail_rollback;
         BUFFER_TRANSACTION_NEW_FRAG(&trx_buf->hdr_buffer, 0, frag, goto fail_rollback)
         *WRITE_POS(frag) = subs[i].options;
@@ -1389,6 +1446,9 @@ int mqtt_ng_generate_subscribe(struct transaction_buffer *trx_buf, struct mqtt_s
     trx_buf->hdr_buffer.tail_frag->flags |= BUFFER_FRAG_MQTT_PACKET_TAIL;
     transaction_buffer_transaction_commit(trx_buf)
     return MQTT_NG_MSGGEN_OK;
+fail_user_rollback:
+    transaction_buffer_transaction_rollback(trx_buf, ret);
+    return MQTT_NG_MSGGEN_USER_ERROR;
 fail_rollback:
     transaction_buffer_transaction_rollback(trx_buf, ret);
     return MQTT_NG_MSGGEN_BUFFER_OOM;
@@ -2489,6 +2549,87 @@ static int mqtt_ng_unittest_reject_malformed_properties_packet(
     return errors;
 }
 
+static int mqtt_ng_unittest_2byte_field_lengths(void)
+{
+    int errors = 0;
+    size_t too_long_len = (size_t)UINT16_MAX + 1;
+    char *field = mallocz(too_long_len + 1);
+    memset(field, 'x', too_long_len);
+    field[too_long_len] = '\0';
+
+    uint16_t encoded_len = 0;
+    field[UINT16_MAX] = '\0';
+    MQTT_NG_TEST(
+        mqtt_ng_get_2byte_field_length("test field", field, &encoded_len) && encoded_len == UINT16_MAX,
+        "two-byte field accepts exactly 65535 bytes");
+    field[UINT16_MAX] = 'x';
+    MQTT_NG_TEST(
+        !mqtt_ng_get_2byte_field_length("test field", field, &encoded_len),
+        "two-byte field rejects 65536 bytes");
+
+    rbuf_t input = rbuf_create(128, 128);
+    struct mqtt_ng_init settings = {
+        .data_in = input,
+        .data_out_fnc = NULL,
+        .user_ctx = NULL,
+        .connack_callback = NULL,
+        .puback_callback = NULL,
+        .msg_callback = NULL,
+    };
+    struct mqtt_ng_client *client = mqtt_ng_init(&settings);
+    MQTT_NG_TEST(client != NULL, "mqtt_ng_init succeeds for two-byte field test");
+    if (!client) {
+        rbuf_free(input);
+        freez(field);
+        return errors;
+    }
+
+    struct mqtt_auth_properties auth = {.client_id = field};
+    MQTT_NG_TEST(
+        mqtt_ng_generate_connect(&client->main_buffer, &auth, NULL, 60) == NULL,
+        "CONNECT rejects oversized Client ID");
+
+    auth.client_id = "client";
+    auth.username = field;
+    MQTT_NG_TEST(
+        mqtt_ng_generate_connect(&client->main_buffer, &auth, NULL, 60) == NULL,
+        "CONNECT rejects oversized User Name");
+
+    auth.username = NULL;
+    auth.password = field;
+    MQTT_NG_TEST(
+        mqtt_ng_generate_connect(&client->main_buffer, &auth, NULL, 60) == NULL,
+        "CONNECT rejects oversized Password");
+
+    auth.password = NULL;
+    struct mqtt_lwt_properties lwt = {.will_topic = field};
+    MQTT_NG_TEST(
+        mqtt_ng_generate_connect(&client->main_buffer, &auth, &lwt, 60) == NULL,
+        "CONNECT rejects oversized Will Topic");
+
+    struct mqtt_sub sub = {.topic = field};
+    MQTT_NG_TEST(
+        mqtt_ng_subscribe(client, &sub, 1) == MQTT_NG_MSGGEN_USER_ERROR,
+        "SUBSCRIBE rejects oversized Topic Filter");
+
+    char payload = 'x';
+    uint16_t packet_id = 0;
+    MQTT_NG_TEST(
+        mqtt_ng_publish(
+            client, field, NULL, &payload, CALLER_RESPONSIBILITY, sizeof(payload), 0, &packet_id) ==
+            MQTT_NG_MSGGEN_USER_ERROR,
+        "PUBLISH rejects oversized Topic Name");
+
+    MQTT_NG_TEST(
+        BUFFER_BYTES_USED(&client->main_buffer.hdr_buffer) == 0,
+        "oversized two-byte fields queue no fragments");
+
+    mqtt_ng_destroy(client);
+    rbuf_free(input);
+    freez(field);
+    return errors;
+}
+
 static int mqtt_ng_unittest_topic_alias_uint16(void)
 {
     int errors = 0;
@@ -2808,6 +2949,7 @@ int mqtt_ng_unittest(void)
 
     fprintf(stderr, "\nrunning mqtt_ng unittest\n");
 
+    errors += mqtt_ng_unittest_2byte_field_lengths();
     errors += mqtt_ng_unittest_reset_after_partial_publish();
     errors += mqtt_ng_unittest_topic_alias_uint16();
     errors += mqtt_ng_unittest_partial_suback_reason_codes();

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -948,7 +948,7 @@ mqtt_msg_data mqtt_ng_generate_connect(
     ret = frag;
 
     // MQTT Fixed Header
-    size_t needed_bytes = 1 /* Packet type */ + MQTT_VARSIZE_INT_BYTES(size) + sizeof(mqtt_protocol_name_frag) + 1 /* CONNECT FLAGS */ + 2 /* keepalive */ + 1 /* Properties TODO now fixed 0*/;
+    size_t needed_bytes = 1 /* Packet type */ + MQTT_VARSIZE_INT_BYTES(size) + sizeof(mqtt_protocol_name_frag) + 1 /* CONNECT FLAGS */ + 2 /* keepalive */ + 4 /* Properties TODO now fixed to Topic Alias Maximum */;
     CHECK_BYTES_AVAILABLE(&trx_buf->hdr_buffer, needed_bytes, goto fail_rollback)
 
     *WRITE_POS(frag) = MQTT_CPT_CONNECT << 4;

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -129,6 +129,17 @@ struct mqtt_wss_client_struct {
 #endif
 };
 
+static void mqtt_wss_close_sockfd(mqtt_wss_client client)
+{
+    if (client->sockfd >= 0)
+        close(client->sockfd);
+
+    client->sockfd = -1;
+    client->poll_fds[POLLFD_SOCKET].fd = -1;
+    client->poll_fds[POLLFD_SOCKET].events = 0;
+    client->poll_fds[POLLFD_SOCKET].revents = 0;
+}
+
 static void mws_connack_callback_ng(void *user_ctx, int code)
 {
     mqtt_wss_client client = user_ctx;
@@ -164,6 +175,8 @@ mqtt_wss_client mqtt_wss_new(
     mqtt_wss_client client = callocz(1, sizeof(struct mqtt_wss_client_struct));
 
     spinlock_init(&client->stat_lock);
+    client->sockfd = -1;
+    client->poll_fds[POLLFD_SOCKET].fd = -1;
 
     client->msg_callback = msg_callback;
     client->puback_callback = puback_callback;
@@ -241,8 +254,7 @@ void mqtt_wss_destroy(mqtt_wss_client client)
     if (client->ssl_ctx)
         SSL_CTX_free(client->ssl_ctx);
 
-    if (client->sockfd > 0)
-        close(client->sockfd);
+    mqtt_wss_close_sockfd(client);
 
     freez(client);
 }
@@ -351,8 +363,7 @@ int mqtt_wss_connect(
 
     client->ssl_flags = ssl_flags;
 
-    if (client->sockfd > 0)
-        close(client->sockfd);
+    mqtt_wss_close_sockfd(client);
 
     char port_str[16];
     snprintf(port_str, sizeof(port_str) -1, "%d", client->port);
@@ -392,13 +403,16 @@ int mqtt_wss_connect(
 
     if (fcntl(client->sockfd, F_SETFL, fcntl(client->sockfd, F_GETFL, 0) | O_NONBLOCK) == -1) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Error setting O_NONBLOCK to TCP socket. \"%s\"", strerror(errno));
+        mqtt_wss_close_sockfd(client);
         return -8;
     }
 
     if (client->proxy_type != MQTT_WSS_DIRECT) {
         if (aclk_proxy_negotiation_connect(client->sockfd, client->proxy_type, client->proxy_uname, client->proxy_passwd,
-                                           client->target_host, client->target_port, 10000))
+                                           client->target_host, client->target_port, 10000)) {
+            mqtt_wss_close_sockfd(client);
             return -4;
+        }
 
         // Credentials are only needed for proxy negotiation; wipe them now.
         aclk_sensitive_free(&client->proxy_passwd);
@@ -413,6 +427,7 @@ int mqtt_wss_connect(
 #else
     if (OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL) != 1) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Failed to initialize SSL");
+        mqtt_wss_close_sockfd(client);
         return -1;
     };
 #endif
@@ -440,6 +455,7 @@ int mqtt_wss_connect(
     if (!(client->ssl_flags & MQTT_WSS_SSL_DONT_CHECK_CERTS)) {
         if (!SSL_set_ex_data(client->ssl, 0, client)) {
             nd_log(NDLS_DAEMON, NDLP_ERR, "Could not SSL_set_ex_data");
+            mqtt_wss_close_sockfd(client);
             return -4;
         }
     }
@@ -448,6 +464,7 @@ int mqtt_wss_connect(
 
     if (!SSL_set_tlsext_host_name(client->ssl, client->target_host)) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Error setting TLS SNI host");
+        mqtt_wss_close_sockfd(client);
         return -7;
     }
 
@@ -462,6 +479,7 @@ int mqtt_wss_connect(
         if (!X509_VERIFY_PARAM_set1_ip_asc(param, client->target_host) &&
             !X509_VERIFY_PARAM_set1_host(param, client->target_host, 0)) {
             nd_log(NDLS_DAEMON, NDLP_ERR, "Error setting TLS hostname verification host");
+            mqtt_wss_close_sockfd(client);
             return -7;
         }
     }
@@ -469,6 +487,7 @@ int mqtt_wss_connect(
     result = SSL_connect(client->ssl);
     if (result != -1 && result != 1) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "SSL could not connect");
+        mqtt_wss_close_sockfd(client);
         return -5;
     }
 
@@ -476,6 +495,7 @@ int mqtt_wss_connect(
         int ec = SSL_get_error(client->ssl, result);
         if (ec != SSL_ERROR_WANT_READ && ec != SSL_ERROR_WANT_WRITE) {
             nd_log(NDLS_DAEMON, NDLP_ERR, "Failed to start SSL connection");
+            mqtt_wss_close_sockfd(client);
             return -6;
         }
     }
@@ -502,6 +522,7 @@ int mqtt_wss_connect(
     int ret = mqtt_ng_connect(client->mqtt, &auth, mqtt_params->will_msg ? &lwt : NULL, client->mqtt_keepalive);
     if (ret) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Error generating MQTT connect");
+        mqtt_wss_close_sockfd(client);
         return 1;
     }
 
@@ -512,6 +533,7 @@ int mqtt_wss_connect(
         int rc = mqtt_wss_service(client, 60 * MSEC_PER_SEC);
         if(rc) {
             nd_log(NDLS_DAEMON, NDLP_ERR, "Error connecting to MQTT WSS server \"%s\", port %d. Code: %d", host, port, rc);
+            mqtt_wss_close_sockfd(client);
             return 2;
         }
     }
@@ -593,8 +615,7 @@ void mqtt_wss_disconnect(mqtt_wss_client client, int timeout_ms)
     // or timeout happens (unusual) in which case we close
     mqtt_wss_service_all(client, timeout_ms / 4);
 
-    close(client->sockfd);
-    client->sockfd = -1;
+    mqtt_wss_close_sockfd(client);
 }
 
 static void mqtt_wss_wakeup(mqtt_wss_client client)

--- a/src/claim/cloud-status.c
+++ b/src/claim/cloud-status.c
@@ -36,17 +36,19 @@ CLOUD_STATUS cloud_status(void) {
 }
 
 time_t cloud_last_change(void) {
-    time_t ret = MAX(last_conn_time_mqtt, last_disconnect_time);
+    time_t last_conn = __atomic_load_n(&last_conn_time_mqtt, __ATOMIC_RELAXED);
+    time_t last_disconnect = __atomic_load_n(&last_disconnect_time, __ATOMIC_RELAXED);
+    time_t ret = MAX(last_conn, last_disconnect);
     if(!ret) ret = netdata_start_time;
     return ret;
 }
 
 time_t cloud_next_connection_attempt(void) {
-    return next_connection_attempt;
+    return __atomic_load_n(&next_connection_attempt, __ATOMIC_RELAXED);
 }
 
 size_t cloud_connection_id(void) {
-    return aclk_connection_counter;
+    return (size_t)__atomic_load_n(&aclk_connection_counter, __ATOMIC_RELAXED);
 }
 
 const char *cloud_status_aclk_offline_reason() {

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -382,6 +382,8 @@ RRDHOST *rrdhost_create(
 
     spinlock_init(&host->receiver_lock);
     spinlock_init(&host->rrdhost_update_lock);
+    rw_spinlock_init(&host->ml_host_rwlock);
+    __atomic_store_n(&host->ml_running, false, __ATOMIC_RELAXED);
     spinlock_init(&host->aclk.spinlock);
 
     if (likely(!archived)) {

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -330,7 +330,9 @@ struct rrdhost {
 
     // ------------------------------------------------------------------------
     // ML handle
+    RW_SPINLOCK ml_host_rwlock;
     rrd_ml_host_t *ml_host;
+    bool ml_running;                                      // atomic
 
     // ------------------------------------------------------------------------
     // Support for host-level labels

--- a/src/ml/ad_charts.cc
+++ b/src/ml/ad_charts.cc
@@ -245,7 +245,7 @@ void ml_update_dimensions_chart(ml_host_t *host, const ml_machine_learning_stats
         }
 
         rrddim_set_by_pointer(host->ml_running_rs,
-                              host->ml_running_rd, host->ml_running);
+                              host->ml_running_rd, ml_running_load(host->rh));
         rrdset_done(host->ml_running_rs);
     }
 }
@@ -377,7 +377,7 @@ void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number 
         /*
          * Compute the values of the dimensions based on the host rate chart
         */
-        if (host->ml_running) {
+        if (ml_running_load(host->rh)) {
             // Reclaim the previous host's query scratch before starting the
             // next one. Cheap no-op on the first iteration of a fresh arena.
             onewayalloc_reset(owa);

--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -478,6 +478,7 @@ static void test_chart_update_dimension_counts()
     spinlock_init(&dim.slock);
 
     ml_chart_t chart = {};
+    spinlock_init(&chart.mls_spinlock);
 
     dim.mls = MACHINE_LEARNING_STATUS_DISABLED_DUE_TO_EXCLUDED_CHART;
     dim.mt = METRIC_TYPE_VARIABLE;
@@ -488,7 +489,7 @@ static void test_chart_update_dimension_counts()
     ML_TEST_ASSERT(chart.mls.num_machine_learning_status_enabled == 0,
                    "excluded dimensions must not increment enabled status");
 
-    chart.mls = {};
+    ml_chart_reset_stats(&chart);
     dim.mls = MACHINE_LEARNING_STATUS_ENABLED;
     dim.mt = METRIC_TYPE_CONSTANT;
     dim.ts = TRAINING_STATUS_UNTRAINED;
@@ -504,7 +505,7 @@ static void test_chart_update_dimension_counts()
     ML_TEST_ASSERT(chart.mls.num_anomalous_dimensions == 0,
                    "constant dimensions must ignore anomaly input");
 
-    chart.mls = {};
+    ml_chart_reset_stats(&chart);
     dim.mt = METRIC_TYPE_VARIABLE;
     dim.ts = TRAINING_STATUS_UNTRAINED;
     ml_chart_update_dimension(&chart, &dim, true);
@@ -515,7 +516,7 @@ static void test_chart_update_dimension_counts()
     ML_TEST_ASSERT(chart.mls.num_anomalous_dimensions == 0,
                    "untrained dimensions must not count anomaly input");
 
-    chart.mls = {};
+    ml_chart_reset_stats(&chart);
     dim.ts = TRAINING_STATUS_TRAINED;
     ml_chart_update_dimension(&chart, &dim, true);
     ML_TEST_ASSERT(chart.mls.num_training_status_trained == 1,
@@ -525,7 +526,7 @@ static void test_chart_update_dimension_counts()
     ML_TEST_ASSERT(chart.mls.num_normal_dimensions == 0,
                    "trained anomalous dimensions must not increment normal count");
 
-    chart.mls = {};
+    ml_chart_reset_stats(&chart);
     dim.ts = TRAINING_STATUS_SILENCED;
     ml_chart_update_dimension(&chart, &dim, false);
     ML_TEST_ASSERT(chart.mls.num_training_status_silenced == 1,

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1180,6 +1180,40 @@ ml_chart_is_available_for_ml(ml_chart_t *chart)
     return rrdset_is_available_for_exporting_and_alarms(chart->rs);
 }
 
+static void ml_chart_stats_add(ml_machine_learning_stats_t *dst, const ml_machine_learning_stats_t &src)
+{
+    dst->num_machine_learning_status_enabled += src.num_machine_learning_status_enabled;
+    dst->num_machine_learning_status_disabled_sp += src.num_machine_learning_status_disabled_sp;
+
+    dst->num_metric_type_constant += src.num_metric_type_constant;
+    dst->num_metric_type_variable += src.num_metric_type_variable;
+
+    dst->num_training_status_untrained += src.num_training_status_untrained;
+    dst->num_training_status_pending_without_model += src.num_training_status_pending_without_model;
+    dst->num_training_status_trained += src.num_training_status_trained;
+    dst->num_training_status_pending_with_model += src.num_training_status_pending_with_model;
+    dst->num_training_status_silenced += src.num_training_status_silenced;
+
+    dst->num_anomalous_dimensions += src.num_anomalous_dimensions;
+    dst->num_normal_dimensions += src.num_normal_dimensions;
+}
+
+void ml_chart_reset_stats(ml_chart_t *chart)
+{
+    spinlock_lock(&chart->mls_spinlock);
+    chart->mls = {};
+    spinlock_unlock(&chart->mls_spinlock);
+}
+
+ml_machine_learning_stats_t ml_chart_get_stats(ml_chart_t *chart)
+{
+    spinlock_lock(&chart->mls_spinlock);
+    ml_machine_learning_stats_t mls = chart->mls;
+    spinlock_unlock(&chart->mls_spinlock);
+
+    return mls;
+}
+
 void
 ml_chart_update_dimension(ml_chart_t *chart, ml_dimension_t *dim, bool is_anomalous)
 {
@@ -1189,46 +1223,52 @@ ml_chart_update_dimension(ml_chart_t *chart, ml_dimension_t *dim, bool is_anomal
     enum ml_training_status ts = dim->ts;
     spinlock_unlock(&dim->slock);
 
+    ml_machine_learning_stats_t delta = {};
+
     switch (mls) {
         case MACHINE_LEARNING_STATUS_DISABLED_DUE_TO_EXCLUDED_CHART:
-            chart->mls.num_machine_learning_status_disabled_sp++;
-            return;
+            delta.num_machine_learning_status_disabled_sp++;
+            break;
         case MACHINE_LEARNING_STATUS_ENABLED: {
-            chart->mls.num_machine_learning_status_enabled++;
+            delta.num_machine_learning_status_enabled++;
 
             switch (mt) {
                 case METRIC_TYPE_CONSTANT:
-                    chart->mls.num_metric_type_constant++;
-                    chart->mls.num_training_status_trained++;
-                    chart->mls.num_normal_dimensions++;
-                    return;
+                    delta.num_metric_type_constant++;
+                    delta.num_training_status_trained++;
+                    delta.num_normal_dimensions++;
+                    break;
                 case METRIC_TYPE_VARIABLE:
-                    chart->mls.num_metric_type_variable++;
+                    delta.num_metric_type_variable++;
+
+                    switch (ts) {
+                        case TRAINING_STATUS_UNTRAINED:
+                            delta.num_training_status_untrained++;
+                            break;
+                        case TRAINING_STATUS_TRAINED:
+                            delta.num_training_status_trained++;
+
+                            delta.num_anomalous_dimensions += is_anomalous;
+                            delta.num_normal_dimensions += !is_anomalous;
+                            break;
+                        case TRAINING_STATUS_SILENCED:
+                            delta.num_training_status_silenced++;
+                            delta.num_training_status_trained++;
+
+                            delta.num_anomalous_dimensions += is_anomalous;
+                            delta.num_normal_dimensions += !is_anomalous;
+                            break;
+                    }
                     break;
             }
 
-            switch (ts) {
-                case TRAINING_STATUS_UNTRAINED:
-                    chart->mls.num_training_status_untrained++;
-                    return;
-                case TRAINING_STATUS_TRAINED:
-                    chart->mls.num_training_status_trained++;
-
-                    chart->mls.num_anomalous_dimensions += is_anomalous;
-                    chart->mls.num_normal_dimensions += !is_anomalous;
-                    return;
-                case TRAINING_STATUS_SILENCED:
-                    chart->mls.num_training_status_silenced++;
-                    chart->mls.num_training_status_trained++;
-
-                    chart->mls.num_anomalous_dimensions += is_anomalous;
-                    chart->mls.num_normal_dimensions += !is_anomalous;
-                    return;
-            }
-
-            return;
+            break;
         }
     }
+
+    spinlock_lock(&chart->mls_spinlock);
+    ml_chart_stats_add(&chart->mls, delta);
+    spinlock_unlock(&chart->mls_spinlock);
 }
 
 /*
@@ -1269,7 +1309,7 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
             if (!ml_chart_is_available_for_ml(chart))
                 continue;
 
-            ml_machine_learning_stats_t chart_mls = chart->mls;
+            ml_machine_learning_stats_t chart_mls = ml_chart_get_stats(chart);
 
             host_mls.num_machine_learning_status_enabled += chart_mls.num_machine_learning_status_enabled;
             host_mls.num_machine_learning_status_disabled_sp += chart_mls.num_machine_learning_status_disabled_sp;

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -756,11 +756,17 @@ ml_dimension_deserialize_kmeans(const char *json_str)
 
     // ml_host may have been unpublished by ml_host_delete() concurrently;
     // the acquired RRDHOST keeps RH alive but not RH->ml_host.
-    ml_host_t *host = AcqDim.host();
-    if (!host) {
-        pulse_ml_models_ignored();
-        json_object_put(root);
-        return true;
+    ml_queue_t *queue;
+    {
+        AcquiredMLHost acquired_host = AcqDim.host();
+        ml_host_t *host = acquired_host.get();
+        if (!host) {
+            pulse_ml_models_ignored();
+            json_object_put(root);
+            return true;
+        }
+
+        queue = host->queue;
     }
 
     ml_queue_item_t item;
@@ -768,7 +774,7 @@ ml_dimension_deserialize_kmeans(const char *json_str)
     item.add_existing_model = {
         DLI, inlined_km
     };
-    ml_queue_push(host->queue, item);
+    ml_queue_push(queue, item);
 
     json_object_put(root);
     return true;
@@ -859,10 +865,11 @@ static bool ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim,
 {
     worker_is_busy(WORKER_TRAIN_UPDATE_MODELS);
 
+    // Sample ml_running inside the same slock critical section as the
+    // reset_generation check, so a stop that starts first cancels this install.
     spinlock_lock(&dim->slock);
 
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&dim->rd->rrdset->rrdhost->ml_host, __ATOMIC_ACQUIRE);
-    if (!ml_should_publish_model_update(host && host->ml_running,
+    if (!ml_should_publish_model_update(ml_running_load(dim->rd->rrdset->rrdhost),
                                         dim->reset_generation,
                                         expected_generation,
                                         &dim->training_in_progress)) {
@@ -1242,10 +1249,10 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
     ml_machine_learning_stats_t host_mls = {};
     calculated_number_t host_anomaly_rate = 0.0;
 
-    if (host->ml_running) {
-        // Snapshot the stop generation before the unlocked walk. If it changes
-        // by the time we publish, a stop ran while we were reading chart->mls
-        // and the accumulated snapshot must be discarded.
+    if (ml_running_load(host->rh)) {
+        // Snapshot the stop generation before the chart walk. If it changes by
+        // the time we publish, a stop overlapped the walk and the accumulated
+        // snapshot must be discarded.
         uint64_t stop_gen_before = host->ml_stop_generation.load();
 
         /*
@@ -1312,15 +1319,15 @@ ml_host_detect_once(ml_host_t *host, ONEWAYALLOC *owa)
         // Discard the snapshot if either (a) ml_running is now false, or
         // (b) the stop generation changed since the walk started — the
         // latter catches a stop+start that completed during the walk and
-        // would otherwise pass the boolean check. In either case our
-        // unlocked chart->mls reads may have raced ml_host_stop, so zero
-        // the snapshot and the per-context counts. The chart updates below
-        // run unconditionally: ml_update_dimensions_chart reads
-        // host->ml_running directly (so the ml_running chart records the
-        // stop), and the chart-update path resets and republishes the rest.
+        // would otherwise pass the boolean check. In either case the chart
+        // walk may have spanned stop's resets, so zero the snapshot and the
+        // per-context counts. The chart updates below run unconditionally:
+        // ml_update_dimensions_chart reads the host running state directly (so
+        // the ml_running chart records the stop), and the chart-update path resets
+        // and republishes the rest.
         netdata_mutex_lock(&host->mutex);
         uint64_t stop_gen_after = host->ml_stop_generation.load();
-        if (!host->ml_running || stop_gen_before != stop_gen_after) {
+        if (!ml_running_load(host->rh) || stop_gen_before != stop_gen_after) {
             host_mls = {};
             host_anomaly_rate = 0.0;
 
@@ -1373,7 +1380,8 @@ void ml_detect_main(void *arg)
         RRDHOST *rh;
         rrd_rdlock();
         rrdhost_foreach_read(rh) {
-            ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
+            AcquiredMLHost acquired_host(rh);
+            ml_host_t *host = acquired_host.get();
             if (!host)
                 continue;
 
@@ -1511,8 +1519,7 @@ static enum ml_worker_result ml_worker_add_existing_model(ml_worker_t *worker, m
         return ML_WORKER_RESULT_OK;
     }
 
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&Dim->rd->rrdset->rrdhost->ml_host, __ATOMIC_ACQUIRE);
-    if (!host || !host->ml_running) {
+    if (!ml_running_load(Dim->rd->rrdset->rrdhost)) {
         pulse_ml_models_ignored();
         return ML_WORKER_RESULT_OK;
     }

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1248,15 +1248,15 @@ ml_chart_update_dimension(ml_chart_t *chart, ml_dimension_t *dim, bool is_anomal
                         case TRAINING_STATUS_TRAINED:
                             delta.num_training_status_trained++;
 
-                            delta.num_anomalous_dimensions += is_anomalous;
-                            delta.num_normal_dimensions += !is_anomalous;
+                            delta.num_anomalous_dimensions += is_anomalous ? 1 : 0;
+                            delta.num_normal_dimensions += is_anomalous ? 0 : 1;
                             break;
                         case TRAINING_STATUS_SILENCED:
                             delta.num_training_status_silenced++;
                             delta.num_training_status_trained++;
 
-                            delta.num_anomalous_dimensions += is_anomalous;
-                            delta.num_normal_dimensions += !is_anomalous;
+                            delta.num_anomalous_dimensions += is_anomalous ? 1 : 0;
+                            delta.num_normal_dimensions += is_anomalous ? 0 : 1;
                             break;
                     }
                     break;

--- a/src/ml/ml_chart.h
+++ b/src/ml/ml_chart.h
@@ -10,8 +10,11 @@ struct ml_dimension_t;
 struct ml_chart_t {
     RRDSET *rs;
     ml_machine_learning_stats_t mls;
+    SPINLOCK mls_spinlock;
 };
 
+void ml_chart_reset_stats(ml_chart_t *chart);
+ml_machine_learning_stats_t ml_chart_get_stats(ml_chart_t *chart);
 void ml_chart_update_dimension(ml_chart_t *chart, ml_dimension_t *dim, bool is_anomalous);
 
 #endif /* NETDATA_ML_CHART_H */

--- a/src/ml/ml_dimension.h
+++ b/src/ml/ml_dimension.h
@@ -136,10 +136,9 @@ public:
         return acquire_failure_reason;
     }
 
-    ml_host_t *host() const {
+    AcquiredMLHost host() const {
         assert(acquired());
-        RRDHOST *RH = rrdhost_acquired_to_rrdhost(AcqRH);
-        return reinterpret_cast<ml_host_t *>(__atomic_load_n(&RH->ml_host, __ATOMIC_ACQUIRE));
+        return AcquiredMLHost(rrdhost_acquired_to_rrdhost(AcqRH));
     }
 
     ml_dimension_t *dimension() const {

--- a/src/ml/ml_host.h
+++ b/src/ml/ml_host.h
@@ -40,10 +40,10 @@ typedef struct {
 
     // Incremented at the END of every ml_host_stop, after all chart/dim resets
     // have committed. ml_host_detect_once samples this before and after its
-    // unlocked chart walk; a change means a stop completed during the walk
-    // (so detect raced with stop's chart->mls writes) or a stop+start cycle
-    // happened around the walk. In either case the accumulated snapshot must
-    // be discarded even if ml_running is back to true at the re-check.
+    // chart walk; a change means a stop completed during the walk or a
+    // stop+start cycle happened around the walk. In either case the
+    // accumulated snapshot must be discarded even if ml_running is back to true
+    // at the re-check.
     std::atomic<uint64_t> ml_stop_generation;
 
     ml_machine_learning_stats_t mls;
@@ -57,7 +57,7 @@ typedef struct {
     // cannot carry host->mutex into that walk), so a racing start cannot
     // re-enable ml_running while stop is mid-reset. Without it, a detect walk
     // could observe ml_running==true with an unchanged stop generation and
-    // publish a snapshot torn by stop's in-flight chart->mls resets.
+    // publish a snapshot spanning stop's in-flight resets.
     netdata_mutex_t start_stop_mutex;
 
     ml_queue_t *queue;

--- a/src/ml/ml_host.h
+++ b/src/ml/ml_host.h
@@ -35,7 +35,7 @@ typedef struct {
     uint32_t anomalous_dimensions;
 } ml_context_anomaly_rate_t;
 
-typedef struct {
+typedef struct ml_host {
     RRDHOST *rh;
 
     // Incremented at the END of every ml_host_stop, after all chart/dim resets
@@ -115,13 +115,13 @@ static ALWAYS_INLINE void ml_running_store(RRDHOST *rh, bool running)
 #ifdef __cplusplus
 class AcquiredMLHost {
 public:
-    explicit AcquiredMLHost(RRDHOST *rh) : RH(rh), Host(nullptr)
+    explicit AcquiredMLHost(RRDHOST *rh) : RH(rh)
     {
         if (!RH)
             return;
 
         rw_spinlock_read_lock(&RH->ml_host_rwlock);
-        Host = reinterpret_cast<ml_host_t *>(__atomic_load_n(&RH->ml_host, __ATOMIC_ACQUIRE));
+        Host = __atomic_load_n(&RH->ml_host, __ATOMIC_ACQUIRE);
         if (!Host)
             release();
     }
@@ -174,7 +174,7 @@ public:
 
 private:
     RRDHOST *RH;
-    ml_host_t *Host;
+    ml_host_t *Host = nullptr;
 };
 #endif
 

--- a/src/ml/ml_host.h
+++ b/src/ml/ml_host.h
@@ -38,8 +38,6 @@ typedef struct {
 typedef struct {
     RRDHOST *rh;
 
-    std::atomic<bool> ml_running;
-
     // Incremented at the END of every ml_host_stop, after all chart/dim resets
     // have committed. ml_host_detect_once samples this before and after its
     // unlocked chart walk; a change means a stop completed during the walk
@@ -103,5 +101,81 @@ typedef struct {
 
     bool reset_pointers;
 } ml_host_t;
+
+static ALWAYS_INLINE bool ml_running_load(const RRDHOST *rh)
+{
+    return __atomic_load_n(&rh->ml_running, __ATOMIC_RELAXED);
+}
+
+static ALWAYS_INLINE void ml_running_store(RRDHOST *rh, bool running)
+{
+    __atomic_store_n(&rh->ml_running, running, __ATOMIC_RELAXED);
+}
+
+#ifdef __cplusplus
+class AcquiredMLHost {
+public:
+    explicit AcquiredMLHost(RRDHOST *rh) : RH(rh), Host(nullptr)
+    {
+        if (!RH)
+            return;
+
+        rw_spinlock_read_lock(&RH->ml_host_rwlock);
+        Host = reinterpret_cast<ml_host_t *>(__atomic_load_n(&RH->ml_host, __ATOMIC_ACQUIRE));
+        if (!Host)
+            release();
+    }
+
+    AcquiredMLHost(const AcquiredMLHost &) = delete;
+    AcquiredMLHost &operator=(const AcquiredMLHost &) = delete;
+
+    AcquiredMLHost(AcquiredMLHost &&other) noexcept : RH(other.RH), Host(other.Host)
+    {
+        other.RH = nullptr;
+        other.Host = nullptr;
+    }
+
+    AcquiredMLHost &operator=(AcquiredMLHost &&other) noexcept
+    {
+        if (this != &other) {
+            release();
+            RH = other.RH;
+            Host = other.Host;
+            other.RH = nullptr;
+            other.Host = nullptr;
+        }
+
+        return *this;
+    }
+
+    ~AcquiredMLHost()
+    {
+        release();
+    }
+
+    ml_host_t *get() const
+    {
+        return Host;
+    }
+
+    explicit operator bool() const
+    {
+        return Host != nullptr;
+    }
+
+    void release()
+    {
+        if (RH) {
+            rw_spinlock_read_unlock(&RH->ml_host_rwlock);
+            RH = nullptr;
+            Host = nullptr;
+        }
+    }
+
+private:
+    RRDHOST *RH;
+    ml_host_t *Host;
+};
+#endif
 
 #endif /* NETDATA_ML_HOST_H */

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -211,7 +211,7 @@ void ml_host_stop(RRDHOST *rh) {
             continue;
 
         // reset chart
-        chart->mls = ml_machine_learning_stats_t();
+        ml_chart_reset_stats(chart);
 
         void *rdp = NULL;
         rrddim_foreach_read(rdp, rs) {
@@ -244,9 +244,8 @@ void ml_host_stop(RRDHOST *rh) {
 
     // Publish the stop only after every chart->mls / dim reset is committed.
     // ml_host_detect_once treats a generation change as "discard the snapshot",
-    // so bumping here guarantees that if detect saw stale chart->mls it will
-    // either also observe the new generation or have already published before
-    // any of our resets started.
+    // so bumping here guarantees that a detector spanning the reset cannot
+    // publish the mixed pre/post-stop snapshot.
     host->ml_stop_generation.fetch_add(1);
 
     netdata_mutex_unlock(&host->start_stop_mutex);
@@ -353,6 +352,7 @@ void ml_chart_new(RRDSET *rs)
 
     chart->rs = rs;
     chart->mls = ml_machine_learning_stats_t();
+    spinlock_init(&chart->mls_spinlock);
 
     // Publish with release semantics so readers that load rs->ml_chart with
     // acquire semantics observe the chart's `rs` and `mls` fields as fully
@@ -388,7 +388,7 @@ ALWAYS_INLINE_ONLY bool ml_chart_update_begin(RRDSET *rs)
     if (!chart)
         return false;
 
-    chart->mls = {};
+    ml_chart_reset_stats(chart);
     return true;
 }
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -22,9 +22,15 @@ static void ml_host_clear_context_anomaly_rate(ml_host_t *host)
 
 static void ml_dimension_enqueue_create_model(RRDHOST *rh, RRDDIM *rd)
 {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
-    if (!host)
-        return;
+    ml_queue_t *queue;
+    {
+        AcquiredMLHost acquired_host(rh);
+        ml_host_t *host = acquired_host.get();
+        if (!host)
+            return;
+
+        queue = host->queue;
+    }
 
     ml_dimension_t *dim = (ml_dimension_t *) rd->ml_dimension;
     if (!dim)
@@ -49,7 +55,7 @@ static void ml_dimension_enqueue_create_model(RRDHOST *rh, RRDDIM *rd)
         rd->id
     );
 
-    ml_queue_push(host->queue, item);
+    ml_queue_push(queue, item);
 }
 
 bool ml_capable()
@@ -95,28 +101,23 @@ void ml_host_new(RRDHOST *rh)
     netdata_mutex_init(&host->start_stop_mutex);
     spinlock_init(&host->context_anomaly_rate_spinlock);
 
-    host->ml_running = false;
     host->ml_stop_generation = 0;
 
-    // Publish with release semantics so readers that load rh->ml_host with
-    // acquire semantics observe the host's `rh`, `ml_running`, `mutex`,
-    // `queue`, etc. as fully initialized. Without this, the C++ compiler
-    // may reorder field stores after the publish store of rh->ml_host, and
-    // a concurrent reader would see host != NULL with partially-initialized
-    // fields, producing SIGSEGV faults inside ml_dimension_is_anomalous and
-    // similar readers.
+    // Publish under the per-RRDHOST lifetime lock so readers cannot race
+    // ml_host_delete() while acquiring this pointer.
+    rw_spinlock_write_lock(&rh->ml_host_rwlock);
+    ml_running_store(rh, false);
     __atomic_store_n(&rh->ml_host, (rrd_ml_host_t *)host, __ATOMIC_RELEASE);
+    rw_spinlock_write_unlock(&rh->ml_host_rwlock);
 }
 
 void ml_host_delete(RRDHOST *rh)
 {
-    // Atomically detach `rh->ml_host` and obtain the previous pointer in a
-    // single RMW. Using exchange (rather than separate load + store) keeps
-    // the unpublish and the freeing on this thread strictly ordered: no
-    // store/operation that follows can be reordered before the unpublish,
-    // so concurrent readers observe either the live host or NULL -- never
-    // the freed host memory.
+    rw_spinlock_write_lock(&rh->ml_host_rwlock);
+    ml_running_store(rh, false);
     ml_host_t *host = (ml_host_t *) __atomic_exchange_n(&rh->ml_host, (rrd_ml_host_t *)NULL, __ATOMIC_ACQ_REL);
+    rw_spinlock_write_unlock(&rh->ml_host_rwlock);
+
     if (!host)
         return;
 
@@ -128,7 +129,8 @@ void ml_host_delete(RRDHOST *rh)
 }
 
 void ml_host_start(RRDHOST *rh) {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
+    AcquiredMLHost acquired_host(rh);
+    ml_host_t *host = acquired_host.get();
     if (!host)
         return;
 
@@ -137,7 +139,7 @@ void ml_host_start(RRDHOST *rh) {
     // and concurrent ml_host_start() calls must not run the sweep twice.
     netdata_mutex_lock(&host->start_stop_mutex);
 
-    if (host->ml_running) {
+    if (ml_running_load(rh)) {
         netdata_mutex_unlock(&host->start_stop_mutex);
         return;
     }
@@ -146,7 +148,7 @@ void ml_host_start(RRDHOST *rh) {
     // flip is bounded by the same critical section that performs the sweep.
     netdata_mutex_lock(&host->mutex);
 
-    host->ml_running = true;
+    ml_running_store(rh, true);
 
     void *rsp = NULL;
     rrdset_foreach_read(rsp, host->rh) {
@@ -166,7 +168,8 @@ void ml_host_start(RRDHOST *rh) {
 }
 
 void ml_host_stop(RRDHOST *rh) {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
+    AcquiredMLHost acquired_host(rh);
+    ml_host_t *host = acquired_host.get();
     if (!host)
         return;
 
@@ -177,17 +180,16 @@ void ml_host_stop(RRDHOST *rh) {
     // stop generation and publish a snapshot torn by our in-flight resets.
     netdata_mutex_lock(&host->start_stop_mutex);
 
-    if (!host->ml_running) {
+    if (!ml_running_load(rh)) {
         netdata_mutex_unlock(&host->start_stop_mutex);
         return;
     }
 
     // Prevent new ML activity from publishing while we reset host/dimension
     // state. The ml_running flag gates collectors and the detect loop; the
-    // stop generation is bumped at the end of the function so a concurrent
-    // ml_host_detect_once that observes the new generation is guaranteed to
-    // also see all of our chart->mls / dim resets via seq_cst ordering.
-    host->ml_running = false;
+    // stop generation is bumped at the end so a concurrent ml_host_detect_once
+    // that spans this stop discards its accumulated snapshot.
+    ml_running_store(rh, false);
 
     netdata_mutex_lock(&host->mutex);
 
@@ -252,10 +254,12 @@ void ml_host_stop(RRDHOST *rh) {
 
 void ml_host_get_info(RRDHOST *rh, BUFFER *wb)
 {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
-    if (!host) {
-        buffer_json_member_add_boolean(wb, "enabled", false);
-        return;
+    {
+        AcquiredMLHost acquired_host(rh);
+        if (!acquired_host) {
+            buffer_json_member_add_boolean(wb, "enabled", false);
+            return;
+        }
     }
 
     buffer_json_member_add_uint64(wb, "version", 1);
@@ -285,14 +289,15 @@ void ml_host_get_info(RRDHOST *rh, BUFFER *wb)
 
 void ml_host_get_detection_info(RRDHOST *rh, BUFFER *wb)
 {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
+    AcquiredMLHost acquired_host(rh);
+    ml_host_t *host = acquired_host.get();
     if (!host)
         return;
 
     netdata_mutex_lock(&host->mutex);
 
     buffer_json_member_add_uint64(wb, "version", 2);
-    buffer_json_member_add_uint64(wb, "ml-running", host->ml_running);
+    buffer_json_member_add_uint64(wb, "ml-running", ml_running_load(rh));
     buffer_json_member_add_uint64(wb, "anomalous-dimensions", host->mls.num_anomalous_dimensions);
     buffer_json_member_add_uint64(wb, "normal-dimensions", host->mls.num_normal_dimensions);
     buffer_json_member_add_uint64(wb, "total-dimensions", host->mls.num_anomalous_dimensions +
@@ -303,7 +308,8 @@ void ml_host_get_detection_info(RRDHOST *rh, BUFFER *wb)
 }
 
 bool ml_host_get_host_status(RRDHOST *rh, struct ml_metrics_statistics *mlm) {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
+    AcquiredMLHost acquired_host(rh);
+    ml_host_t *host = acquired_host.get();
     if (!host) {
         memset(mlm, 0, sizeof(*mlm));
         return false;
@@ -323,11 +329,7 @@ bool ml_host_get_host_status(RRDHOST *rh, struct ml_metrics_statistics *mlm) {
 }
 
 bool ml_host_running(RRDHOST *rh) {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
-    if(!host)
-        return false;
-
-    return host->ml_running;
+    return rh && ml_running_load(rh);
 }
 
 void ml_host_get_models(RRDHOST *rh, BUFFER *wb)
@@ -341,9 +343,11 @@ void ml_host_get_models(RRDHOST *rh, BUFFER *wb)
 
 void ml_chart_new(RRDSET *rs)
 {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rs->rrdhost->ml_host, __ATOMIC_ACQUIRE);
-    if (!host)
-        return;
+    {
+        AcquiredMLHost acquired_host(rs->rrdhost);
+        if (!acquired_host)
+            return;
+    }
 
     ml_chart_t *chart = new ml_chart_t();
 
@@ -362,9 +366,11 @@ void ml_chart_new(RRDSET *rs)
 
 void ml_chart_delete(RRDSET *rs)
 {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rs->rrdhost->ml_host, __ATOMIC_ACQUIRE);
-    if (!host)
-        return;
+    {
+        AcquiredMLHost acquired_host(rs->rrdhost);
+        if (!acquired_host)
+            return;
+    }
 
     // Atomically detach `rs->ml_chart` and obtain the previous pointer in a
     // single RMW. Using exchange (rather than separate load + store) keeps
@@ -432,8 +438,7 @@ void ml_dimension_new(RRDDIM *rd)
     // will sweep all untrained dimensions and enqueue them when it runs.
     // This avoids double-enqueueing the same dim from both paths.
     RRDHOST *rh = rd->rrdset->rrdhost;
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
-    if (host && host->ml_running)
+    if (ml_running_load(rh))
         ml_dimension_enqueue_create_model(rh, rd);
 }
 
@@ -474,8 +479,7 @@ ALWAYS_INLINE_ONLY void ml_dimension_received_anomaly(RRDDIM *rd, bool is_anomal
     if (!dim)
         return;
 
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rd->rrdset->rrdhost->ml_host, __ATOMIC_ACQUIRE);
-    if (!host || !host->ml_running)
+    if (!ml_running_load(rd->rrdset->rrdhost))
         return;
 
     ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rd->rrdset->ml_chart, __ATOMIC_ACQUIRE);
@@ -493,8 +497,7 @@ bool ml_dimension_is_anomalous(RRDDIM *rd, time_t curr_time, double value, bool 
     if (!dim)
         return false;
 
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rd->rrdset->rrdhost->ml_host, __ATOMIC_ACQUIRE);
-    if (!host || !host->ml_running)
+    if (!ml_running_load(rd->rrdset->rrdhost))
         return false;
 
     ml_chart_t *chart = (ml_chart_t *) __atomic_load_n(&rd->rrdset->ml_chart, __ATOMIC_ACQUIRE);
@@ -778,7 +781,8 @@ bool ml_model_received_from_child(RRDHOST *host, const char *json)
 }
 
 void ml_host_disconnected(RRDHOST *rh) {
-    ml_host_t *host = (ml_host_t *) __atomic_load_n(&rh->ml_host, __ATOMIC_ACQUIRE);
+    AcquiredMLHost acquired_host(rh);
+    ml_host_t *host = acquired_host.get();
     if (!host)
         return;
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens ACLK MQTT and ML subsystems to prevent races and corruption: fixes socket and buffer issues, validates MQTT field sizes, and adds proper locking around ML host and chart stats. Improves stability of reconnects and status reporting without changing behavior.

- **Bug Fixes**
  - ACLK: use relaxed atomics for counters/timestamps; status endpoints now read consistent snapshots.
  - ACLK: bound exponential backoff with integer math; cap attempts and clamp safely.
  - ACLK: guard binary publish buffer length against size_t overflow; return HTTP_RESP_CONTENT_TOO_LONG on overflow.
  - ACLK: prevent duplicate query-pool returns from corrupting the free stack.
  - MQTT WSS: centralize socket close/reset; initialize fd to -1; fix double-close and leaked fd paths in `mqtt_wss_client`.
  - MQTT: reserve full CONNECT properties header; validate all 2-byte UTF-8 fields (Client ID, Will Topic, User Name, Password, Topic Name/Filter) ≤ 65535 and reuse cached lengths.
  - MQTT: treat Topic Alias as uint16 end-to-end; fix alias lookups/logging; add focused unittests.
  - ML: guard `ml_host` lifetime with per-host RW lock and an `AcquiredMLHost` helper; initialize `rrdhost.ml_host_rwlock`.
  - ML: move `ml_running` to `RRDHOST` with relaxed atomics; running checks are lock-free and initialized in `rrdhost_create`.
  - ML: protect chart stats with a per-chart spinlock; add reset/get helpers; publish per-dimension deltas under the lock; detection snapshots use the getter; update unit tests accordingly.
  - ML: check `ml_running` under the dimension lock during model updates to cancel installs if a stop began.

<sup>Written for commit ba5977cc7734a83a487ef68c7c53ebbe5f449fca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

