### PR TITLE
Netdata fixes part 87

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3154,6 +3154,10 @@ add_executable(stream-receiver-hops-test EXCLUDE_FROM_ALL
         src/streaming/tests/stream-handshake-hops-test.c)
 target_link_libraries(stream-receiver-hops-test libnetdata)
 
+add_executable(stream-replay-endpoints-test EXCLUDE_FROM_ALL
+        src/streaming/tests/stream-replay-endpoints-test.c)
+target_link_libraries(stream-replay-endpoints-test libnetdata)
+
 if(OS_LINUX)
         add_executable(http-auth-bearer-test EXCLUDE_FROM_ALL
                 src/web/api/tests/http-auth-bearer-test.c)

--- a/src/streaming/stream-replication-receiver.c
+++ b/src/streaming/stream-replication-receiver.c
@@ -185,7 +185,8 @@ bool replicate_chart_request(send_command callback, struct parser *parser, RRDHO
             r.gap.from = r.local_db.last_entry_t;
         else
             // we don't have any data, the gap is the max timeframe we are allowed to replicate
-            r.gap.from = r.local_db.wall_clock_time - r.host->stream.replication.period;
+            r.gap.from = r.local_db.wall_clock_time > r.host->stream.replication.period ?
+                             r.local_db.wall_clock_time - r.host->stream.replication.period : 0;
 
     }
     else {

--- a/src/streaming/stream-sender-execute.c
+++ b/src/streaming/stream-sender-execute.c
@@ -344,6 +344,10 @@ bool stream_sender_execute_commands(struct sender_state *s) {
                                   before ? before : "(unset)");
             }
             else {
+                time_t parsed_after;
+                time_t parsed_before;
+                (void)stream_sender_parse_replay_endpoints(after, before, &parsed_after, &parsed_before);
+
 #ifdef REPLICATION_TRACKING
                 RRDSET *st = rrdset_find(s->host, chart_id, true);
                 if(st)
@@ -352,8 +356,8 @@ bool stream_sender_execute_commands(struct sender_state *s) {
 
                 replication_sender_request_add(
                     s, chart_id,
-                    strtoll(after, NULL, 0),
-                    strtoll(before, NULL, 0),
+                    parsed_after,
+                    parsed_before,
                     stream_parse_enable_streaming(start_streaming));
             }
         }

--- a/src/streaming/stream-sender-internals.h
+++ b/src/streaming/stream-sender-internals.h
@@ -10,6 +10,46 @@
 #include "stream-parents.h"
 #include "stream-circular-buffer.h"
 
+static inline bool stream_sender_parse_replay_endpoint(const char *value, time_t *endpoint) {
+    if(!value || !endpoint || value[0] < '0' || value[0] > '9')
+        return false;
+
+    char *endptr;
+    int saved_errno = errno;
+    errno = 0;
+    uintmax_t parsed = strtoumax(value, &endptr, 10);
+    int conversion_errno = errno;
+    errno = saved_errno;
+
+    uintmax_t maximum = (uintmax_t)nd_time_t_max();
+    if(maximum > (uintmax_t)ULONG_MAX)
+        maximum = (uintmax_t)ULONG_MAX;
+    if(maximum > (uintmax_t)SIZE_MAX)
+        maximum = (uintmax_t)SIZE_MAX;
+
+    if(conversion_errno != 0 || *endptr != '\0' || parsed > maximum)
+        return false;
+
+    *endpoint = (time_t)parsed;
+    return true;
+}
+
+static inline bool stream_sender_parse_replay_endpoints(
+    const char *after, const char *before, time_t *parsed_after, time_t *parsed_before)
+{
+    if(!parsed_after || !parsed_before)
+        return false;
+
+    time_t validated_after;
+    time_t validated_before;
+    bool valid = stream_sender_parse_replay_endpoint(after, &validated_after) &&
+                 stream_sender_parse_replay_endpoint(before, &validated_before);
+
+    *parsed_after = valid ? validated_after : 0;
+    *parsed_before = valid ? validated_before : 0;
+    return valid;
+}
+
 // connector thread
 #define WORKER_SENDER_CONNECTOR_JOB_CONNECTING                          0
 #define WORKER_SENDER_CONNECTOR_JOB_CONNECTED                           1

