### PR TITLE
Sanitize kickstart.sh arguments that might be evaulated in privileged contexts.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -397,9 +397,8 @@ is_valid_url() {
 }
 
 sanitize_string() {
-  printf '%s\n' "${1}" | tr -cd "[:alnum:] ._-="
   v="${1}"
-  r="$(printf '%s\n' "${1}" | tr -cd "[:alnum:] ._-")"
+  r="$(printf '%s\n' "${1}" | tr -cd "[:alnum:] ._=-")"
   [ "${v}" = "${r}" ] || warning "Unsafe characters found in string, sanitized to ${r}"
   echo "${r}"
 }

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1397,7 +1397,7 @@ write_claim_config() {
   fi
 
   claim_config="${config_path}/claim.conf"
-  claim_config_tmp="${tmpdir}/claim.conf"
+  claim_config_tmp="$(mktemp -p "${tmpdir}")"
 
   if [ "${DRY_RUN}" -eq 1 ]; then
     progress "Would attempt to write claiming configuration to ${claim_config}"
@@ -1419,9 +1419,9 @@ write_claim_config() {
       config="${config}\n    insecure = ${NETDATA_CLAIM_INSECURE}"
   fi
 
-  printf "${config}\n" > "${claim_config_tmp}" || return 1
+  printf "%s\n" "${config}" > "${claim_config_tmp}" || return 1
+  run_as_root chown "root:${NETDATA_CLAIM_GROUP:-netdata}" "${claim_config_tmp}" || return 1
   run_as_root chmod 0640 "${claim_config_tmp}" || return 1
-  run_as_root chown ":${NETDATA_CLAIM_GROUP:-netdata}" "${claim_config_tmp}" || return 1
   run_as_root mv -f "${claim_config_tmp}" "${claim_config}" || return 1
 
   if [ -z "${NETDATA_CLAIM_NORELOAD}" ]; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F0522
+# Next unused error code: F0524
 
 # ======================================================================
 # Constants
@@ -391,8 +391,28 @@ trap 'trap_handler 15 0' TERM
 # ======================================================================
 # Utility functions
 
+# Check if a URL is valid, and ensure it uses one of the specified protocols.
+is_valid_url() {
+  echo "${1}" | grep -qE "^(${2})+://([^@\/:[:space:]]+(:[^@\/:[:space:]]*)?@)?(\[[0-9A-Fa-f:]+\]|[A-Za-z0-9.-]+)(:[0-9]{1,5})?(/[-A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=]*)?$'" || return 1
+}
+
 sanitize_string() {
-    printf '%s\n' "$1" | tr -cd "[:alnum:] :/.,_-"
+  printf '%s\n' "${1}" | tr -cd "[:alnum:] ._-="
+  v="${1}"
+  r="$(printf '%s\n' "${1}" | tr -cd "[:alnum:] ._-")"
+  [ "${v}" = "${r}" ] || warning "Unsafe characters found in string, sanitized to ${r}"
+  echo "${r}"
+}
+
+sanitize_path() {
+  v="${1}"
+  _path_unsafe=";&'\"|\\<>()\n\$*?\`{}[]"
+  if [ -z "${_path_replace}" ]; then
+    _path_replace="$(printf "%$(printf "%s" "${_path_unsafe}" | wc -m)s" | tr " " "_")"
+  fi
+  r="$(printf '%s\n' "$1" | tr "${_path_unsafe}" "${_path_replace}")"
+  [ "${v}" = "${r}" ] || warning "Unsafe characters found in path, sanitized to ${r}"
+  echo "${r}"
 }
 
 canonical_path() {
@@ -2619,7 +2639,7 @@ parse_args() {
       "--interactive") INTERACTIVE=1 ;;
       "--dry-run") DRY_RUN=1 ;;
       "--release-channel")
-        RELEASE_CHANNEL="$(sanitize_string "${2}" | tr '[:upper:]' '[:lower:]')"
+        RELEASE_CHANNEL="$(echo "${2}" | tr '[:upper:]' '[:lower:]')"
         case "${RELEASE_CHANNEL}" in
           nightly|stable|default) shift 1 ;;
           *)
