### PR TITLE
skill how-tos: add 5 new how-tos, fix query-nodes.md response shape

### DIFF
--- a/.agents/skills/query-agent-events/how-tos/INDEX.md
+++ b/.agents/skills/query-agent-events/how-tos/INDEX.md
@@ -19,12 +19,9 @@ the same analysis from scratch.
 
 ## Catalog
 
-(empty -- entries grow as assistants encounter
-not-yet-documented questions)
-
 | Topic | Slug | Notes |
 |---|---|---|
-| -- | -- | -- |
+| Trace a stack-symbol regression to a concurrent mutator | `trace-stack-symbol-regression-to-mutator.md` | Separates direct vs stack-only matches, finds the first affected build, maps the faulting call, and validates shared-state lifetime evidence. |
 
 ## How to add a how-to
 

--- a/.agents/skills/query-agent-events/how-tos/trace-stack-symbol-regression-to-mutator.md
+++ b/.agents/skills/query-agent-events/how-tos/trace-stack-symbol-regression-to-mutator.md
@@ -1,0 +1,214 @@
+# Trace a stack-symbol crash regression to a concurrent mutator
+
+Use this workflow when many agent-events rows mention the same stack symbol, but the symbol may be either the faulting function or only a lower frame, and the suspected regression must be tied to a source change.
+
+## 1. Preserve the reported interval exactly
+
+Cloud log links carry millisecond epoch bounds. Convert them to seconds for the Function payload and record the UTC interval in the local SOW:
+
+```bash
+date -u -d @"$((AFTER_MS / 1000))" '+%Y-%m-%d %H:%M:%S UTC'
+date -u -d @"$((BEFORE_MS / 1000))" '+%Y-%m-%d %H:%M:%S UTC'
+```
+
+Do not put the Cloud link, node ID, or any event identifier in a durable artifact.
+
+## 2. Query crash classes first, then apply the symbol as FTS
+
+A symbol inside `AE_FATAL_STACK_TRACE` is not necessarily the value of `AE_FATAL_FUNCTION`. Use the structured crash selection first and the symbol only as a residual full-text narrower:
+
+```bash
+.agents/skills/query-agent-events/scripts/get-events.sh \
+  --since "$AFTER_SECONDS" \
+  --before "$BEFORE_SECONDS" \
+  --health crash \
+  --version all \
+  --query "$SYMBOL" \
+  --facets AE_FATAL_SIGNAL_CODE,AE_FATAL_FUNCTION,AE_AGENT_VERSION,AE_AGENT_HEALTH,AE_EXIT_CAUSE \
+  --last 10000 \
+  --output .local/audits/query-agent-events/symbol-window.json
+```
+
+Why:
+
+- `AE_AGENT_HEALTH` uses the facet index to reduce the search to crash records.
+- `query` then finds the symbol anywhere in the already narrowed record, including the stack trace.
+- `--version all` is intentional for a reported exact interval; auto-version filtering could hide the first affected build.
+
+## 3. Prove that the response is complete
+
+Do not interpret row counts before checking the envelope:
+
+```bash
+jq '{status, partial, pagination, items, sampling:._sampling, rows:(.data|length)}' \
+  .local/audits/query-agent-events/symbol-window.json
+```
+
+Required checks:
+
+- `status == 200`
+- `partial == false`
+- `items.returned == items.matched`
+- `items.returned < items.max_to_return`
+- `_sampling.sampled == 0`
+
+If any check fails, narrow the query further or paginate before drawing conclusions.
+
+## 4. Separate direct-function matches from stack-only matches
+
+Function responses store rows as arrays and provide the field indexes in `columns`. Always project by the column map; column order is not a stable contract.
+
+Calculate separately:
+
+- rows where `AE_FATAL_FUNCTION == $SYMBOL`;
+- rows where `AE_FATAL_STACK_TRACE` contains `$SYMBOL` but `AE_FATAL_FUNCTION` differs;
+- the symbol's frame number and the first symbolized application frame;
+- normalized application stack families after replacing raw addresses.
+
+The distinction matters:
+
+- A direct `AE_FATAL_FUNCTION` match supports the symbol as the captured fault location.
+- A stack-only match proves only that the symbol was on the call chain.
+- If every stack places the symbol at the first application frame, stack-only metadata differences may be status-file timing artifacts, but this remains an inference until the call-site mapping is checked.
+
+Raw stack addresses remain in the gitignored audit dump. Durable notes use only normalized frames such as `0xADDR`.
+
+## 5. Measure prevalence against the correct denominator
+
+The matching slice cannot provide a crash rate. Fetch all crash-class events for the affected versions over the same interval, using explicit structured version values and no FTS:
+
+```bash
+.agents/skills/query-agent-events/scripts/get-events.sh \
+  --since "$AFTER_SECONDS" \
+  --before "$BEFORE_SECONDS" \
+  --health crash \
+  --versions "$AFFECTED_VERSIONS_CSV" \
+  --facets AE_FATAL_SIGNAL_CODE,AE_FATAL_FUNCTION,AE_AGENT_VERSION \
+  --last 10000 \
+  --output .local/audits/query-agent-events/affected-version-crashes.json
+```
+
+Report at least:
+
+- matching symbol rows / all crash-class rows;
+- matching symbol rows / all signal-crash rows;
+- distinct affected agents;
+- per-version matching rows and distinct agents.
+
+Do not call per-version row shares "rates" without an active-install population denominator. Nightly rollout time strongly biases the version mix.
+
+## 6. Find the first affected build
+
+For a recent regression, widen to 7 days but keep both structured crash and explicit recent-version selections. Include several versions before and after the apparent boundary.
+
+Interpretation rules:
+
+- A single historical row with a different signal or stack family is not the same regression.
+- The first build with a sharp, repeated cluster is the candidate boundary.
+- Account for the after-the-fact posting model and 23-hour client dedup described in `../update-cadence.md`.
+
+Map version strings to repository commits through `packaging/version`:
+
+```bash
+git log --format='%H %ad %s' --date=iso-strict -- packaging/version
+git log -S"$VERSION" --format='%H %ad %s' --date=iso-strict -- packaging/version
+```
+
+Then list commits between the last unaffected and first affected nightly.
+
+## 7. Prove which same-symbol call failed
+
+One static function can have multiple call sites with different inputs. Read every reference, then inspect the built binary's DWARF line mapping:
+
+```bash
+rg -n "\\b${SYMBOL}\\s*\\(" src
+nm -an /path/to/netdata | rg "$SYMBOL|CALLER_FUNCTION"
+objdump -dSl --disassemble=CALLER_FUNCTION /path/to/netdata
+```
+
+Match the caller line reported by the event stack to the disassembly. This can distinguish, for example, an environment-vector encoding call from a command-argument encoding call even though both enter the same function.
+
+Use a binary built from the same source blob as the affected nightly. Verify equivalence with `git rev-parse REV:path/to/source.c` before relying on the mapping.
+
+## 8. Use fault-address shape as supporting memory-lifetime evidence
+
+Group fault addresses without publishing them:
+
+- null / low-page;
+- normal-width mapped-looking userspace address;
+- shortened heap-derived value;
+- other.
+
+On glibc releases using safe-linking, a freed tcache chunk's first machine word can resemble its heap address shifted right by 12 bits. The [glibc safe-linking patch](https://sourceware.org/pipermail/libc-alpha/2020-March/112022.html) defines the pointer mangling used by tcache. If the crash dereferences that shortened value from the first slot of a stale vector, this is strong use-after-free evidence.
+
+Do not diagnose a tcache use-after-free from address shape alone. Require all of:
+
+- the exact faulting read from source/line mapping;
+- a vector or object that a concurrent mutator can reallocate and free;
+- a version boundary containing that mutator;
+- consistent event stacks and address classes.
+
+## 9. Search the boundary for concurrent mutators
+
+Search all C and C++ sources, not only `*.c` and `*.h`:
+
+```bash
+rg -n --glob '*.{c,h,cc,cpp,cxx}' \
+  '\b(setenv|unsetenv|putenv|clearenv|nd_setenv)\s*\(' src
+git log --format='%H %ad %s' --date=iso-strict LAST_UNAFFECTED..FIRST_AFFECTED
+```
+
+For each candidate:
+
+1. Prove it is absent from the last unaffected build and present in the first affected build:
+
+   ```bash
+   git merge-base --is-ancestor CANDIDATE LAST_UNAFFECTED
+   git merge-base --is-ancestor CANDIDATE FIRST_AFFECTED
+   ```
+
+2. Prove its execution overlaps the crashing readers by tracing thread creation and startup order.
+3. Check whether the mutation is common to the affected population, rather than enabled only by an uncommon optional feature.
+4. Verify the platform contract. For example, the [GNU libc environment documentation](https://sourceware.org/glibc/manual/2.29/html_node/Environment-Access.html) marks environment mutation as `MT-Unsafe const:env`; a reader walking `environ` concurrently is not protected by libc's writer lock. Check version-specific changes too: [glibc 2.41 retained old environment arrays](https://sourceware.org/pipermail/glibc-bugs/2025-July/059702.html), reducing one failure mode without making direct concurrent `environ` use a portable contract.
+
+## 10. State confidence precisely
+
+Use this evidence ladder:
+
+- **Symptom cluster:** same symbol appears in many records.
+- **Fault localization:** same symbol is the first application frame and the call site is identified.
+- **Memory-failure class:** fault-address shape and source read identify stale/freed input.
+- **Regression boundary:** the cluster starts in the first build containing a specific mutator.
+- **Root cause established:** the mutator's execution overlaps the reader and explains the exact invalid value.
+- **Reproduced:** a focused concurrency test or core confirms the stale object directly.
+
+Do not skip from symptom cluster to root cause. If the final two levels are missing, label the result a working theory and state the evidence still required.
+
+## How I figured this out
+
+Files and guides used:
+
+- `../AE_FIELDS.md`
+- `../query-discipline.md`
+- `../finding-crashes.md`
+- `../update-cadence.md`
+- `../recipes/find-by-function.md`
+- `scripts/get-events.sh`
+- `scripts/analyze-events.sh`
+- the implicated function, every call site, startup thread tables, and version-changing commits
+
+Queries used:
+
+- exact-window crash selection plus residual stack-symbol FTS;
+- exact-window all-crashes query for explicit affected versions;
+- seven-day crash selection over explicit recent versions for the regression boundary;
+- local `jq` projection through the response `columns` map.
+
+Validation used:
+
+- response completeness and sampling checks;
+- normalized stack-family clustering;
+- distinct-agent and per-version counts;
+- built-binary DWARF/disassembly call-site mapping;
+- commit ancestry checks around the first affected build;
+- primary libc documentation for environment-mutation thread safety.

--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,6 @@ install.sh
 
 # Local AI/agent planning notes. Durable SOW/spec work lives under .agents/.
 TODO-*.md
+
+corrosion/
+_deps/

--- a/docs/netdata-ai/skills/query-netdata-agents/how-tos/INDEX.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/how-tos/INDEX.md
@@ -82,6 +82,7 @@ skill-verification harness questions for `verify/questions.md`; replace each
 - [find-containers-for-topology-port-direct.md](./find-containers-for-topology-port-direct.md) -- find containers or pods exposing a specific TCP port from the direct Agent topology Function payload.
 - `flows-top-talkers-direct.md` (stub -- not yet authored)
 - [validate-direct-local-flow-function.md](./validate-direct-local-flow-function.md) -- prove a local Cloud-connected `flows:netflow` Function works through a Cloud-minted direct-agent bearer.
+- [audit-stored-flow-timestamps-direct.md](./audit-stored-flow-timestamps-direct.md) -- audit retained raw-flow timestamp and duration coverage with aggregate-only output, distinguishing exporter timing from receive-time fallback.
 
 ### Metrics
 

--- a/docs/netdata-ai/skills/query-netdata-agents/how-tos/audit-stored-flow-timestamps-direct.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/how-tos/audit-stored-flow-timestamps-direct.md
@@ -1,0 +1,165 @@
+# Audit stored flow timestamp coverage without exposing raw rows
+
+## Question
+
+Do retained raw NetFlow/IPFIX records contain genuine flow start and end
+timestamps that can support duration-aware time-series reconstruction, or only
+collector receive-time fallbacks?
+
+## Inputs
+
+- A local Netdata Agent running `netflow-plugin`.
+- `NODE_UUID`, `MACHINE_GUID`, and `AGENT_HOST` for the token-safe direct-Agent
+  wrapper.
+- The Agent cache directory. The system-package default is
+  `/var/cache/netdata`; the default raw-flow root is
+  `/var/cache/netdata/flows/raw`.
+
+Raw flow rows reveal network endpoints and traffic volumes. This procedure
+prints only field names and aggregate counts.
+
+## Steps
+
+1. Confirm the flow Function is available through the token-safe wrapper:
+
+   ```bash
+   source docs/netdata-ai/skills/query-netdata-agents/scripts/_lib.sh
+   agents_load_env
+
+   agents_call_function \
+       --via agent \
+       --node "$NODE_UUID" \
+       --host "$AGENT_HOST" \
+       --machine-guid "$MACHINE_GUID" \
+       --function flows:netflow \
+       --body '{"info":true}' \
+     | jq '{status, type, has_history}'
+   ```
+
+   The public Function intentionally does not expose `FLOW_START_USEC`,
+   `FLOW_END_USEC`, or `OBSERVATION_TIME_MILLIS` as grouping or selection
+   fields. Inspect their stored presence locally instead of printing Function
+   rows.
+
+2. Select one raw-journal instance directory and confirm its size and file
+   count:
+
+   ```bash
+   CACHE_DIR="${NETDATA_CACHE_DIR:-/var/cache/netdata}"
+   RAW_ROOT="$CACHE_DIR/flows/raw"
+   RAW_DIR="$(find "$RAW_ROOT" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+
+   test -n "$RAW_DIR"
+   du -sh "$RAW_DIR"
+   find "$RAW_DIR" -maxdepth 1 -type f -name '*.journal' | wc -l
+   ```
+
+   If `RAW_ROOT` contains multiple instance directories, run the remaining
+   steps once per directory. Do not merge them silently.
+
+3. Check the exact retained field catalog and protocol values without reading
+   row contents:
+
+   ```bash
+   journalctl --directory="$RAW_DIR" --no-pager --field=FLOW_VERSION
+
+   journalctl --directory="$RAW_DIR" --no-pager -N \
+     | rg 'FLOW_START_USEC|FLOW_END_USEC|OBSERVATION_TIME_MILLIS|_SOURCE_REALTIME_TIMESTAMP' \
+     | sort
+   ```
+
+   Field-catalog absence means the field does not occur anywhere in the
+   retained journal set. Presence proves only that at least one row has it; use
+   the next step to estimate coverage.
+
+4. Take a stratified sample from every retained journal file and emit only
+   aggregate timestamp checks:
+
+   ```bash
+   find "$RAW_DIR" -maxdepth 1 -type f -name '*.journal' -print0 \
+     | while IFS= read -r -d '' file; do
+         journalctl --file="$file" --no-pager -n 500 -o json 2>/dev/null \
+           | jq -s '
+               def n($x): (($x // "0") | tonumber);
+               reduce .[] as $r
+                 ({records:0, start:0, end:0, observation:0,
+                   end_eq_source:0, positive_duration:0};
+                  .records += 1
+                  | .start += (if n($r.FLOW_START_USEC) > 0 then 1 else 0 end)
+                  | .end += (if n($r.FLOW_END_USEC) > 0 then 1 else 0 end)
+                  | .observation +=
+                      (if n($r.OBSERVATION_TIME_MILLIS) > 0 then 1 else 0 end)
+                  | .end_eq_source +=
+                      (if n($r.FLOW_END_USEC) > 0 and
+                          n($r.FLOW_END_USEC) == n($r._SOURCE_REALTIME_TIMESTAMP)
+                       then 1 else 0 end)
+                  | .positive_duration +=
+                      (if n($r.FLOW_START_USEC) > 0 and
+                          n($r.FLOW_END_USEC) > n($r.FLOW_START_USEC)
+                       then 1 else 0 end))'
+       done \
+     | jq -s '
+         reduce .[] as $x
+           ({files_sampled:length, records:0, start:0, end:0, observation:0,
+             end_eq_source:0, positive_duration:0};
+            .records += $x.records
+            | .start += $x.start
+            | .end += $x.end
+            | .observation += $x.observation
+            | .end_eq_source += $x.end_eq_source
+            | .positive_duration += $x.positive_duration)'
+   ```
+
+5. Interpret the aggregate with Netdata's decoder semantics:
+
+   - `start > 0` and `positive_duration > 0`: at least some records contain a
+     usable interval. Validate clock ordering and duration distribution before
+     using it for pro-rating.
+   - `start == 0`: no sampled record has a usable duration, regardless of
+     whether `end` is populated.
+   - `end == end_eq_source` together with no start is evidence that the stored
+     end is the collector input-time fallback. Netdata fills a missing flow end
+     with `input_realtime_usec` before storage in
+     `src/crates/netflow-plugin/src/decoder.rs`.
+   - `observation > 0` is a separate timestamp and does not by itself provide a
+     flow duration.
+
+## Output
+
+The result is a compact aggregate such as:
+
+```json
+{
+  "files_sampled": 100,
+  "records": 50000,
+  "start": 0,
+  "end": 50000,
+  "observation": 0,
+  "end_eq_source": 50000,
+  "positive_duration": 0
+}
+```
+
+This example means the retained records do not contain a usable flow interval.
+The apparent end timestamp is receive-time fallback data, not proof that the
+exporter supplied an end time.
+
+## Notes / gotchas
+
+- The field catalog checks the complete retained journal set; the numeric
+  coverage command is deliberately a stratified sample to avoid scanning and
+  materializing every sensitive row.
+- Equality with `_SOURCE_REALTIME_TIMESTAMP` must be interpreted together with
+  the Agent's timestamp-source configuration. With the default `input` source,
+  it is collector reception time.
+- Never save `journalctl -o json` output for raw flows in a durable or committed
+  location. Stream directly into aggregate-only `jq` processing.
+- A start/end interval supports only uniform-rate estimation. It cannot recover
+  bursts inside the interval.
+
+## Source guides
+
+- [Direct-agent skill](../SKILL.md)
+- [Network-flow Functions](../query-flows.md)
+- [Validate a local flow Function](./validate-direct-local-flow-function.md)
+

--- a/docs/netdata-ai/skills/query-netdata-cloud/how-tos/INDEX.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/how-tos/INDEX.md
@@ -56,11 +56,17 @@ skill-verification harness questions for `verify/questions.md`; replace each
 - `find-node-hardware-specs.md` (stub -- not yet authored)
 - `find-node-os.md` (stub -- not yet authored)
 
+### Metrics / fleet SLOs
+
+- [`compare-explicit-and-room-wide-node-scope.md`](./compare-explicit-and-room-wide-node-scope.md) -- compare a fixed UUID scope with the current room-wide node scope; explains why all-room queries omit `scope.nodes` and use `selectors.nodes: ["*"]`, why a large UUID selector is redundant and expensive, and how to pass large payloads through the token-safe wrapper with `@file`.
+- [`fleet-connectivity-slo-queries.md`](./fleet-connectivity-slo-queries.md) -- single-dimension fleet percentages (percent of devices connected/streaming, percent of devices with a boolean dimension at 1 or 0) and ranking devices by percent of time a boolean dimension was 0; includes the average-of-boolean trick and the countif-through-Cloud caveat.
+
 ### Streaming / parents / vnodes
 
 - `is-node-a-parent-and-children.md` (stub -- not yet authored)
 - `is-node-a-child-and-parent-target.md` (stub -- not yet authored)
 - `list-vnodes-on-node.md` (stub -- not yet authored)
+- [`diagnose-no-data-on-zoom-parent-retention-gaps.md`](./diagnose-no-data-on-zoom-parent-retention-gaps.md) -- why a node shows "No data" when zooming in while wider zoom renders fine: identify the serving agent from jsonwrap `.agents`, compare forced-tier queries (tier 0 vs 1 vs 2), reduce all-null rows to gap runs, run the decisive control test (does the PARENT's own local data have the same tier0 hole?), read the parent's daemon log via the `windows-events`/`systemd-journal` Function for `DBENGINE` write errors, and quantify child streaming flapping via `netdata.streaming_outbound` `replicating` buckets.
 
 ### Collectors / jobs
 

--- a/docs/netdata-ai/skills/query-netdata-cloud/how-tos/compare-explicit-and-room-wide-node-scope.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/how-tos/compare-explicit-and-room-wide-node-scope.md
@@ -1,0 +1,285 @@
+# Compare explicit node scope with all room nodes
+
+## Question
+
+What changes when a Cloud Scope Data query contains an explicit list of node
+UUIDs instead of selecting all current nodes in the room with `"*"`?
+
+## Inputs
+
+- `SPACE`: Space UUID.
+- `ROOM`: Room UUID.
+- `CONTEXT`: metric context to query, such as `system.cpu`.
+- A repository `.env` containing `NETDATA_CLOUD_TOKEN` and
+  `NETDATA_CLOUD_HOSTNAME`.
+
+Prepare the token-safe wrapper and a private audit directory once:
+
+```bash
+cd /path/to/netdata
+
+source docs/netdata-ai/skills/query-netdata-agents/scripts/_lib.sh
+agents_load_env
+
+SPACE="YOUR_SPACE_ID"
+ROOM="YOUR_ROOM_ID"
+CONTEXT="system.cpu"
+BEFORE=$(date +%s)
+AFTER=$((BEFORE - 300))
+
+AUDIT="$(agents_audit_dir)/cloud-node-scope-comparison"
+mkdir -p "$AUDIT"
+chmod 0700 "$AUDIT"
+umask 077
+```
+
+Raw node inventories and query responses contain node identities. Keep them
+under `.local/audits/`; do not paste them into issues, documentation, or logs.
+
+## Steps
+
+### 1. Capture the current room node inventory
+
+This provides the explicit snapshot used by the comparison.
+
+```bash
+agents_query_cloud POST \
+  "/api/v3/spaces/$SPACE/rooms/$ROOM/nodes" \
+  '{}' >"$AUDIT/room-nodes.json"
+
+jq '[.nodes[].nd]' "$AUDIT/room-nodes.json" \
+  >"$AUDIT/explicit-node-ids.json"
+```
+
+This step makes one wrapper call. The `jq` command only prepares the private
+input for the next call.
+
+### 2. Query the explicit node snapshot efficiently
+
+Put UUIDs only in `scope.nodes`. Use `"*"` in `selectors.nodes` to select every
+node already admitted by that scope.
+
+```bash
+jq -n \
+  --slurpfile nodes "$AUDIT/explicit-node-ids.json" \
+  --arg context "$CONTEXT" \
+  --argjson after "$AFTER" \
+  --argjson before "$BEFORE" \
+  '{
+    scope: {
+      nodes: $nodes[0],
+      contexts: [$context]
+    },
+    selectors: {
+      nodes: ["*"],
+      contexts: ["*"],
+      instances: ["*"],
+      dimensions: ["*"],
+      labels: ["*"],
+      alerts: ["*"]
+    },
+    window: {
+      after: $after,
+      before: $before,
+      points: 1
+    },
+    aggregations: {
+      metrics: [{group_by: ["node"], aggregation: "sum"}],
+      time: {time_group: "average"}
+    },
+    format: "json2",
+    options: ["jsonwrap", "minify", "unaligned"],
+    timeout: 180000
+  }' >"$AUDIT/request-explicit-scope.json"
+
+agents_query_cloud POST \
+  "/api/v3/spaces/$SPACE/rooms/$ROOM/data" \
+  "@$AUDIT/request-explicit-scope.json" \
+  >"$AUDIT/response-explicit-scope.json"
+```
+
+Passing `@file` through `agents_query_cloud` is important for large fleets. A
+large JSON body passed inline becomes one process argument and can exceed the
+operating system's per-argument limit before cURL makes a network request.
+
+### 3. Query all current room nodes
+
+Omit `scope.nodes`. Keep `selectors.nodes: ["*"]`.
+
+```bash
+jq -n \
+  --arg context "$CONTEXT" \
+  --argjson after "$AFTER" \
+  --argjson before "$BEFORE" \
+  '{
+    scope: {
+      contexts: [$context]
+    },
+    selectors: {
+      nodes: ["*"],
+      contexts: ["*"],
+      instances: ["*"],
+      dimensions: ["*"],
+      labels: ["*"],
+      alerts: ["*"]
+    },
+    window: {
+      after: $after,
+      before: $before,
+      points: 1
+    },
+    aggregations: {
+      metrics: [{group_by: ["node"], aggregation: "sum"}],
+      time: {time_group: "average"}
+    },
+    format: "json2",
+    options: ["jsonwrap", "minify", "unaligned"],
+    timeout: 180000
+  }' >"$AUDIT/request-room-scope.json"
+
+agents_query_cloud POST \
+  "/api/v3/spaces/$SPACE/rooms/$ROOM/data" \
+  "@$AUDIT/request-room-scope.json" \
+  >"$AUDIT/response-room-scope.json"
+```
+
+### 4. Compare sanitized response summaries locally
+
+This step makes no API call and does not print node identities:
+
+```bash
+for response in \
+  "$AUDIT/response-explicit-scope.json" \
+  "$AUDIT/response-room-scope.json"; do
+  jq '{
+    summary_nodes: ((.summary.nodes // []) | length),
+    selected_nodes: (.totals.nodes.sl // 0),
+    queried_nodes: (.totals.nodes.qr // 0),
+    result_series: (((.result.labels // []) | length) - 1),
+    result_rows: ((.result.data // []) | length),
+    timings: .timings
+  }' "$response"
+
+  jq -cS '.result' "$response" | sha256sum
+done
+```
+
+For a stable room whose explicit snapshot still equals current membership, the
+two forms target the same node universe and should produce equivalent results.
+Sequential calls can still differ if routing, context availability, or node data
+changes between them.
+
+This equivalence applies only to the two request forms shown above: explicit
+`scope.nodes` plus a wildcard selector, and omitted `scope.nodes` plus a wildcard
+selector. It does not apply to duplicating a fleet-sized UUID list in
+`selectors.nodes`; that form can be corrupted in downstream transport.
+
+## Output
+
+Return only:
+
+- explicit snapshot node count;
+- current room node count;
+- whether the two node-ID sets match;
+- selected and successfully queried node counts for each response;
+- response/result equality or hashes;
+- wall-clock and response timing summaries;
+- any HTTP status or timeout, with identifiers redacted.
+
+Do not return raw response bodies, UUIDs, hostnames, machine GUIDs, claim IDs, or
+tokens.
+
+## Verified oversized-selector failure decomposition
+
+In one sanitized large-fleet A/B, both requests retained the same explicit
+`scope.nodes` list and every other field. Only `selectors.nodes` changed between
+`["*"]` and a duplicate copy of the full UUID list.
+
+| Response section | `"*"` selector | UUID-list selector | Delta |
+|---|---:|---:|---:|
+| Entire response | 3,113,406 bytes | 42,218,154 bytes | +39,104,748 bytes |
+| `summary` | 2,084,959 bytes | 35,741,434 bytes | +33,656,475 bytes |
+| `result` | 225,791 bytes | 6,240,138 bytes | +6,014,347 bytes |
+| `view` | 439,166 bytes | 145,786 bytes | -293,380 bytes |
+| `db` | 362,273 bytes | 89,515 bytes | -272,758 bytes |
+
+The UUID-list response was larger even though it returned fewer nodes and
+series:
+
+- `summary.instances` grew from 4,463 entries / 832,077 bytes to 399,230
+  entries / 35,248,814 bytes. This single field added 34,416,737 bytes, or
+  88.01% of the total response delta.
+- Time-series rows grew from 1 to 301. Result value cells grew from 4,437 to
+  441,868, while returned series fell from 4,437 to 1,468.
+- Node metadata fell from 4,463 to 1,620 entries, offsetting 824,911 bytes of
+  the expansion. The percentages of positive contributors therefore exceed
+  100% before subtracting the smaller sections.
+
+This is evidence of a changed query, not legitimate UUID-list overhead. The
+oversized `nodes` selector is truncated before `points`, `scope_contexts`, and
+`scope_nodes`. The missing context scope expands metadata to excluded contexts
+and instances; the missing one-point request defaults to all available points;
+and the missing node scope makes the truncated selector prefix act as scope.
+
+Cloud split the scoped nodes across three routed requests in this run. Their
+decoded Agent URLs were 52,207, 55,500, and 58,312 bytes with `"*"`, all below
+the 65,536-byte limit. Duplicating the UUID list in the selector increased them
+to 278,164, 281,457, and 284,269 bytes. Truncation occurred inside `nodes`
+after approximately 1,767 complete UUID patterns, before any later parameter.
+
+## Notes / gotchas
+
+- **All current room nodes:** omit `scope.nodes`; set
+  `selectors.nodes: ["*"]`.
+- **Fixed subset with tight metadata:** put exact UUIDs in `scope.nodes`; keep
+  `selectors.nodes: ["*"]` unless a second data-only filter is genuinely needed.
+- **Do not use `scope.nodes: ["*"]`:** the Cloud JSON endpoint validates scope
+  node entries as UUIDs and rejects `"*"` with HTTP 400.
+- **Never duplicate a fleet-sized UUID list in `selectors.nodes`:** Cloud sends
+  the full selector to every routed Agent or Parent in a GET query parameter.
+  The Agent decodes at most 65,536 URL bytes and silently keeps the truncated
+  prefix. Since the `nodes` parameter sorts before parameters including
+  `options`, `points`, `scope_contexts`, `scope_nodes`, `time_group`, and
+  `timeout`, truncation can discard those parameters too. Verified outcomes
+  include a wrong node subset, a one-point request returning the default
+  per-second rows, metadata expansion, a much larger response, and timeout.
+  Keep exact UUIDs only in `scope.nodes` and use `selectors.nodes: ["*"]`.
+- **Large routed scopes still need care:** Cloud partitions `scope.nodes` by
+  route, while it copies `selectors.nodes` wholesale. Partitioning made the
+  wildcard-selector form fit in the verified case, but a sufficiently large
+  single routed scope can still approach the same Agent URL limit.
+- **Separate four independent effects:**
+  - Node scope and selectors determine which nodes are eligible.
+  - `group_by: ["node"]` can return one result series per eligible node.
+  - The aggregation-pass chain determines the numeric values of those results.
+  - Duplicating UUIDs in the selector can corrupt the downstream request before
+    matching begins.
+
+  A large series count, an inflated aggregate value, and an expensive request
+  require different diagnoses. They are not evidence that UUID selection itself
+  changes aggregation math. Compare the same node set and aggregation chain
+  before attributing a difference to the selector form.
+- **Scope and selector are different:** scope controls data and metadata;
+  selectors filter queried data inside that scope.
+- **Room-wide is dynamic:** nodes added to the room become eligible without
+  rebuilding the request. An explicit list is a snapshot and cannot include
+  later additions.
+- **Revisit a copied `limit`:** `limit` caps returned result dimensions, not the
+  room scope. With `group_by: ["node"]`, a value copied from today's node count
+  can truncate future node series. Omit it when no explicit result cap is
+  intended.
+- **`"*"` does not guarantee one series per room node:** the context, dimensions,
+  time window, routing, retention, and node state still determine which nodes
+  have queryable data.
+- **Keep `scope.contexts`:** omitting it broadens metadata to every context in the
+  room and can produce a very large response.
+- **Latency is not deterministic:** compare semantics and payload size first;
+  transient routing or Agent delays can dominate individual timing samples.
+
+## Source guides
+
+- [`query-metrics.md`](../query-metrics.md) — Scope Data request fields,
+  scope/selector semantics, response structure, and query limits.
+- [`query-nodes.md`](../query-nodes.md) — room node inventory and node metadata.
+- [`SKILL.md`](../SKILL.md) — authentication, token-safe wrappers, and sensitive
+  data handling.

--- a/docs/netdata-ai/skills/query-netdata-cloud/how-tos/diagnose-no-data-on-zoom-parent-retention-gaps.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/how-tos/diagnose-no-data-on-zoom-parent-retention-gaps.md
@@ -1,0 +1,211 @@
+# Diagnose "No data on zoom" / per-chart data gaps for a node behind Netdata Parents
+
+## Symptom
+
+- Zooming into a time range on a node's charts shows **"No data"**, while the
+  same range renders fine at a wider zoom level (coarser points-per-pixel).
+- Different charts of the same node show **different multi-hour gaps** at the
+  same zoom level.
+- Data "comes back on its own" without any restart or operator action.
+
+## Root-cause pattern this how-to detects
+
+The node streams to one or more Netdata Parents and is connected to Cloud
+**indirectly** (`connection_type: "indirect"` — the child is not claimed, so
+every Cloud query is served by a parent's copy of the data). The parent has
+**holes in tier0** (per-second data) while tier1/tier2 (per-minute/per-hour)
+are complete. The dashboard's zoomed queries need tier0 → "No data"; wide
+queries are satisfied by higher tiers → data appears.
+
+Tier1/tier2 are generated on the parent from the same ingested samples as
+tier0 — they are never replicated. So **tier1 full + tier0 empty on the same
+agent proves the samples were ingested and tier0 lost them at/after storage**
+(each tier writes to its own datafiles and file descriptors). The verified
+real-world case behind this how-to: the parent's active tier0 datafile file
+descriptor went bad (`EBADF`), every extent write failed for ~5 hours until
+the datafile rotated, and all hosts stored on that parent lost tier0 for the
+window — while streaming, ingestion, tier1 and tier2 continued normally.
+Steps 6–7 below discriminate this from streaming/replication problems.
+
+## Step 0 — prerequisites
+
+Source the token-safe wrappers and resolve space/room/node IDs (see
+[SKILL.md](../SKILL.md) discovery endpoints):
+
+```bash
+source docs/netdata-ai/skills/query-netdata-agents/scripts/_lib.sh
+agents_load_env
+SPACE="YOUR_SPACE_ID"; ROOM="YOUR_ROOM_ID"; NODE="YOUR_NODE_UUID"
+```
+
+## Step 1 — check how the node is connected to Cloud
+
+```bash
+agents_query_cloud POST "/api/v3/spaces/$SPACE/rooms/$ROOM/nodes" '{}' \
+  | jq '.nodes[] | select(.nd == "'$NODE'") | {nm, v, state, replication, isPreferred}'
+```
+
+`replication.connection_type: "indirect"` means Cloud can only see what the
+parents hold — the child's local (usually complete) retention is unreachable.
+
+## Step 2 — reproduce the zoom query and identify the serving agent + tier
+
+Query the suspect window at high resolution (5s/point or finer) with
+`options: ["jsonwrap"]`. The response's `.agents[0].nm` is the agent that
+served the query; `.db.per_tier[]` shows how many points each tier provided.
+
+```bash
+read -r -d '' PAYLOAD <<EOF
+{
+  "scope": { "nodes": ["$NODE"], "contexts": ["system.cpu"] },
+  "selectors": { "nodes": ["*"], "contexts": ["*"], "instances": ["*"], "dimensions": ["*"], "labels": ["*"] },
+  "window": { "after": WINDOW_START_EPOCH, "before": WINDOW_END_EPOCH, "points": 360 },
+  "aggregations": { "metrics": [{ "group_by": ["dimension"], "aggregation": "avg" }], "time": { "time_group": "average" } },
+  "format": "json2", "options": ["jsonwrap", "minify"], "timeout": 30000
+}
+EOF
+agents_query_cloud POST "/api/v3/spaces/$SPACE/rooms/$ROOM/data" "$PAYLOAD" \
+  | jq '{served_by: .agents[0].nm, per_tier: [.db.per_tier[] | {tier, points}],
+         null_rows: ([.result.data[] | select(([.[1:][] | .[0]] | map(select(. != null)) | length) == 0)] | length),
+         rows: (.result.data | length)}'
+```
+
+In json2 format each cell is a tuple `[value, anomaly_rate, annotation]` —
+test `.[0]` for null, not the tuple itself.
+
+## Step 3 — compare tiers over the same window
+
+Re-run the same payload with `"tier": 0`, then `"tier": 1`, then `"tier": 2`
+added to `window`. The signature of this failure mode:
+
+- tier 0 → all rows null, `per_tier[0].points` near zero
+- tier 1 and 2 → full data
+
+## Step 4 — map the tier0 holes over a wide window
+
+Force `"tier": 0`, widen the window (several hours), 500 points, then reduce
+consecutive all-null rows to gap runs:
+
+```bash
+jq -r '.result.data | sort_by(.[0])
+  | map({ts: .[0], null: (([.[1:][] | .[0]] | map(select(. != null)) | length) == 0)})
+  | reduce .[] as $p ({runs: [], cur: null};
+      if $p.null then (if .cur == null then .cur = {s: $p.ts, e: $p.ts} else .cur.e = $p.ts end)
+      else (if .cur != null then .runs += [.cur] | .cur = null else . end) end)
+  | (.runs + (if .cur then [.cur] else [] end))
+  | map("GAP \(.s|strftime("%m-%d %H:%M")) -> \(.e|strftime("%m-%d %H:%M")) UTC (\(((.e-.s)/60)|floor) min)") | .[]'
+```
+
+Repeat for several contexts (e.g. `system.cpu` plus a few collector charts).
+Per-chart different holes ⇒ per-chart replication starvation, not a collector
+outage.
+
+## Step 5 — quantify streaming flapping on the child
+
+Context `netdata.streaming_outbound` (dimensions: `connecting`, `pending`,
+`offline`, `waiting`, `replicating`, `running`, `no dst`, `failed`). Query
+with `group_by: ["dimension"]`, `aggregation: "max"`, `time_group: "max"`,
+~2-minute buckets. Count buckets where `replicating >= 0.5`:
+
+- A healthy child shows `replicating` only right after a (re)connect.
+- A flapping child shows `replicating` touching 1 in a large fraction of all
+  buckets (in the incident that produced this how-to: 74% and 94% on the two
+  affected children — a reconnect + re-replication every ~4–6 minutes, around
+  the clock).
+
+Check sibling nodes too: if several children flap, the cause is the network
+path or the parent, not the node.
+
+On the parent, context `netdata.streaming_inbound` (instances
+`..._permanent` / `..._ephemeral`) gives the aggregate view: the average of
+the `replicating` dimension over time is the fraction of time at least one
+child was replicating.
+
+## Step 6 — THE CONTROL TEST: check the parent's own local charts
+
+This is the decisive discriminator. Run the Step 4 gap map against the
+**parent's own node** (its `system.cpu`, `netdata.server_cpu` — data that
+never crossed the network), and against the parent's other children:
+
+- Parent's own charts have the **same tier0 hole** ⇒ the problem is local to
+  the parent's dbengine tier0 storage. Streaming/replication is NOT the
+  cause, no matter how bad the flapping looks.
+- Parent's own charts are clean, only streamed children have holes ⇒ the
+  problem is in delivery (streaming/replication starvation).
+
+Also run the gap map on the *other* parents' own charts — if only one parent
+is affected, the fault is that machine, not the fleet.
+
+Corroborating signals on the affected parent for the local-storage case
+(query them over the incident window; use auto/tier1 so you can see values
+inside the tier0 hole):
+
+- `netdata.db_samples_collected` steady across the hole ⇒ ingestion never
+  stopped; the engine accepted the samples.
+- `netdata.uptime` monotonic ⇒ no restart, so the loss was not a crash.
+- `netdata.memory` / `system.ram` sane ⇒ not memory pressure.
+
+## Step 7 — read the parent's daemon log for storage errors
+
+The parent's own error log names the failing operation. On a Windows parent,
+Netdata registers Event Log channels — query the `windows-events` Function
+through Cloud (source ids from `info=true`; note `Netdata/Daemon` is a small
+circular buffer, ~1 MiB, so hours-old triggers may already be overwritten —
+check early):
+
+```bash
+read -r -d '' PAYLOAD <<EOF
+{
+  "after": WINDOW_START_EPOCH, "before": WINDOW_END_EPOCH, "last": 300,
+  "query": "dbengine",
+  "selections": { "__logs_sources": ["Netdata/Daemon"] }
+}
+EOF
+agents_call_function --via cloud --node "PARENT_NODE_UUID" \
+  --function windows-events --body "$PAYLOAD"
+```
+
+On a Linux parent, use `systemd-journal` with the same payload shape.
+
+In the verified incident this returned
+`DBENGINE: Tier 0, bad file descriptor` (Unix errno 9) repeating every 10
+seconds (the dbengine extent-write error is rate-limited to 1 per 10s) for
+~5 hours, ending seconds before `created datafile-1-NNNN` — and the
+journalfile of the dying datafile indexed at a tiny fraction of its healthy
+neighbors (6.63MiB/724 extents vs 187MiB/32893 extents). Every extent write
+during the window was dropped; rotation to a fresh datafile (new fd)
+self-healed the storage. The Windows `System` channel around the trigger
+time can reveal external causes (updates, snapshots, time changes).
+
+## Interpreting the result
+
+| Evidence | Conclusion |
+|---|---|
+| Zoom query served by a parent, tier0 all null, tier1/2 full | Parent has tier0 holes; dashboard zoom hits tier0. Samples WERE ingested (tier1 proves it) — tier0 lost them locally |
+| Parent's OWN charts have the same hole (Step 6) | Parent-local dbengine tier0 storage failure — not streaming |
+| Only streamed children have holes, parent's own charts clean | Delivery problem: streaming flaps / replication starvation |
+| Different gap boundaries per context | Page-granular loss (each metric's pages span different ranges) |
+| `replicating` active in most buckets on `netdata.streaming_outbound` | Child↔parent link flaps or parent throttles replication (chronic issue worth its own follow-up, but not necessarily the data-loss cause) |
+| `connection_type: "indirect"` | Cloud cannot fall back to the child's local retention |
+| Daemon log: `DBENGINE: Tier N, <io error>` every 10s (Step 7) | Extent writes failing; data dropped at flush; identify what invalidated the fd/filesystem |
+
+Fix directions depend on which case Step 6 proved: for parent-local storage
+failures, investigate the parent machine (filesystem, AV/backup agents
+touching the dbengine files, disk health) and report the daemon-log evidence
+to Netdata engineering; for delivery problems, fix the network path /
+parent capacity, consider claiming the children directly, and upgrade agents
+if the version predates streaming stability fixes.
+
+Note: replication in the streaming protocol transfers **tier0 only**
+(`stream-replication-sender.c` queries `rd->tiers[0].smh`); tier1/tier2 are
+generated on each agent from what it ingests. This is why "tier1 has it,
+tier0 doesn't" can never be produced by replication — it always means local
+tier0 storage loss on the serving agent.
+
+## Source guides
+
+- [query-metrics.md](../query-metrics.md) — request body reference
+  (scope, selectors, window, aggregations, response shape)
+- [query-logs.md](../query-logs.md) — systemd-journal / windows-events
+  Function payload reference
+- SKILL.md — discovery endpoints (`/spaces`, `/rooms`, `/nodes`)

--- a/docs/netdata-ai/skills/query-netdata-cloud/how-tos/fleet-connectivity-slo-queries.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/how-tos/fleet-connectivity-slo-queries.md
@@ -1,0 +1,150 @@
+# Fleet connectivity SLO queries (percent connected, boolean-dimension ratios, device ranking)
+
+## Question
+
+For a fleet of devices (IoT gateways, robots, edge nodes) streaming to
+Netdata parents:
+
+1. Single chart, 1 dimension: what percentage of the fleet is connected
+   (streaming) right now / over time?
+2. Single chart, 1 dimension: what percentage of devices have a boolean
+   (0/1) collector dimension set to 1 (e.g. an "upstream reachable"
+   check)?
+3. The opposite: percentage of devices with that dimension at 0.
+4. Rank/filter devices by the percentage of time the boolean dimension
+   was 0 (find the devices that never connect).
+
+## Inputs
+
+- `TOKEN`, `SPACE`, `ROOM` (see SKILL.md prerequisites)
+- The boolean context and dimension name, e.g. context
+  `mycollector.upstream_connectivity`, dimension `Overall`
+- A time window (`after` in relative seconds)
+
+## Key insight: `average` of a 0/1 metric IS the ratio
+
+All four questions reduce to one trick: the **average of a 0/1 series
+is the fraction of 1s**. No `countif` needed (see gotcha 3):
+
+- Averaged **across devices** at each point in time → fraction of the
+  fleet at 1 at that moment (questions 1, 2, 3).
+- Averaged **over time** per device → fraction of time that device was
+  at 1 (question 4).
+
+## Steps
+
+1. **Percent of fleet connected (from the parents' per-child streaming
+   state).** Netdata parents (v2.10.0-nightly 2026-06+ pulse) expose
+   `netdata.streaming.in.state` — a per-child one-hot chart with 0/1
+   dimensions `running`, `offline`, `archived`, `waiting`,
+   `waiting replication`, `replicating`. The fleet ratio is the average
+   of `running` across all tracked children:
+
+   ```bash
+   source docs/netdata-ai/skills/query-netdata-agents/scripts/_lib.sh
+   agents_load_env
+   agents_query_cloud POST /api/v3/spaces/$SPACE/rooms/$ROOM/data '{
+    "scope":{"contexts":["netdata.streaming.in.state"],"dimensions":["running"]},
+    "selectors":{"nodes":["*"],"contexts":["*"],"instances":["*"],"dimensions":["*"],"labels":["*"],"alerts":["*"]},
+    "window":{"after":-21600,"before":0,"points":12},
+    "aggregations":{"metrics":[{"group_by":["selected"],"aggregation":"avg"}],
+                    "time":{"time_group":"average"}},
+    "format":"json2","options":["jsonwrap","minify","unaligned"],"timeout":60000}' \
+   | jq -r '.result.data[] | [(.[0]|todate), ((.[1][0]*10000|round)/100)] | @tsv'
+   ```
+
+   One column, values 0–1 (multiply by 100 for %). The denominator is
+   every child the parents still track — including `archived` ones
+   (see gotcha 1).
+
+2. **Percent of devices with a boolean dimension at 1.** Same pattern
+   on the collector context — average the 0/1 dimension across all
+   instances:
+
+   ```bash
+   agents_query_cloud POST /api/v3/spaces/$SPACE/rooms/$ROOM/data '{
+    "scope":{"contexts":["CONTEXT"],"dimensions":["DIMENSION"]},
+    "selectors":{"nodes":["*"],"contexts":["*"],"instances":["*"],"dimensions":["*"],"labels":["*"],"alerts":["*"]},
+    "window":{"after":-21600,"before":0,"points":12},
+    "aggregations":{"metrics":[{"group_by":["selected"],"aggregation":"avg"}],
+                    "time":{"time_group":"average"}},
+    "format":"json2","options":["jsonwrap","minify","unaligned"],"timeout":60000}' \
+   | jq -r '.result.data[] | [(.[0]|todate), ((.[1][0]*10000|round)/100)] | @tsv'
+   ```
+
+3. **The opposite ratio** is `100 − (step 2)`, computed client-side:
+
+   ```bash
+   ... | jq -r '.result.data[] | [(.[0]|todate), (100 - (.[1][0]*10000|round)/100)] | @tsv'
+   ```
+
+   Do NOT use `time_group: countif "=0"` through Netdata Cloud for
+   this — see gotcha 3.
+
+4. **Rank devices by percent of time the dimension was 1 (or 0).**
+   Group by node, average over the whole window into a single point,
+   then sort client-side:
+
+   ```bash
+   agents_query_cloud POST /api/v3/spaces/$SPACE/rooms/$ROOM/data '{
+    "scope":{"contexts":["CONTEXT"],"dimensions":["DIMENSION"]},
+    "selectors":{"nodes":["*"],"contexts":["*"],"instances":["*"],"dimensions":["*"],"labels":["*"],"alerts":["*"]},
+    "window":{"after":-86400,"before":0,"points":1},
+    "aggregations":{"metrics":[{"group_by":["node"],"aggregation":"avg"}],
+                    "time":{"time_group":"average"}},
+    "format":"json2","options":["jsonwrap","minify","unaligned"],"timeout":120000}' > /tmp/rank.json
+
+   # bottom 20 = devices with the LOWEST fraction of time at 1
+   jq -r '.view.dimensions as $d
+          | [range(0; ($d.ids|length)) | {n:$d.names[.], v:$d.sts.avg[.]}]
+          | sort_by(.v) | .[:20][]
+          | [((.v*10000|round)/100|tostring)+"%", .n] | @tsv' /tmp/rank.json
+   ```
+
+   `sort_by(.v)` ascending = most-disconnected first; `sort_by(-.v)`
+   for the healthiest. The per-device value is in
+   `view.dimensions.sts.avg[]` when `points:1`.
+
+## Output
+
+- Steps 1–3: a timestamped series of fleet-wide percentages (one
+  dimension — chartable as-is).
+- Step 4: a ranked table `percent<TAB>hostname` of all devices.
+
+## Notes / gotchas
+
+1. **Denominator semantics.** In step 1 the denominator is all
+   children the parents track, including `archived` (long-gone or
+   re-parented duplicates), until their charts obsolete. In steps 2–4
+   the denominator is only devices whose collector produced data in
+   the window — fully offline devices drop out of the average
+   entirely (they have gaps, and gap points are excluded from group-by
+   aggregation). Pair step 1 (connectivity) with step 2 (health of the
+   connected) for the complete picture.
+2. **Instances vs room nodes will not match.** Parents can track more
+   children than the room shows as nodes (archived duplicates after
+   re-parenting), so do not expect `totals.instances` to equal the
+   room node count.
+3. **`countif` through Netdata Cloud is unreliable (verified
+   2026-07-06).** On a multi-parent space, `time_group: countif` with
+   `group_by: selected` returned ~29–43% of the true value, and
+   `options: ["percentage"]` returned >100% values. Plain
+   `time_group: average` on the same data returned correct results.
+   Until the Cloud aggregation of these is fixed, use the
+   average-of-boolean trick above. (Direct agent queries are not
+   affected.)
+4. **Tier-0 retention on busy parents is short.** A parent with
+   thousands of children may hold only minutes of per-second data
+   (observed: ~18 minutes with ~5.6k children). Queries over longer
+   windows silently use tier 1+ (per-minute averages) — fine for
+   the average-of-boolean trick, another reason `countif` (which
+   needs raw samples) is fragile here.
+5. **Boolean-ness matters.** These patterns assume the dimension is
+   strictly 0/1. If a collector emits other values, the average is no
+   longer a ratio.
+
+## Source guides
+
+- [query-metrics.md](../query-metrics.md) — request body reference
+  (scope, selectors, window, aggregations, response shape)
+- SKILL.md — discovery endpoints (`/spaces`, `/rooms`, `/nodes`)

--- a/docs/netdata-ai/skills/query-netdata-cloud/query-nodes.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/query-nodes.md
@@ -26,7 +26,7 @@ filter language.
 ## Use the wrapper
 
 ```bash
-source "$(git rev-parse --show-toplevel)/.agents/skills/query-netdata-agents/scripts/_lib.sh"
+source "$(git rev-parse --show-toplevel)/docs/netdata-ai/skills/query-netdata-agents/scripts/_lib.sh"
 agents_load_env
 
 agents_query_cloud POST "/api/v3/spaces/$SPACE/rooms/$ROOM/nodes" '{}'
@@ -37,14 +37,15 @@ never reaches stdout.
 
 ## Per-node response fields
 
-Verified live -- response is a JSON array, each entry an object:
+Verified live -- the response is a JSON object with a `nodes` array. Each entry
+in `.nodes[]` is an object:
 
 | Field | Description |
 |---|---|
 | `nd` | **Node UUID.** This is the value to pass anywhere the API expects a node id (e.g. `/api/v2/nodes/{nd}/function?...`) |
 | `mg` | Machine GUID (stable per OS install) |
 | `nm` | Hostname |
-| `state` | `reachable` (live) / `stale` (disconnected) / `offline` |
+| `state` | `reachable` (live), `stale` (historical data remains), or `unreachable` |
 | `v` | Agent version (e.g. `v2.10.3-nightly`) |
 | `labels` | Object: all `_*` chart-labels keyed by name (architecture, kernel, OS, CPU count, RAM, container/k8s/cloud-provider info) |
 | `hw` | `{cpus, memory, disk_space, architecture}` summary |
@@ -61,19 +62,19 @@ Verified live -- response is a JSON array, each entry an object:
 ```bash
 # Hostname -> node UUID lookup.
 agents_query_cloud POST "/api/v3/spaces/$SPACE/rooms/$ROOM/nodes" '{}' \
-  | jq -r --arg HOST "costa-desktop" '.[] | select(.nm==$HOST) | .nd'
+  | jq -r --arg HOST "example-host" '.nodes[] | select(.nm==$HOST) | .nd'
 
 # All "reachable" nodes' (UUID, hostname, version) tuples.
 agents_query_cloud POST "/api/v3/spaces/$SPACE/rooms/$ROOM/nodes" '{}' \
-  | jq -r '.[] | select(.state=="reachable") | "\(.nd)\t\(.nm)\t\(.v)"'
+  | jq -r '.nodes[] | select(.state=="reachable") | "\(.nd)\t\(.nm)\t\(.v)"'
 
 # Nodes whose label `_is_parent` is true.
 agents_query_cloud POST "/api/v3/spaces/$SPACE/rooms/$ROOM/nodes" '{}' \
-  | jq -r '.[] | select(.labels._is_parent=="true") | .nm'
+  | jq -r '.nodes[] | select(.labels._is_parent=="true") | .nm'
 
 # Aggregate by cloud provider.
 agents_query_cloud POST "/api/v3/spaces/$SPACE/rooms/$ROOM/nodes" '{}' \
-  | jq -r '[.[] | .labels._cloud_provider_type // "unknown"] | group_by(.) | map({(.[0]): length}) | add'
+  | jq -r '[.nodes[] | .labels._cloud_provider_type // "unknown"] | group_by(.) | map({(.[0]): length}) | add'
 ```
 
 ## Hardware / OS facts


### PR DESCRIPTION
### Changes

**query-agent-events:**
- New how-to: trace a stack-symbol crash regression to a concurrent mutator

**query-netdata-agents:**
- New how-to: audit stored flow timestamp coverage via direct Agent API

**query-netdata-cloud:**
- New how-tos: compare explicit vs room-wide node scope, diagnose 'no data on zoom' parent retention gaps, fleet connectivity SLO queries
- Fix `query-nodes.md`: response is `{nodes: [...]}` not a bare array; update `state` values and jq examples

**Other:**
- `.gitignore`: add `corrosion/` and `_deps/` cmake build directories

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five new skill how‑tos across agent‑events, direct Agent, and Cloud queries to improve crash triage, flow timestamp audits, node scoping, zoom‑gap diagnosis, and fleet SLOs. Also fixes `query-netdata-cloud/query-nodes.md` response shape and examples, updates how‑to indexes, and adds `corrosion/` and `_deps/` to `.gitignore`.

- **New Features**
  - `query-agent-events`: how‑to to trace a stack‑symbol crash regression to a concurrent mutator.
  - `query-netdata-agents`: how‑to to audit stored NetFlow/IPFIX timestamp coverage via the direct Agent API (aggregate‑only output; distinguishes exporter timestamps vs receive‑time fallback).
  - `query-netdata-cloud`: how‑tos for explicit vs room‑wide node scope (omit `scope.nodes`, dangers of oversized UUID selectors, `@file` payloads), diagnosing “No data on zoom” from parent tier0 gaps, and fleet connectivity SLOs (average‑of‑boolean pattern, ranking, and the `countif`‑through‑Cloud caveat).

- **Bug Fixes**
  - `query-netdata-cloud/query-nodes.md`: response is `{nodes:[...]}` (not a bare array); update `state` values (`reachable`, `stale`, `unreachable`), fix `jq` paths/selectors, and correct the wrapper `source` path.

<sup>Written for commit 94c46f1be73c165dec024b95ae40601011923a82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

