### PR TITLE
agent-events: add optional OTLP log export of accepted events

### DIFF
--- a/packaging/tools/agent-events/otlp.go
+++ b/packaging/tools/agent-events/otlp.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+	logapi "go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// The OTel plugin partitions log streams by (service.namespace, service.name).
+const (
+	otlpServiceNamespace = "netdata"
+	otlpServiceName      = "agent-events"
+)
+
+// otlpEmitter exports accepted events as OTel log records over OTLP/gRPC.
+type otlpEmitter struct {
+	provider *sdklog.LoggerProvider
+	logger   logapi.Logger
+	endpoint string
+}
+
+func newOTLPEmitter(ctx context.Context, endpoint string) (*otlpEmitter, error) {
+	// Insecure transport: the target is the local OTel plugin listener, which
+	// defaults to plaintext gRPC on localhost.
+	exporter, err := otlploggrpc.New(ctx,
+		otlploggrpc.WithEndpoint(endpoint),
+		otlploggrpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTLP log exporter: %w", err)
+	}
+	res := resource.NewSchemaless(
+		attribute.String("service.namespace", otlpServiceNamespace),
+		attribute.String("service.name", otlpServiceName),
+	)
+	provider := sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+		sdklog.WithResource(res),
+	)
+	return &otlpEmitter{
+		provider: provider,
+		logger:   provider.Logger(otlpServiceName),
+		endpoint: endpoint,
+	}, nil
+}
+
+// emit queues one event for asynchronous export; it never blocks the request.
+func (e *otlpEmitter) emit(ctx context.Context, event map[string]interface{}, payload []byte) {
+	e.logger.Emit(ctx, buildRecord(time.Now(), event, payload))
+}
+
+func (e *otlpEmitter) shutdown(ctx context.Context) error {
+	return e.provider.Shutdown(ctx)
+}
+
+// buildRecord is the single mapping seam between the event document and the
+// OTel log record. The whole enriched document travels as a JSON string body:
+// the ingestion side explodes it into typed body.* fields, keeping this server
+// agnostic to status-file schema changes. Fields promoted to explicit OTLP
+// attributes in the future must be added here, with the remainder staying in
+// the body.
+func buildRecord(ts time.Time, event map[string]interface{}, payload []byte) logapi.Record {
+	var rec logapi.Record
+	rec.SetTimestamp(ts)
+	rec.SetObservedTimestamp(ts)
+	rec.SetBody(logapi.StringValue(string(payload)))
+	if sev, text, ok := severityFromPriority(event["priority"]); ok {
+		rec.SetSeverity(sev)
+		rec.SetSeverityText(text)
+	}
+	return rec
+}
+
+// severityFromPriority maps the event's syslog priority to an OTel severity
+// per the OTel Logs Data Model severity mappings. An absent or malformed
+// priority leaves the severity unspecified rather than guessing.
+func severityFromPriority(v interface{}) (logapi.Severity, string, bool) {
+	f, ok := v.(float64) // encoding/json decodes JSON numbers as float64
+	if !ok || f != float64(int(f)) {
+		return logapi.SeverityUndefined, "", false
+	}
+	switch int(f) {
+	case 0:
+		return logapi.SeverityFatal, "emergency", true
+	case 1:
+		return logapi.SeverityError3, "alert", true
+	case 2:
+		return logapi.SeverityError2, "critical", true
+	case 3:
+		return logapi.SeverityError, "error", true
+	case 4:
+		return logapi.SeverityWarn, "warning", true
+	case 5:
+		return logapi.SeverityInfo2, "notice", true
+	case 6:
+		return logapi.SeverityInfo, "info", true
+	case 7:
+		return logapi.SeverityDebug, "debug", true
+	default:
+		return logapi.SeverityUndefined, "", false
+	}
+}

