### PR TITLE
otel-plugin: exit the legacy-logs worker when there is nothing to serve

### DIFF
--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -3477,6 +3477,7 @@ dependencies = [
  "netdata-plugin-schema",
  "netdata-plugin-types",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",

--- a/src/crates/netdata-plugin/bridge/src/lib.rs
+++ b/src/crates/netdata-plugin/bridge/src/lib.rs
@@ -10,6 +10,8 @@
 //! 1. Worker connects to the supervisor's IPC socket.
 //! 2. Supervisor sends `Configure` with the worker's resolved config.
 //! 3. Worker initializes, then sends `Ready` with zero or more function declarations.
+//!    The legacy-logs worker may instead send `Disabled` — nothing to serve or
+//!    init failed — and exit immediately after.
 //! 4. Supervisor registers the declarations and enters its main loop.
 
 pub mod config;
@@ -133,10 +135,16 @@ pub enum LegacyLogsRequest {
 /// Messages sent from the legacy-logs worker back to the supervisor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LegacyLogsResponse {
-    /// Worker is initialized and ready. Carries zero or more function declarations.
+    /// Worker is initialized and ready. Carries the function declarations to
+    /// register.
     Ready {
         declarations: Vec<FunctionDeclaration>,
     },
+    /// Worker will not serve — the legacy journal directory is absent or the
+    /// handler failed to initialize (details in the worker's own logs) — and
+    /// exits immediately after sending this. Terminal: no further messages
+    /// follow, and the supervisor is expected to reap the child.
+    Disabled,
     /// Function completed.
     Result(FunctionResult),
     /// Progress update for a running function.

--- a/src/crates/otel-legacy-logs/Cargo.toml
+++ b/src/crates/otel-legacy-logs/Cargo.toml
@@ -22,3 +22,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/src/crates/otel-legacy-logs/src/lib.rs
+++ b/src/crates/otel-legacy-logs/src/lib.rs
@@ -4,6 +4,9 @@
 //! It registers a single `legacy-otel-logs` function and serves it over the
 //! journal files written by the former otel plugin, via the restored
 //! `journal-function` query stack. It never writes to those files.
+//!
+//! When the journal directory is absent or the handler fails to initialize,
+//! the worker reports `Disabled` and exits instead of lingering idle.
 
 mod handler;
 
@@ -46,27 +49,26 @@ pub async fn run_worker(socket_path: &str) -> Result<()> {
 
     // The former otel journal directory is absent on the vast majority of
     // installs (the former logs feature was experimental). When it is missing
-    // there is nothing to view: register no function and idle. This keeps the
-    // otel-plugin healthy and avoids surfacing a perpetually-empty function on
-    // installs that never used the former plugin.
+    // there is nothing to view: report Disabled and exit so no idle process
+    // lingers for the plugin's lifetime. An existing-but-empty directory
+    // intentionally keeps the worker: the handler watches the directory, so
+    // journal files restored into it later are picked up.
     if !config.journal_dir.is_dir() {
         tracing::info!(
             journal_dir = %config.journal_dir.display(),
             "former otel journal directory not present; legacy-otel-logs disabled"
         );
         supervisor
-            .send(LegacyLogsResponse::Ready {
-                declarations: vec![],
-            })
+            .send(LegacyLogsResponse::Disabled)
             .await
-            .context("failed to signal ready to supervisor")?;
-        return run_idle(supervisor).await;
+            .context("failed to signal disabled to supervisor")?;
+        return Ok(());
     }
 
-    // Init failure must not take down the otel-plugin: the legacy
-    // viewer is best-effort. On a handler-init error (e.g. unwritable cache dir,
-    // foyer init failure) self-disable exactly like the absent-dir path — register
-    // nothing and idle — instead of bailing the worker.
+    // Init failure must not take down the otel-plugin: the legacy viewer is
+    // best-effort. On a handler-init error (e.g. unwritable cache dir, foyer
+    // init failure) self-disable exactly like the absent-dir path — report
+    // Disabled and exit — instead of bailing the worker.
     let handler = match LegacyLogsHandler::new(&config).await {
         Ok(handler) => handler,
         Err(e) => {
@@ -75,12 +77,10 @@ pub async fn run_worker(socket_path: &str) -> Result<()> {
                 "failed to initialize legacy-logs handler; legacy-otel-logs disabled: {e:#}"
             );
             supervisor
-                .send(LegacyLogsResponse::Ready {
-                    declarations: vec![],
-                })
+                .send(LegacyLogsResponse::Disabled)
                 .await
-                .context("failed to signal ready to supervisor")?;
-            return run_idle(supervisor).await;
+                .context("failed to signal disabled to supervisor")?;
+            return Ok(());
         }
     };
     let declarations = vec![handler.declaration()];
@@ -106,22 +106,6 @@ pub async fn run_worker(socket_path: &str) -> Result<()> {
         tracing::error!("legacy-logs event loop error: {e:#}");
     }
     result.context("legacy-logs event loop error")
-}
-
-/// Idle loop used when the journal directory is absent: nothing is registered,
-/// so the worker only needs to react to a graceful Shutdown.
-async fn run_idle(mut supervisor: Connection<LegacyLogsResponse, LegacyLogsRequest>) -> Result<()> {
-    loop {
-        match supervisor.recv().await.context("supervisor recv failed")? {
-            LegacyLogsRequest::Shutdown => {
-                tracing::info!("received Shutdown from supervisor");
-                return Ok(());
-            }
-            other => {
-                tracing::debug!("ignoring request while disabled: {other:?}");
-            }
-        }
-    }
 }
 
 /// One run-loop iteration's input.

--- a/src/crates/otel-legacy-logs/tests/handshake.rs
+++ b/src/crates/otel-legacy-logs/tests/handshake.rs
@@ -1,7 +1,7 @@
 //! Worker lifecycle handshake tests: the worker must report `Disabled` and
-//! exit when there is nothing to serve, and must serve (then shut down
-//! gracefully) when the journal directory exists — even an empty one, whose
-//! watcher picks up files restored later.
+//! exit when there is nothing to serve (absent journal dir, handler init
+//! failure), and must serve (then shut down gracefully) when the journal
+//! directory exists — even an empty one.
 
 use std::time::Duration;
 
@@ -59,6 +59,27 @@ async fn reports_disabled_and_exits_when_journal_dir_absent() {
         dir.path().join("does-not-exist"),
         dir.path().join("cache"),
     );
+    conn.send(LegacyLogsRequest::Configure(config)).await.unwrap();
+
+    match recv(&mut conn).await {
+        LegacyLogsResponse::Disabled => {}
+        other => panic!("expected Disabled, got {other:?}"),
+    }
+    assert_exits(worker).await;
+}
+
+#[tokio::test]
+async fn reports_disabled_and_exits_when_handler_init_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("legacy.sock");
+    let journal_dir = dir.path().join("journal");
+    std::fs::create_dir_all(&journal_dir).unwrap();
+    // A cache path nested under a regular file makes the disk-cache init fail.
+    let blocker = dir.path().join("blocker");
+    std::fs::write(&blocker, b"not a directory").unwrap();
+    let (mut conn, worker) = start(sock.to_str().unwrap()).await;
+
+    let config = LegacyLogsConfig::new(journal_dir, blocker.join("cache"));
     conn.send(LegacyLogsRequest::Configure(config)).await.unwrap();
 
     match recv(&mut conn).await {

--- a/src/crates/otel-legacy-logs/tests/handshake.rs
+++ b/src/crates/otel-legacy-logs/tests/handshake.rs
@@ -1,0 +1,89 @@
+//! Worker lifecycle handshake tests: the worker must report `Disabled` and
+//! exit when there is nothing to serve, and must serve (then shut down
+//! gracefully) when the journal directory exists — even an empty one, whose
+//! watcher picks up files restored later.
+
+use std::time::Duration;
+
+use bridge::config::LegacyLogsConfig;
+use bridge::{LegacyLogsRequest, LegacyLogsResponse};
+use ferryboat::{Connection, Endpoint, Listener};
+use tokio::task::JoinHandle;
+
+/// Bind the supervisor side of the socket, spawn `run_worker` against it, and
+/// return the accepted connection plus the worker's join handle.
+async fn start(
+    sock: &str,
+) -> (
+    Connection<LegacyLogsRequest, LegacyLogsResponse>,
+    JoinHandle<anyhow::Result<()>>,
+) {
+    let mut listener = Listener::<LegacyLogsRequest, LegacyLogsResponse>::bind(Endpoint::ipc(sock))
+        .max_message_size(bridge::IPC_MAX_MESSAGE_SIZE)
+        .open()
+        .unwrap();
+    let sock = sock.to_owned();
+    let worker = tokio::spawn(async move { otel_legacy_logs::run_worker(&sock).await });
+    let conn = tokio::time::timeout(Duration::from_secs(10), listener.accept())
+        .await
+        .expect("worker did not connect")
+        .unwrap();
+    (conn, worker)
+}
+
+async fn recv(
+    conn: &mut Connection<LegacyLogsRequest, LegacyLogsResponse>,
+) -> LegacyLogsResponse {
+    tokio::time::timeout(Duration::from_secs(30), conn.recv())
+        .await
+        .expect("timed out waiting for worker response")
+        .unwrap()
+}
+
+/// The worker future must complete cleanly within the timeout.
+async fn assert_exits(worker: JoinHandle<anyhow::Result<()>>) {
+    tokio::time::timeout(Duration::from_secs(5), worker)
+        .await
+        .expect("worker did not exit")
+        .expect("worker task panicked")
+        .expect("worker returned an error");
+}
+
+#[tokio::test]
+async fn reports_disabled_and_exits_when_journal_dir_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("legacy.sock");
+    let (mut conn, worker) = start(sock.to_str().unwrap()).await;
+
+    let config = LegacyLogsConfig::new(
+        dir.path().join("does-not-exist"),
+        dir.path().join("cache"),
+    );
+    conn.send(LegacyLogsRequest::Configure(config)).await.unwrap();
+
+    match recv(&mut conn).await {
+        LegacyLogsResponse::Disabled => {}
+        other => panic!("expected Disabled, got {other:?}"),
+    }
+    assert_exits(worker).await;
+}
+
+#[tokio::test]
+async fn serves_when_journal_dir_exists_even_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("legacy.sock");
+    let journal_dir = dir.path().join("journal");
+    std::fs::create_dir_all(&journal_dir).unwrap();
+    let (mut conn, worker) = start(sock.to_str().unwrap()).await;
+
+    let config = LegacyLogsConfig::new(journal_dir, dir.path().join("cache"));
+    conn.send(LegacyLogsRequest::Configure(config)).await.unwrap();
+
+    match recv(&mut conn).await {
+        LegacyLogsResponse::Ready { declarations } => assert_eq!(declarations.len(), 1),
+        other => panic!("expected Ready, got {other:?}"),
+    }
+
+    conn.send(LegacyLogsRequest::Shutdown).await.unwrap();
+    assert_exits(worker).await;
+}

