### PR TITLE
fix(plugins.d): prevent plugins from overwriting reserved dyncfg functions

### DIFF
--- a/src/database/rrdfunctions.c
+++ b/src/database/rrdfunctions.c
@@ -193,7 +193,11 @@ static inline bool is_function_restricted(const char *name, const char *tags) {
     return (name && name[0] == '_' && name[1] == '_') || (tags && strstr(tags, RRDFUNCTIONS_TAG_HIDDEN) != NULL);
 }
 
-static inline bool is_function_dyncfg(const char *name) {
+// Reports whether a function name is a reserved dynamic-configuration name -
+// the `config` catch-all or any per-config `config <id>` function. Exposed so
+// the pluginsd FUNCTION handler can refuse external registrations that would
+// otherwise overwrite (swap) the built-in dyncfg execute callback.
+bool rrd_function_name_is_dyncfg(const char *name) {
     if(!name || !*name)
         return false;
 
@@ -208,7 +212,7 @@ static inline bool is_function_dyncfg(const char *name) {
 }
 
 static inline RRD_FUNCTION_OPTIONS get_function_options(RRDSET *st, const char *name, const char *tags) {
-    if(is_function_dyncfg(name))
+    if(rrd_function_name_is_dyncfg(name))
         return RRD_FUNCTION_DYNCFG;
 
     RRD_FUNCTION_OPTIONS options = st ? RRD_FUNCTION_LOCAL : RRD_FUNCTION_GLOBAL;

--- a/src/database/rrdfunctions.h
+++ b/src/database/rrdfunctions.h
@@ -76,6 +76,9 @@ void rrd_function_add(RRDHOST *host, RRDSET *st, const char *name, int timeout, 
 
 bool rrd_function_del(RRDHOST *host, RRDSET *st, const char *name, bool from_streaming, bool internal);
 
+// true if name is a reserved dynamic-configuration function name ("config" or "config <id>")
+bool rrd_function_name_is_dyncfg(const char *name);
+
 // call a function, to be run from anywhere
 int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
                      HTTP_ACCESS user_access, const char *cmd,

--- a/src/plugins.d/pluginsd_functions.c
+++ b/src/plugins.d/pluginsd_functions.c
@@ -383,9 +383,13 @@ PARSER_RC pluginsd_function(char **words, size_t num_words, PARSER *parser) {
         char sanitized_name[sizeof(PLUGINSD_FUNCTION_CONFIG) + 4];
         rrd_functions_sanitize(sanitized_name, name, sizeof(sanitized_name));
         if(rrd_function_name_is_dyncfg(sanitized_name)) {
+            // Log the sanitized name (what we actually classify on), not the raw name:
+            // a raw name with leading whitespace/control chars or embedded newlines
+            // would make this log line misleading or malformed. The id part of a
+            // "config <id>" name is truncated here, which is fine for a warning.
             nd_log(NDLS_DAEMON, NDLP_WARNING,
                    "PLUGINSD: 'host:%s' attempted to register reserved dynamic-configuration function '%s' via FUNCTION. Ignoring it.",
-                   rrdhost_hostname(host), name);
+                   rrdhost_hostname(host), sanitized_name);
             return PARSER_RC_OK;
         }
     }

--- a/src/plugins.d/pluginsd_functions.c
+++ b/src/plugins.d/pluginsd_functions.c
@@ -354,6 +354,42 @@ PARSER_RC pluginsd_function(char **words, size_t num_words, PARSER *parser) {
         return PARSER_RC_ERROR;
     }
 
+    // Reserved dynamic-configuration function names ("config", "config <id>") are
+    // owned exclusively by the dyncfg subsystem on localhost. A LOCAL plugin
+    // registering one would collide in host->functions and make
+    // rrd_functions_conflict_callback() swap the built-in dyncfg execute callback
+    // out, hijacking the config tree. Local plugins do dyncfg via the DYNCFG
+    // protocol (not FUNCTION), so no legitimate local registration uses these names.
+    //
+    // Streaming is the exception and MUST be preserved: a child streams a single
+    // synthetic "config" proxy (dyncfg_add_streaming()) so the parent can forward
+    // config commands to it. That registration targets the child's host (never the
+    // parent's localhost built-in), so it cannot hijack anything. Only guard
+    // non-streaming (local plugin) registrations, matching the from_streaming
+    // distinction used by the FUNCTION_DEL handler / rrd_function_del().
+    //
+    // Check the SANITIZED name: rrd_function_add() keys host->functions on the
+    // sanitized form, which strips leading spaces/control chars. A raw name like
+    // " config" or "\tconfig" would otherwise slip past this guard yet still
+    // collide with the built-in "config" key. The predicate only inspects
+    // "config" plus the following byte, so the buffer needs room for "config", one
+    // full following UTF-8 character (up to 4 bytes), and the terminator. That
+    // makes the classification of that byte byte-identical to the full key
+    // rrd_function_add() computes, so e.g. "config<multibyte>" is correctly NOT
+    // treated as a dyncfg name (distinct key, no collision), while "config" and
+    // "config <id>" still are.
+    bool from_streaming = (parser->repertoire & PARSER_INIT_STREAMING) != 0;
+    if(!from_streaming) {
+        char sanitized_name[sizeof(PLUGINSD_FUNCTION_CONFIG) + 4];
+        rrd_functions_sanitize(sanitized_name, name, sizeof(sanitized_name));
+        if(rrd_function_name_is_dyncfg(sanitized_name)) {
+            nd_log(NDLS_DAEMON, NDLP_WARNING,
+                   "PLUGINSD: 'host:%s' attempted to register reserved dynamic-configuration function '%s' via FUNCTION. Ignoring it.",
+                   rrdhost_hostname(host), name);
+            return PARSER_RC_OK;
+        }
+    }
+
     int timeout_s = PLUGINS_FUNCTIONS_TIMEOUT_DEFAULT;
     if (timeout_str && *timeout_str) {
         timeout_s = str2i(timeout_str);


### PR DESCRIPTION
##### Summary
- A FUNCTION registration whose sanitized name matches a dyncfg function ("config"/"config <id>") swapped the built-in dyncfg callback out, breaking the config tree. 
- Reject such names at the pluginsd boundary, mirroring the existing FUNCTION_DEL guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents reserved dyncfg function names ("config", "config <id>") from being registered by local plugins, avoiding overwrite of the built-in callback and config tree breakage.

- **Bug Fixes**
  - Add a guard in `pluginsd` for non-streaming FUNCTION registrations using the sanitized name; log the sanitized name on attempts and ignore. Streaming’s synthetic "config" proxy is preserved.
  - Export `rrd_function_name_is_dyncfg()` and use it in function option selection to classify dyncfg functions.

<sup>Written for commit 41646fc1ed4f163c7510429d256722de54a78847. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

