### PR TITLE
Fix phpfpm response body leak on every collection cycle

### DIFF
--- a/src/go/plugin/go.d/collector/phpfpm/client.go
+++ b/src/go/plugin/go.d/collector/phpfpm/client.go
@@ -131,6 +131,7 @@ func (c *socketClient) getStatus() (*status, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error on getting data from socket '%s': %v", c.socket, err)
 	}
+	defer resp.Body.Close()
 
 	content, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -186,6 +187,7 @@ func (c *tcpClient) getStatus() (*status, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error on getting data from address '%s': %v", c.address, err)
 	}
+	defer resp.Body.Close()
 
 	content, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
##### Summary
unixSocketClient.getStatus() and tcpClient.getStatus() call fcgiclient.Get() which returns an http.Response, then read resp.Body via io.ReadAll but never close it. Each collection cycle leaks one file descriptor. Over time this exhausts FDs, causing subsequent connections to fail. Add defer resp.Body.Close() immediately after obtaining the response in both methods, ensuring the body is closed on all return paths (success and error).

##### Test Plan
Code review verified. defer resp.Body.Close() runs on every exit path. If the fcgiclient library internally closes the body, double-close is a no-op per Go's io. ReadCloser contract.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix response body leak in `phpfpm` collector by deferring Close in both socket and TCP status requests. Prevents FD exhaustion and connection failures during long runs.

- **Bug Fixes**
  - Added defer resp.Body.Close() after obtaining the response in `socketClient.getStatus` and `tcpClient.getStatus` to close bodies on all return paths.

<sup>Written for commit dc5aa09ca37fce30a81aea6d3efaadceb7fd5698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

