### PR TITLE
fix streaming receiver discarding delivered data on child disconnect

### DIFF
--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -947,8 +947,15 @@ bool stream_receive_process_poll_events(struct stream_thread *sth, struct receiv
         return false;
     }
 
-    if (unlikely(events & (ND_POLL_ERROR | ND_POLL_HUP | ND_POLL_INVALID))) {
-        // we have errors on this socket
+    // ND_POLL_HUP together with ND_POLL_READ means the peer disconnected,
+    // but data it already delivered is still pending in the socket buffer.
+    // Removing the receiver here would discard that data, so keep reading:
+    // polling is level-triggered, both flags stay set while data remains,
+    // and when the buffer is drained recv() returns 0 and the read path
+    // removes the receiver with the same disconnect reason.
+    if (unlikely((events & (ND_POLL_ERROR | ND_POLL_INVALID)) ||
+                 ((events & ND_POLL_HUP) && !(events & ND_POLL_READ)))) {
+        // we have errors on this socket, or EOF with nothing left to read
 
         worker_is_busy(WORKER_STREAM_JOB_DISCONNECT_SOCKET_ERROR);
 


### PR DESCRIPTION
## Problem

When a streaming child disconnects immediately after writing — a crash, a restart, a short-lived connection, or completing replication and moving on — the parent discards data TCP has already delivered to it.

`stream_receive_process_poll_events()` removes the receiver on `ND_POLL_HUP` before processing `ND_POLL_READ`. Linux epoll (level-triggered in `nd-poll.c`) reports `EPOLLIN|EPOLLRDHUP` together from the moment the peer's FIN is queued — regardless of how much delivered data is still unread — so the teardown runs with data pending in the socket buffer, and that data is silently dropped.

Measured with a protocol-level fake child pushing a 3000-row replication burst and closing right after the final `REND`: only 221 rows were stored. The receiver's own accounting shows exactly one read buffer consumed (`bytes_in` = chart metadata + 15487 bytes = one `PLUGINSD_LINE_MAX` read); strace shows the next `epoll_wait` returning `EPOLLIN|EPOLLRDHUP` and no further `recvfrom` on the socket. Bursts smaller than one read buffer lose a timing-dependent amount (zero to everything); anything larger loses deterministically.

Replication heals this loss only when the child reconnects with local retention. Ephemeral children (k8s pods, autoscaled VMs), children running `[db] mode = none` or with small retention, and setups with replication disabled lose the delivered data permanently — and every child restart leaves a parent-side gap until the reconnect happens.

## Fix

Remove the receiver immediately only on `ND_POLL_ERROR`/`ND_POLL_INVALID` (real socket errors — on RST the kernel has already dropped the receive queue), or on `ND_POLL_HUP` without `ND_POLL_READ` (EOF with nothing readable). When HUP arrives together with READ, run the normal read path: one buffer per poll cycle — the same fairness any connected child gets — while level-triggered polling keeps re-reporting both flags; when the buffer is drained, `recv()` returns 0 and the existing read-path teardown removes the receiver with the same disconnect reason as before.

No new state, no drain loop, no protocol or configuration change. SSL connections terminate the same way: `SSL_ERROR_ZERO_RETURN` maps to 0 (clean close) and transport EOF maps to -1 (`SSL_ERROR_SYSCALL`), so the drain cannot spin.

## Validation

End-to-end against a stock daemon, with a fake child speaking the real streaming protocol at a fixed epoch:

- 30,000-point live `BEGIN2/SET2` burst + immediate close: **before 723/30000 stored, after 30000/30000**.
- 30,000-point replication (`RBEGIN/RSET/REND`) burst + immediate close: **before 3716/30000, after 30000/30000**.
- Byte ledger: `bytes_in` = metadata + full payload after the fix (210245 = 178 + 210067), for every iteration.
- Round-trip regression suite unchanged: live and replication ingestion byte-exact (values, gaps, anomaly bits, annotations), multiple children per context, chart labels, restart/journal-v2 replay.
- Teardown robustness: a child disconnecting mid-replication-dialogue (the parent's queued `REPLAY_CHART` reply hits a dead socket) leaves the daemon healthy and serving; a 30-cycle connect/burst/immediate-close soak shows no crash and no stuck receivers.

## Notes

- RST with buffered data still discards — the kernel drops the receive queue on RST; unchanged, unfixable at this layer.
- The sender-side event loop (`stream-sender.c`) has the same HUP-before-read ordering; its inbound traffic is parent control messages. Left untouched here pending evidence of impact.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents data loss in the stream receiver when a child disconnects right after writing by draining readable data before teardown. We now keep reading on HUP if data is pending, so delivered rows are not dropped.

- **Bug Fixes**
  - Only remove the receiver immediately on `ND_POLL_ERROR`/`ND_POLL_INVALID`, or on `ND_POLL_HUP` without `ND_POLL_READ`.
  - If `ND_POLL_HUP` arrives with `ND_POLL_READ`, continue the normal read path until `recv()` returns 0, then tear down.
  - No new state or loops; protocol and SSL behavior unchanged. Verified full ingestion of burst writes with immediate close.

<sup>Written for commit a4e763cbf2cc19f97b328faad9fed7293a84c416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

