### PR TITLE
perf(go.d/metrix): reduce structured flatten allocations

### DIFF
--- a/src/go/pkg/metrix/collector_store_scope_bench_test.go
+++ b/src/go/pkg/metrix/collector_store_scope_bench_test.go
@@ -19,30 +19,32 @@ var benchmarkHostScopesSink []HostScope
 // outside the timer and verify the exact output count before timing so skipped
 // projection work cannot look like an optimization.
 //
-// Latest developer-laptop comparison (darwin/arm64, Apple M4 Pro, 2026-07-27).
-// Results are medians of -count=10; ns/op is a trend indicator, not a CI gate.
+// Reproducible comparison (darwin/arm64, Apple M4 Pro, 2026-07-27):
+//   - merge-base production: beede2920e18ec0e0efa3c522367ce26deec1281
+//   - optimized production: 1f59fa84ba593a0560663d1ce185542485eddf7d
+//   - identical benchmark harness: 759296896a6758c2d8919df169a3d14807d6650d
+//
+// The merge base predates most of this matrix. The harness versions of
+// collector_store_scope_bench_test.go, reader_bench_test.go, and
+// summary_bench_test.go were therefore overlaid unchanged onto clean trees at
+// both production revisions. Results are medians of -count=10; ns/op is a
+// developer-laptop trend indicator, not a CI gate.
 //
 //	go test -run '^$' -bench 'FlattenProjectionCold$' -benchmem -benchtime=100ms -count=10 ./pkg/metrix
 //
