### PR TITLE
Fix agent compilation on FreeBSD

### DIFF
--- a/packaging/cmake/Modules/NetdataSQLite.cmake
+++ b/packaging/cmake/Modules/NetdataSQLite.cmake
@@ -48,7 +48,8 @@ function(netdata_bundle_sqlite3)
                 SOURCE_DIR "${sqlite_SOURCE_DIR}"
                 BINARY_DIR "${sqlite_BINARY_DIR}"
                 CONFIGURE_COMMAND "${sqlite_SOURCE_DIR}/configure" --enable-update-limit
-                BUILD_COMMAND make sqlite3.c sqlite3.h
+                # GNU Make jobserver flags are not understood by FreeBSD make.
+                BUILD_COMMAND "${CMAKE_COMMAND}" -E env MAKEFLAGS= make sqlite3.c sqlite3.h
                 INSTALL_COMMAND ${CMAKE_COMMAND} -E copy
                         "${sqlite_BINARY_DIR}/sqlite3.c"
                         "${sqlite_BINARY_DIR}/sqlite3.h"


### PR DESCRIPTION
##### Summary
- Fix agent compilation (SQLITE) on FreeBSD


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix agent compilation on FreeBSD by clearing MAKEFLAGS during the bundled `SQLite` build. This avoids GNU Make jobserver flags that FreeBSD `make` doesn’t understand, restoring a successful build.

<sup>Written for commit 6c067e9933e71a56fef88db558c9a30147273cd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