@@ -2638,7 +2658,7 @@ parse_args() {
       "--no-updates") NETDATA_AUTO_UPDATES=0 ;;
       "--auto-update") NETDATA_AUTO_UPDATES="1" ;;
       "--auto-update-type"|"--auto-update-method")
-        NETDATA_AUTO_UPDATE_TYPE="$(sanitize_string "${2}" | tr '[:upper:]' '[:lower:]')"
+        NETDATA_AUTO_UPDATE_TYPE="$(echo "${2}" | tr '[:upper:]' '[:lower:]')"
         case "${NETDATA_AUTO_UPDATE_TYPE}" in
           systemd|interval|crontab) shift 1 ;;
           *)
@@ -2662,19 +2682,27 @@ parse_args() {
         NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --disable-telemetry"
         ;;
       "--install-prefix")
-        INSTALL_PREFIX="$(sanitize_string "${2}")"
+        p="$(sanitize_path "${2}")"
+        if [ "${p}" != "${2}" ]; then
+          fatal "Unsafe characters detected in install prefix" F0525
+        fi
+        INSTALL_PREFIX="${p}"
         shift 1
         ;;
       "--old-install-prefix")
-        OLD_INSTALL_PREFIX="$(sanitize_string "${2}")"
+        p="$(sanitize_path "${2}")"
+        if [ "${p}" != "${2}" ]; then
+          fatal "Unsafe characters detected in old install prefix" F0526
+        fi
+        OLD_INSTALL_PREFIX="${p}"
         shift 1
         ;;
       "--install-major-version")
-        INSTALL_MAJOR_VERSION="$(sanitize_string "${2}")"
+        INSTALL_MAJOR_VERSION="${2}"
         shift 1
         ;;
       "--install-version")
-        INSTALL_VERSION="$(sanitize_string "${2}")"
+        INSTALL_VERSION="${2}"
         AUTO_UPDATE=0
         shift 1
         ;;
@@ -2702,9 +2730,8 @@ parse_args() {
       "--static-only") NETDATA_REQUESTED_INSTALL_TYPE="static" ;;
       "--build-only") NETDATA_REQUESTED_INSTALL_TYPE="build" ;;
       "--install-type")
-        t="$(sanitize_string "${2}")"
-        case "${t}" in
-          native|static|build|auto|any) NETDATA_REQUESTED_INSTALL_TYPE="${t}" ;;
+        case "${2}" in
+          native|static|build|auto|any) NETDATA_REQUESTED_INSTALL_TYPE="${2}" ;;
           *) fatal "${2} is not a recognized install type. Please specify one of native, static, build, auto, or any." F051F ;;
         esac
         shift 1
@@ -2712,10 +2739,18 @@ parse_args() {
       "--claim-"*)
         optname="$(echo "${1}" | cut -d '-' -f 4-)"
         case "${optname}" in
+          url)
+            is_valid_url "${2}" "http|https" || fatal "${2} is not a valid claim URL" F0522
+            NETDATA_CLAIM_URL="${2}"
+            shift 1
+            ;;
+          proxy)
+            is_valid_url "${2}" "http|https|socks|socks5" || fatal "${2} is not a valid claim proxy URL" F0523
+            NETDATA_CLAIM_PROXY="${2}"
+            shift 1
+            ;;
           token) NETDATA_CLAIM_TOKEN="$(sanitize_string "${2}")"; shift 1 ;;
           rooms) NETDATA_CLAIM_ROOMS="$(sanitize_string "${2}")"; shift 1 ;;
-          url) NETDATA_CLAIM_URL="$(sanitize_string "${2}")"; shift 1 ;;
-          proxy) NETDATA_CLAIM_PROXY="$(sanitize_string "${2}")"; shift 1 ;;
           noproxy) NETDATA_CLAIM_PROXY="none" ;;
           insecure) NETDATA_CLAIM_INSECURE=yes ;;
           noreload) NETDATA_CLAIM_NORELOAD=1 ;;
