### PR TITLE
Correctly preserve PWD while ensuring temporary directory is set in kickstart.sh.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -556,6 +556,7 @@ run_as_root() {
 }
 
 run_script() {
+  old_pwd="${PWD}"
   set_tmpdir
 
   export NETDATA_SCRIPT_STATUS_PATH="${tmpdir}/.script-status"
@@ -576,6 +577,7 @@ run_script() {
     rm -f "${NETDATA_SCRIPT_STATUS_PATH}"
   fi
 
+  cd "${old_pwd}" || true
   return "${ret}"
 }
 
@@ -725,7 +727,9 @@ handle_wget_result() {
 check_for_remote_file() {
   url="${1}"
 
+  old_pwd="${PWD}"
   set_tmpdir
+  cd "${old_pwd}" || true
   dl_log="${tmpdir}/download.log"
   rm -f "${dl_log}"
 
@@ -757,7 +761,9 @@ download() {
   url="${1}"
   dest="${2}"
 
+  old_pwd="${PWD}"
   set_tmpdir
+  cd "${old_pwd}" || true
   dl_log="${tmpdir}/download.log"
   rm -f "${dl_log}"
 
@@ -787,7 +793,9 @@ get_actual_version() {
     major="${1}"
     channel="${2}"
     url="${RELEASE_INFO_URL}/${channel}/${major}"
+    old_pwd="${PWD}"
     set_tmpdir
+    cd "${old_pwd}" || true
     tmp_file="${tmpdir}/version-info"
 
     if check_for_remote_file "${RELEASE_INFO_URL}"; then
@@ -804,7 +812,9 @@ get_actual_version() {
 
 get_redirect() {
   url="${1}"
+  old_pwd="${PWD}"
   set_tmpdir
+  cd "${old_pwd}" || true
   output="${tmpdir}/download.log"
   rm -f "${output}"
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -577,7 +577,7 @@ run_script() {
     rm -f "${NETDATA_SCRIPT_STATUS_PATH}"
   fi
 
-  cd "${old_pwd}" || true
+  cd "${old_pwd}" || fatal "Failed to change current working directory to ${old_pwd}." F000A
   return "${ret}"
 }
 
@@ -729,7 +729,7 @@ check_for_remote_file() {
 
   old_pwd="${PWD}"
   set_tmpdir
-  cd "${old_pwd}" || true
+  cd "${old_pwd}" || fatal "Failed to change current working directory to ${old_pwd}." F000A
   dl_log="${tmpdir}/download.log"
   rm -f "${dl_log}"
 
@@ -763,7 +763,7 @@ download() {
 
   old_pwd="${PWD}"
   set_tmpdir
-  cd "${old_pwd}" || true
+  cd "${old_pwd}" || fatal "Failed to change current working directory to ${old_pwd}." F000A
   dl_log="${tmpdir}/download.log"
   rm -f "${dl_log}"
 
@@ -795,7 +795,7 @@ get_actual_version() {
     url="${RELEASE_INFO_URL}/${channel}/${major}"
     old_pwd="${PWD}"
     set_tmpdir
-    cd "${old_pwd}" || true
+    cd "${old_pwd}" || fatal "Failed to change current working directory to ${old_pwd}." F000A
     tmp_file="${tmpdir}/version-info"
 
     if check_for_remote_file "${RELEASE_INFO_URL}"; then
@@ -814,7 +814,7 @@ get_redirect() {
   url="${1}"
   old_pwd="${PWD}"
   set_tmpdir
-  cd "${old_pwd}" || true
+  cd "${old_pwd}" || fatal "Failed to change current working directory to ${old_pwd}." F000A
   output="${tmpdir}/download.log"
   rm -f "${output}"
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -795,7 +795,7 @@ get_actual_version() {
     url="${RELEASE_INFO_URL}/${channel}/${major}"
     old_pwd="${PWD}"
     set_tmpdir
-    cd "${old_pwd}" || fatal "Failed to change current working directory to ${old_pwd}." F000A
+    cd "${old_pwd}" || true
     tmp_file="${tmpdir}/version-info"
 
     if check_for_remote_file "${RELEASE_INFO_URL}"; then


### PR DESCRIPTION
##### Summary

Fixes broken offline install prep, as well as a few other issues.

##### Test Plan

Requires manual testing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the current working directory while initializing the temp directory in `packaging/installer/kickstart.sh`. Fixes offline install prep, avoids side effects from directory changes, and fails fast on PWD restore except in `get_actual_version` where failure is tolerated.

- **Bug Fixes**
  - Save `PWD` before `set_tmpdir`; restore it in `run_script`, `check_for_remote_file`, `download`, and `get_redirect` (fatal on failure, F000A). In `get_actual_version`, attempt restore but ignore failure.
  - Keep status, logs, and version files under `tmpdir` without changing the caller’s directory.

<sup>Written for commit 5d9706c0c4e107dcdff646a3ece84da8dedf672a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

