### PR TITLE
dbengine: record metric retention start when its first page gets data

### DIFF
--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "database/rrd.h"
+#include "database/rrddim-collection.h"
 
 #ifdef ENABLE_DBENGINE
 
@@ -356,6 +357,105 @@ static size_t dbengine_test_rrdr_single_region(
     return errors + value_errors + time_errors + update_every_errors;
 }
 
+static size_t test_dbengine_burst_retention_case(
+    RRDHOST *host, const char *id,
+    size_t points, size_t leading_gaps, bool flush_before_check,
+    time_t expected_first, time_t expected_last) {
+    size_t errors = 0;
+
+    fprintf(stderr, "DBENGINE Burst Retention Test: '%s', %zu points (%zu leading gaps)...\n",
+            id, points, leading_gaps);
+
+    RRDSET *st = rrdset_create(host, "netdata", id, id, "netdata", NULL, "Unit Testing", "a value", "unittest",
+                               NULL, 1, 1, RRDSET_TYPE_LINE);
+    RRDDIM *rd = rrddim_add(st, "dim", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+    // burst-store points at fixed timestamps, the way the streaming receiver
+    // stores replicated history of a newly-created chart: many points land in
+    // the open hot page before any retention reader runs
+    time_t t0 = START_TIMESTAMP;
+    for(size_t p = 0; p < points; p++) {
+        if(p < leading_gaps)
+            rrddim_store_metric(rd, (usec_t)(t0 + 1 + (time_t)p) * USEC_PER_SEC, NAN, SN_EMPTY_SLOT);
+        else
+            rrddim_store_metric(rd, (usec_t)(t0 + 1 + (time_t)p) * USEC_PER_SEC, (NETDATA_DOUBLE)(p % 10), SN_DEFAULT_FLAGS);
+    }
+
+    // gap-only cases must flush before the first retention read: pages that
+    // never received a real value are discarded at flush and must not leave
+    // any retention behind
+    if(flush_before_check) {
+        for(size_t tier = 0; tier < nd_profile.storage_tiers; tier++)
+            storage_engine_store_flush(rd->tiers[tier].sch);
+    }
+
+    // this is the first retention reader; it used to stamp first_time_s from
+    // the newest hot point (sub-page bursts) or the first page flush had
+    // already stamped the page end time (multi-page bursts), hiding all
+    // earlier points of the burst from queries until a restart
+    time_t first = 0, last = 0;
+    rrdeng_metric_retention_by_id(host->db[0].si, rd->uuid, &first, &last);
+
+    if(first != expected_first) {
+        fprintf(stderr, " >>> DBENGINE: BURST RETENTION: '%s' first_entry is %ld, expected %ld\n",
+                id, first, expected_first);
+        errors++;
+    }
+
+    if(last != expected_last) {
+        fprintf(stderr, " >>> DBENGINE: BURST RETENTION: '%s' last_entry is %ld, expected %ld\n",
+                id, last, expected_last);
+        errors++;
+    }
+
+    // a second read must return the same retention (the first read must not
+    // have persisted anything different)
+    time_t first2 = 0, last2 = 0;
+    rrdeng_metric_retention_by_id(host->db[0].si, rd->uuid, &first2, &last2);
+
+    if(first2 != first || last2 != last) {
+        fprintf(stderr, " >>> DBENGINE: BURST RETENTION: '%s' retention is not stable across reads: "
+                        "%ld - %ld, then %ld - %ld\n",
+                id, first, last, first2, last2);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_burst_retention(RRDHOST *host) {
+    size_t errors = 0;
+    time_t t0 = START_TIMESTAMP;
+
+    // sub-page burst: no page flush happens while storing
+    errors += test_dbengine_burst_retention_case(host, "dbengine-burst-subpage",
+                                                 100, 0, false, t0 + 1, t0 + 100);
+
+    // multi-page burst: the first pages fill and are flushed while storing
+    errors += test_dbengine_burst_retention_case(host, "dbengine-burst-multipage",
+                                                 4000, 0, false, t0 + 1, t0 + 4000);
+
+    // leading gaps: retention starts at the page start (like journal replay
+    // registers pages with leading gaps), stamped when the first real value
+    // arrives
+    errors += test_dbengine_burst_retention_case(host, "dbengine-burst-leading-gaps",
+                                                 100, 5, false, t0 + 1, t0 + 100);
+
+    // gap-only pages: discarded at flush, so the page start must NOT be
+    // recorded as retention; what remains is the pre-existing reader
+    // fallback from latest_time_s_hot (which survives the flush - the
+    // flush's clear is filtered out by mrg_metric_set_hot_latest_time_s
+    // ignoring zero), giving first == last == the last gap time
+    errors += test_dbengine_burst_retention_case(host, "dbengine-burst-all-gaps",
+                                                 100, 100, true, t0 + 100, t0 + 100);
+
+    // gap-only pages discarded at page-full rotation: same, at capacity
+    errors += test_dbengine_burst_retention_case(host, "dbengine-burst-all-gaps-capacity",
+                                                 1100, 1100, true, t0 + 1100, t0 + 1100);
+
+    return errors;
+}
+
 int test_dbengine(void) {
     // provide enough threads to dbengine
     setenv("UV_THREADPOOL_SIZE", "48", 1);
@@ -370,6 +470,8 @@ int test_dbengine(void) {
     RRDHOST *host = dbengine_rrdhost_find_or_create("unittest-dbengine");
     if(!host)
         fatal("Failed to initialize host");
+
+    errors += test_dbengine_burst_retention(host);
 
     RRDSET *st[CHARTS] = { 0 };
     RRDDIM *rd[CHARTS][DIMS] = { 0 };

--- a/src/database/engine/mrg-internals.h
+++ b/src/database/engine/mrg-internals.h
@@ -145,8 +145,11 @@ static time_t mrg_metric_get_first_time_s_smart(MRG *mrg __maybe_unused, METRIC 
 
         if(first_time_s <= 0)
             first_time_s = 0;
-        else
-            __atomic_store_n(&metric->first_time_s, first_time_s, __ATOMIC_RELAXED);
+        else if(!set_metric_field_with_condition(metric->first_time_s, first_time_s, _current <= 0))
+            // lost the race to a concurrent writer publishing the real
+            // retention start (the collector, when the page gets its first
+            // real value) - never overwrite it
+            first_time_s = __atomic_load_n(&metric->first_time_s, __ATOMIC_RELAXED);
     }
 
     return first_time_s;

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -679,15 +679,17 @@ void collect_page_flags_to_buffer(BUFFER *wb, RRDENG_COLLECT_PAGE_FLAGS flags) {
     if(flags & RRDENG_PAGE_CONFLICT)
         buffer_strcat(wb, "CONFLICT ");
     if(flags & RRDENG_PAGE_FULL)
-        buffer_strcat(wb, "PAGE_FULL");
+        buffer_strcat(wb, "PAGE_FULL ");
     if(flags & RRDENG_PAGE_COLLECT_FINALIZE)
-        buffer_strcat(wb, "COLLECT_FINALIZE");
+        buffer_strcat(wb, "COLLECT_FINALIZE ");
     if(flags & RRDENG_PAGE_UPDATE_EVERY_CHANGE)
-        buffer_strcat(wb, "UPDATE_EVERY_CHANGE");
+        buffer_strcat(wb, "UPDATE_EVERY_CHANGE ");
     if(flags & RRDENG_PAGE_STEP_TOO_SMALL)
-        buffer_strcat(wb, "STEP_TOO_SMALL");
+        buffer_strcat(wb, "STEP_TOO_SMALL ");
     if(flags & RRDENG_PAGE_STEP_UNALIGNED)
-        buffer_strcat(wb, "STEP_UNALIGNED");
+        buffer_strcat(wb, "STEP_UNALIGNED ");
+    if(flags & RRDENG_PAGE_RETENTION_RECORDED)
+        buffer_strcat(wb, "RETENTION_RECORDED ");
 }
 
 ALWAYS_INLINE VALIDATED_PAGE_DESCRIPTOR validate_extent_page_descr(const struct rrdeng_extent_page_descr *descr, time_t now_s, uint32_t overwrite_zero_update_every_s, bool have_read_error) {

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -231,6 +231,7 @@ typedef enum __attribute__ ((__packed__)) {
     RRDENG_PAGE_UPDATE_EVERY_CHANGE   = (1 << 11),
     RRDENG_PAGE_STEP_TOO_SMALL        = (1 << 12),
     RRDENG_PAGE_STEP_UNALIGNED        = (1 << 13),
+    RRDENG_PAGE_RETENTION_RECORDED    = (1 << 14),
 } RRDENG_COLLECT_PAGE_FLAGS;
 
 struct rrdeng_collect_handle {

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -494,6 +494,21 @@ static PGD *rrdeng_alloc_new_page_data(struct rrdeng_collect_handle *handle, use
     return d;
 }
 
+static ALWAYS_INLINE void rrdeng_store_metric_first_retention(struct rrdeng_collect_handle *handle) {
+    if(likely((handle->page_flags & (RRDENG_PAGE_RETENTION_RECORDED | RRDENG_PAGE_CREATED_IN_FUTURE)) ||
+              pgd_is_empty(handle->page_data)))
+        return;
+
+    // once the page holds a real (non-gap) value, record the page start as
+    // the metric's retention start; gap-only pages are discarded at flush,
+    // so they must not leave retention behind; without this stamp, a metric
+    // without retention gets first_time_s set by the first retention reader
+    // using the newest hot point, hiding all older points of this page from
+    // queries (burst ingestion: replication catch-up)
+    mrg_metric_expand_retention(main_mrg, handle->metric, pgc_page_start_time_s(handle->pgc_page), 0, 0);
+    handle->page_flags |= RRDENG_PAGE_RETENTION_RECORDED;
+}
+
 static ALWAYS_INLINE_HOT void rrdeng_store_metric_append_point(STORAGE_COLLECT_HANDLE *sch,
                                              const usec_t point_in_time_ut,
                                              const NETDATA_DOUBLE n,
@@ -521,12 +536,16 @@ static ALWAYS_INLINE_HOT void rrdeng_store_metric_append_point(STORAGE_COLLECT_H
     if(unlikely(!handle->pgc_page)) {
         rrdeng_store_metric_create_new_page(handle, ctx, point_in_time_ut, handle->page_data);
         // handle->position is set to 1 already
+
+        rrdeng_store_metric_first_retention(handle);
     }
     else {
         // update an existing page
         pgc_page_hot_set_end_time_s(main_cache, handle->pgc_page,
                                     (time_t) (point_in_time_ut / USEC_PER_SEC), additional_bytes);
         handle->page_end_time_ut = point_in_time_ut;
+
+        rrdeng_store_metric_first_retention(handle);
 
         if(unlikely(++handle->page_position >= handle->page_entries_max)) {
             internal_fatal(handle->page_position > handle->page_entries_max, "DBENGINE: exceeded page max number of points");


### PR DESCRIPTION
##### Summary

A brand-new dbengine metric has no `first_time_s` in the metrics registry (MRG). Today it gets stamped lazily, by whichever of these happens first:

- the first retention reader (`mrg_metric_get_first_time_s_smart()`) falls back to `latest_time_s_hot` — the **newest** hot point — and persists it as the metric's **first** time; or
- the first page-full flush records the flushed page's **end** time (`mrg_metric_set_clean_latest_time_s()`).

Every query is clamped to the registered retention, so all points already stored in the open hot page **before** that stamp are stored correctly but invisible to queries. Nothing lowers `first_time_s` at runtime — the visibility loss is permanent until the agent restarts and journal replay rebuilds retention from disk.

Normal once-per-`update_every` collection is unaffected (the per-second housekeeping stamps right after the first point). **Burst ingestion of a new metric is the victim** — most notably streaming replication of a newly-created chart:

- replicated history that fits in one page: everything except the tail is hidden (measured: 59-point burst → 1 point visible);
- replicated history spanning multiple pages: the entire interior of the first page is hidden (measured: 3000-point burst → `first_entry` stamped at the end of the first 341-slot page, 340 points hidden);
- a parent with under-stamped retention also under-declares it upstream, propagating the hole to chained parents.

The fix has two parts:

1. **Record the true retention start when the page holds real data.** When a metric's page receives its first non-gap value, record the page cache's registered page start time in MRG using the same conditional-expand helper the journal-v2 loader uses (`mrg_metric_expand_retention()` — set only if unset or older). The stamp fires at the page's empty→non-empty transition, not at page creation: gap-only pages (`PAGE_OPTION_ALL_VALUES_EMPTY`) are discarded at flush and must not leave retention behind — and ordinary collection stores NAN for dimensions without a value, so gap-leading new metrics are normal. Using the page start (rather than the first real value's time) matches how journal replay registers pages with leading gaps after a restart. The stamp runs once per page (tracked by a new `RRDENG_PAGE_RETENTION_RECORDED` page flag); the point data is in the page before it is added to the cache, so no premature visibility is introduced. Pages flagged `RRDENG_PAGE_CREATED_IN_FUTURE` keep the previous behavior.

2. **Make the reader's lazy fallback race-safe.** The persist in `mrg_metric_get_first_time_s_smart()` was an unconditional store: a reader that observed `first_time_s == 0` and got delayed could overwrite the correct page start recorded by the collector, re-creating the visibility loss for that metric. It now publishes through the existing `set_metric_field_with_condition()` CAS idiom (first writer wins) and, on a lost race, returns the winning value instead of overwriting it. This also stops two concurrent readers from stamping different fallback values over each other — a pre-existing race that part 1 alone would have narrowed but not closed.

Not addressed here (pre-existing, unchanged by this PR): for a metric that only ever produced gaps, the reader fallback still publishes `first == last == the last gap time` after its page is discarded, because the flush's hot-time clear is filtered out by `mrg_metric_set_hot_latest_time_s()` ignoring zero. The new gap-case unit tests pin this behavior with a comment; fixing it requires deciding hot-time semantics (query freshness, zero-retention cleanup) and deserves its own change — tracked in #23095.

##### Test Plan

**Committed regression test** — `test_dbengine_burst_retention()` in `dbengine-unittest.c`, running as part of `netdata -W unittest`. It covers both burst shapes (sub-page: 100 points; multi-page: 4000 points) plus a retention-stability re-read. Red/green verified: with the fixes reverted and only the test applied, the suite fails with the exact bug signatures (sub-page: `first_entry` = the last point, 99 points hidden; multi-page: `first_entry` = the end of the first page, 553 points hidden); with the fixes, the full unittest suite passes.

**End-to-end** — reproduced and validated with a scripted streaming child pushing deterministic fixtures (fixed 2023-epoch timestamps, values `i % 10`) to a stock parent (dbengine, 3 tiers, ML/health off), querying `/api/v3/data` with absolute windows and forced tiers.

Before the fix:

| scenario | stored | visible before restart | `first_entry` |
|---|---|---|---|
| replication burst, sub-page (59 points) | 59 | **1** | last point |
| replication burst, multi-page (2999 points) | 2999 | **2659** | end of first page (t0+342) |
| live `BEGIN2`/`SET2` burst (60 points) | 60 | **1** | last point |
| paced live collection | n | n | correct |

With the fix (same scenarios, virgin dbengine, all checks scripted):

- sub-page replication: 59/59 visible, `first_entry` = t0+2, values exact;
- multi-page replication: 2999/2999 visible, `first_entry` = t0+2, values exact;
- live burst: 60/60 visible, `first_entry` = t0+1, values exact;
- restart cross-check: results after restart identical to before restart (pre-fix, the restart *changed* the results — that asymmetry was the bug);
- paced live collection: unchanged.

gdb tracing of `rrddim_store_metric` confirmed the storage layer was never at fault (all burst points append to the same page, happy path) — only the retention metadata was wrong, which is why the fix targets page creation and not the store path.

The reader-side race (part 2) is not deterministically reproducible by an external harness (it needs a reader descheduled between two specific loads); it was identified by inspection, and the guarded publish is validated by the same full matrix passing unchanged plus the CAS idiom being the one already used for every other conditional MRG retention update.

##### Additional Information

Step-by-step reproduction without any special tooling: stream a chart with pre-existing history from a child to a parent the child has never streamed that chart to before (replication catch-up), then query the parent for the replicated window and compare with the same query after restarting the parent.

<details> <summary>For users: How does this change affect me?</summary>

Affected area: parents receiving streamed/replicated data, and any burst ingestion of brand-new metrics (dbengine).

Before this change, when a child streamed a newly-created chart to a parent, most of the chart's replicated history was invisible on the parent (queries and dashboards showed the chart starting "now") until the parent was restarted. With this change, the replicated history is immediately visible. No configuration change is needed; no data format changes; existing data is unaffected.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes retention stamping for new dbengine metrics so burst-ingested history is visible immediately. We now record retention at the first real data on a page and make the reader fallback race-safe.

- Bug Fixes
  - Stamp the page start in MRG when a page first gets a non-gap value using `mrg_metric_expand_retention()`. Runs once per page via `RRDENG_PAGE_RETENTION_RECORDED`; skips gap-only pages and pages created in the future.
  - Make `mrg_metric_get_first_time_s_smart()` publish with CAS (`set_metric_field_with_condition()`), returning the winning value to avoid overwriting correct retention.
  - Add `test_dbengine_burst_retention` covering sub-page, multi-page, leading gaps, and gap-only cases; reproduces pre-fix failures and validates the fix.

<sup>Written for commit fe82d9def764f37380f67dbd1a4e9af559c6d8c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

