### PR TITLE
Fix metadata cleanup when agent is in RAM mode

### DIFF
--- a/src/daemon/config/netdata-conf-db.c
+++ b/src/daemon/config/netdata-conf-db.c
@@ -376,28 +376,43 @@ void netdata_conf_section_db(void) {
     }
 
 #ifdef ENABLE_DBENGINE
-    // Detect an actual dbengine datafile (".ndf"), not merely the directory: an
-    // empty dbengine dir left by a failed/aborted init is NOT persisted data and
-    // must not disable RAM-mode metadata cleanup. A datafile means this agent has
-    // dbengine data on disk even when currently running a non-dbengine mode, so
-    // RAM cleanup keeps dimension rows that still back that data (agent
-    // temporarily switched dbengine -> ram/alloc). Only meaningful in a
-    // dbengine-capable build; without dbengine the data can never be read back,
-    // so the flag stays false and RAM cleanup proceeds.
-    {
+    // Detect an actual dbengine datafile (".ndf") in ANY tier directory. Two
+    // reasons to scan datafiles across every tier rather than test one directory:
+    //   - an empty dbengine dir left by a failed/aborted init is NOT persisted
+    //     data and must not disable RAM-mode metadata cleanup;
+    //   - tier 0 (<cache>/dbengine) can have no datafiles while a higher tier
+    //     (<cache>/dbengine-tierN) still retains history, so a tier-0-only check
+    //     could wrongly report "no data" and delete metadata still backing
+    //     tier-N data (data loss).
+    // Iterate the compile-time maximum RRD_STORAGE_TIERS, not the configured
+    // nd_profile.storage_tiers: in a non-dbengine mode the configured count is
+    // forced to 1, but the on-disk data was written by a previous dbengine run
+    // that may have created up to RRD_STORAGE_TIERS tier directories. Tier dirs
+    // that do not exist are simply skipped.
+    // A datafile in any tier means this agent has dbengine data on disk even when
+    // currently running a non-dbengine mode, so RAM cleanup keeps dimension rows
+    // that still back that data (agent temporarily switched dbengine -> ram/alloc).
+    // Only meaningful in a dbengine-capable build; without dbengine the data can
+    // never be read back, so the flag stays false and RAM cleanup proceeds.
+    for (size_t tier = 0; tier < RRD_STORAGE_TIERS && !dbengine_datafiles_present; tier++) {
         char dbenginepath[FILENAME_MAX + 1];
-        snprintfz(dbenginepath, sizeof(dbenginepath) - 1, "%s/dbengine", netdata_configured_cache_dir);
+        if (tier == 0)
+            snprintfz(dbenginepath, sizeof(dbenginepath) - 1, "%s/dbengine", netdata_configured_cache_dir);
+        else
+            snprintfz(dbenginepath, sizeof(dbenginepath) - 1, "%s/dbengine-tier%zu", netdata_configured_cache_dir, tier);
+
         DIR *dir = opendir(dbenginepath);
-        if (dir) {
-            struct dirent *de;
-            while ((de = readdir(dir))) {
-                if (strendswith(de->d_name, ".ndf")) { // DATAFILE_EXTENSION
-                    dbengine_datafiles_present = true;
-                    break;
-                }
+        if (!dir)
+            continue;
+
+        struct dirent *de;
+        while ((de = readdir(dir))) {
+            if (strendswith(de->d_name, ".ndf")) { // DATAFILE_EXTENSION
+                dbengine_datafiles_present = true;
+                break;
             }
-            closedir(dir);
         }
+        closedir(dir);
     }
 #endif
 

--- a/src/daemon/config/netdata-conf-db.c
+++ b/src/daemon/config/netdata-conf-db.c
@@ -407,7 +407,13 @@ void netdata_conf_section_db(void) {
 
         struct dirent *de;
         while ((de = readdir(dir))) {
-            if (strendswith(de->d_name, ".ndf")) { // DATAFILE_EXTENSION
+            // Validate the name exactly as dbengine generates and scans it
+            // ("datafile-<tier>-<fileno>.ndf"), using the same sscanf template as
+            // scan_data_files(). Requiring both numeric fields to parse means an
+            // unrelated *.ndf entry is not mistaken for persisted data.
+            unsigned int df_tier, df_fileno;
+            if (sscanf(de->d_name, DATAFILE_PREFIX RRDENG_FILE_NUMBER_SCAN_TMPL DATAFILE_EXTENSION,
+                       &df_tier, &df_fileno) == 2) {
                 dbengine_datafiles_present = true;
                 break;
             }

--- a/src/daemon/config/netdata-conf-db.c
+++ b/src/daemon/config/netdata-conf-db.c
@@ -391,7 +391,7 @@ void netdata_conf_section_db(void) {
         if (dir) {
             struct dirent *de;
             while ((de = readdir(dir))) {
-                if (strstr(de->d_name, ".ndf")) { // DATAFILE_EXTENSION
+                if (strendswith(de->d_name, ".ndf")) { // DATAFILE_EXTENSION
                     dbengine_datafiles_present = true;
                     break;
                 }

--- a/src/daemon/config/netdata-conf-db.c
+++ b/src/daemon/config/netdata-conf-db.c
@@ -375,16 +375,31 @@ void netdata_conf_section_db(void) {
         }
     }
 
-    // The dbengine directory is created only by dbengine initialization, so its
-    // presence means this agent has dbengine data on disk even if it is currently
-    // running a non-dbengine memory mode. RAM-mode metadata cleanup uses this to
-    // avoid deleting dimension rows that still back on-disk dbengine data (agent
-    // temporarily switched dbengine -> ram/alloc).
+#ifdef ENABLE_DBENGINE
+    // Detect an actual dbengine datafile (".ndf"), not merely the directory: an
+    // empty dbengine dir left by a failed/aborted init is NOT persisted data and
+    // must not disable RAM-mode metadata cleanup. A datafile means this agent has
+    // dbengine data on disk even when currently running a non-dbengine mode, so
+    // RAM cleanup keeps dimension rows that still back that data (agent
+    // temporarily switched dbengine -> ram/alloc). Only meaningful in a
+    // dbengine-capable build; without dbengine the data can never be read back,
+    // so the flag stays false and RAM cleanup proceeds.
     {
         char dbenginepath[FILENAME_MAX + 1];
         snprintfz(dbenginepath, sizeof(dbenginepath) - 1, "%s/dbengine", netdata_configured_cache_dir);
-        dbengine_datafiles_present = (access(dbenginepath, F_OK) == 0);
+        DIR *dir = opendir(dbenginepath);
+        if (dir) {
+            struct dirent *de;
+            while ((de = readdir(dir))) {
+                if (strstr(de->d_name, ".ndf")) { // DATAFILE_EXTENSION
+                    dbengine_datafiles_present = true;
+                    break;
+                }
+            }
+            closedir(dir);
+        }
     }
+#endif
 
     // ------------------------------------------------------------------------
     // get default database size

--- a/src/daemon/config/netdata-conf-db.c
+++ b/src/daemon/config/netdata-conf-db.c
@@ -7,6 +7,7 @@
 int default_rrd_history_entries = RRD_DEFAULT_HISTORY_ENTRIES;
 
 bool dbengine_enabled = false; // will become true if and when dbengine is initialized
+bool dbengine_datafiles_present = false; // detected at startup, regardless of the configured memory mode
 bool dbengine_use_direct_io = true;
 static size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS] = {1, 60, 60, 60, 60};
 static time_t storage_tiers_retention_time_s[RRD_STORAGE_TIERS] = {14 * DAYS, 90 * DAYS, 2 * 365 * DAYS, 2 * 365 * DAYS, 2 * 365 * DAYS};
@@ -372,6 +373,17 @@ void netdata_conf_section_db(void) {
             netdata_log_error("Invalid memory mode '%s' given. Using '%s'", mode, rrd_memory_mode_name(default_rrd_memory_mode));
             inicfg_set(&netdata_config, CONFIG_SECTION_DB, "db", rrd_memory_mode_name(default_rrd_memory_mode));
         }
+    }
+
+    // The dbengine directory is created only by dbengine initialization, so its
+    // presence means this agent has dbengine data on disk even if it is currently
+    // running a non-dbengine memory mode. RAM-mode metadata cleanup uses this to
+    // avoid deleting dimension rows that still back on-disk dbengine data (agent
+    // temporarily switched dbengine -> ram/alloc).
+    {
+        char dbenginepath[FILENAME_MAX + 1];
+        snprintfz(dbenginepath, sizeof(dbenginepath) - 1, "%s/dbengine", netdata_configured_cache_dir);
+        dbengine_datafiles_present = (access(dbenginepath, F_OK) == 0);
     }
 
     // ------------------------------------------------------------------------

--- a/src/daemon/config/netdata-conf-db.h
+++ b/src/daemon/config/netdata-conf-db.h
@@ -6,6 +6,7 @@
 #include "libnetdata/libnetdata.h"
 
 extern bool dbengine_enabled;
+extern bool dbengine_datafiles_present; // dbengine datafiles exist on disk, even if the agent is not currently running dbengine
 extern bool dbengine_use_direct_io;
 
 extern int default_rrd_history_entries;

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -213,8 +213,20 @@ static void rrddim_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 
     netdata_log_debug(D_RRD_CALLS, "rrddim_free() %s.%s", rrdset_name(st), rrddim_name(rd));
 
-    if (!rrddim_finalize_collection_and_check_retention(rd) && rd->rrd_memory_mode == RRD_DB_MODE_DBENGINE) {
-        /* This metric has no data and no references */
+    // finalize collection first (tears down tier collect handles); its return
+    // means "the db still has retention for this dimension".
+    bool has_db_retention = rrddim_finalize_collection_and_check_retention(rd);
+
+    // Delete the dimension's SQLite metadata when freeing it leaves no queryable
+    // data behind:
+    //   - dbengine: only when no on-disk retention remains;
+    //   - ram/alloc/none: all use the in-memory rrddim storage backend, so data
+    //     lives only in RAM and a freed dimension is always orphaned (the
+    //     retention check above misreports these modes as retained).
+    if ((rd->rrd_memory_mode == RRD_DB_MODE_DBENGINE && !has_db_retention) ||
+        rd->rrd_memory_mode == RRD_DB_MODE_RAM ||
+        rd->rrd_memory_mode == RRD_DB_MODE_ALLOC ||
+        rd->rrd_memory_mode == RRD_DB_MODE_NONE) {
         metaqueue_delete_dimension_uuid(uuidmap_uuid_ptr(rd->uuid));
     }
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2389,7 +2389,13 @@ static void do_pending_uuid_deletion(struct meta_config_s *config, struct judy_l
 
         nd_uuid_t *uuid = *Pvalue;
         if (likely(!SHUTDOWN_REQUESTED(config))) {
-            if (dimension_can_be_deleted(uuid, NULL, false))
+            // Every queued uuid came from the free path (rrddim_delete_callback)
+            // for a dimension with no persistent retention. When dbengine is
+            // disabled, dimension_can_be_deleted() always returns false, so a
+            // pure-RAM agent could never clean up; trust the free-path enqueue in
+            // that case. dbengine-enabled agents keep the retention re-check,
+            // which guards the replication/backfill race.
+            if (!dbengine_enabled || dimension_can_be_deleted(uuid, NULL, false))
                 delete_dimension_uuid(uuid, NULL, false);
         }
     }

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2391,11 +2391,14 @@ static void do_pending_uuid_deletion(struct meta_config_s *config, struct judy_l
         if (likely(!SHUTDOWN_REQUESTED(config))) {
             // Every queued uuid came from the free path (rrddim_delete_callback)
             // for a dimension with no persistent retention. When dbengine is
-            // disabled, dimension_can_be_deleted() always returns false, so a
-            // pure-RAM agent could never clean up; trust the free-path enqueue in
-            // that case. dbengine-enabled agents keep the retention re-check,
-            // which guards the replication/backfill race.
-            if (!dbengine_enabled || dimension_can_be_deleted(uuid, NULL, false))
+            // disabled AND there are no dbengine datafiles on disk, this is a
+            // pure-RAM agent that could never clean up otherwise, so trust the
+            // free-path enqueue. If dbengine datafiles exist (an agent temporarily
+            // switched dbengine -> ram/alloc), the uuid may still back on-disk
+            // data, so keep the row. dbengine-enabled agents keep the retention
+            // re-check, which also guards the replication/backfill race.
+            if ((!dbengine_enabled && !dbengine_datafiles_present) ||
+                dimension_can_be_deleted(uuid, NULL, false))
                 delete_dimension_uuid(uuid, NULL, false);
         }
     }

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2718,16 +2718,23 @@ static void start_metadata_hosts(uv_work_t *req)
     // still has to release the worker-owned Judy list on that path.
     store_ctx_cleanup_list(config, (struct judy_list_t *)worker->pending_ctx_cleanup_list);
 
+    // Process queued dimension deletions BEFORE storing host metadata. A
+    // dimension can be freed (which enqueues its uuid here) and then re-created
+    // reusing the same uuid; if we stored first and deleted after, the queued
+    // delete would wipe the freshly stored metadata of the now-live dimension
+    // (and RRDSET_FLAG_METADATA_UPDATE would already be cleared, so it would not
+    // be re-stored). Deleting first and storing after keeps the live dimension's
+    // metadata.
+    // This helper already skips dimension deletion once shutdown starts, but it
+    // still has to release the worker-owned Judy list on that path.
+    do_pending_uuid_deletion(config, (struct judy_list_t *)worker->pending_uuid_deletion);
+
     worker_is_busy(UV_EVENT_METADATA_STORE);
 
     store_hosts_metadata(config, true, false);
 
     COMPUTE_DURATION(report_duration, "us", all_started_ut, now_monotonic_usec());
     nd_log_daemon(NDLP_DEBUG, "Checking all hosts completed in %s", report_duration);
-
-    // This helper already skips dimension deletion once shutdown starts, but it
-    // still has to release the worker-owned Judy list on that path.
-    do_pending_uuid_deletion(config, (struct judy_list_t *)worker->pending_uuid_deletion);
 
     if (!SHUTDOWN_REQUESTED(config)) {
         run_metadata_cleanup(config);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2392,8 +2392,9 @@ static void do_pending_uuid_deletion(struct meta_config_s *config, struct judy_l
             // Every queued uuid came from the free path (rrddim_delete_callback)
             // for a dimension with no persistent retention. When dbengine is
             // disabled AND there are no dbengine datafiles on disk, this is a
-            // pure-RAM agent that could never clean up otherwise, so trust the
-            // free-path enqueue. If dbengine datafiles exist (an agent temporarily
+            // pure in-memory agent (ram/alloc/none) that could never clean up
+            // otherwise, so trust the free-path enqueue. If dbengine datafiles
+            // exist (an agent temporarily
             // switched dbengine -> ram/alloc), the uuid may still back on-disk
             // data, so keep the row. dbengine-enabled agents keep the retention
             // re-check, which also guards the replication/backfill race.
@@ -2722,7 +2723,7 @@ static void start_metadata_hosts(uv_work_t *req)
     // dimension can be freed (which enqueues its uuid here) and then re-created
     // reusing the same uuid; if we stored first and deleted after, the queued
     // delete would wipe the freshly stored metadata of the now-live dimension
-    // (and RRDSET_FLAG_METADATA_UPDATE would already be cleared, so it would not
+    // (and RRDDIM_FLAG_METADATA_UPDATE would already be cleared, so it would not
     // be re-stored). Deleting first and storing after keeps the live dimension's
     // metadata.
     // This helper already skips dimension deletion once shutdown starts, but it


### PR DESCRIPTION
##### Summary
- Freed dimensions in ram/alloc/none modes never deleted their SQLite metadata, so netdata-meta.db grew forever under chart churn (followup PR will eliminate uneeded db store all together)
- Both delete paths were dbengine-only, so non-dbengine dimensions were never cleaned up.
- Fix: delete the metadata on free for the in-memory modes too.
- No change to dbengine behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale SQLite metadata cleanup for freed dimensions in RAM/ALLOC/NONE modes so netdata-meta.db doesn’t grow under chart churn, and safeguards `dbengine`-backed metadata when the agent temporarily runs in non-`dbengine` mode. Adds strict cross-tier detection of real `dbengine` datafiles to avoid false positives.

- **Bug Fixes**
  - Delete dimension metadata on free for RAM/ALLOC/NONE; for `dbengine`, delete only when no on-disk retention remains.
  - At startup, scan all `dbengine` tier directories and detect real datafiles using the exact filename template (not just “.ndf” suffix); when `dbengine` is disabled, delete queued dimensions only if no datafiles exist (protects temporary `dbengine` → RAM/ALLOC switches and tier-0-empty cases).
  - Process queued dimension deletions before storing host metadata to avoid wiping metadata for dimensions re-created with the same UUID.

<sup>Written for commit 60115a69c7bb5cd05437e1d772f5ea9ff7cd211d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

