### PR TITLE
libnetdata: own process environment state

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,10 +31,16 @@ jobs:
           files: |
             **/*.c
             **/*.cc
+            **/*.cpp
             **/*.h
             **/*.hh
+            **/*.hpp
+            **/*.m
+            **/*.mm
             **/*.in
             **/*.patch
+            src/libnetdata/environment/check-native-environment.py
+            src/libnetdata/environment/check-native-environment-unittest.py
             src/aclk/aclk-schemas/
             src/ml/dlib/
           files_ignore: |
@@ -52,6 +58,7 @@ jobs:
             .gitignore
             .github/data/distros.yml
             .github/workflows/build.yml
+            .github/workflows/checks.yml
             packaging/cmake/
             packaging/*.version
             packaging/*.checksums
@@ -119,3 +126,27 @@ jobs:
       - name: Build
         if: needs.file-check.outputs.run == 'true'
         run: docker build -f .github/dockerfiles/Dockerfile.clang .
+
+  native-environment-checks:
+    # Gated on file-check, whose source globs must cover every suffix
+    # check-native-environment.py scans (.c/.cc/.cpp/.h/.hh/.hpp/.m/.mm) or a bypass
+    # in an uncovered suffix could skip this job. No submodules: the allowlist covers
+    # only main-tree files, so scanning third-party submodule code would false-positive.
+    name: Native Environment
+    needs:
+      - file-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip Check
+        id: skip
+        if: needs.file-check.outputs.run != 'true'
+        run: echo "SKIPPED"
+      - name: Checkout
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/checkout@v7
+      - name: Test native environment checker
+        if: needs.file-check.outputs.run == 'true'
+        run: python3 src/libnetdata/environment/check-native-environment-unittest.py
+      - name: Check native environment bypass
+        if: needs.file-check.outputs.run == 'true'
+        run: python3 src/libnetdata/environment/check-native-environment.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,14 +6,22 @@ on:
     branches:
       - master
     paths:
+      - '.github/workflows/tests.yml'
       - 'CMakeLists.txt'
       - '**.c'
       - '**.h'
+      - 'src/libnetdata/environment/**'
+      - 'src/libnetdata/spawn_server/**'
+      - 'tests/run-unit-tests.sh'
   pull_request:
     paths:
+      - '.github/workflows/tests.yml'
       - 'CMakeLists.txt'
       - '**.c'
       - '**.h'
+      - 'src/libnetdata/environment/**'
+      - 'src/libnetdata/spawn_server/**'
+      - 'tests/run-unit-tests.sh'
 env:
   DISABLE_TELEMETRY: 1
 concurrency:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1039,6 +1039,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/eval/re2c_lemon/lexer.c
         src/libnetdata/eval/re2c_lemon/parser.c
         src/libnetdata/eval/re2c_lemon/parser_wrapper.c
+        src/libnetdata/environment/environment.c
+        src/libnetdata/environment/environment.h
         src/libnetdata/facets/facets.c
         src/libnetdata/facets/facets.h
         src/libnetdata/functions_evloop/functions_evloop.c
@@ -2893,6 +2895,11 @@ endif()
 
 add_executable(spawn-tester src/libnetdata/spawn_server/spawn-tester.c)
 target_link_libraries(spawn-tester libnetdata)
+
+add_executable(environment-unittest EXCLUDE_FROM_ALL
+        src/libnetdata/environment/environment-unittest.c)
+target_compile_definitions(environment-unittest PRIVATE NETDATA_INTERNAL_CHECKS=1)
+target_link_libraries(environment-unittest libnetdata)
 
 if(ENABLE_PLUGIN_APPS)
     set(APPS_PLUGIN_FILES

--- a/src/aclk/aclk_proxy.c
+++ b/src/aclk/aclk_proxy.c
@@ -100,14 +100,15 @@ static void __attribute__((destructor)) aclk_proxy_mutex_destroy(void)
     netdata_mutex_destroy(&aclk_proxy_mutex);
 }
 
-static inline int check_environment_proxy(const char **proxy, ACLK_PROXY_TYPE *type)
+static inline int check_environment_proxy(char **proxy, ACLK_PROXY_TYPE *type)
 {
     const char *var = "http_proxy";
-    char *tmp = getenv(var);
+    CLEAN_CHAR_P *tmp = nd_environment_get_dup(var);
 
     if (!tmp || !*tmp) {
+        freez(tmp);
         var = "https_proxy";
-        tmp = getenv(var);
+        tmp = nd_environment_get_dup(var);
         if (!tmp || !*tmp)
             return 1;
     }
@@ -125,6 +126,7 @@ static inline int check_environment_proxy(const char **proxy, ACLK_PROXY_TYPE *t
                "ACLK: using %s proxy %s (%s, from %s)",
                *type == PROXY_TYPE_HTTP ? "HTTP" : (*type == PROXY_TYPE_SOCKS5H ? "SOCKS5H" : "SOCKS5"),
                display, strchr(tmp, '@') ? "with credentials" : "without credentials", proxy_source);
+        tmp = NULL;
         return 0;
     }
 
@@ -154,7 +156,8 @@ const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type)
     }
 
     if (strcmp(proxy, ACLK_PROXY_ENV) == 0) {
-        if (check_environment_proxy(&proxy, type) != 0) {
+        char *environment_proxy = NULL;
+        if (check_environment_proxy(&environment_proxy, type) != 0) {
             if (cloud_config_proxy_is_explicitly_set())
                 nd_log(NDLS_DAEMON, NDLP_WARNING,
                        "ACLK: proxy is explicitly set to 'env' but neither 'http_proxy' nor 'https_proxy'"
@@ -164,6 +167,8 @@ const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type)
             proxy_source = NULL;
             proxy = NULL;
         }
+        else
+            proxy = environment_proxy;
         return proxy;
     }
 

--- a/src/claim/claim-with-api.c
+++ b/src/claim/claim-with-api.c
@@ -498,26 +498,29 @@ static bool claim_extra_opts_has_token(const char *opts, const char *token, size
 }
 
 bool claim_agent_from_environment(void) {
-    const char *url = getenv("NETDATA_CLAIM_URL");
+    CLEAN_CHAR_P *url_env = nd_environment_get_dup("NETDATA_CLAIM_URL");
+    const char *url = url_env;
     if(!url || !*url) {
         url = inicfg_get(&cloud_config, CONFIG_SECTION_GLOBAL, "url", DEFAULT_CLOUD_BASE_URL);
         if(!url || !*url) return false;
     }
 
-    const char *token = getenv("NETDATA_CLAIM_TOKEN");
+    CLEAN_CHAR_P *token = nd_environment_get_dup("NETDATA_CLAIM_TOKEN");
     if(!token || !*token)
         return false;
 
-    const char *rooms = getenv("NETDATA_CLAIM_ROOMS");
+    CLEAN_CHAR_P *rooms_env = nd_environment_get_dup("NETDATA_CLAIM_ROOMS");
+    const char *rooms = rooms_env;
     if(!rooms)
         rooms = "";
 
-    const char *proxy = getenv("NETDATA_CLAIM_PROXY");
+    CLEAN_CHAR_P *proxy_env = nd_environment_get_dup("NETDATA_CLAIM_PROXY");
+    const char *proxy = proxy_env;
     if(!proxy || !*proxy)
         proxy = "env";
 
     bool insecure = CONFIG_BOOLEAN_NO;
-    const char *from_env = getenv("NETDATA_EXTRA_CLAIM_OPTS");
+    CLEAN_CHAR_P *from_env = nd_environment_get_dup("NETDATA_EXTRA_CLAIM_OPTS");
     if(claim_extra_opts_has_token(from_env, "-insecure", sizeof("-insecure") - 1))
         insecure = CONFIG_BOOLEAN_YES;
 

--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -752,13 +752,12 @@ static void apps_lookup_netipc_try_start(void)
 
 int main(int argc, char **argv) {
     nd_log_initialize_for_external_plugins("apps.plugin");
-    netdata_threads_init_for_external_plugins(0);
 
     pagesize = (size_t)sysconf(_SC_PAGESIZE);
 
     bool send_resource_usage = true;
     {
-        const char *s = getenv("NETDATA_INTERNALS_MONITORING");
+        CLEAN_CHAR_P *s = nd_environment_get_dup("NETDATA_INTERNALS_MONITORING");
         if(s && *s && strcmp(s, "NO") == 0)
             send_resource_usage = false;
     }
@@ -766,17 +765,18 @@ int main(int argc, char **argv) {
     // since apps.plugin runs as root, prevent it from opening symbolic links
     procfile_open_flags = O_RDONLY|O_NOFOLLOW;
 
-    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
+    if(!netdata_configured_host_prefix)
+        netdata_configured_host_prefix = "";
     if(verify_netdata_host_prefix(true) == -1) exit(1);
 
-    user_config_dir = getenv("NETDATA_USER_CONFIG_DIR");
+    user_config_dir = nd_environment_get_dup("NETDATA_USER_CONFIG_DIR");
     if(user_config_dir == NULL) {
         // netdata_log_info("NETDATA_CONFIG_DIR is not passed from netdata");
         user_config_dir = CONFIG_DIR;
     }
     // else netdata_log_info("Found NETDATA_USER_CONFIG_DIR='%s'", user_config_dir);
 
-    stock_config_dir = getenv("NETDATA_STOCK_CONFIG_DIR");
+    stock_config_dir = nd_environment_get_dup("NETDATA_STOCK_CONFIG_DIR");
     if(stock_config_dir == NULL) {
         // netdata_log_info("NETDATA_CONFIG_DIR is not passed from netdata");
         stock_config_dir = LIBCONFIG_DIR;
@@ -817,6 +817,13 @@ int main(int argc, char **argv) {
 #endif
     }
 #endif
+
+    if(!os_run_dir(true))
+        fatal("Cannot establish the runtime directory");
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
+
+    netdata_threads_init_for_external_plugins(0);
 
     netdata_log_info("started on pid %d", getpid());
 

--- a/src/collectors/apps.plugin/tests/test_apps_cgroups_lookup_client_abort.c
+++ b/src/collectors/apps.plugin/tests/test_apps_cgroups_lookup_client_abort.c
@@ -221,6 +221,11 @@ static void mock_server_thread(void *arg)
 
 int main(void)
 {
+    if (nd_environment_init() != 0 || nd_environment_freeze_process() != 0) {
+        fprintf(stderr, "failed to initialize and freeze the process environment: %s\n", strerror(errno));
+        return 1;
+    }
+
     char temp_dir[] = "./apps-cgroups-lookup-abort-test.XXXXXX";
     nipc_managed_server_t server = { 0 };
     ND_THREAD *server_thread = NULL;

--- a/src/collectors/cgroups.plugin/cgroup-lookup-test/cgroup-lookup-test.c
+++ b/src/collectors/cgroups.plugin/cgroup-lookup-test/cgroup-lookup-test.c
@@ -66,7 +66,22 @@ static char *read_line_path(void)
 
 int main(int argc, char **argv)
 {
+    if(nd_environment_init() != 0) {
+        fprintf(stderr, "Cannot initialize the process environment: %s\n", strerror(errno));
+        return 1;
+    }
+
     const char *run_dir = argc > 1 ? argv[1] : os_run_dir(true);
+    if(!run_dir) {
+        fprintf(stderr, "Cannot resolve the runtime directory.\n");
+        return 1;
+    }
+
+    if(nd_environment_freeze_process() != 0) {
+        fprintf(stderr, "Cannot freeze the process environment: %s\n", strerror(errno));
+        return 1;
+    }
+
     const char *service_name = argc > 2 ? argv[2] : "cgroups-lookup";
     char **owned_paths = NULL;
     nipc_str_view_t *paths = NULL;

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -2,9 +2,8 @@
 
 #include "libnetdata/libnetdata.h"
 
-extern char **environ;
-
 static SPAWN_SERVER *spawn_server = NULL;
+static ND_ENVIRONMENT *spawn_environment = NULL;
 
 static char env_netdata_host_prefix[FILENAME_MAX + 50] = "";
 static char env_netdata_log_method[FILENAME_MAX + 50] = "";
@@ -742,40 +741,6 @@ int verify_path(const char *path) {
     return 0;
 }
 
-/*
-char *fix_path_variable(void) {
-    const char *path = getenv("PATH");
-    if(!path || !*path) return 0;
-
-    char *p = strdupz(path);
-    char *safe_path = callocz(1, strlen(p) + strlen("PATH=") + 1);
-    strcpy(safe_path, "PATH=");
-
-    int added = 0;
-    char *ptr = p;
-    while(ptr && *ptr) {
-        char *s = strsep(&ptr, ":");
-        if(s && *s) {
-            if(verify_path(s) == -1) {
-                nd_log(NDLS_COLLECTORS, NDLP_ERR, "the PATH variable includes an invalid path '%s' - removed it.", s);
-            }
-            else {
-                nd_log(NDLS_COLLECTORS, NDLP_DEBUG, "the PATH variable includes a valid path '%s'.", s);
-                if(added) strcat(safe_path, ":");
-                strcat(safe_path, s);
-                added++;
-            }
-        }
-    }
-
-    nd_log(NDLS_COLLECTORS, NDLP_DEBUG, "unsafe PATH:      '%s'.", path);
-    nd_log(NDLS_COLLECTORS, NDLP_DEBUG, "  safe PATH: '%s'.", safe_path);
-
-    freez(p);
-    return safe_path;
-}
-*/
-
 // ----------------------------------------------------------------------------
 // main
 
@@ -783,6 +748,11 @@ static void cleanup_spawn_server_on_fatal(void) {
     if(spawn_server) {
         spawn_server_destroy(spawn_server);
         spawn_server = NULL;
+    }
+
+    if(spawn_environment) {
+        nd_environment_destroy(spawn_environment);
+        spawn_environment = NULL;
     }
 }
 
