### PR TITLE
Make warnings and fatal errors more obnoxiously visible.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -454,7 +454,7 @@ cleanup() {
   if [ -z "${NO_CLEANUP}" ] && [ -n "${tmpdir}" ]; then
     cd || true
     DRY_RUN=0
-    run_as_root rm -rf "${tmpdir}"
+    run_as_root_silent rm -rf "${tmpdir}"
   fi
 }
 
@@ -562,6 +562,17 @@ run_as_root() {
   fi
 
   run ${ROOTCMD} "${@}"
+}
+
+# Only to be used in cleanup code.
+run_as_root_silent() {
+  confirm_root_support
+
+  if [ "$(id -u)" -ne "0" ]; then
+    printf >&2 "Root privileges required to run %s\n" "${*}"
+  fi
+
+  ${ROOTCMD} "${@}"
 }
 
 run_script() {

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -410,6 +410,17 @@ setup_terminal() {
   TPUT_BOLD=""
   TPUT_DIM=""
 
+  case "${COLUMNS}" in
+    "" | *[!0-9]*) TERM_WIDTH=80 ;;
+    *)
+      if [ "${COLUMNS}" -ge 0 ]; then
+        TERM_WIDTH="${COLUMNS}"
+      else
+        TERM_WIDTH="80"
+      fi
+      ;;
+  esac
+
   # Is stderr on the terminal? If not, then fail
   test -t 2 || return 1
 
@@ -468,8 +479,7 @@ deferred_warnings() {
 }
 
 fatal() {
-  width="${COLUMNS:-80}"
-  bracket="${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}$(printf "%${width}s" " " | tr " " "X")${TPUT_RESET}"
+  bracket="${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}$(printf "%${TERM_WIDTH}s" " " | tr " " "X")${TPUT_RESET}"
   printf >&2 "%s\n\n" "${bracket}"
   deferred_warnings
   printf >&2 "%s\n" "${bracket}"
@@ -602,8 +612,7 @@ run_script() {
 }
 
 warning() {
-  width="${COLUMNS:-80}"
-  bracket="${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}$(printf "%${width}s" " " | tr " " "=")${TPUT_RESET}"
+  bracket="${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}$(printf "%${TERM_WIDTH}s" " " | tr " " "=")${TPUT_RESET}"
   msg="${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*}"
   printf >&2 "%s\n%s\n%s\n" "${bracket}" "${msg}" "${bracket}"
   NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - ${*}"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -468,8 +468,17 @@ deferred_warnings() {
 }
 
 fatal() {
+  width="${COLUMNS:-80}"
+  bracket="${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}$(printf "%${width}s" " " | tr " " "X")${TPUT_RESET}"
+  printf >&2 "%s\n\n" "${bracket}"
   deferred_warnings
-  printf >&2 "%b\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${1}"
+  printf >&2 "%s\n" "${bracket}"
+  printf >&2 "%s\n" "${TPUT_BOLD} A FATAL ERROR WAS ENCOUNTERED! ${TPUT_RESET}"
+  printf >&2 "%s\n" "${TPUT_BOLD} \\/ \\/ \\/ \\/ \\/ \\/ \\/ \\/ \\/ \\/ ${TPUT_RESET}"
+  printf >&2 "\n%b\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${1}"
+  printf >&2 "%s\n" "${TPUT_BOLD} /\\ /\\ /\\ /\\ /\\ /\\ /\\ /\\ /\\ /\\ ${TPUT_RESET}"
+  printf >&2 "%s\n" "${TPUT_BOLD} A FATAL ERROR WAS ENCOUNTERED! ${TPUT_RESET}"
+  printf >&2 "%s\n" "${bracket}"
   printf >&2 "%s\n" "For community support, you can connect with us on:"
   support_list
   telemetry_event "INSTALL_FAILED" "${1}" "${2}"
@@ -582,7 +591,10 @@ run_script() {
 }
 
 warning() {
-  printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*}"
+  width="${COLUMNS:-80}"
+  bracket="${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}$(printf "%${width}s" " " | tr " " "=")${TPUT_RESET}"
+  msg="${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*}"
+  printf >&2 "%s\n%s\n%s\n" "${bracket}" "${msg}" "${bracket}"
   NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - ${*}"
 }
 


### PR DESCRIPTION
##### Summary

We’ve had recurring issues with users not paying any attention to warnings or fatal errors reported by the kickstart.sh installer script and thinking that just because it got to the end of a run that Netdata was installed without issue. This PR makes such messages significantly more obnoxious and hopefully clearly visible and present to attempt to mitigate this.

An example of what things look like with this PR:

```
 --- Using /tmp/netdata-kickstart-XXXXAAfDhb as a temporary directory. ---
 --- Checking for existing installations of Netdata... ---
 --- No existing installations of netdata found, assuming this is a fresh install. ---
================================================================================
 WARNING  Unable to determine Linux distribution for native packages.
================================================================================
XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

The following non-fatal warnings or errors were encountered:

  - Unable to determine Linux distribution for native packages.

XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 A FATAL ERROR WAS ENCOUNTERED!
 \/ \/ \/ \/ \/ \/ \/ \/ \/ \/

 ABORTED  Native packages are not available for this system, unable to install.

 /\ /\ /\ /\ /\ /\ /\ /\ /\ /\
 A FATAL ERROR WAS ENCOUNTERED!
XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
For community support, you can connect with us on:
  - GitHub: https://github.com/netdata/netdata/discussions
  - Discord: https://discord.gg/5ygS846fR6
  - Our community forums: https://community.netdata.cloud/
```

The bracketing of the error messages will automatically scale to full-width of the terminal if the terminal properly sets the `$COLUMNS` variable, otherwise it’s 80 characters wide, and the bracketing lines themselves use the same white-on-red as the `ABORTED` and  `WARNING` bits.

##### Test Plan

n/a


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make warnings and fatal errors in `kickstart.sh` hard to miss, and make cleanup silent to avoid a misleading OK on failure. Correctly handles terminal width so banners fill the screen consistently.

- **New Features**
  - Warnings render inside red banner lines that scale to terminal width using "="; validates `$COLUMNS` (numeric only) and falls back to 80.
  - Fatal errors show a prominent block with “A FATAL ERROR WAS ENCOUNTERED!” markers and wide “X” brackets; deferred warnings print first, then support links.
  - Cleanup now runs silently to avoid a final green OK after fatal errors; no change to install logic or exit behavior.

<sup>Written for commit 43e338313a779a06b98d63a042ddbae806b909b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



