### PR TITLE
Make otel-plugin durable-write I/O errors name the operation and path

### DIFF
--- a/src/crates/chunk-file/src/container.rs
+++ b/src/crates/chunk-file/src/container.rs
@@ -69,7 +69,9 @@ pub enum Error {
     /// The TOC failed to parse or validate — carries the raw layer's
     /// structured error so callers can match the specific failure
     /// (duplicate id, non-monotonic offset, out-of-bounds, ...).
-    #[error("TOC error: {0}")]
+    /// Transparent: embedding the source in the message while also
+    /// chaining it would print it twice in anyhow chains.
+    #[error(transparent)]
     Toc(#[from] crate::Error),
 
     /// The container framing is malformed beyond the TOC itself —
@@ -100,7 +102,7 @@ pub enum Error {
     },
 
     /// Underlying I/O failed (streaming writer).
-    #[error("I/O error: {0}")]
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 }
 

--- a/src/crates/ferryboat/src/lib.rs
+++ b/src/crates/ferryboat/src/lib.rs
@@ -218,16 +218,18 @@ fn registry() -> &'static Mutex<HashMap<String, Box<dyn Any + Send + Sync>>> {
 /// Errors returned by [`Connection::send`] and [`Connection::recv`].
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Transport-level I/O error.
-    #[error("io: {0}")]
+    /// Transport-level I/O error. Transparent (as are the codec wrappers
+    /// below): embedding the source in the message while also chaining it
+    /// would print it twice in anyhow chains.
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
     /// Failed to serialize a message.
-    #[error("serialization: {0}")]
+    #[error(transparent)]
     Encode(#[from] bincode::error::EncodeError),
 
     /// Failed to deserialize a message.
-    #[error("deserialization: {0}")]
+    #[error(transparent)]
     Decode(#[from] bincode::error::DecodeError),
 
     /// The other side of the connection has been closed.

--- a/src/crates/file-registry/src/durable.rs
+++ b/src/crates/file-registry/src/durable.rs
@@ -49,7 +49,11 @@ fn tmp_path(final_path: &Path) -> PathBuf {
 ///
 /// The kind is the only structured field preserved: `raw_os_error()`
 /// and `source()` are intentionally flattened into the message text.
-fn annotate(e: io::Error, op: &str, path: &Path) -> io::Error {
+///
+/// Public so streaming producers that write through the [`AtomicFile`]
+/// handle themselves (e.g. the SFST builder) can annotate their own
+/// write-phase failures with [`AtomicFile::tmp_path`].
+pub fn annotate(e: io::Error, op: &str, path: &Path) -> io::Error {
     io::Error::new(e.kind(), format!("{op} {}: {e}", path.display()))
 }
 
@@ -98,6 +102,13 @@ impl AtomicFile {
             },
             file,
         ))
+    }
+
+    /// The temp path this guard owns — for callers that stream through
+    /// the returned file themselves and want to [`annotate`] their own
+    /// write-phase failures with the actual path being written.
+    pub fn tmp_path(&self) -> &Path {
+        &self.tmp
     }
 
     /// Make the write durable: fsync `file` (which must be the one

--- a/src/crates/file-registry/src/durable.rs
+++ b/src/crates/file-registry/src/durable.rs
@@ -46,6 +46,9 @@ fn tmp_path(final_path: &Path) -> PathBuf {
 /// `NotFound` tolerance) keeps working. `std::fs` errors carry no path;
 /// without this a production failure logs as a bare "Permission denied"
 /// with no hint of what was being written where.
+///
+/// The kind is the only structured field preserved: `raw_os_error()`
+/// and `source()` are intentionally flattened into the message text.
 fn annotate(e: io::Error, op: &str, path: &Path) -> io::Error {
     io::Error::new(e.kind(), format!("{op} {}: {e}", path.display()))
 }
@@ -135,7 +138,8 @@ impl Drop for AtomicFile {
 /// whole-buffer convenience over [`AtomicFile`].
 pub fn write_atomic(final_path: &Path, bytes: &[u8]) -> io::Result<()> {
     let (guard, mut file) = AtomicFile::create(final_path)?;
-    file.write_all(bytes)?;
+    file.write_all(bytes)
+        .map_err(|e| annotate(e, "write temp file", &tmp_path(final_path)))?;
     guard.commit(file)
 }
 
@@ -205,29 +209,36 @@ mod tests {
         std::fs::create_dir(&locked).unwrap();
         std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o555)).unwrap();
 
-        // Creating the temp file inside the read-only dir fails.
+        // Capture results, then restore permissions so the tempdir can be
+        // removed even if an assert below fails.
         let path = locked.join("seq_highwater");
-        let err = write_atomic(&path, b"x").unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
-        let msg = err.to_string();
-        assert!(
-            msg.contains("create temp file") && msg.contains(&tmp_path(&path).display().to_string()),
-            "message must name the operation and path: {msg}"
-        );
-
-        // Creating a parent under the read-only dir fails in create_dir_all.
+        let created = write_atomic(&path, b"x");
         let nested = locked.join("shared").join("seq_highwater");
-        let err = write_atomic(&nested, b"x").unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
-        let msg = err.to_string();
-        assert!(
-            msg.contains("create parent directory")
-                && msg.contains(&nested.parent().unwrap().display().to_string()),
-            "message must name the operation and parent path: {msg}"
-        );
-
-        // Restore so tempdir cleanup can remove it.
+        let nested_created = write_atomic(&nested, b"x");
         std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Under root the chmod doesn't deny anything; only assert when
+        // the writes actually failed.
+        if let Err(err) = created {
+            // Creating the temp file inside the read-only dir fails.
+            assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+            let msg = err.to_string();
+            assert!(
+                msg.contains("create temp file")
+                    && msg.contains(&tmp_path(&path).display().to_string()),
+                "message must name the operation and path: {msg}"
+            );
+        }
+        if let Err(err) = nested_created {
+            // Creating a parent under the read-only dir fails in create_dir_all.
+            assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+            let msg = err.to_string();
+            assert!(
+                msg.contains("create parent directory")
+                    && msg.contains(&nested.parent().unwrap().display().to_string()),
+                "message must name the operation and parent path: {msg}"
+            );
+        }
     }
 
     #[test]

--- a/src/crates/file-registry/src/durable.rs
+++ b/src/crates/file-registry/src/durable.rs
@@ -41,9 +41,20 @@ fn tmp_path(final_path: &Path) -> PathBuf {
     PathBuf::from(os)
 }
 
+/// Wrap an `io::Error` with the failing operation and path, preserving
+/// the [`io::ErrorKind`] so callers' kind-based handling (e.g.
+/// `NotFound` tolerance) keeps working. `std::fs` errors carry no path;
+/// without this a production failure logs as a bare "Permission denied"
+/// with no hint of what was being written where.
+fn annotate(e: io::Error, op: &str, path: &Path) -> io::Error {
+    io::Error::new(e.kind(), format!("{op} {}: {e}", path.display()))
+}
+
 /// fsync a directory so a rename inside it survives power loss.
 pub fn fsync_dir(dir: &Path) -> io::Result<()> {
-    File::open(dir)?.sync_all()
+    File::open(dir)
+        .and_then(|f| f.sync_all())
+        .map_err(|e| annotate(e, "fsync directory", dir))
 }
 
 /// Guard for an in-progress atomic write.
@@ -71,10 +82,11 @@ impl AtomicFile {
     pub fn create(final_path: impl Into<PathBuf>) -> io::Result<(Self, File)> {
         let final_path = final_path.into();
         if let Some(parent) = final_path.parent() {
-            std::fs::create_dir_all(parent)?;
+            std::fs::create_dir_all(parent)
+                .map_err(|e| annotate(e, "create parent directory", parent))?;
         }
         let tmp = tmp_path(&final_path);
-        let file = File::create(&tmp)?;
+        let file = File::create(&tmp).map_err(|e| annotate(e, "create temp file", &tmp))?;
         Ok((
             Self {
                 tmp,
@@ -90,9 +102,11 @@ impl AtomicFile {
     /// buffering layers), rename the temp over the final path, and
     /// fsync the parent directory.
     pub fn commit(mut self, file: File) -> io::Result<()> {
-        file.sync_all()?;
+        file.sync_all()
+            .map_err(|e| annotate(e, "fsync temp file", &self.tmp))?;
         drop(file);
-        std::fs::rename(&self.tmp, &self.final_path)?;
+        std::fs::rename(&self.tmp, &self.final_path)
+            .map_err(|e| annotate(e, "rename temp file over", &self.final_path))?;
         self.committed = true;
         if let Some(parent) = self.final_path.parent() {
             fsync_dir(parent)?;
@@ -175,6 +189,45 @@ mod tests {
         write_atomic(&path, b"v2").unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"v2");
         assert!(!tmp_path(&path).exists());
+    }
+
+    /// A failed write must say what it was doing and where — the whole
+    /// point of `annotate`. An unwritable directory (the production
+    /// failure mode this was born from) must surface the operation and
+    /// the full path while preserving the ErrorKind callers branch on.
+    #[test]
+    #[cfg(unix)]
+    fn io_errors_carry_operation_path_and_kind() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        // Creating the temp file inside the read-only dir fails.
+        let path = locked.join("seq_highwater");
+        let err = write_atomic(&path, b"x").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("create temp file") && msg.contains(&tmp_path(&path).display().to_string()),
+            "message must name the operation and path: {msg}"
+        );
+
+        // Creating a parent under the read-only dir fails in create_dir_all.
+        let nested = locked.join("shared").join("seq_highwater");
+        let err = write_atomic(&nested, b"x").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("create parent directory")
+                && msg.contains(&nested.parent().unwrap().display().to_string()),
+            "message must name the operation and parent path: {msg}"
+        );
+
+        // Restore so tempdir cleanup can remove it.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     #[test]

--- a/src/crates/file-registry/src/durable.rs
+++ b/src/crates/file-registry/src/durable.rs
@@ -139,7 +139,7 @@ impl Drop for AtomicFile {
 pub fn write_atomic(final_path: &Path, bytes: &[u8]) -> io::Result<()> {
     let (guard, mut file) = AtomicFile::create(final_path)?;
     file.write_all(bytes)
-        .map_err(|e| annotate(e, "write temp file", &tmp_path(final_path)))?;
+        .map_err(|e| annotate(e, "write temp file", &guard.tmp))?;
     guard.commit(file)
 }
 

--- a/src/crates/netdata-plugin/error/src/lib.rs
+++ b/src/crates/netdata-plugin/error/src/lib.rs
@@ -6,8 +6,10 @@ pub type Result<T> = std::result::Result<T, NetdataPluginError>;
 /// Error types that can occur in netdata plugin operations
 #[derive(Error, Debug)]
 pub enum NetdataPluginError {
-    /// Transport layer error (I/O, network)
-    #[error("transport error: {0}")]
+    /// Transport layer error (I/O, network). Transparent: embedding the
+    /// source in the message while also chaining it would print it twice
+    /// in anyhow chains.
+    #[error(transparent)]
     Transport(#[from] std::io::Error),
 
     /// Protocol parsing or communication error

--- a/src/crates/ng-index/src/lib.rs
+++ b/src/crates/ng-index/src/lib.rs
@@ -24,9 +24,11 @@ pub use ng_flatten::{
 /// Errors reading a flattened WAL or building an SFST from it.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("wal error: {0}")]
+    // Wrapper variants are transparent: embedding the source in the message
+    // while also chaining it would print it twice in anyhow chains.
+    #[error(transparent)]
     Wal(#[from] wal::Error),
-    #[error("io error: {0}")]
+    #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error("no .wal file found in {0}")]
     NoWal(PathBuf),
@@ -37,12 +39,15 @@ pub enum Error {
          refusing to decode frames written by a different codec"
     )]
     PayloadFormat { found: u16, expected: u16 },
-    #[error("frame {frame}: bincode decode failed: {source}")]
+    // The message keeps only the frame context; the `source` field is
+    // chained by thiserror (field named `source`), so embedding it here
+    // too would print it twice in anyhow chains.
+    #[error("frame {frame}: bincode decode failed")]
     BincodeDecode {
         frame: u64,
         source: bincode::error::DecodeError,
     },
-    #[error("sfst build failed: {0}")]
+    #[error(transparent)]
     Sfst(#[from] sfst::Error),
 }
 

--- a/src/crates/ng-index/src/lib.rs
+++ b/src/crates/ng-index/src/lib.rs
@@ -39,13 +39,14 @@ pub enum Error {
          refusing to decode frames written by a different codec"
     )]
     PayloadFormat { found: u16, expected: u16 },
-    // The message keeps only the frame context; the `source` field is
-    // chained by thiserror (field named `source`), so embedding it here
-    // too would print it twice in anyhow chains.
-    #[error("frame {frame}: bincode decode failed")]
+    // The decode error is embedded in the message, NOT chained (a field
+    // named `source` would be auto-chained by thiserror and then print
+    // twice in anyhow chains). Display-only consumers (the ledger indexer
+    // logs `{e}`) need the decode reason in the message itself.
+    #[error("frame {frame}: bincode decode failed: {err}")]
     BincodeDecode {
         frame: u64,
-        source: bincode::error::DecodeError,
+        err: bincode::error::DecodeError,
     },
     #[error(transparent)]
     Sfst(#[from] sfst::Error),

--- a/src/crates/ng-index/src/sfst_build.rs
+++ b/src/crates/ng-index/src/sfst_build.rs
@@ -164,9 +164,9 @@ fn populate_row_index(
 
         let flattened: FlattenedLogRequest = {
             let _t = metrics.scope("deserialize");
-            decode_log_frame(frame.data).map_err(|source| Error::BincodeDecode {
+            decode_log_frame(frame.data).map_err(|err| Error::BincodeDecode {
                 frame: stats.frames,
-                source,
+                err,
             })?
         };
 
@@ -354,9 +354,9 @@ fn populate_trace_row_index(
 
         let flattened: ng_flatten::FlattenedTraceRequest = {
             let _t = metrics.scope("deserialize");
-            ng_flatten::decode_trace_frame(frame.data).map_err(|source| Error::BincodeDecode {
+            ng_flatten::decode_trace_frame(frame.data).map_err(|err| Error::BincodeDecode {
                 frame: stats.frames,
-                source,
+                err,
             })?
         };
 

--- a/src/crates/otel-catalog/src/lib.rs
+++ b/src/crates/otel-catalog/src/lib.rs
@@ -37,15 +37,17 @@ pub const CONTAINER_VERSION: u32 = 1;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("JSON error: {0}")]
+    // Wrapper variants are transparent: embedding the source in the message
+    // while also chaining it would print it twice in anyhow chains.
+    #[error(transparent)]
     Json(#[from] serde_json::Error),
 
     #[error("unsupported catalog format version: {0}")]
     UnsupportedVersion(u32),
 
-    #[error("container error: {0}")]
+    #[error(transparent)]
     Container(#[from] chunk_file::container::Error),
 
-    #[error("I/O error: {0}")]
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 }

--- a/src/crates/sfsq/src/logs/wal_scan.rs
+++ b/src/crates/sfsq/src/logs/wal_scan.rs
@@ -52,7 +52,9 @@ use super::query::LogsQuery;
 #[derive(Debug, thiserror::Error)]
 pub enum FlattenedScanError {
     /// The WAL container could not be read (open or frame iteration).
-    #[error("wal read: {0}")]
+    /// Transparent: embedding the source in the message while also
+    /// chaining it would print it twice in anyhow chains.
+    #[error(transparent)]
     Wal(#[from] wal::Error),
     /// The WAL header names a frame codec other than the ng-flatten logs
     /// format this scan implements — refuse before decoding any frame.

--- a/src/crates/sfst/src/build.rs
+++ b/src/crates/sfst/src/build.rs
@@ -266,10 +266,24 @@ pub(crate) fn build_and_write(
     // produced this index was already durably deleted, losing the
     // seq's data with no recovery path.
     let (guard, file) = file_registry::durable::AtomicFile::create(out_path)?;
+    // The streaming writes happen through the file handle, outside the
+    // guard's own annotated steps — annotate their failures (ENOSPC mid
+    // chunk stream is a realistic production event) with the temp path
+    // being written, like every other durable-write step.
+    let annotate_io = |e: Error, op: &str| match e {
+        Error::Io(io) => Error::Io(file_registry::durable::annotate(io, op, guard.tmp_path())),
+        other => other,
+    };
     let (buf, summary, metadata) =
-        build_into(row_index, std::io::BufWriter::new(file), content_meta)?;
-    let file = buf.into_inner().map_err(|e| e.into_error())?;
-    let file_size = file.metadata()?.len();
+        build_into(row_index, std::io::BufWriter::new(file), content_meta)
+            .map_err(|e| annotate_io(e, "write SFST chunks to temp file"))?;
+    let file = buf
+        .into_inner()
+        .map_err(|e| annotate_io(e.into_error().into(), "flush temp file"))?;
+    let file_size = file
+        .metadata()
+        .map_err(|e| file_registry::durable::annotate(e, "stat temp file", guard.tmp_path()))?
+        .len();
     guard.commit(file)?;
     tracing::info!(
         "index written path={} size_kb={} write_ms={} total_ms={}",

--- a/src/crates/sfst/src/error.rs
+++ b/src/crates/sfst/src/error.rs
@@ -4,19 +4,20 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Underlying I/O failed during read/write/flush/sync. Auto-lifted
-    /// from [`std::io::Error`].
-    #[error("I/O error: {0}")]
+    /// from [`std::io::Error`]. Transparent: embedding the source in the
+    /// message while also chaining it would print it twice in anyhow chains.
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
     /// `bincode::encode_to_vec` rejected a value while packing a chunk
     /// payload.
-    #[error("bincode encode error: {0}")]
+    #[error(transparent)]
     BincodeEncode(#[from] bincode::error::EncodeError),
 
     /// `bincode::decode_from_slice` failed while unpacking a chunk
     /// payload — the bytes don't match the expected shape, or are
     /// truncated.
-    #[error("bincode decode error: {0}")]
+    #[error(transparent)]
     BincodeDecode(#[from] bincode::error::DecodeError),
 
     /// `zstd` compression or decompression failed without surfacing as

--- a/src/crates/wal/src/error.rs
+++ b/src/crates/wal/src/error.rs
@@ -2,7 +2,10 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("I/O error: {0}")]
+    // Transparent: the io::Error (annotated with op + path by
+    // file_registry::durable) is the whole message. Embedding it here AND
+    // chaining it via #[from] would print it twice in anyhow chains.
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
     #[error("invalid WAL header: {0}")]

--- a/src/crates/wal/src/error.rs
+++ b/src/crates/wal/src/error.rs
@@ -2,9 +2,10 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    // Transparent: the io::Error (annotated with op + path by
-    // file_registry::durable) is the whole message. Embedding it here AND
-    // chaining it via #[from] would print it twice in anyhow chains.
+    // Transparent: the io::Error is the whole message (durable-write
+    // errors arrive already annotated with op + path by
+    // file_registry::durable). Embedding it here AND chaining it via
+    // #[from] would print it twice in anyhow chains.
     #[error(transparent)]
     Io(#[from] std::io::Error),
 


### PR DESCRIPTION
## Summary

An otel-plugin restart loop on a staging node was traced to the ingestor's first mandatory startup write — the seq high-water file under `{base_dir}/shared/` — failing on an unwritable directory. The fatal log line was:

```
ingestor event loop error: initializing seq high-water allocator: I/O error: Permission denied (os error 13): Permission denied (os error 13)
```

No operation, no path, and the OS error printed twice. This PR fixes both defects:

- **`file-registry` durable writes now name the operation and path.** Every failing step of the atomic-write sequence (create parent directory, create/write/flush/stat/fsync the temp file, rename, fsync the parent dir) wraps its `io::Error` with the operation and the full path, preserving the `ErrorKind` callers branch on. All durable writers (seq high-water, SFST, catalogs, file-cache, recovery) inherit this. The streaming SFST build — which writes through the `AtomicFile` handle itself — annotates its own write-phase failures via the now-public `annotate()` and a new `AtomicFile::tmp_path()` accessor.
- **Error chains no longer double-print their source.** Wrapper variants declaring `#[error("...{0}")]` while also chaining the source via `#[from]` rendered the source twice in anyhow `{:#}` chains. Every such variant in the otel-plugin's active error chains (`wal`, `sfst`, `otel-catalog`, `chunk-file`, `ng-index`, `ferryboat`, `sfsq`, `netdata-plugin/error`) is now `#[error(transparent)]`. The one context-adding variant (`ng-index BincodeDecode`) keeps the decode reason embedded in its message instead of chaining it, because the ledger indexer logs it via plain `Display`.

The same failure now logs as:

```
ingestor worker failed: initializing seq high-water allocator: create temp file /var/lib/netdata/otel/shared/seq_highwater.tmp: Permission denied (os error 13)
```

## Verification

- New unit test (`file-registry`) asserts operation + path + preserved `ErrorKind` on permission failures, following the repo's root-guarded permission-test convention.
- `cargo test` green across all touched crates and their consumers (file-registry, wal, sfst, otel-catalog, chunk-file, ng-index, ferryboat, sfsq, sfsq-cli, netdata-plugin-error, netdata-plugin-protocol, file-lifecycle, file-cache, otel-ingestor, otel-ledger, otel-plugin).
- Live agent verification: 200 OTLP log records ingested and queried back (200/200 matched, facets exact); WALs sealed into SFSTs through the annotated streaming path with zero errors; the original incident reproduced against the live agent (read-only `shared/` dir) produced the new message above; after restoring permissions the plugin recovered with no data loss.
- No consumer depends on the removed Display prefixes, `raw_os_error()`, or source-chain traversal; `ErrorKind`-based handling is unaffected. The legacy `journal-*` crates keep the old pattern intentionally (slated for removal).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Durable-write I/O errors now include the operation and full path, and wrapper errors are made transparent to stop double-printed sources. This fixes confusing startup failures and preserves existing `ErrorKind`-based handling.

- **Bug Fixes**
  - `file-registry`: annotate every durable step with op + path (create parent dir, create/write/fsync/stat temp file, rename, fsync parent). Expose `annotate()` and `AtomicFile::tmp_path()`; `write_atomic` now annotates its write. All durable writers inherit this (seq high-water, SFST, catalogs, file-cache, recovery).
  - `sfst` build: annotate streaming writes, flush, and stat using the temp path for clear ENOSPC/permission errors.
  - Error enums switched to `#[error(transparent)]` to avoid duplicate sources in anyhow chains across `wal`, `sfst`, `otel-catalog`, `ng-index`, `chunk-file`, `ferryboat`, `sfsq`, `netdata-plugin/error`. `ng-index::BincodeDecode` now embeds the decode reason in the message without chaining.

<sup>Written for commit 2d416c0b0582347b360ea2b1439ee18cfbeb56a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

