### PR TITLE
Netdata fixes part 79

### DIFF
--- a/src/web/api/v3/api_v3_settings.c
+++ b/src/web/api/v3/api_v3_settings.c
@@ -115,6 +115,78 @@ static inline size_t settings_get_version(const char *path, bool have_lock) {
     return settings_extract_json_version(buffer_tostring(wb));
 }
 
+static FILE *settings_open_tmp_file(const char *filename) {
+    struct stat before;
+    bool reuse = lstat(filename, &before) == 0;
+    if(reuse && !S_ISREG(before.st_mode)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if(!reuse && errno != ENOENT)
+        return NULL;
+
+    int flags = O_WRONLY | O_CLOEXEC | O_NONBLOCK;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    if(!reuse)
+        flags |= O_CREAT | O_EXCL;
+
+    int fd = open(filename, flags, 0666);
+    if(fd == -1)
+        return NULL;
+
+    struct stat after;
+    if(fstat(fd, &after) != 0) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if(!S_ISREG(after.st_mode) ||
+       (reuse && (before.st_dev != after.st_dev || before.st_ino != after.st_ino))) {
+        close(fd);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if(reuse && ftruncate(fd, 0) != 0) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    FILE *fp = fdopen(fd, "w");
+    if(!fp) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+    }
+
+    return fp;
+}
+
+static bool settings_write_tmp_file(FILE *fp, const char *data, size_t len) {
+    size_t written = fwrite(data, 1, len, fp);
+    int saved_errno = errno;
+    bool failed = ferror(fp) || written != len;
+
+    if(fclose(fp) != 0) {
+        if(!failed)
+            saved_errno = errno;
+
+        failed = true;
+    }
+
+    if(failed)
+        errno = saved_errno;
+
+    return !failed;
+}
+
 static inline int settings_put(struct web_client *w, char *file) {
     rw_spinlock_write_lock(&settings_spinlock);
 
@@ -169,7 +241,7 @@ static inline int settings_put(struct web_client *w, char *file) {
     settings_filename(tmp_filename, file, "new");
 
     // Save the updated JSON string to a file
-    FILE *fp = fopen(tmp_filename, "w");
+    FILE *fp = settings_open_tmp_file(tmp_filename);
     if (fp == NULL) {
         rw_spinlock_write_unlock(&settings_spinlock);
         nd_log(NDLS_DAEMON, NDLP_ERR, "cannot open/create settings file '%s'", tmp_filename);
@@ -178,13 +250,8 @@ static inline int settings_put(struct web_client *w, char *file) {
             "Cannot create payload file",
             HTTP_RESP_INTERNAL_SERVER_ERROR);
     }
-    size_t len = strlen(updated_json_str);
-    size_t written = fwrite(updated_json_str, 1, len, fp);
-    int saved_errno = errno;
-    if(fclose(fp) != 0 || written != len) {
-        if(written == len)
-            saved_errno = errno;
-
+    if(!settings_write_tmp_file(fp, updated_json_str, strlen(updated_json_str))) {
+        int saved_errno = errno;
         unlink(tmp_filename);
         rw_spinlock_write_unlock(&settings_spinlock);
         errno = saved_errno;


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the API v3 Settings PUT path to safely handle temp files and detect all buffered write errors. Prevents unsafe publication and returns HTTP 500 on any write/close failure.

- **Bug Fixes**
  - Safer `.new` temp handling: reject non-regular files; open with `O_CREAT|O_EXCL` (on create), `O_NOFOLLOW` (when available), `O_NONBLOCK`, `O_CLOEXEC`; verify with `lstat`/`fstat`; reuse only the same regular inode; truncate only after validation.
  - Robust write path: use a helper that checks short writes, samples `ferror` before `fclose`, checks `fclose`, and preserves the first write-side `errno`; on failure remove `.new`, skip rename, keep existing settings, and return HTTP 500.

<sup>Written for commit 88102c72f53aba858ec01d63239ffe7ee522729e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

