### PR TITLE
Add regression tests for function access verification in MCP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1815,6 +1815,7 @@ set(RRD_PLUGIN_FILES
         src/database/rrdfunctions-inflight.h
         src/database/rrdfunctions-exporters.c
         src/database/rrdfunctions-exporters.h
+        src/database/rrdfunctions-unittest.c
         src/database/rrdfunctions-internals.h
         src/database/rrdcollector-internals.h
         src/database/rrd-database-mode.h
@@ -2021,6 +2022,7 @@ set(WEB_PLUGIN_FILES
         src/web/mcp/mcp-tools-list-metadata.h
         src/web/mcp/mcp-tools-execute-function.c
         src/web/mcp/mcp-tools-execute-function.h
+        src/web/mcp/mcp-tools-execute-function-unittest.c
         src/web/mcp/mcp-tools-execute-function-internal.h
         src/web/mcp/mcp-tools-execute-function-registry.c
         src/web/mcp/mcp-tools-execute-function-registry.h

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -268,6 +268,26 @@ int unittest_prepare_rrd(const char **user) {
     return 0;
 }
 
+// Standalone `-W <name>` unittest driver: bring up sqlite + RRD, run one test,
+// tear everything down, and return the test's exit code.
+static int unittest_run_with_rrd(int (*test_fn)(void)) {
+    unittest_running = true;
+
+    if(sqlite_library_init())
+        return 1;
+    rrdlabels_aral_init(false);
+
+    const char *user = NULL;
+    int rc = unittest_prepare_rrd(&user);
+    if(!rc)
+        rc = test_fn();
+
+    sqlite_close_databases();
+    sqlite_library_shutdown();
+    rrdlabels_aral_destroy(false);
+    return rc;
+}
+
 static void fatal_status_file_save(void) {
     daemon_status_file_update_status(DAEMON_STATUS_NONE);
     exit(1);
@@ -694,51 +714,12 @@ int netdata_main(int argc, char **argv) {
                             unittest_running = true;
                             return health_config_unittest();
                         }
-                        else if(strcmp(optarg, "dyncfgtest") == 0) {
-                            unittest_running = true;
-                            if(sqlite_library_init())
-                                return 1;
-                            rrdlabels_aral_init(false);
-
-                            int rc = unittest_prepare_rrd(&user);
-                            if (!rc)
-                                rc = dyncfg_unittest();
-
-                            sqlite_close_databases();
-                            sqlite_library_shutdown();
-                            rrdlabels_aral_destroy(false);
-                            return rc;
-                        }
-                        else if(strcmp(optarg, "functionsaccesstest") == 0) {
-                            unittest_running = true;
-                            if(sqlite_library_init())
-                                return 1;
-                            rrdlabels_aral_init(false);
-
-                            int rc = unittest_prepare_rrd(&user);
-                            if (!rc)
-                                rc = rrdfunctions_verify_access_unittest();
-
-                            sqlite_close_databases();
-                            sqlite_library_shutdown();
-                            rrdlabels_aral_destroy(false);
-                            return rc;
-                        }
-                        else if(strcmp(optarg, "mcpfunctionaccesstest") == 0) {
-                            unittest_running = true;
-                            if(sqlite_library_init())
-                                return 1;
-                            rrdlabels_aral_init(false);
-
-                            int rc = unittest_prepare_rrd(&user);
-                            if (!rc)
-                                rc = mcp_execute_function_access_unittest();
-
-                            sqlite_close_databases();
-                            sqlite_library_shutdown();
-                            rrdlabels_aral_destroy(false);
-                            return rc;
-                        }
+                        else if(strcmp(optarg, "dyncfgtest") == 0)
+                            return unittest_run_with_rrd(dyncfg_unittest);
+                        else if(strcmp(optarg, "functionsaccesstest") == 0)
+                            return unittest_run_with_rrd(rrdfunctions_verify_access_unittest);
+                        else if(strcmp(optarg, "mcpfunctionaccesstest") == 0)
+                            return unittest_run_with_rrd(mcp_execute_function_access_unittest);
                         else if(strncmp(optarg, createdataset_string, strlen(createdataset_string)) == 0) {
                             optarg += strlen(createdataset_string);
                             unsigned history_seconds = strtoul(optarg, NULL, 0);

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -226,6 +226,8 @@ int unittest_stream_compressions(void);
 int uuid_unittest(void);
 int progress_unittest(void);
 int dyncfg_unittest(void);
+int rrdfunctions_verify_access_unittest(void);
+int mcp_execute_function_access_unittest(void);
 int eval_unittest(void);
 int duration_unittest(void);
 int statistical_unittest(void);
@@ -484,6 +486,8 @@ int netdata_main(int argc, char **argv) {
                             if (uuid_unittest()) return 1;
                             if (os_socket_egress_interface_unittest()) return 1;
                             if (dyncfg_unittest()) return 1;
+                            if (rrdfunctions_verify_access_unittest()) return 1;
+                            if (mcp_execute_function_access_unittest()) return 1;
                             if (eval_unittest()) return 1;
                             if (duration_unittest()) return 1;
                             if (statistical_unittest()) return 1;
@@ -699,6 +703,36 @@ int netdata_main(int argc, char **argv) {
                             int rc = unittest_prepare_rrd(&user);
                             if (!rc)
                                 rc = dyncfg_unittest();
+
+                            sqlite_close_databases();
+                            sqlite_library_shutdown();
+                            rrdlabels_aral_destroy(false);
+                            return rc;
+                        }
+                        else if(strcmp(optarg, "functionsaccesstest") == 0) {
+                            unittest_running = true;
+                            if(sqlite_library_init())
+                                return 1;
+                            rrdlabels_aral_init(false);
+
+                            int rc = unittest_prepare_rrd(&user);
+                            if (!rc)
+                                rc = rrdfunctions_verify_access_unittest();
+
+                            sqlite_close_databases();
+                            sqlite_library_shutdown();
+                            rrdlabels_aral_destroy(false);
+                            return rc;
+                        }
+                        else if(strcmp(optarg, "mcpfunctionaccesstest") == 0) {
+                            unittest_running = true;
+                            if(sqlite_library_init())
+                                return 1;
+                            rrdlabels_aral_init(false);
+
+                            int rc = unittest_prepare_rrd(&user);
+                            if (!rc)
+                                rc = mcp_execute_function_access_unittest();
 
                             sqlite_close_databases();
                             sqlite_library_shutdown();

--- a/src/database/rrdfunctions-unittest.c
+++ b/src/database/rrdfunctions-unittest.c
@@ -48,6 +48,7 @@ int rrdfunctions_verify_access_unittest(void) {
                      HTTP_ACCESS_NONE, true, rrdfunctions_unittest_noop_cb, NULL);
 
     struct {
+        RRDHOST *host;
         const char *fn;
         HTTP_ACCESS user_access;
         bool allow_restricted;
@@ -56,27 +57,31 @@ int rrdfunctions_verify_access_unittest(void) {
     } cases[] = {
         // GHSA-6628-vxm3-4g8g: anonymous caller denied on the protected function.
         // (~SIGNED_ID -> 412, exactly what /api/v3/function returned in the report.)
-        { "protected-fn", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_PRECOND_FAIL, false },
+        { host, "protected-fn", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_PRECOND_FAIL, false },
 
         // Signed-in but still missing same-space + sensitive-data -> denied (403, has SIGNED_ID).
-        { "protected-fn", HTTP_ACCESS_SIGNED_ID, false, HTTP_RESP_FORBIDDEN, false },
+        { host, "protected-fn", HTTP_ACCESS_SIGNED_ID, false, HTTP_RESP_FORBIDDEN, false },
 
         // Fully authorized caller -> allowed, item acquired.
-        { "protected-fn", HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_SENSITIVE_DATA,
+        { host, "protected-fn", HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_SENSITIVE_DATA,
           false, HTTP_RESP_OK, true },
 
         // Restricted function is blocked from this API even for a fully authorized caller.
-        { "__restricted-fn", HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_SENSITIVE_DATA,
+        { host, "__restricted-fn", HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_SENSITIVE_DATA,
           false, HTTP_RESP_FORBIDDEN, false },
 
         // ... unless the internal caller explicitly allows restricted functions.
-        { "__restricted-fn", HTTP_ACCESS_ANONYMOUS_DATA, true, HTTP_RESP_OK, true },
+        { host, "__restricted-fn", HTTP_ACCESS_ANONYMOUS_DATA, true, HTTP_RESP_OK, true },
 
         // Public function stays reachable anonymously — the gate must not over-block.
-        { "public-fn", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_OK, true },
+        { host, "public-fn", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_OK, true },
 
         // Unknown function -> 404, no item.
-        { "does-not-exist", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_NOT_FOUND, false },
+        { host, "does-not-exist", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_NOT_FOUND, false },
+
+        // No host to route to -> 500, no item, error body populated. Guards the early
+        // !host branch that resets out_acquired before any function lookup.
+        { NULL, "protected-fn", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_INTERNAL_SERVER_ERROR, false },
     };
 
     int errors = 0;
@@ -84,10 +89,10 @@ int rrdfunctions_verify_access_unittest(void) {
         CLEAN_BUFFER *wb = buffer_create(0, NULL);
         const DICTIONARY_ITEM *item = (const DICTIONARY_ITEM *)(uintptr_t)0x1; // poison: verify it is reset
 
-        int code = rrd_function_verify_access(host, wb, cases[i].fn,
+        int code = rrd_function_verify_access(cases[i].host, wb, cases[i].fn,
                                               cases[i].user_access, cases[i].allow_restricted, &item);
 
-        bool ok = false, item_ok = false;
+        bool ok = false, item_ok = false, body_ok = false;
 
         if(code != cases[i].expect_code) {
             fprintf(stderr, "  FAILED case %zu (%s, access 0x%x, allow_restricted=%d): "
@@ -113,10 +118,22 @@ int rrdfunctions_verify_access_unittest(void) {
         else
             item_ok = true;
 
-        if(item)
-            dictionary_acquired_item_release(host->functions, item);
+        // Denial must emit an error body (rrd_call_function_error), not silently return an
+        // empty result_wb. A regression that drops the message would still pass the code and
+        // item checks above but would leave the caller with nothing — the security fix
+        // requires the denial to be explicit. Authorized calls do not touch result_wb here.
+        if(cases[i].expect_code != HTTP_RESP_OK && buffer_strlen(wb) == 0) {
+            fprintf(stderr, "  FAILED case %zu (%s): denial produced an empty error body\n",
+                    i, cases[i].fn);
+            errors++;
+        }
+        else
+            body_ok = true;
 
-        if(ok && item_ok)
+        if(item)
+            dictionary_acquired_item_release(cases[i].host->functions, item);
+
+        if(ok && item_ok && body_ok)
             fprintf(stderr, "  OK case %zu: %s (access 0x%x, allow_restricted=%d) -> %d\n",
                     i, cases[i].fn, (unsigned)cases[i].user_access, cases[i].allow_restricted, code);
     }

--- a/src/database/rrdfunctions-unittest.c
+++ b/src/database/rrdfunctions-unittest.c
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "rrd.h"
+#include "rrdfunctions-internals.h"
+
+// ----------------------------------------------------------------------------
+// Regression test for GHSA-6628-vxm3-4g8g.
+//
+// The MCP execute_function path used to build parameter-validation / "info"
+// help output (log source names, file counts, sizes, coverage windows,
+// timestamps) BEFORE enforcing the caller's access level, while the normal
+// /api/v3/function path denied the same anonymous caller. The fix routes both
+// paths through rrd_function_verify_access(): /api/v3 via rrd_function_run(),
+// and MCP by calling it directly before disclosing any metadata.
+//
+// This test pins the shared gate: for a protected function (like
+// systemd-journal, which requires signed-in + same-space + sensitive-data), an
+// anonymous caller MUST be denied, and the acquire/release contract of
+// out_acquired MUST hold (item set iff authorized, never leaked on denial). If
+// the gate ever regresses, every caller that relies on it — including MCP —
+// regresses with it.
+
+static int rrdfunctions_unittest_noop_cb(struct rrd_function_execute *rfe __maybe_unused, void *data __maybe_unused) {
+    // never reached: verify_access authorizes without executing
+    return HTTP_RESP_OK;
+}
+
+int rrdfunctions_verify_access_unittest(void) {
+    fprintf(stderr, "\n%s() running...\n", __FUNCTION__);
+
+    RRDHOST *host = localhost;
+    if(!host) {
+        fprintf(stderr, "  FAILED: localhost is NULL (rrd_init not prepared)\n");
+        return 1;
+    }
+
+    // A protected function mirroring systemd-journal's requirements.
+    rrd_function_add(host, NULL, "protected-fn", 10, 0, 1, "protected", "logs",
+                     HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_SENSITIVE_DATA,
+                     true, rrdfunctions_unittest_noop_cb, NULL);
+
+    // A restricted function: name starting with "__" flags RRD_FUNCTION_RESTRICTED.
+    rrd_function_add(host, NULL, "__restricted-fn", 10, 0, 1, "restricted", "top",
+                     HTTP_ACCESS_NONE, true, rrdfunctions_unittest_noop_cb, NULL);
+
+    // A public function requiring nothing — baseline that the gate does not over-block.
+    rrd_function_add(host, NULL, "public-fn", 10, 0, 1, "public", "top",
+                     HTTP_ACCESS_NONE, true, rrdfunctions_unittest_noop_cb, NULL);
+
+    struct {
+        const char *fn;
+        HTTP_ACCESS user_access;
+        bool allow_restricted;
+        int expect_code;
+        bool expect_item;
+    } cases[] = {
+        // GHSA-6628-vxm3-4g8g: anonymous caller denied on the protected function.
+        // (~SIGNED_ID -> 412, exactly what /api/v3/function returned in the report.)
+        { "protected-fn", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_PRECOND_FAIL, false },
+
+        // Signed-in but still missing same-space + sensitive-data -> denied (403, has SIGNED_ID).
+        { "protected-fn", HTTP_ACCESS_SIGNED_ID, false, HTTP_RESP_FORBIDDEN, false },
+
+        // Fully authorized caller -> allowed, item acquired.
+        { "protected-fn", HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_SENSITIVE_DATA,
+          false, HTTP_RESP_OK, true },
+
+        // Restricted function is blocked from this API even for a fully authorized caller.
+        { "__restricted-fn", HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_SENSITIVE_DATA,
+          false, HTTP_RESP_FORBIDDEN, false },
+
+        // ... unless the internal caller explicitly allows restricted functions.
+        { "__restricted-fn", HTTP_ACCESS_ANONYMOUS_DATA, true, HTTP_RESP_OK, true },
+
+        // Public function stays reachable anonymously — the gate must not over-block.
+        { "public-fn", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_OK, true },
+
+        // Unknown function -> 404, no item.
+        { "does-not-exist", HTTP_ACCESS_ANONYMOUS_DATA, false, HTTP_RESP_NOT_FOUND, false },
+    };
+
+    int errors = 0;
+    for(size_t i = 0; i < _countof(cases); i++) {
+        CLEAN_BUFFER *wb = buffer_create(0, NULL);
+        const DICTIONARY_ITEM *item = (const DICTIONARY_ITEM *)(uintptr_t)0x1; // poison: verify it is reset
+
+        int code = rrd_function_verify_access(host, wb, cases[i].fn,
+                                              cases[i].user_access, cases[i].allow_restricted, &item);
+
+        bool ok = false, item_ok = false;
+
+        if(code != cases[i].expect_code) {
+            fprintf(stderr, "  FAILED case %zu (%s, access 0x%x, allow_restricted=%d): "
+                            "got code %d, expected %d\n",
+                    i, cases[i].fn, (unsigned)cases[i].user_access, cases[i].allow_restricted,
+                    code, cases[i].expect_code);
+            errors++;
+        }
+        else
+            ok = true;
+
+        // Acquire/release contract: item set iff authorized, never left dangling on denial.
+        if(cases[i].expect_item && !item) {
+            fprintf(stderr, "  FAILED case %zu (%s): expected an acquired item, got NULL\n",
+                    i, cases[i].fn);
+            errors++;
+        }
+        else if(!cases[i].expect_item && item != NULL) {
+            fprintf(stderr, "  FAILED case %zu (%s): item must be NULL on denial, but it is set\n",
+                    i, cases[i].fn);
+            errors++;
+        }
+        else
+            item_ok = true;
+
+        if(item)
+            dictionary_acquired_item_release(host->functions, item);
+
+        if(ok && item_ok)
+            fprintf(stderr, "  OK case %zu: %s (access 0x%x, allow_restricted=%d) -> %d\n",
+                    i, cases[i].fn, (unsigned)cases[i].user_access, cases[i].allow_restricted, code);
+    }
+
+    rrd_function_del(host, NULL, "protected-fn", false, true);
+    rrd_function_del(host, NULL, "__restricted-fn", false, true);
+    rrd_function_del(host, NULL, "public-fn", false, true);
+
+    fprintf(stderr, "%s() %s (%d error%s)\n\n",
+            __FUNCTION__, errors ? "FAILED" : "passed", errors, errors == 1 ? "" : "s");
+
+    return errors;
+}

--- a/src/database/rrdfunctions.h
+++ b/src/database/rrdfunctions.h
@@ -96,6 +96,10 @@ int rrd_function_verify_access(RRDHOST *host, BUFFER *result_wb, const char *cmd
                               HTTP_ACCESS user_access, bool allow_restricted,
                               const DICTIONARY_ITEM **out_acquired);
 
+// Regression test for rrd_function_verify_access() access gating (GHSA-6628-vxm3-4g8g).
+// Requires a prepared RRD (localhost). Returns the number of failures (0 = pass).
+int rrdfunctions_verify_access_unittest(void);
+
 bool rrd_function_available(RRDHOST *host, const char *function);
 bool rrd_function_is_available(struct rrd_host_function *rdcf, RRDHOST *host);
 

--- a/src/web/mcp/mcp-tools-execute-function-unittest.c
+++ b/src/web/mcp/mcp-tools-execute-function-unittest.c
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "mcp-tools-execute-function.h"
+#include "mcp-tools-execute-function-registry.h"
+#include "database/rrdfunctions-inline.h"
+
+// ----------------------------------------------------------------------------
+// Regression test for GHSA-6628-vxm3-4g8g.
+//
+// An anonymous MCP execute_function caller could obtain protected function
+// metadata (systemd-journal __logs_sources option names, file counts, sizes,
+// coverage windows, timestamps) that the normal /api/v3/function path denies.
+// The metadata is produced by mcp_functions_registry_get() -> "<fn> info", run
+// with HTTP_ACCESS_ALL — so before the fix it ignored the caller's real access.
+//
+// The fix authorizes the caller (rrd_function_verify_access) in
+// mcp_tool_execute_function_execute() BEFORE that metadata path runs.
+//
+// This test drives the real MCP handler with an anonymous caller and a
+// protected function whose "info" callback:
+//   (a) increments a call counter — reaching it means the elevated metadata
+//       path executed, which must NOT happen for an unauthorized caller; and
+//   (b) embeds a secret marker in its option metadata — which must never appear
+//       in the response sent to an unauthorized caller.
+// Remove the authorization call from the handler and this test fails: the
+// handler falls through to the info path, the counter increments, and the
+// marker leaks.
+
+#define MCP_UT_FN "unittest-mcp-protected"
+#define MCP_UT_SECRET "UNITTEST_SECRET_SOURCE_METADATA"
+
+static int mcp_ut_info_calls = 0;
+
+// Inline execute callback. Returns a systemd-journal-like "info" schema whose
+// required parameter carries option metadata (the sensitive part). Reaching
+// here means the function actually ran under elevated privileges.
+static int mcp_ut_protected_cb(BUFFER *wb, const char *function __maybe_unused,
+                               BUFFER *payload __maybe_unused, const char *source __maybe_unused) {
+    mcp_ut_info_calls++;
+
+    buffer_flush(wb);
+    wb->content_type = CT_APPLICATION_JSON;
+    buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_MINIFY);
+    buffer_json_member_add_uint64(wb, "v", 3);
+    buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
+    buffer_json_member_add_string(wb, "type", "table");
+    buffer_json_member_add_string(wb, "help", "unittest protected function");
+
+    buffer_json_member_add_array(wb, "required_params");
+    {
+        buffer_json_add_array_item_object(wb); // the __logs_sources selector
+        buffer_json_member_add_string(wb, "id", "__logs_sources");
+        buffer_json_member_add_string(wb, "name", "source");
+        buffer_json_member_add_string(wb, "help", "select a log source");
+        buffer_json_member_add_string(wb, "type", "select");
+
+        buffer_json_member_add_array(wb, "options");
+        {
+            buffer_json_add_array_item_object(wb);
+            buffer_json_member_add_string(wb, "id", "all");
+            buffer_json_member_add_string(wb, "name", "all");
+            // Sensitive metadata that /api/v3/function denies to anonymous callers.
+            buffer_json_member_add_string(wb, "info", MCP_UT_SECRET " 4 files, 48MiB, covering 2d");
+            buffer_json_object_close(wb);
+        }
+        buffer_json_array_close(wb); // options
+
+        buffer_json_object_close(wb);
+    }
+    buffer_json_array_close(wb); // required_params
+
+    buffer_json_finalize(wb);
+    return HTTP_RESP_OK;
+}
+
+static bool mcp_ut_output_contains(MCP_CLIENT *mcpc, const char *needle) {
+    if (mcpc->error && buffer_strlen(mcpc->error) && strstr(buffer_tostring(mcpc->error), needle))
+        return true;
+    for (size_t i = 0; i < mcpc->response_chunks_used; i++) {
+        BUFFER *b = mcpc->response_chunks[i].buffer;
+        if (b && buffer_strlen(b) && strstr(buffer_tostring(b), needle))
+            return true;
+    }
+    return false;
+}
+
+static struct json_object *mcp_ut_params(const char *node, const char *function) {
+    struct json_object *p = json_object_new_object();
+    json_object_object_add(p, "node", json_object_new_string(node));
+    json_object_object_add(p, "function", json_object_new_string(function));
+    return p;
+}
+
+int mcp_execute_function_access_unittest(void) {
+    fprintf(stderr, "\n%s() running...\n", __FUNCTION__);
+
+    RRDHOST *host = localhost;
+    if (!host) {
+        fprintf(stderr, "  FAILED: localhost is NULL (rrd_init not prepared)\n");
+        return 1;
+    }
+
+    mcp_functions_registry_init();
+
+    // The info path executes the function, which registers an inflight request.
+    // Normal startup (and dyncfg_unittest) initialize this global; the standalone
+    // -W mcpfunctionaccesstest path does not, so ensure it here (init is idempotent).
+    rrd_functions_inflight_init();
+
+    // A protected function mirroring systemd-journal's access requirements.
+    rrd_function_add_inline(host, NULL, MCP_UT_FN, 10, 0, 1,
+                            "unittest protected function", "logs",
+                            HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_SENSITIVE_DATA,
+                            mcp_ut_protected_cb);
+
+    const char *node = rrdhost_hostname(host);
+    int errors = 0;
+
+    // ---- CASE 1: anonymous caller MUST be denied before any metadata is generated.
+    // Runs first, while the registry cache is empty: if the authorization gate is
+    // removed, the handler reaches mcp_functions_registry_get() -> "<fn> info",
+    // the callback fires, and the option metadata leaks.
+    {
+        MCP_CLIENT *mcpc = mcp_create_client(MCP_TRANSPORT_HTTP, NULL);
+        USER_AUTH anon;
+        memset(&anon, 0, sizeof(anon));
+        anon.access = HTTP_ACCESS_ANONYMOUS_DATA;
+        mcpc->user_auth = &anon;
+
+        struct json_object *params = mcp_ut_params(node, MCP_UT_FN);
+
+        mcp_ut_info_calls = 0;
+        MCP_RETURN_CODE rc = mcp_tool_execute_function_execute(mcpc, params, 0);
+
+        if (rc == MCP_RC_OK) {
+            fprintf(stderr, "  FAILED: anonymous execute_function returned MCP_RC_OK (expected denial)\n");
+            errors++;
+        }
+        if (mcp_ut_info_calls != 0) {
+            fprintf(stderr, "  FAILED: metadata (info) path executed for anonymous caller "
+                            "(callback fired %d time(s)) — GHSA-6628-vxm3-4g8g regression\n",
+                    mcp_ut_info_calls);
+            errors++;
+        }
+        if (mcp_ut_output_contains(mcpc, MCP_UT_SECRET)) {
+            fprintf(stderr, "  FAILED: protected option metadata leaked to anonymous caller — "
+                            "GHSA-6628-vxm3-4g8g regression\n");
+            errors++;
+        }
+        if (rc != MCP_RC_OK && mcp_ut_info_calls == 0 && !mcp_ut_output_contains(mcpc, MCP_UT_SECRET))
+            fprintf(stderr, "  OK: anonymous caller denied before metadata generation\n");
+
+        json_object_put(params);
+        mcp_free_client(mcpc);
+    }
+
+    // ---- CASE 2 (positive control): an authorized caller reaches the metadata path.
+    // Without this, CASE 1's zero would be meaningless — proves the callback CAN
+    // fire through this handler and the gate does not over-block. The authorized
+    // caller supplies no selections, so the handler stops at the required-params
+    // prompt (no data query), keeping the control robust.
+    {
+        MCP_CLIENT *mcpc = mcp_create_client(MCP_TRANSPORT_HTTP, NULL);
+        USER_AUTH full;
+        memset(&full, 0, sizeof(full));
+        full.access = HTTP_ACCESS_ALL;
+        mcpc->user_auth = &full;
+
+        struct json_object *params = mcp_ut_params(node, MCP_UT_FN);
+
+        mcp_ut_info_calls = 0;
+        (void) mcp_tool_execute_function_execute(mcpc, params, 0);
+
+        if (mcp_ut_info_calls == 0) {
+            fprintf(stderr, "  FAILED: authorized caller never reached the metadata path "
+                            "(gate over-blocks, or the positive control is broken)\n");
+            errors++;
+        }
+        else
+            fprintf(stderr, "  OK: authorized caller reached the metadata path "
+                            "(callback fired %d time(s))\n", mcp_ut_info_calls);
+
+        json_object_put(params);
+        mcp_free_client(mcpc);
+    }
+
+    rrd_function_del(host, NULL, MCP_UT_FN, false, true);
+    mcp_functions_registry_cleanup();
+
+    fprintf(stderr, "%s() %s (%d error%s)\n\n",
+            __FUNCTION__, errors ? "FAILED" : "passed", errors, errors == 1 ? "" : "s");
+    return errors;
+}

--- a/src/web/mcp/mcp-tools-execute-function.h
+++ b/src/web/mcp/mcp-tools-execute-function.h
@@ -11,4 +11,9 @@ void mcp_tool_execute_function_schema(BUFFER *buffer);
 // Execution function - performs the function execution
 MCP_RETURN_CODE mcp_tool_execute_function_execute(MCP_CLIENT *mcpc, struct json_object *params, MCP_REQUEST_ID id);
 
+// Regression test: anonymous execute_function must not disclose protected function
+// metadata (GHSA-6628-vxm3-4g8g). Requires a prepared RRD (localhost). Returns the
+// number of failures (0 = pass).
+int mcp_execute_function_access_unittest(void);
+
 #endif // NETDATA_MCP_TOOLS_EXECUTE_FUNCTION_H


### PR DESCRIPTION
##### Summary
- Add unittests for MCP / Functions access verification tests (unittest)
- Standalone flags (-W mcpfunctionaccesstest, -W functionsaccesstest)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests to verify access control in RRD function verification and MCP `execute_function`, preventing unauthorized function metadata disclosure (GHSA-6628-vxm3-4g8g).

- **New Features**
  - New unittest entrypoints: `rrdfunctions_verify_access_unittest()` and `mcp_execute_function_access_unittest()`; both require a prepared localhost RRD and return failure count.
  - CLI flags: `-W functionsaccesstest` and `-W mcpfunctionaccesstest` to run them standalone.

- **Refactors**
  - Introduced `unittest_run_with_rrd()` to centralize SQLite/RRD setup/teardown; used by `dyncfgtest`, `functionsaccesstest`, and `mcpfunctionaccesstest`.
  - Included both tests in the default `-W unittests` run.
  - Log sanitized names for reserved dynamic-configuration function registration attempts.

<sup>Written for commit e77f58d8668136915cc4cd3b8c0f571adf3b82f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

