### PR TITLE
Netdata fixes part 67

### DIFF
--- a/packaging/cmake/Modules/NetdataYAML.cmake
+++ b/packaging/cmake/Modules/NetdataYAML.cmake
@@ -56,7 +56,10 @@ macro(netdata_detect_libyaml)
                 netdata_bundle_libyaml()
                 set(ENABLE_BUNDLED_LIBYAML True PARENT_SCOPE)
                 set(NETDATA_YAML_LDFLAGS yaml)
-                get_target_property(NETDATA_YAML_INCLUDE_DIRS yaml INTERFACE_INCLUDE_DIRECTORIES)
+                get_target_property(NETDATA_YAML_TARGET_INCLUDE_DIRS yaml INTERFACE_INCLUDE_DIRECTORIES)
+                # Pinned libyaml exposes yaml.h first and its generated config.h second.
+                # Prepend only the public headers; the yaml target propagates the full interface.
+                list(GET NETDATA_YAML_TARGET_INCLUDE_DIRS 0 NETDATA_YAML_INCLUDE_DIRS)
                 get_target_property(NETDATA_YAML_CFLAGS_OTHER yaml INTERFACE_COMPILE_DEFINITIONS)
         else()
                 set(NETDATA_YAML_LDFLAGS ${YAML_LDFLAGS})

--- a/src/aclk/aclk_query.c
+++ b/src/aclk/aclk_query.c
@@ -222,5 +222,6 @@ int send_bin_msg(mqtt_wss_client client, aclk_query_t *query)
         query->data.bin_payload.size,
         query->data.bin_payload.topic,
         query->data.bin_payload.msg_name);
+    query->data.bin_payload.payload = NULL;
     return 0;
 }

--- a/src/aclk/aclk_query_queue.c
+++ b/src/aclk/aclk_query_queue.c
@@ -90,6 +90,16 @@ void aclk_query_free(aclk_query_t *query)
             freez(query->data.node_id);
             freez(query->machine_guid);
             break;
+        case ALARM_PROVIDE_CFG:
+        case ALARM_SNAPSHOT:
+        case REGISTER_NODE:
+        case NODE_STATE_UPDATE:
+        case UPDATE_NODE_INFO:
+        case UPDATE_NODE_COLLECTORS:
+        case CTX_SEND_SNAPSHOT:
+        case CTX_SEND_SNAPSHOT_UPD:
+            freez(query->data.bin_payload.payload);
+            break;
         // keep following cases together
         case CTX_STOP_STREAMING:
         case CTX_CHECKPOINT:

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -36,6 +36,7 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
 
     if (unlikely(!topic)) {
         netdata_log_error("Couldn't get topic. Aborting message send.");
+        freez(msg);
         return 0;
     }
 

--- a/src/aclk/aclk_tx_msgs.h
+++ b/src/aclk/aclk_tx_msgs.h
@@ -8,6 +8,7 @@
 #include "schema-wrappers/schema_wrappers.h"
 #include "aclk_util.h"
 
+// Consumes msg on every return path.
 uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname);
 
 void aclk_http_msg_v2_err(mqtt_wss_client client, const char *topic, const char *msg_id, int http_code, int ec, const char* emsg, const char *payload, size_t payload_len);

--- a/src/aclk/https_client.c
+++ b/src/aclk/https_client.c
@@ -275,7 +275,7 @@ static int parse_http_hdr(rbuf_t buf, http_parse_ctx *parse_ctx)
     buf_val[idx_end] = 0;
 
     for (ptr = buf_key; *ptr; ptr++)
-        *ptr = tolower(*ptr);
+        *ptr = tolower((uint8_t)*ptr);
 
     if (process_http_hdr(parse_ctx, buf_key, buf_val))
         return 1;

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -337,7 +337,7 @@ int ws_client_parse_handshake_resp(ws_client *client)
             rbuf_bump_tail(client->buf_read, strlen(WS_HTTP_NEWLINE));
 
             for (int i = 0; hdr->key[i]; i++)
-                hdr->key[i] = tolower(hdr->key[i]);
+                hdr->key[i] = tolower((uint8_t)hdr->key[i]);
 
             if (ws_client_add_http_header(client, hdr))
                 return WS_CLIENT_PROTOCOL_ERROR;

--- a/src/aclk/schema-wrappers/alarm_stream.cc
+++ b/src/aclk/schema-wrappers/alarm_stream.cc
@@ -202,6 +202,11 @@ alarm_snapshot_proto_ptr_t generate_alarm_snapshot_proto(struct alarm_snapshot *
     return msg;
 }
 