--- a/src/crates/otel-plugin/src/supervisor.rs
+++ b/src/crates/otel-plugin/src/supervisor.rs
@@ -119,7 +119,8 @@ struct Supervisor {
     legacy_child: ChildGuard,
     /// Whether the legacy-logs worker is usable. The legacy viewer is a
     /// best-effort backward-compat surface and is fully decoupled from the new
-    /// pipeline: a configure failure or a runtime crash flips this to `false`
+    /// pipeline: a `Disabled` handshake (nothing to serve — the worker exits),
+    /// a configure failure, or a runtime crash flips this to `false`
     /// and the supervisor keeps serving ingestor + ledger. The
     /// ingestor/ledger remain fatal on failure by design. Monotonic: once
     /// `false` it stays `false` — workers are never restarted (see `run`).
@@ -218,7 +219,26 @@ impl Supervisor {
                 self.register_declarations(Worker::LegacyLogs, declarations)
                     .await?;
             }
-            other => bail!("expected Ready from legacy-logs, got: {other:?}"),
+            LegacyLogsResponse::Disabled => {
+                // Nothing to serve (or handler init failed — the worker logged
+                // why). The worker exits right after sending this; reap it here
+                // so it does not sit as a zombie until plugin shutdown.
+                tracing::info!("legacy-logs reported Disabled; reaping the worker");
+                self.disable_legacy();
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(2),
+                    self.legacy_child.child.wait(),
+                )
+                .await
+                {
+                    Ok(Ok(status)) => tracing::info!("legacy-logs exited: {status}"),
+                    Ok(Err(e)) => tracing::warn!("failed to reap legacy-logs: {e}"),
+                    Err(_) => {
+                        tracing::warn!("legacy-logs did not exit within 2s after Disabled")
+                    }
+                }
+            }
+            other => bail!("expected Ready or Disabled from legacy-logs, got: {other:?}"),
         }
         Ok(())
     }
