### PR TITLE
Netdata fixes part 75

### DIFF
--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -956,9 +956,10 @@ void aclk_create_node_instance_job(RRDHOST *host)
 
     aclk_query_t *query = aclk_query_new(REGISTER_NODE);
     int32_t hops =  rrdhost_ingestion_hops(host);
+    RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
     node_instance_creation_t node_instance_creation = {
         .hops = hops,
-        .hostname = rrdhost_hostname(host),
+        .hostname = string2str(identity.hostname),
         .machine_guid = host->machine_guid,
         .claim_id = claim_id.str
     };
@@ -966,6 +967,7 @@ void aclk_create_node_instance_job(RRDHOST *host)
     query->data.bin_payload.topic = ACLK_TOPICID_CREATE_NODE;
     query->data.bin_payload.msg_name = "CreateNodeInstance";
     query->data.bin_payload.payload = generate_node_instance_creation(&query->data.bin_payload.size, &node_instance_creation);
+    rrdhost_identity_release(&identity);
 
     nd_log_daemon(NDLP_DEBUG, "Queuing registration for host=%s, hops=%d", host->machine_guid, hops);
 

--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -519,7 +519,9 @@ void analytics_alarms(void)
             continue;
         }
 
-        switch (rc->status) {
+        RRDCALC_RUNTIME_SNAPSHOT snapshot;
+        rrdcalc_runtime_snapshot_get(rc, &snapshot);
+        switch (snapshot.status) {
             case RRDCALC_STATUS_WARNING:
                 alarm_warn++;
                 break;

--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -354,19 +354,42 @@ static cmd_status_t cmd_dumpconfig(char *args, char **message)
     return CMD_STATUS_SUCCESS;
 }
 
-static int remove_ephemeral_host(BUFFER *wb, RRDHOST *host, bool report_error, bool unregister)
+static int remove_ephemeral_host(BUFFER *wb, const char *machine_guid, bool report_error, bool unregister)
 {
+    rrd_rdlock();
+    RRDHOST *host = rrdhost_find_by_guid(machine_guid);
+    if (!host) {
+        rrd_rdunlock();
+        return 0;
+    }
+
     if (host == localhost) {
         if (report_error)
             buffer_sprintf(wb, "Node '%s' (machine guid: %s) is our localhost - not changing it",
                            rrdhost_hostname(host), host->machine_guid);
+        rrd_rdunlock();
         return 0;
     }
+
+    bool locked = unregister ? rw_spinlock_trywrite_lock(&host->metadata_lifetime_lock)
+                             : rw_spinlock_tryread_lock(&host->metadata_lifetime_lock);
+    if (!locked) {
+        if (report_error)
+            buffer_sprintf(wb, "Node '%s' (machine guid: %s) is busy - try again",
+                           rrdhost_hostname(host), host->machine_guid);
+        rrd_rdunlock();
+        return -1;
+    }
+    rrd_rdunlock();
 
     if (rrdhost_is_online(host)) {
         if (report_error)
             buffer_sprintf(wb, "Node '%s' (machine guid: %s) is online - not changing it",
                            rrdhost_hostname(host), host->machine_guid);
+        if (unregister)
+            rw_spinlock_write_unlock(&host->metadata_lifetime_lock);
+        else
+            rw_spinlock_read_unlock(&host->metadata_lifetime_lock);
         return 0;
     }
 
@@ -389,13 +412,14 @@ static int remove_ephemeral_host(BUFFER *wb, RRDHOST *host, bool report_error, b
         host->node_id = UUID_ZERO;
         buffer_sprintf(wb, "Node '%s' (machine guid: %s) has been unregistered",
                        rrdhost_hostname(host), host->machine_guid);
-        rrdhost_free___without_having_rrd_wrlock(host);
+        rrdhost_free___consume_metadata_lifetime_writelock(host);
         return 1;
     }
 
     if (marked) {
         buffer_sprintf(wb, "Node '%s' (machine guid: %s) has been marked ephemeral",
                        rrdhost_hostname(host), host->machine_guid);
+        rw_spinlock_read_unlock(&host->metadata_lifetime_lock);
         return 1;
     }
 
@@ -404,6 +428,7 @@ static int remove_ephemeral_host(BUFFER *wb, RRDHOST *host, bool report_error, b
                        rrdhost_hostname(host), host->machine_guid);
     }
 
+    rw_spinlock_read_unlock(&host->metadata_lifetime_lock);
     return 0;
 }
 
@@ -419,12 +444,16 @@ static cmd_status_t cmd_remove_stale_node_internal(char *args, char **message, b
         goto done;
     }
 
-    RRDHOST *host = NULL;
-    host = rrdhost_find_by_guid(args);
+    char machine_guid[UUID_STR_LEN] = "";
+    rrd_rdlock();
+    RRDHOST *host = rrdhost_find_by_guid(args);
     if (!host)
         host = rrdhost_find_by_node_id(args);
+    if (host)
+        strncpyz(machine_guid, host->machine_guid, sizeof(machine_guid));
+    rrd_rdunlock();
 
-    if (!host) {
+    if (!machine_guid[0]) {
         sqlite3_stmt *res = NULL;
 
         bool report_error = strcmp(args, "ALL_NODES") != 0;
@@ -439,31 +468,36 @@ static cmd_status_t cmd_remove_stale_node_internal(char *args, char **message, b
 
         param = 0;
         int cnt = 0;
+        int busy = 0;
         while (sqlite3_step_monitored(res) == SQLITE_ROW) {
             char guid[UUID_STR_LEN];
             if (!sqlite3_column_uuid_unparse_lower(res, 0, guid))
                 continue;
-            host = rrdhost_find_by_guid(guid);
-            if (host) {
-                int rc = remove_ephemeral_host(wb, host, report_error, unregister);
-                if(rc) {
-                    cnt += rc;
+            int rc = remove_ephemeral_host(wb, guid, report_error, unregister);
+            if (rc > 0) {
+                cnt += rc;
+                buffer_fast_strcat(wb, "\n", 1);
+            }
+            else if (rc < 0) {
+                busy++;
+                if (report_error)
                     buffer_fast_strcat(wb, "\n", 1);
-                }
             }
         }
-        if (!cnt && buffer_strlen(wb) == 0) {
+        if (!cnt && !busy && buffer_strlen(wb) == 0) {
             if (report_error)
                 buffer_sprintf(wb, "No match for \"%s\"", args);
             else
                 buffer_sprintf(wb, "No stale nodes found");
         }
+        else if (busy && !report_error)
+            buffer_sprintf(wb, "%d node%s %s busy - try again", busy, busy == 1 ? "" : "s", busy == 1 ? "is" : "are");
     done0:
         REPORT_BIND_FAIL(res, param);
         SQLITE_FINALIZE(res);
     }
     else
-        (void) remove_ephemeral_host(wb, host, true, unregister);
+        (void) remove_ephemeral_host(wb, machine_guid, true, unregister);
 
 done:
     *message = strdupz(buffer_tostring(wb));

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -262,6 +262,9 @@ static void svc_rrdhost_cleanup_orphan_hosts(RRDHOST *protected_host) {
                 continue;
         }
 
+        if (!rw_spinlock_trywrite_lock(&host->metadata_lifetime_lock))
+            continue;
+
         worker_is_busy(UV_EVENT_FREE_HOST);
 
         if (delete) {
@@ -287,17 +290,22 @@ static void svc_rrdhost_cleanup_orphan_hosts(RRDHOST *protected_host) {
 
             // Re-validate host still exists for cleanup
             RRDHOST *host_check = rrdhost_find_by_guid(machine_guid);
-            if (host_check) {
+            if (host_check == host) {
                 unregister_node(host_check->machine_guid);
+                rw_spinlock_write_unlock(&host->metadata_lifetime_lock);
                 rrdhost_free___while_having_rrd_wrlock(host_check);
             }
+            else
+                rw_spinlock_write_unlock(&host->metadata_lifetime_lock);
 
             // Restart iteration - the list may have changed while lock was released
             next = localhost;
             now = now_realtime_sec();
         }
-        else
+        else {
             rrdhost_cleanup_data_collection_and_health(host);
+            rw_spinlock_write_unlock(&host->metadata_lifetime_lock);
+        }
     }
     rrd_wrunlock();
 }

--- a/src/database/contexts/api_v1_contexts.c
+++ b/src/database/contexts/api_v1_contexts.c
@@ -361,7 +361,9 @@ static inline int rrdcontext_to_json_callback(const DICTIONARY_ITEM *item, void 
 
 int rrdcontext_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, const char *context, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions) {
     if(!host->rrdctx.contexts) {
-        netdata_log_error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, rrdhost_hostname(host));
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        netdata_log_error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, string2str(identity.hostname));
+        rrdhost_identity_release(&identity);
         return HTTP_RESP_NOT_FOUND;
     }
 
@@ -398,7 +400,9 @@ int rrdcontext_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, R
 
 int rrdcontexts_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions) {
     if(!host->rrdctx.contexts) {
-        netdata_log_error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, rrdhost_hostname(host));
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        netdata_log_error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, string2str(identity.hostname));
+        rrdhost_identity_release(&identity);
         return HTTP_RESP_NOT_FOUND;
     }
 
@@ -411,7 +415,9 @@ int rrdcontexts_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, 
         rrdr_relative_window_to_absolute_query(&after, &before, NULL, false);
 
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_DEFAULT);
-    buffer_json_member_add_string(wb, "hostname", rrdhost_hostname(host));
+    RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+    buffer_json_member_add_string(wb, "hostname", string2str(identity.hostname));
+    rrdhost_identity_release(&identity);
     buffer_json_member_add_string(wb, "machine_guid", host->machine_guid);
     buffer_json_member_add_string(wb, "node_id", node_uuid);
     CLAIM_ID claim_id = rrdhost_claim_id_get(host);

--- a/src/database/contexts/api_v2_contexts.c
+++ b/src/database/contexts/api_v2_contexts.c
@@ -313,13 +313,13 @@ static ssize_t rrdcontext_to_json_v2_add_context(void *data, RRDCONTEXT_ACQUIRED
     return 1;
 }
 
