### PR TITLE
Netdata fixes part 71

### DIFF
--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -514,16 +514,18 @@ static int aclk_get_transport_idx(aclk_env_t *env) {
 ACLK_STATUS aclk_status = ACLK_STATUS_OFFLINE;
 
 const char *aclk_status_to_string(void) {
-    if(aclk_status == ACLK_STATUS_CONNECTED)
+    ACLK_STATUS status = __atomic_load_n(&aclk_status, __ATOMIC_RELAXED);
+
+    if(status == ACLK_STATUS_CONNECTED)
         return "connected";
 
-    if((int)aclk_status < (int)ND_SOCK_ERR_MAX)
-        return ND_SOCK_ERROR_2str((ND_SOCK_ERROR)aclk_status);
+    if((int)status < (int)ND_SOCK_ERR_MAX)
+        return ND_SOCK_ERROR_2str((ND_SOCK_ERROR)status);
 
-    if((int)aclk_status < (int)HTTPS_CLIENT_RESP_MAX)
-        return https_client_resp_t_2str((https_client_resp_t)aclk_status);
+    if((int)status < (int)HTTPS_CLIENT_RESP_MAX)
+        return https_client_resp_t_2str((https_client_resp_t)status);
 
-    switch(aclk_status) {
+    switch(status) {
         case ACLK_STATUS_CONNECTED:
             return "connected";
 
@@ -593,7 +595,7 @@ const char *aclk_status_to_string(void) {
 }
 
 void aclk_status_set(ACLK_STATUS status) {
-    aclk_status = status;
+    __atomic_store_n(&aclk_status, status, __ATOMIC_RELAXED);
 
     ND_LOG_STACK lgs[] = {
         ND_LOG_FIELD_UUID(NDF_MESSAGE_ID, &aclk_connection_msgid),

--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -1067,7 +1067,7 @@ static void fill_alert_status_for_host(BUFFER *wb, RRDHOST *host)
         "\n\t\tCheckpoints: %d"
         "\n\t\tAlert count: %d"
         "\n\t\tAlert snapshot count: %d",
-        aclk_host_config->stream_alerts,
+        aclk_alert_streaming_enabled(aclk_host_config),
         aclk_host_config->checkpoint_count,
         aclk_host_config->alert_count,
         aclk_host_config->snapshot_count);
@@ -1191,7 +1191,7 @@ static void fill_alert_status_for_host_json(json_object *obj, RRDHOST *host)
     if (!aclk_host_config)
         return;
 
-    json_object *tmp = json_object_new_int(aclk_host_config->stream_alerts);
+    json_object *tmp = json_object_new_int(aclk_alert_streaming_enabled(aclk_host_config));
     json_object_object_add(obj, "updates", tmp);
 
     tmp = json_object_new_int(aclk_host_config->checkpoint_count);

--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -65,9 +65,6 @@ int aclk_disable_runtime = 0;
 
 ACLK_DISCONNECT_ACTION disconnect_req = ACLK_NO_DISCONNECT;
 
-usec_t aclk_session_us = 0;
-time_t aclk_session_sec = 0;
-
 time_t last_conn_time_mqtt = 0;
 time_t last_conn_time_appl = 0;
 time_t last_disconnect_time = 0;
@@ -752,9 +749,7 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
         }
 #endif
 
-        aclk_session_newarch = now_realtime_usec();
-        aclk_session_sec = aclk_session_newarch / USEC_PER_SEC;
-        aclk_session_us = aclk_session_newarch % USEC_PER_SEC;
+        aclk_session_store(now_realtime_usec());
 
         mqtt_conn_params.will_msg = aclk_generate_lwt(&mqtt_conn_params.will_msg_len);
 
@@ -1007,7 +1002,7 @@ void aclk_update_node_instance_job(RRDHOST *host, int live, int queryable, struc
         .hops = hops,
         .live = live,
         .queryable = queryable,
-        .session_id = aclk_session_newarch};
+        .session_id = aclk_session_load()};
 
     char node_id[UUID_STR_LEN];
     uuid_unparse_lower(host->node_id.uuid, node_id);

--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -443,7 +443,7 @@ static unsigned long aclk_reconnect_delay() {
     unsigned long recon_delay;
     time_t now;
 
-    if (aclk_disable_runtime) {
+    if (__atomic_load_n(&aclk_disable_runtime, __ATOMIC_RELAXED)) {
         aclk_tbeb_reset();
         return 60 * MSEC_PER_SEC;
     }
@@ -1125,8 +1125,9 @@ char *aclk_state(void)
     time_t next_connection_attempt_snapshot = __atomic_load_n(&next_connection_attempt, __ATOMIC_RELAXED);
     float last_backoff_value_snapshot;
     __atomic_load(&last_backoff_value, &last_backoff_value_snapshot, __ATOMIC_RELAXED);
+    bool disable_runtime = __atomic_load_n(&aclk_disable_runtime, __ATOMIC_RELAXED);
 
-    buffer_sprintf(wb, "Online: %s\nReconnect count: %d\nBanned By Cloud: %s\n", aclk_is_online ? "Yes" : "No", connection_counter > 0 ? (connection_counter - 1) : 0, aclk_disable_runtime ? "Yes" : "No");
+    buffer_sprintf(wb, "Online: %s\nReconnect count: %d\nBanned By Cloud: %s\n", aclk_is_online ? "Yes" : "No", connection_counter > 0 ? (connection_counter - 1) : 0, disable_runtime ? "Yes" : "No");
     if (last_conn_time_mqtt_snapshot && ((tmptr = localtime_r(&last_conn_time_mqtt_snapshot, &tmbuf))) ) {
         char timebuf[26];
         strftime(timebuf, 26, "%Y-%m-%d %H:%M:%S", tmptr);
@@ -1315,7 +1316,7 @@ char *aclk_state_json(void)
         tmp = json_object_new_double(last_backoff_value_snapshot);
     json_object_object_add(msg, "last-backoff-value", tmp);
 
-    tmp = json_object_new_boolean(aclk_disable_runtime);
+    tmp = json_object_new_boolean(__atomic_load_n(&aclk_disable_runtime, __ATOMIC_RELAXED));
     json_object_object_add(msg, "banned-by-cloud", tmp);
 
     grp = json_object_new_array();

--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -342,9 +342,11 @@ static int handle_connection(mqtt_wss_client client)
             return 1;
         }
 
-        if (disconnect_req != ACLK_NO_DISCONNECT) {
+        ACLK_DISCONNECT_ACTION action = __atomic_load_n(&disconnect_req, __ATOMIC_RELAXED);
+        if (action != ACLK_NO_DISCONNECT) {
+            action = __atomic_exchange_n(&disconnect_req, ACLK_NO_DISCONNECT, __ATOMIC_RELAXED);
             const char *reason;
-            switch (disconnect_req) {
+            switch (action) {
                 case ACLK_CLOUD_DISCONNECT:
                     worker_is_busy(WORKER_ACLK_CMD_DISCONNECT);
                     reason = "cloud request";
@@ -370,7 +372,6 @@ static int handle_connection(mqtt_wss_client client)
 
             nd_log(NDLS_DAEMON, NDLP_NOTICE, "Going to restart connection due to \"%s\"", reason);
 
-            disconnect_req = ACLK_NO_DISCONNECT;
             aclk_graceful_disconnect(client);
             aclk_shared_state.mqtt_shutdown_msg_id = -1;
             aclk_shared_state.mqtt_shutdown_msg_rcvd = 0;

--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -109,7 +109,6 @@ static void aclk_ssl_keylog_cb(const SSL *ssl, const char *line)
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
-OSSL_DECODER_CTX *aclk_dctx = NULL;
 EVP_PKEY *aclk_private_key = NULL;
 #else
 static RSA *aclk_private_key = NULL;
@@ -119,10 +118,6 @@ static int load_private_key()
     if (aclk_private_key != NULL) {
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
         EVP_PKEY_free(aclk_private_key);
-        if (aclk_dctx)
-            OSSL_DECODER_CTX_free(aclk_dctx);
-
-        aclk_dctx = NULL;
 #else
         RSA_free(aclk_private_key);
 #endif
@@ -139,44 +134,57 @@ static int load_private_key()
     }
     netdata_log_debug(D_ACLK, "Claimed agent loaded private key len=%ld bytes", bytes_read);
 
+    int rc = 1;
     BIO *key_bio = BIO_new_mem_buf(private_key, -1);
     if (key_bio==NULL) {
         netdata_log_error("ACLK: Claimed agent cannot establish ACLK - failed to create BIO for key");
-        goto biofailed;
+        goto cleanup;
     }
 
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
-    aclk_dctx = OSSL_DECODER_CTX_new_for_pkey(&aclk_private_key, "PEM", NULL,
-                                              "RSA",
-                                              OSSL_KEYMGMT_SELECT_PRIVATE_KEY,
-                                              NULL, NULL);
+    OSSL_DECODER_CTX *dctx = OSSL_DECODER_CTX_new_for_pkey(&aclk_private_key, "PEM", NULL,
+                                                          "RSA",
+                                                          OSSL_KEYMGMT_SELECT_PRIVATE_KEY,
+                                                          NULL, NULL);
 
-    if (!aclk_dctx) {
+    if (!dctx) {
         netdata_log_error("ACLK: Loading private key (from claiming) failed - no OpenSSL Decoders found");
-        goto biofailed;
+        goto cleanup;
     }
 
     // this is necesseary to avoid RSA key with wrong size
-    if (!OSSL_DECODER_from_bio(aclk_dctx, key_bio)) {
+    int decoded = OSSL_DECODER_from_bio(dctx, key_bio);
+    OSSL_DECODER_CTX_free(dctx);
+    if (!decoded) {
         netdata_log_error("ACLK: Decoding private key (from claiming) failed - invalid format.");
-        goto biofailed;
+        goto cleanup;
     }
 #else
     aclk_private_key = PEM_read_bio_RSAPrivateKey(key_bio, NULL, NULL, NULL);
-#endif
     BIO_free(key_bio);
+    key_bio = NULL;
+#endif
     if (aclk_private_key!=NULL)
-    {
-        freez(private_key);
-        return 0;
+        rc = 0;
+    else {
+        char err[512];
+        ERR_error_string_n(ERR_get_error(), err, sizeof(err));
+        netdata_log_error("ACLK: Claimed agent cannot establish ACLK - cannot create private key: %s", err);
     }
-    char err[512];
-    ERR_error_string_n(ERR_get_error(), err, sizeof(err));
-    netdata_log_error("ACLK: Claimed agent cannot establish ACLK - cannot create private key: %s", err);
 
-biofailed:
+cleanup:
+    if (key_bio)
+        BIO_free(key_bio);
+    if (rc && aclk_private_key) {
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
+        EVP_PKEY_free(aclk_private_key);
+#else
+        RSA_free(aclk_private_key);
+#endif
+        aclk_private_key = NULL;
+    }
     freez(private_key);
-    return 1;
+    return rc;
 }
 
 /**

--- a/src/aclk/aclk.h
+++ b/src/aclk/aclk.h
@@ -77,9 +77,6 @@ extern time_t last_disconnect_time;
 extern time_t next_connection_attempt;
 extern float last_backoff_value;
 
-extern usec_t aclk_session_us;
-extern time_t aclk_session_sec;
-
 extern time_t aclk_block_until;
 
 extern int aclk_connection_counter;

--- a/src/aclk/aclk_otp.c
+++ b/src/aclk/aclk_otp.c
@@ -183,7 +183,7 @@ static int aclk_parse_otp_error(const char *json_str) {
     }
 
     if (block_retry > 0)
-        aclk_disable_runtime = 1;
+        __atomic_store_n(&aclk_disable_runtime, 1, __ATOMIC_RELAXED);
 
     if (backoff > 0)
         aclk_block_until = now_monotonic_sec() + backoff;
@@ -263,7 +263,7 @@ static int aclk_parse_otp_error(const char *json_str) {
     }
 
     if (block_retry > 0)
-        aclk_disable_runtime = 1;
+        __atomic_store_n(&aclk_disable_runtime, 1, __ATOMIC_RELAXED);
 
     if (backoff > 0)
         aclk_block_until = now_monotonic_sec() + backoff;

--- a/src/aclk/aclk_query.c
+++ b/src/aclk/aclk_query.c
@@ -222,5 +222,6 @@ int send_bin_msg(mqtt_wss_client client, aclk_query_t *query)
         query->data.bin_payload.size,
         query->data.bin_payload.topic,
         query->data.bin_payload.msg_name);
+    query->data.bin_payload.payload = NULL;
     return 0;
 }

--- a/src/aclk/aclk_query_queue.c
+++ b/src/aclk/aclk_query_queue.c
@@ -90,6 +90,16 @@ void aclk_query_free(aclk_query_t *query)
             freez(query->data.node_id);
             freez(query->machine_guid);
             break;
+        case ALARM_PROVIDE_CFG:
+        case ALARM_SNAPSHOT:
+        case REGISTER_NODE:
+        case NODE_STATE_UPDATE:
+        case UPDATE_NODE_INFO:
+        case UPDATE_NODE_COLLECTORS:
+        case CTX_SEND_SNAPSHOT:
+        case CTX_SEND_SNAPSHOT_UPD:
+            freez(query->data.bin_payload.payload);
+            break;
         // keep following cases together
         case CTX_STOP_STREAMING:
         case CTX_CHECKPOINT:

--- a/src/aclk/aclk_rx_msgs.c
+++ b/src/aclk/aclk_rx_msgs.c
@@ -379,7 +379,7 @@ int handle_disconnect_req(const char *msg, size_t msg_len)
             "Cloud asks not to reconnect for %u seconds. We shall honor that request",
             (unsigned int)cmd->reconnect_after_s);
     }
-    disconnect_req = ACLK_CLOUD_DISCONNECT;
+    __atomic_store_n(&disconnect_req, ACLK_CLOUD_DISCONNECT, __ATOMIC_RELAXED);
     freez(cmd->error_description);
     freez(cmd);
     return 0;

--- a/src/aclk/aclk_rx_msgs.c
+++ b/src/aclk/aclk_rx_msgs.c
@@ -370,7 +370,7 @@ int handle_disconnect_req(const char *msg, size_t msg_len)
         return 1;
     if (cmd->permaban) {
         netdata_log_error("Cloud Banned This Agent!");
-        aclk_disable_runtime = 1;
+        __atomic_store_n(&aclk_disable_runtime, 1, __ATOMIC_RELAXED);
     }
     netdata_log_info("Cloud requested disconnect (EC=%u, \"%s\")", (unsigned int)cmd->error_code, cmd->error_description);
     if (cmd->reconnect_after_s > 0) {

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -140,12 +140,14 @@ static struct json_object *create_hdr(const char *type, const char *msg_id)
     tmp = json_object_new_int64(ts_us);
     json_object_object_add(obj, "timestamp-offset-usec", tmp);
 
-    tmp = json_object_new_int64(aclk_session_sec);
+    usec_t session = aclk_session_load();
+
+    tmp = json_object_new_int64(session / USEC_PER_SEC);
     json_object_object_add(obj, "connect", tmp);
 
 // TODO handle this somehow see above
-//    tmp = json_object_new_uint64(0 /* TODO aclk_session_us */);
-    tmp = json_object_new_int64(aclk_session_us);
+//    tmp = json_object_new_uint64(session % USEC_PER_SEC);
+    tmp = json_object_new_int64(session % USEC_PER_SEC);
     json_object_object_add(obj, "connect-offset-usec", tmp);
 
     tmp = json_object_new_int(ACLK_HEADER_VERSION);
@@ -299,7 +301,7 @@ uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable
     update_agent_connection_t conn = {
         .reachable = (reachable ? 1 : 0),
         .lwt = 0,
-        .session_id = aclk_session_newarch,
+        .session_id = aclk_session_load(),
         .capabilities = aclk_get_agent_capas(),
     };
 
@@ -333,7 +335,7 @@ char *aclk_generate_lwt(size_t *size) {
     update_agent_connection_t conn = {
         .reachable = 0,
         .lwt = 1,
-        .session_id = aclk_session_newarch,
+        .session_id = aclk_session_load(),
         .capabilities = NULL
     };
 

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -36,6 +36,7 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
 
     if (unlikely(!topic)) {
         netdata_log_error("Couldn't get topic. Aborting message send.");
+        freez(msg);
         return 0;
     }
 

--- a/src/aclk/aclk_tx_msgs.h
+++ b/src/aclk/aclk_tx_msgs.h
@@ -8,6 +8,7 @@
 #include "schema-wrappers/schema_wrappers.h"
 #include "aclk_util.h"
 
+// Consumes msg on every return path.
 uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname);
 
 void aclk_http_msg_v2_err(mqtt_wss_client client, const char *topic, const char *msg_id, int http_code, int ec, const char* emsg, const char *payload, size_t payload_len);

--- a/src/aclk/aclk_util.h
+++ b/src/aclk/aclk_util.h
@@ -22,6 +22,14 @@
 // and are supposed not to be needed outside of ACLK
 extern usec_t aclk_session_newarch;
 
+static inline usec_t aclk_session_load(void) {
+    return __atomic_load_n(&aclk_session_newarch, __ATOMIC_RELAXED);
+}
+
+static inline void aclk_session_store(usec_t session) {
+    __atomic_store_n(&aclk_session_newarch, session, __ATOMIC_RELAXED);
+}
+
 extern int chart_batch_id;
 
 typedef enum {

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -725,7 +725,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
             worker_is_busy(WORKER_ACLK_SENT_PING);
         } else {
             if (ping_timeout && ping_timeout < now) {
-                disconnect_req = ACLK_PING_TIMEOUT;
+                __atomic_store_n(&disconnect_req, ACLK_PING_TIMEOUT, __ATOMIC_RELAXED);
                 ping_timeout = 0;
             }
             // if poll timed out and user requested timeout was being used

--- a/src/aclk/schema-wrappers/alarm_stream.cc
+++ b/src/aclk/schema-wrappers/alarm_stream.cc
@@ -202,6 +202,11 @@ alarm_snapshot_proto_ptr_t generate_alarm_snapshot_proto(struct alarm_snapshot *
     return msg;
 }
 
+void destroy_alarm_snapshot_proto(alarm_snapshot_proto_ptr_t snapshot)
+{
+    delete (AlarmSnapshot *)snapshot;
+}
+
 void add_alarm_log_entry2snapshot(alarm_snapshot_proto_ptr_t snapshot, struct alarm_log_entry *data)
 {
     AlarmSnapshot *alarm_snapshot = (AlarmSnapshot *)snapshot;
@@ -219,10 +224,10 @@ char *generate_alarm_snapshot_bin(size_t *len, alarm_snapshot_proto_ptr_t snapsh
     char *bin = (char*)mallocz(*len);
     if (!alarm_snapshot->SerializeToArray(bin, *len)) {
         freez(bin);
-        delete alarm_snapshot;
+        destroy_alarm_snapshot_proto(snapshot);
         return NULL;
     }
 
-    delete alarm_snapshot;
+    destroy_alarm_snapshot_proto(snapshot);
     return bin;
 }

--- a/src/aclk/schema-wrappers/alarm_stream.h
+++ b/src/aclk/schema-wrappers/alarm_stream.h
@@ -126,6 +126,7 @@ struct send_alarm_checkpoint parse_send_alarm_checkpoint(const char *data, size_
 char *generate_alarm_checkpoint(size_t *len, struct alarm_checkpoint *data);
 
 alarm_snapshot_proto_ptr_t generate_alarm_snapshot_proto(struct alarm_snapshot *data);
+void destroy_alarm_snapshot_proto(alarm_snapshot_proto_ptr_t snapshot);
 void add_alarm_log_entry2snapshot(alarm_snapshot_proto_ptr_t snapshot, struct alarm_log_entry *data);
 char *generate_alarm_snapshot_bin(size_t *len, alarm_snapshot_proto_ptr_t snapshot);
 

--- a/src/claim/claim.c
+++ b/src/claim/claim.c
@@ -145,10 +145,10 @@ bool claim_id_matches_any(const char *claim_id) {
  * If this happens with the ACLK active under an old claim then we MUST KILL THE LINK
  */
 bool load_claiming_state(void) {
-    if (aclk_online()) {
+    bool reconnect_aclk = aclk_online();
+    if (reconnect_aclk) {
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "CLAIM: agent was already connected to NC - forcing reconnection under new credentials");
-        __atomic_store_n(&disconnect_req, ACLK_RELOAD_CONF, __ATOMIC_RELAXED);
     }
     __atomic_store_n(&aclk_disable_runtime, 0, __ATOMIC_RELAXED);
 
@@ -168,6 +168,9 @@ bool load_claiming_state(void) {
 
     invalidate_node_instances(&localhost->host_id.uuid, have_claimed_id ? &uuid.uuid : NULL);
     metaqueue_store_claim_id(&localhost->host_id.uuid, have_claimed_id ? &uuid.uuid : NULL);
+
+    if (reconnect_aclk)
+        __atomic_store_n(&disconnect_req, ACLK_RELOAD_CONF, __ATOMIC_RELAXED);
 
     errno_clear();
 

--- a/src/claim/claim.c
+++ b/src/claim/claim.c
@@ -148,7 +148,7 @@ bool load_claiming_state(void) {
     if (aclk_online()) {
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "CLAIM: agent was already connected to NC - forcing reconnection under new credentials");
-        disconnect_req = ACLK_RELOAD_CONF;
+        __atomic_store_n(&disconnect_req, ACLK_RELOAD_CONF, __ATOMIC_RELAXED);
     }
     __atomic_store_n(&aclk_disable_runtime, 0, __ATOMIC_RELAXED);
 

--- a/src/claim/claim.c
+++ b/src/claim/claim.c
@@ -150,7 +150,7 @@ bool load_claiming_state(void) {
                "CLAIM: agent was already connected to NC - forcing reconnection under new credentials");
         disconnect_req = ACLK_RELOAD_CONF;
     }
-    aclk_disable_runtime = 0;
+    __atomic_store_n(&aclk_disable_runtime, 0, __ATOMIC_RELAXED);
 
     ND_UUID uuid = claimed_id_load();
     if(UUIDiszero(uuid)) {

--- a/src/claim/cloud-status.c
+++ b/src/claim/cloud-status.c
@@ -15,7 +15,7 @@ ENUM_STR_MAP_DEFINE(CLOUD_STATUS) = {
 ENUM_STR_DEFINE_FUNCTIONS(CLOUD_STATUS, CLOUD_STATUS_AVAILABLE, "available");
 
 CLOUD_STATUS cloud_status(void) {
-    if(unlikely(aclk_disable_runtime))
+    if(unlikely(__atomic_load_n(&aclk_disable_runtime, __ATOMIC_RELAXED)))
         return CLOUD_STATUS_BANNED;
 
     if(likely(aclk_online()))
@@ -52,7 +52,7 @@ size_t cloud_connection_id(void) {
 }
 
 const char *cloud_status_aclk_offline_reason() {
-    if(aclk_disable_runtime)
+    if(__atomic_load_n(&aclk_disable_runtime, __ATOMIC_RELAXED))
         return "banned";
 
     return aclk_status_to_string();

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -405,10 +405,8 @@ static void aclk_run_query(struct aclk_sync_config_s *config, aclk_query_t *quer
     if (ok_to_send) {
         if (client)
             send_bin_msg(client, query);
-        else {
-            freez(query->data.bin_payload.payload);
+        else
             nd_log_daemon(NDLP_ERR, "No client to send message %u", query->type);
-        }
     }
 
     aclk_query_free(query);

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1025,7 +1025,7 @@ void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid __maybe_unused, nd_u
     // the CAS pairs with ACQUIRE loads of host->aclk_host_config in readers so they
     // cannot observe the pointer with zero-initialized fields (host == NULL etc.).
     aclk_host_config->host = host;
-    aclk_host_config->stream_alerts = false;
+    aclk_alert_streaming_set(aclk_host_config, false);
     time_t now = now_realtime_sec();
     aclk_host_config->node_info_send_time = (host == localhost || NULL == localhost) ? now - 25 : now;
 

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -34,6 +34,12 @@ enum aclk_database_opcode {
     ACLK_MAX_ENUMERATIONS_DEFINED
 };
 
+enum aclk_alert_snapshot_state {
+    ACLK_ALERT_SNAPSHOT_IDLE = 0,
+    ACLK_ALERT_SNAPSHOT_PENDING,
+    ACLK_ALERT_SNAPSHOT_READY,
+};
+
 typedef struct aclk_sync_cfg_t {
     RRDHOST *host;
     uv_timer_t timer;
@@ -49,8 +55,8 @@ typedef struct aclk_sync_cfg_t {
     uint64_t pending_ctx_version_hash;
     time_t pending_ctx_saved_monotonic_s;
 
-    int8_t send_snapshot;
-    bool stream_alerts;
+    int8_t send_snapshot; // atomic: shared by health, query, and alert-push workers
+    bool stream_alerts;   // atomic: published by query worker and read by alert-push/status threads
     int alert_count;
     int snapshot_count;
     int checkpoint_count;
@@ -58,6 +64,54 @@ typedef struct aclk_sync_cfg_t {
     time_t node_collectors_send;
     char node_id[UUID_STR_LEN];
 } aclk_sync_cfg_t;
+
+static inline enum aclk_alert_snapshot_state aclk_alert_snapshot_state_get(aclk_sync_cfg_t *aclk_host_config)
+{
+    return (enum aclk_alert_snapshot_state)__atomic_load_n(&aclk_host_config->send_snapshot, __ATOMIC_ACQUIRE);
+}
+
+static inline void aclk_alert_snapshot_request(aclk_sync_cfg_t *aclk_host_config)
+{
+    // A request arriving while READY is covered by the full snapshot already scheduled from the frozen health state.
+    int8_t expected = ACLK_ALERT_SNAPSHOT_IDLE;
+    (void)__atomic_compare_exchange_n(
+        &aclk_host_config->send_snapshot,
+        &expected,
+        ACLK_ALERT_SNAPSHOT_PENDING,
+        false,
+        __ATOMIC_RELAXED,
+        __ATOMIC_RELAXED);
+}
+
+static inline bool aclk_alert_snapshot_mark_ready(aclk_sync_cfg_t *aclk_host_config)
+{
+    int8_t expected = __atomic_load_n(&aclk_host_config->send_snapshot, __ATOMIC_RELAXED);
+    if (expected != ACLK_ALERT_SNAPSHOT_PENDING)
+        return false;
+
+    return __atomic_compare_exchange_n(
+        &aclk_host_config->send_snapshot,
+        &expected,
+        ACLK_ALERT_SNAPSHOT_READY,
+        false,
+        __ATOMIC_RELEASE,
+        __ATOMIC_RELAXED);
+}
+
+static inline void aclk_alert_snapshot_complete(aclk_sync_cfg_t *aclk_host_config)
+{
+    __atomic_store_n(&aclk_host_config->send_snapshot, ACLK_ALERT_SNAPSHOT_IDLE, __ATOMIC_RELEASE);
+}
+
+static inline bool aclk_alert_streaming_enabled(aclk_sync_cfg_t *aclk_host_config)
+{
+    return __atomic_load_n(&aclk_host_config->stream_alerts, __ATOMIC_ACQUIRE);
+}
+
+static inline void aclk_alert_streaming_set(aclk_sync_cfg_t *aclk_host_config, bool enabled)
+{
+    __atomic_store_n(&aclk_host_config->stream_alerts, enabled, __ATOMIC_RELEASE);
+}
 
 void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid, nd_uuid_t *node_id);
 void destroy_aclk_config(RRDHOST *host);

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -707,22 +707,23 @@ void aclk_push_alert_events_for_all_hosts(void)
         rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_ALERTS);
 
         struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
-        if (!aclk_host_config || false == aclk_host_config->stream_alerts || rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
+        if (!aclk_host_config || !aclk_alert_streaming_enabled(aclk_host_config) || rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
             (void)process_alert_pending_queue(host);
             commit_alert_events(host);
             continue;
         }
 
-        if (aclk_host_config->send_snapshot) {
+        enum aclk_alert_snapshot_state snapshot_state = aclk_alert_snapshot_state_get(aclk_host_config);
+        if (snapshot_state != ACLK_ALERT_SNAPSHOT_IDLE) {
             rrdhost_flag_set(host, RRDHOST_FLAG_ACLK_STREAM_ALERTS);
-            if (aclk_host_config->send_snapshot == 1)
+            if (snapshot_state == ACLK_ALERT_SNAPSHOT_PENDING)
                 continue;
             (void)process_alert_pending_queue(host);
             commit_alert_events(host);
             rebuild_host_alert_version_table(host);
             send_alert_snapshot_to_cloud(host);
             aclk_host_config->snapshot_count++;
-            aclk_host_config->send_snapshot = 0;
+            aclk_alert_snapshot_complete(aclk_host_config);
         }
         else
             aclk_push_alert_event(host, &res, &res_version);
@@ -993,7 +994,7 @@ static void schedule_alert_snapshot_if_needed(struct aclk_sync_cfg_t *aclk_host_
             (long long unsigned)cloud_version,
             (long long unsigned)local_version);
 
-        aclk_host_config->send_snapshot = 1;
+        aclk_alert_snapshot_request(aclk_host_config);
         rrdhost_flag_set(aclk_host_config->host, RRDHOST_FLAG_ACLK_STREAM_ALERTS);
     }
     else
@@ -1178,7 +1179,9 @@ void aclk_start_alert_streaming(char *node_id, uint64_t cloud_version)
     nd_log(NDLS_ACCESS, NDLP_DEBUG, "ACLK REQ [%s (%s)]: STREAM ALERTS ENABLED", node_id,
         aclk_host_config->host ? rrdhost_hostname(aclk_host_config->host) : "N/A");
     schedule_alert_snapshot_if_needed(aclk_host_config, cloud_version);
-    aclk_host_config->stream_alerts = true;
+    aclk_alert_streaming_set(aclk_host_config, true);
+    if (aclk_alert_snapshot_state_get(aclk_host_config) != ACLK_ALERT_SNAPSHOT_IDLE)
+        rrdhost_flag_set(aclk_host_config->host, RRDHOST_FLAG_ACLK_STREAM_ALERTS);
 }
 
 // Do checkpoint alert version check

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -1123,6 +1123,9 @@ void send_alert_snapshot_to_cloud(RRDHOST *host __maybe_unused)
         if (cnt == ALARM_EVENTS_PER_CHUNK) {
             if (aclk_online_for_alerts())
                 aclk_send_alarm_snapshot(snapshot_proto);
+            else
+                destroy_alarm_snapshot_proto(snapshot_proto);
+            snapshot_proto = NULL;
             cnt = 0;
             if (alarm_snap.chunk < chunks) {
                 alarm_snap.chunk++;
@@ -1133,6 +1136,8 @@ void send_alert_snapshot_to_cloud(RRDHOST *host __maybe_unused)
     }
     if (cnt)
         aclk_send_alarm_snapshot(snapshot_proto);
+    else
+        destroy_alarm_snapshot_proto(snapshot_proto);
 
     nd_log(
         NDLS_ACCESS,

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -414,7 +414,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
     worker_is_busy(WORKER_HEALTH_JOB_HOST_LOCK);
     {
         struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
-        if (aclk_host_config && aclk_host_config->send_snapshot == 2)
+        if (aclk_host_config && aclk_alert_snapshot_state_get(aclk_host_config) == ACLK_ALERT_SNAPSHOT_READY)
             return;
     }
 
@@ -851,8 +851,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
 
     if (!__atomic_load_n(&host->health.pending_transitions, __ATOMIC_RELAXED)) {
         struct aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
-        if (aclk_host_config && aclk_host_config->send_snapshot == 1) {
-            aclk_host_config->send_snapshot = 2;
+        if (aclk_host_config && aclk_alert_snapshot_mark_ready(aclk_host_config)) {
             rrdhost_flag_set(host, RRDHOST_FLAG_ACLK_STREAM_ALERTS);
         } else {
             worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_QUEUE);

--- a/src/streaming/protocol/command-begin-set-end-init.c
+++ b/src/streaming/protocol/command-begin-set-end-init.c
@@ -5,7 +5,7 @@
 #include "plugins.d/pluginsd_internals.h"
 
 static BUFFER *preferred_sender_buffer(RRDHOST *host) {
-    if(host->stream.snd.commit.receiver_tid == gettid_cached())
+    if(__atomic_load_n(&host->stream.snd.commit.receiver_tid, __ATOMIC_RELAXED) == gettid_cached())
         return sender_host_buffer(host);
     else
         return sender_thread_buffer(host->sender, HOST_THREAD_BUFFER_INITIAL_SIZE);

--- a/src/streaming/stream-compression/brotli.c
+++ b/src/streaming/stream-compression/brotli.c
@@ -88,7 +88,7 @@ void stream_decompressor_init_brotli(struct decompressor_state *state) {
         if (!state->stream)
             return;
 
-        simple_ring_buffer_make_room(&state->output, COMPRESSION_MAX_CHUNK);
+        simple_ring_buffer_set_capacity(&state->output, COMPRESSION_MAX_CHUNK + 1);
         state->initialized = true;
     }
 }
@@ -126,9 +126,9 @@ size_t stream_decompress_brotli(struct decompressor_state *state, const char *co
 
     size_t decompressed_size = state->output.size - available_out;
     if(available_out == 0) {
-        netdata_log_error("STREAM_DECOMPRESS: BrotliDecoderDecompressStream() needs a bigger output buffer than the one we provided "
-                          "(output buffer %zu bytes, compressed payload %zu bytes)",
-                          state->output.size, compressed_size);
+        netdata_log_error("STREAM_DECOMPRESS: BrotliDecoderDecompressStream() produced at least %zu bytes, exceeding "
+                          "the max supported size of %zu bytes (compressed payload %zu bytes)",
+                          state->output.size, (size_t)COMPRESSION_MAX_CHUNK, compressed_size);
         return 0;
     }
 

--- a/src/streaming/stream-compression/compression.c
+++ b/src/streaming/stream-compression/compression.c
@@ -723,6 +723,81 @@ cleanup:
     return errors;
 }
 
+static int unittest_stream_decompression_boundary(compression_algorithm_t algorithm, const char *name) {
+    fprintf(stderr, "\nTesting streaming decompression boundary with %s\n", name);
+
+    char payload[COMPRESSION_MAX_CHUNK + 1];
+    for(size_t i = 0; i < sizeof(payload); i++)
+        payload[i] = 'A' + (i % 26);
+
+    static const size_t sizes[] = {
+        COMPRESSION_MAX_CHUNK,
+        COMPRESSION_MAX_CHUNK + 1,
+    };
+
+    int errors = 0;
+
+    for(size_t i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+        struct compressor_state cctx = {
+            .algorithm = algorithm,
+        };
+        struct decompressor_state dctx = {
+            .algorithm = algorithm,
+        };
+
+        stream_compressor_init(&cctx);
+        stream_decompressor_init(&dctx);
+
+        if(!cctx.initialized || !dctx.initialized) {
+            fprintf(stderr, "  FAILED: %s state initialization failed\n", name);
+            errors++;
+            goto cleanup;
+        }
+
+        const char *compressed;
+        static const char warmup[] = "warmup\n";
+        size_t compressed_size = stream_compress(&cctx, warmup, sizeof(warmup) - 1, &compressed);
+        size_t decompressed_size = stream_decompress(&dctx, compressed, compressed_size);
+        if(decompressed_size != sizeof(warmup) - 1 ||
+           memcmp(dctx.output.data, warmup, sizeof(warmup) - 1) != 0) {
+            fprintf(stderr, "  FAILED: %s warm-up decompression returned %zu bytes\n", name, decompressed_size);
+            errors++;
+            goto cleanup;
+        }
+        dctx.output.read_pos += decompressed_size;
+
+        compressed_size = stream_compress(&cctx, payload, sizes[i], &compressed);
+        if(!compressed_size || compressed_size > COMPRESSION_MAX_MSG_SIZE) {
+            fprintf(stderr, "  FAILED: %s compressed %zu-byte boundary payload to invalid size %zu\n",
+                    name, sizes[i], compressed_size);
+            errors++;
+            goto cleanup;
+        }
+
+        decompressed_size = stream_decompress(&dctx, compressed, compressed_size);
+        if(sizes[i] == COMPRESSION_MAX_CHUNK) {
+            if(decompressed_size != sizes[i] ||
+               stream_decompressed_bytes_in_buffer(&dctx) != sizes[i] ||
+               memcmp(dctx.output.data, payload, sizes[i]) != 0) {
+                fprintf(stderr, "  FAILED: %s exact-boundary decompression returned %zu bytes\n",
+                        name, decompressed_size);
+                errors++;
+            }
+        }
+        else if(decompressed_size != 0) {
+            fprintf(stderr, "  FAILED: %s accepted %zu-byte over-limit output\n", name, decompressed_size);
+            errors++;
+        }
+
+cleanup:
+        stream_compressor_destroy(&cctx);
+        stream_decompressor_destroy(&dctx);
+    }
+
+    fprintf(stderr, "Streaming decompression boundary with %s: %s\n", name, errors ? "FAILED" : "OK");
+    return errors;
+}
+
 #ifdef ENABLE_ZSTD
 int unittest_stream_decompress_bomb_zstd(void);
 #endif
@@ -740,6 +815,11 @@ int unittest_stream_compressions(void) {
     ret += unittest_stream_compression(COMPRESSION_ALGORITHM_LZ4, "LZ4");
     ret += unittest_stream_compression(COMPRESSION_ALGORITHM_BROTLI, "BROTLI");
     ret += unittest_stream_compression(COMPRESSION_ALGORITHM_GZIP, "GZIP");
+
+#ifdef ENABLE_BROTLI
+    ret += unittest_stream_decompression_boundary(COMPRESSION_ALGORITHM_BROTLI, "BROTLI");
+#endif
+    ret += unittest_stream_decompression_boundary(COMPRESSION_ALGORITHM_GZIP, "GZIP");
 
     ret += unittest_stream_compression_speed(COMPRESSION_ALGORITHM_ZSTD, "ZSTD");
     ret += unittest_stream_compression_speed(COMPRESSION_ALGORITHM_LZ4, "LZ4");

--- a/src/streaming/stream-compression/compression.h
+++ b/src/streaming/stream-compression/compression.h
@@ -97,6 +97,19 @@ static inline void simple_ring_buffer_make_room(SIMPLE_RING_BUFFER *b, size_t si
     }
 }
 
+static inline void simple_ring_buffer_set_capacity(SIMPLE_RING_BUFFER *b, size_t size) {
+    if(unlikely(!b))
+        fatal("STREAM_COMPRESSION: NULL simple ring buffer");
+
+    if(unlikely(b->read_pos > size || b->write_pos > size))
+        fatal("STREAM_COMPRESSION: capacity below live ring buffer positions");
+
+    if(b->size != size) {
+        b->data = (const char *)reallocz((void *)b->data, size);
+        b->size = size;
+    }
+}
+
 static inline void simple_ring_buffer_append_data(SIMPLE_RING_BUFFER *b, const void *data, size_t size) {
     simple_ring_buffer_make_room(b, size);
     memcpy((void *)(b->data + b->write_pos), data, size);

--- a/src/streaming/stream-compression/gzip.c
+++ b/src/streaming/stream-compression/gzip.c
@@ -104,7 +104,7 @@ void stream_decompressor_init_gzip(struct decompressor_state *state) {
             return;
         }
 
-        simple_ring_buffer_make_room(&state->output, COMPRESSION_MAX_CHUNK);
+        simple_ring_buffer_set_capacity(&state->output, COMPRESSION_MAX_CHUNK + 1);
         state->initialized = true;
     }
 }
@@ -145,9 +145,9 @@ size_t stream_decompress_gzip(struct decompressor_state *state, const char *comp
     }
 
     if(strm->avail_out == 0) {
-        netdata_log_error("STREAM_DECOMPRESS: inflate() needs a bigger output buffer than the one we provided "
-                          "(compressed payload %zu bytes, output buffer size %zu bytes)"
-                          , compressed_size, state->output.size);
+        netdata_log_error("STREAM_DECOMPRESS: inflate() produced at least %zu bytes, exceeding the max supported "
+                          "size of %zu bytes (compressed payload %zu bytes)",
+                          state->output.size, (size_t)COMPRESSION_MAX_CHUNK, compressed_size);
         return 0;
     }
 

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -487,7 +487,7 @@ void stream_receiver_move_to_running_unsafe(struct stream_thread *sth, struct re
     rpt->thread.line_buffer = buffer_create(sizeof(rpt->thread.uncompressed.read_buffer), NULL);
 
     // help preferred_sender_buffer() select the right buffer
-    rpt->host->stream.snd.commit.receiver_tid = gettid_cached();
+    __atomic_store_n(&rpt->host->stream.snd.commit.receiver_tid, gettid_cached(), __ATOMIC_RELAXED);
 
     rpt->replication.last_progress_ut = now_monotonic_usec();
 
@@ -1348,6 +1348,7 @@ void rrdhost_clear_receiver(struct receiver_state *rpt, STREAM_HANDSHAKE reason)
             host->health.enabled = false;
 
             rrdhost_flag_set(host, RRDHOST_FLAG_ORPHAN);
+            __atomic_store_n(&host->stream.snd.commit.receiver_tid, 0, __ATOMIC_RELAXED);
             host->receiver = NULL;
         }
     }

--- a/src/streaming/stream-sender-commit.c
+++ b/src/streaming/stream-sender-commit.c
@@ -33,10 +33,11 @@ static BUFFER *sender_commit_start_with_trace(struct sender_state *s, struct sen
               commit->last_function ? commit->last_function : "(null)",
               func ? func : "(null)");
 
-    if(unlikely(commit->receiver_tid && commit->receiver_tid != gettid_cached()))
+    pid_t receiver_tid = __atomic_load_n(&commit->receiver_tid, __ATOMIC_RELAXED);
+    if(unlikely(receiver_tid && receiver_tid != gettid_cached()))
         fatal("STREAM SND '%s' [to %s]: thread buffer is reserved for tid %d, but it used by thread %d function '%s()'.",
               rrdhost_hostname(s->host), s->remote_ip,
-              commit->receiver_tid, gettid_cached(), func ? func : "(null)");
+              receiver_tid, gettid_cached(), func ? func : "(null)");
 
     if(unlikely(commit->wb &&
                  commit->wb->size > default_size &&
@@ -242,7 +243,7 @@ void sender_thread_commit_with_trace(struct sender_state *s, BUFFER *wb, STREAM_
     }
     else {
         commit = &s->host->stream.snd.commit;
-        is_receiver = commit->receiver_tid == gettid_cached();
+        is_receiver = __atomic_load_n(&commit->receiver_tid, __ATOMIC_RELAXED) == gettid_cached();
     }
 
     if (unlikely(wb != commit->wb))

--- a/src/web/mcp/mcp-tools-execute-function-registry.c
+++ b/src/web/mcp/mcp-tools-execute-function-registry.c
@@ -410,9 +410,16 @@ MCP_FUNCTION_REGISTRY_ENTRY *mcp_functions_registry_get(RRDHOST *host, const cha
     MCP_FUNCTION_REGISTRY_ENTRY *entry = dictionary_get(functions_registry, key_str);
     MCP_FUNCTION_REGISTRY_ENTRY *old_entry = NULL;
 
-    if(entry && entry->last_update + MCP_FUNCTIONS_REGISTRY_TTL < now && spinlock_trylock(&entry->update_spinlock)) {
-        old_entry = entry;
-        entry = NULL;
+    if(entry) {
+        rw_spinlock_read_lock(&entry->spinlock);
+
+        if(entry->last_update + MCP_FUNCTIONS_REGISTRY_TTL < now && spinlock_trylock(&entry->update_spinlock)) {
+            rw_spinlock_read_unlock(&entry->spinlock);
+            old_entry = entry;
+            entry = NULL;
+        }
+        else
+            return entry;
     }
 
     if(!entry) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes ACLK, streaming, and MCP by removing cross-thread races, fixing memory ownership, and accepting exact-size gzip/Brotli frames; improves status reporting and reconnect behavior without changing public contracts.

- **Bug Fixes**
  - Made ACLK diagnostics and controls thread-safe with relaxed atomics (status, disconnect requests, runtime ban, session ID); snapshot these in text/JSON state and cloud status; also made streaming `receiver_tid` atomic and cleared it on detach.
  - Published a single microsecond session ID and read it consistently in headers, LWT, agent connection updates, and node updates.
  - Fixed memory leaks in alarm snapshots and MQTT binary sends: added snapshot destructor, cleared consumed payload handles, unified `aclk_query_free()` coverage, and made `aclk_send_bin_message_subtopic_pid()` consume `msg` on all paths; also freed OpenSSL 3 decoder/BIO on key-load failures.
  - Accepted exact 16 KiB gzip/Brotli output by reserving a +1 probe byte and improved overflow errors; added boundary unit tests and a safe ring-buffer capacity setter.
  - Synchronized alert snapshot flow with atomic IDLE/PENDING/READY transitions and an atomic streaming gate; scheduled snapshots only when needed and completed them reliably.
  - Prevented a race in the MCP function registry by taking the entry read lock before TTL checks; stale refresh ownership remains unchanged.

<sup>Written for commit c5e61aed1afa399886f9a4e71a25e9d9d6eefb43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

