### PR TITLE
Netdata fixes part 62

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -43,7 +43,7 @@ static void parse_command_reply(BUFFER *buf)
          pos < response_string + response_string_size  && !syntax_error ;
          ++pos) {
         /* Skip white-space characters */
-        for ( ; isspace(*pos) && ('\0' != *pos); ++pos) ;
+        for ( ; isspace((uint8_t)*pos) && ('\0' != *pos); ++pos) ;
 
         if ('\0' == *pos)
             continue;

--- a/src/libnetdata/adaptive_resortable_list/adaptive_resortable_list.c
+++ b/src/libnetdata/adaptive_resortable_list/adaptive_resortable_list.c
@@ -298,7 +298,7 @@ int arl_check(ARL_BASE *base, const char *keyword, const char *value) {
 #endif
 
     // it should be the first entry (pointed by base->next_keyword)
-    if(likely(!strcmp(keyword, e->name))) {
+    if(likely(e && !strcmp(keyword, e->name))) {
         // it is
 
 #ifdef NETDATA_INTERNAL_CHECKS

--- a/src/libnetdata/avl/avl.c
+++ b/src/libnetdata/avl/avl.c
@@ -58,7 +58,13 @@ avl_t *avl_insert(avl_tree_type *tree, avl_t *item) {
 
     // assert(tree != NULL && item != NULL);
 
-    z = (avl_t *) &tree->root;
+    /* Real sentinel node; avoids treating tree->root storage as avl_t. */
+    avl_t root_parent = {
+        .avl_link = { tree->root, NULL },
+        .avl_balance = 0,
+    };
+
+    z = &root_parent;
     y = tree->root;
     dir = 0;
     for (q = z, p = y; p != NULL; q = p, p = p->avl_link[dir]) {
@@ -77,7 +83,10 @@ avl_t *avl_insert(avl_tree_type *tree, avl_t *item) {
     // tree->avl_count++;
     n->avl_link[0] = n->avl_link[1] = NULL;
     n->avl_balance = 0;
-    if (y == NULL) return n;
+    if (y == NULL) {
+        tree->root = root_parent.avl_link[0];
+        return n;
+    }
 
     for (p = y, k = 0; p != n; p = p->avl_link[da[k]], k++)
         if (da[k] == 0)
@@ -133,11 +142,15 @@ avl_t *avl_insert(avl_tree_type *tree, avl_t *item) {
             w->avl_balance = 0;
         }
     }
-    else return n;
+    else {
+        tree->root = root_parent.avl_link[0];
+        return n;
+    }
 
     z->avl_link[y != z->avl_link[0]] = w;
 
     // tree->avl_generation++;
+    tree->root = root_parent.avl_link[0];
     return n;
 }
 
@@ -154,8 +167,14 @@ avl_t *avl_remove(avl_tree_type *tree, avl_t *item) {
 
     // assert (tree != NULL && item != NULL);
 
+    /* Real sentinel node; avoids treating tree->root storage as avl_t. */
+    avl_t root_parent = {
+        .avl_link = { tree->root, NULL },
+        .avl_balance = 0,
+    };
+
     k = 0;
-    p = (avl_t *) &tree->root;
+    p = &root_parent;
     for(cmp = -1; cmp != 0; cmp = tree->compar(item, p)) {
         unsigned char dir = (unsigned char)(cmp > 0);
 
@@ -286,6 +305,7 @@ avl_t *avl_remove(avl_tree_type *tree, avl_t *item) {
 
     // tree->avl_count--;
     // tree->avl_generation++;
+    tree->root = root_parent.avl_link[0];
     return item;
 }
 

--- a/src/libnetdata/buffer/buffer.h
+++ b/src/libnetdata/buffer/buffer.h
@@ -160,9 +160,11 @@ ALWAYS_INLINE
 static void _buffer_json_depth_push(BUFFER *wb, BUFFER_JSON_NODE_TYPE type) {
     int next_depth = wb->json.depth + 1;
 
-    if(unlikely(next_depth < 0 || next_depth >= BUFFER_JSON_MAX_DEPTH))
+    if(next_depth < 0 || next_depth >= BUFFER_JSON_MAX_DEPTH) {
         fatal("BUFFER JSON: invalid nesting depth %d (next %d, max %d)",
               wb->json.depth, next_depth, BUFFER_JSON_MAX_DEPTH - 1);
+        return;
+    }
 
     wb->json.depth = (int8_t)next_depth;
 #ifdef NETDATA_INTERNAL_CHECKS

--- a/src/libnetdata/socket/socket.c
+++ b/src/libnetdata/socket/socket.c
@@ -649,6 +649,12 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
 
     int nfd = accept4(fd, (struct sockaddr *)&sadr, &addrlen, flags | DEFAULT_SOCKET_FLAGS);
     if (likely(nfd >= 0)) {
+        if(unlikely(!client_ip || ipsize < 2 || !client_port || portsize < 2)) {
+            close(nfd);
+            errno = EINVAL;
+            return -1;
+        }
+
         if (getnameinfo((struct sockaddr *)&sadr, addrlen, client_ip, (socklen_t)ipsize,
                         client_port, (socklen_t)portsize, NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens core components by removing undefined behavior and validating inputs across CLI, ARL, AVL, JSON buffer, and sockets. Prevents crashes and leaks without changing behavior for valid callers.

- **Bug Fixes**
  - CLI: cast bytes to (uint8_t) before isspace().
  - ARL: null-check fast-path pointer before strcmp(); fall back to slow path if NULL.
  - AVL: replace fake root aliasing with a real stack sentinel and copy back the root link.
  - Buffer JSON: add an explicit return after fatal() on invalid nesting depth.
  - Socket: after accept4(), validate client address/port pointers and sizes; close fd and return EINVAL on invalid input.

<sup>Written for commit 0ff586202725f2bcfe18a034509467a17759a9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

