### PR TITLE
Update vendored NetIPC SHM allocation

### DIFF
--- a/src/crates/netipc/src/transport/shm.rs
+++ b/src/crates/netipc/src/transport/shm.rs
@@ -44,8 +44,10 @@ pub enum ShmError {
     PathTooLong,
     /// open/shm_open failed.
     Open(i32),
-    /// ftruncate failed.
+    /// Legacy compatibility; SHM creation no longer uses ftruncate.
     Truncate(i32),
+    /// Backing storage allocation failed.
+    Allocate(i32),
     /// mmap failed.
     Mmap(i32),
     /// Header magic mismatch.
@@ -76,6 +78,7 @@ impl std::fmt::Display for ShmError {
             ShmError::PathTooLong => write!(f, "SHM path exceeds limit"),
             ShmError::Open(e) => write!(f, "open failed: errno {e}"),
             ShmError::Truncate(e) => write!(f, "ftruncate failed: errno {e}"),
+            ShmError::Allocate(e) => write!(f, "SHM allocation failed: errno {e}"),
             ShmError::Mmap(e) => write!(f, "mmap failed: errno {e}"),
             ShmError::BadMagic => write!(f, "SHM header magic mismatch"),
             ShmError::BadVersion => write!(f, "SHM header version mismatch"),
@@ -269,25 +272,15 @@ impl ShmContext {
             return Err(ShmError::Open(errno()));
         }
 
-        if unsafe { libc::ftruncate(fd, region_size as libc::off_t) } < 0 {
-            let e = errno();
+        if let Err(e) = allocate_region(fd, region_size) {
             unsafe {
                 libc::close(fd);
                 libc::unlink(c_path.as_ptr());
             }
-            return Err(ShmError::Truncate(e));
+            return Err(ShmError::Allocate(e));
         }
 
-        let base = unsafe {
-            libc::mmap(
-                ptr::null_mut(),
-                region_size,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_SHARED,
-                fd,
-                0,
-            )
-        };
+        let base = unsafe { map_region(fd, region_size) };
         if base == libc::MAP_FAILED {
             let e = errno();
             unsafe {
@@ -868,6 +861,109 @@ fn path_to_cstring(path: &Path) -> Result<std::ffi::CString, ShmError> {
 
 fn errno() -> i32 {
     unsafe { *libc::__errno_location() }
+}
+
+/// Reserve all backing storage before exposing the region through mmap.
+///
+/// Linux may interrupt fallocate before it changes the file, so retry EINTR.
+/// Every other error is returned to the caller; SHM has no unsafe sparse-file
+/// fallback.
+fn allocate_region(fd: i32, region_size: usize) -> Result<(), i32> {
+    loop {
+        #[cfg(test)]
+        record_fallocate_call();
+
+        #[cfg(test)]
+        let result = match take_fallocate_fault() {
+            Some(error) => {
+                unsafe { *libc::__errno_location() = error };
+                -1
+            }
+            None => unsafe { libc::fallocate(fd, 0, 0, region_size as libc::off_t) },
+        };
+
+        #[cfg(not(test))]
+        let result = unsafe { libc::fallocate(fd, 0, 0, region_size as libc::off_t) };
+
+        if result == 0 {
+            return Ok(());
+        }
+
+        let error = errno();
+        if error != libc::EINTR {
+            return Err(error);
+        }
+    }
+}
+
+unsafe fn map_region(fd: i32, region_size: usize) -> *mut libc::c_void {
+    #[cfg(test)]
+    record_mmap_call();
+
+    libc::mmap(
+        ptr::null_mut(),
+        region_size,
+        libc::PROT_READ | libc::PROT_WRITE,
+        libc::MAP_SHARED,
+        fd,
+        0,
+    )
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct ShmSyscallTestState {
+    fallocate_faults: std::collections::VecDeque<i32>,
+    fallocate_calls: usize,
+    mmap_calls: usize,
+}
+
+#[cfg(test)]
+thread_local! {
+    static SHM_SYSCALL_TEST_STATE: std::cell::RefCell<ShmSyscallTestState> =
+        std::cell::RefCell::new(ShmSyscallTestState::default());
+}
+
+#[cfg(test)]
+fn install_fallocate_faults(errors: &[i32]) {
+    SHM_SYSCALL_TEST_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        assert!(
+            state.fallocate_faults.is_empty(),
+            "fallocate fault sequence already installed"
+        );
+        state.fallocate_faults.extend(errors.iter().copied());
+        state.fallocate_calls = 0;
+        state.mmap_calls = 0;
+    });
+}
+
+#[cfg(test)]
+fn clear_fallocate_faults() {
+    SHM_SYSCALL_TEST_STATE.with(|state| *state.borrow_mut() = ShmSyscallTestState::default());
+}
+
+#[cfg(test)]
+fn take_fallocate_fault() -> Option<i32> {
+    SHM_SYSCALL_TEST_STATE.with(|state| state.borrow_mut().fallocate_faults.pop_front())
+}
+
+#[cfg(test)]
+fn record_fallocate_call() {
+    SHM_SYSCALL_TEST_STATE.with(|state| state.borrow_mut().fallocate_calls += 1);
+}
+
+#[cfg(test)]
+fn record_mmap_call() {
+    SHM_SYSCALL_TEST_STATE.with(|state| state.borrow_mut().mmap_calls += 1);
+}
+
+#[cfg(test)]
+fn syscall_test_counts() -> (usize, usize) {
+    SHM_SYSCALL_TEST_STATE.with(|state| {
+        let state = state.borrow();
+        (state.fallocate_calls, state.mmap_calls)
+    })
 }
 
 fn pid_alive(pid: i32) -> bool {

--- a/src/crates/netipc/src/transport/shm_tests.rs
+++ b/src/crates/netipc/src/transport/shm_tests.rs
@@ -19,6 +19,21 @@ fn cleanup_shm(service: &str, session_id: u64) {
     let _ = std::fs::remove_file(&path);
 }
 
+struct FallocateFaultGuard;
+
+impl FallocateFaultGuard {
+    fn install(errors: &[i32]) -> Self {
+        install_fallocate_faults(errors);
+        Self
+    }
+}
+
+impl Drop for FallocateFaultGuard {
+    fn drop(&mut self) {
+        clear_fallocate_faults();
+    }
+}
+
 fn wait_for_server_ready(rx: &mpsc::Receiver<u64>, service: &str) -> u64 {
     rx.recv_timeout(SERVER_READY_TIMEOUT).unwrap_or_else(|err| {
         panic!("timed out waiting for server readiness for service={service}: {err}")
@@ -523,6 +538,7 @@ fn shm_error_display_all_variants() {
         (ShmError::PathTooLong, "SHM path exceeds limit"),
         (ShmError::Open(2), "open failed: errno 2"),
         (ShmError::Truncate(28), "ftruncate failed: errno 28"),
+        (ShmError::Allocate(28), "SHM allocation failed: errno 28"),
         (ShmError::Mmap(12), "mmap failed: errno 12"),
         (ShmError::BadMagic, "SHM header magic mismatch"),
         (ShmError::BadVersion, "SHM header version mismatch"),
@@ -540,6 +556,86 @@ fn shm_error_display_all_variants() {
     }
     let e: &dyn std::error::Error = &ShmError::PathTooLong;
     let _ = format!("{e}");
+}
+
+#[test]
+fn test_server_create_allocate_enospc_cleans_up_before_mmap() {
+    ensure_run_dir();
+    let svc = "rs_shm_alloc_enospc";
+    let sid = 0xa110_c001;
+    cleanup_shm(svc, sid);
+
+    let fault = FallocateFaultGuard::install(&[libc::ENOSPC]);
+    let err = match ShmContext::server_create(TEST_RUN_DIR, svc, sid, 1024, 1024) {
+        Ok(_) => panic!("injected ENOSPC must fail SHM creation"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err, ShmError::Allocate(libc::ENOSPC));
+    assert_eq!(syscall_test_counts(), (1, 0), "mmap must not be reached");
+
+    let path = build_shm_path(TEST_RUN_DIR, svc, sid).expect("SHM path");
+    assert!(!path.exists(), "failed allocation must unlink its file");
+
+    drop(fault);
+    let mut server = ShmContext::server_create(TEST_RUN_DIR, svc, sid, 1024, 1024)
+        .expect("cleanup must permit recreation at the same path");
+    server.destroy();
+}
+
+#[test]
+fn test_server_create_retries_fallocate_after_eintr() {
+    ensure_run_dir();
+    let svc = "rs_shm_alloc_eintr";
+    let sid = 0xa110_c002;
+    cleanup_shm(svc, sid);
+
+    let _fault = FallocateFaultGuard::install(&[libc::EINTR]);
+    let mut server = ShmContext::server_create(TEST_RUN_DIR, svc, sid, 1024, 2048)
+        .expect("fallocate must retry EINTR");
+
+    assert_eq!(
+        syscall_test_counts(),
+        (2, 1),
+        "one interrupted allocation retry must precede one mmap"
+    );
+
+    let request = unsafe {
+        std::slice::from_raw_parts(
+            server.base.add(server.request_offset as usize),
+            server.request_capacity as usize,
+        )
+    };
+    let response = unsafe {
+        std::slice::from_raw_parts(
+            server.base.add(server.response_offset as usize),
+            server.response_capacity as usize,
+        )
+    };
+    assert!(request.iter().all(|byte| *byte == 0));
+    assert!(response.iter().all(|byte| *byte == 0));
+
+    server.destroy();
+}
+
+#[test]
+fn test_server_create_does_not_fallback_when_fallocate_is_unsupported() {
+    ensure_run_dir();
+    let svc = "rs_shm_alloc_unsupported";
+    let sid = 0xa110_c003;
+    cleanup_shm(svc, sid);
+
+    let _fault = FallocateFaultGuard::install(&[libc::EOPNOTSUPP]);
+    let err = match ShmContext::server_create(TEST_RUN_DIR, svc, sid, 1024, 1024) {
+        Ok(_) => panic!("unsupported fallocate must disable SHM creation"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err, ShmError::Allocate(libc::EOPNOTSUPP));
+    assert_eq!(syscall_test_counts(), (1, 0), "mmap must not be reached");
+
+    let path = build_shm_path(TEST_RUN_DIR, svc, sid).expect("SHM path");
+    assert!(!path.exists(), "failed allocation must unlink its file");
 }
 
 // -----------------------------------------------------------------------

--- a/src/go/pkg/netipc/transport/posix/shm_linux.go
+++ b/src/go/pkg/netipc/transport/posix/shm_linux.go
@@ -61,6 +61,8 @@ const (
 var (
 	ErrShmPathTooLong = errors.New("SHM path exceeds limit")
 	ErrShmOpen        = errors.New("SHM open failed")
+	ErrShmAllocate    = errors.New("SHM allocation failed")
+	// Deprecated: SHM creation no longer uses ftruncate; use ErrShmAllocate.
 	ErrShmTruncate    = errors.New("SHM ftruncate failed")
 	ErrShmMmap        = errors.New("SHM mmap failed")
 	ErrShmBadMagic    = errors.New("SHM header magic mismatch")
@@ -140,8 +142,24 @@ func (c *ShmContext) OwnerAlive() bool {
 //  Server API
 // ---------------------------------------------------------------------------
 
+type shmFallocateFunc func(fd int, mode uint32, off, len int64) error
+
+func shmPreallocate(fd int, size int64, fallocate shmFallocateFunc) error {
+	for {
+		err := fallocate(fd, 0, 0, size)
+		if err == syscall.EINTR {
+			continue
+		}
+		return err
+	}
+}
+
 // ShmServerCreate creates a SHM region at {runDir}/{serviceName}-{sessionID}.ipcshm.
 func ShmServerCreate(runDir, serviceName string, sessionID uint64, reqCapacity, respCapacity uint32) (*ShmContext, error) {
+	return shmServerCreate(runDir, serviceName, sessionID, reqCapacity, respCapacity, syscall.Fallocate)
+}
+
+func shmServerCreate(runDir, serviceName string, sessionID uint64, reqCapacity, respCapacity uint32, fallocate shmFallocateFunc) (*ShmContext, error) {
 	path, err := buildShmPath(runDir, serviceName, sessionID)
 	if err != nil {
 		return nil, err
@@ -171,10 +189,10 @@ func ShmServerCreate(runDir, serviceName string, sessionID uint64, reqCapacity, 
 	}
 	fd := int(f.Fd())
 
-	if err := syscall.Ftruncate(fd, int64(regionSize)); err != nil {
+	if err := shmPreallocate(fd, int64(regionSize), fallocate); err != nil {
 		_ = f.Close()
 		_ = os.Remove(path)
-		return nil, fmt.Errorf("%w: %v", ErrShmTruncate, err)
+		return nil, fmt.Errorf("%w: %w", ErrShmAllocate, err)
 	}
 
 	data, err := syscall.Mmap(fd, 0, regionSize,

--- a/src/go/pkg/netipc/transport/posix/shm_more_edge_test.go
+++ b/src/go/pkg/netipc/transport/posix/shm_more_edge_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -31,6 +32,99 @@ func fillShmHeader(data []byte, ownerPID int32, ownerGen uint32, reqOff, reqCap,
 	binary.NativeEndian.PutUint32(data[shmHeaderReqCapOff:shmHeaderReqCapOff+4], reqCap)
 	binary.NativeEndian.PutUint32(data[shmHeaderRespOffOff:shmHeaderRespOffOff+4], respOff)
 	binary.NativeEndian.PutUint32(data[shmHeaderRespCapOff:shmHeaderRespCapOff+4], respCap)
+}
+
+func TestShmServerCreatePreallocation(t *testing.T) {
+	t.Run("ENOSPC preserves cause and removes file", func(t *testing.T) {
+		runDir := t.TempDir()
+		const (
+			svc       = "go_shm_allocate_enospc"
+			sessionID = uint64(41)
+		)
+
+		var calls int
+		var gotMode uint32
+		var gotOff, gotLen int64
+		ctx, err := shmServerCreate(runDir, svc, sessionID, 1024, 2048,
+			func(_ int, mode uint32, off, len int64) error {
+				calls++
+				gotMode, gotOff, gotLen = mode, off, len
+				return syscall.ENOSPC
+			})
+		if ctx != nil {
+			ctx.ShmDestroy()
+			t.Fatal("allocation failure returned a context")
+		}
+		if !errors.Is(err, ErrShmAllocate) {
+			t.Fatalf("create error = %v, want ErrShmAllocate", err)
+		}
+		if !errors.Is(err, syscall.ENOSPC) {
+			t.Fatalf("create error = %v, want underlying ENOSPC", err)
+		}
+		if calls != 1 {
+			t.Fatalf("fallocate calls = %d, want 1", calls)
+		}
+		wantLen := int64(shmAlign64(uint32(shmHeaderLen)) + shmAlign64(1024) + shmAlign64(2048))
+		if gotMode != 0 || gotOff != 0 || gotLen != wantLen {
+			t.Fatalf("fallocate args = mode %d off %d len %d, want 0, 0, %d", gotMode, gotOff, gotLen, wantLen)
+		}
+
+		path, pathErr := buildShmPath(runDir, svc, sessionID)
+		if pathErr != nil {
+			t.Fatalf("build path: %v", pathErr)
+		}
+		if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("failed allocation file should be removed, stat err = %v", statErr)
+		}
+	})
+
+	t.Run("unsupported allocation has no sparse fallback", func(t *testing.T) {
+		runDir := t.TempDir()
+		const (
+			svc       = "go_shm_allocate_unsupported"
+			sessionID = uint64(43)
+		)
+
+		ctx, err := shmServerCreate(runDir, svc, sessionID, 1024, 1024,
+			func(_ int, _ uint32, _, _ int64) error {
+				return syscall.EOPNOTSUPP
+			})
+		if ctx != nil {
+			ctx.ShmDestroy()
+			t.Fatal("unsupported allocation returned a context")
+		}
+		if !errors.Is(err, ErrShmAllocate) || !errors.Is(err, syscall.EOPNOTSUPP) {
+			t.Fatalf("create error = %v, want allocation error wrapping EOPNOTSUPP", err)
+		}
+
+		path, pathErr := buildShmPath(runDir, svc, sessionID)
+		if pathErr != nil {
+			t.Fatalf("build path: %v", pathErr)
+		}
+		if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("unsupported allocation file should be removed, stat err = %v", statErr)
+		}
+	})
+
+	t.Run("EINTR retries", func(t *testing.T) {
+		runDir := t.TempDir()
+		var calls int
+		ctx, err := shmServerCreate(runDir, "go_shm_allocate_eintr", 42, 1024, 1024,
+			func(fd int, mode uint32, off, len int64) error {
+				calls++
+				if calls == 1 {
+					return syscall.EINTR
+				}
+				return syscall.Fallocate(fd, mode, off, len)
+			})
+		if err != nil {
+			t.Fatalf("create after EINTR: %v", err)
+		}
+		defer ctx.ShmDestroy()
+		if calls != 2 {
+			t.Fatalf("fallocate calls = %d, want 2", calls)
+		}
+	})
 }
 
 func writeRawShmRegionFile(t *testing.T, runDir, service string, sessionID uint64, size int, fill func([]byte)) string {

--- a/src/libnetdata/netipc/include/netipc/netipc_shm.h
+++ b/src/libnetdata/netipc/include/netipc/netipc_shm.h
@@ -41,7 +41,7 @@ typedef enum {
     NIPC_SHM_OK = 0,
     NIPC_SHM_ERR_PATH_TOO_LONG,     /* SHM path exceeds limit */
     NIPC_SHM_ERR_OPEN,              /* open/shm_open failed */
-    NIPC_SHM_ERR_TRUNCATE,          /* ftruncate failed */
+    NIPC_SHM_ERR_TRUNCATE,          /* legacy compatibility; creation no longer truncates */
     NIPC_SHM_ERR_MMAP,              /* mmap failed */
     NIPC_SHM_ERR_BAD_MAGIC,         /* header magic mismatch */
     NIPC_SHM_ERR_BAD_VERSION,       /* header version mismatch */
@@ -53,6 +53,7 @@ typedef enum {
     NIPC_SHM_ERR_TIMEOUT,           /* futex wait timed out */
     NIPC_SHM_ERR_BAD_PARAM,         /* invalid argument */
     NIPC_SHM_ERR_PEER_DEAD,         /* owner process has exited */
+    NIPC_SHM_ERR_ALLOCATE,          /* backing allocation failed; errno preserved */
 } nipc_shm_error_t;
 
 /* ------------------------------------------------------------------ */
@@ -216,6 +217,17 @@ bool nipc_shm_owner_alive(const nipc_shm_ctx_t *ctx);
  * is dead (or whose generation mismatches) are unlinked.
  */
 void nipc_shm_cleanup_stale(const char *run_dir, const char *service_name);
+
+#ifdef NIPC_INTERNAL_TESTING
+typedef enum {
+    NIPC_SHM_TEST_FAULT_NONE = 0,
+    NIPC_SHM_TEST_FAULT_ALLOCATE,
+} nipc_shm_test_fault_site_t;
+
+void nipc_shm_test_fault_set(nipc_shm_test_fault_site_t site,
+                             int error_number);
+void nipc_shm_test_fault_clear(void);
+#endif
 
 /* Get the file descriptor for external event integration. */
 static inline int nipc_shm_fd(const nipc_shm_ctx_t *ctx) {

--- a/src/libnetdata/netipc/src/transport/posix/netipc_shm.c
+++ b/src/libnetdata/netipc/src/transport/posix/netipc_shm.c
@@ -1,3 +1,7 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 /*
  * netipc_shm.c - L1 POSIX SHM transport (Linux only).
  *
@@ -352,11 +356,18 @@ nipc_shm_error_t nipc_shm_server_create(const char *run_dir,
         return NIPC_SHM_ERR_OPEN;
     }
 
-    if (ftruncate(fd, (off_t)region_size) < 0) {
+    int allocate_rc;
+    do {
+        allocate_rc = fallocate(fd, 0, 0, (off_t)region_size);
+    } while (allocate_rc < 0 && errno == EINTR);
+
+    if (allocate_rc < 0) {
+        int allocation_errno = errno;
         close(fd);
         unlinkat(dir_fd, shm_name, 0);
         close(dir_fd);
-        return NIPC_SHM_ERR_TRUNCATE;
+        errno = allocation_errno;
+        return NIPC_SHM_ERR_ALLOCATE;
     }
 
     void *map = mmap(NULL, region_size, PROT_READ | PROT_WRITE,


### PR DESCRIPTION
## Summary

- update Netdata's vendored C, Rust, and Go NetIPC sources from [plugin-ipc PR #11](https://github.com/netdata/plugin-ipc/pull/11)
- allocate the complete Linux SHM backing file with native `fallocate()` before `mmap()`
- return an explicit allocation-stage error instead of risking SIGBUS when the backing store is full
- retain managed baseline transport fallback when SHM preparation returns an ordinary error

## Vendor integrity

- source implementation commit: `dd3c546a90789c96c8eb31bd0b0f97c5a9b70a4c`
- source preflight head: `0b5ace0bacad7f8d7b77ecd1187054ccf2c916aa`
- previous source baseline: `98ec474d103ab2a7ed150f88c37225b74e1a9d27`
- previous Netdata vendor baseline: `ca9a5426a6b1cdf6e1b2c82d3d5710e9e0a66fed`
- normalized comparison after vendoring: no C, Rust, or Go differences
- exactly six planned vendor files changed; Netdata wrappers, Cargo workspace files, Go module/import ownership, and unrelated files are preserved

## Compatibility and risk

- no wire layout, offsets, capacities, negotiation values, configuration, or Windows transport code changed
- the C error enum is append-only; Rust and Go preserve the underlying OS allocation cause
- Linux now requires the `fallocate` syscall for NetIPC SHM creation
- errno-returning allocation or seccomp denials use managed baseline fallback when configured
- strict seccomp kill/trap policies must allow `fallocate`, because terminated or SIGSYS-delivered calls cannot fall back in-process
- native Windows and MSYSTEM=MSYS continue to use their separate committed page-file mapping implementation

## Validation

Source preflight:

- 28/28 applicable plugin-ipc PR checks passed
- current Semgrep, CodeQL C/Go/Rust POSIX/Windows, gosec, and Codacy SARIF categories: zero results
- Dependabot and secret scanning: zero open alerts
- Linux CTest 49/49; Rust 380/380; Go coverage/test gates passed
- real 64 KiB tmpfs exhaustion returns ENOSPC normally in C, Rust, and Go with no SIGBUS or leaked file
- Alpine/musl, sanitizers, race detectors, native Windows/MSYS, and C/Rust/Go interoperability passed

Netdata integration:

- C `netipc` target built successfully
- Rust `netipc`: 380/380 tests passed
- Go `pkg/netipc/...`: all packages passed, including raw-service stress coverage
- Rust/Go formatting, `git diff --check`, local SOW audit, and normalized vendor comparison passed
- two independent downstream reviews found no correctness, security, portability, packaging, equality, or Windows-isolation defect


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preallocated Linux SHM backing files with `fallocate()` and return explicit allocation errors to prevent SIGBUS, updating the vendored NetIPC C/Rust/Go sources from `plugin-ipc`. Keeps graceful fallback to the managed transport when SHM prep fails.

- **Bug Fixes**
  - Reserve the full SHM backing store with `fallocate()` before `mmap()` and retry on `EINTR`.
  - Return an allocation error (C: `NIPC_SHM_ERR_ALLOCATE`; Rust: `ShmError::Allocate`; Go: `ErrShmAllocate`) with preserved `errno`, skip `mmap`, and unlink on failure.
  - Keep the legacy truncate error for compatibility; creation no longer uses `ftruncate()`.
  - No wire/layout changes; Windows path unchanged. Added focused Rust/Go tests for `ENOSPC`, `EOPNOTSUPP`, and `EINTR`.

- **Migration**
  - Linux now requires the `fallocate` syscall for NetIPC SHM; allow it in seccomp policies or SHM creation will fail.
  - Ordinary allocation errors still fall back to the managed baseline transport when configured.

<sup>Written for commit 7f6ccbadba9f9e1da4f36b016f97669395882c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

