### PR TITLE
fix systemd-journal.plugin memory retention after queries and its apps.plugin accounting

### DIFF
--- a/src/collectors/apps.plugin/apps_groups.conf
+++ b/src/collectors/apps.plugin/apps_groups.conf
@@ -242,7 +242,7 @@ afp: netatalk afpd cnid_dbd cnid_metad
 ## -----------------------------------------------------------------------------
 ## Desktops
 
-systemd-journald: *systemd-journal*
+systemd-journald: systemd-journald systemd-journal-remote systemd-journal-upload systemd-journal-gatewayd
 systemd: systemd systemd-*
 
 ## GNOME

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -431,8 +431,10 @@ int main(int argc, char **argv)
 
         bool cancelled = false;
         usec_t stop_monotonic_ut = now_monotonic_usec() + 600 * USEC_PER_SEC;
+        // "__logs_sources" is LQS_PARAMETER_SOURCE (logs_query_status.h); a plain
+        // "source:" is parsed as a filter on a user field named "source" and matches nothing
         char buf[] =
-            "systemd-journal after:-8640000 before:0 direction:backward last:200 data_only:false slice:true facets: source:all";
+            "systemd-journal after:-8640000 before:0 direction:backward last:200 data_only:false slice:true facets: __logs_sources:all";
         function_systemd_journal("123", buf, &stop_monotonic_ut, &cancelled, NULL, HTTP_ACCESS_ALL, NULL, NULL);
         exit(1);
     }

--- a/src/libnetdata/functions_evloop/functions_evloop.c
+++ b/src/libnetdata/functions_evloop/functions_evloop.c
@@ -135,6 +135,12 @@ static void rrd_functions_worker_globals_worker_main(void *arg) {
             dictionary_del(wg->worker_queue, j->transaction);
             dictionary_acquired_item_release(wg->worker_queue, acquired);
             dictionary_garbage_collect(wg->worker_queue);
+
+            // when all workers become idle, return the freed query memory to the OS;
+            // otherwise glibc keeps it in its arenas and the plugin retains the RSS
+            // high-water mark of the biggest query it ever executed
+            if(!dictionary_entries(wg->worker_queue))
+                mallocz_release_as_much_memory_to_the_system();
         }
     }
 }


### PR DESCRIPTION
Fixes two independent issues around `systemd-journal.plugin`, plus one coupled debug-mode fix.

## 1. apps.plugin wrongly accounts `systemd-journal.plugin` as `systemd-journald`

The `systemd-journald` group in `apps_groups.conf` used the substring pattern `*systemd-journal*`, which matches against the full process **cmdline**. This wrongly captured netdata's own `/usr/libexec/netdata/plugins.d/systemd-journal.plugin` (and anything else with `systemd-journal` anywhere in its cmdline, e.g. `journalctl -u systemd-journald`), polluting journald accounting with netdata's log-query workload.

**Fix:** match the journald family by exact process names: `systemd-journald`, `systemd-journal-remote`, `systemd-journal-upload`, `systemd-journal-gatewayd`. Names longer than the 15-char comm limit are reconstructed from the cmdline by apps.plugin, so exact matching works for all four (verified live, including a running `systemd-journal-upload`).

**Dashboard-visible change:** netdata's journal plugin now appears as its own group (`sd-jrnl.plugin`, its runtime process name), like every other netdata external plugin, instead of inflating `systemd-journald`.

## 2. `systemd-journal.plugin` retains the RSS high-water mark of its biggest query forever

It is **not a leak**: ASAN/LSan reports identical output (1102 bytes of one-time init globals) for a trivial `info` request and for a 16-second full-text search over 117 GB of journals — leaked bytes do not scale with work. All per-query memory (facets, LQS, buffers, `sd_journal` handles) is freed at query end.

The problem is that glibc keeps the freed memory in its arenas and never returns it to the OS: the plugin never calls `malloc_trim()` (the only trim in the tree runs in the daemon's dbengine eviction — a different process), and `M_TRIM_THRESHOLD` cannot be inherited through the environment.

Measured with 3 heavy queries (7-day full-text search, ~7.7M rows evaluated each), plugin driven over the plugins.d protocol:

| | baseline | after 3 queries | after `malloc_trim(0)` via gdb |
|---|---|---|---|
| `MALLOC_ARENA_MAX=4` (parent) | 15,240 kB | 37,516 kB | 18,536 kB |
| `MALLOC_ARENA_MAX=1` (standalone) | 15,288 kB | 27,204 kB | 17,276 kB |

**Fix:** in the `functions_evloop` worker, after a function job completes and the worker queue is empty (no pending and no running jobs), call `mallocz_release_as_much_memory_to_the_system()`. Under back-to-back load no trim happens (memory is actively reused); the last job of every burst always trims, so no retention window remains. This covers all function plugins with the same pattern (systemd-journal, windows-events, macos-logs, systemd-units, network-viewer, debugfs, freeipmi, apps, ebpf). On platforms without `malloc_trim()` (musl static builds, macOS, Windows, FreeBSD) it compiles to a no-op.

With the fix, the same experiment gives:

| | baseline | after 3 queries | external `malloc_trim(0)` recovers |
|---|---|---|---|
| `MALLOC_ARENA_MAX=4` | 16,604 kB | 19,084 kB | 0 kB |
| `MALLOC_ARENA_MAX=1` | 15,272 kB | 17,180 kB | 0 kB |

Query results are unchanged (same evaluated/matched/returned counts), and ASAN reports no new leaks.

## 3. `systemd-journal.plugin debug` mode evaluated 0 rows

The hidden `debug` command-line mode still used the stale GET parameter `source:all`; the parameter was renamed to `__logs_sources`. The stale name is parsed as a filter on a user field named `source`, matching nothing. Fixed to use `__logs_sources:all` — debug mode now evaluates the journal normally (27.9M rows on the test box, was 0).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match exact journald process names so `systemd-journal.plugin` is no longer counted under `systemd-journald`. Trim freed memory when function workers go idle to avoid retained RSS, and fix debug mode to read from all sources.

- **Bug Fixes**
  - apps.plugin: Replace `*systemd-journal*` with exact names (`systemd-journald`, `systemd-journal-remote`, `systemd-journal-upload`, `systemd-journal-gatewayd`). The plugin now appears as `sd-jrnl.plugin`, not under journald.
  - Memory: In `functions_evloop`, when the worker queue becomes empty, call `mallocz_release_as_much_memory_to_the_system()` to return freed memory to the OS. Applies to all function plugins; no-op where `malloc_trim()` isn’t available.
  - Debug mode: Use `__logs_sources:all` instead of `source:all` so the journal is evaluated.

<sup>Written for commit 7c60108bdb0c4d8a803c00781151ba556d6700f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

