### PR TITLE
Netdata fixes part 68

### DIFF
--- a/src/daemon/protected-access.c
+++ b/src/daemon/protected-access.c
@@ -104,8 +104,8 @@ void signal_protected_access_check(int sig, siginfo_t *si, void *context __maybe
             frame->fault_address = fault_addr;
             frame->signal_code = signal_code(sig, si->si_code);
 
-            // Update the depth to unwind all nested frames up to this one
-            state->depth = i;
+            // Unwind nested frames while keeping this frame for diagnostics and cleanup.
+            state->depth = i + 1;
 
             // Jump back to the sigsetjmp point in PROTECTED_ACCESS_START
             // The '1' becomes the non-zero return value of sigsetjmp.

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1658,7 +1658,8 @@ bool journalfile_migrate_to_v2_callback(Word_t section, unsigned datafile_fileno
         return false;
     }
 
-    struct journal_metric_list_to_sort *uuid_list = NULL;
+    // Recovery cleanup reads this after siglongjmp(), including after allocation.
+    struct journal_metric_list_to_sort * volatile uuid_list = NULL;
 
     PROTECTED_ACCESS_SETUP(data_start, total_file_size, path, "migrate");
     if(no_signal_received) {

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -64,14 +64,27 @@ void journalfile_v1_generate_path(struct rrdengine_datafile *datafile, char *str
 
 // ----------------------------------------------------------------------------
 
+static ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire_internal(
+    struct rrdengine_journalfile *journalfile, size_t *data_size,
+    time_t wanted_first_time_s, time_t wanted_last_time_s,
+    JOURNALFILE_V2_ACCESS_HINT hint, bool cleanup_on_failure);
+static bool journalfile_v2_data_needs_permanent_unmap(struct rrdengine_journalfile *journalfile);
+static bool journalfile_v2_data_unmap_permanently_if_indexed(struct rrdengine_journalfile *journalfile);
+
 ALWAYS_INLINE struct rrdengine_datafile *njfv2idx_find_and_acquire_j2_header(NJFV2IDX_FIND_STATE *s) {
     if (unlikely(!s)) return NULL;
 
     struct rrdengine_datafile *datafile = NULL;
+    struct rrdengine_datafile *cleanup_datafile = NULL;
+    Pvoid_t *PValue = NULL;
+
+restart:
+    datafile = NULL;
+    cleanup_datafile = NULL;
+    PValue = NULL;
+    s->j2_header_acquired = NULL;
 
     rw_spinlock_read_lock(&s->ctx->njfv2idx.spinlock);
-
-    Pvoid_t *PValue = NULL;
 
     if(unlikely(!s->init)) {
         s->init = true;
@@ -128,11 +141,18 @@ ALWAYS_INLINE struct rrdengine_datafile *njfv2idx_find_and_acquire_j2_header(NJF
                                                       s->wanted_end_time_s);
 
         if(rc == PAGE_IS_IN_RANGE) {
-            s->j2_header_acquired = journalfile_v2_data_acquire(journalfile, NULL,
-                                                                s->wanted_start_time_s,
-                                                                s->wanted_end_time_s);
+            // This scan holds the index read lock, so write-side cleanup must be deferred.
+            s->j2_header_acquired = journalfile_v2_data_acquire_internal(
+                journalfile, NULL, s->wanted_start_time_s, s->wanted_end_time_s,
+                JOURNALFILE_V2_ACCESS_AUTO, false);
             if(s->j2_header_acquired) {
                 // this is good to return
+                break;
+            }
+
+            if(journalfile_v2_data_needs_permanent_unmap(journalfile)) {
+                cleanup_datafile = datafile;
+                datafile = NULL;
                 break;
             }
 
@@ -161,6 +181,12 @@ ALWAYS_INLINE struct rrdengine_datafile *njfv2idx_find_and_acquire_j2_header(NJF
         s->j2_header_acquired = NULL;
 
     rw_spinlock_read_unlock(&s->ctx->njfv2idx.spinlock);
+
+    if(cleanup_datafile) {
+        journalfile_v2_data_unmap_permanently_if_indexed(cleanup_datafile->journalfile);
+        datafile_release(cleanup_datafile, DATAFILE_ACQUIRE_PAGE_DETAILS);
+        goto restart;
+    }
 
     return datafile;
 }
@@ -203,11 +229,16 @@ static void njfv2idx_add(struct rrdengine_datafile *datafile) {
     rw_spinlock_write_unlock(&ctx->njfv2idx.spinlock);
 }
 
-static void njfv2idx_remove(struct rrdengine_datafile *datafile) {
-    internal_fatal(!datafile->journalfile->njfv2idx.indexed_as, "DBENGINE: NJFV2IDX journalfile to remove is not indexed");
-
+static bool njfv2idx_remove_internal(struct rrdengine_datafile *datafile, bool required) {
     struct rrdengine_instance *ctx = datafile_ctx(datafile);
     rw_spinlock_write_lock(&ctx->njfv2idx.spinlock);
+
+    if(!datafile->journalfile->njfv2idx.indexed_as) {
+        if(required)
+            internal_fatal(true, "DBENGINE: NJFV2IDX journalfile to remove is not indexed");
+        rw_spinlock_write_unlock(&ctx->njfv2idx.spinlock);
+        return false;
+    }
 
     int rc = JudyLDel(&ctx->njfv2idx.JudyL, datafile->journalfile->njfv2idx.indexed_as, PJE0);
     (void)rc;
@@ -216,6 +247,15 @@ static void njfv2idx_remove(struct rrdengine_datafile *datafile) {
     datafile->journalfile->njfv2idx.indexed_as = 0;
 
     rw_spinlock_write_unlock(&ctx->njfv2idx.spinlock);
+    return true;
+}
+
+static void njfv2idx_remove(struct rrdengine_datafile *datafile) {
+    (void)njfv2idx_remove_internal(datafile, true);
+}
+
+static bool njfv2idx_remove_if_indexed(struct rrdengine_datafile *datafile) {
+    return njfv2idx_remove_internal(datafile, false);
 }
 
 // ----------------------------------------------------------------------------
@@ -356,8 +396,39 @@ void journalfile_v2_data_unmount_cleanup(time_t now_s) {
     }
 }
 
-ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire_with_hint(struct rrdengine_journalfile *journalfile,
-    size_t *data_size, time_t wanted_first_time_s, time_t wanted_last_time_s, JOURNALFILE_V2_ACCESS_HINT hint)
+static bool journalfile_v2_data_release_failed_acquire(struct rrdengine_journalfile *journalfile) {
+    bool needs_permanent_unmap = false;
+
+    spinlock_tracked_lock(&journalfile->data_spinlock);
+
+    internal_fatal(journalfile->v2.refcount < 1, "trying to release a non-acquired journalfile");
+
+    if(likely(journalfile->v2.refcount > 0)) {
+        journalfile->v2.refcount--;
+
+        if(!journalfile->v2.refcount) {
+            journalfile->v2.not_needed_since_s = 0;
+            needs_permanent_unmap = !(journalfile->v2.flags & JOURNALFILE_FLAG_IS_AVAILABLE);
+        }
+    }
+
+    spinlock_tracked_unlock(&journalfile->data_spinlock);
+
+    return needs_permanent_unmap;
+}
+
+static bool journalfile_v2_data_needs_permanent_unmap(struct rrdengine_journalfile *journalfile) {
+    spinlock_tracked_lock(&journalfile->data_spinlock);
+    bool needs_permanent_unmap = !journalfile->v2.refcount &&
+        !(journalfile->v2.flags & JOURNALFILE_FLAG_IS_AVAILABLE);
+    spinlock_tracked_unlock(&journalfile->data_spinlock);
+
+    return needs_permanent_unmap;
+}
+
+static ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire_internal(struct rrdengine_journalfile *journalfile,
+    size_t *data_size, time_t wanted_first_time_s, time_t wanted_last_time_s,
+    JOURNALFILE_V2_ACCESS_HINT hint, bool cleanup_on_failure)
 {
     spinlock_tracked_lock(&journalfile->data_spinlock);
 
@@ -399,10 +470,22 @@ ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire_with_hint(st
     }
     spinlock_tracked_unlock(&journalfile->data_spinlock);
 
-    if(do_we_need_it)
-        return journalfile_v2_mounted_data_get(journalfile, data_size);
+    if(do_we_need_it) {
+        struct journal_v2_header *j2_header = journalfile_v2_mounted_data_get(journalfile, data_size);
+        if(unlikely(!j2_header) && journalfile_v2_data_release_failed_acquire(journalfile) && cleanup_on_failure)
+            journalfile_v2_data_unmap_permanently_if_indexed(journalfile);
+
+        return j2_header;
+    }
 
     return NULL;
+}
+
+ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire_with_hint(struct rrdengine_journalfile *journalfile,
+    size_t *data_size, time_t wanted_first_time_s, time_t wanted_last_time_s, JOURNALFILE_V2_ACCESS_HINT hint)
+{
+    return journalfile_v2_data_acquire_internal(
+        journalfile, data_size, wanted_first_time_s, wanted_last_time_s, hint, true);
 }
 
 ALWAYS_INLINE struct journal_v2_header *journalfile_v2_data_acquire(struct rrdengine_journalfile *journalfile, size_t *data_size, time_t wanted_first_time_s, time_t wanted_last_time_s) {
@@ -480,9 +563,7 @@ void journalfile_v2_data_set(struct rrdengine_journalfile *journalfile, int fd, 
     njfv2idx_add(journalfile->datafile);
 }
 
-static void journalfile_v2_data_unmap_permanently(struct rrdengine_journalfile *journalfile) {
-    njfv2idx_remove(journalfile->datafile);
-
+static void journalfile_v2_data_clear_unmapped_state(struct rrdengine_journalfile *journalfile) {
     bool has_references = false;
     char path_v2[RRDENG_PATH_MAX];
 
@@ -515,6 +596,19 @@ static void journalfile_v2_data_unmap_permanently(struct rrdengine_journalfile *
         spinlock_tracked_unlock(&journalfile->data_spinlock);
 
     } while(has_references);
+}
+
+static void journalfile_v2_data_unmap_permanently(struct rrdengine_journalfile *journalfile) {
+    njfv2idx_remove(journalfile->datafile);
+    journalfile_v2_data_clear_unmapped_state(journalfile);
+}
+
+static bool journalfile_v2_data_unmap_permanently_if_indexed(struct rrdengine_journalfile *journalfile) {
+    if(!njfv2idx_remove_if_indexed(journalfile->datafile))
+        return false;
+
+    journalfile_v2_data_clear_unmapped_state(journalfile);
+    return true;
 }
 
 struct rrdengine_journalfile *journalfile_alloc_and_init(struct rrdengine_datafile *datafile)
@@ -1227,7 +1321,7 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
     journalfile_v2_data_release(journalfile);
 
     if (unlikely(failed)) {
-        journalfile_v2_data_unmap_permanently(journalfile);
+        journalfile_v2_data_unmap_permanently_if_indexed(journalfile);
         return;
     }
 

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -471,7 +471,7 @@ void journalfile_v2_data_set(struct rrdengine_journalfile *journalfile, int fd, 
     struct journal_v2_header *j2_header = journalfile->mmap.data;
     journalfile->v2.first_time_s = (time_t)(j2_header->start_time_ut / USEC_PER_SEC);
     journalfile->v2.last_time_s = (time_t)(j2_header->end_time_ut / USEC_PER_SEC);
-    journalfile->v2.size_of_directory = j2_header->metric_offset + j2_header->metric_count * sizeof(struct journal_metric_list);
+    journalfile->v2.size_of_directory = MIN(j2_header->metric_trailer_offset, journalfile->mmap.size);
 
     journalfile_v2_mounted_data_unmount(journalfile, true, true);
 

--- a/src/database/engine/mrg-internals.h
+++ b/src/database/engine/mrg-internals.h
@@ -63,6 +63,8 @@ struct mrg {
     } __attribute__((aligned(64))) index[UUIDMAP_PARTITIONS];
 };
 
+_Static_assert(_Alignof(MRG) == 64, "MRG must remain cache-line aligned");
+
 static inline void MRG_STATS_DUPLICATE_ADD(MRG *mrg, size_t partition) {
     __atomic_add_fetch(&mrg->index[partition].stats.additions_duplicate, 1, __ATOMIC_RELAXED);
 }

--- a/src/database/engine/mrg-unittest.c
+++ b/src/database/engine/mrg-unittest.c
@@ -8,6 +8,16 @@ static struct rrdengine_instance test_ctx_0 = {0};
 static struct rrdengine_instance test_ctx_1 = {0};
 static struct rrdengine_instance test_ctx_tier[4] = { 0 }; // For stress test tiers
 
+static int mrg_allocation_alignment_unittest(MRG *mrg) {
+    if((uintptr_t)mrg % _Alignof(MRG) == 0)
+        return 0;
+
+    fprintf(stderr,
+            "DBENGINE METRIC: MRG allocation is not aligned to %zu bytes\n",
+            (size_t)_Alignof(MRG));
+    return 1;
+}
+
 struct mrg_stress_entry {
     nd_uuid_t uuid;
     time_t after;
@@ -187,6 +197,7 @@ static int mrg_destroy_referenced_metric_unittest(void) {
     int errors = 0;
 
     MRG *mrg = mrg_create_for_unittest();
+    errors += mrg_allocation_alignment_unittest(mrg);
     nd_uuid_t uuid;
     uuid_generate(uuid);
 
@@ -361,6 +372,7 @@ int mrg_unittest(void) {
 
     // Use mrg_create_for_unittest to avoid pre-loaded metrics that block deletion
     MRG *mrg = mrg_create_for_unittest();
+    errors += mrg_allocation_alignment_unittest(mrg);
 
 #ifndef NETDATA_INTERNAL_CHECKS
     errors += mrg_metrics_delete_underflow_unittest(mrg);

--- a/src/database/engine/mrg.c
+++ b/src/database/engine/mrg.c
@@ -47,7 +47,9 @@ static bool mrg_destroy_claim_metric(METRIC *metric, METRIC ***claimed, size_t *
 }
 
 static MRG *mrg_create_internal(bool load_from_db) {
-    MRG *mrg = callocz(1, sizeof(MRG));
+    MRG *mrg;
+    (void)posix_memalignz((void **)&mrg, _Alignof(MRG), sizeof(*mrg));
+    memset(mrg, 0, sizeof(*mrg));
 
     for(size_t i = 0; i < _countof(mrg->index) ; i++) {
         rw_spinlock_init(&mrg->index[i].rw_spinlock);
@@ -170,7 +172,7 @@ size_t mrg_destroy(MRG *mrg) {
     pulse_aral_unregister_statistics(&mrg_aral_statistics);
 
     // Free the MRG structure
-    freez(mrg);
+    posix_memalign_freez(mrg);
 
     return referenced;
 }

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -499,7 +499,8 @@ static NOT_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_inst
     time_t wanted_start_time_s = (time_t)(start_time_ut / USEC_PER_SEC);
     time_t wanted_end_time_s = (time_t)(end_time_ut / USEC_PER_SEC);
 
-    size_t pages_found = 0;
+    // Recovery may return a partial result after a later mmap access faults.
+    volatile size_t pages_found = 0;
 
     NJFV2IDX_FIND_STATE state = {
             .init = false,
@@ -563,9 +564,10 @@ static NOT_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_inst
                 goto release_journal;
             }
 
-            struct journal_page_list *page_list =
-                (struct journal_page_list *)((uint8_t *)page_list_header + sizeof(*page_list_header));
-            struct journal_extent_list *extent_list = (void *)((uint8_t *)j2_header + j2_header->extent_offset);
+            const volatile struct journal_page_list *page_list =
+                (const volatile struct journal_page_list *)((uint8_t *)page_list_header + sizeof(*page_list_header));
+            const volatile struct journal_extent_list *extent_list =
+                (const volatile struct journal_extent_list *)((uint8_t *)j2_header + j2_header->extent_offset);
             uint32_t extent_entries = j2_header->extent_count;
             uint32_t uuid_page_entries = page_list_header->entries;
             size_t page_list_size;
@@ -580,7 +582,7 @@ static NOT_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_inst
             }
 
             for (uint32_t index = 0; index < uuid_page_entries; index++) {
-                struct journal_page_list *page_entry_in_journal = &page_list[index];
+                const volatile struct journal_page_list *page_entry_in_journal = &page_list[index];
 
                 time_t page_first_time_s = page_entry_in_journal->delta_start_s + journal_start_time_s;
                 time_t page_last_time_s = page_entry_in_journal->delta_end_s + journal_start_time_s;
@@ -595,7 +597,8 @@ static NOT_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_inst
                     break;
 
                 // Make sure index is valid for this file
-                if (page_entry_in_journal->extent_index >= extent_entries) {
+                uint32_t extent_index = page_entry_in_journal->extent_index;
+                if (extent_index >= extent_entries) {
                     nd_log_limit_static_thread_var(erl, 60, 0);
                     nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
                                  "DBENGINE: Invalid extent index in journalfile %u",
@@ -604,15 +607,16 @@ static NOT_INLINE_HOT size_t get_page_list_from_journal_v2(struct rrdengine_inst
                 }
 
                 uint32_t page_update_every_s = page_entry_in_journal->update_every_s;
+                struct extent_io_data ei = {
+                    .block = OFFSET_TO_BLOCK(extent_list[extent_index].datafile_offset),
+                    .bytes = extent_list[extent_index].datafile_size,
+                    .fileno = datafile->fileno,
+                };
 
                 if (datafile_acquire(datafile, DATAFILE_ACQUIRE_OPEN_CACHE)) {
                     //for open cache item
                     // add this page to open cache
                     bool added = false;
-                    struct extent_io_data ei = {0};
-                    ei.block = OFFSET_TO_BLOCK(extent_list[page_entry_in_journal->extent_index].datafile_offset);
-                    ei.bytes = extent_list[page_entry_in_journal->extent_index].datafile_size;
-                    ei.fileno = datafile->fileno;
 
                     PGC_ENTRY e = {0};
                     e.hot = false;

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1240,7 +1240,7 @@ static time_t find_uuid_first_time(
     struct uuid_first_time_s *uuid_first_entry_list,
     size_t count)
 {
-    time_t global_first_time_s = LONG_MAX;
+    volatile time_t global_first_time_s = LONG_MAX;
 
     // acquire the datafile to work with it
     netdata_rwlock_rdlock(&ctx->datafiles.rwlock);
@@ -1253,8 +1253,8 @@ static time_t find_uuid_first_time(
         return global_first_time_s;
 
     unsigned journalfile_count = 0;
-    size_t binary_match = 0;
-    size_t not_matching_bsearches = 0;
+    volatile size_t binary_match = 0;
+    volatile size_t not_matching_bsearches = 0;
 
     bool agent_shutdown = false;
     while (datafile) {

--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -318,6 +318,39 @@ bool gorilla_buffer_patch(gorilla_buffer_t *gbuf, size_t nbuffers, uint32_t *ent
     return true;
 }
 
+size_t gorilla_buffer_unpatched_nbuffers(const gorilla_buffer_t *gbuf) {
+    size_t nbuffers = 0;
+    while(gbuf) {
+        nbuffers++;
+
+        if(gbuf->header.next) {
+            const auto *buf = static_cast<const unsigned char *>(static_cast<const void *>(gbuf));
+            gbuf = static_cast<const gorilla_buffer_t *>(static_cast<const void *>(buf + RRDENG_GORILLA_32BIT_BUFFER_SIZE));
+        }
+        else
+            break;
+    }
+
+    return nbuffers;
+}
+
+size_t gorilla_buffer_unpatched_nbytes(const gorilla_buffer_t *gbuf) {
+    size_t nbytes = sizeof(gorilla_buffer_t);
+    while(gbuf) {
+        if(gbuf->header.next) {
+            nbytes += RRDENG_GORILLA_32BIT_BUFFER_SIZE;
+            const auto *buf = static_cast<const unsigned char *>(static_cast<const void *>(gbuf));
+            gbuf = static_cast<const gorilla_buffer_t *>(static_cast<const void *>(buf + RRDENG_GORILLA_32BIT_BUFFER_SIZE));
+        }
+        else {
+            nbytes += gorilla_buffer_nbytes(gbuf->header.nbits);
+            break;
+        }
+    }
+
+    return nbytes;
+}
+
 gorilla_reader_t gorilla_writer_get_reader(const gorilla_writer_t *gw)
 {
     const gorilla_buffer_t *buffer = __atomic_load_n(&gw->head_buffer, __ATOMIC_ACQUIRE);

--- a/src/libnetdata/gorilla/gorilla.h
+++ b/src/libnetdata/gorilla/gorilla.h
@@ -68,6 +68,8 @@ uint32_t gorilla_writer_optimal_nbytes(const gorilla_writer_t *gw);
 bool gorilla_writer_serialize(const gorilla_writer_t *gw, uint8_t *dst, uint32_t dst_size);
 
 bool gorilla_buffer_patch(gorilla_buffer_t *buf, size_t nbuffers, uint32_t *entries);
+size_t gorilla_buffer_unpatched_nbuffers(const gorilla_buffer_t *gbuf);
+size_t gorilla_buffer_unpatched_nbytes(const gorilla_buffer_t *gbuf);
 gorilla_reader_t gorilla_reader_init(gorilla_buffer_t *buf);
 bool gorilla_reader_read(gorilla_reader_t *gr, uint32_t *number);
 

--- a/src/libnetdata/object-state/object-state.c
+++ b/src/libnetdata/object-state/object-state.c
@@ -77,8 +77,8 @@ bool object_state_acquire(OBJECT_STATE *os, OBJECT_STATE_ID wanted_state_id) {
     REFCOUNT desired;
 
     do {
-        // If refcount is negative, it means deactivation is in progress or complete
-        if(expected < 0)
+        // Negative values mean deactivation; saturated refcounts cannot be incremented safely.
+        if(expected < 0 || expected >= REFCOUNT_MAX)
             return false;
 
         desired = expected + 1;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened DBEngine journal mapping/recovery, Gorilla disk decoding, and MRG allocation to prevent out-of-bounds access, stale index entries, and undefined behavior under malformed data. Normal behavior and performance remain unchanged.

- **Bug Fixes**
  - Journal v2: roll back failed remaps, remove stale index entries, and defer unmap safely; scanners restart if cleanup runs.
  - Bound directory madvise by `metric_trailer_offset` and the mmap size to avoid overlong advice.
  - Protected recovery: keep the faulting frame (depth = i+1), mark recovery-crossing locals volatile, and avoid open-cache leaks; validate extent index before use.
  - Gorilla: bound disk buffer chains by known count, add helpers to compute unpatched buffers/bytes, and reject malformed pages instead of touching OOB memory.
  - MRG: allocate/free with 64‑byte alignment using `posix_memalignz`/`posix_memalign_freez`; add a compile-time assert and unit tests.
  - Object-state: reject saturated acquires to prevent refcount overflow.

<sup>Written for commit 10d63758bebbcf6cebb0a7a2abebcdc56c4ba653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

