### PR TITLE
Netdata fixes part 74

### DIFF
--- a/src/daemon/dyncfg/dyncfg-files.c
+++ b/src/daemon/dyncfg/dyncfg-files.c
@@ -67,6 +67,17 @@ void dyncfg_file_save(const char *id, DYNCFG *df) {
     fclose(fp);
 }
 
+bool dyncfg_file_read_payload(FILE *fp, BUFFER *payload, size_t expected_size) {
+    buffer_flush(payload);
+    buffer_need_bytes(payload, expected_size);
+
+    size_t read_size = fread(payload->buffer, 1, expected_size, fp);
+    payload->len = read_size;
+    payload->buffer[read_size] = '\0';
+
+    return read_size == expected_size && !ferror(fp);
+}
+
 void dyncfg_file_load(const char *d_name) {
     char filename[PATH_MAX];
     snprintf(filename, sizeof(filename), "%s/%s", dyncfg_globals.dir, d_name);
@@ -146,6 +157,14 @@ void dyncfg_file_load(const char *d_name) {
         }
     }
 
+    if(ferror(fp)) {
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "DYNCFG: failed while reading metadata from file '%s'. Ignoring it.", filename);
+        fclose(fp);
+        dyncfg_cleanup(&tmp);
+        return;
+    }
+
     if (read_payload) {
         // Determine the actual size of the remaining file content
         int rc = 0;
@@ -194,13 +213,20 @@ void dyncfg_file_load(const char *d_name) {
         tmp.dyncfg.payload = buffer_create(actual_size, NULL);
         tmp.dyncfg.payload->content_type = content_type;
 
-        buffer_need_bytes(tmp.dyncfg.payload, actual_size);
-        tmp.dyncfg.payload->len = fread(tmp.dyncfg.payload->buffer, 1, actual_size, fp);
+        if(!dyncfg_file_read_payload(fp, tmp.dyncfg.payload, actual_size)) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "DYNCFG: failed to read the complete payload from file '%s': expected %zu bytes, read %zu, stream error: %s. Ignoring it.",
+                   filename, actual_size, (size_t)tmp.dyncfg.payload->len, ferror(fp) ? "yes" : "no");
+
+            fclose(fp);
+            dyncfg_cleanup(&tmp);
+            return;
+        }
 
         if (content_length != tmp.dyncfg.payload->len) {
             nd_log(NDLS_DAEMON, NDLP_WARNING,
                    "DYNCFG: content_length %zu does not match actual payload size %zu for file '%s'",
-                   content_length, actual_size, filename);
+                   content_length, (size_t)tmp.dyncfg.payload->len, filename);
         }
     }
 

--- a/src/daemon/dyncfg/dyncfg-internals.h
+++ b/src/daemon/dyncfg/dyncfg-internals.h
@@ -57,6 +57,7 @@ void dyncfg_load_all(void);
 void dyncfg_file_load(const char *filename);
 void dyncfg_file_save(const char *id, DYNCFG *df);
 void dyncfg_file_delete(const char *id);
+bool dyncfg_file_read_payload(FILE *fp, BUFFER *payload, size_t expected_size);
 
 // Returns the canonical command mask a node should advertise given its type
 // and current source_type. Idempotent and order-independent: re-run after a

--- a/src/daemon/dyncfg/dyncfg-unittest.c
+++ b/src/daemon/dyncfg/dyncfg-unittest.c
@@ -575,6 +575,208 @@ void dyncfg_unittest_delete_cb(const DICTIONARY_ITEM *item __maybe_unused, void 
     freez((void *)v->source);
 }
 