@@ -2745,20 +2780,18 @@ parse_args() {
         fi
         ;;
       "--offline-architecture")
-        arch="$(sanitize_string "${2}")"
-        if echo "${STATIC_INSTALL_ARCHES}" | grep -qw "${arch}"; then
-          NETDATA_OFFLINE_ARCHES="${NETDATA_OFFLINE_ARCHES} ${arch}"
+        if echo "${STATIC_INSTALL_ARCHES}" | grep -qw "${2}"; then
+          NETDATA_OFFLINE_ARCHES="${NETDATA_OFFLINE_ARCHES} ${2}"
         else
-          fatal "${arch} is not a recognized static build architecture (supported architectures are ${STATIC_INSTALL_ARCHES})" F0518
+          fatal "${2} is not a recognized static build architecture (supported architectures are ${STATIC_INSTALL_ARCHES})" F0518
         fi
         shift 1
         ;;
       "--offline-install-source")
         if [ -d "${2}" ]; then
-          p="$(sanitize_string "${2}")"
-          NETDATA_OFFLINE_INSTALL_SOURCE="${p}"
+          NETDATA_OFFLINE_INSTALL_SOURCE="${2}"
           # shellcheck disable=SC2164
-          NETDATA_TARBALL_BASEURL="file://$(cd "${p}"; pwd)"
+          NETDATA_TARBALL_BASEURL="file://$(cd "${2}"; pwd)"
           shift 1
         else
           fatal "A source directory must be specified with the --offline-install-source option." F0501

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -393,7 +393,7 @@ trap 'trap_handler 15 0' TERM
 
 # Check if a URL is valid, and ensure it uses one of the specified protocols.
 is_valid_url() {
-  echo "${1}" | grep -qE "^(${2})+://([^@\/:[:space:]]+(:[^@\/:[:space:]]*)?@)?(\[[0-9A-Fa-f:]+\]|[A-Za-z0-9.-]+)(:[0-9]{1,5})?(/[-A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=]*)?$'" || return 1
+  echo "${1}" | grep -qE "^(${2})+://([^@\/:[:space:]]+(:[^@\/:[:space:]]*)?@)?(\[[0-9A-Fa-f:]+\]|[A-Za-z0-9.-]+)(:[0-9]{1,5})?(/[-A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=]*)?$" || return 1
 }
 
 sanitize_string() {

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1378,6 +1378,10 @@ is_netdata_running() {
 }
 
 write_claim_config() {
+  old_pwd="${PWD}"
+  set_tmpdir
+  cd "${old_pwd}" || fatal "Failed to change current working directory to ${old_pwd}." F000A
+
   if [ -z "${INSTALL_PREFIX}" ] || [ "${INSTALL_PREFIX}" = "/" ]; then
     config_path="/etc/netdata"
     netdatacli="$(command -v netdatacli)"
@@ -1393,6 +1397,7 @@ write_claim_config() {
   fi
 
   claim_config="${config_path}/claim.conf"
+  claim_config_tmp="${tmpdir}/claim.conf"
 
   if [ "${DRY_RUN}" -eq 1 ]; then
     progress "Would attempt to write claiming configuration to ${claim_config}"
@@ -1414,11 +1419,10 @@ write_claim_config() {
       config="${config}\n    insecure = ${NETDATA_CLAIM_INSECURE}"
   fi
 
-  run_as_root touch "${claim_config}.tmp" || return 1
-  run_as_root chmod 0640 "${claim_config}.tmp" || return 1
-  run_as_root chown ":${NETDATA_CLAIM_GROUP:-netdata}" "${claim_config}.tmp" || return 1
-  run_as_root sh -c "printf '${config}\\n' > \"${claim_config}.tmp\"" || return 1
-  run_as_root mv -f "${claim_config}.tmp" "${claim_config}" || return 1
+  printf "${config}\n" > "${claim_config_tmp}" || return 1
+  run_as_root chmod 0640 "${claim_config_tmp}" || return 1
+  run_as_root chown ":${NETDATA_CLAIM_GROUP:-netdata}" "${claim_config_tmp}" || return 1
+  run_as_root mv -f "${claim_config_tmp}" "${claim_config}" || return 1
 
   if [ -z "${NETDATA_CLAIM_NORELOAD}" ]; then
     if [ -n "${netdatacli}" ]; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1397,7 +1397,7 @@ write_claim_config() {
   fi
 
   claim_config="${config_path}/claim.conf"
-  claim_config_tmp="$(mktemp -p "${tmpdir}")"
+  claim_config_tmp="$(mktemp "${tmpdir}/claim.conf.XXXXXX")"
 
   if [ "${DRY_RUN}" -eq 1 ]; then
     progress "Would attempt to write claiming configuration to ${claim_config}"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -391,6 +391,10 @@ trap 'trap_handler 15 0' TERM
 # ======================================================================
 # Utility functions
 
+sanitize_string() {
+    printf '%s\n' "$1" | tr -cd "[:alnum:] :/.,_-"
+}
+
 canonical_path() {
   OLDPWD="$(pwd)"
   cd "$(dirname "${1}")" || exit 1
@@ -2615,7 +2619,7 @@ parse_args() {
       "--interactive") INTERACTIVE=1 ;;
       "--dry-run") DRY_RUN=1 ;;
       "--release-channel")
-        RELEASE_CHANNEL="$(echo "${2}" | tr '[:upper:]' '[:lower:]')"
+        RELEASE_CHANNEL="$(sanitize_string "${2}" | tr '[:upper:]' '[:lower:]')"
         case "${RELEASE_CHANNEL}" in
           nightly|stable|default) shift 1 ;;
           *)
@@ -2634,7 +2638,7 @@ parse_args() {
       "--no-updates") NETDATA_AUTO_UPDATES=0 ;;
       "--auto-update") NETDATA_AUTO_UPDATES="1" ;;
       "--auto-update-type"|"--auto-update-method")
