### PR TITLE
fix false PARTIAL annotations on complete data

### DIFF
--- a/src/web/api/queries/query-cardinality-limit.c
+++ b/src/web/api/queries/query-cardinality-limit.c
@@ -120,7 +120,9 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
     // source RRDR: the formatters expect the reduced result to be
     // structurally identical to the original one - a missing array either
     // crashes them (gbc on the aggregatable path) or silently drops output
-    // sections (dgbc, vh, dqp, dl)
+    // sections (dgbc, vh, dqp, dl); hgbc is intentionally NOT mirrored -
+    // it is internal to the group-by passes and consumed (freed and NULLed)
+    // by rrd2rrdr_group_by_finalize() before this reduction runs
     if(new_r->d) {
         if(r->dp)
             new_r->dp = onewayalloc_callocz(owa, new_r->d, sizeof(*new_r->dp));

--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -2,6 +2,11 @@
 
 #include "query-internal.h"
 
+// hgbc packs, per point, the count of hidden (percentage denominator)
+// contributions and, in the top bit, whether any of them was itself partial
+#define HGBC_PARTIAL_FLAG (1U << 31)
+#define HGBC_COUNT_MASK   (~HGBC_PARTIAL_FLAG)
+
 void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
                                          RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
                                          STORAGE_POINT *query_points, size_t pass __maybe_unused) {
@@ -71,6 +76,42 @@ void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t
             *co |= (o_tmp & (RRDR_VALUE_RESET | RRDR_VALUE_PARTIAL));
             *ar += ar_tmp;
             (*gbc)++;
+        }
+        else if(r_dst->hgbc) {
+            // count the hidden (denominator) contributions too, so that
+            // an incomplete denominator can be detected as partial; a
+            // denominator source that is itself partial (a shadow bucket
+            // stamped at its own pass) taints the point through the top
+            // bit - hgbc is internal to group-by and never leaves finalize
+            r_dst->hgbc[idx_dst]++;
+            if(o_tmp & RRDR_VALUE_PARTIAL)
+                r_dst->hgbc[idx_dst] |= HGBC_PARTIAL_FLAG;
+        }
+    }
+}
+
+// stamp RRDR_VALUE_PARTIAL on every point that received fewer contributions
+// than the sources mapped into its dimension - visible sources are counted
+// by gbc, hidden (percentage denominator) sources by hgbc; this runs at
+// EVERY group-by pass, because the next pass only sees whole groups: a group
+// missing some of its own members would otherwise arrive complete-looking
+// there; visible flags propagate upward with the values through
+// rrd2rrdr_group_by_add_metric(), hidden flags through the hgbc top bit
+static void rrd2rrdr_group_by_stamp_partial(RRDR *r, const uint32_t *expected_gbc, const uint32_t *expected_hgbc) {
+    for(size_t i = 0; i < r->n ;i++) {
+        for(size_t d = 0; d < r->d ;d++) {
+            size_t idx = i * r->d + d;
+
+            uint32_t gbc = r->gbc[idx];
+            if(!gbc)
+                // points without visible contributions are empty, not partial
+                continue;
+
+            uint32_t hgbc = r->hgbc ? r->hgbc[idx] : 0;
+            if(gbc != expected_gbc[d] ||
+               (hgbc & HGBC_COUNT_MASK) != expected_hgbc[d] ||
+               (hgbc & HGBC_PARTIAL_FLAG))
+                r->o[idx] |= RRDR_VALUE_PARTIAL;
         }
     }
 }
@@ -252,22 +293,64 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
 
     // do the additional passes on RRDRs
     RRDR *last_r = r_tmp->group_by.r;
