### PR TITLE
Fix two memory leaks on chart/dimension churn (ram + all engines)

### DIFF
--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -36,15 +36,21 @@ static bool svc_rrddim_obsolete_to_archive(RRDDIM *rd, bool chart_obsolete) {
 
 // Returns the number of dimensions actually archived this call.
 //
+// chart_obsolete: the whole chart is being torn down (RRDSET_FLAG_OBSOLETE).
+// It selects every dimension as a candidate and authorizes archiving dimensions
+// that carry no per-dimension RRDDIM_FLAG_OBSOLETE (chart-level obsoletion does
+// not set the per-dimension flag). When false, only individually-flagged
+// dimensions are candidates (the RRDSET_FLAG_OBSOLETE_DIMENSIONS path).
+//
 // Two callable shapes:
-//   1. all_dimensions == false and RRDSET_FLAG_OBSOLETE_DIMENSIONS unset:
+//   1. chart_obsolete == false and RRDSET_FLAG_OBSOLETE_DIMENSIONS unset:
 //      early-return path. Nothing scanned, flag not touched, returns 0.
 //   2. Any other case: scans the dimensions. The flag is cleared up
 //      front, then re-set at the end iff some candidate could not be
 //      archived this pass. Callers on this path can detect "all
 //      candidates archived" by reading the flag after the call.
-static inline size_t svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all_dimensions) {
-    if(!all_dimensions && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS))
+static inline size_t svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool chart_obsolete) {
+    if(!chart_obsolete && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS))
         return 0;
 
     worker_is_busy(UV_EVENT_ARCHIVE_CHART_DIMENSIONS);
