### PR TITLE
fix cgroup-name timeout environment race

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-name-config.c
+++ b/src/collectors/cgroups.plugin/cgroup-name-config.c
@@ -2,8 +2,20 @@
 
 #include "cgroup-name-config.h"
 
+#include <limits.h>
+#include <stdint.h>
 #include <string.h>
 
 bool cgroup_name_is_legacy_default_helper(const char *configured, const char *legacy_default) {
     return configured && legacy_default && strcmp(configured, legacy_default) == 0;
+}
+
+int cgroup_name_timeout_ms_from_seconds(time_t timeout_s) {
+    if (timeout_s <= 0)
+        return 0;
+
+    if ((uintmax_t)timeout_s > (uintmax_t)INT_MAX / 1000)
+        return INT_MAX;
+
+    return (int)((uintmax_t)timeout_s * 1000);
 }

--- a/src/collectors/cgroups.plugin/cgroup-name-config.h
+++ b/src/collectors/cgroups.plugin/cgroup-name-config.h
@@ -4,7 +4,9 @@
 #define NETDATA_CGROUP_NAME_CONFIG_H
 
 #include <stdbool.h>
+#include <time.h>
 
 bool cgroup_name_is_legacy_default_helper(const char *configured, const char *legacy_default);
+int cgroup_name_timeout_ms_from_seconds(time_t timeout_s);
 
 #endif // NETDATA_CGROUP_NAME_CONFIG_H

--- a/src/collectors/cgroups.plugin/cgroup-name/FLOW.md
+++ b/src/collectors/cgroups.plugin/cgroup-name/FLOW.md
@@ -65,7 +65,9 @@ equal to the installed legacy `plugins.d/cgroup-name.sh` path is migrated to
 the new binary; all custom helper paths remain unchanged.
 
 `NETDATA_CGROUP_NAME_TIMEOUT_MS` carries the operator budget X (from the
-`[plugin:cgroups]` `cgroup-name timeout` option, default 120s). The helper sets
+`[plugin:cgroups]` `cgroup-name timeout` option, default 120s). The Agent exports
+it from the cgroups static-thread initializer, before worker threads start; it
+must not mutate the process environment from the cgroups worker. The helper sets
 `expires_at = start + X` and shares one deadline `context.Context` across every
 external command and HTTP call, so each call gets the remaining budget and
 calls after expiry are not attempted. HTTP response bodies are capped (16 MiB

--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -243,6 +243,18 @@ static void cgroup_find_v1_mount(struct mountinfo *root, char *filename,
     *base = strdupz(filename);
 }
 
+void cgroups_init(void) {
+    time_t timeout_s = inicfg_get_duration_seconds(
+        &netdata_config, "plugin:cgroups", "cgroup-name timeout", 120);
+    cgroup_name_timeout_ms = cgroup_name_timeout_ms_from_seconds(timeout_s);
+
+    char timeout_env[32];
+    snprintfz(timeout_env, sizeof(timeout_env), "%d", cgroup_name_timeout_ms);
+
+    // The process environment must be finalized before worker threads start.
+    nd_setenv("NETDATA_CGROUP_NAME_TIMEOUT_MS", timeout_env, 1);
+}
+
 void read_cgroup_plugin_configuration() {
     system_page_size = sysconf(_SC_PAGESIZE);
 
@@ -395,26 +407,6 @@ void read_cgroup_plugin_configuration() {
         cgroups_rename_script = NULL;
         collector_error("CGROUP: cgroup-name helper '%s' is not executable; cgroup renaming is disabled.",
                        configured_cgroup_name ? configured_cgroup_name : "");
-    }
-
-    // single operator knob for the whole cgroup-name invocation: the helper
-    // receives it and self-terminates by then; discovery waits this long plus a
-    // grace period before killing the helper. 0 means unbounded (legacy).
-    time_t cgroup_name_timeout_s = inicfg_get_duration_seconds(
-        &netdata_config, "plugin:cgroups", "cgroup-name timeout", 120);
-    if (cgroup_name_timeout_s <= 0)
-        cgroup_name_timeout_ms = 0;
-    else if ((uintmax_t)cgroup_name_timeout_s > (uintmax_t)INT_MAX / MSEC_PER_SEC)
-        cgroup_name_timeout_ms = INT_MAX;
-    else
-        cgroup_name_timeout_ms = (int)((uintmax_t)cgroup_name_timeout_s * MSEC_PER_SEC);
-
-    // the helper inherits this and self-terminates by then; discovery enforces
-    // the same budget plus a grace period on the parent side
-    {
-        char timeout_env[32];
-        snprintfz(timeout_env, sizeof(timeout_env), "%d", cgroup_name_timeout_ms);
-        nd_setenv("NETDATA_CGROUP_NAME_TIMEOUT_MS", timeout_env, 1);
     }
 
     snprintfz(filename, FILENAME_MAX, "%s/cgroup-network", netdata_configured_primary_plugins_dir);

--- a/src/collectors/cgroups.plugin/tests/test_cgroup_name_config.c
+++ b/src/collectors/cgroups.plugin/tests/test_cgroup_name_config.c
@@ -2,7 +2,44 @@
 
 #include "../cgroup-name-config.h"
 
+#include <limits.h>
 #include <stdio.h>
+
+static int test_timeout_conversion(void)
+{
+    struct timeout_case {
+        const char *name;
+        time_t seconds;
+        int expected_ms;
+    };
+    static const struct timeout_case cases[] = {
+        { .name = "negative timeout is unbounded", .seconds = -1, .expected_ms = 0 },
+        { .name = "zero timeout is unbounded", .seconds = 0, .expected_ms = 0 },
+        { .name = "one second", .seconds = 1, .expected_ms = 1000 },
+        { .name = "default timeout", .seconds = 120, .expected_ms = 120000 },
+        {
+            .name = "largest whole-second timeout",
+            .seconds = INT_MAX / 1000,
+            .expected_ms = (INT_MAX / 1000) * 1000,
+        },
+        {
+            .name = "overflow clamps to int max",
+            .seconds = (time_t)(INT_MAX / 1000) + 1,
+            .expected_ms = INT_MAX,
+        },
+    };
+
+    int failures = 0;
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        int actual = cgroup_name_timeout_ms_from_seconds(cases[i].seconds);
+        if (actual != cases[i].expected_ms) {
+            fprintf(stderr, "%s: expected %d, got %d\n", cases[i].name, cases[i].expected_ms, actual);
+            failures++;
+        }
+    }
+
+    return failures;
+}
 
 int main(void)
 {
@@ -60,6 +97,8 @@ int main(void)
             failures++;
         }
     }