+
+    // how many sources are expected to contribute to every point of each
+    // dimension, in the units gbc counts at each pass: metrics at the first
+    // pass, prior-pass groups at later passes; dgbc cannot be this comparand
+    // - it counts metrics at every pass, including the hidden ones - so
+    // complete data would flag PARTIAL; the split between expected_gbc and
+    // expected_hgbc mirrors the routing rule of
+    // rrd2rrdr_group_by_add_metric(): hidden sources feed the percentage
+    // denominator (vh) and are counted by hgbc, never by gbc
+    ONEWAYALLOC *owa = last_r->internal.owa;
+    uint32_t *expected_gbc = onewayalloc_callocz(owa, last_r->d, sizeof(*expected_gbc));
+    uint32_t *expected_hgbc = onewayalloc_callocz(owa, last_r->d, sizeof(*expected_hgbc));
+
+    // the first pass received its contributions per metric during query
+    // execution
+    for(size_t m = 0; m < qt->query.used ;m++) {
+        QUERY_METRIC *qm = query_metric(qt, m);
+        if((qm->status & RRDR_DIMENSION_HIDDEN) && last_r->vh)
+            expected_hgbc[qm->grouped_as.first_slot]++;
+        else
+            expected_gbc[qm->grouped_as.first_slot]++;
+    }
+    rrd2rrdr_group_by_stamp_partial(last_r, expected_gbc, expected_hgbc);
+
     rrdr2rrdr_group_by_calculate_percentage_of_group(last_r);
 
     RRDR *r = last_r->group_by.r;
     size_t pass = 0;
     while(r) {
         pass++;
+        onewayalloc_freez(owa, expected_gbc);
+        onewayalloc_freez(owa, expected_hgbc);
+        expected_gbc = onewayalloc_callocz(owa, r->d, sizeof(*expected_gbc));
+        expected_hgbc = onewayalloc_callocz(owa, r->d, sizeof(*expected_hgbc));
+
         for(size_t d = 0; d < last_r->d ;d++) {
+            if((last_r->od[d] & RRDR_DIMENSION_HIDDEN) && r->vh)
+                expected_hgbc[last_r->dgbs[d]]++;
+            else
+                expected_gbc[last_r->dgbs[d]]++;
+
             rrd2rrdr_group_by_add_metric(r, last_r->dgbs[d], last_r, d,
                                          qt->request.group_by[pass].aggregation,
                                          &last_r->dqp[d], pass);
         }
+        rrd2rrdr_group_by_stamp_partial(r, expected_gbc, expected_hgbc);
         rrdr2rrdr_group_by_calculate_percentage_of_group(r);
 
         last_r = r;
         r = last_r->group_by.r;
     }
+
+    onewayalloc_freez(owa, expected_gbc);
+    onewayalloc_freez(owa, expected_hgbc);
+
+    // the hidden contribution counters are internal to the group-by passes
+    onewayalloc_freez(owa, last_r->hgbc);
+    last_r->hgbc = NULL;
 
     // free all RRDRs except the last one
     r = r_tmp;
@@ -320,9 +403,6 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
 
             if(likely(gbc)) {
                 *co &= ~RRDR_VALUE_EMPTY;
-
-                if(gbc != r->dgbc[d])
-                    *co |= RRDR_VALUE_PARTIAL;
 
                 NETDATA_DOUBLE n;
 

--- a/src/web/api/queries/query-group-by-init.c
+++ b/src/web/api/queries/query-group-by-init.c
@@ -495,10 +495,17 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
                 r->gbc = onewayalloc_callocz(
                     owa, onewayalloc_mul_or_fatal(r->n, r->d, "RRDR group-by counts"), sizeof(*r->gbc));
 
-                if(hidden_dimensions && ((group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) || (aggregation_method == RRDR_GROUP_BY_FUNCTION_PERCENTAGE)))
+                if(hidden_dimensions && ((group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) || (aggregation_method == RRDR_GROUP_BY_FUNCTION_PERCENTAGE))) {
                     // this is where we are going to group the hidden dimensions
                     r->vh = onewayalloc_mallocz(
                         owa, onewayalloc_mul3_or_fatal(r->n, r->d, sizeof(*r->vh), "RRDR hidden values"));
+
+                    // to know when the hidden (denominator) side of a point is
+                    // incomplete, its contributions are counted like gbc counts
+                    // the visible ones
+                    r->hgbc = onewayalloc_callocz(
+                        owa, onewayalloc_mul_or_fatal(r->n, r->d, "RRDR hidden group-by counts"), sizeof(*r->hgbc));
+                }
             }
         }
 

