### PR TITLE
Netdata fixes part 70

### DIFF
--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -455,7 +455,7 @@ static void parse_args(int argc, char **argv)
             }
             i++;
             int64_t seconds = 0;
-            if(!duration_parse(argv[i], &seconds, "s", "s")) {
+            if(!duration_parse(argv[i], &seconds, "s", "s") || seconds > INT_MAX) {
                 fprintf(stderr, "Cannot parse '--pss' value '%s'.\n", argv[i]);
                 exit(1);
             }
@@ -464,8 +464,6 @@ static void parse_args(int argc, char **argv)
             }
             else {
                 pss_refresh_period = (int)seconds;
-                if(pss_refresh_period < 1)
-                    pss_refresh_period = 1;
             }
             continue;
         }

--- a/src/libnetdata/json/json-c-parser-inline.h
+++ b/src/libnetdata/json/json-c-parser-inline.h
@@ -14,6 +14,34 @@
 // helper: convert a bool to JSONC_REQUIRED / JSONC_OPTIONAL
 #define JSONC_REQUIRE_IF(cond) ((cond) ? JSONC_REQUIRED : JSONC_OPTIONAL)
 
+#define JSONC_INTEGER_DESTINATION_IS_UNSIGNED(dst) _Generic((dst), \
+    unsigned char: true,                                             \
+    unsigned short: true,                                            \
+    unsigned int: true,                                              \
+    unsigned long: true,                                             \
+    unsigned long long: true,                                        \
+    default: false)
+
+static inline bool jsonc_double_fits_integer_destination(double value, size_t size, bool is_unsigned) {
+    if(!size || size > sizeof(uint64_t))
+        return false;
+
+    unsigned bits = (unsigned)(size * CHAR_BIT);
+    double limit = (double)(UINT64_C(1) << (bits - 1)) * (is_unsigned ? 2.0 : 1.0);
+
+    if(!netdata_double_isnumber(value) || value >= limit)
+        return false;
+
+    if(is_unsigned)
+        return value > -1.0;
+
+    double minimum = -limit;
+    double below_minimum = minimum - 1.0;
+
+    // At 64 bits, double rounds minimum - 1 back to minimum.
+    return below_minimum == minimum ? value >= minimum : value > below_minimum;
+}
+
 #define JSONC_PARSE_BOOL_OR_ERROR_AND_RETURN(jobj, path, member, dst, error, flags) do {                     \
     json_object *_j;                                                                                            \
     if (json_object_object_get_ex(jobj, member, &_j)) {                                                         \
@@ -422,7 +450,13 @@
             dst = json_object_get_int64(_j);                                                                    \
         }                                                                                                       \
         else if (json_object_is_type(_j, json_type_double)) {                                                   \
-            dst = (typeof(dst))json_object_get_double(_j);                                                      \
+            double _val = json_object_get_double(_j);                                                           \
+            if (!jsonc_double_fits_integer_destination(                                                         \
+                    _val, sizeof(dst), JSONC_INTEGER_DESTINATION_IS_UNSIGNED(dst))) {                            \
+                buffer_sprintf(error, "cannot convert to int64 for '%s.%s'", path, member);                     \
+                return false;                                                                                   \
+            }                                                                                                   \
+            dst = (typeof(dst))_val;                                                                            \
         }                                                                                                       \
         else if (json_object_is_type(_j, json_type_boolean)) {                                                  \
             dst = json_object_get_boolean(_j) ? 1 : 0;                                                          \
@@ -458,7 +492,14 @@
             dst = json_object_get_uint64(_j);                                                                   \
         }                                                                                                       \
         else if (json_object_is_type(_j, json_type_double)) {                                                   \
-            dst = (typeof(dst))json_object_get_double(_j);                                                      \
+            double _val = json_object_get_double(_j);                                                           \
+            const double _limit = (double)(UINT64_C(1) << 63) * 2.0;                                            \
+            if (!netdata_double_isnumber(_val) || _val < 0.0 || _val >= _limit) {                              \
+                buffer_sprintf(error, "cannot convert to uint64 for '%s.%s'", path, member);                    \
+                return false;                                                                                   \
+            }                                                                                                   \
+            uint64_t _converted = (uint64_t)_val;                                                               \
+            dst = (typeof(dst))_converted;                                                                      \
         }                                                                                                       \
         else if (json_object_is_type(_j, json_type_boolean)) {                                                  \
             dst = json_object_get_boolean(_j) ? 1 : 0;                                                          \

--- a/src/libnetdata/json/json-c-parser-unittest.c
+++ b/src/libnetdata/json/json-c-parser-unittest.c
@@ -26,9 +26,37 @@ static bool wrap_parse_int64(json_object *jobj, const char *member,
     return true;
 }
 
+static bool wrap_parse_int64_to_int16(json_object *jobj, const char *member,
+                                      int16_t *dst, BUFFER *error, int flags) {
+    const char *path = "";
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, member, *dst, error, flags);
+    return true;
+}
+
+static bool wrap_parse_int64_to_int(json_object *jobj, const char *member,
+                                    int *dst, BUFFER *error, int flags) {
+    const char *path = "";
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, member, *dst, error, flags);
+    return true;
+}
+
+static bool wrap_parse_int64_to_uint32(json_object *jobj, const char *member,
+                                       uint32_t *dst, BUFFER *error, int flags) {
+    const char *path = "";
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, member, *dst, error, flags);
+    return true;
+}
+
 // --- UINT64 ---
 static bool wrap_parse_uint64(json_object *jobj, const char *member,
                               uint64_t *dst, BUFFER *error, int flags) {
+    const char *path = "";
+    JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, member, *dst, error, flags);
+    return true;
+}
+
+static bool wrap_parse_uint64_to_uint32(json_object *jobj, const char *member,
+                                        uint32_t *dst, BUFFER *error, int flags) {
     const char *path = "";
     JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, member, *dst, error, flags);
     return true;
