### PR TITLE
Correctly handle EPEL on RHEL 7.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1630,8 +1630,13 @@ check_special_native_deps() {
     fi
 
     if [ "${DISTRO}" = "rhel" ]; then
+      if [ "${SYSVERSION}" -eq 7 ]; then
+        epel_url="https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
+      else
+        epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-${SYSVERSION}.noarch.rpm"
+      fi
       # shellcheck disable=SC2086
-      if ! run_as_root env ${env} ${pm_cmd} ${install_subcmd} ${pkg_install_opts} "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${SYSVERSION}.noarch.rpm"; then
+      if ! run_as_root env ${env} ${pm_cmd} ${install_subcmd} ${pkg_install_opts} "${epel_url}"; then
         warning "Failed to install EPEL, even though it is required to install native packages on this system."
         return 1
       fi


### PR DESCRIPTION
##### Summary

Fedora has moved the EPEL package for RHEL 7 to their repo archives, so pull from there instead of from the usual dl.fedoraproject.org URL for RHEL 7.

##### Test Plan

Confirm that running the kickstart script to install on a clean install of RHEL 7 works correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix EPEL install on RHEL 7 in the kickstart script by using the Fedora Archives URL for `epel-release-7-14.noarch.rpm`. Other RHEL versions still use `epel-release-latest-${SYSVERSION}.noarch.rpm` from dl.fedoraproject.org.

<sup>Written for commit 300fd99f0d1ee3506aa2cef071d7db9efd4e40bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