@@ -295,8 +315,15 @@ impl Supervisor {
         if let Err(e) = self.ledger.send(LedgerRequest::Shutdown).await {
             tracing::warn!("failed to send Shutdown to ledger: {e}");
         }
-        if let Err(e) = self.legacy.send(LegacyLogsRequest::Shutdown).await {
-            tracing::warn!("failed to send Shutdown to legacy-logs: {e}");
+        // A disabled legacy worker is already gone (exited or crashed) — skip
+        // the doomed send. The child wait below stays unconditional: on the
+        // crash/configure-failure paths nobody has reaped the child yet, and
+        // re-waiting an already-reaped child returns its cached exit status
+        // (tokio fuses the child after the first successful wait).
+        if self.legacy_alive {
+            if let Err(e) = self.legacy.send(LegacyLogsRequest::Shutdown).await {
+                tracing::warn!("failed to send Shutdown to legacy-logs: {e}");
+            }
         }
 
         // The agent waits 3 seconds after sending QUIT before sending SIGTERM.
@@ -438,6 +465,12 @@ impl Supervisor {
             } => self.forward_progress(transaction, done, total).await,
             LegacyLogsResponse::Ready { .. } => {
                 tracing::warn!("unexpected late Ready from legacy-logs");
+            }
+            LegacyLogsResponse::Disabled => {
+                // Only expected during the Configure handshake; a late one
+                // still means "worker is gone", so honor it.
+                tracing::warn!("unexpected late Disabled from legacy-logs, disabling it");
+                self.disable_legacy();
             }
         }
     }