-void buffer_json_node_add_v2_mcp(BUFFER *wb, RRDHOST *host, size_t ni __maybe_unused) {
+void buffer_json_node_add_v2_mcp(BUFFER *wb, RRDHOST *host, const RRDHOST_IDENTITY *identity, size_t ni __maybe_unused) {
     buffer_json_member_add_string(wb, "machine_guid", host->machine_guid);
 
     if(!UUIDiszero(host->node_id))
         buffer_json_member_add_uuid(wb, "node_id", host->node_id.uuid);
 
-    buffer_json_member_add_string(wb, "hostname", rrdhost_hostname(host));
+    buffer_json_member_add_string(wb, "hostname", string2str(identity->hostname));
 
     buffer_json_member_add_string(wb, "relationship",
                                   host == localhost ? "localhost" :
@@ -475,12 +475,14 @@ static inline void rrdhost_health_to_json_v2(BUFFER *wb, const char *key, RRDHOS
 }
 
 static void rrdcontext_to_json_v2_rrdhost(BUFFER *wb, RRDHOST *host, struct rrdcontext_to_json_v2_data *ctl, size_t node_id) {
+    RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+
     buffer_json_add_array_item_object(wb); // this node
 
     if(ctl->options & CONTEXTS_OPTION_MCP)
-        buffer_json_node_add_v2_mcp(wb, host, node_id);
+        buffer_json_node_add_v2_mcp(wb, host, &identity, node_id);
     else
-        buffer_json_node_add_v2(wb, host, node_id, 0,
+        buffer_json_node_add_v2(wb, host, &identity, node_id, 0,
                             (ctl->mode & CONTEXTS_V2_AGENTS) && !(ctl->mode & CONTEXTS_V2_NODE_INSTANCES));
 
     if(ctl->mode & (CONTEXTS_V2_NODES_INFO | CONTEXTS_V2_NODES_STREAM_PATH | CONTEXTS_V2_NODE_INSTANCES)) {
@@ -488,7 +490,7 @@ static void rrdcontext_to_json_v2_rrdhost(BUFFER *wb, RRDHOST *host, struct rrdc
         rrdhost_status(host, ctl->now, &s, RRDHOST_STATUS_ALL);
 
         if (ctl->mode & (CONTEXTS_V2_NODES_INFO | CONTEXTS_V2_NODES_STREAM_PATH)) {
-            buffer_json_member_add_string(wb, "v", rrdhost_program_version(host));
+            buffer_json_member_add_string(wb, "v", string2str(identity.prog_version));
 
             host_labels2json(host, wb, "labels");
             spinlock_lock(&host->rrdhost_update_lock);
@@ -565,6 +567,7 @@ static void rrdcontext_to_json_v2_rrdhost(BUFFER *wb, RRDHOST *host, struct rrdc
         }
     }
     buffer_json_object_close(wb); // this node
+    rrdhost_identity_release(&identity);
 }
 
 static bool rrdhost_alert_status_snapshot_read(RRDHOST *host, struct health_alert_status_counts *snapshot) {

--- a/src/database/contexts/api_v2_contexts_alert_transitions.c
+++ b/src/database/contexts/api_v2_contexts_alert_transitions.c
@@ -114,6 +114,31 @@ struct facet_entry {
     uint32_t count;
 };
 
+struct alert_transition_host_snapshot {
+    RRDHOST_IDENTITY identity;
+    ND_UUID node_id;
+    bool found;
+};
+
+static struct alert_transition_host_snapshot alert_transition_host_snapshot_acquire(const char *machine_guid) {
+    struct alert_transition_host_snapshot snapshot = { 0 };
+
+    rrd_rdlock();
+    RRDHOST *host = rrdhost_find_by_guid(machine_guid);
+    if(host) {
+        snapshot.identity = rrdhost_identity_acquire(host);
+        snapshot.node_id = host->node_id;
+        snapshot.found = true;
+    }
+    rrd_rdunlock();
+
+    return snapshot;
+}
+
+static void alert_transition_host_snapshot_release(struct alert_transition_host_snapshot *snapshot) {
+    rrdhost_identity_release(&snapshot->identity);
+}
+
 static struct sql_alert_transition_fixed_size *contexts_v2_alert_transition_dup(struct sql_alert_transition_data *t, const char *machine_guid, struct sql_alert_transition_fixed_size *dst) {
     struct sql_alert_transition_fixed_size *n = dst ? dst : mallocz(sizeof(*n));
 
@@ -343,11 +368,13 @@ void contexts_v2_alert_transitions_to_json(BUFFER *wb, struct rrdcontext_to_json
                         {
                             buffer_json_member_add_string(wb, "id", x_dfe.name);
                             if (i == ATF_NODE) {
-                                RRDHOST *host = rrdhost_find_by_guid(x_dfe.name);
-                                if (host)
-                                    buffer_json_member_add_string(wb, "name", rrdhost_hostname(host));
+                                struct alert_transition_host_snapshot snapshot =
+                                    alert_transition_host_snapshot_acquire(x_dfe.name);
+                                if (snapshot.found)
+                                    buffer_json_member_add_string(wb, "name", string2str(snapshot.identity.hostname));
                                 else
                                     buffer_json_member_add_string(wb, "name", x_dfe.name);
+                                alert_transition_host_snapshot_release(&snapshot);
                             } else
                                 buffer_json_member_add_string(wb, "name", x_dfe.name);
                             buffer_json_member_add_uint64(wb, "count", x->count);
@@ -367,7 +394,8 @@ void contexts_v2_alert_transitions_to_json(BUFFER *wb, struct rrdcontext_to_json
     for(struct sql_alert_transition_fixed_size *t = data.base; t ; t = t->next) {
         buffer_json_add_array_item_object(wb);
         {
-            RRDHOST *host = rrdhost_find_by_guid(t->machine_guid);
+            struct alert_transition_host_snapshot snapshot =
+                alert_transition_host_snapshot_acquire(t->machine_guid);
 
             buffer_json_member_add_uint64(wb, JSKEY(alert_global_id), t->global_id);
             buffer_json_member_add_string(wb, "alert", *t->alert_name ? t->alert_name : NULL);
@@ -376,15 +404,16 @@ void contexts_v2_alert_transitions_to_json(BUFFER *wb, struct rrdcontext_to_json
                 buffer_json_member_add_uuid(wb, "transition_id", t->transition_id);
                 buffer_json_member_add_string(wb, "machine_guid", t->machine_guid);
 
-                if(host && !UUIDiszero(host->node_id))
-                    buffer_json_member_add_uuid(wb, "node_id", host->node_id.uuid);
+                if(snapshot.found && !UUIDiszero(snapshot.node_id))
+                    buffer_json_member_add_uuid(wb, "node_id", snapshot.node_id.uuid);
             }
 
             buffer_json_member_add_uuid(wb, "config_hash_id", t->config_hash_id);
 
-            if(host) {
-                buffer_json_member_add_string(wb, "hostname", rrdhost_hostname(host));
+            if(snapshot.found) {
+                buffer_json_member_add_string(wb, "hostname", string2str(snapshot.identity.hostname));
             }
+            alert_transition_host_snapshot_release(&snapshot);
 
             if(!(ctl->options & CONTEXTS_OPTION_MCP)) {
                 buffer_json_member_add_string(wb, "instance", *t->chart ? t->chart : NULL);

--- a/src/database/contexts/api_v2_contexts_alerts.c
+++ b/src/database/contexts/api_v2_contexts_alerts.c
@@ -712,7 +712,7 @@ static void alert_instances_v2_insert_callback(const DICTIONARY_ITEM *item __may
     t->name = rc->config.name;
     t->source = rc->config.source;
     t->info = rc->config.info;
-    t->summary = rc->summary;
+    rrdcalc_runtime_strings_acquire(rc, &t->summary, NULL);
     t->host = rc->rrdset->rrdhost;
     t->alarm_id = rc->id;
     t->ni = ctl->nodes.ni;
@@ -725,8 +725,9 @@ static bool alert_instances_v2_conflict_callback(const DICTIONARY_ITEM *item __m
     return true;
 }
 
-static void alert_instances_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, void *value __maybe_unused, void *data __maybe_unused) {
-    ;
+static void alert_instances_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused) {
+    struct sql_alert_instance_v2_entry *t = value;
+    string_freez(t->summary);
 }
 
 static void rrdcontext_v2_set_transition_filter(const char *machine_guid, const char *context, time_t alarm_id, void *data) {

--- a/src/database/contexts/api_v2_contexts_alerts.c
+++ b/src/database/contexts/api_v2_contexts_alerts.c
@@ -10,8 +10,15 @@ struct alert_counts {
     size_t error;
 };
 
+struct alert_runtime_snapshot {
+    RRDCALC *rc;
+    RRDCALC_RUNTIME_SNAPSHOT state;
+};
+
 struct alert_v2_entry {
     RRDCALC *tmp;
+    RRDCALC_STATUS tmp_status;
+    NETDATA_DOUBLE tmp_value;
 
     STRING *name;
     STRING *summary;
@@ -57,31 +64,34 @@ bool rrdcontext_matches_alert(struct rrdcontext_to_json_v2_data *ctl, RRDCONTEXT
                 if(ctl->alerts.alarm_id_filter && ctl->alerts.alarm_id_filter != (time_t)rcl->id)
                     continue;
 
+                struct alert_runtime_snapshot alert = { .rc = rcl };
+                rrdcalc_runtime_snapshot_get(rcl, &alert.state);
+
                 size_t m = ctl->request->alerts.status & CONTEXTS_ALERT_STATUSES ? 0 : 1;
 
                 if (!m) {
                     if ((ctl->request->alerts.status & CONTEXT_ALERT_UNINITIALIZED) &&
-                        rcl->status == RRDCALC_STATUS_UNINITIALIZED)
+                        alert.state.status == RRDCALC_STATUS_UNINITIALIZED)
                         m++;
 
                     if ((ctl->request->alerts.status & CONTEXT_ALERT_UNDEFINED) &&
-                        rcl->status == RRDCALC_STATUS_UNDEFINED)
+                        alert.state.status == RRDCALC_STATUS_UNDEFINED)
                         m++;
 
                     if ((ctl->request->alerts.status & CONTEXT_ALERT_CLEAR) &&
-                        rcl->status == RRDCALC_STATUS_CLEAR)
+                        alert.state.status == RRDCALC_STATUS_CLEAR)
                         m++;
 
                     if ((ctl->request->alerts.status & CONTEXT_ALERT_RAISED) &&
-                        rcl->status >= RRDCALC_STATUS_RAISED)
+                        alert.state.status >= RRDCALC_STATUS_RAISED)
                         m++;
 
                     if ((ctl->request->alerts.status & CONTEXT_ALERT_WARNING) &&
-                        rcl->status == RRDCALC_STATUS_WARNING)
+                        alert.state.status == RRDCALC_STATUS_WARNING)
                         m++;
 
                     if ((ctl->request->alerts.status & CONTEXT_ALERT_CRITICAL) &&
-                        rcl->status == RRDCALC_STATUS_CRITICAL)
+                        alert.state.status == RRDCALC_STATUS_CRITICAL)
                         m++;
 
                     if(!m)
@@ -92,6 +102,8 @@ bool rrdcontext_matches_alert(struct rrdcontext_to_json_v2_data *ctl, RRDCONTEXT
                 if(summary_requested) {
                     struct alert_v2_entry t = {
                         .tmp = rcl,
+                        .tmp_status = alert.state.status,
+                        .tmp_value = alert.state.value,
                     };
                     struct alert_v2_entry *a2e =
                         dictionary_set(ctl->alerts.summary, string2str(rcl->config.name),
@@ -103,28 +115,28 @@ bool rrdcontext_matches_alert(struct rrdcontext_to_json_v2_data *ctl, RRDCONTEXT
                                             (ssize_t)string_strlen(rcl->config.type),
                                             NULL,
                                             sizeof(struct alert_by_x_entry),
-                                            rcl);
+                                            &alert);
 
                     dictionary_set_advanced(ctl->alerts.by_component,
                                             string2str(rcl->config.component),
                                             (ssize_t)string_strlen(rcl->config.component),
                                             NULL,
                                             sizeof(struct alert_by_x_entry),
-                                            rcl);
+                                            &alert);
 
                     dictionary_set_advanced(ctl->alerts.by_classification,
                                             string2str(rcl->config.classification),
                                             (ssize_t)string_strlen(rcl->config.classification),
                                             NULL,
                                             sizeof(struct alert_by_x_entry),
-                                            rcl);
+                                            &alert);
 
                     dictionary_set_advanced(ctl->alerts.by_recipient,
                                             string2str(rcl->config.recipient),
                                             (ssize_t)string_strlen(rcl->config.recipient),
                                             NULL,
                                             sizeof(struct alert_by_x_entry),
-                                            rcl);
+                                            &alert);
 
                     char module[128];
                     rrdlabels_get_value_strcpyz(st->rrdlabels, module, sizeof(module), "_collect_module");
@@ -136,7 +148,7 @@ bool rrdcontext_matches_alert(struct rrdcontext_to_json_v2_data *ctl, RRDCONTEXT
                                             -1,
                                             NULL,
                                             sizeof(struct alert_by_x_entry),
-                                            rcl);
+                                            &alert);
                 }
 
                 matches++;
@@ -148,7 +160,15 @@ bool rrdcontext_matches_alert(struct rrdcontext_to_json_v2_data *ctl, RRDCONTEXT
                     struct sql_alert_instance_v2_entry z = {
                         .ati = ati,
                         .tmp = rcl,
+                        .status = alert.state.status,
+                        .flags = alert.state.run_flags,
+                        .value = alert.state.value,
+                        .last_updated = alert.state.last_updated,
+                        .last_status_change = alert.state.last_status_change,
+                        .last_status_change_value = alert.state.last_status_change_value,
+                        .global_id = alert.state.global_id,
                     };
+                    uuid_copy(z.last_transition_id, alert.state.last_transition_id);
                     dictionary_set(ctl->alerts.alert_instances, key, &z, sizeof(z));
                 }
             }
@@ -160,8 +180,8 @@ bool rrdcontext_matches_alert(struct rrdcontext_to_json_v2_data *ctl, RRDCONTEXT
     return matches != 0;
 }
 
-static void alert_counts_add(struct alert_counts *t, RRDCALC *rc) {
-    switch(rc->status) {
+static void alert_counts_add(struct alert_counts *t, RRDCALC_STATUS status, NETDATA_DOUBLE value) {
+    switch(status) {
         case RRDCALC_STATUS_CRITICAL:
             t->critical++;
             break;
@@ -180,17 +200,18 @@ static void alert_counts_add(struct alert_counts *t, RRDCALC *rc) {
 
         case RRDCALC_STATUS_UNDEFINED:
         default:
-            if(!netdata_double_isnumber(rc->value))
+            if(!netdata_double_isnumber(value))
                 t->error++;
 
             break;
     }
 }
 
-static void alerts_v2_add(struct alert_v2_entry *t, RRDCALC *rc) {
+static void alerts_v2_add(
+    struct alert_v2_entry *t, RRDCALC *rc, RRDCALC_STATUS status, NETDATA_DOUBLE value) {
     t->instances++;
 
-    alert_counts_add(&t->counts, rc);
+    alert_counts_add(&t->counts, status, value);
 
     dictionary_set(t->nodes, rc->rrdset->rrdhost->machine_guid, NULL, 0);
 
@@ -210,13 +231,14 @@ static void alerts_by_x_insert_callback(const DICTIONARY_ITEM *item __maybe_unus
         silent_string = string_strdupz("silent");
 
     struct alert_by_x_entry *b = value;
-    RRDCALC *rc = data;
-    if(!rc) {
+    struct alert_runtime_snapshot *alert = data;
+    if(!alert) {
         // prototype
         b->prototypes.available++;
     }
     else {
-        alert_counts_add(&b->running.counts, rc);
+        RRDCALC *rc = alert->rc;
+        alert_counts_add(&b->running.counts, alert->state.status, alert->state.value);
 
         b->running.total++;
 
@@ -256,7 +278,7 @@ static void alerts_v2_insert_callback(const DICTIONARY_ITEM *item __maybe_unused
     t->nodes = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_VALUE_LINK_DONT_CLONE|DICT_OPTION_NAME_LINK_DONT_CLONE);
     t->configs = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_VALUE_LINK_DONT_CLONE);
 
-    alerts_v2_add(t, rc);
+    alerts_v2_add(t, rc, t->tmp_status, t->tmp_value);
 }
 
 static bool alerts_v2_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused, void *old_value, void *new_value, void *data __maybe_unused) {
@@ -272,7 +294,7 @@ static bool alerts_v2_conflict_callback(const DICTIONARY_ITEM *item __maybe_unus
         rrdlabels_add(t->component, string2str(rc->config.component), "yes", RRDLABEL_SRC_AUTO);
     if (string_strlen(rc->config.type))
         rrdlabels_add(t->type, string2str(rc->config.type), "yes", RRDLABEL_SRC_AUTO);
-    alerts_v2_add(t, rc);
+    alerts_v2_add(t, rc, n->tmp_status, n->tmp_value);
     return true;
 }
 
@@ -689,20 +711,13 @@ static void alert_instances_v2_insert_callback(const DICTIONARY_ITEM *item __may
     t->component = rc->config.component;
     t->name = rc->config.name;
     t->source = rc->config.source;
-    t->status = rc->status;
-    t->flags = rc->run_flags;
     t->info = rc->config.info;
     t->summary = rc->summary;
-    t->value = rc->value;
-    t->last_updated = rc->last_updated;
-    t->last_status_change = rc->last_status_change;
-    t->last_status_change_value = rc->last_status_change_value;
     t->host = rc->rrdset->rrdhost;
     t->alarm_id = rc->id;
     t->ni = ctl->nodes.ni;
 
     uuid_copy(t->config_hash_id, rc->config.hash_id);
-    health_alarm_log_get_global_id_and_transition_id_for_rrdcalc(rc, &t->global_id, &t->last_transition_id);
 }
 
 static bool alert_instances_v2_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused, void *old_value __maybe_unused, void *new_value __maybe_unused, void *data __maybe_unused) {

--- a/src/database/contexts/api_v2_contexts_alerts.c
+++ b/src/database/contexts/api_v2_contexts_alerts.c
@@ -235,7 +235,7 @@ static void alerts_v2_insert_callback(const DICTIONARY_ITEM *item __maybe_unused
     struct alert_v2_entry *t = value;
     RRDCALC *rc = t->tmp;
     t->name = rc->config.name;
-    t->summary = rc->config.summary; // the original summary
+    t->summary = string_dup(rc->config.summary); // the original summary
     t->context = rrdlabels_create();
     t->recipient = rrdlabels_create();
     t->classification = rrdlabels_create();
@@ -279,6 +279,7 @@ static bool alerts_v2_conflict_callback(const DICTIONARY_ITEM *item __maybe_unus
 static void alerts_v2_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused) {
     struct alert_v2_entry *t = value;
 
+    string_freez(t->summary);
     rrdlabels_destroy(t->context);
     rrdlabels_destroy(t->recipient);
     rrdlabels_destroy(t->classification);

--- a/src/database/contexts/query_scope.c
+++ b/src/database/contexts/query_scope.c
@@ -18,6 +18,15 @@ ssize_t query_scope_foreach_host(SIMPLE_PATTERN *scope_hosts_sp, SIMPLE_PATTERN 
     uint64_t t_hash = 0;
 
     dfe_start_read(rrdhost_root_index, host) {
+        RRDHOST_IDENTITY identity = { 0 };
+        char host_machine_guid[GUID_LEN + 1] = "";
+
+        if(scope_hosts_sp || hosts_sp)
+            identity = rrdhost_identity_acquire(host);
+
+        if(hosts_sp)
+            strncpyz(host_machine_guid, host->machine_guid, GUID_LEN);
+
         if(!UUIDiszero(host->node_id))
             uuid_unparse_lower(host->node_id.uuid, host_node_id_str);
         else
@@ -25,7 +34,7 @@ ssize_t query_scope_foreach_host(SIMPLE_PATTERN *scope_hosts_sp, SIMPLE_PATTERN 
 
         SIMPLE_PATTERN_RESULT match = SP_MATCHED_POSITIVE;
         if(scope_hosts_sp) {
-            match = simple_pattern_matches_string_extract(scope_hosts_sp, host->hostname, NULL, 0);
+            match = simple_pattern_matches_string_extract(scope_hosts_sp, identity.hostname, NULL, 0);
             if(match == SP_NOT_MATCHED) {
                 match = simple_pattern_matches_extract(scope_hosts_sp, host->machine_guid, NULL, 0);
                 if(match == SP_NOT_MATCHED && *host_node_id_str)
@@ -33,21 +42,24 @@ ssize_t query_scope_foreach_host(SIMPLE_PATTERN *scope_hosts_sp, SIMPLE_PATTERN 
             }
         }
 
-        if(match != SP_MATCHED_POSITIVE)
+        if(match != SP_MATCHED_POSITIVE) {
+            rrdhost_identity_release(&identity);
             continue;
+        }
 
         dfe_unlock(host);
 
         if(hosts_sp) {
-            match = simple_pattern_matches_string_extract(hosts_sp, host->hostname, NULL, 0);
+            match = simple_pattern_matches_string_extract(hosts_sp, identity.hostname, NULL, 0);
             if(match == SP_NOT_MATCHED) {
-                match = simple_pattern_matches_extract(hosts_sp, host->machine_guid, NULL, 0);
+                match = simple_pattern_matches_extract(hosts_sp, host_machine_guid, NULL, 0);
                 if(match == SP_NOT_MATCHED && *host_node_id_str)
                     match = simple_pattern_matches_extract(hosts_sp, host_node_id_str, NULL, 0);
             }
         }
 
         bool queryable_host = (match == SP_MATCHED_POSITIVE);
+        rrdhost_identity_release(&identity);
 
         v_hash += dictionary_version(host->rrdctx.contexts);
         h_hash += rrdcontext_queue_version(&host->rrdctx.hub_queue);

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -642,7 +642,9 @@ static void query_target_eval_instance_rrdcalc(QUERY_TARGET_LOCALS *qtl __maybe_
     if (st) {
         rw_spinlock_read_lock(&st->alerts.spinlock);
         for (RRDCALC *rc = st->alerts.base; rc; rc = rc->next) {
-            switch(rc->status) {
+            RRDCALC_RUNTIME_SNAPSHOT snapshot;
+            rrdcalc_runtime_snapshot_get(rc, &snapshot);
+            switch(snapshot.status) {
                 case RRDCALC_STATUS_CLEAR:
                     qi->alerts.clear++;
                     qc->alerts.clear++;
@@ -708,7 +710,9 @@ static bool query_target_match_alert_pattern(RRDINSTANCE_ACQUIRED *ria, SIMPLE_P
 
             buffer_fast_strcat(wb, string2str(rc->config.name), string_strlen(rc->config.name));
             buffer_fast_strcat(wb, ":", 1);
-            buffer_strcat(wb, rrdcalc_status2string(rc->status));
+            RRDCALC_RUNTIME_SNAPSHOT snapshot;
+            rrdcalc_runtime_snapshot_get(rc, &snapshot);
+            buffer_strcat(wb, rrdcalc_status2string(snapshot.status));
 
             ret = simple_pattern_matches_buffer_extract(pattern, wb, NULL, 0);
 

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -230,6 +230,7 @@ typedef struct query_target_locals {
     size_t metrics_skipped_due_to_not_matching_timeframe;
 
     char host_node_id_str[UUID_STR_LEN];
+    const STRING *host_hostname; // borrowed while query_node_add() traverses one host
     QUERY_NODE *qn; // temp to pass on callbacks, ignore otherwise - no need to free
 } QUERY_TARGET_LOCALS;
 
@@ -569,14 +570,14 @@ static inline STRING *rrdinstance_create_id_fqdn_v2(RRDINSTANCE_ACQUIRED *ria) {
     return string_strdupz(buffer);
 }
 
-static inline STRING *rrdinstance_create_name_fqdn_v2(RRDINSTANCE_ACQUIRED *ria) {
+static inline STRING *rrdinstance_create_name_fqdn_v2(
+    RRDINSTANCE_ACQUIRED *ria, const STRING *host_hostname) {
     if(unlikely(!ria))
         return NULL;
 
     char buffer[RRD_ID_LENGTH_MAX + 1];
 
-    RRDHOST *host = rrdinstance_acquired_rrdhost(ria);
-    snprintfz(buffer, RRD_ID_LENGTH_MAX, "%s@%s", rrdinstance_acquired_name(ria), rrdhost_hostname(host));
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "%s@%s", rrdinstance_acquired_name(ria), string2str(host_hostname));
     return string_strdupz(buffer);
 }
 
@@ -591,12 +592,13 @@ inline STRING *query_instance_id_fqdn(QUERY_INSTANCE *qi, size_t version) {
     return qi->id_fqdn;
 }
 
-inline STRING *query_instance_name_fqdn(QUERY_INSTANCE *qi, size_t version) {
+inline STRING *query_instance_name_fqdn(
+    QUERY_INSTANCE *qi, size_t version, const STRING *host_hostname) {
     if(!qi->name_fqdn) {
         if (version <= 1)
             qi->name_fqdn = rrdinstance_create_name_fqdn_v1(qi->ria);
         else
-            qi->name_fqdn = rrdinstance_create_name_fqdn_v2(qi->ria);
+            qi->name_fqdn = rrdinstance_create_name_fqdn_v2(qi->ria, host_hostname);
     }
 
     return qi->name_fqdn;
@@ -768,6 +770,7 @@ static inline SIMPLE_PATTERN_RESULT query_instance_matches(QUERY_INSTANCE *qi,
                                              bool match_ids,
                                              bool match_names,
                                              size_t version,
+                                             const STRING *host_hostname,
                                              char *host_node_id_str) {
     SIMPLE_PATTERN_RESULT ret = SP_MATCHED_POSITIVE;
 
@@ -781,7 +784,7 @@ static inline SIMPLE_PATTERN_RESULT query_instance_matches(QUERY_INSTANCE *qi,
         if (ret == SP_NOT_MATCHED && match_ids)
             ret = simple_pattern_matches_string_extract(instances_sp, query_instance_id_fqdn(qi, version), NULL, 0);
         if (ret == SP_NOT_MATCHED && match_names)
-            ret = simple_pattern_matches_string_extract(instances_sp, query_instance_name_fqdn(qi, version), NULL, 0);
+            ret = simple_pattern_matches_string_extract(instances_sp, query_instance_name_fqdn(qi, version, host_hostname), NULL, 0);
 
         if (ret == SP_NOT_MATCHED && match_ids && host_node_id_str[0]) {
             char buffer[RRD_ID_LENGTH_MAX + 1];
@@ -820,7 +823,8 @@ static bool query_instance_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_C
 
     if(queryable_instance && filter_instances)
         queryable_instance = (SP_MATCHED_POSITIVE == query_instance_matches(
-                qi, ri, qt->instances.pattern, qtl->match_ids, qtl->match_names, qt->request.version, qtl->host_node_id_str));
+                qi, ri, qt->instances.pattern, qtl->match_ids, qtl->match_names, qt->request.version,
+                qtl->host_hostname, qtl->host_node_id_str));
 
     if(queryable_instance)
         queryable_instance = query_instance_matches_labels(
@@ -911,7 +915,7 @@ static ssize_t query_scope_foreach_instance(QUERY_TARGET_LOCALS *qtl, QUERY_NODE
             QUERY_INSTANCE qi = { .ria = qt->request.ria };
             SIMPLE_PATTERN_RESULT ret = query_instance_matches(&qi, ri,
                 qt->instances.scope_pattern, qtl->match_ids, qtl->match_names, 
-                qt->request.version, qtl->host_node_id_str);
+                qt->request.version, qtl->host_hostname, qtl->host_node_id_str);
             query_instance_strings_free(&qi);
             if(ret != SP_MATCHED_POSITIVE)
                 return 0;
@@ -942,7 +946,7 @@ static ssize_t query_scope_foreach_instance(QUERY_TARGET_LOCALS *qtl, QUERY_NODE
             QUERY_INSTANCE qi = { .ria = ria };
             SIMPLE_PATTERN_RESULT ret = query_instance_matches(&qi, ri,
                 qt->instances.scope_pattern, qtl->match_ids, qtl->match_names, 
-                qt->request.version, qtl->host_node_id_str);
+                qt->request.version, qtl->host_hostname, qtl->host_node_id_str);
             query_instance_strings_free(&qi);
             if(ret != SP_MATCHED_POSITIVE) {
                 rrdinstance_release(ria);
@@ -979,7 +983,7 @@ static ssize_t query_scope_foreach_instance(QUERY_TARGET_LOCALS *qtl, QUERY_NODE
                 QUERY_INSTANCE qi = { .ria = ria };
                 SIMPLE_PATTERN_RESULT ret = query_instance_matches(&qi, ri,
                     qt->instances.scope_pattern, qtl->match_ids, qtl->match_names, 
-                    qt->request.version, qtl->host_node_id_str);
+                    qt->request.version, qtl->host_hostname, qtl->host_node_id_str);
                 query_instance_strings_free(&qi);
                 if(ret != SP_MATCHED_POSITIVE)
                     continue;
@@ -1078,6 +1082,12 @@ static ssize_t query_node_add(void *data, RRDHOST *host, bool queryable_host) {
 
     qtl->qn = qn;
 
+    RRDHOST_IDENTITY host_identity = { 0 };
+    if(qt->request.version >= 2 && qtl->match_names &&
+       (qt->instances.scope_pattern || qt->instances.pattern))
+        host_identity = rrdhost_identity_acquire(host);
+    qtl->host_hostname = host_identity.hostname;
+
     ssize_t added = 0;
     if(unlikely(qt->request.rca)) {
         if(query_context_add(qtl, qt->request.rca, true))
@@ -1099,6 +1109,8 @@ static ssize_t query_node_add(void *data, RRDHOST *host, bool queryable_host) {
             added = 0;
     }
 
+    qtl->host_hostname = NULL;
+    rrdhost_identity_release(&host_identity);
     qtl->qn = NULL;
 
     if(!added) {
@@ -1122,9 +1134,21 @@ void query_target_generate_name(QUERY_TARGET *qt) {
     if(qt->request.options & RRDR_OPTION_SELECTED_TIER)
         snprintfz(tier_buffer, 20, "/tier:%zu", qt->request.tier);
 
+    RRDHOST *query_name_host = NULL;
+    if(qt->request.st)
+        query_name_host = qt->request.st->rrdhost;
+    else if(qt->request.host &&
+            (qt->request.version < 2 ||
+             (qt->request.rca && qt->request.ria && qt->request.rma)))
+        query_name_host = qt->request.host;
+
+    RRDHOST_IDENTITY query_name_identity = { 0 };
+    if(query_name_host)
+        query_name_identity = rrdhost_identity_acquire(query_name_host);
+
     if(qt->request.st)
         snprintfz(qt->id, MAX_QUERY_TARGET_ID_LENGTH, "chart://hosts:%s/instance:%s/dimensions:%s/after:%lld/before:%lld/points:%zu/group:%s%s/options:%s%s%s"
-                , rrdhost_hostname(qt->request.st->rrdhost)
+                , string2str(query_name_identity.hostname)
                 , rrdset_name(qt->request.st)
                 , (qt->request.dimensions) ? qt->request.dimensions : "*"
                 , (long long)qt->request.after
@@ -1138,7 +1162,7 @@ void query_target_generate_name(QUERY_TARGET *qt) {
         );
     else if(qt->request.host && qt->request.rca && qt->request.ria && qt->request.rma)
         snprintfz(qt->id, MAX_QUERY_TARGET_ID_LENGTH, "metric://hosts:%s/context:%s/instance:%s/dimension:%s/after:%lld/before:%lld/points:%zu/group:%s%s/options:%s%s%s"
-                , rrdhost_hostname(qt->request.host)
+                , string2str(query_name_identity.hostname)
                 , rrdcontext_acquired_id(qt->request.rca)
                 , rrdinstance_acquired_id(qt->request.ria)
                 , rrdmetric_acquired_id(qt->request.rma)
@@ -1174,7 +1198,7 @@ void query_target_generate_name(QUERY_TARGET *qt) {
         );
     else
         snprintfz(qt->id, MAX_QUERY_TARGET_ID_LENGTH, "context://hosts:%s/contexts:%s/instances:%s/dimensions:%s/after:%lld/before:%lld/points:%zu/group:%s%s/options:%s%s%s"
-                , (qt->request.host) ? rrdhost_hostname(qt->request.host) : ((qt->request.nodes) ? qt->request.nodes : "*")
+                , (qt->request.host) ? string2str(query_name_identity.hostname) : ((qt->request.nodes) ? qt->request.nodes : "*")
                 , (qt->request.contexts) ? qt->request.contexts : "*"
                 , (qt->request.instances) ? qt->request.instances : "*"
                 , (qt->request.dimensions) ? qt->request.dimensions : "*"
@@ -1187,6 +1211,8 @@ void query_target_generate_name(QUERY_TARGET *qt) {
                 , resampling_buffer
                 , tier_buffer
         );
+
+    rrdhost_identity_release(&query_name_identity);
 
     // Sanitize the query ID - safe because qt->id is ASCII-only (from snprintfz)
     char buf[MAX_QUERY_TARGET_ID_LENGTH + 1];
@@ -1297,8 +1323,12 @@ QUERY_TARGET *query_target_create(QUERY_TARGET_REQUEST *qtr) {
         }
         else if (unlikely(host != qtl.st->rrdhost)) {
             // Oops! A different host!
+            RRDHOST_IDENTITY host_identity = rrdhost_identity_acquire(host);
+            RRDHOST_IDENTITY chart_host_identity = rrdhost_identity_acquire(qtl.st->rrdhost);
             netdata_log_error("QUERY TARGET: RRDSET '%s' given does not belong to host '%s'. Switching query host to '%s'",
-                  rrdset_name(qtl.st), rrdhost_hostname(host), rrdhost_hostname(qtl.st->rrdhost));
+                  rrdset_name(qtl.st), string2str(host_identity.hostname), string2str(chart_host_identity.hostname));
+            rrdhost_identity_release(&chart_host_identity);
+            rrdhost_identity_release(&host_identity);
             host = qtl.st->rrdhost;
         }
     }
@@ -1315,7 +1345,6 @@ QUERY_TARGET *query_target_create(QUERY_TARGET_REQUEST *qtr) {
         qt->versions.alerts_hard_hash = dictionary_version(host->rrdcalc_root_index);
         qt->versions.alerts_soft_hash = __atomic_load_n(&host->health_transitions, __ATOMIC_RELAXED);
         query_node_add(&qtl, host, true);
-        qtl.nodes = rrdhost_hostname(host);
     }
     else
         query_scope_foreach_host(qt->nodes.scope_pattern, qt->nodes.pattern,
@@ -1352,6 +1381,10 @@ ssize_t weights_foreach_rrdmetric_in_context(RRDCONTEXT_ACQUIRED *rca,
 
     char host_node_id_str[UUID_STR_LEN] = "";
 
+    RRDHOST_IDENTITY host_identity = { 0 };
+    if(version >= 2 && match_names && (scope_instances_sp || instances_sp))
+        host_identity = rrdhost_identity_acquire(rc->rrdhost);
+
     bool proceed = true;
 
     ssize_t count = 0;
@@ -1365,7 +1398,9 @@ ssize_t weights_foreach_rrdmetric_in_context(RRDCONTEXT_ACQUIRED *rca,
                 // Check scope_instances first - if it doesn't match, skip entirely
                 if(scope_instances_sp) {
                     QUERY_INSTANCE qi = { .ria = ria, };
-                    SIMPLE_PATTERN_RESULT ret = query_instance_matches(&qi, ri, scope_instances_sp, match_ids, match_names, version, host_node_id_str);
+                    SIMPLE_PATTERN_RESULT ret = query_instance_matches(
+                        &qi, ri, scope_instances_sp, match_ids, match_names, version,
+                        host_identity.hostname, host_node_id_str);
                     query_instance_strings_free(&qi);
 
                     if (ret != SP_MATCHED_POSITIVE)
@@ -1380,7 +1415,9 @@ ssize_t weights_foreach_rrdmetric_in_context(RRDCONTEXT_ACQUIRED *rca,
 
                 if(instances_sp) {
                     QUERY_INSTANCE qi = { .ria = ria, };
-                    SIMPLE_PATTERN_RESULT ret = query_instance_matches(&qi, ri, instances_sp, match_ids, match_names, version, host_node_id_str);
+                    SIMPLE_PATTERN_RESULT ret = query_instance_matches(
+                        &qi, ri, instances_sp, match_ids, match_names, version,
+                        host_identity.hostname, host_node_id_str);
                     query_instance_strings_free(&qi);
 
                     if (ret != SP_MATCHED_POSITIVE)
@@ -1445,6 +1482,7 @@ ssize_t weights_foreach_rrdmetric_in_context(RRDCONTEXT_ACQUIRED *rca,
                     break;
             }
     dfe_done(ri);
-    
+
+    rrdhost_identity_release(&host_identity);
     return count;
 }

--- a/src/database/contexts/rrdcontext.h
+++ b/src/database/contexts/rrdcontext.h
@@ -682,7 +682,7 @@ int rrdcontext_to_json_v2(BUFFER *wb, struct api_v2_contexts_request *req, CONTE
 
 RRDCONTEXT_TO_JSON_OPTIONS rrdcontext_to_json_parse_options(char *o);
 void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now_s, bool info, bool array, CONTEXTS_OPTIONS options);
-void buffer_json_node_add_v2(BUFFER *wb, RRDHOST *host, size_t ni, usec_t duration_ut, bool status);
+void buffer_json_node_add_v2(BUFFER *wb, RRDHOST *host, const RRDHOST_IDENTITY *identity, size_t ni, usec_t duration_ut, bool status);
 void buffer_json_query_timings(BUFFER *wb, const char *key, struct query_timings *timings);
 void buffer_json_cloud_timings(BUFFER *wb, const char *key, struct query_timings *timings);
 void buffer_json_agent_status_id(BUFFER *wb, size_t ai, usec_t duration_ut);

--- a/src/database/contexts/rrdcontext.h
+++ b/src/database/contexts/rrdcontext.h
@@ -604,7 +604,7 @@ static inline const char *query_metric_name(QUERY_TARGET *qt, QUERY_METRIC *qm) 
 struct storage *query_metric_storage_engine(QUERY_TARGET *qt, QUERY_METRIC *qm, size_t tier);
 
 STRING *query_instance_id_fqdn(QUERY_INSTANCE *qi, size_t version);
-STRING *query_instance_name_fqdn(QUERY_INSTANCE *qi, size_t version);
+STRING *query_instance_name_fqdn(QUERY_INSTANCE *qi, size_t version, const STRING *host_hostname);
 
 void query_target_free(void);
 void query_target_release(QUERY_TARGET *qt);

--- a/src/database/rrdhost-status.c
+++ b/src/database/rrdhost-status.c
@@ -330,7 +330,9 @@ static void rrdhost_status_health_internal(RRDHOST_STATUS *s, RRDHOST_FLAGS flag
                 continue;
             }
 
-            switch (rc->status) {
+            RRDCALC_RUNTIME_SNAPSHOT snapshot;
+            rrdcalc_runtime_snapshot_get(rc, &snapshot);
+            switch (snapshot.status) {
                 default:
                 case RRDCALC_STATUS_REMOVED:
                     break;

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -406,6 +406,7 @@ RRDHOST *rrdhost_create(
 
     spinlock_init(&host->receiver_lock);
     spinlock_init(&host->rrdhost_update_lock);
+    rw_spinlock_init(&host->metadata_lifetime_lock);
     rw_spinlock_init(&host->ml_host_rwlock);
     __atomic_store_n(&host->ml_running, false, __ATOMIC_RELAXED);
     spinlock_init(&host->aclk.spinlock);
@@ -731,16 +732,30 @@ RRDHOST *rrdhost_find_or_create(
         if (likely(!archived && rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)))
             return host;
 
-        /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
-        nd_log(NDLS_DAEMON, NDLP_INFO,
-               "Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
-               rrdhost_hostname(host),
-               rrd_memory_mode_name(host->rrd_memory_mode),
-               rrd_memory_mode_name(mode));
-
         rrd_wrlock();
-        rrdhost_free___while_having_rrd_wrlock(host);
-        host = NULL;
+        host = rrdhost_find_by_guid(guid);
+        if (host && host->rrd_memory_mode != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
+            if (likely(!archived && rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD))) {
+                rrd_wrunlock();
+                return host;
+            }
+
+            if (!rw_spinlock_trywrite_lock(&host->metadata_lifetime_lock)) {
+                rrd_wrunlock();
+                return NULL;
+            }
+
+            /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
+            nd_log(NDLS_DAEMON, NDLP_INFO,
+                   "Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
+                   rrdhost_hostname(host),
+                   rrd_memory_mode_name(host->rrd_memory_mode),
+                   rrd_memory_mode_name(mode));
+
+            rw_spinlock_write_unlock(&host->metadata_lifetime_lock);
+            rrdhost_free___while_having_rrd_wrlock(host);
+            host = NULL;
+        }
         rrd_wrunlock();
     }
 
@@ -912,11 +927,12 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host) {
     rrdhost_free_unlinked(host);
 }
 
-void rrdhost_free___without_having_rrd_wrlock(RRDHOST *host) {
+void rrdhost_free___consume_metadata_lifetime_writelock(RRDHOST *host) {
     if(!host) return;
 
     rrd_wrlock();
     rrdhost_unlink___while_having_rrd_wrlock(host);
+    rw_spinlock_write_unlock(&host->metadata_lifetime_lock);
     rrd_wrunlock();
 
     rrdhost_free_unlinked(host);

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -212,13 +212,17 @@ void rrdhost_tz_free(RRDHOST_TZ *tz) {
     tz->utc_offset = 0;
 }
 
-RRDHOST_IDENTITY rrdhost_identity_acquire(RRDHOST *host) {
-    RRDHOST_IDENTITY identity;
+static inline RRDHOST_IDENTITY rrdhost_identity_acquire_unsafe(RRDHOST *host) {
+    return (RRDHOST_IDENTITY) {
+        .hostname = string_dup(host->hostname),
+        .prog_name = string_dup(host->program_name),
+        .prog_version = string_dup(host->program_version),
+    };
+}
 
+RRDHOST_IDENTITY rrdhost_identity_acquire(RRDHOST *host) {
     spinlock_lock(&host->rrdhost_update_lock);
-    identity.hostname = string_dup(host->hostname);
-    identity.prog_name = string_dup(host->program_name);
-    identity.prog_version = string_dup(host->program_version);
+    RRDHOST_IDENTITY identity = rrdhost_identity_acquire_unsafe(host);
     spinlock_unlock(&host->rrdhost_update_lock);
 
     return identity;
@@ -231,6 +235,26 @@ void rrdhost_identity_release(RRDHOST_IDENTITY *identity) {
     identity->hostname = NULL;
     identity->prog_name = NULL;
     identity->prog_version = NULL;
+}
+
+RRDHOST_METADATA_IDENTITY rrdhost_metadata_identity_acquire(RRDHOST *host) {
+    spinlock_lock(&host->rrdhost_update_lock);
+    RRDHOST_METADATA_IDENTITY identity = {
+        .common = rrdhost_identity_acquire_unsafe(host),
+        .registry_hostname = string_dup(host->registry_hostname),
+        .os = string_dup(host->os),
+    };
+    spinlock_unlock(&host->rrdhost_update_lock);
+
+    return identity;
+}
+
+void rrdhost_metadata_identity_release(RRDHOST_METADATA_IDENTITY *identity) {
+    rrdhost_identity_release(&identity->common);
+    string_freez(identity->registry_hostname);
+    string_freez(identity->os);
+    identity->registry_hostname = NULL;
+    identity->os = NULL;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -539,6 +539,15 @@ typedef struct {
 RRDHOST_IDENTITY rrdhost_identity_acquire(RRDHOST *host);
 void rrdhost_identity_release(RRDHOST_IDENTITY *identity);
 
+typedef struct {
+    RRDHOST_IDENTITY common;
+    STRING *registry_hostname;
+    STRING *os;
+} RRDHOST_METADATA_IDENTITY;
+
+RRDHOST_METADATA_IDENTITY rrdhost_metadata_identity_acquire(RRDHOST *host);
+void rrdhost_metadata_identity_release(RRDHOST_METADATA_IDENTITY *identity);
+
 // Thread-safe timezone snapshot from an RRDHOST.
 // The returned struct owns strdup'd copies; release with rrdhost_tz_free().
 typedef struct {

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -327,6 +327,7 @@ struct rrdhost {
     // locks
 
     SPINLOCK rrdhost_update_lock;
+    RW_SPINLOCK metadata_lifetime_lock;
 
     // ------------------------------------------------------------------------
     // ML handle
@@ -516,7 +517,7 @@ RRDHOST *rrdhost_find_or_create(
 void rrdhost_free_all(void);
 
 void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host);
-void rrdhost_free___without_having_rrd_wrlock(RRDHOST *host);
+void rrdhost_free___consume_metadata_lifetime_writelock(RRDHOST *host);
 void rrdhost_cleanup_data_collection_and_health(RRDHOST *host);
 
 bool rrdhost_should_be_cleaned_up(RRDHOST *host, RRDHOST *protected_host, time_t now_s);

--- a/src/database/rrdset-index-id.c
+++ b/src/database/rrdset-index-id.c
@@ -351,7 +351,13 @@ static RRDSET *rrdset_index_find(RRDHOST *host, const char *id) {
 }
 
 RRDSET *rrdset_find(RRDHOST *host, const char *id, bool include_obsolete) {
-    netdata_log_debug(D_RRD_CALLS, "rrdset_find() for chart '%s' in host '%s'", id, rrdhost_hostname(host));
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(debug_flags & D_RRD_CALLS)) {
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        netdata_log_debug(D_RRD_CALLS, "rrdset_find() for chart '%s' in host '%s'", id, string2str(identity.hostname));
+        rrdhost_identity_release(&identity);
+    }
+#endif
     RRDSET *st = rrdset_index_find(host, id);
 
     if(st) {
@@ -365,7 +371,13 @@ RRDSET *rrdset_find(RRDHOST *host, const char *id, bool include_obsolete) {
 }
 
 RRDSET *rrdset_find_bytype(RRDHOST *host, const char *type, const char *id, bool include_obsolete) {
-    netdata_log_debug(D_RRD_CALLS, "rrdset_find_bytype() for chart '%s.%s' in host '%s'", type, id, rrdhost_hostname(host));
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(debug_flags & D_RRD_CALLS)) {
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        netdata_log_debug(D_RRD_CALLS, "rrdset_find_bytype() for chart '%s.%s' in host '%s'", type, id, string2str(identity.hostname));
+        rrdhost_identity_release(&identity);
+    }
+#endif
 
     char buf[RRD_ID_LENGTH_MAX + 1];
     strncpyz(buf, type, RRD_ID_LENGTH_MAX - 1);
@@ -377,7 +389,13 @@ RRDSET *rrdset_find_bytype(RRDHOST *host, const char *type, const char *id, bool
 }
 
 RRDSET_ACQUIRED *rrdset_find_and_acquire(RRDHOST *host, const char *id, bool include_obsolete) {
-    netdata_log_debug(D_RRD_CALLS, "rrdset_find_and_acquire() for host %s, chart %s", rrdhost_hostname(host), id);
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(debug_flags & D_RRD_CALLS)) {
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        netdata_log_debug(D_RRD_CALLS, "rrdset_find_and_acquire() for host %s, chart %s", string2str(identity.hostname), id);
+        rrdhost_identity_release(&identity);
+    }
+#endif
 
     // the index stays allocated for the whole life of the host (archiving only
     // flushes it); this guard is defense-in-depth for callers racing with

--- a/src/database/rrdset-index-name.c
+++ b/src/database/rrdset-index-name.c
@@ -18,7 +18,13 @@ STRING *rrdset_fix_name(RRDHOST *host, const char *chart_full_id, const char *ty
     strncpyz(new_name, sanitized_name, CONFIG_MAX_VALUE);
 
     if(rrdset_index_find_name(host, new_name)) {
-        netdata_log_debug(D_RRD_CALLS, "RRDSET: chart name '%s' on host '%s' already exists.", new_name, rrdhost_hostname(host));
+#ifdef NETDATA_INTERNAL_CHECKS
+        if(unlikely(debug_flags & D_RRD_CALLS)) {
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+            netdata_log_debug(D_RRD_CALLS, "RRDSET: chart name '%s' on host '%s' already exists.", new_name, string2str(identity.hostname));
+            rrdhost_identity_release(&identity);
+        }
+#endif
         if(!strcmp(chart_full_id, full_name) && (!current_name || !*current_name)) {
             unsigned i = 1;
 

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -72,9 +72,10 @@ static void build_node_info(RRDHOST *host, struct aclk_sync_completion *sync_com
         host_version = stream_receiver_program_version_strdupz(host);
 
     RRDHOST_TZ host_tz = rrdhost_tz_get(host);
+    RRDHOST_METADATA_IDENTITY identity = rrdhost_metadata_identity_acquire(host);
 
-    node_info.data.name = rrdhost_hostname(host);
-    node_info.data.os = rrdhost_os(host);
+    node_info.data.name = string2str(identity.common.hostname);
+    node_info.data.os = string2str(identity.os);
     node_info.data.version = host_version ? host_version : NETDATA_VERSION;
     node_info.data.release_channel = get_release_channel();
     node_info.data.timezone = host_tz.abbrev_timezone;
@@ -95,10 +96,11 @@ static void build_node_info(RRDHOST *host, struct aclk_sync_completion *sync_com
         NDLP_DEBUG,
         "ACLK RES [%s (%s)]: NODE INFO SENT for guid [%s] (%s)",
         aclk_host_config->node_id,
-        rrdhost_hostname(host),
+        string2str(identity.common.hostname),
         host->machine_guid,
         host == localhost ? "parent" : "child");
 
+    rrdhost_metadata_identity_release(&identity);
     rrd_rdunlock();
     rrdhost_tz_free(&host_tz);
     freez(node_info.node_instance_capabilities);

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -157,6 +157,16 @@ void send_node_update_with_wait(RRDHOST *host, int live, int queryable)
     // sc is automatically freed when both waiter and query release their references
 }
 
+static inline void hostname_snapshot_update(STRING **snapshot, RRDHOST *host)
+{
+    spinlock_lock(&host->rrdhost_update_lock);
+    STRING *hostname = string_dup(host->hostname);
+    spinlock_unlock(&host->rrdhost_update_lock);
+
+    string_freez(*snapshot);
+    *snapshot = hostname;
+}
+
 void aclk_check_node_info_and_collectors(void)
 {
     RRDHOST *host;
@@ -188,7 +198,7 @@ void aclk_check_node_info_and_collectors(void)
         if (unlikely(rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD))) {
             internal_error(true, "ACLK SYNC: Context still pending for %s", rrdhost_hostname(host));
             context_loading++;
-            context_loading_host = host->hostname;
+            hostname_snapshot_update(&context_loading_host, host);
             continue;
         }
 
@@ -198,13 +208,13 @@ void aclk_check_node_info_and_collectors(void)
         if (unlikely(rrdhost_receiver_replicating_charts(host))) {
             internal_error(true, "ACLK SYNC: Host %s is still replicating in", rrdhost_hostname(host));
             replicating_rcv++;
-            replicating_rcv_host = host->hostname;
+            hostname_snapshot_update(&replicating_rcv_host, host);
         }
 
         if (unlikely(rrdhost_sender_replicating_charts(host))) {
             internal_error(true, "ACLK SYNC: Host %s is still replicating out", rrdhost_hostname(host));
             replicating_snd++;
-            replicating_snd_host = host->hostname;
+            hostname_snapshot_update(&replicating_snd_host, host);
         }
 
 #ifdef REPLICATION_TRACKING
@@ -218,7 +228,7 @@ void aclk_check_node_info_and_collectors(void)
 
         if (!pp_queue_empty && (aclk_host_config->node_info_send_time || aclk_host_config->node_collectors_send)) {
             context_pp++;
-            context_pp_host = host->hostname;
+            hostname_snapshot_update(&context_pp_host, host);
         }
 
         if (pp_queue_empty && aclk_host_config->node_info_send_time &&
@@ -289,4 +299,9 @@ void aclk_check_node_info_and_collectors(void)
                      replay_counters_txt
                      );
     }
+
+    string_freez(context_loading_host);
+    string_freez(replicating_rcv_host);
+    string_freez(replicating_snd_host);
+    string_freez(context_pp_host);
 }

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -763,6 +763,7 @@ void sql_health_alarm_log_load(RRDHOST *host)
         if(unlikely(rc)) {
             if (rrdcalc_isrepeating(rc)) {
                 rc->last_repeat = last_repeat;
+                rrdcalc_runtime_snapshot_publish_repeat_state(rc);
                 // We iterate through repeating alarm entries only to
                 // find the latest last_repeat timestamp. Otherwise,
                 // there is no need to keep them in memory.

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -1093,7 +1093,7 @@ static int store_host_metadata(RRDHOST *host)
     RRDHOST_TZ host_tz = { 0 };
 
     if (!PREPARE_STATEMENT(db_meta, SQL_STORE_HOST_INFO, &res))
-        return false;
+        return 1;
 
     RRDHOST_METADATA_IDENTITY identity = rrdhost_metadata_identity_acquire(host);
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -235,7 +235,7 @@ struct meta_config_s {
     uv_loop_t loop;
     uv_async_t async;
     uv_timer_t timer_req;
-    time_t metadata_check_after;
+    time_t metadata_check_after __attribute__((aligned(8)));
     Pvoid_t ae_DelJudyL;
     bool initialized;
     bool ctx_load_running;
@@ -1474,7 +1474,7 @@ static bool run_cleanup_cycle(struct cleanup_cycle *c, struct meta_config_s *wc)
     time_t now = now_realtime_sec();
 
     if (!c->next_execution_t) {
-        c->next_execution_t = now + METADATA_MAINTENANCE_FIRST_CHECK;
+        c->next_execution_t = nd_time_t_add_saturating(now, METADATA_MAINTENANCE_FIRST_CHECK);
         c->snapshot_pending = true;
     }
 
@@ -1497,7 +1497,7 @@ static bool run_cleanup_cycle(struct cleanup_cycle *c, struct meta_config_s *wc)
         if (c->complete_repeat_after) {
             // Re-arm for another full pass; the snapshot is deferred to the
             // next entry past the timer so it isn't stale by then.
-            c->next_execution_t = now + c->complete_repeat_after;
+            c->next_execution_t = nd_time_t_add_saturating(now, c->complete_repeat_after);
             c->last_row_id = 0;
             c->snapshot_pending = true;
         }
@@ -1533,7 +1533,7 @@ static bool run_cleanup_cycle(struct cleanup_cycle *c, struct meta_config_s *wc)
     SQLITE_FINALIZE(action_res);
 
     now = now_realtime_sec();
-    c->next_execution_t = now + c->repeat_after;
+    c->next_execution_t = nd_time_t_add_saturating(now, c->repeat_after);
 
     nd_log_daemon(NDLP_DEBUG,
                   "%s checked %u, deleted %u. Checks will resume in %d seconds",
@@ -1597,12 +1597,12 @@ static void cleanup_health_log(struct meta_config_s *config)
     time_t now = now_realtime_sec();
 
     if (!next_execution_t)
-        next_execution_t = now + METADATA_MAINTENANCE_FIRST_CHECK;
+        next_execution_t = nd_time_t_add_saturating(now, METADATA_MAINTENANCE_FIRST_CHECK);
 
     if (next_execution_t && next_execution_t > now)
         return;
 
-    next_execution_t = now + METADATA_HEALTH_LOG_INTERVAL;
+    next_execution_t = nd_time_t_add_saturating(now, METADATA_HEALTH_LOG_INTERVAL);
 
     RRDHOST *host;
     worker_is_busy(UV_EVENT_HEALTH_LOG_CLEANUP);
@@ -1660,9 +1660,9 @@ static void async_cb(uv_async_t *handle __maybe_unused)
 
 static void timer_cb(uv_timer_t *handle)
 {
-   struct meta_config_s *config = handle->data;
-   if (config->metadata_check_after <  now_realtime_sec())
-       config->store_metadata = true;
+    struct meta_config_s *config = handle->data;
+    if (__atomic_load_n(&config->metadata_check_after, __ATOMIC_RELAXED) < now_realtime_sec())
+        config->store_metadata = true;
 }
 
 void vacuum_database(sqlite3 *database, const char *db_alias, int threshold, int vacuum_pc, time_t *next_run)
@@ -1672,7 +1672,7 @@ void vacuum_database(sqlite3 *database, const char *db_alias, int threshold, int
         return;
 
     if (next_run)
-        *next_run = now + DATABASE_VACUUM_FREQUENCY_SECONDS;
+        *next_run = nd_time_t_add_saturating(now, DATABASE_VACUUM_FREQUENCY_SECONDS);
 
     int free_pages = get_free_page_count(database);
     int total_pages = get_database_page_count(database);
@@ -1804,7 +1804,7 @@ void run_metadata_cleanup(struct meta_config_s *config)
     time_t now = now_realtime_sec();
 
     if (!next_context_list_cleanup)
-        next_context_list_cleanup = now + 5;
+        next_context_list_cleanup = nd_time_t_add_saturating(now, 5);
 
     if (next_context_list_cleanup < now && sql_metadata_wal_size_acceptable()) {
         RRDHOST *host;
@@ -1816,7 +1816,7 @@ void run_metadata_cleanup(struct meta_config_s *config)
         }
         dfe_done(host);
         worker_is_idle();
-        next_context_list_cleanup = now_realtime_sec() + METADATA_MAINTENANCE_CTX_CLEAN_REPEAT;
+        next_context_list_cleanup = nd_time_t_add_saturating(now_realtime_sec(), METADATA_MAINTENANCE_CTX_CLEAN_REPEAT);
     }
 
     if (unlikely(SHUTDOWN_REQUESTED(config)))
@@ -2500,34 +2500,63 @@ static void store_hosts_metadata(struct meta_config_s *config, bool is_worker, b
     BUFFER *work_buffer = buffer_create(1024, NULL);
 
     size_t count = 0;
-    dfe_start_reentrant(rrdhost_root_index, host)
-    {
-        count++;
-        if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED) || !rrdhost_flag_check(host, RRDHOST_FLAG_METADATA_UPDATE))
-            continue;
+    DICTFE host_dfe = {
+        .dict = rrdhost_root_index,
+        .rw = DICTIONARY_LOCK_REENTRANT,
+    };
 
-        // check the shutdown BEFORE clearing the pending flag, so a host
-        // interrupted by shutdown keeps its pending status for the final scan
-        if (!final && SHUTDOWN_REQUESTED(config))
+    bool first = true;
+    bool stop = false;
+    while (!stop) {
+        // The global lock bridges the linked dictionary value to its per-host lifetime lock.
+        rrd_rdlock();
+        host = first ? dictionary_foreach_start_rw(&host_dfe) : dictionary_foreach_next(&host_dfe);
+        first = false;
+
+        if (!host_dfe.item && !host) {
+            rrd_rdunlock();
             break;
+        }
 
-        rrdhost_flag_clear(host, RRDHOST_FLAG_METADATA_UPDATE);
+        count++;
+        bool host_locked = false;
+        bool report_progress = false;
+        if (!rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED) && rrdhost_flag_check(host, RRDHOST_FLAG_METADATA_UPDATE)) {
+            host_locked = rw_spinlock_tryread_lock(&host->metadata_lifetime_lock);
+            if (host_locked) {
+                // Check shutdown before clearing the pending flag so the final scan can pick it up.
+                if (!final && SHUTDOWN_REQUESTED(config))
+                    stop = true;
+                else {
+                    rrdhost_flag_clear(host, RRDHOST_FLAG_METADATA_UPDATE);
+                    report_progress = !is_worker;
+                }
+            }
+        }
 
-        if (is_worker)
-            worker_is_busy(UV_EVENT_STORE_HOST);
+        rrd_rdunlock();
 
-        // store labels, claim_id, host and system info (if needed)
-        store_host_info_and_metadata_with_buffer(host, work_buffer);
+        if (host_locked) {
+            if (!stop) {
+                if (is_worker)
+                    worker_is_busy(UV_EVENT_STORE_HOST);
 
-        if (is_worker)
-            worker_is_idle();
+                // store labels, claim_id, host and system info (if needed)
+                store_host_info_and_metadata_with_buffer(host, work_buffer);
 
-        metadata_scan_host(config, host, is_worker, final, work_buffer);
+                if (is_worker)
+                    worker_is_idle();
 
-        if (!is_worker)
+                metadata_scan_host(config, host, is_worker, final, work_buffer);
+            }
+
+            rw_spinlock_read_unlock(&host->metadata_lifetime_lock);
+        }
+
+        if (report_progress)
             nd_log_daemon(NDLP_INFO, "METADATA: Progress of metadata storage: %6.2f%% completed", (100.0 * count / host_count));
     }
-    dfe_done(host);
+    dictionary_foreach_done(&host_dfe);
 
     buffer_free(work_buffer);
 
@@ -2553,7 +2582,7 @@ static void start_metadata_hosts(uv_work_t *req)
     time_t now = now_realtime_sec();
     if (now> next_maintenance_check) {
         run_maintenace();
-        next_maintenance_check = now + SERVICE_HEARTBEAT;
+        next_maintenance_check = nd_time_t_add_saturating(now, SERVICE_HEARTBEAT);
     }
 
     worker_data_t *worker = req->data;
@@ -2584,7 +2613,10 @@ static void start_metadata_hosts(uv_work_t *req)
         run_metadata_cleanup(config);
     }
 
-    config->metadata_check_after = now_realtime_sec() + METADATA_HOST_CHECK_INTERVAL;
+    __atomic_store_n(
+        &config->metadata_check_after,
+        nd_time_t_add_saturating(now_realtime_sec(), METADATA_HOST_CHECK_INTERVAL),
+        __ATOMIC_RELAXED);
     worker_is_idle();
 }
 
@@ -2623,7 +2655,10 @@ static void metadata_event_loop(void *arg)
     config->timer_req.data = config;
 
     nd_log(NDLS_DAEMON, NDLP_DEBUG, "Starting metadata sync thread");
-    config->metadata_check_after = now_realtime_sec() + METADATA_HOST_CHECK_FIRST_CHECK;
+    __atomic_store_n(
+        &config->metadata_check_after,
+        nd_time_t_add_saturating(now_realtime_sec(), METADATA_HOST_CHECK_FIRST_CHECK),
+        __ATOMIC_RELAXED);
 
     worker_data_t *worker;
     Pvoid_t *Pvalue;

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -1095,12 +1095,14 @@ static int store_host_metadata(RRDHOST *host)
     if (!PREPARE_STATEMENT(db_meta, SQL_STORE_HOST_INFO, &res))
         return false;
 
+    RRDHOST_METADATA_IDENTITY identity = rrdhost_metadata_identity_acquire(host);
+
     int param = 0;
     SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_blob(res, ++param, &host->host_id.uuid, sizeof(host->host_id.uuid), SQLITE_STATIC));
-    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, rrdhost_hostname(host), 0));
-    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, rrdhost_registry_hostname(host), 1));
+    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, string2str(identity.common.hostname), 0));
+    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, string2str(identity.registry_hostname), 1));
     SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int(res, ++param, host->rrd_update_every));
-    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, rrdhost_os(host), 1));
+    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, string2str(identity.os), 1));
     host_tz = rrdhost_tz_get(host);
     SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, host_tz.timezone, 1));
     SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, "", 1));
@@ -1108,8 +1110,8 @@ static int store_host_metadata(RRDHOST *host)
     SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int(res, ++param, host->rrd_memory_mode));
     SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, host_tz.abbrev_timezone, 1));
     SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int(res, ++param, host_tz.utc_offset));
-    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, rrdhost_program_name(host), 1));
-    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, rrdhost_program_version(host), 1));
+    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, string2str(identity.common.prog_name), 1));
+    SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, string2str(identity.common.prog_version), 1));
     SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int64(res, ++param, host->rrd_history_entries));
     SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int(res, ++param, (int)host->health.enabled));
     SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int64(res, ++param, (sqlite3_int64) host->stream.snd.status.last_connected));
@@ -1117,9 +1119,10 @@ static int store_host_metadata(RRDHOST *host)
     int store_rc = sqlite3_step_monitored(res);
 
     if (unlikely(store_rc != SQLITE_DONE))
-        error_report("Failed to store host %s, rc = %d", rrdhost_hostname(host), store_rc);
+        error_report("Failed to store host %s, rc = %d", string2str(identity.common.hostname), store_rc);
 
     SQLITE_FINALIZE(res);
+    rrdhost_metadata_identity_release(&identity);
     rrdhost_tz_free(&host_tz);
 
     return store_rc != SQLITE_DONE;
@@ -1127,6 +1130,7 @@ static int store_host_metadata(RRDHOST *host)
 bind_fail:
     REPORT_BIND_FAIL(res, param);
     SQLITE_FINALIZE(res);
+    rrdhost_metadata_identity_release(&identity);
     rrdhost_tz_free(&host_tz);
     return 1;
 }

--- a/src/health/health.h
+++ b/src/health/health.h
@@ -96,7 +96,6 @@ void health_string2json(BUFFER *wb, const char *prefix, const char *label, const
 
 void health_log_alert_transition_with_trace(RRDHOST *host, ALARM_ENTRY *ae, int line, const char *file, const char *function);
 #define health_log_alert(host, ae) health_log_alert_transition_with_trace(host, ae, __LINE__, __FILE__, __FUNCTION__)
-bool health_alarm_log_get_global_id_and_transition_id_for_rrdcalc(RRDCALC *rc, usec_t *global_id, nd_uuid_t *transitions_id);
 
 int alert_variable_lookup_trace(RRDHOST *host, RRDSET *st, const char *variable, BUFFER *wb);
 

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -442,8 +442,10 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
         RRDSET *st = NULL;
         RRDSET_ACQUIRED *rsa = rrdcalc_rrdset_acquire_linked(host, rc, &st);
         if(unlikely(!rsa)) {
-            if (unlikely(rc->run_flags & RRDCALC_FLAG_RUNNABLE))
+            if (unlikely(rc->run_flags & RRDCALC_FLAG_RUNNABLE)) {
                 rc->run_flags &= ~RRDCALC_FLAG_RUNNABLE;
+                rrdcalc_runtime_snapshot_publish_run_flags(rc);
+            }
 
             continue;
         }
@@ -453,8 +455,10 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
 
         if(unlikely(!rrdcalc_rrdset_read_lock_if_matches(rc, st))) {
             rrdset_acquired_release(rsa);
-            if (unlikely(rc->run_flags & RRDCALC_FLAG_RUNNABLE))
+            if (unlikely(rc->run_flags & RRDCALC_FLAG_RUNNABLE)) {
                 rc->run_flags &= ~RRDCALC_FLAG_RUNNABLE;
+                rrdcalc_runtime_snapshot_publish_run_flags(rc);
+            }
 
             continue;
         }
@@ -466,6 +470,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
         if (health_silencers_update_disabled_silenced(host, rc)) {
             rrdcalc_rrdset_read_unlock(st);
             rrdset_acquired_release(rsa);
+            rrdcalc_runtime_snapshot_publish_run_flags(rc);
             continue;
         }
 
@@ -512,6 +517,10 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
         if (unlikely(!rrdcalc_isrunnable(rc, st, now, next_run))) {
             if (unlikely(rc->run_flags & RRDCALC_FLAG_RUNNABLE))
                 rc->run_flags &= ~RRDCALC_FLAG_RUNNABLE;
+            if(removed_ae)
+                rrdcalc_runtime_snapshot_publish(rc, removed_ae->global_id, &removed_ae->transition_id);
+            else
+                rrdcalc_runtime_snapshot_publish_run_flags(rc);
             rrdset_acquired_release(rsa);
             continue;
         }
@@ -617,6 +626,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
             RRDSET_ACQUIRED *rsa = rrdcalc_rrdset_acquire_linked(host, rc, &st);
             if(unlikely(!rsa)) {
                 rc->run_flags &= ~RRDCALC_FLAG_RUNNABLE;
+                rrdcalc_runtime_snapshot_publish_run_flags(rc);
                 continue;
             }
 
@@ -661,9 +671,11 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
             // --------------------------------------------------------
             // check if the new status and the old differ
 
+            ALARM_ENTRY *transition_ae = NULL;
             if (status != rc->status) {
                 if(unlikely(!rrdcalc_rrdset_read_lock_if_matches(rc, st))) {
                     rc->run_flags &= ~RRDCALC_FLAG_RUNNABLE;
+                    rrdcalc_runtime_snapshot_publish_run_flags(rc);
                     rrdset_acquired_release(rsa);
                     continue;
                 }
@@ -700,7 +712,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                 rc->delay_last = delay;
                 rc->delay_up_to_timestamp = nd_time_t_add_saturating(now, delay);
 
-                ALARM_ENTRY *ae = health_create_alarm_entry(
+                transition_ae = health_create_alarm_entry(
                     host,
                     rc,
                     now,
@@ -718,13 +730,13 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                 );
                 rrdcalc_rrdset_read_unlock(st);
 
-                health_alarm_log_add_entry(host, ae, false);
-                health_log_alert(host, ae);
+                health_alarm_log_add_entry(host, transition_ae, false);
+                health_log_alert(host, transition_ae);
 
                 nd_log(NDLS_DAEMON, NDLP_DEBUG,
                        "[%s]: Alert event for [%s.%s], value [%s], status [%s].",
-                       rrdhost_hostname(host), ae_chart_id(ae), ae_name(ae), ae_new_value_string(ae),
-                       rrdcalc_status2string(ae->new_status));
+                       rrdhost_hostname(host), ae_chart_id(transition_ae), ae_name(transition_ae),
+                       ae_new_value_string(transition_ae), rrdcalc_status2string(transition_ae->new_status));
 
                 health_alert_status_counts_sub(&status_counts, rc->status);
                 health_alert_status_counts_add(&status_counts, status);
@@ -743,6 +755,10 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
 
             rc->last_updated = now;
             rc->next_update = nd_time_t_add_saturating(now, rc->config.update_every);
+            rrdcalc_runtime_snapshot_publish(
+                rc,
+                transition_ae ? transition_ae->global_id : 0,
+                transition_ae ? &transition_ae->transition_id : NULL);
 
             if (*next_run > rc->next_update)
                 *next_run = rc->next_update;
@@ -758,6 +774,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
             if(unlikely(!service_running(SERVICE_HEALTH) || !rrdhost_should_run_health(host)))
                 break;
 
+            RRDCALC_FLAGS run_flags_before = rc->run_flags;
             int repeat_every = 0;
             if(unlikely(rrdcalc_isrepeating(rc) && rc->delay_up_to_timestamp <= now)) {
                 if(unlikely(rc->status == RRDCALC_STATUS_WARNING)) {
@@ -776,6 +793,9 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
             }
             else
                 continue;
+
+            if(rc->run_flags != run_flags_before)
+                rrdcalc_runtime_snapshot_publish_run_flags(rc);
 
             if(unlikely(repeat_every > 0 && nd_time_t_add_compare(rc->last_repeat, repeat_every, now) <= 0)) {
                 RRDSET *st = NULL;
@@ -819,6 +839,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                     ae->flags |= HEALTH_ENTRY_RUN_ONCE;
                 }
                 rc->run_flags |= RRDCALC_FLAG_RUN_ONCE;
+                rrdcalc_runtime_snapshot_publish_run_flags(rc);
                 health_send_notification(host, ae, hrm);
                 netdata_log_debug(D_HEALTH, "Notification sent for the repeating alarm %u.", ae->alarm_id);
                 health_alarm_wait_for_execution(ae);

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -839,7 +839,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                     ae->flags |= HEALTH_ENTRY_RUN_ONCE;
                 }
                 rc->run_flags |= RRDCALC_FLAG_RUN_ONCE;
-                rrdcalc_runtime_snapshot_publish_run_flags(rc);
+                rrdcalc_runtime_snapshot_publish_repeat_state(rc);
                 health_send_notification(host, ae, hrm);
                 netdata_log_debug(D_HEALTH, "Notification sent for the repeating alarm %u.", ae->alarm_id);
                 health_alarm_wait_for_execution(ae);

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -334,25 +334,37 @@ static void do_eval_expression(
         if (result)
             *result = NAN;
 
-        netdata_log_debug(D_HEALTH,
-                          "Health on host '%s', alarm '%s.%s': %s expression failed with error: %s",
-                          rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc), expression_type,
-                          expression_error_msg(expression)
-        );
+#ifdef NETDATA_INTERNAL_CHECKS
+        if(unlikely(debug_flags & D_HEALTH)) {
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+            netdata_log_debug(D_HEALTH,
+                              "Health on host '%s', alarm '%s.%s': %s expression failed with error: %s",
+                              string2str(identity.hostname), rrdcalc_chart_name(rc), rrdcalc_name(rc), expression_type,
+                              expression_error_msg(expression)
+            );
+            rrdhost_identity_release(&identity);
+        }
+#endif
         return;
     }
 
     rc->run_flags &= ~error_type;
-    netdata_log_debug(D_HEALTH,
-                      "Health on host '%s', alarm '%s.%s': %s expression gave value "
-                      NETDATA_DOUBLE_FORMAT ": %s (source: %s)",
-                      rrdhost_hostname(host),
-                      rrdcalc_chart_name(rc),
-                      rrdcalc_name(rc),
-                      expression_type,
-                      expression_result(expression),
-                      expression_error_msg(expression),
-                      rrdcalc_source(rc));
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(debug_flags & D_HEALTH)) {
+        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+        netdata_log_debug(D_HEALTH,
+                          "Health on host '%s', alarm '%s.%s': %s expression gave value "
+                          NETDATA_DOUBLE_FORMAT ": %s (source: %s)",
+                          string2str(identity.hostname),
+                          rrdcalc_chart_name(rc),
+                          rrdcalc_name(rc),
+                          expression_type,
+                          expression_result(expression),
+                          expression_error_msg(expression),
+                          rrdcalc_source(rc));
+        rrdhost_identity_release(&identity);
+    }
+#endif
     if (calc_status)
         *calc_status = rrdcalc_value2status(expression_result(expression));
     else
@@ -575,9 +587,15 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                 rc->value = NAN;
                 rc->run_flags |= RRDCALC_FLAG_DB_ERROR;
 
-                netdata_log_debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database lookup returned error %d",
-                                  rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc), ret
-                );
+#ifdef NETDATA_INTERNAL_CHECKS
+                if(unlikely(debug_flags & D_HEALTH)) {
+                    RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+                    netdata_log_debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database lookup returned error %d",
+                                      string2str(identity.hostname), rrdcalc_chart_name(rc), rrdcalc_name(rc), ret
+                    );
+                    rrdhost_identity_release(&identity);
+                }
+#endif
             } else
                 rc->run_flags &= ~RRDCALC_FLAG_DB_ERROR;
 
@@ -586,16 +604,28 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                 rc->value = NAN;
                 rc->run_flags |= RRDCALC_FLAG_DB_NAN;
 
-                netdata_log_debug(D_HEALTH,
-                                  "Health on host '%s', alarm '%s.%s': database lookup returned empty value (possibly value is not collected yet)",
-                                  rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc)
-                );
+#ifdef NETDATA_INTERNAL_CHECKS
+                if(unlikely(debug_flags & D_HEALTH)) {
+                    RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+                    netdata_log_debug(D_HEALTH,
+                                      "Health on host '%s', alarm '%s.%s': database lookup returned empty value (possibly value is not collected yet)",
+                                      string2str(identity.hostname), rrdcalc_chart_name(rc), rrdcalc_name(rc)
+                    );
+                    rrdhost_identity_release(&identity);
+                }
+#endif
             } else
                 rc->run_flags &= ~RRDCALC_FLAG_DB_NAN;
 
-            netdata_log_debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database lookup gave value " NETDATA_DOUBLE_FORMAT,
-                              rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc), rc->value
-            );
+#ifdef NETDATA_INTERNAL_CHECKS
+            if(unlikely(debug_flags & D_HEALTH)) {
+                RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+                netdata_log_debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database lookup gave value " NETDATA_DOUBLE_FORMAT,
+                                  string2str(identity.hostname), rrdcalc_chart_name(rc), rrdcalc_name(rc), rc->value
+                );
+                rrdhost_identity_release(&identity);
+            }
+#endif
         }
 
         // ------------------------------------------------------------

--- a/src/health/health_json.c
+++ b/src/health/health_json.c
@@ -39,6 +39,10 @@ static inline void health_rrdcalc_values2json_nolock(
 
 static inline void health_rrdcalc2json_nolock(
     RRDHOST *host, BUFFER *wb, RRDCALC *rc, const RRDCALC_RUNTIME_SNAPSHOT *snapshot) {
+    CLEAN_STRING *summary = NULL;
+    CLEAN_STRING *info = NULL;
+    rrdcalc_runtime_strings_acquire(rc, &summary, &info);
+
     char value_string[100 + 1];
     format_value_and_unit(value_string, 100, snapshot->value, rrdcalc_units(rc), -1);
 
@@ -94,8 +98,8 @@ static inline void health_rrdcalc2json_nolock(
                    , rc->config.recipient?rrdcalc_recipient(rc):string2str(host->health.default_recipient)
                    , rrdcalc_source(rc)
                    , rrdcalc_units(rc)
-                   , string2str(rc->summary)
-                   , string2str(rc->info)
+                   , string2str(summary)
+                   , string2str(info)
                    , rrdcalc_status2string(snapshot->status)
                    , (unsigned long)snapshot->last_status_change
                    , (unsigned long)snapshot->last_updated

--- a/src/health/health_json.c
+++ b/src/health/health_json.c
@@ -13,7 +13,8 @@ void health_string2json(BUFFER *wb, const char *prefix, const char *label, const
         buffer_sprintf(wb, "%s\"%s\":null%s", prefix, label, suffix);
 }
 
-static inline void health_rrdcalc_values2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC *rc) {
+static inline void health_rrdcalc_values2json_nolock(
+    RRDHOST *host, BUFFER *wb, RRDCALC *rc, const RRDCALC_RUNTIME_SNAPSHOT *snapshot) {
     (void)host;
     buffer_sprintf(wb,
                    "\t\t\"%s.%s\": {\n"
@@ -22,23 +23,24 @@ static inline void health_rrdcalc_values2json_nolock(RRDHOST *host, BUFFER *wb, 
                    , (unsigned long)rc->id);
 
     buffer_strcat(wb, "\t\t\t\"value\":");
-    buffer_print_netdata_double(wb, rc->value);
+    buffer_print_netdata_double(wb, snapshot->value);
     buffer_strcat(wb, ",\n");
 
     buffer_strcat(wb, "\t\t\t\"last_updated\":");
-    buffer_sprintf(wb, "%lu", (unsigned long)rc->last_updated);
+    buffer_sprintf(wb, "%lu", (unsigned long)snapshot->last_updated);
     buffer_strcat(wb, ",\n");
 
     buffer_sprintf(wb,
                    "\t\t\t\"status\": \"%s\"\n"
-                   , rrdcalc_status2string(rc->status));
+                   , rrdcalc_status2string(snapshot->status));
 
     buffer_strcat(wb, "\t\t}");
 }
 
-static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC *rc) {
+static inline void health_rrdcalc2json_nolock(
+    RRDHOST *host, BUFFER *wb, RRDCALC *rc, const RRDCALC_RUNTIME_SNAPSHOT *snapshot) {
     char value_string[100 + 1];
-    format_value_and_unit(value_string, 100, rc->value, rrdcalc_units(rc), -1);
+    format_value_and_unit(value_string, 100, snapshot->value, rrdcalc_units(rc), -1);
 
     char hash_id[GUID_LEN + 1];
     uuid_unparse_lower(rc->config.hash_id, hash_id);
@@ -86,30 +88,30 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                    , rc->config.component?rrdcalc_component(rc):"Unknown"
                    , rc->config.type?rrdcalc_type(rc):"Unknown"
                    , (rc->rrdset)?"true":"false"
-                   , (rc->run_flags & RRDCALC_FLAG_DISABLED)?"true":"false"
-                   , (rc->run_flags & RRDCALC_FLAG_SILENCED)?"true":"false"
+                   , (snapshot->run_flags & RRDCALC_FLAG_DISABLED)?"true":"false"
+                   , (snapshot->run_flags & RRDCALC_FLAG_SILENCED)?"true":"false"
                    , rc->config.exec?rrdcalc_exec(rc):string2str(host->health.default_exec)
                    , rc->config.recipient?rrdcalc_recipient(rc):string2str(host->health.default_recipient)
                    , rrdcalc_source(rc)
                    , rrdcalc_units(rc)
                    , string2str(rc->summary)
                    , string2str(rc->info)
-                   , rrdcalc_status2string(rc->status)
-                   , (unsigned long)rc->last_status_change
-                   , (unsigned long)rc->last_updated
-                   , (unsigned long)rc->next_update
+                   , rrdcalc_status2string(snapshot->status)
+                   , (unsigned long)snapshot->last_status_change
+                   , (unsigned long)snapshot->last_updated
+                   , (unsigned long)snapshot->next_update
                    , rc->config.update_every
                    , rc->config.delay_up_duration
                    , rc->config.delay_down_duration
                    , rc->config.delay_max_duration
                    , rc->config.delay_multiplier
-                   , rc->delay_last
-                   , (unsigned long)rc->delay_up_to_timestamp
+                   , snapshot->delay_last
+                   , (unsigned long)snapshot->delay_up_to_timestamp
                    , rc->config.warn_repeat_every
                    , rc->config.crit_repeat_every
                    , value_string
-                   , (unsigned long)rc->last_repeat
-                   , (unsigned long)rc->times_repeat
+                   , (unsigned long)snapshot->last_repeat
+                   , (unsigned long)snapshot->times_repeat
     );
 
     if(unlikely(rc->config.alert_action_options & ALERT_ACTION_OPTION_NO_CLEAR_NOTIFICATION)) {
@@ -127,8 +129,8 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                         "\t\t\t\"lookup_after\": %d,\n"
                         "\t\t\t\"lookup_before\": %d,\n"
                         "\t\t\t\"lookup_options\": \"",
-                       (unsigned long) rc->db_after,
-                       (unsigned long) rc->db_before,
+                       (unsigned long)snapshot->db_after,
+                       (unsigned long)snapshot->db_before,
                        time_grouping_id2txt(rc->config.time_group),
                        rc->config.after,
                        rc->config.before
@@ -161,7 +163,7 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
     buffer_strcat(wb, ",\n");
 
     buffer_strcat(wb, "\t\t\t\"value\":");
-    buffer_print_netdata_double(wb, rc->value);
+    buffer_print_netdata_double(wb, snapshot->value);
     buffer_strcat(wb, "\n");
 
     buffer_strcat(wb, "\t\t}");
@@ -192,9 +194,13 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
                     rrdcalc_rrdset_read_unlock(st);
                     continue;
                 }
-                if(unlikely(st->context == tok_string
-                             && ((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status)))
-                    numberOfAlarms++;
+                if(unlikely(st->context == tok_string)) {
+                    RRDCALC_RUNTIME_SNAPSHOT snapshot;
+                    rrdcalc_runtime_snapshot_get(rc, &snapshot);
+                    if(unlikely((status == RRDCALC_STATUS_RAISED) ?
+                                    (snapshot.status >= RRDCALC_STATUS_WARNING) : snapshot.status == status))
+                        numberOfAlarms++;
+                }
                 rrdcalc_rrdset_read_unlock(st);
             }
             foreach_rrdcalc_in_rrdhost_done(rc);
@@ -215,7 +221,10 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
                 rrdcalc_rrdset_read_unlock(st);
                 continue;
             }
-            if(unlikely((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status))
+            RRDCALC_RUNTIME_SNAPSHOT snapshot;
+            rrdcalc_runtime_snapshot_get(rc, &snapshot);
+            if(unlikely((status == RRDCALC_STATUS_RAISED) ?
+                            (snapshot.status >= RRDCALC_STATUS_WARNING) : snapshot.status == status))
                 numberOfAlarms++;
             rrdcalc_rrdset_read_unlock(st);
         }
@@ -225,7 +234,11 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
     buffer_sprintf(wb, "%d", numberOfAlarms);
 }
 
-static void health_alarms2json_fill_alarms(RRDHOST *host, BUFFER *wb, int all, void (*fp)(RRDHOST *, BUFFER *, RRDCALC *)) {
+static void health_alarms2json_fill_alarms(
+    RRDHOST *host,
+    BUFFER *wb,
+    int all,
+    void (*fp)(RRDHOST *, BUFFER *, RRDCALC *, const RRDCALC_RUNTIME_SNAPSHOT *)) {
     RRDCALC *rc;
     int i = 0;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
@@ -242,13 +255,16 @@ static void health_alarms2json_fill_alarms(RRDHOST *host, BUFFER *wb, int all, v
             continue;
         }
 
-        if(likely(!all && !(rc->status == RRDCALC_STATUS_WARNING || rc->status == RRDCALC_STATUS_CRITICAL))) {
+        RRDCALC_RUNTIME_SNAPSHOT snapshot;
+        rrdcalc_runtime_snapshot_get(rc, &snapshot);
+
+        if(likely(!all && !(snapshot.status == RRDCALC_STATUS_WARNING || snapshot.status == RRDCALC_STATUS_CRITICAL))) {
             rrdcalc_rrdset_read_unlock(st);
             continue;
         }
 
         if(likely(i)) buffer_strcat(wb, ",\n");
-        fp(host, wb, rc);
+        fp(host, wb, rc, &snapshot);
         i++;
         rrdcalc_rrdset_read_unlock(st);
     }

--- a/src/health/health_log.c
+++ b/src/health/health_log.c
@@ -207,8 +207,9 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     STRING *recipient = rc->config.recipient;
     STRING *source = rc->config.source;
     STRING *units = rc->config.units;
-    STRING *summary = rc->summary;
-    STRING *info = rc->info;
+    STRING *summary = NULL;
+    STRING *info = NULL;
+    rrdcalc_runtime_strings_acquire(rc, &summary, &info);
 
     if (duration < 0)
         duration = 0;
@@ -242,8 +243,8 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     ae->old_value_string = string_strdupz(format_value_and_unit(value_string, 100, ae->old_value, ae_units(ae), -1));
     ae->new_value_string = string_strdupz(format_value_and_unit(value_string, 100, ae->new_value, ae_units(ae), -1));
 
-    ae->summary = string_dup(summary);
-    ae->info = string_dup(info);
+    ae->summary = summary;
+    ae->info = info;
     ae->old_status = old_status;
     ae->new_status = new_status;
     ae->duration = duration;

--- a/src/health/health_notifications.c
+++ b/src/health/health_notifications.c
@@ -513,34 +513,6 @@ done:
     health_alarm_log_save(host, ae, false);
 }
 
-bool health_alarm_log_get_global_id_and_transition_id_for_rrdcalc(RRDCALC *rc, usec_t *global_id, nd_uuid_t *transitions_id) {
-    if(!rc->rrdset)
-        return false;
-
-    RRDHOST *host = rc->rrdset->rrdhost;
-
-    rw_spinlock_read_lock(&host->health_log.spinlock);
-
-    ALARM_ENTRY *ae;
-    for(ae = host->health_log.alarms; ae ; ae = ae->next) {
-        if(unlikely(ae->alarm_id == rc->id))
-            break;
-    }
-
-    if(ae) {
-        *global_id = ae->global_id;
-        uuid_copy(*transitions_id, ae->transition_id);
-    }
-    else {
-        *global_id = 0;
-        uuid_clear(*transitions_id);
-    }
-
-    rw_spinlock_read_unlock(&host->health_log.spinlock);
-
-    return ae != NULL;
-}
-
 void health_alarm_log_process_to_send_notifications(RRDHOST *host, struct health_raised_summary *hrm) {
     time_t now = now_realtime_sec();
 

--- a/src/health/health_variable.c
+++ b/src/health/health_variable.c
@@ -162,7 +162,7 @@ static bool variable_lookup_context(struct variable_lookup_job *vbd, const char 
     return found;
 }
 
-bool alert_variable_from_running_alerts(struct variable_lookup_job *vbd) {
+static bool alert_variable_from_running_alerts(struct variable_lookup_job *vbd, bool snapshot_values) {
     bool found = false;
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(vbd->host, rc) {
@@ -172,7 +172,16 @@ bool alert_variable_from_running_alerts(struct variable_lookup_job *vbd) {
             if(!rsa)
                 continue;
 
-            variable_lookup_add_result_with_score(vbd, (NETDATA_DOUBLE)rc->value, st, "alarm value");
+            NETDATA_DOUBLE value;
+            if(snapshot_values) {
+                RRDCALC_RUNTIME_SNAPSHOT snapshot;
+                rrdcalc_runtime_snapshot_get(rc, &snapshot);
+                value = snapshot.value;
+            }
+            else
+                value = rc->value;
+
+            variable_lookup_add_result_with_score(vbd, value, st, "alarm value");
             rrdset_acquired_release(rsa);
             found = true;
         }
@@ -410,7 +419,7 @@ bool alert_variable_lookup_internal(STRING *variable, void *data, NETDATA_DOUBLE
     }
 
     // alert names
-    if(alert_variable_from_running_alerts(&vbd)) {
+    if(alert_variable_from_running_alerts(&vbd, wb != NULL)) {
         found = true;
         goto find_best_scored;
     }

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -78,6 +78,17 @@ void rrdcalc_runtime_snapshot_get(RRDCALC *rc, RRDCALC_RUNTIME_SNAPSHOT *snapsho
     rw_spinlock_read_unlock(&rc->runtime_snapshot.spinlock);
 }
 
+void rrdcalc_runtime_strings_acquire(RRDCALC *rc, STRING **summary, STRING **info) {
+    rw_spinlock_read_lock(&rc->runtime_snapshot.spinlock);
+
+    if(summary)
+        *summary = string_dup(rc->summary);
+    if(info)
+        *info = string_dup(rc->info);
+
+    rw_spinlock_read_unlock(&rc->runtime_snapshot.spinlock);
+}
+
 inline const char *rrdcalc_status2string(RRDCALC_STATUS status) {
     switch(status) {
         case RRDCALC_STATUS_REMOVED:
@@ -160,6 +171,15 @@ uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint3
 // ----------------------------------------------------------------------------
 // RRDCALC replacing info/summary text variables with RRDSET labels
 
+static void rrdcalc_runtime_string_replace(RRDCALC *rc, STRING **field, STRING *replacement) {
+    rw_spinlock_write_lock(&rc->runtime_snapshot.spinlock);
+    STRING *old = *field;
+    *field = replacement;
+    rw_spinlock_write_unlock(&rc->runtime_snapshot.spinlock);
+
+    string_freez(old);
+}
+
 static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RRDCALC *rc) {
     if (!line || !*line)
         return NULL;
@@ -218,25 +238,21 @@ void rrdcalc_update_info_using_rrdset_labels(RRDCALC *rc) {
     if(rc->rrdset && rc->rrdset->rrdlabels) {
         uint32_t labels_version = rrdlabels_version(rc->rrdset->rrdlabels);
         if (rc->labels_version != labels_version) {
-            STRING *old;
+            STRING *info = rrdcalc_replace_variables_with_rrdset_labels(string2str(rc->config.info), rc);
+            rrdcalc_runtime_string_replace(rc, &rc->info, info);
 
-            old = rc->info;
-            rc->info = rrdcalc_replace_variables_with_rrdset_labels(string2str(rc->config.info), rc);
-            string_freez(old);
-
-            old = rc->summary;
-            rc->summary = rrdcalc_replace_variables_with_rrdset_labels(string2str(rc->config.summary), rc);
-            string_freez(old);
+            STRING *summary = rrdcalc_replace_variables_with_rrdset_labels(string2str(rc->config.summary), rc);
+            rrdcalc_runtime_string_replace(rc, &rc->summary, summary);
 
             rc->labels_version = labels_version;
         }
     }
 
     if(!rc->summary)
-        rc->summary = string_dup(rc->config.summary);
+        rrdcalc_runtime_string_replace(rc, &rc->summary, string_dup(rc->config.summary));
 
     if(!rc->info)
-        rc->info = string_dup(rc->config.info);
+        rrdcalc_runtime_string_replace(rc, &rc->info, string_dup(rc->config.info));
 }
 
 // ----------------------------------------------------------------------------

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -42,6 +42,13 @@ void rrdcalc_runtime_snapshot_publish(RRDCALC *rc, usec_t global_id, const nd_uu
     state->last_updated = rc->last_updated;
     state->last_status_change = rc->last_status_change;
     state->last_status_change_value = rc->last_status_change_value;
+    state->next_update = rc->next_update;
+    state->db_after = rc->db_after;
+    state->db_before = rc->db_before;
+    state->delay_up_to_timestamp = rc->delay_up_to_timestamp;
+    state->last_repeat = rc->last_repeat;
+    state->delay_last = rc->delay_last;
+    state->times_repeat = rc->times_repeat;
 
     if(transition_id) {
         state->global_id = global_id;
@@ -54,6 +61,14 @@ void rrdcalc_runtime_snapshot_publish(RRDCALC *rc, usec_t global_id, const nd_uu
 void rrdcalc_runtime_snapshot_publish_run_flags(RRDCALC *rc) {
     rw_spinlock_write_lock(&rc->runtime_snapshot.spinlock);
     rc->runtime_snapshot.state.run_flags = rc->run_flags;
+    rw_spinlock_write_unlock(&rc->runtime_snapshot.spinlock);
+}
+
+void rrdcalc_runtime_snapshot_publish_repeat_state(RRDCALC *rc) {
+    rw_spinlock_write_lock(&rc->runtime_snapshot.spinlock);
+    rc->runtime_snapshot.state.run_flags = rc->run_flags;
+    rc->runtime_snapshot.state.last_repeat = rc->last_repeat;
+    rc->runtime_snapshot.state.times_repeat = rc->times_repeat;
     rw_spinlock_write_unlock(&rc->runtime_snapshot.spinlock);
 }
 

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -32,6 +32,37 @@ void rrdcalc_flags_to_json_array(BUFFER *wb, const char *key, RRDCALC_FLAGS flag
     buffer_json_array_close(wb);
 }
 
+void rrdcalc_runtime_snapshot_publish(RRDCALC *rc, usec_t global_id, const nd_uuid_t *transition_id) {
+    rw_spinlock_write_lock(&rc->runtime_snapshot.spinlock);
+
+    RRDCALC_RUNTIME_SNAPSHOT *state = &rc->runtime_snapshot.state;
+    state->status = rc->status;
+    state->run_flags = rc->run_flags;
+    state->value = rc->value;
+    state->last_updated = rc->last_updated;
+    state->last_status_change = rc->last_status_change;
+    state->last_status_change_value = rc->last_status_change_value;
+
+    if(transition_id) {
+        state->global_id = global_id;
+        uuid_copy(state->last_transition_id, *transition_id);
+    }
+
+    rw_spinlock_write_unlock(&rc->runtime_snapshot.spinlock);
+}
+
+void rrdcalc_runtime_snapshot_publish_run_flags(RRDCALC *rc) {
+    rw_spinlock_write_lock(&rc->runtime_snapshot.spinlock);
+    rc->runtime_snapshot.state.run_flags = rc->run_flags;
+    rw_spinlock_write_unlock(&rc->runtime_snapshot.spinlock);
+}
+
+void rrdcalc_runtime_snapshot_get(RRDCALC *rc, RRDCALC_RUNTIME_SNAPSHOT *snapshot) {
+    rw_spinlock_read_lock(&rc->runtime_snapshot.spinlock);
+    *snapshot = rc->runtime_snapshot.state;
+    rw_spinlock_read_unlock(&rc->runtime_snapshot.spinlock);
+}
+
 inline const char *rrdcalc_status2string(RRDCALC_STATUS status) {
     switch(status) {
         case RRDCALC_STATUS_REMOVED:
@@ -266,6 +297,7 @@ static void rrdcalc_link_to_rrdset(RRDCALC *rc) {
 
     health_alarm_log_add_entry(host, ae, true);
     health_log_alert(host, ae);
+    rrdcalc_runtime_snapshot_publish(rc, ae->global_id, &ae->transition_id);
     rrdset_flag_set(st, RRDSET_FLAG_HAS_RRDCALC_LINKED);
 }
 
@@ -340,6 +372,7 @@ static void rrdcalc_rrdhost_insert_callback(const DICTIONARY_ITEM *item __maybe_
     rc->times_repeat = 0;
     rc->last_status_change_value = rc->value;
     rc->last_status_change = now_realtime_sec();
+    rw_spinlock_init(&rc->runtime_snapshot.spinlock);
 
     if(!rc->config.units)
         rc->config.units = string_dup(st->units);
@@ -364,6 +397,7 @@ static void rrdcalc_rrdhost_insert_callback(const DICTIONARY_ITEM *item __maybe_
     expression_set_variable_lookup_callback(rc->config.critical, alert_variable_lookup, rc);
 
     rrdcalc_update_info_using_rrdset_labels(rc);
+    rrdcalc_runtime_snapshot_publish(rc, 0, NULL);
 
     ctr->react_action = RRDCALC_REACT_NEW;
 }

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -42,6 +42,17 @@ void rrdcalc_flags_to_json_array(BUFFER *wb, const char *key, RRDCALC_FLAGS flag
 
 #define RRDCALC_ALL_OPTIONS_EXCLUDING_THE_RRDR_ONES (RRDCALC_OPTION_NO_CLEAR_NOTIFICATION)
 
+typedef struct rrdcalc_runtime_snapshot {
+    RRDCALC_STATUS status;
+    RRDCALC_FLAGS run_flags;
+    NETDATA_DOUBLE value;
+    time_t last_updated;
+    time_t last_status_change;
+    NETDATA_DOUBLE last_status_change_value;
+    usec_t global_id;
+    nd_uuid_t last_transition_id;
+} RRDCALC_RUNTIME_SNAPSHOT;
+
 struct rrdcalc {
     uint32_t id;                    // the unique id of this alarm
     uint32_t next_event_id;         // the next event id that will be used for this alarm
@@ -79,6 +90,11 @@ struct rrdcalc {
     int delay_up_current;           // the current up notification delay duration
     int delay_down_current;         // the current down notification delay duration
     int delay_last;                 // the last delay we used
+
+    struct {
+        RW_SPINLOCK spinlock;
+        RRDCALC_RUNTIME_SNAPSHOT state;
+    } runtime_snapshot;
 
     // ------------------------------------------------------------------------
     // the chart this alarm it is linked to
@@ -175,6 +191,10 @@ void rrdcalc_from_rrdset_release(RRDSET *st, const RRDCALC_ACQUIRED *rca);
 RRDCALC *rrdcalc_acquired_to_rrdcalc(const RRDCALC_ACQUIRED *rca);
 
 const char *rrdcalc_status2string(RRDCALC_STATUS status);
+
+void rrdcalc_runtime_snapshot_publish(RRDCALC *rc, usec_t global_id, const nd_uuid_t *transition_id);
+void rrdcalc_runtime_snapshot_publish_run_flags(RRDCALC *rc);
+void rrdcalc_runtime_snapshot_get(RRDCALC *rc, RRDCALC_RUNTIME_SNAPSHOT *snapshot);
 
 uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id, nd_uuid_t *config_hash_id);
 

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -51,6 +51,13 @@ typedef struct rrdcalc_runtime_snapshot {
     NETDATA_DOUBLE last_status_change_value;
     usec_t global_id;
     nd_uuid_t last_transition_id;
+    time_t next_update;
+    time_t db_after;
+    time_t db_before;
+    time_t delay_up_to_timestamp;
+    time_t last_repeat;
+    int delay_last;
+    uint32_t times_repeat;
 } RRDCALC_RUNTIME_SNAPSHOT;
 
 struct rrdcalc {
@@ -194,6 +201,7 @@ const char *rrdcalc_status2string(RRDCALC_STATUS status);
 
 void rrdcalc_runtime_snapshot_publish(RRDCALC *rc, usec_t global_id, const nd_uuid_t *transition_id);
 void rrdcalc_runtime_snapshot_publish_run_flags(RRDCALC *rc);
+void rrdcalc_runtime_snapshot_publish_repeat_state(RRDCALC *rc);
 void rrdcalc_runtime_snapshot_get(RRDCALC *rc, RRDCALC_RUNTIME_SNAPSHOT *snapshot);
 
 uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id, nd_uuid_t *config_hash_id);

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -203,6 +203,7 @@ void rrdcalc_runtime_snapshot_publish(RRDCALC *rc, usec_t global_id, const nd_uu
 void rrdcalc_runtime_snapshot_publish_run_flags(RRDCALC *rc);
 void rrdcalc_runtime_snapshot_publish_repeat_state(RRDCALC *rc);
 void rrdcalc_runtime_snapshot_get(RRDCALC *rc, RRDCALC_RUNTIME_SNAPSHOT *snapshot);
+void rrdcalc_runtime_strings_acquire(RRDCALC *rc, STRING **summary, STRING **info);
 
 uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id, nd_uuid_t *config_hash_id);
 

--- a/src/health/rrdvar.c
+++ b/src/health/rrdvar.c
@@ -273,11 +273,13 @@ void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *wb) {
             if(unlikely(!alert_st))
                 continue;
 
+            RRDCALC_RUNTIME_SNAPSHOT snapshot;
+            rrdcalc_runtime_snapshot_get(rc, &snapshot);
             tmp = (struct scored) {
                 .existing = false,
                 .chart = string_dup(alert_st->id),
                 .context = string_dup(alert_st->context),
-                .value = rc->value,
+                .value = snapshot.value,
                 .score = rrdlabels_common_count(alert_st->rrdlabels, st->rrdlabels),
             };
             rrdcalc_rrdset_read_unlock(alert_st);

--- a/src/plugins.d/plugins_d.c
+++ b/src/plugins.d/plugins_d.c
@@ -159,10 +159,11 @@ static void pluginsd_worker_thread(void *arg) {
         };
         ND_LOG_STACK_PUSH(lgs);
 
+        bool retry = false;
         count = pluginsd_process(cd->host, cd,
                                  spawn_popen_read_fd(cd->unsafe.pi),
                                  spawn_popen_write_fd(cd->unsafe.pi),
-                                 0);
+                                 0, &retry);
 
         nd_log(NDLS_COLLECTORS, NDLP_WARNING,
                "PLUGINSD: 'host:%s', '%s' (pid %d) disconnected after %zu successful data collections.",
@@ -171,7 +172,9 @@ static void pluginsd_worker_thread(void *arg) {
         int worker_ret_code = spawn_popen_kill(cd->unsafe.pi, 3 * MSEC_PER_SEC);
         cd->unsafe.pi = NULL;
 
-        if(likely(worker_ret_code == 0))
+        if (retry && worker_ret_code != -1)
+            pluginsd_sleep(cd->update_every);
+        else if(likely(worker_ret_code == 0))
             pluginsd_worker_thread_handle_success(cd);
         else
             pluginsd_worker_thread_handle_error(cd, worker_ret_code);

--- a/src/plugins.d/plugins_d.h
+++ b/src/plugins.d/plugins_d.h
@@ -45,7 +45,7 @@ struct plugind {
 
 extern struct plugind *pluginsd_root;
 
-size_t pluginsd_process(struct rrdhost *host, struct plugind *cd, int fd_input, int fd_output, int trust_durations);
+size_t pluginsd_process(struct rrdhost *host, struct plugind *cd, int fd_input, int fd_output, int trust_durations, bool *retry);
 
 struct parser;
 void pluginsd_process_cleanup(struct parser *parser);

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -236,6 +236,12 @@ static inline PARSER_RC pluginsd_host_define_end(char **words __maybe_unused, si
 
     rrdhost_system_info_free(system_info);
 
+    if (!host) {
+        pluginsd_host_define_cleanup(parser);
+        parser->user.retry = true;
+        return PARSER_RC_ERROR;
+    }
+
     rrdhost_option_set(host, RRDHOST_OPTION_VIRTUAL_HOST);
     rrdhost_flag_set(host, RRDHOST_FLAG_COLLECTOR_ONLINE);
     object_state_activate_if_not_activated(&host->state_id);
@@ -1307,8 +1313,9 @@ bool parser_reconstruct_context(BUFFER *wb, void *ptr) {
     return true;
 }
 
-inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, int fd_input, int fd_output, int trust_durations)
+inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, int fd_input, int fd_output, int trust_durations, bool *retry)
 {
+    *retry = false;
     int enabled = cd->unsafe.enabled;
 
     if (fd_input == -1 || fd_output == -1 || !enabled) {
@@ -1379,13 +1386,14 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, int fd_input, 
     }
 
     cd->unsafe.enabled = parser->user.enabled;
+    *retry = parser->user.retry;
     count = parser->user.data_collections_count;
 
     if(likely(count)) {
         cd->successful_collections += count;
         cd->serial_failures = 0;
     }
-    else
+    else if (!*retry)
         cd->serial_failures++;
 
     {

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -23,9 +23,16 @@ static inline PARSER_RC pluginsd_set(char **words, size_t num_words, PARSER *par
 
     st->pluginsd.set = true;
 
-    if (unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)))
-        netdata_log_debug(D_PLUGINSD, "PLUGINSD: 'host:%s/chart:%s/dim:%s' SET is setting value to '%s'",
-              rrdhost_hostname(host), rrdset_id(st), dimension, value && *value ? value : "UNSET");
+    if (unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG))) {
+#ifdef NETDATA_INTERNAL_CHECKS
+        if(unlikely(debug_flags & D_PLUGINSD)) {
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+            netdata_log_debug(D_PLUGINSD, "PLUGINSD: 'host:%s/chart:%s/dim:%s' SET is setting value to '%s'",
+                              string2str(identity.hostname), rrdset_id(st), dimension, value && *value ? value : "UNSET");
+            rrdhost_identity_release(&identity);
+        }
+#endif
+    }
 
     if (value && *value) {
         if(rrddim_is_float(rd))

--- a/src/plugins.d/pluginsd_parser.h
+++ b/src/plugins.d/pluginsd_parser.h
@@ -60,6 +60,7 @@ typedef struct parser_user_object {
     size_t clabel_count;
     size_t data_collections_count;
     int enabled;
+    bool retry;
 
 #ifdef NETDATA_LOG_STREAM_RECEIVER
     void *rpt;

--- a/src/streaming/stream-receiver-connection.c
+++ b/src/streaming/stream-receiver-connection.c
@@ -201,10 +201,10 @@ static bool stream_receiver_send_first_response(struct receiver_state *rpt) {
         if(!host) {
             stream_receiver_log_status(
                 rpt,
-                "rejecting streaming connection; failed to find or create the required host structure",
-                STREAM_HANDSHAKE_PARENT_INTERNAL_ERROR, NDLP_ERR);
+                "rejecting streaming connection; host creation is busy, retry later",
+                STREAM_HANDSHAKE_PARENT_BUSY_TRY_LATER, NDLP_NOTICE);
 
-            stream_send_error_on_taken_over_connection(rpt, START_STREAMING_ERROR_INTERNAL_ERROR);
+            stream_send_error_on_taken_over_connection(rpt, START_STREAMING_ERROR_BUSY_TRY_LATER);
             return false;
         }
 

--- a/src/web/api/formatters/charts2json.c
+++ b/src/web/api/formatters/charts2json.c
@@ -60,10 +60,14 @@ void charts2json(RRDHOST *host, BUFFER *wb) {
 
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_DEFAULT);
 
-    buffer_json_member_add_string(wb, "hostname", rrdhost_hostname(host));
-    buffer_json_member_add_string(wb, "version", rrdhost_program_version(host));
-    buffer_json_member_add_string(wb, "release_channel", get_release_channel());
-    buffer_json_member_add_string(wb, "os", rrdhost_os(host));
+    {
+        RRDHOST_METADATA_IDENTITY identity = rrdhost_metadata_identity_acquire(host);
+        buffer_json_member_add_string(wb, "hostname", string2str(identity.common.hostname));
+        buffer_json_member_add_string(wb, "version", string2str(identity.common.prog_version));
+        buffer_json_member_add_string(wb, "release_channel", get_release_channel());
+        buffer_json_member_add_string(wb, "os", string2str(identity.os));
+        rrdhost_metadata_identity_release(&identity);
+    }
     {
         RRDHOST_TZ host_tz = rrdhost_tz_get(host);
         buffer_json_member_add_string(wb, "timezone", host_tz.timezone);
@@ -108,7 +112,9 @@ void charts2json(RRDHOST *host, BUFFER *wb) {
         rrdhost_foreach_read(h) {
             if(!rrdhost_should_be_cleaned_up(h, host, now) /*&& !rrdhost_flag_check(h, RRDHOST_FLAG_ARCHIVED) */) {
                 buffer_json_add_array_item_object(wb);
-                buffer_json_member_add_string(wb, "hostname", rrdhost_hostname(h));
+                RRDHOST_IDENTITY identity = rrdhost_identity_acquire(h);
+                buffer_json_member_add_string(wb, "hostname", string2str(identity.hostname));
+                rrdhost_identity_release(&identity);
                 buffer_json_object_close(wb);
             }
         }

--- a/src/web/api/formatters/jsonwrap-objects-tree.c
+++ b/src/web/api/formatters/jsonwrap-objects-tree.c
@@ -11,12 +11,14 @@ static void rrdset_rrdcalc_entries_v2(BUFFER *wb, RRDINSTANCE_ACQUIRED *ria) {
         if(st->alerts.base) {
             buffer_json_member_add_object(wb, "alerts");
             for(RRDCALC *rc = st->alerts.base; rc ;rc = rc->next) {
-                if(rc->status < RRDCALC_STATUS_CLEAR)
+                RRDCALC_RUNTIME_SNAPSHOT snapshot;
+                rrdcalc_runtime_snapshot_get(rc, &snapshot);
+                if(snapshot.status < RRDCALC_STATUS_CLEAR)
                     continue;
 
                 buffer_json_member_add_object(wb, string2str(rc->config.name));
-                buffer_json_member_add_string(wb, JSKEY(status), rrdcalc_status2string(rc->status));
-                buffer_json_member_add_double(wb, JSKEY(value), rc->value);
+                buffer_json_member_add_string(wb, JSKEY(status), rrdcalc_status2string(snapshot.status));
+                buffer_json_member_add_double(wb, JSKEY(value), snapshot.value);
                 buffer_json_member_add_string(wb, JSKEY(units), string2str(rc->config.units));
                 buffer_json_object_close(wb);
             }

--- a/src/web/api/formatters/jsonwrap-objects-tree.c
+++ b/src/web/api/formatters/jsonwrap-objects-tree.c
@@ -90,7 +90,9 @@ void query_target_detailed_objects_tree(BUFFER *wb, RRDR *r, RRDR_OPTIONS option
                         if(qn->node_id[0])
                             buffer_json_member_add_string(wb, JSKEY(node_id), qn->node_id);
                         buffer_json_member_add_uint64(wb, JSKEY(node_index), qn->slot);
-                        buffer_json_member_add_string(wb, JSKEY(hostname), rrdhost_hostname(host));
+                        RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+                        buffer_json_member_add_string(wb, JSKEY(hostname), string2str(identity.hostname));
+                        rrdhost_identity_release(&identity);
                         buffer_json_member_add_object(wb, "contexts");
 
                         last_host = host;

--- a/src/web/api/formatters/jsonwrap-summary-alerts.c
+++ b/src/web/api/formatters/jsonwrap-summary-alerts.c
@@ -18,7 +18,9 @@ void query_target_summary_alerts_v2(BUFFER *wb, QUERY_TARGET *qt, const char *ke
                 for (RRDCALC *rc = st->alerts.base; rc; rc = rc->next) {
                     z = dictionary_set(dict, string2str(rc->config.name), NULL, sizeof(*z));
 
-                    switch(rc->status) {
+                    RRDCALC_RUNTIME_SNAPSHOT snapshot;
+                    rrdcalc_runtime_snapshot_get(rc, &snapshot);
+                    switch(snapshot.status) {
                         case RRDCALC_STATUS_CLEAR:
                             z->clear++;
                             break;

--- a/src/web/api/formatters/jsonwrap-summary-nodes.c
+++ b/src/web/api/formatters/jsonwrap-summary-nodes.c
@@ -8,6 +8,7 @@ typedef struct {
     size_t index;                // Original index in the array
     NETDATA_DOUBLE contribution; // Sorting metric (usually volume contribution)
     const char *name;           // Name for display
+    RRDHOST_IDENTITY identity;
 } CARDINALITY_ITEM;
 
 // Comparison function for sorting items by contribution
@@ -42,7 +43,8 @@ void query_target_summary_nodes_v2(BUFFER *wb, QUERY_TARGET *qt, const char *key
         for (size_t c = 0; c < count; c++) {
             QUERY_NODE *qn = query_node(qt, c);
             items[c].index = c;
-            items[c].name = rrdhost_hostname(qn->rrdhost);
+            items[c].identity = rrdhost_identity_acquire(qn->rrdhost);
+            items[c].name = string2str(items[c].identity.hostname);
 
             // Use query points as the metric for contribution
             if (qt->query_points.sum > 0)
@@ -69,7 +71,7 @@ void query_target_summary_nodes_v2(BUFFER *wb, QUERY_TARGET *qt, const char *key
                 QUERY_NODE *qn = query_node(qt, items[i].index);
                 RRDHOST *host = qn->rrdhost;
                 buffer_json_add_array_item_object(wb);
-                buffer_json_node_add_v2(wb, host, qn->slot, qn->duration_ut, show_node_status);
+                buffer_json_node_add_v2(wb, host, &items[i].identity, qn->slot, qn->duration_ut, show_node_status);
 
                 // Only include detailed statistics if MINIMAL_STATS option is not set
                 if (!(qt->window.options & RRDR_OPTION_MINIMAL_STATS)) {
@@ -123,14 +125,19 @@ void query_target_summary_nodes_v2(BUFFER *wb, QUERY_TARGET *qt, const char *key
             buffer_json_object_close(wb);
         }
 
+        for (size_t c = 0; c < count; c++)
+            rrdhost_identity_release(&items[c].identity);
+
         freez(items);
     } else {
         // No limiting needed, output all nodes
         for (size_t c = 0; c < count; c++) {
             QUERY_NODE *qn = query_node(qt, c);
             RRDHOST *host = qn->rrdhost;
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
             buffer_json_add_array_item_object(wb);
-            buffer_json_node_add_v2(wb, host, qn->slot, qn->duration_ut, show_node_status);
+            buffer_json_node_add_v2(wb, host, &identity, qn->slot, qn->duration_ut, show_node_status);
+            rrdhost_identity_release(&identity);
 
             // Only include detailed statistics if MINIMAL_STATS option is not set
             if (!(qt->window.options & RRDR_OPTION_MINIMAL_STATS)) {

--- a/src/web/api/formatters/jsonwrap-v2.c
+++ b/src/web/api/formatters/jsonwrap-v2.c
@@ -330,8 +330,11 @@ void rrdr_json_wrapper_begin2(RRDR *r, BUFFER *wb) {
             buffer_json_object_close(wb); // scope
 
             buffer_json_member_add_object(wb, "selectors");
-            if (qt->request.host)
-                buffer_json_member_add_string(wb, "nodes", rrdhost_hostname(qt->request.host));
+            if (qt->request.host) {
+                RRDHOST_IDENTITY identity = rrdhost_identity_acquire(qt->request.host);
+                buffer_json_member_add_string(wb, "nodes", string2str(identity.hostname));
+                rrdhost_identity_release(&identity);
+            }
             else
                 buffer_json_member_add_string(wb, "nodes", qt->request.nodes);
             buffer_json_member_add_string(wb, "contexts", qt->request.contexts);

--- a/src/web/api/formatters/jsonwrap-v2.c
+++ b/src/web/api/formatters/jsonwrap-v2.c
@@ -17,12 +17,12 @@ void buffer_json_agent_status_id(BUFFER *wb, size_t ai, usec_t duration_ut) {
     buffer_json_object_close(wb);
 }
 
-void buffer_json_node_add_v2(BUFFER *wb, RRDHOST *host, size_t ni, usec_t duration_ut, bool status) {
+void buffer_json_node_add_v2(BUFFER *wb, RRDHOST *host, const RRDHOST_IDENTITY *identity, size_t ni, usec_t duration_ut, bool status) {
     buffer_json_member_add_string(wb, JSKEY(machine_guid), host->machine_guid);
 
     if(!UUIDiszero(host->node_id))
         buffer_json_member_add_uuid(wb, JSKEY(node_id), host->node_id.uuid);
-    buffer_json_member_add_string(wb, JSKEY(hostname), rrdhost_hostname(host));
+    buffer_json_member_add_string(wb, JSKEY(hostname), string2str(identity->hostname));
     buffer_json_member_add_uint64(wb, JSKEY(node_index), ni);
 
     if(status)

--- a/src/web/api/formatters/rrdset2json.c
+++ b/src/web/api/formatters/rrdset2json.c
@@ -84,9 +84,11 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
         DOUBLE_LINKED_LIST_FOREACH_FORWARD(st->alerts.base, rc, prev, next)
         {
             {
+                RRDCALC_RUNTIME_SNAPSHOT snapshot;
+                rrdcalc_runtime_snapshot_get(rc, &snapshot);
                 buffer_json_member_add_object(wb, rrdcalc_name(rc));
                 buffer_json_member_add_string_or_empty(wb, "id", rrdcalc_name(rc));
-                buffer_json_member_add_string_or_empty(wb, "status", rrdcalc_status2string(rc->status));
+                buffer_json_member_add_string_or_empty(wb, "status", rrdcalc_status2string(snapshot.status));
                 buffer_json_member_add_string_or_empty(wb, "units", rrdcalc_units(rc));
                 buffer_json_member_add_int64(wb, "duration", (int64_t)rc->config.update_every);
                 buffer_json_object_close(wb);

--- a/src/web/api/queries/query-group-by-init.c
+++ b/src/web/api/queries/query-group-by-init.c
@@ -141,7 +141,10 @@ static void query_group_by_make_dimension_id(BUFFER *key, RRDR_GROUP_BY group_by
     }
 }
 
-static void query_group_by_make_dimension_name(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, GROUP_BY_HIDDEN_MODE hidden_mode) {
+static void query_group_by_make_dimension_name(
+    BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc,
+    QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, GROUP_BY_HIDDEN_MODE hidden_mode,
+    const STRING *host_hostname) {
     buffer_flush(key);
     if(unlikely(query_metric_hidden_bucket(qm, hidden_mode) && hidden_mode == GROUP_BY_HIDDEN_GLOBAL)) {
         buffer_strcat(key, "__hidden_dimensions__");
@@ -169,7 +172,7 @@ static void query_group_by_make_dimension_name(BUFFER *key, RRDR_GROUP_BY group_
             if (group_by & RRDR_GROUP_BY_NODE)
                 buffer_strcat(key, rrdinstance_acquired_name(qi->ria));
             else
-                buffer_strcat(key, string2str(query_instance_name_fqdn(qi, qt->request.version)));
+                buffer_strcat(key, string2str(query_instance_name_fqdn(qi, qt->request.version, host_hostname)));
         }
 
         if (group_by & RRDR_GROUP_BY_LABEL) {
@@ -185,7 +188,7 @@ static void query_group_by_make_dimension_name(BUFFER *key, RRDR_GROUP_BY group_
             if (buffer_strlen(key) != 0)
                 buffer_fast_strcat(key, ",", 1);
 
-            buffer_strcat(key, rrdhost_hostname(qn->rrdhost));
+            buffer_strcat(key, string2str(host_hostname));
         }
 
         if (group_by & RRDR_GROUP_BY_CONTEXT) {
@@ -354,6 +357,8 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             label_keys = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED | DICT_OPTION_DONT_OVERWRITE_VALUE, NULL, 0);
 
         QUERY_INSTANCE *last_qi = NULL;
+        RRDHOST *identity_host = NULL;
+        RRDHOST_IDENTITY host_identity = { 0 };
         size_t priority = 0;
         time_t update_every_max = 0;
         for (size_t d = 0; d < qt->query.used; d++) {
@@ -362,6 +367,13 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             QUERY_INSTANCE *qi = query_instance(qt, qm->link.query_instance_id);
             QUERY_CONTEXT *qc = query_context(qt, qm->link.query_context_id);
             QUERY_NODE *qn = query_node(qt, qm->link.query_node_id);
+
+            if((group_by & (RRDR_GROUP_BY_INSTANCE | RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE | RRDR_GROUP_BY_NODE)) &&
+               qn->rrdhost != identity_host) {
+                rrdhost_identity_release(&host_identity);
+                host_identity = rrdhost_identity_acquire(qn->rrdhost);
+                identity_host = qn->rrdhost;
+            }
 
             if (qi != last_qi) {
                 last_qi = qi;
@@ -399,7 +411,8 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
                 // ----------------------------------------------------------------
                 // generate the dimension name
 
-                query_group_by_make_dimension_name(key, group_by, g, qt, qn, qc, qi, qd, qm, hidden_mode);
+                query_group_by_make_dimension_name(
+                    key, group_by, g, qt, qn, qc, qi, qd, qm, hidden_mode, host_identity.hostname);
                 entries[pos].name = string_strdupz(buffer_tostring(key));
 
                 // add the rest of the info
@@ -453,6 +466,8 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
                 rrdlabels_walkthrough_read(rrdinstance_acquired_labels(qi->ria),
                                            rrdlabels_traversal_cb_to_group_by_label_key, entries[pos].dl);
         }
+
+        rrdhost_identity_release(&host_identity);
 
         RRDR *r = rrdr_create(owa, qt, added, qt->window.points);
         if (!r) {

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -489,6 +489,30 @@ void query_weights_worker_thread(void *arg)
     thread_data->local_anomaly_bit_used = false;
     memset(&thread_data->local_versions, 0, sizeof(struct query_versions));
 
+    // Copy only immutable query inputs; mutable state is shared atomically or owned by this worker.
+    struct query_weights_data local_qwd = {
+        .qwr = main_qwd->qwr,
+        .shared_qwd = main_qwd,
+        .scope_contexts_sp = main_qwd->scope_contexts_sp,
+        .scope_instances_sp = main_qwd->scope_instances_sp,
+        .scope_dimensions_sp = main_qwd->scope_dimensions_sp,
+        .contexts_sp = main_qwd->contexts_sp,
+        .instances_sp = main_qwd->instances_sp,
+        .dimensions_sp = main_qwd->dimensions_sp,
+        .alerts_sp = main_qwd->alerts_sp,
+        .scope_labels_pa = main_qwd->scope_labels_pa,
+        .labels_pa = main_qwd->labels_pa,
+        .timeout_us = main_qwd->timeout_us,
+        .timings.received_ut = main_qwd->timings.received_ut,
+        .examined_dimensions = thread_data->local_examined_dimensions,
+        .anomaly_bit_used = thread_data->local_anomaly_bit_used,
+        .register_zero = main_qwd->register_zero,
+        .results = thread_data->local_results,
+        .host_snapshots = main_qwd->host_snapshots,
+        .stats = thread_data->local_stats,
+        .shifts = main_qwd->shifts,
+    };
+
     // Process assigned hosts
     for (size_t i = 0; i < thread_data->host_count; i++) {
         RRDHOST *host = thread_data->hosts[i];
@@ -512,15 +536,6 @@ void query_weights_worker_thread(void *arg)
             __atomic_store_n(&main_qwd->interrupted, true, __ATOMIC_RELAXED);
             break;
         }
-
-        // Create a local query_weights_data for this thread
-        struct query_weights_data local_qwd = *main_qwd;
-        local_qwd.shared_qwd = main_qwd;
-        local_qwd.results = thread_data->local_results;
-        local_qwd.stats = thread_data->local_stats;
-        local_qwd.examined_dimensions = thread_data->local_examined_dimensions;
-        local_qwd.anomaly_bit_used = thread_data->local_anomaly_bit_used;
-        local_qwd.versions = thread_data->local_versions;
 
         char uuid[UUID_STR_LEN];
         if(!UUIDiszero(host->node_id))

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -56,6 +56,7 @@ typedef enum {
 struct register_result {
     RESULT_FLAGS flags;
     RRDHOST *host;
+    STRING *hostname;
     RRDCONTEXT_ACQUIRED *rca;
     RRDINSTANCE_ACQUIRED *ria;
     RRDMETRIC_ACQUIRED *rma;
@@ -64,6 +65,62 @@ struct register_result {
     STORAGE_POINT baseline;
     usec_t duration_ut;
 };
+
+struct weights_host_snapshot {
+    RRDHOST *host;
+    STRING *hostname;
+};
+
+static bool weights_host_snapshot_conflict_callback(
+    const DICTIONARY_ITEM *item __maybe_unused, void *old_value __maybe_unused, void *new_value, void *data __maybe_unused) {
+    struct weights_host_snapshot *snapshot = new_value;
+
+    string_freez(snapshot->hostname);
+    snapshot->hostname = NULL;
+    return false;
+}
+
+static void weights_host_snapshot_delete_callback(
+    const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused) {
+    struct weights_host_snapshot *snapshot = value;
+
+    string_freez(snapshot->hostname);
+    snapshot->hostname = NULL;
+}
+
+static DICTIONARY *weights_host_snapshots_init(void) {
+    DICTIONARY *snapshots = dictionary_create_advanced(
+        DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE, NULL, sizeof(struct weights_host_snapshot));
+
+    dictionary_register_conflict_callback(snapshots, weights_host_snapshot_conflict_callback, NULL);
+    dictionary_register_delete_callback(snapshots, weights_host_snapshot_delete_callback, NULL);
+    return snapshots;
+}
+
+static struct weights_host_snapshot *weights_host_snapshot_get(DICTIONARY *snapshots, RRDHOST *host) {
+    char key[2 * sizeof(void *) + 3];
+    int key_len = snprintfz(key, sizeof(key), "%p", (void *)host);
+
+    struct weights_host_snapshot *snapshot = dictionary_get_advanced(snapshots, key, key_len);
+    if(likely(snapshot))
+        return snapshot;
+
+    RRDHOST_IDENTITY identity = rrdhost_identity_acquire(host);
+    struct weights_host_snapshot candidate = {
+        .host = host,
+        .hostname = identity.hostname,
+    };
+    identity.hostname = NULL;
+    rrdhost_identity_release(&identity);
+
+    snapshot = dictionary_set_advanced(snapshots, key, key_len, &candidate, sizeof(candidate), NULL);
+    if(unlikely(!snapshot)) {
+        string_freez(candidate.hostname);
+        fatal("QUERY WEIGHTS: failed to retain a host hostname");
+    }
+
+    return snapshot;
+}
 
 static DICTIONARY *register_result_init() {
     DICTIONARY *results = dictionary_create_advanced(DICT_OPTION_FIXED_SIZE, NULL, sizeof(struct register_result));
@@ -108,7 +165,8 @@ static void merge_results_dictionaries(DICTIONARY *main_results, DICTIONARY *loc
 static ssize_t weights_do_node_callback(void *data, RRDHOST *host, bool queryable);
 static ssize_t weights_do_context_callback(void *data, RRDCONTEXT_ACQUIRED *rca, bool queryable_context);
 
-static void register_result(DICTIONARY *results, RRDHOST *host, RRDCONTEXT_ACQUIRED *rca, RRDINSTANCE_ACQUIRED *ria,
+static void register_result(DICTIONARY *results, RRDHOST *host, STRING *hostname,
+                            RRDCONTEXT_ACQUIRED *rca, RRDINSTANCE_ACQUIRED *ria,
                             RRDMETRIC_ACQUIRED *rma, NETDATA_DOUBLE value, RESULT_FLAGS flags,
                             STORAGE_POINT *highlighted, STORAGE_POINT *baseline, WEIGHTS_STATS *stats,
                             bool register_zero, usec_t duration_ut) {
@@ -129,6 +187,7 @@ static void register_result(DICTIONARY *results, RRDHOST *host, RRDCONTEXT_ACQUI
     struct register_result t = {
         .flags = flags,
         .host = host,
+        .hostname = hostname,
         .rca = rca,
         .ria = ria,
         .rma = rma,
@@ -371,6 +430,8 @@ struct query_weights_data {
     bool register_zero;
 
     DICTIONARY *results;
+    DICTIONARY *host_snapshots;
+    struct weights_host_snapshot *host_snapshot;
     WEIGHTS_STATS stats;
     RRDHOST **hosts_array;
     size_t total_hosts;
@@ -463,9 +524,12 @@ void query_weights_worker_thread(void *arg)
         else
             uuid[0] = '\0';
 
+        local_qwd.host_snapshot = weights_host_snapshot_get(local_qwd.host_snapshots, host);
+
         SIMPLE_PATTERN_RESULT match = SP_MATCHED_POSITIVE;
         if(main_qwd->scope_nodes_sp) {
-            match = simple_pattern_matches_string_extract(main_qwd->scope_nodes_sp, host->hostname, NULL, 0);
+            match = simple_pattern_matches_string_extract(
+                main_qwd->scope_nodes_sp, local_qwd.host_snapshot->hostname, NULL, 0);
             if(match == SP_NOT_MATCHED) {
                 match = simple_pattern_matches_extract(main_qwd->scope_nodes_sp, host->machine_guid, NULL, 0);
                 if(match == SP_NOT_MATCHED && *uuid)
@@ -477,7 +541,8 @@ void query_weights_worker_thread(void *arg)
             continue;
 
         if(main_qwd->nodes_sp) {
-            match = simple_pattern_matches_string_extract(main_qwd->nodes_sp, host->hostname, NULL, 0);
+            match = simple_pattern_matches_string_extract(
+                main_qwd->nodes_sp, local_qwd.host_snapshot->hostname, NULL, 0);
             if(match == SP_NOT_MATCHED) {
                 match = simple_pattern_matches_extract(main_qwd->nodes_sp, host->machine_guid, NULL, 0);
                 if(match == SP_NOT_MATCHED && *uuid)
@@ -1198,7 +1263,7 @@ static size_t registered_results_to_json_multinode_group_by(
                 buffer_fast_strcat(key, "@", 1);
                 buffer_fast_strcat(name, "@", 1);
                 buffer_strcat(key, node_uuid);
-                buffer_strcat(name, rrdhost_hostname(t->host));
+                buffer_strcat(name, string2str(t->hostname));
             }
         }
         if(qwd->qwr->group_by.group_by & RRDR_GROUP_BY_NODE) {
@@ -1208,7 +1273,7 @@ static size_t registered_results_to_json_multinode_group_by(
             }
 
             buffer_strcat(key, node_uuid);
-            buffer_strcat(name, rrdhost_hostname(t->host));
+            buffer_strcat(name, string2str(t->hostname));
         }
         if(qwd->qwr->group_by.group_by & RRDR_GROUP_BY_CONTEXT) {
             if(buffer_strlen(key)) {
@@ -1550,7 +1615,7 @@ cleanup:
 }
 
 static void rrdset_metric_correlations_ks2(
-        RRDHOST *host,
+        RRDHOST *host, STRING *hostname,
         RRDCONTEXT_ACQUIRED *rca, RRDINSTANCE_ACQUIRED *ria, RRDMETRIC_ACQUIRED *rma,
         DICTIONARY *results,
         time_t baseline_after, time_t baseline_before,
@@ -1605,7 +1670,7 @@ static void rrdset_metric_correlations_ks2(
 
         // to spread the results evenly, 0.0 needs to be the less correlated and 1.0 the most correlated
         // so, we flip the result of kstwo()
-        register_result(results, host, rca, ria, rma, 1.0 - prob, RESULT_IS_BASE_HIGH_RATIO, &highlighted_sp,
+        register_result(results, host, hostname, rca, ria, rma, 1.0 - prob, RESULT_IS_BASE_HIGH_RATIO, &highlighted_sp,
                         &baseline_sp, stats, register_zero, ended_ut - started_ut);
     }
 
@@ -1627,7 +1692,7 @@ static void merge_query_value_to_stats(QUERY_VALUE *qv, WEIGHTS_STATS *stats, si
 }
 
 static void rrdset_metric_correlations_volume(
-        RRDHOST *host,
+        RRDHOST *host, STRING *hostname,
         RRDCONTEXT_ACQUIRED *rca, RRDINSTANCE_ACQUIRED *ria, RRDMETRIC_ACQUIRED *rma,
         DICTIONARY *results,
         time_t baseline_after, time_t baseline_before,
@@ -1694,7 +1759,7 @@ static void rrdset_metric_correlations_volume(
         pcent = highlight_countif.value;
     }
 
-    register_result(results, host, rca, ria, rma, pcent, flags, &highlight_average.sp, &baseline_average.sp, stats,
+    register_result(results, host, hostname, rca, ria, rma, pcent, flags, &highlight_average.sp, &baseline_average.sp, stats,
                     register_zero, baseline_average.duration_ut + highlight_average.duration_ut + highlight_countif.duration_ut);
 }
 
@@ -1702,7 +1767,7 @@ static void rrdset_metric_correlations_volume(
 // VALUE / ANOMALY RATE algorithm functions
 
 static void rrdset_weights_value(
-        RRDHOST *host,
+        RRDHOST *host, STRING *hostname,
         RRDCONTEXT_ACQUIRED *rca, RRDINSTANCE_ACQUIRED *ria, RRDMETRIC_ACQUIRED *rma,
         DICTIONARY *results,
         time_t after, time_t before,
@@ -1719,7 +1784,7 @@ static void rrdset_weights_value(
     merge_query_value_to_stats(&qv, stats, 1);
 
     if(netdata_double_isnumber(qv.value))
-        register_result(results, host, rca, ria, rma, qv.value, 0, &qv.sp, NULL, stats, register_zero, qv.duration_ut);
+        register_result(results, host, hostname, rca, ria, rma, qv.value, 0, &qv.sp, NULL, stats, register_zero, qv.duration_ut);
 }
 
 static void rrdset_weights_multi_dimensional_value(struct query_weights_data *qwd) {
@@ -1765,6 +1830,8 @@ static void rrdset_weights_multi_dimensional_value(struct query_weights_data *qw
     };
 
     size_t queries = 0;
+    RRDHOST *last_host = NULL;
+    struct weights_host_snapshot *host_snapshot = NULL;
     for(size_t d = 0; d < r->d ;d++) {
         qwd->examined_dimensions++;
 
@@ -1786,7 +1853,12 @@ static void rrdset_weights_multi_dimensional_value(struct query_weights_data *qw
             QUERY_CONTEXT *qc = query_context(r->internal.qt, qm->link.query_context_id);
             QUERY_NODE *qn = query_node(r->internal.qt, qm->link.query_node_id);
 
-            register_result(qwd->results, qn->rrdhost, qc->rca, qi->ria, qd->rma, qv.value, 0,
+            if(!host_snapshot || qn->rrdhost != last_host) {
+                last_host = qn->rrdhost;
+                host_snapshot = weights_host_snapshot_get(qwd->host_snapshots, last_host);
+            }
+
+            register_result(qwd->results, qn->rrdhost, host_snapshot->hostname, qc->rca, qi->ria, qd->rma, qv.value, 0,
                             &r->internal.qt->query.array[d].query_points, NULL,
                             &qwd->stats, qwd->register_zero, qm->duration_ut);
         }
@@ -1969,7 +2041,7 @@ static int registered_results_to_json_mcp_callback(const DICTIONARY_ITEM *item _
 
     // Add metadata
     // Add node name
-    buffer_json_add_array_item_string(wb, rrdhost_hostname(t->host));
+    buffer_json_add_array_item_string(wb, string2str(t->hostname));
     
     // Add context
     buffer_json_add_array_item_string(wb, rrdcontext_acquired_id(t->rca));
@@ -2115,7 +2187,7 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
     switch(qwr->method) {
         case WEIGHTS_METHOD_VALUE:
             rrdset_weights_value(
-                    host, rca, ria, rma,
+                    host, qwd->host_snapshot->hostname, rca, ria, rma,
                     qwd->results,
                     qwr->after, qwr->before,
                     qwr->options, qwr->time_group_method, qwr->time_group_options, qwr->tier,
@@ -2126,7 +2198,7 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
         case WEIGHTS_METHOD_ANOMALY_RATE:
             qwr->options |= RRDR_OPTION_ANOMALY_BIT;
             rrdset_weights_value(
-                    host, rca, ria, rma,
+                    host, qwd->host_snapshot->hostname, rca, ria, rma,
                     qwd->results,
                     qwr->after, qwr->before,
                     qwr->options, qwr->time_group_method, qwr->time_group_options, qwr->tier,
@@ -2136,7 +2208,7 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
 
         case WEIGHTS_METHOD_MC_VOLUME:
             rrdset_metric_correlations_volume(
-                    host, rca, ria, rma,
+                    host, qwd->host_snapshot->hostname, rca, ria, rma,
                     qwd->results,
                     qwr->baseline_after, qwr->baseline_before,
                     qwr->after, qwr->before,
@@ -2148,7 +2220,7 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
         default:
         case WEIGHTS_METHOD_MC_KS2:
             rrdset_metric_correlations_ks2(
-                    host, rca, ria, rma,
+                    host, qwd->host_snapshot->hostname, rca, ria, rma,
                     qwd->results,
                     qwr->baseline_after, qwr->baseline_before,
                     qwr->after, qwr->before, qwr->points,
@@ -2379,6 +2451,9 @@ static ssize_t weights_do_node_callback(void *data, RRDHOST *host, bool queryabl
 
     struct query_weights_data *qwd = data;
 
+    if(!qwd->host_snapshot || qwd->host_snapshot->host != host)
+        qwd->host_snapshot = weights_host_snapshot_get(qwd->host_snapshots, host);
+
     ssize_t ret = query_scope_foreach_context(host, qwd->qwr->scope_contexts,
                                 qwd->scope_contexts_sp, qwd->contexts_sp,
                                 weights_do_context_callback, queryable, qwd);
@@ -2422,6 +2497,7 @@ int web_api_v12_weights(BUFFER *wb, QUERY_WEIGHTS_REQUEST *qwr) {
             .examined_dimensions = 0,
             .register_zero = true,
             .results = register_result_init(),
+            .host_snapshots = weights_host_snapshots_init(),
             .stats = {},
             .shifts = 0,
             .total_workload = {0}, // Initialize workload statistics
@@ -2645,6 +2721,7 @@ cleanup:
     pattern_array_free(qwd.labels_pa);
 
     register_result_destroy(qwd.results);
+    dictionary_destroy(qwd.host_snapshots);
 
     if(error) {
         buffer_flush(wb);

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -427,6 +427,7 @@ struct query_weights_data {
     struct query_timings timings;
 
     size_t examined_dimensions;
+    bool anomaly_bit_used;
     bool register_zero;
 
     DICTIONARY *results;
@@ -449,6 +450,7 @@ struct query_weights_thread_data {
     DICTIONARY *local_results;
     WEIGHTS_STATS local_stats;
     size_t local_examined_dimensions;
+    bool local_anomaly_bit_used;
     struct query_versions local_versions;
     RRDHOST **hosts;
     struct completion completion;
@@ -484,6 +486,7 @@ void query_weights_worker_thread(void *arg)
     // Initialize local statistics
     memset(&thread_data->local_stats, 0, sizeof(WEIGHTS_STATS));
     thread_data->local_examined_dimensions = 0;
+    thread_data->local_anomaly_bit_used = false;
     memset(&thread_data->local_versions, 0, sizeof(struct query_versions));
 
     // Process assigned hosts
@@ -516,6 +519,7 @@ void query_weights_worker_thread(void *arg)
         local_qwd.results = thread_data->local_results;
         local_qwd.stats = thread_data->local_stats;
         local_qwd.examined_dimensions = thread_data->local_examined_dimensions;
+        local_qwd.anomaly_bit_used = thread_data->local_anomaly_bit_used;
         local_qwd.versions = thread_data->local_versions;
 
         char uuid[UUID_STR_LEN];
@@ -560,6 +564,7 @@ void query_weights_worker_thread(void *arg)
 
         // Process the host using the callback
         ssize_t ret = weights_do_node_callback(&local_qwd, host, queryable_host);
+        thread_data->local_anomaly_bit_used = local_qwd.anomaly_bit_used;
         if (ret < 0)
             break;
 
@@ -2196,12 +2201,13 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
             break;
 
         case WEIGHTS_METHOD_ANOMALY_RATE:
-            qwr->options |= RRDR_OPTION_ANOMALY_BIT;
+            qwd->anomaly_bit_used = true;
             rrdset_weights_value(
                     host, qwd->host_snapshot->hostname, rca, ria, rma,
                     qwd->results,
                     qwr->after, qwr->before,
-                    qwr->options, qwr->time_group_method, qwr->time_group_options, qwr->tier,
+                    qwr->options | RRDR_OPTION_ANOMALY_BIT,
+                    qwr->time_group_method, qwr->time_group_options, qwr->tier,
                     &qwd->stats, qwd->register_zero
             );
             break;
@@ -2413,6 +2419,7 @@ static ssize_t query_scope_foreach_host_parallel(SIMPLE_PATTERN *scope_hosts_sp,
 
     // Wait for all threads to complete
     ssize_t total_added = 0;
+    bool anomaly_bit_used = false;
     for (size_t i = 0; i < num_threads; i++) {
         completion_wait_for(&thread_data[i].completion);
         completion_destroy(&thread_data[i].completion);
@@ -2423,6 +2430,7 @@ static ssize_t query_scope_foreach_host_parallel(SIMPLE_PATTERN *scope_hosts_sp,
 
         // Accumulate examined dimensions
         __atomic_fetch_add(&qwd->examined_dimensions, thread_data[i].local_examined_dimensions, __ATOMIC_RELAXED);
+        anomaly_bit_used |= thread_data[i].local_anomaly_bit_used;
 
         // Merge version hashes
         qwd->versions.contexts_hard_hash += thread_data[i].local_versions.contexts_hard_hash;
@@ -2434,6 +2442,7 @@ static ssize_t query_scope_foreach_host_parallel(SIMPLE_PATTERN *scope_hosts_sp,
         register_result_destroy(thread_data[i].local_results);
     }
 
+    qwd->anomaly_bit_used |= anomaly_bit_used;
     total_added = (ssize_t) dictionary_entries(qwd->results);
 
     // Cleanup
@@ -2606,6 +2615,10 @@ int web_api_v12_weights(BUFFER *wb, QUERY_WEIGHTS_REQUEST *qwr) {
             query_scope_foreach_host_parallel(qwd.scope_nodes_sp, qwd.nodes_sp, &qwd);
         }
     }
+
+    // Preserve response metadata only after worker reads of the request have finished.
+    if(qwd.anomaly_bit_used)
+        qwr->options |= RRDR_OPTION_ANOMALY_BIT;
 
     if(!qwd.register_zero) {
         // put it back, to show it in the response

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -1064,8 +1064,10 @@ static size_t registered_results_to_json_multinode_no_group_by(
             if(!dun->exposed)
                 continue;
 
+            RRDHOST_IDENTITY identity = rrdhost_identity_acquire(dun->host);
             buffer_json_add_array_item_object(wb);
-            buffer_json_node_add_v2(wb, dun->host, dun->i, dun->duration_ut, true);
+            buffer_json_node_add_v2(wb, dun->host, &identity, dun->i, dun->duration_ut, true);
+            rrdhost_identity_release(&identity);
             buffer_json_object_close(wb);
         }
         dfe_done(dun);

--- a/src/web/api/v1/api_v1_allmetrics.c
+++ b/src/web/api/v1/api_v1_allmetrics.c
@@ -108,7 +108,9 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, const char *filter_
         char alarm[SHELL_ELEMENT_MAX + 1];
         shell_name_copy(alarm, rrdcalc_name(rc), SHELL_ELEMENT_MAX);
 
-        NETDATA_DOUBLE n = rc->value;
+        RRDCALC_RUNTIME_SNAPSHOT snapshot;
+        rrdcalc_runtime_snapshot_get(rc, &snapshot);
+        NETDATA_DOUBLE n = snapshot.value;
 
         if(isnan(n) || isinf(n))
             buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_VALUE=\"\"      # %s\n", chart, alarm, rrdcalc_units(rc));
@@ -117,7 +119,8 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, const char *filter_
             buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_VALUE=\"" NETDATA_DOUBLE_FORMAT_ZERO "\"      # %s\n", chart, alarm, n, rrdcalc_units(rc));
         }
 
-        buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_STATUS=\"%s\"\n", chart, alarm, rrdcalc_status2string(rc->status));
+        buffer_sprintf(
+            wb, "NETDATA_ALARM_%s_%s_STATUS=\"%s\"\n", chart, alarm, rrdcalc_status2string(snapshot.status));
         rw_spinlock_read_unlock(&alert_st->alerts.spinlock);
     }
     foreach_rrdcalc_in_rrdhost_done(rc);

--- a/src/web/api/v1/api_v1_badge/web_buffer_svg.c
+++ b/src/web/api/v1/api_v1_badge/web_buffer_svg.c
@@ -1072,8 +1072,11 @@ int api_v1_badge(RRDHOST *host, struct web_client *w, char *url) {
         else
             buffer_no_cacheable(w->response.data);
 
+        RRDCALC_RUNTIME_SNAPSHOT snapshot;
+        rrdcalc_runtime_snapshot_get(rc, &snapshot);
+
         if(!value_color) {
-            switch(rc->status) {
+            switch(snapshot.status) {
                 case RRDCALC_STATUS_CRITICAL:
                     value_color = "red";
                     break;
@@ -1102,7 +1105,8 @@ int api_v1_badge(RRDHOST *host, struct web_client *w, char *url) {
 
         buffer_svg(w->response.data,
                 label,
-                (isnan(rc->value)||isinf(rc->value)) ? rc->value : rc->value * multiply / divide,
+                (isnan(snapshot.value)||isinf(snapshot.value)) ?
+                    snapshot.value : snapshot.value * multiply / divide,
                 units,
                 label_color,
                 value_color,

--- a/src/web/api/v1/api_v1_info.c
+++ b/src/web/api/v1/api_v1_info.c
@@ -89,7 +89,9 @@ static void web_client_api_request_v1_info_summary_alarm_statuses(RRDHOST *host,
             continue;
         }
 
-        switch(rc->status) {
+        RRDCALC_RUNTIME_SNAPSHOT snapshot;
+        rrdcalc_runtime_snapshot_get(rc, &snapshot);
+        switch(snapshot.status) {
             case RRDCALC_STATUS_WARNING:
                 warning++;
                 break;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes host identity and alert state across the stack to remove use-after-free and data races, and fixes metadata, streaming, plugins.d, query, and API edge cases without changing outputs.

- **Bug Fixes**
  - Retain host/node identity snapshots across ACLK (node info/creation), contexts v1/v2 (incl. v2 debug), legacy charts JSON, weights, queries, plugins.d debug logs, and diagnostics to prevent freed-pointer reads and mixed generations.
  - Publish a coherent `RRDCALC_RUNTIME_SNAPSHOT` (status/value/timestamps/flags plus next_update, db_* window, delay, repeat, transition IDs); switch all readers (v1/v2 JSON, badges, analytics, variables, host status, objects-tree/summary) to it; protect runtime summary/info strings; restore repeat state on health-log load.
  - Protect metadata with per-host `metadata_lifetime_lock`; ephemeral removal resolves by GUID and reports BUSY; orphan cleanup/free consumes the lock; streaming handshake now returns BUSY/TRY_LATER. SQLite host metadata writes bind a retained identity and fix the prepare-failure return to trigger retries.
  - Queries/weights: snapshot hostnames for scope filters, FQDN names, group keys, and result rows; isolate parallel DB-engine worker state and avoid shared anomaly-option mutation.

- **Refactors**
  - JSON helpers accept a borrowed `RRDHOST_IDENTITY` (v2 node/MCP); callers acquire/release once per node.
  - Query/weights paths take hostnames from retained snapshots; updated helpers and signatures keep outputs and ordering unchanged. Plugins.d workers expose a retry hint and back off one interval before restart.

<sup>Written for commit b12aa0a402943349c2e7d9155ddf1e5f6ba72c4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

