### PR TITLE
fix(daemon): propagate ephemeral node marking to Netdata Cloud

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -410,7 +410,17 @@ static int remove_ephemeral_host(BUFFER *wb, const char *machine_guid, bool repo
         marked = true;
     }
 
-    sql_set_host_label(&host->host_id.uuid, "_is_ephemeral", "true");
+    // the node info we send below transmits host->rrdlabels as the node's complete
+    // label set, so the in-memory label has to change too - the host_label row is
+    // only read back at startup. Archived hosts are created without labels, so load
+    // the existing ones instead of starting an empty set, which would wipe every
+    // other label of this node on the other side.
+    if (!host->rrdlabels)
+        host->rrdlabels = sql_load_host_labels(&host->host_id.uuid);
+
+    marked |= rrdlabels_add_changed(host->rrdlabels, HOST_LABEL_IS_EPHEMERAL, "true", RRDLABEL_SRC_CONFIG);
+
+    sql_set_host_label(&host->host_id.uuid, HOST_LABEL_IS_EPHEMERAL, "true");
     pulse_host_status(host, 0, 0);
 
     if (marked)

--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -410,21 +410,29 @@ static int remove_ephemeral_host(BUFFER *wb, const char *machine_guid, bool repo
         marked = true;
     }
 
-    // the node info we send below transmits host->rrdlabels as the node's complete
-    // label set, so the in-memory label has to change too - the host_label row is
-    // only read back at startup. Archived hosts are created without labels, so load
-    // the existing ones instead of starting an empty set, which would wipe every
-    // other label of this node on the other side.
-    if (!host->rrdlabels)
-        host->rrdlabels = sql_load_host_labels(&host->host_id.uuid);
-
-    marked |= rrdlabels_add_changed(host->rrdlabels, HOST_LABEL_IS_EPHEMERAL, "true", RRDLABEL_SRC_CONFIG);
+    // host->rrdlabels is the copy that matters: build_node_info() transmits it as the
+    // node's complete label set, and meta_store_host_labels() rewrites the host_label
+    // rows from it. Updating only the row below leaves the cloud believing the node is
+    // permanent, and lets a later metadata store revert that row. Update the dictionary
+    // in place - RRDLABELS is internally locked, while replacing the pointer would race
+    // readers that assume it stays valid for the lifetime of the host.
+    bool label_changed = host->rrdlabels &&
+        rrdlabels_add_changed(host->rrdlabels, HOST_LABEL_IS_EPHEMERAL, "true", RRDLABEL_SRC_CONFIG);
+    marked |= label_changed;
 
     sql_set_host_label(&host->host_id.uuid, HOST_LABEL_IS_EPHEMERAL, "true");
     pulse_host_status(host, 0, 0);
 
-    if (marked)
+    // only a change in the transmitted labels needs an update; a host that has none in
+    // memory gets no update at all, because that would publish an empty set and drop
+    // every other label this node has
+    if (label_changed)
         send_node_info_with_wait(host);
