### PR TITLE
Make attempting to update unsupported installs fatal in kickstart.sh.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1223,20 +1223,11 @@ handle_existing_install() {
         return 0
       elif [ "${INSTALL_TYPE}" = "unknown" ]; then
         claimonly_notice="If you just want to claim this install, you should re-run this command with the --claim-only option instead."
-        if [ "${EXISTING_INSTALL_IS_NATIVE}" -eq 1 ]; then
-          failmsg="Attempting to update an installation managed by the system package manager is known to not work in most cases. If you are trying to install the latest version of Netdata, you will need to manually uninstall it through your system package manager. ${claimonly_notice}"
-          promptmsg="Attempting to update an installation managed by the system package manager is known to not work in most cases. If you are trying to install the latest version of Netdata, you will need to manually uninstall it through your system package manager. ${claimonly_notice} Are you sure you want to continue?"
-        else
-          failmsg="We do not support trying to update or claim installations when we cannot determine the install type. You will need to uninstall the existing install using the same method you used to install it to proceed. ${claimonly_notice}"
-          promptmsg="Attempting to update an existing install with an unknown installation type is not officially supported. It may work, but it also might break your system. ${claimonly_notice} Are you sure you want to continue?"
-        fi
         if [ "${INTERACTIVE}" -eq 0 ] && [ "${ACTION}" != "claim" ]; then
-          fatal "${failmsg}" F0106
-        elif [ "${INTERACTIVE}" -eq 1 ] && [ "${ACTION}" != "claim" ]; then
-          if confirm "${promptmsg}"; then
-            progress "OK, continuing"
+          if [ "${EXISTING_INSTALL_IS_NATIVE}" -eq 1 ]; then
+            fatal "Attempting to update an installation managed by the system package manager is known to not work in most cases. If you are trying to install the latest version of Netdata, you will need to manually uninstall it through your system package manager. ${claimonly_notice}" F0106
           else
-            fatal "Cancelling update of unknown installation type at user request." F050C
+            fatal "We do not support trying to update or claim installations when we cannot determine the install type. You will need to uninstall the existing install using the same method you used to install it to proceed. ${claimonly_notice}" F0106
           fi
         fi
       fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1223,7 +1223,7 @@ handle_existing_install() {
         return 0
       elif [ "${INSTALL_TYPE}" = "unknown" ]; then
         claimonly_notice="If you just want to claim this install, you should re-run this command with the --claim-only option instead."
-        if [ "${INTERACTIVE}" -eq 0 ] && [ "${ACTION}" != "claim" ]; then
+        if [ "${ACTION}" != "claim" ]; then
           if [ "${EXISTING_INSTALL_IS_NATIVE}" -eq 1 ]; then
             fatal "Attempting to update an installation managed by the system package manager is known to not work in most cases. If you are trying to install the latest version of Netdata, you will need to manually uninstall it through your system package manager. ${claimonly_notice}" F0106
           else

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1227,7 +1227,7 @@ handle_existing_install() {
           if [ "${EXISTING_INSTALL_IS_NATIVE}" -eq 1 ]; then
             fatal "Attempting to update an installation managed by the system package manager is known to not work in most cases. If you are trying to install the latest version of Netdata, you will need to manually uninstall it through your system package manager. ${claimonly_notice}" F0106
           else
-            fatal "We do not support trying to update or claim installations when we cannot determine the install type. You will need to uninstall the existing install using the same method you used to install it to proceed. ${claimonly_notice}" F0106
+            fatal "We do not support trying to update installations when we cannot determine the install type. You will need to uninstall the existing install using the same method you used to install it to proceed. ${claimonly_notice}" F0106
           fi
         fi
       fi


### PR DESCRIPTION
##### Summary

This was never really officially supported to begin with, it just happened to work in some rare cases. However, some users don’t read the message warning them about the risk and just select yes anyway, then run into issues when things don’t work. Given this, instead of prompting the user for confirmation, just make it a fatal error.

##### Test Plan

n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make unsupported update attempts in `kickstart.sh` fatal by removing the confirmation prompt. Unknown installs can still be claimed with `--claim-only`; all update attempts abort in both interactive and non-interactive modes.

- **Migration**
  - To claim an existing install, re-run with the `--claim-only` option.
  - To update to the latest version, uninstall via your system package manager (or original install method), then reinstall.

<sup>Written for commit 7f5374fa8d80ecc5afa1ab34d04829f4834b6704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

