### PR TITLE
Netdata fixes part 63

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3139,6 +3139,10 @@ if(OS_LINUX)
     target_link_libraries(apps-cgroups-lookup-client-abort-test libnetdata)
 endif()
 
+add_executable(stream-receiver-hops-test EXCLUDE_FROM_ALL
+        src/streaming/tests/stream-handshake-hops-test.c)
+target_link_libraries(stream-receiver-hops-test libnetdata)
+
 if(ENABLE_CGROUPS_LOOKUP_SERVER)
     add_executable(cgroup-lookup-netipc-test EXCLUDE_FROM_ALL
             src/collectors/cgroups.plugin/tests/test_cgroup_lookup_netipc.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -977,6 +977,7 @@ set(LIBNETDATA_FILES
         src/libnetdata/clocks/clocks.h
         src/libnetdata/clocks/clocks-internals.h
         src/libnetdata/clocks/clocks-unittest.c
+        src/libnetdata/clocks/time_t_arithmetic.h
         src/libnetdata/completion/completion.c
         src/libnetdata/completion/completion.h
         src/libnetdata/datetime/iso8601.c

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -232,6 +232,7 @@ int health_config_unittest(void);
 int utf8_sanitizer_unittest(void);
 int yaml_unittest(void);
 int json_c_parser_unittest(void);
+int stream_path_json_unittest(void);
 int query_plan_unittest(void);
 #ifdef ENABLE_ML
 int ml_unittest(void);
@@ -399,6 +400,8 @@ int netdata_main(int argc, char **argv) {
                         if(strcmp(optarg, "jsonctest") == 0) {
                             unittest_running = true;
                             if (json_c_parser_unittest()) return 1;
+                            if (stream_path_json_unittest())
+                                return 1;
                             fprintf(stderr, "\n\nJSON-C PARSER TESTS PASSED\n\n");
                             return 0;
                         }
@@ -477,6 +480,8 @@ int netdata_main(int argc, char **argv) {
                             if (health_config_unittest()) return 1;
                             if (yaml_unittest()) return 1;
                             if (json_c_parser_unittest()) return 1;
+                            if (stream_path_json_unittest())
+                                return 1;
                             if (unittest_waiting_queue()) return 1;
                             if (rw_spinlock_unittest()) return 1;
                             if (uuidmap_unittest()) return 1;

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -187,7 +187,7 @@ static void insert_alert_queue(
     if (!aclk_host_config)
         return;
 
-    time_t submit_delay = trigger_time + calculate_delay(old_status, new_status);
+    time_t submit_delay = nd_time_t_add_saturating(trigger_time, calculate_delay(old_status, new_status));
 
     int param = 0;
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &host->host_id.uuid, sizeof(host->host_id.uuid), SQLITE_STATIC));

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -160,7 +160,7 @@ static inline int rrdcalc_isrunnable(RRDCALC *rc, RRDSET *st, time_t now, time_t
     time_t first = rrdset_first_entry_s(st);
     time_t last = rrdset_last_entry_s(st);
 
-    if(unlikely(now + update_every < first /* || now - update_every > last */)) {
+    if(unlikely(nd_time_t_add_compare(now, update_every, first) < 0 /* || now - update_every > last */)) {
         netdata_log_debug(D_HEALTH
                           , "Health not examining alarm '%s.%s' yet (wanted time is out of bounds - we need %lu but got %lu - %lu)."
                           , rrdcalc_chart_name(rc), rrdcalc_name(rc), (unsigned long) now, (unsigned long) first
@@ -169,9 +169,11 @@ static inline int rrdcalc_isrunnable(RRDCALC *rc, RRDSET *st, time_t now, time_t
     }
 
     if(RRDCALC_HAS_DB_LOOKUP(rc)) {
-        time_t needed = now + rc->config.before + rc->config.after;
+        intmax_t lookup_offset = (intmax_t)rc->config.before + (intmax_t)rc->config.after;
+        time_t needed = nd_time_t_add_saturating(now, lookup_offset);
 
-        if(needed + update_every < first || needed - update_every > last) {
+        if(nd_time_t_add_compare(now, lookup_offset + update_every, first) < 0 ||
+           nd_time_t_add_compare(now, lookup_offset - update_every, last) > 0) {
             netdata_log_debug(D_HEALTH,
                 "Health not examining alarm '%s.%s' yet (not enough data yet - we need %lu but got %lu - %lu).",
                 rrdcalc_chart_name(rc),
@@ -395,7 +397,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                health_globals.config.postpone_alarms_during_hibernation_for_seconds);
 
         host->health.delay_up_to =
-            now + health_globals.config.postpone_alarms_during_hibernation_for_seconds;
+            nd_time_t_add_saturating(now, health_globals.config.postpone_alarms_during_hibernation_for_seconds);
     }
 
     if (unlikely(host->health.delay_up_to)) {
@@ -471,7 +473,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
         // has stopped being collected for 60 seconds
         if (unlikely(rc->status != RRDCALC_STATUS_REMOVED &&
                      rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) &&
-                     now > (st->last_collected_time.tv_sec + 60))) {
+                     nd_time_t_add_compare(st->last_collected_time.tv_sec, 60, now) < 0)) {
 
             if (!rrdcalc_isrepeating(rc)) {
                 worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
@@ -696,7 +698,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                 //      delay = (int)(rc->delay_up_to_timestamp - now);
 
                 rc->delay_last = delay;
-                rc->delay_up_to_timestamp = now + delay;
+                rc->delay_up_to_timestamp = nd_time_t_add_saturating(now, delay);
 
                 ALARM_ENTRY *ae = health_create_alarm_entry(
                     host,
@@ -740,7 +742,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
             }
 
             rc->last_updated = now;
-            rc->next_update = now + rc->config.update_every;
+            rc->next_update = nd_time_t_add_saturating(now, rc->config.update_every);
 
             if (*next_run > rc->next_update)
                 *next_run = rc->next_update;
@@ -775,7 +777,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
             else
                 continue;
 
-            if(unlikely(repeat_every > 0 && (rc->last_repeat + repeat_every) <= now)) {
+            if(unlikely(repeat_every > 0 && nd_time_t_add_compare(rc->last_repeat, repeat_every, now) <= 0)) {
                 RRDSET *st = NULL;
                 RRDSET_ACQUIRED *rsa = rrdcalc_rrdset_acquire_linked(host, rc, &st);
                 if(unlikely(!rsa))
@@ -785,6 +787,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                     rrdset_acquired_release(rsa);
                     continue;
                 }
+
 
                 worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
                 rc->last_repeat = now;
@@ -873,7 +876,7 @@ static void health_event_loop(void) {
 
         time_t now = now_realtime_sec();
         bool apply_hibernation_delay = false;
-        time_t next_run = now + health_globals.config.run_at_least_every_seconds;
+        time_t next_run = nd_time_t_add_saturating(now, health_globals.config.run_at_least_every_seconds);
 
         if (unlikely(check_if_resumed_from_suspension())) {
             apply_hibernation_delay = true;

--- a/src/health/health_log.c
+++ b/src/health/health_log.c
@@ -248,7 +248,7 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     ae->new_status = new_status;
     ae->duration = duration;
     ae->delay = delay;
-    ae->delay_up_to_timestamp = when + delay;
+    ae->delay_up_to_timestamp = nd_time_t_add_saturating(when, delay);
     ae->flags |= flags;
 
     ae->last_repeat = 0;
@@ -366,7 +366,7 @@ void health_alarm_log_cleanup(RRDHOST *host) {
     ALARM_ENTRY *ae = host->health_log.alarms;
     while(ae) {
         // Check if entry is old enough to be deleted
-        if(ae->when < now - retention && 
+        if(nd_time_t_add_compare(now, -(intmax_t)retention, ae->when) > 0 &&
            (ae->flags & HEALTH_ENTRY_FLAG_UPDATED) && // Only remove entries that have been processed/updated
            __atomic_load_n(&ae->pending_save_count, __ATOMIC_RELAXED) == 0) { // Only remove entries not pending save
             

--- a/src/health/health_notifications.c
+++ b/src/health/health_notifications.c
@@ -580,7 +580,7 @@ void health_alarm_log_process_to_send_notifications(RRDHOST *host, struct health
             ||
             ((ae->new_status == RRDCALC_STATUS_REMOVED) &&
              (ae->flags & HEALTH_ENTRY_FLAG_SAVED) &&
-             (ae->when + 86400 < now_realtime_sec())))
+             (nd_time_t_add_compare(ae->when, 86400, now_realtime_sec()) < 0)))
         {
             DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(host->health_log.alarms, ae, prev, next);
             health_alarm_log_free_one_nochecks_nounlink(ae);

--- a/src/libnetdata/clocks/clocks-unittest.c
+++ b/src/libnetdata/clocks/clocks-unittest.c
@@ -102,6 +102,46 @@ static int clocks_usec_delta_or_zero_saturates_backward_samples(void) {
     return errors;
 }
 
+static int clocks_time_t_arithmetic_preserves_order(void) {
+    int errors = 0;
+    const time_t maximum = nd_time_t_max();
+    const time_t minimum = nd_time_t_min();
+
+    CLOCKS_TEST(nd_time_t_add_saturating(100, 23) == 123,
+                "representable positive time_t addition is preserved");
+    CLOCKS_TEST(nd_time_t_add_saturating(100, -23) == 77,
+                "representable negative time_t addition is preserved");
+    CLOCKS_TEST(nd_time_t_add_saturating(maximum, 1) == maximum,
+                "positive time_t overflow saturates at the maximum");
+    CLOCKS_TEST(nd_time_t_add_saturating(minimum, -1) == minimum,
+                "negative time_t overflow saturates at the minimum");
+
+    CLOCKS_TEST(nd_time_t_add_compare(maximum, 1, maximum) > 0,
+                "an unrepresentable future sum remains after every time_t");
+    CLOCKS_TEST(nd_time_t_add_compare(minimum, -1, minimum) < 0,
+                "an unrepresentable past sum remains before every time_t");
+    CLOCKS_TEST(nd_time_t_add_compare(maximum, -1, maximum) < 0,
+                "a representable boundary subtraction preserves ordering");
+    CLOCKS_TEST(nd_time_t_add_compare(minimum, 1, minimum) > 0,
+                "a representable boundary addition preserves ordering");
+    CLOCKS_TEST(nd_time_t_add_compare(100, 23, 123) == 0,
+                "representable time_t addition preserves equality");
+
+    intmax_t combined_offset = (intmax_t)INT_MAX + (intmax_t)INT_MAX - (intmax_t)INT_MAX;
+    CLOCKS_TEST(nd_time_t_add_compare(maximum - INT_MAX, combined_offset, maximum) == 0,
+                "combined offsets are compared after mathematical cancellation");
+
+    if(sizeof(time_t) < sizeof(intmax_t)) {
+        intmax_t beyond_time_t = (intmax_t)maximum + 1;
+        CLOCKS_TEST(nd_time_t_add_saturating(0, beyond_time_t) == maximum,
+                    "wide positive offset saturates on narrower time_t");
+        CLOCKS_TEST(nd_time_t_add_compare(0, beyond_time_t, maximum) > 0,
+                    "wide positive offset compares beyond narrower time_t");
+    }
+
+    return errors;
+}
+
 int clocks_unittest(void) {
     int errors = 0;
 
@@ -112,6 +152,7 @@ int clocks_unittest(void) {
     errors += clocks_retry_stops_when_budget_is_exhausted();
     errors += clocks_retry_treats_backward_monotonic_sample_as_no_elapsed_time();
     errors += clocks_usec_delta_or_zero_saturates_backward_samples();
+    errors += clocks_time_t_arithmetic_preserves_order();
 
     if(errors)
         fprintf(stderr, "clocks unittest: %d ERROR(S)\n", errors);

--- a/src/libnetdata/clocks/clocks.h
+++ b/src/libnetdata/clocks/clocks.h
@@ -5,6 +5,7 @@
 
 #include "../libnetdata.h"
 #include "libnetdata/os/random.h"
+#include "time_t_arithmetic.h"
 
 #ifndef HAVE_CLOCK_GETTIME
 struct timespec {

--- a/src/libnetdata/clocks/time_t_arithmetic.h
+++ b/src/libnetdata/clocks/time_t_arithmetic.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_TIME_T_ARITHMETIC_H
+#define NETDATA_TIME_T_ARITHMETIC_H 1
+
+#include <limits.h>
+#include <stdint.h>
+#include <time.h>
+
+#ifdef __cplusplus
+static_assert((time_t)-1 < (time_t)0, "time arithmetic requires signed time_t");
+static_assert(sizeof(time_t) <= sizeof(intmax_t), "time_t must fit in intmax_t");
+#else
+_Static_assert((time_t)-1 < (time_t)0, "time arithmetic requires signed time_t");
+_Static_assert(sizeof(time_t) <= sizeof(intmax_t), "time_t must fit in intmax_t");
+#endif
+
+static inline time_t nd_time_t_max(void) {
+    return (time_t)(((uintmax_t)1 << (sizeof(time_t) * CHAR_BIT - 1)) - 1);
+}
+
+static inline time_t nd_time_t_min(void) {
+    return -nd_time_t_max() - 1;
+}
+
+// Compare the mathematical sum to a time_t without first narrowing the sum.
+static inline int nd_time_t_add_compare(time_t base, intmax_t offset, time_t value) {
+    intmax_t sum;
+    if(__builtin_add_overflow((intmax_t)base, offset, &sum))
+        return offset < 0 ? -1 : 1;
+
+    return (sum > (intmax_t)value) - (sum < (intmax_t)value);
+}
+
+// Preserve every representable sum and keep unrepresentable timestamps monotonic.
+static inline time_t nd_time_t_add_saturating(time_t base, intmax_t offset) {
+    intmax_t sum;
+    if(__builtin_add_overflow((intmax_t)base, offset, &sum))
+        return offset < 0 ? nd_time_t_min() : nd_time_t_max();
+
+    if(sum > (intmax_t)nd_time_t_max())
+        return nd_time_t_max();
+
+    if(sum < (intmax_t)nd_time_t_min())
+        return nd_time_t_min();
+
+    return (time_t)sum;
+}
+
+#endif // NETDATA_TIME_T_ARITHMETIC_H

--- a/src/streaming/stream-path.c
+++ b/src/streaming/stream-path.c
@@ -6,6 +6,8 @@
 #include "stream-sender-internals.h"
 #include "plugins.d/pluginsd_internals.h"
 
+#define STREAM_PATH_MAX_ENTRIES UINT16_MAX
+
 typedef enum __attribute__((packed)) {
     STREAM_PATH_FLAG_NONE       = 0,
     STREAM_PATH_FLAG_ACLK       = (1 << 0),
@@ -328,17 +330,22 @@ void stream_path_node_id_updated(RRDHOST *host) {
 
 static bool parse_single_path(json_object *jobj, const char *path, STREAM_PATH *p, BUFFER *error) {
     uint32_t version = 0;
+    int64_t hops = 0;
+    uint64_t since = 0;
+    uint64_t first_time_t = 0;
+    int64_t start_time_ms = 0;
+    int64_t shutdown_time_ms = 0;
     JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "version", version, error, JSONC_OPTIONAL);
 
     JSONC_PARSE_TXT2STRING_OR_ERROR_AND_RETURN(jobj, path, "hostname", p->hostname, error, JSONC_REQUIRED);
     JSONC_PARSE_TXT2UUID_OR_ERROR_AND_RETURN(jobj, path, "host_id", p->host_id.uuid, error, JSONC_REQUIRED);
     JSONC_PARSE_TXT2UUID_OR_ERROR_AND_RETURN(jobj, path, "node_id", p->node_id.uuid, error, JSONC_REQUIRED);
     JSONC_PARSE_TXT2UUID_OR_ERROR_AND_RETURN(jobj, path, "claim_id", p->claim_id.uuid, error, JSONC_REQUIRED);
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "hops", p->hops, error, JSONC_REQUIRED);
-    JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "since", p->since, error, JSONC_REQUIRED);
-    JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "first_time_t", p->first_time_t, error, JSONC_REQUIRED);
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "start_time", p->start_time_ms, error, JSONC_REQUIRED);
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "shutdown_time", p->shutdown_time_ms, error, JSONC_REQUIRED);
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "hops", hops, error, JSONC_REQUIRED);
+    JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "since", since, error, JSONC_REQUIRED);
+    JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "first_time_t", first_time_t, error, JSONC_REQUIRED);
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "start_time", start_time_ms, error, JSONC_REQUIRED);
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "shutdown_time", shutdown_time_ms, error, JSONC_REQUIRED);
     JSONC_PARSE_ARRAY_OF_TXT2BITMAP_OR_ERROR_AND_RETURN(jobj, path, "flags", STREAM_PATH_FLAGS_2id_one, p->flags, error, JSONC_OPTIONAL);
     JSONC_PARSE_ARRAY_OF_TXT2BITMAP_OR_ERROR_AND_RETURN(jobj, path, "capabilities", stream_capabilities_parse_one, p->capabilities, error, JSONC_OPTIONAL);
 
@@ -352,8 +359,13 @@ static bool parse_single_path(json_object *jobj, const char *path, STREAM_PATH *
         return false;
     }
 
-    if(p->hops < 0) {
+    if (hops < 0) {
         buffer_strcat(error, "hops cannot be negative (probably the child disconnected from the Netdata before us");
+        return false;
+    }
+
+    if (hops > INT16_MAX) {
+        buffer_sprintf(error, "hops cannot exceed %d", INT16_MAX);
         return false;
     }
 
@@ -362,10 +374,36 @@ static bool parse_single_path(json_object *jobj, const char *path, STREAM_PATH *
         return false;
     }
 
-    if(p->since <= 0) {
+    if (since == 0) {
         buffer_strcat(error, "since cannot be <= 0");
         return false;
     }
+
+    if (since > (uint64_t)nd_time_t_max()) {
+        buffer_sprintf(error, "since cannot exceed %" PRIdMAX, (intmax_t)nd_time_t_max());
+        return false;
+    }
+
+    if (first_time_t > (uint64_t)nd_time_t_max()) {
+        buffer_sprintf(error, "first_time_t cannot exceed %" PRIdMAX, (intmax_t)nd_time_t_max());
+        return false;
+    }
+
+    if (start_time_ms < 0 || start_time_ms > (int64_t)UINT32_MAX) {
+        buffer_sprintf(error, "start_time must be between 0 and %" PRIu32, UINT32_MAX);
+        return false;
+    }
+
+    if (shutdown_time_ms < 0 || shutdown_time_ms > (int64_t)UINT32_MAX) {
+        buffer_sprintf(error, "shutdown_time must be between 0 and %" PRIu32, UINT32_MAX);
+        return false;
+    }
+
+    p->hops = (int16_t)hops;
+    p->since = (time_t)since;
+    p->first_time_t = (time_t)first_time_t;
+    p->start_time_ms = (uint32_t)start_time_ms;
+    p->shutdown_time_ms = (uint32_t)shutdown_time_ms;
 
     return true;
 }
@@ -411,26 +449,44 @@ bool stream_path_set_from_json(RRDHOST *host, const char *json, bool from_parent
     if (json_object_object_get_ex(jobj, STREAM_PATH_JSON_MEMBER, &_jarray) &&
         json_object_is_type(_jarray, json_type_array)) {
         size_t items = json_object_array_length(_jarray);
-        host->stream.path.array = callocz(items, sizeof(*host->stream.path.array));
-        host->stream.path.size = items;
+        if (items > STREAM_PATH_MAX_ENTRIES) {
+            nd_log(
+                NDLS_DAEMON,
+                NDLP_ERR,
+                "STREAM PATH '%s': Array has %zu items, but the maximum is %u",
+                rrdhost_hostname(host),
+                items,
+                (unsigned int)STREAM_PATH_MAX_ENTRIES);
+        } else {
+            host->stream.path.array = callocz(items, sizeof(*host->stream.path.array));
+            host->stream.path.size = (uint16_t)items;
 
-        for (size_t i = 0; i < items; ++i) {
-            json_object *joption = json_object_array_get_idx(_jarray, i);
-            if (!json_object_is_type(joption, json_type_object)) {
-                nd_log(NDLS_DAEMON, NDLP_ERR,
-                       "STREAM PATH '%s': Array item No %zu is not an object: %s",
-                       rrdhost_hostname(host), i, json);
-                continue;
-            }
+            for (size_t i = 0; i < items; ++i) {
+                json_object *joption = json_object_array_get_idx(_jarray, i);
+                if (!json_object_is_type(joption, json_type_object)) {
+                    nd_log(
+                        NDLS_DAEMON,
+                        NDLP_ERR,
+                        "STREAM PATH '%s': Array item No %zu is not an object: %s",
+                        rrdhost_hostname(host),
+                        i,
+                        json);
+                    continue;
+                }
 
-            if(!parse_single_path(joption, "", &host->stream.path.array[host->stream.path.used], error)) {
-                stream_path_cleanup(&host->stream.path.array[host->stream.path.used]);
-                nd_log(NDLS_DAEMON, NDLP_ERR,
-                       "STREAM PATH '%s': Array item No %zu cannot be parsed: %s: %s",
-                       rrdhost_hostname(host), i, buffer_tostring(error), json);
+                if (!parse_single_path(joption, "", &host->stream.path.array[host->stream.path.used], error)) {
+                    stream_path_cleanup(&host->stream.path.array[host->stream.path.used]);
+                    nd_log(
+                        NDLS_DAEMON,
+                        NDLP_ERR,
+                        "STREAM PATH '%s': Array item No %zu cannot be parsed: %s: %s",
+                        rrdhost_hostname(host),
+                        i,
+                        buffer_tostring(error),
+                        json);
+                } else
+                    host->stream.path.used++;
             }
-            else
-                host->stream.path.used++;
         }
     }
 
@@ -457,4 +513,184 @@ bool stream_path_set_from_json(RRDHOST *host, const char *json, bool from_parent
 
 void rrdhost_stream_path_init(RRDHOST *host) {
     rw_spinlock_init(&host->stream.path.spinlock);
+}
+
+int stream_path_json_unittest(void)
+{
+    char time_t_max_str[32];
+    char after_time_t_max_str[32];
+    char after_time_t_max_quoted_str[34];
+    uint64_t time_t_max = (uint64_t)nd_time_t_max();
+    uint64_t after_time_t_max = time_t_max + 1;
+    snprintfz(time_t_max_str, sizeof(time_t_max_str), "%" PRIu64, time_t_max);
+    snprintfz(after_time_t_max_str, sizeof(after_time_t_max_str), "%" PRIu64, after_time_t_max);
+    snprintfz(after_time_t_max_quoted_str, sizeof(after_time_t_max_quoted_str), "\"%" PRIu64 "\"", after_time_t_max);
+
+    struct stream_path_json_test {
+        const char *name;
+        const char *hops;
+        const char *start_time;
+        const char *shutdown_time;
+        bool expected_ok;
+        int16_t expected_hops;
+        uint32_t expected_start_time;
+        uint32_t expected_shutdown_time;
+        const char *since;
+        const char *first_time_t;
+        bool check_timestamps;
+        time_t expected_since;
+        time_t expected_first_time_t;
+    } tests[] = {
+        {"exact endpoints", "32767", "4294967295", "4294967295", true, INT16_MAX, UINT32_MAX, UINT32_MAX},
+        {"lower endpoints", "0", "0", "0", true, 0, 0, 0, "1", "0", true, 1, 0},
+        {"boolean and null coercions", "true", "null", "false", true, 1, 0, 0, "true", "null", true, 1, 0},
+        {"double truncation", "1.9", "1.9", "1.9", true, 1, 1, 1, "1.9", "1.9", true, 1, 1},
+        {"fractional zero coercion", "0.9", "-0.5", "-0.5", true, 0, 0, 0, "1", "0.9", true, 1, 0},
+        {"hops below destination", "-65536", "1", "1", false, 0, 0, 0},
+        {"hops positive wrap", "65536", "1", "1", false, 0, 0, 0},
+        {"hops string wrap", "\"65536\"", "1", "1", false, 0, 0, 0},
+        {"negative start time", "1", "-1", "1", false, 0, 0, 0},
+        {"start time above endpoint", "1", "4294967296", "1", false, 0, 0, 0},
+        {"start time string wrap", "1", "\"4294967296\"", "1", false, 0, 0, 0},
+        {"negative shutdown time", "1", "1", "-1", false, 0, 0, 0},
+        {"shutdown time above endpoint", "1", "1", "4294967296", false, 0, 0, 0},
+        {"shutdown time string wrap", "1", "1", "\"4294967296\"", false, 0, 0, 0},
+        {"time_t upper endpoints",
+         "1",
+         "1",
+         "1",
+         true,
+         1,
+         1,
+         1,
+         time_t_max_str,
+         time_t_max_str,
+         true,
+         (time_t)time_t_max,
+         (time_t)time_t_max},
+        {"since above time_t", "1", "1", "1", false, 0, 0, 0, after_time_t_max_str, "1"},
+        {"since string above time_t", "1", "1", "1", false, 0, 0, 0, after_time_t_max_quoted_str, "1"},
+        {"first_time_t above time_t", "1", "1", "1", false, 0, 0, 0, "1", after_time_t_max_str},
+        {"first_time_t string above time_t", "1", "1", "1", false, 0, 0, 0, "1", after_time_t_max_quoted_str},
+        {"first_time_t negative integer coercion", "1", "1", "1", true, 1, 1, 1, "1", "-1", true, 1, 0},
+    };
+
+    int failed = 0;
+    BUFFER *wb = buffer_create(0, NULL);
+    BUFFER *error = buffer_create(0, NULL);
+
+    fprintf(stderr, "\nStream Path JSON Unit Tests\n===========================\n");
+
+    for (size_t i = 0; i < _countof(tests); i++) {
+        buffer_flush(wb);
+        buffer_flush(error);
+        buffer_sprintf(
+            wb,
+            "{\"hostname\":\"test-host\","
+            "\"host_id\":\"11111111-1111-1111-1111-111111111111\","
+            "\"node_id\":\"00000000-0000-0000-0000-000000000000\","
+            "\"claim_id\":\"00000000-0000-0000-0000-000000000000\","
+            "\"hops\":%s,\"since\":%s,\"first_time_t\":%s,"
+            "\"start_time\":%s,\"shutdown_time\":%s,"
+            "\"capabilities\":[\"V1\"]}",
+            tests[i].hops,
+            tests[i].since ? tests[i].since : "1",
+            tests[i].first_time_t ? tests[i].first_time_t : "1",
+            tests[i].start_time,
+            tests[i].shutdown_time);
+
+        json_object *jobj = json_tokener_parse(buffer_tostring(wb));
+        STREAM_PATH p = {
+            .hops = 123,
+            .since = 123,
+            .first_time_t = 123,
+            .start_time_ms = 123,
+            .shutdown_time_ms = 123,
+        };
+        bool ok = jobj && parse_single_path(jobj, "", &p, error);
+
+        time_t expected_since = tests[i].check_timestamps ? tests[i].expected_since : 1;
+        time_t expected_first_time_t = tests[i].check_timestamps ? tests[i].expected_first_time_t : 1;
+        bool values_ok = ok && p.hops == tests[i].expected_hops && p.since == expected_since &&
+                         p.first_time_t == expected_first_time_t && p.start_time_ms == tests[i].expected_start_time &&
+                         p.shutdown_time_ms == tests[i].expected_shutdown_time;
+        bool failure_unchanged = !ok && p.hops == 123 && p.since == 123 && p.first_time_t == 123 &&
+                                 p.start_time_ms == 123 && p.shutdown_time_ms == 123;
+
+        if (ok != tests[i].expected_ok || (ok && !values_ok) || (!ok && !failure_unchanged)) {
+            fprintf(
+                stderr,
+                "FAILED: %s (expected %s, got %s; hops=%d, since=%" PRId64 ", first_time_t=%" PRId64 ", start=%" PRIu32
+                ", shutdown=%" PRIu32 ", error='%s')\n",
+                tests[i].name,
+                tests[i].expected_ok ? "success" : "failure",
+                ok ? "success" : "failure",
+                p.hops,
+                (int64_t)p.since,
+                (int64_t)p.first_time_t,
+                p.start_time_ms,
+                p.shutdown_time_ms,
+                buffer_tostring(error));
+            failed++;
+        }
+
+        stream_path_cleanup(&p);
+        if (jobj)
+            json_object_put(jobj);
+    }
+
+    const char invalid_payload[] = "{\"streaming_path\":[{"
+                                   "\"hostname\":\"test-host\","
+                                   "\"host_id\":\"11111111-1111-1111-1111-111111111111\","
+                                   "\"node_id\":\"00000000-0000-0000-0000-000000000000\","
+                                   "\"claim_id\":\"00000000-0000-0000-0000-000000000000\","
+                                   "\"hops\":65536,\"since\":1,\"first_time_t\":1,"
+                                   "\"start_time\":1,\"shutdown_time\":1,"
+                                   "\"capabilities\":[\"V1\"]}]}";
+    RRDHOST host = {.hostname = string_strdupz("test-host")};
+    rrdhost_stream_path_init(&host);
+
+    for (size_t i = 0; i < 2; i++) {
+        bool from_parent = i != 0;
+        bool ok = stream_path_set_from_json(&host, invalid_payload, from_parent);
+        if (ok || host.stream.path.used != 0) {
+            fprintf(
+                stderr,
+                "FAILED: %s stream_path_set_from_json caller accepted or published an invalid item\n",
+                from_parent ? "parent" : "child");
+            failed++;
+        }
+        rrdhost_stream_path_clear(&host, true);
+    }
+
+    BUFFER *oversized = buffer_create(0, NULL);
+    buffer_strcat(oversized, "{\"streaming_path\":[");
+    for (size_t i = 0; i <= STREAM_PATH_MAX_ENTRIES; i++) {
+        if (i)
+            buffer_fast_strcat(oversized, ",", 1);
+        buffer_fast_strcat(oversized, "null", 4);
+    }
+    buffer_strcat(oversized, "]}");
+
+    for (size_t i = 0; i < 2; i++) {
+        bool from_parent = i != 0;
+        bool ok = stream_path_set_from_json(&host, buffer_tostring(oversized), from_parent);
+        if (ok || host.stream.path.array || host.stream.path.size || host.stream.path.used) {
+            fprintf(
+                stderr,
+                "FAILED: %s stream_path_set_from_json caller accepted an oversized array\n",
+                from_parent ? "parent" : "child");
+            failed++;
+        }
+    }
+    buffer_free(oversized);
+
+    string_freez(host.hostname);
+    buffer_free(error);
+    buffer_free(wb);
+
+    if (!failed)
+        fprintf(stderr, "All %zu stream path JSON scalar tests and cardinality checks passed.\n", _countof(tests));
+
+    return failed;
 }

--- a/src/streaming/stream-receiver-connection.c
+++ b/src/streaming/stream-receiver-connection.c
@@ -377,6 +377,7 @@ int stream_receiver_accept_connection(struct web_client *w, char *decoded_query_
     rpt->config.update_every = nd_profile.update_every;
 
     // parse the parameters and fill rpt and rpt->system_info
+    bool invalid_hops = false;
 
     while(decoded_query_string) {
         char *value = strsep_skip_consecutive_separators(&decoded_query_string, "&");
@@ -414,8 +415,12 @@ int stream_receiver_accept_connection(struct web_client *w, char *decoded_query_
             rpt->utc_offset = (int32_t)strtol(value, NULL, 0);
 
         else if(!strcmp(name, "hops")) {
-            rpt->hops = (int16_t)strtol(value, NULL, 0);
-            rrdhost_system_info_hops_set(rpt->system_info, rpt->hops);
+            int16_t hops;
+            invalid_hops = !stream_receiver_parse_hops(value, &hops);
+            if(!invalid_hops) {
+                rpt->hops = hops;
+                rrdhost_system_info_hops_set(rpt->system_info, rpt->hops);
+            }
         }
 
         else if(!strcmp(name, "ml_capable"))
@@ -479,6 +484,16 @@ int stream_receiver_accept_connection(struct web_client *w, char *decoded_query_
     }
 
     // check if we should accept this connection
+
+    if(invalid_hops) {
+        stream_receiver_log_status(
+            rpt,
+            "rejecting streaming connection; request has an invalid hops value",
+            STREAM_HANDSHAKE_PARENT_DENIED_ACCESS, NDLP_WARNING);
+
+        stream_receiver_free(rpt);
+        return stream_receiver_response_permission_denied(w);
+    }
 
     if(!rpt->key || !*rpt->key) {
         stream_receiver_log_status(

--- a/src/streaming/stream-receiver-connection.c
+++ b/src/streaming/stream-receiver-connection.c
@@ -416,11 +416,12 @@ int stream_receiver_accept_connection(struct web_client *w, char *decoded_query_
 
         else if(!strcmp(name, "hops")) {
             int16_t hops;
-            invalid_hops = !stream_receiver_parse_hops(value, &hops);
-            if(!invalid_hops) {
+            if(stream_receiver_parse_hops(value, &hops)) {
                 rpt->hops = hops;
                 rrdhost_system_info_hops_set(rpt->system_info, rpt->hops);
             }
+            else
+                invalid_hops = true;
         }
 
         else if(!strcmp(name, "ml_capable"))

--- a/src/streaming/stream-receiver-internals.h
+++ b/src/streaming/stream-receiver-internals.h
@@ -19,6 +19,21 @@ void stream_receiver_log_payload(struct receiver_state *rpt, const char *payload
 #include "database/rrd.h"
 #include "plugins.d/plugins_d.h"
 
+static inline bool stream_receiver_parse_hops(const char *value, int16_t *hops) {
+    if(!value || !hops)
+        return false;
+
+    char *endptr;
+    errno = 0;
+    long parsed = strtol(value, &endptr, 0);
+
+    if(errno != 0 || endptr == value || *endptr != '\0' || parsed < 1 || parsed > INT16_MAX)
+        return false;
+
+    *hops = (int16_t)parsed;
+    return true;
+}
+
 struct parser;
 
 struct receiver_state {

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -1267,7 +1267,7 @@ RRDHOST_SET_RECEIVER_RESULT rrdhost_set_receiver(RRDHOST *host, struct receiver_
 
         if (rpt->config.health.enabled != CONFIG_BOOLEAN_NO) {
             if (rpt->config.health.delay > 0) {
-                host->health.delay_up_to = now_realtime_sec() + rpt->config.health.delay;
+                host->health.delay_up_to = nd_time_t_add_saturating(now_realtime_sec(), rpt->config.health.delay);
                 nd_log(NDLS_DAEMON, NDLP_DEBUG,
                        "STREAM RCV '%s' [from [%s]:%s]: "
                        "Postponing health checks for %" PRId64 " seconds, because it was just connected.",

--- a/src/streaming/stream-sender-execute.c
+++ b/src/streaming/stream-sender-execute.c
@@ -144,22 +144,28 @@ static void cleanup_deferred_data(struct sender_state *s) {
 
 static bool stream_sender_defer_is_end_keyword_prefix(struct sender_state *s, const char *line, size_t line_len) {
     const char *end_keyword = s->thread.defer.end_keyword;
-    if(unlikely(!end_keyword))
+    if(!end_keyword)
         return false;
 
-    size_t keyword_len = strlen(end_keyword);
+    for(size_t i = 0; i < line_len; i++) {
+        if(!end_keyword[i] || line[i] != end_keyword[i])
+            return false;
+    }
 
-    return line_len <= keyword_len && memcmp(line, end_keyword, line_len) == 0;
+    return true;
 }
 
 static bool stream_sender_defer_is_end_keyword(struct sender_state *s, const char *line, size_t line_len) {
     const char *end_keyword = s->thread.defer.end_keyword;
-    if(unlikely(!end_keyword))
+    if(!end_keyword)
         return false;
 
-    size_t keyword_len = strlen(end_keyword);
+    for(size_t i = 0; i < line_len; i++) {
+        if(!end_keyword[i] || line[i] != end_keyword[i])
+            return false;
+    }
 
-    return line_len == keyword_len && memcmp(line, end_keyword, line_len) == 0;
+    return end_keyword[line_len] == '\0';
 }
 
 static bool stream_sender_defer_payload_append(struct sender_state *s, const char *line, size_t line_len, bool add_newline) {

--- a/src/streaming/tests/stream-handshake-hops-test.c
+++ b/src/streaming/tests/stream-handshake-hops-test.c
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "libnetdata/libnetdata.h"
+#include "streaming/stream-receiver-internals.h"
+
+typedef struct {
+    const char *value;
+    bool valid;
+    int16_t expected;
+} HOPS_TEST;
+
+static bool check_hops(const HOPS_TEST *test) {
+    int16_t hops = 12345;
+    bool valid = stream_receiver_parse_hops(test->value, &hops);
+
+    if(valid != test->valid) {
+        fprintf(stderr, "hops value '%s' was %s, expected %s\n",
+                test->value ? test->value : "(null)",
+                valid ? "accepted" : "rejected",
+                test->valid ? "accepted" : "rejected");
+        return false;
+    }
+
+    if(valid && hops != test->expected) {
+        fprintf(stderr, "hops value '%s' parsed as %d, expected %d\n",
+                test->value, hops, test->expected);
+        return false;
+    }
+
+    if(!valid && hops != 12345) {
+        fprintf(stderr, "rejected hops value '%s' changed the output to %d\n",
+                test->value ? test->value : "(null)", hops);
+        return false;
+    }
+
+    return true;
+}
+
+int main(void) {
+    static const HOPS_TEST tests[] = {
+        { .value = "1", .valid = true, .expected = 1 },
+        { .value = "42", .valid = true, .expected = 42 },
+        { .value = "32767", .valid = true, .expected = INT16_MAX },
+        { .value = "+42", .valid = true, .expected = 42 },
+        { .value = " 42", .valid = true, .expected = 42 },
+        { .value = "0x2a", .valid = true, .expected = 42 },
+        { .value = "052", .valid = true, .expected = 42 },
+
+        { .value = NULL, .valid = false },
+        { .value = "", .valid = false },
+        { .value = " ", .valid = false },
+        { .value = "+", .valid = false },
+        { .value = "-", .valid = false },
+        { .value = "0", .valid = false },
+        { .value = "-0", .valid = false },
+        { .value = "-1", .valid = false },
+        { .value = "-32768", .valid = false },
+        { .value = "-32769", .valid = false },
+        { .value = "32768", .valid = false },
+        { .value = "65535", .valid = false },
+        { .value = "65536", .valid = false },
+        { .value = "0x8000", .valid = false },
+        { .value = "abc", .valid = false },
+        { .value = "0x", .valid = false },
+        { .value = "12abc", .valid = false },
+        { .value = "1 ", .valid = false },
+        { .value = "1\n", .valid = false },
+        { .value = "9223372036854775807", .valid = false },
+        { .value = "9223372036854775808", .valid = false },
+        { .value = "-9223372036854775808", .valid = false },
+        { .value = "-9223372036854775809", .valid = false },
+    };
+
+    for(size_t i = 0; i < _countof(tests); i++) {
+        if(!check_hops(&tests[i]))
+            return 1;
+    }
+
+    if(stream_receiver_parse_hops("1", NULL)) {
+        fprintf(stderr, "accepted a null output pointer\n");
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens streaming handshake validation and Stream Path JSON range checks, and makes Health scheduling safe on 32-bit `time_t`. Also hardens the sender’s deferred terminator matching and wires focused tests under `--unittest` and `--jsonctest`.

- **Bug Fixes**
  - Health time math: use `nd_time_t_add_saturating`/`nd_time_t_add_compare` for deadlines and comparisons across Health (event loop, retention/cleanup, notifications) and the SQLite alert-queue; also for receiver health delay; adds time arithmetic unittests.
  - Receiver handshake: strictly parse `hops` in 1..INT16_MAX and reject invalid requests via the permission-denied path; adds `stream-receiver-hops-test`.
  - Stream Path JSON: parse into wide locals, validate domains (`hops` 0..INT16_MAX, `since`/`first_time_t` within `time_t`, `start_time`/`shutdown_time` in 0..UINT32_MAX), cap arrays at UINT16_MAX, and assign only after validation; adds scalar/cardinality tests runnable via `--jsonctest`/`--unittest`.
  - Sender: compare end keywords byte-by-byte for prefix/exact matches to avoid unbounded reads; no behavior change for valid input.

<sup>Written for commit ba1aca0bce9b40568d65b73dc4745af2c348e038. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

