### PR TITLE
fix max/min grouping for negative values

### DIFF
--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -2,6 +2,8 @@
 
 #include "common.h"
 #include "web/api/formatters/rrd2json.h"
+#include "web/api/queries/max/max.h"
+#include "web/api/queries/min/min.h"
 #include "database/contexts/rrdcontext-internal.h"
 #ifdef OS_WINDOWS
 #include "win_system-info.h"
@@ -1584,6 +1586,31 @@ static int test_incremental_sum_lookup_respects_update_every(void) {
     return rc;
 }
 
+static int test_min_max_grouping_with_negative_values(void) {
+    static const NETDATA_DOUBLE values[] = { 1, 1, 1, -2 };
+    struct tg_max max_state = { 0 };
+    struct tg_min min_state = { 0 };
+    RRDR r = { 0 };
+
+    for(size_t i = 0; i < _countof(values); i++) {
+        r.time_grouping.data = &max_state;
+        tg_max_add(&r, values[i]);
+
+        r.time_grouping.data = &min_state;
+        tg_min_add(&r, values[i]);
+    }
+
+    if(max_state.max != 1 || min_state.min != -2) {
+        fprintf(stderr,
+                "min/max grouping with negative values failed: expected max 1 and min -2, got max "
+                NETDATA_DOUBLE_FORMAT " and min " NETDATA_DOUBLE_FORMAT "\n",
+                max_state.max, min_state.min);
+        return 1;
+    }
+
+    return 0;
+}
+
 static int test_rrdmetric_algorithm_follows_rrddim(void) {
     fprintf(stderr, "%s() running...\n", __FUNCTION__);
 
@@ -1695,6 +1722,9 @@ int run_all_mockup_tests(void)
         return 1;
 #endif
     if(test_incremental_sum_lookup_respects_update_every())
+        return 1;
+
+    if(test_min_max_grouping_with_negative_values())
         return 1;
 
     if(test_rrdmetric_algorithm_follows_rrddim())

--- a/src/web/api/queries/max/max.h
+++ b/src/web/api/queries/max/max.h
@@ -31,7 +31,7 @@ static inline void tg_max_free(RRDR *r) {
 static inline void tg_max_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_max *g = (struct tg_max *)r->time_grouping.data;
 
-    if(!g->count || fabsndd(value) > fabsndd(g->max)) {
+    if(!g->count || value > g->max) {
         g->max = value;
         g->count++;
     }

--- a/src/web/api/queries/min/min.h
+++ b/src/web/api/queries/min/min.h
@@ -31,7 +31,7 @@ static inline void tg_min_free(RRDR *r) {
 static inline void tg_min_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_min *g = (struct tg_min *)r->time_grouping.data;
 
-    if(!g->count || fabsndd(value) < fabsndd(g->min)) {
+    if(!g->count || value < g->min) {
         g->min = value;
         g->count++;
     }


### PR DESCRIPTION
##### Summary

`tg_max_add()` and `tg_min_add()` incorrectly handle negative values. Both functions compare candidate values using `fabsndd()`, so `group=max` and `group=min` order samples by absolute magnitude instead of their signed arithmetic value.

For `{1, 1, 1, -2}`, `group=max` incorrectly returns `-2` and `group=min` incorrectly returns `1`; the expected results are `1` and `-2`.

This change compares signed values directly, matching the documented sample maximum/minimum behavior and the signed MIN/MAX aggregation used elsewhere in the query engine. It also adds a regression test for negative inputs.

The magnitude-based behavior of `group=extremes` remains unchanged because it is intentional.

##### Test Plan

- Added `test_min_max_grouping_with_negative_values()` to `src/daemon/unit_test.c`, which is exercised by `netdata -W unittest`.
- Confirmed that the original implementation returns `max = -2` and `min = 1` for `{1, 1, 1, -2}`.
- Confirmed that the corrected implementation returns `max = 1` and `min = -2`.
- Verified mixed-sign, all-negative, and all-positive cases with a focused Clang test driver.
- Ran `git diff --check`.
- The full `netdata -W unittest` suite was not run locally because CMake is not available in the local environment. The repository CI workflow will exercise the added regression test.

##### Additional Information

This is a user-visible behavior change for queries and alert lookups using `max` or `min` on metrics containing negative values. Positive-only inputs are unchanged.

Users who need magnitude-based selection can use `group=extremes`. `options=absolute` remains available when values should be converted to their absolute magnitude before grouping.

<details>
<summary>For users: How does this change affect me?</summary>

API queries, badges, dashboards, and alerts using `group=max`, `group=min`, `lookup: max`, or `lookup: min` will now return the true arithmetic maximum or minimum when the underlying metric contains negative values.

Previously, these operations could select values by absolute magnitude. For example, among `{1, 1, 1, -2}`, `max` returned `-2` and `min` returned `1`. They will now correctly return `1` and `-2`.

Positive-only metrics are unaffected. Use `group=extremes` when selecting the signed value with the greatest absolute magnitude is intentional.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix max/min time-grouping to compare signed values instead of absolute magnitude, so negative inputs are handled correctly. Queries and alerts using `group=max`/`group=min` now return the true arithmetic maximum/minimum; use `group=extremes` for magnitude-based selection.

- **Bug Fixes**
  - Replace `fabsndd()` comparisons with direct signed comparisons in `src/web/api/queries/max/max.h` and `src/web/api/queries/min/min.h`.
  - Add regression test `test_min_max_grouping_with_negative_values()` to verify `{1, 1, 1, -2}` yields `max = 1` and `min = -2`.

<sup>Written for commit 44a92b68cce1bb5c5e7a5772102c160317f15af7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

