### PR TITLE
feat(go.d/chartengine): update mutable chart labels

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -197,6 +197,18 @@ source files for evidence.
   retry path handles it. Limit only fail-soft warnings/errors where collection
   continues with partial or stale data.
 
+## Chart Label Identity
+
+- Labels used by `instances.by_labels` or a dimension `name_from_label` define
+  chart or dimension identity. Changing one creates a new chart or dimension;
+  collectors MUST NOT use identity churn merely to refresh metadata.
+- `label_promotion` defines non-identity chart metadata. Chartengine reconciles
+  its effective intersection on existing charts and emits a complete
+  replacement only when it changes.
+- Collectors MUST continue publishing numeric samples at their required cadence.
+  A label-only replacement updates chart metadata; it is not a substitute for
+  numeric sample-and-hold output.
+
 ## Host Scopes
 
 - Host scopes SHOULD be used only after a product decision says the data belongs

--- a/src/go/plugin/framework/chartemit/apply.go
+++ b/src/go/plugin/framework/chartemit/apply.go
@@ -3,8 +3,10 @@
 package chartemit
 
 import (
+	"cmp"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 
@@ -22,6 +24,7 @@ const (
 type normalizedActions struct {
 	createCharts     map[string]CreateChartAction
 	createDimsByID   map[string][]CreateDimensionAction
+	updateLabels     []UpdateChartLabelsAction
 	updateCharts     []UpdateChartAction
 	removeDimensions []RemoveDimensionAction
 	removeCharts     []RemoveChartAction
@@ -59,6 +62,7 @@ func ApplyPlan(api *netdataapi.API, plan Plan, env EmitEnv) error {
 		return err
 	}
 	emitCreatePhase(api, env, normalized)
+	emitLabelUpdatePhase(api, env, normalized.updateLabels)
 	emitUpdatePhase(api, env, normalized.updateCharts)
 	emitRemovePhase(api, env, normalized)
 	return nil
@@ -67,6 +71,7 @@ func ApplyPlan(api *netdataapi.API, plan Plan, env EmitEnv) error {
 func hasEmissions(actions normalizedActions) bool {
 	return len(actions.createCharts) > 0 ||
 		len(actions.createDimsByID) > 0 ||
+		len(actions.updateLabels) > 0 ||
 		len(actions.updateCharts) > 0 ||
 		len(actions.removeDimensions) > 0 ||
 		len(actions.removeCharts) > 0
@@ -111,6 +116,9 @@ func validateTypeIDBudget(typeID string, actions normalizedActions) error {
 	for chartID := range actions.createDimsByID {
 		seen[chartID] = struct{}{}
 	}
+	for _, update := range actions.updateLabels {
+		seen[update.ChartID] = struct{}{}
+	}
 	for _, update := range actions.updateCharts {
 		seen[update.ChartID] = struct{}{}
 	}
@@ -130,16 +138,21 @@ func validateTypeIDBudget(typeID string, actions normalizedActions) error {
 }
 
 func normalizeActions(actions []EngineAction) normalizedActions {
-	out := normalizedActions{
-		createCharts:   make(map[string]CreateChartAction),
-		createDimsByID: make(map[string][]CreateDimensionAction),
-	}
+	var out normalizedActions
 	for _, action := range actions {
 		switch v := action.(type) {
 		case CreateChartAction:
+			if out.createCharts == nil {
+				out.createCharts = make(map[string]CreateChartAction)
+			}
 			out.createCharts[v.ChartID] = v
 		case CreateDimensionAction:
+			if out.createDimsByID == nil {
+				out.createDimsByID = make(map[string][]CreateDimensionAction)
+			}
 			out.createDimsByID[v.ChartID] = append(out.createDimsByID[v.ChartID], v)
+		case UpdateChartLabelsAction:
+			out.updateLabels = append(out.updateLabels, v)
 		case UpdateChartAction:
 			out.updateCharts = append(out.updateCharts, v)
 		case RemoveDimensionAction:
@@ -188,9 +201,6 @@ func emitCreatePhase(api *netdataapi.API, env EmitEnv, actions normalizedActions
 			continue
 		}
 		emitChart(api, env, chartID, dims[0].ChartMeta, false)
-		// Dimension-only chart creation path still needs chart labels and commit.
-		emitChartLabels(api, env, nil)
-		api.CLABELCOMMIT()
 		for _, dim := range dims {
 			emitDimension(api, dimensionEmission{
 				Name:       dim.Name,
@@ -201,6 +211,22 @@ func emitCreatePhase(api *netdataapi.API, env EmitEnv, actions normalizedActions
 				Divisor:    dim.Divisor,
 			})
 		}
+	}
+}
+
+func emitLabelUpdatePhase(api *netdataapi.API, env EmitEnv, updates []UpdateChartLabelsAction) {
+	if len(updates) == 0 {
+		return
+	}
+	if len(updates) > 1 {
+		slices.SortFunc(updates, func(a, b UpdateChartLabelsAction) int {
+			return cmp.Compare(a.ChartID, b.ChartID)
+		})
+	}
+	for _, update := range updates {
+		emitChart(api, env, update.ChartID, update.Meta, false)
+		emitChartLabels(api, env, update.Labels)
+		api.CLABELCOMMIT()
 	}
 }
 

--- a/src/go/plugin/framework/chartemit/apply_test.go
+++ b/src/go/plugin/framework/chartemit/apply_test.go
@@ -284,7 +284,7 @@ func TestApplyPlanGapsNonFiniteFloatUpdate(t *testing.T) {
 	assert.Contains(t, out, "SET 'value' = \n")
 }
 
-func TestApplyPlanDimensionOnlyCreateEmitsLabelsAndCommit(t *testing.T) {
+func TestApplyPlanDimensionOnlyCreatePreservesExistingLabels(t *testing.T) {
 	var buf bytes.Buffer
 	api := netdataapi.New(&buf)
 
@@ -326,11 +326,9 @@ func TestApplyPlanDimensionOnlyCreateEmitsLabelsAndCommit(t *testing.T) {
 	assert.Equal(t, `HOST ''
 
 CHART 'collector.job.dimension_only_chart' '' 'Dimension-only chart' '1' 'Runtime' 'runtime.dimension_only' 'line' '0' '1' '' 'go.d.plugin' 'runtime'
-CLABEL 'instance' 'localhost' '2'
-CLABEL '_collect_job' 'job01' '1'
-CLABEL_COMMIT
 DIMENSION 'value' 'value' 'absolute' '1' '1' ''
 `, out)
+	assert.NotContains(t, out, "CLABEL")
 }
 
 func TestApplyPlanSanitizesWireValues(t *testing.T) {

--- a/src/go/plugin/framework/chartemit/mutable_labels_bench_test.go
+++ b/src/go/plugin/framework/chartemit/mutable_labels_bench_test.go
@@ -26,43 +26,57 @@ func BenchmarkApplyPlanChartCreateLabels(b *testing.B) {
 	for _, chartCount := range []int{1, 100, 1000} {
 		for _, labelCount := range []int{0, 4, 16, 64} {
 			b.Run(fmt.Sprintf("charts_%d/labels_%d", chartCount, labelCount), func(b *testing.B) {
-				plan := benchmarkChartLabelPlan(chartCount, labelCount)
-				writer := &benchmarkByteCounter{}
-				api := netdataapi.New(writer)
-				env := EmitEnv{
-					TypeID:      "benchmark.job",
-					UpdateEvery: 1,
-					Plugin:      "go.d.plugin",
-					Module:      "benchmark",
-					JobName:     "benchmark",
-					JobLabels:   map[string]string{"configured": "label"},
-				}
-				if err := ApplyPlan(api, plan, env); err != nil {
-					b.Fatalf("warm label plan: %v", err)
-				}
-				warmBytes := writer.bytes
-				if warmBytes == 0 {
-					b.Fatal("warm label plan emitted no bytes")
-				}
-				b.SetBytes(warmBytes)
-
-				b.ReportAllocs()
-				b.ResetTimer()
-				b.ReportMetric(float64(chartCount), "charts/op")
-				b.ReportMetric(float64(chartCount*labelCount), "promoted_labels/op")
-				for range b.N {
-					writer.bytes = 0
-					if err := ApplyPlan(api, plan, env); err != nil {
-						b.Fatalf("apply label plan: %v", err)
-					}
-					benchmarkChartLabelWireBytes = writer.bytes
-				}
-				b.StopTimer()
-				if writer.bytes != warmBytes {
-					b.Fatalf("wire bytes = %d, want %d", writer.bytes, warmBytes)
-				}
+				benchmarkApplyChartLabels(b, benchmarkChartLabelPlan(chartCount, labelCount), chartCount, labelCount)
 			})
 		}
+	}
+}
+
+func BenchmarkApplyPlanChartUpdateLabels(b *testing.B) {
+	for _, chartCount := range []int{1, 100, 1000} {
+		for _, labelCount := range []int{0, 4, 16, 64} {
+			b.Run(fmt.Sprintf("charts_%d/labels_%d", chartCount, labelCount), func(b *testing.B) {
+				benchmarkApplyChartLabels(b, benchmarkChartLabelUpdatePlan(chartCount, labelCount), chartCount, labelCount)
+			})
+		}
+	}
+}
+
+func benchmarkApplyChartLabels(b *testing.B, plan Plan, chartCount, labelCount int) {
+	b.Helper()
+	writer := &benchmarkByteCounter{}
+	api := netdataapi.New(writer)
+	env := EmitEnv{
+		TypeID:      "benchmark.job",
+		UpdateEvery: 1,
+		Plugin:      "go.d.plugin",
+		Module:      "benchmark",
+		JobName:     "benchmark",
+		JobLabels:   map[string]string{"configured": "label"},
+	}
+	if err := ApplyPlan(api, plan, env); err != nil {
+		b.Fatalf("warm label plan: %v", err)
+	}
+	warmBytes := writer.bytes
+	if warmBytes == 0 {
+		b.Fatal("warm label plan emitted no bytes")
+	}
+	b.SetBytes(warmBytes)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.ReportMetric(float64(chartCount), "charts/op")
+	b.ReportMetric(float64(chartCount*labelCount), "promoted_labels/op")
+	for range b.N {
+		writer.bytes = 0
+		if err := ApplyPlan(api, plan, env); err != nil {
+			b.Fatalf("apply label plan: %v", err)
+		}
+		benchmarkChartLabelWireBytes = writer.bytes
+	}
+	b.StopTimer()
+	if writer.bytes != warmBytes {
+		b.Fatalf("wire bytes = %d, want %d", writer.bytes, warmBytes)
 	}
 }
 
@@ -118,6 +132,20 @@ func benchmarkChartLabelPlan(chartCount, labelCount int) Plan {
 				Type:    chartengine.ChartTypeLine,
 			},
 			Labels: labels,
+		})
+	}
+	return Plan{Actions: actions}
+}
+
+func benchmarkChartLabelUpdatePlan(chartCount, labelCount int) Plan {
+	created := benchmarkChartLabelPlan(chartCount, labelCount)
+	actions := make([]EngineAction, 0, chartCount)
+	for _, action := range created.Actions {
+		create := action.(chartengine.CreateChartAction)
+		actions = append(actions, chartengine.UpdateChartLabelsAction{
+			ChartID: create.ChartID,
+			Meta:    create.Meta,
+			Labels:  create.Labels,
 		})
 	}
 	return Plan{Actions: actions}

--- a/src/go/plugin/framework/chartemit/mutable_labels_bench_test.go
+++ b/src/go/plugin/framework/chartemit/mutable_labels_bench_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartemit
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine"
+)
+
+var benchmarkChartLabelWireBytes int64
+
+type benchmarkByteCounter struct {
+	bytes int64
+}
+
+func (w *benchmarkByteCounter) Write(p []byte) (int, error) {
+	w.bytes += int64(len(p))
+	return len(p), nil
+}
+
+func BenchmarkApplyPlanChartCreateLabels(b *testing.B) {
+	for _, chartCount := range []int{1, 100, 1000} {
+		for _, labelCount := range []int{0, 4, 16, 64} {
+			b.Run(fmt.Sprintf("charts_%d/labels_%d", chartCount, labelCount), func(b *testing.B) {
+				plan := benchmarkChartLabelPlan(chartCount, labelCount)
+				writer := &benchmarkByteCounter{}
+				api := netdataapi.New(writer)
+				env := EmitEnv{
+					TypeID:      "benchmark.job",
+					UpdateEvery: 1,
+					Plugin:      "go.d.plugin",
+					Module:      "benchmark",
+					JobName:     "benchmark",
+					JobLabels:   map[string]string{"configured": "label"},
+				}
+				if err := ApplyPlan(api, plan, env); err != nil {
+					b.Fatalf("warm label plan: %v", err)
+				}
+				warmBytes := writer.bytes
+				if warmBytes == 0 {
+					b.Fatal("warm label plan emitted no bytes")
+				}
+				b.SetBytes(warmBytes)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				b.ReportMetric(float64(chartCount), "charts/op")
+				b.ReportMetric(float64(chartCount*labelCount), "promoted_labels/op")
+				for range b.N {
+					writer.bytes = 0
+					if err := ApplyPlan(api, plan, env); err != nil {
+						b.Fatalf("apply label plan: %v", err)
+					}
+					benchmarkChartLabelWireBytes = writer.bytes
+				}
+				b.StopTimer()
+				if writer.bytes != warmBytes {
+					b.Fatalf("wire bytes = %d, want %d", writer.bytes, warmBytes)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkApplyPlanChartValueUpdates(b *testing.B) {
+	for _, chartCount := range []int{1, 100, 1000} {
+		b.Run(fmt.Sprintf("charts_%d", chartCount), func(b *testing.B) {
+			plan := benchmarkChartValuePlan(chartCount)
+			writer := &benchmarkByteCounter{}
+			api := netdataapi.New(writer)
+			env := EmitEnv{TypeID: "benchmark.job", UpdateEvery: 1}
+			if err := ApplyPlan(api, plan, env); err != nil {
+				b.Fatalf("warm value plan: %v", err)
+			}
+			warmBytes := writer.bytes
+			if warmBytes == 0 {
+				b.Fatal("warm value plan emitted no bytes")
+			}
+			b.SetBytes(warmBytes)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.ReportMetric(float64(chartCount), "charts/op")
+			for range b.N {
+				writer.bytes = 0
+				if err := ApplyPlan(api, plan, env); err != nil {
+					b.Fatalf("apply value plan: %v", err)
+				}
+				benchmarkChartLabelWireBytes = writer.bytes
+			}
+			b.StopTimer()
+			if writer.bytes != warmBytes {
+				b.Fatalf("wire bytes = %d, want %d", writer.bytes, warmBytes)
+			}
+		})
+	}
+}
+
+func benchmarkChartLabelPlan(chartCount, labelCount int) Plan {
+	actions := make([]EngineAction, 0, chartCount)
+	for chart := range chartCount {
+		labels := make(map[string]string, labelCount)
+		for label := range labelCount {
+			labels[fmt.Sprintf("label_%02d", label)] = "value_" + strconv.Itoa(label)
+		}
+		actions = append(actions, chartengine.CreateChartAction{
+			ChartTemplateID: "benchmark",
+			ChartID:         "chart_" + strconv.Itoa(chart),
+			Meta: chartengine.ChartMeta{
+				Title:   "Benchmark",
+				Family:  "Benchmark",
+				Context: "benchmark.chart",
+				Units:   "units",
+				Type:    chartengine.ChartTypeLine,
+			},
+			Labels: labels,
+		})
+	}
+	return Plan{Actions: actions}
+}
+
+func benchmarkChartValuePlan(chartCount int) Plan {
+	actions := make([]EngineAction, 0, chartCount)
+	for chart := range chartCount {
+		actions = append(actions, chartengine.UpdateChartAction{
+			ChartID: "chart_" + strconv.Itoa(chart),
+			Values: []chartengine.UpdateDimensionValue{{
+				Name:  "value",
+				Int64: int64(chart),
+			}},
+		})
+	}
+	return Plan{Actions: actions}
+}

--- a/src/go/plugin/framework/chartemit/mutable_labels_test.go
+++ b/src/go/plugin/framework/chartemit/mutable_labels_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartemit
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyPlanUpdatesChartLabelsWithoutDimensions(t *testing.T) {
+	var buf bytes.Buffer
+	api := netdataapi.New(&buf)
+	meta := chartengine.ChartMeta{
+		Title:   "Service",
+		Family:  "Service",
+		Context: "service.value",
+		Units:   "value",
+		Type:    chartengine.ChartTypeLine,
+	}
+	plan := Plan{Actions: []EngineAction{
+		chartengine.UpdateChartLabelsAction{
+			ChartID: "service_node-1",
+			Meta:    meta,
+			Labels:  map[string]string{"owner": "owner-b"},
+		},
+		chartengine.UpdateChartAction{
+			ChartID: "service_node-1",
+			Values:  []chartengine.UpdateDimensionValue{{Name: "value", Int64: 1}},
+		},
+	}}
+
+	err := ApplyPlan(api, plan, EmitEnv{
+		TypeID:      "collector.job",
+		UpdateEvery: 1,
+		Plugin:      "go.d.plugin",
+		Module:      "service",
+		JobName:     "job01",
+		JobLabels:   map[string]string{"configured": "label"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "HOST ''\n\n"+
+		"CHART 'collector.job.service_node-1' '' 'Service' 'value' 'Service' 'service.value' 'line' '0' '1' '' 'go.d.plugin' 'service'\n"+
+		"CLABEL 'configured' 'label' '2'\n"+
+		"CLABEL 'owner' 'owner-b' '1'\n"+
+		"CLABEL '_collect_job' 'job01' '1'\n"+
+		"CLABEL_COMMIT\n"+
+		"BEGIN 'collector.job.service_node-1'\n"+
+		"SET 'value' = 1\n"+
+		"END\n\n", buf.String())
+	assert.NotContains(t, buf.String(), "DIMENSION")
+}
+
+func TestApplyPlanLabelReplacementKeepsConfiguredAndReservedLabels(t *testing.T) {
+	var buf bytes.Buffer
+	api := netdataapi.New(&buf)
+	plan := Plan{Actions: []EngineAction{
+		chartengine.UpdateChartLabelsAction{
+			ChartID: "service_node-1",
+			Meta: chartengine.ChartMeta{
+				Title:   "Service",
+				Family:  "Service",
+				Context: "service.value",
+				Units:   "value",
+				Type:    chartengine.ChartTypeLine,
+			},
+			Labels: nil,
+		},
+	}}
+
+	err := ApplyPlan(api, plan, EmitEnv{
+		TypeID:      "collector.job",
+		UpdateEvery: 1,
+		Plugin:      "go.d.plugin",
+		Module:      "service",
+		JobName:     "job01",
+		JobLabels:   map[string]string{"configured": "label"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "HOST ''\n\n"+
+		"CHART 'collector.job.service_node-1' '' 'Service' 'value' 'Service' 'service.value' 'line' '0' '1' '' 'go.d.plugin' 'service'\n"+
+		"CLABEL 'configured' 'label' '2'\n"+
+		"CLABEL '_collect_job' 'job01' '1'\n"+
+		"CLABEL_COMMIT\n", buf.String())
+	assert.NotContains(t, buf.String(), "DIMENSION")
+	assert.NotContains(t, buf.String(), "BEGIN")
+}

--- a/src/go/plugin/framework/chartemit/types.go
+++ b/src/go/plugin/framework/chartemit/types.go
@@ -34,11 +34,12 @@ type Plan = chartengine.Plan
 // Action aliases keep chartemit independent from planner internals while
 // reusing the action model.
 type (
-	EngineAction          = chartengine.EngineAction
-	CreateChartAction     = chartengine.CreateChartAction
-	CreateDimensionAction = chartengine.CreateDimensionAction
-	UpdateChartAction     = chartengine.UpdateChartAction
-	UpdateDimensionValue  = chartengine.UpdateDimensionValue
-	RemoveDimensionAction = chartengine.RemoveDimensionAction
-	RemoveChartAction     = chartengine.RemoveChartAction
+	EngineAction            = chartengine.EngineAction
+	CreateChartAction       = chartengine.CreateChartAction
+	CreateDimensionAction   = chartengine.CreateDimensionAction
+	UpdateChartLabelsAction = chartengine.UpdateChartLabelsAction
+	UpdateChartAction       = chartengine.UpdateChartAction
+	UpdateDimensionValue    = chartengine.UpdateDimensionValue
+	RemoveDimensionAction   = chartengine.RemoveDimensionAction
+	RemoveChartAction       = chartengine.RemoveChartAction
 )

--- a/src/go/plugin/framework/chartengine/actions.go
+++ b/src/go/plugin/framework/chartengine/actions.go
@@ -12,6 +12,7 @@ type ActionKind uint8
 const (
 	ActionCreateChart ActionKind = iota + 1
 	ActionCreateDimension
+	ActionUpdateChartLabels
 	ActionUpdateChart
 	ActionRemoveDimension
 	ActionRemoveChart
@@ -45,6 +46,15 @@ type CreateDimensionAction struct {
 }
 
 func (a CreateDimensionAction) Kind() ActionKind { return ActionCreateDimension }
+
+// UpdateChartLabelsAction replaces the non-identity labels of one materialized chart.
+type UpdateChartLabelsAction struct {
+	ChartID string
+	Meta    program.ChartMeta
+	Labels  map[string]string
+}
+
+func (a UpdateChartLabelsAction) Kind() ActionKind { return ActionUpdateChartLabels }
 
 // UpdateDimensionValue carries one resolved value for UPDATE emission.
 type UpdateDimensionValue struct {

--- a/src/go/plugin/framework/chartengine/lifecycle.go
+++ b/src/go/plugin/framework/chartengine/lifecycle.go
@@ -24,14 +24,11 @@ type materializedChartState struct {
 }
 
 // materializedChartPresentation uses copy-on-write for ordered dimensions,
-// canonical labels, and membership. labelScratch is non-semantic reconciler
-// storage: observations are cleared before PreparePlan returns and retained
-// capacity follows current, not historical, membership.
+// canonical labels, and exact series membership.
 type materializedChartPresentation struct {
 	orderedDims     []string
 	labelValues     map[string]string
 	labelMembership []chartLabelMembership
-	labelScratch    *chartLabelScratch
 }
 
 // materializedDimensionState tracks one materialized dimension in a chart.
@@ -231,7 +228,6 @@ func (c *materializedChartState) pruneScratchEntries(currentSeq uint64) {
 func (c *materializedChartState) replaceLabels(
 	values map[string]string,
 	membership []chartLabelMembership,
-	scratch *chartLabelScratch,
 ) {
 	next := materializedChartPresentation{}
 	if c.presentation != nil {
@@ -239,7 +235,15 @@ func (c *materializedChartState) replaceLabels(
 	}
 	next.labelValues = values
 	next.labelMembership = membership
-	next.labelScratch = scratch
+	c.presentation = &next
+}
+
+func (c *materializedChartState) replaceLabelMembership(membership []chartLabelMembership) {
+	next := materializedChartPresentation{}
+	if c.presentation != nil {
+		next = *c.presentation
+	}
+	next.labelMembership = membership
 	c.presentation = &next
 }
 

--- a/src/go/plugin/framework/chartengine/lifecycle.go
+++ b/src/go/plugin/framework/chartengine/lifecycle.go
@@ -18,9 +18,19 @@ type materializedChartState struct {
 	lifecycle          program.LifecyclePolicy
 	lastSeenSuccessSeq uint64
 	dimensions         map[string]*materializedDimensionState
-	orderedDims        []string
+	presentation       *materializedChartPresentation
 	orderedDimsDirty   bool
 	scratchEntries     map[string]*dimBuildEntry
+}
+
+// materializedChartPresentation is an immutable, copy-on-write snapshot of
+// derived chart presentation state. Transactional clones can share it until
+// dimension ordering or labels change.
+type materializedChartPresentation struct {
+	orderedDims     []string
+	labelValues     map[string]string
+	labelMembership []chartLabelMembership
+	labelScratch    *chartLabelScratch
 }
 
 // materializedDimensionState tracks one materialized dimension in a chart.
@@ -69,7 +79,7 @@ func (c *materializedChartState) clone() *materializedChartState {
 		meta:               c.meta,
 		lifecycle:          c.lifecycle,
 		lastSeenSuccessSeq: c.lastSeenSuccessSeq,
-		orderedDims:        append([]string(nil), c.orderedDims...),
+		presentation:       c.presentation,
 		orderedDimsDirty:   c.orderedDimsDirty,
 	}
 	if len(c.dimensions) > 0 {
@@ -108,7 +118,7 @@ func (s *materializedState) ensureChart(
 		if chart.templateID != templateID {
 			chart.templateID = templateID
 			chart.dimensions = make(map[string]*materializedDimensionState)
-			chart.orderedDims = nil
+			chart.presentation = nil
 			chart.orderedDimsDirty = false
 			chart.scratchEntries = nil
 		}
@@ -166,12 +176,17 @@ func (c *materializedChartState) removeDimension(name string) {
 }
 
 func (c *materializedChartState) orderedDimensionNames() []string {
-	if !c.orderedDimsDirty && len(c.orderedDims) == len(c.dimensions) {
-		return c.orderedDims
+	if !c.orderedDimsDirty && c.presentation != nil && len(c.presentation.orderedDims) == len(c.dimensions) {
+		return c.presentation.orderedDims
 	}
-	c.orderedDims = orderedMaterializedDimensionNames(c.dimensions)
+	next := materializedChartPresentation{}
+	if c.presentation != nil {
+		next = *c.presentation
+	}
+	next.orderedDims = orderedMaterializedDimensionNames(c.dimensions)
+	c.presentation = &next
 	c.orderedDimsDirty = false
-	return c.orderedDims
+	return c.presentation.orderedDims
 }
 
 func (c *materializedChartState) checkoutScratchEntries(dimCap int) map[string]*dimBuildEntry {
@@ -179,6 +194,13 @@ func (c *materializedChartState) checkoutScratchEntries(dimCap int) map[string]*
 		return c.scratchEntries
 	}
 	c.scratchEntries = make(map[string]*dimBuildEntry, dimCap)
+	return c.scratchEntries
+}
+
+func (c *materializedChartState) dimensionScratchEntries() map[string]*dimBuildEntry {
+	if c == nil {
+		return nil
+	}
 	return c.scratchEntries
 }
 
@@ -203,6 +225,21 @@ func (c *materializedChartState) pruneScratchEntries(currentSeq uint64) {
 		}
 		delete(c.scratchEntries, name)
 	}
+}
+
+func (c *materializedChartState) replaceLabels(
+	values map[string]string,
+	membership []chartLabelMembership,
+	scratch *chartLabelScratch,
+) {
+	next := materializedChartPresentation{}
+	if c.presentation != nil {
+		next = *c.presentation
+	}
+	next.labelValues = values
+	next.labelMembership = membership
+	next.labelScratch = scratch
+	c.presentation = &next
 }
 
 func shouldExpire(lastSeenSuccessSeq, currentSuccessSeq uint64, expireAfterCycles int) bool {

--- a/src/go/plugin/framework/chartengine/lifecycle.go
+++ b/src/go/plugin/framework/chartengine/lifecycle.go
@@ -23,9 +23,10 @@ type materializedChartState struct {
 	scratchEntries     map[string]*dimBuildEntry
 }
 
-// materializedChartPresentation is an immutable, copy-on-write snapshot of
-// derived chart presentation state. Transactional clones can share it until
-// dimension ordering or labels change.
+// materializedChartPresentation uses copy-on-write for ordered dimensions,
+// canonical labels, and membership. labelScratch is non-semantic reconciler
+// storage: observations are cleared before PreparePlan returns and retained
+// capacity follows current, not historical, membership.
 type materializedChartPresentation struct {
 	orderedDims     []string
 	labelValues     map[string]string

--- a/src/go/plugin/framework/chartengine/matcher.go
+++ b/src/go/plugin/framework/chartengine/matcher.go
@@ -38,6 +38,8 @@ type routeCandidate struct {
 
 type matchIndex struct {
 	chartsByID       map[string]program.Chart
+	labelPolicies    map[string]*chartLabelPolicy
+	autogenLabels    *chartLabelPolicy
 	byMetricName     map[string][]routeCandidate
 	wildcardMatchers []routeCandidate
 }
@@ -45,12 +47,15 @@ type matchIndex struct {
 func buildMatchIndex(charts []program.Chart) matchIndex {
 	index := matchIndex{
 		chartsByID:       make(map[string]program.Chart, len(charts)),
+		labelPolicies:    make(map[string]*chartLabelPolicy, len(charts)),
+		autogenLabels:    compileAutogenChartLabelPolicy(),
 		byMetricName:     make(map[string][]routeCandidate),
 		wildcardMatchers: make([]routeCandidate, 0),
 	}
 
 	for _, chart := range charts {
 		index.chartsByID[chart.TemplateID] = chart
+		index.labelPolicies[chart.TemplateID] = compileChartLabelPolicy(chart)
 		for i, dim := range chart.Dimensions {
 			candidate := routeCandidate{
 				chartTemplateID: chart.TemplateID,

--- a/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartengine
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+)
+
+var benchmarkMutableLabelPlanSink Plan
+
+func BenchmarkBuildPlanMutableLabels(b *testing.B) {
+	for _, chartCount := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("unchanged_chart_scaling/charts_%d/labels_4", chartCount), func(b *testing.B) {
+			reader := newBenchmarkMutableLabelReader(b, chartCount, 1, 4, nil)
+			benchmarkMutableLabelPlanning(b, chartCount, 1, 4, reader)
+		})
+	}
+
+	for _, labelCount := range []int{0, 4, 16, 64} {
+		b.Run(fmt.Sprintf("unchanged_label_scaling/charts_100/dims_10/labels_%d", labelCount), func(b *testing.B) {
+			reader := newBenchmarkMutableLabelReader(b, 100, 10, labelCount, nil)
+			benchmarkMutableLabelPlanning(b, 100, 10, labelCount, reader)
+		})
+	}
+
+	for _, shape := range []struct {
+		charts int
+		dims   int
+	}{
+		{charts: 1000, dims: 1},
+		{charts: 100, dims: 10},
+		{charts: 1, dims: 1000},
+	} {
+		b.Run(fmt.Sprintf("unchanged_shape/charts_%d/dims_%d/labels_4", shape.charts, shape.dims), func(b *testing.B) {
+			reader := newBenchmarkMutableLabelReader(b, shape.charts, shape.dims, 4, nil)
+			benchmarkMutableLabelPlanning(b, shape.charts, shape.dims, 4, reader)
+		})
+	}
+
+	b.Run("one_changed/charts_1000/dims_10/labels_4", func(b *testing.B) {
+		base := newBenchmarkMutableLabelReader(b, 1000, 10, 4, nil)
+		changed := newBenchmarkMutableLabelReader(b, 1000, 10, 4, func(chart int) bool { return chart == 0 })
+		benchmarkMutableLabelPlanning(b, 1000, 10, 4, base, changed)
+	})
+
+	b.Run("all_changed/charts_1000/dims_10/labels_4", func(b *testing.B) {
+		base := newBenchmarkMutableLabelReader(b, 1000, 10, 4, nil)
+		changed := newBenchmarkMutableLabelReader(b, 1000, 10, 4, func(int) bool { return true })
+		benchmarkMutableLabelPlanning(b, 1000, 10, 4, base, changed)
+	})
+}
+
+func BenchmarkBuildPlanMutableLabelsCreate(b *testing.B) {
+	for _, chartCount := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("charts_%d/labels_4", chartCount), func(b *testing.B) {
+			reader := newBenchmarkMutableLabelReader(b, chartCount, 1, 4, nil)
+			template := benchmarkMutableLabelTemplate(4)
+			engine, err := New(WithRuntimeStore(nil))
+			if err != nil {
+				b.Fatalf("new engine: %v", err)
+			}
+			if err := engine.LoadYAML(template, 1); err != nil {
+				b.Fatalf("load template: %v", err)
+			}
+			if _, err := buildPlan(engine, reader); err != nil {
+				b.Fatalf("warm routes: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.ReportMetric(float64(chartCount), "charts/op")
+			b.ReportMetric(float64(chartCount), "dims/op")
+			b.ReportMetric(float64(chartCount*4), "promoted_label_entries/op")
+			b.ReportMetric(float64(chartCount), "series/op")
+			for i := range b.N {
+				b.StopTimer()
+				engine.ResetMaterialized()
+				reader.seq = uint64(i) + 2
+				b.StartTimer()
+
+				plan, err := buildPlan(engine, reader)
+				if err != nil {
+					b.Fatalf("build creation plan: %v", err)
+				}
+				benchmarkMutableLabelPlanSink = plan
+			}
+			b.StopTimer()
+			benchmarkAssertActionMix(b, benchmarkMutableLabelPlanSink, chartCount, chartCount, chartCount)
+		})
+	}
+}
+
+func benchmarkMutableLabelPlanning(b *testing.B, chartCount, dimsPerChart, labelCount int, readers ...*benchmarkSequenceReader) {
+	b.Helper()
+	if len(readers) == 0 {
+		b.Fatal("at least one reader is required")
+	}
+
+	engine, err := New(WithRuntimeStore(nil))
+	if err != nil {
+		b.Fatalf("new engine: %v", err)
+	}
+	if err := engine.LoadYAML(benchmarkMutableLabelTemplate(labelCount), 1); err != nil {
+		b.Fatalf("load template: %v", err)
+	}
+	initial, err := buildPlan(engine, readers[0])
+	if err != nil {
+		b.Fatalf("materialize charts: %v", err)
+	}
+	benchmarkAssertActionMix(b, initial, chartCount, chartCount*dimsPerChart, chartCount)
+	for _, reader := range readers {
+		reader.raw.ForEachSeriesIdentityRaw(func(metrix.SeriesIdentity, metrix.SeriesMeta, string, []metrix.Label, metrix.SampleValue) {})
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.ReportMetric(float64(chartCount), "charts/op")
+	b.ReportMetric(float64(chartCount*dimsPerChart), "dims/op")
+	b.ReportMetric(float64(chartCount*dimsPerChart*labelCount), "promoted_label_entries/op")
+	b.ReportMetric(float64(chartCount*dimsPerChart), "series/op")
+	for i := range b.N {
+		reader := readers[0]
+		if len(readers) > 1 && i%2 == 0 {
+			reader = readers[1+(i/2)%(len(readers)-1)]
+		}
+		reader.seq = uint64(i) + 2
+		plan, err := buildPlan(engine, reader)
+		if err != nil {
+			b.Fatalf("build steady-state plan: %v", err)
+		}
+		benchmarkMutableLabelPlanSink = plan
+	}
+	b.StopTimer()
+	benchmarkAssertActionMix(b, benchmarkMutableLabelPlanSink, 0, 0, chartCount)
+}
+
+type benchmarkSequenceReader struct {
+	metrix.Reader
+	raw metrix.SeriesIdentityRawIterator
+	seq uint64
+}
+
+func (r *benchmarkSequenceReader) CollectMeta() metrix.CollectMeta {
+	meta := r.Reader.CollectMeta()
+	meta.LastAttemptSeq = r.seq
+	meta.LastAttemptStatus = metrix.CollectStatusSuccess
+	meta.LastSuccessSeq = r.seq
+	return meta
+}
+
+func (r *benchmarkSequenceReader) ForEachSeriesIdentity(fn func(metrix.SeriesIdentity, metrix.SeriesMeta, string, metrix.LabelView, metrix.SampleValue)) {
+	r.Reader.ForEachSeriesIdentity(func(identity metrix.SeriesIdentity, meta metrix.SeriesMeta, name string, labels metrix.LabelView, value metrix.SampleValue) {
+		meta.LastSeenSuccessSeq = r.seq
+		fn(identity, meta, name, labels, value)
+	})
+}
+
+func (r *benchmarkSequenceReader) ForEachSeriesIdentityRaw(fn func(metrix.SeriesIdentity, metrix.SeriesMeta, string, []metrix.Label, metrix.SampleValue)) {
+	r.raw.ForEachSeriesIdentityRaw(func(identity metrix.SeriesIdentity, meta metrix.SeriesMeta, name string, labels []metrix.Label, value metrix.SampleValue) {
+		meta.LastSeenSuccessSeq = r.seq
+		fn(identity, meta, name, labels, value)
+	})
+}
+
+func (r *benchmarkSequenceReader) FlattenedRead() bool {
+	aware, ok := r.Reader.(interface{ FlattenedRead() bool })
+	return ok && aware.FlattenedRead()
+}
+
+func newBenchmarkMutableLabelReader(b *testing.B, chartCount, dimsPerChart, labelCount int, changed func(int) bool) *benchmarkSequenceReader {
+	b.Helper()
+	store := metrix.NewCollectorStore()
+	managed, ok := metrix.AsCycleManagedStore(store)
+	if !ok {
+		b.Fatal("collector store is not cycle-managed")
+	}
+	cc := managed.CycleController()
+	meter := store.Write().SnapshotMeter("")
+	gauge := meter.Gauge("bench_metric")
+
+	cc.BeginCycle()
+	for chart := range chartCount {
+		for dimension := range dimsPerChart {
+			labels := make([]metrix.Label, 0, labelCount+2)
+			labels = append(labels,
+				metrix.Label{Key: "chart_id", Value: strconv.Itoa(chart)},
+				metrix.Label{Key: "dim_id", Value: strconv.Itoa(dimension)},
+			)
+			for label := range labelCount {
+				value := "base_" + strconv.Itoa(label)
+				if changed != nil && changed(chart) {
+					value = "next_" + strconv.Itoa(label)
+				}
+				labels = append(labels, metrix.Label{Key: fmt.Sprintf("label_%02d", label), Value: value})
+			}
+			gauge.Observe(metrix.SampleValue(chart*dimsPerChart+dimension), meter.LabelSet(labels...))
+		}
+	}
+	if err := cc.CommitCycleSuccess(); err != nil {
+		b.Fatalf("commit benchmark cycle: %v", err)
+	}
+	reader := store.Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	raw, ok := reader.(metrix.SeriesIdentityRawIterator)
+	if !ok {
+		b.Fatal("benchmark reader does not support raw identity iteration")
+	}
+	return &benchmarkSequenceReader{Reader: reader, raw: raw, seq: 1}
+}
+
+func benchmarkMutableLabelTemplate(labelCount int) []byte {
+	var sb strings.Builder
+	sb.WriteString("version: v1\n" +
+		"groups:\n" +
+		"  - family: Bench\n" +
+		"    metrics: [bench_metric]\n" +
+		"    charts:\n" +
+		"      - id: bench\n" +
+		"        title: Bench metric\n" +
+		"        context: bench.metric\n" +
+		"        units: units\n" +
+		"        instances:\n" +
+		"          by_labels: [chart_id]\n")
+	if labelCount > 0 {
+		sb.WriteString("        label_promotion:\n")
+		for label := range labelCount {
+			fmt.Fprintf(&sb, "          - label_%02d\n", label)
+		}
+	}
+	sb.WriteString("        dimensions:\n" +
+		"          - selector: bench_metric\n" +
+		"            name_from_label: dim_id\n")
+	return []byte(sb.String())
+}
+
+func benchmarkActionKindCount(plan Plan, kind ActionKind) int {
+	var count int
+	for _, action := range plan.Actions {
+		if action.Kind() == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func benchmarkAssertActionMix(b *testing.B, plan Plan, createCharts, createDimensions, updateCharts int) {
+	b.Helper()
+	wantTotal := createCharts + createDimensions + updateCharts
+	if len(plan.Actions) != wantTotal {
+		b.Fatalf("actions = %d, want %d", len(plan.Actions), wantTotal)
+	}
+	expected := map[ActionKind]int{
+		ActionCreateChart:     createCharts,
+		ActionCreateDimension: createDimensions,
+		ActionUpdateChart:     updateCharts,
+		ActionRemoveDimension: 0,
+		ActionRemoveChart:     0,
+	}
+	for kind, want := range expected {
+		if got := benchmarkActionKindCount(plan, kind); got != want {
+			b.Fatalf("action kind %d count = %d, want %d", kind, got, want)
+		}
+	}
+}

--- a/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
@@ -42,17 +42,25 @@ func BenchmarkBuildPlanMutableLabels(b *testing.B) {
 		})
 	}
 
-	b.Run("one_changed/charts_1000/dims_10/labels_4", func(b *testing.B) {
-		base := newBenchmarkMutableLabelReader(b, 1000, 10, 4, nil)
-		changed := newBenchmarkMutableLabelReader(b, 1000, 10, 4, func(chart int) bool { return chart == 0 })
-		benchmarkMutableLabelPlanning(b, 1000, 10, 4, 1, base, changed)
-	})
+	for _, labelCount := range []int{4, 16, 64} {
+		b.Run(fmt.Sprintf("one_changed/charts_1000/dims_10/labels_%d", labelCount), func(b *testing.B) {
+			base := newBenchmarkMutableLabelReader(b, 1000, 10, labelCount, nil)
+			changed := newBenchmarkMutableLabelReader(b, 1000, 10, labelCount, func(chart int) bool { return chart == 0 })
+			benchmarkMutableLabelPlanning(b, 1000, 10, labelCount, 1, base, changed)
+		})
 
-	b.Run("all_changed/charts_1000/dims_10/labels_4", func(b *testing.B) {
-		base := newBenchmarkMutableLabelReader(b, 1000, 10, 4, nil)
-		changed := newBenchmarkMutableLabelReader(b, 1000, 10, 4, func(int) bool { return true })
-		benchmarkMutableLabelPlanning(b, 1000, 10, 4, 1000, base, changed)
-	})
+		b.Run(fmt.Sprintf("all_changed/charts_1000/dims_10/labels_%d", labelCount), func(b *testing.B) {
+			base := newBenchmarkMutableLabelReader(b, 1000, 10, labelCount, nil)
+			changed := newBenchmarkMutableLabelReader(b, 1000, 10, labelCount, func(int) bool { return true })
+			benchmarkMutableLabelPlanning(b, 1000, 10, labelCount, 1000, base, changed)
+		})
+
+		b.Run(fmt.Sprintf("membership_changed_effective_labels_unchanged/charts_1000/dims_10/labels_%d", labelCount), func(b *testing.B) {
+			base := newBenchmarkMutableLabelReaderWithMembershipChange(b, 1000, 10, labelCount, func(int) bool { return false })
+			changed := newBenchmarkMutableLabelReaderWithMembershipChange(b, 1000, 10, labelCount, func(chart int) bool { return chart == 0 })
+			benchmarkMutableLabelPlanning(b, 1000, 10, labelCount, 0, base, changed)
+		})
+	}
 }
 
 func BenchmarkBuildPlanMutableLabelsCreate(b *testing.B) {
@@ -173,6 +181,27 @@ func (r *benchmarkSequenceReader) FlattenedRead() bool {
 }
 
 func newBenchmarkMutableLabelReader(b *testing.B, chartCount, dimsPerChart, labelCount int, changed func(int) bool) *benchmarkSequenceReader {
+	return newBenchmarkMutableLabelReaderWithMutations(b, chartCount, dimsPerChart, labelCount, changed, nil)
+}
+
+func newBenchmarkMutableLabelReaderWithMembershipChange(
+	b *testing.B,
+	chartCount,
+	dimsPerChart,
+	labelCount int,
+	changed func(int) bool,
+) *benchmarkSequenceReader {
+	return newBenchmarkMutableLabelReaderWithMutations(b, chartCount, dimsPerChart, labelCount, nil, changed)
+}
+
+func newBenchmarkMutableLabelReaderWithMutations(
+	b *testing.B,
+	chartCount,
+	dimsPerChart,
+	labelCount int,
+	promotedChanged func(int) bool,
+	membershipChanged func(int) bool,
+) *benchmarkSequenceReader {
 	b.Helper()
 	store := metrix.NewCollectorStore()
 	managed, ok := metrix.AsCycleManagedStore(store)
@@ -191,9 +220,16 @@ func newBenchmarkMutableLabelReader(b *testing.B, chartCount, dimsPerChart, labe
 				metrix.Label{Key: "chart_id", Value: strconv.Itoa(chart)},
 				metrix.Label{Key: "dim_id", Value: strconv.Itoa(dimension)},
 			)
+			if membershipChanged != nil {
+				value := "base"
+				if membershipChanged(chart) {
+					value = "next"
+				}
+				labels = append(labels, metrix.Label{Key: "membership_marker", Value: value})
+			}
 			for label := range labelCount {
 				value := "base_" + strconv.Itoa(label)
-				if changed != nil && changed(chart) {
+				if promotedChanged != nil && promotedChanged(chart) {
 					value = "next_" + strconv.Itoa(label)
 				}
 				labels = append(labels, metrix.Label{Key: fmt.Sprintf("label_%02d", label), Value: value})

--- a/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
@@ -19,6 +19,12 @@ func BenchmarkBuildPlanMutableLabels(b *testing.B) {
 			reader := newBenchmarkMutableLabelReader(b, chartCount, 1, 4, nil)
 			benchmarkMutableLabelPlanning(b, chartCount, 1, 4, 0, reader)
 		})
+
+		b.Run(fmt.Sprintf("one_changed_unrelated_series_scaling/charts_%d/labels_4", chartCount), func(b *testing.B) {
+			base := newBenchmarkMutableLabelReader(b, chartCount, 1, 4, nil)
+			changed := newBenchmarkMutableLabelReader(b, chartCount, 1, 4, func(chart int) bool { return chart == 0 })
+			benchmarkMutableLabelPlanning(b, chartCount, 1, 4, 1, base, changed)
+		})
 	}
 
 	for _, labelCount := range []int{0, 4, 16, 64} {

--- a/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
@@ -27,6 +27,22 @@ func BenchmarkBuildPlanMutableLabels(b *testing.B) {
 		})
 	}
 
+	for _, seriesCount := range []int{100, 1000, 10000} {
+		chartCount := seriesCount / 2
+		b.Run(fmt.Sprintf("unchanged_later_membership_shape/series_%d/charts_%d/dims_2/labels_4", seriesCount, chartCount), func(b *testing.B) {
+			reader := newBenchmarkMutableLabelReader(b, chartCount, 2, 4, nil)
+			benchmarkMutableLabelPlanning(b, chartCount, 2, 4, 0, reader)
+		})
+
+		b.Run(fmt.Sprintf("later_membership_changed_unrelated_series_scaling/series_%d/charts_%d/dims_2/labels_4", seriesCount, chartCount), func(b *testing.B) {
+			base := newBenchmarkMutableLabelReaderWithSeriesMembershipChange(b, chartCount, 2, 4, func(int, int) bool { return false })
+			changed := newBenchmarkMutableLabelReaderWithSeriesMembershipChange(b, chartCount, 2, 4, func(chart, dimension int) bool {
+				return chart == 0 && dimension == 1
+			})
+			benchmarkMutableLabelPlanning(b, chartCount, 2, 4, 0, base, changed)
+		})
+	}
+
 	for _, labelCount := range []int{0, 4, 16, 64} {
 		b.Run(fmt.Sprintf("unchanged_label_scaling/charts_100/dims_10/labels_%d", labelCount), func(b *testing.B) {
 			reader := newBenchmarkMutableLabelReader(b, 100, 10, labelCount, nil)
@@ -187,7 +203,11 @@ func (r *benchmarkSequenceReader) FlattenedRead() bool {
 }
 
 func newBenchmarkMutableLabelReader(b *testing.B, chartCount, dimsPerChart, labelCount int, changed func(int) bool) *benchmarkSequenceReader {
-	return newBenchmarkMutableLabelReaderWithMutations(b, chartCount, dimsPerChart, labelCount, changed, nil)
+	var promotedChanged func(int, int) bool
+	if changed != nil {
+		promotedChanged = func(chart, _ int) bool { return changed(chart) }
+	}
+	return newBenchmarkMutableLabelReaderWithMutations(b, chartCount, dimsPerChart, labelCount, promotedChanged, nil)
 }
 
 func newBenchmarkMutableLabelReaderWithMembershipChange(
@@ -197,6 +217,20 @@ func newBenchmarkMutableLabelReaderWithMembershipChange(
 	labelCount int,
 	changed func(int) bool,
 ) *benchmarkSequenceReader {
+	var membershipChanged func(int, int) bool
+	if changed != nil {
+		membershipChanged = func(chart, _ int) bool { return changed(chart) }
+	}
+	return newBenchmarkMutableLabelReaderWithMutations(b, chartCount, dimsPerChart, labelCount, nil, membershipChanged)
+}
+
+func newBenchmarkMutableLabelReaderWithSeriesMembershipChange(
+	b *testing.B,
+	chartCount,
+	dimsPerChart,
+	labelCount int,
+	changed func(chart, dimension int) bool,
+) *benchmarkSequenceReader {
 	return newBenchmarkMutableLabelReaderWithMutations(b, chartCount, dimsPerChart, labelCount, nil, changed)
 }
 
@@ -205,8 +239,8 @@ func newBenchmarkMutableLabelReaderWithMutations(
 	chartCount,
 	dimsPerChart,
 	labelCount int,
-	promotedChanged func(int) bool,
-	membershipChanged func(int) bool,
+	promotedChanged func(int, int) bool,
+	membershipChanged func(int, int) bool,
 ) *benchmarkSequenceReader {
 	b.Helper()
 	store := metrix.NewCollectorStore()
@@ -228,14 +262,14 @@ func newBenchmarkMutableLabelReaderWithMutations(
 			)
 			if membershipChanged != nil {
 				value := "base"
-				if membershipChanged(chart) {
+				if membershipChanged(chart, dimension) {
 					value = "next"
 				}
 				labels = append(labels, metrix.Label{Key: "membership_marker", Value: value})
 			}
 			for label := range labelCount {
 				value := "base_" + strconv.Itoa(label)
-				if promotedChanged != nil && promotedChanged(chart) {
+				if promotedChanged != nil && promotedChanged(chart, dimension) {
 					value = "next_" + strconv.Itoa(label)
 				}
 				labels = append(labels, metrix.Label{Key: fmt.Sprintf("label_%02d", label), Value: value})

--- a/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_bench_test.go
@@ -17,14 +17,14 @@ func BenchmarkBuildPlanMutableLabels(b *testing.B) {
 	for _, chartCount := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprintf("unchanged_chart_scaling/charts_%d/labels_4", chartCount), func(b *testing.B) {
 			reader := newBenchmarkMutableLabelReader(b, chartCount, 1, 4, nil)
-			benchmarkMutableLabelPlanning(b, chartCount, 1, 4, reader)
+			benchmarkMutableLabelPlanning(b, chartCount, 1, 4, 0, reader)
 		})
 	}
 
 	for _, labelCount := range []int{0, 4, 16, 64} {
 		b.Run(fmt.Sprintf("unchanged_label_scaling/charts_100/dims_10/labels_%d", labelCount), func(b *testing.B) {
 			reader := newBenchmarkMutableLabelReader(b, 100, 10, labelCount, nil)
-			benchmarkMutableLabelPlanning(b, 100, 10, labelCount, reader)
+			benchmarkMutableLabelPlanning(b, 100, 10, labelCount, 0, reader)
 		})
 	}
 
@@ -38,20 +38,20 @@ func BenchmarkBuildPlanMutableLabels(b *testing.B) {
 	} {
 		b.Run(fmt.Sprintf("unchanged_shape/charts_%d/dims_%d/labels_4", shape.charts, shape.dims), func(b *testing.B) {
 			reader := newBenchmarkMutableLabelReader(b, shape.charts, shape.dims, 4, nil)
-			benchmarkMutableLabelPlanning(b, shape.charts, shape.dims, 4, reader)
+			benchmarkMutableLabelPlanning(b, shape.charts, shape.dims, 4, 0, reader)
 		})
 	}
 
 	b.Run("one_changed/charts_1000/dims_10/labels_4", func(b *testing.B) {
 		base := newBenchmarkMutableLabelReader(b, 1000, 10, 4, nil)
 		changed := newBenchmarkMutableLabelReader(b, 1000, 10, 4, func(chart int) bool { return chart == 0 })
-		benchmarkMutableLabelPlanning(b, 1000, 10, 4, base, changed)
+		benchmarkMutableLabelPlanning(b, 1000, 10, 4, 1, base, changed)
 	})
 
 	b.Run("all_changed/charts_1000/dims_10/labels_4", func(b *testing.B) {
 		base := newBenchmarkMutableLabelReader(b, 1000, 10, 4, nil)
 		changed := newBenchmarkMutableLabelReader(b, 1000, 10, 4, func(int) bool { return true })
-		benchmarkMutableLabelPlanning(b, 1000, 10, 4, base, changed)
+		benchmarkMutableLabelPlanning(b, 1000, 10, 4, 1000, base, changed)
 	})
 }
 
@@ -90,12 +90,12 @@ func BenchmarkBuildPlanMutableLabelsCreate(b *testing.B) {
 				benchmarkMutableLabelPlanSink = plan
 			}
 			b.StopTimer()
-			benchmarkAssertActionMix(b, benchmarkMutableLabelPlanSink, chartCount, chartCount, chartCount)
+			benchmarkAssertActionMix(b, benchmarkMutableLabelPlanSink, chartCount, chartCount, 0, chartCount)
 		})
 	}
 }
 
-func benchmarkMutableLabelPlanning(b *testing.B, chartCount, dimsPerChart, labelCount int, readers ...*benchmarkSequenceReader) {
+func benchmarkMutableLabelPlanning(b *testing.B, chartCount, dimsPerChart, labelCount, expectedLabelUpdates int, readers ...*benchmarkSequenceReader) {
 	b.Helper()
 	if len(readers) == 0 {
 		b.Fatal("at least one reader is required")
@@ -112,7 +112,7 @@ func benchmarkMutableLabelPlanning(b *testing.B, chartCount, dimsPerChart, label
 	if err != nil {
 		b.Fatalf("materialize charts: %v", err)
 	}
-	benchmarkAssertActionMix(b, initial, chartCount, chartCount*dimsPerChart, chartCount)
+	benchmarkAssertActionMix(b, initial, chartCount, chartCount*dimsPerChart, 0, chartCount)
 	for _, reader := range readers {
 		reader.raw.ForEachSeriesIdentityRaw(func(metrix.SeriesIdentity, metrix.SeriesMeta, string, []metrix.Label, metrix.SampleValue) {})
 	}
@@ -136,7 +136,7 @@ func benchmarkMutableLabelPlanning(b *testing.B, chartCount, dimsPerChart, label
 		benchmarkMutableLabelPlanSink = plan
 	}
 	b.StopTimer()
-	benchmarkAssertActionMix(b, benchmarkMutableLabelPlanSink, 0, 0, chartCount)
+	benchmarkAssertActionMix(b, benchmarkMutableLabelPlanSink, 0, 0, expectedLabelUpdates, chartCount)
 }
 
 type benchmarkSequenceReader struct {
@@ -247,18 +247,19 @@ func benchmarkActionKindCount(plan Plan, kind ActionKind) int {
 	return count
 }
 
-func benchmarkAssertActionMix(b *testing.B, plan Plan, createCharts, createDimensions, updateCharts int) {
+func benchmarkAssertActionMix(b *testing.B, plan Plan, createCharts, createDimensions, updateChartLabels, updateCharts int) {
 	b.Helper()
-	wantTotal := createCharts + createDimensions + updateCharts
+	wantTotal := createCharts + createDimensions + updateChartLabels + updateCharts
 	if len(plan.Actions) != wantTotal {
 		b.Fatalf("actions = %d, want %d", len(plan.Actions), wantTotal)
 	}
 	expected := map[ActionKind]int{
-		ActionCreateChart:     createCharts,
-		ActionCreateDimension: createDimensions,
-		ActionUpdateChart:     updateCharts,
-		ActionRemoveDimension: 0,
-		ActionRemoveChart:     0,
+		ActionCreateChart:       createCharts,
+		ActionCreateDimension:   createDimensions,
+		ActionUpdateChartLabels: updateChartLabels,
+		ActionUpdateChart:       updateCharts,
+		ActionRemoveDimension:   0,
+		ActionRemoveChart:       0,
 	}
 	for kind, want := range expected {
 		if got := benchmarkActionKindCount(plan, kind); got != want {

--- a/src/go/plugin/framework/chartengine/mutable_labels_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_test.go
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartengine
+
+import (
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const mutableLabelsTestTemplate = "version: v1\n" +
+	"groups:\n" +
+	"  - family: Service\n" +
+	"    metrics: [service_value]\n" +
+	"    charts:\n" +
+	"      - id: service\n" +
+	"        title: Service\n" +
+	"        context: service.value\n" +
+	"        units: value\n" +
+	"        instances:\n" +
+	"          by_labels: [instance]\n" +
+	"        label_promotion: [owner, zone]\n" +
+	"        dimensions:\n" +
+	"          - selector: service_value\n" +
+	"            name: value\n"
+
+func TestBuildPlanUpdatesMutableNonIdentityLabels(t *testing.T) {
+	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-a", "zone-a")
+	initial, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	create := findCreateChartAction(initial)
+	require.NotNil(t, create)
+	assert.Equal(t, map[string]string{
+		"instance": "node-1",
+		"owner":    "owner-a",
+		"zone":     "zone-a",
+	}, create.Labels)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-b", "")
+	changed, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{ActionUpdateChartLabels, ActionUpdateChart}, actionKinds(changed.Actions))
+	update := findUpdateChartLabelsAction(changed)
+	require.NotNil(t, update)
+	assert.Equal(t, create.ChartID, update.ChartID)
+	assert.Equal(t, map[string]string{
+		"instance": "node-1",
+		"owner":    "owner-b",
+	}, update.Labels)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-b", "")
+	unchanged, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{ActionUpdateChart}, actionKinds(unchanged.Actions))
+}
+
+func TestBuildPlanIdentityLabelChangeCreatesNewChart(t *testing.T) {
+	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-a", "")
+	initial, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	initialCreate := findCreateChartAction(initial)
+	require.NotNil(t, initialCreate)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-2", "owner-a", "")
+	changed, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{ActionCreateChart, ActionCreateDimension, ActionUpdateChart}, actionKinds(changed.Actions))
+	assert.Nil(t, findUpdateChartLabelsAction(changed))
+	nextCreate := findCreateChartAction(changed)
+	require.NotNil(t, nextCreate)
+	assert.NotEqual(t, initialCreate.ChartID, nextCreate.ChartID)
+}
+
+func TestBuildPlanMutableLabelUpdateRetriesAfterAbort(t *testing.T) {
+	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-a", "")
+	_, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-b", "")
+	reader := store.Read(metrix.ReadFlatten())
+	attempt, err := engine.PreparePlan(reader)
+	require.NoError(t, err)
+	require.NotNil(t, findUpdateChartLabelsAction(attempt.Plan()))
+	attempt.Abort()
+
+	retry, err := engine.PreparePlan(reader)
+	require.NoError(t, err)
+	require.NotNil(t, findUpdateChartLabelsAction(retry.Plan()))
+	require.NoError(t, retry.Commit())
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-b", "")
+	unchanged, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{ActionUpdateChart}, actionKinds(unchanged.Actions))
+}
+
+func TestBuildPlanReconcilesLabelsWhenSeriesMembershipChanges(t *testing.T) {
+	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+
+	observeMutableLabelSeries(t, cycle, meter, gauge,
+		mutableLabelSeries{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-a"},
+		mutableLabelSeries{instance: "node-1", owner: "owner-a", zone: "zone-b", shard: "shard-b"},
+	)
+	initial, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	create := findCreateChartAction(initial)
+	require.NotNil(t, create)
+	assert.Equal(t, map[string]string{
+		"instance": "node-1",
+		"owner":    "owner-a",
+	}, create.Labels)
+
+	observeMutableLabelSeries(t, cycle, meter, gauge,
+		mutableLabelSeries{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-a"},
+	)
+	expanded, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	update := findUpdateChartLabelsAction(expanded)
+	require.NotNil(t, update)
+	assert.Equal(t, map[string]string{
+		"instance": "node-1",
+		"owner":    "owner-a",
+		"zone":     "zone-a",
+	}, update.Labels)
+
+	// The series identity changes, but the effective promoted labels do not.
+	observeMutableLabelSeries(t, cycle, meter, gauge,
+		mutableLabelSeries{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-c"},
+	)
+	sameLabels, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{ActionUpdateChart}, actionKinds(sameLabels.Actions))
+
+	observeMutableLabelSeries(t, cycle, meter, gauge,
+		mutableLabelSeries{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-c"},
+	)
+	stable, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{ActionUpdateChart}, actionKinds(stable.Actions))
+}
+
+func TestBuildPlanDimensionIdentityChangeCreatesNewDimension(t *testing.T) {
+	engine, err := New(WithRuntimeStore(nil))
+	require.NoError(t, err)
+	require.NoError(t, engine.LoadYAML([]byte("version: v1\n"+
+		"groups:\n"+
+		"  - family: Service\n"+
+		"    metrics: [service_value]\n"+
+		"    charts:\n"+
+		"      - id: service\n"+
+		"        title: Service\n"+
+		"        context: service.value\n"+
+		"        units: value\n"+
+		"        instances:\n"+
+		"          by_labels: [instance]\n"+
+		"        label_promotion: [owner]\n"+
+		"        dimensions:\n"+
+		"          - selector: service_value\n"+
+		"            name_from_label: mode\n"), 1))
+
+	store := metrix.NewCollectorStore()
+	managed, ok := metrix.AsCycleManagedStore(store)
+	require.True(t, ok)
+	cycle := managed.CycleController()
+	meter := store.Write().SnapshotMeter("")
+	gauge := meter.Gauge("service_value")
+
+	observeMutableDimension(t, cycle, meter, gauge, "read")
+	initial, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	create := findCreateChartAction(initial)
+	require.NotNil(t, create)
+
+	observeMutableDimension(t, cycle, meter, gauge, "write")
+	changed, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{ActionCreateDimension, ActionUpdateChart}, actionKinds(changed.Actions))
+	assert.Nil(t, findUpdateChartLabelsAction(changed))
+	assert.Nil(t, findCreateChartAction(changed))
+	createDimension := changed.Actions[0].(CreateDimensionAction)
+	assert.Equal(t, create.ChartID, createDimension.ChartID)
+	assert.Equal(t, "write", createDimension.Name)
+}
+
+func TestBuildPlanMutableLabelsWithGenericReader(t *testing.T) {
+	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-a", "")
+	_, err := buildPlan(engine, genericMutableLabelReader{Reader: store.Read(metrix.ReadFlatten())})
+	require.NoError(t, err)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-b", "")
+	changed, err := buildPlan(engine, genericMutableLabelReader{Reader: store.Read(metrix.ReadFlatten())})
+	require.NoError(t, err)
+	update := findUpdateChartLabelsAction(changed)
+	require.NotNil(t, update)
+	assert.Equal(t, "owner-b", update.Labels["owner"])
+}
+
+type mutableLabelSeries struct {
+	instance string
+	owner    string
+	zone     string
+	shard    string
+}
+
+type genericMutableLabelReader struct {
+	metrix.Reader
+}
+
+func observeMutableLabelSeries(
+	t *testing.T,
+	cycle metrix.CycleController,
+	meter metrix.SnapshotMeter,
+	gauge metrix.SnapshotGauge,
+	series ...mutableLabelSeries,
+) {
+	t.Helper()
+	cycle.BeginCycle()
+	for _, item := range series {
+		gauge.Observe(1, meter.LabelSet(
+			metrix.Label{Key: "instance", Value: item.instance},
+			metrix.Label{Key: "owner", Value: item.owner},
+			metrix.Label{Key: "zone", Value: item.zone},
+			metrix.Label{Key: "shard", Value: item.shard},
+		))
+	}
+	require.NoError(t, cycle.CommitCycleSuccess())
+}
+
+func observeMutableDimension(
+	t *testing.T,
+	cycle metrix.CycleController,
+	meter metrix.SnapshotMeter,
+	gauge metrix.SnapshotGauge,
+	mode string,
+) {
+	t.Helper()
+	cycle.BeginCycle()
+	gauge.Observe(1, meter.LabelSet(
+		metrix.Label{Key: "instance", Value: "node-1"},
+		metrix.Label{Key: "owner", Value: "owner-a"},
+		metrix.Label{Key: "mode", Value: mode},
+	))
+	require.NoError(t, cycle.CommitCycleSuccess())
+}
+
+func newMutableLabelsTestState(t *testing.T) (*Engine, metrix.CollectorStore, metrix.CycleController, metrix.SnapshotMeter, metrix.SnapshotGauge) {
+	t.Helper()
+	engine, err := New(WithRuntimeStore(nil))
+	require.NoError(t, err)
+	require.NoError(t, engine.LoadYAML([]byte(mutableLabelsTestTemplate), 1))
+
+	store := metrix.NewCollectorStore()
+	managed, ok := metrix.AsCycleManagedStore(store)
+	require.True(t, ok)
+	meter := store.Write().SnapshotMeter("")
+	return engine, store, managed.CycleController(), meter, meter.Gauge("service_value")
+}
+
+func observeMutableLabels(t *testing.T, cycle metrix.CycleController, meter metrix.SnapshotMeter, gauge metrix.SnapshotGauge, instance, owner, zone string) {
+	t.Helper()
+	labels := []metrix.Label{
+		{Key: "instance", Value: instance},
+		{Key: "owner", Value: owner},
+	}
+	if zone != "" {
+		labels = append(labels, metrix.Label{Key: "zone", Value: zone})
+	}
+	cycle.BeginCycle()
+	gauge.Observe(1, meter.LabelSet(labels...))
+	require.NoError(t, cycle.CommitCycleSuccess())
+}
+
+func findUpdateChartLabelsAction(plan Plan) *UpdateChartLabelsAction {
+	for _, action := range plan.Actions {
+		if update, ok := action.(UpdateChartLabelsAction); ok {
+			return &update
+		}
+	}
+	return nil
+}

--- a/src/go/plugin/framework/chartengine/mutable_labels_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_test.go
@@ -312,6 +312,56 @@ func TestBuildPlanChangedFirstMembershipShrinksCanonicalCapacity(t *testing.T) {
 	}
 }
 
+func TestBuildPlanReplaysReaderOnlyAfterMatchingMembershipPrefix(t *testing.T) {
+	tests := map[string]struct {
+		changed        []mutableLabelSeries
+		wantIterations int
+	}{
+		"first member mismatch": {
+			changed: []mutableLabelSeries{
+				{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-0"},
+				{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-b"},
+			},
+			wantIterations: 1,
+		},
+		"later member mismatch": {
+			changed: []mutableLabelSeries{
+				{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-a"},
+				{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-z"},
+			},
+			wantIterations: 2,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+			initial := []mutableLabelSeries{
+				{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-a"},
+				{instance: "node-1", owner: "owner-a", zone: "zone-a", shard: "shard-b"},
+			}
+			observeMutableLabelSeries(t, cycle, meter, gauge, initial...)
+			_, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+			require.NoError(t, err)
+
+			observeMutableLabelSeries(t, cycle, meter, gauge, tc.changed...)
+			reader := newCountingMutableLabelReader(t, store.Read(metrix.ReadFlatten()))
+			plan, err := buildPlan(engine, reader)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantIterations, reader.iterations)
+			assert.Equal(t, []ActionKind{ActionUpdateChart}, actionKinds(plan.Actions))
+			chart := engine.state.materialized.charts["service_node-1"]
+			require.NotNil(t, chart)
+			require.NotNil(t, chart.presentation)
+			assert.Equal(t, map[string]string{
+				"instance": "node-1",
+				"owner":    "owner-a",
+				"zone":     "zone-a",
+			}, chart.presentation.labelValues)
+		})
+	}
+}
+
 func TestBuildPlanAbortedHighCardinalityProposalDoesNotEnterCommittedLabelState(t *testing.T) {
 	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
 
@@ -355,6 +405,24 @@ type mutableLabelSeries struct {
 
 type genericMutableLabelReader struct {
 	metrix.Reader
+}
+
+type countingMutableLabelReader struct {
+	metrix.Reader
+	raw        metrix.SeriesIdentityRawIterator
+	iterations int
+}
+
+func newCountingMutableLabelReader(t *testing.T, reader metrix.Reader) *countingMutableLabelReader {
+	t.Helper()
+	raw, ok := reader.(metrix.SeriesIdentityRawIterator)
+	require.True(t, ok)
+	return &countingMutableLabelReader{Reader: reader, raw: raw}
+}
+
+func (r *countingMutableLabelReader) ForEachSeriesIdentityRaw(fn func(metrix.SeriesIdentity, metrix.SeriesMeta, string, []metrix.Label, metrix.SampleValue)) {
+	r.iterations++
+	r.raw.ForEachSeriesIdentityRaw(fn)
 }
 
 func assertCanonicalLabelMembership(t *testing.T, engine *Engine, want int) {

--- a/src/go/plugin/framework/chartengine/mutable_labels_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_test.go
@@ -3,6 +3,7 @@
 package chartengine
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
@@ -90,6 +91,7 @@ func TestBuildPlanMutableLabelUpdateRetriesAfterAbort(t *testing.T) {
 	attempt, err := engine.PreparePlan(reader)
 	require.NoError(t, err)
 	require.NotNil(t, findUpdateChartLabelsAction(attempt.Plan()))
+	assertReleasedLabelObservations(t, engine, 2)
 	attempt.Abort()
 
 	retry, err := engine.PreparePlan(reader)
@@ -206,6 +208,55 @@ func TestBuildPlanMutableLabelsWithGenericReader(t *testing.T) {
 	assert.Equal(t, "owner-b", update.Labels["owner"])
 }
 
+func TestBuildPlanActionLabelsDoNotAliasCommittedState(t *testing.T) {
+	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-a", "")
+	initial, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	create := findCreateChartAction(initial)
+	require.NotNil(t, create)
+	create.Labels["owner"] = "owner-b"
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-b", "")
+	changed, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	update := findUpdateChartLabelsAction(changed)
+	require.NotNil(t, update)
+	assert.Equal(t, "owner-b", update.Labels["owner"])
+	update.Labels["owner"] = "owner-c"
+
+	observeMutableLabels(t, cycle, meter, gauge, "node-1", "owner-c", "")
+	changedAgain, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	updateAgain := findUpdateChartLabelsAction(changedAgain)
+	require.NotNil(t, updateAgain)
+	assert.Equal(t, "owner-c", updateAgain.Labels["owner"])
+}
+
+func TestBuildPlanReleasesRawLabelObservationsAfterCardinalityDrop(t *testing.T) {
+	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+
+	series := make([]mutableLabelSeries, 128)
+	for i := range series {
+		series[i] = mutableLabelSeries{
+			instance: "node-1",
+			owner:    "owner-a",
+			zone:     "zone-a",
+			shard:    fmt.Sprintf("shard-%03d", i),
+		}
+	}
+	observeMutableLabelSeries(t, cycle, meter, gauge, series...)
+	_, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assertReleasedLabelObservations(t, engine, 256)
+
+	observeMutableLabelSeries(t, cycle, meter, gauge, series[0])
+	_, err = buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assertReleasedLabelObservations(t, engine, 2)
+}
+
 type mutableLabelSeries struct {
 	instance string
 	owner    string
@@ -215,6 +266,22 @@ type mutableLabelSeries struct {
 
 type genericMutableLabelReader struct {
 	metrix.Reader
+}
+
+func assertReleasedLabelObservations(t *testing.T, engine *Engine, maxCapacity int) {
+	t.Helper()
+	chart := engine.state.materialized.charts["service_node-1"]
+	require.NotNil(t, chart)
+	require.NotNil(t, chart.presentation)
+	scratch := chart.presentation.labelScratch
+	require.NotNil(t, scratch)
+	assert.Zero(t, len(scratch.observations))
+	assert.LessOrEqual(t, cap(scratch.observations), maxCapacity)
+	for _, observation := range scratch.observations[:cap(scratch.observations)] {
+		assert.Empty(t, observation.seriesID)
+		assert.Empty(t, observation.dimensionKeyLabel)
+		assert.Nil(t, observation.rawLabels)
+	}
 }
 
 func observeMutableLabelSeries(

--- a/src/go/plugin/framework/chartengine/mutable_labels_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_test.go
@@ -273,6 +273,45 @@ func TestBuildPlanCanonicalMembershipTracksCurrentCardinality(t *testing.T) {
 	assertCanonicalLabelMembership(t, engine, 1)
 }
 
+func TestBuildPlanChangedFirstMembershipShrinksCanonicalCapacity(t *testing.T) {
+	tests := map[string]struct {
+		owner       string
+		wantUpdated bool
+	}{
+		"effective labels unchanged": {owner: "owner-a"},
+		"effective labels changed":   {owner: "owner-b", wantUpdated: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+
+			series := make([]mutableLabelSeries, 128)
+			for i := range series {
+				series[i] = mutableLabelSeries{
+					instance: "node-1",
+					owner:    "owner-a",
+					zone:     "zone-a",
+					shard:    fmt.Sprintf("shard-%03d", i),
+				}
+			}
+			observeMutableLabelSeries(t, cycle, meter, gauge, series...)
+			_, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+			require.NoError(t, err)
+			assertCanonicalLabelMembership(t, engine, 128)
+
+			changed := series[0]
+			changed.shard = "changed-first-member"
+			changed.owner = tc.owner
+			observeMutableLabelSeries(t, cycle, meter, gauge, changed)
+			plan, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantUpdated, findUpdateChartLabelsAction(plan) != nil)
+			assertCanonicalLabelMembership(t, engine, 1)
+		})
+	}
+}
+
 func TestBuildPlanAbortedHighCardinalityProposalDoesNotEnterCommittedLabelState(t *testing.T) {
 	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
 

--- a/src/go/plugin/framework/chartengine/mutable_labels_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_test.go
@@ -4,6 +4,7 @@ package chartengine
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
@@ -27,6 +28,16 @@ const mutableLabelsTestTemplate = "version: v1\n" +
 	"        dimensions:\n" +
 	"          - selector: service_value\n" +
 	"            name: value\n"
+
+func TestMaterializedChartPresentationDoesNotOwnMutableLabelWorkspace(t *testing.T) {
+	typ := reflect.TypeFor[materializedChartPresentation]()
+	fields := make([]string, 0, typ.NumField())
+	for i := range typ.NumField() {
+		fields = append(fields, typ.Field(i).Name)
+	}
+	assert.Equal(t, []string{"orderedDims", "labelValues", "labelMembership"}, fields,
+		"committed chart presentation must contain only semantic copy-on-write state")
+}
 
 func TestBuildPlanUpdatesMutableNonIdentityLabels(t *testing.T) {
 	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
@@ -91,7 +102,7 @@ func TestBuildPlanMutableLabelUpdateRetriesAfterAbort(t *testing.T) {
 	attempt, err := engine.PreparePlan(reader)
 	require.NoError(t, err)
 	require.NotNil(t, findUpdateChartLabelsAction(attempt.Plan()))
-	assertReleasedLabelObservations(t, engine, 2)
+	assertCanonicalLabelMembership(t, engine, 1)
 	attempt.Abort()
 
 	retry, err := engine.PreparePlan(reader)
@@ -234,7 +245,7 @@ func TestBuildPlanActionLabelsDoNotAliasCommittedState(t *testing.T) {
 	assert.Equal(t, "owner-c", updateAgain.Labels["owner"])
 }
 
-func TestBuildPlanReleasesRawLabelObservationsAfterCardinalityDrop(t *testing.T) {
+func TestBuildPlanCanonicalMembershipTracksCurrentCardinality(t *testing.T) {
 	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
 
 	series := make([]mutableLabelSeries, 128)
@@ -249,12 +260,51 @@ func TestBuildPlanReleasesRawLabelObservationsAfterCardinalityDrop(t *testing.T)
 	observeMutableLabelSeries(t, cycle, meter, gauge, series...)
 	_, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
-	assertReleasedLabelObservations(t, engine, 256)
+	assertCanonicalLabelMembership(t, engine, 128)
+
+	observeMutableLabelSeries(t, cycle, meter, gauge, series[:100]...)
+	_, err = buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assertCanonicalLabelMembership(t, engine, 100)
 
 	observeMutableLabelSeries(t, cycle, meter, gauge, series[0])
 	_, err = buildPlan(engine, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
-	assertReleasedLabelObservations(t, engine, 2)
+	assertCanonicalLabelMembership(t, engine, 1)
+}
+
+func TestBuildPlanAbortedHighCardinalityProposalDoesNotEnterCommittedLabelState(t *testing.T) {
+	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
+
+	series := make([]mutableLabelSeries, 128)
+	for i := range series {
+		series[i] = mutableLabelSeries{
+			instance: "node-1",
+			owner:    "owner-a",
+			zone:     "zone-a",
+			shard:    fmt.Sprintf("shard-%03d", i),
+		}
+	}
+	observeMutableLabelSeries(t, cycle, meter, gauge, series[0])
+	_, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assertCanonicalLabelMembership(t, engine, 1)
+
+	observeMutableLabelSeries(t, cycle, meter, gauge, series...)
+	attempt, err := engine.PreparePlan(store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assertCanonicalLabelMembership(t, engine, 1)
+	staged := attempt.state.materialized.charts["service_node-1"]
+	require.NotNil(t, staged)
+	require.NotNil(t, staged.presentation)
+	assert.Len(t, staged.presentation.labelMembership, 128)
+	attempt.Abort()
+
+	observeMutableLabelSeries(t, cycle, meter, gauge, series[0])
+	retry, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{ActionUpdateChart}, actionKinds(retry.Actions))
+	assertCanonicalLabelMembership(t, engine, 1)
 }
 
 type mutableLabelSeries struct {
@@ -268,19 +318,16 @@ type genericMutableLabelReader struct {
 	metrix.Reader
 }
 
-func assertReleasedLabelObservations(t *testing.T, engine *Engine, maxCapacity int) {
+func assertCanonicalLabelMembership(t *testing.T, engine *Engine, want int) {
 	t.Helper()
 	chart := engine.state.materialized.charts["service_node-1"]
 	require.NotNil(t, chart)
 	require.NotNil(t, chart.presentation)
-	scratch := chart.presentation.labelScratch
-	require.NotNil(t, scratch)
-	assert.Zero(t, len(scratch.observations))
-	assert.LessOrEqual(t, cap(scratch.observations), maxCapacity)
-	for _, observation := range scratch.observations[:cap(scratch.observations)] {
-		assert.Empty(t, observation.seriesID)
-		assert.Empty(t, observation.dimensionKeyLabel)
-		assert.Nil(t, observation.rawLabels)
+	assert.Len(t, chart.presentation.labelMembership, want)
+	assert.LessOrEqual(t, cap(chart.presentation.labelMembership), max(1, want*2))
+	for _, membership := range chart.presentation.labelMembership[len(chart.presentation.labelMembership):cap(chart.presentation.labelMembership)] {
+		assert.Empty(t, membership.seriesID)
+		assert.Empty(t, membership.dimensionKeyLabel)
 	}
 }
 

--- a/src/go/plugin/framework/chartengine/mutable_labels_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_test.go
@@ -32,8 +32,8 @@ const mutableLabelsTestTemplate = "version: v1\n" +
 func TestMaterializedChartPresentationDoesNotOwnMutableLabelWorkspace(t *testing.T) {
 	typ := reflect.TypeFor[materializedChartPresentation]()
 	fields := make([]string, 0, typ.NumField())
-	for i := range typ.NumField() {
-		fields = append(fields, typ.Field(i).Name)
+	for field := range typ.Fields() {
+		fields = append(fields, field.Name)
 	}
 	assert.Equal(t, []string{"orderedDims", "labelValues", "labelMembership"}, fields,
 		"committed chart presentation must contain only semantic copy-on-write state")

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -104,7 +104,7 @@ type chartState struct {
 	chartID         string
 	meta            program.ChartMeta
 	lifecycle       program.LifecyclePolicy
-	labelScratch    *chartLabelScratch
+	labelTracker    chartLabelTracker
 	entries         map[string]*dimBuildEntry
 	observedCount   int
 	currentBuildSeq uint64
@@ -196,7 +196,6 @@ func (e *Engine) preparePlan(reader metrix.Reader) (Plan, materializedState, uin
 		e.logWarningf("chartengine build prepare failed: %v", err)
 		return Plan{}, materializedState{}, 0, 0, 0, false, err
 	}
-	defer ctx.releaseLabelObservations()
 	phaseStartedAt = time.Now()
 	if err := validateBuildReaderForInferredDimensions(ctx.index, reader); err != nil {
 		sample.phaseValidateSeconds = time.Since(phaseStartedAt).Seconds()
@@ -275,18 +274,6 @@ func (e *Engine) preparePlan(reader metrix.Reader) (Plan, materializedState, uin
 	attemptID := e.nextAttemptIDLocked()
 	e.state.outstanding = attemptID
 	return out, staged, e.state.engineEpoch, e.state.commitSeq, attemptID, true, nil
-}
-
-func (ctx *planBuildContext) releaseLabelObservations() {
-	if ctx == nil {
-		return
-	}
-	for _, chart := range ctx.chartsByID {
-		if chart == nil || chart.labelScratch == nil {
-			continue
-		}
-		chart.labelScratch.releaseObservations()
-	}
 }
 
 func validateBuildReaderForInferredDimensions(index matchIndex, reader metrix.Reader) error {
@@ -381,30 +368,39 @@ func (e *Engine) preparePlanBuildContext(
 }
 
 func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
+	return e.forEachPlanSeriesRoute(ctx, false)
+}
+
+func (e *Engine) forEachPlanSeriesRoute(ctx *planBuildContext, replayLabels bool) error {
 	var firstErr error
 	buildSeq := ctx.collectMeta.LastSuccessSeq
+	trackStats := !replayLabels
 	process := func(
 		identity metrix.SeriesIdentity,
 		meta metrix.SeriesMeta,
 		name string,
 		labels metrix.LabelView,
-		rawLabels []metrix.Label,
-		raw bool,
 		v metrix.SampleValue,
 	) {
-		ctx.seriesScanned++
+		if trackStats {
+			ctx.seriesScanned++
+		}
 		if firstErr != nil {
 			return
 		}
 		if e.state.cfg.seriesSelection == seriesSelectionLastSuccessOnly &&
 			meta.LastSeenSuccessSeq != ctx.collectMeta.LastSuccessSeq {
-			ctx.seriesFilteredBySeq++
-			ctx.cache.MarkSeenIfPresent(identity, buildSeq)
+			if trackStats {
+				ctx.seriesFilteredBySeq++
+				ctx.cache.MarkSeenIfPresent(identity, buildSeq)
+			}
 			return
 		}
 		if selector := e.state.cfg.selector; selector != nil && !selector.Matches(name, labels) {
-			ctx.seriesFilteredBySel++
-			ctx.cache.MarkSeenIfPresent(identity, buildSeq)
+			if trackStats {
+				ctx.seriesFilteredBySel++
+				ctx.cache.MarkSeenIfPresent(identity, buildSeq)
+			}
 			return
 		}
 
@@ -423,12 +419,14 @@ func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 			firstErr = err
 			return
 		}
-		if hit {
-			e.addRouteCacheHit()
-			ctx.routeCacheHits++
-		} else {
-			e.addRouteCacheMiss()
-			ctx.routeCacheMisses++
+		if trackStats {
+			if hit {
+				e.addRouteCacheHit()
+				ctx.routeCacheHits++
+			} else {
+				e.addRouteCacheMiss()
+				ctx.routeCacheMisses++
+			}
 		}
 		if len(routes) == 0 {
 			autoRoutes, ok, err := e.resolveAutogenRoute(ctx.reader, name, labels, meta)
@@ -438,18 +436,33 @@ func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 			}
 			if ok {
 				routes = autoRoutes
-				ctx.seriesAutogenMatched++
-				ctx.seriesMatched++
+				if trackStats {
+					ctx.seriesAutogenMatched++
+					ctx.seriesMatched++
+				}
 			} else {
-				ctx.seriesUnmatched++
+				if trackStats {
+					ctx.seriesUnmatched++
+				}
 				return
 			}
-		} else {
+		} else if trackStats {
 			ctx.seriesMatched++
 		}
 
 		for _, route := range routes {
-			if err := ctx.accumulateRoute(ctx.index, route, identity, meta, labels, rawLabels, raw, v); err != nil {
+			if replayLabels {
+				chart := ctx.chartsByID[route.ChartID]
+				if chart == nil || chart.templateID != route.ChartTemplateID || !chart.labelTracker.needsReplay() {
+					continue
+				}
+				if err := chart.labelTracker.observeReplay(labels, route.DimensionKeyLabel); err != nil {
+					firstErr = err
+					return
+				}
+				continue
+			}
+			if err := ctx.accumulateRoute(ctx.index, route, identity, meta, labels, v); err != nil {
 				firstErr = err
 				return
 			}
@@ -460,13 +473,13 @@ func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 		view := &labelSliceView{}
 		rawIter.ForEachSeriesIdentityRaw(func(identity metrix.SeriesIdentity, meta metrix.SeriesMeta, name string, labels []metrix.Label, v metrix.SampleValue) {
 			view.items = labels
-			process(identity, meta, name, view, labels, true, v)
+			process(identity, meta, name, view, v)
 		})
 		return firstErr
 	}
 
 	ctx.flat.ForEachSeriesIdentity(func(identity metrix.SeriesIdentity, meta metrix.SeriesMeta, name string, labels metrix.LabelView, v metrix.SampleValue) {
-		process(identity, meta, name, labels, nil, false, v)
+		process(identity, meta, name, labels, v)
 	})
 	return firstErr
 }
@@ -477,8 +490,6 @@ func (ctx *planBuildContext) accumulateRoute(
 	identity metrix.SeriesIdentity,
 	seriesMeta metrix.SeriesMeta,
 	labels metrix.LabelView,
-	rawLabels []metrix.Label,
-	raw bool,
 	value metrix.SampleValue,
 ) error {
 	cs, exists := ctx.chartsByID[route.ChartID]
@@ -486,7 +497,6 @@ func (ctx *planBuildContext) accumulateRoute(
 		if !route.Autogen && isAutogenTemplateID(cs.templateID) {
 			// Template wins over autogen on chart-id collision.
 			ctx.chartOwners[route.ChartID] = route.ChartTemplateID
-			cs.labelScratch.releaseObservations()
 			delete(ctx.chartsByID, route.ChartID)
 			cs = nil
 			exists = false
@@ -523,27 +533,16 @@ func (ctx *planBuildContext) accumulateRoute(
 			entries = make(map[string]*dimBuildEntry, dimCap)
 		}
 
-		var labelScratch *chartLabelScratch
+		var previousPresentation *materializedChartPresentation
 		if matchingMaterializedChart && matChart.presentation != nil {
-			labelScratch = matChart.presentation.labelScratch
+			previousPresentation = matChart.presentation
 		}
-		if labelScratch == nil && route.Autogen {
-			labelScratch = &chartLabelScratch{accumulator: newAutogenChartLabelAccumulator()}
-		}
-		if labelScratch == nil {
-			chart, ok := index.chartsByID[route.ChartTemplateID]
-			if !ok {
-				return fmt.Errorf("chartengine: route references unknown chart template %q", route.ChartTemplateID)
-			}
-			labelScratch = &chartLabelScratch{accumulator: newChartLabelAccumulator(chart)}
-		}
-		labelScratch.resetObservations()
 		cs = &chartState{
 			templateID:      route.ChartTemplateID,
 			chartID:         route.ChartID,
 			meta:            route.Meta,
 			lifecycle:       route.Lifecycle,
-			labelScratch:    labelScratch,
+			labelTracker:    newChartLabelTracker(previousPresentation),
 			entries:         entries,
 			currentBuildSeq: ctx.buildCycle,
 		}
@@ -583,8 +582,12 @@ func (ctx *planBuildContext) accumulateRoute(
 		entry.value += value
 	}
 
-	if cs.labelScratch != nil {
-		if err := cs.labelScratch.observe(identity, labels, rawLabels, raw, route.DimensionKeyLabel); err != nil {
+	if cs.labelTracker.observeMembership(identity, route.DimensionKeyLabel) {
+		policy := labelPolicyForTemplate(index, route.ChartTemplateID, route.Autogen)
+		if policy == nil {
+			return fmt.Errorf("chartengine: route references unknown chart template %q", route.ChartTemplateID)
+		}
+		if err := cs.labelTracker.observeDuringScan(policy, labels, route.DimensionKeyLabel); err != nil {
 			return err
 		}
 	}
@@ -603,7 +606,18 @@ func (ctx *planBuildContext) accumulateRoute(
 	return nil
 }
 
+func labelPolicyForTemplate(index matchIndex, templateID string, autogen bool) *chartLabelPolicy {
+	if autogen {
+		return index.autogenLabels
+	}
+	return index.labelPolicies[templateID]
+}
+
 func (e *Engine) materializePlanCharts(ctx *planBuildContext) error {
+	if err := e.reconcileChangedChartLabels(ctx); err != nil {
+		return err
+	}
+
 	chartIDs := make([]string, 0, len(ctx.chartsByID))
 	for chartID, cs := range ctx.chartsByID {
 		if cs.observedCount == 0 {
@@ -617,26 +631,31 @@ func (e *Engine) materializePlanCharts(ctx *planBuildContext) error {
 		cs := ctx.chartsByID[chartID]
 		matChart, chartCreated := ctx.materialized.ensureChart(cs.chartID, cs.templateID, cs.meta, cs.lifecycle)
 		previousPresentation := matChart.presentation
-		membershipChanged := previousPresentation == nil || !cs.labelScratch.membershipMatches(previousPresentation.labelMembership)
+		membershipChanged := cs.labelTracker.changed()
 		if membershipChanged {
-			if err := cs.labelScratch.reconcile(); err != nil {
-				return err
-			}
-			chartLabels := cs.labelScratch.accumulator.materialize()
-			matChart.replaceLabels(maps.Clone(chartLabels), cs.labelScratch.cloneMembership(), cs.labelScratch)
-			if chartCreated {
-				ctx.out.Actions = append(ctx.out.Actions, CreateChartAction{
-					ChartTemplateID: cs.templateID,
-					ChartID:         cs.chartID,
-					Meta:            cs.meta,
-					Labels:          chartLabels,
-				})
-			} else if previousPresentation == nil || !maps.Equal(previousPresentation.labelValues, chartLabels) {
-				ctx.out.Actions = append(ctx.out.Actions, UpdateChartLabelsAction{
-					ChartID: cs.chartID,
-					Meta:    cs.meta,
-					Labels:  chartLabels,
-				})
+			membership := cs.labelTracker.membership()
+			accumulator := cs.labelTracker.accumulator()
+			labelsChanged := previousPresentation == nil ||
+				!accumulator.materializedEquals(previousPresentation.labelValues)
+			if labelsChanged {
+				chartLabels := accumulator.materialize()
+				matChart.replaceLabels(maps.Clone(chartLabels), membership)
+				if chartCreated {
+					ctx.out.Actions = append(ctx.out.Actions, CreateChartAction{
+						ChartTemplateID: cs.templateID,
+						ChartID:         cs.chartID,
+						Meta:            cs.meta,
+						Labels:          chartLabels,
+					})
+				} else {
+					ctx.out.Actions = append(ctx.out.Actions, UpdateChartLabelsAction{
+						ChartID: cs.chartID,
+						Meta:    cs.meta,
+						Labels:  chartLabels,
+					})
+				}
+			} else {
+				matChart.replaceLabelMembership(membership)
 			}
 		} else if chartCreated {
 			return fmt.Errorf("chartengine: new chart %q unexpectedly matched prior label membership", cs.chartID)
@@ -697,6 +716,28 @@ func (e *Engine) materializePlanCharts(ctx *planBuildContext) error {
 		matChart.pruneScratchEntries(cs.currentBuildSeq)
 	}
 	return nil
+}
+
+func (e *Engine) reconcileChangedChartLabels(ctx *planBuildContext) error {
+	needsReplay := false
+	for _, chart := range ctx.chartsByID {
+		if chart == nil || chart.observedCount == 0 || !chart.labelTracker.finishMembership() {
+			continue
+		}
+		if chart.labelTracker.needsReplay() {
+			policy := labelPolicyForTemplate(ctx.index, chart.templateID, isAutogenTemplateID(chart.templateID))
+			if policy == nil {
+				return fmt.Errorf("chartengine: missing label policy for chart template %q", chart.templateID)
+			}
+			chart.labelTracker.beginReplay(policy)
+			needsReplay = true
+		}
+	}
+	if !needsReplay {
+		return nil
+	}
+
+	return e.forEachPlanSeriesRoute(ctx, true)
 }
 
 func observedDimensionNames(cs *chartState, matChart *materializedChartState) []string {

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -737,6 +737,9 @@ func (e *Engine) reconcileChangedChartLabels(ctx *planBuildContext) error {
 		return nil
 	}
 
+	// A mismatch may be discovered after a matching prefix whose labels were not
+	// retained. Replay the immutable current snapshot only on changed cycles and
+	// use the same route walk so selection and autogen semantics cannot diverge.
 	return e.forEachPlanSeriesRoute(ctx, true)
 }
 

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -196,6 +196,7 @@ func (e *Engine) preparePlan(reader metrix.Reader) (Plan, materializedState, uin
 		e.logWarningf("chartengine build prepare failed: %v", err)
 		return Plan{}, materializedState{}, 0, 0, 0, false, err
 	}
+	defer ctx.releaseLabelObservations()
 	phaseStartedAt = time.Now()
 	if err := validateBuildReaderForInferredDimensions(ctx.index, reader); err != nil {
 		sample.phaseValidateSeconds = time.Since(phaseStartedAt).Seconds()
@@ -274,6 +275,18 @@ func (e *Engine) preparePlan(reader metrix.Reader) (Plan, materializedState, uin
 	attemptID := e.nextAttemptIDLocked()
 	e.state.outstanding = attemptID
 	return out, staged, e.state.engineEpoch, e.state.commitSeq, attemptID, true, nil
+}
+
+func (ctx *planBuildContext) releaseLabelObservations() {
+	if ctx == nil {
+		return
+	}
+	for _, chart := range ctx.chartsByID {
+		if chart == nil || chart.labelScratch == nil {
+			continue
+		}
+		chart.labelScratch.releaseObservations()
+	}
 }
 
 func validateBuildReaderForInferredDimensions(index matchIndex, reader metrix.Reader) error {
@@ -473,6 +486,7 @@ func (ctx *planBuildContext) accumulateRoute(
 		if !route.Autogen && isAutogenTemplateID(cs.templateID) {
 			// Template wins over autogen on chart-id collision.
 			ctx.chartOwners[route.ChartID] = route.ChartTemplateID
+			cs.labelScratch.releaseObservations()
 			delete(ctx.chartsByID, route.ChartID)
 			cs = nil
 			exists = false
@@ -609,7 +623,7 @@ func (e *Engine) materializePlanCharts(ctx *planBuildContext) error {
 				return err
 			}
 			chartLabels := cs.labelScratch.accumulator.materialize()
-			matChart.replaceLabels(chartLabels, cs.labelScratch.cloneMembership(), cs.labelScratch)
+			matChart.replaceLabels(maps.Clone(chartLabels), cs.labelScratch.cloneMembership(), cs.labelScratch)
 			if chartCreated {
 				ctx.out.Actions = append(ctx.out.Actions, CreateChartAction{
 					ChartTemplateID: cs.templateID,

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -4,6 +4,7 @@ package chartengine
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"sort"
 	"strconv"
@@ -50,7 +51,9 @@ func (v labelSliceView) CloneMap() map[string]string {
 	return out
 }
 
-// Plan is the deterministic planner output consumed by chartemit.
+// Plan is the deterministic planner output consumed by chartemit. Actions and
+// their referenced maps and slices are immutable snapshots; consumers must not
+// mutate them.
 //
 // Current scope:
 //   - create/update/remove actions for chart and dimension lifecycle,
@@ -101,7 +104,7 @@ type chartState struct {
 	chartID         string
 	meta            program.ChartMeta
 	lifecycle       program.LifecyclePolicy
-	labels          *chartLabelAccumulator
+	labelScratch    *chartLabelScratch
 	entries         map[string]*dimBuildEntry
 	observedCount   int
 	currentBuildSeq uint64
@@ -260,6 +263,7 @@ func (e *Engine) preparePlan(reader metrix.Reader) (Plan, materializedState, uin
 	actionCounts := actionKindCounts(out.Actions)
 	sample.actionCreateChart = actionCounts.actionCreateChart
 	sample.actionCreateDimension = actionCounts.actionCreateDimension
+	sample.actionUpdateChartLabels = actionCounts.actionUpdateChartLabels
 	sample.actionUpdateChart = actionCounts.actionUpdateChart
 	sample.actionRemoveDimension = actionCounts.actionRemoveDimension
 	sample.actionRemoveChart = actionCounts.actionRemoveChart
@@ -366,7 +370,15 @@ func (e *Engine) preparePlanBuildContext(
 func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 	var firstErr error
 	buildSeq := ctx.collectMeta.LastSuccessSeq
-	process := func(identity metrix.SeriesIdentity, meta metrix.SeriesMeta, name string, labels metrix.LabelView, v metrix.SampleValue) {
+	process := func(
+		identity metrix.SeriesIdentity,
+		meta metrix.SeriesMeta,
+		name string,
+		labels metrix.LabelView,
+		rawLabels []metrix.Label,
+		raw bool,
+		v metrix.SampleValue,
+	) {
 		ctx.seriesScanned++
 		if firstErr != nil {
 			return
@@ -424,7 +436,7 @@ func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 		}
 
 		for _, route := range routes {
-			if err := ctx.accumulateRoute(ctx.index, route, meta, labels, v); err != nil {
+			if err := ctx.accumulateRoute(ctx.index, route, identity, meta, labels, rawLabels, raw, v); err != nil {
 				firstErr = err
 				return
 			}
@@ -435,13 +447,13 @@ func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 		view := &labelSliceView{}
 		rawIter.ForEachSeriesIdentityRaw(func(identity metrix.SeriesIdentity, meta metrix.SeriesMeta, name string, labels []metrix.Label, v metrix.SampleValue) {
 			view.items = labels
-			process(identity, meta, name, view, v)
+			process(identity, meta, name, view, labels, true, v)
 		})
 		return firstErr
 	}
 
 	ctx.flat.ForEachSeriesIdentity(func(identity metrix.SeriesIdentity, meta metrix.SeriesMeta, name string, labels metrix.LabelView, v metrix.SampleValue) {
-		process(identity, meta, name, labels, v)
+		process(identity, meta, name, labels, nil, false, v)
 	})
 	return firstErr
 }
@@ -449,8 +461,11 @@ func (e *Engine) scanPlanSeries(ctx *planBuildContext) error {
 func (ctx *planBuildContext) accumulateRoute(
 	index matchIndex,
 	route routeBinding,
+	identity metrix.SeriesIdentity,
 	seriesMeta metrix.SeriesMeta,
 	labels metrix.LabelView,
+	rawLabels []metrix.Label,
+	raw bool,
 	value metrix.SampleValue,
 ) error {
 	cs, exists := ctx.chartsByID[route.ChartID]
@@ -486,28 +501,35 @@ func (ctx *planBuildContext) accumulateRoute(
 
 		dimCap := ctx.dimCapHints[route.ChartID]
 		var entries map[string]*dimBuildEntry
-		var labelsAcc *chartLabelAccumulator
-		if matChart := ctx.materializedByID[route.ChartID]; matChart != nil {
+		matChart := ctx.materializedByID[route.ChartID]
+		matchingMaterializedChart := matChart != nil && matChart.templateID == route.ChartTemplateID
+		if matchingMaterializedChart {
 			entries = matChart.checkoutScratchEntries(dimCap)
-			// Labels are only emitted on chart creation, so skip observe work for existing charts.
-			labelsAcc = nil
 		} else {
 			entries = make(map[string]*dimBuildEntry, dimCap)
-			labelsAcc = newAutogenChartLabelAccumulator()
-			if !route.Autogen {
-				chart, ok := index.chartsByID[route.ChartTemplateID]
-				if !ok {
-					return fmt.Errorf("chartengine: route references unknown chart template %q", route.ChartTemplateID)
-				}
-				labelsAcc = newChartLabelAccumulator(chart)
-			}
 		}
+
+		var labelScratch *chartLabelScratch
+		if matchingMaterializedChart && matChart.presentation != nil {
+			labelScratch = matChart.presentation.labelScratch
+		}
+		if labelScratch == nil && route.Autogen {
+			labelScratch = &chartLabelScratch{accumulator: newAutogenChartLabelAccumulator()}
+		}
+		if labelScratch == nil {
+			chart, ok := index.chartsByID[route.ChartTemplateID]
+			if !ok {
+				return fmt.Errorf("chartengine: route references unknown chart template %q", route.ChartTemplateID)
+			}
+			labelScratch = &chartLabelScratch{accumulator: newChartLabelAccumulator(chart)}
+		}
+		labelScratch.resetObservations()
 		cs = &chartState{
 			templateID:      route.ChartTemplateID,
 			chartID:         route.ChartID,
 			meta:            route.Meta,
 			lifecycle:       route.Lifecycle,
-			labels:          labelsAcc,
+			labelScratch:    labelScratch,
 			entries:         entries,
 			currentBuildSeq: ctx.buildCycle,
 		}
@@ -547,8 +569,8 @@ func (ctx *planBuildContext) accumulateRoute(
 		entry.value += value
 	}
 
-	if cs.labels != nil {
-		if err := cs.labels.observe(labels, route.DimensionKeyLabel); err != nil {
+	if cs.labelScratch != nil {
+		if err := cs.labelScratch.observe(identity, labels, rawLabels, raw, route.DimensionKeyLabel); err != nil {
 			return err
 		}
 	}
@@ -580,21 +602,30 @@ func (e *Engine) materializePlanCharts(ctx *planBuildContext) error {
 	for _, chartID := range chartIDs {
 		cs := ctx.chartsByID[chartID]
 		matChart, chartCreated := ctx.materialized.ensureChart(cs.chartID, cs.templateID, cs.meta, cs.lifecycle)
-		if chartCreated {
-			chartLabels := map[string]string(nil)
-			if cs.labels != nil {
-				labels, err := cs.labels.materialize()
-				if err != nil {
-					return err
-				}
-				chartLabels = labels
+		previousPresentation := matChart.presentation
+		membershipChanged := previousPresentation == nil || !cs.labelScratch.membershipMatches(previousPresentation.labelMembership)
+		if membershipChanged {
+			if err := cs.labelScratch.reconcile(); err != nil {
+				return err
 			}
-			ctx.out.Actions = append(ctx.out.Actions, CreateChartAction{
-				ChartTemplateID: cs.templateID,
-				ChartID:         cs.chartID,
-				Meta:            cs.meta,
-				Labels:          chartLabels,
-			})
+			chartLabels := cs.labelScratch.accumulator.materialize()
+			matChart.replaceLabels(chartLabels, cs.labelScratch.cloneMembership(), cs.labelScratch)
+			if chartCreated {
+				ctx.out.Actions = append(ctx.out.Actions, CreateChartAction{
+					ChartTemplateID: cs.templateID,
+					ChartID:         cs.chartID,
+					Meta:            cs.meta,
+					Labels:          chartLabels,
+				})
+			} else if previousPresentation == nil || !maps.Equal(previousPresentation.labelValues, chartLabels) {
+				ctx.out.Actions = append(ctx.out.Actions, UpdateChartLabelsAction{
+					ChartID: cs.chartID,
+					Meta:    cs.meta,
+					Labels:  chartLabels,
+				})
+			}
+		} else if chartCreated {
+			return fmt.Errorf("chartengine: new chart %q unexpectedly matched prior label membership", cs.chartID)
 		}
 		matChart.lastSeenSuccessSeq = ctx.collectMeta.LastSuccessSeq
 

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -19,16 +19,20 @@ type compiledInstanceLabelPlan struct {
 	includeAll   bool
 }
 
+type chartLabelPolicy struct {
+	mode         program.PromotionMode
+	promoteKeys  map[string]struct{}
+	excluded     map[string]struct{}
+	instancePlan compiledInstanceLabelPlan
+}
+
 type chartLabelAccumulator struct {
-	mode                   program.PromotionMode
-	promoteKeys            map[string]struct{}
-	excluded               map[string]struct{}
+	policy                 *chartLabelPolicy
 	dimensionKeyExclusions map[string]struct{}
 	instance               map[string]string
 	selected               map[string]string
 	initialized            bool
 
-	instancePlan      compiledInstanceLabelPlan
 	instanceKeys      map[string]struct{}
 	resolvedScratch   []instanceLabelValue
 	includeAllScratch []string
@@ -39,68 +43,70 @@ type chartLabelMembership struct {
 	dimensionKeyLabel string
 }
 
-type chartLabelObservation struct {
-	chartLabelMembership
-	rawLabels []metrix.Label
+type chartLabelTracker struct {
+	previous *materializedChartPresentation
+	change   *chartLabelChange
+	observed int
 }
 
-type chartLabelScratch struct {
-	accumulator  *chartLabelAccumulator
-	observations []chartLabelObservation
-	raw          bool
+type chartLabelChange struct {
+	proposedMembership  []chartLabelMembership
+	accumulator         *chartLabelAccumulator
+	reconcileDuringScan bool
 }
 
-func newChartLabelAccumulator(chart program.Chart) *chartLabelAccumulator {
+func compileChartLabelPolicy(chart program.Chart) *chartLabelPolicy {
 	plan := compileInstanceLabelPlan(chart.Identity)
-	acc := &chartLabelAccumulator{
+	policy := &chartLabelPolicy{
 		mode:        chart.Labels.Mode,
 		promoteKeys: make(map[string]struct{}, len(chart.Labels.PromoteKeys)),
 		excluded: make(map[string]struct{},
 			len(chart.Labels.Exclusions.SelectorConstrainedKeys)+len(chart.Labels.Exclusions.DimensionKeyLabels)),
-		dimensionKeyExclusions: make(map[string]struct{}),
-		instance:               make(map[string]string),
-		selected:               make(map[string]string),
-		instancePlan:           plan,
-		instanceKeys:           make(map[string]struct{}, len(plan.explicitKeys)),
-		resolvedScratch:        make([]instanceLabelValue, 0, len(plan.explicitKeys)),
-		includeAllScratch:      make([]string, 0, len(plan.explicitKeys)),
+		instancePlan: plan,
 	}
 	for _, key := range chart.Labels.PromoteKeys {
 		key = strings.TrimSpace(key)
 		if key == "" {
 			continue
 		}
-		acc.promoteKeys[key] = struct{}{}
+		policy.promoteKeys[key] = struct{}{}
 	}
 	for _, key := range chart.Labels.Exclusions.SelectorConstrainedKeys {
 		key = strings.TrimSpace(key)
 		if key == "" {
 			continue
 		}
-		acc.excluded[key] = struct{}{}
+		policy.excluded[key] = struct{}{}
 	}
 	for _, key := range chart.Labels.Exclusions.DimensionKeyLabels {
 		key = strings.TrimSpace(key)
 		if key == "" {
 			continue
 		}
-		acc.excluded[key] = struct{}{}
+		policy.excluded[key] = struct{}{}
 	}
-	return acc
+	return policy
 }
 
-func newAutogenChartLabelAccumulator() *chartLabelAccumulator {
+func compileAutogenChartLabelPolicy() *chartLabelPolicy {
+	return &chartLabelPolicy{
+		mode:         program.PromotionModeAutoIntersection,
+		promoteKeys:  make(map[string]struct{}),
+		excluded:     make(map[string]struct{}),
+		instancePlan: compileInstanceLabelPlan(program.ChartIdentity{}),
+	}
+}
+
+func newChartLabelAccumulator(policy *chartLabelPolicy) *chartLabelAccumulator {
+	plan := policy.instancePlan
 	return &chartLabelAccumulator{
-		mode:                   program.PromotionModeAutoIntersection,
-		promoteKeys:            make(map[string]struct{}),
-		excluded:               make(map[string]struct{}),
+		policy:                 policy,
 		dimensionKeyExclusions: make(map[string]struct{}),
-		instance:               make(map[string]string),
-		selected:               make(map[string]string),
-		instancePlan:           compileInstanceLabelPlan(program.ChartIdentity{}),
-		instanceKeys:           make(map[string]struct{}),
-		resolvedScratch:        make([]instanceLabelValue, 0),
-		includeAllScratch:      make([]string, 0),
+		instance:               make(map[string]string, len(plan.explicitKeys)),
+		selected:               make(map[string]string, len(policy.promoteKeys)),
+		instanceKeys:           make(map[string]struct{}, len(plan.explicitKeys)),
+		resolvedScratch:        make([]instanceLabelValue, 0, len(plan.explicitKeys)),
+		includeAllScratch:      make([]string, 0, len(plan.explicitKeys)),
 	}
 }
 
@@ -117,103 +123,101 @@ func (a *chartLabelAccumulator) reset() {
 	a.initialized = false
 }
 
-func (s *chartLabelScratch) resetObservations() {
-	if s == nil {
-		return
-	}
-	s.observations = s.observations[:0]
+func newChartLabelTracker(previous *materializedChartPresentation) chartLabelTracker {
+	return chartLabelTracker{previous: previous}
 }
 
-func (s *chartLabelScratch) releaseObservations() {
-	if s == nil {
-		return
+func (c *chartLabelChange) ensureAccumulator(policy *chartLabelPolicy) *chartLabelAccumulator {
+	if c.accumulator == nil {
+		c.accumulator = newChartLabelAccumulator(policy)
 	}
-	current := len(s.observations)
-	clear(s.observations)
-	// Keep steady-state reuse, but discard a historical high-water allocation
-	// once current membership falls below half its capacity.
-	if cap(s.observations) > current*2 {
-		if current == 0 {
-			s.observations = nil
-		} else {
-			s.observations = make([]chartLabelObservation, 0, current)
-		}
-	} else {
-		s.observations = s.observations[:0]
-	}
-	s.raw = false
+	return c.accumulator
 }
 
-func (s *chartLabelScratch) observe(
+func (t *chartLabelTracker) observeMembership(
 	identity metrix.SeriesIdentity,
-	labels metrix.LabelView,
-	rawLabels []metrix.Label,
-	raw bool,
 	dimensionKeyLabel string,
-) error {
-	if len(s.observations) == 0 {
-		s.raw = raw
-		if !raw {
-			s.accumulator.reset()
-		}
+) bool {
+	previousMembership := t.previousMembership()
+	membership := chartLabelMembership{
+		seriesID:          identity.ID,
+		dimensionKeyLabel: dimensionKeyLabel,
 	}
-	s.observations = append(s.observations, chartLabelObservation{
-		chartLabelMembership: chartLabelMembership{
-			seriesID:          identity.ID,
-			dimensionKeyLabel: dimensionKeyLabel,
-		},
-		rawLabels: rawLabels,
-	})
-	if !raw {
-		return s.accumulator.observe(labels, dimensionKeyLabel)
-	}
-	return nil
-}
-
-func (s *chartLabelScratch) membershipMatches(current []chartLabelMembership) bool {
-	if s == nil || len(s.observations) != len(current) {
+	index := t.observed
+	t.observed++
+	if t.change == nil && index < len(previousMembership) && previousMembership[index] == membership {
 		return false
 	}
-	for i := range s.observations {
-		if s.observations[i].chartLabelMembership != current[i] {
-			return false
+
+	if t.change == nil {
+		capacity := max(len(previousMembership), t.observed)
+		t.change = &chartLabelChange{
+			proposedMembership:  make([]chartLabelMembership, 0, capacity),
+			reconcileDuringScan: t.previous == nil,
 		}
+		t.change.proposedMembership = append(t.change.proposedMembership, previousMembership[:index]...)
 	}
-	return true
+	t.change.proposedMembership = append(t.change.proposedMembership, membership)
+	return t.change.reconcileDuringScan
 }
 
-func (s *chartLabelScratch) reconcile() error {
-	if s == nil || s.accumulator == nil {
-		return nil
-	}
-	if !s.raw {
-		return nil
-	}
-	s.accumulator.reset()
-	view := &labelSliceView{}
-	for i := range s.observations {
-		observation := &s.observations[i]
-		view.items = observation.rawLabels
-		if err := s.accumulator.observe(view, observation.dimensionKeyLabel); err != nil {
-			return err
-		}
-	}
-	return nil
+func (t *chartLabelTracker) observeDuringScan(policy *chartLabelPolicy, labels metrix.LabelView, dimensionKeyLabel string) error {
+	return t.change.ensureAccumulator(policy).observe(labels, dimensionKeyLabel)
 }
 
-func (s *chartLabelScratch) cloneMembership() []chartLabelMembership {
-	if s == nil || len(s.observations) == 0 {
+func (t *chartLabelTracker) finishMembership() bool {
+	previousMembership := t.previousMembership()
+	if t.change == nil && t.observed != len(previousMembership) {
+		t.change = &chartLabelChange{
+			proposedMembership: append(
+				make([]chartLabelMembership, 0, t.observed),
+				previousMembership[:t.observed]...,
+			),
+			reconcileDuringScan: t.previous == nil,
+		}
+	}
+	return t.change != nil
+}
+
+func (t *chartLabelTracker) previousMembership() []chartLabelMembership {
+	if t.previous == nil {
 		return nil
 	}
-	out := make([]chartLabelMembership, len(s.observations))
-	for i := range s.observations {
-		out[i] = s.observations[i].chartLabelMembership
+	return t.previous.labelMembership
+}
+
+func (t *chartLabelTracker) beginReplay(policy *chartLabelPolicy) {
+	t.change.ensureAccumulator(policy).reset()
+}
+
+func (t *chartLabelTracker) observeReplay(labels metrix.LabelView, dimensionKeyLabel string) error {
+	return t.change.accumulator.observe(labels, dimensionKeyLabel)
+}
+
+func (t *chartLabelTracker) needsReplay() bool {
+	return t.change != nil && !t.change.reconcileDuringScan
+}
+
+func (t *chartLabelTracker) changed() bool {
+	return t.change != nil
+}
+
+func (t *chartLabelTracker) membership() []chartLabelMembership {
+	if t.change != nil {
+		return t.change.proposedMembership
 	}
-	return out
+	return t.previousMembership()
+}
+
+func (t *chartLabelTracker) accumulator() *chartLabelAccumulator {
+	if t.change == nil {
+		return nil
+	}
+	return t.change.accumulator
 }
 
 func (a *chartLabelAccumulator) isExcluded(key string) bool {
-	if _, ok := a.excluded[key]; ok {
+	if _, ok := a.policy.excluded[key]; ok {
 		return true
 	}
 	_, ok := a.dimensionKeyExclusions[key]
@@ -272,10 +276,10 @@ func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLab
 		return nil
 	}
 
-	switch a.mode {
+	switch a.policy.mode {
 	case program.PromotionModeExplicitIntersection:
 		if !a.initialized {
-			for key := range a.promoteKeys {
+			for key := range a.policy.promoteKeys {
 				if a.isExcluded(key) {
 					continue
 				}
@@ -364,7 +368,7 @@ func (a *chartLabelAccumulator) resolveInstanceLabelsForObserve(labels metrix.La
 	a.resetInstanceKeys()
 
 	resolved := a.resolvedScratch[:0]
-	for _, key := range a.instancePlan.explicitKeys {
+	for _, key := range a.policy.instancePlan.explicitKeys {
 		value, ok := labels.Get(key)
 		if !ok {
 			a.resolvedScratch = resolved[:0]
@@ -373,13 +377,13 @@ func (a *chartLabelAccumulator) resolveInstanceLabelsForObserve(labels metrix.La
 		resolved = append(resolved, instanceLabelValue{Key: key, Value: value})
 	}
 
-	if a.instancePlan.includeAll {
+	if a.policy.instancePlan.includeAll {
 		extra := a.includeAllScratch[:0]
 		labels.Range(func(key, _ string) bool {
-			if _, excluded := a.instancePlan.excludeSet[key]; excluded {
+			if _, excluded := a.policy.instancePlan.excludeSet[key]; excluded {
 				return true
 			}
-			if _, already := a.instancePlan.explicitSet[key]; already {
+			if _, already := a.policy.instancePlan.explicitSet[key]; already {
 				return true
 			}
 			extra = append(extra, key)
@@ -429,4 +433,41 @@ func (a *chartLabelAccumulator) materialize() map[string]string {
 	}
 	delete(out, collectJobLabel)
 	return out
+}
+
+func (a *chartLabelAccumulator) materializedEquals(values map[string]string) bool {
+	if a == nil {
+		return len(values) == 0
+	}
+
+	count := 0
+	for key := range a.instance {
+		if strings.TrimSpace(key) == "" || key == collectJobLabel {
+			continue
+		}
+		if _, overridden := a.selected[key]; overridden {
+			continue
+		}
+		count++
+	}
+	for key := range a.selected {
+		if strings.TrimSpace(key) == "" || key == collectJobLabel {
+			continue
+		}
+		count++
+	}
+	if count != len(values) {
+		return false
+	}
+
+	for key, want := range values {
+		got, ok := a.selected[key]
+		if !ok {
+			got, ok = a.instance[key]
+		}
+		if !ok || got != want {
+			return false
+		}
+	}
+	return true
 }

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -124,6 +124,26 @@ func (s *chartLabelScratch) resetObservations() {
 	s.observations = s.observations[:0]
 }
 
+func (s *chartLabelScratch) releaseObservations() {
+	if s == nil {
+		return
+	}
+	current := len(s.observations)
+	clear(s.observations)
+	// Keep steady-state reuse, but discard a historical high-water allocation
+	// once current membership falls below half its capacity.
+	if cap(s.observations) > current*2 {
+		if current == 0 {
+			s.observations = nil
+		} else {
+			s.observations = make([]chartLabelObservation, 0, current)
+		}
+	} else {
+		s.observations = s.observations[:0]
+	}
+	s.raw = false
+}
+
 func (s *chartLabelScratch) observe(
 	identity metrix.SeriesIdentity,
 	labels metrix.LabelView,

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -150,9 +150,8 @@ func (t *chartLabelTracker) observeMembership(
 	}
 
 	if t.change == nil {
-		capacity := max(len(previousMembership), t.observed)
 		t.change = &chartLabelChange{
-			proposedMembership:  make([]chartLabelMembership, 0, capacity),
+			proposedMembership:  make([]chartLabelMembership, 0, t.observed),
 			reconcileDuringScan: t.previous == nil,
 		}
 		t.change.proposedMembership = append(t.change.proposedMembership, previousMembership[:index]...)

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -152,7 +152,7 @@ func (t *chartLabelTracker) observeMembership(
 	if t.change == nil {
 		t.change = &chartLabelChange{
 			proposedMembership:  make([]chartLabelMembership, 0, t.observed),
-			reconcileDuringScan: t.previous == nil,
+			reconcileDuringScan: t.previous == nil || index == 0,
 		}
 		t.change.proposedMembership = append(t.change.proposedMembership, previousMembership[:index]...)
 	}

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -20,17 +20,34 @@ type compiledInstanceLabelPlan struct {
 }
 
 type chartLabelAccumulator struct {
-	mode        program.PromotionMode
-	promoteKeys map[string]struct{}
-	excluded    map[string]struct{}
-	instance    map[string]string
-	selected    map[string]string
-	initialized bool
+	mode                   program.PromotionMode
+	promoteKeys            map[string]struct{}
+	excluded               map[string]struct{}
+	dimensionKeyExclusions map[string]struct{}
+	instance               map[string]string
+	selected               map[string]string
+	initialized            bool
 
 	instancePlan      compiledInstanceLabelPlan
 	instanceKeys      map[string]struct{}
 	resolvedScratch   []instanceLabelValue
 	includeAllScratch []string
+}
+
+type chartLabelMembership struct {
+	seriesID          metrix.SeriesID
+	dimensionKeyLabel string
+}
+
+type chartLabelObservation struct {
+	chartLabelMembership
+	rawLabels []metrix.Label
+}
+
+type chartLabelScratch struct {
+	accumulator  *chartLabelAccumulator
+	observations []chartLabelObservation
+	raw          bool
 }
 
 func newChartLabelAccumulator(chart program.Chart) *chartLabelAccumulator {
@@ -40,12 +57,13 @@ func newChartLabelAccumulator(chart program.Chart) *chartLabelAccumulator {
 		promoteKeys: make(map[string]struct{}, len(chart.Labels.PromoteKeys)),
 		excluded: make(map[string]struct{},
 			len(chart.Labels.Exclusions.SelectorConstrainedKeys)+len(chart.Labels.Exclusions.DimensionKeyLabels)),
-		instance:          make(map[string]string),
-		selected:          make(map[string]string),
-		instancePlan:      plan,
-		instanceKeys:      make(map[string]struct{}, len(plan.explicitKeys)),
-		resolvedScratch:   make([]instanceLabelValue, 0, len(plan.explicitKeys)),
-		includeAllScratch: make([]string, 0, len(plan.explicitKeys)),
+		dimensionKeyExclusions: make(map[string]struct{}),
+		instance:               make(map[string]string),
+		selected:               make(map[string]string),
+		instancePlan:           plan,
+		instanceKeys:           make(map[string]struct{}, len(plan.explicitKeys)),
+		resolvedScratch:        make([]instanceLabelValue, 0, len(plan.explicitKeys)),
+		includeAllScratch:      make([]string, 0, len(plan.explicitKeys)),
 	}
 	for _, key := range chart.Labels.PromoteKeys {
 		key = strings.TrimSpace(key)
@@ -73,16 +91,113 @@ func newChartLabelAccumulator(chart program.Chart) *chartLabelAccumulator {
 
 func newAutogenChartLabelAccumulator() *chartLabelAccumulator {
 	return &chartLabelAccumulator{
-		mode:              program.PromotionModeAutoIntersection,
-		promoteKeys:       make(map[string]struct{}),
-		excluded:          make(map[string]struct{}),
-		instance:          make(map[string]string),
-		selected:          make(map[string]string),
-		instancePlan:      compileInstanceLabelPlan(program.ChartIdentity{}),
-		instanceKeys:      make(map[string]struct{}),
-		resolvedScratch:   make([]instanceLabelValue, 0),
-		includeAllScratch: make([]string, 0),
+		mode:                   program.PromotionModeAutoIntersection,
+		promoteKeys:            make(map[string]struct{}),
+		excluded:               make(map[string]struct{}),
+		dimensionKeyExclusions: make(map[string]struct{}),
+		instance:               make(map[string]string),
+		selected:               make(map[string]string),
+		instancePlan:           compileInstanceLabelPlan(program.ChartIdentity{}),
+		instanceKeys:           make(map[string]struct{}),
+		resolvedScratch:        make([]instanceLabelValue, 0),
+		includeAllScratch:      make([]string, 0),
 	}
+}
+
+func (a *chartLabelAccumulator) reset() {
+	if a == nil {
+		return
+	}
+	clear(a.dimensionKeyExclusions)
+	clear(a.instance)
+	clear(a.selected)
+	clear(a.instanceKeys)
+	a.resolvedScratch = a.resolvedScratch[:0]
+	a.includeAllScratch = a.includeAllScratch[:0]
+	a.initialized = false
+}
+
+func (s *chartLabelScratch) resetObservations() {
+	if s == nil {
+		return
+	}
+	s.observations = s.observations[:0]
+}
+
+func (s *chartLabelScratch) observe(
+	identity metrix.SeriesIdentity,
+	labels metrix.LabelView,
+	rawLabels []metrix.Label,
+	raw bool,
+	dimensionKeyLabel string,
+) error {
+	if len(s.observations) == 0 {
+		s.raw = raw
+		if !raw {
+			s.accumulator.reset()
+		}
+	}
+	s.observations = append(s.observations, chartLabelObservation{
+		chartLabelMembership: chartLabelMembership{
+			seriesID:          identity.ID,
+			dimensionKeyLabel: dimensionKeyLabel,
+		},
+		rawLabels: rawLabels,
+	})
+	if !raw {
+		return s.accumulator.observe(labels, dimensionKeyLabel)
+	}
+	return nil
+}
+
+func (s *chartLabelScratch) membershipMatches(current []chartLabelMembership) bool {
+	if s == nil || len(s.observations) != len(current) {
+		return false
+	}
+	for i := range s.observations {
+		if s.observations[i].chartLabelMembership != current[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *chartLabelScratch) reconcile() error {
+	if s == nil || s.accumulator == nil {
+		return nil
+	}
+	if !s.raw {
+		return nil
+	}
+	s.accumulator.reset()
+	view := &labelSliceView{}
+	for i := range s.observations {
+		observation := &s.observations[i]
+		view.items = observation.rawLabels
+		if err := s.accumulator.observe(view, observation.dimensionKeyLabel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *chartLabelScratch) cloneMembership() []chartLabelMembership {
+	if s == nil || len(s.observations) == 0 {
+		return nil
+	}
+	out := make([]chartLabelMembership, len(s.observations))
+	for i := range s.observations {
+		out[i] = s.observations[i].chartLabelMembership
+	}
+	return out
+}
+
+func (a *chartLabelAccumulator) isExcluded(key string) bool {
+	if _, ok := a.excluded[key]; ok {
+		return true
+	}
+	_, ok := a.dimensionKeyExclusions[key]
+	return ok
 }
 
 func compileInstanceLabelPlan(identity program.ChartIdentity) compiledInstanceLabelPlan {
@@ -129,7 +244,7 @@ func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLab
 	}
 
 	if key := strings.TrimSpace(dimensionKeyLabel); key != "" {
-		a.excluded[key] = struct{}{}
+		a.dimensionKeyExclusions[key] = struct{}{}
 	}
 
 	ok := a.resolveInstanceLabelsForObserve(labels)
@@ -141,7 +256,7 @@ func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLab
 	case program.PromotionModeExplicitIntersection:
 		if !a.initialized {
 			for key := range a.promoteKeys {
-				if _, excluded := a.excluded[key]; excluded {
+				if a.isExcluded(key) {
 					continue
 				}
 				if a.isInstanceKey(key) {
@@ -157,7 +272,7 @@ func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLab
 			return nil
 		}
 		for key, value := range a.selected {
-			if _, excluded := a.excluded[key]; excluded {
+			if a.isExcluded(key) {
 				delete(a.selected, key)
 				continue
 			}
@@ -178,7 +293,7 @@ func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLab
 	default:
 		if !a.initialized {
 			labels.Range(func(key, value string) bool {
-				if _, excluded := a.excluded[key]; excluded {
+				if a.isExcluded(key) {
 					return true
 				}
 				if a.isInstanceKey(key) {
@@ -191,7 +306,7 @@ func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLab
 			return nil
 		}
 		for key, value := range a.selected {
-			if _, excluded := a.excluded[key]; excluded {
+			if a.isExcluded(key) {
 				delete(a.selected, key)
 				continue
 			}
@@ -275,9 +390,9 @@ func (a *chartLabelAccumulator) isInstanceKey(key string) bool {
 	return ok
 }
 
-func (a *chartLabelAccumulator) materialize() (map[string]string, error) {
+func (a *chartLabelAccumulator) materialize() map[string]string {
 	if a == nil {
-		return nil, nil
+		return nil
 	}
 	out := make(map[string]string, len(a.instance)+len(a.selected))
 	for key, value := range a.instance {
@@ -293,5 +408,5 @@ func (a *chartLabelAccumulator) materialize() (map[string]string, error) {
 		out[key] = value
 	}
 	delete(out, collectJobLabel)
-	return out, nil
+	return out
 }

--- a/src/go/plugin/framework/chartengine/planner_labels_test.go
+++ b/src/go/plugin/framework/chartengine/planner_labels_test.go
@@ -65,7 +65,7 @@ func TestChartLabelAccumulatorIntersectsLabels(t *testing.T) {
 				},
 			}
 
-			acc := newChartLabelAccumulator(chart)
+			acc := newChartLabelAccumulator(compileChartLabelPolicy(chart))
 			require.NotNil(t, acc)
 
 			for _, labels := range tc.observed {

--- a/src/go/plugin/framework/chartengine/planner_labels_test.go
+++ b/src/go/plugin/framework/chartengine/planner_labels_test.go
@@ -73,8 +73,7 @@ func TestChartLabelAccumulatorIntersectsLabels(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			got, err := acc.materialize()
-			require.NoError(t, err)
+			got := acc.materialize()
 			assert.Equal(t, tc.want, got)
 			assert.NotContains(t, got, "mode")
 			assert.NotContains(t, got, "selector_fixed")

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -2153,9 +2153,9 @@ groups:
 
 	matChart := e.state.materialized.charts["service_mode"]
 	require.NotNil(t, matChart)
-	require.Contains(t, matChart.scratchEntries, "ok")
-	require.Contains(t, matChart.scratchEntries, "warn")
-	require.NotNil(t, matChart.scratchEntries["ok"])
+	require.Contains(t, matChart.dimensionScratchEntries(), "ok")
+	require.Contains(t, matChart.dimensionScratchEntries(), "warn")
+	require.NotNil(t, matChart.dimensionScratchEntries()["ok"])
 
 	cc.BeginCycle()
 	mode.Observe(3, okSet)
@@ -2179,8 +2179,8 @@ groups:
 	matChart = e.state.materialized.charts["service_mode"]
 	require.NotNil(t, matChart)
 	assert.NotContains(t, matChart.dimensions, "warn")
-	require.Contains(t, matChart.scratchEntries, "warn")
-	require.Contains(t, matChart.scratchEntries, "ok")
+	require.Contains(t, matChart.dimensionScratchEntries(), "warn")
+	require.Contains(t, matChart.dimensionScratchEntries(), "ok")
 
 	cc.BeginCycle()
 	mode.Observe(4, okSet)
@@ -2195,8 +2195,8 @@ groups:
 
 	matChart = e.state.materialized.charts["service_mode"]
 	require.NotNil(t, matChart)
-	assert.NotContains(t, matChart.scratchEntries, "warn")
-	require.Contains(t, matChart.scratchEntries, "ok")
+	assert.NotContains(t, matChart.dimensionScratchEntries(), "warn")
+	require.Contains(t, matChart.dimensionScratchEntries(), "ok")
 }
 
 func TestBuildPlanSequenceModeScenarios(t *testing.T) {
@@ -2272,9 +2272,9 @@ groups:
 
 				matChart := e.state.materialized.charts["component_load"]
 				require.NotNil(t, matChart)
-				require.Contains(t, matChart.scratchEntries, "ok")
-				require.Contains(t, matChart.scratchEntries, "warn")
-				require.NotNil(t, matChart.scratchEntries["ok"])
+				require.Contains(t, matChart.dimensionScratchEntries(), "ok")
+				require.Contains(t, matChart.dimensionScratchEntries(), "warn")
+				require.NotNil(t, matChart.dimensionScratchEntries()["ok"])
 
 				plan2, err := buildPlan(e, reader)
 				require.NoError(t, err)
@@ -2290,8 +2290,8 @@ groups:
 
 				matChart = e.state.materialized.charts["component_load"]
 				require.NotNil(t, matChart)
-				require.Contains(t, matChart.scratchEntries, "ok")
-				require.Contains(t, matChart.scratchEntries, "warn")
+				require.Contains(t, matChart.dimensionScratchEntries(), "ok")
+				require.Contains(t, matChart.dimensionScratchEntries(), "warn")
 			},
 		},
 	}

--- a/src/go/plugin/framework/chartengine/runtime_metrics.go
+++ b/src/go/plugin/framework/chartengine/runtime_metrics.go
@@ -44,11 +44,12 @@ type runtimeMetrics struct {
 	planChartInstances     metrix.StatefulGauge
 	planInferredDimensions metrix.StatefulGauge
 
-	actionCreateChart     metrix.StatefulCounter
-	actionCreateDimension metrix.StatefulCounter
-	actionUpdateChart     metrix.StatefulCounter
-	actionRemoveDimension metrix.StatefulCounter
-	actionRemoveChart     metrix.StatefulCounter
+	actionCreateChart       metrix.StatefulCounter
+	actionCreateDimension   metrix.StatefulCounter
+	actionUpdateChartLabels metrix.StatefulCounter
+	actionUpdateChart       metrix.StatefulCounter
+	actionRemoveDimension   metrix.StatefulCounter
+	actionRemoveChart       metrix.StatefulCounter
 
 	lifecycleRemovedChartByCap        metrix.StatefulCounter
 	lifecycleRemovedChartByExpiry     metrix.StatefulCounter
@@ -72,11 +73,12 @@ type PlanRuntimeSample struct {
 	planChartInstances     int
 	planInferredDimensions int
 
-	actionCreateChart     int
-	actionCreateDimension int
-	actionUpdateChart     int
-	actionRemoveDimension int
-	actionRemoveChart     int
+	actionCreateChart       int
+	actionCreateDimension   int
+	actionUpdateChartLabels int
+	actionUpdateChart       int
+	actionRemoveDimension   int
+	actionRemoveChart       int
 
 	lifecycleRemovedChartByCap        int
 	lifecycleRemovedChartByExpiry     int
@@ -260,11 +262,12 @@ func newRuntimeMetrics(store metrix.RuntimeStore) *runtimeMetrics {
 			metrix.WithUnit("dimensions"),
 		),
 
-		actionCreateChart:     actions.WithLabelValues("create_chart"),
-		actionCreateDimension: actions.WithLabelValues("create_dimension"),
-		actionUpdateChart:     actions.WithLabelValues("update_chart"),
-		actionRemoveDimension: actions.WithLabelValues("remove_dimension"),
-		actionRemoveChart:     actions.WithLabelValues("remove_chart"),
+		actionCreateChart:       actions.WithLabelValues("create_chart"),
+		actionCreateDimension:   actions.WithLabelValues("create_dimension"),
+		actionUpdateChartLabels: actions.WithLabelValues("update_chart_labels"),
+		actionUpdateChart:       actions.WithLabelValues("update_chart"),
+		actionRemoveDimension:   actions.WithLabelValues("remove_dimension"),
+		actionRemoveChart:       actions.WithLabelValues("remove_chart"),
 
 		lifecycleRemovedChartByCap:        lifecycleRemoved.WithLabelValues("chart", "cap"),
 		lifecycleRemovedChartByExpiry:     lifecycleRemoved.WithLabelValues("chart", "expiry"),
@@ -345,6 +348,9 @@ func (m *runtimeMetrics) observeBuild(sample PlanRuntimeSample) {
 	}
 	if sample.actionCreateDimension > 0 {
 		m.actionCreateDimension.Add(float64(sample.actionCreateDimension))
+	}
+	if sample.actionUpdateChartLabels > 0 {
+		m.actionUpdateChartLabels.Add(float64(sample.actionUpdateChartLabels))
 	}
 	if sample.actionUpdateChart > 0 {
 		m.actionUpdateChart.Add(float64(sample.actionUpdateChart))
@@ -460,7 +466,7 @@ func (m *runtimeMetrics) observeBuildRollup(samples []PlanRuntimeSample) {
 	var routeCacheRetained, routeCachePruned, routeCacheFullDrops int
 	var seriesScanned, seriesMatched, seriesUnmatched, seriesAutogenMatched uint64
 	var seriesFilteredBySeq, seriesFilteredBySel uint64
-	var actionCreateChart, actionCreateDimension, actionUpdateChart, actionRemoveDimension, actionRemoveChart int
+	var actionCreateChart, actionCreateDimension, actionUpdateChartLabels, actionUpdateChart, actionRemoveDimension, actionRemoveChart int
 	var lifecycleRemovedChartByCap, lifecycleRemovedChartByExpiry int
 	var lifecycleRemovedDimensionByCap, lifecycleRemovedDimensionByExpiry int
 	var routeCacheEntries, planChartInstances, planInferredDimensions int
@@ -525,6 +531,7 @@ func (m *runtimeMetrics) observeBuildRollup(samples []PlanRuntimeSample) {
 
 		actionCreateChart += sample.actionCreateChart
 		actionCreateDimension += sample.actionCreateDimension
+		actionUpdateChartLabels += sample.actionUpdateChartLabels
 		actionUpdateChart += sample.actionUpdateChart
 		actionRemoveDimension += sample.actionRemoveDimension
 		actionRemoveChart += sample.actionRemoveChart
@@ -568,6 +575,7 @@ func (m *runtimeMetrics) observeBuildRollup(samples []PlanRuntimeSample) {
 
 	addIfPositive(m.actionCreateChart, float64(actionCreateChart))
 	addIfPositive(m.actionCreateDimension, float64(actionCreateDimension))
+	addIfPositive(m.actionUpdateChartLabels, float64(actionUpdateChartLabels))
 	addIfPositive(m.actionUpdateChart, float64(actionUpdateChart))
 	addIfPositive(m.actionRemoveDimension, float64(actionRemoveDimension))
 	addIfPositive(m.actionRemoveChart, float64(actionRemoveChart))
@@ -597,6 +605,8 @@ func actionKindCounts(actions []EngineAction) PlanRuntimeSample {
 			out.actionCreateChart++
 		case ActionCreateDimension:
 			out.actionCreateDimension++
+		case ActionUpdateChartLabels:
+			out.actionUpdateChartLabels++
 		case ActionUpdateChart:
 			out.actionUpdateChart++
 		case ActionRemoveDimension:

--- a/src/go/plugin/framework/chartengine/runtime_metrics_test.go
+++ b/src/go/plugin/framework/chartengine/runtime_metrics_test.go
@@ -390,6 +390,16 @@ func TestEngineRuntimeObservabilityScenarios(t *testing.T) {
 	}
 }
 
+func TestActionKindCountsIncludesChartLabelUpdates(t *testing.T) {
+	got := actionKindCounts([]EngineAction{
+		UpdateChartLabelsAction{},
+		UpdateChartAction{},
+	})
+
+	assert.Equal(t, 1, got.actionUpdateChartLabels)
+	assert.Equal(t, 1, got.actionUpdateChart)
+}
+
 func testNow() time.Time {
 	return time.Now().Add(-time.Second)
 }

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -521,6 +521,10 @@ charts:
 | `lifecycle`       | object        | no       |                        | Instance/dimension cap and expiry (see [lifecycle](#lifecycle)).             |
 | `dimensions`      | array         | **yes**  |                        | At least one dimension required (see [dimensions](#6-dimensions)).           |
 
+Chart and dimension identity labels are immutable routing inputs: changing one creates a new chart or dimension
+ID. Promoted labels are non-identity metadata. When their effective intersection changes, chartengine updates the
+existing chart with a complete replacement label set; it does not recreate the chart or its dimensions.
+
 > [!TIP]
 > When `algorithm` is omitted, the engine infers it from metric name suffixes. You only need to set it explicitly when the suffix doesn't match the intended behavior (e.g., a gauge metric named `*_total`).
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates promoted (non-identity) chart labels in-place without recreating charts. Adds a label update action and a dedicated emission phase in `chartengine`/`chartemit`, with safer state handling, metrics, and benchmarks.

- **New Features**
  - Introduced `UpdateChartLabelsAction` and a label-only emission phase in `chartemit` to send `CLABEL` updates followed by `CLABEL_COMMIT`; updates are sorted and emitted per chart.
  - Planner reconciles `label_promotion` via a new label policy/tracker; emits label updates only when the effective intersection changes, with replay only if a later mismatch is detected along the same selector path.
  - Dimension-only chart creates now preserve existing labels; no redundant `CLABEL` re-emission.
  - Docs clarify that labels used by `instances.by_labels` and `name_from_label` define identity; promoted labels are metadata and are updated in place.

- **Performance**
  - Copy-on-write chart presentation isolates mutable label state (ordered dimensions, canonical label values, membership) so aborted plans don’t leak; membership growth is bounded.
  - Avoids redundant label replay by requiring a matching prefix; only replays when needed.
  - Runtime metrics now track `update_chart_labels`; added planner and emitter benchmarks for label updates and value updates at scale.

<sup>Written for commit 5386533aad03c841ed7ed1428208cf65574a94a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

