### PR TITLE
Netdata fixes part 66

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -237,6 +237,7 @@ int query_plan_unittest(void);
 int api_v1_allmetrics_json_unittest(void);
 int exporting_json_connector_unittest(void);
 int exporting_opentsdb_http_unittest(void);
+int exporting_opentsdb_telnet_unittest(void);
 #ifdef ENABLE_ML
 int ml_unittest(void);
 #endif
@@ -450,6 +451,7 @@ int netdata_main(int argc, char **argv) {
                             if (api_v1_allmetrics_json_unittest()) return 1;
                             if (exporting_json_connector_unittest()) return 1;
                             if (exporting_opentsdb_http_unittest()) return 1;
+                            if (exporting_opentsdb_telnet_unittest()) return 1;
                             if (ringbuffer_unittest()) return 1;
                             if (log_stack_unittest()) return 1;
                             if (clocks_unittest()) return 1;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -234,6 +234,9 @@ int yaml_unittest(void);
 int json_c_parser_unittest(void);
 int stream_path_json_unittest(void);
 int query_plan_unittest(void);
+int api_v1_allmetrics_json_unittest(void);
+int exporting_json_connector_unittest(void);
+int exporting_opentsdb_http_unittest(void);
 #ifdef ENABLE_ML
 int ml_unittest(void);
 #endif
@@ -444,6 +447,9 @@ int netdata_main(int argc, char **argv) {
                             if (unit_test_buffer()) return 1;
                             if (unit_test_str2ld()) return 1;
                             if (buffer_unittest()) return 1;
+                            if (api_v1_allmetrics_json_unittest()) return 1;
+                            if (exporting_json_connector_unittest()) return 1;
+                            if (exporting_opentsdb_http_unittest()) return 1;
                             if (ringbuffer_unittest()) return 1;
                             if (log_stack_unittest()) return 1;
                             if (clocks_unittest()) return 1;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -236,6 +236,7 @@ int stream_path_json_unittest(void);
 int query_plan_unittest(void);
 int api_v1_allmetrics_json_unittest(void);
 int exporting_json_connector_unittest(void);
+int exporting_graphite_unittest(void);
 int exporting_opentsdb_http_unittest(void);
 int exporting_opentsdb_telnet_unittest(void);
 #ifdef ENABLE_ML
@@ -450,6 +451,7 @@ int netdata_main(int argc, char **argv) {
                             if (buffer_unittest()) return 1;
                             if (api_v1_allmetrics_json_unittest()) return 1;
                             if (exporting_json_connector_unittest()) return 1;
+                            if (exporting_graphite_unittest()) return 1;
                             if (exporting_opentsdb_http_unittest()) return 1;
                             if (exporting_opentsdb_telnet_unittest()) return 1;
                             if (ringbuffer_unittest()) return 1;

--- a/src/exporting/check_filters.c
+++ b/src/exporting/check_filters.c
@@ -25,7 +25,15 @@ int rrdhost_is_exportable(struct instance *instance, RRDHOST *host)
     RRDHOST_FLAGS *flags = &host->exporting_flags[instance->index];
 
     if (unlikely((*flags & (RRDHOST_FLAG_EXPORTING_SEND | RRDHOST_FLAG_EXPORTING_DONT_SEND)) == 0)) {
-        const char *host_name = (host == localhost) ? "localhost" : rrdhost_hostname(host);
+        RRDHOST_IDENTITY identity = { 0 };
+        const char *host_name;
+
+        if (host == localhost)
+            host_name = "localhost";
+        else {
+            identity = rrdhost_identity_acquire(host);
+            host_name = string2str(identity.hostname);
+        }
 
         if (!instance->config.hosts_pattern || simple_pattern_matches(instance->config.hosts_pattern, host_name)) {
             *flags |= RRDHOST_FLAG_EXPORTING_SEND;
@@ -34,6 +42,8 @@ int rrdhost_is_exportable(struct instance *instance, RRDHOST *host)
             *flags |= RRDHOST_FLAG_EXPORTING_DONT_SEND;
             netdata_log_info("disabled exporting of host '%s' for instance '%s'", host_name, instance->config.name);
         }
+
+        rrdhost_identity_release(&identity);
     }
 
     if (likely(*flags & RRDHOST_FLAG_EXPORTING_SEND))

--- a/src/exporting/check_filters.c
+++ b/src/exporting/check_filters.c
@@ -79,18 +79,36 @@ int rrdset_is_exportable(struct instance *instance, RRDSET *st)
             *flags |= RRDSET_FLAG_EXPORTING_SEND;
         else {
             *flags |= RRDSET_FLAG_EXPORTING_IGNORE;
-            netdata_log_debug(D_EXPORTING, "EXPORTING: not sending chart '%s' of host '%s', because it is disabled for exporting.", rrdset_id(st), rrdhost_hostname(host));
+#ifdef NETDATA_INTERNAL_CHECKS
+            if(unlikely(debug_flags & D_EXPORTING)) {
+                RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+                netdata_log_debug(D_EXPORTING, "EXPORTING: not sending chart '%s' of host '%s', because it is disabled for exporting.", rrdset_id(st), string2str(identity.hostname));
+                rrdhost_identity_release(&identity);
+            }
+#endif
             return 0;
         }
     }
 
     if(unlikely(!rrdset_is_available_for_exporting_and_alarms(st))) {
-        netdata_log_debug(D_EXPORTING, "EXPORTING: not sending chart '%s' of host '%s', because it is not available for exporting.", rrdset_id(st), rrdhost_hostname(host));
+#ifdef NETDATA_INTERNAL_CHECKS
+        if(unlikely(debug_flags & D_EXPORTING)) {
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+            netdata_log_debug(D_EXPORTING, "EXPORTING: not sending chart '%s' of host '%s', because it is not available for exporting.", rrdset_id(st), string2str(identity.hostname));
+            rrdhost_identity_release(&identity);
+        }
+#endif
         return 0;
     }
 
     if(unlikely(st->rrd_memory_mode == RRD_DB_MODE_NONE && !(EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_AS_COLLECTED))) {
-        netdata_log_debug(D_EXPORTING, "EXPORTING: not sending chart '%s' of host '%s' because its memory mode is '%s' and the exporting engine requires database access.", rrdset_id(st), rrdhost_hostname(host), rrd_memory_mode_name(host->rrd_memory_mode));
+#ifdef NETDATA_INTERNAL_CHECKS
+        if(unlikely(debug_flags & D_EXPORTING)) {
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+            netdata_log_debug(D_EXPORTING, "EXPORTING: not sending chart '%s' of host '%s' because its memory mode is '%s' and the exporting engine requires database access.", rrdset_id(st), string2str(identity.hostname), rrd_memory_mode_name(host->rrd_memory_mode));
+            rrdhost_identity_release(&identity);
+        }
+#endif
         return 0;
     }
 

--- a/src/exporting/clean_connectors.c
+++ b/src/exporting/clean_connectors.c
@@ -34,6 +34,7 @@ void clean_instance(struct instance *instance)
 {
     clean_instance_config(&instance->config);
     buffer_free(instance->labels_buffer);
+    buffer_free(instance->metric_prefix_buffer);
 
     netdata_cond_destroy(&instance->cond_var);
 }

--- a/src/exporting/exporting_engine.h
+++ b/src/exporting/exporting_engine.h
@@ -206,6 +206,7 @@ struct instance {
     int skip_chart;
 
     BUFFER *labels_buffer;
+    BUFFER *metric_prefix_buffer;
 
     time_t after;
     time_t before;

--- a/src/exporting/graphite/graphite.c
+++ b/src/exporting/graphite/graphite.c
@@ -82,8 +82,141 @@ void sanitize_graphite_label_value(char *dst, const char *src, size_t len)
     *dst = '\0';
 }
 
+static size_t graphite_utf8_decode(const char *src, size_t len, uint32_t *codepoint) {
+    const uint8_t *s = (const uint8_t *)src;
+    uint32_t cp = s[0];
+    uint32_t minimum = 0;
+    size_t bytes = 1;
+
+    if(cp < 0x80)
+        goto done;
+    else if((cp & 0xE0) == 0xC0) {
+        cp &= 0x1F;
+        minimum = 0x80;
+        bytes = 2;
+    }
+    else if((cp & 0xF0) == 0xE0) {
+        cp &= 0x0F;
+        minimum = 0x800;
+        bytes = 3;
+    }
+    else if((cp & 0xF8) == 0xF0) {
+        cp &= 0x07;
+        minimum = 0x10000;
+        bytes = 4;
+    }
+    else
+        goto done;
+
+    if(bytes > len)
+        goto invalid;
+
+    for(size_t i = 1; i < bytes; i++) {
+        if((s[i] & 0xC0) != 0x80)
+            goto invalid;
+
+        cp = (cp << 6) | (s[i] & 0x3F);
+    }
+
+    if(cp < minimum || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF))
+        goto invalid;
+
+done:
+    *codepoint = cp;
+    return bytes;
+
+invalid:
+    *codepoint = s[0];
+    return 1;
+}
+
+static bool graphite_unicode_is_whitespace(uint32_t codepoint) {
+    return (codepoint >= 0x0009 && codepoint <= 0x000D) ||
+           (codepoint >= 0x001C && codepoint <= 0x0020) ||
+           codepoint == 0x0085 || codepoint == 0x00A0 || codepoint == 0x1680 ||
+           (codepoint >= 0x2000 && codepoint <= 0x200A) ||
+           codepoint == 0x2028 || codepoint == 0x2029 || codepoint == 0x202F ||
+           codepoint == 0x205F || codepoint == 0x3000;
+}
+
+static void sanitize_graphite_metric_path_value(char *dst, const char *src, size_t len) {
+    while(*src && len) {
+        uint32_t codepoint;
+        size_t bytes = graphite_utf8_decode(src, len, &codepoint);
+
+        if(codepoint == ';' || graphite_unicode_is_whitespace(codepoint))
+            memset(dst, '_', bytes);
+        else
+            memcpy(dst, src, bytes);
+
+        dst += bytes;
+        src += bytes;
+        len -= bytes;
+    }
+
+    *dst = '\0';
+}
+
+static void buffer_strcat_graphite_metric_path_value(BUFFER *wb, const char *src) {
+    size_t len = strlen(src);
+
+    buffer_need_bytes(wb, len + 1);
+    sanitize_graphite_metric_path_value(&wb->buffer[wb->len], src, len);
+    wb->len += len;
+    buffer_overflow_check(wb);
+}
+
+static void format_graphite_metric_prefix(
+    struct instance *instance,
+    const char *chart_name,
+    const char *dimension_name) {
+    buffer_fast_strcat(
+        instance->buffer,
+        buffer_tostring(instance->metric_prefix_buffer),
+        buffer_strlen(instance->metric_prefix_buffer));
+    buffer_sprintf(
+        instance->buffer,
+        ".%s.%s%s ",
+        chart_name,
+        dimension_name,
+        instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "");
+}
+
+static void format_graphite_metric_double(
+    struct instance *instance,
+    const char *chart_name,
+    const char *dimension_name,
+    NETDATA_DOUBLE value,
+    unsigned long long timestamp) {
+    format_graphite_metric_prefix(instance, chart_name, dimension_name);
+    buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT " %llu\n", value, timestamp);
+}
+
+static void format_graphite_metric_integer(
+    struct instance *instance,
+    const char *chart_name,
+    const char *dimension_name,
+    collected_number value,
+    unsigned long long timestamp) {
+    format_graphite_metric_prefix(instance, chart_name, dimension_name);
+    buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT " %llu\n", value, timestamp);
+}
+
+static int format_graphite_metric_stored(
+    struct instance *instance,
+    const char *chart_name,
+    const char *dimension_name,
+    NETDATA_DOUBLE value,
+    unsigned long long timestamp) {
+    if(isnan(value))
+        return 0;
+
+    format_graphite_metric_double(instance, chart_name, dimension_name, value, timestamp);
+    return 0;
+}
+
 /**
- * Format host labels for JSON connector
+ * Format host identity and labels for Graphite connector
  *
  * @param instance an instance data structure.
  * @param host a data collecting host.
@@ -94,6 +227,22 @@ int format_host_labels_graphite_plaintext(struct instance *instance, RRDHOST *ho
 {
     if (!instance->labels_buffer)
         instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
+
+    if (!instance->metric_prefix_buffer)
+        instance->metric_prefix_buffer = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
+    else
+        buffer_flush(instance->metric_prefix_buffer);
+
+    buffer_strcat_graphite_metric_path_value(instance->metric_prefix_buffer, instance->config.prefix);
+    buffer_putc(instance->metric_prefix_buffer, '.');
+
+    if (host == localhost)
+        buffer_strcat_graphite_metric_path_value(instance->metric_prefix_buffer, instance->config.hostname);
+    else {
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        buffer_strcat_graphite_metric_path_value(instance->metric_prefix_buffer, string2str(identity.hostname));
+        rrdhost_identity_release(&identity);
+    }
 
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
@@ -115,7 +264,6 @@ int format_host_labels_graphite_plaintext(struct instance *instance, RRDHOST *ho
 int format_dimension_collected_graphite_plaintext(struct instance *instance, RRDDIM *rd)
 {
     RRDSET *st = rd->rrdset;
-    RRDHOST *host = st->rrdhost;
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     exporting_name_copy(
@@ -130,25 +278,17 @@ int format_dimension_collected_graphite_plaintext(struct instance *instance, RRD
         RRD_ID_LENGTH_MAX);
 
     if(rrddim_is_float(rd))
-        buffer_sprintf(
-            instance->buffer,
-            "%s.%s.%s.%s%s " NETDATA_DOUBLE_FORMAT " %llu\n",
-            instance->config.prefix,
-            (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+        format_graphite_metric_double(
+            instance,
             chart_name,
             dimension_name,
-            (instance->labels_buffer) ? buffer_tostring(instance->labels_buffer) : "",
             rrddim_last_collected_as_double(rd),
             (unsigned long long)rd->collector.last_collected_time.tv_sec);
     else
-        buffer_sprintf(
-            instance->buffer,
-            "%s.%s.%s.%s%s " COLLECTED_NUMBER_FORMAT " %llu\n",
-            instance->config.prefix,
-            (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+        format_graphite_metric_integer(
+            instance,
             chart_name,
             dimension_name,
-            (instance->labels_buffer) ? buffer_tostring(instance->labels_buffer) : "",
             (collected_number)rrddim_last_collected_raw_int(rd),
             (unsigned long long)rd->collector.last_collected_time.tv_sec);
 
@@ -165,7 +305,6 @@ int format_dimension_collected_graphite_plaintext(struct instance *instance, RRD
 int format_dimension_stored_graphite_plaintext(struct instance *instance, RRDDIM *rd)
 {
     RRDSET *st = rd->rrdset;
-    RRDHOST *host = st->rrdhost;
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     exporting_name_copy(
@@ -182,21 +321,12 @@ int format_dimension_stored_graphite_plaintext(struct instance *instance, RRDDIM
     time_t last_t;
     NETDATA_DOUBLE value = exporting_calculate_value_from_stored_data(instance, rd, &last_t);
 
-    if(isnan(value))
-        return 0;
-
-    buffer_sprintf(
-        instance->buffer,
-        "%s.%s.%s.%s%s " NETDATA_DOUBLE_FORMAT " %llu\n",
-        instance->config.prefix,
-        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+    return format_graphite_metric_stored(
+        instance,
         chart_name,
         dimension_name,
-        (instance->labels_buffer) ? buffer_tostring(instance->labels_buffer) : "",
         value,
         (unsigned long long)last_t);
-
-    return 0;
 }
 
 /**
@@ -222,4 +352,308 @@ void graphite_http_prepare_header(struct instance *instance)
         (unsigned long int) buffer_strlen(simple_connector_data->last_buffer->buffer));
 
     return;
+}
+
+typedef enum {
+    GRAPHITE_TEST_COLLECTED_FLOAT,
+    GRAPHITE_TEST_COLLECTED_INTEGER,
+    GRAPHITE_TEST_STORED,
+} GRAPHITE_TEST_BRANCH;
+
+static int graphite_unittest_case(
+    const char *description,
+    GRAPHITE_TEST_BRANCH branch,
+    const char *prefix,
+    const char *hostname,
+    const char *labels,
+    const char *expected) {
+    struct instance instance = { 0 };
+    instance.config.prefix = prefix;
+    instance.buffer = buffer_create(0, NULL);
+    instance.metric_prefix_buffer = buffer_create(0, NULL);
+    instance.labels_buffer = buffer_create(0, NULL);
+    BUFFER *wb = instance.buffer;
+
+    buffer_strcat_graphite_metric_path_value(instance.metric_prefix_buffer, prefix);
+    buffer_putc(instance.metric_prefix_buffer, '.');
+    buffer_strcat_graphite_metric_path_value(instance.metric_prefix_buffer, hostname);
+    buffer_strcat(instance.labels_buffer, labels);
+
+    switch(branch) {
+        case GRAPHITE_TEST_COLLECTED_FLOAT:
+            format_graphite_metric_double(&instance, "chart.name", "dimension.name", 1.5, 42);
+            break;
+        case GRAPHITE_TEST_COLLECTED_INTEGER:
+            format_graphite_metric_integer(&instance, "chart.name", "dimension.name", 15, 42);
+            break;
+        case GRAPHITE_TEST_STORED:
+            format_graphite_metric_stored(&instance, "chart.name", "dimension.name", -2.5, 42);
+            break;
+    }
+
+    int errors = 0;
+    if(strcmp(buffer_tostring(instance.buffer), expected) != 0) {
+        fprintf(
+            stderr,
+            "Graphite %s output mismatch\nexpected: %s\nactual:   %s\n",
+            description,
+            expected,
+            buffer_tostring(instance.buffer));
+        errors++;
+    }
+
+    size_t newline_count = 0;
+    for(const char *s = buffer_tostring(instance.buffer); *s; s++) {
+        if(*s == '\n')
+            newline_count++;
+        else if(*s == '\r' || *s == '\t' || *s == '\v' || *s == '\f') {
+            fprintf(stderr, "Graphite %s output retained a protocol delimiter\n", description);
+            errors++;
+            break;
+        }
+    }
+
+    if(newline_count != 1 || !buffer_strlen(wb) || wb->buffer[wb->len - 1] != '\n') {
+        fprintf(stderr, "Graphite %s output is not exactly one newline-terminated record\n", description);
+        errors++;
+    }
+
+    buffer_free(instance.labels_buffer);
+    buffer_free(instance.metric_prefix_buffer);
+    buffer_free(instance.buffer);
+    return errors;
+}
+
+static int graphite_unicode_whitespace_unittest(void) {
+    static const char whitespace[] =
+        "\x09\x0a\x0b\x0c\x0d\x1c\x1d\x1e\x1f\x20"
+        "\xc2\x85\xc2\xa0\xe1\x9a\x80"
+        "\xe2\x80\x80\xe2\x80\x81\xe2\x80\x82\xe2\x80\x83\xe2\x80\x84\xe2\x80\x85"
+        "\xe2\x80\x86\xe2\x80\x87\xe2\x80\x88\xe2\x80\x89\xe2\x80\x8a"
+        "\xe2\x80\xa8\xe2\x80\xa9\xe2\x80\xaf\xe2\x81\x9f\xe3\x80\x80";
+
+    const size_t whitespace_bytes = sizeof(whitespace) - 1;
+    char prefix[sizeof(whitespace) + 1];
+    char hostname[sizeof(whitespace) + 1];
+    char normalized[sizeof(whitespace)];
+
+    prefix[0] = 'p';
+    hostname[0] = 'h';
+    memcpy(&prefix[1], whitespace, sizeof(whitespace));
+    memcpy(&hostname[1], whitespace, sizeof(whitespace));
+    memset(normalized, '_', whitespace_bytes);
+    normalized[whitespace_bytes] = '\0';
+
+    int errors = 0;
+    char expected[512];
+
+    snprintf(
+        expected,
+        sizeof(expected),
+        "p%s.h%s.chart.name.dimension.name 1.5000000 42\n",
+        normalized,
+        normalized);
+    errors += graphite_unittest_case(
+        "collected floating Unicode whitespace", GRAPHITE_TEST_COLLECTED_FLOAT, prefix, hostname, "", expected);
+
+    snprintf(expected, sizeof(expected), "p%s.h%s.chart.name.dimension.name 15 42\n", normalized, normalized);
+    errors += graphite_unittest_case(
+        "collected integer Unicode whitespace", GRAPHITE_TEST_COLLECTED_INTEGER, prefix, hostname, "", expected);
+
+    snprintf(
+        expected,
+        sizeof(expected),
+        "p%s.h%s.chart.name.dimension.name -2.5000000 42\n",
+        normalized,
+        normalized);
+    errors += graphite_unittest_case(
+        "stored Unicode whitespace", GRAPHITE_TEST_STORED, prefix, hostname, "", expected);
+
+    return errors;
+}
+
+int exporting_graphite_unittest(void) {
+    int errors = 0;
+
+    errors += graphite_unittest_case(
+        "collected floating ordinary metadata",
+        GRAPHITE_TEST_COLLECTED_FLOAT,
+        "netdata",
+        "localhost",
+        ";label=value",
+        "netdata.localhost.chart.name.dimension.name;label=value 1.5000000 42\n");
+
+    errors += graphite_unittest_case(
+        "collected integer ordinary metadata",
+        GRAPHITE_TEST_COLLECTED_INTEGER,
+        "netdata",
+        "localhost",
+        "",
+        "netdata.localhost.chart.name.dimension.name 15 42\n");
+
+    errors += graphite_unittest_case(
+        "stored ordinary metadata",
+        GRAPHITE_TEST_STORED,
+        "netdata",
+        "localhost",
+        "",
+        "netdata.localhost.chart.name.dimension.name -2.5000000 42\n");
+
+    struct instance nan_instance = { 0 };
+    BUFFER *nan_wb = buffer_create(0, NULL);
+    nan_instance.buffer = nan_wb;
+    nan_instance.metric_prefix_buffer = buffer_create(0, NULL);
+    buffer_strcat(nan_instance.metric_prefix_buffer, "netdata.localhost");
+    if(format_graphite_metric_stored(&nan_instance, "chart.name", "dimension.name", NAN, 42) != 0 ||
+       buffer_strlen(nan_wb) != 0) {
+        fprintf(stderr, "Graphite stored NaN handling changed\n");
+        errors++;
+    }
+    buffer_free(nan_instance.metric_prefix_buffer);
+    buffer_free(nan_wb);
+
+    errors += graphite_unittest_case(
+        "accepted punctuation and UTF-8",
+        GRAPHITE_TEST_COLLECTED_FLOAT,
+        "Netdata-A_9/part.:@[]+()Ε",
+        "Host-A_9/path.example:@[]+()λλάδα",
+        "",
+        "Netdata-A_9/part.:@[]+()Ε.Host-A_9/path.example:@[]+()λλάδα.chart.name.dimension.name 1.5000000 42\n");
+
+    errors += graphite_unicode_whitespace_unittest();
+
+    errors += graphite_unittest_case(
+        "hostile metadata",
+        GRAPHITE_TEST_COLLECTED_FLOAT,
+        "pre fix;bad~tag\tbad\r\nmetric",
+        "host name;bad~tag\tbad\r\nmetric",
+        "",
+        "pre_fix_bad~tag_bad__metric.host_name_bad~tag_bad__metric.chart.name.dimension.name 1.5000000 42\n");
+
+    errors += graphite_unittest_case(
+        "all-invalid metadata",
+        GRAPHITE_TEST_COLLECTED_FLOAT,
+        " ;\t\r\n",
+        " ;\t\r\n",
+        "",
+        "_____._____.chart.name.dimension.name 1.5000000 42\n");
+
+    errors += graphite_unittest_case(
+        "tilde compatibility",
+        GRAPHITE_TEST_COLLECTED_FLOAT,
+        "~pre~fix~",
+        "~host~name~",
+        "",
+        "~pre~fix~.~host~name~.chart.name.dimension.name 1.5000000 42\n");
+
+    errors += graphite_unittest_case(
+        "empty metadata",
+        GRAPHITE_TEST_COLLECTED_FLOAT,
+        "",
+        "",
+        "",
+        "..chart.name.dimension.name 1.5000000 42\n");
+
+    errors += graphite_unittest_case(
+        "colliding invalid metadata",
+        GRAPHITE_TEST_COLLECTED_FLOAT,
+        "pre fix",
+        "host;name",
+        "",
+        "pre_fix.host_name.chart.name.dimension.name 1.5000000 42\n");
+
+    errors += graphite_unittest_case(
+        "colliding valid metadata",
+        GRAPHITE_TEST_COLLECTED_FLOAT,
+        "pre_fix",
+        "host_name",
+        "",
+        "pre_fix.host_name.chart.name.dimension.name 1.5000000 42\n");
+
+    char long_prefix[4097];
+    char long_hostname[4097];
+    memset(long_prefix, 'p', sizeof(long_prefix) - 1);
+    memset(long_hostname, 'h', sizeof(long_hostname) - 1);
+    long_prefix[1024] = '\n';
+    long_hostname[3072] = '\t';
+    long_prefix[sizeof(long_prefix) - 1] = '\0';
+    long_hostname[sizeof(long_hostname) - 1] = '\0';
+
+    struct instance instance = { 0 };
+    instance.config.prefix = long_prefix;
+    instance.buffer = buffer_create(0, NULL);
+    instance.metric_prefix_buffer = buffer_create(0, NULL);
+    BUFFER *wb = instance.buffer;
+    buffer_strcat_graphite_metric_path_value(instance.metric_prefix_buffer, long_prefix);
+    buffer_putc(instance.metric_prefix_buffer, '.');
+    buffer_strcat_graphite_metric_path_value(instance.metric_prefix_buffer, long_hostname);
+    format_graphite_metric_double(&instance, "chart.name", "dimension.name", 1.5, 42);
+
+    const size_t expected_length = strlen(long_prefix) + 1 + strlen(long_hostname) +
+                                   strlen(".chart.name.dimension.name 1.5000000 42\n");
+    if(buffer_strlen(wb) != expected_length || wb->buffer[1024] != '_' ||
+       wb->buffer[strlen(long_prefix) + 1 + 3072] != '_' ||
+       strchr(buffer_tostring(wb), '\t') || strchr(buffer_tostring(wb), '\r') ||
+       strchr(buffer_tostring(wb), '\n') != &wb->buffer[wb->len - 1]) {
+        fprintf(stderr, "Graphite long metadata was truncated or retained a protocol delimiter\n");
+        errors++;
+    }
+    buffer_free(instance.metric_prefix_buffer);
+    buffer_free(instance.buffer);
+
+    RRDLABELS *labels = rrdlabels_create();
+    rrdlabels_add(labels, "configured", "label value~bad", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "automatic", "excluded", RRDLABEL_SRC_AUTO);
+    BUFFER *labels_buffer = buffer_create(0, NULL);
+    struct instance labels_instance = { 0 };
+    labels_instance.config.options = EXPORTING_OPTION_SEND_CONFIGURED_LABELS;
+    rrdlabels_to_buffer(
+        labels,
+        labels_buffer,
+        ";",
+        "=",
+        "",
+        "",
+        exporting_labels_filter_callback,
+        &labels_instance,
+        NULL,
+        sanitize_graphite_label_value);
+    if(strcmp(buffer_tostring(labels_buffer), ";configured=label_value_bad") != 0) {
+        fprintf(stderr, "Graphite label filtering or sanitization changed\n");
+        errors++;
+    }
+    buffer_free(labels_buffer);
+    rrdlabels_destroy(labels);
+
+    RRDHOST child = { 0 };
+    spinlock_init(&child.rrdhost_update_lock);
+    child.hostname = string_strdupz("child host");
+    child.program_name = string_strdupz("netdata");
+    child.program_version = string_strdupz("1");
+
+    struct instance child_instance = { 0 };
+    child_instance.config.prefix = "netdata";
+    child_instance.buffer = buffer_create(0, NULL);
+    format_host_labels_graphite_plaintext(&child_instance, &child);
+
+    STRING *old_hostname = child.hostname;
+    child.hostname = string_strdupz("renamed child");
+    string_freez(old_hostname);
+
+    format_graphite_metric_double(&child_instance, "chart.name", "dimension.name", 1.5, 42);
+    if(strcmp(
+           buffer_tostring(child_instance.buffer),
+           "netdata.child_host.chart.name.dimension.name 1.5000000 42\n") != 0) {
+        fprintf(stderr, "Graphite child hostname snapshot did not survive identity replacement\n");
+        errors++;
+    }
+
+    buffer_free(child_instance.labels_buffer);
+    buffer_free(child_instance.metric_prefix_buffer);
+    buffer_free(child_instance.buffer);
+    string_freez(child.hostname);
+    string_freez(child.program_name);
+    string_freez(child.program_version);
+
+    return errors;
 }

--- a/src/exporting/graphite/graphite.c
+++ b/src/exporting/graphite/graphite.c
@@ -318,7 +318,7 @@ int format_dimension_stored_graphite_plaintext(struct instance *instance, RRDDIM
         (instance->config.options & EXPORTING_OPTION_SEND_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
         RRD_ID_LENGTH_MAX);
 
-    time_t last_t;
+    time_t last_t = 0;
     NETDATA_DOUBLE value = exporting_calculate_value_from_stored_data(instance, rd, &last_t);
 
     return format_graphite_metric_stored(

--- a/src/exporting/json/json.c
+++ b/src/exporting/json/json.c
@@ -130,6 +130,47 @@ int format_host_labels_json_plaintext(struct instance *instance, RRDHOST *host)
     return 0;
 }
 
+static void format_dimension_json_plaintext_prefix(
+    BUFFER *wb,
+    const char *prefix,
+    const char *hostname,
+    const char *labels,
+    const char *chart_id,
+    const char *chart_name,
+    const char *chart_family,
+    const char *chart_context,
+    const char *chart_type,
+    const char *units,
+    const char *dimension_id,
+    const char *dimension_name,
+    bool stored) {
+    buffer_strcat(wb, "{\"prefix\":\"");
+    buffer_json_strcat(wb, prefix);
+    buffer_strcat(wb, "\",\"hostname\":\"");
+    buffer_json_strcat(wb, hostname);
+    buffer_strcat(wb, "\",");
+    buffer_strcat(wb, labels);
+
+    buffer_strcat(wb, "\"chart_id\":\"");
+    buffer_json_strcat(wb, chart_id);
+    buffer_strcat(wb, "\",\"chart_name\":\"");
+    buffer_json_strcat(wb, chart_name);
+    buffer_strcat(wb, "\",\"chart_family\":\"");
+    buffer_json_strcat(wb, chart_family);
+    buffer_strcat(wb, stored ? "\",\"chart_context\": \"" : "\",\"chart_context\":\"");
+    buffer_json_strcat(wb, chart_context);
+    buffer_strcat(wb, "\",\"chart_type\":\"");
+    buffer_json_strcat(wb, chart_type);
+    buffer_strcat(wb, stored ? "\",\"units\": \"" : "\",\"units\":\"");
+    buffer_json_strcat(wb, units);
+
+    buffer_strcat(wb, "\",\"id\":\"");
+    buffer_json_strcat(wb, dimension_id);
+    buffer_strcat(wb, "\",\"name\":\"");
+    buffer_json_strcat(wb, dimension_name);
+    buffer_strcat(wb, "\",\"value\":");
+}
+
 /**
  * Format dimension using collected data for JSON connector
  *
@@ -147,29 +188,11 @@ int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM 
         buffer_strcat(instance->buffer, ",\n");
     }
 
-    buffer_sprintf(
+    format_dimension_json_plaintext_prefix(
         instance->buffer,
-
-        "{"
-        "\"prefix\":\"%s\","
-        "\"hostname\":\"%s\","
-        "%s"
-
-        "\"chart_id\":\"%s\","
-        "\"chart_name\":\"%s\","
-        "\"chart_family\":\"%s\","
-        "\"chart_context\":\"%s\","
-        "\"chart_type\":\"%s\","
-        "\"units\":\"%s\","
-
-        "\"id\":\"%s\","
-        "\"name\":\"%s\","
-        "\"value\":",
-
         instance->config.prefix,
         (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
         instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "",
-
         rrdset_id(st),
         rrdset_name(st),
         rrdset_family(st),
@@ -177,7 +200,8 @@ int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM 
         rrdset_parts_type(st),
         rrdset_units(st),
         rrddim_id(rd),
-        rrddim_name(rd));
+        rrddim_name(rd),
+        false);
 
     if(rrddim_is_float(rd))
         buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, rrddim_last_collected_as_double(rd));
@@ -217,30 +241,11 @@ int format_dimension_stored_json_plaintext(struct instance *instance, RRDDIM *rd
             buffer_strcat(instance->buffer, ",\n");
     }
 
-    buffer_sprintf(
+    format_dimension_json_plaintext_prefix(
         instance->buffer,
-        "{"
-        "\"prefix\":\"%s\","
-        "\"hostname\":\"%s\","
-        "%s"
-
-        "\"chart_id\":\"%s\","
-        "\"chart_name\":\"%s\","
-        "\"chart_family\":\"%s\","
-        "\"chart_context\": \"%s\","
-        "\"chart_type\":\"%s\","
-        "\"units\": \"%s\","
-
-        "\"id\":\"%s\","
-        "\"name\":\"%s\","
-        "\"value\":" NETDATA_DOUBLE_FORMAT ","
-
-        "\"timestamp\": %llu}",
-
         instance->config.prefix,
         (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
         instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "",
-
         rrdset_id(st),
         rrdset_name(st),
         rrdset_family(st),
@@ -249,8 +254,12 @@ int format_dimension_stored_json_plaintext(struct instance *instance, RRDDIM *rd
         rrdset_units(st),
         rrddim_id(rd),
         rrddim_name(rd),
-        value,
+        true);
 
+    buffer_sprintf(
+        instance->buffer,
+        NETDATA_DOUBLE_FORMAT ",\"timestamp\": %llu}",
+        value,
         (unsigned long long)last_t);
 
     if (instance->config.type != EXPORTING_CONNECTOR_TYPE_JSON_HTTP) {
@@ -311,4 +320,115 @@ void json_http_prepare_header(struct instance *instance)
         (unsigned long int) buffer_strlen(simple_connector_data->last_buffer->buffer));
 
     return;
+}
+
+static int json_plaintext_unittest_case(
+    const char *description,
+    bool stored,
+    const char *prefix,
+    const char *hostname,
+    const char *chart_id,
+    const char *chart_name,
+    const char *chart_family,
+    const char *chart_context,
+    const char *chart_type,
+    const char *units,
+    const char *dimension_id,
+    const char *dimension_name,
+    const char *expected) {
+    BUFFER *wb = buffer_create(0, NULL);
+    format_dimension_json_plaintext_prefix(
+        wb,
+        prefix,
+        hostname,
+        "\"labels\":{\"label\":\"value\"},",
+        chart_id,
+        chart_name,
+        chart_family,
+        chart_context,
+        chart_type,
+        units,
+        dimension_id,
+        dimension_name,
+        stored);
+    buffer_strcat(wb, stored ? "1.5,\"timestamp\": 42}" : "1.5,\"timestamp\":42}");
+
+    int errors = 0;
+    if(strcmp(buffer_tostring(wb), expected) != 0) {
+        fprintf(
+            stderr,
+            "exporting JSON %s output mismatch\nexpected: %s\nactual:   %s\n",
+            description,
+            expected,
+            buffer_tostring(wb));
+        errors++;
+    }
+
+    json_object *root = json_tokener_parse(buffer_tostring(wb));
+    json_object *member = NULL, *labels = NULL;
+#define CHECK_JSON_STRING(key, value)                                                                                   \
+    (!json_object_object_get_ex(root, key, &member) || strcmp(json_object_get_string(member), value) != 0)
+    if(!root || !json_object_is_type(root, json_type_object) || json_object_object_length(root) != 13 ||
+       CHECK_JSON_STRING("prefix", prefix) || CHECK_JSON_STRING("hostname", hostname) ||
+       CHECK_JSON_STRING("chart_id", chart_id) || CHECK_JSON_STRING("chart_name", chart_name) ||
+       CHECK_JSON_STRING("chart_family", chart_family) || CHECK_JSON_STRING("chart_context", chart_context) ||
+       CHECK_JSON_STRING("chart_type", chart_type) || CHECK_JSON_STRING("units", units) ||
+       CHECK_JSON_STRING("id", dimension_id) || CHECK_JSON_STRING("name", dimension_name) ||
+       !json_object_object_get_ex(root, "labels", &labels) || !json_object_is_type(labels, json_type_object) ||
+       !json_object_object_get_ex(labels, "label", &member) || strcmp(json_object_get_string(member), "value") != 0 ||
+       !json_object_object_get_ex(root, "value", &member) || json_object_get_double(member) != 1.5 ||
+       !json_object_object_get_ex(root, "timestamp", &member) || json_object_get_int64(member) != 42) {
+        fprintf(stderr, "exporting JSON %s schema or decoded value mismatch\n", description);
+        errors++;
+    }
+#undef CHECK_JSON_STRING
+
+    if(root)
+        json_object_put(root);
+    buffer_free(wb);
+    return errors;
+}
+
+int exporting_json_connector_unittest(void) {
+    int errors = 0;
+
+    errors += json_plaintext_unittest_case(
+        "ordinary collected metadata",
+        false,
+        "netdata",
+        "localhost",
+        "chart.id",
+        "chart.name",
+        "family",
+        "context",
+        "line",
+        "units",
+        "dimension.id",
+        "dimension.name",
+        "{\"prefix\":\"netdata\",\"hostname\":\"localhost\",\"labels\":{\"label\":\"value\"},"
+        "\"chart_id\":\"chart.id\",\"chart_name\":\"chart.name\",\"chart_family\":\"family\","
+        "\"chart_context\":\"context\",\"chart_type\":\"line\",\"units\":\"units\","
+        "\"id\":\"dimension.id\",\"name\":\"dimension.name\",\"value\":1.5,\"timestamp\":42}");
+
+    errors += json_plaintext_unittest_case(
+        "hostile stored metadata",
+        true,
+        "pre\"\\\x01",
+        "host\nname",
+        "chart\tid",
+        "chart\rname",
+        "family\bname",
+        "context\fname",
+        "type\"name",
+        "units\\name",
+        "dimension\"id",
+        "dimension\nname",
+        "{\"prefix\":\"pre\\\"\\\\\\u0001\",\"hostname\":\"host\\nname\","
+        "\"labels\":{\"label\":\"value\"},\"chart_id\":\"chart\\tid\","
+        "\"chart_name\":\"chart\\rname\",\"chart_family\":\"family\\bname\","
+        "\"chart_context\": \"context\\fname\",\"chart_type\":\"type\\\"name\","
+        "\"units\": \"units\\\\name\",\"id\":\"dimension\\\"id\","
+        "\"name\":\"dimension\\nname\",\"value\":1.5,\"timestamp\": 42}");
+
+    return errors;
 }

--- a/src/exporting/json/json.c
+++ b/src/exporting/json/json.c
@@ -118,6 +118,19 @@ int format_host_labels_json_plaintext(struct instance *instance, RRDHOST *host)
     if (!instance->labels_buffer)
         instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
+    if (!instance->metric_prefix_buffer)
+        instance->metric_prefix_buffer = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
+    else
+        buffer_flush(instance->metric_prefix_buffer);
+
+    if (host == localhost)
+        buffer_strcat(instance->metric_prefix_buffer, instance->config.hostname);
+    else {
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        buffer_strcat(instance->metric_prefix_buffer, string2str(identity.hostname));
+        rrdhost_identity_release(&identity);
+    }
+
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
 
@@ -189,7 +202,6 @@ static bool format_dimension_stored_json_plaintext_value_is_exportable(NETDATA_D
 int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM *rd)
 {
     RRDSET *st = rd->rrdset;
-    RRDHOST *host = st->rrdhost;
 
     if (instance->config.type == EXPORTING_CONNECTOR_TYPE_JSON_HTTP) {
         if (buffer_strlen((BUFFER *)instance->buffer) > 2)
@@ -199,7 +211,7 @@ int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM 
     format_dimension_json_plaintext_prefix(
         instance->buffer,
         instance->config.prefix,
-        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+        buffer_tostring(instance->metric_prefix_buffer),
         instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "",
         rrdset_id(st),
         rrdset_name(st),
@@ -236,7 +248,6 @@ int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM 
 int format_dimension_stored_json_plaintext(struct instance *instance, RRDDIM *rd)
 {
     RRDSET *st = rd->rrdset;
-    RRDHOST *host = st->rrdhost;
 
     time_t last_t;
     NETDATA_DOUBLE value = exporting_calculate_value_from_stored_data(instance, rd, &last_t);
@@ -252,7 +263,7 @@ int format_dimension_stored_json_plaintext(struct instance *instance, RRDDIM *rd
     format_dimension_json_plaintext_prefix(
         instance->buffer,
         instance->config.prefix,
-        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+        buffer_tostring(instance->metric_prefix_buffer),
         instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "",
         rrdset_id(st),
         rrdset_name(st),

--- a/src/exporting/json/json.c
+++ b/src/exporting/json/json.c
@@ -171,6 +171,14 @@ static void format_dimension_json_plaintext_prefix(
     buffer_strcat(wb, "\",\"value\":");
 }
 
+static void format_dimension_json_plaintext_value(BUFFER *wb, NETDATA_DOUBLE value) {
+    buffer_print_netdata_double_fixed(wb, value);
+}
+
+static bool format_dimension_stored_json_plaintext_value_is_exportable(NETDATA_DOUBLE value) {
+    return !isnan(value);
+}
+
 /**
  * Format dimension using collected data for JSON connector
  *
@@ -204,7 +212,7 @@ int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM 
         false);
 
     if(rrddim_is_float(rd))
-        buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, rrddim_last_collected_as_double(rd));
+        format_dimension_json_plaintext_value(instance->buffer, rrddim_last_collected_as_double(rd));
     else
         buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT, (collected_number)rrddim_last_collected_raw_int(rd));
 
@@ -233,7 +241,7 @@ int format_dimension_stored_json_plaintext(struct instance *instance, RRDDIM *rd
     time_t last_t;
     NETDATA_DOUBLE value = exporting_calculate_value_from_stored_data(instance, rd, &last_t);
 
-    if(isnan(value))
+    if(!format_dimension_stored_json_plaintext_value_is_exportable(value))
         return 0;
 
     if (instance->config.type == EXPORTING_CONNECTOR_TYPE_JSON_HTTP) {
@@ -256,11 +264,8 @@ int format_dimension_stored_json_plaintext(struct instance *instance, RRDDIM *rd
         rrddim_name(rd),
         true);
 
-    buffer_sprintf(
-        instance->buffer,
-        NETDATA_DOUBLE_FORMAT ",\"timestamp\": %llu}",
-        value,
-        (unsigned long long)last_t);
+    format_dimension_json_plaintext_value(instance->buffer, value);
+    buffer_sprintf(instance->buffer, ",\"timestamp\": %llu}", (unsigned long long)last_t);
 
     if (instance->config.type != EXPORTING_CONNECTOR_TYPE_JSON_HTTP) {
         buffer_strcat(instance->buffer, "\n");
@@ -351,7 +356,8 @@ static int json_plaintext_unittest_case(
         dimension_id,
         dimension_name,
         stored);
-    buffer_strcat(wb, stored ? "1.5,\"timestamp\": 42}" : "1.5,\"timestamp\":42}");
+    format_dimension_json_plaintext_value(wb, 1.5);
+    buffer_strcat(wb, stored ? ",\"timestamp\": 42}" : ",\"timestamp\":42}");
 
     int errors = 0;
     if(strcmp(buffer_tostring(wb), expected) != 0) {
@@ -389,6 +395,123 @@ static int json_plaintext_unittest_case(
     return errors;
 }
 
+static int json_plaintext_number_unittest_case(
+    const char *description, NETDATA_DOUBLE value, bool stored, bool expect_record, bool expect_null) {
+    int errors = 0;
+    BUFFER *actual_value = buffer_create(0, NULL);
+    BUFFER *expected_value = buffer_create(0, NULL);
+    BUFFER *record = buffer_create(0, NULL);
+
+    if(expect_record) {
+        format_dimension_json_plaintext_value(actual_value, value);
+        if(expect_null)
+            buffer_strcat(expected_value, "null");
+        else
+            buffer_sprintf(expected_value, NETDATA_DOUBLE_FORMAT, value);
+
+        if(strcmp(buffer_tostring(actual_value), buffer_tostring(expected_value)) != 0) {
+            fprintf(
+                stderr,
+                "exporting JSON %s %s numeric output mismatch\nexpected: %s\nactual:   %s\n",
+                stored ? "stored" : "collected",
+                description,
+                buffer_tostring(expected_value),
+                buffer_tostring(actual_value));
+            errors++;
+        }
+
+        format_dimension_json_plaintext_prefix(
+            record,
+            "netdata",
+            "localhost",
+            "\"labels\":{},",
+            "chart.id",
+            "chart.name",
+            "family",
+            "context",
+            "line",
+            "units",
+            "dimension.id",
+            "dimension.name",
+            stored);
+        format_dimension_json_plaintext_value(record, value);
+        buffer_strcat(record, stored ? ",\"timestamp\": 42}" : ",\"timestamp\":42}");
+
+        json_object *root = json_tokener_parse(buffer_tostring(record));
+        json_object *member = NULL;
+        if(!root || !json_object_is_type(root, json_type_object) ||
+           !json_object_object_get_ex(root, "value", &member)) {
+            fprintf(stderr, "exporting JSON %s %s record is not valid JSON\n",
+                    stored ? "stored" : "collected", description);
+            errors++;
+        }
+
+        if(root)
+            json_object_put(root);
+    }
+    else if(format_dimension_stored_json_plaintext_value_is_exportable(value)) {
+        fprintf(stderr, "exporting JSON stored %s should remain an omitted gap\n", description);
+        errors++;
+    }
+
+    buffer_free(record);
+    buffer_free(expected_value);
+    buffer_free(actual_value);
+    return errors;
+}
+
+static int json_plaintext_transport_unittest(void) {
+    int errors = 0;
+
+    BUFFER *plaintext = buffer_create(0, NULL);
+    buffer_strcat(plaintext, "{\"value\":");
+    format_dimension_json_plaintext_value(plaintext, INFINITY);
+    buffer_strcat(plaintext, ",\"timestamp\":42}\n");
+    if(strcmp(buffer_tostring(plaintext), "{\"value\":null,\"timestamp\":42}\n") != 0) {
+        fprintf(stderr, "exporting JSON plaintext transport framing mismatch\n");
+        errors++;
+    }
+    buffer_free(plaintext);
+
+    struct instance instance = { 0 };
+    instance.config.name = "JSON unit test";
+    instance.connector_specific_data = callocz(1, sizeof(struct simple_connector_data));
+    instance.buffer = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
+
+    struct simple_connector_data *connector = instance.connector_specific_data;
+    struct simple_connector_buffer *queued = callocz(1, sizeof(*queued));
+    queued->header = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
+    queued->buffer = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
+    queued->next = queued;
+    connector->first_buffer = connector->last_buffer = queued;
+
+    open_batch_json_http(&instance);
+    buffer_strcat(instance.buffer, "{\"value\":");
+    format_dimension_json_plaintext_value(instance.buffer, 1.5);
+    buffer_strcat(instance.buffer, "},\n{\"value\":");
+    format_dimension_json_plaintext_value(instance.buffer, -INFINITY);
+    buffer_strcat(instance.buffer, "}");
+    instance.stats.buffered_metrics = 2;
+    close_batch_json_http(&instance);
+
+    const char *expected = "[\n{\"value\":1.5000000},\n{\"value\":null}\n]\n";
+    const size_t expected_size = strlen(expected);
+    if(strcmp(buffer_tostring(queued->buffer), expected) != 0 || queued->buffered_metrics != 2 ||
+       queued->buffered_bytes != expected_size || queued->used != 1 ||
+       connector->total_buffered_metrics != 2 || instance.stats.buffered_metrics != 0 ||
+       (size_t)instance.stats.buffered_bytes != expected_size || buffer_strlen((BUFFER *)instance.buffer) != 0) {
+        fprintf(stderr, "exporting JSON HTTP batch, counter, or retry-buffer mismatch\n");
+        errors++;
+    }
+
+    buffer_free(instance.buffer);
+    buffer_free(queued->header);
+    buffer_free(queued->buffer);
+    freez(queued);
+    freez(connector);
+    return errors;
+}
+
 int exporting_json_connector_unittest(void) {
     int errors = 0;
 
@@ -408,7 +531,7 @@ int exporting_json_connector_unittest(void) {
         "{\"prefix\":\"netdata\",\"hostname\":\"localhost\",\"labels\":{\"label\":\"value\"},"
         "\"chart_id\":\"chart.id\",\"chart_name\":\"chart.name\",\"chart_family\":\"family\","
         "\"chart_context\":\"context\",\"chart_type\":\"line\",\"units\":\"units\","
-        "\"id\":\"dimension.id\",\"name\":\"dimension.name\",\"value\":1.5,\"timestamp\":42}");
+        "\"id\":\"dimension.id\",\"name\":\"dimension.name\",\"value\":1.5000000,\"timestamp\":42}");
 
     errors += json_plaintext_unittest_case(
         "hostile stored metadata",
@@ -428,7 +551,46 @@ int exporting_json_connector_unittest(void) {
         "\"chart_name\":\"chart\\rname\",\"chart_family\":\"family\\bname\","
         "\"chart_context\": \"context\\fname\",\"chart_type\":\"type\\\"name\","
         "\"units\": \"units\\\\name\",\"id\":\"dimension\\\"id\","
-        "\"name\":\"dimension\\nname\",\"value\":1.5,\"timestamp\": 42}");
+        "\"name\":\"dimension\\nname\",\"value\":1.5000000,\"timestamp\": 42}");
+
+#ifdef NETDATA_WITH_LONG_DOUBLE
+    const NETDATA_DOUBLE minimum_normal = LDBL_MIN;
+    const NETDATA_DOUBLE minimum_subnormal = nextafterl(0.0L, 1.0L);
+#else
+    const NETDATA_DOUBLE minimum_normal = DBL_MIN;
+    const NETDATA_DOUBLE minimum_subnormal = nextafter(0.0, 1.0);
+#endif
+    const struct {
+        const char *description;
+        NETDATA_DOUBLE value;
+        bool expect_null;
+    } number_cases[] = {
+        { "positive zero", 0.0, false },
+        { "negative zero", copysignndd(0.0, -1.0), false },
+        { "maximum finite", NETDATA_DOUBLE_MAX, false },
+        { "minimum finite", -NETDATA_DOUBLE_MAX, false },
+        { "minimum positive normal", minimum_normal, false },
+        { "minimum negative normal", -minimum_normal, false },
+        { "minimum positive subnormal", minimum_subnormal, false },
+        { "minimum negative subnormal", -minimum_subnormal, false },
+        { "NaN", NAN, true },
+        { "positive infinity", INFINITY, true },
+        { "negative infinity", -INFINITY, true },
+    };
+
+    for(size_t i = 0; i < _countof(number_cases); i++) {
+        const bool stored_record = !isnan(number_cases[i].value);
+        errors += json_plaintext_number_unittest_case(
+            number_cases[i].description, number_cases[i].value, false, true, number_cases[i].expect_null);
+        errors += json_plaintext_number_unittest_case(
+            number_cases[i].description,
+            number_cases[i].value,
+            true,
+            stored_record,
+            number_cases[i].expect_null);
+    }
+
+    errors += json_plaintext_transport_unittest();
 
     return errors;
 }

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -296,6 +296,29 @@ int format_host_labels_opentsdb_http(struct instance *instance, RRDHOST *host) {
     return 0;
 }
 
+static void format_opentsdb_http_prefix(
+    BUFFER *wb,
+    const char *prefix,
+    const char *chart_name,
+    const char *dimension_name,
+    unsigned long long timestamp) {
+    buffer_strcat(wb, "{\"metric\":\"");
+    buffer_json_strcat(wb, prefix);
+    buffer_putc(wb, '.');
+    buffer_json_strcat(wb, chart_name);
+    buffer_putc(wb, '.');
+    buffer_json_strcat(wb, dimension_name);
+    buffer_sprintf(wb, "\",\"timestamp\":%llu,\"value\":", timestamp);
+}
+
+static void format_opentsdb_http_suffix(BUFFER *wb, const char *hostname, const char *labels) {
+    buffer_strcat(wb, ",\"tags\":{\"host\":\"");
+    buffer_json_strcat(wb, hostname);
+    buffer_strcat(wb, "\"");
+    buffer_strcat(wb, labels);
+    buffer_strcat(wb, "}}");
+}
+
 /**
  * Format dimension using collected data for OpenTSDB HTTP connector
  *
@@ -323,12 +346,8 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
     if (buffer_strlen((BUFFER *)instance->buffer) > 2)
         buffer_strcat(instance->buffer, ",\n");
 
-    buffer_sprintf(
+    format_opentsdb_http_prefix(
         instance->buffer,
-        "{"
-        "\"metric\":\"%s.%s.%s\","
-        "\"timestamp\":%llu,"
-        "\"value\":",
         instance->config.prefix,
         chart_name,
         dimension_name,
@@ -339,13 +358,8 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
     else
         buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT, (collected_number)rrddim_last_collected_raw_int(rd));
 
-    buffer_sprintf(
+    format_opentsdb_http_suffix(
         instance->buffer,
-        ","
-        "\"tags\":{"
-        "\"host\":\"%s\"%s"
-        "}"
-        "}",
         (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
         instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "");
 
@@ -385,23 +399,89 @@ int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd)
     if (buffer_strlen((BUFFER *)instance->buffer) > 2)
         buffer_strcat(instance->buffer, ",\n");
 
-    buffer_sprintf(
+    format_opentsdb_http_prefix(
         instance->buffer,
-        "{"
-        "\"metric\":\"%s.%s.%s\","
-        "\"timestamp\":%llu,"
-        "\"value\":" NETDATA_DOUBLE_FORMAT ","
-        "\"tags\":{"
-        "\"host\":\"%s\"%s"
-        "}"
-        "}",
         instance->config.prefix,
         chart_name,
         dimension_name,
-        (unsigned long long)last_t,
-        value,
+        (unsigned long long)last_t);
+
+    buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, value);
+
+    format_opentsdb_http_suffix(
+        instance->buffer,
         (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
         instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "");
 
     return 0;
+}
+
+static int opentsdb_http_unittest_case(
+    const char *description,
+    const char *prefix,
+    const char *chart_name,
+    const char *dimension_name,
+    const char *hostname,
+    const char *expected) {
+    BUFFER *wb = buffer_create(0, NULL);
+    format_opentsdb_http_prefix(wb, prefix, chart_name, dimension_name, 42);
+    buffer_strcat(wb, "1.5");
+    format_opentsdb_http_suffix(wb, hostname, ",\"label\":\"value\"");
+
+    int errors = 0;
+    if(strcmp(buffer_tostring(wb), expected) != 0) {
+        fprintf(
+            stderr,
+            "OpenTSDB HTTP JSON %s output mismatch\nexpected: %s\nactual:   %s\n",
+            description,
+            expected,
+            buffer_tostring(wb));
+        errors++;
+    }
+
+    char metric[1024];
+    snprintfz(metric, sizeof(metric), "%s.%s.%s", prefix, chart_name, dimension_name);
+
+    json_object *root = json_tokener_parse(buffer_tostring(wb));
+    json_object *member = NULL, *tags = NULL;
+    if(!root || !json_object_is_type(root, json_type_object) || json_object_object_length(root) != 4 ||
+       !json_object_object_get_ex(root, "metric", &member) || strcmp(json_object_get_string(member), metric) != 0 ||
+       !json_object_object_get_ex(root, "timestamp", &member) || json_object_get_int64(member) != 42 ||
+       !json_object_object_get_ex(root, "value", &member) || json_object_get_double(member) != 1.5 ||
+       !json_object_object_get_ex(root, "tags", &tags) || !json_object_is_type(tags, json_type_object) ||
+       json_object_object_length(tags) != 2 || !json_object_object_get_ex(tags, "host", &member) ||
+       strcmp(json_object_get_string(member), hostname) != 0 ||
+       !json_object_object_get_ex(tags, "label", &member) || strcmp(json_object_get_string(member), "value") != 0) {
+        fprintf(stderr, "OpenTSDB HTTP JSON %s schema or decoded value mismatch\n", description);
+        errors++;
+    }
+
+    if(root)
+        json_object_put(root);
+    buffer_free(wb);
+    return errors;
+}
+
+int exporting_opentsdb_http_unittest(void) {
+    int errors = 0;
+
+    errors += opentsdb_http_unittest_case(
+        "ordinary metadata",
+        "netdata",
+        "chart.name",
+        "dimension.name",
+        "localhost",
+        "{\"metric\":\"netdata.chart.name.dimension.name\",\"timestamp\":42,\"value\":1.5,"
+        "\"tags\":{\"host\":\"localhost\",\"label\":\"value\"}}");
+
+    errors += opentsdb_http_unittest_case(
+        "hostile metadata",
+        "pre\"\\\x01",
+        "chart\nname",
+        "dimension\tname",
+        "host\r\"\\name",
+        "{\"metric\":\"pre\\\"\\\\\\u0001.chart\\nname.dimension\\tname\",\"timestamp\":42,"
+        "\"value\":1.5,\"tags\":{\"host\":\"host\\r\\\"\\\\name\",\"label\":\"value\"}}");
+
+    return errors;
 }

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -164,6 +164,34 @@ static void format_opentsdb_telnet_suffix(BUFFER *wb, const char *host_and_label
     buffer_putc(wb, '\n');
 }
 
+static bool opentsdb_value_is_exportable(NETDATA_DOUBLE value) {
+    return netdata_double_isnumber(value);
+}
+
+static bool format_opentsdb_telnet_metric(
+    struct instance *instance,
+    const char *prefix,
+    const char *chart_name,
+    const char *dimension_name,
+    unsigned long long timestamp,
+    bool value_is_float,
+    NETDATA_DOUBLE value,
+    collected_number integer_value) {
+    if(value_is_float && !opentsdb_value_is_exportable(value))
+        return false;
+
+    BUFFER *wb = instance->buffer;
+    format_opentsdb_telnet_prefix(wb, prefix, chart_name, dimension_name, timestamp);
+
+    if(value_is_float)
+        buffer_sprintf(wb, NETDATA_DOUBLE_FORMAT, value);
+    else
+        buffer_sprintf(wb, COLLECTED_NUMBER_FORMAT, integer_value);
+
+    format_opentsdb_telnet_suffix(wb, buffer_tostring(instance->labels_buffer));
+    return true;
+}
+
 /**
  * Format host identity and labels for OpenTSDB Telnet connector
  *
@@ -217,19 +245,26 @@ int format_dimension_collected_opentsdb_telnet(struct instance *instance, RRDDIM
         (instance->config.options & EXPORTING_OPTION_SEND_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
         RRD_ID_LENGTH_MAX);
 
-    format_opentsdb_telnet_prefix(
-        instance->buffer,
-        instance->config.prefix,
-        chart_name,
-        dimension_name,
-        (unsigned long long)rd->collector.last_collected_time.tv_sec);
-
     if(rrddim_is_float(rd))
-        buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, rrddim_last_collected_as_double(rd));
+        format_opentsdb_telnet_metric(
+            instance,
+            instance->config.prefix,
+            chart_name,
+            dimension_name,
+            (unsigned long long)rd->collector.last_collected_time.tv_sec,
+            true,
+            rrddim_last_collected_as_double(rd),
+            0);
     else
-        buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT, (collected_number)rrddim_last_collected_raw_int(rd));
-
-    format_opentsdb_telnet_suffix(instance->buffer, buffer_tostring(instance->labels_buffer));
+        format_opentsdb_telnet_metric(
+            instance,
+            instance->config.prefix,
+            chart_name,
+            dimension_name,
+            (unsigned long long)rd->collector.last_collected_time.tv_sec,
+            false,
+            0.0,
+            (collected_number)rrddim_last_collected_raw_int(rd));
 
     return 0;
 }
@@ -257,22 +292,18 @@ int format_dimension_stored_opentsdb_telnet(struct instance *instance, RRDDIM *r
         (instance->config.options & EXPORTING_OPTION_SEND_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
         RRD_ID_LENGTH_MAX);
 
-    time_t last_t;
+    time_t last_t = 0;
     NETDATA_DOUBLE value = exporting_calculate_value_from_stored_data(instance, rd, &last_t);
 
-    if(isnan(value))
-        return 0;
-
-    format_opentsdb_telnet_prefix(
-        instance->buffer,
+    format_opentsdb_telnet_metric(
+        instance,
         instance->config.prefix,
         chart_name,
         dimension_name,
-        (unsigned long long)last_t);
-
-    buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, value);
-
-    format_opentsdb_telnet_suffix(instance->buffer, buffer_tostring(instance->labels_buffer));
+        (unsigned long long)last_t,
+        true,
+        value,
+        0);
 
     return 0;
 }
@@ -346,6 +377,37 @@ static void format_opentsdb_http_suffix(BUFFER *wb, const char *hostname, const 
     buffer_strcat(wb, "}}");
 }
 
+static bool format_opentsdb_http_metric(
+    struct instance *instance,
+    RRDHOST *host,
+    const char *prefix,
+    const char *chart_name,
+    const char *dimension_name,
+    unsigned long long timestamp,
+    bool value_is_float,
+    NETDATA_DOUBLE value,
+    collected_number integer_value) {
+    if(value_is_float && !opentsdb_value_is_exportable(value))
+        return false;
+
+    BUFFER *wb = instance->buffer;
+    if(buffer_strlen(wb) > 2)
+        buffer_strcat(wb, ",\n");
+
+    format_opentsdb_http_prefix(wb, prefix, chart_name, dimension_name, timestamp);
+
+    if(value_is_float)
+        buffer_sprintf(wb, NETDATA_DOUBLE_FORMAT, value);
+    else
+        buffer_sprintf(wb, COLLECTED_NUMBER_FORMAT, integer_value);
+
+    format_opentsdb_http_suffix(
+        wb,
+        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+        instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "");
+    return true;
+}
+
 /**
  * Format dimension using collected data for OpenTSDB HTTP connector
  *
@@ -370,25 +432,28 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
         (instance->config.options & EXPORTING_OPTION_SEND_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
         RRD_ID_LENGTH_MAX);
 
-    if (buffer_strlen((BUFFER *)instance->buffer) > 2)
-        buffer_strcat(instance->buffer, ",\n");
-
-    format_opentsdb_http_prefix(
-        instance->buffer,
-        instance->config.prefix,
-        chart_name,
-        dimension_name,
-        (unsigned long long)rd->collector.last_collected_time.tv_sec);
-
     if(rrddim_is_float(rd))
-        buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, rrddim_last_collected_as_double(rd));
+        format_opentsdb_http_metric(
+            instance,
+            host,
+            instance->config.prefix,
+            chart_name,
+            dimension_name,
+            (unsigned long long)rd->collector.last_collected_time.tv_sec,
+            true,
+            rrddim_last_collected_as_double(rd),
+            0);
     else
-        buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT, (collected_number)rrddim_last_collected_raw_int(rd));
-
-    format_opentsdb_http_suffix(
-        instance->buffer,
-        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
-        instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "");
+        format_opentsdb_http_metric(
+            instance,
+            host,
+            instance->config.prefix,
+            chart_name,
+            dimension_name,
+            (unsigned long long)rd->collector.last_collected_time.tv_sec,
+            false,
+            0.0,
+            (collected_number)rrddim_last_collected_raw_int(rd));
 
     return 0;
 }
@@ -417,28 +482,19 @@ int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd)
         (instance->config.options & EXPORTING_OPTION_SEND_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
         RRD_ID_LENGTH_MAX);
 
-    time_t last_t;
+    time_t last_t = 0;
     NETDATA_DOUBLE value = exporting_calculate_value_from_stored_data(instance, rd, &last_t);
 
-    if(isnan(value))
-        return 0;
-
-    if (buffer_strlen((BUFFER *)instance->buffer) > 2)
-        buffer_strcat(instance->buffer, ",\n");
-
-    format_opentsdb_http_prefix(
-        instance->buffer,
+    format_opentsdb_http_metric(
+        instance,
+        host,
         instance->config.prefix,
         chart_name,
         dimension_name,
-        (unsigned long long)last_t);
-
-    buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, value);
-
-    format_opentsdb_http_suffix(
-        instance->buffer,
-        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
-        instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "");
+        (unsigned long long)last_t,
+        true,
+        value,
+        0);
 
     return 0;
 }
@@ -489,6 +545,179 @@ static int opentsdb_http_unittest_case(
     return errors;
 }
 
+static int opentsdb_number_unittest(void) {
+    int errors = 0;
+
+#ifdef NETDATA_WITH_LONG_DOUBLE
+    const NETDATA_DOUBLE minimum_normal = LDBL_MIN;
+    const NETDATA_DOUBLE minimum_subnormal = nextafterl(0.0L, 1.0L);
+#else
+    const NETDATA_DOUBLE minimum_normal = DBL_MIN;
+    const NETDATA_DOUBLE minimum_subnormal = nextafter(0.0, 1.0);
+#endif
+    const struct {
+        const char *description;
+        NETDATA_DOUBLE value;
+        bool expect_record;
+    } number_cases[] = {
+        { "positive zero", 0.0, true },
+        { "negative zero", copysignndd(0.0, -1.0), true },
+        { "maximum finite", NETDATA_DOUBLE_MAX, true },
+        { "minimum finite", -NETDATA_DOUBLE_MAX, true },
+        { "minimum positive normal", minimum_normal, true },
+        { "minimum negative normal", -minimum_normal, true },
+        { "minimum positive subnormal", minimum_subnormal, true },
+        { "minimum negative subnormal", -minimum_subnormal, true },
+        { "NaN", NAN, false },
+        { "positive infinity", INFINITY, false },
+        { "negative infinity", -INFINITY, false },
+    };
+
+    for(size_t i = 0; i < _countof(number_cases); i++) {
+        BUFFER *http = buffer_create(0, NULL);
+        BUFFER *expected_http = buffer_create(0, NULL);
+        buffer_strcat(http, "[\n");
+        buffer_strcat(expected_http, "[\n");
+
+        struct instance http_instance = {
+            .config.hostname = "localhost",
+            .buffer = http,
+        };
+        bool http_record = format_opentsdb_http_metric(
+            &http_instance,
+            localhost,
+            "netdata",
+            "chart.name",
+            "dimension.name",
+            42,
+            true,
+            number_cases[i].value,
+            0);
+        if(number_cases[i].expect_record) {
+            format_opentsdb_http_prefix(expected_http, "netdata", "chart.name", "dimension.name", 42);
+            buffer_sprintf(expected_http, NETDATA_DOUBLE_FORMAT, number_cases[i].value);
+            format_opentsdb_http_suffix(expected_http, "localhost", "");
+        }
+
+        if(http_record != number_cases[i].expect_record ||
+           strcmp(buffer_tostring(http), buffer_tostring(expected_http)) != 0) {
+            fprintf(
+                stderr,
+                "OpenTSDB HTTP %s omission or numeric output mismatch\nexpected: %s\nactual:   %s\n",
+                number_cases[i].description,
+                buffer_tostring(expected_http),
+                buffer_tostring(http));
+            errors++;
+        }
+
+        buffer_free(expected_http);
+        buffer_free(http);
+
+        BUFFER *telnet = buffer_create(0, NULL);
+        BUFFER *expected_telnet = buffer_create(0, NULL);
+        buffer_strcat(telnet, "existing\n");
+        buffer_strcat(expected_telnet, "existing\n");
+
+        BUFFER *telnet_labels = buffer_create(0, NULL);
+        buffer_strcat(telnet_labels, " host=localhost label=value");
+        struct instance telnet_instance = {
+            .buffer = telnet,
+            .labels_buffer = telnet_labels,
+        };
+        bool telnet_record = format_opentsdb_telnet_metric(
+            &telnet_instance,
+            "netdata",
+            "chart.name",
+            "dimension.name",
+            42,
+            true,
+            number_cases[i].value,
+            0);
+        if(number_cases[i].expect_record) {
+            format_opentsdb_telnet_prefix(expected_telnet, "netdata", "chart.name", "dimension.name", 42);
+            buffer_sprintf(expected_telnet, NETDATA_DOUBLE_FORMAT, number_cases[i].value);
+            format_opentsdb_telnet_suffix(expected_telnet, " host=localhost label=value");
+        }
+
+        if(telnet_record != number_cases[i].expect_record ||
+           strcmp(buffer_tostring(telnet), buffer_tostring(expected_telnet)) != 0) {
+            fprintf(
+                stderr,
+                "OpenTSDB Telnet %s omission or numeric output mismatch\nexpected: %s\nactual:   %s\n",
+                number_cases[i].description,
+                buffer_tostring(expected_telnet),
+                buffer_tostring(telnet));
+            errors++;
+        }
+
+        buffer_free(expected_telnet);
+        buffer_free(telnet_labels);
+        buffer_free(telnet);
+    }
+
+    BUFFER *http_batch = buffer_create(0, NULL);
+    buffer_strcat(http_batch, "[\n");
+    struct instance http_instance = {
+        .config.hostname = "localhost",
+        .buffer = http_batch,
+    };
+    bool first_record = format_opentsdb_http_metric(
+        &http_instance, localhost, "netdata", "chart", "first", 42, true, 1.5, 0);
+    size_t before_omission = buffer_strlen(http_batch);
+    bool omitted_record = format_opentsdb_http_metric(
+        &http_instance, localhost, "netdata", "chart", "omitted", 42, true, INFINITY, 0);
+    size_t after_omission = buffer_strlen(http_batch);
+    bool second_record = format_opentsdb_http_metric(
+        &http_instance, localhost, "netdata", "chart", "second", 42, true, -2.5, 0);
+    buffer_strcat(http_batch, "\n]\n");
+
+    BUFFER *expected_batch = buffer_create(0, NULL);
+    buffer_strcat(expected_batch, "[\n");
+    format_opentsdb_http_prefix(expected_batch, "netdata", "chart", "first", 42);
+    buffer_sprintf(expected_batch, NETDATA_DOUBLE_FORMAT, (NETDATA_DOUBLE)1.5);
+    format_opentsdb_http_suffix(expected_batch, "localhost", "");
+    buffer_strcat(expected_batch, ",\n");
+    format_opentsdb_http_prefix(expected_batch, "netdata", "chart", "second", 42);
+    buffer_sprintf(expected_batch, NETDATA_DOUBLE_FORMAT, (NETDATA_DOUBLE)-2.5);
+    format_opentsdb_http_suffix(expected_batch, "localhost", "");
+    buffer_strcat(expected_batch, "\n]\n");
+
+    if(!first_record || omitted_record || !second_record || after_omission != before_omission ||
+       strcmp(buffer_tostring(http_batch), buffer_tostring(expected_batch)) != 0) {
+        fprintf(
+            stderr,
+            "OpenTSDB HTTP omitted value changed array framing\nexpected: %s\nactual:   %s\n",
+            buffer_tostring(expected_batch),
+            buffer_tostring(http_batch));
+        errors++;
+    }
+
+    buffer_free(expected_batch);
+    buffer_free(http_batch);
+
+    BUFFER *integers = buffer_create(0, NULL);
+    buffer_strcat(integers, "[\n");
+    struct instance integer_instance = {
+        .config.hostname = "localhost",
+        .buffer = integers,
+    };
+    bool integer_record = format_opentsdb_http_metric(
+        &integer_instance, localhost, "netdata", "chart", "integer", 42, false, NAN, INT64_MIN);
+    BUFFER *expected_integers = buffer_create(0, NULL);
+    buffer_strcat(expected_integers, "[\n");
+    format_opentsdb_http_prefix(expected_integers, "netdata", "chart", "integer", 42);
+    buffer_sprintf(expected_integers, COLLECTED_NUMBER_FORMAT, (collected_number)INT64_MIN);
+    format_opentsdb_http_suffix(expected_integers, "localhost", "");
+    if(!integer_record || strcmp(buffer_tostring(integers), buffer_tostring(expected_integers)) != 0) {
+        fprintf(stderr, "OpenTSDB collected integer output changed\n");
+        errors++;
+    }
+    buffer_free(expected_integers);
+    buffer_free(integers);
+
+    return errors;
+}
+
 int exporting_opentsdb_http_unittest(void) {
     int errors = 0;
 
@@ -509,6 +738,8 @@ int exporting_opentsdb_http_unittest(void) {
         "host\r\"\\name",
         "{\"metric\":\"pre\\\"\\\\\\u0001.chart\\nname.dimension\\tname\",\"timestamp\":42,"
         "\"value\":1.5,\"tags\":{\"host\":\"host\\r\\\"\\\\name\",\"label\":\"value\"}}");
+
+    errors += opentsdb_number_unittest();
 
     return errors;
 }

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -134,8 +134,38 @@ void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
     *dst = '\0';
 }
 
+static void buffer_strcat_opentsdb_telnet_value(BUFFER *wb, const char *src) {
+    size_t len = strlen(src);
+
+    buffer_need_bytes(wb, len + 1);
+    sanitize_opentsdb_label_value(&wb->buffer[wb->len], src, len);
+    wb->len += len;
+    buffer_overflow_check(wb);
+}
+
+static void format_opentsdb_telnet_prefix(
+    BUFFER *wb,
+    const char *prefix,
+    const char *chart_name,
+    const char *dimension_name,
+    unsigned long long timestamp) {
+    buffer_strcat(wb, "put ");
+    buffer_strcat_opentsdb_telnet_value(wb, prefix);
+    buffer_sprintf(wb, ".%s.%s %llu ", chart_name, dimension_name, timestamp);
+}
+
+static void format_opentsdb_telnet_host(BUFFER *wb, const char *hostname) {
+    buffer_strcat(wb, " host=");
+    buffer_strcat_opentsdb_telnet_value(wb, hostname);
+}
+
+static void format_opentsdb_telnet_suffix(BUFFER *wb, const char *host_and_labels) {
+    buffer_strcat(wb, host_and_labels);
+    buffer_putc(wb, '\n');
+}
+
 /**
- * Format host labels for JSON connector
+ * Format host identity and labels for OpenTSDB Telnet connector
  *
  * @param instance an instance data structure.
  * @param host a data collecting host.
@@ -145,6 +175,14 @@ void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
 int format_host_labels_opentsdb_telnet(struct instance *instance, RRDHOST *host) {
     if(!instance->labels_buffer)
         instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
+
+    if(host == localhost)
+        format_opentsdb_telnet_host(instance->labels_buffer, instance->config.hostname);
+    else {
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        format_opentsdb_telnet_host(instance->labels_buffer, string2str(identity.hostname));
+        rrdhost_identity_release(&identity);
+    }
 
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
@@ -166,7 +204,6 @@ int format_host_labels_opentsdb_telnet(struct instance *instance, RRDHOST *host)
 int format_dimension_collected_opentsdb_telnet(struct instance *instance, RRDDIM *rd)
 {
     RRDSET *st = rd->rrdset;
-    RRDHOST *host = st->rrdhost;
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     exporting_name_copy(
@@ -180,28 +217,19 @@ int format_dimension_collected_opentsdb_telnet(struct instance *instance, RRDDIM
         (instance->config.options & EXPORTING_OPTION_SEND_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
         RRD_ID_LENGTH_MAX);
 
+    format_opentsdb_telnet_prefix(
+        instance->buffer,
+        instance->config.prefix,
+        chart_name,
+        dimension_name,
+        (unsigned long long)rd->collector.last_collected_time.tv_sec);
+
     if(rrddim_is_float(rd))
-        buffer_sprintf(
-            instance->buffer,
-            "put %s.%s.%s %llu " NETDATA_DOUBLE_FORMAT " host=%s%s\n",
-            instance->config.prefix,
-            chart_name,
-            dimension_name,
-            (unsigned long long)rd->collector.last_collected_time.tv_sec,
-            rrddim_last_collected_as_double(rd),
-            (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
-            (instance->labels_buffer) ? buffer_tostring(instance->labels_buffer) : "");
+        buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, rrddim_last_collected_as_double(rd));
     else
-        buffer_sprintf(
-            instance->buffer,
-            "put %s.%s.%s %llu " COLLECTED_NUMBER_FORMAT " host=%s%s\n",
-            instance->config.prefix,
-            chart_name,
-            dimension_name,
-            (unsigned long long)rd->collector.last_collected_time.tv_sec,
-            (collected_number)rrddim_last_collected_raw_int(rd),
-            (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
-            (instance->labels_buffer) ? buffer_tostring(instance->labels_buffer) : "");
+        buffer_sprintf(instance->buffer, COLLECTED_NUMBER_FORMAT, (collected_number)rrddim_last_collected_raw_int(rd));
+
+    format_opentsdb_telnet_suffix(instance->buffer, buffer_tostring(instance->labels_buffer));
 
     return 0;
 }
@@ -216,7 +244,6 @@ int format_dimension_collected_opentsdb_telnet(struct instance *instance, RRDDIM
 int format_dimension_stored_opentsdb_telnet(struct instance *instance, RRDDIM *rd)
 {
     RRDSET *st = rd->rrdset;
-    RRDHOST *host = st->rrdhost;
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     exporting_name_copy(
@@ -236,16 +263,16 @@ int format_dimension_stored_opentsdb_telnet(struct instance *instance, RRDDIM *r
     if(isnan(value))
         return 0;
 
-    buffer_sprintf(
+    format_opentsdb_telnet_prefix(
         instance->buffer,
-        "put %s.%s.%s %llu " NETDATA_DOUBLE_FORMAT " host=%s%s\n",
         instance->config.prefix,
         chart_name,
         dimension_name,
-        (unsigned long long)last_t,
-        value,
-        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
-        (instance->labels_buffer) ? buffer_tostring(instance->labels_buffer) : "");
+        (unsigned long long)last_t);
+
+    buffer_sprintf(instance->buffer, NETDATA_DOUBLE_FORMAT, value);
+
+    format_opentsdb_telnet_suffix(instance->buffer, buffer_tostring(instance->labels_buffer));
 
     return 0;
 }
@@ -482,6 +509,136 @@ int exporting_opentsdb_http_unittest(void) {
         "host\r\"\\name",
         "{\"metric\":\"pre\\\"\\\\\\u0001.chart\\nname.dimension\\tname\",\"timestamp\":42,"
         "\"value\":1.5,\"tags\":{\"host\":\"host\\r\\\"\\\\name\",\"label\":\"value\"}}");
+
+    return errors;
+}
+
+static int opentsdb_telnet_unittest_case(
+    const char *description,
+    const char *prefix,
+    const char *hostname,
+    const char *labels,
+    const char *expected) {
+    BUFFER *host_and_labels = buffer_create(0, NULL);
+    format_opentsdb_telnet_host(host_and_labels, hostname);
+    buffer_strcat(host_and_labels, labels);
+
+    BUFFER *wb = buffer_create(0, NULL);
+    format_opentsdb_telnet_prefix(wb, prefix, "chart.name", "dimension.name", 42);
+    buffer_strcat(wb, "1.5");
+    format_opentsdb_telnet_suffix(wb, buffer_tostring(host_and_labels));
+
+    int errors = 0;
+    if(strcmp(buffer_tostring(wb), expected) != 0) {
+        fprintf(
+            stderr,
+            "OpenTSDB Telnet %s output mismatch\nexpected: %s\nactual:   %s\n",
+            description,
+            expected,
+            buffer_tostring(wb));
+        errors++;
+    }
+
+    size_t newline_count = 0;
+    for(const char *s = buffer_tostring(wb); *s; s++) {
+        if(*s == '\n')
+            newline_count++;
+        else if(*s == '\r' || *s == '\t') {
+            fprintf(stderr, "OpenTSDB Telnet %s output retained a protocol delimiter\n", description);
+            errors++;
+            break;
+        }
+    }
+
+    if(newline_count != 1 || !buffer_strlen(wb) || wb->buffer[wb->len - 1] != '\n') {
+        fprintf(stderr, "OpenTSDB Telnet %s output is not exactly one newline-terminated command\n", description);
+        errors++;
+    }
+
+    buffer_free(wb);
+    buffer_free(host_and_labels);
+    return errors;
+}
+
+int exporting_opentsdb_telnet_unittest(void) {
+    int errors = 0;
+
+    errors += opentsdb_telnet_unittest_case(
+        "ordinary metadata",
+        "netdata",
+        "localhost",
+        " label=value",
+        "put netdata.chart.name.dimension.name 42 1.5 host=localhost label=value\n");
+
+    errors += opentsdb_telnet_unittest_case(
+        "allowed punctuation",
+        "Netdata-A_9/part.",
+        "Host-A_9/path.example",
+        " label=value",
+        "put Netdata-A_9/part..chart.name.dimension.name 42 1.5 host=Host-A_9/path.example label=value\n");
+
+    errors += opentsdb_telnet_unittest_case(
+        "hostile metadata",
+        "pre fix\tbad\r\nput",
+        "host name\tbad\r\nput",
+        " label=value",
+        "put pre_fix_bad__put.chart.name.dimension.name 42 1.5 host=host_name_bad__put label=value\n");
+
+    errors += opentsdb_telnet_unittest_case(
+        "all-invalid metadata",
+        " \t\r\n",
+        " \t\r\n",
+        " label=value",
+        "put ____.chart.name.dimension.name 42 1.5 host=____ label=value\n");
+
+    errors += opentsdb_telnet_unittest_case(
+        "empty metadata",
+        "",
+        "",
+        "",
+        "put .chart.name.dimension.name 42 1.5 host=\n");
+
+    errors += opentsdb_telnet_unittest_case(
+        "colliding invalid metadata",
+        "pre fix",
+        "host name",
+        "",
+        "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name\n");
+
+    errors += opentsdb_telnet_unittest_case(
+        "colliding valid metadata",
+        "pre_fix",
+        "host_name",
+        "",
+        "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name\n");
+
+    char long_prefix[4097];
+    char long_hostname[4097];
+    memset(long_prefix, 'p', sizeof(long_prefix) - 1);
+    memset(long_hostname, 'h', sizeof(long_hostname) - 1);
+    long_prefix[1024] = '\n';
+    long_hostname[3072] = '\t';
+    long_prefix[sizeof(long_prefix) - 1] = '\0';
+    long_hostname[sizeof(long_hostname) - 1] = '\0';
+
+    BUFFER *host_and_labels = buffer_create(0, NULL);
+    format_opentsdb_telnet_host(host_and_labels, long_hostname);
+
+    BUFFER *wb = buffer_create(0, NULL);
+    format_opentsdb_telnet_prefix(wb, long_prefix, "chart.name", "dimension.name", 42);
+    buffer_strcat(wb, "1.5");
+    format_opentsdb_telnet_suffix(wb, buffer_tostring(host_and_labels));
+
+    const size_t expected_length = strlen("put ") + strlen(long_prefix) + strlen(".chart.name.dimension.name 42 1.5 host=") +
+                                   strlen(long_hostname) + 1;
+    if(buffer_strlen(wb) != expected_length || wb->buffer[sizeof("put ") - 1 + 1024] != '_' ||
+       strchr(buffer_tostring(wb), '\t') || strchr(buffer_tostring(wb), '\r') ||
+       strchr(buffer_tostring(wb), '\n') != &wb->buffer[wb->len - 1]) {
+        fprintf(stderr, "OpenTSDB Telnet long metadata was truncated or retained a protocol delimiter\n");
+        errors++;
+    }
+    buffer_free(wb);
+    buffer_free(host_and_labels);
 
     return errors;
 }

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -345,6 +345,19 @@ int format_host_labels_opentsdb_http(struct instance *instance, RRDHOST *host) {
     if (!instance->labels_buffer)
         instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
+    if (!instance->metric_prefix_buffer)
+        instance->metric_prefix_buffer = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
+    else
+        buffer_flush(instance->metric_prefix_buffer);
+
+    if (host == localhost)
+        buffer_strcat(instance->metric_prefix_buffer, instance->config.hostname);
+    else {
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        buffer_strcat(instance->metric_prefix_buffer, string2str(identity.hostname));
+        rrdhost_identity_release(&identity);
+    }
+
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
 
@@ -379,7 +392,7 @@ static void format_opentsdb_http_suffix(BUFFER *wb, const char *hostname, const 
 
 static bool format_opentsdb_http_metric(
     struct instance *instance,
-    RRDHOST *host,
+    const char *hostname,
     const char *prefix,
     const char *chart_name,
     const char *dimension_name,
@@ -403,7 +416,7 @@ static bool format_opentsdb_http_metric(
 
     format_opentsdb_http_suffix(
         wb,
-        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+        hostname,
         instance->labels_buffer ? buffer_tostring(instance->labels_buffer) : "");
     return true;
 }
@@ -418,7 +431,6 @@ static bool format_opentsdb_http_metric(
 int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *rd)
 {
     RRDSET *st = rd->rrdset;
-    RRDHOST *host = st->rrdhost;
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     exporting_name_copy(
@@ -435,7 +447,7 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
     if(rrddim_is_float(rd))
         format_opentsdb_http_metric(
             instance,
-            host,
+            buffer_tostring(instance->metric_prefix_buffer),
             instance->config.prefix,
             chart_name,
             dimension_name,
@@ -446,7 +458,7 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
     else
         format_opentsdb_http_metric(
             instance,
-            host,
+            buffer_tostring(instance->metric_prefix_buffer),
             instance->config.prefix,
             chart_name,
             dimension_name,
@@ -468,7 +480,6 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
 int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd)
 {
     RRDSET *st = rd->rrdset;
-    RRDHOST *host = st->rrdhost;
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     exporting_name_copy(
@@ -487,7 +498,7 @@ int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd)
 
     format_opentsdb_http_metric(
         instance,
-        host,
+        buffer_tostring(instance->metric_prefix_buffer),
         instance->config.prefix,
         chart_name,
         dimension_name,
@@ -585,7 +596,7 @@ static int opentsdb_number_unittest(void) {
         };
         bool http_record = format_opentsdb_http_metric(
             &http_instance,
-            localhost,
+            "localhost",
             "netdata",
             "chart.name",
             "dimension.name",
@@ -662,13 +673,13 @@ static int opentsdb_number_unittest(void) {
         .buffer = http_batch,
     };
     bool first_record = format_opentsdb_http_metric(
-        &http_instance, localhost, "netdata", "chart", "first", 42, true, 1.5, 0);
+        &http_instance, "localhost", "netdata", "chart", "first", 42, true, 1.5, 0);
     size_t before_omission = buffer_strlen(http_batch);
     bool omitted_record = format_opentsdb_http_metric(
-        &http_instance, localhost, "netdata", "chart", "omitted", 42, true, INFINITY, 0);
+        &http_instance, "localhost", "netdata", "chart", "omitted", 42, true, INFINITY, 0);
     size_t after_omission = buffer_strlen(http_batch);
     bool second_record = format_opentsdb_http_metric(
-        &http_instance, localhost, "netdata", "chart", "second", 42, true, -2.5, 0);
+        &http_instance, "localhost", "netdata", "chart", "second", 42, true, -2.5, 0);
     buffer_strcat(http_batch, "\n]\n");
 
     BUFFER *expected_batch = buffer_create(0, NULL);
@@ -702,7 +713,7 @@ static int opentsdb_number_unittest(void) {
         .buffer = integers,
     };
     bool integer_record = format_opentsdb_http_metric(
-        &integer_instance, localhost, "netdata", "chart", "integer", 42, false, NAN, INT64_MIN);
+        &integer_instance, "localhost", "netdata", "chart", "integer", 42, false, NAN, INT64_MIN);
     BUFFER *expected_integers = buffer_create(0, NULL);
     buffer_strcat(expected_integers, "[\n");
     format_opentsdb_http_prefix(expected_integers, "netdata", "chart", "integer", 42);

--- a/src/exporting/process_data.c
+++ b/src/exporting/process_data.c
@@ -107,16 +107,22 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
 
     if (unlikely(before < first_t || after > last_t)) {
         // the chart has not been updated in the wanted timeframe
-        netdata_log_debug(
-            D_EXPORTING,
-            "EXPORTING: %s.%s.%s: aligned timeframe %lu to %lu is outside the chart's database range %lu to %lu",
-            rrdhost_hostname(host),
-            rrdset_id(st),
-            rrddim_id(rd),
-            (unsigned long)after,
-            (unsigned long)before,
-            (unsigned long)first_t,
-            (unsigned long)last_t);
+#ifdef NETDATA_INTERNAL_CHECKS
+        if(unlikely(debug_flags & D_EXPORTING)) {
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+            netdata_log_debug(
+                D_EXPORTING,
+                "EXPORTING: %s.%s.%s: aligned timeframe %lu to %lu is outside the chart's database range %lu to %lu",
+                string2str(identity.hostname),
+                rrdset_id(st),
+                rrddim_id(rd),
+                (unsigned long)after,
+                (unsigned long)before,
+                (unsigned long)first_t,
+                (unsigned long)last_t);
+            rrdhost_identity_release(&identity);
+        }
+#endif
         return NAN;
     }
 
@@ -142,14 +148,20 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     pulse_queries_exporters_query_completed(points_read);
 
     if (unlikely(!counter)) {
-        netdata_log_debug(
-            D_EXPORTING,
-            "EXPORTING: %s.%s.%s: no values stored in database for range %lu to %lu",
-            rrdhost_hostname(host),
-            rrdset_id(st),
-            rrddim_id(rd),
-            (unsigned long)after,
-            (unsigned long)before);
+#ifdef NETDATA_INTERNAL_CHECKS
+        if(unlikely(debug_flags & D_EXPORTING)) {
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+            netdata_log_debug(
+                D_EXPORTING,
+                "EXPORTING: %s.%s.%s: no values stored in database for range %lu to %lu",
+                string2str(identity.hostname),
+                rrdset_id(st),
+                rrddim_id(rd),
+                (unsigned long)after,
+                (unsigned long)before);
+            rrdhost_identity_release(&identity);
+        }
+#endif
         return NAN;
     }
 

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -47,33 +47,51 @@ inline int can_send_rrdset(struct instance *instance, RRDSET *st, SIMPLE_PATTERN
             rrdset_flag_set(st, RRDSET_FLAG_EXPORTING_SEND);
         } else {
             rrdset_flag_set(st, RRDSET_FLAG_EXPORTING_IGNORE);
-            netdata_log_debug(
-                D_EXPORTING,
-                "EXPORTING: not sending chart '%s' of host '%s', because it is disabled for exporting.",
-                rrdset_id(st),
-                rrdhost_hostname(host));
+#ifdef NETDATA_INTERNAL_CHECKS
+            if(unlikely(debug_flags & D_EXPORTING)) {
+                RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+                netdata_log_debug(
+                    D_EXPORTING,
+                    "EXPORTING: not sending chart '%s' of host '%s', because it is disabled for exporting.",
+                    rrdset_id(st),
+                    string2str(identity.hostname));
+                rrdhost_identity_release(&identity);
+            }
+#endif
             return 0;
         }
     }
 
     if (unlikely(!rrdset_is_available_for_exporting_and_alarms(st))) {
-        netdata_log_debug(
-            D_EXPORTING,
-            "EXPORTING: not sending chart '%s' of host '%s', because it is not available for exporting.",
-            rrdset_id(st),
-            rrdhost_hostname(host));
+#ifdef NETDATA_INTERNAL_CHECKS
+        if(unlikely(debug_flags & D_EXPORTING)) {
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+            netdata_log_debug(
+                D_EXPORTING,
+                "EXPORTING: not sending chart '%s' of host '%s', because it is not available for exporting.",
+                rrdset_id(st),
+                string2str(identity.hostname));
+            rrdhost_identity_release(&identity);
+        }
+#endif
         return 0;
     }
 
     if (unlikely(
             st->rrd_memory_mode == RRD_DB_MODE_NONE &&
             !(EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_AS_COLLECTED))) {
-        netdata_log_debug(
-            D_EXPORTING,
-            "EXPORTING: not sending chart '%s' of host '%s' because its memory mode is '%s' and the exporting connector requires database access.",
-            rrdset_id(st),
-            rrdhost_hostname(host),
-            rrd_memory_mode_name(host->rrd_memory_mode));
+#ifdef NETDATA_INTERNAL_CHECKS
+        if(unlikely(debug_flags & D_EXPORTING)) {
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+            netdata_log_debug(
+                D_EXPORTING,
+                "EXPORTING: not sending chart '%s' of host '%s' because its memory mode is '%s' and the exporting connector requires database access.",
+                rrdset_id(st),
+                string2str(identity.hostname),
+                rrd_memory_mode_name(host->rrd_memory_mode));
+            rrdhost_identity_release(&identity);
+        }
+#endif
         return 0;
     }
 

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -532,7 +532,7 @@ static void generate_as_collected_from_metric(BUFFER *wb,
 
 static void prometheus_print_os_info(
     BUFFER *wb,
-    RRDHOST *host,
+    const char *hostname,
     PROMETHEUS_OUTPUT_OPTIONS output_options)
 {
     FILE *fp;
@@ -550,7 +550,7 @@ static void prometheus_print_os_info(
         return;
     }
 
-    buffer_sprintf(wb, "netdata_os_info{instance=\"%s\"", rrdhost_hostname(host));
+    buffer_sprintf(wb, "netdata_os_info{instance=\"%s\"", hostname);
 
     while (fgets(buf, BUFSIZ, fp)) {
       char *in, *sanitized;
@@ -864,10 +864,11 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
     PROMETHEUS_OUTPUT_OPTIONS output_options,
     PROM_CONTEXT_OPTIONS_JudyLSet *context_options)
 {
+    RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
     SIMPLE_PATTERN *filter = simple_pattern_create(filter_string, NULL, SIMPLE_PATTERN_EXACT, true);
 
     char hostname[PROMETHEUS_ELEMENT_MAX + 1];
-    prometheus_label_copy(hostname, rrdhost_hostname(host), sizeof(hostname));
+    prometheus_label_copy(hostname, string2str(identity.hostname), sizeof(hostname));
 
     format_host_labels_prometheus(instance, host);
 
@@ -875,8 +876,8 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
         wb,
         "netdata_info{instance=\"%s\",application=\"%s\",version=\"%s\"",
         hostname,
-        rrdhost_program_name(host),
-        rrdhost_program_version(host));
+        string2str(identity.prog_name),
+        string2str(identity.prog_version));
 
     if (instance->labels_buffer && *buffer_tostring(instance->labels_buffer)) {
         buffer_sprintf(wb, ",%s", buffer_tostring(instance->labels_buffer));
@@ -896,7 +897,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
         buffer_flush(instance->labels_buffer);
 
     if (instance->config.options & EXPORTING_OPTION_SEND_AUTOMATIC_LABELS)
-        prometheus_print_os_info(wb, host, output_options);
+        prometheus_print_os_info(wb, string2str(identity.hostname), output_options);
 
 
     BUFFER *plabels_buffer = buffer_create(0, NULL);
@@ -924,7 +925,10 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
 
     // for each context
     if (!host->rrdctx.contexts) {
-        netdata_log_error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, rrdhost_hostname(host));
+        netdata_log_error(
+            "%s(): request for host '%s' that does not have rrdcontexts initialized.",
+            __FUNCTION__,
+            string2str(identity.hostname));
         goto allmetrics_cleanup;
     }
 
@@ -934,6 +938,7 @@ allmetrics_cleanup:
     simple_pattern_free(filter);
     buffer_free(plabels_buffer);
     string_freez(opts.prometheus);
+    rrdhost_identity_release(&identity);
 }
 
 /**

--- a/src/exporting/prometheus/remote_write/remote_write.c
+++ b/src/exporting/prometheus/remote_write/remote_write.c
@@ -166,15 +166,24 @@ int format_host_prometheus_remote_write(struct instance *instance, RRDHOST *host
     struct prometheus_remote_write_specific_data *connector_specific_data =
         (struct prometheus_remote_write_specific_data *)simple_connector_data->connector_specific_data;
 
+    if (!instance->metric_prefix_buffer)
+        instance->metric_prefix_buffer = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
+    else
+        buffer_flush(instance->metric_prefix_buffer);
+
+    RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+    const char *output_hostname =
+        (host == localhost) ? instance->config.hostname : string2str(identity.hostname);
+    buffer_strcat(instance->metric_prefix_buffer, output_hostname);
+
     char hostname[PROMETHEUS_ELEMENT_MAX + 1];
-    prometheus_label_copy(
-        hostname,
-        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
-        sizeof(hostname));
+    prometheus_label_copy(hostname, output_hostname, sizeof(hostname));
 
     add_host_info(
         connector_specific_data->write_request,
-        "netdata_info", hostname, rrdhost_program_name(host), rrdhost_program_version(host), now_realtime_usec() / USEC_PER_MS);
+        "netdata_info", hostname, string2str(identity.prog_name), string2str(identity.prog_version),
+        now_realtime_usec() / USEC_PER_MS);
+    rrdhost_identity_release(&identity);
     
     if (unlikely(sending_labels_configured(instance))) {
         struct format_remote_write_label_callback tmp = {
@@ -237,7 +246,6 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
         char name[PROMETHEUS_LABELS_MAX + 1];
         char dimension[PROMETHEUS_ELEMENT_MAX + 1];
         char *suffix = "";
-        RRDHOST *host = rd->rrdset->rrdhost;
 
         if (as_collected) {
             // we need as-collected / raw data
@@ -245,6 +253,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
             if (unlikely(rd->collector.last_collected_time.tv_sec < instance->after)) {
 #ifdef NETDATA_INTERNAL_CHECKS
                 if(unlikely(debug_flags & D_EXPORTING)) {
+                    RRDHOST *host = rd->rrdset->rrdhost;
                     RRDHOST_IDENTITY identity = { 0 };
                     const char *host_name;
 
@@ -287,7 +296,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                 add_metric(
                         connector_specific_data->write_request,
                         name, chart, family, dimension,
-                    (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+                    buffer_tostring(instance->metric_prefix_buffer),
                         rrddim_last_collected_as_double(rd), timeval_msec(&rd->collector.last_collected_time));
             } else {
                 // the dimensions of the chart, do not have the same algorithm, multiplier or divisor
@@ -304,7 +313,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                 add_metric(
                         connector_specific_data->write_request,
                         name, chart, family, NULL,
-                    (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+                    buffer_tostring(instance->metric_prefix_buffer),
                         rrddim_last_collected_as_double(rd), timeval_msec(&rd->collector.last_collected_time));
             }
         } else {
@@ -329,7 +338,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                 add_metric(
                     connector_specific_data->write_request,
                     name, chart, family, dimension,
-                    (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
+                    buffer_tostring(instance->metric_prefix_buffer),
                     value, last_t * MSEC_PER_SEC);
             }
         }
@@ -343,7 +352,6 @@ static int format_variable_prometheus_remote_write_callback(const DICTIONARY_ITE
 
     struct prometheus_remote_write_variables_callback_options *opts = data;
 
-    RRDHOST *host = opts->host;
     struct instance *instance = opts->instance;
     struct simple_connector_data *simple_connector_data =
         (struct simple_connector_data *)instance->connector_specific_data;
@@ -358,7 +366,7 @@ static int format_variable_prometheus_remote_write_callback(const DICTIONARY_ITE
 
     NETDATA_DOUBLE value = rrdvar2number(rv);
     add_variable(connector_specific_data->write_request, name,
-        (host == localhost) ? instance->config.hostname : rrdhost_hostname(host), value, opts->now / USEC_PER_MS);
+        buffer_tostring(instance->metric_prefix_buffer), value, opts->now / USEC_PER_MS);
 
     return 0;
 }
@@ -373,7 +381,6 @@ static int format_variable_prometheus_remote_write_callback(const DICTIONARY_ITE
 int format_variables_prometheus_remote_write(struct instance *instance, RRDHOST *host)
 {
     struct prometheus_remote_write_variables_callback_options opt = {
-        .host = host,
         .instance = instance,
         .now = now_realtime_usec(),
     };

--- a/src/exporting/prometheus/remote_write/remote_write.c
+++ b/src/exporting/prometheus/remote_write/remote_write.c
@@ -243,15 +243,29 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
             // we need as-collected / raw data
 
             if (unlikely(rd->collector.last_collected_time.tv_sec < instance->after)) {
-                netdata_log_debug(
-                    D_EXPORTING,
-                    "EXPORTING: not sending dimension '%s' of chart '%s' from host '%s', "
-                    "its last data collection (%lu) is not within our timeframe (%lu to %lu)",
-                    rrddim_id(rd), rrdset_id(rd->rrdset),
-                    (host == localhost) ? instance->config.hostname : rrdhost_hostname(host),
-                    (unsigned long)rd->collector.last_collected_time.tv_sec,
-                    (unsigned long)instance->after,
-                    (unsigned long)instance->before);
+#ifdef NETDATA_INTERNAL_CHECKS
+                if(unlikely(debug_flags & D_EXPORTING)) {
+                    RRDHOST_IDENTITY identity = { 0 };
+                    const char *host_name;
+
+                    if(host == localhost)
+                        host_name = instance->config.hostname;
+                    else {
+                        identity = rrdhost_identity_acquire(host);
+                        host_name = string2str(identity.hostname);
+                    }
+
+                    netdata_log_debug(
+                        D_EXPORTING,
+                        "EXPORTING: not sending dimension '%s' of chart '%s' from host '%s', "
+                        "its last data collection (%lu) is not within our timeframe (%lu to %lu)",
+                        rrddim_id(rd), rrdset_id(rd->rrdset), host_name,
+                        (unsigned long)rd->collector.last_collected_time.tv_sec,
+                        (unsigned long)instance->after,
+                        (unsigned long)instance->before);
+                    rrdhost_identity_release(&identity);
+                }
+#endif
                 return 0;
             }
 

--- a/src/exporting/prometheus/remote_write/remote_write.h
+++ b/src/exporting/prometheus/remote_write/remote_write.h
@@ -12,7 +12,6 @@ struct prometheus_remote_write_specific_data {
 };
 
 struct prometheus_remote_write_variables_callback_options {
-    RRDHOST *host;
     time_t now;
     struct instance *instance;
 };

--- a/src/libnetdata/buffer/buffer.h
+++ b/src/libnetdata/buffer/buffer.h
@@ -693,6 +693,14 @@ static void buffer_print_netdata_double(BUFFER *wb, NETDATA_DOUBLE value) {
     buffer_overflow_check(wb);
 }
 
+ALWAYS_INLINE
+static void buffer_print_netdata_double_fixed(BUFFER *wb, NETDATA_DOUBLE value) {
+    if(unlikely(!netdata_double_isnumber(value)))
+        buffer_fast_strcat(wb, "null", 4);
+    else
+        buffer_sprintf(wb, NETDATA_DOUBLE_FORMAT, value);
+}
+
 #define DOUBLE_HEX_MAX_LENGTH ((sizeof(IEEE754_DOUBLE_HEX_PREFIX) - 1) + (sizeof(uint64_t) * 2) + 1)
 ALWAYS_INLINE
 static void buffer_print_netdata_double_hex(BUFFER *wb, NETDATA_DOUBLE value) {

--- a/src/web/api/functions/function-topology-streaming.c
+++ b/src/web/api/functions/function-topology-streaming.c
@@ -9,9 +9,10 @@ static bool streaming_topology_host_guid(RRDHOST *host, char *dst, size_t dst_si
 static bool streaming_topology_uuid_guid(ND_UUID host_id, char *dst, size_t dst_size);
 static void streaming_topology_agent_id_for_host(RRDHOST *host, char *dst, size_t dst_size);
 static void streaming_topology_actor_id_from_guid(const char *guid, char *dst, size_t dst_size);
+static void streaming_topology_actor_id_for_host(RRDHOST *host, char *dst, size_t dst_size);
 static void streaming_topology_actor_id_for_uuid(ND_UUID host_id, char *dst, size_t dst_size);
 static uint32_t *streaming_topology_parent_child_count_get(DICTIONARY *parent_child_count, RRDHOST *host);
-static struct streaming_topology_descendant_list *streaming_topology_descendants_get(DICTIONARY *parent_descendants, RRDHOST *host);
+static struct streaming_topology_descendant_list *streaming_topology_descendants_get(DICTIONARY *parent_descendants, const char *host_guid);
 
 enum streaming_topology_received_type {
     STREAMING_TOPOLOGY_RECEIVED_STREAMING = 0,
@@ -20,7 +21,8 @@ enum streaming_topology_received_type {
 };
 
 struct streaming_topology_descendant {
-    RRDHOST *host;
+    char host_machine_guid[UUID_STR_LEN];
+    char actor_id[256];
     ND_UUID source_uuid;
     bool source_local;
     uint8_t type;
@@ -112,10 +114,8 @@ static uint32_t *streaming_topology_parent_child_count_get(DICTIONARY *parent_ch
     return dictionary_get(parent_child_count, host_guid);
 }
 
-static struct streaming_topology_descendant_list *streaming_topology_descendants_get(DICTIONARY *parent_descendants, RRDHOST *host) {
-    char host_guid[UUID_STR_LEN];
-
-    if(!streaming_topology_host_guid(host, host_guid, sizeof(host_guid)))
+static struct streaming_topology_descendant_list *streaming_topology_descendants_get(DICTIONARY *parent_descendants, const char *host_guid) {
+    if(!host_guid || !*host_guid)
         return NULL;
 
     return dictionary_get(parent_descendants, host_guid);
@@ -152,12 +152,15 @@ static void streaming_topology_descendants_append(
         list->size = new_size;
     }
 
-    list->items[list->used++] = (struct streaming_topology_descendant) {
-        .host = host,
-        .source_uuid = source_uuid,
-        .source_local = source_local,
-        .type = (uint8_t)type,
-    };
+    if(!host || !host->machine_guid[0])
+        return;
+
+    struct streaming_topology_descendant *item = &list->items[list->used++];
+    snprintfz(item->host_machine_guid, sizeof(item->host_machine_guid), "%s", host->machine_guid);
+    streaming_topology_actor_id_for_host(host, item->actor_id, sizeof(item->actor_id));
+    item->source_uuid = source_uuid;
+    item->source_local = source_local;
+    item->type = (uint8_t)type;
 }
 
 static const char *streaming_topology_received_type_to_string(enum streaming_topology_received_type type) {
@@ -293,7 +296,7 @@ typedef struct streaming_topology_v1_actor {
     uint64_t health_critical;
     uint64_t health_warning;
     uint64_t health_clear;
-    RRDHOST *host;
+    char host_machine_guid[UUID_STR_LEN];
     bool synthetic;
 } STREAMING_TOPOLOGY_V1_ACTOR;
 
@@ -421,6 +424,11 @@ typedef struct streaming_topology_v1_payload {
     DICTIONARY *emitted_links;
 } STREAMING_TOPOLOGY_V1_PAYLOAD;
 
+struct streaming_topology_v1_acquired_host {
+    RRDHOST_ACQUIRED *acquired;
+    RRDHOST *host;
+};
+
 static void streaming_topology_v1_strncpy(char *dst, size_t dst_size, const char *src) {
     if(!dst || !dst_size)
         return;
@@ -434,6 +442,34 @@ static void streaming_topology_v1_uuid_str(ND_UUID uuid, char *dst, size_t dst_s
 
     if(!streaming_topology_uuid_guid(uuid, dst, dst_size))
         dst[0] = '\0';
+}
+
+static struct streaming_topology_v1_acquired_host streaming_topology_v1_host_acquire(const char *host_machine_guid) {
+    struct streaming_topology_v1_acquired_host ret = { 0 };
+
+    if(!host_machine_guid || !*host_machine_guid)
+        return ret;
+
+    rrd_rdlock();
+
+    ret.acquired = rrdhost_find_and_acquire(host_machine_guid);
+    ret.host = rrdhost_acquired_to_rrdhost(ret.acquired);
+    if(!ret.host) {
+        rrdhost_acquired_release(ret.acquired);
+        rrd_rdunlock();
+        ret.acquired = NULL;
+    }
+
+    return ret;
+}
+
+static void streaming_topology_v1_host_release(struct streaming_topology_v1_acquired_host *host) {
+    if(!host || !host->acquired)
+        return;
+
+    rrdhost_acquired_release(host->acquired);
+    rrd_rdunlock();
+    *host = (struct streaming_topology_v1_acquired_host){ 0 };
 }
 
 static void streaming_topology_v1_actor_index_set(STREAMING_TOPOLOGY_V1_PAYLOAD *payload, const char *actor_id, uint64_t index) {
@@ -563,7 +599,8 @@ static int streaming_topology_v1_collect_host_label(
 static void streaming_topology_v1_collect_actor_labels(
     STREAMING_TOPOLOGY_V1_PAYLOAD *payload,
     uint64_t actor_index,
-    STREAMING_TOPOLOGY_V1_ACTOR *actor) {
+    STREAMING_TOPOLOGY_V1_ACTOR *actor,
+    RRDHOST *host) {
     if(!payload || !actor)
         return;
 
@@ -590,12 +627,12 @@ static void streaming_topology_v1_collect_actor_labels(
     streaming_topology_v1_add_actor_label_uint(payload, actor_index, "health_warning", actor->health_warning, "metric");
     streaming_topology_v1_add_actor_label_uint(payload, actor_index, "health_clear", actor->health_clear, "metric");
 
-    if(actor->host && actor->host->rrdlabels) {
+    if(host && host->rrdlabels) {
         struct streaming_topology_v1_host_label_ctx ctx = {
             .payload = payload,
             .actor = actor_index,
         };
-        rrdlabels_walkthrough_read(actor->host->rrdlabels, streaming_topology_v1_collect_host_label, &ctx);
+        rrdlabels_walkthrough_read(host->rrdlabels, streaming_topology_v1_collect_host_label, &ctx);
     }
 }
 
@@ -890,7 +927,7 @@ static bool streaming_topology_v1_collect_synth_actor(
     streaming_topology_v1_strncpy(actor->stream_status, sizeof(actor->stream_status), "unknown");
     streaming_topology_v1_strncpy(actor->ml_status, sizeof(actor->ml_status), "unknown");
     streaming_topology_v1_strncpy(actor->health_status, sizeof(actor->health_status), "unknown");
-    streaming_topology_v1_collect_actor_labels(ctx->payload, ctx->payload->actors_used - 1, actor);
+    streaming_topology_v1_collect_actor_labels(ctx->payload, ctx->payload->actors_used - 1, actor, NULL);
     return true;
 }
 
@@ -909,7 +946,7 @@ static void streaming_topology_v1_collect_actors(
         RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
 
         STREAMING_TOPOLOGY_V1_ACTOR *actor = streaming_topology_v1_add_actor(payload, actor_id);
-        actor->host = host;
+        streaming_topology_v1_strncpy(actor->host_machine_guid, sizeof(actor->host_machine_guid), host->machine_guid);
         streaming_topology_v1_strncpy(actor->type, sizeof(actor->type),
             streaming_topology_v1_node_type(host, &status, parent_child_count));
         streaming_topology_host_guid(host, actor->machine_guid, sizeof(actor->machine_guid));
@@ -943,7 +980,7 @@ static void streaming_topology_v1_collect_actors(
             actor->health_clear = status.health.alerts.clear;
         }
 
-        streaming_topology_v1_collect_actor_labels(payload, payload->actors_used - 1, actor);
+        streaming_topology_v1_collect_actor_labels(payload, payload->actors_used - 1, actor, host);
         rrdhost_identity_release(&identity);
     }
     dfe_done(host);
@@ -1209,11 +1246,13 @@ static void streaming_topology_v1_collect_actor_detail_rows(
 
     for(size_t i = 0; i < payload->actors_used; i++) {
         STREAMING_TOPOLOGY_V1_ACTOR *actor = &payload->actors[i];
-        if(!actor->host)
+        struct streaming_topology_v1_acquired_host acquired_host =
+            streaming_topology_v1_host_acquire(actor->host_machine_guid);
+        if(!acquired_host.acquired)
             continue;
 
         RRDHOST_STATUS status;
-        rrdhost_status(actor->host, now, &status, RRDHOST_STATUS_ALL);
+        rrdhost_status(acquired_host.host, now, &status, RRDHOST_STATUS_ALL);
 
         size_t path_rows_start = payload->stream_path_used;
         struct streaming_topology_v1_stream_path_ctx sp_ctx = {
@@ -1221,7 +1260,9 @@ static void streaming_topology_v1_collect_actor_detail_rows(
             .actor = i,
             .emitted = false,
         };
-        rrdhost_stream_path_visit(actor->host, 0, streaming_topology_v1_collect_stream_path_row, &sp_ctx);
+        rrdhost_stream_path_visit(acquired_host.host, 0, streaming_topology_v1_collect_stream_path_row, &sp_ctx);
+        streaming_topology_v1_host_release(&acquired_host);
+
         for(size_t pi = path_rows_start; pi < payload->stream_path_used; pi++) {
             STREAMING_TOPOLOGY_V1_STREAM_PATH_ROW *path_row = &payload->stream_path_rows[pi];
             if(!path_row->since_ut)
@@ -1277,25 +1318,31 @@ static void streaming_topology_v1_collect_actor_detail_rows(
 
     for(size_t i = 0; i < payload->actors_used; i++) {
         STREAMING_TOPOLOGY_V1_ACTOR *parent = &payload->actors[i];
-        if(!parent->host || parent->child_count == 0)
+        if(!parent->host_machine_guid[0] || parent->child_count == 0)
             continue;
 
         struct streaming_topology_descendant_list *nodes =
-            streaming_topology_descendants_get(parent_descendants, parent->host);
+            streaming_topology_descendants_get(parent_descendants, parent->machine_guid);
         if(!nodes)
             continue;
 
         for(size_t j = 0; j < nodes->used; j++) {
             struct streaming_topology_descendant *descendant = &nodes->items[j];
-            if(!descendant->host || descendant->host == parent->host)
+            if(!descendant->host_machine_guid[0] || strcmp(descendant->actor_id, parent->actor_id) == 0)
                 continue;
 
             uint64_t child_actor;
-            if(!streaming_topology_v1_actor_index_for_host(payload, descendant->host, &child_actor))
+            if(!streaming_topology_v1_actor_index_get(payload, descendant->actor_id, &child_actor))
+                continue;
+
+            struct streaming_topology_v1_acquired_host acquired_descendant =
+                streaming_topology_v1_host_acquire(descendant->host_machine_guid);
+            if(!acquired_descendant.acquired)
                 continue;
 
             RRDHOST_STATUS status;
-            rrdhost_status(descendant->host, now, &status, RRDHOST_STATUS_ALL);
+            rrdhost_status(acquired_descendant.host, now, &status, RRDHOST_STATUS_ALL);
+            streaming_topology_v1_host_release(&acquired_descendant);
 
             STREAMING_TOPOLOGY_V1_INBOUND_ROW *row = streaming_topology_v1_add_inbound_row(payload);
             row->parent_actor = i;
@@ -1334,12 +1381,18 @@ static void streaming_topology_v1_collect_actor_detail_rows(
 
     for(size_t i = 0; i < payload->actors_used; i++) {
         STREAMING_TOPOLOGY_V1_ACTOR *actor = &payload->actors[i];
-        if(!actor->host)
+        struct streaming_topology_v1_acquired_host acquired_host =
+            streaming_topology_v1_host_acquire(actor->host_machine_guid);
+        if(!acquired_host.acquired)
             continue;
 
-        RRDHOST *path_host = rrdhost_is_virtual(actor->host) ? localhost : actor->host;
+        RRDHOST *path_host = rrdhost_is_virtual(acquired_host.host) ? localhost : acquired_host.host;
         ND_UUID path[128];
         uint16_t path_n = streaming_topology_get_path_ids(path_host, 0, path, 128);
+
+        RRDHOST_STATUS node_status;
+        rrdhost_status(acquired_host.host, now, &node_status, RRDHOST_STATUS_ALL);
+        streaming_topology_v1_host_release(&acquired_host);
 
         uint64_t destination_actor = 0;
         bool has_destination_actor = false;
@@ -1353,9 +1406,6 @@ static void streaming_topology_v1_collect_actor_detail_rows(
 
         if(!has_destination_actor)
             continue;
-
-        RRDHOST_STATUS node_status;
-        rrdhost_status(actor->host, now, &node_status, RRDHOST_STATUS_ALL);
 
         STREAMING_TOPOLOGY_V1_OUTBOUND_ROW *row = streaming_topology_v1_add_outbound_row(payload);
         row->sender_actor = localhost_actor;

--- a/src/web/api/v1/api_v1_allmetrics.c
+++ b/src/web/api/v1/api_v1_allmetrics.c
@@ -127,6 +127,42 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, const char *filter_
 
 // ----------------------------------------------------------------------------
 
+static void allmetrics_json_chart_begin(
+    BUFFER *wb,
+    bool prepend_comma,
+    const char *id,
+    const char *name,
+    const char *family,
+    const char *context,
+    const char *units,
+    int64_t last_updated) {
+    buffer_strcat(wb, prepend_comma ? ",\n\t\"" : "\n\t\"");
+    buffer_json_strcat(wb, id);
+    buffer_strcat(wb, "\": {\n\t\t\"name\":\"");
+    buffer_json_strcat(wb, name);
+    buffer_strcat(wb, "\",\n\t\t\"family\":\"");
+    buffer_json_strcat(wb, family);
+    buffer_strcat(wb, "\",\n\t\t\"context\":\"");
+    buffer_json_strcat(wb, context);
+    buffer_strcat(wb, "\",\n\t\t\"units\":\"");
+    buffer_json_strcat(wb, units);
+    buffer_sprintf(
+        wb,
+        "\",\n"
+        "\t\t\"last_updated\": %" PRId64 ",\n"
+        "\t\t\"dimensions\": {",
+        last_updated);
+}
+
+static void allmetrics_json_dimension_begin(
+    BUFFER *wb, bool prepend_comma, const char *id, const char *name) {
+    buffer_strcat(wb, prepend_comma ? ",\n\t\t\t\"" : "\n\t\t\t\"");
+    buffer_json_strcat(wb, id);
+    buffer_strcat(wb, "\": {\n\t\t\t\t\"name\": \"");
+    buffer_json_strcat(wb, name);
+    buffer_strcat(wb, "\",\n\t\t\t\t\"value\": ");
+}
+
 void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, const char *filter_string, BUFFER *wb) {
     analytics_log_json();
     SIMPLE_PATTERN *filter = simple_pattern_create(filter_string, NULL, SIMPLE_PATTERN_EXACT, true);
@@ -143,17 +179,9 @@ void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, const char *filter_s
             continue;
 
         if(rrdset_is_available_for_viewers(st)) {
-            buffer_sprintf(
+            allmetrics_json_chart_begin(
                 wb,
-                "%s\n"
-                "\t\"%s\": {\n"
-                "\t\t\"name\":\"%s\",\n"
-                "\t\t\"family\":\"%s\",\n"
-                "\t\t\"context\":\"%s\",\n"
-                "\t\t\"units\":\"%s\",\n"
-                "\t\t\"last_updated\": %"PRId64",\n"
-                "\t\t\"dimensions\": {",
-                chart_counter ? "," : "",
+                chart_counter != 0,
                 rrdset_id(st),
                 rrdset_name(st),
                 rrdset_family(st),
@@ -168,13 +196,9 @@ void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, const char *filter_s
             RRDDIM *rd;
             rrddim_foreach_read(rd, st) {
                 if(rd->collector.counter && !rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) {
-                    buffer_sprintf(
+                    allmetrics_json_dimension_begin(
                         wb,
-                        "%s\n"
-                        "\t\t\t\"%s\": {\n"
-                        "\t\t\t\t\"name\": \"%s\",\n"
-                        "\t\t\t\t\"value\": ",
-                        dimension_counter ? "," : "",
+                        dimension_counter != 0,
                         rrddim_id(rd),
                         rrddim_name(rd));
 
@@ -197,6 +221,129 @@ void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, const char *filter_s
 
     buffer_strcat(wb, "\n}");
     simple_pattern_free(filter);
+}
+
+static int allmetrics_json_unittest_case(
+    const char *description,
+    const char *chart_id,
+    const char *chart_name,
+    const char *family,
+    const char *context,
+    const char *units,
+    const char *dimension_id,
+    const char *dimension_name,
+    const char *expected) {
+    int errors = 0;
+    BUFFER *wb = buffer_create(0, NULL);
+
+    buffer_strcat(wb, "{");
+    allmetrics_json_chart_begin(wb, false, chart_id, chart_name, family, context, units, 42);
+    allmetrics_json_dimension_begin(wb, false, dimension_id, dimension_name);
+    buffer_strcat(wb, "1.5\n\t\t\t}\n\t\t}\n\t}\n}");
+
+    if(strcmp(buffer_tostring(wb), expected) != 0) {
+        fprintf(stderr, "allmetrics JSON %s output mismatch\nexpected: %s\nactual:   %s\n",
+                description, expected, buffer_tostring(wb));
+        errors++;
+    }
+
+    json_object *root = json_tokener_parse(buffer_tostring(wb));
+    json_object *chart = NULL, *member = NULL, *dimensions = NULL, *dimension = NULL;
+    if(!root || !json_object_is_type(root, json_type_object) || json_object_object_length(root) != 1 ||
+       !json_object_object_get_ex(root, chart_id, &chart) || !json_object_is_type(chart, json_type_object) ||
+       json_object_object_length(chart) != 6 ||
+       !json_object_object_get_ex(chart, "name", &member) || strcmp(json_object_get_string(member), chart_name) != 0 ||
+       !json_object_object_get_ex(chart, "family", &member) || strcmp(json_object_get_string(member), family) != 0 ||
+       !json_object_object_get_ex(chart, "context", &member) || strcmp(json_object_get_string(member), context) != 0 ||
+       !json_object_object_get_ex(chart, "units", &member) || strcmp(json_object_get_string(member), units) != 0 ||
+       !json_object_object_get_ex(chart, "last_updated", &member) || json_object_get_int64(member) != 42 ||
+       !json_object_object_get_ex(chart, "dimensions", &dimensions) ||
+       !json_object_is_type(dimensions, json_type_object) || json_object_object_length(dimensions) != 1 ||
+       !json_object_object_get_ex(dimensions, dimension_id, &dimension) ||
+       !json_object_is_type(dimension, json_type_object) || json_object_object_length(dimension) != 2 ||
+       !json_object_object_get_ex(dimension, "name", &member) ||
+       strcmp(json_object_get_string(member), dimension_name) != 0 ||
+       !json_object_object_get_ex(dimension, "value", &member) || json_object_get_double(member) != 1.5) {
+        fprintf(stderr, "allmetrics JSON %s schema or value mismatch\n", description);
+        errors++;
+    }
+
+    if(root)
+        json_object_put(root);
+    buffer_free(wb);
+    return errors;
+}
+
+int api_v1_allmetrics_json_unittest(void) {
+    int errors = 0;
+
+    errors += allmetrics_json_unittest_case(
+        "ordinary metadata",
+        "chart.id", "chart.name", "family", "context", "units", "dimension.id", "dimension.name",
+        "{\n"
+        "\t\"chart.id\": {\n"
+        "\t\t\"name\":\"chart.name\",\n"
+        "\t\t\"family\":\"family\",\n"
+        "\t\t\"context\":\"context\",\n"
+        "\t\t\"units\":\"units\",\n"
+        "\t\t\"last_updated\": 42,\n"
+        "\t\t\"dimensions\": {\n"
+        "\t\t\t\"dimension.id\": {\n"
+        "\t\t\t\t\"name\": \"dimension.name\",\n"
+        "\t\t\t\t\"value\": 1.5\n"
+        "\t\t\t}\n"
+        "\t\t}\n"
+        "\t}\n"
+        "}");
+
+    errors += allmetrics_json_unittest_case(
+        "hostile metadata",
+        "chart\"\\\x01 \xCE\xA9", "chart\"name", "family\\name", "context\nname", "units\tname",
+        "dimension\rkey", "dimension\bname \xCE\xA9",
+        "{\n"
+        "\t\"chart\\\"\\\\\\u0001 \xCE\xA9\": {\n"
+        "\t\t\"name\":\"chart\\\"name\",\n"
+        "\t\t\"family\":\"family\\\\name\",\n"
+        "\t\t\"context\":\"context\\nname\",\n"
+        "\t\t\"units\":\"units\\tname\",\n"
+        "\t\t\"last_updated\": 42,\n"
+        "\t\t\"dimensions\": {\n"
+        "\t\t\t\"dimension\\rkey\": {\n"
+        "\t\t\t\t\"name\": \"dimension\\bname \xCE\xA9\",\n"
+        "\t\t\t\t\"value\": 1.5\n"
+        "\t\t\t}\n"
+        "\t\t}\n"
+        "\t}\n"
+        "}");
+
+    BUFFER *wb = buffer_create(0, NULL);
+    allmetrics_json_chart_begin(wb, true, "chart", "name", "family", "context", "units", 42);
+    if(strcmp(
+           buffer_tostring(wb),
+           ",\n\t\"chart\": {\n"
+           "\t\t\"name\":\"name\",\n"
+           "\t\t\"family\":\"family\",\n"
+           "\t\t\"context\":\"context\",\n"
+           "\t\t\"units\":\"units\",\n"
+           "\t\t\"last_updated\": 42,\n"
+           "\t\t\"dimensions\": {") != 0) {
+        fprintf(stderr, "allmetrics JSON subsequent chart prefix mismatch\n");
+        errors++;
+    }
+
+    buffer_flush(wb);
+    allmetrics_json_dimension_begin(wb, true, "dimension", "name");
+    if(strcmp(
+           buffer_tostring(wb),
+           ",\n\t\t\t\"dimension\": {\n"
+           "\t\t\t\t\"name\": \"name\",\n"
+           "\t\t\t\t\"value\": ") != 0) {
+        fprintf(stderr, "allmetrics JSON subsequent dimension prefix mismatch\n");
+        errors++;
+    }
+    buffer_free(wb);
+
+    return errors;
 }
 
 int api_v1_allmetrics(RRDHOST *host, struct web_client *w, char *url) {

--- a/src/web/api/v1/api_v1_allmetrics.c
+++ b/src/web/api/v1/api_v1_allmetrics.c
@@ -163,6 +163,10 @@ static void allmetrics_json_dimension_begin(
     buffer_strcat(wb, "\",\n\t\t\t\t\"value\": ");
 }
 
+static void allmetrics_json_value(BUFFER *wb, NETDATA_DOUBLE value) {
+    buffer_print_netdata_double_fixed(wb, value);
+}
+
 void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, const char *filter_string, BUFFER *wb) {
     analytics_log_json();
     SIMPLE_PATTERN *filter = simple_pattern_create(filter_string, NULL, SIMPLE_PATTERN_EXACT, true);
@@ -202,10 +206,7 @@ void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, const char *filter_s
                         rrddim_id(rd),
                         rrddim_name(rd));
 
-                    if(isnan(rd->collector.last_stored_value))
-                        buffer_strcat(wb, "null");
-                    else
-                        buffer_sprintf(wb, NETDATA_DOUBLE_FORMAT, rd->collector.last_stored_value);
+                    allmetrics_json_value(wb, rd->collector.last_stored_value);
 
                     buffer_strcat(wb, "\n\t\t\t}");
 
@@ -239,7 +240,8 @@ static int allmetrics_json_unittest_case(
     buffer_strcat(wb, "{");
     allmetrics_json_chart_begin(wb, false, chart_id, chart_name, family, context, units, 42);
     allmetrics_json_dimension_begin(wb, false, dimension_id, dimension_name);
-    buffer_strcat(wb, "1.5\n\t\t\t}\n\t\t}\n\t}\n}");
+    allmetrics_json_value(wb, 1.5);
+    buffer_strcat(wb, "\n\t\t\t}\n\t\t}\n\t}\n}");
 
     if(strcmp(buffer_tostring(wb), expected) != 0) {
         fprintf(stderr, "allmetrics JSON %s output mismatch\nexpected: %s\nactual:   %s\n",
@@ -274,6 +276,46 @@ static int allmetrics_json_unittest_case(
     return errors;
 }
 
+static int allmetrics_json_value_unittest_case(
+    const char *description, NETDATA_DOUBLE value, bool expect_null) {
+    int errors = 0;
+    BUFFER *actual = buffer_create(0, NULL);
+    BUFFER *expected = buffer_create(0, NULL);
+    BUFFER *document = buffer_create(0, NULL);
+
+    allmetrics_json_value(actual, value);
+    if(expect_null)
+        buffer_strcat(expected, "null");
+    else
+        buffer_sprintf(expected, NETDATA_DOUBLE_FORMAT, value);
+
+    if(strcmp(buffer_tostring(actual), buffer_tostring(expected)) != 0) {
+        fprintf(
+            stderr,
+            "allmetrics JSON %s numeric output mismatch\nexpected: %s\nactual:   %s\n",
+            description,
+            buffer_tostring(expected),
+            buffer_tostring(actual));
+        errors++;
+    }
+
+    buffer_sprintf(document, "{\"value\":%s}", buffer_tostring(actual));
+    json_object *root = json_tokener_parse(buffer_tostring(document));
+    json_object *member = NULL;
+    if(!root || !json_object_is_type(root, json_type_object) || json_object_object_length(root) != 1 ||
+       !json_object_object_get_ex(root, "value", &member)) {
+        fprintf(stderr, "allmetrics JSON %s numeric output is not valid JSON\n", description);
+        errors++;
+    }
+
+    if(root)
+        json_object_put(root);
+    buffer_free(document);
+    buffer_free(expected);
+    buffer_free(actual);
+    return errors;
+}
+
 int api_v1_allmetrics_json_unittest(void) {
     int errors = 0;
 
@@ -290,7 +332,7 @@ int api_v1_allmetrics_json_unittest(void) {
         "\t\t\"dimensions\": {\n"
         "\t\t\t\"dimension.id\": {\n"
         "\t\t\t\t\"name\": \"dimension.name\",\n"
-        "\t\t\t\t\"value\": 1.5\n"
+        "\t\t\t\t\"value\": 1.5000000\n"
         "\t\t\t}\n"
         "\t\t}\n"
         "\t}\n"
@@ -310,7 +352,7 @@ int api_v1_allmetrics_json_unittest(void) {
         "\t\t\"dimensions\": {\n"
         "\t\t\t\"dimension\\rkey\": {\n"
         "\t\t\t\t\"name\": \"dimension\\bname \xCE\xA9\",\n"
-        "\t\t\t\t\"value\": 1.5\n"
+        "\t\t\t\t\"value\": 1.5000000\n"
         "\t\t\t}\n"
         "\t\t}\n"
         "\t}\n"
@@ -342,6 +384,35 @@ int api_v1_allmetrics_json_unittest(void) {
         errors++;
     }
     buffer_free(wb);
+
+#ifdef NETDATA_WITH_LONG_DOUBLE
+    const NETDATA_DOUBLE minimum_normal = LDBL_MIN;
+    const NETDATA_DOUBLE minimum_subnormal = nextafterl(0.0L, 1.0L);
+#else
+    const NETDATA_DOUBLE minimum_normal = DBL_MIN;
+    const NETDATA_DOUBLE minimum_subnormal = nextafter(0.0, 1.0);
+#endif
+    const struct {
+        const char *description;
+        NETDATA_DOUBLE value;
+        bool expect_null;
+    } number_cases[] = {
+        { "positive zero", 0.0, false },
+        { "negative zero", copysignndd(0.0, -1.0), false },
+        { "maximum finite", NETDATA_DOUBLE_MAX, false },
+        { "minimum finite", -NETDATA_DOUBLE_MAX, false },
+        { "minimum positive normal", minimum_normal, false },
+        { "minimum negative normal", -minimum_normal, false },
+        { "minimum positive subnormal", minimum_subnormal, false },
+        { "minimum negative subnormal", -minimum_subnormal, false },
+        { "NaN", NAN, true },
+        { "positive infinity", INFINITY, true },
+        { "negative infinity", -INFINITY, true },
+    };
+
+    for(size_t i = 0; i < _countof(number_cases); i++)
+        errors += allmetrics_json_value_unittest_case(
+            number_cases[i].description, number_cases[i].value, number_cases[i].expect_null);
 
     return errors;
 }

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -506,13 +506,23 @@ static int web_server_static_file(struct web_client *w, char *filename) {
     if(is_dir && !web_client_flag_check(w, WEB_CLIENT_FLAG_PATH_HAS_TRAILING_SLASH))
         return append_slash_to_url_and_redirect(w);
 
-    // open the file
-    int fd = open(web_filename, O_RDONLY | O_CLOEXEC);
+    // Avoid open-time effects for known special objects; O_NONBLOCK covers FIFO replacement races.
+    int fd = -1;
+    if(!S_ISREG(statbuf.st_mode))
+        errno = EINVAL;
+    else
+        fd = open(web_filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
 
     if(fd != -1 && fstat(fd, &statbuf) != 0) {
         int saved_errno = errno;
         close(fd);
         errno = saved_errno;
+        fd = -1;
+    }
+
+    if(fd != -1 && !S_ISREG(statbuf.st_mode)) {
+        close(fd);
+        errno = EINVAL;
         fd = -1;
     }
 


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened exporters and web API by escaping dynamic JSON, sanitizing Graphite/OpenTSDB outputs, omitting nonfinite values, snapshotting host identity to prevent races, and guarding static file serving. Also stabilized streaming topology by avoiding stale host pointers.

- **Bug Fixes**
  - Escape dynamic JSON in v1 allmetrics, JSON exporters, and OpenTSDB HTTP; emit null for NaN/∞ via `buffer_print_netdata_double_fixed` (schema unchanged).
  - Sanitize Graphite metric paths and OpenTSDB Telnet prefix/host fields; omit nonfinite values in all OpenTSDB paths; initialize Graphite stored timestamp to avoid indeterminate reads.
  - Pin host identity across exporters, allmetrics, filters, Remote Write, and debug logs using `RRDHOST_IDENTITY`; add and free `instance->metric_prefix_buffer` for consistent per-host prefixes and to prevent use-after-free.
  - Web server: reject non-regular static files and open with `O_NONBLOCK` to avoid FIFO/device blocking; preserve normal file behavior.
  - Streaming topology: replace stored host pointers with GUID/actor strings; reacquire live hosts under read locks per detail row and skip missing hosts.

- **Refactors**
  - Factor safe JSON/allmetrics string assembly; add unit test registrations in `main.c`; minor Prometheus Remote Write cleanup and buffer helper additions.

<sup>Written for commit 7b4b31af586cfd3a6ec597beeb4e66e2297969af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

