### PR TITLE
exclude the pre-window storage point from the first bucket of tier queries

### DIFF
--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -292,7 +292,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             if(likely(new_point.sp.end_time_s < now_end_time)) { // likely to favor tier0
                 // this db point ends before our now_end_time
 
-                if(likely(new_point.sp.end_time_s >= now_start_time)) { // likely to favor tier0
+                if(likely(new_point.sp.end_time_s > now_start_time)) { // likely to favor tier0
                     // this db point ends after our now_start time
 
                     query_add_point_to_group(r, new_point, ops, add_flush);


### PR DESCRIPTION
##### Summary

Queries served from storage tiers 1 and above include data from **before the requested window** in the first point of the result, whenever the requested `after` falls exactly on a tier point boundary — the common case, since dashboards and API clients send aligned windows.

**The problem.** Tier `N>0` reads deliberately expand their storage scan a few points backwards (`POINTS_TO_EXPAND_QUERY`, `query_planer_initialize_plans()`), so the first visible point can be interpolated at exactly the requested time. Points fetched by this expansion that end *before* the window start correctly take a reference-only path. But a point ending **exactly at** the window start passed the inclusive bucket-assignment check (`end_time_s >= now_start_time` — `now_start_time` of the first bucket is the query's exclusive-left edge) and was **added into the first bucket**, although its data lies entirely outside `(after, before]`.

**Observed effect.** The first point of a boundary-aligned tier-1 query contained two tier windows instead of one: sums doubled, min/max/average contaminated by up to one full tier window (one minute at tier 1, one hour at tier 2, at the default tiering) of pre-window data — and the extra point also leaked into the bucket's anomaly rate and the dimension's query-wide statistics (used by weights and percentage contributions). This affects forced-tier queries and auto-tier queries alike (any zoomed-out view served from tier ≥ 1), and the same mechanism applies at mid-query tier switches — including a tier-0 plan that follows a coarser one, since non-first plans are expanded backwards regardless of tier. Pure per-second (tier 0) queries are not affected — their first plan is not expanded.

**The fix.** Make the comparison strictly greater, so the boundary point is routed to the existing reference-only branch — the one whose comment already documents this exact purpose ("this is desirable for the first point of the query because it allows us to interpolate the next point at exactly the time we will want"). Points ending strictly inside a bucket are unaffected. Boundary points of later buckets never reach this check: the previous bucket's interpolation path consumes them first, so the change is confined to freshly-fetched pre-window points.

##### Verification

- Reproduced deterministically with a controlled streaming child pushing fixed datasets into a clean parent: a boundary-aligned tier-1 query returned a first bucket of `sum = 540` where the window contains exactly `270` (two 60-sample windows merged); after the change it returns `270`. A tier-0 control on the same data confirms per-second reads behave identically before and after.
- Full regression pass over the same harness: live and replicated ingestion, tier-0 identity read-back (values, anomaly rates, annotations), tier-1/tier-2 rollup arithmetic (sum/min/max/average/anomaly-count) including partial windows, gap runs, stored-empty windows, resets, non-default `update every`, and restart persistence — no behavioral change anywhere except the fixed first bucket.
- Six independent code reviews of the change were run before opening this PR; findings were verified empirically against the harness.

##### Test Plan

- CI.
- The regression harness described above (streaming ingestion + query read-back against arithmetic oracles) passes with the fix applied and fails only its "bug must reproduce" guard, confirming the bug is gone.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tiered query bucket assignment to exclude the pre-window boundary point when the window starts on a tier boundary, preventing inflated first-bucket aggregates and stats. Affects tier ≥1 and mid-query plan transitions; tier 0’s first plan is unchanged.

- **Bug Fixes**
  - Use a strict `>` comparison for bucket start to route the boundary point to the reference-only path.
  - First bucket now only includes data within (after, before]; interior points and later buckets are unchanged.
  - Verified with regression harness and CI; first-bucket sums and rollups now match expected values.

<sup>Written for commit ff281571da62fc020dbd12ec47ba164e34a6ba48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

