### PR TITLE
Fix UDP socket fallback when inet_diag handlers are missing

### DIFF
--- a/.github/workflows/topology-container-tests.yml
+++ b/.github/workflows/topology-container-tests.yml
@@ -10,6 +10,7 @@ on:
       - 'src/collectors/apps.plugin/**'
       - 'src/collectors/network-viewer.plugin/**'
       - 'src/collectors/common-cgroups/**'
+      - 'src/libnetdata/local-sockets/**'
       - 'src/libnetdata/netipc/**'
   pull_request:
     paths:
@@ -18,6 +19,7 @@ on:
       - 'src/collectors/apps.plugin/**'
       - 'src/collectors/network-viewer.plugin/**'
       - 'src/collectors/common-cgroups/**'
+      - 'src/libnetdata/local-sockets/**'
       - 'src/libnetdata/netipc/**'
 
 concurrency:
@@ -33,6 +35,7 @@ env:
     apps-cgroups-lookup-client-abort-test
     cgroup-lookup-netipc-test
     cgroup-orchestrator-test
+    local-sockets-mnl-test
     network-viewer-apps-lookup-client-test
     network-viewer-topology-containers-test
 
@@ -58,7 +61,7 @@ jobs:
             cmake ninja-build pkg-config flex bison g++ \
             libatomic1 libsystemd-dev libpcre2-dev libcurl4-openssl-dev \
             liblz4-dev libzstd-dev libuv1-dev libssl-dev libelf-dev \
-            libjson-c-dev libyaml-dev zlib1g-dev uuid-dev python3-jsonschema \
+            libjson-c-dev libyaml-dev libmnl-dev zlib1g-dev uuid-dev python3-jsonschema \
             libprotobuf-dev protobuf-compiler
 
       - name: Configure
@@ -117,7 +120,7 @@ jobs:
             cmake ninja-build pkg-config flex bison g++ \
             libatomic1 libsystemd-dev libpcre2-dev libcurl4-openssl-dev \
             liblz4-dev libzstd-dev libuv1-dev libssl-dev libelf-dev \
-            libjson-c-dev libyaml-dev zlib1g-dev uuid-dev \
+            libjson-c-dev libyaml-dev libmnl-dev zlib1g-dev uuid-dev \
             libprotobuf-dev protobuf-compiler
 
       - name: Configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3388,6 +3388,14 @@ if(ENABLE_PLUGIN_LOCAL_LISTENERS)
                 DESTINATION usr/libexec/netdata/plugins.d)
 endif()
 
+if(OS_LINUX AND MNL_FOUND)
+        add_executable(local-sockets-mnl-test EXCLUDE_FROM_ALL
+                src/libnetdata/local-sockets/tests/test_local_sockets_mnl.c)
+        target_compile_options(local-sockets-mnl-test PRIVATE ${MNL_CFLAGS_OTHER})
+        target_include_directories(local-sockets-mnl-test PRIVATE ${MNL_INCLUDE_DIRS})
+        target_link_libraries(local-sockets-mnl-test libnetdata ${MNL_LIBRARIES})
+endif()
+
 if(ENABLE_PLUGIN_NETWORK_VIEWER)
         if(USE_LTO AND CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_SIZEOF_VOID_P EQUAL 4)
                 # GCC still performs LTO when linking slim LTO static archives into a

