### PR TITLE
Netdata fixes part 82

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -714,9 +714,9 @@ int verify_path(const char *path) {
         }
     }
 
-    if(strstr(path, "/../")) {
+    if(strstr(path, "/../") || strendswith(path, "/..")) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "invalid parent path sequence detected in '%s'", path);
-        return 1;
+        return -1;
     }
 
     if(path[0] != '/') {

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -373,6 +373,7 @@ pid_t read_pid_from_cgroup_file(const char *filename) {
     FILE *fp = fdopen(fd, "r");
     if(!fp) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot upgrade fd to fp for file '%s'.", filename);
+        close(fd);
         return 0;
     }
 

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -587,26 +587,28 @@ static void read_from_spawned(SPAWN_INSTANCE *si, const char *name __maybe_unuse
     char buffer[CGROUP_NETWORK_INTERFACE_MAX_LINE + 1];
     char *s;
     FILE *fp = fdopen(spawn_server_instance_read_fd(si), "r");
-    while((s = fgets(buffer, CGROUP_NETWORK_INTERFACE_MAX_LINE, fp))) {
-        trim(s);
+    if(fp) {
+        while((s = fgets(buffer, CGROUP_NETWORK_INTERFACE_MAX_LINE, fp))) {
+            trim(s);
 
-        if(*s && *s != '\n') {
-            char *t = s;
-            while(*t && *t != ' ') t++;
-            if(*t == ' ') {
-                *t = '\0';
-                t++;
+            if(*s && *s != '\n') {
+                char *t = s;
+                while(*t && *t != ' ') t++;
+                if(*t == ' ') {
+                    *t = '\0';
+                    t++;
+                }
+
+                if(strcmp(s, "EXIT") == 0)
+                    break;
+
+                if(!*s || !*t) continue;
+                add_device(s, t);
             }
-
-            if(strcmp(s, "EXIT") == 0)
-                break;
-
-            if(!*s || !*t) continue;
-            add_device(s, t);
         }
+        fclose(fp);
+        spawn_server_instance_read_fd_unset(si);
     }
-    fclose(fp);
-    spawn_server_instance_read_fd_unset(si);
     spawn_server_exec_kill(spawn_server, si, 0);
 }
 

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -2,13 +2,15 @@
 
 #include "libnetdata/libnetdata.h"
 
-SPAWN_SERVER *spawn_server = NULL;
+extern char **environ;
 
-char env_netdata_host_prefix[FILENAME_MAX + 50] = "";
-char env_netdata_log_method[FILENAME_MAX + 50] = "";
-char env_netdata_log_format[FILENAME_MAX + 50] = "";
-char env_netdata_log_level[FILENAME_MAX + 50] = "";
-char *environment[] = {
+static SPAWN_SERVER *spawn_server = NULL;
+
+static char env_netdata_host_prefix[FILENAME_MAX + 50] = "";
+static char env_netdata_log_method[FILENAME_MAX + 50] = "";
+static char env_netdata_log_format[FILENAME_MAX + 50] = "";
+static char env_netdata_log_level[FILENAME_MAX + 50] = "";
+static char *environment[] = {
         "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
         env_netdata_host_prefix,
         env_netdata_log_method,
@@ -793,8 +795,6 @@ int main(int argc, const char **argv) {
         collector_error("setresuid(0, 0, 0) failed.");
 
     nd_log_initialize_for_external_plugins("cgroup-network");
-    spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_EXEC | SPAWN_SERVER_OPTION_CALLBACK, NULL, spawn_callback, argc, argv);
-    nd_log_register_fatal_final_cb(cleanup_spawn_server_on_fatal);
 
     // since cgroup-network runs as root, prevent it from opening symbolic links
     procfile_open_flags = O_RDONLY|O_NOFOLLOW;
@@ -807,6 +807,10 @@ int main(int argc, const char **argv) {
 
     if(netdata_configured_host_prefix[0] != '\0' && verify_path(netdata_configured_host_prefix) == -1)
         fatal("invalid NETDATA_HOST_PREFIX '%s'", netdata_configured_host_prefix);
+
+    int helper = 1;
+    if (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL)
+        helper = 0;
 
     // ------------------------------------------------------------------------
     // build a safe environment for our script
@@ -829,6 +833,14 @@ int main(int argc, const char **argv) {
 
     // ------------------------------------------------------------------------
 
+    // This is a dedicated privileged process; no child may inherit its caller's environment.
+    environ = environment;
+
+    spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_EXEC | SPAWN_SERVER_OPTION_CALLBACK, NULL, spawn_callback, argc, argv);
+    // Spawn initialization may publish its detected runtime directory; do not pass it to helper requests.
+    environ = environment;
+    nd_log_register_fatal_final_cb(cleanup_spawn_server_on_fatal);
+
     if(argc == 2 && (!strcmp(argv[1], "version") || !strcmp(argv[1], "-version") || !strcmp(argv[1], "--version") || !strcmp(argv[1], "-v") || !strcmp(argv[1], "-V"))) {
         fprintf(stderr, "cgroup-network %s\n", NETDATA_VERSION);
         exit(0);
@@ -838,9 +850,6 @@ int main(int argc, const char **argv) {
         usage();
 
     int arg = 1;
-    int helper = 1;
-    if (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL)
-        helper = 0;
 
     if(!strcmp(argv[arg], "-p") || !strcmp(argv[arg], "--pid")) {
         pid = atoi(argv[arg+1]);

--- a/src/collectors/cgroups.plugin/cgroup_ebpfgo_cachestat.c
+++ b/src/collectors/cgroups.plugin/cgroup_ebpfgo_cachestat.c
@@ -32,17 +32,15 @@ static procfile *cgroup_ebpfgo_open_nonempty_procs_file(char *path_buf, size_t p
         if (stat(path_buf, &buf) == 0) {
             procfile *ff = cgroup_ebpfgo_open_procfile_fd(path_buf);
             if (ff) {
-                procfile *read = procfile_readall(ff);
-                if (read) {
-                    size_t lines = procfile_lines(read);
+                ff = procfile_readall(ff);
+                if (ff) {
+                    size_t lines = procfile_lines(ff);
                     if (lines > 0) {
                         snprintfz(best_path, sizeof(best_path) - 1, "%s", path_buf);
-                        best = read;
+                        best = ff;
                     } else {
-                        procfile_close(read);
+                        procfile_close(ff);
                     }
-                } else {
-                    procfile_close(ff);
                 }
             }
         }
@@ -70,26 +68,24 @@ static procfile *cgroup_ebpfgo_open_nonempty_procs_file(char *path_buf, size_t p
         if (!ff)
             continue;
 
-        procfile *read = procfile_readall(ff);
-        if (!read) {
-            procfile_close(ff);
+        ff = procfile_readall(ff);
+        if (!ff)
             continue;
-        }
 
-        size_t lines = procfile_lines(read);
+        size_t lines = procfile_lines(ff);
         if (lines == 0) {
-            procfile_close(read);
+            procfile_close(ff);
             continue;
         }
 
         if (!best || lines > best_lines) {
             if (best)
                 procfile_close(best);
-            best = read;
+            best = ff;
             best_lines = lines;
             snprintfz(best_path, sizeof(best_path) - 1, "%s", path_buf);
         } else {
-            procfile_close(read);
+            procfile_close(ff);
         }
     }
 

--- a/src/collectors/ebpf.plugin/ebpf_functions.c
+++ b/src/collectors/ebpf.plugin/ebpf_functions.c
@@ -435,7 +435,7 @@ static void ebpf_function_socket_manipulation(
             rw_spinlock_write_lock(&network_viewer_opt.rw_spinlock);
             ebpf_clean_ip_structure(&network_viewer_opt.included_ips);
             ebpf_clean_ip_structure(&network_viewer_opt.excluded_ips);
-            ebpf_parse_ips_unsafe((char *)name);
+            ebpf_parse_ips_unsafe(name);
             rw_spinlock_write_unlock(&network_viewer_opt.rw_spinlock);
 
             ebpf_socket_clean_judy_array_unsafe();
@@ -444,7 +444,7 @@ static void ebpf_function_socket_manipulation(
             rw_spinlock_write_lock(&network_viewer_opt.rw_spinlock);
             ebpf_clean_port_structure(&network_viewer_opt.included_port);
             ebpf_clean_port_structure(&network_viewer_opt.excluded_port);
-            ebpf_parse_ports((char *)name);
+            ebpf_parse_ports(name);
             rw_spinlock_write_unlock(&network_viewer_opt.rw_spinlock);
 
             ebpf_socket_clean_judy_array_unsafe();

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -1528,7 +1528,7 @@ static int ebpf_is_specific_ip_inside_range(union netdata_ip_t *cmp, int family)
  * Is port inside range
  *
  * Verify if the cmp port is inside the range [first, last].
- * This function expects only the last parameter as big endian.
+ * The destination port is provided in network byte order and converted before comparison.
  *
  * @param cmp    the value to compare
  *
@@ -1539,6 +1539,8 @@ static int ebpf_is_port_inside_range(uint16_t cmp)
     // We do not have restrictions for ports.
     if (!network_viewer_opt.excluded_port && !network_viewer_opt.included_port)
         return 1;
+
+    cmp = ntohs(cmp);
 
     // Test if port is excluded
     ebpf_network_viewer_port_list_t *move = network_viewer_opt.excluded_port;
@@ -2069,7 +2071,7 @@ void ebpf_read_socket_thread(void *ptr)
  * Fill the structure with values read from /proc or hash table.
  *
  * @param out   the structure where we will store data.
- * @param value the ports we are listen to.
+ * @param value the network-order port to store.
  * @param proto the protocol used for this connection.
  * @param in    the structure with values read form different sources.
  */
@@ -2088,12 +2090,14 @@ fill_nv_port_list(ebpf_network_viewer_port_list_t *out, uint16_t value, uint16_t
  *
  * Update link list when it is necessary.
  *
- * @param value the ports we are listen to.
+ * @param value the host-order port we are listening to.
  * @param proto the protocol used with port connection.
  * @param in    the structure with values read form different sources.
  */
 void update_listen_table(uint16_t value, uint16_t proto, netdata_passive_connection_t *in)
 {
+    value = htons(value);
+
     ebpf_network_viewer_port_list_t *w;
     if (likely(listen_ports)) {
         ebpf_network_viewer_port_list_t *move = listen_ports, *store = listen_ports;

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -1607,6 +1607,9 @@ int hostname_matches_pattern(char *cmp)
 int ebpf_is_socket_allowed(netdata_socket_idx_t *key, netdata_socket_t *data)
 {
     int ret = 0;
+
+    rw_spinlock_read_lock(&network_viewer_opt.rw_spinlock);
+
     // If family is not AF_UNSPEC and it is different of specified
     if (network_viewer_opt.family && network_viewer_opt.family != data->family)
         goto endsocketallowed;
@@ -1617,6 +1620,7 @@ int ebpf_is_socket_allowed(netdata_socket_idx_t *key, netdata_socket_t *data)
     ret = ebpf_is_specific_ip_inside_range(&key->daddr, data->family);
 
 endsocketallowed:
+    rw_spinlock_read_unlock(&network_viewer_opt.rw_spinlock);
     return ret;
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -1477,6 +1477,13 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
  *
  *****************************************************************/
 
+static inline bool ebpf_ip_entry_matches_family(const ebpf_network_viewer_ip_list_t *entry, int family)
+{
+    // The parser tags "*" as AF_INET6, but its policy contract is dual-stack.
+    return entry->ver == family ||
+           (entry->value && entry->value[0] == '*' && entry->value[1] == '\0');
+}
+
 /**
  * Is specific ip inside the range
  *
@@ -1495,13 +1502,15 @@ static int ebpf_is_specific_ip_inside_range(union netdata_ip_t *cmp, int family)
     uint32_t ipv4_test = htonl(cmp->addr32[0]);
     ebpf_network_viewer_ip_list_t *move = network_viewer_opt.excluded_ips;
     while (move) {
-        if (family == AF_INET) {
-            if (move->first.addr32[0] <= ipv4_test && ipv4_test <= move->last.addr32[0])
-                return 0;
-        } else {
-            if (memcmp(move->first.addr8, cmp->addr8, sizeof(union netdata_ip_t)) <= 0 &&
-                memcmp(move->last.addr8, cmp->addr8, sizeof(union netdata_ip_t)) >= 0) {
-                return 0;
+        if (ebpf_ip_entry_matches_family(move, family)) {
+            if (family == AF_INET) {
+                if (move->first.addr32[0] <= ipv4_test && ipv4_test <= move->last.addr32[0])
+                    return 0;
+            } else {
+                if (memcmp(move->first.addr8, cmp->addr8, sizeof(union netdata_ip_t)) <= 0 &&
+                    memcmp(move->last.addr8, cmp->addr8, sizeof(union netdata_ip_t)) >= 0) {
+                    return 0;
+                }
             }
         }
         move = move->next;
@@ -1509,13 +1518,15 @@ static int ebpf_is_specific_ip_inside_range(union netdata_ip_t *cmp, int family)
 
     move = network_viewer_opt.included_ips;
     while (move) {
-        if (family == AF_INET && move->ver == AF_INET) {
-            if (move->first.addr32[0] <= ipv4_test && move->last.addr32[0] >= ipv4_test)
-                return 1;
-        } else {
-            if (move->ver == AF_INET6 && memcmp(move->first.addr8, cmp->addr8, sizeof(union netdata_ip_t)) <= 0 &&
-                memcmp(move->last.addr8, cmp->addr8, sizeof(union netdata_ip_t)) >= 0) {
-                return 1;
+        if (ebpf_ip_entry_matches_family(move, family)) {
+            if (family == AF_INET) {
+                if (move->first.addr32[0] <= ipv4_test && move->last.addr32[0] >= ipv4_test)
+                    return 1;
+            } else {
+                if (memcmp(move->first.addr8, cmp->addr8, sizeof(union netdata_ip_t)) <= 0 &&
+                    memcmp(move->last.addr8, cmp->addr8, sizeof(union netdata_ip_t)) >= 0) {
+                    return 1;
+                }
             }
         }
         move = move->next;

--- a/src/collectors/ebpf.plugin/ebpf_socket.h
+++ b/src/collectors/ebpf.plugin/ebpf_socket.h
@@ -176,11 +176,11 @@ typedef struct ebpf_network_viewer_port_list {
     char *value;
     uint32_t hash;
 
-    uint16_t first;
-    uint16_t last;
+    uint16_t first; // network byte order
+    uint16_t last;  // network byte order
 
-    uint16_t cmp_first;
-    uint16_t cmp_last;
+    uint16_t cmp_first; // host byte order
+    uint16_t cmp_last;  // host byte order
 
     uint16_t protocol;
     uint32_t pid;

--- a/src/collectors/ebpf.plugin/ebpf_unittest.c
+++ b/src/collectors/ebpf.plugin/ebpf_unittest.c
@@ -464,9 +464,16 @@ static void test_ebpf_parse_ports_basic(void)
     network_viewer_opt.included_port = NULL;
     network_viewer_opt.excluded_port = NULL;
 
-    ebpf_parse_ports("80 443");
+    static const char input[] = "80 443";
+    ebpf_parse_ports(input);
 
     EBPF_UT_ASSERT(network_viewer_opt.included_port != NULL, "Port list should not be NULL after parsing '80 443'");
+    EBPF_UT_ASSERT(strcmp(input, "80 443") == 0, "Port parser should not modify its input");
+
+    size_t entries = 0;
+    for (ebpf_network_viewer_port_list_t *entry = network_viewer_opt.included_port; entry; entry = entry->next)
+        entries++;
+    EBPF_UT_ASSERT(entries == 2, "Port parser should create one entry for each input token");
 
     ebpf_clean_port_structure(&network_viewer_opt.included_port);
     network_viewer_opt.included_port = NULL;
@@ -511,13 +518,20 @@ static void test_ebpf_parse_ips_basic(void)
 
     network_viewer_opt.included_ips = NULL;
 
-    ebpf_parse_ips_unsafe("192.168.1.1");
+    static const char input[] = "192.168.1.1 10.0.0.1";
+    ebpf_parse_ips_unsafe(input);
 
     EBPF_UT_ASSERT(network_viewer_opt.included_ips != NULL, "IP list should not be NULL after parsing IP");
+    EBPF_UT_ASSERT(strcmp(input, "192.168.1.1 10.0.0.1") == 0, "IP parser should not modify its input");
 
     if (network_viewer_opt.included_ips) {
         EBPF_UT_ASSERT(network_viewer_opt.included_ips->ver == AF_INET, "IP should be IPv4");
     }
+
+    size_t entries = 0;
+    for (ebpf_network_viewer_ip_list_t *entry = network_viewer_opt.included_ips; entry; entry = entry->next)
+        entries++;
+    EBPF_UT_ASSERT(entries == 2, "IP parser should create one entry for each input token");
 
     ebpf_clean_ip_structure(&network_viewer_opt.included_ips);
     network_viewer_opt.included_ips = NULL;
@@ -717,6 +731,52 @@ static void test_parse_network_viewer_section_null(void)
 }
 
 /**
+ * Test parse_network_viewer_section preserves configuration values
+ *
+ * Tests that repeated parsing consumes all list entries without changing the
+ * configuration strings retained by inicfg.
+ */
+static void test_parse_network_viewer_section_preserves_config(void)
+{
+    fprintf(stderr, "\n=== Testing parse_network_viewer_section preserves config ===\n");
+
+    struct config cfg = APPCONFIG_INITIALIZER;
+    static const char ports[] = "80 443";
+    static const char ips[] = "192.168.1.1 10.0.0.1";
+
+    inicfg_set(&cfg, EBPF_NETWORK_VIEWER_SECTION, EBPF_CONFIG_PORTS, ports);
+    inicfg_set(&cfg, EBPF_NETWORK_VIEWER_SECTION, "ips", ips);
+
+    for (size_t pass = 0; pass < 2; pass++) {
+        parse_network_viewer_section(&cfg);
+
+        EBPF_UT_ASSERT(
+            strcmp(inicfg_get(&cfg, EBPF_NETWORK_VIEWER_SECTION, EBPF_CONFIG_PORTS, NULL), ports) == 0,
+            "Network viewer parsing should preserve the configured port list");
+        EBPF_UT_ASSERT(
+            strcmp(inicfg_get(&cfg, EBPF_NETWORK_VIEWER_SECTION, "ips", NULL), ips) == 0,
+            "Network viewer parsing should preserve the configured IP list");
+
+        size_t port_entries = 0;
+        for (ebpf_network_viewer_port_list_t *entry = network_viewer_opt.included_port; entry; entry = entry->next)
+            port_entries++;
+        EBPF_UT_ASSERT(port_entries == 2, "Each parse should consume every configured port token");
+
+        size_t ip_entries = 0;
+        for (ebpf_network_viewer_ip_list_t *entry = network_viewer_opt.included_ips; entry; entry = entry->next)
+            ip_entries++;
+        EBPF_UT_ASSERT(ip_entries == 2, "Each parse should consume every configured IP token");
+
+        ebpf_clean_port_structure(&network_viewer_opt.included_port);
+        ebpf_clean_port_structure(&network_viewer_opt.excluded_port);
+        ebpf_clean_ip_structure(&network_viewer_opt.included_ips);
+        ebpf_clean_ip_structure(&network_viewer_opt.excluded_ips);
+    }
+
+    inicfg_free(&cfg);
+}
+
+/**
  * Test ebpf_load_collector_config
  *
  * Tests the ebpf_load_collector_config function with non-existent path
@@ -766,6 +826,7 @@ void ebpf_library_run_unittests(void)
     test_ebpf_enable_specific_chart();
     test_ebpf_enable_chart();
     test_parse_network_viewer_section_null();
+    test_parse_network_viewer_section_preserves_config();
     test_ebpf_load_collector_config();
 
     fprintf(stderr, "\n");

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
@@ -1167,13 +1167,16 @@ void ebpf_fill_ip_list_unsafe(
  *
  * Parse the IP ranges given and create Network Viewer IP Structure
  *
- * @param ptr  is a pointer with the text to parse.
+ * @param source  is a pointer with the text to parse.
  */
-void ebpf_parse_ips_unsafe(const char *ptr)
+void ebpf_parse_ips_unsafe(const char *source)
 {
     // No value
-    if (unlikely(!ptr))
+    if (unlikely(!source))
         return;
+
+    CLEAN_CHAR_P *input = strdupz(source);
+    char *ptr = input;
 
     while (likely(ptr)) {
         // Move forward until next valid character
@@ -1507,13 +1510,16 @@ fillenvpl:
  *
  * Parse the port ranges given and create Network Viewer Port Structure
  *
- * @param ptr  is a pointer with the text to parse.
+ * @param source  is a pointer with the text to parse.
  */
-void ebpf_parse_ports(const char *ptr)
+void ebpf_parse_ports(const char *source)
 {
     // No value
-    if (unlikely(!ptr))
+    if (unlikely(!source))
         return;
+
+    CLEAN_CHAR_P *input = strdupz(source);
+    char *ptr = input;
 
     while (likely(ptr)) {
         // Move forward until next valid character

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
@@ -1369,8 +1369,11 @@ static inline void fill_port_list(ebpf_network_viewer_port_list_t **out, ebpf_ne
                     cmp_last);
                 freez(move->value);
                 move->value = in->value;
+                move->hash = in->hash;
                 move->first = in->first;
                 move->last = in->last;
+                move->cmp_first = in->cmp_first;
+                move->cmp_last = in->cmp_last;
                 freez(in);
                 return;
             }
@@ -1389,8 +1392,8 @@ static inline void fill_port_list(ebpf_network_viewer_port_list_t **out, ebpf_ne
     netdata_log_info(
         "Adding values %s( %u, %u) to %s port list used on network viewer",
         in->value,
-        in->first,
-        in->last,
+        ntohs(in->first),
+        ntohs(in->last),
         (*out == network_viewer_opt.included_port) ? "included" : "excluded");
 #endif
 }
@@ -1418,6 +1421,7 @@ static void ebpf_parse_service_list(void **out, const char *service)
     w->hash = simple_hash(service);
 
     w->first = w->last = (uint16_t)serv->s_port;
+    w->cmp_first = w->cmp_last = ntohs((uint16_t)serv->s_port);
 
     fill_port_list(list, w);
 }
@@ -1498,8 +1502,8 @@ fillenvpl:
     w = callocz(1, sizeof(ebpf_network_viewer_port_list_t));
     w->value = copied;
     w->hash = simple_hash(copied);
-    w->first = (uint16_t)first;
-    w->last = (uint16_t)last;
+    w->first = htons((uint16_t)first);
+    w->last = htons((uint16_t)last);
     w->cmp_first = (uint16_t)first;
     w->cmp_last = (uint16_t)last;
 
@@ -1825,7 +1829,7 @@ void read_local_ports(char *filename, uint8_t proto)
 
         // Read local port
         uint16_t port = (uint16_t)strtol(procfile_lineword(ff, l, 2), NULL, 16);
-        update_listen_table(htons(port), proto, &values);
+        update_listen_table(port, proto, &values);
     }
 
     procfile_close(ff);

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
@@ -727,7 +727,7 @@ static inline in_addr_t ebpf_netmask(int prefix)
     if (prefix == 0)
         return (~((in_addr_t)-1));
     else
-        return (in_addr_t)(~((1 << (32 - prefix)) - 1));
+        return (in_addr_t)(~((1U << (32 - prefix)) - 1));
 }
 
 /**

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
@@ -1050,6 +1050,8 @@ static void ebpf_parse_ip_list_unsafe(void **out, const char *ip)
         memcpy(last.addr8, first.addr8, sizeof(first.addr8));
     }
 
+    freez(clean_end);
+
     ebpf_network_viewer_ip_list_t *store;
 
 storethisip:

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf_library.c
@@ -855,6 +855,18 @@ static inline int ebpf_ip2nl(uint8_t *dst, const char *ip, int domain, char *sou
     return 0;
 }
 
+static bool ebpf_parse_cidr_prefix(const char *text, int minimum, int maximum, int *prefix)
+{
+    char *end;
+    long value = strtol(text, &end, 10);
+
+    if (end == text || *end || value < minimum || value > maximum)
+        return false;
+
+    *prefix = (int)value;
+    return true;
+}
+
 /**
  * Clean IP structure
  *
@@ -939,12 +951,12 @@ static void ebpf_parse_ip_list_unsafe(void **out, const char *ip)
         }
 
         if (!select) { // CIDR
-            select = ebpf_ip2nl(first.addr8, ip, AF_INET, ipdup);
+            select = ebpf_ip2nl(first.addr8, clean_end, AF_INET, ipdup);
             if (select)
                 goto cleanipdup;
 
-            select = (int)str2i(end);
-            if (select < NETDATA_MINIMUM_IPV4_CIDR || select > NETDATA_MAXIMUM_IPV4_CIDR) {
+            if (!ebpf_parse_cidr_prefix(
+                    end, NETDATA_MINIMUM_IPV4_CIDR, NETDATA_MAXIMUM_IPV4_CIDR, &select)) {
                 netdata_log_info("The specified CIDR %s is not valid, the IP %s will be ignored.", end, ip);
                 goto cleanipdup;
             }
@@ -961,7 +973,7 @@ static void ebpf_parse_ip_list_unsafe(void **out, const char *ip)
 
             last.addr32[0] = htonl(ebpf_broadcast(ntohl(first.addr32[0]), select));
         } else { // Range
-            select = ebpf_ip2nl(first.addr8, ip, AF_INET, ipdup);
+            select = ebpf_ip2nl(first.addr8, clean_end, AF_INET, ipdup);
             if (select)
                 goto cleanipdup;
 
@@ -991,7 +1003,7 @@ static void ebpf_parse_ip_list_unsafe(void **out, const char *ip)
                 goto cleanipdup;
             }
 
-            select = ebpf_ip2nl(first.addr8, ip, AF_INET6, ipdup);
+            select = ebpf_ip2nl(first.addr8, clean_end, AF_INET6, ipdup);
             if (select)
                 goto cleanipdup;
 
@@ -1006,14 +1018,13 @@ static void ebpf_parse_ip_list_unsafe(void **out, const char *ip)
                 goto cleanipdup;
             }
 
-            select = str2i(end);
-            if (select < 0 || select > 128) {
+            if (!ebpf_parse_cidr_prefix(end, 0, 128, &select)) {
                 netdata_log_info("The CIDR %s is not valid, the address %s will be ignored.", end, ip);
                 goto cleanipdup;
             }
 
             uint64_t prefix = (uint64_t)select;
-            select = ebpf_ip2nl(first.addr8, ip, AF_INET6, ipdup);
+            select = ebpf_ip2nl(first.addr8, clean_end, AF_INET6, ipdup);
             if (select)
                 goto cleanipdup;
 

--- a/src/collectors/proc.plugin/sys_block_zram.c
+++ b/src/collectors/proc.plugin/sys_block_zram.c
@@ -175,26 +175,24 @@ static void free_device(DICTIONARY *dict, const char *name)
     dictionary_del(dict, name);
 }
 
-static inline int read_mm_stat(procfile *ff, MM_STAT *stats) {
-    ff = procfile_readall(ff);
-    if (!ff)
+static inline int read_mm_stat(procfile **p_ff, MM_STAT *stats) {
+    *p_ff = procfile_readall(*p_ff);
+    if (!*p_ff)
         return -1;
-    if (procfile_lines(ff) < 1) {
-        procfile_close(ff);
-        return -1;
-    }
-    if (procfile_linewords(ff, 0) < 7) {
-        procfile_close(ff);
+
+    if (procfile_lines(*p_ff) < 1 || procfile_linewords(*p_ff, 0) < 7) {
+        procfile_close(*p_ff);
+        *p_ff = NULL;
         return -1;
     }
 
-    stats->orig_data_size = str2ull(procfile_word(ff, 0), NULL);
-    stats->compr_data_size = str2ull(procfile_word(ff, 1), NULL);
-    stats->mem_used_total = str2ull(procfile_word(ff, 2), NULL);
-    stats->mem_limit = str2ull(procfile_word(ff, 3), NULL);
-    stats->mem_used_max = str2ull(procfile_word(ff, 4), NULL);
-    stats->same_pages = str2ull(procfile_word(ff, 5), NULL);
-    stats->pages_compacted = str2ull(procfile_word(ff, 6), NULL);
+    stats->orig_data_size = str2ull(procfile_word(*p_ff, 0), NULL);
+    stats->compr_data_size = str2ull(procfile_word(*p_ff, 1), NULL);
+    stats->mem_used_total = str2ull(procfile_word(*p_ff, 2), NULL);
+    stats->mem_limit = str2ull(procfile_word(*p_ff, 3), NULL);
+    stats->mem_used_max = str2ull(procfile_word(*p_ff, 4), NULL);
+    stats->same_pages = str2ull(procfile_word(*p_ff, 5), NULL);
+    stats->pages_compacted = str2ull(procfile_word(*p_ff, 6), NULL);
     return 0;
 }
 
@@ -206,7 +204,7 @@ static int collect_zram_metrics(const DICTIONARY_ITEM *item, void *entry, void *
     MM_STAT mm;
     int value;
 
-    if (unlikely(read_mm_stat(dev->file, &mm) < 0)) {
+    if (unlikely(read_mm_stat(&dev->file, &mm) < 0)) {
         free_device(dict, name);
         return -1;
     }

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -88,10 +88,32 @@ static struct prometheus_server {
     struct prometheus_server *next;
 } *prometheus_server_root = NULL;
 
+static struct prometheus_unit_alias {
+    const char *newunit;
+    uint32_t hash;
+    const char *oldunit;
+} prometheus_unit_aliases[] = {
+    { "KiB/s", 0, "kilobytes/s" },
+    { "MiB/s", 0, "MB/s" },
+    { "GiB/s", 0, "GB/s" },
+    { "KiB", 0, "KB" },
+    { "MiB", 0, "MB" },
+    { "GiB", 0, "GB" },
+    { "inodes", 0, "Inodes" },
+    { "percentage", 0, "percent" },
+    { "faults/s", 0, "page faults/s" },
+    { "KiB/operation", 0, "kilobytes per operation" },
+    { "milliseconds/operation", 0, "ms per operation" },
+    { NULL, 0, NULL },
+};
+
 static netdata_mutex_t prometheus_server_root_mutex;
 
-static void __attribute__((constructor)) init_mutex(void) {
+static void __attribute__((constructor)) init_prometheus(void) {
     netdata_mutex_init(&prometheus_server_root_mutex);
+
+    for(size_t i = 0; prometheus_unit_aliases[i].newunit; i++)
+        prometheus_unit_aliases[i].hash = simple_hash(prometheus_unit_aliases[i].newunit);
 }
 
 static void __attribute__((destructor)) destroy_mutex(void) {
@@ -200,38 +222,14 @@ inline char *prometheus_units_copy(char *d, const char *s, size_t usable, int sh
     char *ret = d;
     size_t n;
 
-    // Fix for issue 5227
+    // Legacy unit aliases for pre-v1.12 metric names.
     if (unlikely(showoldunits)) {
-        static struct {
-            const char *newunit;
-            uint32_t hash;
-            const char *oldunit;
-        } units[] = { { "KiB/s", 0, "kilobytes/s" },
-                      { "MiB/s", 0, "MB/s" },
-                      { "GiB/s", 0, "GB/s" },
-                      { "KiB", 0, "KB" },
-                      { "MiB", 0, "MB" },
-                      { "GiB", 0, "GB" },
-                      { "inodes", 0, "Inodes" },
-                      { "percentage", 0, "percent" },
-                      { "faults/s", 0, "page faults/s" },
-                      { "KiB/operation", 0, "kilobytes per operation" },
-                      { "milliseconds/operation", 0, "ms per operation" },
-                      { NULL, 0, NULL } };
-        static int initialized = 0;
-        int i;
-
-        if (unlikely(!initialized)) {
-            for (i = 0; units[i].newunit; i++)
-                units[i].hash = simple_hash(units[i].newunit);
-            initialized = 1;
-        }
-
         uint32_t hash = simple_hash(s);
-        for (i = 0; units[i].newunit; i++) {
-            if (unlikely(hash == units[i].hash && !strcmp(s, units[i].newunit))) {
+        for (size_t i = 0; prometheus_unit_aliases[i].newunit; i++) {
+            if (unlikely(hash == prometheus_unit_aliases[i].hash &&
+                         !strcmp(s, prometheus_unit_aliases[i].newunit))) {
                 // netdata_log_info("matched extension for filename '%s': '%s'", filename, last_dot);
-                s = units[i].oldunit;
+                s = prometheus_unit_aliases[i].oldunit;
                 sorig = s;
                 break;
             }


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 
- Fixes CID 504738

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `cgroup-network` and eBPF network viewer while fixing parsing, byte order, and concurrency issues; also resolves procfile ownership bugs and removes a Prometheus unit alias race. No interface changes; behavior is safer and more correct.

- Bug Fixes
  - `cgroup-network`: enforce a curated environment for privileged helpers, reject parent path components (`/../` and trailing `/..`) with consistent `-1`, and handle `fdopen()` failures by guarding parsing and closing fds.
  - eBPF network viewer: preserve const parser inputs, restore IPv4/IPv6 range and CIDR parsing, use unsigned IPv4 netmask shift, require same-family IP matches with `*` remaining dual-stack, fix port filter byte order and comparisons, protect socket policy reads with a read lock, and normalize listen-port updates; minor const cleanups in Function handlers.
  - Prometheus: precompute legacy unit alias hashes at init and use a shared alias table to remove a data race.
  - Proc plugins: keep authoritative `procfile` ownership after `procfile_readall()` in zram and cgroup cachestat paths to prevent UAF/double-close.
  - Tests: add unit tests for immutable port/IP parsing and repeated config parsing to prevent regressions.

<sup>Written for commit 032aa3eaaa15af397ce6f2bc055f9e218ae8f7c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

