### PR TITLE
Netdata fixes part 69

### DIFF
--- a/src/health/health-config-unittest.c
+++ b/src/health/health-config-unittest.c
@@ -452,6 +452,160 @@ static int test_dyncfg_update_every_boundaries(int *passed) {
     return failed;
 }
 
+typedef enum {
+    DYNCFG_INTEGER_DB_LOOKUP,
+    DYNCFG_INTEGER_DELAY,
+    DYNCFG_INTEGER_REPEAT,
+} DYNCFG_INTEGER_SECTION;
+
+static int test_dyncfg_integer_destination_boundaries(int *passed) {
+    static const struct {
+        DYNCFG_INTEGER_SECTION section;
+        const char *member;
+        const char *value;
+        int expected_code;
+        const char *description;
+        const char *expected_text;
+        const char *expected_absent_text;
+    } tests[] = {
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "-2147483648", HTTP_RESP_OK, "after accepts INT_MIN", "-2147483648s" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "2147483647", HTTP_RESP_OK, "after accepts INT_MAX", "2147483647s" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "before", "-2147483648", HTTP_RESP_OK, "before accepts INT_MIN", "at -2147483648s" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "before", "2147483647", HTTP_RESP_OK, "before accepts INT_MAX", "at 2147483647s" },
+        { DYNCFG_INTEGER_DELAY, "up", "-2147483648", HTTP_RESP_OK, "delay up accepts INT_MIN", "-2147483648s" },
+        { DYNCFG_INTEGER_DELAY, "up", "2147483647", HTTP_RESP_OK, "delay up accepts INT_MAX", "2147483647s" },
+        { DYNCFG_INTEGER_DELAY, "down", "-2147483648", HTTP_RESP_OK, "delay down accepts INT_MIN", "down -2147483648s" },
+        { DYNCFG_INTEGER_DELAY, "down", "2147483647", HTTP_RESP_OK, "delay down accepts INT_MAX", "down 2147483647s" },
+        { DYNCFG_INTEGER_DELAY, "max", "-2147483648", HTTP_RESP_OK, "delay max accepts INT_MIN", "max -2147483648s" },
+        { DYNCFG_INTEGER_DELAY, "max", "2147483647", HTTP_RESP_OK, "delay max accepts INT_MAX", "max 2147483647s" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "0", HTTP_RESP_OK, "warning repeat accepts zero", " off" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "2147483647", HTTP_RESP_OK, "warning repeat accepts INT_MAX", "warning 2147483647s" },
+        { DYNCFG_INTEGER_REPEAT, "critical", "0", HTTP_RESP_OK, "critical repeat accepts zero", " off" },
+        { DYNCFG_INTEGER_REPEAT, "critical", "2147483647", HTTP_RESP_OK, "critical repeat accepts INT_MAX", "critical 2147483647s" },
+
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "1.5", HTTP_RESP_OK, "after preserves fractional-double truncation", "1s" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "true", HTTP_RESP_OK, "after preserves boolean conversion", "1s" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "null", HTTP_RESP_OK, "after preserves null conversion", NULL, "lookup" },
+        { DYNCFG_INTEGER_DELAY, "up", "-1.5", HTTP_RESP_OK, "delay preserves negative fractional-double truncation", "-1s" },
+        { DYNCFG_INTEGER_DELAY, "up", "false", HTTP_RESP_OK, "delay preserves false conversion", NULL, "delay" },
+        { DYNCFG_INTEGER_DELAY, "up", "null", HTTP_RESP_OK, "delay preserves null conversion", NULL, "delay" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "1.5", HTTP_RESP_OK, "repeat preserves fractional-double truncation", "warning 1s" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "true", HTTP_RESP_OK, "repeat preserves boolean conversion", "warning 1s" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "null", HTTP_RESP_OK, "repeat preserves null conversion", " off" },
+
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "2147483648", HTTP_RESP_BAD_REQUEST, "after rejects integer above INT_MAX" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "\"2147483648\"", HTTP_RESP_BAD_REQUEST, "after rejects string above INT_MAX" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "-2147483649", HTTP_RESP_BAD_REQUEST, "after rejects integer below INT_MIN" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "\"-2147483649\"", HTTP_RESP_BAD_REQUEST, "after rejects string below INT_MIN" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "before", "2147483648", HTTP_RESP_BAD_REQUEST, "before rejects integer above INT_MAX" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "before", "\"2147483648\"", HTTP_RESP_BAD_REQUEST, "before rejects string above INT_MAX" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "before", "-2147483649", HTTP_RESP_BAD_REQUEST, "before rejects integer below INT_MIN" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "before", "\"-2147483649\"", HTTP_RESP_BAD_REQUEST, "before rejects string below INT_MIN" },
+
+        { DYNCFG_INTEGER_DELAY, "up", "2147483648", HTTP_RESP_BAD_REQUEST, "delay up rejects integer above INT_MAX" },
+        { DYNCFG_INTEGER_DELAY, "up", "\"2147483648\"", HTTP_RESP_BAD_REQUEST, "delay up rejects string above INT_MAX" },
+        { DYNCFG_INTEGER_DELAY, "up", "-2147483649", HTTP_RESP_BAD_REQUEST, "delay up rejects integer below INT_MIN" },
+        { DYNCFG_INTEGER_DELAY, "up", "\"-2147483649\"", HTTP_RESP_BAD_REQUEST, "delay up rejects string below INT_MIN" },
+        { DYNCFG_INTEGER_DELAY, "down", "2147483648", HTTP_RESP_BAD_REQUEST, "delay down rejects integer above INT_MAX" },
+        { DYNCFG_INTEGER_DELAY, "down", "\"2147483648\"", HTTP_RESP_BAD_REQUEST, "delay down rejects string above INT_MAX" },
+        { DYNCFG_INTEGER_DELAY, "down", "-2147483649", HTTP_RESP_BAD_REQUEST, "delay down rejects integer below INT_MIN" },
+        { DYNCFG_INTEGER_DELAY, "down", "\"-2147483649\"", HTTP_RESP_BAD_REQUEST, "delay down rejects string below INT_MIN" },
+        { DYNCFG_INTEGER_DELAY, "max", "2147483648", HTTP_RESP_BAD_REQUEST, "delay max rejects integer above INT_MAX" },
+        { DYNCFG_INTEGER_DELAY, "max", "\"2147483648\"", HTTP_RESP_BAD_REQUEST, "delay max rejects string above INT_MAX" },
+        { DYNCFG_INTEGER_DELAY, "max", "-2147483649", HTTP_RESP_BAD_REQUEST, "delay max rejects integer below INT_MIN" },
+        { DYNCFG_INTEGER_DELAY, "max", "\"-2147483649\"", HTTP_RESP_BAD_REQUEST, "delay max rejects string below INT_MIN" },
+
+        { DYNCFG_INTEGER_REPEAT, "warning", "-1", HTTP_RESP_BAD_REQUEST, "warning repeat rejects negative integer" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "\"-1\"", HTTP_RESP_BAD_REQUEST, "warning repeat rejects negative string" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "2147483648", HTTP_RESP_BAD_REQUEST, "warning repeat rejects integer above INT_MAX" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "\"2147483648\"", HTTP_RESP_BAD_REQUEST, "warning repeat rejects string above INT_MAX" },
+        { DYNCFG_INTEGER_REPEAT, "critical", "-1", HTTP_RESP_BAD_REQUEST, "critical repeat rejects negative integer" },
+        { DYNCFG_INTEGER_REPEAT, "critical", "\"-1\"", HTTP_RESP_BAD_REQUEST, "critical repeat rejects negative string" },
+        { DYNCFG_INTEGER_REPEAT, "critical", "2147483648", HTTP_RESP_BAD_REQUEST, "critical repeat rejects integer above INT_MAX" },
+        { DYNCFG_INTEGER_REPEAT, "critical", "\"2147483648\"", HTTP_RESP_BAD_REQUEST, "critical repeat rejects string above INT_MAX" },
+
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "2147483648.0", HTTP_RESP_BAD_REQUEST, "after rejects double above INT_MAX" },
+        { DYNCFG_INTEGER_DB_LOOKUP, "after", "-2147483649.0", HTTP_RESP_BAD_REQUEST, "after rejects double below INT_MIN" },
+        { DYNCFG_INTEGER_DELAY, "up", "2147483648.0", HTTP_RESP_BAD_REQUEST, "delay rejects double above INT_MAX" },
+        { DYNCFG_INTEGER_DELAY, "up", "-2147483649.0", HTTP_RESP_BAD_REQUEST, "delay rejects double below INT_MIN" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "-1.0", HTTP_RESP_BAD_REQUEST, "repeat rejects negative double" },
+        { DYNCFG_INTEGER_REPEAT, "warning", "2147483648.0", HTTP_RESP_BAD_REQUEST, "repeat rejects double above INT_MAX" },
+    };
+
+    int failed = 0;
+    for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+        CLEAN_BUFFER *payload = buffer_create(0, NULL);
+        CLEAN_BUFFER *result = buffer_create(0, NULL);
+
+        buffer_strcat(payload, "{\"format_version\":1,\"rules\":[{\"enabled\":true,\"type\":\"instance\",\"config\":{");
+        switch(tests[i].section) {
+            case DYNCFG_INTEGER_DB_LOOKUP:
+                if(strcmp(tests[i].member, "before") == 0)
+                    buffer_sprintf(payload, "\"value\":{\"database_lookup\":{\"after\":1,\"before\":%s}}",
+                                   tests[i].value);
+                else
+                    buffer_sprintf(payload, "\"value\":{\"database_lookup\":{\"%s\":%s}}",
+                                   tests[i].member, tests[i].value);
+                break;
+            case DYNCFG_INTEGER_DELAY:
+                if(strcmp(tests[i].member, "max") == 0)
+                    buffer_sprintf(payload, "\"value\":{},\"action\":{\"delay\":{\"up\":1,\"max\":%s}}",
+                                   tests[i].value);
+                else
+                    buffer_sprintf(payload, "\"value\":{},\"action\":{\"delay\":{\"%s\":%s}}",
+                                   tests[i].member, tests[i].value);
+                break;
+            case DYNCFG_INTEGER_REPEAT:
+                buffer_sprintf(payload, "\"value\":{},\"action\":{\"repeat\":{\"enabled\":true,\"%s\":%s}}",
+                               tests[i].member, tests[i].value);
+                break;
+        }
+        buffer_strcat(payload, ",\"match\":{\"on\":\"chart\"}}}]}" );
+
+        int code = dyncfg_health_cb(NULL, "health:alert:prototype", DYNCFG_CMD_USERCONFIG, "unittest",
+                                    payload, NULL, NULL, result, HTTP_ACCESS_NONE, NULL, NULL);
+        bool has_field_error = tests[i].expected_code == HTTP_RESP_OK ||
+                               (strstr(buffer_tostring(result), tests[i].member) &&
+                                strstr(buffer_tostring(result), "range"));
+        bool has_expected_text = !tests[i].expected_text ||
+                                 strstr(buffer_tostring(result), tests[i].expected_text);
+        bool lacks_unexpected_text = !tests[i].expected_absent_text ||
+                                     !strstr(buffer_tostring(result), tests[i].expected_absent_text);
+
+        if(code != tests[i].expected_code || !has_field_error || !has_expected_text || !lacks_unexpected_text) {
+            fprintf(stderr, "FAILED [%s]: code=%d response='%s'\n",
+                    tests[i].description, code, buffer_tostring(result));
+            failed++;
+        }
+        else
+            (*passed)++;
+    }
+
+    CLEAN_BUFFER *payload = buffer_create(0, NULL);
+    CLEAN_BUFFER *result = buffer_create(0, NULL);
+    buffer_strcat(payload,
+                  "{\"format_version\":1,\"rules\":["
+                  "{\"enabled\":true,\"type\":\"instance\",\"config\":{"
+                  "\"value\":{},\"action\":{\"delay\":{\"up\":1}},\"match\":{\"on\":\"first\"}}},"
+                  "{\"enabled\":true,\"type\":\"instance\",\"config\":{"
+                  "\"value\":{},\"action\":{\"repeat\":{\"enabled\":true,\"warning\":-1}},"
+                  "\"match\":{\"on\":\"second\"}}}]}" );
+
+    int code = dyncfg_health_cb(NULL, "health:alert:prototype", DYNCFG_CMD_USERCONFIG, "unittest",
+                                payload, NULL, NULL, result, HTTP_ACCESS_NONE, NULL, NULL);
+    if(code != HTTP_RESP_BAD_REQUEST || !strstr(buffer_tostring(result), "warning") ||
+       !strstr(buffer_tostring(result), "range")) {
+        fprintf(stderr,
+                "FAILED [invalid repeat in a later rule rejects the complete prototype]: code=%d response='%s'\n",
+                code, buffer_tostring(result));
+        failed++;
+    }
+    else
+        (*passed)++;
+
+    return failed;
+}
+
 static int test_dyncfg_delay_multiplier_boundaries(int *passed) {
     static const struct {
         const char *multiplier;
@@ -740,6 +894,7 @@ int health_config_unittest(void) {
 
     failed += test_db_lookup_frequency_boundaries(&passed);
     failed += test_dyncfg_update_every_boundaries(&passed);
+    failed += test_dyncfg_integer_destination_boundaries(&passed);
     failed += test_dyncfg_delay_multiplier_boundaries(&passed);
     failed += test_delay_parser_multiplier_boundaries(&passed);
     failed += test_delay_multiplier_runtime_boundaries(&passed);

--- a/src/health/health-config-unittest.c
+++ b/src/health/health-config-unittest.c
@@ -338,6 +338,45 @@ static int run_db_lookup_test(const db_lookup_test_case_t *test) {
     return errors;
 }
 
+static int test_db_lookup_frequency_boundaries(int *passed) {
+    static const struct {
+        int after;
+        const char *every;
+        int expected_every;
+        const char *description;
+    } tests[] = {
+        { INT_MIN, NULL, INT_MIN < -INT_MAX ? 0 : INT_MAX, "minimum after uses a representable frequency" },
+        { INT_MIN, "1s", 1, "minimum after accepts an explicit frequency" },
+        { INT_MIN + 1, NULL, -(INT_MIN + 1), "adjacent minimum after keeps its magnitude" },
+        { -1, NULL, 1, "ordinary negative after keeps its magnitude" },
+        { INT_MAX, NULL, INT_MAX, "maximum after keeps its magnitude" },
+    };
+
+    int failed = 0;
+    for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+        char buffer[128];
+        snprintfz(buffer, sizeof(buffer), "average %ds%s%s",
+                  tests[i].after, tests[i].every ? " every " : "", tests[i].every ? tests[i].every : "");
+
+        struct rrd_alert_config ac = { 0 };
+        ac.time_group_value = NAN;
+
+        int result = health_parse_db_lookup(1, "unittest", buffer, &ac);
+        if(!result || ac.after != tests[i].after || ac.update_every != tests[i].expected_every) {
+            fprintf(stderr,
+                    "FAILED [%s]: result=%d after=%d update_every=%d\n",
+                    tests[i].description, result, ac.after, ac.update_every);
+            failed++;
+        }
+        else
+            (*passed)++;
+
+        string_freez(ac.dimensions);
+    }
+
+    return failed;
+}
+
 int health_config_unittest(void) {
     int passed = 0;
     int failed = 0;
@@ -357,6 +396,8 @@ int health_config_unittest(void) {
             failed += errors;
         }
     }
+
+    failed += test_db_lookup_frequency_boundaries(&passed);
 
     fprintf(stderr, "\n===================================================\n");
     fprintf(stderr, "Health config parser tests: %d passed, %d failed\n\n", passed, failed);

--- a/src/health/health-config-unittest.c
+++ b/src/health/health-config-unittest.c
@@ -452,6 +452,245 @@ static int test_dyncfg_update_every_boundaries(int *passed) {
     return failed;
 }
 
+static int test_dyncfg_delay_multiplier_boundaries(int *passed) {
+    static const struct {
+        const char *multiplier;
+        int expected_code;
+        const char *description;
+    } tests[] = {
+        { "0", HTTP_RESP_OK, "zero multiplier remains accepted" },
+        { "-1", HTTP_RESP_OK, "negative multiplier remains accepted" },
+        { "0.5", HTTP_RESP_OK, "fractional multiplier remains accepted" },
+        { "9223372036854775807", HTTP_RESP_OK, "maximum int64 multiplier remains accepted" },
+        { "-9223372036854775808", HTTP_RESP_OK, "minimum int64 multiplier remains accepted" },
+        { "3.4028234663852886e38", HTTP_RESP_OK, "FLT_MAX multiplier remains accepted" },
+        { "3.4028236e38", HTTP_RESP_BAD_REQUEST, "value above FLT_MAX is rejected before narrowing" },
+        { "1e100", HTTP_RESP_BAD_REQUEST, "large finite double is rejected before narrowing" },
+        { "\"nan\"", HTTP_RESP_BAD_REQUEST, "NaN string is rejected" },
+        { "\"inf\"", HTTP_RESP_BAD_REQUEST, "infinity string is rejected" },
+        { "null", HTTP_RESP_BAD_REQUEST, "null multiplier is rejected" },
+    };
+
+    int failed = 0;
+    for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+        CLEAN_BUFFER *payload = buffer_create(0, NULL);
+        CLEAN_BUFFER *result = buffer_create(0, NULL);
+
+        buffer_sprintf(payload,
+                       "{\"format_version\":1,\"rules\":[{\"enabled\":true,\"type\":\"instance\","
+                       "\"config\":{\"value\":{},\"action\":{\"delay\":{\"up\":1,\"down\":0,\"max\":10,"
+                       "\"multiplier\":%s}},\"match\":{\"on\":\"chart\"}}}]}",
+                       tests[i].multiplier);
+
+        int code = dyncfg_health_cb(NULL, "health:alert:prototype", DYNCFG_CMD_USERCONFIG, "unittest",
+                                    payload, NULL, NULL, result, HTTP_ACCESS_NONE, NULL, NULL);
+        bool has_expected_error = code == HTTP_RESP_OK || strstr(buffer_tostring(result), "multiplier") != NULL;
+
+        if(code != tests[i].expected_code || !has_expected_error) {
+            fprintf(stderr, "FAILED [%s]: code=%d response='%s'\n",
+                    tests[i].description, code, buffer_tostring(result));
+            failed++;
+        }
+        else
+            (*passed)++;
+    }
+
+    return failed;
+}
+
+static int run_delay_parse_case(
+    const char *input, int initial_max,
+    int expected_up, int expected_down, int expected_max, float expected_multiplier,
+    const char *description) {
+    char buffer[256];
+    strncpyz(buffer, input, sizeof(buffer) - 1);
+
+    int up = 123;
+    int down = 456;
+    int max = initial_max;
+    float multiplier = 7.0f;
+
+    int result = health_parse_delay(1, "unittest", buffer, &up, &down, &max, &multiplier);
+    if(!result || up != expected_up || down != expected_down || max != expected_max ||
+       multiplier != expected_multiplier) {
+        fprintf(stderr,
+                "FAILED [%s]: result=%d up=%d down=%d max=%d multiplier=%g\n",
+                description, result, up, down, max, (double)multiplier);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int test_delay_parser_multiplier_boundaries(int *passed) {
+    static const struct {
+        const char *input;
+        int initial_max;
+        int expected_up;
+        int expected_down;
+        int expected_max;
+        float expected_multiplier;
+        const char *description;
+    } tests[] = {
+        { "up 10s", 0, 10, 0, 10, 1.0f, "omitted values keep documented defaults" },
+        { "down 15m multiplier 1.5", 0, 0, 900, 1350, 1.5f, "ordinary fractional multiplier" },
+        { "up 3s multiplier 0.5", 0, 3, 0, 1, 0.5f, "fractional product truncates toward zero" },
+        { "up -3s multiplier 1.5", 0, -3, 0, 0, 1.5f, "negative duration preserves zero default max" },
+        { "up 10s multiplier 2 max 7s", 0, 10, 0, 7, 2.0f, "explicit maximum remains authoritative" },
+        { "up 10s multiplier 0", 0, 10, 0, 10, 1.0f, "zero multiplier uses text default" },
+        { "up 10s multiplier -2", 0, 10, 0, 10, 1.0f, "negative multiplier uses text default" },
+        { "up 10s multiplier nan", 0, 10, 0, 10, 1.0f, "NaN multiplier uses text default" },
+        { "up 10s multiplier inf", 0, 10, 0, 10, 1.0f, "infinite multiplier uses text default" },
+        { "max 7s", 0, 0, 0, 7, 1.0f, "explicit maximum with omitted delays" },
+        { "up 2s", 5, 2, 0, 5, 1.0f, "prior larger maximum remains unchanged" },
+        { "up 16777220s", 16777219, 16777220, 0, 16777219, 1.0f,
+          "prior maximum preserves the existing float comparison" },
+    };
+
+    int failed = 0;
+    for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+        int rc = run_delay_parse_case(
+            tests[i].input, tests[i].initial_max,
+            tests[i].expected_up, tests[i].expected_down, tests[i].expected_max,
+            tests[i].expected_multiplier, tests[i].description);
+        failed += rc;
+        if(!rc)
+            (*passed)++;
+    }
+
+    char input[256];
+    snprintfz(input, sizeof(input), "up %ds", INT_MAX);
+    int rc = run_delay_parse_case(input, 0, INT_MAX, 0, INT_MAX, 1.0f,
+                                  "INT_MAX duration has a representable default maximum");
+    failed += rc;
+    if(!rc)
+        (*passed)++;
+
+    snprintfz(input, sizeof(input), "up %ds", INT_MAX);
+    rc = run_delay_parse_case(input, INT_MAX - 1, INT_MAX, 0, INT_MAX - 1, 1.0f,
+                              "rounded INT_MAX product preserves the prior maximum comparison");
+    failed += rc;
+    if(!rc)
+        (*passed)++;
+
+    snprintfz(input, sizeof(input), "down %ds multiplier 2", INT_MIN);
+    rc = run_delay_parse_case(input, 0, 0, INT_MIN, 0, 2.0f,
+                              "INT_MIN negative product does not change the default maximum");
+    failed += rc;
+    if(!rc)
+        (*passed)++;
+
+    snprintfz(input, sizeof(input), "up 1s multiplier %a", (double)FLT_MAX);
+    rc = run_delay_parse_case(input, 0, 1, 0, INT_MAX, FLT_MAX,
+                              "largest finite multiplier bounds the omitted maximum");
+    failed += rc;
+    if(!rc)
+        (*passed)++;
+
+    return failed;
+}
+
+static int test_delay_multiplier_runtime_boundaries(int *passed) {
+    static const struct {
+        int delay;
+        float multiplier;
+        int maximum;
+        int expected;
+        const char *description;
+    } tests[] = {
+        { 10, 1.5f, 100, 15, "ordinary multiplication" },
+        { 3, 1.5f, 100, 4, "positive fractional truncation" },
+        { -3, 1.5f, 100, -4, "negative fractional truncation" },
+        { 10, 2.0f, 15, 15, "configured maximum clamps product" },
+        { 10, 2.0f, -5, -5, "negative configured maximum keeps existing clamp semantics" },
+        { 10, 0.0f, 100, 0, "zero Dynamic Configuration multiplier" },
+        { 10, -2.0f, 100, -20, "negative Dynamic Configuration multiplier" },
+        { INT_MAX, 1.0f, INT_MAX, INT_MAX, "INT_MAX float rounding is bounded" },
+        { INT_MAX, 0.5f, INT_MAX, 1073741824, "large representable product keeps float rounding" },
+        { INT_MIN, 2.0f, INT_MAX, INT_MIN, "negative out-of-range product uses lower endpoint" },
+        { INT_MAX, -1.0f, INT_MAX, INT_MIN, "negative boundary product remains representable" },
+        { INT_MIN, -1.0f, 17, 17, "positive out-of-range product uses configured maximum" },
+        { 1, FLT_MAX, 123, 123, "largest positive finite multiplier uses configured maximum" },
+        { -1, FLT_MAX, INT_MAX, INT_MIN, "largest negative product uses lower endpoint" },
+    };
+
+    int failed = 0;
+    for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+        int actual = health_delay_apply_multiplier(tests[i].delay, tests[i].multiplier, tests[i].maximum);
+        if(actual != tests[i].expected) {
+            fprintf(stderr, "FAILED [%s]: expected=%d actual=%d\n",
+                    tests[i].description, tests[i].expected, actual);
+            failed++;
+        }
+        else
+            (*passed)++;
+    }
+
+    return failed;
+}
+
+static int test_prototype_rejects_non_finite_delay_multiplier(int *passed) {
+    static const float tests[] = { NAN, INFINITY, -INFINITY };
+    int failed = 0;
+
+    for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+        RRD_ALERT_PROTOTYPE ap = { 0 };
+        ap.match.on.chart = string_strdupz("chart");
+        ap.config.name = string_strdupz("unittest");
+        ap.config.source = string_strdupz("unittest");
+        ap.config.update_every = 1;
+        ap.config.delay_multiplier = tests[i];
+
+        const char *failed_at = NULL;
+        int error = 0;
+        ap.config.calculation = expression_parse("1", &failed_at, &error);
+
+        char *msg = NULL;
+        if(!ap.config.calculation || health_prototype_add(&ap, &msg) || !msg ||
+           strcmp(msg, "non-finite delay multiplier") != 0) {
+            fprintf(stderr,
+                    "FAILED [prototype rejects non-finite delay multiplier %g]: msg='%s'\n",
+                    (double)tests[i], msg ? msg : "");
+            failed++;
+        }
+        else
+            (*passed)++;
+
+        health_prototype_cleanup(&ap);
+    }
+
+    RRD_ALERT_PROTOTYPE ap = { 0 };
+    ap.match.on.chart = string_strdupz("chart");
+    ap.config.name = string_strdupz("unittest");
+    ap.config.source = string_strdupz("unittest");
+    ap.config.update_every = 1;
+    ap.config.delay_multiplier = 1.0f;
+
+    const char *failed_at = NULL;
+    int error = 0;
+    ap.config.calculation = expression_parse("1", &failed_at, &error);
+
+    RRD_ALERT_PROTOTYPE *second = callocz(1, sizeof(*second));
+    second->config.name = string_strdupz("unittest");
+    second->config.source = string_strdupz("unittest");
+    second->config.delay_multiplier = NAN;
+    DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(ap._internal.next, second, _internal.prev, _internal.next);
+
+    char *msg = NULL;
+    if(!ap.config.calculation || health_prototype_add(&ap, &msg) || !msg ||
+       strcmp(msg, "non-finite delay multiplier") != 0) {
+        fprintf(stderr, "FAILED [prototype rejects non-finite multiplier in later rule]: msg='%s'\n",
+                msg ? msg : "");
+        failed++;
+    }
+    else
+        (*passed)++;
+
+    health_prototype_cleanup(&ap);
+
+    return failed;
+}
+
 static int test_prototype_rejects_non_positive_update_every(int *passed) {
     static const int tests[] = { -1, 0 };
     int failed = 0;
@@ -501,6 +740,10 @@ int health_config_unittest(void) {
 
     failed += test_db_lookup_frequency_boundaries(&passed);
     failed += test_dyncfg_update_every_boundaries(&passed);
+    failed += test_dyncfg_delay_multiplier_boundaries(&passed);
+    failed += test_delay_parser_multiplier_boundaries(&passed);
+    failed += test_delay_multiplier_runtime_boundaries(&passed);
+    failed += test_prototype_rejects_non_finite_delay_multiplier(&passed);
     failed += test_prototype_rejects_non_positive_update_every(&passed);
 
     fprintf(stderr, "\n===================================================\n");

--- a/src/health/health-config-unittest.c
+++ b/src/health/health-config-unittest.c
@@ -342,14 +342,19 @@ static int test_db_lookup_frequency_boundaries(int *passed) {
     static const struct {
         int after;
         const char *every;
+        bool expected_result;
         int expected_every;
         const char *description;
     } tests[] = {
-        { INT_MIN, NULL, INT_MIN < -INT_MAX ? 0 : INT_MAX, "minimum after uses a representable frequency" },
-        { INT_MIN, "1s", 1, "minimum after accepts an explicit frequency" },
-        { INT_MIN + 1, NULL, -(INT_MIN + 1), "adjacent minimum after keeps its magnitude" },
-        { -1, NULL, 1, "ordinary negative after keeps its magnitude" },
-        { INT_MAX, NULL, INT_MAX, "maximum after keeps its magnitude" },
+        { INT_MIN, NULL, true, INT_MIN < -INT_MAX ? 0 : INT_MAX, "minimum after uses a representable frequency" },
+        { INT_MIN, "1s", true, 1, "minimum after accepts an explicit frequency" },
+        { INT_MIN + 1, NULL, true, -(INT_MIN + 1), "adjacent minimum after keeps its magnitude" },
+        { -600, "-1s", false, 600, "negative frequency preserves the derived default" },
+        { -600, "0s", true, 0, "zero frequency remains the missing-frequency sentinel" },
+        { -600, "1s", true, 1, "minimum positive frequency is accepted" },
+        { -600, "10s", true, 10, "ordinary positive frequency is accepted" },
+        { -1, NULL, true, 1, "ordinary negative after keeps its magnitude" },
+        { INT_MAX, NULL, true, INT_MAX, "maximum after keeps its magnitude" },
     };
 
     int failed = 0;
@@ -362,7 +367,8 @@ static int test_db_lookup_frequency_boundaries(int *passed) {
         ac.time_group_value = NAN;
 
         int result = health_parse_db_lookup(1, "unittest", buffer, &ac);
-        if(!result || ac.after != tests[i].after || ac.update_every != tests[i].expected_every) {
+        if((bool)result != tests[i].expected_result || ac.after != tests[i].after ||
+           ac.update_every != tests[i].expected_every) {
             fprintf(stderr,
                     "FAILED [%s]: result=%d after=%d update_every=%d\n",
                     tests[i].description, result, ac.after, ac.update_every);
@@ -372,6 +378,102 @@ static int test_db_lookup_frequency_boundaries(int *passed) {
             (*passed)++;
 
         string_freez(ac.dimensions);
+    }
+
+    return failed;
+}
+
+static int test_dyncfg_update_every_boundaries(int *passed) {
+    static const struct {
+        const char *value_member;
+        int expected_code;
+        bool expected_every;
+        const char *expected_error;
+        const char *description;
+    } tests[] = {
+        { "", HTTP_RESP_OK, false, NULL, "omitted frequency remains optional for user config conversion" },
+        { "\"update_every\":0", HTTP_RESP_OK, false, NULL, "zero frequency remains the missing-frequency sentinel" },
+        { "\"update_every\":-1", HTTP_RESP_BAD_REQUEST, false, "negative", "negative integer frequency is rejected" },
+        { "\"update_every\":\"-1\"", HTTP_RESP_BAD_REQUEST, false, "negative", "negative string frequency is rejected" },
+        { "\"update_every\":-4294967295", HTTP_RESP_BAD_REQUEST, false, "negative", "large negative integer cannot wrap positive" },
+        { "\"update_every\":\"-4294967295\"", HTTP_RESP_BAD_REQUEST, false, "negative", "large negative string cannot wrap positive" },
+        { "\"update_every\":9223372036854775807", HTTP_RESP_BAD_REQUEST, false, "maximum", "out-of-range positive frequency is rejected" },
+        { "\"update_every\":1", HTTP_RESP_OK, true, NULL, "minimum positive frequency is accepted" },
+        { "\"update_every\":10", HTTP_RESP_OK, true, NULL, "ordinary positive frequency is accepted" },
+    };
+
+    int failed = 0;
+    for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+        CLEAN_BUFFER *payload = buffer_create(0, NULL);
+        CLEAN_BUFFER *result = buffer_create(0, NULL);
+
+        buffer_sprintf(payload,
+                       "{\"format_version\":1,\"rules\":[{\"enabled\":true,\"type\":\"instance\","
+                       "\"config\":{\"value\":{%s},\"match\":{\"on\":\"chart\"}}}]}",
+                       tests[i].value_member);
+
+        int code = dyncfg_health_cb(NULL, "health:alert:prototype", DYNCFG_CMD_USERCONFIG, "unittest",
+                                    payload, NULL, NULL, result, HTTP_ACCESS_NONE, NULL, NULL);
+        bool has_every = strstr(buffer_tostring(result), "every: ") != NULL;
+        bool has_expected_error = !tests[i].expected_error ||
+                                  strstr(buffer_tostring(result), tests[i].expected_error) != NULL;
+
+        if(code != tests[i].expected_code || has_every != tests[i].expected_every ||
+           !has_expected_error) {
+            fprintf(stderr,
+                    "FAILED [%s]: code=%d has_every=%d response='%s'\n",
+                    tests[i].description, code, has_every, buffer_tostring(result));
+            failed++;
+        }
+        else
+            (*passed)++;
+    }
+
+    CLEAN_BUFFER *payload = buffer_create(0, NULL);
+    CLEAN_BUFFER *result = buffer_create(0, NULL);
+    buffer_strcat(payload,
+                  "{\"format_version\":1,\"rules\":["
+                  "{\"enabled\":true,\"type\":\"instance\",\"config\":{"
+                  "\"value\":{\"update_every\":1},\"match\":{\"on\":\"first\"}}},"
+                  "{\"enabled\":true,\"type\":\"instance\",\"config\":{"
+                  "\"value\":{\"update_every\":-1},\"match\":{\"on\":\"second\"}}}]}" );
+
+    int code = dyncfg_health_cb(NULL, "health:alert:prototype", DYNCFG_CMD_USERCONFIG, "unittest",
+                                payload, NULL, NULL, result, HTTP_ACCESS_NONE, NULL, NULL);
+    if(code != HTTP_RESP_BAD_REQUEST || !strstr(buffer_tostring(result), "negative")) {
+        fprintf(stderr,
+                "FAILED [negative frequency in a later rule is rejected]: code=%d response='%s'\n",
+                code, buffer_tostring(result));
+        failed++;
+    }
+    else
+        (*passed)++;
+
+    return failed;
+}
+
+static int test_prototype_rejects_non_positive_update_every(int *passed) {
+    static const int tests[] = { -1, 0 };
+    int failed = 0;
+
+    for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+        RRD_ALERT_PROTOTYPE ap = { 0 };
+        ap.match.on.chart = string_strdupz("chart");
+        ap.config.name = string_strdupz("unittest");
+        ap.config.source = string_strdupz("unittest");
+        ap.config.update_every = tests[i];
+
+        char *msg = NULL;
+        if(health_prototype_add(&ap, &msg) || !msg || strcmp(msg, "missing update frequency") != 0) {
+            fprintf(stderr,
+                    "FAILED [prototype rejects update_every=%d]: msg='%s'\n",
+                    tests[i], msg ? msg : "");
+            failed++;
+        }
+        else
+            (*passed)++;
+
+        health_prototype_cleanup(&ap);
     }
 
     return failed;
@@ -398,6 +500,8 @@ int health_config_unittest(void) {
     }
 
     failed += test_db_lookup_frequency_boundaries(&passed);
+    failed += test_dyncfg_update_every_boundaries(&passed);
+    failed += test_prototype_rejects_non_positive_update_every(&passed);
 
     fprintf(stderr, "\n===================================================\n");
     fprintf(stderr, "Health config parser tests: %d passed, %d failed\n\n", passed, failed);

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -3,7 +3,7 @@
 #include "health.h"
 #include "health_internals.h"
 
-static inline int health_parse_delay(
+int health_parse_delay(
         size_t line, const char *filename, char *string,
         int *delay_up_duration,
         int *delay_down_duration,
@@ -73,11 +73,11 @@ static inline int health_parse_delay(
         *delay_multiplier = 1.0;
 
     if(!given_max) {
-        if((*delay_max_duration) < (*delay_up_duration) * (*delay_multiplier))
-            *delay_max_duration = (int)((*delay_up_duration) * (*delay_multiplier));
+        if(health_delay_product_exceeds(*delay_up_duration, *delay_multiplier, *delay_max_duration))
+            *delay_max_duration = health_delay_apply_multiplier(*delay_up_duration, *delay_multiplier, INT_MAX);
 
-        if((*delay_max_duration) < (*delay_down_duration) * (*delay_multiplier))
-            *delay_max_duration = (int)((*delay_down_duration) * (*delay_multiplier));
+        if(health_delay_product_exceeds(*delay_down_duration, *delay_multiplier, *delay_max_duration))
+            *delay_max_duration = health_delay_apply_multiplier(*delay_down_duration, *delay_multiplier, INT_MAX);
     }
 
     return 1;

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -112,6 +112,15 @@ static inline ALERT_ACTION_OPTIONS health_parse_options(const char *s) {
     return options;
 }
 
+static inline bool health_parse_update_every(const char *value, int *update_every) {
+    int parsed;
+    if(!duration_parse_seconds(value, &parsed) || parsed < 0)
+        return false;
+
+    *update_every = parsed;
+    return true;
+}
+
 static inline int health_parse_repeat(
         size_t line,
         const char *file,
@@ -336,7 +345,7 @@ int health_parse_db_lookup(size_t line, const char *filename, char *string, stru
             while(*s && !isspace((uint8_t)*s)) s++;
             while(*s && isspace((uint8_t)*s)) *s++ = '\0';
 
-            if (!duration_parse_seconds(value, &ac->update_every)) {
+            if (!health_parse_update_every(value, &ac->update_every)) {
                 netdata_log_error("Health configuration at line %zu of file '%s': invalid duration '%s' for '%s' keyword",
                                   line, filename, value, key);
                 return 0;
@@ -763,7 +772,7 @@ int health_readfile(const char *filename, void *data __maybe_unused, bool stock_
             health_parse_db_lookup(line, filename, value, ac);
         }
         else if(hash == hash_every && !strcasecmp(key, HEALTH_EVERY_KEY)) {
-            if(!duration_parse_seconds(value, &ac->update_every))
+            if(!health_parse_update_every(value, &ac->update_every))
                 netdata_log_error(
                     "Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' "
                     "cannot parse duration: '%s'.",

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -309,8 +309,9 @@ int health_parse_db_lookup(size_t line, const char *filename, char *string, stru
         return 0;
     }
 
-    // sane defaults
-    ac->update_every = ABS(ac->after);
+    // derive the default only when its positive magnitude fits in int
+    if(ac->after >= -INT_MAX)
+        ac->update_every = ABS(ac->after);
 
     // now we may have optional parameters
     while(*s) {

--- a/src/health/health_dyncfg.c
+++ b/src/health/health_dyncfg.c
@@ -22,6 +22,19 @@ static char *health_dyncfg_alert_prototype_id_strdupz(const char *alert_name) {
 // ---------------------------------------------------------------------------------------------------------------------
 // parse the json object of an alert definition
 
+static bool parse_bounded_int64(json_object *jobj, const char *path, const char *member, int64_t *value,
+                                int64_t minimum, int64_t maximum, BUFFER *error, unsigned flags) {
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, member, *value, error, flags);
+
+    if(*value < minimum || *value > maximum) {
+        buffer_sprintf(error, "value for '%s.%s' is outside range [%" PRId64 ", %" PRId64 "]",
+                       path, member, minimum, maximum);
+        return false;
+    }
+
+    return true;
+}
+
 static void dims_grouping_to_rrdr_options(RRD_ALERT_PROTOTYPE *ap) {
     ap->config.options &= ~(RRDR_OPTIONS_DIMS_AGGREGATION);
 
@@ -81,8 +94,15 @@ static bool parse_match(json_object *jobj, const char *path, struct rrd_alert_ma
 }
 
 static bool parse_config_value_database_lookup(json_object *jobj, const char *path, struct rrd_alert_config *config, BUFFER *error, unsigned flags) {
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "after", config->after, error, flags);
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "before", config->before, error, flags);
+    int64_t after = config->after;
+    int64_t before = config->before;
+    if(!parse_bounded_int64(jobj, path, "after", &after, INT_MIN, INT_MAX, error, flags) ||
+       !parse_bounded_int64(jobj, path, "before", &before, INT_MIN, INT_MAX, error, flags))
+        return false;
+
+    config->after = (int)after;
+    config->before = (int)before;
+
     JSONC_PARSE_TXT2ENUM_OR_ERROR_AND_RETURN(jobj, path, "time_group", time_grouping_txt2id, config->time_group, error, flags);
     JSONC_PARSE_TXT2ENUM_OR_ERROR_AND_RETURN(jobj, path, "dims_group", alerts_dims_grouping2id, config->dims_group, error, flags);
     JSONC_PARSE_TXT2ENUM_OR_ERROR_AND_RETURN(jobj, path, "data_source", alerts_data_sources2id, config->data_source, error, flags);
@@ -134,9 +154,17 @@ static bool parse_config_conditions(json_object *jobj, const char *path, struct 
 }
 
 static bool parse_config_action_delay(json_object *jobj, const char *path, struct rrd_alert_config *config, BUFFER *error, unsigned flags) {
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "up", config->delay_up_duration, error, flags);
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "down", config->delay_down_duration, error, flags);
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "max", config->delay_max_duration, error, flags);
+    int64_t up = config->delay_up_duration;
+    int64_t down = config->delay_down_duration;
+    int64_t max = config->delay_max_duration;
+    if(!parse_bounded_int64(jobj, path, "up", &up, INT_MIN, INT_MAX, error, flags) ||
+       !parse_bounded_int64(jobj, path, "down", &down, INT_MIN, INT_MAX, error, flags) ||
+       !parse_bounded_int64(jobj, path, "max", &max, INT_MIN, INT_MAX, error, flags))
+        return false;
+
+    config->delay_up_duration = (int)up;
+    config->delay_down_duration = (int)down;
+    config->delay_max_duration = (int)max;
 
     json_object *jmultiplier = NULL;
     bool multiplier_is_int = json_object_object_get_ex(jobj, "multiplier", &jmultiplier) &&
@@ -155,8 +183,16 @@ static bool parse_config_action_delay(json_object *jobj, const char *path, struc
 
 static bool parse_config_action_repeat(json_object *jobj, const char *path, struct rrd_alert_config *config, BUFFER *error, unsigned flags) {
     JSONC_PARSE_BOOL_OR_ERROR_AND_RETURN(jobj, path, "enabled", config->has_custom_repeat_config, error, flags);
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "warning", config->warn_repeat_every, error, flags);
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "critical", config->crit_repeat_every, error, flags);
+
+    int64_t warning = config->warn_repeat_every;
+    int64_t critical = config->crit_repeat_every;
+    if(!parse_bounded_int64(jobj, path, "warning", &warning, 0, INT_MAX, error, flags) ||
+       !parse_bounded_int64(jobj, path, "critical", &critical, 0, INT_MAX, error, flags))
+        return false;
+
+    config->warn_repeat_every = (uint32_t)warning;
+    config->crit_repeat_every = (uint32_t)critical;
+
     return true;
 }
 

--- a/src/health/health_dyncfg.c
+++ b/src/health/health_dyncfg.c
@@ -111,7 +111,19 @@ static bool parse_config_value(json_object *jobj, const char *path, struct rrd_a
     JSONC_PARSE_SUBOBJECT_CB(jobj, path, "database_lookup", config, parse_config_value_database_lookup, error, flags);
     JSONC_PARSE_TXT2EXPRESSION_OR_ERROR_AND_RETURN(jobj, path, "calculation", config->calculation, error, JSONC_OPTIONAL);
     JSONC_PARSE_TXT2STRING_OR_ERROR_AND_RETURN(jobj, path, "units", config->units, error, JSONC_OPTIONAL);
-    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "update_every", config->update_every, error, flags);
+    int64_t update_every = config->update_every;
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "update_every", update_every, error, flags);
+    if(update_every < 0) {
+        buffer_sprintf(error, "negative value for '%s.update_every'", path);
+        return false;
+    }
+    if(update_every > INT_MAX) {
+        buffer_sprintf(error, "value for '%s.update_every' exceeds maximum %d", path, INT_MAX);
+        return false;
+    }
+
+    config->update_every = (int)update_every;
+
     return true;
 }
 

--- a/src/health/health_dyncfg.c
+++ b/src/health/health_dyncfg.c
@@ -137,7 +137,19 @@ static bool parse_config_action_delay(json_object *jobj, const char *path, struc
     JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "up", config->delay_up_duration, error, flags);
     JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "down", config->delay_down_duration, error, flags);
     JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "max", config->delay_max_duration, error, flags);
-    JSONC_PARSE_DOUBLE_OR_ERROR_AND_RETURN(jobj, path, "multiplier", config->delay_multiplier, error, flags);
+
+    json_object *jmultiplier = NULL;
+    bool multiplier_is_int = json_object_object_get_ex(jobj, "multiplier", &jmultiplier) &&
+                             jmultiplier && json_object_is_type(jmultiplier, json_type_int);
+
+    double multiplier = config->delay_multiplier;
+    JSONC_PARSE_DOUBLE_OR_ERROR_AND_RETURN(jobj, path, "multiplier", multiplier, error, flags);
+    if(!isfinite(multiplier) || multiplier < -(double)FLT_MAX || multiplier > (double)FLT_MAX) {
+        buffer_sprintf(error, "non-finite or out-of-range value for '%s.multiplier'", path);
+        return false;
+    }
+    config->delay_multiplier = multiplier_is_int ? (float)json_object_get_int64(jmultiplier) : (float)multiplier;
+
     return true;
 }
 

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -625,13 +625,10 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                     rc->delay_last = 0;
                     rc->delay_up_to_timestamp = 0;
                 } else {
-                    rc->delay_up_current = (int)((float)rc->delay_up_current * rc->config.delay_multiplier);
-                    if (rc->delay_up_current > rc->config.delay_max_duration)
-                        rc->delay_up_current = rc->config.delay_max_duration;
-
-                    rc->delay_down_current = (int)((float)rc->delay_down_current * rc->config.delay_multiplier);
-                    if (rc->delay_down_current > rc->config.delay_max_duration)
-                        rc->delay_down_current = rc->config.delay_max_duration;
+                    rc->delay_up_current = health_delay_apply_multiplier(
+                        rc->delay_up_current, rc->config.delay_multiplier, rc->config.delay_max_duration);
+                    rc->delay_down_current = health_delay_apply_multiplier(
+                        rc->delay_down_current, rc->config.delay_multiplier, rc->config.delay_max_duration);
                 }
 
                 if (status > rc->status)

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -141,7 +141,7 @@ static inline int rrdcalc_isrunnable(RRDCALC *rc, time_t now, time_t *next_run) 
         return 0;
     }
 
-    if(unlikely(!rc->config.update_every)) {
+    if(unlikely(rc->config.update_every <= 0)) {
         netdata_log_debug(D_HEALTH, "Health not running alarm '%s.%s'. It does not have an update frequency", rrdcalc_chart_name(rc), rrdcalc_name(rc));
         return 0;
     }

--- a/src/health/health_internals.h
+++ b/src/health/health_internals.h
@@ -43,6 +43,41 @@
 #define HEALTH_HOST_LABEL_KEY "host labels"
 #define HEALTH_CHART_LABEL_KEY "chart labels"
 
+static inline int health_delay_apply_multiplier(int delay, float multiplier, int maximum) {
+    const float float_delay = (float)delay;
+
+    // Prove the range widely, then preserve the existing float multiplication and truncation.
+    const double wide = (double)float_delay * (double)multiplier;
+
+    if(wide > (double)INT_MAX)
+        return maximum;
+
+    if(wide < (double)INT_MIN)
+        return INT_MIN;
+
+    const float multiplied = float_delay * multiplier;
+    if((double)multiplied > (double)maximum)
+        return maximum;
+
+    if((double)multiplied < (double)INT_MIN)
+        return INT_MIN;
+
+    return (int)multiplied;
+}
+
+static inline bool health_delay_product_exceeds(int delay, float multiplier, int value) {
+    const float float_delay = (float)delay;
+    const double wide = (double)float_delay * (double)multiplier;
+
+    if(wide > (double)FLT_MAX)
+        return true;
+
+    if(wide < -(double)FLT_MAX)
+        return false;
+
+    return (float)value < float_delay * multiplier;
+}
+
 void alert_action_options_to_buffer_json_array(BUFFER *wb, const char *key, ALERT_ACTION_OPTIONS options);
 void alert_action_options_to_buffer(BUFFER *wb, ALERT_ACTION_OPTIONS options);
 ALERT_ACTION_OPTIONS alert_action_options_parse(char *o);
@@ -103,6 +138,9 @@ int health_readfile(const char *filename, void *data, bool stock_config);
 
 // for unit testing
 int health_parse_db_lookup(size_t line, const char *filename, char *string, struct rrd_alert_config *ac);
+int health_parse_delay(size_t line, const char *filename, char *string,
+                       int *delay_up_duration, int *delay_down_duration,
+                       int *delay_max_duration, float *delay_multiplier);
 void unlink_alarm_notify_in_progress(ALARM_ENTRY *ae);
 void wait_for_all_notifications_to_finish_before_allowing_health_to_be_cleaned_up(void);
 

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -432,7 +432,7 @@ bool health_prototype_add(RRD_ALERT_PROTOTYPE *ap, char **msg) {
         }
     }
 
-    if(!ap->config.update_every) {
+    if(ap->config.update_every <= 0) {
         netdata_log_error(
             "HEALTH: alert '%s' has no frequency (parameter 'every'). Source: %s",
             string2str(ap->config.name), string2str(ap->config.source));

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -450,6 +450,17 @@ bool health_prototype_add(RRD_ALERT_PROTOTYPE *ap, char **msg) {
         return false;
     }
 
+    for(RRD_ALERT_PROTOTYPE *t = ap; t; t = t->_internal.next) {
+        if(!isfinite(t->config.delay_multiplier)) {
+            netdata_log_error(
+                "HEALTH: alert '%s' has a non-finite delay multiplier. Source: %s",
+                string2str(t->config.name), string2str(t->config.source));
+            if(msg)
+                *msg = "non-finite delay multiplier";
+            return false;
+        }
+    }
+
     // activate the match patterns in it
     bool enabled = false;
     for(RRD_ALERT_PROTOTYPE *t = ap; t ;t = t->_internal.next) {

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -136,10 +136,13 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
         }
 
         var[i] = '\0';
-        pos = m - temp + 1;
+        size_t match_pos = m - temp;
+        pos = match_pos + 1;
 
         if (!strcmp(var, RRDCALC_VAR_FAMILY)) {
-            char *buf = find_and_replace(temp, var, (rc->rrdset && rc->rrdset->family) ? rrdset_family(rc->rrdset) : "", m);
+            const char *family = (rc->rrdset && rc->rrdset->family) ? rrdset_family(rc->rrdset) : "";
+            char *buf = find_and_replace(temp, var, family, m);
+            pos = match_pos + strlen(family);
             freez(temp);
             temp = buf;
         }
@@ -154,6 +157,7 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
                 rrdlabels_get_value_strdup_or_null(rc->rrdset->rrdlabels, &lbl_value, label_val);
                 if (lbl_value) {
                     char *buf = find_and_replace(temp, var, lbl_value, m);
+                    pos = match_pos + strlen(lbl_value);
                     freez(temp);
                     temp = buf;
                     freez(lbl_value);

--- a/src/libnetdata/facets/facets.c
+++ b/src/libnetdata/facets/facets.c
@@ -2658,6 +2658,7 @@ static uint32_t facets_sort_and_reorder_values(FACET_KEY *k) {
 
     size_t entries = k->values.used;
     struct facet_value_restore {
+        FACET_VALUE *v;
         const char *name;
         uint32_t name_len;
     } *values = mallocz(entries * sizeof(*values));
@@ -2668,6 +2669,7 @@ static uint32_t facets_sort_and_reorder_values(FACET_KEY *k) {
         if(used >= entries)
             break;
 
+        values[used].v = v;
         values[used].name = v->name;
         values[used].name_len = v->name_len;
         used++;
@@ -2680,17 +2682,12 @@ static uint32_t facets_sort_and_reorder_values(FACET_KEY *k) {
 
     ret = facets_sort_and_reorder_values_internal(k);
 
-    used = 0;
-    foreach_value_in_key(k, v) {
-        if(used >= entries)
-            break;
-
+    for(uint32_t i = 0; i < used; i++) {
+        v = values[i].v;
         freez((void *)v->name);
-        v->name = values[used].name;
-        v->name_len = values[used].name_len;
-        used++;
+        v->name = values[i].name;
+        v->name_len = values[i].name_len;
     }
-    foreach_value_in_key_done(v);
 
     buffer_free(tb);
     freez(values);

--- a/src/libnetdata/facets/facets.c
+++ b/src/libnetdata/facets/facets.c
@@ -151,8 +151,8 @@ typedef struct facet_value {
     uint32_t final_facet_value_counter;
     uint32_t order;
 
-    uint32_t *histogram;
-    uint32_t min, max, sum;
+    uint64_t *histogram;
+    uint64_t min, max, sum;
 
     struct facet_value *prev, *next;
 } FACET_VALUE;
@@ -925,6 +925,13 @@ void facets_set_timeframe_and_histogram_by_name(FACETS *facets, const char *key_
     facets_set_timeframe_and_histogram_by_id(facets, hash_str, after_ut, before_ut);
 }
 
+static inline uint64_t facets_u64_saturating_add(uint64_t current, uint64_t add) {
+    if(unlikely(add > UINT64_MAX - current))
+        return UINT64_MAX;
+
+    return current + add;
+}
+
 static inline uint32_t facets_histogram_slot_at_time_ut(FACETS *facets, usec_t usec, FACET_VALUE *v) {
     if(unlikely(!v->histogram))
         v->histogram = callocz(facets->histogram.slots, sizeof(*v->histogram));
@@ -947,7 +954,7 @@ static inline uint32_t facets_histogram_slot_at_time_ut(FACETS *facets, usec_t u
 
 static inline void facets_histogram_update_value_slot(FACETS *facets, usec_t usec, FACET_VALUE *v) {
     uint32_t slot = facets_histogram_slot_at_time_ut(facets, usec, v);
-    v->histogram[slot]++;
+    v->histogram[slot] = facets_u64_saturating_add(v->histogram[slot], 1);
 }
 
 static inline void facets_histogram_update_value(FACETS *facets, usec_t usec) {
@@ -971,6 +978,46 @@ static usec_t overlap_duration_ut(usec_t start1, usec_t end1, usec_t start2, use
         return overlap_end - overlap_start;
     else
         return 0; // No overlap
+}
+
+static size_t facets_estimated_entries_for_overlap(usec_t overlap_ut, size_t entries, usec_t total_ut) {
+    if(!overlap_ut || !entries)
+        return 0;
+
+    if(overlap_ut == total_ut)
+        return entries;
+
+#if defined(__SIZEOF_INT128__)
+    return (size_t)(((__uint128_t)overlap_ut * (__uint128_t)entries) / (__uint128_t)total_ut);
+#else
+    if(entries <= UINT64_MAX / overlap_ut)
+        return (size_t)((overlap_ut * (uint64_t)entries) / total_ut);
+
+    size_t quotient = 0;
+    usec_t remainder = 0;
+
+    for(size_t bit = sizeof(entries) * CHAR_BIT; bit > 0; bit--) {
+        // The quotient cannot exceed the already processed prefix of entries.
+        quotient *= 2;
+        if(remainder >= total_ut - remainder) {
+            remainder -= total_ut - remainder;
+            quotient++;
+        }
+        else
+            remainder += remainder;
+
+        if(entries & ((size_t)1 << (bit - 1))) {
+            if(remainder >= total_ut - overlap_ut) {
+                remainder -= total_ut - overlap_ut;
+                quotient++;
+            }
+            else
+                remainder += overlap_ut;
+        }
+    }
+
+    return quotient;
+#endif
 }
 
 void facets_update_estimations(FACETS *facets, usec_t from_ut, usec_t to_ut, size_t entries) {
@@ -1000,9 +1047,11 @@ void facets_update_estimations(FACETS *facets, usec_t from_ut, usec_t to_ut, siz
 
     FACET_VALUE *v = facets->histogram.key->estimated_value.v;
 
+#ifdef NETDATA_INTERNAL_CHECKS
     size_t slots = 0;
-    size_t total_ut = to_ut - from_ut;
-    ssize_t remaining_entries = (ssize_t)entries;
+    size_t remaining_entries = entries;
+#endif
+    usec_t total_ut = to_ut - from_ut;
     size_t slot = facets_histogram_slot_at_time_ut(facets, from_ut, v);
     for(; slot < facets->histogram.slots ;slot++) {
         usec_t slot_start_ut = facets->histogram.after_ut + slot * facets->histogram.slot_width_ut;
@@ -1013,17 +1062,23 @@ void facets_update_estimations(FACETS *facets, usec_t from_ut, usec_t to_ut, siz
 
         usec_t overlap_ut = overlap_duration_ut(from_ut, to_ut, slot_start_ut, slot_end_ut);
 
-        size_t slot_entries = (overlap_ut * entries) / total_ut;
-        v->histogram[slot] += slot_entries;
-        remaining_entries -= (ssize_t)slot_entries;
+        size_t slot_entries = facets_estimated_entries_for_overlap(overlap_ut, entries, total_ut);
+        v->histogram[slot] = facets_u64_saturating_add(v->histogram[slot], slot_entries);
+#ifdef NETDATA_INTERNAL_CHECKS
+        internal_fatal(slot_entries > remaining_entries,
+                       "distribution of estimations assigned more entries than available");
+        remaining_entries -= slot_entries;
         slots++;
+#endif
     }
 
+#ifdef NETDATA_INTERNAL_CHECKS
     // Check if all entries are assigned
     // This should always be true if the distribution is correct
-    internal_fatal(remaining_entries < 0 || remaining_entries >= (ssize_t)(slots),
-                   "distribution of estimations is not accurate - there are %zd remaining entries",
+    internal_fatal(remaining_entries >= slots,
+                   "distribution of estimations is not accurate - there are %zu remaining entries",
                    remaining_entries);
+#endif
 }
 
 void facets_row_finished_unsampled(FACETS *facets, usec_t usec) {
@@ -1234,7 +1289,7 @@ static inline void facets_histogram_value_arp(BUFFER *wb, FACETS *facets __maybe
     buffer_json_array_close(wb); // key
 }
 
-static inline void facets_histogram_value_con(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key, uint32_t sum) {
+static inline void facets_histogram_value_con(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key, uint64_t sum) {
     buffer_json_member_add_array(wb, key);
     {
         if(k && k->values.enabled) {
@@ -1255,7 +1310,7 @@ static void facets_histogram_generate(FACETS *facets, FACET_KEY *k, BUFFER *wb) 
     CLEAN_BUFFER *tmp = buffer_create(0, NULL);
 
     size_t dimensions = 0;
-    uint32_t min = UINT32_MAX, max = 0, sum = 0, count = 0;
+    uint64_t min = UINT64_MAX, max = 0, sum = 0, count = 0;
 
     if(k && k->values.enabled) {
         FACET_VALUE *v;
@@ -1267,12 +1322,12 @@ static void facets_histogram_generate(FACETS *facets, FACET_KEY *k, BUFFER *wb) 
 
             dimensions++;
 
-            v->min = UINT32_MAX;
+            v->min = UINT64_MAX;
             v->max = 0;
             v->sum = 0;
 
             for(uint32_t i = 0; i < facets->histogram.slots ;i++) {
-                uint32_t n = v->histogram[i];
+                uint64_t n = v->histogram[i];
 
                 if(n < min)
                     min = n;
@@ -1280,7 +1335,7 @@ static void facets_histogram_generate(FACETS *facets, FACET_KEY *k, BUFFER *wb) 
                 if(n > max)
                     max = n;
 
-                sum += n;
+                sum = facets_u64_saturating_add(sum, n);
                 count++;
 
                 if(n < v->min)
@@ -1289,7 +1344,7 @@ static void facets_histogram_generate(FACETS *facets, FACET_KEY *k, BUFFER *wb) 
                 if(n > v->max)
                     v->max = n;
 
-                v->sum += n;
+                v->sum = facets_u64_saturating_add(v->sum, n);
             }
         }
         foreach_value_in_key_done(v);


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens Health alert parsing/scheduling and fixes Facets histogram overflows. Adds strict bounds for durations and multipliers, prevents negative/overflowing values, and fixes a label-substitution loop; histograms now use 64‑bit counters with safe estimation.

- **Bug Fixes**
  - Health: reject non‑positive `update_every` in text/JSON; bound JSON integers for lookup windows, delays, and repeat intervals to valid int ranges.
  - Health: derive implicit `every` from `after` only when representable (guards `INT_MIN`); scheduler now skips rules with `every <= 0`.
  - Health: validate delay multipliers (reject NaN/Inf/out‑of‑range), and apply them with a checked helper to avoid float-to-int overflow; clamp by configured max.
  - Health: fix placeholder replacement in alert labels to resume scanning after the inserted text, preventing re‑entry and runaway growth.
  - Facets: switch histogram buckets and min/max/sum to `uint64_t` with saturating adds; compute per‑slot estimates with 128‑bit math (or a safe fallback) to avoid overflow and truncation.
  - Facets: restore transformed values by identity instead of position to avoid mismatched frees on future list mutations.

- **Refactors**
  - Introduced helpers for safe delay math (`health_delay_apply_multiplier`, `health_delay_product_exceeds`) and bounded JSON int parsing; made `health_parse_delay` testable.
  - Added targeted unit tests covering frequency bounds, delay multipliers, JSON integer ranges, and prototype admission.

<sup>Written for commit db15dee084ab46b7560825c7878e37d06bb60477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