@@ -58,7 +64,7 @@ static inline size_t svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all
     size_t dim_archives = 0;
 
     dfe_start_write(st->rrddim_root_index, rd) {
-        bool candidate = (all_dimensions || rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE));
+        bool candidate = (chart_obsolete || rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE));
 
         if(candidate) {
             dim_candidates++;
@@ -66,12 +72,7 @@ static inline size_t svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all
             if(rd->collector.last_collected_time.tv_sec + rrdset_free_obsolete_time_s < now) {
                 size_t references = dictionary_acquired_item_references(rd_dfe.item);
                 if(references == 1) {
-                    // all_dimensions is set only on the chart-obsolete path
-                    // (svc_rrdhost_cleanup_charts_marked_obsolete calls this with
-                    // all_dimensions=true for RRDSET_FLAG_OBSOLETE charts), so it
-                    // doubles as the chart_obsolete authorization to archive
-                    // dimensions that carry no per-dimension obsolete flag.
-                    if(svc_rrddim_obsolete_to_archive(rd, all_dimensions))
+                    if(svc_rrddim_obsolete_to_archive(rd, chart_obsolete))
                         dim_archives++;
                 }
             }
@@ -137,7 +138,7 @@ static inline size_t svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
             partial_candidates++;
 
             if(!is_replicating) {
-                archived_items += svc_rrdset_archive_obsolete_dimensions(st, false);
+                archived_items += svc_rrdset_archive_obsolete_dimensions(st, /* chart_obsolete = */ false);
 
                 // "all candidates archived" -> flag was not re-set inside.
                 if(!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS))
@@ -149,7 +150,7 @@ static inline size_t svc_rrdhost_cleanup_charts_marked_obsolete(RRDHOST *host) {
             full_candidates++;
 
             if(!is_replicating && svc_rrdset_lock_for_deletion(st, now)) {
-                archived_items += svc_rrdset_archive_obsolete_dimensions(st, true);
+                archived_items += svc_rrdset_archive_obsolete_dimensions(st, /* chart_obsolete = */ true);
 
                 if(!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS)) {
                     full_archives++;

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -2,11 +2,17 @@
 
 #include "common.h"
 
-static bool svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
+// chart_obsolete: the whole chart is being torn down (RRDSET_FLAG_OBSOLETE), so
+// every dimension must be archived/freed even though chart-level obsoletion does
+// not set RRDDIM_FLAG_OBSOLETE on the dimensions. Without this authorization the
+// per-dimension flag gate below would reject every dimension of a chart-level
+// obsoletion, the caller could never reach rrdset_free(), and the chart plus its
+// ring buffers would be retained until process exit.
+static bool svc_rrddim_obsolete_to_archive(RRDDIM *rd, bool chart_obsolete) {
     RRDSET *st = rd->rrdset;
 
-    if(rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE) && spinlock_trylock(&rd->destroy_lock)) {
-        if(!rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) {
+    if((chart_obsolete || rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) && spinlock_trylock(&rd->destroy_lock)) {
+        if(!chart_obsolete && !rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) {
             spinlock_unlock(&rd->destroy_lock);
             return false;
         }
@@ -60,7 +66,12 @@ static inline size_t svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all
             if(rd->collector.last_collected_time.tv_sec + rrdset_free_obsolete_time_s < now) {
                 size_t references = dictionary_acquired_item_references(rd_dfe.item);
                 if(references == 1) {
-                    if(svc_rrddim_obsolete_to_archive(rd))
+                    // all_dimensions is set only on the chart-obsolete path
+                    // (svc_rrdhost_cleanup_charts_marked_obsolete calls this with
+                    // all_dimensions=true for RRDSET_FLAG_OBSOLETE charts), so it
+                    // doubles as the chart_obsolete authorization to archive
+                    // dimensions that carry no per-dimension obsolete flag.
+                    if(svc_rrddim_obsolete_to_archive(rd, all_dimensions))
                         dim_archives++;
                 }
             }

--- a/src/database/ram/rrddim_mem.c
+++ b/src/database/ram/rrddim_mem.c
@@ -196,9 +196,9 @@ static void rrddim_metric_free_handle(struct mem_metric_handle *mh) {
 
 STORAGE_METRIC_HANDLE *rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *si) {
     while(true) {
-        struct mem_metric_handle *mh;
+        struct mem_metric_handle *mh = (struct mem_metric_handle *)rrddim_metric_get_by_id(si, rd->uuid);
 
-        while((mh = (struct mem_metric_handle *)rrddim_metric_get_by_id(si, rd->uuid)) == NULL) {
+        if(!mh) {
             netdata_rwlock_wrlock(&rrddim_Judy_rwlock);
             JudyAllocThreadPulseReset();
             Pvoid_t *PValue = JudyLIns(&rrddim_Judy_array, rd->uuid, PJE0);
@@ -219,6 +219,14 @@ STORAGE_METRIC_HANDLE *rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE 
                     mh = NULL;
             }
             netdata_rwlock_wrunlock(&rrddim_Judy_rwlock);
+
+            // The indexed handle is being deleted concurrently (acquire failed);
+            // retry the lookup. Do NOT re-run get_by_id here: mh already carries
+            // this caller's single reference (either refcount = 1 from the create
+            // branch, or the +1 from refcount_acquire in the else branch), and
+            // re-fetching would acquire a second reference that nothing releases.
+            if(!mh)
+                continue;
         }
 
         if(unlikely(rrddim_metric_handle_rrddim_load(mh) != rd)) {


### PR DESCRIPTION
##### Summary
- Chart-level obsoletion never freed its charts/dimensions — the per-dimension archive gate rejected every dim, so rrdset_free() was never reached. Affects all engines.
- The ram-engine get_or_create returned metric handles with refcount 2, stranding the handle and its ring buffer forever. Ram/alloc mode only.
- Both fixes preserve the query-outlives-deletion, references == 1, and replication gates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two memory leaks during chart/dimension churn. Charts now free all dimensions on obsoletion, and RAM mode no longer leaks metric handles due to double refcounts.

- **Bug Fixes**
  - Chart-level obsoletion (all engines): archive all dimensions even without per-dimension flags, allowing `rrdset_free()` to run and freeing ring buffers. Preserves query-outlives-deletion, references==1, and replication gates.
  - RAM engine `get_or_create`: remove double-acquire path that returned handles with refcount=2. Avoids re-fetch after a failed acquire, keeping a single reference and preventing leaked handles and ring buffers.

<sup>Written for commit 75c24435148b1df96728ea34204c0a3e1f2f303b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

