### PR TITLE
Improve Network Flow collector accounting charts

### DIFF
--- a/docs/npm/network-flows/field-reference.md
+++ b/docs/npm/network-flows/field-reference.md
@@ -76,6 +76,8 @@ For recognized NSEL templates:
 
 This event policy means the number of NSEL exporter records is intentionally different from the number of stored traffic rows. It also means a lost UDP update remains a visible gap: Netdata does not use a later teardown total to fabricate traffic at the wrong time.
 
+The operational charts make this difference explicit: `netflow.nsel_events` counts event records, `netflow.nsel_rows` counts emitted forward/reverse rows, and `netflow.nsel_exceptions` explains missing or suppressed directions.
+
 ## Identity — who and what
 
 | Field | Type | v5 | v7 | v9 | IPFIX | sFlow | Description |

--- a/docs/npm/network-flows/quick-start.md
+++ b/docs/npm/network-flows/quick-start.md
@@ -166,7 +166,7 @@ If the Sankey is empty after 60-90 seconds, work through this:
 
 3. **Plugin actually decoding.**
 
-   Open the standard Netdata charts page and find `netflow.input_packets`. If `udp_received` is rising but `parsed_packets` isn't, datagrams are arriving but failing to decode. Check `parse_errors` and `template_errors` to narrow down. See [Plugin Health Charts](/docs/npm/network-flows/visualization/dashboard-cards.md).
+   Open the standard Netdata charts page. `netflow.input_packets` confirms UDP arrival; `netflow.protocol_packets` shows whether the packets are v5, v7, v9, IPFIX, or sFlow. If UDP rises but no protocol does, check `parse_errors` in `netflow.decoder_exceptions`. For v9/IPFIX, check missing-template dimensions in `netflow.flow_sets`. See [Plugin Health Charts](/docs/npm/network-flows/visualization/dashboard-cards.md).
 
 4. **Plugin log lines.**
 

--- a/docs/npm/network-flows/troubleshooting.md
+++ b/docs/npm/network-flows/troubleshooting.md
@@ -67,15 +67,16 @@ If nothing matches, the plugin isn't listening. See "doesn't start" above.
 
 **Third check:** what do the plugin's own counters say?
 
-Open `netflow.input_packets` on the standard Netdata charts page. The dimensions tell the story:
+Open the plugin health charts on the standard Netdata charts page:
 
-- `udp_received > 0`, `parsed_packets == 0` — datagrams arriving, none decoding successfully. Wrong protocol on the listener, or all datagrams malformed.
-- `udp_received > 0`, `parsed_packets > 0`, but no per-protocol counter (`netflow_v9`, `ipfix`, etc.) is moving — the protocol you're sending may be disabled in the plugin config. Check `protocols.v9`, `protocols.ipfix`, etc. in `netflow.yaml`.
-- `parse_errors` rising in lockstep with `udp_received` — datagrams aren't valid for the protocols the plugin supports. Capture a small UDP sample with `tcpdump -w` and inspect it with Wireshark.
+- `netflow.input_packets` `udp_received` rising — datagrams are reaching the listener.
+- `netflow.protocol_packets` not rising — none of those datagrams decode as v5, v7, v9, IPFIX, or sFlow. Check `parse_errors` in `netflow.decoder_exceptions`, then capture a small UDP sample with `tcpdump -w`.
+- A protocol dimension rising together with `disabled_protocol_packets` — valid traffic is arriving, but that protocol is disabled in `netflow.yaml`.
+- `netflow.flow_records` rising but `netflow.flow_rows` `journaled` not rising — follow the row chart and decoder exceptions to find filtering, intentional suppression, or journal failure.
 
 ### sFlow packets arrive, but no sFlow rows appear
 
-sFlow datagrams can carry flow samples, counter samples, or both. Netdata's Network Flows view creates flow rows from sFlow flow samples only. Counter-only sFlow traffic is valid sFlow traffic, and `netflow.input_packets` can show `sflow` increasing, but there are no source/destination flow rows to display.
+sFlow datagrams can carry flow samples, counter samples, or both. Netdata's Network Flows view creates flow rows from sFlow flow samples only. Counter-only sFlow traffic is valid: `netflow.protocol_packets` shows `sflow` increasing and `netflow.sflow_samples` shows `counter` samples, but there are no source/destination flow rows to display.
 
 Capture a small sample and check the sFlow sample types:
 
@@ -96,12 +97,7 @@ Counters show received traffic but you suspect data loss.
 
 **Template errors (NetFlow v9, IPFIX):**
 
-```bash
-# Watch the template_errors dimension
-# In the dashboard: netflow.input_packets > template_errors
-```
-
-If it's climbing, the exporter is sending data records before their templates. Either:
+Watch `v9_missing_template` and `ipfix_missing_template` in `netflow.flow_sets`. If either is climbing, the exporter is sending Data Sets before their templates are available. Either:
 
 - The exporter restarted and the plugin's template cache is stale. Wait for the exporter to send the next template (the cadence depends on the exporter's `template-refresh` configuration — vendor defaults vary widely), or restart the exporter to force an immediate template refresh.
 - Templates are sent rarely. Cisco IOS / IOS-XE Flexible NetFlow ships a default `template data timeout` of **600 seconds (10 minutes)**; Juniper and others have their own defaults, often longer. After a plugin restart, you'll see template errors until the next template re-send. **Fix on the router side**: lower the template refresh interval to 60 seconds (the [Quick Start](/docs/npm/network-flows/quick-start.md) configurations show this).
@@ -118,13 +114,13 @@ NSEL exporter records and stored traffic rows are intentionally not one-to-one:
 - One update can create two rows: initiator traffic in the reported direction and nonzero responder traffic with endpoints swapped.
 - An all-zero initiator direction remains visible. An all-zero responder direction is suppressed and diagnosed. A direction with only bytes or only packets is stored with zero for the missing member and diagnosed as partial.
 
-The Network Flows function response exposes cumulative `decoded_nsel_*` statistics for received event types, malformed/counterless/partial records, suppressed zero responders, and emitted forward/reverse rows. These statistics are not yet dimensions of `netflow.input_packets`; the health-chart layout is tracked separately.
+Use `netflow.nsel_events` for received event types, `netflow.nsel_rows` for emitted directions, and `netflow.nsel_exceptions` for malformed counter outcomes and suppressed zero responders.
 
-If `template_errors` rises, check the v9 template refresh cadence. On first startup, Netdata cannot decode data received before the first template. Learned templates are persisted for later restarts, but v9 streams are separated by exporter IP, UDP source port, and Source ID; a new source port needs its own template.
+If `v9_missing_template` rises in `netflow.flow_sets`, check the v9 template refresh cadence. On first startup, Netdata cannot decode data received before the first template. Learned templates are persisted for later restarts, but v9 streams are separated by exporter IP, UDP source port, and Source ID; a new source port needs its own template.
 
 **UDP kernel drops:**
 
