### PR TITLE
perf(go.d/metrix): eliminate repeated multiscope flattening

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/go-v2-host-scope.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/go-v2-host-scope.md
@@ -20,9 +20,22 @@ or virtual-node targets.
   in default scope and multiple non-default scopes without collision.
 - `Read()` without `ReadHostScope` returns default-scope series only.
 - `Read(ReadHostScope(key))` returns only that scope's series.
+- Scoped lookup, metadata, and iteration use immutable per-scope indexes. Their
+  work is proportional to the selected scope, not to peer-scope series.
 - `Reader.HostScopes()` enumerates all scopes present in the snapshot and is not
   filtered by the reader's active host scope.
+- `Reader.MetricMeta(name)` is scope-local. A fresh reader may fall back to stale
+  metadata only in the active scope; neither fresh nor raw readers may return
+  peer-scope metadata.
+- CollectorStore readers implement the optional
+  `metrix.FreshVisibleHostScopesReader` capability. It returns only scopes with a
+  series visible under freshness-filtered semantics.
 - Flattened synthetic series preserve the source host scope.
+- CollectorStore builds one complete flattened projection per exact published
+  snapshot and shares it across raw/fresh scoped readers. Success, failure, and
+  abort snapshots do not reuse a projection across their metadata boundary.
+- RuntimeStore remains per-read and does not expose the fresh-visible-scope
+  capability.
 - Scope metadata conflicts in one collect cycle are data errors surfaced through
   `CommitCycleSuccess() error`, not panics.
 
@@ -31,6 +44,11 @@ or virtual-node targets.
 - V2 jobruntime owns host/vnode orchestration. Chartengine remains host-agnostic.
 - One `chartengine.Engine` is used per host scope for a job.
 - Scope engines are created lazily.
+- `postCheck` requires `FreshVisibleHostScopesReader`; an incompatible metric
+  store fails before collection starts.
+- After a successful commit, jobruntime obtains live scopes directly from the
+  shared flattened snapshot's fresh-visible catalog. It does not probe every
+  scope with another flattened read.
 - Default-scope metrics continue to emit under the job-level vnode when one is
   configured, otherwise under the global host.
 - Explicit non-default scopes emit under their `metrix.HostScope` GUID and host

--- a/src/go/pkg/metrix/README.md
+++ b/src/go/pkg/metrix/README.md
@@ -64,7 +64,7 @@ Current ownership map:
 | Runtime store, immediate writes, overlay snapshots | `runtime_store.go`, `runtime_model.go`, `runtime_write.go`, `runtime_commit.go` |
 | Write API, meters, Vec, instruments | `backend.go`, `meter.go`, `vec.go`, `vec_cache.go`, `vec_factory.go`, `vec_handles.go`, `gauge.go`, `counter.go`, `histogram.go`, `summary.go`, `summary_sketch.go`, `stateset.go`, `measureset.go`, `measureset_normalize.go`, `measureset_store.go`, `seeded.go` |
 | Labels, label sets, metadata, validation | `labels.go`, `labelset.go`, `meta.go`, `value_validation.go` |
-| Snapshot reads and flattening | `reader.go`, `reader_flatten.go` |
+| Snapshot reads, indexing, and flattening | `reader.go`, `reader_index.go`, `reader_flatten.go` |
 | Public-contract tests | `public_contract_test.go` (`package metrix_test`); white-box implementation tests remain in `package metrix` |
 | Selector expressions | `selector/` |
 
@@ -109,8 +109,10 @@ flowchart LR
 
 Key properties that fall out of this shape:
 