--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -978,10 +978,16 @@ static inline int local_sockets_libmnl_cb_error(const struct nlmsghdr *nlh, void
 
 static inline int local_sockets_libmnl_cb_done(const struct nlmsghdr *nlh, void *data __maybe_unused) {
     int err;
+    size_t payload_len = mnl_nlmsg_get_payload_len(nlh);
 
     // Dump errors are carried in NLMSG_DONE, which libmnl's default callback ignores.
-    if(mnl_nlmsg_get_payload_len(nlh) < sizeof(err))
+    if(!payload_len)
         return MNL_CB_STOP;
+
+    if(payload_len < sizeof(err)) {
+        errno = EBADMSG;
+        return MNL_CB_ERROR;
+    }
 
     memcpy(&err, mnl_nlmsg_get_payload(nlh), sizeof(err));
     if(err >= 0)

--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -964,6 +964,49 @@ static inline int local_sockets_libmnl_cb_data(const struct nlmsghdr *nlh, void 
     return MNL_CB_OK;
 }
 
+static inline int local_sockets_libmnl_cb_error(const struct nlmsghdr *nlh, void *data __maybe_unused) {
+    const struct nlmsgerr *err = mnl_nlmsg_get_payload(nlh);
+
+    if(mnl_nlmsg_get_payload_len(nlh) < sizeof(*err)) {
+        errno = EBADMSG;
+        return MNL_CB_ERROR;
+    }
+
+    errno = err->error < 0 ? -err->error : err->error;
+    return err->error == 0 ? MNL_CB_STOP : MNL_CB_ERROR;
+}
+
+static inline int local_sockets_libmnl_cb_done(const struct nlmsghdr *nlh, void *data __maybe_unused) {
+    int err;
+
+    // Dump errors are carried in NLMSG_DONE, which libmnl's default callback ignores.
+    if(mnl_nlmsg_get_payload_len(nlh) < sizeof(err))
+        return MNL_CB_STOP;
+
+    memcpy(&err, mnl_nlmsg_get_payload(nlh), sizeof(err));
+    if(err >= 0)
+        return MNL_CB_STOP;
+
+    errno = -err;
+    return MNL_CB_ERROR;
+}
+
+static inline int local_sockets_libmnl_cb_run(
+    const void *buf,
+    size_t numbytes,
+    unsigned int seq,
+    unsigned int portid,
+    mnl_cb_t cb_data,
+    void *data) {
+    static const mnl_cb_t control_callbacks[NLMSG_DONE + 1] = {
+        [NLMSG_ERROR] = local_sockets_libmnl_cb_error,
+        [NLMSG_DONE] = local_sockets_libmnl_cb_done,
+    };
+
+    return mnl_cb_run2(
+        buf, numbytes, seq, portid, cb_data, data, control_callbacks, _countof(control_callbacks));
+}
+
 static inline bool local_sockets_libmnl_get_sockets(LS_STATE *ls, uint16_t family, uint16_t protocol) {
     ls->tmp_protocol = protocol;
 
@@ -1009,23 +1052,20 @@ static inline bool local_sockets_libmnl_get_sockets(LS_STATE *ls, uint16_t famil
     }
 
     bool rc = true;
-    size_t received = 0;
-    ssize_t ret;
-    while ((ret = mnl_socket_recvfrom(nl, buf, sizeof(buf))) > 0) {
-        ret = mnl_cb_run(buf, ret, 0, 0, local_sockets_libmnl_cb_data, ls);
+    ssize_t received;
+    while ((received = mnl_socket_recvfrom(nl, buf, sizeof(buf))) > 0) {
+        int ret = local_sockets_libmnl_cb_run(buf, received, 0, 0, local_sockets_libmnl_cb_data, ls);
         if (ret == MNL_CB_ERROR) {
-            local_sockets_log(ls, "mnl_cb_run() failed");
+            local_sockets_log(ls, "socket diagnostic netlink response failed");
             rc = false;
             break;
         }
         else if (ret <= MNL_CB_STOP)
             break;
-
-        received++;
     }
     mnl_socket_close(nl);
 
-    if (ret == -1) {
+    if (received == -1) {
         local_sockets_log(ls, "mnl_socket_recvfrom() failed");
         rc = false;
     }

--- a/src/libnetdata/local-sockets/tests/test_local_sockets_mnl.c
+++ b/src/libnetdata/local-sockets/tests/test_local_sockets_mnl.c
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "libnetdata/local-sockets/local-sockets.h"
+
+static bool expect_result(int actual, int expected, int actual_errno, int expected_errno, const char *message) {
+    if(actual == expected && actual_errno == expected_errno)
+        return true;
+
+    fprintf(
+        stderr,
+        "%s: expected result %d and errno %d, got result %d and errno %d\n",
+        message,
+        expected,
+        expected_errno,
+        actual,
+        actual_errno);
+    return false;
+}
+
+static struct nlmsghdr *put_control_message(void *buf, uint16_t type, const void *payload, size_t payload_len) {
+    struct nlmsghdr *nlh = mnl_nlmsg_put_header(buf);
+    nlh->nlmsg_type = type;
+
+    if(payload_len) {
+        void *dst = mnl_nlmsg_put_extra_header(nlh, payload_len);
+        memcpy(dst, payload, payload_len);
+    }
+
+    return nlh;
+}
+
+static bool test_done_without_payload(void) {
+    char buf[256] = { 0 };
+    struct nlmsghdr *nlh = put_control_message(buf, NLMSG_DONE, NULL, 0);
+
+    errno = 0;
+    int result = local_sockets_libmnl_cb_run(buf, nlh->nlmsg_len, 0, 0, NULL, NULL);
+    return expect_result(result, MNL_CB_STOP, errno, 0, "NLMSG_DONE without payload");
+}
+
+static bool test_done_success(void) {
+    char buf[256] = { 0 };
+    int done = 0;
+    struct nlmsghdr *nlh = put_control_message(buf, NLMSG_DONE, &done, sizeof(done));
+
+    errno = 0;
+    int result = local_sockets_libmnl_cb_run(buf, nlh->nlmsg_len, 0, 0, NULL, NULL);
+    return expect_result(result, MNL_CB_STOP, errno, 0, "successful NLMSG_DONE");
+}
+
+static bool test_done_error(void) {
+    char buf[256] = { 0 };
+    int done = -ENOENT;
+    struct nlmsghdr *nlh = put_control_message(buf, NLMSG_DONE, &done, sizeof(done));
+
+    errno = 0;
+    int result = local_sockets_libmnl_cb_run(buf, nlh->nlmsg_len, 0, 0, NULL, NULL);
+    return expect_result(result, MNL_CB_ERROR, errno, ENOENT, "error-bearing NLMSG_DONE");
+}
+
+static bool test_nlmsg_error(void) {
+    char buf[256] = { 0 };
+    struct nlmsgerr error = { .error = -EOPNOTSUPP };
+    struct nlmsghdr *nlh = put_control_message(buf, NLMSG_ERROR, &error, sizeof(error));
+
+    errno = 0;
+    int result = local_sockets_libmnl_cb_run(buf, nlh->nlmsg_len, 0, 0, NULL, NULL);
+    return expect_result(result, MNL_CB_ERROR, errno, EOPNOTSUPP, "NLMSG_ERROR");
+}
+
+static bool test_nlmsg_error_ack(void) {
+    char buf[256] = { 0 };
+    struct nlmsgerr error = { .error = 0 };
+    struct nlmsghdr *nlh = put_control_message(buf, NLMSG_ERROR, &error, sizeof(error));
+
+    errno = 0;
+    int result = local_sockets_libmnl_cb_run(buf, nlh->nlmsg_len, 0, 0, NULL, NULL);
+    return expect_result(result, MNL_CB_STOP, errno, 0, "successful NLMSG_ERROR acknowledgment");
+}
+
+static bool test_truncated_nlmsg_error(void) {
+    char buf[256] = { 0 };
+    struct nlmsghdr *nlh = put_control_message(buf, NLMSG_ERROR, NULL, 0);
+
+    errno = 0;
+    int result = local_sockets_libmnl_cb_run(buf, nlh->nlmsg_len, 0, 0, NULL, NULL);
+    return expect_result(result, MNL_CB_ERROR, errno, EBADMSG, "truncated NLMSG_ERROR");
+}
+
+static int data_callback(const struct nlmsghdr *nlh __maybe_unused, void *data) {
+    size_t *calls = data;
+    (*calls)++;
+    return MNL_CB_OK;
+}
+
+static bool test_data_message(void) {
+    char buf[256] = { 0 };
+    struct nlmsghdr *nlh = mnl_nlmsg_put_header(buf);
+    nlh->nlmsg_type = SOCK_DIAG_BY_FAMILY;
+    size_t calls = 0;
+
+    errno = 0;
+    int result = local_sockets_libmnl_cb_run(buf, nlh->nlmsg_len, 0, 0, data_callback, &calls);
+    return expect_result(result, MNL_CB_OK, errno, 0, "socket data message") && calls == 1;
+}
+
+int main(void) {
+    bool ok = true;
+
+    ok = test_done_without_payload() && ok;
+    ok = test_done_success() && ok;
+    ok = test_done_error() && ok;
+    ok = test_nlmsg_error() && ok;
+    ok = test_nlmsg_error_ack() && ok;
+    ok = test_truncated_nlmsg_error() && ok;
+    ok = test_data_message() && ok;
+
+    return ok ? 0 : 1;
+}

--- a/src/libnetdata/local-sockets/tests/test_local_sockets_mnl.c
+++ b/src/libnetdata/local-sockets/tests/test_local_sockets_mnl.c
@@ -58,6 +58,17 @@ static bool test_done_error(void) {
     return expect_result(result, MNL_CB_ERROR, errno, ENOENT, "error-bearing NLMSG_DONE");
 }
 
+static bool test_truncated_done(void) {
+    char buf[256] = { 0 };
+    struct nlmsghdr *nlh = mnl_nlmsg_put_header(buf);
+    nlh->nlmsg_type = NLMSG_DONE;
+    nlh->nlmsg_len++;
+
+    errno = 0;
+    int result = local_sockets_libmnl_cb_run(buf, nlh->nlmsg_len, 0, 0, NULL, NULL);
+    return expect_result(result, MNL_CB_ERROR, errno, EBADMSG, "truncated NLMSG_DONE");
+}
+
 static bool test_nlmsg_error(void) {
     char buf[256] = { 0 };
     struct nlmsgerr error = { .error = -EOPNOTSUPP };
@@ -110,6 +121,7 @@ int main(void) {
     ok = test_done_without_payload() && ok;
     ok = test_done_success() && ok;
     ok = test_done_error() && ok;
+    ok = test_truncated_done() && ok;
     ok = test_nlmsg_error() && ok;
     ok = test_nlmsg_error_ack() && ok;
     ok = test_truncated_nlmsg_error() && ok;


### PR DESCRIPTION
##### Summary

Linux socket-diag dump failures may be returned as a negative errno in the
payload of `NLMSG_DONE`. libmnl's default `mnl_cb_run()` completion callback
ignores that payload, so the shared local-sockets scanner treated a failed UDP
dump as an empty successful result and skipped its existing `/proc/net/*`
fallback.

This change:

- uses `mnl_cb_run2()` with control callbacks that preserve `NLMSG_ERROR`
  behavior and decode error-bearing `NLMSG_DONE` messages;
- returns backend failure for kernel dump errors, allowing the existing `/proc`
  fallback to enumerate the sockets;
- adds deterministic synthetic-netlink regression coverage; and
- runs that coverage in the existing normal and ASAN Linux unit-test jobs.

The fix is in the shared scanner, so it applies to both `local-listeners` and
`network-viewer.plugin`.

##### Test Plan

- Built `local-sockets-mnl-test`, `local-listeners`, and
  `network-viewer.plugin` with libmnl 1.0.5.
- Ran `local-sockets-mnl-test` successfully.
- Ran the focused test under AddressSanitizer with
  `detect_leaks=0:abort_on_error=1`.
- Verified the local successful libmnl path and forced `/proc` path returned the
  same UDP inventory count (95 rows in the validation run).
- Ran `actionlint .github/workflows/topology-container-tests.yml`.
- Ran `git diff --check`.

##### Additional Information

The reported reproduction is a Jetson Orin running Linux `5.15.185-tegra` with
`CONFIG_INET_DIAG=y`, but no `CONFIG_INET_UDP_DIAG` support or `udp_diag`
module. The libmnl path returned zero UDP sockets while `ss`, `/proc/net/udp*`,
and the forced `/proc` scanner path each returned 49.

<details> <summary>For users: How does this change affect me?</summary>

On Linux kernels that lack a requested protocol-specific inet-diag handler,
Netdata now falls back to `/proc/net/*` instead of showing an empty socket
inventory. No configuration or public API changes are required.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UDP socket discovery when inet_diag handlers are missing by detecting error-bearing netlink completions and falling back to `/proc/net/*`. Also hardens control message parsing to avoid false “success” cases. This restores UDP inventories in `local-listeners` and `network-viewer.plugin` on affected Linux kernels.

- **Bug Fixes**
  - Switched to `mnl_cb_run2()` with control callbacks to properly handle `NLMSG_ERROR` and error-bearing `NLMSG_DONE`, including truncation checks and errno propagation.
  - Propagates netlink dump errors from the `libmnl` path so the shared scanner reports backend failure and triggers the `/proc/net/*` fallback.
  - Added deterministic synthetic-netlink tests covering success, error, ack, and truncated control messages; integrated into CMake/CI and added `libmnl-dev` to CI dependencies.

<sup>Written for commit 4547fbf19dc07de4259ef2959801d71b71fcbec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