-        NETDATA_AUTO_UPDATE_TYPE="$(echo "${2}" | tr '[:upper:]' '[:lower:]')"
+        NETDATA_AUTO_UPDATE_TYPE="$(sanitize_string "${2}" | tr '[:upper:]' '[:lower:]')"
         case "${NETDATA_AUTO_UPDATE_TYPE}" in
           systemd|interval|crontab) shift 1 ;;
           *)
@@ -2658,19 +2662,19 @@ parse_args() {
         NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --disable-telemetry"
         ;;
       "--install-prefix")
-        INSTALL_PREFIX="${2}"
+        INSTALL_PREFIX="$(sanitize_string "${2}")"
         shift 1
         ;;
       "--old-install-prefix")
-        OLD_INSTALL_PREFIX="${2}"
+        OLD_INSTALL_PREFIX="$(sanitize_string "${2}")"
         shift 1
         ;;
       "--install-major-version")
-        INSTALL_MAJOR_VERSION="${2}"
+        INSTALL_MAJOR_VERSION="$(sanitize_string "${2}")"
         shift 1
         ;;
       "--install-version")
-        INSTALL_VERSION="${2}"
+        INSTALL_VERSION="$(sanitize_string "${2}")"
         AUTO_UPDATE=0
         shift 1
         ;;
@@ -2698,8 +2702,9 @@ parse_args() {
       "--static-only") NETDATA_REQUESTED_INSTALL_TYPE="static" ;;
       "--build-only") NETDATA_REQUESTED_INSTALL_TYPE="build" ;;
       "--install-type")
-        case "${2}" in
-          native|static|build|auto|any) NETDATA_REQUESTED_INSTALL_TYPE="${2}" ;;
+        t="$(sanitize_string "${2}")"
+        case "${t}" in
+          native|static|build|auto|any) NETDATA_REQUESTED_INSTALL_TYPE="${t}" ;;
           *) fatal "${2} is not a recognized install type. Please specify one of native, static, build, auto, or any." F051F ;;
         esac
         shift 1