-- **Reads are lock-free.** A reader holds an immutable snapshot; commits swap in
-  a new one. Any number of goroutines read concurrently.
+- **Reads do not take the commit lock.** A reader holds an immutable snapshot;
+  commits swap in a new one. The first index or flattened-view request for a
+  CollectorStore snapshot synchronizes one builder; subsequent readers use the
+  published immutable result concurrently.
 - **Writes are invisible until commit.** A half-collected or failed cycle never
   leaks partial data to readers.
 - **Commit is transactional.** Either the whole cycle publishes, or (on
@@ -276,6 +278,41 @@ The `Reader` interface exposes typed getters
 (`Value/Delta/Histogram/Summary/StateSet/MeasureSet`), metadata
 (`SeriesMeta/MetricMeta/CollectMeta`), host scopes, and iteration helpers
 (`ForEachByName/ForEachSeries/ForEachMatch`).
+
+### Snapshot-owned projection and scope indexes
+
+`CollectorStore` owns read acceleration at the published-snapshot boundary:
+
+- The first `Read(ReadFlatten())` for one exact snapshot builds the complete
+  flattened scalar projection and its deterministic indexes.
+- Later flattened readers of that snapshot reuse the same immutable projection.
+- A successful commit and a failed/aborted attempt each publish a new exact
+  snapshot, so freshness metadata and cached projections cannot cross the
+  boundary.
+- Scalar gauge/counter series are shared with the canonical snapshot because
+  committed series are immutable. Structured families allocate their synthetic
+  flattened series once per snapshot.
+- Raw and flattened readers use immutable per-scope name indexes. Scoped lookup
+  and iteration therefore depend on that scope's series, not on peer-scope
+  cardinality.
+
+`RuntimeStore` deliberately keeps per-read flattening because its immediate-write
+overlay snapshots have a different lifetime and reuse profile. It still uses
+the same deterministic reader indexes within each read.
+
+### Host-scope reads and metadata
+
+- `Read()` selects the default host scope; `ReadHostScope(key)` selects one
+  explicit scope.
+- `HostScopes()` returns every scope present in the snapshot, independent of the
+  reader's active scope. Returned metadata is defensively cloned.
+- `MetricMeta(name)` is scope-local. Fresh readers prefer visible series and may
+  fall back to stale metadata only inside the active scope; raw readers may use
+  stale metadata in that scope. Neither mode falls back to a peer scope.
+- CollectorStore readers optionally implement
+  `FreshVisibleHostScopesReader`. Its `FreshVisibleHostScopes()` result contains
+  only scopes with at least one series visible under normal freshness rules and
+  is independent of `ReadRaw()`.
 
 ## Instruments
 
@@ -485,5 +522,6 @@ see [how-to-write-a-collector.md](/src/go/plugin/go.d/docs/how-to-write-a-collec
 | Descriptor resolution | Observed authorities per name are grouped in a fingerprint-indexed map (no cap); one canonical descriptor per accepted name. |
 | Descriptor eviction | One O(descriptor-universe) sweep at commit, after retention; `instrumentZeroSince` tracks idle-since on the successful-commit clock. |
 | Runtime commit | Overlay/compaction strategy with its own retention pruning. |
-| Iteration | Name-indexed deterministic iteration for reader traversal. |
+| Collector read projection | One failure-safe lazy flattened projection per exact published snapshot; concurrent first users synchronize on one complete build. |
+| Iteration | Immutable per-scope name indexes and pre-sorted names; scoped traversal is independent of foreign-scope series. |
 | Identity | Canonical metric+labels key with a stable `SeriesIdentity` hash. |

--- a/src/go/pkg/metrix/collector_cycle.go
+++ b/src/go/pkg/metrix/collector_cycle.go
@@ -36,11 +36,10 @@ func (c *storeCycleController) BeginCycle() {
 // clears the active cycle, and returns err. All staged writes and staged
 // registrations from the aborted cycle are discarded (never merged).
 func (c *storeCycleController) abortWithError(oldSnap *readSnapshot, err error) error {
-	abortSnap := &readSnapshot{
+	abortSnap := attachCollectorSnapshot(&readSnapshot{
 		collectMeta: oldSnap.collectMeta,
 		series:      oldSnap.series,
-		byName:      oldSnap.byName,
-	}
+	})
 	abortSnap.collectMeta.LastAttemptSeq = c.core.active.seq
 	abortSnap.collectMeta.LastAttemptStatus = CollectStatusFailed
 	c.core.snapshot.Store(abortSnap)
@@ -91,7 +90,6 @@ func (c *storeCycleController) CommitCycleSuccess() error {
 	next := &readSnapshot{
 		collectMeta: oldSnap.collectMeta,
 		series:      make(map[string]*committedSeries, len(oldSnap.series)),
-		byName:      nil,
 	}
 	commitHostScopes := make(map[string]HostScope)
 
@@ -282,7 +280,7 @@ func (c *storeCycleController) CommitCycleSuccess() error {
 	next.collectMeta.EvictedDescriptors += evicted
 	next.collectMeta.DroppedNames += uint64(len(resolution.drop))
 
-	c.core.snapshot.Store(next)
+	c.core.snapshot.Store(attachCollectorSnapshot(next))
 	c.core.successSeq = successSeq
 	c.core.active = nil
 	return nil
@@ -339,11 +337,10 @@ func (c *storeCycleController) AbortCycle() {
 	oldSnap := c.core.snapshot.Load()
 	// Alias previous committed maps directly. Safe by invariant:
 	// committed series/snapshots are immutable after publish.
-	abortSnap := &readSnapshot{
+	abortSnap := attachCollectorSnapshot(&readSnapshot{
 		collectMeta: oldSnap.collectMeta,
 		series:      oldSnap.series,
-		byName:      oldSnap.byName,
-	}
+	})
 
 	abortSnap.collectMeta.LastAttemptSeq = c.core.active.seq
 	abortSnap.collectMeta.LastAttemptStatus = CollectStatusFailed

--- a/src/go/pkg/metrix/collector_store.go
+++ b/src/go/pkg/metrix/collector_store.go
@@ -27,11 +27,10 @@ func NewCollectorStore(opts ...CollectorStoreOption) CollectorStore {
 			descriptorGraceCycles:    grace,
 		},
 	}
-	core.snapshot.Store(&readSnapshot{
+	core.snapshot.Store(attachCollectorSnapshot(&readSnapshot{
 		collectMeta: CollectMeta{LastAttemptStatus: CollectStatusUnknown},
 		series:      make(map[string]*committedSeries),
-		byName:      make(map[string][]*committedSeries),
-	})
+	}))
 	return &storeView{core: core}
 }
 
@@ -52,9 +51,14 @@ func (s *storeView) Read(opts ...ReadOption) Reader {
 	cfg := resolveReadConfig(opts...)
 	snap := s.core.snapshot.Load()
 	if cfg.flatten {
-		snap = flattenSnapshot(snap)
+		snap = snap.collectorFlattenedSnapshot()
 	}
-	return &storeReader{snap: snap, raw: cfg.raw, flattened: cfg.flatten, hostScopeKey: cfg.hostScopeKey}
+	return &collectorReader{storeReader: storeReader{
+		snap:         snap,
+		raw:          cfg.raw,
+		flattened:    cfg.flatten,
+		hostScopeKey: cfg.hostScopeKey,
+	}}
 }
 
 func (s *storeView) Write() Writer {

--- a/src/go/pkg/metrix/collector_store_projection_test.go
+++ b/src/go/pkg/metrix/collector_store_projection_test.go
@@ -195,11 +195,32 @@ func TestCollectorStoreSnapshotIndexShape(t *testing.T) {
 
 	indexedSeries := len(index.defaultScope.byName["projection.value"])
 	require.Equal(t, []string{"projection.value"}, index.defaultScope.names)
+	require.Empty(t, index.defaultScope.structuredMetaByName)
 	for _, scope := range index.byScope {
 		require.Equal(t, []string{"projection.value"}, scope.names)
+		require.Empty(t, scope.structuredMetaByName)
 		indexedSeries += len(scope.byName["projection.value"])
 	}
 	require.Equal(t, totalSeries, indexedSeries)
+}
+
+func TestCollectorStoreSnapshotIndexSeparatesStructuredMetadataFromScalarIteration(t *testing.T) {
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	histogram := store.Write().SnapshotMeter("svc").Histogram("latency", WithHistogramBounds(1))
+
+	cycle.BeginCycle()
+	histogram.ObservePoint(HistogramPoint{
+		Count:   1,
+		Sum:     0.5,
+		Buckets: []BucketPoint{{UpperBound: 1, CumulativeCount: 1}},
+	})
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	scope := store.Read().(*collectorReader).scopeIndex()
+	require.Empty(t, scope.byName)
+	require.Empty(t, scope.names)
+	require.Contains(t, scope.structuredMetaByName, "svc.latency")
 }
 
 func TestCollectorStoreWarmPathAllocationShape(t *testing.T) {

--- a/src/go/pkg/metrix/collector_store_projection_test.go
+++ b/src/go/pkg/metrix/collector_store_projection_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	projectionReaderSink Reader
+	projectionScopesSink []HostScope
+	projectionCountSink  int
+)
+
+func TestCollectorStoreFlattenProjectionIsSnapshotOwned(t *testing.T) {
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	gauge := store.Write().SnapshotMeter("svc").Gauge("load")
+
+	cycle.BeginCycle()
+	gauge.Observe(1)
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	first := store.Read(ReadFlatten()).(*collectorReader)
+	second := store.Read(ReadFlatten()).(*collectorReader)
+	require.Same(t, first.snap, second.snap)
+
+	rawSeries := store.(*storeView).core.snapshot.Load().series["svc.load"]
+	flatSeries := first.snap.series["svc.load"]
+	require.Same(t, rawSeries, flatSeries, "scalar projection must share immutable committed series")
+
+	old := first
+	cycle.BeginCycle()
+	gauge.Observe(2)
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	current := store.Read(ReadFlatten()).(*collectorReader)
+	require.NotSame(t, old.snap, current.snap)
+	mustValue(t, old, "svc.load", nil, 1)
+	mustValue(t, current, "svc.load", nil, 2)
+}
+
+func TestCollectorStoreConcurrentFlattenProjectionIsShared(t *testing.T) {
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	gauge := store.Write().SnapshotMeter("svc").Gauge("load")
+
+	cycle.BeginCycle()
+	gauge.Observe(1)
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	const totalReaders = 32
+	snapshots := make([]*readSnapshot, totalReaders)
+	start := make(chan struct{})
+	var wait sync.WaitGroup
+	for i := range totalReaders {
+		wait.Go(func() {
+			<-start
+			snapshots[i] = store.Read(ReadFlatten()).(*collectorReader).snap
+		})
+	}
+	close(start)
+	wait.Wait()
+
+	for _, snapshot := range snapshots[1:] {
+		require.Same(t, snapshots[0], snapshot)
+	}
+}
+
+func TestCollectorStoreFreshVisibleHostScopesFollowExactSnapshot(t *testing.T) {
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	scopeA := HostScope{ScopeKey: "scope-a", GUID: "guid-a", Hostname: "host-a", Labels: map[string]string{"scope": "a"}}
+	scopeB := HostScope{ScopeKey: "scope-b", GUID: "guid-b", Hostname: "host-b", Labels: map[string]string{"scope": "b"}}
+	scopeC := HostScope{ScopeKey: "scope-c", GUID: "guid-c", Hostname: "host-c", Labels: map[string]string{"scope": "c"}}
+	snapshotMeter := store.Write().SnapshotMeter("svc")
+	freshA := snapshotMeter.WithHostScope(scopeA).Gauge("fresh")
+	staleC := snapshotMeter.WithHostScope(scopeC).Gauge("stale")
+	committedB := store.Write().StatefulMeter("svc").WithHostScope(scopeB).Gauge("committed")
+
+	cycle.BeginCycle()
+	freshA.Observe(1)
+	staleC.Observe(1)
+	committedB.Set(1)
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	cycle.BeginCycle()
+	freshA.Observe(2)
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	successReader := store.Read(ReadFlatten())
+	successScopes := freshVisibleHostScopes(t, successReader)
+	require.Equal(t, []HostScope{scopeA, scopeB}, successScopes)
+	successScopes[0].Hostname = "mutated"
+	successScopes[0].Labels["scope"] = "mutated"
+	require.Equal(t, []HostScope{scopeA, scopeB}, freshVisibleHostScopes(t, successReader))
+
+	cycle.BeginCycle()
+	freshA.Observe(3)
+	cycle.AbortCycle()
+
+	failedReader := store.Read(ReadFlatten())
+	require.Equal(t, []HostScope{scopeB}, freshVisibleHostScopes(t, failedReader))
+	require.Equal(t, []HostScope{scopeA, scopeB}, freshVisibleHostScopes(t, successReader))
+}
+
+func TestRuntimeStoreFlattenProjectionRemainsPerRead(t *testing.T) {
+	store := NewRuntimeStore()
+	store.Write().StatefulMeter("runtime").Gauge("load").Set(1)
+
+	first := store.Read(ReadFlatten()).(*storeReader)
+	second := store.Read(ReadFlatten()).(*storeReader)
+
+	assert.NotSame(t, first.snap, second.snap)
+	_, ok := any(first).(FreshVisibleHostScopesReader)
+	assert.False(t, ok)
+}
+
+func TestRetryableLazyPointerRetriesAfterPanic(t *testing.T) {
+	var lazy retryableLazyPointer[int]
+	builds := 0
+
+	require.Panics(t, func() {
+		lazy.get(func() *int {
+			builds++
+			panic("build failed")
+		})
+	})
+
+	value := lazy.get(func() *int {
+		builds++
+		result := 42
+		return &result
+	})
+	require.Equal(t, 42, *value)
+	require.Equal(t, 2, builds)
+
+	again := lazy.get(func() *int {
+		t.Fatal("published lazy value was rebuilt")
+		return nil
+	})
+	require.Same(t, value, again)
+}
+
+func TestCollectorStoreSnapshotIndexShape(t *testing.T) {
+	const (
+		totalSeries = 256
+		totalScopes = 8
+	)
+	store := projectionScopedStore(t, totalSeries, totalScopes)
+	reader := store.Read(ReadFlatten()).(*collectorReader)
+	index := reader.snapshotIndex()
+
+	require.Len(t, index.hostScopes, totalScopes)
+	require.Len(t, index.freshVisibleHostScopes, totalScopes)
+	require.True(t, index.hasDefaultScope)
+	require.Len(t, index.byScope, totalScopes-1)
+
+	indexedSeries := len(index.defaultScope.byName["projection.value"])
+	require.Equal(t, []string{"projection.value"}, index.defaultScope.names)
+	for _, scope := range index.byScope {
+		require.Equal(t, []string{"projection.value"}, scope.names)
+		indexedSeries += len(scope.byName["projection.value"])
+	}
+	require.Equal(t, totalSeries, indexedSeries)
+}
+
+func TestCollectorStoreWarmPathAllocationShape(t *testing.T) {
+	small := projectionScopedStore(t, 32, 32)
+	large := projectionScopedStore(t, 8192, 32)
+	small.Read(ReadFlatten())
+	large.Read(ReadFlatten())
+
+	smallReadAllocs := testing.AllocsPerRun(100, func() {
+		projectionReaderSink = small.Read(ReadFlatten())
+	})
+	largeReadAllocs := testing.AllocsPerRun(100, func() {
+		projectionReaderSink = large.Read(ReadFlatten())
+	})
+	require.LessOrEqual(t, smallReadAllocs, float64(3))
+	require.Equal(t, smallReadAllocs, largeReadAllocs)
+
+	smallReader := small.Read(ReadRaw())
+	largeReader := large.Read(ReadRaw())
+	smallReader.HostScopes()
+	largeReader.HostScopes()
+	smallScopeAllocs := testing.AllocsPerRun(20, func() {
+		projectionScopesSink = smallReader.HostScopes()
+	})
+	largeScopeAllocs := testing.AllocsPerRun(20, func() {
+		projectionScopesSink = largeReader.HostScopes()
+	})
+	require.Equal(t, smallScopeAllocs, largeScopeAllocs)
+}
+
+func TestCollectorStoreScopedIterationAllocationsIgnoreForeignSeries(t *testing.T) {
+	withoutForeign := projectionForeignScopeStore(t, 0)
+	withForeign := projectionForeignScopeStore(t, 4096)
+	withoutForeignReader := withoutForeign.Read(ReadRaw(), ReadHostScope("target"))
+	withForeignReader := withForeign.Read(ReadRaw(), ReadHostScope("target"))
+	require.Equal(t, 16, projectionCountSeries(withoutForeignReader))
+	require.Equal(t, 16, projectionCountSeries(withForeignReader))
+
+	withoutForeignAllocs := testing.AllocsPerRun(100, func() {
+		projectionCountSink = projectionCountSeries(withoutForeignReader)
+	})
+	withForeignAllocs := testing.AllocsPerRun(100, func() {
+		projectionCountSink = projectionCountSeries(withForeignReader)
+	})
+	require.Equal(t, withoutForeignAllocs, withForeignAllocs)
+}
+
+func freshVisibleHostScopes(t *testing.T, reader Reader) []HostScope {
+	t.Helper()
+	scopes, ok := reader.(FreshVisibleHostScopesReader)
+	require.True(t, ok, "reader does not expose fresh-visible host scopes")
+	return scopes.FreshVisibleHostScopes()
+}
+
+func projectionScopedStore(t *testing.T, totalSeries, totalScopes int) CollectorStore {
+	t.Helper()
+	require.GreaterOrEqual(t, totalSeries, totalScopes)
+
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	gaugeVec := store.Write().SnapshotMeter("projection").Vec("id").Gauge("value")
+	scopes := make([]HostScope, totalScopes)
+	for i := 1; i < totalScopes; i++ {
+		value := strconv.Itoa(i)
+		scopes[i] = HostScope{
+			ScopeKey: "scope-" + value,
+			GUID:     "guid-" + value,
+			Hostname: "host-" + value,
+			Labels:   map[string]string{"scope": value},
+		}
+	}
+	handles := make([]SnapshotGauge, totalSeries)
+	for i := range totalSeries {
+		scope := scopes[i%totalScopes]
+		var err error
+		if scope.IsDefault() {
+			handles[i], err = gaugeVec.GetWithLabelValues(strconv.Itoa(i))
+		} else {
+			handles[i], err = gaugeVec.WithHostScope(scope).GetWithLabelValues(strconv.Itoa(i))
+		}
+		require.NoError(t, err)
+	}
+
+	cycle.BeginCycle()
+	for i, handle := range handles {
+		handle.Observe(SampleValue(i))
+	}
+	require.NoError(t, cycle.CommitCycleSuccess())
+	return store
+}
+
+func projectionForeignScopeStore(t *testing.T, foreignSeries int) CollectorStore {
+	t.Helper()
+
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	gaugeVec := store.Write().SnapshotMeter("projection").Vec("id").Gauge("value")
+	target := HostScope{ScopeKey: "target", GUID: "target-guid", Hostname: "target"}
+	foreign := HostScope{ScopeKey: "foreign", GUID: "foreign-guid", Hostname: "foreign"}
+	handles := make([]SnapshotGauge, 0, 16+foreignSeries)
+	for i := range 16 {
+		handle, err := gaugeVec.WithHostScope(target).GetWithLabelValues("target-" + strconv.Itoa(i))
+		require.NoError(t, err)
+		handles = append(handles, handle)
+	}
+	for i := range foreignSeries {
+		handle, err := gaugeVec.WithHostScope(foreign).GetWithLabelValues("foreign-" + strconv.Itoa(i))
+		require.NoError(t, err)
+		handles = append(handles, handle)
+	}
+
+	cycle.BeginCycle()
+	for i, handle := range handles {
+		handle.Observe(SampleValue(i))
+	}
+	require.NoError(t, cycle.CommitCycleSuccess())
+	return store
+}
+
+func projectionCountSeries(reader Reader) int {
+	count := 0
+	reader.ForEachSeries(func(string, LabelView, SampleValue) {
+		count++
+	})
+	return count
+}

--- a/src/go/pkg/metrix/collector_store_projection_test.go
+++ b/src/go/pkg/metrix/collector_store_projection_test.go
@@ -109,9 +109,36 @@ func TestCollectorStoreFreshVisibleHostScopesFollowExactSnapshot(t *testing.T) {
 	require.Equal(t, []HostScope{scopeA, scopeB}, freshVisibleHostScopes(t, successReader))
 }
 
+func TestCollectorStoreCommitErrorPublishesNewProjection(t *testing.T) {
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	meter := store.Write().SnapshotMeter("svc")
+
+	cycle.BeginCycle()
+	meter.Gauge("load").Observe(1)
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	success := store.Read(ReadFlatten()).(*collectorReader)
+	require.Equal(t, []HostScope{{}}, freshVisibleHostScopes(t, success))
+
+	cycle.BeginCycle()
+	meter.Gauge("load").Observe(2)
+	meter.Counter("load").ObserveTotal(3)
+	require.ErrorContains(t, cycle.CommitCycleSuccess(), "conflicting instrument kinds")
+
+	failed := store.Read(ReadFlatten()).(*collectorReader)
+	require.NotSame(t, success.snap, failed.snap)
+	require.Same(t, failed.snap, store.Read(ReadFlatten()).(*collectorReader).snap)
+	require.Equal(t, CollectStatusFailed, failed.CollectMeta().LastAttemptStatus)
+	require.Empty(t, freshVisibleHostScopes(t, failed))
+	mustValue(t, success, "svc.load", nil, 1)
+	mustValue(t, store.Read(ReadRaw(), ReadFlatten()), "svc.load", nil, 1)
+}
+
 func TestRuntimeStoreFlattenProjectionRemainsPerRead(t *testing.T) {
 	store := NewRuntimeStore()
-	store.Write().StatefulMeter("runtime").Gauge("load").Set(1)
+	gauge := store.Write().StatefulMeter("runtime").Gauge("load")
+	gauge.Set(1)
 
 	first := store.Read(ReadFlatten()).(*storeReader)
 	second := store.Read(ReadFlatten()).(*storeReader)
@@ -119,6 +146,11 @@ func TestRuntimeStoreFlattenProjectionRemainsPerRead(t *testing.T) {
 	assert.NotSame(t, first.snap, second.snap)
 	_, ok := any(first).(FreshVisibleHostScopesReader)
 	assert.False(t, ok)
+
+	gauge.Set(2)
+	current := store.Read(ReadFlatten())
+	mustValue(t, first, "runtime.load", nil, 1)
+	mustValue(t, current, "runtime.load", nil, 2)
 }
 
 func TestRetryableLazyPointerRetriesAfterPanic(t *testing.T) {
@@ -198,12 +230,36 @@ func TestCollectorStoreWarmPathAllocationShape(t *testing.T) {
 	require.Equal(t, smallScopeAllocs, largeScopeAllocs)
 }
 
-func TestCollectorStoreScopedIterationAllocationsIgnoreForeignSeries(t *testing.T) {
+func TestCollectorStoreScopedIterationDoesNotVisitForeignPartition(t *testing.T) {
 	withoutForeign := projectionForeignScopeStore(t, 0)
 	withForeign := projectionForeignScopeStore(t, 4096)
 	withoutForeignReader := withoutForeign.Read(ReadRaw(), ReadHostScope("target"))
 	withForeignReader := withForeign.Read(ReadRaw(), ReadHostScope("target"))
 	require.Equal(t, 16, projectionCountSeries(withoutForeignReader))
+	require.Equal(t, 16, projectionCountSeries(withForeignReader))
+
+	indexed := withForeignReader.(*collectorReader)
+	selected := indexed.scopeIndex()
+	require.Same(t, indexed.snapshotIndex().byScope["target"], selected)
+	require.Equal(t, 16, projectionCountIndexedSeries(selected))
+	foreign := indexed.snapshotIndex().byScope["foreign"]
+	require.Equal(t, 4096, projectionCountIndexedSeries(foreign))
+
+	// Poison the foreign records after immutable partition publication. A late
+	// global scan would now pass them through the target-scope visibility check
+	// and invoke the callback; selected-partition traversal never visits them.
+	for _, series := range foreign.byName {
+		for _, item := range series {
+			item.hostScopeKey = "target"
+		}
+	}
+	globalVisible := 0
+	for _, item := range indexed.snap.series {
+		if item.desc != nil && isScalarKind(item.desc.kind) && indexed.visible(item) {
+			globalVisible++
+		}
+	}
+	require.Equal(t, 16+4096, globalVisible, "poison must make late global filtering observable")
 	require.Equal(t, 16, projectionCountSeries(withForeignReader))
 
 	withoutForeignAllocs := testing.AllocsPerRun(100, func() {
@@ -292,5 +348,13 @@ func projectionCountSeries(reader Reader) int {
 	reader.ForEachSeries(func(string, LabelView, SampleValue) {
 		count++
 	})
+	return count
+}
+
+func projectionCountIndexedSeries(index *snapshotScopeIndex) int {
+	count := 0
+	for _, series := range index.byName {
+		count += len(series)
+	}
 	return count
 }

--- a/src/go/pkg/metrix/collector_store_scope_bench_test.go
+++ b/src/go/pkg/metrix/collector_store_scope_bench_test.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+var benchmarkHostScopesSink []HostScope
+
+func BenchmarkCollectorStoreFlattenProjectionCold(b *testing.B) {
+	for _, instances := range []int{32, 512} {
+		b.Run(fmt.Sprintf("structured_instances_%d", instances), func(b *testing.B) {
+			store := benchmarkCommittedMixedStore(b, instances)
+			snapshot := store.(*storeView).core.snapshot.Load()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				flat := flattenSnapshot(snapshot)
+				if flat.collectMeta.LastSuccessSeq == 0 {
+					b.Fatal("expected committed snapshot")
+				}
+				benchmarkReaderCountSink = len(flat.series)
+			}
+		})
+	}
+}
+
+func BenchmarkCollectorStoreFlattenProjectionWarm(b *testing.B) {
+	for _, instances := range []int{32, 512} {
+		b.Run(fmt.Sprintf("structured_instances_%d", instances), func(b *testing.B) {
+			store := benchmarkCommittedMixedStore(b, instances)
+			if meta := store.Read(ReadFlatten()).CollectMeta(); meta.LastSuccessSeq == 0 {
+				b.Fatal("expected committed snapshot")
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				reader := store.Read(ReadFlatten())
+				if meta := reader.CollectMeta(); meta.LastSuccessSeq == 0 {
+					b.Fatal("expected committed snapshot")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCollectorStoreHostScopes(b *testing.B) {
+	const totalSeries = 4096
+
+	for _, totalScopes := range []int{1, 8, 64, 512} {
+		b.Run(fmt.Sprintf("series_%d/scopes_%d", totalSeries, totalScopes), func(b *testing.B) {
+			store := benchmarkCommittedScopedScalarStore(b, totalSeries, totalScopes)
+			reader := store.Read(ReadRaw())
+			scopes := reader.HostScopes()
+			if len(scopes) != totalScopes {
+				b.Fatalf("expected %d scopes, got %d", totalScopes, len(scopes))
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				scopes = reader.HostScopes()
+				if len(scopes) != totalScopes {
+					b.Fatalf("expected %d scopes, got %d", totalScopes, len(scopes))
+				}
+				benchmarkHostScopesSink = scopes
+			}
+		})
+	}
+}
+
+func BenchmarkCollectorStoreFlattenFanoutWarm(b *testing.B) {
+	const totalSeries = 4096
+
+	for _, totalScopes := range []int{1, 8, 64, 512} {
+		b.Run(fmt.Sprintf("series_%d/scopes_%d", totalSeries, totalScopes), func(b *testing.B) {
+			benchmarkCollectorStoreFlattenFanoutWarm(b, totalSeries, totalScopes)
+		})
+	}
+}
+
+func BenchmarkCollectorStoreFlattenFanoutBySeriesWarm(b *testing.B) {
+	const totalScopes = 32
+
+	for _, totalSeries := range []int{32, 512, 8192} {
+		b.Run(fmt.Sprintf("scopes_%d/series_%d", totalScopes, totalSeries), func(b *testing.B) {
+			benchmarkCollectorStoreFlattenFanoutWarm(b, totalSeries, totalScopes)
+		})
+	}
+}
+
+func BenchmarkCollectorStoreFlattenProjectionVisibilityCold(b *testing.B) {
+	const (
+		totalSeries = 4096
+		totalScopes = 64
+	)
+
+	for _, mode := range []string{"fresh", "stale", "committed", "failed_attempt"} {
+		b.Run(mode, func(b *testing.B) {
+			store, cycle, _ := benchmarkScopedScalarFixture(b, totalSeries, totalScopes, mode == "committed")
+			switch mode {
+			case "stale":
+				cycle.BeginCycle()
+				if err := cycle.CommitCycleSuccess(); err != nil {
+					b.Fatalf("commit stale visibility fixture: %v", err)
+				}
+			case "failed_attempt":
+				cycle.BeginCycle()
+				cycle.AbortCycle()
+			}
+			snapshot := store.(*storeView).core.snapshot.Load()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				flat := flattenSnapshot(snapshot)
+				if len(flat.series) != totalSeries {
+					b.Fatalf("expected %d series, got %d", totalSeries, len(flat.series))
+				}
+				benchmarkReaderCountSink = len(flat.series)
+			}
+		})
+	}
+}
+
+func BenchmarkCollectorStoreFlattenProjectionConcurrentFirst(b *testing.B) {
+	const (
+		totalSeries = 4096
+		totalScopes = 64
+		readers     = 32
+	)
+
+	store, cycle, writes := benchmarkScopedScalarFixture(b, totalSeries, totalScopes, false)
+	results := make([]Reader, readers)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		b.StopTimer()
+		cycle.BeginCycle()
+		for i, write := range writes {
+			write(SampleValue(i))
+		}
+		if err := cycle.CommitCycleSuccess(); err != nil {
+			b.Fatalf("commit concurrent projection fixture: %v", err)
+		}
+
+		start := make(chan struct{})
+		var ready, done sync.WaitGroup
+		ready.Add(readers)
+		done.Add(readers)
+		for i := range readers {
+			go func() {
+				defer done.Done()
+				ready.Done()
+				<-start
+				results[i] = store.Read(ReadFlatten())
+			}()
+		}
+		ready.Wait()
+
+		b.StartTimer()
+		close(start)
+		done.Wait()
+		b.StopTimer()
+
+		for _, reader := range results {
+			if reader.CollectMeta().LastSuccessSeq == 0 {
+				b.Fatal("expected committed snapshot")
+			}
+		}
+		b.StartTimer()
+	}
+}
+
+func BenchmarkCollectorStoreScopedIteration(b *testing.B) {
+	const targetSeries = 16
+
+	for _, foreignSeries := range []int{0, 1024, 16384} {
+		b.Run(fmt.Sprintf("target_%d/foreign_%d", targetSeries, foreignSeries), func(b *testing.B) {
+			store, targetScopeKey := benchmarkCommittedForeignScopeStore(b, targetSeries, foreignSeries)
+			reader := store.Read(ReadRaw(), ReadHostScope(targetScopeKey))
+			count := benchmarkCountReaderSeries(reader)
+			if count != targetSeries {
+				b.Fatalf("expected %d target series, got %d", targetSeries, count)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				count = benchmarkCountReaderSeries(reader)
+				if count != targetSeries {
+					b.Fatalf("expected %d target series, got %d", targetSeries, count)
+				}
+				benchmarkReaderCountSink = count
+			}
+		})
+	}
+}
+
+func benchmarkCommittedScopedScalarStore(b *testing.B, totalSeries, totalScopes int) CollectorStore {
+	b.Helper()
+	store, _, _ := benchmarkScopedScalarFixture(b, totalSeries, totalScopes, false)
+	return store
+}
+
+func benchmarkScopedScalarFixture(b *testing.B, totalSeries, totalScopes int, committed bool) (CollectorStore, CycleController, []func(SampleValue)) {
+	b.Helper()
+	if totalScopes < 1 || totalSeries < totalScopes {
+		b.Fatalf("invalid scoped fixture: %d series across %d scopes", totalSeries, totalScopes)
+	}
+
+	store := NewCollectorStore()
+	cycle := benchmarkCycleController(b, store)
+	scopes := benchmarkHostScopes(totalScopes)
+	writes := make([]func(SampleValue), totalSeries)
+
+	if committed {
+		gaugeVec := store.Write().StatefulMeter("reader.scoped").Vec("id").Gauge("value")
+		for i := range totalSeries {
+			scope := scopes[i%totalScopes]
+			scopedGaugeVec := gaugeVec
+			if !scope.IsDefault() {
+				scopedGaugeVec = gaugeVec.WithHostScope(scope)
+			}
+			handle, err := scopedGaugeVec.GetWithLabelValues(strconv.Itoa(i))
+			if err != nil {
+				b.Fatalf("create scoped stateful gauge handle: %v", err)
+			}
+			writes[i] = func(value SampleValue) {
+				handle.Set(value)
+			}
+		}
+	} else {
+		gaugeVec := store.Write().SnapshotMeter("reader.scoped").Vec("id").Gauge("value")
+		for i := range totalSeries {
+			scope := scopes[i%totalScopes]
+			scopedGaugeVec := gaugeVec
+			if !scope.IsDefault() {
+				scopedGaugeVec = gaugeVec.WithHostScope(scope)
+			}
+			handle, err := scopedGaugeVec.GetWithLabelValues(strconv.Itoa(i))
+			if err != nil {
+				b.Fatalf("create scoped snapshot gauge handle: %v", err)
+			}
+			writes[i] = func(value SampleValue) {
+				handle.Observe(value)
+			}
+		}
+	}
+
+	cycle.BeginCycle()
+	for i, write := range writes {
+		write(SampleValue(i))
+	}
+	if err := cycle.CommitCycleSuccess(); err != nil {
+		b.Fatalf("commit scoped store: %v", err)
+	}
+	return store, cycle, writes
+}
+
+func benchmarkCollectorStoreFlattenFanoutWarm(b *testing.B, totalSeries, totalScopes int) {
+	b.Helper()
+
+	store := benchmarkCommittedScopedScalarStore(b, totalSeries, totalScopes)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		discovery := store.Read(ReadRaw(), ReadFlatten())
+		scopes := discovery.HostScopes()
+		if len(scopes) != totalScopes {
+			b.Fatalf("expected %d scopes, got %d", totalScopes, len(scopes))
+		}
+		for _, scope := range scopes {
+			fresh := store.Read(ReadFlatten(), ReadHostScope(scope.ScopeKey))
+			raw := store.Read(ReadRaw(), ReadFlatten(), ReadHostScope(scope.ScopeKey))
+			if fresh.CollectMeta().LastSuccessSeq == 0 || raw.CollectMeta().LastSuccessSeq == 0 {
+				b.Fatal("expected committed snapshot")
+			}
+		}
+	}
+}
+
+func benchmarkCommittedForeignScopeStore(b *testing.B, targetSeries, foreignSeries int) (CollectorStore, string) {
+	b.Helper()
+
+	store := NewCollectorStore()
+	cycle := benchmarkCycleController(b, store)
+	gaugeVec := store.Write().SnapshotMeter("reader.foreign").Vec("id").Gauge("value")
+	targetScope := HostScope{ScopeKey: "target", GUID: "target-guid", Hostname: "target"}
+	foreignScope := HostScope{ScopeKey: "foreign", GUID: "foreign-guid", Hostname: "foreign"}
+	handles := make([]SnapshotGauge, 0, targetSeries+foreignSeries)
+
+	for i := range targetSeries {
+		handle, err := gaugeVec.WithHostScope(targetScope).GetWithLabelValues("target-" + strconv.Itoa(i))
+		if err != nil {
+			b.Fatalf("create target gauge handle: %v", err)
+		}
+		handles = append(handles, handle)
+	}
+	for i := range foreignSeries {
+		handle, err := gaugeVec.WithHostScope(foreignScope).GetWithLabelValues("foreign-" + strconv.Itoa(i))
+		if err != nil {
+			b.Fatalf("create foreign gauge handle: %v", err)
+		}
+		handles = append(handles, handle)
+	}
+
+	cycle.BeginCycle()
+	for i, handle := range handles {
+		handle.Observe(SampleValue(i))
+	}
+	if err := cycle.CommitCycleSuccess(); err != nil {
+		b.Fatalf("commit foreign-scope store: %v", err)
+	}
+	return store, targetScope.ScopeKey
+}
+
+func benchmarkHostScopes(totalScopes int) []HostScope {
+	scopes := make([]HostScope, totalScopes)
+	for i := 1; i < totalScopes; i++ {
+		value := strconv.Itoa(i)
+		scopes[i] = HostScope{
+			ScopeKey: "scope-" + value,
+			GUID:     "guid-" + value,
+			Hostname: "host-" + value,
+			Labels:   map[string]string{"scope": value},
+		}
+	}
+	return scopes
+}
+
+func benchmarkCountReaderSeries(reader Reader) int {
+	count := 0
+	reader.ForEachSeries(func(string, LabelView, SampleValue) {
+		count++
+	})
+	return count
+}

--- a/src/go/pkg/metrix/host_scope.go
+++ b/src/go/pkg/metrix/host_scope.go
@@ -5,7 +5,6 @@ package metrix
 import (
 	"fmt"
 	"maps"
-	"sort"
 	"strings"
 )
 
@@ -82,26 +81,4 @@ func hostScopeEqual(a, b HostScope) bool {
 		return false
 	}
 	return maps.Equal(a.Labels, b.Labels)
-}
-
-func sortedHostScopes(scopes map[string]HostScope) []HostScope {
-	if len(scopes) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(scopes))
-	for key := range scopes {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	out := make([]HostScope, 0, len(keys))
-	if scope, ok := scopes[""]; ok {
-		out = append(out, cloneHostScope(scope))
-	}
-	for _, key := range keys {
-		if key == "" {
-			continue
-		}
-		out = append(out, cloneHostScope(scopes[key]))
-	}
-	return out
 }

--- a/src/go/pkg/metrix/interfaces.go
+++ b/src/go/pkg/metrix/interfaces.go
@@ -58,7 +58,9 @@ type Reader interface {
 	StateSet(name string, labels Labels) (StateSetPoint, bool)
 	MeasureSet(name string, labels Labels) (MeasureSetPoint, bool)
 	SeriesMeta(name string, labels Labels) (SeriesMeta, bool)
-	// MetricMeta resolves metadata by metric name in the active reader view.
+	// MetricMeta resolves metadata by metric name in the active reader view and
+	// host scope. A freshness-filtered reader may fall back to stale metadata in
+	// that same scope, never to metadata from another scope.
 	// With Read(ReadFlatten()), lookups use flattened scalar series names.
 	// Example: histogram families resolve via *_bucket/*_count/*_sum names.
 	MetricMeta(name string) (MetricMeta, bool)
@@ -92,6 +94,14 @@ type Reader interface {
 // Callers must not mutate returned label slices.
 type SeriesIdentityRawIterator interface {
 	ForEachSeriesIdentityRaw(fn func(identity SeriesIdentity, meta SeriesMeta, name string, labels []Label, v SampleValue))
+}
+
+// FreshVisibleHostScopesReader is an optional CollectorStore reader capability
+// that returns the host scopes containing at least one series visible under
+// freshness-filtered Read() semantics. The result is deterministic and is not
+// affected by ReadRaw(). Returned scope metadata is defensively cloned.
+type FreshVisibleHostScopesReader interface {
+	FreshVisibleHostScopes() []HostScope
 }
 
 // Writer is the declaration/write entrypoint for collection stores.

--- a/src/go/pkg/metrix/metric_meta_store_test.go
+++ b/src/go/pkg/metrix/metric_meta_store_test.go
@@ -165,3 +165,53 @@ func TestMetricMetaScenarios(t *testing.T) {
 		t.Run(name, tc.run)
 	}
 }
+
+func TestMetricMetaHostScopeIsolation(t *testing.T) {
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	scopeA := HostScope{ScopeKey: "scope-a", GUID: "guid-a", Hostname: "host-a"}
+	scopeB := HostScope{ScopeKey: "scope-b", GUID: "guid-b", Hostname: "host-b"}
+	meter := store.Write().SnapshotMeter("svc")
+	gaugeA := meter.WithHostScope(scopeA).Gauge("load", WithDescription("Load"))
+	gaugeB := meter.WithHostScope(scopeB).Gauge("load", WithDescription("Load"))
+
+	cycle.BeginCycle()
+	gaugeA.Observe(1)
+	gaugeB.Observe(2)
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	cycle.BeginCycle()
+	gaugeB.Observe(3)
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	for _, flattened := range []bool{false, true} {
+		name := "canonical"
+		opts := []ReadOption{ReadHostScope(scopeA.ScopeKey)}
+		if flattened {
+			name = "flattened"
+			opts = append(opts, ReadFlatten())
+		}
+
+		t.Run(name+"/stale_metadata_falls_back_within_scope", func(t *testing.T) {
+			_, valueOK := store.Read(opts...).Value("svc.load", nil)
+			require.False(t, valueOK, "stale cycle-fresh value must remain hidden")
+
+			meta, metaOK := store.Read(opts...).MetricMeta("svc.load")
+			require.True(t, metaOK)
+			assert.Equal(t, "Load", meta.Description)
+		})
+
+		t.Run(name+"/missing_scope_never_falls_back_to_peer", func(t *testing.T) {
+			missingOpts := []ReadOption{ReadHostScope("scope-missing")}
+			if flattened {
+				missingOpts = append(missingOpts, ReadFlatten())
+			}
+			_, freshOK := store.Read(missingOpts...).MetricMeta("svc.load")
+			require.False(t, freshOK)
+
+			missingOpts = append(missingOpts, ReadRaw())
+			_, rawOK := store.Read(missingOpts...).MetricMeta("svc.load")
+			require.False(t, rawOK)
+		})
+	}
+}

--- a/src/go/pkg/metrix/metric_meta_store_test.go
+++ b/src/go/pkg/metrix/metric_meta_store_test.go
@@ -199,6 +199,11 @@ func TestMetricMetaHostScopeIsolation(t *testing.T) {
 			meta, metaOK := store.Read(opts...).MetricMeta("svc.load")
 			require.True(t, metaOK)
 			assert.Equal(t, "Load", meta.Description)
+
+			rawOpts := append(append([]ReadOption(nil), opts...), ReadRaw())
+			rawMeta, rawOK := store.Read(rawOpts...).MetricMeta("svc.load")
+			require.True(t, rawOK)
+			assert.Equal(t, "Load", rawMeta.Description)
 		})
 
 		t.Run(name+"/missing_scope_never_falls_back_to_peer", func(t *testing.T) {

--- a/src/go/pkg/metrix/metric_meta_store_test.go
+++ b/src/go/pkg/metrix/metric_meta_store_test.go
@@ -166,6 +166,108 @@ func TestMetricMetaScenarios(t *testing.T) {
 	}
 }
 
+func TestMetricMetaCanonicalStructuredFamilies(t *testing.T) {
+	tests := map[string]func(t *testing.T) Reader{
+		"collector": func(t *testing.T) Reader {
+			store := NewCollectorStore()
+			cycle := cycleController(t, store)
+			scope := HostScope{ScopeKey: "scope-a", GUID: "guid-a", Hostname: "host-a"}
+			meter := store.Write().SnapshotMeter("svc").WithHostScope(scope)
+			histogram := meter.Histogram("histogram", WithHistogramBounds(1), WithDescription("Histogram"))
+			summary := meter.Summary("summary", WithDescription("Summary"))
+			stateSet := meter.StateSet("state", WithStateSetStates("down", "up"), WithDescription("State set"))
+			measureSet := meter.MeasureSetGauge(
+				"measures",
+				WithMeasureSetFields(MeasureFieldSpec{Name: "value"}),
+				WithDescription("Measure set"),
+			)
+
+			cycle.BeginCycle()
+			histogram.ObservePoint(HistogramPoint{
+				Count:   1,
+				Sum:     0.5,
+				Buckets: []BucketPoint{{UpperBound: 1, CumulativeCount: 1}},
+			})
+			summary.ObservePoint(SummaryPoint{Count: 1, Sum: 0.5})
+			stateSet.Enable("up")
+			measureSet.ObservePoint(MeasureSetPoint{Values: []SampleValue{1}})
+			require.NoError(t, cycle.CommitCycleSuccess())
+
+			_, ok := store.Read().MetricMeta("svc.histogram")
+			require.False(t, ok, "structured metadata must not fall back from the default scope")
+			return store.Read(ReadHostScope(scope.ScopeKey))
+		},
+		"runtime": func(t *testing.T) Reader {
+			store := NewRuntimeStore()
+			meter := store.Write().StatefulMeter("svc")
+			meter.Histogram("histogram", WithHistogramBounds(1), WithDescription("Histogram")).Observe(0.5)
+			meter.Summary("summary", WithDescription("Summary")).Observe(0.5)
+			meter.StateSet("state", WithStateSetStates("down", "up"), WithDescription("State set")).Enable("up")
+			meter.MeasureSetGauge(
+				"measures",
+				WithMeasureSetFields(MeasureFieldSpec{Name: "value"}),
+				WithDescription("Measure set"),
+			).SetPoint(MeasureSetPoint{Values: []SampleValue{1}})
+			return store.Read()
+		},
+	}
+
+	for storeName, setup := range tests {
+		t.Run(storeName, func(t *testing.T) {
+			reader := setup(t)
+			assertStructuredMetricMeta(t, reader)
+		})
+	}
+}
+
+func assertStructuredMetricMeta(t *testing.T, reader Reader) {
+	t.Helper()
+
+	tests := map[string]struct {
+		description string
+		typed       func() bool
+	}{
+		"svc.histogram": {
+			description: "Histogram",
+			typed: func() bool {
+				_, ok := reader.Histogram("svc.histogram", nil)
+				return ok
+			},
+		},
+		"svc.summary": {
+			description: "Summary",
+			typed: func() bool {
+				_, ok := reader.Summary("svc.summary", nil)
+				return ok
+			},
+		},
+		"svc.state": {
+			description: "State set",
+			typed: func() bool {
+				_, ok := reader.StateSet("svc.state", nil)
+				return ok
+			},
+		},
+		"svc.measures": {
+			description: "Measure set",
+			typed: func() bool {
+				_, ok := reader.MeasureSet("svc.measures", nil)
+				return ok
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.True(t, tc.typed(), "typed getter must resolve the canonical structured family")
+
+			meta, ok := reader.MetricMeta(name)
+			require.True(t, ok, "MetricMeta must resolve the canonical structured family")
+			assert.Equal(t, tc.description, meta.Description)
+		})
+	}
+}
+
 func TestMetricMetaHostScopeIsolation(t *testing.T) {
 	store := NewCollectorStore()
 	cycle := cycleController(t, store)

--- a/src/go/pkg/metrix/reader.go
+++ b/src/go/pkg/metrix/reader.go
@@ -5,7 +5,6 @@ package metrix
 import (
 	"maps"
 	"slices"
-	"sort"
 	"sync"
 )
 
@@ -17,8 +16,14 @@ type storeReader struct {
 	seriesOnce   sync.Once
 	series       map[string]*committedSeries
 	indexOnce    sync.Once
-	index        map[string][]*committedSeries
+	index        *snapshotSeriesIndex
 }
+
+type collectorReader struct {
+	storeReader
+}
+
+var emptySnapshotScopeIndex snapshotScopeIndex
 
 type familyView struct {
 	name   string
@@ -167,8 +172,7 @@ func (r *storeReader) SeriesMeta(name string, labels Labels) (SeriesMeta, bool) 
 }
 
 func (r *storeReader) MetricMeta(name string) (MetricMeta, bool) {
-	index := r.byNameIndex()
-	series := index[name]
+	series := r.scopeIndex().byName[name]
 	if len(series) == 0 {
 		return MetricMeta{}, false
 	}
@@ -193,26 +197,23 @@ func (r *storeReader) CollectMeta() CollectMeta {
 }
 
 func (r *storeReader) HostScopes() []HostScope {
-	// Scope discovery intentionally ignores this reader's active scope filter so
-	// jobruntime can enumerate all host partitions from one snapshot.
-	scopes := make(map[string]HostScope)
-	for _, s := range r.seriesView() {
-		scopes[s.hostScopeKey] = cloneHostScope(s.hostScope)
-	}
-	return sortedHostScopes(scopes)
+	// Scope discovery intentionally ignores this reader's active scope filter.
+	return cloneHostScopes(r.snapshotIndex().hostScopes)
+}
+
+func (r *collectorReader) FreshVisibleHostScopes() []HostScope {
+	return cloneHostScopes(r.snapshotIndex().freshVisibleHostScopes)
 }
 
 func (r *storeReader) Family(name string) (FamilyView, bool) {
-	index := r.byNameIndex()
-	if slices.ContainsFunc(index[name], r.visible) {
+	if slices.ContainsFunc(r.scopeIndex().byName[name], r.visible) {
 		return familyView{name: name, reader: r}, true
 	}
 	return nil, false
 }
 
 func (r *storeReader) ForEachByName(name string, fn func(labels LabelView, v SampleValue)) {
-	index := r.byNameIndex()
-	for _, s := range index[name] {
+	for _, s := range r.scopeIndex().byName[name] {
 		if r.visible(s) {
 			fn(labelView{items: s.labels}, s.value)
 		}
@@ -232,14 +233,9 @@ func (r *storeReader) ForEachSeriesIdentity(fn func(identity SeriesIdentity, met
 }
 
 func (r *storeReader) ForEachSeriesIdentityRaw(fn func(identity SeriesIdentity, meta SeriesMeta, name string, labels []Label, v SampleValue)) {
-	index := r.byNameIndex()
-	names := make([]string, 0, len(index))
-	for name := range index {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		for _, s := range index[name] {
+	scope := r.scopeIndex()
+	for _, name := range scope.names {
+		for _, s := range scope.byName[name] {
 			if r.visible(s) {
 				hash := s.hash64
 				if hash == 0 {
@@ -255,8 +251,7 @@ func (r *storeReader) ForEachSeriesIdentityRaw(fn func(identity SeriesIdentity, 
 }
 
 func (r *storeReader) ForEachMatch(name string, match func(labels LabelView) bool, fn func(labels LabelView, v SampleValue)) {
-	index := r.byNameIndex()
-	for _, s := range index[name] {
+	for _, s := range r.scopeIndex().byName[name] {
 		if !r.visible(s) {
 			continue
 		}
@@ -285,12 +280,19 @@ func (r *storeReader) lookup(name string, labels Labels) (*committedSeries, bool
 	return lookupSnapshotSeries(r.snap, key)
 }
 
-func (r *storeReader) byNameIndex() map[string][]*committedSeries {
-	if r.snap.runtimeBase == nil && r.snap.byName != nil {
-		return r.snap.byName
+func (r *storeReader) scopeIndex() *snapshotScopeIndex {
+	if scope := r.snapshotIndex().scope(r.hostScopeKey); scope != nil {
+		return scope
+	}
+	return &emptySnapshotScopeIndex
+}
+
+func (r *storeReader) snapshotIndex() *snapshotSeriesIndex {
+	if r.snap.index != nil || r.snap.collector != nil {
+		return r.snap.seriesIndex()
 	}
 	r.indexOnce.Do(func() {
-		r.index = buildByName(r.seriesView())
+		r.index = buildSnapshotSeriesIndex(r.seriesView(), r.snap.collectMeta)
 	})
 	return r.index
 }
@@ -345,12 +347,10 @@ func (r *storeReader) visible(s *committedSeries) bool {
 	if r.raw {
 		return true
 	}
-	if s.desc == nil {
-		return false
-	}
-	if s.desc.freshness == FreshnessCommitted {
-		return true
-	}
-	meta := r.snap.collectMeta
-	return meta.LastAttemptStatus == CollectStatusSuccess && s.meta.LastSeenSuccessSeq == meta.LastSuccessSeq
+	return freshSeriesVisible(s, r.snap.collectMeta)
 }
+
+var _ Reader = (*storeReader)(nil)
+var _ Reader = (*collectorReader)(nil)
+var _ SeriesIdentityRawIterator = (*collectorReader)(nil)
+var _ FreshVisibleHostScopesReader = (*collectorReader)(nil)

--- a/src/go/pkg/metrix/reader.go
+++ b/src/go/pkg/metrix/reader.go
@@ -172,24 +172,15 @@ func (r *storeReader) SeriesMeta(name string, labels Labels) (SeriesMeta, bool) 
 }
 
 func (r *storeReader) MetricMeta(name string) (MetricMeta, bool) {
-	series := r.scopeIndex().byName[name]
-	if len(series) == 0 {
+	scope := r.scopeIndex()
+	if series := scope.byName[name]; len(series) > 0 {
+		return series[0].desc.meta, true
+	}
+	desc := scope.structuredMetaByName[name]
+	if desc == nil {
 		return MetricMeta{}, false
 	}
-	for _, s := range series {
-		if s.desc == nil {
-			continue
-		}
-		if r.raw || r.visible(s) {
-			return s.desc.meta, true
-		}
-	}
-	for _, s := range series {
-		if s.desc != nil {
-			return s.desc.meta, true
-		}
-	}
-	return MetricMeta{}, false
+	return desc.meta, true
 }
 
 func (r *storeReader) CollectMeta() CollectMeta {

--- a/src/go/pkg/metrix/reader_bench_test.go
+++ b/src/go/pkg/metrix/reader_bench_test.go
@@ -13,13 +13,13 @@ var (
 	benchmarkReaderCountSink int
 )
 
-// Reader benchmarks guard lookup, flattening, and iteration paths before the
-// package-layout refactor. Latest results are measured on a developer laptop,
-// not CI, and should be treated as before/after trend indicators.
+// Reader benchmarks guard lookup and iteration paths. Latest results are
+// measured on a developer laptop, not CI, and should be treated as before/after
+// trend indicators. CollectorStore flatten construction and cached acquisition
+// have dedicated cold and warm benchmarks in collector_store_scope_bench_test.go.
 // Latest (developer laptop, -count=10): ValueLookup s1 76-79ns/2allocs, s1000
-// 82-84ns/2; FlattenConstruction s10 52us/1135allocs, s100 586us/10706;
-// ForEachSeriesIdentityRaw s100 371ns/2, s1000 4.7us/2; RuntimeOverlayValueLookup
-// d1 76ns/2, d64 440-468ns/2.
+// 82-84ns/2; ForEachSeriesIdentityRaw s100 371ns/2, s1000 4.7us/2;
+// RuntimeOverlayValueLookup d1 76ns/2, d64 440-468ns/2.
 func BenchmarkReaderValueLookup(b *testing.B) {
 	tests := []int{1, 1000}
 
@@ -37,26 +37,6 @@ func BenchmarkReaderValueLookup(b *testing.B) {
 					b.Fatal("expected value")
 				}
 				benchmarkReaderValueSink = v
-			}
-		})
-	}
-}
-
-func BenchmarkReaderFlattenConstruction(b *testing.B) {
-	tests := []int{10, 100}
-
-	for _, totalSeries := range tests {
-		b.Run(fmt.Sprintf("series_%d", totalSeries), func(b *testing.B) {
-			s := benchmarkCommittedMixedStore(b, totalSeries)
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				r := s.Read(ReadFlatten())
-				meta := r.CollectMeta()
-				if meta.LastSuccessSeq == 0 {
-					b.Fatal("expected committed snapshot")
-				}
 			}
 		})
 	}

--- a/src/go/pkg/metrix/reader_flatten.go
+++ b/src/go/pkg/metrix/reader_flatten.go
@@ -9,7 +9,6 @@ func flattenSnapshot(src *readSnapshot) *readSnapshot {
 	dst := &readSnapshot{
 		collectMeta: src.collectMeta,
 		series:      make(map[string]*committedSeries, len(series)),
-		byName:      make(map[string][]*committedSeries),
 	}
 
 	for _, s := range series {
@@ -18,7 +17,7 @@ func flattenSnapshot(src *readSnapshot) *readSnapshot {
 		}
 		switch s.desc.kind {
 		case kindGauge, kindCounter:
-			dst.series[s.key] = cloneCommittedSeries(s)
+			dst.series[s.key] = s
 		case kindHistogram:
 			appendFlattenedHistogramSeries(dst, s)
 		case kindSummary:
@@ -30,7 +29,7 @@ func flattenSnapshot(src *readSnapshot) *readSnapshot {
 		}
 	}
 
-	dst.byName = buildByName(dst.series)
+	dst.index = buildSnapshotSeriesIndex(dst.series, dst.collectMeta)
 	return dst
 }
 
@@ -70,7 +69,7 @@ func appendFlattenedHistogramSeries(dst *readSnapshot, src *committedSeries) {
 			key:          key,
 			name:         name,
 			hostScopeKey: src.hostScopeKey,
-			hostScope:    cloneHostScope(src.hostScope),
+			hostScope:    src.hostScope,
 			labels:       labels,
 			labelsKey:    labelsKey,
 			desc: &instrumentDescriptor{
@@ -113,7 +112,7 @@ func appendFlattenedHistogramSeries(dst *readSnapshot, src *committedSeries) {
 			key:          infKey,
 			name:         infName,
 			hostScopeKey: src.hostScopeKey,
-			hostScope:    cloneHostScope(src.hostScope),
+			hostScope:    src.hostScope,
 			labels:       infLabels,
 			labelsKey:    infLabelsKey,
 			desc: &instrumentDescriptor{
@@ -184,7 +183,7 @@ func appendFlattenedHistogramScalar(dst *readSnapshot, src *committedSeries, nam
 		key:          key,
 		name:         name,
 		hostScopeKey: src.hostScopeKey,
-		hostScope:    cloneHostScope(src.hostScope),
+		hostScope:    src.hostScope,
 		labels:       items,
 		labelsKey:    labelsKey,
 		desc: &instrumentDescriptor{
@@ -254,7 +253,7 @@ func appendFlattenedSummarySeries(dst *readSnapshot, src *committedSeries) {
 			key:          key,
 			name:         src.name,
 			hostScopeKey: src.hostScopeKey,
-			hostScope:    cloneHostScope(src.hostScope),
+			hostScope:    src.hostScope,
 			labels:       labels,
 			labelsKey:    labelsKey,
 			desc: &instrumentDescriptor{
@@ -363,7 +362,7 @@ func appendFlattenedStateSetSeries(dst *readSnapshot, src *committedSeries) {
 			key:          key,
 			name:         src.name,
 			hostScopeKey: src.hostScopeKey,
-			hostScope:    cloneHostScope(src.hostScope),
+			hostScope:    src.hostScope,
 			labels:       labels,
 			labelsKey:    labelsKey,
 			desc: &instrumentDescriptor{
@@ -421,7 +420,7 @@ func appendFlattenedMeasureSetSeries(dst *readSnapshot, src *committedSeries) {
 			key:          key,
 			name:         name,
 			hostScopeKey: src.hostScopeKey,
-			hostScope:    cloneHostScope(src.hostScope),
+			hostScope:    src.hostScope,
 			labels:       labels,
 			labelsKey:    labelsKey,
 			desc: &instrumentDescriptor{

--- a/src/go/pkg/metrix/reader_index.go
+++ b/src/go/pkg/metrix/reader_index.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+)
+
+type snapshotSeriesIndex struct {
+	hostScopes             []HostScope
+	freshVisibleHostScopes []HostScope
+	defaultScope           snapshotScopeIndex
+	hasDefaultScope        bool
+	byScope                map[string]*snapshotScopeIndex
+	// singleHostScope backs the common unscoped catalog without a slice allocation.
+	singleHostScope [1]HostScope
+}
+
+type snapshotScopeIndex struct {
+	byName map[string][]*committedSeries
+	names  []string
+}
+
+type indexedHostScope struct {
+	scope HostScope
+	fresh bool
+}
+
+type retryableLazyPointer[T any] struct {
+	value atomic.Pointer[T]
+	mu    sync.Mutex
+}
+
+func (lazy *retryableLazyPointer[T]) get(build func() *T) *T {
+	if value := lazy.value.Load(); value != nil {
+		return value
+	}
+
+	lazy.mu.Lock()
+	defer lazy.mu.Unlock()
+	if value := lazy.value.Load(); value != nil {
+		return value
+	}
+	value := build()
+	lazy.value.Store(value)
+	return value
+}
+
+func attachCollectorSnapshot(snapshot *readSnapshot) *readSnapshot {
+	snapshot.collector = &collectorSnapshotState{}
+	return snapshot
+}
+
+func (snapshot *readSnapshot) collectorFlattenedSnapshot() *readSnapshot {
+	return snapshot.collector.flattened.get(func() *readSnapshot {
+		return attachCollectorSnapshot(flattenSnapshot(snapshot))
+	})
+}
+
+func (snapshot *readSnapshot) seriesIndex() *snapshotSeriesIndex {
+	if snapshot.index != nil {
+		return snapshot.index
+	}
+	return snapshot.collector.index.get(func() *snapshotSeriesIndex {
+		return buildSnapshotSeriesIndex(snapshot.series, snapshot.collectMeta)
+	})
+}
+
+func buildSnapshotSeriesIndex(series map[string]*committedSeries, meta CollectMeta) *snapshotSeriesIndex {
+	index := &snapshotSeriesIndex{}
+	var (
+		defaultHostScope indexedHostScope
+		hasDefaultHost   bool
+		hostScopes       map[string]indexedHostScope
+	)
+
+	for _, item := range series {
+		fresh := freshSeriesVisible(item, meta)
+		if item.hostScopeKey == "" {
+			defaultHostScope.scope = item.hostScope
+			defaultHostScope.fresh = defaultHostScope.fresh || fresh
+			hasDefaultHost = true
+		} else {
+			if hostScopes == nil {
+				hostScopes = make(map[string]indexedHostScope)
+			}
+			hostScope := hostScopes[item.hostScopeKey]
+			hostScope.scope = item.hostScope
+			hostScope.fresh = hostScope.fresh || fresh
+			hostScopes[item.hostScopeKey] = hostScope
+		}
+		if item.desc == nil || !isScalarKind(item.desc.kind) {
+			continue
+		}
+		scope := index.ensureScope(item.hostScopeKey)
+		if scope.byName == nil {
+			scope.byName = make(map[string][]*committedSeries)
+		}
+		scope.byName[item.name] = append(scope.byName[item.name], item)
+	}
+
+	totalScopes := len(hostScopes)
+	freshScopes := 0
+	if hasDefaultHost {
+		totalScopes++
+		if defaultHostScope.fresh {
+			freshScopes++
+		}
+	}
+	for _, hostScope := range hostScopes {
+		if hostScope.fresh {
+			freshScopes++
+		}
+	}
+
+	if totalScopes == 1 && hasDefaultHost {
+		index.singleHostScope[0] = cloneHostScope(defaultHostScope.scope)
+		index.hostScopes = index.singleHostScope[:]
+	} else if totalScopes > 0 {
+		index.hostScopes = make([]HostScope, 0, totalScopes)
+		if hasDefaultHost {
+			index.hostScopes = append(index.hostScopes, cloneHostScope(defaultHostScope.scope))
+		}
+		keys := make([]string, 0, len(hostScopes))
+		for key := range hostScopes {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			index.hostScopes = append(index.hostScopes, cloneHostScope(hostScopes[key].scope))
+		}
+	}
+
+	if freshScopes == totalScopes {
+		index.freshVisibleHostScopes = index.hostScopes
+	} else if freshScopes > 0 {
+		index.freshVisibleHostScopes = make([]HostScope, 0, freshScopes)
+		if hasDefaultHost && defaultHostScope.fresh {
+			index.freshVisibleHostScopes = append(index.freshVisibleHostScopes, index.hostScopes[0])
+		}
+		for _, scope := range index.hostScopes {
+			if scope.ScopeKey == "" {
+				continue
+			}
+			if hostScopes[scope.ScopeKey].fresh {
+				index.freshVisibleHostScopes = append(index.freshVisibleHostScopes, scope)
+			}
+		}
+	}
+
+	if index.hasDefaultScope {
+		buildSnapshotScopeIndex(&index.defaultScope)
+	}
+	for _, scope := range index.byScope {
+		buildSnapshotScopeIndex(scope)
+	}
+	return index
+}
+
+func (index *snapshotSeriesIndex) ensureScope(scopeKey string) *snapshotScopeIndex {
+	if scopeKey == "" {
+		index.hasDefaultScope = true
+		return &index.defaultScope
+	}
+	if index.byScope == nil {
+		index.byScope = make(map[string]*snapshotScopeIndex)
+	}
+	scope := index.byScope[scopeKey]
+	if scope == nil {
+		scope = &snapshotScopeIndex{}
+		index.byScope[scopeKey] = scope
+	}
+	return scope
+}
+
+func (index *snapshotSeriesIndex) scope(scopeKey string) *snapshotScopeIndex {
+	if scopeKey == "" {
+		if index.hasDefaultScope {
+			return &index.defaultScope
+		}
+		return nil
+	}
+	return index.byScope[scopeKey]
+}
+
+func buildSnapshotScopeIndex(scope *snapshotScopeIndex) {
+	scope.names = make([]string, 0, len(scope.byName))
+	for name, items := range scope.byName {
+		scope.names = append(scope.names, name)
+		sort.Slice(items, func(i, j int) bool {
+			return items[i].labelsKey < items[j].labelsKey
+		})
+	}
+	sort.Strings(scope.names)
+}
+
+func freshSeriesVisible(series *committedSeries, meta CollectMeta) bool {
+	if series.desc == nil {
+		return false
+	}
+	if series.desc.freshness == FreshnessCommitted {
+		return true
+	}
+	return meta.LastAttemptStatus == CollectStatusSuccess &&
+		series.meta.LastSeenSuccessSeq == meta.LastSuccessSeq
+}
+
+func cloneHostScopes(scopes []HostScope) []HostScope {
+	if len(scopes) == 0 {
+		return nil
+	}
+	cloned := make([]HostScope, len(scopes))
+	for i, scope := range scopes {
+		cloned[i] = cloneHostScope(scope)
+	}
+	return cloned
+}

--- a/src/go/pkg/metrix/reader_index.go
+++ b/src/go/pkg/metrix/reader_index.go
@@ -20,7 +20,9 @@ type snapshotSeriesIndex struct {
 
 type snapshotScopeIndex struct {
 	byName map[string][]*committedSeries
-	names  []string
+	// Keep metadata separate so structured families never enter scalar iteration.
+	structuredMetaByName map[string]*instrumentDescriptor
+	names                []string
 }
 
 type indexedHostScope struct {
@@ -91,10 +93,17 @@ func buildSnapshotSeriesIndex(series map[string]*committedSeries, meta CollectMe
 			hostScope.fresh = hostScope.fresh || fresh
 			hostScopes[item.hostScopeKey] = hostScope
 		}
-		if item.desc == nil || !isScalarKind(item.desc.kind) {
+		if item.desc == nil {
 			continue
 		}
 		scope := index.ensureScope(item.hostScopeKey)
+		if !isScalarKind(item.desc.kind) {
+			if scope.structuredMetaByName == nil {
+				scope.structuredMetaByName = make(map[string]*instrumentDescriptor)
+			}
+			scope.structuredMetaByName[item.name] = item.desc
+			continue
+		}
 		if scope.byName == nil {
 			scope.byName = make(map[string][]*committedSeries)
 		}

--- a/src/go/pkg/metrix/runtime_commit.go
+++ b/src/go/pkg/metrix/runtime_commit.go
@@ -8,10 +8,8 @@ func (r *runtimeStoreBackend) commitRuntimeWrite(apply func(old, next *readSnaps
 
 	oldSnap := r.core.snapshot.Load()
 	next := &readSnapshot{
-		collectMeta: oldSnap.collectMeta,
-		series:      make(map[string]*committedSeries, 1),
-		// byName index is built lazily by readers for runtime snapshots.
-		byName:       nil,
+		collectMeta:  oldSnap.collectMeta,
+		series:       make(map[string]*committedSeries, 1),
 		runtimeBase:  oldSnap,
 		runtimeDepth: oldSnap.runtimeDepth + 1,
 	}
@@ -106,7 +104,6 @@ func (r *runtimeStoreBackend) compactRuntimeSnapshot(snap *readSnapshot, nowUnix
 	return &readSnapshot{
 		collectMeta:  snap.collectMeta,
 		series:       series,
-		byName:       nil,
 		runtimeBase:  nil,
 		runtimeDepth: 0,
 	}, evicted

--- a/src/go/pkg/metrix/series_helpers.go
+++ b/src/go/pkg/metrix/series_helpers.go
@@ -4,7 +4,6 @@ package metrix
 
 import (
 	"maps"
-	"sort"
 )
 
 func newCommittedSeries(key, name, hostScopeKey string, hostScope HostScope, labels []Label, labelsKey string, desc *instrumentDescriptor) *committedSeries {
@@ -93,26 +92,6 @@ func refreshCommittedHostScopes(old, next *readSnapshot, scopes map[string]HostS
 func markSeriesSeen(series *committedSeries, attemptSeq, successSeq uint64) {
 	series.meta.LastSeenSuccessSeq = attemptSeq
 	series.lastSeenSuccessCycle = successSeq
-}
-
-// buildByName builds deterministic per-name iteration lists for snapshot readers.
-func buildByName(series map[string]*committedSeries) map[string][]*committedSeries {
-	byName := make(map[string][]*committedSeries)
-	for _, s := range series {
-		if s.desc == nil || !isScalarKind(s.desc.kind) {
-			continue
-		}
-		byName[s.name] = append(byName[s.name], s)
-	}
-	for _, lst := range byName {
-		sort.Slice(lst, func(i, j int) bool {
-			if lst[i].hostScopeKey != lst[j].hostScopeKey {
-				return lst[i].hostScopeKey < lst[j].hostScopeKey
-			}
-			return lst[i].labelsKey < lst[j].labelsKey
-		})
-	}
-	return byName
 }
 
 // makeSeriesKey joins host scope, metric name, and canonical label key into one stable identity key.

--- a/src/go/pkg/metrix/store_model.go
+++ b/src/go/pkg/metrix/store_model.go
@@ -75,12 +75,20 @@ type committedSeries struct {
 
 type readSnapshot struct {
 	collectMeta CollectMeta
-	series      map[string]*committedSeries   // key => series
-	byName      map[string][]*committedSeries // metric name => stable ordered series list
+	series      map[string]*committedSeries // key => series
+	// index is non-nil when a complete immutable index was built with this
+	// snapshot. Collector canonical snapshots build it lazily through collector.
+	index     *snapshotSeriesIndex
+	collector *collectorSnapshotState
 	// runtimeBase links runtime snapshots in overlay mode (nil for materialized snapshots).
 	runtimeBase *readSnapshot
 	// runtimeDepth tracks overlay chain depth for runtime compaction heuristics.
 	runtimeDepth int
+}
+
+type collectorSnapshotState struct {
+	index     retryableLazyPointer[snapshotSeriesIndex]
+	flattened retryableLazyPointer[readSnapshot]
 }
 
 type cycleFrame struct {

--- a/src/go/plugin/framework/jobruntime/job_v2.go
+++ b/src/go/plugin/framework/jobruntime/job_v2.go
@@ -512,6 +512,9 @@ func (j *JobV2) postCheck() error {
 	if !ok {
 		return fmt.Errorf("metric store is not cycle-managed")
 	}
+	if _, ok := store.Read().(metrix.FreshVisibleHostScopesReader); !ok {
+		return fmt.Errorf("metric store reader does not expose fresh-visible host scopes")
+	}
 
 	opts := []chartengine.Option{
 		chartengine.WithLogger(j.Logger.With(slog.String("component", "chartengine"))),

--- a/src/go/plugin/framework/jobruntime/job_v2.go
+++ b/src/go/plugin/framework/jobruntime/job_v2.go
@@ -512,7 +512,7 @@ func (j *JobV2) postCheck() error {
 	if !ok {
 		return fmt.Errorf("metric store is not cycle-managed")
 	}
-	if _, ok := store.Read().(metrix.FreshVisibleHostScopesReader); !ok {
+	if _, ok := store.Read(metrix.ReadFlatten()).(metrix.FreshVisibleHostScopesReader); !ok {
 		return fmt.Errorf("metric store reader does not expose fresh-visible host scopes")
 	}
 

--- a/src/go/plugin/framework/jobruntime/job_v2_multiscope_bench_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_multiscope_bench_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobruntime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+)
+
+var benchmarkLiveScopesSink map[string]metrix.HostScope
+
+func BenchmarkBV2LiveScopeSetWarm(b *testing.B) {
+	const seriesPerScope = 8
+
+	for _, totalScopes := range []int{1, 8, 64, 512} {
+		b.Run(fmt.Sprintf("scopes_%d/series_per_scope_%d", totalScopes, seriesPerScope), func(b *testing.B) {
+			store, _ := benchmarkJobV2ScopedStore(b, totalScopes, seriesPerScope)
+			job := &JobV2{store: store}
+			live := job.liveScopeSet()
+			if len(live) != totalScopes {
+				b.Fatalf("expected %d live scopes, got %d", totalScopes, len(live))
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				live = job.liveScopeSet()
+				if len(live) != totalScopes {
+					b.Fatalf("expected %d live scopes, got %d", totalScopes, len(live))
+				}
+				benchmarkLiveScopesSink = live
+			}
+		})
+	}
+}
+
+func BenchmarkBV2CollectAndEmitMultiScope(b *testing.B) {
+	const seriesPerScope = 1
+
+	for _, totalScopes := range []int{1, 8, 64} {
+		b.Run(fmt.Sprintf("scopes_%d/series_per_scope_%d", totalScopes, seriesPerScope), func(b *testing.B) {
+			store, handles := benchmarkJobV2ScopedStore(b, totalScopes, seriesPerScope)
+			module := &mockModuleV2{
+				store:    store,
+				template: chartTemplateV2(),
+				collectFunc: func(context.Context) error {
+					for i, handle := range handles {
+						handle.Observe(metrix.SampleValue(i + 1))
+					}
+					return nil
+				},
+			}
+			job := NewJobV2(JobV2Config{
+				PluginName:  pluginName,
+				Name:        jobName,
+				ModuleName:  modName,
+				FullName:    modName + "_" + jobName,
+				Module:      module,
+				Out:         io.Discard,
+				UpdateEvery: 1,
+			})
+			job.Mute()
+			if err := job.postCheck(); err != nil {
+				b.Fatalf("initialize JobV2: %v", err)
+			}
+			job.runOnce()
+			if job.panicked.Load() || job.retries.Load() != 0 {
+				b.Fatal("warm-up collection failed")
+			}
+			if len(job.scopeStates) != totalScopes {
+				b.Fatalf("expected %d scope states, got %d", totalScopes, len(job.scopeStates))
+			}
+			b.Cleanup(job.Cleanup)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				job.runOnce()
+				if job.panicked.Load() || job.retries.Load() != 0 {
+					b.Fatal("collection failed")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkBV2CollectAndEmitRetainedScopes(b *testing.B) {
+	const totalScopes = 64
+
+	store, handles := benchmarkJobV2ScopedStore(b, totalScopes, 1)
+	observeAll := true
+	module := &mockModuleV2{
+		store:    store,
+		template: chartTemplateV2ExpireAfterOne(),
+		collectFunc: func(context.Context) error {
+			for i, handle := range handles {
+				if observeAll || i%2 == 0 {
+					handle.Observe(metrix.SampleValue(i + 1))
+				}
+			}
+			observeAll = !observeAll
+			return nil
+		},
+	}
+	job := NewJobV2(JobV2Config{
+		PluginName:  pluginName,
+		Name:        jobName,
+		ModuleName:  modName,
+		FullName:    modName + "_" + jobName,
+		Module:      module,
+		Out:         io.Discard,
+		UpdateEvery: 1,
+	})
+	job.Mute()
+	if err := job.postCheck(); err != nil {
+		b.Fatalf("initialize JobV2: %v", err)
+	}
+	job.runOnce()
+	if job.panicked.Load() || job.retries.Load() != 0 {
+		b.Fatal("warm-up collection failed")
+	}
+	b.Cleanup(job.Cleanup)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		job.runOnce()
+		if job.panicked.Load() || job.retries.Load() != 0 {
+			b.Fatal("collection failed")
+		}
+	}
+}
+
+func benchmarkJobV2ScopedStore(b *testing.B, totalScopes, seriesPerScope int) (metrix.CollectorStore, []metrix.SnapshotGauge) {
+	b.Helper()
+	if totalScopes < 1 || seriesPerScope < 1 {
+		b.Fatalf("invalid JobV2 fixture: %d scopes with %d series each", totalScopes, seriesPerScope)
+	}
+
+	store := metrix.NewCollectorStore()
+	managed, ok := metrix.AsCycleManagedStore(store)
+	if !ok {
+		b.Fatal("store does not expose cycle control")
+	}
+	cycle := managed.CycleController()
+	gaugeVec := store.Write().SnapshotMeter("apache").Vec("id").Gauge("workers_busy")
+	handles := make([]metrix.SnapshotGauge, 0, totalScopes*seriesPerScope)
+
+	for scopeIndex := range totalScopes {
+		scope := benchmarkJobV2HostScope(scopeIndex)
+		for seriesIndex := range seriesPerScope {
+			labelValue := strconv.Itoa(scopeIndex) + "-" + strconv.Itoa(seriesIndex)
+			var (
+				handle metrix.SnapshotGauge
+				err    error
+			)
+			if scope.IsDefault() {
+				handle, err = gaugeVec.GetWithLabelValues(labelValue)
+			} else {
+				handle, err = gaugeVec.WithHostScope(scope).GetWithLabelValues(labelValue)
+			}
+			if err != nil {
+				b.Fatalf("create JobV2 gauge handle: %v", err)
+			}
+			handles = append(handles, handle)
+		}
+	}
+
+	cycle.BeginCycle()
+	for i, handle := range handles {
+		handle.Observe(metrix.SampleValue(i + 1))
+	}
+	if err := cycle.CommitCycleSuccess(); err != nil {
+		b.Fatalf("commit JobV2 fixture: %v", err)
+	}
+	return store, handles
+}
+
+func benchmarkJobV2HostScope(index int) metrix.HostScope {
+	if index == 0 {
+		return metrix.HostScope{}
+	}
+	value := strconv.Itoa(index)
+	return metrix.HostScope{
+		ScopeKey: "scope-" + value,
+		GUID:     "guid-" + value,
+		Hostname: "host-" + value,
+		Labels:   map[string]string{"scope": value},
+	}
+}

--- a/src/go/plugin/framework/jobruntime/job_v2_scope.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_scope.go
@@ -62,11 +62,10 @@ func (j *JobV2) newScopeEngine() (*chartengine.Engine, error) {
 
 func (j *JobV2) liveScopeSet() map[string]metrix.HostScope {
 	scopes := make(map[string]metrix.HostScope)
-	reader := j.store.Read(metrix.ReadRaw(), metrix.ReadFlatten())
-	for _, scope := range reader.HostScopes() {
-		if j.scopeHasVisibleSeries(scope.ScopeKey) {
-			scopes[scope.ScopeKey] = scope
-		}
+	reader := j.store.Read(metrix.ReadFlatten())
+	visibleScopes := reader.(metrix.FreshVisibleHostScopesReader)
+	for _, scope := range visibleScopes.FreshVisibleHostScopes() {
+		scopes[scope.ScopeKey] = scope
 	}
 	return scopes
 }
@@ -83,15 +82,6 @@ func (j *JobV2) scopeWorkSet(liveScopes map[string]metrix.HostScope) map[string]
 		scopes[key] = state.scope
 	}
 	return scopes
-}
-
-func (j *JobV2) scopeHasVisibleSeries(scopeKey string) bool {
-	reader := j.store.Read(metrix.ReadFlatten(), metrix.ReadHostScope(scopeKey))
-	found := false
-	reader.ForEachSeries(func(string, metrix.LabelView, metrix.SampleValue) {
-		found = true
-	})
-	return found
 }
 
 func sortedScopeKeys(scopes map[string]metrix.HostScope) []string {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up multiscope reads by sharing one flattened projection and per-scope indexes per published `CollectorStore` snapshot, and updates Job V2 to discover live scopes without extra reads. Also restores structured metric metadata lookups.

- **New Features**
  - `CollectorStore` builds one flattened scalar projection per exact snapshot and reuses it across `Read(ReadFlatten())`; success/failure/abort publish a new projection.
  - Immutable per-scope indexes drive lookups and iteration; scoped reads don’t scan foreign scopes.
  - Adds `FreshVisibleHostScopesReader` with `FreshVisibleHostScopes()` that returns only scopes with at least one fresh-visible series and is independent of `ReadRaw()`.
  - Scalar series reuse canonical storage; structured families allocate synthetic flattened series once per snapshot, and structured metric metadata lookups are restored via per-scope indexes.

- **Migration**
  - `jobruntime` now requires `FreshVisibleHostScopesReader`; it fails `postCheck` if missing and uses the shared fresh-visible catalog for live scope discovery (no per-scope flattened reads).
  - `MetricMeta(name)` is scope-local: fresh readers may fall back to stale metadata only within the active scope; no peer-scope fallback.
  - `RuntimeStore` remains per-read flattening and doesn’t expose fresh-visible scopes.

<sup>Written for commit df2b0d4644fbc8959e1408f5f42edc54cc27ea59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

