### PR TITLE
Netdata fixes part 64

### DIFF
--- a/src/daemon/dyncfg/dyncfg-files.c
+++ b/src/daemon/dyncfg/dyncfg-files.c
@@ -261,12 +261,15 @@ void dyncfg_load_all(void) {
 // schemas loading
 
 static bool dyncfg_read_file_to_buffer(const char *filename, BUFFER *dst) {
-    int fd = open(filename, O_RDONLY | O_CLOEXEC, 0666);
+    struct stat st = { 0 };
+    if(stat(filename, &st) != 0 || !S_ISREG(st.st_mode))
+        return false;
+
+    int fd = open(filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK, 0666);
     if(unlikely(fd == -1))
         return false;
 
-    struct stat st = { 0 };
-    if(fstat(fd, &st) != 0) {
+    if(fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
         close(fd);
         return false;
     }

--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -148,7 +148,16 @@ static bool machine_guid_write_to_file(const char *filename, ND_MACHINE_GUID *ho
         return false;
     }
 
-    close(fd);
+    if (close(fd) != 0) {
+        int saved_errno = errno;
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot close the temporary GUID file '%s'", tmp_filename);
+
+        if (unlink(tmp_filename) != 0)
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot remove the temporary GUID file '%s' after close failure", tmp_filename);
+
+        errno = saved_errno;
+        return false;
+    }
 
     struct timespec times[2] = {
         usec_to_timespec(h.last_modified_ut), // access time

--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -172,6 +172,8 @@ static bool machine_guid_write_to_file(const char *filename, ND_MACHINE_GUID *ho
 }
 
 static ND_MACHINE_GUID nd_machine_guid = { 0 };
+static bool nd_machine_guid_available = false;
+static SPINLOCK nd_machine_guid_spinlock = SPINLOCK_INITIALIZER;
 
 static ND_MACHINE_GUID machine_guid_get_or_create(void) {
     char pathname[FILENAME_MAX];
@@ -235,9 +237,16 @@ static ND_MACHINE_GUID machine_guid_get_or_create(void) {
 }
 
 ND_MACHINE_GUID *machine_guid_get(void) {
-    if(UUIDiszero(nd_machine_guid.uuid)) {
-        nd_machine_guid = machine_guid_get_or_create();
-        nd_setenv("NETDATA_REGISTRY_UNIQUE_ID", nd_machine_guid.txt, 1);
+    if(unlikely(!__atomic_load_n(&nd_machine_guid_available, __ATOMIC_ACQUIRE))) {
+        spinlock_lock(&nd_machine_guid_spinlock);
+
+        if(unlikely(!__atomic_load_n(&nd_machine_guid_available, __ATOMIC_ACQUIRE))) {
+            nd_machine_guid = machine_guid_get_or_create();
+            nd_setenv("NETDATA_REGISTRY_UNIQUE_ID", nd_machine_guid.txt, 1);
+            __atomic_store_n(&nd_machine_guid_available, true, __ATOMIC_RELEASE);
+        }
+
+        spinlock_unlock(&nd_machine_guid_spinlock);
     }
 
     return &nd_machine_guid;

--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -283,9 +283,8 @@ static bool machine_guid_write_to_file(const char *directory, const char *filena
         return machine_guid_close_and_unlink_temporary(fd, tmp_filename, saved_errno, "write failure");
     }
 
-    mode_t current_umask = umask(0); // Flawfinder: ignore - read and immediately restore the startup umask.
-    umask(current_umask); // Flawfinder: ignore - restore the startup umask.
-    if (fchmod(fd, 0444 & ~current_umask) != 0) {
+    // Keep the established daemon permissions without changing the process-wide umask.
+    if (fchmod(fd, 0440) != 0) {
         int saved_errno = errno;
         nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot set permissions on temporary GUID file '%s'", tmp_filename);
         return machine_guid_close_and_unlink_temporary(fd, tmp_filename, saved_errno, "permission failure");

--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -58,10 +58,24 @@ static bool machine_guid_read_from_file(const char *filename, ND_MACHINE_GUID *h
     ND_MACHINE_GUID h;
     memset(&h, 0, sizeof(h));
 
-    int fd = open(filename, O_RDONLY | O_CLOEXEC);
+    struct stat st;
+    if (stat(filename, &st) != 0 || !S_ISREG(st.st_mode)) {
+        if(log_errors)
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot open GUID file '%s' for reading", filename);
+        return false;
+    }
+
+    int fd = open(filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
     if (fd == -1) {
         if(log_errors)
             nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot open GUID file '%s' for reading", filename);
+        return false;
+    }
+
+    if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
+        if(log_errors)
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot stat the GUID file '%s'", filename);
+        close(fd);
         return false;
     }
 
@@ -92,13 +106,14 @@ static bool machine_guid_read_from_file(const char *filename, ND_MACHINE_GUID *h
         return false;
     }
 
-    struct stat st;
+    // Preserve the original post-read timestamp and metadata-error semantics.
     if (fstat(fd, &st) != 0) {
         if(log_errors)
             nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot stat the GUID file '%s'", filename);
         close(fd);
         return false;
     }
+
     close(fd);
 
     // Recreate the text version of it, ensuring lowercase format.

--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -51,7 +51,7 @@ static bool machine_guid_check_blacklisted(const char *guid) {
     return false;
 }
 
-static bool machine_guid_read_from_file(const char *filename, ND_MACHINE_GUID *host_id) {
+static bool machine_guid_read_from_file(const char *filename, ND_MACHINE_GUID *host_id, bool log_errors) {
     if (!filename || !*filename)
         return false;
 
@@ -60,32 +60,42 @@ static bool machine_guid_read_from_file(const char *filename, ND_MACHINE_GUID *h
 
     int fd = open(filename, O_RDONLY | O_CLOEXEC);
     if (fd == -1) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot open GUID file '%s' for reading", filename);
+        if(log_errors)
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot open GUID file '%s' for reading", filename);
         return false;
     }
 
-    if (read(fd, h.txt, sizeof(h.txt) - 1) != sizeof(h.txt) - 1) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot read GUID file '%s'", filename);
+    ssize_t bytes;
+    do {
+        bytes = read(fd, h.txt, sizeof(h.txt) - 1);
+    } while(bytes < 0 && errno == EINTR);
+
+    if (bytes != sizeof(h.txt) - 1) {
+        if(log_errors)
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot read GUID file '%s'", filename);
         close(fd);
         return false;
     }
     h.txt[sizeof(h.txt) - 1] = '\0';
 
     if (uuid_parse(h.txt, h.uuid.uuid) != 0) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot parse GUID from file '%s'", filename);
+        if(log_errors)
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot parse GUID from file '%s'", filename);
         close(fd);
         return false;
     }
 
     if (UUIDiszero(h.uuid)) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: GUID read from file '%s' is zero", filename);
+        if(log_errors)
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: GUID read from file '%s' is zero", filename);
         close(fd);
         return false;
     }
 
     struct stat st;
     if (fstat(fd, &st) != 0) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot stat the GUID file '%s'", filename);
+        if(log_errors)
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot stat the GUID file '%s'", filename);
         close(fd);
         return false;
     }
@@ -114,10 +124,101 @@ static struct timespec usec_to_timespec(usec_t usec) {
     return ts;
 }
 
-static bool machine_guid_write_to_file(const char *filename, ND_MACHINE_GUID *host_id) {
-    static size_t save_id = 0;
+static bool machine_guid_unlink_temporary(const char *tmp_filename, int saved_errno, const char *reason) {
+    if (unlink(tmp_filename) != 0 && errno != ENOENT)
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "MACHINE_GUID: cannot remove the temporary GUID file '%s' after %s",
+               tmp_filename, reason);
 
-    if (!filename || !*filename)
+    errno = saved_errno;
+    return false;
+}
+
+static bool machine_guid_close_and_unlink_temporary(
+    int fd, const char *tmp_filename, int saved_errno, const char *reason) {
+    if (close(fd) != 0)
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "MACHINE_GUID: cannot close the temporary GUID file '%s' after %s",
+               tmp_filename, reason);
+
+    return machine_guid_unlink_temporary(tmp_filename, saved_errno, reason);
+}
+
+static bool machine_guid_rename_and_sync(const char *directory, const char *tmp_filename, const char *filename) {
+#if defined(OS_WINDOWS)
+    UNUSED(directory);
+
+    wchar_t *windows_tmp = os_translate_msys_to_windows_pathW(tmp_filename);
+    wchar_t *windows_final = os_translate_msys_to_windows_pathW(filename);
+    if (!windows_tmp || !windows_final) {
+        freez(windows_tmp);
+        freez(windows_final);
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "MACHINE_GUID: cannot translate GUID publication paths for Windows");
+        errno = EINVAL;
+        return false;
+    }
+
+    bool moved = MoveFileExW(windows_tmp, windows_final, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+    DWORD error = moved ? ERROR_SUCCESS : GetLastError();
+    freez(windows_tmp);
+    freez(windows_final);
+
+    if (!moved) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "MACHINE_GUID: cannot move temporary GUID file '%s' to '%s' (Windows error %lu)",
+               tmp_filename, filename, (unsigned long)error);
+        errno = EIO;
+        return false;
+    }
+
+    return true;
+#else
+    if (rename(tmp_filename, filename) != 0) {
+        int saved_errno = errno;
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "MACHINE_GUID: cannot rename temporary GUID file '%s' to '%s'",
+               tmp_filename, filename);
+        errno = saved_errno;
+        return false;
+    }
+
+    int directory_flags = O_RDONLY | O_CLOEXEC;
+#ifdef O_DIRECTORY
+    directory_flags |= O_DIRECTORY;
+#endif
+    int directory_fd = open(directory, directory_flags);
+    if (directory_fd == -1) {
+        int saved_errno = errno;
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "MACHINE_GUID: cannot open GUID directory '%s' for synchronization", directory);
+        errno = saved_errno;
+        return false;
+    }
+
+    if (fsync(directory_fd) != 0) {
+        int saved_errno = errno;
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "MACHINE_GUID: cannot synchronize GUID directory '%s'", directory);
+        if (close(directory_fd) != 0)
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "MACHINE_GUID: cannot close GUID directory '%s' after synchronization failure", directory);
+        errno = saved_errno;
+        return false;
+    }
+
+    if (close(directory_fd) != 0) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "MACHINE_GUID: cannot close GUID directory '%s' after synchronization", directory);
+        return false;
+    }
+
+    return true;
+#endif
+}
+
+static bool machine_guid_write_to_file(const char *directory, const char *filename, ND_MACHINE_GUID *host_id) {
+    if (!directory || !*directory || !filename || !*filename)
         return false;
 
     ND_MACHINE_GUID h;
@@ -132,31 +233,47 @@ static bool machine_guid_write_to_file(const char *filename, ND_MACHINE_GUID *ho
     // Create the text representation before writing.
     uuid_unparse_lower(h.uuid.uuid, h.txt);
 
-    // Use a temporary filename for atomic writes.
+    // Use an exclusive temporary file so concurrent processes and stale files cannot collide.
     char tmp_filename[FILENAME_MAX];
-    snprintf(tmp_filename, sizeof(tmp_filename), "%s.%zu", filename, __atomic_add_fetch(&save_id, 1, __ATOMIC_RELAXED));
+    int rc = snprintf(tmp_filename, sizeof(tmp_filename), "%s.tmp.XXXXXX", filename);
+    if (rc < 0 || (size_t)rc >= sizeof(tmp_filename)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "MACHINE_GUID: temporary GUID filename for '%s' is too long", filename);
+        errno = ENAMETOOLONG;
+        return false;
+    }
 
-    int fd = open(tmp_filename, O_WRONLY | O_CREAT | O_TRUNC, 0444);
+    int fd = mkstemp(tmp_filename);
     if (fd == -1) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot create the temporary GUID file '%s'", tmp_filename);
         return false;
     }
 