--- a/src/crates/otel-plugin/src/supervisor.rs
+++ b/src/crates/otel-plugin/src/supervisor.rs
@@ -19,6 +19,12 @@ use tokio::process::Command;
 /// Maximum time to wait for a worker to connect after spawning.
 const WORKER_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Bound on reaping the legacy-logs child after it reports `Disabled`. The
+/// worker exits right after sending it, so this only fires if the worker
+/// wedges mid-exit; distinct from the shutdown budget in `shutdown_workers`,
+/// which is sized to the agent's 3s QUIT→SIGTERM window.
+const LEGACY_REAP_TIMEOUT: Duration = Duration::from_secs(2);
+
 use crate::config;
 
 /// Parse a required identity env var into a [`uuid::Uuid`], hard-erroring with a
@@ -109,13 +115,14 @@ struct Supervisor {
     // Moving a guard above its connection would SIGKILL workers before their IPC
     // channel closes, defeating graceful shutdown.
     ingestor: Connection<IngestorRequest, IngestorResponse>,
-    #[allow(dead_code)] // drop-only: SIGKILL fallback for the ingestor worker
+    /// Waited on during shutdown; SIGKILL fallback on drop.
     ingestor_child: ChildGuard,
     ledger: Connection<LedgerRequest, LedgerResponse>,
-    #[allow(dead_code)] // drop-only: SIGKILL fallback for the ledger worker
+    /// Waited on during shutdown; SIGKILL fallback on drop.
     ledger_child: ChildGuard,
     legacy: Connection<LegacyLogsRequest, LegacyLogsResponse>,
-    #[allow(dead_code)] // drop-only: SIGKILL fallback for the legacy-logs worker
+    /// Reaped on `Disabled` (`reap_legacy`) and waited on during shutdown;
+    /// SIGKILL fallback on drop.
     legacy_child: ChildGuard,
     /// Whether the legacy-logs worker is usable. The legacy viewer is a
     /// best-effort backward-compat surface and is fully decoupled from the new
@@ -225,18 +232,7 @@ impl Supervisor {
                 // so it does not sit as a zombie until plugin shutdown.
                 tracing::info!("legacy-logs reported Disabled; reaping the worker");
                 self.disable_legacy();
-                match tokio::time::timeout(
-                    std::time::Duration::from_secs(2),
-                    self.legacy_child.child.wait(),
-                )
-                .await
-                {
-                    Ok(Ok(status)) => tracing::info!("legacy-logs exited: {status}"),
-                    Ok(Err(e)) => tracing::warn!("failed to reap legacy-logs: {e}"),
-                    Err(_) => {
-                        tracing::warn!("legacy-logs did not exit within 2s after Disabled")
-                    }
-                }
+                self.reap_legacy().await;
             }
             other => bail!("expected Ready or Disabled from legacy-logs, got: {other:?}"),
         }
