### PR TITLE
Remove redundant status message for ACLK connection state 

### DIFF
--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -532,9 +532,6 @@ const char *aclk_status_to_string(void) {
         return https_client_resp_t_2str((https_client_resp_t)status);
 
     switch(status) {
-        case ACLK_STATUS_CONNECTED:
-            return "connected";
-
         case ACLK_STATUS_OFFLINE:
             return "offline";
 


### PR DESCRIPTION
##### Summary
- Fix CID 504948 (dead code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant ACLK_STATUS_CONNECTED case in aclk_status_to_string to resolve CID 504948 (dead code). This cleans up an unreachable path and keeps status reporting consistent with the existing HTTPS client mapping.

<sup>Written for commit 3e190261d33af57cd4574c274d32b53faa42ceb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