+void destroy_alarm_snapshot_proto(alarm_snapshot_proto_ptr_t snapshot)
+{
+    delete (AlarmSnapshot *)snapshot;
+}
+
 void add_alarm_log_entry2snapshot(alarm_snapshot_proto_ptr_t snapshot, struct alarm_log_entry *data)
 {
     AlarmSnapshot *alarm_snapshot = (AlarmSnapshot *)snapshot;
@@ -219,10 +224,10 @@ char *generate_alarm_snapshot_bin(size_t *len, alarm_snapshot_proto_ptr_t snapsh
     char *bin = (char*)mallocz(*len);
     if (!alarm_snapshot->SerializeToArray(bin, *len)) {
         freez(bin);
-        delete alarm_snapshot;
+        destroy_alarm_snapshot_proto(snapshot);
         return NULL;
     }
 
-    delete alarm_snapshot;
+    destroy_alarm_snapshot_proto(snapshot);
     return bin;
 }

--- a/src/aclk/schema-wrappers/alarm_stream.h
+++ b/src/aclk/schema-wrappers/alarm_stream.h
@@ -126,6 +126,7 @@ struct send_alarm_checkpoint parse_send_alarm_checkpoint(const char *data, size_
 char *generate_alarm_checkpoint(size_t *len, struct alarm_checkpoint *data);
 
 alarm_snapshot_proto_ptr_t generate_alarm_snapshot_proto(struct alarm_snapshot *data);
+void destroy_alarm_snapshot_proto(alarm_snapshot_proto_ptr_t snapshot);
 void add_alarm_log_entry2snapshot(alarm_snapshot_proto_ptr_t snapshot, struct alarm_log_entry *data);
 char *generate_alarm_snapshot_bin(size_t *len, alarm_snapshot_proto_ptr_t snapshot);
 

--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -884,7 +884,7 @@ static inline void discovery_find_all_cgroups_v2() {
 
 static int is_digits_only(const char *s) {
     do {
-        if (!isdigit(*s++)) {
+        if (!isdigit((uint8_t)*s++)) {
             return 0;
         }
     } while (*s);

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -704,7 +704,7 @@ int verify_path(const char *path) {
 
     const char *s = path;
     while(*s != '\0') {
-        if (isalnum(*s) || is_valid_path_symbol(*s))
+        if (isalnum((uint8_t)*s) || is_valid_path_symbol(*s))
             s += 1;
         else if (*s == '\\' && is_valid_hex_escape(s))
             s += 4;

--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -107,7 +107,7 @@ static enum cgroups_systemd_setting cgroups_detect_systemd(const char *exec)
                 end = begin = begin + strlen(SYSTEMD_HIERARCHY_STRING);
                 if (!*begin)
                     break;
-                while (isalpha(*end))
+                while (isalpha((uint8_t)*end))
                     end++;
                 *end = 0;
                 for (int i = 0; cgroups_systemd_options[i].name; i++) {

--- a/src/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/src/collectors/debugfs.plugin/debugfs_plugin.c
@@ -101,7 +101,7 @@ static int debugfs_am_i_running_as_root()
 void debugfs2lower(char *name)
 {
     while (*name) {
-        *name = tolower(*name);
+        *name = tolower((uint8_t)*name);
         name++;
     }
 }

--- a/src/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/src/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -330,7 +330,7 @@ static int hardirq_parse_interrupts(char *irq_name, int irq)
         if (unlikely(!words))
             continue;
         const char *id = procfile_lineword(ff, l, 0);
-        if (!isdigit(id[0]))
+        if (!isdigit((uint8_t)id[0]))
             continue;
 
         int cmp = str2i(id);

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
@@ -651,7 +651,7 @@ static void ebpf_link_hostnames(const char *parse)
     char *clean = move;
     while (likely(move)) {
         // Find the first valid value
-        while (isspace(*move))
+        while (isspace((uint8_t)*move))
             move++;
 
         // No valid value found
@@ -1177,7 +1177,7 @@ void ebpf_parse_ips_unsafe(const char *ptr)
 
     while (likely(ptr)) {
         // Move forward until next valid character
-        while (isspace(*ptr))
+        while (isspace((uint8_t)*ptr))
             ptr++;
 
         // No valid value found
@@ -1517,7 +1517,7 @@ void ebpf_parse_ports(const char *ptr)
 
     while (likely(ptr)) {
         // Move forward until next valid character
-        while (isspace(*ptr))
+        while (isspace((uint8_t)*ptr))
             ptr++;
 
         // No valid value found
@@ -1536,10 +1536,10 @@ void ebpf_parse_ports(const char *ptr)
             ptr++;
         }
 
-        if (isdigit(*ptr)) { // Parse port
+        if (isdigit((uint8_t)*ptr)) { // Parse port
             ebpf_parse_port_list(
                 neg ? (void **)&network_viewer_opt.excluded_port : (void **)&network_viewer_opt.included_port, ptr);
-        } else if (isalpha(*ptr)) { // Parse service
+        } else if (isalpha((uint8_t)*ptr)) { // Parse service
             ebpf_parse_service_list(
                 neg ? (void **)&network_viewer_opt.excluded_port : (void **)&network_viewer_opt.included_port, ptr);
         } else if (*ptr == '*') { // All

--- a/src/collectors/log2journal/log2journal-json.c
+++ b/src/collectors/log2journal/log2journal-json.c
@@ -32,7 +32,7 @@ static inline void json_skip_spaces(LOG_JSON_STATE *js) {
     const char *s = json_current_pos(js);
     const char *start = s;
 
-    while(isspace(*s)) s++;
+    while(isspace((uint8_t)*s)) s++;
 
     js->pos += s - start;
 }
@@ -236,7 +236,8 @@ size_t parse_surrogate(const char *s, char *d, size_t *remaining) {
 
     if (s[1] == 'u') {
         // Handle \uXXXX
-        if (!isxdigit(s[2]) || !isxdigit(s[3]) || !isxdigit(s[4]) || !isxdigit(s[5])) {
+        if (!isxdigit((uint8_t)s[2]) || !isxdigit((uint8_t)s[3]) || !isxdigit((uint8_t)s[4]) ||
+            !isxdigit((uint8_t)s[5])) {
             return 0; // Not a valid \uXXXX sequence
         }
 
@@ -248,8 +249,8 @@ size_t parse_surrogate(const char *s, char *d, size_t *remaining) {
 
         if (codepoint >= 0xD800 && codepoint <= 0xDBFF) {
             // Possible start of surrogate pair
-            if (s[6] == '\\' && s[7] == 'u' && isxdigit(s[8]) && isxdigit(s[9]) &&
-                isxdigit(s[10]) && isxdigit(s[11])) {
+            if (s[6] == '\\' && s[7] == 'u' && isxdigit((uint8_t)s[8]) && isxdigit((uint8_t)s[9]) &&
+                isxdigit((uint8_t)s[10]) && isxdigit((uint8_t)s[11])) {
                 // Valid low surrogate
                 unsigned low_surrogate = strtoul(&s[8], NULL, 16);
                 if (low_surrogate < 0xDC00 || low_surrogate > 0xDFFF) {
@@ -266,7 +267,7 @@ size_t parse_surrogate(const char *s, char *d, size_t *remaining) {
     else {
         // Handle \UXXXXXXXX
         for (int i = 2; i < 10; i++) {
-            if (!isxdigit(s[i])) {
+            if (!isxdigit((uint8_t)s[i])) {
                 return 0; // Not a valid \UXXXXXXXX sequence
             }
             hex[i - 2] = s[i];

--- a/src/collectors/log2journal/log2journal-logfmt.c
+++ b/src/collectors/log2journal/log2journal-logfmt.c
@@ -27,7 +27,7 @@ static inline void logfmt_skip_spaces(LOGFMT_STATE *lfs) {
     const char *s = logfmt_current_pos(lfs);
     const char *start = s;
 
-    while(isspace(*s)) s++;
+    while(isspace((uint8_t)*s)) s++;
 
     lfs->pos += s - start;
 }

--- a/src/collectors/log2journal/log2journal-params.c
+++ b/src/collectors/log2journal/log2journal-params.c
@@ -152,7 +152,7 @@ static bool parse_rename(LOG_JOB *jb, const char *param) {
 }
 
 static bool is_symbol(char c) {
-    return !isalpha(c) && !isdigit(c) && !iscntrl(c);
+    return !isalpha((uint8_t)c) && !isdigit((uint8_t)c) && !iscntrl((uint8_t)c);
 }
 
 struct {

--- a/src/collectors/log2journal/log2journal.c
+++ b/src/collectors/log2journal/log2journal.c
@@ -122,13 +122,13 @@ static inline void validate_key(LOG_JOB *jb __maybe_unused, HASHED_KEY *k) {
     for(size_t i = 0; i < k->len ;i++) {
         char c = k->key[i];
 
-        if((c < 'A' || c > 'Z') && !isdigit(c) && c != '_') {
+        if((c < 'A' || c > 'Z') && !isdigit((uint8_t)c) && c != '_') {
             l2j_log("WARNING: key '%s' contains characters that are not allowed by systemd-journal.", k->key);
             break;
         }
     }
 
-    if(isdigit(k->key[0]))
+    if(isdigit((uint8_t)k->key[0]))
         l2j_log("WARNING: key '%s' starts with a digit and may not be accepted by systemd-journal.", k->key);
 
     if(k->key[0] == '_')
@@ -464,11 +464,11 @@ static char *get_next_line(LOG_JOB *jb __maybe_unused, char *buffer, size_t size
     size_t len = strlen(line);
 
     // remove trailing newlines and spaces
-    while(len > 1 && (line[len - 1] == '\n' || isspace(line[len - 1])))
+    while(len > 1 && (line[len - 1] == '\n' || isspace((uint8_t)line[len - 1])))
         line[--len] = '\0';
 
     // skip leading spaces
-    while(isspace(*line)) {
+    while(isspace((uint8_t)*line)) {
         line++;
         len--;
     }

--- a/src/collectors/proc.plugin/plugin_proc.c
+++ b/src/collectors/proc.plugin/plugin_proc.c
@@ -293,7 +293,7 @@ int get_numa_node_count(void)
             if (strncmp(de->d_name, "node", 4) != 0)
                 continue;
 
-            if (!isdigit(de->d_name[4]))
+            if (!isdigit((uint8_t)de->d_name[4]))
                 continue;
 
             numa_node_count++;

--- a/src/collectors/proc.plugin/proc_interrupts.c
+++ b/src/collectors/proc.plugin/proc_interrupts.c
@@ -299,7 +299,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
             irr->total += irr->cpu[c].value;
         }
 
-        if(unlikely(isdigit(irr->id[0]))) {
+        if(unlikely(isdigit((uint8_t)irr->id[0]))) {
             size_t first_name_word = proc_interrupts_name_first_word(ff, l, cpus, words);
             proc_interrupts_build_name(irr->name, ff, l, first_name_word, words, irr->id, idlen);
         }

--- a/src/collectors/proc.plugin/proc_self_mountinfo.c
+++ b/src/collectors/proc.plugin/proc_self_mountinfo.c
@@ -151,7 +151,7 @@ static char *strdupz_decoding_octal(const char *string) {
     while(*s) {
         if(unlikely(*s == '\\')) {
             s++;
-            if(likely(isdigit(*s) && isdigit(s[1]) && isdigit(s[2]))) {
+            if(likely(isdigit((uint8_t)*s) && isdigit((uint8_t)s[1]) && isdigit((uint8_t)s[2]))) {
                 char c = *s++ - '0';
                 c <<= 3;
                 c |= *s++ - '0';

--- a/src/collectors/proc.plugin/proc_stat.c
+++ b/src/collectors/proc.plugin/proc_stat.c
@@ -996,7 +996,7 @@ int do_proc_stat(int update_every, usec_t dt) {
                         for(state = 0; state < cpuidle_charts[core].cpuidle_state_len; state++) {
                             strncpyz(cpuidle_dim_id, cpuidle_charts[core].cpuidle_state[state].name, RRD_ID_LENGTH_MAX);
                             for(int i = 0; cpuidle_dim_id[i]; i++)
-                                cpuidle_dim_id[i] = tolower(cpuidle_dim_id[i]);
+                                cpuidle_dim_id[i] = tolower((uint8_t)cpuidle_dim_id[i]);
                             cpuidle_charts[core].cpuidle_state[state].rd = rrddim_add(cpuidle_charts[core].st, cpuidle_dim_id,
                                                                                       cpuidle_charts[core].cpuidle_state[state].name,
                                                                                       1, 1, RRD_ALGORITHM_PCENT_OVER_DIFF_TOTAL);

--- a/src/collectors/proc.plugin/sys_devices_pci_aer.c
+++ b/src/collectors/proc.plugin/sys_devices_pci_aer.c
@@ -119,7 +119,7 @@ static void find_all_pci_aer(AER_TYPE types) {
 
     struct dirent *de = NULL;
     while((de = readdir(dir))) {
-        if(de->d_type == DT_DIR && de->d_name[0] == 'p' && de->d_name[1] == 'c' && de->d_name[2] == 'i' && isdigit(de->d_name[3]))
+        if(de->d_type == DT_DIR && de->d_name[0] == 'p' && de->d_name[1] == 'c' && de->d_name[2] == 'i' && isdigit((uint8_t)de->d_name[3]))
             recursively_find_pci_aer(types, pci_aer_dirname, de->d_name, 1);
     }
     closedir(dir);

--- a/src/collectors/proc.plugin/sys_devices_system_edac_mc.c
+++ b/src/collectors/proc.plugin/sys_devices_system_edac_mc.c
@@ -52,7 +52,7 @@ static void find_all_mc() {
 
     struct dirent *de = NULL;
     while((de = readdir(dir))) {
-        if(de->d_type == DT_DIR && de->d_name[0] == 'm' && de->d_name[1] == 'c' && isdigit(de->d_name[2])) {
+        if(de->d_type == DT_DIR && de->d_name[0] == 'm' && de->d_name[1] == 'c' && isdigit((uint8_t)de->d_name[2])) {
             struct mc *m = callocz(1, sizeof(struct mc));
             m->name = strdupz(de->d_name);
 
@@ -98,7 +98,7 @@ static void find_all_mc() {
 
             if (de->d_type == DT_DIR &&
                 ((strncmp(de->d_name, "rank", 4) == 0 || strncmp(de->d_name, "dimm", 4) == 0)) &&
-                isdigit(de->d_name[4])) {
+                isdigit((uint8_t)de->d_name[4])) {
 
                 struct edac_dimm *d = callocz(1, sizeof(struct edac_dimm));
                 d->name = strdupz(de->d_name);

--- a/src/collectors/proc.plugin/sys_devices_system_node.c
+++ b/src/collectors/proc.plugin/sys_devices_system_node.c
@@ -44,7 +44,7 @@ static int find_all_nodes() {
         if(strncmp(de->d_name, "node", 4) != 0)
             continue;
 
-        if(!isdigit(de->d_name[4]))
+        if(!isdigit((uint8_t)de->d_name[4]))
             continue;
 
         numa_node_count++;

--- a/src/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -47,7 +47,7 @@ void buffer_json_journal_versions(BUFFER *wb)
 
 static bool journal_sd_id128_parse(const char *in, NsdId128 *ret)
 {
-    while (isspace(*in))
+    while (isspace((uint8_t)*in))
         in++;
 
     char uuid[33];
@@ -400,7 +400,7 @@ static void files_registry_insert_cb(const DICTIONARY_ITEM *item, void *value, v
 
                 if (e) {
                     const char *d = s;
-                    for (; d < e && (isdigit(*d) || *d == '.' || *d == ':'); d++)
+                    for (; d < e && (isdigit((uint8_t)*d) || *d == '.' || *d == ':'); d++)
                         ;
                     if (d == e) {
                         // a valid IP address

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -45,8 +45,17 @@ static struct {
     { SIGXFSZ, "SIGXFSZ", 0, NETDATA_SIGNAL_DEADLY, EXIT_REASON_SIGXFSZ },
 };
 
-static void (*original_handlers[NSIG])(int) = {0};
-static void (*original_sigactions[NSIG])(int, siginfo_t *, void *) = {0};
+typedef void (*SIGNAL_HANDLER)(int);
+typedef void (*SIGNAL_SIGACTION)(int, siginfo_t *, void *);
+
+static SIGNAL_HANDLER original_handlers[NSIG] = {0};
+static SIGNAL_SIGACTION original_sigactions[NSIG] = {0};
+
+// Signal-handler atomics must never fall back to a locking runtime helper.
+_Static_assert(__atomic_always_lock_free(sizeof(original_handlers[0]), original_handlers),
+               "signal handler pointers must be lock-free");
+_Static_assert(__atomic_always_lock_free(sizeof(original_sigactions[0]), original_sigactions),
+               "signal sigaction pointers must be lock-free");
 
 NEVER_INLINE
 void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused) {
@@ -59,7 +68,12 @@ void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused)
         __atomic_fetch_add(&signals_waiting[i].count, 1, __ATOMIC_RELAXED);
 
         if(signals_waiting[i].action == NETDATA_SIGNAL_DEADLY) {
-            bool chained_handler = original_sigactions[signo] || (original_handlers[signo] && original_handlers[signo] != SIG_IGN && original_handlers[signo] != SIG_DFL);
+            SIGNAL_SIGACTION original_sigaction =
+                __atomic_load_n(&original_sigactions[signo], __ATOMIC_ACQUIRE);
+            SIGNAL_HANDLER original_handler =
+                __atomic_load_n(&original_handlers[signo], __ATOMIC_ACQUIRE);
+            bool chained_handler = original_sigaction ||
+                (original_handler && original_handler != SIG_IGN && original_handler != SIG_DFL);
 
             // Update the status file
             SIGNAL_CODE sc = info ? signal_code(signo, info->si_code) : 0;
@@ -105,13 +119,13 @@ void nd_signal_handler(int signo, siginfo_t *info, void *context __maybe_unused)
 
             // Chain to the original handler if it exists
             if(chained_handler) {
-                if (original_sigactions[signo]) {
-                    original_sigactions[signo](signo, info, context);
+                if (original_sigaction) {
+                    original_sigaction(signo, info, context);
                     return; // Original handler should handle the signal
                 }
 
-                if (original_handlers[signo]) {
-                    original_handlers[signo](signo);
+                if (original_handler) {
+                    original_handler(signo);
                     return; // Original handler should handle the signal
                 }
             }
@@ -162,8 +176,10 @@ void nd_cleanup_deadly_signals(void) {
             netdata_log_error("SIGNAL: Failed to cleanup signal handler for: %s", signals_waiting[i].name);
     }
 
-    memset(original_handlers, 0, sizeof(original_handlers));
-    memset(original_sigactions, 0, sizeof(original_sigactions));
+    for(size_t signo = 0; signo < NSIG; signo++) {
+        __atomic_store_n(&original_handlers[signo], (SIGNAL_HANDLER)0, __ATOMIC_RELEASE);
+        __atomic_store_n(&original_sigactions[signo], (SIGNAL_SIGACTION)0, __ATOMIC_RELEASE);
+    }
 }
 
 void nd_initialize_signals(bool chain_existing) {
@@ -190,9 +206,9 @@ void nd_initialize_signals(bool chain_existing) {
             (uintptr_t)old_act.sa_handler != (uintptr_t)nd_signal_handler) {
             // Save the original handlers for chaining
             if (old_act.sa_flags & SA_SIGINFO)
-                original_sigactions[signo] = old_act.sa_sigaction;
+                __atomic_store_n(&original_sigactions[signo], old_act.sa_sigaction, __ATOMIC_RELEASE);
             else
-                original_handlers[signo] = old_act.sa_handler;
+                __atomic_store_n(&original_handlers[signo], old_act.sa_handler, __ATOMIC_RELEASE);
         }
 
         switch (signals_waiting[i].action) {

--- a/src/daemon/status-file-product.c
+++ b/src/daemon/status-file-product.c
@@ -371,7 +371,7 @@ static bool has_ecc_memory(void) {
 
     while ((entry = readdir(dir))) {
         // Look for "mc0", "mc1", etc. directories
-        if (strncmp(entry->d_name, "mc", 2) == 0 && isdigit(entry->d_name[2])) {
+        if (strncmp(entry->d_name, "mc", 2) == 0 && isdigit((uint8_t)entry->d_name[2])) {
             // Check for presence of ECC-related files in this mc directory
             char mc_path[FILENAME_MAX + 1];
             snprintfz(mc_path, FILENAME_MAX, "%s/%s/ce_count", edac_path, entry->d_name);
@@ -418,7 +418,7 @@ static bool has_multiple_cpu_sockets(void) {
 
     while ((entry = readdir(dir))) {
         // Check for cpu directories (cpu0, cpu1, etc.)
-        if (strncmp(entry->d_name, "cpu", 3) == 0 && isdigit(entry->d_name[3])) {
+        if (strncmp(entry->d_name, "cpu", 3) == 0 && isdigit((uint8_t)entry->d_name[3])) {
             char topology_path[FILENAME_MAX + 1];
             char physical_id[64];
 

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -1042,7 +1042,10 @@ static void post_status_file(struct post_status_file_thread_data *d) {
     buffer_json_member_add_uint64(wb, "agent_pid_now", getpid());
     buffer_json_member_add_boolean(wb, "host_memory_critical",
                                    OS_SYSTEM_MEMORY_OK(d->status->memory) && d->status->memory.ram_available_bytes <= d->status->oom_protection);
-    buffer_json_member_add_uint64(wb, "host_memory_free_percent", (uint64_t)round(os_system_memory_available_percent(d->status->memory)));
+    uint64_t host_memory_free_percent;
+    if(!parser_round_number_to_uint64(os_system_memory_available_percent(d->status->memory), &host_memory_free_percent))
+        host_memory_free_percent = UINT64_MAX;
+    buffer_json_member_add_uint64(wb, "host_memory_free_percent", host_memory_free_percent);
     buffer_json_member_add_string(wb, "agent_health", agent_health(d->status));
     daemon_status_file_to_json(wb, d->status);
     buffer_json_finalize(wb);

--- a/src/database/rrdfunctions.c
+++ b/src/database/rrdfunctions.c
@@ -201,7 +201,7 @@ static inline bool is_function_dyncfg(const char *name) {
         return false;
 
     char c = name[sizeof(PLUGINSD_FUNCTION_CONFIG) - 1];
-    if(c == 0 || isspace(c))
+    if(c == 0 || isspace((uint8_t)c))
         return true;
 
     return false;

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -405,10 +405,8 @@ static void aclk_run_query(struct aclk_sync_config_s *config, aclk_query_t *quer
     if (ok_to_send) {
         if (client)
             send_bin_msg(client, query);
-        else {
-            freez(query->data.bin_payload.payload);
+        else
             nd_log_daemon(NDLP_ERR, "No client to send message %u", query->type);
-        }
     }
 
     aclk_query_free(query);

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -1123,6 +1123,9 @@ void send_alert_snapshot_to_cloud(RRDHOST *host __maybe_unused)
         if (cnt == ALARM_EVENTS_PER_CHUNK) {
             if (aclk_online_for_alerts())
                 aclk_send_alarm_snapshot(snapshot_proto);
+            else
+                destroy_alarm_snapshot_proto(snapshot_proto);
+            snapshot_proto = NULL;
             cnt = 0;
             if (alarm_snap.chunk < chunks) {
                 alarm_snap.chunk++;
@@ -1133,6 +1136,8 @@ void send_alert_snapshot_to_cloud(RRDHOST *host __maybe_unused)
     }
     if (cnt)
         aclk_send_alarm_snapshot(snapshot_proto);
+    else
+        destroy_alarm_snapshot_proto(snapshot_proto);
 
     nd_log(
         NDLS_ACCESS,

--- a/src/exporting/process_data.c
+++ b/src/exporting/process_data.c
@@ -19,7 +19,7 @@ size_t exporting_name_copy(char *dst, const char *src, size_t max_len)
     for (n = 0; *src && n < max_len; dst++, src++, n++) {
         char c = *src;
 
-        if (c != '.' && !isalnum(c))
+        if (c != '.' && !isalnum((uint8_t)c))
             *dst = '_';
         else
             *dst = c;

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -241,7 +241,7 @@ inline char *prometheus_units_copy(char *d, const char *s, size_t usable, int sh
     for (n = 1; *s && n < usable; d++, s++, n++) {
         register char c = *s;
 
-        if (!isalnum(c))
+        if (!isalnum((uint8_t)c))
             *d = '_';
         else
             *d = c;

--- a/src/exporting/prometheus/remote_write/remote_write.c
+++ b/src/exporting/prometheus/remote_write/remote_write.c
@@ -54,7 +54,7 @@ int process_prometheus_remote_write_response(BUFFER *buffer, struct instance *in
 
     // do nothing with HTTP responses 200 or 204
 
-    while (!isspace(*s) && len) {
+    while (!isspace((uint8_t)*s) && len) {
         s++;
         len--;
     }

--- a/src/exporting/send_data.c
+++ b/src/exporting/send_data.c
@@ -36,7 +36,7 @@ int exporting_discard_response(BUFFER *buffer, struct instance *instance) {
 
     for(; *s && d < e ;s++) {
         char c = *s;
-        if(unlikely(!isprint(c))) c = ' ';
+        if(unlikely(!isprint((uint8_t)c))) c = ' ';
         *d++ = c;
     }
     *d = '\0';

--- a/src/libnetdata/facets/facets.c
+++ b/src/libnetdata/facets/facets.c
@@ -1772,6 +1772,7 @@ void facets_destroy(FACETS *facets) {
     simple_pattern_free(facets->visible_keys);
     simple_pattern_free(facets->included_keys);
     simple_pattern_free(facets->excluded_keys);
+    simple_pattern_free(facets->query);
 
     while(facets->base) {
         FACET_ROW *r = facets->base;

--- a/src/libnetdata/json/json.c
+++ b/src/libnetdata/json/json.c
@@ -52,6 +52,11 @@ jsmntok_t *json_tokenise(char *js, size_t len, size_t *count)
 
     int ret = jsmn_parse(&parser, js, len, tokens, n);
     while (ret == JSMN_ERROR_NOMEM) {
+        if(unlikely(n > INT_MAX / 2 || (size_t)n > SIZE_MAX / sizeof(*tokens) / 2)) {
+            freez(tokens);
+            return NULL;
+        }
+
         n *= 2;
         jsmntok_t *new = reallocz(tokens, sizeof(jsmntok_t) * n);
         if(!new) {

--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -617,7 +617,7 @@ static inline bool local_sockets_is_path_a_pid(const char *s) {
     if(!s || !*s) return false;
 
     while(*s) {
-        if(!isdigit(*s++))
+        if(!isdigit((uint8_t)*s++))
             return false;
     }
 

--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -576,7 +576,7 @@ static inline void local_sockets_fix_cmdline(char* str) {
 
     // map invalid characters to underscores
     while(*s) {
-        if(*s == '|' || iscntrl(*s)) *s = '_';
+        if(*s == '|' || iscntrl((uint8_t)*s)) *s = '_';
         s++;
     }
 }
@@ -599,7 +599,7 @@ local_sockets_read_proc_inode_link(LS_STATE *ls, const char *filename, uint64_t 
     link_target[len] = '\0';
 
     len = strlen(type);
-    if(strncmp(link_target, type, len) == 0 && link_target[len] == ':' && link_target[len + 1] == '[' && isdigit(link_target[len + 2])) {
+    if(strncmp(link_target, type, len) == 0 && link_target[len] == ':' && link_target[len + 1] == '[' && isdigit((uint8_t)link_target[len + 2])) {
         *inode = strtoull(&link_target[len + 2], NULL, 10);
         // ll_log(ls, "read link of type '%s' '%s' from '%s', inode = %"PRIu64, type, link_target, filename, *inode);
         return true;

--- a/src/libnetdata/parsers/duration-unittest.c
+++ b/src/libnetdata/parsers/duration-unittest.c
@@ -2,6 +2,8 @@
 
 #include "libnetdata/libnetdata.h"
 #include "duration.h"
+#include "entries.h"
+#include "size.h"
 
 typedef struct {
     const char *input;
@@ -459,6 +461,149 @@ static int test_duration_parse_seconds_int_range(void) {
     return failed;
 }
 
+static int test_parser_fixed_width_conversions(void) {
+    int failed = 0;
+
+    struct {
+        const char *input;
+        const char *default_unit;
+        const char *output_unit;
+        bool should_succeed;
+        int64_t expected;
+        const char *description;
+    } duration_tests[] = {
+        { "nan", "ns", "ns", false, 0, "duration NaN fails" },
+        { "inf", "ns", "ns", false, 0, "duration infinity fails" },
+        { "-inf", "ns", "ns", false, 0, "negative duration infinity fails" },
+        { "1e400ns", "ns", "ns", false, 0, "duration exponent overflow fails" },
+        { "1e300y", "ns", "ns", false, 0, "duration unit scaling overflow fails" },
+        { "9223372036854775808ns", "ns", "ns", false, 0, "duration positive limit fails" },
+        { "-9223372036854775808ns", "ns", "ns", false, 0, "duration negative limit fails" },
+        { "0ns-9223372036854775808ns", "ns", "ns", false, 0, "duration final negative limit fails" },
+        { "0ns-9223372036854775808ns1ns", "ns", "ns", true, -INT64_MAX, "duration minimum intermediate cancels" },
+        { "0ns-9223372036854775808ns-1ns", "ns", "ns", false, 0, "duration negative sum overflow fails" },
+        { "9223372036854774784ns1024ns", "ns", "ns", false, 0, "duration positive sum overflow fails" },
+        { "0ns-9223372036854774784ns-1024ns", "ns", "ns", false, 0, "duration summed negative limit fails" },
+        { "9223372036854774784ns", "ns", "ns", true, INT64_C(9223372036854774784), "large duration succeeds" },
+        { "-9223372036854774784ns", "ns", "ns", true, -INT64_C(9223372036854774784), "large negative duration succeeds" },
+        { "9223372036854774784ns ago", "ns", "ns", true, -INT64_C(9223372036854774784), "large duration ago succeeds" },
+        { "9223372036854774784ns-1024ns", "ns", "ns", true, INT64_C(9223372036854773760), "large duration subtraction succeeds" },
+        { "1.5s", "s", "s", true, 2, "duration half rounds away from zero" },
+    };
+
+    for(size_t i = 0; i < sizeof(duration_tests) / sizeof(duration_tests[0]); i++) {
+        int64_t result = INT64_C(0x123456789);
+        bool success = duration_parse(
+            duration_tests[i].input, &result, duration_tests[i].default_unit, duration_tests[i].output_unit);
+
+        if(success != duration_tests[i].should_succeed || result != duration_tests[i].expected) {
+            fprintf(stderr,
+                    "FAILED: %s: success=%d result=%" PRId64 "\n",
+                    duration_tests[i].description, success, result);
+            failed++;
+        }
+    }
+
+    struct {
+        const char *input;
+        const char *default_unit;
+        bool should_succeed;
+        uint64_t expected;
+        const char *description;
+    } size_tests[] = {
+        { "nanB", "B", false, 0, "size NaN fails" },
+        { "infB", "B", false, 0, "size infinity fails" },
+        { "1e400B", "B", false, 0, "size exponent overflow fails" },
+        { "0x1p64B", "B", false, 0, "size hexadecimal exponent overflow fails" },
+        { "18446744073709551616B", "B", false, 0, "size unsigned limit fails" },
+        { "18446744073709560KB", "B", false, 0, "size unit scaling overflow fails" },
+        { "17592186044416", "MiB", false, 0, "size default unit scaling overflow fails" },
+        { "-1B", "B", false, 0, "negative size fails" },
+        { "18446744073709549568B", "B", true, UINT64_C(18446744073709549568), "large size succeeds" },
+        { "1536B", "KiB", true, 2, "size half rounds up" },
+        { "1535B", "KiB", true, 1, "size below half rounds down" },
+    };
+
+    for(size_t i = 0; i < sizeof(size_tests) / sizeof(size_tests[0]); i++) {
+        uint64_t result = UINT64_C(0x123456789);
+        bool success = size_parse(size_tests[i].input, &result, size_tests[i].default_unit);
+
+        if(success != size_tests[i].should_succeed || result != size_tests[i].expected) {
+            fprintf(stderr,
+                    "FAILED: %s: success=%d result=%" PRIu64 "\n",
+                    size_tests[i].description, success, result);
+            failed++;
+        }
+    }
+
+    struct {
+        const char *input;
+        const char *default_unit;
+        bool should_succeed;
+        uint64_t expected;
+        const char *description;
+    } entries_tests[] = {
+        { "nan", "", false, 0, "entries NaN fails" },
+        { "inf", "", false, 0, "entries infinity fails" },
+        { "1e400", "", false, 0, "entries exponent overflow fails" },
+        { "18446744073709551616", "", false, 0, "entries unsigned limit fails" },
+        { "18446744074G", "", false, 0, "entries unit scaling overflow fails" },
+        { "-1", "", false, 0, "negative entries fail" },
+        { "18446744073709549568", "", true, UINT64_C(18446744073709549568), "large entries value succeeds" },
+        { "1.5K", "K", true, 2, "entries half rounds up" },
+    };
+
+    for(size_t i = 0; i < sizeof(entries_tests) / sizeof(entries_tests[0]); i++) {
+        uint64_t result = UINT64_C(0x123456789);
+        bool success = entries_parse(entries_tests[i].input, &result, entries_tests[i].default_unit);
+
+        if(success != entries_tests[i].should_succeed || result != entries_tests[i].expected) {
+            fprintf(stderr,
+                    "FAILED: %s: success=%d result=%" PRIu64 "\n",
+                    entries_tests[i].description, success, result);
+            failed++;
+        }
+    }
+
+    int64_t signed_result;
+    uint64_t unsigned_result;
+    const NETDATA_DOUBLE signed_limit = (NETDATA_DOUBLE)(UINT64_C(1) << 63);
+    const NETDATA_DOUBLE unsigned_limit = signed_limit * 2.0;
+
+    if(parser_round_number_to_int64(NAN, &signed_result) ||
+       parser_round_number_to_int64(INFINITY, &signed_result) ||
+       parser_round_number_to_int64(signed_limit, &signed_result) ||
+       !parser_round_number_to_int64(-signed_limit, &signed_result) || signed_result != INT64_MIN ||
+       !parser_round_number_to_int64(1.5, &signed_result) || signed_result != 2 ||
+       !parser_round_number_to_int64(-1.5, &signed_result) || signed_result != -2) {
+        fprintf(stderr, "FAILED: checked signed conversion boundaries or rounding\n");
+        failed++;
+    }
+
+    if(parser_round_number_to_uint64(NAN, &unsigned_result) ||
+       parser_round_number_to_uint64(INFINITY, &unsigned_result) ||
+       parser_round_number_to_uint64(-1.0, &unsigned_result) ||
+       parser_round_number_to_uint64(unsigned_limit, &unsigned_result) ||
+       !parser_round_number_to_uint64(1.5, &unsigned_result) || unsigned_result != 2 ||
+       !parser_round_number_to_uint64(-0.0, &unsigned_result) || unsigned_result != 0) {
+        fprintf(stderr, "FAILED: checked unsigned conversion boundaries or rounding\n");
+        failed++;
+    }
+
+    NETDATA_DOUBLE uint64_max_as_number = (NETDATA_DOUBLE)UINT64_MAX;
+    if(uint64_max_as_number < unsigned_limit) {
+        if(!parser_round_number_to_uint64(uint64_max_as_number, &unsigned_result) ||
+           unsigned_result != UINT64_MAX ||
+           !size_parse("18446744073709551615B", &unsigned_result, "B") || unsigned_result != UINT64_MAX ||
+           !entries_parse("18446744073709551615", &unsigned_result, "") || unsigned_result != UINT64_MAX) {
+            fprintf(stderr, "FAILED: representable uint64 maximum conversion\n");
+            failed++;
+        }
+    }
+
+    return failed;
+}
+
 int duration_unittest(void) {
     int passed = 0;
     int failed = 0;
@@ -498,6 +643,14 @@ int duration_unittest(void) {
         printf("All int range tests passed\n");
     } else {
         failed += range_failed;
+    }
+
+    printf("\nRunning fixed-width parser conversion tests...\n");
+    int conversion_failed = test_parser_fixed_width_conversions();
+    if(conversion_failed == 0) {
+        printf("All fixed-width parser conversion tests passed\n");
+    } else {
+        failed += conversion_failed;
     }
 
     printf("\n===============================================================\n");

--- a/src/libnetdata/parsers/duration.c
+++ b/src/libnetdata/parsers/duration.c
@@ -253,8 +253,21 @@ bool duration_parse(const char *duration, int64_t *result, const char *default_u
             }
         }
 
-        v += (int64_t)round(value * (NETDATA_DOUBLE)du->multiplier);
+        int64_t nanoseconds;
+        if(!parser_round_number_to_int64(value * (NETDATA_DOUBLE)du->multiplier, &nanoseconds) ||
+           (nanoseconds > 0 && v > INT64_MAX - nanoseconds) ||
+           (nanoseconds < 0 && v < INT64_MIN - nanoseconds)) {
+            *result = 0;
+            return false;
+        }
+
+        v += nanoseconds;
         parsed_any_duration = true;
+    }
+
+    if(v == INT64_MIN) {
+        *result = 0;
+        return false;
     }
 
     v *= sign;

--- a/src/libnetdata/parsers/entries.c
+++ b/src/libnetdata/parsers/entries.c
@@ -111,7 +111,12 @@ bool entries_parse(const char *entries_str, uint64_t *result, const char *defaul
         }
     }
 
-    uint64_t bytes = (uint64_t)round(value * (NETDATA_DOUBLE)su->multiplier);
+    uint64_t bytes;
+    if(!parser_round_number_to_uint64(value * (NETDATA_DOUBLE)su->multiplier, &bytes)) {
+        *result = 0;
+        return false;
+    }
+
     *result = entries_round_to_resolution_int(bytes, su_def->multiplier);
 
     return true;

--- a/src/libnetdata/parsers/parsers.h
+++ b/src/libnetdata/parsers/parsers.h
@@ -4,6 +4,29 @@
 #define NETDATA_PARSERS_H
 
 #include "../libnetdata.h"
+
+static inline bool parser_round_number_to_int64(NETDATA_DOUBLE value, int64_t *result) {
+    value = roundndd(value);
+    const NETDATA_DOUBLE limit = (NETDATA_DOUBLE)(UINT64_C(1) << 63);
+
+    if(!netdata_double_isnumber(value) || value < -limit || value >= limit)
+        return false;
+
+    *result = (int64_t)value;
+    return true;
+}
+
+static inline bool parser_round_number_to_uint64(NETDATA_DOUBLE value, uint64_t *result) {
+    value = roundndd(value);
+    const NETDATA_DOUBLE limit = (NETDATA_DOUBLE)(UINT64_C(1) << 63) * 2.0;
+
+    if(!netdata_double_isnumber(value) || value < 0.0 || value >= limit)
+        return false;
+
+    *result = (uint64_t)value;
+    return true;
+}
+
 #include "size.h"
 #include "entries.h"
 #include "duration.h"

--- a/src/libnetdata/parsers/size.c
+++ b/src/libnetdata/parsers/size.c
@@ -139,7 +139,12 @@ bool size_parse(const char *size_str, uint64_t *result, const char *default_unit
         }
     }
 
-    uint64_t bytes = (uint64_t)round(value * (NETDATA_DOUBLE)su->multiplier);
+    uint64_t bytes;
+    if(!parser_round_number_to_uint64(value * (NETDATA_DOUBLE)su->multiplier, &bytes)) {
+        *result = 0;
+        return false;
+    }
+
     *result = size_round_to_resolution_int(bytes, su_def->multiplier);
 
     return true;

--- a/src/libnetdata/simple_hashtable/simple_hashtable.h
+++ b/src/libnetdata/simple_hashtable/simple_hashtable.h
@@ -270,7 +270,7 @@ static inline void simple_hashtable_replace_value_sorted_named(SIMPLE_HASHTABLE_
 
 static inline void simple_hashtable_init_named(SIMPLE_HASHTABLE_NAMED *ht, size_t size) {
     memset(ht, 0, sizeof(*ht));
-    ht->size = size;
+    ht->size = size ? size : 1;
     ht->hashtable = callocz(ht->size, sizeof(*ht->hashtable));
 }
 

--- a/src/libnetdata/simple_pattern/simple_pattern.c
+++ b/src/libnetdata/simple_pattern/simple_pattern.c
@@ -323,12 +323,15 @@ SIMPLE_PATTERN_RESULT simple_pattern_matches_length_extract(SIMPLE_PATTERN *list
 }
 
 static inline void free_pattern(struct simple_pattern *m) {
-    if(!m) return;
+    while(m) {
+        struct simple_pattern *next = m->next;
 
-    free_pattern(m->child);
-    free_pattern(m->next);
-    freez((void *)m->match);
-    freez(m);
+        free_pattern(m->child);
+        freez((void *)m->match);
+        freez(m);
+
+        m = next;
+    }
 }
 
 void simple_pattern_free(SIMPLE_PATTERN *list) {

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -24,8 +24,8 @@ extern char **environ;
 #endif
 
 static size_t spawn_server_id = 0;
-static volatile bool spawn_server_exit = false;
-static volatile bool spawn_server_sigchld = false;
+static volatile sig_atomic_t spawn_server_exit = false;
+static volatile sig_atomic_t spawn_server_sigchld = false;
 static SPAWN_REQUEST *spawn_server_requests = NULL;
 
 #define SPAWN_SERVER_IOV_MAX 10

--- a/src/libnetdata/statistical/statistical.c
+++ b/src/libnetdata/statistical/statistical.c
@@ -159,8 +159,12 @@ inline void sort_series(NETDATA_DOUBLE *series, size_t entries) {
 }
 
 inline NETDATA_DOUBLE *copy_series(const NETDATA_DOUBLE *series, size_t entries) {
-    NETDATA_DOUBLE *copy = mallocz(sizeof(NETDATA_DOUBLE) * entries);
-    memcpy(copy, series, sizeof(NETDATA_DOUBLE) * entries);
+    if(unlikely(entries > SIZE_MAX / sizeof(*series)))
+        fatal("copy_series() cannot copy %zu entries.", entries);
+
+    size_t size = sizeof(*series) * entries;
+    NETDATA_DOUBLE *copy = mallocz(size);
+    memcpy(copy, series, size);
     return copy;
 }
 

--- a/src/libnetdata/uuid/uuid.c
+++ b/src/libnetdata/uuid/uuid.c
@@ -6,11 +6,8 @@ ND_UUID UUID_generate_from_hash(const void *payload, size_t payload_len) {
     assert(sizeof(XXH128_hash_t) == sizeof(ND_UUID));
 
     ND_UUID uuid = UUID_ZERO;
-    XXH128_hash_t *xxh3_128 = (XXH128_hash_t *)&uuid;
-
-    // Hash the payload using XXH128
-    // Assume xxh128_hash_function is your function to generate XXH128 hash
-    *xxh3_128 = XXH3_128bits(payload, payload_len);
+    XXH128_hash_t xxh3_128 = XXH3_128bits(payload, payload_len);
+    memcpy(uuid.uuid, &xxh3_128, sizeof(xxh3_128));
 
     // Set the UUID version (here, setting it to 4)
     uuid.uuid[6] = (uuid.uuid[6] & 0x0F) | 0x40; // Version 4

--- a/src/libnetdata/yaml/yaml-unittest.c
+++ b/src/libnetdata/yaml/yaml-unittest.c
@@ -303,6 +303,61 @@ cleanup:
     return failed;
 }
 
+static int test_yaml_mapping_keys(void) {
+    int failed = 0;
+    BUFFER *error = buffer_create(0, NULL);
+
+    const char *embedded_nul =
+        "valid:\n"
+        "  - retained\n"
+        "  - nested:\n"
+        "      \"bad\\0key\":\n"
+        "        child: ignored\n";
+    struct json_object *json = yaml_parse_string(embedded_nul, error, YAML2JSON_ALL_VALUES_AS_STRINGS);
+    if (json || !strstr(buffer_tostring(error), "embedded NUL")) {
+        fprintf(stderr, "FAILED: test_yaml_mapping_keys: embedded NUL key was not rejected: %s\n",
+                buffer_tostring(error));
+        failed++;
+    }
+    if (json)
+        json_object_put(json);
+
+    buffer_flush(error);
+    const char *valid_keys =
+        "anchor: &key alias-key\n"
+        "*key: alias-value\n"
+        "\"\": empty-value\n"
+        "\"a\\x01b\": control-value\n"
+        "duplicate: first\n"
+        "duplicate: second\n";
+    json = yaml_parse_string(valid_keys, error, YAML2JSON_DEFAULT);
+    const char control_key[] = {'a', '\x01', 'b', '\0'};
+    struct json_object *value = NULL;
+    if (!json ||
+        json_object_object_length(json) != 5 ||
+        !json_object_object_get_ex(json, "alias-key", &value) ||
+        !json_object_is_type(value, json_type_string) ||
+        strcmp(json_object_get_string(value), "alias-value") != 0 ||
+        !json_object_object_get_ex(json, "", &value) ||
+        !json_object_is_type(value, json_type_string) ||
+        strcmp(json_object_get_string(value), "empty-value") != 0 ||
+        !json_object_object_get_ex(json, control_key, &value) ||
+        !json_object_is_type(value, json_type_string) ||
+        strcmp(json_object_get_string(value), "control-value") != 0 ||
+        !json_object_object_get_ex(json, "duplicate", &value) ||
+        !json_object_is_type(value, json_type_string) ||
+        strcmp(json_object_get_string(value), "second") != 0) {
+        fprintf(stderr, "FAILED: test_yaml_mapping_keys: representable key behavior changed: %s\n",
+                buffer_tostring(error));
+        failed++;
+    }
+    if (json)
+        json_object_put(json);
+
+    buffer_free(error);
+    return failed;
+}
+
 static int test_yaml_generation(void) {
     int failed = 0;
     
@@ -647,6 +702,7 @@ int yaml_unittest(void) {
         {"test_yaml_parse_strings", test_yaml_parse_strings},
         {"test_yaml_parse_arrays", test_yaml_parse_arrays},
         {"test_yaml_parse_objects", test_yaml_parse_objects},
+        {"test_yaml_mapping_keys", test_yaml_mapping_keys},
         {"test_yaml_generation", test_yaml_generation},
         {"test_yaml_parse_errors", test_yaml_parse_errors},
         {"test_yaml_file_operations", test_yaml_file_operations},

--- a/src/libnetdata/yaml/yaml.c
+++ b/src/libnetdata/yaml/yaml.c
@@ -84,6 +84,12 @@ static struct json_object *yaml_mapping_to_json(yaml_document_t *document, yaml_
             return NULL;
         }
 
+        if (unlikely(memchr(key_node->data.scalar.value, '\0', key_node->data.scalar.length))) {
+            buffer_strcat(error, "YAML mapping key contains an embedded NUL byte");
+            json_object_put(object);
+            return NULL;
+        }
+
         const char *key = (const char *)key_node->data.scalar.value;
         size_t error_len = buffer_strlen(error);
         struct json_object *value_obj = yaml_node_to_json(document, value_node, error, flags, depth);

--- a/src/libnetdata/yaml/yaml.c
+++ b/src/libnetdata/yaml/yaml.c
@@ -148,19 +148,26 @@ static bool parse_number_with_underscores(const char *str, size_t len, long long
     return false;
 }
 
-static struct json_object *yaml_scalar_to_json(yaml_node_t *node, YAML2JSON_FLAGS flags) {
+static struct json_object *yaml_scalar_to_json(yaml_node_t *node, BUFFER *error, YAML2JSON_FLAGS flags) {
     const char *value = (const char *)node->data.scalar.value;
     size_t length = node->data.scalar.length;
 
+    if (unlikely(length >= INT_MAX)) {
+        buffer_sprintf(error, "YAML scalar is too long (max %d bytes)", INT_MAX - 1);
+        return NULL;
+    }
+
+    int json_length = (int)length;
+
     // If YAML2JSON_ALL_VALUES_AS_STRINGS flag is set, always return as string
     if (flags & YAML2JSON_ALL_VALUES_AS_STRINGS) {
-        return json_object_new_string_len(value, (int)length);
+        return json_object_new_string_len(value, json_length);
     }
 
     // Only plain scalars get implicit type conversion (null/bool/number).
     // Quoted, literal block (|), and folded block (>) scalars are always strings.
     if (node->data.scalar.style != YAML_PLAIN_SCALAR_STYLE) {
-        return json_object_new_string_len(value, (int)length);
+        return json_object_new_string_len(value, json_length);
     }
 
     // Handle null and tilde (case-insensitive for null)
@@ -255,7 +262,7 @@ static struct json_object *yaml_scalar_to_json(yaml_node_t *node, YAML2JSON_FLAG
     }
 
     // Default to string
-    return json_object_new_string_len(value, (int)length);
+    return json_object_new_string_len(value, json_length);
 }
 
 static struct json_object *yaml_node_to_json(yaml_document_t *document, yaml_node_t *node, BUFFER *error, YAML2JSON_FLAGS flags, int depth) {
@@ -271,7 +278,7 @@ static struct json_object *yaml_node_to_json(yaml_document_t *document, yaml_nod
 
     switch (node->type) {
         case YAML_SCALAR_NODE:
-            return yaml_scalar_to_json(node, flags);
+            return yaml_scalar_to_json(node, error, flags);
 
         case YAML_SEQUENCE_NODE:
             return yaml_sequence_to_json(document, node, error, flags, depth + 1);

--- a/src/libnetdata/yaml/yaml.c
+++ b/src/libnetdata/yaml/yaml.c
@@ -473,10 +473,16 @@ static int yaml_add_object_to_document(yaml_document_t *document, struct json_ob
 
     json_object_object_foreach(object, key, value) {
         size_t key_len = strlen(key);
+        if (unlikely(key_len >= INT_MAX)) {
+            buffer_sprintf(error, "JSON object key is too long for YAML generation (max %d bytes)", INT_MAX - 1);
+            return 0;
+        }
+
+        int yaml_key_len = (int)key_len;
         yaml_scalar_style_t key_style = yaml_string_scalar_style(key, key_len);
         int key_node = yaml_document_add_scalar(document, NULL,
                                                (yaml_char_t *)key,
-                                               key_len,
+                                               yaml_key_len,
                                                key_style);
         if (!key_node) {
             buffer_sprintf(error, "Failed to add key '%s' to YAML document", key);
@@ -568,11 +574,17 @@ static int yaml_add_json_to_document(yaml_document_t *document, struct json_obje
         case json_type_string: {
             const char *str = json_object_get_string(json);
             size_t len = json_object_get_string_len(json);
+            if (unlikely(len >= INT_MAX)) {
+                buffer_sprintf(error, "JSON string is too long for YAML generation (max %d bytes)", INT_MAX - 1);
+                return 0;
+            }
+
+            int yaml_len = (int)len;
             yaml_scalar_style_t style = yaml_string_scalar_style(str, len);
 
             return yaml_document_add_scalar(document, NULL,
                                           (yaml_char_t *)str,
-                                          len,
+                                          yaml_len,
                                           style);
         }
 

--- a/src/libnetdata/yaml/yaml.c
+++ b/src/libnetdata/yaml/yaml.c
@@ -148,6 +148,13 @@ static bool parse_number_with_underscores(const char *str, size_t len, long long
     return false;
 }
 
+static inline struct json_object *yaml_scalar_json_or_error(struct json_object *json, BUFFER *error) {
+    if (unlikely(!json))
+        buffer_strcat(error, "Failed to create JSON scalar");
+
+    return json;
+}
+
 static struct json_object *yaml_scalar_to_json(yaml_node_t *node, BUFFER *error, YAML2JSON_FLAGS flags) {
     const char *value = (const char *)node->data.scalar.value;
     size_t length = node->data.scalar.length;
@@ -161,13 +168,13 @@ static struct json_object *yaml_scalar_to_json(yaml_node_t *node, BUFFER *error,
 
     // If YAML2JSON_ALL_VALUES_AS_STRINGS flag is set, always return as string
     if (flags & YAML2JSON_ALL_VALUES_AS_STRINGS) {
-        return json_object_new_string_len(value, json_length);
+        return yaml_scalar_json_or_error(json_object_new_string_len(value, json_length), error);
     }
 
     // Only plain scalars get implicit type conversion (null/bool/number).
     // Quoted, literal block (|), and folded block (>) scalars are always strings.
     if (node->data.scalar.style != YAML_PLAIN_SCALAR_STYLE) {
-        return json_object_new_string_len(value, json_length);
+        return yaml_scalar_json_or_error(json_object_new_string_len(value, json_length), error);
     }
 
     // Handle null and tilde (case-insensitive for null)
@@ -181,13 +188,13 @@ static struct json_object *yaml_scalar_to_json(yaml_node_t *node, BUFFER *error,
     if ((length == 4 && strcasecmp(value, "true") == 0) ||
         (length == 3 && strcasecmp(value, "yes") == 0) ||
         (length == 2 && strcasecmp(value, "on") == 0)) {
-        return json_object_new_boolean(1);
+        return yaml_scalar_json_or_error(json_object_new_boolean(1), error);
     }
 
     if ((length == 5 && strcasecmp(value, "false") == 0) ||
         (length == 2 && strcasecmp(value, "no") == 0) ||
         (length == 3 && strcasecmp(value, "off") == 0)) {
-        return json_object_new_boolean(0);
+        return yaml_scalar_json_or_error(json_object_new_boolean(0), error);
     }
 
     // Try to parse as number
@@ -215,12 +222,12 @@ static struct json_object *yaml_scalar_to_json(yaml_node_t *node, BUFFER *error,
                 if (cleaned_len > 2) {
                     long long int_val = strtoll(cleaned + 2, &endptr, base);
                     if (errno == 0 && *endptr == '\0')
-                        return json_object_new_int64(int_val);
+                        return yaml_scalar_json_or_error(json_object_new_int64(int_val), error);
                 }
             } else {
                 long long int_val = strtoll(value + 2, &endptr, base);
                 if (errno == 0 && endptr == value + length)
-                    return json_object_new_int64(int_val);
+                    return yaml_scalar_json_or_error(json_object_new_int64(int_val), error);
             }
         }
     }
@@ -241,9 +248,9 @@ static struct json_object *yaml_scalar_to_json(yaml_node_t *node, BUFFER *error,
         
         if (parse_number_with_underscores(value, length, &int_result, &double_result, &is_double)) {
             if (is_double) {
-                return json_object_new_double(double_result);
+                return yaml_scalar_json_or_error(json_object_new_double(double_result), error);
             } else {
-                return json_object_new_int64(int_result);
+                return yaml_scalar_json_or_error(json_object_new_int64(int_result), error);
             }
         }
     }
@@ -251,18 +258,18 @@ static struct json_object *yaml_scalar_to_json(yaml_node_t *node, BUFFER *error,
     // Try integer
     long long int_val = strtoll(value, &endptr, 10);
     if (errno == 0 && endptr == value + length && *value != '\0') {
-        return json_object_new_int64(int_val);
+        return yaml_scalar_json_or_error(json_object_new_int64(int_val), error);
     }
 
     // Try double
     errno = 0;
     double double_val = strtod(value, &endptr);
     if (errno == 0 && endptr == value + length && *value != '\0') {
-        return json_object_new_double(double_val);
+        return yaml_scalar_json_or_error(json_object_new_double(double_val), error);
     }
 
     // Default to string
-    return json_object_new_string_len(value, json_length);
+    return yaml_scalar_json_or_error(json_object_new_string_len(value, json_length), error);
 }
 
 static struct json_object *yaml_node_to_json(yaml_document_t *document, yaml_node_t *node, BUFFER *error, YAML2JSON_FLAGS flags, int depth) {

--- a/src/web/api/http_header.c
+++ b/src/web/api/http_header.c
@@ -266,9 +266,9 @@ static void http_header_sec_websocket_extensions(struct web_client *w, const cha
         while (token) {
             // Trim leading/trailing spaces
             char *ext = token;
-            while (*ext && isspace(*ext)) ext++;
+            while (*ext && isspace((uint8_t)*ext)) ext++;
             char *end = ext + strlen(ext) - 1;
-            while (end > ext && isspace(*end)) *end-- = '\0';
+            while (end > ext && isspace((uint8_t)*end)) *end-- = '\0';
 
             // Check if this is permessage-deflate extension
             if (strncmp(ext, "permessage-deflate", 18) == 0) {
@@ -284,9 +284,9 @@ static void http_header_sec_websocket_extensions(struct web_client *w, const cha
 
                     while (param) {
                         // Trim leading/trailing spaces
-                        while (*param && isspace(*param)) param++;
+                        while (*param && isspace((uint8_t)*param)) param++;
                         end = param + strlen(param) - 1;
-                        while (end > param && isspace(*end)) *end-- = '\0';
+                        while (end > param && isspace((uint8_t)*end)) *end-- = '\0';
 
                         // Client no context takeover
                         if (strcmp(param, "client_no_context_takeover") == 0)

--- a/src/web/api/queries/query-cardinality-limit.c
+++ b/src/web/api/queries/query-cardinality-limit.c
@@ -2,9 +2,15 @@
 
 #include "query-internal.h"
 
+typedef struct {
+    size_t dim_idx;
+    NETDATA_DOUBLE contribution;
+    const char *id;
+} CARDINALITY_DIMENSION;
+
 static int compare_contributions(const void *a, const void *b) {
-    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; const char *id; } *da = a;
-    const struct { size_t dim_idx; NETDATA_DOUBLE contribution; const char *id; } *db = b;
+    const CARDINALITY_DIMENSION *da = a;
+    const CARDINALITY_DIMENSION *db = b;
 
     if (da->contribution > db->contribution) return -1;
     if (da->contribution < db->contribution) return 1;
@@ -79,11 +85,7 @@ RRDR *rrd2rrdr_cardinality_limit(RRDR *r) {
     }
 
     // Create array of dimension indices sorted by contribution (descending)
-    struct {
-        size_t dim_idx;
-        NETDATA_DOUBLE contribution;
-        const char *id;
-    } *sorted_dims = onewayalloc_mallocz(
+    CARDINALITY_DIMENSION *sorted_dims = onewayalloc_mallocz(
         owa, onewayalloc_mul_or_fatal(queried_count, sizeof(*sorted_dims), "RRDR cardinality dimensions"));
 
     size_t sorted_idx = 0;

--- a/src/web/api/queries/query-window.c
+++ b/src/web/api/queries/query-window.c
@@ -23,7 +23,7 @@
 bool query_target_calculate_window(QUERY_TARGET *qt) {
     if (unlikely(!qt)) return false;
 
-    size_t points_requested = (long)qt->request.points;
+    size_t points_requested = qt->request.points;
     time_t after_requested = qt->request.after;
     time_t before_requested = qt->request.before;
     RRDR_TIME_GROUPING group_method = qt->request.time_group_method;

--- a/src/web/mcp/adapters/mcp-websocket.c
+++ b/src/web/mcp/adapters/mcp-websocket.c
@@ -111,12 +111,12 @@ void mcp_websocket_on_message(struct websocket_server_client *wsc, const char *m
     }
 
     if (json_object_is_type(request, json_type_array)) {
-        int len = (int)json_object_array_length(request);
+        size_t len = json_object_array_length(request);
         BUFFER **responses = NULL;
         size_t responses_used = 0;
         size_t responses_size = 0;
 
-        for (int i = 0; i < len; i++) {
+        for (size_t i = 0; i < len; i++) {
             struct json_object *req_item = json_object_array_get_idx(request, i);
             BUFFER *resp_item = mcp_jsonrpc_process_single_request(mcpc, req_item, NULL);
             if (resp_item) {

--- a/src/web/rtc/webrtc.c
+++ b/src/web/rtc/webrtc.c
@@ -174,11 +174,11 @@ static void webrtc_config_ice_servers(void) {
     strcpy(tmp, servers);
     char *s = tmp, *e;
     while(*s) {
-        if(isspace(*s))
+        if(isspace((uint8_t)*s))
             s++;
 
         e = s;
-        while(*e && !isspace(*e))
+        while(*e && !isspace((uint8_t)*e))
             e++;
 
         if(s != e && webrtc_base.iceServersCount < WEBRTC_MAX_ICE_SERVERS) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens memory safety and parser robustness across ACLK, YAML/JSON, fixed-width number parsers, signals, Web APIs, exporters, and directory parsers, and isolates bundled `libyaml` headers. Fixes leaks, undefined behaviors, ctype byte‑domain misuse, and width/overflow issues without changing public behavior.

- **Bug Fixes**
  - ACLK: fix alarm snapshot ownership; add snapshot destructor; clear consumed payloads; always free rejected/missing-topic messages; extend query-free to all binary payload types.
  - Signals: publish and clear chained handlers with lock-free atomics; use `sig_atomic_t` for `spawn_server` flags.
  - Parsers: add checked rounding for int64/uint64; guard duration accumulation; make `size`/`entries`/`duration` reject NaN/Inf/overflow; add focused tests; saturate derived memory percentages instead of undefined casts.
  - YAML/JSON: reject embedded‑NUL mapping keys; bound scalar lengths for `json-c`; propagate scalar constructor failures; bound JSON→YAML key/string lengths; add key‑behavior tests.
  - JSON (no‑`json-c` fallback): bound `jsmn` token growth to prevent signed/size overflow.
  - Patterns/facets: free `facets->query`; make sibling cleanup iterative to avoid stack blowups.
  - UUID: replace strict‑aliasing punning with `memcpy`.
  - Queries: keep `size_t` width in window calc; use `size_t` for WebSocket batch length; unify cardinality sort element type and add deterministic tie‑break by dimension id; expose folded count and ranking cut; mark aggregates partial when folding empties with values.
  - Hashtable: normalize zero‑capacity init to one slot.
  - Statistical: reject overflowing series copies in `copy_series()`.
  - ctype domains: cast bytes to `uint8_t` at `is*()` boundaries across directory scans, config parsers, eBPF/IP/port parsing, WebRTC ICE, local‑sockets PID checks, journal parsing, and exporter name/unit sanitizers.

- **Dependencies**
  - Build: in `NetdataYAML.cmake`, prepend only pinned public `libyaml` headers so Netdata’s `config.h` wins; keep full target interface via the `yaml` link.

<sup>Written for commit c47ea84f93d1c64c8c710d3689eb195e42babb83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