--- a/packaging/tools/agent-events/otlp_test.go
+++ b/packaging/tools/agent-events/otlp_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	logapi "go.opentelemetry.io/otel/log"
+)
+
+func TestSeverityFromPriority(t *testing.T) {
+	tests := map[string]struct {
+		input    interface{}
+		wantSev  logapi.Severity
+		wantText string
+		wantOK   bool
+	}{
+		"emergency":         {float64(0), logapi.SeverityFatal, "emergency", true},
+		"alert":             {float64(1), logapi.SeverityError3, "alert", true},
+		"critical":          {float64(2), logapi.SeverityError2, "critical", true},
+		"error":             {float64(3), logapi.SeverityError, "error", true},
+		"warning":           {float64(4), logapi.SeverityWarn, "warning", true},
+		"notice":            {float64(5), logapi.SeverityInfo2, "notice", true},
+		"info":              {float64(6), logapi.SeverityInfo, "info", true},
+		"debug":             {float64(7), logapi.SeverityDebug, "debug", true},
+		"missing":           {nil, logapi.SeverityUndefined, "", false},
+		"string value":      {"3", logapi.SeverityUndefined, "", false},
+		"fractional number": {3.5, logapi.SeverityUndefined, "", false},
+		"out of range":      {float64(8), logapi.SeverityUndefined, "", false},
+		"negative":          {float64(-1), logapi.SeverityUndefined, "", false},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sev, text, ok := severityFromPriority(tc.input)
+			if sev != tc.wantSev || text != tc.wantText || ok != tc.wantOK {
+				t.Errorf("severityFromPriority(%v) = (%v, %q, %v), want (%v, %q, %v)",
+					tc.input, sev, text, ok, tc.wantSev, tc.wantText, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestBuildRecord(t *testing.T) {
+	ts := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	payload := []byte(`{"exit_cause":"deadly signal","priority":2,"agent":{"id":"test"}}`)
+
+	tests := map[string]struct {
+		event    map[string]interface{}
+		wantSev  logapi.Severity
+		wantText string
+	}{
+		"with priority":      {map[string]interface{}{"priority": float64(2)}, logapi.SeverityError2, "critical"},
+		"without priority":   {map[string]interface{}{}, logapi.SeverityUndefined, ""},
+		"malformed priority": {map[string]interface{}{"priority": "high"}, logapi.SeverityUndefined, ""},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			rec := buildRecord(ts, tc.event, payload)
+			if !rec.Timestamp().Equal(ts) {
+				t.Errorf("Timestamp = %v, want %v", rec.Timestamp(), ts)
+			}
+			if !rec.ObservedTimestamp().Equal(ts) {
+				t.Errorf("ObservedTimestamp = %v, want %v", rec.ObservedTimestamp(), ts)
+			}
+			if got := rec.Body().AsString(); got != string(payload) {
+				t.Errorf("Body = %q, want %q", got, string(payload))
+			}
+			if rec.Severity() != tc.wantSev {
+				t.Errorf("Severity = %v, want %v", rec.Severity(), tc.wantSev)
+			}
+			if rec.SeverityText() != tc.wantText {
+				t.Errorf("SeverityText = %q, want %q", rec.SeverityText(), tc.wantText)
+			}
+		})
+	}
+}

--- a/packaging/tools/agent-events/run.sh
+++ b/packaging/tools/agent-events/run.sh
@@ -2,6 +2,11 @@
 
 #	--dedup-logfile=/opt/agent-events/log/dedup.log \
 
+# Dual-write evaluation: add the flag below to the server command to also
+# export accepted events as OTel log records to the local Netdata OTel plugin
+# (see otlp.go). The journald pipeline below is unaffected.
+#	--otlp-endpoint=127.0.0.1:4317 \
+
 stdbuf -oL /opt/agent-events/server \
 	--port=30001 \
 	--dedup-key=agent.id \

--- a/packaging/tools/agent-events/server.go
+++ b/packaging/tools/agent-events/server.go
@@ -63,6 +63,9 @@ var (
 	// Track active connections for graceful shutdown
 	activeConnections int32
 
+	// Optional OTLP log export of accepted events (nil when disabled)
+	otlpLogs *otlpEmitter
+
 	// OpenTelemetry meter provider and metrics
 	meterProvider *sdkmetric.MeterProvider
 	meter         metric.Meter
@@ -381,6 +384,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if shouldProcess {
 		// Write to stdout for normal processing
 		fmt.Println(string(outputBytes))
+		if otlpLogs != nil {
+			otlpLogs.emit(ctx, fullData, outputBytes)
+		}
 		requestsCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("status", "success")))
 	} else if dedupLogger != nil {
 		// Write to dedup log file if it's a duplicate and logging is enabled
@@ -433,6 +439,14 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 		"log_enabled": dedupLogEnabled,
 		"log_file":    dedupLogPath,
 	}
+	otlpEndpoint := ""
+	if otlpLogs != nil {
+		otlpEndpoint = otlpLogs.endpoint
+	}
+	status["otlp"] = map[string]interface{}{
+		"enabled":  otlpLogs != nil,
+		"endpoint": otlpEndpoint,
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(status); err != nil {
@@ -461,6 +475,7 @@ func main() {
 	flag.StringVar(&dedupLogFile, "dedup-logfile", "", "File to log deduplicated requests (empty to disable)")
 	flag.Var(&keyPaths, "dedup-key", "JSON path (dot-notation) for deduplication key (can be used multiple times)")
 	flag.StringVar(&dedupSeparator, "dedup-separator", "-", "Separator used between multi-key values")
+	otlpEndpoint := flag.String("otlp-endpoint", "", "OTLP/gRPC endpoint (host:port) to also export accepted events as OTel log records (empty to disable)")
 	flag.Parse()
 
 	// Configure final logger based on flags
@@ -504,6 +519,17 @@ func main() {
 	if _, err := initMetrics(); err != nil { // Handle potential error from initMetrics
 		slog.Error("failed to initialize metrics", "error", err)
 		os.Exit(1)
+	}
+
+	// Initialize optional OTLP log export of accepted events
+	if *otlpEndpoint != "" {
+		var err error
+		otlpLogs, err = newOTLPEmitter(context.Background(), *otlpEndpoint)
+		if err != nil {
+			slog.Error("failed to initialize OTLP log export", "endpoint", *otlpEndpoint, "error", err)
+			os.Exit(1)
+		}
+		slog.Info("OTLP log export enabled", "endpoint", *otlpEndpoint)
 	}
 
 	// Start background tasks
@@ -578,6 +604,15 @@ func main() {
 			slog.Error("server shutdown failed", "error", err)
 		} else {
 			slog.Info("server shutdown completed gracefully")
+		}
+
+		// Flush OTLP log export after the server drains, so records emitted by
+		// in-flight requests are not lost
+		if otlpLogs != nil {
+			slog.Info("shutting down OTLP log export")
+			if err := otlpLogs.shutdown(shutdownCtx); err != nil {
+				slog.Error("OTLP log export shutdown failed", "error", err)
+			}
 		}
 
 		// Close deduplication log file if open


### PR DESCRIPTION
## Summary

Adds an optional, flag-gated OTLP/gRPC exporter to the agent-events ingestion server (`packaging/tools/agent-events/`), so accepted events can additionally be stored through the Netdata OTel logs pipeline while the existing stdout → log2journal → journald path remains unchanged. The goal is to dual-write in production for a while, evaluate the OTel logs pipeline against the journald store with real traffic, and decide on a cut-over afterwards.

- `--otlp-endpoint=<host:port>` (default empty = disabled): with the flag unset, behavior is byte-identical to today.
- Each accepted (non-duplicate) event becomes one OTel log record: the enriched JSON document travels as the log body — the OTel plugin explodes it into typed, faceted `body.*` fields, so the server stays agnostic to status-file schema changes, same as the log2journal path today.
- Severity number/text derive from the event's syslog `priority`; timestamp is the server receive time (matching journald semantics); stream identity is `service.namespace=netdata`, `service.name=agent-events`.
- `buildRecord()` is the single mapping seam: promoting fields from the JSON body to explicit OTLP attributes later happens only there.
- Export is async (SDK batch processor) and never blocks request handling; duplicates suppressed by the server-side dedup are not exported; a graceful shutdown flushes buffered records after the HTTP server drains; `/healthz` reports the export state.
- `run.sh` documents the flag (commented); enabling it is a deployment decision.

## Validation

- `build.sh` (build + full `go test -v`): green; existing `server_test.go` unmodified.
- New table-driven tests for the syslog→OTel severity mapping (per the OTel Logs Data Model severity mappings) and record construction.
- End-to-end against a live agent with the OTel plugin: events POSTed to the modified server were ingested over OTLP and queried back via the `otel-logs` Function with correct severity, faceted `body.*` fields (exit_cause, agent_health, fatal.function, agent.version, ...), intact multi-line stack traces, dedup suppression, and graceful-shutdown flush observed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional OTLP/gRPC log exporter to the agent-events server to dual-write accepted events to the Netdata OTel logs pipeline while keeping the existing journald path unchanged. Enable with `--otlp-endpoint=<host:port>`; when unset, behavior is unchanged.

- New Features
  - Each accepted (non-duplicate) event exports as one OTel log record with the enriched JSON as the body.
  - Severity maps from syslog `priority`; timestamp is server receive time; stream tags `service.namespace=netdata`, `service.name=agent-events`.
  - Async batching; never blocks requests; graceful shutdown flushes pending records after the HTTP server drains.
  - `/healthz` reports exporter state; `run.sh` documents the flag.
  - Single mapping seam via `buildRecord()`; unit tests cover severity mapping and record construction.

- Migration
  - Default is off. To enable dual-write, start the server with `--otlp-endpoint=127.0.0.1:4317` (local Netdata OTel plugin) and verify via `/healthz`.

<sup>Written for commit 9057b6ea9844e403302c5483614c468805b636c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

