### PR TITLE
api: escape dimension names in the v1 JSON formatters

### DIFF
--- a/src/web/api/formatters/csv/csv.c
+++ b/src/web/api/formatters/csv/csv.c
@@ -21,7 +21,13 @@ void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const 
         }
         buffer_strcat(wb, separator);
         if(options & RRDR_OPTION_LABEL_QUOTES) buffer_strcat(wb, "\"");
-        buffer_strcat(wb, string2str(r->dn[c]));
+        if(format == DATASOURCE_CSV_JSON_ARRAY)
+            // the array format is JSON: a quote or backslash in a
+            // dimension name (or a label value under group_by=label)
+            // must be escaped or the payload breaks
+            buffer_json_strcat(wb, string2str(r->dn[c]));
+        else
+            buffer_strcat(wb, string2str(r->dn[c]));
         if(options & RRDR_OPTION_LABEL_QUOTES) buffer_strcat(wb, "\"");
         i++;
     }

--- a/src/web/api/formatters/json/json.c
+++ b/src/web/api/formatters/json/json.c
@@ -121,7 +121,9 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
             continue;
 
         buffer_fast_strcat(wb, pre_label, pre_label_len);
-        buffer_strcat(wb, string2str(r->dn[c]));
+        // dimension names can carry any character (label values become
+        // names under group_by=label) - escape them or the JSON breaks
+        buffer_json_strcat(wb, string2str(r->dn[c]));
         buffer_fast_strcat(wb, post_label, post_label_len);
         i++;
     }

--- a/src/web/api/formatters/json/json.c
+++ b/src/web/api/formatters/json/json.c
@@ -8,6 +8,21 @@
 #define JSON_DATES_JS 1
 #define JSON_DATES_TIMESTAMP 2
 
+// the google visualization flavor (datatable + google_json) emits labels as
+// single-quoted JavaScript strings - escape the delimiter and the backslash;
+// control characters become \u escapes, which JavaScript accepts too
+static void rrdr2json_single_quoted_strcat(BUFFER *wb, const char *txt) {
+    for(const unsigned char *t = (const unsigned char *)txt; *t ; t++) {
+        if(unlikely(*t < ' '))
+            buffer_sprintf(wb, "\\u%04X", (unsigned)*t);
+        else {
+            if(unlikely(*t == '\\' || *t == '\''))
+                buffer_putc(wb, '\\');
+            buffer_putc(wb, (char)*t);
+        }
+    }
+}
+
 void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
     json_keys_init((options & RRDR_OPTION_LONG_JSON_KEYS) ? JSON_KEYS_OPTION_LONG_KEYS : 0);
     
@@ -122,8 +137,12 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
 
         buffer_fast_strcat(wb, pre_label, pre_label_len);
         // dimension names can carry any character (label values become
-        // names under group_by=label) - escape them or the JSON breaks
-        buffer_json_strcat(wb, string2str(r->dn[c]));
+        // names under group_by=label) - escape them or the JSON breaks;
+        // the escaping must match the active string quote
+        if(unlikely(sq[0] == '\''))
+            rrdr2json_single_quoted_strcat(wb, string2str(r->dn[c]));
+        else
+            buffer_json_strcat(wb, string2str(r->dn[c]));
         buffer_fast_strcat(wb, post_label, post_label_len);
         i++;
     }
@@ -243,8 +262,14 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
 
             buffer_fast_strcat(wb, pre_value, pre_value_len);
 
-            if(unlikely( options & RRDR_OPTION_OBJECTSROWS ))
-                buffer_sprintf(wb, "%s%s%s: ", kq, string2str(r->dn[c]), kq);
+            if(unlikely( options & RRDR_OPTION_OBJECTSROWS )) {
+                // the row object keys repeat the dimension names - escape them
+                // like the header (datatable clears this option, so the key
+                // quote is always ")
+                buffer_fast_strcat(wb, "\"", 1);
+                buffer_json_strcat(wb, string2str(r->dn[c]));
+                buffer_fast_strcat(wb, "\": ", 3);
+            }
 
             if(co[c] & RRDR_VALUE_EMPTY && !(options & (RRDR_OPTION_INTERNAL_AR))) {
                 if(unlikely(options & RRDR_OPTION_NULL2ZERO))


### PR DESCRIPTION
## What

The classic `json`, `jsonp` and `datatable` formatters write dimension names between quotes with **no JSON escaping** (the `rrdr2json` header loop), and `csvjsonarray` does the same through the csv renderer's label-quotes path. A double quote or a backslash in a dimension name — or in a **label value**, since label values become result names under `group_by=label` — produces **invalid JSON**. The v2/v3 `json2` path escapes properly.

## How

Dimension names are JSON-escaped (`buffer_json_strcat`) at both header loops:

- unconditionally in the json renderer (all its output shapes are JSON);
- for the `csvjsonarray` format in the csv renderer — plain csv/tsv/markdown/html headers keep their current raw rendering.

## Verification

Validated against the query-contract corpus (#23130): the deterministic red case for this bug (a dimension named `dim"quote` breaking all four formats) no longer reproduces — all four payloads parse as valid JSON with the name intact — while the byte-exact pins for csv/tsv (CRLF, cell values), ssv reductions, the gviz envelope, label-quotes and the format aliases are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape dimension names and per-row keys in v1 JSON output to keep payloads valid when names or label values contain quotes, apostrophes, backslashes, or control characters. Affects `json`, `jsonp`, `datatable` (incl. `google_json`), and `csvjsonarray`; non-JSON header formats stay unchanged.

- **Bug Fixes**
  - JSON-escape dimension names in headers and per-row `objectrows` keys for `json`, `jsonp`, `datatable`; use a single-quoted escaper for the `datatable`+`google_json` flavor.
  - JSON-escape names for `csvjsonarray` in the CSV renderer; `csv`/`tsv`/`markdown`/`html` headers remain raw.

<sup>Written for commit 88e3585cd2707143691341e77923cd0d28928fbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

