### PR TITLE
make csvjsonarray timestamps always numeric

### DIFF
--- a/src/web/api/formatters/rrd2json.c
+++ b/src/web/api/formatters/rrd2json.c
@@ -263,22 +263,30 @@ int data_query_execute(ONEWAYALLOC *owa, BUFFER *wb, QUERY_TARGET *qt, time_t *l
         }
         break;
 
-    case DATASOURCE_CSV_JSON_ARRAY:
+    case DATASOURCE_CSV_JSON_ARRAY: {
+        // JSON has no date type: without a numeric timestamp option the csv
+        // renderer emits an unquoted local-time date string, making the
+        // whole response invalid JSON - this format is always numeric
+        RRDR_OPTIONS csv_options = options | RRDR_OPTION_LABEL_QUOTES;
+        if(!(csv_options & RRDR_OPTION_MILLISECONDS))
+            csv_options |= RRDR_OPTION_SECONDS;
+
         wb->content_type = CT_APPLICATION_JSON;
         if(options & RRDR_OPTION_JSON_WRAP) {
             wrapper_begin(r, wb);
             buffer_json_member_add_array(wb, "result");
-            rrdr2csv(r, wb, format, options | RRDR_OPTION_LABEL_QUOTES, "[", ",", "]", ",\n");
+            rrdr2csv(r, wb, format, csv_options, "[", ",", "]", ",\n");
             buffer_json_array_close(wb);
             wrapper_end(r, wb);
         }
         else {
             wb->content_type = CT_APPLICATION_JSON;
             buffer_strcat(wb, "[\n");
-            rrdr2csv(r, wb, format, options | RRDR_OPTION_LABEL_QUOTES, "[", ",", "]", ",\n");
+            rrdr2csv(r, wb, format, csv_options, "[", ",", "]", ",\n");
             buffer_strcat(wb, "\n]");
         }
         break;
+    }
 
     case DATASOURCE_TSV:
         if(options & RRDR_OPTION_JSON_WRAP) {


### PR DESCRIPTION
## Summary

`format=csvjsonarray` without `seconds` or `ms` in the options emits the timestamp as a bare, unquoted, local-time date string:

```
"result":[["time","a","b","c"],
[2023-11-15 00:14:20,1,2,5],
```

— making the **entire response invalid JSON**, on all API versions (verified live on v1, v2 and v3). There is no code-level default adding `seconds` anywhere; the dashboards always passed it explicitly, which is why this never surfaced. Nothing can depend on the current no-timestamp-option output: it was never parseable — not as JSON, and not as JavaScript either (`2023-11-15 00:14:20` is a syntax error as a JS expression), so not even eval-based consumers could ever have read it.

## Fix

JSON has no date type, so csvjsonarray now defaults to numeric `seconds` timestamps; `ms` is honored when requested. Applied once in the csvjsonarray branch of `rrd2json.c`, covering both call sites (with and without `jsonwrap`).

The Google Visualization formats (`datatable`/`datasource` with `google_json`), whose `Date(y,m,d,...)` cells are **deliberately** not strict JSON per that API's contract, are untouched.

## Validation

Red/green with a deterministic fixture (one chart, three dimensions, fixed 2023 epoch):
- RED (master): v3+jsonwrap and v1 plain csvjsonarray without `seconds`/`ms` are invalid JSON (bare date strings).
- GREEN (this branch): both parse as valid JSON with numeric epoch timestamps and correct values; `ms` produces millisecond timestamps; explicit `seconds` unchanged; the #23115 label-quotes behavior is regression-pinned in the same harness (10/10 checks).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `format=csvjsonarray` always outputs numeric timestamps so responses are valid JSON. Defaults to seconds when no option is provided; `ms` still works.

- **Bug Fixes**
  - Fixed invalid JSON caused by bare date strings when `seconds`/`ms` wasn’t set.
  - Enforced numeric timestamps by default (seconds) for both plain and `jsonwrap` responses; `ms` is honored when requested.

<sup>Written for commit a1f2724058def41eeda56bbec8bad10b0e547dde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

