### PR TITLE
flush pending host metadata on graceful shutdown

### DIFF
--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2815,7 +2815,13 @@ static void metadata_event_loop(void *arg)
     // hosts that connected after the last scan cycle still have their
     // metadata pending - store it now, or they will not exist after the
     // restart and their database files will be orphaned
-    store_hosts_metadata(config, false, true);
+    // (skip if a worker scan outlived the callback wait above: it is still
+    // using db_meta and no new scan can start once the command loop exits)
+    if (!config->metadata_running)
+        store_hosts_metadata(config, false, true);
+    else
+        nd_log_daemon(NDLP_WARNING,
+                      "METADATA: skipping the final host metadata flush - a metadata scan is still running");
 
     if (pending_ctx_cleanup_list) {
         Word_t Index = 0;

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2142,8 +2142,13 @@ static void metadata_scan_host(struct meta_config_s *config, RRDHOST *host, bool
 
     rrdset_foreach_reentrant(st, host) {
 
-        if (!final && SHUTDOWN_REQUESTED(config))
+        // when a normal scan is interrupted by shutdown, re-mark the host
+        // as pending (the caller cleared its flag) so the final shutdown
+        // flush picks it up and completes the remaining charts
+        if (!final && SHUTDOWN_REQUESTED(config)) {
+            host_need_recheck = true;
             break;
+        }
 
         if(rrdset_flag_check(st, RRDSET_FLAG_METADATA_UPDATE)) {
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2125,7 +2125,7 @@ size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, 
 }
 #endif
 
-static void metadata_scan_host(struct meta_config_s *config, RRDHOST *host, bool is_worker, BUFFER *work_buffer)
+static void metadata_scan_host(struct meta_config_s *config, RRDHOST *host, bool is_worker, bool final, BUFFER *work_buffer)
 {
     static bool skip_models = false;
     RRDSET *st;
@@ -2142,7 +2142,7 @@ static void metadata_scan_host(struct meta_config_s *config, RRDHOST *host, bool
 
     rrdset_foreach_reentrant(st, host) {
 
-        if (SHUTDOWN_REQUESTED(config))
+        if (!final && SHUTDOWN_REQUESTED(config))
             break;
 
         if(rrdset_flag_check(st, RRDSET_FLAG_METADATA_UPDATE)) {
@@ -2473,7 +2473,7 @@ void store_host_info_and_metadata(RRDHOST *host)
     store_host_info_and_metadata_with_buffer(host, NULL);
 }
 
-static void store_hosts_metadata(struct meta_config_s *config, bool is_worker)
+static void store_hosts_metadata(struct meta_config_s *config, bool is_worker, bool final)
 {
     RRDHOST *host;
     size_t host_count = 0;
@@ -2497,10 +2497,12 @@ static void store_hosts_metadata(struct meta_config_s *config, bool is_worker)
         if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED) || !rrdhost_flag_check(host, RRDHOST_FLAG_METADATA_UPDATE))
             continue;
 
-        rrdhost_flag_clear(host, RRDHOST_FLAG_METADATA_UPDATE);
-
-        if (SHUTDOWN_REQUESTED(config))
+        // check the shutdown BEFORE clearing the pending flag, so a host
+        // interrupted by shutdown keeps its pending status for the final scan
+        if (!final && SHUTDOWN_REQUESTED(config))
             break;
+
+        rrdhost_flag_clear(host, RRDHOST_FLAG_METADATA_UPDATE);
 
         if (is_worker)
             worker_is_busy(UV_EVENT_STORE_HOST);
@@ -2511,7 +2513,7 @@ static void store_hosts_metadata(struct meta_config_s *config, bool is_worker)
         if (is_worker)
             worker_is_idle();
 
-        metadata_scan_host(config, host, is_worker, work_buffer);
+        metadata_scan_host(config, host, is_worker, final, work_buffer);
 
         if (!is_worker)
             nd_log_daemon(NDLP_INFO, "METADATA: Progress of metadata storage: %6.2f%% completed", (100.0 * count / host_count));
@@ -2560,7 +2562,7 @@ static void start_metadata_hosts(uv_work_t *req)
 
     worker_is_busy(UV_EVENT_METADATA_STORE);
 
-    store_hosts_metadata(config, true);
+    store_hosts_metadata(config, true, false);
 
     COMPUTE_DURATION(report_duration, "us", all_started_ut, now_monotonic_usec());
     nd_log_daemon(NDLP_DEBUG, "Checking all hosts completed in %s", report_duration);
@@ -2804,6 +2806,11 @@ static void metadata_event_loop(void *arg)
 
     store_alert_transitions(pending_alert_list, false, true);
     store_sql_statements(pending_sql_statement, false, true);
+
+    // hosts that connected after the last scan cycle still have their
+    // metadata pending - store it now, or they will not exist after the
+    // restart and their database files will be orphaned
+    store_hosts_metadata(config, false, true);
 
     if (pending_ctx_cleanup_list) {
         Word_t Index = 0;


### PR DESCRIPTION
## Problem

A child host that connects to a parent for the first time shortly before a **graceful** parent shutdown is entirely forgotten: after the restart the parent answers `This netdata does not maintain a database for host`, and the child's dbengine files are left orphaned on disk.

Host records reach the sqlite metadata database only through the periodic scan (`METADATA_HOST_CHECK_INTERVAL` = 5 seconds: timer → `METADATA_STORE` → `start_metadata_hosts` → `store_hosts_metadata`). The metasync shutdown path flushes pending alert transitions and pending SQL statements — but never runs a final host scan. Any host still flagged `RRDHOST_FLAG_METADATA_UPDATE` at shutdown is silently dropped.

Measured with an A/B test against a stock daemon: two identical children, one connected 8 seconds before a graceful restart (a scan cycle had run), one connected less than 1 second before. After the restart the first was fully intact; the second was gone — host 404, retention `[0,0]`, data unreachable.

Real-world: a parent restarting (for example during an update) within seconds of a new child's first connection forgets that child and its streamed history. Children that reconnect with local retention re-register and re-replicate; ephemeral children (k8s pods, autoscaled VMs) and children without local retention lose the data permanently.

There was also a small pre-existing race in the same lines: the scan loop cleared a host's `RRDHOST_FLAG_METADATA_UPDATE` **before** checking the shutdown break, so a shutdown racing a normal scan dropped that host's pending status even when the host would survive.

## Fix

Mirror the existing shutdown flushes (`store_alert_transitions()` / `store_sql_statements()` already take a shutdown mode):

- `store_hosts_metadata()` and `metadata_scan_host()` get a `final` flag; their `SHUTDOWN_REQUESTED` loop breaks become `!final && SHUTDOWN_REQUESTED`.
- The shutdown break in `store_hosts_metadata()` is now checked **before** clearing the pending flag, so an interrupted scan keeps the host pending for the final pass.
- The metasync shutdown path calls `store_hosts_metadata(config, false, true)` right after the existing statement flush.

The final scan runs synchronously on the metasync thread at shutdown step 18 of 22 — collectors and dbengine tiers are already stopped (host/chart structures are quiescent and still allocated), and the SQL databases close later at step 20. Work is bounded by hosts actually pending — the same work the next 5-second tick would have done.

## Validation

End-to-end against a stock daemon with a protocol-level fake child:

- A/B restart test: the fresh child (<1s old at restart) now survives a graceful restart with all data queryable, byte-exact; the aged control unchanged.
- Full regression suite green: ingestion round-trips (live, replication, gaps, resets, anomaly bits, negatives, `update_every` variants, quantization contract), multi-child, chart labels, and three additional restart/journal-replay cycles per run, including a host with gap-only dimensions restarted mid-life.
- Repeated runs: deterministic.

## Notes

- Crash/SIGKILL shutdowns are out of scope — nothing can flush; the periodic scan remains the only protection there.
- The sync scan mode (`is_worker == false`) skips ML model loading and logs per-host progress — same behavior it had; it was previously unused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flushes pending host metadata during graceful shutdown so new child hosts aren’t forgotten after restart and their data stays queryable. Prevents orphaned dbengine files and “This netdata does not maintain a database for host” errors.

- **Bug Fixes**
  - Run a final host metadata scan in the metasync shutdown path after alert and SQL flushes.
  - Add a `final` flag to `metadata_scan_host()`/`store_hosts_metadata()`; bypass shutdown breaks on the final pass and keep shutdown‑interrupted hosts pending (check before clearing `RRDHOST_FLAG_METADATA_UPDATE` and re‑mark mid‑scan) so all metadata is persisted.
  - Skip the final flush if a scan worker is still running to avoid interleaved transactions on the same connection; log a warning instead.

<sup>Written for commit b0820d05dd036109828c34d895255c0c9919b343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