--- a/src/web/api/queries/rrdr.c
+++ b/src/web/api/queries/rrdr.c
@@ -82,6 +82,7 @@ inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r) {
     onewayalloc_freez(owa, r->dqp);
     onewayalloc_freez(owa, r->ar);
     onewayalloc_freez(owa, r->gbc);
+    onewayalloc_freez(owa, r->hgbc);
     onewayalloc_freez(owa, r->dgbc);
     onewayalloc_freez(owa, r->dgbs);
 

--- a/src/web/api/queries/rrdr.h
+++ b/src/web/api/queries/rrdr.h
@@ -75,6 +75,7 @@ typedef struct rrdresult {
     RRDR_VALUE_FLAGS *o;      // array n x d options for each value returned
     NETDATA_DOUBLE *ar;       // array n x d of anomaly rates (0 - 100)
     uint32_t *gbc;            // array n x d of group by count - NOT ALLOCATED when RRDR is created
+    uint32_t *hgbc;           // array n x d of hidden (vh) group by count, internal to group-by - NOT ALLOCATED when RRDR is created
 
     struct {
         size_t group;         // how many collected values were grouped for each row - NEEDED BY GROUPING FUNCTIONS


### PR DESCRIPTION
## Summary

The `PARTIAL` point annotation (bit 4 of the agreed agent/cloud/frontend annotation bitmap — "this point aggregates fewer sources than expected") was falsely set on **every row of complete, gap-free data** for two common query shapes. Since Netdata Cloud merges the agents' annotation bits as-is, the false flag reached dashboards fleet-wide, teaching users to ignore the one signal that marks genuinely incomplete data.

## Root cause

`rrd2rrdr_group_by_finalize()` decided partiality with `gbc != dgbc`, and the two counters do not count the same thing:

- `gbc` counts, per point, the contributions that actually arrived — in the units of the current pass (metrics at the first grouping pass, prior-pass *groups* at later passes), and only for sources that feed the visible value.
- `dgbc` counts, per dimension, the grouped **metrics** at every pass — including the hidden metrics that feed the percentage denominator (`vh`) and never increment `gbc`.

So two query shapes flagged every point of complete data:

1. **percentage-of-group + dimension filter**: `dgbc` includes the hidden denominator metrics, `gbc` never does → `1 != 2` everywhere.
2. **any two-level group-by where a level-1 group holds more than one metric**: at the final pass `gbc` counts groups, `dgbc` counts metrics → e.g. `3 != 6` everywhere.

## The fix

Partiality is now decided per pass, against expectations computed in the units that pass actually counts, using the same routing rule that gates the counters:

- **`expected_gbc` / `expected_hgbc` per dimension per pass**: visible sources (metrics at the first pass via `grouped_as.first_slot`, prior-pass groups at later passes via `dgbs`) versus hidden (denominator) sources, split exactly like `rrd2rrdr_group_by_add_metric()` routes them.
- **Per-pass stamping** (`rrd2rrdr_group_by_stamp_partial()`): each pass's points are stamped before they feed the next pass, because the next pass only sees whole groups — a group missing some of its own members would otherwise arrive complete-looking. Stamped flags propagate upward with the values through the existing `RESET|PARTIAL` propagation.
- **Hidden (denominator) coverage** — new internal per-point counter `hgbc`, allocated only when `vh` is, incremented in the hidden branch of `add_metric`: a point whose denominator is incomplete reports a percentage computed from missing data, so it is partial too. A denominator source that is *itself* partial (an internally-incomplete shadow bucket arriving at a later percentage pass) taints the point through the counter's top bit (`HGBC_PARTIAL_FLAG`). `hgbc` never leaves the group-by code — it is freed and NULLed on the final RRDR inside finalize.

**Nothing else changes**: `gbc` keeps its units (the AVERAGE division and raw-mode counts depend on them), and `dgbc` remains exactly what the API exposes as `view.dimensions.aggregated`.

Genuine partials keep working by construction: the expectations count every source that *should* contribute — including metrics with no data in the window — so the counters diverge exactly when data is genuinely missing. (A dimension that never delivered a sample has no retention and is excluded at query-target construction, on master and here alike — that is exclusion, not partiality.)

## Validation

Red/green with a fixture harness streaming deterministic data through the real streaming protocol (33 checks):

- RED (master): both shapes flag 60/60 rows of complete data (values verified complete); the false flag is present in `options=raw` output too — what Cloud consumes.
- GREEN: both shapes 0/60; three control queries unchanged; genuine-partial cases all exact —
  - an instance with data only in the second half of the window flags exactly the missing rows;
  - a metric missing *inside* a level-1 group flags through a second grouping pass;
  - a missing hidden denominator flags the rows whose percentage was computed from absent data (the values are literally 100% there);
  - an internally-partial shadow bucket taints the final result through the denominator at a later percentage pass;
- The 61-check `cardinality_limit` regression matrix (#23108) passes unchanged; `netdata -W unittest` query tests all pass.

Cloud note: cloud-charts-service merges the agents' annotation values (bitwise-OR style, plus deriving partial when merging an empty point with a non-empty one across nodes) and does not recompute this comparison — the agent-side fix is complete on its own.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false PARTIAL flags on complete, gap-free data in group-by queries by deciding partiality per pass with expected contribution counts. Prevents misleading PARTIAL annotations from reaching Cloud dashboards.

- **Bug Fixes**
  - Stamp `RRDR_VALUE_PARTIAL` per pass using expected visible (`expected_gbc`) and hidden (`expected_hgbc`) counts, matching how sources are routed.
  - Added internal `hgbc` counter to track hidden (percentage denominator) contributions; top bit carries “denominator was partial” taint. Freed before the final result.
  - Removed the old `gbc != dgbc` comparison that caused false PARTIAL in:
    - percentage-of-group with a dimension filter
    - two-level group-by where a level-1 group has multiple metrics
  - Ensures incomplete groups are marked before feeding the next pass so partiality propagates correctly.
  - `gbc` and `dgbc` behavior is unchanged; `hgbc` is internal and never exposed.

<sup>Written for commit 633fb3824051447a3487d71c98a2249423f7fee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