@@ -254,6 +250,21 @@ impl Supervisor {
         self.routing.retain(|_, w| !matches!(w, Worker::LegacyLogs));
         self.transactions
             .retain(|_, w| !matches!(w, Worker::LegacyLogs));
+    }
+
+    /// Reap the legacy-logs child with a bounded wait, logging the outcome.
+    /// Safe to call after a prior successful wait — tokio fuses the child, so
+    /// a re-wait returns the cached exit status — and a timed-out wait here is
+    /// covered later by `shutdown_workers`' unconditional wait and, last
+    /// resort, ChildGuard's SIGKILL on drop.
+    async fn reap_legacy(&mut self) {
+        match tokio::time::timeout(LEGACY_REAP_TIMEOUT, self.legacy_child.child.wait()).await {
+            Ok(Ok(status)) => tracing::info!("legacy-logs exited: {status}"),
+            Ok(Err(e)) => tracing::warn!("failed to reap legacy-logs: {e}"),
+            Err(_) => tracing::warn!(
+                "legacy-logs did not exit within {LEGACY_REAP_TIMEOUT:?} after Disabled"
+            ),
+        }
     }
 
     /// Route a function call from the agent to the appropriate worker.
@@ -471,6 +482,7 @@ impl Supervisor {
                 // still means "worker is gone", so honor it.
                 tracing::warn!("unexpected late Disabled from legacy-logs, disabling it");
                 self.disable_legacy();
+                self.reap_legacy().await;
             }
         }
     }


### PR DESCRIPTION
##### Summary

The otel-plugin supervisor spawns three worker subprocesses: ledger, ingestor, and legacy-logs. The legacy-logs worker is a read-only viewer over the journal files written by the former otel plugin. On installs where that journal directory does not exist — every fresh installation, since the former logs feature was experimental — the worker used to register no function and then park in an idle loop for the plugin's entire lifetime: a useless process with its own runtime, a few MB of RSS, and a confusing entry in the process table.

This PR makes "nothing to serve" an explicit, terminal outcome:

