### PR TITLE
Netdata fixes part 84

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,15 +757,6 @@ int main() {
 }
 " HAVE_BUILTIN_ATOMICS)
 
-check_cxx_source_compiles("
-#include <stdint.h>
-int main(void) {
-        uint64_t a;
-        __sync_add_and_fetch(&a, 1);
-        return 0;
-}
-" ARCH_SUPPORTS_64BIT_ATOMICS)
-
 check_c_source_compiles("
 void my_printf(char const *s, ...) __attribute__((format(gnu_printf, 1, 2)));
 int main() { return 0; }

--- a/src/daemon/signal-handler.c
+++ b/src/daemon/signal-handler.c
@@ -45,6 +45,10 @@ static struct {
     { SIGXFSZ, "SIGXFSZ", 0, NETDATA_SIGNAL_DEADLY, EXIT_REASON_SIGXFSZ },
 };
 
+_Static_assert(__atomic_always_lock_free(sizeof(signals_waiting[0].count),
+                                         &signals_waiting[0].count),
+               "signal pending counters must be lock-free");
+
 typedef void (*SIGNAL_HANDLER)(int);
 typedef void (*SIGNAL_SIGACTION)(int, siginfo_t *, void *);
 

--- a/src/daemon/status-file-io.c
+++ b/src/daemon/status-file-io.c
@@ -12,6 +12,17 @@ static const char *status_file_io_fallback_dirs[] = {
     ".",
 };
 
+static bool status_file_io_obsolete_removed = false;
+static _Alignas(8) uint64_t status_file_io_tmp_attempt_counter = 0;
+
+_Static_assert(__atomic_always_lock_free(sizeof(status_file_io_obsolete_removed),
+                                         &status_file_io_obsolete_removed),
+               "signal-safe status cleanup state must be lock-free");
+_Static_assert(__alignof__(status_file_io_tmp_attempt_counter) >= sizeof(status_file_io_tmp_attempt_counter),
+               "signal-safe status temporary counter must be naturally aligned");
+_Static_assert(__atomic_always_lock_free(sizeof(status_file_io_tmp_attempt_counter), NULL),
+               "signal-safe status temporary counter must be lock-free");
+
 static void status_file_io_fallback_dirs_update(void) {
     status_file_io_fallback_dirs[0] = netdata_configured_cache_dir;
 }
@@ -43,7 +54,8 @@ static void status_file_io_remove_obsolete(const char *protected_dir, const char
     // IMPORTANT: NO LOCKS OR ALLOCATIONS HERE, THIS FUNCTION IS CALLED FROM SIGNAL HANDLERS
     // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS
 
-    FUNCTION_RUN_ONCE();
+    if(__atomic_exchange_n(&status_file_io_obsolete_removed, true, __ATOMIC_RELAXED))
+        return;
 
     char dst[FILENAME_MAX];
 
@@ -111,13 +123,11 @@ static bool status_file_io_save_this(const char *directory, const char *filename
     if(!directory || !*directory)
         return false;
 
-    static uint64_t tmp_attempt_counter = 0;
-
     char final[FILENAME_MAX];
     char temp[FILENAME_MAX];
     char tid_str[UINT64_MAX_LENGTH];
 
-    print_uint64(tid_str, __atomic_add_fetch(&tmp_attempt_counter, 1, __ATOMIC_RELAXED));
+    print_uint64(tid_str, __atomic_add_fetch(&status_file_io_tmp_attempt_counter, 1, __ATOMIC_RELAXED));
     size_t dir_len = strlen(directory);
     size_t fil_len = strlen(filename);
     size_t tid_len = strlen(tid_str);

--- a/src/daemon/status-file.c
+++ b/src/daemon/status-file.c
@@ -84,6 +84,16 @@ static SPINLOCK session_status_for_signals_spinlock = SPINLOCK_INITIALIZER;
 #define SESSION_STATUS_SNAPSHOT_COPYING (UINT32_C(1) << 31)
 static uint32_t session_status_snapshot_source_state = 0;
 
+_Static_assert(__atomic_always_lock_free(sizeof(session_status_for_signals_state),
+                                         &session_status_for_signals_state),
+               "signal status snapshot state must be lock-free");
+_Static_assert(__atomic_always_lock_free(sizeof(session_status_snapshot_source_state),
+                                         &session_status_snapshot_source_state),
+               "status snapshot source state must be lock-free");
+_Static_assert(__atomic_always_lock_free(sizeof(session_status_for_signals[0].v),
+                                         &session_status_for_signals[0].v),
+               "signal status version state must be lock-free");
+
 static void daemon_status_file_session_status_writer_enter(void) {
     uint32_t state = __atomic_load_n(&session_status_snapshot_source_state, __ATOMIC_ACQUIRE);
 
@@ -181,6 +191,19 @@ typedef struct daemon_status_fatal_snapshot {
 } DAEMON_STATUS_FATAL_SNAPSHOT;
 
 static DAEMON_STATUS_FATAL_SNAPSHOT fatal_snapshot = { 0 };
+
+_Static_assert(__atomic_always_lock_free(sizeof(fatal_snapshot.filename[0]),
+                                         &fatal_snapshot.filename[0]),
+               "fatal snapshot bytes must be lock-free");
+_Static_assert(__atomic_always_lock_free(sizeof(fatal_snapshot.thread_id),
+                                         &fatal_snapshot.thread_id),
+               "fatal snapshot thread id must be lock-free");
+_Static_assert(__atomic_always_lock_free(sizeof(fatal_snapshot.line),
+                                         &fatal_snapshot.line),
+               "fatal snapshot line must be lock-free");
+_Static_assert(__atomic_always_lock_free(sizeof(fatal_snapshot.worker_job_id),
+                                         &fatal_snapshot.worker_job_id),
+               "fatal snapshot worker id must be lock-free");
 
 static void daemon_status_file_out_of_memory(void);
 
@@ -1084,7 +1107,34 @@ static void static_save_buffer_init(void) {
     buffer_flush(static_save_buffer);
 }
 
-static bool daemon_status_file_saved = false;
+enum daemon_status_file_startup_save_state {
+    DAEMON_STATUS_FILE_STARTUP_SAVE_WAITING,
+    DAEMON_STATUS_FILE_STARTUP_SAVE_SUCCEEDED,
+    DAEMON_STATUS_FILE_STARTUP_SAVE_CLOSED,
+};
+
+static uint32_t daemon_status_file_startup_save_state = DAEMON_STATUS_FILE_STARTUP_SAVE_WAITING;
+
+_Static_assert(__atomic_always_lock_free(sizeof(daemon_status_file_startup_save_state),
+                                         &daemon_status_file_startup_save_state),
+               "signal-safe startup save state must be lock-free");
+
+static void daemon_status_file_mark_startup_save_succeeded(void) {
+    uint32_t expected = __atomic_load_n(&daemon_status_file_startup_save_state, __ATOMIC_RELAXED);
+    if(expected != DAEMON_STATUS_FILE_STARTUP_SAVE_WAITING)
+        return;
+
+    __atomic_compare_exchange_n(&daemon_status_file_startup_save_state, &expected,
+                                DAEMON_STATUS_FILE_STARTUP_SAVE_SUCCEEDED, false,
+                                __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+}
+
+static bool daemon_status_file_close_startup_save_gate(void) {
+    return __atomic_exchange_n(&daemon_status_file_startup_save_state,
+                               DAEMON_STATUS_FILE_STARTUP_SAVE_CLOSED,
+                               __ATOMIC_RELAXED) == DAEMON_STATUS_FILE_STARTUP_SAVE_SUCCEEDED;
+}
+
 static void daemon_status_file_save(BUFFER *wb, DAEMON_STATUS_FILE *ds, bool log) {
     // IMPORTANT: NO LOCKS OR ALLOCATIONS HERE, THIS FUNCTION IS CALLED FROM SIGNAL HANDLERS
     // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS
@@ -1101,7 +1151,7 @@ static void daemon_status_file_save(BUFFER *wb, DAEMON_STATUS_FILE *ds, bool log
     buffer_json_finalize(wb);
 
     if(status_file_io_save(STATUS_FILENAME, buffer_tostring(wb), buffer_strlen(wb), log))
-        daemon_status_file_saved = true;
+        daemon_status_file_mark_startup_save_succeeded();
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -1498,13 +1548,14 @@ void daemon_status_file_check_crash(void) {
            NETDATA_VERSION, msg, cause, buffer_tostring(wb));
 
     daemon_status_file_startup_step("startup(crash reports check)");
+    bool current_status_saved = daemon_status_file_close_startup_save_gate();
 
     enum crash_report_t r = check_crash_reports_config();
     if( // must be first for netdata.conf option to be used
         (r == DSF_REPORT_ALL || (this_is_a_crash && r == DSF_REPORT_CRASHES)) &&
 
         // we have a previous status, or we managed to save the current one
-        (!no_previous_status || daemon_status_file_saved) &&
+        (!no_previous_status || current_status_saved) &&
 
         // we have more than 2 restarts, or this is not a CI run
         (last_session_status.restarts > 1 || !nd_is_running_under_ci()) &&
@@ -1687,9 +1738,16 @@ static void daemon_status_file_out_of_memory(void) {
     daemon_status_file_save_twice_if_we_can_get_stack_trace(static_save_buffer, &session_status, true);
 }
 
+static bool daemon_status_file_deadly_signal_received_once = false;
+
+_Static_assert(__atomic_always_lock_free(sizeof(daemon_status_file_deadly_signal_received_once),
+                                         &daemon_status_file_deadly_signal_received_once),
+               "deadly signal one-shot state must be lock-free");
+
 NEVER_INLINE
 bool daemon_status_file_deadly_signal_received(EXIT_REASON reason, SIGNAL_CODE code, void *fault_address, bool chained_handler) {
-    FUNCTION_RUN_ONCE_RET(true);
+    if(__atomic_exchange_n(&daemon_status_file_deadly_signal_received_once, true, __ATOMIC_RELAXED))
+        return true;
 
     // IMPORTANT: NO LOCKS OR ALLOCATIONS HERE, THIS FUNCTION IS CALLED FROM SIGNAL HANDLERS
     // THIS FUNCTION MUST USE ONLY ASYNC-SIGNAL-SAFE OPERATIONS


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make status saves safe inside signal handlers by enforcing lock-free atomics and removing data races. Fixes rare crashes and missing crash reports during startup and deadly-signal paths.

- **Bug Fixes**
  - Replaced run-once macros in signal paths with relaxed atomic exchanges (obsolete cleanup and deadly-signal gate).
  - Added compile-time checks to ensure all signal-path scalars are lock-free (status flags, counters, fatal snapshot fields).
  - Aligned and made the temporary filename counter lock-free to avoid helper calls in signals.
  - Replaced the non-atomic “saved” flag with a WAITING/SUCCEEDED/CLOSED gate; crash check consumes it once.
  - Preserved I/O behavior and file formats; changes are synchronization-only.

- **Refactors**
  - Removed the unused `ARCH_SUPPORTS_64BIT_ATOMICS` probe from CMake; rely on standard atomics and existing `libatomic` linkage.

<sup>Written for commit ad5cb3e6e177026cf1959fcb1fc06f5b2078c624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

