### PR TITLE
fix(jobmgr): harden stopping rejection classification

### DIFF
--- a/src/go/plugin/agent/jobmgr/functions/process_ingress.go
+++ b/src/go/plugin/agent/jobmgr/functions/process_ingress.go
@@ -335,10 +335,8 @@ func (pi *ProcessIngress) dispositionDeliveryError(port processInputPort, err er
 	if err == nil {
 		return err
 	}
-	expectedStopping := err == jobmgr.ErrStopped
-	if stopping, ok := err.(*lifecycle.StoppingRejection); ok {
-		expectedStopping = stopping.Generation == port.Generation()
-	}
+	expectedStopping := err == jobmgr.ErrStopped ||
+		lifecycle.ContainsOnlyCurrentStoppingRejections(err, port.Generation())
 	if !expectedStopping {
 		return err
 	}

--- a/src/go/plugin/agent/jobmgr/functions/process_ingress_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/process_ingress_test.go
@@ -5,6 +5,7 @@ package functions
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -196,7 +197,7 @@ func TestProcessIngressDiscardsPartialBodyOnFence(t *testing.T) {
 	require.NoError(t, <-done)
 }
 
-func TestProcessIngressSealedPauseClassifiesExactStoppingDelivery(t *testing.T) {
+func TestProcessIngressSealedPauseClassifiesStoppingDelivery(t *testing.T) {
 	structuralErr := errors.New("structural delivery failure")
 	tests := map[string]struct {
 		deliveryErr    error
@@ -206,6 +207,23 @@ func TestProcessIngressSealedPauseClassifiesExactStoppingDelivery(t *testing.T) 
 			deliveryErr: &lifecycle.StoppingRejection{
 				Generation: 1,
 			},
+			wantSuppressed: true,
+		},
+		"wrapped current generation stopping rejection": {
+			deliveryErr: fmt.Errorf("wrapped: %w", &lifecycle.StoppingRejection{
+				Generation: 1,
+			}),
+			wantSuppressed: true,
+		},
+		"joined current generation stopping rejections": {
+			deliveryErr: errors.Join(
+				&lifecycle.StoppingRejection{
+					Generation: 1,
+				},
+				&lifecycle.StoppingRejection{
+					Generation: 1,
+				},
+			),
 			wantSuppressed: true,
 		},
 		"legacy exact stopped rejection": {

--- a/src/go/plugin/agent/jobmgr/joboutput/autodetection_retry.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/autodetection_retry.go
@@ -285,8 +285,7 @@ func (adri *autoDetectionRetryIndex) runWorker() {
 				break
 			}
 			if err := adri.dispatch(retry); err != nil {
-				stopping, clean := err.(*lifecycle.StoppingRejection)
-				if clean && stopping.Generation == adri.run {
+				if lifecycle.ContainsOnlyCurrentStoppingRejections(err, adri.run) {
 					return
 				}
 				adri.fail(err)

--- a/src/go/plugin/agent/jobmgr/joboutput/autodetection_retry_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/autodetection_retry_test.go
@@ -314,6 +314,21 @@ func TestAutoDetectionRetryClassifiesStoppingSubmission(t *testing.T) {
 		"exact current stopping token is clean": {submitErr: &lifecycle.StoppingRejection{
 			Generation: 1,
 		}},
+		"wrapped current stopping token is clean": {
+			submitErr: fmt.Errorf("wrapped: %w", &lifecycle.StoppingRejection{
+				Generation: 1,
+			}),
+		},
+		"joined current stopping tokens are clean": {
+			submitErr: errors.Join(
+				&lifecycle.StoppingRejection{
+					Generation: 1,
+				},
+				&lifecycle.StoppingRejection{
+					Generation: 1,
+				},
+			),
+		},
 		"wrong generation is structural": {
 			submitErr: &lifecycle.StoppingRejection{
 				Generation: 2,

--- a/src/go/plugin/agent/jobmgr/lifecycle/run.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/run.go
@@ -20,6 +20,18 @@ func (sr *StoppingRejection) Error() string {
 	return fmt.Sprintf("jobmgr run %d is stopping", sr.Generation)
 }
 
+// ContainsOnlyCurrentStoppingRejections reports whether every leaf in err is a
+// stopping rejection for generation. Mixed or malformed error trees fail closed.
+func ContainsOnlyCurrentStoppingRejections(err error, generation uint64) bool {
+	if generation == 0 {
+		return false
+	}
+	return allErrorLeavesMatch(err, func(leaf error) bool {
+		stopping, ok := leaf.(*StoppingRejection)
+		return ok && stopping.Generation == generation
+	})
+}
+
 type RunSupervisor struct {
 	mu         sync.Mutex         // guards all fields
 	generation uint64             // this run's generation number

--- a/src/go/plugin/agent/jobmgr/lifecycle/task_inherited.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/task_inherited.go
@@ -436,7 +436,7 @@ func (ts *TaskSupervisor) completeInherited(ref InheritedTaskRef, taskErr error)
 	}
 	cleanStop := false
 	normalized := taskErr
-	if ts.run != nil && ts.run.IsStopping() && onlyCurrentStoppingRejections(taskErr, ts.run.Generation()) {
+	if ts.run != nil && ts.run.IsStopping() && ContainsOnlyCurrentStoppingRejections(taskErr, ts.run.Generation()) {
 		cleanStop = true
 		normalized = nil
 	}
@@ -473,16 +473,6 @@ func (itr *inheritedTaskRegistry) complete(ref InheritedTaskRef, taskErr error, 
 	slot.finished = true
 	close(slot.done)
 	return spontaneousFailure, taskErr
-}
-
-func onlyCurrentStoppingRejections(err error, generation uint64) bool {
-	if generation == 0 {
-		return false
-	}
-	return allErrorLeavesMatch(err, func(leaf error) bool {
-		stopping, ok := leaf.(*StoppingRejection)
-		return ok && stopping.Generation == generation
-	})
 }
 
 func runInheritedTask(ctx context.Context, work InheritedTaskWork) (err error) {

--- a/src/go/plugin/agent/jobmgr/lifecycle/task_inherited_test.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/task_inherited_test.go
@@ -13,6 +13,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type malformedErrorTree struct {
+	children []error
+}
+
+func (met malformedErrorTree) Error() string {
+	return "malformed error tree"
+}
+
+func (met malformedErrorTree) Unwrap() []error {
+	return met.children
+}
+
+type malformedErrorWrapper struct {
+	child error
+}
+
+func (mew *malformedErrorWrapper) Error() string {
+	return "malformed error wrapper"
+}
+
+func (mew *malformedErrorWrapper) Unwrap() error {
+	return mew.child
+}
+
 func TestInheritedTaskRunCancelJoinRelease(t *testing.T) {
 	supervisor := newResourceTaskSupervisor(t)
 	owner := ResourceIdentity{
@@ -220,10 +244,21 @@ func TestStoppingErrorTreeMatchingIsStrictAndBounded(t *testing.T) {
 		"mixed real error":     {err: errors.Join(current, errors.New("cleanup failed"))},
 		"generic cancellation": {err: context.Canceled},
 		"tree over bound":      {err: deep},
+		"typed nil stopping rejection": {
+			err: (*StoppingRejection)(nil),
+		},
+		"typed nil wrapper": {
+			err: (*malformedErrorWrapper)(nil),
+		},
+		"nil joined child": {
+			err: malformedErrorTree{
+				children: []error{current, nil},
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.want, onlyCurrentStoppingRejections(test.err, current.Generation))
+			require.Equal(t, test.want, ContainsOnlyCurrentStoppingRejections(test.err, current.Generation))
 		})
 	}
 }

--- a/src/go/plugin/agent/jobmgr/lifecycle/types.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/types.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -101,6 +102,16 @@ func canonicalCancellationCause(cause error) (canonical error, deadline, ok bool
 
 const strictErrorTreeLimit = 32
 
+func isNilErrorValue(err error) bool {
+	value := reflect.ValueOf(err)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
 func allErrorLeavesMatch(err error, match func(error) bool) bool {
 	if err == nil || match == nil {
 		return false
@@ -116,28 +127,24 @@ func allErrorLeavesMatch(err error, match func(error) bool) bool {
 		}
 		count--
 		current := pending[count]
-		if current == nil {
-			continue
+		if current == nil || isNilErrorValue(current) {
+			return false
 		}
-		if joined, ok := current.(interface {
-			Unwrap() []error
-		}); ok {
+		if joined, ok := current.(interface{ Unwrap() []error }); ok {
 			children := joined.Unwrap()
 			if len(children) == 0 || count+len(children) > strictErrorTreeLimit {
 				return false
 			}
 			for _, child := range children {
 				if child == nil {
-					continue
+					return false
 				}
 				pending[count] = child
 				count++
 			}
 			continue
 		}
-		if wrapped, ok := current.(interface {
-			Unwrap() error
-		}); ok {
+		if wrapped, ok := current.(interface{ Unwrap() error }); ok {
 			child := wrapped.Unwrap()
 			if child == nil || count == strictErrorTreeLimit {
 				return false


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens stopping error classification so we only suppress delivery/submission errors for the current run, even when errors are wrapped or joined. Prevents misclassifying malformed error trees and leaking stopping errors as structural failures.

- **Bug Fixes**
  - Added `lifecycle.ContainsOnlyCurrentStoppingRejections` to validate error trees and match only current-generation `StoppingRejection` leaves; fails closed on nil leaves, typed-nil wrappers, empty joins, or over-depth trees.
  - Replaced ad-hoc checks in `process_ingress` and `joboutput/autodetection_retry` to use the new helper and treat these as clean stops; preserved legacy `jobmgr.ErrStopped` handling.
  - Tightened `allErrorLeavesMatch` to detect typed-nil errors and reject malformed trees.
  - Expanded tests to cover wrapped/joined stopping errors and malformed trees across ingress, autodetection retry, and inherited task flows.

<sup>Written for commit a131203d8e7a4d080c7dd511566682457bcb2f1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