@@ -373,11 +401,146 @@ static int test_parse_int64(void) {
     T(ok && dst == 0, "int64: int 0");
     json_object_put(root);
 
-    // --- type: double (truncated) ---
-    root = json_object_new_object();
-    json_object_object_add(root, "k", json_object_new_double(3.7));
-    dst = 0; R(); ok = wrap_parse_int64(root, "k", &dst, error, 0);
-    T(ok && dst == 3, "int64: double 3.7→3");
+    // --- type: double (truncated, with destination-aware range checks) ---
+    {
+        const double limit = (double)(UINT64_C(1) << 63);
+        const double below_limit = nextafter(limit, 0.0);
+        struct {
+            double value;
+            bool expected_ok;
+            int64_t expected;
+            const char *description;
+        } tests[] = {
+            { -INFINITY, false, 0, "int64: double -infinity rejected" },
+            { nextafter(-limit, -INFINITY), false, 0, "int64: double below INT64_MIN rejected" },
+            { -limit, true, INT64_MIN, "int64: double INT64_MIN accepted" },
+            { -3.7, true, -3, "int64: double -3.7→-3" },
+            { 3.7, true, 3, "int64: double 3.7→3" },
+            { below_limit, true, (int64_t)below_limit, "int64: largest double below 2^63 accepted" },
+            { limit, false, 0, "int64: double 2^63 rejected" },
+            { INFINITY, false, 0, "int64: double infinity rejected" },
+            { NAN, false, 0, "int64: double NaN rejected" },
+        };
+
+        for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+            root = json_object_new_object();
+            json_object_object_add(root, "k", json_object_new_double(tests[i].value));
+            dst = INT64_C(0x123456789); R();
+            ok = wrap_parse_int64(root, "k", &dst, error, JSONC_OPTIONAL);
+            T(ok == tests[i].expected_ok && (!ok || dst == tests[i].expected), tests[i].description);
+            T(ok || dst == INT64_C(0x123456789), "int64: rejected double leaves destination unchanged");
+            json_object_put(root);
+        }
+    }
+
+    // Narrow signed destinations retain every value whose truncated result fits.
+    {
+        int16_t dst16;
+        struct {
+            double value;
+            bool expected_ok;
+            int16_t expected;
+            const char *description;
+        } tests[] = {
+            { (double)INT16_MIN - 0.5, true, INT16_MIN, "int16: fractional lower endpoint accepted" },
+            { (double)INT16_MIN - 1.0, false, 0, "int16: value below lower endpoint rejected" },
+            { (double)INT16_MAX + 0.5, true, INT16_MAX, "int16: fractional upper endpoint accepted" },
+            { (double)INT16_MAX + 1.0, false, 0, "int16: value above upper endpoint rejected" },
+        };
+
+        for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+            root = json_object_new_object();
+            json_object_object_add(root, "k", json_object_new_double(tests[i].value));
+            dst16 = 1234; R();
+            ok = wrap_parse_int64_to_int16(root, "k", &dst16, error, JSONC_OPTIONAL);
+            T(ok == tests[i].expected_ok && (!ok || dst16 == tests[i].expected), tests[i].description);
+            T(ok || dst16 == 1234, "int16: rejected double leaves destination unchanged");
+            json_object_put(root);
+        }
+    }
+
+    {
+        int dst_int;
+        const double lower = -(double)(UINT64_C(1) << (sizeof(dst_int) * CHAR_BIT - 1));
+        const double upper = -lower;
+        struct {
+            double value;
+            bool expected_ok;
+            int expected;
+            const char *description;
+        } tests[] = {
+            { lower - 0.5, true, INT_MIN, "int: fractional lower endpoint accepted" },
+            { lower - 1.0, false, 0, "int: value below lower endpoint rejected" },
+            { upper - 0.5, true, INT_MAX, "int: fractional upper endpoint accepted" },
+            { upper, false, 0, "int: value above upper endpoint rejected" },
+        };
+
+        for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+            root = json_object_new_object();
+            json_object_object_add(root, "k", json_object_new_double(tests[i].value));
+            dst_int = 123456; R();
+            ok = wrap_parse_int64_to_int(root, "k", &dst_int, error, JSONC_OPTIONAL);
+            T(ok == tests[i].expected_ok && (!ok || dst_int == tests[i].expected), tests[i].description);
+            T(ok || dst_int == 123456, "int: rejected double leaves destination unchanged");
+            json_object_put(root);
+        }
+    }
+
+    // The signed macro also has uint32_t destinations in current stream and health callers.
+    {
+        uint32_t dst32;
+        const double upper = (double)(UINT64_C(1) << 32);
+        struct {
+            double value;
+            bool expected_ok;
+            uint32_t expected;
+            const char *description;
+        } tests[] = {
+            { -1.0, false, 0, "int64-to-uint32: -1 rejected" },
+            { -0.5, true, 0, "int64-to-uint32: negative fraction truncates to zero" },
+            { upper - 0.5, true, UINT32_MAX, "int64-to-uint32: fractional upper endpoint accepted" },
+            { upper, false, 0, "int64-to-uint32: 2^32 rejected" },
+        };
+
+        for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+            root = json_object_new_object();
+            json_object_object_add(root, "k", json_object_new_double(tests[i].value));
+            dst32 = UINT32_C(123456); R();
+            ok = wrap_parse_int64_to_uint32(root, "k", &dst32, error, JSONC_OPTIONAL);
+            T(ok == tests[i].expected_ok && (!ok || dst32 == tests[i].expected), tests[i].description);
+            T(ok || dst32 == UINT32_C(123456), "int64-to-uint32: rejected double leaves destination unchanged");
+            json_object_put(root);
+        }
+    }
+
+    // Exact integer syntax remains on json-c's integer branch without double rounding.
+    root = json_tokener_parse("{\"k\":9223372036854775807}");
+    json_object *integer_value = NULL;
+    T(root && json_object_object_get_ex(root, "k", &integer_value) &&
+      json_object_is_type(integer_value, json_type_int),
+      "int64: parsed INT64_MAX uses json_type_int");
+    dst = 0; R(); ok = wrap_parse_int64(root, "k", &dst, error, JSONC_OPTIONAL);
+    T(ok && dst == INT64_MAX, "int64: parsed integer INT64_MAX preserved exactly");
+    json_object_put(root);
+
+    root = json_tokener_parse("{\"k\":-9223372036854775808}");
+    dst = 0; R(); ok = wrap_parse_int64(root, "k", &dst, error, JSONC_OPTIONAL);
+    T(ok && dst == INT64_MIN, "int64: parsed integer INT64_MIN preserved exactly");
+    json_object_put(root);
+
+    root = json_tokener_parse("{\"k\":9223372036854775807.0}");
+    dst = 0; R(); ok = wrap_parse_int64(root, "k", &dst, error, JSONC_OPTIONAL);
+    T(!ok, "int64: parsed double rounded to 2^63 rejected");
+    json_object_put(root);
+
+    root = json_tokener_parse("{\"k\":-9223372036854775808.0}");
+    dst = 0; R(); ok = wrap_parse_int64(root, "k", &dst, error, JSONC_OPTIONAL);
+    T(ok && dst == INT64_MIN, "int64: parsed double INT64_MIN accepted");
+    json_object_put(root);
+
+    root = json_tokener_parse("{\"k\":1e400}");
+    dst = 0; R(); ok = wrap_parse_int64(root, "k", &dst, error, JSONC_OPTIONAL);
+    T(!ok, "int64: parsed exponent overflow rejected");
     json_object_put(root);
 
     // --- type: boolean ---
