### PR TITLE
add limit parameter to data queries for top-N dimensions

### DIFF
--- a/src/web/api/netdata-swagger.json
+++ b/src/web/api/netdata-swagger.json
@@ -1041,6 +1041,9 @@
             "$ref": "#/components/parameters/cardinalityLimit"
           },
           {
+            "$ref": "#/components/parameters/dataLimit"
+          },
+          {
             "$ref": "#/components/parameters/timeoutMS"
           },
           {
@@ -1230,6 +1233,9 @@
           },
           {
             "$ref": "#/components/parameters/cardinalityLimit"
+          },
+          {
+            "$ref": "#/components/parameters/dataLimit"
           },
           {
             "$ref": "#/components/parameters/timeoutMS"
@@ -7202,6 +7208,17 @@
         "required": false,
         "schema": {
           "type": "string"
+        }
+      },
+      "dataLimit": {
+        "name": "limit",
+        "in": "query",
+        "description": "Limits the number of dimensions returned by a data query to the top-N contributors: the query engine keeps the `limit` highest-contributing dimensions and folds the rest into one `remaining` aggregate dimension (equivalent to `cardinality_limit` = `limit` + 1; `cardinality_limit`, when given, takes precedence). Agents that predate this parameter ignore it and return all dimensions, so clients can use it without version gating.\n",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "minimum": 1
         }
       },
       "cardinalityLimit": {

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -877,6 +877,7 @@ paths:
         - $ref: '#/components/parameters/dataTimeResampling2'
         - $ref: '#/components/parameters/dataFormat2'
         - $ref: '#/components/parameters/cardinalityLimit'
+        - $ref: '#/components/parameters/dataLimit'
         - $ref: '#/components/parameters/timeoutMS'
         - $ref: '#/components/parameters/callback'
         - $ref: '#/components/parameters/filename'
@@ -1000,6 +1001,7 @@ paths:
         - $ref: '#/components/parameters/dataTimeResampling2'
         - $ref: '#/components/parameters/dataFormat2'
         - $ref: '#/components/parameters/cardinalityLimit'
+        - $ref: '#/components/parameters/dataLimit'
         - $ref: '#/components/parameters/timeoutMS'
         - $ref: '#/components/parameters/callback'
         - $ref: '#/components/parameters/filename'
@@ -9207,6 +9209,16 @@ components:
       required: false
       schema:
         type: string
+    dataLimit:
+      name: limit
+      in: query
+      description: |
+        Limits the number of dimensions returned by a data query to the top-N contributors: the query engine keeps the `limit` highest-contributing dimensions and folds the rest into one `remaining` aggregate dimension (equivalent to `cardinality_limit` = `limit` + 1; `cardinality_limit`, when given, takes precedence). Agents that predate this parameter ignore it and return all dimensions, so clients can use it without version gating.
+      required: false
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
     cardinalityLimit:
       name: cardinality_limit
       in: query

--- a/src/web/api/v1/api_v1_data.c
+++ b/src/web/api/v1/api_v1_data.c
@@ -30,6 +30,7 @@ int api_v1_data(RRDHOST *host, struct web_client *w, char *url) {
     char *chart_labels_filter = NULL;
     char *group_options = NULL;
     char *cardinality_limit_str = NULL;
+    char *limit_str = NULL;
     size_t tier = 0;
     size_t cardinality_limit = 0;
     RRDR_TIME_GROUPING group = RRDR_GROUPING_AVERAGE;
@@ -66,6 +67,7 @@ int api_v1_data(RRDHOST *host, struct web_client *w, char *url) {
         else if(!strcmp(name, "gtime")) group_time_str = value;
         else if(!strcmp(name, "group_options")) group_options = value;
         else if(!strcmp(name, "cardinality_limit")) cardinality_limit_str = value;
+        else if(!strcmp(name, "limit")) limit_str = value;
         else if(!strcmp(name, "group")) {
             group = time_grouping_parse(value, RRDR_GROUPING_AVERAGE);
         }
@@ -154,6 +156,13 @@ int api_v1_data(RRDHOST *host, struct web_client *w, char *url) {
     
     if (cardinality_limit_str && *cardinality_limit_str)
         cardinality_limit = str2ul(cardinality_limit_str);
+    else if (limit_str && *limit_str) {
+        // limit=N: top-N dimensions plus the 'remaining' aggregate; ignored
+        // by agents that predate the parameter (see api_v2_data.c)
+        size_t limit = str2ul(limit_str);
+        if (limit)
+            cardinality_limit = (limit < SIZE_MAX) ? limit + 1 : limit;
+    }
 
     QUERY_TARGET_REQUEST qtr = {
         .version = 1,

--- a/src/web/api/v2/api_v2_data.c
+++ b/src/web/api/v2/api_v2_data.c
@@ -52,6 +52,7 @@ static int api_v23_data_internal(RRDHOST *host __maybe_unused, struct web_client
     char *time_group_options = NULL;
     char *tier_str = NULL;
     char *cardinality_limit_str = NULL;
+    char *limit_str = NULL;
     size_t tier = 0;
     size_t cardinality_limit = 0;
     RRDR_TIME_GROUPING time_group = RRDR_GROUPING_AVERAGE;
@@ -116,6 +117,7 @@ static int api_v23_data_internal(RRDHOST *host __maybe_unused, struct web_client
         else if(!strcmp(name, "time_resampling")) resampling_time_str = value;
         else if(!strcmp(name, "tier")) tier_str = value;
         else if(!strcmp(name, "cardinality_limit")) cardinality_limit_str = value;
+        else if(!strcmp(name, "limit")) limit_str = value;
         else if(!strcmp(name, "callback")) responseHandler = value;
         else if(!strcmp(name, "filename")) outFileName = value;
         else if(!strcmp(name, "tqx")) {
@@ -198,6 +200,16 @@ static int api_v23_data_internal(RRDHOST *host __maybe_unused, struct web_client
     
     if(cardinality_limit_str && *cardinality_limit_str) {
         cardinality_limit = str2ul(cardinality_limit_str);
+    }
+    else if(limit_str && *limit_str) {
+        // limit=N means "return at most N dimensions"; the engine reserves
+        // one extra slot for the 'remaining N dimensions' aggregate, so the
+        // response carries the top-N plus the folded tail. Agents without
+        // this parameter ignore it, which lets clients use it without
+        // version gating.
+        size_t limit = str2ul(limit_str);
+        if(limit)
+            cardinality_limit = (limit < SIZE_MAX) ? limit + 1 : limit;
     }
 
     time_t    before = (before_str && *before_str)?str2l(before_str):0;


### PR DESCRIPTION
## Summary

Adds a `limit` query parameter to `/api/v1/data` and `/api/v2|v3/data`:
`limit=N` returns the N highest-contributing dimensions plus one `remaining`
aggregate dimension — equivalent to `cardinality_limit = N + 1` (an explicit
`cardinality_limit`, when given, takes precedence).

## Why a new parameter

`cardinality_limit` exists on all agents — including versions where combining
it with aggregatable (`raw`) responses crashes (fixed in #23108). An
aggregator like Netdata Cloud therefore cannot safely send it to a mixed
fleet without version gating.

`limit` is ignored by agents that predate it (the data query parsers skip
unknown parameters), so the rollout is self-gating: old agents return all
dimensions exactly as today, new agents return the ranked top-N. No
capability, no version checks.

This unblocks pushing top-N down to agents for node/instance groupings,
where per-agent top-N provably contains the global top-N (a node or
instance is never shared across agents).

## Validation

Verified live against a parent with two streaming children (4 dimensions,
distinct contributions):

- `limit=2` → top-2 by contribution + `remaining 2 dimensions`, identical
  to `cardinality_limit=3`
- `cardinality_limit=3&limit=1` → `cardinality_limit` wins
- a pre-parameter binary with `limit=2` → parameter ignored, all dimensions
- `limit` values at the integer boundary are clamped instead of overflowing
  to unlimited

Swagger (yaml + json) documents the parameter on the v2/v3 data endpoints.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new `limit` query parameter to data endpoints to request the top-N dimensions plus a single `remaining` aggregate. This enables safe top‑N queries on agents without version checks.

- **New Features**
  - Support `limit` on `/api/v1/data` and `/api/v2|v3/data`; returns top‑N dimensions + `remaining`; equivalent to `cardinality_limit = N + 1`. If both are set, `cardinality_limit` wins.
  - Backward compatible: agents that predate `limit` ignore it and return all dimensions, so mixed fleets work without gating.
  - Updated Swagger (`netdata-swagger.json`/`.yaml`) to document `limit` (int64, min=1) and added input clamping to prevent overflow.

<sup>Written for commit c9e61905837d56bda927e07562045919c7d4c557. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

