### PR TITLE
make cardinality_limit deterministic on ties and partial on mixed folds

### DIFF
--- a/src/web/api/queries/query-cardinality-limit.c
+++ b/src/web/api/queries/query-cardinality-limit.c
@@ -3,12 +3,17 @@
 #include "query-internal.h"
 
 static int compare_contributions(const void *a, const void *b) {
-    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; } *da = a;
-    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; } *db = b;
+    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; const char *id; } *da = a;
+    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; const char *id; } *db = b;
 
     if (da->contribution > db->contribution) return -1;
     if (da->contribution < db->contribution) return 1;
-    return 0;
+
+    // deterministic tie-break by dimension id: qsort() is not stable, and
+    // aggregators (Netdata Cloud) break equal-contribution ties by name -
+    // without this, which of two tied dimensions survives the fold would be
+    // unspecified and could differ from the merger's own choice
+    return strcmp(da->id, db->id);
 }
 
 // merge the group-by labels of a folded dimension into the labels
@@ -77,6 +82,7 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
     struct {
         size_t dim_idx;
         NETDATA_DOUBLE contribution;
+        const char *id;
     } *sorted_dims = onewayalloc_mallocz(
         owa, onewayalloc_mul_or_fatal(queried_count, sizeof(*sorted_dims), "RRDR cardinality dimensions"));
 
@@ -85,6 +91,7 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
         if (r->od[d] & RRDR_DIMENSION_QUERIED) {
             sorted_dims[sorted_idx].dim_idx = d;
             sorted_dims[sorted_idx].contribution = contributions[d];
+            sorted_dims[sorted_idx].id = string2str(r->di[d]);
             sorted_idx++;
         }
     }
@@ -270,6 +277,7 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
             uint32_t aggregated_gbc = 0;
             RRDR_VALUE_FLAGS aggregated_flags = RRDR_VALUE_NOTHING;
             bool has_values = false;
+            bool has_empty = false;
 
             for (size_t i = kept_dimensions; i < queried_count; i++) {
                 size_t src_d = sorted_dims[i].dim_idx;
@@ -297,8 +305,19 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
 
                         has_values = true;
                     }
+                    else
+                        has_empty = true;
                 }
+                else
+                    has_empty = true;
             }
+
+            // folding an empty point together with values makes the
+            // aggregate partial - the same rule the mergers apply when they
+            // fold dimensions themselves; without it the bucket looks
+            // complete and live-edge trimming keeps incomplete rows
+            if(has_values && has_empty)
+                aggregated_flags |= RRDR_VALUE_PARTIAL;
 
             if(new_r->vh)
                 new_r->vh[dst_idx] = aggregated_hidden;


### PR DESCRIPTION
## Summary

Two corrections to the `cardinality_limit` fold, both aligning the agent with
what aggregators (Netdata Cloud) do when they fold dimensions themselves:

1. **Deterministic ties.** The contribution comparator gains a dimension-id
   tie-break: `qsort()` is not stable, so which of two equal-contribution
   dimensions survived the fold was unspecified — it could flip between
   runs, making a "top-N" tile alternate between equally-sized dimensions
   with different time-series shapes, and could differ from the merger's own
   name-ordered choice on fleet queries.

2. **Partial visibility.** Folding an empty point together with values now
   marks the aggregate point `PARTIAL`. The `remaining` bucket used to look
   complete even when some folded dimensions had no data at that point,
   hiding incompleteness from live-edge trimming.

## Validation

Verified live against a real agent:
- with a per-dimension gap, the `remaining` bucket reports `pa=PARTIAL`
  exactly on the mixed rows and stays clean elsewhere;
- with two dimensions tied at the top and `limit=1`, the name-ascending
  winner is kept deterministically.

Follow-up to #23128; makes the pushed-down top-N (cloud-charts-service#681)
bit-consistent between the agents and the merger.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `cardinality_limit` deterministic on equal-contribution ties and mark mixed empty/value folds as PARTIAL. This stabilizes top‑N results and reveals incomplete rows for correct trimming, matching Netdata Cloud behavior.

- **Bug Fixes**
  - Break ties by dimension id in the contribution comparator to keep top‑N stable and consistent with the aggregator.
  - When folding, mark the `remaining` bucket PARTIAL if empty points are combined with values, so live-edge trimming sees incomplete rows.

<sup>Written for commit 787bfd32ff9ae0ed3b3b226c63d9b0d69b7b6848. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