-    if (write(fd, h.txt, sizeof(h.txt) - 1) != sizeof(h.txt) - 1) {
+    size_t written = 0;
+    while (written < sizeof(h.txt) - 1) {
+        ssize_t bytes = write(fd, &h.txt[written], sizeof(h.txt) - 1 - written);
+        if (bytes > 0) {
+            written += (size_t)bytes;
+            continue;
+        }
+
+        if (bytes < 0 && errno == EINTR)
+            continue;
+
+        if (bytes == 0)
+            errno = EIO;
+
+        int saved_errno = errno;
         nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot write GUID to the temporary GUID file '%s'", tmp_filename);
-        close(fd);
-        return false;
+        return machine_guid_close_and_unlink_temporary(fd, tmp_filename, saved_errno, "write failure");
     }
 
-    if (close(fd) != 0) {
+    mode_t current_umask = umask(0); // Flawfinder: ignore - read and immediately restore the startup umask.
+    umask(current_umask); // Flawfinder: ignore - restore the startup umask.
+    if (fchmod(fd, 0444 & ~current_umask) != 0) {
         int saved_errno = errno;
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot close the temporary GUID file '%s'", tmp_filename);
-
-        if (unlink(tmp_filename) != 0)
-            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot remove the temporary GUID file '%s' after close failure", tmp_filename);
-
-        errno = saved_errno;
-        return false;
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot set permissions on temporary GUID file '%s'", tmp_filename);
+        return machine_guid_close_and_unlink_temporary(fd, tmp_filename, saved_errno, "permission failure");
     }
 
     struct timespec times[2] = {
@@ -164,15 +281,24 @@ static bool machine_guid_write_to_file(const char *filename, ND_MACHINE_GUID *ho
         usec_to_timespec(h.last_modified_ut), // modification time
     };
 
-    // Update file timestamps.
     if (utimensat(AT_FDCWD, tmp_filename, times, 0) < 0)
         nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot update the timestamps of the temporary GUID file '%s'", tmp_filename);
 
-    // Rename the temporary file to the target filename atomically.
-    if (rename(tmp_filename, filename) != 0) {
-        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot rename temporary GUID file '%s' to '%s'", tmp_filename, filename);
-        unlink(tmp_filename);
-        return false;
+    if (fsync(fd) != 0) {
+        int saved_errno = errno;
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot synchronize temporary GUID file '%s'", tmp_filename);
+        return machine_guid_close_and_unlink_temporary(fd, tmp_filename, saved_errno, "synchronization failure");
+    }
+
+    if (close(fd) != 0) {
+        int saved_errno = errno;
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot close the temporary GUID file '%s'", tmp_filename);
+        return machine_guid_unlink_temporary(tmp_filename, saved_errno, "close failure");
+    }
+
+    if (!machine_guid_rename_and_sync(directory, tmp_filename, filename)) {
+        int saved_errno = errno;
+        return machine_guid_unlink_temporary(tmp_filename, saved_errno, "publication failure");
     }
 
     nd_log(NDLS_DAEMON, NDLP_INFO, "MACHINE_GUID: GUID saved to file '%s'", filename);
@@ -187,22 +313,35 @@ static SPINLOCK nd_machine_guid_spinlock = SPINLOCK_INITIALIZER;
 static ND_MACHINE_GUID machine_guid_get_or_create(void) {
     char pathname[FILENAME_MAX];
     char filename[FILENAME_MAX];
+    char lock_filename[FILENAME_MAX];
 
     netdata_conf_section_directories();
 
     ND_MACHINE_GUID h;
     memset(&h, 0, sizeof(h));
 
-    // Build the file path.
-    snprintfz(pathname, sizeof(pathname), "%s/registry", netdata_configured_varlib_dir);
-    snprintfz(filename, sizeof(filename), "%s/%s", pathname, "netdata.public.unique.id");
+    bool paths_valid = true;
+    int rc = snprintf(pathname, sizeof(pathname), "%s/registry", netdata_configured_varlib_dir);
+    if (rc < 0 || (size_t)rc >= sizeof(pathname)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: registry directory path is too long");
+        paths_valid = false;
+    }
+
+    if (paths_valid) {
+        rc = snprintf(filename, sizeof(filename), "%s/%s", pathname, "netdata.public.unique.id");
+        if (rc < 0 || (size_t)rc >= sizeof(filename)) {
+            nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: GUID filename is too long");
+            paths_valid = false;
+        }
+    }
 
     // Attempt to read the GUID from the file.
-    if (machine_guid_read_from_file(filename, &h))
+    if (paths_valid && machine_guid_read_from_file(filename, &h, true))
         return h;
 
     // Log failure to read the file.
-    nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: failed to read GUID from file '%s'", filename);
+    if (paths_valid)
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: failed to read GUID from file '%s'", filename);
 
     // Attempt to retrieve GUID from daemon status file.
     h = daemon_status_file_get_host_id();
@@ -219,6 +358,9 @@ static ND_MACHINE_GUID machine_guid_get_or_create(void) {
     h.last_modified_ut = now_realtime_usec();
     rfc3339_datetime_ut(h.last_modified_ut_rfc3339, sizeof(h.last_modified_ut_rfc3339), h.last_modified_ut, 2, true);
     nd_machine_guid = h;
+
+    if (!paths_valid)
+        return h;
 
     // Avoid a check-then-create race; mkdir() + EEXIST is sufficient.
     errno_clear();
@@ -238,9 +380,30 @@ static ND_MACHINE_GUID machine_guid_get_or_create(void) {
         }
     }
 
+    // The lock file must persist so every contender continues to lock the same inode.
+    rc = snprintf(lock_filename, sizeof(lock_filename), "%s.lock", filename);
+    if (rc < 0 || (size_t)rc >= sizeof(lock_filename)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: lock filename for '%s' is too long", filename);
+        return h;
+    }
+
+    FILE_LOCK lock = file_lock_get_wait(lock_filename);
+    if (!FILE_LOCK_OK(lock)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot acquire publication lock '%s'", lock_filename);
+        return h;
+    }
+
+    ND_MACHINE_GUID published;
+    if (machine_guid_read_from_file(filename, &published, false)) {
+        file_lock_release(lock);
+        return published;
+    }
+
     errno_clear();
-    if (!machine_guid_write_to_file(filename, &h))
+    if (!machine_guid_write_to_file(pathname, filename, &h))
         nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot save GUID to file '%s'", filename);
+
+    file_lock_release(lock);
 
     return h;
 }

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -7,6 +7,7 @@
 // call clocks_init() once, to optimize these default settings
 static clockid_t clock_boottime_to_use = CLOCK_MONOTONIC;
 static clockid_t clock_monotonic_to_use = CLOCK_MONOTONIC;
+static netdata_mutex_t uptime_msec_mutex;
 
 // the default clock resolution is 1ms
 #define DEFAULT_CLOCK_RESOLUTION_UT ((usec_t)0 * USEC_PER_SEC + (usec_t)1 * USEC_PER_MS)
@@ -85,6 +86,8 @@ static usec_t get_clock_resolution(clockid_t clock) {
 // perform any initializations required for clocks
 
 static __attribute__((constructor)) void clocks_init(void) {
+    fatal_assert(0 == netdata_mutex_init(&uptime_msec_mutex));
+
     os_get_system_HZ();
 
     // monotonic raw has to be tested before boottime
@@ -107,6 +110,7 @@ static __attribute__((destructor)) void clocks_fin(void) {
 #if defined(OS_WINDOWS)
     timeEndPeriod(1);
 #endif
+    netdata_mutex_destroy(&uptime_msec_mutex);
 }
 
 ALWAYS_INLINE time_t now_sec(clockid_t clk_id) {
@@ -522,6 +526,9 @@ static inline collected_number read_proc_uptime(const char *filename) {
 
 inline collected_number uptime_msec(const char *filename){
     static int use_boottime = -1;
+    collected_number uptime = 1;
+
+    netdata_mutex_lock(&uptime_msec_mutex);
 
     if(unlikely(use_boottime == -1)) {
         collected_number uptime_boottime = uptime_from_boottime();
@@ -532,6 +539,7 @@ inline collected_number uptime_msec(const char *filename){
 
         if(delta <= 1000 && uptime_boottime != 0) {
             procfile_close(read_proc_uptime_ff);
+            read_proc_uptime_ff = NULL;
             netdata_log_info("Using now_boottime_usec() for uptime (dt is %lld ms)", delta);
             use_boottime = 1;
         }
@@ -541,15 +549,16 @@ inline collected_number uptime_msec(const char *filename){
         }
         else {
             netdata_log_error("Cannot find any way to read uptime on this system.");
-            return 1;
+            goto done;
         }
     }
 
-    collected_number uptime;
     if(use_boottime)
         uptime = uptime_from_boottime();
     else
         uptime = read_proc_uptime(filename);
 
+done:
+    netdata_mutex_unlock(&uptime_msec_mutex);
     return uptime;
 }

--- a/src/libnetdata/datetime/rfc3339.c
+++ b/src/libnetdata/datetime/rfc3339.c
@@ -272,7 +272,12 @@ bool rfc3339_parse_ut(const char *rfc3339, usec_t *timestamp_ut, char **endptr) 
 
 #if defined(HAVE_TIMEGM)
     // If available, use timegm() which interprets tm as UTC.
+    int saved_errno = errno;
+    errno = 0;
     epoch_s = timegm(&tm);
+    if (epoch_s == (time_t)-1 && errno != 0)
+        return false; // Error in time conversion
+    errno = saved_errno;
 #else
     // Use mktime(), which assumes tm is local time, then adjust.
     epoch_s = mktime(&tm);

--- a/src/libnetdata/inicfg/inicfg_api.c
+++ b/src/libnetdata/inicfg/inicfg_api.c
@@ -432,7 +432,7 @@ time_t inicfg_get_duration_days_to_seconds(struct config *root, const char *sect
         return default_value_seconds;
     }
 
-    return (unsigned)ABS(result);
+    return ABS(result);
 }
 
 long long inicfg_get_number(struct config *root, const char *section, const char *name, long long value) {
@@ -567,7 +567,7 @@ uint64_t inicfg_get_size_mb(struct config *root, const char *section, const char
         return default_value;
     }
 
-    return (unsigned)result;
+    return result;
 }
 
 uint64_t inicfg_set_size_mb(struct config *root, const char *section, const char *name, uint64_t value) {

--- a/src/libnetdata/inicfg/inicfg_api.c
+++ b/src/libnetdata/inicfg/inicfg_api.c
@@ -338,8 +338,8 @@ time_t inicfg_get_duration_seconds(struct config *root, const char *section, con
 
     int result = 0;
     if(!duration_parse_seconds(s, &result)) {
-        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_DURATION_IN_SECS);
         netdata_log_error("config option '[%s].%s = %s' is configured with an invalid duration", section, name, s);
+        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_DURATION_IN_SECS);
         return default_value;
     }
 
@@ -381,8 +381,8 @@ msec_t inicfg_get_duration_ms(struct config *root, const char *section, const ch
 
     smsec_t result = 0;
     if(!duration_parse_msec_t(s, &result)) {
-        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_DURATION_IN_MS);
         netdata_log_error("config option '[%s].%s = %s' is configured with an invalid duration", section, name, s);
+        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_DURATION_IN_MS);
         return default_value;
     }
 
@@ -427,8 +427,8 @@ time_t inicfg_get_duration_days_to_seconds(struct config *root, const char *sect
 
     int64_t result = 0;
     if(!duration_parse(s, &result, "d", "s")) {
-        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_DURATION_IN_DAYS_TO_SECONDS);
         netdata_log_error("config option '[%s].%s = %s' is configured with an invalid duration", section, name, s);
+        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_DURATION_IN_DAYS_TO_SECONDS);
         return default_value_seconds;
     }
 
@@ -521,8 +521,8 @@ uint64_t inicfg_get_size_bytes(struct config *root, const char *section, const c
     const char *s = string2str(opt->value);
     uint64_t result = 0;
     if(!size_parse_bytes(s, &result)) {
-        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_SIZE_IN_BYTES);
         netdata_log_error("config option '[%s].%s = %s' is configured with an invalid size", section, name, s);
+        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_SIZE_IN_BYTES);
         return default_value;
     }
 
@@ -562,8 +562,8 @@ uint64_t inicfg_get_size_mb(struct config *root, const char *section, const char
     const char *s = string2str(opt->value);
     uint64_t result = 0;
     if(!size_parse_mb(s, &result)) {
-        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_SIZE_IN_MB);
         netdata_log_error("config option '[%s].%s = %s' is configured with an invalid size", section, name, s);
+        inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_SIZE_IN_MB);
         return default_value;
     }
 

--- a/src/libnetdata/inicfg/inicfg_api.c
+++ b/src/libnetdata/inicfg/inicfg_api.c
@@ -336,14 +336,16 @@ time_t inicfg_get_duration_seconds(struct config *root, const char *section, con
 
     const char *s = string2str(opt->value);
 
-    int result = 0;
-    if(!duration_parse_seconds(s, &result)) {
+    int parsed = 0;
+    time_t result = 0;
+    if(!duration_parse_seconds(s, &parsed) ||
+       (parsed < 0 && __builtin_sub_overflow((time_t)0, parsed, &result))) {
         netdata_log_error("config option '[%s].%s = %s' is configured with an invalid duration", section, name, s);
         inicfg_set_raw_value(root, section, name, default_str, CONFIG_VALUE_TYPE_DURATION_IN_SECS);
         return default_value;
     }
 
-    return ABS(result);
+    return parsed < 0 ? result : (time_t)parsed;
 }
 
 time_t inicfg_set_duration_seconds(struct config *root, const char *section, const char *name, time_t value) {

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -601,14 +601,17 @@ static int read_txt_file(const char *filename, char *buffer, size_t size) {
 
 ALWAYS_INLINE
 static bool read_txt_file_to_buffer(const char *filename, BUFFER *wb, size_t max_size) {
-    // Open the file
-    int fd = open(filename, O_RDONLY | O_CLOEXEC);
+    struct stat st;
+    if (stat(filename, &st) == -1 || !S_ISREG(st.st_mode))
+        return false;
+
+    // O_NONBLOCK prevents a replacement FIFO from waiting during open().
+    int fd = open(filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
     if (fd == -1)
         return false;
 
     // Get the file size
-    struct stat st;
-    if (fstat(fd, &st) == -1) {
+    if (fstat(fd, &st) == -1 || !S_ISREG(st.st_mode)) {
         close(fd);
         return false;
     }

--- a/src/libnetdata/json/json-c-parser-unittest.c
+++ b/src/libnetdata/json/json-c-parser-unittest.c
@@ -1529,6 +1529,12 @@ static int test_format_rfc3339(void) {
     parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00.1234567890Z", &parsed, NULL);
     T(!parsed_ok && parsed == 999, "parse_rfc3339: more than 9 fractional digits fail without overwriting output");
 
+#if defined(HAVE_TIMEGM)
+    parsed = 999;
+    parsed_ok = rfc3339_parse_ut("1969-12-31T23:59:59Z", &parsed, NULL);
+    T(parsed_ok, "parse_rfc3339: valid timegm -1 timestamp succeeds");
+#endif
+
     parsed = 999;
     parsed_ok = rfc3339_parse_ut("1970-01-01T00:00:00. 123Z", &parsed, NULL);
     T(!parsed_ok && parsed == 999, "parse_rfc3339: fractional whitespace fails without overwriting output");

--- a/src/libnetdata/os/file_lock.c
+++ b/src/libnetdata/os/file_lock.c
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "file_lock.h"
+#include "os.h"
+#include "../memory/nd-mallocz.h"
+
+#include <errno.h>
+#include <stdbool.h>
 
 #if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_MACOS)
 #include <sys/file.h>
@@ -10,54 +15,9 @@
 
 #if defined(OS_WINDOWS)
 #include <windows.h>
-#include <stdlib.h>
-
-#if defined(__CYGWIN__) || defined(__MSYS__)
-#include <sys/types.h>
-#include <sys/cygwin.h>
 #endif
 
-static wchar_t *file_lock_utf8_to_utf16(const char *filename) {
-    int wpath_size = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
-    if(wpath_size <= 0)
-        return NULL;
-
-    wchar_t *wpath = malloc((size_t)wpath_size * sizeof(*wpath));
-    if(!wpath)
-        return NULL;
-
-    if(MultiByteToWideChar(CP_UTF8, 0, filename, -1, wpath, wpath_size) <= 0) {
-        free(wpath);
-        return NULL;
-    }
-
-    return wpath;
-}
-
-static wchar_t *file_lock_windows_path(const char *filename) {
-#if defined(__CYGWIN__) || defined(__MSYS__)
-    ssize_t wpath_size = cygwin_conv_path(CCP_POSIX_TO_WIN_W, filename, NULL, 0);
-    if(wpath_size > 0) {
-        wchar_t *wpath = malloc((size_t)wpath_size);
-        if(!wpath)
-            return NULL;
-
-        if(cygwin_conv_path(CCP_POSIX_TO_WIN_W, filename, wpath, wpath_size) == 0)
-            return wpath;
-
-        free(wpath);
-    }
-
-    // Absolute POSIX-style paths require runtime translation before Win32 APIs can use them.
-    if(filename[0] == '/')
-        return NULL;
-#endif
-
-    return file_lock_utf8_to_utf16(filename);
-}
-#endif
-
-FILE_LOCK file_lock_get(const char *filename) {
+static FILE_LOCK file_lock_get_internal(const char *filename, bool wait) {
     if(!filename || !*filename)
         return FILE_LOCK_INVALID;
 
@@ -67,16 +27,22 @@ FILE_LOCK file_lock_get(const char *filename) {
     if(fd == -1)
         return FILE_LOCK_INVALID;
 
-    // LOCK_NB makes flock() non-blocking
-    if(flock(fd, LOCK_EX | LOCK_NB) == -1) {
+    int rc;
+    do {
+        rc = flock(fd, LOCK_EX | (wait ? 0 : LOCK_NB));
+    } while(wait && rc == -1 && errno == EINTR);
+
+    if(rc == -1) {
+        int saved_errno = errno;
         close(fd);
+        errno = saved_errno;
         return FILE_LOCK_INVALID;
     }
 
     return (FILE_LOCK){ .fd = fd };
 
 #elif defined(OS_WINDOWS)
-    wchar_t *wpath = file_lock_windows_path(filename);
+    wchar_t *wpath = os_translate_msys_to_windows_pathW(filename);
     if(!wpath)
         return FILE_LOCK_INVALID;
 
@@ -91,7 +57,7 @@ FILE_LOCK file_lock_get(const char *filename) {
         NULL
     );
 
-    free(wpath);
+    freez(wpath);
 
     if(hFile == INVALID_HANDLE_VALUE)
         return FILE_LOCK_INVALID;
@@ -114,9 +80,13 @@ FILE_LOCK file_lock_get(const char *filename) {
 
     // Try to lock the entire file
     OVERLAPPED overlapped = {0};
+    DWORD flags = LOCKFILE_EXCLUSIVE_LOCK;
+    if(!wait)
+        flags |= LOCKFILE_FAIL_IMMEDIATELY;
+
     if(!LockFileEx(
             hFile,
-            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            flags,
             0,
             MAXDWORD,
             MAXDWORD,
@@ -130,6 +100,14 @@ FILE_LOCK file_lock_get(const char *filename) {
 #else
 #error "Unsupported operating system"
 #endif
+}
+
+FILE_LOCK file_lock_get(const char *filename) {
+    return file_lock_get_internal(filename, false);
+}
+
+FILE_LOCK file_lock_get_wait(const char *filename) {
+    return file_lock_get_internal(filename, true);
 }
 
 void file_lock_release(FILE_LOCK lock) {

--- a/src/libnetdata/os/file_lock.h
+++ b/src/libnetdata/os/file_lock.h
@@ -41,6 +41,16 @@ typedef struct file_lock {
 FILE_LOCK file_lock_get(const char *filename);
 
 /**
+ * Get an exclusive file lock, waiting for the current owner if necessary.
+ *
+ * The lock is automatically released when the process exits or crashes.
+ *
+ * @param filename UTF-8 encoded filename (MSYS2/Cygwin path format or native Windows path on Windows)
+ * @return FILE_LOCK The lock handle. Use FILE_LOCK_OK() to check if lock was acquired
+ */
+FILE_LOCK file_lock_get_wait(const char *filename);
+
+/**
  * Release a file lock
  *
  * Releases a previously acquired file lock. After calling this function,

--- a/src/libnetdata/os/file_lock.h
+++ b/src/libnetdata/os/file_lock.h
@@ -7,6 +7,23 @@
 
 #if defined(OS_WINDOWS)
 #include <windows.h>
+
+// wincrypt.h (included via windows.h) defines macros that conflict with OpenSSL
+#ifdef X509_NAME
+#undef X509_NAME
+#endif
+#ifdef X509_EXTENSIONS
+#undef X509_EXTENSIONS
+#endif
+#ifdef PKCS7_SIGNER_INFO
+#undef PKCS7_SIGNER_INFO
+#endif
+#ifdef OCSP_REQUEST
+#undef OCSP_REQUEST
+#endif
+#ifdef OCSP_RESPONSE
+#undef OCSP_RESPONSE
+#endif
 #endif
 
 typedef struct file_lock {

--- a/src/libnetdata/os/os.c
+++ b/src/libnetdata/os/os.c
@@ -94,6 +94,39 @@ char *os_translate_msys_to_windows_path(const char *src) {
     return converted_path;
 }
 
+wchar_t *os_translate_msys_to_windows_pathW(const char *src) {
+    if (!src)
+        return NULL;
+
+#if defined(__CYGWIN__) || defined(__MSYS__)
+    ssize_t cygwin_size = cygwin_conv_path(CCP_POSIX_TO_WIN_W, src, NULL, 0);
+    if (cygwin_size > 0) {
+        wchar_t *converted_path = mallocz((size_t)cygwin_size);
+        if (cygwin_conv_path(CCP_POSIX_TO_WIN_W, src, converted_path, (size_t)cygwin_size) == 0)
+            return converted_path;
+
+        freez(converted_path);
+    }
+
+    // Absolute POSIX paths require the MSYS/Cygwin runtime's mount translation.
+    if (src[0] == '/')
+        return NULL;
+#endif
+
+    CLEAN_CHAR_P *translated = os_translate_msys_to_windows_path(src);
+    int converted_size = MultiByteToWideChar(CP_UTF8, 0, translated, -1, NULL, 0);
+    if (converted_size <= 0)
+        return NULL;
+
+    wchar_t *converted_path = mallocz((size_t)converted_size * sizeof(*converted_path));
+    if (MultiByteToWideChar(CP_UTF8, 0, translated, -1, converted_path, converted_size) <= 0) {
+        freez(converted_path);
+        return NULL;
+    }
+
+    return converted_path;
+}
+
 char *os_translate_path(char *dst, const char *src, size_t dst_size) {
     if (!dst || !dst_size)
         return dst;

--- a/src/libnetdata/os/os.h
+++ b/src/libnetdata/os/os.h
@@ -64,6 +64,8 @@ static char *strncpyz(char *dst, const char *src, size_t dst_size_minus_1);
 #if defined(OS_WINDOWS)
 char *os_translate_path(char *dst, const char *src, size_t dst_size);
 char *os_translate_msys_to_windows_path(const char *src);
+// Returns newly allocated UTF-16 storage for Win32 wide-character APIs; caller must freez().
+wchar_t *os_translate_msys_to_windows_pathW(const char *src);
 // Returns newly allocated POSIX-style storage; caller must free.
 char *os_translate_windows_to_msys_path(const char *src);
 #else

--- a/src/web/api/v1/api_v1_manage.c
+++ b/src/web/api/v1/api_v1_manage.c
@@ -14,13 +14,16 @@ static char *get_mgmt_api_key(void) {
         return guid;
 
     // read it from disk
+    struct stat st;
+    int fd = -1;
 #ifdef O_NOFOLLOW
-    int fd = open(api_key_filename, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    if(lstat(api_key_filename, &st) == 0 && S_ISREG(st.st_mode))
+        fd = open(api_key_filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK | O_NOFOLLOW);
 #else
-    int fd = open(api_key_filename, O_RDONLY | O_CLOEXEC);
+    if(stat(api_key_filename, &st) == 0 && S_ISREG(st.st_mode))
+        fd = open(api_key_filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
 #endif
     if(fd != -1) {
-        struct stat st;
         if(fstat(fd, &st) != 0 || !S_ISREG(st.st_mode))
             netdata_log_error("Management API key file '%s' is not a regular file, regenerating.", api_key_filename);
         else {
@@ -50,10 +53,14 @@ static char *get_mgmt_api_key(void) {
 
         // save it
 #ifdef O_NOFOLLOW
-        struct stat st;
         // O_RDWR avoids blocking on FIFOs (O_WRONLY blocks until a reader arrives).
         // O_TRUNC is omitted so truncation only happens after fstat() confirms a regular file.
-        fd = open(api_key_filename, O_RDWR|O_CREAT|O_CLOEXEC|O_NOFOLLOW, 0600);
+        if(lstat(api_key_filename, &st) == 0 && !S_ISREG(st.st_mode)) {
+            netdata_log_error("Management API key file '%s' is not a regular file.", api_key_filename);
+            goto temp_key;
+        }
+
+        fd = open(api_key_filename, O_RDWR|O_CREAT|O_CLOEXEC|O_NONBLOCK|O_NOFOLLOW, 0600);
         if(fd == -1) {
             netdata_log_error("Cannot create unique management API key file '%s'. Please adjust config parameter 'netdata management api key file' to a proper path and file.", api_key_filename);
             goto temp_key;

--- a/src/web/api/v1/api_v1_manage.c
+++ b/src/web/api/v1/api_v1_manage.c
@@ -20,11 +20,16 @@ static char *get_mgmt_api_key(void) {
     if(lstat(api_key_filename, &st) == 0 && S_ISREG(st.st_mode))
         fd = open(api_key_filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK | O_NOFOLLOW);
 #else
-    if(stat(api_key_filename, &st) == 0 && S_ISREG(st.st_mode))
+    struct stat path_st;
+    if(lstat(api_key_filename, &path_st) == 0 && S_ISREG(path_st.st_mode))
         fd = open(api_key_filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
 #endif
     if(fd != -1) {
-        if(fstat(fd, &st) != 0 || !S_ISREG(st.st_mode))
+        if(fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)
+#ifndef O_NOFOLLOW
+           || st.st_dev != path_st.st_dev || st.st_ino != path_st.st_ino
+#endif
+        )
             netdata_log_error("Management API key file '%s' is not a regular file, regenerating.", api_key_filename);
         else {
             char buf[GUID_LEN + 1];


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens file I/O and startup identity: rejects special files, uses nonblocking opens, adds TOCTTOU checks, and makes machine GUID publication atomic and durable. Also fixes concurrency in uptime and GUID init, corrects RFC3339 and config parsing (including wide parsed values), adds a blocking file-lock API, and resolves Windows OpenSSL macro conflicts.

- **Bug Fixes**
  - Reject and avoid blocking on FIFOs/special files by prechecking regular files, opening with O_NONBLOCK, and revalidating with fstat() in DynCfg schema reads, machine GUID reads, management API key reads/writes, and shared text-file helpers.
  - Management API key: add lstat() and dev/inode consistency checks to guard TOCTTOU; keep nonblocking opens and regular-file enforcement.
  - Machine GUID: publish atomically and durably via mkstemp(), full EINTR-safe writes, fchmod 0440, fsync on file and parent dir, checked close, and atomic rename; post-lock reread prevents races; handle path truncation.
  - Serialize machine GUID first-use with a spinlock and publish the env var once.
  - Serialize uptime source selection with a mutex and clear the cached procfile safely.
  - RFC3339: treat timegm() errors as failures; add a unit test for the valid -1 timestamp.
  - inicfg: log invalid values before resetting; fix INT_MIN duration handling; preserve full-width results for days→seconds and MiB; correct ms/bytes invalid-value logging order.
  - Windows build: undefine OpenSSL-conflicting macros from `windows.h`.

- **New Features**
  - Added blocking file locks: file_lock_get_wait() for cross-process coordination.
  - Windows: added os_translate_msys_to_windows_pathW(); use wide paths and MoveFileExW for durable GUID publication.

<sup>Written for commit 67e80e2ba7e1263e9f21a8363d9183e229089b97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