--- a/src/streaming/tests/stream-replay-endpoints-test.c
+++ b/src/streaming/tests/stream-replay-endpoints-test.c
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "libnetdata/libnetdata.h"
+#include "streaming/stream-sender-internals.h"
+
+typedef struct {
+    const char *value;
+    bool valid;
+    time_t expected;
+} REPLAY_ENDPOINT_TEST;
+
+static bool check_endpoint(const REPLAY_ENDPOINT_TEST *test) {
+    time_t endpoint = 12345;
+    bool valid = stream_sender_parse_replay_endpoint(test->value, &endpoint);
+
+    if(valid != test->valid) {
+        fprintf(stderr, "replay endpoint '%s' was %s, expected %s\n",
+                test->value ? test->value : "(null)",
+                valid ? "accepted" : "rejected",
+                test->valid ? "accepted" : "rejected");
+        return false;
+    }
+
+    if(valid && endpoint != test->expected) {
+        fprintf(stderr, "replay endpoint '%s' parsed as %" PRIdMAX ", expected %" PRIdMAX "\n",
+                test->value, (intmax_t)endpoint, (intmax_t)test->expected);
+        return false;
+    }
+
+    if(!valid && endpoint != 12345) {
+        fprintf(stderr, "rejected replay endpoint '%s' changed the output to %" PRIdMAX "\n",
+                test->value ? test->value : "(null)", (intmax_t)endpoint);
+        return false;
+    }
+
+    return true;
+}
+
+int main(void) {
+    uintmax_t maximum = (uintmax_t)nd_time_t_max();
+    if(maximum > (uintmax_t)ULONG_MAX)
+        maximum = (uintmax_t)ULONG_MAX;
+    if(maximum > (uintmax_t)SIZE_MAX)
+        maximum = (uintmax_t)SIZE_MAX;
+
+    char maximum_string[64];
+    char above_maximum_string[64];
+    snprintf(maximum_string, sizeof(maximum_string), "%" PRIuMAX, maximum);
+    snprintf(above_maximum_string, sizeof(above_maximum_string), "%" PRIuMAX, maximum + 1);
+
+    const REPLAY_ENDPOINT_TEST tests[] = {
+        { .value = "0", .valid = true, .expected = 0 },
+        { .value = "1", .valid = true, .expected = 1 },
+        { .value = "010", .valid = true, .expected = 10 },
+        { .value = maximum_string, .valid = true, .expected = (time_t)maximum },
+
+        { .value = NULL, .valid = false },
+        { .value = "", .valid = false },
+        { .value = " ", .valid = false },
+        { .value = " 1", .valid = false },
+        { .value = "1 ", .valid = false },
+        { .value = "+1", .valid = false },
+        { .value = "-1", .valid = false },
+        { .value = "0x10", .valid = false },
+        { .value = "12x", .valid = false },
+        { .value = above_maximum_string, .valid = false },
+        { .value = "18446744073709551616", .valid = false },
+    };
+
+    for(size_t i = 0; i < _countof(tests); i++) {
+        if(!check_endpoint(&tests[i]))
+            return 1;
+    }
+
+    if(stream_sender_parse_replay_endpoint("1", NULL)) {
+        fprintf(stderr, "accepted a null replay endpoint output pointer\n");
+        return 1;
+    }
+
+    errno = EDOM;
+    time_t errno_endpoint;
+    if(!stream_sender_parse_replay_endpoint("1", &errno_endpoint) || errno != EDOM) {
+        fprintf(stderr, "valid replay endpoint parsing changed errno\n");
+        return 1;
+    }
+
+    errno = E2BIG;
+    if(stream_sender_parse_replay_endpoint("18446744073709551616", &errno_endpoint) || errno != E2BIG) {
+        fprintf(stderr, "invalid replay endpoint parsing changed errno\n");
+        return 1;
+    }
+
+    time_t after = 12345;
+    time_t before = 12345;
+    if(!stream_sender_parse_replay_endpoints("10", "20", &after, &before) || after != 10 || before != 20) {
+        fprintf(stderr, "failed to preserve a valid replay endpoint pair\n");
+        return 1;
+    }
+
+    if(stream_sender_parse_replay_endpoints("invalid", "20", &after, &before) || after != 0 || before != 0) {
+        fprintf(stderr, "failed to normalize an invalid replay endpoint pair\n");
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/web/api/netdata-swagger.json
+++ b/src/web/api/netdata-swagger.json
@@ -1465,7 +1465,11 @@
               "type": "string",
               "enum": [
                 "yes",
-                "no"
+                "no",
+                "1",
+                "0",
+                "true",
+                "false"
               ],
               "default": "no"
             }
@@ -1479,7 +1483,11 @@
               "type": "string",
               "enum": [
                 "yes",
-                "no"
+                "no",
+                "1",
+                "0",
+                "true",
+                "false"
               ],
               "default": "yes"
             }
