### PR TITLE
fix(x509check): fix misleading error message on PEM decode failure

### DIFF
--- a/src/go/plugin/go.d/collector/x509check/provider.go
+++ b/src/go/plugin/go.d/collector/x509check/provider.go
@@ -76,7 +76,7 @@ func (f fromFile) certificates() ([]*x509.Certificate, error) {
 
 	block, _ := pem.Decode(content)
 	if block == nil {
-		return nil, fmt.Errorf("error on decoding '%s': %v", f.path, err)
+		return nil, fmt.Errorf("error on decoding '%s': PEM decode failed (not a valid PEM file)", f.path)
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)


### PR DESCRIPTION
## Summary

Fixes #23133

The `fromFile.certificates()` function in `src/go/plugin/go.d/collector/x509check/provider.go` produced a misleading error message when PEM decoding failed.

### Problem

`pem.Decode` returns `(p *pem.Block, rest []byte)`, not `(block, error)`. The code discarded the second return value with `_` and then referenced the `err` variable from `os.ReadFile` above — which is always `nil` at that point — in the error format string:

```go
block, _ := pem.Decode(content)
if block == nil {
    return nil, fmt.Errorf("error on decoding '%s': %v", f.path, err)  // err is nil here
}
```

This produced the confusing message: `error on decoding '/path/to/cert.pem': <nil>`

### Fix

Use a descriptive error message that does not reference the nil `err` variable:

```go
return nil, fmt.Errorf("error on decoding '%s': PEM decode failed (not a valid PEM file)", f.path)
```

### Testing

- Added `TestFromFile_certificates_ReturnsErrorOnInvalidPEM` which writes a non-PEM file, calls `fromFile.certificates()`, and asserts:
  - An error is returned
  - The error message does not contain `<nil>`
  - The error message contains `PEM decode failed`
- All existing x509check tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a misleading error in `x509check` when PEM decoding fails by returning a clear message instead of `...: <nil>`. Closes #23133.

- **Bug Fixes**
  - `fromFile.certificates()` now reports “PEM decode failed (not a valid PEM file)” when `pem.Decode` returns `nil`.

<sup>Written for commit bafebf79ed4988108eb1cc7cb8354a5445edb13b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

