### PR TITLE
docs (go.d): wrap hand-authored docs at 120 columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,6 +464,8 @@ When writing or updating these artifacts:
   a multi-requirement paragraph; keep a single rule-plus-rationale as one bullet.
 - Preserve precision over brevity. Formatting is for readability, not for
   weakening contracts or removing necessary evidence.
+- Wrap markdown prose at ~120 columns (SHOULD), not 80. Code blocks, tables, and generated files keep their own
+  formats. Keep reflow-only (whitespace) changes in separate commits from content changes.
 
 ### Open-Source Reference Evidence
 

--- a/src/go/pkg/metrix/README.md
+++ b/src/go/pkg/metrix/README.md
@@ -1,35 +1,29 @@
 # metrix
 
-`metrix` is the metrics storage and read API used by go.d `ModuleV2` collectors
-and runtime/internal components. A collector writes metrics into a store each
-collect cycle; readers (chart planning, tooling) see a consistent, immutable
+`metrix` is the metrics storage and read API used by go.d `ModuleV2` collectors and runtime/internal components. A
+collector writes metrics into a store each collect cycle; readers (chart planning, tooling) see a consistent, immutable
 snapshot of the last successful cycle.
 
-This document is human-oriented. Read it top to bottom as a journey: the
-plain-language model first, then the collect cycle, then the part that makes
-metrix safe for unbounded metric streams — **descriptor identity and
-retention** — and finally the precise API reference, contracts, and pitfalls.
+This document is human-oriented. Read it top to bottom as a journey: the plain-language model first, then the collect
+cycle, then the part that makes metrix safe for unbounded metric streams — **descriptor identity and retention** — and
+finally the precise API reference, contracts, and pitfalls.
 
 **Audience**: `ModuleV2` collector authors and framework contributors.
 
 **See also**: [charttpl](/src/go/plugin/framework/charttpl/README.md) (template DSL),
 [chartengine](/src/go/plugin/framework/chartengine/README.md) (compile + plan),
-[how-to-write-a-collector.md](/src/go/plugin/go.d/docs/how-to-write-a-collector.md)
-(end-to-end integration).
+[how-to-write-a-collector.md](/src/go/plugin/go.d/docs/how-to-write-a-collector.md) (end-to-end integration).
 
 ## What metrix Does
 
-A collector does not build charts or hold metric state itself. It **observes
-values into a store**, and the store owns everything else: series identity,
-per-name descriptors, snapshot publication, and lifecycle.
+A collector does not build charts or hold metric state itself. It **observes values into a store**, and the store owns
+everything else: series identity, per-name descriptors, snapshot publication, and lifecycle.
 
 The central rule is simple:
 
-> One metric **name** has exactly one **descriptor**. The store resolves and
-> publishes that descriptor atomically at commit, keeps it while the name is in
-> use, and **evicts it after the name goes idle** — so an unbounded stream of
-> metric names (statsd, push, client-driven names) cannot grow the store without
-> bound.
+> One metric **name** has exactly one **descriptor**. The store resolves and publishes that descriptor atomically at
+> commit, keeps it while the name is in use, and **evicts it after the name goes idle** — so an unbounded stream of
+> metric names (statsd, push, client-driven names) cannot grow the store without bound.
 
 Two store flavors exist for two kinds of producer:
 
@@ -38,20 +32,17 @@ Two store flavors exist for two kinds of producer:
 | Collector jobs (`ModuleV2`)      | `CollectorStore` | Cycle-scoped writes, snapshot reads, chart planning input  |
 | Internal/runtime instrumentation | `RuntimeStore`   | Stateful immediate-commit writes, runtime metrics planning |
 
-The rest of this document is mostly about `CollectorStore` (the cycle model and
-the descriptor lifecycle). `RuntimeStore` differences are called out where they
-matter.
+The rest of this document is mostly about `CollectorStore` (the cycle model and the descriptor lifecycle).
+`RuntimeStore` differences are called out where they matter.
 
 ## Source Map
 
-`metrix` intentionally keeps its public API and implementation in one Go package.
-The public import path is `github.com/netdata/netdata/go/plugins/pkg/metrix`;
-`metrix/selector` is the only subpackage and imports the root package. The root
-package must not import `selector`, or it would create a cycle.
+`metrix` intentionally keeps its public API and implementation in one Go package. The public import path is
+`github.com/netdata/netdata/go/plugins/pkg/metrix`; `metrix/selector` is the only subpackage and imports the root
+package. The root package must not import `selector`, or it would create a cycle.
 
-This single-package shape preserves root-defined public type identity and avoids
-facade/wrapper overhead on write, commit, read, and Vec hot paths. Use file
-ownership, tests, and docs to keep the package navigable; introduce a new
+This single-package shape preserves root-defined public type identity and avoids facade/wrapper overhead on write,
+commit, read, and Vec hot paths. Use file ownership, tests, and docs to keep the package navigable; introduce a new
 subpackage only when a future concern has a proven one-way dependency boundary.
 
 Current ownership map:
@@ -70,8 +61,8 @@ Current ownership map:
 
 ## The Big Picture
 
-A few words carry the whole model. This table is the vocabulary the rest of the
-document uses; later sections make each part precise.
+A few words carry the whole model. This table is the vocabulary the rest of the document uses; later sections make each
+part precise.
 
 | Term | Plain meaning |
 | --- | --- |
@@ -109,19 +100,17 @@ flowchart LR
 
 Key properties that fall out of this shape:
 
-- **Reads do not take the commit lock.** A reader holds an immutable snapshot;
-  commits swap in a new one. The first index or flattened-view request for a
-  CollectorStore snapshot synchronizes one builder; subsequent readers use the
+- **Reads do not take the commit lock.** A reader holds an immutable snapshot; commits swap in a new one. The first
+  index or flattened-view request for a CollectorStore snapshot synchronizes one builder; subsequent readers use the
   published immutable result concurrently.
-- **Writes are invisible until commit.** A half-collected or failed cycle never
-  leaks partial data to readers.
-- **Commit is transactional.** Either the whole cycle publishes, or (on
-  `AbortCycle` / an unresolvable conflict) nothing changes.
+- **Writes are invisible until commit.** A half-collected or failed cycle never leaks partial data to readers.
+- **Commit is transactional.** Either the whole cycle publishes, or (on `AbortCycle` / an unresolvable conflict) nothing
+  changes.
 
 ## The Collect Cycle
 
-A `CollectorStore` write only exists inside a cycle. The job runtime drives the
-cycle around the collector's `Collect`; `ModuleV2` collectors just write.
+A `CollectorStore` write only exists inside a cycle. The job runtime drives the cycle around the collector's `Collect`;
+`ModuleV2` collectors just write.
 
 | Phase   | Action                                                                                         |
 |---------|------------------------------------------------------------------------------------------------|
@@ -130,51 +119,41 @@ cycle around the collector's `Collect`; `ModuleV2` collectors just write.
 | Success | `CommitCycleSuccess` resolves descriptors, applies retention, and publishes a new snapshot.     |
 | Failure | `AbortCycle` discards all staged writes and staged registrations — the committed state is untouched. |
 
-`RuntimeStore` has **no cycle API**: writes commit immediately, each producing a
-new overlay snapshot, and it is **stateful-only** (snapshot-mode registration
-returns an error; calling snapshot record methods panics).
+`RuntimeStore` has **no cycle API**: writes commit immediately, each producing a new overlay snapshot, and it is
+**stateful-only** (snapshot-mode registration returns an error; calling snapshot record methods panics).
 
 ## Metric Identity: Names, Series, and Descriptors
 
-Every write resolves to a **series** — the metric name plus a canonical key
-built from its sorted labels. Many series can share one name (same metric,
-different label values).
+Every write resolves to a **series** — the metric name plus a canonical key built from its sorted labels. Many series
+can share one name (same metric, different label values).
 
-All series of a name share **one descriptor**. The descriptor is the name's
-contract and is the thing whose growth metrix bounds:
+All series of a name share **one descriptor**. The descriptor is the name's contract and is the thing whose growth
+metrix bounds:
 
-- **Authority** — kind, mode, freshness, window, and the type schema (histogram
-  bounds / summary quantiles). Two writes with different authority for one name
-  are a conflict.
-- **Declaration** — metadata (description, unit, chart family/priority, float).
-  Compatible declarations for one authority are **merged** into a single
-  canonical descriptor; a genuine conflict (e.g. two different units) fails.
+- **Authority** — kind, mode, freshness, window, and the type schema (histogram bounds / summary quantiles). Two writes
+  with different authority for one name are a conflict.
+- **Declaration** — metadata (description, unit, chart family/priority, float). Compatible declarations for one
+  authority are **merged** into a single canonical descriptor; a genuine conflict (e.g. two different units) fails.
 
-At commit the store computes exactly **one canonical descriptor per accepted
-name** and stamps every surviving series of that name with it, so readers,
-the registry, and every series agree regardless of write or label order.
+At commit the store computes exactly **one canonical descriptor per accepted name** and stamps every surviving series of
+that name with it, so readers, the registry, and every series agree regardless of write or label order.
 
 ## Descriptor Lifecycle and Retention
 
-This is the core of why metrix is safe for push-style, client-driven metric
-names. It applies to `CollectorStore` (`RuntimeStore` has its own bounded
-retention path).
+This is the core of why metrix is safe for push-style, client-driven metric names. It applies to `CollectorStore`
+(`RuntimeStore` has its own bounded retention path).
 
 ### Two coupled retentions
 
-Two things age out, on the **successful-commit clock** (only successful commits
-advance it; aborted cycles do not):
+Two things age out, on the **successful-commit clock** (only successful commits advance it; aborted cycles do not):
 
-1. **Series retention** — a series not observed for `expireAfterSuccessCycles`
-   successful commits is evicted. `maxSeries` optionally caps the total series
-   count, evicting the oldest first.
-2. **Descriptor grace** — after a name's *last* series is gone, its descriptor is
-   kept for `descriptorGraceCycles` more successful commits (in case the name
-   returns), then swept from the registry.
+1. **Series retention** — a series not observed for `expireAfterSuccessCycles` successful commits is evicted.
+   `maxSeries` optionally caps the total series count, evicting the oldest first.
+2. **Descriptor grace** — after a name's *last* series is gone, its descriptor is kept for `descriptorGraceCycles` more
+   successful commits (in case the name returns), then swept from the registry.
 
-So a fully idle name's descriptor lives `expire + grace` successful commits past
-its last observation. Defaults: `expire = 10`, `maxSeries = 0` (disabled),
-`grace = expire` (so grace ≥ expire holds by construction).
+So a fully idle name's descriptor lives `expire + grace` successful commits past its last observation. Defaults:
+`expire = 10`, `maxSeries = 0` (disabled), `grace = expire` (so grace ≥ expire holds by construction).
 
 ### The descriptor state machine
 
