### PR TITLE
Enable the otel-plugin on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1188,7 +1188,7 @@ jobs:
         id: build-source
         if: needs.file-check.outputs.run == 'true'
         run: |
-          sudo bash ./netdata-installer.sh --install-no-prefix /usr/local/netdata --dont-wait --dont-start-it --one-time-build
+          sudo bash ./netdata-installer.sh --install-no-prefix /usr/local/netdata --dont-wait --dont-start-it --one-time-build --enable-plugin-otel
       - name: Test Agent start up
         id: test-agent
         if: needs.file-check.outputs.run == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -802,7 +802,7 @@ jobs:
         if: needs.file-check.outputs.run == 'true'
         run: |
           docker run --security-opt seccomp=unconfined -e DISABLE_TELEMETRY=1 --network host \
-                 -v $PWD:/netdata -w /netdata \
+                 -v "$PWD":/netdata -w /netdata \
                  ubuntu:latest /bin/sh -x /netdata/.github/scripts/run-updater-check.sh
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,7 @@ mark_as_advanced(ENABLE_DASHBOARD)
 option(ENABLE_PLUGIN_GO "Enable metric collectors written in Go" ${DEFAULT_FEATURE_STATE})
 cmake_dependent_option(ENABLE_ND_MCP "Build nd-mcp stdio-to-websocket bridge for MCP integration" ${DEFAULT_FEATURE_STATE} "ENABLE_PLUGIN_GO" False)
 option(ENABLE_PLUGIN_SCRIPTS "Enable the experimental scripts plugin (Nagios compatibility module)" ON)
