### PR TITLE
fix(go.d/functions): clamp over-limit function timeouts instead of 400

### DIFF
--- a/src/go/plugin/agent/jobmgr/internal/jobmgrtest/agent_driver.go
+++ b/src/go/plugin/agent/jobmgr/internal/jobmgrtest/agent_driver.go
@@ -683,11 +683,12 @@ func runAgentFunctionTimeoutBoundaries(ctx context.Context) error {
 				status  int
 			}{
 				"negative":         {timeout: "-1", status: 400},
-				"one over maximum": {timeout: "901", status: 400},
 				"integer overflow": {timeout: "9223372036854775808", status: 400},
 				"zero":             {timeout: "0", status: 200},
 				"one second":       {timeout: "1", status: 200},
-				"maximum":          {timeout: "900", status: 200},
+				"at maximum":       {timeout: "120", status: 200},
+				"over maximum":     {timeout: "121", status: 200},
+				"milliseconds":     {timeout: "60000", status: 200},
 			}
 			for name, test := range tests {
 				uid := "jobmgrtest-timeout-" + strings.ReplaceAll(name, " ", "-")

--- a/src/go/plugin/framework/functions/capsule.go
+++ b/src/go/plugin/framework/functions/capsule.go
@@ -18,7 +18,7 @@ const (
 	MaximumInputLineBytes   = 64 * 1024
 	MaximumCommandLineBytes = 15_487
 	MaximumInputBodyBytes   = 20 * 1024 * 1024
-	MaximumFunctionTimeout  = 15 * time.Minute
+	MaximumFunctionTimeout  = 2 * time.Minute
 	initialBodyCapacity     = 64 * 1024
 )
 
@@ -254,9 +254,13 @@ func parseCapsuleCall(fields []string) (Call, bool, error) {
 		return Call{}, false, errors.New("Function ingress: payload content type is missing")
 	}
 	timeoutSeconds, err := strconv.ParseInt(fields[2], 10, 64)
-	if err != nil || timeoutSeconds < 0 ||
-		timeoutSeconds > int64(MaximumFunctionTimeout/time.Second) {
+	if err != nil || timeoutSeconds < 0 {
 		return Call{}, false, errors.New("Function ingress: invalid timeout")
+	}
+	// Callers may send an unset (0) or wrong-unit (e.g. milliseconds) timeout;
+	// clamp to the maximum and proceed rather than failing the whole call.
+	if maxSeconds := int64(MaximumFunctionTimeout / time.Second); timeoutSeconds == 0 || timeoutSeconds > maxSeconds {
+		timeoutSeconds = maxSeconds
 	}
 	callFields := strings.Fields(fields[3])
 	if len(callFields) == 0 {

--- a/src/go/plugin/framework/functions/capsule.go
+++ b/src/go/plugin/framework/functions/capsule.go
@@ -15,10 +15,10 @@ import (
 )
 
 const (
-	MaximumInputLineBytes   = 64 * 1024
+	maximumInputLineBytes   = 64 * 1024
 	MaximumCommandLineBytes = 15_487
 	MaximumInputBodyBytes   = 20 * 1024 * 1024
-	MaximumFunctionTimeout  = 2 * time.Minute
+	maximumFunctionTimeout  = 2 * time.Minute
 	initialBodyCapacity     = 64 * 1024
 )
 
@@ -36,9 +36,9 @@ type Call struct {
 	HasPayload  bool
 }
 
-// ReadReturnGate fences reader returns while process ingress changes Agent
+// readReturnGate fences reader returns while process ingress changes Agent
 // generation.
-type ReadReturnGate interface {
+type readReturnGate interface {
 	AcquireInputRead(context.Context) (bool, error)
 	ReleaseInputRead()
 }
@@ -71,17 +71,17 @@ type payloadState struct {
 
 func NewInputCapsule(reader io.Reader) (*InputCapsule, error) {
 	if reader == nil {
-		return nil, errors.New("Function ingress: nil input reader")
+		return nil, errors.New("function ingress: nil input reader")
 	}
 	return &InputCapsule{reader: reader}, nil
 }
 
 func (capsule *InputCapsule) Run(ctx context.Context, consumer Consumer) error {
 	if ctx == nil || consumer == nil {
-		return errors.New("Function ingress: invalid run")
+		return errors.New("function ingress: invalid run")
 	}
-	reader := bufio.NewReaderSize(capsule.reader, MaximumInputLineBytes+1)
-	gate, _ := consumer.(ReadReturnGate)
+	reader := bufio.NewReaderSize(capsule.reader, maximumInputLineBytes+1)
+	gate, _ := consumer.(readReturnGate)
 	for {
 		segment, readErr := reader.ReadSlice('\n')
 		if gate != nil {
@@ -94,7 +94,7 @@ func (capsule *InputCapsule) Run(ctx context.Context, consumer Consumer) error {
 					if errors.Is(readErr, io.EOF) {
 						return nil
 					}
-					return fmt.Errorf("Function ingress: read after containment: %w", readErr)
+					return fmt.Errorf("function ingress: read after containment: %w", readErr)
 				}
 				continue
 			}
@@ -116,7 +116,7 @@ func (capsule *InputCapsule) consumeRead(ctx context.Context, consumer Consumer,
 	complete := !errors.Is(readErr, bufio.ErrBufferFull)
 	if capsule.payload != nil {
 		if errors.Is(readErr, io.EOF) && (len(segment) == 0 || !hasLF(segment)) {
-			return false, false, errors.Join(errors.New("Function ingress: unterminated payload"), capsule.abortPayload())
+			return false, false, errors.Join(errors.New("function ingress: unterminated payload"), capsule.abortPayload())
 		}
 		quit, handleErr := capsule.handlePayloadSegment(ctx, consumer, segment, complete)
 		if handleErr != nil {
@@ -137,14 +137,14 @@ func (capsule *InputCapsule) consumeRead(ctx context.Context, consumer Consumer,
 	} else if !complete {
 		uid := rejectionUID(string(segment))
 		if uid == "" {
-			return false, false, errors.New("Function ingress: oversized line lacks safe UID")
+			return false, false, errors.New("function ingress: oversized line lacks safe UID")
 		}
 		capsule.discarding = true
 		capsule.discardingUID = strings.Clone(uid)
 	} else if len(segment) > 0 {
 		line, _, terminated := splitLine(segment)
 		if !terminated {
-			return false, false, errors.New("Function ingress: unterminated line")
+			return false, false, errors.New("function ingress: unterminated line")
 		}
 		if len(line) > MaximumCommandLineBytes {
 			if uid := rejectionUID(string(line)); uid != "" {
@@ -153,7 +153,7 @@ func (capsule *InputCapsule) consumeRead(ctx context.Context, consumer Consumer,
 				}
 				return false, false, nil
 			}
-			return false, false, errors.New("Function ingress: oversized command lacks safe UID")
+			return false, false, errors.New("function ingress: oversized command lacks safe UID")
 		}
 		quit, handleErr := capsule.handleCommandLine(ctx, consumer, string(line))
 		if handleErr != nil {
@@ -173,7 +173,7 @@ func (capsule *InputCapsule) consumeRead(ctx context.Context, consumer Consumer,
 		if errors.Is(readErr, io.EOF) {
 			return false, true, nil
 		}
-		return false, false, fmt.Errorf("Function ingress: read: %w", readErr)
+		return false, false, fmt.Errorf("function ingress: read: %w", readErr)
 	}
 	return false, false, nil
 }
@@ -244,27 +244,27 @@ func rejectionUID(line string) string {
 
 func parseCapsuleCall(fields []string) (Call, bool, error) {
 	if len(fields) != 6 && len(fields) != 7 {
-		return Call{}, false, errors.New("Function ingress: invalid command")
+		return Call{}, false, errors.New("function ingress: invalid command")
 	}
 	payload := fields[0] == "FUNCTION_PAYLOAD"
 	if fields[0] != "FUNCTION" && !payload {
-		return Call{}, false, errors.New("Function ingress: invalid command")
+		return Call{}, false, errors.New("function ingress: invalid command")
 	}
 	if payload && len(fields) != 7 {
-		return Call{}, false, errors.New("Function ingress: payload content type is missing")
+		return Call{}, false, errors.New("function ingress: payload content type is missing")
 	}
 	timeoutSeconds, err := strconv.ParseInt(fields[2], 10, 64)
 	if err != nil || timeoutSeconds < 0 {
-		return Call{}, false, errors.New("Function ingress: invalid timeout")
+		return Call{}, false, errors.New("function ingress: invalid timeout")
 	}
 	// Callers may send an unset (0) or wrong-unit (e.g. milliseconds) timeout;
 	// clamp to the maximum and proceed rather than failing the whole call.
-	if maxSeconds := int64(MaximumFunctionTimeout / time.Second); timeoutSeconds == 0 || timeoutSeconds > maxSeconds {
+	if maxSeconds := int64(maximumFunctionTimeout / time.Second); timeoutSeconds == 0 || timeoutSeconds > maxSeconds {
 		timeoutSeconds = maxSeconds
 	}
 	callFields := strings.Fields(fields[3])
 	if len(callFields) == 0 {
-		return Call{}, false, errors.New("Function ingress: empty call")
+		return Call{}, false, errors.New("function ingress: empty call")
 	}
 	call := Call{
 		UID: fields[1], Timeout: time.Duration(timeoutSeconds) * time.Second,
@@ -285,7 +285,7 @@ func (capsule *InputCapsule) handlePayloadSegment(ctx context.Context, consumer 
 		var terminated bool
 		content, ending, terminated = splitLine(segment)
 		if !terminated {
-			return false, errors.New("Function ingress: unterminated payload line")
+			return false, errors.New("function ingress: unterminated payload line")
 		}
 	}
 	if complete && !state.lineStarted {
@@ -300,7 +300,7 @@ func (capsule *InputCapsule) handlePayloadSegment(ctx context.Context, consumer 
 		case bytes.HasPrefix(content, []byte("FUNCTION_CANCEL")):
 			fields := strings.Fields(string(content))
 			if len(fields) != 2 || fields[0] != "FUNCTION_CANCEL" {
-				return false, errors.New("Function ingress: invalid payload cancel")
+				return false, errors.New("function ingress: invalid payload cancel")
 			}
 			if fields[1] == state.call.UID {
 				uid := state.call.UID
@@ -434,16 +434,16 @@ func tokenize(line string) ([]string, error) {
 			}
 		}
 		if end == len(line) {
-			return nil, errors.New("Function ingress: unterminated quote")
+			return nil, errors.New("function ingress: unterminated quote")
 		}
 		value, err := strconv.Unquote(line[offset : end+1])
 		if err != nil {
-			return nil, errors.New("Function ingress: invalid quoted field")
+			return nil, errors.New("function ingress: invalid quoted field")
 		}
 		fields = append(fields, value)
 		offset = end + 1
 		if offset < len(line) && line[offset] != ' ' {
-			return nil, errors.New("Function ingress: missing field separator")
+			return nil, errors.New("function ingress: missing field separator")
 		}
 	}
 	return fields, nil

--- a/src/go/plugin/framework/functions/capsule_test.go
+++ b/src/go/plugin/framework/functions/capsule_test.go
@@ -34,7 +34,7 @@ func TestInputCapsuleParsesFunctionCancelAndQuit(t *testing.T) {
 
 func TestInputCapsuleResynchronizesSafeUIDHeaderErrors(t *testing.T) {
 	consumer := &recordingCapsuleConsumer{}
-	oversized := "FUNCTION oversized 30 \"" + strings.Repeat("x", MaximumInputLineBytes) + "\" 0xFFFF \"source\"\n"
+	oversized := "FUNCTION oversized 30 \"" + strings.Repeat("x", maximumInputLineBytes) + "\" 0xFFFF \"source\"\n"
 	input := "FUNCTION bad-time nope \"x\" 0xFFFF \"source\"\n" + oversized +
 		"FUNCTION good 30 \"perf:work-001 mode:F token:good\" 0xFFFF \"source\"\nQUIT\n"
 	capsule, err := NewInputCapsule(strings.NewReader(input))
@@ -101,11 +101,11 @@ func TestInputCapsuleCommandLineAndTimeoutBoundaries(t *testing.T) {
 		timeout time.Duration
 	}{
 		{uid: "line-exact", timeout: 30 * time.Second},
-		{uid: "timeout-zero", timeout: MaximumFunctionTimeout},
+		{uid: "timeout-zero", timeout: maximumFunctionTimeout},
 		{uid: "timeout-one", timeout: time.Second},
-		{uid: "timeout-at-max", timeout: MaximumFunctionTimeout},
-		{uid: "timeout-over", timeout: MaximumFunctionTimeout},
-		{uid: "timeout-millis", timeout: MaximumFunctionTimeout},
+		{uid: "timeout-at-max", timeout: maximumFunctionTimeout},
+		{uid: "timeout-over", timeout: maximumFunctionTimeout},
+		{uid: "timeout-millis", timeout: maximumFunctionTimeout},
 	}
 	if len(consumer.calls) != len(wantAccepted) {
 		t.Fatalf("accepted count differs: got=%d want=%d calls=%#v", len(consumer.calls), len(wantAccepted), consumer.calls)

--- a/src/go/plugin/framework/functions/capsule_test.go
+++ b/src/go/plugin/framework/functions/capsule_test.go
@@ -80,11 +80,12 @@ func TestInputCapsuleCommandLineAndTimeoutBoundaries(t *testing.T) {
 	overLine := capsuleFunctionLineOfLength(t, "line-over", 30, MaximumCommandLineBytes+1)
 	input := exactLine + "\n" + overLine + "\n" +
 		"FUNCTION timeout-negative -1 \"perf:work\" 0xFFFF \"source\"\n" +
-		"FUNCTION timeout-over 901 \"perf:work\" 0xFFFF \"source\"\n" +
 		"FUNCTION timeout-overflow 9223372036854775808 \"perf:work\" 0xFFFF \"source\"\n" +
 		"FUNCTION timeout-zero 0 \"perf:work\" 0xFFFF \"source\"\n" +
 		"FUNCTION timeout-one 1 \"perf:work\" 0xFFFF \"source\"\n" +
-		"FUNCTION timeout-max 900 \"perf:work\" 0xFFFF \"source\"\nQUIT\n"
+		"FUNCTION timeout-at-max 120 \"perf:work\" 0xFFFF \"source\"\n" +
+		"FUNCTION timeout-over 121 \"perf:work\" 0xFFFF \"source\"\n" +
+		"FUNCTION timeout-millis 60000 \"perf:work\" 0xFFFF \"source\"\nQUIT\n"
 	consumer := &recordingCapsuleConsumer{}
 	capsule, err := NewInputCapsule(strings.NewReader(input))
 	if err != nil {
@@ -93,17 +94,31 @@ func TestInputCapsuleCommandLineAndTimeoutBoundaries(t *testing.T) {
 	if err := capsule.Run(context.Background(), consumer); err != nil {
 		t.Fatal(err)
 	}
-	if len(consumer.calls) != 4 ||
-		consumer.calls[0].UID != "line-exact" ||
-		consumer.calls[1].Timeout != 0 ||
-		consumer.calls[2].Timeout != time.Second ||
-		consumer.calls[3].Timeout != MaximumFunctionTimeout {
-		t.Fatalf("accepted command boundaries differ: %#v", consumer.calls)
+	// Unset (0) and any value above the maximum clamp to MaximumFunctionTimeout;
+	// 1..max pass through unchanged.
+	wantAccepted := []struct {
+		uid     string
+		timeout time.Duration
+	}{
+		{uid: "line-exact", timeout: 30 * time.Second},
+		{uid: "timeout-zero", timeout: MaximumFunctionTimeout},
+		{uid: "timeout-one", timeout: time.Second},
+		{uid: "timeout-at-max", timeout: MaximumFunctionTimeout},
+		{uid: "timeout-over", timeout: MaximumFunctionTimeout},
+		{uid: "timeout-millis", timeout: MaximumFunctionTimeout},
+	}
+	if len(consumer.calls) != len(wantAccepted) {
+		t.Fatalf("accepted count differs: got=%d want=%d calls=%#v", len(consumer.calls), len(wantAccepted), consumer.calls)
+	}
+	for i, want := range wantAccepted {
+		if consumer.calls[i].UID != want.uid || consumer.calls[i].Timeout != want.timeout {
+			t.Fatalf("accepted call %d differs: got uid=%q timeout=%v want uid=%q timeout=%v",
+				i, consumer.calls[i].UID, consumer.calls[i].Timeout, want.uid, want.timeout)
+		}
 	}
 	wantRejected := []recordedCapsuleRejection{
 		{uid: "line-over", status: 400},
 		{uid: "timeout-negative", status: 400},
-		{uid: "timeout-over", status: 400},
 		{uid: "timeout-overflow", status: 400},
 	}
 	if fmt.Sprint(consumer.rejections) != fmt.Sprint(wantRejected) || !consumer.quit {


### PR DESCRIPTION
##### Summary

The function protocol parser rejected any FUNCTION call whose timeout exceeded the maximum, returning 400 Bad Request. Netdata Cloud sends the timeout in milliseconds while the wire contract is seconds, so ordinary timeouts read as huge values and were rejected.

Lower the maximum to 2 minutes and clamp instead of reject: an unset (0) or over-limit timeout is capped at the maximum and the call proceeds.

Negative and non-numeric/overflow timeouts still return 400; values within range pass through unchanged.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp over-limit function timeouts and lower the maximum to 2 minutes to stop 400s when Cloud sends millisecond values. Calls with 0 or too-large timeouts now run using the capped value; only negative or non-numeric/overflow timeouts return 400.

- **Bug Fixes**
  - Clamp unset (0) and over-limit timeouts to a 2-minute max; 1..120s pass through; negative and overflow still 400.
  - Prevent rejection when Cloud sends milliseconds; wire contract remains seconds.
  - Updated tests and agent driver to cover clamping and millisecond inputs.

- **Refactors**
  - Unexported internal constants/interfaces and normalized error messages; no behavior change beyond timeout rules.

<sup>Written for commit 2d0b033e665b8cc7ddaa6c139f8af0a5ee901d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

