### PR TITLE
Fix potential buffer overread in Windows timezone mapping

### DIFF
--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -790,10 +790,13 @@ static int map_windows_tz_to_iana(char *out, char *win_id, char *geo_name) {
 
         strncpyz(out, s, strlen(s));
 
-        //Escape:" Region="
-        char *cmpregion = end+ 10;
-        if (!strncmp(cmpregion, geo_name, 2))
-            break;
+        //Escape:" Region=
+        char *region = strstr(end + 1, "Region=\"");
+        if (region) {
+            char *cmpregion = region + 8; // skip past "Region="
+            if (!strncmp(cmpregion, geo_name, 2))
+                break;
+        }
 
         copied = 1;
     }


### PR DESCRIPTION
##### Summary
map_windows_tz_to_iana() in analytics.c parses Windows' TimezoneMapping.xml to map Windows timezone IDs to IANA names. It uses a hardcoded offset end + 10 to locate the " Region=" attribute after finding the closing quote of the TZID value. If the XML line is malformed or truncated (e.g., missing the Region attribute), the pointer arithmetic lands past valid data, causing a buffer overread.
Replace the hardcoded offset with strstr(end + 1, "Region=\"") so that missing or misplaced attributes are safely skipped.

##### Test Plan

Verified logic equivalence for well-formed input: strstr finds "Region=\"" at the same position as the old end + 10 assumed, and region + 8 (skipping "Region=") points to the same data. For malformed input (missing Region attribute), the old code would overread beyond the buffer; the new code receives NULL from strstr and safely continues to the next line.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a file descriptor leak in the `phpfpm` collector and a buffer overread risk in Windows timezone mapping. Improves stability during long runtimes and with malformed XML.

- **Bug Fixes**
  - `phpfpm`: Close response bodies in both socket and TCP `getStatus()` paths to stop one FD leak per collection cycle.
  - Analytics (Windows): Use a safe search for the Region attribute (`strstr` for `Region="`) instead of a fixed offset to avoid reading past the buffer when the attribute is missing.

<sup>Written for commit eb5f03600776510cac3c6dd08487cc8acb425c72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

