### PR TITLE
bump go.d min go version go 1.26.2

### DIFF
--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/netdata/netdata/go/plugins
 
-go 1.26.0
+go 1.26.2
 
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.302.0
 

--- a/src/go/plugin/ibm.d/modules/as400/helpers.go
+++ b/src/go/plugin/ibm.d/modules/as400/helpers.go
@@ -242,16 +242,16 @@ func (c *Collector) parseIBMiVersion() {
 					c.versionRelease = release
 				}
 				modStr := remainder[mIdx+1:]
-				modNum := ""
+				var modNum strings.Builder
 				for _, ch := range modStr {
 					if ch >= '0' && ch <= '9' {
-						modNum += string(ch)
+						modNum.WriteString(string(ch))
 					} else {
 						break
 					}
 				}
-				if modNum != "" {
-					if mod, err := strconv.Atoi(modNum); err == nil {
+				if modNum.String() != "" {
+					if mod, err := strconv.Atoi(modNum.String()); err == nil {
 						c.versionMod = mod
 					}
 				}


### PR DESCRIPTION
##### Summary

go 1.26.0 `go fix` has a bug

> Go 1.26.0’s stringscut analyzer mistakenly treats every call returning []byte like a []byte(value) conversion.


CI uses go version from `go.mod`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped minimum Go version to 1.26.2 to avoid the Go 1.26.0 stringscut analyzer bug triggered by `go fix`. Also tightened AS/400 version parsing for safer numeric extraction.

- **Dependencies**
  - Set module `github.com/netdata/netdata/go/plugins` to Go 1.26.2 in `github.com/netdata/netdata/go/plugins`’s `go.mod` (CI uses this version).

- **Bug Fixes**
  - In AS/400 helpers, switched from string concatenation to `strings.Builder` when parsing the module number to prevent false positives and improve robustness.

<sup>Written for commit d61c58cdbfbc0d7b5fb1a7e9dfac17d1d2e28de3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

