### PR TITLE
Add missing information for #23151

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -168,9 +168,9 @@ int help(int exitcode) {
             "  -W simple-pattern pattern string\n"
             "                           Check if string matches pattern and exit.\n\n"
 #ifdef OS_WINDOWS
-            "  -W perflibdump [key]\n"
-            "                           Dump the Windows Performance Counters Registry in JSON\n"
-            "                           to C:\\Windows\\Temp\\NetdataDump.json.\n\n"
+            "  -W perflibdump [key] [-perflibfile FILENAME]\n"
+            "                           Dump the Windows Performance Counters Registry in JSON.\n"
+            "                           Prints to stdout, or to FILENAME when -perflibfile is given.\n\n"
 #endif
     );
 
@@ -241,7 +241,7 @@ int ml_unittest(void);
 bool netdata_random_session_id_generate(void);
 
 #ifdef OS_WINDOWS
-int windows_perflib_dump(const char *key);
+int windows_perflib_dump(const char *key, const char *filename);
 #endif
 
 int unittest_prepare_rrd(const char **user) {
@@ -596,7 +596,22 @@ int netdata_main(int argc, char **argv) {
 #endif
 #ifdef OS_WINDOWS
                         else if(strcmp(optarg, "perflibdump") == 0) {
-                            return windows_perflib_dump(optind + 1 > argc ? NULL : argv[optind]);
+                            // -W perflibdump [key] [-perflibfile FILENAME]
+                            // without -perflibfile the dump goes to stdout
+                            const char *key = NULL;
+                            const char *filename = NULL;
+                            for(int a = optind; a < argc; a++) {
+                                if(strcmp(argv[a], "-perflibfile") == 0) {
+                                    if(a + 1 >= argc) {
+                                        fprintf(stderr, "Option -perflibfile requires a filename argument.\n");
+                                        return 1;
+                                    }
+                                    filename = argv[++a];
+                                }
+                                else
+                                    key = argv[a];
+                            }
+                            return windows_perflib_dump(key, filename);
                         }
                         else if(strcmp(optarg, "perflibnamestest") == 0) {
                             unittest_running = true;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -169,7 +169,8 @@ int help(int exitcode) {
             "                           Check if string matches pattern and exit.\n\n"
 #ifdef OS_WINDOWS
             "  -W perflibdump [key]\n"
-            "                           Dump the Windows Performance Counters Registry in JSON.\n\n"
+            "                           Dump the Windows Performance Counters Registry in JSON\n"
+            "                           to C:\\Windows\\Temp\\NetdataDump.json.\n\n"
 #endif
     );
 

--- a/src/libnetdata/os/windows-perflib/perflib-dump.c
+++ b/src/libnetdata/os/windows-perflib/perflib-dump.c
@@ -526,7 +526,25 @@ int windows_perflib_dump(const char *key) {
     perflibQueryAndTraverse(id, dumpDataCb, dumpObjectCb, dumpInstanceCb, dumpInstanceCounterCb, dumpCounterCb, wb);
 
     buffer_json_finalize(wb);
-    printf("\n%s\n", buffer_tostring(wb));
+
+    const char *filename = "C:\\Windows\\Temp\\NetdataDump.json";
+    FILE *fp = fopen(filename, "wb");
+    if(!fp) {
+        fprintf(stderr, "Cannot open '%s' for writing: %s\n", filename, strerror(errno));
+        perflibFreePerformanceData();
+        return 1;
+    }
+
+    size_t len = buffer_strlen(wb);
+    if(fwrite(buffer_tostring(wb), 1, len, fp) != len) {
+        fprintf(stderr, "Failed to write the perflib dump to '%s': %s\n", filename, strerror(errno));
+        fclose(fp);
+        perflibFreePerformanceData();
+        return 1;
+    }
+
+    fclose(fp);
+    fprintf(stderr, "Perflib dump written to '%s'\n", filename);
 
     perflibFreePerformanceData();
 

--- a/src/libnetdata/os/windows-perflib/perflib-dump.c
+++ b/src/libnetdata/os/windows-perflib/perflib-dump.c
@@ -505,9 +505,12 @@ bool dumpInstanceCounterCb(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE *pObjec
 }
 
 
-int windows_perflib_dump(const char *key) {
+int windows_perflib_dump(const char *key, const char *filename) {
     if(key && !*key)
         key = NULL;
+
+    if(filename && !*filename)
+        filename = NULL;
 
     PerflibNamesRegistryInitialize();
 
@@ -527,7 +530,13 @@ int windows_perflib_dump(const char *key) {
 
     buffer_json_finalize(wb);
 
-    const char *filename = "C:\\Windows\\Temp\\NetdataDump.json";
+    if(!filename) {
+        // no output file specified - print the dump to stdout
+        printf("\n%s\n", buffer_tostring(wb));
+        perflibFreePerformanceData();
+        return 0;
+    }
+
     FILE *fp = fopen(filename, "wb");
     if(!fp) {
         fprintf(stderr, "Cannot open '%s' for writing: %s\n", filename, strerror(errno));
@@ -543,7 +552,12 @@ int windows_perflib_dump(const char *key) {
         return 1;
     }
 
-    fclose(fp);
+    if(fclose(fp) != 0) {
+        fprintf(stderr, "Failed to flush/close '%s': %s\n", filename, strerror(errno));
+        perflibFreePerformanceData();
+        return 1;
+    }
+
     fprintf(stderr, "Perflib dump written to '%s'\n", filename);
 
     perflibFreePerformanceData();


### PR DESCRIPTION
##### Summary
This PR redirects missing information to finalize #23151

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Perflib dump now prints JSON to stdout by default, or to a file when -perflibfile FILENAME is provided. Updated -W help text, added file write error handling, and a completion message when writing; addresses #23151.

<sup>Written for commit 6a27ecd5a769151adf3c6f2e0087e792d8bc1589. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

