### PR TITLE
Netdata fixes part 83

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -1053,9 +1053,15 @@ static inline void read_cgroup_network_interfaces(struct cgroup *cg) {
         return;
     }
 
+    FILE *child_stdout = spawn_popen_stdout(instance);
+    if(unlikely(!child_stdout)) {
+        spawn_popen_kill(instance, 0);
+        return;
+    }
+
     char *s;
     char buffer[CGROUP_NETWORK_INTERFACE_MAX_LINE + 1];
-    while((s = fgets(buffer, CGROUP_NETWORK_INTERFACE_MAX_LINE, spawn_popen_stdout(instance)))) {
+    while((s = fgets(buffer, CGROUP_NETWORK_INTERFACE_MAX_LINE, child_stdout))) {
         trim(s);
 
         if(*s && *s != '\n') {

--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -102,7 +102,13 @@ static enum cgroups_systemd_setting cgroups_detect_systemd(const char *exec)
     } else if (ret == 0) {
         collector_info("Cannot get the output of \"%s\" within timeout (%d ms)", exec, timeout);
     } else {
-        while (fgets(buf, MAXSIZE_PROC_CMDLINE, spawn_popen_stdout(pi)) != NULL) {
+        FILE *child_stdout = spawn_popen_stdout(pi);
+        if(unlikely(!child_stdout)) {
+            spawn_popen_kill(pi, 0);
+            return retval;
+        }
+
+        while (fgets(buf, MAXSIZE_PROC_CMDLINE, child_stdout) != NULL) {
             if ((begin = strstr(buf, SYSTEMD_HIERARCHY_STRING))) {
                 end = begin = begin + strlen(SYSTEMD_HIERARCHY_STRING);
                 if (!*begin)
@@ -167,7 +173,13 @@ static enum cgroups_type cgroups_try_detect_version()
         collector_error("cannot run 'grep cgroup /proc/filesystems'");
         return CGROUPS_AUTODETECT_FAIL;
     }
-    while (fgets(buf, MAXSIZE_PROC_CMDLINE, spawn_popen_stdout(pi)) != NULL) {
+    FILE *child_stdout = spawn_popen_stdout(pi);
+    if(unlikely(!child_stdout)) {
+        spawn_popen_kill(pi, 0);
+        return CGROUPS_AUTODETECT_FAIL;
+    }
+
+    while (fgets(buf, MAXSIZE_PROC_CMDLINE, child_stdout) != NULL) {
         if (strstr(buf, "cgroup2")) {
             cgroups2_available = 1;
             break;

--- a/src/collectors/tc.plugin/plugin_tc.c
+++ b/src/collectors/tc.plugin/plugin_tc.c
@@ -929,7 +929,11 @@ void tc_main(void *ptr) {
         }
 
         char buffer[TC_LINE_MAX+1] = "";
-        while(fgets(buffer, TC_LINE_MAX, spawn_popen_stdout(tc_child_instance)) != NULL) {
+        FILE *child_stdout = spawn_popen_stdout(tc_child_instance);
+        if(unlikely(!child_stdout))
+            goto child_done;
+
+        while(fgets(buffer, TC_LINE_MAX, child_stdout) != NULL) {
             if(unlikely(!service_running(SERVICE_COLLECTORS))) break;
 
             buffer[TC_LINE_MAX] = '\0';
@@ -1135,6 +1139,7 @@ void tc_main(void *ptr) {
             worker_is_idle();
         }
 
+child_done:;
         // fgets() failed or loop broke
         int code = spawn_popen_kill(tc_child_instance, 0);
         tc_child_instance = NULL;

--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -413,21 +413,26 @@ void analytics_alarms_notifications(void)
     POPEN_INSTANCE *instance = spawn_popen_run(script);
     if (instance) {
         char line[200 + 1];
+        FILE *child_stdout = spawn_popen_stdout(instance);
 
-        while (fgets(line, 200, spawn_popen_stdout(instance)) != NULL) {
-            char *end = line;
-            while (*end && *end != '\n')
-                end++;
-            *end = '\0';
+        if(unlikely(!child_stdout))
+            spawn_popen_kill(instance, 0);
+        else {
+            while (fgets(line, 200, child_stdout) != NULL) {
+                char *end = line;
+                while (*end && *end != '\n')
+                    end++;
+                *end = '\0';
 
-            if (likely(cnt))
-                buffer_strcat(b, "|");
+                if (likely(cnt))
+                    buffer_strcat(b, "|");
 
-            buffer_strcat(b, line);
+                buffer_strcat(b, line);
 
-            cnt++;
+                cnt++;
+            }
+            spawn_popen_wait(instance);
         }
-        spawn_popen_wait(instance);
     }
     freez(script);
 

--- a/src/database/rrdhost-labels.c
+++ b/src/database/rrdhost-labels.c
@@ -179,8 +179,14 @@ static bool rrdhost_load_kubernetes_labels(void) {
     POPEN_INSTANCE *instance = spawn_popen_run(label_script);
     if(!instance) return false;
 
+    FILE *child_stdout = spawn_popen_stdout(instance);
+    if(unlikely(!child_stdout)) {
+        spawn_popen_kill(instance, 0);
+        return false;
+    }
+
     char buffer[1000 + 1];
-    while (fgets(buffer, 1000, spawn_popen_stdout(instance)) != NULL)
+    while (fgets(buffer, 1000, child_stdout) != NULL)
         rrdlabels_add_pair(localhost->rrdlabels, buffer, RRDLABEL_SRC_AUTO|RRDLABEL_SRC_K8S);
 
     // Non-zero exit code means that all the script output is error messages. We've shown already any message that didn't include a ':'

--- a/src/libnetdata/libnetdata.c
+++ b/src/libnetdata/libnetdata.c
@@ -161,9 +161,16 @@ BUFFER *run_command_and_get_output_to_buffer(const char *command, int max_line_l
 
     POPEN_INSTANCE *pi = spawn_popen_run(command);
     if(pi) {
+        FILE *child_stdout = spawn_popen_stdout(pi);
+        if(unlikely(!child_stdout)) {
+            spawn_popen_kill(pi, 0);
+            buffer_free(wb);
+            return NULL;
+        }
+
         size_t buffer_size = (size_t)max_line_length + 1;
         CLEAN_CHAR_P *buffer = mallocz(buffer_size);
-        while (fgets(buffer, max_line_length, spawn_popen_stdout(pi))) {
+        while (fgets(buffer, max_line_length, child_stdout)) {
             buffer[max_line_length] = '\0';
             buffer_strcat(wb, buffer);
         }
@@ -184,10 +191,16 @@ bool run_command_and_copy_output_to_stdout(const char *command, int max_line_len
 
     POPEN_INSTANCE *pi = spawn_popen_run(command);
     if(pi) {
+        FILE *child_stdout = spawn_popen_stdout(pi);
+        if(unlikely(!child_stdout)) {
+            spawn_popen_kill(pi, 0);
+            return false;
+        }
+
         size_t buffer_size = (size_t)max_line_length + 1;
         CLEAN_CHAR_P *buffer = mallocz(buffer_size);
 
-        while (fgets(buffer, max_line_length, spawn_popen_stdout(pi)))
+        while (fgets(buffer, max_line_length, child_stdout))
             fprintf(stdout, "%s", buffer);
 
         spawn_popen_kill(pi, 0);

--- a/src/libnetdata/spawn_server/spawn-tester.c
+++ b/src/libnetdata/spawn_server/spawn-tester.c
@@ -99,20 +99,29 @@ static void test_popen_echo_loop(POPEN_INSTANCE *pi, const char *msg, size_t ite
     size_t buffer_size = len * 2;
     CLEAN_CHAR_P *buffer = mallocz(buffer_size);
 
+    FILE *child_stdin = spawn_popen_stdin(pi);
+    FILE *child_stdout = child_stdin ? spawn_popen_stdout(pi) : NULL;
+    if(!child_stdin || !child_stdout) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot open popen child streams");
+        spawn_popen_kill(pi, 0);
+        netdata_main_spawn_server_cleanup();
+        exit(1);
+    }
+
     for(size_t j = 0; j < iterations; j++) {
         fprintf(stderr, "-");
         memset(buffer, 0, buffer_size);
 
-        size_t rc = fwrite(msg, 1, len, spawn_popen_stdin(pi));
+        size_t rc = fwrite(msg, 1, len, child_stdin);
         if (rc != len) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR,
                    "Cannot write to plugin. Expected to write %zu bytes, wrote %zu bytes",
                    len, rc);
             exit(1);
         }
-        fflush(spawn_popen_stdin(pi));
+        fflush(child_stdin);
 
-        char *s = fgets(buffer, (int)buffer_size, spawn_popen_stdout(pi));
+        char *s = fgets(buffer, (int)buffer_size, child_stdout);
         if (!s || strlen(s) != len) {
             nd_log(NDLS_COLLECTORS, NDLP_ERR,
                    "Cannot read from plugin. Expected to read %zu bytes, read %zu bytes",
@@ -347,12 +356,19 @@ void test_popen_plugin_echo_and_exit(const char *argv0) {
     }
 
     char buffer[1024];
+    FILE *child_stdout = spawn_popen_stdout(pi);
+    if(!child_stdout) {
+        spawn_popen_kill(pi, 0);
+        netdata_main_spawn_server_cleanup();
+        exit(1);
+    }
+
     size_t reads = 0;
     for(size_t j = 0; j < 30 ;j++) {
         fprintf(stderr, "-");
         memset(buffer, 0, sizeof(buffer));
 
-        char *s = fgets(buffer, sizeof(buffer), spawn_popen_stdout(pi));
+        char *s = fgets(buffer, sizeof(buffer), child_stdout);
         if(!s) break;
         reads++;
         if (strlen(s) != strlen(ECHO_AND_EXIT_MSG)) {


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crash paths by validating and caching `spawn_popen_stdout()`/`spawn_popen_stdin()` before use, and cleaning up the child process on failure. Normal behavior is unchanged; this removes NULL `FILE*` usage across several collectors and helpers.

- **Bug Fixes**
  - Cache and check child `FILE*` streams once; on NULL, call `spawn_popen_kill()` and exit via existing error paths.
  - Switch read/write loops to use the cached handles; avoid repeated accessors.
  - Ensure proper cleanup with `spawn_popen_wait()` where needed.
  - Applies to: cgroups discovery and systemd/version detection, `tc` plugin, analytics aggregation, Kubernetes label loader, `libnetdata` command helpers, and spawn tester.

<sup>Written for commit 2197cb35285fdad3b53016ae866d250c5ea2805f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

