### PR TITLE
Netdata fixes part 73

### DIFF
--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -24,7 +24,7 @@ static bool check_and_generate_certificates() {
     CLEAN_CHAR_P *private_key_file = filename_from_path_entry_strdupz(netdata_configured_cloud_dir, "private.pem");
     CLEAN_CHAR_P *public_key_file = filename_from_path_entry_strdupz(netdata_configured_cloud_dir, "public.pem");
 
-    // Check if private key exists
+    // Check if the public key exists; it is the completion marker for the pair.
     fp = fopen(public_key_file, "r");
     if (fp) {
         fclose(fp);
@@ -66,17 +66,29 @@ static bool check_and_generate_certificates() {
         EVP_PKEY_free(pkey);
         return false;
     }
-    fclose(fp);
+    if (fclose(fp) != 0) {
+        claim_agent_failure_reason_set("Cannot write private key file: %s", private_key_file);
+        EVP_PKEY_free(pkey);
+        return false;
+    }
 
     // Save public key
     fp = fopen(public_key_file, "wb");
     if (!fp || !PEM_write_PUBKEY(fp, pkey)) {
         claim_agent_failure_reason_set("Cannot write public key file: %s", public_key_file);
-        if (fp) fclose(fp);
+        if (fp) {
+            fclose(fp);
+            unlink(public_key_file);
+        }
         EVP_PKEY_free(pkey);
         return false;
     }
-    fclose(fp);
+    if (fclose(fp) != 0) {
+        claim_agent_failure_reason_set("Cannot write public key file: %s", public_key_file);
+        unlink(public_key_file);
+        EVP_PKEY_free(pkey);
+        return false;
+    }
 
     EVP_PKEY_free(pkey);
     return true;

--- a/src/claim/claim.c
+++ b/src/claim/claim.c
@@ -37,9 +37,19 @@ bool claimed_id_save_to_file(const char *claimed_id_str) {
     const char *filename = filename_from_path_entry_strdupz(netdata_configured_cloud_dir, "claimed_id");
     FILE *fp = fopen(filename, "w");
     if(fp) {
-        fprintf(fp, "%s", claimed_id_str);
-        fclose(fp);
-        ret = true;
+        int written = fprintf(fp, "%s", claimed_id_str);
+        int saved_errno = errno;
+        if(fclose(fp) != 0 || written < 0) {
+            if(written >= 0)
+                saved_errno = errno;
+
+            errno = saved_errno;
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "CLAIM: cannot save file '%s'.", filename);
+            ret = false;
+        }
+        else
+            ret = true;
     }
     else {
         nd_log(NDLS_DAEMON, NDLP_ERR,

--- a/src/claim/cloud-conf.c
+++ b/src/claim/cloud-conf.c
@@ -115,8 +115,17 @@ bool cloud_conf_save(void) {
         return false;
     }
 
-    fprintf(fp, "%s", buffer_tostring(wb));
-    fclose(fp);
+    int written = fprintf(fp, "%s", buffer_tostring(wb));
+    int saved_errno = errno;
+    if(fclose(fp) != 0 || written < 0) {
+        if(written >= 0)
+            saved_errno = errno;
+
+        errno = saved_errno;
+        nd_log(NDLS_DAEMON, NDLP_ERR, "Cannot save file '%s'.", filename);
+        return false;
+    }
+
     return true;
 }
 

--- a/src/collectors/windows-events.plugin/windows-events-query-evt-variant.c
+++ b/src/collectors/windows-events.plugin/windows-events-query-evt-variant.c
@@ -121,13 +121,14 @@ static inline void append_double(BUFFER *b, double n, const char *separator) {
 
 static inline void append_guid(BUFFER *b, GUID *guid, const char *separator) {
     fatal_assert(sizeof(GUID) == sizeof(nd_uuid_t));
-    if (!guid) return;
+
+    ND_UUID uuid;
+    if (!wevt_GUID_to_ND_UUID(&uuid, guid)) return;
 
     append_separator_if_needed(b, separator);
 
-    ND_UUID *uuid = (ND_UUID *)guid;
     buffer_need_bytes(b, UUID_STR_LEN);
-    uuid_unparse_lower(uuid->uuid, &b->buffer[b->len]);
+    uuid_unparse_lower(uuid.uuid, &b->buffer[b->len]);
     b->len += UUID_STR_LEN - 1;
 
     internal_fatal(buffer_strlen(b) != strlen(buffer_tostring(b)),

--- a/src/libnetdata/buffer/buffer.c
+++ b/src/libnetdata/buffer/buffer.c
@@ -535,6 +535,10 @@ int buffer_unittest(void) {
     buffer_int64_roundtrip(wb, NUMBER_ENCODING_HEX, (int64_t)-9223372036854775807ULL, "-0x7FFFFFFFFFFFFFFF");
     buffer_int64_roundtrip(wb, NUMBER_ENCODING_BASE64, (int64_t)-9223372036854775807ULL, "-#H//////////");
 
+    errors += buffer_int64_roundtrip(wb, NUMBER_ENCODING_DECIMAL, INT64_MIN, "-9223372036854775808");
+    errors += buffer_int64_roundtrip(wb, NUMBER_ENCODING_HEX, INT64_MIN, "-0x8000000000000000");
+    errors += buffer_int64_roundtrip(wb, NUMBER_ENCODING_BASE64, INT64_MIN, "-#IAAAAAAAAAA");
+
     static const struct {
         const char *encoded;
         int64_t expected;

--- a/src/libnetdata/buffer/buffer.c
+++ b/src/libnetdata/buffer/buffer.c
@@ -478,6 +478,17 @@ static int buffer_int64_roundtrip(BUFFER *wb, NUMBER_ENCODING encoding, int64_t 
     return errors;
 }
 
+static int buffer_int64_parse(const char *encoded, int64_t expected) {
+    int64_t value = str2ll_encoded(encoded);
+
+    if(value == expected)
+        return 0;
+
+    netdata_log_error("BUFFER: string '%s' resolves to %lld, expected %lld",
+                      encoded, (long long)value, (long long)expected);
+    return 1;
+}
+
 static int buffer_double_roundtrip(BUFFER *wb, NUMBER_ENCODING encoding, NETDATA_DOUBLE value, const char *expected) {
     int errors = 0;
     buffer_flush(wb);
@@ -523,6 +534,50 @@ int buffer_unittest(void) {
     buffer_int64_roundtrip(wb, NUMBER_ENCODING_DECIMAL, (int64_t)-9223372036854775807ULL, "-9223372036854775807");
     buffer_int64_roundtrip(wb, NUMBER_ENCODING_HEX, (int64_t)-9223372036854775807ULL, "-0x7FFFFFFFFFFFFFFF");
     buffer_int64_roundtrip(wb, NUMBER_ENCODING_BASE64, (int64_t)-9223372036854775807ULL, "-#H//////////");
+
+    static const struct {
+        const char *encoded;
+        int64_t expected;
+    } int64_parse_tests[] = {
+        { "0", 0 },
+        { "-0", 0 },
+        { "9223372036854775807", LLONG_MAX },
+        { "0x7FFFFFFFFFFFFFFF", LLONG_MAX },
+        { "#H//////////", LLONG_MAX },
+        { "-9223372036854775808", LLONG_MIN },
+        { "-0x8000000000000000", LLONG_MIN },
+        { "-#IAAAAAAAAAA", LLONG_MIN },
+        { "9223372036854775808", LLONG_MIN },
+        { "0x8000000000000000", LLONG_MIN },
+        { "#IAAAAAAAAAA", LLONG_MIN },
+        { "-9223372036854775809", LLONG_MAX },
+        { "-0x8000000000000001", LLONG_MAX },
+        { "-#IAAAAAAAAAB", LLONG_MAX },
+        { "18446744073709551615", -1 },
+        { "-18446744073709551615", 1 },
+        { "18446744073709551616", 0 },
+        { "0x10000000000000000", 0 },
+        { "#QAAAAAAAAAA", 0 },
+        { " 9223372036854775808", LLONG_MIN },
+        { " -9223372036854775808", 0 },
+        { "- 9223372036854775808", LLONG_MIN },
+        { " 0x8000000000000000", 0 },
+        { "- 0x8000000000000000", 0 },
+        { "-9223372036854775808suffix", LLONG_MIN },
+        { "-0x8000000000000000!suffix", LLONG_MIN },
+        { "-#IAAAAAAAAAA!suffix", LLONG_MIN },
+        { "", 0 },
+        { "-", 0 },
+        { "+1", 0 },
+        { "--1", 0 },
+        { "#", 0 },
+        { "0x", 0 },
+        { "-#", 0 },
+        { "-0x", 0 },
+    };
+
+    for(size_t i = 0; i < _countof(int64_parse_tests); i++)
+        errors += buffer_int64_parse(int64_parse_tests[i].encoded, int64_parse_tests[i].expected);
 
     buffer_double_roundtrip(wb, NUMBER_ENCODING_DECIMAL, 0, "0");
     buffer_double_roundtrip(wb, NUMBER_ENCODING_HEX, 0, "%0");

--- a/src/libnetdata/buffer/buffer.h
+++ b/src/libnetdata/buffer/buffer.h
@@ -561,14 +561,15 @@ static size_t print_uint64(char *dst, uint64_t value) {
 ALWAYS_INLINE
 static size_t print_int64(char *dst, int64_t value) {
     size_t len = 0;
+    uint64_t magnitude = (uint64_t)value;
 
     if(value < 0) {
         *dst++ = '-';
-        value = -value;
+        magnitude = UINT64_C(0) - magnitude;
         len++;
     }
 
-    return print_uint64(dst, value) + len;
+    return print_uint64(dst, magnitude) + len;
 }
 
 #define UINT64_MAX_LENGTH (24) // 21 should be enough
@@ -646,13 +647,14 @@ static void buffer_print_uint64_base64(BUFFER *wb, uint64_t value) {
 ALWAYS_INLINE
 static void buffer_print_int64_hex(BUFFER *wb, int64_t value) {
     buffer_need_bytes(wb, 2);
+    uint64_t magnitude = (uint64_t)value;
 
     if(value < 0) {
         buffer_putc(wb, '-');
-        value = -value;
+        magnitude = UINT64_C(0) - magnitude;
     }
 
-    buffer_print_uint64_hex(wb, (uint64_t)value);
+    buffer_print_uint64_hex(wb, magnitude);
 
     buffer_overflow_check(wb);
 }
@@ -660,13 +662,14 @@ static void buffer_print_int64_hex(BUFFER *wb, int64_t value) {
 ALWAYS_INLINE
 static void buffer_print_int64_base64(BUFFER *wb, int64_t value) {
     buffer_need_bytes(wb, 2);
+    uint64_t magnitude = (uint64_t)value;
 
     if(value < 0) {
         buffer_putc(wb, '-');
-        value = -value;
+        magnitude = UINT64_C(0) - magnitude;
     }
 
-    buffer_print_uint64_base64(wb, (uint64_t)value);
+    buffer_print_uint64_base64(wb, magnitude);
 
     buffer_overflow_check(wb);
 }

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -135,7 +135,7 @@ static int str2i(const char *s) {
 
     if(unlikely(*s == '-')) {
         s++;
-        return -(int) str2u(s);
+        return (int)-str2u(s);
     }
     else {
         if(unlikely(*s == '+')) s++;
@@ -162,7 +162,7 @@ static long str2l(const char *s) {
 
     if(unlikely(*s == '-')) {
         s++;
-        return -(long) str2ul(s);
+        return (long)-str2ul(s);
     }
     else {
         if(unlikely(*s == '+')) s++;
@@ -222,7 +222,7 @@ static long long str2ll(const char *s, char **endptr) {
 
     if(unlikely(*s == '-')) {
         s++;
-        return -(long long) str2uint64_t(s, endptr);
+        return (long long)-str2uint64_t(s, endptr);
     }
     else {
         if(unlikely(*s == '+')) s++;
@@ -422,7 +422,7 @@ static unsigned long long str2ull_encoded(const char *s) {
 ALWAYS_INLINE
 static long long str2ll_encoded(const char *s) {
     if(*s == '-')
-        return -(long long) str2ull_encoded(&s[1]);
+        return (long long)-str2ull_encoded(&s[1]);
     else
         return (long long) str2ull_encoded(s);
 }

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -421,10 +421,17 @@ static unsigned long long str2ull_encoded(const char *s) {
 
 ALWAYS_INLINE
 static long long str2ll_encoded(const char *s) {
+    unsigned long long n;
+
     if(*s == '-')
-        return (long long)-str2ull_encoded(&s[1]);
+        n = -str2ull_encoded(&s[1]);
     else
-        return (long long) str2ull_encoded(s);
+        n = str2ull_encoded(s);
+
+    if(n <= (unsigned long long)LLONG_MAX)
+        return (long long)n;
+
+    return LLONG_MIN + (long long)(n - (unsigned long long)LLONG_MAX - 1);
 }
 
 ALWAYS_INLINE

--- a/src/registry/registry_db.c
+++ b/src/registry/registry_db.c
@@ -170,7 +170,7 @@ int registry_db_save(void) {
     netdata_log_debug(D_REGISTRY, "REGISTRY: saved %d persons", persons_saved);
 
     // save the totals
-    fprintf(fp, "T\t%016llx\t%016llx\t%016llx\t%016llx\t%016llx\t%016llx\n",
+    int totals_saved = fprintf(fp, "T\t%016llx\t%016llx\t%016llx\t%016llx\t%016llx\t%016llx\n",
             registry.persons_count,
             registry.machines_count,
             registry.usages_count + 1, // this is required - it is lost on db rotation
@@ -179,7 +179,19 @@ int registry_db_save(void) {
             registry.machines_urls_count
     );
 
-    fclose(fp);
+    int saved_errno = errno;
+    if(fclose(fp) != 0 || totals_saved < 0) {
+        if(totals_saved >= 0)
+            saved_errno = errno;
+
+        unlink(tmp_filename);
+        registry.consecutive_save_failures++;
+        registry.last_save_failure = now_realtime_sec();
+        errno = saved_errno;
+        netdata_log_error("REGISTRY: Cannot save temporary registry file '%s'", tmp_filename);
+        nd_log_limits_reset();
+        return -1;
+    }
 
     errno_clear();
 

--- a/src/registry/registry_db.c
+++ b/src/registry/registry_db.c
@@ -113,8 +113,9 @@ int registry_db_save(void) {
     // Implement exponential backoff for save failures
     if(registry.consecutive_save_failures > 0) {
         time_t now = now_realtime_sec();
-        time_t backoff_seconds = 60 * (1 << (registry.consecutive_save_failures - 1)); // 60s, 120s, 240s, etc.
-        if(backoff_seconds > 3600) backoff_seconds = 3600; // Cap at 1 hour
+        time_t backoff_seconds = registry.consecutive_save_failures < 7 ?
+                                     60 * (1 << (registry.consecutive_save_failures - 1)) : // 60s, 120s, etc.
+                                     3600; // Cap at 1 hour
         
         if((now - registry.last_save_failure) < backoff_seconds) {
             netdata_log_debug(D_REGISTRY, "REGISTRY: skipping save due to backoff (failed %d times, waiting %ld seconds)", 

--- a/src/streaming/stream-sender-commit.c
+++ b/src/streaming/stream-sender-commit.c
@@ -125,9 +125,11 @@ void sender_buffer_commit(struct sender_state *s, BUFFER *wb, struct sender_buff
                         // so that the decompressor will have a whole line to work with
 
                         const char *t = &src[COMPRESSION_MAX_MSG_SIZE];
-                        while (--t >= src)
+                        while (t > src) {
+                            t--;
                             if (unlikely(*t == '\n'))
                                 break;
+                        }
 
                         if (t <= src)
                             size_to_compress = COMPRESSION_MAX_MSG_SIZE;

--- a/src/web/api/http_auth.c
+++ b/src/web/api/http_auth.c
@@ -118,14 +118,19 @@ static bool bearer_token_save_to_file(nd_uuid_t token, struct bearer_token *bt) 
         return false;
     }
 
-    if(fwrite(buffer_tostring(wb), 1, buffer_strlen(wb), fp) != buffer_strlen(wb)) {
-        fclose(fp);
+    size_t len = buffer_strlen(wb);
+    size_t written = fwrite(buffer_tostring(wb), 1, len, fp);
+    int saved_errno = errno;
+    if(fclose(fp) != 0 || written != len) {
+        if(written == len)
+            saved_errno = errno;
+
         unlink(filename);
+        errno = saved_errno;
         nd_log(NDLS_DAEMON, NDLP_ERR, "Cannot save file '%s'", filename);
         return false;
     }
 
-    fclose(fp);
     return true;
 }
 

--- a/src/web/api/v3/api_v3_settings.c
+++ b/src/web/api/v3/api_v3_settings.c
@@ -179,17 +179,21 @@ static inline int settings_put(struct web_client *w, char *file) {
             HTTP_RESP_INTERNAL_SERVER_ERROR);
     }
     size_t len = strlen(updated_json_str);
-    if(fwrite(updated_json_str, 1, len, fp) != len) {
-        fclose(fp);
+    size_t written = fwrite(updated_json_str, 1, len, fp);
+    int saved_errno = errno;
+    if(fclose(fp) != 0 || written != len) {
+        if(written == len)
+            saved_errno = errno;
+
         unlink(tmp_filename);
         rw_spinlock_write_unlock(&settings_spinlock);
+        errno = saved_errno;
         nd_log(NDLS_DAEMON, NDLP_ERR, "cannot save settings to file '%s'", tmp_filename);
         return rrd_call_function_error(
             w->response.data,
             "Cannot save payload to file",
             HTTP_RESP_INTERNAL_SERVER_ERROR);
     }
-    fclose(fp);
 
     char filename[FILENAME_MAX];
     settings_filename(filename, file, NULL);

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -1530,7 +1530,8 @@ void web_client_process_request_from_web_server(struct web_client *w) {
                         web_client_flag_set(w, WEB_CLIENT_FLAG_PATH_HAS_TRAILING_SLASH);
 
                     // check if there is a filename extension
-                    while (--e > s) {
+                    while (e > s + 1) {
+                        e--;
                         if (*e == '/')
                             break;
                         if(*e == '.') {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened persistence and integer encode/parse across the agent, and removed undefined behavior in reverse scans and GUID handling. No API or behavior changes; this prevents silent data loss and UB while keeping outputs identical on success.

- **Bug Fixes**
  - File saves: check write and fclose results; clean up temp files on failure. Applied to settings PUT, bearer token save, cloud config, claimed_id, registry DB totals, and claim key generation (uses public key as the pair sentinel and cleans up on close errors).
  - Integer parsing: define INT/LONG/LLONG minimum handling in `str2i/str2l/str2ll/str2ll_encoded` without UB; keep unsigned arithmetic until the final cast.
  - Integer encoding: emit INT64_MIN safely in decimal, hex, and base64 by computing unsigned magnitude first.
  - Tests: add exhaustive int64 parse/round‑trip cases, including extrema and malformed forms.
  - UB removals: guard reverse cursor scans in legacy streaming splitter and web path extension check; behavior and boundaries unchanged.
  - Windows Events: avoid misaligned `ND_UUID` by copying GUID bytes with the helper before formatting.
  - Registry: cap exponential save backoff at 1h before shifting to avoid overflow; keeps 60,120,…,3600 cadence.

<sup>Written for commit 56babcc8c279ffcab6cf0085be23296a5f0182c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