+
+    failures += test_timeout_conversion();
 
     return failures ? 1 : 0;
 }

--- a/src/daemon/static_threads_linux.c
+++ b/src/daemon/static_threads_linux.c
@@ -3,6 +3,7 @@
 #include "common.h"
 
 void cgroups_main(void *ptr);
+void cgroups_init(void);
 void proc_main(void *ptr);
 void diskspace_main(void *ptr);
 void tc_main(void *ptr);
@@ -42,7 +43,7 @@ static const struct netdata_static_thread static_threads_linux[] = {
         .config_name = "cgroups",
         .enabled = 1,
         .thread = NULL,
-        .init_routine = NULL,
+        .init_routine = cgroups_init,
         .start_routine = cgroups_main
     },
     {


### PR DESCRIPTION
## Summary

- initialize the cgroup-name timeout before static worker threads start
- remove the cgroups worker-time mutation of the process environment
- preserve the existing helper environment and positional-argument contracts
- test timeout conversion boundaries and document the startup-order requirement

## Root cause

PR #22685 exported NETDATA_CGROUP_NAME_TIMEOUT_MS from read_cgroup_plugin_configuration(), which runs in the cgroups worker. At the same time, spawn-server requests serialize the process-global environ vector. libc may reallocate and free that vector during setenv(), so the concurrent traversal can use freed memory and crash in argv_encode().

The cgroups static-thread init_routine runs after netdata.conf is loaded but before static workers are created. Moving only the timeout parsing and export there preserves current behavior while ensuring the environment mutation is single-threaded. The rest of the cgroups configuration remains in its worker because it depends on localhost initialization.

Regressed by #22685.

## Validation

- cgroup-name-config-test
- cgroup-orchestrator-test
- cgroups-plugin-labels-test
- go test ./... in the cgroup-name helper
- complete CMake netdata target build and link
- linked netdata -V smoke test
- git diff --check
- sensitive-data and local SOW audits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalize the cgroup-name timeout before worker threads start to fix a process environment race that could crash spawn-server during concurrent env serialization. Existing helper behavior and arguments are unchanged.

- **Bug Fixes**
  - Parse and export `NETDATA_CGROUP_NAME_TIMEOUT_MS` in `cgroups_init()` so `setenv()` runs single-threaded.
  - Remove environment mutation from the cgroups worker; keep the rest of its config logic unchanged.
  - Add `cgroup_name_timeout_ms_from_seconds()` with overflow clamping and boundary tests.
  - Document the startup-order requirement in `FLOW.md`.

<sup>Written for commit c449f92b0f1e7ca46af331d31b9bcd193babd8a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

