### PR TITLE
Stop static packages shipping builder runtime state; repair otel dir ownership

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -179,6 +179,16 @@ run find /opt/netdata -type d -exec chmod go+rx '{}' \+
 
 install_netdata_dirs
 
+# Earlier static packages leaked the builder's otel-plugin state into the
+# archive; extracting it left root-owned parent directories under
+# var/log/netdata/otel, which the otel-plugin (running as netdata) cannot
+# write to, crash-looping the plugin. Repair ownership on every
+# install/update so affected installs self-heal. The daemon only chowns
+# the log dir non-recursively, so nothing else fixes the subtree.
+if [ -d "${NETDATA_LOG_DIR}/otel" ]; then
+  run chown -R ${NETDATA_USER}:${NETDATA_GROUP} "${NETDATA_LOG_DIR}/otel"
+fi
+
 if [ -d /opt/netdata/usr/libexec/netdata/plugins.d/ebpf.d ]; then
   run chown -R root:${NETDATA_GROUP} /opt/netdata/usr/libexec/netdata/plugins.d/ebpf.d
 fi

--- a/packaging/makeself/jobs/81-netdata-runtime-check.sh
+++ b/packaging/makeself/jobs/81-netdata-runtime-check.sh
@@ -200,7 +200,14 @@ check_static_installer_systemd_capability_bounding_set || exit 1
 
 trap - EXIT
 
-run rm -rv "${NETDATA_INSTALL_PATH}/var/lib/netdata" "${NETDATA_INSTALL_PATH}/var/cache/netdata"
+# var/log must be cleaned too: the runtime check above ran the agent, so
+# the tree holds builder runtime state (daemon logs, the otel-plugin's
+# storage dirs and seq high-water file). Shipping it is harmful — makeself
+# archives only files and empty leaf dirs, so on extraction the missing
+# parent dirs are created root-owned and the otel-plugin (running as
+# netdata) can no longer write its state, crash-looping the plugin.
+# 90-prepare-archive-source.sh re-creates all three dirs empty afterwards.
+run rm -rv "${NETDATA_INSTALL_PATH}/var/lib/netdata" "${NETDATA_INSTALL_PATH}/var/cache/netdata" "${NETDATA_INSTALL_PATH}/var/log/netdata"
 
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true


### PR DESCRIPTION
## Summary

Static `.gz.run` packages have been shipping runtime state from the build machine, and since the otel-plugin started persisting storage under `var/log/netdata/otel/v2` (#22720), that leak crash-loops the otel-plugin on every static install that updates.

The chain:

1. `packaging/makeself/jobs/81-netdata-runtime-check.sh` runs the freshly built agent inside the builder as a smoke test. The cleanup afterwards removed `var/lib/netdata` and `var/cache/netdata` — but not `var/log/netdata`.
2. The archive therefore ships the builder's `daemon.log`/`collector.log`/`access.log` plus the otel-plugin's `otel/v2/{logs,traces}/{wal,index,catalog}/` directories and a real `otel/v2/shared/seq_highwater` file.
3. makeself archives only files and empty leaf directories, so extraction (`tar xp` as root, on install and on every nightly auto-update) creates the missing parent directories — `otel/`, `otel/v2/`, `otel/v2/shared/` — owned `root:root`.
4. The otel-plugin runs as the `netdata` user. Its first mandatory startup write (`shared/seq_highwater.tmp`) fails with EACCES in the root-owned directory, which is fatal by design, so the agent restarts the plugin every ~10s, forever. The failure is invisible on DEB/RPM installs (they ship no `var/log` content) and re-masks itself daily because the restart counter resets on the nightly update.

Reproduced end-to-end with the published 2026-07-24 nightly artifact in a clean Ubuntu 24.04 container: extraction plus the installer's permission pass yields a root-owned `shared/` and `Permission denied` for the `netdata` user.

## Changes

- **`81-netdata-runtime-check.sh`**: clean `var/log/netdata` after the runtime check, like `var/lib` and `var/cache`. `90-prepare-archive-source.sh` already re-creates all three empty with `.keep`. Verified that job 89's `netdata -W buildinfo` writes no log content afterwards, and that the no-longer-shipped `traps/` directory is recreated at install time by `install_netdata_snmp_trap_log_dir`.
- **`install-or-update.sh`**: chown `var/log/netdata/otel` recursively back to the `netdata` user on every install/update, so installs already broken by earlier packages self-heal on their next update (the daemon only chowns the log dir itself, never the subtree).

## Verification

- Container repro against the real nightly artifact: before the repair, `netdata` cannot create `shared/seq_highwater.tmp` (the exact production failure); after the repair chown, the write succeeds.
- shellcheck: no new findings on either edited file.

Related: #23250 improved the plugin's error reporting for this failure class (the original log line showed neither operation nor path).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop static `.gz.run` packages from shipping build-machine logs and otel state, and fix `var/log/netdata/otel` ownership so the otel-plugin starts reliably on static installs. Earlier installs will self-heal on the next update.

- **Bug Fixes**
  - `81-netdata-runtime-check.sh`: clean `var/log/netdata` after the smoke test (like `var/lib` and `var/cache`) to avoid packaging logs and `otel/v2` state.
  - `install-or-update.sh`: recursively chown `var/log/netdata/otel` to `netdata:netdata` on every install/update to repair root-owned dirs from previous packages.

<sup>Written for commit 21cee329417692783687c15afaef7b626a1b98e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