-The plugin doesn't count these. Check at the OS level:
+On Linux, watch `kernel_dropped` in `netflow.input_packets`. It is the sum of the kernel drop counters for the plugin's exact listener sockets. You can verify it at the OS level:
 
 ```bash
 sudo ss -uamn sport = :2055        # inspect the d<N> field inside skmem:(...)
@@ -271,7 +267,7 @@ sudo tcpdump -w /tmp/flow-sample.cap -c 200 'udp port 2055 or udp port 6343'
 Collect this before opening a bug report:
 
 - Plugin version (`netdata -V` from the running daemon).
-- A sample of `netflow.input_packets` chart for the failure window — all dimensions visible.
+- Samples of `netflow.input_packets`, `netflow.protocol_packets`, `netflow.decoder_exceptions`, and `netflow.flow_rows` for the failure window. For v9/IPFIX include `netflow.flow_sets`; for sFlow or NSEL include their protocol-specific charts.
 - A sample of `netflow.facet_values`, `netflow.tier_index_entries`, and `netflow.open_tiers` if performance-related. Include `netflow.memory_resident_bytes` only if memory diagnostics were enabled.
 - A small packet-capture file (`tcpdump -w` from the agent's interface) reproducing the issue.
 - Sanitised `netflow.yaml` (redact internal IPs, customer names, secrets).

--- a/docs/npm/network-flows/validation.md
+++ b/docs/npm/network-flows/validation.md
@@ -44,7 +44,7 @@ The SNMP-derived bandwidth: from your SNMP monitoring (Netdata's `snmp.d`, your 
 
 **Not acceptable: more than 30% gap.** That indicates one of:
 
-- UDP drops at the kernel. Check the alert mentioned above, or run `sudo ss -uamn sport = :2055` / `sudo ss -uamn sport = :6343` and inspect the `d<N>` value inside the `skmem:(...)` line (the `sock_drop` counter increments on every dropped datagram). The `-n` flag keeps the port numeric in the output.
+- UDP drops at the kernel. On Linux, check `kernel_dropped` in `netflow.input_packets`, or run `sudo ss -uamn sport = :2055` / `sudo ss -uamn sport = :6343` and inspect the `d<N>` value inside the `skmem:(...)` line (the `sock_drop` counter increments on every dropped datagram). The `-n` flag keeps the port numeric in the output.
 - Sampling rate not honoured (the exporter is sampling but not communicating the rate). See "Sampling rate verification" below.
 - Wrong interfaces being exported.
 
@@ -105,8 +105,11 @@ These are charts the plugin already exposes. Tune the alert thresholds to your e
 | Signal | Where | Suggested alert |
 |---|---|---|
 | `udp_received` rate dropped | `netflow.input_packets` | Sustained 0 during business hours indicates the listener is up but no exporter is sending. |
-| `parse_errors` rising | `netflow.input_packets` | Sustained > 5% of `udp_received` indicates the wire is producing malformed datagrams. |
-| `template_errors` rising | `netflow.input_packets` | Sustained > 1% of `udp_received` after the warm-up period indicates an exporter sends data records before templates. |
+| `kernel_dropped` rising | `netflow.input_packets` | Any sustained Linux listener-buffer loss means traffic never reached the decoder. |
+| `parse_errors` rising | `netflow.decoder_exceptions` | Compare with `udp_received`; sustained errors indicate malformed or unsupported datagrams. |
+| Missing-template Sets rising | `netflow.flow_sets` | Sustained `v9_missing_template` or `ipfix_missing_template` after warm-up means Data Sets arrive without an available template. |
+| Recognized packets intentionally ignored | `netflow.decoder_exceptions` | `disabled_protocol_packets` means valid traffic is excluded by protocol configuration. |
+| Decoded rows not reaching storage | `netflow.flow_rows` | `decoded` must equal `classifier_filtered + journaled + write_failed`; alert on any `write_failed`. |
 | Memory/state growing | `netflow.facet_values`, `netflow.tier_index_entries`, `netflow.open_tiers`; optional `netflow.memory_accounted_bytes` | Default count charts show state-cardinality growth. If byte diagnostics are enabled and `unaccounted` climbs linearly without ingest growth, suspect unattributed allocation. |
 | `decoder_scopes` unbounded growth | `netflow.decoder_scopes` | An exporter is rotating template IDs; investigate per-router behaviour. |
 | Disk write errors | `netflow.raw_journal_ops` `write_errors` | Any non-zero indicates filesystem trouble. |

--- a/docs/npm/network-flows/visualization/dashboard-cards.md
+++ b/docs/npm/network-flows/visualization/dashboard-cards.md
@@ -21,14 +21,29 @@ diagnostics charts update on `charts.memory_diagnostics.interval` when enabled.
 
 | Chart | Type | What it shows |
 |---|---|---|
-| `netflow.input_packets` | line, packets/s | Datagrams: received, parsed, errored, per-protocol counts |
+| `netflow.input_packets` | line, packets/s | UDP datagrams received, empty datagrams, and Linux socket-buffer drops |
 | `netflow.input_bytes` | line, bytes/s | UDP byte rate |
+| `netflow.protocol_packets` | stacked, packets/s | Successfully identified v5, v7, v9, IPFIX, and sFlow packets |
+| `netflow.flow_sets` | stacked, sets/s | NetFlow v9 and IPFIX Data, Options Data, Template, missing-template, and ignored Sets |
+| `netflow.templates` | stacked, templates/s | Data and Options Template definitions received over v9 and IPFIX |
+| `netflow.flow_records` | stacked, records/s | v5, v7, v9, and IPFIX Data Records decoded |
+| `netflow.options_records` | stacked, records/s | v9/IPFIX Options Records and sampling configuration sent in Data Records |
+| `netflow.sflow_samples` | stacked, samples/s | sFlow flow, counter, discarded-packet, real-time, and unknown samples |
+| `netflow.decoder_exceptions` | line, events/s | Receive, parse, template, disabled-protocol, eviction, counter, decapsulation, and unsupported-data exceptions |
+| `netflow.flow_rows` | line, rows/s | Decoded rows and their final filtered, journaled, or write-failed outcomes |
+| `netflow.nsel_events` | stacked, records/s | Cisco NSEL update, create, teardown, deny, unsupported, and malformed records |
+| `netflow.nsel_rows` | stacked, rows/s | Forward and reverse rows emitted from NSEL updates |
+| `netflow.nsel_exceptions` | line, events/s | Counterless updates, partial counter directions, and suppressed zero responders |
 | `netflow.raw_journal_ops` | line, ops/s | Raw journal: writes, sync calls, errors |
 | `netflow.raw_journal_bytes` | line, bytes/s | Raw journal logical bytes written |
 | `netflow.materialized_tier_ops` | line, ops/s | Rollup tiers: rows produced per tier, flushes, errors |
 | `netflow.materialized_tier_bytes` | stacked, bytes/s | Rollup tier byte rate, broken down by tier |
+| `netflow.tier_commit_age` | line, seconds | Time since each tier worker completed a commit |
+| `netflow.tier_commit_duration` | line, microseconds | Duration of each tier's most recent commit |
+| `netflow.tier_commit_batches` | line, batches/s | Completed commit batches per tier |
+| `netflow.tier_commit_stretched` | line, events/s | Tier commits that exceeded their planned window |
 | `netflow.open_tiers` | stacked, rows | Rows currently open per tier |
-| `netflow.journal_io_ops` | line, ops/s | Decoder-state persist operations and errors |
+| `netflow.journal_io_ops` | line, ops/s | Decoder-state persistence and facet-index operations/errors |
 | `netflow.journal_io_bytes` | line, bytes/s | Decoder-state persist byte rate |
 | `netflow.decoder_scopes` | line, scopes | Distinct (exporter, observation domain) scopes the decoder tracks |
 | `netflow.facet_values` | line, values | Published facet value cardinality |
@@ -42,15 +57,62 @@ diagnostics charts update on `charts.memory_diagnostics.interval` when enabled.
 
 ## Reading the most useful charts
 
-### `netflow.input_packets`
+### Input and protocol packets
 
-The single most important chart. Five families of dimensions:
+`netflow.input_packets` describes the UDP socket only:
 
-- **`udp_received`** — datagrams pulled off the socket. If this is zero, nothing is reaching the plugin (firewall, no exporter, wrong port).
-- **`parse_attempts`, `parsed_packets`** — should track each other on a healthy collector. If `parse_attempts` is high but `parsed_packets` is low, datagrams are arriving but failing to decode.
-- **`parse_errors`** — counts datagrams that failed parsing for any reason (truncated, malformed, unsupported version).
-- **`template_errors`** — counts data records arriving before their template (v9 / IPFIX). Should be near zero in steady state. A sustained non-zero rate means the exporter is sending templates too rarely or your collector has lost template state.
-- **`netflow_v5`, `netflow_v7`, `netflow_v9`, `ipfix`, `sflow`** — per-protocol successful counts. Useful to identify "which protocol is actually arriving".
+- **`udp_received`** — every datagram pulled from a listener socket, including empty datagrams.
+- **`empty`** — received zero-length datagrams. This is a subset of `udp_received`.
+- **`kernel_dropped`** — datagrams Linux dropped because a specific listener socket's receive buffer was full. The plugin reads the kernel counter once per second by exact socket identity. It is zero on platforms that do not expose this counter.
+
+`netflow.protocol_packets` reports successfully identified **v5, v7, v9, IPFIX, and sFlow packets separately**. These counters still increase when that protocol is disabled for row production, so `disabled_protocol_packets` can explain why recognized traffic did not reach storage.
+
+### Sets, templates, records, and samples
+
+Do not compare these rates as though they were the same thing:
+
+- One UDP datagram can contain multiple v9/IPFIX Sets.
+- One Set can contain multiple template definitions or Data Records.
+- One sFlow datagram can contain multiple samples.
+- One Data Record can produce zero, one, or two stored rows.
+
+Use `netflow.flow_sets` to verify v9/IPFIX control traffic. `*_missing_template` means a Data Set could not be decoded because its template was unavailable. `v9_ignored` is a reserved Set ID; `ipfix_ignored` covers template withdrawals and reserved Set IDs.
+
+Use `netflow.templates` to verify that exporters refresh both Data and Options Templates. Use `netflow.flow_records` for decoded Data Records, `netflow.options_records` for sampling/options traffic, and `netflow.sflow_samples` to distinguish flow-bearing sFlow samples from valid counter-only traffic. A Set first received without a template is counted as missing; if the parser later replays it after learning the template, its decoded records are counted then.
+
+### `netflow.flow_rows`
+
+This chart follows records after decoding. Its cumulative counters obey:
+
+`decoded = classifier_filtered + journaled + write_failed`
+
+If records are visible but rows are not:
+
+- `classifier_filtered` means configured enrichment/classifier policy rejected them.
+- `write_failed` means the journal could not store them.
+- A gap before `decoded` is explained by the protocol-specific charts and `netflow.decoder_exceptions`.
+
+### Cisco NSEL charts
+
+NSEL records and traffic rows are intentionally not one-to-one:
+
+- `netflow.nsel_events` counts every recognized event record by type.
+- `netflow.nsel_rows` counts forward and reverse traffic rows emitted from event-5 updates.
+- `netflow.nsel_exceptions` explains update records that produced fewer rows because counters were missing, partial, or zero.
+
+Create, teardown, and deny events are visible in `netflow.nsel_events` but are not stored as traffic rows.
+
+### `netflow.decoder_exceptions`
+
+All dimensions are exceptional **events**, but they occur at different stages:
+
+- `udp_receive_errors`, `udp_socket_setup_errors`, and `parse_errors` identify socket/parser failures.
+- `missing_template_sets` identifies v9/IPFIX Sets received without an available template.
+- `disabled_protocol_packets` identifies valid packets intentionally excluded by configuration.
+- `parser_source_evictions` identifies exporter parser state removed at the configured source limit.
+- `partial_counter_records`, `decapsulation_failed_records`, `unsupported_data_sets`, and `ipfix_zero_reverse_records` explain record-to-row differences.
+
+Because these dimensions count different objects, use them to identify causes; do not add them together or divide all of them by one common denominator.
 
 ### `netflow.decoder_scopes`
 
@@ -84,24 +146,26 @@ This one breaks RSS down by what's mapped. Useful when you want to attribute "th
 These charts do not include:
 
 - **Per-exporter ingest counter.** No per-source rate dimension. Decoder-scope cardinality tells you how many sources, not how busy each one is.
-- **UDP socket drops.** Kernel-level drops (full receive buffer, NIC drops) are not surfaced. Use OS-level signals such as `sudo ss -uamn sport = :2055` and `sudo ss -uamn sport = :6343` for per-socket drops, or `grep ^Udp: /proc/net/snmp` for the system-wide `RcvbufErrors` counter.
-- **Template cache hit ratio.** `template_errors` counts misses; there's no corresponding "hits" counter to form a ratio.
+- **NIC and network-wide packet loss.** `kernel_dropped` covers only the plugin's Linux UDP listener sockets, not upstream network loss or NIC drops.
+- **Template cache hit ratio.** Missing-template Sets are counted, but there is no corresponding hit counter.
 - **GeoIP staleness signal.** No "MMDB last loaded" timestamp or version. The mapping memory dimensions tell you if a database is loaded, not how old it is.
 - **Per-tier query latency.** These charts cover ingest and storage; query-side performance isn't observable.
 - **BioRIS counters.** BioRIS routing-state details are not published as chart dimensions.
-- **Cisco NSEL outcome counters.** Typed `decoded_nsel_*` counters are present in Network Flows function response stats, but their final health-chart grouping is intentionally not designed yet.
 
 ## How to use these charts for diagnosis
 
 | Symptom | Look at | What it means |
 |---|---|---|
-| Network Flows view is empty | `netflow.input_packets` `udp_received` | Zero = no datagrams arriving (firewall? wrong port?). Non-zero with `parsed_packets` zero = wrong protocol or all datagrams malformed. |
-| Sudden drop in flows | per-protocol dimensions | Identifies which protocol stopped (helps narrow whether it's a router, a router class, or all routers). |
-| Templates failing | `template_errors` rising | Exporter not sending templates often enough; collector lost cache; cache mismatch after firmware update. |
+| Network Flows view is empty | `netflow.input_packets`, then `netflow.protocol_packets` | No UDP = network/listener problem. UDP without protocol packets = malformed or unsupported traffic; check decoder exceptions. |
+| Sudden drop in flows | `netflow.protocol_packets`, `netflow.flow_records`, `netflow.flow_rows` | Identifies whether traffic stopped at the exporter, decoder, classifier, or journal. |
+| Templates failing | `*_missing_template` in `netflow.flow_sets` | Exporter not sending templates often enough, collector has not learned them yet, or exporter identity changed. |
+| sFlow packets but no rows | `netflow.sflow_samples` | Counter-only samples are valid but do not contain endpoint traffic rows. |
+| NSEL records but fewer rows | `netflow.nsel_events`, `netflow.nsel_rows`, `netflow.nsel_exceptions` | Non-update events are intentionally not traffic; directional counter outcomes explain event-5 rows. |
+| UDP loss under load | `kernel_dropped` in `netflow.input_packets` | Linux listener receive buffer overflow. This does not cover upstream or NIC loss. |
 | Cache growing without bound | `decoder_scopes` rising over hours | Exporter churn or unstable template IDs. Investigate per-router behaviour. |
 | Memory pressure | `netflow.facet_values`, `netflow.tier_index_entries`, `netflow.open_tiers`; optional `netflow.memory_*` diagnostics | Default count charts show where state cardinality grows. If byte diagnostics are enabled and `unaccounted` grows → unattributed allocation, possibly a leak. |
 | Disk write stalls | `netflow.raw_journal_ops` `write_errors`, `sync_errors` | Disk full, permission denied, fs error. |
-| Decoder state not persisting | `netflow.journal_io_ops` | `decoder_state_persist_calls` should tick periodically. `*_errors` should be 0. |
+| Decoder/facet state not persisting | `netflow.journal_io_ops` | Persist calls should tick periodically; all error dimensions should remain zero. |
 
 ## Where these are NOT shown
 

--- a/integrations/_common.py
+++ b/integrations/_common.py
@@ -24,10 +24,18 @@ COLLECTOR_SOURCES = [
     (AGENT_REPO, REPO_PATH / 'src' / 'go' / 'plugin' / 'scripts.d' / 'collector', True),
     (AGENT_REPO, REPO_PATH / 'src' / 'go' / 'plugin' / 'ibm.d' / 'modules', True),
     (AGENT_REPO, REPO_PATH / 'src' / 'go' / 'plugin' / 'ibm.d' / 'modules' / 'websphere', True),
-    (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'netflow-plugin' / 'metadata.yaml', False),
-    (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'netflow-plugin' / 'taxonomy.yaml', False),
     (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'otel-plugin' / 'metadata.yaml', False),
     (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'otel-plugin' / 'taxonomy.yaml', False),
+]
+
+FLOWS_SOURCES = [
+    (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'netflow-plugin' / 'metadata.yaml', False),
+]
+
+TAXONOMY_SOURCES = [
+    *COLLECTOR_SOURCES,
+    *FLOWS_SOURCES,
+    (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'netflow-plugin' / 'taxonomy.yaml', False),
 ]
 
 GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS', False)
@@ -85,10 +93,10 @@ def make_validator(schema_ref):
 COLLECTOR_VALIDATOR = make_validator('./collector.json#')
 
 
-def get_collector_metadata_entries():
+def get_metadata_entries(sources):
     ret = []
 
-    for r, d, m in COLLECTOR_SOURCES:
+    for r, d, m in sources:
         if d.exists() and d.is_dir() and m:
             for item in d.glob(METADATA_PATTERN):
                 ret.append((r, item))
@@ -97,6 +105,10 @@ def get_collector_metadata_entries():
                 ret.append((r, d))
 
     return ret
+
+
+def get_collector_metadata_entries():
+    return get_metadata_entries(COLLECTOR_SOURCES)
 
 
 def load_yaml(src):
@@ -121,10 +133,10 @@ def load_yaml(src):
     return data
 
 
-def load_collectors():
+def load_collectors(sources=None):
     ret = []
 
-    entries = get_collector_metadata_entries()
+    entries = get_metadata_entries(COLLECTOR_SOURCES if sources is None else sources)
 
     for repo, path in entries:
         debug(f'Loading {path}.')

--- a/integrations/_common.py
+++ b/integrations/_common.py
@@ -24,6 +24,8 @@ COLLECTOR_SOURCES = [
     (AGENT_REPO, REPO_PATH / 'src' / 'go' / 'plugin' / 'scripts.d' / 'collector', True),
     (AGENT_REPO, REPO_PATH / 'src' / 'go' / 'plugin' / 'ibm.d' / 'modules', True),
     (AGENT_REPO, REPO_PATH / 'src' / 'go' / 'plugin' / 'ibm.d' / 'modules' / 'websphere', True),
+    (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'netflow-plugin' / 'metadata.yaml', False),
+    (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'netflow-plugin' / 'taxonomy.yaml', False),
     (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'otel-plugin' / 'metadata.yaml', False),
     (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'otel-plugin' / 'taxonomy.yaml', False),
 ]

--- a/integrations/check_collector_taxonomy.py
+++ b/integrations/check_collector_taxonomy.py
@@ -7,7 +7,7 @@ import sys
 from ruamel.yaml import YAML, YAMLError
 
 from gen_taxonomy import FATAL, Finding, build_taxonomy, dynamic_declarations, module_contexts, relpath
-from _common import REPO_PATH, get_collector_metadata_entries
+from _common import REPO_PATH, TAXONOMY_SOURCES, get_metadata_entries
 
 
 def run_git(*args):
@@ -78,7 +78,7 @@ def metadata_metrics_touched(diff_range, path):
 
 
 def collector_metadata_paths():
-    return {path.resolve() for _, path in get_collector_metadata_entries()}
+    return {path.resolve() for _, path in get_metadata_entries(TAXONOMY_SOURCES)}
 
 
 def touched_collectors(diff_range):

--- a/integrations/gen_integrations.py
+++ b/integrations/gen_integrations.py
@@ -9,6 +9,7 @@ from jsonschema import ValidationError
 
 from _common import (
     AGENT_REPO,
+    FLOWS_SOURCES,
     INTEGRATIONS_PATH,
     METADATA_PATTERN,
     REPO_PATH,
@@ -26,10 +27,6 @@ OUTPUT_PATH = INTEGRATIONS_PATH / 'integrations.js'
 JSON_PATH = INTEGRATIONS_PATH / 'integrations.json'
 CATEGORIES_FILE = INTEGRATIONS_PATH / 'categories.yaml'
 DISTROS_FILE = REPO_PATH / '.github' / 'data' / 'distros.yml'
-
-FLOWS_SOURCES = [
-    (AGENT_REPO, REPO_PATH / 'src' / 'crates' / 'netflow-plugin' / 'metadata.yaml', False),
-]
 
 DEVICE_SOURCES = [
     (AGENT_REPO,

--- a/integrations/gen_taxonomy.py
+++ b/integrations/gen_taxonomy.py
@@ -10,10 +10,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from _common import (
-    COLLECTOR_SOURCES,
     GITHUB_ACTIONS,
     INTEGRATIONS_PATH,
     REPO_PATH,
+    TAXONOMY_SOURCES,
     WARNINGS,
     load_collectors,
     load_yaml,
@@ -155,7 +155,7 @@ def source_info():
 
 def discover_taxonomy_files():
     files = []
-    for _, root, recursive in COLLECTOR_SOURCES:
+    for _, root, recursive in TAXONOMY_SOURCES:
         if root.exists() and root.is_dir() and recursive:
             files.extend(root.glob('*/taxonomy.yaml'))
         elif root.exists() and root.is_file() and root.name == 'taxonomy.yaml':
@@ -285,7 +285,7 @@ def dynamic_declarations(module):
 
 def build_metadata_indexes(findings):
     warning_start = len(WARNINGS)
-    modules = load_collectors()
+    modules = load_collectors(TAXONOMY_SOURCES)
     for path, message in WARNINGS[warning_start:]:
         findings.append(Finding('TAX001', FATAL, Path(path), message))
 

--- a/integrations/tests/test_taxonomy.py
+++ b/integrations/tests/test_taxonomy.py
@@ -10,8 +10,20 @@ from unittest.mock import patch
 INTEGRATIONS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(INTEGRATIONS_DIR))
 
+import _common
 import check_collector_taxonomy
 import gen_taxonomy
+
+
+class TaxonomySourceTest(unittest.TestCase):
+    def test_flow_metadata_is_loaded_once_and_available_to_taxonomy(self):
+        collector_paths = {path for _, path, _ in _common.COLLECTOR_SOURCES}
+        flow_paths = {path for _, path, _ in _common.FLOWS_SOURCES}
+        taxonomy_paths = {path for _, path, _ in _common.TAXONOMY_SOURCES}
+
+        self.assertTrue(flow_paths)
+        self.assertTrue(flow_paths.isdisjoint(collector_paths))
+        self.assertTrue(flow_paths.issubset(taxonomy_paths))
 
 
 class TaxonomySchemaTest(unittest.TestCase):
@@ -319,7 +331,7 @@ class TaxonomyResolverTest(unittest.TestCase):
     def test_metadata_loader_warnings_are_taxonomy_findings(self):
         original_len = len(gen_taxonomy.WARNINGS)
 
-        def fake_load_collectors():
+        def fake_load_collectors(*_args):
             gen_taxonomy.WARNINGS.append(('metadata.yaml', 'invalid metadata'))
             return []
 
@@ -685,7 +697,7 @@ modules:
         with patch.object(check_collector_taxonomy, 'run_git', return_value=diff), \
                 patch.object(
                     check_collector_taxonomy,
-                    'get_collector_metadata_entries',
+                    'get_metadata_entries',
                     return_value=[('netdata/netdata', collector_metadata)],
                 ), \
                 patch.object(

--- a/src/crates/netflow-plugin/integrations/ipfix.md
+++ b/src/crates/netflow-plugin/integrations/ipfix.md
@@ -132,7 +132,9 @@ protocols:
 ### Verifying flow data is arriving and diagnosing failures
 
 See [Troubleshooting](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/troubleshooting) for
-the full diagnostic recipe. For IPFIX specifically, watch the `template_errors` dimension
-on `netflow.input_packets` -- IPFIX is template-driven and data records arriving before
-their templates are dropped. See also
+the full diagnostic recipe. Use `netflow.input_packets` for UDP arrival,
+`netflow.protocol_packets` for v5/v7/v9/IPFIX/sFlow identification, and
+`netflow.decoder_exceptions` for parse failures. For v9/IPFIX, watch the
+missing-template dimensions on `netflow.flow_sets`; Data Sets arriving before
+their templates cannot be decoded. See also
 [Validation and Data Quality](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/validation-and-data-quality).

--- a/src/crates/netflow-plugin/metadata.yaml
+++ b/src/crates/netflow-plugin/metadata.yaml
@@ -181,11 +181,150 @@ modules:
         [Field Reference](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/field-reference).
         Cisco ASA NSEL event 5 emits initiator and nonzero responder directions as separate
         rows. Create, teardown, deny, malformed, and counterless events are excluded from traffic.
+        The plugin also publishes the operational health metrics below. They describe collector
+        input and processing; they are not the stored flow traffic queried by Network Flows.
         For visualisation guidance see [Sankey and Table](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/visualization/sankey-and-table),
         [Time-Series](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/visualization/time-series),
         and [Maps and Globe](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/visualization/maps-and-globe).
       availability: []
-      scopes: []
+      scopes:
+        - name: global
+          description: These metrics describe the global Network Flows collector pipeline.
+          labels: []
+          metrics:
+            - name: netdata.netflow.input_packets
+              description: UDP datagrams received by the collector and listener-buffer losses.
+              unit: packets/s
+              chart_type: line
+              dimensions:
+                - name: udp_received
+                - name: kernel_dropped
+                - name: empty
+            - name: netdata.netflow.protocol_packets
+              description: Successfully identified network-flow packets by wire protocol.
+              unit: packets/s
+              chart_type: stacked
+              dimensions:
+                - name: netflow_v5
+                - name: netflow_v7
+                - name: netflow_v9
+                - name: ipfix
+                - name: sflow
+            - name: netdata.netflow.flow_sets
+              description: NetFlow v9 and IPFIX Sets by protocol and Set purpose.
+              unit: sets/s
+              chart_type: stacked
+              dimensions:
+                - name: v9_data
+                - name: v9_options_data
+                - name: v9_templates
+                - name: v9_options_templates
+                - name: v9_missing_template
+                - name: v9_ignored
+                - name: ipfix_data
+                - name: ipfix_options_data
+                - name: ipfix_templates
+                - name: ipfix_options_templates
+                - name: ipfix_missing_template
+                - name: ipfix_ignored
+            - name: netdata.netflow.templates
+              description: NetFlow v9 and IPFIX template definitions received.
+              unit: templates/s
+              chart_type: stacked
+              dimensions:
+                - name: v9_data
+                - name: v9_options
+                - name: ipfix_data
+                - name: ipfix_options
+            - name: netdata.netflow.flow_records
+              description: Data Records decoded by wire protocol before row projection.
+              unit: records/s
+              chart_type: stacked
+              dimensions:
+                - name: netflow_v5
+                - name: netflow_v7
+                - name: netflow_v9
+                - name: ipfix
+            - name: netdata.netflow.options_records
+              description: Options Records and sampling configuration Data Records.
+              unit: records/s
+              chart_type: stacked
+              dimensions:
+                - name: netflow_v9
+                - name: ipfix
+                - name: sampling_data
+            - name: netdata.netflow.sflow_samples
+              description: sFlow samples by sample type.
+              unit: samples/s
+              chart_type: stacked
+              dimensions:
+                - name: flow
+                - name: counter
+                - name: discarded_packet
+                - name: rt_metric
+                - name: rt_flow
+                - name: unknown
+            - name: netdata.netflow.decoder_exceptions
+              description: Exceptional receive and decode outcomes that explain missing rows.
+              unit: events/s
+              chart_type: line
+              dimensions:
+                - name: udp_receive_errors
+                - name: udp_socket_setup_errors
+                - name: parse_errors
+                - name: missing_template_sets
+                - name: disabled_protocol_packets
+                - name: parser_source_evictions
+                - name: partial_counter_records
+                - name: decapsulation_failed_records
+                - name: unsupported_data_sets
+                - name: ipfix_zero_reverse_records
+            - name: netdata.netflow.flow_rows
+              description: Decoded rows and their final filtering or journal outcomes.
+              unit: rows/s
+              chart_type: line
+              dimensions:
+                - name: decoded
+                - name: classifier_filtered
+                - name: journaled
+                - name: write_failed
+            - name: netdata.netflow.nsel_events
+              description: Cisco NSEL records by firewall event type.
+              unit: records/s
+              chart_type: stacked
+              dimensions:
+                - name: update
+                - name: create
+                - name: teardown
+                - name: denied
+                - name: unsupported
+                - name: malformed
+            - name: netdata.netflow.nsel_rows
+              description: Forward and reverse traffic rows projected from Cisco NSEL updates.
+              unit: rows/s
+              chart_type: stacked
+              dimensions:
+                - name: forward
+                - name: reverse
+            - name: netdata.netflow.nsel_exceptions
+              description: Cisco NSEL counter outcomes that suppress or modify row projection.
+              unit: events/s
+              chart_type: line
+              dimensions:
+                - name: counterless_updates
+                - name: partial_counter_directions
+                - name: zero_responder
+            - name: netdata.netflow.journal_io_ops
+              description: Decoder-state persistence and facet-index operations and errors.
+              unit: ops/s
+              chart_type: line
+              dimensions:
+                - name: decoder_state_persist_calls
+                - name: decoder_state_write_errors
+                - name: decoder_state_move_errors
+                - name: facet_active_update_errors
+                - name: facet_lifecycle_errors
+                - name: facet_persist_errors
 
   - meta:
       plugin_name: netflow-plugin
@@ -311,9 +450,11 @@ modules:
           - name: Verifying flow data is arriving and diagnosing failures
             description: |
               See [Troubleshooting](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/troubleshooting) for
-              the full diagnostic recipe. For IPFIX specifically, watch the `template_errors` dimension
-              on `netflow.input_packets` -- IPFIX is template-driven and data records arriving before
-              their templates are dropped. See also
+              the full diagnostic recipe. Use `netflow.input_packets` for UDP arrival,
+              `netflow.protocol_packets` for v5/v7/v9/IPFIX/sFlow identification, and
+              `netflow.decoder_exceptions` for parse failures. For v9/IPFIX, watch the
+              missing-template dimensions on `netflow.flow_sets`; Data Sets arriving before
+              their templates cannot be decoded. See also
               [Validation and Data Quality](https://learn.netdata.cloud/docs/network-performance-monitoring/network-flows/validation-and-data-quality).
     alerts: []
     metrics:

--- a/src/crates/netflow-plugin/src/charts.rs
+++ b/src/crates/netflow-plugin/src/charts.rs
@@ -17,11 +17,13 @@ mod metrics;
 mod process_maps;
 mod runtime;
 mod snapshot;
+mod udp;
 
 use metrics::*;
 pub(crate) use process_maps::*;
 pub(crate) use runtime::*;
 use snapshot::*;
+use udp::*;
 
 #[cfg(test)]
 mod tests;

--- a/src/crates/netflow-plugin/src/charts/metrics.rs
+++ b/src/crates/netflow-plugin/src/charts/metrics.rs
@@ -3,7 +3,7 @@ use super::*;
 #[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
 #[schemars(
     extend("x-chart-id" = "netflow.input_packets"),
-    extend("x-chart-title" = "Netflow Input Packets"),
+    extend("x-chart-title" = "Netflow UDP Input Packets"),
     extend("x-chart-units" = "packets/s"),
     extend("x-chart-type" = "line"),
     extend("x-chart-family" = "netflow"),
@@ -13,13 +13,21 @@ pub(super) struct InputPacketsMetrics {
     #[schemars(extend("x-dimension-algorithm" = "incremental"))]
     pub(super) udp_received: u64,
     #[schemars(extend("x-dimension-algorithm" = "incremental"))]
-    pub(super) parse_attempts: u64,
+    pub(super) kernel_dropped: u64,
     #[schemars(extend("x-dimension-algorithm" = "incremental"))]
-    pub(super) parsed_packets: u64,
-    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
-    pub(super) parse_errors: u64,
-    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
-    pub(super) template_errors: u64,
+    pub(super) empty: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.protocol_packets"),
+    extend("x-chart-title" = "Netflow Protocol Packets"),
+    extend("x-chart-units" = "packets/s"),
+    extend("x-chart-type" = "stacked"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.protocol_packets"),
+)]
+pub(super) struct ProtocolPacketsMetrics {
     #[schemars(extend("x-dimension-algorithm" = "incremental"))]
     pub(super) netflow_v5: u64,
     #[schemars(extend("x-dimension-algorithm" = "incremental"))]
@@ -30,6 +38,234 @@ pub(super) struct InputPacketsMetrics {
     pub(super) ipfix: u64,
     #[schemars(extend("x-dimension-algorithm" = "incremental"))]
     pub(super) sflow: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.flow_sets"),
+    extend("x-chart-title" = "Netflow Sets"),
+    extend("x-chart-units" = "sets/s"),
+    extend("x-chart-type" = "stacked"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.flow_sets"),
+)]
+pub(super) struct FlowSetMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) v9_data: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) v9_options_data: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) v9_templates: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) v9_options_templates: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) v9_missing_template: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) v9_ignored: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix_data: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix_options_data: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix_templates: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix_options_templates: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix_missing_template: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix_ignored: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.templates"),
+    extend("x-chart-title" = "Netflow Template Definitions"),
+    extend("x-chart-units" = "templates/s"),
+    extend("x-chart-type" = "stacked"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.templates"),
+)]
+pub(super) struct TemplateMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) v9_data: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) v9_options: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix_data: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix_options: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.flow_records"),
+    extend("x-chart-title" = "Netflow Decoded Data Records"),
+    extend("x-chart-units" = "records/s"),
+    extend("x-chart-type" = "stacked"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.flow_records"),
+)]
+pub(super) struct FlowRecordMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) netflow_v5: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) netflow_v7: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) netflow_v9: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.options_records"),
+    extend("x-chart-title" = "Netflow Options Records"),
+    extend("x-chart-units" = "records/s"),
+    extend("x-chart-type" = "stacked"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.options_records"),
+)]
+pub(super) struct OptionsRecordMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) netflow_v9: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) sampling_data: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.sflow_samples"),
+    extend("x-chart-title" = "sFlow Samples"),
+    extend("x-chart-units" = "samples/s"),
+    extend("x-chart-type" = "stacked"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.sflow_samples"),
+)]
+pub(super) struct SflowSampleMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) flow: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) counter: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) discarded_packet: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) rt_metric: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) rt_flow: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) unknown: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.decoder_exceptions"),
+    extend("x-chart-title" = "Netflow Decoder Exceptions"),
+    extend("x-chart-units" = "events/s"),
+    extend("x-chart-type" = "line"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.decoder_exceptions"),
+)]
+pub(super) struct DecoderExceptionMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) udp_receive_errors: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) udp_socket_setup_errors: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) parse_errors: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) missing_template_sets: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) disabled_protocol_packets: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) parser_source_evictions: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) partial_counter_records: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) decapsulation_failed_records: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) unsupported_data_sets: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) ipfix_zero_reverse_records: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.flow_rows"),
+    extend("x-chart-title" = "Netflow Row Pipeline"),
+    extend("x-chart-units" = "rows/s"),
+    extend("x-chart-type" = "line"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.flow_rows"),
+)]
+pub(super) struct FlowRowMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) decoded: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) classifier_filtered: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) journaled: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) write_failed: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.nsel_events"),
+    extend("x-chart-title" = "Cisco NSEL Events"),
+    extend("x-chart-units" = "records/s"),
+    extend("x-chart-type" = "stacked"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.nsel_events"),
+)]
+pub(super) struct NselEventMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) update: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) create: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) teardown: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) denied: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) unsupported: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) malformed: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.nsel_rows"),
+    extend("x-chart-title" = "Cisco NSEL Rows"),
+    extend("x-chart-units" = "rows/s"),
+    extend("x-chart-type" = "stacked"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.nsel_rows"),
+)]
+pub(super) struct NselRowMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) forward: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) reverse: u64,
+}
+
+#[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[schemars(
+    extend("x-chart-id" = "netflow.nsel_exceptions"),
+    extend("x-chart-title" = "Cisco NSEL Exceptions"),
+    extend("x-chart-units" = "events/s"),
+    extend("x-chart-type" = "line"),
+    extend("x-chart-family" = "netflow"),
+    extend("x-chart-context" = "netdata.netflow.nsel_exceptions"),
+)]
+pub(super) struct NselExceptionMetrics {
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) counterless_updates: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) partial_counter_directions: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) zero_responder: u64,
 }
 
 #[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]
@@ -230,6 +466,12 @@ pub(super) struct JournalIoOpsMetrics {
     pub(super) decoder_state_write_errors: u64,
     #[schemars(extend("x-dimension-algorithm" = "incremental"))]
     pub(super) decoder_state_move_errors: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) facet_active_update_errors: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) facet_lifecycle_errors: u64,
+    #[schemars(extend("x-dimension-algorithm" = "incremental"))]
+    pub(super) facet_persist_errors: u64,
 }
 
 #[derive(JsonSchema, NetdataChart, Default, Clone, PartialEq, Serialize, Deserialize, Debug)]

--- a/src/crates/netflow-plugin/src/charts/runtime.rs
+++ b/src/crates/netflow-plugin/src/charts/runtime.rs
@@ -7,6 +7,17 @@ use tokio::io::{AsyncRead, AsyncWrite};
 pub(crate) struct NetflowCharts {
     input_packets: ChartHandle<InputPacketsMetrics>,
     input_bytes: ChartHandle<InputBytesMetrics>,
+    protocol_packets: ChartHandle<ProtocolPacketsMetrics>,
+    flow_sets: ChartHandle<FlowSetMetrics>,
+    templates: ChartHandle<TemplateMetrics>,
+    flow_records: ChartHandle<FlowRecordMetrics>,
+    options_records: ChartHandle<OptionsRecordMetrics>,
+    sflow_samples: ChartHandle<SflowSampleMetrics>,
+    decoder_exceptions: ChartHandle<DecoderExceptionMetrics>,
+    flow_rows: ChartHandle<FlowRowMetrics>,
+    nsel_events: ChartHandle<NselEventMetrics>,
+    nsel_rows: ChartHandle<NselRowMetrics>,
+    nsel_exceptions: ChartHandle<NselExceptionMetrics>,
     raw_journal_ops: ChartHandle<RawJournalOpsMetrics>,
     raw_journal_bytes: ChartHandle<RawJournalBytesMetrics>,
     materialized_tier_ops: ChartHandle<MaterializedTierOpsMetrics>,
@@ -42,6 +53,24 @@ impl NetflowCharts {
                 .register_chart(InputPacketsMetrics::default(), Duration::from_secs(1)),
             input_bytes: runtime
                 .register_chart(InputBytesMetrics::default(), Duration::from_secs(1)),
+            protocol_packets: runtime
+                .register_chart(ProtocolPacketsMetrics::default(), Duration::from_secs(1)),
+            flow_sets: runtime.register_chart(FlowSetMetrics::default(), Duration::from_secs(1)),
+            templates: runtime.register_chart(TemplateMetrics::default(), Duration::from_secs(1)),
+            flow_records: runtime
+                .register_chart(FlowRecordMetrics::default(), Duration::from_secs(1)),
+            options_records: runtime
+                .register_chart(OptionsRecordMetrics::default(), Duration::from_secs(1)),
+            sflow_samples: runtime
+                .register_chart(SflowSampleMetrics::default(), Duration::from_secs(1)),
+            decoder_exceptions: runtime
+                .register_chart(DecoderExceptionMetrics::default(), Duration::from_secs(1)),
+            flow_rows: runtime.register_chart(FlowRowMetrics::default(), Duration::from_secs(1)),
+            nsel_events: runtime
+                .register_chart(NselEventMetrics::default(), Duration::from_secs(1)),
+            nsel_rows: runtime.register_chart(NselRowMetrics::default(), Duration::from_secs(1)),
+            nsel_exceptions: runtime
+                .register_chart(NselExceptionMetrics::default(), Duration::from_secs(1)),
             raw_journal_ops: runtime
                 .register_chart(RawJournalOpsMetrics::default(), Duration::from_secs(1)),
             raw_journal_bytes: runtime
@@ -120,6 +149,7 @@ impl NetflowCharts {
                 tokio::select! {
                     _ = shutdown.cancelled() => break,
                     _ = interval.tick() => {
+                        sample_udp_kernel_drops(metrics.as_ref());
                         open_tier_sample = sample_open_tier_state(open_tiers.as_ref(), open_tier_sample);
                         tier_index_cardinality = sample_tier_index_cardinality(
                             tier_flow_indexes.as_ref(),
@@ -152,6 +182,24 @@ impl NetflowCharts {
             .update(|chart| *chart = snapshot.input_packets);
         self.input_bytes
             .update(|chart| *chart = snapshot.input_bytes);
+        self.protocol_packets
+            .update(|chart| *chart = snapshot.protocol_packets);
+        self.flow_sets.update(|chart| *chart = snapshot.flow_sets);
+        self.templates.update(|chart| *chart = snapshot.templates);
+        self.flow_records
+            .update(|chart| *chart = snapshot.flow_records);
+        self.options_records
+            .update(|chart| *chart = snapshot.options_records);
+        self.sflow_samples
+            .update(|chart| *chart = snapshot.sflow_samples);
+        self.decoder_exceptions
+            .update(|chart| *chart = snapshot.decoder_exceptions);
+        self.flow_rows.update(|chart| *chart = snapshot.flow_rows);
+        self.nsel_events
+            .update(|chart| *chart = snapshot.nsel_events);
+        self.nsel_rows.update(|chart| *chart = snapshot.nsel_rows);
+        self.nsel_exceptions
+            .update(|chart| *chart = snapshot.nsel_exceptions);
         self.raw_journal_ops
             .update(|chart| *chart = snapshot.raw_journal_ops);
         self.raw_journal_bytes

--- a/src/crates/netflow-plugin/src/charts/snapshot.rs
+++ b/src/crates/netflow-plugin/src/charts/snapshot.rs
@@ -5,6 +5,17 @@ use crate::memory_allocator::AllocatorMemorySample;
 pub(super) struct NetflowChartsSnapshot {
     pub(super) input_packets: InputPacketsMetrics,
     pub(super) input_bytes: InputBytesMetrics,
+    pub(super) protocol_packets: ProtocolPacketsMetrics,
+    pub(super) flow_sets: FlowSetMetrics,
+    pub(super) templates: TemplateMetrics,
+    pub(super) flow_records: FlowRecordMetrics,
+    pub(super) options_records: OptionsRecordMetrics,
+    pub(super) sflow_samples: SflowSampleMetrics,
+    pub(super) decoder_exceptions: DecoderExceptionMetrics,
+    pub(super) flow_rows: FlowRowMetrics,
+    pub(super) nsel_events: NselEventMetrics,
+    pub(super) nsel_rows: NselRowMetrics,
+    pub(super) nsel_exceptions: NselExceptionMetrics,
     pub(super) raw_journal_ops: RawJournalOpsMetrics,
     pub(super) raw_journal_bytes: RawJournalBytesMetrics,
     pub(super) materialized_tier_ops: MaterializedTierOpsMetrics,
@@ -83,15 +94,103 @@ impl NetflowChartsSnapshot {
         Self {
             input_packets: InputPacketsMetrics {
                 udp_received: metrics.udp_packets_received.load(Ordering::Relaxed),
-                parse_attempts: metrics.parse_attempts.load(Ordering::Relaxed),
-                parsed_packets: metrics.parsed_packets.load(Ordering::Relaxed),
-                parse_errors: metrics.parse_errors.load(Ordering::Relaxed),
-                template_errors: metrics.template_errors.load(Ordering::Relaxed),
+                kernel_dropped: metrics.udp_kernel_drops.load(Ordering::Relaxed),
+                empty: metrics.udp_empty_packets.load(Ordering::Relaxed),
+            },
+            protocol_packets: ProtocolPacketsMetrics {
                 netflow_v5: metrics.netflow_v5_packets.load(Ordering::Relaxed),
                 netflow_v7: metrics.netflow_v7_packets.load(Ordering::Relaxed),
                 netflow_v9: metrics.netflow_v9_packets.load(Ordering::Relaxed),
                 ipfix: metrics.ipfix_packets.load(Ordering::Relaxed),
                 sflow: metrics.sflow_datagrams.load(Ordering::Relaxed),
+            },
+            flow_sets: FlowSetMetrics {
+                v9_data: metrics.v9_data_sets.load(Ordering::Relaxed),
+                v9_options_data: metrics.v9_options_data_sets.load(Ordering::Relaxed),
+                v9_templates: metrics.v9_template_sets.load(Ordering::Relaxed),
+                v9_options_templates: metrics.v9_options_template_sets.load(Ordering::Relaxed),
+                v9_missing_template: metrics.v9_missing_template_sets.load(Ordering::Relaxed),
+                v9_ignored: metrics.v9_ignored_sets.load(Ordering::Relaxed),
+                ipfix_data: metrics.ipfix_data_sets.load(Ordering::Relaxed),
+                ipfix_options_data: metrics.ipfix_options_data_sets.load(Ordering::Relaxed),
+                ipfix_templates: metrics.ipfix_template_sets.load(Ordering::Relaxed),
+                ipfix_options_templates: metrics
+                    .ipfix_options_template_sets
+                    .load(Ordering::Relaxed),
+                ipfix_missing_template: metrics.ipfix_missing_template_sets.load(Ordering::Relaxed),
+                ipfix_ignored: metrics.ipfix_ignored_sets.load(Ordering::Relaxed),
+            },
+            templates: TemplateMetrics {
+                v9_data: metrics.v9_data_templates.load(Ordering::Relaxed),
+                v9_options: metrics.v9_options_templates.load(Ordering::Relaxed),
+                ipfix_data: metrics.ipfix_data_templates.load(Ordering::Relaxed),
+                ipfix_options: metrics.ipfix_options_templates.load(Ordering::Relaxed),
+            },
+            flow_records: FlowRecordMetrics {
+                netflow_v5: metrics.netflow_v5_records.load(Ordering::Relaxed),
+                netflow_v7: metrics.netflow_v7_records.load(Ordering::Relaxed),
+                netflow_v9: metrics.netflow_v9_records.load(Ordering::Relaxed),
+                ipfix: metrics.ipfix_records.load(Ordering::Relaxed),
+            },
+            options_records: OptionsRecordMetrics {
+                netflow_v9: metrics.v9_options_records.load(Ordering::Relaxed),
+                ipfix: metrics.ipfix_options_records.load(Ordering::Relaxed),
+                sampling_data: metrics.sampling_option_records.load(Ordering::Relaxed),
+            },
+            sflow_samples: SflowSampleMetrics {
+                flow: metrics.sflow_flow_samples.load(Ordering::Relaxed),
+                counter: metrics.sflow_counter_samples.load(Ordering::Relaxed),
+                discarded_packet: metrics.sflow_discarded_samples.load(Ordering::Relaxed),
+                rt_metric: metrics.sflow_rt_metric_samples.load(Ordering::Relaxed),
+                rt_flow: metrics.sflow_rt_flow_samples.load(Ordering::Relaxed),
+                unknown: metrics.sflow_unknown_samples.load(Ordering::Relaxed),
+            },
+            decoder_exceptions: DecoderExceptionMetrics {
+                udp_receive_errors: metrics.udp_receive_errors.load(Ordering::Relaxed),
+                udp_socket_setup_errors: metrics.udp_socket_setup_errors.load(Ordering::Relaxed),
+                parse_errors: metrics.parse_errors.load(Ordering::Relaxed),
+                missing_template_sets: metrics.missing_template_sets.load(Ordering::Relaxed),
+                disabled_protocol_packets: metrics
+                    .disabled_protocol_packets
+                    .load(Ordering::Relaxed),
+                parser_source_evictions: metrics.parser_source_evictions.load(Ordering::Relaxed),
+                partial_counter_records: metrics.partial_counter_records.load(Ordering::Relaxed),
+                decapsulation_failed_records: metrics
+                    .decapsulation_failed_records
+                    .load(Ordering::Relaxed),
+                unsupported_data_sets: metrics.unsupported_data_sets.load(Ordering::Relaxed),
+                ipfix_zero_reverse_records: metrics
+                    .ipfix_zero_reverse_records
+                    .load(Ordering::Relaxed),
+            },
+            flow_rows: FlowRowMetrics {
+                decoded: metrics.decoded_rows.load(Ordering::Relaxed),
+                classifier_filtered: metrics.enrichment_filtered_rows.load(Ordering::Relaxed),
+                journaled: metrics.journal_entries_written.load(Ordering::Relaxed),
+                write_failed: metrics.journal_write_errors.load(Ordering::Relaxed),
+            },
+            nsel_events: NselEventMetrics {
+                update: metrics.nsel_update_records.load(Ordering::Relaxed),
+                create: metrics.nsel_create_records.load(Ordering::Relaxed),
+                teardown: metrics.nsel_teardown_records.load(Ordering::Relaxed),
+                denied: metrics.nsel_denied_records.load(Ordering::Relaxed),
+                unsupported: metrics
+                    .nsel_unsupported_event_records
+                    .load(Ordering::Relaxed),
+                malformed: metrics.nsel_malformed_records.load(Ordering::Relaxed),
+            },
+            nsel_rows: NselRowMetrics {
+                forward: metrics.nsel_forward_rows.load(Ordering::Relaxed),
+                reverse: metrics.nsel_reverse_rows.load(Ordering::Relaxed),
+            },
+            nsel_exceptions: NselExceptionMetrics {
+                counterless_updates: metrics
+                    .nsel_counterless_update_records
+                    .load(Ordering::Relaxed),
+                partial_counter_directions: metrics
+                    .nsel_partial_counter_records
+                    .load(Ordering::Relaxed),
+                zero_responder: metrics.nsel_zero_responder_records.load(Ordering::Relaxed),
             },
             input_bytes: InputBytesMetrics {
                 udp_received: metrics.udp_bytes_received.load(Ordering::Relaxed),
@@ -158,6 +257,11 @@ impl NetflowChartsSnapshot {
                 decoder_state_move_errors: metrics
                     .decoder_state_move_errors
                     .load(Ordering::Relaxed),
+                facet_active_update_errors: metrics
+                    .facet_active_update_errors
+                    .load(Ordering::Relaxed),
+                facet_lifecycle_errors: metrics.facet_lifecycle_errors.load(Ordering::Relaxed),
+                facet_persist_errors: metrics.facet_persist_errors.load(Ordering::Relaxed),
             },
             journal_io_bytes: JournalIoBytesMetrics {
                 decoder_state_persist_bytes: metrics

--- a/src/crates/netflow-plugin/src/charts/tests.rs
+++ b/src/crates/netflow-plugin/src/charts/tests.rs
@@ -166,35 +166,116 @@ fn memory_byte_charts_are_registered_only_when_enabled() {
 #[test]
 fn snapshot_collects_current_metric_totals_and_open_rows() {
     let metrics = IngestMetrics::default();
-    metrics.udp_packets_received.store(11, Ordering::Relaxed);
+    metrics.udp_packets_received.store(101, Ordering::Relaxed);
     metrics.udp_bytes_received.store(22, Ordering::Relaxed);
-    metrics.udp_empty_packets.store(12, Ordering::Relaxed);
-    metrics.udp_kernel_drops.store(13, Ordering::Relaxed);
-    metrics.netflow_v5_packets.store(14, Ordering::Relaxed);
-    metrics.netflow_v7_packets.store(15, Ordering::Relaxed);
-    metrics.netflow_v9_packets.store(16, Ordering::Relaxed);
-    metrics.ipfix_packets.store(17, Ordering::Relaxed);
-    metrics.sflow_datagrams.store(18, Ordering::Relaxed);
-    metrics.v9_data_sets.store(19, Ordering::Relaxed);
-    metrics.ipfix_data_sets.store(20, Ordering::Relaxed);
-    metrics.v9_data_templates.store(21, Ordering::Relaxed);
-    metrics.netflow_v9_records.store(22, Ordering::Relaxed);
-    metrics.ipfix_records.store(23, Ordering::Relaxed);
-    metrics.v9_options_records.store(24, Ordering::Relaxed);
-    metrics.sampling_option_records.store(25, Ordering::Relaxed);
-    metrics.sflow_counter_samples.store(26, Ordering::Relaxed);
-    metrics.parse_errors.store(27, Ordering::Relaxed);
-    metrics.missing_template_sets.store(28, Ordering::Relaxed);
-    metrics.nsel_update_records.store(29, Ordering::Relaxed);
-    metrics.nsel_malformed_records.store(30, Ordering::Relaxed);
-    metrics.nsel_forward_rows.store(31, Ordering::Relaxed);
+    metrics.udp_kernel_drops.store(102, Ordering::Relaxed);
+    metrics.udp_empty_packets.store(103, Ordering::Relaxed);
+    metrics.netflow_v5_packets.store(104, Ordering::Relaxed);
+    metrics.netflow_v7_packets.store(105, Ordering::Relaxed);
+    metrics.netflow_v9_packets.store(106, Ordering::Relaxed);
+    metrics.ipfix_packets.store(107, Ordering::Relaxed);
+    metrics.sflow_datagrams.store(108, Ordering::Relaxed);
+    metrics.v9_data_sets.store(109, Ordering::Relaxed);
+    metrics.v9_options_data_sets.store(110, Ordering::Relaxed);
+    metrics.v9_template_sets.store(111, Ordering::Relaxed);
+    metrics
+        .v9_options_template_sets
+        .store(112, Ordering::Relaxed);
+    metrics
+        .v9_missing_template_sets
+        .store(113, Ordering::Relaxed);
+    metrics.v9_ignored_sets.store(114, Ordering::Relaxed);
+    metrics.ipfix_data_sets.store(115, Ordering::Relaxed);
+    metrics
+        .ipfix_options_data_sets
+        .store(116, Ordering::Relaxed);
+    metrics.ipfix_template_sets.store(117, Ordering::Relaxed);
+    metrics
+        .ipfix_options_template_sets
+        .store(118, Ordering::Relaxed);
+    metrics
+        .ipfix_missing_template_sets
+        .store(119, Ordering::Relaxed);
+    metrics.ipfix_ignored_sets.store(120, Ordering::Relaxed);
+    metrics.v9_data_templates.store(121, Ordering::Relaxed);
+    metrics.v9_options_templates.store(122, Ordering::Relaxed);
+    metrics.ipfix_data_templates.store(123, Ordering::Relaxed);
+    metrics
+        .ipfix_options_templates
+        .store(124, Ordering::Relaxed);
+    metrics.netflow_v5_records.store(125, Ordering::Relaxed);
+    metrics.netflow_v7_records.store(126, Ordering::Relaxed);
+    metrics.netflow_v9_records.store(127, Ordering::Relaxed);
+    metrics.ipfix_records.store(128, Ordering::Relaxed);
+    metrics.v9_options_records.store(129, Ordering::Relaxed);
+    metrics.ipfix_options_records.store(130, Ordering::Relaxed);
+    metrics
+        .sampling_option_records
+        .store(131, Ordering::Relaxed);
+    metrics.sflow_flow_samples.store(132, Ordering::Relaxed);
+    metrics.sflow_counter_samples.store(133, Ordering::Relaxed);
+    metrics
+        .sflow_discarded_samples
+        .store(134, Ordering::Relaxed);
+    metrics
+        .sflow_rt_metric_samples
+        .store(135, Ordering::Relaxed);
+    metrics.sflow_rt_flow_samples.store(136, Ordering::Relaxed);
+    metrics.sflow_unknown_samples.store(137, Ordering::Relaxed);
+    metrics.udp_receive_errors.store(138, Ordering::Relaxed);
+    metrics
+        .udp_socket_setup_errors
+        .store(139, Ordering::Relaxed);
+    metrics.parse_errors.store(140, Ordering::Relaxed);
+    metrics.missing_template_sets.store(141, Ordering::Relaxed);
+    metrics
+        .disabled_protocol_packets
+        .store(142, Ordering::Relaxed);
+    metrics
+        .parser_source_evictions
+        .store(143, Ordering::Relaxed);
+    metrics
+        .partial_counter_records
+        .store(144, Ordering::Relaxed);
+    metrics
+        .decapsulation_failed_records
+        .store(145, Ordering::Relaxed);
+    metrics.unsupported_data_sets.store(146, Ordering::Relaxed);
+    metrics
+        .ipfix_zero_reverse_records
+        .store(147, Ordering::Relaxed);
+    metrics
+        .enrichment_filtered_rows
+        .store(148, Ordering::Relaxed);
+    metrics
+        .journal_entries_written
+        .store(149, Ordering::Relaxed);
+    metrics.journal_write_errors.store(150, Ordering::Relaxed);
+    metrics.decoded_rows.store(447, Ordering::Relaxed);
+    metrics.nsel_update_records.store(151, Ordering::Relaxed);
+    metrics.nsel_create_records.store(152, Ordering::Relaxed);
+    metrics.nsel_teardown_records.store(153, Ordering::Relaxed);
+    metrics.nsel_denied_records.store(154, Ordering::Relaxed);
+    metrics
+        .nsel_unsupported_event_records
+        .store(155, Ordering::Relaxed);
+    metrics.nsel_malformed_records.store(156, Ordering::Relaxed);
+    metrics.nsel_forward_rows.store(157, Ordering::Relaxed);
+    metrics.nsel_reverse_rows.store(158, Ordering::Relaxed);
     metrics
         .nsel_counterless_update_records
-        .store(32, Ordering::Relaxed);
-    metrics.decoded_rows.store(40, Ordering::Relaxed);
-    metrics.enrichment_filtered_rows.store(3, Ordering::Relaxed);
-    metrics.journal_write_errors.store(4, Ordering::Relaxed);
-    metrics.journal_entries_written.store(33, Ordering::Relaxed);
+        .store(159, Ordering::Relaxed);
+    metrics
+        .nsel_partial_counter_records
+        .store(160, Ordering::Relaxed);
+    metrics
+        .nsel_zero_responder_records
+        .store(161, Ordering::Relaxed);
+    metrics
+        .facet_active_update_errors
+        .store(162, Ordering::Relaxed);
+    metrics.facet_lifecycle_errors.store(163, Ordering::Relaxed);
+    metrics.facet_persist_errors.store(164, Ordering::Relaxed);
     metrics.raw_journal_syncs.store(44, Ordering::Relaxed);
     metrics
         .raw_journal_logical_bytes
@@ -287,33 +368,72 @@ fn snapshot_collects_current_metric_totals_and_open_rows() {
             },
         },
     );
-    assert_eq!(snapshot.input_packets.udp_received, 11);
-    assert_eq!(snapshot.input_packets.empty, 12);
-    assert_eq!(snapshot.input_packets.kernel_dropped, 13);
+    assert_eq!(snapshot.input_packets.udp_received, 101);
+    assert_eq!(snapshot.input_packets.kernel_dropped, 102);
+    assert_eq!(snapshot.input_packets.empty, 103);
     assert_eq!(snapshot.input_bytes.udp_received, 22);
-    assert_eq!(snapshot.protocol_packets.netflow_v5, 14);
-    assert_eq!(snapshot.protocol_packets.netflow_v7, 15);
-    assert_eq!(snapshot.protocol_packets.netflow_v9, 16);
-    assert_eq!(snapshot.protocol_packets.ipfix, 17);
-    assert_eq!(snapshot.protocol_packets.sflow, 18);
-    assert_eq!(snapshot.flow_sets.v9_data, 19);
-    assert_eq!(snapshot.flow_sets.ipfix_data, 20);
-    assert_eq!(snapshot.templates.v9_data, 21);
-    assert_eq!(snapshot.flow_records.netflow_v9, 22);
-    assert_eq!(snapshot.flow_records.ipfix, 23);
-    assert_eq!(snapshot.options_records.netflow_v9, 24);
-    assert_eq!(snapshot.options_records.sampling_data, 25);
-    assert_eq!(snapshot.sflow_samples.counter, 26);
-    assert_eq!(snapshot.decoder_exceptions.parse_errors, 27);
-    assert_eq!(snapshot.decoder_exceptions.missing_template_sets, 28);
-    assert_eq!(snapshot.nsel_events.update, 29);
-    assert_eq!(snapshot.nsel_events.malformed, 30);
-    assert_eq!(snapshot.nsel_rows.forward, 31);
-    assert_eq!(snapshot.nsel_exceptions.counterless_updates, 32);
-    assert_eq!(snapshot.flow_rows.decoded, 40);
-    assert_eq!(snapshot.flow_rows.classifier_filtered, 3);
-    assert_eq!(snapshot.flow_rows.journaled, 33);
-    assert_eq!(snapshot.flow_rows.write_failed, 4);
+    assert_eq!(snapshot.protocol_packets.netflow_v5, 104);
+    assert_eq!(snapshot.protocol_packets.netflow_v7, 105);
+    assert_eq!(snapshot.protocol_packets.netflow_v9, 106);
+    assert_eq!(snapshot.protocol_packets.ipfix, 107);
+    assert_eq!(snapshot.protocol_packets.sflow, 108);
+    assert_eq!(snapshot.flow_sets.v9_data, 109);
+    assert_eq!(snapshot.flow_sets.v9_options_data, 110);
+    assert_eq!(snapshot.flow_sets.v9_templates, 111);
+    assert_eq!(snapshot.flow_sets.v9_options_templates, 112);
+    assert_eq!(snapshot.flow_sets.v9_missing_template, 113);
+    assert_eq!(snapshot.flow_sets.v9_ignored, 114);
+    assert_eq!(snapshot.flow_sets.ipfix_data, 115);
+    assert_eq!(snapshot.flow_sets.ipfix_options_data, 116);
+    assert_eq!(snapshot.flow_sets.ipfix_templates, 117);
+    assert_eq!(snapshot.flow_sets.ipfix_options_templates, 118);
+    assert_eq!(snapshot.flow_sets.ipfix_missing_template, 119);
+    assert_eq!(snapshot.flow_sets.ipfix_ignored, 120);
+    assert_eq!(snapshot.templates.v9_data, 121);
+    assert_eq!(snapshot.templates.v9_options, 122);
+    assert_eq!(snapshot.templates.ipfix_data, 123);
+    assert_eq!(snapshot.templates.ipfix_options, 124);
+    assert_eq!(snapshot.flow_records.netflow_v5, 125);
+    assert_eq!(snapshot.flow_records.netflow_v7, 126);
+    assert_eq!(snapshot.flow_records.netflow_v9, 127);
+    assert_eq!(snapshot.flow_records.ipfix, 128);
+    assert_eq!(snapshot.options_records.netflow_v9, 129);
+    assert_eq!(snapshot.options_records.ipfix, 130);
+    assert_eq!(snapshot.options_records.sampling_data, 131);
+    assert_eq!(snapshot.sflow_samples.flow, 132);
+    assert_eq!(snapshot.sflow_samples.counter, 133);
+    assert_eq!(snapshot.sflow_samples.discarded_packet, 134);
+    assert_eq!(snapshot.sflow_samples.rt_metric, 135);
+    assert_eq!(snapshot.sflow_samples.rt_flow, 136);
+    assert_eq!(snapshot.sflow_samples.unknown, 137);
+    assert_eq!(snapshot.decoder_exceptions.udp_receive_errors, 138);
+    assert_eq!(snapshot.decoder_exceptions.udp_socket_setup_errors, 139);
+    assert_eq!(snapshot.decoder_exceptions.parse_errors, 140);
+    assert_eq!(snapshot.decoder_exceptions.missing_template_sets, 141);
+    assert_eq!(snapshot.decoder_exceptions.disabled_protocol_packets, 142);
+    assert_eq!(snapshot.decoder_exceptions.parser_source_evictions, 143);
+    assert_eq!(snapshot.decoder_exceptions.partial_counter_records, 144);
+    assert_eq!(
+        snapshot.decoder_exceptions.decapsulation_failed_records,
+        145
+    );
+    assert_eq!(snapshot.decoder_exceptions.unsupported_data_sets, 146);
+    assert_eq!(snapshot.decoder_exceptions.ipfix_zero_reverse_records, 147);
+    assert_eq!(snapshot.flow_rows.classifier_filtered, 148);
+    assert_eq!(snapshot.flow_rows.journaled, 149);
+    assert_eq!(snapshot.flow_rows.write_failed, 150);
+    assert_eq!(snapshot.flow_rows.decoded, 447);
+    assert_eq!(snapshot.nsel_events.update, 151);
+    assert_eq!(snapshot.nsel_events.create, 152);
+    assert_eq!(snapshot.nsel_events.teardown, 153);
+    assert_eq!(snapshot.nsel_events.denied, 154);
+    assert_eq!(snapshot.nsel_events.unsupported, 155);
+    assert_eq!(snapshot.nsel_events.malformed, 156);
+    assert_eq!(snapshot.nsel_rows.forward, 157);
+    assert_eq!(snapshot.nsel_rows.reverse, 158);
+    assert_eq!(snapshot.nsel_exceptions.counterless_updates, 159);
+    assert_eq!(snapshot.nsel_exceptions.partial_counter_directions, 160);
+    assert_eq!(snapshot.nsel_exceptions.zero_responder, 161);
     assert_eq!(
         snapshot.flow_rows.decoded,
         snapshot
@@ -322,7 +442,8 @@ fn snapshot_collects_current_metric_totals_and_open_rows() {
             .saturating_add(snapshot.flow_rows.journaled)
             .saturating_add(snapshot.flow_rows.write_failed)
     );
-    assert_eq!(snapshot.raw_journal_ops.entries_written, 33);
+    assert_eq!(snapshot.raw_journal_ops.entries_written, 149);
+    assert_eq!(snapshot.raw_journal_ops.write_errors, 150);
     assert_eq!(snapshot.raw_journal_ops.sync_calls, 44);
     assert_eq!(snapshot.raw_journal_bytes.logical_written, 55);
     assert_eq!(snapshot.materialized_tier_ops.minute_1_rows, 66);
@@ -331,6 +452,9 @@ fn snapshot_collects_current_metric_totals_and_open_rows() {
         77
     );
     assert_eq!(snapshot.journal_io_ops.decoder_state_persist_calls, 88);
+    assert_eq!(snapshot.journal_io_ops.facet_active_update_errors, 162);
+    assert_eq!(snapshot.journal_io_ops.facet_lifecycle_errors, 163);
+    assert_eq!(snapshot.journal_io_ops.facet_persist_errors, 164);
     assert_eq!(snapshot.journal_io_bytes.decoder_state_persist_bytes, 99);
     assert_eq!(snapshot.decoder_scopes.v9_sources, 5);
     assert_eq!(snapshot.decoder_scopes.ipfix_sources, 6);

--- a/src/crates/netflow-plugin/src/charts/tests.rs
+++ b/src/crates/netflow-plugin/src/charts/tests.rs
@@ -8,6 +8,54 @@ use rt::PluginRuntime;
 
 #[test]
 fn chart_metadata_uses_honest_contexts_and_units() {
+    let input = InputPacketsMetrics::chart_metadata();
+    assert_eq!(input.context, "netdata.netflow.input_packets");
+    assert_eq!(input.units, "packets/s");
+
+    let protocols = ProtocolPacketsMetrics::chart_metadata();
+    assert_eq!(protocols.context, "netdata.netflow.protocol_packets");
+    assert_eq!(protocols.units, "packets/s");
+
+    let sets = FlowSetMetrics::chart_metadata();
+    assert_eq!(sets.context, "netdata.netflow.flow_sets");
+    assert_eq!(sets.units, "sets/s");
+
+    let templates = TemplateMetrics::chart_metadata();
+    assert_eq!(templates.context, "netdata.netflow.templates");
+    assert_eq!(templates.units, "templates/s");
+
+    let records = FlowRecordMetrics::chart_metadata();
+    assert_eq!(records.context, "netdata.netflow.flow_records");
+    assert_eq!(records.units, "records/s");
+
+    let options = OptionsRecordMetrics::chart_metadata();
+    assert_eq!(options.context, "netdata.netflow.options_records");
+    assert_eq!(options.units, "records/s");
+
+    let samples = SflowSampleMetrics::chart_metadata();
+    assert_eq!(samples.context, "netdata.netflow.sflow_samples");
+    assert_eq!(samples.units, "samples/s");
+
+    let exceptions = DecoderExceptionMetrics::chart_metadata();
+    assert_eq!(exceptions.context, "netdata.netflow.decoder_exceptions");
+    assert_eq!(exceptions.units, "events/s");
+
+    let rows = FlowRowMetrics::chart_metadata();
+    assert_eq!(rows.context, "netdata.netflow.flow_rows");
+    assert_eq!(rows.units, "rows/s");
+
+    let nsel_events = NselEventMetrics::chart_metadata();
+    assert_eq!(nsel_events.context, "netdata.netflow.nsel_events");
+    assert_eq!(nsel_events.units, "records/s");
+
+    let nsel_rows = NselRowMetrics::chart_metadata();
+    assert_eq!(nsel_rows.context, "netdata.netflow.nsel_rows");
+    assert_eq!(nsel_rows.units, "rows/s");
+
+    let nsel_exceptions = NselExceptionMetrics::chart_metadata();
+    assert_eq!(nsel_exceptions.context, "netdata.netflow.nsel_exceptions");
+    assert_eq!(nsel_exceptions.units, "events/s");
+
     let raw_bytes = RawJournalBytesMetrics::chart_metadata();
     assert_eq!(raw_bytes.context, "netdata.netflow.raw_journal_bytes");
     assert_eq!(raw_bytes.family, "netflow");
@@ -120,6 +168,32 @@ fn snapshot_collects_current_metric_totals_and_open_rows() {
     let metrics = IngestMetrics::default();
     metrics.udp_packets_received.store(11, Ordering::Relaxed);
     metrics.udp_bytes_received.store(22, Ordering::Relaxed);
+    metrics.udp_empty_packets.store(12, Ordering::Relaxed);
+    metrics.udp_kernel_drops.store(13, Ordering::Relaxed);
+    metrics.netflow_v5_packets.store(14, Ordering::Relaxed);
+    metrics.netflow_v7_packets.store(15, Ordering::Relaxed);
+    metrics.netflow_v9_packets.store(16, Ordering::Relaxed);
+    metrics.ipfix_packets.store(17, Ordering::Relaxed);
+    metrics.sflow_datagrams.store(18, Ordering::Relaxed);
+    metrics.v9_data_sets.store(19, Ordering::Relaxed);
+    metrics.ipfix_data_sets.store(20, Ordering::Relaxed);
+    metrics.v9_data_templates.store(21, Ordering::Relaxed);
+    metrics.netflow_v9_records.store(22, Ordering::Relaxed);
+    metrics.ipfix_records.store(23, Ordering::Relaxed);
+    metrics.v9_options_records.store(24, Ordering::Relaxed);
+    metrics.sampling_option_records.store(25, Ordering::Relaxed);
+    metrics.sflow_counter_samples.store(26, Ordering::Relaxed);
+    metrics.parse_errors.store(27, Ordering::Relaxed);
+    metrics.missing_template_sets.store(28, Ordering::Relaxed);
+    metrics.nsel_update_records.store(29, Ordering::Relaxed);
+    metrics.nsel_malformed_records.store(30, Ordering::Relaxed);
+    metrics.nsel_forward_rows.store(31, Ordering::Relaxed);
+    metrics
+        .nsel_counterless_update_records
+        .store(32, Ordering::Relaxed);
+    metrics.decoded_rows.store(40, Ordering::Relaxed);
+    metrics.enrichment_filtered_rows.store(3, Ordering::Relaxed);
+    metrics.journal_write_errors.store(4, Ordering::Relaxed);
     metrics.journal_entries_written.store(33, Ordering::Relaxed);
     metrics.raw_journal_syncs.store(44, Ordering::Relaxed);
     metrics
@@ -214,7 +288,36 @@ fn snapshot_collects_current_metric_totals_and_open_rows() {
         },
     );
     assert_eq!(snapshot.input_packets.udp_received, 11);
+    assert_eq!(snapshot.input_packets.empty, 12);
+    assert_eq!(snapshot.input_packets.kernel_dropped, 13);
     assert_eq!(snapshot.input_bytes.udp_received, 22);
+    assert_eq!(snapshot.protocol_packets.netflow_v5, 14);
+    assert_eq!(snapshot.protocol_packets.netflow_v7, 15);
+    assert_eq!(snapshot.protocol_packets.netflow_v9, 16);
+    assert_eq!(snapshot.protocol_packets.ipfix, 17);
+    assert_eq!(snapshot.protocol_packets.sflow, 18);
+    assert_eq!(snapshot.flow_sets.v9_data, 19);
+    assert_eq!(snapshot.flow_sets.ipfix_data, 20);
+    assert_eq!(snapshot.templates.v9_data, 21);
+    assert_eq!(snapshot.flow_records.netflow_v9, 22);
+    assert_eq!(snapshot.flow_records.ipfix, 23);
+    assert_eq!(snapshot.options_records.netflow_v9, 24);
+    assert_eq!(snapshot.options_records.sampling_data, 25);
+    assert_eq!(snapshot.sflow_samples.counter, 26);
+    assert_eq!(snapshot.decoder_exceptions.parse_errors, 27);
+    assert_eq!(snapshot.decoder_exceptions.missing_template_sets, 28);
+    assert_eq!(snapshot.nsel_events.update, 29);
+    assert_eq!(snapshot.nsel_events.malformed, 30);
+    assert_eq!(snapshot.nsel_rows.forward, 31);
+    assert_eq!(snapshot.nsel_exceptions.counterless_updates, 32);
+    assert_eq!(
+        snapshot.flow_rows.decoded,
+        snapshot
+            .flow_rows
+            .classifier_filtered
+            .saturating_add(snapshot.flow_rows.journaled)
+            .saturating_add(snapshot.flow_rows.write_failed)
+    );
     assert_eq!(snapshot.raw_journal_ops.entries_written, 33);
     assert_eq!(snapshot.raw_journal_ops.sync_calls, 44);
     assert_eq!(snapshot.raw_journal_bytes.logical_written, 55);

--- a/src/crates/netflow-plugin/src/charts/tests.rs
+++ b/src/crates/netflow-plugin/src/charts/tests.rs
@@ -310,6 +310,10 @@ fn snapshot_collects_current_metric_totals_and_open_rows() {
     assert_eq!(snapshot.nsel_events.malformed, 30);
     assert_eq!(snapshot.nsel_rows.forward, 31);
     assert_eq!(snapshot.nsel_exceptions.counterless_updates, 32);
+    assert_eq!(snapshot.flow_rows.decoded, 40);
+    assert_eq!(snapshot.flow_rows.classifier_filtered, 3);
+    assert_eq!(snapshot.flow_rows.journaled, 33);
+    assert_eq!(snapshot.flow_rows.write_failed, 4);
     assert_eq!(
         snapshot.flow_rows.decoded,
         snapshot

--- a/src/crates/netflow-plugin/src/charts/udp.rs
+++ b/src/crates/netflow-plugin/src/charts/udp.rs
@@ -1,0 +1,85 @@
+use crate::ingest::IngestMetrics;
+#[cfg(any(target_os = "linux", test))]
+use std::collections::HashSet;
+#[cfg(target_os = "linux")]
+use std::sync::atomic::Ordering;
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_udp_socket_drops(contents: &str, listener_inodes: &HashSet<u64>) -> (u64, HashSet<u64>) {
+    let mut drops = 0_u64;
+    let mut found = HashSet::with_capacity(listener_inodes.len());
+
+    for line in contents.lines().skip(1) {
+        let mut columns = line.split_ascii_whitespace();
+        let (Some(inode), Some(socket_drops)) = (columns.nth(9), columns.nth(2)) else {
+            continue;
+        };
+        let (Ok(inode), Ok(socket_drops)) = (inode.parse::<u64>(), socket_drops.parse::<u64>())
+        else {
+            continue;
+        };
+        if listener_inodes.contains(&inode) && found.insert(inode) {
+            drops = drops.saturating_add(socket_drops);
+        }
+    }
+
+    (drops, found)
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn sample_udp_kernel_drops(metrics: &IngestMetrics) {
+    let listener_inodes: HashSet<u64> = metrics.udp_listener_socket_inodes().into_iter().collect();
+    if listener_inodes.is_empty() {
+        return;
+    }
+
+    let mut drops = 0_u64;
+    let mut found = HashSet::with_capacity(listener_inodes.len());
+    for path in ["/proc/net/udp", "/proc/net/udp6"] {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let (file_drops, file_found) = parse_udp_socket_drops(&contents, &listener_inodes);
+        drops = drops.saturating_add(file_drops);
+        found.extend(file_found);
+    }
+
+    if found.len() == listener_inodes.len() {
+        metrics.udp_kernel_drops.store(drops, Ordering::Relaxed);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(super) fn sample_udp_kernel_drops(_metrics: &IngestMetrics) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROC_NET_UDP: &str = "\
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops
+  11: 0100007F:0801 00000000:0000 07 00000000:00000000 00:00000000 00000000  1000        0 111 2 0000000000000000 7
+  12: 0100007F:0802 00000000:0000 07 00000000:00000000 00:00000000 00000000  1000        0 222 2 0000000000000000 9
+  13: 0100007F:0803 00000000:0000 07 00000000:00000000 00:00000000 00000000  1000        0 broken 2 0000000000000000 5
+malformed
+";
+
+    #[test]
+    fn parses_only_exact_listener_socket_inodes() {
+        let listeners = HashSet::from([111_u64, 333_u64]);
+        let (drops, found) = parse_udp_socket_drops(PROC_NET_UDP, &listeners);
+
+        assert_eq!(drops, 7);
+        assert_eq!(found, HashSet::from([111]));
+    }
+
+    #[test]
+    fn does_not_count_one_socket_twice() {
+        let duplicated = format!("{PROC_NET_UDP}{}", PROC_NET_UDP.lines().nth(1).unwrap());
+        let listeners = HashSet::from([111_u64]);
+        let (drops, found) = parse_udp_socket_drops(&duplicated, &listeners);
+
+        assert_eq!(drops, 7);
+        assert_eq!(found, HashSet::from([111]));
+    }
+}

--- a/src/crates/netflow-plugin/src/decoder.rs
+++ b/src/crates/netflow-plugin/src/decoder.rs
@@ -102,9 +102,44 @@ pub(crate) struct DecodeStats {
     pub(crate) parse_attempts: u64,
     pub(crate) parsed_packets: u64,
     pub(crate) parse_errors: u64,
-    pub(crate) template_errors: u64,
+    pub(crate) missing_template_sets: u64,
+    pub(crate) disabled_protocol_packets: u64,
     pub(crate) parser_source_evictions: u64,
     pub(crate) partial_counter_records: u64,
+    pub(crate) decapsulation_failed_records: u64,
+    pub(crate) sampling_option_records: u64,
+    pub(crate) unsupported_data_sets: u64,
+    pub(crate) decoded_rows: u64,
+    pub(crate) enrichment_filtered_rows: u64,
+    pub(crate) ipfix_zero_reverse_records: u64,
+    pub(crate) v9_data_sets: u64,
+    pub(crate) v9_options_data_sets: u64,
+    pub(crate) v9_template_sets: u64,
+    pub(crate) v9_options_template_sets: u64,
+    pub(crate) v9_missing_template_sets: u64,
+    pub(crate) v9_ignored_sets: u64,
+    pub(crate) ipfix_data_sets: u64,
+    pub(crate) ipfix_options_data_sets: u64,
+    pub(crate) ipfix_template_sets: u64,
+    pub(crate) ipfix_options_template_sets: u64,
+    pub(crate) ipfix_missing_template_sets: u64,
+    pub(crate) ipfix_ignored_sets: u64,
+    pub(crate) v9_data_templates: u64,
+    pub(crate) v9_options_templates: u64,
+    pub(crate) ipfix_data_templates: u64,
+    pub(crate) ipfix_options_templates: u64,
+    pub(crate) netflow_v5_records: u64,
+    pub(crate) netflow_v7_records: u64,
+    pub(crate) netflow_v9_records: u64,
+    pub(crate) ipfix_records: u64,
+    pub(crate) v9_options_records: u64,
+    pub(crate) ipfix_options_records: u64,
+    pub(crate) sflow_flow_samples: u64,
+    pub(crate) sflow_counter_samples: u64,
+    pub(crate) sflow_discarded_samples: u64,
+    pub(crate) sflow_rt_metric_samples: u64,
+    pub(crate) sflow_rt_flow_samples: u64,
+    pub(crate) sflow_unknown_samples: u64,
     pub(crate) nsel_records: u64,
     pub(crate) nsel_update_records: u64,
     pub(crate) nsel_create_records: u64,
@@ -129,9 +164,44 @@ impl DecodeStats {
         self.parse_attempts += other.parse_attempts;
         self.parsed_packets += other.parsed_packets;
         self.parse_errors += other.parse_errors;
-        self.template_errors += other.template_errors;
+        self.missing_template_sets += other.missing_template_sets;
+        self.disabled_protocol_packets += other.disabled_protocol_packets;
         self.parser_source_evictions += other.parser_source_evictions;
         self.partial_counter_records += other.partial_counter_records;
+        self.decapsulation_failed_records += other.decapsulation_failed_records;
+        self.sampling_option_records += other.sampling_option_records;
+        self.unsupported_data_sets += other.unsupported_data_sets;
+        self.decoded_rows += other.decoded_rows;
+        self.enrichment_filtered_rows += other.enrichment_filtered_rows;
+        self.ipfix_zero_reverse_records += other.ipfix_zero_reverse_records;
+        self.v9_data_sets += other.v9_data_sets;
+        self.v9_options_data_sets += other.v9_options_data_sets;
+        self.v9_template_sets += other.v9_template_sets;
+        self.v9_options_template_sets += other.v9_options_template_sets;
+        self.v9_missing_template_sets += other.v9_missing_template_sets;
+        self.v9_ignored_sets += other.v9_ignored_sets;
+        self.ipfix_data_sets += other.ipfix_data_sets;
+        self.ipfix_options_data_sets += other.ipfix_options_data_sets;
+        self.ipfix_template_sets += other.ipfix_template_sets;
+        self.ipfix_options_template_sets += other.ipfix_options_template_sets;
+        self.ipfix_missing_template_sets += other.ipfix_missing_template_sets;
+        self.ipfix_ignored_sets += other.ipfix_ignored_sets;
+        self.v9_data_templates += other.v9_data_templates;
+        self.v9_options_templates += other.v9_options_templates;
+        self.ipfix_data_templates += other.ipfix_data_templates;
+        self.ipfix_options_templates += other.ipfix_options_templates;
+        self.netflow_v5_records += other.netflow_v5_records;
+        self.netflow_v7_records += other.netflow_v7_records;
+        self.netflow_v9_records += other.netflow_v9_records;
+        self.ipfix_records += other.ipfix_records;
+        self.v9_options_records += other.v9_options_records;
+        self.ipfix_options_records += other.ipfix_options_records;
+        self.sflow_flow_samples += other.sflow_flow_samples;
+        self.sflow_counter_samples += other.sflow_counter_samples;
+        self.sflow_discarded_samples += other.sflow_discarded_samples;
+        self.sflow_rt_metric_samples += other.sflow_rt_metric_samples;
+        self.sflow_rt_flow_samples += other.sflow_rt_flow_samples;
+        self.sflow_unknown_samples += other.sflow_unknown_samples;
         self.nsel_records += other.nsel_records;
         self.nsel_update_records += other.nsel_update_records;
         self.nsel_create_records += other.nsel_create_records;

--- a/src/crates/netflow-plugin/src/decoder/protocol/entry.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/entry.rs
@@ -48,87 +48,6 @@ pub(crate) fn decode_sflow(
     batch
 }
 
-fn account_disabled_v9_packet(packet: &V9, stats: &mut DecodeStats) {
-    for flowset in &packet.flowsets {
-        match &flowset.body {
-            V9FlowSetBody::Template(templates) => {
-                stats.v9_template_sets += 1;
-                stats.v9_data_templates += templates.templates.len() as u64;
-            }
-            V9FlowSetBody::OptionsTemplate(templates) => {
-                stats.v9_options_template_sets += 1;
-                stats.v9_options_templates += templates.templates.len() as u64;
-            }
-            V9FlowSetBody::Data(data) => {
-                stats.v9_data_sets += 1;
-                stats.netflow_v9_records += data.fields.len() as u64;
-            }
-            V9FlowSetBody::OptionsData(data) => {
-                stats.v9_options_data_sets += 1;
-                stats.v9_options_records += data.fields.len() as u64;
-            }
-            V9FlowSetBody::NoTemplate(_) => {
-                stats.v9_missing_template_sets += 1;
-                stats.missing_template_sets += 1;
-            }
-            V9FlowSetBody::Empty => stats.v9_ignored_sets += 1,
-        }
-    }
-}
-
-fn account_disabled_ipfix_packet(packet: &IPFix, stats: &mut DecodeStats) {
-    for flowset in &packet.flowsets {
-        match &flowset.body {
-            IPFixFlowSetBody::Template(_) | IPFixFlowSetBody::V9Template(_) => {
-                stats.ipfix_template_sets += 1;
-                stats.ipfix_data_templates += 1;
-            }
-            IPFixFlowSetBody::Templates(templates) => {
-                stats.ipfix_template_sets += 1;
-                stats.ipfix_data_templates += templates.len() as u64;
-            }
-            IPFixFlowSetBody::V9Templates(templates) => {
-                stats.ipfix_template_sets += 1;
-                stats.ipfix_data_templates += templates.len() as u64;
-            }
-            IPFixFlowSetBody::OptionsTemplate(_) | IPFixFlowSetBody::V9OptionsTemplate(_) => {
-                stats.ipfix_options_template_sets += 1;
-                stats.ipfix_options_templates += 1;
-            }
-            IPFixFlowSetBody::OptionsTemplates(templates) => {
-                stats.ipfix_options_template_sets += 1;
-                stats.ipfix_options_templates += templates.len() as u64;
-            }
-            IPFixFlowSetBody::V9OptionsTemplates(templates) => {
-                stats.ipfix_options_template_sets += 1;
-                stats.ipfix_options_templates += templates.len() as u64;
-            }
-            IPFixFlowSetBody::Data(data) => {
-                stats.ipfix_data_sets += 1;
-                stats.ipfix_records += data.fields.len() as u64;
-            }
-            IPFixFlowSetBody::V9Data(data) => {
-                stats.ipfix_data_sets += 1;
-                stats.ipfix_records += data.fields.len() as u64;
-                stats.unsupported_data_sets += 1;
-            }
-            IPFixFlowSetBody::OptionsData(data) => {
-                stats.ipfix_options_data_sets += 1;
-                stats.ipfix_options_records += data.fields.len() as u64;
-            }
-            IPFixFlowSetBody::V9OptionsData(data) => {
-                stats.ipfix_options_data_sets += 1;
-                stats.ipfix_options_records += data.fields.len() as u64;
-            }
-            IPFixFlowSetBody::NoTemplate(_) => {
-                stats.ipfix_missing_template_sets += 1;
-                stats.missing_template_sets += 1;
-            }
-            IPFixFlowSetBody::Empty => stats.ipfix_ignored_sets += 1,
-        }
-    }
-}
-
 pub(crate) fn decode_netflow_result(
     result: ParseResult,
     sampling: &mut SamplingState,
@@ -202,7 +121,7 @@ pub(crate) fn decode_netflow_result(
                     );
                 } else {
                     batch.stats.disabled_protocol_packets += 1;
-                    account_disabled_v9_packet(&v9, &mut batch.stats);
+                    account_v9_packet(&v9, &mut batch.stats);
                 }
             }
             NetflowPacket::IPFix(ipfix) => {
@@ -219,7 +138,7 @@ pub(crate) fn decode_netflow_result(
                     );
                 } else {
                     batch.stats.disabled_protocol_packets += 1;
-                    account_disabled_ipfix_packet(&ipfix, &mut batch.stats);
+                    account_ipfix_packet(&ipfix, &mut batch.stats);
                 }
             }
             _ => {}

--- a/src/crates/netflow-plugin/src/decoder/protocol/entry.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/entry.rs
@@ -10,6 +10,7 @@ pub(crate) fn is_sflow_payload(payload: &[u8]) -> bool {
 pub(crate) fn decode_sflow(
     source: SocketAddr,
     payload: &[u8],
+    enabled: bool,
     decapsulation_mode: DecapsulationMode,
     timestamp_source: TimestampSource,
     input_realtime_usec: u64,
@@ -26,12 +27,17 @@ pub(crate) fn decode_sflow(
         Ok(datagram) => {
             batch.stats.parsed_packets = 1;
             batch.stats.sflow_datagrams = 1;
+            if !enabled {
+                batch.stats.disabled_protocol_packets = 1;
+            }
             batch.flows = extract_sflow_flows(
                 source,
                 datagram,
                 decapsulation_mode,
                 timestamp_source,
                 input_realtime_usec,
+                enabled,
+                &mut batch.stats,
             );
         }
         Err(_err) => {
@@ -42,28 +48,85 @@ pub(crate) fn decode_sflow(
     batch
 }
 
-pub(crate) fn missing_template_ids(packets: &[NetflowPacket]) -> HashSet<u16> {
-    let mut ids = HashSet::new();
-    for packet in packets {
-        match packet {
-            NetflowPacket::V9(packet) => {
-                for flowset in &packet.flowsets {
-                    if let V9FlowSetBody::NoTemplate(info) = &flowset.body {
-                        ids.insert(info.template_id);
-                    }
-                }
+fn account_disabled_v9_packet(packet: &V9, stats: &mut DecodeStats) {
+    for flowset in &packet.flowsets {
+        match &flowset.body {
+            V9FlowSetBody::Template(templates) => {
+                stats.v9_template_sets += 1;
+                stats.v9_data_templates += templates.templates.len() as u64;
             }
-            NetflowPacket::IPFix(packet) => {
-                for flowset in &packet.flowsets {
-                    if let IPFixFlowSetBody::NoTemplate(info) = &flowset.body {
-                        ids.insert(info.template_id);
-                    }
-                }
+            V9FlowSetBody::OptionsTemplate(templates) => {
+                stats.v9_options_template_sets += 1;
+                stats.v9_options_templates += templates.templates.len() as u64;
             }
-            _ => {}
+            V9FlowSetBody::Data(data) => {
+                stats.v9_data_sets += 1;
+                stats.netflow_v9_records += data.fields.len() as u64;
+            }
+            V9FlowSetBody::OptionsData(data) => {
+                stats.v9_options_data_sets += 1;
+                stats.v9_options_records += data.fields.len() as u64;
+            }
+            V9FlowSetBody::NoTemplate(_) => {
+                stats.v9_missing_template_sets += 1;
+                stats.missing_template_sets += 1;
+            }
+            V9FlowSetBody::Empty => stats.v9_ignored_sets += 1,
         }
     }
-    ids
+}
+
+fn account_disabled_ipfix_packet(packet: &IPFix, stats: &mut DecodeStats) {
+    for flowset in &packet.flowsets {
+        match &flowset.body {
+            IPFixFlowSetBody::Template(_) | IPFixFlowSetBody::V9Template(_) => {
+                stats.ipfix_template_sets += 1;
+                stats.ipfix_data_templates += 1;
+            }
+            IPFixFlowSetBody::Templates(templates) => {
+                stats.ipfix_template_sets += 1;
+                stats.ipfix_data_templates += templates.len() as u64;
+            }
+            IPFixFlowSetBody::V9Templates(templates) => {
+                stats.ipfix_template_sets += 1;
+                stats.ipfix_data_templates += templates.len() as u64;
+            }
+            IPFixFlowSetBody::OptionsTemplate(_) | IPFixFlowSetBody::V9OptionsTemplate(_) => {
+                stats.ipfix_options_template_sets += 1;
+                stats.ipfix_options_templates += 1;
+            }
+            IPFixFlowSetBody::OptionsTemplates(templates) => {
+                stats.ipfix_options_template_sets += 1;
+                stats.ipfix_options_templates += templates.len() as u64;
+            }
+            IPFixFlowSetBody::V9OptionsTemplates(templates) => {
+                stats.ipfix_options_template_sets += 1;
+                stats.ipfix_options_templates += templates.len() as u64;
+            }
+            IPFixFlowSetBody::Data(data) => {
+                stats.ipfix_data_sets += 1;
+                stats.ipfix_records += data.fields.len() as u64;
+            }
+            IPFixFlowSetBody::V9Data(data) => {
+                stats.ipfix_data_sets += 1;
+                stats.ipfix_records += data.fields.len() as u64;
+                stats.unsupported_data_sets += 1;
+            }
+            IPFixFlowSetBody::OptionsData(data) => {
+                stats.ipfix_options_data_sets += 1;
+                stats.ipfix_options_records += data.fields.len() as u64;
+            }
+            IPFixFlowSetBody::V9OptionsData(data) => {
+                stats.ipfix_options_data_sets += 1;
+                stats.ipfix_options_records += data.fields.len() as u64;
+            }
+            IPFixFlowSetBody::NoTemplate(_) => {
+                stats.ipfix_missing_template_sets += 1;
+                stats.missing_template_sets += 1;
+            }
+            IPFixFlowSetBody::Empty => stats.ipfix_ignored_sets += 1,
+        }
+    }
 }
 
 pub(crate) fn decode_netflow_result(
@@ -88,15 +151,13 @@ pub(crate) fn decode_netflow_result(
         ..Default::default()
     };
 
-    if !missing_template_ids(&result.packets).is_empty() {
-        batch.stats.template_errors = 1;
-    }
     batch.stats.parsed_packets = result.packets.len() as u64;
     for (packet_index, packet) in result.packets.into_iter().enumerate() {
         match packet {
             NetflowPacket::V5(v5) => {
+                batch.stats.netflow_v5_packets += 1;
+                batch.stats.netflow_v5_records += v5.flowsets.len() as u64;
                 if enable_v5 {
-                    batch.stats.netflow_v5_packets += 1;
                     append_v5_records(
                         source,
                         &mut batch.flows,
@@ -104,11 +165,14 @@ pub(crate) fn decode_netflow_result(
                         timestamp_source,
                         input_realtime_usec,
                     );
+                } else {
+                    batch.stats.disabled_protocol_packets += 1;
                 }
             }
             NetflowPacket::V7(v7) => {
+                batch.stats.netflow_v7_packets += 1;
+                batch.stats.netflow_v7_records += v7.flowsets.len() as u64;
                 if enable_v7 {
-                    batch.stats.netflow_v7_packets += 1;
                     append_v7_records(
                         source,
                         &mut batch.flows,
@@ -116,11 +180,13 @@ pub(crate) fn decode_netflow_result(
                         timestamp_source,
                         input_realtime_usec,
                     );
+                } else {
+                    batch.stats.disabled_protocol_packets += 1;
                 }
             }
             NetflowPacket::V9(v9) => {
+                batch.stats.netflow_v9_packets += 1;
                 if enable_v9 {
-                    batch.stats.netflow_v9_packets += 1;
                     append_v9_records(
                         source,
                         &mut batch.flows,
@@ -134,20 +200,26 @@ pub(crate) fn decode_netflow_result(
                         input_realtime_usec,
                         &mut batch.stats,
                     );
+                } else {
+                    batch.stats.disabled_protocol_packets += 1;
+                    account_disabled_v9_packet(&v9, &mut batch.stats);
                 }
             }
             NetflowPacket::IPFix(ipfix) => {
+                batch.stats.ipfix_packets += 1;
                 if enable_ipfix {
-                    batch.stats.ipfix_packets += 1;
-                    batch.stats.partial_counter_records += append_ipfix_records(
+                    append_ipfix_records(
                         source,
-                        &mut batch.flows,
+                        &mut batch,
                         ipfix,
                         sampling,
                         decapsulation_mode,
                         timestamp_source,
                         input_realtime_usec,
                     );
+                } else {
+                    batch.stats.disabled_protocol_packets += 1;
+                    account_disabled_ipfix_packet(&ipfix, &mut batch.stats);
                 }
             }
             _ => {}
@@ -156,7 +228,12 @@ pub(crate) fn decode_netflow_result(
 
     if let Some(err) = result.error {
         if is_template_error(&err.to_string()) {
-            batch.stats.template_errors = 1;
+            // Most missing templates are represented by an exact NoTemplate
+            // Set above. A parser-level template error has no Set object, so
+            // account for one unresolved Set only when none was returned.
+            if batch.stats.missing_template_sets == 0 {
+                batch.stats.missing_template_sets = 1;
+            }
         } else {
             batch.stats.parse_errors = 1;
         }

--- a/src/crates/netflow-plugin/src/decoder/protocol/ipfix.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/ipfix.rs
@@ -1,7 +1,9 @@
 use super::*;
 
+mod accounting;
 mod record;
 mod templates;
 
+pub(crate) use accounting::*;
 pub(crate) use record::*;
 pub(crate) use templates::*;

--- a/src/crates/netflow-plugin/src/decoder/protocol/ipfix/accounting.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/ipfix/accounting.rs
@@ -1,0 +1,58 @@
+use super::super::*;
+
+pub(crate) fn account_ipfix_flowset(body: &IPFixFlowSetBody, stats: &mut DecodeStats) {
+    match body {
+        IPFixFlowSetBody::Template(_) | IPFixFlowSetBody::V9Template(_) => {
+            stats.ipfix_template_sets += 1;
+            stats.ipfix_data_templates += 1;
+        }
+        IPFixFlowSetBody::Templates(templates) => {
+            stats.ipfix_template_sets += 1;
+            stats.ipfix_data_templates += templates.len() as u64;
+        }
+        IPFixFlowSetBody::V9Templates(templates) => {
+            stats.ipfix_template_sets += 1;
+            stats.ipfix_data_templates += templates.len() as u64;
+        }
+        IPFixFlowSetBody::OptionsTemplate(_) | IPFixFlowSetBody::V9OptionsTemplate(_) => {
+            stats.ipfix_options_template_sets += 1;
+            stats.ipfix_options_templates += 1;
+        }
+        IPFixFlowSetBody::OptionsTemplates(templates) => {
+            stats.ipfix_options_template_sets += 1;
+            stats.ipfix_options_templates += templates.len() as u64;
+        }
+        IPFixFlowSetBody::V9OptionsTemplates(templates) => {
+            stats.ipfix_options_template_sets += 1;
+            stats.ipfix_options_templates += templates.len() as u64;
+        }
+        IPFixFlowSetBody::Data(data) => {
+            stats.ipfix_data_sets += 1;
+            stats.ipfix_records += data.fields.len() as u64;
+        }
+        IPFixFlowSetBody::V9Data(data) => {
+            stats.ipfix_data_sets += 1;
+            stats.ipfix_records += data.fields.len() as u64;
+            stats.unsupported_data_sets += 1;
+        }
+        IPFixFlowSetBody::OptionsData(data) => {
+            stats.ipfix_options_data_sets += 1;
+            stats.ipfix_options_records += data.fields.len() as u64;
+        }
+        IPFixFlowSetBody::V9OptionsData(data) => {
+            stats.ipfix_options_data_sets += 1;
+            stats.ipfix_options_records += data.fields.len() as u64;
+        }
+        IPFixFlowSetBody::NoTemplate(_) => {
+            stats.ipfix_missing_template_sets += 1;
+            stats.missing_template_sets += 1;
+        }
+        IPFixFlowSetBody::Empty => stats.ipfix_ignored_sets += 1,
+    }
+}
+
+pub(crate) fn account_ipfix_packet(packet: &IPFix, stats: &mut DecodeStats) {
+    for flowset in &packet.flowsets {
+        account_ipfix_flowset(&flowset.body, stats);
+    }
+}

--- a/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record.rs
@@ -7,5 +7,5 @@ mod state;
 
 pub(crate) use append::append_ipfix_records;
 pub(crate) use fields::apply_ipfix_record_field;
-pub(crate) use finalize::finalize_ipfix_record;
+pub(crate) use finalize::{IPFixRecordRejection, finalize_ipfix_record};
 pub(crate) use state::IPFixRecordBuildState;

--- a/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/append.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/append.rs
@@ -2,14 +2,14 @@ use super::*;
 
 pub(crate) fn append_ipfix_records(
     source: SocketAddr,
-    out: &mut Vec<DecodedFlow>,
+    batch: &mut DecodedBatch,
     packet: IPFix,
     sampling: &mut SamplingState,
     decapsulation_mode: DecapsulationMode,
     timestamp_source: TimestampSource,
     input_realtime_usec: u64,
-) -> u64 {
-    let mut partial_counter_records = 0_u64;
+) {
+    let DecodedBatch { flows: out, stats } = batch;
     let export_usec = unix_timestamp_to_usec(packet.header.export_time as u64, 0);
     let observation_domain_id = packet.header.observation_domain_id;
     let version = 10_u16;
@@ -17,6 +17,8 @@ pub(crate) fn append_ipfix_records(
     for flowset in packet.flowsets {
         match flowset.body {
             IPFixFlowSetBody::Data(data) => {
+                stats.ipfix_data_sets += 1;
+                stats.ipfix_records += data.fields.len() as u64;
                 for record in data.fields {
                     let mut rec = base_record("ipfix", source);
                     let mut state = IPFixRecordBuildState::default();
@@ -32,6 +34,12 @@ pub(crate) fn append_ipfix_records(
                         );
                     }
 
+                    let sampling_option_record = looks_like_sampling_option_record_from_rec(
+                        &rec,
+                        state.observed_sampling_rate,
+                    );
+                    let decapsulation_failed = state.decap_required && !state.decap_ok;
+                    let reverse_present = state.reverse_present;
                     let Some((forward, reverse, partial_counter_record)) = finalize_ipfix_record(
                         rec,
                         state,
@@ -43,11 +51,19 @@ pub(crate) fn append_ipfix_records(
                         timestamp_source,
                         input_realtime_usec,
                     ) else {
+                        if sampling_option_record {
+                            stats.sampling_option_records += 1;
+                        } else if decapsulation_failed {
+                            stats.decapsulation_failed_records += 1;
+                        }
                         continue;
                     };
 
                     if partial_counter_record {
-                        partial_counter_records += 1;
+                        stats.partial_counter_records += 1;
+                    }
+                    if reverse_present && reverse.is_none() {
+                        stats.ipfix_zero_reverse_records += 1;
                     }
 
                     out.push(forward);
@@ -56,9 +72,50 @@ pub(crate) fn append_ipfix_records(
                     }
                 }
             }
-            _ => continue,
+            IPFixFlowSetBody::V9Data(data) => {
+                stats.ipfix_data_sets += 1;
+                stats.ipfix_records += data.fields.len() as u64;
+                stats.unsupported_data_sets += 1;
+            }
+            IPFixFlowSetBody::OptionsData(data) => {
+                stats.ipfix_options_data_sets += 1;
+                stats.ipfix_options_records += data.fields.len() as u64;
+            }
+            IPFixFlowSetBody::V9OptionsData(data) => {
+                stats.ipfix_options_data_sets += 1;
+                stats.ipfix_options_records += data.fields.len() as u64;
+            }
+            IPFixFlowSetBody::Template(_) | IPFixFlowSetBody::V9Template(_) => {
+                stats.ipfix_template_sets += 1;
+                stats.ipfix_data_templates += 1;
+            }
+            IPFixFlowSetBody::Templates(templates) => {
+                stats.ipfix_template_sets += 1;
+                stats.ipfix_data_templates += templates.len() as u64;
+            }
+            IPFixFlowSetBody::V9Templates(templates) => {
+                stats.ipfix_template_sets += 1;
+                stats.ipfix_data_templates += templates.len() as u64;
+            }
+            IPFixFlowSetBody::OptionsTemplate(_) | IPFixFlowSetBody::V9OptionsTemplate(_) => {
+                stats.ipfix_options_template_sets += 1;
+                stats.ipfix_options_templates += 1;
+            }
+            IPFixFlowSetBody::OptionsTemplates(templates) => {
+                stats.ipfix_options_template_sets += 1;
+                stats.ipfix_options_templates += templates.len() as u64;
+            }
+            IPFixFlowSetBody::V9OptionsTemplates(templates) => {
+                stats.ipfix_options_template_sets += 1;
+                stats.ipfix_options_templates += templates.len() as u64;
+            }
+            IPFixFlowSetBody::NoTemplate(_) => {
+                stats.ipfix_missing_template_sets += 1;
+                stats.missing_template_sets += 1;
+            }
+            IPFixFlowSetBody::Empty => {
+                stats.ipfix_ignored_sets += 1;
+            }
         }
     }
-
-    partial_counter_records
 }

--- a/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/append.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/append.rs
@@ -15,10 +15,9 @@ pub(crate) fn append_ipfix_records(
     let version = 10_u16;
 
     for flowset in packet.flowsets {
+        account_ipfix_flowset(&flowset.body, stats);
         match flowset.body {
             IPFixFlowSetBody::Data(data) => {
-                stats.ipfix_data_sets += 1;
-                stats.ipfix_records += data.fields.len() as u64;
                 for record in data.fields {
                     let mut rec = base_record("ipfix", source);
                     let mut state = IPFixRecordBuildState::default();
@@ -72,50 +71,7 @@ pub(crate) fn append_ipfix_records(
                     }
                 }
             }
-            IPFixFlowSetBody::V9Data(data) => {
-                stats.ipfix_data_sets += 1;
-                stats.ipfix_records += data.fields.len() as u64;
-                stats.unsupported_data_sets += 1;
-            }
-            IPFixFlowSetBody::OptionsData(data) => {
-                stats.ipfix_options_data_sets += 1;
-                stats.ipfix_options_records += data.fields.len() as u64;
-            }
-            IPFixFlowSetBody::V9OptionsData(data) => {
-                stats.ipfix_options_data_sets += 1;
-                stats.ipfix_options_records += data.fields.len() as u64;
-            }
-            IPFixFlowSetBody::Template(_) | IPFixFlowSetBody::V9Template(_) => {
-                stats.ipfix_template_sets += 1;
-                stats.ipfix_data_templates += 1;
-            }
-            IPFixFlowSetBody::Templates(templates) => {
-                stats.ipfix_template_sets += 1;
-                stats.ipfix_data_templates += templates.len() as u64;
-            }
-            IPFixFlowSetBody::V9Templates(templates) => {
-                stats.ipfix_template_sets += 1;
-                stats.ipfix_data_templates += templates.len() as u64;
-            }
-            IPFixFlowSetBody::OptionsTemplate(_) | IPFixFlowSetBody::V9OptionsTemplate(_) => {
-                stats.ipfix_options_template_sets += 1;
-                stats.ipfix_options_templates += 1;
-            }
-            IPFixFlowSetBody::OptionsTemplates(templates) => {
-                stats.ipfix_options_template_sets += 1;
-                stats.ipfix_options_templates += templates.len() as u64;
-            }
-            IPFixFlowSetBody::V9OptionsTemplates(templates) => {
-                stats.ipfix_options_template_sets += 1;
-                stats.ipfix_options_templates += templates.len() as u64;
-            }
-            IPFixFlowSetBody::NoTemplate(_) => {
-                stats.ipfix_missing_template_sets += 1;
-                stats.missing_template_sets += 1;
-            }
-            IPFixFlowSetBody::Empty => {
-                stats.ipfix_ignored_sets += 1;
-            }
+            _ => {}
         }
     }
 }

--- a/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/append.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/append.rs
@@ -33,13 +33,8 @@ pub(crate) fn append_ipfix_records(
                         );
                     }
 
-                    let sampling_option_record = looks_like_sampling_option_record_from_rec(
-                        &rec,
-                        state.observed_sampling_rate,
-                    );
-                    let decapsulation_failed = state.decap_required && !state.decap_ok;
                     let reverse_present = state.reverse_present;
-                    let Some((forward, reverse, partial_counter_record)) = finalize_ipfix_record(
+                    let projection = finalize_ipfix_record(
                         rec,
                         state,
                         source,
@@ -49,13 +44,17 @@ pub(crate) fn append_ipfix_records(
                         export_usec,
                         timestamp_source,
                         input_realtime_usec,
-                    ) else {
-                        if sampling_option_record {
+                    );
+                    let (forward, reverse, partial_counter_record) = match projection {
+                        Ok(projected) => projected,
+                        Err(IPFixRecordRejection::SamplingOption) => {
                             stats.sampling_option_records += 1;
-                        } else if decapsulation_failed {
-                            stats.decapsulation_failed_records += 1;
+                            continue;
                         }
-                        continue;
+                        Err(IPFixRecordRejection::DecapsulationFailed) => {
+                            stats.decapsulation_failed_records += 1;
+                            continue;
+                        }
                     };
 
                     if partial_counter_record {

--- a/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/finalize.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/ipfix/record/finalize.rs
@@ -1,6 +1,12 @@
 use super::state::IPFixRecordBuildState;
 use super::*;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IPFixRecordRejection {
+    SamplingOption,
+    DecapsulationFailed,
+}
+
 fn reverse_metric_value(reverse_overrides: &FlowFields, key: &'static str) -> u64 {
     reverse_overrides
         .get(key)
@@ -50,7 +56,7 @@ pub(crate) fn finalize_ipfix_record(
     export_usec: u64,
     timestamp_source: TimestampSource,
     input_realtime_usec: u64,
-) -> Option<(DecodedFlow, Option<DecodedFlow>, bool)> {
+) -> Result<(DecodedFlow, Option<DecodedFlow>, bool), IPFixRecordRejection> {
     state.apply_sampling_packet_ratio();
     apply_sampling_state_record(
         &mut rec,
@@ -63,10 +69,10 @@ pub(crate) fn finalize_ipfix_record(
     );
 
     if looks_like_sampling_option_record_from_rec(&rec, state.observed_sampling_rate) {
-        return None;
+        return Err(IPFixRecordRejection::SamplingOption);
     }
     if state.decap_required && !state.decap_ok {
-        return None;
+        return Err(IPFixRecordRejection::DecapsulationFailed);
     }
 
     // Session and observation-point counters measure different traffic.
@@ -92,7 +98,7 @@ pub(crate) fn finalize_ipfix_record(
         .then(|| build_reverse_ipfix_flow(&rec, &state.reverse_overrides, source_ts))
         .flatten();
 
-    Some((
+    Ok((
         DecodedFlow {
             record: rec,
             source_realtime_usec: source_ts,
@@ -332,11 +338,11 @@ mod tests {
             123,
         );
 
-        assert!(decoded.is_some());
+        assert!(decoded.is_ok());
     }
 
     #[test]
-    fn finalize_ipfix_record_drops_failed_datalink_decap_records() {
+    fn finalize_ipfix_record_reports_failed_datalink_decap() {
         let rec = forward_record();
         let mut sampling = SamplingState::default();
         let state = IPFixRecordBuildState {
@@ -357,6 +363,34 @@ mod tests {
             123,
         );
 
-        assert!(decoded.is_none());
+        assert!(matches!(
+            decoded,
+            Err(IPFixRecordRejection::DecapsulationFailed)
+        ));
+    }
+
+    #[test]
+    fn finalize_ipfix_record_reports_sampling_option_after_deriving_packet_ratio() {
+        let rec = FlowRecord::default();
+        let mut sampling = SamplingState::default();
+        let state = IPFixRecordBuildState {
+            sampling_packet_interval: Some(1),
+            sampling_packet_space: Some(999),
+            ..Default::default()
+        };
+
+        let decoded = finalize_ipfix_record(
+            rec,
+            state,
+            "127.0.0.1:2055".parse().unwrap(),
+            10,
+            42,
+            &mut sampling,
+            0,
+            TimestampSource::Input,
+            123,
+        );
+
+        assert!(matches!(decoded, Err(IPFixRecordRejection::SamplingOption)));
     }
 }

--- a/src/crates/netflow-plugin/src/decoder/protocol/sflow/packet.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/sflow/packet.rs
@@ -6,6 +6,8 @@ pub(crate) fn extract_sflow_flows(
     decapsulation_mode: DecapsulationMode,
     timestamp_source: TimestampSource,
     input_realtime_usec: u64,
+    emit_rows: bool,
+    stats: &mut DecodeStats,
 ) -> Vec<DecodedFlow> {
     let exporter_ip_override = sflow_agent_ip_addr(&datagram.agent_address);
     let source_realtime_usec = timestamp_source.select(input_realtime_usec, None, None);
@@ -15,6 +17,10 @@ pub(crate) fn extract_sflow_flows(
     for sample in datagram.samples {
         match sample.sample_data {
             SampleData::FlowSample(sample_data) => {
+                stats.sflow_flow_samples += 1;
+                if !emit_rows {
+                    continue;
+                }
                 let mut in_if = if sample_data.input.is_single() {
                     Some(sample_data.input.value())
                 } else {
@@ -51,9 +57,15 @@ pub(crate) fn extract_sflow_flows(
                     need_decap,
                 ) {
                     flows.push(flow);
+                } else {
+                    stats.decapsulation_failed_records += 1;
                 }
             }
             SampleData::FlowSampleExpanded(sample_data) => {
+                stats.sflow_flow_samples += 1;
+                if !emit_rows {
+                    continue;
+                }
                 let mut in_if = if sample_data.input.format == SFLOW_INTERFACE_FORMAT_INDEX {
                     Some(sample_data.input.value)
                 } else {
@@ -91,9 +103,25 @@ pub(crate) fn extract_sflow_flows(
                     need_decap,
                 ) {
                     flows.push(flow);
+                } else {
+                    stats.decapsulation_failed_records += 1;
                 }
             }
-            _ => {}
+            SampleData::CountersSample(_) | SampleData::CountersSampleExpanded(_) => {
+                stats.sflow_counter_samples += 1;
+            }
+            SampleData::DiscardedPacket(_) => {
+                stats.sflow_discarded_samples += 1;
+            }
+            SampleData::RtMetric { .. } => {
+                stats.sflow_rt_metric_samples += 1;
+            }
+            SampleData::RtFlow { .. } => {
+                stats.sflow_rt_flow_samples += 1;
+            }
+            SampleData::Unknown { .. } => {
+                stats.sflow_unknown_samples += 1;
+            }
         }
     }
 

--- a/src/crates/netflow-plugin/src/decoder/protocol/v9.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/v9.rs
@@ -1,7 +1,9 @@
+mod accounting;
 mod nsel;
 mod records;
 mod templates;
 
+pub(crate) use accounting::*;
 pub(crate) use nsel::*;
 pub(crate) use records::*;
 pub(crate) use templates::*;

--- a/src/crates/netflow-plugin/src/decoder/protocol/v9/accounting.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/v9/accounting.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+
+pub(crate) fn account_v9_flowset(body: &V9FlowSetBody, stats: &mut DecodeStats) {
+    match body {
+        V9FlowSetBody::Template(templates) => {
+            stats.v9_template_sets += 1;
+            stats.v9_data_templates += templates.templates.len() as u64;
+        }
+        V9FlowSetBody::OptionsTemplate(templates) => {
+            stats.v9_options_template_sets += 1;
+            stats.v9_options_templates += templates.templates.len() as u64;
+        }
+        V9FlowSetBody::Data(data) => {
+            stats.v9_data_sets += 1;
+            stats.netflow_v9_records += data.fields.len() as u64;
+        }
+        V9FlowSetBody::OptionsData(data) => {
+            stats.v9_options_data_sets += 1;
+            stats.v9_options_records += data.fields.len() as u64;
+        }
+        V9FlowSetBody::NoTemplate(_) => {
+            stats.v9_missing_template_sets += 1;
+            stats.missing_template_sets += 1;
+        }
+        V9FlowSetBody::Empty => stats.v9_ignored_sets += 1,
+    }
+}
+
+pub(crate) fn account_v9_packet(packet: &V9, stats: &mut DecodeStats) {
+    for flowset in &packet.flowsets {
+        account_v9_flowset(&flowset.body, stats);
+    }
+}

--- a/src/crates/netflow-plugin/src/decoder/protocol/v9/records.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/v9/records.rs
@@ -26,6 +26,8 @@ pub(crate) fn append_v9_records(
             .unwrap_or(false);
         match flowset.body {
             V9FlowSetBody::Data(data) => {
+                stats.v9_data_sets += 1;
+                stats.netflow_v9_records += data.fields.len() as u64;
                 for record in data.fields {
                     let mut rec = base_record("v9", source);
                     let mut sampler_id: Option<u64> = None;
@@ -116,9 +118,6 @@ pub(crate) fn append_v9_records(
                     rec.flow_end_usec = flow_end_usec.unwrap_or(0);
                     if nsel {
                         let projection = project_nsel_record(rec, nsel_state, input_realtime_usec);
-                        stats.partial_counter_records = stats
-                            .partial_counter_records
-                            .saturating_add(projection.stats.partial_counter_records);
                         projection.stats.merge_into(stats);
                         if let Some(flow) = projection.forward {
                             out.push(flow);
@@ -140,9 +139,11 @@ pub(crate) fn append_v9_records(
                     );
 
                     if looks_like_sampling_option_record_from_rec(&rec, observed_sampling_rate) {
+                        stats.sampling_option_records += 1;
                         continue;
                     }
                     if decap_required && !decap_ok {
+                        stats.decapsulation_failed_records += 1;
                         continue;
                     }
 
@@ -166,7 +167,25 @@ pub(crate) fn append_v9_records(
                     });
                 }
             }
-            _ => continue,
+            V9FlowSetBody::OptionsData(data) => {
+                stats.v9_options_data_sets += 1;
+                stats.v9_options_records += data.fields.len() as u64;
+            }
+            V9FlowSetBody::Template(templates) => {
+                stats.v9_template_sets += 1;
+                stats.v9_data_templates += templates.templates.len() as u64;
+            }
+            V9FlowSetBody::OptionsTemplate(templates) => {
+                stats.v9_options_template_sets += 1;
+                stats.v9_options_templates += templates.templates.len() as u64;
+            }
+            V9FlowSetBody::NoTemplate(_) => {
+                stats.v9_missing_template_sets += 1;
+                stats.missing_template_sets += 1;
+            }
+            V9FlowSetBody::Empty => {
+                stats.v9_ignored_sets += 1;
+            }
         }
     }
 }

--- a/src/crates/netflow-plugin/src/decoder/protocol/v9/records.rs
+++ b/src/crates/netflow-plugin/src/decoder/protocol/v9/records.rs
@@ -20,14 +20,13 @@ pub(crate) fn append_v9_records(
     );
 
     for (flowset_index, flowset) in packet.flowsets.into_iter().enumerate() {
+        account_v9_flowset(&flowset.body, stats);
         let nsel = nsel_flowsets
             .and_then(|flowsets| flowsets.get(flowset_index))
             .copied()
             .unwrap_or(false);
         match flowset.body {
             V9FlowSetBody::Data(data) => {
-                stats.v9_data_sets += 1;
-                stats.netflow_v9_records += data.fields.len() as u64;
                 for record in data.fields {
                     let mut rec = base_record("v9", source);
                     let mut sampler_id: Option<u64> = None;
@@ -167,25 +166,7 @@ pub(crate) fn append_v9_records(
                     });
                 }
             }
-            V9FlowSetBody::OptionsData(data) => {
-                stats.v9_options_data_sets += 1;
-                stats.v9_options_records += data.fields.len() as u64;
-            }
-            V9FlowSetBody::Template(templates) => {
-                stats.v9_template_sets += 1;
-                stats.v9_data_templates += templates.templates.len() as u64;
-            }
-            V9FlowSetBody::OptionsTemplate(templates) => {
-                stats.v9_options_template_sets += 1;
-                stats.v9_options_templates += templates.templates.len() as u64;
-            }
-            V9FlowSetBody::NoTemplate(_) => {
-                stats.v9_missing_template_sets += 1;
-                stats.missing_template_sets += 1;
-            }
-            V9FlowSetBody::Empty => {
-                stats.v9_ignored_sets += 1;
-            }
+            _ => {}
         }
     }
 }

--- a/src/crates/netflow-plugin/src/decoder/state/runtime/decode.rs
+++ b/src/crates/netflow-plugin/src/decoder/state/runtime/decode.rs
@@ -48,10 +48,11 @@ impl FlowDecoders {
             self.expire_v9_templates(context, input_realtime_usec);
         }
 
-        let mut batch = if is_sflow && self.enable_sflow {
+        let mut batch = if is_sflow {
             decode_sflow(
                 source,
                 payload,
+                self.enable_sflow,
                 self.decapsulation_mode,
                 self.timestamp_source,
                 input_realtime_usec,
@@ -112,10 +113,14 @@ impl FlowDecoders {
             apply_missing_flow_time_fallback(flow, input_realtime_usec);
         }
 
+        batch.stats.decoded_rows = batch.flows.len() as u64;
         if let Some(enricher) = &mut self.enricher {
+            let decoded_rows = batch.flows.len();
             batch
                 .flows
                 .retain_mut(|flow| enricher.enrich_record(&mut flow.record));
+            batch.stats.enrichment_filtered_rows =
+                decoded_rows.saturating_sub(batch.flows.len()) as u64;
         }
 
         if template_state_changed {

--- a/src/crates/netflow-plugin/src/decoder/tests.rs
+++ b/src/crates/netflow-plugin/src/decoder/tests.rs
@@ -199,12 +199,12 @@ fn netflow_parser_fixtures_matrix() {
 
         assert!(
             pass,
-            "fixture {} failed: attempts={}, parsed={}, errors={}, template_errors={}, v5={}, v9={}, ipfix={}",
+            "fixture {} failed: attempts={}, parsed={}, errors={}, missing_template_sets={}, v5={}, v9={}, ipfix={}",
             fixture.name,
             stats.parse_attempts,
             stats.parsed_packets,
             stats.parse_errors,
-            stats.template_errors,
+            stats.missing_template_sets,
             stats.netflow_v5_packets,
             stats.netflow_v9_packets,
             stats.ipfix_packets
@@ -447,6 +447,32 @@ fn emits_flow_records_for_v5_fixture() {
 }
 
 #[test]
+fn disabled_v5_is_still_counted_without_emitting_rows() {
+    let mut decoders = FlowDecoders::with_protocols(false, true, true, true, true);
+    let (stats, records) = decode_pcap(&fixture_dir().join("nfv5.pcap"), &mut decoders);
+
+    assert!(stats.netflow_v5_packets > 0);
+    assert!(stats.netflow_v5_records > 0);
+    assert_eq!(stats.disabled_protocol_packets, stats.netflow_v5_packets);
+    assert_eq!(records, 0);
+}
+
+#[test]
+fn disabled_sflow_is_still_counted_without_emitting_rows() {
+    let mut decoders = FlowDecoders::with_protocols(true, true, true, true, false);
+    let (stats, records) = decode_pcap(
+        &fixture_dir().join("data-sflow-expanded-sample.pcap"),
+        &mut decoders,
+    );
+
+    assert!(stats.sflow_datagrams > 0);
+    assert!(stats.sflow_flow_samples > 0);
+    assert_eq!(stats.disabled_protocol_packets, stats.sflow_datagrams);
+    assert_eq!(stats.parse_errors, 0);
+    assert_eq!(records, 0);
+}
+
+#[test]
 fn keeps_valid_flows_parsed_before_a_trailing_error() {
     let path = fixture_dir().join("nfv5.pcap");
     let file = File::open(&path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
@@ -579,24 +605,21 @@ fn legacy_v7_records_populate_flow_window_timestamps() {
         }],
     };
 
-    let mut out = Vec::new();
-    super::append_v7_records(
-        source,
-        &mut out,
-        packet,
-        TimestampSource::Input,
-        TEST_INPUT_REALTIME_USEC,
-    );
+    let mut decoders = FlowDecoders::new();
+    let batch =
+        decoders.decode_udp_payload_at(source, &packet.to_be_bytes(), TEST_INPUT_REALTIME_USEC);
 
-    assert_eq!(out.len(), 1);
-    assert_eq!(out[0].record.flow_start_usec, 119_000_000);
-    assert_eq!(out[0].record.flow_end_usec, 120_000_000);
+    assert_eq!(batch.stats.netflow_v7_packets, 1);
+    assert_eq!(batch.stats.netflow_v7_records, 1);
+    assert_eq!(batch.flows.len(), 1);
+    assert_eq!(batch.flows[0].record.flow_start_usec, 119_000_000);
+    assert_eq!(batch.flows[0].record.flow_end_usec, 120_000_000);
     assert_eq!(
-        out[0].record.src_prefix,
+        batch.flows[0].record.src_prefix,
         Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
     );
     assert_eq!(
-        out[0].record.dst_prefix,
+        batch.flows[0].record.dst_prefix,
         Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
     );
 }
@@ -1442,7 +1465,7 @@ fn v9_nsel_update_projects_initiator_and_responder_directions() {
     let decoded = decoders.decode_udp_payload_at(source, &data, 77_000_000);
 
     assert_eq!(decoded.stats.parse_errors, 0);
-    assert_eq!(decoded.stats.template_errors, 0);
+    assert_eq!(decoded.stats.missing_template_sets, 0);
     assert_eq!(decoded.stats.nsel_records, 1);
     assert_eq!(decoded.stats.nsel_update_records, 1);
     assert_eq!(decoded.stats.nsel_forward_rows, 1);
@@ -1583,7 +1606,7 @@ fn v9_nsel_missing_counter_partner_is_zero_and_diagnosed() {
     let decoded = decoders.decode_udp_payload_at(source, &data, 2_000_000);
 
     assert_eq!(decoded.stats.nsel_partial_counter_records, 2);
-    assert_eq!(decoded.stats.partial_counter_records, 2);
+    assert_eq!(decoded.stats.partial_counter_records, 0);
     assert_eq!(decoded.flows.len(), 2);
     assert!(decoded.flows.iter().any(|flow| {
         flow.record.src_addr == Some("10.0.0.1".parse().unwrap())
@@ -3227,11 +3250,11 @@ fn v9_epoch_millisecond_fields_are_absolute_in_both_template_orders() {
 
         let template_batch = decoders.decode_udp_payload(source, &template);
         assert_eq!(template_batch.stats.parse_errors, 0);
-        assert_eq!(template_batch.stats.template_errors, 0);
+        assert_eq!(template_batch.stats.missing_template_sets, 0);
 
         let decoded = decoders.decode_udp_payload_at(source, &data, 1);
         assert_eq!(decoded.stats.parse_errors, 0);
-        assert_eq!(decoded.stats.template_errors, 0);
+        assert_eq!(decoded.stats.missing_template_sets, 0);
         assert_eq!(decoded.flows.len(), 1);
         assert_eq!(
             decoded.flows[0].record.flow_start_usec,
@@ -3699,7 +3722,7 @@ fn v9_parser_source_eviction_does_not_restore_evicted_state() {
 
     assert_eq!(decoded.stats.parse_attempts, 1);
     assert_eq!(decoded.stats.parser_source_evictions, 1);
-    assert_eq!(decoded.stats.template_errors, 1);
+    assert_eq!(decoded.stats.missing_template_sets, 1);
     assert!(decoded.flows.is_empty());
 }
 
@@ -3722,7 +3745,7 @@ fn ipfix_parser_source_eviction_does_not_restore_evicted_state() {
 
     assert_eq!(decoded.stats.parse_attempts, 1);
     assert_eq!(decoded.stats.parser_source_evictions, 1);
-    assert_eq!(decoded.stats.template_errors, 1);
+    assert_eq!(decoded.stats.missing_template_sets, 1);
     assert!(decoded.flows.is_empty());
 }
 
@@ -3778,7 +3801,7 @@ fn genuinely_unknown_v9_template_is_not_retried() {
     let decoded = FlowDecoders::new().decode_udp_payload(source, &data);
 
     assert_eq!(decoded.stats.parse_attempts, 1);
-    assert_eq!(decoded.stats.template_errors, 1);
+    assert_eq!(decoded.stats.missing_template_sets, 1);
     assert!(decoded.flows.is_empty());
 }
 
@@ -3911,7 +3934,7 @@ fn v9_template_lifetime_uses_collector_receive_time_and_data_does_not_refresh_it
     );
     let expired = decoders.decode_udp_payload_at(source, &data, learned_at + 10_000_000);
     assert!(expired.flows.is_empty());
-    assert_eq!(expired.stats.template_errors, 1);
+    assert_eq!(expired.stats.missing_template_sets, 1);
 }
 
 #[test]
@@ -3973,7 +3996,7 @@ fn persisted_v9_template_lifetime_survives_restart() {
 
     let expired = restored.decode_udp_payload_at(source, &data, learned_at + 10_000_000);
     assert!(expired.flows.is_empty());
-    assert_eq!(expired.stats.template_errors, 1);
+    assert_eq!(expired.stats.missing_template_sets, 1);
 }
 
 #[test]
@@ -4196,11 +4219,11 @@ fn v9_flowset_parses_more_than_parser_default_when_datagram_allows_it() {
 
     let template_batch = decoders.decode_udp_payload(source, &template);
     assert_eq!(template_batch.stats.parse_errors, 0);
-    assert_eq!(template_batch.stats.template_errors, 0);
+    assert_eq!(template_batch.stats.missing_template_sets, 0);
 
     let data_batch = decoders.decode_udp_payload(source, &data);
     assert_eq!(data_batch.stats.parse_errors, 0);
-    assert_eq!(data_batch.stats.template_errors, 0);
+    assert_eq!(data_batch.stats.missing_template_sets, 0);
     assert_eq!(data_batch.flows.len(), RECORD_COUNT);
     assert!(
         data_batch
@@ -4232,11 +4255,11 @@ fn ipfix_flowset_parses_more_than_parser_default_when_datagram_allows_it() {
 
     let template_batch = decoders.decode_udp_payload(source, &template);
     assert_eq!(template_batch.stats.parse_errors, 0);
-    assert_eq!(template_batch.stats.template_errors, 0);
+    assert_eq!(template_batch.stats.missing_template_sets, 0);
 
     let data_batch = decoders.decode_udp_payload(source, &data);
     assert_eq!(data_batch.stats.parse_errors, 0);
-    assert_eq!(data_batch.stats.template_errors, 0);
+    assert_eq!(data_batch.stats.missing_template_sets, 0);
     assert_eq!(data_batch.flows.len(), RECORD_COUNT);
     assert!(
         data_batch
@@ -4548,11 +4571,14 @@ fn decode_synthetic_counter_record(
 
     let template_batch = decoders.decode_udp_payload(source, &template);
     assert_eq!(template_batch.stats.parse_errors, 0, "{protocol:?}");
-    assert_eq!(template_batch.stats.template_errors, 0, "{protocol:?}");
+    assert_eq!(
+        template_batch.stats.missing_template_sets, 0,
+        "{protocol:?}"
+    );
 
     let decoded = decoders.decode_udp_payload(source, &data);
     assert_eq!(decoded.stats.parse_errors, 0, "{protocol:?}");
-    assert_eq!(decoded.stats.template_errors, 0, "{protocol:?}");
+    assert_eq!(decoded.stats.missing_template_sets, 0, "{protocol:?}");
     assert_eq!(decoded.flows.len(), 1, "{protocol:?}");
 
     (decoded.stats, decoded.flows[0].record.to_fields())
@@ -4604,11 +4630,11 @@ fn decode_synthetic_ipfix_raw_counter_flows_with_sampling(
 
     let template_batch = decoders.decode_udp_payload(source, &template);
     assert_eq!(template_batch.stats.parse_errors, 0);
-    assert_eq!(template_batch.stats.template_errors, 0);
+    assert_eq!(template_batch.stats.missing_template_sets, 0);
 
     let decoded = decoders.decode_udp_payload(source, &data);
     assert_eq!(decoded.stats.parse_errors, 0);
-    assert_eq!(decoded.stats.template_errors, 0);
+    assert_eq!(decoded.stats.missing_template_sets, 0);
 
     let mut counters = decoded
         .flows
@@ -4647,11 +4673,14 @@ fn decode_synthetic_raw_record(
 
     let template_batch = decoders.decode_udp_payload(source, &template);
     assert_eq!(template_batch.stats.parse_errors, 0, "{protocol:?}");
-    assert_eq!(template_batch.stats.template_errors, 0, "{protocol:?}");
+    assert_eq!(
+        template_batch.stats.missing_template_sets, 0,
+        "{protocol:?}"
+    );
 
     let decoded = decoders.decode_udp_payload(source, &data);
     assert_eq!(decoded.stats.parse_errors, 0, "{protocol:?}");
-    assert_eq!(decoded.stats.template_errors, 0, "{protocol:?}");
+    assert_eq!(decoded.stats.missing_template_sets, 0, "{protocol:?}");
     assert_eq!(decoded.flows.len(), 1, "{protocol:?}");
 
     (decoded.stats, decoded.flows[0].record.to_fields())

--- a/src/crates/netflow-plugin/src/decoder/tests.rs
+++ b/src/crates/netflow-plugin/src/decoder/tests.rs
@@ -473,6 +473,33 @@ fn disabled_sflow_is_still_counted_without_emitting_rows() {
 }
 
 #[test]
+fn ipfix_sampling_packet_ratio_data_record_is_counted_when_suppressed() {
+    const TEMPLATE_ID: u16 = 256;
+    const OBSERVATION_DOMAIN_ID: u32 = 42;
+    const SAMPLING_PACKET_INTERVAL: u16 = 305;
+    const SAMPLING_PACKET_SPACE: u16 = 306;
+
+    let source = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 2055);
+    let fields = [
+        (SAMPLING_PACKET_INTERVAL, 1_u64.to_be_bytes().to_vec()),
+        (SAMPLING_PACKET_SPACE, 999_u64.to_be_bytes().to_vec()),
+    ];
+    let (template, data) =
+        synthetic_ipfix_raw_field_packets(TEMPLATE_ID, OBSERVATION_DOMAIN_ID, &fields);
+    let mut decoders = FlowDecoders::new();
+
+    let template_batch = decoders.decode_udp_payload(source, &template);
+    assert_eq!(template_batch.stats.parse_errors, 0);
+
+    let decoded = decoders.decode_udp_payload(source, &data);
+    assert_eq!(decoded.stats.parse_errors, 0);
+    assert_eq!(decoded.stats.ipfix_records, 1);
+    assert_eq!(decoded.stats.sampling_option_records, 1);
+    assert_eq!(decoded.stats.decapsulation_failed_records, 0);
+    assert!(decoded.flows.is_empty());
+}
+
+#[test]
 fn keeps_valid_flows_parsed_before_a_trailing_error() {
     let path = fixture_dir().join("nfv5.pcap");
     let file = File::open(&path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));

--- a/src/crates/netflow-plugin/src/ingest/metrics.rs
+++ b/src/crates/netflow-plugin/src/ingest/metrics.rs
@@ -1,18 +1,58 @@
 use super::tier_commit::TierCommitTelemetry;
 use super::*;
 
-pub(super) const INGEST_STATS_SNAPSHOT_KEY_COUNT: usize = 71;
+pub(super) const INGEST_STATS_SNAPSHOT_KEY_COUNT: usize = 114;
 
 #[derive(Default)]
 pub(crate) struct IngestMetrics {
     pub(crate) udp_packets_received: AtomicU64,
     pub(crate) udp_bytes_received: AtomicU64,
+    pub(crate) udp_empty_packets: AtomicU64,
+    pub(crate) udp_receive_errors: AtomicU64,
+    pub(crate) udp_socket_setup_errors: AtomicU64,
+    pub(crate) udp_kernel_drops: AtomicU64,
+    pub(crate) udp_listener_socket_inodes: RwLock<Vec<u64>>,
     pub(crate) parse_attempts: AtomicU64,
     pub(crate) parsed_packets: AtomicU64,
     pub(crate) parse_errors: AtomicU64,
-    pub(crate) template_errors: AtomicU64,
+    pub(crate) missing_template_sets: AtomicU64,
+    pub(crate) disabled_protocol_packets: AtomicU64,
     pub(crate) parser_source_evictions: AtomicU64,
     pub(crate) partial_counter_records: AtomicU64,
+    pub(crate) decapsulation_failed_records: AtomicU64,
+    pub(crate) sampling_option_records: AtomicU64,
+    pub(crate) unsupported_data_sets: AtomicU64,
+    pub(crate) decoded_rows: AtomicU64,
+    pub(crate) enrichment_filtered_rows: AtomicU64,
+    pub(crate) ipfix_zero_reverse_records: AtomicU64,
+    pub(crate) v9_data_sets: AtomicU64,
+    pub(crate) v9_options_data_sets: AtomicU64,
+    pub(crate) v9_template_sets: AtomicU64,
+    pub(crate) v9_options_template_sets: AtomicU64,
+    pub(crate) v9_missing_template_sets: AtomicU64,
+    pub(crate) v9_ignored_sets: AtomicU64,
+    pub(crate) ipfix_data_sets: AtomicU64,
+    pub(crate) ipfix_options_data_sets: AtomicU64,
+    pub(crate) ipfix_template_sets: AtomicU64,
+    pub(crate) ipfix_options_template_sets: AtomicU64,
+    pub(crate) ipfix_missing_template_sets: AtomicU64,
+    pub(crate) ipfix_ignored_sets: AtomicU64,
+    pub(crate) v9_data_templates: AtomicU64,
+    pub(crate) v9_options_templates: AtomicU64,
+    pub(crate) ipfix_data_templates: AtomicU64,
+    pub(crate) ipfix_options_templates: AtomicU64,
+    pub(crate) netflow_v5_records: AtomicU64,
+    pub(crate) netflow_v7_records: AtomicU64,
+    pub(crate) netflow_v9_records: AtomicU64,
+    pub(crate) ipfix_records: AtomicU64,
+    pub(crate) v9_options_records: AtomicU64,
+    pub(crate) ipfix_options_records: AtomicU64,
+    pub(crate) sflow_flow_samples: AtomicU64,
+    pub(crate) sflow_counter_samples: AtomicU64,
+    pub(crate) sflow_discarded_samples: AtomicU64,
+    pub(crate) sflow_rt_metric_samples: AtomicU64,
+    pub(crate) sflow_rt_flow_samples: AtomicU64,
+    pub(crate) sflow_unknown_samples: AtomicU64,
     pub(crate) nsel_records: AtomicU64,
     pub(crate) nsel_update_records: AtomicU64,
     pub(crate) nsel_create_records: AtomicU64,
@@ -36,6 +76,9 @@ pub(crate) struct IngestMetrics {
     pub(crate) journal_sync_errors: AtomicU64,
     pub(crate) raw_journal_syncs: AtomicU64,
     pub(crate) raw_journal_sync_errors: AtomicU64,
+    pub(crate) facet_active_update_errors: AtomicU64,
+    pub(crate) facet_lifecycle_errors: AtomicU64,
+    pub(crate) facet_persist_errors: AtomicU64,
     pub(crate) tier_entries_written: AtomicU64,
     pub(crate) minute_1_entries_written: AtomicU64,
     pub(crate) minute_5_entries_written: AtomicU64,
@@ -79,53 +122,87 @@ pub(crate) struct IngestMetrics {
 }
 
 impl IngestMetrics {
+    pub(crate) fn replace_udp_listener_socket_inodes(&self, inodes: Vec<u64>) {
+        match self.udp_listener_socket_inodes.write() {
+            Ok(mut current) => *current = inodes,
+            Err(poisoned) => *poisoned.into_inner() = inodes,
+        }
+    }
+
+    pub(crate) fn udp_listener_socket_inodes(&self) -> Vec<u64> {
+        match self.udp_listener_socket_inodes.read() {
+            Ok(current) => current.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
     pub(crate) fn apply_decode_stats(&self, stats: &DecodeStats) {
-        self.parse_attempts
-            .fetch_add(stats.parse_attempts, Ordering::Relaxed);
-        self.parsed_packets
-            .fetch_add(stats.parsed_packets, Ordering::Relaxed);
-        self.parse_errors
-            .fetch_add(stats.parse_errors, Ordering::Relaxed);
-        self.template_errors
-            .fetch_add(stats.template_errors, Ordering::Relaxed);
-        self.parser_source_evictions
-            .fetch_add(stats.parser_source_evictions, Ordering::Relaxed);
-        self.partial_counter_records
-            .fetch_add(stats.partial_counter_records, Ordering::Relaxed);
-        self.nsel_records
-            .fetch_add(stats.nsel_records, Ordering::Relaxed);
-        self.nsel_update_records
-            .fetch_add(stats.nsel_update_records, Ordering::Relaxed);
-        self.nsel_create_records
-            .fetch_add(stats.nsel_create_records, Ordering::Relaxed);
-        self.nsel_teardown_records
-            .fetch_add(stats.nsel_teardown_records, Ordering::Relaxed);
-        self.nsel_denied_records
-            .fetch_add(stats.nsel_denied_records, Ordering::Relaxed);
-        self.nsel_unsupported_event_records
-            .fetch_add(stats.nsel_unsupported_event_records, Ordering::Relaxed);
-        self.nsel_malformed_records
-            .fetch_add(stats.nsel_malformed_records, Ordering::Relaxed);
-        self.nsel_counterless_update_records
-            .fetch_add(stats.nsel_counterless_update_records, Ordering::Relaxed);
-        self.nsel_partial_counter_records
-            .fetch_add(stats.nsel_partial_counter_records, Ordering::Relaxed);
-        self.nsel_zero_responder_records
-            .fetch_add(stats.nsel_zero_responder_records, Ordering::Relaxed);
-        self.nsel_forward_rows
-            .fetch_add(stats.nsel_forward_rows, Ordering::Relaxed);
-        self.nsel_reverse_rows
-            .fetch_add(stats.nsel_reverse_rows, Ordering::Relaxed);
-        self.netflow_v5_packets
-            .fetch_add(stats.netflow_v5_packets, Ordering::Relaxed);
-        self.netflow_v7_packets
-            .fetch_add(stats.netflow_v7_packets, Ordering::Relaxed);
-        self.netflow_v9_packets
-            .fetch_add(stats.netflow_v9_packets, Ordering::Relaxed);
-        self.ipfix_packets
-            .fetch_add(stats.ipfix_packets, Ordering::Relaxed);
-        self.sflow_datagrams
-            .fetch_add(stats.sflow_datagrams, Ordering::Relaxed);
+        macro_rules! add_nonzero {
+            ($field:ident) => {
+                if stats.$field != 0 {
+                    self.$field.fetch_add(stats.$field, Ordering::Relaxed);
+                }
+            };
+        }
+
+        add_nonzero!(parse_attempts);
+        add_nonzero!(parsed_packets);
+        add_nonzero!(parse_errors);
+        add_nonzero!(missing_template_sets);
+        add_nonzero!(disabled_protocol_packets);
+        add_nonzero!(parser_source_evictions);
+        add_nonzero!(partial_counter_records);
+        add_nonzero!(decapsulation_failed_records);
+        add_nonzero!(sampling_option_records);
+        add_nonzero!(unsupported_data_sets);
+        add_nonzero!(decoded_rows);
+        add_nonzero!(enrichment_filtered_rows);
+        add_nonzero!(ipfix_zero_reverse_records);
+        add_nonzero!(v9_data_sets);
+        add_nonzero!(v9_options_data_sets);
+        add_nonzero!(v9_template_sets);
+        add_nonzero!(v9_options_template_sets);
+        add_nonzero!(v9_missing_template_sets);
+        add_nonzero!(v9_ignored_sets);
+        add_nonzero!(ipfix_data_sets);
+        add_nonzero!(ipfix_options_data_sets);
+        add_nonzero!(ipfix_template_sets);
+        add_nonzero!(ipfix_options_template_sets);
+        add_nonzero!(ipfix_missing_template_sets);
+        add_nonzero!(ipfix_ignored_sets);
+        add_nonzero!(v9_data_templates);
+        add_nonzero!(v9_options_templates);
+        add_nonzero!(ipfix_data_templates);
+        add_nonzero!(ipfix_options_templates);
+        add_nonzero!(netflow_v5_records);
+        add_nonzero!(netflow_v7_records);
+        add_nonzero!(netflow_v9_records);
+        add_nonzero!(ipfix_records);
+        add_nonzero!(v9_options_records);
+        add_nonzero!(ipfix_options_records);
+        add_nonzero!(sflow_flow_samples);
+        add_nonzero!(sflow_counter_samples);
+        add_nonzero!(sflow_discarded_samples);
+        add_nonzero!(sflow_rt_metric_samples);
+        add_nonzero!(sflow_rt_flow_samples);
+        add_nonzero!(sflow_unknown_samples);
+        add_nonzero!(nsel_records);
+        add_nonzero!(nsel_update_records);
+        add_nonzero!(nsel_create_records);
+        add_nonzero!(nsel_teardown_records);
+        add_nonzero!(nsel_denied_records);
+        add_nonzero!(nsel_unsupported_event_records);
+        add_nonzero!(nsel_malformed_records);
+        add_nonzero!(nsel_counterless_update_records);
+        add_nonzero!(nsel_partial_counter_records);
+        add_nonzero!(nsel_zero_responder_records);
+        add_nonzero!(nsel_forward_rows);
+        add_nonzero!(nsel_reverse_rows);
+        add_nonzero!(netflow_v5_packets);
+        add_nonzero!(netflow_v7_packets);
+        add_nonzero!(netflow_v9_packets);
+        add_nonzero!(ipfix_packets);
+        add_nonzero!(sflow_datagrams);
     }
 
     pub(crate) fn update_decoder_scope_snapshot(&self, snapshot: DecoderScopeSnapshot) {
@@ -159,12 +236,68 @@ impl IngestMetrics {
 
         insert!("udp_packets_received", udp_packets_received);
         insert!("udp_bytes_received", udp_bytes_received);
+        insert!("udp_empty_packets", udp_empty_packets);
+        insert!("udp_receive_errors", udp_receive_errors);
+        insert!("udp_socket_setup_errors", udp_socket_setup_errors);
+        insert!("udp_kernel_drops", udp_kernel_drops);
         insert!("decoded_parse_attempts", parse_attempts);
         insert!("decoded_parsed_packets", parsed_packets);
         insert!("decoded_parse_errors", parse_errors);
-        insert!("decoded_template_errors", template_errors);
+        // Retain the existing function-stat key while making its unit exact.
+        insert!("decoded_template_errors", missing_template_sets);
+        insert!("decoded_missing_template_sets", missing_template_sets);
+        insert!(
+            "decoded_disabled_protocol_packets",
+            disabled_protocol_packets
+        );
         insert!("decoded_parser_source_evictions", parser_source_evictions);
         insert!("decoded_partial_counter_records", partial_counter_records);
+        insert!(
+            "decoded_decapsulation_failed_records",
+            decapsulation_failed_records
+        );
+        insert!("decoded_sampling_option_records", sampling_option_records);
+        insert!("decoded_unsupported_data_sets", unsupported_data_sets);
+        insert!("decoded_rows", decoded_rows);
+        insert!("enrichment_filtered_rows", enrichment_filtered_rows);
+        insert!(
+            "decoded_ipfix_zero_reverse_records",
+            ipfix_zero_reverse_records
+        );
+        insert!("decoded_v9_data_sets", v9_data_sets);
+        insert!("decoded_v9_options_data_sets", v9_options_data_sets);
+        insert!("decoded_v9_template_sets", v9_template_sets);
+        insert!("decoded_v9_options_template_sets", v9_options_template_sets);
+        insert!("decoded_v9_missing_template_sets", v9_missing_template_sets);
+        insert!("decoded_v9_ignored_sets", v9_ignored_sets);
+        insert!("decoded_ipfix_data_sets", ipfix_data_sets);
+        insert!("decoded_ipfix_options_data_sets", ipfix_options_data_sets);
+        insert!("decoded_ipfix_template_sets", ipfix_template_sets);
+        insert!(
+            "decoded_ipfix_options_template_sets",
+            ipfix_options_template_sets
+        );
+        insert!(
+            "decoded_ipfix_missing_template_sets",
+            ipfix_missing_template_sets
+        );
+        insert!("decoded_ipfix_ignored_sets", ipfix_ignored_sets);
+        insert!("decoded_v9_data_templates", v9_data_templates);
+        insert!("decoded_v9_options_templates", v9_options_templates);
+        insert!("decoded_ipfix_data_templates", ipfix_data_templates);
+        insert!("decoded_ipfix_options_templates", ipfix_options_templates);
+        insert!("decoded_netflow_v5_records", netflow_v5_records);
+        insert!("decoded_netflow_v7_records", netflow_v7_records);
+        insert!("decoded_netflow_v9_records", netflow_v9_records);
+        insert!("decoded_ipfix_records", ipfix_records);
+        insert!("decoded_v9_options_records", v9_options_records);
+        insert!("decoded_ipfix_options_records", ipfix_options_records);
+        insert!("decoded_sflow_flow_samples", sflow_flow_samples);
+        insert!("decoded_sflow_counter_samples", sflow_counter_samples);
+        insert!("decoded_sflow_discarded_samples", sflow_discarded_samples);
+        insert!("decoded_sflow_rt_metric_samples", sflow_rt_metric_samples);
+        insert!("decoded_sflow_rt_flow_samples", sflow_rt_flow_samples);
+        insert!("decoded_sflow_unknown_samples", sflow_unknown_samples);
         insert!("decoded_nsel_records", nsel_records);
         insert!("decoded_nsel_update_records", nsel_update_records);
         insert!("decoded_nsel_create_records", nsel_create_records);
@@ -200,6 +333,9 @@ impl IngestMetrics {
         insert!("journal_sync_errors", journal_sync_errors);
         insert!("raw_journal_syncs", raw_journal_syncs);
         insert!("raw_journal_sync_errors", raw_journal_sync_errors);
+        insert!("facet_active_update_errors", facet_active_update_errors);
+        insert!("facet_lifecycle_errors", facet_lifecycle_errors);
+        insert!("facet_persist_errors", facet_persist_errors);
         insert!("tier_entries_written", tier_entries_written);
         insert!("minute_1_entries_written", minute_1_entries_written);
         insert!("minute_5_entries_written", minute_5_entries_written);

--- a/src/crates/netflow-plugin/src/ingest/service.rs
+++ b/src/crates/netflow-plugin/src/ingest/service.rs
@@ -14,6 +14,7 @@ struct MaterializedTierWriters {
 #[derive(Clone)]
 struct FacetLifecycleObserver {
     runtime: Arc<crate::facet_runtime::FacetRuntime>,
+    metrics: Arc<IngestMetrics>,
 }
 
 impl LogLifecycleObserver for FacetLifecycleObserver {
@@ -27,12 +28,18 @@ impl LogLifecycleObserver for FacetLifecycleObserver {
                 let archived_path = Path::new(archived.path());
                 let active_path = Path::new(active.path());
                 if let Err(err) = self.runtime.observe_rotation(archived_path, active_path) {
+                    self.metrics
+                        .facet_lifecycle_errors
+                        .fetch_add(1, Ordering::Relaxed);
                     tracing::warn!("facet runtime rotation update failed: {}", err);
                 }
             }
             LogLifecycleEvent::RetainedDeleted { files } => {
                 let paths: Vec<PathBuf> = files.iter().map(|f| PathBuf::from(f.path())).collect();
                 if let Err(err) = self.runtime.observe_deleted_paths(&paths) {
+                    self.metrics
+                        .facet_lifecycle_errors
+                        .fetch_add(1, Ordering::Relaxed);
                     tracing::warn!("facet runtime retention update failed: {}", err);
                 }
             }

--- a/src/crates/netflow-plugin/src/ingest/service/init.rs
+++ b/src/crates/netflow-plugin/src/ingest/service/init.rs
@@ -31,6 +31,7 @@ impl IngestService {
         let lifecycle_observer: Arc<dyn journal_sdk_log_writer::LogLifecycleObserver> =
             Arc::new(FacetLifecycleObserver {
                 runtime: Arc::clone(&facet_runtime),
+                metrics: Arc::clone(&metrics),
             });
         let build_journal_cfg = |tier: TierKind| {
             let origin = Origin {

--- a/src/crates/netflow-plugin/src/ingest/service/runtime.rs
+++ b/src/crates/netflow-plugin/src/ingest/service/runtime.rs
@@ -1,8 +1,26 @@
 use super::super::*;
 use super::IngestService;
 use std::future::poll_fn;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 use std::task::Poll;
 use tokio::io::ReadBuf;
+
+#[cfg(target_os = "linux")]
+fn udp_socket_inode(socket: &UdpSocket) -> Option<u64> {
+    let target = fs::read_link(format!("/proc/self/fd/{}", socket.as_raw_fd())).ok()?;
+    let target = target.to_str()?;
+    target
+        .strip_prefix("socket:[")?
+        .strip_suffix(']')?
+        .parse()
+        .ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn udp_socket_inode(_socket: &UdpSocket) -> Option<u64> {
+    None
+}
 
 async fn recv_from_any_listener(
     sockets: &[UdpSocket],
@@ -49,6 +67,9 @@ impl IngestService {
                     let (socket_index, received, source) = match recv {
                         Ok(result) => result,
                         Err(err) => {
+                            self.metrics
+                                .udp_receive_errors
+                                .fetch_add(1, Ordering::Relaxed);
                             tracing::warn!("udp recv error: {}", err);
                             continue;
                         }
@@ -79,9 +100,12 @@ impl IngestService {
             let socket = UdpSocket::bind(&listen)
                 .await
                 .with_context(|| format!("failed to bind {}", listen))?;
-            Self::expand_receive_buffer(&socket, &listen);
+            self.expand_receive_buffer(&socket, &listen);
             sockets.push(socket);
         }
+        self.metrics.replace_udp_listener_socket_inodes(
+            sockets.iter().filter_map(udp_socket_inode).collect(),
+        );
         self.spawn_tier_commit_workers();
         Ok(sockets)
     }
@@ -105,9 +129,7 @@ impl IngestService {
             // rotation and at shutdown. Facet state still persists on the tick
             // cadence, and the entry counter keeps accumulating so shutdown
             // performs one final sync.
-            if let Err(err) = self.facet_runtime.persist_if_dirty() {
-                tracing::warn!("facet runtime persist failed: {}", err);
-            }
+            self.persist_facets_if_dirty();
             entries_since_sync
         };
         self.persist_decoder_state_if_due(now);
@@ -124,10 +146,13 @@ impl IngestService {
     /// what absorbs those stalls; the OS default (typically ~208 KiB, only a
     /// few tens of datagrams) overflows after a few milliseconds at high flow
     /// rates. The kernel caps unprivileged requests at net.core.rmem_max.
-    fn expand_receive_buffer(socket: &UdpSocket, listen: &str) {
+    fn expand_receive_buffer(&self, socket: &UdpSocket, listen: &str) {
         const REQUESTED_RECV_BUFFER_BYTES: usize = 64 * 1024 * 1024;
         let sock_ref = socket2::SockRef::from(socket);
         if let Err(err) = sock_ref.set_recv_buffer_size(REQUESTED_RECV_BUFFER_BYTES) {
+            self.metrics
+                .udp_socket_setup_errors
+                .fetch_add(1, Ordering::Relaxed);
             tracing::warn!(
                 "failed to expand UDP receive buffer for {}: {}",
                 listen,
@@ -143,6 +168,9 @@ impl IngestService {
                 REQUESTED_RECV_BUFFER_BYTES
             ),
             Err(err) => {
+                self.metrics
+                    .udp_socket_setup_errors
+                    .fetch_add(1, Ordering::Relaxed);
                 tracing::warn!(
                     "failed to read back UDP receive buffer for {}: {}",
                     listen,
@@ -158,16 +186,19 @@ impl IngestService {
         payload: &[u8],
         mut entries_since_sync: usize,
     ) -> usize {
-        if payload.is_empty() {
-            return entries_since_sync;
-        }
-
         self.metrics
             .udp_packets_received
             .fetch_add(1, Ordering::Relaxed);
         self.metrics
             .udp_bytes_received
             .fetch_add(payload.len() as u64, Ordering::Relaxed);
+
+        if payload.is_empty() {
+            self.metrics
+                .udp_empty_packets
+                .fetch_add(1, Ordering::Relaxed);
+            return entries_since_sync;
+        }
 
         let receive_time_usec = now_usec();
         let packet_context = self.prepare_decoder_state_namespace(source, payload);
@@ -225,6 +256,9 @@ impl IngestService {
                 .facet_runtime
                 .observe_active_record(Path::new(&active_path), record)
         {
+            self.metrics
+                .facet_active_update_errors
+                .fetch_add(1, Ordering::Relaxed);
             tracing::warn!("facet runtime raw write update failed: {}", err);
         }
 
@@ -305,9 +339,7 @@ impl IngestService {
         self.tier_handoff.begin_shutdown();
         let _ = self.sync_if_needed(entries_since_sync);
         super::tier_commit::join_workers(std::mem::take(&mut self.tier_worker_handles));
-        if let Err(err) = self.facet_runtime.persist_if_dirty() {
-            tracing::warn!("facet runtime persist failed: {}", err);
-        }
+        self.persist_facets_if_dirty();
         self.persist_decoder_state();
     }
 
@@ -420,11 +452,18 @@ impl IngestService {
             tracing::warn!("journal sync failed: {}", err);
         }
 
-        if let Err(err) = self.facet_runtime.persist_if_dirty() {
-            tracing::warn!("facet runtime persist failed: {}", err);
-        }
+        self.persist_facets_if_dirty();
 
         0
+    }
+
+    fn persist_facets_if_dirty(&self) {
+        if let Err(err) = self.facet_runtime.persist_if_dirty() {
+            self.metrics
+                .facet_persist_errors
+                .fetch_add(1, Ordering::Relaxed);
+            tracing::warn!("facet runtime persist failed: {}", err);
+        }
     }
 
     /// Pre-worker mode only (in-process tests/benchmarks); after the workers
@@ -446,9 +485,7 @@ impl IngestService {
             tracing::warn!("tier journal sync failed: {}", err);
             return 1;
         }
-        if let Err(err) = self.facet_runtime.persist_if_dirty() {
-            tracing::warn!("facet runtime persist failed: {}", err);
-        }
+        self.persist_facets_if_dirty();
         0
     }
 

--- a/src/crates/netflow-plugin/src/ingest/tier_commit.rs
+++ b/src/crates/netflow-plugin/src/ingest/tier_commit.rs
@@ -527,6 +527,9 @@ pub(super) fn commit_batch(
                 if let Err(err) = facet_runtime
                     .observe_active_contribution(Path::new(active_file.path()), &contribution)
                 {
+                    metrics
+                        .facet_active_update_errors
+                        .fetch_add(1, Ordering::Relaxed);
                     tracing::warn!("facet runtime tier {:?} write update failed: {}", tier, err);
                 }
             }

--- a/src/crates/netflow-plugin/src/ingest_tests.rs
+++ b/src/crates/netflow-plugin/src/ingest_tests.rs
@@ -1,5 +1,6 @@
 use super::test_support::{
-    decode_fixture_sequence, find_flow, new_test_ingest_service, new_test_ingest_service_in_dir,
+    decode_fixture_sequence, extract_udp_payloads, find_flow, fixture_dir, new_test_ingest_service,
+    new_test_ingest_service_in_dir,
 };
 use super::*;
 use crate::plugin_config::DecapsulationMode as ConfigDecapsulationMode;
@@ -37,6 +38,50 @@ fn ingest_metrics_extend_snapshot_preserves_existing_query_stats_on_key_collisio
         "existing query stats must keep the old snapshot-then-query override behavior"
     );
     assert_eq!(stats.get("decoded_parse_attempts").copied(), Some(67));
+}
+
+#[test]
+fn empty_udp_datagram_is_received_but_not_decoded() {
+    let (_tmp, mut service) = new_test_ingest_service(ConfigDecapsulationMode::None);
+    let source = "192.0.2.1:2055".parse().expect("test source");
+
+    let entries = service.handle_received_packet_for_test(source, &[], 0);
+
+    assert_eq!(entries, 0);
+    assert_eq!(
+        service.metrics.udp_packets_received.load(Ordering::Relaxed),
+        1
+    );
+    assert_eq!(service.metrics.udp_empty_packets.load(Ordering::Relaxed), 1);
+    assert_eq!(service.metrics.parse_attempts.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn decoded_row_accounting_reconciles_with_filter_and_journal_outcomes() {
+    let (_tmp, mut service) = new_test_ingest_service(ConfigDecapsulationMode::None);
+    let mut entries_since_sync = 0;
+    for payload in extract_udp_payloads(&fixture_dir().join("nfv5.pcap")) {
+        entries_since_sync = service.handle_received_packet_for_test(
+            payload.source,
+            &payload.data,
+            entries_since_sync,
+        );
+    }
+
+    let decoded = service.metrics.decoded_rows.load(Ordering::Relaxed);
+    let filtered = service
+        .metrics
+        .enrichment_filtered_rows
+        .load(Ordering::Relaxed);
+    let journaled = service
+        .metrics
+        .journal_entries_written
+        .load(Ordering::Relaxed);
+    let write_failed = service.metrics.journal_write_errors.load(Ordering::Relaxed);
+
+    assert!(decoded > 0);
+    assert_eq!(decoded, filtered + journaled + write_failed);
+    assert_eq!(entries_since_sync as u64, journaled);
 }
 
 #[test]

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -596,6 +596,12 @@ async fn e2e_ingest_receives_from_multiple_listeners() {
     let ingest_task = tokio::spawn(async move { service.run(run_shutdown).await });
 
     tokio::time::sleep(Duration::from_millis(100)).await;
+    #[cfg(target_os = "linux")]
+    assert_eq!(
+        metrics.udp_listener_socket_inodes().len(),
+        2,
+        "each Linux UDP listener must publish its exact socket inode"
+    );
     let payloads = fixture_udp_payloads("nfv5.pcap");
     let expected_packets = (payloads.len() * 2) as u64;
     replay_payloads_udp(&listen_a, &payloads).await;

--- a/src/crates/netflow-plugin/taxonomy.yaml
+++ b/src/crates/netflow-plugin/taxonomy.yaml
@@ -5,7 +5,7 @@ placements:
   - id: network-flows
     section_id: netdata
     title: Network Flows
-    icon: network-wired
+    icon: snmp
     items:
       - type: group
         id: input

--- a/src/crates/netflow-plugin/taxonomy.yaml
+++ b/src/crates/netflow-plugin/taxonomy.yaml
@@ -1,0 +1,38 @@
+taxonomy_version: 1
+plugin_name: netflow-plugin
+module_name: netflow
+placements:
+  - id: network-flows
+    section_id: netdata
+    title: Network Flows
+    icon: network-wired
+    items:
+      - type: group
+        id: input
+        title: Input
+        items:
+          - netdata.netflow.input_packets
+          - netdata.netflow.protocol_packets
+      - type: group
+        id: decoding
+        title: Decoding
+        items:
+          - netdata.netflow.flow_sets
+          - netdata.netflow.templates
+          - netdata.netflow.flow_records
+          - netdata.netflow.options_records
+          - netdata.netflow.sflow_samples
+          - netdata.netflow.decoder_exceptions
+          - netdata.netflow.flow_rows
+      - type: group
+        id: cisco-nsel
+        title: Cisco NSEL
+        items:
+          - netdata.netflow.nsel_events
+          - netdata.netflow.nsel_rows
+          - netdata.netflow.nsel_exceptions
+      - type: group
+        id: state
+        title: Collector State
+        items:
+          - netdata.netflow.journal_io_ops


### PR DESCRIPTION
## Summary

- correct `netflow.input_packets` so it reports UDP datagram outcomes only
- add separate packet counters for NetFlow v5, v7, v9, IPFIX, and sFlow
- add coherent charts for Sets, templates, decoded records, sFlow samples, decoder exceptions, row outcomes, and Cisco NSEL
- expose Linux listener-buffer drops by sampling the exact UDP socket inodes outside the receive hot path
- document the accounting model and add integration metadata and taxonomy

## Why

The existing input chart mixes UDP datagrams, parser attempts, decoded protocol packets, records, and errors under one `packets/s` unit. It also leaves several valid no-row and failure outcomes invisible, which makes production support ambiguous.

This change separates each processing layer and proves the row outcome invariant:

`decoded = classifier_filtered + journaled + write_failed`

## User impact

The early `netflow.input_packets` chart contract is intentionally corrected: its non-UDP dimensions move to dedicated contexts. Existing dashboards or alerts using those dimensions must use the new charts.

The flow journal format, stored records, rollups, and query behavior do not change.

## Validation

- `cargo fmt -p netflow-plugin -- --check`
- `cargo check -p netflow-plugin --tests`
- `cargo test -p netflow-plugin`: 646 passed, 26 manual benchmarks ignored
- integration metadata loader: 21 flows loaded
- taxonomy generator and collector-taxonomy checks
- release ingest benchmark, 2,000 rounds per protocol: full-ingest variation versus baseline ranged from -0.6% to +2.2%, with no measurable regression

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits UDP input metrics from decoding and row accounting, and centralizes v9/IPFIX Flow Set accounting. Adds focused charts for protocols, sets/templates, records/rows, and exceptions to simplify troubleshooting, exposes Linux UDP socket-buffer drops, and fixes integration metadata/taxonomy so placements load correctly.

- New Features
  - `netflow.input_packets` now shows only UDP: `udp_received`, `kernel_dropped`, `empty`.
  - New charts: `netflow.protocol_packets`, `netflow.flow_sets`, `netflow.templates`, `netflow.flow_records`, `netflow.options_records`, `netflow.flow_rows`, `netflow.sflow_samples`, `netflow.decoder_exceptions`, `netflow.nsel_events`, `netflow.nsel_rows`, `netflow.nsel_exceptions`.
  - `decoder_exceptions` explains decoding/no-row cases: parse failures, missing-template Sets, disabled-protocol packets, enrichment drops.
  - Disabled protocols are counted but emit no rows; sFlow samples are counted even when disabled.
  - Taxonomy places charts under clear UI groups; integration metadata generation now includes `netflow-plugin` sources and taxonomy.

- Migration
  - Update dashboards/alerts that used non-UDP dimensions on `netflow.input_packets` to `netflow.protocol_packets`, `netflow.flow_sets`, and `netflow.decoder_exceptions`. Stored flow format and queries are unchanged.

<sup>Written for commit fe7d40c96a1efb75da33fa07e87d7206d0248528. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