+    else if (!host->rrdlabels)
+        nd_log_daemon(NDLP_WARNING,
+                      "Node '%s' (machine guid: %s) has no labels in memory - "
+                      "could not inform Netdata Cloud that it is ephemeral",
+                      rrdhost_hostname(host), host->machine_guid);
 
     if (unregister) {
         send_node_update_with_wait(host, 0, 0);


### PR DESCRIPTION
##### Summary

`netdatacli mark-stale-nodes-ephemeral` and `netdatacli remove-stale-node` report success but tell Netdata Cloud the opposite of what the operator asked for.

`remove_ephemeral_host()` records the ephemeral state in three places, and the one it transmits is the one it never updated:

- it sets `RRDHOST_OPTION_EPHEMERAL_HOST` on the host,
- it writes `_is_ephemeral=true` into the `host_label` table via `sql_set_host_label()`, which is only read back at startup,
- it then calls `send_node_info_with_wait()`, and `build_node_info()` transmits `host->rrdlabels` (`src/database/sqlite/sqlite_aclk_node.c:85`).

For a streamed child, `host->rrdlabels` holds `_is_ephemeral="false"`, written explicitly by `pluginsd_update_host_ephemerality()` (`src/plugins.d/pluginsd_parser.c:194-207`). Nothing in the CLI path touches that dictionary, so the `UpdateNodeInfo` message sent by the command carries `_is_ephemeral="false"` at the exact moment the command is trying to say `true`. The value only becomes correct after an Agent restart, when `load_archived_host_from_row()` reloads labels from SQLite (`src/database/sqlite/sqlite_aclk.c:200`).

The user-visible consequences, for operators who decommission nodes and then mark them ephemeral as documented in [Node Types and Lifecycle Strategies](https://github.com/netdata/netdata/blob/master/docs/nodes-ephemerality.md):

- node-unreachable notifications are not suppressed for the marked node,
- ephemeral node cleanup never runs for it, so decommissioned nodes linger.

This regressed silently: #21456 added the node-info send so the cloud would learn about the change, but the payload it sends was never corrected.

Three parts to the fix:

1. Update `host->rrdlabels` as well, using `rrdlabels_add_changed()` — the same call the streaming receiver already uses for this label.
2. Load the stored labels first when the host has none. `rrdhost_create()` allocates `rrdlabels` only for non-archived hosts (`src/database/rrdhost.c:414-418`), so an archived host can reach this path without them. Since node info transmits the dictionary as the node's **complete** label set, starting from an empty one would replace every other label of that node (`_os`, `_architecture`, `_install_type`, ...) rather than just adding this one.
3. Fold the label change into `marked`. The node-info send was gated purely on the host-option transition, so marking a node ephemeral and later running `remove-stale-node` on it sent nothing at all the second time.

##### Test Plan

Verified with two Agents built from this branch, in isolated directories on ports 19998/19997, with `NETDATA_PIPENAME` pointed at per-instance sockets and unclaimed so the ACLK stays offline. A child streams to a parent, the child is stopped (simulating a decommission), `netdatacli mark-stale-nodes-ephemeral <child>` runs on the parent, and the host labels are read back over HTTP **without restarting the parent**. `/api/v1/info` renders `host->rrdlabels` (`host_labels2json()`, `src/web/api/web_api.c:5-9`) — the same dictionary node info transmits — so the test observes the transmitted value.

```
BEFORE (child streaming): _is_ephemeral = false     18 host labels
AFTER  (marked ephemeral): _is_ephemeral = true     18 host labels

label set delta:  < _is_ephemeral=false
                  > _is_ephemeral=true

PASS - the label transmitted to the cloud now says true
PASS - no host label was lost
```

A repeat invocation correctly reports `is already ephemeral - not changing it`.

Counterfactual, to confirm the test covers the defect rather than the environment: with only the pre-fix line restored and rebuilt, the same run gives

```
Node 'eph-test-child' ... has been marked ephemeral
AFTER  (marked ephemeral): _is_ephemeral = false
FAIL - the cloud would still be told the node is permanent
```

Same-failure scan for the same class of bug elsewhere:

- `sql_set_host_label()` has exactly one caller, the site fixed here.
- The three other writers of `RRDHOST_OPTION_EPHEMERAL_HOST` cannot drift from the label: `sqlite_aclk.c:196` sets the option from the DB column and then loads `host->rrdlabels` from the same rows, and `pluginsd_parser.c:198-207` derives the option *from* the label and writes the normalized label back.

##### Additional Information

The stored `host_label` row is deliberately kept: it is the startup-time source of truth for both the option flag and `sql_load_host_labels()`. The change makes the in-memory copy agree with it instead of replacing it.

Side effect worth noting: `meta_store_host_labels()` rewrites the whole `host_label` table from `host->rrdlabels` whenever `RRDHOST_FLAG_METADATA_LABELS` is set. Before this change that could write `_is_ephemeral=false` back over the CLI's own DB write; now the two agree, so the stored row can no longer be clobbered.

Scope note: this fixes the Agent side only. A node marked ephemeral while it is **stale** is still not cleaned up by Netdata Cloud, because cloud-side ephemeral cleanup triggers on the **unreachable** state. `remove-stale-node` does reach unreachable and now works end to end; `mark-stale-nodes-ephemeral` alone leaves the node stale. That remaining gap is cloud-side behavior and is not addressed here.

<details> <summary>For users: How does this change affect me?</summary>

This affects anyone who decommissions nodes and marks them ephemeral from a Parent, which is the workflow documented in [Node Types and Lifecycle Strategies](https://github.com/netdata/netdata/blob/master/docs/nodes-ephemerality.md#mark-permanently-offline-nodes-as-ephemeral).

Before this change, `netdatacli mark-stale-nodes-ephemeral` and `netdatacli remove-stale-node` printed a success message while Netdata Cloud was still told the node is permanent, until the Agent was restarted. Node-unreachable notifications kept firing for decommissioned nodes, and the nodes were never cleaned up from the Cloud UI.

After this change the ephemeral marking reaches Netdata Cloud immediately, with no Agent restart, and the node's other labels are left untouched. Teams with high node churn get the decommission behaviour the documentation describes: `remove-stale-node` marks the node ephemeral, drives it offline, and Netdata Cloud removes it instead of paging.

Nodes that were marked ephemeral before upgrading are not repaired retroactively — re-run the command after upgrading, or restart the Agent, for the correct value to be sent.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes propagation of ephemeral node marking to Netdata Cloud for `netdatacli mark-stale-nodes-ephemeral` and `netdatacli remove-stale-node`. Cloud now receives `_is_ephemeral=true` immediately, without an Agent restart, and the update is applied safely without races or label loss.

- **Bug Fixes**
  - Update `host->rrdlabels` in place using `rrdlabels_add_changed()` before sending node info to avoid pointer races.
  - Send node info only when the transmitted label actually changes; base the decision on the label change, not the host option.
  - If a host has no labels in memory, do not send node info and log a warning to avoid publishing an empty label set and dropping other labels.

<sup>Written for commit 196d7e57e7b16058749dcc9688f2020553605f70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

