### PR TITLE
Netdata fixes part 81

### DIFF
--- a/src/daemon/machine-guid.c
+++ b/src/daemon/machine-guid.c
@@ -283,8 +283,9 @@ static bool machine_guid_write_to_file(const char *directory, const char *filena
         return machine_guid_close_and_unlink_temporary(fd, tmp_filename, saved_errno, "write failure");
     }
 
-    // Keep the established daemon permissions without changing the process-wide umask.
-    if (fchmod(fd, 0440) != 0) {
+    mode_t current_umask = umask(0); // Flawfinder: ignore - read and immediately restore the startup umask.
+    umask(current_umask); // Flawfinder: ignore - restore the startup umask.
+    if (fchmod(fd, 0444 & ~current_umask) != 0) {
         int saved_errno = errno;
         nd_log(NDLS_DAEMON, NDLP_ERR, "MACHINE_GUID: cannot set permissions on temporary GUID file '%s'", tmp_filename);
         return machine_guid_close_and_unlink_temporary(fd, tmp_filename, saved_errno, "permission failure");

--- a/src/libnetdata/os/file_lock.c
+++ b/src/libnetdata/os/file_lock.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "file_lock.h"
 #include "os.h"
+#include "file_lock.h"
 #include "../memory/nd-mallocz.h"
 
 #include <errno.h>

--- a/src/web/api/v1/api_v1_manage.c
+++ b/src/web/api/v1/api_v1_manage.c
@@ -20,16 +20,11 @@ static char *get_mgmt_api_key(void) {
     if(lstat(api_key_filename, &st) == 0 && S_ISREG(st.st_mode))
         fd = open(api_key_filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK | O_NOFOLLOW);
 #else
-    struct stat path_st;
-    if(lstat(api_key_filename, &path_st) == 0 && S_ISREG(path_st.st_mode))
+    if(stat(api_key_filename, &st) == 0 && S_ISREG(st.st_mode))
         fd = open(api_key_filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
 #endif
     if(fd != -1) {
-        if(fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)
-#ifndef O_NOFOLLOW
-           || st.st_dev != path_st.st_dev || st.st_ino != path_st.st_ino
-#endif
-        )
+        if(fstat(fd, &st) != 0 || !S_ISREG(st.st_mode))
             netdata_log_error("Management API key file '%s' is not a regular file, regenerating.", api_key_filename);
         else {
             char buf[GUID_LEN + 1];


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes machine GUID file permissions to respect the startup umask, hardens management API key reads to avoid blocking on special files, and fixes a Windows include-order build issue. Addresses Linear #22881.

- **Bug Fixes**
  - Machine GUID: read/restore the process umask and set permissions via fchmod(0444 & ~umask) without changing global umask state.
  - Management API key: precheck with stat, open with O_NONBLOCK, and validate with fstat to ensure a regular file; removes the device/inode fallback check on non-O_NOFOLLOW platforms.
  - Windows build: include "os.h" before "file_lock.h" to resolve header ordering conflicts.

<sup>Written for commit de13b2aa8b94eb335d53d15cecc5efebfd69d9e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

