### PR TITLE
Netdata fixes part 72

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -503,6 +503,7 @@ int netdata_main(int argc, char **argv) {
 #ifdef OS_WINDOWS
                             if (perflibnamestest_main()) return 1;
 #endif
+                            sqlite_close_databases();
                             sqlite_library_shutdown();
                             rrdlabels_aral_destroy(false);
                             fprintf(stderr, "\n\nALL TESTS PASSED\n\n");

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1027,7 +1027,8 @@ void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid __maybe_unused, nd_u
     aclk_host_config->host = host;
     aclk_host_config->stream_alerts = false;
     time_t now = now_realtime_sec();
-    aclk_host_config->node_info_send_time = (host == localhost || NULL == localhost) ? now - 25 : now;
+    aclk_host_config->node_info_send_time =
+        (host == localhost || NULL == localhost) ? nd_time_t_add_saturating(now, -25) : now;
 
     struct aclk_sync_cfg_t *expected = NULL;
     if (__atomic_compare_exchange_n(&host->aclk_host_config, &expected, aclk_host_config, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED)) {
@@ -1167,7 +1168,7 @@ void aclk_synchronization_init(void)
 
     if (sem_init) {
         int finished_vnodes = 0;
-        time_t deadline = now_realtime_sec() + 60;  // hard timeput to avoid infinite block
+        time_t deadline = nd_time_t_add_saturating(now_realtime_sec(), 60);  // hard timeput to avoid infinite block
         while (finished_vnodes < node_data.vnodes) {
             if (uv_sem_trywait(&ctx_sem) == 0) {
                 finished_vnodes++;

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -234,7 +234,7 @@ void aclk_check_node_info_and_collectors(void)
         }
 
         if (pp_queue_empty && aclk_host_config->node_info_send_time &&
-            aclk_host_config->node_info_send_time + 30 < now) {
+            nd_time_t_add_compare(aclk_host_config->node_info_send_time, 30, now) < 0) {
             aclk_host_config->node_info_send_time = 0;
             build_node_info(host, NULL);
             schedule_node_state_update(host, 10000);
@@ -242,7 +242,7 @@ void aclk_check_node_info_and_collectors(void)
         }
 
         if (pp_queue_empty && aclk_host_config->node_collectors_send &&
-            aclk_host_config->node_collectors_send + 30 < now) {
+            nd_time_t_add_compare(aclk_host_config->node_collectors_send, 30, now) < 0) {
             build_node_collectors(host);
             internal_error(true, "ACLK SYNC: Sending collectors for %s", rrdhost_hostname(host));
             aclk_host_config->node_collectors_send = 0;

--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -368,13 +368,21 @@ int ctx_unittest(void)
     nd_uuid_t host_uuid;
     uuid_generate(host_uuid);
 
+    sqlite3 *saved_db_context_meta = db_context_meta;
+    bool owns_sqlite_lifecycle = !saved_db_context_meta;
+
     if (sqlite_library_init())
         return 1;
 
     int rc = sql_init_context_database(1);
 
-    if (rc != SQLITE_OK)
+    if (rc != SQLITE_OK) {
+        sql_close_database(db_context_meta, "CONTEXT");
+        db_context_meta = saved_db_context_meta;
+        if (owns_sqlite_lifecycle)
+            sqlite_library_shutdown();
         return 1;
+    }
 
     // Store a context
     VERSIONED_CONTEXT_DATA context_data;
@@ -446,7 +454,9 @@ int ctx_unittest(void)
     netdata_log_info("List context end after delete");
 
     sql_close_database(db_context_meta, "CONTEXT");
-    sqlite_library_shutdown();
+    db_context_meta = saved_db_context_meta;
+    if (owns_sqlite_lifecycle)
+        sqlite_library_shutdown();
 
     return 0;
 }

--- a/src/database/sqlite/sqlite_db_migration.c
+++ b/src/database/sqlite/sqlite_db_migration.c
@@ -47,13 +47,17 @@ int db_table_count(sqlite3 *database)
 int table_exists_in_database(sqlite3 *database, const char *table)
 {
     char *err_msg = NULL;
-    char sql[128];
 
     int exists = 0;
 
-    snprintf(sql, sizeof(sql) - 1, "select 1 from sqlite_schema where type = 'table' and name = '%s'", table);
+    char *sql = sqlite3_mprintf("select 1 from sqlite_schema where type = 'table' and name = %Q", table);
+    if (unlikely(!sql)) {
+        netdata_log_info("Error checking table existence; failed to allocate SQL statement");
+        return 0;
+    }
 
     int rc = sqlite3_exec_monitored(database, sql, return_int_cb, (void *) &exists, &err_msg);
+    sqlite3_free(sql);
     if (rc != SQLITE_OK) {
         netdata_log_info("Error checking table existence; %s", err_msg);
         sqlite3_free(err_msg);
@@ -65,13 +69,17 @@ int table_exists_in_database(sqlite3 *database, const char *table)
 static int column_exists_in_table(sqlite3 *database, const char *table, const char *column)
 {
     char *err_msg = NULL;
-    char sql[128];
 
     int exists = 0;
 
-    snprintf(sql, sizeof(sql) - 1, "SELECT 1 FROM pragma_table_info('%s') where name = '%s'", table, column);
+    char *sql = sqlite3_mprintf("SELECT 1 FROM pragma_table_info(%Q) where name = %Q", table, column);
+    if (unlikely(!sql)) {
+        netdata_log_info("Error checking column existence; failed to allocate SQL statement");
+        return 0;
+    }
 
     int rc = sqlite3_exec_monitored(database, sql, return_int_cb, (void *) &exists, &err_msg);
+    sqlite3_free(sql);
     if (rc != SQLITE_OK) {
         netdata_log_info("Error checking column existence; %s", err_msg);
         sqlite3_free(err_msg);
@@ -187,18 +195,22 @@ static int do_migration_v2_v3(sqlite3 *database)
 }
 
 // For every table whose name matches 'like_pattern' and is missing 'column',
-// run each statement in 'stmts_fmt' (one '%s' placeholder for the table name).
+// run each SQLite-formatted statement in 'stmts_fmt' (one '%w' conversion inside double quotes).
 static int add_column_to_matching_tables(
     sqlite3 *database, const char *like_pattern, const char *column,
     const char *const *stmts_fmt, size_t stmt_count, const char *err_context)
 {
-    char sql[256];
-
-    snprintfz(sql, sizeof(sql) - 1,
-              "SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE '%s'", like_pattern);
+    char *sql = sqlite3_mprintf(
+        "SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE %Q", like_pattern);
+    if (unlikely(!sql)) {
+        error_report("Failed to allocate statement to alter %s tables", err_context);
+        return 1;
+    }
 
     sqlite3_stmt *res = NULL;
-    if (sqlite3_prepare_v2(database, sql, -1, &res, 0) != SQLITE_OK) {
+    int rc = sqlite3_prepare_v2(database, sql, -1, &res, 0);
+    sqlite3_free(sql);
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to alter %s tables", err_context);
         return 1;
     }
@@ -210,8 +222,15 @@ static int add_column_to_matching_tables(
         char *table = strdupz(name);
         if (!column_exists_in_table(database, table, column)) {
             for (size_t i = 0; i < stmt_count; i++) {
-                snprintfz(sql, sizeof(sql) - 1, stmts_fmt[i], table);
+                sql = sqlite3_mprintf(stmts_fmt[i], table);
+                if (unlikely(!sql)) {
+                    error_report("Failed to allocate statement to alter %s tables", err_context);
+                    freez(table);
+                    SQLITE_FINALIZE(res);
+                    return 1;
+                }
                 sqlite3_exec_monitored(database, sql, 0, 0, NULL);
+                sqlite3_free(sql);
             }
         }
         freez(table);
@@ -224,7 +243,7 @@ static int add_column_to_matching_tables(
 
 static int do_migration_v3_v4(sqlite3 *database)
 {
-    const char *stmts[] = { "ALTER TABLE %s ADD chart_context text" };
+    const char *stmts[] = { "ALTER TABLE \"%w\" ADD chart_context text" };
     return add_column_to_matching_tables(database, "health_log_%", "chart_context", stmts, 1, "health_log");
 }
 
@@ -241,15 +260,15 @@ static int do_migration_v5_v6(sqlite3 *database)
 static int do_migration_v6_v7(sqlite3 *database)
 {
     const char *stmts[] = {
-        "ALTER TABLE %s ADD filtered_alert_unique_id",
-        "UPDATE %s SET filtered_alert_unique_id = alert_unique_id",
+        "ALTER TABLE \"%w\" ADD filtered_alert_unique_id",
+        "UPDATE \"%w\" SET filtered_alert_unique_id = alert_unique_id",
     };
     return add_column_to_matching_tables(database, "aclk_alert_%", "filtered_alert_unique_id", stmts, 2, "aclk_alert");
 }
 
 static int do_migration_v7_v8(sqlite3 *database)
 {
-    const char *stmts[] = { "ALTER TABLE %s ADD transition_id blob" };
+    const char *stmts[] = { "ALTER TABLE \"%w\" ADD transition_id blob" };
     return add_column_to_matching_tables(database, "health_log_%", "transition_id", stmts, 1, "health_log");
 }
 
@@ -356,8 +375,8 @@ static int do_migration_v11_v12(sqlite3 *database)
     return rc;
 }
 
-// Run 'stmt_fmt' (one '%s' placeholder for the object name) against every name
-// returned by 'select_sql', batched into a single execution.
+// Run 'stmt_fmt' (one '%w' conversion inside double quotes) against every name returned
+// by 'select_sql', batched into a single execution.
 static int execute_on_matching_names(
     sqlite3 *database, const char *select_sql, const char *stmt_fmt, const char *err_context)
 {
@@ -373,7 +392,15 @@ static int execute_on_matching_names(
         const char *name = (const char *) sqlite3_column_text(res, 0);
         if (unlikely(!name))
             continue;
-        buffer_sprintf(wb, stmt_fmt, name);
+        char *sql = sqlite3_mprintf(stmt_fmt, name);
+        if (unlikely(!sql)) {
+            error_report("Failed to allocate statement to %s", err_context);
+            SQLITE_FINALIZE(res);
+            buffer_free(wb);
+            return 1;
+        }
+        buffer_strcat(wb, sql);
+        sqlite3_free(sql);
         count++;
     }
 
@@ -391,7 +418,7 @@ static int do_migration_v14_v15(sqlite3 *database)
     return execute_on_matching_names(
         database,
         "SELECT name FROM sqlite_schema WHERE type = \"index\" AND name LIKE \"aclk_alert_index@_%\" ESCAPE \"@\"",
-        "DROP INDEX IF EXISTS %s; ",
+        "DROP INDEX IF EXISTS \"%w\"; ",
         "drop unused indices");
 }
 
@@ -400,7 +427,7 @@ static int do_migration_v15_v16(sqlite3 *database)
     return execute_on_matching_names(
         database,
         "SELECT name FROM sqlite_schema WHERE type = \"table\" AND name LIKE \"aclk_alert_%\"",
-        "ANALYZE %s ; ",
+        "ANALYZE \"%w\"; ",
         "analyze aclk_alert tables");
 }
 

--- a/src/libnetdata/spawn_server/spawn-tester.c
+++ b/src/libnetdata/spawn_server/spawn-tester.c
@@ -480,6 +480,79 @@ void test_popen_plugin_timedwait_kill(const char *argv0) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
+#if !defined(OS_WINDOWS)
+static int callback_wait_for_sigterm(SPAWN_REQUEST *request) {
+    struct sigaction sigterm_action, sigchld_action;
+    sigset_t mask;
+
+    if(sigaction(SIGTERM, NULL, &sigterm_action) == -1 ||
+       sigaction(SIGCHLD, NULL, &sigchld_action) == -1 ||
+       pthread_sigmask(SIG_BLOCK, NULL, &mask) != 0 ||
+       sigterm_action.sa_handler != SIG_DFL ||
+       sigchld_action.sa_handler != SIG_DFL ||
+       sigismember(&mask, SIGTERM) != 0 ||
+       sigismember(&mask, SIGCHLD) != 0)
+        return EXIT_FAILURE;
+
+    static const char ready = 'R';
+    if(write(request->fds[1], &ready, sizeof(ready)) != sizeof(ready))
+        return EXIT_FAILURE;
+
+    for(;;)
+        pause();
+}
+
+static void test_callback_signal_lifecycle(int argc, const char **argv) {
+    SPAWN_SERVER *server = spawn_server_create(
+        SPAWN_SERVER_OPTION_CALLBACK, "test-callback", callback_wait_for_sigterm, argc, argv);
+    if(!server) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot create callback spawn server");
+        exit(1);
+    }
+
+    SPAWN_INSTANCE *si = spawn_server_exec(
+        server, STDERR_FILENO, STDIN_FILENO, NULL, NULL, 0, SPAWN_INSTANCE_TYPE_CALLBACK);
+    if(!si) {
+        spawn_server_destroy(server);
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot run callback signal lifecycle test");
+        exit(1);
+    }
+
+    char ready = 0;
+    if(read(spawn_server_instance_read_fd(si), &ready, sizeof(ready)) != sizeof(ready) || ready != 'R') {
+        spawn_server_exec_kill(server, si, 0);
+        spawn_server_destroy(server);
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Callback child did not enter with default unblocked lifecycle signals");
+        exit(1);
+    }
+
+    int status = spawn_server_exec_kill(server, si, 0);
+    if(!WIFSIGNALED(status) || WTERMSIG(status) != SIGTERM) {
+        spawn_server_destroy(server);
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Callback child should terminate with SIGTERM, raw status is %d", status);
+        exit(1);
+    }
+
+    si = spawn_server_exec(server, STDERR_FILENO, STDIN_FILENO, NULL, NULL, 0, SPAWN_INSTANCE_TYPE_CALLBACK);
+    if(!si) {
+        spawn_server_destroy(server);
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot run immediate callback signal lifecycle test");
+        exit(1);
+    }
+
+    status = spawn_server_exec_kill(server, si, 0);
+    spawn_server_destroy(server);
+
+    if(!WIFSIGNALED(status) || WTERMSIG(status) != SIGTERM) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "Immediately killed callback child should terminate with SIGTERM, raw status is %d", status);
+        exit(1);
+    }
+}
+#endif
+
+// --------------------------------------------------------------------------------------------------------------------
+
 int main(int argc, const char **argv) {
     if(argc > 1 && strcmp(argv[1], "plugin-kill-to-stop") == 0)
         return plugin_kill_to_stop();
@@ -519,6 +592,11 @@ int main(int argc, const char **argv) {
         test_int_fds_plugin_close_to_stop(server, argv[0]);
     }
     spawn_server_destroy(server);
+
+#if !defined(OS_WINDOWS)
+    fprintf(stderr, "\n\nTESTING callback signal lifecycle\n\n");
+    test_callback_signal_lifecycle(argc, argv);
+#endif
 
     fprintf(stderr, "\n\nTESTING popen\n\n");
     netdata_main_spawn_server_init("test", argc, argv);

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -358,15 +358,64 @@ static bool spawn_server_run_callback(SPAWN_SERVER *server __maybe_unused, SPAWN
         return false;
     }
 
+    // Do not let the callback child run the spawn server's private signal handlers before it can reset them.
+    sigset_t callback_signals, previous_mask;
+    sigemptyset(&callback_signals);
+    sigaddset(&callback_signals, SIGTERM);
+    sigaddset(&callback_signals, SIGCHLD);
+
+    int mask_rc = pthread_sigmask(SIG_BLOCK, &callback_signals, &previous_mask);
+    if(mask_rc != 0) {
+        errno = mask_rc;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to block callback child signals before fork().");
+        return false;
+    }
+
     pid_t pid = fork();
+    int fork_errno = errno;
+
+    if(pid != 0) {
+        mask_rc = pthread_sigmask(SIG_SETMASK, &previous_mask, NULL);
+        if(mask_rc != 0) {
+            if(pid > 0) {
+                kill(pid, SIGKILL);
+
+                while(waitpid(pid, NULL, 0) == -1 && errno == EINTR) { }
+            }
+
+            spawn_server_exit = true;
+            nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to restore signal mask after callback fork().");
+            errno = mask_rc;
+            return false;
+        }
+    }
+
     if (pid < 0) {
         // fork failed
 
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to fork() child for callback.");
+        errno = fork_errno;
         return false;
     }
     else if (pid == 0) {
         // the child
+
+        struct sigaction sa = {
+            .sa_handler = SIG_DFL,
+        };
+        sigemptyset(&sa.sa_mask);
+
+        if(sigaction(SIGTERM, &sa, NULL) == -1 || sigaction(SIGCHLD, &sa, NULL) == -1) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to reset callback child signal handlers.");
+            _exit(EXIT_FAILURE);
+        }
+
+        mask_rc = pthread_sigmask(SIG_SETMASK, &previous_mask, NULL);
+        if(mask_rc != 0) {
+            errno = mask_rc;
+            nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to restore callback child signal mask.");
+            _exit(EXIT_FAILURE);
+        }
 
         // close the server sockets;
         close(server->sock); server->sock = -1;

--- a/src/registry/registry_db.c
+++ b/src/registry/registry_db.c
@@ -313,6 +313,9 @@ size_t registry_db_load(void) {
                 }
                 *url++ = '\0';
 
+                size_t machine_name_len;
+                char *machine_name = registry_fix_machine_name(&s[69], &machine_name_len);
+
                 if(*url != 'h' && *url != '*') {
                     netdata_log_error("REGISTRY: person URL line %zu does not have a valid url: %s", line, url);
                     continue;
@@ -333,7 +336,7 @@ size_t registry_db_load(void) {
 
                 REGISTRY_PERSON_URL *pu = registry_person_url_index_find(p, u);
                 if(!pu)
-                    pu = registry_person_url_allocate(p, m, u, &s[69], strlen(&s[69]), first_t);
+                    pu = registry_person_url_allocate(p, m, u, machine_name, machine_name_len, first_t);
                 else
                     netdata_log_error("REGISTRY: person URL line %zu is duplicate, reusing the old one.", line);
 

--- a/src/registry/registry_internals.c
+++ b/src/registry/registry_internals.c
@@ -28,11 +28,10 @@ int regenerate_guid(const char *guid, char *result) {
     return 0;
 }
 
-// make sure the names of the machines / URLs do not contain any tabs
-// (which are used as our separator in the database files)
+// make sure values do not contain whitespace separators used by the database files
 // and are properly trimmed (before and after)
-static inline char *registry_fix_machine_name(char *name, size_t *len) {
-    char *s = name?name:"";
+static inline char *registry_fix_string(char *value, size_t *len, size_t max_length) {
+    char *s = value ? value : "";
 
     // skip leading spaces
     while(*s && isspace((uint8_t)*s)) s++;
@@ -54,24 +53,26 @@ static inline char *registry_fix_machine_name(char *name, size_t *len) {
             break;
     }
 
+    size_t length = t - s;
+    if(length > max_length) {
+        length = max_length;
+        while(length && s[length - 1] == ' ')
+            length--;
+        s[length] = '\0';
+    }
+
     if(likely(len))
-        *len = (t - s);
+        *len = length;
 
     return s;
 }
 
+char *registry_fix_machine_name(char *name, size_t *len) {
+    return registry_fix_string(name, len, registry.max_name_length);
+}
+
 static inline char *registry_fix_url(char *url, size_t *len) {
-    size_t l = 0;
-    char *s = registry_fix_machine_name(url, &l);
-
-    // protection from too big URLs
-    if(l > registry.max_url_length) {
-        l = registry.max_url_length;
-        s[l] = '\0';
-    }
-
-    if(len) *len = l;
-    return s;
+    return registry_fix_string(url, len, registry.max_url_length);
 }
 
 

--- a/src/registry/registry_internals.c
+++ b/src/registry/registry_internals.c
@@ -194,16 +194,19 @@ REGISTRY_PERSON *registry_request_delete(const char *person_guid, char *machine_
 
     STRING *d_url = string_strdupz(delete_url);
     REGISTRY_PERSON_URL *dpu = registry_person_url_index_find(p, d_url);
-    string_freez(d_url);
 
     if(!dpu) {
         netdata_log_info("Registry Delete Request: URL not found for person: '%s', machine '%s', url '%s', delete url '%s'", p->guid
              , m->guid, string2str(pu->url), delete_url);
+        string_freez(d_url);
         return NULL;
     }
 
-    registry_log('D', p, m, pu->url, string2str(dpu->url));
+    STRING *request_url = string_dup(pu->url);
     registry_person_unlink_from_url(p, dpu);
+    registry_log('D', p, m, request_url, string2str(d_url));
+    string_freez(request_url);
+    string_freez(d_url);
 
     return p;
 }

--- a/src/registry/registry_internals.h
+++ b/src/registry/registry_internals.h
@@ -73,6 +73,7 @@ struct registry {
 extern struct registry registry;
 
 // REGISTRY LOW-LEVEL REQUESTS (in registry-internals.c)
+char *registry_fix_machine_name(char *name, size_t *len);
 REGISTRY_PERSON *registry_request_access(const char *person_guid, char *machine_guid, char *url, char *name, time_t when);
 REGISTRY_PERSON *registry_request_delete(const char *person_guid, char *machine_guid, char *url, char *delete_url, time_t when);
 REGISTRY_MACHINE *registry_request_machine(const char *person_guid, char *request_machine, STRING **hostname);

--- a/src/registry/registry_person.c
+++ b/src/registry/registry_person.c
@@ -39,9 +39,7 @@ REGISTRY_PERSON_URL *registry_person_url_allocate(REGISTRY_PERSON *p, REGISTRY_M
 
     REGISTRY_PERSON_URL *pu = aral_mallocz(registry.person_urls_aral);
 
-    // a simple strcpy() should do the job,
-    // but I prefer to be safe, since the caller specified name_len
-    pu->machine_name = string_strdupz(machine_name);
+    pu->machine_name = string_strndupz(machine_name, machine_name_len);
 
     pu->machine = m;
     pu->first_t = pu->last_t = (uint32_t)when;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened SQLite migrations and time-safe scheduling, fixed callback child signal handling, and enforced registry machine-name bounds. Restored SQLite handle ownership in tests and ensured DBs close during unit-test teardown.

- **Bug Fixes**
  - SQLite migrations: build SQL with sqlite3_mprintf(); quote values (%Q) and identifiers ("%w"); free all formatted strings.
  - Time safety: use nd_time_t_add_saturating()/nd_time_t_add_compare() in ACLK and metadata to define deadline arithmetic and avoid time32 overflow.
  - Metadata timer: align and publish metadata_check_after with relaxed atomics to remove a data race.
  - Spawn server (callback): block SIGTERM/SIGCHLD across fork, set SIG_DFL in child, restore masks; added lifecycle tests; immediate kills now terminate with SIGTERM.
  - Registry: normalize and clamp machine names/URLs; use normalized machine name on DB load; store with string_strndupz(len); unlink before logging delete so compaction/replay persists deletions.
  - Tests/teardown: preserve/restore the SQLite context handle in ctx_unittest; close databases before sqlite shutdown; call sqlite_close_databases() on unit-test success.

<sup>Written for commit f1f22a15393216deb5da6d556377938c5453b460. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

