### PR TITLE
feat(go.d/cloudwatch): add resource tag filtering

### DIFF
--- a/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
@@ -285,8 +285,8 @@ Discovery then finds which *instances* of those profiles exist per target and re
   the series gaps until fresh data, and a stale value is never re-emitted.
   Without an explicit override, only `rate: true` metrics at `sum` or
   `sample_count` default to zero; every other statistic gaps. The cache otherwise
-  persists until the instance leaves discovery and `pruneObserved` drops it.
-- `pruneObserved` drops both cached series and per-(target, region, period) schedule entries
+  persists until the instance leaves discovery and `reconcilePlan` drops it.
+- `reconcilePlan` drops both cached series and per-(target, region, period) schedule entries
   absent from the current plan when that immutable plan is rebuilt, so removed resources
   stop being re-emitted and a group that later reappears is queried on its first cycle
   back rather than waiting for a stale schedule entry to expire.
@@ -309,7 +309,8 @@ refreshDiscovery → refreshTags → buildQueryPlan → … → observe
 - **Failure state.** A failed filtered group becomes `unknown`. On the first failure,
   every candidate is withheld and reserved from lower-priority rules. After a success,
   last-known matched members continue to be queried while every other candidate remains
-  reserved. Failed groups retry next collect; successful groups use the discovery TTL.
+  reserved. Freshness and retry state are fetch-group-local: failed groups retry next
+  collect while successful groups keep their result until its discovery TTL expires.
   Optional label enrichment carries last-known labels and never controls identity.
 - **Label resolution (`tagresolve.go`).** `resolveTagPlan` turns
   `labels.resource_tags` into a per-profile `awsKey → label` plan once. Global config
@@ -317,10 +318,12 @@ refreshDiscovery → refreshTags → buildQueryPlan → … → observe
   `account_id`, `region`, or dimension labels are skipped with one warning. The optional
   `label` resolves collisions; the default is the sanitized key (`Name` → `name`).
 - **ARN↔dimension join (`tagjoin.go`).** RGTA returns ARN + tags; the cache is keyed by
-  the profile's ARN-projectable `joinKey`. A per-profile mapper (a default
-  last-resource-segment extractor plus overrides for ALB/NLB/target-group/ECS/OpenSearch/
+  the profile's ARN-projectable `joinKey`. A namespace-bound per-profile mapper (a
+  default single-component resource-id extractor plus overrides for ALB/NLB/target-group/ECS/OpenSearch/
   Step-Functions) derives the `joinKey` from the ARN, and the instance side projects its
-  dimension values onto the same key. Parent-resource profiles (S3,
+  dimension values onto the same key. The compiler accepts a registered mapper only
+  when an override retains its expected CloudWatch namespace and every join dimension
+  remains identifying (not constant). Parent-resource profiles (S3,
   DynamoDB-operation, and ALB-target) key on the parent dimension so children
   inherit its tags.
   A default-selected profile without a safe association is skipped when filtering is

--- a/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
@@ -148,22 +148,24 @@ compiler state, and installed execution plan:
 
 - YAML and JSON use normal typed decoding; unknown keys are ignored. `Config.validate`
   decides whether the resulting configuration is valid during `Init` / `Check`.
-  Known future rule fields (`filters`, `labels`, `series`, and `query`) remain typed
-  so non-null values are rejected until their implementation phases land; null is
-  equivalent to omission.
 - Named credential sources describe only credential acquisition. Named targets
   describe monitored identities and optional role assumption. Ordered rules bind
-  targets to profile selectors and regions.
+  targets to profile selectors, regions, and effective resource-tag predicates.
+- `defaults.filters.resource_tags` is inherited when a rule omits
+  `filters.resource_tags`; a present list replaces the default and `[]` disables it.
+  Predicates are canonicalized once: exact case-sensitive keys are ANDed and the
+  exact values for one key are ORed.
 - `compileConfig` coordinates a private staged compiler that resolves every reference, rejects unused credential/target
   definitions, applies profile defaults/include/exclude semantics, intersects
   intrinsic supported regions, enforces target/role partition consistency, and
   emits immutable ordered scopes.
-- Exact duplicate target/profile/region scopes are removed statically with one
+- Exact duplicate target/profile/region/predicate scopes are removed statically with one
   bounded aggregate diagnostic per affected rule. Same-account cross-target overlap remains until discovery,
-  where final emitted-series identity can be evaluated correctly.
+  where final instance identity can be evaluated correctly. Scopes with different
+  predicates remain ordered policy scopes even when they share one discovery scan.
 - Fixed internal caps bound credentials, 64 targets, rules, list references,
   candidate-scope evaluation, and compiled scopes. Overflow fails compilation and never installs a partial plan;
-  these safeguards are not public tuning settings.
+  `limits.max_instances` is the separate public bound on final selected instances.
 
 ## Discovery
 
@@ -196,8 +198,8 @@ Discovery then finds which *instances* of those profiles exist per target and re
   targets**, so a transient per-region/namespace failure never drops series.
   Only a first-ever pass where every scope errors is fatal; after any
   snapshot exists, discovery errors are warnings.
-- A warning fires at ≥1000 discovered instances (a cost signal); collection is
-  never truncated.
+- A warning fires at ≥1000 discovered instances as an early cost signal. The
+  separate final-instance limit is applied later, after tag filtering and overlap.
 
 ## Query Planning And Scheduling
 
@@ -209,9 +211,13 @@ Discovery then finds which *instances* of those profiles exist per target and re
   Identity labels are `{account_id, region}` plus one label per identifying
   instance dimension (a `constant` dimension is sent in the query but not
   labeled). The exported series name is `<profile>.<metric_id>_<statistic>`.
-- Compiled scope order and a final-series identity set enforce rule precedence:
-  the first rule/target that produces a series owns it. This catches dynamic
+- Resource-tag membership is applied before metric/statistic expansion. Compiled
+  scope order and a final-instance identity set enforce rule precedence: the first
+  matching rule/target owns the whole instance. This catches dynamic
   overlap when distinct targets resolve to the same account and see the same resource.
+- `limits.max_instances` counts those owned final instances, not planned metric
+  queries. Overflow rejects the rebuilt plan atomically and leaves the previous
+  immutable plan installed; there is no first-N truncation.
 - Queries are grouped by `queryGroupKey{target, region, period}` — the batch unit
   (shared client and time window) and the scheduling unit.
 - The `observationStore` keeps a per-(target, region, period) `nextQueryAt`. `dueGroups`
@@ -285,47 +291,50 @@ Discovery then finds which *instances* of those profiles exist per target and re
   stop being re-emitted and a group that later reappears is queried on its first cycle
   back rather than waiting for a stale schedule entry to expire.
 
-## Tag Enrichment (`tags.go`, `tagjoin.go`, `tagresolve.go`)
+## Resource Tag Filtering And Labels (`tags.go`, `tag_fetch.go`, `tagjoin.go`, `tagresolve.go`)
 
-Opt-in (`tags` config, empty by default). When set, the collector attaches selected
-AWS resource tags as **non-identity** chart labels, so `i-0abc123` also carries
-`owner`/`project`/`name`/… without changing series identity. It slots into the cycle
-between discovery and query planning:
+Resource-tag predicates select instances before query expansion. Separately,
+`labels.resource_tags` copies selected AWS tags to **non-identity** chart labels.
+Both use one resolution stage between discovery and query planning:
 
 ```text
 refreshDiscovery → refreshTags → buildQueryPlan → … → observe
 ```
 
-- **Client + cache.** A Resource Groups Tagging API (RGTA) client is built per
-  `{target, region}` (the same generic `clientCache[T]` as the CloudWatch client).
-  `refreshTags` runs on the discovery TTL and is best-effort: a per-`{target, region}`
-  failure keeps that scope's **last-known** tags (a first-run failure yields none) and
-  never fails the cycle. With no tags configured, no RGTA client is ever built.
-- **Resolution (`tagresolve.go`).** `resolveTagPlan` turns the allowlist into a
-  per-profile `awsKey → label` plan, once. It is **non-fatal**: an entry whose label is
-  empty/invalid, collides with a reserved (`account_id`/`region`) or dimension label, or
-  duplicates another tag is **skipped with a warning** — never a config error, never an
-  emitted duplicate key (which would panic `metrix`). `rename` resolves collisions; the
-  default label is the sanitized key (`Name` → `name`).
+- **Focused fetches.** A Resource Groups Tagging API (RGTA) client is cached per
+  `{target, region}`. Policy scopes sharing target, region, and canonical predicate
+  share a fetch group. Each request supplies native `TagFilters` and the union of
+  compatible `ResourceTypeFilters`; pages are streamed directly into membership and
+  label indexes, locally rechecked, and intersected with discovered candidates.
+- **Failure state.** A failed filtered group becomes `unknown`. On the first failure,
+  every candidate is withheld and reserved from lower-priority rules. After a success,
+  last-known matched members continue to be queried while every other candidate remains
+  reserved. Failed groups retry next collect; successful groups use the discovery TTL.
+  Optional label enrichment carries last-known labels and never controls identity.
+- **Label resolution (`tagresolve.go`).** `resolveTagPlan` turns
+  `labels.resource_tags` into a per-profile `awsKey → label` plan once. Global config
+  validation rejects malformed or duplicate entries; profile-specific collisions with
+  `account_id`, `region`, or dimension labels are skipped with one warning. The optional
+  `label` resolves collisions; the default is the sanitized key (`Name` → `name`).
 - **ARN↔dimension join (`tagjoin.go`).** RGTA returns ARN + tags; the cache is keyed by
   the profile's ARN-projectable `joinKey`. A per-profile mapper (a default
   last-resource-segment extractor plus overrides for ALB/NLB/target-group/ECS/OpenSearch/
   Step-Functions) derives the `joinKey` from the ARN, and the instance side projects its
-  dimension values onto the same key. **Safe failure mode:** a wrong ARN assumption is a
-  cache *miss* (no tags), never *wrong* tags, because the instance side uses real
-  dimension values. Parent-resource profiles (S3, DynamoDB-operation, ALB-target) key on
-  the parent dimension so children inherit its tags. Unregistered profiles
-  (auto_scaling, bedrock, and the ambiguous cloudfront/api_gateway/msk/elasticache) carry
-  no tags.
+  dimension values onto the same key. Parent-resource profiles (S3,
+  DynamoDB-operation, and ALB-target) key on the parent dimension so children
+  inherit its tags.
+  A default-selected profile without a safe association is skipped when filtering is
+  effective; explicitly including one is a config error unless that rule disables or
+  replaces the filter. Labels-only use remains best-effort for unsupported profiles.
 - **Emission split.** Identity `labels` (`{account_id, region, <dims>}`) and `tagLabels`
   travel separately through `plannedQuery`/`querySample`/`observedSeries`. `writeSample`
   emits `labels + tagLabels` in a fresh slice; `observedKey` (the retention/scheduling
   identity) uses **identity labels only**, so a tag change never churns scheduling, and
   retention re-emit carries the last-known `tagLabels`. `chartengine` `auto_intersection`
   then promotes the tag labels as non-identity chart labels — no template change.
-- **INV.2.** Tags only ADD labels; they never gate series existence. A custom profile
-  that names a tag in `instances.by_labels` (or uses `["*"]`) is out of scope — that is
-  the operator's own chart-identity choice.
+  A changed effective label set invalidates the plan once; observation reconciliation
+  updates retained tag labels and the normal numeric snapshot causes chartengine to
+  emit a label-only chart-definition update for an existing chart.
 
 ## Dynamic Charts
 
@@ -425,8 +434,8 @@ Each target's AWS account id is resolved through STS `GetCallerIdentity`
 fail-soft and retried: an unresolved target stays pending while healthy targets
 continue; only a cycle with no resolved target fails. Named targets are never
 deduplicated by account id because their permissions and visible resources may
-differ. Dynamic final-series overlap is deduplicated later by ordered rule/target
-precedence. AWS does not require an explicit IAM permission grant for
+differ. Dynamic final-instance overlap is deduplicated later by ordered
+rule/target precedence. AWS does not require an explicit IAM permission grant for
 `GetCallerIdentity`.
 
 Partition consistency is enforced per target. A target cannot span AWS
@@ -483,13 +492,14 @@ verify current per-region prices on the CloudWatch pricing page.)
 - **Job-level placement** — AWS resources are chart instances via `by_labels`.
   They use the configured job `vnode` or the Agent host; no per-target/resource
   HostScope is generated.
-- **Tags are additive** — the opt-in `tags` allowlist adds non-identity labels
-  only; it never gates series existence and never overwrites an identity label
-  (a colliding tag is skipped with a warning).
+- **Tag filters fail closed** — unknown membership never becomes unfiltered
+  collection and never allows a lower-priority rule to claim the candidate.
+- **Tag labels are non-identity** — `labels.resource_tags` can update labels on an
+  existing chart but cannot change its identity or overwrite an identity label.
 - **Compiled configuration** — operator-facing credentials, targets, and ordered
-  rules are validated and expanded once. Discovery, `query_offset`, `timeout`,
-  the opt-in `tags` allowlist, `vnode`, and the framework's common fields remain
-  job-level settings.
+  rules are validated and expanded once. Discovery, tag-label presentation,
+  `limits.max_instances`, `query_offset`, `timeout`, `vnode`, and the framework's
+  common fields remain job-level settings.
   Concurrency, batch size, and the recently-active period bound are internal
   constants.
 

--- a/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
@@ -151,7 +151,7 @@ compiler state, and installed execution plan:
 - Named credential sources describe only credential acquisition. Named targets
   describe monitored identities and optional role assumption. Ordered rules bind
   targets to profile selectors, regions, and effective resource-tag predicates.
-- `defaults.filters.resource_tags` is inherited when a rule omits
+- `rule_defaults.filters.resource_tags` is inherited when a rule omits
   `filters.resource_tags`; a present list replaces the default and `[]` disables it.
   Predicates are canonicalized once: exact case-sensitive keys are ANDed and the
   exact values for one key are ORed.

--- a/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
@@ -306,6 +306,9 @@ refreshDiscovery → refreshTags → buildQueryPlan → … → observe
   share a fetch group. Each request supplies native `TagFilters` and the union of
   compatible `ResourceTypeFilters`; pages are streamed directly into membership and
   label indexes, locally rechecked, and intersected with discovered candidates.
+  Fetch topology is rebuilt only when discovery changes, and predicate groups share
+  one candidate index per target/region/profile. Cached results retain membership,
+  labels, scope ids, and freshness—not fetch-time candidate maps.
 - **Failure state.** A failed filtered group becomes `unknown`. On the first failure,
   every candidate is withheld and reserved from lower-priority rules. After a success,
   last-known matched members continue to be queried while every other candidate remains
@@ -448,14 +451,15 @@ aws-eusc).
 
 ## Concurrency
 
-- `apiConcurrency` (5) bounds both the discovery fan-out and the GetMetricData
-  chunk execution, via `conc/pool`. `metricsPerQuery` (500) is the GetMetricData
-  batch size. Both are internal constants, not config.
+- `apiConcurrency` (5) bounds ListMetrics discovery, RGTA fetch groups, and
+  GetMetricData chunk execution via `conc/pool`. `metricsPerQuery` (500) is the
+  GetMetricData batch size. Both are internal constants, not config.
 - `clientCache` builds at most one CloudWatch client per (target, region), under
   a mutex, caching only successes (a transient credential error is retried next
   call).
 - The top-level `collect` stages run sequentially, and the per-cycle `store`
-  write is single-threaded. Only discovery and query execution fan out.
+  write is single-threaded. Discovery, resource-tag lookup, and query execution
+  fan out within their respective stages.
 
 ## Cost Model
 

--- a/src/go/plugin/go.d/collector/cloudwatch/collect.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/collect.go
@@ -14,9 +14,12 @@ func (c *Collector) collect(ctx context.Context) error {
 	if err := c.refreshDiscovery(ctx); err != nil {
 		return err
 	}
-	c.refreshTags(ctx) // best-effort tag enrichment; never gates collection (INV.2)
+	c.refreshTags(ctx)
 
-	plan := c.currentQueryPlan()
+	plan, err := c.currentQueryPlan()
+	if err != nil {
+		return err
+	}
 
 	now := c.now()
 	due := c.observations.dueGroups(c.queryGroups, now)

--- a/src/go/plugin/go.d/collector/cloudwatch/collector.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/collector.go
@@ -52,6 +52,7 @@ func New() *Collector {
 			AutoDetectionRetry: defaultAutoDetectRetry,
 			Discovery:          DiscoveryConfig{RefreshEvery: defaultDiscoveryRefresh},
 			QueryOffset:        defaultQueryOffset,
+			Limits:             LimitsConfig{MaxInstances: defaultMaxInstances},
 			Timeout:            defaultTimeout,
 		},
 		store:               metrix.NewCollectorStore(),
@@ -97,8 +98,8 @@ type Collector struct {
 
 	observations *observationStore // retention cache + per-(target, region, period) query schedule
 
-	tags     tagSnapshot              // resource tag cache, refreshed with discovery (empty when tags unconfigured)
-	tagPlans map[string][]resolvedTag // per-profile resolved tag->label plans (nil when tags unconfigured)
+	tags          tagSnapshot              // resource-tag membership and label cache, refreshed with discovery
+	tagLabelPlans map[string][]resolvedTag // per-profile resolved tag->label plans (nil until compiled)
 }
 
 func (c *Collector) Init(context.Context) error {
@@ -134,7 +135,7 @@ func (c *Collector) Cleanup(context.Context) {
 	c.rgtaClients.reset()
 	c.observations.reset()
 	c.tags = tagSnapshot{}
-	c.tagPlans = nil
+	c.tagLabelPlans = nil
 }
 
 func (c *Collector) Configuration() any { return c.Config }

--- a/src/go/plugin/go.d/collector/cloudwatch/collector.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/collector.go
@@ -100,6 +100,7 @@ type Collector struct {
 
 	tags          tagSnapshot              // resource-tag membership and label cache, refreshed with discovery
 	tagLabelPlans map[string][]resolvedTag // per-profile resolved tag->label plans (nil until compiled)
+	tagFetchPlan  []tagFetchGroup          // immutable discovery-derived RGTA topology (nil when invalidated)
 }
 
 func (c *Collector) Init(context.Context) error {
@@ -136,6 +137,7 @@ func (c *Collector) Cleanup(context.Context) {
 	c.observations.reset()
 	c.tags = tagSnapshot{}
 	c.tagLabelPlans = nil
+	c.tagFetchPlan = nil
 }
 
 func (c *Collector) Configuration() any { return c.Config }

--- a/src/go/plugin/go.d/collector/cloudwatch/collector_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/collector_test.go
@@ -86,7 +86,7 @@ func setSingleTargetPlan(c *Collector, account string, regions []string, profile
 	for _, region := range regions {
 		for _, profile := range profiles {
 			plan.Scopes = append(plan.Scopes, collectionScope{
-				Target: target, Profile: profile, Region: region, TagJoin: plan.TagJoins[profile.Name],
+				Target: target, Profile: profile, Region: region,
 			})
 		}
 	}

--- a/src/go/plugin/go.d/collector/cloudwatch/collector_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/collector_test.go
@@ -76,10 +76,18 @@ func setSingleTargetPlan(c *Collector, account string, regions []string, profile
 	plan := &collectionPlan{
 		Targets:  []*collectionTarget{target},
 		Profiles: profiles,
+		TagJoins: make(map[string]*tagJoin),
+	}
+	for _, profile := range profiles {
+		if join, err := resolveTagJoinProfile(profile); err == nil {
+			plan.TagJoins[profile.Name] = join
+		}
 	}
 	for _, region := range regions {
 		for _, profile := range profiles {
-			plan.Scopes = append(plan.Scopes, collectionScope{Target: target, Profile: profile, Region: region})
+			plan.Scopes = append(plan.Scopes, collectionScope{
+				Target: target, Profile: profile, Region: region, TagJoin: plan.TagJoins[profile.Name],
+			})
 		}
 	}
 	resolved := resolvedTarget{target: target, accountID: account}

--- a/src/go/plugin/go.d/collector/cloudwatch/config.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	Credentials        []CredentialSourceConfig `yaml:"credentials" json:"credentials"`
 	Targets            []TargetConfig           `yaml:"targets" json:"targets"`
 	Rules              []RuleConfig             `yaml:"rules" json:"rules"`
-	Defaults           DefaultsConfig           `yaml:"defaults,omitempty" json:"defaults,omitempty"`
+	RuleDefaults       RuleDefaultsConfig       `yaml:"rule_defaults,omitempty" json:"rule_defaults,omitempty"`
 	Labels             LabelsConfig             `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Limits             LimitsConfig             `yaml:"limits,omitempty" json:"limits,omitempty"`
 	Discovery          DiscoveryConfig          `yaml:"discovery" json:"discovery"`
@@ -64,11 +64,11 @@ type RuleConfig struct {
 	Filters  *RuleFiltersConfig     `yaml:"filters,omitempty" json:"filters,omitempty"`
 }
 
-type DefaultsConfig struct {
-	Filters DefaultFiltersConfig `yaml:"filters,omitempty" json:"filters,omitempty"`
+type RuleDefaultsConfig struct {
+	Filters RuleDefaultFiltersConfig `yaml:"filters,omitempty" json:"filters,omitempty"`
 }
 
-type DefaultFiltersConfig struct {
+type RuleDefaultFiltersConfig struct {
 	ResourceTags []ResourceTagFilterConfig `yaml:"resource_tags,omitempty" json:"resource_tags,omitempty"`
 }
 

--- a/src/go/plugin/go.d/collector/cloudwatch/config.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config.go
@@ -36,9 +36,9 @@ type Config struct {
 	Credentials        []CredentialSourceConfig `yaml:"credentials" json:"credentials"`
 	Targets            []TargetConfig           `yaml:"targets" json:"targets"`
 	Rules              []RuleConfig             `yaml:"rules" json:"rules"`
-	RuleDefaults       RuleDefaultsConfig       `yaml:"rule_defaults,omitempty" json:"rule_defaults,omitempty"`
-	Labels             LabelsConfig             `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Limits             LimitsConfig             `yaml:"limits,omitempty" json:"limits,omitempty"`
+	RuleDefaults       RuleDefaultsConfig       `yaml:"rule_defaults,omitempty" json:"rule_defaults"`
+	Labels             LabelsConfig             `yaml:"labels,omitempty" json:"labels"`
+	Limits             LimitsConfig             `yaml:"limits,omitempty" json:"limits"`
 	Discovery          DiscoveryConfig          `yaml:"discovery" json:"discovery"`
 	QueryOffset        int                      `yaml:"query_offset,omitempty" json:"query_offset"`
 	Timeout            confopt.Duration         `yaml:"timeout,omitempty" json:"timeout"`
@@ -65,7 +65,7 @@ type RuleConfig struct {
 }
 
 type RuleDefaultsConfig struct {
-	Filters RuleDefaultFiltersConfig `yaml:"filters,omitempty" json:"filters,omitempty"`
+	Filters RuleDefaultFiltersConfig `yaml:"filters,omitempty" json:"filters"`
 }
 
 type RuleDefaultFiltersConfig struct {

--- a/src/go/plugin/go.d/collector/cloudwatch/config.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config.go
@@ -20,11 +20,10 @@ const (
 	defaultTimeout          = confopt.Duration(30 * time.Second)
 )
 
-// apiConcurrency bounds concurrent AWS API calls (discovery fan-out and
-// GetMetricData query chunks); 5 stays well under CloudWatch's account-level
-// request rates. metricsPerQuery is the GetMetricData batch size; 500 is the AWS
-// hard maximum per call. Neither is an operator decision, so both are fixed
-// constants rather than config.
+// apiConcurrency bounds concurrent AWS API calls (ListMetrics discovery,
+// resource-tag lookup, and GetMetricData query chunks). metricsPerQuery is the
+// GetMetricData batch size; 500 is the AWS hard maximum per call. Neither is an
+// operator decision, so both are fixed constants rather than config.
 const (
 	apiConcurrency  = 5
 	metricsPerQuery = 500

--- a/src/go/plugin/go.d/collector/cloudwatch/config.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config.go
@@ -16,6 +16,7 @@ const (
 	defaultAutoDetectRetry  = 0
 	defaultDiscoveryRefresh = 300
 	defaultQueryOffset      = 600
+	defaultMaxInstances     = 1000
 	defaultTimeout          = confopt.Duration(30 * time.Second)
 )
 
@@ -36,8 +37,10 @@ type Config struct {
 	Credentials        []CredentialSourceConfig `yaml:"credentials" json:"credentials"`
 	Targets            []TargetConfig           `yaml:"targets" json:"targets"`
 	Rules              []RuleConfig             `yaml:"rules" json:"rules"`
+	Defaults           DefaultsConfig           `yaml:"defaults,omitempty" json:"defaults,omitempty"`
+	Labels             LabelsConfig             `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Limits             LimitsConfig             `yaml:"limits,omitempty" json:"limits,omitempty"`
 	Discovery          DiscoveryConfig          `yaml:"discovery" json:"discovery"`
-	Tags               []TagConfig              `yaml:"tags,omitempty" json:"tags,omitempty"`
 	QueryOffset        int                      `yaml:"query_offset,omitempty" json:"query_offset"`
 	Timeout            confopt.Duration         `yaml:"timeout,omitempty" json:"timeout"`
 }
@@ -59,10 +62,41 @@ type RuleConfig struct {
 	Targets  []string               `yaml:"targets" json:"targets"`
 	Profiles *ProfileSelectorConfig `yaml:"profiles,omitempty" json:"profiles,omitempty"`
 	Regions  []string               `yaml:"regions" json:"regions"`
-	Filters  any                    `yaml:"filters,omitempty" json:"filters,omitempty"`
-	Labels   any                    `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Series   any                    `yaml:"series,omitempty" json:"series,omitempty"`
-	Query    any                    `yaml:"query,omitempty" json:"query,omitempty"`
+	Filters  *RuleFiltersConfig     `yaml:"filters,omitempty" json:"filters,omitempty"`
+}
+
+type DefaultsConfig struct {
+	Filters DefaultFiltersConfig `yaml:"filters,omitempty" json:"filters,omitempty"`
+}
+
+type DefaultFiltersConfig struct {
+	ResourceTags []ResourceTagFilterConfig `yaml:"resource_tags,omitempty" json:"resource_tags,omitempty"`
+}
+
+// RuleFiltersConfig distinguishes an omitted resource_tags field (inherit the
+// per-job default) from an explicitly empty list (disable it for this rule).
+type RuleFiltersConfig struct {
+	ResourceTags *[]ResourceTagFilterConfig `yaml:"resource_tags,omitempty" json:"resource_tags,omitempty"`
+}
+
+type ResourceTagFilterConfig struct {
+	Key    string   `yaml:"key" json:"key"`
+	Values []string `yaml:"values" json:"values"`
+}
+
+type LabelsConfig struct {
+	ResourceTags []ResourceTagLabelConfig `yaml:"resource_tags,omitempty" json:"resource_tags,omitempty"`
+}
+
+// ResourceTagLabelConfig maps one exact AWS tag key to a Netdata label. Label
+// defaults to the sanitized AWS key when omitted.
+type ResourceTagLabelConfig struct {
+	Key   string `yaml:"key" json:"key"`
+	Label string `yaml:"label,omitempty" json:"label,omitempty"`
+}
+
+type LimitsConfig struct {
+	MaxInstances int `yaml:"max_instances,omitempty" json:"max_instances"`
 }
 
 type ProfileSelectorConfig struct {
@@ -73,17 +107,6 @@ type ProfileSelectorConfig struct {
 
 func (c *ProfileSelectorConfig) includesDefaults() bool {
 	return c == nil || c.Defaults == nil || *c.Defaults
-}
-
-// TagConfig selects one AWS resource tag to emit as an additional label. Name is
-// the AWS tag key (case-sensitive). Rename optionally sets the Netdata label name;
-// without it the label is the sanitized tag key. An empty allowlist disables tag
-// enrichment entirely (no RGTA calls, no extra IAM). Tag resolution -- sanitize,
-// collision skip-and-warn, per-service ARN join -- is non-fatal and runs after
-// profile selection, never in config validation.
-type TagConfig struct {
-	Name   string `yaml:"name" json:"name"`
-	Rename string `yaml:"rename,omitempty" json:"rename,omitempty"`
 }
 
 type DiscoveryConfig struct {
@@ -111,6 +134,9 @@ func (c *Config) applyDefaults() {
 	if c.QueryOffset <= 0 {
 		c.QueryOffset = defaultQueryOffset
 	}
+	if c.Limits.MaxInstances == 0 {
+		c.Limits.MaxInstances = defaultMaxInstances
+	}
 	if c.Timeout.Duration() == 0 {
 		c.Timeout = defaultTimeout
 	}
@@ -131,11 +157,21 @@ func (c Config) validate() error {
 	if c.Timeout.Duration() < 0 {
 		errs = append(errs, errors.New("'timeout' cannot be negative"))
 	}
+	if c.Limits.MaxInstances < 0 {
+		errs = append(errs, errors.New("'limits.max_instances' must be >= 1"))
+	}
 	if err := validateConfigStructure(c); err != nil {
 		errs = append(errs, err)
 	}
 
 	return errors.Join(errs...)
+}
+
+func (r RuleConfig) effectiveResourceTagFilters(defaults []ResourceTagFilterConfig) []ResourceTagFilterConfig {
+	if r.Filters == nil || r.Filters.ResourceTags == nil {
+		return defaults
+	}
+	return *r.Filters.ResourceTags
 }
 
 func normalizeRegions(regions []string) []string {

--- a/src/go/plugin/go.d/collector/cloudwatch/config_schema.json
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_schema.json
@@ -171,7 +171,7 @@
       },
       "rules": {
         "title": "Collection rules",
-        "description": "Ordered target, profile, and region selections. Earlier rules own overlapping final metric series; within one rule, earlier targets own overlaps.",
+        "description": "Ordered target, profile, region, and resource-filter selections. The earliest matching rule and target own each overlapping final resource instance.",
         "type": "array",
         "minItems": 1,
         "maxItems": 256,
@@ -247,6 +247,43 @@
                 "type": "string",
                 "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)+-[0-9]+$"
               }
+            },
+            "filters": {
+              "title": "Resource filters",
+              "description": "Selection predicates for this rule. Omit resource_tags to inherit the job default; set it to an empty list to disable the default for this rule.",
+              "type": "object",
+              "properties": {
+                "resource_tags": {
+                  "title": "AWS resource tag filters",
+                  "description": "Replaces the job-default resource tag filters for this rule. All keys must match; any listed value may match for one key. Keys and values are exact and case-sensitive. An explicitly included profile without a safe resource-tag association is rejected.",
+                  "type": "array",
+                  "maxItems": 50,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "title": "AWS tag key",
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "values": {
+                        "title": "Accepted values",
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 20,
+                        "uniqueItems": true,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "values"
+                    ]
+                  }
+                }
+              }
             }
           },
           "required": [
@@ -254,6 +291,93 @@
             "targets",
             "regions"
           ]
+        }
+      },
+      "defaults": {
+        "title": "Collection defaults",
+        "description": "Job-wide defaults inherited by collection rules that do not replace them.",
+        "type": "object",
+        "properties": {
+          "filters": {
+            "title": "Resource filters",
+            "type": "object",
+            "properties": {
+              "resource_tags": {
+                "title": "Default AWS resource tag filters",
+                "description": "Select only resources matching these exact tags unless a rule replaces or explicitly disables the list. All keys must match; any listed value may match for one key. Default-selected profiles without a safe resource-tag association are skipped with a diagnostic.",
+                "type": "array",
+                "maxItems": 50,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "title": "AWS tag key",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "values": {
+                      "title": "Accepted values",
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 20,
+                      "uniqueItems": true,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "values"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "labels": {
+        "title": "Resource labels",
+        "description": "Optional AWS resource tags copied to every matching Netdata chart as non-identity labels.",
+        "type": "object",
+        "properties": {
+          "resource_tags": {
+            "title": "AWS resource tag labels",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "title": "AWS tag key",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "label": {
+                  "title": "Netdata label",
+                  "description": "Optional label key. When omitted, the AWS tag key is normalized to a Netdata label key.",
+                  "type": "string",
+                  "pattern": "^(?:|[a-z][a-z0-9_]*)$"
+                }
+              },
+              "required": [
+                "key"
+              ]
+            }
+          }
+        }
+      },
+      "limits": {
+        "title": "Collection limits",
+        "description": "Safety bounds applied after resource filtering and ordered-rule overlap resolution.",
+        "type": "object",
+        "properties": {
+          "max_instances": {
+            "title": "Maximum instances",
+            "description": "Maximum distinct final CloudWatch resource instances. Metric and statistic fan-out is not counted. Raise this explicitly for intentionally larger jobs.",
+            "type": "integer",
+            "minimum": 1,
+            "default": 1000
+          }
         }
       },
       "discovery": {
@@ -271,26 +395,6 @@
             "type": "boolean",
             "default": true
           }
-        }
-      },
-      "tags": {
-        "title": "Resource tag labels",
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "title": "AWS tag key",
-              "type": "string"
-            },
-            "rename": {
-              "title": "Netdata label",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name"
-          ]
         }
       },
       "query_offset": {
@@ -389,7 +493,7 @@
     },
     "rules": {
       "ui:listFlavour": "list",
-      "ui:help": "Add ordered collection rules. Earlier rules own overlapping final metric series; target order breaks ties within a rule.",
+      "ui:help": "Add ordered collection rules. The earliest matching rule and target own each overlapping final resource instance.",
       "items": {
         "name": {
           "ui:help": "Stable rule name used in validation and diagnostics.",
@@ -428,7 +532,71 @@
           "items": {
             "ui:placeholder": "us-east-1"
           }
+        },
+        "filters": {
+          "ui:help": "Omit Resource tags to inherit the job default. A non-empty list replaces the default; an explicit empty list disables tag filtering for this rule.",
+          "resource_tags": {
+            "ui:listFlavour": "list",
+            "ui:help": "Exact, case-sensitive AWS tag predicates. All keys must match; any value listed for one key may match. Explicitly included profiles must support safe resource-tag association.",
+            "items": {
+              "key": {
+                "ui:help": "Exact AWS resource tag key.",
+                "ui:placeholder": "Environment"
+              },
+              "values": {
+                "ui:listFlavour": "list",
+                "ui:help": "Accepted exact values for this key.",
+                "items": {
+                  "ui:placeholder": "production"
+                }
+              }
+            }
+          }
         }
+      }
+    },
+    "defaults": {
+      "ui:help": "Defaults inherited by rules that do not provide their own value.",
+      "filters": {
+        "resource_tags": {
+          "ui:listFlavour": "list",
+          "ui:help": "Default exact AWS resource tag predicates. All keys must match; any listed value may match for one key. Unsupported default-selected profiles are skipped and reported.",
+          "items": {
+            "key": {
+              "ui:help": "Exact, case-sensitive AWS resource tag key.",
+              "ui:placeholder": "Environment"
+            },
+            "values": {
+              "ui:listFlavour": "list",
+              "ui:help": "Accepted exact, case-sensitive values for this key.",
+              "items": {
+                "ui:placeholder": "production"
+              }
+            }
+          }
+        }
+      }
+    },
+    "labels": {
+      "resource_tags": {
+        "ui:listFlavour": "list",
+        "ui:help": "Copy selected AWS tags to Netdata chart labels. This affects presentation only and does not select resources.",
+        "items": {
+          "key": {
+            "ui:help": "Exact AWS resource tag key.",
+            "ui:placeholder": "Owner"
+          },
+          "label": {
+            "ui:help": "Optional Netdata label key. Leave empty to normalize the AWS tag key automatically.",
+            "ui:placeholder": "resource_owner"
+          }
+        }
+      }
+    },
+    "limits": {
+      "max_instances": {
+        "ui:help": "Maximum distinct final resource instances after filtering and overlap resolution. Raise this only for an intentionally larger job.",
+        "ui:placeholder": "1000"
       }
     },
     "discovery": {
@@ -437,20 +605,6 @@
       },
       "recently_active_only": {
         "ui:help": "When enabled, collect only metrics with recent datapoints. Disable this to retain inactive metrics discovered by CloudWatch."
-      }
-    },
-    "tags": {
-      "ui:listFlavour": "list",
-      "ui:help": "Copy selected AWS resource tags to Netdata labels. This requires the Resource Groups Tagging API permission.",
-      "items": {
-        "name": {
-          "ui:help": "Exact AWS resource tag key.",
-          "ui:placeholder": "Environment"
-        },
-        "rename": {
-          "ui:help": "Optional Netdata label name. Leave empty to use the AWS tag key.",
-          "ui:placeholder": "environment"
-        }
       }
     },
     "vnode": {
@@ -466,7 +620,8 @@
             "update_every",
             "autodetection_retry",
             "query_offset",
-            "timeout"
+            "timeout",
+            "limits"
           ]
         },
         {
@@ -488,10 +643,16 @@
           ]
         },
         {
-          "title": "Discovery & Tags",
+          "title": "Resource Tags",
           "fields": [
-            "discovery",
-            "tags"
+            "defaults",
+            "labels"
+          ]
+        },
+        {
+          "title": "Discovery",
+          "fields": [
+            "discovery"
           ]
         },
         {

--- a/src/go/plugin/go.d/collector/cloudwatch/config_schema.json
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_schema.json
@@ -293,8 +293,8 @@
           ]
         }
       },
-      "defaults": {
-        "title": "Collection defaults",
+      "rule_defaults": {
+        "title": "Rule defaults",
         "description": "Job-wide defaults inherited by collection rules that do not replace them.",
         "type": "object",
         "properties": {
@@ -555,7 +555,7 @@
         }
       }
     },
-    "defaults": {
+    "rule_defaults": {
       "ui:help": "Defaults inherited by rules that do not provide their own value.",
       "filters": {
         "resource_tags": {
@@ -639,13 +639,13 @@
         {
           "title": "Collection Rules",
           "fields": [
+            "rule_defaults",
             "rules"
           ]
         },
         {
           "title": "Resource Tags",
           "fields": [
-            "defaults",
             "labels"
           ]
         },

--- a/src/go/plugin/go.d/collector/cloudwatch/config_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_test.go
@@ -86,28 +86,28 @@ func TestConfig_validateResourceTagConfiguration(t *testing.T) {
 		wantErr string
 	}{
 		"valid exact filters and labels": {mutate: func(c *Config) {
-			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production", "staging"}}}
+			c.RuleDefaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production", "staging"}}}
 			c.Rules[0].Filters = &RuleFiltersConfig{ResourceTags: filters(ResourceTagFilterConfig{Key: "team", Values: []string{"sre"}})}
 			c.Labels.ResourceTags = []ResourceTagLabelConfig{{Key: "Owner", Label: "resource_owner"}}
 		}},
 		"filter key required": {mutate: func(c *Config) {
-			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Values: []string{"production"}}}
+			c.RuleDefaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Values: []string{"production"}}}
 		}, wantErr: ".key must not be empty"},
 		"filter values required": {mutate: func(c *Config) {
-			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment"}}
+			c.RuleDefaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment"}}
 		}, wantErr: ".values must contain at least one value"},
 		"duplicate filter key rejected": {mutate: func(c *Config) {
-			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{
+			c.RuleDefaults.Filters.ResourceTags = []ResourceTagFilterConfig{
 				{Key: "environment", Values: []string{"production"}},
 				{Key: "environment", Values: []string{"staging"}},
 			}
 		}, wantErr: "duplicate key"},
 		"duplicate exact value rejected": {mutate: func(c *Config) {
-			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production", "production"}}}
+			c.RuleDefaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production", "production"}}}
 		}, wantErr: "duplicate value"},
 		"more than 50 keys rejected": {mutate: func(c *Config) {
 			for i := range maxResourceTagFilters + 1 {
-				c.Defaults.Filters.ResourceTags = append(c.Defaults.Filters.ResourceTags, ResourceTagFilterConfig{Key: fmt.Sprintf("key-%d", i), Values: []string{"value"}})
+				c.RuleDefaults.Filters.ResourceTags = append(c.RuleDefaults.Filters.ResourceTags, ResourceTagFilterConfig{Key: fmt.Sprintf("key-%d", i), Values: []string{"value"}})
 			}
 		}, wantErr: "maximum is 50"},
 		"more than 20 values rejected": {mutate: func(c *Config) {
@@ -115,7 +115,7 @@ func TestConfig_validateResourceTagConfiguration(t *testing.T) {
 			for i := range maxResourceTagValues + 1 {
 				entry.Values = append(entry.Values, fmt.Sprintf("value-%d", i))
 			}
-			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{entry}
+			c.RuleDefaults.Filters.ResourceTags = []ResourceTagFilterConfig{entry}
 		}, wantErr: "maximum is 20"},
 		"label key required": {mutate: func(c *Config) {
 			c.Labels.ResourceTags = []ResourceTagLabelConfig{{Label: "owner"}}
@@ -145,7 +145,7 @@ func TestConfig_validateResourceTagConfiguration(t *testing.T) {
 func TestConfig_validateResourceTagConfiguration_RedactsDuplicateValue(t *testing.T) {
 	const sensitive = "SENSITIVE_TAG_VALUE"
 	cfg := validBaseConfig()
-	cfg.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{
+	cfg.RuleDefaults.Filters.ResourceTags = []ResourceTagFilterConfig{{
 		Key: "environment", Values: []string{sensitive, sensitive},
 	}}
 
@@ -168,10 +168,11 @@ func TestConfigSchema_RuntimeContract(t *testing.T) {
 	assert.ElementsMatch(t, []string{"credentials", "targets", "rules"}, doc.JSONSchema.Required)
 	for _, key := range []string{
 		"update_every", "autodetection_retry", "vnode", "credentials", "targets", "rules",
-		"defaults", "labels", "limits", "discovery", "query_offset", "timeout",
+		"rule_defaults", "labels", "limits", "discovery", "query_offset", "timeout",
 	} {
 		assert.Contains(t, doc.JSONSchema.Properties, key)
 	}
+	assert.NotContains(t, doc.JSONSchema.Properties, "defaults")
 	assert.NotContains(t, doc.JSONSchema.Properties, "tags")
 	for key, want := range map[string]string{
 		"credentials": `[{"name":"sdk_default","type":"default"}]`,
@@ -205,8 +206,8 @@ func TestConfigSchema_DynCfgUX(t *testing.T) {
 		{title: "Base", fields: []string{"update_every", "autodetection_retry", "query_offset", "timeout", "limits"}},
 		{title: "Credentials", fields: []string{"credentials"}},
 		{title: "Targets", fields: []string{"targets"}},
-		{title: "Collection Rules", fields: []string{"rules"}},
-		{title: "Resource Tags", fields: []string{"defaults", "labels"}},
+		{title: "Collection Rules", fields: []string{"rule_defaults", "rules"}},
+		{title: "Resource Tags", fields: []string{"labels"}},
 		{title: "Discovery", fields: []string{"discovery"}},
 		{title: "Virtual Node", fields: []string{"vnode"}},
 	}
@@ -244,8 +245,8 @@ func TestConfigSchema_DynCfgUX(t *testing.T) {
 	assert.Equal(t, "list", schemaObjectAt(t, doc, "uiSchema", "rules", "items", "targets")["ui:listFlavour"])
 	assert.Equal(t, "ec2", schemaObjectAt(t, doc, "uiSchema", "rules", "items", "profiles", "include", "items")["ui:placeholder"])
 	assert.Equal(t, "us-east-1", schemaObjectAt(t, doc, "uiSchema", "rules", "items", "regions", "items")["ui:placeholder"])
-	assert.Equal(t, "list", schemaObjectAt(t, doc, "uiSchema", "defaults", "filters", "resource_tags")["ui:listFlavour"])
-	assert.Equal(t, "Environment", schemaObjectAt(t, doc, "uiSchema", "defaults", "filters", "resource_tags", "items", "key")["ui:placeholder"])
+	assert.Equal(t, "list", schemaObjectAt(t, doc, "uiSchema", "rule_defaults", "filters", "resource_tags")["ui:listFlavour"])
+	assert.Equal(t, "Environment", schemaObjectAt(t, doc, "uiSchema", "rule_defaults", "filters", "resource_tags", "items", "key")["ui:placeholder"])
 	assert.Equal(t, "list", schemaObjectAt(t, doc, "uiSchema", "labels", "resource_tags")["ui:listFlavour"])
 	assert.Equal(t, "Owner", schemaObjectAt(t, doc, "uiSchema", "labels", "resource_tags", "items", "key")["ui:placeholder"])
 	assert.NotEmpty(t, schemaObjectAt(t, doc, "uiSchema", "credentials")["ui:help"])
@@ -329,7 +330,7 @@ func TestConfigSchema_ValidationParity(t *testing.T) {
 
 	t.Run("resource tag filter inheritance and explicit disable are valid", func(t *testing.T) {
 		cfg := cloneConfigMap(t, valid)
-		cfg["defaults"] = map[string]any{"filters": map[string]any{"resource_tags": []any{
+		cfg["rule_defaults"] = map[string]any{"filters": map[string]any{"resource_tags": []any{
 			map[string]any{"key": "environment", "values": []any{"production", "staging"}},
 		}}}
 		cfg["labels"] = map[string]any{"resource_tags": []any{
@@ -346,7 +347,7 @@ func TestConfigSchema_ValidationParity(t *testing.T) {
 
 	t.Run("resource tag filter requires at least one value", func(t *testing.T) {
 		cfg := cloneConfigMap(t, valid)
-		cfg["defaults"] = map[string]any{"filters": map[string]any{"resource_tags": []any{
+		cfg["rule_defaults"] = map[string]any{"filters": map[string]any{"resource_tags": []any{
 			map[string]any{"key": "environment", "values": []any{}},
 		}}}
 		assert.Error(t, schema.Validate(cfg))
@@ -506,16 +507,22 @@ func TestConfig_LegacyTopLevelTagsAreNotDecoded(t *testing.T) {
 	assert.Empty(t, cfg.Labels.ResourceTags, "the removed prototype has no alias or compatibility decoder")
 }
 
+func TestConfig_ReplacedDefaultsKeyIsNotDecoded(t *testing.T) {
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte("defaults:\n  filters:\n    resource_tags:\n      - key: env\n        values: [prod]\n"), &cfg))
+	assert.Empty(t, cfg.RuleDefaults.Filters.ResourceTags, "the replaced key has no alias or compatibility decoder")
+}
+
 func TestConfig_ResourceTagFilterInheritanceDecode(t *testing.T) {
 	var cfg Config
-	require.NoError(t, yaml.Unmarshal([]byte("defaults:\n  filters:\n    resource_tags:\n      - key: env\n        values: [prod]\nrules:\n  - name: inherit\n  - name: disable\n    filters:\n      resource_tags: []\n"), &cfg))
+	require.NoError(t, yaml.Unmarshal([]byte("rule_defaults:\n  filters:\n    resource_tags:\n      - key: env\n        values: [prod]\nrules:\n  - name: inherit\n  - name: disable\n    filters:\n      resource_tags: []\n"), &cfg))
 	require.Len(t, cfg.Rules, 2)
 	assert.Nil(t, cfg.Rules[0].Filters)
 	require.NotNil(t, cfg.Rules[1].Filters)
 	require.NotNil(t, cfg.Rules[1].Filters.ResourceTags)
 	assert.Empty(t, *cfg.Rules[1].Filters.ResourceTags)
-	assert.Equal(t, cfg.Defaults.Filters.ResourceTags, cfg.Rules[0].effectiveResourceTagFilters(cfg.Defaults.Filters.ResourceTags))
-	assert.Empty(t, cfg.Rules[1].effectiveResourceTagFilters(cfg.Defaults.Filters.ResourceTags))
+	assert.Equal(t, cfg.RuleDefaults.Filters.ResourceTags, cfg.Rules[0].effectiveResourceTagFilters(cfg.RuleDefaults.Filters.ResourceTags))
+	assert.Empty(t, cfg.Rules[1].effectiveResourceTagFilters(cfg.RuleDefaults.Filters.ResourceTags))
 }
 
 func TestNormalizeRegions(t *testing.T) {

--- a/src/go/plugin/go.d/collector/cloudwatch/config_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_test.go
@@ -4,6 +4,7 @@ package cloudwatch
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -78,6 +79,69 @@ func TestConfig_validate(t *testing.T) {
 	}
 }
 
+func TestConfig_validateResourceTagConfiguration(t *testing.T) {
+	filters := func(entries ...ResourceTagFilterConfig) *[]ResourceTagFilterConfig { return &entries }
+	tests := map[string]struct {
+		mutate  func(*Config)
+		wantErr string
+	}{
+		"valid exact filters and labels": {mutate: func(c *Config) {
+			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production", "staging"}}}
+			c.Rules[0].Filters = &RuleFiltersConfig{ResourceTags: filters(ResourceTagFilterConfig{Key: "team", Values: []string{"sre"}})}
+			c.Labels.ResourceTags = []ResourceTagLabelConfig{{Key: "Owner", Label: "resource_owner"}}
+		}},
+		"filter key required": {mutate: func(c *Config) {
+			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Values: []string{"production"}}}
+		}, wantErr: ".key must not be empty"},
+		"filter values required": {mutate: func(c *Config) {
+			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment"}}
+		}, wantErr: ".values must contain at least one value"},
+		"duplicate filter key rejected": {mutate: func(c *Config) {
+			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{
+				{Key: "environment", Values: []string{"production"}},
+				{Key: "environment", Values: []string{"staging"}},
+			}
+		}, wantErr: "duplicate key"},
+		"duplicate exact value rejected": {mutate: func(c *Config) {
+			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production", "production"}}}
+		}, wantErr: "duplicate value"},
+		"more than 50 keys rejected": {mutate: func(c *Config) {
+			for i := range maxResourceTagFilters + 1 {
+				c.Defaults.Filters.ResourceTags = append(c.Defaults.Filters.ResourceTags, ResourceTagFilterConfig{Key: fmt.Sprintf("key-%d", i), Values: []string{"value"}})
+			}
+		}, wantErr: "maximum is 50"},
+		"more than 20 values rejected": {mutate: func(c *Config) {
+			entry := ResourceTagFilterConfig{Key: "environment"}
+			for i := range maxResourceTagValues + 1 {
+				entry.Values = append(entry.Values, fmt.Sprintf("value-%d", i))
+			}
+			c.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{entry}
+		}, wantErr: "maximum is 20"},
+		"label key required": {mutate: func(c *Config) {
+			c.Labels.ResourceTags = []ResourceTagLabelConfig{{Label: "owner"}}
+		}, wantErr: ".key must not be empty"},
+		"invalid emitted label rejected": {mutate: func(c *Config) {
+			c.Labels.ResourceTags = []ResourceTagLabelConfig{{Key: "Owner", Label: "Bad-Label"}}
+		}, wantErr: "not a valid label key"},
+		"duplicate emitted label rejected": {mutate: func(c *Config) {
+			c.Labels.ResourceTags = []ResourceTagLabelConfig{{Key: "Owner", Label: "owner"}, {Key: "owner", Label: "owner"}}
+		}, wantErr: "duplicate label"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := validBaseConfig()
+			tc.mutate(&cfg)
+			err := cfg.validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestConfigSchema_RuntimeContract(t *testing.T) {
 	data, err := os.ReadFile("config_schema.json")
 	require.NoError(t, err)
@@ -91,10 +155,11 @@ func TestConfigSchema_RuntimeContract(t *testing.T) {
 	assert.ElementsMatch(t, []string{"credentials", "targets", "rules"}, doc.JSONSchema.Required)
 	for _, key := range []string{
 		"update_every", "autodetection_retry", "vnode", "credentials", "targets", "rules",
-		"discovery", "tags", "query_offset", "timeout",
+		"defaults", "labels", "limits", "discovery", "query_offset", "timeout",
 	} {
 		assert.Contains(t, doc.JSONSchema.Properties, key)
 	}
+	assert.NotContains(t, doc.JSONSchema.Properties, "tags")
 	for key, want := range map[string]string{
 		"credentials": `[{"name":"sdk_default","type":"default"}]`,
 		"targets":     `[{"name":"base","credentials":"sdk_default"}]`,
@@ -124,11 +189,12 @@ func TestConfigSchema_DynCfgUX(t *testing.T) {
 		title  string
 		fields []string
 	}{
-		{title: "Base", fields: []string{"update_every", "autodetection_retry", "query_offset", "timeout"}},
+		{title: "Base", fields: []string{"update_every", "autodetection_retry", "query_offset", "timeout", "limits"}},
 		{title: "Credentials", fields: []string{"credentials"}},
 		{title: "Targets", fields: []string{"targets"}},
 		{title: "Collection Rules", fields: []string{"rules"}},
-		{title: "Discovery & Tags", fields: []string{"discovery", "tags"}},
+		{title: "Resource Tags", fields: []string{"defaults", "labels"}},
+		{title: "Discovery", fields: []string{"discovery"}},
 		{title: "Virtual Node", fields: []string{"vnode"}},
 	}
 	tabs, ok := schemaObjectAt(t, doc, "uiSchema", "ui:options")["tabs"].([]any)
@@ -165,8 +231,10 @@ func TestConfigSchema_DynCfgUX(t *testing.T) {
 	assert.Equal(t, "list", schemaObjectAt(t, doc, "uiSchema", "rules", "items", "targets")["ui:listFlavour"])
 	assert.Equal(t, "ec2", schemaObjectAt(t, doc, "uiSchema", "rules", "items", "profiles", "include", "items")["ui:placeholder"])
 	assert.Equal(t, "us-east-1", schemaObjectAt(t, doc, "uiSchema", "rules", "items", "regions", "items")["ui:placeholder"])
-	assert.Equal(t, "list", schemaObjectAt(t, doc, "uiSchema", "tags")["ui:listFlavour"])
-	assert.Equal(t, "Environment", schemaObjectAt(t, doc, "uiSchema", "tags", "items", "name")["ui:placeholder"])
+	assert.Equal(t, "list", schemaObjectAt(t, doc, "uiSchema", "defaults", "filters", "resource_tags")["ui:listFlavour"])
+	assert.Equal(t, "Environment", schemaObjectAt(t, doc, "uiSchema", "defaults", "filters", "resource_tags", "items", "key")["ui:placeholder"])
+	assert.Equal(t, "list", schemaObjectAt(t, doc, "uiSchema", "labels", "resource_tags")["ui:listFlavour"])
+	assert.Equal(t, "Owner", schemaObjectAt(t, doc, "uiSchema", "labels", "resource_tags", "items", "key")["ui:placeholder"])
 	assert.NotEmpty(t, schemaObjectAt(t, doc, "uiSchema", "credentials")["ui:help"])
 	assert.NotEmpty(t, schemaObjectAt(t, doc, "uiSchema", "discovery", "recently_active_only")["ui:help"])
 	assert.NotEmpty(t, schemaObjectAt(t, doc, "uiSchema", "vnode")["ui:placeholder"])
@@ -245,6 +313,32 @@ func TestConfigSchema_ValidationParity(t *testing.T) {
 	}
 	require.NoError(t, schema.Validate(valid))
 	require.NoError(t, validateRuntimeConfigMap(t, valid))
+
+	t.Run("resource tag filter inheritance and explicit disable are valid", func(t *testing.T) {
+		cfg := cloneConfigMap(t, valid)
+		cfg["defaults"] = map[string]any{"filters": map[string]any{"resource_tags": []any{
+			map[string]any{"key": "environment", "values": []any{"production", "staging"}},
+		}}}
+		cfg["labels"] = map[string]any{"resource_tags": []any{
+			map[string]any{"key": "Owner", "label": "resource_owner"},
+		}}
+		cfg["limits"] = map[string]any{"max_instances": 2000}
+		cfg["rules"] = []any{
+			map[string]any{"name": "filtered", "targets": []any{"base"}, "regions": []any{"us-east-1"}, "profiles": map[string]any{"defaults": false, "include": []any{"ec2"}}},
+			map[string]any{"name": "unfiltered", "targets": []any{"base"}, "regions": []any{"us-east-1"}, "profiles": map[string]any{"defaults": false, "include": []any{"cloudfront"}}, "filters": map[string]any{"resource_tags": []any{}}},
+		}
+		assert.NoError(t, schema.Validate(cfg))
+		assert.NoError(t, validateRuntimeConfigMap(t, cfg))
+	})
+
+	t.Run("resource tag filter requires at least one value", func(t *testing.T) {
+		cfg := cloneConfigMap(t, valid)
+		cfg["defaults"] = map[string]any{"filters": map[string]any{"resource_tags": []any{
+			map[string]any{"key": "environment", "values": []any{}},
+		}}}
+		assert.Error(t, schema.Validate(cfg))
+		assert.Error(t, validateRuntimeConfigMap(t, cfg))
+	})
 
 	t.Run("nested static credential source is valid", func(t *testing.T) {
 		cfg := cloneConfigMap(t, valid)
@@ -387,46 +481,28 @@ func validateRuntimeConfigMap(t *testing.T, raw map[string]any) error {
 	return err
 }
 
-func TestConfig_TagsDecode(t *testing.T) {
+func TestConfig_ResourceTagLabelsDecode(t *testing.T) {
 	var cfg Config
-	require.NoError(t, yaml.Unmarshal([]byte("tags:\n  - name: owner\n  - name: Name\n    rename: instance_name\n"), &cfg))
-	assert.Equal(t, []TagConfig{{Name: "owner"}, {Name: "Name", Rename: "instance_name"}}, cfg.Tags)
+	require.NoError(t, yaml.Unmarshal([]byte("labels:\n  resource_tags:\n    - key: owner\n    - key: Name\n      label: instance_name\n"), &cfg))
+	assert.Equal(t, []ResourceTagLabelConfig{{Key: "owner"}, {Key: "Name", Label: "instance_name"}}, cfg.Labels.ResourceTags)
 }
 
-func TestConfig_validateRejectsReservedRuleFields(t *testing.T) {
-	tests := map[string]func(*RuleConfig){
-		"filters": func(rule *RuleConfig) { rule.Filters = map[string]any{} },
-		"labels":  func(rule *RuleConfig) { rule.Labels = []any{} },
-		"series":  func(rule *RuleConfig) { rule.Series = false },
-		"query":   func(rule *RuleConfig) { rule.Query = "unsupported" },
-	}
-	for name, mutate := range tests {
-		t.Run(name, func(t *testing.T) {
-			cfg := validBaseConfig()
-			mutate(&cfg.Rules[0])
-			assert.ErrorContains(t, cfg.validate(), "reserved for a later phase")
-		})
-	}
+func TestConfig_LegacyTopLevelTagsAreNotDecoded(t *testing.T) {
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte("tags:\n  - name: owner\n    rename: resource_owner\n"), &cfg))
+	assert.Empty(t, cfg.Labels.ResourceTags, "the removed prototype has no alias or compatibility decoder")
 }
 
-func TestConfig_DecodedReservedRuleFieldsReachRuntimeValidation(t *testing.T) {
-	tests := map[string]struct {
-		decode func(*RuleConfig) error
-	}{
-		"YAML": {decode: func(rule *RuleConfig) error {
-			return yaml.Unmarshal([]byte("filters: {}\n"), rule)
-		}},
-		"JSON": {decode: func(rule *RuleConfig) error {
-			return json.Unmarshal([]byte(`{"query":{}}`), rule)
-		}},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			cfg := validBaseConfig()
-			require.NoError(t, tc.decode(&cfg.Rules[0]))
-			assert.ErrorContains(t, cfg.validate(), "reserved for a later phase")
-		})
-	}
+func TestConfig_ResourceTagFilterInheritanceDecode(t *testing.T) {
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte("defaults:\n  filters:\n    resource_tags:\n      - key: env\n        values: [prod]\nrules:\n  - name: inherit\n  - name: disable\n    filters:\n      resource_tags: []\n"), &cfg))
+	require.Len(t, cfg.Rules, 2)
+	assert.Nil(t, cfg.Rules[0].Filters)
+	require.NotNil(t, cfg.Rules[1].Filters)
+	require.NotNil(t, cfg.Rules[1].Filters.ResourceTags)
+	assert.Empty(t, *cfg.Rules[1].Filters.ResourceTags)
+	assert.Equal(t, cfg.Defaults.Filters.ResourceTags, cfg.Rules[0].effectiveResourceTagFilters(cfg.Defaults.Filters.ResourceTags))
+	assert.Empty(t, cfg.Rules[1].effectiveResourceTagFilters(cfg.Defaults.Filters.ResourceTags))
 }
 
 func TestNormalizeRegions(t *testing.T) {

--- a/src/go/plugin/go.d/collector/cloudwatch/config_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_test.go
@@ -142,6 +142,19 @@ func TestConfig_validateResourceTagConfiguration(t *testing.T) {
 	}
 }
 
+func TestConfig_validateResourceTagConfiguration_RedactsDuplicateValue(t *testing.T) {
+	const sensitive = "SENSITIVE_TAG_VALUE"
+	cfg := validBaseConfig()
+	cfg.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{
+		Key: "environment", Values: []string{sensitive, sensitive},
+	}}
+
+	err := cfg.validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate value")
+	assert.NotContains(t, err.Error(), sensitive)
+}
+
 func TestConfigSchema_RuntimeContract(t *testing.T) {
 	data, err := os.ReadFile("config_schema.json")
 	require.NoError(t, err)

--- a/src/go/plugin/go.d/collector/cloudwatch/config_validate.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_validate.go
@@ -31,7 +31,7 @@ func validateConfigStructure(cfg Config) error {
 	return errors.Join(
 		credentialErr,
 		targetErr,
-		validateResourceTagFilters("defaults.filters.resource_tags", cfg.Defaults.Filters.ResourceTags),
+		validateResourceTagFilters("rule_defaults.filters.resource_tags", cfg.RuleDefaults.Filters.ResourceTags),
 		validateResourceTagLabels("labels.resource_tags", cfg.Labels.ResourceTags),
 		validateRules(cfg, targetNames),
 	)
@@ -46,8 +46,8 @@ func validateRawLimits(cfg Config) error {
 		return fmt.Errorf("'targets' contains %d entries; maximum is %d", len(cfg.Targets), maxTargets)
 	case len(cfg.Rules) > maxRules:
 		return fmt.Errorf("'rules' contains %d entries; maximum is %d", len(cfg.Rules), maxRules)
-	case len(cfg.Defaults.Filters.ResourceTags) > maxResourceTagFilters:
-		return fmt.Errorf("'defaults.filters.resource_tags' contains %d entries; maximum is %d", len(cfg.Defaults.Filters.ResourceTags), maxResourceTagFilters)
+	case len(cfg.RuleDefaults.Filters.ResourceTags) > maxResourceTagFilters:
+		return fmt.Errorf("'rule_defaults.filters.resource_tags' contains %d entries; maximum is %d", len(cfg.RuleDefaults.Filters.ResourceTags), maxResourceTagFilters)
 	}
 	for i, rule := range cfg.Rules {
 		path := fmt.Sprintf("rules[%d]", i)

--- a/src/go/plugin/go.d/collector/cloudwatch/config_validate.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_validate.go
@@ -207,7 +207,7 @@ func validateResourceTagFilters(path string, filters []ResourceTagFilterConfig) 
 		seenValues := make(map[string]struct{}, len(filter.Values))
 		for j, value := range filter.Values {
 			if _, ok := seenValues[value]; ok {
-				errs = append(errs, fmt.Errorf("%s.values contains duplicate value %q at index %d", itemPath, value, j))
+				errs = append(errs, fmt.Errorf("%s.values contains a duplicate value at index %d", itemPath, j))
 			} else {
 				seenValues[value] = struct{}{}
 			}

--- a/src/go/plugin/go.d/collector/cloudwatch/config_validate.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_validate.go
@@ -12,10 +12,12 @@ import (
 )
 
 const (
-	maxCredentialSources = 64
-	maxTargets           = 64
-	maxRules             = 256
-	maxReferencesPerRule = 256
+	maxCredentialSources  = 64
+	maxTargets            = 64
+	maxRules              = 256
+	maxReferencesPerRule  = 256
+	maxResourceTagFilters = 50
+	maxResourceTagValues  = 20
 )
 
 var configNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,63}$`)
@@ -29,6 +31,8 @@ func validateConfigStructure(cfg Config) error {
 	return errors.Join(
 		credentialErr,
 		targetErr,
+		validateResourceTagFilters("defaults.filters.resource_tags", cfg.Defaults.Filters.ResourceTags),
+		validateResourceTagLabels("labels.resource_tags", cfg.Labels.ResourceTags),
 		validateRules(cfg, targetNames),
 	)
 }
@@ -42,6 +46,8 @@ func validateRawLimits(cfg Config) error {
 		return fmt.Errorf("'targets' contains %d entries; maximum is %d", len(cfg.Targets), maxTargets)
 	case len(cfg.Rules) > maxRules:
 		return fmt.Errorf("'rules' contains %d entries; maximum is %d", len(cfg.Rules), maxRules)
+	case len(cfg.Defaults.Filters.ResourceTags) > maxResourceTagFilters:
+		return fmt.Errorf("'defaults.filters.resource_tags' contains %d entries; maximum is %d", len(cfg.Defaults.Filters.ResourceTags), maxResourceTagFilters)
 	}
 	for i, rule := range cfg.Rules {
 		path := fmt.Sprintf("rules[%d]", i)
@@ -54,6 +60,8 @@ func validateRawLimits(cfg Config) error {
 			return fmt.Errorf("%s.profiles.include contains %d entries; maximum is %d", path, len(rule.Profiles.Include), maxReferencesPerRule)
 		case rule.Profiles != nil && len(rule.Profiles.Exclude) > maxReferencesPerRule:
 			return fmt.Errorf("%s.profiles.exclude contains %d entries; maximum is %d", path, len(rule.Profiles.Exclude), maxReferencesPerRule)
+		case rule.Filters != nil && rule.Filters.ResourceTags != nil && len(*rule.Filters.ResourceTags) > maxResourceTagFilters:
+			return fmt.Errorf("%s.filters.resource_tags contains %d entries; maximum is %d", path, len(*rule.Filters.ResourceTags), maxResourceTagFilters)
 		}
 	}
 	return nil
@@ -172,18 +180,65 @@ func validateRules(cfg Config, targetNames map[string]struct{}) error {
 		if err := validateRuleRegions(path, rule.Regions); err != nil {
 			errs = append(errs, err)
 		}
-		for _, field := range []struct {
-			name  string
-			value any
-		}{
-			{name: "filters", value: rule.Filters},
-			{name: "labels", value: rule.Labels},
-			{name: "series", value: rule.Series},
-			{name: "query", value: rule.Query},
-		} {
-			if field.value != nil {
-				errs = append(errs, fmt.Errorf("%s.%s is reserved for a later phase", path, field.name))
+		if rule.Filters != nil && rule.Filters.ResourceTags != nil {
+			errs = append(errs, validateResourceTagFilters(path+".filters.resource_tags", *rule.Filters.ResourceTags))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func validateResourceTagFilters(path string, filters []ResourceTagFilterConfig) error {
+	seenKeys := make(map[string]struct{}, len(filters))
+	var errs []error
+	for i, filter := range filters {
+		itemPath := fmt.Sprintf("%s[%d]", path, i)
+		if filter.Key == "" {
+			errs = append(errs, fmt.Errorf("%s.key must not be empty", itemPath))
+		} else if _, ok := seenKeys[filter.Key]; ok {
+			errs = append(errs, fmt.Errorf("%s contains duplicate key %q", path, filter.Key))
+		} else {
+			seenKeys[filter.Key] = struct{}{}
+		}
+		if len(filter.Values) == 0 {
+			errs = append(errs, fmt.Errorf("%s.values must contain at least one value", itemPath))
+		} else if len(filter.Values) > maxResourceTagValues {
+			errs = append(errs, fmt.Errorf("%s.values contains %d entries; maximum is %d", itemPath, len(filter.Values), maxResourceTagValues))
+		}
+		seenValues := make(map[string]struct{}, len(filter.Values))
+		for j, value := range filter.Values {
+			if _, ok := seenValues[value]; ok {
+				errs = append(errs, fmt.Errorf("%s.values contains duplicate value %q at index %d", itemPath, value, j))
+			} else {
+				seenValues[value] = struct{}{}
 			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func validateResourceTagLabels(path string, labels []ResourceTagLabelConfig) error {
+	seenKeys := make(map[string]struct{}, len(labels))
+	seenLabels := make(map[string]struct{}, len(labels))
+	var errs []error
+	for i, entry := range labels {
+		itemPath := fmt.Sprintf("%s[%d]", path, i)
+		if entry.Key == "" {
+			errs = append(errs, fmt.Errorf("%s.key must not be empty", itemPath))
+		} else if _, ok := seenKeys[entry.Key]; ok {
+			errs = append(errs, fmt.Errorf("%s contains duplicate key %q", path, entry.Key))
+		} else {
+			seenKeys[entry.Key] = struct{}{}
+		}
+		label := entry.Label
+		if label == "" {
+			label = sanitizeLabel(entry.Key)
+		}
+		if !labelKeyRe.MatchString(label) {
+			errs = append(errs, fmt.Errorf("%s.label %q is not a valid label key", itemPath, label))
+		} else if _, ok := seenLabels[label]; ok {
+			errs = append(errs, fmt.Errorf("%s contains duplicate label %q", path, label))
+		} else {
+			seenLabels[label] = struct{}{}
 		}
 	}
 	return errors.Join(errs...)

--- a/src/go/plugin/go.d/collector/cloudwatch/discover.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/discover.go
@@ -213,9 +213,9 @@ func discoverAll(
 	return results
 }
 
-// buildDiscoverySnapshot assembles a snapshot from per-target results. Targets
-// that errored are returned as a separate error list (the caller logs them and
-// applies fail-soft); only non-empty successful targets populate the snapshot.
+// buildDiscoverySnapshot assembles a snapshot from namespace-group results and
+// returns the number of failed groups. Failed groups retain their previous
+// profile instances; successful groups replace theirs.
 func buildDiscoverySnapshot(results []discoveryGroupResult, prev map[discoveryKey][]discoveredInstance, now time.Time, refreshEvery int) (discoverySnapshot, int) {
 	snap := discoverySnapshot{
 		Instances: make(map[discoveryKey][]discoveredInstance),
@@ -247,7 +247,7 @@ func buildDiscoverySnapshot(results []discoveryGroupResult, prev map[discoveryKe
 
 // highInstanceCountWarn is the discovered-instance count at or above which the
 // collector logs a cost-visibility warning. Collection is never truncated.
-const highInstanceCountWarn = 1000
+const highInstanceCountWarn = defaultMaxInstances
 
 func (c *Collector) loadCatalog() (cwprofiles.Catalog, error) {
 	if c.newCatalog != nil {
@@ -310,6 +310,7 @@ func (c *Collector) refreshDiscovery(ctx context.Context) error {
 	}
 
 	c.discovery = snap
+	c.markTagsStale()
 	c.invalidateQueryPlan()
 	c.logDiscovery(snap)
 

--- a/src/go/plugin/go.d/collector/cloudwatch/discover.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/discover.go
@@ -358,18 +358,32 @@ func (c *Collector) discoveryGroups() []discoveryGroup {
 		return nil
 	}
 
-	index := make(map[string]int)
+	type groupKey struct {
+		target, region, namespace string
+		recentlyActive            bool
+	}
+	type profileKey struct {
+		group   groupKey
+		profile string
+	}
+	index := make(map[groupKey]int)
+	seenProfiles := make(map[profileKey]struct{})
 	var groups []discoveryGroup
 	for _, scope := range c.plan.Scopes {
 		if _, ok := c.resolvedByRef[scope.Target.Name]; !ok {
 			continue
 		}
 		recent := profileUsesRecentlyActive(scope.Profile.Config, c.recentlyActiveOnly())
-		key := fmt.Sprintf("%s\x00%s\x00%s\x00%t", scope.Target.Name, scope.Region, scope.Profile.Config.Namespace, recent)
+		key := groupKey{
+			target: scope.Target.Name, region: scope.Region,
+			namespace: scope.Profile.Config.Namespace, recentlyActive: recent,
+		}
 		if i, ok := index[key]; ok {
-			// Compiled scopes are unique by target/profile/region, so a profile can
-			// occur only once in a compatible discovery group.
-			groups[i].Profiles = append(groups[i].Profiles, scope.Profile)
+			pk := profileKey{group: key, profile: scope.Profile.Name}
+			if _, seen := seenProfiles[pk]; !seen {
+				groups[i].Profiles = append(groups[i].Profiles, scope.Profile)
+				seenProfiles[pk] = struct{}{}
+			}
 			continue
 		}
 		index[key] = len(groups)
@@ -377,6 +391,7 @@ func (c *Collector) discoveryGroups() []discoveryGroup {
 			Target: scope.Target.Name, Region: scope.Region, Namespace: scope.Profile.Config.Namespace,
 			RecentlyActive: recent, Profiles: []cwprofiles.ResolvedProfile{scope.Profile},
 		})
+		seenProfiles[profileKey{group: key, profile: scope.Profile.Name}] = struct{}{}
 	}
 	return groups
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/discover.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/discover.go
@@ -310,6 +310,7 @@ func (c *Collector) refreshDiscovery(ctx context.Context) error {
 	}
 
 	c.discovery = snap
+	c.invalidateTagFetchPlan()
 	c.markTagsStale()
 	c.invalidateQueryPlan()
 	c.logDiscovery(snap)

--- a/src/go/plugin/go.d/collector/cloudwatch/discover_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/discover_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -416,6 +417,37 @@ func TestCollector_DiscoveryGroupsDeduplicateCompatibleNamespaceScans(t *testing
 	assert.Equal(t, 1, fake.calls, "compatible profiles share one ListMetrics scan")
 }
 
+func TestCollector_DiscoveryGroupsDeduplicateProfileAcrossTagPolicies(t *testing.T) {
+	falseValue := false
+	filters := func(value string) *RuleFiltersConfig {
+		entries := []ResourceTagFilterConfig{{Key: "environment", Values: []string{value}}}
+		return &RuleFiltersConfig{ResourceTags: &entries}
+	}
+	cfg := validBaseConfig()
+	cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &falseValue, Include: []string{"ec2"}}
+	cfg.Rules[0].Filters = filters("production")
+	cfg.Rules = append(cfg.Rules, RuleConfig{
+		Name: "staging", Targets: []string{"base"}, Regions: []string{"us-east-1"},
+		Profiles: &ProfileSelectorConfig{Defaults: &falseValue, Include: []string{"ec2"}},
+		Filters:  filters("staging"),
+	})
+	plan, _, err := compileTestConfig(t, cfg)
+	require.NoError(t, err)
+	require.Len(t, plan.Scopes, 2, "different tag policies remain distinct collection scopes")
+	assert.Same(t, plan.Scopes[0].TagJoin, plan.Scopes[1].TagJoin, "profile association is validated and compiled once")
+
+	c := New()
+	c.plan = plan
+	c.resolvedByRef = map[string]resolvedTarget{
+		"base": {target: plan.Targets[0], accountID: "000000000000"},
+	}
+
+	groups := c.discoveryGroups()
+	require.Len(t, groups, 1)
+	require.Len(t, groups[0].Profiles, 1, "shared discovery contains one matcher per profile")
+	assert.Equal(t, "ec2", groups[0].Profiles[0].Name)
+}
+
 func TestCollector_DiscoveryGroupsKeepRecentlyActiveBehaviorSeparate(t *testing.T) {
 	c := New()
 	fast := resolved("fast", dimProfile("AWS/Shared", 300, "Id"))
@@ -452,6 +484,50 @@ func TestDiscoverySnapshot_Expired(t *testing.T) {
 	assert.False(t, snap.expired(time.Unix(1299, 0)))
 	assert.True(t, snap.expired(time.Unix(1300, 0)))
 	assert.True(t, snap.expired(time.Unix(1500, 0)))
+}
+
+func BenchmarkDiscoverProfileGroupPolicyCount(b *testing.B) {
+	const instances = 1000
+	catalog, err := cwprofiles.DefaultCatalog()
+	if err != nil {
+		b.Fatal(err)
+	}
+	metrics := make([]cwtypes.Metric, instances)
+	for i := range instances {
+		metrics[i] = mkMetric("CPUUtilization", "InstanceId", fmt.Sprintf("i-%d", i))
+	}
+	for _, policies := range []int{1, 4} {
+		b.Run(fmt.Sprintf("policies=%d", policies), func(b *testing.B) {
+			cfg := resourceTagPolicyConfig(policies)
+			cfg.applyDefaults()
+			plan, _, err := compileConfig(cfg, catalog)
+			if err != nil {
+				b.Fatal(err)
+			}
+			c := New()
+			c.plan = plan
+			c.resolvedByRef = map[string]resolvedTarget{
+				"base": {target: plan.Targets[0], accountID: "000000000000"},
+			}
+			groups := c.discoveryGroups()
+			if len(groups) != 1 || len(groups[0].Profiles) != 1 {
+				b.Fatalf("got %d groups with %d profiles, want one shared group/profile", len(groups), len(groups[0].Profiles))
+			}
+			client := &nsCloudWatch{byNS: map[string][]cwtypes.Metric{"AWS/EC2": metrics}}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				got, err := discoverProfileGroup(context.Background(), client, groups[0])
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(got["ec2"]) != instances {
+					b.Fatalf("discovered %d instances, want %d", len(got["ec2"]), instances)
+				}
+			}
+		})
+	}
 }
 
 // dimValues extracts the dimension-value slices for stable comparison.

--- a/src/go/plugin/go.d/collector/cloudwatch/discover_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/discover_test.go
@@ -434,7 +434,7 @@ func TestCollector_DiscoveryGroupsDeduplicateProfileAcrossTagPolicies(t *testing
 	plan, _, err := compileTestConfig(t, cfg)
 	require.NoError(t, err)
 	require.Len(t, plan.Scopes, 2, "different tag policies remain distinct collection scopes")
-	assert.Same(t, plan.Scopes[0].TagJoin, plan.Scopes[1].TagJoin, "profile association is validated and compiled once")
+	assert.NotNil(t, plan.TagJoins["ec2"], "profile association is validated and compiled once")
 
 	c := New()
 	c.plan = plan
@@ -571,15 +571,18 @@ func TestCollector_refreshDiscovery_TTLCaching(t *testing.T) {
 	assert.Equal(t, 2, c.discovery.totalInstances())
 	callsAfterFirst := fakes["us-east-1"].calls
 	assert.Positive(t, callsAfterFirst)
+	c.tagFetchPlan = []tagFetchGroup{{key: tagFetchKey{target: "topology-sentinel"}}}
 
 	// Within TTL: no refetch.
 	require.NoError(t, c.refreshDiscovery(context.Background()))
 	assert.Equal(t, callsAfterFirst, fakes["us-east-1"].calls, "must not refetch within TTL")
+	assert.Len(t, c.tagFetchPlan, 1, "cached tag topology follows the discovery lifetime")
 
 	// After TTL: refetch.
 	c.now = func() time.Time { return base.Add(301 * time.Second) }
 	require.NoError(t, c.refreshDiscovery(context.Background()))
 	assert.Greater(t, fakes["us-east-1"].calls, callsAfterFirst, "must refetch after TTL")
+	assert.Nil(t, c.tagFetchPlan, "a new discovery snapshot invalidates tag fetch topology")
 }
 
 func TestCollector_refreshDiscovery_TotalFailureFirstPassErrors(t *testing.T) {

--- a/src/go/plugin/go.d/collector/cloudwatch/identity.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/identity.go
@@ -79,7 +79,7 @@ func (c *Collector) ensureTargets(ctx context.Context) error {
 		c.invalidateQueryPlan()
 		c.markDiscoveryStale() // discover the newly-resolved account this cycle, not after refresh_every
 		c.markTagsStale()      // and fetch its tags this cycle, so its first charts are created tagged
-		c.Infof("CloudWatch: target %q resolved to AWS account %s", target.Name, result.accountID)
+		c.Infof("CloudWatch: target %q resolved successfully", target.Name)
 	}
 	c.warnOperationFailures(logKeyAccountResolveFailed, "account resolution", " (will retry next cycle)", failures)
 

--- a/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
@@ -82,7 +82,7 @@ This collector is supported on all platforms.
 
 This collector supports collecting metrics from multiple instances of this integration, including remote instances.
 
-Every target requires `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`. The collector calls `sts:GetCallerIdentity` for account attribution, but [AWS does not require an explicit permission grant for that operation](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html). A credential source used by a target with `assume_role` additionally requires `sts:AssumeRole` for that role ARN. Resource tag filtering (`defaults.filters.resource_tags` or `rules[].filters.resource_tags`) and resource tag labels (`labels.resource_tags`) additionally require `tag:GetResources`.
+Every target requires `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`. The collector calls `sts:GetCallerIdentity` for account attribution, but [AWS does not require an explicit permission grant for that operation](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html). A credential source used by a target with `assume_role` additionally requires `sts:AssumeRole` for that role ARN. Resource tag filtering (`rule_defaults.filters.resource_tags` or `rules[].filters.resource_tags`) and resource tag labels (`labels.resource_tags`) additionally require `tag:GetResources`.
 
 
 ### Default Behavior
@@ -202,10 +202,10 @@ A user profile file with the same basename as a stock profile overrides it.
 |  | rules[].profiles.include | Profile basenames to add explicitly. Set `defaults` to `false` to collect only this list, including profiles disabled by default. |  | no |
 |  | rules[].profiles.exclude | Profile basenames to remove from the selected set. A profile cannot be both included and excluded. |  | no |
 |  | rules[].regions | Canonical lowercase AWS region codes selected by this rule. The compiler intersects them with intrinsic profile restrictions; for example, CloudFront supports only `us-east-1`. |  | yes |
-| **Resource Filters** | defaults.filters.resource_tags | Job-wide list of exact, case-sensitive AWS resource tag predicates inherited by rules that omit `rules[].filters.resource_tags`. All keys must match; any listed value for one key may match. The Resource Groups Tagging API performs the focused lookup and requires `tag:GetResources`. |  | no |
-|  | defaults.filters.resource_tags[].key | Exact AWS resource tag key. A filter list supports at most 50 distinct keys. |  | yes |
-|  | defaults.filters.resource_tags[].values | One to 20 exact, case-sensitive accepted values for this key. Values for one key are ORed. |  | yes |
-|  | rules[].filters.resource_tags | Per-rule replacement for `defaults.filters.resource_tags`. Omit it to inherit the default, provide a non-empty list to replace the default, or set `[]` to disable tag filtering for this rule. |  | no |
+| **Resource Filters** | rule_defaults.filters.resource_tags | Job-wide list of exact, case-sensitive AWS resource tag predicates inherited by rules that omit `rules[].filters.resource_tags`. All keys must match; any listed value for one key may match. The Resource Groups Tagging API performs the focused lookup and requires `tag:GetResources`. |  | no |
+|  | rule_defaults.filters.resource_tags[].key | Exact AWS resource tag key. A filter list supports at most 50 distinct keys. |  | yes |
+|  | rule_defaults.filters.resource_tags[].values | One to 20 exact, case-sensitive accepted values for this key. Values for one key are ORed. |  | yes |
+|  | rules[].filters.resource_tags | Per-rule replacement for `rule_defaults.filters.resource_tags`. Omit it to inherit the default, provide a non-empty list to replace the default, or set `[]` to disable tag filtering for this rule. |  | no |
 |  | rules[].filters.resource_tags[].key | Exact AWS resource tag key. A filter list supports at most 50 distinct keys. |  | yes |
 |  | rules[].filters.resource_tags[].values | One to 20 exact, case-sensitive accepted values for this key. Values for one key are ORed. |  | yes |
 | **Resource Labels** | labels.resource_tags | Optional AWS resource tags copied to charts as non-identity labels. This is presentation only and does not select resources. Tag values may contain personal data, so expose only keys intended for Netdata. Requires `tag:GetResources`. |  | no |
@@ -381,7 +381,7 @@ jobs:
     targets:
       - name: base
         credentials: sdk_default
-    defaults:
+    rule_defaults:
       filters:
         resource_tags:
           - key: managed-by
@@ -593,7 +593,7 @@ Check the following:
 
 - **Permissions** -- each target allows `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`; `GetCallerIdentity` needs no explicit grant. Targets with `assume_role` also require `sts:AssumeRole` on the source identity. Resource tag filtering or labels require `tag:GetResources`.
 - **Rules** -- `rules[].targets`, `rules[].profiles`, and `rules[].regions` select the expected target, service, and region. CloudFront publishes metrics only in `us-east-1`; its profile enforces this automatically.
-- **Resource filters** -- a rule that omits `filters.resource_tags` inherits `defaults.filters.resource_tags`. An explicitly included profile without a safe Resource Groups Tagging API association is rejected; use `filters.resource_tags: []` for a deliberate unfiltered rule.
+- **Resource filters** -- a rule that omits `filters.resource_tags` inherits `rule_defaults.filters.resource_tags`. An explicitly included profile without a safe Resource Groups Tagging API association is rejected; use `filters.resource_tags: []` for a deliberate unfiltered rule.
 - **Resources are active** -- confirm in the AWS CloudWatch console that the resources are publishing metrics.
 - **Collector logs** -- check for authentication or API errors:
   ```bash

--- a/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
@@ -75,14 +75,14 @@ Replace `AWS/<Service>` with the service namespace (for example `AWS/AmazonMQ`) 
 :::
 
 
-The collector compiles named credential sources, monitored targets, and ordered collection rules into an immutable runtime plan. It discovers available metrics with CloudWatch `ListMetrics`, sharing a scan when target, region, namespace, and recent-activity behavior match, then applies each profile's exact dimension matcher. It queries the resulting metric series in `GetMetricData` batches. Each target resolves its AWS account id through `sts:GetCallerIdentity`; target names remain distinct execution identities even when they resolve to the same account. Rule order, then target order within each rule, resolves overlap: the first rule/target that produces a final metric series owns it.
+The collector compiles named credential sources, monitored targets, and ordered collection rules into an immutable runtime plan. It discovers available metrics with CloudWatch `ListMetrics`, sharing a scan when target, region, namespace, and recent-activity behavior match, then applies each profile's exact dimension matcher. Optional resource-tag predicates are resolved with the Resource Groups Tagging API before query expansion. It queries the selected metric series in `GetMetricData` batches. Each target resolves its AWS account id through `sts:GetCallerIdentity`; target names remain distinct execution identities even when they resolve to the same account. Rule order, then target order within each rule, resolves overlap: the first matching rule/target that produces a final resource instance owns it.
 
 
 This collector is supported on all platforms.
 
 This collector supports collecting metrics from multiple instances of this integration, including remote instances.
 
-Every target requires `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`. The collector calls `sts:GetCallerIdentity` for account attribution, but [AWS does not require an explicit permission grant for that operation](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html). A credential source used by a target with `assume_role` additionally requires `sts:AssumeRole` for that role ARN. Resource tag enrichment (the optional `tags` option) additionally requires `tag:GetResources`.
+Every target requires `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`. The collector calls `sts:GetCallerIdentity` for account attribution, but [AWS does not require an explicit permission grant for that operation](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html). A credential source used by a target with `assume_role` additionally requires `sts:AssumeRole` for that role ARN. Resource tag filtering (`defaults.filters.resource_tags` or `rules[].filters.resource_tags`) and resource tag labels (`labels.resource_tags`) additionally require `tag:GetResources`.
 
 
 ### Default Behavior
@@ -96,13 +96,13 @@ A rule that omits `profiles` selects all default-enabled profiles for its target
 
 - Minimum collection interval is 60 seconds (CloudWatch's minimum metric period).
 - CloudWatch publishes metrics with a delay; the effective query offset is `max(query_offset, period)`, so long-period metrics (such as the daily S3 storage metrics) are inherently about one period behind.
-- There is no cap on discovered resources; a warning is logged at 1000 or more discovered instances (collection is never truncated).
-- Resources are labeled by their identifying CloudWatch dimensions (for example EC2 `instance_id`). Selected resource tags can additionally be attached as labels via the opt-in `tags` option (using the Resource Groups Tagging API); tags are enrichment only and never change a resource's identity. (A dimension that is constant across resources, such as CloudFront's `Region=Global`, is used to match and query metrics but is not turned into a label.)
+- `limits.max_instances` defaults to 1000 distinct final resource instances after tag filtering and overlap resolution. Exceeding it rejects the refreshed query plan; resources are never silently truncated.
+- Resources are labeled by their identifying CloudWatch dimensions (for example EC2 `instance_id`). Selected resource tags can additionally be attached as non-identity labels via `labels.resource_tags`; changing those tags updates labels without changing chart identity. (A dimension that is constant across resources, such as CloudFront's `Region=Global`, is used to match and query metrics but is not turned into a label.)
 
 
 #### Performance Impact
 
-AWS bills CloudWatch API usage. `GetMetricData` (the metric queries) is the cost driver, billed per metric requested; `ListMetrics` discovery falls under the free tier and then costs a fraction as much. As a rough anchor, `GetMetricData` is billed at roughly $0.01 per 1,000 metrics requested -- confirm current [CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/) for your region. Each combination of target, instance, metric, and statistic is one billed query, run once per its own period (not once per collection cycle), so cost scales with selected targets, discovered instances, metrics, statistics, and their periods -- not with `update_every`. The collector minimizes it with curated profiles, single-statistic defaults, exact dimension filtering, shared compatible discovery scans, cached discovery/query plans, and `recently_active_only`. To reduce cost further, narrow `rules[].targets`, `rules[].profiles`, or `rules[].regions`.
+AWS bills CloudWatch API usage. `GetMetricData` (the metric queries) is the cost driver, billed per metric requested; `ListMetrics` discovery falls under the free tier and then costs a fraction as much. As a rough anchor, `GetMetricData` is billed at roughly $0.01 per 1,000 metrics requested -- confirm current [CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/) for your region. Each combination of target, instance, metric, and statistic is one billed query, run once per its own period (not once per collection cycle), so cost scales with selected targets, selected instances, metrics, statistics, and their periods -- not with `update_every`. The collector minimizes it with curated profiles, exact resource-tag and dimension filtering, single-statistic defaults, shared compatible discovery scans, cached discovery/query plans, and `recently_active_only`. To reduce cost further, narrow `rules[].targets`, `rules[].profiles`, `rules[].regions`, or configure resource tag filters.
 
 
 ## Setup
@@ -146,7 +146,7 @@ Attach a policy such as:
 }
 ```
 
-`cloudwatch:ListMetrics` and `cloudwatch:GetMetricData` do not support resource-level permissions, so `"Resource": "*"` is required -- this is already least-privilege for these read actions. `GetCallerIdentity` needs no explicit grant. Scope `sts:AssumeRole` to the specific role ARN(s) rather than `*`. To enable resource tag enrichment (the optional `tags` option), also grant `tag:GetResources` (it likewise requires `"Resource": "*"`).
+`cloudwatch:ListMetrics` and `cloudwatch:GetMetricData` do not support resource-level permissions, so `"Resource": "*"` is required -- this is already least-privilege for these read actions. `GetCallerIdentity` needs no explicit grant. Scope `sts:AssumeRole` to the specific role ARN(s) rather than `*`. To enable resource tag filtering or labels, also grant `tag:GetResources` (it likewise requires `"Resource": "*"`).
 
 Define one or more named credential sources:
 
@@ -195,16 +195,25 @@ A user profile file with the same basename as a stock profile overrides it.
 |  | targets[].credentials | Name of the credential source used by this target. |  | yes |
 |  | targets[].assume_role.role_arn | Optional IAM role ARN to assume using the target's credential source. |  | no |
 |  | targets[].assume_role.external_id | Optional value supplied by the role owner when the role trust policy requires an external ID. It is not an AWS password or access key. |  | no |
-| **Rules** | rules | Ordered collection rules. Each rule selects targets, profiles, and regions. Earlier rules own duplicate final metric series; within one rule, the earliest entry in `rules[].targets` owns the series. |  | yes |
+| **Rules** | rules | Ordered collection rules. Each rule selects targets, profiles, regions, and optional resource-tag filters. The earliest matching rule and target own each overlapping final resource instance. |  | yes |
 |  | rules[].name | Unique rule name used in diagnostics. |  | yes |
 |  | rules[].targets | Ordered names of monitored targets selected by this rule. Order breaks overlap ties within the rule. |  | yes |
 |  | rules[].profiles.defaults | Include all default-enabled profiles. Defaults to `true` when `profiles` or `defaults` is omitted. | yes | no |
 |  | rules[].profiles.include | Profile basenames to add explicitly. Set `defaults` to `false` to collect only this list, including profiles disabled by default. |  | no |
 |  | rules[].profiles.exclude | Profile basenames to remove from the selected set. A profile cannot be both included and excluded. |  | no |
 |  | rules[].regions | Canonical lowercase AWS region codes selected by this rule. The compiler intersects them with intrinsic profile restrictions; for example, CloudFront supports only `us-east-1`. |  | yes |
+| **Resource Filters** | defaults.filters.resource_tags | Job-wide list of exact, case-sensitive AWS resource tag predicates inherited by rules that omit `rules[].filters.resource_tags`. All keys must match; any listed value for one key may match. The Resource Groups Tagging API performs the focused lookup and requires `tag:GetResources`. |  | no |
+|  | defaults.filters.resource_tags[].key | Exact AWS resource tag key. A filter list supports at most 50 distinct keys. |  | yes |
+|  | defaults.filters.resource_tags[].values | One to 20 exact, case-sensitive accepted values for this key. Values for one key are ORed. |  | yes |
+|  | rules[].filters.resource_tags | Per-rule replacement for `defaults.filters.resource_tags`. Omit it to inherit the default, provide a non-empty list to replace the default, or set `[]` to disable tag filtering for this rule. |  | no |
+|  | rules[].filters.resource_tags[].key | Exact AWS resource tag key. A filter list supports at most 50 distinct keys. |  | yes |
+|  | rules[].filters.resource_tags[].values | One to 20 exact, case-sensitive accepted values for this key. Values for one key are ORed. |  | yes |
+| **Resource Labels** | labels.resource_tags | Optional AWS resource tags copied to charts as non-identity labels. This is presentation only and does not select resources. Tag values may contain personal data, so expose only keys intended for Netdata. Requires `tag:GetResources`. |  | no |
+|  | labels.resource_tags[].key | Exact, case-sensitive AWS resource tag key. |  | yes |
+|  | labels.resource_tags[].label | Optional Netdata label key. When omitted, the AWS key is normalized (`Name` becomes `name`). Use an explicit label to avoid invalid names or collisions with identity labels such as `region`. |  | no |
+| **Limits** | limits.max_instances | Maximum distinct final CloudWatch resource instances after filtering and ordered-rule overlap resolution, before metric/statistic expansion. Overflow rejects the refreshed plan; collection never truncates to the first N resources. | 1000 | no |
 | **Discovery** | discovery.refresh_every | How often (seconds) to re-discover metrics. Minimum 60. | 300 | no |
 |  | discovery.recently_active_only | List only metrics active in the last 3 hours. Automatically disabled for metrics whose period exceeds 3 hours (such as the daily S3 storage metrics). | yes | no |
-| **Tags** | tags | Optional allowlist of AWS resource tags to attach as extra labels on collected metrics, looked up via the Resource Groups Tagging API. Empty by default -- with no tags listed, no tag lookup runs and no extra IAM is needed. Each entry has a `name` (the AWS tag key, case-sensitive) and an optional `rename` (the Netdata label name; the default is the sanitized key, so `Name` becomes `name`). Use `rename` when the key is not a valid label (for example an `aws:`-prefixed key) or collides with a built-in label such as `region`. Enabling tags requires the `tag:GetResources` IAM permission. Note: tag values become label values and may contain personal data (such as owner emails), so list only tags you want exposed as labels. Tags apply only to profiles with a supported resource-ARN join; some services are not tag-enriched: Auto Scaling and Bedrock (not taggable via the Resource Groups Tagging API), and -- pending a reliable ARN join -- API Gateway, CloudFront, MSK, and ElastiCache. Tags behave as create-time chart labels: a tag that first appears or changes value after a chart already exists is reflected only when that chart is next recreated. |  | no |
 | **Virtual Node** | vnode | Associates this data collection job with a [Virtual Node](https://learn.netdata.cloud/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts#virtual-nodes). |  | no |
 
 
@@ -353,6 +362,49 @@ jobs:
           defaults: true
           include: [alb_target, dynamodb_operation, s3_requests, ebs_stalled_io]
         regions: [us-east-1]
+
+```
+</details>
+
+###### Filter resources by tag and add tag labels
+
+Apply one job-wide exact tag filter, disable it for an unsupported profile, and expose selected AWS tags as mutable non-identity chart labels.
+
+<details open><summary>Config</summary>
+
+```yaml
+jobs:
+  - name: tagged_resources
+    credentials:
+      - name: sdk_default
+        type: default
+    targets:
+      - name: base
+        credentials: sdk_default
+    defaults:
+      filters:
+        resource_tags:
+          - key: managed-by
+            values: [platform]
+    rules:
+      - name: filtered-defaults
+        targets: [base]
+        regions: [us-east-1]
+      - name: unfiltered-cloudfront
+        targets: [base]
+        profiles:
+          defaults: false
+          include: [cloudfront]
+        regions: [us-east-1]
+        filters:
+          resource_tags: []
+    labels:
+      resource_tags:
+        - key: Name
+        - key: owner
+          label: resource_owner
+    limits:
+      max_instances: 1000
 
 ```
 </details>
@@ -539,8 +591,9 @@ docker logs netdata 2>&1 | grep cloudwatch
 
 Check the following:
 
-- **Permissions** -- each target allows `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`; `GetCallerIdentity` needs no explicit grant. Targets with `assume_role` also require `sts:AssumeRole` on the source identity.
+- **Permissions** -- each target allows `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`; `GetCallerIdentity` needs no explicit grant. Targets with `assume_role` also require `sts:AssumeRole` on the source identity. Resource tag filtering or labels require `tag:GetResources`.
 - **Rules** -- `rules[].targets`, `rules[].profiles`, and `rules[].regions` select the expected target, service, and region. CloudFront publishes metrics only in `us-east-1`; its profile enforces this automatically.
+- **Resource filters** -- a rule that omits `filters.resource_tags` inherits `defaults.filters.resource_tags`. An explicitly included profile without a safe Resource Groups Tagging API association is rejected; use `filters.resource_tags: []` for a deliberate unfiltered rule.
 - **Resources are active** -- confirm in the AWS CloudWatch console that the resources are publishing metrics.
 - **Collector logs** -- check for authentication or API errors:
   ```bash

--- a/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
@@ -113,14 +113,14 @@ modules:
 
           :::
         method_description: |
-          The collector compiles named credential sources, monitored targets, and ordered collection rules into an immutable runtime plan. It discovers available metrics with CloudWatch `ListMetrics`, sharing a scan when target, region, namespace, and recent-activity behavior match, then applies each profile's exact dimension matcher. It queries the resulting metric series in `GetMetricData` batches. Each target resolves its AWS account id through `sts:GetCallerIdentity`; target names remain distinct execution identities even when they resolve to the same account. Rule order, then target order within each rule, resolves overlap: the first rule/target that produces a final metric series owns it.
+          The collector compiles named credential sources, monitored targets, and ordered collection rules into an immutable runtime plan. It discovers available metrics with CloudWatch `ListMetrics`, sharing a scan when target, region, namespace, and recent-activity behavior match, then applies each profile's exact dimension matcher. Optional resource-tag predicates are resolved with the Resource Groups Tagging API before query expansion. It queries the selected metric series in `GetMetricData` batches. Each target resolves its AWS account id through `sts:GetCallerIdentity`; target names remain distinct execution identities even when they resolve to the same account. Rule order, then target order within each rule, resolves overlap: the first matching rule/target that produces a final resource instance owns it.
       supported_platforms:
         include: []
         exclude: []
       multi_instance: true
       additional_permissions:
         description: |
-          Every target requires `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`. The collector calls `sts:GetCallerIdentity` for account attribution, but [AWS does not require an explicit permission grant for that operation](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html). A credential source used by a target with `assume_role` additionally requires `sts:AssumeRole` for that role ARN. Resource tag enrichment (the optional `tags` option) additionally requires `tag:GetResources`.
+          Every target requires `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`. The collector calls `sts:GetCallerIdentity` for account attribution, but [AWS does not require an explicit permission grant for that operation](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html). A credential source used by a target with `assume_role` additionally requires `sts:AssumeRole` for that role ARN. Resource tag filtering (`defaults.filters.resource_tags` or `rules[].filters.resource_tags`) and resource tag labels (`labels.resource_tags`) additionally require `tag:GetResources`.
       default_behavior:
         auto_detection:
           description: |
@@ -129,11 +129,11 @@ modules:
           description: |
             - Minimum collection interval is 60 seconds (CloudWatch's minimum metric period).
             - CloudWatch publishes metrics with a delay; the effective query offset is `max(query_offset, period)`, so long-period metrics (such as the daily S3 storage metrics) are inherently about one period behind.
-            - There is no cap on discovered resources; a warning is logged at 1000 or more discovered instances (collection is never truncated).
-            - Resources are labeled by their identifying CloudWatch dimensions (for example EC2 `instance_id`). Selected resource tags can additionally be attached as labels via the opt-in `tags` option (using the Resource Groups Tagging API); tags are enrichment only and never change a resource's identity. (A dimension that is constant across resources, such as CloudFront's `Region=Global`, is used to match and query metrics but is not turned into a label.)
+            - `limits.max_instances` defaults to 1000 distinct final resource instances after tag filtering and overlap resolution. Exceeding it rejects the refreshed query plan; resources are never silently truncated.
+            - Resources are labeled by their identifying CloudWatch dimensions (for example EC2 `instance_id`). Selected resource tags can additionally be attached as non-identity labels via `labels.resource_tags`; changing those tags updates labels without changing chart identity. (A dimension that is constant across resources, such as CloudFront's `Region=Global`, is used to match and query metrics but is not turned into a label.)
         performance_impact:
           description: |
-            AWS bills CloudWatch API usage. `GetMetricData` (the metric queries) is the cost driver, billed per metric requested; `ListMetrics` discovery falls under the free tier and then costs a fraction as much. As a rough anchor, `GetMetricData` is billed at roughly $0.01 per 1,000 metrics requested -- confirm current [CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/) for your region. Each combination of target, instance, metric, and statistic is one billed query, run once per its own period (not once per collection cycle), so cost scales with selected targets, discovered instances, metrics, statistics, and their periods -- not with `update_every`. The collector minimizes it with curated profiles, single-statistic defaults, exact dimension filtering, shared compatible discovery scans, cached discovery/query plans, and `recently_active_only`. To reduce cost further, narrow `rules[].targets`, `rules[].profiles`, or `rules[].regions`.
+            AWS bills CloudWatch API usage. `GetMetricData` (the metric queries) is the cost driver, billed per metric requested; `ListMetrics` discovery falls under the free tier and then costs a fraction as much. As a rough anchor, `GetMetricData` is billed at roughly $0.01 per 1,000 metrics requested -- confirm current [CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/) for your region. Each combination of target, instance, metric, and statistic is one billed query, run once per its own period (not once per collection cycle), so cost scales with selected targets, selected instances, metrics, statistics, and their periods -- not with `update_every`. The collector minimizes it with curated profiles, exact resource-tag and dimension filtering, single-statistic defaults, shared compatible discovery scans, cached discovery/query plans, and `recently_active_only`. To reduce cost further, narrow `rules[].targets`, `rules[].profiles`, `rules[].regions`, or configure resource tag filters.
     setup:
       prerequisites:
         list:
@@ -159,7 +159,7 @@ modules:
               }
               ```
 
-              `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData` do not support resource-level permissions, so `"Resource": "*"` is required -- this is already least-privilege for these read actions. `GetCallerIdentity` needs no explicit grant. Scope `sts:AssumeRole` to the specific role ARN(s) rather than `*`. To enable resource tag enrichment (the optional `tags` option), also grant `tag:GetResources` (it likewise requires `"Resource": "*"`).
+              `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData` do not support resource-level permissions, so `"Resource": "*"` is required -- this is already least-privilege for these read actions. `GetCallerIdentity` needs no explicit grant. Scope `sts:AssumeRole` to the specific role ARN(s) rather than `*`. To enable resource tag filtering or labels, also grant `tag:GetResources` (it likewise requires `"Resource": "*"`).
 
               Define one or more named credential sources:
 
@@ -267,7 +267,7 @@ modules:
               required: false
               group: Targets
             - name: rules
-              description: Ordered collection rules. Each rule selects targets, profiles, and regions. Earlier rules own duplicate final metric series; within one rule, the earliest entry in `rules[].targets` owns the series.
+              description: Ordered collection rules. Each rule selects targets, profiles, regions, and optional resource-tag filters. The earliest matching rule and target own each overlapping final resource instance.
               default_value: ""
               required: true
               group: Rules
@@ -301,6 +301,56 @@ modules:
               default_value: ""
               required: true
               group: Rules
+            - name: defaults.filters.resource_tags
+              description: Job-wide list of exact, case-sensitive AWS resource tag predicates inherited by rules that omit `rules[].filters.resource_tags`. All keys must match; any listed value for one key may match. The Resource Groups Tagging API performs the focused lookup and requires `tag:GetResources`.
+              default_value: ""
+              required: false
+              group: Resource Filters
+            - name: defaults.filters.resource_tags[].key
+              description: Exact AWS resource tag key. A filter list supports at most 50 distinct keys.
+              default_value: ""
+              required: true
+              group: Resource Filters
+            - name: defaults.filters.resource_tags[].values
+              description: One to 20 exact, case-sensitive accepted values for this key. Values for one key are ORed.
+              default_value: ""
+              required: true
+              group: Resource Filters
+            - name: rules[].filters.resource_tags
+              description: Per-rule replacement for `defaults.filters.resource_tags`. Omit it to inherit the default, provide a non-empty list to replace the default, or set `[]` to disable tag filtering for this rule.
+              default_value: ""
+              required: false
+              group: Resource Filters
+            - name: rules[].filters.resource_tags[].key
+              description: Exact AWS resource tag key. A filter list supports at most 50 distinct keys.
+              default_value: ""
+              required: true
+              group: Resource Filters
+            - name: rules[].filters.resource_tags[].values
+              description: One to 20 exact, case-sensitive accepted values for this key. Values for one key are ORed.
+              default_value: ""
+              required: true
+              group: Resource Filters
+            - name: labels.resource_tags
+              description: Optional AWS resource tags copied to charts as non-identity labels. This is presentation only and does not select resources. Tag values may contain personal data, so expose only keys intended for Netdata. Requires `tag:GetResources`.
+              default_value: ""
+              required: false
+              group: Resource Labels
+            - name: labels.resource_tags[].key
+              description: Exact, case-sensitive AWS resource tag key.
+              default_value: ""
+              required: true
+              group: Resource Labels
+            - name: labels.resource_tags[].label
+              description: Optional Netdata label key. When omitted, the AWS key is normalized (`Name` becomes `name`). Use an explicit label to avoid invalid names or collisions with identity labels such as `region`.
+              default_value: ""
+              required: false
+              group: Resource Labels
+            - name: limits.max_instances
+              description: Maximum distinct final CloudWatch resource instances after filtering and ordered-rule overlap resolution, before metric/statistic expansion. Overflow rejects the refreshed plan; collection never truncates to the first N resources.
+              default_value: 1000
+              required: false
+              group: Limits
             - name: discovery.refresh_every
               description: How often (seconds) to re-discover metrics. Minimum 60.
               default_value: 300
@@ -311,12 +361,6 @@ modules:
               default_value: true
               required: false
               group: Discovery
-            - name: tags
-              description: |
-                Optional allowlist of AWS resource tags to attach as extra labels on collected metrics, looked up via the Resource Groups Tagging API. Empty by default -- with no tags listed, no tag lookup runs and no extra IAM is needed. Each entry has a `name` (the AWS tag key, case-sensitive) and an optional `rename` (the Netdata label name; the default is the sanitized key, so `Name` becomes `name`). Use `rename` when the key is not a valid label (for example an `aws:`-prefixed key) or collides with a built-in label such as `region`. Enabling tags requires the `tag:GetResources` IAM permission. Note: tag values become label values and may contain personal data (such as owner emails), so list only tags you want exposed as labels. Tags apply only to profiles with a supported resource-ARN join; some services are not tag-enriched: Auto Scaling and Bedrock (not taggable via the Resource Groups Tagging API), and -- pending a reliable ARN join -- API Gateway, CloudFront, MSK, and ElastiCache. Tags behave as create-time chart labels: a tag that first appears or changes value after a chart already exists is reflected only when that chart is next recreated.
-              default_value: ""
-              required: false
-              group: Tags
             - name: vnode
               description: Associates this data collection job with a [Virtual Node](https://learn.netdata.cloud/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts#virtual-nodes).
               default_value: ""
@@ -404,6 +448,41 @@ modules:
                           defaults: true
                           include: [alb_target, dynamodb_operation, s3_requests, ebs_stalled_io]
                         regions: [us-east-1]
+            - name: Filter resources by tag and add tag labels
+              description: Apply one job-wide exact tag filter, disable it for an unsupported profile, and expose selected AWS tags as mutable non-identity chart labels.
+              config: |
+                jobs:
+                  - name: tagged_resources
+                    credentials:
+                      - name: sdk_default
+                        type: default
+                    targets:
+                      - name: base
+                        credentials: sdk_default
+                    defaults:
+                      filters:
+                        resource_tags:
+                          - key: managed-by
+                            values: [platform]
+                    rules:
+                      - name: filtered-defaults
+                        targets: [base]
+                        regions: [us-east-1]
+                      - name: unfiltered-cloudfront
+                        targets: [base]
+                        profiles:
+                          defaults: false
+                          include: [cloudfront]
+                        regions: [us-east-1]
+                        filters:
+                          resource_tags: []
+                    labels:
+                      resource_tags:
+                        - key: Name
+                        - key: owner
+                          label: resource_owner
+                    limits:
+                      max_instances: 1000
     troubleshooting:
       problems:
         list:
@@ -411,8 +490,9 @@ modules:
             description: |
               Check the following:
 
-              - **Permissions** -- each target allows `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`; `GetCallerIdentity` needs no explicit grant. Targets with `assume_role` also require `sts:AssumeRole` on the source identity.
+              - **Permissions** -- each target allows `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`; `GetCallerIdentity` needs no explicit grant. Targets with `assume_role` also require `sts:AssumeRole` on the source identity. Resource tag filtering or labels require `tag:GetResources`.
               - **Rules** -- `rules[].targets`, `rules[].profiles`, and `rules[].regions` select the expected target, service, and region. CloudFront publishes metrics only in `us-east-1`; its profile enforces this automatically.
+              - **Resource filters** -- a rule that omits `filters.resource_tags` inherits `defaults.filters.resource_tags`. An explicitly included profile without a safe Resource Groups Tagging API association is rejected; use `filters.resource_tags: []` for a deliberate unfiltered rule.
               - **Resources are active** -- confirm in the AWS CloudWatch console that the resources are publishing metrics.
               - **Collector logs** -- check for authentication or API errors:
                 ```bash

--- a/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
@@ -120,7 +120,7 @@ modules:
       multi_instance: true
       additional_permissions:
         description: |
-          Every target requires `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`. The collector calls `sts:GetCallerIdentity` for account attribution, but [AWS does not require an explicit permission grant for that operation](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html). A credential source used by a target with `assume_role` additionally requires `sts:AssumeRole` for that role ARN. Resource tag filtering (`defaults.filters.resource_tags` or `rules[].filters.resource_tags`) and resource tag labels (`labels.resource_tags`) additionally require `tag:GetResources`.
+          Every target requires `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`. The collector calls `sts:GetCallerIdentity` for account attribution, but [AWS does not require an explicit permission grant for that operation](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html). A credential source used by a target with `assume_role` additionally requires `sts:AssumeRole` for that role ARN. Resource tag filtering (`rule_defaults.filters.resource_tags` or `rules[].filters.resource_tags`) and resource tag labels (`labels.resource_tags`) additionally require `tag:GetResources`.
       default_behavior:
         auto_detection:
           description: |
@@ -301,23 +301,23 @@ modules:
               default_value: ""
               required: true
               group: Rules
-            - name: defaults.filters.resource_tags
+            - name: rule_defaults.filters.resource_tags
               description: Job-wide list of exact, case-sensitive AWS resource tag predicates inherited by rules that omit `rules[].filters.resource_tags`. All keys must match; any listed value for one key may match. The Resource Groups Tagging API performs the focused lookup and requires `tag:GetResources`.
               default_value: ""
               required: false
               group: Resource Filters
-            - name: defaults.filters.resource_tags[].key
+            - name: rule_defaults.filters.resource_tags[].key
               description: Exact AWS resource tag key. A filter list supports at most 50 distinct keys.
               default_value: ""
               required: true
               group: Resource Filters
-            - name: defaults.filters.resource_tags[].values
+            - name: rule_defaults.filters.resource_tags[].values
               description: One to 20 exact, case-sensitive accepted values for this key. Values for one key are ORed.
               default_value: ""
               required: true
               group: Resource Filters
             - name: rules[].filters.resource_tags
-              description: Per-rule replacement for `defaults.filters.resource_tags`. Omit it to inherit the default, provide a non-empty list to replace the default, or set `[]` to disable tag filtering for this rule.
+              description: Per-rule replacement for `rule_defaults.filters.resource_tags`. Omit it to inherit the default, provide a non-empty list to replace the default, or set `[]` to disable tag filtering for this rule.
               default_value: ""
               required: false
               group: Resource Filters
@@ -459,7 +459,7 @@ modules:
                     targets:
                       - name: base
                         credentials: sdk_default
-                    defaults:
+                    rule_defaults:
                       filters:
                         resource_tags:
                           - key: managed-by
@@ -492,7 +492,7 @@ modules:
 
               - **Permissions** -- each target allows `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`; `GetCallerIdentity` needs no explicit grant. Targets with `assume_role` also require `sts:AssumeRole` on the source identity. Resource tag filtering or labels require `tag:GetResources`.
               - **Rules** -- `rules[].targets`, `rules[].profiles`, and `rules[].regions` select the expected target, service, and region. CloudFront publishes metrics only in `us-east-1`; its profile enforces this automatically.
-              - **Resource filters** -- a rule that omits `filters.resource_tags` inherits `defaults.filters.resource_tags`. An explicitly included profile without a safe Resource Groups Tagging API association is rejected; use `filters.resource_tags: []` for a deliberate unfiltered rule.
+              - **Resource filters** -- a rule that omits `filters.resource_tags` inherits `rule_defaults.filters.resource_tags`. An explicitly included profile without a safe Resource Groups Tagging API association is rejected; use `filters.resource_tags: []` for a deliberate unfiltered rule.
               - **Resources are active** -- confirm in the AWS CloudWatch console that the resources are publishing metrics.
               - **Collector logs** -- check for authentication or API errors:
                 ```bash

--- a/src/go/plugin/go.d/collector/cloudwatch/multiaccount_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/multiaccount_test.go
@@ -100,7 +100,7 @@ func TestBuildQueryPlan_FirstTargetOwnsSameAccountSeries(t *testing.T) {
 		{Target: "first", Profile: "ec2", Region: "us-east-1"}:  {{DimensionValues: []string{"i-1"}}},
 		{Target: "second", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
 	}}
-	plan := c.buildQueryPlan()
+	plan := requireBuildQueryPlan(t, c)
 	require.NotEmpty(t, plan)
 	perInstance := 0
 	for _, metric := range c.plan.Scopes[0].Profile.Config.Metrics {
@@ -123,7 +123,7 @@ func TestBuildQueryPlan_SameAccountDisjointResourcesSurvive(t *testing.T) {
 		{Target: "first", Profile: "ec2", Region: "us-east-1"}:  {{DimensionValues: []string{"i-1"}}},
 		{Target: "second", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-2"}}},
 	}}
-	plan := c.buildQueryPlan()
+	plan := requireBuildQueryPlan(t, c)
 	perInstance := 0
 	for _, metric := range c.plan.Scopes[0].Profile.Config.Metrics {
 		perInstance += len(metric.Statistics)
@@ -142,7 +142,7 @@ func TestCurrentQueryPlan_RebindsRetainedSeriesWhenEarlierTargetTakesOwnership(t
 		{Target: "second", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
 	}}
 
-	oldPlan := c.currentQueryPlan()
+	oldPlan := requireCurrentQueryPlan(t, c)
 	require.NotEmpty(t, oldPlan)
 	oldQuery := oldPlan[0]
 	require.Equal(t, "second", oldQuery.target)
@@ -166,7 +166,7 @@ func TestCurrentQueryPlan_RebindsRetainedSeriesWhenEarlierTargetTakesOwnership(t
 	require.NoError(t, cycle.CommitCycleSuccess())
 
 	require.NoError(t, c.ensureTargets(context.Background()))
-	newPlan := c.currentQueryPlan()
+	newPlan := requireCurrentQueryPlan(t, c)
 	require.NotEmpty(t, newPlan)
 	newQuery := newPlan[0]
 	require.Equal(t, "first", newQuery.target)

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
@@ -25,16 +25,21 @@ type planCompiler struct {
 	usedCredentials  map[string]struct{}
 	usedTargets      map[string]struct{}
 	selectedProfiles map[string]cwprofiles.ResolvedProfile
-	seenScopes       map[string]string
+	seenScopes       map[compiledScopeKey]string
 	targetPartitions map[string]map[string]struct{}
 	candidateChecks  int
 }
 
+type compiledScopeKey struct {
+	target, profile, region, filter string
+}
+
 type ruleDiagnostics struct {
-	ruleName       string
-	skippedProfile []string
-	shadowed       int
-	shadowSample   *shadowSample
+	ruleName              string
+	skippedProfile        []string
+	skippedTagAssociation []string
+	shadowed              int
+	shadowSample          *shadowSample
 }
 
 type shadowSample struct {
@@ -62,7 +67,7 @@ func newPlanCompiler(cfg Config, catalog cwprofiles.Catalog) *planCompiler {
 		usedCredentials:   make(map[string]struct{}),
 		usedTargets:       make(map[string]struct{}),
 		selectedProfiles:  make(map[string]cwprofiles.ResolvedProfile),
-		seenScopes:        make(map[string]string),
+		seenScopes:        make(map[compiledScopeKey]string),
 		targetPartitions:  make(map[string]map[string]struct{}),
 	}
 }
@@ -112,6 +117,8 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 		return diagnostics, err
 	}
 	regions := normalizeRegions(rule.Regions)
+	tagFilters := compileResourceTagFilters(rule.effectiveResourceTagFilters(pc.cfg.Defaults.Filters.ResourceTags))
+	filterKey := resourceTagFilterSignature(tagFilters)
 
 	candidates := len(targets) * len(profiles) * len(regions)
 	if candidates > maxCandidateScopeChecks-pc.candidateChecks {
@@ -138,6 +145,15 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 			diagnostics.skippedProfile = append(diagnostics.skippedProfile, profile.Name)
 			continue
 		}
+		if len(tagFilters) > 0 {
+			if err := validateTagJoinProfile(profile); err != nil {
+				if _, explicit := explicitlyIncluded[profile.Name]; explicit {
+					return diagnostics, fmt.Errorf("%s explicitly includes profile %q with resource tag filtering, but it has no safe tag association: %w", path, profile.Name, err)
+				}
+				diagnostics.skippedTagAssociation = append(diagnostics.skippedTagAssociation, profile.Name)
+				continue
+			}
+		}
 		eligibleProfiles = append(eligibleProfiles, profileRegions{profile: profile, regions: supported})
 	}
 	if len(eligibleProfiles) == 0 {
@@ -148,7 +164,7 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 		pc.usedTargets[target.Name] = struct{}{}
 		for _, selected := range eligibleProfiles {
 			for _, region := range selected.regions {
-				if err := pc.addScope(ruleName, target, selected.profile, region, &diagnostics); err != nil {
+				if err := pc.addScope(ruleName, target, selected.profile, region, tagFilters, filterKey, &diagnostics); err != nil {
 					return diagnostics, err
 				}
 			}
@@ -157,8 +173,8 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 	return diagnostics, nil
 }
 
-func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, profile cwprofiles.ResolvedProfile, region string, diagnostics *ruleDiagnostics) error {
-	key := target.Name + "\x00" + profile.Name + "\x00" + region
+func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, profile cwprofiles.ResolvedProfile, region string, tagFilters []resourceTagFilter, filterKey string, diagnostics *ruleDiagnostics) error {
+	key := compiledScopeKey{target: target.Name, profile: profile.Name, region: region, filter: filterKey}
 	if owner, ok := pc.seenScopes[key]; ok {
 		diagnostics.shadowed++
 		if diagnostics.shadowSample == nil {
@@ -170,7 +186,10 @@ func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, prof
 		return fmt.Errorf("compiled collection scopes exceed maximum %d", maxCompiledScopes)
 	}
 	pc.seenScopes[key] = ruleName
-	pc.plan.Scopes = append(pc.plan.Scopes, collectionScope{Target: target, Profile: profile, Region: region})
+	pc.plan.Scopes = append(pc.plan.Scopes, collectionScope{
+		ID: len(pc.plan.Scopes), Rule: ruleName, Target: target, Profile: profile, Region: region,
+		TagFilter: tagFilters,
+	})
 	pc.selectedProfiles[profile.Name] = profile
 	if !slices.Contains(target.Regions, region) {
 		target.Regions = append(target.Regions, region)
@@ -216,6 +235,9 @@ func (d ruleDiagnostics) messages() []string {
 	var messages []string
 	if len(d.skippedProfile) > 0 {
 		messages = append(messages, fmt.Sprintf("rule %q skips default profiles unsupported in its regions: %s", d.ruleName, strings.Join(d.skippedProfile, ", ")))
+	}
+	if len(d.skippedTagAssociation) > 0 {
+		messages = append(messages, fmt.Sprintf("rule %q skips default profiles without a safe resource-tag association: %s", d.ruleName, strings.Join(d.skippedTagAssociation, ", ")))
 	}
 	if d.shadowed > 0 {
 		sample := d.shadowSample

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
@@ -21,7 +21,6 @@ type planCompiler struct {
 	targetRoleARN     map[string]string
 	profiles          []cwprofiles.ResolvedProfile
 	profilesByName    map[string]cwprofiles.ResolvedProfile
-	tagJoinsByProfile map[string]*tagJoin
 	tagJoinErrors     map[string]error
 
 	usedCredentials  map[string]struct{}
@@ -58,19 +57,17 @@ func newPlanCompiler(cfg Config, catalog cwprofiles.Catalog) *planCompiler {
 	for _, source := range cfg.Credentials {
 		credentialsByName[source.Name] = source.CredentialConfig
 	}
-	tagJoinsByProfile := make(map[string]*tagJoin)
 	return &planCompiler{
 		cfg: cfg,
 		plan: &collectionPlan{
 			Targets:  make([]*collectionTarget, 0, len(cfg.Targets)),
-			TagJoins: tagJoinsByProfile,
+			TagJoins: make(map[string]*tagJoin),
 		},
 		credentialsByName: credentialsByName,
 		targetsByRef:      make(map[string]*collectionTarget, len(cfg.Targets)),
 		targetRoleARN:     make(map[string]string, len(cfg.Targets)),
 		profiles:          profiles,
 		profilesByName:    profilesByName,
-		tagJoinsByProfile: tagJoinsByProfile,
 		tagJoinErrors:     make(map[string]error),
 		usedCredentials:   make(map[string]struct{}),
 		usedTargets:       make(map[string]struct{}),
@@ -137,7 +134,6 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 	type profileRegions struct {
 		profile cwprofiles.ResolvedProfile
 		regions []string
-		tagJoin *tagJoin
 	}
 	eligibleProfiles := make([]profileRegions, 0, len(profiles))
 	for _, profile := range profiles {
@@ -154,9 +150,8 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 			diagnostics.skippedProfile = append(diagnostics.skippedProfile, profile.Name)
 			continue
 		}
-		var tagJoin *tagJoin
 		if len(tagFilters) > 0 || len(pc.cfg.Labels.ResourceTags) > 0 {
-			resolved, err := pc.resolveTagJoin(profile)
+			_, err := pc.resolveTagJoin(profile)
 			if err != nil && len(tagFilters) > 0 {
 				if _, explicit := explicitlyIncluded[profile.Name]; explicit {
 					return diagnostics, fmt.Errorf("%s explicitly includes profile %q with resource tag filtering, but it has no safe tag association: %w", path, profile.Name, err)
@@ -164,9 +159,8 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 				diagnostics.skippedTagAssociation = append(diagnostics.skippedTagAssociation, profile.Name)
 				continue
 			}
-			tagJoin = resolved
 		}
-		eligibleProfiles = append(eligibleProfiles, profileRegions{profile: profile, regions: supported, tagJoin: tagJoin})
+		eligibleProfiles = append(eligibleProfiles, profileRegions{profile: profile, regions: supported})
 	}
 	if len(eligibleProfiles) == 0 {
 		return diagnostics, fmt.Errorf("%s compiles to no collection scopes", path)
@@ -176,7 +170,7 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 		pc.usedTargets[target.Name] = struct{}{}
 		for _, selected := range eligibleProfiles {
 			for _, region := range selected.regions {
-				if err := pc.addScope(ruleName, target, selected.profile, region, tagFilters, filterKey, selected.tagJoin, &diagnostics); err != nil {
+				if err := pc.addScope(ruleName, target, selected.profile, region, tagFilters, filterKey, &diagnostics); err != nil {
 					return diagnostics, err
 				}
 			}
@@ -185,7 +179,7 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 	return diagnostics, nil
 }
 
-func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, profile cwprofiles.ResolvedProfile, region string, tagFilters []resourceTagFilter, filterKey string, tagJoin *tagJoin, diagnostics *ruleDiagnostics) error {
+func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, profile cwprofiles.ResolvedProfile, region string, tagFilters []resourceTagFilter, filterKey string, diagnostics *ruleDiagnostics) error {
 	key := compiledScopeKey{target: target.Name, profile: profile.Name, region: region, filter: filterKey}
 	if owner, ok := pc.seenScopes[key]; ok {
 		diagnostics.shadowed++
@@ -199,8 +193,7 @@ func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, prof
 	}
 	pc.seenScopes[key] = ruleName
 	pc.plan.Scopes = append(pc.plan.Scopes, collectionScope{
-		ID: len(pc.plan.Scopes), Rule: ruleName, Target: target, Profile: profile, Region: region,
-		TagFilter: tagFilters, TagJoin: tagJoin,
+		Target: target, Profile: profile, Region: region, TagFilter: tagFilters,
 	})
 	pc.selectedProfiles[profile.Name] = profile
 	if !slices.Contains(target.Regions, region) {
@@ -214,7 +207,7 @@ func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, prof
 }
 
 func (pc *planCompiler) resolveTagJoin(profile cwprofiles.ResolvedProfile) (*tagJoin, error) {
-	if join, ok := pc.tagJoinsByProfile[profile.Name]; ok {
+	if join, ok := pc.plan.TagJoins[profile.Name]; ok {
 		return join, nil
 	}
 	if err, ok := pc.tagJoinErrors[profile.Name]; ok {
@@ -225,7 +218,7 @@ func (pc *planCompiler) resolveTagJoin(profile cwprofiles.ResolvedProfile) (*tag
 		pc.tagJoinErrors[profile.Name] = err
 		return nil, err
 	}
-	pc.tagJoinsByProfile[profile.Name] = join
+	pc.plan.TagJoins[profile.Name] = join
 	return join, nil
 }
 

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
@@ -122,7 +122,7 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 		return diagnostics, err
 	}
 	regions := normalizeRegions(rule.Regions)
-	tagFilters := compileResourceTagFilters(rule.effectiveResourceTagFilters(pc.cfg.Defaults.Filters.ResourceTags))
+	tagFilters := compileResourceTagFilters(rule.effectiveResourceTagFilters(pc.cfg.RuleDefaults.Filters.ResourceTags))
 	filterKey := resourceTagFilterSignature(tagFilters)
 
 	candidates := len(targets) * len(profiles) * len(regions)

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
@@ -21,6 +21,8 @@ type planCompiler struct {
 	targetRoleARN     map[string]string
 	profiles          []cwprofiles.ResolvedProfile
 	profilesByName    map[string]cwprofiles.ResolvedProfile
+	tagJoinsByProfile map[string]*tagJoin
+	tagJoinErrors     map[string]error
 
 	usedCredentials  map[string]struct{}
 	usedTargets      map[string]struct{}
@@ -56,14 +58,20 @@ func newPlanCompiler(cfg Config, catalog cwprofiles.Catalog) *planCompiler {
 	for _, source := range cfg.Credentials {
 		credentialsByName[source.Name] = source.CredentialConfig
 	}
+	tagJoinsByProfile := make(map[string]*tagJoin)
 	return &planCompiler{
-		cfg:               cfg,
-		plan:              &collectionPlan{Targets: make([]*collectionTarget, 0, len(cfg.Targets))},
+		cfg: cfg,
+		plan: &collectionPlan{
+			Targets:  make([]*collectionTarget, 0, len(cfg.Targets)),
+			TagJoins: tagJoinsByProfile,
+		},
 		credentialsByName: credentialsByName,
 		targetsByRef:      make(map[string]*collectionTarget, len(cfg.Targets)),
 		targetRoleARN:     make(map[string]string, len(cfg.Targets)),
 		profiles:          profiles,
 		profilesByName:    profilesByName,
+		tagJoinsByProfile: tagJoinsByProfile,
+		tagJoinErrors:     make(map[string]error),
 		usedCredentials:   make(map[string]struct{}),
 		usedTargets:       make(map[string]struct{}),
 		selectedProfiles:  make(map[string]cwprofiles.ResolvedProfile),
@@ -129,6 +137,7 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 	type profileRegions struct {
 		profile cwprofiles.ResolvedProfile
 		regions []string
+		tagJoin *tagJoin
 	}
 	eligibleProfiles := make([]profileRegions, 0, len(profiles))
 	for _, profile := range profiles {
@@ -145,16 +154,19 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 			diagnostics.skippedProfile = append(diagnostics.skippedProfile, profile.Name)
 			continue
 		}
-		if len(tagFilters) > 0 {
-			if err := validateTagJoinProfile(profile); err != nil {
+		var tagJoin *tagJoin
+		if len(tagFilters) > 0 || len(pc.cfg.Labels.ResourceTags) > 0 {
+			resolved, err := pc.resolveTagJoin(profile)
+			if err != nil && len(tagFilters) > 0 {
 				if _, explicit := explicitlyIncluded[profile.Name]; explicit {
 					return diagnostics, fmt.Errorf("%s explicitly includes profile %q with resource tag filtering, but it has no safe tag association: %w", path, profile.Name, err)
 				}
 				diagnostics.skippedTagAssociation = append(diagnostics.skippedTagAssociation, profile.Name)
 				continue
 			}
+			tagJoin = resolved
 		}
-		eligibleProfiles = append(eligibleProfiles, profileRegions{profile: profile, regions: supported})
+		eligibleProfiles = append(eligibleProfiles, profileRegions{profile: profile, regions: supported, tagJoin: tagJoin})
 	}
 	if len(eligibleProfiles) == 0 {
 		return diagnostics, fmt.Errorf("%s compiles to no collection scopes", path)
@@ -164,7 +176,7 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 		pc.usedTargets[target.Name] = struct{}{}
 		for _, selected := range eligibleProfiles {
 			for _, region := range selected.regions {
-				if err := pc.addScope(ruleName, target, selected.profile, region, tagFilters, filterKey, &diagnostics); err != nil {
+				if err := pc.addScope(ruleName, target, selected.profile, region, tagFilters, filterKey, selected.tagJoin, &diagnostics); err != nil {
 					return diagnostics, err
 				}
 			}
@@ -173,7 +185,7 @@ func (pc *planCompiler) compileRule(index int, rule RuleConfig) (ruleDiagnostics
 	return diagnostics, nil
 }
 
-func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, profile cwprofiles.ResolvedProfile, region string, tagFilters []resourceTagFilter, filterKey string, diagnostics *ruleDiagnostics) error {
+func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, profile cwprofiles.ResolvedProfile, region string, tagFilters []resourceTagFilter, filterKey string, tagJoin *tagJoin, diagnostics *ruleDiagnostics) error {
 	key := compiledScopeKey{target: target.Name, profile: profile.Name, region: region, filter: filterKey}
 	if owner, ok := pc.seenScopes[key]; ok {
 		diagnostics.shadowed++
@@ -188,7 +200,7 @@ func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, prof
 	pc.seenScopes[key] = ruleName
 	pc.plan.Scopes = append(pc.plan.Scopes, collectionScope{
 		ID: len(pc.plan.Scopes), Rule: ruleName, Target: target, Profile: profile, Region: region,
-		TagFilter: tagFilters,
+		TagFilter: tagFilters, TagJoin: tagJoin,
 	})
 	pc.selectedProfiles[profile.Name] = profile
 	if !slices.Contains(target.Regions, region) {
@@ -199,6 +211,22 @@ func (pc *planCompiler) addScope(ruleName string, target *collectionTarget, prof
 	}
 	pc.targetPartitions[target.Name][awsregion.Partition(region)] = struct{}{}
 	return nil
+}
+
+func (pc *planCompiler) resolveTagJoin(profile cwprofiles.ResolvedProfile) (*tagJoin, error) {
+	if join, ok := pc.tagJoinsByProfile[profile.Name]; ok {
+		return join, nil
+	}
+	if err, ok := pc.tagJoinErrors[profile.Name]; ok {
+		return nil, err
+	}
+	join, err := resolveTagJoinProfile(profile)
+	if err != nil {
+		pc.tagJoinErrors[profile.Name] = err
+		return nil, err
+	}
+	pc.tagJoinsByProfile[profile.Name] = join
+	return join, nil
 }
 
 func (pc *planCompiler) validateUsageAndPartitions() error {

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
@@ -177,7 +177,7 @@ func TestCompileConfig_ResourceTagFilterInheritanceReplacementAndDisable(t *test
 	override := []ResourceTagFilterConfig{{Key: "team", Values: []string{"sre"}}}
 	disabled := []ResourceTagFilterConfig{}
 	cfg := validBaseConfig()
-	cfg.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production"}}}
+	cfg.RuleDefaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production"}}}
 	cfg.Rules = []RuleConfig{
 		{Name: "inherited", Targets: []string{"base"}, Profiles: selector, Regions: []string{"us-east-1"}},
 		{Name: "replaced", Targets: []string{"base"}, Profiles: selector, Regions: []string{"us-east-1"}, Filters: &RuleFiltersConfig{ResourceTags: &override}},
@@ -222,7 +222,7 @@ func TestCompileConfig_ResourceTagFilterUnsupportedProfiles(t *testing.T) {
 
 	t.Run("default selection skips unsupported profiles", func(t *testing.T) {
 		cfg := validBaseConfig()
-		cfg.Defaults.Filters.ResourceTags = filter
+		cfg.RuleDefaults.Filters.ResourceTags = filter
 		plan, diagnostics, err := compileTestConfig(t, cfg)
 		require.NoError(t, err)
 		assert.NotContains(t, scopeProfileNames(plan.Scopes), "api_gateway")
@@ -232,7 +232,7 @@ func TestCompileConfig_ResourceTagFilterUnsupportedProfiles(t *testing.T) {
 	t.Run("explicit unsupported profile fails", func(t *testing.T) {
 		defaults := false
 		cfg := validBaseConfig()
-		cfg.Defaults.Filters.ResourceTags = filter
+		cfg.RuleDefaults.Filters.ResourceTags = filter
 		cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"api_gateway"}}
 		_, _, err := compileTestConfig(t, cfg)
 		assert.ErrorContains(t, err, "no safe tag association")
@@ -242,7 +242,7 @@ func TestCompileConfig_ResourceTagFilterUnsupportedProfiles(t *testing.T) {
 		defaults := false
 		disabled := []ResourceTagFilterConfig{}
 		cfg := validBaseConfig()
-		cfg.Defaults.Filters.ResourceTags = filter
+		cfg.RuleDefaults.Filters.ResourceTags = filter
 		cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"api_gateway"}}
 		cfg.Rules[0].Filters = &RuleFiltersConfig{ResourceTags: &disabled}
 		plan, _, err := compileTestConfig(t, cfg)

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
@@ -188,7 +188,6 @@ func TestCompileConfig_ResourceTagFilterInheritanceReplacementAndDisable(t *test
 	require.NoError(t, err)
 	assert.Empty(t, diagnostics)
 	require.Len(t, plan.Scopes, 3, "distinct effective predicates remain ordered policy scopes")
-	assert.Equal(t, []string{"inherited", "replaced", "disabled"}, []string{plan.Scopes[0].Rule, plan.Scopes[1].Rule, plan.Scopes[2].Rule})
 	assert.Equal(t, []resourceTagFilter{{key: "environment", values: []string{"production"}}}, plan.Scopes[0].TagFilter)
 	assert.Equal(t, []resourceTagFilter{{key: "team", values: []string{"sre"}}}, plan.Scopes[1].TagFilter)
 	assert.Empty(t, plan.Scopes[2].TagFilter)

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
@@ -171,6 +171,88 @@ func TestCompileConfig_StaticScopeFirstRuleWins(t *testing.T) {
 	assert.Contains(t, diagnostics[0], `rule "first" owns`)
 }
 
+func TestCompileConfig_ResourceTagFilterInheritanceReplacementAndDisable(t *testing.T) {
+	defaults := false
+	selector := &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"ec2"}}
+	override := []ResourceTagFilterConfig{{Key: "team", Values: []string{"sre"}}}
+	disabled := []ResourceTagFilterConfig{}
+	cfg := validBaseConfig()
+	cfg.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production"}}}
+	cfg.Rules = []RuleConfig{
+		{Name: "inherited", Targets: []string{"base"}, Profiles: selector, Regions: []string{"us-east-1"}},
+		{Name: "replaced", Targets: []string{"base"}, Profiles: selector, Regions: []string{"us-east-1"}, Filters: &RuleFiltersConfig{ResourceTags: &override}},
+		{Name: "disabled", Targets: []string{"base"}, Profiles: selector, Regions: []string{"us-east-1"}, Filters: &RuleFiltersConfig{ResourceTags: &disabled}},
+	}
+
+	plan, diagnostics, err := compileTestConfig(t, cfg)
+	require.NoError(t, err)
+	assert.Empty(t, diagnostics)
+	require.Len(t, plan.Scopes, 3, "distinct effective predicates remain ordered policy scopes")
+	assert.Equal(t, []string{"inherited", "replaced", "disabled"}, []string{plan.Scopes[0].Rule, plan.Scopes[1].Rule, plan.Scopes[2].Rule})
+	assert.Equal(t, []resourceTagFilter{{key: "environment", values: []string{"production"}}}, plan.Scopes[0].TagFilter)
+	assert.Equal(t, []resourceTagFilter{{key: "team", values: []string{"sre"}}}, plan.Scopes[1].TagFilter)
+	assert.Empty(t, plan.Scopes[2].TagFilter)
+}
+
+func TestCompileConfig_EquivalentResourceTagFiltersDeduplicate(t *testing.T) {
+	defaults := false
+	selector := &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"ec2"}}
+	first := []ResourceTagFilterConfig{
+		{Key: "team", Values: []string{"platform", "sre"}},
+		{Key: "environment", Values: []string{"production"}},
+	}
+	second := []ResourceTagFilterConfig{
+		{Key: "environment", Values: []string{"production"}},
+		{Key: "team", Values: []string{"sre", "platform"}},
+	}
+	cfg := validBaseConfig()
+	cfg.Rules = []RuleConfig{
+		{Name: "owner", Targets: []string{"base"}, Profiles: selector, Regions: []string{"us-east-1"}, Filters: &RuleFiltersConfig{ResourceTags: &first}},
+		{Name: "duplicate", Targets: []string{"base"}, Profiles: selector, Regions: []string{"us-east-1"}, Filters: &RuleFiltersConfig{ResourceTags: &second}},
+	}
+
+	plan, diagnostics, err := compileTestConfig(t, cfg)
+	require.NoError(t, err)
+	assert.Len(t, plan.Scopes, 1)
+	require.Len(t, diagnostics, 1)
+	assert.Contains(t, diagnostics[0], "shadowed")
+}
+
+func TestCompileConfig_ResourceTagFilterUnsupportedProfiles(t *testing.T) {
+	filter := []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production"}}}
+
+	t.Run("default selection skips unsupported profiles", func(t *testing.T) {
+		cfg := validBaseConfig()
+		cfg.Defaults.Filters.ResourceTags = filter
+		plan, diagnostics, err := compileTestConfig(t, cfg)
+		require.NoError(t, err)
+		assert.NotContains(t, scopeProfileNames(plan.Scopes), "api_gateway")
+		assert.Contains(t, strings.Join(diagnostics, "\n"), "api_gateway")
+	})
+
+	t.Run("explicit unsupported profile fails", func(t *testing.T) {
+		defaults := false
+		cfg := validBaseConfig()
+		cfg.Defaults.Filters.ResourceTags = filter
+		cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"api_gateway"}}
+		_, _, err := compileTestConfig(t, cfg)
+		assert.ErrorContains(t, err, "no safe tag association")
+	})
+
+	t.Run("explicit empty override permits unsupported profile unfiltered", func(t *testing.T) {
+		defaults := false
+		disabled := []ResourceTagFilterConfig{}
+		cfg := validBaseConfig()
+		cfg.Defaults.Filters.ResourceTags = filter
+		cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"api_gateway"}}
+		cfg.Rules[0].Filters = &RuleFiltersConfig{ResourceTags: &disabled}
+		plan, _, err := compileTestConfig(t, cfg)
+		require.NoError(t, err)
+		require.Len(t, plan.Scopes, 1)
+		assert.Empty(t, plan.Scopes[0].TagFilter)
+	})
+}
+
 func TestCompileConfig_TargetMayUseStaticCredentialsForAssumeRole(t *testing.T) {
 	cfg := validBaseConfig()
 	cfg.Credentials = []CredentialSourceConfig{

--- a/src/go/plugin/go.d/collector/cloudwatch/query_plan.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/query_plan.go
@@ -124,7 +124,7 @@ func (c *Collector) buildQueryPlan() ([]plannedQuery, error) {
 	if maxInstances <= 0 {
 		maxInstances = defaultMaxInstances
 	}
-	for _, scope := range c.plan.Scopes {
+	for scopeID, scope := range c.plan.Scopes {
 		resolved, ok := c.resolvedTargetByRef(scope.Target.Name)
 		if !ok {
 			continue
@@ -132,8 +132,8 @@ func (c *Collector) buildQueryPlan() ([]plannedQuery, error) {
 		prof := scope.Profile
 		nDims := len(prof.Config.Instance.Dimensions)
 		dimNames := prof.Config.DimensionNames()
-		join := scope.TagJoin
-		membershipUnknown := scope.hasTagFilter() && c.tags.scopeUnknown(scope.ID)
+		join := c.plan.TagJoins[prof.Name]
+		membershipUnknown := scope.hasTagFilter() && c.tags.scopeUnknown(scopeID)
 		instances := c.discovery.Instances[discoveryKey{Target: scope.Target.Name, Profile: prof.Name, Region: scope.Region}]
 		for _, inst := range instances {
 			if len(inst.DimensionValues) != nDims {
@@ -157,7 +157,7 @@ func (c *Collector) buildQueryPlan() ([]plannedQuery, error) {
 					reserved++
 					continue
 				}
-				selected := c.tags.scopeSelected(scope.ID, joinKey)
+				selected := c.tags.scopeSelected(scopeID, joinKey)
 				if !selected && !membershipUnknown {
 					continue
 				}

--- a/src/go/plugin/go.d/collector/cloudwatch/query_plan.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/query_plan.go
@@ -63,16 +63,20 @@ func (c *Collector) invalidateQueryPlan() {
 // discovery, and tag snapshots. Those inputs change on a much slower cadence than
 // Collect, so rebuilding only on invalidation avoids repeating per-series
 // allocations during every collection cycle.
-func (c *Collector) currentQueryPlan() []plannedQuery {
+func (c *Collector) currentQueryPlan() ([]plannedQuery, error) {
 	if !c.planDirty {
-		return c.queryPlan
+		return c.queryPlan, nil
+	}
+	next, err := c.buildQueryPlan()
+	if err != nil {
+		return nil, err
 	}
 	previous := c.queryPlan
-	c.queryPlan = c.buildQueryPlan()
+	c.queryPlan = next
 	c.queryGroups, c.queriesByGroup = groupQueryPlan(c.queryPlan)
 	c.observations.reconcilePlan(previous, c.queryPlan)
 	c.planDirty = false
-	return c.queryPlan
+	return c.queryPlan, nil
 }
 
 func groupQueryPlan(plan []plannedQuery) ([]queryGroupKey, map[queryGroupKey][]plannedQuery) {
@@ -103,17 +107,23 @@ func queryWindow(now time.Time, period, queryOffset int) (start, end time.Time) 
 	return time.Unix(endSec-periodSec, 0).UTC(), time.Unix(endSec, 0).UTC()
 }
 
-// buildQueryPlan follows compiled scope order and keeps the first query for each
-// final emitted identity. This resolves dynamic overlap when distinct targets later
-// resolve to the same account and discover the same resource.
-func (c *Collector) buildQueryPlan() []plannedQuery {
+// buildQueryPlan follows compiled scope order and assigns each final instance to
+// its earliest matching rule. An unknown tag-filter result reserves the candidate
+// from lower rules without querying it, which keeps failures fail-closed.
+func (c *Collector) buildQueryPlan() ([]plannedQuery, error) {
 	if c.plan == nil {
-		return nil
+		return nil, nil
 	}
 	var plan []plannedQuery
 	idx := 0
-	seen := make(map[string]struct{})
+	owned := make(map[string]struct{})
 	shadowed := 0
+	reserved := 0
+	instanceCount := 0
+	maxInstances := c.Limits.MaxInstances
+	if maxInstances <= 0 {
+		maxInstances = defaultMaxInstances
+	}
 	for _, scope := range c.plan.Scopes {
 		resolved, ok := c.resolvedTargetByRef(scope.Target.Name)
 		if !ok {
@@ -121,37 +131,77 @@ func (c *Collector) buildQueryPlan() []plannedQuery {
 		}
 		prof := scope.Profile
 		nDims := len(prof.Config.Instance.Dimensions)
+		dimNames := prof.Config.DimensionNames()
+		join, hasJoin := tagJoins[prof.Name]
+		membershipUnknown := scope.hasTagFilter() && c.tags.scopeUnknown(scope.ID)
 		instances := c.discovery.Instances[discoveryKey{Target: scope.Target.Name, Profile: prof.Name, Region: scope.Region}]
 		for _, inst := range instances {
 			if len(inst.DimensionValues) != nDims {
 				continue // defensive: snapshot/profile mismatch
 			}
+			instanceKey := finalInstanceKey(prof.Name, resolved.accountID, scope.Region, prof.Config.Instance.Dimensions, inst.DimensionValues)
+			if _, exists := owned[instanceKey]; exists {
+				shadowed++
+				continue
+			}
+
+			if scope.hasTagFilter() {
+				if !hasJoin {
+					owned[instanceKey] = struct{}{}
+					reserved++
+					continue
+				}
+				joinKey, ok := join.instanceJoinKey(dimNames, inst.DimensionValues)
+				if !ok {
+					owned[instanceKey] = struct{}{}
+					reserved++
+					continue
+				}
+				selected := c.tags.scopeSelected(scope.ID, joinKey)
+				if !selected && !membershipUnknown {
+					continue
+				}
+				owned[instanceKey] = struct{}{}
+				if !selected {
+					reserved++
+					continue
+				}
+			} else {
+				owned[instanceKey] = struct{}{}
+			}
+
+			instanceCount++
+			if instanceCount > maxInstances {
+				return nil, fmt.Errorf("CloudWatch query plan contains more than limits.max_instances=%d final instances", maxInstances)
+			}
 			labels, dims := c.instanceLabelsAndDims(resolved.accountID, prof, scope.Region, inst)
 			tagLabels := c.tagLabelsFor(scope.Target.Name, resolved.accountID, scope.Region, prof, inst.DimensionValues)
 			queries := c.metricQueries(scope.Target.Name, prof, scope.Region, labels, tagLabels, dims, &idx)
-			for _, query := range queries {
-				key := finalSeriesKey(query.seriesName, query.labels)
-				if _, ok := seen[key]; ok {
-					shadowed++
-					continue
-				}
-				seen[key] = struct{}{}
-				plan = append(plan, query)
-			}
+			plan = append(plan, queries...)
 		}
 	}
 	if shadowed > 0 {
 		c.Limit(logKeyRuleShadowed, 1, recurringLogEvery).
-			Warningf("CloudWatch collection rules shadowed %d duplicate final series; earliest rule/target order owns each series", shadowed)
+			Warningf("CloudWatch collection rules shadowed %d duplicate final instance(s); earliest matching rule/target order owns each instance", shadowed)
 	}
-	return plan
+	if reserved > 0 {
+		c.Limit(logKeyTagRefreshFailed+"_reserved", 1, recurringLogEvery).
+			Warningf("CloudWatch resource tag filtering reserved %d instance(s) from lower-priority rules while membership was unknown", reserved)
+	}
+	return plan, nil
 }
 
-func finalSeriesKey(seriesName string, labels []metrix.Label) string {
+func finalInstanceKey(profileName, accountID, region string, dimensions []cwprofiles.InstanceDimension, values []string) string {
 	var key strings.Builder
-	key.WriteString(seriesName)
-	for _, label := range labels {
-		key.WriteString("\x00" + label.Key + "\x00" + label.Value)
+	writeSignaturePart(&key, profileName)
+	writeSignaturePart(&key, accountID)
+	writeSignaturePart(&key, region)
+	for i, dimension := range dimensions {
+		if dimension.IsConstant() {
+			continue
+		}
+		writeSignaturePart(&key, dimension.Label)
+		writeSignaturePart(&key, values[i])
 	}
 	return key.String()
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/query_plan.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/query_plan.go
@@ -132,7 +132,7 @@ func (c *Collector) buildQueryPlan() ([]plannedQuery, error) {
 		prof := scope.Profile
 		nDims := len(prof.Config.Instance.Dimensions)
 		dimNames := prof.Config.DimensionNames()
-		join, hasJoin := tagJoins[prof.Name]
+		join := scope.TagJoin
 		membershipUnknown := scope.hasTagFilter() && c.tags.scopeUnknown(scope.ID)
 		instances := c.discovery.Instances[discoveryKey{Target: scope.Target.Name, Profile: prof.Name, Region: scope.Region}]
 		for _, inst := range instances {
@@ -146,7 +146,7 @@ func (c *Collector) buildQueryPlan() ([]plannedQuery, error) {
 			}
 
 			if scope.hasTagFilter() {
-				if !hasJoin {
+				if join == nil {
 					owned[instanceKey] = struct{}{}
 					reserved++
 					continue
@@ -175,7 +175,7 @@ func (c *Collector) buildQueryPlan() ([]plannedQuery, error) {
 				return nil, fmt.Errorf("CloudWatch query plan contains more than limits.max_instances=%d final instances", maxInstances)
 			}
 			labels, dims := c.instanceLabelsAndDims(resolved.accountID, prof, scope.Region, inst)
-			tagLabels := c.tagLabelsFor(scope.Target.Name, resolved.accountID, scope.Region, prof, inst.DimensionValues)
+			tagLabels := c.tagLabelsFor(scope.Target.Name, resolved.accountID, scope.Region, prof, join, inst.DimensionValues)
 			queries := c.metricQueries(scope.Target.Name, prof, scope.Region, labels, tagLabels, dims, &idx)
 			plan = append(plan, queries...)
 		}
@@ -193,15 +193,15 @@ func (c *Collector) buildQueryPlan() ([]plannedQuery, error) {
 
 func finalInstanceKey(profileName, accountID, region string, dimensions []cwprofiles.InstanceDimension, values []string) string {
 	var key strings.Builder
-	writeSignaturePart(&key, profileName)
-	writeSignaturePart(&key, accountID)
-	writeSignaturePart(&key, region)
+	writeLengthPrefixed(&key, profileName)
+	writeLengthPrefixed(&key, accountID)
+	writeLengthPrefixed(&key, region)
 	for i, dimension := range dimensions {
 		if dimension.IsConstant() {
 			continue
 		}
-		writeSignaturePart(&key, dimension.Label)
-		writeSignaturePart(&key, values[i])
+		writeLengthPrefixed(&key, dimension.Label)
+		writeLengthPrefixed(&key, values[i])
 	}
 	return key.String()
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/query_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/query_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	goruntime "runtime"
 	"sync"
 	"testing"
 	"time"
@@ -89,12 +90,26 @@ func labelValue(labels []metrix.Label, key string) string {
 	return ""
 }
 
+func requireBuildQueryPlan(t testing.TB, c *Collector) []plannedQuery {
+	t.Helper()
+	plan, err := c.buildQueryPlan()
+	require.NoError(t, err)
+	return plan
+}
+
+func requireCurrentQueryPlan(t testing.TB, c *Collector) []plannedQuery {
+	t.Helper()
+	plan, err := c.currentQueryPlan()
+	require.NoError(t, err)
+	return plan
+}
+
 func TestBuildQueryPlan(t *testing.T) {
 	c := ec2QueryCollector([]string{"us-east-1"}, map[string][][]string{
 		"us-east-1": {{"i-1"}, {"i-2"}},
 	})
 
-	plan := c.buildQueryPlan()
+	plan := requireBuildQueryPlan(t, c)
 	require.Len(t, plan, 6) // 2 instances x (1 + 2 statistics)
 
 	ids := make(map[string]bool)
@@ -153,7 +168,7 @@ func TestBuildQueryPlan_ConstantDimension(t *testing.T) {
 		{Target: "base", Profile: "cloudfront", Region: "us-east-1"}: {{DimensionValues: []string{"E1", "Global"}}},
 	}}
 
-	plan := c.buildQueryPlan()
+	plan := requireBuildQueryPlan(t, c)
 	require.Len(t, plan, 1)
 	pq := plan[0]
 
@@ -181,7 +196,7 @@ func TestBuildQueryPlan_MultiRegionAndEmpty(t *testing.T) {
 		"us-west-2": {{"i-2"}},
 	})
 
-	plan := c.buildQueryPlan()
+	plan := requireBuildQueryPlan(t, c)
 	perRegion := map[string]int{}
 	for _, pq := range plan {
 		assert.Equal(t, pq.region, labelValue(pq.labels, "region"), "region label matches the query's region")
@@ -191,7 +206,7 @@ func TestBuildQueryPlan_MultiRegionAndEmpty(t *testing.T) {
 	assert.Equal(t, 3, perRegion["us-west-2"])
 
 	empty := ec2QueryCollector([]string{"us-east-1"}, map[string][][]string{})
-	assert.Empty(t, empty.buildQueryPlan(), "no discovered instances -> empty plan")
+	assert.Empty(t, requireBuildQueryPlan(t, empty), "no discovered instances -> empty plan")
 }
 
 func TestCurrentQueryPlan_CachesUntilInputsChange(t *testing.T) {
@@ -199,9 +214,9 @@ func TestCurrentQueryPlan_CachesUntilInputsChange(t *testing.T) {
 		"us-east-1": {{"i-1"}},
 	})
 
-	first := c.currentQueryPlan()
+	first := requireCurrentQueryPlan(t, c)
 	require.NotEmpty(t, first)
-	second := c.currentQueryPlan()
+	second := requireCurrentQueryPlan(t, c)
 	require.NotEmpty(t, second)
 	assert.Same(t, &first[0], &second[0], "unchanged inputs reuse the compiled query blueprint")
 	group := first[0].groupKey()
@@ -211,11 +226,109 @@ func TestCurrentQueryPlan_CachesUntilInputsChange(t *testing.T) {
 		c.discovery.Instances[discoveryKey{Target: "base", Profile: "ec2", Region: "us-east-1"}],
 		discoveredInstance{DimensionValues: []string{"i-2"}},
 	)
-	assert.Len(t, c.currentQueryPlan(), len(first), "mutating an input without invalidation does not rebuild")
+	assert.Len(t, requireCurrentQueryPlan(t, c), len(first), "mutating an input without invalidation does not rebuild")
 
 	c.invalidateQueryPlan()
-	assert.Len(t, c.currentQueryPlan(), len(first)*2, "input invalidation rebuilds the query blueprint")
+	assert.Len(t, requireCurrentQueryPlan(t, c), len(first)*2, "input invalidation rebuilds the query blueprint")
 	assert.NotContains(t, c.observations.nextQueryAt, group, "adding a query to an existing group makes the expanded group immediately due")
+}
+
+func filteredOverlapCollector(t *testing.T) *Collector {
+	t.Helper()
+	c := multiTargetCollector(t, map[string]stsClient{
+		"first":  &seqSTS{accounts: []string{"111111111111"}},
+		"second": &seqSTS{accounts: []string{"111111111111"}},
+	})
+	require.NoError(t, c.ensureTargets(context.Background()))
+	require.Len(t, c.plan.Scopes, 2)
+	c.plan.Scopes[0].ID = 0
+	c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
+	c.plan.Scopes[1].ID = 1
+	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+		{Target: "first", Profile: "ec2", Region: "us-east-1"}: {
+			{DimensionValues: []string{"i-1"}}, {DimensionValues: []string{"i-2"}},
+		},
+		{Target: "second", Profile: "ec2", Region: "us-east-1"}: {
+			{DimensionValues: []string{"i-1"}}, {DimensionValues: []string{"i-2"}},
+		},
+	}}
+	return c
+}
+
+func queryOwnersByInstance(plan []plannedQuery) map[string]string {
+	owners := make(map[string]string)
+	for _, query := range plan {
+		owners[labelValue(query.labels, "instance_id")] = query.target
+	}
+	return owners
+}
+
+func TestBuildQueryPlan_OrderedResourceTagFiltering(t *testing.T) {
+	t.Run("known non-match falls through to lower rule", func(t *testing.T) {
+		c := filteredOverlapCollector(t)
+		c.tags = tagSnapshot{
+			members: tagMembership{0: {"i-1": {}}},
+			unknown: map[int]struct{}{}, fetchedAt: time.Unix(1, 0),
+		}
+
+		plan := requireBuildQueryPlan(t, c)
+		assert.Equal(t, map[string]string{"i-1": "first", "i-2": "second"}, queryOwnersByInstance(plan))
+	})
+
+	t.Run("first failure reserves every candidate from lower rules", func(t *testing.T) {
+		c := filteredOverlapCollector(t)
+		c.tags = tagSnapshot{members: tagMembership{}, unknown: map[int]struct{}{0: {}}}
+
+		assert.Empty(t, requireBuildQueryPlan(t, c))
+	})
+
+	t.Run("later failure queries last-known members and reserves the rest", func(t *testing.T) {
+		c := filteredOverlapCollector(t)
+		c.tags = tagSnapshot{
+			members: tagMembership{0: {"i-1": {}}},
+			unknown: map[int]struct{}{0: {}},
+		}
+
+		plan := requireBuildQueryPlan(t, c)
+		assert.Equal(t, map[string]string{"i-1": "first"}, queryOwnersByInstance(plan))
+	})
+}
+
+func TestBuildQueryPlan_MaxInstances(t *testing.T) {
+	t.Run("counts final instances before metric expansion", func(t *testing.T) {
+		c := ec2QueryCollector([]string{"us-east-1"}, map[string][][]string{"us-east-1": {{"i-1"}, {"i-2"}}})
+		c.Limits.MaxInstances = 1
+		plan, err := c.buildQueryPlan()
+		assert.Nil(t, plan)
+		assert.ErrorContains(t, err, "limits.max_instances=1")
+	})
+
+	t.Run("overlapping copies count once", func(t *testing.T) {
+		c := filteredOverlapCollector(t)
+		c.plan.Scopes[0].TagFilter = nil
+		c.discovery.Instances[discoveryKey{Target: "first", Profile: "ec2", Region: "us-east-1"}] = []discoveredInstance{{DimensionValues: []string{"i-1"}}}
+		c.discovery.Instances[discoveryKey{Target: "second", Profile: "ec2", Region: "us-east-1"}] = []discoveredInstance{{DimensionValues: []string{"i-1"}}}
+		c.Limits.MaxInstances = 1
+		assert.NotEmpty(t, requireBuildQueryPlan(t, c))
+	})
+}
+
+func TestCurrentQueryPlan_OverflowRetainsLastValidPlan(t *testing.T) {
+	c := ec2QueryCollector([]string{"us-east-1"}, map[string][][]string{"us-east-1": {{"i-1"}}})
+	c.Limits.MaxInstances = 1
+	previous := requireCurrentQueryPlan(t, c)
+	require.NotEmpty(t, previous)
+
+	c.discovery.Instances[discoveryKey{Target: "base", Profile: "ec2", Region: "us-east-1"}] = append(
+		c.discovery.Instances[discoveryKey{Target: "base", Profile: "ec2", Region: "us-east-1"}],
+		discoveredInstance{DimensionValues: []string{"i-2"}},
+	)
+	c.invalidateQueryPlan()
+	plan, err := c.currentQueryPlan()
+	assert.Nil(t, plan)
+	assert.ErrorContains(t, err, "limits.max_instances=1")
+	assert.Equal(t, previous, c.queryPlan, "a rejected refresh does not replace the last valid plan")
+	assert.True(t, c.planDirty, "the next collect retries the rejected refresh")
 }
 
 func BenchmarkCurrentQueryPlanCached(b *testing.B) {
@@ -224,13 +337,50 @@ func BenchmarkCurrentQueryPlanCached(b *testing.B) {
 		instances[i] = []string{fmt.Sprintf("i-%d", i)}
 	}
 	c := ec2QueryCollector([]string{"us-east-1"}, map[string][][]string{"us-east-1": instances})
-	require.NotEmpty(b, c.currentQueryPlan())
+	require.NotEmpty(b, requireCurrentQueryPlan(b, c))
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		if len(c.currentQueryPlan()) == 0 {
+		plan, err := c.currentQueryPlan()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(plan) == 0 {
 			b.Fatal("cached plan unexpectedly empty")
+		}
+	}
+}
+
+func BenchmarkBuildQueryPlan(b *testing.B) {
+	for _, instances := range []int{100, 1000, 10000} {
+		for _, selectedPercent := range []int{100, 10} {
+			b.Run(fmt.Sprintf("instances_%d/selected_%d_percent", instances, selectedPercent), func(b *testing.B) {
+				values := make([][]string, instances)
+				for i := range values {
+					values[i] = []string{fmt.Sprintf("i-%d", i)}
+				}
+				c := ec2QueryCollector([]string{"us-east-1"}, map[string][][]string{"us-east-1": values})
+				c.Limits.MaxInstances = instances + 1
+				if selectedPercent < 100 {
+					c.plan.Scopes[0].ID = 0
+					c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
+					c.tags = tagSnapshot{members: make(tagMembership), unknown: map[int]struct{}{}, fetchedAt: time.Unix(1, 0)}
+					for i := 0; i < instances; i += 100 / selectedPercent {
+						c.tags.members.add(0, fmt.Sprintf("i-%d", i))
+					}
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					plan, err := c.buildQueryPlan()
+					if err != nil {
+						b.Fatal(err)
+					}
+					goruntime.KeepAlive(plan)
+				}
+			})
 		}
 	}
 }
@@ -301,7 +451,7 @@ func TestExecuteQueries(t *testing.T) {
 			c := ec2QueryCollector([]string{"us-east-1"}, tc.instances)
 			useFakeClient(c, tc.fake)
 
-			samples, _, _, err := c.executeQueries(context.Background(), c.buildQueryPlan(), time.Unix(1_000_000_000, 0))
+			samples, _, _, err := c.executeQueries(context.Background(), requireBuildQueryPlan(t, c), time.Unix(1_000_000_000, 0))
 			if tc.wantErr {
 				assert.Error(t, err)
 				return
@@ -451,7 +601,7 @@ func (f *pagingGMD) GetMetricData(_ context.Context, in *cloudwatch.GetMetricDat
 
 func TestExecuteQueries_PaginationAndDedup(t *testing.T) {
 	c := ec2QueryCollector([]string{"us-east-1"}, map[string][][]string{"us-east-1": {{"i-1"}}})
-	plan := c.buildQueryPlan()
+	plan := requireBuildQueryPlan(t, c)
 	require.Len(t, plan, 3) // cpu_utilization_average, duration_average, duration_p90
 
 	fake := &pagingGMD{
@@ -524,7 +674,7 @@ func TestExecuteQueries_RegionClientFailures(t *testing.T) {
 			}
 			c.newCloudWatchClient = func(aws.Config) cloudwatchClient { return fake }
 
-			samples, _, _, err := c.executeQueries(context.Background(), c.buildQueryPlan(), time.Unix(1_000_000_000, 0))
+			samples, _, _, err := c.executeQueries(context.Background(), requireBuildQueryPlan(t, c), time.Unix(1_000_000_000, 0))
 			if tc.wantErr {
 				assert.Error(t, err)
 				return

--- a/src/go/plugin/go.d/collector/cloudwatch/query_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/query_test.go
@@ -243,10 +243,8 @@ func filteredOverlapCollector(t *testing.T) *Collector {
 	require.Len(t, c.plan.Scopes, 2)
 	join, err := resolveTagJoinProfile(c.plan.Scopes[0].Profile)
 	require.NoError(t, err)
-	c.plan.Scopes[0].ID = 0
+	c.plan.TagJoins["ec2"] = join
 	c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
-	c.plan.Scopes[0].TagJoin = join
-	c.plan.Scopes[1].ID = 1
 	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
 		{Target: "first", Profile: "ec2", Region: "us-east-1"}: {
 			{DimensionValues: []string{"i-1"}}, {DimensionValues: []string{"i-2"}},
@@ -366,7 +364,6 @@ func BenchmarkBuildQueryPlan(b *testing.B) {
 				c := ec2QueryCollector([]string{"us-east-1"}, map[string][][]string{"us-east-1": values})
 				c.Limits.MaxInstances = instances + 1
 				if selectedPercent < 100 {
-					c.plan.Scopes[0].ID = 0
 					c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
 					c.tags = tagSnapshot{members: make(tagMembership), unknown: map[int]struct{}{}, fetchedAt: time.Unix(1, 0)}
 					for i := 0; i < instances; i += 100 / selectedPercent {

--- a/src/go/plugin/go.d/collector/cloudwatch/query_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/query_test.go
@@ -241,8 +241,11 @@ func filteredOverlapCollector(t *testing.T) *Collector {
 	})
 	require.NoError(t, c.ensureTargets(context.Background()))
 	require.Len(t, c.plan.Scopes, 2)
+	join, err := resolveTagJoinProfile(c.plan.Scopes[0].Profile)
+	require.NoError(t, err)
 	c.plan.Scopes[0].ID = 0
 	c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
+	c.plan.Scopes[0].TagJoin = join
 	c.plan.Scopes[1].ID = 1
 	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
 		{Target: "first", Profile: "ec2", Region: "us-east-1"}: {

--- a/src/go/plugin/go.d/collector/cloudwatch/runtime.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/runtime.go
@@ -22,10 +22,15 @@ type collectionTarget struct {
 }
 
 type collectionScope struct {
-	Target  *collectionTarget
-	Profile cwprofiles.ResolvedProfile
-	Region  string
+	ID        int
+	Rule      string
+	Target    *collectionTarget
+	Profile   cwprofiles.ResolvedProfile
+	Region    string
+	TagFilter []resourceTagFilter
 }
+
+func (s collectionScope) hasTagFilter() bool { return len(s.TagFilter) > 0 }
 
 func (c *Collector) ensurePlan() error {
 	if c.plan != nil {

--- a/src/go/plugin/go.d/collector/cloudwatch/runtime.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/runtime.go
@@ -13,6 +13,7 @@ type collectionPlan struct {
 	Targets  []*collectionTarget
 	Scopes   []collectionScope
 	Profiles []cwprofiles.ResolvedProfile
+	TagJoins map[string]*tagJoin
 }
 
 type collectionTarget struct {
@@ -28,6 +29,7 @@ type collectionScope struct {
 	Profile   cwprofiles.ResolvedProfile
 	Region    string
 	TagFilter []resourceTagFilter
+	TagJoin   *tagJoin
 }
 
 func (s collectionScope) hasTagFilter() bool { return len(s.TagFilter) > 0 }

--- a/src/go/plugin/go.d/collector/cloudwatch/runtime.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/runtime.go
@@ -23,13 +23,10 @@ type collectionTarget struct {
 }
 
 type collectionScope struct {
-	ID        int
-	Rule      string
 	Target    *collectionTarget
 	Profile   cwprofiles.ResolvedProfile
 	Region    string
 	TagFilter []resourceTagFilter
-	TagJoin   *tagJoin
 }
 
 func (s collectionScope) hasTagFilter() bool { return len(s.TagFilter) > 0 }

--- a/src/go/plugin/go.d/collector/cloudwatch/signature.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/signature.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"strconv"
+	"strings"
+)
+
+// writeLengthPrefixed appends one collision-safe string component to a signature.
+func writeLengthPrefixed(b *strings.Builder, value string) {
+	b.WriteString(strconv.Itoa(len(value)))
+	b.WriteByte(':')
+	b.WriteString(value)
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/tag_fetch.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tag_fetch.go
@@ -21,6 +21,16 @@ type tagFetchKey struct {
 	target, region, filter string
 }
 
+func lessTagFetchKey(a, b tagFetchKey) bool {
+	if a.target != b.target {
+		return a.target < b.target
+	}
+	if a.region != b.region {
+		return a.region < b.region
+	}
+	return a.filter < b.filter
+}
+
 // tagFetchGroup is one deduplicated RGTA request stream. Policy scopes sharing
 // target, region, and exact predicate share the fetch while retaining separate
 // ordered membership identities.
@@ -29,13 +39,12 @@ type tagFetchGroup struct {
 	account string
 	filters []resourceTagFilter
 
-	profiles               map[string]struct{}
+	joins                  map[string]*tagJoin
 	profilesByResourceType map[string][]string
 	scopeIDsByProfile      map[string][]int
 	candidatesByProfile    map[string]map[string]struct{}
 	tagKeys                map[string]struct{}
 	resourceTypes          []string
-	hasLabels              bool
 }
 
 type tagFetchResult struct {
@@ -53,8 +62,8 @@ func (c *Collector) tagFetchGroups() []tagFetchGroup {
 		if !ok {
 			return
 		}
-		join, ok := tagJoins[scope.Profile.Name]
-		if !ok {
+		join := scope.TagJoin
+		if join == nil {
 			return
 		}
 		instances := c.discovery.Instances[discoveryKey{Target: scope.Target.Name, Profile: scope.Profile.Name, Region: scope.Region}]
@@ -68,7 +77,7 @@ func (c *Collector) tagFetchGroups() []tagFetchGroup {
 		if group == nil {
 			group = &tagFetchGroup{
 				key: key, account: resolved.accountID, filters: filters,
-				profiles:               make(map[string]struct{}),
+				joins:                  make(map[string]*tagJoin),
 				profilesByResourceType: make(map[string][]string),
 				scopeIDsByProfile:      make(map[string][]int),
 				candidatesByProfile:    make(map[string]map[string]struct{}),
@@ -79,8 +88,8 @@ func (c *Collector) tagFetchGroups() []tagFetchGroup {
 			}
 			groups[key] = group
 		}
-		if _, exists := group.profiles[scope.Profile.Name]; !exists {
-			group.profiles[scope.Profile.Name] = struct{}{}
+		if _, exists := group.joins[scope.Profile.Name]; !exists {
+			group.joins[scope.Profile.Name] = join
 			for _, resourceType := range join.resourceTypes {
 				group.profilesByResourceType[resourceType] = append(group.profilesByResourceType[resourceType], scope.Profile.Name)
 				if !slices.Contains(group.resourceTypes, resourceType) {
@@ -89,7 +98,6 @@ func (c *Collector) tagFetchGroups() []tagFetchGroup {
 			}
 			for _, label := range c.tagLabelPlans[scope.Profile.Name] {
 				group.tagKeys[label.awsKey] = struct{}{}
-				group.hasLabels = true
 			}
 		}
 		if includeMembership && !slices.Contains(group.scopeIDsByProfile[scope.Profile.Name], scope.ID) {
@@ -126,14 +134,7 @@ func (c *Collector) tagFetchGroups() []tagFetchGroup {
 		out = append(out, *group)
 	}
 	sort.Slice(out, func(i, j int) bool {
-		a, b := out[i].key, out[j].key
-		if a.target != b.target {
-			return a.target < b.target
-		}
-		if a.region != b.region {
-			return a.region < b.region
-		}
-		return a.filter < b.filter
+		return lessTagFetchKey(out[i].key, out[j].key)
 	})
 	return out
 }
@@ -219,7 +220,10 @@ func indexFetchedResource(
 		return
 	}
 	for _, profileName := range profileNames {
-		join := tagJoins[profileName]
+		join := group.joins[profileName]
+		if join == nil {
+			continue
+		}
 		joinKey, ok := join.arnJoinKey(parsed)
 		if !ok {
 			continue

--- a/src/go/plugin/go.d/collector/cloudwatch/tag_fetch.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tag_fetch.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgtatypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+)
+
+type tagFetchKey struct {
+	target, region, filter string
+}
+
+// tagFetchGroup is one deduplicated RGTA request stream. Policy scopes sharing
+// target, region, and exact predicate share the fetch while retaining separate
+// ordered membership identities.
+type tagFetchGroup struct {
+	key     tagFetchKey
+	account string
+	filters []resourceTagFilter
+
+	profiles               map[string]struct{}
+	profilesByResourceType map[string][]string
+	scopeIDsByProfile      map[string][]int
+	candidatesByProfile    map[string]map[string]struct{}
+	tagKeys                map[string]struct{}
+	resourceTypes          []string
+	hasLabels              bool
+}
+
+type tagFetchResult struct {
+	group           tagFetchGroup
+	members         tagMembership
+	labels          map[tagCacheKey][]metrix.Label
+	confirmedLabels map[tagCacheKey]struct{}
+	err             error
+}
+
+func (c *Collector) tagFetchGroups() []tagFetchGroup {
+	groups := make(map[tagFetchKey]*tagFetchGroup)
+	addScope := func(scope collectionScope, filters []resourceTagFilter, includeMembership bool) {
+		resolved, ok := c.resolvedTargetByRef(scope.Target.Name)
+		if !ok {
+			return
+		}
+		join, ok := tagJoins[scope.Profile.Name]
+		if !ok {
+			return
+		}
+		instances := c.discovery.Instances[discoveryKey{Target: scope.Target.Name, Profile: scope.Profile.Name, Region: scope.Region}]
+		if len(instances) == 0 {
+			return
+		}
+
+		filterKey := resourceTagFilterSignature(filters)
+		key := tagFetchKey{target: scope.Target.Name, region: scope.Region, filter: filterKey}
+		group := groups[key]
+		if group == nil {
+			group = &tagFetchGroup{
+				key: key, account: resolved.accountID, filters: filters,
+				profiles:               make(map[string]struct{}),
+				profilesByResourceType: make(map[string][]string),
+				scopeIDsByProfile:      make(map[string][]int),
+				candidatesByProfile:    make(map[string]map[string]struct{}),
+				tagKeys:                make(map[string]struct{}),
+			}
+			for _, filter := range filters {
+				group.tagKeys[filter.key] = struct{}{}
+			}
+			groups[key] = group
+		}
+		if _, exists := group.profiles[scope.Profile.Name]; !exists {
+			group.profiles[scope.Profile.Name] = struct{}{}
+			for _, resourceType := range join.resourceTypes {
+				group.profilesByResourceType[resourceType] = append(group.profilesByResourceType[resourceType], scope.Profile.Name)
+				if !slices.Contains(group.resourceTypes, resourceType) {
+					group.resourceTypes = append(group.resourceTypes, resourceType)
+				}
+			}
+			for _, label := range c.tagLabelPlans[scope.Profile.Name] {
+				group.tagKeys[label.awsKey] = struct{}{}
+				group.hasLabels = true
+			}
+		}
+		if includeMembership && !slices.Contains(group.scopeIDsByProfile[scope.Profile.Name], scope.ID) {
+			group.scopeIDsByProfile[scope.Profile.Name] = append(group.scopeIDsByProfile[scope.Profile.Name], scope.ID)
+		}
+		candidates := group.candidatesByProfile[scope.Profile.Name]
+		if candidates == nil {
+			candidates = make(map[string]struct{}, len(instances))
+			group.candidatesByProfile[scope.Profile.Name] = candidates
+		}
+		dimNames := scope.Profile.Config.DimensionNames()
+		for _, instance := range instances {
+			if joinKey, ok := join.instanceJoinKey(dimNames, instance.DimensionValues); ok {
+				candidates[joinKey] = struct{}{}
+			}
+		}
+	}
+
+	for _, scope := range c.plan.Scopes {
+		if scope.hasTagFilter() {
+			addScope(scope, scope.TagFilter, true)
+		}
+		if len(c.tagLabelPlans[scope.Profile.Name]) > 0 && !scope.hasTagFilter() {
+			addScope(scope, nil, false)
+		}
+	}
+
+	out := make([]tagFetchGroup, 0, len(groups))
+	for _, group := range groups {
+		sort.Strings(group.resourceTypes)
+		for resourceType := range group.profilesByResourceType {
+			sort.Strings(group.profilesByResourceType[resourceType])
+		}
+		out = append(out, *group)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i].key, out[j].key
+		if a.target != b.target {
+			return a.target < b.target
+		}
+		if a.region != b.region {
+			return a.region < b.region
+		}
+		return a.filter < b.filter
+	})
+	return out
+}
+
+func (c *Collector) fetchTagGroup(ctx context.Context, group tagFetchGroup) tagFetchResult {
+	result := tagFetchResult{
+		group:           group,
+		members:         make(tagMembership),
+		labels:          make(map[tagCacheKey][]metrix.Label),
+		confirmedLabels: make(map[tagCacheKey]struct{}),
+	}
+	client, err := c.rgtaClients.forTargetRegion(ctx, group.key.target, group.key.region)
+	if err != nil {
+		result.err = fmt.Errorf("build client: %w", err)
+		return result
+	}
+	result.err = walkResourceTags(ctx, client, group.resourceTypes, group.filters, c.Timeout.Duration(), func(resource rgtatypes.ResourceTagMapping) {
+		indexFetchedResource(result.members, result.labels, result.confirmedLabels, group, resource, c.tagLabelPlans)
+	})
+	return result
+}
+
+func walkResourceTags(ctx context.Context, client rgtaClient, resourceTypes []string, filters []resourceTagFilter, timeout time.Duration, fn func(rgtatypes.ResourceTagMapping)) error {
+	cctx, cancel := withTimeout(ctx, timeout)
+	defer cancel()
+
+	tagFilters := make([]rgtatypes.TagFilter, len(filters))
+	for i, filter := range filters {
+		tagFilters[i] = rgtatypes.TagFilter{Key: aws.String(filter.key), Values: slices.Clone(filter.values)}
+	}
+	seenTokens := make(map[string]struct{})
+	var token *string
+	for {
+		input := &resourcegroupstaggingapi.GetResourcesInput{
+			PaginationToken:     token,
+			ResourcesPerPage:    aws.Int32(100),
+			ResourceTypeFilters: resourceTypes,
+			TagFilters:          tagFilters,
+		}
+		response, err := client.GetResources(cctx, input)
+		if err != nil {
+			return err
+		}
+		for _, resource := range response.ResourceTagMappingList {
+			fn(resource)
+		}
+		if response.PaginationToken == nil || *response.PaginationToken == "" {
+			return nil
+		}
+		if _, duplicate := seenTokens[*response.PaginationToken]; duplicate {
+			return fmt.Errorf("GetResources returned duplicate pagination token")
+		}
+		seenTokens[*response.PaginationToken] = struct{}{}
+		token = response.PaginationToken
+	}
+}
+
+func indexFetchedResource(
+	members tagMembership,
+	labels map[tagCacheKey][]metrix.Label,
+	confirmedLabels map[tagCacheKey]struct{},
+	group tagFetchGroup,
+	resource rgtatypes.ResourceTagMapping,
+	labelPlans map[string][]resolvedTag,
+) {
+	if resource.ResourceARN == nil {
+		return
+	}
+	parsed, err := arn.Parse(*resource.ResourceARN)
+	if err != nil {
+		return
+	}
+	if (parsed.AccountID != "" && parsed.AccountID != group.account) ||
+		(parsed.Region != "" && parsed.Region != group.key.region) {
+		return
+	}
+	profileNames := group.profilesByResourceType[deriveResourceType(parsed)]
+	if len(profileNames) == 0 {
+		return
+	}
+	tags := selectedTagMap(resource.Tags, group.tagKeys)
+	if !resourceMatchesFilters(tags, group.filters) {
+		return
+	}
+	for _, profileName := range profileNames {
+		join := tagJoins[profileName]
+		joinKey, ok := join.arnJoinKey(parsed)
+		if !ok {
+			continue
+		}
+		if _, candidate := group.candidatesByProfile[profileName][joinKey]; !candidate {
+			continue
+		}
+		for _, scopeID := range group.scopeIDsByProfile[profileName] {
+			members.add(scopeID, joinKey)
+		}
+		plan := labelPlans[profileName]
+		if len(plan) == 0 {
+			continue
+		}
+		labelKey := tagCacheKey{
+			target: group.key.target, account: group.account, region: group.key.region,
+			profile: profileName, joinKey: joinKey,
+		}
+		confirmedLabels[labelKey] = struct{}{}
+		if resolved := applyTagPlan(plan, tags); len(resolved) > 0 {
+			labels[labelKey] = resolved
+		}
+	}
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/tag_fetch.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tag_fetch.go
@@ -55,18 +55,31 @@ type tagFetchResult struct {
 	err             error
 }
 
-func (c *Collector) tagFetchGroups() []tagFetchGroup {
+func (c *Collector) currentTagFetchPlan() []tagFetchGroup {
+	if c.tagFetchPlan == nil {
+		c.tagFetchPlan = c.buildTagFetchPlan()
+	}
+	return c.tagFetchPlan
+}
+
+func (c *Collector) invalidateTagFetchPlan() {
+	c.tagFetchPlan = nil
+}
+
+func (c *Collector) buildTagFetchPlan() []tagFetchGroup {
 	groups := make(map[tagFetchKey]*tagFetchGroup)
-	addScope := func(scope collectionScope, filters []resourceTagFilter, includeMembership bool) {
+	candidateIndexes := make(map[discoveryKey]map[string]struct{})
+	addScope := func(scopeID int, scope collectionScope, filters []resourceTagFilter, includeMembership bool) {
 		resolved, ok := c.resolvedTargetByRef(scope.Target.Name)
 		if !ok {
 			return
 		}
-		join := scope.TagJoin
+		join := c.plan.TagJoins[scope.Profile.Name]
 		if join == nil {
 			return
 		}
-		instances := c.discovery.Instances[discoveryKey{Target: scope.Target.Name, Profile: scope.Profile.Name, Region: scope.Region}]
+		candidateKey := discoveryKey{Target: scope.Target.Name, Profile: scope.Profile.Name, Region: scope.Region}
+		instances := c.discovery.Instances[candidateKey]
 		if len(instances) == 0 {
 			return
 		}
@@ -100,28 +113,29 @@ func (c *Collector) tagFetchGroups() []tagFetchGroup {
 				group.tagKeys[label.awsKey] = struct{}{}
 			}
 		}
-		if includeMembership && !slices.Contains(group.scopeIDsByProfile[scope.Profile.Name], scope.ID) {
-			group.scopeIDsByProfile[scope.Profile.Name] = append(group.scopeIDsByProfile[scope.Profile.Name], scope.ID)
+		if includeMembership && !slices.Contains(group.scopeIDsByProfile[scope.Profile.Name], scopeID) {
+			group.scopeIDsByProfile[scope.Profile.Name] = append(group.scopeIDsByProfile[scope.Profile.Name], scopeID)
 		}
-		candidates := group.candidatesByProfile[scope.Profile.Name]
-		if candidates == nil {
+		candidates, indexed := candidateIndexes[candidateKey]
+		if !indexed {
 			candidates = make(map[string]struct{}, len(instances))
-			group.candidatesByProfile[scope.Profile.Name] = candidates
-		}
-		dimNames := scope.Profile.Config.DimensionNames()
-		for _, instance := range instances {
-			if joinKey, ok := join.instanceJoinKey(dimNames, instance.DimensionValues); ok {
-				candidates[joinKey] = struct{}{}
+			dimNames := scope.Profile.Config.DimensionNames()
+			for _, instance := range instances {
+				if joinKey, ok := join.instanceJoinKey(dimNames, instance.DimensionValues); ok {
+					candidates[joinKey] = struct{}{}
+				}
 			}
+			candidateIndexes[candidateKey] = candidates
 		}
+		group.candidatesByProfile[scope.Profile.Name] = candidates
 	}
 
-	for _, scope := range c.plan.Scopes {
+	for scopeID, scope := range c.plan.Scopes {
 		if scope.hasTagFilter() {
-			addScope(scope, scope.TagFilter, true)
+			addScope(scopeID, scope, scope.TagFilter, true)
 		}
 		if len(c.tagLabelPlans[scope.Profile.Name]) > 0 && !scope.hasTagFilter() {
-			addScope(scope, nil, false)
+			addScope(scopeID, scope, nil, false)
 		}
 	}
 

--- a/src/go/plugin/go.d/collector/cloudwatch/tagfilter.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagfilter.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// resourceTagFilter is the canonical compiled form of one exact AWS tag
+// predicate. Filters are sorted by key and their values are sorted so equivalent
+// user configurations share one stable fetch signature.
+type resourceTagFilter struct {
+	key    string
+	values []string
+}
+
+func compileResourceTagFilters(config []ResourceTagFilterConfig) []resourceTagFilter {
+	filters := make([]resourceTagFilter, len(config))
+	for i, filter := range config {
+		filters[i] = resourceTagFilter{key: filter.Key, values: slices.Clone(filter.Values)}
+		slices.Sort(filters[i].values)
+	}
+	slices.SortFunc(filters, func(a, b resourceTagFilter) int { return strings.Compare(a.key, b.key) })
+	return filters
+}
+
+func resourceTagFilterSignature(filters []resourceTagFilter) string {
+	var b strings.Builder
+	for _, filter := range filters {
+		writeSignaturePart(&b, filter.key)
+		b.WriteByte(':')
+		for _, value := range filter.values {
+			writeSignaturePart(&b, value)
+		}
+		b.WriteByte(';')
+	}
+	return b.String()
+}
+
+func writeSignaturePart(b *strings.Builder, value string) {
+	b.WriteString(strconv.Itoa(len(value)))
+	b.WriteByte(':')
+	b.WriteString(value)
+}
+
+func resourceMatchesFilters(tags map[string]string, filters []resourceTagFilter) bool {
+	for _, filter := range filters {
+		value, ok := tags[filter.key]
+		if !ok || !slices.Contains(filter.values, value) {
+			return false
+		}
+	}
+	return true
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/tagfilter.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagfilter.go
@@ -4,7 +4,6 @@ package cloudwatch
 
 import (
 	"slices"
-	"strconv"
 	"strings"
 )
 
@@ -29,20 +28,14 @@ func compileResourceTagFilters(config []ResourceTagFilterConfig) []resourceTagFi
 func resourceTagFilterSignature(filters []resourceTagFilter) string {
 	var b strings.Builder
 	for _, filter := range filters {
-		writeSignaturePart(&b, filter.key)
+		writeLengthPrefixed(&b, filter.key)
 		b.WriteByte(':')
 		for _, value := range filter.values {
-			writeSignaturePart(&b, value)
+			writeLengthPrefixed(&b, value)
 		}
 		b.WriteByte(';')
 	}
 	return b.String()
-}
-
-func writeSignaturePart(b *strings.Builder, value string) {
-	b.WriteString(strconv.Itoa(len(value)))
-	b.WriteByte(':')
-	b.WriteString(value)
 }
 
 func resourceMatchesFilters(tags map[string]string, filters []resourceTagFilter) bool {

--- a/src/go/plugin/go.d/collector/cloudwatch/tagfilter_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagfilter_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cloudwatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceMatchesFilters_ExactANDOR(t *testing.T) {
+	filters := compileResourceTagFilters([]ResourceTagFilterConfig{
+		{Key: "team", Values: []string{"sre", "platform"}},
+		{Key: "environment", Values: []string{"production"}},
+	})
+
+	assert.True(t, resourceMatchesFilters(map[string]string{"team": "sre", "environment": "production"}, filters))
+	assert.True(t, resourceMatchesFilters(map[string]string{"team": "platform", "environment": "production"}, filters))
+	assert.False(t, resourceMatchesFilters(map[string]string{"team": "SRE", "environment": "production"}, filters), "values are case-sensitive")
+	assert.False(t, resourceMatchesFilters(map[string]string{"team": "sre"}, filters), "every key is required")
+	assert.False(t, resourceMatchesFilters(map[string]string{"team": "sre", "environment": "production-east"}, filters), "values are exact")
+}
+
+func TestResourceTagFilterSignature_CanonicalAndCollisionSafe(t *testing.T) {
+	first := compileResourceTagFilters([]ResourceTagFilterConfig{
+		{Key: "team", Values: []string{"sre", "platform"}},
+		{Key: "environment", Values: []string{"production"}},
+	})
+	second := compileResourceTagFilters([]ResourceTagFilterConfig{
+		{Key: "environment", Values: []string{"production"}},
+		{Key: "team", Values: []string{"platform", "sre"}},
+	})
+
+	assert.Equal(t, resourceTagFilterSignature(first), resourceTagFilterSignature(second))
+	assert.NotEqual(t,
+		resourceTagFilterSignature([]resourceTagFilter{{key: "a", values: []string{"bc"}}}),
+		resourceTagFilterSignature([]resourceTagFilter{{key: "ab", values: []string{"c"}}}),
+	)
+}

--- a/src/go/plugin/go.d/collector/cloudwatch/tagjoin.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagjoin.go
@@ -32,68 +32,83 @@ import (
 // collide with another discovered instance, so associations are internal, reviewed,
 // and covered by ARN-shape tests rather than inferred from arbitrary profiles.
 type tagJoin struct {
+	namespace     string
 	resourceTypes []string
 	joinDims      []string
 	arnValues     func(a arn.ARN) ([]string, bool)
 }
 
-// tagJoins is the per-profile (by basename) join registry. Only profiles listed
-// here can use generic resource-tag filtering and labels. Labels-only use skips
-// an unregistered profile; an effective filter applies the compiler's explicit
-// skip/error policy instead of collecting that profile unfiltered.
+// tagJoins is the registry of association definitions by stock profile basename.
+// The compiler binds a definition only when the effective profile still has its
+// expected namespace and identifying dimensions; runtime code receives that
+// validated capability and never infers safety from the basename alone.
 var tagJoins = map[string]tagJoin{
-	// Sound single-dimension joins: default extractor (resource-id = last segment).
-	"ec2":         {resourceTypes: []string{"ec2:instance"}, joinDims: []string{"InstanceId"}},
-	"ebs":         {resourceTypes: []string{"ec2:volume"}, joinDims: []string{"VolumeId"}},
-	"efs":         {resourceTypes: []string{"elasticfilesystem:file-system"}, joinDims: []string{"FileSystemId"}},
-	"nat_gateway": {resourceTypes: []string{"ec2:natgateway"}, joinDims: []string{"NatGatewayId"}},
-	"vpn":         {resourceTypes: []string{"ec2:vpn-connection"}, joinDims: []string{"VpnId"}},
+	// Sound single-dimension joins using the default resource-id extractor.
+	"ec2":         {namespace: "AWS/EC2", resourceTypes: []string{"ec2:instance"}, joinDims: []string{"InstanceId"}},
+	"ebs":         {namespace: "AWS/EBS", resourceTypes: []string{"ec2:volume"}, joinDims: []string{"VolumeId"}},
+	"efs":         {namespace: "AWS/EFS", resourceTypes: []string{"elasticfilesystem:file-system"}, joinDims: []string{"FileSystemId"}},
+	"nat_gateway": {namespace: "AWS/NATGateway", resourceTypes: []string{"ec2:natgateway"}, joinDims: []string{"NatGatewayId"}},
+	"vpn":         {namespace: "AWS/VPN", resourceTypes: []string{"ec2:vpn-connection"}, joinDims: []string{"VpnId"}},
 	// rds and docdb share the rds:db ARN type. The join is unambiguous because a
 	// DBInstanceIdentifier is unique per account+region across the rds:db family
 	// (RDS/DocDB/Neptune), so an ARN matches at most one discovered instance and
 	// cross-family entries are inert. (Confirmed in live smoke.)
-	"rds":      {resourceTypes: []string{"rds:db"}, joinDims: []string{"DBInstanceIdentifier"}},
-	"docdb":    {resourceTypes: []string{"rds:db"}, joinDims: []string{"DBInstanceIdentifier"}},
-	"lambda":   {resourceTypes: []string{"lambda:function"}, joinDims: []string{"FunctionName"}},
-	"sqs":      {resourceTypes: []string{"sqs"}, joinDims: []string{"QueueName"}},
-	"sns":      {resourceTypes: []string{"sns"}, joinDims: []string{"TopicName"}},
-	"eks":      {resourceTypes: []string{"eks:cluster"}, joinDims: []string{"ClusterName"}},
-	"kinesis":  {resourceTypes: []string{"kinesis:stream"}, joinDims: []string{"StreamName"}},
-	"firehose": {resourceTypes: []string{"firehose:deliverystream"}, joinDims: []string{"DeliveryStreamName"}},
-	"redshift": {resourceTypes: []string{"redshift:cluster"}, joinDims: []string{"ClusterIdentifier"}},
-	"dynamodb": {resourceTypes: []string{"dynamodb:table"}, joinDims: []string{"TableName"}},
+	"rds":      {namespace: "AWS/RDS", resourceTypes: []string{"rds:db"}, joinDims: []string{"DBInstanceIdentifier"}},
+	"docdb":    {namespace: "AWS/DocDB", resourceTypes: []string{"rds:db"}, joinDims: []string{"DBInstanceIdentifier"}},
+	"lambda":   {namespace: "AWS/Lambda", resourceTypes: []string{"lambda:function"}, joinDims: []string{"FunctionName"}},
+	"sqs":      {namespace: "AWS/SQS", resourceTypes: []string{"sqs"}, joinDims: []string{"QueueName"}},
+	"sns":      {namespace: "AWS/SNS", resourceTypes: []string{"sns"}, joinDims: []string{"TopicName"}},
+	"eks":      {namespace: "AWS/EKS", resourceTypes: []string{"eks:cluster"}, joinDims: []string{"ClusterName"}},
+	"kinesis":  {namespace: "AWS/Kinesis", resourceTypes: []string{"kinesis:stream"}, joinDims: []string{"StreamName"}},
+	"firehose": {namespace: "AWS/Firehose", resourceTypes: []string{"firehose:deliverystream"}, joinDims: []string{"DeliveryStreamName"}},
+	"redshift": {namespace: "AWS/Redshift", resourceTypes: []string{"redshift:cluster"}, joinDims: []string{"ClusterIdentifier"}},
+	"dynamodb": {namespace: "AWS/DynamoDB", resourceTypes: []string{"dynamodb:table"}, joinDims: []string{"TableName"}},
 
 	// Parent-resource joins: joinDims is the parent dimension only, so children
 	// (across storage_type / filter_id / operation) inherit the parent's tags.
-	"s3":                 {resourceTypes: []string{"s3"}, joinDims: []string{"BucketName"}},
-	"s3_requests":        {resourceTypes: []string{"s3"}, joinDims: []string{"BucketName"}},
-	"dynamodb_operation": {resourceTypes: []string{"dynamodb:table"}, joinDims: []string{"TableName"}},
+	"s3":                 {namespace: "AWS/S3", resourceTypes: []string{"s3"}, joinDims: []string{"BucketName"}},
+	"s3_requests":        {namespace: "AWS/S3", resourceTypes: []string{"s3"}, joinDims: []string{"BucketName"}},
+	"dynamodb_operation": {namespace: "AWS/DynamoDB", resourceTypes: []string{"dynamodb:table"}, joinDims: []string{"TableName"}},
 
 	// Overrides: shared/quirky ARN shapes.
-	"elb":            {resourceTypes: []string{"elasticloadbalancing:loadbalancer"}, joinDims: []string{"LoadBalancerName"}, arnValues: elbClassicARNValues},
-	"alb":            {resourceTypes: []string{"elasticloadbalancing:loadbalancer"}, joinDims: []string{"LoadBalancer"}, arnValues: albARNValues},
-	"nlb":            {resourceTypes: []string{"elasticloadbalancing:loadbalancer"}, joinDims: []string{"LoadBalancer"}, arnValues: nlbARNValues},
-	"alb_target":     {resourceTypes: []string{"elasticloadbalancing:targetgroup"}, joinDims: []string{"TargetGroup"}, arnValues: albTargetARNValues},
-	"ecs":            {resourceTypes: []string{"ecs:service"}, joinDims: []string{"ClusterName", "ServiceName"}, arnValues: ecsARNValues},
-	"opensearch":     {resourceTypes: []string{"es:domain"}, joinDims: []string{"ClientId", "DomainName"}, arnValues: opensearchARNValues},
-	"step_functions": {resourceTypes: []string{"states:stateMachine"}, joinDims: []string{"StateMachineArn"}, arnValues: stepFunctionsARNValues},
+	"elb":            {namespace: "AWS/ELB", resourceTypes: []string{"elasticloadbalancing:loadbalancer"}, joinDims: []string{"LoadBalancerName"}, arnValues: elbClassicARNValues},
+	"alb":            {namespace: "AWS/ApplicationELB", resourceTypes: []string{"elasticloadbalancing:loadbalancer"}, joinDims: []string{"LoadBalancer"}, arnValues: albARNValues},
+	"nlb":            {namespace: "AWS/NetworkELB", resourceTypes: []string{"elasticloadbalancing:loadbalancer"}, joinDims: []string{"LoadBalancer"}, arnValues: nlbARNValues},
+	"alb_target":     {namespace: "AWS/ApplicationELB", resourceTypes: []string{"elasticloadbalancing:targetgroup"}, joinDims: []string{"TargetGroup"}, arnValues: albTargetARNValues},
+	"ecs":            {namespace: "AWS/ECS", resourceTypes: []string{"ecs:service"}, joinDims: []string{"ClusterName", "ServiceName"}, arnValues: ecsARNValues},
+	"opensearch":     {namespace: "AWS/ES", resourceTypes: []string{"es:domain"}, joinDims: []string{"ClientId", "DomainName"}, arnValues: opensearchARNValues},
+	"step_functions": {namespace: "AWS/States", resourceTypes: []string{"states:stateMachine"}, joinDims: []string{"StateMachineArn"}, arnValues: stepFunctionsARNValues},
 	// eventbridge is default-bus-only ({RuleName}); its override rejects custom-bus
 	// rule ARNs so a custom-bus rule cannot mis-tag a same-named default-bus rule.
-	"eventbridge": {resourceTypes: []string{"events:rule"}, joinDims: []string{"RuleName"}, arnValues: eventbridgeARNValues},
+	"eventbridge": {namespace: "AWS/Events", resourceTypes: []string{"events:rule"}, joinDims: []string{"RuleName"}, arnValues: eventbridgeARNValues},
 }
 
-func validateTagJoinProfile(profile cwprofiles.ResolvedProfile) error {
+func resolveTagJoinProfile(profile cwprofiles.ResolvedProfile) (*tagJoin, error) {
 	join, ok := tagJoins[profile.Name]
 	if !ok {
-		return fmt.Errorf("profile is not registered")
+		return nil, fmt.Errorf("profile is not registered")
 	}
-	dimensions := profile.Config.DimensionNames()
+	if profile.Config.Namespace != join.namespace {
+		return nil, fmt.Errorf("association requires namespace %q", join.namespace)
+	}
 	for _, name := range join.joinDims {
-		if indexOfString(dimensions, name) < 0 {
-			return fmt.Errorf("association requires dimension %q", name)
+		found := false
+		for _, dimension := range profile.Config.Instance.Dimensions {
+			if dimension.Name != name {
+				continue
+			}
+			found = true
+			if dimension.IsConstant() {
+				return nil, fmt.Errorf("association requires identifying dimension %q", name)
+			}
+			break
+		}
+		if !found {
+			return nil, fmt.Errorf("association requires dimension %q", name)
 		}
 	}
-	return nil
+	resolved := join
+	return &resolved, nil
 }
 
 // defaultARNValues extracts a single-segment resource id: the part after the FIRST

--- a/src/go/plugin/go.d/collector/cloudwatch/tagjoin.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagjoin.go
@@ -3,6 +3,7 @@
 package cloudwatch
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -22,13 +23,14 @@ import (
 //     parent-resource profile (e.g. S3 across storage_type) it is only the parent
 //     dimension, so every child instance inherits the parent's tags.
 //   - arnValues extracts the joinDims values from an ARN (nil => defaultARNValues,
-//     the resource-id after the last '/' or ':'). It returns ok=false when the ARN
+//     a single-segment resource id after the first '/' or ':'). It returns ok=false when the ARN
 //     is not this profile's flavour (e.g. a classic-ELB extractor rejects an ALB
 //     ARN), so a shared resource type can fan out to the right profile.
 //
-// Safety: a wrong extraction can only MISS (the arn-side key won't equal any
-// instance-side key, so that resource contributes no tags) — it can never mislabel,
-// because the instance side always uses the real discovered dimension values.
+// Safety requirement: every registered extractor must reject ambiguous ARN shapes
+// and project exactly the dimensions named by joinDims. A wrong projection could
+// collide with another discovered instance, so associations are internal, reviewed,
+// and covered by ARN-shape tests rather than inferred from arbitrary profiles.
 type tagJoin struct {
 	resourceTypes []string
 	joinDims      []string
@@ -36,9 +38,9 @@ type tagJoin struct {
 }
 
 // tagJoins is the per-profile (by basename) join registry. Only profiles listed
-// here are tag-enriched; a profile with no entry (risky/ambiguous joins like
-// cloudfront/api_gateway/msk/elasticache, or non-taggable auto_scaling/bedrock)
-// simply carries no tags — graceful under INV.2.
+// here can use generic resource-tag filtering and labels. Labels-only use skips
+// an unregistered profile; an effective filter applies the compiler's explicit
+// skip/error policy instead of collecting that profile unfiltered.
 var tagJoins = map[string]tagJoin{
 	// Sound single-dimension joins: default extractor (resource-id = last segment).
 	"ec2":         {resourceTypes: []string{"ec2:instance"}, joinDims: []string{"InstanceId"}},
@@ -78,6 +80,20 @@ var tagJoins = map[string]tagJoin{
 	// eventbridge is default-bus-only ({RuleName}); its override rejects custom-bus
 	// rule ARNs so a custom-bus rule cannot mis-tag a same-named default-bus rule.
 	"eventbridge": {resourceTypes: []string{"events:rule"}, joinDims: []string{"RuleName"}, arnValues: eventbridgeARNValues},
+}
+
+func validateTagJoinProfile(profile cwprofiles.ResolvedProfile) error {
+	join, ok := tagJoins[profile.Name]
+	if !ok {
+		return fmt.Errorf("profile is not registered")
+	}
+	dimensions := profile.Config.DimensionNames()
+	for _, name := range join.joinDims {
+		if indexOfString(dimensions, name) < 0 {
+			return fmt.Errorf("association requires dimension %q", name)
+		}
+	}
+	return nil
 }
 
 // defaultARNValues extracts a single-segment resource id: the part after the FIRST
@@ -209,6 +225,13 @@ func (tj tagJoin) arnJoinKey(a arn.ARN) (string, bool) {
 // instanceJoinKey computes this profile's join key from a discovered instance's
 // dimension values (ordered by dimNames = Profile.DimensionNames()).
 func (tj tagJoin) instanceJoinKey(dimNames, values []string) (string, bool) {
+	if len(tj.joinDims) == 1 {
+		idx := indexOfString(dimNames, tj.joinDims[0])
+		if idx < 0 || idx >= len(values) {
+			return "", false
+		}
+		return values[idx], true
+	}
 	parts := make([]string, len(tj.joinDims))
 	for i, jd := range tj.joinDims {
 		idx := indexOfString(dimNames, jd)
@@ -236,46 +259,4 @@ func deriveResourceType(a arn.ARN) string {
 		return a.Service + ":" + a.Resource[:i]
 	}
 	return a.Service
-}
-
-// selectedTagJoins returns the registered joins for the given selected profiles,
-// keyed by profile basename. Profiles with no registered join are omitted (no tags).
-func selectedTagJoins(profiles []cwprofiles.ResolvedProfile) map[string]tagJoin {
-	out := make(map[string]tagJoin)
-	for _, p := range profiles {
-		if tj, ok := tagJoins[p.Name]; ok {
-			out[p.Name] = tj
-		}
-	}
-	return out
-}
-
-// resourceTypeFilters is the deduped union of ResourceTypeFilters across the given
-// joins, to narrow the RGTA GetResources scan.
-func resourceTypeFilters(joins map[string]tagJoin) []string {
-	seen := make(map[string]struct{})
-	var out []string
-	for _, tj := range joins {
-		for _, rt := range tj.resourceTypes {
-			if _, dup := seen[rt]; dup {
-				continue
-			}
-			seen[rt] = struct{}{}
-			out = append(out, rt)
-		}
-	}
-	return out
-}
-
-// resourceTypeIndex maps each resource-type to the profile basenames that claim it
-// (a shared type like elasticloadbalancing:loadbalancer fans out to elb/alb/nlb,
-// disambiguated by each join's arnValues).
-func resourceTypeIndex(joins map[string]tagJoin) map[string][]string {
-	out := make(map[string][]string)
-	for name, tj := range joins {
-		for _, rt := range tj.resourceTypes {
-			out[rt] = append(out[rt], name)
-		}
-	}
-	return out
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/tagjoin_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagjoin_test.go
@@ -5,6 +5,7 @@ package cloudwatch
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -146,11 +147,41 @@ func TestTagJoins_DimsExistInProfiles(t *testing.T) {
 	for name, tj := range tagJoins {
 		p, ok := byName[name]
 		require.Truef(t, ok, "tagJoins references unknown profile %q", name)
-		dims := p.Config.DimensionNames()
+		assert.Equalf(t, p.Config.Namespace, tj.namespace, "profile %q association namespace", name)
 		for _, jd := range tj.joinDims {
-			assert.Containsf(t, dims, jd, "profile %q joinDim %q missing from dimensions %v", name, jd, dims)
+			var dimension *cwprofiles.InstanceDimension
+			for i := range p.Config.Instance.Dimensions {
+				if p.Config.Instance.Dimensions[i].Name == jd {
+					dimension = &p.Config.Instance.Dimensions[i]
+					break
+				}
+			}
+			if assert.NotNilf(t, dimension, "profile %q joinDim %q missing", name, jd) {
+				assert.Falsef(t, dimension.IsConstant(), "profile %q joinDim %q must identify the resource", name, jd)
+			}
 		}
 	}
+}
+
+func TestResolveTagJoinProfile_RejectsIncompatibleOverride(t *testing.T) {
+	t.Run("namespace changed", func(t *testing.T) {
+		profile := cwprofiles.ResolvedProfile{Name: "ec2", Config: ec2QueryProfile()}
+		profile.Config.Namespace = "Custom/Unrelated"
+
+		_, err := resolveTagJoinProfile(profile)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "namespace")
+	})
+
+	t.Run("join dimension made constant", func(t *testing.T) {
+		profile := cwprofiles.ResolvedProfile{Name: "ec2", Config: ec2QueryProfile()}
+		profile.Config.Instance.Dimensions[0].Label = ""
+		profile.Config.Instance.Dimensions[0].Constant = aws.String("i-fixed")
+
+		_, err := resolveTagJoinProfile(profile)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "identifying")
+	})
 }
 
 func mustParseARN(t *testing.T, s string) arn.ARN {

--- a/src/go/plugin/go.d/collector/cloudwatch/tagjoin_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagjoin_test.go
@@ -153,20 +153,6 @@ func TestTagJoins_DimsExistInProfiles(t *testing.T) {
 	}
 }
 
-func TestResourceTypeFiltersAndIndex(t *testing.T) {
-	joins := map[string]tagJoin{
-		"ec2": tagJoins["ec2"],
-		"elb": tagJoins["elb"],
-		"alb": tagJoins["alb"],
-		"nlb": tagJoins["nlb"],
-	}
-	assert.ElementsMatch(t, []string{"ec2:instance", "elasticloadbalancing:loadbalancer"}, resourceTypeFilters(joins))
-
-	idx := resourceTypeIndex(joins)
-	assert.ElementsMatch(t, []string{"ec2"}, idx["ec2:instance"])
-	assert.ElementsMatch(t, []string{"elb", "alb", "nlb"}, idx["elasticloadbalancing:loadbalancer"])
-}
-
 func mustParseARN(t *testing.T, s string) arn.ARN {
 	t.Helper()
 	a, err := arn.Parse(s)

--- a/src/go/plugin/go.d/collector/cloudwatch/tagresolve.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagresolve.go
@@ -40,10 +40,10 @@ func sanitizeLabel(key string) string {
 // dimLabels. Profile-specific collisions are non-fatal: the entry is skipped and
 // described in warnings because tag labels are optional enrichment.
 //
-// An entry is skipped when its target label:
-//   - equals a reserved identity label (account_id, region) or one of the profile's
-//     dimension labels — which would duplicate an emitted label key and panic metrix;
-//   - duplicates an already-surviving tag's label.
+// Job-level validation has already rejected duplicate AWS keys and emitted labels.
+// At this profile-specific stage, an entry is skipped only when its target label
+// equals a reserved identity label (account_id, region) or one of the profile's
+// dimension labels, which would duplicate an emitted label key and panic metrix.
 //
 // The surviving plan is the same for every instance of the profile; only the tag
 // VALUES differ per resource, applied at cache-build time.

--- a/src/go/plugin/go.d/collector/cloudwatch/tagresolve.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagresolve.go
@@ -20,7 +20,7 @@ type resolvedTag struct {
 
 // sanitizeLabel derives a default label from an AWS tag key: lowercase, with every
 // character outside [a-z0-9_] replaced by '_'. The result may still be invalid
-// (e.g. a leading digit); resolveTagPlan validates it and skips on failure.
+// (e.g. a leading digit); configuration validation rejects such a derived label.
 func sanitizeLabel(key string) string {
 	var b strings.Builder
 	b.Grow(len(key))

--- a/src/go/plugin/go.d/collector/cloudwatch/tagresolve.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagresolve.go
@@ -35,21 +35,19 @@ func sanitizeLabel(key string) string {
 	return b.String()
 }
 
-// resolveTagPlan turns the job's tag allowlist into the ordered set of
+// resolveTagPlan turns the job's validated tag-label configuration into the ordered set of
 // (AWS key -> label) that survive for a profile whose identity dimension labels are
-// dimLabels. It is NON-FATAL: a bad or colliding entry is skipped and described in
-// warnings, never an error (tags are optional enrichment).
+// dimLabels. Profile-specific collisions are non-fatal: the entry is skipped and
+// described in warnings because tag labels are optional enrichment.
 //
 // An entry is skipped when its target label:
-//   - is empty or fails the label-key regex (after sanitize, when not renamed);
 //   - equals a reserved identity label (account_id, region) or one of the profile's
 //     dimension labels — which would duplicate an emitted label key and panic metrix;
-//   - duplicates an already-surviving tag's label; or
-//   - repeats an AWS key already seen in this allowlist.
+//   - duplicates an already-surviving tag's label.
 //
 // The surviving plan is the same for every instance of the profile; only the tag
 // VALUES differ per resource, applied at cache-build time.
-func resolveTagPlan(tags []TagConfig, dimLabels []string) (plan []resolvedTag, warnings []string) {
+func resolveTagPlan(tags []ResourceTagLabelConfig, dimLabels []string) (plan []resolvedTag, warnings []string) {
 	if len(tags) == 0 {
 		return nil, nil
 	}
@@ -59,39 +57,16 @@ func resolveTagPlan(tags []TagConfig, dimLabels []string) (plan []resolvedTag, w
 		reserved[d] = "dimension"
 	}
 
-	seenAWS := make(map[string]struct{}, len(tags))
-	seenLabel := make(map[string]struct{}, len(tags))
-
 	for _, t := range tags {
-		awsKey := t.Name
-		if strings.TrimSpace(awsKey) == "" {
-			warnings = append(warnings, "skipped a tag entry with an empty name")
-			continue
-		}
-		if _, dup := seenAWS[awsKey]; dup {
-			warnings = append(warnings, fmt.Sprintf("skipped duplicate tag %q", awsKey))
-			continue
-		}
-		seenAWS[awsKey] = struct{}{}
-
-		label := t.Rename
+		awsKey := t.Key
+		label := t.Label
 		if label == "" {
 			label = sanitizeLabel(awsKey)
-		}
-		if !labelKeyRe.MatchString(label) {
-			warnings = append(warnings, fmt.Sprintf("skipped tag %q: label %q is not a valid label key (rename it)", awsKey, label))
-			continue
 		}
 		if kind, ok := reserved[label]; ok {
 			warnings = append(warnings, fmt.Sprintf("skipped tag %q: label %q collides with a %s label (rename it)", awsKey, label, kind))
 			continue
 		}
-		if _, dup := seenLabel[label]; dup {
-			warnings = append(warnings, fmt.Sprintf("skipped tag %q: label %q duplicates another tag's label (rename it)", awsKey, label))
-			continue
-		}
-		seenLabel[label] = struct{}{}
-
 		plan = append(plan, resolvedTag{awsKey: awsKey, label: label})
 	}
 	return plan, warnings

--- a/src/go/plugin/go.d/collector/cloudwatch/tagresolve_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagresolve_test.go
@@ -15,7 +15,7 @@ func TestSanitizeLabel(t *testing.T) {
 		"Environment":               "environment",
 		"aws:autoscaling:groupName": "aws_autoscaling_groupname",
 		"app.kubernetes.io/team":    "app_kubernetes_io_team",
-		"123abc":                    "123abc", // stays invalid (leading digit); resolveTagPlan skips it
+		"123abc":                    "123abc", // stays invalid; config validation requires an explicit valid label
 	}
 	for in, want := range tests {
 		t.Run(in, func(t *testing.T) {
@@ -26,7 +26,7 @@ func TestSanitizeLabel(t *testing.T) {
 
 func TestResolveTagPlan(t *testing.T) {
 	tests := map[string]struct {
-		tags      []TagConfig
+		tags      []ResourceTagLabelConfig
 		dimLabels []string
 		wantPlan  []resolvedTag
 		wantWarn  int
@@ -37,59 +37,34 @@ func TestResolveTagPlan(t *testing.T) {
 			wantWarn: 0,
 		},
 		"plain keys pass through": {
-			tags:     []TagConfig{{Name: "owner"}, {Name: "project"}},
+			tags:     []ResourceTagLabelConfig{{Key: "owner"}, {Key: "project"}},
 			wantPlan: []resolvedTag{{"owner", "owner"}, {"project", "project"}},
 		},
 		"Name sanitizes to name": {
-			tags:     []TagConfig{{Name: "Name"}},
+			tags:     []ResourceTagLabelConfig{{Key: "Name"}},
 			wantPlan: []resolvedTag{{"Name", "name"}},
 		},
 		"rename overrides default": {
-			tags:     []TagConfig{{Name: "Name", Rename: "instance_name"}},
+			tags:     []ResourceTagLabelConfig{{Key: "Name", Label: "instance_name"}},
 			wantPlan: []resolvedTag{{"Name", "instance_name"}},
 		},
 		"region tag collides with reserved -> skipped": {
-			tags:     []TagConfig{{Name: "region"}},
+			tags:     []ResourceTagLabelConfig{{Key: "region"}},
 			wantPlan: nil,
 			wantWarn: 1,
 		},
 		"region tag renamed -> kept": {
-			tags:     []TagConfig{{Name: "region", Rename: "aws_region"}},
+			tags:     []ResourceTagLabelConfig{{Key: "region", Label: "aws_region"}},
 			wantPlan: []resolvedTag{{"region", "aws_region"}},
 		},
 		"collision with a profile dimension label -> skipped": {
-			tags:      []TagConfig{{Name: "instance_id"}},
+			tags:      []ResourceTagLabelConfig{{Key: "instance_id"}},
 			dimLabels: []string{"instance_id"},
 			wantPlan:  nil,
 			wantWarn:  1,
 		},
-		"duplicate AWS key -> one kept": {
-			tags:     []TagConfig{{Name: "owner"}, {Name: "owner"}},
-			wantPlan: []resolvedTag{{"owner", "owner"}},
-			wantWarn: 1,
-		},
-		"two keys sanitizing to the same label -> second skipped": {
-			tags:     []TagConfig{{Name: "Name"}, {Name: "name"}},
-			wantPlan: []resolvedTag{{"Name", "name"}},
-			wantWarn: 1,
-		},
-		"invalid rename -> skipped": {
-			tags:     []TagConfig{{Name: "foo", Rename: "Bad-Name"}},
-			wantPlan: nil,
-			wantWarn: 1,
-		},
-		"key sanitizing to an invalid label -> skipped": {
-			tags:     []TagConfig{{Name: "123abc"}},
-			wantPlan: nil,
-			wantWarn: 1,
-		},
-		"empty name -> skipped": {
-			tags:     []TagConfig{{Name: "  "}},
-			wantPlan: nil,
-			wantWarn: 1,
-		},
 		"survivors kept when mixed with skips": {
-			tags:      []TagConfig{{Name: "owner"}, {Name: "region"}, {Name: "project"}},
+			tags:      []ResourceTagLabelConfig{{Key: "owner"}, {Key: "region"}, {Key: "project"}},
 			dimLabels: []string{"instance_id"},
 			wantPlan:  []resolvedTag{{"owner", "owner"}, {"project", "project"}},
 			wantWarn:  1,

--- a/src/go/plugin/go.d/collector/cloudwatch/tagresolve_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tagresolve_test.go
@@ -31,7 +31,7 @@ func TestResolveTagPlan(t *testing.T) {
 		wantPlan  []resolvedTag
 		wantWarn  int
 	}{
-		"empty allowlist disables": {
+		"empty selection disables": {
 			tags:     nil,
 			wantPlan: nil,
 			wantWarn: 0,

--- a/src/go/plugin/go.d/collector/cloudwatch/tags.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sort"
 	"time"
 
 	rgtatypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
@@ -34,14 +35,24 @@ func (m tagMembership) add(scopeID int, joinKey string) {
 	m[scopeID][joinKey] = struct{}{}
 }
 
-func (m tagMembership) merge(other tagMembership) {
+// tagGroupSnapshot is the independently cached result of one RGTA fetch group.
+// A failed refresh keeps the last complete result but marks its policy scopes
+// unknown and expires only this group for retry.
+type tagGroupSnapshot struct {
+	group           tagFetchGroup
+	members         tagMembership
+	labels          map[tagCacheKey][]metrix.Label
+	confirmedLabels map[tagCacheKey]struct{}
+	lastSuccess     time.Time
+	expiresAt       time.Time
+	unknown         bool
+}
+
+// share copies only the scope index; the per-scope member sets are immutable once
+// a fetch result is installed and can be shared by the effective snapshot.
+func (m tagMembership) share(other tagMembership) {
 	for scopeID, joinKeys := range other {
-		if m[scopeID] == nil && len(joinKeys) > 0 {
-			m[scopeID] = make(map[string]struct{}, len(joinKeys))
-		}
-		for joinKey := range joinKeys {
-			m[scopeID][joinKey] = struct{}{}
-		}
+		m[scopeID] = joinKeys
 	}
 }
 
@@ -70,6 +81,7 @@ type tagSnapshot struct {
 	labels    map[tagCacheKey][]metrix.Label
 	members   tagMembership
 	unknown   map[int]struct{}
+	groups    map[tagFetchKey]tagGroupSnapshot
 	fetchedAt time.Time
 	expiresAt time.Time
 }
@@ -115,6 +127,10 @@ func (s tagSnapshot) sameEffective(other tagSnapshot) bool {
 // markTagsStale forces the next refreshTags to re-fetch even within the TTL.
 func (c *Collector) markTagsStale() {
 	c.tags.expiresAt = time.Time{}
+	for key, state := range c.tags.groups {
+		state.expiresAt = time.Time{}
+		c.tags.groups[key] = state
+	}
 }
 
 // profileDimLabels returns a profile's identifying (non-constant) dimension labels —
@@ -139,7 +155,7 @@ func (c *Collector) computeTagLabelPlans() {
 		return
 	}
 	for _, p := range c.plan.Profiles {
-		if _, ok := tagJoins[p.Name]; !ok {
+		if c.plan.TagJoins[p.Name] == nil {
 			continue
 		}
 		plan, warnings := resolveTagPlan(c.Labels.ResourceTags, profileDimLabels(p.Config))
@@ -181,25 +197,8 @@ func (c *Collector) refreshTags(ctx context.Context) {
 	}
 
 	ttl := time.Duration(c.Discovery.RefreshEvery) * time.Second
-
-	next := tagSnapshot{
-		labels:    make(map[tagCacheKey][]metrix.Label),
-		members:   make(tagMembership),
-		unknown:   make(map[int]struct{}),
-		fetchedAt: now,
-		expiresAt: now.Add(ttl),
-	}
-
-	groups := c.tagFetchGroups()
-	results := make([]tagFetchResult, len(groups))
-	p := pool.New().WithMaxGoroutines(max(1, apiConcurrency))
-	for i := range groups {
-		i := i
-		p.Go(func() {
-			results[i] = c.fetchTagGroup(ctx, groups[i])
-		})
-	}
-	p.Wait()
+	states, due := selectDueTagGroups(c.tagFetchGroups(), c.tags.groups, now)
+	results := c.fetchTagGroups(ctx, due)
 
 	// If the parent collect context was canceled or timed out during the fan-out, do
 	// NOT commit next or advance the TTL: that would suppress tag retries until the next
@@ -210,31 +209,8 @@ func (c *Collector) refreshTags(ctx context.Context) {
 		return
 	}
 
-	var failures []operationFailure
-	confirmedLabels := make(map[tagCacheKey]struct{})
-	for _, result := range results {
-		if result.err != nil {
-			carryForwardTagGroup(&next, c.tags, result.group, confirmedLabels)
-			failures = append(failures, operationFailure{
-				Target: result.group.key.target,
-				Region: result.group.key.region,
-				Scope:  fmt.Sprintf("profiles=%d", len(result.group.profiles)),
-				Err:    result.err,
-			})
-			continue
-		}
-		next.members.merge(result.members)
-		for key := range result.confirmedLabels {
-			confirmedLabels[key] = struct{}{}
-			delete(next.labels, key)
-		}
-		for key, labels := range result.labels {
-			next.labels[key] = labels
-		}
-	}
-	if len(failures) > 0 {
-		next.expiresAt = time.Time{}
-	}
+	failures := applyTagFetchResults(states, c.tags.groups, results, now, ttl)
+	next := mergeTagGroupSnapshots(states, now, now.Add(ttl))
 	c.warnOperationFailures(logKeyTagRefreshFailed, "resource tag lookup", " (retaining fail-closed membership and last-known labels)", failures)
 
 	changed := !next.sameEffective(c.tags)
@@ -244,46 +220,127 @@ func (c *Collector) refreshTags(ctx context.Context) {
 	}
 }
 
-func carryForwardTagGroup(dst *tagSnapshot, previous tagSnapshot, group tagFetchGroup, confirmedLabels map[tagCacheKey]struct{}) {
-	for _, scopeIDs := range group.scopeIDsByProfile {
-		for _, scopeID := range scopeIDs {
-			dst.unknown[scopeID] = struct{}{}
+func selectDueTagGroups(groups []tagFetchGroup, previous map[tagFetchKey]tagGroupSnapshot, now time.Time) (map[tagFetchKey]tagGroupSnapshot, []tagFetchGroup) {
+	states := make(map[tagFetchKey]tagGroupSnapshot, len(groups))
+	var due []tagFetchGroup
+	for _, group := range groups {
+		state, ok := previous[group.key]
+		if ok && now.Before(state.expiresAt) {
+			state.group = group
+			states[group.key] = state
+			continue
+		}
+		due = append(due, group)
+	}
+	return states, due
+}
+
+func (c *Collector) fetchTagGroups(ctx context.Context, groups []tagFetchGroup) []tagFetchResult {
+	results := make([]tagFetchResult, len(groups))
+	p := pool.New().WithMaxGoroutines(max(1, apiConcurrency))
+	for i := range groups {
+		i := i
+		p.Go(func() {
+			results[i] = c.fetchTagGroup(ctx, groups[i])
+		})
+	}
+	p.Wait()
+	return results
+}
+
+func applyTagFetchResults(states, previous map[tagFetchKey]tagGroupSnapshot, results []tagFetchResult, now time.Time, ttl time.Duration) []operationFailure {
+	var failures []operationFailure
+	for _, result := range results {
+		if result.err == nil {
+			states[result.group.key] = tagGroupSnapshot{
+				group: result.group, members: result.members, labels: result.labels,
+				confirmedLabels: result.confirmedLabels,
+				lastSuccess:     now,
+				expiresAt:       now.Add(ttl),
+			}
+			continue
+		}
+
+		state := previous[result.group.key]
+		state.group = result.group
+		state.unknown = true
+		state.expiresAt = time.Time{}
+		if state.members == nil {
+			state.members = make(tagMembership)
+		}
+		if state.labels == nil {
+			state.labels = make(map[tagCacheKey][]metrix.Label)
+		}
+		if state.confirmedLabels == nil {
+			state.confirmedLabels = make(map[tagCacheKey]struct{})
+		}
+		states[result.group.key] = state
+		failures = append(failures, operationFailure{
+			Target: result.group.key.target,
+			Region: result.group.key.region,
+			Scope:  fmt.Sprintf("profiles=%d", len(result.group.joins)),
+			Err:    result.err,
+		})
+	}
+	return failures
+}
+
+func mergeTagGroupSnapshots(states map[tagFetchKey]tagGroupSnapshot, fetchedAt, emptyExpiresAt time.Time) tagSnapshot {
+	labelCapacity := 0
+	membershipCapacity := 0
+	unknownCapacity := 0
+	for _, state := range states {
+		labelCapacity = max(labelCapacity, len(state.confirmedLabels))
+		membershipCapacity += len(state.members)
+		if state.unknown {
+			for _, scopeIDs := range state.group.scopeIDsByProfile {
+				unknownCapacity += len(scopeIDs)
+			}
 		}
 	}
-	for _, scopeIDs := range group.scopeIDsByProfile {
-		for _, scopeID := range scopeIDs {
-			joinKeys := previous.members[scopeID]
-			if len(joinKeys) == 0 {
-				continue
+	next := tagSnapshot{
+		labels: make(map[tagCacheKey][]metrix.Label, labelCapacity), members: make(tagMembership, membershipCapacity),
+		unknown: make(map[int]struct{}, unknownCapacity), groups: states,
+		fetchedAt: fetchedAt, expiresAt: emptyExpiresAt,
+	}
+	keys := make([]tagFetchKey, 0, len(states))
+	for key := range states {
+		keys = append(keys, key)
+	}
+	if len(keys) > 1 {
+		sort.Slice(keys, func(i, j int) bool {
+			a, b := states[keys[i]], states[keys[j]]
+			if !a.lastSuccess.Equal(b.lastSuccess) {
+				return a.lastSuccess.Before(b.lastSuccess)
 			}
-			copied := make(map[string]struct{}, len(joinKeys))
-			for joinKey := range joinKeys {
-				copied[joinKey] = struct{}{}
+			return lessTagFetchKey(keys[i], keys[j])
+		})
+	}
+	for _, key := range keys {
+		state := states[key]
+		next.members.share(state.members)
+		if state.unknown {
+			for _, scopeIDs := range state.group.scopeIDsByProfile {
+				for _, scopeID := range scopeIDs {
+					next.unknown[scopeID] = struct{}{}
+				}
 			}
-			dst.members[scopeID] = copied
+		}
+		if state.expiresAt.IsZero() || state.expiresAt.Before(next.expiresAt) {
+			next.expiresAt = state.expiresAt
+		}
+		for labelKey := range state.confirmedLabels {
+			delete(next.labels, labelKey)
+			if labels, ok := state.labels[labelKey]; ok {
+				next.labels[labelKey] = labels
+			}
 		}
 	}
-	if !group.hasLabels {
-		return
-	}
-	for profile, candidates := range group.candidatesByProfile {
-		for joinKey := range candidates {
-			key := tagCacheKey{
-				target: group.key.target, account: group.account, region: group.key.region,
-				profile: profile, joinKey: joinKey,
-			}
-			if _, confirmed := confirmedLabels[key]; confirmed {
-				continue
-			}
-			if labels, ok := previous.labels[key]; ok {
-				dst.labels[key] = labels
-			}
-		}
-	}
+	return next
 }
 
 func selectedTagMap(tags []rgtatypes.Tag, selected map[string]struct{}) map[string]string {
-	out := make(map[string]string, len(selected))
+	out := make(map[string]string, min(len(tags), len(selected)))
 	for _, t := range tags {
 		if t.Key == nil || t.Value == nil {
 			continue
@@ -311,15 +368,14 @@ func applyTagPlan(plan []resolvedTag, tags map[string]string) []metrix.Label {
 
 // tagLabelsFor returns the cached, non-identity tag labels for one discovered
 // instance, or nil when tags are off, the profile has no join, or none are cached.
-func (c *Collector) tagLabelsFor(target, account, region string, prof cwprofiles.ResolvedProfile, values []string) []metrix.Label {
+func (c *Collector) tagLabelsFor(target, account, region string, prof cwprofiles.ResolvedProfile, join *tagJoin, values []string) []metrix.Label {
 	if len(c.tags.labels) == 0 {
 		return nil
 	}
-	tj, ok := tagJoins[prof.Name]
-	if !ok {
+	if join == nil {
 		return nil
 	}
-	jk, ok := tj.instanceJoinKey(prof.Config.DimensionNames(), values)
+	jk, ok := join.instanceJoinKey(prof.Config.DimensionNames(), values)
 	if !ok {
 		return nil
 	}

--- a/src/go/plugin/go.d/collector/cloudwatch/tags.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags.go
@@ -5,10 +5,9 @@ package cloudwatch
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	rgtatypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 	"github.com/sourcegraph/conc/pool"
 
@@ -26,17 +25,51 @@ type tagCacheKey struct {
 	joinKey string
 }
 
-type tagScopeKey struct {
-	target string
-	region string
+type tagMembership map[int]map[string]struct{}
+
+func (m tagMembership) add(scopeID int, joinKey string) {
+	if m[scopeID] == nil {
+		m[scopeID] = make(map[string]struct{})
+	}
+	m[scopeID][joinKey] = struct{}{}
 }
 
-// tagSnapshot is the cached result of one tag refresh: resolved labels per resource,
-// with a TTL. On a per-(target, region) RGTA failure the previous snapshot's entries
-// for that (target, region) are carried forward (last-known); a first-run failure
-// simply yields no tags. Never gates series existence (INV.2).
+func (m tagMembership) merge(other tagMembership) {
+	for scopeID, joinKeys := range other {
+		if m[scopeID] == nil && len(joinKeys) > 0 {
+			m[scopeID] = make(map[string]struct{}, len(joinKeys))
+		}
+		for joinKey := range joinKeys {
+			m[scopeID][joinKey] = struct{}{}
+		}
+	}
+}
+
+func (m tagMembership) equal(other tagMembership) bool {
+	if len(m) != len(other) {
+		return false
+	}
+	for scopeID, joinKeys := range m {
+		otherJoinKeys, ok := other[scopeID]
+		if !ok || len(joinKeys) != len(otherJoinKeys) {
+			return false
+		}
+		for joinKey := range joinKeys {
+			if _, ok := otherJoinKeys[joinKey]; !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// tagSnapshot is one immutable view of tag-filter membership and emitted resource
+// labels. A failed scope is unknown: last-known members remain selected, while all
+// other candidates are reserved from lower-priority rules until the next retry.
 type tagSnapshot struct {
 	labels    map[tagCacheKey][]metrix.Label
+	members   tagMembership
+	unknown   map[int]struct{}
 	fetchedAt time.Time
 	expiresAt time.Time
 }
@@ -45,9 +78,41 @@ func (s tagSnapshot) expired(now time.Time) bool {
 	return s.fetchedAt.IsZero() || !now.Before(s.expiresAt)
 }
 
-// markTagsStale forces the next refreshTags to re-fetch even within the TTL. Called
-// when a new target resolves: its tags must be fetched this cycle, before its charts
-// are created, because chart labels are set only at chart creation.
+func (s tagSnapshot) scopeUnknown(scopeID int) bool {
+	if s.fetchedAt.IsZero() {
+		return true
+	}
+	_, ok := s.unknown[scopeID]
+	return ok
+}
+
+func (s tagSnapshot) scopeSelected(scopeID int, joinKey string) bool {
+	_, ok := s.members[scopeID][joinKey]
+	return ok
+}
+
+func (s tagSnapshot) sameEffective(other tagSnapshot) bool {
+	if s.fetchedAt.IsZero() != other.fetchedAt.IsZero() {
+		return false
+	}
+	if !s.members.equal(other.members) || len(s.unknown) != len(other.unknown) || len(s.labels) != len(other.labels) {
+		return false
+	}
+	for key := range s.unknown {
+		if _, ok := other.unknown[key]; !ok {
+			return false
+		}
+	}
+	for key, labels := range s.labels {
+		otherLabels, ok := other.labels[key]
+		if !ok || !slices.Equal(labels, otherLabels) {
+			return false
+		}
+	}
+	return true
+}
+
+// markTagsStale forces the next refreshTags to re-fetch even within the TTL.
 func (c *Collector) markTagsStale() {
 	c.tags.expiresAt = time.Time{}
 }
@@ -64,19 +129,20 @@ func profileDimLabels(prof cwprofiles.Profile) []string {
 	return out
 }
 
-// computeTagPlans resolves the per-profile tag-label plan once (the allowlist and
+// computeTagLabelPlans resolves the per-profile tag-label plan once (the allowlist and
 // profiles are fixed per job) and logs each skip once. Profiles with no registered
 // ARN join or an empty resolved plan are omitted, so they carry no tags.
-func (c *Collector) computeTagPlans() {
-	if len(c.Tags) == 0 {
+func (c *Collector) computeTagLabelPlans() {
+	plans := make(map[string][]resolvedTag)
+	if len(c.Labels.ResourceTags) == 0 {
+		c.tagLabelPlans = plans
 		return
 	}
-	plans := make(map[string][]resolvedTag)
 	for _, p := range c.plan.Profiles {
 		if _, ok := tagJoins[p.Name]; !ok {
 			continue
 		}
-		plan, warnings := resolveTagPlan(c.Tags, profileDimLabels(p.Config))
+		plan, warnings := resolveTagPlan(c.Labels.ResourceTags, profileDimLabels(p.Config))
 		for _, w := range warnings {
 			c.Warningf("CloudWatch tags (profile %q): %s", p.Name, w)
 		}
@@ -84,73 +150,53 @@ func (c *Collector) computeTagPlans() {
 			plans[p.Name] = plan
 		}
 	}
-	c.tagPlans = plans
+	c.tagLabelPlans = plans
 }
 
-// refreshTags rebuilds the tag cache when its TTL has expired. It is best-effort and
-// NEVER gates collection: a per-(target, region) failure carries last-known tags
-// forward (or yields none on the first pass). Opt-in: with no configured tags (so no
-// resolved plans) it is a no-op and no RGTA client is ever built.
+func (c *Collector) hasTagWork() bool {
+	if len(c.Labels.ResourceTags) > 0 {
+		return true
+	}
+	for _, scope := range c.plan.Scopes {
+		if scope.hasTagFilter() {
+			return true
+		}
+	}
+	return false
+}
+
+// refreshTags replaces the tag snapshot when its TTL expires. Filter failures are
+// fail-closed: first-run membership is unknown, and later failures retain last-known
+// members. Failed groups retry on the next collect instead of advancing the TTL.
 func (c *Collector) refreshTags(ctx context.Context) {
-	if len(c.Tags) == 0 {
-		return // opt-in: no tags configured, so never build an RGTA client
+	if !c.hasTagWork() {
+		return
 	}
-	if c.tagPlans == nil {
-		c.computeTagPlans() // resolve per-profile plans once (allowlist + profiles are fixed)
-	}
-	if len(c.tagPlans) == 0 {
-		return // every configured tag was skipped, or no selected profile has an ARN join
+	if c.tagLabelPlans == nil {
+		c.computeTagLabelPlans()
 	}
 	now := c.now()
 	if !c.tags.expired(now) {
 		return
 	}
 
-	joins := selectedTagJoins(c.plan.Profiles)
-	filters := resourceTypeFilters(joins)
-	rtIndex := resourceTypeIndex(joins)
 	ttl := time.Duration(c.Discovery.RefreshEvery) * time.Second
 
 	next := tagSnapshot{
 		labels:    make(map[tagCacheKey][]metrix.Label),
+		members:   make(tagMembership),
+		unknown:   make(map[int]struct{}),
 		fetchedAt: now,
 		expiresAt: now.Add(ttl),
 	}
 
-	// Fetch each (target, region) concurrently (bounded), so a slow or hung RGTA
-	// endpoint cannot serialize into a targets x regions x timeout collection stall;
-	// the per-call timeout bounds each fetch. Indexing into the shared map is done
-	// serially afterwards to avoid a data race. Mirrors discovery's fan-out.
-	type tagFetch struct {
-		target, account, region string
-		resources               []rgtatypes.ResourceTagMapping
-		err                     error
-	}
-	var targets []tagFetch
-	seenTargets := make(map[string]struct{})
-	for _, scope := range c.plan.Scopes {
-		resolved, ok := c.resolvedTargetByRef(scope.Target.Name)
-		if !ok {
-			continue
-		}
-		key := scope.Target.Name + "\x00" + scope.Region
-		if _, ok := seenTargets[key]; ok {
-			continue
-		}
-		seenTargets[key] = struct{}{}
-		targets = append(targets, tagFetch{target: scope.Target.Name, account: resolved.accountID, region: scope.Region})
-	}
-
+	groups := c.tagFetchGroups()
+	results := make([]tagFetchResult, len(groups))
 	p := pool.New().WithMaxGoroutines(max(1, apiConcurrency))
-	for i := range targets {
-		t := &targets[i]
+	for i := range groups {
+		i := i
 		p.Go(func() {
-			client, err := c.rgtaClients.forTargetRegion(ctx, t.target, t.region)
-			if err != nil {
-				t.err = fmt.Errorf("build client: %w", err)
-				return
-			}
-			t.resources, t.err = getAllResources(ctx, client, filters, c.Timeout.Duration())
+			results[i] = c.fetchTagGroup(ctx, groups[i])
 		})
 	}
 	p.Wait()
@@ -164,117 +210,85 @@ func (c *Collector) refreshTags(ctx context.Context) {
 		return
 	}
 
-	var failedScopes map[tagScopeKey]struct{}
 	var failures []operationFailure
-	for _, t := range targets {
-		if t.err != nil {
-			if failedScopes == nil {
-				failedScopes = make(map[tagScopeKey]struct{})
-			}
-			failedScopes[tagScopeKey{target: t.target, region: t.region}] = struct{}{}
-			failures = append(failures, operationFailure{Target: t.target, Region: t.region, Err: t.err})
+	confirmedLabels := make(map[tagCacheKey]struct{})
+	for _, result := range results {
+		if result.err != nil {
+			carryForwardTagGroup(&next, c.tags, result.group, confirmedLabels)
+			failures = append(failures, operationFailure{
+				Target: result.group.key.target,
+				Region: result.group.key.region,
+				Scope:  fmt.Sprintf("profiles=%d", len(result.group.profiles)),
+				Err:    result.err,
+			})
 			continue
 		}
-		indexResourceTags(next.labels, t.target, t.account, t.region, t.resources, rtIndex, joins, c.tagPlans)
+		next.members.merge(result.members)
+		for key := range result.confirmedLabels {
+			confirmedLabels[key] = struct{}{}
+			delete(next.labels, key)
+		}
+		for key, labels := range result.labels {
+			next.labels[key] = labels
+		}
 	}
-	if len(failedScopes) > 0 {
-		carryForwardFailedTags(next.labels, c.tags.labels, failedScopes)
+	if len(failures) > 0 {
+		next.expiresAt = time.Time{}
 	}
-	c.warnOperationFailures(logKeyTagRefreshFailed, "tag lookup", " (using last-known tags)", failures)
+	c.warnOperationFailures(logKeyTagRefreshFailed, "resource tag lookup", " (retaining fail-closed membership and last-known labels)", failures)
 
+	changed := !next.sameEffective(c.tags)
 	c.tags = next
-	c.invalidateQueryPlan()
+	if changed {
+		c.invalidateQueryPlan()
+	}
 }
 
-// carryForwardFailedTags scans the previous snapshot once, preserving entries for
-// every target-region whose RGTA refresh failed.
-func carryForwardFailedTags(dst, previous map[tagCacheKey][]metrix.Label, failed map[tagScopeKey]struct{}) {
-	for k, v := range previous {
-		if _, ok := failed[tagScopeKey{target: k.target, region: k.region}]; ok {
-			dst[k] = v
+func carryForwardTagGroup(dst *tagSnapshot, previous tagSnapshot, group tagFetchGroup, confirmedLabels map[tagCacheKey]struct{}) {
+	for _, scopeIDs := range group.scopeIDsByProfile {
+		for _, scopeID := range scopeIDs {
+			dst.unknown[scopeID] = struct{}{}
+		}
+	}
+	for _, scopeIDs := range group.scopeIDsByProfile {
+		for _, scopeID := range scopeIDs {
+			joinKeys := previous.members[scopeID]
+			if len(joinKeys) == 0 {
+				continue
+			}
+			copied := make(map[string]struct{}, len(joinKeys))
+			for joinKey := range joinKeys {
+				copied[joinKey] = struct{}{}
+			}
+			dst.members[scopeID] = copied
+		}
+	}
+	if !group.hasLabels {
+		return
+	}
+	for profile, candidates := range group.candidatesByProfile {
+		for joinKey := range candidates {
+			key := tagCacheKey{
+				target: group.key.target, account: group.account, region: group.key.region,
+				profile: profile, joinKey: joinKey,
+			}
+			if _, confirmed := confirmedLabels[key]; confirmed {
+				continue
+			}
+			if labels, ok := previous.labels[key]; ok {
+				dst.labels[key] = labels
+			}
 		}
 	}
 }
 
-// getAllResources pages through RGTA GetResources, narrowed to the given resource
-// types, and returns every tagged resource mapping.
-func getAllResources(ctx context.Context, client rgtaClient, filters []string, timeout time.Duration) ([]rgtatypes.ResourceTagMapping, error) {
-	cctx, cancel := withTimeout(ctx, timeout)
-	defer cancel()
-
-	var out []rgtatypes.ResourceTagMapping
-	var token *string
-	for {
-		in := &resourcegroupstaggingapi.GetResourcesInput{PaginationToken: token}
-		if len(filters) > 0 {
-			in.ResourceTypeFilters = filters
-		}
-		resp, err := client.GetResources(cctx, in)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, resp.ResourceTagMappingList...)
-		if resp.PaginationToken == nil || *resp.PaginationToken == "" {
-			break
-		}
-		token = resp.PaginationToken
-	}
-	return out, nil
-}
-
-// indexResourceTags resolves each tagged resource to its (profile, joinKey) and
-// stores the resolved tag labels. A resource whose ARN does not parse, whose type
-// no selected profile claims, or whose join key cannot be built is skipped.
-func indexResourceTags(
-	dst map[tagCacheKey][]metrix.Label,
-	target, account, region string,
-	resources []rgtatypes.ResourceTagMapping,
-	rtIndex map[string][]string,
-	joins map[string]tagJoin,
-	plans map[string][]resolvedTag,
-) {
-	for _, res := range resources {
-		if res.ResourceARN == nil {
-			continue
-		}
-		a, err := arn.Parse(*res.ResourceARN)
-		if err != nil {
-			continue
-		}
-		// RGTA is queried per (target, region), so a resource whose ARN names a
-		// different account or region should not appear; skip it if it does, so tags
-		// are never cached against the wrong target. Empty ARN fields (e.g. S3, which
-		// carries no account/region) are allowed.
-		if (a.AccountID != "" && a.AccountID != account) || (a.Region != "" && a.Region != region) {
-			continue
-		}
-		profNames := rtIndex[deriveResourceType(a)]
-		if len(profNames) == 0 {
-			continue
-		}
-		tags := tagMap(res.Tags)
-		for _, profName := range profNames {
-			plan := plans[profName]
-			if len(plan) == 0 {
-				continue
-			}
-			jk, ok := joins[profName].arnJoinKey(a)
-			if !ok {
-				continue
-			}
-			labels := applyTagPlan(plan, tags)
-			if len(labels) == 0 {
-				continue
-			}
-			dst[tagCacheKey{target: target, account: account, region: region, profile: profName, joinKey: jk}] = labels
-		}
-	}
-}
-
-func tagMap(tags []rgtatypes.Tag) map[string]string {
-	out := make(map[string]string, len(tags))
+func selectedTagMap(tags []rgtatypes.Tag, selected map[string]struct{}) map[string]string {
+	out := make(map[string]string, len(selected))
 	for _, t := range tags {
-		if t.Key != nil && t.Value != nil {
+		if t.Key == nil || t.Value == nil {
+			continue
+		}
+		if _, ok := selected[*t.Key]; ok {
 			out[*t.Key] = *t.Value
 		}
 	}

--- a/src/go/plugin/go.d/collector/cloudwatch/tags.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags.go
@@ -39,7 +39,7 @@ func (m tagMembership) add(scopeID int, joinKey string) {
 // A failed refresh keeps the last complete result but marks its policy scopes
 // unknown and expires only this group for retry.
 type tagGroupSnapshot struct {
-	group           tagFetchGroup
+	scopeIDs        []int
 	members         tagMembership
 	labels          map[tagCacheKey][]metrix.Label
 	confirmedLabels map[tagCacheKey]struct{}
@@ -145,7 +145,7 @@ func profileDimLabels(prof cwprofiles.Profile) []string {
 	return out
 }
 
-// computeTagLabelPlans resolves the per-profile tag-label plan once (the allowlist and
+// computeTagLabelPlans resolves the per-profile tag-label plan once (the selection and
 // profiles are fixed per job) and logs each skip once. Profiles with no registered
 // ARN join or an empty resolved plan are omitted, so they carry no tags.
 func (c *Collector) computeTagLabelPlans() {
@@ -197,7 +197,7 @@ func (c *Collector) refreshTags(ctx context.Context) {
 	}
 
 	ttl := time.Duration(c.Discovery.RefreshEvery) * time.Second
-	states, due := selectDueTagGroups(c.tagFetchGroups(), c.tags.groups, now)
+	states, due := selectDueTagGroups(c.currentTagFetchPlan(), c.tags.groups, now)
 	results := c.fetchTagGroups(ctx, due)
 
 	// If the parent collect context was canceled or timed out during the fan-out, do
@@ -226,7 +226,6 @@ func selectDueTagGroups(groups []tagFetchGroup, previous map[tagFetchKey]tagGrou
 	for _, group := range groups {
 		state, ok := previous[group.key]
 		if ok && now.Before(state.expiresAt) {
-			state.group = group
 			states[group.key] = state
 			continue
 		}
@@ -253,7 +252,7 @@ func applyTagFetchResults(states, previous map[tagFetchKey]tagGroupSnapshot, res
 	for _, result := range results {
 		if result.err == nil {
 			states[result.group.key] = tagGroupSnapshot{
-				group: result.group, members: result.members, labels: result.labels,
+				scopeIDs: tagGroupScopeIDs(result.group), members: result.members, labels: result.labels,
 				confirmedLabels: result.confirmedLabels,
 				lastSuccess:     now,
 				expiresAt:       now.Add(ttl),
@@ -262,7 +261,7 @@ func applyTagFetchResults(states, previous map[tagFetchKey]tagGroupSnapshot, res
 		}
 
 		state := previous[result.group.key]
-		state.group = result.group
+		state.scopeIDs = tagGroupScopeIDs(result.group)
 		state.unknown = true
 		state.expiresAt = time.Time{}
 		if state.members == nil {
@@ -285,6 +284,15 @@ func applyTagFetchResults(states, previous map[tagFetchKey]tagGroupSnapshot, res
 	return failures
 }
 
+func tagGroupScopeIDs(group tagFetchGroup) []int {
+	var scopeIDs []int
+	for _, ids := range group.scopeIDsByProfile {
+		scopeIDs = append(scopeIDs, ids...)
+	}
+	sort.Ints(scopeIDs)
+	return scopeIDs
+}
+
 func mergeTagGroupSnapshots(states map[tagFetchKey]tagGroupSnapshot, fetchedAt, emptyExpiresAt time.Time) tagSnapshot {
 	labelCapacity := 0
 	membershipCapacity := 0
@@ -293,9 +301,7 @@ func mergeTagGroupSnapshots(states map[tagFetchKey]tagGroupSnapshot, fetchedAt, 
 		labelCapacity = max(labelCapacity, len(state.confirmedLabels))
 		membershipCapacity += len(state.members)
 		if state.unknown {
-			for _, scopeIDs := range state.group.scopeIDsByProfile {
-				unknownCapacity += len(scopeIDs)
-			}
+			unknownCapacity += len(state.scopeIDs)
 		}
 	}
 	next := tagSnapshot{
@@ -320,10 +326,8 @@ func mergeTagGroupSnapshots(states map[tagFetchKey]tagGroupSnapshot, fetchedAt, 
 		state := states[key]
 		next.members.share(state.members)
 		if state.unknown {
-			for _, scopeIDs := range state.group.scopeIDsByProfile {
-				for _, scopeID := range scopeIDs {
-					next.unknown[scopeID] = struct{}{}
-				}
+			for _, scopeID := range state.scopeIDs {
+				next.unknown[scopeID] = struct{}{}
 			}
 		}
 		if state.expiresAt.IsZero() || state.expiresAt.Before(next.expiresAt) {

--- a/src/go/plugin/go.d/collector/cloudwatch/tags.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags.go
@@ -5,6 +5,7 @@ package cloudwatch
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"time"
@@ -51,9 +52,7 @@ type tagGroupSnapshot struct {
 // share copies only the scope index; the per-scope member sets are immutable once
 // a fetch result is installed and can be shared by the effective snapshot.
 func (m tagMembership) share(other tagMembership) {
-	for scopeID, joinKeys := range other {
-		m[scopeID] = joinKeys
-	}
+	maps.Copy(m, other)
 }
 
 func (m tagMembership) equal(other tagMembership) bool {
@@ -238,7 +237,6 @@ func (c *Collector) fetchTagGroups(ctx context.Context, groups []tagFetchGroup) 
 	results := make([]tagFetchResult, len(groups))
 	p := pool.New().WithMaxGoroutines(max(1, apiConcurrency))
 	for i := range groups {
-		i := i
 		p.Go(func() {
 			results[i] = c.fetchTagGroup(ctx, groups[i])
 		})

--- a/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"slices"
 	"strconv"
 	"sync"
@@ -405,7 +406,6 @@ func TestRefreshTags_FilterMembershipFailureLifecycle(t *testing.T) {
 	c := New()
 	configureExactRule(c, []string{"us-east-1"}, []string{"ec2"})
 	setSingleTargetPlan(c, "000000000000", []string{"us-east-1"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
-	c.plan.Scopes[0].ID = 7
 	c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
 	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
 		{Target: "base", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
@@ -416,14 +416,14 @@ func TestRefreshTags_FilterMembershipFailureLifecycle(t *testing.T) {
 	c.now = func() time.Time { return base }
 
 	c.refreshTags(context.Background())
-	assert.True(t, c.tags.scopeUnknown(7), "a first failure is unknown")
-	assert.False(t, c.tags.scopeSelected(7, "i-1"))
+	assert.True(t, c.tags.scopeUnknown(0), "a first failure is unknown")
+	assert.False(t, c.tags.scopeSelected(0, "i-1"))
 	assert.True(t, c.tags.expired(base), "a failed group retries next collect")
 
 	rgta.err = nil
 	c.refreshTags(context.Background())
-	assert.False(t, c.tags.scopeUnknown(7))
-	assert.True(t, c.tags.scopeSelected(7, "i-1"))
+	assert.False(t, c.tags.scopeUnknown(0))
+	assert.True(t, c.tags.scopeSelected(0, "i-1"))
 	assert.False(t, c.tags.expired(base), "a successful refresh advances the TTL")
 	require.Len(t, rgta.gotTags, 1)
 	assert.Equal(t, "environment", aws.ToString(rgta.gotTags[0].Key))
@@ -432,8 +432,8 @@ func TestRefreshTags_FilterMembershipFailureLifecycle(t *testing.T) {
 	rgta.err = errors.New("throttled again")
 	c.markTagsStale()
 	c.refreshTags(context.Background())
-	assert.True(t, c.tags.scopeUnknown(7))
-	assert.True(t, c.tags.scopeSelected(7, "i-1"), "a later failure retains last-known membership")
+	assert.True(t, c.tags.scopeUnknown(0))
+	assert.True(t, c.tags.scopeSelected(0, "i-1"), "a later failure retains last-known membership")
 }
 
 func TestRefreshTags_FailedGroupRetriesWithoutRefetchingHealthyGroup(t *testing.T) {
@@ -445,7 +445,6 @@ func TestRefreshTags_FailedGroupRetriesWithoutRefetchingHealthyGroup(t *testing.
 	configureExactRule(c, []string{"us-east-1", "us-west-2"}, []string{"ec2"})
 	setSingleTargetPlan(c, "000000000000", []string{"us-east-1", "us-west-2"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
 	for i := range c.plan.Scopes {
-		c.plan.Scopes[i].ID = i
 		c.plan.Scopes[i].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
 	}
 	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
@@ -466,6 +465,9 @@ func TestRefreshTags_FailedGroupRetriesWithoutRefetchingHealthyGroup(t *testing.
 	assert.False(t, c.tags.scopeUnknown(0))
 	assert.True(t, c.tags.scopeSelected(0, "i-east"))
 	assert.True(t, c.tags.scopeUnknown(1))
+	require.Len(t, c.tagFetchPlan, 2)
+	firstTopology := &c.tagFetchPlan[0]
+	c.tagFetchPlan[0].candidatesByProfile["ec2"]["topology-sentinel"] = struct{}{}
 
 	healthy.err = errors.New("healthy group must not be called before its TTL")
 	c.refreshTags(context.Background())
@@ -474,6 +476,8 @@ func TestRefreshTags_FailedGroupRetriesWithoutRefetchingHealthyGroup(t *testing.
 	assert.Equal(t, 2, failing.calls, "the failed group retries on the next collect")
 	assert.False(t, c.tags.scopeUnknown(0), "an unnecessary retry must not turn fresh membership unknown")
 	assert.True(t, c.tags.scopeSelected(0, "i-east"))
+	assert.Same(t, firstTopology, &c.tagFetchPlan[0], "failed-group retry reuses discovery-derived topology")
+	assert.Contains(t, c.tagFetchPlan[0].candidatesByProfile["ec2"], "topology-sentinel")
 }
 
 func TestRefreshTags_FirstSuccessfulEmptySnapshotInvalidatesImplicitUnknown(t *testing.T) {
@@ -481,7 +485,6 @@ func TestRefreshTags_FirstSuccessfulEmptySnapshotInvalidatesImplicitUnknown(t *t
 	c := New()
 	configureExactRule(c, []string{"us-east-1"}, []string{"ec2"})
 	setSingleTargetPlan(c, "000000000000", []string{"us-east-1"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
-	c.plan.Scopes[0].ID = 7
 	c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
 	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
 		{Target: "base", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
@@ -494,7 +497,7 @@ func TestRefreshTags_FirstSuccessfulEmptySnapshotInvalidatesImplicitUnknown(t *t
 	c.refreshTags(context.Background())
 
 	assert.False(t, c.tags.fetchedAt.IsZero())
-	assert.False(t, c.tags.scopeUnknown(7))
+	assert.False(t, c.tags.scopeUnknown(0))
 	assert.True(t, c.planDirty, "known-empty membership must rebuild a plan previously compiled from implicit unknown state")
 }
 
@@ -505,7 +508,6 @@ func TestRefreshTags_LaterPageFailureIsAtomic(t *testing.T) {
 	c := New()
 	configureExactRule(c, []string{"us-east-1"}, []string{"ec2"})
 	setSingleTargetPlan(c, "000000000000", []string{"us-east-1"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
-	c.plan.Scopes[0].ID = 7
 	c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
 	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
 		{Target: "base", Profile: "ec2", Region: "us-east-1"}: {
@@ -517,8 +519,8 @@ func TestRefreshTags_LaterPageFailureIsAtomic(t *testing.T) {
 	c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
 
 	c.refreshTags(context.Background())
-	require.True(t, c.tags.scopeSelected(7, "i-1"))
-	require.False(t, c.tags.scopeUnknown(7))
+	require.True(t, c.tags.scopeSelected(0, "i-1"))
+	require.False(t, c.tags.scopeUnknown(0))
 
 	rgta.resources = []rgtatypes.ResourceTagMapping{
 		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-2", "environment", "production"),
@@ -527,9 +529,9 @@ func TestRefreshTags_LaterPageFailureIsAtomic(t *testing.T) {
 	c.markTagsStale()
 	c.refreshTags(context.Background())
 
-	assert.True(t, c.tags.scopeUnknown(7))
-	assert.True(t, c.tags.scopeSelected(7, "i-1"), "the prior complete snapshot is retained")
-	assert.False(t, c.tags.scopeSelected(7, "i-2"), "partial data from the failed refresh is discarded")
+	assert.True(t, c.tags.scopeUnknown(0))
+	assert.True(t, c.tags.scopeSelected(0, "i-1"), "the prior complete snapshot is retained")
+	assert.False(t, c.tags.scopeSelected(0, "i-2"), "partial data from the failed refresh is discarded")
 }
 
 func TestWalkResourceTags_PaginatesAndUsesNativeFilters(t *testing.T) {
@@ -572,7 +574,7 @@ func TestTagFetchGroups_SeparateFetchIdentityFromPolicyScopes(t *testing.T) {
 		}}
 		c.tagLabelPlans = map[string][]resolvedTag{}
 
-		groups := c.tagFetchGroups()
+		groups := c.currentTagFetchPlan()
 		require.Len(t, groups, 1)
 		assert.ElementsMatch(t, []string{"ec2:instance", "ec2:volume"}, groups[0].resourceTypes)
 		assert.Len(t, groups[0].joins, 2)
@@ -591,10 +593,15 @@ func TestTagFetchGroups_SeparateFetchIdentityFromPolicyScopes(t *testing.T) {
 		}}
 		c.tagLabelPlans = map[string][]resolvedTag{}
 
-		groups := c.tagFetchGroups()
+		groups := c.currentTagFetchPlan()
 		require.Len(t, groups, 4)
 		for _, group := range groups {
 			assert.Len(t, group.scopeIDsByProfile["ec2"], 1)
+		}
+		groups[0].candidatesByProfile["ec2"]["shared-sentinel"] = struct{}{}
+		for _, group := range groups[1:] {
+			assert.Contains(t, group.candidatesByProfile["ec2"], "shared-sentinel",
+				"predicate groups must share one discovery-derived candidate index")
 		}
 	})
 }
@@ -739,13 +746,13 @@ func TestMergeTagGroupSnapshots_RetainsIndependentGroupState(t *testing.T) {
 	}
 	states := map[tagFetchKey]tagGroupSnapshot{
 		failedGroup.key: {
-			group: failedGroup, members: tagMembership{7: {"i-1": {}}},
+			scopeIDs: []int{7}, members: tagMembership{7: {"i-1": {}}},
 			labels:          map[tagCacheKey][]metrix.Label{matching: {{Key: "owner", Value: "one"}}},
 			confirmedLabels: map[tagCacheKey]struct{}{matching: {}},
 			lastSuccess:     now.Add(-time.Minute), unknown: true,
 		},
 		healthyGroup.key: {
-			group: healthyGroup, members: tagMembership{8: {"i-2": {}}},
+			scopeIDs: []int{8}, members: tagMembership{8: {"i-2": {}}},
 			labels:          map[tagCacheKey][]metrix.Label{healthy: {{Key: "owner", Value: "two"}}},
 			confirmedLabels: map[tagCacheKey]struct{}{healthy: {}},
 			lastSuccess:     now, expiresAt: now.Add(time.Minute),
@@ -770,7 +777,7 @@ func BenchmarkMergeTagGroupSnapshots(b *testing.B) {
 		candidatesByProfile: map[string]map[string]struct{}{"ec2": make(map[string]struct{}, cachedTags)},
 	}
 	state := tagGroupSnapshot{
-		group: group, members: tagMembership{7: make(map[string]struct{}, cachedTags)},
+		scopeIDs: []int{7}, members: tagMembership{7: make(map[string]struct{}, cachedTags)},
 		labels:          make(map[tagCacheKey][]metrix.Label, cachedTags),
 		confirmedLabels: make(map[tagCacheKey]struct{}, cachedTags), unknown: true,
 	}
@@ -888,6 +895,52 @@ func BenchmarkRefreshTagsPolicyCount(b *testing.B) {
 			b.StopTimer()
 			if got := len(c.tags.members); got != policies {
 				b.Fatalf("got %d policy membership sets, want %d", got, policies)
+			}
+		})
+	}
+}
+
+func BenchmarkRefreshTagsFailedGroupRetry(b *testing.B) {
+	regions := []string{"ap-southeast-1", "eu-west-1", "us-east-1", "us-west-2"}
+	for _, candidates := range []int{100, 10000} {
+		b.Run(fmt.Sprintf("candidates_per_group=%d", candidates), func(b *testing.B) {
+			c := New()
+			c.Logger = logger.NewWithWriter(io.Discard)
+			configureExactRule(c, regions, []string{"ec2"})
+			setSingleTargetPlan(c, "000000000000", regions, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
+			for i := range c.plan.Scopes {
+				c.plan.Scopes[i].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
+			}
+			instances := make([]discoveredInstance, candidates)
+			for i := range instances {
+				instances[i] = discoveredInstance{DimensionValues: []string{fmt.Sprintf("i-%d", i)}}
+			}
+			c.discovery = discoverySnapshot{Instances: make(map[discoveryKey][]discoveredInstance)}
+			clients := make(map[string]*fakeRGTA, len(regions))
+			for _, region := range regions {
+				c.discovery.Instances[discoveryKey{Target: "base", Profile: "ec2", Region: region}] = instances
+				clients[region] = &fakeRGTA{}
+			}
+			clients["us-west-2"].err = errors.New("throttled")
+			c.rgtaClients = newClientCache(func(_ context.Context, _, region string) (rgtaClient, error) {
+				return clients[region], nil
+			})
+			c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
+			c.refreshTags(context.Background())
+			if len(c.tagFetchPlan) != len(regions) {
+				b.Fatalf("got %d topology groups, want %d", len(c.tagFetchPlan), len(regions))
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				c.refreshTags(context.Background())
+			}
+			b.StopTimer()
+			for _, region := range regions[:len(regions)-1] {
+				if clients[region].calls != 1 {
+					b.Fatalf("healthy region %s called %d times, want 1", region, clients[region].calls)
+				}
 			}
 		})
 	}

--- a/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
@@ -27,18 +27,32 @@ import (
 // fakeRGTA is a Resource Groups Tagging API stub returning canned resources, or an
 // error when err is set. calls counts GetResources invocations across pages/cycles.
 type fakeRGTA struct {
-	resources  []rgtatypes.ResourceTagMapping   // single page (used when pages is nil)
-	pages      [][]rgtatypes.ResourceTagMapping // multi-page: call N returns page N, with a token until the last
-	err        error
-	calls      int
-	gotFilters []string // ResourceTypeFilters seen on the most recent request
+	resources   []rgtatypes.ResourceTagMapping   // single page (used when pages is nil)
+	pages       [][]rgtatypes.ResourceTagMapping // multi-page: call N returns page N, with a token until the last
+	err         error
+	pageErr     error // returned after the first page when a pagination token is present
+	calls       int
+	gotFilters  []string // ResourceTypeFilters seen on the most recent request
+	gotTags     []rgtatypes.TagFilter
+	gotPageSize int32
 }
 
 func (f *fakeRGTA) GetResources(_ context.Context, in *resourcegroupstaggingapi.GetResourcesInput, _ ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
 	f.calls++
 	f.gotFilters = in.ResourceTypeFilters
+	f.gotTags = in.TagFilters
+	f.gotPageSize = aws.ToInt32(in.ResourcesPerPage)
 	if f.err != nil {
 		return nil, f.err
+	}
+	if f.pageErr != nil {
+		if in.PaginationToken != nil {
+			return nil, f.pageErr
+		}
+		return &resourcegroupstaggingapi.GetResourcesOutput{
+			ResourceTagMappingList: f.resources,
+			PaginationToken:        aws.String("next"),
+		}, nil
 	}
 	if f.pages != nil {
 		idx := f.calls - 1
@@ -84,10 +98,10 @@ func seriesLabels(t *testing.T, c *Collector, namePrefix string) map[string]stri
 
 // ec2TagCollector wires the end-to-end EC2 collector with a fake RGTA client and the
 // given tag allowlist. The instance is i-1 in account 000000000000, region us-east-1.
-func ec2TagCollector(t *testing.T, tags []TagConfig, rgta rgtaClient) *Collector {
+func ec2TagCollector(t *testing.T, tags []ResourceTagLabelConfig, rgta rgtaClient) *Collector {
 	t.Helper()
 	c, _ := endToEndCollector(10)
-	c.Config.Tags = tags
+	c.Config.Labels.ResourceTags = tags
 	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
 	c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
 	return c
@@ -95,12 +109,12 @@ func ec2TagCollector(t *testing.T, tags []TagConfig, rgta rgtaClient) *Collector
 
 func TestCollect_TagEnrichment(t *testing.T) {
 	tests := map[string]struct {
-		tags  []TagConfig
+		tags  []ResourceTagLabelConfig
 		rgta  *fakeRGTA
 		check func(t *testing.T, labels map[string]string)
 	}{
 		"attaches allowlisted tags as non-identity labels (with rename)": {
-			tags: []TagConfig{{Name: "owner"}, {Name: "team", Rename: "squad"}},
+			tags: []ResourceTagLabelConfig{{Key: "owner"}, {Key: "team", Label: "squad"}},
 			rgta: &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
 				rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "alice", "team", "sre"),
 			}},
@@ -113,8 +127,8 @@ func TestCollect_TagEnrichment(t *testing.T) {
 				assert.Equal(t, "us-east-1", labels["region"])
 			},
 		},
-		"INV.2: an untagged instance still collects, without tag labels": {
-			tags: []TagConfig{{Name: "owner"}},
+		"an untagged instance still collects when tags are labels only": {
+			tags: []ResourceTagLabelConfig{{Key: "owner"}},
 			rgta: &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
 				rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-999", "owner", "bob"),
 			}},
@@ -124,8 +138,8 @@ func TestCollect_TagEnrichment(t *testing.T) {
 				assert.False(t, ok, "no tag label for an untagged instance")
 			},
 		},
-		"INV.2: an RGTA failure leaves the series (no tags, no panic)": {
-			tags: []TagConfig{{Name: "owner"}},
+		"a labels-only RGTA failure leaves the series": {
+			tags: []ResourceTagLabelConfig{{Key: "owner"}},
 			rgta: &fakeRGTA{err: errors.New("access denied")},
 			check: func(t *testing.T, labels map[string]string) {
 				assert.Equal(t, "i-1", labels["instance_id"], "series survives an RGTA failure")
@@ -134,7 +148,7 @@ func TestCollect_TagEnrichment(t *testing.T) {
 			},
 		},
 		"a tag colliding with a reserved label is skipped, not overwriting it": {
-			tags: []TagConfig{{Name: "region"}, {Name: "owner"}},
+			tags: []ResourceTagLabelConfig{{Key: "region"}, {Key: "owner"}},
 			rgta: &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
 				rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "region", "bogus", "owner", "alice"),
 			}},
@@ -161,7 +175,7 @@ func TestCollect_TagRetentionReEmitCarriesTags(t *testing.T) {
 	rgta := &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
 		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "alice"),
 	}}
-	c := ec2TagCollector(t, []TagConfig{{Name: "owner"}}, rgta)
+	c := ec2TagCollector(t, []ResourceTagLabelConfig{{Key: "owner"}}, rgta)
 	base := time.Unix(1_000_000_000, 0)
 
 	// Cycle 1: queried + tagged.
@@ -178,6 +192,48 @@ func TestCollect_TagRetentionReEmitCarriesTags(t *testing.T) {
 		"re-emitted (not-due) series keeps its tag labels")
 }
 
+func TestCollect_TagLabelAddChangeRemoveUpdatesExistingSeries(t *testing.T) {
+	rgta := &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "environment", "production"),
+	}}
+	c := ec2TagCollector(t, []ResourceTagLabelConfig{{Key: "owner"}}, rgta)
+	base := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return base }
+
+	_, err := collecttest.CollectScalarSeries(c)
+	require.NoError(t, err)
+	_, hasOwner := seriesLabels(t, c, "ec2.cpu_utilization_average")["owner"]
+	assert.False(t, hasOwner)
+
+	rgta.resources = []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "environment", "production", "owner", "alice"),
+	}
+	c.markTagsStale()
+	c.now = func() time.Time { return base.Add(60 * time.Second) }
+	_, err = collecttest.CollectScalarSeries(c)
+	require.NoError(t, err)
+	assert.Equal(t, "alice", seriesLabels(t, c, "ec2.cpu_utilization_average")["owner"])
+
+	rgta.resources = []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "environment", "production", "owner", "bob"),
+	}
+	c.markTagsStale()
+	c.now = func() time.Time { return base.Add(120 * time.Second) }
+	_, err = collecttest.CollectScalarSeries(c)
+	require.NoError(t, err)
+	assert.Equal(t, "bob", seriesLabels(t, c, "ec2.cpu_utilization_average")["owner"])
+
+	rgta.resources = []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "environment", "production"),
+	}
+	c.markTagsStale()
+	c.now = func() time.Time { return base.Add(180 * time.Second) }
+	_, err = collecttest.CollectScalarSeries(c)
+	require.NoError(t, err)
+	_, hasOwner = seriesLabels(t, c, "ec2.cpu_utilization_average")["owner"]
+	assert.False(t, hasOwner, "removing an AWS tag removes the non-identity label without recreating the series")
+}
+
 func TestRefreshTags_FirstFailureNoneThenSuccessThenCarryForward(t *testing.T) {
 	rgta := &fakeRGTA{
 		err: errors.New("throttled"),
@@ -187,12 +243,15 @@ func TestRefreshTags_FirstFailureNoneThenSuccessThenCarryForward(t *testing.T) {
 	}
 	c := New()
 	configureExactRule(c, []string{"us-east-1"}, []string{"ec2"})
-	c.Config.Tags = []TagConfig{{Name: "owner"}}
+	c.Config.Labels.ResourceTags = []ResourceTagLabelConfig{{Key: "owner"}}
 	setSingleTargetPlan(c, "000000000000", []string{"us-east-1"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
+	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+		{Target: "base", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
+	}}
 	c.newAWSConfig = func(context.Context, awsauth.Identity, string) (aws.Config, error) { return aws.Config{}, nil }
 	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
-	c.computeTagPlans()
-	require.NotEmpty(t, c.tagPlans, "owner resolves to a plan for ec2")
+	c.computeTagLabelPlans()
+	require.NotEmpty(t, c.tagLabelPlans, "owner resolves to a plan for ec2")
 
 	key := tagCacheKey{target: "base", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-1"}
 	base := time.Unix(1_000_000_000, 0)
@@ -218,25 +277,130 @@ func TestRefreshTags_FirstFailureNoneThenSuccessThenCarryForward(t *testing.T) {
 		"a later RGTA failure keeps the last-known tags")
 }
 
-func TestGetAllResources_PaginatesAndFiltersByType(t *testing.T) {
+func TestRefreshTags_FilterMembershipFailureLifecycle(t *testing.T) {
+	rgta := &fakeRGTA{
+		err: errors.New("throttled"),
+		resources: []rgtatypes.ResourceTagMapping{
+			rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "environment", "production"),
+		},
+	}
+	c := New()
+	configureExactRule(c, []string{"us-east-1"}, []string{"ec2"})
+	setSingleTargetPlan(c, "000000000000", []string{"us-east-1"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
+	c.plan.Scopes[0].ID = 7
+	c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
+	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+		{Target: "base", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
+	}}
+	c.newAWSConfig = func(context.Context, awsauth.Identity, string) (aws.Config, error) { return aws.Config{}, nil }
+	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
+	base := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return base }
+
+	c.refreshTags(context.Background())
+	assert.True(t, c.tags.scopeUnknown(7), "a first failure is unknown")
+	assert.False(t, c.tags.scopeSelected(7, "i-1"))
+	assert.True(t, c.tags.expired(base), "a failed group retries next collect")
+
+	rgta.err = nil
+	c.refreshTags(context.Background())
+	assert.False(t, c.tags.scopeUnknown(7))
+	assert.True(t, c.tags.scopeSelected(7, "i-1"))
+	assert.False(t, c.tags.expired(base), "a successful refresh advances the TTL")
+	require.Len(t, rgta.gotTags, 1)
+	assert.Equal(t, "environment", aws.ToString(rgta.gotTags[0].Key))
+	assert.Equal(t, []string{"production"}, rgta.gotTags[0].Values)
+
+	rgta.err = errors.New("throttled again")
+	c.markTagsStale()
+	c.refreshTags(context.Background())
+	assert.True(t, c.tags.scopeUnknown(7))
+	assert.True(t, c.tags.scopeSelected(7, "i-1"), "a later failure retains last-known membership")
+}
+
+func TestRefreshTags_FirstSuccessfulEmptySnapshotInvalidatesImplicitUnknown(t *testing.T) {
+	rgta := &fakeRGTA{}
+	c := New()
+	configureExactRule(c, []string{"us-east-1"}, []string{"ec2"})
+	setSingleTargetPlan(c, "000000000000", []string{"us-east-1"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
+	c.plan.Scopes[0].ID = 7
+	c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
+	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+		{Target: "base", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
+	}}
+	c.newAWSConfig = func(context.Context, awsauth.Identity, string) (aws.Config, error) { return aws.Config{}, nil }
+	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
+	c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
+	c.planDirty = false
+
+	c.refreshTags(context.Background())
+
+	assert.False(t, c.tags.fetchedAt.IsZero())
+	assert.False(t, c.tags.scopeUnknown(7))
+	assert.True(t, c.planDirty, "known-empty membership must rebuild a plan previously compiled from implicit unknown state")
+}
+
+func TestRefreshTags_LaterPageFailureIsAtomic(t *testing.T) {
+	rgta := &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "environment", "production"),
+	}}
+	c := New()
+	configureExactRule(c, []string{"us-east-1"}, []string{"ec2"})
+	setSingleTargetPlan(c, "000000000000", []string{"us-east-1"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
+	c.plan.Scopes[0].ID = 7
+	c.plan.Scopes[0].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
+	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+		{Target: "base", Profile: "ec2", Region: "us-east-1"}: {
+			{DimensionValues: []string{"i-1"}}, {DimensionValues: []string{"i-2"}},
+		},
+	}}
+	c.newAWSConfig = func(context.Context, awsauth.Identity, string) (aws.Config, error) { return aws.Config{}, nil }
+	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
+	c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
+
+	c.refreshTags(context.Background())
+	require.True(t, c.tags.scopeSelected(7, "i-1"))
+	require.False(t, c.tags.scopeUnknown(7))
+
+	rgta.resources = []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-2", "environment", "production"),
+	}
+	rgta.pageErr = errors.New("second page failed")
+	c.markTagsStale()
+	c.refreshTags(context.Background())
+
+	assert.True(t, c.tags.scopeUnknown(7))
+	assert.True(t, c.tags.scopeSelected(7, "i-1"), "the prior complete snapshot is retained")
+	assert.False(t, c.tags.scopeSelected(7, "i-2"), "partial data from the failed refresh is discarded")
+}
+
+func TestWalkResourceTags_PaginatesAndUsesNativeFilters(t *testing.T) {
 	fake := &fakeRGTA{pages: [][]rgtatypes.ResourceTagMapping{
 		{rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "a")},
 		{rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-2", "owner", "b")},
 	}}
 
-	got, err := getAllResources(context.Background(), fake, []string{"ec2:instance"}, 0)
+	var got []rgtatypes.ResourceTagMapping
+	err := walkResourceTags(context.Background(), fake, []string{"ec2:instance"}, []resourceTagFilter{
+		{key: "env", values: []string{"prod", "staging"}},
+	}, 0, func(resource rgtatypes.ResourceTagMapping) { got = append(got, resource) })
 	require.NoError(t, err)
 	assert.Len(t, got, 2, "both pages are fetched")
 	assert.Equal(t, 2, fake.calls, "the pagination token is followed")
 	assert.Equal(t, []string{"ec2:instance"}, fake.gotFilters, "ResourceTypeFilters is passed through to RGTA")
+	require.Equal(t, []rgtatypes.TagFilter{{Key: aws.String("env"), Values: []string{"prod", "staging"}}}, fake.gotTags)
+	assert.Equal(t, int32(100), fake.gotPageSize)
 }
 
 func tagUnitCollector(t *testing.T, rgta rgtaClient) *Collector {
 	t.Helper()
 	c := New()
 	configureExactRule(c, []string{"us-east-1"}, []string{"ec2"})
-	c.Config.Tags = []TagConfig{{Name: "owner"}}
+	c.Config.Labels.ResourceTags = []ResourceTagLabelConfig{{Key: "owner"}}
 	setSingleTargetPlan(c, "000000000000", []string{"us-east-1"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
+	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+		{Target: "base", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
+	}}
 	c.newAWSConfig = func(context.Context, awsauth.Identity, string) (aws.Config, error) { return aws.Config{}, nil }
 	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
 	return c
@@ -260,8 +424,10 @@ func TestRefreshTags_MarkStaleForcesRefetchWithinTTL(t *testing.T) {
 	require.Equal(t, 1, rgta.calls, "within the TTL there is no re-fetch")
 
 	c.markTagsStale()
+	c.planDirty = false
 	c.refreshTags(context.Background())
 	assert.Equal(t, 2, rgta.calls, "markTagsStale forces a re-fetch within the TTL")
+	assert.False(t, c.planDirty, "an unchanged effective snapshot does not rebuild the query plan")
 }
 
 func TestRefreshTags_CanceledContextDoesNotAdvanceTTL(t *testing.T) {
@@ -293,7 +459,7 @@ func TestRefreshTags_ReportsIndependentTargetFailures(t *testing.T) {
 	c := New()
 	c.Logger = logger.NewWithWriter(&logs)
 	c.Config = twoTargetConfig()
-	c.Config.Tags = []TagConfig{{Name: "owner"}}
+	c.Config.Labels.ResourceTags = []ResourceTagLabelConfig{{Key: "owner"}}
 	require.NoError(t, c.Init(context.Background()))
 	require.NoError(t, c.ensurePlan())
 	c.resolvedByRef = make(map[string]resolvedTarget)
@@ -301,6 +467,10 @@ func TestRefreshTags_ReportsIndependentTargetFailures(t *testing.T) {
 		resolved := resolvedTarget{target: target, accountID: "000000000000"}
 		c.resolvedByRef[target.Name] = resolved
 	}
+	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+		{Target: "first", Profile: "ec2", Region: "us-east-1"}:  {{DimensionValues: []string{"i-1"}}},
+		{Target: "second", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
+	}}
 	c.newAWSConfig = func(context.Context, awsauth.Identity, string) (aws.Config, error) { return aws.Config{}, nil }
 	c.newRGTAClient = func(aws.Config) rgtaClient { return failingRGTA{err: errors.New(sensitive)} }
 
@@ -312,73 +482,158 @@ func TestRefreshTags_ReportsIndependentTargetFailures(t *testing.T) {
 	assert.NotContains(t, logs.String(), sensitive)
 }
 
-func TestIndexResourceTags_SkipsForeignAccountRegion(t *testing.T) {
+func TestIndexFetchedResource_SkipsForeignAccountRegion(t *testing.T) {
 	// RGTA is queried per (account, region); a resource whose ARN names a different
 	// account or region must not be cached against the queried target.
-	joins := selectedTagJoins([]cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
-	rtIndex := resourceTypeIndex(joins)
 	plans := map[string][]resolvedTag{"ec2": {{awsKey: "owner", label: "owner"}}}
-	dst := map[tagCacheKey][]metrix.Label{}
+	members := tagMembership{}
+	labels := map[tagCacheKey][]metrix.Label{}
+	confirmed := map[tagCacheKey]struct{}{}
+	group := tagFetchGroup{
+		key: tagFetchKey{target: "base", region: "us-east-1"}, account: "000000000000",
+		profilesByResourceType: map[string][]string{"ec2:instance": {"ec2"}},
+		scopeIDsByProfile:      map[string][]int{"ec2": {7}},
+		tagKeys:                map[string]struct{}{"owner": {}},
+		candidatesByProfile: map[string]map[string]struct{}{"ec2": {
+			"i-ok": {}, "i-acct": {}, "i-region": {},
+		}},
+	}
 
 	resources := []rgtatypes.ResourceTagMapping{
 		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-ok", "owner", "a"),
 		rgtaResource("arn:aws:ec2:us-east-1:999999999999:instance/i-acct", "owner", "b"),   // wrong account
 		rgtaResource("arn:aws:ec2:eu-west-1:000000000000:instance/i-region", "owner", "c"), // wrong region
 	}
-	indexResourceTags(dst, "base", "000000000000", "us-east-1", resources, rtIndex, joins, plans)
+	for _, resource := range resources {
+		indexFetchedResource(members, labels, confirmed, group, resource, plans)
+	}
 
-	require.Len(t, dst, 1, "only the same-account, same-region resource is cached")
-	assert.Contains(t, dst, tagCacheKey{target: "base", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-ok"})
+	wantLabelKey := tagCacheKey{target: "base", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-ok"}
+	assert.Equal(t, tagMembership{7: {"i-ok": {}}}, members)
+	assert.Equal(t, map[tagCacheKey][]metrix.Label{wantLabelKey: {{Key: "owner", Value: "a"}}}, labels)
+	assert.Equal(t, map[tagCacheKey]struct{}{wantLabelKey: {}}, confirmed)
 }
 
-func TestCarryForwardFailedTags_CopiesOnlyFailedScopes(t *testing.T) {
-	matchingFirst := tagCacheKey{target: "first", region: "us-east-1", joinKey: "i-1"}
-	matchingSecond := tagCacheKey{target: "second", region: "eu-west-1", joinKey: "i-2"}
-	notFailed := tagCacheKey{target: "third", region: "us-east-1", joinKey: "i-3"}
-	previous := map[tagCacheKey][]metrix.Label{
-		matchingFirst:  {{Key: "owner", Value: "one"}},
-		matchingSecond: {{Key: "owner", Value: "two"}},
-		notFailed:      {{Key: "owner", Value: "three"}},
+func TestCarryForwardTagGroup_RetainsOnlyGroupState(t *testing.T) {
+	matching := tagCacheKey{target: "first", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-1"}
+	notFailed := tagCacheKey{target: "second", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-2"}
+	previous := tagSnapshot{
+		labels: map[tagCacheKey][]metrix.Label{
+			matching:  {{Key: "owner", Value: "one"}},
+			notFailed: {{Key: "owner", Value: "two"}},
+		},
+		members: tagMembership{7: {"i-1": {}}, 8: {"i-2": {}}},
 	}
-	failed := map[tagScopeKey]struct{}{
-		{target: "first", region: "us-east-1"}:  {},
-		{target: "second", region: "eu-west-1"}: {},
+	dst := tagSnapshot{labels: map[tagCacheKey][]metrix.Label{}, members: tagMembership{}, unknown: map[int]struct{}{}}
+	group := tagFetchGroup{
+		key: tagFetchKey{target: "first", region: "us-east-1"}, account: "000000000000",
+		scopeIDsByProfile:   map[string][]int{"ec2": {7}},
+		candidatesByProfile: map[string]map[string]struct{}{"ec2": {"i-1": {}}},
+		hasLabels:           true,
 	}
-	dst := make(map[tagCacheKey][]metrix.Label)
 
-	carryForwardFailedTags(dst, previous, failed)
+	carryForwardTagGroup(&dst, previous, group, nil)
 
-	assert.Equal(t, map[tagCacheKey][]metrix.Label{
-		matchingFirst:  previous[matchingFirst],
-		matchingSecond: previous[matchingSecond],
-	}, dst)
+	assert.Equal(t, map[tagCacheKey][]metrix.Label{matching: previous.labels[matching]}, dst.labels)
+	assert.Equal(t, tagMembership{7: {"i-1": {}}}, dst.members)
+	assert.Equal(t, map[int]struct{}{7: {}}, dst.unknown)
 }
 
 func BenchmarkCarryForwardTagsFailures(b *testing.B) {
-	const (
-		cachedTags = 8192
-		failures   = 64
-	)
-	c := New()
-	c.tags.labels = make(map[tagCacheKey][]metrix.Label, cachedTags)
-	for i := range cachedTags {
-		c.tags.labels[tagCacheKey{
-			target:  "target-" + strconv.Itoa(i%failures),
-			region:  "us-east-1",
-			joinKey: strconv.Itoa(i),
-		}] = nil
+	const cachedTags = 8192
+	previous := tagSnapshot{
+		labels:  make(map[tagCacheKey][]metrix.Label, cachedTags),
+		members: tagMembership{7: make(map[string]struct{}, cachedTags)},
 	}
-	failed := make(map[tagScopeKey]struct{}, failures)
-	for i := range failures {
-		failed[tagScopeKey{target: "target-" + strconv.Itoa(i), region: "us-east-1"}] = struct{}{}
+	group := tagFetchGroup{
+		key: tagFetchKey{target: "target", region: "us-east-1"}, account: "000000000000",
+		scopeIDsByProfile:   map[string][]int{"ec2": {7}},
+		candidatesByProfile: map[string]map[string]struct{}{"ec2": make(map[string]struct{}, cachedTags)},
+		hasLabels:           true,
+	}
+	for i := range cachedTags {
+		joinKey := strconv.Itoa(i)
+		previous.labels[tagCacheKey{
+			target: "target", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: joinKey,
+		}] = nil
+		previous.members.add(7, joinKey)
+		group.candidatesByProfile["ec2"][joinKey] = struct{}{}
 	}
 
 	b.ReportAllocs()
 	for range b.N {
-		dst := make(map[tagCacheKey][]metrix.Label, cachedTags)
-		carryForwardFailedTags(dst, c.tags.labels, failed)
-		if len(dst) != cachedTags {
-			b.Fatalf("carried forward %d tags, want %d", len(dst), cachedTags)
+		dst := tagSnapshot{
+			labels: make(map[tagCacheKey][]metrix.Label, cachedTags), members: make(tagMembership), unknown: make(map[int]struct{}),
 		}
+		carryForwardTagGroup(&dst, previous, group, nil)
+		if len(dst.labels) != cachedTags || len(dst.members[7]) != cachedTags {
+			b.Fatalf("carried forward %d labels and %d members, want %d", len(dst.labels), len(dst.members[7]), cachedTags)
+		}
+	}
+}
+
+func BenchmarkIndexFetchedResources(b *testing.B) {
+	for _, count := range []int{100, 1000, 10000} {
+		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			resources := make([]rgtatypes.ResourceTagMapping, count)
+			candidates := make(map[string]struct{}, count)
+			for i := range resources {
+				joinKey := "i-" + strconv.Itoa(i)
+				candidates[joinKey] = struct{}{}
+				resources[i] = rgtaResource(
+					"arn:aws:ec2:us-east-1:000000000000:instance/"+joinKey,
+					"environment", "production", "owner", "platform",
+				)
+			}
+			group := tagFetchGroup{
+				key: tagFetchKey{target: "base", region: "us-east-1"}, account: "000000000000",
+				filters:                []resourceTagFilter{{key: "environment", values: []string{"production"}}},
+				profilesByResourceType: map[string][]string{"ec2:instance": {"ec2"}},
+				scopeIDsByProfile:      map[string][]int{"ec2": {7}},
+				candidatesByProfile:    map[string]map[string]struct{}{"ec2": candidates},
+				tagKeys:                map[string]struct{}{"environment": {}, "owner": {}},
+			}
+			plans := map[string][]resolvedTag{"ec2": {{awsKey: "owner", label: "owner"}}}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				members := make(tagMembership)
+				labels := make(map[tagCacheKey][]metrix.Label)
+				confirmed := make(map[tagCacheKey]struct{})
+				for _, resource := range resources {
+					indexFetchedResource(members, labels, confirmed, group, resource, plans)
+				}
+				if len(members[7]) != count || len(labels) != count {
+					b.Fatalf("indexed %d members and %d labels, want %d", len(members[7]), len(labels), count)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkTagSnapshotSameEffective(b *testing.B) {
+	for _, count := range []int{100, 1000, 10000} {
+		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			left := tagSnapshot{labels: make(map[tagCacheKey][]metrix.Label, count), members: tagMembership{7: make(map[string]struct{}, count)}, unknown: map[int]struct{}{}}
+			right := tagSnapshot{labels: make(map[tagCacheKey][]metrix.Label, count), members: tagMembership{7: make(map[string]struct{}, count)}, unknown: map[int]struct{}{}}
+			for i := range count {
+				joinKey := strconv.Itoa(i)
+				key := tagCacheKey{target: "base", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: joinKey}
+				labels := []metrix.Label{{Key: "owner", Value: "platform"}}
+				left.labels[key] = labels
+				right.labels[key] = labels
+				left.members.add(7, joinKey)
+				right.members.add(7, joinKey)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if !left.sameEffective(right) {
+					b.Fatal("equal snapshots differ")
+				}
+			}
+		})
 	}
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
@@ -226,7 +226,7 @@ func TestCollect_ResourceTagFilteringFromPublicConfig(t *testing.T) {
 		{Name: "replacement", Credentials: "sdk_default"},
 		{Name: "fallback", Credentials: "sdk_default"},
 	}
-	cfg.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production"}}}
+	cfg.RuleDefaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production"}}}
 	cfg.Rules = []RuleConfig{
 		{
 			Name: "inherited", Targets: []string{"inherited"}, Regions: []string{"us-east-1"},

--- a/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/tags_test.go
@@ -6,11 +6,15 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	rgtatypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 
@@ -35,6 +39,33 @@ type fakeRGTA struct {
 	gotFilters  []string // ResourceTypeFilters seen on the most recent request
 	gotTags     []rgtatypes.TagFilter
 	gotPageSize int32
+}
+
+type recordingRGTA struct {
+	mu        sync.Mutex
+	resources []rgtatypes.ResourceTagMapping
+	inputs    []*resourcegroupstaggingapi.GetResourcesInput
+}
+
+type staticRGTA struct {
+	resources []rgtatypes.ResourceTagMapping
+}
+
+func (f staticRGTA) GetResources(context.Context, *resourcegroupstaggingapi.GetResourcesInput, ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	return &resourcegroupstaggingapi.GetResourcesOutput{ResourceTagMappingList: f.resources}, nil
+}
+
+func (f *recordingRGTA) GetResources(_ context.Context, in *resourcegroupstaggingapi.GetResourcesInput, _ ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	f.mu.Lock()
+	f.inputs = append(f.inputs, in)
+	f.mu.Unlock()
+	return &resourcegroupstaggingapi.GetResourcesOutput{ResourceTagMappingList: f.resources}, nil
+}
+
+func (f *recordingRGTA) requests() []*resourcegroupstaggingapi.GetResourcesInput {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.inputs)
 }
 
 func (f *fakeRGTA) GetResources(_ context.Context, in *resourcegroupstaggingapi.GetResourcesInput, _ ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
@@ -76,6 +107,21 @@ func rgtaResource(arn string, kv ...string) rgtatypes.ResourceTagMapping {
 	return m
 }
 
+func resourceTagPolicyConfig(count int) Config {
+	defaults := false
+	cfg := validBaseConfig()
+	cfg.Rules = nil
+	for i := range count {
+		filters := []ResourceTagFilterConfig{{Key: "policy", Values: []string{strconv.Itoa(i)}}}
+		cfg.Rules = append(cfg.Rules, RuleConfig{
+			Name: fmt.Sprintf("policy-%d", i), Targets: []string{"base"}, Regions: []string{"us-east-1"},
+			Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"ec2"}},
+			Filters:  &RuleFiltersConfig{ResourceTags: &filters},
+		})
+	}
+	return cfg
+}
+
 // seriesLabels returns the label set of the single emitted series whose name has the
 // given prefix (fails if not exactly one), read from the collector's metric store.
 func seriesLabels(t *testing.T, c *Collector, namePrefix string) map[string]string {
@@ -97,7 +143,7 @@ func seriesLabels(t *testing.T, c *Collector, namePrefix string) map[string]stri
 }
 
 // ec2TagCollector wires the end-to-end EC2 collector with a fake RGTA client and the
-// given tag allowlist. The instance is i-1 in account 000000000000, region us-east-1.
+// given resource-tag label config. The instance is i-1 in account 000000000000, region us-east-1.
 func ec2TagCollector(t *testing.T, tags []ResourceTagLabelConfig, rgta rgtaClient) *Collector {
 	t.Helper()
 	c, _ := endToEndCollector(10)
@@ -113,7 +159,7 @@ func TestCollect_TagEnrichment(t *testing.T) {
 		rgta  *fakeRGTA
 		check func(t *testing.T, labels map[string]string)
 	}{
-		"attaches allowlisted tags as non-identity labels (with rename)": {
+		"attaches selected tags as non-identity labels (with rename)": {
 			tags: []ResourceTagLabelConfig{{Key: "owner"}, {Key: "team", Label: "squad"}},
 			rgta: &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
 				rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-1", "owner", "alice", "team", "sre"),
@@ -167,6 +213,78 @@ func TestCollect_TagEnrichment(t *testing.T) {
 			tc.check(t, seriesLabels(t, c, "ec2.cpu_utilization_average"))
 		})
 	}
+}
+
+func TestCollect_ResourceTagFilteringFromPublicConfig(t *testing.T) {
+	defaults := false
+	replacement := []ResourceTagFilterConfig{{Key: "owner", Values: []string{"platform"}}}
+	disabled := []ResourceTagFilterConfig{}
+	cfg := validBaseConfig()
+	cfg.Targets = []TargetConfig{
+		{Name: "inherited", Credentials: "sdk_default"},
+		{Name: "replacement", Credentials: "sdk_default"},
+		{Name: "fallback", Credentials: "sdk_default"},
+	}
+	cfg.Defaults.Filters.ResourceTags = []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production"}}}
+	cfg.Rules = []RuleConfig{
+		{
+			Name: "inherited", Targets: []string{"inherited"}, Regions: []string{"us-east-1"},
+			Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"ec2"}},
+		},
+		{
+			Name: "replacement", Targets: []string{"replacement"}, Regions: []string{"us-east-1"},
+			Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"ec2"}},
+			Filters:  &RuleFiltersConfig{ResourceTags: &replacement},
+		},
+		{
+			Name: "fallback", Targets: []string{"fallback"}, Regions: []string{"us-east-1"},
+			Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"ec2"}},
+			Filters:  &RuleFiltersConfig{ResourceTags: &disabled},
+		},
+	}
+
+	cw := &nsCloudWatch{byNS: map[string][]cwtypes.Metric{"AWS/EC2": {
+		mkMetric("CPUUtilization", "InstanceId", "i-prod"),
+		mkMetric("CPUUtilization", "InstanceId", "i-owner"),
+		mkMetric("CPUUtilization", "InstanceId", "i-other"),
+	}}}
+	rgta := &recordingRGTA{resources: []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-prod", "environment", "production"),
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-owner", "owner", "platform"),
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-other", "environment", "development"),
+	}}
+	c := New()
+	c.Config = cfg
+	c.newCatalog = cwprofiles.DefaultCatalog
+	c.newAWSConfig = func(_ context.Context, _ awsauth.Identity, region string) (aws.Config, error) {
+		return aws.Config{Region: region}, nil
+	}
+	c.newSTSClient = func(aws.Config) stsClient { return &fakeSTS{account: "000000000000"} }
+	c.newCloudWatchClient = func(aws.Config) cloudwatchClient { return cw }
+	c.newRGTAClient = func(aws.Config) rgtaClient { return rgta }
+	c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
+
+	require.NoError(t, c.Init(context.Background()))
+	require.NoError(t, c.Collect(context.Background()))
+	require.Len(t, c.plan.Scopes, 3)
+	assert.Equal(t, "environment", c.plan.Scopes[0].TagFilter[0].key, "omitted rule filter inherits the job default")
+	assert.Equal(t, "owner", c.plan.Scopes[1].TagFilter[0].key, "present rule filter replaces the job default")
+	assert.Empty(t, c.plan.Scopes[2].TagFilter, "an explicit empty rule filter disables the job default")
+	assert.Equal(t, map[string]string{
+		"i-prod": "inherited", "i-owner": "replacement", "i-other": "fallback",
+	}, queryOwnersByInstance(c.queryPlan))
+
+	requests := rgta.requests()
+	require.Len(t, requests, 2, "the unfiltered fallback rule does not make an RGTA request")
+	gotFilters := make(map[string][]string)
+	for _, request := range requests {
+		require.Len(t, request.TagFilters, 1)
+		gotFilters[aws.ToString(request.TagFilters[0].Key)] = request.TagFilters[0].Values
+		assert.Equal(t, []string{"ec2:instance"}, request.ResourceTypeFilters)
+	}
+	assert.Equal(t, map[string][]string{
+		"environment": {"production"}, "owner": {"platform"},
+	}, gotFilters)
 }
 
 func TestCollect_TagRetentionReEmitCarriesTags(t *testing.T) {
@@ -318,6 +436,46 @@ func TestRefreshTags_FilterMembershipFailureLifecycle(t *testing.T) {
 	assert.True(t, c.tags.scopeSelected(7, "i-1"), "a later failure retains last-known membership")
 }
 
+func TestRefreshTags_FailedGroupRetriesWithoutRefetchingHealthyGroup(t *testing.T) {
+	healthy := &fakeRGTA{resources: []rgtatypes.ResourceTagMapping{
+		rgtaResource("arn:aws:ec2:us-east-1:000000000000:instance/i-east", "environment", "production"),
+	}}
+	failing := &fakeRGTA{err: errors.New("throttled")}
+	c := New()
+	configureExactRule(c, []string{"us-east-1", "us-west-2"}, []string{"ec2"})
+	setSingleTargetPlan(c, "000000000000", []string{"us-east-1", "us-west-2"}, []cwprofiles.ResolvedProfile{{Name: "ec2", Config: ec2QueryProfile()}})
+	for i := range c.plan.Scopes {
+		c.plan.Scopes[i].ID = i
+		c.plan.Scopes[i].TagFilter = []resourceTagFilter{{key: "environment", values: []string{"production"}}}
+	}
+	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+		{Target: "base", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-east"}}},
+		{Target: "base", Profile: "ec2", Region: "us-west-2"}: {{DimensionValues: []string{"i-west"}}},
+	}}
+	c.rgtaClients = newClientCache(func(_ context.Context, _, region string) (rgtaClient, error) {
+		if region == "us-east-1" {
+			return healthy, nil
+		}
+		return failing, nil
+	})
+	c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
+
+	c.refreshTags(context.Background())
+	require.Equal(t, 1, healthy.calls)
+	require.Equal(t, 1, failing.calls)
+	assert.False(t, c.tags.scopeUnknown(0))
+	assert.True(t, c.tags.scopeSelected(0, "i-east"))
+	assert.True(t, c.tags.scopeUnknown(1))
+
+	healthy.err = errors.New("healthy group must not be called before its TTL")
+	c.refreshTags(context.Background())
+
+	assert.Equal(t, 1, healthy.calls, "a healthy group remains cached until its own TTL")
+	assert.Equal(t, 2, failing.calls, "the failed group retries on the next collect")
+	assert.False(t, c.tags.scopeUnknown(0), "an unnecessary retry must not turn fresh membership unknown")
+	assert.True(t, c.tags.scopeSelected(0, "i-east"))
+}
+
 func TestRefreshTags_FirstSuccessfulEmptySnapshotInvalidatesImplicitUnknown(t *testing.T) {
 	rgta := &fakeRGTA{}
 	c := New()
@@ -390,6 +548,55 @@ func TestWalkResourceTags_PaginatesAndUsesNativeFilters(t *testing.T) {
 	assert.Equal(t, []string{"ec2:instance"}, fake.gotFilters, "ResourceTypeFilters is passed through to RGTA")
 	require.Equal(t, []rgtatypes.TagFilter{{Key: aws.String("env"), Values: []string{"prod", "staging"}}}, fake.gotTags)
 	assert.Equal(t, int32(100), fake.gotPageSize)
+}
+
+func TestTagFetchGroups_SeparateFetchIdentityFromPolicyScopes(t *testing.T) {
+	catalog, err := cwprofiles.DefaultCatalog()
+	require.NoError(t, err)
+
+	t.Run("same predicate shares one fetch across profiles", func(t *testing.T) {
+		defaults := false
+		filters := []ResourceTagFilterConfig{{Key: "environment", Values: []string{"production"}}}
+		cfg := validBaseConfig()
+		cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"ec2", "ebs"}}
+		cfg.Rules[0].Filters = &RuleFiltersConfig{ResourceTags: &filters}
+		cfg.applyDefaults()
+		plan, _, err := compileConfig(cfg, catalog)
+		require.NoError(t, err)
+		c := New()
+		c.plan = plan
+		c.resolvedByRef = map[string]resolvedTarget{"base": {target: plan.Targets[0], accountID: "000000000000"}}
+		c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+			{Target: "base", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
+			{Target: "base", Profile: "ebs", Region: "us-east-1"}: {{DimensionValues: []string{"vol-1"}}},
+		}}
+		c.tagLabelPlans = map[string][]resolvedTag{}
+
+		groups := c.tagFetchGroups()
+		require.Len(t, groups, 1)
+		assert.ElementsMatch(t, []string{"ec2:instance", "ec2:volume"}, groups[0].resourceTypes)
+		assert.Len(t, groups[0].joins, 2)
+	})
+
+	t.Run("different predicates remain separate", func(t *testing.T) {
+		cfg := resourceTagPolicyConfig(4)
+		cfg.applyDefaults()
+		plan, _, err := compileConfig(cfg, catalog)
+		require.NoError(t, err)
+		c := New()
+		c.plan = plan
+		c.resolvedByRef = map[string]resolvedTarget{"base": {target: plan.Targets[0], accountID: "000000000000"}}
+		c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+			{Target: "base", Profile: "ec2", Region: "us-east-1"}: {{DimensionValues: []string{"i-1"}}},
+		}}
+		c.tagLabelPlans = map[string][]resolvedTag{}
+
+		groups := c.tagFetchGroups()
+		require.Len(t, groups, 4)
+		for _, group := range groups {
+			assert.Len(t, group.scopeIDsByProfile["ec2"], 1)
+		}
+	})
 }
 
 func tagUnitCollector(t *testing.T, rgta rgtaClient) *Collector {
@@ -489,8 +696,11 @@ func TestIndexFetchedResource_SkipsForeignAccountRegion(t *testing.T) {
 	members := tagMembership{}
 	labels := map[tagCacheKey][]metrix.Label{}
 	confirmed := map[tagCacheKey]struct{}{}
+	join, err := resolveTagJoinProfile(cwprofiles.ResolvedProfile{Name: "ec2", Config: ec2QueryProfile()})
+	require.NoError(t, err)
 	group := tagFetchGroup{
 		key: tagFetchKey{target: "base", region: "us-east-1"}, account: "000000000000",
+		joins:                  map[string]*tagJoin{"ec2": join},
 		profilesByResourceType: map[string][]string{"ec2:instance": {"ec2"}},
 		scopeIDsByProfile:      map[string][]int{"ec2": {7}},
 		tagKeys:                map[string]struct{}{"owner": {}},
@@ -514,60 +724,73 @@ func TestIndexFetchedResource_SkipsForeignAccountRegion(t *testing.T) {
 	assert.Equal(t, map[tagCacheKey]struct{}{wantLabelKey: {}}, confirmed)
 }
 
-func TestCarryForwardTagGroup_RetainsOnlyGroupState(t *testing.T) {
+func TestMergeTagGroupSnapshots_RetainsIndependentGroupState(t *testing.T) {
 	matching := tagCacheKey{target: "first", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-1"}
-	notFailed := tagCacheKey{target: "second", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-2"}
-	previous := tagSnapshot{
-		labels: map[tagCacheKey][]metrix.Label{
-			matching:  {{Key: "owner", Value: "one"}},
-			notFailed: {{Key: "owner", Value: "two"}},
-		},
-		members: tagMembership{7: {"i-1": {}}, 8: {"i-2": {}}},
-	}
-	dst := tagSnapshot{labels: map[tagCacheKey][]metrix.Label{}, members: tagMembership{}, unknown: map[int]struct{}{}}
-	group := tagFetchGroup{
+	healthy := tagCacheKey{target: "second", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: "i-2"}
+	now := time.Unix(1_000_000_000, 0)
+	failedGroup := tagFetchGroup{
 		key: tagFetchKey{target: "first", region: "us-east-1"}, account: "000000000000",
 		scopeIDsByProfile:   map[string][]int{"ec2": {7}},
 		candidatesByProfile: map[string]map[string]struct{}{"ec2": {"i-1": {}}},
-		hasLabels:           true,
+	}
+	healthyGroup := tagFetchGroup{
+		key: tagFetchKey{target: "second", region: "us-east-1"}, account: "000000000000",
+		scopeIDsByProfile: map[string][]int{"ec2": {8}},
+	}
+	states := map[tagFetchKey]tagGroupSnapshot{
+		failedGroup.key: {
+			group: failedGroup, members: tagMembership{7: {"i-1": {}}},
+			labels:          map[tagCacheKey][]metrix.Label{matching: {{Key: "owner", Value: "one"}}},
+			confirmedLabels: map[tagCacheKey]struct{}{matching: {}},
+			lastSuccess:     now.Add(-time.Minute), unknown: true,
+		},
+		healthyGroup.key: {
+			group: healthyGroup, members: tagMembership{8: {"i-2": {}}},
+			labels:          map[tagCacheKey][]metrix.Label{healthy: {{Key: "owner", Value: "two"}}},
+			confirmedLabels: map[tagCacheKey]struct{}{healthy: {}},
+			lastSuccess:     now, expiresAt: now.Add(time.Minute),
+		},
 	}
 
-	carryForwardTagGroup(&dst, previous, group, nil)
+	got := mergeTagGroupSnapshots(states, now, now.Add(time.Minute))
 
-	assert.Equal(t, map[tagCacheKey][]metrix.Label{matching: previous.labels[matching]}, dst.labels)
-	assert.Equal(t, tagMembership{7: {"i-1": {}}}, dst.members)
-	assert.Equal(t, map[int]struct{}{7: {}}, dst.unknown)
+	assert.Equal(t, map[tagCacheKey][]metrix.Label{
+		matching: {{Key: "owner", Value: "one"}}, healthy: {{Key: "owner", Value: "two"}},
+	}, got.labels)
+	assert.Equal(t, tagMembership{7: {"i-1": {}}, 8: {"i-2": {}}}, got.members)
+	assert.Equal(t, map[int]struct{}{7: {}}, got.unknown)
+	assert.True(t, got.expiresAt.IsZero(), "the failed group remains due without expiring the healthy group's own state")
 }
 
-func BenchmarkCarryForwardTagsFailures(b *testing.B) {
+func BenchmarkMergeTagGroupSnapshots(b *testing.B) {
 	const cachedTags = 8192
-	previous := tagSnapshot{
-		labels:  make(map[tagCacheKey][]metrix.Label, cachedTags),
-		members: tagMembership{7: make(map[string]struct{}, cachedTags)},
-	}
 	group := tagFetchGroup{
 		key: tagFetchKey{target: "target", region: "us-east-1"}, account: "000000000000",
 		scopeIDsByProfile:   map[string][]int{"ec2": {7}},
 		candidatesByProfile: map[string]map[string]struct{}{"ec2": make(map[string]struct{}, cachedTags)},
-		hasLabels:           true,
+	}
+	state := tagGroupSnapshot{
+		group: group, members: tagMembership{7: make(map[string]struct{}, cachedTags)},
+		labels:          make(map[tagCacheKey][]metrix.Label, cachedTags),
+		confirmedLabels: make(map[tagCacheKey]struct{}, cachedTags), unknown: true,
 	}
 	for i := range cachedTags {
 		joinKey := strconv.Itoa(i)
-		previous.labels[tagCacheKey{
+		key := tagCacheKey{
 			target: "target", account: "000000000000", region: "us-east-1", profile: "ec2", joinKey: joinKey,
-		}] = nil
-		previous.members.add(7, joinKey)
+		}
+		state.labels[key] = nil
+		state.confirmedLabels[key] = struct{}{}
+		state.members.add(7, joinKey)
 		group.candidatesByProfile["ec2"][joinKey] = struct{}{}
 	}
+	states := map[tagFetchKey]tagGroupSnapshot{group.key: state}
 
 	b.ReportAllocs()
 	for range b.N {
-		dst := tagSnapshot{
-			labels: make(map[tagCacheKey][]metrix.Label, cachedTags), members: make(tagMembership), unknown: make(map[int]struct{}),
-		}
-		carryForwardTagGroup(&dst, previous, group, nil)
-		if len(dst.labels) != cachedTags || len(dst.members[7]) != cachedTags {
-			b.Fatalf("carried forward %d labels and %d members, want %d", len(dst.labels), len(dst.members[7]), cachedTags)
+		got := mergeTagGroupSnapshots(states, time.Time{}, time.Time{})
+		if len(got.labels) != cachedTags || len(got.members[7]) != cachedTags {
+			b.Fatalf("merged %d labels and %d members, want %d", len(got.labels), len(got.members[7]), cachedTags)
 		}
 	}
 }
@@ -575,6 +798,10 @@ func BenchmarkCarryForwardTagsFailures(b *testing.B) {
 func BenchmarkIndexFetchedResources(b *testing.B) {
 	for _, count := range []int{100, 1000, 10000} {
 		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			join, err := resolveTagJoinProfile(cwprofiles.ResolvedProfile{Name: "ec2", Config: ec2QueryProfile()})
+			if err != nil {
+				b.Fatal(err)
+			}
 			resources := make([]rgtatypes.ResourceTagMapping, count)
 			candidates := make(map[string]struct{}, count)
 			for i := range resources {
@@ -587,6 +814,7 @@ func BenchmarkIndexFetchedResources(b *testing.B) {
 			}
 			group := tagFetchGroup{
 				key: tagFetchKey{target: "base", region: "us-east-1"}, account: "000000000000",
+				joins:                  map[string]*tagJoin{"ec2": join},
 				filters:                []resourceTagFilter{{key: "environment", values: []string{"production"}}},
 				profilesByResourceType: map[string][]string{"ec2:instance": {"ec2"}},
 				scopeIDsByProfile:      map[string][]int{"ec2": {7}},
@@ -607,6 +835,59 @@ func BenchmarkIndexFetchedResources(b *testing.B) {
 				if len(members[7]) != count || len(labels) != count {
 					b.Fatalf("indexed %d members and %d labels, want %d", len(members[7]), len(labels), count)
 				}
+			}
+		})
+	}
+}
+
+func BenchmarkRefreshTagsPolicyCount(b *testing.B) {
+	const resources = 1000
+	catalog, err := cwprofiles.DefaultCatalog()
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, policies := range []int{1, 4} {
+		b.Run(fmt.Sprintf("policies=%d", policies), func(b *testing.B) {
+			cfg := resourceTagPolicyConfig(policies)
+			cfg.applyDefaults()
+			plan, _, err := compileConfig(cfg, catalog)
+			if err != nil {
+				b.Fatal(err)
+			}
+			mappings := make([]rgtatypes.ResourceTagMapping, resources)
+			instances := make([]discoveredInstance, resources)
+			for i := range resources {
+				id := fmt.Sprintf("i-%d", i)
+				instances[i] = discoveredInstance{DimensionValues: []string{id}}
+				mappings[i] = rgtaResource(
+					"arn:aws:ec2:us-east-1:000000000000:instance/"+id,
+					"policy", strconv.Itoa(i%policies),
+				)
+			}
+			c := New()
+			c.Config = cfg
+			c.plan = plan
+			c.resolvedByRef = map[string]resolvedTarget{
+				"base": {target: plan.Targets[0], accountID: "000000000000"},
+			}
+			c.discovery = discoverySnapshot{Instances: map[discoveryKey][]discoveredInstance{
+				{Target: "base", Profile: "ec2", Region: "us-east-1"}: instances,
+			}}
+			client := staticRGTA{resources: mappings}
+			c.rgtaClients = newClientCache(func(context.Context, string, string) (rgtaClient, error) {
+				return client, nil
+			})
+			c.now = func() time.Time { return time.Unix(1_000_000_000, 0) }
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				c.markTagsStale()
+				c.refreshTags(context.Background())
+			}
+			b.StopTimer()
+			if got := len(c.tags.members); got != policies {
+				b.Fatalf("got %d policy membership sets, want %d", got, policies)
 			}
 		})
 	}

--- a/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
+++ b/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
@@ -35,7 +35,7 @@
       "filters": {"resource_tags": [{"key": "environment", "values": ["production", "staging"]}]}
     }
   ],
-  "defaults": {"filters": {"resource_tags": [{"key": "managed-by", "values": ["platform"]}]}},
+  "rule_defaults": {"filters": {"resource_tags": [{"key": "managed-by", "values": ["platform"]}]}},
   "labels": {"resource_tags": [{"key": "owner", "label": "resource_owner"}]},
   "limits": {"max_instances": 123},
   "discovery": {"refresh_every": 123, "recently_active_only": true},

--- a/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
+++ b/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
@@ -3,7 +3,10 @@
   "update_every": 123,
   "autodetection_retry": 123,
   "credentials": [
-    {"name": "sdk_default", "type": "default"},
+    {
+      "name": "sdk_default",
+      "type": "default"
+    },
     {
       "name": "bootstrap",
       "type": "static",
@@ -15,7 +18,10 @@
     }
   ],
   "targets": [
-    {"name": "base", "credentials": "sdk_default"},
+    {
+      "name": "base",
+      "credentials": "sdk_default"
+    },
     {
       "name": "production",
       "credentials": "bootstrap",
@@ -26,19 +32,74 @@
     }
   ],
   "rules": [
-    {"name": "base-defaults", "targets": ["base"], "regions": ["us-east-1"]},
+    {
+      "name": "base-defaults",
+      "targets": [
+        "base"
+      ],
+      "regions": [
+        "us-east-1"
+      ]
+    },
     {
       "name": "production-services",
-      "targets": ["production"],
-      "profiles": {"defaults": false, "include": ["ec2", "rds"], "exclude": ["cloudfront"]},
-      "regions": ["us-east-1", "eu-west-1"],
-      "filters": {"resource_tags": [{"key": "environment", "values": ["production", "staging"]}]}
+      "targets": [
+        "production"
+      ],
+      "profiles": {
+        "defaults": false,
+        "include": [
+          "ec2",
+          "rds"
+        ],
+        "exclude": [
+          "cloudfront"
+        ]
+      },
+      "regions": [
+        "us-east-1",
+        "eu-west-1"
+      ],
+      "filters": {
+        "resource_tags": [
+          {
+            "key": "environment",
+            "values": [
+              "production",
+              "staging"
+            ]
+          }
+        ]
+      }
     }
   ],
-  "rule_defaults": {"filters": {"resource_tags": [{"key": "managed-by", "values": ["platform"]}]}},
-  "labels": {"resource_tags": [{"key": "owner", "label": "resource_owner"}]},
-  "limits": {"max_instances": 123},
-  "discovery": {"refresh_every": 123, "recently_active_only": true},
+  "rule_defaults": {
+    "filters": {
+      "resource_tags": [
+        {
+          "key": "managed-by",
+          "values": [
+            "platform"
+          ]
+        }
+      ]
+    }
+  },
+  "labels": {
+    "resource_tags": [
+      {
+        "key": "owner",
+        "label": "resource_owner"
+      }
+    ]
+  },
+  "limits": {
+    "max_instances": 123
+  },
+  "discovery": {
+    "refresh_every": 123,
+    "recently_active_only": true
+  },
   "query_offset": 123,
   "timeout": 123.123
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
+++ b/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
@@ -31,11 +31,14 @@
       "name": "production-services",
       "targets": ["production"],
       "profiles": {"defaults": false, "include": ["ec2", "rds"], "exclude": ["cloudfront"]},
-      "regions": ["us-east-1", "eu-west-1"]
+      "regions": ["us-east-1", "eu-west-1"],
+      "filters": {"resource_tags": [{"key": "environment", "values": ["production", "staging"]}]}
     }
   ],
+  "defaults": {"filters": {"resource_tags": [{"key": "managed-by", "values": ["platform"]}]}},
+  "labels": {"resource_tags": [{"key": "owner", "label": "resource_owner"}]},
+  "limits": {"max_instances": 123},
   "discovery": {"refresh_every": 123, "recently_active_only": true},
-  "tags": [{"name": "ok", "rename": "ok"}],
   "query_offset": 123,
   "timeout": 123.123
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/cloudwatch/testdata/config.yaml
@@ -33,7 +33,7 @@ rules:
       resource_tags:
         - key: environment
           values: [production, staging]
-defaults:
+rule_defaults:
   filters:
     resource_tags:
       - key: managed-by

--- a/src/go/plugin/go.d/collector/cloudwatch/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/cloudwatch/testdata/config.yaml
@@ -29,11 +29,23 @@ rules:
       include: [ec2, rds]
       exclude: [cloudfront]
     regions: [us-east-1, eu-west-1]
+    filters:
+      resource_tags:
+        - key: environment
+          values: [production, staging]
+defaults:
+  filters:
+    resource_tags:
+      - key: managed-by
+        values: [platform]
+labels:
+  resource_tags:
+    - key: owner
+      label: resource_owner
+limits:
+  max_instances: 123
 discovery:
   refresh_every: 123
   recently_active_only: true
-tags:
-  - name: "ok"
-    rename: "ok"
 query_offset: 123
 timeout: 123.123

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.conf
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.conf
@@ -20,7 +20,7 @@
 ##   credentials - named AWS SDK default-chain or static/session sources
 ##   targets     - up to 64 named monitored identities, optionally assuming one role
 ##   rules       - ordered target/profile/region selections
-##   defaults    - job-wide filters inherited by rules
+##   rule_defaults - job-wide filters inherited by rules
 ##   labels      - optional AWS tags copied to non-identity chart labels
 ##   limits      - final-instance safety bounds
 ##
@@ -29,7 +29,7 @@
 ## selects all default-enabled profiles.
 ## Set profiles.defaults to false and list profiles.include to select only named
 ## profiles. profiles.exclude removes profiles from the selected set.
-## A rule inherits defaults.filters.resource_tags when it omits
+## A rule inherits rule_defaults.filters.resource_tags when it omits
 ## filters.resource_tags. A non-empty rule list replaces the default; [] disables
 ## it. Tag keys and values are exact and case-sensitive. All keys are ANDed; values
 ## for one key are ORed.
@@ -88,7 +88,7 @@
 #    targets:
 #      - name: base
 #        credentials: sdk_default
-#    defaults:
+#    rule_defaults:
 #      filters:
 #        resource_tags:
 #          - key: managed-by

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.conf
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.conf
@@ -14,18 +14,25 @@
 ## The collector calls STS GetCallerIdentity for account attribution, but AWS
 ## does not require an explicit permission grant for that operation.
 ##   plus sts:AssumeRole for targets with assume_role
-##   plus tag:GetResources when tags are configured
+##   plus tag:GetResources when resource tag filters or labels are configured
 ##
 ## Configuration model:
 ##   credentials - named AWS SDK default-chain or static/session sources
 ##   targets     - up to 64 named monitored identities, optionally assuming one role
 ##   rules       - ordered target/profile/region selections
+##   defaults    - job-wide filters inherited by rules
+##   labels      - optional AWS tags copied to non-identity chart labels
+##   limits      - final-instance safety bounds
 ##
 ## Rule order, then target order within each rule, defines overlap ownership: the
-## first rule/target that produces a final metric series owns it. Omitting profiles
+## first matching rule/target owns the whole final resource instance. Omitting profiles
 ## selects all default-enabled profiles.
 ## Set profiles.defaults to false and list profiles.include to select only named
 ## profiles. profiles.exclude removes profiles from the selected set.
+## A rule inherits defaults.filters.resource_tags when it omits
+## filters.resource_tags. A non-empty rule list replaces the default; [] disables
+## it. Tag keys and values are exact and case-sensitive. All keys are ANDed; values
+## for one key are ORed.
 ##
 ## Secret fields support go.d secret references. Prefer ${env:...}, ${file:...},
 ## ${cmd:...}, or ${store:...}; do not put plaintext credentials in this file.
@@ -74,20 +81,35 @@
 #          include: [ec2, rds, lambda]
 #        regions: [us-east-1]
 #
-#  - name: with_tags
+#  - name: resource_tag_filtering_and_labels
 #    credentials:
 #      - name: sdk_default
 #        type: default
 #    targets:
 #      - name: base
 #        credentials: sdk_default
+#    defaults:
+#      filters:
+#        resource_tags:
+#          - key: managed-by
+#            values: [platform]
 #    rules:
-#      - name: base-defaults
+#      - name: production-defaults
 #        targets: [base]
 #        regions: [us-east-1]
-#    tags:
-#      - name: Name          # AWS Name tag -> label name
-#      - name: owner         # -> label owner
-#      - name: environment   # -> label environment
-#      - name: region        # rename collision with built-in region label
-#        rename: aws_region
+#      - name: unfiltered-cloudfront
+#        targets: [base]
+#        profiles:
+#          defaults: false
+#          include: [cloudfront]
+#        regions: [us-east-1]
+#        filters:
+#          resource_tags: []  # explicitly disable the inherited default
+#    labels:
+#      resource_tags:
+#        - key: Name                 # AWS Name tag -> label name
+#        - key: owner                # -> label owner
+#        - key: region               # avoid built-in region label collision
+#          label: aws_region
+#    limits:
+#      max_instances: 1000


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds resource tag filtering to the `go.d/cloudwatch` collector so you can select resources by exact AWS tags and optionally copy tag values into chart labels. This reduces noise and cost by only collecting from resources that match your policies.

- **New Features**
  - Rule- and job-level tag filters: `rules[].filters.resource_tags` with inheritance from `rule_defaults.filters.resource_tags`; set `[]` to disable per rule.
  - Exact, case-sensitive matching: keys are ANDed; values for the same key are ORed.
  - Tag-to-label mapping via `labels.resource_tags` (key → label) with stricter validation to avoid collisions and invalid names.
  - Efficient tag fetching via AWS Resource Groups Tagging API with per target/region/predicate dedup and a fail-soft, per-group cache.
  - Query plan integrates tag policies and enforces `limits.max_instances` (default 1000).
  - Updated docs, schema, examples, and tests.

- **Migration**
  - If you used `tags`, move to `labels.resource_tags`; provide an explicit valid `label` when the derived one would be invalid.
  - Add `tag:GetResources` to IAM when using resource tag filters or labels.
  - Set job-wide defaults in `rule_defaults.filters.resource_tags`; override in `rules[].filters.resource_tags`; use `[]` to disable the default for a rule.
  - Optionally tune `limits.max_instances` if you expect more than 1000 matching instances.

<sup>Written for commit 2bec9d628e14d21bc8df77a681cda923f2af03fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