-cmake_dependent_option(ENABLE_PLUGIN_OTEL "Enable collection of OpenTelemetry metrics and logs" ${DEFAULT_FEATURE_STATE} "OS_LINUX" False)
+cmake_dependent_option(ENABLE_PLUGIN_OTEL "Enable collection of OpenTelemetry metrics and logs" ${DEFAULT_FEATURE_STATE} "OS_LINUX OR OS_MACOS" False)
 cmake_dependent_option(ENABLE_PLUGIN_NETFLOW "Enable NetFlow/IPFIX/sFlow flow analysis plugin" False "NOT OS_WINDOWS" False)
 option(ENABLE_PLUGIN_PYTHON "Enable metric collectors written in Python" ${DEFAULT_FEATURE_STATE})
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Next unused error code: I0012
+# Next unused error code: I0016
 
 export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 uniquepath() {
@@ -217,7 +217,7 @@ USAGE: ${PROGRAM} [options]
   --enable-plugin-systemd-journal Enable the systemd journal plugin. Default: enable it when libsystemd is available.
   --disable-plugin-systemd-journal Explicitly disable the systemd journal plugin.
   --internal-systemd-journal Enable the internal journal file reader instead of using libsystemd
-  --enable-plugin-otel Enable the Netdata OpenTelemetry plugin. Default: disabled
+  --enable-plugin-otel Enable the Netdata OpenTelemetry plugin. Default: disabled, except on macOS where it is enabled when a suitable Rust toolchain is found
   --disable-plugin-otel Explicitly disable the Netdata OpenTelemetry plugin.
   --enable-plugin-netflow    Enable the NetFlow/IPFIX/sFlow flow analysis plugin. Default: disabled.
   --disable-plugin-netflow   Explicitly disable the NetFlow/IPFIX/sFlow flow analysis plugin.
@@ -268,7 +268,7 @@ ENABLE_GO=1
 ENABLE_PYTHON=1
 ENABLE_CHARTS=1
 ENABLE_NETFLOW=0
-ENABLE_OTEL=0
+ENABLE_OTEL=""
 ENABLE_IBM=0
 ENABLE_SCRIPTS=1
 FORCE_LEGACY_CXX=0
@@ -600,6 +600,57 @@ if [ "${ENABLE_IBM}" -eq 1 ]; then
       ENABLE_IBM=0
     fi
   fi
+fi
+
+# -----------------------------------------------------------------------------
+# The otel-plugin needs a Rust toolchain covering the workspace MSRV. On macOS
+# it is enabled automatically when one is present (the dependency script,
+# packaging/installer/install-required-packages.sh, provisions one via rustup
+# or Homebrew); everywhere else it stays opt-in. Toolchain provisioning cannot
+# happen here: on macOS this script runs as root, where Homebrew refuses to
+# operate.
+
+required_rust_version() {
+  grep '^rust-version' "${NETDATA_SOURCE_DIR}/src/crates/Cargo.toml" 2>/dev/null | head -n 1 | sed -e 's/.*"\([0-9.]*\)".*/\1/'
+}
+
+# Succeeds when version ${2} >= version ${1}; components compared numerically,
+# missing components count as 0. Twin of the check in
+# packaging/installer/install-required-packages.sh (which is also used
+# standalone and cannot source this file).
+version_covers() {
+  _vc_i=1
+  while [ "${_vc_i}" -le 3 ]; do
+    _vc_r="$(echo "${1}." | cut -d . -f "${_vc_i}" | sed -e 's/[^0-9].*//')"
+    _vc_a="$(echo "${2}." | cut -d . -f "${_vc_i}" | sed -e 's/[^0-9].*//')"
+    [ "${_vc_a:-0}" -gt "${_vc_r:-0}" ] && return 0
+    [ "${_vc_a:-0}" -lt "${_vc_r:-0}" ] && return 1
+    _vc_i=$((_vc_i + 1))
+  done
+  return 0
+}
+
+rust_covers_required_version() {
+  command -v cargo >/dev/null 2>&1 || return 1
+  rust_version_min="$(required_rust_version)"
+  [ -z "${rust_version_min}" ] && return 0
+  rust_version_have="$(rustc --version 2>/dev/null | cut -d ' ' -f 2)"
+  [ -z "${rust_version_have}" ] && return 1
+  version_covers "${rust_version_min}" "${rust_version_have}"
+}
+
+if [ -z "${ENABLE_OTEL}" ]; then
+  ENABLE_OTEL=0
+  if [ "$(uname -s)" = "Darwin" ]; then
+    if rust_covers_required_version; then
+      progress "Found Rust toolchain ($(rustc --version 2>/dev/null)), the otel-plugin will be built."
+      ENABLE_OTEL=1
+    else
+      warning "Building without the otel-plugin: no Rust toolchain covering version $(required_rust_version) found. Run packaging/installer/install-required-packages.sh (or install Rust via rustup or 'brew install rust') and re-run the installer to enable it."
+    fi
+  fi
+elif [ "${ENABLE_OTEL}" -eq 1 ] && ! rust_covers_required_version; then
+  fatal "The otel-plugin was explicitly enabled, but no Rust toolchain covering version $(required_rust_version) was found. Install one (via rustup or 'brew install rust') and re-run the installer." I0015
 fi
 
 # -----------------------------------------------------------------------------

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -606,51 +606,67 @@ fi
 # The otel-plugin needs a Rust toolchain covering the workspace MSRV. On macOS
 # it is enabled automatically when one is present (the dependency script,
 # packaging/installer/install-required-packages.sh, provisions one via rustup
-# or Homebrew); everywhere else it stays opt-in. Toolchain provisioning cannot
-# happen here: on macOS this script runs as root, where Homebrew refuses to
-# operate.
+# or Homebrew), and an explicit --enable-plugin-otel without a usable
+# toolchain fails fast. Toolchain provisioning cannot happen here: on macOS
+# this script runs as root, where Homebrew refuses to operate. These checks
+# are macOS-only by design — on every other platform the plugin stays opt-in
+# and toolchain resolution is left to CMake/Corrosion, exactly as before.
 
-required_rust_version() {
-  grep '^rust-version' "${NETDATA_SOURCE_DIR}/src/crates/Cargo.toml" 2>/dev/null | head -n 1 | sed -e 's/.*"\([0-9.]*\)".*/\1/'
-}
+if [ "$(uname -s)" = "Darwin" ]; then
+  required_rust_version() {
+    grep '^rust-version' "${NETDATA_SOURCE_DIR}/src/crates/Cargo.toml" 2>/dev/null | head -n 1 | sed -e 's/.*"\([0-9.]*\)".*/\1/'
+  }
 
-# Succeeds when version ${2} >= version ${1}; components compared numerically,
-# missing components count as 0. Twin of the check in
-# packaging/installer/install-required-packages.sh (which is also used
-# standalone and cannot source this file).
-version_covers() {
-  _vc_i=1
-  while [ "${_vc_i}" -le 3 ]; do
-    _vc_r="$(echo "${1}." | cut -d . -f "${_vc_i}" | sed -e 's/[^0-9].*//')"
-    _vc_a="$(echo "${2}." | cut -d . -f "${_vc_i}" | sed -e 's/[^0-9].*//')"
-    [ "${_vc_a:-0}" -gt "${_vc_r:-0}" ] && return 0
-    [ "${_vc_a:-0}" -lt "${_vc_r:-0}" ] && return 1
-    _vc_i=$((_vc_i + 1))
-  done
-  return 0
-}
+  # Succeeds when version ${2} >= version ${1}; components compared
+  # numerically, missing components count as 0. Twin of the check in
+  # packaging/installer/install-required-packages.sh (which is also used
+  # standalone and cannot source this file).
+  version_covers() {
+    _vc_i=1
+    while [ "${_vc_i}" -le 3 ]; do
+      _vc_r="$(echo "${1}." | cut -d . -f "${_vc_i}" | sed -e 's/[^0-9].*//')"
+      _vc_a="$(echo "${2}." | cut -d . -f "${_vc_i}" | sed -e 's/[^0-9].*//')"
+      [ "${_vc_a:-0}" -gt "${_vc_r:-0}" ] && return 0
+      [ "${_vc_a:-0}" -lt "${_vc_r:-0}" ] && return 1
+      _vc_i=$((_vc_i + 1))
+    done
+    return 0
+  }
 
-rust_covers_required_version() {
-  command -v cargo >/dev/null 2>&1 || return 1
-  rust_version_min="$(required_rust_version)"
-  [ -z "${rust_version_min}" ] && return 0
-  rust_version_have="$(rustc --version 2>/dev/null | cut -d ' ' -f 2)"
-  [ -z "${rust_version_have}" ] && return 1
-  version_covers "${rust_version_min}" "${rust_version_have}"
-}
+  rust_covers_required_version() {
+    # Sourcing /etc/profile above ran path_helper, which may have reset PATH
+    # and hidden the toolchain; probe the locations Corrosion's FindRust
+    # considers, plus Homebrew's Apple Silicon prefix.
+    rustc_cmd="$(PATH="${HOME}/.cargo/bin:/opt/homebrew/bin:${PATH}" command -v rustc 2>/dev/null)"
+    cargo_cmd="$(PATH="${HOME}/.cargo/bin:/opt/homebrew/bin:${PATH}" command -v cargo 2>/dev/null)"
+    { [ -n "${rustc_cmd}" ] && [ -n "${cargo_cmd}" ]; } || return 1
+    rust_version_min="$(required_rust_version)"
+    if [ -n "${rust_version_min}" ]; then
+      rust_version_have="$("${rustc_cmd}" --version 2>/dev/null | cut -d ' ' -f 2)"
+      [ -z "${rust_version_have}" ] && return 1
+      version_covers "${rust_version_min}" "${rust_version_have}" || return 1
+    fi
+    # Make the approved toolchain visible to CMake/Corrosion as well.
+    cargo_bin_dir="$(dirname "${cargo_cmd}")"
+    export PATH="${cargo_bin_dir}:${PATH}"
+  }
 
-if [ -z "${ENABLE_OTEL}" ]; then
-  ENABLE_OTEL=0
-  if [ "$(uname -s)" = "Darwin" ]; then
+  if [ -z "${ENABLE_OTEL}" ]; then
+    ENABLE_OTEL=0
     if rust_covers_required_version; then
-      progress "Found Rust toolchain ($(rustc --version 2>/dev/null)), the otel-plugin will be built."
+      progress "Found Rust toolchain (${rustc_cmd}), the otel-plugin will be built."
       ENABLE_OTEL=1
     else
       warning "Building without the otel-plugin: no Rust toolchain covering version $(required_rust_version) found. Run packaging/installer/install-required-packages.sh (or install Rust via rustup or 'brew install rust') and re-run the installer to enable it."
     fi
+  elif [ "${ENABLE_OTEL}" -eq 1 ] && ! rust_covers_required_version; then
+    fatal "The otel-plugin was explicitly enabled, but no Rust toolchain covering version $(required_rust_version) was found. Install one (via rustup or 'brew install rust') and re-run the installer." I0015
   fi
-elif [ "${ENABLE_OTEL}" -eq 1 ] && ! rust_covers_required_version; then
-  fatal "The otel-plugin was explicitly enabled, but no Rust toolchain covering version $(required_rust_version) was found. Install one (via rustup or 'brew install rust') and re-run the installer." I0015
+else
+  # otel-plugin remains opt-in on non-macOS platforms; empty means default-off.
+  if [ -z "${ENABLE_OTEL}" ]; then
+    ENABLE_OTEL=0
+  fi
 fi
 
 # -----------------------------------------------------------------------------

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -636,10 +636,13 @@ if [ "$(uname -s)" = "Darwin" ]; then
   rust_covers_required_version() {
     # Sourcing /etc/profile above ran path_helper, which may have reset PATH
     # and hidden the toolchain; probe the locations Corrosion's FindRust
-    # considers, plus Homebrew's Apple Silicon prefix.
-    rustc_cmd="$(PATH="${HOME}/.cargo/bin:/opt/homebrew/bin:${PATH}" command -v rustc 2>/dev/null)"
+    # considers, plus Homebrew's Apple Silicon prefix. Validate the rustc
+    # that ships next to the selected cargo, so a mixed installation cannot
+    # pass the check with a different compiler.
     cargo_cmd="$(PATH="${HOME}/.cargo/bin:/opt/homebrew/bin:${PATH}" command -v cargo 2>/dev/null)"
-    { [ -n "${rustc_cmd}" ] && [ -n "${cargo_cmd}" ]; } || return 1
+    [ -n "${cargo_cmd}" ] || return 1
+    rustc_cmd="${cargo_cmd%/*}/rustc"
+    [ -x "${rustc_cmd}" ] || return 1
     rust_version_min="$(required_rust_version)"
     if [ -n "${rust_version_min}" ]; then
       rust_version_have="$("${rustc_cmd}" --version 2>/dev/null | cut -d ' ' -f 2)"
@@ -647,8 +650,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
       version_covers "${rust_version_min}" "${rust_version_have}" || return 1
     fi
     # Make the approved toolchain visible to CMake/Corrosion as well.
-    cargo_bin_dir="$(dirname "${cargo_cmd}")"
-    export PATH="${cargo_bin_dir}:${PATH}"
+    export PATH="${cargo_cmd%/*}:${PATH}"
   }
 
   if [ -z "${ENABLE_OTEL}" ]; then

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -114,9 +114,9 @@ Platforms in the community support tier are those which are primarily supported 
 | Fedora      | Rawhide   | No                       |                                                                                                           |
 | FreeBSD     | 13-STABLE | No                       | Netdata is included in the FreeBSD Ports Tree, and this is the recommended installation method on FreeBSD |
 | Gentoo      | Latest    | No                       |                                                                                                           |
-| macOS       | 13        | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies                         |
-| macOS       | 12        | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies                         |
-| macOS       | 11        | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies.                        |
+| macOS       | 26        | No                       | Apple Silicon builds are validated in CI. Requires Homebrew for dependencies                              |
+| macOS       | 15        | No                       | Apple Silicon builds are validated in CI. Requires Homebrew for dependencies                              |
+| macOS       | 14        | No                       | Apple Silicon builds are validated in CI. Requires Homebrew for dependencies                              |
 
 ## Binary Distribution Packages
 
@@ -144,7 +144,7 @@ Source builds are expected to work for all platforms in the Core tier because th
 |  **FreeBSD and derivatives**   |     13-STABLE     |
 |   **Gentoo and derivatives**   |      Latest       |
 | **Arch Linux and derivatives** |  Latest from AUR  |
-|           **macOS**            |    11, 12, 13     |
+|           **macOS**            |    14, 15, 26     |
 
 ## Third-party supported platforms
 

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 # We use lots of computed variable names in here, so we need to disable shellcheck 2034
+# shellcheck disable=SC2329
+# The install_*/validate_* functions are invoked indirectly through the
+# ${package_installer} variable, which shellcheck cannot see
 
 export PATH="${PATH}:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 export LC_ALL=C
@@ -1246,11 +1249,14 @@ version_covers() {
 }
 
 rust_toolchain_ok() {
-  # succeeds when a cargo/rustc on PATH satisfies NETDATA_RUST_MSRV
+  # Succeeds when a cargo/rustc satisfies NETDATA_RUST_MSRV. Probes the
+  # rustup and Homebrew locations too, as they may not be on PATH yet.
   [ "${IGNORE_INSTALLED}" -eq 1 ] && return 1
-  command -v cargo > /dev/null 2>&1 || return 1
-  local v
-  v="$(rustc --version 2> /dev/null | cut -d ' ' -f 2)"
+  local rustc_cmd v
+  PATH="${HOME}/.cargo/bin:/opt/homebrew/bin:${PATH}" command -v cargo > /dev/null 2>&1 || return 1
+  rustc_cmd="$(PATH="${HOME}/.cargo/bin:/opt/homebrew/bin:${PATH}" command -v rustc 2> /dev/null)"
+  [ -n "${rustc_cmd}" ] || return 1
+  v="$("${rustc_cmd}" --version 2> /dev/null | cut -d ' ' -f 2)"
   [ -z "${v}" ] && return 1
   version_covers "${NETDATA_RUST_MSRV}" "${v}"
 }
@@ -1353,10 +1359,13 @@ packages() {
     suitable_package flex
     suitable_package libcurl-dev
 
-    # Rust toolchain for the otel-plugin (macOS only, see pkg_rust). Prefer
-    # an existing toolchain covering the MSRV, then rustup (handled after
-    # package installation by ensure_rustup_toolchain), then Homebrew rust.
-    rust_toolchain_ok || require_cmd rustup || suitable_package rust
+    # Rust toolchain for the otel-plugin (macOS only; other platforms
+    # provide Rust outside this script). Prefer an existing toolchain
+    # covering the MSRV, then rustup (handled after package installation by
+    # ensure_rustup_toolchain), then Homebrew rust.
+    if [ "${tree}" = "macos" ]; then
+      rust_toolchain_ok || require_cmd rustup || suitable_package rust
+    fi
   fi
 
   # -------------------------------------------------------------------------

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
-# We use lots of computed variable names in here, so we need to disable shellcheck 2034
-# shellcheck disable=SC2329
-# The install_*/validate_* functions are invoked indirectly through the
-# ${package_installer} variable, which shellcheck cannot see
+# shellcheck disable=SC2034,SC2329
+# SC2034: we use lots of computed variable names in here.
+# SC2329: the install_*/validate_* functions are invoked indirectly through
+#         the ${package_installer} variable, which shellcheck cannot see.
 
 export PATH="${PATH}:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 export LC_ALL=C

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1085,6 +1085,13 @@ declare -A pkg_python3=(
   ['centos-6']="WARNING|"
 )
 
+# Rust toolchain for the otel-plugin. Only macOS provisions it here; on Linux
+# it comes from the CI builder images or the user's own toolchain.
+declare -A pkg_rust=(
+  ['macos']="rust"
+  ['default']="NOTREQUIRED"
+)
+
 declare -A pkg_screen=(
   ['gentoo']="app-misc/screen"
   ['sabayon']="app-misc/screen"
@@ -1219,6 +1226,49 @@ suitable_package() {
   fi
 }
 
+# Minimum Rust version needed to build Netdata's Rust components
+# (otel-plugin). Keep in sync with `rust-version` in src/crates/Cargo.toml.
+NETDATA_RUST_MSRV="1.91"
+
+# Succeeds when version ${2} >= version ${1}; components compared numerically,
+# missing components count as 0. Twin of the check in netdata-installer.sh
+# (this script is also used standalone and cannot source it).
+version_covers() {
+  local i=1 r a
+  while [ "${i}" -le 3 ]; do
+    r="$(echo "${1}." | cut -d . -f "${i}" | sed -e 's/[^0-9].*//')"
+    a="$(echo "${2}." | cut -d . -f "${i}" | sed -e 's/[^0-9].*//')"
+    [ "${a:-0}" -gt "${r:-0}" ] && return 0
+    [ "${a:-0}" -lt "${r:-0}" ] && return 1
+    i=$((i + 1))
+  done
+  return 0
+}
+
+rust_toolchain_ok() {
+  # succeeds when a cargo/rustc on PATH satisfies NETDATA_RUST_MSRV
+  [ "${IGNORE_INSTALLED}" -eq 1 ] && return 1
+  command -v cargo > /dev/null 2>&1 || return 1
+  local v
+  v="$(rustc --version 2> /dev/null | cut -d ' ' -f 2)"
+  [ -z "${v}" ] && return 1
+  version_covers "${NETDATA_RUST_MSRV}" "${v}"
+}
+
+ensure_rustup_toolchain() {
+  # When rustup manages the toolchain, install one covering the MSRV instead
+  # of layering a Homebrew rust next to it. Sets a default only when none is
+  # configured; an existing too-old default is the user's to switch.
+  command -v rustup > /dev/null 2>&1 || return 0
+  rust_toolchain_ok && return 0
+  run rustup toolchain install stable || return 1
+  rustup default > /dev/null 2>&1 || run rustup default stable
+  if ! rust_toolchain_ok; then
+    echo >&2 "WARNING: the default rustup toolchain does not satisfy Rust >= ${NETDATA_RUST_MSRV},"
+    echo >&2 "         which Netdata's otel-plugin needs. Run: rustup default stable"
+  fi
+}
+
 packages() {
   # detect the packages we need to install on this system
 
@@ -1302,6 +1352,11 @@ packages() {
     suitable_package pcre2
     suitable_package flex
     suitable_package libcurl-dev
+
+    # Rust toolchain for the otel-plugin (macOS only, see pkg_rust). Prefer
+    # an existing toolchain covering the MSRV, then rustup (handled after
+    # package installation by ensure_rustup_toolchain), then Homebrew rust.
+    rust_toolchain_ok || require_cmd rustup || suitable_package rust
   fi
 
   # -------------------------------------------------------------------------
@@ -2098,6 +2153,10 @@ else
   echo >&2
   echo >&2 "All required packages are already installed. Now proceed to the next step."
   echo >&2
+fi
+
+if [ "${tree}" = "macos" ] && [ "${PACKAGES_NETDATA}" -ne 0 ] && [ "${IGNORE_INSTALLED}" -eq 0 ]; then
+  ensure_rustup_toolchain
 fi
 
 remote_log "OK"

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1249,13 +1249,16 @@ version_covers() {
 }
 
 rust_toolchain_ok() {
-  # Succeeds when a cargo/rustc satisfies NETDATA_RUST_MSRV. Probes the
-  # rustup and Homebrew locations too, as they may not be on PATH yet.
+  # Succeeds when a matched cargo/rustc pair satisfies NETDATA_RUST_MSRV.
+  # Probes the rustup and Homebrew locations too, as they may not be on PATH
+  # yet, and validates the rustc that ships next to the selected cargo so a
+  # mixed installation cannot pass the check with a different compiler.
   [ "${IGNORE_INSTALLED}" -eq 1 ] && return 1
-  local rustc_cmd v
-  PATH="${HOME}/.cargo/bin:/opt/homebrew/bin:${PATH}" command -v cargo > /dev/null 2>&1 || return 1
-  rustc_cmd="$(PATH="${HOME}/.cargo/bin:/opt/homebrew/bin:${PATH}" command -v rustc 2> /dev/null)"
-  [ -n "${rustc_cmd}" ] || return 1
+  local cargo_cmd rustc_cmd v
+  cargo_cmd="$(PATH="${HOME}/.cargo/bin:/opt/homebrew/bin:${PATH}" command -v cargo 2> /dev/null)"
+  [ -n "${cargo_cmd}" ] || return 1
+  rustc_cmd="${cargo_cmd%/*}/rustc"
+  [ -x "${rustc_cmd}" ] || return 1
   v="$("${rustc_cmd}" --version 2> /dev/null | cut -d ' ' -f 2)"
   [ -z "${v}" ] && return 1
   version_covers "${NETDATA_RUST_MSRV}" "${v}"
@@ -1264,15 +1267,13 @@ rust_toolchain_ok() {
 ensure_rustup_toolchain() {
   # When rustup manages the toolchain, install one covering the MSRV instead
   # of layering a Homebrew rust next to it. Sets a default only when none is
-  # configured; an existing too-old default is the user's to switch.
+  # configured; an existing too-old default is the user's to switch (the
+  # final verification below reports it).
   command -v rustup > /dev/null 2>&1 || return 0
   rust_toolchain_ok && return 0
   run rustup toolchain install stable || return 1
   rustup default > /dev/null 2>&1 || run rustup default stable
-  if ! rust_toolchain_ok; then
-    echo >&2 "WARNING: the default rustup toolchain does not satisfy Rust >= ${NETDATA_RUST_MSRV},"
-    echo >&2 "         which Netdata's otel-plugin needs. Run: rustup default stable"
-  fi
+  return 0
 }
 
 packages() {
@@ -2165,7 +2166,17 @@ else
 fi
 
 if [ "${tree}" = "macos" ] && [ "${PACKAGES_NETDATA}" -ne 0 ] && [ "${IGNORE_INSTALLED}" -eq 0 ]; then
-  ensure_rustup_toolchain
+  # The otel-plugin is enabled by default on macOS and needs a Rust
+  # toolchain covering the MSRV; fail loudly when one could not be set up.
+  if ! ensure_rustup_toolchain || ! rust_toolchain_ok; then
+    echo >&2
+    echo >&2 "Failed to set up a Rust toolchain covering version ${NETDATA_RUST_MSRV}, which"
+    echo >&2 "the Netdata otel-plugin (enabled by default on macOS) requires."
+    echo >&2 "Install one with 'rustup default stable' or 'brew install rust' and run this script again,"
+    echo >&2 "or build Netdata with --disable-plugin-otel."
+    remote_log "FAILED" "rust-toolchain"
+    exit 1
+  fi
 fi
 
 remote_log "OK"

--- a/packaging/installer/methods/macos.md
+++ b/packaging/installer/methods/macos.md
@@ -134,6 +134,14 @@ We don't recommend installing Netdata from source on macOS, as it can be difficu
    brew install ossp-uuid autoconf automake pkg-config libuv lz4 json-c openssl libtool cmake
    ```
 
+   To include the OpenTelemetry plugin (`otel-plugin`), also install a Rust toolchain. It is built automatically when a toolchain covering the minimum version (`rust-version` in `src/crates/Cargo.toml`) is available:
+
+   ```bash
+   brew install rust
+   ```
+
+   If you use [rustup](https://rustup.rs/), a stable toolchain works as well; Homebrew Rust is only the fallback when neither `cargo` nor `rustup` is present.
+
 4. Download Netdata from our GitHub repository:
 
    ```bash
@@ -159,3 +167,4 @@ Netdata works on macOS, albeit with some limitations.
 
 - The number of charts displaying system metrics is limited, but you can use any of Netdata's [external plugins](/src/plugins.d/README.md) to monitor any services you might have installed on your macOS system.
 - You could also use a macOS system as the parent node in a [streaming configuration](/src/streaming/README.md).
+- The OpenTelemetry plugin (`otel-plugin`) is built by default when a Rust toolchain is available, so a macOS node can also ingest OTLP metrics, logs, and traces.

--- a/packaging/installer/methods/macos.md
+++ b/packaging/installer/methods/macos.md
@@ -134,13 +134,7 @@ We don't recommend installing Netdata from source on macOS, as it can be difficu
    brew install ossp-uuid autoconf automake pkg-config libuv lz4 json-c openssl libtool cmake
    ```
 
-   To include the OpenTelemetry plugin (`otel-plugin`), also install a Rust toolchain. It is built automatically when a toolchain covering the minimum version (`rust-version` in `src/crates/Cargo.toml`) is available:
-
-   ```bash
-   brew install rust
-   ```
-
-   If you use [rustup](https://rustup.rs/), a stable toolchain works as well; Homebrew Rust is only the fallback when neither `cargo` nor `rustup` is present.
+   To include the OpenTelemetry plugin (`otel-plugin`), also install a Rust toolchain — either `brew install rust` or a stable toolchain via [rustup](https://rustup.rs/). The plugin is built automatically when a toolchain covering the minimum version (`rust-version` in `src/crates/Cargo.toml`) is available; without one, the installer prints a warning and builds the agent without the plugin.
 
 4. Download Netdata from our GitHub repository:
 


### PR DESCRIPTION
##### Summary

Makes the otel-plugin (OpenTelemetry OTLP ingestion) buildable and enabled by default on macOS.

The Rust code and its full dependency closure are already portable to macOS: `cargo check --target aarch64-apple-darwin` passes for all workspace crates, `io-uring`/`inotify` are Linux-target-gated by foyer/notify and drop out of the Darwin dependency tree, and every `cfg(target_os = "linux")` site has a working non-Linux fallback. The only blockers were in the build system:

- **CMake**: `ENABLE_PLUGIN_OTEL` was hard-gated to `OS_LINUX`, so it was forced off and hidden on macOS. The gate now includes `OS_MACOS` (mirroring the `ENABLE_PLUGIN_APPS` precedent).
- **Installer default**: `netdata-installer.sh` now auto-enables the otel-plugin on macOS when a Rust toolchain covering the workspace MSRV (`rust-version` in `src/crates/Cargo.toml`) is present, and warns-and-skips otherwise — same auto-detect convention as other feature checks. An explicit `--enable-plugin-otel` without a suitable toolchain now fails fast with an actionable message instead of a cryptic Corrosion configure error. Other platforms keep the opt-in default.
- **Toolchain provisioning**: `install-required-packages.sh` (which macOS runs as the invoking user, where Homebrew works) now ensures a Rust toolchain on macOS: reuse an existing `cargo`/`rustc` when it covers the MSRV, prefer `rustup toolchain install stable` when rustup is installed (never layering Homebrew rust next to it, and never switching an existing default), and fall back to `brew install rust`. Linux behavior is unchanged — Rust there keeps coming from the CI builder images or the user's own toolchain.
- **CI**: the macOS jobs now pass `--enable-plugin-otel` so a toolchain-provisioning failure hard-fails the build instead of silently soft-disabling the plugin.
- **Docs**: macOS install docs mention the Rust requirement; the stale macOS rows in `PLATFORM_SUPPORT.md` (Intel-only claim, macOS 11-13) are refreshed to match what CI actually validates (Apple Silicon, macOS 14/15/26).

##### Test Plan

- The `macos-build` CI jobs (macos-14/15/26) now build with `--enable-plugin-otel` and run the agent startup runtime check.
- `cargo check --target aarch64-apple-darwin` passes for the otel-plugin workspace crates (the C-sys crates — zstd-sys, ring, aws-lc-sys — need the Apple toolchain present on the runners).
- `sh -n` / `bash -n` on both modified shell scripts; the version-comparison helper is covered by manual case testing in sh and bash (missing components, pre-release suffixes, multi-digit minors).
- Linux/Windows/FreeBSD paths are unaffected by construction: the CMake gate only adds Darwin, the installer default resolution only changes behavior on Darwin, and the dependency-script hook is a no-op outside the macOS tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the `otel-plugin` on macOS and build it by default when a Rust toolchain meeting the workspace MSRV is available. Other platforms remain opt-in and unchanged.

- **New Features**
  - CMake allows `ENABLE_PLUGIN_OTEL` on macOS.
  - Installer (macOS): auto-enables `otel-plugin` when Rust meets the MSRV; explicit `--enable-plugin-otel` fails fast without a suitable toolchain; dependency script provisions Rust via `rustup` (preferred) or Homebrew.
  - CI/Docs: macOS CI builds with `--enable-plugin-otel`; platform support updated (Apple Silicon, macOS 14/15/26); macOS source-install docs now clearly recommend `rustup` or Homebrew and explain that without a toolchain the installer warns and builds without the plugin.

- **Bug Fixes**
  - Restrict Rust toolchain pre-flight to macOS; probe `${HOME}/.cargo/bin` and `/opt/homebrew/bin`; export the approved toolchain to `PATH`.
  - Harden macOS Rust setup: fail clearly if an MSRV-capable toolchain can’t be set up; validate matched `cargo`/`rustc` in both the installer and dependency script.
  - CI/lint cleanups: quote `$PWD` in the updater-check job; silence `SC2329` and consolidate shellcheck disables in `install-required-packages.sh`.

<sup>Written for commit 316badc0830837c6bb445e11a58ceb23fb50135a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

