### PR TITLE
expose the cardinality fold cut in jsonwrap v2

### DIFF
--- a/src/web/api/formatters/jsonwrap-v2.c
+++ b/src/web/api/formatters/jsonwrap-v2.c
@@ -445,6 +445,21 @@ void rrdr_json_wrapper_begin2(RRDR *r, BUFFER *wb) {
         query_target_functions(wb, "functions", r);
 }
 
+void rrdr_json_wrapper_cardinality_v2(BUFFER *wb, RRDR *r, RRDR_OPTIONS options __maybe_unused) {
+    if(!r->cardinality.folded)
+        return;
+
+    // emitted only when the cardinality fold ran: how many dimensions were
+    // folded into 'remaining' and the largest folded |sum| contribution (the
+    // ranking cut). Aggregators (Netdata Cloud) use the cut to prove whether
+    // a merged top-N is exact - a dimension this agent did not return can
+    // contribute at most the cut
+    buffer_json_member_add_object(wb, "cardinality");
+    buffer_json_member_add_uint64(wb, "folded", r->cardinality.folded);
+    buffer_json_member_add_double(wb, "cut", r->cardinality.cut);
+    buffer_json_object_close(wb);
+}
+
 void rrdr_json_wrapper_partial_data_trimming_v2(BUFFER *wb, RRDR *r, RRDR_OPTIONS options) {
     if(!(options & (RRDR_OPTION_DEBUG | RRDR_OPTION_RETURN_RAW)))
         return;
@@ -512,6 +527,7 @@ void rrdr_json_wrapper_end2(RRDR *r, BUFFER *wb) {
         }
 
         rrdr_json_wrapper_partial_data_trimming_v2(wb, r, options);
+        rrdr_json_wrapper_cardinality_v2(wb, r, options);
 
         if(options & RRDR_OPTION_RETURN_RAW)
             buffer_json_member_add_uint64(wb, "points", rrdr_rows(r));

--- a/src/web/api/formatters/jsonwrap.h
+++ b/src/web/api/formatters/jsonwrap.h
@@ -14,6 +14,7 @@ void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb);
 
 void rrdr_json_wrapper_begin2(RRDR *r, BUFFER *wb);
 void rrdr_json_wrapper_end2(RRDR *r, BUFFER *wb);
+void rrdr_json_wrapper_cardinality_v2(BUFFER *wb, RRDR *r, RRDR_OPTIONS options);
 void rrdr_json_wrapper_partial_data_trimming_v2(BUFFER *wb, RRDR *r, RRDR_OPTIONS options);
 
 struct query_versions;

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -10141,6 +10141,9 @@ components:
                 Present only when the query's `cardinality_limit` (or `limit`) folded dimensions into the `remaining` aggregate.
                 Aggregators merging limited responses from many agents use `cut` to prove whether their merged top-N is exact: a dimension this agent did not return contributes at most `cut`, so when the N-th ranked merged candidate exceeds the sum of all agents' cuts, no hidden dimension can outrank it.
               type: object
+              required:
+                - folded
+                - cut
               properties:
                 folded:
                   description: The number of dimensions folded into the `remaining` aggregate.

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -10136,6 +10136,18 @@ components:
               description: |
                 The newest unix epoch timestamp of the data returned in the `result`.
               type: integer
+            cardinality:
+              description: |
+                Present only when the query's `cardinality_limit` (or `limit`) folded dimensions into the `remaining` aggregate.
+                Aggregators merging limited responses from many agents use `cut` to prove whether their merged top-N is exact: a dimension this agent did not return contributes at most `cut`, so when the N-th ranked merged candidate exceeds the sum of all agents' cuts, no hidden dimension can outrank it.
+              type: object
+              properties:
+                folded:
+                  description: The number of dimensions folded into the `remaining` aggregate.
+                  type: integer
+                cut:
+                  description: The largest folded absolute sum contribution - the ranking cut.
+                  type: number
             partial_data_trimming:
               description: |
                 Information related to trimming of the last few points of the `result`, that was required to remove (increasing) partial data.

--- a/src/web/api/queries/query-cardinality-limit.c
+++ b/src/web/api/queries/query-cardinality-limit.c
@@ -120,6 +120,13 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
     new_r->rows = r->rows;
     new_r->stats = r->stats;
 
+    // expose what the fold hid: the count of folded dimensions and the
+    // largest folded contribution (the ranking cut). Aggregators use the
+    // cut to prove whether a merged top-N is exact: any dimension an agent
+    // did not return contributes at most this much
+    new_r->cardinality.folded = queried_count - kept_dimensions;
+    new_r->cardinality.cut = sorted_dims[kept_dimensions].contribution;
+
     // Copy timestamps
     memcpy(new_r->t, r->t, r->n * sizeof(time_t));
 

