### PR TITLE
Update go version

### DIFF
--- a/src/collectors/ebpf.plugin/ebpfgo.plugin/go.mod
+++ b/src/collectors/ebpf.plugin/ebpfgo.plugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/netdata/netdata/src/collectors/ebpf.plugin/ebpfgo.plugin
 
-go 1.26.0
+go 1.26.2
 
 // Packages from go/plugins (netipc, netdataapi) are co-developed in this
 // repository.  The replace directive lets the module resolve them from the


### PR DESCRIPTION
##### Summary
Update ebpfgo modules.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped Go for `ebpfgo.plugin` from 1.26.0 to 1.26.2 to pick up patch fixes and keep builds consistent.

- **Migration**
  - Ensure local and CI builds use Go 1.26.2 for `src/collectors/ebpf.plugin/ebpfgo.plugin`.

<sup>Written for commit 5f405357ec480e03854e2a3360c9136d977e9959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

