### PR TITLE
Netdata fixes part 86

### DIFF
--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -760,7 +760,9 @@ static void aclk_synchronization_event_loop(void *arg)
                         create_aclk_config(host, &host->host_id.uuid, &host->node_id.uuid);
                         aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
                     }
-                    aclk_host_config->node_info_send_time = (host == localhost || immediate) ? 1 : now_realtime_sec();
+                    aclk_send_timestamp_set(
+                        &aclk_host_config->node_info_send_time,
+                        (host == localhost || immediate) ? 1 : now_realtime_sec());
                     break;
                 case ACLK_CANCEL_NODE_UPDATE_TIMER:
                     host = cmd.param[0];
@@ -1027,8 +1029,9 @@ void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid __maybe_unused, nd_u
     aclk_host_config->host = host;
     aclk_alert_streaming_set(aclk_host_config, false);
     time_t now = now_realtime_sec();
-    aclk_host_config->node_info_send_time =
-        (host == localhost || NULL == localhost) ? nd_time_t_add_saturating(now, -25) : now;
+    aclk_send_timestamp_set(
+        &aclk_host_config->node_info_send_time,
+        (host == localhost || NULL == localhost) ? nd_time_t_add_saturating(now, -25) : now);
 
     struct aclk_sync_cfg_t *expected = NULL;
     if (__atomic_compare_exchange_n(&host->aclk_host_config, &expected, aclk_host_config, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED)) {

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -40,6 +40,8 @@ enum aclk_alert_snapshot_state {
     ACLK_ALERT_SNAPSHOT_READY,
 };
 
+typedef time_t aclk_send_timestamp_t __attribute__((aligned(8)));
+
 typedef struct aclk_sync_cfg_t {
     RRDHOST *host;
     uv_timer_t timer;
@@ -60,10 +62,28 @@ typedef struct aclk_sync_cfg_t {
     int alert_count;
     int snapshot_count;
     int checkpoint_count;
-    time_t node_info_send_time;
-    time_t node_collectors_send;
+    aclk_send_timestamp_t node_info_send_time;  // atomic: event loop to alert-push worker
+    aclk_send_timestamp_t node_collectors_send; // atomic: node-info builders to alert-push worker
     char node_id[UUID_STR_LEN];
 } aclk_sync_cfg_t;
+
+static inline time_t aclk_send_timestamp_get(const aclk_send_timestamp_t *send_time)
+{
+    return __atomic_load_n(send_time, __ATOMIC_ACQUIRE);
+}
+
+static inline void aclk_send_timestamp_set(aclk_send_timestamp_t *send_time, time_t value)
+{
+    __atomic_store_n(send_time, value, __ATOMIC_RELEASE);
+}
+
+static inline bool aclk_send_timestamp_claim(aclk_send_timestamp_t *send_time, time_t expected)
+{
+    // A same-value publication before this claim is covered by the send that follows;
+    // one after the claim remains pending instead of being cleared.
+    return __atomic_compare_exchange_n(
+        send_time, &expected, 0, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+}
 
 static inline enum aclk_alert_snapshot_state aclk_alert_snapshot_state_get(aclk_sync_cfg_t *aclk_host_config)
 {

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -106,7 +106,7 @@ static void build_node_info(RRDHOST *host, struct aclk_sync_completion *sync_com
     freez(node_info.node_instance_capabilities);
     freez(host_version);
 
-    aclk_host_config->node_collectors_send = now_realtime_sec();
+    aclk_send_timestamp_set(&aclk_host_config->node_collectors_send, now_realtime_sec());
 }
 
 void send_node_info_with_wait(RRDHOST *host)
@@ -204,7 +204,9 @@ void aclk_check_node_info_and_collectors(void)
             continue;
         }
 
-        if (!aclk_host_config->node_info_send_time && !aclk_host_config->node_collectors_send)
+        time_t node_info_send_time = aclk_send_timestamp_get(&aclk_host_config->node_info_send_time);
+        time_t node_collectors_send = aclk_send_timestamp_get(&aclk_host_config->node_collectors_send);
+        if (!node_info_send_time && !node_collectors_send)
             continue;
 
         if (unlikely(rrdhost_receiver_replicating_charts(host))) {
@@ -228,24 +230,26 @@ void aclk_check_node_info_and_collectors(void)
 
         bool pp_queue_empty = !rrdcontext_queue_entries(&host->rrdctx.pp_queue);
 
-        if (!pp_queue_empty && (aclk_host_config->node_info_send_time || aclk_host_config->node_collectors_send)) {
+        if (!pp_queue_empty && (node_info_send_time || node_collectors_send)) {
             context_pp++;
             hostname_snapshot_update(&context_pp_host, host);
         }
 
-        if (pp_queue_empty && aclk_host_config->node_info_send_time &&
-            nd_time_t_add_compare(aclk_host_config->node_info_send_time, 30, now) < 0) {
-            aclk_host_config->node_info_send_time = 0;
+        node_info_send_time = aclk_send_timestamp_get(&aclk_host_config->node_info_send_time);
+        if (pp_queue_empty && node_info_send_time &&
+            nd_time_t_add_compare(node_info_send_time, 30, now) < 0 &&
+            aclk_send_timestamp_claim(&aclk_host_config->node_info_send_time, node_info_send_time)) {
             build_node_info(host, NULL);
             schedule_node_state_update(host, 10000);
             internal_error(true, "ACLK SYNC: Sending node info for %s", rrdhost_hostname(host));
         }
 
-        if (pp_queue_empty && aclk_host_config->node_collectors_send &&
-            nd_time_t_add_compare(aclk_host_config->node_collectors_send, 30, now) < 0) {
+        node_collectors_send = aclk_send_timestamp_get(&aclk_host_config->node_collectors_send);
+        if (pp_queue_empty && node_collectors_send &&
+            nd_time_t_add_compare(node_collectors_send, 30, now) < 0 &&
+            aclk_send_timestamp_claim(&aclk_host_config->node_collectors_send, node_collectors_send)) {
             build_node_collectors(host);
             internal_error(true, "ACLK SYNC: Sending collectors for %s", rrdhost_hostname(host));
-            aclk_host_config->node_collectors_send = 0;
         }
     }
     dfe_done(host);


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data races in ACLK send scheduling by making node-info and collectors send timestamps atomic and aligned. Prevents missed or overwritten send requests across threads without changing timing or behavior.

- **Bug Fixes**
  - Added `aclk_send_timestamp_t` and atomic helpers (get/set/claim with acquire/release/CAS).
  - Replaced direct timestamp reads/writes in event loop and builders with atomic ops; claim due work before sending.
  - Avoids clearing newer publications and ensures correctness on 32-bit time64 targets.

<sup>Written for commit 060392ab6615a393ec9b6f1a35f6a1bf972a3176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

