### PR TITLE
Bounded-cardinality process grouping (macOS) and hardware sensors summaries, histogram and function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1686,6 +1686,8 @@ set(INTERNAL_COLLECTORS_FILES
         src/collectors/common-contexts/mem-pgfaults.h
         src/collectors/common-contexts/mem-available.h
         src/collectors/common-contexts/power-supply.h
+        src/collectors/common-contexts/hw-sensors.h
+        src/collectors/common-contexts/hw-sensors-function.h
 )
 
 set(INTERCOMMUNICATION_COLLECTORS_FILES

--- a/src/collectors/apps.plugin/README.md
+++ b/src/collectors/apps.plugin/README.md
@@ -140,6 +140,28 @@ interpreters: process1 process2 process3
 
 - For each process specified, all of its subprocesses will be automatically grouped, not just the matched process itself.
 
+### Automatic grouping on macOS
+
+On macOS, `launchd` spawns almost every process directly, and Apple ships hundreds of distinct helper processes (XPC services, app extensions, framework helpers, standalone daemons).
+To keep the number of groups meaningful, processes that do not match any group in `apps_groups.conf` are grouped automatically based on their executable path:
+
+| Executable                                                            | Group                                              |
+|-----------------------------------------------------------------------|----------------------------------------------------|
+| Application bundles (`*.app`, `*.appex`), Apple or third-party        | one group per application (`Finder`, `Xcode`, ...) |
+| Apple framework helpers (binaries inside `*.framework` bundles)       | `system-frameworks`                                |
+| Apple standalone daemons (`/usr/libexec`, `/usr/sbin`, `/bin`, ...)   | `system-daemons`                                   |
+| Driver extensions (`*.dext`)                                          | `driver-extensions`                                |
+| Third-party frameworks                                                | one group per framework                            |
+| Third-party plain binaries                                            | one group per process name                         |
+
+Since `apps_groups.conf` matches take precedence over automatic grouping, aggregated components can be re-exposed individually by naming them in the configuration.
+The stock configuration already re-exposes famous, long-stable macOS components (`windowserver`, `spotlight`, `media-analysis`, `coreaudio`, `fseventsd`, `icloud`, `nsurlsessiond`, `timemachine`, `videotoolbox`) — see the `MacOS system components of interest` section of `apps_groups.conf`.
+To re-expose any other component, add a line, e.g.:
+
+```text
+airdrop-sharing: sharingd
+```
+
 ### Matching processes
 
 `apps.plugin` uses different fields for process matching depending on the operating system:

--- a/src/collectors/apps.plugin/apps_groups.conf
+++ b/src/collectors/apps.plugin/apps_groups.conf
@@ -33,7 +33,7 @@
 #interpreters: clear
 
 #interpreters: python python2 python3
-#interpreters: sh bash zsh
+#interpreters: sh bash zsh dash csh tcsh ksh
 #interpreters: node perl awk
 
 ## -----------------------------------------------------------------------------

--- a/src/collectors/apps.plugin/apps_groups.conf
+++ b/src/collectors/apps.plugin/apps_groups.conf
@@ -20,7 +20,7 @@
 #managers: init spawn-plugins
 
 ## MacOS process managers
-#managers: launchd spawn-plugins
+#managers: launchd sshd-session spawn-plugins
 
 ## Windows process managers
 #managers: wininit services explorer System netdata
@@ -262,3 +262,41 @@ desktop: lightdm lightdm-*
 desktop: gdm gdm-* dbus-* xdg-* ibus-* evolution-* accounts-daemon colord
 desktop: geoclue pulse* pipewire* wireplumber jack* touchegg pulseaudio
 desktop: Xwayland Xorg
+
+## -----------------------------------------------------------------------------
+## MacOS system components of interest
+##
+## On MacOS, processes not matched by this file are grouped automatically by
+## their executable path: applications keep their own group, Apple framework
+## helpers are aggregated into 'system-frameworks', Apple standalone daemons
+## into 'system-daemons', and driver extensions into 'driver-extensions'.
+##
+## The entries below re-expose famous, long-stable components that would
+## otherwise be hidden inside those buckets. All names are unique to MacOS.
+
+## The display compositor - usually the top CPU consumer on a Mac.
+windowserver: WindowServer
+
+## Spotlight indexing and search.
+spotlight: mds mds_stores mdworker* corespotlightd spotlightknowledged* mdbulkimport
+
+## Photo and media content analysis (face recognition, object detection).
+media-analysis: photoanalysisd photolibraryd mediaanalysisd*
+
+## CoreAudio daemons.
+coreaudio: coreaudiod audiomxd systemsoundserverd
+
+## Filesystem events notification daemon.
+fseventsd: fseventsd
+
+## iCloud synchronization.
+icloud: cloudd cloudphotod
+
+## Background network transfers (App Store, iCloud, software updates).
+nsurlsessiond: nsurlsessiond
+
+## Time Machine backups.
+timemachine: backupd backupd-helper
+
+## Hardware-accelerated video encoding/decoding services.
+videotoolbox: VTDecoderXPCService* VTEncoderXPCService*

--- a/src/collectors/apps.plugin/apps_os_macos.c
+++ b/src/collectors/apps.plugin/apps_os_macos.c
@@ -245,6 +245,13 @@ STRING *apps_os_tree_target_name_macos(struct pid_stat *p) {
         size_t len = e ? (size_t)(e - s) : strlen(s);
 
         if(len) {
+            // precedence is intentionally asymmetric:
+            // - an application counts only when NOT inside a framework
+            //   (frameworks embed helper .apps that belong to the framework)
+            //   and the OUTERMOST such application wins (helpers inside an
+            //   app belong to the app);
+            // - frameworks keep the INNERMOST match (the actual owner);
+            // - when both matched, the application wins (see below).
             if(component_has_suffix(s, len, ".framework")) {
                 // keep the innermost framework
                 fw = s;

--- a/src/collectors/apps.plugin/apps_os_macos.c
+++ b/src/collectors/apps.plugin/apps_os_macos.c
@@ -136,6 +136,161 @@ bool apps_os_get_pid_cmdline_macos(struct pid_stat *p, char *cmdline, size_t max
     return true;
 }
 
+// --------------------------------------------------------------------------------------------------------------------
+// tree target naming
+//
+// macOS has a flat process tree: launchd (pid 1) spawns almost everything, so
+// the tree fallback would otherwise create one group per distinct process name
+// (hundreds of XPC services, appex widgets, framework helpers and standalone
+// daemons). Instead, we derive the group from the executable path:
+//
+// - Apple's bundle grammar is a stable, decades-old contract: *.app / *.appex
+//   identify applications, *.framework the owning subsystem, *.dext driver
+//   extensions - new macOS components follow it automatically, so this needs
+//   no per-version maintenance.
+// - The system volume is sealed (SIP since 10.11, SSV since 11.0), so path
+//   prefixes reliably separate Apple system binaries from user software.
+//
+// Groups derived for processes not matched by apps_groups.conf:
+// - applications (Apple or not): one group per application bundle
+// - user software: one group per framework bundle; comm for plain binaries
+// - Apple framework helpers: aggregated into "system-frameworks"
+// - Apple standalone daemons: aggregated into "system-daemons"
+// - driver extensions: aggregated into "driver-extensions"
+//
+// apps_groups.conf matches run before tree grouping, so users can re-expose
+// any aggregated component by naming it there.
+
+static const char *apple_system_prefixes[] = {
+    "/System/",         // frameworks, system apps, CoreServices, Cryptexes, iOSSupport
+    "/usr/libexec/",
+    "/usr/sbin/",
+    "/usr/bin/",
+    "/sbin/",
+    "/bin/",
+    "/Library/Apple/",  // Apple-managed additions (e.g. Rosetta)
+};
+
+static bool is_apple_system_path(const char *path) {
+    for(size_t i = 0; i < sizeof(apple_system_prefixes) / sizeof(apple_system_prefixes[0]) ; i++) {
+        if(strncmp(path, apple_system_prefixes[i], strlen(apple_system_prefixes[i])) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool component_has_suffix(const char *s, size_t len, const char *suffix) {
+    size_t slen = strlen(suffix);
+    return len > slen && strncmp(s + len - slen, suffix, slen) == 0;
+}
+
+static STRING *string_from_path_component(const char *s, size_t len) {
+    char buf[FILENAME_MAX + 1];
+    if(len > FILENAME_MAX) len = FILENAME_MAX;
+    memcpy(buf, s, len);
+    buf[len] = '\0';
+
+    sanitize_apps_plugin_chart_meta(buf);
+    if(!buf[0]) return NULL;
+
+    return string_strdupz(buf);
+}
+
+static bool macos_get_executable_path(pid_t pid, char *path, size_t size) {
+    if(proc_pidpath(pid, path, (uint32_t)size) > 0 && path[0] == '/')
+        return true;
+
+    // proc_pidpath() fails for some entitled/protected processes (e.g. staged
+    // OS-update services); KERN_PROCARGS2 still exposes the executable path
+    // recorded by the kernel at exec time, as its first string.
+    int mib[3] = {CTL_KERN, KERN_PROCARGS2, pid};
+    size_t args_size = 0;
+    if(sysctl(mib, 3, NULL, &args_size, NULL, 0) == -1 || args_size <= sizeof(int))
+        return false;
+
+    char *args = mallocz(args_size);
+    if(sysctl(mib, 3, args, &args_size, NULL, 0) == -1 || args_size <= sizeof(int)) {
+        freez(args);
+        return false;
+    }
+
+    // layout: [argc][executable path]\0[padding]\0[argv[0]]...
+    const char *exec_path = args + sizeof(int);
+    size_t len = strnlen(exec_path, args_size - sizeof(int));
+    bool ok = (len > 0 && len < size && exec_path[0] == '/');
+    if(ok) {
+        memcpy(path, exec_path, len);
+        path[len] = '\0';
+    }
+
+    freez(args);
+    return ok;
+}
+
+STRING *apps_os_tree_target_name_macos(struct pid_stat *p) {
+    // launchd keeps its own name; interpreters keep their script-derived comm
+    if(p->pid == INIT_PID || is_process_an_interpreter(p))
+        return NULL;
+
+    char path[PROC_PIDPATHINFO_MAXSIZE];
+    if(!macos_get_executable_path(p->pid, path, sizeof(path)))
+        return NULL; // no executable path: fall back to comm naming
+
+    const char *app = NULL, *fw = NULL;
+    size_t app_len = 0, fw_len = 0;
+    bool has_dext = false;
+
+    for(const char *s = path + 1; *s ;) {
+        const char *e = strchr(s, '/');
+        size_t len = e ? (size_t)(e - s) : strlen(s);
+
+        if(len) {
+            if(component_has_suffix(s, len, ".framework")) {
+                // keep the innermost framework
+                fw = s;
+                fw_len = len - strlen(".framework");
+            }
+            else if(!app && !fw && component_has_suffix(s, len, ".app")) {
+                // keep the outermost application not owned by a framework
+                app = s;
+                app_len = len - strlen(".app");
+            }
+            else if(!app && !fw && component_has_suffix(s, len, ".appex")) {
+                app = s;
+                app_len = len - strlen(".appex");
+            }
+            else if(component_has_suffix(s, len, ".dext"))
+                has_dext = true;
+        }
+
+        if(!e) break;
+        s = e + 1;
+    }
+
+    // applications keep their own group, Apple or not
+    if(app)
+        return string_from_path_component(app, app_len);
+
+    if(has_dext)
+        return string_strdupz("driver-extensions");
+
+    bool apple = is_apple_system_path(path);
+
+    if(fw) {
+        if(apple)
+            return string_strdupz("system-frameworks");
+
+        // user-land framework helpers (e.g. Xcode's CoreSimulator)
+        return string_from_path_component(fw, fw_len);
+    }
+
+    if(apple)
+        return string_strdupz("system-daemons");
+
+    // user-land plain binaries keep the default comm naming
+    return NULL;
+}
+
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
 bool apps_os_read_pid_io_macos(struct pid_stat *p, void *ptr) {
     struct pid_info *pi = ptr;

--- a/src/collectors/apps.plugin/apps_plugin.h
+++ b/src/collectors/apps.plugin/apps_plugin.h
@@ -864,4 +864,18 @@ bool OS_FUNCTION(apps_os_read_global_cpu_utilization)(void);
 // return the total physical memory of the system, in bytes
 uint64_t OS_FUNCTION(apps_os_get_total_memory)(void);
 
+// optional: derive the name of a tree (fallback) target from OS-specific
+// process information (e.g. the executable path).
+// Returns an owned STRING, or NULL to use the default naming (name/comm).
+#if defined(OS_MACOS)
+STRING *apps_os_tree_target_name_macos(struct pid_stat *p);
+static inline STRING *apps_os_tree_target_name(struct pid_stat *p) {
+    return apps_os_tree_target_name_macos(p);
+}
+#else
+static inline STRING *apps_os_tree_target_name(struct pid_stat *p __maybe_unused) {
+    return NULL;
+}
+#endif
+
 #endif //NETDATA_APPS_PLUGIN_H

--- a/src/collectors/apps.plugin/apps_targets.c
+++ b/src/collectors/apps.plugin/apps_targets.c
@@ -136,6 +136,14 @@ void apps_managers_and_aggregators_init(void) {
     managed_list_add(&tree.interpreters, "python3");
     managed_list_add(&tree.interpreters, "sh");
     managed_list_add(&tree.interpreters, "bash");
+    // the remaining login shells shipped with macOS (/etc/shells) - a shell
+    // that is a tree root (e.g. an SSH session) must group by its comm, not
+    // by the path-derived Apple system bucket
+    managed_list_add(&tree.interpreters, "zsh");
+    managed_list_add(&tree.interpreters, "dash");
+    managed_list_add(&tree.interpreters, "csh");
+    managed_list_add(&tree.interpreters, "tcsh");
+    managed_list_add(&tree.interpreters, "ksh");
     managed_list_add(&tree.interpreters, "node");
     managed_list_add(&tree.interpreters, "perl");
 }

--- a/src/collectors/apps.plugin/apps_targets.c
+++ b/src/collectors/apps.plugin/apps_targets.c
@@ -112,6 +112,7 @@ void apps_managers_and_aggregators_init(void) {
     managed_list_add(&tree.managers, "init");
 #elif defined(OS_MACOS)
     managed_list_add(&tree.managers, "launchd");
+    managed_list_add(&tree.managers, "sshd-session");   // per-connection ssh session managers
 #endif
 
 #if defined(OS_WINDOWS)
@@ -184,11 +185,16 @@ struct target *get_tree_target(struct pid_stat *p) {
         search_for = string_dup(KernelAggregator);
     }
     else {
+        // OS-specific naming (macOS: derived from the executable path)
+        search_for = apps_os_tree_target_name(p);
+
+        if(!search_for) {
 #if (PROCESSES_HAVE_COMM_AND_NAME == 1)
-        search_for = string_dup(p->name ? p->name : p->comm);
+            search_for = string_dup(p->name ? p->name : p->comm);
 #else
-        search_for = string_dup(p->comm);
+            search_for = string_dup(p->comm);
 #endif
+        }
     }
 
     // find an existing target with the required name

--- a/src/collectors/common-contexts/common-contexts.h
+++ b/src/collectors/common-contexts/common-contexts.h
@@ -36,5 +36,6 @@ typedef void (*instance_labels_cb_t)(RRDSET *st, void *data);
 #include "disk-svctm.h"
 #include "disk-avgsz.h"
 #include "power-supply.h"
+#include "hw-sensors.h"
 
 #endif //NETDATA_COMMON_CONTEXTS_H

--- a/src/collectors/common-contexts/hw-sensors-function.h
+++ b/src/collectors/common-contexts/hw-sensors-function.h
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_HW_SENSORS_FUNCTION_H
+#define NETDATA_HW_SENSORS_FUNCTION_H
+
+// --------------------------------------------------------------------------------------------------------------------
+// Shared schema of the cross-OS "sensors" function
+//
+// Every hardware-sensor producer exposes a "sensors" function with the SAME
+// table schema, so the UI experience is identical on every operating system.
+// This header is self-contained (libnetdata BUFFER APIs only), so it is
+// usable both by in-daemon producers (macos.plugin, windows.plugin) and by
+// external PLUGINSD plugins (debugfs.plugin).
+//
+// Producers emit one data row per sensor, with the values in EXACTLY this
+// order (matching hw_sensors_function_columns() below):
+//
+//   1. Chart      - the per-sensor chart id (unique key, sticky)
+//   2. Label      - human-readable sensor label
+//   3. Kind       - temperature/voltage/current/power/fan/...
+//   4. Subsystem  - hardware subsystem (cpu, soc, memory, storage, ...)
+//   5. Source     - discovery source (smc, iohid, libsensors, ...)
+//   6. Device     - device / chip identifier
+//   7. Sensor     - producer-specific sensor identifier
+//   8. Reading    - current reading (double; NAN when not available)
+//   9. Units      - units of the reading
+//  10. State      - sensor/collection state (ok, missing, alarm, ...)
+//  11. Charts     - charting mode ("per-sensor" or "summary")
+//  12. Count      - always 1 (powers grouped sensor-count tiles)
+//  13. Temperature- Reading when Kind is temperature, else NAN
+//  14. Fan        - Reading when Kind is fan, else NAN
+//  15. Voltage    - Reading when Kind is voltage, else NAN
+//  16. Current    - Reading when Kind is current, else NAN
+//  17. Power      - Reading when Kind is power, else NAN
+//
+// The registration-follows-discovery rule also applies to every producer:
+// the function is only registered/declared once at least one sensor exists.
+
+static inline void hw_sensors_function_columns(BUFFER *wb) {
+    buffer_json_member_add_object(wb, "columns");
+    {
+        size_t field_id = 0;
+
+        buffer_rrdf_table_add_field(wb, field_id++, "Chart", "Per-Sensor Chart ID",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_UNIQUE_KEY | RRDF_FIELD_OPTS_STICKY,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Label", "Sensor Label",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Kind", "Sensor Kind",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Subsystem", "Hardware Subsystem",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Source", "Discovery Source",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Device", "Device / Chip",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Sensor", "Sensor Identifier",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Reading", "Current Reading",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                3, NULL, NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Units", "Reading Units",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "State", "Sensor State",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Charts", "Charting Mode",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Count", "Sensors Count",
+                RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                0, "sensors", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Temperature", "Temperature",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                2, "degrees Celsius", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Fan", "Fan Speed",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                0, "rpm", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Voltage", "Voltage",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                3, "V", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Current", "Current",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                3, "A", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Power", "Power",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                2, "W", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+    }
+    buffer_json_object_close(wb); // columns
+}
+
+static inline void hw_sensors_function_presentation(BUFFER *wb) {
+    buffer_json_member_add_string(wb, "default_sort_column", "Label");
+
+    buffer_json_member_add_object(wb, "charts");
+    {
+        buffer_json_member_add_object(wb, "Sensors");
+        {
+            buffer_json_member_add_string(wb, "name", "Sensors");
+            buffer_json_member_add_string(wb, "type", "stacked-bar");
+            buffer_json_member_add_array(wb, "columns");
+            {
+                buffer_json_add_array_item_string(wb, "Count");
+            }
+            buffer_json_array_close(wb);
+        }
+        buffer_json_object_close(wb);
+
+        static const char *kind_charts[] = {"Temperature", "Fan", "Voltage", "Current", "Power"};
+        for (size_t i = 0; i < sizeof(kind_charts) / sizeof(kind_charts[0]); i++) {
+            buffer_json_member_add_object(wb, kind_charts[i]);
+            {
+                buffer_json_member_add_string(wb, "name", kind_charts[i]);
+                buffer_json_member_add_string(wb, "type", "stacked-bar");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, kind_charts[i]);
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+        }
+    }
+    buffer_json_object_close(wb); // charts
+
+    buffer_json_member_add_array(wb, "default_charts");
+    {
+        buffer_json_add_array_item_array(wb);
+        buffer_json_add_array_item_string(wb, "Sensors");
+        buffer_json_add_array_item_string(wb, "Subsystem");
+        buffer_json_array_close(wb);
+
+        buffer_json_add_array_item_array(wb);
+        buffer_json_add_array_item_string(wb, "Temperature");
+        buffer_json_add_array_item_string(wb, "Subsystem");
+        buffer_json_array_close(wb);
+    }
+    buffer_json_array_close(wb);
+
+    buffer_json_member_add_object(wb, "group_by");
+    {
+        static const struct {
+            const char *id;
+            const char *name;
+        } groups[] = {
+            {"Kind", "Sensors by Kind"},
+            {"Subsystem", "Sensors by Subsystem"},
+            {"Source", "Sensors by Discovery Source"},
+            {"Device", "Sensors by Device"},
+            {"State", "Sensors by State"},
+        };
+
+        for (size_t i = 0; i < sizeof(groups) / sizeof(groups[0]); i++) {
+            buffer_json_member_add_object(wb, groups[i].id);
+            {
+                buffer_json_member_add_string(wb, "name", groups[i].name);
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, groups[i].id);
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+        }
+    }
+    buffer_json_object_close(wb); // group_by
+}
+
+#endif //NETDATA_HW_SENSORS_FUNCTION_H

--- a/src/collectors/common-contexts/hw-sensors-function.h
+++ b/src/collectors/common-contexts/hw-sensors-function.h
@@ -36,114 +36,84 @@
 // The registration-follows-discovery rule also applies to every producer:
 // the function is only registered/declared once at least one sensor exists.
 
-static inline void hw_sensors_function_columns(BUFFER *wb) {
-    buffer_json_member_add_object(wb, "columns");
-    {
-        size_t field_id = 0;
+typedef struct {
+    const char *id;
+    const char *name;
+    RRDF_FIELD_TYPE type;
+    RRDF_FIELD_TRANSFORM transform;
+    int decimal_points;
+    const char *units;
+    RRDF_FIELD_SORT sort;
+    RRDF_FIELD_SUMMARY summary;
+    RRDF_FIELD_FILTER filter;
+    RRDF_FIELD_OPTIONS options;
+} hw_sensors_function_column;
 
-        buffer_rrdf_table_add_field(wb, field_id++, "Chart", "Per-Sensor Chart ID",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_UNIQUE_KEY | RRDF_FIELD_OPTS_STICKY,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Label", "Sensor Label",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Kind", "Sensor Kind",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Subsystem", "Hardware Subsystem",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Source", "Discovery Source",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Device", "Device / Chip",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Sensor", "Sensor Identifier",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Reading", "Current Reading",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                3, NULL, NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Units", "Reading Units",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "State", "Sensor State",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Charts", "Charting Mode",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Count", "Sensors Count",
-                RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                0, "sensors", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Temperature", "Temperature",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                2, "degrees Celsius", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Fan", "Fan Speed",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                0, "rpm", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Voltage", "Voltage",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                3, "V", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Current", "Current",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                3, "A", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Power", "Power",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                2, "W", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
+static inline void hw_sensors_function_columns(BUFFER *wb) {
+    static const hw_sensors_function_column columns[] = {
+        {"Chart", "Per-Sensor Chart ID", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_UNIQUE_KEY | RRDF_FIELD_OPTS_STICKY},
+        {"Label", "Sensor Label", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH},
+        {"Kind", "Sensor Kind", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_VISIBLE},
+        {"Subsystem", "Hardware Subsystem", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_VISIBLE},
+        {"Source", "Discovery Source", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_NONE},
+        {"Device", "Device / Chip", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_NONE},
+        {"Sensor", "Sensor Identifier", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_NONE},
+        {"Reading", "Current Reading", RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_TRANSFORM_NUMBER, 3, NULL,
+         RRDF_FIELD_SORT_DESCENDING, RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+         RRDF_FIELD_OPTS_VISIBLE},
+        {"Units", "Reading Units", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH},
+        {"State", "Sensor State", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_VISIBLE},
+        {"Charts", "Charting Mode", RRDF_FIELD_TYPE_STRING, RRDF_FIELD_TRANSFORM_NONE, 0, NULL,
+         RRDF_FIELD_SORT_ASCENDING, RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+         RRDF_FIELD_OPTS_NONE},
+        {"Count", "Sensors Count", RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_TRANSFORM_NUMBER, 0, "sensors",
+         RRDF_FIELD_SORT_DESCENDING, RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
+         RRDF_FIELD_OPTS_NONE},
+        {"Temperature", "Temperature", RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_TRANSFORM_NUMBER, 2, "degrees Celsius",
+         RRDF_FIELD_SORT_DESCENDING, RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+         RRDF_FIELD_OPTS_NONE},
+        {"Fan", "Fan Speed", RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_TRANSFORM_NUMBER, 0, "rpm",
+         RRDF_FIELD_SORT_DESCENDING, RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+         RRDF_FIELD_OPTS_NONE},
+        {"Voltage", "Voltage", RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_TRANSFORM_NUMBER, 3, "V",
+         RRDF_FIELD_SORT_DESCENDING, RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+         RRDF_FIELD_OPTS_NONE},
+        {"Current", "Current", RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_TRANSFORM_NUMBER, 3, "A",
+         RRDF_FIELD_SORT_DESCENDING, RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+         RRDF_FIELD_OPTS_NONE},
+        {"Power", "Power", RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_TRANSFORM_NUMBER, 2, "W",
+         RRDF_FIELD_SORT_DESCENDING, RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
+         RRDF_FIELD_OPTS_NONE},
+    };
+
+    buffer_json_member_add_object(wb, "columns");
+
+    for (size_t i = 0; i < sizeof(columns) / sizeof(columns[0]); i++) {
+        const hw_sensors_function_column *c = &columns[i];
+        buffer_rrdf_table_add_field(wb, i, c->id, c->name,
+                c->type, RRDF_FIELD_VISUAL_VALUE, c->transform,
+                c->decimal_points, c->units, NAN, c->sort, NULL,
+                c->summary, c->filter, c->options, NULL);
     }
+
     buffer_json_object_close(wb); // columns
 }
 

--- a/src/collectors/common-contexts/hw-sensors.h
+++ b/src/collectors/common-contexts/hw-sensors.h
@@ -12,14 +12,15 @@
 //
 // Buckets are DISJOINT bands (not cumulative): each dimension counts the
 // sensors whose current reading falls inside its band only, and every sensor
-// increments exactly one bucket. Dimensions are named after the band's upper
-// bound, in degrees Celsius: 10C-wide bands through the benign range,
-// 5C-wide bands in the 80-100C action zone, one overflow bucket above 100C.
+// increments exactly one bucket. Dimensions are named after the band's
+// EXCLUSIVE upper bound, in degrees Celsius: dimension "40" counts t < 40,
+// "50" counts 40 <= t < 50, ..., "100" counts 95 <= t < 100, and "+Inf"
+// counts t >= 100. 10C-wide bands through the benign range, 5C-wide bands
+// in the 80-100C action zone.
 //
 // Producers using this header: macos.plugin, windows.plugin.
-// Producers mirroring this contract (different emission mechanisms — keep in
-// sync by hand): go.d/collector/sensors (Go), debugfs.plugin libsensors
-// (PLUGINSD text protocol).
+// Producers mirroring this contract (different emission mechanism - keep in
+// sync by hand): debugfs.plugin libsensors (PLUGINSD text protocol).
 
 #define HW_SENSORS_TEMPERATURE_HISTOGRAM_CONTEXT "system.hw.sensor.temperature.histogram"
 #define HW_SENSORS_TEMPERATURE_HISTOGRAM_TITLE "Temperature Sensors Distribution"

--- a/src/collectors/common-contexts/hw-sensors.h
+++ b/src/collectors/common-contexts/hw-sensors.h
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_HW_SENSORS_H
+#define NETDATA_HW_SENSORS_H
+
+// --------------------------------------------------------------------------------------------------------------------
+// Cross-OS temperature sensors histogram
+//
+// PERMANENT CONTRACT: every hardware-sensor producer emits this context with
+// exactly these buckets, so Netdata Cloud can sum the bucket counts across
+// nodes into a fleet-wide thermal distribution view.
+//
+// Buckets are DISJOINT bands (not cumulative): each dimension counts the
+// sensors whose current reading falls inside its band only, and every sensor
+// increments exactly one bucket. Dimensions are named after the band's upper
+// bound, in degrees Celsius: 10C-wide bands through the benign range,
+// 5C-wide bands in the 80-100C action zone, one overflow bucket above 100C.
+//
+// Producers using this header: macos.plugin, windows.plugin.
+// Producers mirroring this contract (different emission mechanisms — keep in
+// sync by hand): go.d/collector/sensors (Go), debugfs.plugin libsensors
+// (PLUGINSD text protocol).
+
+#define HW_SENSORS_TEMPERATURE_HISTOGRAM_CONTEXT "system.hw.sensor.temperature.histogram"
+#define HW_SENSORS_TEMPERATURE_HISTOGRAM_TITLE "Temperature Sensors Distribution"
+#define HW_SENSORS_TEMPERATURE_HISTOGRAM_UNITS "sensors"
+#define HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS 10
+
+static const int hw_sensors_temperature_histogram_upper_bounds[HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS - 1] = {
+    40, 50, 60, 70, 80, 85, 90, 95, 100,
+};
+
+static const char *hw_sensors_temperature_histogram_dimensions[HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS] = {
+    "40", "50", "60", "70", "80", "85", "90", "95", "100", "+Inf",
+};
+
+typedef struct {
+    RRDSET *st;
+    RRDDIM *rds[HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS];
+    uint32_t counts[HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS];
+} HW_SENSORS_TEMPERATURE_HISTOGRAM;
+
+static inline void hw_sensors_temperature_histogram_reset(HW_SENSORS_TEMPERATURE_HISTOGRAM *h) {
+    memset(h->counts, 0, sizeof(h->counts));
+}
+
+static inline void hw_sensors_temperature_histogram_add(HW_SENSORS_TEMPERATURE_HISTOGRAM *h, NETDATA_DOUBLE celsius) {
+    size_t i = 0;
+    while (i < HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS - 1 &&
+           celsius >= (NETDATA_DOUBLE)hw_sensors_temperature_histogram_upper_bounds[i])
+        i++;
+
+    h->counts[i]++;
+}
+
+static inline void common_hw_sensors_temperature_histogram(
+    HW_SENSORS_TEMPERATURE_HISTOGRAM *h,
+    int update_every,
+    const char *plugin,
+    const char *module)
+{
+    if (unlikely(!h->st)) {
+        // do not create the chart before at least one temperature sensor
+        // exists - machines without temperature sensors get no chart at all
+        uint32_t total = 0;
+        for (size_t i = 0; i < HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS; i++)
+            total += h->counts[i];
+        if (!total)
+            return;
+
+        h->st = rrdset_create_localhost(
+            "sensors",
+            "temperature_histogram",
+            NULL,
+            "Temperature",
+            HW_SENSORS_TEMPERATURE_HISTOGRAM_CONTEXT,
+            HW_SENSORS_TEMPERATURE_HISTOGRAM_TITLE,
+            HW_SENSORS_TEMPERATURE_HISTOGRAM_UNITS,
+            plugin,
+            module,
+            NETDATA_CHART_PRIO_SENSORS - 10,
+            update_every,
+            RRDSET_TYPE_HEATMAP);
+
+        for (size_t i = 0; i < HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS; i++)
+            h->rds[i] = rrddim_add(
+                h->st, hw_sensors_temperature_histogram_dimensions[i], NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    }
+
+    for (size_t i = 0; i < HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS; i++)
+        rrddim_set_by_pointer(h->st, h->rds[i], (collected_number)h->counts[i]);
+
+    rrdset_done(h->st);
+}
+
+#endif //NETDATA_HW_SENSORS_H

--- a/src/collectors/common-contexts/hw-sensors.h
+++ b/src/collectors/common-contexts/hw-sensors.h
@@ -46,6 +46,11 @@ static inline void hw_sensors_temperature_histogram_reset(HW_SENSORS_TEMPERATURE
 }
 
 static inline void hw_sensors_temperature_histogram_add(HW_SENSORS_TEMPERATURE_HISTOGRAM *h, NETDATA_DOUBLE celsius) {
+    // NAN fails every comparison below and would silently land in the first
+    // bucket - reject invalid readings here to protect all producers
+    if (unlikely(!isfinite(celsius)))
+        return;
+
     size_t i = 0;
     while (i < HW_SENSORS_TEMPERATURE_HISTOGRAM_BUCKETS - 1 &&
            celsius >= (NETDATA_DOUBLE)hw_sensors_temperature_histogram_upper_bounds[i])

--- a/src/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/src/collectors/debugfs.plugin/debugfs_plugin.c
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
     heartbeat_t hb;
     heartbeat_init(&hb, update_every * USEC_PER_SEC);
 
-    for (iteration = 0; iteration < 86400; iteration++) {
+    for (iteration = 0; iteration < 86400 && !__atomic_load_n(&debugfs_plugin_exit, __ATOMIC_ACQUIRE); iteration++) {
         heartbeat_next(&hb);
         int enabled = 0;
 
@@ -284,5 +284,11 @@ int main(int argc, char **argv)
     fprintf(stdout, "EXIT\n");
     fflush(stdout);
     netdata_mutex_unlock(&stdout_mutex);
+
+    // when the functions evloop reader requested the exit (QUIT / stdin
+    // error), propagate the exit status it recorded
+    if (__atomic_load_n(&debugfs_plugin_exit, __ATOMIC_ACQUIRE))
+        return debugfs_exit_status;
+
     return 0;
 }

--- a/src/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/src/collectors/debugfs.plugin/debugfs_plugin.c
@@ -236,6 +236,14 @@ int main(int argc, char **argv)
 
     debugfs_parse_args(argc, argv);
 
+    // the event loop for functions served by the modules
+    static bool debugfs_plugin_exit = false;
+    static int debugfs_exit_status = 0;
+    struct functions_evloop_globals *wg =
+        functions_evloop_init(1, "DEBUGFS", &stdout_mutex, &debugfs_plugin_exit, &debugfs_exit_status);
+
+    module_libsensors_register_functions(wg);
+
     size_t iteration;
     heartbeat_t hb;
     heartbeat_init(&hb, update_every * USEC_PER_SEC);

--- a/src/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/src/collectors/debugfs.plugin/debugfs_plugin.c
@@ -281,6 +281,11 @@ int main(int argc, char **argv)
         }
     }
 
+    // whether the functions evloop reader (QUIT / stdin error) requested this
+    // exit - latched before cancelling the threads, because cancellation also
+    // makes the reader set the exit flag on its way out
+    bool evloop_requested_exit = __atomic_load_n(&debugfs_plugin_exit, __ATOMIC_ACQUIRE);
+
     // stop serving functions before tearing down the modules' state: a
     // worker running concurrently with shutdown could otherwise write a
     // function result after the terminal EXIT marker, or use freed state
@@ -295,8 +300,9 @@ int main(int argc, char **argv)
     netdata_mutex_unlock(&stdout_mutex);
 
     // when the functions evloop reader requested the exit (QUIT / stdin
-    // error), propagate the exit status it recorded
-    if (__atomic_load_n(&debugfs_plugin_exit, __ATOMIC_ACQUIRE))
+    // error), propagate the exit status it recorded; on our own exit paths
+    // (daily restart, all modules disabled, EPIPE) keep our own status
+    if (evloop_requested_exit)
         return debugfs_exit_status;
 
     return rc;

--- a/src/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/src/collectors/debugfs.plugin/debugfs_plugin.c
@@ -248,6 +248,7 @@ int main(int argc, char **argv)
     heartbeat_t hb;
     heartbeat_init(&hb, update_every * USEC_PER_SEC);
 
+    int rc = 0;
     for (iteration = 0; iteration < 86400 && !__atomic_load_n(&debugfs_plugin_exit, __ATOMIC_ACQUIRE); iteration++) {
         heartbeat_next(&hb);
         int enabled = 0;
@@ -264,7 +265,8 @@ int main(int argc, char **argv)
 
         if (!enabled) {
             netdata_log_info("all modules are disabled, exiting...");
-            return 1;
+            rc = 1;
+            break;
         }
 
         netdata_mutex_lock(&stdout_mutex);
@@ -274,9 +276,16 @@ int main(int argc, char **argv)
 
         if (ferror(stdout) && errno == EPIPE) {
             netdata_log_error("error writing to stdout: EPIPE. Exiting...");
-            return 1;
+            rc = 1;
+            break;
         }
     }
+
+    // stop serving functions before tearing down the modules' state: a
+    // worker running concurrently with shutdown could otherwise write a
+    // function result after the terminal EXIT marker, or use freed state
+    functions_evloop_cancel_threads(wg);
+    functions_evloop_join_threads(wg);
 
     module_libsensors_cleanup();
 
@@ -290,5 +299,5 @@ int main(int argc, char **argv)
     if (__atomic_load_n(&debugfs_plugin_exit, __ATOMIC_ACQUIRE))
         return debugfs_exit_status;
 
-    return 0;
+    return rc;
 }

--- a/src/collectors/debugfs.plugin/debugfs_plugin.h
+++ b/src/collectors/debugfs.plugin/debugfs_plugin.h
@@ -18,6 +18,7 @@ int do_module_libsensors(int update_every, const char *name);
 int do_module_audit(int update_every, const char *name);
 
 void module_libsensors_cleanup(void);
+void module_libsensors_register_functions(struct functions_evloop_globals *wg);
 
 void debugfs2lower(char *name);
 const char *debugfs_rrdset_type_name(RRDSET_TYPE chart_type);

--- a/src/collectors/debugfs.plugin/metadata.yaml
+++ b/src/collectors/debugfs.plugin/metadata.yaml
@@ -533,3 +533,293 @@ modules:
                 - name: silent
                 - name: printk
                 - name: panic
+  - meta:
+      plugin_name: debugfs.plugin
+      module_name: libsensors
+      monitored_instance:
+        name: Linux Hardware Sensors (libsensors)
+        link: 'https://hwmon.wiki.kernel.org/lm_sensors'
+        categories:
+          - data-collection.hardware-and-sensors
+        icon_filename: 'microchip.svg'
+      related_resources:
+        integrations:
+          list: []
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords:
+        - sensors
+        - temperature
+        - voltage
+        - fan
+        - current
+        - power
+        - energy
+        - humidity
+        - hwmon
+        - lm-sensors
+    overview:
+      data_collection:
+        metrics_description: >
+          Collects hardware sensor readings (temperature, voltage, fan speed, current, power,
+          energy, humidity and intrusion state) from all hardware monitoring chips exposed by
+          the Linux hwmon subsystem. Every sensor gets its own chart, a cross-platform
+          temperature histogram summarizes all temperature sensors in fixed bands, and a live
+          `sensors` function lists every discovered sensor with its current reading and state.
+        method_description: >
+          Uses a bundled copy of the libsensors library (the same library behind the `sensors`
+          command) to enumerate and read the hardware monitoring chips exposed under
+          `/sys/class/hwmon`.
+      supported_platforms:
+        include:
+          - Linux
+        exclude: []
+      multi_instance: false
+      additional_permissions:
+        description: >
+          The hwmon sysfs attributes are generally world-readable, so no additional permissions
+          beyond the ones the debugfs plugin already has are required.
+      default_behavior:
+        auto_detection:
+          description: >
+            All hardware monitoring chips exposed by the hwmon subsystem are detected and
+            collected automatically. The collection interval is automatically raised above the
+            configured update every when reading the sensors is slow.
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list: []
+      configuration:
+        file:
+          name: 'netdata.conf'
+          section_name: '[plugin:debugfs]'
+          description: 'This is netdata main configuration file.'
+        options:
+          description: ''
+          folding:
+            title: 'Config options'
+            enabled: true
+          list:
+            - name: update every
+              description: Data collection frequency.
+              default_value: 1
+              required: false
+            - name: command options
+              description: Additinal parameters for collector
+              default_value: ""
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list: []
+    troubleshooting:
+      problems:
+        list: []
+    alerts: []
+    metrics:
+      folding:
+        title: Metrics
+        enabled: false
+      description: >
+        Per-sensor charts are created for every supported reading of every discovered sensor;
+        the alarm charts expose only the states each sensor driver actually supports. The
+        temperature histogram is a single host-wide chart with the same fixed bands on every
+        operating system: each dimension is a DISJOINT band named after its EXCLUSIVE upper
+        bound in degrees Celsius, and every temperature sensor is counted in exactly one band.
+      availability: []
+      scopes:
+        - name: sensor
+          description: "These metrics refer to a hardware sensor chip feature."
+          labels:
+            - name: feature
+              description: Stable sensor feature identifier
+            - name: label
+              description: Human-readable sensor label
+            - name: chip_id
+              description: Sensor chip identifier
+            - name: path
+              description: The hwmon sysfs path of the sensor chip
+            - name: subsystem
+              description: Hardware subsystem the sensor chip belongs to
+            - name: driver
+              description: Kernel driver providing the sensor
+          metrics:
+            - name: system.hw.sensor.temperature.input
+              description: Sensor Temperature
+              unit: "degrees Celsius"
+              chart_type: line
+              dimensions:
+                - name: input
+            - name: system.hw.sensor.temperature.alarm
+              description: Sensor Temperature Alarm Status
+              unit: "status"
+              chart_type: line
+              dimensions:
+                - name: clear
+                - name: warning
+                - name: cap
+                - name: alarm
+                - name: critical
+                - name: emergency
+                - name: fault
+            - name: system.hw.sensor.voltage.input
+              description: Sensor Voltage
+              unit: "Volts"
+              chart_type: line
+              dimensions:
+                - name: input
+            - name: system.hw.sensor.voltage.average
+              description: Sensor Voltage Average
+              unit: "Volts"
+              chart_type: line
+              dimensions:
+                - name: average
+            - name: system.hw.sensor.voltage.alarm
+              description: Sensor Voltage Alarm Status
+              unit: "status"
+              chart_type: line
+              dimensions:
+                - name: clear
+                - name: warning
+                - name: cap
+                - name: alarm
+                - name: critical
+                - name: emergency
+                - name: fault
+            - name: system.hw.sensor.fan.input
+              description: Sensor Fan Speed
+              unit: "rotations per minute"
+              chart_type: line
+              dimensions:
+                - name: input
+            - name: system.hw.sensor.fan.alarm
+              description: Sensor Fan Alarm Status
+              unit: "status"
+              chart_type: line
+              dimensions:
+                - name: clear
+                - name: warning
+                - name: cap
+                - name: alarm
+                - name: critical
+                - name: emergency
+                - name: fault
+            - name: system.hw.sensor.current.input
+              description: Sensor Current
+              unit: "Amperes"
+              chart_type: line
+              dimensions:
+                - name: input
+            - name: system.hw.sensor.current.average
+              description: Sensor Current Average
+              unit: "Amperes"
+              chart_type: line
+              dimensions:
+                - name: average
+            - name: system.hw.sensor.current.alarm
+              description: Sensor Current Alarm Status
+              unit: "status"
+              chart_type: line
+              dimensions:
+                - name: clear
+                - name: warning
+                - name: cap
+                - name: alarm
+                - name: critical
+                - name: emergency
+                - name: fault
+            - name: system.hw.sensor.power.input
+              description: Sensor Power
+              unit: "Watts"
+              chart_type: line
+              dimensions:
+                - name: input
+            - name: system.hw.sensor.power.average
+              description: Sensor Power Average
+              unit: "Watts"
+              chart_type: line
+              dimensions:
+                - name: average
+            - name: system.hw.sensor.power.alarm
+              description: Sensor Power Alarm Status
+              unit: "status"
+              chart_type: line
+              dimensions:
+                - name: clear
+                - name: warning
+                - name: cap
+                - name: alarm
+                - name: critical
+                - name: emergency
+                - name: fault
+            - name: system.hw.sensor.energy.input
+              description: Sensor Energy
+              unit: "Joules"
+              chart_type: line
+              dimensions:
+                - name: input
+            - name: system.hw.sensor.energy.alarm
+              description: Sensor Energy Alarm Status
+              unit: "status"
+              chart_type: line
+              dimensions:
+                - name: clear
+                - name: warning
+                - name: cap
+                - name: alarm
+                - name: critical
+                - name: emergency
+                - name: fault
+            - name: system.hw.sensor.humidity.input
+              description: Sensor Humidity
+              unit: "percentage"
+              chart_type: line
+              dimensions:
+                - name: input
+            - name: system.hw.sensor.humidity.alarm
+              description: Sensor Humidity Alarm Status
+              unit: "status"
+              chart_type: line
+              dimensions:
+                - name: clear
+                - name: warning
+                - name: cap
+                - name: alarm
+                - name: critical
+                - name: emergency
+                - name: fault
+            - name: system.hw.sensor.intrusion.alarm
+              description: Sensor Intrusion Alarm Status
+              unit: "status"
+              chart_type: line
+              dimensions:
+                - name: clear
+                - name: warning
+                - name: cap
+                - name: alarm
+                - name: critical
+                - name: emergency
+                - name: fault
+        - name: global
+          description: "Host-wide summary of all temperature sensors."
+          labels: []
+          metrics:
+            - name: system.hw.sensor.temperature.histogram
+              description: Distribution of all temperature sensors in fixed bands
+              unit: "sensors"
+              chart_type: heatmap
+              dimensions:
+                - name: "40"
+                - name: "50"
+                - name: "60"
+                - name: "70"
+                - name: "80"
+                - name: "85"
+                - name: "90"
+                - name: "95"
+                - name: "100"
+                - name: "+Inf"

--- a/src/collectors/debugfs.plugin/metadata.yaml
+++ b/src/collectors/debugfs.plugin/metadata.yaml
@@ -68,7 +68,7 @@ modules:
               default_value: 1
               required: false
             - name: command options
-              description: Additinal parameters for collector
+              description: Additional parameters for collector
               default_value: ""
               required: false
         examples:
@@ -211,7 +211,7 @@ modules:
               default_value: 1
               required: false
             - name: command options
-              description: Additinal parameters for collector
+              description: Additional parameters for collector
               default_value: ""
               required: false
         examples:
@@ -353,7 +353,7 @@ modules:
               default_value: 1
               required: false
             - name: command options
-              description: Additinal parameters for collector
+              description: Additional parameters for collector
               default_value: ""
               required: false
         examples:
@@ -608,7 +608,7 @@ modules:
               default_value: 1
               required: false
             - name: command options
-              description: Additinal parameters for collector
+              description: Additional parameters for collector
               default_value: ""
               required: false
         examples:

--- a/src/collectors/debugfs.plugin/module-libsensors.c
+++ b/src/collectors/debugfs.plugin/module-libsensors.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "debugfs_plugin.h"
+#include "../common-contexts/hw-sensors-function.h"
 
 #define NETDATA_CALCULATED_STATES 1
 
@@ -1249,7 +1250,9 @@ static void libsensors_emit_temperature_histogram(int update_every, const char *
     }
     dfe_done(s);
 
-    if (!total)
+    // before the chart exists, zero sensors means nothing to expose;
+    // after it exists, keep sending (zero counts are truthful data)
+    if (!exposed && !total)
         return;
 
     if (!exposed) {
@@ -1284,19 +1287,22 @@ static void libsensors_emit_temperature_histogram(int update_every, const char *
     "Lists all hardware sensors discovered on this host, with their current readings."
 
 // guards sensors_dict contents between the collection thread and function threads
-static netdata_mutex_t sensors_data_mutex = NETDATA_MUTEX_INITIALIZER;
+// (netdata_mutex_t is uv_mutex_t - it has no static initializer)
+static netdata_mutex_t sensors_data_mutex;
 
-static const char *libsensors_state_to_string(SENSOR_STATE state) {
-    switch(state) {
-        case SENSOR_STATE_CLEAR: return "clear";
-        case SENSOR_STATE_WARNING: return "warning";
-        case SENSOR_STATE_ALARM: return "alarm";
-        case SENSOR_STATE_CRITICAL: return "critical";
-        case SENSOR_STATE_EMERGENCY: return "emergency";
-        case SENSOR_STATE_FAULT: return "fault";
-        case SENSOR_STATE_CAP: return "cap";
-        default: return "unknown";
-    }
+static void __attribute__((constructor)) sensors_data_mutex_init(void) {
+    netdata_mutex_init(&sensors_data_mutex);
+}
+
+static const char *libsensors_function_state(SENSOR *s) {
+    if (!s->read)
+        return "missing";
+
+    // cross-OS convention: the healthy state is reported as "ok"
+    if (s->state == SENSOR_STATE_CLEAR)
+        return "ok";
+
+    return SENSOR_STATE_2str(s->state);
 }
 
 static void libsensors_function_sensors(
@@ -1322,13 +1328,26 @@ static void libsensors_function_sensors(
     if (sensors_dict) {
         SENSOR *s;
         dfe_start_read(sensors_dict, s) {
-            bool fresh = !isnan(s->input);
-            const char *kind = SENSOR_TYPE_2str(s->feature.type);
+            // function-row Kind and Units use the cross-OS names
+            // (libsensors' "curr" -> "current", "Volts" -> "V", ...)
+            const char *kind = (s->feature.type == SENSORS_FEATURE_CURR) ? "current"
+                                                                         : SENSOR_TYPE_2str(s->feature.type);
+            const char *units = s->config.units;
+            switch (s->feature.type) {
+                case SENSORS_FEATURE_IN: units = "V"; break;
+                case SENSORS_FEATURE_CURR: units = "A"; break;
+                case SENSORS_FEATURE_POWER: units = "W"; break;
+                default: break;
+            }
+
             const char *label =
                 (s->feature.label) ? string2str(s->feature.label) : string2str(s->feature.name);
 
+            // point to the chart this sensor actually has: state-only sensors
+            // (e.g. intrusion) have an _alarm chart, not an _input one
             char chart_id[RRD_ID_LENGTH_MAX + 16];
-            snprintfz(chart_id, sizeof(chart_id), "sensors.%s_input", string2str(s->id));
+            snprintfz(chart_id, sizeof(chart_id), "sensors.%s%s", string2str(s->id),
+                      (!s->exposed_input && s->exposed_states) ? "_alarm" : "_input");
 
             buffer_json_add_array_item_array(wb);
 
@@ -1340,8 +1359,8 @@ static void libsensors_function_sensors(
             buffer_json_add_array_item_string(wb, string2str(s->chip.id));
             buffer_json_add_array_item_string(wb, string2str(s->feature.name));
             buffer_json_add_array_item_double(wb, s->input);
-            buffer_json_add_array_item_string(wb, s->config.units);
-            buffer_json_add_array_item_string(wb, fresh ? libsensors_state_to_string(s->state) : "missing");
+            buffer_json_add_array_item_string(wb, units);
+            buffer_json_add_array_item_string(wb, libsensors_function_state(s));
             buffer_json_add_array_item_string(wb, "per-sensor");
             buffer_json_add_array_item_uint64(wb, 1); // Count - enables grouped sensor-count charts
 
@@ -1361,188 +1380,8 @@ static void libsensors_function_sensors(
 
     buffer_json_array_close(wb); // data
 
-    buffer_json_member_add_object(wb, "columns");
-    {
-        size_t field_id = 0;
-
-        buffer_rrdf_table_add_field(wb, field_id++, "Chart", "Per-Sensor Chart ID",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_UNIQUE_KEY | RRDF_FIELD_OPTS_STICKY,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Label", "Sensor Label",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Kind", "Sensor Kind",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Subsystem", "Hardware Subsystem",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Source", "Discovery Source",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Device", "Device / Chip",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Sensor", "Sensor Identifier",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Reading", "Current Reading",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                3, NULL, NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Units", "Reading Units",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "State", "Sensor State",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Charts", "Charting Mode",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Count", "Sensors Count",
-                RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                0, "sensors", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Temperature", "Temperature",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                2, "degrees Celsius", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Fan", "Fan Speed",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                0, "rpm", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Voltage", "Voltage",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                3, "V", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Current", "Current",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                3, "A", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Power", "Power",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                2, "W", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-    }
-    buffer_json_object_close(wb); // columns
-
-    buffer_json_member_add_string(wb, "default_sort_column", "Label");
-
-    buffer_json_member_add_object(wb, "charts");
-    {
-        buffer_json_member_add_object(wb, "Sensors");
-        {
-            buffer_json_member_add_string(wb, "name", "Sensors");
-            buffer_json_member_add_string(wb, "type", "stacked-bar");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Count");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        static const char *kind_charts[] = {"Temperature", "Fan", "Voltage", "Current", "Power"};
-        for (size_t i = 0; i < _countof(kind_charts); i++) {
-            buffer_json_member_add_object(wb, kind_charts[i]);
-            {
-                buffer_json_member_add_string(wb, "name", kind_charts[i]);
-                buffer_json_member_add_string(wb, "type", "stacked-bar");
-                buffer_json_member_add_array(wb, "columns");
-                {
-                    buffer_json_add_array_item_string(wb, kind_charts[i]);
-                }
-                buffer_json_array_close(wb);
-            }
-            buffer_json_object_close(wb);
-        }
-    }
-    buffer_json_object_close(wb); // charts
-
-    buffer_json_member_add_array(wb, "default_charts");
-    {
-        buffer_json_add_array_item_array(wb);
-        buffer_json_add_array_item_string(wb, "Sensors");
-        buffer_json_add_array_item_string(wb, "Subsystem");
-        buffer_json_array_close(wb);
-
-        buffer_json_add_array_item_array(wb);
-        buffer_json_add_array_item_string(wb, "Temperature");
-        buffer_json_add_array_item_string(wb, "Subsystem");
-        buffer_json_array_close(wb);
-    }
-    buffer_json_array_close(wb);
-
-    buffer_json_member_add_object(wb, "group_by");
-    {
-        static const struct {
-            const char *id;
-            const char *name;
-        } groups[] = {
-            {"Kind", "Sensors by Kind"},
-            {"Subsystem", "Sensors by Subsystem"},
-            {"Device", "Sensors by Device"},
-            {"State", "Sensors by State"},
-        };
-
-        for (size_t i = 0; i < _countof(groups); i++) {
-            buffer_json_member_add_object(wb, groups[i].id);
-            {
-                buffer_json_member_add_string(wb, "name", groups[i].name);
-                buffer_json_member_add_array(wb, "columns");
-                {
-                    buffer_json_add_array_item_string(wb, groups[i].id);
-                }
-                buffer_json_array_close(wb);
-            }
-            buffer_json_object_close(wb);
-        }
-    }
-    buffer_json_object_close(wb); // group_by
+    hw_sensors_function_columns(wb);
+    hw_sensors_function_presentation(wb);
 
     buffer_json_member_add_time_t(wb, "expires", now_realtime_sec() + 1);
     buffer_json_finalize(wb);
@@ -1550,7 +1389,13 @@ static void libsensors_function_sensors(
     wb->response_code = HTTP_RESP_OK;
     wb->content_type = CT_APPLICATION_JSON;
     wb->expires = now_realtime_sec() + 1;
+
+    // serialize the multi-write function result with the collector's
+    // CHART/SET emission - interleaving would corrupt the PLUGINSD stream
+    netdata_mutex_lock(&stdout_mutex);
     pluginsd_function_result_to_stdout(transaction, wb);
+    netdata_mutex_unlock(&stdout_mutex);
+
     buffer_free(wb);
 }
 
@@ -1587,16 +1432,20 @@ void libsensors_thread(void *ptr __maybe_unused) {
     {
         SENSOR *s;
 
+        netdata_mutex_lock(&sensors_data_mutex);
         sensors_collect_data(); // do the first before starting measurements
         dfe_start_read(sensors_dict, s) { set_sensor_state(s); } dfe_done(s);
+        netdata_mutex_unlock(&sensors_data_mutex);
 
         usec_t max_ut = 0;
         size_t samples = 0;
         usec_t started_ut = now_monotonic_usec();
         for(size_t i = 0; i < 5; i++) {
             usec_t before_ut = now_monotonic_usec();
+            netdata_mutex_lock(&sensors_data_mutex);
             sensors_collect_data();
             dfe_start_read(sensors_dict, s) { set_sensor_state(s); } dfe_done(s);
+            netdata_mutex_unlock(&sensors_data_mutex);
             usec_t after_ut = now_monotonic_usec();
             max_ut = MAX(max_ut, after_ut - before_ut);
             samples++;
@@ -1649,14 +1498,20 @@ void libsensors_thread(void *ptr __maybe_unused) {
         if(collect_failed)
             break;
 
+        // lock order: stdout_mutex first, then sensors_data_mutex.
+        // sensor_process() mutates sensor state and the "sensors" function
+        // threads traverse the dictionary, so emission needs both. the
+        // function threads never hold sensors_data_mutex while waiting for
+        // stdout_mutex, so this ordering cannot deadlock.
         netdata_mutex_lock(&stdout_mutex);
+        netdata_mutex_lock(&sensors_data_mutex);
 
         // expose the function only on hosts that actually have sensors
         if(!function_declared && dictionary_entries(sensors_dict)) {
             fprintf(stdout, PLUGINSD_KEYWORD_FUNCTION " GLOBAL \"sensors\" %d \"%s\" \"top\" " HTTP_ACCESS_FORMAT " %d\n",
                     PLUGINS_FUNCTIONS_TIMEOUT_DEFAULT, LIBSENSORS_FUNCTION_SENSORS_HELP,
                     (HTTP_ACCESS_FORMAT_CAST)(HTTP_ACCESS_ANONYMOUS_DATA),
-                    RRDFUNCTIONS_PRIORITY_DEFAULT / 10);
+                    RRDFUNCTIONS_PRIORITY_DEFAULT);
             function_declared = true;
         }
 
@@ -1668,6 +1523,7 @@ void libsensors_thread(void *ptr __maybe_unused) {
 
         libsensors_emit_temperature_histogram(update_every, "sensors");
 
+        netdata_mutex_unlock(&sensors_data_mutex);
         fflush(stdout);
         netdata_mutex_unlock(&stdout_mutex);
     }
@@ -1675,8 +1531,12 @@ void libsensors_thread(void *ptr __maybe_unused) {
 cleanup:
     libsensors_running = false;
 
+    // serialize with in-flight "sensors" function requests: they must either
+    // finish before the dictionary is destroyed, or observe it as NULL
+    netdata_mutex_lock(&sensors_data_mutex);
     dictionary_destroy(sensors_dict);
     sensors_dict = NULL;
+    netdata_mutex_unlock(&sensors_data_mutex);
 }
 
 static ND_THREAD *libsensors = NULL;

--- a/src/collectors/debugfs.plugin/module-libsensors.c
+++ b/src/collectors/debugfs.plugin/module-libsensors.c
@@ -964,8 +964,9 @@ static size_t states_count(SENSOR_STATE state) {
 }
 
 static void sensor_process(SENSOR *s, int update_every, const char *name) {
-    // evaluate the state of the feature
-    set_sensor_state(s);
+    // the caller has already evaluated the sensor state via set_sensor_state()
+    // in the collect-locked section, so that concurrent "sensors" function
+    // requests observe values and states from the same cycle
     internal_fatal(s->state == 0,
                    "SENSORS: state %u is not a valid state", s->state);
 
@@ -1241,7 +1242,9 @@ static void libsensors_emit_temperature_histogram(int update_every, const char *
 
     SENSOR *s;
     dfe_start_read(sensors_dict, s) {
-        if (s->feature.type != SENSORS_FEATURE_TEMP || isnan(s->input))
+        // skip sensors missing from this cycle's enumeration too: their
+        // cached s->input holds the last value they ever reported
+        if (s->feature.type != SENSORS_FEATURE_TEMP || !s->read || isnan(s->input))
             continue;
 
         size_t i = 0;
@@ -1295,6 +1298,10 @@ static netdata_mutex_t sensors_data_mutex;
 
 static void __attribute__((constructor)) sensors_data_mutex_init(void) {
     netdata_mutex_init(&sensors_data_mutex);
+}
+
+static void __attribute__((destructor)) sensors_data_mutex_destroy(void) {
+    netdata_mutex_destroy(&sensors_data_mutex);
 }
 
 static const char *libsensors_function_state(SENSOR *s) {
@@ -1352,6 +1359,11 @@ static void libsensors_function_sensors(
             snprintfz(chart_id, sizeof(chart_id), "sensors.%s%s", string2str(s->id),
                       (!s->exposed_input && s->exposed_states) ? "_alarm" : "_input");
 
+            // a sensor missing from this cycle's enumeration keeps its stale
+            // cached value in s->input - report NAN so the Reading column
+            // agrees with the "missing" state
+            NETDATA_DOUBLE reading = s->read ? s->input : NAN;
+
             buffer_json_add_array_item_array(wb);
 
             buffer_json_add_array_item_string(wb, chart_id);
@@ -1361,18 +1373,18 @@ static void libsensors_function_sensors(
             buffer_json_add_array_item_string(wb, "libsensors");
             buffer_json_add_array_item_string(wb, string2str(s->chip.id));
             buffer_json_add_array_item_string(wb, string2str(s->feature.name));
-            buffer_json_add_array_item_double(wb, s->input);
+            buffer_json_add_array_item_double(wb, reading);
             buffer_json_add_array_item_string(wb, units);
             buffer_json_add_array_item_string(wb, libsensors_function_state(s));
             buffer_json_add_array_item_string(wb, "per-sensor");
             buffer_json_add_array_item_uint64(wb, 1); // Count - enables grouped sensor-count charts
 
             // per-kind value columns - they power the per-kind aggregation tiles
-            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_TEMP ? s->input : NAN);
-            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_FAN ? s->input : NAN);
-            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_IN ? s->input : NAN);
-            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_CURR ? s->input : NAN);
-            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_POWER ? s->input : NAN);
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_TEMP ? reading : NAN);
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_FAN ? reading : NAN);
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_IN ? reading : NAN);
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_CURR ? reading : NAN);
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_POWER ? reading : NAN);
 
             buffer_json_array_close(wb);
         }
@@ -1548,6 +1560,8 @@ cleanup:
     sensors_dict = NULL;
     libsensors_histogram_exposed = false;
     netdata_mutex_unlock(&sensors_data_mutex);
+
+    sensors_cleanup(); // releases libsensors' internal state
 }
 
 static ND_THREAD *libsensors = NULL;

--- a/src/collectors/debugfs.plugin/module-libsensors.c
+++ b/src/collectors/debugfs.plugin/module-libsensors.c
@@ -1211,6 +1211,354 @@ static int sensors_collect_data(void) {
     return subfeatures_collected ? 0 : 1;
 }
 
+// ----------------------------------------------------------------------------
+// cross-OS temperature histogram
+//
+// MIRRORS src/collectors/common-contexts/hw-sensors.h (PERMANENT contract,
+// keep in sync by hand - this plugin emits PLUGINSD text, not RRDSET calls):
+// disjoint buckets named by their upper bound in degrees Celsius; every
+// sensor increments exactly one bucket.
+
+#define LIBSENSORS_HISTOGRAM_BUCKETS 10
+
+static const double libsensors_histogram_upper_bounds[LIBSENSORS_HISTOGRAM_BUCKETS - 1] = {
+    40, 50, 60, 70, 80, 85, 90, 95, 100,
+};
+
+static const char *libsensors_histogram_dimensions[LIBSENSORS_HISTOGRAM_BUCKETS] = {
+    "40", "50", "60", "70", "80", "85", "90", "95", "100", "+Inf",
+};
+
+static void libsensors_emit_temperature_histogram(int update_every, const char *name) {
+    static bool exposed = false;
+
+    uint32_t counts[LIBSENSORS_HISTOGRAM_BUCKETS] = {0};
+    size_t total = 0;
+
+    SENSOR *s;
+    dfe_start_read(sensors_dict, s) {
+        if (s->feature.type != SENSORS_FEATURE_TEMP || isnan(s->input))
+            continue;
+
+        size_t i = 0;
+        while (i < LIBSENSORS_HISTOGRAM_BUCKETS - 1 && s->input >= libsensors_histogram_upper_bounds[i])
+            i++;
+
+        counts[i]++;
+        total++;
+    }
+    dfe_done(s);
+
+    if (!total)
+        return;
+
+    if (!exposed) {
+        printf(
+            PLUGINSD_KEYWORD_CHART
+            " 'sensors.temperature_histogram' '' 'Temperature Sensors Distribution' 'sensors' 'Temperature' "
+            "'system.hw.sensor.temperature.histogram' heatmap 69990 %d '' debugfs %s\n",
+            update_every, name);
+
+        for (size_t i = 0; i < LIBSENSORS_HISTOGRAM_BUCKETS; i++)
+            printf(PLUGINSD_KEYWORD_DIMENSION " '%s' '' absolute 1 1 ''\n", libsensors_histogram_dimensions[i]);
+
+        exposed = true;
+    }
+
+    printf(PLUGINSD_KEYWORD_BEGIN " 'sensors.temperature_histogram'\n");
+    for (size_t i = 0; i < LIBSENSORS_HISTOGRAM_BUCKETS; i++)
+        printf(
+            PLUGINSD_KEYWORD_SET " '%s' = %u\n", libsensors_histogram_dimensions[i], (unsigned)counts[i]);
+    printf(PLUGINSD_KEYWORD_END "\n");
+}
+
+// ----------------------------------------------------------------------------
+// the "sensors" function
+//
+// Cross-OS contract (mirrors the macos.plugin implementation - keep the
+// column schema, charts, group_by and registration-follows-discovery rule in
+// sync by hand): one table row per sensor; the per-sensor chart id is the
+// unique key and the only sticky column.
+
+#define LIBSENSORS_FUNCTION_SENSORS_HELP                                                                               \
+    "Lists all hardware sensors discovered on this host, with their current readings."
+
+// guards sensors_dict contents between the collection thread and function threads
+static netdata_mutex_t sensors_data_mutex = NETDATA_MUTEX_INITIALIZER;
+
+static const char *libsensors_state_to_string(SENSOR_STATE state) {
+    switch(state) {
+        case SENSOR_STATE_CLEAR: return "clear";
+        case SENSOR_STATE_WARNING: return "warning";
+        case SENSOR_STATE_ALARM: return "alarm";
+        case SENSOR_STATE_CRITICAL: return "critical";
+        case SENSOR_STATE_EMERGENCY: return "emergency";
+        case SENSOR_STATE_FAULT: return "fault";
+        case SENSOR_STATE_CAP: return "cap";
+        default: return "unknown";
+    }
+}
+
+static void libsensors_function_sensors(
+    const char *transaction, char *function __maybe_unused, usec_t *stop_monotonic_ut __maybe_unused,
+    bool *cancelled __maybe_unused, BUFFER *payload __maybe_unused, HTTP_ACCESS access __maybe_unused,
+    const char *source __maybe_unused, void *data __maybe_unused)
+{
+    BUFFER *wb = buffer_create(4096, NULL);
+
+    buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_DEFAULT);
+
+    const char *hostname = getenv("NETDATA_HOSTNAME");
+    buffer_json_member_add_string(wb, "hostname", hostname ? hostname : "localhost");
+    buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
+    buffer_json_member_add_string(wb, "type", "table");
+    buffer_json_member_add_time_t(wb, "update_every", 1);
+    buffer_json_member_add_boolean(wb, "has_history", false);
+    buffer_json_member_add_string(wb, "help", LIBSENSORS_FUNCTION_SENSORS_HELP);
+    buffer_json_member_add_array(wb, "data");
+
+    netdata_mutex_lock(&sensors_data_mutex);
+
+    if (sensors_dict) {
+        SENSOR *s;
+        dfe_start_read(sensors_dict, s) {
+            bool fresh = !isnan(s->input);
+            const char *kind = SENSOR_TYPE_2str(s->feature.type);
+            const char *label =
+                (s->feature.label) ? string2str(s->feature.label) : string2str(s->feature.name);
+
+            char chart_id[RRD_ID_LENGTH_MAX + 16];
+            snprintfz(chart_id, sizeof(chart_id), "sensors.%s_input", string2str(s->id));
+
+            buffer_json_add_array_item_array(wb);
+
+            buffer_json_add_array_item_string(wb, chart_id);
+            buffer_json_add_array_item_string(wb, label);
+            buffer_json_add_array_item_string(wb, kind);
+            buffer_json_add_array_item_string(wb, string2str(s->chip.subsystem));
+            buffer_json_add_array_item_string(wb, "libsensors");
+            buffer_json_add_array_item_string(wb, string2str(s->chip.id));
+            buffer_json_add_array_item_string(wb, string2str(s->feature.name));
+            buffer_json_add_array_item_double(wb, s->input);
+            buffer_json_add_array_item_string(wb, s->config.units);
+            buffer_json_add_array_item_string(wb, fresh ? libsensors_state_to_string(s->state) : "missing");
+            buffer_json_add_array_item_string(wb, "per-sensor");
+            buffer_json_add_array_item_uint64(wb, 1); // Count - enables grouped sensor-count charts
+
+            // per-kind value columns - they power the per-kind aggregation tiles
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_TEMP ? s->input : NAN);
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_FAN ? s->input : NAN);
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_IN ? s->input : NAN);
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_CURR ? s->input : NAN);
+            buffer_json_add_array_item_double(wb, s->feature.type == SENSORS_FEATURE_POWER ? s->input : NAN);
+
+            buffer_json_array_close(wb);
+        }
+        dfe_done(s);
+    }
+
+    netdata_mutex_unlock(&sensors_data_mutex);
+
+    buffer_json_array_close(wb); // data
+
+    buffer_json_member_add_object(wb, "columns");
+    {
+        size_t field_id = 0;
+
+        buffer_rrdf_table_add_field(wb, field_id++, "Chart", "Per-Sensor Chart ID",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_UNIQUE_KEY | RRDF_FIELD_OPTS_STICKY,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Label", "Sensor Label",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Kind", "Sensor Kind",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Subsystem", "Hardware Subsystem",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Source", "Discovery Source",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Device", "Device / Chip",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Sensor", "Sensor Identifier",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Reading", "Current Reading",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                3, NULL, NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Units", "Reading Units",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "State", "Sensor State",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Charts", "Charting Mode",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Count", "Sensors Count",
+                RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                0, "sensors", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Temperature", "Temperature",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                2, "degrees Celsius", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Fan", "Fan Speed",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                0, "rpm", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Voltage", "Voltage",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                3, "V", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Current", "Current",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                3, "A", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Power", "Power",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                2, "W", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+    }
+    buffer_json_object_close(wb); // columns
+
+    buffer_json_member_add_string(wb, "default_sort_column", "Label");
+
+    buffer_json_member_add_object(wb, "charts");
+    {
+        buffer_json_member_add_object(wb, "Sensors");
+        {
+            buffer_json_member_add_string(wb, "name", "Sensors");
+            buffer_json_member_add_string(wb, "type", "stacked-bar");
+            buffer_json_member_add_array(wb, "columns");
+            {
+                buffer_json_add_array_item_string(wb, "Count");
+            }
+            buffer_json_array_close(wb);
+        }
+        buffer_json_object_close(wb);
+
+        static const char *kind_charts[] = {"Temperature", "Fan", "Voltage", "Current", "Power"};
+        for (size_t i = 0; i < _countof(kind_charts); i++) {
+            buffer_json_member_add_object(wb, kind_charts[i]);
+            {
+                buffer_json_member_add_string(wb, "name", kind_charts[i]);
+                buffer_json_member_add_string(wb, "type", "stacked-bar");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, kind_charts[i]);
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+        }
+    }
+    buffer_json_object_close(wb); // charts
+
+    buffer_json_member_add_array(wb, "default_charts");
+    {
+        buffer_json_add_array_item_array(wb);
+        buffer_json_add_array_item_string(wb, "Sensors");
+        buffer_json_add_array_item_string(wb, "Subsystem");
+        buffer_json_array_close(wb);
+
+        buffer_json_add_array_item_array(wb);
+        buffer_json_add_array_item_string(wb, "Temperature");
+        buffer_json_add_array_item_string(wb, "Subsystem");
+        buffer_json_array_close(wb);
+    }
+    buffer_json_array_close(wb);
+
+    buffer_json_member_add_object(wb, "group_by");
+    {
+        static const struct {
+            const char *id;
+            const char *name;
+        } groups[] = {
+            {"Kind", "Sensors by Kind"},
+            {"Subsystem", "Sensors by Subsystem"},
+            {"Device", "Sensors by Device"},
+            {"State", "Sensors by State"},
+        };
+
+        for (size_t i = 0; i < _countof(groups); i++) {
+            buffer_json_member_add_object(wb, groups[i].id);
+            {
+                buffer_json_member_add_string(wb, "name", groups[i].name);
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, groups[i].id);
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+        }
+    }
+    buffer_json_object_close(wb); // group_by
+
+    buffer_json_member_add_time_t(wb, "expires", now_realtime_sec() + 1);
+    buffer_json_finalize(wb);
+
+    wb->response_code = HTTP_RESP_OK;
+    wb->content_type = CT_APPLICATION_JSON;
+    wb->expires = now_realtime_sec() + 1;
+    pluginsd_function_result_to_stdout(transaction, wb);
+    buffer_free(wb);
+}
+
+void module_libsensors_register_functions(struct functions_evloop_globals *wg) {
+    functions_evloop_add_function(
+        wg, "sensors", libsensors_function_sensors, PLUGINS_FUNCTIONS_TIMEOUT_DEFAULT, NULL);
+}
+
 static bool libsensors_running = false;
 static int libsensors_update_every = 1;
 
@@ -1289,19 +1637,36 @@ void libsensors_thread(void *ptr __maybe_unused) {
     heartbeat_t hb;
     heartbeat_init(&hb, update_every * USEC_PER_SEC);
 
+    bool function_declared = false;
+
     while(!nd_thread_signaled_to_cancel()) {
         heartbeat_next(&hb);
 
-        if(sensors_collect_data())
+        netdata_mutex_lock(&sensors_data_mutex);
+        int collect_failed = sensors_collect_data();
+        netdata_mutex_unlock(&sensors_data_mutex);
+
+        if(collect_failed)
             break;
 
         netdata_mutex_lock(&stdout_mutex);
+
+        // expose the function only on hosts that actually have sensors
+        if(!function_declared && dictionary_entries(sensors_dict)) {
+            fprintf(stdout, PLUGINSD_KEYWORD_FUNCTION " GLOBAL \"sensors\" %d \"%s\" \"top\" " HTTP_ACCESS_FORMAT " %d\n",
+                    PLUGINS_FUNCTIONS_TIMEOUT_DEFAULT, LIBSENSORS_FUNCTION_SENSORS_HELP,
+                    (HTTP_ACCESS_FORMAT_CAST)(HTTP_ACCESS_ANONYMOUS_DATA),
+                    RRDFUNCTIONS_PRIORITY_DEFAULT / 10);
+            function_declared = true;
+        }
 
         SENSOR *s;
         dfe_start_read(sensors_dict, s) {
             sensor_process(s, update_every, "sensors");
         }
         dfe_done(s);
+
+        libsensors_emit_temperature_histogram(update_every, "sensors");
 
         fflush(stdout);
         netdata_mutex_unlock(&stdout_mutex);

--- a/src/collectors/debugfs.plugin/module-libsensors.c
+++ b/src/collectors/debugfs.plugin/module-libsensors.c
@@ -1230,8 +1230,11 @@ static const char *libsensors_histogram_dimensions[LIBSENSORS_HISTOGRAM_BUCKETS]
     "40", "50", "60", "70", "80", "85", "90", "95", "100", "+Inf",
 };
 
+// file scope so cleanup can reset it - a future in-process restart of this
+// module must re-emit the CHART definition
+static bool libsensors_histogram_exposed = false;
+
 static void libsensors_emit_temperature_histogram(int update_every, const char *name) {
-    static bool exposed = false;
 
     uint32_t counts[LIBSENSORS_HISTOGRAM_BUCKETS] = {0};
     size_t total = 0;
@@ -1252,10 +1255,10 @@ static void libsensors_emit_temperature_histogram(int update_every, const char *
 
     // before the chart exists, zero sensors means nothing to expose;
     // after it exists, keep sending (zero counts are truthful data)
-    if (!exposed && !total)
+    if (!libsensors_histogram_exposed && !total)
         return;
 
-    if (!exposed) {
+    if (!libsensors_histogram_exposed) {
         printf(
             PLUGINSD_KEYWORD_CHART
             " 'sensors.temperature_histogram' '' 'Temperature Sensors Distribution' 'sensors' 'Temperature' "
@@ -1265,7 +1268,7 @@ static void libsensors_emit_temperature_histogram(int update_every, const char *
         for (size_t i = 0; i < LIBSENSORS_HISTOGRAM_BUCKETS; i++)
             printf(PLUGINSD_KEYWORD_DIMENSION " '%s' '' absolute 1 1 ''\n", libsensors_histogram_dimensions[i]);
 
-        exposed = true;
+        libsensors_histogram_exposed = true;
     }
 
     printf(PLUGINSD_KEYWORD_BEGIN " 'sensors.temperature_histogram'\n");
@@ -1493,6 +1496,13 @@ void libsensors_thread(void *ptr __maybe_unused) {
 
         netdata_mutex_lock(&sensors_data_mutex);
         int collect_failed = sensors_collect_data();
+        if(!collect_failed) {
+            // refresh derived values/states in the same locked section, so a
+            // concurrent "sensors" function request never observes values
+            // from the previous cycle
+            SENSOR *t;
+            dfe_start_read(sensors_dict, t) { set_sensor_state(t); } dfe_done(t);
+        }
         netdata_mutex_unlock(&sensors_data_mutex);
 
         if(collect_failed)
@@ -1536,6 +1546,7 @@ cleanup:
     netdata_mutex_lock(&sensors_data_mutex);
     dictionary_destroy(sensors_dict);
     sensors_dict = NULL;
+    libsensors_histogram_exposed = false;
     netdata_mutex_unlock(&sensors_data_mutex);
 }
 

--- a/src/collectors/debugfs.plugin/taxonomy.yaml
+++ b/src/collectors/debugfs.plugin/taxonomy.yaml
@@ -1,0 +1,5 @@
+taxonomy_version: 1
+plugin_name: debugfs.plugin
+module_name: libsensors
+taxonomy_optout:
+  reason: debugfs.plugin covers heterogeneous Linux kernel subsystems (memory fragmentation, zswap, powercap, audit, libsensors hardware sensors) across independent collection modules. Dashboard taxonomy placement for these contexts has not yet been defined.

--- a/src/collectors/macos.plugin/macos_power.c
+++ b/src/collectors/macos.plugin/macos_power.c
@@ -199,7 +199,7 @@ static void macos_power_source_temperature_labels(RRDSET *st, const struct macos
     rrdlabels_add(st->rrdlabels, "subsystem", "battery", RRDLABEL_SRC_AUTO);
     rrdlabels_add(st->rrdlabels, "chip_id", ps->ps.name, RRDLABEL_SRC_AUTO);
     rrdlabels_add(st->rrdlabels, "feature", "battery_temperature", RRDLABEL_SRC_AUTO);
-    rrdlabels_add(st->rrdlabels, "name", "Battery Temperature", RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "label", "Battery Temperature", RRDLABEL_SRC_AUTO);
     rrdlabels_add(st->rrdlabels, "path", path, RRDLABEL_SRC_AUTO);
     rrdlabels_add(st->rrdlabels, "sensor", "battery_temperature", RRDLABEL_SRC_AUTO);
 }

--- a/src/collectors/macos.plugin/macos_powermetrics.c
+++ b/src/collectors/macos.plugin/macos_powermetrics.c
@@ -528,7 +528,9 @@ static void macos_powermetrics_store_sample(const struct macos_powermetrics_samp
     pm.sample_sequence++;
     pm.failed_permanently = false;
     pm.logged_unavailable = false;
-    pm.logged_loop_failure = false;
+    // logged_loop_failure is NOT reset here: probe samples are also stored,
+    // so resetting per sample would re-arm the log-once guard every failed
+    // loop cycle and flood the log. It is reset only after a productive loop.
     pm.logged_parse_error = false;
     netdata_mutex_unlock(&pm.mutex);
 }
@@ -591,10 +593,10 @@ static POPEN_INSTANCE *macos_powermetrics_start_loop(const struct macos_powermet
         NULL,
     };
 
+    // no -n: powermetrics must stream until netdata stops it
+    // (-n 0 means "zero samples and exit" on current macOS)
     const char *argv_direct[] = {
         pm.command,
-        "-n",
-        "0",
         "-b",
         "0",
         "-i",
@@ -818,8 +820,12 @@ static void macos_powermetrics_thread(void *ptr __maybe_unused)
         bool loop_produced_sample = sequence_after_loop > sequence_before_loop;
         macos_powermetrics_sleep_interruptibly(
             loop_produced_sample ? MACOS_POWERMETRICS_INITIAL_BACKOFF_MS : backoff_ms);
-        if (loop_produced_sample)
+        if (loop_produced_sample) {
             backoff_ms = MACOS_POWERMETRICS_INITIAL_BACKOFF_MS;
+            netdata_mutex_lock(&pm.mutex);
+            pm.logged_loop_failure = false;
+            netdata_mutex_unlock(&pm.mutex);
+        }
         else {
             if (backoff_ms < MACOS_POWERMETRICS_MAX_BACKOFF_MS)
                 backoff_ms *= 2;
@@ -915,7 +921,7 @@ static void macos_powermetrics_add_sensor_labels(
     rrdlabels_add(st->rrdlabels, "chip_id", "powermetrics", RRDLABEL_SRC_AUTO);
     rrdlabels_add(st->rrdlabels, "device", "powermetrics", RRDLABEL_SRC_AUTO);
     rrdlabels_add(st->rrdlabels, "feature", feature, RRDLABEL_SRC_AUTO);
-    rrdlabels_add(st->rrdlabels, "name", label, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "label", label, RRDLABEL_SRC_AUTO);
     rrdlabels_add(st->rrdlabels, "path", path, RRDLABEL_SRC_AUTO);
     rrdlabels_add(st->rrdlabels, "sensor", feature, RRDLABEL_SRC_AUTO);
 }

--- a/src/collectors/macos.plugin/macos_sensors.c
+++ b/src/collectors/macos.plugin/macos_sensors.c
@@ -197,6 +197,11 @@ static struct macos_sensor_rollup *sensor_rollups_root = NULL;
 // (netdata_mutex_t is uv_mutex_t - it has no static initializer)
 static netdata_mutex_t macos_sensors_mutex;
 
+// deliberately no matching destructor: this code runs inside the daemon,
+// which calls exit() while collector and function threads may still hold
+// this mutex - destroying a held uv mutex aborts. external plugins (e.g.
+// debugfs.plugin) pair a destructor because their main() joins all threads
+// before returning.
 static void __attribute__((constructor)) macos_sensors_mutex_init(void) {
     netdata_mutex_init(&macos_sensors_mutex);
 }

--- a/src/collectors/macos.plugin/macos_sensors.c
+++ b/src/collectors/macos.plugin/macos_sensors.c
@@ -1423,8 +1423,11 @@ int do_macos_sensors(int update_every, usec_t dt __maybe_unused)
 
     netdata_mutex_unlock(&macos_sensors_mutex);
 
-    // expose the function only on hosts that actually have sensors
-    // (only this collection thread mutates the sensors list)
+    // expose the function only on hosts that actually have sensors.
+    // reading sensor_charts_root without the mutex is safe: collection (add),
+    // this check, and macos_sensors_cleanup() (remove - a pthread cleanup
+    // handler of this same plugin thread) all run on this thread; the
+    // function workers are the only other readers and they take the mutex
     static bool function_registered = false;
     if (unlikely(!function_registered && sensor_charts_root)) {
         rrd_function_add_inline(localhost, NULL, "sensors", 10,

--- a/src/collectors/macos.plugin/macos_sensors.c
+++ b/src/collectors/macos.plugin/macos_sensors.c
@@ -7,6 +7,7 @@
 #define _COMMON_PLUGIN_NAME "macos.plugin"
 #define _COMMON_PLUGIN_MODULE_NAME "sensors"
 #include "../common-contexts/common-contexts.h"
+#include "../common-contexts/hw-sensors-function.h"
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
@@ -192,8 +193,13 @@ struct macos_sensor_rollup {
 static struct macos_sensor_rollup *sensor_rollups_root = NULL;
 
 // guards sensor_charts_root and per-sensor values between the collection
-// cycle and the "sensors" function threads
+// cycle, the "sensors" function threads and cleanup
+// (netdata_mutex_t is uv_mutex_t - it has no static initializer)
 static netdata_mutex_t macos_sensors_mutex;
+
+static void __attribute__((constructor)) macos_sensors_mutex_init(void) {
+    netdata_mutex_init(&macos_sensors_mutex);
+}
 
 static const struct macos_hid_sensor_source macos_hid_sensor_sources[] = {
     {
@@ -1164,6 +1170,9 @@ static bool macos_sensors_collect_hid_source(const struct macos_hid_sensor_sourc
     // kind, the product name alone is the sensor identity. Appending per-boot
     // identifiers unconditionally (as done before) minted new time-series on
     // every reboot. Only true duplicates get a service-specific suffix.
+    // Known trade-off: if a duplicate product appears mid-run (hot-plug), the
+    // first device's identity changes from bare product to a suffixed one -
+    // acceptable, since built-in sensors do not hot-plug in practice.
     char (*products)[128] = callocz((size_t)count ? (size_t)count : 1, sizeof(*products));
     for (CFIndex i = 0; i < count; i++) {
         IOHIDServiceClientRef svc = (IOHIDServiceClientRef)CFArrayGetValueAtIndex(services, i);
@@ -1370,220 +1379,8 @@ static int macos_sensors_function(
 
     buffer_json_array_close(wb); // data
 
-    buffer_json_member_add_object(wb, "columns");
-    {
-        size_t field_id = 0;
-
-        buffer_rrdf_table_add_field(wb, field_id++, "Chart", "Per-Sensor Chart ID",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_UNIQUE_KEY | RRDF_FIELD_OPTS_STICKY,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Label", "Sensor Label",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Kind", "Sensor Kind",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Subsystem", "Hardware Subsystem",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Source", "Discovery Source",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Device", "Device / Chip",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Sensor", "Sensor Identifier",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Reading", "Current Reading",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                3, NULL, NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Units", "Reading Units",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "State", "Collection State",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_VISIBLE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Charts", "Charting Mode",
-                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Count", "Sensors Count",
-                RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                0, "sensors", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Temperature", "Temperature",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                2, "degrees Celsius", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Fan", "Fan Speed",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                0, "rpm", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Voltage", "Voltage",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                3, "V", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Current", "Current",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                3, "A", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-        buffer_rrdf_table_add_field(wb, field_id++, "Power", "Power",
-                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
-                2, "W", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
-                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
-                RRDF_FIELD_OPTS_NONE,
-                NULL);
-    }
-    buffer_json_object_close(wb); // columns
-
-    buffer_json_member_add_string(wb, "default_sort_column", "Label");
-
-    buffer_json_member_add_object(wb, "charts");
-    {
-        buffer_json_member_add_object(wb, "Sensors");
-        {
-            buffer_json_member_add_string(wb, "name", "Sensors");
-            buffer_json_member_add_string(wb, "type", "stacked-bar");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Count");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        static const char *kind_charts[] = {"Temperature", "Fan", "Voltage", "Current", "Power"};
-        for (size_t i = 0; i < _countof(kind_charts); i++) {
-            buffer_json_member_add_object(wb, kind_charts[i]);
-            {
-                buffer_json_member_add_string(wb, "name", kind_charts[i]);
-                buffer_json_member_add_string(wb, "type", "stacked-bar");
-                buffer_json_member_add_array(wb, "columns");
-                {
-                    buffer_json_add_array_item_string(wb, kind_charts[i]);
-                }
-                buffer_json_array_close(wb);
-            }
-            buffer_json_object_close(wb);
-        }
-    }
-    buffer_json_object_close(wb); // charts
-
-    buffer_json_member_add_array(wb, "default_charts");
-    {
-        buffer_json_add_array_item_array(wb);
-        buffer_json_add_array_item_string(wb, "Sensors");
-        buffer_json_add_array_item_string(wb, "Subsystem");
-        buffer_json_array_close(wb);
-
-        buffer_json_add_array_item_array(wb);
-        buffer_json_add_array_item_string(wb, "Temperature");
-        buffer_json_add_array_item_string(wb, "Subsystem");
-        buffer_json_array_close(wb);
-    }
-    buffer_json_array_close(wb);
-
-    buffer_json_member_add_object(wb, "group_by");
-    {
-        buffer_json_member_add_object(wb, "Kind");
-        {
-            buffer_json_member_add_string(wb, "name", "Sensors by Kind");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Kind");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "Subsystem");
-        {
-            buffer_json_member_add_string(wb, "name", "Sensors by Subsystem");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Subsystem");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "Source");
-        {
-            buffer_json_member_add_string(wb, "name", "Sensors by Discovery Source");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Source");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "Device");
-        {
-            buffer_json_member_add_string(wb, "name", "Sensors by Device");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Device");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "State");
-        {
-            buffer_json_member_add_string(wb, "name", "Sensors by Collection State");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "State");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-    }
-    buffer_json_object_close(wb); // group_by
+    hw_sensors_function_columns(wb);
+    hw_sensors_function_presentation(wb);
     buffer_json_member_add_time_t(wb, "expires", now_realtime_sec() + 1);
     buffer_json_finalize(wb);
 
@@ -1600,12 +1397,7 @@ int do_macos_sensors(int update_every, usec_t dt __maybe_unused)
             return 1;
     }
 
-    static bool sensors_initialized = false;
-    if (unlikely(!sensors_initialized)) {
-        netdata_mutex_init(&macos_sensors_mutex);
-        macos_sensors_init();
-        sensors_initialized = true;
-    }
+    macos_sensors_init();
 
     netdata_mutex_lock(&macos_sensors_mutex);
 
@@ -1647,6 +1439,10 @@ bool macos_sensors_fan_available(void)
 
 void macos_sensors_cleanup(void)
 {
+    // serialize with in-flight "sensors" function requests: they must not
+    // observe the list while it is being freed
+    netdata_mutex_lock(&macos_sensors_mutex);
+
     while (sensor_charts_root) {
         struct macos_sensor_chart *s = sensor_charts_root;
         sensor_charts_root = s->next;
@@ -1657,6 +1453,19 @@ void macos_sensors_cleanup(void)
         struct macos_smc_sensor_candidate *c = smc_candidates_root;
         smc_candidates_root = c->next;
         freez(c);
+    }
+
+    while (sensor_rollups_root) {
+        struct macos_sensor_rollup *r = sensor_rollups_root;
+        sensor_rollups_root = r->next;
+        if (r->st)
+            rrdset_is_obsolete___safe_from_collector_thread(r->st);
+        freez(r);
+    }
+
+    if (temperature_histogram.st) {
+        rrdset_is_obsolete___safe_from_collector_thread(temperature_histogram.st);
+        memset(&temperature_histogram, 0, sizeof(temperature_histogram));
     }
 
     macos_smc_close(&smc_connection);
@@ -1670,4 +1479,6 @@ void macos_sensors_cleanup(void)
     smc_gpu_temperature_available = false;
     hid_gpu_temperature_available = false;
     smc_fan_available = false;
+
+    netdata_mutex_unlock(&macos_sensors_mutex);
 }

--- a/src/collectors/macos.plugin/macos_sensors.c
+++ b/src/collectors/macos.plugin/macos_sensors.c
@@ -4,6 +4,10 @@
 #include "macos_smc.h"
 #include "plugin_macos.h"
 
+#define _COMMON_PLUGIN_NAME "macos.plugin"
+#define _COMMON_PLUGIN_MODULE_NAME "sensors"
+#include "../common-contexts/common-contexts.h"
+
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
 #include <ctype.h>
@@ -59,6 +63,8 @@ struct macos_sensor_chart {
 
     bool seen;
     unsigned missing_cycles;
+    NETDATA_DOUBLE last_value;
+    bool has_value;
     RRDSET *st;
     RRDDIM *rd;
 
@@ -151,6 +157,43 @@ static bool hid_gpu_temperature_available = false;
 static bool smc_fan_available = false;
 static bool last_gpu_temperature_available = false;
 static bool last_gpu_power_available = false;
+
+// per-channel charts are opt-in for high-cardinality kinds; the default view
+// is the summary charts (per-subsystem rollups + the temperature histogram)
+static bool do_per_sensor_charts[MACOS_SENSOR_KIND_COUNT] = {
+    [MACOS_SENSOR_TEMPERATURE] = false,
+    [MACOS_SENSOR_FAN] = true,
+    [MACOS_SENSOR_VOLTAGE] = false,
+    [MACOS_SENSOR_CURRENT] = false,
+    [MACOS_SENSOR_POWER] = false,
+};
+
+static HW_SENSORS_TEMPERATURE_HISTOGRAM temperature_histogram = {0};
+
+struct macos_sensor_rollup {
+    enum macos_sensor_kind kind;
+    char subsystem[64];
+
+    RRDSET *st;
+    RRDDIM *rd_min;
+    RRDDIM *rd_avg;
+    RRDDIM *rd_max;
+    RRDDIM *rd_sum;
+    bool obsolete;
+
+    unsigned count;
+    NETDATA_DOUBLE min;
+    NETDATA_DOUBLE max;
+    NETDATA_DOUBLE sum;
+
+    struct macos_sensor_rollup *next;
+};
+
+static struct macos_sensor_rollup *sensor_rollups_root = NULL;
+
+// guards sensor_charts_root and per-sensor values between the collection
+// cycle and the "sensors" function threads
+static netdata_mutex_t macos_sensors_mutex;
 
 static const struct macos_hid_sensor_source macos_hid_sensor_sources[] = {
     {
@@ -581,13 +624,104 @@ static void macos_sensors_free_chart(struct macos_sensor_chart *s)
     freez(s);
 }
 
+static struct macos_sensor_rollup *macos_sensors_get_or_create_rollup(enum macos_sensor_kind kind, const char *subsystem)
+{
+    for (struct macos_sensor_rollup *r = sensor_rollups_root; r; r = r->next) {
+        if (r->kind == kind && !strcmp(r->subsystem, subsystem))
+            return r;
+    }
+
+    struct macos_sensor_rollup *r = callocz(1, sizeof(*r));
+    r->kind = kind;
+    snprintfz(r->subsystem, sizeof(r->subsystem), "%s", subsystem);
+    r->next = sensor_rollups_root;
+    sensor_rollups_root = r;
+    return r;
+}
+
+static void macos_sensors_update_rollup_chart(struct macos_sensor_rollup *r, int update_every)
+{
+    if (!r->count) {
+        if (r->st && !r->obsolete) {
+            rrdset_is_obsolete___safe_from_collector_thread(r->st);
+            r->obsolete = true;
+        }
+        return;
+    }
+
+    const struct macos_sensor_kind_def *def = &macos_sensor_defs[r->kind];
+
+    if (!r->st) {
+        char id[RRD_ID_LENGTH_MAX + 1];
+        const char *context;
+        const char *title;
+        int priority;
+
+        if (r->kind == MACOS_SENSOR_TEMPERATURE) {
+            snprintfz(id, sizeof(id), "temperature_subsystem_%s", r->subsystem);
+            context = "system.hw.sensor.temperature.subsystem";
+            title = "Temperature Summary";
+            priority = NETDATA_CHART_PRIO_SENSORS - 8;
+        }
+        else {
+            snprintfz(id, sizeof(id), "power_subsystem_%s", r->subsystem);
+            context = "system.hw.sensor.power.subsystem";
+            title = "Power Summary";
+            priority = NETDATA_CHART_PRIO_SENSORS - 6;
+        }
+
+        netdata_fix_chart_id(id);
+
+        r->st = rrdset_create_localhost(
+            "sensors",
+            id,
+            NULL,
+            def->family,
+            context,
+            title,
+            def->units,
+            "macos.plugin",
+            "sensors",
+            priority,
+            update_every,
+            RRDSET_TYPE_LINE);
+
+        rrdlabels_add(r->st->rrdlabels, "subsystem", r->subsystem, RRDLABEL_SRC_AUTO);
+
+        if (r->kind == MACOS_SENSOR_TEMPERATURE) {
+            r->rd_min = rrddim_add(r->st, "min", NULL, 1, def->divisor, RRD_ALGORITHM_ABSOLUTE);
+            r->rd_avg = rrddim_add(r->st, "avg", NULL, 1, def->divisor, RRD_ALGORITHM_ABSOLUTE);
+            r->rd_max = rrddim_add(r->st, "max", NULL, 1, def->divisor, RRD_ALGORITHM_ABSOLUTE);
+        }
+        else
+            r->rd_sum = rrddim_add(r->st, "power", NULL, 1, def->divisor, RRD_ALGORITHM_ABSOLUTE);
+    }
+
+    if (r->obsolete) {
+        rrdset_isnot_obsolete___safe_from_collector_thread(r->st);
+        r->obsolete = false;
+    }
+
+    if (r->kind == MACOS_SENSOR_TEMPERATURE) {
+        rrddim_set_by_pointer(r->st, r->rd_min, (collected_number)llround(r->min * (NETDATA_DOUBLE)def->divisor));
+        rrddim_set_by_pointer(
+            r->st, r->rd_avg,
+            (collected_number)llround(r->sum / (NETDATA_DOUBLE)r->count * (NETDATA_DOUBLE)def->divisor));
+        rrddim_set_by_pointer(r->st, r->rd_max, (collected_number)llround(r->max * (NETDATA_DOUBLE)def->divisor));
+    }
+    else
+        rrddim_set_by_pointer(r->st, r->rd_sum, (collected_number)llround(r->sum * (NETDATA_DOUBLE)def->divisor));
+
+    rrdset_done(r->st);
+}
+
 static void macos_sensors_begin_cycle(void)
 {
     for (struct macos_sensor_chart *s = sensor_charts_root; s; s = s->next)
         s->seen = false;
 }
 
-static void macos_sensors_finish_cycle(bool smc_attempted, bool hid_attempted)
+static void macos_sensors_finish_cycle(bool smc_attempted, bool hid_attempted, int update_every)
 {
     struct macos_sensor_chart **pp = &sensor_charts_root;
     while (*pp) {
@@ -606,8 +740,10 @@ static void macos_sensors_finish_cycle(bool smc_attempted, bool hid_attempted)
 
         if (!s->seen) {
             if (s->missing_cycles < MACOS_SENSORS_MISSING_CYCLES_BEFORE_OBSOLETE &&
-                ++s->missing_cycles == MACOS_SENSORS_MISSING_CYCLES_BEFORE_OBSOLETE)
+                ++s->missing_cycles == MACOS_SENSORS_MISSING_CYCLES_BEFORE_OBSOLETE) {
                 macos_sensors_obsolete_chart(s);
+                s->has_value = false;
+            }
 
             pp = &s->next;
             continue;
@@ -627,6 +763,42 @@ static void macos_sensors_finish_cycle(bool smc_attempted, bool hid_attempted)
         else if (s->kind == MACOS_SENSOR_TEMPERATURE && strcmp(s->subsystem, "gpu") == 0)
             smc_gpu_temperature_available = true;
     }
+
+    // ------------------------------------------------------------------
+    // summary views: temperature histogram + per-subsystem rollups.
+    // SMC values refresh on their own cadence; the last known value of each
+    // sensor is used until the sensor is missing long enough to be obsoleted.
+
+    hw_sensors_temperature_histogram_reset(&temperature_histogram);
+
+    for (struct macos_sensor_rollup *r = sensor_rollups_root; r; r = r->next) {
+        r->count = 0;
+        r->min = r->max = r->sum = 0.0;
+    }
+
+    for (struct macos_sensor_chart *s = sensor_charts_root; s; s = s->next) {
+        if (!s->has_value || s->missing_cycles >= MACOS_SENSORS_MISSING_CYCLES_BEFORE_OBSOLETE)
+            continue;
+
+        if (s->kind != MACOS_SENSOR_TEMPERATURE && s->kind != MACOS_SENSOR_POWER)
+            continue;
+
+        if (s->kind == MACOS_SENSOR_TEMPERATURE)
+            hw_sensors_temperature_histogram_add(&temperature_histogram, s->last_value);
+
+        struct macos_sensor_rollup *r = macos_sensors_get_or_create_rollup(s->kind, s->subsystem);
+        if (!r->count || s->last_value < r->min)
+            r->min = s->last_value;
+        if (!r->count || s->last_value > r->max)
+            r->max = s->last_value;
+        r->sum += s->last_value;
+        r->count++;
+    }
+
+    common_hw_sensors_temperature_histogram(&temperature_histogram, update_every, "macos.plugin", "sensors");
+
+    for (struct macos_sensor_rollup *r = sensor_rollups_root; r; r = r->next)
+        macos_sensors_update_rollup_chart(r, update_every);
 }
 
 static void macos_sensors_update_chart(
@@ -656,6 +828,13 @@ static void macos_sensors_update_chart(
 
     s->seen = true;
     s->missing_cycles = 0;
+    s->last_value = value;
+    s->has_value = true;
+
+    // high-cardinality kinds chart per-channel only when enabled; the value
+    // is still collected above to feed the summary charts
+    if (!do_per_sensor_charts[s->kind])
+        return;
 
     if (!s->st) {
         s->st = rrdset_create_localhost(
@@ -677,7 +856,7 @@ static void macos_sensors_update_chart(
         rrdlabels_add(s->st->rrdlabels, "chip_id", s->chip_id, RRDLABEL_SRC_AUTO);
         rrdlabels_add(s->st->rrdlabels, "device", s->chip_id, RRDLABEL_SRC_AUTO);
         rrdlabels_add(s->st->rrdlabels, "feature", s->feature, RRDLABEL_SRC_AUTO);
-        rrdlabels_add(s->st->rrdlabels, "name", s->label, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(s->st->rrdlabels, "label", s->label, RRDLABEL_SRC_AUTO);
         rrdlabels_add(s->st->rrdlabels, "path", s->path, RRDLABEL_SRC_AUTO);
         rrdlabels_add(s->st->rrdlabels, "source", s->source, RRDLABEL_SRC_AUTO);
         rrdlabels_add(s->st->rrdlabels, "sensor", s->feature, RRDLABEL_SRC_AUTO);
@@ -940,6 +1119,21 @@ static bool macos_sensors_cf_value_identifier(CFTypeRef value, char *dst, size_t
 
 static bool macos_sensors_hid_service_identifier(IOHIDServiceClientRef service, char *dst, size_t dst_size)
 {
+    // Prefer LocationID: it derives from the hardware topology and is stable
+    // across reboots. IORegistryEntryID is unique per boot, so identities
+    // built from it would mint new time-series on every system restart.
+    CFTypeRef location_id = macos_iohid_service_copy_property(service, CFSTR("LocationID"));
+    if (location_id) {
+        bool ok = macos_sensors_cf_value_identifier(location_id, dst, dst_size);
+        CFRelease(location_id);
+        if (ok) {
+            char prefixed[128];
+            snprintfz(prefixed, sizeof(prefixed), "location_%s", dst);
+            snprintfz(dst, dst_size, "%s", prefixed);
+            return true;
+        }
+    }
+
     CFTypeRef registry_id = macos_iohid_service_get_registry_id(service);
     if (macos_sensors_cf_value_identifier(registry_id, dst, dst_size)) {
         char prefixed[128];
@@ -948,19 +1142,7 @@ static bool macos_sensors_hid_service_identifier(IOHIDServiceClientRef service, 
         return true;
     }
 
-    CFTypeRef location_id = macos_iohid_service_copy_property(service, CFSTR("LocationID"));
-    if (!location_id)
-        return false;
-
-    bool ok = macos_sensors_cf_value_identifier(location_id, dst, dst_size);
-    CFRelease(location_id);
-    if (!ok)
-        return false;
-
-    char prefixed[128];
-    snprintfz(prefixed, sizeof(prefixed), "location_%s", dst);
-    snprintfz(dst, dst_size, "%s", prefixed);
-    return true;
+    return false;
 }
 
 static bool macos_sensors_collect_hid_source(const struct macos_hid_sensor_source *source, int update_every)
@@ -977,6 +1159,20 @@ static bool macos_sensors_collect_hid_source(const struct macos_hid_sensor_sourc
         return true;
 
     CFIndex count = CFArrayGetCount(services);
+
+    // Identity stability: when a service's product name is unique within this
+    // kind, the product name alone is the sensor identity. Appending per-boot
+    // identifiers unconditionally (as done before) minted new time-series on
+    // every reboot. Only true duplicates get a service-specific suffix.
+    char (*products)[128] = callocz((size_t)count ? (size_t)count : 1, sizeof(*products));
+    for (CFIndex i = 0; i < count; i++) {
+        IOHIDServiceClientRef svc = (IOHIDServiceClientRef)CFArrayGetValueAtIndex(services, i);
+        if (svc && macos_sensors_hid_product_name(svc, products[i], sizeof(products[i])))
+            netdata_fix_chart_id(products[i]);
+        else
+            products[i][0] = '\0';
+    }
+
     for (CFIndex i = 0; i < count; i++) {
         IOHIDServiceClientRef service = (IOHIDServiceClientRef)CFArrayGetValueAtIndex(services, i);
         if (!service)
@@ -1005,23 +1201,31 @@ static bool macos_sensors_collect_hid_source(const struct macos_hid_sensor_sourc
         if (!macos_sensors_validate_value(source->kind, value))
             continue;
 
-        char feature[128];
-        char base_feature[128] = "";
-        if (has_product) {
-            snprintfz(base_feature, sizeof(base_feature), "%s", label);
-            netdata_fix_chart_id(base_feature);
+        bool product_is_unique = false;
+        if (products[i][0]) {
+            product_is_unique = true;
+            for (CFIndex j = 0; j < count; j++) {
+                if (j != i && strcmp(products[j], products[i]) == 0) {
+                    product_is_unique = false;
+                    break;
+                }
+            }
         }
 
-        char service_identifier[128] = "";
-        bool has_service_identifier =
-            macos_sensors_hid_service_identifier(service, service_identifier, sizeof(service_identifier));
+        char feature[128];
+        if (product_is_unique) {
+            snprintfz(feature, sizeof(feature), "%s", products[i]);
+        }
+        else {
+            char service_identifier[128] = "";
+            if (!macos_sensors_hid_service_identifier(service, service_identifier, sizeof(service_identifier)))
+                continue;
 
-        if (base_feature[0] && has_service_identifier)
-            snprintfz(feature, sizeof(feature), "%s_%s", base_feature, service_identifier);
-        else if (has_service_identifier)
-            snprintfz(feature, sizeof(feature), "%s_%s", source->feature_prefix, service_identifier);
-        else
-            continue;
+            if (products[i][0])
+                snprintfz(feature, sizeof(feature), "%s_%s", products[i], service_identifier);
+            else
+                snprintfz(feature, sizeof(feature), "%s_%s", source->feature_prefix, service_identifier);
+        }
 
         netdata_fix_chart_id(feature);
 
@@ -1050,6 +1254,7 @@ static bool macos_sensors_collect_hid_source(const struct macos_hid_sensor_sourc
             hid_gpu_temperature_available = true;
     }
 
+    freez(products);
     CFRelease(services);
     return true;
 }
@@ -1088,7 +1293,302 @@ static void macos_sensors_init(void)
     if (smc_collection_every_s < 1)
         smc_collection_every_s = 1;
 
+    do_per_sensor_charts[MACOS_SENSOR_TEMPERATURE] = inicfg_get_boolean(
+        &netdata_config, "plugin:macos:sensors", "per sensor temperature charts",
+        do_per_sensor_charts[MACOS_SENSOR_TEMPERATURE]);
+    do_per_sensor_charts[MACOS_SENSOR_FAN] = inicfg_get_boolean(
+        &netdata_config, "plugin:macos:sensors", "per sensor fan charts",
+        do_per_sensor_charts[MACOS_SENSOR_FAN]);
+    do_per_sensor_charts[MACOS_SENSOR_VOLTAGE] = inicfg_get_boolean(
+        &netdata_config, "plugin:macos:sensors", "per sensor voltage charts",
+        do_per_sensor_charts[MACOS_SENSOR_VOLTAGE]);
+    do_per_sensor_charts[MACOS_SENSOR_CURRENT] = inicfg_get_boolean(
+        &netdata_config, "plugin:macos:sensors", "per sensor current charts",
+        do_per_sensor_charts[MACOS_SENSOR_CURRENT]);
+    do_per_sensor_charts[MACOS_SENSOR_POWER] = inicfg_get_boolean(
+        &netdata_config, "plugin:macos:sensors", "per sensor power charts",
+        do_per_sensor_charts[MACOS_SENSOR_POWER]);
+
     initialized = true;
+}
+
+#define MACOS_SENSORS_FUNCTION_HELP                                                                                    \
+    "Lists all hardware sensors discovered on this host (SMC and IOHID), with their current readings - including "    \
+    "the sensors that are aggregated into the summary charts and not charted individually."
+
+static int macos_sensors_function(
+    BUFFER *wb, const char *function __maybe_unused, BUFFER *payload __maybe_unused, const char *source __maybe_unused)
+{
+    netdata_mutex_lock(&macos_sensors_mutex);
+
+    buffer_flush(wb);
+    wb->content_type = CT_APPLICATION_JSON;
+    buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_DEFAULT);
+
+    buffer_json_member_add_string(wb, "hostname", rrdhost_hostname(localhost));
+    buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
+    buffer_json_member_add_string(wb, "type", "table");
+    buffer_json_member_add_time_t(wb, "update_every", 1);
+    buffer_json_member_add_boolean(wb, "has_history", false);
+    buffer_json_member_add_string(wb, "help", MACOS_SENSORS_FUNCTION_HELP);
+    buffer_json_member_add_array(wb, "data");
+
+    for (struct macos_sensor_chart *s = sensor_charts_root; s; s = s->next) {
+        const struct macos_sensor_kind_def *def = &macos_sensor_defs[s->kind];
+        bool fresh = s->has_value && s->missing_cycles < MACOS_SENSORS_MISSING_CYCLES_BEFORE_OBSOLETE;
+        NETDATA_DOUBLE reading = fresh ? s->last_value : NAN;
+
+        // the chart id this sensor has (or would have) in per-sensor mode,
+        // so users can correlate function rows with dashboard charts
+        char chart_id[RRD_ID_LENGTH_MAX + 16];
+        snprintfz(chart_id, sizeof(chart_id), "sensors.%s", s->id);
+
+        buffer_json_add_array_item_array(wb);
+
+        buffer_json_add_array_item_string(wb, chart_id);
+        buffer_json_add_array_item_string(wb, s->label);
+        buffer_json_add_array_item_string(wb, def->name);
+        buffer_json_add_array_item_string(wb, s->subsystem);
+        buffer_json_add_array_item_string(wb, s->source);
+        buffer_json_add_array_item_string(wb, s->chip_id);
+        buffer_json_add_array_item_string(wb, s->feature);
+        buffer_json_add_array_item_double(wb, reading);
+        buffer_json_add_array_item_string(wb, def->units);
+        buffer_json_add_array_item_string(wb, fresh ? "ok" : "missing");
+        buffer_json_add_array_item_string(wb, do_per_sensor_charts[s->kind] ? "per-sensor" : "summary");
+        buffer_json_add_array_item_uint64(wb, 1); // Count - enables grouped sensor-count charts
+
+        // per-kind value columns - they power the per-kind aggregation tiles
+        buffer_json_add_array_item_double(wb, s->kind == MACOS_SENSOR_TEMPERATURE ? reading : NAN);
+        buffer_json_add_array_item_double(wb, s->kind == MACOS_SENSOR_FAN ? reading : NAN);
+        buffer_json_add_array_item_double(wb, s->kind == MACOS_SENSOR_VOLTAGE ? reading : NAN);
+        buffer_json_add_array_item_double(wb, s->kind == MACOS_SENSOR_CURRENT ? reading : NAN);
+        buffer_json_add_array_item_double(wb, s->kind == MACOS_SENSOR_POWER ? reading : NAN);
+
+        buffer_json_array_close(wb);
+    }
+
+    buffer_json_array_close(wb); // data
+
+    buffer_json_member_add_object(wb, "columns");
+    {
+        size_t field_id = 0;
+
+        buffer_rrdf_table_add_field(wb, field_id++, "Chart", "Per-Sensor Chart ID",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_UNIQUE_KEY | RRDF_FIELD_OPTS_STICKY,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Label", "Sensor Label",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Kind", "Sensor Kind",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Subsystem", "Hardware Subsystem",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Source", "Discovery Source",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Device", "Device / Chip",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Sensor", "Sensor Identifier",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Reading", "Current Reading",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                3, NULL, NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Units", "Reading Units",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_FULL_WIDTH,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "State", "Collection State",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_VISIBLE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Charts", "Charting Mode",
+                RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Count", "Sensors Count",
+                RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                0, "sensors", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Temperature", "Temperature",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                2, "degrees Celsius", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Fan", "Fan Speed",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                0, "rpm", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Voltage", "Voltage",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                3, "V", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Current", "Current",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                3, "A", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_MAX, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+        buffer_rrdf_table_add_field(wb, field_id++, "Power", "Power",
+                RRDF_FIELD_TYPE_BAR_WITH_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NUMBER,
+                2, "W", NAN, RRDF_FIELD_SORT_DESCENDING, NULL,
+                RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_NONE,
+                NULL);
+    }
+    buffer_json_object_close(wb); // columns
+
+    buffer_json_member_add_string(wb, "default_sort_column", "Label");
+
+    buffer_json_member_add_object(wb, "charts");
+    {
+        buffer_json_member_add_object(wb, "Sensors");
+        {
+            buffer_json_member_add_string(wb, "name", "Sensors");
+            buffer_json_member_add_string(wb, "type", "stacked-bar");
+            buffer_json_member_add_array(wb, "columns");
+            {
+                buffer_json_add_array_item_string(wb, "Count");
+            }
+            buffer_json_array_close(wb);
+        }
+        buffer_json_object_close(wb);
+
+        static const char *kind_charts[] = {"Temperature", "Fan", "Voltage", "Current", "Power"};
+        for (size_t i = 0; i < _countof(kind_charts); i++) {
+            buffer_json_member_add_object(wb, kind_charts[i]);
+            {
+                buffer_json_member_add_string(wb, "name", kind_charts[i]);
+                buffer_json_member_add_string(wb, "type", "stacked-bar");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, kind_charts[i]);
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+        }
+    }
+    buffer_json_object_close(wb); // charts
+
+    buffer_json_member_add_array(wb, "default_charts");
+    {
+        buffer_json_add_array_item_array(wb);
+        buffer_json_add_array_item_string(wb, "Sensors");
+        buffer_json_add_array_item_string(wb, "Subsystem");
+        buffer_json_array_close(wb);
+
+        buffer_json_add_array_item_array(wb);
+        buffer_json_add_array_item_string(wb, "Temperature");
+        buffer_json_add_array_item_string(wb, "Subsystem");
+        buffer_json_array_close(wb);
+    }
+    buffer_json_array_close(wb);
+
+    buffer_json_member_add_object(wb, "group_by");
+    {
+        buffer_json_member_add_object(wb, "Kind");
+        {
+            buffer_json_member_add_string(wb, "name", "Sensors by Kind");
+            buffer_json_member_add_array(wb, "columns");
+            {
+                buffer_json_add_array_item_string(wb, "Kind");
+            }
+            buffer_json_array_close(wb);
+        }
+        buffer_json_object_close(wb);
+
+        buffer_json_member_add_object(wb, "Subsystem");
+        {
+            buffer_json_member_add_string(wb, "name", "Sensors by Subsystem");
+            buffer_json_member_add_array(wb, "columns");
+            {
+                buffer_json_add_array_item_string(wb, "Subsystem");
+            }
+            buffer_json_array_close(wb);
+        }
+        buffer_json_object_close(wb);
+
+        buffer_json_member_add_object(wb, "Source");
+        {
+            buffer_json_member_add_string(wb, "name", "Sensors by Discovery Source");
+            buffer_json_member_add_array(wb, "columns");
+            {
+                buffer_json_add_array_item_string(wb, "Source");
+            }
+            buffer_json_array_close(wb);
+        }
+        buffer_json_object_close(wb);
+
+        buffer_json_member_add_object(wb, "Device");
+        {
+            buffer_json_member_add_string(wb, "name", "Sensors by Device");
+            buffer_json_member_add_array(wb, "columns");
+            {
+                buffer_json_add_array_item_string(wb, "Device");
+            }
+            buffer_json_array_close(wb);
+        }
+        buffer_json_object_close(wb);
+
+        buffer_json_member_add_object(wb, "State");
+        {
+            buffer_json_member_add_string(wb, "name", "Sensors by Collection State");
+            buffer_json_member_add_array(wb, "columns");
+            {
+                buffer_json_add_array_item_string(wb, "State");
+            }
+            buffer_json_array_close(wb);
+        }
+        buffer_json_object_close(wb);
+    }
+    buffer_json_object_close(wb); // group_by
+    buffer_json_member_add_time_t(wb, "expires", now_realtime_sec() + 1);
+    buffer_json_finalize(wb);
+
+    netdata_mutex_unlock(&macos_sensors_mutex);
+    return HTTP_RESP_OK;
 }
 
 int do_macos_sensors(int update_every, usec_t dt __maybe_unused)
@@ -1100,7 +1600,14 @@ int do_macos_sensors(int update_every, usec_t dt __maybe_unused)
             return 1;
     }
 
-    macos_sensors_init();
+    static bool sensors_initialized = false;
+    if (unlikely(!sensors_initialized)) {
+        netdata_mutex_init(&macos_sensors_mutex);
+        macos_sensors_init();
+        sensors_initialized = true;
+    }
+
+    netdata_mutex_lock(&macos_sensors_mutex);
 
     macos_sensors_begin_cycle();
     bool smc_attempted = false;
@@ -1109,7 +1616,21 @@ int do_macos_sensors(int update_every, usec_t dt __maybe_unused)
         smc_attempted = macos_sensors_collect_smc(update_every);
     if (do_hid)
         hid_attempted = macos_sensors_collect_hid(update_every);
-    macos_sensors_finish_cycle(smc_attempted, hid_attempted);
+    macos_sensors_finish_cycle(smc_attempted, hid_attempted, update_every);
+
+    netdata_mutex_unlock(&macos_sensors_mutex);
+
+    // expose the function only on hosts that actually have sensors
+    // (only this collection thread mutates the sensors list)
+    static bool function_registered = false;
+    if (unlikely(!function_registered && sensor_charts_root)) {
+        rrd_function_add_inline(localhost, NULL, "sensors", 10,
+                                RRDFUNCTIONS_PRIORITY_DEFAULT, RRDFUNCTIONS_VERSION_DEFAULT,
+                                MACOS_SENSORS_FUNCTION_HELP,
+                                "top", HTTP_ACCESS_ANONYMOUS_DATA,
+                                macos_sensors_function);
+        function_registered = true;
+    }
 
     return 0;
 }

--- a/src/collectors/macos.plugin/macos_sensors.c
+++ b/src/collectors/macos.plugin/macos_sensors.c
@@ -1165,6 +1165,10 @@ static bool macos_sensors_collect_hid_source(const struct macos_hid_sensor_sourc
         return true;
 
     CFIndex count = CFArrayGetCount(services);
+    if (!count) {
+        CFRelease(services);
+        return true;
+    }
 
     // Identity stability: when a service's product name is unique within this
     // kind, the product name alone is the sensor identity. Appending per-boot
@@ -1173,7 +1177,9 @@ static bool macos_sensors_collect_hid_source(const struct macos_hid_sensor_sourc
     // Known trade-off: if a duplicate product appears mid-run (hot-plug), the
     // first device's identity changes from bare product to a suffixed one -
     // acceptable, since built-in sensors do not hot-plug in practice.
-    char (*products)[128] = callocz((size_t)count ? (size_t)count : 1, sizeof(*products));
+    // the O(count^2) duplicate scan below is fine: Apple Silicon exposes at
+    // most a few dozen IOHID services per kind
+    char (*products)[128] = callocz((size_t)count, sizeof(*products));
     for (CFIndex i = 0; i < count; i++) {
         IOHIDServiceClientRef svc = (IOHIDServiceClientRef)CFArrayGetValueAtIndex(services, i);
         if (svc && macos_sensors_hid_product_name(svc, products[i], sizeof(products[i])))

--- a/src/collectors/macos.plugin/metadata.yaml
+++ b/src/collectors/macos.plugin/metadata.yaml
@@ -309,6 +309,31 @@ modules:
               description: Enable or disable direct IOHID temperature, current, and voltage sensor monitoring.
               default_value: yes
               required: false
+            - name: per sensor temperature charts
+              section_name: plugin:macos:sensors
+              description: Chart every temperature sensor individually, in addition to the per-subsystem summary charts and the temperature histogram.
+              default_value: no
+              required: false
+            - name: per sensor fan charts
+              section_name: plugin:macos:sensors
+              description: Chart every fan sensor individually.
+              default_value: yes
+              required: false
+            - name: per sensor voltage charts
+              section_name: plugin:macos:sensors
+              description: Chart every voltage sensor individually (per-regulator rails), in addition to the summary charts.
+              default_value: no
+              required: false
+            - name: per sensor current charts
+              section_name: plugin:macos:sensors
+              description: Chart every current sensor individually (per-regulator rails), in addition to the summary charts.
+              default_value: no
+              required: false
+            - name: per sensor power charts
+              section_name: plugin:macos:sensors
+              description: Chart every power sensor individually, in addition to the per-subsystem power summary charts.
+              default_value: no
+              required: false
             - name: discovery every
               section_name: plugin:macos:sensors
               description: How often to rescan AppleSMC for available hardware sensor keys.
@@ -890,8 +915,8 @@ modules:
               description: Sensor chip or macOS service identifier
             - name: feature
               description: Stable sensor feature identifier
-            - name: name
-              description: Human-readable sensor name
+            - name: label
+              description: Human-readable sensor label
             - name: path
               description: Stable source path for the sensor
             - name: source
@@ -931,6 +956,35 @@ modules:
               chart_type: line
               dimensions:
                 - name: input
+            - name: system.hw.sensor.temperature.subsystem
+              description: Temperature summary per hardware subsystem
+              unit: "degrees Celsius"
+              chart_type: line
+              dimensions:
+                - name: min
+                - name: avg
+                - name: max
+            - name: system.hw.sensor.power.subsystem
+              description: Power total per hardware subsystem
+              unit: "W"
+              chart_type: line
+              dimensions:
+                - name: power
+            - name: system.hw.sensor.temperature.histogram
+              description: Distribution of all temperature sensors in fixed bands
+              unit: "sensors"
+              chart_type: heatmap
+              dimensions:
+                - name: "40"
+                - name: "50"
+                - name: "60"
+                - name: "70"
+                - name: "80"
+                - name: "85"
+                - name: "90"
+                - name: "95"
+                - name: "100"
+                - name: "+Inf"
             - name: system.hw.sensor.state.input
               description: Sensor state input
               unit: "status"

--- a/src/collectors/utils/ndsudo.c
+++ b/src/collectors/utils/ndsudo.c
@@ -256,7 +256,9 @@ struct command {
     },
     {
         .name = "powermetrics-thermal-smc-gpu-loop",
-        .params = "-n 0 -b 0 -i {{sampleIntervalMs}} -s thermal,smc,gpu_power -f plist",
+        // no -n: powermetrics must stream until netdata stops it
+        // (-n 0 means "zero samples and exit" on current macOS)
+        .params = "-b 0 -i {{sampleIntervalMs}} -s thermal,smc,gpu_power -f plist",
         .search = {
             [0] = NDSUDO_MACOS_POWERMETRICS_PATH,
             [1] = NULL,
@@ -264,7 +266,7 @@ struct command {
     },
     {
         .name = "powermetrics-thermal-gpu-loop",
-        .params = "-n 0 -b 0 -i {{sampleIntervalMs}} -s thermal,gpu_power -f plist",
+        .params = "-b 0 -i {{sampleIntervalMs}} -s thermal,gpu_power -f plist",
         .search = {
             [0] = NDSUDO_MACOS_POWERMETRICS_PATH,
             [1] = NULL,
@@ -272,7 +274,7 @@ struct command {
     },
     {
         .name = "powermetrics-thermal-smc-loop",
-        .params = "-n 0 -b 0 -i {{sampleIntervalMs}} -s thermal,smc -f plist",
+        .params = "-b 0 -i {{sampleIntervalMs}} -s thermal,smc -f plist",
         .search = {
             [0] = NDSUDO_MACOS_POWERMETRICS_PATH,
             [1] = NULL,
@@ -280,7 +282,7 @@ struct command {
     },
     {
         .name = "powermetrics-thermal-loop",
-        .params = "-n 0 -b 0 -i {{sampleIntervalMs}} -s thermal -f plist",
+        .params = "-b 0 -i {{sampleIntervalMs}} -s thermal -f plist",
         .search = {
             [0] = NDSUDO_MACOS_POWERMETRICS_PATH,
             [1] = NULL,

--- a/src/collectors/windows.plugin/GetSensors.c
+++ b/src/collectors/windows.plugin/GetSensors.c
@@ -933,9 +933,13 @@ int dict_sensors_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *val
     sensors_data_chart(sd, *update_every);
 
     if (sd->sensor_data_type == NETDATA_WIN_SENSOR_CELSIUS && sd->div_factor > 0)
+        // same value math as the per-sensor chart dimensions, including the
+        // external-config multiplier override
         hw_sensors_temperature_histogram_add(
             &sensors_temperature_histogram,
-            (((NETDATA_DOUBLE)sd->current_data_value[0] + sd->add_factor) * sd->mult_factor) / sd->div_factor);
+            (((NETDATA_DOUBLE)sd->current_data_value[0] + sd->add_factor) *
+             (sd->external_config ? (NETDATA_DOUBLE)sd->external_config->multiplier : sd->mult_factor)) /
+                sd->div_factor);
 
     return 1;
 }

--- a/src/collectors/windows.plugin/GetSensors.c
+++ b/src/collectors/windows.plugin/GetSensors.c
@@ -932,14 +932,17 @@ int dict_sensors_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *val
 
     sensors_data_chart(sd, *update_every);
 
-    if (sd->sensor_data_type == NETDATA_WIN_SENSOR_CELSIUS && sd->div_factor > 0)
+    if (sd->sensor_data_type == NETDATA_WIN_SENSOR_CELSIUS && sd->div_factor > 0) {
         // same value math as the per-sensor chart dimensions, including the
         // external-config multiplier override
-        hw_sensors_temperature_histogram_add(
-            &sensors_temperature_histogram,
+        NETDATA_DOUBLE celsius =
             (((NETDATA_DOUBLE)sd->current_data_value[0] + sd->add_factor) *
              (sd->external_config ? (NETDATA_DOUBLE)sd->external_config->multiplier : sd->mult_factor)) /
-                sd->div_factor);
+            sd->div_factor;
+
+        if (isfinite(celsius))
+            hw_sensors_temperature_histogram_add(&sensors_temperature_histogram, celsius);
+    }
 
     return 1;
 }

--- a/src/collectors/windows.plugin/GetSensors.c
+++ b/src/collectors/windows.plugin/GetSensors.c
@@ -323,6 +323,7 @@ struct sensor_data {
     bool first_time;
     bool enabled;
     bool read_ok; // last collection cycle read this sensor's value successfully
+    size_t seen_generation; // last enumeration pass that returned this sensor
     enum netdata_win_sensor_monitored sensor_data_type;
     struct win_sensor_config *config;
     struct netdata_sensors_extra_values *values;
@@ -352,6 +353,12 @@ struct sensor_data {
 };
 
 DICTIONARY *sensors;
+
+// bumped by the sensor thread after each COMPLETED enumeration pass, so
+// consumers can tell current sensors from ones that disappeared from the
+// Sensor API; guarded by sensors_mutex. not bumped on failed polls - a
+// transient API failure freezes the last known state instead of aging it out
+static size_t sensors_enum_generation = 0;
 
 static void netdata_sensors_free_extra_values(struct netdata_sensors_extra_values *values)
 {
@@ -638,6 +645,11 @@ static void netdata_get_sensors()
         __netdata_mutex_lock(&sensors_mutex);
         struct sensor_data *sd = dictionary_set(sensors, thread_values, NULL, sizeof(*sd));
 
+        // stamped with the NEXT generation: ">= sensors_enum_generation"
+        // keeps a sensor alive through the in-flight pass and expires it one
+        // completed pass after it disappears from the enumeration
+        sd->seen_generation = sensors_enum_generation + 1;
+
         if (unlikely(!sd->initialized)) {
             netdata_initialize_sensor_dict(sd, pSensor);
             sd->initialized = true;
@@ -691,6 +703,10 @@ static void netdata_get_sensors()
 
         pSensor->lpVtbl->Release(pSensor);
     }
+
+    __netdata_mutex_lock(&sensors_mutex);
+    sensors_enum_generation++;
+    __netdata_mutex_unlock(&sensors_mutex);
 
     pSensorCollection->lpVtbl->Release(pSensorCollection);
 }
@@ -937,7 +953,8 @@ int dict_sensors_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *val
 
     sensors_data_chart(sd, *update_every);
 
-    if (sd->sensor_data_type == NETDATA_WIN_SENSOR_CELSIUS && sd->div_factor > 0 && sd->read_ok) {
+    if (sd->sensor_data_type == NETDATA_WIN_SENSOR_CELSIUS && sd->div_factor > 0 && sd->read_ok &&
+        sd->seen_generation >= sensors_enum_generation) {
         // same value math as the per-sensor chart dimensions, including the
         // external-config multiplier override
         NETDATA_DOUBLE celsius =

--- a/src/collectors/windows.plugin/GetSensors.c
+++ b/src/collectors/windows.plugin/GetSensors.c
@@ -1022,9 +1022,11 @@ void do_Sensors_cleanup()
         memset(&sensors_temperature_histogram, 0, sizeof(sensors_temperature_histogram));
     }
 
-    __netdata_mutex_destroy(&sensors_mutex);
+    // destroy the mutex last, in case a future dictionary delete callback
+    // ever needs it (today none does; the sensor thread is already joined)
     dictionary_destroy(sensors);
     sensors = NULL;
+    __netdata_mutex_destroy(&sensors_mutex);
     // Note: pSensorManager is owned and cleaned up by the sensor thread itself
     // No additional cleanup needed here since the thread has already released resources
 }

--- a/src/collectors/windows.plugin/GetSensors.c
+++ b/src/collectors/windows.plugin/GetSensors.c
@@ -322,6 +322,7 @@ struct sensor_data {
     bool initialized;
     bool first_time;
     bool enabled;
+    bool read_ok; // last collection cycle read this sensor's value successfully
     enum netdata_win_sensor_monitored sensor_data_type;
     struct win_sensor_config *config;
     struct netdata_sensors_extra_values *values;
@@ -517,6 +518,7 @@ static void netdata_sensors_get_data(struct sensor_data *sd, ISensor *pSensor)
             sd->sensor_data_type = i;
             sd->config = &configs[i];
             sd->enabled = true;
+            sd->read_ok = true;
 
             if (i == NETDATA_WIN_SENSOR_TYPE_DISTANCE_X) {
                 netdata_collect_sensor_data(&sd->current_data_value[1],
@@ -557,6 +559,7 @@ static void netdata_sensors_get_custom_data(struct sensor_data *sd, ISensor *pSe
                 sd->sensor_data_type = i;
                 sd->config = &configs[NETDATA_WIN_SENSOR_LAST_WELL_DEFINED];
                 sd->enabled = true;
+                sd->read_ok = true;
                 sd->current_data_value[0] = current;
             }  else {
                 if (unlikely(!sd->values)) {
@@ -649,10 +652,12 @@ static void netdata_get_sensors()
             if (unlikely(!sd->enabled))
                 netdata_sensors_get_custom_data(sd, pSensor);
         } else if (likely(sd->enabled)) {
-            netdata_collect_sensor_data(&sd->current_data_value[0],
-                                        pSensor,
-                                        sensor_keys[sd->sensor_data_type],
-                                        sd->div_factor);
+            // on failure the value is forced to 0 - track validity so the
+            // temperature histogram does not count failed reads as 0 degrees
+            sd->read_ok = netdata_collect_sensor_data(&sd->current_data_value[0],
+                                                      pSensor,
+                                                      sensor_keys[sd->sensor_data_type],
+                                                      sd->div_factor);
             if (sd->sensor_data_type == NETDATA_WIN_SENSOR_TYPE_DISTANCE_X) {
                 netdata_collect_sensor_data(&sd->current_data_value[1],
                                             pSensor,
@@ -932,7 +937,7 @@ int dict_sensors_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *val
 
     sensors_data_chart(sd, *update_every);
 
-    if (sd->sensor_data_type == NETDATA_WIN_SENSOR_CELSIUS && sd->div_factor > 0) {
+    if (sd->sensor_data_type == NETDATA_WIN_SENSOR_CELSIUS && sd->div_factor > 0 && sd->read_ok) {
         // same value math as the per-sensor chart dimensions, including the
         // external-config multiplier override
         NETDATA_DOUBLE celsius =
@@ -992,6 +997,13 @@ void do_Sensors_cleanup()
 
     if (!sensors)
         return;
+
+    // retire the histogram chart like the per-sensor charts the dictionary
+    // destructor obsoletes below, and forget its state for a future lifecycle
+    if (sensors_temperature_histogram.st) {
+        rrdset_is_obsolete___safe_from_collector_thread(sensors_temperature_histogram.st);
+        memset(&sensors_temperature_histogram, 0, sizeof(sensors_temperature_histogram));
+    }
 
     __netdata_mutex_destroy(&sensors_mutex);
     dictionary_destroy(sensors);

--- a/src/collectors/windows.plugin/GetSensors.c
+++ b/src/collectors/windows.plugin/GetSensors.c
@@ -4,6 +4,10 @@
 #include "windows-internals.h"
 #include "libnetdata/os/windows-wmi/windows-wmi.h"
 
+#define _COMMON_PLUGIN_NAME "windows.plugin"
+#define _COMMON_PLUGIN_MODULE_NAME "GetSensors"
+#include "../common-contexts/common-contexts.h"
+
 #include <windows.h>
 #include <wchar.h>
 
@@ -796,7 +800,7 @@ static void sensors_states_chart(struct sensor_data *sd, int update_every)
             update_every,
             RRDSET_TYPE_LINE);
 
-        rrdlabels_add(sd->st_sensor_state->rrdlabels, "name", sd->name, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(sd->st_sensor_state->rrdlabels, "label", sd->name, RRDLABEL_SRC_AUTO);
         rrdlabels_add(sd->st_sensor_state->rrdlabels, "manufacturer", sd->manufacturer, RRDLABEL_SRC_AUTO);
         rrdlabels_add(sd->st_sensor_state->rrdlabels, "model", sd->model, RRDLABEL_SRC_AUTO);
 
@@ -869,7 +873,7 @@ static void sensors_data_chart(struct sensor_data *sd, int update_every)
             update_every,
             RRDSET_TYPE_LINE);
 
-        rrdlabels_add(sd->st_sensor_data->rrdlabels, "name", sd->name, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(sd->st_sensor_data->rrdlabels, "label", sd->name, RRDLABEL_SRC_AUTO);
         rrdlabels_add(sd->st_sensor_data->rrdlabels, "manufacturer", sd->manufacturer, RRDLABEL_SRC_AUTO);
         rrdlabels_add(sd->st_sensor_data->rrdlabels, "model", sd->model, RRDLABEL_SRC_AUTO);
 
@@ -910,6 +914,9 @@ static void sensors_data_chart(struct sensor_data *sd, int update_every)
     rrdset_done(sd->st_sensor_data);
 }
 
+// cross-OS temperature histogram - contract in common-contexts/hw-sensors.h
+static HW_SENSORS_TEMPERATURE_HISTOGRAM sensors_temperature_histogram = {0};
+
 int dict_sensors_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused)
 {
     int *update_every = data;
@@ -924,6 +931,11 @@ int dict_sensors_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void *val
         return 1;
 
     sensors_data_chart(sd, *update_every);
+
+    if (sd->sensor_data_type == NETDATA_WIN_SENSOR_CELSIUS && sd->div_factor > 0)
+        hw_sensors_temperature_histogram_add(
+            &sensors_temperature_histogram,
+            (((NETDATA_DOUBLE)sd->current_data_value[0] + sd->add_factor) * sd->mult_factor) / sd->div_factor);
 
     return 1;
 }
@@ -940,7 +952,10 @@ int do_GetSensors(int update_every, usec_t dt __maybe_unused)
     }
 
     __netdata_mutex_lock(&sensors_mutex);
+    hw_sensors_temperature_histogram_reset(&sensors_temperature_histogram);
     dictionary_sorted_walkthrough_read(sensors, dict_sensors_charts_cb, &update_every);
+    common_hw_sensors_temperature_histogram(
+        &sensors_temperature_histogram, update_every, "windows.plugin", "GetSensors");
     __netdata_mutex_unlock(&sensors_mutex);
     return 0;
 }

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -1417,7 +1417,7 @@ modules:
         - name: Sensor
           description: "These metrics refer to Sensors."
           labels:
-            - name: name
+            - name: label
               description: Sensor friendly name.
             - name: manufacturer
               description: The sensor manufacturer.
@@ -1430,6 +1430,21 @@ modules:
               chart_type: line
               dimensions:
                 - name: input
+            - name: system.hw.sensor.temperature.histogram
+              description: Distribution of all temperature sensors in fixed bands
+              unit: "sensors"
+              chart_type: heatmap
+              dimensions:
+                - name: "40"
+                - name: "50"
+                - name: "60"
+                - name: "70"
+                - name: "80"
+                - name: "85"
+                - name: "90"
+                - name: "95"
+                - name: "100"
+                - name: "+Inf"
             - name: system.hw.sensor.power.input
               description: Sensor Power
               unit: "W"

--- a/src/libnetdata/functions_evloop/functions_evloop.c
+++ b/src/libnetdata/functions_evloop/functions_evloop.c
@@ -325,7 +325,9 @@ static void rrd_functions_worker_globals_reader_main(void *arg) {
     }
 
     int status = 0;
-    if(!__atomic_load_n(wg->plugin_should_exit, __ATOMIC_ACQUIRE)) {
+    if(!__atomic_load_n(wg->plugin_should_exit, __ATOMIC_ACQUIRE) && !nd_thread_signaled_to_cancel()) {
+        // a genuine stdin EOF/error - not a QUIT command and not the plugin
+        // shutting down on its own and cancelling this thread
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "Read error on stdin");
         status = 1;
     }


### PR DESCRIPTION
## Summary

This PR fixes runaway per-node cardinality on macOS (processes and hardware sensors), fixes three sensor bugs, and introduces two cross-OS conventions: a fleet-aggregatable temperature histogram and a `sensors` function.

### apps.plugin: path-derived process grouping (macOS)

macOS has a flat process tree (`launchd` spawns almost everything) and the stock `apps_groups.conf` is Linux-oriented, so every unmatched process became its own group: **~600 groups (~6,000 time-series) per Mac**.

Processes not matched by `apps_groups.conf` are now grouped by their executable path:

| Executable | Group |
|---|---|
| Application bundles (`*.app`, `*.appex`) | one group per application |
| Apple framework helpers (`*.framework`, XPC services) | `system-frameworks` |
| Apple standalone daemons (`/usr/libexec`, `/usr/sbin`, ...) | `system-daemons` |
| Driver extensions (`*.dext`) | `driver-extensions` |
| Third-party frameworks | one group per framework |
| Third-party plain binaries | one group per process name |

Apple's bundle grammar and the sealed system volume (SIP/SSV) make this classification stable across macOS versions - no name lists to maintain. Famous components (WindowServer, Spotlight, media analysis, CoreAudio, iCloud, Time Machine, VideoToolbox, ...) are re-exposed as named groups via the stock `apps_groups.conf`, and any aggregated component can be re-exposed with one config line.

**Live result on an M4 Mac mini: 598 groups → 85**, with `system-frameworks`/`system-daemons` absorbing ~85% of all processes while contributing almost no CPU to the buckets (WindowServer, previously hidden noise among 600 groups, is now clearly visible as the top consumer).

### macos.plugin sensors: three fixes

1. **Label key contract**: per-sensor chart labels used `name` on macOS and Windows while both Linux producers use `label`. All producers now use `label`.
2. **Identity stability**: IOHID sensor identities embedded the per-boot `IORegistryEntryID` (`PMU_tdie5_registry_1000006e3`), minting new time-series on every reboot. Unique product names are now used as-is (`PMU_tdie5`); true duplicates disambiguate via reboot-stable `LocationID`.
3. **powermetrics loop was dead on arrival**: the loop profiles used `-n 0`, which on current macOS means "take zero samples and exit". The thermal pressure chart collected data only briefly after each restart, then cycled probe→instant-exit→backoff forever (7,779 identical log errors in 6 days on the test Mac, because the log-once guard was re-armed by every probe sample). The loop now streams until stopped, and the guard only re-arms after a productive loop.

### sensors cardinality (macOS)

An M4 Mac mini exposes ~405 sensors (202 temperatures, ~150 per-regulator voltage/current rails). Per-channel charts are now **opt-in** for temperature/voltage/current/power; the default views are:

- `system.hw.sensor.temperature.subsystem` - min/avg/max per subsystem (cpu, soc, memory, storage, ambient, ...)
- `system.hw.sensor.power.subsystem` - power totals per subsystem (watts add meaningfully)
- the cross-OS histogram below

**Live result: ~405 sensor charts → ~25**, everything still collected internally, per-channel detail one config switch away.

### Cross-OS temperature histogram

New permanent contract (`src/collectors/common-contexts/hw-sensors.h`): `system.hw.sensor.temperature.histogram` - a population histogram of ALL temperature sensors in fixed, disjoint buckets (upper bounds `40,50,60,70,80,85,90,95,100,+Inf` °C; 10°C bands in the benign range, 5°C bands in the 80-100°C action zone). Implemented identically on **macOS**, **Windows** (`GetSensors`) and **Linux** (`debugfs.plugin`/libsensors), so bucket counts can be summed across nodes for a fleet-wide thermal distribution view. The chart is only created on hosts that have temperature sensors.

### `sensors` function

A live table of every discovered sensor - including the ones aggregated into summaries: label, kind, subsystem, source, device, current reading, units, state. The per-sensor chart id is the table's unique key (chart ↔ row correlation), per-kind aggregation tiles (Temperature/Fan/Voltage/Current/Power) re-aggregate under user-selected groupings (by kind, subsystem, device, state). Registered only on hosts that actually have sensors.

Implemented on macOS and `debugfs.plugin` (its first function, served via the functions event loop). The Windows implementation follows on this branch.

## Validation

- macOS: built and deployed on an M4 Mac mini; process grouping, sensor summaries, histogram, function and all three fixes verified live (including `powermetrics -n 0` vs streaming behavior verified against the real binary).
- Linux go.d: initially received the histogram too; reverted intentionally - the go.d sensors collector is disabled by default (`debugfs.plugin` is the Linux producer) and is treated as a leftover.
- Linux `debugfs.plugin` and Windows changes compile-verified by CI (Linux/Windows-only sources).

## Notes for reviewers

- The histogram bucket edges are a **permanent public contract** - once shipped they must never change, or historical heatmaps break.
- The macOS per-sensor label key rename (`name` → `label`) and the IOHID identity change alter young contexts (first shipped days ago) - migration impact is minimal and intentional.
- Follow-ups planned on this branch: Windows `sensors` function, `metadata.yaml`/docs sync for the three producers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps macOS process and sensor cardinality and adds fleet‑ready sensor views across OSes. Introduces path‑based process grouping, per‑subsystem summaries, a cross‑OS temperature histogram, and a unified `sensors` function, with fixes for labels, identity, stream loops, and hardened histogram, shutdown, and data validity paths.

- **New Features**
  - `apps.plugin` (macOS): Group unmatched processes by executable path; apps keep their own group, Apple helpers/daemons and driver extensions aggregate into `system-frameworks`, `system-daemons`, `driver-extensions`. Stock `apps_groups.conf` re‑exposes key components; adds `sshd-session` to managers and treats login shells as interpreters (`zsh`, `dash`, `csh`, `tcsh`, `ksh`) so shell roots group by their comm. Result: ~600→~85 groups.
  - Hardware sensors (macOS): Default to summaries with per‑subsystem temperature min/avg/max and power totals; per‑channel charts are opt‑in for temperature/voltage/current/power. Result: ~405→~25 charts.
  - Cross‑OS temperature histogram: `system.hw.sensor.temperature.histogram` with fixed disjoint buckets (`40,50,60,70,80,85,90,95,100,+Inf` °C), implemented in `macos.plugin`, `windows.plugin` (`GetSensors`), and `debugfs.plugin`. Shared contract in `common-contexts/hw-sensors.h`.
  - `sensors` function: Lists all discovered sensors with live readings and metadata; includes per‑kind tiles and grouping (by kind/subsystem/device/state). Implemented in `macos.plugin` and `debugfs.plugin`; shared schema in `common-contexts/hw-sensors-function.h`. Registered only on hosts with sensors.
  - `debugfs.plugin` docs: Documented the `libsensors` module and new histogram/function contexts in `metadata.yaml`; added `taxonomy.yaml` with `taxonomy_optout`.

- **Bug Fixes**
  - Labels: Use `label` as the per‑sensor label key on macOS and Windows to match Linux.
  - Identity stability (macOS IOHID): Use unique product names; disambiguate true duplicates via reboot‑stable `LocationID`.
  - `powermetrics` loop (macOS): Remove `-n 0` so it streams until stopped; re‑arm the log‑once guard only after a productive loop.
  - `debugfs.plugin`: Fully synchronized `sensors_dict` access and function emission; skip sensors missing from the current cycle; write function results under `stdout_mutex`; honor QUIT and propagate exit status; cancel/join function workers before cleanup; destroy the sensors mutex and release libsensors state on exit; re‑emit histogram CHART on restart.
  - Windows `GetSensors`: Count temperatures in the histogram only on successful, finite reads; match per‑sensor chart math (incl. external multiplier); retire the histogram chart on cleanup; age sensors out of the histogram when they disappear from enumeration while failed polls freeze last known state; destroy the sensors mutex after the dictionary to avoid future teardown races.
  - Histogram helper: `common-contexts/hw-sensors.h` rejects non‑finite readings for all producers.
  - macOS sensors cleanup: Run under a mutex; obsolete and free rollup/histogram charts safely.
  - Docs/metadata: Clarify function registration notes and fix minor typos in `metadata.yaml`.

<sup>Written for commit 99bc2af508f2d805ce9f88b68cdc80772b4304f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