- A new `LegacyLogsResponse::Disabled` IPC variant. `Ready` now always means "alive and serving declarations"; `Disabled` means "nothing to view or init failed — details in the worker's logs — exiting now".
- The worker sends `Disabled` and exits in both no-serve branches (absent journal dir; handler init failure such as an unwritable cache dir). The `run_idle` loop is removed.
- The supervisor handles `Disabled` by disabling legacy routing and reaping the child with a bounded wait (`reap_legacy()` / `LEGACY_REAP_TIMEOUT`), so no zombie lingers until shutdown. A defensive late-`Disabled` arm does the same.
- `shutdown_workers` skips only the doomed IPC `Shutdown` send when the worker is already gone; the three-way child wait stays unconditional so a crashed or configure-failed worker is still reaped there (tokio fuses the child, so re-waiting an already-reaped child returns its cached exit status).

Deliberately unchanged: an existing-but-empty journal directory keeps the worker alive. The handler watches the directory, so journal files restored into it later are picked up; directory presence is the marker that the former feature was used. The ingestor and ledger lifecycles (fatal on failure by design) are untouched, and the agent-facing surface is identical — the `legacy-otel-logs` function was never declared in the no-serve case before, and still is not.

The protocol change is internal-only: supervisor and workers are the same re-exec'd binary over a private unix socket, so there is no cross-version wire concern.

##### Test Plan

- New integration tests in `src/crates/otel-legacy-logs/tests/handshake.rs` drive the real `run_worker` over a ferryboat socket:
  - absent journal dir → `Disabled` + worker future completes cleanly;
  - handler init failure (cache path nested under a regular file → `ENOTDIR`) → `Disabled` + clean exit;
  - existing (even empty) journal dir → `Ready` with one declaration, then graceful `Shutdown`.
- `cargo test` for `bridge` (19), `otel-legacy-logs` (6 unit + 3 integration), and `otel-plugin` (87) all pass; clippy clean on the changed code.
- Manual run of the built plugin with no journal dir: at t+4s the process tree shows only the ledger and ingestor children; logs show `Disabled` → `legacy-logs exited: exit status: 0` at info level, and shutdown is clean (exit 0, no warnings).

##### Additional Information

The second commit addresses review follow-ups: hoists the bounded reap into a shared `reap_legacy()` helper with a named timeout constant, reaps on the late-`Disabled` arm too, replaces the stale `drop-only` comments on the `ChildGuard` fields, adds the init-failure test, and trims the test module doc to what the tests assert.

<details> <summary>For users: How does this change affect me?</summary>

On fresh installations (or any install that never used the former otel plugin's experimental logs feature), the otel-plugin no longer keeps an idle `legacy-logs` helper process running. Nothing else changes: if you have legacy otel journal files on disk, the `legacy-otel-logs` function keeps working exactly as before.
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `legacy-logs` worker exit when there’s nothing to serve, removing an idle process and preventing zombies. Adds a `Disabled` handshake and supervisor reaping; behavior when the journal directory exists is unchanged.

- **New Features**
  - Add `LegacyLogsResponse::Disabled`; worker sends it when the journal dir is absent or handler init fails, then exits.
  - Remove the idle loop; an existing-but-empty journal dir still serves (`Ready`) and watches for restored files.
  - Supervisor handles `Disabled` by disabling legacy routing and reaping the child via `reap_legacy` with `LEGACY_REAP_TIMEOUT`; also covers a late `Disabled`.
  - Shutdown skips only the IPC `Shutdown` send if legacy already exited; still waits on the child unconditionally.
  - Add handshake tests covering absent dir, init failure, and empty dir using the real `run_worker` over a ferryboat socket.

- **Dependencies**
  - Add `tempfile` as a dev dependency in `otel-legacy-logs` for tests.

<sup>Written for commit 99a88b5ff593c1c644dd4ddded01e9bb0a2d87fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

