### PR TITLE
fix view.dimensions.sts.avg for group-by aggregations sum, min, max, extremes

### DIFF
--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -288,13 +288,15 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
     if(!query_target_aggregatable(qt) && r->partial_data_trimming.expected_after < qt->window.before)
         rrdr2rrdr_group_by_partial_trimming(r);
 
-    // percentage points are already normalized (0-100), so their sts pair must
-    // average over the view rows to stay consistent with min/max (row extremes),
-    // not over the per-point source contributions (gbc); in aggregatable (raw)
-    // mode the values are not percentaged and the cloud derives the statistics,
-    // so the (sum, gbc) pair is kept as-is
-    bool percentage_stats_by_rows =
-        aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE && !query_target_aggregatable(qt);
+    // for every aggregation except AVERAGE the plotted value is already the
+    // final group aggregate (the percentage, the sum, the min, the max), so
+    // the sts pair must average over the view rows to stay consistent with
+    // min/max (row extremes), not over the per-point source contributions
+    // (gbc); AVERAGE accumulates pre-division group sums, so its (sum, gbc)
+    // pair is a correct weighted mean; in aggregatable (raw) mode the cloud
+    // derives the statistics, so the (sum, gbc) pair is kept as-is
+    bool stats_by_rows =
+        aggregation != RRDR_GROUP_BY_FUNCTION_AVERAGE && !query_target_aggregatable(qt);
 
     // apply averaging, remove RRDR_VALUE_EMPTY, find the non-zero dimensions, min and max
     size_t global_min_max_values = 0;
@@ -326,9 +328,9 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
 
                 sum += *cn;
 
-                // when the sts pair is per-row (percentage), the anomaly rate must
-                // also be accumulated per-row (the row mean), not per-contribution
-                ars += percentage_stats_by_rows ? (*ar / (NETDATA_DOUBLE)gbc) : *ar;
+                // when the sts pair is per-row, the anomaly rate must also be
+                // accumulated per-row (the row mean), not per-contribution
+                ars += stats_by_rows ? (*ar / (NETDATA_DOUBLE)gbc) : *ar;
 
                 if(aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE && !query_target_aggregatable(qt))
                     n = (*cn /= gbc);
@@ -361,7 +363,7 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
                         global_max = n;
                 }
 
-                count += percentage_stats_by_rows ? 1 : gbc;
+                count += stats_by_rows ? 1 : gbc;
             }
         }
 


### PR DESCRIPTION
##### Summary

`view.dimensions.sts.avg` is wrong for the group-by aggregations `sum`, `min`, `max` and `extremes`: it can land far outside `[sts.min, sts.max]`. A flat sum line at 30 built from 2 source series reports `min=30, avg=15, max=30`, and the error grows with the number of sources — a fleet chart summing 1,000 devices reports an average 1,000× too small, while the plotted data is correct.

**Root cause.** The final statistics pass in `rrd2rrdr_group_by_finalize()` accumulates the pair `(sum += value, count += gbc)` per output dimension, and the formatter derives `avg = sum/count`. For `average` this is correct by construction: `sum` accumulates the pre-division group sums, so `Σsums/Σgbc` is the weighted mean of the plotted points. For every other aggregation the plotted value is already the final group aggregate — the sum, the min, the max — so dividing by the number of per-point source contributions averages the values over a population they do not describe. This is the same accounting that #23035 fixed for `percentage`; `sum`/`min`/`max` have the identical disease.

**Fix.** Generalize the row-consistent statistics introduced by #23035 from `percentage` to every aggregation except `average` (`sum`, `min`, `max`, `extremes`): accumulate `count` per non-empty view row (and the anomaly rate per-row accordingly). `sts.avg` becomes the mean of the plotted points, consistent with `sts.min`/`sts.max` which are row extremes. For `min`/`max` queries this makes `sts.avg` the mean of the per-row group minima/maxima — the only meaning consistent with the rest of the block.

##### Scope / what is intentionally NOT affected

- **Aggregatable (`raw`) responses are byte-identical.** The `(sum, gbc)` pair is kept as-is; the consumer (Netdata Cloud) derives the statistics.
- **`average` is unchanged** — its weighted pair is correct today.
- **`percentage` is unchanged** — it already uses row-consistent statistics since #23035.
- The plotted data, `gbc`, `dgbc`, partial-data flagging, and v1 endpoints are untouched.

##### Test Plan

Validated red/green with a scripted streaming child pushing deterministic fixtures (fixed timestamps, hand-computable values) to a stock parent: two instances of one context streaming constants 10 and 20 (60 points, one scripted anomalous sample), plus a two-dimension chart for the percentage control.

| query | plotted line | sts.avg before | sts.avg after |
|---|---|---|---|
| `aggregation=sum` | 30 (all points) | **15** | **30** ✓ |
| `aggregation=min` | 10 | **5** | **10** ✓ |
| `aggregation=max` | 20 | **10** | **20** ✓ |
| `aggregation=extremes` | 20 | 10 | **20** ✓ |
| `aggregation=avg` (control) | 15 | 15 | 15 (unchanged) |
| `aggregation=percentage` (control) | 25 | 25 | 25 (unchanged) |
| `options=raw` sum control | — | (sum=1800, count=120) | identical (unchanged) |

The anomaly rate follows: with one anomalous source sample in one row of two contributions, `arp` reports the mean row anomaly rate (≈0.83% over 60 rows).

##### Additional Information

Reproduction on any live agent: pick a context with more than one instance, query `/api/v3/data?scope_contexts=X&group_by=selected&aggregation=sum&format=json2&options=jsonwrap` and compare `view.dimensions.sts.avg` with the plotted values — the avg reads roughly `true_avg / number_of_source_series`.

<details> <summary>For users: How does this change affect me?</summary>

Affected area: the min/avg/max summary shown next to each dimension under charts, and anything that sorts or ranks by the average, whenever the chart uses the sum, min or max grouping (the plotted lines were always correct).

Before this change, the "Avg" column under such charts was too small by a factor equal to the number of sources aggregated (instances/nodes). With this change it reports the true average of the plotted points. No configuration change; no data or API shape changes — only the values become correct.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrong `view.dimensions.sts.avg` for group-by `sum`, `min`, `max`, and `extremes`. Averages are now computed per row, so they match the plotted values and stay within `[sts.min, sts.max]`.

- **Bug Fixes**
  - Use row-based counting for stats in all aggregations except `average` (non-aggregatable responses).
  - Align anomaly rate with row-based stats (mean per row).
  - Keep aggregatable (`raw`) responses unchanged; `(sum, gbc)` is still emitted.
  - No changes to plotted data, `gbc`/`dgbc`, partial-data flags, or v1 endpoints.

<sup>Written for commit 920062b6da41801fa529f762e2a629e61ef081a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