@@ -202,21 +181,20 @@ flowchart LR
     class evicted hard;
 ```
 
-- **LIVE** — at least one series exists. The descriptor is authoritative; a
-  conflicting re-registration of a truly-live name fails loud.
-- **ZERO-LIVE-IN-GRACE** — the series aged out but the descriptor lingers, so a
-  briefly-absent name resumes without re-registration churn.
-- **EVICTED** — swept from the registry. The name is a clean slate: it may
-  reappear with the **same or a changed** contract and re-register without error.
+- **LIVE** — at least one series exists. The descriptor is authoritative; a conflicting re-registration of a truly-live
+  name fails loud.
+- **ZERO-LIVE-IN-GRACE** — the series aged out but the descriptor lingers, so a briefly-absent name resumes without
+  re-registration churn.
+- **EVICTED** — swept from the registry. The name is a clean slate: it may reappear with the **same or a changed**
+  contract and re-register without error.
 
-The sweep runs at commit, after retention, over the whole descriptor universe
-(the names in the registry) in one pass — bounded work, no per-series refcounts.
+The sweep runs at commit, after retention, over the whole descriptor universe (the names in the registry) in one pass —
+bounded work, no per-series refcounts.
 
 ### Conflict resolution at commit
 
-Because registration is staged and resolved at commit (never a mid-cycle panic
-for collector code), a name observed with an incompatible authority is resolved
-by state:
+Because registration is staged and resolved at commit (never a mid-cycle panic for collector code), a name observed with
+an incompatible authority is resolved by state:
 
 | Situation | Outcome |
 | --- | --- |
@@ -227,11 +205,10 @@ by state:
 
 ### Consumers that cache per-name state
 
-A consumer that caches handles keyed off a metric name (the prometheus writer)
-must keep its cache alive at least as long as metrix keeps the descriptor, or it
-would re-register a name metrix still holds. The store exposes this via an
-**optional** interface (type assertion; not part of `CollectorStore`, so
-existing implementations and fakes keep compiling):
+A consumer that caches handles keyed off a metric name (the prometheus writer) must keep its cache alive at least as
+long as metrix keeps the descriptor, or it would re-register a name metrix still holds. The store exposes this via an
+**optional** interface (type assertion; not part of `CollectorStore`, so existing implementations and fakes keep
+compiling):
 
 ```go
 type DescriptorRetention interface {
@@ -240,20 +217,18 @@ type DescriptorRetention interface {
 }
 ```
 
-`DescriptorRetentionWindow()` returns `DescriptorRetentionUnbounded`
-(`math.MaxUint64`) when series expiry is disabled (`WithExpireAfterSuccessCycles(0)`),
-meaning descriptors can live indefinitely — a consumer must then never age out
-its cached state for that name.
+`DescriptorRetentionWindow()` returns `DescriptorRetentionUnbounded` (`math.MaxUint64`) when series expiry is disabled
+(`WithExpireAfterSuccessCycles(0)`), meaning descriptors can live indefinitely — a consumer must then never age out its
+cached state for that name.
 
 ## Reading
 
-`Read(...)` returns an immutable `Reader` over the latest published snapshot.
-Two independent axes control what and how it reads:
+`Read(...)` returns an immutable `Reader` over the latest published snapshot. Two independent axes control what and how
+it reads:
 
-- **Raw** (`ReadRaw()`) — bypass freshness filtering; return all committed series
-  regardless of when last observed.
-- **Flatten** (`ReadFlatten()`) — project complex types (Histogram, Summary,
-  StateSet, MeasureSet) into individual scalar series.
+- **Raw** (`ReadRaw()`) — bypass freshness filtering; return all committed series regardless of when last observed.
+- **Flatten** (`ReadFlatten()`) — project complex types (Histogram, Summary, StateSet, MeasureSet) into individual
+  scalar series.
 
 | Read options                     | Visibility           | Shape                    |
 |----------------------------------|----------------------|--------------------------|
@@ -264,68 +239,55 @@ Two independent axes control what and how it reads:
 
 **Freshness** decides visibility for non-raw reads:
 
-- `FreshnessCycle` — the series must have been observed in the latest successful
-  cycle to be visible.
-- `FreshnessCommitted` — the series stays visible as long as it is committed,
-  even if not re-observed this cycle.
+- `FreshnessCycle` — the series must have been observed in the latest successful cycle to be visible.
+- `FreshnessCommitted` — the series stays visible as long as it is committed, even if not re-observed this cycle.
 
 **Window** decides how stateful histogram/summary instruments accumulate:
 
 - `WindowCumulative` — observations accumulate across cycles.
 - `WindowCycle` — observations reset each cycle.
 
-The `Reader` interface exposes typed getters
-(`Value/Delta/Histogram/Summary/StateSet/MeasureSet`), metadata
-(`SeriesMeta/MetricMeta/CollectMeta`), host scopes, and iteration helpers
-(`ForEachByName/ForEachSeries/ForEachMatch`).
+The `Reader` interface exposes typed getters (`Value/Delta/Histogram/Summary/StateSet/MeasureSet`), metadata
+(`SeriesMeta/MetricMeta/CollectMeta`), host scopes, and iteration helpers (`ForEachByName/ForEachSeries/ForEachMatch`).
 
 ### Snapshot-owned projection and scope indexes
 
 `CollectorStore` owns read acceleration at the published-snapshot boundary:
 
-- The first `Read(ReadFlatten())` for one exact snapshot builds the complete
-  flattened scalar projection and its deterministic indexes.
+- The first `Read(ReadFlatten())` for one exact snapshot builds the complete flattened scalar projection and its
+  deterministic indexes.
 - Later flattened readers of that snapshot reuse the same immutable projection.
-- A successful commit and a failed/aborted attempt each publish a new exact
-  snapshot, so freshness metadata and cached projections cannot cross the
-  boundary.
-- Scalar gauge/counter series are shared with the canonical snapshot because
-  committed series are immutable. Structured families allocate their synthetic
-  flattened series once per snapshot.
-- Raw and flattened readers use immutable per-scope name indexes. Scoped lookup
-  and iteration therefore depend on that scope's series, not on peer-scope
-  cardinality.
+- A successful commit and a failed/aborted attempt each publish a new exact snapshot, so freshness metadata and cached
+  projections cannot cross the boundary.
+- Scalar gauge/counter series are shared with the canonical snapshot because committed series are immutable. Structured
+  families allocate their synthetic flattened series once per snapshot.
+- Raw and flattened readers use immutable per-scope name indexes. Scoped lookup and iteration therefore depend on that
+  scope's series, not on peer-scope cardinality.
 
-`RuntimeStore` deliberately keeps per-read flattening because its immediate-write
-overlay snapshots have a different lifetime and reuse profile. It still uses
-the same deterministic reader indexes within each read.
+`RuntimeStore` deliberately keeps per-read flattening because its immediate-write overlay snapshots have a different
+lifetime and reuse profile. It still uses the same deterministic reader indexes within each read.
 
 ### Host-scope reads and metadata
 
-- `Read()` selects the default host scope; `ReadHostScope(key)` selects one
-  explicit scope.
-- `HostScopes()` returns every scope present in the snapshot, independent of the
-  reader's active scope. Returned metadata is defensively cloned.
-- `MetricMeta(name)` is scope-local. Fresh readers prefer visible series and may
-  fall back to stale metadata only inside the active scope; raw readers may use
-  stale metadata in that scope. Neither mode falls back to a peer scope.
-- CollectorStore readers optionally implement
-  `FreshVisibleHostScopesReader`. Its `FreshVisibleHostScopes()` result contains
-  only scopes with at least one series visible under normal freshness rules and
-  is independent of `ReadRaw()`.
+- `Read()` selects the default host scope; `ReadHostScope(key)` selects one explicit scope.
+- `HostScopes()` returns every scope present in the snapshot, independent of the reader's active scope. Returned
+  metadata is defensively cloned.
+- `MetricMeta(name)` is scope-local. Fresh readers prefer visible series and may fall back to stale metadata only inside
+  the active scope; raw readers may use stale metadata in that scope. Neither mode falls back to a peer scope.
+- CollectorStore readers optionally implement `FreshVisibleHostScopesReader`. Its `FreshVisibleHostScopes()` result
+  contains only scopes with at least one series visible under normal freshness rules and is independent of `ReadRaw()`.
 
 ## Instruments
 
-An instrument is declared on a meter and identified by its name; observing
-through it writes a series.
+An instrument is declared on a meter and identified by its name; observing through it writes a series.
 
 | Mode     | Meter                | Freshness default    | Window default     |
 |----------|----------------------|----------------------|--------------------|
 | Snapshot | `SnapshotMeter(...)` | `FreshnessCycle`     | `WindowCumulative` |
 | Stateful | `StatefulMeter(...)` | `FreshnessCommitted` | `WindowCumulative` |
 
-Kinds: **Gauge**, **Counter**, **Histogram**, **Summary**, **StateSet**, and
-**MeasureSet** (below). Instruments accept options:
+Kinds: **Gauge**, **Counter**, **Histogram**, **Summary**, **StateSet**, and **MeasureSet** (below). Instruments accept
+options:
 
 | Option                                                                            | Scope                                                                                          |
 |-----------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
@@ -341,15 +303,12 @@ Kinds: **Gauge**, **Counter**, **Histogram**, **Summary**, **StateSet**, and
 
 ## MeasureSet
 
-`MeasureSet` stores one logical metric family with a fixed ordered list of named
-numeric fields — a structured family, similar to `StateSet` for chart autogen.
+`MeasureSet` stores one logical metric family with a fixed ordered list of named numeric fields — a structured family,
+similar to `StateSet` for chart autogen.
 
-- **Family-level semantics** — a family is either gauge-like or counter-like;
-  never mixed per field.
-- **Family-level metadata** — `Description`, `ChartFamily`, and `Unit` apply to
-  the whole family.
-- **Field-level schema** — `MeasureFieldSpec` declares per-field `Name` and
-  `Float`.
+- **Family-level semantics** — a family is either gauge-like or counter-like; never mixed per field.
+- **Family-level metadata** — `Description`, `ChartFamily`, and `Unit` apply to the whole family.
+- **Field-level schema** — `MeasureFieldSpec` declares per-field `Name` and `Float`.
 
 ### Writers
 
@@ -362,13 +321,11 @@ numeric fields — a structured family, similar to `StateSet` for chart autogen.
 
 - **Prefer named write helpers** over raw positional `MeasureSetPoint` values.
 - **Snapshot handles** support full-family positional and named writes.
-- **Stateful handles** additionally support singular field writes
-  (`SetField`/`AddField`), which update only the addressed field on top of the
-  committed/staged family.
-- **Snapshot singular field writes do not exist** (phase 1): snapshot mode models
-  one sampled family point per cycle; partial field visibility is deferred.
-- **Named full-family writes require the exact declared field set** — missing or
-  unknown fields panic.
+- **Stateful handles** additionally support singular field writes (`SetField`/`AddField`), which update only the
+  addressed field on top of the committed/staged family.
+- **Snapshot singular field writes do not exist** (phase 1): snapshot mode models one sampled family point per cycle;
+  partial field visibility is deferred.
+- **Named full-family writes require the exact declared field set** — missing or unknown fields panic.
 
 ### Schema example
 
@@ -419,21 +376,18 @@ usage.AddField("limit", 3)
 | StateSet    | `<name>{<name>=state}` with scalar 0/1 values                                                                    |
 | MeasureSet  | `<name>_<field>{measure_field=field}`; flattened kind follows family semantics (`Gauge` or `Counter`)            |
 
-Histogram bucket flattening emits non-overlapping range bucket totals while
-keeping the `le` label as the bucket upper bound: the first finite bucket is
-`<= le[0]`; each later finite bucket is `(previous le, current le]`; `+Inf` is
-`count - last finite cumulative bucket`. Typed `Histogram()` reads stay canonical
-cumulative points.
+Histogram bucket flattening emits non-overlapping range bucket totals while keeping the `le` label as the bucket upper
+bound: the first finite bucket is `<= le[0]`; each later finite bucket is `(previous le, current le]`; `+Inf` is
+`count - last finite cumulative bucket`. Typed `Histogram()` reads stay canonical cumulative points.
 
-Flatten metadata is exposed via `SeriesMeta.Kind`, `SeriesMeta.SourceKind`, and
-`SeriesMeta.FlattenRole`. `MeasureSet` flattening keeps per-field metric names
-for `MetricMeta(name)` compatibility and adds a synthetic `measure_field=<field>`
-label for explicit field identity.
+Flatten metadata is exposed via `SeriesMeta.Kind`, `SeriesMeta.SourceKind`, and `SeriesMeta.FlattenRole`. `MeasureSet`
+flattening keeps per-field metric names for `MetricMeta(name)` compatibility and adds a synthetic
+`measure_field=<field>` label for explicit field identity.
 
 ## Configuration
 
-`NewCollectorStore(opts ...CollectorStoreOption)` is variadic and additive;
-existing callers keep working. The options tune the retention model above:
+`NewCollectorStore(opts ...CollectorStoreOption)` is variadic and additive; existing callers keep working. The options
+tune the retention model above:
 
 | Option | Default | Effect |
 | --- | --- | --- |
@@ -441,8 +395,8 @@ existing callers keep working. The options tune the retention model above:
 | `WithMaxSeries(n)` | `0` (off) | Hard cap on total committed series; oldest evicted past the cap. |
 | `WithDescriptorGraceCycles(n)` | `= expire` | Successful commits a descriptor is kept after its last series is gone, before the sweep removes it. |
 
-Eviction and drop activity is exposed as cumulative counters on the per-snapshot
-`CollectMeta` (read via `Reader.CollectMeta()`); metrix itself never logs:
+Eviction and drop activity is exposed as cumulative counters on the per-snapshot `CollectMeta` (read via
+`Reader.CollectMeta()`); metrix itself never logs:
 
 | Field | Meaning |
 | --- | --- |
@@ -479,39 +433,34 @@ _ = point
 _ = ok
 ```
 
-For a complete collector integration pattern (cycle management, error handling),
-see [how-to-write-a-collector.md](/src/go/plugin/go.d/docs/how-to-write-a-collector.md).
+For a complete collector integration pattern (cycle management, error handling), see
+[how-to-write-a-collector.md](/src/go/plugin/go.d/docs/how-to-write-a-collector.md).
 
 ## Contracts and Pitfalls
 
-- **Descriptor lifetime is not permanent.** A fully idle name evicts after
-  `expire + grace` successful commits and can then be re-registered with a
-  changed contract. Consumers that cache per-name handles must read
-  `DescriptorRetention` and not outlive the window.
-- **Aborted cycles freeze the clocks.** Retention, grace, and the sweep advance
-  only on successful commits, so endpoint downtime does not age anything out.
+- **Descriptor lifetime is not permanent.** A fully idle name evicts after `expire + grace` successful commits and can
+  then be re-registered with a changed contract. Consumers that cache per-name handles must read `DescriptorRetention`
+  and not outlive the window.
+- **Aborted cycles freeze the clocks.** Retention, grace, and the sweep advance only on successful commits, so endpoint
+  downtime does not age anything out.
 - **Label sets** — `LabelSet` is store-owned; do not share between stores.
-- **Counter deltas** — `Delta()` requires a contiguous sequence (N, N+1). In
-  `CollectorStore` this is per-cycle (a missed successful cycle breaks the delta);
-  in `RuntimeStore` it is per-series per-write (skipping a write does not break it).
-- **Snapshot freshness** — snapshot-mode instruments cannot use
-  `FreshnessCommitted`.
-- **Runtime writes** — `RuntimeStore` rejects snapshot-mode registration with an
-  error; calling snapshot record methods (`ObserveTotal`, `ObservePoint`) panics.
-  MeasureSet families work only through `StatefulMeter(...)`.
-- **MeasureSet named writes** require the exact declared field set; snapshot
-  singular field writes are absent in phase 1.
-- **MeasureSet counter semantics** — stateful counter-like families reject
-  negative `AddPoint(...)` deltas, like scalar counters.
-- **Window/freshness coupling** — stateful histogram/summary with `WindowCycle`
-  requires (and silently forces) `FreshnessCycle`; an explicit non-Cycle freshness
-  with `WindowCycle` is an error.
-- **Truly-live schema conflicts fail the commit.** Re-registering an
-  actively-observed name with a different kind/mode/schema fails loud (transactional);
-  an idle name is superseded instead. Init-time registration keeps a synchronous panic.
-- **Summary NaN quantiles** — a summary point may carry NaN quantile *values*
-  (e.g. an empty window); they are stored (only Inf is rejected) and render as a
-  chart gap downstream. Count and Sum must be finite.
+- **Counter deltas** — `Delta()` requires a contiguous sequence (N, N+1). In `CollectorStore` this is per-cycle (a
+  missed successful cycle breaks the delta); in `RuntimeStore` it is per-series per-write (skipping a write does not
+  break it).
+- **Snapshot freshness** — snapshot-mode instruments cannot use `FreshnessCommitted`.
+- **Runtime writes** — `RuntimeStore` rejects snapshot-mode registration with an error; calling snapshot record methods
+  (`ObserveTotal`, `ObservePoint`) panics. MeasureSet families work only through `StatefulMeter(...)`.
+- **MeasureSet named writes** require the exact declared field set; snapshot singular field writes are absent in
+  phase 1.
+- **MeasureSet counter semantics** — stateful counter-like families reject negative `AddPoint(...)` deltas, like scalar
+  counters.
+- **Window/freshness coupling** — stateful histogram/summary with `WindowCycle` requires (and silently forces)
+  `FreshnessCycle`; an explicit non-Cycle freshness with `WindowCycle` is an error.
+- **Truly-live schema conflicts fail the commit.** Re-registering an actively-observed name with a different
+  kind/mode/schema fails loud (transactional); an idle name is superseded instead. Init-time registration keeps a
+  synchronous panic.
+- **Summary NaN quantiles** — a summary point may carry NaN quantile *values* (e.g. an empty window); they are stored
+  (only Inf is rejected) and render as a chart gap downstream. Count and Sum must be finite.
 
 ## Internal Architecture Notes
 

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -234,16 +234,12 @@ groups:
 | [**groups**](#4-groups)                       | Recursive chart groups — the core of the template. |
 
 > [!NOTE]
-> Some consumers embed a chart template as a **single group** instead of a full
-> spec — for example a
-> [Prometheus profile](/src/go/plugin/go.d/collector/prometheus/profile-format.md)'s
-> `template:` key holds one item of the `groups` list above (written without
-> the leading dash), and the collector supplies `version` and `engine` itself.
-> All group and chart fields documented below apply unchanged; the spec-level
-> `version`, top-level `context_namespace`, and `engine` fields do not. To
-> exclude noisy metrics in that setting, use the consumer's own mechanism --
-> for Prometheus profiles, the job `selector` or a relabeling `drop` rule --
-> since `engine.selector` is unavailable.
+> Some consumers embed a chart template as a **single group** instead of a full spec — for example a
+> [Prometheus profile](/src/go/plugin/go.d/collector/prometheus/profile-format.md)'s `template:` key holds one item of
+> the `groups` list above (written without the leading dash), and the collector supplies `version` and `engine` itself.
+> All group and chart fields documented below apply unchanged; the spec-level `version`, top-level `context_namespace`,
+> and `engine` fields do not. To exclude noisy metrics in that setting, use the consumer's own mechanism -- for
+> Prometheus profiles, the job `selector` or a relabeling `drop` rule -- since `engine.selector` is unavailable.
 
 ---
 

--- a/src/go/plugin/framework/functions/README.md
+++ b/src/go/plugin/framework/functions/README.md
@@ -1,30 +1,25 @@
 # Function framework boundary
 
-`plugin/framework/functions` contains the process-facing Function protocol
-boundary shared by Job Manager and service discovery. It does not own a
-dispatcher, worker pool, scheduler, invocation ledger, or runtime component.
+`plugin/framework/functions` contains the process-facing Function protocol boundary shared by Job Manager and service
+discovery. It does not own a dispatcher, worker pool, scheduler, invocation ledger, or runtime component.
 
 ## Retained contracts
 
-- `Function` is the compatibility value used by framework registries and
-  handlers.
-- `Registry` publishes and withdraws prefix Function handlers for service
-  discovery.
-- `InputCapsule` is the process-fixed bounded parser for `FUNCTION`,
-  `FUNCTION_PAYLOAD`, `FUNCTION_CANCEL`, and `QUIT` input.
+- `Function` is the compatibility value used by framework registries and handlers.
+- `Registry` publishes and withdraws prefix Function handlers for service discovery.
+- `InputCapsule` is the process-fixed bounded parser for `FUNCTION`, `FUNCTION_PAYLOAD`, `FUNCTION_CANCEL`, and `QUIT`
+  input.
 - `Consumer` receives immutable parsed calls and control events.
 - `TerminalFinalizer` is the terminal-response callback contract.
 - `BuildJSONPayload` is a passive helper.
 
-The active Job Manager generation owns routing, UID admission, cancellation,
-deadlines, ordering, task execution, terminal-once behavior, and runtime
-metrics. Those responsibilities live under `plugin/agent/jobmgr`.
+The active Job Manager generation owns routing, UID admission, cancellation, deadlines, ordering, task execution,
+terminal-once behavior, and runtime metrics. Those responsibilities live under `plugin/agent/jobmgr`.
 
 ## Input ownership
 
-`InputCapsule` owns only the payload currently being parsed. A complete call is
-transferred to `Consumer`; a partial payload stays process-owned across run
-rotation until it is drained or discarded by the process ingress protocol.
+`InputCapsule` owns only the payload currently being parsed. A complete call is transferred to `Consumer`; a partial
+payload stays process-owned across run rotation until it is drained or discarded by the process ingress protocol.
 
 The capsule:
 
@@ -36,7 +31,6 @@ The capsule:
 
 ## Concurrency
 
-This package imposes no process-wide limit on concurrent Function execution.
-The Job Manager task supervisor maintains separate framework-control and
-generic-Function scheduling classes. Collector implementations may serialize
-their own handlers when their internal state requires it.
+This package imposes no process-wide limit on concurrent Function execution. The Job Manager task supervisor maintains
+separate framework-control and generic-Function scheduling classes. Collector implementations may serialize their own
+handlers when their internal state requires it.

--- a/src/go/plugin/go.d/collector/cloudwatch/profile-format.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/profile-format.md
@@ -1,56 +1,43 @@
 # AWS CloudWatch profile format
 
-CloudWatch profiles define which metrics the collector queries and how those
-metrics become Netdata charts. Each profile covers one CloudWatch namespace and
-one exact resource-dimension grain.
+CloudWatch profiles define which metrics the collector queries and how those metrics become Netdata charts. Each profile
+covers one CloudWatch namespace and one exact resource-dimension grain.
 
 | Location                                                    | Purpose                             |
 |:------------------------------------------------------------|:------------------------------------|
 | `/usr/lib/netdata/conf.d/go.d/cloudwatch.profiles/default/` | Stock profiles shipped with Netdata |
 | `/etc/netdata/go.d/cloudwatch.profiles/`                    | User profiles                       |
 
-To customize a stock profile, copy it to the user directory and keep the same
-filename -- a user profile fully replaces the stock profile with that basename.
-Restart the go.d process after changing profiles because the catalog is cached
+To customize a stock profile, copy it to the user directory and keep the same filename -- a user profile fully replaces
+the stock profile with that basename. Restart the go.d process after changing profiles because the catalog is cached
 process-wide.
 
 ## How profiles work
 
-A profile is a YAML file with five parts: identity fields (`version`,
-`display_name`, `namespace`), `query` timing defaults, an `instance` dimension
-set, `metrics`, and a chart `template`. At runtime the collector uses them in
-four steps:
+A profile is a YAML file with five parts: identity fields (`version`, `display_name`, `namespace`), `query` timing
+defaults, an `instance` dimension set, `metrics`, and a chart `template`. At runtime the collector uses them in four
+steps:
 
-1. **Selection** -- collection rules in `go.d/cloudwatch.conf` choose profiles.
-   A rule that omits `profiles` selects every default-enabled profile; a
-   profile marked `disabled: true` must be named explicitly in
-   `profiles.include`.
-2. **Discovery** -- the collector scans the profile's namespace with
-   `ListMetrics` and keeps only metrics whose dimension names match
-   `instance.dimensions` exactly. Each distinct combination of dimension
-   values becomes one monitored instance. A profile whose dimensions are all
-   constants skips discovery entirely: the instance is known statically.
-3. **Query** -- every enabled metric/statistic pair is fetched with
-   `GetMetricData`, using timing resolved from the job configuration and the
-   profile's `query` defaults.
-4. **Charts** -- the exported series feed the `template`, which renders one
-   chart instance per monitored resource.
+1. **Selection** -- collection rules in `go.d/cloudwatch.conf` choose profiles. A rule that omits `profiles` selects
+   every default-enabled profile; a profile marked `disabled: true` must be named explicitly in `profiles.include`.
+2. **Discovery** -- the collector scans the profile's namespace with `ListMetrics` and keeps only metrics whose
+   dimension names match `instance.dimensions` exactly. Each distinct combination of dimension values becomes one
+   monitored instance. A profile whose dimensions are all constants skips discovery entirely: the instance is known
+   statically.
+3. **Query** -- every enabled metric/statistic pair is fetched with `GetMetricData`, using timing resolved from the job
+   configuration and the profile's `query` defaults.
+4. **Charts** -- the exported series feed the `template`, which renders one chart instance per monitored resource.
 
-Naming flows from the filename. A file named `example.yaml` is selected as
-`example` and exports series beginning with `example.`. Chart contexts come
-from the template: the final context is
-`cloudwatch.<template context_namespace>.<chart context>` -- in the example
-below, `cloudwatch.example.requests`. Stock profiles set `context_namespace`
-to the profile name so series and contexts stay aligned; follow that
-convention.
+Naming flows from the filename. A file named `example.yaml` is selected as `example` and exports series beginning with
+`example.`. Chart contexts come from the template: the final context is
+`cloudwatch.<template context_namespace>.<chart context>` -- in the example below, `cloudwatch.example.requests`. Stock
+profiles set `context_namespace` to the profile name so series and contexts stay aligned; follow that convention.
 
-Job configuration can reshape a profile without editing it: rules select or
-drop metrics (`rules[].metrics`), change statistics, and override query timing.
-Edit or author profile YAML only for new metrics, dimensions, or charts.
+Job configuration can reshape a profile without editing it: rules select or drop metrics (`rules[].metrics`), change
+statistics, and override query timing. Edit or author profile YAML only for new metrics, dimensions, or charts.
 
-> **The loader ignores unknown YAML keys.** A misspelled field name does not
-> produce an error -- it silently does nothing. When a profile change has no
-> effect, re-check the field spelling first.
+> **The loader ignores unknown YAML keys.** A misspelled field name does not produce an error -- it silently does
+> nothing. When a profile change has no effect, re-check the field spelling first.
 
 ## Complete example
 
@@ -117,8 +104,7 @@ template:
 
 ## Authoring workflow
 
-1. Inspect the service's CloudWatch namespace, metric names, and exact
-   dimension sets:
+1. Inspect the service's CloudWatch namespace, metric names, and exact dimension sets:
 
    ```bash
    aws cloudwatch list-metrics --namespace "AWS/Example" --region us-east-1 --output json \
@@ -142,15 +128,13 @@ template:
    | each `Dimensions[].Name`   | `instance.dimensions[].name`. Identifying values become `label`; fixed qualifiers become `constant`.                                 |
    | `MetricName`               | `metrics[].metric_name`                                                                                                              |
 
-   `list-metrics` does not report statistics -- choose them from the AWS
-   service's metric documentation (typically `sum` for counters, `average` or
-   percentiles for latencies).
+   `list-metrics` does not report statistics -- choose them from the AWS service's metric documentation (typically `sum`
+   for counters, `average` or percentiles for latencies).
 
 2. Start from the closest stock profile and choose one resource grain.
-3. Keep the default metric set focused; CloudWatch bills `GetMetricData` per
-   requested metric. Declare expensive or specialized additions with
-   `disabled: true`, and keep their matching chart definitions active so an
-   operator can enable them only through job configuration.
+3. Keep the default metric set focused; CloudWatch bills `GetMetricData` per requested metric. Declare expensive or
+   specialized additions with `disabled: true`, and keep their matching chart definitions active so an operator can
+   enable them only through job configuration.
 4. Run the collector tests and profile-catalog validation:
 
    ```bash
@@ -158,8 +142,8 @@ template:
    go test -count=1 ./plugin/go.d/collector/cloudwatch/...
    ```
 
-5. Restart go.d and verify discovery, exported labels, chart identity, gaps, and
-   the expected CloudWatch API volume in a test account.
+5. Restart go.d and verify discovery, exported labels, chart identity, gaps, and the expected CloudWatch API volume in a
+   test account.
 
 The sections below are the field-by-field reference.
 
@@ -177,28 +161,23 @@ The sections below are the field-by-field reference.
 | `metrics`           |   yes    | Default-enabled and opt-in metrics available for every discovered instance. At least one metric.                                                       |
 | `template`          |   yes    | Dynamic chart template populated from the exported series. At least one chart.                                                                         |
 
-The filename must match `^[a-z][a-z0-9_]*$` (plus the `.yaml` or `.yml` extension):
-lowercase, starting with a letter, using only letters, digits, and
-underscores. The basename is the profile name used everywhere else.
+The filename must match `^[a-z][a-z0-9_]*$` (plus the `.yaml` or `.yml` extension): lowercase, starting with a letter,
+using only letters, digits, and underscores. The basename is the profile name used everywhere else.
 
 ### Supported regions
 
-Use `supported_regions` only when AWS publishes a service's CloudWatch metrics
-in a fixed subset of regions. CloudFront, for example, is a global service whose
-metrics are published in `us-east-1`:
+Use `supported_regions` only when AWS publishes a service's CloudWatch metrics in a fixed subset of regions. CloudFront,
+for example, is a global service whose metrics are published in `us-east-1`:
 
 ```yaml
 supported_regions: [us-east-1]
 ```
 
-Each entry must be a valid canonical lowercase AWS region code, with no
-duplicates. The collection-rule compiler intersects `rules[].regions` with this
-list:
+Each entry must be a valid canonical lowercase AWS region code, with no duplicates. The collection-rule compiler
+intersects `rules[].regions` with this list:
 
-- A default-selected profile with no intersection is skipped and reported once
-  during startup.
-- A profile explicitly named in `profiles.include` with no intersection is a
-  configuration error.
+- A default-selected profile with no intersection is skipped and reported once during startup.
+- A profile explicitly named in `profiles.include` with no intersection is a configuration error.
 - An omitted `supported_regions` field means that every rule region is allowed.
 
 An explicitly empty list is invalid; omit the field for unrestricted profiles.
@@ -213,63 +192,53 @@ An explicitly empty list is invalid; omit the field for unrestricted profiles.
 | `lookback`          |          no          | Rolling retrieval horizon. It must be positive, at least one period, an exact multiple of the effective period, and no more than 1,440 buckets. Omission follows the resolved period. |
 | `publication_delay` |          no          | Delay before querying a closed bucket -- collector scheduling policy, not an AWS publication SLA. Default `10m`; `0` is valid.                                                        |
 
-Durations accept duration strings or numeric seconds and must resolve to whole
-seconds. Stock profiles use canonical strings such as `1m`, `10m`, and `24h`;
-custom profiles should do the same for readability.
+Durations accept duration strings or numeric seconds and must resolve to whole seconds. Stock profiles use canonical
+strings such as `1m`, `10m`, and `24h`; custom profiles should do the same for readability.
 
-Every metric may define an optional `query` object with the same fields. Job
-configuration resolves each field independently in this order, from highest to
-lowest precedence:
+Every metric may define an optional `query` object with the same fields. Job configuration resolves each field
+independently in this order, from highest to lowest precedence:
 
 1. `rules[].query` (job configuration)
 2. `rule_defaults.query` (job configuration)
 3. `metrics[].query` (profile)
 4. profile `query`
 
-After inheritance, the collector validates the complete policy. The combined
-`publication_delay + lookback + period` horizon must not exceed 14 days.
+After inheritance, the collector validates the complete policy. The combined `publication_delay + lookback + period`
+horizon must not exceed 14 days.
 
 ## Instance dimensions
 
-`instance.dimensions` is the exact CloudWatch dimension-name set accepted during
-discovery. Metrics with missing or extra dimensions do not match. This prevents
-different CloudWatch aggregation grains from collapsing into one resource.
+`instance.dimensions` is the exact CloudWatch dimension-name set accepted during discovery. Metrics with missing or
+extra dimensions do not match. This prevents different CloudWatch aggregation grains from collapsing into one resource.
 
 Each dimension sets exactly one of:
 
-- `label`: emit the dimension value as a Netdata identity label. Labels use
-  lowercase letters, digits, and underscores, start with a letter, and cannot be
-  `account_id` or `region` -- the collector attaches those two identity labels
-  to every instance automatically.
-- `constant`: require an exact CloudWatch dimension value, include it in the
-  query, but do not emit it as a label. Use this for a fixed qualifier such as
-  CloudFront's `Region=Global`.
+- `label`: emit the dimension value as a Netdata identity label. Labels use lowercase letters, digits, and underscores,
+  start with a letter, and cannot be `account_id` or `region` -- the collector attaches those two identity labels to
+  every instance automatically.
+- `constant`: require an exact CloudWatch dimension value, include it in the query, but do not emit it as a label. Use
+  this for a fixed qualifier such as CloudFront's `Region=Global`.
 
-Dimension names and constant values are matched verbatim and must not have
-leading or trailing whitespace. Names and emitted labels must be unique within
-the profile.
+Dimension names and constant values are matched verbatim and must not have leading or trailing whitespace. Names and
+emitted labels must be unique within the profile.
 
-When every declared dimension is constant, the collector already knows the
-complete instance and queries it directly. Such profiles do not call
-`ListMetrics`. Profiles with at least one identifying dimension use discovery
-normally.
+When every declared dimension is constant, the collector already knows the complete instance and queries it directly.
+Such profiles do not call `ListMetrics`. Profiles with at least one identifying dimension use discovery normally.
 
 ### One profile per grain
 
-When AWS publishes the same MetricNames at multiple exact dimension sets, write
-one profile per grain. Use separate profile and context names so the identities
-cannot merge, and mark a higher-cardinality grain `disabled: true` when it should
-be opt-in.
+When AWS publishes the same MetricNames at multiple exact dimension sets, write one profile per grain. Use separate
+profile and context names so the identities cannot merge, and mark a higher-cardinality grain `disabled: true` when it
+should be opt-in.
 
 Stock examples:
 
-- `privatelink_endpoint.yaml` and `privatelink_endpoint_subnet.yaml` are the
-  parent/child pair: the child adds `Subnet Id`, while the collector's reviewed
-  tag-association registry joins both profiles on their parent `VPC Endpoint Id`.
-- The five `privatelink_service*.yaml` profiles are the multi-child example:
-  all detailed Availability Zone, load-balancer, and consumer-endpoint grains
-  remain separate, but every one joins tags through the parent `Service Id` and
-  `ec2:vpc-endpoint-service` resource.
+- `privatelink_endpoint.yaml` and `privatelink_endpoint_subnet.yaml` are the parent/child pair: the child adds
+  `Subnet Id`, while the collector's reviewed tag-association registry joins both profiles on their parent
+  `VPC Endpoint Id`.
+- The five `privatelink_service*.yaml` profiles are the multi-child example: all detailed Availability Zone,
+  load-balancer, and consumer-endpoint grains remain separate, but every one joins tags through the parent `Service Id`
+  and `ec2:vpc-endpoint-service` resource.
 
 ## Metrics
 
@@ -285,9 +254,8 @@ Every `metrics` entry supports:
 | `query`       |    no    | Metric-specific `period`, `lookback`, and/or `publication_delay` overrides. Omitted fields inherit independently.                                                                                                                                    |
 | `nil_as_zero` |    no    | Map a clean no-datapoint response to `0` (`true`) or a gap (`false`). Default: rate totals map to `0`, all other statistics to a gap.                                                                                                                |
 
-**Percentiles** range from `p0` through `p100` with at most two decimal places
-(`p90`, `p99.9`, `p99.99`). **Metric IDs** and CloudWatch metric names must be
-unique within a profile.
+**Percentiles** range from `p0` through `p100` with at most two decimal places (`p90`, `p99.9`, `p99.99`). **Metric
+IDs** and CloudWatch metric names must be unique within a profile.
 
 The exported series name is:
 
@@ -295,15 +263,14 @@ The exported series name is:
 <profile>.<metric_id>_<normalized_statistic>
 ```
 
-Chart selectors may use the shorthand `<metric_id>_<statistic>` shown in the
-example; the loader qualifies it with the profile name.
+Chart selectors may use the shorthand `<metric_id>_<statistic>` shown in the example; the loader qualifies it with the
+profile name.
 
 ### How rules select profile metrics
 
-Omitting `rules[].metrics` collects the default-enabled metrics from every
-selected profile. A metric group changes only its named profile; selected
-profiles without a group keep their defaults. The group includes defaults when
-`defaults` is omitted or `true`, so adding an opt-in metric is concise:
+Omitting `rules[].metrics` collects the default-enabled metrics from every selected profile. A metric group changes only
+its named profile; selected profiles without a group keep their defaults. The group includes defaults when `defaults` is
+omitted or `true`, so adding an opt-in metric is concise:
 
 ```yaml
 profiles:
@@ -314,37 +281,30 @@ metrics:
       - name: Latency
 ```
 
-Set `defaults: false` when the profile must use only the listed MetricNames. If
-both the group and metric omit `statistics`, the collector uses every statistic
-declared for that metric in the profile.
+Set `defaults: false` when the profile must use only the listed MetricNames. If both the group and metric omit
+`statistics`, the collector uses every statistic declared for that metric in the profile.
 
 ## Chart template rules
 
 The `template` uses Netdata's dynamic chart-template format. See the complete
-[Chart Template Format](/src/go/plugin/framework/charttpl/README.md) for every
-group, chart, instance, label-promotion, lifecycle, dimension, presentation,
-and selector field. CloudWatch profiles add these restrictions:
+[Chart Template Format](/src/go/plugin/framework/charttpl/README.md) for every group, chart, instance, label-promotion,
+lifecycle, dimension, presentation, and selector field. CloudWatch profiles add these restrictions:
 
-- Set `context_namespace` at the template root to the profile name; the
-  emitted context is `cloudwatch.<context_namespace>.<chart context>`.
-- Every chart must set `algorithm: absolute`. CloudWatch returns per-period
-  aggregates, not cumulative counters.
-- Every chart's effective `instances.by_labels` must include `account_id`,
-  `region`, and every identifying dimension `label`. Constant dimensions are not
-  included. A `*` wildcard entry satisfies the requirement; a `!label` entry
+- Set `context_namespace` at the template root to the profile name; the emitted context is
+  `cloudwatch.<context_namespace>.<chart context>`.
+- Every chart must set `algorithm: absolute`. CloudWatch returns per-period aggregates, not cumulative counters.
+- Every chart's effective `instances.by_labels` must include `account_id`, `region`, and every identifying dimension
+  `label`. Constant dimensions are not included. A `*` wildcard entry satisfies the requirement; a `!label` entry
   excludes that label, but excluding a required identity label fails validation.
-- Do not author `template.metrics`; the collector derives the visible series
-  from `metrics`.
+- Do not author `template.metrics`; the collector derives the visible series from `metrics`.
 - Every dimension selector must resolve to a series exported by the profile.
-- Set an explicit `id` on every chart and keep it unique across the loaded
-  profile catalog. A collision between two stock profiles fails loading; a
-  collision involving a user profile logs a warning and drops the colliding
-  chart. The uniqueness check covers only explicitly set IDs.
+- Set an explicit `id` on every chart and keep it unique across the loaded profile catalog. A collision between two
+  stock profiles fails loading; a collision involving a user profile logs a warning and drops the colliding chart. The
+  uniqueness check covers only explicitly set IDs.
 
-Unlike charttpl's strict standalone decoding, a CloudWatch profile's template
-is validated structurally but unknown keys are ignored (see "How profiles
-work").
+Unlike charttpl's strict standalone decoding, a CloudWatch profile's template is validated structurally but unknown keys
+are ignored (see "How profiles work").
 
-The collector divides rate totals by the effective query period before emission
-and marks all emitted CloudWatch metric families as floating-point values.
+The collector divides rate totals by the effective query period before emission and marks all emitted CloudWatch metric
+families as floating-point values.
 

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -146,21 +146,21 @@ modules:
               required: false
               group: Customization
               detailed_description: |
-                A list of relabeling blocks. Each block applies a list of Prometheus
-                `metric_relabel_configs` rules to the metrics whose name matches `match`. See the
-                [relabeling reference](/src/go/plugin/go.d/collector/prometheus/profile-format.md#metric-relabeling)
-                for the full action set and more examples.
+                A list of relabeling blocks. Each block applies a list of Prometheus `metric_relabel_configs` rules to
+                the metrics whose name matches `match`. See the
+                [relabeling reference](/src/go/plugin/go.d/collector/prometheus/profile-format.md#metric-relabeling) for
+                the full action set and more examples.
 
-                - `match`: Netdata simple patterns matched against the full metric name — including
-                  any `_bucket`/`_sum`/`_count` suffix, so prefer globs like `app_lat*` over an exact
-                  `app_lat` (space-separated; `*` matches any sequence, `?` any character, a leading
-                  `!` negates). Use `*` to target every metric. Required.
-                - `metric_relabel_configs`: Prometheus relabel rules (`source_labels`, `separator`,
-                  `regex`, `modulus`, `target_label`, `replacement`, `action`), applied in order to
-                  the scraped samples before charts are built.
+                - `match`: Netdata simple patterns matched against the full metric name — including any
+                  `_bucket`/`_sum`/`_count` suffix, so prefer globs like `app_lat*` over an exact `app_lat`
+                  (space-separated; `*` matches any sequence, `?` any character, a leading `!` negates). Use `*` to
+                  target every metric. Required.
+                - `metric_relabel_configs`: Prometheus relabel rules (`source_labels`, `separator`, `regex`, `modulus`,
+                  `target_label`, `replacement`, `action`), applied in order to the scraped samples before charts are
+                  built.
 
-                Relabeling that would corrupt a histogram or summary — splitting it, dropping a
-                component, mutating the `le`/`quantile` label, or merging two families — is rejected.
+                Relabeling that would corrupt a histogram or summary — splitting it, dropping a component, mutating the
+                `le`/`quantile` label, or merging two families — is rejected.
 
                 ```yaml
                 relabeling:
@@ -179,15 +179,17 @@ modules:
               group: Customization
               detailed_description: |
                 Profiles ship curated charts for recognized exporters -- see the
-                [profile format](/src/go/plugin/go.d/collector/prometheus/profile-format.md) for the
-                file format and how to author your own. `profiles.mode` selects them:
+                [profile format](/src/go/plugin/go.d/collector/prometheus/profile-format.md) for the file format and how
+                to author your own. `profiles.mode` selects them:
 
                 - `auto` (default): every profile whose `match` hits at least one scraped metric.
-                - `exact`: only the profiles named in `mode_exact.entries` (each must match, or the job fails its check).
+                - `exact`: only the profiles named in `mode_exact.entries` (each must match, or the job fails its
+                  check).
                 - `combined`: `auto` plus the profiles named in `mode_combined.entries`.
                 - `none`: no profiles — generic autogen charts only (the pre-profile behavior).
 
-                Only the block matching the selected mode (`mode_exact` or `mode_combined`) is read; entries under the other block are ignored. Metrics not covered by a selected profile keep their generic autogen charts.
+                Only the block matching the selected mode (`mode_exact` or `mode_combined`) is read; entries under the
+                other block are ignored. Metrics not covered by a selected profile keep their generic autogen charts.
 
                 ```yaml
                 profiles:

--- a/src/go/plugin/go.d/collector/prometheus/profile-format.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-format.md
@@ -1,15 +1,12 @@
 # Prometheus profile format
 
-Prometheus profiles ship curated charts for recognized exporters. Without a
-profile, the generic Prometheus collector renders one chart per scraped metric
-(autogeneration). A profile replaces that flat list, for the metrics it knows,
-with a designed dashboard menu: named sections, per-instance charts, meaningful
-dimensions, units, and heatmaps. You are not limited to the stock library --
-you can author a profile for your own application's metrics too.
+Prometheus profiles ship curated charts for recognized exporters. Without a profile, the generic Prometheus collector
+renders one chart per scraped metric (autogeneration). A profile replaces that flat list, for the metrics it knows, with
+a designed dashboard menu: named sections, per-instance charts, meaningful dimensions, units, and heatmaps. You are not
+limited to the stock library -- you can author a profile for your own application's metrics too.
 
-This page documents the profile file format and the job-level
-[metric relabeling](#metric-relabeling) option that reshapes scraped metrics
-before profiles and charts see them.
+This page documents the profile file format and the job-level [metric relabeling](#metric-relabeling) option that
+reshapes scraped metrics before profiles and charts see them.
 
 Profiles reshape metrics an existing job already scrapes --
 [set up the Prometheus collector job](/src/go/plugin/go.d/collector/prometheus/integrations/prometheus_endpoint.md)
@@ -20,24 +17,19 @@ first.
 | `/usr/lib/netdata/conf.d/go.d/prometheus.profiles/default/` | Stock profiles shipped with Netdata |
 | `/etc/netdata/go.d/prometheus.profiles/`                    | User profiles                       |
 
-To customize a stock profile, copy it to the user directory and keep the same
-filename -- a user profile fully replaces the stock profile with that basename.
-Restart the Netdata Agent (which restarts the go.d plugin) after changing
-profiles because the catalog is cached for the plugin's lifetime.
+To customize a stock profile, copy it to the user directory and keep the same filename -- a user profile fully replaces
+the stock profile with that basename. Restart the Netdata Agent (which restarts the go.d plugin) after changing profiles
+because the catalog is cached for the plugin's lifetime.
 
-> **Profiles are strictly validated.** A misspelled or unknown field is an
-> error, not silently ignored. A broken user profile is skipped with a warning
-> in the log (the stock profile of the same name, if any, stays in effect),
-> and a descriptive validation error is reported -- unknown or misspelled keys
-> are named explicitly.
+> **Profiles are strictly validated.** A misspelled or unknown field is an error, not silently ignored. A broken user
+> profile is skipped with a warning in the log (the stock profile of the same name, if any, stays in effect), and a
+> descriptive validation error is reported -- unknown or misspelled keys are named explicitly.
 
 ## Complete example
 
-A profile is a YAML file with three top-level keys: `match` selects the
-profile by scraped metric names, `app` names the application the charts belong
-to, and `template` defines the charts. Everything below `template` is
-Netdata's [Chart Template Format](/src/go/plugin/framework/charttpl/README.md);
-inline comments explain each field.
+A profile is a YAML file with three top-level keys: `match` selects the profile by scraped metric names, `app` names the
+application the charts belong to, and `template` defines the charts. Everything below `template` is Netdata's
+[Chart Template Format](/src/go/plugin/framework/charttpl/README.md); inline comments explain each field.
 
 ```yaml
 # example.yaml -- the basename (before .yaml/.yml) is the profile name
@@ -128,33 +120,25 @@ template:
 
 At runtime the collector uses profiles in four steps:
 
-1. **Scrape** -- the job scrapes the endpoint. The `selector` job option
-   filters unwanted series
-   ([selector syntax](/src/go/pkg/prometheus/selector/README.md)), and
-   [relabeling](#metric-relabeling) rewrites metric names and labels.
-   Profiles and charts only ever see the result.
-2. **Selection** -- once, at job autodetection, each profile's `match` is
-   tested against the scraped metric family names, per the job's
-   `profiles.mode` (see
-   [Selecting profiles in job configuration](#selecting-profiles-in-job-configuration)).
-   The selection is cached until the job restarts.
-3. **App resolution** -- the job's `app` option wins; when unset, the first
-   selected profile that declares an `app` provides it; the job name is the
-   last resort. If selected profiles declare different apps, the first (in
-   selection order) wins and the rest are logged -- set the job's `app` to
-   disambiguate.
-4. **Charts** -- the selected profiles' templates are merged on top of the
-   autogeneration base. Series matched by a profile's selectors get the
-   curated charts; every other scraped metric family keeps its generic
-   autogen chart, so profile coverage never loses data.
+1. **Scrape** -- the job scrapes the endpoint. The `selector` job option filters unwanted series
+   ([selector syntax](/src/go/pkg/prometheus/selector/README.md)), and [relabeling](#metric-relabeling) rewrites metric
+   names and labels. Profiles and charts only ever see the result.
+2. **Selection** -- once, at job autodetection, each profile's `match` is tested against the scraped metric family
+   names, per the job's `profiles.mode` (see
+   [Selecting profiles in job configuration](#selecting-profiles-in-job-configuration)). The selection is cached until
+   the job restarts.
+3. **App resolution** -- the job's `app` option wins; when unset, the first selected profile that declares an `app`
+   provides it; the job name is the last resort. If selected profiles declare different apps, the first (in selection
+   order) wins and the rest are logged -- set the job's `app` to disambiguate.
+4. **Charts** -- the selected profiles' templates are merged on top of the autogeneration base. Series matched by a
+   profile's selectors get the curated charts; every other scraped metric family keeps its generic autogen chart, so
+   profile coverage never loses data.
 
-Chart contexts compose as
-`prometheus.<app>.<template context_namespace>.<chart context>` -- in the
-example above, `prometheus.example.example.http_requests`. When the resolved
-app equals the profile's `context_namespace` (the common case: the job has no
-`app` set and the profile provides it), the redundant segment is dropped, so
-the emitted context is `prometheus.example.http_requests`. Autogen charts for
-uncovered metrics keep their `prometheus.<app>.<metric>` contexts.
+Chart contexts compose as `prometheus.<app>.<template context_namespace>.<chart context>` -- in the example above,
+`prometheus.example.example.http_requests`. When the resolved app equals the profile's `context_namespace` (the common
+case: the job has no `app` set and the profile provides it), the redundant segment is dropped, so the emitted context is
+`prometheus.example.http_requests`. Autogen charts for uncovered metrics keep their `prometheus.<app>.<metric>`
+contexts.
 
 ## Top-level fields
 
@@ -164,115 +148,86 @@ uncovered metrics keep their `prometheus.<app>.<metric>` contexts.
 | `app`      |    no    | Application identity used as the `app` segment of chart contexts when the job does not set one. Must match `^[a-z][a-z0-9_]*$`.                       |
 | `template` |   yes    | Chart template group defining the curated charts. At least one chart.                                                                                 |
 
-The filename must match `^[a-z][a-z0-9_]*$` (plus the `.yaml` or `.yml`
-extension): lowercase, starting with a letter, using only letters, digits, and
-underscores -- `my_app.yaml`, not `my-app.yaml` or `MyApp.yaml`. The basename
-is the profile name used everywhere else -- in
-`profiles.mode_exact`/`mode_combined` entries and in log messages.
+The filename must match `^[a-z][a-z0-9_]*$` (plus the `.yaml` or `.yml` extension): lowercase, starting with a letter,
+using only letters, digits, and underscores -- `my_app.yaml`, not `my-app.yaml` or `MyApp.yaml`. The basename is the
+profile name used everywhere else -- in `profiles.mode_exact`/`mode_combined` entries and in log messages.
 
 ### `match`
 
 `match` decides whether the profile applies to a job:
 
-- It is tested against the **metric family names** of the scraped metrics --
-  the series name with the `_bucket`/`_sum`/`_count` suffix removed for
-  histograms and summaries (`example_http_request_duration_seconds`, not
-  `example_http_request_duration_seconds_bucket`). Counters keep their
-  `_total` suffix in the family name -- Netdata does not strip it, so match
-  `foo_total` or a glob, never a bare `foo`. (This is the opposite of the
-  template's dimension selectors and the relabeling block `match`, which both
-  work on the full suffixed names -- see
-  [Chart template rules](#chart-template-rules) and
-  [the relabeling block `match`](#the-relabeling-block-match).)
-- It sees the names **after** the job's `selector` and `relabeling` have been
-  applied, so a rename can bring an endpoint's metrics into (or out of) a
-  profile's match.
-- Syntax is a Netdata
-  [simple pattern](/src/libnetdata/simple_pattern/README.md): a space-separated
-  list of globs where `*` matches any sequence, `?` matches any single
-  character, and a leading `!` negates a term.
+- It is tested against the **metric family names** of the scraped metrics -- the series name with the
+  `_bucket`/`_sum`/`_count` suffix removed for histograms and summaries (`example_http_request_duration_seconds`, not
+  `example_http_request_duration_seconds_bucket`). Counters keep their `_total` suffix in the family name -- Netdata
+  does not strip it, so match `foo_total` or a glob, never a bare `foo`. (This is the opposite of the template's
+  dimension selectors and the relabeling block `match`, which both work on the full suffixed names -- see
+  [Chart template rules](#chart-template-rules) and [the relabeling block `match`](#the-relabeling-block-match).)
+- It sees the names **after** the job's `selector` and `relabeling` have been applied, so a rename can bring an
+  endpoint's metrics into (or out of) a profile's match.
+- Syntax is a Netdata [simple pattern](/src/libnetdata/simple_pattern/README.md): a space-separated list of globs where
+  `*` matches any sequence, `?` matches any single character, and a leading `!` negates a term.
 
-Keep the pattern narrow -- anchored to the exporter's metric prefix, such as
-`haproxy_*`. In the default `auto` mode every catalog profile whose `match`
-hits at least one scraped metric family is selected, so an over-broad pattern attaches
-the profile to unrelated jobs.
+Keep the pattern narrow -- anchored to the exporter's metric prefix, such as `haproxy_*`. In the default `auto` mode
+every catalog profile whose `match` hits at least one scraped metric family is selected, so an over-broad pattern
+attaches the profile to unrelated jobs.
 
 ### `app`
 
-`app` is the application identity of the exporter the profile understands --
-the `app` segment of `prometheus.<app>.*` chart contexts, which the Netdata UI
-turns into an Applications dashboard section. It is used only when the job has
-no `app` of its own (set by the user or by service discovery); a configured
-job `app` always wins, and the job name is the last resort. Stock profiles set
-`app` and `template.context_namespace` to the profile name so contexts stay
-short and aligned; follow that convention.
+`app` is the application identity of the exporter the profile understands -- the `app` segment of `prometheus.<app>.*`
+chart contexts, which the Netdata UI turns into an Applications dashboard section. It is used only when the job has no
+`app` of its own (set by the user or by service discovery); a configured job `app` always wins, and the job name is the
+last resort. Stock profiles set `app` and `template.context_namespace` to the profile name so contexts stay short and
+aligned; follow that convention.
 
 ## Chart template rules
 
-The `template` value is one group of Netdata's dynamic chart-template format.
-See the complete
-[Chart Template Format](/src/go/plugin/framework/charttpl/README.md) for every
-group, chart, instance, label, lifecycle, dimension, presentation, and
-selector field. Prometheus profiles add these rules:
+The `template` value is one group of Netdata's dynamic chart-template format. See the complete
+[Chart Template Format](/src/go/plugin/framework/charttpl/README.md) for every group, chart, instance, label, lifecycle,
+dimension, presentation, and selector field. Prometheus profiles add these rules:
 
-- **The template is a group, not a full spec.** The linked reference's
-  examples show complete `charts.yaml` specs (a `version` plus a top-level
-  `groups` list); a profile's `template` is one item of that `groups` list,
-  written without the leading dash -- you author the *content of one group*:
-  `family`, `context_namespace`, `metrics`, `charts`, nested `groups`, and
-  `chart_defaults`. `instances`, `lifecycle`, and `label_promotion` are
-  per-chart fields, not group fields (`instances` and `label_promotion` can
-  also be set once for a whole group via `chart_defaults`). The spec-level
-  `version` and `engine` fields are rejected. The collector wraps your group
-  into its per-job spec, where autogeneration for uncovered metrics stays
-  enabled.
-- **Set `context_namespace` at the template root to the profile name.** This
-  is the group-level `context_namespace` field -- a profile has no separate
-  top-level one; the collector supplies the `prometheus.<app>` prefix. The
-  emitted context is `prometheus.<app>.<context_namespace>.<chart context>`,
-  with the namespace segment dropped when it equals the resolved app.
-- **Leave chart `id` unset.** The format allows an explicit `id`, but when
-  omitted the ID is derived from the chart's composed context, keeping chart
-  identities aligned with contexts -- every stock profile relies on that.
-  Keep every chart's `context` unique within the profile -- when the same
-  measurement exists at several scopes, prefix the context with the scope
-  (`process_requests`, `frontend_requests`, `backend_requests`).
-- **`algorithm` is optional.** When omitted, the engine infers it from the
-  metric (see the Chart Template Format); the examples here set it explicitly
-  for readability.
-- **Dimension selectors address scraped series by their exposition names**,
-  after `selector` filtering and relabeling. This is the opposite surface
-  from the profile's `match`: a histogram dimension selector must use the
-  suffixed name (`foo_bucket`), and one written with the family name (`foo`)
-  matches nothing -- the curated chart silently never appears. The names:
+- **The template is a group, not a full spec.** The linked reference's examples show complete `charts.yaml` specs (a
+  `version` plus a top-level `groups` list); a profile's `template` is one item of that `groups` list, written without
+  the leading dash -- you author the *content of one group*: `family`, `context_namespace`, `metrics`, `charts`, nested
+  `groups`, and `chart_defaults`. `instances`, `lifecycle`, and `label_promotion` are per-chart fields, not group fields
+  (`instances` and `label_promotion` can also be set once for a whole group via `chart_defaults`). The spec-level
+  `version` and `engine` fields are rejected. The collector wraps your group into its per-job spec, where autogeneration
+  for uncovered metrics stays enabled.
+- **Set `context_namespace` at the template root to the profile name.** This is the group-level `context_namespace`
+  field -- a profile has no separate top-level one; the collector supplies the `prometheus.<app>` prefix. The emitted
+  context is `prometheus.<app>.<context_namespace>.<chart context>`, with the namespace segment dropped when it equals
+  the resolved app.
+- **Leave chart `id` unset.** The format allows an explicit `id`, but when omitted the ID is derived from the chart's
+  composed context, keeping chart identities aligned with contexts -- every stock profile relies on that. Keep every
+  chart's `context` unique within the profile -- when the same measurement exists at several scopes, prefix the context
+  with the scope (`process_requests`, `frontend_requests`, `backend_requests`).
+- **`algorithm` is optional.** When omitted, the engine infers it from the metric (see the Chart Template Format); the
+  examples here set it explicitly for readability.
+- **Dimension selectors address scraped series by their exposition names**, after `selector` filtering and relabeling.
+  This is the opposite surface from the profile's `match`: a histogram dimension selector must use the suffixed name
+  (`foo_bucket`), and one written with the family name (`foo`) matches nothing -- the curated chart silently never
+  appears. The names:
   - a gauge or counter `foo` is the series `foo`;
-  - a histogram `foo` is selectable as `foo_bucket` (per-`le` bucket
-    dimensions, rendered as a heatmap), `foo_count`, and `foo_sum`;
-  - a summary `bar` is selectable as `bar` (per-`quantile` dimensions),
-    `bar_count`, and `bar_sum`;
-  - series keep their scraped labels, which is what `instances.by_labels`,
-    `name_from_label`, and label selectors work on.
-- **Only collected series can be charted.** `*_info` families are skipped.
-  Untyped families are collected only when the name ends in `_total` (treated
-  as a counter) or the job's `fallback_type` option maps them to a gauge or
-  counter (`fallback_type.gauge` takes precedence, so a `_total`-suffixed name
-  mapped to gauge is charted as a gauge). A profile cannot chart what the job
-  does not collect.
-- **Every group that contains charts must list the metrics its selectors
-  reference in its `metrics` list** (or inherit them from an ancestor group).
-  A selector on a metric outside the group's declared scope fails validation.
+  - a histogram `foo` is selectable as `foo_bucket` (per-`le` bucket dimensions, rendered as a heatmap), `foo_count`,
+    and `foo_sum`;
+  - a summary `bar` is selectable as `bar` (per-`quantile` dimensions), `bar_count`, and `bar_sum`;
+  - series keep their scraped labels, which is what `instances.by_labels`, `name_from_label`, and label selectors work
+    on.
+- **Only collected series can be charted.** `*_info` families are skipped. Untyped families are collected only when the
+  name ends in `_total` (treated as a counter) or the job's `fallback_type` option maps them to a gauge or counter
+  (`fallback_type.gauge` takes precedence, so a `_total`-suffixed name mapped to gauge is charted as a gauge). A profile
+  cannot chart what the job does not collect.
+- **Every group that contains charts must list the metrics its selectors reference in its `metrics` list** (or inherit
+  them from an ancestor group). A selector on a metric outside the group's declared scope fails validation.
 
 ## Selecting profiles in job configuration
 
 The job's `profiles.mode` controls which catalog profiles apply:
 
-- `auto` (default): every profile whose `match` hits at least one scraped
-  metric family.
-- `exact`: only the profiles named in `mode_exact.entries`; each must match
-  the scraped metrics, or the job fails its check.
-- `combined`: `auto` plus the profiles named in `mode_combined.entries`,
-  deduplicated. The named entries follow the same rule as `exact`: each must
-  match, or the job fails its check.
+- `auto` (default): every profile whose `match` hits at least one scraped metric family.
+- `exact`: only the profiles named in `mode_exact.entries`; each must match the scraped metrics, or the job fails its
+  check.
+- `combined`: `auto` plus the profiles named in `mode_combined.entries`, deduplicated. The named entries follow the same
+  rule as `exact`: each must match, or the job fails its check.
 - `none`: no profiles -- generic autogen charts only.
 
 ```yaml
@@ -286,33 +241,29 @@ jobs:
           - name: example
 ```
 
-Only the block matching the selected mode (`mode_exact` or `mode_combined`) is
-read, and a name that exists in neither the stock nor the user catalog is a
-configuration error in both modes. Scraped metrics not charted by any selected
-profile keep their generic autogen charts -- a profile cannot disable
-autogeneration; to hide metrics you do not chart, drop them with the job's
-`selector` option or a `relabeling` drop rule.
+Only the block matching the selected mode (`mode_exact` or `mode_combined`) is read, and a name that exists in neither
+the stock nor the user catalog is a configuration error in both modes. Scraped metrics not charted by any selected
+profile keep their generic autogen charts -- a profile cannot disable autogeneration; to hide metrics you do not chart,
+drop them with the job's `selector` option or a `relabeling` drop rule.
 
-`profiles`, `relabeling`, `selector`, `fallback_type`, and `app` are all job
-options in `go.d/prometheus.conf` -- edit it with `sudo ./edit-config
-go.d/prometheus.conf` from your
+`profiles`, `relabeling`, `selector`, `fallback_type`, and `app` are all job options in `go.d/prometheus.conf` -- edit
+it with `sudo ./edit-config go.d/prometheus.conf` from your
 [Netdata config directory](/docs/netdata-agent/configuration/README.md).
 
 ## Authoring workflow
 
-1. Inspect what the endpoint actually exposes -- family names, types, and
-   labels are exactly what `match` and the template's selectors work on:
+1. Inspect what the endpoint actually exposes -- family names, types, and labels are exactly what `match` and the
+   template's selectors work on:
 
    ```bash
    curl -s http://127.0.0.1:9090/metrics | grep '# TYPE'
    curl -s http://127.0.0.1:9090/metrics | grep -v '^#' | head -20
    ```
 
-   The second command shows the series themselves -- the `{label="value"}`
-   pairs are what `instances.by_labels`, `name_from_label`, and selector
-   label filters work on. If the endpoint prints no `# TYPE` lines, its
-   metrics are untyped: only `_total`-suffixed names are collected (as
-   counters) until the job's `fallback_type` option maps the rest:
+   The second command shows the series themselves -- the `{label="value"}` pairs are what `instances.by_labels`,
+   `name_from_label`, and selector label filters work on. If the endpoint prints no `# TYPE` lines, its metrics are
+   untyped: only `_total`-suffixed names are collected (as counters) until the job's `fallback_type` option maps the
+   rest:
 
    ```yaml
    fallback_type:
@@ -320,15 +271,12 @@ go.d/prometheus.conf` from your
      counter: ['myapp_events_*']
    ```
 
-2. Start from the [Complete example](#complete-example) above or from a stock
-   profile (for example
-   [`haproxy.yaml`](/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml),
-   installed under `/usr/lib/netdata/conf.d/go.d/prometheus.profiles/default/`).
-   Name the file after the exporter.
-3. Save it under `prometheus.profiles/` in your Netdata user config directory
-   (typically `/etc/netdata`); the file must be readable by the `netdata`
-   user. Then restart the Netdata Agent (the profile catalog is cached for
-   the plugin's lifetime):
+2. Start from the [Complete example](#complete-example) above or from a stock profile (for example
+   [`haproxy.yaml`](/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml), installed under
+   `/usr/lib/netdata/conf.d/go.d/prometheus.profiles/default/`). Name the file after the exporter.
+3. Save it under `prometheus.profiles/` in your Netdata user config directory (typically `/etc/netdata`); the file must
+   be readable by the `netdata` user. Then restart the Netdata Agent (the profile catalog is cached for the plugin's
+   lifetime):
 
    ```bash
    sudo mkdir -p /etc/netdata/go.d/prometheus.profiles/
@@ -336,52 +284,40 @@ go.d/prometheus.conf` from your
    sudo systemctl restart netdata
    ```
 
-4. While iterating, pin the job to the profile with `profiles.mode: exact` --
-   a profile that fails to match then fails the job check loudly instead of
-   silently falling back to autogen charts. Check the log:
+4. While iterating, pin the job to the profile with `profiles.mode: exact` -- a profile that fails to match then fails
+   the job check loudly instead of silently falling back to autogen charts. Check the log:
 
    ```bash
    journalctl -u netdata --no-pager | grep -E 'profile|prometheus'
    ```
 
-   On success the collector logs
-   `profiles: mode "exact" selected 1 profile(s): example`. Failures do not
-   carry the `profiles:` prefix: a non-matching exact profile fails the job
-   check with `profile "example" matches no scraped metric (pattern ...)`, and
-   a broken user profile is skipped once at catalog load with
-   `ignoring invalid user profile ...` followed by the validation error.
+   On success the collector logs `profiles: mode "exact" selected 1 profile(s): example`. Failures do not carry the
+   `profiles:` prefix: a non-matching exact profile fails the job check with
+   `profile "example" matches no scraped metric (pattern ...)`, and a broken user profile is skipped once at catalog
+   load with `ignoring invalid user profile ...` followed by the validation error.
 
-   For a faster loop than restarting the Agent, run the plugin in debug mode.
-   It loads user profiles from the same directories as the Agent and prints
-   selection and validation messages at startup, then keeps collecting until
-   you press Ctrl+C. The plugin path varies by install type -- static installs
-   keep it under `/opt/netdata`:
+   For a faster loop than restarting the Agent, run the plugin in debug mode. It loads user profiles from the same
+   directories as the Agent and prints selection and validation messages at startup, then keeps collecting until you
+   press Ctrl+C. The plugin path varies by install type -- static installs keep it under `/opt/netdata`:
 
    ```bash
    sudo -u netdata /usr/libexec/netdata/plugins.d/go.d.plugin -d -m prometheus
    ```
 
-5. Verify the dashboard: the curated charts appear in the node's left-hand
-   menu under the section named by the template's `family`, with
-   `prometheus.<app>.*` contexts, and uncovered metrics remain as autogen
-   charts.
+5. Verify the dashboard: the curated charts appear in the node's left-hand menu under the section named by the
+   template's `family`, with `prometheus.<app>.*` contexts, and uncovered metrics remain as autogen charts.
 
-If the profile is selected but a curated chart is missing or empty, the usual
-causes are: a dimension selector written with the metric family name instead
-of the suffixed exposition name (`foo` instead of `foo_bucket`);
-`instances.by_labels` or `name_from_label` naming a label the series does not
-carry; or the metric not being collected at all (untyped without `_total` or
-`fallback_type`). The giveaway is the metric appearing as a generic autogen
-chart instead of in your curated one. Selector matching is not validated --
-neither the job check nor debug mode flags a selector that matches nothing --
-so re-run the commands from step 1 and compare the exact series names and
-label keys against your `metrics` lists, selectors, and labels.
+If the profile is selected but a curated chart is missing or empty, the usual causes are: a dimension selector written
+with the metric family name instead of the suffixed exposition name (`foo` instead of `foo_bucket`);
+`instances.by_labels` or `name_from_label` naming a label the series does not carry; or the metric not being collected
+at all (untyped without `_total` or `fallback_type`). The giveaway is the metric appearing as a generic autogen chart
+instead of in your curated one. Selector matching is not validated -- neither the job check nor debug mode flags a
+selector that matches nothing -- so re-run the commands from step 1 and compare the exact series names and label keys
+against your `metrics` lists, selectors, and labels.
 
-To contribute a profile to Netdata, add it under
-`src/go/plugin/go.d/config/go.d/prometheus.profiles/default/`. Stock profiles
-are held to a stricter standard than user profiles: a broken stock profile is
-not skipped -- an invalid header, name, or duplicate fails the whole catalog,
-and an invalid template fails the check of every job that selects it. The
+To contribute a profile to Netdata, add it under `src/go/plugin/go.d/config/go.d/prometheus.profiles/default/`. Stock
+profiles are held to a stricter standard than user profiles: a broken stock profile is not skipped -- an invalid header,
+name, or duplicate fails the whole catalog, and an invalid template fails the check of every job that selects it. The
 collector test suite validates every stock profile before merge:
 
 ```bash
@@ -391,66 +327,51 @@ go test -count=1 ./plugin/go.d/collector/prometheus/...
 
 ## Metric relabeling
 
-Relabeling rewrites, adds, drops, or filters a scraped metric -- its name and
-its labels -- **before** profiles are matched and charts are built. It is a
-job-level configuration option (`relabeling`), not a profile field: it works
-with or without profiles, and profiles see the relabeled result. The rule
-shape is Prometheus-compatible: it mirrors Prometheus
+Relabeling rewrites, adds, drops, or filters a scraped metric -- its name and its labels -- **before** profiles are
+matched and charts are built. It is a job-level configuration option (`relabeling`), not a profile field: it works with
+or without profiles, and profiles see the relabeled result. The rule shape is Prometheus-compatible: it mirrors
+Prometheus
 [`metric_relabel_configs`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs),
-so rules you already use in Prometheus carry over -- with these deliberate
-exceptions: the `__name__` handling of the label-name actions (see
-[Actions](#actions)), and the histogram/summary integrity protection, which
-rejects rules -- such as thinning buckets by `le` -- that Prometheus allows
-(see [Histogram and summary safety](#histogram-and-summary-safety)). When
-porting, wrap your flat `metric_relabel_configs` list in a `relabeling` block
-with a required `match` (use `'*'` for all metrics). The job's `selector`
-option runs first, on the original scraped names -- relabeling sees only what
-the selector kept, so a rename cannot recover a series the selector dropped
-under its old name.
+so rules you already use in Prometheus carry over -- with these deliberate exceptions: the `__name__` handling of the
+label-name actions (see [Actions](#actions)), and the histogram/summary integrity protection, which rejects rules --
+such as thinning buckets by `le` -- that Prometheus allows (see
+[Histogram and summary safety](#histogram-and-summary-safety)). When porting, wrap your flat `metric_relabel_configs`
+list in a `relabeling` block with a required `match` (use `'*'` for all metrics). The job's `selector` option runs
+first, on the original scraped names -- relabeling sees only what the selector kept, so a rename cannot recover a series
+the selector dropped under its old name.
 
-Use it to keep noisy metrics out of your dashboards, fold high-cardinality
-labels away, derive new labels, rename metrics, normalize label casing -- or
-rename an exporter's metrics so a stock profile recognizes them -- without
+Use it to keep noisy metrics out of your dashboards, fold high-cardinality labels away, derive new labels, rename
+metrics, normalize label casing -- or rename an exporter's metrics so a stock profile recognizes them -- without
 touching the application you are scraping.
 
-> **Note:** The removed `label_prefix` option prefixed every label key.
-> Relabeling covers its practical use case -- avoiding collisions with the
-> labels Netdata adds when re-exporting -- with a targeted `labelmap` rule
-> (see the [example](#prefix-label-names-replaces-label_prefix)). A blanket
-> all-labels rename has no direct equivalent: `labelmap` copies labels, it
-> does not rename them.
+> **Note:** The removed `label_prefix` option prefixed every label key. Relabeling covers its practical use case --
+> avoiding collisions with the labels Netdata adds when re-exporting -- with a targeted `labelmap` rule (see the
+> [example](#prefix-label-names-replaces-label_prefix)). A blanket all-labels rename has no direct equivalent:
+> `labelmap` copies labels, it does not rename them.
 
 ### How a rule reads
 
-Relabeling operates per scraped **series** (one sample line of the
-exposition), not per metric family. Each rule transforms one series in a few
-steps:
+Relabeling operates per scraped **series** (one sample line of the exposition), not per metric family. Each rule
+transforms one series in a few steps:
 
-1. **Join** the values of the metric's `source_labels` (with `separator`) into
-   one input string. The metric's own name is available as a special label,
-   `__name__`.
-2. **Match** that input against `regex`. The `regex` is a regular expression
-   that must match the **whole** input, not a substring (wrap it in `.*` to
-   match a part).
-3. **Act**: the `action` decides what happens -- set or rename a label, drop
-   or keep the metric, and so on. If you omit `action`, it defaults to
-   `replace`.
-4. **Write** -- `replace` writes the expanded `replacement` (with `regex`
-   capture groups: `$1`, or `${name}`) into `target_label`; use `__name__` to
-   rename the metric. `lowercase`/`uppercase`/`hashmod` also write
-   `target_label`, but without `replacement` expansion. The keep/drop actions
-   write nothing, and the label-name actions operate on label names directly,
-   never on `target_label` -- see [Actions](#actions).
+1. **Join** the values of the metric's `source_labels` (with `separator`) into one input string. The metric's own name
+   is available as a special label, `__name__`.
+2. **Match** that input against `regex`. The `regex` is a regular expression that must match the **whole** input, not a
+   substring (wrap it in `.*` to match a part).
+3. **Act**: the `action` decides what happens -- set or rename a label, drop or keep the metric, and so on. If you omit
+   `action`, it defaults to `replace`.
+4. **Write** -- `replace` writes the expanded `replacement` (with `regex` capture groups: `$1`, or `${name}`) into
+   `target_label`; use `__name__` to rename the metric. `lowercase`/`uppercase`/`hashmod` also write `target_label`, but
+   without `replacement` expansion. The keep/drop actions write nothing, and the label-name actions operate on label
+   names directly, never on `target_label` -- see [Actions](#actions).
 
-Two different matchers are at play -- don't confuse them: a block's `match` is
-a **glob** (simple pattern) over the metric name, while a rule's `regex` is an
-**anchored regular expression** over the joined label values.
+Two different matchers are at play -- don't confuse them: a block's `match` is a **glob** (simple pattern) over the
+metric name, while a rule's `regex` is an **anchored regular expression** over the joined label values.
 
 ### Quick start
 
-Add a `relabeling` block to a job. This drops the `go_gc_duration_seconds`
-metric and derives an HTTP `code_class` label (`2xx`, `4xx`, ...) on every
-`http_*` metric:
+Add a `relabeling` block to a job. This drops the `go_gc_duration_seconds` metric and derives an HTTP `code_class` label
+(`2xx`, `4xx`, ...) on every `http_*` metric:
 
 ```yaml
 jobs:
@@ -468,16 +389,14 @@ jobs:
             replacement: '${1}xx'
 ```
 
-The drop and label-deriving techniques are explained step by step under
-[Relabeling examples](#relabeling-examples).
+The drop and label-deriving techniques are explained step by step under [Relabeling examples](#relabeling-examples).
 
 ### Relabeling configuration
 
-`relabeling` is a **list of blocks**. Each block has a `match` and a list of
-rules; the rules apply only to metrics whose name matches the block's `match`.
-Grouping rules under a block lets you scope a set of rules to a subset of
-metrics by name, instead of repeating a name match in every rule. Relabeling
-is opt-in -- jobs without a `relabeling` section are unaffected.
+`relabeling` is a **list of blocks**. Each block has a `match` and a list of rules; the rules apply only to metrics
+whose name matches the block's `match`. Grouping rules under a block lets you scope a set of rules to a subset of
+metrics by name, instead of repeating a name match in every rule. Relabeling is opt-in -- jobs without a `relabeling`
+section are unaffected.
 
 ```yaml
 jobs:
@@ -499,25 +418,21 @@ jobs:
 
 `match` selects which metrics a block's rules apply to. It is **required**.
 
-- Syntax is a Netdata
-  [simple pattern](/src/libnetdata/simple_pattern/README.md): a
-  space-separated list of globs where `*` matches any sequence, `?` matches
-  any single character, and a leading `!` negates a term.
-- It is matched against the **full metric name, including** the
-  `_bucket`/`_sum`/`_count` suffixes of histograms and summaries. Prefer a
-  glob like `app_lat*` over an exact `app_lat`, otherwise the histogram's
-  `_bucket`/`_sum`/`_count` series will not match. (Profile
-  [`match`](#match) works on family base names instead.)
+- Syntax is a Netdata [simple pattern](/src/libnetdata/simple_pattern/README.md): a space-separated list of globs where
+  `*` matches any sequence, `?` matches any single character, and a leading `!` negates a term.
+- It is matched against the **full metric name, including** the `_bucket`/`_sum`/`_count` suffixes of histograms and
+  summaries. Prefer a glob like `app_lat*` over an exact `app_lat`, otherwise the histogram's `_bucket`/`_sum`/`_count`
+  series will not match. (Profile [`match`](#match) works on family base names instead.)
 - Use `*` to target **every** metric.
 
-Blocks run in order, and `match` sees each metric's **current** name -- so a
-block can match the new name produced by an earlier block's rename.
+Blocks run in order, and `match` sees each metric's **current** name -- so a block can match the new name produced by an
+earlier block's rename.
 
 #### Rule fields
 
-Inside a block, `metric_relabel_configs` is a list of rules applied **in
-order** (see [How a rule reads](#how-a-rule-reads)). Every field is optional
-except where an action requires it; `action` defaults to `replace`.
+Inside a block, `metric_relabel_configs` is a list of rules applied **in order** (see
+[How a rule reads](#how-a-rule-reads)). Every field is optional except where an action requires it; `action` defaults to
+`replace`.
 
 | Field           | Description                                                                                                                              | Default   |
 |:----------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:----------|
@@ -545,30 +460,23 @@ except where an action requires it; `action` defaults to `replace`.
 | `lowercase` | Set `target_label` to the lowercased joined input. See [example](#normalize-label-case).                                                                                                                |
 | `uppercase` | Set `target_label` to the uppercased joined input. See [example](#normalize-label-case).                                                                                                                |
 
-> **Differs from Prometheus.** The label-name actions `labelmap`,
-> `labeldrop`, and `labelkeep` act on labels only -- they never touch the
-> metric name (`__name__`). In Prometheus, `__name__` is visible to these
-> three actions; a ported rule that relied on that (a `labelkeep` whose regex
-> omits `__name__`, a blanket `labeldrop`, a `labelmap` over the metric name)
-> silently leaves the metric name untouched in Netdata. To rename a metric,
-> use a `replace` rule with `target_label: __name__`.
+> **Differs from Prometheus.** The label-name actions `labelmap`, `labeldrop`, and `labelkeep` act on labels only --
+> they never touch the metric name (`__name__`). In Prometheus, `__name__` is visible to these three actions; a ported
+> rule that relied on that (a `labelkeep` whose regex omits `__name__`, a blanket `labeldrop`, a `labelmap` over the
+> metric name) silently leaves the metric name untouched in Netdata. To rename a metric, use a `replace` rule with
+> `target_label: __name__`.
 
 ### How relabeling runs
 
-1. For each scraped metric, every block whose `match` matches the metric's
-   **current** name runs, in order.
-2. Within a block, rules run in order. Each rule joins `source_labels` into an
-   input string and applies its `action`.
-3. A rule can rename the metric (write `__name__`), so a later block or rule
-   sees the new name.
-4. If any rule drops the metric, the remaining rules and blocks are skipped
-   for it.
+1. For each scraped metric, every block whose `match` matches the metric's **current** name runs, in order.
+2. Within a block, rules run in order. Each rule joins `source_labels` into an input string and applies its `action`.
+3. A rule can rename the metric (write `__name__`), so a later block or rule sees the new name.
+4. If any rule drops the metric, the remaining rules and blocks are skipped for it.
 
 #### Histogram and summary safety
 
-A histogram or summary is assembled from several series --
-`_bucket`/`_sum`/`_count`, or per-quantile series. Netdata will **not** let
-relabeling silently corrupt one. A rule that would:
+A histogram or summary is assembled from several series -- `_bucket`/`_sum`/`_count`, or per-quantile series. Netdata
+will **not** let relabeling silently corrupt one. A rule that would:
 
 - split a histogram/summary across multiple metric names,
 - drop only some of its components,
@@ -576,21 +484,17 @@ relabeling silently corrupt one. A rule that would:
 - merge two metric families together, or
 - duplicate a component,
 
-is rejected. The job **fails at autodetection**, so a bad rule is caught
-immediately; if the exposition changes at runtime, the affected metric family is
-**dropped** (rather than charted with wrong values) and the rest of the job
-keeps working.
+is rejected. The job **fails at autodetection**, so a bad rule is caught immediately; if the exposition changes at
+runtime, the affected metric family is **dropped** (rather than charted with wrong values) and the rest of the job keeps
+working.
 
-This also covers the common Prometheus technique of thinning histogram
-buckets: a `keep`/`drop` rule on the `le` (or `quantile`) label is treated as
-corrupting the metric family, never as thinning it -- the job fails its check
-when the check scrape shows the family partially dropped or mutated, and the
-whole metric family is dropped if the exposition drifts into corruption later
-at runtime. Reduce histogram cardinality at the exporter or with the job's
-`selector` option instead.
+This also covers the common Prometheus technique of thinning histogram buckets: a `keep`/`drop` rule on the `le` (or
+`quantile`) label is treated as corrupting the metric family, never as thinning it -- the job fails its check when the
+check scrape shows the family partially dropped or mutated, and the whole metric family is dropped if the exposition
+drifts into corruption later at runtime. Reduce histogram cardinality at the exporter or with the job's `selector`
+option instead.
 
-Plain gauges and counters have no such restriction -- you can rename, relabel,
-split, or drop them freely.
+Plain gauges and counters have no such restriction -- you can rename, relabel, split, or drop them freely.
 
 ### Relabeling examples
 
@@ -605,15 +509,12 @@ relabeling:
       - action: drop
 ```
 
-`match: 'go_*'` already selects the metrics, so the rule needs no `regex` --
-it drops every metric the block sees.
+`match: 'go_*'` already selects the metrics, so the rule needs no `regex` -- it drops every metric the block sees.
 
 #### Keep only specific metrics
 
-Within a metric family, drop everything except a chosen series by matching a
-label.
-This keeps only `node_systemd_unit_state` samples whose `state` is `active`,
-dropping the rest:
+Within a metric family, drop everything except a chosen series by matching a label. This keeps only
+`node_systemd_unit_state` samples whose `state` is `active`, dropping the rest:
 
 ```yaml
 relabeling:
@@ -624,8 +525,7 @@ relabeling:
         action: keep
 ```
 
-`keep` drops any sample whose `state` label is not exactly `active` (the
-`regex` is fully anchored).
+`keep` drops any sample whose `state` label is not exactly `active` (the `regex` is fully anchored).
 
 #### Add a derived label
 
@@ -641,8 +541,7 @@ relabeling:
         replacement: '${1}xx'
 ```
 
-For `code="404"`, the rule writes `code_class="4xx"`. The original `code`
-label is left untouched.
+For `code="404"`, the rule writes `code_class="4xx"`. The original `code` label is left untouched.
 
 #### Rename a metric
 
@@ -658,10 +557,8 @@ relabeling:
         replacement: '$1'
 ```
 
-`legacy_app_requests_total` becomes `app_requests_total`. (Renaming a
-histogram/summary is allowed only when all of its components are renamed
-together -- see
-[Histogram and summary safety](#histogram-and-summary-safety).)
+`legacy_app_requests_total` becomes `app_requests_total`. (Renaming a histogram/summary is allowed only when all of its
+components are renamed together -- see [Histogram and summary safety](#histogram-and-summary-safety).)
 
 #### Remove a high-cardinality label
 
@@ -675,8 +572,8 @@ relabeling:
         action: labeldrop
 ```
 
-Every `pod_uid` label is removed from all metrics. To drop several, use an
-alternation like `regex: 'pod_uid|instance_id'`.
+Every `pod_uid` label is removed from all metrics. To drop several, use an alternation like
+`regex: 'pod_uid|instance_id'`.
 
 #### Keep only a few labels
 
@@ -690,13 +587,12 @@ relabeling:
         action: labelkeep
 ```
 
-`labelkeep` removes every label whose name is **not** in the regex. The metric
-name (`__name__`) is always kept, so you do not list it.
+`labelkeep` removes every label whose name is **not** in the regex. The metric name (`__name__`) is always kept, so you
+do not list it.
 
 #### Normalize label case
 
-Lowercase a label value so `GET`, `Get`, and `get` collapse into one
-dimension:
+Lowercase a label value so `GET`, `Get`, and `get` collapse into one dimension:
 
 ```yaml
 relabeling:
@@ -707,17 +603,15 @@ relabeling:
         action: lowercase
 ```
 
-Use `uppercase` for the opposite. These actions take `source_labels`,
-`separator`, and `target_label` (the target is often the same label).
+Use `uppercase` for the opposite. These actions take `source_labels`, `separator`, and `target_label` (the target is
+often the same label).
 
 #### Prefix label names (replaces `label_prefix`)
 
-When these metrics are re-exported in Prometheus format, Netdata adds its own
-`instance`, `family`, `chart`, and `dimension` labels. If the scraped endpoint
-already uses one of those names, the re-export emits a duplicate label and a
-downstream Prometheus rejects the scrape. Rename the colliding labels -- copy
-them to a prefixed name with `labelmap`, then drop the originals with
-`labeldrop`:
+When these metrics are re-exported in Prometheus format, Netdata adds its own `instance`, `family`, `chart`, and
+`dimension` labels. If the scraped endpoint already uses one of those names, the re-export emits a duplicate label and a
+downstream Prometheus rejects the scrape. Rename the colliding labels -- copy them to a prefixed name with `labelmap`,
+then drop the originals with `labeldrop`:
 
 ```yaml
 relabeling:
@@ -730,20 +624,16 @@ relabeling:
         action: labeldrop
 ```
 
-`labelmap` copies `instance` -> `app_instance` and `family` -> `app_family`
-(the `( )` capture feeds `$1` in `replacement`); the `labeldrop` then removes
-the originals -- its anchored regex matches those names exactly, not the new
-`app_` ones. Add more names to the alternation for other collisions;
-`__name__` is never affected. The removed `label_prefix` option prefixed
-every label key; the re-export collision shown here is the problem it existed
-to solve. Prefix only the labels that actually collide -- a generic
-all-labels rename is not expressible with these actions, because `labelmap`
-copies labels and the originals cannot be dropped without naming them.
+`labelmap` copies `instance` -> `app_instance` and `family` -> `app_family` (the `( )` capture feeds `$1` in
+`replacement`); the `labeldrop` then removes the originals -- its anchored regex matches those names exactly, not the
+new `app_` ones. Add more names to the alternation for other collisions; `__name__` is never affected. The removed
+`label_prefix` option prefixed every label key; the re-export collision shown here is the problem it existed to solve.
+Prefix only the labels that actually collide -- a generic all-labels rename is not expressible with these actions,
+because `labelmap` copies labels and the originals cannot be dropped without naming them.
 
 #### Scope rules to a subset of metrics
 
-Each block's `match` already scopes its rules. Combine blocks to apply
-different rules to different metric sets:
+Each block's `match` already scopes its rules. Combine blocks to apply different rules to different metric sets:
 
 ```yaml
 relabeling:
@@ -758,5 +648,5 @@ relabeling:
         action: uppercase
 ```
 
-The first block touches only `http_*` metrics; the second touches `db_*` and
-`cache_*`. A metric matched by no block is left unchanged.
+The first block touches only `http_*` metrics; the second touches `db_*` and `cache_*`. A metric matched by no block is
+left unchanged.

--- a/src/go/plugin/go.d/config/go.d/snmp.trap-profiles/profile-format.md
+++ b/src/go/plugin/go.d/config/go.d/snmp.trap-profiles/profile-format.md
@@ -4,12 +4,13 @@
 
 ## Overview
 
-An **SNMP trap profile** defines _how a specific class of SNMP trap notifications is decoded, classified, and rendered_ by the Netdata SNMP trap subsystem.
+An **SNMP trap profile** defines _how a specific class of SNMP trap notifications is decoded, classified, and rendered_
+by the Netdata SNMP trap subsystem.
 
 :::info
 
-Trap profiles are reusable and declarative — you never need to modify the
-collector source code to support a new device or vendor.
+Trap profiles are reusable and declarative — you never need to modify the collector source code to support a new device
+or vendor.
 
 :::
 
@@ -21,41 +22,32 @@ A profile tells the Netdata SNMP trap plugin:
 - how to **render** each trap into a human-readable journal `MESSAGE`
 - which optional **metrics** and charts can be derived from selected traps
 
-Trap profiles do **not** define journal field names manually. The plugin derives
-indexed `TRAP_VAR_*` journal fields from received non-sensitive, non-redundant
-event varbinds, and also keeps the complete structured audit copy in
-`TRAP_JSON` (see the SNMP trap subsystem design doc). Profiles may define
-optional trap-to-metric rules and chart definitions. Listener jobs still decide
-whether to enable those rules through `profile_metrics`.
+Trap profiles do **not** define journal field names manually. The plugin derives indexed `TRAP_VAR_*` journal fields
+from received non-sensitive, non-redundant event varbinds, and also keeps the complete structured audit copy in
+`TRAP_JSON` (see the SNMP trap subsystem design doc). Profiles may define optional trap-to-metric rules and chart
+definitions. Listener jobs still decide whether to enable those rules through `profile_metrics`.
 
-A profile is a single YAML file. One file per vendor by convention; stock
-profiles ship under `default/` and are organized by inferred enterprise-PEN
-vendor (`ciscosystems.yaml`, `huawei-technology-co-ltd.yaml`,
-`juniper-networks-inc.yaml`, …) plus the IETF-standard file (`standard.yaml`)
-and the IEEE LLDP file (`ieee-lldp.yaml`).
+A profile is a single YAML file. One file per vendor by convention; stock profiles ship under `default/` and are
+organized by inferred enterprise-PEN vendor (`ciscosystems.yaml`, `huawei-technology-co-ltd.yaml`,
+`juniper-networks-inc.yaml`, …) plus the IETF-standard file (`standard.yaml`) and the IEEE LLDP file (`ieee-lldp.yaml`).
 
 ### How profiles are loaded
 
-The plugin reads stock profiles from the go.d stock config directory
-`snmp.trap-profiles/default/` subdirectory (typically
-`/usr/lib/netdata/conf.d/go.d/snmp.trap-profiles/default/`) and operator
-profiles from the go.d user config directory `snmp.trap-profiles/` subdirectory
-(typically `/etc/netdata/go.d/snmp.trap-profiles/`). Stock files are plain
-`.yaml` in the source repository for reviewability; installed packages ship
-them as `.yaml.zst`. The loader accepts `.yaml`, `.yml`, `.yaml.zst`, and
-`.yml.zst`; draft-era `.yaml.gz` and `.yml.gz` files are also accepted as a
+The plugin reads stock profiles from the go.d stock config directory `snmp.trap-profiles/default/` subdirectory
+(typically `/usr/lib/netdata/conf.d/go.d/snmp.trap-profiles/default/`) and operator profiles from the go.d user config
+directory `snmp.trap-profiles/` subdirectory (typically `/etc/netdata/go.d/snmp.trap-profiles/`). Stock files are plain
+`.yaml` in the source repository for reviewability; installed packages ship them as `.yaml.zst`. The loader accepts
+`.yaml`, `.yml`, `.yaml.zst`, and `.yml.zst`; draft-era `.yaml.gz` and `.yml.gz` files are also accepted as a
 compatibility fallback.
 
-Profiles are loaded **only when the first runnable SNMP trap job is created** —
-Netdata agents that do not receive traps never pay the memory footprint.
+Profiles are loaded **only when the first runnable SNMP trap job is created** — Netdata agents that do not receive traps
+never pay the memory footprint.
 
-Profile loading is shared across trap jobs: the first runnable job eagerly
-loads operator profiles, validates stock profiles, builds a stock OID route
-table, and later jobs reuse the same cache. Stock profile definitions are loaded
-into memory only when the first matching trap OID needs that stock file. Failed
-profile validation is a creation-time job failure surfaced to DynCfg; it does
-not leave a permanently poisoned cache. If all trap jobs are removed, the cache
-is released and the next trap job creation validates profiles again.
+Profile loading is shared across trap jobs: the first runnable job eagerly loads operator profiles, validates stock
+profiles, builds a stock OID route table, and later jobs reuse the same cache. Stock profile definitions are loaded into
+memory only when the first matching trap OID needs that stock file. Failed profile validation is a creation-time job
+failure surfaced to DynCfg; it does not leave a permanently poisoned cache. If all trap jobs are removed, the cache is
+released and the next trap job creation validates profiles again.
 
 ## File layout
 
@@ -132,8 +124,8 @@ metrics:
 
 ### File-level `varbinds:` table
 
-Name-keyed map of varbind metadata shared across every trap in the file. Each
-entry is the slim shipping form of a single MIB object:
+Name-keyed map of varbind metadata shared across every trap in the file. Each entry is the slim shipping form of a
+single MIB object:
 
 | Field         | Required | Type   | Notes |
 |---------------|----------|--------|-------|
@@ -142,30 +134,23 @@ entry is the slim shipping form of a single MIB object:
 | `enum`        | no       | map    | Numeric-string → label for `INTEGER` enumerations |
 | `constraints` | no       | string | Size/range constraint expression (e.g., `SIZE(0..16)`, `(1..65535)`) |
 
-> **Future field**: a `display_hint` member (render hint such as `1x:` for MAC
-> or `1d.1d.1d.1d` for IPv4) will be added when the plugin's renderer needs
-> it. The current extractor keeps DISPLAY-HINT data in intermediate JSONL when
-> `gomib` exposes it, but the stock profile emitter does not write
-> `display_hint`; the field is reserved for the renderer work that will consume
-> it.
+> **Future field**: a `display_hint` member (render hint such as `1x:` for MAC or `1d.1d.1d.1d` for IPv4) will be added
+> when the plugin's renderer needs it. The current extractor keeps DISPLAY-HINT data in intermediate JSONL when `gomib`
+> exposes it, but the stock profile emitter does not write `display_hint`; the field is reserved for the renderer work
+> that will consume it.
 
-Plugin behaviour: varbinds that the plugin sees on a trap but cannot resolve
-via the file table fall back to raw OID-keyed rendering — there is **no
-runtime MIB compilation** in the plugin. Operators convert custom MIBs to
-profile YAMLs offline with the installed helper
-`/usr/libexec/netdata/plugins.d/snmp-trap-profile-gen` and drop the generated
-YAML files under `/etc/netdata/go.d/snmp.trap-profiles/`. The varbind still
-lands in the `TRAP_JSON` journal field with its OID, ASN.1-decoded type, and
-value. If it is not a sensitive or protocol-control varbind, the plugin also
-emits an indexed `TRAP_VAR_OID_<NUMERIC_OID>` journal field.
+Plugin behaviour: varbinds that the plugin sees on a trap but cannot resolve via the file table fall back to raw
+OID-keyed rendering — there is **no runtime MIB compilation** in the plugin. Operators convert custom MIBs to profile
+YAMLs offline with the installed helper `/usr/libexec/netdata/plugins.d/snmp-trap-profile-gen` and drop the generated
+YAML files under `/etc/netdata/go.d/snmp.trap-profiles/`. The varbind still lands in the `TRAP_JSON` journal field with
+its OID, ASN.1-decoded type, and value. If it is not a sensitive or protocol-control varbind, the plugin also emits an
+indexed `TRAP_VAR_OID_<NUMERIC_OID>` journal field.
 
 ### Duplicate symbolic name handling in `TRAP_JSON` and `TRAP_VAR_*`
 
-`TRAP_JSON` is an object keyed by varbind symbolic name. In the rare case
-where two varbinds in a single trap share the same symbolic name (e.g.
-two vendor MIBs each import a varbind that resolved to the same display
-name), later entries use deterministic suffixes (`#2`, `#3`, ...) to avoid
-duplicate JSON object keys. Example:
+`TRAP_JSON` is an object keyed by varbind symbolic name. In the rare case where two varbinds in a single trap share the
+same symbolic name (e.g. two vendor MIBs each import a varbind that resolved to the same display name), later entries
+use deterministic suffixes (`#2`, `#3`, ...) to avoid duplicate JSON object keys. Example:
 
 ```json
 {
@@ -174,46 +159,36 @@ duplicate JSON object keys. Example:
 }
 ```
 
-The first occurrence wins the symbolic name; subsequent duplicates use
-suffixed keys. Profile authors should avoid this by giving the conflicting
-varbinds distinct symbolic names in the file-scoped `varbinds:` table; the
-fallback exists only for cases where no such authoring control is possible at
-extraction time or where malformed senders repeat OIDs.
+The first occurrence wins the symbolic name; subsequent duplicates use suffixed keys. Profile authors should avoid this
+by giving the conflicting varbinds distinct symbolic names in the file-scoped `varbinds:` table; the fallback exists
+only for cases where no such authoring control is possible at extraction time or where malformed senders repeat OIDs.
 
-Indexed journal fields use a separate collision-safe namespace. A received
-symbolic varbind `ifOperStatus` emits `TRAP_VAR_IFOPERSTATUS`; if its value has
-an enum label, the label is written to `TRAP_VAR_IFOPERSTATUS` and the numeric
-value is written to `TRAP_VAR_IFOPERSTATUS_RAW`. Duplicate/sanitized field-name
-collisions receive deterministic suffixes (`_2`, `_3`, ...). Protocol-control
-varbinds that duplicate first-class fields (`sysUpTime.0`, `snmpTrapOID.0`,
-`snmpTrapAddress.0`, `snmpTrapEnterprise.0`) are kept in `TRAP_JSON` but not
-emitted as `TRAP_VAR_*`; the sensitive SNMP community varbind is omitted.
-Generated field names are capped to journald's 64-byte field-name limit. Long
-symbolic/OID-derived names keep a readable prefix plus a stable hash suffix; the
-complete varbind identity stays in `TRAP_JSON`.
+Indexed journal fields use a separate collision-safe namespace. A received symbolic varbind `ifOperStatus` emits
+`TRAP_VAR_IFOPERSTATUS`; if its value has an enum label, the label is written to `TRAP_VAR_IFOPERSTATUS` and the numeric
+value is written to `TRAP_VAR_IFOPERSTATUS_RAW`. Duplicate/sanitized field-name collisions receive deterministic
+suffixes (`_2`, `_3`, ...). Protocol-control varbinds that duplicate first-class fields (`sysUpTime.0`, `snmpTrapOID.0`,
+`snmpTrapAddress.0`, `snmpTrapEnterprise.0`) are kept in `TRAP_JSON` but not emitted as `TRAP_VAR_*`; the sensitive SNMP
+community varbind is omitted. Generated field names are capped to journald's 64-byte field-name limit. Long
+symbolic/OID-derived names keep a readable prefix plus a stable hash suffix; the complete varbind identity stays in
+`TRAP_JSON`.
 
-Generator rule: a varbind record produced by the MIB extractor that does
-NOT have both a resolvable `oid` AND a `type` (MIB syntax) is dropped at
-emit time — it never enters the `varbinds:` table, and any reference to it
-from a trap entry's `varbinds:` list is removed in lockstep. This keeps the
-shipped pack free of dangling references; description templates can only
-reference varbinds that survive to disk.
+Generator rule: a varbind record produced by the MIB extractor that does NOT have both a resolvable `oid` AND a `type`
+(MIB syntax) is dropped at emit time — it never enters the `varbinds:` table, and any reference to it from a trap
+entry's `varbinds:` list is removed in lockstep. This keeps the shipped pack free of dangling references; description
+templates can only reference varbinds that survive to disk.
 
 ### Optional `metrics:` rules and `charts:`
 
-Profiles may define trap-to-metric rules next to trap decode information. These
-rules are inert until a listener job enables them with `profile_metrics`.
+Profiles may define trap-to-metric rules next to trap decode information. These rules are inert until a listener job
+enables them with `profile_metrics`.
 
-Metric rules are merged through `extends:` by rule `name`; a child profile can
-replace or disable an inherited rule by using the same name. Chart definitions
-are merged by chart `id`.
+Metric rules are merged through `extends:` by rule `name`; a child profile can replace or disable an inherited rule by
+using the same name. Chart definitions are merged by chart `id`.
 
-Custom profile files under `/etc/netdata/go.d/snmp.trap-profiles/` are loaded
-eagerly. Stock trap profiles remain lazy when the loaded profile set has no
-metric rules and no listener enables `profile_metrics`. When custom profile
-metric rules exist, or when a listener enables `profile_metrics`, stock profiles
-are loaded before rule selection so custom rules can validate references to
-stock trap names before the first matching trap.
+Custom profile files under `/etc/netdata/go.d/snmp.trap-profiles/` are loaded eagerly. Stock trap profiles remain lazy
+when the loaded profile set has no metric rules and no listener enables `profile_metrics`. When custom profile metric
+rules exist, or when a listener enables `profile_metrics`, stock profiles are loaded before rule selection so custom
+rules can validate references to stock trap names before the first matching trap.
 
 Enable profile metrics in the listener job, not in the profile file:
 
@@ -237,93 +212,70 @@ profile_metrics:
 
 Selection modes:
 
-- `profile_metrics.enabled` defaults to `false`; profile rules are inactive
-  until the job enables them.
+- `profile_metrics.enabled` defaults to `false`; profile rules are inactive until the job enables them.
 - `none`: no profile metric rules are evaluated.
 - `auto`: enable rules marked `auto_safe: true`.
 - `exact`: enable only names listed in `profile_metrics.include`.
 - `combined`: enable `auto_safe: true` rules plus names listed in `include`.
 
-`profile_metrics.include` is valid only with `mode: exact` or
-`mode: combined`. It is rejected with `mode: none` or `mode: auto`, because it
-would otherwise look configured while having no selection effect.
+`profile_metrics.include` is valid only with `mode: exact` or `mode: combined`. It is rejected with `mode: none` or
+`mode: auto`, because it would otherwise look configured while having no selection effect.
 
-Use `auto_safe: true` only for rules reviewed as bounded and safe for trap
-hubs. A child profile rule with the same `name` fully replaces the inherited
-rule; if an operator replacement sets `auto_safe: true`, the operator owns that
+Use `auto_safe: true` only for rules reviewed as bounded and safe for trap hubs. A child profile rule with the same
+`name` fully replaces the inherited rule; if an operator replacement sets `auto_safe: true`, the operator owns that
 safety decision.
 
 Identity behavior:
 
-- `identity.device: source` emits device-attributable metrics under vnode host
-  scope when trap enrichment supplies an unambiguous `SourceVnodeID`.
-- When no vnode is known, the metric is emitted under the listener job with
-  bounded `source_id` and `source_kind` labels.
-- Ambiguous or conflicting vnode enrichment falls back to source-label metrics
-  and increments attribution diagnostics instead of creating or migrating vnode
-  metrics.
-- Vnode-scoped profile metric series also include `source_id` and
-  `source_kind`; generated chart instances use the same label identity in both
-  vnode and fallback modes.
-- `identity.device: source_label` always emits under the listener job with
-  bounded `source_id` and `source_kind` labels, even when vnode enrichment is
-  available.
-- `identity.device: listener` is only for listener-owned rules that should merge
-  all source devices.
-- `source_id_privacy: hash` hides raw source values behind a stable local hash
-  derived from the selected source value, job name, and SDK local Agent identity.
-  Use `raw` only when source labels are acceptable in your environment.
-  Treat hashed `source_id` values as local listener identifiers, not portable
-  join keys across Agents, listeners, or reinstalls.
-  The local salt comes from the systemd journal SDK host identity helper. On
-  platforms without a native machine ID, the helper uses its configured Netdata
-  state directory for synthesized stable local identity. The emitted `source_id`
-  is truncated to 16 hex characters.
-- `source_kind` is a closed label set: `vnode`, `listener`,
-  `trusted_trap_address`, `udp_peer`, `entry_source`, `hostname_or_ip`,
-  `trap_varbind`, `topology_ifindex`, `source`, or `other`.
+- `identity.device: source` emits device-attributable metrics under vnode host scope when trap enrichment supplies an
+  unambiguous `SourceVnodeID`.
+- When no vnode is known, the metric is emitted under the listener job with bounded `source_id` and `source_kind`
+  labels.
+- Ambiguous or conflicting vnode enrichment falls back to source-label metrics and increments attribution diagnostics
+  instead of creating or migrating vnode metrics.
+- Vnode-scoped profile metric series also include `source_id` and `source_kind`; generated chart instances use the same
+  label identity in both vnode and fallback modes.
+- `identity.device: source_label` always emits under the listener job with bounded `source_id` and `source_kind` labels,
+  even when vnode enrichment is available.
+- `identity.device: listener` is only for listener-owned rules that should merge all source devices.
+- `source_id_privacy: hash` hides raw source values behind a stable local hash derived from the selected source value,
+  job name, and SDK local Agent identity. Use `raw` only when source labels are acceptable in your environment. Treat
+  hashed `source_id` values as local listener identifiers, not portable join keys across Agents, listeners, or
+  reinstalls. The local salt comes from the systemd journal SDK host identity helper. On platforms without a native
+  machine ID, the helper uses its configured Netdata state directory for synthesized stable local identity. The emitted
+  `source_id` is truncated to 16 hex characters.
+- `source_kind` is a closed label set: `vnode`, `listener`, `trusted_trap_address`, `udp_peer`, `entry_source`,
+  `hostname_or_ip`, `trap_varbind`, `topology_ifindex`, `source`, or `other`.
 
 Cardinality behavior:
 
-- `limits.max_sources` caps non-listener source identities tracked by the job,
-  including vnode and fallback sources.
-- `limits.max_resources_per_source` is the default per-source, per-resource-class
-  resource cap.
-- `identity.resource.max_per_source` overrides the default for one rule's
-  resource class.
-- `identity.resource.key_from_varbind` must reference an integer-like bounded
-  varbind (`INTEGER`, `Integer32`, `Unsigned32`, or `Gauge32`). String, MAC,
-  username, address, and payload-like fields are rejected as resource keys to
-  protect metric cardinality.
-  `Counter32`, `Counter64`, and `TimeTicks` are valid sample values, not
-  resource identity keys.
-- `identity.resource.class` must be one of the stock classes `interface`,
-  `peer`, `neighbor`, `sensor`, `alarm`, `pool`, `l2_topology`, `component`, or
-  a site-specific lowercase class beginning with `site_`, such as
-  `site_foo_sensor`.
+- `limits.max_sources` caps non-listener source identities tracked by the job, including vnode and fallback sources.
+- `limits.max_resources_per_source` is the default per-source, per-resource-class resource cap.
+- `identity.resource.max_per_source` overrides the default for one rule's resource class.
+- `identity.resource.key_from_varbind` must reference an integer-like bounded varbind (`INTEGER`, `Integer32`,
+  `Unsigned32`, or `Gauge32`). String, MAC, username, address, and payload-like fields are rejected as resource keys to
+  protect metric cardinality. `Counter32`, `Counter64`, and `TimeTicks` are valid sample values, not resource identity
+  keys.
+- `identity.resource.class` must be one of the stock classes `interface`, `peer`, `neighbor`, `sensor`, `alarm`, `pool`,
+  `l2_topology`, `component`, or a site-specific lowercase class beginning with `site_`, such as `site_foo_sensor`.
 - `limits.max_instances_per_job` is the final job-level safety cap.
-- `limits.overflow` currently supports `drop_and_count`: accepted traps are
-  still committed, but over-cap metric instances are skipped and diagnostics
-  increment.
-- `charts.lifecycle.expire_after_cycles` counts go.d collection cycles, so
-  changing the listener job `update_every` changes its wall-clock expiry time.
-  State rule `state.ttl` uses wall-clock duration syntax and must be greater
-  than zero when set.
-- Expired series are removed. If the same source/resource appears again later,
-  the next committed trap creates a fresh series; counter charts may show a
-  reset after idle expiry.
-- All rules that share one chart must have the same label shape. Do not mix
-  resource and non-resource rules in one chart, and do not mix multiple
-  `identity.resource.class` values in one chart.
+- `limits.overflow` currently supports `drop_and_count`: accepted traps are still committed, but over-cap metric
+  instances are skipped and diagnostics increment.
+- `charts.lifecycle.expire_after_cycles` counts go.d collection cycles, so changing the listener job `update_every`
+  changes its wall-clock expiry time. State rule `state.ttl` uses wall-clock duration syntax and must be greater than
+  zero when set.
+- Expired series are removed. If the same source/resource appears again later, the next committed trap creates a fresh
+  series; counter charts may show a reset after idle expiry.
+- All rules that share one chart must have the same label shape. Do not mix resource and non-resource rules in one
+  chart, and do not mix multiple `identity.resource.class` values in one chart.
 
 Supported rule types:
 
 - `counter`: increments a counter when `on_trap` is committed.
 - `sample`: reads a numeric varbind from `value_from_varbind` on `on_trap`.
-- `state`: sets or clears a gauge using either `problem_trap`/`clear_trap` or
-  `on_trap` plus `state.set_when` and `state.clear_when`.
-  For same-OID state rules, `state.set_when` takes precedence when both
-  `state.set_when` and `state.clear_when` match the same trap.
+- `state`: sets or clears a gauge using either `problem_trap`/`clear_trap` or `on_trap` plus `state.set_when` and
+  `state.clear_when`. For same-OID state rules, `state.set_when` takes precedence when both `state.set_when` and
+  `state.clear_when` match the same trap.
 
 Canonical rule fields:
 
@@ -352,52 +304,44 @@ Canonical rule fields:
 Predicate behavior:
 
 - Multiple `where` predicates are ANDed.
-- Predicates may reference one of the synthetic fields `category`, `severity`,
-  `trap_name`, or `trap_oid`.
-- Varbind predicates must reference varbinds declared on every trap the rule can
-  process; typos fail profile validation instead of silently missing.
-- Each predicate must include at least one condition operator: `equals`, `in`,
-  `exists`, `absent`, `greater_than`, `less_than`, or `range`.
+- Predicates may reference one of the synthetic fields `category`, `severity`, `trap_name`, or `trap_oid`.
+- Varbind predicates must reference varbinds declared on every trap the rule can process; typos fail profile validation
+  instead of silently missing.
+- Each predicate must include at least one condition operator: `equals`, `in`, `exists`, `absent`, `greater_than`,
+  `less_than`, or `range`.
 - Compact map-form `where` is accepted for hand-authored rules, for example
   `where: { ccmHistoryEventTerminalType: { in: [console, terminal] } }`.
 - `equals` and `in` match enum labels when the referenced varbind has an enum.
-- Numeric predicates support `greater_than`, `less_than`, and inclusive
-  two-value `range`; bounds must be finite numbers and `range` must have
-  exactly two values ordered with `lower <= upper`.
-- Non-finite runtime varbind values such as `NaN` or `Inf` do not match numeric
-  predicates and increment the rule-miss diagnostic.
+- Numeric predicates support `greater_than`, `less_than`, and inclusive two-value `range`; bounds must be finite numbers
+  and `range` must have exactly two values ordered with `lower <= upper`.
+- Non-finite runtime varbind values such as `NaN` or `Inf` do not match numeric predicates and increment the rule-miss
+  diagnostic.
 - `exists` and `absent` match varbind presence.
-- `not: true` negates a predicate only when the referenced varbind is present;
-  use `absent: true` to match missing varbinds. `not` cannot be combined with
-  `exists` or `absent`.
+- `not: true` negates a predicate only when the referenced varbind is present; use `absent: true` to match missing
+  varbinds. `not` cannot be combined with `exists` or `absent`.
 
 Missing-value behavior:
 
 - `drop` skips the metric update and increments the rule-miss diagnostic.
-- `zero` is supported only for `sample` rules when absence explicitly means
-  zero. It is not valid for `counter` or `state`; state rules must use explicit
-  set/clear predicates or trap pairs.
-- `unknown_dimension` is supported only with `identity.resource`; it emits the
-  bounded resource ID `unknown`.
-- `error` skips the metric update and increments the extraction-failure
-  diagnostic.
+- `zero` is supported only for `sample` rules when absence explicitly means zero. It is not valid for `counter` or
+  `state`; state rules must use explicit set/clear predicates or trap pairs.
+- `unknown_dimension` is supported only with `identity.resource`; it emits the bounded resource ID `unknown`.
+- `error` skips the metric update and increments the extraction-failure diagnostic.
 
 Numeric sample behavior:
 
-- Accepted numeric source types are `INTEGER`, `Integer32`, `Unsigned32`,
-  `Gauge32`, `Counter32`, `Counter64`, and `TimeTicks`.
-- `Counter32`, `Counter64`, and `TimeTicks` are accepted only for sample rules;
-  they are not valid `identity.resource.key_from_varbind` types.
-- `TimeTicks` values are converted from hundredths of seconds to seconds before
-  `scale` is applied.
-- `scale.multiplier` and `scale.divisor` are applied before the metric is
-  emitted. Use chart units and metric names that describe the scaled value.
-- `Counter32` and `Counter64` trap varbinds are treated as absolute
-  trap-reported snapshots. They are not converted into rates from sparse trap
-  arrivals.
+- Accepted numeric source types are `INTEGER`, `Integer32`, `Unsigned32`, `Gauge32`, `Counter32`, `Counter64`, and
+  `TimeTicks`.
+- `Counter32`, `Counter64`, and `TimeTicks` are accepted only for sample rules; they are not valid
+  `identity.resource.key_from_varbind` types.
+- `TimeTicks` values are converted from hundredths of seconds to seconds before `scale` is applied.
+- `scale.multiplier` and `scale.divisor` are applied before the metric is emitted. Use chart units and metric names that
+  describe the scaled value.
+- `Counter32` and `Counter64` trap varbinds are treated as absolute trap-reported snapshots. They are not converted into
+  rates from sparse trap arrivals.
 
-Diagnostics are emitted as continuous receiver metrics on the
-`snmp.trap.profile_metric_diagnostics` chart with these dimensions:
+Diagnostics are emitted as continuous receiver metrics on the `snmp.trap.profile_metric_diagnostics` chart with these
+dimensions:
 
 - `rule_missed`
 - `extraction_failed`
@@ -405,39 +349,33 @@ Diagnostics are emitted as continuous receiver metrics on the
 - `overflow_dropped`
 - `source_transitions`
 
-Diagnostics are listener-scoped receiver metrics. They are not emitted under
-per-device vnode scopes. `attribution_failed` includes cases where
-`identity.unresolved_source: drop_metric_instance` refuses fallback source-label
-emission. `overflow_dropped` is reserved for source, resource, chart, or job
-cardinality caps. `source_transitions` counts when the same raw source maps to a
-different metric identity, for example from fallback source labels to vnode
-scope after enrichment starts resolving the device.
+Diagnostics are listener-scoped receiver metrics. They are not emitted under per-device vnode scopes.
+`attribution_failed` includes cases where `identity.unresolved_source: drop_metric_instance` refuses fallback
+source-label emission. `overflow_dropped` is reserved for source, resource, chart, or job cardinality caps.
+`source_transitions` counts when the same raw source maps to a different metric identity, for example from fallback
+source labels to vnode scope after enrichment starts resolving the device.
 
 Runtime ordering:
 
-- Profile metrics update only after the trap is successfully committed to the
-  authoritative output backend. When journal and OTLP are both enabled, journal
-  commitment is authoritative and OTLP failures are `otlp_export_failed`
-  export/source errors. When OTLP is the only output backend, OTLP export
-  failures are terminal write failures and also increment
-  `pipeline.write_failed` and source-attributed `source_pipeline.write_failed`
-  when the source is known.
+- Profile metrics update only after the trap is successfully committed to the authoritative output backend. When journal
+  and OTLP are both enabled, journal commitment is authoritative and OTLP failures are `otlp_export_failed`
+  export/source errors. When OTLP is the only output backend, OTLP export failures are terminal write failures and also
+  increment `pipeline.write_failed` and source-attributed `source_pipeline.write_failed` when the source is known.
 - Dedup-suppressed traps and write-failed traps do not update profile metrics.
-- Trap-derived samples and states are last-reported values. They are not
-  continuously polled measurements.
+- Trap-derived samples and states are last-reported values. They are not continuously polled measurements.
 
 Compact aliases are accepted for common hand-authored rules:
 
-- Compact aliases are for operator-authored profiles. Stock and generated
-  profile output should use canonical fields for reviewability.
+- Compact aliases are for operator-authored profiles. Stock and generated profile output should use canonical fields for
+  reviewability.
 - `metric`: alias for `output.metric`
 - `dimension`: alias for `output.dimension`
 - `chart_id`: alias for `output.chart`
 - `value`: alias for `value_from_varbind`
 - `resource.key`: alias for `identity.resource.key_from_varbind`
 - `resource.max`: alias for `identity.resource.max_per_source`
-- `state.varbind` plus `state.set` and `state.clear`: compact same-OID state
-  rule syntax. Both `set` and `clear` are required.
+- `state.varbind` plus `state.set` and `state.clear`: compact same-OID state rule syntax. Both `set` and `clear` are
+  required.
 
 Chart metadata defaults and validation:
 
@@ -512,9 +450,8 @@ Reserved metric name prefixes:
 - `snmp_trap_metric_`
 - `snmp_trap_profile_metrics_`
 
-Built-in source receiver metrics are automatic. Profile authors should not
-recreate receiver pipeline health with profile rules; use profile metrics for
-vendor or site semantics, such as trap-derived state, counters, and bounded
+Built-in source receiver metrics are automatic. Profile authors should not recreate receiver pipeline health with
+profile rules; use profile metrics for vendor or site semantics, such as trap-derived state, counters, and bounded
 resource samples.
 
 ### Trap entries (`traps:` list)
@@ -533,47 +470,40 @@ Each list entry defines one trap notification.
 | `labels`      | no       | map     | Operator-overridable: key → template producing a `TRAP_TAG_<KEY>` journal field. Dynamic references must be bounded-cardinality. |
 | `dedup_key_varbinds` | no | list | Names of varbinds that participate in the deduplication fingerprint; every name must resolve to the file-scoped `varbinds:` table |
 
-> Note: the `name:` field encodes the source MIB module already. There is no
-> separate `mib:` field on a trap entry — that would be redundant.
+> Note: the `name:` field encodes the source MIB module already. There is no separate `mib:` field on a trap entry —
+> that would be redundant.
 
 #### Trap OID `.0.` tolerance
 
-SMIv1 `TRAP-TYPE` notifications use the RFC 3584 `enterprise.0.specific`
-notification OID form. SMIv2 `NOTIFICATION-TYPE` notifications often use
-`parent.specific` without the inserted `.0.` segment. Some MIB conversion
+SMIv1 `TRAP-TYPE` notifications use the RFC 3584 `enterprise.0.specific` notification OID form. SMIv2
+`NOTIFICATION-TYPE` notifications often use `parent.specific` without the inserted `.0.` segment. Some MIB conversion
 tools can emit either form for the same trap family.
 
-The plugin matches trap profile entries exact-first. If exact lookup misses, it
-tries one alternate trap OID by adding or removing a single `.0.` immediately
-before the final OID arc. For example, a received
-`1.3.6.1.4.1.14179.2.6.3.0.24` can match a profile `oid:` of
-`1.3.6.1.4.1.14179.2.6.3.24`, and the reverse is also true. If both forms are
-present as separate profile entries, the exact match wins.
+The plugin matches trap profile entries exact-first. If exact lookup misses, it tries one alternate trap OID by adding
+or removing a single `.0.` immediately before the final OID arc. For example, a received `1.3.6.1.4.1.14179.2.6.3.0.24`
+can match a profile `oid:` of `1.3.6.1.4.1.14179.2.6.3.24`, and the reverse is also true. If both forms are present as
+separate profile entries, the exact match wins.
 
 This tolerance applies only to trap OID lookup.
 
-Varbind OID resolution is exact-match-first. If a profile varbind OID does not
-exactly match a received PDU varbind OID, it also matches received varbind OIDs
-under `profile_oid + "."`. This covers SMI table cells such as `ifIndex.1` for
-a profile column OID `ifIndex`, and scalar `.0` instances for profiles that use
-the base scalar OID. When mapping a received PDU varbind OID back to profile
-metadata, exact match wins; otherwise the longest matching profile varbind OID
-prefix wins. The trap-OID `.0.` alternate spelling rule is not applied to
-varbind OIDs.
+Varbind OID resolution is exact-match-first. If a profile varbind OID does not exactly match a received PDU varbind OID,
+it also matches received varbind OIDs under `profile_oid + "."`. This covers SMI table cells such as `ifIndex.1` for a
+profile column OID `ifIndex`, and scalar `.0` instances for profiles that use the base scalar OID. When mapping a
+received PDU varbind OID back to profile metadata, exact match wins; otherwise the longest matching profile varbind OID
+prefix wins. The trap-OID `.0.` alternate spelling rule is not applied to varbind OIDs.
 
-When deduplication includes configured `dedup_key_varbinds` and one of those
-varbinds is absent from a received PDU, the fingerprint uses a missing-value
-sentinel distinct from the empty string. Profile authors should list only
-varbinds normally present on every PDU for that trap OID.
+When deduplication includes configured `dedup_key_varbinds` and one of those varbinds is absent from a received PDU, the
+fingerprint uses a missing-value sentinel distinct from the empty string. Profile authors should list only varbinds
+normally present on every PDU for that trap OID.
 
 #### Varbind references
 
 `varbinds:` on a trap entry is a list. Each element is either:
 
-- **a string** — the varbind name, resolved via the file-level `varbinds:`
-  table (the normal case for stock profiles), or
-- **a dict** — a full inline `varbind` definition for varbinds that are
-  not in the table (operator additions, vendor-specific one-offs):
+- **a string** — the varbind name, resolved via the file-level `varbinds:` table (the normal case for stock profiles),
+  or
+- **a dict** — a full inline `varbind` definition for varbinds that are not in the table (operator additions,
+  vendor-specific one-offs):
 
   ```yaml
   varbinds:
@@ -583,13 +513,11 @@ varbinds normally present on every PDU for that trap OID.
       type: Counter32
   ```
 
-The order of `varbinds:` on a trap entry is not significant — the plugin
-matches arriving varbinds by OID at runtime.
+The order of `varbinds:` on a trap entry is not significant — the plugin matches arriving varbinds by OID at runtime.
 
 #### Description template
 
-`description:` is a restricted Go `text/template` string substituted at render
-time. Supported functions:
+`description:` is a restricted Go `text/template` string substituted at render time. Supported functions:
 
 | Reference | Resolved to |
 |---|---|
@@ -603,37 +531,31 @@ time. Supported functions:
 | `{{raw "varbindName"}}` | Varbind raw value (numeric for enums, undecoded bytes for OctetString) |
 | `{{first ...}}` | First non-empty argument, for optional-varbind fallback |
 
-Supported control flow is limited to `{{with ...}}{{else}}{{end}}`, using the
-same restricted function calls allowed for plain actions.
-Known-but-absent varbinds render as an empty string, not `<missing>`, so use
-`with` or `first` when optional context is included:
+Supported control flow is limited to `{{with ...}}{{else}}{{end}}`, using the same restricted function calls allowed for
+plain actions. Known-but-absent varbinds render as an empty string, not `<missing>`, so use `with` or `first` when
+optional context is included:
 
 ```yaml
 description: '{{with first (value "ifDescr") (value "ifName") (value "ifIndex")}}Interface {{.}} went down{{else}}Interface went down{{end}} on {{hostname}}.'
 ```
 
-Unknown functions, unknown varbind names, malformed templates, variables,
-assignments, `if`, `range`, arbitrary pipelines, and template inclusion actions
-fail at profile load so configuration errors are visible at job creation time.
+Unknown functions, unknown varbind names, malformed templates, variables, assignments, `if`, `range`, arbitrary
+pipelines, and template inclusion actions fail at profile load so configuration errors are visible at job creation time.
 
-If `description:` is absent the plugin renders the default template
-`"{{trap_name}} on {{hostname}}."`.
+If `description:` is absent the plugin renders the default template `"{{trap_name}} on {{hostname}}."`.
 
-The rendered `MESSAGE` is capped at 512 bytes, including the ASCII `...`
-truncation marker when truncation is needed. Multi-line MESSAGE values are
-written using systemd-journal's binary field encoding so embedded newlines never
-inject other journal fields.
+The rendered `MESSAGE` is capped at 512 bytes, including the ASCII `...` truncation marker when truncation is needed.
+Multi-line MESSAGE values are written using systemd-journal's binary field encoding so embedded newlines never inject
+other journal fields.
 
-The `status` field is informational. The plugin does not filter, drop, or warn
-on `deprecated` / `mandatory` / `obsolete` / `optional` traps.
-Known `status` values are still validated so typos fail at profile load instead
-of silently entering the shipped pack.
+The `status` field is informational. The plugin does not filter, drop, or warn on `deprecated` / `mandatory` /
+`obsolete` / `optional` traps. Known `status` values are still validated so typos fail at profile load instead of
+silently entering the shipped pack.
 
 ### Categories — closed set
 
-`category` MUST be one of these 8 canonical slugs. Stock profiles use this set;
-operator overrides cannot extend it. Cross-cutting concerns (compliance scope,
-tenant, datacenter, change window…) are expressed as **labels**, not as new
+`category` MUST be one of these 8 canonical slugs. Stock profiles use this set; operator overrides cannot extend it.
+Cross-cutting concerns (compliance scope, tenant, datacenter, change window…) are expressed as **labels**, not as new
 categories.
 
 | Slug            | Meaning |
@@ -649,8 +571,8 @@ categories.
 
 ### Severities — closed set, mapped to syslog PRIORITY
 
-`severity` MUST be one of these 8 syslog levels. The plugin maps each to a
-numeric `PRIORITY` field on the journal entry:
+`severity` MUST be one of these 8 syslog levels. The plugin maps each to a numeric `PRIORITY` field on the journal
+entry:
 
 | Slug      | PRIORITY | Use it for |
 |-----------|----------|------------|
@@ -665,64 +587,48 @@ numeric `PRIORITY` field on the journal entry:
 
 ## Cardinality discipline
 
-The trap subsystem enforces cardinality discipline at the metric / label
-surface only — the journal (including the rendered MESSAGE) has no
-cardinality restriction. See the trap subsystem design doc §4 for full
-rationale.
+The trap subsystem enforces cardinality discipline at the metric / label surface only — the journal (including the
+rendered MESSAGE) has no cardinality restriction. See the trap subsystem design doc §4 for full rationale.
 
 In profile terms:
 
-- `description:` and `varbinds:` references — **no restriction**. Free use of
-  any varbind including high-cardinality data (MAC, IP, username, packet
-  content). These land in MESSAGE, indexed `TRAP_VAR_*` journal fields, and
-  `TRAP_JSON` unless the varbind is sensitive or a protocol-control duplicate.
-- `labels:` — **bounded-cardinality only**. Templates that reference
-  unbounded varbinds (MAC, IP, username) are rejected at profile load with
-  a clear error. Labels become `TRAP_TAG_<KEY>=<VALUE>` journal fields and
-  propagate to metric labels.
+- `description:` and `varbinds:` references — **no restriction**. Free use of any varbind including high-cardinality
+  data (MAC, IP, username, packet content). These land in MESSAGE, indexed `TRAP_VAR_*` journal fields, and `TRAP_JSON`
+  unless the varbind is sensitive or a protocol-control duplicate.
+- `labels:` — **bounded-cardinality only**. Templates that reference unbounded varbinds (MAC, IP, username) are rejected
+  at profile load with a clear error. Labels become `TRAP_TAG_<KEY>=<VALUE>` journal fields and propagate to metric
+  labels.
 
 ## Operator overrides
 
-Operators do not copy entire stock profiles to make changes. Instead they
-place small override files under `/etc/netdata/go.d/snmp.trap-profiles/`.
-The plugin loader mirrors the SNMP polling plugin's multipath pattern
+Operators do not copy entire stock profiles to make changes. Instead they place small override files under
+`/etc/netdata/go.d/snmp.trap-profiles/`. The plugin loader mirrors the SNMP polling plugin's multipath pattern
 (`src/go/plugin/go.d/collector/snmp/ddsnmp/load.go`):
 
-1. **Same filename in higher-priority directory replaces the lower-priority
-   one entirely.** Operator `ciscosystems.yaml` fully replaces stock
-   `ciscosystems.yaml` or installed `ciscosystems.yaml.zst` — copy + edit the
-   whole file to customize one vendor.
-2. **Different filename adds entries.** Operator `site-additions.yaml`
-   (different filename) merges its `traps:` into the loaded set without
-   touching stock files. Metric-only site profiles can also use a different
-   filename and reference stock traps by MIB-qualified trap name in
-   `on_trap`, `problem_trap`, or `clear_trap`.
-3. **`extends:` chain field-merge** (when an override profile lists
-   `extends: [_base.yaml, other-base.yaml]`): entries must be YAML filenames
-   only, not paths. The loader merges trap
-   entries by OID; fields specified in the override file win over fields
-   from the extended bases; later entries in `extends:` override earlier
-   ones for the same field.
+1. **Same filename in higher-priority directory replaces the lower-priority one entirely.** Operator `ciscosystems.yaml`
+   fully replaces stock `ciscosystems.yaml` or installed `ciscosystems.yaml.zst` — copy + edit the whole file to
+   customize one vendor.
+2. **Different filename adds entries.** Operator `site-additions.yaml` (different filename) merges its `traps:` into the
+   loaded set without touching stock files. Metric-only site profiles can also use a different filename and reference
+   stock traps by MIB-qualified trap name in `on_trap`, `problem_trap`, or `clear_trap`.
+3. **`extends:` chain field-merge** (when an override profile lists `extends: [_base.yaml, other-base.yaml]`): entries
+   must be YAML filenames only, not paths. The loader merges trap entries by OID; fields specified in the override file
+   win over fields from the extended bases; later entries in `extends:` override earlier ones for the same field.
 
 ### `TRAP_TAG_*` label namespace and collision-free design
 
-Operator labels — `labels: { tenant: acme, oper_status: '{{value "ifOperStatus"}}' }` —
-always emit as `TRAP_TAG_<KEY_UPPERCASE>` journal fields (e.g.
-`TRAP_TAG_TENANT=acme`, `TRAP_TAG_OPER_STATUS=down`). The
-dedicated `TRAP_TAG_*` namespace structurally prevents collisions with
-plugin-controlled `TRAP_*` fields, even when an operator label key
-happens to match a plugin field name. For example, a profile with
-`labels: { interface_state: '{{value "ifOperStatus"}}' }` and a co-located topology plugin
-both populate journal fields, but in different namespaces: the operator
-label becomes `TRAP_TAG_INTERFACE_STATE`, the topology field becomes
-`TRAP_INTERFACE`. Both can co-exist on the same trap entry without
-conflict.
+Operator labels — `labels: { tenant: acme, oper_status: '{{value "ifOperStatus"}}' }` — always emit as
+`TRAP_TAG_<KEY_UPPERCASE>` journal fields (e.g. `TRAP_TAG_TENANT=acme`, `TRAP_TAG_OPER_STATUS=down`). The dedicated
+`TRAP_TAG_*` namespace structurally prevents collisions with plugin-controlled `TRAP_*` fields, even when an operator
+label key happens to match a plugin field name. For example, a profile with
+`labels: { interface_state: '{{value "ifOperStatus"}}' }` and a co-located topology plugin both populate journal fields,
+but in different namespaces: the operator label becomes `TRAP_TAG_INTERFACE_STATE`, the topology field becomes
+`TRAP_INTERFACE`. Both can co-exist on the same trap entry without conflict.
 
-Dynamic label references must be bounded-cardinality at profile-load time. The
-MVP accepts static strings, `TRAP_NAME`, `TRAP_DEVICE_VENDOR`, enum-backed
-varbinds, booleans, and small numeric ranges. It rejects unbounded values such
-as hostnames, source IPs, interface descriptions, MAC addresses, usernames,
-packet contents, and raw numeric OID references without profile metadata.
+Dynamic label references must be bounded-cardinality at profile-load time. The MVP accepts static strings, `TRAP_NAME`,
+`TRAP_DEVICE_VENDOR`, enum-backed varbinds, booleans, and small numeric ranges. It rejects unbounded values such as
+hostnames, source IPs, interface descriptions, MAC addresses, usernames, packet contents, and raw numeric OID references
+without profile metadata.
 
 ```yaml
 # /etc/netdata/go.d/snmp.trap-profiles/site-additions.yaml
@@ -734,17 +640,14 @@ traps:
       change_window: business_hours
 ```
 
-Per-OID metric extraction lives in profile `metrics:` and `charts:` sections.
-Listener jobs only enable/select those profile rules and choose identity,
-privacy, and cardinality limits through `profile_metrics`.
+Per-OID metric extraction lives in profile `metrics:` and `charts:` sections. Listener jobs only enable/select those
+profile rules and choose identity, privacy, and cardinality limits through `profile_metrics`.
 
 ## Generated stock profiles
 
-Stock profiles under `default/` are generated by
-`src/go/cmd/snmptrapprofilegen`, shipped as
-`/usr/libexec/netdata/plugins.d/snmp-trap-profile-gen`, from public MIB sources
-and an LLM classification step. The helper can also convert operator MIBs
-offline:
+Stock profiles under `default/` are generated by `src/go/cmd/snmptrapprofilegen`, shipped as
+`/usr/libexec/netdata/plugins.d/snmp-trap-profile-gen`, from public MIB sources and an LLM classification step. The
+helper can also convert operator MIBs offline:
 
 ```sh
 /usr/libexec/netdata/plugins.d/snmp-trap-profile-gen generate \
@@ -754,11 +657,10 @@ offline:
 ```
 
 By default the helper reads the bundled IANA PEN snapshot from
-`/usr/lib/netdata/conf.d/go.d/snmp.profiles/metadata/iana-enterprise-numbers.txt`.
-Pass `--refresh-pen` to fetch the current IANA registry before emission.
-The run also writes review artifacts under `--out-dir`: `traps.jsonl`,
-`extraction-report.json`, `conflicts.json` for duplicate trap OIDs, and
-`source-conflicts.json` when multiple MIB files define the same module name.
+`/usr/lib/netdata/conf.d/go.d/snmp.profiles/metadata/iana-enterprise-numbers.txt`. Pass `--refresh-pen` to fetch the
+current IANA registry before emission. The run also writes review artifacts under `--out-dir`: `traps.jsonl`,
+`extraction-report.json`, `conflicts.json` for duplicate trap OIDs, and `source-conflicts.json` when multiple MIB files
+define the same module name.
 
-Edits to files under `default/` are overwritten on regeneration; operator
-modifications belong in the user override directory, not in stock files.
+Edits to files under `default/` are overwritten on regeneration; operator modifications belong in the user override
+directory, not in stock files.

--- a/src/go/plugin/go.d/docs/helper-packages.md
+++ b/src/go/plugin/go.d/docs/helper-packages.md
@@ -1,9 +1,8 @@
 # Go Helper Packages For go.d Collectors
 
-Use existing helper packages before adding collector-local plumbing. A helper is
-not better because it is shared; it is better when it gives users the same
-configuration shape, the same safety behavior, or the same testable parsing path
-as other collectors.
+Use existing helper packages before adding collector-local plumbing. A helper is not better because it is shared; it is
+better when it gives users the same configuration shape, the same safety behavior, or the same testable parsing path as
+other collectors.
 
 This guide covers helper surfaces used by go.d collectors across:
 
@@ -11,8 +10,8 @@ This guide covers helper surfaces used by go.d collectors across:
 - `src/go/plugin/go.d/pkg/*` for go.d-specific helpers;
 - `src/go/logger` for the logger embedded through `collectorapi.Base`.
 
-It is not an exhaustive API reference. Before adding a local helper, search
-these roots for an existing package that already owns the behavior.
+It is not an exhaustive API reference. Before adding a local helper, search these roots for an existing package that
+already owns the behavior.
 
 ## Helper Roots
 
@@ -48,17 +47,13 @@ Use `src/go/pkg/confopt` for common configuration value types.
 
 When:
 
-- users configure durations that should accept strings such as `5s`, `30m`, or
-  numeric seconds;
-- users need explicit `auto` / `enabled` / `disabled` behavior instead of a
-  plain boolean;
-- a migration needs to preserve legacy pointer-boolean semantics without
-  keeping pointer plumbing in new code.
+- users configure durations that should accept strings such as `5s`, `30m`, or numeric seconds;
+- users need explicit `auto` / `enabled` / `disabled` behavior instead of a plain boolean;
+- a migration needs to preserve legacy pointer-boolean semantics without keeping pointer plumbing in new code.
 
 Why:
 
-- `confopt.Duration` and `confopt.LongDuration` centralize YAML/JSON duration
-  parsing and formatting;
+- `confopt.Duration` and `confopt.LongDuration` centralize YAML/JSON duration parsing and formatting;
 - `confopt.AutoBool` makes tri-state behavior explicit and schema-friendly;
 - collectors avoid ad hoc parsers and inconsistent boolean defaults.
 
@@ -69,18 +64,15 @@ Use `src/go/pkg/web` for HTTP-based collectors.
 When:
 
 - the collector talks to an HTTP or HTTPS endpoint;
-- users need the normal Netdata HTTP options: `url`, timeout, redirects, proxy,
-  basic auth, bearer token file, headers, body, method, and TLS fields;
+- users need the normal Netdata HTTP options: `url`, timeout, redirects, proxy, basic auth, bearer token file, headers,
+  body, method, and TLS fields;
 - the collector builds repeated requests against the same endpoint.
 
 Why:
 
-- `web.HTTPConfig` embeds `web.RequestConfig` and `web.ClientConfig` so HTTP
-  collectors expose the same option surface;
-- `web.NewHTTPClient(c.ClientConfig)` applies timeout, TLS, proxy, redirect, and
-  HTTP/2 behavior consistently;
-- `web.NewHTTPRequest(c.RequestConfig)` and
-  `web.NewHTTPRequestWithPath(c.RequestConfig, path)` apply user agent,
+- `web.HTTPConfig` embeds `web.RequestConfig` and `web.ClientConfig` so HTTP collectors expose the same option surface;
+- `web.NewHTTPClient(c.ClientConfig)` applies timeout, TLS, proxy, redirect, and HTTP/2 behavior consistently;
+- `web.NewHTTPRequest(c.RequestConfig)` and `web.NewHTTPRequestWithPath(c.RequestConfig, path)` apply user agent,
   authentication, headers, body, and safe path joining.
 
 Pattern:
@@ -91,14 +83,12 @@ type Config struct {
 }
 ```
 
-Use `src/go/pkg/tlscfg` directly only when the collector is not HTTP-based but
-still needs TLS, such as Redis or x509-style checks. HTTP collectors should get
-TLS behavior through `web.HTTPConfig`.
+Use `src/go/pkg/tlscfg` directly only when the collector is not HTTP-based but still needs TLS, such as Redis or
+x509-style checks. HTTP collectors should get TLS behavior through `web.HTTPConfig`.
 
 ## Prometheus Endpoints
 
-Use `src/go/pkg/prometheus` when the upstream endpoint exposes Prometheus text
-format.
+Use `src/go/pkg/prometheus` when the upstream endpoint exposes Prometheus text format.
 
 When:
 
@@ -110,8 +100,7 @@ Why:
 
 - it reuses `web.RequestConfig` and `*http.Client`;
 - it handles Prometheus text parsing and gzip responses;
-- selectors avoid parsing or processing metric families the collector will not
-  use.
+- selectors avoid parsing or processing metric families the collector will not use.
 
 Do not hand-roll text exposition parsing in a collector.
 
@@ -131,18 +120,16 @@ Why:
 - tests can cover selector behavior without custom parser logic;
 - existing logical matchers can combine conditions when needed.
 
-Do not invent a selector language unless the upstream API requires one. Prefer a
-single simple-pattern field for simple cases; add separate include/exclude fields
-only when the user problem needs that shape.
+Do not invent a selector language unless the upstream API requires one. Prefer a single simple-pattern field for simple
+cases; add separate include/exclude fields only when the user problem needs that shape.
 
-Do not use `src/go/pkg/selectorcore` for user-facing collector selectors. It is
-the lower-level selector metadata/parser surface used by template and selector
-engines, not the normal collector selector helper.
+Do not use `src/go/pkg/selectorcore` for user-facing collector selectors. It is the lower-level selector metadata/parser
+surface used by template and selector engines, not the normal collector selector helper.
 
 ## Limited Logging
 
-Collectors embed `collectorapi.Base`, which embeds `*logger.Logger`. Use the
-logger's built-in limiting before adding collector-local rate-limit state.
+Collectors embed `collectorapi.Base`, which embeds `*logger.Logger`. Use the logger's built-in limiting before adding
+collector-local rate-limit state.
 
 When:
 
@@ -152,13 +139,12 @@ When:
 
 Why:
 
-- in go.d jobs, `c.Once(key).Warningf(...)` is cycle-local because the runtime
-  resets `Once` state each `runOnce`; it is useful for suppressing duplicate
-  messages inside one cycle only;
-- `c.Limit(key, n, window).Warningf(...)` logs at most `n` messages per key per
-  window and is the right default for cross-cycle spam control;
-- the limiter is shared through the collector logger and already used by modern
-  collectors such as Cato Networks, PAN-OS, and vSphere.
+- in go.d jobs, `c.Once(key).Warningf(...)` is cycle-local because the runtime resets `Once` state each `runOnce`; it is
+  useful for suppressing duplicate messages inside one cycle only;
+- `c.Limit(key, n, window).Warningf(...)` logs at most `n` messages per key per window and is the right default for
+  cross-cycle spam control;
+- the limiter is shared through the collector logger and already used by modern collectors such as Cato Networks,
+  PAN-OS, and vSphere.
 
 Pattern:
 
@@ -167,19 +153,16 @@ c.Limit("mycollector:operation:error", 1, time.Hour).
     Warningf("operation failed: %v", err)
 ```
 
-Use stable keys. Include the operation and bounded error class when needed, but
-do not put unbounded IDs, URLs, query strings, customer names, or raw provider
-messages in the key.
+Use stable keys. Include the operation and bounded error class when needed, but do not put unbounded IDs, URLs, query
+strings, customer names, or raw provider messages in the key.
 
-Custom warning gates are justified only when the built-in count-per-window
-semantics are not the right behavior, for example when logging only on state
-transitions. Document that reason in the PR description or design note so
-reviewers can see why the built-in limiter was not enough.
+Custom warning gates are justified only when the built-in count-per-window semantics are not the right behavior, for
+example when logging only on state transitions. Document that reason in the PR description or design note so reviewers
+can see why the built-in limiter was not enough.
 
 ## Socket Clients
 
-Use `src/go/plugin/go.d/pkg/socket` for simple TCP, UDP, or Unix-socket
-line-protocol collectors.
+Use `src/go/plugin/go.d/pkg/socket` for simple TCP, UDP, or Unix-socket line-protocol collectors.
 
 When:
 
@@ -190,10 +173,8 @@ When:
 Why:
 
 - socket address parsing is shared across collectors;
-- connect, command, read, disconnect, deadline, and line-limit behavior stay
-  consistent;
-- tests can use the helper's fake TCP/UDP/Unix servers instead of custom socket
-  harnesses.
+- connect, command, read, disconnect, deadline, and line-limit behavior stay consistent;
+- tests can use the helper's fake TCP/UDP/Unix servers instead of custom socket harnesses.
 
 Do not hand-roll socket dial/read loops for common line-oriented protocols.
 
@@ -222,13 +203,11 @@ Use:
 - `RunDirect` only when direct execution is intentionally required;
 - `FindBinary` for PATH/default-path discovery.
 
-Do not call `exec.Command` directly unless the helper cannot support the case and
-the reason is documented.
+Do not call `exec.Command` directly unless the helper cannot support the case and the reason is documented.
 
 ## Log File Collectors
 
-Use `src/go/plugin/go.d/pkg/logs` for collectors that parse application log
-files.
+Use `src/go/plugin/go.d/pkg/logs` for collectors that parse application log files.
 
 When:
 
@@ -240,11 +219,9 @@ Why:
 
 - `logs.Reader` is log-rotation aware;
 - `logs.NewParser` centralizes supported parser types;
-- `logs.IsParseError` lets collection logic treat malformed rows differently
-  from source failures.
+- `logs.IsParseError` lets collection logic treat malformed rows differently from source failures.
 
-Do not open and seek log files manually unless the collector's source is not a
-normal file-tail workflow.
+Do not open and seek log files manually unless the collector's source is not a normal file-tail workflow.
 
 ## IP Ranges
 
@@ -267,8 +244,7 @@ Use `src/go/plugin/go.d/pkg/sqlquery` for repeated SQL row-scanning patterns.
 
 When:
 
-- the collector or Function scans rows into strings, integers, floats, or discard
-  columns;
+- the collector or Function scans rows into strings, integers, floats, or discard columns;
 - the collector needs table-column discovery with `?` or `$1` placeholders;
 - the row-to-value assignment is generic across queries.
 
@@ -280,8 +256,7 @@ Why:
 
 ## Cloud Auth Helpers
 
-Use `src/go/plugin/go.d/pkg/cloudauth` when a cloud collector needs supported
-cloud-provider credentials.
+Use `src/go/plugin/go.d/pkg/cloudauth` when a cloud collector needs supported cloud-provider credentials.
 
 When:
 
@@ -310,44 +285,35 @@ Why:
 
 ## Profile Catalog Helpers
 
-Use `src/go/plugin/go.d/pkg/profilecatalog` when a collector ships curated
-per-target "profiles" as YAML files (a profile's identity is its file basename)
-and loads them from stock plus user directories. Used by the `prometheus`,
+Use `src/go/plugin/go.d/pkg/profilecatalog` when a collector ships curated per-target "profiles" as YAML files (a
+profile's identity is its file basename) and loads them from stock plus user directories. Used by the `prometheus`,
 `azure_monitor`, and `cloudwatch` collectors.
 
 When:
 
-- the collector reads profiles from `config/go.d/<name>.profiles/` (stock) and
-  the user config dirs;
-- it needs stock/user override precedence (user overrides stock by basename),
-  the stock-fatal / user-skip error policy, and a process-wide cached catalog.
+- the collector reads profiles from `config/go.d/<name>.profiles/` (stock) and the user config dirs;
+- it needs stock/user override precedence (user overrides stock by basename), the stock-fatal / user-skip error policy,
+  and a process-wide cached catalog.
 
 Why:
 
-- one shared `Load[P]` + `Catalog[P]` + `Cached[T]` replaces per-collector copies
-  of the directory walk, override precedence, and singleton caching;
-- it is generic over the collector's profile type `P` and oblivious to matching
-  (matching stays in the collector);
-- decode depth is the collector's choice via `Options.Decode`: parse everything
-  eagerly, or parse a lightweight header now and hydrate the heavy part later
-  (as `prometheus` does for its chart templates).
+- one shared `Load[P]` + `Catalog[P]` + `Cached[T]` replaces per-collector copies of the directory walk, override
+  precedence, and singleton caching;
+- it is generic over the collector's profile type `P` and oblivious to matching (matching stays in the collector);
+- decode depth is the collector's choice via `Options.Decode`: parse everything eagerly, or parse a lightweight header
+  now and hydrate the heavy part later (as `prometheus` does for its chart templates).
 
-Do NOT put matching logic in this package; it is a catalog + loader, not a
-matcher. Keep the profile schema, its decode/validate, the `defaultDirSpecs`
-directory resolution (location-specific), and specialized queries in the
-collector's own `*profiles` package, wrapping `profilecatalog.Catalog[P]` by
-struct embedding.
+Do NOT put matching logic in this package; it is a catalog + loader, not a matcher. Keep the profile schema, its
+decode/validate, the `defaultDirSpecs` directory resolution (location-specific), and specialized queries in the
+collector's own `*profiles` package, wrapping `profilecatalog.Catalog[P]` by struct embedding.
 
 ## Legacy V1 Helpers
 
-`src/go/pkg/stm` converts structs into `map[string]int64`.
-`src/go/plugin/go.d/pkg/oldmetrix` provides V1 metric vector helper types such
-as counters, summaries, histograms, and boolean conversions used by existing V1
-collectors. Both helpers are V1-shaped. New V2 collectors MUST NOT use them as
-their metric path.
+`src/go/pkg/stm` converts structs into `map[string]int64`. `src/go/plugin/go.d/pkg/oldmetrix` provides V1 metric vector
+helper types such as counters, summaries, histograms, and boolean conversions used by existing V1 collectors. Both
+helpers are V1-shaped. New V2 collectors MUST NOT use them as their metric path.
 
 Acceptable uses:
 
 - maintaining an existing V1 collector;
-- temporary parity tests during V1-to-V2 migration, provided the helper is not
-  reachable from the final runtime path.
+- temporary parity tests during V1-to-V2 migration, provided the helper is not reachable from the final runtime path.

--- a/src/go/plugin/go.d/docs/how-to-write-a-collector.md
+++ b/src/go/plugin/go.d/docs/how-to-write-a-collector.md
@@ -1,49 +1,37 @@
 # How to Write a go.d Collector (V2)
 
-This is the canonical starting point for new go.d collectors. New collectors
-MUST use framework V2. V1 collectors remain in the tree for compatibility and
-maintenance only.
+This is the canonical starting point for new go.d collectors. New collectors MUST use framework V2. V1 collectors remain
+in the tree for compatibility and maintenance only.
 
-For migrating an existing V1 collector, use
-`src/go/plugin/go.d/docs/migrate-v1-to-v2.md` instead. Migration is
+For migrating an existing V1 collector, use `src/go/plugin/go.d/docs/migrate-v1-to-v2.md` instead. Migration is
 compatibility work and has different rules from new collector authoring.
 
-Use `src/go/plugin/go.d/collector/cato_networks/` as the primary modern example.
-It is large, so copy the pattern, not the whole shape. The useful references are
-called out below by responsibility.
+Use `src/go/plugin/go.d/collector/cato_networks/` as the primary modern example. It is large, so copy the pattern, not
+the whole shape. The useful references are called out below by responsibility.
 
 ## Before Writing Code
 
 Do the design work first:
 
-1. Read the upstream API or protocol docs. Do not infer current behavior from
-   memory or from generated SDK types alone.
-2. Check existing helper packages before implementing parser, HTTP, selector,
-   command-execution, SQL, ping, log-reading, or log-limiting plumbing. Start
-   with `src/go/plugin/go.d/docs/helper-packages.md`.
-3. You MUST aim for the clean end state, not the smallest initial diff. If the
-   clean collector design requires a framework improvement, surface that as a
-   design decision and follow
-   `src/go/plugin/framework/docs/changing-framework-code.md` instead of hiding
-   it behind collector-local glue.
-4. Decide the monitored entities and cardinality bounds. If one job collects
-   remote resources that SHOULD be separate Netdata nodes, design V2 host scopes
-   from the start.
-5. Decide the minimal public config surface. Public config is a compatibility
-   contract. Use constants for internal tuning such as page limits, scan cadence,
-   retry limits, fan-out concurrency, and cache TTLs unless the operator has a
-   real decision to make. A proposed config option MUST name that concrete
-   operator decision; "operators may want to tune it" is not enough.
-6. Decide whether the collector needs Functions or topology. Functions are
-   interactive live/snapshot views; metrics are time series. New topology
-   producers MUST use `src/go/pkg/topology/v1` and validate against
+1. Read the upstream API or protocol docs. Do not infer current behavior from memory or from generated SDK types alone.
+2. Check existing helper packages before implementing parser, HTTP, selector, command-execution, SQL, ping, log-reading,
+   or log-limiting plumbing. Start with `src/go/plugin/go.d/docs/helper-packages.md`.
+3. You MUST aim for the clean end state, not the smallest initial diff. If the clean collector design requires a
+   framework improvement, surface that as a design decision and follow
+   `src/go/plugin/framework/docs/changing-framework-code.md` instead of hiding it behind collector-local glue.
+4. Decide the monitored entities and cardinality bounds. If one job collects remote resources that SHOULD be separate
+   Netdata nodes, design V2 host scopes from the start.
+5. Decide the minimal public config surface. Public config is a compatibility contract. Use constants for internal
+   tuning such as page limits, scan cadence, retry limits, fan-out concurrency, and cache TTLs unless the operator has a
+   real decision to make. A proposed config option MUST name that concrete operator decision; "operators may want to
+   tune it" is not enough.
+6. Decide whether the collector needs Functions or topology. Functions are interactive live/snapshot views; metrics are
+   time series. New topology producers MUST use `src/go/pkg/topology/v1` and validate against
    `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`.
-7. Plan collector consistency using
-   `.agents/skills/integrations-lifecycle/consistency.md`. Generated
-   integration pages and README symlinks are outputs, not hand-authored sources.
-8. Plan the first coherent batch and its boundaries. At each boundary, you MUST
-   re-check whether new work has drifted out of scope; defer it or land it
-   independently before continuing.
+7. Plan collector consistency using `.agents/skills/integrations-lifecycle/consistency.md`. Generated integration pages
+   and README symlinks are outputs, not hand-authored sources.
+8. Plan the first coherent batch and its boundaries. At each boundary, you MUST re-check whether new work has drifted
+   out of scope; defer it or land it independently before continuing.
 
 ## Source References
 
@@ -53,23 +41,19 @@ Primary V2 reference:
 
 Read these files by responsibility:
 
-- `collector.go`: registration, defaults, public lifecycle methods,
-  `MetricStore()`, `ChartTemplateYAML()`, and Function wiring.
-- `config.go`: config defaults, normalization, validation, and intentionally
-  small public config.
-- `collect.go`, `collect_metrics.go`, `collect_bgp.go`: collection
-  orchestration and split domain operations.
-- `metrix.go`, `write_metrics.go`, `charts.yaml`: typed instruments, metric
-  writes, chart template, `StateSet`, `instances.by_labels`, and
-  `label_promotion`. Audit every `instances.by_labels` identity choice instead
-  of copying labels from the example blindly.
+- `collector.go`: registration, defaults, public lifecycle methods, `MetricStore()`, `ChartTemplateYAML()`, and Function
+  wiring.
+- `config.go`: config defaults, normalization, validation, and intentionally small public config.
+- `collect.go`, `collect_metrics.go`, `collect_bgp.go`: collection orchestration and split domain operations.
+- `metrix.go`, `write_metrics.go`, `charts.yaml`: typed instruments, metric writes, chart template, `StateSet`,
+  `instances.by_labels`, and `label_promotion`. Audit every `instances.by_labels` identity choice instead of copying
+  labels from the example blindly.
 - `host_scope.go`: deterministic per-site V2 host scopes/vnodes.
-- `func_deps.go`, `catofunc/`: Function subpackage boundary behind a narrow
-  dependency interface.
-- `topology_store.go`, `topology.go`, `topology_test.go`: immutable topology
-  snapshot publishing and topology v1 schema validation.
-- `config_test.go`, `collector_lifecycle_test.go`, `collector_collect_test.go`,
-  `charts_test.go`: table-driven V2 tests and fixture validation.
+- `func_deps.go`, `catofunc/`: Function subpackage boundary behind a narrow dependency interface.
+- `topology_store.go`, `topology.go`, `topology_test.go`: immutable topology snapshot publishing and topology v1 schema
+  validation.
+- `config_test.go`, `collector_lifecycle_test.go`, `collector_collect_test.go`, `charts_test.go`: table-driven V2 tests
+  and fixture validation.
 
 Framework/API references:
 
@@ -86,8 +70,7 @@ Framework/API references:
 
 ## File Layout
 
-Start with this layout and add focused files only when a responsibility needs
-its own boundary:
+Start with this layout and add focused files only when a responsibility needs its own boundary:
 
 ```text
 src/go/plugin/go.d/collector/<name>/
@@ -111,31 +94,26 @@ src/go/plugin/go.d/collector/<name>/
 
 Common optional splits:
 
-Most collectors need none of these optional files. Add one only when the
-collector has the corresponding product surface or state boundary; do not create
-empty `host_scope.go`, `topology.go`, or `<name>func/` files just because Cato
-has them.
+Most collectors need none of these optional files. Add one only when the collector has the corresponding product surface
+or state boundary; do not create empty `host_scope.go`, `topology.go`, or `<name>func/` files just because Cato has
+them.
 
-- `init.go` when `Init()` needs helper setup for clients, matchers, caches, or
-  other persistent state. Keep the public `Init()` method itself in
-  `collector.go`; let it call focused helpers such as `initClient()` or
-  `initSiteSelector()`.
-- `collect_<operation>.go` when the collector has multiple distinct collection
-  operations, such as discovery, account metrics, BGP, or inventory.
-- `normalize_<operation>.go` when API payload normalization would otherwise
-  dominate `collect.go`.
+- `init.go` when `Init()` needs helper setup for clients, matchers, caches, or other persistent state. Keep the public
+  `Init()` method itself in `collector.go`; let it call focused helpers such as `initClient()` or `initSiteSelector()`.
+- `collect_<operation>.go` when the collector has multiple distinct collection operations, such as discovery, account
+  metrics, BGP, or inventory.
+- `normalize_<operation>.go` when API payload normalization would otherwise dominate `collect.go`.
 - `host_scope.go` when the collector emits generated vnodes.
 - `<name>func/` plus `func_deps.go` when the collector exposes Functions.
 - `topology.go` and `topology_store.go` when the collector emits topology.
 
-Avoid files whose names hide their responsibility. For example, a file named
-`diagnostics.go` SHOULD NOT contain only error classification.
+Avoid files whose names hide their responsibility. For example, a file named `diagnostics.go` SHOULD NOT contain only
+error classification.
 
 ## Registration And Lifecycle
 
-New collectors MUST implement `collectorapi.CollectorV2` from
-`src/go/plugin/framework/collectorapi/collector.go` and register via `CreateV2`.
-In practice, `collector.go` should:
+New collectors MUST implement `collectorapi.CollectorV2` from `src/go/plugin/framework/collectorapi/collector.go` and
+register via `CreateV2`. In practice, `collector.go` should:
 
 - embed `config_schema.json` for `JobConfigSchema`;
 - embed `charts.yaml` for `ChartTemplateYAML()`;
@@ -161,22 +139,17 @@ Public lifecycle and framework-contract methods MUST stay in `collector.go`:
 - `MetricStore() metrix.CollectorStore`
 - `ChartTemplateYAML() string`
 
-Collectors that need a long-running side-effect loop MAY additionally implement
-`collectorapi.CollectorV2Runner` with `Run(context.Context) error`. Use this
-only when work must start with the running job lifecycle but must not wait for
-the next globally aligned `Collect()` tick, such as an agent-wide Function state
-refresh. The runtime starts `Run()` only after the job starts, never during
-autodetection or DynCfg `test`, cancels it on stop, and waits for it before
-`Cleanup()`. The implementation MUST return promptly after `ctx.Done()` and
-SHOULD make in-flight I/O cancellation-aware where the underlying library allows
-it.
+Collectors that need a long-running side-effect loop MAY additionally implement `collectorapi.CollectorV2Runner` with
+`Run(context.Context) error`. Use this only when work must start with the running job lifecycle but must not wait for
+the next globally aligned `Collect()` tick, such as an agent-wide Function state refresh. The runtime starts `Run()`
+only after the job starts, never during autodetection or DynCfg `test`, cancels it on stop, and waits for it before
+`Cleanup()`. The implementation MUST return promptly after `ctx.Done()` and SHOULD make in-flight I/O cancellation-aware
+where the underlying library allows it.
 
-`Init()` validates config, prepares matchers/clients, and initializes persistent
-state. Explicit setup details SHOULD live in helper methods, preferably in
-`init.go`, so the public method reads as the lifecycle sequence. `Check()` MUST
-be a cheap auth/connectivity probe, not a full collection. `Collect()` MUST run
-the real write path through `metrix`. `Cleanup()` closes idle connections and
-forwards Function cleanup.
+`Init()` validates config, prepares matchers/clients, and initializes persistent state. Explicit setup details SHOULD
+live in helper methods, preferably in `init.go`, so the public method reads as the lifecycle sequence. `Check()` MUST be
+a cheap auth/connectivity probe, not a full collection. `Collect()` MUST run the real write path through `metrix`.
+`Cleanup()` closes idle connections and forwards Function cleanup.
 
 ## Config
 
@@ -196,21 +169,16 @@ Implementation tuning SHOULD use constants:
 - retry/backoff internals;
 - API batching constraints.
 
-You MUST NOT add a config option just because it is easy to expose. Once
-shipped, it is hard to remove and MUST stay synchronized across `Config`,
-`config_schema.json`, stock `.conf`, metadata, generated docs, and tests.
-A proposed config option MUST name the concrete operator decision it enables;
-"operators may want to tune it" is not enough.
+You MUST NOT add a config option just because it is easy to expose. Once shipped, it is hard to remove and MUST stay
+synchronized across `Config`, `config_schema.json`, stock `.conf`, metadata, generated docs, and tests. A proposed
+config option MUST name the concrete operator decision it enables; "operators may want to tune it" is not enough.
 
-For SaaS/API credentials, examples SHOULD prefer secret indirection such as
-`${env:COLLECTOR_API_KEY}` or `${file:/run/secrets/collector_api_key}` instead
-of realistic-looking inline credentials. Schema fields that carry secrets MUST
-be marked sensitive and use password-style UI handling where the schema
-supports it.
+For SaaS/API credentials, examples SHOULD prefer secret indirection such as `${env:COLLECTOR_API_KEY}` or
+`${file:/run/secrets/collector_api_key}` instead of realistic-looking inline credentials. Schema fields that carry
+secrets MUST be marked sensitive and use password-style UI handling where the schema supports it.
 
-Selectors SHOULD use existing matcher packages such as `src/go/pkg/matcher`
-unless the upstream API forces a different grammar. Document the exact matching
-input, for example "site name when present, otherwise site ID."
+Selectors SHOULD use existing matcher packages such as `src/go/pkg/matcher` unless the upstream API forces a different
+grammar. Document the exact matching input, for example "site name when present, otherwise site ID."
 
 ## Collect Flow
 
@@ -224,57 +192,46 @@ input, for example "site name when present, otherwise site ID."
 6. publish any immutable Function/topology snapshot;
 7. write metrics to `metrix`.
 
-When the collector performs several upstream calls or collection operations,
-those operations SHOULD be split into focused files named by operation, for
-example `collect_metrics.go` or `collect_bgp.go`. `collect.go` SHOULD explain
-the cycle; the operation files SHOULD own the operation-specific API calls,
-fail-soft behavior, and merge rules.
+When the collector performs several upstream calls or collection operations, those operations SHOULD be split into
+focused files named by operation, for example `collect_metrics.go` or `collect_bgp.go`. `collect.go` SHOULD explain the
+cycle; the operation files SHOULD own the operation-specific API calls, fail-soft behavior, and merge rules.
 
-Fail-soft behavior MUST be used only when partial data is still truthful. If one
-optional operation fails, log a rate-limited warning and omit or preserve only
-values that remain honest. If the core operation fails, return an error with
-context.
+Fail-soft behavior MUST be used only when partial data is still truthful. If one optional operation fails, log a
+rate-limited warning and omit or preserve only values that remain honest. If the core operation fails, return an error
+with context.
 
-`Collect()` MUST preserve context cancellation. If the context is canceled
-during a partial path, `Collect()` MUST return the context error so the runtime
-aborts the cycle instead of committing a stale or partial frame.
+`Collect()` MUST preserve context cancellation. If the context is canceled during a partial path, `Collect()` MUST
+return the context error so the runtime aborts the cycle instead of committing a stale or partial frame.
 
 ## Metrics And Charts
 
-Metric instruments SHOULD be built once in `New()` when the metric surface is
-known. Use a typed collector metrics struct so write code is a value mapping,
-not repeated dynamic instrument lookup.
+Metric instruments SHOULD be built once in `New()` when the metric surface is known. Use a typed collector metrics
+struct so write code is a value mapping, not repeated dynamic instrument lookup.
 
 Use the right instrument:
 
-- `SnapshotGaugeVec` for labeled current values; use scalar
-  `SnapshotMeter.Gauge` only when the metric is intentionally unlabeled;
+- `SnapshotGaugeVec` for labeled current values; use scalar `SnapshotMeter.Gauge` only when the metric is intentionally
+  unlabeled;
 - `Counter.ObserveTotal()` for source counters;
-- `StateSet` SHOULD be used for fixed mutually exclusive states, such as
-  connected vs disconnected or up vs down.
+- `StateSet` SHOULD be used for fixed mutually exclusive states, such as connected vs disconnected or up vs down.
 
 `charts.yaml` is the chart contract. Every template MUST define:
 
 - `version: v1`;
 - `context_namespace`;
 
-Templates SHOULD also group charts by operational area, use
-`instances.by_labels` for stable instance identity when charts are
-entity-scoped, use `label_promotion` for descriptive labels that should not
-define uniqueness, and keep the default lifecycle unless a concrete reason
-exists to override it.
+Templates SHOULD also group charts by operational area, use `instances.by_labels` for stable instance identity when
+charts are entity-scoped, use `label_promotion` for descriptive labels that should not define uniqueness, and keep the
+default lifecycle unless a concrete reason exists to override it.
 
-Metric labels and chart instance labels MUST be bounded and stable. Use IDs for
-identity. Mutable display names SHOULD be promoted with `label_promotion`.
-Do not blindly copy `instances.by_labels` from Cato or any other example; audit
-every label used for chart identity and record why it is stable enough for that
-collector.
+Metric labels and chart instance labels MUST be bounded and stable. Use IDs for identity. Mutable display names SHOULD
+be promoted with `label_promotion`. Do not blindly copy `instances.by_labels` from Cato or any other example; audit
+every label used for chart identity and record why it is stable enough for that collector.
 
 ## Host Scopes And Vnodes
 
-Use `metrix.HostScope` when one job emits data for remote entities that SHOULD
-appear as separate Netdata nodes. Labels alone are not enough for that product
-semantics.
+Use `metrix.HostScope` when one job emits data for remote entities that SHOULD appear as separate Netdata nodes. Labels
+alone are not enough for that product semantics.
 
 Rules:
 
@@ -282,57 +239,47 @@ Rules:
 - Hostname may use a human-readable name when safe, with stable fallback.
 - Add `_vnode_type=<source>` and useful source labels.
 - Route every metric for that remote entity through the same host scope.
-- Keep the default host scope empty unless the metric truly belongs to the
-  agent/job host.
+- Keep the default host scope empty unless the metric truly belongs to the agent/job host.
 
 Use `.agents/skills/project-writing-go-modules-framework-v2/go-v2-host-scope.md` for the framework contract.
 
 ## Functions
 
-Functions MUST NOT freely access collector internals. Put Function code in a
-dedicated subpackage, for example `<name>func/`, with a narrow `Deps` interface
-declared by that subpackage.
+Functions MUST NOT freely access collector internals. Put Function code in a dedicated subpackage, for example
+`<name>func/`, with a narrow `Deps` interface declared by that subpackage.
 
-Non-topology Function responses MUST conform to
-`src/plugins.d/FUNCTION_UI_SCHEMA.json`; topology Function responses MUST
-conform to `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`. Function payloads
-MUST be validated with `src/go/tools/functions-validation/` or an equivalent
-schema-validation test, and the validation method must be recorded.
+Non-topology Function responses MUST conform to `src/plugins.d/FUNCTION_UI_SCHEMA.json`; topology Function responses
+MUST conform to `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`. Function payloads MUST be validated with
+`src/go/tools/functions-validation/` or an equivalent schema-validation test, and the validation method must be
+recorded.
 
 Pattern:
 
 - collector package owns state and implements a small adapter in `func_deps.go`;
 - Function package owns method IDs, router, handlers, presentation, and tests;
-- Function package MUST import only framework/function types and other allowed
-  dependencies, not the collector package;
-- the Function package `Deps` interface MUST expose only the methods the
-  Function needs and MUST NOT expose, return, or embed `*Collector`;
+- Function package MUST import only framework/function types and other allowed dependencies, not the collector package;
+- the Function package `Deps` interface MUST expose only the methods the Function needs and MUST NOT expose, return, or
+  embed `*Collector`;
 - `Collector.Cleanup()` forwards cleanup to the Function router.
 
-Use `catofunc/` as the primary example. Test the Function package with fake
-deps so the boundary is compile-enforced.
+Use `catofunc/` as the primary example. Test the Function package with fake deps so the boundary is compile-enforced.
 
 ## Topology
 
-New topology producers MUST use `src/go/pkg/topology/v1`. The non-v1 root
-`src/go/pkg/topology` payload model has been retired and MUST NOT be
-reintroduced for topology payloads.
+New topology producers MUST use `src/go/pkg/topology/v1`. The non-v1 root `src/go/pkg/topology` payload model has been
+retired and MUST NOT be reintroduced for topology payloads.
 
 Rules:
 
-- build topology from normalized collector state, not directly from raw API
-  payloads;
+- build topology from normalized collector state, not directly from raw API payloads;
 - publish immutable snapshots for Function readers;
 - MUST NOT mutate a published topology value;
-- use `src/go/plugin/go.d/collector/cato_networks/topology.go` as the concrete
-  construction reference for actors, links, detail tables, and telemetry fields;
-- MUST validate topology payloads in tests with both
-  `topologyv1.ValidateDecodedData` and
-  `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`; see
-  `src/go/plugin/go.d/collector/cato_networks/topology_test.go`
+- use `src/go/plugin/go.d/collector/cato_networks/topology.go` as the concrete construction reference for actors, links,
+  detail tables, and telemetry fields;
+- MUST validate topology payloads in tests with both `topologyv1.ValidateDecodedData` and
+  `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`; see `src/go/plugin/go.d/collector/cato_networks/topology_test.go`
   `validateCatoTopologyV1Data` for the full marshal/decode/schema check shape;
-- follow `.agents/skills/project-create-topology/SKILL.md` for actor/link/table
-  design.
+- follow `.agents/skills/project-create-topology/SKILL.md` for actor/link/table design.
 
 ## Repository Wiring
 
@@ -340,32 +287,26 @@ For a new collector `<name>`:
 
 1. Add the collector package under `src/go/plugin/go.d/collector/<name>/`.
 2. Import it in `src/go/plugin/go.d/collector/init.go`.
-3. Add the default stock config:
-   `src/go/plugin/go.d/config/go.d/<name>.conf`.
+3. Add the default stock config: `src/go/plugin/go.d/config/go.d/<name>.conf`.
 4. Add the module toggle in `src/go/plugin/go.d/config/go.d.conf`.
 5. Add or update `src/go/plugin/go.d/README.md`.
-6. Add health alerts under `src/health/health.d/<name>.conf` only when alerts
-   are useful and backed by emitted chart contexts.
-7. If adding or changing service-discovery rules under
-   `src/go/plugin/go.d/config/go.d/sd/` or `sdext`, update generated
+6. Add health alerts under `src/health/health.d/<name>.conf` only when alerts are useful and backed by emitted chart
+   contexts.
+7. If adding or changing service-discovery rules under `src/go/plugin/go.d/config/go.d/sd/` or `sdext`, update generated
    service-discovery documentation through the integrations lifecycle recipe.
-8. Generate `integrations/<slug>.md` and the README symlink from
-   `metadata.yaml`.
-   Single-integration collector directories normally use the symlinked README.
-   Multi-integration plugin directories may keep a hand-authored umbrella
+8. Generate `integrations/<slug>.md` and the README symlink from `metadata.yaml`. Single-integration collector
+   directories normally use the symlinked README. Multi-integration plugin directories may keep a hand-authored umbrella
    README; follow `.agents/skills/integrations-lifecycle/consistency.md`.
 
-Use `.agents/skills/integrations-lifecycle/recipes/add-go-collector.md` for the
-integration-generation commands and taxonomy pipeline details.
+Use `.agents/skills/integrations-lifecycle/recipes/add-go-collector.md` for the integration-generation commands and
+taxonomy pipeline details.
 
-The PR description or design note MUST enumerate the relevant collector
-consistency artifacts and justify every artifact that did not need a matching
-change. Most of this is not CI-enforced; it must be reviewer-visible.
+The PR description or design note MUST enumerate the relevant collector consistency artifacts and justify every artifact
+that did not need a matching change. Most of this is not CI-enforced; it must be reviewer-visible.
 
 ## Tests
 
-Tests SHOULD be table-driven with `map[string]struct{}` when cases share setup and
-assertion shape.
+Tests SHOULD be table-driven with `map[string]struct{}` when cases share setup and assertion shape.
 
 Recommended test coverage:
 
@@ -373,19 +314,17 @@ Recommended test coverage:
 - config validation, including required credentials and unsafe URLs;
 - `Init`, cheap `Check`, `Collect`, `Cleanup`, `MetricStore`;
 - hard failure, partial failure, context cancellation, and recovery behavior;
-- chart-template schema validation with `collecttest.AssertChartTemplateSchema`
-  and chart-template compile validation through the chartengine path used by
-  nearby V2 collectors;
+- chart-template schema validation with `collecttest.AssertChartTemplateSchema` and chart-template compile validation
+  through the chartengine path used by nearby V2 collectors;
 - post-collect chart coverage with `collecttest.AssertChartCoverage`;
 - state-set values for every known state and unknown fallback;
 - host-scope routing when scopes/vnodes are used;
 - Function handler tests with fake deps when Functions exist;
 - topology schema validation when topology exists;
-- fixture validity and attribution when fixtures come from public third-party
-  projects.
+- fixture validity and attribution when fixtures come from public third-party projects.
 
-Do not let tests depend on real credentials or live services unless the test is
-explicitly an integration test gated outside the default unit-test path.
+Do not let tests depend on real credentials or live services unless the test is explicitly an integration test gated
+outside the default unit-test path.
 
 ## Validate Locally
 
@@ -401,11 +340,9 @@ Verify that go.d can load the module:
 timeout 15s go run ./cmd/godplugin -m <name> -d
 ```
 
-Success means the module is registered, a job starts, and the command keeps
-running until the timeout stops it. Treat `unknown module`, `no jobs started`,
-config-load errors, or an immediate exit before the timeout as failures. Use
-`-c <config-dir>` when the test config lives outside the normal go.d config
-search path.
+Success means the module is registered, a job starts, and the command keeps running until the timeout stops it. Treat
+`unknown module`, `no jobs started`, config-load errors, or an immediate exit before the timeout as failures. Use
+`-c <config-dir>` when the test config lives outside the normal go.d config search path.
 
 When the collector uses concurrency or Functions, also run:
 
@@ -413,24 +350,20 @@ When the collector uses concurrency or Functions, also run:
 go test -race -count=1 ./plugin/go.d/collector/<name>/...
 ```
 
-When integration metadata, generated pages, taxonomy, or health alerts change,
-run the relevant integrations pipeline checks from
-`.agents/skills/integrations-lifecycle/`.
+When integration metadata, generated pages, taxonomy, or health alerts change, run the relevant integrations pipeline
+checks from `.agents/skills/integrations-lifecycle/`.
 
-Do not claim full-project validation from a narrow collector command. State
-exactly what was run.
+Do not claim full-project validation from a narrow collector command. State exactly what was run.
 
 ## Anti-Patterns
 
 - New collector using `Collect() map[string]int64`.
 - Full live collection from `Check()`.
-- Starting operational background polling from `Check()` or `Init()`; use the
-  optional V2 runner hook when polling must be tied to the running job lifecycle.
+- Starting operational background polling from `Check()` or `Init()`; use the optional V2 runner hook when polling must
+  be tied to the running job lifecycle.
 - Public config knobs for internal implementation details.
-- Custom selector or retry framework when existing package/framework behavior is
-  enough.
-- Collector-local singleton, adapter, or glue code that substitutes for a
-  missing shared framework capability.
+- Custom selector or retry framework when existing package/framework behavior is enough.
+- Collector-local singleton, adapter, or glue code that substitutes for a missing shared framework capability.
 - Per-cycle warning/error logs for recoverable partial failures.
 - Metric charts for collector internals when logs are enough.
 - Mutable names used as chart or vnode identity.

--- a/src/go/plugin/go.d/docs/migrate-v1-to-v2.md
+++ b/src/go/plugin/go.d/docs/migrate-v1-to-v2.md
@@ -2,29 +2,25 @@
 
 Requirement language follows the root `AGENTS.md` definitions.
 
-This guide is for migrating an existing go.d collector from framework V1 to
-framework V2. It is not the starting point for a new collector; use
-`src/go/plugin/go.d/docs/how-to-write-a-collector.md` for new work.
+This guide is for migrating an existing go.d collector from framework V1 to framework V2. It is not the starting point
+for a new collector; use `src/go/plugin/go.d/docs/how-to-write-a-collector.md` for new work.
 
-V1 collectors are public integrations. A migration MUST preserve their existing
-user-visible contracts unless the user explicitly approves a breaking change.
+V1 collectors are public integrations. A migration MUST preserve their existing user-visible contracts unless the user
+explicitly approves a breaking change.
 
 ## Core Rule
 
-A V1-to-V2 migration is compatibility work first. The clean end state is a V2
-collector that behaves like the old collector from the user's point of view,
-with the old public contracts preserved and the internal collection path moved
+A V1-to-V2 migration is compatibility work first. The clean end state is a V2 collector that behaves like the old
+collector from the user's point of view, with the old public contracts preserved and the internal collection path moved
 to `collectorapi.CollectorV2` and `metrix.CollectorStore`.
 
-Do not combine a compatibility migration with new enrichment, new topology,
-new host scopes, config expansion, chart redesign, or framework changes unless
-that work is required for the migration itself. If the migration reveals useful
+Do not combine a compatibility migration with new enrichment, new topology, new host scopes, config expansion, chart
+redesign, or framework changes unless that work is required for the migration itself. If the migration reveals useful
 new work, split it into a later batch.
 
 ## Before Writing Code
 
-Create a compatibility manifest before implementation. The manifest can live in
-the active TODO or SOW. It MUST cover:
+Create a compatibility manifest before implementation. The manifest can live in the active TODO or SOW. It MUST cover:
 
 1. Module identity.
    - collector directory;
@@ -32,8 +28,7 @@ the active TODO or SOW. It MUST cover:
    - chart-template `context_namespace` and any group context namespaces;
    - `go.d.conf` toggle;
    - stock job config path;
-   - service-discovery rules, if any, including
-     `src/go/plugin/go.d/config/go.d/sd/` and
+   - service-discovery rules, if any, including `src/go/plugin/go.d/config/go.d/sd/` and
      `src/go/plugin/go.d/discovery/sdext/` references.
 2. Registration and lifecycle.
    - current `collectorapi.Register` entry;
@@ -53,11 +48,9 @@ the active TODO or SOW. It MUST cover:
    - dimension IDs and names;
    - algorithms;
    - units;
-   - title, family, type, priority, multiplier, divisor, hidden, and float
-     flags;
+   - title, family, type, priority, multiplier, divisor, hidden, and float flags;
    - labels;
-   - chart variables (`Vars`) -- STOP if present; see `Chart Variables`
-     before implementation;
+   - chart variables (`Vars`) -- STOP if present; see `Chart Variables` before implementation;
    - dynamic chart/instance generation rules;
    - chart lifecycle and obsoletion timing.
 5. Integration artifacts.
@@ -82,46 +75,39 @@ A V2 migration MUST replace the V1 collection path:
 - `New()` creates `metrix.NewCollectorStore()`;
 - the collector stores `metrix.CollectorStore`;
 - `Configuration()` preserves existing config return behavior;
-- `VirtualNode()` preserves existing vnode behavior when the V1 collector has
-  one;
+- `VirtualNode()` preserves existing vnode behavior when the V1 collector has one;
 - `MetricStore()` returns the store;
 - `ChartTemplateYAML()` returns embedded `charts.yaml`;
-- if the compatibility manifest contains V1 chart `Vars`, the migration stops
-  until the `Chart Variables` decision path is resolved;
+- if the compatibility manifest contains V1 chart `Vars`, the migration stops until the `Chart Variables` decision path
+  is resolved;
 - `Collect(ctx)` returns `error` and writes observations to `metrix`;
-- the completed migration removes the V1 `Collect() map[string]int64` output
-  path and any runtime bridge from V1 maps into V2 `metrix`.
-- the completed migration removes `Charts()` and runtime `collectorapi.Charts`
-  mutation from the production collection path.
+- the completed migration removes the V1 `Collect() map[string]int64` output path and any runtime bridge from V1 maps
+  into V2 `metrix`.
+- the completed migration removes `Charts()` and runtime `collectorapi.Charts` mutation from the production collection
+  path.
 
-Use `src/go/plugin/framework/collectorapi/collector.go` as the source of truth
-for the interface.
+Use `src/go/plugin/framework/collectorapi/collector.go` as the source of truth for the interface.
 
 ## Parity During Development
 
-Temporary V1 logic can be useful while developing the migration. For example,
-tests can compare V1 map output against V2 `metrix` observations after mapping
-both sides through the V1 chart manifest and any V2 chart-identity tooling that
+Temporary V1 logic can be useful while developing the migration. For example, tests can compare V1 map output against V2
+`metrix` observations after mapping both sides through the V1 chart manifest and any V2 chart-identity tooling that
 exists for the migration.
 
-Do not invent an unreviewed local snapshot format when the comparison needs
-compiled chart identity that the framework does not expose. If the migration
-needs reusable chart-identity or alert-variable comparison helpers, treat that
-as a framework/test-helper prerequisite and follow
-`src/go/plugin/framework/docs/changing-framework-code.md` before relying on it.
+Do not invent an unreviewed local snapshot format when the comparison needs compiled chart identity that the framework
+does not expose. If the migration needs reusable chart-identity or alert-variable comparison helpers, treat that as a
+framework/test-helper prerequisite and follow `src/go/plugin/framework/docs/changing-framework-code.md` before relying
+on it.
 
-That parity bridge is a development tool only. It MUST NOT remain in the final
-migrated collector runtime path. A finished migration that runs as
-V1-to-bridge-to-V2 is not a clean end state.
+That parity bridge is a development tool only. It MUST NOT remain in the final migrated collector runtime path. A
+finished migration that runs as V1-to-bridge-to-V2 is not a clean end state.
 
-Runtime path means any code reachable from `Init(ctx)`, `Check(ctx)`,
-`Collect(ctx)`, or `Cleanup(ctx)` during normal execution. V1 collection logic
-MUST NOT remain reachable from that runtime path, regardless of function names
-or return types.
+Runtime path means any code reachable from `Init(ctx)`, `Check(ctx)`, `Collect(ctx)`, or `Cleanup(ctx)` during normal
+execution. V1 collection logic MUST NOT remain reachable from that runtime path, regardless of function names or return
+types.
 
-If parity helpers are useful long term, keep only `_test.go` helpers or
-fixtures under `testdata/`. Before finishing, audit imports and prove no
-non-test file imports the old V1 path or parity bridge.
+If parity helpers are useful long term, keep only `_test.go` helpers or fixtures under `testdata/`. Before finishing,
+audit imports and prove no non-test file imports the old V1 path or parity bridge.
 
 From `src/go`, run an import audit for the migrated collector:
 
@@ -132,12 +118,10 @@ rg -n 'Collect\(.*map\[string\]int64|map\[string\]int64|collectorapi\.Charts|fun
   plugin/go.d/collector/<collector> -g '*.go'
 ```
 
-The dependency command MUST return no runtime dependencies on old V1-only
-helpers such as `stm`, `oldmetrix`, or any collector-local parity bridge
-package. The source grep MUST NOT find a remaining runtime V1 map output,
-runtime `collectorapi.Charts` mutation, or `Charts()` path. If the old path is
-hard to identify, delete the temporary bridge and build/test the collector; the
-final runtime must still compile without it.
+The dependency command MUST return no runtime dependencies on old V1-only helpers such as `stm`, `oldmetrix`, or any
+collector-local parity bridge package. The source grep MUST NOT find a remaining runtime V1 map output, runtime
+`collectorapi.Charts` mutation, or `Charts()` path. If the old path is hard to identify, delete the temporary bridge and
+build/test the collector; the final runtime must still compile without it.
 
 ## What Must Stay Stable
 
@@ -149,8 +133,7 @@ Unless the user approves a breaking change, the migration MUST preserve:
 - chart IDs;
 - dimension IDs and names;
 - dimension algorithms;
-- chart title, family, type, priority, units, multiplier, divisor, hidden, and
-  float flags;
+- chart title, family, type, priority, units, multiplier, divisor, hidden, and float flags;
 - chart variable semantics used by health alerts;
 - health alert lookups;
 - metadata metric descriptions and units;
@@ -160,11 +143,10 @@ Unless the user approves a breaking change, the migration MUST preserve:
 - vnode behavior;
 - user-facing lifecycle behavior.
 
-If an existing collector has an accidental bug or inconsistent artifact, record
-it separately. Fix it in the migration only when preserving the bug would make
-the V2 collector incorrect or untestable; otherwise split the fix into its own
-tracked batch in the active TODO/SOW with owner-approved disposition. Do not
-close a migration with vague deferred items.
+If an existing collector has an accidental bug or inconsistent artifact, record it separately. Fix it in the migration
+only when preserving the bug would make the V2 collector incorrect or untestable; otherwise split the fix into its own
+tracked batch in the active TODO/SOW with owner-approved disposition. Do not close a migration with vague deferred
+items.
 
 ## Implementation Shape
 
@@ -182,108 +164,91 @@ charts.yaml           # V2 chart template
 *_test.go             # focused, table-driven tests
 ```
 
-Keep public lifecycle methods in `collector.go`. Helper methods can move into
-focused files when that makes ownership clearer.
+Keep public lifecycle methods in `collector.go`. Helper methods can move into focused files when that makes ownership
+clearer.
 
 ## Lifecycle Rules
 
-- `Init(ctx)` MUST perform setup and validation only. It MUST NOT collect the
-  full metric set just to initialize state.
-- `Check(ctx)` SHOULD be a cheap probe when the upstream API supports one. If
-  V1 used full collection for autodetection, preserve the user-visible result
-  while making the V2 path as light as the source allows.
-- `Collect(ctx)` MUST write observations to `metrix` and return an error only
-  when the cycle should abort. Fail-soft partial collection must be deliberate,
-  tested, and logged without per-cycle spam.
-- `Cleanup(ctx)` MUST preserve existing cleanup behavior and release any V2
-  Function or client resources added by the migration.
+- `Init(ctx)` MUST perform setup and validation only. It MUST NOT collect the full metric set just to initialize state.
+- `Check(ctx)` SHOULD be a cheap probe when the upstream API supports one. If V1 used full collection for autodetection,
+  preserve the user-visible result while making the V2 path as light as the source allows.
+- `Collect(ctx)` MUST write observations to `metrix` and return an error only when the cycle should abort. Fail-soft
+  partial collection must be deliberate, tested, and logged without per-cycle spam.
+- `Cleanup(ctx)` MUST preserve existing cleanup behavior and release any V2 Function or client resources added by the
+  migration.
 
 ## Metrics And Charts
 
 Use typed `metrix` instruments and `charts.yaml`.
 
-- Prefer creating instruments once when the metric surface is stable. Some
-  collectors intentionally build instruments in the collection path when the
-  surface is dynamic; if you keep that pattern, record why it is still the clean
-  V2 shape for that collector.
+- Prefer creating instruments once when the metric surface is stable. Some collectors intentionally build instruments in
+  the collection path when the surface is dynamic; if you keep that pattern, record why it is still the clean V2 shape
+  for that collector.
 - Use `StateSet` for fixed one-active-state values.
 - Use `Counter.ObserveTotal()` when the upstream value is a source counter.
-- Put multipliers, divisors, hidden flags, float formatting, `instances`, and
-  `label_promotion` in `charts.yaml`, not ad hoc runtime chart code.
-- Preserve V1 dimension algorithms exactly unless the old algorithm was wrong
-  and the user approves the change.
+- Put multipliers, divisors, hidden flags, float formatting, `instances`, and `label_promotion` in `charts.yaml`, not ad
+  hoc runtime chart code.
+- Preserve V1 dimension algorithms exactly unless the old algorithm was wrong and the user approves the change.
 
-When adding labels during migration, verify they are bounded and do not alter
-chart identity unexpectedly. Labels that improve filtering are acceptable only
-when they do not break existing chart/dimension contracts.
+When adding labels during migration, verify they are bounded and do not alter chart identity unexpectedly. Labels that
+improve filtering are acceptable only when they do not break existing chart/dimension contracts.
 
 ### Chart Variables
 
-V1 `collectorapi.Chart.Vars` have no direct `charts.yaml` / `charttpl` support
-today. Some shipped health alerts depend on those variables.
+V1 `collectorapi.Chart.Vars` have no direct `charts.yaml` / `charttpl` support today. Some shipped health alerts depend
+on those variables.
 
-If the V1 collector uses `Vars`, the migration MUST NOT silently drop them.
-Choose one of these paths before implementation:
+If the V1 collector uses `Vars`, the migration MUST NOT silently drop them. Choose one of these paths before
+implementation:
 
-- add clean framework support by following
-  `src/go/plugin/framework/docs/changing-framework-code.md`;
+- add clean framework support by following `src/go/plugin/framework/docs/changing-framework-code.md`;
 - preserve the alert semantics through an approved equivalent design;
-- get explicit user approval for a breaking alert change and update health,
-  metadata, generated docs, and release notes accordingly.
+- get explicit user approval for a breaking alert change and update health, metadata, generated docs, and release notes
+  accordingly.
 
-Until one of those paths is approved, migrating a collector that uses chart
-variables is blocked. Known V1 go.d collectors using chart variables at the
-time of writing include `postgres`, `cockroachdb`, `hdfs`, `puppet`, `scaleio`,
+Until one of those paths is approved, migrating a collector that uses chart variables is blocked. Known V1 go.d
+collectors using chart variables at the time of writing include `postgres`, `cockroachdb`, `hdfs`, `puppet`, `scaleio`,
 `whoisquery`, and `zookeeper`.
 
 ### Obsoletion Timing
 
-V1 collectors often obsolete dynamic charts immediately with `MarkRemove()` /
-`MarkNotCreated()`. V2 chart templates expire unseen chart instances through
-`lifecycle.expire_after_cycles` and related chartengine policy. Exact immediate
-V1 timing is not always reproducible in V2.
+V1 collectors often obsolete dynamic charts immediately with `MarkRemove()` / `MarkNotCreated()`. V2 chart templates
+expire unseen chart instances through `lifecycle.expire_after_cycles` and related chartengine policy. Exact immediate V1
+timing is not always reproducible in V2.
 
-For every V1 dynamic chart, record the old obsoletion timing and choose the V2
-lifecycle policy deliberately. If the timing changes, document the behavioral
-change and get approval when it affects alerts or user-visible chart lifetime.
+For every V1 dynamic chart, record the old obsoletion timing and choose the V2 lifecycle policy deliberately. If the
+timing changes, document the behavioral change and get approval when it affects alerts or user-visible chart lifetime.
 
 ### Dynamic IDs And Contexts
 
-V1 collectors often build chart IDs with `fmt.Sprintf`. V2 templates derive
-contexts from `context_namespace`, group context namespaces, and chart context
-leaves. V2 autogen also has `engine.autogen.max_type_id_len` behavior.
+V1 collectors often build chart IDs with `fmt.Sprintf`. V2 templates derive contexts from `context_namespace`, group
+context namespaces, and chart context leaves. V2 autogen also has `engine.autogen.max_type_id_len` behavior.
 
-The migration MUST prove that generated chart IDs, contexts, and dimensions
-match the old public contract, or explicitly record and approve any difference.
+The migration MUST prove that generated chart IDs, contexts, and dimensions match the old public contract, or explicitly
+record and approve any difference.
 
 ## Config Rules
 
-Migrations MUST keep existing YAML and JSON field names. Do not rename config
-keys to match new code style.
+Migrations MUST keep existing YAML and JSON field names. Do not rename config keys to match new code style.
 
-Do not add public config options as part of a migration unless they are required
-to preserve existing behavior. A proposed config option MUST name the concrete
-operator decision it enables; "operators may want to tune it" is not enough.
-Internal tuning SHOULD use constants. New user choices belong in a later
-feature batch with schema, stock config, metadata, and docs updated together.
+Do not add public config options as part of a migration unless they are required to preserve existing behavior. A
+proposed config option MUST name the concrete operator decision it enables; "operators may want to tune it" is not
+enough. Internal tuning SHOULD use constants. New user choices belong in a later feature batch with schema, stock
+config, metadata, and docs updated together.
 
-`autodetection_retry`, `update_every`, and `vnode` are job/runtime fields in
-many existing collectors. Preserve the migrated collector's current YAML/JSON
-behavior and keep `config.go`, `config_schema.json`, stock config, and metadata
-consistent. Do not copy another collector's schema treatment for these fields
-without checking current framework expectations.
+`autodetection_retry`, `update_every`, and `vnode` are job/runtime fields in many existing collectors. Preserve the
+migrated collector's current YAML/JSON behavior and keep `config.go`, `config_schema.json`, stock config, and metadata
+consistent. Do not copy another collector's schema treatment for these fields without checking current framework
+expectations.
 
 ## Host Scopes, Functions, And Topology
 
-Host scopes, Functions, and topology are product design choices, not automatic
-migration side effects.
+Host scopes, Functions, and topology are product design choices, not automatic migration side effects.
 
 - If the V1 collector already has vnode behavior, preserve it.
-- If adding host scopes would be useful but is not required for compatibility,
-  split it into a later product decision.
-- If the collector exposes Functions, isolate Function code in a dedicated
-  `<name>func/` package behind a narrow `Deps` interface. That interface MUST
-  NOT expose, return, or embed `*Collector`.
+- If adding host scopes would be useful but is not required for compatibility, split it into a later product decision.
+- If the collector exposes Functions, isolate Function code in a dedicated `<name>func/` package behind a narrow `Deps`
+  interface. That interface MUST NOT expose, return, or embed `*Collector`.
 - New topology producers MUST use `src/go/pkg/topology/v1` and validate against
   `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`.
 
@@ -291,101 +256,81 @@ migration side effects.
 
 Migration tests MUST prove compatibility and V2 behavior.
 
-Current shared helpers can prove schema validation, template compilation, and
-fixture chart coverage. They do not prove full V1-to-V2 chart identity parity,
-and they do not prove alert variables unless the migration records the variable
+Current shared helpers can prove schema validation, template compilation, and fixture chart coverage. They do not prove
+full V1-to-V2 chart identity parity, and they do not prove alert variables unless the migration records the variable
 source explicitly.
 
-The non-negotiable minimum is alert-observable parity. The migration MUST prove
-that health alert `on:` contexts, referenced dimensions, referenced variables,
-and dimension algorithms/units used by alerts still resolve after migration.
-This is provable today with chart-template checks plus manual alert-variable
-review.
+The non-negotiable minimum is alert-observable parity. The migration MUST prove that health alert `on:` contexts,
+referenced dimensions, referenced variables, and dimension algorithms/units used by alerts still resolve after
+migration. This is provable today with chart-template checks plus manual alert-variable review.
 
-Exhaustive compiled chart-identity parity is broader: title, family, type,
-priority, multiplier, divisor, hidden, float flags, label promotion, and
-lifecycle policy. If existing exported helpers cannot observe those fields,
-either add a framework `collecttest` helper under
-`src/go/plugin/framework/docs/changing-framework-code.md`, or record a manual
-comparison recipe with exact fields and evidence. Do not claim exhaustive chart
-identity parity without one of those paths.
+Exhaustive compiled chart-identity parity is broader: title, family, type, priority, multiplier, divisor, hidden, float
+flags, label promotion, and lifecycle policy. If existing exported helpers cannot observe those fields, either add a
+framework `collecttest` helper under `src/go/plugin/framework/docs/changing-framework-code.md`, or record a manual
+comparison recipe with exact fields and evidence. Do not claim exhaustive chart identity parity without one of those
+paths.
 
 At minimum:
 
 - config YAML/JSON serialization compatibility;
 - `Init`, `Check`, `Collect`, and `Cleanup` lifecycle coverage;
-- metric-store cycle behavior, including `BeginCycle`, successful commit, and
-  abort on expected hard collection errors;
-- alert-observable parity for chart contexts, dimension IDs/names, algorithms,
-  units, and variables used by health alerts;
+- metric-store cycle behavior, including `BeginCycle`, successful commit, and abort on expected hard collection errors;
+- alert-observable parity for chart contexts, dimension IDs/names, algorithms, units, and variables used by health
+  alerts;
 - chart template schema/decode/validate/compile coverage;
 - chart coverage for fixture data expected to materialize all dimensions;
-- health alert compatibility when alerts exist: each alert `on:` context must
-  exist in the compiled template, and every variable referenced by alert
-  calculations must still be provided by a dimension, variable-equivalent
-  design, or approved alert change;
+- health alert compatibility when alerts exist: each alert `on:` context must exist in the compiled template, and every
+  variable referenced by alert calculations must still be provided by a dimension, variable-equivalent design, or
+  approved alert change;
 - generated integration artifact consistency when metadata/taxonomy changes;
 - taxonomy coverage checks when chart contexts change;
 - host-scope tests if scopes/vnodes are preserved or introduced.
 
-`collecttest.AssertChartCoverage` is not a replacement for chart-identity
-parity. It verifies that emitted series and the template agree; it can still
-pass when both writer and template were renamed consistently.
+`collecttest.AssertChartCoverage` is not a replacement for chart-identity parity. It verifies that emitted series and
+the template agree; it can still pass when both writer and template were renamed consistently.
 
-Exhaustive chart-identity parity is required before claiming full compatibility.
-If the migration lacks a shared helper or recorded manual comparison recipe for
-the compiled fields listed above, claim only the narrower compatibility that was
-actually proven.
+Exhaustive chart-identity parity is required before claiming full compatibility. If the migration lacks a shared helper
+or recorded manual comparison recipe for the compiled fields listed above, claim only the narrower compatibility that
+was actually proven.
 
-Until a shared alert-variable helper exists, use a manual grep/review pass for
-alert variables:
+Until a shared alert-variable helper exists, use a manual grep/review pass for alert variables:
 
 ```bash
 rg -n "\\$[A-Za-z_][A-Za-z0-9_]*" src/health/health.d/<collector>.conf
 rg -n "Vars:" src/go/plugin/go.d/collector/<collector> -g '*.go'
 ```
 
-Every referenced variable must still be supplied by a dimension,
-variable-equivalent design, or approved alert change.
+Every referenced variable must still be supplied by a dimension, variable-equivalent design, or approved alert change.
 
-Prefer table-driven tests using `map[string]struct{}` keyed by case name when
-cases share setup and assertion shape.
+Prefer table-driven tests using `map[string]struct{}` keyed by case name when cases share setup and assertion shape.
 
 ### Parity manifest recipe
 
-When chart-identity parity needs the compiled fields above and no shared helper
-observes them, this is a concrete form of that "manual comparison recipe": prove
-context/dimension/value parity by rendering BOTH collectors into one manifest
+When chart-identity parity needs the compiled fields above and no shared helper observes them, this is a concrete form
+of that "manual comparison recipe": prove context/dimension/value parity by rendering BOTH collectors into one manifest
 shape, without depending on chart-ID string equality.
 
-1. Freeze the V1 output as a golden manifest. For representative fixtures, run
-   the V1 `Collect()` + `Charts()` and serialize, per chart: context, type,
-   family, units, priority, and per dimension the name, algorithm, and de-scaled
-   value (the V1 `map[string]int64` value divided by the dimension `Div`). Commit
-   the goldens under `testdata/`.
-2. Render the V2 path into the same shape. Load the collector's LIVE
-   `ChartTemplateYAML()` into a real `chartengine`, run a cycle through the real
-   `Collect()` and `metrix` store, plan against the store, and read the plan's
+1. Freeze the V1 output as a golden manifest. For representative fixtures, run the V1 `Collect()` + `Charts()` and
+   serialize, per chart: context, type, family, units, priority, and per dimension the name, algorithm, and de-scaled
+   value (the V1 `map[string]int64` value divided by the dimension `Div`). Commit the goldens under `testdata/`.
+2. Render the V2 path into the same shape. Load the collector's LIVE `ChartTemplateYAML()` into a real `chartengine`,
+   run a cycle through the real `Collect()` and `metrix` store, plan against the store, and read the plan's
    create/update actions into the same per-chart structure.
-3. Compare structurally with a float tolerance. V1 truncates `value*Div` to
-   `int64` while V2 stores the true float, so compare values within a tolerance
-   (for example `1e-3`), not for exact equality. Assert that context, family,
-   units, dimension names, and dimension algorithms match.
+3. Compare structurally with a float tolerance. V1 truncates `value*Div` to `int64` while V2 stores the true float, so
+   compare values within a tolerance (for example `1e-3`), not for exact equality. Assert that context, family, units,
+   dimension names, and dimension algorithms match.
 
-Compare chart IDs too when the migration preserves them (the default). Omit only
-chart-ID equality when the user approved a breaking chart-ID change -- then the
-preserved contract is the context, and chart-ID-keyed alert examples in
-`src/health/REFERENCE.md` must be updated. A gap (NaN or absent value) MUST fail
-the comparison loudly; never silently map it to 0.
+Compare chart IDs too when the migration preserves them (the default). Omit only chart-ID equality when the user
+approved a breaking chart-ID change -- then the preserved contract is the context, and chart-ID-keyed alert examples in
+`src/health/REFERENCE.md` must be updated. A gap (NaN or absent value) MUST fail the comparison loudly; never silently
+map it to 0.
 
-The render MUST go through the collector's LIVE `ChartTemplateYAML()` and store,
-not a separately rebuilt template -- a test that rebuilds the template can pass
-even when the shipped `ChartTemplateYAML()` is wrong.
+The render MUST go through the collector's LIVE `ChartTemplateYAML()` and store, not a separately rebuilt template -- a
+test that rebuilds the template can pass even when the shipped `ChartTemplateYAML()` is wrong.
 
 ## Validation
 
-Run the narrowest commands that prove the changed contract. Typical migration
-validation includes:
+Run the narrowest commands that prove the changed contract. Typical migration validation includes:
 
 ```bash
 cd src/go
@@ -394,26 +339,19 @@ go test -race -count=1 ./plugin/go.d/collector/<name>/...
 timeout 15s go run ./cmd/godplugin -m <name> -d
 ```
 
-For the load-verification command, success means the module is registered, a
-job starts, and the command keeps running until the timeout stops it. Treat
-`unknown module`, `no jobs started`, config-load errors, or an immediate exit
-before the timeout as failures. Use `-c <config-dir>` when the migrated test
-config lives outside the normal go.d config search path.
+For the load-verification command, success means the module is registered, a job starts, and the command keeps running
+until the timeout stops it. Treat `unknown module`, `no jobs started`, config-load errors, or an immediate exit before
+the timeout as failures. Use `-c <config-dir>` when the migrated test config lives outside the normal go.d config search
+path.
 
-Also run framework or integration checks when the migration touches those
-contracts:
+Also run framework or integration checks when the migration touches those contracts:
 
-- chart template/framework changes:
-  `go test -count=1 ./plugin/framework/charttpl ./plugin/framework/chartengine`
-- `metrix` changes:
-  `go test -count=1 ./pkg/metrix/...`
-- runtime/framework changes:
-  follow `src/go/plugin/framework/docs/changing-framework-code.md`
-- metadata/taxonomy/generated docs:
-  follow `.agents/skills/integrations-lifecycle/consistency.md`
+- chart template/framework changes: `go test -count=1 ./plugin/framework/charttpl ./plugin/framework/chartengine`
+- `metrix` changes: `go test -count=1 ./pkg/metrix/...`
+- runtime/framework changes: follow `src/go/plugin/framework/docs/changing-framework-code.md`
+- metadata/taxonomy/generated docs: follow `.agents/skills/integrations-lifecycle/consistency.md`
 
-Record exactly what ran. Full validation MUST NOT be claimed from a narrow
-command.
+Record exactly what ran. Full validation MUST NOT be claimed from a narrow command.
 
 ## Commit Shape
 
@@ -425,16 +363,14 @@ Prefer small coherent commits:
 4. Update synchronized integration artifacts.
 5. Add follow-up enrichment only in a separate batch.
 
-If the migration requires a framework change, stop and follow
-`src/go/plugin/framework/docs/changing-framework-code.md` before implementing
-collector-local glue.
+If the migration requires a framework change, stop and follow `src/go/plugin/framework/docs/changing-framework-code.md`
+before implementing collector-local glue.
 
 ## Anti-Patterns
 
-- Rewriting chart IDs, contexts, or dimensions only because the V2 template
-  makes a new name easier.
-- Adding labels, host scopes, topology, or Functions in the same commit as the
-  compatibility migration without a product decision.
+- Rewriting chart IDs, contexts, or dimensions only because the V2 template makes a new name easier.
+- Adding labels, host scopes, topology, or Functions in the same commit as the compatibility migration without a product
+  decision.
 - Shipping a V1-to-bridge-to-V2 runtime path after the V2 store is in place.
 - Hiding framework gaps in collector-local helpers.
 - Treating generated integration pages or README symlinks as authoring sources.

--- a/src/libnetdata/simple_pattern/README.md
+++ b/src/libnetdata/simple_pattern/README.md
@@ -1,23 +1,18 @@
 # Simple patterns
 
-Unix prefers regular expressions. But they are just too hard, too cryptic
-to use, write and understand.
+Unix prefers regular expressions. But they are just too hard, too cryptic to use, write and understand.
 
 So, Netdata supports **simple patterns**.
 
-Simple patterns are a space separated list of words, that can have `*`
-as a wildcard. Each word may use any number of `*`. Simple patterns
-allow **negative** matches by prefixing a word with `!`.
+Simple patterns are a space separated list of words, that can have `*` as a wildcard. Each word may use any number of
+`*`. Simple patterns allow **negative** matches by prefixing a word with `!`.
 
-So, `pattern = !*bad* *` will match anything, except all those that
-contain the word `bad`. 
+So, `pattern = !*bad* *` will match anything, except all those that contain the word `bad`.
 
-Simple patterns are quite powerful: `pattern = *foobar* !foo* !*bar *`
-matches everything containing `foobar`, except strings that start
-with `foo` or end with `bar`.
+Simple patterns are quite powerful: `pattern = *foobar* !foo* !*bar *` matches everything containing `foobar`, except
+strings that start with `foo` or end with `bar`.
 
-You can use the Netdata command line to check simple patterns,
-like this:
+You can use the Netdata command line to check simple patterns, like this:
 
 ```sh
 # netdata -W simple-pattern '*foobar* !foo* !*bar *' 'hello world'
@@ -30,8 +25,7 @@ RESULT: NOT MATCHED - pattern '*foobar* !foo* !*bar *' does not match 'hello wor
 RESULT: MATCHED - pattern '*foobar* !foo* !*bar *' matches 'hello world foobar'
 ```
 
-Netdata stops processing to the first positive or negative match
-(left to right). If it is not matched by either positive or negative
-patterns, it is denied at the end.
+Netdata stops processing to the first positive or negative match (left to right). If it is not matched by either
+positive or negative patterns, it is denied at the end.
 
 


### PR DESCRIPTION
Reflow the 80-column hand-wrapped reference docs to ~120 columns, matching the repository's configured code limits (clang-format ColumnLimit 120, golines -m 120). Whitespace-only: the token stream of every reflowed file is unchanged. Record the convention in AGENTS.md so new docs follow it.

Generated integration pages are not reflowed here; CI regenerates them from metadata.yaml after merge.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reflowed hand-authored reference docs to ~120 columns to match repo code limits and improve readability. Content is unchanged; whitespace-only edits.

- **Refactors**
  - Wrapped Markdown/YAML prose at ~120 columns across docs in `src/go/...` and `src/libnetdata/...`.
  - Added the wrapping guideline to `AGENTS.md` and noted to keep reflow-only changes separate from content edits.
  - Skipped generated integration pages; CI will regenerate them from `metadata.yaml` after merge.

<sup>Written for commit 17410eb5a7be20e95003f7ce5001353a15fe52ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

