### PR TITLE
fix group-by percentage at the second grouping level with a dimensions filter

### DIFF
--- a/src/web/api/queries/query-group-by-init.c
+++ b/src/web/api/queries/query-group-by-init.c
@@ -2,15 +2,47 @@
 
 #include "query-internal.h"
 
-static void query_group_by_make_dimension_key(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, bool query_has_percentage_of_group) {
+// how hidden dimensions are grouped at each group-by pass:
+//
+// - GROUP_BY_HIDDEN_NORMAL: hidden dimensions group together with the
+//   selected ones; used at the pass that computes percentage-of-group (the
+//   value router splits them to the hidden values array vh using the
+//   per-metric RRDR_DIMENSION_HIDDEN flag) and at any pass after it.
+//
+// - GROUP_BY_HIDDEN_GLOBAL: all hidden dimensions collapse into a single
+//   query-wide bucket; used when the query has no percentage-of-group
+//   (they are only needed as a total, e.g. for options=percentage).
+//
+// - GROUP_BY_HIDDEN_SHADOW: hidden dimensions group per-group into shadow
+//   buckets that keep RRDR_DIMENSION_HIDDEN; used at passes BEFORE the
+//   percentage-of-group pass, so that the hidden (denominator) values are
+//   aggregated with the same grouping as the selected (numerator) values
+//   and reach the percentage pass separated from them.
+typedef enum {
+    GROUP_BY_HIDDEN_NORMAL = 0,
+    GROUP_BY_HIDDEN_GLOBAL,
+    GROUP_BY_HIDDEN_SHADOW,
+} GROUP_BY_HIDDEN_MODE;
+
+static inline bool query_metric_hidden_bucket(QUERY_METRIC *qm, GROUP_BY_HIDDEN_MODE hidden_mode) {
+    return (qm->status & RRDR_DIMENSION_HIDDEN) && hidden_mode != GROUP_BY_HIDDEN_NORMAL;
+}
+
+static void query_group_by_make_dimension_key(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, GROUP_BY_HIDDEN_MODE hidden_mode) {
     buffer_flush(key);
-    if(unlikely(!query_has_percentage_of_group && qm->status & RRDR_DIMENSION_HIDDEN)) {
+    if(unlikely(query_metric_hidden_bucket(qm, hidden_mode) && hidden_mode == GROUP_BY_HIDDEN_GLOBAL)) {
         buffer_strcat(key, "__hidden_dimensions__");
     }
     else if(unlikely(group_by & RRDR_GROUP_BY_SELECTED)) {
         buffer_strcat(key, "selected");
     }
     else {
+        if (unlikely(query_metric_hidden_bucket(qm, hidden_mode)))
+            // GROUP_BY_HIDDEN_SHADOW: prefix the normal group key, so
+            // hidden dimensions land in a per-group shadow bucket,
+            // separate from the selected dimensions of the same group
+            buffer_strcat(key, "__hidden_dimensions__");
+
         if (group_by & RRDR_GROUP_BY_DIMENSION) {
             buffer_fast_strcat(key, "|", 1);
             buffer_strcat(key, query_metric_name(qt, qm));
@@ -46,16 +78,24 @@ static void query_group_by_make_dimension_key(BUFFER *key, RRDR_GROUP_BY group_b
     }
 }
 
-static void query_group_by_make_dimension_id(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, bool query_has_percentage_of_group) {
+static void query_group_by_make_dimension_id(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, GROUP_BY_HIDDEN_MODE hidden_mode) {
     buffer_flush(key);
-    if(unlikely(!query_has_percentage_of_group && qm->status & RRDR_DIMENSION_HIDDEN)) {
+    if(unlikely(query_metric_hidden_bucket(qm, hidden_mode) && hidden_mode == GROUP_BY_HIDDEN_GLOBAL)) {
         buffer_strcat(key, "__hidden_dimensions__");
     }
     else if(unlikely(group_by & RRDR_GROUP_BY_SELECTED)) {
         buffer_strcat(key, "selected");
     }
     else {
+        if (unlikely(query_metric_hidden_bucket(qm, hidden_mode)))
+            // GROUP_BY_HIDDEN_SHADOW: shadow buckets exist only in
+            // intermediate RRDRs; their ids are never exposed
+            buffer_strcat(key, "__hidden_dimensions__");
+
         if (group_by & RRDR_GROUP_BY_DIMENSION) {
+            if (buffer_strlen(key) != 0)
+                buffer_fast_strcat(key, ",", 1);
+
             buffer_strcat(key, query_metric_name(qt, qm));
         }
 
@@ -101,16 +141,24 @@ static void query_group_by_make_dimension_id(BUFFER *key, RRDR_GROUP_BY group_by
     }
 }
 
-static void query_group_by_make_dimension_name(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, bool query_has_percentage_of_group) {
+static void query_group_by_make_dimension_name(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, GROUP_BY_HIDDEN_MODE hidden_mode) {
     buffer_flush(key);
-    if(unlikely(!query_has_percentage_of_group && qm->status & RRDR_DIMENSION_HIDDEN)) {
+    if(unlikely(query_metric_hidden_bucket(qm, hidden_mode) && hidden_mode == GROUP_BY_HIDDEN_GLOBAL)) {
         buffer_strcat(key, "__hidden_dimensions__");
     }
     else if(unlikely(group_by & RRDR_GROUP_BY_SELECTED)) {
         buffer_strcat(key, "selected");
     }
     else {
+        if (unlikely(query_metric_hidden_bucket(qm, hidden_mode)))
+            // GROUP_BY_HIDDEN_SHADOW: shadow buckets exist only in
+            // intermediate RRDRs; their names are never exposed
+            buffer_strcat(key, "__hidden_dimensions__");
+
         if (group_by & RRDR_GROUP_BY_DIMENSION) {
+            if (buffer_strlen(key) != 0)
+                buffer_fast_strcat(key, ",", 1);
+
             buffer_strcat(key, query_metric_name(qt, qm));
         }
 
@@ -253,6 +301,27 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
         }
     }
 
+    // find the pass that consumes the hidden dimensions to compute
+    // percentage-of-group; passes before it must keep the hidden
+    // dimensions grouped separately from the selected ones (shadow
+    // buckets), or their values would be merged and the percentage
+    // pass could not split numerator from denominator;
+    // unlike query_target_has_percentage_of_group() this scan stops at
+    // the first RRDR_GROUP_BY_NONE pass (the main loop below does too),
+    // so a percentage aggregation on a NONE pass resolves to NORMAL mode
+    // everywhere - the same behavior such a query had before this scan
+    ssize_t percentage_of_group_pass = -1;
+    for(size_t g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++) {
+        if(qt->request.group_by[g].group_by == RRDR_GROUP_BY_NONE)
+            break;
+
+        if((qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) ||
+            qt->request.group_by[g].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE) {
+            percentage_of_group_pass = (ssize_t)g;
+            break;
+        }
+    }
+
     size_t added = 0;
     RRDR *first_r = NULL, *last_r = NULL;
     BUFFER *key = buffer_create(0, NULL);
@@ -275,6 +344,11 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
 
         size_t hidden_dimensions = 0;
         bool final_grouping = (g == MAX_QUERY_GROUP_BY_PASSES - 1 || qt->request.group_by[g + 1].group_by == RRDR_GROUP_BY_NONE) ? true : false;
+
+        GROUP_BY_HIDDEN_MODE hidden_mode =
+            (!query_has_percentage_of_group)                 ? GROUP_BY_HIDDEN_GLOBAL :
+            ((ssize_t)g < percentage_of_group_pass)          ? GROUP_BY_HIDDEN_SHADOW :
+                                                               GROUP_BY_HIDDEN_NORMAL;
 
         if (final_grouping && (options & RRDR_OPTION_GROUP_BY_LABELS))
             label_keys = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED | DICT_OPTION_DONT_OVERWRITE_VALUE, NULL, 0);
@@ -305,7 +379,7 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             // --------------------------------------------------------------------
             // generate the group by key
 
-            query_group_by_make_dimension_key(key, group_by, g, qt, qn, qc, qi, qd, qm, query_has_percentage_of_group);
+            query_group_by_make_dimension_key(key, group_by, g, qt, qn, qc, qi, qd, qm, hidden_mode);
 
             // lookup the key in the dictionary
 
@@ -319,13 +393,13 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
                 // ----------------------------------------------------------------
                 // generate the dimension id
 
-                query_group_by_make_dimension_id(key, group_by, g, qt, qn, qc, qi, qd, qm, query_has_percentage_of_group);
+                query_group_by_make_dimension_id(key, group_by, g, qt, qn, qc, qi, qd, qm, hidden_mode);
                 entries[pos].id = string_strdupz(buffer_tostring(key));
 
                 // ----------------------------------------------------------------
                 // generate the dimension name
 
-                query_group_by_make_dimension_name(key, group_by, g, qt, qn, qc, qi, qd, qm, query_has_percentage_of_group);
+                query_group_by_make_dimension_name(key, group_by, g, qt, qn, qc, qi, qd, qm, hidden_mode);
                 entries[pos].name = string_strdupz(buffer_tostring(key));
 
                 // add the rest of the info
@@ -364,10 +438,13 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             // the query target adds to it the non-zero flag
             qm->status |= RRDR_DIMENSION_GROUPED;
 
-            if(query_has_percentage_of_group)
+            if(query_has_percentage_of_group && !query_metric_hidden_bucket(qm, hidden_mode))
                 // when the query has percentage of group
                 // there will be no hidden dimensions in the final query,
-                // so we have to remove the hidden flag from all dimensions
+                // so we have to remove the hidden flag from all dimensions;
+                // hidden (shadow/global) buckets keep the flag - it is what
+                // routes their values to the percentage denominator (vh)
+                // at the percentage-of-group pass
                 entries[pos].od |= qm->status & ~RRDR_DIMENSION_HIDDEN;
             else
                 entries[pos].od |= qm->status;


### PR DESCRIPTION
##### Summary

Queries that combine a `dimensions=` filter with two group-by levels where the **second** level computes `percentage` — e.g. `group_by=instance&aggregation=sum&group_by[1]=selected&aggregation[1]=percentage` — return a **completely empty response** (zero dimensions) whenever every instance has at least one filtered-out dimension, which is the common case since all instances of a context normally share the same dimensions. When some instances have no filtered-out dimensions, the response is non-empty but **silently wrong**: only those instances reach the numerator.

**Root cause.** The `percentage` group-by aggregation computes *selected ÷ (selected + hidden)*, where the hidden dimensions (those excluded by the filter) are still queried to serve as the denominator. To route them, `rrd2rrdr_group_by_initialize()` disables the "collapse hidden dimensions into their own bucket" rule **query-wide** whenever any pass uses percentage — but that is only correct **at the pass that computes the percentage** (where the value router splits values per-metric into the hidden array `vh`). At an earlier pass it is wrong twice over:

1. hidden and selected metrics of the same instance group into the **same** bucket, so their values merge — the numerator/denominator separation is destroyed before the percentage pass can use it;
2. each such bucket inherits `RRDR_DIMENSION_HIDDEN` from its hidden metrics, so the percentage pass routes the **whole bucket** to the denominator and never marks the output dimension `QUERIED` — the formatter then drops it, producing the empty response.

**Fix.** Make the hidden-dimension grouping decision per-pass instead of per-query:

| pass | hidden dimensions grouping |
|---|---|
| no percentage-of-group in the query | single query-wide bucket (unchanged — used e.g. by `options=percentage`) |
| passes **before** the percentage pass | **per-group shadow buckets** (same group key, prefixed) that keep the HIDDEN flag |
| the percentage pass and later | grouped with the selected ones, per-metric routing to `vh` (unchanged) |

With shadow buckets, the hidden values are aggregated with the **same grouping** as the selected values (per instance, per node, per label — whatever level 1 groups by), and the existing value router delivers them to the percentage pass's denominator: shadow buckets → `vh`, clean buckets → the numerator.

##### Scope / what is intentionally NOT affected

- **Single-pass percentage, `percentage-of-instance`, and percentage at the FIRST pass** keep their exact behavior (the mode is NORMAL at the consuming pass, as today).
- **Queries without percentage-of-group** keep the query-wide hidden bucket (GLOBAL mode), byte-identical behavior.
- **Aggregatable (`raw`) responses**: two-level percentage rows are now byte-identical to single-pass raw percentage rows (value, count, hidden columns) — the consumer (Netdata Cloud) derives the percentage the same way.
- Shadow buckets exist only in intermediate RRDRs, which are freed before formatting — their ids/names are never exposed in any response.
- v1 queries are untouched (they never reach this code path with group-by).

##### Test Plan

Validated red/green with a scripted streaming child pushing deterministic constants (fixed timestamps, hand-computable values) to a stock parent. Context `emp`: 2 instances with dims `a=10,b=40` and `a=20,b=30`. Context `mix`: the same plus a third instance with only `a=5`.

| query (`dimensions=a` unless noted) | correct | before | after |
|---|---|---|---|
| emp: `[instance,sum]→[selected,percentage]` | 30% (=30/100) | **EMPTY** (zero dims) | **30%** ✓ |
| mix: same | 33.33% (=35/105) | **4.76%** (=5/105) | **33.33%** ✓ |
| emp: single-pass `[selected,percentage]` (control) | 30% | 30% | 30% (unchanged) |
| emp: `[instance,sum]→[selected,sum]` (control) | 30 | 30 | 30 (unchanged) |
| emp: two-level percentage, **no filter** (control) | — | plain sum (100) | plain sum (100) (unchanged) |
| emp: two-level percentage `options=raw` | — | — | rows byte-identical to single-pass raw ✓ |
| view `sts` of the fixed two-level percentage | min=avg=max=30 | — | 30/30/30 ✓ |

A 12-check regression suite for the summary-statistics behavior of single-pass group-by (percentage, sum, min, max, average, raw mode — the #23035/#23097 behavior) passes unchanged on the fixed binary.

##### Additional Information

Reproduction on any live agent: pick a context with more than one instance and more than one dimension, and query
`/api/v3/data?scope_contexts=X&dimensions=<one-dim>&group_by=instance&aggregation=sum&group_by[1]=selected&aggregation[1]=percentage&format=json2&options=jsonwrap` — before this change, `view.dimensions.ids` is empty and the data rows contain no values.

<details> <summary>For users: How does this change affect me?</summary>

Affected area: queries that ask for a dimension as a **percentage of the total**, computed **after grouping by instance, node, or label** — for example "reads as % of all disk I/O, summed per disk first" on dashboards or through the API.

Before this change such queries returned an empty chart (or a wrong percentage when instances had differing dimensions). With this change they return the correct percentage. No configuration change; no API shape change — responses that were empty now carry data.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty or incorrect results for two-level group-by queries with a dimensions filter when the second level uses percentage. Hidden values are now kept separate before the percentage pass, so numerator and denominator are computed correctly.

- **Bug Fixes**
  - Queries like group_by=instance→selected with `aggregation[1]=percentage` and `dimensions=` now return correct data (no empty or skewed results).
  - Hidden-dimension grouping is per pass:
    - Before percentage: per-group shadow buckets (keep HIDDEN).
    - At/after percentage: grouped with selected; per-metric routing splits to denominator.
    - No percentage-of-group: single global hidden bucket (unchanged).
  - No API changes. Behavior unchanged for single-pass percentage, percentage at the first pass, percentage-of-instance, and queries without percentage-of-group.

<sup>Written for commit 5a894cc811376a4b48ae8108a6b7b7daa510bc47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

