### PR TITLE
Perflib improvements

### DIFF
--- a/src/collectors/windows.plugin/perflib-ad.c
+++ b/src/collectors/windows.plugin/perflib-ad.c
@@ -3871,10 +3871,10 @@ int do_PerflibAD(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     if (!do_AD(pDataBlock, update_every))
-        return -1;
+        return 0;
 
     return 0;
 }

--- a/src/collectors/windows.plugin/perflib-adcs.c
+++ b/src/collectors/windows.plugin/perflib-adcs.c
@@ -704,10 +704,10 @@ int do_PerflibADCS(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     if (!do_ADCS(pDataBlock, update_every))
-        return -1;
+        return 0;
 
     return 0;
 }

--- a/src/collectors/windows.plugin/perflib-adfs.c
+++ b/src/collectors/windows.plugin/perflib-adfs.c
@@ -1518,10 +1518,10 @@ int do_PerflibADFS(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     if (!do_ADFS(pDataBlock, update_every))
-        return -1;
+        return 0;
 
     return 0;
 }

--- a/src/collectors/windows.plugin/perflib-memory.c
+++ b/src/collectors/windows.plugin/perflib-memory.c
@@ -863,10 +863,10 @@ int do_PerflibMemory(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     if (!do_memory(pDataBlock, update_every))
-        return -1;
+        return 0;
 
     return 0;
 }

--- a/src/collectors/windows.plugin/perflib-network.c
+++ b/src/collectors/windows.plugin/perflib-network.c
@@ -1058,7 +1058,7 @@ int do_PerflibNetwork(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     usec_t now_ut = now_monotonic_usec();
     do_network_interface(pDataBlock, update_every, true, now_ut);

--- a/src/collectors/windows.plugin/perflib-numa.c
+++ b/src/collectors/windows.plugin/perflib-numa.c
@@ -107,7 +107,7 @@ int do_PerflibNUMA(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     do_numa(pDataBlock, update_every);
 

--- a/src/collectors/windows.plugin/perflib-objects.c
+++ b/src/collectors/windows.plugin/perflib-objects.c
@@ -66,10 +66,10 @@ int do_PerflibObjects(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     if (!do_objects(pDataBlock, update_every))
-        return -1;
+        return 0;
 
     return 0;
 }

--- a/src/collectors/windows.plugin/perflib-processes.c
+++ b/src/collectors/windows.plugin/perflib-processes.c
@@ -75,7 +75,7 @@ int do_PerflibProcesses(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     do_processes(pDataBlock, update_every);
 

--- a/src/collectors/windows.plugin/perflib-processor.c
+++ b/src/collectors/windows.plugin/perflib-processor.c
@@ -204,7 +204,7 @@ int do_PerflibProcessor(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     do_processors(pDataBlock, update_every);
 

--- a/src/collectors/windows.plugin/perflib-smb.c
+++ b/src/collectors/windows.plugin/perflib-smb.c
@@ -239,7 +239,9 @@ int do_PerflibSMB(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        // A failed Perflib query is transient; return -1 only when the object
+        // is not registered, otherwise the main loop disables this module.
+        return 0;
 
     do_smb_server_shares(pDataBlock, update_every);
 

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -728,23 +728,18 @@ int do_PerflibStorage(int update_every, usec_t dt __maybe_unused)
     // Each perflibGetPerformanceData() call reuses the same internal buffer, so we must
     // query and consume each block before issuing the next call to avoid pointer aliasing.
     usec_t now_ut = now_monotonic_usec();
-    bool processed_any = false;
 
     if (logical_id != PERFLIB_REGISTRY_NAME_NOT_FOUND) {
         PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(logical_id);
-        if (pDataBlock) {
+        if (pDataBlock)
             do_logical_disk(pDataBlock, update_every, now_ut);
-            processed_any = true;
-        }
     }
 
     if (physical_id != PERFLIB_REGISTRY_NAME_NOT_FOUND) {
         PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(physical_id);
-        if (pDataBlock) {
+        if (pDataBlock)
             do_physical_disk(pDataBlock, update_every, now_ut);
-            processed_any = true;
-        }
     }
 
-    return processed_any ? 0 : -1;
+    return 0;
 }

--- a/src/collectors/windows.plugin/perflib-thermalzone.c
+++ b/src/collectors/windows.plugin/perflib-thermalzone.c
@@ -100,7 +100,7 @@ int do_PerflibThermalZone(int update_every, usec_t dt __maybe_unused)
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     do_thermal_zones(pDataBlock, update_every);
 

--- a/src/collectors/windows.plugin/perflib-web-service.c
+++ b/src/collectors/windows.plugin/perflib-web-service.c
@@ -1371,7 +1371,7 @@ static int iis_web_service(char *name, int update_every, typeof(bool(PERF_DATA_B
 
     PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
     if (!pDataBlock)
-        return -1;
+        return 0;
 
     routine(pDataBlock, update_every);
     return 0;


### PR DESCRIPTION
##### Summary
After the customer notified us that a specific metric was not available to him, but the metrics are present in the Perflib dump, we are modifying our current collection to avoid shutting down the metric if a specific metric in the group is missed.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Windows Perflib collectors resilient to transient failures by not shutting down when a metric group or data block is missing. We now return 0 instead of -1 on these cases, so other metrics keep flowing.

- **Bug Fixes**
  - All Perflib collectors return 0 when `perflibGetPerformanceData()` yields no data, preventing unintended disablement.
  - SMB: treat missing data blocks as transient; do not disable unless the object is unregistered.
  - Storage: removed “processed_any” gating; always return 0 after attempting logical/physical disk reads.

<sup>Written for commit 374c9166a841634942e1976a1c8e3fe33a96c1a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