@@ -1493,7 +1501,11 @@
               "type": "string",
               "enum": [
                 "yes",
-                "no"
+                "no",
+                "1",
+                "0",
+                "true",
+                "false"
               ],
               "default": "yes"
             }
@@ -1507,7 +1519,11 @@
               "type": "string",
               "enum": [
                 "yes",
-                "no"
+                "no",
+                "1",
+                "0",
+                "true",
+                "false"
               ],
               "default": "yes"
             }
@@ -1521,7 +1537,11 @@
               "type": "string",
               "enum": [
                 "yes",
-                "no"
+                "no",
+                "1",
+                "0",
+                "true",
+                "false"
               ],
               "default": "yes"
             }

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -1150,9 +1150,13 @@ paths:
           schema:
             type: string
             enum:
-              - yes
-              - no
-            default: no
+              - "yes"
+              - "no"
+              - "1"
+              - "0"
+              - "true"
+              - "false"
+            default: "no"
         - name: timestamps
           in: query
           description: |
@@ -1161,9 +1165,13 @@ paths:
           schema:
             type: string
             enum:
-              - yes
-              - no
-            default: yes
+              - "yes"
+              - "no"
+              - "1"
+              - "0"
+              - "true"
+              - "false"
+            default: "yes"
         - name: names
           in: query
           description: |
@@ -1172,9 +1180,13 @@ paths:
           schema:
             type: string
             enum:
-              - yes
-              - no
-            default: yes
+              - "yes"
+              - "no"
+              - "1"
+              - "0"
+              - "true"
+              - "false"
+            default: "yes"
         - name: oldunits
           in: query
           description: |
@@ -1183,9 +1195,13 @@ paths:
           schema:
             type: string
             enum:
-              - yes
-              - no
-            default: yes
+              - "yes"
+              - "no"
+              - "1"
+              - "0"
+              - "true"
+              - "false"
+            default: "yes"
         - name: hideunits
           in: query
           description: |
@@ -1194,9 +1210,13 @@ paths:
           schema:
             type: string
             enum:
-              - yes
-              - no
-            default: yes
+              - "yes"
+              - "no"
+              - "1"
+              - "0"
+              - "true"
+              - "false"
+            default: "yes"
         - name: server
           in: query
           description: |


### PR DESCRIPTION
##### Summary
- Netdata fixes based on #22881 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened streaming replay endpoint parsing and clamped the initial replication gap to zero to prevent invalid timestamps and negative ranges. Also aligned v1 allmetrics OpenAPI enums with accepted boolean aliases.

- **Bug Fixes**
  - Validate replay `after`/`before` as strict base-10, non-negative, bounded values via new helpers; normalize invalid pairs to 0,0, preserve errno, and use parsed values in the sender; added `stream-replay-endpoints-test` (EXCLUDE_FROM_ALL).
  - Clamp the producer’s initial gap at 0 when the replication period exceeds the current wall clock to avoid negative `time_t`.
  - Expand v1 allmetrics enums in `netdata-swagger.yaml` and `netdata-swagger.json` to include "yes", "no", "1", "0", "true", "false".

<sup>Written for commit 0ca6d5519e44f7d9d2ef025573d61716a1b5b950. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