-// Representative merge-base -> optimized results:
-//   - scalar/512: 65,776 ns/op, 37,400 B/op, 21 allocs/op ->
-//     65,700 ns/op, 37,400 B/op, 21 allocs/op.
-//   - mixed/512: 4,283,642 ns/op, 7,708,624 B/op, 54,445 allocs/op ->
-//     3,512,606 ns/op, 7,185,122 B/op, 45,741 allocs/op.
-//   - histogram labels_8/512: 9,491,069 ns/op, 17,264,506 B/op, 109,683 allocs/op ->
-//     4,872,335 ns/op, 10,581,270 B/op, 63,603 allocs/op.
-//   - summary no quantiles/512: 409,571 ns/op, 945,202 B/op, 6,182 allocs/op ->
-//     323,502 ns/op, 904,242 B/op, 4,134 allocs/op.
-//   - summary fanout_8/labels_8/512: 6,175,011 ns/op, 12,206,788 B/op, 72,786 allocs/op ->
-//     3,417,920 ns/op, 7,987,910 B/op, 45,650 allocs/op.
-//   - stateset fanout_8/labels_8/512: 5,057,474 ns/op, 10,526,588 B/op, 57,402 allocs/op ->
-//     2,872,449 ns/op, 6,954,871 B/op, 37,434 allocs/op.
-//   - measureset gauge fanout_8/labels_8/512: 5,365,286 ns/op, 10,578,861 B/op, 61,579 allocs/op ->
-//     3,105,037 ns/op, 7,465,883 B/op, 45,195 allocs/op.
-//   - measureset counter fanout_8/labels_8/512: 5,049,261 ns/op, 10,578,861 B/op, 61,579 allocs/op ->
-//     2,847,366 ns/op, 7,465,886 B/op, 45,195 allocs/op.
-//   - measureset gauge fanout_2/labels_1/512: 569,917 ns/op, 1,125,107 B/op, 9,254 allocs/op ->
-//     476,628 ns/op, 1,125,110 B/op, 9,254 allocs/op.
+// Representative merge-base -> optimized results (`ns/op` is the local trend):
+//   - scalar/512: ns/op +1.9%; 37,400 -> 37,400 B/op; 21 -> 21 allocs/op.
+//   - mixed/512: ns/op -18.1%; 7,709,253 -> 7,182,939 B/op;
+//     54,445 -> 45,741 allocs/op.
+//   - histogram labels_8/512: ns/op -47.5%; 17,267,578 -> 10,579,147 B/op;
+//     109,683 -> 63,603 allocs/op.
+//   - summary fanout_8/labels_8/512: ns/op -44.1%; 12,206,783 -> 7,987,898 B/op;
+//     72,786 -> 45,650 allocs/op.
+//   - stateset fanout_8/labels_8/512: ns/op -42.7%; 10,526,587 -> 6,954,869 B/op;
+//     57,402 -> 37,434 allocs/op.
+//   - measureset gauge/counter fanout_8/labels_8/512:
+//     ns/op -39.8%/-41.7%; 10,578,865/10,578,856 ->
+//     7,465,884/7,465,880 B/op; 61,579 -> 45,195 allocs/op.
 func BenchmarkCollectorStoreFlattenProjectionCold(b *testing.B) {
 	for _, instances := range []int{32, 512} {
 		b.Run(fmt.Sprintf("structured_instances_%d", instances), func(b *testing.B) {

--- a/src/go/pkg/metrix/collector_store_scope_bench_test.go
+++ b/src/go/pkg/metrix/collector_store_scope_bench_test.go
@@ -11,10 +11,13 @@ import (
 
 var benchmarkHostScopesSink []HostScope
 
-// Cold flatten construction is O(source series + projected outputs*labels). It
-// retains no global cache; CollectorStore owns one projection per exact snapshot.
-// The benchmarks keep setup outside the timer and verify the exact output count
-// before timing so skipped projection work cannot look like an optimization.
+// Cold flatten builds both projected series and their lookup index. Label/key
+// construction is O(source series + projected label/key bytes); index construction
+// adds sum(k log k) label-key comparisons across scope/name groups plus scope/name
+// catalog sorting. It retains no global cache, introduces no quadratic scan, and
+// CollectorStore owns one projection per exact snapshot. The benchmarks keep setup
+// outside the timer and verify the exact output count before timing so skipped
+// projection work cannot look like an optimization.
 //
 // Latest developer-laptop comparison (darwin/arm64, Apple M4 Pro, 2026-07-27).
 // Results are medians of -count=10; ns/op is a trend indicator, not a CI gate.

--- a/src/go/pkg/metrix/collector_store_scope_bench_test.go
+++ b/src/go/pkg/metrix/collector_store_scope_bench_test.go
@@ -30,6 +30,56 @@ func BenchmarkCollectorStoreFlattenProjectionCold(b *testing.B) {
 	}
 }
 
+func BenchmarkCollectorStoreScalarFlattenProjectionCold(b *testing.B) {
+	for _, instances := range []int{32, 512} {
+		b.Run(fmt.Sprintf("instances_%d", instances), func(b *testing.B) {
+			store := benchmarkCommittedScalarStore(b, instances)
+			snapshot := store.(*storeView).core.snapshot.Load()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				flat := flattenSnapshot(snapshot)
+				benchmarkReaderCountSink = len(flat.series)
+			}
+		})
+	}
+}
+
+func BenchmarkCollectorStoreHistogramFlattenProjectionCold(b *testing.B) {
+	for _, labels := range []int{1, 8} {
+		for _, instances := range []int{32, 512} {
+			b.Run(fmt.Sprintf("labels_%d/instances_%d", labels, instances), func(b *testing.B) {
+				store := benchmarkCommittedHistogramStore(b, instances, labels)
+				snapshot := store.(*storeView).core.snapshot.Load()
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					flat := flattenSnapshot(snapshot)
+					benchmarkReaderCountSink = len(flat.series)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkCollectorStoreSummaryNoQuantilesFlattenProjectionCold(b *testing.B) {
+	for _, instances := range []int{32, 512} {
+		b.Run(fmt.Sprintf("instances_%d", instances), func(b *testing.B) {
+			store := benchmarkCommittedSummaryNoQuantilesStore(b, instances)
+			snapshot := store.(*storeView).core.snapshot.Load()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				flat := flattenSnapshot(snapshot)
+				benchmarkReaderCountSink = len(flat.series)
+			}
+		})
+	}
+}
+
 func BenchmarkCollectorStoreFlattenProjectionWarm(b *testing.B) {
 	for _, instances := range []int{32, 512} {
 		b.Run(fmt.Sprintf("structured_instances_%d", instances), func(b *testing.B) {
@@ -48,6 +98,85 @@ func BenchmarkCollectorStoreFlattenProjectionWarm(b *testing.B) {
 			}
 		})
 	}
+}
+
+func benchmarkCommittedHistogramStore(b *testing.B, totalSeries, totalLabels int) CollectorStore {
+	b.Helper()
+
+	store := NewCollectorStore()
+	cycle := benchmarkCycleController(b, store)
+	meter := store.Write().SnapshotMeter("reader.flatten")
+	labelNames := []string{"instance", "job", "method", "namespace", "region", "service", "status", "zone"}[:totalLabels]
+	vector := meter.Vec(labelNames...).Histogram(
+		"latency",
+		WithHistogramBounds(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
+	)
+	handles := make([]SnapshotHistogram, totalSeries)
+	for i := range handles {
+		labelValues := make([]string, totalLabels)
+		labelValues[0] = strconv.Itoa(i)
+		for j := 1; j < totalLabels; j++ {
+			labelValues[j] = fmt.Sprintf("value_%d", j)
+		}
+		handle, err := vector.GetWithLabelValues(labelValues...)
+		if err != nil {
+			b.Fatalf("create histogram handle: %v", err)
+		}
+		handles[i] = handle
+	}
+
+	buckets := []BucketPoint{
+		{UpperBound: 0.005, CumulativeCount: 1},
+		{UpperBound: 0.01, CumulativeCount: 2},
+		{UpperBound: 0.025, CumulativeCount: 3},
+		{UpperBound: 0.05, CumulativeCount: 4},
+		{UpperBound: 0.1, CumulativeCount: 5},
+		{UpperBound: 0.25, CumulativeCount: 6},
+		{UpperBound: 0.5, CumulativeCount: 7},
+		{UpperBound: 1, CumulativeCount: 8},
+		{UpperBound: 2.5, CumulativeCount: 9},
+		{UpperBound: 5, CumulativeCount: 10},
+		{UpperBound: 10, CumulativeCount: 11},
+		{UpperBound: 30, CumulativeCount: 12},
+	}
+	cycle.BeginCycle()
+	for _, handle := range handles {
+		handle.ObservePoint(HistogramPoint{
+			Count:   13,
+			Sum:     42,
+			Buckets: buckets,
+		})
+	}
+	if err := cycle.CommitCycleSuccess(); err != nil {
+		b.Fatalf("commit histogram store: %v", err)
+	}
+	return store
+}
+
+func benchmarkCommittedSummaryNoQuantilesStore(b *testing.B, totalSeries int) CollectorStore {
+	b.Helper()
+
+	store := NewCollectorStore()
+	cycle := benchmarkCycleController(b, store)
+	vector := store.Write().SnapshotMeter("reader.flatten").Vec("id").Summary("duration")
+	handles := make([]SnapshotSummary, totalSeries)
+	for i := range handles {
+		handle, err := vector.GetWithLabelValues(strconv.Itoa(i))
+		if err != nil {
+			b.Fatalf("create summary handle: %v", err)
+		}
+		handles[i] = handle
+	}
+
+	cycle.BeginCycle()
+	for i, handle := range handles {
+		value := SampleValue(i + 1)
+		handle.ObservePoint(SummaryPoint{Count: value, Sum: value * 10})
+	}
+	if err := cycle.CommitCycleSuccess(); err != nil {
+		b.Fatalf("commit summary store: %v", err)
+	}
+	return store
 }
 
 func BenchmarkCollectorStoreHostScopes(b *testing.B) {

--- a/src/go/pkg/metrix/collector_store_scope_bench_test.go
+++ b/src/go/pkg/metrix/collector_store_scope_bench_test.go
@@ -11,21 +11,41 @@ import (
 
 var benchmarkHostScopesSink []HostScope
 
+// Cold flatten construction is O(source series + projected outputs*labels). It
+// retains no global cache; CollectorStore owns one projection per exact snapshot.
+// The benchmarks keep setup outside the timer and verify the exact output count
+// before timing so skipped projection work cannot look like an optimization.
+//
+// Latest developer-laptop comparison (darwin/arm64, Apple M4 Pro, 2026-07-27).
+// Results are medians of -count=10; ns/op is a trend indicator, not a CI gate.
+//
+//	go test -run '^$' -bench 'FlattenProjectionCold$' -benchmem -benchtime=100ms -count=10 ./pkg/metrix
+//
+// Representative merge-base -> optimized results:
+//   - scalar/512: 65,776 ns/op, 37,400 B/op, 21 allocs/op ->
+//     65,700 ns/op, 37,400 B/op, 21 allocs/op.
+//   - mixed/512: 4,283,642 ns/op, 7,708,624 B/op, 54,445 allocs/op ->
+//     3,512,606 ns/op, 7,185,122 B/op, 45,741 allocs/op.
+//   - histogram labels_8/512: 9,491,069 ns/op, 17,264,506 B/op, 109,683 allocs/op ->
+//     4,872,335 ns/op, 10,581,270 B/op, 63,603 allocs/op.
+//   - summary no quantiles/512: 409,571 ns/op, 945,202 B/op, 6,182 allocs/op ->
+//     323,502 ns/op, 904,242 B/op, 4,134 allocs/op.
+//   - summary fanout_8/labels_8/512: 6,175,011 ns/op, 12,206,788 B/op, 72,786 allocs/op ->
+//     3,417,920 ns/op, 7,987,910 B/op, 45,650 allocs/op.
+//   - stateset fanout_8/labels_8/512: 5,057,474 ns/op, 10,526,588 B/op, 57,402 allocs/op ->
+//     2,872,449 ns/op, 6,954,871 B/op, 37,434 allocs/op.
+//   - measureset gauge fanout_8/labels_8/512: 5,365,286 ns/op, 10,578,861 B/op, 61,579 allocs/op ->
+//     3,105,037 ns/op, 7,465,883 B/op, 45,195 allocs/op.
+//   - measureset counter fanout_8/labels_8/512: 5,049,261 ns/op, 10,578,861 B/op, 61,579 allocs/op ->
+//     2,847,366 ns/op, 7,465,886 B/op, 45,195 allocs/op.
+//   - measureset gauge fanout_2/labels_1/512: 569,917 ns/op, 1,125,107 B/op, 9,254 allocs/op ->
+//     476,628 ns/op, 1,125,110 B/op, 9,254 allocs/op.
 func BenchmarkCollectorStoreFlattenProjectionCold(b *testing.B) {
 	for _, instances := range []int{32, 512} {
 		b.Run(fmt.Sprintf("structured_instances_%d", instances), func(b *testing.B) {
 			store := benchmarkCommittedMixedStore(b, instances)
 			snapshot := store.(*storeView).core.snapshot.Load()
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for b.Loop() {
-				flat := flattenSnapshot(snapshot)
-				if flat.collectMeta.LastSuccessSeq == 0 {
-					b.Fatal("expected committed snapshot")
-				}
-				benchmarkReaderCountSink = len(flat.series)
-			}
+			benchmarkFlattenProjectionCold(b, snapshot, 15*instances)
 		})
 	}
 }
@@ -35,13 +55,7 @@ func BenchmarkCollectorStoreScalarFlattenProjectionCold(b *testing.B) {
 		b.Run(fmt.Sprintf("instances_%d", instances), func(b *testing.B) {
 			store := benchmarkCommittedScalarStore(b, instances)
 			snapshot := store.(*storeView).core.snapshot.Load()
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for b.Loop() {
-				flat := flattenSnapshot(snapshot)
-				benchmarkReaderCountSink = len(flat.series)
-			}
+			benchmarkFlattenProjectionCold(b, snapshot, instances)
 		})
 	}
 }
@@ -52,13 +66,7 @@ func BenchmarkCollectorStoreHistogramFlattenProjectionCold(b *testing.B) {
 			b.Run(fmt.Sprintf("labels_%d/instances_%d", labels, instances), func(b *testing.B) {
 				store := benchmarkCommittedHistogramStore(b, instances, labels)
 				snapshot := store.(*storeView).core.snapshot.Load()
-
-				b.ReportAllocs()
-				b.ResetTimer()
-				for b.Loop() {
-					flat := flattenSnapshot(snapshot)
-					benchmarkReaderCountSink = len(flat.series)
-				}
+				benchmarkFlattenProjectionCold(b, snapshot, 15*instances)
 			})
 		}
 	}
@@ -69,23 +77,53 @@ func BenchmarkCollectorStoreSummaryNoQuantilesFlattenProjectionCold(b *testing.B
 		b.Run(fmt.Sprintf("instances_%d", instances), func(b *testing.B) {
 			store := benchmarkCommittedSummaryNoQuantilesStore(b, instances)
 			snapshot := store.(*storeView).core.snapshot.Load()
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for b.Loop() {
-				flat := flattenSnapshot(snapshot)
-				benchmarkReaderCountSink = len(flat.series)
-			}
+			benchmarkFlattenProjectionCold(b, snapshot, 2*instances)
 		})
 	}
+}
+
+func BenchmarkCollectorStoreSummaryFlattenProjectionCold(b *testing.B) {
+	benchmarkStructuredFlattenShapes(b, 3, func(b *testing.B, shape flattenProjectionBenchmarkShape) {
+		store := benchmarkCommittedSummaryStore(b, shape.instances, shape.labels, shape.fanout)
+		snapshot := store.(*storeView).core.snapshot.Load()
+		benchmarkFlattenProjectionCold(b, snapshot, (shape.fanout+2)*shape.instances)
+	})
+}
+
+func BenchmarkCollectorStoreStateSetFlattenProjectionCold(b *testing.B) {
+	benchmarkStructuredFlattenShapes(b, 2, func(b *testing.B, shape flattenProjectionBenchmarkShape) {
+		store := benchmarkCommittedStateSetStore(b, shape.instances, shape.labels, shape.fanout)
+		snapshot := store.(*storeView).core.snapshot.Load()
+		benchmarkFlattenProjectionCold(b, snapshot, shape.fanout*shape.instances)
+	})
+}
+
+func BenchmarkCollectorStoreMeasureSetGaugeFlattenProjectionCold(b *testing.B) {
+	benchmarkStructuredFlattenShapes(b, 2, func(b *testing.B, shape flattenProjectionBenchmarkShape) {
+		store := benchmarkCommittedMeasureSetStore(b, shape.instances, shape.labels, shape.fanout, MeasureSetSemanticsGauge)
+		snapshot := store.(*storeView).core.snapshot.Load()
+		benchmarkFlattenProjectionCold(b, snapshot, shape.fanout*shape.instances)
+	})
+}
+
+func BenchmarkCollectorStoreMeasureSetCounterFlattenProjectionCold(b *testing.B) {
+	benchmarkStructuredFlattenShapes(b, 2, func(b *testing.B, shape flattenProjectionBenchmarkShape) {
+		store := benchmarkCommittedMeasureSetStore(b, shape.instances, shape.labels, shape.fanout, MeasureSetSemanticsCounter)
+		snapshot := store.(*storeView).core.snapshot.Load()
+		benchmarkFlattenProjectionCold(b, snapshot, shape.fanout*shape.instances)
+	})
 }
 
 func BenchmarkCollectorStoreFlattenProjectionWarm(b *testing.B) {
 	for _, instances := range []int{32, 512} {
 		b.Run(fmt.Sprintf("structured_instances_%d", instances), func(b *testing.B) {
 			store := benchmarkCommittedMixedStore(b, instances)
-			if meta := store.Read(ReadFlatten()).CollectMeta(); meta.LastSuccessSeq == 0 {
+			reader := store.Read(ReadFlatten())
+			if meta := reader.CollectMeta(); meta.LastSuccessSeq == 0 {
 				b.Fatal("expected committed snapshot")
+			}
+			if got := benchmarkCountReaderSeries(reader); got != 15*instances {
+				b.Fatalf("expected %d flattened series, got %d", 15*instances, got)
 			}
 
 			b.ReportAllocs()
@@ -100,27 +138,102 @@ func BenchmarkCollectorStoreFlattenProjectionWarm(b *testing.B) {
 	}
 }
 
-func benchmarkCommittedHistogramStore(b *testing.B, totalSeries, totalLabels int) CollectorStore {
+type flattenProjectionBenchmarkShape struct {
+	instances int
+	labels    int
+	fanout    int
+}
+
+var flattenProjectionBenchmarkLabelNames = []string{
+	"instance",
+	"job",
+	"method",
+	"namespace",
+	"region",
+	"service",
+	"status",
+	"zone",
+}
+
+func benchmarkStructuredFlattenShapes(
+	b *testing.B,
+	lowFanout int,
+	run func(b *testing.B, shape flattenProjectionBenchmarkShape),
+) {
 	b.Helper()
 
+	shapes := []flattenProjectionBenchmarkShape{
+		{instances: 32, labels: 1, fanout: lowFanout},
+		{instances: 512, labels: 1, fanout: lowFanout},
+		{instances: 512, labels: 8, fanout: lowFanout},
+		{instances: 512, labels: 8, fanout: 8},
+	}
+	for _, shape := range shapes {
+		name := fmt.Sprintf("fanout_%d/labels_%d/instances_%d", shape.fanout, shape.labels, shape.instances)
+		b.Run(name, func(b *testing.B) {
+			run(b, shape)
+		})
+	}
+}
+
+func benchmarkFlattenProjectionCold(b *testing.B, snapshot *readSnapshot, wantSeries int) {
+	b.Helper()
+	requireFlattenProjectionSeries(b, snapshot, wantSeries)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkReaderCountSink = len(flattenSnapshot(snapshot).series)
+	}
+}
+
+func requireFlattenProjectionSeries(tb testing.TB, snapshot *readSnapshot, wantSeries int) {
+	tb.Helper()
+
+	flat := flattenSnapshot(snapshot)
+	if flat.collectMeta.LastSuccessSeq == 0 {
+		tb.Fatal("expected committed snapshot")
+	}
+	if got := len(flat.series); got != wantSeries {
+		tb.Fatalf("expected %d flattened series, got %d", wantSeries, got)
+	}
+}
+
+func benchmarkFlattenLabelNames(tb testing.TB, totalLabels int) []string {
+	tb.Helper()
+
+	if totalLabels < 1 || totalLabels > len(flattenProjectionBenchmarkLabelNames) {
+		tb.Fatalf("invalid flatten fixture label count: %d", totalLabels)
+	}
+	return flattenProjectionBenchmarkLabelNames[:totalLabels]
+}
+
+func benchmarkFlattenLabelValues(totalLabels, series int) []string {
+	values := make([]string, totalLabels)
+	values[0] = strconv.Itoa(series)
+	for i := 1; i < totalLabels; i++ {
+		values[i] = fmt.Sprintf("value_%d", i)
+	}
+	return values
+}
+
+func benchmarkCommittedHistogramStore(tb testing.TB, totalSeries, totalLabels int) CollectorStore {
+	tb.Helper()
+
 	store := NewCollectorStore()
-	cycle := benchmarkCycleController(b, store)
+	cycle := benchmarkCycleController(tb, store)
 	meter := store.Write().SnapshotMeter("reader.flatten")
-	labelNames := []string{"instance", "job", "method", "namespace", "region", "service", "status", "zone"}[:totalLabels]
+	labelNames := benchmarkFlattenLabelNames(tb, totalLabels)
 	vector := meter.Vec(labelNames...).Histogram(
 		"latency",
 		WithHistogramBounds(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
 	)
 	handles := make([]SnapshotHistogram, totalSeries)
 	for i := range handles {
-		labelValues := make([]string, totalLabels)
-		labelValues[0] = strconv.Itoa(i)
-		for j := 1; j < totalLabels; j++ {
-			labelValues[j] = fmt.Sprintf("value_%d", j)
-		}
+		labelValues := benchmarkFlattenLabelValues(totalLabels, i)
 		handle, err := vector.GetWithLabelValues(labelValues...)
 		if err != nil {
-			b.Fatalf("create histogram handle: %v", err)
+			tb.Fatalf("create histogram handle: %v", err)
 		}
 		handles[i] = handle
 	}
@@ -148,22 +261,52 @@ func benchmarkCommittedHistogramStore(b *testing.B, totalSeries, totalLabels int
 		})
 	}
 	if err := cycle.CommitCycleSuccess(); err != nil {
-		b.Fatalf("commit histogram store: %v", err)
+		tb.Fatalf("commit histogram store: %v", err)
 	}
 	return store
 }
 
-func benchmarkCommittedSummaryNoQuantilesStore(b *testing.B, totalSeries int) CollectorStore {
-	b.Helper()
+func benchmarkCommittedSummaryNoQuantilesStore(tb testing.TB, totalSeries int) CollectorStore {
+	tb.Helper()
+	return benchmarkCommittedSummaryStoreWithLabels(tb, totalSeries, []string{"id"}, 0)
+}
+
+func benchmarkCommittedSummaryStore(tb testing.TB, totalSeries, totalLabels, totalQuantiles int) CollectorStore {
+	tb.Helper()
+	return benchmarkCommittedSummaryStoreWithLabels(
+		tb,
+		totalSeries,
+		benchmarkFlattenLabelNames(tb, totalLabels),
+		totalQuantiles,
+	)
+}
+
+func benchmarkCommittedSummaryStoreWithLabels(
+	tb testing.TB,
+	totalSeries int,
+	labelNames []string,
+	totalQuantiles int,
+) CollectorStore {
+	tb.Helper()
 
 	store := NewCollectorStore()
-	cycle := benchmarkCycleController(b, store)
-	vector := store.Write().SnapshotMeter("reader.flatten").Vec("id").Summary("duration")
+	cycle := benchmarkCycleController(tb, store)
+	quantiles := make([]float64, totalQuantiles)
+	for i := range quantiles {
+		quantiles[i] = float64(i+1) / float64(totalQuantiles+1)
+	}
+	meter := store.Write().SnapshotMeter("reader.flatten").Vec(labelNames...)
+	var vector SnapshotSummaryVec
+	if len(quantiles) == 0 {
+		vector = meter.Summary("duration")
+	} else {
+		vector = meter.Summary("duration", WithSummaryQuantiles(quantiles...))
+	}
 	handles := make([]SnapshotSummary, totalSeries)
 	for i := range handles {
-		handle, err := vector.GetWithLabelValues(strconv.Itoa(i))
+		handle, err := vector.GetWithLabelValues(benchmarkFlattenLabelValues(len(labelNames), i)...)
 		if err != nil {
-			b.Fatalf("create summary handle: %v", err)
+			tb.Fatalf("create summary handle: %v", err)
 		}
 		handles[i] = handle
 	}
@@ -171,10 +314,94 @@ func benchmarkCommittedSummaryNoQuantilesStore(b *testing.B, totalSeries int) Co
 	cycle.BeginCycle()
 	for i, handle := range handles {
 		value := SampleValue(i + 1)
-		handle.ObservePoint(SummaryPoint{Count: value, Sum: value * 10})
+		point := SummaryPoint{Count: value, Sum: value * 10}
+		for j, quantile := range quantiles {
+			point.Quantiles = append(point.Quantiles, QuantilePoint{
+				Quantile: quantile,
+				Value:    value + SampleValue(j),
+			})
+		}
+		handle.ObservePoint(point)
 	}
 	if err := cycle.CommitCycleSuccess(); err != nil {
-		b.Fatalf("commit summary store: %v", err)
+		tb.Fatalf("commit summary store: %v", err)
+	}
+	return store
+}
+
+func benchmarkCommittedStateSetStore(tb testing.TB, totalSeries, totalLabels, totalStates int) CollectorStore {
+	tb.Helper()
+
+	store := NewCollectorStore()
+	cycle := benchmarkCycleController(tb, store)
+	states := make([]string, totalStates)
+	for i := range states {
+		states[i] = fmt.Sprintf("state_%d", i)
+	}
+	vector := store.Write().SnapshotMeter("reader.flatten").
+		Vec(benchmarkFlattenLabelNames(tb, totalLabels)...).
+		StateSet("mode", WithStateSetStates(states...), WithStateSetMode(ModeEnum))
+	handles := make([]StateSetInstrument, totalSeries)
+	for i := range handles {
+		handle, err := vector.GetWithLabelValues(benchmarkFlattenLabelValues(totalLabels, i)...)
+		if err != nil {
+			tb.Fatalf("create stateset handle: %v", err)
+		}
+		handles[i] = handle
+	}
+
+	cycle.BeginCycle()
+	for i, handle := range handles {
+		handle.Enable(states[i%len(states)])
+	}
+	if err := cycle.CommitCycleSuccess(); err != nil {
+		tb.Fatalf("commit stateset store: %v", err)
+	}
+	return store
+}
+
+func benchmarkCommittedMeasureSetStore(
+	tb testing.TB,
+	totalSeries, totalLabels, totalFields int,
+	semantics MeasureSetSemantics,
+) CollectorStore {
+	tb.Helper()
+
+	store := NewCollectorStore()
+	cycle := benchmarkCycleController(tb, store)
+	fields := make([]MeasureFieldSpec, totalFields)
+	values := make([]SampleValue, totalFields)
+	for i := range fields {
+		fields[i] = MeasureFieldSpec{Name: fmt.Sprintf("field_%d", i)}
+		values[i] = SampleValue(i + 1)
+	}
+	meter := store.Write().SnapshotMeter("reader.flatten").Vec(benchmarkFlattenLabelNames(tb, totalLabels)...)
+
+	cycle.BeginCycle()
+	switch semantics {
+	case MeasureSetSemanticsGauge:
+		vector := meter.MeasureSetGauge("payload", WithMeasureSetFields(fields...))
+		for i := range totalSeries {
+			handle, err := vector.GetWithLabelValues(benchmarkFlattenLabelValues(totalLabels, i)...)
+			if err != nil {
+				tb.Fatalf("create measureset gauge handle: %v", err)
+			}
+			handle.ObservePoint(MeasureSetPoint{Values: values})
+		}
+	case MeasureSetSemanticsCounter:
+		vector := meter.MeasureSetCounter("payload", WithMeasureSetFields(fields...))
+		for i := range totalSeries {
+			handle, err := vector.GetWithLabelValues(benchmarkFlattenLabelValues(totalLabels, i)...)
+			if err != nil {
+				tb.Fatalf("create measureset counter handle: %v", err)
+			}
+			handle.ObserveTotalPoint(MeasureSetPoint{Values: values})
+		}
+	default:
+		tb.Fatalf("unsupported measureset semantics: %d", semantics)
+	}
+	if err := cycle.CommitCycleSuccess(); err != nil {
+		tb.Fatalf("commit measureset store: %v", err)
 	}
 	return store
 }
@@ -244,15 +471,12 @@ func BenchmarkCollectorStoreFlattenProjectionVisibilityCold(b *testing.B) {
 				cycle.AbortCycle()
 			}
 			snapshot := store.(*storeView).core.snapshot.Load()
+			requireFlattenProjectionSeries(b, snapshot, totalSeries)
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				flat := flattenSnapshot(snapshot)
-				if len(flat.series) != totalSeries {
-					b.Fatalf("expected %d series, got %d", totalSeries, len(flat.series))
-				}
-				benchmarkReaderCountSink = len(flat.series)
+				benchmarkReaderCountSink = len(flattenSnapshot(snapshot).series)
 			}
 		})
 	}
@@ -303,6 +527,9 @@ func BenchmarkCollectorStoreFlattenProjectionConcurrentFirst(b *testing.B) {
 			if reader.CollectMeta().LastSuccessSeq == 0 {
 				b.Fatal("expected committed snapshot")
 			}
+		}
+		if got := benchmarkCountReaderSeries(results[0]); got != totalSeries {
+			b.Fatalf("expected %d flattened series, got %d", totalSeries, got)
 		}
 		b.StartTimer()
 	}

--- a/src/go/pkg/metrix/labels.go
+++ b/src/go/pkg/metrix/labels.go
@@ -71,6 +71,44 @@ func canonicalizeLabels(input map[string]string) ([]Label, string, error) {
 	return labels, b.String(), nil
 }
 
+// mergeCanonicalLabel inserts or replaces one label in an immutable, sorted canonical label slice.
+func mergeCanonicalLabel(base []Label, extra Label) ([]Label, string, error) {
+	if extra.Key == "" {
+		return nil, "", errInvalidLabelKey
+	}
+
+	out := make([]Label, 0, len(base)+1)
+	var b strings.Builder
+	inserted := false
+
+	for _, label := range base {
+		if !inserted && extra.Key <= label.Key {
+			out = append(out, extra)
+			b.WriteString(extra.Key)
+			b.WriteByte('\xff')
+			b.WriteString(extra.Value)
+			b.WriteByte('\xff')
+			inserted = true
+			if extra.Key == label.Key {
+				continue
+			}
+		}
+		out = append(out, label)
+		b.WriteString(label.Key)
+		b.WriteByte('\xff')
+		b.WriteString(label.Value)
+		b.WriteByte('\xff')
+	}
+	if !inserted {
+		out = append(out, extra)
+		b.WriteString(extra.Key)
+		b.WriteByte('\xff')
+		b.WriteString(extra.Value)
+		b.WriteByte('\xff')
+	}
+	return out, b.String(), nil
+}
+
 // labelsFromSet merges precompiled label sets and validates ownership/duplicates.
 func labelsFromSet(sets []LabelSet, owner meterBackend) ([]Label, string, error) {
 	if len(sets) == 0 {

--- a/src/go/pkg/metrix/labels_merge_test.go
+++ b/src/go/pkg/metrix/labels_merge_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeCanonicalLabelMatchesCanonicalizeLabels(t *testing.T) {
+	tests := map[string]struct {
+		base  map[string]string
+		extra Label
+	}{
+		"empty base": {
+			extra: Label{Key: "m", Value: "value"},
+		},
+		"insert at beginning": {
+			base:  map[string]string{"m": "middle", "z": "last"},
+			extra: Label{Key: "a", Value: "first"},
+		},
+		"insert in middle": {
+			base:  map[string]string{"a": "first", "z": "last"},
+			extra: Label{Key: "m", Value: "middle"},
+		},
+		"insert at end": {
+			base:  map[string]string{"a": "first", "m": "middle"},
+			extra: Label{Key: "z", Value: "last"},
+		},
+		"replace duplicate like map assignment": {
+			base:  map[string]string{"a": "first", "m": "old", "z": "last"},
+			extra: Label{Key: "m", Value: "new"},
+		},
+		"empty value": {
+			base:  map[string]string{"a": "first"},
+			extra: Label{Key: "m", Value: ""},
+		},
+		"packed delimiter in value": {
+			base:  map[string]string{"a": "first"},
+			extra: Label{Key: "m", Value: "before\xffafter"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			base, _, err := canonicalizeLabels(tc.base)
+			require.NoError(t, err)
+			before := append([]Label(nil), base...)
+
+			gotLabels, gotKey, err := mergeCanonicalLabel(base, tc.extra)
+			require.NoError(t, err)
+
+			reference := make(map[string]string, len(tc.base)+1)
+			for key, value := range tc.base {
+				reference[key] = value
+			}
+			reference[tc.extra.Key] = tc.extra.Value
+			wantLabels, wantKey, err := canonicalizeLabels(reference)
+			require.NoError(t, err)
+
+			require.Equal(t, wantLabels, gotLabels)
+			require.Equal(t, wantKey, gotKey)
+			require.Equal(t, before, base, "merge mutated canonical source labels")
+		})
+	}
+}
+
+func TestMergeCanonicalLabelRejectsEmptyKey(t *testing.T) {
+	labels, key, err := mergeCanonicalLabel(
+		[]Label{{Key: "a", Value: "value"}},
+		Label{Value: "invalid"},
+	)
+	require.ErrorIs(t, err, errInvalidLabelKey)
+	require.Nil(t, labels)
+	require.Empty(t, key)
+}

--- a/src/go/pkg/metrix/labels_merge_test.go
+++ b/src/go/pkg/metrix/labels_merge_test.go
@@ -3,6 +3,7 @@
 package metrix
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -52,9 +53,7 @@ func TestMergeCanonicalLabelMatchesCanonicalizeLabels(t *testing.T) {
 			require.NoError(t, err)
 
 			reference := make(map[string]string, len(tc.base)+1)
-			for key, value := range tc.base {
-				reference[key] = value
-			}
+			maps.Copy(reference, tc.base)
 			reference[tc.extra.Key] = tc.extra.Value
 			wantLabels, wantKey, err := canonicalizeLabels(reference)
 			require.NoError(t, err)

--- a/src/go/pkg/metrix/reader_bench_test.go
+++ b/src/go/pkg/metrix/reader_bench_test.go
@@ -92,18 +92,18 @@ func BenchmarkRuntimeOverlayValueLookup(b *testing.B) {
 	}
 }
 
-func benchmarkCommittedScalarStore(b *testing.B, totalSeries int) CollectorStore {
-	b.Helper()
+func benchmarkCommittedScalarStore(tb testing.TB, totalSeries int) CollectorStore {
+	tb.Helper()
 
 	s := NewCollectorStore()
-	cc := benchmarkCycleController(b, s)
+	cc := benchmarkCycleController(tb, s)
 	gv := s.Write().SnapshotMeter("reader.scalar").Vec("id").Gauge("value")
 	handles := make([]SnapshotGauge, totalSeries)
 
 	for i := range totalSeries {
 		h, err := gv.GetWithLabelValues(strconv.Itoa(i))
 		if err != nil {
-			b.Fatalf("create gauge handle: %v", err)
+			tb.Fatalf("create gauge handle: %v", err)
 		}
 		handles[i] = h
 	}
@@ -113,17 +113,17 @@ func benchmarkCommittedScalarStore(b *testing.B, totalSeries int) CollectorStore
 		h.Observe(SampleValue(i))
 	}
 	if err := cc.CommitCycleSuccess(); err != nil {
-		b.Fatalf("commit scalar store: %v", err)
+		tb.Fatalf("commit scalar store: %v", err)
 	}
 
 	return s
 }
 
-func benchmarkCommittedMixedStore(b *testing.B, totalSeries int) CollectorStore {
-	b.Helper()
+func benchmarkCommittedMixedStore(tb testing.TB, totalSeries int) CollectorStore {
+	tb.Helper()
 
 	s := NewCollectorStore()
-	cc := benchmarkCycleController(b, s)
+	cc := benchmarkCycleController(tb, s)
 	m := s.Write().SnapshotMeter("reader.flatten")
 	hv := m.Vec("id").Histogram("latency", WithHistogramBounds(1, 2, 5))
 	sv := m.Vec("id").Summary("request_time", WithSummaryQuantiles(0.5, 0.9, 0.99))
@@ -143,25 +143,25 @@ func benchmarkCommittedMixedStore(b *testing.B, totalSeries int) CollectorStore 
 
 		h, err := hv.GetWithLabelValues(id)
 		if err != nil {
-			b.Fatalf("create histogram handle: %v", err)
+			tb.Fatalf("create histogram handle: %v", err)
 		}
 		hists[i] = h
 
 		sum, err := sv.GetWithLabelValues(id)
 		if err != nil {
-			b.Fatalf("create summary handle: %v", err)
+			tb.Fatalf("create summary handle: %v", err)
 		}
 		summaries[i] = sum
 
 		state, err := ssv.GetWithLabelValues(id)
 		if err != nil {
-			b.Fatalf("create stateset handle: %v", err)
+			tb.Fatalf("create stateset handle: %v", err)
 		}
 		states[i] = state
 
 		measureSet, err := msv.GetWithLabelValues(id)
 		if err != nil {
-			b.Fatalf("create measureset handle: %v", err)
+			tb.Fatalf("create measureset handle: %v", err)
 		}
 		measureSets[i] = measureSet
 	}
@@ -199,7 +199,7 @@ func benchmarkCommittedMixedStore(b *testing.B, totalSeries int) CollectorStore 
 		})
 	}
 	if err := cc.CommitCycleSuccess(); err != nil {
-		b.Fatalf("commit mixed store: %v", err)
+		tb.Fatalf("commit mixed store: %v", err)
 	}
 
 	return s

--- a/src/go/pkg/metrix/reader_flatten.go
+++ b/src/go/pkg/metrix/reader_flatten.go
@@ -44,43 +44,41 @@ func appendFlattenedHistogramSeries(dst *readSnapshot, src *committedSeries) {
 		return
 	}
 
+	bucketName := src.name + "_bucket"
+	bucketDesc := &instrumentDescriptor{
+		name:      bucketName,
+		kind:      kindCounter,
+		mode:      src.desc.mode,
+		freshness: src.desc.freshness,
+		window:    src.desc.window,
+		meta:      src.desc.meta,
+	}
 	prevCumulative := SampleValue(0)
 	for i, ub := range schema.bounds {
 		cumulative := src.histogramCumulative[i]
 		bucketValue := cumulative - prevCumulative
 		prevCumulative = cumulative
 
-		labelsMap := make(map[string]string, len(src.labels)+1)
-		for _, lbl := range src.labels {
-			labelsMap[lbl.Key] = lbl.Value
-		}
-		labelsMap[HistogramBucketLabel] = formatHistogramBucketLabel(ub)
-
-		labels, labelsKey, err := canonicalizeLabels(labelsMap)
+		labels, labelsKey, err := mergeCanonicalLabel(src.labels, Label{
+			Key:   HistogramBucketLabel,
+			Value: formatHistogramBucketLabel(ub),
+		})
 		if err != nil {
 			continue
 		}
 
-		name := src.name + "_bucket"
-		key := makeSeriesKey(src.hostScopeKey, name, labelsKey)
+		key := makeSeriesKey(src.hostScopeKey, bucketName, labelsKey)
 		series := &committedSeries{
 			id:           SeriesID(key),
 			hash64:       seriesIDHash(SeriesID(key)),
 			key:          key,
-			name:         name,
+			name:         bucketName,
 			hostScopeKey: src.hostScopeKey,
 			hostScope:    src.hostScope,
 			labels:       labels,
 			labelsKey:    labelsKey,
-			desc: &instrumentDescriptor{
-				name:      name,
-				kind:      kindCounter,
-				mode:      src.desc.mode,
-				freshness: src.desc.freshness,
-				window:    src.desc.window,
-				meta:      src.desc.meta,
-			},
-			value: bucketValue,
+			desc:         bucketDesc,
+			value:        bucketValue,
 			meta: flattenedSeriesMeta(
 				src.meta,
 				MetricKindCounter,
@@ -97,33 +95,23 @@ func appendFlattenedHistogramSeries(dst *readSnapshot, src *committedSeries) {
 		dst.series[key] = series
 	}
 
-	infMap := make(map[string]string, len(src.labels)+1)
-	for _, lbl := range src.labels {
-		infMap[lbl.Key] = lbl.Value
-	}
-	infMap[HistogramBucketLabel] = formatHistogramBucketLabel(math.Inf(1))
-	infLabels, infLabelsKey, err := canonicalizeLabels(infMap)
+	infLabels, infLabelsKey, err := mergeCanonicalLabel(src.labels, Label{
+		Key:   HistogramBucketLabel,
+		Value: formatHistogramBucketLabel(math.Inf(1)),
+	})
 	if err == nil {
-		infName := src.name + "_bucket"
-		infKey := makeSeriesKey(src.hostScopeKey, infName, infLabelsKey)
+		infKey := makeSeriesKey(src.hostScopeKey, bucketName, infLabelsKey)
 		series := &committedSeries{
 			id:           SeriesID(infKey),
 			hash64:       seriesIDHash(SeriesID(infKey)),
 			key:          infKey,
-			name:         infName,
+			name:         bucketName,
 			hostScopeKey: src.hostScopeKey,
 			hostScope:    src.hostScope,
 			labels:       infLabels,
 			labelsKey:    infLabelsKey,
-			desc: &instrumentDescriptor{
-				name:      infName,
-				kind:      kindCounter,
-				mode:      src.desc.mode,
-				freshness: src.desc.freshness,
-				window:    src.desc.window,
-				meta:      src.desc.meta,
-			},
-			value: src.histogramCount - prevCumulative,
+			desc:         bucketDesc,
+			value:        src.histogramCount - prevCumulative,
 			meta: flattenedSeriesMeta(
 				src.meta,
 				MetricKindCounter,
@@ -147,36 +135,24 @@ func appendFlattenedHistogramSeries(dst *readSnapshot, src *committedSeries) {
 		dst,
 		src,
 		src.name+"_count",
-		src.labels,
 		src.histogramCount,
 		src.histogramPreviousCount,
 		flattenedCounterDeltaSupported(src) && src.histogramHasPrev,
 		flattenedSeriesMeta(src.meta, MetricKindCounter, MetricKindHistogram, FlattenRoleHistogramCount),
-		src.desc,
 	)
 	appendFlattenedHistogramScalar(
 		dst,
 		src,
 		src.name+"_sum",
-		src.labels,
 		src.histogramSum,
 		src.histogramPreviousSum,
 		flattenedCounterDeltaSupported(src) && src.histogramHasPrev,
 		flattenedSeriesMeta(src.meta, MetricKindCounter, MetricKindHistogram, FlattenRoleHistogramSum),
-		src.desc,
 	)
 }
 
-func appendFlattenedHistogramScalar(dst *readSnapshot, src *committedSeries, name string, labels []Label, value, previous SampleValue, hasPrev bool, meta SeriesMeta, desc *instrumentDescriptor) {
-	labelsMap := make(map[string]string, len(labels))
-	for _, lbl := range labels {
-		labelsMap[lbl.Key] = lbl.Value
-	}
-	items, labelsKey, err := canonicalizeLabels(labelsMap)
-	if err != nil {
-		return
-	}
-	key := makeSeriesKey(src.hostScopeKey, name, labelsKey)
+func appendFlattenedHistogramScalar(dst *readSnapshot, src *committedSeries, name string, value, previous SampleValue, hasPrev bool, meta SeriesMeta) {
+	key := makeSeriesKey(src.hostScopeKey, name, src.labelsKey)
 	series := &committedSeries{
 		id:           SeriesID(key),
 		hash64:       seriesIDHash(SeriesID(key)),
@@ -184,15 +160,15 @@ func appendFlattenedHistogramScalar(dst *readSnapshot, src *committedSeries, nam
 		name:         name,
 		hostScopeKey: src.hostScopeKey,
 		hostScope:    src.hostScope,
-		labels:       items,
-		labelsKey:    labelsKey,
+		labels:       src.labels,
+		labelsKey:    src.labelsKey,
 		desc: &instrumentDescriptor{
 			name:      name,
 			kind:      kindCounter,
-			mode:      desc.mode,
-			freshness: desc.freshness,
-			window:    desc.window,
-			meta:      desc.meta,
+			mode:      src.desc.mode,
+			freshness: src.desc.freshness,
+			window:    src.desc.window,
+			meta:      src.desc.meta,
 		},
 		value: value,
 		meta:  meta,
@@ -212,37 +188,38 @@ func appendFlattenedSummarySeries(dst *readSnapshot, src *committedSeries) {
 		dst,
 		src,
 		src.name+"_count",
-		src.labels,
 		src.summaryCount,
 		src.summaryPreviousCount,
 		flattenedCounterDeltaSupported(src) && src.summaryHasPrev,
 		flattenedSeriesMeta(src.meta, MetricKindCounter, MetricKindSummary, FlattenRoleSummaryCount),
-		src.desc,
 	)
 	appendFlattenedHistogramScalar(
 		dst,
 		src,
 		src.name+"_sum",
-		src.labels,
 		src.summarySum,
 		src.summaryPreviousSum,
 		flattenedCounterDeltaSupported(src) && src.summaryHasPrev,
 		flattenedSeriesMeta(src.meta, MetricKindCounter, MetricKindSummary, FlattenRoleSummarySum),
-		src.desc,
 	)
 
-	if schema == nil {
+	if schema == nil || len(schema.quantiles) == 0 {
 		return
 	}
 
+	quantileDesc := &instrumentDescriptor{
+		name:      src.name,
+		kind:      kindGauge,
+		mode:      src.desc.mode,
+		freshness: src.desc.freshness,
+		window:    src.desc.window,
+		meta:      src.desc.meta,
+	}
 	for i, q := range schema.quantiles {
-		labelsMap := make(map[string]string, len(src.labels)+1)
-		for _, lbl := range src.labels {
-			labelsMap[lbl.Key] = lbl.Value
-		}
-		labelsMap[SummaryQuantileLabel] = formatSummaryQuantileLabel(q)
-
-		labels, labelsKey, err := canonicalizeLabels(labelsMap)
+		labels, labelsKey, err := mergeCanonicalLabel(src.labels, Label{
+			Key:   SummaryQuantileLabel,
+			Value: formatSummaryQuantileLabel(q),
+		})
 		if err != nil {
 			continue
 		}
@@ -256,15 +233,8 @@ func appendFlattenedSummarySeries(dst *readSnapshot, src *committedSeries) {
 			hostScope:    src.hostScope,
 			labels:       labels,
 			labelsKey:    labelsKey,
-			desc: &instrumentDescriptor{
-				name:      src.name,
-				kind:      kindGauge,
-				mode:      src.desc.mode,
-				freshness: src.desc.freshness,
-				window:    src.desc.window,
-				meta:      src.desc.meta,
-			},
-			value: src.summaryQuantiles[i],
+			desc:         quantileDesc,
+			value:        src.summaryQuantiles[i],
 			meta: flattenedSeriesMeta(
 				src.meta,
 				MetricKindGauge,
@@ -338,19 +308,24 @@ func appendFlattenedStateSetSeries(dst *readSnapshot, src *committedSeries) {
 		return
 	}
 
+	stateDesc := &instrumentDescriptor{
+		name:      src.name,
+		kind:      kindGauge,
+		mode:      src.desc.mode,
+		freshness: src.desc.freshness,
+		window:    src.desc.window,
+		meta:      src.desc.meta,
+	}
 	for _, state := range schema.states {
 		value := SampleValue(0)
 		if src.stateSetValues[state] {
 			value = 1
 		}
 
-		labelsMap := make(map[string]string, len(src.labels)+1)
-		for _, lbl := range src.labels {
-			labelsMap[lbl.Key] = lbl.Value
-		}
-		labelsMap[src.name] = state
-
-		labels, labelsKey, err := canonicalizeLabels(labelsMap)
+		labels, labelsKey, err := mergeCanonicalLabel(src.labels, Label{
+			Key:   src.name,
+			Value: state,
+		})
 		if err != nil {
 			continue
 		}
@@ -365,15 +340,8 @@ func appendFlattenedStateSetSeries(dst *readSnapshot, src *committedSeries) {
 			hostScope:    src.hostScope,
 			labels:       labels,
 			labelsKey:    labelsKey,
-			desc: &instrumentDescriptor{
-				name:      src.name,
-				kind:      kindGauge,
-				mode:      src.desc.mode,
-				freshness: src.desc.freshness,
-				window:    src.desc.window,
-				meta:      src.desc.meta,
-			},
-			value: value,
+			desc:         stateDesc,
+			value:        value,
 			meta: flattenedSeriesMeta(
 				src.meta,
 				MetricKindGauge,
@@ -398,13 +366,10 @@ func appendFlattenedMeasureSetSeries(dst *readSnapshot, src *committedSeries) {
 	}
 
 	for i, field := range schema.fields {
-		labelsMap := make(map[string]string, len(src.labels)+1)
-		for _, lbl := range src.labels {
-			labelsMap[lbl.Key] = lbl.Value
-		}
-		labelsMap[MeasureSetFieldLabel] = field.Name
-
-		labels, labelsKey, err := canonicalizeLabels(labelsMap)
+		labels, labelsKey, err := mergeCanonicalLabel(src.labels, Label{
+			Key:   MeasureSetFieldLabel,
+			Value: field.Name,
+		})
 		if err != nil {
 			continue
 		}

--- a/src/go/pkg/metrix/reader_flatten_identity_test.go
+++ b/src/go/pkg/metrix/reader_flatten_identity_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenSnapshotPreservesCanonicalSeriesIdentity(t *testing.T) {
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	meter := store.Write().SnapshotMeter("svc")
+	labelNames := []string{"a", "m", "z"}
+	labelValues := []string{"first", "middle", "last"}
+
+	histogram, err := meter.Vec(labelNames...).Histogram("latency", WithHistogramBounds(1, 2)).GetWithLabelValues(labelValues...)
+	require.NoError(t, err)
+	summary, err := meter.Vec(labelNames...).Summary("duration", WithSummaryQuantiles(0.5, 0.9)).GetWithLabelValues(labelValues...)
+	require.NoError(t, err)
+	stateSet, err := meter.Vec(labelNames...).StateSet(
+		"mode",
+		WithStateSetStates("maintenance", "operational"),
+		WithStateSetMode(ModeEnum),
+	).GetWithLabelValues(labelValues...)
+	require.NoError(t, err)
+	measureSet, err := meter.Vec(labelNames...).MeasureSetGauge(
+		"payload",
+		WithMeasureSetFields(
+			MeasureFieldSpec{Name: "bytes"},
+			MeasureFieldSpec{Name: "rows"},
+		),
+	).GetWithLabelValues(labelValues...)
+	require.NoError(t, err)
+
+	cycle.BeginCycle()
+	histogram.ObservePoint(HistogramPoint{
+		Count: 3,
+		Sum:   4,
+		Buckets: []BucketPoint{
+			{UpperBound: 1, CumulativeCount: 1},
+			{UpperBound: 2, CumulativeCount: 2},
+		},
+	})
+	summary.ObservePoint(SummaryPoint{
+		Count: 2,
+		Sum:   3,
+		Quantiles: []QuantilePoint{
+			{Quantile: 0.5, Value: 1},
+			{Quantile: 0.9, Value: 2},
+		},
+	})
+	stateSet.ObserveStateSet(StateSetPoint{
+		States: map[string]bool{"operational": true},
+	})
+	measureSet.ObservePoint(MeasureSetPoint{Values: []SampleValue{128, 4}})
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	snapshot := store.(*storeView).core.snapshot.Load()
+	sourceLabels := make(map[string][]Label, len(snapshot.series))
+	for key, series := range snapshot.series {
+		sourceLabels[key] = append([]Label(nil), series.labels...)
+	}
+
+	flat := flattenSnapshot(snapshot)
+	baseLabels := map[string]string{"a": "first", "m": "middle", "z": "last"}
+
+	requireFlattenedSeriesIdentity(t, flat, "svc.latency_count", baseLabels)
+	requireFlattenedSeriesIdentity(t, flat, "svc.latency_sum", baseLabels)
+	requireFlattenedSeriesIdentity(t, flat, "svc.latency_bucket", labelsWith(baseLabels, HistogramBucketLabel, "1"))
+	requireFlattenedSeriesIdentity(t, flat, "svc.latency_bucket", labelsWith(baseLabels, HistogramBucketLabel, "+Inf"))
+	requireFlattenedSeriesIdentity(t, flat, "svc.duration_count", baseLabels)
+	requireFlattenedSeriesIdentity(t, flat, "svc.duration_sum", baseLabels)
+	requireFlattenedSeriesIdentity(t, flat, "svc.duration", labelsWith(baseLabels, SummaryQuantileLabel, "0.5"))
+	requireFlattenedSeriesIdentity(t, flat, "svc.mode", labelsWith(baseLabels, "svc.mode", "operational"))
+	requireFlattenedSeriesIdentity(t, flat, "svc.payload_bytes", labelsWith(baseLabels, MeasureSetFieldLabel, "bytes"))
+
+	histogramSource := requireSnapshotSeriesByName(t, snapshot, "svc.latency")
+	require.Same(t, &histogramSource.labels[0], &requireFlattenedSeries(t, flat, "svc.latency_count", baseLabels).labels[0])
+	require.Same(t, &histogramSource.labels[0], &requireFlattenedSeries(t, flat, "svc.latency_sum", baseLabels).labels[0])
+	summarySource := requireSnapshotSeriesByName(t, snapshot, "svc.duration")
+	require.Same(t, &summarySource.labels[0], &requireFlattenedSeries(t, flat, "svc.duration_count", baseLabels).labels[0])
+	require.Same(t, &summarySource.labels[0], &requireFlattenedSeries(t, flat, "svc.duration_sum", baseLabels).labels[0])
+
+	for key, want := range sourceLabels {
+		require.Equal(t, want, snapshot.series[key].labels, "flattening mutated source labels for %q", key)
+	}
+}
+
+func TestFlattenSnapshotReusesRoleDescriptorsWithinSourceSeries(t *testing.T) {
+	store := NewCollectorStore()
+	cycle := cycleController(t, store)
+	meter := store.Write().SnapshotMeter("svc")
+
+	histogram := meter.Histogram("latency", WithHistogramBounds(1, 2))
+	summary := meter.Summary("duration", WithSummaryQuantiles(0.5, 0.9))
+	stateSet := meter.StateSet(
+		"mode",
+		WithStateSetStates("maintenance", "operational"),
+		WithStateSetMode(ModeEnum),
+	)
+
+	cycle.BeginCycle()
+	histogram.ObservePoint(HistogramPoint{
+		Count: 3,
+		Sum:   4,
+		Buckets: []BucketPoint{
+			{UpperBound: 1, CumulativeCount: 1},
+			{UpperBound: 2, CumulativeCount: 2},
+		},
+	})
+	summary.ObservePoint(SummaryPoint{
+		Count: 2,
+		Sum:   3,
+		Quantiles: []QuantilePoint{
+			{Quantile: 0.5, Value: 1},
+			{Quantile: 0.9, Value: 2},
+		},
+	})
+	stateSet.ObserveStateSet(StateSetPoint{
+		States: map[string]bool{"operational": true},
+	})
+	require.NoError(t, cycle.CommitCycleSuccess())
+
+	flat := flattenSnapshot(store.(*storeView).core.snapshot.Load())
+	bucketOne := requireFlattenedSeries(t, flat, "svc.latency_bucket", map[string]string{HistogramBucketLabel: "1"})
+	bucketTwo := requireFlattenedSeries(t, flat, "svc.latency_bucket", map[string]string{HistogramBucketLabel: "2"})
+	bucketInf := requireFlattenedSeries(t, flat, "svc.latency_bucket", map[string]string{HistogramBucketLabel: "+Inf"})
+	require.Same(t, bucketOne.desc, bucketTwo.desc)
+	require.Same(t, bucketOne.desc, bucketInf.desc)
+	require.NotSame(t, bucketOne.desc, requireFlattenedSeries(t, flat, "svc.latency_count", nil).desc)
+	require.NotSame(t, bucketOne.desc, requireFlattenedSeries(t, flat, "svc.latency_sum", nil).desc)
+
+	quantileHalf := requireFlattenedSeries(t, flat, "svc.duration", map[string]string{SummaryQuantileLabel: "0.5"})
+	quantileNinety := requireFlattenedSeries(t, flat, "svc.duration", map[string]string{SummaryQuantileLabel: "0.9"})
+	require.Same(t, quantileHalf.desc, quantileNinety.desc)
+	require.NotSame(t, quantileHalf.desc, requireFlattenedSeries(t, flat, "svc.duration_count", nil).desc)
+	require.NotSame(t, quantileHalf.desc, requireFlattenedSeries(t, flat, "svc.duration_sum", nil).desc)
+
+	stateMaintenance := requireFlattenedSeries(t, flat, "svc.mode", map[string]string{"svc.mode": "maintenance"})
+	stateOperational := requireFlattenedSeries(t, flat, "svc.mode", map[string]string{"svc.mode": "operational"})
+	require.Same(t, stateMaintenance.desc, stateOperational.desc)
+}
+
+func requireFlattenedSeriesIdentity(t *testing.T, snapshot *readSnapshot, name string, labels map[string]string) {
+	t.Helper()
+
+	series := requireFlattenedSeries(t, snapshot, name, labels)
+	items, labelsKey, err := canonicalizeLabels(labels)
+	require.NoError(t, err)
+	key := makeSeriesKey("", name, labelsKey)
+	require.Equal(t, items, series.labels)
+	require.Equal(t, labelsKey, series.labelsKey)
+	require.Equal(t, key, series.key)
+	require.Equal(t, SeriesID(key), series.id)
+	require.Equal(t, seriesIDHash(SeriesID(key)), series.hash64)
+}
+
+func requireFlattenedSeries(t *testing.T, snapshot *readSnapshot, name string, labels map[string]string) *committedSeries {
+	t.Helper()
+
+	_, labelsKey, err := canonicalizeLabels(labels)
+	require.NoError(t, err)
+	key := makeSeriesKey("", name, labelsKey)
+	series := snapshot.series[key]
+	require.NotNil(t, series, "missing flattened series %q", key)
+	return series
+}
+
+func requireSnapshotSeriesByName(t *testing.T, snapshot *readSnapshot, name string) *committedSeries {
+	t.Helper()
+
+	for _, series := range snapshot.series {
+		if series.name == name {
+			return series
+		}
+	}
+	require.FailNow(t, "missing source series", name)
+	return nil
+}
+
+func labelsWith(base map[string]string, key, value string) map[string]string {
+	labels := make(map[string]string, len(base)+1)
+	for k, v := range base {
+		labels[k] = v
+	}
+	labels[key] = value
+	return labels
+}

--- a/src/go/pkg/metrix/reader_flatten_identity_test.go
+++ b/src/go/pkg/metrix/reader_flatten_identity_test.go
@@ -3,6 +3,7 @@
 package metrix
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,25 +36,7 @@ func TestFlattenSnapshotPreservesCanonicalSeriesIdentity(t *testing.T) {
 	require.NoError(t, err)
 
 	cycle.BeginCycle()
-	histogram.ObservePoint(HistogramPoint{
-		Count: 3,
-		Sum:   4,
-		Buckets: []BucketPoint{
-			{UpperBound: 1, CumulativeCount: 1},
-			{UpperBound: 2, CumulativeCount: 2},
-		},
-	})
-	summary.ObservePoint(SummaryPoint{
-		Count: 2,
-		Sum:   3,
-		Quantiles: []QuantilePoint{
-			{Quantile: 0.5, Value: 1},
-			{Quantile: 0.9, Value: 2},
-		},
-	})
-	stateSet.ObserveStateSet(StateSetPoint{
-		States: map[string]bool{"operational": true},
-	})
+	observeStructuredFlattenTestPoints(histogram, summary, stateSet)
 	measureSet.ObservePoint(MeasureSetPoint{Values: []SampleValue{128, 4}})
 	require.NoError(t, cycle.CommitCycleSuccess())
 
@@ -102,25 +85,7 @@ func TestFlattenSnapshotReusesRoleDescriptorsWithinSourceSeries(t *testing.T) {
 	)
 
 	cycle.BeginCycle()
-	histogram.ObservePoint(HistogramPoint{
-		Count: 3,
-		Sum:   4,
-		Buckets: []BucketPoint{
-			{UpperBound: 1, CumulativeCount: 1},
-			{UpperBound: 2, CumulativeCount: 2},
-		},
-	})
-	summary.ObservePoint(SummaryPoint{
-		Count: 2,
-		Sum:   3,
-		Quantiles: []QuantilePoint{
-			{Quantile: 0.5, Value: 1},
-			{Quantile: 0.9, Value: 2},
-		},
-	})
-	stateSet.ObserveStateSet(StateSetPoint{
-		States: map[string]bool{"operational": true},
-	})
+	observeStructuredFlattenTestPoints(histogram, summary, stateSet)
 	require.NoError(t, cycle.CommitCycleSuccess())
 
 	flat := flattenSnapshot(store.(*storeView).core.snapshot.Load())
@@ -141,6 +106,28 @@ func TestFlattenSnapshotReusesRoleDescriptorsWithinSourceSeries(t *testing.T) {
 	stateMaintenance := requireFlattenedSeries(t, flat, "svc.mode", map[string]string{"svc.mode": "maintenance"})
 	stateOperational := requireFlattenedSeries(t, flat, "svc.mode", map[string]string{"svc.mode": "operational"})
 	require.Same(t, stateMaintenance.desc, stateOperational.desc)
+}
+
+func observeStructuredFlattenTestPoints(histogram SnapshotHistogram, summary SnapshotSummary, stateSet StateSetInstrument) {
+	histogram.ObservePoint(HistogramPoint{
+		Count: 3,
+		Sum:   4,
+		Buckets: []BucketPoint{
+			{UpperBound: 1, CumulativeCount: 1},
+			{UpperBound: 2, CumulativeCount: 2},
+		},
+	})
+	summary.ObservePoint(SummaryPoint{
+		Count: 2,
+		Sum:   3,
+		Quantiles: []QuantilePoint{
+			{Quantile: 0.5, Value: 1},
+			{Quantile: 0.9, Value: 2},
+		},
+	})
+	stateSet.ObserveStateSet(StateSetPoint{
+		States: map[string]bool{"operational": true},
+	})
 }
 
 func requireFlattenedSeriesIdentity(t *testing.T, snapshot *readSnapshot, name string, labels map[string]string) {
@@ -182,9 +169,7 @@ func requireSnapshotSeriesByName(t *testing.T, snapshot *readSnapshot, name stri
 
 func labelsWith(base map[string]string, key, value string) map[string]string {
 	labels := make(map[string]string, len(base)+1)
-	for k, v := range base {
-		labels[k] = v
-	}
+	maps.Copy(labels, base)
 	labels[key] = value
 	return labels
 }

--- a/src/go/pkg/metrix/reader_flatten_identity_test.go
+++ b/src/go/pkg/metrix/reader_flatten_identity_test.go
@@ -108,6 +108,89 @@ func TestFlattenSnapshotReusesRoleDescriptorsWithinSourceSeries(t *testing.T) {
 	require.Same(t, stateMaintenance.desc, stateOperational.desc)
 }
 
+func TestFlattenSnapshotAllocationEnvelope(t *testing.T) {
+	const highCardinality = 512
+
+	// Scalar flattening shares canonical series and must stay cardinality-independent.
+	// Structured flattening must stay linear in source series and projected outputs;
+	// these limits also pin the reduced per-output allocation shape.
+	tests := map[string]struct {
+		store      func(testing.TB) CollectorStore
+		wantSeries int
+		maxAllocs  float64
+	}{
+		"scalar allocations stay O(1) with cardinality": {
+			store: func(tb testing.TB) CollectorStore {
+				return benchmarkCommittedScalarStore(tb, highCardinality)
+			},
+			wantSeries: highCardinality,
+			maxAllocs:  25,
+		},
+		"mixed structured allocations stay linear at low cardinality": {
+			store: func(tb testing.TB) CollectorStore {
+				return benchmarkCommittedMixedStore(tb, 32)
+			},
+			wantSeries: 15 * 32,
+			maxAllocs:  100 * 32,
+		},
+		"mixed structured allocations stay linear at high cardinality": {
+			store: func(tb testing.TB) CollectorStore {
+				return benchmarkCommittedMixedStore(tb, highCardinality)
+			},
+			wantSeries: 15 * highCardinality,
+			maxAllocs:  100 * highCardinality,
+		},
+		"histogram allocations stay linear with eight labels": {
+			store: func(tb testing.TB) CollectorStore {
+				return benchmarkCommittedHistogramStore(tb, 32, 8)
+			},
+			wantSeries: 15 * 32,
+			maxAllocs:  140 * 32,
+		},
+		"summary allocations stay linear with eight labels and quantiles": {
+			store: func(tb testing.TB) CollectorStore {
+				return benchmarkCommittedSummaryStore(tb, 32, 8, 8)
+			},
+			wantSeries: 10 * 32,
+			maxAllocs:  105 * 32,
+		},
+		"stateset allocations stay linear with eight labels and states": {
+			store: func(tb testing.TB) CollectorStore {
+				return benchmarkCommittedStateSetStore(tb, 32, 8, 8)
+			},
+			wantSeries: 8 * 32,
+			maxAllocs:  85 * 32,
+		},
+		"measureset gauge allocations stay linear with eight labels and fields": {
+			store: func(tb testing.TB) CollectorStore {
+				return benchmarkCommittedMeasureSetStore(tb, 32, 8, 8, MeasureSetSemanticsGauge)
+			},
+			wantSeries: 8 * 32,
+			maxAllocs:  105 * 32,
+		},
+		"measureset counter allocations stay linear with eight labels and fields": {
+			store: func(tb testing.TB) CollectorStore {
+				return benchmarkCommittedMeasureSetStore(tb, 32, 8, 8, MeasureSetSemanticsCounter)
+			},
+			wantSeries: 8 * 32,
+			maxAllocs:  105 * 32,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := tc.store(t)
+			snapshot := store.(*storeView).core.snapshot.Load()
+			requireFlattenProjectionSeries(t, snapshot, tc.wantSeries)
+
+			allocs := testing.AllocsPerRun(3, func() {
+				benchmarkReaderCountSink = len(flattenSnapshot(snapshot).series)
+			})
+			require.LessOrEqualf(t, allocs, tc.maxAllocs, "flatten allocations %.0f exceed limit %.0f", allocs, tc.maxAllocs)
+		})
+	}
+}
+
 func observeStructuredFlattenTestPoints(histogram SnapshotHistogram, summary SnapshotSummary, stateSet StateSetInstrument) {
 	histogram.ObservePoint(HistogramPoint{
 		Count: 3,

--- a/src/go/pkg/metrix/reader_flatten_identity_test.go
+++ b/src/go/pkg/metrix/reader_flatten_identity_test.go
@@ -109,84 +109,108 @@ func TestFlattenSnapshotReusesRoleDescriptorsWithinSourceSeries(t *testing.T) {
 }
 
 func TestFlattenSnapshotAllocationEnvelope(t *testing.T) {
-	const highCardinality = 512
+	const (
+		lowCardinality  = 32
+		highCardinality = 512
+		cardinalityRate = highCardinality / lowCardinality
+		growthSlack     = 1.10
+	)
 
-	// Scalar flattening shares canonical series and must stay cardinality-independent.
-	// Structured flattening must stay linear in source series and projected outputs;
-	// these limits also pin the reduced per-output allocation shape.
+	measure := func(t *testing.T, store CollectorStore, wantSeries int) float64 {
+		t.Helper()
+		snapshot := store.(*storeView).core.snapshot.Load()
+		requireFlattenProjectionSeries(t, snapshot, wantSeries)
+		return testing.AllocsPerRun(3, func() {
+			benchmarkReaderCountSink = len(flattenSnapshot(snapshot).series)
+		})
+	}
+
+	t.Run("scalar projection allocation count stays bounded", func(t *testing.T) {
+		low := measure(t, benchmarkCommittedScalarStore(t, lowCardinality), lowCardinality)
+		high := measure(t, benchmarkCommittedScalarStore(t, highCardinality), highCardinality)
+
+		// Scalar projection shares committed series. Map and index growth may add
+		// a few allocation events, but must not add per-series object allocations.
+		require.LessOrEqualf(t, low, float64(20), "low-cardinality scalar allocations = %.0f", low)
+		require.LessOrEqualf(t, high, float64(25), "high-cardinality scalar allocations = %.0f", high)
+		require.LessOrEqualf(t, high, low*2, "%dx cardinality grew scalar allocations from %.0f to %.0f", cardinalityRate, low, high)
+	})
+
 	tests := map[string]struct {
-		store      func(testing.TB) CollectorStore
-		wantSeries int
-		maxAllocs  float64
+		store               func(testing.TB, int) CollectorStore
+		wantSeriesPerSource int
+		maxAllocsPerSource  float64
 	}{
-		"scalar allocations stay O(1) with cardinality": {
-			store: func(tb testing.TB) CollectorStore {
-				return benchmarkCommittedScalarStore(tb, highCardinality)
+		"mixed structured": {
+			store: func(tb testing.TB, totalSeries int) CollectorStore {
+				return benchmarkCommittedMixedStore(tb, totalSeries)
 			},
-			wantSeries: highCardinality,
-			maxAllocs:  25,
+			wantSeriesPerSource: 15,
+			maxAllocsPerSource:  100,
 		},
-		"mixed structured allocations stay linear at low cardinality": {
-			store: func(tb testing.TB) CollectorStore {
-				return benchmarkCommittedMixedStore(tb, 32)
+		"histogram with eight labels": {
+			store: func(tb testing.TB, totalSeries int) CollectorStore {
+				return benchmarkCommittedHistogramStore(tb, totalSeries, 8)
 			},
-			wantSeries: 15 * 32,
-			maxAllocs:  100 * 32,
+			wantSeriesPerSource: 15,
+			maxAllocsPerSource:  140,
 		},
-		"mixed structured allocations stay linear at high cardinality": {
-			store: func(tb testing.TB) CollectorStore {
-				return benchmarkCommittedMixedStore(tb, highCardinality)
+		"summary with eight labels and quantiles": {
+			store: func(tb testing.TB, totalSeries int) CollectorStore {
+				return benchmarkCommittedSummaryStore(tb, totalSeries, 8, 8)
 			},
-			wantSeries: 15 * highCardinality,
-			maxAllocs:  100 * highCardinality,
+			wantSeriesPerSource: 10,
+			maxAllocsPerSource:  105,
 		},
-		"histogram allocations stay linear with eight labels": {
-			store: func(tb testing.TB) CollectorStore {
-				return benchmarkCommittedHistogramStore(tb, 32, 8)
+		"stateset with eight labels and states": {
+			store: func(tb testing.TB, totalSeries int) CollectorStore {
+				return benchmarkCommittedStateSetStore(tb, totalSeries, 8, 8)
 			},
-			wantSeries: 15 * 32,
-			maxAllocs:  140 * 32,
+			wantSeriesPerSource: 8,
+			maxAllocsPerSource:  85,
 		},
-		"summary allocations stay linear with eight labels and quantiles": {
-			store: func(tb testing.TB) CollectorStore {
-				return benchmarkCommittedSummaryStore(tb, 32, 8, 8)
+		"measureset gauge with eight labels and fields": {
+			store: func(tb testing.TB, totalSeries int) CollectorStore {
+				return benchmarkCommittedMeasureSetStore(tb, totalSeries, 8, 8, MeasureSetSemanticsGauge)
 			},
-			wantSeries: 10 * 32,
-			maxAllocs:  105 * 32,
+			wantSeriesPerSource: 8,
+			maxAllocsPerSource:  105,
 		},
-		"stateset allocations stay linear with eight labels and states": {
-			store: func(tb testing.TB) CollectorStore {
-				return benchmarkCommittedStateSetStore(tb, 32, 8, 8)
+		"measureset counter with eight labels and fields": {
+			store: func(tb testing.TB, totalSeries int) CollectorStore {
+				return benchmarkCommittedMeasureSetStore(tb, totalSeries, 8, 8, MeasureSetSemanticsCounter)
 			},
-			wantSeries: 8 * 32,
-			maxAllocs:  85 * 32,
-		},
-		"measureset gauge allocations stay linear with eight labels and fields": {
-			store: func(tb testing.TB) CollectorStore {
-				return benchmarkCommittedMeasureSetStore(tb, 32, 8, 8, MeasureSetSemanticsGauge)
-			},
-			wantSeries: 8 * 32,
-			maxAllocs:  105 * 32,
-		},
-		"measureset counter allocations stay linear with eight labels and fields": {
-			store: func(tb testing.TB) CollectorStore {
-				return benchmarkCommittedMeasureSetStore(tb, 32, 8, 8, MeasureSetSemanticsCounter)
-			},
-			wantSeries: 8 * 32,
-			maxAllocs:  105 * 32,
+			wantSeriesPerSource: 8,
+			maxAllocsPerSource:  105,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			store := tc.store(t)
-			snapshot := store.(*storeView).core.snapshot.Load()
-			requireFlattenProjectionSeries(t, snapshot, tc.wantSeries)
+			low := measure(
+				t,
+				tc.store(t, lowCardinality),
+				tc.wantSeriesPerSource*lowCardinality,
+			)
+			high := measure(
+				t,
+				tc.store(t, highCardinality),
+				tc.wantSeriesPerSource*highCardinality,
+			)
 
-			allocs := testing.AllocsPerRun(3, func() {
-				benchmarkReaderCountSink = len(flattenSnapshot(snapshot).series)
-			})
-			require.LessOrEqualf(t, allocs, tc.maxAllocs, "flatten allocations %.0f exceed limit %.0f", allocs, tc.maxAllocs)
+			lowLimit := tc.maxAllocsPerSource * lowCardinality
+			highLimit := tc.maxAllocsPerSource * highCardinality
+			require.LessOrEqualf(t, low, lowLimit, "low-cardinality allocations %.0f exceed limit %.0f", low, lowLimit)
+			require.LessOrEqualf(t, high, highLimit, "high-cardinality allocations %.0f exceed limit %.0f", high, highLimit)
+			require.LessOrEqualf(
+				t,
+				high,
+				low*cardinalityRate*growthSlack,
+				"%dx cardinality grew allocations from %.0f to %.0f",
+				cardinalityRate,
+				low,
+				high,
+			)
 		})
 	}
 }

--- a/src/go/pkg/metrix/runtime_store_bench_test.go
+++ b/src/go/pkg/metrix/runtime_store_bench_test.go
@@ -110,6 +110,22 @@ func BenchmarkRuntimeStoreMixedTypedWriteAndReadFlatten(b *testing.B) {
 	sum := m.Summary("request_time", WithSummaryQuantiles(0.5, 0.9, 0.99))
 	ss := m.StateSet("mode", WithStateSetStates("maintenance", "operational"), WithStateSetMode(ModeEnum))
 
+	// Seed stateful instruments so the preflight matches timed read visibility.
+	g.Set(0)
+	c.Add(1)
+	h.Observe(1)
+	sum.Observe(1)
+	ss.Enable("operational")
+
+	preflight := s.Read(ReadFlatten())
+	count := 0
+	preflight.ForEachSeries(func(_ string, _ LabelView, _ SampleValue) {
+		count++
+	})
+	if count != 15 {
+		b.Fatalf("expected 15 flattened series, got %d", count)
+	}
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/src/go/pkg/metrix/runtime_store_bench_test.go
+++ b/src/go/pkg/metrix/runtime_store_bench_test.go
@@ -36,6 +36,17 @@ import "testing"
 // BenchmarkRuntimeStoreGaugeParallelSet/p4-14               3797656     314.0 ns/op    622 B/op     4 allocs/op
 // BenchmarkRuntimeStoreGaugeParallelSet/p16-14              3520359     341.7 ns/op    622 B/op     4 allocs/op
 // BenchmarkRuntimeStoreMixedTypedWriteAndReadFlatten-14       93160   12230   ns/op  15275 B/op   159 allocs/op
+//
+// After structured flatten allocation optimization (2026-07-27):
+// Merge-base -> optimized; medians of -count=10 on the same developer laptop.
+// ns/op is a trend indicator, while bytes and allocations describe the stable
+// structural improvement.
+//
+//	go test -run '^$' -bench '^BenchmarkRuntimeStoreMixedTypedWriteAndReadFlatten$' -benchmem -benchtime=100ms -count=10 ./pkg/metrix
+//
+// BenchmarkRuntimeStoreMixedTypedWriteAndReadFlatten:
+// 15,579 ns/op, 20,943 B/op, 157 allocs/op ->
+// 15,192 ns/op, 20,103 B/op, 148 allocs/op.
 func BenchmarkRuntimeStoreCounterParallelAdd(b *testing.B) {
 	tests := map[string]struct {
 		parallelism int

--- a/src/go/pkg/metrix/runtime_store_bench_test.go
+++ b/src/go/pkg/metrix/runtime_store_bench_test.go
@@ -38,15 +38,18 @@ import "testing"
 // BenchmarkRuntimeStoreMixedTypedWriteAndReadFlatten-14       93160   12230   ns/op  15275 B/op   159 allocs/op
 //
 // After structured flatten allocation optimization (2026-07-27):
-// Merge-base -> optimized; medians of -count=10 on the same developer laptop.
-// ns/op is a trend indicator, while bytes and allocations describe the stable
-// structural improvement.
+// Merge-base production beede2920e18ec0e0efa3c522367ce26deec1281 ->
+// optimized production 1f59fa84ba593a0560663d1ce185542485eddf7d.
+// The 759296896a6758c2d8919df169a3d14807d6650d version of this benchmark
+// was overlaid unchanged onto clean trees at both revisions. Results are
+// medians of -count=10 on the same developer laptop. ns/op is a trend
+// indicator, while bytes and allocations describe the stable structural
+// improvement.
 //
 //	go test -run '^$' -bench '^BenchmarkRuntimeStoreMixedTypedWriteAndReadFlatten$' -benchmem -benchtime=100ms -count=10 ./pkg/metrix
 //
 // BenchmarkRuntimeStoreMixedTypedWriteAndReadFlatten:
-// 15,579 ns/op, 20,943 B/op, 157 allocs/op ->
-// 15,192 ns/op, 20,103 B/op, 148 allocs/op.
+// ns/op -4.4% local trend; 20,943 -> 20,103 B/op; 157 -> 148 allocs/op.
 func BenchmarkRuntimeStoreCounterParallelAdd(b *testing.B) {
 	tests := map[string]struct {
 		parallelism int

--- a/src/go/pkg/metrix/summary_bench_test.go
+++ b/src/go/pkg/metrix/summary_bench_test.go
@@ -139,11 +139,11 @@ func BenchmarkSummarySnapshotObservePoint(b *testing.B) {
 	}
 }
 
-func benchmarkCycleController(b *testing.B, s CollectorStore) CycleController {
-	b.Helper()
+func benchmarkCycleController(tb testing.TB, s CollectorStore) CycleController {
+	tb.Helper()
 	managed, ok := AsCycleManagedStore(s)
 	if !ok {
-		b.Fatalf("store does not expose cycle control")
+		tb.Fatalf("store does not expose cycle control")
 	}
 	return managed.CycleController()
 }


### PR DESCRIPTION
## Summary

- reuse immutable canonical labels and packed keys for flattened count/sum series
- replace per-output label maps and sorting with one ordered single-label merge
- reuse identical bucket, quantile, and StateSet descriptors within each source series
- add exact identity/immutability tests and cold-projection benchmark coverage

## Why

`flattenSnapshot` builds one flattened projection for each published collector snapshot. Structured outputs were still copying
canonical labels into maps, sorting them again, rebuilding known keys, and allocating identical descriptors inside output loops.

This removes only that redundant work. It adds no cross-cycle cache, retained state, pool, unsafe conversion, or public API change.

## Performance

Synthetic cold-projection microbenchmarks were run from separately compiled baseline/current test binaries over ten alternating
rounds with `GOMAXPROCS=4`. Values below are median changes; they are not end-to-end collector or production CPU claims.

| Workload | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| Mixed structured, 32 instances/type | -27.1% | -6.8% | -15.7% |
| Mixed structured, 512 instances/type | -24.0% | -6.8% | -16.0% |
| Histogram, 1 label, 32 instances | -27.8% | -13.0% | -23.3% |
| Histogram, 1 label, 512 instances | -11.5% | -12.8% | -23.4% |
| Histogram, 8 labels, 32 instances | -41.6% | -38.9% | -41.8% |
| Histogram, 8 labels, 512 instances | -42.5% | -38.8% | -42.0% |
| Summary without quantiles, 32 instances | -28.9% | -4.3% | -31.1% |
| Summary without quantiles, 512 instances | -29.2% | -4.3% | -33.1% |

Scalar cold-projection controls have exactly unchanged bytes and allocations and showed no repeatable timing regression.

## Compatibility and safety

- canonical label order, packed keys, series IDs, and hashes are compared against the existing canonicalization path
- count/sum label sharing is covered by the documented immutable snapshot-label contract
- descriptor sharing stays within one source series and preserves distinct role descriptors
- summaries without configured quantiles have dedicated regression benchmark coverage
- emitted metric identities, values, metadata, deltas, host scopes, and public APIs remain unchanged

## Validation

From `src/go`:

```text
go vet ./pkg/metrix/...
go test -count=1 -race ./pkg/metrix/... ./plugin/framework/chartengine/... ./plugin/framework/jobruntime/... ./plugin/agent/jobmgr/...
go test -count=1 ./plugin/go.d/collector/prometheus/... ./plugin/go.d/collector/mysql/...
```

All checks pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce allocations and CPU in the `metrix` flatten path by merging a single label into canonical slices and reusing descriptors and packed keys. Metric identities and public APIs are unchanged; adds stronger identity tests and broader cold-projection benchmarks with allocation gates.

- **Refactors**
  - Replace per-output label map/sort with an ordered single-label `mergeCanonicalLabel`; reuse source canonical labels and packed keys for scalar projections.
  - Share identical role descriptors within each source series (histogram buckets, summary quantiles, state set states); preserves series identity and label immutability.

- **Tests & Benchmarks**
  - Add parity tests for `mergeCanonicalLabel`; add identity and immutability tests plus descriptor reuse asserts.
  - Expand cold benchmarks to cover scalar, histograms (1/8 labels), summaries with and without quantiles, state sets, and measure sets (gauge/counter); add warm and concurrent cases.
  - Harden harness with preflight series-count checks and allocation-envelope gates across cardinalities; typical structured cold gains range up to ~-47% ns/op with fewer bytes and allocs, while scalar controls remain unchanged.

<sup>Written for commit 2825fea68fe0ae8a2b2abc9e232252f5257a9193. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

