### PR TITLE
Netdata fixes part 76

### DIFF
--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1618,6 +1618,62 @@ static int test_rrdmetric_algorithm_follows_rrddim(void) {
     return rc;
 }
 
+static int test_rrddim_scale_minimum_magnitude(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    RRD_DB_MODE old_default_rrd_memory_mode = default_rrd_memory_mode;
+    default_rrd_memory_mode = RRD_DB_MODE_ALLOC;
+
+    int rc = 0;
+    if(rrddim_scale_magnitude(INT32_MIN) != (int64_t)INT32_MAX + 1) {
+        fprintf(stderr, "%s: INT32_MIN magnitude is not representable\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    RRDSET *st_insert = rrdset_create_localhost(
+        "netdata", "unittest-scale-min-insert", "unittest-scale-min-insert", "netdata", NULL,
+        "Unit Testing", "x", "unittest", NULL, 1,
+        nd_profile.update_every, RRDSET_TYPE_LINE);
+    RRDDIM *insert_a = rrddim_add(st_insert, "a", NULL, INT32_MIN, INT32_MIN, RRD_ALGORITHM_ABSOLUTE);
+    RRDDIM *insert_b = rrddim_add(st_insert, "b", NULL, INT32_MIN, INT32_MIN, RRD_ALGORITHM_ABSOLUTE);
+
+    if(insert_a->multiplier != INT32_MIN || insert_a->divisor != INT32_MIN ||
+       insert_b->multiplier != INT32_MIN || insert_b->divisor != INT32_MIN ||
+       rrdset_flag_check(st_insert, RRDSET_FLAG_HETEROGENEOUS)) {
+        fprintf(stderr, "%s: identical signed-minimum dimensions were not preserved as homogeneous\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    RRDSET *st_multiplier = rrdset_create_localhost(
+        "netdata", "unittest-scale-min-multiplier", "unittest-scale-min-multiplier", "netdata", NULL,
+        "Unit Testing", "x", "unittest", NULL, 1,
+        nd_profile.update_every, RRDSET_TYPE_LINE);
+    rrddim_add(st_multiplier, "a", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    rrddim_add(st_multiplier, "b", NULL, INT32_MIN, 1, RRD_ALGORITHM_ABSOLUTE);
+    rrdset_flag_set(st_multiplier, RRDSET_FLAG_HOMOGENEOUS_CHECK);
+    rrdset_update_heterogeneous_flag(st_multiplier);
+    if(!rrdset_flag_check(st_multiplier, RRDSET_FLAG_HETEROGENEOUS)) {
+        fprintf(stderr, "%s: differing signed-minimum multiplier was not heterogeneous\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    RRDSET *st_divisor = rrdset_create_localhost(
+        "netdata", "unittest-scale-min-divisor", "unittest-scale-min-divisor", "netdata", NULL,
+        "Unit Testing", "x", "unittest", NULL, 1,
+        nd_profile.update_every, RRDSET_TYPE_LINE);
+    rrddim_add(st_divisor, "a", NULL, 1, INT32_MIN, RRD_ALGORITHM_ABSOLUTE);
+    rrddim_add(st_divisor, "b", NULL, 1, INT32_MIN, RRD_ALGORITHM_ABSOLUTE);
+    rrdset_flag_set(st_divisor, RRDSET_FLAG_HOMOGENEOUS_CHECK);
+    rrdset_update_heterogeneous_flag(st_divisor);
+    if(rrdset_flag_check(st_divisor, RRDSET_FLAG_HETEROGENEOUS)) {
+        fprintf(stderr, "%s: identical signed-minimum divisors were not homogeneous\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    default_rrd_memory_mode = old_default_rrd_memory_mode;
+    return rc;
+}
+
 static int test_rrdset_rejects_invalid_update_every(void) {
     fprintf(stderr, "%s() running...\n", __FUNCTION__);
 
@@ -1793,6 +1849,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(test_rrdmetric_algorithm_follows_rrddim())
+        return 1;
+
+    if(test_rrddim_scale_minimum_magnitude())
         return 1;
 
     if(test_rrdset_rejects_invalid_update_every())

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1674,6 +1674,54 @@ static int test_rrddim_scale_minimum_magnitude(void) {
     return rc;
 }
 
+static int test_rrddim_divisor_normalization(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    RRD_DB_MODE old_default_rrd_memory_mode = default_rrd_memory_mode;
+    default_rrd_memory_mode = RRD_DB_MODE_ALLOC;
+
+    RRDSET *st = rrdset_create_localhost(
+        "netdata", "unittest-divisor-normalization", "unittest-divisor-normalization", "netdata", NULL,
+        "Unit Testing", "x", "unittest", NULL, 1,
+        nd_profile.update_every, RRDSET_TYPE_LINE);
+    RRDDIM *rd = rrddim_add(st, "d", NULL, 1, 0, RRD_ALGORITHM_ABSOLUTE);
+
+    int rc = 0;
+    if(rd->divisor != 1) {
+        fprintf(stderr, "%s: construction stored zero divisor as %d instead of 1\n", __FUNCTION__, rd->divisor);
+        rc = 1;
+    }
+
+    if(rrddim_set_divisor(st, rd, 7) != 1 || rd->divisor != 7) {
+        fprintf(stderr, "%s: valid positive divisor was not preserved\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    if(rrddim_set_divisor(st, rd, 0) != 1 || rd->divisor != 1) {
+        fprintf(stderr, "%s: zero divisor update was not normalized to 1\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    if(rrddim_set_divisor(st, rd, 0) != 0 || rd->divisor != 1) {
+        fprintf(stderr, "%s: repeated normalized zero update was not a no-op\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    if(rrddim_set_divisor(st, rd, -7) != 1 || rd->divisor != -7) {
+        fprintf(stderr, "%s: valid negative divisor was not preserved\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    RRDDIM *same_rd = rrddim_add(st, "d", NULL, 1, 0, RRD_ALGORITHM_ABSOLUTE);
+    if(same_rd != rd || rd->divisor != 1) {
+        fprintf(stderr, "%s: conflict update did not preserve identity and normalize zero divisor\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    default_rrd_memory_mode = old_default_rrd_memory_mode;
+    return rc;
+}
+
 static int test_rrdset_rejects_invalid_update_every(void) {
     fprintf(stderr, "%s() running...\n", __FUNCTION__);
 
@@ -1852,6 +1900,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(test_rrddim_scale_minimum_magnitude())
+        return 1;
+
+    if(test_rrddim_divisor_normalization())
         return 1;
 
     if(test_rrdset_rejects_invalid_update_every())

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -2,6 +2,7 @@
 
 #include "common.h"
 #include "web/api/formatters/rrd2json.h"
+#include "web/api/queries/query-internal.h"
 #include "database/contexts/rrdcontext-internal.h"
 #ifdef OS_WINDOWS
 #include "win_system-info.h"
@@ -1899,6 +1900,170 @@ static int test_rrdr_relative_window_extreme_values(void) {
     return errors;
 }
 
+static void query_window_test_target_init(
+    QUERY_TARGET *qt, time_t after, time_t before, size_t points, time_t resampling_time,
+    RRDR_TIME_GROUPING grouping, RRDR_OPTIONS options, time_t update_every) {
+    *qt = (QUERY_TARGET){
+        .request = {
+            .after = after,
+            .before = before,
+            .points = points,
+            .resampling_time = resampling_time,
+            .time_group_method = grouping,
+        },
+        .window = {
+            .options = options,
+            .after = after,
+            .before = before,
+        },
+        .db = {
+            .first_time_s = 1000000000,
+            .last_time_s = 1000000600,
+            .minimum_latest_update_every_s = update_every,
+        },
+    };
+    snprintfz(qt->id, sizeof(qt->id) - 1, "query-window-unittest");
+}
+
+static int test_query_window_resampling_boundaries(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    const time_t maximum = (time_t)(((uintmax_t)1 << (sizeof(time_t) * CHAR_BIT - 1)) - 1);
+    int errors = 0;
+
+#define QUERY_WINDOW_CHECK(condition, message) do {                                 \
+        if(!(condition)) {                                                          \
+            fprintf(stderr, "%s: %s\n", __FUNCTION__, (message));                \
+            errors++;                                                               \
+        }                                                                            \
+    } while(0)
+
+    for(RRDR_TIME_GROUPING grouping = RRDR_GROUPING_AVERAGE;
+        grouping <= RRDR_GROUPING_EXTREMES; grouping++) {
+        QUERY_TARGET qt;
+        query_window_test_target_init(
+            &qt, 1000000001, 1000000600, 10, 60, grouping, RRDR_OPTION_NOT_ALIGNED, 1);
+
+        QUERY_WINDOW_CHECK(query_target_calculate_window(&qt), "valid grouping mode was rejected");
+        QUERY_WINDOW_CHECK(qt.window.time_group_method == grouping, "grouping mode changed");
+        QUERY_WINDOW_CHECK(qt.window.after == 1000000001 && qt.window.before == 1000000600,
+                           "unaligned resampling window changed");
+        QUERY_WINDOW_CHECK(qt.window.points == 10 && qt.window.group == 60,
+                           "unaligned resampling point layout changed");
+        QUERY_WINDOW_CHECK(qt.window.resampling_group == 60 && qt.window.resampling_divisor == 1.0,
+                           "unaligned resampling ratio changed");
+    }
+
+    {
+        QUERY_TARGET qt;
+        query_window_test_target_init(&qt, 1000000001, 1000000600, 10, 60, RRDR_GROUPING_AVERAGE, 0, 1);
+        QUERY_WINDOW_CHECK(query_target_calculate_window(&qt), "valid aligned window was rejected");
+        QUERY_WINDOW_CHECK(qt.window.after == 1000000021 && qt.window.before == 1000000620,
+                           "aligned resampling endpoints changed");
+        QUERY_WINDOW_CHECK(qt.window.points == 10 && qt.window.group == 60,
+                           "aligned resampling point layout changed");
+    }
+
+    {
+        QUERY_TARGET qt;
+        query_window_test_target_init(
+            &qt, 1000000001, 1000000600, 10, 60, RRDR_GROUPING_AVERAGE,
+            RRDR_OPTION_NATURAL_POINTS | RRDR_OPTION_NOT_ALIGNED, 5);
+        QUERY_WINDOW_CHECK(query_target_calculate_window(&qt), "valid natural-points window was rejected");
+        QUERY_WINDOW_CHECK(qt.window.after == 1000000005 && qt.window.before == 1000000600,
+                           "natural-points endpoints changed");
+        QUERY_WINDOW_CHECK(qt.window.points == 10 && qt.window.group == 12 &&
+                           qt.window.query_granularity == 5 && qt.window.resampling_group == 12,
+                           "natural-points layout changed");
+    }
+
+    {
+        QUERY_TARGET qt;
+        query_window_test_target_init(
+            &qt, -600, 0, 10, 0, RRDR_GROUPING_AVERAGE, RRDR_OPTION_NOT_ALIGNED, 1);
+        QUERY_WINDOW_CHECK(query_target_calculate_window(&qt), "valid relative window was rejected");
+        QUERY_WINDOW_CHECK(qt.window.relative, "relative window classification changed");
+    }
+
+    if(maximum > INT_MAX) {
+        const time_t large_resampling = (time_t)((uint64_t)INT_MAX + 1);
+        QUERY_TARGET qt;
+        query_window_test_target_init(
+            &qt, 1000000000, 1000000600, 2, large_resampling,
+            RRDR_GROUPING_AVERAGE, RRDR_OPTION_NOT_ALIGNED, 1);
+        QUERY_WINDOW_CHECK(query_target_calculate_window(&qt), "representable cadence above INT_MAX was rejected");
+        QUERY_WINDOW_CHECK(qt.window.group == (size_t)large_resampling,
+                           "cadence above INT_MAX was narrowed");
+        QUERY_WINDOW_CHECK(qt.window.after == (time_t)(1000000600LL - 4294967295LL),
+                           "large representable final window changed");
+
+        time_t timestamps[2] = { 0 };
+        RRDR r = {
+            .n = 2,
+            .t = timestamps,
+            .internal = { .qt = &qt },
+        };
+        rrd2rrdr_set_timestamps(&r);
+        QUERY_WINDOW_CHECK(r.view.update_every == large_resampling,
+                           "RRDR cadence above INT_MAX was narrowed");
+        QUERY_WINDOW_CHECK(timestamps[1] == qt.window.before,
+                           "large representable timestamps did not end at before");
+
+        if(sizeof(time_t) > sizeof(size_t)) {
+            const time_t duration_above_size_max = (time_t)(((uint64_t)INT_MAX + 1) * 5);
+            query_window_test_target_init(
+                &qt, 1000000000, 1000000600, 2, duration_above_size_max,
+                RRDR_GROUPING_AVERAGE,
+                RRDR_OPTION_NATURAL_POINTS | RRDR_OPTION_NOT_ALIGNED, 5);
+            QUERY_WINDOW_CHECK(query_target_calculate_window(&qt),
+                               "representable time64 duration above SIZE_MAX was rejected");
+            QUERY_WINDOW_CHECK(qt.window.group == (size_t)((uint64_t)INT_MAX + 1),
+                               "time64 duration above SIZE_MAX changed its group");
+        }
+    }
+
+    for(size_t i = 0; i < 2; i++) {
+        QUERY_TARGET qt;
+        query_window_test_target_init(
+            &qt, 1000000000, 1000000600, 2, maximum, RRDR_GROUPING_AVERAGE,
+            i ? RRDR_OPTION_NOT_ALIGNED : 0, 1);
+        QUERY_WINDOW_CHECK(!query_target_calculate_window(&qt),
+                           "unrepresentable maximum resampling window was accepted");
+    }
+
+    {
+        RRDSET *st = rrdset_create_localhost(
+            "netdata", "unittest-query-window-resampling", "unittest-query-window-resampling",
+            "netdata", NULL, "Unit Testing", "x", "unittest", NULL, 1, 1, RRDSET_TYPE_LINE);
+        rrddim_add(st, "d", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+        QUERY_TARGET_REQUEST request = {
+            .version = 1,
+            .st = st,
+            .after = 1000000000,
+            .before = 1000000600,
+            .points = 2,
+            .resampling_time = maximum,
+            .time_group_method = RRDR_GROUPING_AVERAGE,
+            .options = RRDR_OPTION_NOT_ALIGNED,
+            .query_source = QUERY_SOURCE_UNITTEST,
+            .priority = STORAGE_PRIORITY_SYNCHRONOUS,
+        };
+
+        QUERY_WINDOW_CHECK(!query_target_create(&request),
+                           "query target accepted an unrepresentable resampling window");
+
+        request.resampling_time = 60;
+        QUERY_TARGET *qt = query_target_create(&request);
+        QUERY_WINDOW_CHECK(qt, "query target pool did not recover after rejected window");
+        query_target_release(qt);
+    }
+
+#undef QUERY_WINDOW_CHECK
+
+    return errors;
+}
+
 int run_all_mockup_tests(void)
 {
     fprintf(stderr, "%s() running...\n", __FUNCTION__ );
@@ -1934,6 +2099,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(test_rrdr_relative_window_extreme_values())
+        return 1;
+
+    if(test_query_window_resampling_boundaries())
         return 1;
 
     if(!test_variable_renames())

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1806,6 +1806,31 @@ static int test_rrdr_relative_window_extreme_values(void) {
     RRDR_WINDOW_CHECK(!rrdr_relative_window_value_is_relative(maximum),
                       "maximum time_t was classified as relative");
 
+    struct {
+        time_t after;
+        time_t before;
+        bool absolute;
+        const char *name;
+    } query_wrapper_cases[] = {
+        { .after = -300, .before = -60, .absolute = false, .name = "relative" },
+        { .after = 0, .before = 0, .absolute = false, .name = "default" },
+        { .after = -300, .before = maximum, .absolute = false, .name = "mixed" },
+        { .after = maximum - 100, .before = maximum, .absolute = true, .name = "future absolute" },
+        { .after = minimum, .before = maximum, .absolute = true, .name = "extreme absolute" },
+    };
+
+    for(size_t i = 0; i < _countof(query_wrapper_cases); i++) {
+        time_t after = query_wrapper_cases[i].after;
+        time_t before = query_wrapper_cases[i].before;
+        bool absolute = rrdr_relative_window_to_absolute_query(&after, &before, NULL, true);
+
+        if(absolute != query_wrapper_cases[i].absolute) {
+            fprintf(stderr, "%s: query wrapper misclassified %s window as %s\n", __FUNCTION__,
+                    query_wrapper_cases[i].name, absolute ? "absolute" : "relative");
+            errors++;
+        }
+    }
+
     {
         const time_t now = 2000000000;
         time_t after = -300;

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1675,6 +1675,62 @@ static int test_rrddim_scale_minimum_magnitude(void) {
     return rc;
 }
 
+static int test_rrddim_collected_minimum_magnitude(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    RRD_DB_MODE old_default_rrd_memory_mode = default_rrd_memory_mode;
+    default_rrd_memory_mode = RRD_DB_MODE_ALLOC;
+
+    RRDSET *st = rrdset_create_localhost(
+        "netdata", "unittest-collected-min-magnitude", "unittest-collected-min-magnitude", "netdata", NULL,
+        "Unit Testing", "x", "unittest", NULL, 1,
+        nd_profile.update_every, RRDSET_TYPE_LINE);
+    RRDDIM *rd_int = rrddim_add(st, "int", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    RRDDIM *rd_float = rrddim_add(st, "float", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    memset(&rd_float->collector.collected, 0, sizeof(rd_float->collector.collected));
+    rrddim_option_set(rd_float, RRDDIM_OPTION_VALUE_FLOAT);
+
+    const struct {
+        collected_number value;
+        uint64_t expected_max;
+    } cases[] = {
+        { 0, 0 },
+        { 1, 1 },
+        { -1, 1 },
+        { LLONG_MAX, (uint64_t)LLONG_MAX },
+        { -LLONG_MAX, (uint64_t)LLONG_MAX },
+        { LLONG_MIN, UINT64_C(1) << 63 },
+        { 7, UINT64_C(1) << 63 },
+    };
+
+    int rc = 0;
+    for(size_t i = 0; i < _countof(cases); i++) {
+        rrddim_set_by_pointer(st, rd_int, cases[i].value);
+        uint64_t actual = rrddim_collected_max_as_uint64(rd_int);
+        if(actual != cases[i].expected_max) {
+            fprintf(stderr, "%s: case %zu maximum is %" PRIu64 ", expected %" PRIu64 "\n",
+                    __FUNCTION__, i, actual, cases[i].expected_max);
+            rc = 1;
+        }
+    }
+
+    if(rd_int->collector.collected.i.collected_value_max != INT64_MIN ||
+       rrddim_collected_max_as_double(rd_int) != (NETDATA_DOUBLE)(UINT64_C(1) << 63)) {
+        fprintf(stderr, "%s: integer 2^63 maximum representation was not preserved\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    rrddim_set_by_pointer(st, rd_float, LLONG_MIN);
+    rrddim_set_by_pointer(st, rd_float, 7);
+    if(rd_float->collector.collected.f.collected_value_max != (NETDATA_DOUBLE)(UINT64_C(1) << 63)) {
+        fprintf(stderr, "%s: float lane did not preserve the LLONG_MIN magnitude\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    default_rrd_memory_mode = old_default_rrd_memory_mode;
+    return rc;
+}
+
 static int test_rrddim_divisor_normalization(void) {
     fprintf(stderr, "%s() running...\n", __FUNCTION__);
 
@@ -2090,6 +2146,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(test_rrddim_scale_minimum_magnitude())
+        return 1;
+
+    if(test_rrddim_collected_minimum_magnitude())
         return 1;
 
     if(test_rrddim_divisor_normalization())

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1675,6 +1675,101 @@ static int test_rrdset_rejects_invalid_update_every(void) {
     return rc;
 }
 
+static int test_rrdr_relative_window_extreme_values(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    const time_t maximum = (time_t)(((uintmax_t)1 << (sizeof(time_t) * CHAR_BIT - 1)) - 1);
+    const time_t minimum = -maximum - 1;
+    int errors = 0;
+
+#define RRDR_WINDOW_CHECK(condition, message) do {                                  \
+        if(!(condition)) {                                                          \
+            fprintf(stderr, "%s: %s\n", __FUNCTION__, (message));                \
+            errors++;                                                               \
+        }                                                                            \
+    } while(0)
+
+    RRDR_WINDOW_CHECK(rrdr_relative_window_value_is_relative(-API_RELATIVE_TIME_MAX),
+                      "negative relative boundary was classified as absolute");
+    RRDR_WINDOW_CHECK(rrdr_relative_window_value_is_relative(API_RELATIVE_TIME_MAX),
+                      "positive relative boundary was classified as absolute");
+    RRDR_WINDOW_CHECK(!rrdr_relative_window_value_is_relative(-API_RELATIVE_TIME_MAX - 1),
+                      "value below the relative boundary was classified as relative");
+    RRDR_WINDOW_CHECK(!rrdr_relative_window_value_is_relative(API_RELATIVE_TIME_MAX + 1),
+                      "value above the relative boundary was classified as relative");
+    RRDR_WINDOW_CHECK(!rrdr_relative_window_value_is_relative(minimum),
+                      "minimum time_t was classified as relative");
+    RRDR_WINDOW_CHECK(!rrdr_relative_window_value_is_relative(maximum),
+                      "maximum time_t was classified as relative");
+
+    {
+        const time_t now = 2000000000;
+        time_t after = -300;
+        time_t before = -60;
+        bool relative = rrdr_relative_window_to_absolute(&after, &before, now);
+
+        RRDR_WINDOW_CHECK(relative, "ordinary relative window was classified as absolute");
+        RRDR_WINDOW_CHECK(before == now - 60, "ordinary relative before changed");
+        RRDR_WINDOW_CHECK(after == now - 60 - 300 + 1, "ordinary relative after changed");
+    }
+
+    {
+        time_t after = minimum + 100;
+        time_t before = maximum;
+        bool relative = rrdr_relative_window_to_absolute(&after, &before, maximum - 1);
+
+        RRDR_WINDOW_CHECK(!relative, "absolute future window was classified as relative");
+        RRDR_WINDOW_CHECK(before == maximum - 1, "future before was not shifted to now");
+        RRDR_WINDOW_CHECK(after == minimum + 99, "wide intermediate changed a representable shifted after");
+    }
+
+    {
+        time_t after = -3;
+        time_t before = minimum + 1;
+        bool relative = rrdr_relative_window_to_absolute(&after, &before, 123);
+
+        RRDR_WINDOW_CHECK(relative, "mixed relative window was classified as absolute");
+        RRDR_WINDOW_CHECK(before == minimum + 1, "absolute before changed without a future shift");
+        RRDR_WINDOW_CHECK(after == minimum, "unrepresentable relative after did not saturate to time_t minimum");
+    }
+
+    {
+        time_t after = maximum;
+        time_t before = minimum;
+        bool relative = rrdr_relative_window_to_absolute(&after, &before, 123);
+
+        RRDR_WINDOW_CHECK(!relative, "extreme absolute window was classified as relative");
+        RRDR_WINDOW_CHECK(before == 123, "extreme future before was not shifted to now");
+        RRDR_WINDOW_CHECK(after == minimum, "unrepresentable future shift did not saturate to time_t minimum");
+    }
+
+    {
+        time_t after = -1;
+        time_t before = -1;
+        bool relative = rrdr_relative_window_to_absolute(&after, &before, minimum);
+
+        RRDR_WINDOW_CHECK(relative, "minimum-now relative window was classified as absolute");
+        RRDR_WINDOW_CHECK(before == minimum, "minimum-now before did not saturate");
+        RRDR_WINDOW_CHECK(after == minimum, "minimum-now after did not saturate");
+    }
+
+    {
+        time_t after = minimum;
+        time_t before = maximum;
+        time_t now;
+        bool absolute = rrdr_relative_window_to_absolute_query(&after, &before, &now, false);
+        time_t minimum_query_time = now - (10 * 365 * 86400);
+
+        RRDR_WINDOW_CHECK(absolute, "query wrapper changed absolute classification");
+        RRDR_WINDOW_CHECK(before == now, "query wrapper changed shifted before");
+        RRDR_WINDOW_CHECK(after == minimum_query_time, "query wrapper did not apply its existing lower clamp");
+    }
+
+#undef RRDR_WINDOW_CHECK
+
+    return errors;
+}
+
 int run_all_mockup_tests(void)
 {
     fprintf(stderr, "%s() running...\n", __FUNCTION__ );
@@ -1701,6 +1796,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(test_rrdset_rejects_invalid_update_every())
+        return 1;
+
+    if(test_rrdr_relative_window_extreme_values())
         return 1;
 
     if(!test_variable_renames())

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1731,6 +1731,125 @@ static int test_rrddim_collected_minimum_magnitude(void) {
     return rc;
 }
 
+static int test_rrdset_homogeneity_multiplier_sign(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    RRD_DB_MODE old_default_rrd_memory_mode = default_rrd_memory_mode;
+    default_rrd_memory_mode = RRD_DB_MODE_ALLOC;
+
+    struct homogeneity_case {
+        const char *name;
+        int32_t multiplier_a;
+        int32_t multiplier_b;
+        int32_t divisor_a;
+        int32_t divisor_b;
+        RRD_ALGORITHM algorithm_a;
+        RRD_ALGORITHM algorithm_b;
+        bool heterogeneous;
+    } cases[] = {
+        { "negative-positive", -1, 1, 1, 1, RRD_ALGORITHM_ABSOLUTE, RRD_ALGORITHM_ABSOLUTE, false },
+        { "negative-negative", -1, -1, 1, 1, RRD_ALGORITHM_ABSOLUTE, RRD_ALGORITHM_ABSOLUTE, false },
+        { "positive-negative", 1, -1, 1, 1, RRD_ALGORITHM_ABSOLUTE, RRD_ALGORITHM_ABSOLUTE, false },
+        { "unequal-magnitude", -1, 2, 1, 1, RRD_ALGORITHM_ABSOLUTE, RRD_ALGORITHM_ABSOLUTE, true },
+        { "unequal-divisor", -1, 1, 1, 2, RRD_ALGORITHM_ABSOLUTE, RRD_ALGORITHM_ABSOLUTE, true },
+        { "unequal-algorithm", -1, 1, 1, 1, RRD_ALGORITHM_ABSOLUTE, RRD_ALGORITHM_INCREMENTAL, true },
+        { "minimum-magnitude", INT32_MIN, INT32_MIN, 1, 1, RRD_ALGORITHM_ABSOLUTE, RRD_ALGORITHM_ABSOLUTE, false },
+        { "minimum-unequal", INT32_MIN, 1, 1, 1, RRD_ALGORITHM_ABSOLUTE, RRD_ALGORITHM_ABSOLUTE, true },
+    };
+
+    int rc = 0;
+    for(size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        char id[RRD_ID_LENGTH_MAX + 1];
+        snprintfz(id, RRD_ID_LENGTH_MAX, "unittest-homogeneity-%s", cases[i].name);
+
+        RRDSET *st = rrdset_create_localhost(
+            "netdata", id, id, "netdata", NULL, "Unit Testing", "x", "unittest", NULL, 1,
+            nd_profile.update_every, RRDSET_TYPE_LINE);
+        rrddim_add(st, "a", NULL, cases[i].multiplier_a, cases[i].divisor_a, cases[i].algorithm_a);
+        rrddim_add(st, "b", NULL, cases[i].multiplier_b, cases[i].divisor_b, cases[i].algorithm_b);
+
+        bool immediate = rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS);
+        if(immediate != cases[i].heterogeneous) {
+            fprintf(stderr, "%s: %s insertion classified heterogeneous=%d, expected %d\n",
+                    __FUNCTION__, cases[i].name, immediate, cases[i].heterogeneous);
+            rc = 1;
+        }
+
+        rrdset_flag_set(st, RRDSET_FLAG_HOMOGENEOUS_CHECK);
+        rrdset_update_heterogeneous_flag(st);
+        bool deferred = rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS);
+        if(deferred != cases[i].heterogeneous ||
+           rrdset_flag_check(st, RRDSET_FLAG_HOMOGENEOUS_CHECK)) {
+            fprintf(stderr, "%s: %s deferred classified heterogeneous=%d, expected %d (check pending=%d)\n",
+                    __FUNCTION__, cases[i].name, deferred, cases[i].heterogeneous,
+                    rrdset_flag_check(st, RRDSET_FLAG_HOMOGENEOUS_CHECK));
+            rc = 1;
+        }
+    }
+
+    RRDSET *st_single = rrdset_create_localhost(
+        "netdata", "unittest-homogeneity-single", "unittest-homogeneity-single", "netdata", NULL,
+        "Unit Testing", "x", "unittest", NULL, 1, nd_profile.update_every, RRDSET_TYPE_LINE);
+    rrddim_add(st_single, "a", NULL, -1, 1, RRD_ALGORITHM_ABSOLUTE);
+    rrdset_flag_set(st_single, RRDSET_FLAG_HOMOGENEOUS_CHECK);
+    rrdset_update_heterogeneous_flag(st_single);
+    if(rrdset_flag_check(st_single, RRDSET_FLAG_HETEROGENEOUS) ||
+       rrdset_flag_check(st_single, RRDSET_FLAG_HOMOGENEOUS_CHECK)) {
+        fprintf(stderr, "%s: one negative dimension was not homogeneous after deferred recomputation\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    RRDSET *st_update = rrdset_create_localhost(
+        "netdata", "unittest-homogeneity-update", "unittest-homogeneity-update", "netdata", NULL,
+        "Unit Testing", "x", "unittest", NULL, 1, nd_profile.update_every, RRDSET_TYPE_LINE);
+    rrddim_add(st_update, "a", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    rrddim_add(st_update, "b", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+    RRDDIM *first = NULL, *second = NULL, *rd;
+    rrddim_foreach_read(rd, st_update) {
+        if(!first)
+            first = rd;
+        else if(!second)
+            second = rd;
+    }
+    rrddim_foreach_done(rd);
+
+    if(!first || !second) {
+        fprintf(stderr, "%s: failed to locate both metadata-update dimensions\n", __FUNCTION__);
+        rc = 1;
+    }
+    else {
+        rrddim_set_multiplier(st_update, first, -1);
+        if(!rrdset_flag_check(st_update, RRDSET_FLAG_HOMOGENEOUS_CHECK)) {
+            fprintf(stderr, "%s: multiplier metadata update did not request homogeneity recomputation\n", __FUNCTION__);
+            rc = 1;
+        }
+
+        rrdset_update_heterogeneous_flag(st_update);
+        if(rrdset_flag_check(st_update, RRDSET_FLAG_HETEROGENEOUS)) {
+            fprintf(stderr, "%s: equal magnitudes became heterogeneous after first-dimension sign update\n", __FUNCTION__);
+            rc = 1;
+        }
+
+        rrddim_set_multiplier(st_update, second, 2);
+        rrdset_update_heterogeneous_flag(st_update);
+        if(!rrdset_flag_check(st_update, RRDSET_FLAG_HETEROGENEOUS)) {
+            fprintf(stderr, "%s: unequal updated magnitudes were not heterogeneous\n", __FUNCTION__);
+            rc = 1;
+        }
+
+        rrddim_set_multiplier(st_update, second, -1);
+        rrdset_update_heterogeneous_flag(st_update);
+        if(rrdset_flag_check(st_update, RRDSET_FLAG_HETEROGENEOUS)) {
+            fprintf(stderr, "%s: restoring equal negative magnitudes did not clear heterogeneity\n", __FUNCTION__);
+            rc = 1;
+        }
+    }
+
+    default_rrd_memory_mode = old_default_rrd_memory_mode;
+    return rc;
+}
+
 static int test_rrddim_divisor_normalization(void) {
     fprintf(stderr, "%s() running...\n", __FUNCTION__);
 
@@ -2149,6 +2268,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(test_rrddim_collected_minimum_magnitude())
+        return 1;
+
+    if(test_rrdset_homogeneity_multiplier_sign())
         return 1;
 
     if(test_rrddim_divisor_normalization())

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -2219,6 +2219,7 @@ static int test_query_window_resampling_boundaries(void) {
             .before = 1000000600,
             .points = 2,
             .resampling_time = maximum,
+            .alerts = "unittest-alert:*",
             .time_group_method = RRDR_GROUPING_AVERAGE,
             .options = RRDR_OPTION_NOT_ALIGNED,
             .query_source = QUERY_SOURCE_UNITTEST,

--- a/src/database/contexts/api_v2_contexts.c
+++ b/src/database/contexts/api_v2_contexts.c
@@ -1309,7 +1309,6 @@ int rrdcontext_to_json_v2(BUFFER *wb, struct api_v2_contexts_request *req, CONTE
             .alerts.alert_name_pattern = string_to_simple_pattern(req->alerts.alert),
             .window = {
                     .enabled = false,
-                    .relative = false,
                     .after = req->after,
                     .before = req->before,
             },
@@ -1356,8 +1355,7 @@ int rrdcontext_to_json_v2(BUFFER *wb, struct api_v2_contexts_request *req, CONTE
     }
 
     if(req->after || req->before) {
-        ctl.window.relative = rrdr_relative_window_to_absolute_query(
-            &ctl.window.after, &ctl.window.before, &ctl.now, false);
+        rrdr_relative_window_to_absolute_query(&ctl.window.after, &ctl.window.before, &ctl.now, false);
 
         ctl.window.enabled = !(mode & CONTEXTS_V2_ALERT_TRANSITIONS);
     }

--- a/src/database/contexts/api_v2_contexts.h
+++ b/src/database/contexts/api_v2_contexts.h
@@ -82,7 +82,6 @@ struct rrdcontext_to_json_v2_data {
 
     struct {
         bool enabled;
-        bool relative;
         time_t after;
         time_t before;
     } window;

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -1266,9 +1266,9 @@ QUERY_TARGET *query_target_create(QUERY_TARGET_REQUEST *qtr) {
     if(query_target_has_percentage_of_group(qt))
         qt->window.options &= ~RRDR_OPTION_PERCENTAGE;
 
-    qt->internal.relative = rrdr_relative_window_to_absolute_query(&qt->window.after, &qt->window.before
-                                                                   , &qt->window.now, unittest_running
-                                                                  );
+    bool absolute_period_requested = rrdr_relative_window_to_absolute_query(
+        &qt->window.after, &qt->window.before, &qt->window.now, unittest_running);
+    qt->internal.relative = !absolute_period_requested;
 
     // prepare our local variables - we need these across all these functions
     QUERY_TARGET_LOCALS qtl = {

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -1358,7 +1358,10 @@ QUERY_TARGET *query_target_create(QUERY_TARGET_REQUEST *qtr) {
 
     // we need the available db retention for this call
     // so it has to be done last
-    query_target_calculate_window(qt);
+    if(unlikely(!query_target_calculate_window(qt))) {
+        query_target_release(qt);
+        return NULL;
+    }
 
     qt->timings.preprocessed_ut = now_monotonic_usec();
 

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -93,6 +93,9 @@ void query_target_release(QUERY_TARGET *qt) {
     simple_pattern_free(qt->instances.scope_labels_pattern);
     qt->instances.scope_labels_pattern = NULL;
 
+    simple_pattern_free(qt->instances.alerts_pattern);
+    qt->instances.alerts_pattern = NULL;
+
     pattern_array_free(qt->instances.labels_pa);
     qt->instances.labels_pa = NULL;
 

--- a/src/database/contexts/rrdcontext.h
+++ b/src/database/contexts/rrdcontext.h
@@ -350,7 +350,7 @@ typedef struct query_target {
 
     struct {
         time_t now;                         // the current timestamp, the absolute max for any query timestamp
-        bool relative;                      // true when the request made with relative timestamps, true if it was absolute
+        bool relative;                      // true when the request was made with relative timestamps
         bool aligned;
         time_t after;                       // the absolute timestamp this query is about
         time_t before;                      // the absolute timestamp this query is about

--- a/src/database/engine/dbengine-stresstest.c
+++ b/src/database/engine/dbengine-stresstest.c
@@ -45,8 +45,7 @@ static inline void rrddim_set_by_pointer_fake_time(RRDDIM *rd, collected_number 
 
     rd->collector.counter++;
 
-    collected_number v = (value >= 0) ? value : -value;
-    if(unlikely(v > rd->collector.collected.i.collected_value_max)) rrddim_set_collected_max_int(rd, v);
+    rrddim_update_collected_max_from_int(rd, value);
 }
 
 struct dbengine_chart_thread {

--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -87,8 +87,7 @@ static inline void rrddim_set_by_pointer_fake_time(RRDDIM *rd, collected_number 
 
     rd->collector.counter++;
 
-    collected_number v = (value >= 0) ? value : -value;
-    if(unlikely(v > rd->collector.collected.i.collected_value_max)) rrddim_set_collected_max_int(rd, v);
+    rrddim_update_collected_max_from_int(rd, value);
 }
 
 static RRDHOST *dbengine_rrdhost_find_or_create(char *name) {

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -297,8 +297,8 @@ static void rrddim_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
                 continue;
 
             if(td->algorithm != rd->algorithm
-               || ABS(td->multiplier) != ABS(rd->multiplier)
-               || ABS(td->divisor)    != ABS(rd->divisor)) {
+               || rrddim_scale_magnitude(td->multiplier) != rrddim_scale_magnitude(rd->multiplier)
+               || rrddim_scale_magnitude(td->divisor)    != rrddim_scale_magnitude(rd->divisor)) {
                 if(!rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS)) {
 #ifdef NETDATA_INTERNAL_CHECKS
                     netdata_log_info("Dimension '%s' added on chart '%s' of host '%s' is not homogeneous to other dimensions already "

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -682,13 +682,7 @@ collected_number rrddim_timed_set_by_pointer(RRDSET *st __maybe_unused, RRDDIM *
 //        *((int64_t *)Pvalue) = *((int64_t *)Pvalue) + 1;
 //    spinlock_unlock(&st->rrdhost->accounting.spinlock);
 
-    NETDATA_DOUBLE v = value >= 0 ? (NETDATA_DOUBLE)value : (NETDATA_DOUBLE)(-value);
-    if (unlikely(v > rrddim_collected_max_as_double(rd))) {
-        if(rrddim_is_float(rd))
-            rrddim_set_collected_max_float(rd, v);
-        else
-            rrddim_set_collected_max_int(rd, (int64_t)v);
-    }
+    rrddim_update_collected_max_from_int(rd, value);
     // For int dims return the last collected int; for float dims the integer return is meaningless, so return 0 to avoid truncation misuse.
     if(rrddim_is_float(rd))
         return 0;

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -30,6 +30,10 @@ struct rrddim_constructor {
 
 };
 
+static inline int32_t rrddim_normalize_divisor(int32_t divisor) {
+    return divisor ? divisor : 1;
+}
+
 // isolated call to appear
 // separate in statistics
 static void *rrddim_alloc_db(size_t entries) {
@@ -61,8 +65,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 
     rd->algorithm = ctr->algorithm;
     rd->multiplier = ctr->multiplier;
-    rd->divisor = ctr->divisor;
-    if(!rd->divisor) rd->divisor = 1;
+    rd->divisor = rrddim_normalize_divisor(ctr->divisor);
 
     rd->rrdset = st;
 
@@ -444,6 +447,8 @@ inline int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, int32_t multiplier) {
 }
 
 inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, int32_t divisor) {
+    divisor = rrddim_normalize_divisor(divisor);
+
     if(unlikely(rd->divisor == divisor))
         return 0;
 

--- a/src/database/rrddim.h
+++ b/src/database/rrddim.h
@@ -125,7 +125,7 @@ struct rrddim {
         union {
             struct {
                 collected_number collected_value;               // legacy int lane
-                collected_number collected_value_max;           // legacy int lane
+                collected_number collected_value_max;           // unsigned magnitude; INT64_MIN encodes 2^63
                 collected_number last_collected_value;          // legacy int lane
             } i;
             struct {
@@ -232,6 +232,23 @@ static inline void rrddim_set_last_collected_float(RRDDIM *rd, NETDATA_DOUBLE v)
     rd->collector.collected.f.last_collected_value = v;
 }
 
+static inline uint64_t rrddim_collected_max_as_uint64(RRDDIM *rd) {
+    return (uint64_t)rd->collector.collected.i.collected_value_max;
+}
+
+static inline void rrddim_update_collected_max_from_int(RRDDIM *rd, collected_number value) {
+    if(rrddim_is_float(rd)) {
+        NETDATA_DOUBLE magnitude = value >= 0 ? (NETDATA_DOUBLE)value : -(NETDATA_DOUBLE)value;
+        if(unlikely(magnitude > rd->collector.collected.f.collected_value_max))
+            rrddim_set_collected_max_float(rd, magnitude);
+    }
+    else {
+        uint64_t magnitude = value >= 0 ? (uint64_t)value : UINT64_C(0) - (uint64_t)value;
+        if(unlikely(magnitude > rrddim_collected_max_as_uint64(rd)))
+            rrddim_set_collected_max_int(rd, magnitude > INT64_MAX ? INT64_MIN : (int64_t)magnitude);
+    }
+}
+
 static inline NETDATA_DOUBLE rrddim_collected_as_double(RRDDIM *rd) {
     return rrddim_is_float(rd) ? rd->collector.collected.f.collected_value
                                : (NETDATA_DOUBLE)rd->collector.collected.i.collected_value;
@@ -244,7 +261,7 @@ static inline NETDATA_DOUBLE rrddim_last_collected_as_double(RRDDIM *rd) {
 
 static inline NETDATA_DOUBLE rrddim_collected_max_as_double(RRDDIM *rd) {
     return rrddim_is_float(rd) ? rd->collector.collected.f.collected_value_max
-                               : (NETDATA_DOUBLE)rd->collector.collected.i.collected_value_max;
+                               : (NETDATA_DOUBLE)rrddim_collected_max_as_uint64(rd);
 }
 
 static inline int64_t rrddim_last_collected_raw_int(RRDDIM *rd) {

--- a/src/database/rrddim.h
+++ b/src/database/rrddim.h
@@ -165,6 +165,10 @@ size_t rrddim_size(void);
 #define rrddim_foreach_done(rd) \
     dfe_done(rd)
 
+static inline int64_t rrddim_scale_magnitude(int32_t value) {
+    return value < 0 ? -(int64_t)value : (int64_t)value;
+}
+
 struct pluginsd_rrddim {
     RRDDIM_ACQUIRED *rda;
     RRDDIM *rd;

--- a/src/database/rrdset-collection.c
+++ b/src/database/rrdset-collection.c
@@ -790,7 +790,7 @@ void rrdset_timed_done(RRDSET *st, struct timeval now, bool pending_rrdset_next)
                 if(rrddim_is_int(rd)) {
                     uint64_t last = (uint64_t)rd->collector.collected.i.last_collected_value;
                     uint64_t new = (uint64_t)rd->collector.collected.i.collected_value;
-                    uint64_t max = (uint64_t)rd->collector.collected.i.collected_value_max;
+                    uint64_t max = rrddim_collected_max_as_uint64(rd);
 
                     // If the new is smaller than the old (overflow/reset), handle wrap
                     if(unlikely(last > new)) {

--- a/src/database/rrdset-collection.c
+++ b/src/database/rrdset-collection.c
@@ -818,7 +818,7 @@ void rrdset_timed_done(RRDSET *st, struct timeval now, bool pending_rrdset_next)
                     }
                     else {
                         rd->collector.calculated_value +=
-                            (NETDATA_DOUBLE)((int64_t)(rd->collector.collected.i.collected_value - rd->collector.collected.i.last_collected_value))
+                            (NETDATA_DOUBLE)((int64_t)(new - last))
                             * (NETDATA_DOUBLE) rd->multiplier
                             / (NETDATA_DOUBLE) rd->divisor;
                     }

--- a/src/database/rrdset.c
+++ b/src/database/rrdset.c
@@ -180,23 +180,24 @@ void rrdset_update_heterogeneous_flag(RRDSET *st) {
     bool init = false, is_heterogeneous = false;
     RRD_ALGORITHM algorithm;
     int32_t multiplier;
-    int32_t divisor;
+    int64_t divisor;
 
     rrddim_foreach_read(rd, st) {
         if(!init) {
             algorithm = rd->algorithm;
             multiplier = rd->multiplier;
-            divisor = ABS(rd->divisor);
+            divisor = rrddim_scale_magnitude(rd->divisor);
             init = true;
             continue;
         }
 
-        if(algorithm != rd->algorithm || multiplier != ABS(rd->multiplier) || divisor != ABS(rd->divisor)) {
+        if(algorithm != rd->algorithm || multiplier != rrddim_scale_magnitude(rd->multiplier) ||
+           divisor != rrddim_scale_magnitude(rd->divisor)) {
             if(!rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS)) {
                 #ifdef NETDATA_INTERNAL_CHECKS
                 netdata_log_info("Dimension '%s' added on chart '%s' of host '%s' is not homogeneous to other dimensions already present "
                      "(algorithm is '%s' vs '%s', multiplier is %d vs %d, "
-                     "divisor is %d vs %d).",
+                     "divisor is %d vs %" PRId64 ").",
                      rrddim_name(rd),
                      rrdset_name(st),
                      rrdhost_hostname(host),

--- a/src/database/rrdset.c
+++ b/src/database/rrdset.c
@@ -179,13 +179,13 @@ void rrdset_update_heterogeneous_flag(RRDSET *st) {
 
     bool init = false, is_heterogeneous = false;
     RRD_ALGORITHM algorithm;
-    int32_t multiplier;
+    int64_t multiplier;
     int64_t divisor;
 
     rrddim_foreach_read(rd, st) {
         if(!init) {
             algorithm = rd->algorithm;
-            multiplier = rd->multiplier;
+            multiplier = rrddim_scale_magnitude(rd->multiplier);
             divisor = rrddim_scale_magnitude(rd->divisor);
             init = true;
             continue;
@@ -196,7 +196,7 @@ void rrdset_update_heterogeneous_flag(RRDSET *st) {
             if(!rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS)) {
                 #ifdef NETDATA_INTERNAL_CHECKS
                 netdata_log_info("Dimension '%s' added on chart '%s' of host '%s' is not homogeneous to other dimensions already present "
-                     "(algorithm is '%s' vs '%s', multiplier is %d vs %d, "
+                     "(algorithm is '%s' vs '%s', multiplier is %d vs %" PRId64 ", "
                      "divisor is %d vs %" PRId64 ").",
                      rrddim_name(rd),
                      rrdset_name(st),

--- a/src/libnetdata/facets/logs_query_status.h
+++ b/src/libnetdata/facets/logs_query_status.h
@@ -776,6 +776,15 @@ static inline bool lqs_request_parse_and_validate(LOGS_QUERY_STATUS *lqs, BUFFER
        __builtin_sub_overflow(rq->before_s, (time_t)LQS_DEFAULT_QUERY_DURATION, &rq->after_s))
         rq->after_s = rq->before_s;
 
+    // extreme absolute inputs must not wrap the unsigned seconds->microseconds
+    // conversion below (pre-1970 seconds are unrepresentable here; usec_t caps
+    // the upper bound). saturate both endpoints into the representable range.
+    const usec_t lqs_max_time_s = (UINT64_MAX - (USEC_PER_SEC - 1)) / USEC_PER_SEC;
+    if(rq->after_s < 0) rq->after_s = 0;
+    if(rq->before_s < 0) rq->before_s = 0;
+    if((usec_t)rq->after_s > lqs_max_time_s) rq->after_s = (time_t)lqs_max_time_s;
+    if((usec_t)rq->before_s > lqs_max_time_s) rq->before_s = (time_t)lqs_max_time_s;
+
     rq->after_ut = rq->after_s * USEC_PER_SEC;
     rq->before_ut = (rq->before_s * USEC_PER_SEC) + USEC_PER_SEC - 1;
 

--- a/src/libnetdata/facets/logs_query_status.h
+++ b/src/libnetdata/facets/logs_query_status.h
@@ -772,8 +772,9 @@ static inline bool lqs_request_parse_and_validate(LOGS_QUERY_STATUS *lqs, BUFFER
         rq->before_s = tmp;
     }
 
-    if(rq->after_s == rq->before_s)
-        rq->after_s = rq->before_s - LQS_DEFAULT_QUERY_DURATION;
+    if(rq->after_s == rq->before_s &&
+       __builtin_sub_overflow(rq->before_s, (time_t)LQS_DEFAULT_QUERY_DURATION, &rq->after_s))
+        rq->after_s = rq->before_s;
 
     rq->after_ut = rq->after_s * USEC_PER_SEC;
     rq->before_ut = (rq->before_s * USEC_PER_SEC) + USEC_PER_SEC - 1;

--- a/src/libnetdata/libnetdata.c
+++ b/src/libnetdata/libnetdata.c
@@ -547,7 +547,7 @@ bool rrdr_relative_window_to_absolute_query(time_t *after, time_t *before, time_
     time_t before_requested = *before;
     time_t after_requested = *after;
 
-    int absolute_period_requested = rrdr_relative_window_to_absolute(&after_requested, &before_requested, now);
+    bool relative_period_requested = rrdr_relative_window_to_absolute(&after_requested, &before_requested, now);
 
     time_t absolute_minimum_time = rrdr_time_wide_to_time_t(rrdr_time_wide_subtract(
         rrdr_time_wide_from_time_t(now), rrdr_time_wide_from_time_t(10 * 365 * 86400)));
@@ -569,7 +569,7 @@ bool rrdr_relative_window_to_absolute_query(time_t *after, time_t *before, time_
     *before = before_requested;
     *after = after_requested;
 
-    return (absolute_period_requested != 1);
+    return !relative_period_requested;
 }
 
 

--- a/src/libnetdata/libnetdata.c
+++ b/src/libnetdata/libnetdata.c
@@ -442,13 +442,9 @@ static inline int rrdr_time_wide_compare(rrdr_time_wide_t a, rrdr_time_wide_t b)
 _Static_assert((time_t)-1 < (time_t)0, "time-window normalization requires signed time_t");
 _Static_assert(sizeof(time_t) <= sizeof(uintmax_t), "time_t must fit in uintmax_t");
 
-static inline time_t rrdr_time_t_maximum(void) {
-    return (time_t)(((uintmax_t)1 << (sizeof(time_t) * CHAR_BIT - 1)) - 1);
-}
-
 static inline time_t rrdr_time_wide_to_time_t(rrdr_time_wide_t value) {
-    const time_t maximum = rrdr_time_t_maximum();
-    const time_t minimum = -maximum - 1;
+    const time_t maximum = nd_time_t_max();
+    const time_t minimum = nd_time_t_min();
     const rrdr_time_wide_t maximum_wide = rrdr_time_wide_from_time_t(maximum);
     const rrdr_time_wide_t minimum_wide = rrdr_time_wide_from_time_t(minimum);
 

--- a/src/libnetdata/libnetdata.c
+++ b/src/libnetdata/libnetdata.c
@@ -361,39 +361,153 @@ int hash256_string(const unsigned char *string, size_t size, char *hash) {
 }
 
 
+#if defined(__SIZEOF_INT128__)
+typedef __int128 rrdr_time_wide_t;
+
+static inline rrdr_time_wide_t rrdr_time_wide_from_time_t(time_t value) {
+    return value;
+}
+
+static inline rrdr_time_wide_t rrdr_time_wide_add(rrdr_time_wide_t a, rrdr_time_wide_t b) {
+    return a + b;
+}
+
+static inline rrdr_time_wide_t rrdr_time_wide_subtract(rrdr_time_wide_t a, rrdr_time_wide_t b) {
+    return a - b;
+}
+
+static inline rrdr_time_wide_t rrdr_time_wide_negate(rrdr_time_wide_t value) {
+    return -value;
+}
+
+static inline int rrdr_time_wide_compare(rrdr_time_wide_t a, rrdr_time_wide_t b) {
+    return (a > b) - (a < b);
+}
+#else
+// Some 32-bit targets have 64-bit time_t but no native 128-bit integer.
+typedef struct {
+    uintmax_t high;
+    uintmax_t low;
+} rrdr_time_wide_t;
+
+static inline rrdr_time_wide_t rrdr_time_wide_from_time_t(time_t value) {
+    return (rrdr_time_wide_t){
+        .high = value < 0 ? UINTMAX_MAX : 0,
+        .low = (uintmax_t)value,
+    };
+}
+
+static inline rrdr_time_wide_t rrdr_time_wide_add(rrdr_time_wide_t a, rrdr_time_wide_t b) {
+    rrdr_time_wide_t result = {
+        .low = a.low + b.low,
+        .high = a.high + b.high,
+    };
+    result.high += result.low < a.low;
+    return result;
+}
+
+static inline rrdr_time_wide_t rrdr_time_wide_subtract(rrdr_time_wide_t a, rrdr_time_wide_t b) {
+    rrdr_time_wide_t result = {
+        .low = a.low - b.low,
+        .high = a.high - b.high,
+    };
+    result.high -= a.low < b.low;
+    return result;
+}
+
+static inline rrdr_time_wide_t rrdr_time_wide_negate(rrdr_time_wide_t value) {
+    rrdr_time_wide_t result = {
+        .low = ~value.low + 1,
+        .high = ~value.high,
+    };
+    result.high += result.low == 0;
+    return result;
+}
+
+static inline int rrdr_time_wide_compare(rrdr_time_wide_t a, rrdr_time_wide_t b) {
+    const uintmax_t sign_bit = (uintmax_t)1 << (sizeof(uintmax_t) * CHAR_BIT - 1);
+    bool a_is_negative = a.high & sign_bit;
+    bool b_is_negative = b.high & sign_bit;
+
+    if(a_is_negative != b_is_negative)
+        return a_is_negative ? -1 : 1;
+
+    if(a.high != b.high)
+        return a.high > b.high ? 1 : -1;
+
+    return (a.low > b.low) - (a.low < b.low);
+}
+#endif
+
+_Static_assert((time_t)-1 < (time_t)0, "time-window normalization requires signed time_t");
+_Static_assert(sizeof(time_t) <= sizeof(uintmax_t), "time_t must fit in uintmax_t");
+
+static inline time_t rrdr_time_t_maximum(void) {
+    return (time_t)(((uintmax_t)1 << (sizeof(time_t) * CHAR_BIT - 1)) - 1);
+}
+
+static inline time_t rrdr_time_wide_to_time_t(rrdr_time_wide_t value) {
+    const time_t maximum = rrdr_time_t_maximum();
+    const time_t minimum = -maximum - 1;
+    const rrdr_time_wide_t maximum_wide = rrdr_time_wide_from_time_t(maximum);
+    const rrdr_time_wide_t minimum_wide = rrdr_time_wide_from_time_t(minimum);
+
+    if(rrdr_time_wide_compare(value, maximum_wide) > 0)
+        return maximum;
+
+    if(rrdr_time_wide_compare(value, minimum_wide) < 0)
+        return minimum;
+
+#if defined(__SIZEOF_INT128__)
+    return (time_t)value;
+#else
+    if(rrdr_time_wide_compare(value, rrdr_time_wide_from_time_t(0)) >= 0)
+        return (time_t)value.low;
+
+    uintmax_t magnitude = ~value.low + 1;
+    if(magnitude == (uintmax_t)maximum + 1)
+        return minimum;
+
+    return -(time_t)magnitude;
+#endif
+}
+
 bool rrdr_relative_window_to_absolute(time_t *after, time_t *before, time_t now) {
     if(!now) now = now_realtime_sec();
 
     int absolute_period_requested = -1;
-    time_t before_requested = *before;
-    time_t after_requested = *after;
+    const rrdr_time_wide_t zero = rrdr_time_wide_from_time_t(0);
+    rrdr_time_wide_t before_requested = rrdr_time_wide_from_time_t(*before);
+    rrdr_time_wide_t after_requested = rrdr_time_wide_from_time_t(*after);
+    rrdr_time_wide_t now_requested = rrdr_time_wide_from_time_t(now);
 
     // allow relative for before (smaller than API_RELATIVE_TIME_MAX)
-    if(ABS(before_requested) <= API_RELATIVE_TIME_MAX) {
+    if(rrdr_relative_window_value_is_relative(*before)) {
         // if the user asked for a positive relative time,
         // flip it to a negative
-        if(before_requested > 0)
-            before_requested = -before_requested;
+        if(rrdr_time_wide_compare(before_requested, zero) > 0)
+            before_requested = rrdr_time_wide_negate(before_requested);
 
-        before_requested = now + before_requested;
+        before_requested = rrdr_time_wide_add(now_requested, before_requested);
         absolute_period_requested = 0;
     }
 
     // allow relative for after (smaller than API_RELATIVE_TIME_MAX)
-    if(ABS(after_requested) <= API_RELATIVE_TIME_MAX) {
-        if(after_requested > 0)
-            after_requested = -after_requested;
+    if(rrdr_relative_window_value_is_relative(*after)) {
+        if(rrdr_time_wide_compare(after_requested, zero) > 0)
+            after_requested = rrdr_time_wide_negate(after_requested);
 
         // if the user didn't give an after, use the number of points
         // to give a sane default
-        if(after_requested == 0)
-            after_requested = -600;
+        if(rrdr_time_wide_compare(after_requested, zero) == 0)
+            after_requested = rrdr_time_wide_from_time_t(-600);
 
         // since the query engine now returns inclusive timestamps
         // it is awkward to return 6 points when after=-5 is given
         // so for relative queries we add 1 second, to give
         // more predictable results to users.
-        after_requested = before_requested + after_requested + 1;
+        after_requested = rrdr_time_wide_add(
+            rrdr_time_wide_add(before_requested, after_requested), rrdr_time_wide_from_time_t(1));
         absolute_period_requested = 0;
     }
 
@@ -401,8 +515,8 @@ bool rrdr_relative_window_to_absolute(time_t *after, time_t *before, time_t now)
         absolute_period_requested = 1;
 
     // check if the parameters are flipped
-    if(after_requested > before_requested) {
-        long long t = before_requested;
+    if(rrdr_time_wide_compare(after_requested, before_requested) > 0) {
+        rrdr_time_wide_t t = before_requested;
         before_requested = after_requested;
         after_requested = t;
     }
@@ -410,21 +524,22 @@ bool rrdr_relative_window_to_absolute(time_t *after, time_t *before, time_t now)
     // if the query requests future data
     // shift the query back to be in the present time
     // (this may also happen because of the rules above)
-    if(before_requested > now) {
-        time_t delta = before_requested - now;
-        before_requested -= delta;
-        after_requested  -= delta;
+    if(rrdr_time_wide_compare(before_requested, now_requested) > 0) {
+        rrdr_time_wide_t delta = rrdr_time_wide_subtract(before_requested, now_requested);
+        before_requested = rrdr_time_wide_subtract(before_requested, delta);
+        after_requested = rrdr_time_wide_subtract(after_requested, delta);
     }
 
-    *before = before_requested;
-    *after = after_requested;
+    *before = rrdr_time_wide_to_time_t(before_requested);
+    *after = rrdr_time_wide_to_time_t(after_requested);
 
     return (absolute_period_requested != 1);
 }
 
-// Returns 1 if an absolute period was requested or 0 if it was a relative period
+// Returns true if both endpoints were absolute.
 bool rrdr_relative_window_to_absolute_query(time_t *after, time_t *before, time_t *now_ptr, bool unittest) {
-    time_t now = now_realtime_sec() - 1;
+    time_t now = rrdr_time_wide_to_time_t(rrdr_time_wide_subtract(
+        rrdr_time_wide_from_time_t(now_realtime_sec()), rrdr_time_wide_from_time_t(1)));
 
     if(now_ptr)
         *now_ptr = now;
@@ -434,8 +549,10 @@ bool rrdr_relative_window_to_absolute_query(time_t *after, time_t *before, time_
 
     int absolute_period_requested = rrdr_relative_window_to_absolute(&after_requested, &before_requested, now);
 
-    time_t absolute_minimum_time = now - (10 * 365 * 86400);
-    time_t absolute_maximum_time = now + (1 * 365 * 86400);
+    time_t absolute_minimum_time = rrdr_time_wide_to_time_t(rrdr_time_wide_subtract(
+        rrdr_time_wide_from_time_t(now), rrdr_time_wide_from_time_t(10 * 365 * 86400)));
+    time_t absolute_maximum_time = rrdr_time_wide_to_time_t(rrdr_time_wide_add(
+        rrdr_time_wide_from_time_t(now), rrdr_time_wide_from_time_t(1 * 365 * 86400)));
 
     if (after_requested < absolute_minimum_time && !unittest)
         after_requested = absolute_minimum_time;

--- a/src/libnetdata/libnetdata.h
+++ b/src/libnetdata/libnetdata.h
@@ -279,7 +279,10 @@ static inline bool rrdr_relative_window_value_is_relative(time_t value) {
     return value >= -API_RELATIVE_TIME_MAX && value <= API_RELATIVE_TIME_MAX;
 }
 
+// Returns true if either endpoint was relative.
 bool rrdr_relative_window_to_absolute(time_t *after, time_t *before, time_t now);
+
+// Returns true if both endpoints were absolute.
 bool rrdr_relative_window_to_absolute_query(time_t *after, time_t *before, time_t *now_ptr, bool unittest);
 
 int netdata_base64_decode(unsigned char *out, const unsigned char *in, int in_len);

--- a/src/libnetdata/libnetdata.h
+++ b/src/libnetdata/libnetdata.h
@@ -275,6 +275,10 @@ int hash256_string(const unsigned char *string, size_t size, char *hash);
 
 extern bool unittest_running;
 
+static inline bool rrdr_relative_window_value_is_relative(time_t value) {
+    return value >= -API_RELATIVE_TIME_MAX && value <= API_RELATIVE_TIME_MAX;
+}
+
 bool rrdr_relative_window_to_absolute(time_t *after, time_t *before, time_t now);
 bool rrdr_relative_window_to_absolute_query(time_t *after, time_t *before, time_t *now_ptr, bool unittest);
 

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -129,7 +129,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     STORAGE_POINT next1_point = STORAGE_POINT_UNSET;
 
     time_t now_start_time = after_wanted - ops->query_granularity;
-    time_t now_end_time   = after_wanted + ops->view_update_every - ops->query_granularity;
+    time_t now_end_time   = after_wanted + (ops->view_update_every - ops->query_granularity);
 
     size_t db_points_read_since_plan_switch = 0; (void)db_points_read_since_plan_switch;
     size_t query_is_finished_counter = 0;
@@ -443,8 +443,12 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             ops->group_points_non_zero = 0;
             ops->group_point = STORAGE_POINT_UNSET;
 
-            now_end_time += ops->view_update_every;
+            if(points_added < points_wanted)
+                now_end_time += ops->view_update_every;
         } while(now_end_time <= stop_time && points_added < points_wanted);
+
+        if(points_added >= points_wanted)
+            break;
 
         // the loop above increased "now" by ops->view_update_every,
         // but the main loop will increase it too,

--- a/src/web/api/queries/query-group-by.c
+++ b/src/web/api/queries/query-group-by.c
@@ -211,7 +211,7 @@ void rrd2rrdr_set_timestamps(RRDR *r) {
     internal_fatal(qt->window.points != r->n, "QUERY: mismatch to the number of points in qt and r");
 
     r->view.group = qt->window.group;
-    r->view.update_every = (int) query_view_update_every(qt);
+    r->view.update_every = query_view_update_every(qt);
     r->view.before = qt->window.before;
     r->view.after = qt->window.after;
 
@@ -229,12 +229,13 @@ void rrd2rrdr_set_timestamps(RRDR *r) {
     time_t query_granularity = (time_t)(r->view.update_every / r->view.group);
 
     size_t rrdr_line = 0;
-    time_t first_point_end_time = after_wanted + view_update_every - query_granularity;
+    time_t first_point_end_time = after_wanted + (view_update_every - query_granularity);
     time_t now_end_time = first_point_end_time;
 
     while (rrdr_line < points_wanted) {
         r->t[rrdr_line++] = now_end_time;
-        now_end_time += view_update_every;
+        if(rrdr_line < points_wanted)
+            now_end_time += view_update_every;
     }
 
     internal_fatal(r->t[0] != first_point_end_time, "QUERY: wrong first timestamp in the query");

--- a/src/web/api/queries/query-window.c
+++ b/src/web/api/queries/query-window.c
@@ -57,7 +57,8 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
 
     query_debug_log_init();
 
-    if (ABS(before_requested) <= API_RELATIVE_TIME_MAX || ABS(after_requested) <= API_RELATIVE_TIME_MAX) {
+    if (rrdr_relative_window_value_is_relative(before_requested) ||
+        rrdr_relative_window_value_is_relative(after_requested)) {
         relative_period_requested = true;
         natural_points = true;
         options |= RRDR_OPTION_NATURAL_POINTS;

--- a/src/web/api/queries/query-window.c
+++ b/src/web/api/queries/query-window.c
@@ -20,6 +20,24 @@
 #define query_debug_log_free() debug_dummy()
 #endif
 
+static inline bool query_window_uint_to_size(uintmax_t value, size_t *result) {
+    if(unlikely(value > SIZE_MAX))
+        return false;
+
+    *result = (size_t)value;
+    return true;
+}
+
+static inline bool query_window_uint_to_time(uintmax_t value, time_t *result) {
+    const uintmax_t maximum = ((uintmax_t)1 << (sizeof(time_t) * CHAR_BIT - 1)) - 1;
+
+    if(unlikely(value > maximum))
+        return false;
+
+    *result = (time_t)value;
+    return true;
+}
+
 bool query_target_calculate_window(QUERY_TARGET *qt) {
     if (unlikely(!qt)) return false;
 
@@ -164,12 +182,16 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
         query_debug_log(":auto natural points_wanted %zu", points_wanted);
     }
 
-    time_t duration = before_wanted - after_wanted;
+    time_t duration;
+    if(unlikely(__builtin_sub_overflow(before_wanted, after_wanted, &duration) || duration < 0))
+        goto failed;
 
     // if the resampling time is too big, extend the duration to the past
     if (unlikely(resampling_time_requested > duration)) {
-        after_wanted = before_wanted - resampling_time_requested;
-        duration = before_wanted - after_wanted;
+        if(unlikely(__builtin_sub_overflow(before_wanted, resampling_time_requested, &after_wanted)))
+            goto failed;
+
+        duration = resampling_time_requested;
         query_debug_log(":resampling after_wanted %ld", after_wanted);
     }
 
@@ -179,14 +201,25 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
     if (resampling_time_requested > query_granularity && duration % resampling_time_requested) {
         time_t delta = duration % resampling_time_requested;
         if (delta > resampling_time_requested / 10) {
-            after_wanted -= resampling_time_requested - delta;
-            duration = before_wanted - after_wanted;
+            time_t extension = resampling_time_requested - delta;
+            if(unlikely(__builtin_sub_overflow(after_wanted, extension, &after_wanted) ||
+                        __builtin_add_overflow(duration, extension, &duration)))
+                goto failed;
+
             query_debug_log(":resampling2 after_wanted %ld", after_wanted);
         }
     }
 
     // the available points of the query
-    size_t points_available = (duration + 1) / query_granularity;
+    uintmax_t duration_units = (uintmax_t)(duration / query_granularity);
+    if(duration % query_granularity == query_granularity - 1 &&
+       unlikely(__builtin_add_overflow(duration_units, (uintmax_t)1, &duration_units)))
+        goto failed;
+
+    size_t points_available;
+    if(unlikely(!query_window_uint_to_size(duration_units, &points_available)))
+        goto failed;
+
     if (unlikely(points_available <= 0)) points_available = 1;
     query_debug_log(":points_available %zu", points_available);
 
@@ -210,7 +243,13 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
 
     query_debug_log(":group %zu", group);
 
-    if (points_wanted * group * query_granularity < (size_t)duration) {
+    uintmax_t grouped_points;
+    bool grouped_points_fit = !__builtin_mul_overflow(
+        (uintmax_t)points_wanted, (uintmax_t)group, &grouped_points);
+    uintmax_t required_grouped_points = (uintmax_t)(duration / query_granularity) +
+                                        (duration % query_granularity != 0);
+
+    if (grouped_points_fit && grouped_points < required_grouped_points) {
         // the grouping we are going to do, is not enough
         // to cover the entire duration requested, so
         // we have to change the number of points, to make sure we will
@@ -233,9 +272,10 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
     size_t resampling_group = 1;
     if (unlikely(resampling_time_requested > query_granularity)) {
         // the points we should group to satisfy gtime
-        resampling_group = resampling_time_requested / query_granularity;
-        if (unlikely(resampling_time_requested % query_granularity))
-            resampling_group++;
+        uintmax_t resampling_group_wide = (uintmax_t)(resampling_time_requested / query_granularity) +
+                                         (resampling_time_requested % query_granularity != 0);
+        if(unlikely(!query_window_uint_to_size(resampling_group_wide, &resampling_group)))
+            goto failed;
 
         query_debug_log(":resampling group %zu", resampling_group);
 
@@ -245,35 +285,75 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
             query_debug_log(":group less res %zu", group);
         }
         if (unlikely(group % resampling_group)) {
-            group += resampling_group - (group % resampling_group); // make sure group is multiple of resampling_group
+            if(unlikely(__builtin_add_overflow(
+                    group, resampling_group - (group % resampling_group), &group)))
+                goto failed;
+
             query_debug_log(":group mod res %zu", group);
         }
+    }
 
+    uintmax_t view_update_every_wide;
+    time_t view_update_every;
+    if(unlikely(__builtin_mul_overflow(
+                    (uintmax_t)group, (uintmax_t)query_granularity, &view_update_every_wide) ||
+                !query_window_uint_to_time(view_update_every_wide, &view_update_every)))
+        goto failed;
+
+    if (unlikely(resampling_time_requested > query_granularity)) {
         // resampling_divisor = group / resampling_group;
-        resampling_divisor = (NETDATA_DOUBLE) (group * query_granularity) / (NETDATA_DOUBLE) resampling_time_requested;
+        resampling_divisor = (NETDATA_DOUBLE)view_update_every / (NETDATA_DOUBLE)resampling_time_requested;
         query_debug_log(":resampling divisor " NETDATA_DOUBLE_FORMAT, resampling_divisor);
     }
 
     // now that we have group, align the requested timeframe to fit it.
-    if (aligned && before_wanted % (group * query_granularity)) {
-        if (before_is_aligned_to_db_end)
-            before_wanted -= before_wanted % (time_t)(group * query_granularity);
-        else
-            before_wanted += (time_t)(group * query_granularity) - before_wanted % (time_t)(group * query_granularity);
+    // The product is proven representable above; retain the original conversions for negative timestamps.
+    bool alignment_needed = aligned && before_wanted % (group * query_granularity);
+    time_t alignment = aligned ? before_wanted % view_update_every : 0;
+    if (alignment_needed) {
+        if (before_is_aligned_to_db_end) {
+            if(unlikely(__builtin_sub_overflow(before_wanted, alignment, &before_wanted)))
+                goto failed;
+        }
+        else if(alignment > 0) {
+            time_t adjustment = view_update_every - alignment;
+            if(unlikely(__builtin_add_overflow(before_wanted, adjustment, &before_wanted)))
+                goto failed;
+        }
+        else {
+            if(unlikely(__builtin_add_overflow(before_wanted, view_update_every, &before_wanted) ||
+                        __builtin_sub_overflow(before_wanted, alignment, &before_wanted)))
+                goto failed;
+        }
+
         query_debug_log(":align before_wanted %ld", before_wanted);
     }
 
-    after_wanted = before_wanted - (time_t)(points_wanted * group * query_granularity) + query_granularity;
+    uintmax_t preceding_points_duration, final_duration;
+    if(unlikely(__builtin_mul_overflow(
+                    (uintmax_t)(points_wanted - 1), view_update_every_wide, &preceding_points_duration) ||
+                __builtin_add_overflow(preceding_points_duration,
+                                       view_update_every_wide - (uintmax_t)query_granularity,
+                                       &final_duration) ||
+                !query_window_uint_to_time(final_duration, &duration) ||
+                __builtin_sub_overflow(before_wanted, duration, &after_wanted)))
+        goto failed;
+
+    time_t query_start;
+    if(unlikely(__builtin_sub_overflow(after_wanted, query_granularity, &query_start)))
+        goto failed;
+    (void)query_start;
+
     query_debug_log(":final after_wanted %ld", after_wanted);
 
-    duration = before_wanted - after_wanted;
-    query_debug_log(":final duration %ld", duration + 1);
+    query_debug_log(":final duration %ju", final_duration);
 
     query_debug_log_fin();
 
-    internal_error(points_wanted != duration / (query_granularity * group) + 1,
+    uintmax_t calculated_points = final_duration / view_update_every_wide + 1;
+    internal_error((uintmax_t)points_wanted != calculated_points,
                    "QUERY: points_wanted %zu is not points %zu",
-                   points_wanted, (size_t)(duration / (query_granularity * group) + 1));
+                   points_wanted, (size_t)calculated_points);
 
     internal_error(group < resampling_group,
                    "QUERY: group %zu is less than the desired group points %zu",
@@ -301,4 +381,8 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
     qt->window.aligned = aligned;
 
     return true;
+
+failed:
+    query_debug_log_free();
+    return false;
 }

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -4,6 +4,14 @@
 #include "KolmogorovSmirnovDist.h"
 
 #define MAX_POINTS 10000
+
+static bool weights_points_exceed_max(size_t points, uint32_t shifts) {
+    if(unlikely(shifts >= sizeof(points) * CHAR_BIT))
+        return points != 0;
+
+    return points > ((size_t)MAX_POINTS >> shifts);
+}
+
 int metric_correlations_version = 1;
 
 typedef struct weights_stats {
@@ -2591,12 +2599,12 @@ int web_api_v12_weights(BUFFER *wb, QUERY_WEIGHTS_REQUEST *qwr) {
 
         // if the baseline size will not comply to MAX_POINTS
         // lower the window of the baseline
-        while(qwd.shifts && (qwr->points << qwd.shifts) > MAX_POINTS)
+        while(qwd.shifts && weights_points_exceed_max(qwr->points, qwd.shifts))
             qwd.shifts--;
 
         // if the baseline size still does not comply to MAX_POINTS
         // lower the resolution of the highlight and the baseline
-        while((qwr->points << qwd.shifts) > MAX_POINTS)
+        while(weights_points_exceed_max(qwr->points, qwd.shifts))
             qwr->points = qwr->points >> 1;
 
         if(qwr->points < 15) {
@@ -2853,6 +2861,44 @@ static int mc_unittest4(void) {
     return errors + ret;
 }
 
+static int weights_points_exceed_max_unittest(void) {
+    static const struct {
+        size_t points;
+        uint32_t shifts;
+        bool expected;
+        const char *description;
+    } cases[] = {
+        { 0, UINT32_MAX, false, "zero points at maximum shift" },
+        { MAX_POINTS - 1, 0, false, "below maximum" },
+        { MAX_POINTS, 0, false, "at maximum" },
+        { MAX_POINTS + 1, 0, true, "above maximum" },
+        { MAX_POINTS / 2, 1, false, "shifted value at maximum" },
+        { MAX_POINTS / 2 + 1, 1, true, "shifted value above maximum" },
+        { 1, 13, false, "one point below shift threshold" },
+        { 2, 13, true, "two points at shift threshold" },
+        { 1, 14, true, "one point above shift threshold" },
+        { (size_t)1 << (sizeof(size_t) * CHAR_BIT - 1), 1, true, "native-width wrap pair" },
+        { SIZE_MAX, 0, true, "maximum points" },
+        { SIZE_MAX, 29, true, "maximum points at source maximum shift" },
+        { 1, (uint32_t)(sizeof(size_t) * CHAR_BIT - 1), true, "one point at native maximum shift" },
+        { 1, (uint32_t)(sizeof(size_t) * CHAR_BIT), true, "one point at native width" },
+        { 1, UINT32_MAX, true, "one point at maximum shift" },
+    };
+
+    int errors = 0;
+    for(size_t i = 0; i < _countof(cases); i++) {
+        bool actual = weights_points_exceed_max(cases[i].points, cases[i].shifts);
+        int ret = actual == cases[i].expected ? 0 : 1;
+
+        fprintf(stderr, "%s weights point limit %s: points=%zu, shifts=%u, expected=%s, got=%s\n",
+                ret ? "FAILED" : "OK", cases[i].description, cases[i].points, cases[i].shifts,
+                cases[i].expected ? "true" : "false", actual ? "true" : "false");
+        errors += ret;
+    }
+
+    return errors;
+}
+
 int mc_unittest(void) {
     int errors = 0;
 
@@ -2860,6 +2906,7 @@ int mc_unittest(void) {
     errors += mc_unittest2();
     errors += mc_unittest3();
     errors += mc_unittest4();
+    errors += weights_points_exceed_max_unittest();
 
     return errors;
 }

--- a/src/web/mcp/mcp-params.c
+++ b/src/web/mcp/mcp-params.c
@@ -518,8 +518,8 @@ void mcp_params_validate_time_window(time_t *after, time_t *before, time_t now) 
     if (!now) now = now_realtime_sec();
     
     // Check if both are relative times (within 3 years of zero)
-    bool after_is_relative = (ABS(*after) <= API_RELATIVE_TIME_MAX);
-    bool before_is_relative = (ABS(*before) <= API_RELATIVE_TIME_MAX);
+    bool after_is_relative = rrdr_relative_window_value_is_relative(*after);
+    bool before_is_relative = rrdr_relative_window_value_is_relative(*before);
     
     if (after_is_relative && before_is_relative) {
         // Case 1: Both are relative and positive - assistant didn't read instructions
@@ -575,8 +575,8 @@ bool mcp_params_parse_time_window(
     }
     
     // Check if after is later than before (when both are absolute timestamps)
-    bool after_is_absolute = (ABS(*after) > API_RELATIVE_TIME_MAX);
-    bool before_is_absolute = (ABS(*before) > API_RELATIVE_TIME_MAX);
+    bool after_is_absolute = !rrdr_relative_window_value_is_relative(*after);
+    bool before_is_absolute = !rrdr_relative_window_value_is_relative(*before);
     
     if (after_is_absolute && before_is_absolute && *after >= *before) {
         if (error) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes time-window math and resampling overflow-safe on 32/64-bit platforms, fixes rrddim scaling and homogeneity, corrects cache classification, and adds focused tests. Also closes a weights point-limit overflow, frees a leaked alerts filter pattern, and fixes a logs seconds→microseconds overflow.

- **Bug Fixes**
  - Time windows: overflow-safe relative/absolute math with saturation; consistent relative detection; future times shift to now.
  - Resampling: checked math for duration/grouping/alignment; reject unrepresentable windows; no extra final timestamp add.
  - Caching: fix inversion—relative/default/mixed are no-store; all-absolute are public with TTL.
  - RRDDIM/RRDSET metadata: safe INT32_MIN magnitude via rrddim_scale_magnitude; classify homogeneity by magnitude; zero divisors normalize to 1 on create/update.
  - Collected max: exact uint64 magnitude; preserve 2^63 as INT64_MIN; add helpers and use in engine/int paths.
  - Incremental deltas: compute as uint64 to avoid signed-boundary overflow.
  - API contexts/MCP: remove unused relative flag; use shared relative checks.
  - Logs: safe equal-window fallback near time_t minimum; prevent seconds→microseconds conversion overflow by saturating bounds.
  - Weights: prevent MAX_POINTS bypass from shift overflow; add boundary tests.
  - Queries: free compiled alerts_pattern on release to fix a memory leak.
  - Tests: cover extreme windows, resampling boundaries, INT32_MIN magnitudes, divisor normalization, homogeneity, and collected-max behavior.

<sup>Written for commit de332e83f78d969287dfb1a2eab653b5b289b6b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