@@ -2707,15 +2712,15 @@ parse_args() {
       "--claim-"*)
         optname="$(echo "${1}" | cut -d '-' -f 4-)"
         case "${optname}" in
-          token) NETDATA_CLAIM_TOKEN="${2}"; shift 1 ;;
-          rooms) NETDATA_CLAIM_ROOMS="${2}"; shift 1 ;;
-          url) NETDATA_CLAIM_URL="${2}"; shift 1 ;;
-          proxy) NETDATA_CLAIM_PROXY="${2}"; shift 1 ;;
+          token) NETDATA_CLAIM_TOKEN="$(sanitize_string "${2}")"; shift 1 ;;
+          rooms) NETDATA_CLAIM_ROOMS="$(sanitize_string "${2}")"; shift 1 ;;
+          url) NETDATA_CLAIM_URL="$(sanitize_string "${2}")"; shift 1 ;;
+          proxy) NETDATA_CLAIM_PROXY="$(sanitize_string "${2}")"; shift 1 ;;
           noproxy) NETDATA_CLAIM_PROXY="none" ;;
           insecure) NETDATA_CLAIM_INSECURE=yes ;;
           noreload) NETDATA_CLAIM_NORELOAD=1 ;;
           id|user|hostname)
-            NETDATA_CLAIM_EXTRA="${NETDATA_CLAIM_EXTRA} -${optname}=${2}"
+            NETDATA_CLAIM_EXTRA="${NETDATA_CLAIM_EXTRA} -${optname}=$(sanitize_string "${2}")"
             shift 1
             ;;
           verbose|daemon-not-running) NETDATA_CLAIM_EXTRA="${NETDATA_CLAIM_EXTRA} -${optname}" ;;
@@ -2723,35 +2728,37 @@ parse_args() {
         esac
         ;;
       "--local-build-options")
-        LOCAL_BUILD_OPTIONS="${LOCAL_BUILD_OPTIONS} ${2}"
+        LOCAL_BUILD_OPTIONS="${LOCAL_BUILD_OPTIONS} $(sanitize_string "${2}")"
         shift 1
         ;;
       "--static-install-options")
-        STATIC_INSTALL_OPTIONS="${STATIC_INSTALL_OPTIONS} ${2}"
+        STATIC_INSTALL_OPTIONS="${STATIC_INSTALL_OPTIONS} $(sanitize_string "${2}")"
         shift 1
         ;;
       "--prepare-offline-install-source")
         if [ -n "${2}" ]; then
           set_action 'prepare-offline'
-          OFFLINE_TARGET="${2}"
+          OFFLINE_TARGET="$(sanitize_string "${2}")"
           shift 1
         else
           fatal "A target directory must be specified with the --prepare-offline-install-source option." F0500
         fi
         ;;
       "--offline-architecture")
-        if echo "${STATIC_INSTALL_ARCHES}" | grep -qw "${2}"; then
-          NETDATA_OFFLINE_ARCHES="${NETDATA_OFFLINE_ARCHES} ${2}"
+        arch="$(sanitize_string "${2}")"
+        if echo "${STATIC_INSTALL_ARCHES}" | grep -qw "${arch}"; then
+          NETDATA_OFFLINE_ARCHES="${NETDATA_OFFLINE_ARCHES} ${arch}"
         else
-          fatal "${2} is not a recognized static build architecture (supported architectures are ${STATIC_INSTALL_ARCHES})" F0518
+          fatal "${arch} is not a recognized static build architecture (supported architectures are ${STATIC_INSTALL_ARCHES})" F0518
         fi
         shift 1
         ;;
       "--offline-install-source")
         if [ -d "${2}" ]; then
-          NETDATA_OFFLINE_INSTALL_SOURCE="${2}"
+          p="$(sanitize_string "${2}")"
+          NETDATA_OFFLINE_INSTALL_SOURCE="${p}"
           # shellcheck disable=SC2164