@@ -492,10 +655,90 @@ static int test_parse_uint64(void) {
     json_object_put(root);
 
     // --- type: double ---
-    root = json_object_new_object();
-    json_object_object_add(root, "k", json_object_new_double(3.7));
-    dst = 0; R(); ok = wrap_parse_uint64(root, "k", &dst, error, 0);
-    T(ok && dst == 3, "uint64: double 3.7→3");
+    {
+        struct {
+            double value;
+            bool expected_ok;
+            uint64_t expected;
+            const char *description;
+        } tests[] = {
+            { -INFINITY, false, 0, "uint64: double -infinity rejected" },
+            { -1.0, false, 0, "uint64: double -1 rejected" },
+            { -0.5, false, 0, "uint64: negative fractional double rejected" },
+            { -0.0, true, 0, "uint64: double -0.0→0" },
+            { 0.5, true, 0, "uint64: double 0.5→0" },
+            { 3.7, true, 3, "uint64: double 3.7→3" },
+            { INFINITY, false, 0, "uint64: double infinity rejected" },
+            { NAN, false, 0, "uint64: double NaN rejected" },
+        };
+
+        for(size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+            root = json_object_new_object();
+            json_object_object_add(root, "k", json_object_new_double(tests[i].value));
+            dst = UINT64_C(0x123456789); R();
+            ok = wrap_parse_uint64(root, "k", &dst, error, JSONC_OPTIONAL);
+            T(ok == tests[i].expected_ok && (!ok || dst == tests[i].expected), tests[i].description);
+            json_object_put(root);
+        }
+
+        const double limit = (double)(UINT64_C(1) << 63) * 2.0;
+        const double below_limit = nextafter(limit, 0.0);
+
+        root = json_object_new_object();
+        json_object_object_add(root, "k", json_object_new_double(below_limit));
+        dst = 0; R(); ok = wrap_parse_uint64(root, "k", &dst, error, JSONC_OPTIONAL);
+        T(ok && dst == (uint64_t)below_limit, "uint64: largest double below 2^64 accepted");
+        json_object_put(root);
+
+        root = json_object_new_object();
+        json_object_object_add(root, "k", json_object_new_double(limit));
+        dst = 0; R(); ok = wrap_parse_uint64(root, "k", &dst, error, JSONC_OPTIONAL);
+        T(!ok, "uint64: double 2^64 rejected");
+        json_object_put(root);
+
+        const double uint64_max_as_double = (double)UINT64_MAX;
+        root = json_object_new_object();
+        json_object_object_add(root, "k", json_object_new_double(uint64_max_as_double));
+        dst = 0; R(); ok = wrap_parse_uint64(root, "k", &dst, error, JSONC_OPTIONAL);
+        if(uint64_max_as_double < limit)
+            T(ok && dst == UINT64_MAX, "uint64: representable double UINT64_MAX accepted");
+        else
+            T(!ok, "uint64: rounded double UINT64_MAX rejected at 2^64");
+        json_object_put(root);
+    }
+
+    // The macro parses uint64 first, then preserves the integer branch's
+    // existing assignment conversion for narrower destinations.
+    {
+        const double above_uint32 = (double)UINT32_MAX + 1.0;
+        uint32_t dst32 = UINT32_MAX;
+
+        root = json_object_new_object();
+        json_object_object_add(root, "k", json_object_new_double(above_uint32));
+        R(); ok = wrap_parse_uint64_to_uint32(root, "k", &dst32, error, JSONC_OPTIONAL);
+        T(ok && dst32 == 0, "uint64: valid double narrows like integer path");
+        json_object_put(root);
+    }
+
+    // json-c retains integer syntax through its uint64 representation, without
+    // rounding UINT64_MAX through double.
+    root = json_tokener_parse("{\"k\":18446744073709551615}");
+    json_object *integer_value = NULL;
+    T(root && json_object_object_get_ex(root, "k", &integer_value) &&
+      json_object_is_type(integer_value, json_type_int),
+      "uint64: parsed UINT64_MAX uses json_type_int");
+    dst = 0; R(); ok = wrap_parse_uint64(root, "k", &dst, error, JSONC_OPTIONAL);
+    T(ok && dst == UINT64_MAX, "uint64: parsed integer UINT64_MAX preserved exactly");
+    json_object_put(root);
+
+    root = json_tokener_parse("{\"k\":18446744073709551615.0}");
+    dst = 0; R(); ok = wrap_parse_uint64(root, "k", &dst, error, JSONC_OPTIONAL);
+    T(!ok, "uint64: parsed double rounded to 2^64 rejected");
+    json_object_put(root);
+
+    root = json_tokener_parse("{\"k\":1e400}");
+    dst = 0; R(); ok = wrap_parse_uint64(root, "k", &dst, error, JSONC_OPTIONAL);
+    T(!ok, "uint64: parsed exponent overflow rejected");
     json_object_put(root);
 
     // --- type: boolean ---

--- a/src/libnetdata/parsers/entries.c
+++ b/src/libnetdata/parsers/entries.c
@@ -51,7 +51,10 @@ static inline double entries_round_to_resolution_dbl2(uint64_t value, uint64_t r
 }
 
 static inline uint64_t entries_round_to_resolution_int(uint64_t value, uint64_t resolution) {
-    return (value + (resolution / 2)) / resolution;
+    uint64_t quotient = value / resolution;
+    uint64_t remainder = value % resolution;
+
+    return quotient + (remainder >= resolution - resolution / 2);
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/src/libnetdata/parsers/size.c
+++ b/src/libnetdata/parsers/size.c
@@ -79,7 +79,10 @@ static inline double size_round_to_resolution_dbl2(uint64_t value, uint64_t reso
 }
 
 static inline uint64_t size_round_to_resolution_int(uint64_t value, uint64_t resolution) {
-    return (value + (resolution / 2)) / resolution;
+    uint64_t quotient = value / resolution;
+    uint64_t remainder = value % resolution;
+
+    return quotient + (remainder >= resolution - resolution / 2);
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/src/streaming/stream-circular-buffer.c
+++ b/src/streaming/stream-circular-buffer.c
@@ -28,7 +28,10 @@ static inline void stream_circular_buffer_stats_update_unsafe(STREAM_CIRCULAR_BU
     scb->stats.bytes_max_size = scb->cb->max_size;
     scb->stats.bytes_outstanding = cbuffer_next_unsafe(scb->cb, NULL);
     scb->stats.bytes_available = cbuffer_available_size_unsafe(scb->cb);
-    scb->stats.buffer_ratio = (double)(scb->cb->max_size -  scb->stats.bytes_available) * 100.0 / (double)scb->cb->max_size;
+    if(unlikely(!scb->cb->max_size))
+        scb->stats.buffer_ratio = 0.0;
+    else
+        scb->stats.buffer_ratio = (double)(scb->cb->max_size -  scb->stats.bytes_available) * 100.0 / (double)scb->cb->max_size;
 
     __atomic_store_n(&((scb)->atomic.buffer_ratio), (size_t)round(scb->stats.buffer_ratio), __ATOMIC_RELAXED);
 }

--- a/src/web/api/http_header.c
+++ b/src/web/api/http_header.c
@@ -250,6 +250,26 @@ static void http_header_sec_websocket_protocol(struct web_client *w, const char 
     w->websocket.protocol = WEBSOCKET_PROTOCOL_2id(v);
 }
 
+static bool http_header_parse_websocket_window_bits(const char *value, uint8_t *window_bits) {
+    while(isspace((uint8_t)*value))
+        value++;
+
+    unsigned int parsed = 0;
+    while(*value >= '0' && *value <= '9') {
+        unsigned int digit = (unsigned int)(*value++ - '0');
+        if(parsed > (15U - digit) / 10U)
+            return false;
+
+        parsed = parsed * 10U + digit;
+    }
+
+    if(parsed < 8U)
+        return false;
+
+    *window_bits = (uint8_t)parsed;
+    return true;
+}
+
 static void http_header_sec_websocket_extensions(struct web_client *w, const char *v, size_t len __maybe_unused) {
     // Reset extension flags
     w->websocket.ext_flags = WS_EXTENSION_NONE;
@@ -298,8 +318,8 @@ static void http_header_sec_websocket_extensions(struct web_client *w, const cha
 
                         // Server max window bits
                         else if (strncmp(param, "server_max_window_bits=", 23) == 0) {
-                            w->websocket.server_max_window_bits = str2u(param + 23);
-                            if(w->websocket.server_max_window_bits >= 8 && w->websocket.server_max_window_bits <= 15)
+                            if(http_header_parse_websocket_window_bits(
+                                    param + 23, &w->websocket.server_max_window_bits))
                                 w->websocket.ext_flags |= WS_EXTENSION_SERVER_MAX_WINDOW_BITS;
                         }
                         // Server max window bits without value
@@ -310,8 +330,8 @@ static void http_header_sec_websocket_extensions(struct web_client *w, const cha
 
                         // Client max window bits with value
                         else if (strncmp(param, "client_max_window_bits=", 23) == 0) {
-                            w->websocket.client_max_window_bits = str2u(param + 23);
-                            if(w->websocket.client_max_window_bits >= 8 && w->websocket.client_max_window_bits <= 15)
+                            if(http_header_parse_websocket_window_bits(
+                                    param + 23, &w->websocket.client_max_window_bits))
                                 w->websocket.ext_flags |= WS_EXTENSION_CLIENT_MAX_WINDOW_BITS;
                         }
                         // Client max window bits without value

--- a/src/web/api/queries/percentile/percentile.h
+++ b/src/web/api/queries/percentile/percentile.h
@@ -128,28 +128,28 @@ static inline NETDATA_DOUBLE tg_percentile_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr
                 percent_last_slot = 1 - percent_interpolation_slot;
             }
 
-            int start_slot, stop_slot, step, last_slot, interpolation_slot;
+            ssize_t start_slot, stop_slot, step, last_slot, interpolation_slot;
             if(min >= 0.0 && max >= 0.0) {
                 start_slot = 0;
-                stop_slot = start_slot + (int)slots_to_use;
+                stop_slot = start_slot + (ssize_t)slots_to_use;
                 last_slot = stop_slot - 1;
                 interpolation_slot = stop_slot;
                 step = 1;
             }
             else {
-                start_slot = (int)available_slots - 1;
-                stop_slot = start_slot - (int)slots_to_use;
+                start_slot = (ssize_t)available_slots - 1;
+                stop_slot = start_slot - (ssize_t)slots_to_use;
                 last_slot = stop_slot + 1;
                 interpolation_slot = stop_slot;
                 step = -1;
             }
 
             value = 0.0;
-            for(int slot = start_slot; slot != stop_slot ; slot += step)
+            for(ssize_t slot = start_slot; slot != stop_slot ; slot += step)
                 value += g->series[slot];
 
             size_t counted = slots_to_use;
-            if(percent_interpolation_slot > 0.0 && interpolation_slot >= 0 && interpolation_slot < (int)available_slots) {
+            if(percent_interpolation_slot > 0.0 && interpolation_slot >= 0 && interpolation_slot < (ssize_t)available_slots) {
                 value += g->series[interpolation_slot] * percent_interpolation_slot;
                 value += g->series[last_slot] * percent_last_slot;
                 counted++;

--- a/src/web/api/queries/trimmed_mean/trimmed_mean.h
+++ b/src/web/api/queries/trimmed_mean/trimmed_mean.h
@@ -125,28 +125,28 @@ static inline NETDATA_DOUBLE tg_trimmed_mean_flush(RRDR *r, RRDR_VALUE_FLAGS *rr
                 percent_last_slot = 1 - percent_interpolation_slot;
             }
 
-            int start_slot, stop_slot, step, last_slot, interpolation_slot;
+            ssize_t start_slot, stop_slot, step, last_slot, interpolation_slot;
             if(min >= 0.0 && max >= 0.0) {
-                start_slot = (int)((available_slots - slots_to_use) / 2);
-                stop_slot = start_slot + (int)slots_to_use;
+                start_slot = (ssize_t)((available_slots - slots_to_use) / 2);
+                stop_slot = start_slot + (ssize_t)slots_to_use;
                 last_slot = stop_slot - 1;
                 interpolation_slot = stop_slot;
                 step = 1;
             }
             else {
-                start_slot = (int)available_slots - 1 - (int)((available_slots - slots_to_use) / 2);
-                stop_slot = start_slot - (int)slots_to_use;
+                start_slot = (ssize_t)available_slots - 1 - (ssize_t)((available_slots - slots_to_use) / 2);
+                stop_slot = start_slot - (ssize_t)slots_to_use;
                 last_slot = stop_slot + 1;
                 interpolation_slot = stop_slot;
                 step = -1;
             }
 
             value = 0.0;
-            for(int slot = start_slot; slot != stop_slot ; slot += step)
+            for(ssize_t slot = start_slot; slot != stop_slot ; slot += step)
                 value += g->series[slot];
 
             size_t counted = slots_to_use;
-            if(percent_interpolation_slot > 0.0 && interpolation_slot >= 0 && interpolation_slot < (int)available_slots) {
+            if(percent_interpolation_slot > 0.0 && interpolation_slot >= 0 && interpolation_slot < (ssize_t)available_slots) {
                 value += g->series[interpolation_slot] * percent_interpolation_slot;
                 value += g->series[last_slot] * percent_last_slot;
                 counted++;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens numeric parsing and aggregation to prevent overflows, invalid casts, and divide-by-zero across JSON, HTTP/WebSocket, parsers, and streaming. Also tightens `apps.plugin` `--pss` duration handling and expands unit tests.

- **Bug Fixes**
  - JSON: validate double-to-integer conversions by destination width and signedness; reject NaN/Inf and out-of-range; extend unit tests.
  - Parsers: fix unsigned rounding overflow in size/entries by using quotient/remainder; correct nearest rounding without wrap.
  - Streaming: avoid divide-by-zero; report 0% utilization for zero-capacity circular buffers.
  - HTTP: bound WebSocket `server_max_window_bits` and `client_max_window_bits` to 8–15 with safe parsing.
  - Queries: use `ssize_t` indexes in percentile and trimmed-mean to keep large series in-bounds.
  - `apps.plugin`: reject `--pss` durations > `INT_MAX`; remove post-cast clamp while preserving valid ranges.

<sup>Written for commit e63511ab62b1705f21a46cb2ab035d4dcd2ff929. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