@@ -805,14 +775,17 @@ int main(int argc, const char **argv) {
     // ------------------------------------------------------------------------
     // make sure NETDATA_HOST_PREFIX is safe
 
-    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
+    if(!netdata_configured_host_prefix)
+        netdata_configured_host_prefix = "";
     if(verify_netdata_host_prefix(false) == -1) exit(1);
 
     if(netdata_configured_host_prefix[0] != '\0' && verify_path(netdata_configured_host_prefix) == -1)
         fatal("invalid NETDATA_HOST_PREFIX '%s'", netdata_configured_host_prefix);
 
     int helper = 1;
-    if (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL)
+    CLEAN_CHAR_P *kubernetes_service_host = nd_environment_get_dup("KUBERNETES_SERVICE_HOST");
+    CLEAN_CHAR_P *kubernetes_service_port = nd_environment_get_dup("KUBERNETES_SERVICE_PORT");
+    if(kubernetes_service_host && kubernetes_service_port)
         helper = 0;
 
     // ------------------------------------------------------------------------
@@ -821,27 +794,37 @@ int main(int argc, const char **argv) {
     // the first environment variable is a fixed PATH=
     snprintfz(env_netdata_host_prefix, sizeof(env_netdata_host_prefix) - 1, "NETDATA_HOST_PREFIX=%s", netdata_configured_host_prefix);
 
-    char *s;
+    CLEAN_CHAR_P *log_method = nd_environment_get_dup("NETDATA_LOG_METHOD");
+    snprintfz(env_netdata_log_method, sizeof(env_netdata_log_method) - 1,
+              "NETDATA_LOG_METHOD=%s", nd_log_method_for_external_plugins(log_method));
 
-    s = getenv("NETDATA_LOG_METHOD");
-    snprintfz(env_netdata_log_method, sizeof(env_netdata_log_method) - 1, "NETDATA_LOG_METHOD=%s", nd_log_method_for_external_plugins(s));
+    CLEAN_CHAR_P *log_format = nd_environment_get_dup("NETDATA_LOG_FORMAT");
+    if(log_format)
+        snprintfz(env_netdata_log_format, sizeof(env_netdata_log_format) - 1, "NETDATA_LOG_FORMAT=%s", log_format);
 
-    s = getenv("NETDATA_LOG_FORMAT");
-    if (s)
-        snprintfz(env_netdata_log_format, sizeof(env_netdata_log_format) - 1, "NETDATA_LOG_FORMAT=%s", s);
-
-    s = getenv("NETDATA_LOG_LEVEL");
-    if (s)
-        snprintfz(env_netdata_log_level, sizeof(env_netdata_log_level) - 1, "NETDATA_LOG_LEVEL=%s", s);
+    CLEAN_CHAR_P *log_level = nd_environment_get_dup("NETDATA_LOG_LEVEL");
+    if(log_level)
+        snprintfz(env_netdata_log_level, sizeof(env_netdata_log_level) - 1, "NETDATA_LOG_LEVEL=%s", log_level);
 
     // ------------------------------------------------------------------------
 
     // This is a dedicated privileged process; no child may inherit its caller's environment.
-    environ = environment;
+    const char *runtime_directory = os_run_dir(true);
+    spawn_environment = nd_environment_create_isolated((const char *const *)environment);
+    spawn_server = runtime_directory && spawn_environment ?
+        spawn_server_create(SPAWN_SERVER_OPTION_EXEC | SPAWN_SERVER_OPTION_CALLBACK, NULL, spawn_callback,
+                            argc, argv, spawn_environment, runtime_directory) : NULL;
+    if(!spawn_server) {
+        cleanup_spawn_server_on_fatal();
+        fatal("cannot create the restricted spawn server");
+    }
 
-    spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_EXEC | SPAWN_SERVER_OPTION_CALLBACK, NULL, spawn_callback, argc, argv);
-    // Spawn initialization may publish its detected runtime directory; do not pass it to helper requests.
-    environ = environment;
+    if(nd_environment_freeze_process() != 0) {
+        int error = errno;
+        cleanup_spawn_server_on_fatal();
+        fatal("cannot freeze the process environment: %s", strerror(error));
+    }
+
     nd_log_register_fatal_final_cb(cleanup_spawn_server_on_fatal);
 
     if(argc == 2 && (!strcmp(argv[1], "version") || !strcmp(argv[1], "-version") || !strcmp(argv[1], "--version") || !strcmp(argv[1], "-v") || !strcmp(argv[1], "-V"))) {
@@ -890,6 +873,8 @@ int main(int argc, const char **argv) {
 
     spawn_server_destroy(spawn_server);
     spawn_server = NULL;
+    nd_environment_destroy(spawn_environment);
+    spawn_environment = NULL;
 
     if(found <= 0) return 1;
     return 0;

--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1366,7 +1366,9 @@ void cgroups_main(void *ptr) {
     worker_register_job_name(WORKER_CGROUPS_READ, "read");
     worker_register_job_name(WORKER_CGROUPS_CHART, "chart");
 
-    if (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL) {
+    CLEAN_CHAR_P *kubernetes_service_host = nd_environment_get_dup("KUBERNETES_SERVICE_HOST");
+    CLEAN_CHAR_P *kubernetes_service_port = nd_environment_get_dup("KUBERNETES_SERVICE_PORT");
+    if (kubernetes_service_host && kubernetes_service_port) {
         is_inside_k8s = true;
         cgroup_enable_cpuacct_cpu_shares = true;
     }

--- a/src/collectors/cgroups.plugin/tests/test_cgroup_lookup_netipc.c
+++ b/src/collectors/cgroups.plugin/tests/test_cgroup_lookup_netipc.c
@@ -259,6 +259,11 @@ static bool test_snapshot_lookup_helpers(void)
 
 int main(void)
 {
+    if (nd_environment_init() != 0 || nd_environment_freeze_process() != 0) {
+        fprintf(stderr, "failed to initialize and freeze the process environment: %s\n", strerror(errno));
+        return 1;
+    }
+
     char temp_dir[] = "./cgroup-lookup-netipc-test.XXXXXX";
     char service_name[64];
     const char *known_path = "/docker/0123456789abcdef";

--- a/src/collectors/cups.plugin/cups_plugin.c
+++ b/src/collectors/cups.plugin/cups_plugin.c
@@ -315,6 +315,8 @@ void reset_metrics() {
 
 int main(int argc, char **argv) {
     nd_log_initialize_for_external_plugins("cups.plugin");
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
     netdata_threads_init_for_external_plugins(0);
 
     parse_command_line(argc, argv);

--- a/src/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/src/collectors/debugfs.plugin/debugfs_plugin.c
@@ -187,18 +187,18 @@ static void debugfs_parse_args(int argc, char **argv)
 int main(int argc, char **argv)
 {
     nd_log_initialize_for_external_plugins("debugfs.plugin");
-    netdata_threads_init_for_external_plugins(0);
 
-    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
+    if(!netdata_configured_host_prefix)
+        netdata_configured_host_prefix = "";
     if (verify_netdata_host_prefix(true) == -1)
         exit(1);
 
-    user_config_dir = getenv("NETDATA_USER_CONFIG_DIR");
+    user_config_dir = nd_environment_get_dup("NETDATA_USER_CONFIG_DIR");
     if (user_config_dir == NULL) {
         user_config_dir = CONFIG_DIR;
     }
 
-    stock_config_dir = getenv("NETDATA_STOCK_CONFIG_DIR");
+    stock_config_dir = nd_environment_get_dup("NETDATA_STOCK_CONFIG_DIR");
     if (stock_config_dir == NULL) {
         // netdata_log_info("NETDATA_CONFIG_DIR is not passed from netdata");
         stock_config_dir = LIBCONFIG_DIR;
@@ -235,6 +235,11 @@ int main(int argc, char **argv)
     }
 
     debugfs_parse_args(argc, argv);
+
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
+
+    netdata_threads_init_for_external_plugins(0);
 
     // the event loop for functions served by the modules
     static bool debugfs_plugin_exit = false;

--- a/src/collectors/debugfs.plugin/module-libsensors.c
+++ b/src/collectors/debugfs.plugin/module-libsensors.c
@@ -1128,7 +1128,8 @@ static void sensor_process(SENSOR *s, int update_every, const char *name) {
 }
 
 static FILE *sensors_open_file(const char *env_var, const char *def_dir, const char *file) {
-    const char *dir = getenv(env_var);
+    CLEAN_CHAR_P *env_dir = nd_environment_get_dup(env_var);
+    const char *dir = env_dir;
     if(!dir || !*dir)
         dir = def_dir;
 
@@ -1324,7 +1325,7 @@ static void libsensors_function_sensors(
 
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_DEFAULT);
 
-    const char *hostname = getenv("NETDATA_HOSTNAME");
+    CLEAN_CHAR_P *hostname = nd_environment_get_dup("NETDATA_HOSTNAME");
     buffer_json_member_add_string(wb, "hostname", hostname ? hostname : "localhost");
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -1184,19 +1184,19 @@ static void ebpf_allocate_common_vectors()
 static void ebpf_set_global_variables()
 {
     // Get environment variables
-    ebpf_plugin_dir = getenv("NETDATA_PLUGINS_DIR");
+    ebpf_plugin_dir = nd_environment_get_dup("NETDATA_PLUGINS_DIR");
     if (!ebpf_plugin_dir)
         ebpf_plugin_dir = PLUGINS_DIR;
 
-    ebpf_user_config_dir = getenv("NETDATA_USER_CONFIG_DIR");
+    ebpf_user_config_dir = nd_environment_get_dup("NETDATA_USER_CONFIG_DIR");
     if (!ebpf_user_config_dir)
         ebpf_user_config_dir = CONFIG_DIR;
 
-    ebpf_stock_config_dir = getenv("NETDATA_STOCK_CONFIG_DIR");
+    ebpf_stock_config_dir = nd_environment_get_dup("NETDATA_STOCK_CONFIG_DIR");
     if (!ebpf_stock_config_dir)
         ebpf_stock_config_dir = LIBCONFIG_DIR;
 
-    ebpf_configured_log_dir = getenv("NETDATA_LOG_DIR");
+    ebpf_configured_log_dir = nd_environment_get_dup("NETDATA_LOG_DIR");
     if (!ebpf_configured_log_dir)
         ebpf_configured_log_dir = LOG_DIR;
 
@@ -1668,7 +1668,7 @@ void ebpf_send_statistic_data()
  */
 static void update_internal_metric_variable()
 {
-    const char *s = getenv("NETDATA_INTERNALS_MONITORING");
+    CLEAN_CHAR_P *s = nd_environment_get_dup("NETDATA_INTERNALS_MONITORING");
     if (s && *s && strcmp(s, "NO") == 0)
         publish_internal_metrics = false;
 }
@@ -2296,7 +2296,6 @@ int main(int argc, char **argv)
 #endif
 
     nd_log_initialize_for_external_plugins(NETDATA_EBPF_PLUGIN_NAME);
-    netdata_threads_init_for_external_plugins(0);
 
     libjudy_malloc_init();
 
@@ -2319,7 +2318,8 @@ int main(int argc, char **argv)
 
     ebpf_mutex_initialize();
 
-    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
+    if(!netdata_configured_host_prefix)
+        netdata_configured_host_prefix = "";
     if (verify_netdata_host_prefix(true) == -1)
         ebpf_exit(1);
 
@@ -2338,6 +2338,11 @@ int main(int argc, char **argv)
     read_local_ports("/proc/net/tcp6", IPPROTO_TCP);
     read_local_ports("/proc/net/udp", IPPROTO_UDP);
     read_local_ports("/proc/net/udp6", IPPROTO_UDP);
+
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
+
+    netdata_threads_init_for_external_plugins(0);
 
     ebpf_set_static_routine();
 

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -3037,7 +3037,7 @@ void ebpf_parse_service_name_section(struct config *cfg)
         }
     }
 
-    char *port_string = getenv("NETDATA_LISTEN_PORT");
+    CLEAN_CHAR_P *port_string = nd_environment_get_dup("NETDATA_LISTEN_PORT");
     if (port_string) {
         // if variable has an invalid value, we assume netdata is using 19999
         int default_port = str2i(port_string);

--- a/src/collectors/ebpf.plugin/libbpf_api/ebpf.c
+++ b/src/collectors/ebpf.plugin/libbpf_api/ebpf.c
@@ -204,7 +204,8 @@ static int kernel_is_rejected()
         version_string_len = strlen(version_string);
 
     // Open a file with a list of rejected kernels
-    char *config_dir = getenv("NETDATA_USER_CONFIG_DIR");
+    CLEAN_CHAR_P *user_config_dir = nd_environment_get_dup("NETDATA_USER_CONFIG_DIR");
+    const char *config_dir = user_config_dir;
     if (config_dir == NULL) {
         config_dir = CONFIG_DIR;
     }
@@ -219,7 +220,8 @@ static int kernel_is_rejected()
         kernel_reject_list = fopen(filename, "r");
 
         if (!kernel_reject_list) {
-            config_dir = getenv("NETDATA_STOCK_CONFIG_DIR");
+            CLEAN_CHAR_P *stock_config_dir = nd_environment_get_dup("NETDATA_STOCK_CONFIG_DIR");
+            config_dir = stock_config_dir;
             if (config_dir == NULL) {
                 config_dir = LIBCONFIG_DIR;
             }

--- a/src/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/src/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1652,6 +1652,8 @@ static void plugin_exit(int code) {
 
 int main (int argc, char **argv) {
     nd_log_initialize_for_external_plugins("freeipmi.plugin");
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
     netdata_threads_init_for_external_plugins(0); // set the default threads stack size here
 
     bool netdata_do_sel = IPMI_ENABLE_SEL_BY_DEFAULT;

--- a/src/collectors/macos-logs.plugin/macos-logs.c
+++ b/src/collectors/macos-logs.plugin/macos-logs.c
@@ -642,6 +642,8 @@ int main(int argc, char **argv) {
 
     nd_thread_tag_set("macos-logs.plugin");
     nd_log_initialize_for_external_plugins("macos-logs.plugin");
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
     netdata_threads_init_for_external_plugins(0);
 
     used_hashes_registry = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);

--- a/src/collectors/network-viewer.plugin/network-viewer-windows.c
+++ b/src/collectors/network-viewer.plugin/network-viewer-windows.c
@@ -1278,6 +1278,8 @@ int main(int argc, char **argv)
 {
     netdata_mutex_init(&stdout_mutex);
     nd_log_initialize_for_external_plugins("network-viewer.plugin");
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
     netdata_threads_init_for_external_plugins(0);
 
     PerflibNamesRegistryInitialize();

--- a/src/collectors/network-viewer.plugin/network-viewer.c
+++ b/src/collectors/network-viewer.plugin/network-viewer.c
@@ -333,9 +333,12 @@ struct sockets_stats {
 
 static void nv_pid_append(uint32_t **pids, size_t *count, size_t *capacity, pid_t pid);
 
-static inline const char *network_viewer_machine_guid(void) {
-    const char *guid = getenv("NETDATA_REGISTRY_UNIQUE_ID");
-    return (guid && *guid) ? guid : NULL;
+static inline char *network_viewer_machine_guid(void) {
+    char *guid = nd_environment_get_dup("NETDATA_REGISTRY_UNIQUE_ID");
+    if(guid && !*guid)
+        freez(guid);
+
+    return guid;
 }
 
 static inline void topology_options_defaults(NV_TOPOLOGY_OPTIONS *opts) {
@@ -2225,7 +2228,7 @@ static bool topology_prepare_context(
     if(!os_hostname(ctx->hostname, sizeof(ctx->hostname), netdata_configured_host_prefix))
         snprintf(ctx->hostname, sizeof(ctx->hostname), "%s", "localhost");
 
-    const char *machine_guid = network_viewer_machine_guid();
+    CLEAN_CHAR_P *machine_guid = network_viewer_machine_guid();
     if(machine_guid)
         snprintf(ctx->machine_guid, sizeof(ctx->machine_guid), "%s", machine_guid);
 
@@ -7325,18 +7328,33 @@ int main(int argc, char **argv) {
 
     nd_thread_tag_set("NETWORK-VIEWER");
     nd_log_initialize_for_external_plugins("network-viewer.plugin");
-    netdata_threads_init_for_external_plugins(0);
 
-    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
+    if(!netdata_configured_host_prefix)
+        netdata_configured_host_prefix = "";
     if(verify_netdata_host_prefix(true) == -1) exit(1);
 
 #if defined(LOCAL_SOCKETS_USE_SETNS)
-    spawn_srv = spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, "setns", local_sockets_spawn_server_callback, argc, (const char **)argv);
+    const char *runtime_directory = os_run_dir(true);
+    spawn_srv = runtime_directory ?
+        spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, "setns", local_sockets_spawn_server_callback,
+                            argc, (const char **)argv, nd_environment_process(), runtime_directory) : NULL;
     if(spawn_srv == NULL) {
         fprintf(stderr, "Cannot create spawn server.\n");
         exit(1);
     }
 #endif
+
+    if(nd_environment_freeze_process() != 0) {
+        int error = errno;
+#if defined(LOCAL_SOCKETS_USE_SETNS)
+        spawn_server_destroy(spawn_srv);
+        spawn_srv = NULL;
+#endif
+        fprintf(stderr, "Cannot freeze the process environment: %s\n", strerror(error));
+        exit(1);
+    }
+
+    netdata_threads_init_for_external_plugins(0);
 
     cached_usernames_init();
     update_cached_host_users();

--- a/src/collectors/network-viewer.plugin/tests/test_network_viewer_apps_lookup_client.c
+++ b/src/collectors/network-viewer.plugin/tests/test_network_viewer_apps_lookup_client.c
@@ -512,6 +512,11 @@ cleanup_server:
 
 int main(void)
 {
+    if (nd_environment_init() != 0 || nd_environment_freeze_process() != 0) {
+        fprintf(stderr, "failed to initialize and freeze the process environment: %s\n", strerror(errno));
+        return 1;
+    }
+
     char temp_dir[] = "./network-viewer-apps-lookup-test.XXXXXX";
     bool ok = false;
 

--- a/src/collectors/nfacct.plugin/plugin_nfacct.c
+++ b/src/collectors/nfacct.plugin/plugin_nfacct.c
@@ -747,6 +747,8 @@ void nfacct_signals()
 
 int main(int argc, char **argv) {
     nd_log_initialize_for_external_plugins("nfacct.plugin");
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
     netdata_threads_init_for_external_plugins(0);
 
     // ------------------------------------------------------------------------

--- a/src/collectors/perf.plugin/perf_plugin.c
+++ b/src/collectors/perf.plugin/perf_plugin.c
@@ -1286,6 +1286,8 @@ void parse_command_line(int argc, char **argv) {
 
 int main(int argc, char **argv) {
     nd_log_initialize_for_external_plugins("perf.plugin");
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
     netdata_threads_init_for_external_plugins(0);
 
     parse_command_line(argc, argv);

--- a/src/collectors/proc.plugin/proc_net_dev.c
+++ b/src/collectors/proc.plugin/proc_net_dev.c
@@ -1718,7 +1718,9 @@ void netdev_main(void *ptr_is_null __maybe_unused)
     worker_register("NETDEV");
     worker_register_job_name(0, "netdev");
 
-    if (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL)
+    CLEAN_CHAR_P *kubernetes_service_host = nd_environment_get_dup("KUBERNETES_SERVICE_HOST");
+    CLEAN_CHAR_P *kubernetes_service_port = nd_environment_get_dup("KUBERNETES_SERVICE_PORT");
+    if (kubernetes_service_host && kubernetes_service_port)
         virtual_device_collect_delay_secs = 300;
 
     rrd_function_add_inline(localhost, NULL, "network-interfaces", 10,

--- a/src/collectors/proc.plugin/run_reboot_required.c
+++ b/src/collectors/proc.plugin/run_reboot_required.c
@@ -29,7 +29,8 @@ int do_run_reboot_required(int update_every, usec_t dt) {
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/var/run");
 
         // Disable monitoring if running inside a container and the directory is not mounted from the host
-        if (getenv("NETDATA_LISTENER_PORT") != NULL) {
+        CLEAN_CHAR_P *listener_port = nd_environment_get_dup("NETDATA_LISTENER_PORT");
+        if (listener_port) {
             if (!netdata_configured_host_prefix || !*netdata_configured_host_prefix || is_dir_mounted(filename) != 1) {
                 return 1;
             }

--- a/src/collectors/slabinfo.plugin/slabinfo.c
+++ b/src/collectors/slabinfo.plugin/slabinfo.c
@@ -345,6 +345,8 @@ void usage(void) {
 
 int main(int argc, char **argv) {
     nd_log_initialize_for_external_plugins("slabinfo.plugin");
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
     netdata_threads_init_for_external_plugins(0);
 
     program_name = argv[0];

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -401,9 +401,9 @@ int main(int argc, char **argv)
 
     nd_thread_tag_set("sd-jrnl.plugin");
     nd_log_initialize_for_external_plugins("systemd-journal.plugin");
-    netdata_threads_init_for_external_plugins(0);
 
-    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
+    if(!netdata_configured_host_prefix)
+        netdata_configured_host_prefix = "";
     if (verify_netdata_host_prefix(true) == -1)
         exit(1);
 
@@ -438,6 +438,11 @@ int main(int argc, char **argv)
         function_systemd_journal("123", buf, &stop_monotonic_ut, &cancelled, NULL, HTTP_ACCESS_ALL, NULL, NULL);
         exit(1);
     }
+
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
+
+    netdata_threads_init_for_external_plugins(0);
 
     // ------------------------------------------------------------------------
     // watcher thread

--- a/src/collectors/systemd-units.plugin/plugin_systemd_units.c
+++ b/src/collectors/systemd-units.plugin/plugin_systemd_units.c
@@ -2202,9 +2202,9 @@ int main(int argc __maybe_unused, char **argv __maybe_unused)
 {
     nd_thread_tag_set("sd-unit.plugin");
     nd_log_initialize_for_external_plugins("systemd-units.plugin");
-    netdata_threads_init_for_external_plugins(0);
 
-    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
+    if(!netdata_configured_host_prefix)
+        netdata_configured_host_prefix = "";
     if (verify_netdata_host_prefix(true) == -1)
         exit(1);
 
@@ -2218,6 +2218,11 @@ int main(int argc __maybe_unused, char **argv __maybe_unused)
             "123", "systemd-units", &stop_monotonic_ut, &cancelled, NULL, HTTP_ACCESS_ALL, NULL, NULL);
         exit(1);
     }
+
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
+
+    netdata_threads_init_for_external_plugins(0);
 
     // ------------------------------------------------------------------------
     // the event loop for functions

--- a/src/collectors/utils/local_listeners.c
+++ b/src/collectors/utils/local_listeners.c
@@ -30,6 +30,11 @@ static void print_local_listeners(LS_STATE *ls __maybe_unused, const LOCAL_SOCKE
 // --------------------------------------------------------------------------------------------------------------------
 
 int main(int argc, char **argv) {
+    if(nd_environment_init() != 0) {
+        fprintf(stderr, "Cannot initialize the process environment: %s\n", strerror(errno));
+        return 1;
+    }
+
     static struct rusage started, ended;
     getrusage(RUSAGE_SELF, &started);
     bool debug = false;
@@ -64,8 +69,8 @@ int main(int argc, char **argv) {
         .listening_ports_hashtable = { 0 },
     };
 
-    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
-    if(!netdata_configured_host_prefix) netdata_configured_host_prefix = "";
+    CLEAN_CHAR_P *configured_host_prefix = nd_environment_get_dup("NETDATA_HOST_PREFIX");
+    netdata_configured_host_prefix = configured_host_prefix ? configured_host_prefix : "";
 
     // Validate host prefix (must be a real procfs/sysfs mount)
     if(verify_netdata_host_prefix(true) == -1)
@@ -262,7 +267,10 @@ int main(int argc, char **argv) {
     }
 
 #if defined(LOCAL_SOCKETS_USE_SETNS)
-    SPAWN_SERVER *spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, NULL, local_sockets_spawn_server_callback, argc, (const char **)argv);
+    const char *runtime_directory = os_run_dir(true);
+    SPAWN_SERVER *spawn_server = runtime_directory ?
+        spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, NULL, local_sockets_spawn_server_callback,
+                            argc, (const char **)argv, nd_environment_process(), runtime_directory) : NULL;
     if(spawn_server == NULL) {
         fprintf(stderr, "Cannot create spawn server.\n");
         exit(1);
@@ -270,6 +278,15 @@ int main(int argc, char **argv) {
 
     ls.spawn_server = spawn_server;
 #endif
+
+    if(nd_environment_freeze_process() != 0) {
+        int error = errno;
+#if defined(LOCAL_SOCKETS_USE_SETNS)
+        spawn_server_destroy(spawn_server);
+#endif
+        fprintf(stderr, "Cannot freeze the process environment: %s\n", strerror(error));
+        return 1;
+    }
 
     local_sockets_process(&ls);
 

--- a/src/collectors/windows-events.plugin/windows-events.c
+++ b/src/collectors/windows-events.plugin/windows-events.c
@@ -1299,6 +1299,8 @@ void function_windows_events(const char *transaction, char *function, usec_t *st
 int main(int argc __maybe_unused, char **argv __maybe_unused) {
     nd_thread_tag_set("wevt.plugin");
     nd_log_initialize_for_external_plugins("windows-events.plugin");
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
     netdata_threads_init_for_external_plugins(0);
 
     // ------------------------------------------------------------------------

--- a/src/collectors/windows.plugin/GetHardwareInfo.c
+++ b/src/collectors/windows.plugin/GetHardwareInfo.c
@@ -6,7 +6,7 @@
 #include "driver/netdata_driver.h"
 
 static const char *srv_name = "NetdataDriver";
-static const char *drv_path = "%SystemRoot%\\system32\\drivers\\netdata_driver.sys";
+static const char driver_path_suffix[] = "\\drivers\\netdata_driver.sys";
 
 struct cpu_data {
     RRDDIM *rd_cpu_temp;
@@ -35,19 +35,20 @@ static const int IOCTL_RETRY_DELAY_MS = 10;
 static const int THREAD_JOIN_FALLBACK_WAIT_MS = 2000;
 #define INVALID_TEMP ((collected_number)(-1))
 
-static bool netdata_expand_driver_path(char *expanded_path, size_t expanded_path_size)
+static bool netdata_get_driver_path(char *path, size_t path_size)
 {
-    DWORD ret = ExpandEnvironmentStringsA(drv_path, expanded_path, (DWORD)expanded_path_size);
+    UINT ret = GetSystemDirectoryA(path, (UINT)path_size);
     if (ret == 0) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot expand environment strings. Error= %lu \n", GetLastError());
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot get the Windows system directory. Error= %lu\n", GetLastError());
         return false;
     }
 
-    if (ret > expanded_path_size) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Expanded driver path exceeds buffer size (%lu bytes needed)\n", ret);
+    if ((size_t)ret >= path_size || (size_t)ret + sizeof(driver_path_suffix) > path_size) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Windows driver path exceeds buffer size\n");
         return false;
     }
 
+    memcpy(&path[ret], driver_path_suffix, sizeof(driver_path_suffix));
     return true;
 }
 
@@ -94,8 +95,8 @@ int netdata_install_driver()
         return -1;
     }
 
-    char expanded_path[MAX_PATH];
-    if (!netdata_expand_driver_path(expanded_path, sizeof(expanded_path))) {
+    char driver_path[MAX_PATH];
+    if (!netdata_get_driver_path(driver_path, sizeof(driver_path))) {
         CloseServiceHandle(scm);
         return -1;
     }
@@ -109,7 +110,7 @@ int netdata_install_driver()
         SERVICE_KERNEL_DRIVER,
         SERVICE_DEMAND_START,
         SERVICE_ERROR_NORMAL,
-        expanded_path,
+        driver_path,
         NULL,
         NULL,
         NULL,
@@ -130,7 +131,7 @@ int netdata_install_driver()
                     SERVICE_KERNEL_DRIVER,
                     SERVICE_DEMAND_START,
                     SERVICE_ERROR_NORMAL,
-                    expanded_path,
+                    driver_path,
                     NULL,
                     NULL,
                     NULL,
@@ -404,17 +405,17 @@ static void netdata_detect_cpu()
 
 static int initialize()
 {
-    char expanded_path[MAX_PATH];
-    if (!netdata_expand_driver_path(expanded_path, sizeof(expanded_path))) {
+    char driver_path[MAX_PATH];
+    if (!netdata_get_driver_path(driver_path, sizeof(driver_path))) {
         return -1;
     }
 
-    if (GetFileAttributesA(expanded_path) == INVALID_FILE_ATTRIBUTES) {
+    if (GetFileAttributesA(driver_path) == INVALID_FILE_ATTRIBUTES) {
         nd_log(
             NDLS_COLLECTORS,
             NDLP_ERR,
             "Driver not found at '%s'. Please ensure the driver is properly installed.\n",
-            expanded_path);
+            driver_path);
         return -1;
     }
 

--- a/src/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/src/collectors/xenstat.plugin/xenstat_plugin.c
@@ -926,6 +926,8 @@ int main(int argc, char **argv) {
     program_name = PLUGIN_XENSTAT_NAME;
 
     nd_log_initialize_for_external_plugins(PLUGIN_XENSTAT_NAME);
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
     netdata_threads_init_for_external_plugins(0);
 
     // ------------------------------------------------------------------------

--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -888,10 +888,13 @@ void get_system_timezone(void)
 #ifndef OS_WINDOWS
     // avoid flood calls to stat(/etc/localtime)
     // http://stackoverflow.com/questions/4554271/how-to-avoid-excessive-stat-etc-localtime-calls-in-strftime-on-linux
-    const char *tz = getenv("TZ");
+    CLEAN_CHAR_P *tz = nd_environment_get_dup("TZ");
     if (!tz || !*tz) {
-        setenv("TZ", inicfg_get(&netdata_config, CONFIG_SECTION_ENV_VARS, "TZ", ":/etc/localtime"), 1);
-        tz = getenv("TZ");
+        if(nd_environment_set(
+               "TZ", inicfg_get(&netdata_config, CONFIG_SECTION_ENV_VARS, "TZ", ":/etc/localtime"), true) != 0)
+            fatal("Cannot publish required environment variable 'TZ': %s", strerror(errno));
+        freez(tz);
+        tz = nd_environment_get_dup("TZ");
     }
 
     // use the TZ variable if it's an explicit IANA name (not a path starting with ':')
@@ -1145,9 +1148,8 @@ static bool timezone_info_from_tzfile(const char *timezone, time_t t, char *abbr
     if (!timezone_name_is_safe_tzdb_path(timezone))
         return false;
 
-    const char *tzdir = getenv("TZDIR");
-    if (!tzdir || !*tzdir)
-        tzdir = "/usr/share/zoneinfo";
+    CLEAN_CHAR_P *tzdir_env = nd_environment_get_dup("TZDIR");
+    const char *tzdir = (tzdir_env && *tzdir_env) ? tzdir_env : "/usr/share/zoneinfo";
 
     char path[FILENAME_MAX + 1];
     snprintfz(path, sizeof(path), "%s/%s", tzdir, timezone);
@@ -1332,7 +1334,7 @@ bool analytics_check_enabled(void) {
 
     if(access(filename, R_OK) != 0) {
         // the file is not there, check the environment variable
-        const char *s = getenv("DISABLE_TELEMETRY");
+        CLEAN_CHAR_P *s = nd_environment_get_dup("DISABLE_TELEMETRY");
         netdata_anonymous_statistics_enabled = !s || !*s;
     }
     else

--- a/src/daemon/config/netdata-conf-global.c
+++ b/src/daemon/config/netdata-conf-global.c
@@ -3,6 +3,11 @@
 #include "netdata-conf-global.h"
 #include "daemon/common.h"
 
+static void set_required_environment(const char *name, const char *value) {
+    if(nd_environment_set(name, value, true) != 0)
+        fatal("Cannot publish required environment variable '%s': %s", name, strerror(errno));
+}
+
 size_t netdata_conf_cpus(void) {
     static size_t processors = 0;
     static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
@@ -35,7 +40,7 @@ size_t netdata_conf_cpus(void) {
 
     char buf[24];
     snprintfz(buf, sizeof(buf), "%zu", cached_processors);
-    nd_setenv("NETDATA_CONF_CPUS", buf, 1);
+    set_required_environment("NETDATA_CONF_CPUS", buf);
     __atomic_store_n(&processors, cached_processors, __ATOMIC_RELEASE);
 
 skip:
@@ -56,7 +61,7 @@ void netdata_conf_glibc_malloc_initialize(size_t wanted_arenas, size_t trim_thre
 
     char buf[32];
     snprintfz(buf, sizeof(buf), "%zu", wanted_arenas);
-    setenv("MALLOC_ARENA_MAX", buf, true);
+    set_required_environment("MALLOC_ARENA_MAX", buf);
 
 #if defined(HAVE_C_MALLOPT)
     wanted_arenas = inicfg_get_number(&netdata_config, CONFIG_SECTION_GLOBAL, "glibc malloc arena max for netdata", wanted_arenas);
@@ -133,7 +138,7 @@ void libuv_initialize(void) {
 
     char buf[20 + 1];
     snprintfz(buf, sizeof(buf) - 1, "%d", libuv_worker_threads);
-    setenv("UV_THREADPOOL_SIZE", buf, 1);
+    set_required_environment("UV_THREADPOOL_SIZE", buf);
 }
 
 void netdata_conf_section_global_hostname(void) {
@@ -173,7 +178,7 @@ void netdata_conf_section_global_wmi_timeout(void) {
 
     char buf[32];
     snprintfz(buf, sizeof(buf), "%lld", configured);
-    nd_setenv("NETDATA_WMI_STARTUP_TIMEOUT_MS", buf, 1);
+    set_required_environment("NETDATA_WMI_STARTUP_TIMEOUT_MS", buf);
 #endif
 }
 
@@ -190,4 +195,3 @@ void netdata_conf_section_global_run_as_user(const char **user) {
         *user = inicfg_get(&netdata_config, CONFIG_SECTION_GLOBAL, "run as user", (passwd && passwd->pw_name)?passwd->pw_name:"");
     }
 }
-

--- a/src/daemon/config/netdata-conf-logs.c
+++ b/src/daemon/config/netdata-conf-logs.c
@@ -37,7 +37,8 @@ void netdata_conf_section_logs(void) {
     logs = (unsigned long)inicfg_get_number(&netdata_config, CONFIG_SECTION_LOGS, "logs to trigger flood protection", (long long int)logs);
     nd_log_set_flood_protection(logs, period);
 
-    const char *netdata_log_level = getenv("NETDATA_LOG_LEVEL");
+    CLEAN_CHAR_P *netdata_log_level_env = nd_environment_get_dup("NETDATA_LOG_LEVEL");
+    const char *netdata_log_level = netdata_log_level_env;
     netdata_log_level = netdata_log_level ? nd_log_id2priority(nd_log_priority2id(netdata_log_level)) : NDLP_INFO_STR;
 
     nd_log_set_priority_level(inicfg_get(&netdata_config, CONFIG_SECTION_LOGS, "level", netdata_log_level));

--- a/src/daemon/config/netdata-conf-ssl.c
+++ b/src/daemon/config/netdata-conf-ssl.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#define NETDATA_NATIVE_ENVIRONMENT_ACCESS 1
 #include "daemon/common.h"
 #include "netdata-conf-ssl.h"
 #include <curl/curl.h>

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -176,7 +176,8 @@ static void oom_score_adj(void) {
     }
 
     // check the environment
-    const char *s = getenv("OOMScoreAdjust");
+    CLEAN_CHAR_P *oom_score_adjust = nd_environment_get_dup("OOMScoreAdjust");
+    const char *s = oom_score_adjust;
     if(!s || !*s) {
         snprintfz(buf, sizeof(buf) - 1, "%d", (int)wanted_score);
         s = buf;

--- a/src/daemon/environment.c
+++ b/src/daemon/environment.c
@@ -2,6 +2,11 @@
 
 #include "common.h"
 
+static void set_required_environment(const char *name, const char *value) {
+    if(nd_environment_set(name, value, true) != 0)
+        fatal("Cannot publish required child environment variable '%s': %s", name, strerror(errno));
+}
+
 void verify_required_directory(const char *env, const char *dir, bool create_it, int perms) {
     errno_clear();
 
@@ -10,14 +15,14 @@ void verify_required_directory(const char *env, const char *dir, bool create_it,
 
     if (chdir(dir) == 0) {
         if(env)
-            nd_setenv(env, dir, 1);
+            set_required_environment(env, dir);
         return;
     }
 
     if(create_it) {
         if(mkdir(dir, perms) == 0) {
             if(env)
-                nd_setenv(env, dir, 1);
+                set_required_environment(env, dir);
             return;
         }
     }
@@ -65,12 +70,12 @@ void set_environment_for_plugins_and_scripts(void) {
     {
         char b[16];
         snprintfz(b, sizeof(b) - 1, "%d", (int)nd_profile.update_every);
-        nd_setenv("NETDATA_UPDATE_EVERY", b, 1);
+        set_required_environment("NETDATA_UPDATE_EVERY", b);
     }
 
-    nd_setenv("NETDATA_VERSION", NETDATA_VERSION, 1);
-    nd_setenv("NETDATA_HOSTNAME", netdata_configured_hostname, 1);
-    nd_setenv("NETDATA_HOST_PREFIX", netdata_configured_host_prefix, 1);
+    set_required_environment("NETDATA_VERSION", NETDATA_VERSION);
+    set_required_environment("NETDATA_HOSTNAME", netdata_configured_hostname);
+    set_required_environment("NETDATA_HOST_PREFIX", netdata_configured_host_prefix);
 
     verify_required_directory("NETDATA_CONFIG_DIR", netdata_configured_user_config_dir, false, 0);
     verify_required_directory("NETDATA_USER_CONFIG_DIR", netdata_configured_user_config_dir, false, 0);
@@ -92,7 +97,7 @@ void set_environment_for_plugins_and_scripts(void) {
             buffer_strcat(user_plugins_dirs, plugin_directories[i]);
         }
 
-        nd_setenv("NETDATA_USER_PLUGINS_DIRS", buffer_tostring(user_plugins_dirs), 1);
+        set_required_environment("NETDATA_USER_PLUGINS_DIRS", buffer_tostring(user_plugins_dirs));
 
         buffer_free(user_plugins_dirs);
     }
@@ -104,25 +109,28 @@ void set_environment_for_plugins_and_scripts(void) {
         clean = 1;
     }
 
-    nd_setenv("NETDATA_LISTEN_PORT", default_port, 1);
+    set_required_environment("NETDATA_LISTEN_PORT", default_port);
     if (clean)
         freez((char *)default_port);
 
     // set the path we need
     char path[4096];
-    const char *p = getenv("PATH");
-    if (!p) p = "/bin:/usr/bin";
-    snprintfz(path, sizeof(path), "%s:%s", p, "/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
-    setenv("PATH", inicfg_get_path_list(&netdata_config, CONFIG_SECTION_ENV_VARS, "PATH", path), 1);
+    CLEAN_CHAR_P *current_path = nd_environment_get_dup("PATH");
+    snprintfz(path, sizeof(path), "%s:%s", current_path ? current_path : "/bin:/usr/bin",
+              "/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin");
+    set_required_environment(
+        "PATH", inicfg_get_path_list(&netdata_config, CONFIG_SECTION_ENV_VARS, "PATH", path));
 
     // python options
-    p = getenv("PYTHONPATH");
-    if (!p) p = "";
-    setenv("PYTHONPATH", inicfg_get_path_list(&netdata_config, CONFIG_SECTION_ENV_VARS, "PYTHONPATH", p), 1);
+    CLEAN_CHAR_P *python_path = nd_environment_get_dup("PYTHONPATH");
+    set_required_environment(
+        "PYTHONPATH",
+        inicfg_get_path_list(&netdata_config, CONFIG_SECTION_ENV_VARS, "PYTHONPATH",
+                             python_path ? python_path : ""));
 
     // disable buffering for python plugins
-    setenv("PYTHONUNBUFFERED", "1", 1);
+    set_required_environment("PYTHONUNBUFFERED", "1");
 
     // switch to standard locale for plugins
-    setenv("LC_ALL", "C", 1);
+    set_required_environment("LC_ALL", "C");
 }

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -14,6 +14,8 @@
 
 #ifdef OS_WINDOWS
 #include "win_system-info.h"
+extern bool netdata_windows_prepare_path(void);
+extern bool netdata_windows_service_environment_frozen(void);
 #endif
 
 #ifdef ENABLE_SENTRY
@@ -293,11 +295,34 @@ static void fatal_status_file_save(void) {
     exit(1);
 }
 
+static bool environment_freeze_for_early_exit(const char *mode) {
+    if(nd_environment_freeze_process() == 0) {
+#ifdef OS_WINDOWS
+        if(!netdata_windows_service_environment_frozen()) {
+            fprintf(stderr, "Cannot enable Windows service controls after freezing the process environment.\n");
+            return false;
+        }
+#endif
+        return true;
+    }
+
+    fprintf(stderr, "Cannot freeze the process environment for -W %s: %s\n", mode, strerror(errno));
+    return false;
+}
+
 int netdata_main(int argc, char **argv) {
     libjudy_malloc_init();
     string_init();
     analytics_init();
     nd_log_initialize_mutexes();
+    if(nd_environment_init() != 0) {
+        fprintf(stderr, "Cannot initialize the process environment: %s\n", strerror(errno));
+        return 1;
+    }
+#ifdef OS_WINDOWS
+    if(!netdata_windows_prepare_path())
+        return 1;
+#endif
 
     // Register the daemon's per-thread cleanup callback. Each subsystem
     // should own the registration of its own cleanups; this one lives in
@@ -401,31 +426,37 @@ int netdata_main(int argc, char **argv) {
                         char* stresstest_string = "stresstest=";
 
                         if(strcmp(optarg, "pgd-tests") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             return pgd_test(argc, argv);
                         }
 #endif
 
                         if(strcmp(optarg, "sqlite-meta-recover") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             sql_init_meta_database(DB_CHECK_RECOVER, 0);
                             return 0;
                         }
 
                         if(strcmp(optarg, "sqlite-compact") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             sql_init_meta_database(DB_CHECK_RECLAIM_SPACE, 0);
                             return 0;
                         }
 
                         if(strcmp(optarg, "sqlite-analyze") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             sql_init_meta_database(DB_CHECK_ANALYZE, 0);
                             return 0;
                         }
 
                         if(strcmp(optarg, "sqlite-alert-cleanup") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             sql_alert_cleanup(true);
                             return 0;
                         }
 
                         if(strcmp(optarg, "jsonctest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             if (json_c_parser_unittest()) return 1;
                             if (stream_path_json_unittest())
@@ -435,6 +466,7 @@ int netdata_main(int argc, char **argv) {
                         }
 
                         if(strcmp(optarg, "yamltest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             if (yaml_unittest()) return 1;
                             fprintf(stderr, "\n\nYAML TESTS PASSED\n\n");
@@ -443,6 +475,7 @@ int netdata_main(int argc, char **argv) {
 
                         if(strcmp(optarg, "mltest") == 0) {
 #ifdef ENABLE_ML
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             if (ml_unittest()) return 1;
                             fprintf(stderr, "\n\nML TESTS PASSED\n\n");
@@ -465,6 +498,13 @@ int netdata_main(int argc, char **argv) {
                             if (sqlite_library_init())
                                 return 1;
                             rrdlabels_aral_init(false);
+
+                            if(nd_environment_set("UV_THREADPOOL_SIZE", "48", true) != 0) {
+                                fprintf(stderr, "Cannot configure the unittest process environment: %s\n", strerror(errno));
+                                return 1;
+                            }
+                            if(!environment_freeze_for_early_exit(optarg))
+                                return 1;
 
                             if (pluginsd_parser_unittest()) return 1;
                             if (websocket_compression_unittest()) return 1;
@@ -534,21 +574,26 @@ int netdata_main(int argc, char **argv) {
                             return 0;
                         }
                         else if(strcmp(optarg, "escapetest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             return command_argument_sanitization_tests();
                         }
                         else if(strcmp(optarg, "dicttest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return dictionary_unittest(10000);
                         }
                         else if(strcmp(optarg, "dicttest-benchmark") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return dictionary_unittest_benchmark();
                         }
                         else if(strcmp(optarg, "araltest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return aral_unittest(10000);
                         }
                         else if(strcmp(optarg, "aralconcurrency") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
 #ifdef NETDATA_INTERNAL_CHECKS
                             return aral_unittest_concurrency();
@@ -558,34 +603,42 @@ int netdata_main(int argc, char **argv) {
 #endif
                         }
                         else if(strcmp(optarg, "waitqtest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return unittest_waiting_queue();
                         }
                         else if(strcmp(optarg, "uuidmaptest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return uuidmap_unittest();
                         }
                         else if(strcmp(optarg, "lockstest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return locks_stress_test();
                         }
                         else if(strcmp(optarg, "rwlockstest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return rwlocks_stress_test();
                         }
                         else if(strcmp(optarg, "rwspinlocktest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return rw_spinlock_unittest();
                         }
                         else if(strcmp(optarg, "prd-array-stress") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return prd_array_stress_test();
                         }
                         else if(strcmp(optarg, "stringtest") == 0)  {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return string_unittest(10000);
                         }
                         else if(strcmp(optarg, "rrdlabelstest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             rrdlabels_aral_init(true);
                             int rc = rrdlabels_unittest();
@@ -593,6 +646,7 @@ int netdata_main(int argc, char **argv) {
                             return rc;
                         }
                         else if(strcmp(optarg, "rrdhostlabelstest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             rrdlabels_aral_init(true);
                             int rc = rrdhost_labels_unittest();
@@ -600,31 +654,38 @@ int netdata_main(int argc, char **argv) {
                             return rc;
                         }
                         else if(strcmp(optarg, "buffertest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return buffer_unittest();
                         }
                         else if(strcmp(optarg, "ringbuffertest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return ringbuffer_unittest();
                         }
                         else if(strcmp(optarg, "wsclienttest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return ws_client_unittest();
                         }
                         else if(strcmp(optarg, "mqttngtest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return mqtt_ng_unittest();
                         }
                         else if(strcmp(optarg, "test_cmd_pool_fifo") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return test_cmd_pool_fifo();
                         }
                         else if(strcmp(optarg, "uuidtest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return uuid_unittest();
                         }
 #ifdef HAVE_LIBBACKTRACE
                         else if(strcmp(optarg, "stacktracetest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return stacktrace_unittest();
                         }
@@ -646,80 +707,103 @@ int netdata_main(int argc, char **argv) {
                                 else
                                     key = argv[a];
                             }
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             return windows_perflib_dump(key, filename);
                         }
                         else if(strcmp(optarg, "perflibnamestest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return perflibnamestest_main();
                         }
 #endif
                         else if(strcmp(optarg, "utf8sanitizertest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return utf8_sanitizer_unittest();
                         }
                         else if(strcmp(optarg, "queryplantest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return query_plan_unittest();
                         }
 #ifdef ENABLE_DBENGINE
                         else if(strcmp(optarg, "mctest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return mc_unittest();
                         }
                         else if(strcmp(optarg, "ctxtest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return ctx_unittest();
                         }
                         else if(strcmp(optarg, "metatest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return metadata_unittest();
                         }
                         else if(strcmp(optarg, "pgctest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return pgc_unittest();
                         }
                         else if(strcmp(optarg, "mrgtest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return mrg_unittest();
                         }
                         else if(strcmp(optarg, "mrgretentionbench") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return mrg_retention_benchmark();
                         }
                         else if(strcmp(optarg, "parsertest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return pluginsd_parser_unittest();
                         }
                         else if(strcmp(optarg, "websockettest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return websocket_compression_unittest();
                         }
                         else if(strcmp(optarg, "stream_compressions_test") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return unittest_stream_compressions();
                         }
                         else if(strcmp(optarg, "progresstest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return progress_unittest();
                         }
                         else if(strcmp(optarg, "evaltest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return eval_unittest();
                         }
                         else if(strcmp(optarg, "durationtest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return duration_unittest();
                         }
                         else if(strcmp(optarg, "healthconfigtest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             unittest_running = true;
                             return health_config_unittest();
                         }
-                        else if(strcmp(optarg, "dyncfgtest") == 0)
+                        else if(strcmp(optarg, "dyncfgtest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             return unittest_run_with_rrd(dyncfg_unittest);
-                        else if(strcmp(optarg, "functionsaccesstest") == 0)
+                        }
+                        else if(strcmp(optarg, "functionsaccesstest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             return unittest_run_with_rrd(rrdfunctions_verify_access_unittest);
-                        else if(strcmp(optarg, "mcpfunctionaccesstest") == 0)
+                        }
+                        else if(strcmp(optarg, "mcpfunctionaccesstest") == 0) {
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
                             return unittest_run_with_rrd(mcp_execute_function_access_unittest);
+                        }
                         else if(strncmp(optarg, createdataset_string, strlen(createdataset_string)) == 0) {
                             optarg += strlen(createdataset_string);
                             unsigned history_seconds = strtoul(optarg, NULL, 0);
@@ -727,6 +811,7 @@ int netdata_main(int argc, char **argv) {
                             netdata_conf_section_global();
                             nd_profile.update_every = 1;
                             registry_init();
+                            if(!environment_freeze_for_early_exit("createdataset")) return 1;
                             if(rrd_init("dbengine-dataset", NULL, true)) {
                                 fprintf(stderr, "rrd_init failed for unittest\n");
                                 return 1;
@@ -759,7 +844,11 @@ int netdata_main(int argc, char **argv) {
 
                             char workers_str[16];
                             snprintf(workers_str, 15, "%u", workers);
-                            setenv("UV_THREADPOOL_SIZE", workers_str, 1);
+                            if(nd_environment_set("UV_THREADPOOL_SIZE", workers_str, true) != 0) {
+                                fprintf(stderr, "Cannot configure the stress-test process environment: %s\n", strerror(errno));
+                                return 1;
+                            }
+                            if(!environment_freeze_for_early_exit("stresstest")) return 1;
                             dbengine_stress_test(test_duration_sec, dset_charts, query_threads, ramp_up_seconds,
                                                  page_cache_mb, disk_space_mb);
                             return 0;
@@ -941,10 +1030,16 @@ int netdata_main(int argc, char **argv) {
                             return 0;
                         }
                         else if(strcmp(optarg, "buildinfo") == 0) {
+#ifdef OS_WINDOWS
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
+#endif
                             print_build_info();
                             return 0;
                         }
                         else if(strcmp(optarg, "buildinfojson") == 0) {
+#ifdef OS_WINDOWS
+                            if(!environment_freeze_for_early_exit(optarg)) return 1;
+#endif
                             print_build_info_json();
                             return 0;
                         }
@@ -996,26 +1091,7 @@ int netdata_main(int argc, char **argv) {
     netdata_conf_section_logs();
     nd_log_limits_unlimited();
     nd_log_initialize();
-
-    // ----------------------------------------------------------------------------------------------------------------
-    // this MUST be before anything else - to load the old status file before saving a new one
-
-    daemon_status_file_init(); // this loads the old file
-    machine_guid_get(); // after loading the old daemon status file - we may need the machine guid from it
-    nd_log_register_fatal_hook_cb(daemon_status_file_register_fatal);
-    nd_log_register_fatal_final_cb(fatal_status_file_save);
-    exit_initiated_init();
-
-    // ----------------------------------------------------------------------------------------------------------------
-    delta_startup_time("signals");
-
-    signals_block_all_except_deadly();
-    nd_initialize_signals(false); // catches deadly signals and stores them in the status file
-
-    // ----------------------------------------------------------------------------------------------------------------
-
-    netdata_conf_section_global(); // get hostname, host prefix, profile, etc
-    registry_init(); // for machine_guid, must be after netdata_conf_section_global()
+    nd_log_publish_child_environment();
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("run dir");
@@ -1037,16 +1113,39 @@ int netdata_main(int argc, char **argv) {
 //        }
     }
 
+#if !defined(OS_WINDOWS)
+    // macOS DMI discovery may need system_profiler while loading the old status file.
+    delta_startup_time("temp spawn server");
+    if(!netdata_main_spawn_server_init("init", argc, (const char **)argv))
+        fatal("Cannot create the initialization spawn server.");
+#endif
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // load the old status file before anything saves a new one
+
+    daemon_status_file_init(); // this loads the old file
+    machine_guid_get(); // after loading the old daemon status file - we may need the machine guid from it
+    nd_log_register_fatal_hook_cb(daemon_status_file_register_fatal);
+    nd_log_register_fatal_final_cb(fatal_status_file_save);
+    exit_initiated_init();
+
+    // ----------------------------------------------------------------------------------------------------------------
+    delta_startup_time("signals");
+
+    signals_block_all_except_deadly();
+    nd_initialize_signals(false); // catches deadly signals and stores them in the status file
+
+    // ----------------------------------------------------------------------------------------------------------------
+
+    netdata_conf_section_global(); // get hostname, host prefix, profile, etc
+    registry_init(); // for machine_guid, must be after netdata_conf_section_global()
+
     nd_profile_setup();
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("crash reports");
 
     daemon_status_file_check_crash();
-
-    // ----------------------------------------------------------------------------------------------------------------
-    delta_startup_time("temp spawn server");
-    netdata_main_spawn_server_init("init", argc, (const char **)argv);
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("ssl");
@@ -1184,18 +1283,6 @@ int netdata_main(int argc, char **argv) {
 #endif
 
     // ----------------------------------------------------------------------------------------------------------------
-    delta_startup_time("plugins spawn server");
-
-    netdata_main_spawn_server_init("plugins", argc, (const char **)argv);
-
-#ifdef ENABLE_SENTRY
-    // ----------------------------------------------------------------------------------------------------------------
-    delta_startup_time("sentry");
-
-    nd_sentry_init();
-#endif
-
-    // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("home");
 
     // The "HOME" env var points to the root's home dir because Netdata starts as root. Can't use "HOME".
@@ -1206,7 +1293,39 @@ int netdata_main(int argc, char **argv) {
     else
         netdata_configured_home_dir = inicfg_get_path(&netdata_config, CONFIG_SECTION_DIRECTORIES, "home", pw->pw_dir);
 
-    nd_setenv("HOME", netdata_configured_home_dir, 1);
+    if(nd_environment_set("HOME", netdata_configured_home_dir, true) != 0)
+        fatal("Cannot publish the Netdata home directory to the process environment.");
+
+#if defined(OS_WINDOWS)
+    if(!spawn_server_windows_publish_cygwin_path())
+        fatal("Cannot publish the MSYS runtime path.");
+
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
+
+    if(!netdata_windows_service_environment_frozen()) {
+        fprintf(stderr, "Cannot enable Windows service controls after freezing the process environment.\n");
+        return 1;
+    }
+#endif
+
+    // ----------------------------------------------------------------------------------------------------------------
+    delta_startup_time("plugins spawn server");
+
+    if(!netdata_main_spawn_server_init("plugins", argc, (const char **)argv))
+        fatal("Cannot create the plugins spawn server.");
+
+#if !defined(OS_WINDOWS)
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
+#endif
+
+#ifdef ENABLE_SENTRY
+    // ----------------------------------------------------------------------------------------------------------------
+    delta_startup_time("sentry");
+
+    nd_sentry_init();
+#endif
 
     // ----------------------------------------------------------------------------------------------------------------
     delta_startup_time("dyncfg");

--- a/src/daemon/pipename.c
+++ b/src/daemon/pipename.c
@@ -16,10 +16,8 @@ const char *daemon_pipename(void) {
 
     const char *pipename = cached_pipename;
     if(!pipename) {
-        const char *env_pipename = getenv("NETDATA_PIPENAME");
-        if (env_pipename)
-            cached_pipename = strdupz(env_pipename);
-        else {
+        cached_pipename = nd_environment_get_dup("NETDATA_PIPENAME");
+        if (!cached_pipename) {
             //#if defined(OS_WINDOWS)
             // cached_pipename = strdupz("\\\\?\\pipe\\netdata-cli");
             //#else

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -7,10 +7,17 @@
 #include "libnetdata/os/windows-wmi/windows-wmi-GetSystemInfo.h"
 #include "daemon/status-file-dmi.h"
 #include "daemon/status-file-product.h"
+#include "libnetdata/environment/environment.h"
 #include "libnetdata/os/os-windows-wrappers.h"
-#include "libnetdata/os/setenv.h"
 
 #ifdef OS_WINDOWS
+
+static void netdata_windows_publish_environment(const char *name, const char *value) {
+    if(nd_environment_set(name, value, true) != 0)
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "WINDOWS SYSTEM INFO: cannot publish child environment variable '%s': %s",
+               name, strerror(errno));
+}
 
 typedef struct netdata_windows_os_info {
     char name[256];
@@ -82,7 +89,7 @@ static void netdata_windows_cpu_from_system_info(struct rrdhost_system_info *sys
     // by anonymous-statistics.sh (mirrors the Linux system-info.sh dispatch, and the RAM/disk
     // detection pattern in this file).
     (void)rrdhost_system_info_set_by_name(systemInfo, "NETDATA_SYSTEM_CPU_DETECTION", NETDATA_WIN_DETECTION_METHOD);
-    nd_setenv("NETDATA_SYSTEM_CPU_DETECTION", NETDATA_WIN_DETECTION_METHOD, 1);
+    netdata_windows_publish_environment("NETDATA_SYSTEM_CPU_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 
 static void netdata_windows_cpu_vendor_model(struct rrdhost_system_info *systemInfo,
@@ -143,7 +150,7 @@ static void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)
                                            (!size) ? NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN : memSize);
     // Not stored in the struct; consumed from the environment by anonymous-statistics.sh.
     (void)rrdhost_system_info_set_by_name(systemInfo, "NETDATA_SYSTEM_RAM_DETECTION", NETDATA_WIN_DETECTION_METHOD);
-    nd_setenv("NETDATA_SYSTEM_RAM_DETECTION", NETDATA_WIN_DETECTION_METHOD, 1);
+    netdata_windows_publish_environment("NETDATA_SYSTEM_RAM_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 
 static ULONGLONG netdata_windows_get_disk_size(char *cVolume)
@@ -192,7 +199,7 @@ static void netdata_windows_get_total_disk_size(struct rrdhost_system_info *syst
 
     // Not stored in the struct; consumed from the environment by anonymous-statistics.sh.
     (void)rrdhost_system_info_set_by_name(systemInfo, "NETDATA_SYSTEM_DISK_DETECTION", NETDATA_WIN_DETECTION_METHOD);
-    nd_setenv("NETDATA_SYSTEM_DISK_DETECTION", NETDATA_WIN_DETECTION_METHOD, 1);
+    netdata_windows_publish_environment("NETDATA_SYSTEM_DISK_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 
 // Host
@@ -447,15 +454,6 @@ static void netdata_windows_set_container_os_none(struct rrdhost_system_info *sy
                                   NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
 }
 
-static const char *netdata_windows_container_is_official_image(void)
-{
-    const char *official = getenv("NETDATA_OFFICIAL_IMAGE");
-    if(official && *official)
-        return official;
-
-    return NETDATA_DEFAULT_SYSTEM_INFO_VALUE_FALSE;
-}
-
 // Cloud
 static void netdata_windows_cloud(struct rrdhost_system_info *systemInfo)
 {
@@ -488,12 +486,14 @@ static void netdata_windows_container(struct rrdhost_system_info *systemInfo, co
 
     // rrdhost_system_info_set_by_name() recognizes but does not store this key (it has no
     // struct field); its only consumer is anonymous-statistics.sh, which reads it from the
-    // environment. On Linux the system-info.sh dispatch loop nd_setenv()s it — mirror that
-    // here so the flag is not silently dropped on Windows.
-    const char *official_image = netdata_windows_container_is_official_image();
+    // managed environment. Mirror the Linux system-info.sh publication so the flag is not
+    // silently dropped on Windows.
+    CLEAN_CHAR_P *official_image_env = nd_environment_get_dup("NETDATA_OFFICIAL_IMAGE");
+    const char *official_image = official_image_env && *official_image_env ?
+                                     official_image_env : NETDATA_DEFAULT_SYSTEM_INFO_VALUE_FALSE;
     (void)rrdhost_system_info_set_by_name(
         systemInfo, "NETDATA_CONTAINER_IS_OFFICIAL_IMAGE", official_image);
-    nd_setenv("NETDATA_CONTAINER_IS_OFFICIAL_IMAGE", official_image, 1);
+    netdata_windows_publish_environment("NETDATA_CONTAINER_IS_OFFICIAL_IMAGE", official_image);
 }
 
 static void netdata_windows_install_type(struct rrdhost_system_info *systemInfo)
@@ -630,10 +630,10 @@ static void netdata_windows_detect_virtualization(struct rrdhost_system_info *sy
     const char *virt = netdata_windows_detect_virt();
 
     (void)rrdhost_system_info_set_by_name(systemInfo, "NETDATA_SYSTEM_VIRTUALIZATION", virt);
-    nd_setenv("NETDATA_SYSTEM_VIRTUALIZATION", virt, 1);
+    netdata_windows_publish_environment("NETDATA_SYSTEM_VIRTUALIZATION", virt);
 
     (void)rrdhost_system_info_set_by_name(systemInfo, "NETDATA_SYSTEM_VIRT_DETECTION", NETDATA_WIN_DETECTION_METHOD);
-    nd_setenv("NETDATA_SYSTEM_VIRT_DETECTION", NETDATA_WIN_DETECTION_METHOD, 1);
+    netdata_windows_publish_environment("NETDATA_SYSTEM_VIRT_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 
 const char *netdata_windows_container_from_env(const char *k_host, const char *k_port) {
@@ -654,8 +654,10 @@ const char *netdata_windows_container_detection_method(const char *container) {
 }
 
 static const char *netdata_windows_detect_container(void) {
+    CLEAN_CHAR_P *kubernetes_service_host = nd_environment_get_dup("KUBERNETES_SERVICE_HOST");
+    CLEAN_CHAR_P *kubernetes_service_port = nd_environment_get_dup("KUBERNETES_SERVICE_PORT");
     const char *from_env = netdata_windows_container_from_env(
-        getenv("KUBERNETES_SERVICE_HOST"), getenv("KUBERNETES_SERVICE_PORT"));
+        kubernetes_service_host, kubernetes_service_port);
     if(from_env)
         return from_env;
 
@@ -677,10 +679,10 @@ static const char *netdata_windows_detect_container_state(struct rrdhost_system_
     const char *container_detection = netdata_windows_container_detection_method(container);
 
     (void)rrdhost_system_info_set_by_name(systemInfo, "NETDATA_SYSTEM_CONTAINER", container);
-    nd_setenv("NETDATA_SYSTEM_CONTAINER", container, 1);
+    netdata_windows_publish_environment("NETDATA_SYSTEM_CONTAINER", container);
 
     (void)rrdhost_system_info_set_by_name(systemInfo, "NETDATA_SYSTEM_CONTAINER_DETECTION", container_detection);
-    nd_setenv("NETDATA_SYSTEM_CONTAINER_DETECTION", container_detection, 1);
+    netdata_windows_publish_environment("NETDATA_SYSTEM_CONTAINER_DETECTION", container_detection);
 
     return container;
 }

--- a/src/daemon/winsvc.cc
+++ b/src/daemon/winsvc.cc
@@ -36,64 +36,66 @@ static void netdata_service_log(const char *fmt, ...)
 }
 
 static SERVICE_STATUS_HANDLE svc_status_handle = nullptr;
-static SERVICE_STATUS svc_status = {};
+static volatile LONG svc_current_state = SERVICE_STOPPED;
+static volatile LONG svc_environment_frozen = 0;
+static volatile LONG svc_stop_started = 0;
+static volatile LONG svc_checkpoint = 0;
 
-static HANDLE svc_stop_event_handle = nullptr;
 static DWORD svc_stop_control_code = SERVICE_CONTROL_STOP;
 
-static ND_THREAD *cleanup_thread = nullptr;
-
-static bool ReportSvcStatus(DWORD dwCurrentState, DWORD dwWin32ExitCode, DWORD dwWaitHint, DWORD dwControlsAccepted)
+static bool ReportSvcStatus(
+    DWORD dwCurrentState,
+    DWORD dwWin32ExitCode,
+    DWORD dwWaitHint,
+    DWORD dwControlsAccepted,
+    DWORD dwServiceSpecificExitCode = 0)
 {
-    static DWORD dwCheckPoint = 1;
-    svc_status.dwCurrentState = dwCurrentState;
-    svc_status.dwWin32ExitCode = dwWin32ExitCode;
-    svc_status.dwWaitHint = dwWaitHint;
-    svc_status.dwControlsAccepted = dwControlsAccepted;
+    SERVICE_STATUS status = {};
+    status.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
+    status.dwCurrentState = dwCurrentState;
+    status.dwWin32ExitCode = dwWin32ExitCode;
+    status.dwServiceSpecificExitCode = dwServiceSpecificExitCode;
+    status.dwWaitHint = dwWaitHint;
+    status.dwControlsAccepted = dwControlsAccepted;
 
     if (dwCurrentState == SERVICE_RUNNING || dwCurrentState == SERVICE_STOPPED)
     {
-        svc_status.dwCheckPoint = 0;
+        status.dwCheckPoint = 0;
+        InterlockedExchange(&svc_checkpoint, 0);
     }
     else
     {
-        svc_status.dwCheckPoint = dwCheckPoint++;
+        status.dwCheckPoint = (DWORD)InterlockedIncrement(&svc_checkpoint);
     }
 
-    if (!SetServiceStatus(svc_status_handle, &svc_status)) {
+    if (!SetServiceStatus(svc_status_handle, &status)) {
         netdata_service_log("@ReportSvcStatus: SetServiceStatusFailed (%d)", GetLastError());
+        return false;
+    }
+
+    InterlockedExchange(&svc_current_state, (LONG)dwCurrentState);
+    return true;
+}
+
+extern "C" bool netdata_windows_service_environment_frozen(void)
+{
+    if (!svc_status_handle)
+        return true;
+
+    InterlockedExchange(&svc_environment_frozen, 1);
+
+    if (!ReportSvcStatus(SERVICE_RUNNING, NO_ERROR, 0, SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN)) {
+        InterlockedExchange(&svc_environment_frozen, 0);
+        netdata_service_log("Failed to enable service stop and shutdown controls.");
         return false;
     }
 
     return true;
 }
 
-static HANDLE CreateEventHandle(const char *msg)
-{
-    HANDLE h = CreateEvent(NULL, TRUE, FALSE, NULL);
-
-    if (!h)
-    {
-        netdata_service_log("%s", msg);
-
-        if (!ReportSvcStatus(SERVICE_STOPPED, GetLastError(), 1000, 0))
-        {
-            netdata_service_log("Failed to set service status to stopped.");
-        }
-
-        return NULL;
-    }
-
-    return h;
-}
-
 static void call_netdata_cleanup(void *arg)
 {
     UNUSED(arg);
-
-    // Wait until we have to stop the service
-    netdata_service_log("Cleanup thread waiting for stop event...");
-    WaitForSingleObject(svc_stop_event_handle, INFINITE);
 
     // Stop the agent
     netdata_service_log("Running netdata cleanup...");
@@ -113,10 +115,6 @@ static void call_netdata_cleanup(void *arg)
     }
     netdata_exit_gracefully(reason, false);
 
-    // Close event handle
-    netdata_service_log("Closing stop event handle...");
-    CloseHandle(svc_stop_event_handle);
-
     // Set status to stopped
     netdata_service_log("Reporting the service as stopped...");
     ReportSvcStatus(SERVICE_STOPPED, 0, 0, 0);
@@ -133,13 +131,19 @@ static void WINAPI ServiceControlHandler(DWORD controlCode)
         case SERVICE_CONTROL_SHUTDOWN:
         case SERVICE_CONTROL_STOP:
         {
-            if (svc_status.dwCurrentState != SERVICE_RUNNING)
+            if (!InterlockedCompareExchange(&svc_environment_frozen, 0, 0) ||
+                InterlockedCompareExchange(&svc_current_state, 0, 0) != SERVICE_RUNNING)
+                return;
+
+            if (InterlockedCompareExchange(&svc_stop_started, 1, 0))
                 return;
 
             // Set service status to stop-pending
             netdata_service_log("Setting service status to stop-pending...");
-            if (!ReportSvcStatus(SERVICE_STOP_PENDING, 0, 5000, 0))
+            if (!ReportSvcStatus(SERVICE_STOP_PENDING, NO_ERROR, 5000, 0)) {
+                InterlockedExchange(&svc_stop_started, 0);
                 return;
+            }
 
             __atomic_store_n(&svc_stop_control_code, controlCode, __ATOMIC_RELEASE);
 
@@ -147,18 +151,19 @@ static void WINAPI ServiceControlHandler(DWORD controlCode)
             netdata_service_log("Creating cleanup thread...");
             char tag[NETDATA_THREAD_TAG_MAX + 1];
             snprintfz(tag, NETDATA_THREAD_TAG_MAX, "%s", "CLEANUP");
-            cleanup_thread = nd_thread_create(tag, NETDATA_THREAD_OPTION_DEFAULT, call_netdata_cleanup, NULL);
-
-            // Signal the stop request
-            netdata_service_log("Signalling the cleanup thread...");
-            SetEvent(svc_stop_event_handle);
+            ND_THREAD *cleanup_thread = nd_thread_create(
+                tag, NETDATA_THREAD_OPTION_DEFAULT, call_netdata_cleanup, NULL);
+            if (!cleanup_thread) {
+                netdata_service_log("Cannot create the cleanup thread; stopping the service immediately.");
+                ReportSvcStatus(SERVICE_STOPPED, ERROR_NOT_ENOUGH_MEMORY, 0, 0);
+                ExitProcess(ERROR_NOT_ENOUGH_MEMORY);
+            }
             break;
         }
         case SERVICE_CONTROL_INTERROGATE:
-        {
-            ReportSvcStatus(svc_status.dwCurrentState, svc_status.dwWin32ExitCode, svc_status.dwWaitHint, svc_status.dwControlsAccepted);
+            // The status did not change, so the SCM already has the current value.
             break;
-        }
+
         default:
             break;
     }
@@ -180,24 +185,15 @@ void WINAPI ServiceMain(DWORD argc, LPSTR* argv)
 
     // Set status to start-pending
     netdata_service_log("Setting service status to start-pending...");
-    svc_status.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
-    svc_status.dwServiceSpecificExitCode = 0;
-    svc_status.dwCheckPoint = 0;
-    if (!ReportSvcStatus(SERVICE_START_PENDING, 0, 5000, 0))
+    if (!ReportSvcStatus(SERVICE_START_PENDING, NO_ERROR, 5000, 0))
     {
         netdata_service_log("Failed to set service status to start pending.");
         return;
     }
 
-    // Create stop service event handle
-    netdata_service_log("Creating stop service event handle...");
-    svc_stop_event_handle = CreateEventHandle("Failed to create stop event handle");
-    if (!svc_stop_event_handle)
-        return;
-
     // Set status to running
     netdata_service_log("Setting service status to running...");
-    if (!ReportSvcStatus(SERVICE_RUNNING, 0, 5000, SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN))
+    if (!ReportSvcStatus(SERVICE_RUNNING, NO_ERROR, 0, 0))
     {
         netdata_service_log("Failed to set service status to running.");
         return;
@@ -205,16 +201,27 @@ void WINAPI ServiceMain(DWORD argc, LPSTR* argv)
 
     // Run the agent
     netdata_service_log("Running the agent...");
-    netdata_main(argc, argv);
+    int rc = netdata_main(argc, argv);
 
-    netdata_service_log("Agent has been started...");
+    if (rc == 10) {
+        netdata_service_log("Agent has been started.");
+        return;
+    }
+
+    netdata_service_log("Agent stopped with exit code %d.", rc);
+    ReportSvcStatus(
+        SERVICE_STOPPED,
+        rc ? ERROR_SERVICE_SPECIFIC_ERROR : NO_ERROR,
+        0,
+        0,
+        (DWORD)rc);
 }
 
-static bool update_path() {
-    const char *old_path = getenv("PATH");
+extern "C" bool netdata_windows_prepare_path(void) {
+    CLEAN_CHAR_P *old_path = nd_environment_get_dup("PATH");
 
     if (!old_path) {
-        if (setenv("PATH", "/usr/bin", 1) != 0) {
+        if (nd_environment_set("PATH", "/usr/bin", true) != 0) {
             netdata_service_log("Failed to set PATH to /usr/bin");
             return false;
         }
@@ -226,7 +233,7 @@ static bool update_path() {
     char *new_path = (char *) callocz(new_path_length, sizeof(char));
     snprintfz(new_path, new_path_length, "/usr/bin:%s", old_path);
 
-    if (setenv("PATH", new_path, 1) != 0) {
+    if (nd_environment_set("PATH", new_path, true) != 0) {
         netdata_service_log("Failed to add /usr/bin to PATH");
         freez(new_path);
         return false;
@@ -243,10 +250,6 @@ int main(int argc, char *argv[])
 #else
     bool tty = isatty(fileno(stdin)) == 1;
 #endif
-
-    if (!update_path()) {
-        return 1;
-    }
 
     if (tty)
     {

--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -456,9 +456,6 @@ static size_t test_dbengine_burst_retention(RRDHOST *host) {
 }
 
 int test_dbengine(void) {
-    // provide enough threads to dbengine
-    setenv("UV_THREADPOOL_SIZE", "48", 1);
-
     size_t errors = 0, value_errors = 0, time_errors = 0;
 
     nd_log_limits_unlimited();

--- a/src/database/rrdhost-labels.c
+++ b/src/database/rrdhost-labels.c
@@ -96,7 +96,7 @@ static void env_expand_labels_value(const char *src, char *dst, size_t dst_size)
                 default_val = sep + 2;
             }
 
-            const char *env_val = getenv(var_name);
+            CLEAN_CHAR_P *env_val = nd_environment_get_dup(var_name);
             const char *resolved;
 
             if(env_val && *env_val)
@@ -377,11 +377,11 @@ int rrdhost_labels_unittest(void) {
     int errors = 0;
 
     // --- set up test env vars ---
-    setenv("ND_TEST_VAR", "hello", 1);
-    setenv("ND_TEST_DC", "us-east", 1);
-    setenv("ND_TEST_RACK", "rack42", 1);
-    setenv("ND_TEST_EMPTY", "", 1);
-    unsetenv("ND_TEST_UNSET");
+    errors += nd_environment_set("ND_TEST_VAR", "hello", true) != 0;
+    errors += nd_environment_set("ND_TEST_DC", "us-east", true) != 0;
+    errors += nd_environment_set("ND_TEST_RACK", "rack42", true) != 0;
+    errors += nd_environment_set("ND_TEST_EMPTY", "", true) != 0;
+    errors += nd_environment_unset("ND_TEST_UNSET") != 0;
 
     // no variables — pass through unchanged
     errors += env_expand_unittest_check("plain value", "plain value", "plain text");
@@ -435,7 +435,7 @@ int rrdhost_labels_unittest(void) {
     errors += env_expand_unittest_check("${ND_TEST_UNSET:-a:-b}", "a:-b", "default containing :-");
 
     // no recursive expansion — env value containing ${...} is NOT re-expanded
-    setenv("ND_TEST_NESTED", "${ND_TEST_VAR}", 1);
+    errors += nd_environment_set("ND_TEST_NESTED", "${ND_TEST_VAR}", true) != 0;
     errors += env_expand_unittest_check("${ND_TEST_NESTED}", "${ND_TEST_VAR}", "no recursive expansion");
 
     // default containing ${...} is NOT re-expanded
@@ -499,11 +499,11 @@ int rrdhost_labels_unittest(void) {
     }
 
     // --- cleanup test env vars ---
-    unsetenv("ND_TEST_VAR");
-    unsetenv("ND_TEST_DC");
-    unsetenv("ND_TEST_RACK");
-    unsetenv("ND_TEST_EMPTY");
-    unsetenv("ND_TEST_NESTED");
+    errors += nd_environment_unset("ND_TEST_VAR") != 0;
+    errors += nd_environment_unset("ND_TEST_DC") != 0;
+    errors += nd_environment_unset("ND_TEST_RACK") != 0;
+    errors += nd_environment_unset("ND_TEST_EMPTY") != 0;
+    errors += nd_environment_unset("ND_TEST_NESTED") != 0;
 
     errors += is_parent_label_unittest();
 

--- a/src/libnetdata/environment/check-native-environment-unittest.py
+++ b/src/libnetdata/environment/check-native-environment-unittest.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+"""Unit tests for the native-environment source scanner."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import tempfile
+import unittest
+
+
+CHECKER_PATH = pathlib.Path(__file__).with_name("check-native-environment.py")
+SPEC = importlib.util.spec_from_file_location("check_native_environment", CHECKER_PATH)
+if not SPEC or not SPEC.loader:
+    raise RuntimeError(f"cannot load {CHECKER_PATH}")
+
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+class MaskingTests(unittest.TestCase):
+    def assert_masked_tokens(self, source: str, expected: list[str]) -> None:
+        masked = CHECKER.without_comments_and_literals(source)
+        self.assertEqual(len(masked), len(source))
+        self.assertEqual(
+            [index for index, char in enumerate(masked) if char == "\n"],
+            [index for index, char in enumerate(source) if char == "\n"],
+        )
+        self.assertEqual(CHECKER.RAW_TOKEN.findall(masked), expected)
+
+    def test_code_is_preserved(self) -> None:
+        self.assert_masked_tokens("getenv(); setenv();", ["getenv", "setenv"])
+
+    def test_line_comment_is_masked(self) -> None:
+        self.assert_masked_tokens("// getenv\nsetenv();", ["setenv"])
+
+    def test_block_comment_is_masked(self) -> None:
+        self.assert_masked_tokens("/* getenv\n unsetenv */\nputenv();", ["putenv"])
+
+    def test_string_and_character_literals_are_masked(self) -> None:
+        self.assert_masked_tokens(
+            "char *s = \"getenv \\\" setenv\"; char c = '\\''; unsetenv();",
+            ["unsetenv"],
+        )
+
+    def test_cpp_digit_separators_do_not_mask_following_code(self) -> None:
+        self.assert_masked_tokens(
+            "auto decimal = 1'000; auto hex = 0xCA'FE; "
+            "auto grouped = 0xFFFF'FFFF'FFFF; getenv(); setenv();",
+            ["getenv", "setenv"],
+        )
+
+    def test_cpp_prefixed_character_literal_is_still_masked(self) -> None:
+        self.assert_masked_tokens("char8_t c = u8'a'; getenv();", ["getenv"])
+
+    def test_escaped_newline_in_literal_is_preserved(self) -> None:
+        self.assert_masked_tokens('char *s = "getenv\\\nsetenv"; putenv();', ["putenv"])
+
+    def test_cpp_raw_literals_are_masked(self) -> None:
+        fixtures = (
+            'auto s = R"(getenv " // /*)"; setenv();',
+            'auto s = u8R"tag(getenv " // /*\nsetenv)tag"; unsetenv();',
+            'auto s = uR"(getenv)"; putenv();',
+            'auto s = UR"delimiter1234567(getenv)delimiter1234567"; clearenv();',
+            'auto s = LR"x(GetEnvironmentVariableA)x"; setenv();',
+        )
+        expected = (["setenv"], ["unsetenv"], ["putenv"], ["clearenv"], ["setenv"])
+        for source, tokens in zip(fixtures, expected):
+            with self.subTest(source=source):
+                self.assert_masked_tokens(source, tokens)
+
+    def test_unterminated_cpp_raw_literal_is_masked(self) -> None:
+        self.assert_masked_tokens('auto s = R"tag(getenv " //', [])
+
+    def test_unterminated_regions_are_masked(self) -> None:
+        self.assert_masked_tokens("/* getenv", [])
+        self.assert_masked_tokens('"getenv', [])
+
+
+class AuditTests(unittest.TestCase):
+    def test_source_discovery_filters_and_sorts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = pathlib.Path(directory)
+            source = repository / "src"
+            source.mkdir()
+            (source / "z.c").write_text("", encoding="utf-8")
+            (source / "a.h").write_text("", encoding="utf-8")
+            (source / "ignored.py").write_text("", encoding="utf-8")
+
+            paths = [path.name for path in CHECKER._source_files(repository)]
+            self.assertEqual(paths, ["a.h", "z.c"])
+
+    def test_per_file_diagnostics_preserve_order(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = pathlib.Path(directory)
+            path = repository / "src" / "example.c"
+            path.parent.mkdir()
+            path.write_text("getenv();\ngetenv();\n", encoding="utf-8")
+            expected = {"src/example.c": {"getenv": 1, "setenv": 1}}
+
+            relative, violations = CHECKER._audit_source_file(repository, path, expected)
+            self.assertEqual(relative, "src/example.c")
+            self.assertEqual(
+                violations,
+                [
+                    "src/example.c:2: unexpected native environment token 'getenv'",
+                    "src/example.c: expected 1 audited 'setenv' token(s), found 0",
+                ],
+            )
+
+    def test_literal_token_paste_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = pathlib.Path(directory)
+            path = repository / "src" / "example.c"
+            path.parent.mkdir()
+            path.write_text(
+                "get ## env(\"X\");\nGet ## Environment ## Variable ## A(\"X\", 0, 0);\n",
+                encoding="utf-8",
+            )
+
+            _, violations = CHECKER._audit_source_file(repository, path, {})
+            self.assertEqual(
+                violations,
+                [
+                    "src/example.c:1: unexpected token-pasted native environment token 'getenv'",
+                    "src/example.c:2: unexpected token-pasted native environment token "
+                    "'GetEnvironmentVariableA'",
+                ],
+            )
+
+    def test_missing_audited_files_preserve_mapping_order(self) -> None:
+        expected = {
+            "src/present.c": {"getenv": 1},
+            "src/missing.c": {"setenv": 2},
+        }
+        self.assertEqual(
+            CHECKER._missing_audited_file_violations({"src/present.c"}, expected),
+            ["src/missing.c: audited source file is missing (2 token(s))"],
+        )
+
+    def test_report_contract(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            self.assertEqual(CHECKER._report([]), 0)
+        self.assertEqual(stdout.getvalue(), "native environment bypass check: PASS\n")
+        self.assertEqual(stderr.getvalue(), "")
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            self.assertEqual(CHECKER._report(["violation"]), 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(
+            stderr.getvalue(),
+            "Native process-environment access is private to audited adapters:\n  violation\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/libnetdata/environment/check-native-environment.py
+++ b/src/libnetdata/environment/check-native-environment.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+
+"""Reject native process-environment access outside audited adapters."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from collections import Counter
+
+
+EXPECTED_RAW_TOKENS = {
+    # The managed subsystem's private platform adapter and its native-storage tests.
+    "src/libnetdata/environment/environment.c": {
+        "NETDATA_NATIVE_ENVIRONMENT_ACCESS": 1,
+        "environ": 3,
+        "_NSGetEnviron": 2,
+        "GetEnvironmentStringsA": 2,
+        "FreeEnvironmentStringsA": 2,
+        "GetEnvironmentVariableA": 2,
+        "SetEnvironmentVariableA": 7,
+        "getenv": 3,
+        "setenv": 3,
+        "unsetenv": 3,
+    },
+    "src/libnetdata/environment/environment-unittest.c": {
+        "NETDATA_NATIVE_ENVIRONMENT_ACCESS": 1,
+        "GetEnvironmentStringsA": 1,
+        "FreeEnvironmentStringsA": 1,
+        "GetEnvironmentVariableA": 2,
+        "SetEnvironmentVariableA": 1,
+        "getenv": 9,
+        "unsetenv": 1,
+    },
+    # Compatibility bootstrap before the managed subsystem is initialized.
+    "src/libnetdata/os/setenv.c": {
+        "NETDATA_NATIVE_ENVIRONMENT_ACCESS": 1,
+        "GetEnvironmentVariable": 1,
+        "SetEnvironmentVariable": 2,
+        "getenv": 1,
+        "putenv": 1,
+        "setenv": 1,
+    },
+    "src/libnetdata/os/setenv.h": {"setenv": 1},
+    "src/libnetdata/log/nd_log-init.c": {"NETDATA_NATIVE_ENVIRONMENT_ACCESS": 1, "getenv": 2},
+    # Audited single-threaded restricted execution helpers.
+    "src/collectors/utils/nd-run.c": {"clearenv": 1, "environ": 2, "getenv": 5, "setenv": 1},
+    "src/collectors/utils/ndsudo.c": {"getenv": 1, "putenv": 1},
+    # Retained but inactive or unsupported source covered by the inventory.
+    "src/daemon/config/netdata-conf-ssl.c": {
+        "NETDATA_NATIVE_ENVIRONMENT_ACCESS": 1,
+        "getenv": 2,
+        "setenv": 2,
+    },
+    "src/exporting/pubsub/pubsub_publish.cc": {"setenv": 1},
+    # Vendored third-party debug code.
+    "src/libnetdata/libjudy/vendored/JudyL/JudyLGet.c": {"getenv": 1},
+    "src/libnetdata/libjudy/vendored/JudyL/j__udyLGet.c": {"getenv": 1},
+    "src/libnetdata/environment/native-environment-compiler-check.h": {
+        "NETDATA_NATIVE_ENVIRONMENT_ACCESS": 1,
+        "getenv": 1,
+        "_wgetenv": 1,
+        "getenv_s": 1,
+        "_wgetenv_s": 1,
+        "_dupenv_s": 1,
+        "_wdupenv_s": 1,
+        "secure_getenv": 1,
+        "setenv": 1,
+        "unsetenv": 1,
+        "putenv": 1,
+        "_putenv": 1,
+        "_wputenv": 1,
+        "_putenv_s": 1,
+        "_wputenv_s": 1,
+        "clearenv": 1,
+        "environ": 1,
+        "_environ": 1,
+        "__environ": 1,
+        "_wenviron": 1,
+        "_NSGetEnviron": 1,
+        "__p__environ": 1,
+        "GetEnvironmentStringsA": 2,
+        "GetEnvironmentStringsW": 1,
+        "FreeEnvironmentStringsA": 1,
+        "FreeEnvironmentStringsW": 1,
+        "GetEnvironmentVariableA": 1,
+        "GetEnvironmentVariableW": 1,
+        "SetEnvironmentVariableA": 1,
+        "SetEnvironmentVariableW": 1,
+        "ExpandEnvironmentStringsA": 1,
+        "ExpandEnvironmentStringsW": 1,
+    },
+}
+
+SOURCE_SUFFIXES = {".c", ".cc", ".cpp", ".h", ".hh", ".hpp", ".m", ".mm"}
+NATIVE_TOKEN_PATTERN = (
+    r"getenv|_wgetenv|getenv_s|_wgetenv_s|_dupenv_s|_wdupenv_s|secure_getenv|"
+    r"setenv|unsetenv|putenv|_putenv|_wputenv|_putenv_s|_wputenv_s|clearenv|"
+    r"environ|_environ|__environ|_wenviron|_NSGetEnviron|__p__environ|"
+    r"GetEnvironmentStrings(?:A|W)?|FreeEnvironmentStrings(?:A|W)?|"
+    r"GetEnvironmentVariable(?:A|W)?|SetEnvironmentVariable(?:A|W)?|"
+    r"ExpandEnvironmentStrings(?:A|W)?"
+)
+RAW_TOKEN = re.compile(rf"\b(?:{NATIVE_TOKEN_PATTERN}|NETDATA_NATIVE_ENVIRONMENT_ACCESS)\b")
+NATIVE_TOKEN = re.compile(rf"^(?:{NATIVE_TOKEN_PATTERN})$")
+TOKEN_PASTE = re.compile(r"\b[A-Za-z_]\w*(?:\s*##\s*[A-Za-z_]\w*)+\b")
+RAW_LITERAL_OPEN = re.compile(
+    r'(?<!\w)(?:u8|u|U|L)?R"(?P<delimiter>[^ ()\\\t\v\f\r\n]{0,16})\('
+)
+
+MASK_DELIMITERS = (
+    ("//", "line-comment"),
+    ("/*", "block-comment"),
+    ('"', "string"),
+    ("'", "character"),
+)
+QUOTE_BY_STATE = {"string": '"', "character": "'"}
+NUMERIC_TOKEN_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.")
+
+
+def _mask_non_newlines(source: str) -> str:
+    return "".join("\n" if char == "\n" else " " for char in source)
+
+
+def _is_cpp_digit_separator(source: str, position: int) -> bool:
+    if position == 0 or position + 1 >= len(source):
+        return False
+
+    if not source[position - 1].isalnum() or not source[position + 1].isalnum():
+        return False
+
+    start = position - 1
+    while start > 0 and (source[start - 1] in NUMERIC_TOKEN_CHARS or source[start - 1] == "'"):
+        start -= 1
+
+    prefix = source[start:position]
+    return prefix[0].isdigit() or (prefix.startswith(".") and len(prefix) > 1 and prefix[1].isdigit())
+
+
+def _find_character_literal(source: str, index: int) -> int:
+    position = source.find("'", index)
+    while position >= 0 and _is_cpp_digit_separator(source, position):
+        position = source.find("'", position + 1)
+
+    return position
+
+
+def _consume_code_region(source: str, index: int) -> tuple[str, int, str]:
+    matches = []
+    for delimiter, state in MASK_DELIMITERS:
+        position = _find_character_literal(source, index) if delimiter == "'" else source.find(delimiter, index)
+        if position >= 0:
+            matches.append((position, delimiter, state, None))
+
+    raw_literal = RAW_LITERAL_OPEN.search(source, index)
+    if raw_literal:
+        matches.append((raw_literal.start(), "", "raw-literal", raw_literal))
+
+    if not matches:
+        return source[index:], len(source), "code"
+
+    position, delimiter, state, raw_literal = min(matches, key=lambda item: item[0])
+    if raw_literal:
+        terminator = ")" + raw_literal.group("delimiter") + '"'
+        end = source.find(terminator, raw_literal.end())
+        if end < 0:
+            end = len(source)
+        else:
+            end += len(terminator)
+
+        masked = source[index:position] + _mask_non_newlines(source[position:end])
+        return masked, end, "code"
+
+    masked = source[index:position] + " " * len(delimiter)
+    return masked, position + len(delimiter), state
+
+
+def _consume_line_comment(source: str, index: int) -> tuple[str, int, str]:
+    newline = source.find("\n", index)
+    if newline < 0:
+        return " " * (len(source) - index), len(source), "line-comment"
+
+    return " " * (newline - index) + "\n", newline + 1, "code"
+
+
+def _consume_block_comment(source: str, index: int) -> tuple[str, int, str]:
+    end = source.find("*/", index)
+    if end < 0:
+        return _mask_non_newlines(source[index:]), len(source), "block-comment"
+
+    end += 2
+    return _mask_non_newlines(source[index:end]), end, "code"
+
+
+def _consume_quoted_literal(source: str, index: int, state: str) -> tuple[str, int, str]:
+    quote = QUOTE_BY_STATE[state]
+    end = index
+    while end < len(source):
+        char = source[end]
+        following = source[end + 1] if end + 1 < len(source) else ""
+        if char == "\\" and following:
+            end += 2
+            continue
+
+        end += 1
+        if char == quote:
+            return _mask_non_newlines(source[index:end]), end, "code"
+
+    return _mask_non_newlines(source[index:end]), end, state
+
+
+def without_comments_and_literals(source: str) -> str:
+    """Replace C/C++ comments and literals with spaces while retaining newlines."""
+    output: list[str] = []
+    index = 0
+    state = "code"
+
+    while index < len(source):
+        if state == "code":
+            masked, index, state = _consume_code_region(source, index)
+        elif state == "line-comment":
+            masked, index, state = _consume_line_comment(source, index)
+        elif state == "block-comment":
+            masked, index, state = _consume_block_comment(source, index)
+        else:
+            masked, index, state = _consume_quoted_literal(source, index, state)
+
+        output.append(masked)
+
+    return "".join(output)
+
+
+def _source_files(repository: pathlib.Path):
+    for path in sorted((repository / "src").rglob("*")):
+        if path.is_file() and path.suffix in SOURCE_SUFFIXES:
+            yield path
+
+
+def _native_occurrences(source: str) -> tuple[Counter[str], list[tuple[int, str, bool]]]:
+    matches = list(RAW_TOKEN.finditer(source))
+    actual = Counter(match.group(0) for match in matches)
+    occurrences = [(match.start(), match.group(0), False) for match in matches]
+
+    for match in TOKEN_PASTE.finditer(source):
+        token = re.sub(r"\s*##\s*", "", match.group(0))
+        if NATIVE_TOKEN.fullmatch(token):
+            occurrences.append((match.start(), token, True))
+
+    return actual, occurrences
+
+
+def _audit_source_file(
+    repository: pathlib.Path,
+    path: pathlib.Path,
+    expected_raw_tokens=None,
+) -> tuple[str, list[str]]:
+    if expected_raw_tokens is None:
+        expected_raw_tokens = EXPECTED_RAW_TOKENS
+
+    relative = path.relative_to(repository).as_posix()
+    source = without_comments_and_literals(path.read_text(encoding="utf-8", errors="replace"))
+    actual, occurrences = _native_occurrences(source)
+    expected = Counter(expected_raw_tokens.get(relative, {}))
+    violations: list[str] = []
+
+    permitted_so_far: Counter[str] = Counter()
+    for position, token, pasted in sorted(occurrences):
+        line = source.count("\n", 0, position) + 1
+        if pasted:
+            violations.append(
+                f"{relative}:{line}: unexpected token-pasted native environment token '{token}'"
+            )
+            continue
+
+        permitted_so_far[token] += 1
+        if permitted_so_far[token] <= expected[token]:
+            continue
+
+        violations.append(f"{relative}:{line}: unexpected native environment token '{token}'")
+
+    for token, count in expected.items():
+        if actual[token] < count:
+            violations.append(
+                f"{relative}: expected {count} audited '{token}' token(s), found {actual[token]}"
+            )
+
+    return relative, violations
+
+
+def _missing_audited_file_violations(
+    seen: set[str], expected_raw_tokens=None
+) -> list[str]:
+    if expected_raw_tokens is None:
+        expected_raw_tokens = EXPECTED_RAW_TOKENS
+
+    return [
+        f"{relative}: audited source file is missing ({sum(expected.values())} token(s))"
+        for relative, expected in expected_raw_tokens.items()
+        if relative not in seen
+    ]
+
+
+def _report(violations: list[str]) -> int:
+
+    if violations:
+        print("Native process-environment access is private to audited adapters:", file=sys.stderr)
+        for violation in violations:
+            print(f"  {violation}", file=sys.stderr)
+        return 1
+
+    print("native environment bypass check: PASS")
+    return 0
+
+
+def main() -> int:
+    """Audit the repository and return a process-compatible status."""
+    repository = pathlib.Path(__file__).resolve().parents[3]
+    violations: list[str] = []
+    seen: set[str] = set()
+
+    for path in _source_files(repository):
+        relative, source_violations = _audit_source_file(repository, path)
+        seen.add(relative)
+        violations.extend(source_violations)
+
+    violations.extend(_missing_audited_file_violations(seen))
+    return _report(violations)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/libnetdata/environment/environment-unittest.c
+++ b/src/libnetdata/environment/environment-unittest.c
@@ -1,0 +1,990 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#define NETDATA_NATIVE_ENVIRONMENT_ACCESS 1
+#include "libnetdata/libnetdata.h"
+
+static size_t failures = 0;
+
+static bool test_strings_equal(const char *left, const char *right) {
+    return left && right && strcmp(left, right) == 0;
+}
+
+#if defined(OS_WINDOWS)
+static char *windows_inherited_raw = NULL;
+
+static wchar_t *test_windows_wide(const char *text, UINT code_page) {
+    int length = MultiByteToWideChar(code_page, 0, text, -1, NULL, 0);
+    if(length <= 0)
+        return NULL;
+
+    wchar_t *wide = mallocz((size_t)length * sizeof(*wide));
+    if(MultiByteToWideChar(code_page, 0, text, -1, wide, length) <= 0) {
+        freez(wide);
+        return NULL;
+    }
+    return wide;
+}
+
+static char *test_windows_narrow(const wchar_t *wide, UINT code_page) {
+    int length = WideCharToMultiByte(code_page, 0, wide, -1, NULL, 0, NULL, NULL);
+    if(length <= 0)
+        return NULL;
+
+    char *text = mallocz((size_t)length);
+    if(WideCharToMultiByte(code_page, 0, wide, -1, text, length, NULL, NULL) <= 0) {
+        freez(text);
+        return NULL;
+    }
+    return text;
+}
+
+static char *test_windows_transcode(const char *text, UINT from, UINT to) {
+    wchar_t *wide = test_windows_wide(text, from);
+    if(!wide)
+        return NULL;
+    char *converted = test_windows_narrow(wide, to);
+    freez(wide);
+    return converted;
+}
+
+static bool test_windows_name_equal(const char *left, const char *right) {
+    wchar_t *left_wide = test_windows_wide(left, CP_ACP);
+    wchar_t *right_wide = test_windows_wide(right, CP_ACP);
+    if(!left_wide || !right_wide) {
+        freez(left_wide);
+        freez(right_wide);
+        return false;
+    }
+
+    bool equal = CompareStringOrdinal(left_wide, -1, right_wide, -1, TRUE) == CSTR_EQUAL;
+    freez(left_wide);
+    freez(right_wide);
+    return equal;
+}
+
+static bool test_windows_path_list_name(const char *name) {
+    return test_windows_name_equal(name, "PATH") ||
+           test_windows_name_equal(name, "LD_LIBRARY_PATH") ||
+           test_windows_name_equal(name, "ORIGINAL_PATH");
+}
+
+static bool test_windows_single_path_name(const char *name) {
+    return test_windows_name_equal(name, "HOME") ||
+           test_windows_name_equal(name, "SHELL") ||
+           test_windows_name_equal(name, "TMPDIR") ||
+           test_windows_name_equal(name, "TMP") ||
+           test_windows_name_equal(name, "TEMP");
+}
+
+static char *test_windows_expected_raw(const char *name, const char *value) {
+    char *name_oem = test_windows_transcode(name, CP_ACP, CP_OEMCP);
+    char *value_oem = NULL;
+    bool list = test_windows_path_list_name(name);
+    bool path = test_windows_single_path_name(name);
+
+    if(!list && !path)
+        value_oem = test_windows_transcode(value, CP_ACP, CP_OEMCP);
+    else if(!*value && test_windows_name_equal(name, "SHELL"))
+        value_oem = test_windows_transcode(value, CP_ACP, CP_OEMCP);
+    else {
+        cygwin_conv_path_t conversion = CCP_POSIX_TO_WIN_W | (list ? CCP_RELATIVE : CCP_ABSOLUTE);
+        ssize_t required = list
+            ? cygwin_conv_path_list(conversion, value, NULL, 0)
+            : cygwin_conv_path(conversion, value, NULL, 0);
+        if(required > 0) {
+            wchar_t *wide = mallocz((size_t)required);
+            ssize_t rc = list
+                ? cygwin_conv_path_list(conversion, value, wide, (size_t)required)
+                : cygwin_conv_path(conversion, value, wide, (size_t)required);
+            if(rc == 0)
+                value_oem = test_windows_narrow(wide, CP_OEMCP);
+            freez(wide);
+        }
+    }
+
+    if(!name_oem || !value_oem) {
+        freez(name_oem);
+        freez(value_oem);
+        return NULL;
+    }
+
+    size_t name_length = strlen(name_oem);
+    size_t value_length = strlen(value_oem);
+    char *raw = mallocz(name_length + value_length + 2);
+    snprintfz(raw, name_length + value_length + 2, "%s=%s", name_oem, value_oem);
+    freez(name_oem);
+    freez(value_oem);
+    return raw;
+}
+
+static bool test_windows_raw_name_equal(const char *raw, const char *name) {
+    const char *equals = raw ? strchr(raw, '=') : NULL;
+    if(!equals || equals == raw)
+        return false;
+
+    char *raw_name_oem = strndupz(raw, (size_t)(equals - raw));
+    char *raw_name_acp = test_windows_transcode(raw_name_oem, CP_OEMCP, CP_ACP);
+    bool equal = raw_name_acp && test_windows_name_equal(raw_name_acp, name);
+    freez(raw_name_oem);
+    freez(raw_name_acp);
+    return equal;
+}
+
+static const char *test_windows_snapshot_raw(const ND_ENV_SNAPSHOT *snapshot, const char *name) {
+    const char *const *envp = nd_environment_snapshot_envp(snapshot);
+    for(size_t i = 0; envp && envp[i]; i++) {
+        if(test_windows_raw_name_equal(envp[i], name))
+            return envp[i];
+    }
+    return NULL;
+}
+
+static const char *test_windows_block_raw(const char *block, const char *name) {
+    for(const char *entry = block; entry && *entry; entry += strlen(entry) + 1) {
+        if(test_windows_raw_name_equal(entry, name))
+            return entry;
+    }
+    return NULL;
+}
+
+static char *test_windows_native_raw_dup(const char *name) {
+    LPCH block = GetEnvironmentStringsA();
+    if(!block)
+        return NULL;
+
+    char *found = NULL;
+    for(const char *entry = block; *entry; entry += strlen(entry) + 1) {
+        if(test_windows_raw_name_equal(entry, name)) {
+            found = strdupz(entry);
+            break;
+        }
+    }
+    FreeEnvironmentStringsA(block);
+    return found;
+}
+
+static char *test_windows_native_value_dup(const char *name) {
+    SetLastError(ERROR_SUCCESS);
+    DWORD required = GetEnvironmentVariableA(name, NULL, 0);
+    if(!required) {
+        if(GetLastError() == ERROR_SUCCESS)
+            return strdupz("");
+        return NULL;
+    }
+
+    char *value = mallocz(required);
+    SetLastError(ERROR_SUCCESS);
+    DWORD copied = GetEnvironmentVariableA(name, value, required);
+    if(!copied && GetLastError() != ERROR_SUCCESS) {
+        freez(value);
+        return NULL;
+    }
+    return value;
+}
+
+static bool test_windows_crt_drive_entry(const char *raw) {
+    return raw && raw[0] == '!' && raw[1] && raw[2] && raw[3] == '=' &&
+           ((isalpha((unsigned char)raw[1]) && raw[2] == ':') || (raw[1] == ':' && raw[2] == ':'));
+}
+
+
+static int test_windows_child_observation(void) {
+    char *generic_value = test_windows_narrow(L"caf\u00e9", CP_ACP);
+    char *path_value = test_windows_narrow(L"/c/t\u00e9st:/tmp", CP_UTF8);
+    char *expected_generic = generic_value
+        ? test_windows_expected_raw("ND_ENVIRONMENT_TEST_CHILD_GENERIC", generic_value)
+        : NULL;
+    char *expected_path = path_value
+        ? test_windows_expected_raw("LD_LIBRARY_PATH", path_value)
+        : NULL;
+    char *actual_generic = test_windows_native_raw_dup("ND_ENVIRONMENT_TEST_CHILD_GENERIC");
+    char *actual_path = test_windows_native_raw_dup("LD_LIBRARY_PATH");
+    char *generic_native = test_windows_native_value_dup("ND_ENVIRONMENT_TEST_CHILD_GENERIC");
+    char *path_native = test_windows_native_value_dup("LD_LIBRARY_PATH");
+    char *expected_path_native = NULL;
+
+    if(expected_path) {
+        const char *equals = strchr(expected_path, '=');
+        if(equals)
+            expected_path_native = test_windows_transcode(equals + 1, CP_OEMCP, CP_ACP);
+    }
+
+    bool ok = generic_value && path_value && expected_generic && expected_path && actual_generic && actual_path &&
+              generic_native && path_native && expected_path_native &&
+              strcmp(expected_generic, actual_generic) == 0 && strcmp(expected_path, actual_path) == 0 &&
+              strcmp(generic_value, generic_native) == 0 && strcmp(expected_path_native, path_native) == 0;
+    if(!ok) {
+        fprintf(stderr, "environment-unittest: Windows child environment observation failed\n");
+        fprintf(stderr, "  generic raw expected='%s' actual='%s'\n",
+                expected_generic ? expected_generic : "(null)", actual_generic ? actual_generic : "(null)");
+        fprintf(stderr, "  path raw expected='%s' actual='%s'\n",
+                expected_path ? expected_path : "(null)", actual_path ? actual_path : "(null)");
+    }
+
+    freez(generic_value);
+    freez(path_value);
+    freez(expected_generic);
+    freez(expected_path);
+    freez(actual_generic);
+    freez(actual_path);
+    freez(generic_native);
+    freez(path_native);
+    freez(expected_path_native);
+    return ok ? 0 : 90;
+}
+#endif
+
+#define CHECK(expression)                                                                                             \
+    do {                                                                                                              \
+        if(!(expression)) {                                                                                           \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expression);                                  \
+            failures++;                                                                                               \
+        }                                                                                                             \
+    } while(0)
+
+static const char *snapshot_value(const ND_ENV_SNAPSHOT *snapshot, const char *name) {
+    if(!snapshot || !name)
+        return NULL;
+
+    size_t name_length = strlen(name);
+    const char *const *envp = nd_environment_snapshot_envp(snapshot);
+
+    for(size_t i = 0; envp && envp[i]; i++) {
+        if(strncmp(envp[i], name, name_length) == 0 && envp[i][name_length] == '=')
+            return &envp[i][name_length + 1];
+    }
+
+    return NULL;
+}
+
+static void check_snapshot_exact(const ND_ENV_SNAPSHOT *snapshot, const char *const expected[]) {
+    CHECK(snapshot != NULL);
+    CHECK(expected != NULL);
+    if(!snapshot || !expected)
+        return;
+
+    const char *const *envp = nd_environment_snapshot_envp(snapshot);
+    CHECK(envp != NULL);
+    if(!envp)
+        return;
+
+    size_t count = 0;
+    while(expected[count]) {
+        CHECK(envp[count] != NULL);
+        if(envp[count])
+            CHECK(test_strings_equal(envp[count], expected[count]));
+        count++;
+    }
+
+    CHECK(nd_environment_snapshot_entries(snapshot) == count);
+    CHECK(envp[count] == NULL);
+}
+
+static void test_preinit_contract(void) {
+    errno = 0;
+    CHECK(nd_environment_process() == NULL);
+    CHECK(nd_environment_get_dup("PATH") == NULL);
+    CHECK(errno == EPERM);
+
+    errno = 0;
+    CHECK(nd_environment_freeze_process() == -1);
+    CHECK(errno == EPERM);
+
+    errno = 0;
+    CHECK(nd_environment_snapshot_acquire(NULL) == NULL);
+    CHECK(errno == EPERM);
+
+    errno = 0;
+    CHECK(nd_environment_create_isolated(NULL) == NULL);
+    CHECK(errno == EPERM);
+
+    errno = 0;
+    CHECK(nd_environment_set("ND_ENVIRONMENT_TEST_PREINIT", "forbidden", true) == -1);
+    CHECK(errno == EPERM);
+
+    errno = 0;
+    CHECK(nd_environment_unset("ND_ENVIRONMENT_TEST_PREINIT") == -1);
+    CHECK(errno == EPERM);
+}
+
+static void test_import_and_native_mirroring(void) {
+    unsetenv("ND_ENVIRONMENT_TEST_BOOTSTRAP_WRAPPER");
+#if defined(OS_WINDOWS)
+    SetEnvironmentVariableA("ND_ENVIRONMENT_TEST_BOOTSTRAP_WRAPPER", NULL);
+
+    char *inherited_value = test_windows_narrow(L"caf\u00e9", CP_ACP);
+    CHECK(inherited_value != NULL);
+    if(inherited_value) {
+        nd_setenv("ND_ENVIRONMENT_TEST_INHERITED_OEM", inherited_value, 1);
+        windows_inherited_raw = test_windows_native_raw_dup("ND_ENVIRONMENT_TEST_INHERITED_OEM");
+        CHECK(windows_inherited_raw != NULL);
+    }
+    freez(inherited_value);
+#endif
+
+    nd_setenv("ND_ENVIRONMENT_TEST_NATIVE", "imported", 1);
+    CHECK(test_strings_equal(getenv("ND_ENVIRONMENT_TEST_NATIVE"), "imported"));
+    CHECK(nd_environment_init() == 0);
+    CHECK(nd_environment_init() == 0);
+    CHECK(nd_environment_is_initialized());
+    CHECK(!nd_environment_is_process_frozen());
+    CHECK(nd_environment_process() != NULL);
+
+#if defined(OS_WINDOWS)
+    ND_ENV_SNAPSHOT *initial = nd_environment_snapshot_acquire(nd_environment_process());
+    CHECK(initial != NULL);
+    if(initial) {
+        const char *inherited = test_windows_snapshot_raw(initial, "ND_ENVIRONMENT_TEST_INHERITED_OEM");
+        CHECK(inherited != NULL);
+        if(inherited && windows_inherited_raw)
+            CHECK(test_strings_equal(inherited, windows_inherited_raw));
+
+        const char *const *envp = nd_environment_snapshot_envp(initial);
+        for(size_t i = 0; envp && envp[i]; i++)
+            CHECK(!test_windows_crt_drive_entry(envp[i]));
+    }
+    nd_environment_snapshot_release(initial);
+#endif
+
+    char *imported = nd_environment_get_dup("ND_ENVIRONMENT_TEST_NATIVE");
+    CHECK(test_strings_equal(imported, "imported"));
+
+    CHECK(nd_environment_set("ND_ENVIRONMENT_TEST_NATIVE", "initializing", true) == 0);
+    CHECK(test_strings_equal(imported, "imported"));
+    CHECK(test_strings_equal(getenv("ND_ENVIRONMENT_TEST_NATIVE"), "initializing"));
+    freez(imported);
+
+    nd_environment_test_fail_native_once();
+    errno = 0;
+    CHECK(nd_environment_set("ND_ENVIRONMENT_TEST_NATIVE", "must-not-publish", true) == -1);
+    CHECK(errno == EIO);
+
+    char *unchanged = nd_environment_get_dup("ND_ENVIRONMENT_TEST_NATIVE");
+    CHECK(test_strings_equal(unchanged, "initializing"));
+    CHECK(test_strings_equal(getenv("ND_ENVIRONMENT_TEST_NATIVE"), "initializing"));
+    freez(unchanged);
+}
+
+static void test_windows_case_identity(void) {
+#if defined(OS_WINDOWS)
+    const char *const initial[] = { "MiXeD=first", NULL };
+    ND_ENVIRONMENT *environment = nd_environment_create_isolated(initial);
+    CHECK(environment != NULL);
+    if(!environment)
+        return;
+
+    char *value = nd_environment_context_get_dup(environment, "mixed");
+    CHECK(test_strings_equal(value, "first"));
+    freez(value);
+
+    CHECK(nd_environment_context_set(environment, "MIXED", "ignored", false) == 0);
+    CHECK(nd_environment_context_set(environment, "mixed", "second", true) == 0);
+    ND_ENV_SNAPSHOT *snapshot = nd_environment_snapshot_acquire(environment);
+    const char *const expected[] = { "MiXeD=second", NULL };
+    check_snapshot_exact(snapshot, expected);
+
+    CHECK(nd_environment_context_unset(environment, "mIxEd") == 0);
+    char *missing = nd_environment_context_get_dup(environment, "MIXED");
+    CHECK(missing == NULL);
+    freez(missing);
+
+    nd_environment_snapshot_release(snapshot);
+    nd_environment_destroy(environment);
+#endif
+}
+
+static void test_isolated_order_duplicates_and_opaque(void) {
+    const char *const initial[] = {
+        "OPAQUE",
+        "A=first",
+        "A=second",
+        "",
+        "B=",
+        NULL,
+    };
+    ND_ENVIRONMENT *environment = nd_environment_create_isolated(initial);
+    CHECK(environment != NULL);
+    if(!environment)
+        return;
+
+    char *value = nd_environment_context_get_dup(environment, "A");
+    CHECK(test_strings_equal(value, "first"));
+    freez(value);
+
+    ND_ENV_SNAPSHOT *original = nd_environment_snapshot_acquire(environment);
+    CHECK(original != NULL);
+    check_snapshot_exact(original, initial);
+    uint64_t original_generation = nd_environment_snapshot_generation(original);
+
+    CHECK(nd_environment_context_set(environment, "A", "ignored", false) == 0);
+    ND_ENV_SNAPSHOT *no_overwrite = nd_environment_snapshot_acquire(environment);
+    CHECK(no_overwrite == original);
+    CHECK(nd_environment_snapshot_generation(no_overwrite) == original_generation);
+    check_snapshot_exact(no_overwrite, initial);
+    nd_environment_snapshot_release(no_overwrite);
+
+    CHECK(nd_environment_context_set(environment, "A", "replacement", true) == 0);
+    ND_ENV_SNAPSHOT *replaced = nd_environment_snapshot_acquire(environment);
+    const char *const expected_replaced[] = {
+        "OPAQUE",
+        "A=replacement",
+        "A=second",
+        "",
+        "B=",
+        NULL,
+    };
+    check_snapshot_exact(replaced, expected_replaced);
+    CHECK(nd_environment_snapshot_generation(replaced) != original_generation);
+
+    // The old generation is still complete while a newer one is published.
+    check_snapshot_exact(original, initial);
+
+    CHECK(nd_environment_context_set(environment, "C", "last", true) == 0);
+    CHECK(nd_environment_context_unset(environment, "A") == 0);
+    ND_ENV_SNAPSHOT *removed = nd_environment_snapshot_acquire(environment);
+    const char *const expected_removed[] = {
+        "OPAQUE",
+        "",
+        "B=",
+        "C=last",
+        NULL,
+    };
+    check_snapshot_exact(removed, expected_removed);
+
+    nd_environment_snapshot_release(original);
+    nd_environment_snapshot_release(replaced);
+    nd_environment_snapshot_release(removed);
+    nd_environment_destroy(environment);
+}
+
+static void test_empty_and_owned_snapshot_destruction(void) {
+    const char *const empty[] = { NULL };
+    ND_ENVIRONMENT *environment = nd_environment_create_isolated(empty);
+    CHECK(environment != NULL);
+    if(!environment)
+        return;
+
+    ND_ENV_SNAPSHOT *snapshot = nd_environment_snapshot_acquire(environment);
+    CHECK(snapshot != NULL);
+    if(!snapshot) {
+        nd_environment_destroy(environment);
+        return;
+    }
+    CHECK(nd_environment_snapshot_entries(snapshot) == 0);
+    CHECK(nd_environment_snapshot_envp(snapshot)[0] == NULL);
+
+    nd_environment_destroy(environment);
+    CHECK(nd_environment_snapshot_entries(snapshot) == 0);
+    CHECK(nd_environment_snapshot_envp(snapshot)[0] == NULL);
+    nd_environment_snapshot_release(snapshot);
+}
+
+static void test_snapshot_failure_atomicity(void) {
+    const char *const initial[] = { "FAILURE=old", NULL };
+    ND_ENVIRONMENT *environment = nd_environment_create_isolated(initial);
+    CHECK(environment != NULL);
+    if(!environment)
+        return;
+
+    ND_ENV_SNAPSHOT *old = nd_environment_snapshot_acquire(environment);
+    CHECK(old != NULL);
+    if(!old) {
+        nd_environment_destroy(environment);
+        return;
+    }
+
+    CHECK(nd_environment_context_set(environment, "FAILURE", "new", true) == 0);
+    nd_environment_test_fail_snapshot_once();
+    errno = 0;
+    CHECK(nd_environment_snapshot_acquire(environment) == NULL);
+    CHECK(errno == ENOMEM);
+    CHECK(test_strings_equal(snapshot_value(old, "FAILURE"), "old"));
+
+    ND_ENV_SNAPSHOT *current = nd_environment_snapshot_acquire(environment);
+    CHECK(current != NULL);
+    CHECK(test_strings_equal(snapshot_value(current, "FAILURE"), "new"));
+    CHECK(test_strings_equal(snapshot_value(old, "FAILURE"), "old"));
+
+    nd_environment_snapshot_release(old);
+    nd_environment_snapshot_release(current);
+    nd_environment_destroy(environment);
+}
+
+static void test_windows_block_builder(void) {
+    const char *const envp[] = {
+        "z=last",
+        "=C:=drive",
+        "a=first",
+        "A0=prefix",
+        "B=middle",
+        NULL,
+    };
+    const char *const expected[] = {
+        "=C:=drive",
+        "a=first",
+        "A0=prefix",
+        "B=middle",
+        "z=last",
+        NULL,
+    };
+
+    size_t size = 0;
+    char *block = nd_environment_test_windows_block(envp, &size);
+    CHECK(block != NULL);
+
+    if(block) {
+        const char *entry = block;
+        size_t i = 0;
+        while(*entry && expected[i]) {
+            CHECK(test_strings_equal(entry, expected[i]));
+            entry += strlen(entry) + 1;
+            i++;
+        }
+        CHECK(*entry == '\0');
+        CHECK(expected[i] == NULL);
+        CHECK((size_t)(entry - block) + 1 == size);
+        CHECK(entry > block);
+        if(entry > block)
+            CHECK(entry[-1] == '\0');
+        CHECK(entry[0] == '\0');
+    }
+    freez(block);
+
+    const char *const empty[] = { NULL };
+    block = nd_environment_test_windows_block(empty, &size);
+    CHECK(block != NULL);
+    CHECK(size == 2);
+    if(block && size >= 2)
+        CHECK(block[0] == '\0' && block[1] == '\0');
+    freez(block);
+}
+
+typedef struct environment_concurrency_test {
+    ND_ENVIRONMENT *environment;
+    bool stop;
+    size_t errors;
+    size_t acquisitions;
+} ENVIRONMENT_CONCURRENCY_TEST;
+
+static void environment_writer(void *data) {
+    ENVIRONMENT_CONCURRENCY_TEST *test = data;
+    for(size_t i = 0; i < 2000; i++) {
+        char value[32];
+        snprintfz(value, sizeof(value), "%zu", i);
+        if(nd_environment_context_set(test->environment, "RACE", value, true) != 0)
+            __atomic_add_fetch(&test->errors, 1, __ATOMIC_RELAXED);
+    }
+    __atomic_store_n(&test->stop, true, __ATOMIC_RELEASE);
+}
+
+static void environment_reader(void *data) {
+    ENVIRONMENT_CONCURRENCY_TEST *test = data;
+    do {
+        ND_ENV_SNAPSHOT *snapshot = nd_environment_snapshot_acquire(test->environment);
+        if(!snapshot) {
+            __atomic_add_fetch(&test->errors, 1, __ATOMIC_RELAXED);
+            continue;
+        }
+
+        const char *value = snapshot_value(snapshot, "RACE");
+        if(!value || !*value)
+            __atomic_add_fetch(&test->errors, 1, __ATOMIC_RELAXED);
+        else {
+            char first = *value;
+            uv_sleep(0);
+            if(*value != first)
+                __atomic_add_fetch(&test->errors, 1, __ATOMIC_RELAXED);
+        }
+
+        __atomic_add_fetch(&test->acquisitions, 1, __ATOMIC_RELAXED);
+        nd_environment_snapshot_release(snapshot);
+    } while(!__atomic_load_n(&test->stop, __ATOMIC_ACQUIRE));
+}
+
+static void test_concurrent_writers_and_snapshot_readers(void) {
+    const char *const initial[] = { "RACE=0", NULL };
+    ENVIRONMENT_CONCURRENCY_TEST test = {
+        .environment = nd_environment_create_isolated(initial),
+    };
+    CHECK(test.environment != NULL);
+    if(!test.environment)
+        return;
+
+    uv_thread_t writer;
+    uv_thread_t readers[4];
+    size_t readers_started = 0;
+    for(; readers_started < _countof(readers); readers_started++) {
+        int rc = uv_thread_create(&readers[readers_started], environment_reader, &test);
+        CHECK(rc == 0);
+        if(rc != 0)
+            break;
+    }
+
+    bool writer_started = false;
+    if(readers_started == _countof(readers)) {
+        int rc = uv_thread_create(&writer, environment_writer, &test);
+        CHECK(rc == 0);
+        writer_started = rc == 0;
+    }
+
+    if(!writer_started)
+        __atomic_store_n(&test.stop, true, __ATOMIC_RELEASE);
+
+    if(writer_started)
+        CHECK(uv_thread_join(&writer) == 0);
+    for(size_t i = 0; i < readers_started; i++)
+        CHECK(uv_thread_join(&readers[i]) == 0);
+
+    if(writer_started) {
+        CHECK(__atomic_load_n(&test.errors, __ATOMIC_RELAXED) == 0);
+        CHECK(__atomic_load_n(&test.acquisitions, __ATOMIC_RELAXED) > 0);
+    }
+    nd_environment_destroy(test.environment);
+}
+
+static void test_process_freeze(void) {
+    const char *const isolated_initial[] = { "ISOLATED=before", "REMOVE=present", NULL };
+    ND_ENVIRONMENT *isolated = nd_environment_create_isolated(isolated_initial);
+    CHECK(isolated != NULL);
+    if(!isolated)
+        return;
+
+    CHECK(nd_environment_set("ND_ENVIRONMENT_TEST_UNSET", "native-must-remain", true) == 0);
+    ND_ENV_SNAPSHOT *before = nd_environment_snapshot_acquire(nd_environment_process());
+    CHECK(before != NULL);
+    if(!before) {
+        nd_environment_destroy(isolated);
+        return;
+    }
+
+    CHECK(nd_environment_freeze_process() == 0);
+    CHECK(nd_environment_freeze_process() == 0);
+    CHECK(nd_environment_is_process_frozen());
+
+    const char *native = getenv("ND_ENVIRONMENT_TEST_NATIVE");
+    char *native_copy = native ? strdupz(native) : NULL;
+#if defined(OS_WINDOWS)
+    char *native_windows_copy = test_windows_native_raw_dup("ND_ENVIRONMENT_TEST_NATIVE");
+    char *unset_windows_copy = test_windows_native_raw_dup("ND_ENVIRONMENT_TEST_UNSET");
+    char *native_windows_value_copy = test_windows_native_value_dup("ND_ENVIRONMENT_TEST_NATIVE");
+    char *unset_windows_value_copy = test_windows_native_value_dup("ND_ENVIRONMENT_TEST_UNSET");
+#endif
+
+    CHECK(nd_environment_set("ND_ENVIRONMENT_TEST_NATIVE", "managed-only", true) == 0);
+    char *managed = nd_environment_get_dup("ND_ENVIRONMENT_TEST_NATIVE");
+    CHECK(test_strings_equal(managed, "managed-only"));
+    CHECK(test_strings_equal(native_copy, getenv("ND_ENVIRONMENT_TEST_NATIVE")));
+#if defined(OS_WINDOWS)
+    char *native_windows_after = test_windows_native_raw_dup("ND_ENVIRONMENT_TEST_NATIVE");
+    char *native_windows_value_after = test_windows_native_value_dup("ND_ENVIRONMENT_TEST_NATIVE");
+    CHECK(native_windows_copy != NULL);
+    CHECK(native_windows_after != NULL);
+    CHECK(native_windows_value_copy != NULL);
+    CHECK(native_windows_value_after != NULL);
+    if(native_windows_copy && native_windows_after)
+        CHECK(test_strings_equal(native_windows_copy, native_windows_after));
+    if(native_windows_value_copy && native_windows_value_after)
+        CHECK(test_strings_equal(native_windows_value_copy, native_windows_value_after));
+    freez(native_windows_after);
+    freez(native_windows_value_after);
+#endif
+
+    CHECK(nd_environment_unset("ND_ENVIRONMENT_TEST_UNSET") == 0);
+    CHECK(test_strings_equal(getenv("ND_ENVIRONMENT_TEST_UNSET"), "native-must-remain"));
+#if defined(OS_WINDOWS)
+    char *unset_windows_after = test_windows_native_raw_dup("ND_ENVIRONMENT_TEST_UNSET");
+    char *unset_windows_value_after = test_windows_native_value_dup("ND_ENVIRONMENT_TEST_UNSET");
+    CHECK(unset_windows_copy != NULL);
+    CHECK(unset_windows_after != NULL);
+    CHECK(unset_windows_value_copy != NULL);
+    CHECK(unset_windows_value_after != NULL);
+    if(unset_windows_copy && unset_windows_after)
+        CHECK(test_strings_equal(unset_windows_copy, unset_windows_after));
+    if(unset_windows_value_copy && unset_windows_value_after)
+        CHECK(test_strings_equal(unset_windows_value_copy, unset_windows_value_after));
+    freez(unset_windows_after);
+    freez(unset_windows_value_after);
+#endif
+    char *removed = nd_environment_get_dup("ND_ENVIRONMENT_TEST_UNSET");
+    CHECK(removed == NULL);
+    freez(removed);
+
+    CHECK(nd_environment_context_set(isolated, "ISOLATED", "after", true) == 0);
+    CHECK(nd_environment_context_unset(isolated, "REMOVE") == 0);
+    CHECK(nd_environment_context_set(isolated, "APPENDED", "yes", true) == 0);
+    ND_ENV_SNAPSHOT *isolated_after = nd_environment_snapshot_acquire(isolated);
+    const char *const isolated_expected[] = { "ISOLATED=after", "APPENDED=yes", NULL };
+    check_snapshot_exact(isolated_after, isolated_expected);
+
+    ND_ENV_SNAPSHOT *after = nd_environment_snapshot_acquire(nd_environment_process());
+    CHECK(after != NULL);
+    CHECK(test_strings_equal(snapshot_value(after, "ND_ENVIRONMENT_TEST_NATIVE"), "managed-only"));
+    CHECK(test_strings_equal(snapshot_value(before, "ND_ENVIRONMENT_TEST_NATIVE"), "initializing"));
+    CHECK(test_strings_equal(snapshot_value(before, "ND_ENVIRONMENT_TEST_UNSET"), "native-must-remain"));
+    CHECK(snapshot_value(after, "ND_ENVIRONMENT_TEST_UNSET") == NULL);
+
+    nd_setenv("ND_ENVIRONMENT_TEST_BOOTSTRAP_WRAPPER", "managed", 1);
+    char *wrapper = nd_environment_get_dup("ND_ENVIRONMENT_TEST_BOOTSTRAP_WRAPPER");
+    CHECK(test_strings_equal(wrapper, "managed"));
+    CHECK(getenv("ND_ENVIRONMENT_TEST_BOOTSTRAP_WRAPPER") == NULL);
+
+    freez(wrapper);
+    freez(managed);
+    freez(native_copy);
+#if defined(OS_WINDOWS)
+    freez(native_windows_copy);
+    freez(unset_windows_copy);
+    freez(native_windows_value_copy);
+    freez(unset_windows_value_copy);
+#endif
+    nd_environment_snapshot_release(before);
+    nd_environment_snapshot_release(after);
+    nd_environment_snapshot_release(isolated_after);
+    nd_environment_destroy(isolated);
+}
+
+#if defined(OS_WINDOWS)
+static void test_windows_spawned_child_observation(void) {
+    char *generic_value = test_windows_narrow(L"caf\u00e9", CP_ACP);
+    char *path_value = test_windows_narrow(L"/c/t\u00e9st:/tmp", CP_UTF8);
+    CHECK(generic_value != NULL);
+    CHECK(path_value != NULL);
+    if(!generic_value || !path_value) {
+        freez(generic_value);
+        freez(path_value);
+        return;
+    }
+
+    CHECK(nd_environment_set("ND_ENVIRONMENT_TEST_CHILD_GENERIC", generic_value, true) == 0);
+    CHECK(nd_environment_set("LD_LIBRARY_PATH", path_value, true) == 0);
+
+    ND_ENV_SNAPSHOT *snapshot = nd_environment_snapshot_acquire(nd_environment_process());
+    CHECK(snapshot != NULL);
+    if(!snapshot) {
+        freez(generic_value);
+        freez(path_value);
+        return;
+    }
+
+    size_t block_size = 0;
+    const char *block = nd_environment_snapshot_windows_block(snapshot, &block_size);
+    CHECK(block != NULL);
+    CHECK(block_size >= 2);
+    if(!block || block_size < 2) {
+        nd_environment_snapshot_release(snapshot);
+        freez(generic_value);
+        freez(path_value);
+        return;
+    }
+
+    char executable[MAX_PATH + 1] = "";
+    DWORD executable_length = GetModuleFileNameA(NULL, executable, (DWORD)_countof(executable));
+    CHECK(executable_length > 0 && executable_length < _countof(executable));
+    if(!executable_length || executable_length >= _countof(executable)) {
+        nd_environment_snapshot_release(snapshot);
+        freez(generic_value);
+        freez(path_value);
+        return;
+    }
+
+    size_t command_length = executable_length + strlen("\"\" --windows-environment-child") + 1;
+    char *command = mallocz(command_length);
+    snprintfz(command, command_length, "\"%s\" --windows-environment-child", executable);
+
+    STARTUPINFOA startup = { .cb = sizeof(startup) };
+    PROCESS_INFORMATION process = { 0 };
+    BOOL created = CreateProcessA(
+        executable, command, NULL, NULL, FALSE, 0, (LPVOID)block, NULL, &startup, &process);
+    CHECK(created != FALSE);
+    if(created) {
+        CHECK(WaitForSingleObject(process.hProcess, 30000) == WAIT_OBJECT_0);
+        DWORD exit_code = UINT32_MAX;
+        CHECK(GetExitCodeProcess(process.hProcess, &exit_code) != FALSE);
+        CHECK(exit_code == 0);
+        CloseHandle(process.hThread);
+        CloseHandle(process.hProcess);
+    }
+
+    freez(command);
+    nd_environment_snapshot_release(snapshot);
+    freez(generic_value);
+    freez(path_value);
+}
+
+static void test_windows_managed_child_representation(void) {
+    const char *const empty[] = { NULL };
+    ND_ENVIRONMENT *environment = nd_environment_create_isolated(empty);
+    CHECK(environment != NULL);
+    if(!environment)
+        return;
+
+    char *utf8_path = test_windows_narrow(L"/c/t\u00e9st:/tmp", CP_UTF8);
+    char *acp_value = test_windows_narrow(L"caf\u00e9", CP_ACP);
+    CHECK(utf8_path != NULL);
+    CHECK(acp_value != NULL);
+
+    struct {
+        const char *name;
+        const char *value;
+    } cases[] = {
+        { "Path", utf8_path },
+        { "LD_LIBRARY_PATH", "/c/lib:/usr/lib" },
+        { "ORIGINAL_PATH", "/c/original:/bin" },
+        { "HOME", "/home/netdata" },
+        { "SHELL", "/usr/bin/bash" },
+        { "TMPDIR", "/tmp/netdata-dir" },
+        { "TMP", "/tmp/netdata-tmp" },
+        { "TEMP", "/tmp/netdata-temp" },
+        { "ND_ENVIRONMENT_TEST_NONASCII", acp_value },
+    };
+
+    for(size_t i = 0; i < _countof(cases); i++) {
+        if(cases[i].value)
+            CHECK(nd_environment_context_set(environment, cases[i].name, cases[i].value, true) == 0);
+    }
+
+    ND_ENV_SNAPSHOT *snapshot = nd_environment_snapshot_acquire(environment);
+    CHECK(snapshot != NULL);
+    if(snapshot) {
+        size_t block_size = 0;
+        const char *block = nd_environment_snapshot_windows_block(snapshot, &block_size);
+        CHECK(block != NULL);
+        CHECK(block_size >= 2);
+        if(block && block_size >= 2)
+            CHECK(block[block_size - 1] == '\0' && block[block_size - 2] == '\0');
+
+        for(size_t i = 0; i < _countof(cases); i++) {
+            if(!cases[i].value)
+                continue;
+
+            char *expected = test_windows_expected_raw(cases[i].name, cases[i].value);
+            const char *snapshot_raw = test_windows_snapshot_raw(snapshot, cases[i].name);
+            const char *block_raw = test_windows_block_raw(block, cases[i].name);
+            CHECK(expected != NULL);
+            CHECK(snapshot_raw != NULL);
+            CHECK(block_raw != NULL);
+            if(expected && snapshot_raw)
+                CHECK(test_strings_equal(snapshot_raw, expected));
+            if(expected && block_raw)
+                CHECK(test_strings_equal(block_raw, expected));
+            freez(expected);
+        }
+    }
+    nd_environment_snapshot_release(snapshot);
+
+    CHECK(nd_environment_context_set(environment, "shell", "", true) == 0);
+    snapshot = nd_environment_snapshot_acquire(environment);
+    CHECK(snapshot != NULL);
+    if(snapshot) {
+        char *expected = test_windows_expected_raw("SHELL", "");
+        const char *raw = test_windows_snapshot_raw(snapshot, "SHELL");
+        CHECK(expected != NULL);
+        CHECK(raw != NULL);
+        if(expected && raw)
+            CHECK(test_strings_equal(raw, expected));
+        freez(expected);
+    }
+    nd_environment_snapshot_release(snapshot);
+
+    freez(utf8_path);
+    freez(acp_value);
+    nd_environment_destroy(environment);
+}
+#endif
+
+#if !defined(OS_WINDOWS)
+static void test_fork_child_reset_and_replace(void) {
+    pid_t child = fork();
+    CHECK(child >= 0);
+    if(child == 0) {
+        if(nd_environment_fork_child_reset_from_native() != 0)
+            _exit(10);
+        if(nd_environment_is_process_frozen())
+            _exit(11);
+
+        const char *const replacement[] = {
+            "ONLY=yes",
+            "DUP=first",
+            "DUP=second",
+            "OPAQUE",
+            NULL,
+        };
+        if(nd_environment_fork_child_replace(replacement) != 0)
+            _exit(12);
+        if(!getenv("ONLY") || strcmp(getenv("ONLY"), "yes") != 0)
+            _exit(13);
+
+        char *dup = nd_environment_get_dup("DUP");
+        if(!dup || strcmp(dup, "first") != 0)
+            _exit(14);
+        freez(dup);
+
+        ND_ENV_SNAPSHOT *snapshot = nd_environment_snapshot_acquire(nd_environment_process());
+        if(!snapshot)
+            _exit(15);
+        const char *const expected[] = {
+            "ONLY=yes",
+            "DUP=first",
+            "DUP=second",
+            "OPAQUE",
+            NULL,
+        };
+        const char *const *actual = nd_environment_snapshot_envp(snapshot);
+        for(size_t i = 0; expected[i]; i++) {
+            if(!actual[i] || strcmp(actual[i], expected[i]) != 0)
+                _exit(16);
+        }
+        nd_environment_snapshot_release(snapshot);
+
+        if(nd_environment_freeze_process() != 0 || !nd_environment_is_process_frozen())
+            _exit(17);
+        _exit(0);
+    }
+
+    if(child > 0) {
+        int status = 0;
+        CHECK(waitpid(child, &status, 0) == child);
+        CHECK(WIFEXITED(status));
+        CHECK(WEXITSTATUS(status) == 0);
+    }
+}
+#endif
+
+int main(int argc, char **argv) {
+#if defined(OS_WINDOWS)
+    if(argc == 2 && strcmp(argv[1], "--windows-environment-child") == 0)
+        return test_windows_child_observation();
+#else
+    (void)argc;
+    (void)argv;
+#endif
+
+    test_preinit_contract();
+    test_import_and_native_mirroring();
+    test_windows_case_identity();
+    test_isolated_order_duplicates_and_opaque();
+    test_empty_and_owned_snapshot_destruction();
+    test_snapshot_failure_atomicity();
+    test_windows_block_builder();
+    test_process_freeze();
+#if defined(OS_WINDOWS)
+    test_windows_spawned_child_observation();
+    test_windows_managed_child_representation();
+#endif
+#if !defined(OS_WINDOWS)
+    test_fork_child_reset_and_replace();
+#endif
+    test_concurrent_writers_and_snapshot_readers();
+
+#if defined(OS_WINDOWS)
+    freez(windows_inherited_raw);
+#endif
+
+    if(failures) {
+        fprintf(stderr, "environment-unittest: %zu failure(s)\n", failures);
+        return 1;
+    }
+
+    fprintf(stderr, "environment-unittest: PASS\n");
+    return 0;
+}

--- a/src/libnetdata/environment/environment.c
+++ b/src/libnetdata/environment/environment.c
@@ -1,0 +1,1384 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#define NETDATA_NATIVE_ENVIRONMENT_ACCESS 1
+#include "libnetdata/libnetdata.h"
+
+#if defined(OS_MACOS)
+#include <crt_externs.h>
+#endif
+
+#if !defined(OS_MACOS)
+extern char **environ;
+#endif
+
+#define ND_ENVIRONMENT_MAGIC UINT64_C(0x4e44454e5649524f)
+
+typedef struct nd_env_entry {
+    struct nd_env_entry *prev;
+    struct nd_env_entry *next;
+
+    char *raw;
+    char *name;
+    char *value;
+#if defined(OS_WINDOWS)
+    bool managed_from_crt;
+#endif
+} ND_ENV_ENTRY;
+
+typedef struct nd_env_index {
+    ND_ENV_ENTRY *first;
+} ND_ENV_INDEX;
+
+struct nd_env_snapshot {
+    size_t references;
+    uint64_t generation;
+
+    size_t entries;
+    char **envp;
+
+    char *windows_block;
+    size_t windows_block_size;
+};
+
+struct nd_environment {
+    uint64_t magic;
+    bool process_global;
+    bool mirrors_native;
+
+    netdata_mutex_t mutation_mutex;
+    SPINLOCK publication_lock;
+
+    DICTIONARY *index;
+    ND_ENV_ENTRY *entries;
+    size_t entries_count;
+
+    uint64_t generation;
+    ND_ENV_SNAPSHOT *published;
+};
+
+typedef enum nd_environment_process_state {
+    ND_ENVIRONMENT_UNINITIALIZED = 0,
+    ND_ENVIRONMENT_IMPORTING = 1,
+    ND_ENVIRONMENT_INITIALIZING = 2,
+    ND_ENVIRONMENT_PROCESS_FROZEN = 3,
+} ND_ENVIRONMENT_PROCESS_STATE;
+
+static ND_ENVIRONMENT *process_environment = NULL;
+static int process_environment_state = ND_ENVIRONMENT_UNINITIALIZED;
+
+static int test_fail_native_once = 0;
+static int test_fail_snapshot_once = 0;
+
+// --------------------------------------------------------------------------------------------------------------------
+// Platform identity and native enumeration
+
+static char **environment_native_environ(void) {
+#if defined(OS_MACOS)
+    return *_NSGetEnviron();
+#else
+    return environ;
+#endif
+}
+
+static bool environment_name_is_valid(const char *name) {
+    return name && *name && !strchr(name, '=');
+}
+
+static bool environment_raw_parse(const char *raw, const char **value, size_t *name_length) {
+    if(!raw || !*raw)
+        return false;
+
+    const char *equals = strchr(raw, '=');
+    if(!equals || equals == raw)
+        return false;
+
+    if(value)
+        *value = equals + 1;
+    if(name_length)
+        *name_length = (size_t)(equals - raw);
+
+    return true;
+}
+
+static char *environment_ascii_casefold(const char *name) {
+    size_t length = strlen(name);
+    char *key = mallocz(length + 1);
+
+    for(size_t i = 0; i < length; i++)
+        key[i] = (char)tolower((unsigned char)name[i]);
+
+    key[length] = '\0';
+    return key;
+}
+
+#if defined(OS_WINDOWS)
+static wchar_t *environment_windows_wide(const char *text, UINT code_page) {
+    int length = MultiByteToWideChar(code_page, 0, text, -1, NULL, 0);
+    if(length <= 0)
+        return NULL;
+
+    wchar_t *wide = mallocz((size_t)length * sizeof(*wide));
+    if(MultiByteToWideChar(code_page, 0, text, -1, wide, length) <= 0) {
+        freez(wide);
+        return NULL;
+    }
+
+    return wide;
+}
+
+static char *environment_windows_narrow(const wchar_t *wide, UINT code_page) {
+    int length = WideCharToMultiByte(code_page, 0, wide, -1, NULL, 0, NULL, NULL);
+    if(length <= 0)
+        return NULL;
+
+    char *text = mallocz((size_t)length);
+    if(WideCharToMultiByte(code_page, 0, wide, -1, text, length, NULL, NULL) <= 0) {
+        freez(text);
+        return NULL;
+    }
+
+    return text;
+}
+
+static char *environment_windows_transcode(const char *text, UINT from, UINT to) {
+    wchar_t *wide = environment_windows_wide(text, from);
+    if(!wide)
+        return NULL;
+
+    char *converted = environment_windows_narrow(wide, to);
+    freez(wide);
+    return converted;
+}
+
+static char *environment_key(const char *name) {
+    wchar_t *wide = environment_windows_wide(name, CP_ACP);
+    if(!wide)
+        return environment_ascii_casefold(name);
+
+    int wide_length = (int)wcslen(wide) + 1;
+    wchar_t *lower = mallocz((size_t)wide_length * sizeof(*lower));
+    int mapped = LCMapStringEx(
+        LOCALE_NAME_INVARIANT, LCMAP_LOWERCASE, wide, wide_length, lower, wide_length, NULL, NULL, 0);
+    freez(wide);
+
+    if(mapped <= 0) {
+        freez(lower);
+        return environment_ascii_casefold(name);
+    }
+
+    int key_length = WideCharToMultiByte(CP_UTF8, 0, lower, -1, NULL, 0, NULL, NULL);
+    if(key_length <= 0) {
+        freez(lower);
+        return environment_ascii_casefold(name);
+    }
+
+    char *key = mallocz((size_t)key_length);
+    if(WideCharToMultiByte(CP_UTF8, 0, lower, -1, key, key_length, NULL, NULL) <= 0) {
+        freez(lower);
+        freez(key);
+        return environment_ascii_casefold(name);
+    }
+
+    freez(lower);
+    return key;
+}
+#else
+static char *environment_key(const char *name) {
+    return strdupz(name);
+}
+#endif
+
+static bool environment_names_equal(const char *left, const char *right) {
+#if defined(OS_WINDOWS)
+    char *left_key = environment_key(left);
+    char *right_key = environment_key(right);
+    bool equal = strcmp(left_key, right_key) == 0;
+    freez(left_key);
+    freez(right_key);
+    return equal;
+#else
+    return strcmp(left, right) == 0;
+#endif
+}
+
+#if defined(OS_WINDOWS)
+static bool environment_windows_path_list(const char *name) {
+    return environment_names_equal(name, "PATH") ||
+           environment_names_equal(name, "LD_LIBRARY_PATH") ||
+           environment_names_equal(name, "ORIGINAL_PATH");
+}
+
+static bool environment_windows_single_path(const char *name) {
+    return environment_names_equal(name, "HOME") ||
+           environment_names_equal(name, "SHELL") ||
+           environment_names_equal(name, "TMPDIR") ||
+           environment_names_equal(name, "TMP") ||
+           environment_names_equal(name, "TEMP");
+}
+#endif
+
+static char *environment_spawn_value_from_managed(const char *name, const char *value) {
+#if defined(OS_WINDOWS)
+    bool list = environment_windows_path_list(name);
+    bool path = environment_windows_single_path(name);
+
+    if(!list && !path)
+        return environment_windows_transcode(value, CP_ACP, CP_OEMCP);
+
+    // MSYS leaves an empty SHELL unchanged instead of converting it.
+    if(!*value && environment_names_equal(name, "SHELL"))
+        return environment_windows_transcode(value, CP_ACP, CP_OEMCP);
+
+    cygwin_conv_path_t conversion = CCP_POSIX_TO_WIN_W | (list ? CCP_RELATIVE : CCP_ABSOLUTE);
+    ssize_t required = list
+        ? cygwin_conv_path_list(conversion, value, NULL, 0)
+        : cygwin_conv_path(conversion, value, NULL, 0);
+    if(required <= 0)
+        return NULL;
+
+    wchar_t *wide = mallocz((size_t)required);
+    ssize_t result = list
+        ? cygwin_conv_path_list(conversion, value, wide, (size_t)required)
+        : cygwin_conv_path(conversion, value, wide, (size_t)required);
+    if(result != 0) {
+        freez(wide);
+        return NULL;
+    }
+
+    char *converted = environment_windows_narrow(wide, CP_OEMCP);
+    freez(wide);
+    return converted;
+#else
+    (void)name;
+    return strdupz(value);
+#endif
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Owned ordered entries and index
+
+static ND_ENV_ENTRY *environment_entry_from_raw(const char *raw) {
+    ND_ENV_ENTRY *entry = callocz(1, sizeof(*entry));
+    entry->raw = strdupz(raw ? raw : "");
+
+    const char *value = NULL;
+    size_t name_length = 0;
+    if(environment_raw_parse(entry->raw, &value, &name_length)) {
+        entry->name = strndupz(entry->raw, name_length);
+        entry->value = strdupz(value);
+    }
+
+    return entry;
+}
+
+#if defined(OS_WINDOWS)
+static ND_ENV_ENTRY *environment_entry_from_windows_native_raw(const char *raw) {
+    ND_ENV_ENTRY *entry = callocz(1, sizeof(*entry));
+    entry->raw = strdupz(raw ? raw : "");
+
+    const char *value_oem = NULL;
+    size_t name_length = 0;
+    if(environment_raw_parse(entry->raw, &value_oem, &name_length)) {
+        char *name_oem = strndupz(entry->raw, name_length);
+        entry->name = environment_windows_transcode(name_oem, CP_OEMCP, CP_ACP);
+        entry->value = environment_windows_transcode(value_oem, CP_OEMCP, CP_ACP);
+        freez(name_oem);
+
+        if(!entry->name || !entry->value) {
+            freez(entry->name);
+            freez(entry->value);
+            entry->name = NULL;
+            entry->value = NULL;
+        }
+    }
+
+    return entry;
+}
+#endif
+
+static char *environment_compose_raw(const char *name, const char *value) {
+    size_t name_length = strlen(name);
+    size_t value_length = strlen(value);
+
+    if(unlikely(name_length > SIZE_MAX - value_length - 2)) {
+        errno = EOVERFLOW;
+        return NULL;
+    }
+
+    char *raw = mallocz(name_length + value_length + 2);
+    memcpy(raw, name, name_length);
+    raw[name_length] = '=';
+    memcpy(&raw[name_length + 1], value, value_length + 1);
+    return raw;
+}
+
+static char *environment_spawn_raw_from_managed(const char *name, const char *value) {
+#if defined(OS_WINDOWS)
+    char *name_oem = environment_windows_transcode(name, CP_ACP, CP_OEMCP);
+    char *value_oem = environment_spawn_value_from_managed(name, value);
+    if(!name_oem || !value_oem) {
+        freez(name_oem);
+        freez(value_oem);
+        return NULL;
+    }
+
+    char *raw = environment_compose_raw(name_oem, value_oem);
+    freez(name_oem);
+    freez(value_oem);
+    return raw;
+#else
+    return environment_compose_raw(name, value);
+#endif
+}
+
+static ND_ENV_ENTRY *environment_entry_from_name_values(
+    const char *name, const char *managed_value, char *raw) {
+    if(!raw)
+        return NULL;
+
+    ND_ENV_ENTRY *entry = callocz(1, sizeof(*entry));
+    entry->raw = raw;
+    entry->name = strdupz(name);
+    entry->value = strdupz(managed_value);
+    return entry;
+}
+
+static void environment_entry_free(ND_ENV_ENTRY *entry) {
+    if(!entry)
+        return;
+
+    freez(entry->raw);
+    freez(entry->name);
+    freez(entry->value);
+    freez(entry);
+}
+
+static void environment_entry_append(ND_ENVIRONMENT *environment, ND_ENV_ENTRY *entry) {
+    DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(environment->entries, entry, prev, next);
+    environment->entries_count++;
+}
+
+static void environment_entries_clear(ND_ENVIRONMENT *environment) {
+    ND_ENV_ENTRY *entry = environment->entries;
+    while(entry) {
+        ND_ENV_ENTRY *next = entry->next;
+        environment_entry_free(entry);
+        entry = next;
+    }
+
+    environment->entries = NULL;
+    environment->entries_count = 0;
+}
+
+static DICTIONARY *environment_index_create(void) {
+    return dictionary_create_advanced(
+        DICT_OPTION_SINGLE_THREADED | DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE,
+        NULL,
+        sizeof(ND_ENV_INDEX));
+}
+
+static void environment_index_rebuild(ND_ENVIRONMENT *environment) {
+    DICTIONARY *index = environment_index_create();
+
+    for(ND_ENV_ENTRY *entry = environment->entries; entry; entry = entry->next) {
+        if(!entry->name)
+            continue;
+
+        char *key = environment_key(entry->name);
+        ND_ENV_INDEX value = { .first = entry };
+        dictionary_set(index, key, &value, sizeof(value));
+        freez(key);
+    }
+
+    DICTIONARY *old = environment->index;
+    environment->index = index;
+    if(old)
+        dictionary_destroy(old);
+}
+
+static ND_ENV_ENTRY *environment_index_get(ND_ENVIRONMENT *environment, const char *name) {
+    char *key = environment_key(name);
+    ND_ENV_INDEX *indexed = dictionary_get(environment->index, key);
+    freez(key);
+    return indexed ? indexed->first : NULL;
+}
+
+static ND_ENV_ENTRY *environment_find_linear(ND_ENVIRONMENT *environment, const char *name) {
+    for(ND_ENV_ENTRY *entry = environment->entries; entry; entry = entry->next) {
+        if(entry->name && environment_names_equal(entry->name, name))
+            return entry;
+    }
+
+    return NULL;
+}
+
+static int environment_import_vector(ND_ENVIRONMENT *environment, const char *const envp[]) {
+    if(!envp)
+        return 0;
+
+    for(size_t i = 0; envp[i]; i++) {
+        ND_ENV_ENTRY *entry = environment_entry_from_raw(envp[i]);
+#if defined(OS_WINDOWS)
+        if(entry->name) {
+            char *raw = environment_spawn_raw_from_managed(entry->name, entry->value);
+            if(!raw) {
+                environment_entry_free(entry);
+                return -1;
+            }
+
+            freez(entry->raw);
+            entry->raw = raw;
+        }
+#endif
+        environment_entry_append(environment, entry);
+    }
+
+    return 0;
+}
+
+#if defined(OS_WINDOWS)
+static bool environment_windows_crt_drive_entry(const char *raw) {
+    return raw && raw[0] == '!' && raw[1] && raw[2] && raw[3] == '=' &&
+           ((isalpha((unsigned char)raw[1]) && raw[2] == ':') || (raw[1] == ':' && raw[2] == ':'));
+}
+
+static int environment_import_windows_native(ND_ENVIRONMENT *environment) {
+    LPCH block = GetEnvironmentStringsA();
+    if(!block) {
+        errno = EIO;
+        return -1;
+    }
+
+    for(const char *entry = block; *entry; entry += strlen(entry) + 1)
+        environment_entry_append(environment, environment_entry_from_windows_native_raw(entry));
+
+    FreeEnvironmentStringsA(block);
+
+    // MSYS keeps a separate POSIX environment. Append ordinary variables absent
+    // from the Win32 block while retaining native spelling, order, and path values.
+    char **crt = environment_native_environ();
+    if(crt) {
+        for(size_t i = 0; crt[i]; i++) {
+            if(environment_windows_crt_drive_entry(crt[i]))
+                continue;
+
+            const char *value = NULL;
+            size_t name_length = 0;
+            if(!environment_raw_parse(crt[i], &value, &name_length))
+                continue;
+
+            char *name = strndupz(crt[i], name_length);
+            ND_ENV_ENTRY *native_entry = environment_find_linear(environment, name);
+            if(!native_entry) {
+                char *raw = environment_spawn_raw_from_managed(name, value);
+                if(!raw) {
+                    freez(name);
+                    errno = EILSEQ;
+                    return -1;
+                }
+                native_entry = environment_entry_from_name_values(name, value, raw);
+                native_entry->managed_from_crt = true;
+                environment_entry_append(environment, native_entry);
+            }
+            else if(!native_entry->managed_from_crt && strcmp(native_entry->value, value) != 0) {
+                // Managed reads follow the MSYS/CRT representation. The native
+                // raw entry remains the child-facing Win32 representation.
+                freez(native_entry->value);
+                native_entry->value = strdupz(value);
+            }
+            native_entry->managed_from_crt = true;
+            freez(name);
+        }
+    }
+
+    return 0;
+}
+#endif
+
+static ND_ENVIRONMENT *environment_create_empty(bool process_global, bool mirrors_native) {
+    ND_ENVIRONMENT *environment = callocz(1, sizeof(*environment));
+    if(netdata_mutex_init(&environment->mutation_mutex) != 0) {
+        freez(environment);
+        errno = EAGAIN;
+        return NULL;
+    }
+
+    spinlock_init(&environment->publication_lock);
+    environment->index = environment_index_create();
+    environment->process_global = process_global;
+    environment->mirrors_native = mirrors_native;
+    environment->generation = 1;
+    environment->magic = ND_ENVIRONMENT_MAGIC;
+    return environment;
+}
+
+static ND_ENVIRONMENT *environment_create_from_vector(
+    const char *const envp[], bool process_global, bool mirrors_native) {
+    ND_ENVIRONMENT *environment = environment_create_empty(process_global, mirrors_native);
+    if(!environment)
+        return NULL;
+
+    if(environment_import_vector(environment, envp) != 0) {
+        dictionary_destroy(environment->index);
+        netdata_mutex_destroy(&environment->mutation_mutex);
+        environment_entries_clear(environment);
+        freez(environment);
+        return NULL;
+    }
+    environment_index_rebuild(environment);
+    return environment;
+}
+
+static ND_ENVIRONMENT *environment_create_process_from_native(void) {
+#if defined(OS_WINDOWS)
+    ND_ENVIRONMENT *environment = environment_create_empty(true, true);
+    if(!environment)
+        return NULL;
+
+    if(environment_import_windows_native(environment) != 0) {
+        dictionary_destroy(environment->index);
+        netdata_mutex_destroy(&environment->mutation_mutex);
+        environment_entries_clear(environment);
+        freez(environment);
+        return NULL;
+    }
+
+    environment_index_rebuild(environment);
+    return environment;
+#else
+    return environment_create_from_vector((const char *const *)environment_native_environ(), true, true);
+#endif
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Native mutation during the initialization phase
+
+#if defined(OS_WINDOWS)
+static int environment_windows_native_get_dup(const char *name, bool *present, char **value) {
+    *present = false;
+    *value = NULL;
+
+    SetLastError(ERROR_SUCCESS);
+    DWORD required = GetEnvironmentVariableA(name, NULL, 0);
+    if(!required) {
+        DWORD error = GetLastError();
+        if(error == ERROR_ENVVAR_NOT_FOUND)
+            return 0;
+
+        if(error != ERROR_SUCCESS) {
+            errno = EIO;
+            return -1;
+        }
+
+        *present = true;
+        *value = strdupz("");
+        return 0;
+    }
+
+    char *copy = mallocz(required);
+    SetLastError(ERROR_SUCCESS);
+    DWORD copied = GetEnvironmentVariableA(name, copy, required);
+    if(!copied && GetLastError() != ERROR_SUCCESS) {
+        freez(copy);
+        errno = EIO;
+        return -1;
+    }
+
+    *present = true;
+    *value = copy;
+    return 0;
+}
+
+static int environment_windows_native_raw_get_dup(const char *name, char **raw) {
+    *raw = NULL;
+
+    LPCH block = GetEnvironmentStringsA();
+    if(!block) {
+        errno = EIO;
+        return -1;
+    }
+
+    for(const char *candidate = block; *candidate; candidate += strlen(candidate) + 1) {
+        size_t name_length = 0;
+        if(!environment_raw_parse(candidate, NULL, &name_length))
+            continue;
+
+        char *name_oem = strndupz(candidate, name_length);
+        char *name_acp = environment_windows_transcode(name_oem, CP_OEMCP, CP_ACP);
+        freez(name_oem);
+
+        bool matches = name_acp && environment_names_equal(name_acp, name);
+        freez(name_acp);
+        if(matches) {
+            *raw = strdupz(candidate);
+            break;
+        }
+    }
+
+    FreeEnvironmentStringsA(block);
+    if(!*raw) {
+        errno = ENOENT;
+        return -1;
+    }
+
+    return 0;
+}
+
+static void environment_windows_restore_crt(const char *name, const char *old_value) {
+    if(old_value)
+        setenv(name, old_value, 1);
+    else
+        unsetenv(name);
+}
+
+static int environment_native_set(const char *name, const char *value, char **managed_value, char **spawn_raw) {
+    if(__atomic_exchange_n(&test_fail_native_once, 0, __ATOMIC_ACQ_REL)) {
+        errno = EIO;
+        return -1;
+    }
+
+    const char *crt_borrowed = getenv(name);
+    char *old_crt = crt_borrowed ? strdupz(crt_borrowed) : NULL;
+    bool old_native_present = false;
+    char *old_native = NULL;
+    if(environment_windows_native_get_dup(name, &old_native_present, &old_native) != 0) {
+        freez(old_crt);
+        return -1;
+    }
+
+    if(!SetEnvironmentVariableA(name, value)) {
+        freez(old_crt);
+        freez(old_native);
+        errno = EIO;
+        return -1;
+    }
+
+    if(setenv(name, value, 1) != 0) {
+        int saved_errno = errno ? errno : EIO;
+        environment_windows_restore_crt(name, old_crt);
+        SetEnvironmentVariableA(name, old_native_present ? old_native : NULL);
+        freez(old_crt);
+        freez(old_native);
+        errno = saved_errno;
+        return -1;
+    }
+
+    const char *crt_current = getenv(name);
+    if(!crt_current) {
+        environment_windows_restore_crt(name, old_crt);
+        SetEnvironmentVariableA(name, old_native_present ? old_native : NULL);
+        freez(old_crt);
+        freez(old_native);
+        errno = EIO;
+        return -1;
+    }
+
+    bool now_present = false;
+    char *native_value = NULL;
+    char *verified_raw = NULL;
+    if(environment_windows_native_get_dup(name, &now_present, &native_value) != 0 || !now_present ||
+       environment_windows_native_raw_get_dup(name, &verified_raw) != 0) {
+        int saved_errno = errno ? errno : EIO;
+        environment_windows_restore_crt(name, old_crt);
+        SetEnvironmentVariableA(name, old_native_present ? old_native : NULL);
+        freez(old_crt);
+        freez(old_native);
+        freez(native_value);
+        freez(verified_raw);
+        errno = saved_errno;
+        return -1;
+    }
+
+    if(environment_windows_path_list(name) || environment_windows_single_path(name)) {
+        *spawn_raw = environment_spawn_raw_from_managed(name, crt_current);
+        if(!*spawn_raw) {
+            int saved_errno = errno ? errno : EILSEQ;
+            environment_windows_restore_crt(name, old_crt);
+            SetEnvironmentVariableA(name, old_native_present ? old_native : NULL);
+            freez(old_crt);
+            freez(old_native);
+            freez(native_value);
+            freez(verified_raw);
+            errno = saved_errno;
+            return -1;
+        }
+        freez(verified_raw);
+    }
+    else
+        *spawn_raw = verified_raw;
+
+    freez(old_crt);
+    freez(old_native);
+    freez(native_value);
+    *managed_value = strdupz(crt_current);
+    return 0;
+}
+
+static int environment_native_unset(const char *name) {
+    if(__atomic_exchange_n(&test_fail_native_once, 0, __ATOMIC_ACQ_REL)) {
+        errno = EIO;
+        return -1;
+    }
+
+    const char *crt_borrowed = getenv(name);
+    char *old_crt = crt_borrowed ? strdupz(crt_borrowed) : NULL;
+    bool old_native_present = false;
+    char *old_native = NULL;
+    if(environment_windows_native_get_dup(name, &old_native_present, &old_native) != 0) {
+        freez(old_crt);
+        return -1;
+    }
+
+    if(!SetEnvironmentVariableA(name, NULL)) {
+        freez(old_crt);
+        freez(old_native);
+        errno = EIO;
+        return -1;
+    }
+
+    if(unsetenv(name) != 0) {
+        int saved_errno = errno ? errno : EIO;
+        environment_windows_restore_crt(name, old_crt);
+        SetEnvironmentVariableA(name, old_native_present ? old_native : NULL);
+        freez(old_crt);
+        freez(old_native);
+        errno = saved_errno;
+        return -1;
+    }
+
+    freez(old_crt);
+    freez(old_native);
+    return 0;
+}
+#else
+static int environment_native_set(const char *name, const char *value, char **managed_value, char **spawn_raw) {
+    if(__atomic_exchange_n(&test_fail_native_once, 0, __ATOMIC_ACQ_REL)) {
+        errno = EIO;
+        return -1;
+    }
+
+    if(setenv(name, value, 1) != 0)
+        return -1;
+
+    *managed_value = strdupz(value);
+    *spawn_raw = environment_compose_raw(name, value);
+    if(!*spawn_raw) {
+        freez(*managed_value);
+        *managed_value = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+static int environment_native_unset(const char *name) {
+    if(__atomic_exchange_n(&test_fail_native_once, 0, __ATOMIC_ACQ_REL)) {
+        errno = EIO;
+        return -1;
+    }
+
+    return unsetenv(name);
+}
+#endif
+
+// --------------------------------------------------------------------------------------------------------------------
+// Windows environment block builder
+
+typedef struct nd_environment_sort_item {
+    const char *raw;
+    size_t name_length;
+#if defined(OS_WINDOWS)
+    wchar_t *wide_name;
+#endif
+} ND_ENVIRONMENT_SORT_ITEM;
+
+static size_t environment_windows_name_length(const char *raw) {
+    const char *equals = strchr(raw + (raw[0] == '='), '=');
+    return equals ? (size_t)(equals - raw) : strlen(raw);
+}
+
+static int environment_ascii_name_casecmp(
+    const char *left, size_t left_length, const char *right, size_t right_length) {
+    size_t common = MIN(left_length, right_length);
+    for(size_t i = 0; i < common; i++) {
+        unsigned char l = (unsigned char)tolower((unsigned char)left[i]);
+        unsigned char r = (unsigned char)tolower((unsigned char)right[i]);
+        if(l < r)
+            return -1;
+        if(l > r)
+            return 1;
+    }
+
+    return (left_length > right_length) - (left_length < right_length);
+}
+
+static int environment_windows_block_compare(const void *left_ptr, const void *right_ptr) {
+    const ND_ENVIRONMENT_SORT_ITEM *left = left_ptr;
+    const ND_ENVIRONMENT_SORT_ITEM *right = right_ptr;
+
+    int result = 0;
+#if defined(OS_WINDOWS)
+    if(left->wide_name && right->wide_name) {
+        int compared = CompareStringOrdinal(
+            left->wide_name, -1,
+            right->wide_name, -1,
+            TRUE);
+        if(compared == CSTR_LESS_THAN)
+            result = -1;
+        else if(compared == CSTR_GREATER_THAN)
+            result = 1;
+    }
+    else
+#endif
+        result = environment_ascii_name_casecmp(
+            left->raw, left->name_length, right->raw, right->name_length);
+
+    if(!result)
+        result = strcmp(left->raw, right->raw);
+
+    return result;
+}
+
+static char *environment_windows_block_build(
+    const char *const envp[], size_t entries, size_t *block_size) {
+    size_t included = 0;
+    for(size_t i = 0; i < entries; i++) {
+        if(envp[i] && *envp[i])
+            included++;
+    }
+
+    ND_ENVIRONMENT_SORT_ITEM *sorted = included ? callocz(included, sizeof(*sorted)) : NULL;
+    size_t position = 0;
+    for(size_t i = 0; i < entries; i++) {
+        if(!envp[i] || !*envp[i])
+            continue;
+
+        sorted[position].raw = envp[i];
+        sorted[position].name_length = environment_windows_name_length(envp[i]);
+#if defined(OS_WINDOWS)
+        char *name = strndupz(envp[i], sorted[position].name_length);
+        sorted[position].wide_name = environment_windows_wide(name, CP_OEMCP);
+        freez(name);
+#endif
+        position++;
+    }
+
+    if(included > 1)
+        qsort(sorted, included, sizeof(*sorted), environment_windows_block_compare);
+
+    size_t required = included ? 1 : 2;
+    for(size_t i = 0; i < included; i++) {
+        size_t length = strlen(sorted[i].raw) + 1;
+        if(unlikely(required > SIZE_MAX - length)) {
+#if defined(OS_WINDOWS)
+            for(size_t j = 0; j < included; j++)
+                freez(sorted[j].wide_name);
+#endif
+            freez(sorted);
+            errno = EOVERFLOW;
+            return NULL;
+        }
+        required += length;
+    }
+
+    char *block = callocz(required, 1);
+    char *dst = block;
+    for(size_t i = 0; i < included; i++) {
+        size_t length = strlen(sorted[i].raw) + 1;
+        memcpy(dst, sorted[i].raw, length);
+        dst += length;
+    }
+
+#if defined(OS_WINDOWS)
+    for(size_t i = 0; i < included; i++)
+        freez(sorted[i].wide_name);
+#endif
+    freez(sorted);
+
+    if(block_size)
+        *block_size = required;
+    return block;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Immutable snapshots
+
+static void environment_snapshot_free(ND_ENV_SNAPSHOT *snapshot) {
+    if(!snapshot)
+        return;
+
+    for(size_t i = 0; i < snapshot->entries; i++)
+        freez(snapshot->envp[i]);
+    freez(snapshot->envp);
+    freez(snapshot->windows_block);
+    freez(snapshot);
+}
+
+static void environment_snapshot_reference(ND_ENV_SNAPSHOT *snapshot) {
+    size_t references = __atomic_add_fetch(&snapshot->references, 1, __ATOMIC_ACQUIRE);
+    internal_fatal(!references, "ENVIRONMENT: snapshot reference count overflow");
+}
+
+void nd_environment_snapshot_release(ND_ENV_SNAPSHOT *snapshot) {
+    if(!snapshot)
+        return;
+
+    size_t references = __atomic_sub_fetch(&snapshot->references, 1, __ATOMIC_ACQ_REL);
+    if(!references)
+        environment_snapshot_free(snapshot);
+}
+
+static ND_ENV_SNAPSHOT *environment_snapshot_build_locked(ND_ENVIRONMENT *environment) {
+    if(__atomic_exchange_n(&test_fail_snapshot_once, 0, __ATOMIC_ACQ_REL)) {
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    if(unlikely(environment->entries_count == SIZE_MAX)) {
+        errno = EOVERFLOW;
+        return NULL;
+    }
+
+    ND_ENV_SNAPSHOT *snapshot = callocz(1, sizeof(*snapshot));
+    snapshot->references = 1; // context-owned publication reference
+    snapshot->generation = __atomic_load_n(&environment->generation, __ATOMIC_RELAXED);
+    snapshot->entries = environment->entries_count;
+    snapshot->envp = callocz(snapshot->entries + 1, sizeof(*snapshot->envp));
+
+    size_t i = 0;
+    for(ND_ENV_ENTRY *entry = environment->entries; entry; entry = entry->next)
+        snapshot->envp[i++] = strdupz(entry->raw);
+    internal_fatal(i != snapshot->entries, "ENVIRONMENT: ordered entry count changed while snapshotting");
+
+#if defined(OS_WINDOWS)
+    snapshot->windows_block = environment_windows_block_build(
+        (const char *const *)snapshot->envp, snapshot->entries, &snapshot->windows_block_size);
+    if(!snapshot->windows_block) {
+        environment_snapshot_free(snapshot);
+        return NULL;
+    }
+#endif
+
+    return snapshot;
+}
+
+static int environment_snapshot_publish_locked(ND_ENVIRONMENT *environment) {
+    uint64_t generation = __atomic_load_n(&environment->generation, __ATOMIC_RELAXED);
+
+    spinlock_lock(&environment->publication_lock);
+    bool current = environment->published && environment->published->generation == generation;
+    spinlock_unlock(&environment->publication_lock);
+    if(current)
+        return 0;
+
+    ND_ENV_SNAPSHOT *snapshot = environment_snapshot_build_locked(environment);
+    if(!snapshot)
+        return -1;
+
+    spinlock_lock(&environment->publication_lock);
+    ND_ENV_SNAPSHOT *old = environment->published;
+    environment->published = snapshot;
+    spinlock_unlock(&environment->publication_lock);
+
+    nd_environment_snapshot_release(old);
+    return 0;
+}
+
+ND_ENV_SNAPSHOT *nd_environment_snapshot_acquire(ND_ENVIRONMENT *environment) {
+    if(!nd_environment_is_initialized() || !environment || environment->magic != ND_ENVIRONMENT_MAGIC) {
+        errno = EPERM;
+        return NULL;
+    }
+
+    uint64_t generation = __atomic_load_n(&environment->generation, __ATOMIC_ACQUIRE);
+    spinlock_lock(&environment->publication_lock);
+    ND_ENV_SNAPSHOT *snapshot = environment->published;
+    if(snapshot && snapshot->generation == generation) {
+        environment_snapshot_reference(snapshot);
+        spinlock_unlock(&environment->publication_lock);
+        return snapshot;
+    }
+    spinlock_unlock(&environment->publication_lock);
+
+    netdata_mutex_lock(&environment->mutation_mutex);
+
+    generation = __atomic_load_n(&environment->generation, __ATOMIC_RELAXED);
+    spinlock_lock(&environment->publication_lock);
+    snapshot = environment->published;
+    if(snapshot && snapshot->generation == generation) {
+        environment_snapshot_reference(snapshot);
+        spinlock_unlock(&environment->publication_lock);
+        netdata_mutex_unlock(&environment->mutation_mutex);
+        return snapshot;
+    }
+    spinlock_unlock(&environment->publication_lock);
+
+    if(environment_snapshot_publish_locked(environment) != 0) {
+        netdata_mutex_unlock(&environment->mutation_mutex);
+        return NULL;
+    }
+
+    spinlock_lock(&environment->publication_lock);
+    snapshot = environment->published;
+    environment_snapshot_reference(snapshot);
+    spinlock_unlock(&environment->publication_lock);
+
+    netdata_mutex_unlock(&environment->mutation_mutex);
+    return snapshot;
+}
+
+const char *const *nd_environment_snapshot_envp(const ND_ENV_SNAPSHOT *snapshot) {
+    return snapshot ? (const char *const *)snapshot->envp : NULL;
+}
+
+size_t nd_environment_snapshot_entries(const ND_ENV_SNAPSHOT *snapshot) {
+    return snapshot ? snapshot->entries : 0;
+}
+
+uint64_t nd_environment_snapshot_generation(const ND_ENV_SNAPSHOT *snapshot) {
+    return snapshot ? snapshot->generation : 0;
+}
+
+const char *nd_environment_snapshot_windows_block(const ND_ENV_SNAPSHOT *snapshot, size_t *size) {
+    if(size)
+        *size = snapshot ? snapshot->windows_block_size : 0;
+    return snapshot ? snapshot->windows_block : NULL;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Managed reads and mutations
+
+int nd_environment_context_set(
+    ND_ENVIRONMENT *environment, const char *name, const char *value, bool overwrite) {
+    if(!nd_environment_is_initialized() || !environment || environment->magic != ND_ENVIRONMENT_MAGIC) {
+        errno = EPERM;
+        return -1;
+    }
+    if(!environment_name_is_valid(name) || !value) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    netdata_mutex_lock(&environment->mutation_mutex);
+    ND_ENV_ENTRY *entry = environment_index_get(environment, name);
+    if(entry && !overwrite) {
+        netdata_mutex_unlock(&environment->mutation_mutex);
+        return 0;
+    }
+
+    char *managed_value = NULL;
+    char *spawn_raw = NULL;
+    const char *display_name = entry ? entry->name : name;
+    if(environment->mirrors_native) {
+        if(environment_native_set(display_name, value, &managed_value, &spawn_raw) != 0) {
+            netdata_mutex_unlock(&environment->mutation_mutex);
+            return -1;
+        }
+    }
+    else {
+        managed_value = strdupz(value);
+        spawn_raw = environment_spawn_raw_from_managed(display_name, value);
+        if(!spawn_raw) {
+            freez(managed_value);
+            netdata_mutex_unlock(&environment->mutation_mutex);
+            return -1;
+        }
+    }
+
+    bool changed = !entry || strcmp(entry->value, managed_value) != 0 || strcmp(entry->raw, spawn_raw) != 0;
+    if(changed && entry) {
+        freez(entry->raw);
+        freez(entry->value);
+        entry->raw = spawn_raw;
+        entry->value = managed_value;
+        spawn_raw = NULL;
+        managed_value = NULL;
+    }
+    else if(changed) {
+        ND_ENV_ENTRY *new_entry = environment_entry_from_name_values(name, managed_value, spawn_raw);
+        if(!new_entry) {
+            freez(managed_value);
+            freez(spawn_raw);
+            netdata_mutex_unlock(&environment->mutation_mutex);
+            return -1;
+        }
+        spawn_raw = NULL;
+        environment_entry_append(environment, new_entry);
+    }
+
+    freez(managed_value);
+    freez(spawn_raw);
+
+    if(changed) {
+        environment_index_rebuild(environment);
+        __atomic_add_fetch(&environment->generation, 1, __ATOMIC_RELEASE);
+    }
+
+    netdata_mutex_unlock(&environment->mutation_mutex);
+    return 0;
+}
+
+int nd_environment_context_unset(ND_ENVIRONMENT *environment, const char *name) {
+    if(!nd_environment_is_initialized() || !environment || environment->magic != ND_ENVIRONMENT_MAGIC) {
+        errno = EPERM;
+        return -1;
+    }
+    if(!environment_name_is_valid(name)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    netdata_mutex_lock(&environment->mutation_mutex);
+    if(!environment_index_get(environment, name)) {
+        netdata_mutex_unlock(&environment->mutation_mutex);
+        return 0;
+    }
+
+    if(environment->mirrors_native && environment_native_unset(name) != 0) {
+        netdata_mutex_unlock(&environment->mutation_mutex);
+        return -1;
+    }
+
+    ND_ENV_ENTRY *entry = environment->entries;
+    while(entry) {
+        ND_ENV_ENTRY *next = entry->next;
+        if(entry->name && environment_names_equal(entry->name, name)) {
+            DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(environment->entries, entry, prev, next);
+            environment->entries_count--;
+            environment_entry_free(entry);
+        }
+        entry = next;
+    }
+
+    environment_index_rebuild(environment);
+    __atomic_add_fetch(&environment->generation, 1, __ATOMIC_RELEASE);
+    netdata_mutex_unlock(&environment->mutation_mutex);
+    return 0;
+}
+
+char *nd_environment_context_get_dup(ND_ENVIRONMENT *environment, const char *name) {
+    if(!nd_environment_is_initialized() || !environment || environment->magic != ND_ENVIRONMENT_MAGIC) {
+        errno = EPERM;
+        return NULL;
+    }
+    if(!environment_name_is_valid(name)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    netdata_mutex_lock(&environment->mutation_mutex);
+    ND_ENV_ENTRY *entry = environment_index_get(environment, name);
+    char *value = entry ? strdupz(entry->value) : NULL;
+    netdata_mutex_unlock(&environment->mutation_mutex);
+
+    errno = 0;
+    return value;
+}
+
+int nd_environment_set(const char *name, const char *value, bool overwrite) {
+    ND_ENVIRONMENT *environment = nd_environment_process();
+    if(!environment) {
+        errno = EPERM;
+        return -1;
+    }
+
+    return nd_environment_context_set(environment, name, value, overwrite);
+}
+
+int nd_environment_unset(const char *name) {
+    ND_ENVIRONMENT *environment = nd_environment_process();
+    if(!environment) {
+        errno = EPERM;
+        return -1;
+    }
+
+    return nd_environment_context_unset(environment, name);
+}
+
+char *nd_environment_get_dup(const char *name) {
+    ND_ENVIRONMENT *environment = nd_environment_process();
+    if(!environment) {
+        errno = EPERM;
+        return NULL;
+    }
+
+    return nd_environment_context_get_dup(environment, name);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Lifecycle and context ownership
+
+bool nd_environment_is_initialized(void) {
+    return __atomic_load_n(&process_environment_state, __ATOMIC_ACQUIRE) >= ND_ENVIRONMENT_INITIALIZING;
+}
+
+bool nd_environment_is_process_frozen(void) {
+    return __atomic_load_n(&process_environment_state, __ATOMIC_ACQUIRE) == ND_ENVIRONMENT_PROCESS_FROZEN;
+}
+
+ND_ENVIRONMENT *nd_environment_process(void) {
+    if(!nd_environment_is_initialized())
+        return NULL;
+
+    return __atomic_load_n(&process_environment, __ATOMIC_ACQUIRE);
+}
+
+int nd_environment_init(void) {
+    int expected = ND_ENVIRONMENT_UNINITIALIZED;
+    if(!__atomic_compare_exchange_n(
+           &process_environment_state,
+           &expected,
+           ND_ENVIRONMENT_IMPORTING,
+           false,
+           __ATOMIC_ACQ_REL,
+           __ATOMIC_ACQUIRE)) {
+        if(expected >= ND_ENVIRONMENT_INITIALIZING)
+            return 0;
+
+        errno = EBUSY;
+        return -1;
+    }
+
+    ND_ENVIRONMENT *environment = environment_create_process_from_native();
+    if(!environment) {
+        __atomic_store_n(&process_environment_state, ND_ENVIRONMENT_UNINITIALIZED, __ATOMIC_RELEASE);
+        return -1;
+    }
+
+    __atomic_store_n(&process_environment, environment, __ATOMIC_RELEASE);
+    __atomic_store_n(&process_environment_state, ND_ENVIRONMENT_INITIALIZING, __ATOMIC_RELEASE);
+    return 0;
+}
+
+int nd_environment_freeze_process(void) {
+    int state = __atomic_load_n(&process_environment_state, __ATOMIC_ACQUIRE);
+    if(state == ND_ENVIRONMENT_PROCESS_FROZEN)
+        return 0;
+    if(state != ND_ENVIRONMENT_INITIALIZING) {
+        errno = state == ND_ENVIRONMENT_IMPORTING ? EBUSY : EPERM;
+        return -1;
+    }
+
+    ND_ENVIRONMENT *environment = __atomic_load_n(&process_environment, __ATOMIC_ACQUIRE);
+    if(!environment) {
+        errno = EPERM;
+        return -1;
+    }
+
+    netdata_mutex_lock(&environment->mutation_mutex);
+    if(environment_snapshot_publish_locked(environment) != 0) {
+        netdata_mutex_unlock(&environment->mutation_mutex);
+        return -1;
+    }
+
+    environment->mirrors_native = false;
+    __atomic_store_n(&process_environment_state, ND_ENVIRONMENT_PROCESS_FROZEN, __ATOMIC_RELEASE);
+    netdata_mutex_unlock(&environment->mutation_mutex);
+    return 0;
+}
+
+ND_ENVIRONMENT *nd_environment_create_isolated(const char *const envp[]) {
+    if(!nd_environment_is_initialized()) {
+        errno = EPERM;
+        return NULL;
+    }
+
+    return environment_create_from_vector(envp, false, false);
+}
+
+void nd_environment_destroy(ND_ENVIRONMENT *environment) {
+    if(!environment || environment->magic != ND_ENVIRONMENT_MAGIC)
+        return;
+
+    if(environment->process_global) {
+        errno = EPERM;
+        return;
+    }
+
+    netdata_mutex_lock(&environment->mutation_mutex);
+    environment->magic = 0;
+
+    spinlock_lock(&environment->publication_lock);
+    ND_ENV_SNAPSHOT *snapshot = environment->published;
+    environment->published = NULL;
+    spinlock_unlock(&environment->publication_lock);
+
+    dictionary_destroy(environment->index);
+    environment->index = NULL;
+    environment_entries_clear(environment);
+    netdata_mutex_unlock(&environment->mutation_mutex);
+    netdata_mutex_destroy(&environment->mutation_mutex);
+
+    nd_environment_snapshot_release(snapshot);
+    freez(environment);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Post-fork child reset
+
+static void environment_fork_child_abandon_process(void) {
+    __atomic_store_n(&process_environment, NULL, __ATOMIC_RELAXED);
+    __atomic_store_n(&process_environment_state, ND_ENVIRONMENT_UNINITIALIZED, __ATOMIC_RELAXED);
+}
+
+int nd_environment_fork_child_reset_from_native(void) {
+    environment_fork_child_abandon_process();
+    return nd_environment_init();
+}
+
+int nd_environment_fork_child_replace(const char *const envp[]) {
+    if(!envp) {
+        errno = EINVAL;
+        return -1;
+    }
+
+#if defined(OS_WINDOWS)
+    errno = ENOTSUP;
+    return -1;
+#else
+    size_t entries = 0;
+    while(envp[entries]) {
+        if(unlikely(entries == SIZE_MAX - 1)) {
+            errno = EOVERFLOW;
+            return -1;
+        }
+        entries++;
+    }
+
+    char **native = callocz(entries + 1, sizeof(*native));
+    for(size_t i = 0; i < entries; i++)
+        native[i] = strdupz(envp[i]);
+
+#if defined(OS_MACOS)
+    *_NSGetEnviron() = native;
+#else
+    environ = native;
+#endif
+
+    environment_fork_child_abandon_process();
+    return nd_environment_init();
+#endif
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Focused test hooks
+
+void nd_environment_test_fail_native_once(void) {
+    __atomic_store_n(&test_fail_native_once, 1, __ATOMIC_RELEASE);
+}
+
+void nd_environment_test_fail_snapshot_once(void) {
+    __atomic_store_n(&test_fail_snapshot_once, 1, __ATOMIC_RELEASE);
+}
+
+char *nd_environment_test_windows_block(const char *const envp[], size_t *size) {
+    if(!envp) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    size_t entries = 0;
+    while(envp[entries])
+        entries++;
+
+    return environment_windows_block_build(envp, entries, size);
+}

--- a/src/libnetdata/environment/environment.h
+++ b/src/libnetdata/environment/environment.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_ENVIRONMENT_H
+#define NETDATA_ENVIRONMENT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct nd_environment ND_ENVIRONMENT;
+typedef struct nd_env_snapshot ND_ENV_SNAPSHOT;
+
+// Import native storage during single-threaded initialization. Freeze native mirroring before
+// starting application/library workers; managed updates and future child snapshots remain mutable.
+// Lifecycle int functions return 0 on success and -1 with errno on failure.
+int nd_environment_init(void);
+int nd_environment_freeze_process(void);
+bool nd_environment_is_initialized(void);
+bool nd_environment_is_process_frozen(void);
+ND_ENVIRONMENT *nd_environment_process(void);
+
+// Process-global managed environment. Returned values are owned by the caller and freed with freez().
+int nd_environment_set(const char *name, const char *value, bool overwrite);
+int nd_environment_unset(const char *name);
+char *nd_environment_get_dup(const char *name);
+
+// Managed-only contexts for restricted child environments. The owner must serialize destruction
+// against context operations; already-acquired snapshots remain valid independently.
+ND_ENVIRONMENT *nd_environment_create_isolated(const char *const envp[]);
+void nd_environment_destroy(ND_ENVIRONMENT *environment);
+int nd_environment_context_set(ND_ENVIRONMENT *environment, const char *name, const char *value, bool overwrite);
+int nd_environment_context_unset(ND_ENVIRONMENT *environment, const char *name);
+char *nd_environment_context_get_dup(ND_ENVIRONMENT *environment, const char *name);
+
+// Immutable spawn generations. Accessors remain valid until the acquired snapshot is released.
+ND_ENV_SNAPSHOT *nd_environment_snapshot_acquire(ND_ENVIRONMENT *environment);
+void nd_environment_snapshot_release(ND_ENV_SNAPSHOT *snapshot);
+const char *const *nd_environment_snapshot_envp(const ND_ENV_SNAPSHOT *snapshot);
+size_t nd_environment_snapshot_entries(const ND_ENV_SNAPSHOT *snapshot);
+uint64_t nd_environment_snapshot_generation(const ND_ENV_SNAPSHOT *snapshot);
+const char *nd_environment_snapshot_windows_block(const ND_ENV_SNAPSHOT *snapshot, size_t *size);
+
+// Child-only operations used immediately after a safe single-threaded fork().
+int nd_environment_fork_child_reset_from_native(void);
+int nd_environment_fork_child_replace(const char *const envp[]);
+
+#ifdef NETDATA_INTERNAL_CHECKS
+// Focused fault injection and platform-neutral Windows-block validation hooks.
+void nd_environment_test_fail_native_once(void);
+void nd_environment_test_fail_snapshot_once(void);
+char *nd_environment_test_windows_block(const char *const envp[], size_t *size);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NETDATA_ENVIRONMENT_H

--- a/src/libnetdata/environment/native-environment-compiler-check.h
+++ b/src/libnetdata/environment/native-environment-compiler-check.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_NATIVE_ENVIRONMENT_COMPILER_CHECK_H
+#define NETDATA_NATIVE_ENVIRONMENT_COMPILER_CHECK_H
+
+// System and project declarations are already visible when this header is
+// included. Poisoning here also catches native API names produced by macros.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(NETDATA_NATIVE_ENVIRONMENT_ACCESS)
+#if defined(OS_WINDOWS)
+// MSYS aliases the ANSI entry point to its unsuffixed implementation.
+#undef GetEnvironmentStringsA
+#endif
+#pragma GCC poison getenv _wgetenv getenv_s _wgetenv_s _dupenv_s _wdupenv_s secure_getenv
+#pragma GCC poison setenv unsetenv putenv _putenv _wputenv _putenv_s _wputenv_s clearenv
+#pragma GCC poison environ _environ __environ _wenviron _NSGetEnviron __p__environ
+#pragma GCC poison GetEnvironmentStringsA GetEnvironmentStringsW
+#pragma GCC poison FreeEnvironmentStringsA FreeEnvironmentStringsW
+#pragma GCC poison GetEnvironmentVariableA GetEnvironmentVariableW
+#pragma GCC poison SetEnvironmentVariableA SetEnvironmentVariableW
+#pragma GCC poison ExpandEnvironmentStringsA ExpandEnvironmentStringsW
+#endif
+
+#endif // NETDATA_NATIVE_ENVIRONMENT_COMPILER_CHECK_H

--- a/src/libnetdata/libnetdata.h
+++ b/src/libnetdata/libnetdata.h
@@ -4,6 +4,10 @@
 #define NETDATA_LIB_H 1
 
 # ifdef __cplusplus
+// The environment compiler guard is applied at the end of this header. Load
+// the standard C library facade first so later C++ headers cannot redeclare a
+// poisoned native environment API.
+#include <cstdlib>
 extern "C" {
 # endif
 
@@ -94,6 +98,7 @@ struct web_buffer *run_command_and_get_output_to_buffer(const char *command, int
 // this may include windows.h
 #include "os/os.h"
 #include "os/ci.h"
+#include "environment/environment.h"
 
 #include "socket/socket.h"
 #include "socket/nd-sock.h"
@@ -327,6 +332,8 @@ static inline void *CLEANUP_FUNCTION_GET_PTR(void *pptr) {
 }
 
 // --------------------------------------------------------------------------------------------------------------------
+
+#include "environment/native-environment-compiler-check.h"
 
 # ifdef __cplusplus
 }

--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -189,7 +189,6 @@ typedef struct local_socket_state {
     struct timing_work timings[30];
 
 #if defined(LOCAL_SOCKETS_USE_SETNS)
-    bool spawn_server_is_mine;
     SPAWN_SERVER *spawn_server;
 #endif
 
@@ -1350,14 +1349,6 @@ static inline void local_sockets_init(LS_STATE *ls) {
     ls->tmp_protocol = 0;
 #endif
 
-#if defined(LOCAL_SOCKETS_USE_SETNS)
-    if(ls->config.namespaces && ls->spawn_server == NULL) {
-        ls->spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, NULL, local_sockets_spawn_server_callback, 0, NULL);
-        ls->spawn_server_is_mine = true;
-    }
-    else
-        ls->spawn_server_is_mine = false;
-#endif
 }
 
 static inline void local_sockets_cleanup(LS_STATE *ls) {
@@ -1366,14 +1357,6 @@ static inline void local_sockets_cleanup(LS_STATE *ls) {
         procfile_close(ls->ff);
         ls->ff = NULL;
     }
-
-#if defined(LOCAL_SOCKETS_USE_SETNS)
-    if(ls->spawn_server_is_mine) {
-        spawn_server_destroy(ls->spawn_server);
-        ls->spawn_server = NULL;
-        ls->spawn_server_is_mine = false;
-    }
-#endif
 
     // free the sockets hashtable data
     for(SIMPLE_HASHTABLE_SLOT_LOCAL_SOCKET *sl = simple_hashtable_first_read_only_LOCAL_SOCKET(&ls->sockets_hashtable);

--- a/src/libnetdata/log/nd_log-config.c
+++ b/src/libnetdata/log/nd_log-config.c
@@ -2,6 +2,11 @@
 
 #include "nd_log-internals.h"
 
+static void nd_log_publish_environment_value(const char *name, const char *value) {
+    if(nd_environment_set(name, value, true) != 0)
+        fatal("Cannot publish required logging environment variable '%s': %s", name, strerror(errno));
+}
+
 void nd_log_set_user_settings(ND_LOG_SOURCES source, const char *setting) {
     char buf[FILENAME_MAX + 100];
     if(setting && *setting)
@@ -145,22 +150,6 @@ void nd_log_set_user_settings(ND_LOG_SOURCES source, const char *setting) {
     ls->min_priority = NDLP_DEBUG;
 #endif
 
-    if(source == NDLS_COLLECTORS) {
-        // set the method for the collector processes we will spawn
-
-        ND_LOG_METHOD method = NDLM_STDERR;
-        ND_LOG_FORMAT format = NDLF_LOGFMT;
-        ND_LOG_FIELD_PRIORITY priority = ls->min_priority;
-
-        if(IS_VALID_LOG_METHOD_FOR_EXTERNAL_PLUGINS(ls->method)) {
-            method = ls->method;
-            format = ls->format;
-        }
-
-        nd_setenv("NETDATA_LOG_METHOD", nd_log_id2method(method), 1);
-        nd_setenv("NETDATA_LOG_FORMAT", nd_log_id2format(format), 1);
-        nd_setenv("NETDATA_LOG_LEVEL", nd_log_id2priority(priority), 1);
-    }
 }
 
 void nd_log_set_priority_level(const char *setting) {
@@ -178,8 +167,6 @@ void nd_log_set_priority_level(const char *setting) {
             nd_log.sources[i].min_priority = priority;
     }
 
-    // the right one
-    nd_setenv("NETDATA_LOG_LEVEL", nd_log_id2priority(priority), 1);
 }
 
 void nd_log_set_facility(const char *facility) {
@@ -187,7 +174,6 @@ void nd_log_set_facility(const char *facility) {
         facility = "daemon";
 
     nd_log.syslog.facility = nd_log_facility2id(facility);
-    nd_setenv("NETDATA_SYSLOG_FACILITY", nd_log_id2facility(nd_log.syslog.facility), 1);
 }
 
 void nd_log_set_flood_protection(size_t logs, time_t period) {
@@ -205,9 +191,36 @@ void nd_log_set_flood_protection(size_t logs, time_t period) {
     nd_log.sources[NDLS_COLLECTORS].limits.throttle_period = period;
     spinlock_unlock(&nd_log.sources[NDLS_COLLECTORS].limits.spinlock);
 
+}
+
+void nd_log_publish_child_environment(void) {
+    struct nd_log_source *collectors = &nd_log.sources[NDLS_COLLECTORS];
+    ND_LOG_METHOD method = NDLM_STDERR;
+    ND_LOG_FORMAT format = NDLF_LOGFMT;
+
+    if(IS_VALID_LOG_METHOD_FOR_EXTERNAL_PLUGINS(collectors->method)) {
+        method = collectors->method;
+        format = collectors->format;
+    }
+
+    nd_log_publish_environment_value("NETDATA_LOG_METHOD", nd_log_id2method(method));
+    nd_log_publish_environment_value("NETDATA_LOG_FORMAT", nd_log_id2format(format));
+    nd_log_publish_environment_value("NETDATA_LOG_LEVEL", nd_log_id2priority(collectors->min_priority));
+    nd_log_publish_environment_value("NETDATA_SYSLOG_FACILITY", nd_log_id2facility(nd_log.syslog.facility));
+
+    uint32_t period;
+    uint32_t logs;
+    spinlock_lock(&collectors->limits.spinlock);
+    period = collectors->limits.throttle_period;
+    logs = collectors->limits.logs_per_period_backup;
+    spinlock_unlock(&collectors->limits.spinlock);
+
     char buf[100];
-    snprintfz(buf, sizeof(buf), "%" PRIu64, (uint64_t)period);
-    nd_setenv("NETDATA_ERRORS_THROTTLE_PERIOD", buf, 1);
-    snprintfz(buf, sizeof(buf), "%" PRIu64, (uint64_t)logs);
-    nd_setenv("NETDATA_ERRORS_PER_PERIOD", buf, 1);
+    snprintfz(buf, sizeof(buf), "%" PRIu32, period);
+    nd_log_publish_environment_value("NETDATA_ERRORS_THROTTLE_PERIOD", buf);
+    snprintfz(buf, sizeof(buf), "%" PRIu32, logs);
+    nd_log_publish_environment_value("NETDATA_ERRORS_PER_PERIOD", buf);
+
+    if(collectors->method == NDLM_JOURNAL && nd_log.journal_direct.initialized)
+        nd_log_publish_environment_value("NETDATA_SYSTEMD_JOURNAL_PATH", nd_log.journal_direct.filename);
 }

--- a/src/libnetdata/log/nd_log-init.c
+++ b/src/libnetdata/log/nd_log-init.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#define NETDATA_NATIVE_ENVIRONMENT_ACCESS 1
 #include "nd_log-internals.h"
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -49,6 +50,8 @@ void nd_log_initialize_mutexes(void) {
 
 void nd_log_initialize_for_external_plugins(const char *name) {
     nd_log_initialize_mutexes();
+    if(nd_environment_init() != 0)
+        fatal("Cannot initialize the managed process environment");
 
     // if we don't run under Netdata, log to stderr,
     // otherwise, use the logging method Netdata wants us to use.
@@ -77,31 +80,39 @@ void nd_log_initialize_for_external_plugins(const char *name) {
         nd_log.sources[i].fp = NULL;
     }
 
-    nd_log_set_priority_level(getenv("NETDATA_LOG_LEVEL"));
-    nd_log_set_facility(getenv("NETDATA_SYSLOG_FACILITY"));
+    CLEAN_CHAR_P *log_level = nd_environment_get_dup("NETDATA_LOG_LEVEL");
+    CLEAN_CHAR_P *syslog_facility = nd_environment_get_dup("NETDATA_SYSLOG_FACILITY");
+    nd_log_set_priority_level(log_level);
+    nd_log_set_facility(syslog_facility);
 
     time_t period = 1200;
     size_t logs = 200;
-    const char *s = getenv("NETDATA_ERRORS_THROTTLE_PERIOD");
+    CLEAN_CHAR_P *throttle_period = nd_environment_get_dup("NETDATA_ERRORS_THROTTLE_PERIOD");
+    const char *s = throttle_period;
     if(s && *s >= '0' && *s <= '9') {
         period = str2l(s);
         if(period < 0) period = 0;
     }
 
-    s = getenv("NETDATA_ERRORS_PER_PERIOD");
+    CLEAN_CHAR_P *errors_per_period = nd_environment_get_dup("NETDATA_ERRORS_PER_PERIOD");
+    s = errors_per_period;
     if(s && *s >= '0' && *s <= '9')
         logs = str2u(s);
 
     nd_log_set_flood_protection(logs, period);
 
     if(!netdata_configured_host_prefix) {
-        s = getenv("NETDATA_HOST_PREFIX");
-        if(s && *s)
-            netdata_configured_host_prefix = (char *)s;
+        CLEAN_CHAR_P *host_prefix = nd_environment_get_dup("NETDATA_HOST_PREFIX");
+        if(host_prefix && *host_prefix) {
+            netdata_configured_host_prefix = host_prefix;
+            host_prefix = NULL;
+        }
     }
 
-    ND_LOG_METHOD method = nd_log_method2id(getenv("NETDATA_LOG_METHOD"));
-    ND_LOG_FORMAT format = nd_log_format2id(getenv("NETDATA_LOG_FORMAT"));
+    CLEAN_CHAR_P *log_method = nd_environment_get_dup("NETDATA_LOG_METHOD");
+    CLEAN_CHAR_P *log_format = nd_environment_get_dup("NETDATA_LOG_FORMAT");
+    ND_LOG_METHOD method = nd_log_method2id(log_method);
+    ND_LOG_FORMAT format = nd_log_format2id(log_format);
 
     if(!IS_VALID_LOG_METHOD_FOR_EXTERNAL_PLUGINS(method)) {
         if(is_stderr_connected_to_journal()) {
@@ -115,13 +126,15 @@ void nd_log_initialize_for_external_plugins(const char *name) {
     }
 
     switch(method) {
-        case NDLM_JOURNAL:
-            if(!nd_log_journal_direct_init(getenv("NETDATA_SYSTEMD_JOURNAL_PATH")) &&
+        case NDLM_JOURNAL: {
+            CLEAN_CHAR_P *journal_path = nd_environment_get_dup("NETDATA_SYSTEMD_JOURNAL_PATH");
+            if(!nd_log_journal_direct_init(journal_path) &&
                 !nd_log_journal_direct_init(NULL) && !nd_log_journal_systemd_init()) {
                 nd_log(NDLS_COLLECTORS, NDLP_WARNING, "Failed to initialize journal. Using stderr.");
                 method = NDLM_STDERR;
             }
             break;
+        }
 
 #if defined(OS_WINDOWS)
 #if defined(HAVE_ETW)
@@ -155,6 +168,8 @@ void nd_log_initialize_for_external_plugins(const char *name) {
     nd_log.sources[NDLS_COLLECTORS].format = format;
     nd_log.sources[NDLS_COLLECTORS].fd = -1;
     nd_log.sources[NDLS_COLLECTORS].fp = NULL;
+
+    nd_log_publish_child_environment();
 
     //    nd_log(NDLS_COLLECTORS, NDLP_NOTICE, "FINAL_LOG_METHOD: %s", nd_log_id2method(method));
 

--- a/src/libnetdata/log/nd_log-to-systemd-journal.c
+++ b/src/libnetdata/log/nd_log-to-systemd-journal.c
@@ -44,16 +44,9 @@ bool nd_log_journal_socket_available(void) {
     return true;
 }
 
-static void nd_log_journal_direct_set_env(void) {
-    if(nd_log.sources[NDLS_COLLECTORS].method == NDLM_JOURNAL)
-        nd_setenv("NETDATA_SYSTEMD_JOURNAL_PATH", nd_log.journal_direct.filename, 1);
-}
-
 bool nd_log_journal_direct_init(const char *path) {
-    if(nd_log.journal_direct.initialized) {
-        nd_log_journal_direct_set_env();
+    if(nd_log.journal_direct.initialized)
         return true;
-    }
 
     int fd;
     char filename[FILENAME_MAX];
@@ -71,8 +64,6 @@ bool nd_log_journal_direct_init(const char *path) {
     nd_log.journal_direct.initialized = true;
 
     strncpyz(nd_log.journal_direct.filename, filename, sizeof(nd_log.journal_direct.filename) - 1);
-    nd_log_journal_direct_set_env();
-
     return true;
 }
 

--- a/src/libnetdata/log/nd_log.h
+++ b/src/libnetdata/log/nd_log.h
@@ -21,6 +21,7 @@ void nd_log_set_facility(const char *facility);
 void nd_log_set_priority_level(const char *setting);
 void nd_log_initialize_mutexes(void);
 void nd_log_initialize(void);
+void nd_log_publish_child_environment(void);
 void nd_log_reopen_log_files(bool log);
 void chown_open_file(int fd, uid_t uid, gid_t gid);
 void nd_log_chown_log_files(uid_t uid, gid_t gid);

--- a/src/libnetdata/log/systemd-cat-native.c
+++ b/src/libnetdata/log/systemd-cat-native.c
@@ -304,8 +304,10 @@ static log_to_journal_remote_ret_t log_input_to_journal_remote(const char *url, 
         }
     }
 
-    if(global_systemd_invocation_id[0] == '\0' && getenv("INVOCATION_ID"))
-        snprintfz(global_systemd_invocation_id, sizeof(global_systemd_invocation_id), "_SYSTEMD_INVOCATION_ID=%s\n", getenv("INVOCATION_ID"));
+    CLEAN_CHAR_P *invocation_id = nd_environment_get_dup("INVOCATION_ID");
+    if(global_systemd_invocation_id[0] == '\0' && invocation_id)
+        snprintfz(global_systemd_invocation_id, sizeof(global_systemd_invocation_id),
+                  "_SYSTEMD_INVOCATION_ID=%s\n", invocation_id);
 
     if(!key)
         key = DEFAULT_PRIVATE_KEY;
@@ -736,12 +738,15 @@ cleanup:
 
 int main(int argc, char *argv[]) {
     nd_log_initialize_for_external_plugins(argv[0]);
+    if(nd_environment_freeze_process() != 0)
+        fatal("Cannot freeze the process environment: %s", strerror(errno));
 
     int timeout_ms = 0; // wait forever
     bool log_as_netdata = false;
     const char *newline = "\\n";
     const char *namespace = NULL;
-    const char *socket = getenv("NETDATA_SYSTEMD_JOURNAL_PATH");
+    CLEAN_CHAR_P *socket_from_environment = nd_environment_get_dup("NETDATA_SYSTEMD_JOURNAL_PATH");
+    const char *socket = socket_from_environment;
 #ifdef HAVE_LIBCURL
     const char *url = NULL;
     const char *key = NULL;

--- a/src/libnetdata/log/systemd-journal-helpers.c
+++ b/src/libnetdata/log/systemd-journal-helpers.c
@@ -23,7 +23,7 @@ bool is_path_unix_socket(const char *path) {
 }
 
 bool is_stderr_connected_to_journal(void) {
-    const char *journal_stream = getenv("JOURNAL_STREAM");
+    CLEAN_CHAR_P *journal_stream = nd_environment_get_dup("JOURNAL_STREAM");
     if (!journal_stream)
         return false; // JOURNAL_STREAM is not set
 

--- a/src/libnetdata/os/ci.c
+++ b/src/libnetdata/os/ci.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "ci.h"
+#include "libnetdata/libnetdata.h"
 
 #include <stdlib.h>
 
@@ -36,7 +37,8 @@ bool nd_is_running_under_ci(void) {
     };
 
     for (const char **env = ci_vars; *env; env++) {
-        if(getenv(*env))
+        CLEAN_CHAR_P *value = nd_environment_get_dup(*env);
+        if(value)
             return true;
     }
 

--- a/src/libnetdata/os/hostname.c
+++ b/src/libnetdata/os/hostname.c
@@ -73,14 +73,17 @@ bool os_hostname(char *dst, size_t dst_size, const char *filesystem_root __maybe
 #ifdef HAVE_LIBICONV
 #include <iconv.h>
 
-static const char *get_current_locale(void) {
-    const char *locale = getenv("LC_ALL");  // LC_ALL overrides all other locale settings
+static char *get_current_locale(void) {
+    char *locale = nd_environment_get_dup("LC_ALL");  // LC_ALL overrides all other locale settings
 
     if (!locale || !*locale) {
-        locale = getenv("LC_CTYPE");  // Check LC_CTYPE for character encoding
+        freez(locale);
+        locale = nd_environment_get_dup("LC_CTYPE");  // Check LC_CTYPE for character encoding
 
-        if (!locale || !*locale)
-            locale = getenv("LANG");  // Fallback to LANG
+        if (!locale || !*locale) {
+            freez(locale);
+            locale = nd_environment_get_dup("LANG");  // Fallback to LANG
+        }
     }
 
     return locale;
@@ -144,7 +147,7 @@ bool os_hostname(char *dst, size_t dst_size, const char *filesystem_root) {
     char *original_hostname = trim(buf);
 
 #ifdef HAVE_LIBICONV
-    const char *locale = get_current_locale();
+    CLEAN_CHAR_P *locale = get_current_locale();
     if (original_hostname && locale && *locale) {
         char utf8_output[HOST_NAME_MAX * 4 + 1] = "";
         if(iconv_convert_to_utf8(original_hostname, get_encoding_from_locale(locale), utf8_output, sizeof(utf8_output))) {

--- a/src/libnetdata/os/run_dir.c
+++ b/src/libnetdata/os/run_dir.c
@@ -5,6 +5,7 @@
 
 static char *cached_run_dir = NULL;
 static bool cached_run_dir_available = false;
+static bool cached_run_dir_published = false;
 static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
 static inline bool is_dir_accessible(const char *dir, bool rw) {
@@ -15,11 +16,32 @@ static inline bool is_dir_accessible(const char *dir, bool rw) {
     if (!S_ISDIR(st.st_mode))
         return false;
 
-    // Check if we can write to the directory
-    if (access(dir, rw ? W_OK : R_OK) == -1)
+    // Directory access always requires search permission.
+    if (access(dir, (rw ? W_OK : R_OK) | X_OK) == -1)
         return false;
 
     return true;
+}
+
+static bool make_dir_writable(const char *dir) {
+    struct stat st;
+    if(stat(dir, &st) == -1) {
+        if(errno != ENOENT)
+            return false;
+
+        if(mkdir(dir, 0755) == -1 && errno != EEXIST)
+            return false;
+
+        if(stat(dir, &st) == -1)
+            return false;
+    }
+
+    if(!S_ISDIR(st.st_mode)) {
+        errno = ENOTDIR;
+        return false;
+    }
+
+    return access(dir, W_OK | X_OK) == 0;
 }
 
 static inline bool netdata_dir_in_parent(const char *parent, char *out_path, size_t out_path_len, bool rw) {
@@ -42,7 +64,7 @@ static inline bool netdata_dir_in_parent(const char *parent, char *out_path, siz
 static char *detect_run_dir(bool rw) {
     char path[FILENAME_MAX + 1];
 
-    const char *env_dir = getenv("NETDATA_RUN_DIR");
+    CLEAN_CHAR_P *env_dir = nd_environment_get_dup("NETDATA_RUN_DIR");
     if (env_dir && *env_dir) {
         if (is_dir_accessible(env_dir, rw))
             return strdupz(env_dir);
@@ -108,16 +130,13 @@ static char *detect_run_dir(bool rw) {
         return NULL;
 
 success:
-    // Set the environment variable for child processes
-    if(rw)
-        nd_setenv("NETDATA_RUN_DIR", path, 1);
-
     return strdupz(path);
 }
 
 const char *os_run_dir(bool rw) {
     // Fast path - return cached directory if available
-    if(__atomic_load_n(&cached_run_dir_available, __ATOMIC_ACQUIRE))
+    if(__atomic_load_n(&cached_run_dir_available, __ATOMIC_ACQUIRE) &&
+       (!rw || __atomic_load_n(&cached_run_dir_published, __ATOMIC_ACQUIRE)))
         return cached_run_dir;
 
     spinlock_lock(&spinlock);
@@ -132,7 +151,22 @@ const char *os_run_dir(bool rw) {
             __atomic_store_n(&cached_run_dir_available, true, __ATOMIC_RELEASE);
     }
 
+    if(run_dir && rw && !__atomic_load_n(&cached_run_dir_published, __ATOMIC_RELAXED)) {
+        if(!make_dir_writable(run_dir))
+            run_dir = NULL;
+        else if(nd_environment_set("NETDATA_RUN_DIR", run_dir, true) == 0)
+            __atomic_store_n(&cached_run_dir_published, true, __ATOMIC_RELEASE);
+        else
+            run_dir = NULL;
+    }
+
+    int saved_errno = errno;
     spinlock_unlock(&spinlock);
+
+    if(!run_dir) {
+        errno = saved_errno ? saved_errno : EACCES;
+        return NULL;
+    }
 
     errno_clear();
     return run_dir;

--- a/src/libnetdata/os/setenv.c
+++ b/src/libnetdata/os/setenv.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#define NETDATA_NATIVE_ENVIRONMENT_ACCESS 1
 #include "libnetdata/libnetdata.h"
 
 #ifndef HAVE_SETENV
@@ -25,6 +26,11 @@ int os_setenv(const char *name, const char *value, int overwrite) {
 #endif
 
 void nd_setenv(const char *name, const char *value, int overwrite) {
+    if(nd_environment_is_initialized()) {
+        (void)nd_environment_set(name, value, overwrite != 0);
+        return;
+    }
+
 #if defined(OS_WINDOWS)
     if(overwrite)
         SetEnvironmentVariable(name, value);

--- a/src/libnetdata/os/windows-wmi/windows-wmi-GetSystemInfo.c
+++ b/src/libnetdata/os/windows-wmi/windows-wmi-GetSystemInfo.c
@@ -2,13 +2,14 @@
 
 #include "windows-wmi.h"
 #include "windows-wmi-GetSystemInfo.h"
+#include "libnetdata/environment/environment.h"
 
 #if defined(OS_WINDOWS)
 
 #define WMI_GETSYSTEMINFO_TIMEOUT_DEFAULT_MS 5000
 
 static ULONG wmi_getsysteminfo_timeout_ms(void) {
-    const char *env = getenv("NETDATA_WMI_STARTUP_TIMEOUT_MS");
+    CLEAN_CHAR_P *env = nd_environment_get_dup("NETDATA_WMI_STARTUP_TIMEOUT_MS");
     if(!env || !*env) return WMI_GETSYSTEMINFO_TIMEOUT_DEFAULT_MS;
 
     char *end = NULL;

--- a/src/libnetdata/spawn_server/spawn-tester.c
+++ b/src/libnetdata/spawn_server/spawn-tester.c
@@ -2,18 +2,33 @@
 
 #define ENV_VAR_KEY "SPAWN_TESTER"
 #define ENV_VAR_VALUE "1234567890"
+#define ENV_VAR_VALUE_UPDATED "updated-after-freeze"
+
+#if defined(SPAWN_SERVER_VERSION_NOFORK) || \
+    (!defined(OS_WINDOWS) && !defined(SPAWN_SERVER_VERSION_UV) && !defined(SPAWN_SERVER_VERSION_POSIX_SPAWN))
+#define SPAWN_TESTER_NOFORK 1
+#endif
 
 size_t warnings = 0;
 
-void child_check_environment(void) {
-    const char *s = getenv(ENV_VAR_KEY);
-    if(!s || !*s || strcmp(s, ENV_VAR_VALUE) != 0) {
+static void child_check_environment_value(const char *expected) {
+    if(nd_environment_init() != 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot initialize the process environment");
+        exit(1);
+    }
+
+    CLEAN_CHAR_P *s = nd_environment_get_dup(ENV_VAR_KEY);
+    if(!s || !*s || strcmp(s, expected) != 0) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "Wrong environment. Variable '%s' should have value '%s' but it has '%s'",
-               ENV_VAR_KEY, ENV_VAR_VALUE, s ? s : "(unset)");
+               ENV_VAR_KEY, expected, s ? s : "(unset)");
 
         exit(1);
     }
+}
+
+void child_check_environment(void) {
+    child_check_environment_value(ENV_VAR_VALUE);
 }
 
 static bool is_valid_fd(int fd) {
@@ -136,6 +151,34 @@ static void test_popen_echo_loop(POPEN_INSTANCE *pi, const char *msg, size_t ite
         }
     }
     fprintf(stderr, "\n");
+}
+
+static int plugin_check_environment(const char *expected) {
+    child_check_fds();
+    child_check_environment_value(expected);
+    return 0;
+}
+
+static void test_popen_updated_environment(const char *argv0) {
+    const char *params[] = {
+        argv0,
+        "plugin-check-environment",
+        ENV_VAR_VALUE_UPDATED,
+        NULL,
+    };
+
+    POPEN_INSTANCE *pi = spawn_popen_run_argv(params);
+    if(!pi) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot run environment observation child");
+        exit(1);
+    }
+
+    int code = spawn_popen_wait(pi);
+    if(code != 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "Post-freeze environment observation child exited with code %d", code);
+        exit(1);
+    }
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -496,7 +539,7 @@ void test_popen_plugin_timedwait_kill(const char *argv0) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-#if !defined(OS_WINDOWS)
+#if defined(SPAWN_TESTER_NOFORK)
 static int callback_wait_for_sigterm(SPAWN_REQUEST *request) {
     struct sigaction sigterm_action, sigchld_action;
     sigset_t mask;
@@ -518,9 +561,10 @@ static int callback_wait_for_sigterm(SPAWN_REQUEST *request) {
         pause();
 }
 
-static void test_callback_signal_lifecycle(int argc, const char **argv) {
+static void test_callback_signal_lifecycle(int argc, const char **argv, const char *runtime_directory) {
     SPAWN_SERVER *server = spawn_server_create(
-        SPAWN_SERVER_OPTION_CALLBACK, "test-callback", callback_wait_for_sigterm, argc, argv);
+        SPAWN_SERVER_OPTION_CALLBACK, "test-callback", callback_wait_for_sigterm, argc, argv,
+        nd_environment_process(), runtime_directory);
     if(!server) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot create callback spawn server");
         exit(1);
@@ -582,15 +626,161 @@ int main(int argc, const char **argv) {
     if(argc > 1 && strcmp(argv[1], "plugin-close-to-stop") == 0)
         return plugin_close_to_stop();
 
+    if(argc == 3 && strcmp(argv[1], "plugin-check-environment") == 0)
+        return plugin_check_environment(argv[2]);
+
     if(argc <= 1 || strcmp(argv[1], "test") != 0) {
         fprintf(stderr, "Run me with 'test' parameter!\n");
         exit(1);
     }
 
+    if(nd_environment_init() != 0) {
+        fprintf(stderr, "Cannot initialize the process environment: %s\n", strerror(errno));
+        return 1;
+    }
+
     nd_setenv(ENV_VAR_KEY, ENV_VAR_VALUE, 1);
 
     fprintf(stderr, "\n\nTESTING fds\n\n");
-    SPAWN_SERVER *server = spawn_server_create(SPAWN_SERVER_OPTION_EXEC, "test", NULL, argc, argv);
+#if !defined(OS_WINDOWS)
+    char inaccessible_runtime_template[] = "/tmp/netdata-spawn-no-search-XXXXXX";
+    char *inaccessible_runtime = NULL;
+    if(geteuid() != 0) {
+        inaccessible_runtime = mkdtemp(inaccessible_runtime_template);
+        if(!inaccessible_runtime || chmod(inaccessible_runtime, 0200) != 0) {
+            fprintf(stderr, "Cannot create a non-searchable runtime directory fixture: %s\n", strerror(errno));
+            return 1;
+        }
+
+        if(nd_environment_set("NETDATA_RUN_DIR", inaccessible_runtime, true) != 0) {
+            int error = errno;
+            chmod(inaccessible_runtime, 0700);
+            rmdir(inaccessible_runtime);
+            fprintf(stderr, "Cannot configure the runtime directory fixture: %s\n", strerror(error));
+            return 1;
+        }
+    }
+#endif
+    const char *runtime_directory = os_run_dir(true);
+#if !defined(OS_WINDOWS)
+    bool accepted_inaccessible_runtime = inaccessible_runtime && runtime_directory &&
+                                         strcmp(runtime_directory, inaccessible_runtime) == 0;
+    int cleanup_error = 0;
+    if(inaccessible_runtime) {
+        if(chmod(inaccessible_runtime, 0700) != 0)
+            cleanup_error = errno;
+        else if(rmdir(inaccessible_runtime) != 0)
+            cleanup_error = errno;
+    }
+
+    if(cleanup_error) {
+        fprintf(stderr, "Cannot remove the runtime directory fixture: %s\n", strerror(cleanup_error));
+        return 1;
+    }
+
+    if(accepted_inaccessible_runtime) {
+        fprintf(stderr, "A non-searchable runtime directory was accepted\n");
+        return 1;
+    }
+#endif
+    if(!runtime_directory) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot resolve the spawn test runtime directory");
+        exit(1);
+    }
+#if defined(SPAWN_TESTER_NOFORK)
+    SPAWN_SERVER *invalid_runtime_server = spawn_server_create(
+        SPAWN_SERVER_OPTION_EXEC, "invalid-runtime-test", NULL, argc, argv,
+        nd_environment_process(), NULL);
+    if(invalid_runtime_server) {
+        spawn_server_destroy(invalid_runtime_server);
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "Nofork server creation unexpectedly accepted a missing runtime directory");
+        exit(1);
+    }
+
+    char permission_runtime_template[FILENAME_MAX + 1];
+    int permission_runtime_length = snprintf(
+        permission_runtime_template, sizeof(permission_runtime_template),
+        "%s/netdata-spawn-public-XXXXXX", runtime_directory);
+    if(permission_runtime_length < 0 || (size_t)permission_runtime_length >= sizeof(permission_runtime_template)) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot generate the public runtime directory fixture path");
+        exit(1);
+    }
+
+    char *permission_runtime = mkdtemp(permission_runtime_template);
+    if(!permission_runtime) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot create the public runtime directory fixture");
+        exit(1);
+    }
+
+    if(chmod(permission_runtime, 0775) != 0) {
+        int error = errno;
+        rmdir(permission_runtime);
+        errno = error;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot prepare the group-writable runtime directory fixture");
+        exit(1);
+    }
+
+    SPAWN_SERVER *group_runtime_server = spawn_server_create(
+        SPAWN_SERVER_OPTION_EXEC, "group-runtime-test", NULL, argc, argv,
+        nd_environment_process(), permission_runtime);
+    if(!group_runtime_server) {
+        int error = errno;
+        chmod(permission_runtime, 0700);
+        rmdir(permission_runtime);
+        errno = error;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "Nofork server creation unexpectedly rejected a group-writable runtime directory");
+        exit(1);
+    }
+    spawn_server_destroy(group_runtime_server);
+
+    if(chmod(permission_runtime, 0777) != 0) {
+        int error = errno;
+        chmod(permission_runtime, 0700);
+        rmdir(permission_runtime);
+        errno = error;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot prepare the publicly writable runtime directory fixture");
+        exit(1);
+    }
+
+    errno_clear();
+    SPAWN_SERVER *public_runtime_server = spawn_server_create(
+        SPAWN_SERVER_OPTION_EXEC, "public-runtime-test", NULL, argc, argv,
+        nd_environment_process(), permission_runtime);
+    int public_runtime_error = errno;
+    bool public_runtime_accepted = public_runtime_server != NULL;
+    if(public_runtime_server)
+        spawn_server_destroy(public_runtime_server);
+
+    int public_runtime_cleanup_error = 0;
+    if(chmod(permission_runtime, 0700) != 0)
+        public_runtime_cleanup_error = errno;
+    else if(rmdir(permission_runtime) != 0)
+        public_runtime_cleanup_error = errno;
+
+    if(public_runtime_cleanup_error) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "Cannot remove the public runtime directory fixture: %s",
+               strerror(public_runtime_cleanup_error));
+        exit(1);
+    }
+
+    if(public_runtime_accepted || public_runtime_error != EACCES) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "Nofork server creation did not reject a publicly writable runtime directory with EACCES");
+        exit(1);
+    }
+#endif
+#if defined(OS_WINDOWS) || defined(SPAWN_SERVER_VERSION_UV) || defined(SPAWN_SERVER_VERSION_POSIX_SPAWN)
+    if(nd_environment_freeze_process() != 0) {
+        fprintf(stderr, "Cannot freeze the process environment: %s\n", strerror(errno));
+        return 1;
+    }
+#endif
+    SPAWN_SERVER *server = spawn_server_create(
+        SPAWN_SERVER_OPTION_EXEC, "test", NULL, argc, argv,
+        nd_environment_process(), runtime_directory);
     if(!server) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot create spawn server");
         exit(1);
@@ -607,15 +797,64 @@ int main(int argc, const char **argv) {
         fprintf(stderr, "\n\nTESTING fds No %zu (close to stop)\n\n", i + 1);
         test_int_fds_plugin_close_to_stop(server, argv[0]);
     }
+
+#if defined(SPAWN_SERVER_VERSION_UV)
+    fprintf(stderr, "\n\nTESTING server destruction with a live child\n\n");
+    const char *sleep_argv[] = { argv[0], "plugin-sleep-to-stop", NULL };
+    SPAWN_INSTANCE *live_child = spawn_server_exec(
+        server, STDERR_FILENO, -1, sleep_argv, NULL, 0, SPAWN_INSTANCE_TYPE_EXEC);
+    if(!live_child) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot start the live-child shutdown test");
+        exit(1);
+    }
+
+    pid_t live_child_pid = spawn_server_instance_pid(live_child);
+    spawn_server_destroy(server);
+    server = NULL;
+
+    int live_child_status = spawn_server_exec_wait(NULL, live_child);
+    errno_clear();
+    if(live_child_status < 0 || kill(live_child_pid, 0) != -1 || errno != ESRCH) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "Server destruction did not terminate and reap child pid %d (status %d, errno %d)",
+               live_child_pid, live_child_status, errno);
+        exit(1);
+    }
+#endif
+
     spawn_server_destroy(server);
 
-#if !defined(OS_WINDOWS)
+#if defined(SPAWN_TESTER_NOFORK)
     fprintf(stderr, "\n\nTESTING callback signal lifecycle\n\n");
-    test_callback_signal_lifecycle(argc, argv);
+    test_callback_signal_lifecycle(argc, argv, runtime_directory);
 #endif
 
     fprintf(stderr, "\n\nTESTING popen\n\n");
-    netdata_main_spawn_server_init("test", argc, argv);
+    if(!netdata_main_spawn_server_init("test", argc, argv)) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot create global spawn server");
+        exit(1);
+    }
+#if !defined(OS_WINDOWS)
+    if(nd_environment_freeze_process() != 0) {
+        int error = errno;
+        netdata_main_spawn_server_cleanup();
+        fprintf(stderr, "Cannot freeze the process environment: %s\n", strerror(error));
+        return 1;
+    }
+#endif
+
+    if(nd_environment_set(ENV_VAR_KEY, ENV_VAR_VALUE_UPDATED, true) != 0) {
+        netdata_main_spawn_server_cleanup();
+        fprintf(stderr, "Cannot update the managed environment after freeze: %s\n", strerror(errno));
+        return 1;
+    }
+    test_popen_updated_environment(argv[0]);
+    if(nd_environment_set(ENV_VAR_KEY, ENV_VAR_VALUE, true) != 0) {
+        netdata_main_spawn_server_cleanup();
+        fprintf(stderr, "Cannot restore the managed environment after freeze: %s\n", strerror(errno));
+        return 1;
+    }
+
     for(size_t i = 0; i < 5; i++) {
         fprintf(stderr, "\n\nTESTING popen No %zu (kill to stop)\n\n", i + 1);
         test_popen_plugin_kill_to_stop(argv[0]);
@@ -637,6 +876,25 @@ int main(int argc, const char **argv) {
         test_popen_plugin_timedwait_kill(argv[0]);
     }
     netdata_main_spawn_server_cleanup();
+
+#if defined(SPAWN_TESTER_NOFORK)
+    SPAWN_SERVER *late_server = spawn_server_create(
+        SPAWN_SERVER_OPTION_EXEC, "late-test", NULL, argc, argv,
+        nd_environment_process(), runtime_directory);
+    if(late_server) {
+        spawn_server_destroy(late_server);
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "Direct nofork server creation unexpectedly succeeded after environment freeze");
+        exit(1);
+    }
+
+    if(netdata_main_spawn_server_init("late-test", argc, argv)) {
+        netdata_main_spawn_server_cleanup();
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "Global nofork server creation unexpectedly succeeded after environment freeze");
+        exit(1);
+    }
+#endif
 
     fprintf(stderr, "\n\nTests passed! (%zu warnings)\n\n", warnings);
 

--- a/src/libnetdata/spawn_server/spawn_popen.c
+++ b/src/libnetdata/spawn_server/spawn_popen.c
@@ -14,8 +14,13 @@ static SPINLOCK netdata_main_spawn_server_spinlock = SPINLOCK_INITIALIZER;
 bool netdata_main_spawn_server_init(const char *name, int argc, const char **argv) {
     if(netdata_main_spawn_server == NULL) {
         spinlock_lock(&netdata_main_spawn_server_spinlock);
-        if(netdata_main_spawn_server == NULL)
-            netdata_main_spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_EXEC, name, NULL, argc, argv);
+        if(netdata_main_spawn_server == NULL) {
+            ND_ENVIRONMENT *environment = nd_environment_process();
+            const char *runtime_directory = os_run_dir(true);
+            if(environment && runtime_directory)
+                netdata_main_spawn_server = spawn_server_create(
+                    SPAWN_SERVER_OPTION_EXEC, name, NULL, argc, argv, environment, runtime_directory);
+        }
         spinlock_unlock(&netdata_main_spawn_server_spinlock);
     }
 
@@ -58,7 +63,8 @@ FILE *spawn_popen_stdout(POPEN_INSTANCE *pi) {
 }
 
 POPEN_INSTANCE *spawn_popen_run_argv(const char **argv) {
-    netdata_main_spawn_server_init(NULL, 0, NULL);
+    if(!netdata_main_spawn_server_init(NULL, 0, NULL))
+        return NULL;
 
     SPAWN_INSTANCE *si = spawn_server_exec(netdata_main_spawn_server, nd_log_collectors_fd(),
         0, argv, NULL, 0, SPAWN_INSTANCE_TYPE_EXEC);

--- a/src/libnetdata/spawn_server/spawn_server.h
+++ b/src/libnetdata/spawn_server/spawn_server.h
@@ -4,6 +4,7 @@
 #define SPAWN_SERVER_H
 
 #include "../common.h"
+#include "../environment/environment.h"
 
 #define SPAWN_SERVER_TRANSFER_FDS 4
 
@@ -39,7 +40,13 @@ typedef int (*spawn_request_callback_t)(SPAWN_REQUEST *request);
 typedef struct spawn_instance SPAWN_INSTANCE;
 typedef struct spawn_server SPAWN_SERVER;
 
-SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name, spawn_request_callback_t child_callback, int argc, const char **argv);
+// The environment context remains caller-owned and must outlive the server.
+SPAWN_SERVER *spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name,
+                                  spawn_request_callback_t child_callback, int argc, const char **argv,
+                                  ND_ENVIRONMENT *environment, const char *runtime_directory);
+#if defined(OS_WINDOWS)
+bool spawn_server_windows_publish_cygwin_path(void);
+#endif
 void spawn_server_destroy(SPAWN_SERVER *server);
 pid_t spawn_server_pid(SPAWN_SERVER *server);
 

--- a/src/libnetdata/spawn_server/spawn_server_internals.h
+++ b/src/libnetdata/spawn_server/spawn_server_internals.h
@@ -12,6 +12,8 @@
 // used when the caller passes a non-positive timeout_ms (i.e. no explicit grace)
 #define SPAWN_KILL_DEFAULT_GRACE_MS 2000
 
+#if !defined(SPAWN_SERVER_VERSION_WINDOWS) && !defined(SPAWN_SERVER_VERSION_NOFORK) && \
+    !defined(SPAWN_SERVER_VERSION_UV) && !defined(SPAWN_SERVER_VERSION_POSIX_SPAWN)
 #if defined(OS_WINDOWS)
 #define SPAWN_SERVER_VERSION_WINDOWS 1
 // #define SPAWN_SERVER_VERSION_UV 1
@@ -21,16 +23,21 @@
 // #define SPAWN_SERVER_VERSION_UV 1
 // #define SPAWN_SERVER_VERSION_POSIX_SPAWN 1
 #endif
+#endif
 
 struct spawn_server {
     size_t id;
     size_t request_id;
     const char *name;
+    ND_ENVIRONMENT *environment;
 
 #if defined(SPAWN_SERVER_VERSION_UV)
     uv_loop_t *loop;
     uv_thread_t thread;
     uv_async_t async;
+    uv_timer_t shutdown_timer;
+    size_t live_processes;
+    bool shutdown_timer_initialized;
     bool stopping;
 
     SPINLOCK spinlock;
@@ -71,8 +78,10 @@ struct spawn_instance {
 
 #if defined(SPAWN_SERVER_VERSION_UV)
     uv_process_t process;
+    SPAWN_SERVER *server;
     int exit_code;
     uv_sem_t sem;
+    bool process_close_completed;
 #endif
 
 #if defined(SPAWN_SERVER_VERSION_NOFORK)

--- a/src/libnetdata/spawn_server/spawn_server_libuv.c
+++ b/src/libnetdata/spawn_server/spawn_server_libuv.c
@@ -13,6 +13,7 @@ pid_t spawn_server_instance_pid(SPAWN_INSTANCE *si) { return uv_process_get_pid(
 typedef struct work_item {
     int stderr_fd;
     const char **argv;
+    ND_ENV_SNAPSHOT *environment;
     uv_sem_t sem;
     SPAWN_INSTANCE *instance;
     struct work_item *prev;
@@ -114,19 +115,76 @@ static void server_thread(void *arg) {
            "SPAWN SERVER: ended");
 }
 
+static void on_process_closed(uv_handle_t *handle) {
+    SPAWN_INSTANCE *si = (SPAWN_INSTANCE *)handle->data;
+    if(si) {
+        uv_sem_post(&si->sem);
+        __atomic_store_n(&si->process_close_completed, true, __ATOMIC_RELEASE);
+    }
+}
+
+static void wait_for_process_close_callback(SPAWN_INSTANCE *si) {
+    while(!__atomic_load_n(&si->process_close_completed, __ATOMIC_ACQUIRE))
+        uv_sleep(0);
+}
+
+typedef struct inherited_fd_state {
+    int fd;
+    int original_flags;
+    bool changed;
+} inherited_fd_state;
+
+static bool inherited_fd_prepare_for_dup(inherited_fd_state *state, int inherited_fd, int std_fd) {
+    state->fd = inherited_fd;
+    if(inherited_fd == std_fd)
+        return true;
+
+    int flags = fcntl(inherited_fd, F_GETFD);
+    if(flags == -1)
+        return false;
+
+    state->original_flags = flags;
+    if(flags & FD_CLOEXEC)
+        return true;
+
+    if(fcntl(inherited_fd, F_SETFD, flags | FD_CLOEXEC) == -1)
+        return false;
+
+    state->changed = true;
+    return true;
+}
+
+static void inherited_fd_restore(const inherited_fd_state *state) {
+    if(state->changed && fcntl(state->fd, F_SETFD, state->original_flags) == -1)
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: cannot restore inherited descriptor flags");
+}
+
 static void on_process_exit(uv_process_t *req, int64_t exit_status, int term_signal) {
     SPAWN_INSTANCE *si = (SPAWN_INSTANCE *)req->data;
+    SPAWN_SERVER *server = si->server;
     si->exit_code = (int)(term_signal ? term_signal : exit_status << 8);
-    uv_close((uv_handle_t *)req, NULL); // Properly close the process handle
+    uv_close((uv_handle_t *)req, on_process_closed);
+
+    if(server->live_processes > 0)
+        server->live_processes--;
+    else
+        internal_fatal(true, "SPAWN SERVER: live process accounting underflow");
+    if(__atomic_load_n(&server->stopping, __ATOMIC_RELAXED) &&
+       server->live_processes == 0 && server->shutdown_timer_initialized &&
+       !uv_is_closing((uv_handle_t *)&server->shutdown_timer)) {
+        uv_timer_stop(&server->shutdown_timer);
+        uv_close((uv_handle_t *)&server->shutdown_timer, NULL);
+    }
 
     nd_log(NDLS_COLLECTORS, NDLP_ERR,
            "SPAWN SERVER: process with pid %d exited with code %d and term_signal %d",
            si->child_pid, (int)exit_status, term_signal);
 
-    uv_sem_post(&si->sem); // Signal that the process has exited
 }
 
-static SPAWN_INSTANCE *spawn_process_with_libuv(uv_loop_t *loop, int stderr_fd, const char **argv) {
+static SPAWN_INSTANCE *spawn_process_with_libuv(SPAWN_SERVER *server, int stderr_fd, const char **argv,
+                                                const ND_ENV_SNAPSHOT *environment) {
     SPAWN_INSTANCE *si = NULL;
     bool si_sem_init = false;
 
@@ -160,20 +218,37 @@ static SPAWN_INSTANCE *spawn_process_with_libuv(uv_loop_t *loop, int stderr_fd, 
     stdio[2].flags = UV_INHERIT_FD;
     stdio[2].data.fd = stderr_fd;
 
+    inherited_fd_state inherited_fds[3] = { 0 };
+    bool inherited_fds_prepared =
+        inherited_fd_prepare_for_dup(&inherited_fds[0], stdio[0].data.fd, STDIN_FILENO) &&
+        inherited_fd_prepare_for_dup(&inherited_fds[1], stdio[1].data.fd, STDOUT_FILENO) &&
+        inherited_fd_prepare_for_dup(&inherited_fds[2], stdio[2].data.fd, STDERR_FILENO);
+    if(!inherited_fds_prepared) {
+        for(size_t i = 0; i < _countof(inherited_fds); i++)
+            inherited_fd_restore(&inherited_fds[i]);
+
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: cannot mark inherited descriptor close-on-exec");
+        goto cleanup;
+    }
+
     uv_process_options_t options = { 0 };
     options.stdio_count = 3;
     options.stdio = stdio;
     options.exit_cb = on_process_exit;
     options.file = argv[0];
     options.args = (char **)argv;
-    options.env = (char **)environ;
+    options.env = (char **)nd_environment_snapshot_envp(environment);
 
     // uv_spawn() does not close all other open file descriptors
     // we have to close them manually
     int fds[3] = { stdio[0].data.fd, stdio[1].data.fd, stdio[2].data.fd };
     os_close_all_non_std_open_fds_except(fds, 3, CLOSE_RANGE_CLOEXEC);
 
-    int rc = uv_spawn(loop, &si->process, &options);
+    int rc = uv_spawn(server->loop, &si->process, &options);
+    for(size_t i = 0; i < _countof(inherited_fds); i++)
+        inherited_fd_restore(&inherited_fds[i]);
+
     if (rc) {
         errno = uv_errno_to_errno(rc);
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
@@ -183,6 +258,8 @@ static SPAWN_INSTANCE *spawn_process_with_libuv(uv_loop_t *loop, int stderr_fd, 
     }
 
     // Successfully spawned
+    si->server = server;
+    server->live_processes++;
 
     // get the pid of the process spawned
     si->child_pid = uv_process_get_pid(&si->process);
@@ -215,16 +292,60 @@ cleanup:
     return NULL;
 }
 
+static void signal_live_process(uv_handle_t *handle, void *arg) {
+    if(handle->type != UV_PROCESS || uv_is_closing(handle))
+        return;
+
+    int signal = *(int *)arg;
+    int rc = uv_process_kill((uv_process_t *)handle, signal);
+    if(rc != 0 && rc != UV_ESRCH)
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: cannot send signal %d to process %d: %s",
+               signal, uv_process_get_pid((uv_process_t *)handle), uv_strerror(rc));
+}
+
+static void shutdown_timer_callback(uv_timer_t *timer) {
+    SPAWN_SERVER *server = timer->data;
+    int signal = SIGKILL;
+    uv_walk(server->loop, signal_live_process, &signal);
+    uv_close((uv_handle_t *)timer, NULL);
+}
+
+static void begin_shutdown(SPAWN_SERVER *server) {
+    if(!uv_is_closing((uv_handle_t *)&server->async))
+        uv_close((uv_handle_t *)&server->async, NULL);
+
+    if(server->live_processes == 0)
+        return;
+
+    int signal = SIGTERM;
+    uv_walk(server->loop, signal_live_process, &signal);
+
+    int rc = uv_timer_init(server->loop, &server->shutdown_timer);
+    if(rc == 0) {
+        server->shutdown_timer_initialized = true;
+        server->shutdown_timer.data = server;
+        rc = uv_timer_start(
+            &server->shutdown_timer, shutdown_timer_callback, SPAWN_KILL_DEFAULT_GRACE_MS, 0);
+    }
+
+    if(rc != 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: cannot start the shutdown grace timer: %s; sending SIGKILL now",
+               uv_strerror(rc));
+        signal = SIGKILL;
+        uv_walk(server->loop, signal_live_process, &signal);
+        if(server->shutdown_timer_initialized &&
+           !uv_is_closing((uv_handle_t *)&server->shutdown_timer))
+            uv_close((uv_handle_t *)&server->shutdown_timer, NULL);
+    }
+}
+
 static void async_callback(uv_async_t *handle) {
     nd_log(NDLS_COLLECTORS, NDLP_INFO, "SPAWN SERVER: dequeue commands started");
     SPAWN_SERVER *server = (SPAWN_SERVER *)handle->data;
 
-    // Check if the server is stopping
-    if (__atomic_load_n(&server->stopping, __ATOMIC_RELAXED)) {
-        nd_log(NDLS_COLLECTORS, NDLP_INFO, "SPAWN SERVER: stopping...");
-        uv_stop(server->loop);
-        return;
-    }
+    bool stopping = __atomic_load_n(&server->stopping, __ATOMIC_RELAXED);
 
     work_item *item;
     spinlock_lock(&server->spinlock);
@@ -233,19 +354,44 @@ static void async_callback(uv_async_t *handle) {
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(server->work_queue, item, prev, next);
         spinlock_unlock(&server->spinlock);
 
-        item->instance = spawn_process_with_libuv(server->loop, item->stderr_fd, item->argv);
+        if(stopping)
+            item->instance = NULL;
+        else
+            item->instance = spawn_process_with_libuv(server, item->stderr_fd, item->argv, item->environment);
+
+        ND_ENV_SNAPSHOT *environment = item->environment;
+        item->environment = NULL;
+        nd_environment_snapshot_release(environment);
         uv_sem_post(&item->sem);
 
         spinlock_lock(&server->spinlock);
     }
     spinlock_unlock(&server->spinlock);
 
+    if(stopping) {
+        nd_log(NDLS_COLLECTORS, NDLP_INFO, "SPAWN SERVER: stopping...");
+        begin_shutdown(server);
+    }
+
     nd_log(NDLS_COLLECTORS, NDLP_INFO, "SPAWN SERVER: dequeue commands done");
 }
 
 
-SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options __maybe_unused, const char *name, spawn_request_callback_t cb  __maybe_unused, int argc __maybe_unused, const char **argv __maybe_unused) {
+SPAWN_SERVER *spawn_server_create(SPAWN_SERVER_OPTIONS options __maybe_unused, const char *name,
+                                  spawn_request_callback_t cb __maybe_unused, int argc __maybe_unused,
+                                  const char **argv __maybe_unused, ND_ENVIRONMENT *environment,
+                                  const char *runtime_directory __maybe_unused) {
+    if(!nd_environment_is_process_frozen()) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: refusing to start the libuv server before the environment freeze");
+        return NULL;
+    }
+
+    if(!environment)
+        return NULL;
+
     SPAWN_SERVER* server = callocz(1, sizeof(SPAWN_SERVER));
+    server->environment = environment;
     spinlock_init(&server->spinlock);
 
     if (name)
@@ -264,7 +410,13 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options __maybe_unused, c
 
     if (uv_async_init(server->loop, &server->async, async_callback)) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: uv_async_init() failed");
-        uv_loop_close(server->loop);
+        int rc = uv_loop_close(server->loop);
+        if(rc != 0) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN PARENT: uv_loop_close() failed after async initialization failure: %s",
+                   uv_strerror(rc));
+            return NULL;
+        }
         freez(server->loop);
         freez((void *)server->name);
         freez(server);
@@ -275,7 +427,14 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options __maybe_unused, c
     if (uv_thread_create(&server->thread, server_thread, server)) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: uv_thread_create() failed");
         uv_close((uv_handle_t*)&server->async, NULL);
-        uv_loop_close(server->loop);
+        uv_run(server->loop, UV_RUN_DEFAULT);
+        int rc = uv_loop_close(server->loop);
+        if(rc != 0) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN PARENT: uv_loop_close() failed after thread creation failure: %s",
+                   uv_strerror(rc));
+            return NULL;
+        }
         freez(server->loop);
         freez((void *)server->name);
         freez(server);
@@ -286,9 +445,8 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options __maybe_unused, c
 }
 
 static void close_handle(uv_handle_t* handle, void* arg __maybe_unused) {
-    if (!uv_is_closing(handle)) {
+    if(!uv_is_closing(handle) && handle->type != UV_PROCESS)
         uv_close(handle, NULL);
-    }
 }
 
 void spawn_server_destroy(SPAWN_SERVER *server) {
@@ -302,13 +460,19 @@ void spawn_server_destroy(SPAWN_SERVER *server) {
     // Wait for the server thread to finish
     uv_thread_join(&server->thread);
 
-    uv_stop(server->loop);
-    uv_close((uv_handle_t*)&server->async, NULL);
-
-    // Walk through and close any remaining handles
+    // Close only non-process stragglers. Live process handles must reach on_process_exit()
+    // so libuv can reap the child before the handle is closed.
     uv_walk(server->loop, close_handle, NULL);
+    uv_run(server->loop, UV_RUN_DEFAULT);
 
-    uv_loop_close(server->loop);
+    int rc = uv_loop_close(server->loop);
+    if(rc != 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN PARENT: uv_loop_close() failed during shutdown: %s",
+               uv_strerror(rc));
+        return;
+    }
+
     freez(server->loop);
     freez((void *)server->name);
     freez(server);
@@ -324,6 +488,12 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_un
 
     if (uv_sem_init(&item.sem, 0)) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: uv_sem_init() failed");
+        return NULL;
+    }
+
+    item.environment = nd_environment_snapshot_acquire(server->environment);
+    if(!item.environment) {
+        uv_sem_destroy(&item.sem);
         return NULL;
     }
 
@@ -398,6 +568,7 @@ SPAWN_TIMEDWAIT_RESULT spawn_server_exec_timedwait(SPAWN_SERVER *server __maybe_
     }
 
     // the semaphore is consumed - finish exactly like spawn_server_exec_wait()
+    wait_for_process_close_callback(si);
     int st = si->exit_code;
     uv_sem_destroy(&si->sem);
     freez(si);
@@ -414,6 +585,7 @@ int spawn_server_exec_wait(SPAWN_SERVER *server __maybe_unused, SPAWN_INSTANCE *
 
     // Wait for the process to exit
     uv_sem_wait(&si->sem);
+    wait_for_process_close_callback(si);
     int exit_code = si->exit_code;
 
     uv_sem_destroy(&si->sem);

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -16,13 +16,6 @@ pid_t spawn_server_instance_pid(SPAWN_INSTANCE *si) { return si->child_pid; }
 
 pid_t spawn_server_pid(SPAWN_SERVER *server) { return server->server_pid; }
 
-#ifdef __APPLE__
-#include <crt_externs.h>
-#define environ (*_NSGetEnviron())
-#else
-extern char **environ;
-#endif
-
 static size_t spawn_server_id = 0;
 static volatile sig_atomic_t spawn_server_exit = false;
 static volatile sig_atomic_t spawn_server_sigchld = false;
@@ -83,13 +76,13 @@ static int connect_to_spawn_server(const char *path, bool log) {
 // Encoding and decoding of spawn server request argv type of data
 
 // Function to encode argv or envp
-static void* argv_encode(const char **argv, size_t *out_size) {
+static void *argv_encode(const char *const *argv, size_t *out_size) {
     size_t buffer_size = 1024; // Initial buffer size
     size_t buffer_used = 0;
     char *buffer = mallocz(buffer_size);
 
     if(argv) {
-        for (const char **p = argv; *p != NULL; p++) {
+        for (const char *const *p = argv; *p != NULL; p++) {
             if (strlen(*p) == 0)
                 continue; // Skip empty strings
 
@@ -160,6 +153,30 @@ static const char** argv_decode(const char *buffer, size_t size) {
     argv[count] = NULL; // Null-terminate the array
 
     return argv;
+}
+
+static char **environment_vector_dup(ND_ENVIRONMENT *environment) {
+    ND_ENV_SNAPSHOT *snapshot = nd_environment_snapshot_acquire(environment);
+    if(!snapshot)
+        return NULL;
+
+    size_t entries = nd_environment_snapshot_entries(snapshot);
+    const char *const *envp = nd_environment_snapshot_envp(snapshot);
+    char **copy = callocz(entries + 1, sizeof(*copy));
+    for(size_t i = 0; i < entries; i++)
+        copy[i] = strdupz(envp[i]);
+
+    nd_environment_snapshot_release(snapshot);
+    return copy;
+}
+
+static void environment_vector_free(char **envp) {
+    if(!envp)
+        return;
+
+    for(size_t i = 0; envp[i]; i++)
+        freez(envp[i]);
+    freez(envp);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -380,7 +397,9 @@ static bool spawn_server_run_callback(SPAWN_SERVER *server __maybe_unused, SPAWN
             if(pid > 0) {
                 kill(pid, SIGKILL);
 
-                while(waitpid(pid, NULL, 0) == -1 && errno == EINTR) { }
+                while(waitpid(pid, NULL, 0) == -1 && errno == EINTR) {
+                    // Retry until the child is reaped or waitpid() fails permanently.
+                }
             }
 
             spawn_server_exit = true;
@@ -409,6 +428,9 @@ static bool spawn_server_run_callback(SPAWN_SERVER *server __maybe_unused, SPAWN
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to reset callback child signal handlers.");
             _exit(EXIT_FAILURE);
         }
+
+        if(nd_environment_fork_child_reset_from_native() != 0)
+            _exit(EXIT_FAILURE);
 
         mask_rc = pthread_sigmask(SIG_SETMASK, &previous_mask, NULL);
         if(mask_rc != 0) {
@@ -467,8 +489,19 @@ static bool spawn_server_run_callback(SPAWN_SERVER *server __maybe_unused, SPAWN
         close(stdout_fd); stdout_fd = rq->fds[1] = STDOUT_FILENO;
         close(stderr_fd); stderr_fd = rq->fds[2] = STDERR_FILENO;
 
-        // overwrite the process environment
-        environ = (char **)rq->envp;
+        if(nd_environment_fork_child_replace(rq->envp) != 0) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN SERVER: cannot adopt the environment for request No %zu",
+                   rq->request_id);
+            exit(EXIT_FAILURE);
+        }
+
+        if(nd_environment_freeze_process() != 0) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN SERVER: cannot freeze the callback environment for request No %zu",
+                   rq->request_id);
+            exit(EXIT_FAILURE);
+        }
 
         // run the callback and return its code
         exit(server->cb(rq));
@@ -619,7 +652,7 @@ static bool spawn_server_recvmsg_fully(int sock, const struct iovec *iov, size_t
     struct iovec pending[SPAWN_SERVER_IOV_MAX];
     memcpy(pending, iov, sizeof(*iov) * iovlen);
 
-    size_t remaining;
+    size_t remaining = 0;
     if(unlikely(!spawn_server_iov_total_size(pending, iovlen, &remaining))) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "SPAWN SERVER: cannot recvmsg() %s: iovec byte count overflows",
@@ -702,7 +735,7 @@ static bool spawn_server_sendmsg_fully(int sock, const struct iovec *iov, size_t
     struct iovec pending[SPAWN_SERVER_IOV_MAX];
     memcpy(pending, iov, sizeof(*iov) * iovlen);
 
-    size_t remaining;
+    size_t remaining = 0;
     if(unlikely(!spawn_server_iov_total_size(pending, iovlen, &remaining))) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "SPAWN PARENT: cannot sendmsg() %s: iovec byte count overflows",
@@ -807,13 +840,19 @@ static bool spawn_server_is_running(const char *path) {
     return sr.status == STATUS_REPORT_PING;
 }
 
-static bool spawn_server_send_request(ND_UUID *magic, SPAWN_REQUEST *request) {
+static bool spawn_server_send_request(ND_UUID *magic, ND_ENVIRONMENT *environment, SPAWN_REQUEST *request) {
     bool ret = false;
 
     size_t env_size = 0;
     size_t argv_size = 0;
 
-    void *encoded_env = argv_encode(request->envp, &env_size);
+    ND_ENV_SNAPSHOT *snapshot = nd_environment_snapshot_acquire(environment);
+    if(!snapshot)
+        return false;
+
+    void *encoded_env = argv_encode(nd_environment_snapshot_envp(snapshot), &env_size);
+    nd_environment_snapshot_release(snapshot);
+
     void *encoded_argv = argv_encode(request->argv, &argv_size);
 
     struct msghdr msg = {0};
@@ -1377,8 +1416,55 @@ static void replace_stdio_with_dev_null() {
     close(dev_null_fd);
 }
 
-SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name, spawn_request_callback_t child_callback, int argc, const char **argv) {
+SPAWN_SERVER *spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name,
+                                  spawn_request_callback_t child_callback, int argc, const char **argv,
+                                  ND_ENVIRONMENT *environment, const char *runtime_directory) {
+    if(nd_environment_is_process_frozen()) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: refusing to fork a nofork server after the environment freeze");
+        return NULL;
+    }
+
+    if(!environment) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: environment context is required");
+        return NULL;
+    }
+
+    if(!runtime_directory || !*runtime_directory) {
+        errno = EINVAL;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: runtime directory is required");
+        return NULL;
+    }
+
+    struct stat runtime_directory_stat;
+    if(stat(runtime_directory, &runtime_directory_stat) != 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: runtime directory '%s' is not accessible", runtime_directory);
+        return NULL;
+    }
+
+    if(!S_ISDIR(runtime_directory_stat.st_mode)) {
+        errno = ENOTDIR;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: runtime directory '%s' is not a directory", runtime_directory);
+        return NULL;
+    }
+
+    if(runtime_directory_stat.st_mode & S_IWOTH) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: runtime directory '%s' is publicly writable", runtime_directory);
+        errno = EACCES;
+        return NULL;
+    }
+
+    if(access(runtime_directory, W_OK | X_OK) != 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: runtime directory '%s' is not writable or searchable", runtime_directory);
+        return NULL;
+    }
+
     SPAWN_SERVER *server = callocz(1, sizeof(SPAWN_SERVER));
+    char **isolated_child_environment = NULL;
     server->pipe[0] = -1;
     server->pipe[1] = -1;
     server->sock = -1;
@@ -1386,37 +1472,9 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
     server->argc = argc;
     server->argv = argv;
     server->options = options;
+    server->environment = environment;
     server->id = __atomic_add_fetch(&spawn_server_id, 1, __ATOMIC_RELAXED);
     os_uuid_generate_random(server->magic.uuid);
-
-    const char *runtime_directory = getenv("NETDATA_RUN_DIR");
-    if(!runtime_directory || !*runtime_directory)
-        runtime_directory = os_run_dir(true);
-
-    if (runtime_directory) {
-        struct stat statbuf;
-
-        if(!*runtime_directory)
-            // it is empty
-                runtime_directory = NULL;
-
-        else if (stat(runtime_directory, &statbuf) == 0 && S_ISDIR(statbuf.st_mode)) {
-            // it exists and it is a directory
-
-            if (access(runtime_directory, W_OK) != 0) {
-                // it is not writable by us
-                nd_log(NDLS_COLLECTORS, NDLP_ERR, "Runtime directory '%s' is not writable, falling back to '/tmp'", runtime_directory);
-                runtime_directory = NULL;
-            }
-        }
-        else {
-            // it does not exist
-            nd_log(NDLS_COLLECTORS, NDLP_ERR, "Runtime directory '%s' does not exist, falling back to '/tmp'", runtime_directory);
-            runtime_directory = NULL;
-        }
-    }
-    if(!runtime_directory)
-        runtime_directory = "/tmp";
 
     char path[1024];
     int path_length;
@@ -1463,9 +1521,26 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
         goto cleanup;
     }
 
+    if(environment != nd_environment_process()) {
+        isolated_child_environment = environment_vector_dup(environment);
+        if(!isolated_child_environment) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN SERVER: cannot snapshot the isolated server environment");
+            goto cleanup;
+        }
+    }
+
     pid_t pid = fork();
     if (pid == 0) {
         // the child - the spawn server
+
+        int environment_rc = isolated_child_environment ?
+            nd_environment_fork_child_replace((const char *const *)isolated_child_environment) :
+            nd_environment_fork_child_reset_from_native();
+        environment_vector_free(isolated_child_environment);
+        isolated_child_environment = NULL;
+        if(environment_rc != 0)
+            _exit(EXIT_FAILURE);
 
         char buf[16];
         snprintfz(buf, sizeof(buf), "spawn-%s", server->name);
@@ -1483,10 +1558,14 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
         };
         os_close_all_non_std_open_fds_except(fds_to_keep, _countof(fds_to_keep), 0);
         nd_log_reopen_log_files_for_spawn_server(buf);
+        if(nd_environment_freeze_process() != 0)
+            _exit(EXIT_FAILURE);
         _exit(spawn_server_event_loop(server));
     }
     else if (pid > 0) {
         // the parent
+        environment_vector_free(isolated_child_environment);
+        isolated_child_environment = NULL;
         server->server_pid = pid;
         close(server->sock); server->sock = -1;
         close(server->pipe[1]); server->pipe[1] = -1;
@@ -1515,6 +1594,7 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
     nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Cannot fork()");
 
 cleanup:
+    environment_vector_free(isolated_child_environment);
     spawn_server_destroy(server);
     return NULL;
 }
@@ -1701,14 +1781,13 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd, int custo
             [2] = stderr_fd,
             [3] = custom_fd,
         },
-        .envp = (const char **)environ,
         .argv = argv,
         .data = data,
         .data_size = data_size,
         .type = type
     };
 
-    if(!spawn_server_send_request(&server->magic, &request))
+    if(!spawn_server_send_request(&server->magic, server->environment, &request))
         goto cleanup;
 
     close(pipe_stdin[0]); pipe_stdin[0] = -1;

--- a/src/libnetdata/spawn_server/spawn_server_posix.c
+++ b/src/libnetdata/spawn_server/spawn_server_posix.c
@@ -4,13 +4,6 @@
 
 #if defined(SPAWN_SERVER_VERSION_POSIX_SPAWN)
 
-#ifdef __APPLE__
-#include <crt_externs.h>
-#define environ (*_NSGetEnviron())
-#else
-extern char **environ;
-#endif
-
 #define SPAWN_SERVER_MAX_DEFERRED_REAPERS 1
 
 int spawn_server_instance_read_fd(SPAWN_INSTANCE *si) { return si->read_fd; }
@@ -47,8 +40,15 @@ static struct {
 //    }
 //}
 
-SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options __maybe_unused, const char *name, spawn_request_callback_t cb  __maybe_unused, int argc __maybe_unused, const char **argv __maybe_unused) {
+SPAWN_SERVER *spawn_server_create(SPAWN_SERVER_OPTIONS options __maybe_unused, const char *name,
+                                  spawn_request_callback_t cb __maybe_unused, int argc __maybe_unused,
+                                  const char **argv __maybe_unused, ND_ENVIRONMENT *environment,
+                                  const char *runtime_directory __maybe_unused) {
+    if(!environment)
+        return NULL;
+
     SPAWN_SERVER* server = callocz(1, sizeof(SPAWN_SERVER));
+    server->environment = environment;
 
     if (name)
         server->name = strdupz(name);
@@ -92,33 +92,28 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd, int custo
 
     int stdin_pipe[2] = { -1, -1 };
     int stdout_pipe[2] = { -1, -1 };
+    posix_spawn_file_actions_t file_actions;
+    posix_spawnattr_t attr;
+    ND_ENV_SNAPSHOT *snapshot = NULL;
+    bool file_actions_initialized = false;
+    bool attr_initialized = false;
+    bool listed = false;
 
     if (pipe(stdin_pipe) == -1) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: stdin pipe() failed: %s", cmdline);
-        freez(si);
-        return NULL;
+        goto cleanup;
     }
 
     if (pipe(stdout_pipe) == -1) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: stdout pipe() failed: %s", cmdline);
-        close(stdin_pipe[PIPE_READ]);
-        close(stdin_pipe[PIPE_WRITE]);
-        freez(si);
-        return NULL;
+        goto cleanup;
     }
-
-    posix_spawn_file_actions_t file_actions;
-    posix_spawnattr_t attr;
 
     if (posix_spawn_file_actions_init(&file_actions) != 0) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: posix_spawn_file_actions_init() failed: %s", cmdline);
-        close(stdin_pipe[PIPE_READ]);
-        close(stdin_pipe[PIPE_WRITE]);
-        close(stdout_pipe[PIPE_READ]);
-        close(stdout_pipe[PIPE_WRITE]);
-        freez(si);
-        return NULL;
+        goto cleanup;
     }
+    file_actions_initialized = true;
 
     posix_spawn_file_actions_adddup2(&file_actions, stdin_pipe[PIPE_READ], STDIN_FILENO);
     posix_spawn_file_actions_adddup2(&file_actions, stdout_pipe[PIPE_WRITE], STDOUT_FILENO);
@@ -133,36 +128,32 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd, int custo
 
     if (posix_spawnattr_init(&attr) != 0) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: posix_spawnattr_init() failed: %s", cmdline);
-        posix_spawn_file_actions_destroy(&file_actions);
-        close(stdin_pipe[PIPE_READ]);
-        close(stdin_pipe[PIPE_WRITE]);
-        close(stdout_pipe[PIPE_READ]);
-        close(stdout_pipe[PIPE_WRITE]);
-        freez(si);
-        return NULL;
+        goto cleanup;
     }
+    attr_initialized = true;
 
     // Set the flags to reset the signal mask and signal actions
     sigset_t empty_mask;
     sigemptyset(&empty_mask);
     if (posix_spawnattr_setsigmask(&attr, &empty_mask) != 0) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: posix_spawnattr_setsigmask() failed: %s", cmdline);
-        posix_spawn_file_actions_destroy(&file_actions);
-        posix_spawnattr_destroy(&attr);
-        return false;
+        goto cleanup;
     }
 
     short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF;
     if (posix_spawnattr_setflags(&attr, flags) != 0) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN PARENT: posix_spawnattr_setflags() failed: %s", cmdline);
-        posix_spawn_file_actions_destroy(&file_actions);
-        posix_spawnattr_destroy(&attr);
-        return false;
+        goto cleanup;
     }
+
+    snapshot = nd_environment_snapshot_acquire(server->environment);
+    if(!snapshot)
+        goto cleanup;
 
     spinlock_lock(&spawn_globals.spinlock);
     DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(spawn_globals.instances, si, prev, next);
     spinlock_unlock(&spawn_globals.spinlock);
+    listed = true;
 
     // unfortunately, on CYGWIN/MSYS posix_spawn() is not thread safe
     // so, we run it one by one.
@@ -173,23 +164,14 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd, int custo
     os_close_all_non_std_open_fds_except(fds, 3, CLOSE_RANGE_CLOEXEC);
 
     errno_clear();
-    if (posix_spawn(&si->child_pid, argv[0], &file_actions, &attr, (char * const *)argv, environ) != 0) {
+    int spawn_rc = posix_spawn(&si->child_pid, argv[0], &file_actions, &attr, (char *const *)argv,
+                               (char *const *)nd_environment_snapshot_envp(snapshot));
+    nd_environment_snapshot_release(snapshot);
+    snapshot = NULL;
+    if (spawn_rc != 0) {
         spinlock_unlock(&spinlock);
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: posix_spawn() failed: %s", cmdline);
-
-        spinlock_lock(&spawn_globals.spinlock);
-        DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(spawn_globals.instances, si, prev, next);
-        spinlock_unlock(&spawn_globals.spinlock);
-
-        posix_spawnattr_destroy(&attr);
-        posix_spawn_file_actions_destroy(&file_actions);
-
-        close(stdin_pipe[PIPE_READ]);
-        close(stdin_pipe[PIPE_WRITE]);
-        close(stdout_pipe[PIPE_READ]);
-        close(stdout_pipe[PIPE_WRITE]);
-        freez(si);
-        return NULL;
+        goto cleanup;
     }
     spinlock_unlock(&spinlock);
 
@@ -209,6 +191,27 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd, int custo
            "SPAWN SERVER: process created with pid %d: %s",
            si->child_pid, cmdline);
     return si;
+
+cleanup:
+    nd_environment_snapshot_release(snapshot);
+
+    if(listed) {
+        spinlock_lock(&spawn_globals.spinlock);
+        DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(spawn_globals.instances, si, prev, next);
+        spinlock_unlock(&spawn_globals.spinlock);
+    }
+
+    if(attr_initialized)
+        posix_spawnattr_destroy(&attr);
+    if(file_actions_initialized)
+        posix_spawn_file_actions_destroy(&file_actions);
+
+    if(stdin_pipe[PIPE_READ] != -1) close(stdin_pipe[PIPE_READ]);
+    if(stdin_pipe[PIPE_WRITE] != -1) close(stdin_pipe[PIPE_WRITE]);
+    if(stdout_pipe[PIPE_READ] != -1) close(stdout_pipe[PIPE_READ]);
+    if(stdout_pipe[PIPE_WRITE] != -1) close(stdout_pipe[PIPE_WRITE]);
+    freez(si);
+    return NULL;
 }
 
 static int spawn_server_waitpid(SPAWN_INSTANCE *si);

--- a/src/libnetdata/spawn_server/spawn_server_windows.c
+++ b/src/libnetdata/spawn_server/spawn_server_windows.c
@@ -16,30 +16,42 @@ pid_t spawn_server_instance_pid(SPAWN_INSTANCE *si) {
     return (pid_t)si->dwProcessId;
 }
 
-static void update_cygpath_env(void) {
-    static volatile bool done = false;
-
-    if(done) return;
-    done = true;
-
+bool spawn_server_windows_publish_cygwin_path(void) {
     char win_path[MAX_PATH];
 
     // Convert Cygwin root path to Windows path
     errno_clear();
     if(cygwin_conv_path(CCP_POSIX_TO_WIN_A, "/", win_path, sizeof(win_path)) != 0) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot convert Cygwin/MSYS2 base path to Windows path: %s", strerror(errno));
-        return;
+        return false;
     }
 
-    nd_setenv("NETDATA_CYGWIN_BASE_PATH", win_path, 1);
+    if(nd_environment_set("NETDATA_CYGWIN_BASE_PATH", win_path, true) != 0) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot publish the Cygwin/MSYS2 base path");
+        return false;
+    }
 
     nd_log(NDLS_COLLECTORS, NDLP_INFO, "Cygwin/MSYS2 base path set to '%s'", win_path);
+    return true;
 }
 
-SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options __maybe_unused, const char *name, spawn_request_callback_t cb  __maybe_unused, int argc __maybe_unused, const char **argv __maybe_unused) {
-    update_cygpath_env();
+SPAWN_SERVER *spawn_server_create(SPAWN_SERVER_OPTIONS options __maybe_unused, const char *name,
+                                  spawn_request_callback_t cb __maybe_unused, int argc __maybe_unused,
+                                  const char **argv __maybe_unused, ND_ENVIRONMENT *environment,
+                                  const char *runtime_directory __maybe_unused) {
+    if(!nd_environment_is_process_frozen()) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: refusing to start the Windows server before the environment freeze");
+        return NULL;
+    }
+
+    if(!environment) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: environment context is required");
+        return NULL;
+    }
 
     SPAWN_SERVER* server = callocz(1, sizeof(SPAWN_SERVER));
+    server->environment = environment;
     if(name)
         server->name = strdupz(name);
     else
@@ -157,22 +169,9 @@ static void spawn_server_release_stderr_fd(SPAWN_SERVER *server, SPAWN_INSTANCE 
     si->stderr_fd = -1;
 }
 
-//static void print_environment_block(char *env_block) {
-//    if (env_block == NULL) {
-//        fprintf(stderr, "Environment block is NULL\n");
-//        return;
-//    }
-//
-//    char *env = env_block;
-//    while (*env) {
-//        fprintf(stderr, "ENVIRONMENT: %s\n", env);
-//        // Move to the next string in the block
-//        env += strlen(env) + 1;
-//    }
-//}
-
 SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_unused, int custom_fd __maybe_unused, const char **argv, const void *data __maybe_unused, size_t data_size __maybe_unused, SPAWN_INSTANCE_TYPE type) {
     static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
+    ND_ENV_SNAPSHOT *environment_snapshot = NULL;
 
     if (type != SPAWN_INSTANCE_TYPE_EXEC)
         return NULL;
@@ -228,6 +227,24 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_un
         goto cleanup;
     }
 
+    environment_snapshot = nd_environment_snapshot_acquire(server->environment);
+    if(!environment_snapshot) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN PARENT: Cannot acquire environment for request No %zu, command: %s",
+               instance->request_id, command);
+        goto cleanup;
+    }
+
+    size_t environment_block_size = 0;
+    const char *environment_block =
+        nd_environment_snapshot_windows_block(environment_snapshot, &environment_block_size);
+    if(!environment_block || environment_block_size < 2) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN PARENT: Invalid Windows environment for request No %zu, command: %s",
+               instance->request_id, command);
+        goto cleanup;
+    }
+
     // do not run multiple times this section
     // to prevent handles leaking
     spinlock_lock(&spinlock);
@@ -266,10 +283,6 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_un
     si.hStdOutput = stdout_write_handle;
     si.hStdError = stderr_write_handle;
 
-    // Retrieve the current environment block
-    char* env_block = GetEnvironmentStrings();
-//    print_environment_block(env_block);
-
     nd_log(NDLS_COLLECTORS, NDLP_INFO,
            "SPAWN PARENT: Running request No %zu, command: '%s'",
            instance->request_id, command);
@@ -279,17 +292,13 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_un
 
     // Spawn the process
     errno_clear();
-    if (!CreateProcess(NULL, command, NULL, NULL, TRUE, 0, env_block, NULL, &si, &pi)) {
+    if (!CreateProcess(NULL, command, NULL, NULL, TRUE, 0, (LPVOID)environment_block, NULL, &si, &pi)) {
         spinlock_unlock(&spinlock);
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
                "SPAWN PARENT: cannot CreateProcess() for request No %zu, command: %s",
                instance->request_id, command);
-        if(env_block)
-            FreeEnvironmentStrings(env_block);
         goto cleanup;
     }
-
-    FreeEnvironmentStrings(env_block);
 
     // When we create a process with the CreateProcess function, it returns two handles:
     // - one for the process (pi.hProcess) and
@@ -299,6 +308,8 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_un
 
     // end of the critical section
     spinlock_unlock(&spinlock);
+
+    nd_environment_snapshot_release(environment_snapshot);
 
     // Close unused pipe ends
     close(pipe_stdin[PIPE_READ]); pipe_stdin[PIPE_READ] = -1;
@@ -334,6 +345,8 @@ SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd __maybe_un
     if (pipe_stdout[PIPE_WRITE] >= 0) close(pipe_stdout[PIPE_WRITE]);
     if (pipe_stderr[PIPE_READ] >= 0) close(pipe_stderr[PIPE_READ]);
     if (pipe_stderr[PIPE_WRITE] >= 0) close(pipe_stderr[PIPE_WRITE]);
+    if(environment_snapshot)
+        nd_environment_snapshot_release(environment_snapshot);
     freez(instance);
     return NULL;
 }

--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -469,6 +469,9 @@ static int create_uv_thread(uv_thread_t *thread, uv_thread_cb thread_func, void 
 
 ND_THREAD *nd_thread_create(const char *tag, NETDATA_THREAD_OPTIONS options, void (*start_routine)(void *), void *arg)
 {
+    internal_fatal(!nd_environment_is_process_frozen(),
+                   "attempted to create thread '%s' before freezing the process environment", tag);
+
     ND_THREAD *nti = callocz(1, sizeof(*nti));
     spinlock_init(&nti->canceller.spinlock);
     nti->arg = arg;

--- a/src/plugins.d/plugins_d.c
+++ b/src/plugins.d/plugins_d.c
@@ -306,7 +306,8 @@ void *pluginsd_main(void *ptr) {
     // it crashes (both threads) on Alpine after we made it multi-threaded
     // works with "--device /dev/ipmi0", but this is not default
     // see https://github.com/netdata/netdata/pull/15564 for details
-    if (getenv("NETDATA_LISTENER_PORT"))
+    CLEAN_CHAR_P *listener_port = nd_environment_get_dup("NETDATA_LISTENER_PORT");
+    if (listener_port)
         inicfg_get_boolean(&netdata_config, CONFIG_SECTION_PLUGINS, "freeipmi", CONFIG_BOOLEAN_NO);
 
     // store the errno for each plugins directory

--- a/tests/run-unit-tests.sh
+++ b/tests/run-unit-tests.sh
@@ -25,6 +25,19 @@ c_unit_tests() {
   "$HOME"/netdata/usr/sbin/netdata -W unittest
 }
 
+environment_spawn_unit_tests() {
+  echo "Building environment and spawn unit tests"
+
+  cmake --build ./build --target environment-unittest spawn-tester --parallel 2 || return 1
+
+  echo "Running environment and spawn unit tests"
+
+  ASAN_OPTIONS=detect_leaks=0 ./build/environment-unittest || return 1
+  ASAN_OPTIONS=detect_leaks=0 ./build/spawn-tester test
+}
+
 install_netdata || exit 1
+
+environment_spawn_unit_tests || exit 1
 
 c_unit_tests || exit 1


### PR DESCRIPTION
## What changed

- add a libnetdata-owned process environment with explicit initialization and freeze phases
- import native state once, mirror managed writes to native storage only before freeze, and keep later managed updates child-visible
- publish immutable refcounted snapshots for the nofork, POSIX, libuv, and Windows spawn backends
- migrate process-wide readers and writers away from borrowed native environment pointers
- preserve isolated allowlisted environments for privileged helpers
- enforce native-access through compile-time poisoning and a dedicated required CI check
- move application/library worker startup after the environment freeze
- gate Windows service STOP/SHUTDOWN controls until freeze and fail closed if cleanup-thread creation fails

## Why

The native process environment has no safe borrowed-pointer lifetime across mutation. Spawn paths could enumerate pointers while another path replaced native entries, which is an exercised use-after-free class on musl and an invalid concurrency contract on other platforms.

The process also had no single ownership boundary defining when native mutation ended and how later child-only updates were published. Windows additionally sourced child blocks from Win32 storage while several configured values existed only in the MSYS CRT environment.

## Impact

- libraries retain the native values configured during single-threaded startup
- native mutation stops explicitly before Netdata or linked libraries start workers
- future children observe complete immutable generations, including managed updates made after freeze
- existing Unix ordering, duplicates, opaque entries, restricted helper environments, and Windows special entries/path behavior are preserved
- Windows children now receive configured generic managed values that were previously absent or stale
- Windows service STOP/SHUTDOWN requests are accepted only after environment initialization; requests during the short initialization window must be retried
- snapshot acquisition is a short refcounted read with no environment lock held across process creation

Pub/Sub removal is intentionally not part of this change.

## Validation

- Linux debug build, managed-environment unit tests, full nofork spawn suite, JSON tests, build-info bootstrap, and real daemon startup/shutdown
- internal-checks build and runtime
- ASan, UBSan, and TSan focused environment/spawn coverage
- native musl and musl ASan concurrent update/snapshot/spawn coverage
- Sentry-enabled and Sentry-disabled builds and daemon lifecycle
- dedicated full spawn suites with the dormant libuv and POSIX backends selected
- Windows/MSYS2 full Debug build, managed-environment tests, actual spawned-child observations, JSON/build-info tests, real console startup/shutdown, and real SCM service RUNNING/STOPPABLE/graceful-stop validation
- native environment bypass enforcement and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Owns the process environment in `libnetdata` with explicit init/freeze and immutable snapshots, so children see a consistent, safe view. Replaces raw env access with a managed API, enforces it across the tree and CI, and updates spawners, logging, daemon, and plugins.

- **New Features**
  - Managed env (`nd_environment_*`): import native at init, mirror writes until freeze, then serve refcounted immutable snapshots across spawn backends (nofork, POSIX, `libuv`, Windows). Windows children now get consistent values; service STOP/SHUTDOWN activates only after freeze.
  - Threading discipline: `nd_thread_create()` asserts if called before `nd_environment_freeze_process()`. External plugins freeze on start; the daemon initializes and freezes early (e.g. ensures `TZ` via the managed env).
  - API and compatibility: use `nd_environment_get_dup()`, `nd_environment_set()`, `nd_environment_unset()`; `nd_setenv()` forwards to the managed env once initialized.
  - Spawn server API: now requires an environment and runtime dir: `spawn_server_create(options, name, cb, argc, argv, environment, runtime_directory)`; Windows helper `spawn_server_windows_publish_cygwin_path()` publishes the Cygwin/MSYS2 base path.
  - Enforcement and CI: native env APIs are compile‑time poisoned via `native-environment-compiler-check.h`; a new source scanner (`check-native-environment.py`) with unit tests and a workflow is added; new `environment-unittest` and enhanced `spawn-tester` run in CI.

- **Migration**
  - Initialize then freeze early: call `nd_environment_init()` at startup and `nd_environment_freeze_process()` before creating any threads/workers or handling service control.
  - Replace raw env access with `nd_environment_get_dup()`, `nd_environment_set()`, and `nd_environment_unset()` (native APIs are poisoned; only audited adapters may `#define NETDATA_NATIVE_ENVIRONMENT_ACCESS 1`).
  - Update calls to `spawn_server_create(options, name, cb, argc, argv, environment, runtime_directory)`; on Windows, call `spawn_server_windows_publish_cygwin_path()` if needed.

<sup>Written for commit cf30554e8afbb82e900b984edf70cb97da846b67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