-          NETDATA_TARBALL_BASEURL="file://$(cd "${2}"; pwd)"
+          NETDATA_TARBALL_BASEURL="file://$(cd "${p}"; pwd)"
           shift 1
         else
           fatal "A source directory must be specified with the --offline-install-source option." F0501

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -393,7 +393,7 @@ trap 'trap_handler 15 0' TERM
 
 # Check if a URL is valid, and ensure it uses one of the specified protocols.
 is_valid_url() {
-  echo "${1}" | grep -qE "^(${2})+://([^@\/:[:space:]]+(:[^@\/:[:space:]]*)?@)?(\[[0-9A-Fa-f:]+\]|[A-Za-z0-9.-]+)(:[0-9]{1,5})?(/[-A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=]*)?$" || return 1
+  printf "%s\n" "${1}" | grep -qE "^(${2})://([^@\/:[:space:]]+(:[^@\/:[:space:]]*)?@)?(\[[0-9A-Fa-f:]+\]|[A-Za-z0-9.-]+)(:[0-9]{1,5})?(/[-A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=]*)?$" || return 1
 }
 
 sanitize_string() {
@@ -1406,20 +1406,19 @@ write_claim_config() {
 
   progress "Writing claiming configuration to ${claim_config}"
 
-  config="[global]"
-  config="${config}\n    url = ${NETDATA_CLAIM_URL}"
-  config="${config}\n    token = ${NETDATA_CLAIM_TOKEN}"
+  printf "[global]\n" > "${claim_config_tmp}" || return 1
+  printf "    url = %s\n" "${NETDATA_CLAIM_URL}" >> "${claim_config_tmp}" || return 1
+  printf "    token = %s\n" "${NETDATA_CLAIM_TOKEN}" >> "${claim_config_tmp}" || return 1
   if [ -n "${NETDATA_CLAIM_ROOMS}" ]; then
-      config="${config}\n    rooms = ${NETDATA_CLAIM_ROOMS}"
+    printf "    rooms = %s\n" "${NETDATA_CLAIM_ROOMS}" >> "${claim_config_tmp}" || return 1
   fi
   if [ -n "${NETDATA_CLAIM_PROXY}" ]; then
-      config="${config}\n    proxy = ${NETDATA_CLAIM_PROXY}"
+    printf "    proxy = %s\n" "${NETDATA_CLAIM_PROXY}" >> "${claim_config_tmp}" || return 1
   fi
   if [ -n "${NETDATA_CLAIM_INSECURE}" ]; then
-      config="${config}\n    insecure = ${NETDATA_CLAIM_INSECURE}"
+    printf "    insecure = %s\n" "${NETDATA_CLAIM_INSECURE}" >> "${claim_config_tmp}" || return 1
   fi
 
-  printf "%s\n" "${config}" > "${claim_config_tmp}" || return 1
   run_as_root chown "root:${NETDATA_CLAIM_GROUP:-netdata}" "${claim_config_tmp}" || return 1
   run_as_root chmod 0640 "${claim_config_tmp}" || return 1
   run_as_root mv -f "${claim_config_tmp}" "${claim_config}" || return 1


### PR DESCRIPTION
##### Summary

The sanitization limits the option values to a handful of known safe characters that are actually utilized in the option values.

##### Test Plan

n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `kickstart.sh` by strictly validating URLs and rejecting unsafe option values to prevent evaluating user input with elevated privileges. Claim config is written via a secure temp file with explicit ownership, including a macOS compatibility fix.

- **Bug Fixes**
  - Rejects unsafe characters in `--install-prefix` and `--old-install-prefix` with clear errors.
  - Validates `--claim-url` (`http|https`) and `--claim-proxy` (`http|https|socks|socks5`), and sanitizes `--claim-*` (token, rooms, id/user/hostname), `--local-build-options`, `--static-install-options`, and `--prepare-offline-install-source`.
  - Writes `claim.conf` via `mktemp` in a secure temp dir, then chowns to `root:${NETDATA_CLAIM_GROUP:-netdata}`, chmod 0640, and moves it into place to avoid processing user input as root; includes a macOS ownership fix.

<sup>Written for commit 94aa3942b0e4e1ae040f4debab0dbd3545a7823a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

