### PR TITLE
fix csvjsonarray emitting invalid JSON when label-quotes is passed

### DIFF
--- a/src/web/api/formatters/rrd2json.c
+++ b/src/web/api/formatters/rrd2json.c
@@ -268,14 +268,14 @@ int data_query_execute(ONEWAYALLOC *owa, BUFFER *wb, QUERY_TARGET *qt, time_t *l
         if(options & RRDR_OPTION_JSON_WRAP) {
             wrapper_begin(r, wb);
             buffer_json_member_add_array(wb, "result");
-            rrdr2csv(r, wb, format, options + RRDR_OPTION_LABEL_QUOTES, "[", ",", "]", ",\n");
+            rrdr2csv(r, wb, format, options | RRDR_OPTION_LABEL_QUOTES, "[", ",", "]", ",\n");
             buffer_json_array_close(wb);
             wrapper_end(r, wb);
         }
         else {
             wb->content_type = CT_APPLICATION_JSON;
             buffer_strcat(wb, "[\n");
-            rrdr2csv(r, wb, format, options + RRDR_OPTION_LABEL_QUOTES, "[", ",", "]", ",\n");
+            rrdr2csv(r, wb, format, options | RRDR_OPTION_LABEL_QUOTES, "[", ",", "]", ",\n");
             buffer_strcat(wb, "\n]");
         }
         break;


### PR DESCRIPTION
## Summary

The csvjsonarray formatter adds `RRDR_OPTION_LABEL_QUOTES` to the options it passes to `rrdr2csv()` using **arithmetic addition instead of bitwise OR** (`options + RRDR_OPTION_LABEL_QUOTES`, two call sites in `rrd2json.c`). When the caller already passes `label-quotes` — redundant but legal, since csvjsonarray always wants quoted labels — the addition clears the bit and carries into the next one. The header row is then emitted without quotes:

```
"result":[[time,a,b,c],
[1700000060,1,2,5],
```

— making the **entire response invalid JSON**. The carried-into bit is inert at format time (value conversion reads the query window options, which are untouched), so the values themselves stay correct.

Reachable on `/api/v1`, `/api/v2` and `/api/v3` data queries with `format=csvjsonarray&options=label-quotes`, at both call sites (with and without `jsonwrap`).

## Fix

`+` → `|` at both sites. A repository-wide search confirms these are the only two occurrences of arithmetic on `RRDR_OPTION_*` bits.

## Validation

Red/green with a deterministic fixture (one chart, three dimensions, fixed 2023 epoch), covering both call sites:
- RED (master): with `label-quotes` both v3+jsonwrap and v1 plain responses are invalid JSON (unquoted header); without it, valid JSON with correct raw values.
- GREEN (this branch): both variants parse and produce identical result rows.

## Related finding (not addressed here)

While validating this, a separate defect surfaced: `/api/v{2,3}/data?format=csvjsonarray` **without** `seconds` emits unquoted datetime strings (`[2023-11-15 00:14:20,1,2,5]`) — invalid JSON regardless of this fix. v1 avoids it only because its defaults include `seconds`. That needs a small contract decision (quote the dates vs default csvjsonarray to `seconds` on v2/v3) and will be handled separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid JSON from `csvjsonarray` when callers pass `label-quotes` by using bitwise OR to keep header labels quoted. `/api/v1`, `/api/v2`, and `/api/v3` responses are now valid JSON in this case.

- **Bug Fixes**
  - Use `options | RRDR_OPTION_LABEL_QUOTES` instead of `options + RRDR_OPTION_LABEL_QUOTES` at both `rrdr2csv()` call sites in `src/web/api/formatters/rrd2json.c`.
  - Prevents unquoted header rows (e.g., [time,a,b,c]) when `label-quotes` is redundantly supplied.

<sup>Written for commit 7e38c706f69ef8461f166c37df19719ec603db11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