+static void dyncfg_file_unittest_check(bool condition, const char *test) {
+    if(condition)
+        return;
+
+    nd_log(NDLS_DAEMON, NDLP_ERR, "DYNCFG FILE UNITTEST: failed test '%s'", test);
+    dyncfg_unittest_register_error(NULL, NULL);
+}
+
+static bool dyncfg_file_unittest_write(const char *d_name, const void *data, size_t size) {
+    char filename[PATH_MAX];
+    snprintfz(filename, sizeof(filename), "%s/%s", dyncfg_globals.dir, d_name);
+
+    FILE *fp = fopen(filename, "wb");
+    if(!fp)
+        return false;
+
+    bool ok = fwrite(data, 1, size, fp) == size;
+    if(fclose(fp) != 0)
+        ok = false;
+    if(!ok)
+        unlink(filename);
+
+    return ok;
+}
+
+static void dyncfg_file_unittest_unlink(const char *d_name) {
+    char filename[PATH_MAX];
+    snprintfz(filename, sizeof(filename), "%s/%s", dyncfg_globals.dir, d_name);
+    unlink(filename);
+}
+
+static void dyncfg_file_unittest_remove(const char *id) {
+    dictionary_del(dyncfg_globals.nodes, id);
+    dictionary_garbage_collect(dyncfg_globals.nodes);
+    dyncfg_file_delete(id);
+}
+
+static void dyncfg_file_unittest_load_text(const char *test, const char *d_name, const char *text) {
+    if(!dyncfg_file_unittest_write(d_name, text, strlen(text))) {
+        dyncfg_file_unittest_check(false, test);
+        return;
+    }
+
+    dyncfg_file_load(d_name);
+    dyncfg_file_unittest_unlink(d_name);
+}
+
+static void dyncfg_file_unittest(void) {
+    static const unsigned char payload[] = { '{', '}', '\0', 'x' };
+    const char *writer_id = "unittest:dyncfg-load:writer";
+
+    DYNCFG saved = {
+        .host_uuid = UUID_ZERO,
+        .template = string_strdupz("unittest:dyncfg-load"),
+        .path = string_strdupz("/unittests/dyncfg-load"),
+        .cmds = DYNCFG_CMD_GET | DYNCFG_CMD_SCHEMA | DYNCFG_CMD_UPDATE | DYNCFG_CMD_REMOVE,
+        .type = DYNCFG_TYPE_JOB,
+        .sync = true,
+        .dyncfg = {
+            .saves = 0,
+            .user_disabled = true,
+            .source_type = DYNCFG_SOURCE_TYPE_DYNCFG,
+            .source = string_strdupz("dyncfg-file-unittest"),
+            .payload = buffer_create(sizeof(payload), NULL),
+            .created_ut = 1,
+            .modified_ut = 2,
+        },
+    };
+    buffer_memcat(saved.dyncfg.payload, payload, sizeof(payload));
+    saved.dyncfg.payload->content_type = CT_APPLICATION_JSON;
+
+    dyncfg_file_save(writer_id, &saved);
+    CLEAN_CHAR_P *escaped_writer_id = dyncfg_escape_id_for_filename(writer_id);
+    char writer_d_name[FILENAME_MAX];
+    snprintfz(writer_d_name, sizeof(writer_d_name), "%s.dyncfg", escaped_writer_id);
+    dyncfg_file_load(writer_d_name);
+
+    DYNCFG *loaded = dictionary_get(dyncfg_globals.nodes, writer_id);
+    dyncfg_file_unittest_check(loaded != NULL, "production writer artifact is accepted");
+    if(loaded) {
+        dyncfg_file_unittest_check(loaded->type == DYNCFG_TYPE_JOB, "writer type is preserved");
+        dyncfg_file_unittest_check(loaded->dyncfg.saves == 1, "writer save count is preserved");
+        dyncfg_file_unittest_check(loaded->dyncfg.user_disabled, "writer disabled state is preserved");
+        dyncfg_file_unittest_check(
+            loaded->dyncfg.payload && loaded->dyncfg.payload->content_type == CT_APPLICATION_JSON,
+            "writer content type is preserved");
+        dyncfg_file_unittest_check(
+            loaded->dyncfg.payload && loaded->dyncfg.payload->len == sizeof(payload) &&
+                memcmp(loaded->dyncfg.payload->buffer, payload, sizeof(payload)) == 0,
+            "writer payload bytes are preserved");
+    }
+    dyncfg_file_unittest_remove(writer_id);
+    dyncfg_cleanup(&saved);
+
+    const char *minimal_id = "unittest:dyncfg-load:minimal";
+    dyncfg_file_unittest_load_text(
+        "minimal forward-compatible artifact write", "unittest-dyncfg-load-minimal.dyncfg",
+        "version=99\nfuture_key=future value\nid=unittest:dyncfg-load:minimal\n");
+    loaded = dictionary_get(dyncfg_globals.nodes, minimal_id);
+    dyncfg_file_unittest_check(loaded != NULL, "unknown fields and newer versions are accepted");
+    if(loaded) {
+        dyncfg_file_unittest_check(loaded->type == DYNCFG_TYPE_SINGLE, "missing type keeps default");
+        dyncfg_file_unittest_check(loaded->current.status == DYNCFG_STATUS_ORPHAN, "minimal file is orphaned");
+        dyncfg_file_unittest_check(!loaded->dyncfg.payload, "missing payload remains absent");
+    }
+    dyncfg_file_unittest_remove(minimal_id);
+
+    const char *malformed_id = "unittest:dyncfg-load:malformed-metadata";
+    dyncfg_file_unittest_load_text(
+        "malformed optional metadata write", "unittest-dyncfg-load-malformed-metadata.dyncfg",
+        "id=unittest:dyncfg-load:malformed-metadata\n"
+        "type=not-a-type\nsource_type=not-a-source\ncreated=not-a-number\nmodified=-\n"
+        "sync=not-a-bool\nuser_disabled=not-a-bool\nsaves=not-a-number\ncmds=not-a-command\n");
+    loaded = dictionary_get(dyncfg_globals.nodes, malformed_id);
+    dyncfg_file_unittest_check(loaded != NULL, "malformed optional metadata retains compatibility defaults");
+    if(loaded) {
+        dyncfg_file_unittest_check(loaded->type == DYNCFG_TYPE_SINGLE, "unknown type defaults to single");
+        dyncfg_file_unittest_check(
+            loaded->dyncfg.source_type == DYNCFG_SOURCE_TYPE_INTERNAL,
+            "unknown source type defaults to internal");
+    }
+    dyncfg_file_unittest_remove(malformed_id);
+
+    const char *empty_payload_id = "unittest:dyncfg-load:empty-payload";
+    dyncfg_file_unittest_load_text(
+        "empty payload write", "unittest-dyncfg-load-empty-payload.dyncfg",
+        "id=unittest:dyncfg-load:empty-payload\ncontent_type=application/json\ncontent_length=0\n---\n");
+    loaded = dictionary_get(dyncfg_globals.nodes, empty_payload_id);
+    dyncfg_file_unittest_check(
+        loaded && loaded->dyncfg.payload && loaded->dyncfg.payload->len == 0,
+        "empty payload section is accepted");
+    dyncfg_file_unittest_remove(empty_payload_id);
+
+    const char *mismatch_id = "unittest:dyncfg-load:length-mismatch";
+    dyncfg_file_unittest_load_text(
+        "advisory content length write", "unittest-dyncfg-load-length-mismatch.dyncfg",
+        "id=unittest:dyncfg-load:length-mismatch\ncontent_type=application/json\ncontent_length=99\n---\nabc");
+    loaded = dictionary_get(dyncfg_globals.nodes, mismatch_id);
+    dyncfg_file_unittest_check(
+        loaded && loaded->dyncfg.payload && loaded->dyncfg.payload->len == 3 &&
+            memcmp(loaded->dyncfg.payload->buffer, "abc", 3) == 0,
+        "declared length mismatch preserves complete remaining bytes");
+    dyncfg_file_unittest_remove(mismatch_id);
+
+    size_t entries_before = dictionary_entries(dyncfg_globals.nodes);
+    dyncfg_file_unittest_load_text(
+        "missing id write", "unittest-dyncfg-load-missing-id.dyncfg",
+        "path=/unittests\nsource=cleanup-check\ncontent_type=application/json\ncontent_length=2\n---\n{}");
+    dyncfg_file_unittest_check(
+        dictionary_entries(dyncfg_globals.nodes) == entries_before, "missing id is not published");
+
+    entries_before = dictionary_entries(dyncfg_globals.nodes);
+    dyncfg_file_unittest_load_text(
+        "empty id write", "unittest-dyncfg-load-empty-id.dyncfg", "id=\npath=/unittests\n");
+    dyncfg_file_unittest_check(
+        dictionary_entries(dyncfg_globals.nodes) == entries_before, "empty id is not published");
+
+    const char *compatible_id = "unittest dyncfg load compatible";
+    dyncfg_file_unittest_load_text(
+        "historical id syntax write", "unittest-dyncfg-load-compatible-id.dyncfg",
+        "id=unittest dyncfg load compatible\npath=/unittests\n");
+    loaded = dictionary_get(dyncfg_globals.nodes, compatible_id);
+    dyncfg_file_unittest_check(loaded != NULL, "historically accepted id syntax remains compatible");
+    dyncfg_file_unittest_remove(compatible_id);
+
+    CLEAN_BUFFER *read_buffer = buffer_create(8, NULL);
+    FILE *short_fp = tmpfile();
+    dyncfg_file_unittest_check(short_fp != NULL, "create short-read stream");
+    if(short_fp) {
+        dyncfg_file_unittest_check(
+            fwrite("abc", 1, 3, short_fp) == 3 && fseek(short_fp, 0, SEEK_SET) == 0,
+            "prepare short-read stream");
+
+        bool ok = dyncfg_file_read_payload(short_fp, read_buffer, 5);
+        dyncfg_file_unittest_check(!ok && read_buffer->len == 3, "short payload read is rejected");
+        fclose(short_fp);
+    }
+
+#ifndef OS_WINDOWS
+    int error_pipe[2] = { -1, -1 };
+    bool error_pipe_ready =
+        pipe(error_pipe) == 0 && sock_setnonblock(error_pipe[PIPE_READ], true) == 1;
+    dyncfg_file_unittest_check(error_pipe_ready, "create nonblocking read-error stream");
+    if(error_pipe_ready) {
+        FILE *error_fp = fdopen(error_pipe[PIPE_READ], "r");
+        dyncfg_file_unittest_check(error_fp != NULL, "open nonblocking read-error stream");
+        if(error_fp) {
+            bool ok = dyncfg_file_read_payload(error_fp, read_buffer, 1);
+            dyncfg_file_unittest_check(
+                !ok && read_buffer->len == 0 && ferror(error_fp), "payload stream error is rejected");
+            fclose(error_fp);
+            error_pipe[PIPE_READ] = -1;
+        }
+    }
+
+    if(error_pipe[PIPE_READ] != -1)
+        close(error_pipe[PIPE_READ]);
+    if(error_pipe[PIPE_WRITE] != -1)
+        close(error_pipe[PIPE_WRITE]);
+#endif
+}
+
 int dyncfg_unittest(void) {
     dyncfg_unittest_data.nodes = dictionary_create(DICT_OPTION_NONE);
     dictionary_register_delete_callback(dyncfg_unittest_data.nodes, dyncfg_unittest_delete_cb, NULL);
@@ -582,6 +784,7 @@ int dyncfg_unittest(void) {
     dyncfg_unittest_cleanup_files();
     rrd_functions_inflight_init();
     dyncfg_init(false);
+    dyncfg_file_unittest();
 
     // ------------------------------------------------------------------------
     // create the thread for testing async communication

--- a/src/daemon/dyncfg/dyncfg-unittest.c
+++ b/src/daemon/dyncfg/dyncfg-unittest.c
@@ -529,6 +529,7 @@ static int dyncfg_unittest_run(const char *cmd, BUFFER *wb, const char *payload,
 }
 
 static void dyncfg_unittest_cleanup_files(void) {
+    CLEAN_CHAR_P *escaped_prefix = dyncfg_escape_id_for_filename("unittest:");
     char path[FILENAME_MAX];
     snprintfz(path, sizeof(path) - 1, "%s/%s", netdata_configured_varlib_dir, "config");
 
@@ -541,7 +542,9 @@ static void dyncfg_unittest_cleanup_files(void) {
     struct dirent *entry;
     char filename[FILENAME_MAX + sizeof(entry->d_name)];
     while ((entry = readdir(dir)) != NULL) {
-        if ((entry->d_type == DT_REG || entry->d_type == DT_LNK) && strstartswith(entry->d_name, "unittest:") && strendswith(entry->d_name, ".dyncfg")) {
+        if ((entry->d_type == DT_REG || entry->d_type == DT_LNK) &&
+            (strstartswith(entry->d_name, "unittest:") || strstartswith(entry->d_name, escaped_prefix)) &&
+            strendswith(entry->d_name, ".dyncfg")) {
             snprintf(filename, sizeof(filename), "%s/%s", path, entry->d_name);
             nd_log(NDLS_DAEMON, NDLP_INFO, "DYNCFG UNITTEST: deleting file '%s'", filename);
             unlink(filename);
@@ -624,6 +627,20 @@ static void dyncfg_file_unittest_load_text(const char *test, const char *d_name,
 
 static void dyncfg_file_unittest(void) {
     static const unsigned char payload[] = { '{', '}', '\0', 'x' };
+
+    const char *cleanup_id = "unittest:dyncfg-load:cleanup";
+    CLEAN_CHAR_P *escaped_cleanup_id = dyncfg_escape_id_for_filename(cleanup_id);
+    char cleanup_d_name[FILENAME_MAX];
+    snprintfz(cleanup_d_name, sizeof(cleanup_d_name), "%s.dyncfg", escaped_cleanup_id);
+    char cleanup_filename[PATH_MAX];
+    snprintfz(cleanup_filename, sizeof(cleanup_filename), "%s/%s", dyncfg_globals.dir, cleanup_d_name);
+    dyncfg_file_unittest_check(
+        dyncfg_file_unittest_write(cleanup_d_name, "", 0), "canonical cleanup artifact write");
+    dyncfg_unittest_cleanup_files();
+    dyncfg_file_unittest_check(
+        access(cleanup_filename, F_OK) != 0 && errno == ENOENT, "canonical cleanup artifact is removed");
+    dyncfg_file_unittest_unlink(cleanup_d_name);
+
     const char *writer_id = "unittest:dyncfg-load:writer";
 
     DYNCFG saved = {

--- a/src/daemon/status-file-io.c
+++ b/src/daemon/status-file-io.c
@@ -102,10 +102,10 @@ static bool status_file_io_save_this(const char *directory, const char *filename
     // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS
 
     // Linux: https://man7.org/linux/man-pages/man7/signal-safety.7.html
-    // memcpy(), strlen(), open(), write(), fsync(), close(), fchmod(), rename(), unlink()
+    // memcpy(), strlen(), lstat(), open(), fstat(), ftruncate(), write(), fsync(), close(), fchmod(), rename(), unlink()
 
     // MacOS: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/sigaction.2.html#//apple_ref/doc/man/2/sigaction
-    // open(), write(), fsync(), close(), rename(), unlink()
+    // lstat(), open(), fstat(), ftruncate(), write(), fsync(), close(), rename(), unlink()
     // does not explicitly mention fchmod, memcpy(), and strlen(), but they are safe
 
     if(!directory || !*directory)
@@ -138,10 +138,37 @@ static bool status_file_io_save_this(const char *directory, const char *filename
     memcpy(&temp[pos], tid_str, tid_len); pos += tid_len;
     temp[pos] = '\0';
 
-    // Open file with O_WRONLY, O_CREAT, and O_TRUNC flags
-    int fd = open(temp, O_WRONLY | O_CREAT | O_TRUNC, 0664);
+    // Reuse a regular temporary file left by an interrupted save; create absent names exclusively.
+    struct stat before;
+    bool reuse = lstat(temp, &before) == 0;
+    if(reuse && !S_ISREG(before.st_mode))
+        return false;
+
+    if(!reuse && errno != ENOENT)
+        return false;
+
+    int flags = O_WRONLY | O_NONBLOCK;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    if(!reuse)
+        flags |= O_CREAT | O_EXCL;
+
+    int fd = open(temp, flags, 0664);
     if (fd == -1)
         return false;
+
+    struct stat after;
+    if(fstat(fd, &after) != 0 || !S_ISREG(after.st_mode) ||
+       (reuse && (before.st_dev != after.st_dev || before.st_ino != after.st_ino))) {
+        close(fd);
+        return false;
+    }
+
+    if(reuse && ftruncate(fd, 0) != 0) {
+        close(fd);
+        return false;
+    }
 
     /* Write content to file using write() */
     size_t total_written = 0;

--- a/src/registry/registry_db.c
+++ b/src/registry/registry_db.c
@@ -103,6 +103,79 @@ static inline int registry_person_save(const DICTIONARY_ITEM *item __maybe_unuse
 // ----------------------------------------------------------------------------
 // SAVE THE REGISTRY DATABASE
 
+static FILE *registry_db_open_tmp_file(const char *filename) {
+    struct stat before;
+    bool reuse = lstat(filename, &before) == 0;
+    if(reuse && !S_ISREG(before.st_mode)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if(!reuse && errno != ENOENT)
+        return NULL;
+
+    int flags = O_WRONLY;
+    if(reuse) {
+        flags |= O_NOFOLLOW;
+        flags |= O_NONBLOCK;
+    }
+    else
+        flags |= O_CREAT | O_EXCL;
+
+    int fd = open(filename, flags, 0666);
+    if(fd == -1)
+        return NULL;
+
+    struct stat after;
+    if(fstat(fd, &after) != 0) {
+        int saved_errno = errno;
+        if(!reuse)
+            unlink(filename);
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if(!S_ISREG(after.st_mode) ||
+       (reuse && (before.st_dev != after.st_dev || before.st_ino != after.st_ino))) {
+        if(!reuse)
+            unlink(filename);
+        close(fd);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if(reuse) {
+        // O_NONBLOCK protects validation from FIFO races; the returned stream must retain fopen() semantics.
+        int status_flags = fcntl(fd, F_GETFL);
+        if(status_flags == -1 || fcntl(fd, F_SETFL, status_flags & ~(O_NONBLOCK | O_NOFOLLOW)) != 0) {
+            int saved_errno = errno;
+            close(fd);
+            errno = saved_errno;
+            return NULL;
+        }
+    }
+
+    FILE *fp = fdopen(fd, "w");
+    if(!fp) {
+        int saved_errno = errno;
+        if(!reuse)
+            unlink(filename);
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if(reuse && ftruncate(fileno(fp), 0) != 0) {
+        int saved_errno = errno;
+        fclose(fp);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    return fp;
+}
+
 int registry_db_save(void) {
     if(unlikely(!registry.enabled))
         return -1;
@@ -135,7 +208,7 @@ int registry_db_save(void) {
     snprintfz(old_tmp_filename, FILENAME_MAX, "%s.old.tmp", registry.db_filename);
 
     netdata_log_debug(D_REGISTRY, "REGISTRY: Creating file '%s'", tmp_filename);
-    FILE *fp = fopen(tmp_filename, "w");
+    FILE *fp = registry_db_open_tmp_file(tmp_filename);
     if(!fp) {
         netdata_log_error("REGISTRY: Cannot create file: %s", tmp_filename);
         nd_log_limits_reset();

--- a/src/registry/registry_db.c
+++ b/src/registry/registry_db.c
@@ -348,7 +348,7 @@ size_t registry_db_load(void) {
     size_t line = 0;
 
     netdata_log_debug(D_REGISTRY, "REGISTRY: loading active db from: '%s'", registry.db_filename);
-    FILE *fp = fopen(registry.db_filename, "r");
+    FILE *fp = registry_fopen_regular(registry.db_filename, "r");
     if(!fp) {
         if (errno != ENOENT)
             netdata_log_error("REGISTRY: cannot open registry file: '%s'", registry.db_filename);

--- a/src/registry/registry_internals.c
+++ b/src/registry/registry_internals.c
@@ -5,6 +5,76 @@
 
 struct registry registry;
 
+FILE *registry_fopen_regular(const char *filename, const char *mode) {
+    int flags;
+    bool truncate = false;
+
+    if(strcmp(mode, "r") == 0)
+        flags = O_RDONLY;
+    else if(strcmp(mode, "a") == 0)
+        flags = O_WRONLY | O_APPEND | O_CREAT;
+    else if(strcmp(mode, "w") == 0) {
+        flags = O_WRONLY | O_CREAT;
+        truncate = true;
+    }
+    else {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    struct stat st;
+    if(stat(filename, &st) == 0) {
+        if(!S_ISREG(st.st_mode)) {
+            errno = EINVAL;
+            return NULL;
+        }
+    }
+    else if(errno != ENOENT)
+        return NULL;
+
+    int fd = open(filename, flags | O_NONBLOCK, 0666);
+    if(fd == -1)
+        return NULL;
+
+    if(fstat(fd, &st) != 0) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if(!S_ISREG(st.st_mode)) {
+        close(fd);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    int status_flags = fcntl(fd, F_GETFL);
+    if(status_flags == -1 || fcntl(fd, F_SETFL, status_flags & ~O_NONBLOCK) != 0) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    FILE *fp = fdopen(fd, mode);
+    if(!fp) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if(truncate && ftruncate(fd, 0) != 0) {
+        int saved_errno = errno;
+        fclose(fp);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    return fp;
+}
+
 // ----------------------------------------------------------------------------
 // common functions
 

--- a/src/registry/registry_internals.h
+++ b/src/registry/registry_internals.h
@@ -72,6 +72,8 @@ struct registry {
 
 extern struct registry registry;
 
+FILE *registry_fopen_regular(const char *filename, const char *mode);
+
 // REGISTRY LOW-LEVEL REQUESTS (in registry-internals.c)
 REGISTRY_PERSON *registry_request_access(const char *person_guid, char *machine_guid, char *url, char *name, time_t when);
 REGISTRY_PERSON *registry_request_delete(const char *person_guid, char *machine_guid, char *url, char *delete_url, time_t when);

--- a/src/registry/registry_log.c
+++ b/src/registry/registry_log.c
@@ -30,7 +30,7 @@ int registry_log_open(void) {
     if(registry.log_fp)
         fclose(registry.log_fp);
 
-    registry.log_fp = fopen(registry.log_filename, "a");
+    registry.log_fp = registry_fopen_regular(registry.log_filename, "a");
     if(registry.log_fp) {
         if (setvbuf(registry.log_fp, NULL, _IOLBF, 0) != 0)
             netdata_log_error("Cannot set line buffering on registry log file.");
@@ -53,7 +53,7 @@ void registry_log_recreate(void) {
         registry_log_close();
 
         // open it with truncate
-        registry.log_fp = fopen(registry.log_filename, "w");
+        registry.log_fp = registry_fopen_regular(registry.log_filename, "w");
         if(registry.log_fp) fclose(registry.log_fp);
         else
             netdata_log_error("Cannot truncate registry log '%s'", registry.log_filename);
@@ -71,7 +71,7 @@ ssize_t registry_log_load(void) {
     registry_log_close();
 
     netdata_log_debug(D_REGISTRY, "Registry: loading active db from: %s", registry.log_filename);
-    FILE *fp = fopen(registry.log_filename, "r");
+    FILE *fp = registry_fopen_regular(registry.log_filename, "r");
     if(!fp)
         netdata_log_error("Registry: cannot open registry file: %s", registry.log_filename);
     else {

--- a/src/web/api/mcp_auth.c
+++ b/src/web/api/mcp_auth.c
@@ -21,12 +21,30 @@ static bool mcp_api_key_generate_and_save(void) {
     // Construct full path
     char path[PATH_MAX];
     snprintf(path, sizeof(path), "%s/%s", netdata_configured_varlib_dir, MCP_DEV_PREVIEW_API_KEY_FILENAME);
-    
-    // Open file with O_CREAT | O_EXCL to ensure we don't overwrite
-    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+
+    struct stat st;
+    if (stat(path, &st) == 0 && !S_ISREG(st.st_mode)) {
+        netdata_log_error("MCP: API key file %s is not a regular file", path);
+        return false;
+    }
+
+    // Validate the opened object before truncating it.
+    int fd = open(path, O_WRONLY | O_CREAT | O_NONBLOCK, 0600);
     if (fd == -1) {
         netdata_log_error("MCP: Failed to create API key file %s: %s", 
                          path, strerror(errno));
+        return false;
+    }
+
+    if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
+        netdata_log_error("MCP: API key file %s is not a regular file", path);
+        close(fd);
+        return false;
+    }
+
+    if (ftruncate(fd, 0) != 0) {
+        netdata_log_error("MCP: Failed to truncate API key file %s: %s", path, strerror(errno));
+        close(fd);
         return false;
     }
     
@@ -42,14 +60,15 @@ static bool mcp_api_key_generate_and_save(void) {
         return false;
     }
     
-    close(fd);
-    
     // Ensure file permissions are correct (only owner can read/write)
-    if (chmod(path, 0600) == -1) {
+    if (fchmod(fd, 0600) == -1) {
         netdata_log_error("MCP: Failed to set permissions on API key file: %s", strerror(errno));
+        close(fd);
         unlink(path);
         return false;
     }
+
+    close(fd);
     
     netdata_log_info("MCP: Generated new developer preview API key");
     return true;
@@ -59,8 +78,14 @@ static bool mcp_api_key_load(void) {
     // Construct full path
     char path[PATH_MAX];
     snprintf(path, sizeof(path), "%s/%s", netdata_configured_varlib_dir, MCP_DEV_PREVIEW_API_KEY_FILENAME);
-    
-    int fd = open(path, O_RDONLY);
+
+    struct stat st;
+    if (stat(path, &st) == 0 && !S_ISREG(st.st_mode)) {
+        netdata_log_error("MCP: API key file %s is not a regular file", path);
+        return false;
+    }
+
+    int fd = open(path, O_RDONLY | O_NONBLOCK);
     if (fd == -1) {
         if (errno == ENOENT) {
             // File doesn't exist, this is expected on first run
@@ -68,6 +93,12 @@ static bool mcp_api_key_load(void) {
         }
         netdata_log_error("MCP: Failed to open API key file %s: %s", 
                          path, strerror(errno));
+        return false;
+    }
+
+    if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
+        netdata_log_error("MCP: API key file %s is not a regular file", path);
+        close(fd);
         return false;
     }
     


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened file I/O across DynCfg, Registry, Status, and MCP to reject special files, short reads, and blocking opens, preventing startup hangs and partial data publication. Adds exact-length payload reads, validates temp files, and secures configured paths; regular-file behavior is unchanged.

- **Bug Fixes**
  - DynCfg: reject metadata read errors before publish; add exact-count payload reader; report verified sizes in length-mismatch warnings; tests cover short reads/stream errors; cleanup handles escaped `unittest:` IDs.
  - Status: classify temps with lstat; open nonblocking with O_NOFOLLOW; validate via fstat + inode match; truncate only verified stale regular temps; keep rename-based publication.
  - Registry: safe creation/reuse of `<db>.tmp` with type/inode checks and delayed truncation; new `registry_fopen_regular()` validates configured DB/log paths, restores blocking stdio, preserves O_APPEND, and truncates only after verification; used in DB load and log open/recreate/load.
  - MCP API key: require regular file targets; open with O_NONBLOCK; validate with fstat; truncate after validation; set 0600 via fchmod on the opened descriptor.

<sup>Written for commit 99cfd6b9a94bcd61f438c8dd9361ad3683a3349b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