--- a/src/web/api/queries/query-cardinality-limit.c
+++ b/src/web/api/queries/query-cardinality-limit.c
@@ -3,12 +3,17 @@
 #include "query-internal.h"
 
 static int compare_contributions(const void *a, const void *b) {
-    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; } *da = a;
-    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; } *db = b;
+    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; const char *id; } *da = a;
+    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; const char *id; } *db = b;
 
     if (da->contribution > db->contribution) return -1;
     if (da->contribution < db->contribution) return 1;
-    return 0;
+
+    // deterministic tie-break by dimension id: qsort() is not stable, and
+    // aggregators (Netdata Cloud) break equal-contribution ties by name -
+    // without this, which of two tied dimensions survives the fold would be
+    // unspecified and could differ from the merger's own choice
+    return strcmp(da->id, db->id);
 }
 
 // merge the group-by labels of a folded dimension into the labels
@@ -77,6 +82,7 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
     struct {
         size_t dim_idx;
         NETDATA_DOUBLE contribution;
+        const char *id;
     } *sorted_dims = onewayalloc_mallocz(
         owa, onewayalloc_mul_or_fatal(queried_count, sizeof(*sorted_dims), "RRDR cardinality dimensions"));
 
@@ -85,6 +91,7 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
         if (r->od[d] & RRDR_DIMENSION_QUERIED) {
             sorted_dims[sorted_idx].dim_idx = d;
             sorted_dims[sorted_idx].contribution = contributions[d];
+            sorted_dims[sorted_idx].id = string2str(r->di[d]);
             sorted_idx++;
         }
     }
@@ -270,6 +277,7 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
             uint32_t aggregated_gbc = 0;
             RRDR_VALUE_FLAGS aggregated_flags = RRDR_VALUE_NOTHING;
             bool has_values = false;
+            bool has_empty = false;
 
             for (size_t i = kept_dimensions; i < queried_count; i++) {
                 size_t src_d = sorted_dims[i].dim_idx;
@@ -297,8 +305,19 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
 
                         has_values = true;
                     }
+                    else
+                        has_empty = true;
                 }
+                else
+                    has_empty = true;
             }
+
+            // folding an empty point together with values makes the
+            // aggregate partial - the same rule the mergers apply when they
+            // fold dimensions themselves; without it the bucket looks
+            // complete and live-edge trimming keeps incomplete rows
+            if(has_values && has_empty)
+                aggregated_flags |= RRDR_VALUE_PARTIAL;
 
             if(new_r->vh)
                 new_r->vh[dst_idx] = aggregated_hidden;

--- a/src/web/api/queries/rrdr.h
+++ b/src/web/api/queries/rrdr.h
@@ -121,6 +121,11 @@ typedef struct rrdresult {
     } partial_data_trimming;
 
     struct {
+        size_t folded;              // dimensions folded into 'remaining'
+        NETDATA_DOUBLE cut;         // the largest folded |sum| contribution
+    } cardinality;
+
+    struct {
         ONEWAYALLOC *owa;           // the allocator used
         struct query_target *qt;    // the QUERY_TARGET
         size_t contexts;            // temp needed between json_wrapper_begin2() and json_wrapper_end2()


### PR DESCRIPTION
## Summary

When the cardinality fold runs, the v2 json wrapper now carries a small
`view.cardinality` object: how many dimensions were folded into `remaining`
and the **cut** — the largest folded `|sum|` contribution.

## Why

This is the agent half of distributed top-k for spanning groupings
(shared labels, dimensions by name), where a group's global value is the sum
of its per-agent contributions. Local top-k alone can never guarantee the
merged top-N — a group ranked k+1 on every agent can be the global #1 — but
the cut makes the merged answer *verifiable*: a dimension an agent did not
return contributes at most its cut, so when the N-th ranked merged candidate
exceeds the sum of all cuts, no folded dimension can outrank it. The merger
(cloud-charts-service#682) uses this to prove exactness in one round and
fall back to an unlimited fetch only when the proof fails.

The cut is taken from the already-sorted contributions array — no extra
computation. Responses without the fold are unchanged.

## Validation

Verified live: a `limit=1` query on a chart with three dimensions emits
`view.cardinality: {folded: 2, cut: <largest folded contribution>}`; the cut
matches the folded dimension sums on the returned grid; unlimited queries
emit nothing. Documented in swagger.

Stacked on #23129 (same file); merge that first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose cardinality fold metadata in v2 JSON responses to help aggregators prove exact top‑N, and align fold behavior with Cloud by fixing tie‑breaks and partial flags.

- **New Features**
  - Adds `view.cardinality` (only when the fold runs) with `folded` and `cut`; both fields are marked required in Swagger; no change when no fold occurs.

- **Bug Fixes**
  - Deterministic tie-break on equal contributions using dimension id (matches Cloud name ordering).
  - Mark `remaining` as PARTIAL when folding mixes empty and non-empty points, so live-edge trimming behaves correctly.

<sup>Written for commit c565808ac7abe2fac3f2929cb3e25cbab4e7d001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

