### PR TITLE
fix(go.d/jobmgr): harden lifecycle and configuration reconciliation

### DIFF
--- a/src/go/logger/logger.go
+++ b/src/go/logger/logger.go
@@ -40,9 +40,10 @@ func newLogger(w io.Writer, isTerminal bool, depth int) *Logger {
 }
 
 type Logger struct {
-	muted atomic.Bool
-	sl    *slog.Logger
-	rl    *rateLimiter
+	muted            atomic.Bool
+	sl               *slog.Logger
+	rl               *rateLimiter
+	messageSanitizer func(string) string
 }
 
 func (l *Logger) Error(a ...any) {
@@ -123,10 +124,50 @@ func (l *Logger) With(args ...any) *Logger {
 		ll := New()
 		return &Logger{sl: ll.sl.With(args...), rl: ll.rl}
 	}
+	args = sanitizeLogAttributes(l.messageSanitizer, args)
 
-	ll := &Logger{sl: l.sl.With(args...), rl: l.rl}
+	ll := &Logger{sl: l.sl.With(args...), rl: l.rl, messageSanitizer: l.messageSanitizer}
 	ll.muted.Store(l.muted.Load())
 
+	return ll
+}
+
+func sanitizeLogAttributes(sanitize func(string) string, attributes []any) []any {
+	if sanitize == nil || len(attributes) == 0 {
+		return attributes
+	}
+	sanitized := make([]any, 0, len(attributes))
+	for index := 0; index < len(attributes); index++ {
+		switch attribute := attributes[index].(type) {
+		case slog.Attr:
+			sanitized = append(sanitized, slog.String(
+				"redacted_attribute",
+				sanitizeLogMessage(sanitize, fmt.Sprint(attribute.Value.Any())),
+			))
+		case string:
+			sanitized = append(sanitized, "redacted_attribute")
+			if index+1 < len(attributes) {
+				index++
+				sanitized = append(
+					sanitized,
+					sanitizeLogMessage(sanitize, fmt.Sprint(attributes[index])),
+				)
+			}
+		default:
+			sanitized = append(sanitized, sanitizeLogMessage(sanitize, fmt.Sprint(attribute)))
+		}
+	}
+	return sanitized
+}
+
+// WithMessageSanitizer returns a derived logger that sanitizes messages and
+// attributes added after this call. Existing attributes remain unchanged.
+func (l *Logger) WithMessageSanitizer(sanitize func(string) string) *Logger {
+	if l.isNil() {
+		l = New()
+	}
+	ll := &Logger{sl: l.sl, rl: l.rl, messageSanitizer: sanitize}
+	ll.muted.Store(l.muted.Load())
 	return ll
 }
 
@@ -137,8 +178,23 @@ func (l *Logger) log(level slog.Level, msg string) {
 	}
 
 	if !l.muted.Load() {
+		msg = sanitizeLogMessage(l.messageSanitizer, msg)
 		l.sl.Log(context.Background(), level, msg)
 	}
+}
+
+func sanitizeLogMessage(sanitize func(string) string, message string) (sanitized string) {
+	if sanitize == nil {
+		return message
+	}
+	sanitized = "log message redacted"
+	defer func() {
+		_ = recover()
+	}()
+	if result := sanitize(message); result != "" {
+		sanitized = result
+	}
+	return sanitized
 }
 
 func (l *Logger) canLog(level slog.Level) bool {

--- a/src/go/logger/logger_test.go
+++ b/src/go/logger/logger_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -47,4 +48,29 @@ func TestNewWithWriter_WithKeepsWriter(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "captured")
 	assert.True(t, strings.Contains(out, "component=test") || strings.Contains(out, "\"component\":\"test\""))
+}
+
+func TestMessageSanitizerSurvivesWithAndFailsClosed(t *testing.T) {
+	var buf bytes.Buffer
+	log := NewWithWriter(&buf).
+		WithMessageSanitizer(func(string) string { return "sanitized" }).
+		With("component", "test")
+	log.Error("raw marker")
+	require.NotContains(t, buf.String(), "raw marker")
+	require.Contains(t, buf.String(), "sanitized")
+
+	buf.Reset()
+	log.With("endpoint", "raw attribute marker").Error("raw marker")
+	require.NotContains(t, buf.String(), "raw attribute marker")
+	require.NotContains(t, buf.String(), "endpoint")
+	require.Contains(t, buf.String(), "redacted_attribute=sanitized")
+
+	buf.Reset()
+	log = NewWithWriter(&buf).WithMessageSanitizer(func(string) string {
+		panic("raw panic marker")
+	})
+	log.Error("raw message marker")
+	require.NotContains(t, buf.String(), "raw panic marker")
+	require.NotContains(t, buf.String(), "raw message marker")
+	require.Contains(t, buf.String(), "log message redacted")
 }

--- a/src/go/pkg/netdataapi/api.go
+++ b/src/go/pkg/netdataapi/api.go
@@ -167,10 +167,19 @@ func (a *API) FUNCRESULT(result FunctionResult) {
 	_, _ = buf.WriteTo(a)
 }
 
-// CONFIGCREATE creates a new configuration
+// CONFIGCREATE creates a new configuration. Invalid fields are ignored; use
+// TryCONFIGCREATE when the caller must observe an encoding rejection.
 func (a *API) CONFIGCREATE(opts ConfigOpts) {
+	_ = a.TryCONFIGCREATE(opts)
+}
+
+// TryCONFIGCREATE creates a new configuration or returns an encoding error.
+func (a *API) TryCONFIGCREATE(opts ConfigOpts) error {
 	// https://learn.netdata.cloud/docs/contributing/external-plugins/#config
 
+	if err := opts.Validate(); err != nil {
+		return err
+	}
 	_, _ = a.Write([]byte("CONFIG " +
 		opts.ID + " " +
 		"create" + " " +
@@ -181,16 +190,40 @@ func (a *API) CONFIGCREATE(opts ConfigOpts) {
 		opts.Source + "' '" +
 		opts.SupportedCommands + "' 0x0000 0x0000\n\n",
 	))
+	return nil
 }
 
-// CONFIGDELETE deletes a configuration
+// CONFIGDELETE deletes a configuration. Invalid IDs are ignored; use
+// TryCONFIGDELETE when the caller must observe an encoding rejection.
 func (a *API) CONFIGDELETE(id string) {
-	_, _ = a.Write([]byte("CONFIG " + id + " delete\n\n"))
+	_ = a.TryCONFIGDELETE(id)
 }
 
-// CONFIGSTATUS updates a configuration status
+// TryCONFIGDELETE deletes a configuration or returns an encoding error.
+func (a *API) TryCONFIGDELETE(id string) error {
+	if !ValidBareProtocolField(id) {
+		return fmt.Errorf("netdataapi: invalid CONFIG id")
+	}
+	_, _ = a.Write([]byte("CONFIG " + id + " delete\n\n"))
+	return nil
+}
+
+// CONFIGSTATUS updates a configuration status. Invalid fields are ignored; use
+// TryCONFIGSTATUS when the caller must observe an encoding rejection.
 func (a *API) CONFIGSTATUS(id, status string) {
+	_ = a.TryCONFIGSTATUS(id, status)
+}
+
+// TryCONFIGSTATUS updates a configuration status or returns an encoding error.
+func (a *API) TryCONFIGSTATUS(id, status string) error {
+	if !ValidBareProtocolField(id) {
+		return fmt.Errorf("netdataapi: invalid CONFIG id")
+	}
+	if !ValidBareProtocolField(status) {
+		return fmt.Errorf("netdataapi: invalid CONFIG status")
+	}
 	_, _ = a.Write([]byte("CONFIG " + id + " status " + status + "\n\n"))
+	return nil
 }
 
 // FUNCTIONGLOBAL registers a global function with Netdata.

--- a/src/go/pkg/netdataapi/api_test.go
+++ b/src/go/pkg/netdataapi/api_test.go
@@ -279,6 +279,94 @@ func TestCONFIGCREATE(t *testing.T) {
 	require.Equal(t, expected, w.String())
 }
 
+func TestCONFIGCREATEAcceptsWindowsSourcePath(t *testing.T) {
+	w := &bytes.Buffer{}
+	api := New(w)
+
+	require.NoError(t, api.TryCONFIGCREATE(ConfigOpts{
+		ID:                "go.d:collector:module:job",
+		Status:            "running",
+		ConfigType:        "job",
+		Path:              "/collectors/go.d/Jobs",
+		SourceType:        "user",
+		Source:            `discoverer=file_reader,file=C:\Program Files\Netdata\go.d\job.conf`,
+		SupportedCommands: "schema get",
+	}))
+
+	require.Contains(
+		t,
+		w.String(),
+		`'discoverer=file_reader,file=C:\Program Files\Netdata\go.d\job.conf'`,
+	)
+}
+
+func TestCONFIGCREATERefusesUnsafeProtocolFields(t *testing.T) {
+	base := ConfigOpts{
+		ID:                "go.d:collector:module:job",
+		Status:            "running",
+		ConfigType:        "job",
+		Path:              "/collectors/go.d/Jobs",
+		SourceType:        "user",
+		Source:            "file=/etc/netdata/go.d/job.conf",
+		SupportedCommands: "schema get",
+	}
+	tests := map[string]ConfigOpts{
+		"ID separator": func() ConfigOpts {
+			opts := base
+			opts.ID = "go.d:collector:module job"
+			return opts
+		}(),
+		"status separator": func() ConfigOpts {
+			opts := base
+			opts.Status = "not running"
+			return opts
+		}(),
+		"config type delimiter": func() ConfigOpts {
+			opts := base
+			opts.ConfigType = "operator's"
+			return opts
+		}(),
+		"path separator": func() ConfigOpts {
+			opts := base
+			opts.Path = "/collectors/go.d/Service Discovery"
+			return opts
+		}(),
+		"source type delimiter": func() ConfigOpts {
+			opts := base
+			opts.SourceType = "source=user"
+			return opts
+		}(),
+		"quoted field delimiter": func() ConfigOpts {
+			opts := base
+			opts.Source = "file=/etc/netdata/go.d/operator's.conf"
+			return opts
+		}(),
+		"quoted field line break": func() ConfigOpts {
+			opts := base
+			opts.Source = "file=/etc/netdata/go.d/job.conf\nCONFIG injected delete"
+			return opts
+		}(),
+		"quoted field trailing escape": func() ConfigOpts {
+			opts := base
+			opts.Source = `file=C:\`
+			return opts
+		}(),
+		"supported commands delimiter": func() ConfigOpts {
+			opts := base
+			opts.SupportedCommands = "schema operator's"
+			return opts
+		}(),
+	}
+
+	for name, opts := range tests {
+		t.Run(name, func(t *testing.T) {
+			var output bytes.Buffer
+			require.Error(t, New(&output).TryCONFIGCREATE(opts))
+			require.Empty(t, output.String())
+		})
+	}
+}
+
 func TestCONFIGDELETE(t *testing.T) {
 	w := &bytes.Buffer{}
 	api := New(w)
@@ -290,6 +378,13 @@ func TestCONFIGDELETE(t *testing.T) {
 	require.Equal(t, expected, w.String())
 }
 
+func TestCONFIGDELETERefusesUnsafeID(t *testing.T) {
+	var output bytes.Buffer
+
+	require.Error(t, New(&output).TryCONFIGDELETE("test config"))
+	require.Empty(t, output.String())
+}
+
 func TestCONFIGSTATUS(t *testing.T) {
 	w := &bytes.Buffer{}
 	api := New(w)
@@ -299,4 +394,22 @@ func TestCONFIGSTATUS(t *testing.T) {
 	expected := "CONFIG test-config status inactive\n\n"
 
 	require.Equal(t, expected, w.String())
+}
+
+func TestCONFIGSTATUSRefusesUnsafeFields(t *testing.T) {
+	tests := map[string]struct {
+		id     string
+		status string
+	}{
+		"ID":     {id: "test config", status: "running"},
+		"status": {id: "test-config", status: "not running"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var output bytes.Buffer
+			require.Error(t, New(&output).TryCONFIGSTATUS(test.id, test.status))
+			require.Empty(t, output.String())
+		})
+	}
 }

--- a/src/go/pkg/netdataapi/config.go
+++ b/src/go/pkg/netdataapi/config.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netdataapi
+
+import "fmt"
+
+// ValidBareProtocolField reports whether value can be emitted as one unquoted
+// plugins.d protocol field.
+func ValidBareProtocolField(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char <= ' ' || char == 0x7f {
+			return false
+		}
+		switch char {
+		case '=', '\'', '"', '\\':
+			return false
+		}
+	}
+	return true
+}
+
+// ValidSingleQuotedProtocolField reports whether value can be emitted inside
+// one single-quoted plugins.d protocol field.
+func ValidSingleQuotedProtocolField(value string) bool {
+	trailingBackslashes := 0
+	for _, char := range value {
+		if char < ' ' || char == 0x7f || char == '\'' {
+			return false
+		}
+		if char == '\\' {
+			trailingBackslashes++
+		} else {
+			trailingBackslashes = 0
+		}
+	}
+	return trailingBackslashes%2 == 0
+}
+
+// Validate checks whether all CONFIG CREATE fields can be encoded without
+// changing plugins.d field boundaries.
+func (opts ConfigOpts) Validate() error {
+	bareFields := []struct {
+		name  string
+		value string
+	}{
+		{name: "id", value: opts.ID},
+		{name: "status", value: opts.Status},
+		{name: "config type", value: opts.ConfigType},
+		{name: "path", value: opts.Path},
+		{name: "source type", value: opts.SourceType},
+	}
+	for _, field := range bareFields {
+		if !ValidBareProtocolField(field.value) {
+			return fmt.Errorf("netdataapi: invalid CONFIG %s", field.name)
+		}
+	}
+	if !ValidSingleQuotedProtocolField(opts.Source) {
+		return fmt.Errorf("netdataapi: invalid CONFIG source")
+	}
+	if !ValidSingleQuotedProtocolField(opts.SupportedCommands) {
+		return fmt.Errorf("netdataapi: invalid CONFIG supported commands")
+	}
+	return nil
+}

--- a/src/go/pkg/netdataapi/config_test.go
+++ b/src/go/pkg/netdataapi/config_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netdataapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidConfigProtocolFields(t *testing.T) {
+	tests := map[string]struct {
+		value  string
+		bare   bool
+		quoted bool
+	}{
+		"empty":                     {value: "", quoted: true},
+		"safe":                      {value: "source", bare: true, quoted: true},
+		"equals":                    {value: "file=/etc/netdata", quoted: true},
+		"space":                     {value: "file source", quoted: true},
+		"double quote":              {value: `file"source`, quoted: true},
+		"single quote":              {value: "file'source"},
+		"Windows path":              {value: `C:\Program Files\Netdata`, quoted: true},
+		"even trailing backslashes": {value: `file=C:\\`, quoted: true},
+		"odd trailing backslash":    {value: `file=C:\`},
+		"odd trailing backslashes":  {value: `file=C:\\\`},
+		"line break":                {value: "file\nsource"},
+		"delete":                    {value: "file\x7fsource"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.bare, ValidBareProtocolField(test.value))
+			require.Equal(t, test.quoted, ValidSingleQuotedProtocolField(test.value))
+		})
+	}
+}

--- a/src/go/plugin/agent/discovery/sd/dyncfg.go
+++ b/src/go/plugin/agent/discovery/sd/dyncfg.go
@@ -46,8 +46,8 @@ func dyncfgTemplateJobName(fn dyncfg.Function) string {
 	return "test"
 }
 
-func (d *ServiceDiscovery) dyncfgSDTemplateCreate(discovererType string) {
-	d.dyncfgApi.ConfigCreate(netdataapi.ConfigOpts{
+func (d *ServiceDiscovery) dyncfgSDTemplateCreate(discovererType string) error {
+	opts := netdataapi.ConfigOpts{
 		ID:                d.dyncfgTemplateID(discovererType),
 		Status:            dyncfg.StatusAccepted.String(),
 		ConfigType:        dyncfg.ConfigTypeTemplate.String(),
@@ -55,7 +55,12 @@ func (d *ServiceDiscovery) dyncfgSDTemplateCreate(discovererType string) {
 		SourceType:        "internal",
 		Source:            "internal",
 		SupportedCommands: dyncfgSDTemplateCmds(),
-	})
+	}
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+	d.dyncfgApi.ConfigCreate(opts)
+	return nil
 }
 
 // sdCallbacks implements dyncfg.Callbacks[sdConfig]
@@ -91,6 +96,9 @@ func (cb *sdCallbacks) ParseAndValidate(fn dyncfg.Function, name string) (sdConf
 	dt, _, _ := cb.sd.extractDiscovererAndName(fn.ID())
 	if _, err := parseDyncfgPayload(fn.Payload(), dt, name, cb.sd.configDefaults, cb.sd.discovererRegistry(), true); err != nil {
 		return nil, err
+	}
+	if !netdataapi.ValidSingleQuotedProtocolField(fn.Source()) {
+		return nil, fmt.Errorf("invalid Function source")
 	}
 	pkey := pipelineKey(dt, name)
 	cfg, err := newSDConfigFromJSON(fn.Payload(), name, fn.Source(), confgroup.TypeDyncfg, dt, pkey)
@@ -357,7 +365,10 @@ func (d *ServiceDiscovery) registerDyncfgTemplates(ctx context.Context) {
 
 	// Register templates for each discoverer type
 	for _, dt := range d.discovererRegistry().Types() {
-		d.dyncfgSDTemplateCreate(dt)
+		if err := d.dyncfgSDTemplateCreate(dt); err != nil {
+			d.Errorf("failed to register dyncfg template for discoverer type '%s': %v", dt, err)
+			continue
+		}
 		d.Infof("registered dyncfg template for discoverer type '%s'", dt)
 	}
 }

--- a/src/go/plugin/agent/discovery/sd/dyncfg_cache.go
+++ b/src/go/plugin/agent/discovery/sd/dyncfg_cache.go
@@ -65,19 +65,8 @@ func (c sdConfig) UID() string {
 	return c.Source() + ":" + c.ExposedKey()
 }
 
-// SourceTypePriority returns priority based on source type.
-// Higher value = higher priority. Matches confgroup.Config pattern.
 func (c sdConfig) SourceTypePriority() int {
-	switch c.SourceType() {
-	case confgroup.TypeDyncfg:
-		return 16
-	case confgroup.TypeUser:
-		return 8
-	case confgroup.TypeStock:
-		return 2
-	default:
-		return 0
-	}
+	return confgroup.SourceTypePriority(c.SourceType())
 }
 
 // ToPipelineConfig converts sdConfig to pipeline.Config for actually running the pipeline.

--- a/src/go/plugin/agent/discovery/sd/sd.go
+++ b/src/go/plugin/agent/discovery/sd/sd.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/pipeline"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/policy"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
@@ -219,6 +220,10 @@ func (d *ServiceDiscovery) removePipeline(conf confFile) {
 }
 
 func (d *ServiceDiscovery) addPipeline(ctx context.Context, conf confFile) {
+	if !netdataapi.ValidSingleQuotedProtocolField(conf.source) {
+		d.Errorf("config source '%s' cannot be represented in the plugins.d CONFIG protocol", conf.source)
+		return
+	}
 	// Create sdConfig directly from YAML (cleans name for dyncfg compatibility)
 	sourceType := sourceTypeFromPath(conf.source)
 	pipelineKey := pipelineKeyFromSource(conf.source)
@@ -257,6 +262,11 @@ func (d *ServiceDiscovery) addPipeline(ctx context.Context, conf confFile) {
 // addConfig handles adding a config with priority handling.
 // This is the core logic matching jobmgr pattern.
 func (d *ServiceDiscovery) addConfig(ctx context.Context, scfg sdConfig) {
+	if err := d.handler.ValidateConfigCreate(scfg, dyncfg.StatusAccepted); err != nil {
+		d.Errorf("config '%s' cannot be represented in the plugins.d CONFIG protocol: %v", scfg.ExposedKey(), err)
+		return
+	}
+
 	// For file sources: One file = one config. If the file previously provided a different config,
 	// remove the old one first. This handles the case where a file config name changes.
 	if scfg.SourceType() != confgroup.TypeDyncfg {

--- a/src/go/plugin/agent/discovery/sd/sd_test.go
+++ b/src/go/plugin/agent/discovery/sd/sd_test.go
@@ -3,12 +3,14 @@
 package sd
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/pipeline"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -109,6 +111,46 @@ func TestServiceDiscovery_UnsupportedDiscovererConfigIsIgnored(t *testing.T) {
 		wantExposed:   []wantExposedCfg{},
 	}
 	sim.run(t)
+}
+
+func TestServiceDiscovery_WindowsSourcePathIsPublished(t *testing.T) {
+	const source = `C:\Program Files\Netdata\etc\netdata\sd\windows.conf`
+	sim := &discoverySimExt{
+		configs: []confFile{
+			prepareConfigFile(source, "windows"),
+		},
+		wantPipelines: []*mockPipeline{
+			{name: "windows", started: true, stopped: false},
+		},
+		wantExposed: []wantExposedCfg{{
+			discovererType: "net_listeners",
+			name:           "windows",
+			source:         source,
+			sourceType:     sourceTypeFromPath(source),
+			status:         dyncfg.StatusRunning,
+		}},
+		wantOutputContains: `'C:\Program Files\Netdata\etc\netdata\sd\windows.conf'`,
+	}
+	sim.run(t)
+}
+
+func TestServiceDiscovery_UnpublishableConfigDoesNotEnterStateOrWaitGate(t *testing.T) {
+	var output bytes.Buffer
+	discovery, err := NewServiceDiscovery(Config{
+		PluginName:   testPluginName,
+		DyncfgOutput: dyncfg.NewProtocolOutput(&output),
+		Discoverers:  testDiscovererRegistry(),
+	})
+	require.NoError(t, err)
+
+	discovery.addPipeline(
+		t.Context(),
+		prepareConfigFile("/etc/netdata/sd.d/operator.conf", "operator's"),
+	)
+
+	require.Zero(t, exposedCacheCount(discovery.exposed))
+	require.False(t, discovery.handler.WaitingForDecision())
+	require.Empty(t, output.String())
 }
 
 func prepareConfigFile(source, name string) confFile {

--- a/src/go/plugin/agent/discovery/sd/sim_test.go
+++ b/src/go/plugin/agent/discovery/sd/sim_test.go
@@ -33,14 +33,16 @@ type discoverySim struct {
 
 // discoverySimExt is an extended simulation that also checks exposed configs
 type discoverySimExt struct {
-	configs       []confFile
-	wantPipelines []*mockPipeline
-	wantExposed   []wantExposedCfg
+	configs            []confFile
+	wantPipelines      []*mockPipeline
+	wantExposed        []wantExposedCfg
+	wantOutputContains string
 }
 
 type wantExposedCfg struct {
 	discovererType string
 	name           string
+	source         string
 	sourceType     string
 	status         dyncfg.Status
 }
@@ -123,7 +125,13 @@ func (sim *discoverySimExt) run(t *testing.T) {
 			continue
 		}
 		assert.Equal(t, want.sourceType, entry.Cfg.SourceType(), "exposed config '%s:%s' sourceType", want.discovererType, want.name)
+		if want.source != "" {
+			assert.Equal(t, want.source, entry.Cfg.Source(), "exposed config '%s:%s' source", want.discovererType, want.name)
+		}
 		assert.Equal(t, want.status, entry.Status, "exposed config '%s:%s' status", want.discovererType, want.name)
+	}
+	if sim.wantOutputContains != "" {
+		assert.Contains(t, buf.String(), sim.wantOutputContains)
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -175,6 +175,19 @@ flowchart TD
    acquired in a stable global key order and waiters are FIFO per key, so the
    design is deadlock-free and starvation-free.
    `claim_authority.go`.
+   A transaction may explicitly yield only its acquisition-suffix claim while
+   bounded preparation work runs, then must reacquire it before preparation
+   completes. Its resource lane remains active, so another command for the same
+   resource cannot overlap the yielded work. Reacquisition has priority over
+   ordinary waiters. A composite declares the resource lanes its children may
+   use. If one conflicts with an active yielder, the parent is parked before it
+   acquires any claim; an already-waiting parent releases its prefix claims.
+   Its original ticket is retained, while unrelated work remains serviceable on
+   the otherwise-free claim. This prevents both child/lane cycles and
+   head-of-line blocking. When a child of an already-running composite yields,
+   only the matching admission-fence claim is suspended; the parent's other
+   claims remain held. `claim_authority.go`, `claim_yield.go`,
+   `claim_yield_kernel.go`.
 5. **Run task** (off-loop): the actual blocking work — construct a collector,
    run autodetection, call a Function handler, stop a job — runs on a
    `TaskSupervisor` goroutine, never on the loop. `lifecycle/task.go`.
@@ -216,12 +229,51 @@ Two more facts that catch newcomers:
   publications. Netdata owns the global `config` Function that serves the tree
   and delegates per-config operations; go.d emits `CONFIG` object frames but
   never `FUNCTION GLOBAL "config"` or its withdrawal.
+- Go `CONFIG` emission fails closed at the shared `netdataapi` boundary. Bare
+  protocol identities remain strict; single-quoted metadata accepts ordinary
+  internal backslashes (including Windows paths) but rejects controls, the
+  quote delimiter, and a trailing escape that would consume the closing quote.
+
+### Config validation boundary
+
+External configuration is untrusted batch input. Production producers validate
+successfully decoded entries against the exact downstream contracts before
+process construction or WorkPlan submission:
+
+- the vnode file loader and DynCfg vnode adapter validate CONFIG identity and
+  source fields, host-emission metadata, daemon-compatible UUID syntax, and
+  semantic hostname/GUID uniqueness;
+- the secret-store file loader validates each fully stamped config, including
+  kind type and provider support, before passing accepted entries to a run
+  generation;
+- discovered collector proposals validate their final CONFIG job name and
+  source metadata before graph mutation.
+
+An invalid decoded file entry is reported and skipped; a YAML structural/type
+error may reject its containing file without stopping Job Manager. An invalid
+dynamic proposal is a typed proposal rejection and quarantined while sibling
+proposals continue.
+Strict constructor/controller checks remain as defensive invariant enforcement:
+programmatic state that bypasses a production producer is still rejected rather
+than silently normalized or recovered after admission.
 
 ## How the Job Manager Manages Jobs
 
 A **job** is one running collector instance: a module plus a resolved config.
 Jobs are created from stock/user config files at startup, from discovery, or
 from DynCfg commands, and are retried after a failed autodetection.
+
+### Configuration source ownership
+
+Go plugin configurations use one source order: **DynCfg > user > discovered >
+stock > internal/unknown**. Each domain keeps its own lifecycle authority, and
+the collector graph rechecks that order when committing a discovered change;
+candidate selection alone is not authoritative.
+
+A plugin-side DynCfg `add` is replay/upsert-capable because the daemon uses it
+to restore persisted configurations. Ordinary user duplicate adds remain
+create-only at the daemon boundary. Removal targets only the current DynCfg
+override and does not immediately reactivate a masked lower-priority source.
 
 The central guarantee is that **reconfiguring a job never disrupts the running
 one until the replacement is proven ready**. Think of a stage crew swapping
@@ -234,14 +286,14 @@ flowchart TD
     Cmd("add / update / discovered / retry")
     Validate("Validate config<br/>throwaway probe")
     Prepare("Prepare candidate<br/>construct + resolve secrets<br/>(current job still running)")
+    AutoD{"Managed autodetection<br/>yield global jobs claim"}
     Apply("Apply")
     StopOld("Stop + Finalize<br/>prior generation")
-    AutoD{"Managed autodetection<br/>AcceptStart"}
     Live("Start + Publish<br/>new generation live")
     Fail("Commit StatusFailed<br/>schedule retry")
 
-    Cmd --> Validate --> Prepare --> Apply --> StopOld --> AutoD
-    AutoD -->|"ok"| Live
+    Cmd --> Validate --> Prepare --> AutoD
+    AutoD -->|"ok"| Apply --> StopOld --> Live
     AutoD -->|"failed"| Fail
     Fail -. "logical clock due" .-> Prepare
 
@@ -261,12 +313,19 @@ flowchart TD
    *candidate* holding a long-lived resource permit. The current job keeps
    running.
    `joboutput/factory.go`, `joboutput/generation.go`.
-3. **Apply** — the kernel stops and finalizes the prior generation, then calls
-   `AcceptStart` on the candidate. `joboutput/transaction.go`.
-4. **Managed autodetection** — the candidate runs its `Check`/autodetect *after*
-   the old generation is gone. On success the job starts, publishes its
-   Functions, and begins emitting. On a clean failure the graph is committed
-   truthfully as `StatusFailed` (never a fake success) and a retry is scheduled.
+3. **Managed autodetection (non-disruptive)** — the candidate runs its
+   `Check`/autodetect with the caller's task context before acceptance and while
+   the old generation is still live. Job Manager propagates caller cancellation
+   but does not invent a module-agnostic deadline. The transaction temporarily
+   yields the global `dyncfg:jobs` claim but retains its resource lane, so
+   unrelated job-graph work may proceed without allowing a duplicate probe for
+   the same job. On a clean failure the graph is committed truthfully as
+   `StatusFailed` (never a fake success) and a retry is scheduled. Failed
+   candidates are rejected and cleaned before the yielded claim is reacquired,
+   so collector cleanup cannot retain the global claim.
+4. **Apply** — after a successful probe, the kernel stops and finalizes the
+   prior generation, accepts the candidate, starts it, and publishes its
+   Functions. `joboutput/transaction.go`.
 5. **Emitting** — the collector writes protocol frames through a `FrameWriter`,
    which commits whole frames through the one `FrameOwner`.
 
@@ -337,7 +396,13 @@ flowchart TD
 
 The resolver lives in `plugin/agent/secrets/resolver`; it never mutates the
 input config and returns `nil` on any error, so a half-resolved config can never
-reach a collector.
+reach a collector. Once a configuration containing secret references has been
+applied to a collector, Job Manager replaces lifecycle failures with a generic
+redacted error before logging or publishing them. The collector's own logger
+also sanitizes messages and newly attached attributes, so an internally logged
+request error cannot bypass the runtime boundary. Cancellation, DynCfg
+code/retryability, panic classification, and retained-ownership state survive;
+the raw collector cause does not.
 
 ### Changing a store restarts its jobs
 
@@ -349,8 +414,15 @@ generations** per `kind:name`:
    compare-and-swap against the expected generation.
 2. If any running jobs depend on that store key, they are restarted as **one
    composite command** — stop dependents → commit the new generation → start
-   dependents — all under the store's ordering/claim scope
-   (`dyncfg:secretstores`), so nothing else mutates those jobs in between.
+   dependents. The parent retains `dyncfg:dependency-graph` throughout. Each
+   start child temporarily yields only the `dyncfg:jobs` acquisition suffix
+   while its probe runs, so unrelated job-graph work may proceed while
+   dependency mutations remain fenced. Restart recovery has both a bounded
+   aggregate cancellation budget and a fair-share per-child cancellation
+   budget; those budgets bound cooperative collector work, but cannot forcibly
+   stop collector lifecycle code that ignores context. A timed-out child is
+   operational failure only after it reaches a known terminal ownership state;
+   unresolved admitted ownership makes the run dirty.
    `secrets/restart.go`, `secrets/transaction.go`.
 3. The superseded generation is retired only after its last reader scope drains,
    so an in-flight resolution never sees credentials vanish mid-read.
@@ -427,9 +499,12 @@ The rotation is an acknowledged sequence (`composition/process.go` `rotate`):
 4. Withdraw Function publications, close the catalog, cancel and join inherited
    work, stop long-lived resources, and run the finalizer — all executed inside
    the kernel loop.
-5. Require an **exact-zero authority census** (no active tasks, claims, permits,
-   or retained frame bytes). Any leftover marks the run **dirty** and fails the
-   handoff closed rather than silently proceeding.
+5. Require a fully **drained authority census** (no active tasks, claims,
+   permits, or retained frame bytes). A dirty-run-only abandonment may drain an
+   otherwise unjoinable child, but it is recorded by ownership category,
+   diagnosed, and can never satisfy clean quiescence. Any live leftover or
+   abandonment marks the terminal state **dirty** rather than silently claiming
+   a clean handoff.
 6. Construct, start, and adopt the next generation.
 
 **Termination** (SIGINT/SIGTERM) follows the same retirement path with no

--- a/src/go/plugin/agent/jobmgr/claim_authority.go
+++ b/src/go/plugin/agent/jobmgr/claim_authority.go
@@ -15,9 +15,14 @@ const maximumClaimSettlementQuantum = 4
 
 type authorityClaimKey struct {
 	references      int                 // outstanding edges referencing this key
+	yielded         int                 // active suffix yielders retaining reacquisition priority
+	yieldLanes      map[string]int      // active yield reservations by borrower resource lane
 	holder          *authorityClaimEdge // the edge currently holding the key, if any
 	waiterHead      *authorityClaimEdge // head of the FIFO waiter list
 	waiterTail      *authorityClaimEdge // tail of the FIFO waiter list
+	yieldWaiterTail *authorityClaimEdge // tail of the leading yield-reacquisition waiters
+	reservationHead *commandOperation   // composites parked before taking any prefix claim
+	reservationTail *commandOperation   // tail of the pre-acquisition reservation list
 	settlementIndex int                 // index in the settlement heap (-1 when absent)
 }
 
@@ -27,6 +32,7 @@ type authorityClaimEdge struct {
 	key       *authorityClaimKey  // the claim key this edge is registered against
 	held      bool                // the edge currently holds the key
 	waiting   bool                // the edge is parked in the key's waiter list
+	yielded   bool                // the edge has a live suffix-yield reservation
 	prev      *authorityClaimEdge // previous edge in the key's waiter list
 	next      *authorityClaimEdge // next edge in the key's waiter list
 }
@@ -36,7 +42,9 @@ type authorityClaimHeap []*authorityClaimKey
 func (ach *authorityClaimHeap) Len() int { return len(*ach) }
 
 func (ach *authorityClaimHeap) Less(left, right int) bool {
-	return (*ach)[left].waiterHead.operation.claimTicket < (*ach)[right].waiterHead.operation.claimTicket
+	leftOperation := claimSettlementOperation((*ach)[left])
+	rightOperation := claimSettlementOperation((*ach)[right])
+	return leftOperation.claimTicket < rightOperation.claimTicket
 }
 
 func (ach *authorityClaimHeap) Swap(left, right int) {
@@ -129,7 +137,7 @@ func (ca *claimAuthority) register(operation *commandOperation) error {
 
 func (ca *claimAuthority) acquire(operation *commandOperation) (bool, error) {
 	if operation == nil || !operation.claimRegistered || operation.claimWaiting || operation.claimsHeld ||
-		operation.claimCursor != 0 {
+		(operation.claimCursor != 0 && !operation.claimsYielded) {
 		return false, errors.New("jobmgr claims: invalid acquire")
 	}
 	ca.nextTicket++
@@ -137,6 +145,13 @@ func (ca *claimAuthority) acquire(operation *commandOperation) (bool, error) {
 		return false, errors.New("jobmgr claims: ticket wrapped")
 	}
 	operation.claimTicket = ca.nextTicket
+	if edge := compositeYieldConflictEdge(operation); edge != nil {
+		ca.enqueueReservation(edge.key, operation)
+		operation.claimWaiting = true
+		ca.beginRuntimeWait(operation)
+		ca.observeRuntime()
+		return false, nil
+	}
 	granted, err := ca.acquireFromCursor(operation)
 	if err == nil && !granted {
 		ca.beginRuntimeWait(operation)
@@ -146,20 +161,31 @@ func (ca *claimAuthority) acquire(operation *commandOperation) (bool, error) {
 }
 
 func (ca *claimAuthority) cancel(operation *commandOperation) ([]*commandOperation, error) {
-	if operation == nil || !operation.claimRegistered || !operation.claimWaiting || operation.claimsHeld {
+	if operation == nil || !operation.claimRegistered || !operation.claimWaiting || operation.claimsHeld ||
+		operation.claimsYielded {
 		return nil, errors.New("jobmgr claims: operation is not waiting")
 	}
-	edge := &operation.authorityClaimEdges[operation.claimCursor]
-	if err := ca.removeWaiter(edge); err != nil {
-		return nil, err
-	}
-	operation.claimWaiting = false
-	for index := operation.claimCursor - 1; index >= 0; index-- {
-		if err := ca.releaseEdge(&operation.authorityClaimEdges[index]); err != nil {
+	if operation.claimReservationKey != nil {
+		if operation.claimCursor != 0 {
+			return nil, errors.New("jobmgr claims: reserved operation retained a prefix")
+		}
+		if err := ca.removeReservation(operation); err != nil {
 			return nil, err
 		}
+		operation.claimWaiting = false
+	} else {
+		edge := &operation.authorityClaimEdges[operation.claimCursor]
+		if err := ca.removeWaiter(edge); err != nil {
+			return nil, err
+		}
+		operation.claimWaiting = false
+		for index := operation.claimCursor - 1; index >= 0; index-- {
+			if err := ca.releaseEdge(&operation.authorityClaimEdges[index]); err != nil {
+				return nil, err
+			}
+		}
+		operation.claimCursor = 0
 	}
-	operation.claimCursor = 0
 	if err := ca.forget(operation); err != nil {
 		return nil, err
 	}
@@ -184,6 +210,42 @@ func (ca *claimAuthority) release(operation *commandOperation) ([]*commandOperat
 	if err := ca.forget(operation); err != nil {
 		return nil, err
 	}
+	granted, _, err := ca.serviceSettlements(maximumClaimSettlementQuantum)
+	ca.observeRuntime()
+	return granted, err
+}
+
+func (ca *claimAuthority) yield(
+	operation *commandOperation,
+	claim string,
+	borrowerLane string,
+) ([]*commandOperation, error) {
+	if operation == nil || !operation.claimRegistered || !operation.claimsHeld || operation.claimWaiting ||
+		operation.claimCursor != len(operation.authorityClaimEdges) {
+		return nil, errors.New("jobmgr claims: yield without complete held claims")
+	}
+	yieldIndex := len(operation.authorityClaimEdges) - 1
+	if yieldIndex < 0 || operation.authorityClaimEdges[yieldIndex].claim != claim {
+		return nil, errors.New("jobmgr claims: yielded claim is not the acquisition suffix")
+	}
+	edge := &operation.authorityClaimEdges[yieldIndex]
+	edge.yielded = true
+	edge.key.yielded++
+	if edge.key.yieldLanes == nil {
+		edge.key.yieldLanes = make(map[string]int)
+	}
+	edge.key.yieldLanes[borrowerLane]++
+	operation.claimYieldLane = borrowerLane
+	if err := ca.demoteYieldConflictedWaiters(edge.key); err != nil {
+		_ = removeYieldReservation(edge)
+		return nil, err
+	}
+	if err := ca.releaseEdge(edge); err != nil {
+		_ = removeYieldReservation(edge)
+		return nil, err
+	}
+	operation.claimsHeld = false
+	operation.claimCursor = yieldIndex
 	granted, _, err := ca.serviceSettlements(maximumClaimSettlementQuantum)
 	ca.observeRuntime()
 	return granted, err
@@ -215,12 +277,15 @@ func (ca *claimAuthority) acquireFromCursor(operation *commandOperation) (bool, 
 		if edge.held || edge.waiting || edge.key == nil {
 			return false, errors.New("jobmgr claims: invalid acquisition edge")
 		}
-		if edge.key.waiterHead != nil || edge.key.holder != nil {
+		if edge.key.waiterHead != nil || edge.key.holder != nil ||
+			compositeClaimBorrowerBlocked(edge) {
 			ca.enqueueWaiter(edge)
 			operation.claimWaiting = true
 			return false, nil
 		}
-		holdEdge(edge)
+		if err := holdEdge(edge); err != nil {
+			return false, err
+		}
 		ca.refreshSettlement(edge.key)
 		operation.claimCursor++
 	}
@@ -228,9 +293,42 @@ func (ca *claimAuthority) acquireFromCursor(operation *commandOperation) (bool, 
 	return true, nil
 }
 
-func holdEdge(edge *authorityClaimEdge) {
+func holdEdge(edge *authorityClaimEdge) error {
+	if edge == nil || edge.key == nil || edge.held || edge.waiting || edge.key.holder != nil {
+		return errors.New("jobmgr claims: invalid edge hold")
+	}
+	if edge.yielded {
+		if err := removeYieldReservation(edge); err != nil {
+			return err
+		}
+	}
 	edge.held = true
 	edge.key.holder = edge
+	return nil
+}
+
+func removeYieldReservation(edge *authorityClaimEdge) error {
+	if edge == nil || edge.key == nil || !edge.yielded || edge.operation == nil ||
+		edge.key.yielded <= 0 || edge.key.yieldLanes == nil {
+		return errors.New("jobmgr claims: missing yield reservation")
+	}
+	lane := edge.operation.claimYieldLane
+	count := edge.key.yieldLanes[lane]
+	if count <= 0 {
+		return errors.New("jobmgr claims: missing yield lane reservation")
+	}
+	if count == 1 {
+		delete(edge.key.yieldLanes, lane)
+	} else {
+		edge.key.yieldLanes[lane] = count - 1
+	}
+	if len(edge.key.yieldLanes) == 0 {
+		edge.key.yieldLanes = nil
+	}
+	edge.key.yielded--
+	edge.yielded = false
+	edge.operation.claimYieldLane = ""
+	return nil
 }
 
 func (ca *claimAuthority) releaseEdge(edge *authorityClaimEdge) error {
@@ -250,13 +348,36 @@ func (ca *claimAuthority) releaseEdge(edge *authorityClaimEdge) error {
 
 func (ca *claimAuthority) enqueueWaiter(edge *authorityClaimEdge) {
 	edge.waiting = true
-	edge.prev = edge.key.waiterTail
-	if edge.key.waiterTail != nil {
-		edge.key.waiterTail.next = edge
+	if edge.yielded {
+		previous := edge.key.yieldWaiterTail
+		if previous == nil {
+			edge.next = edge.key.waiterHead
+			if edge.next != nil {
+				edge.next.prev = edge
+			} else {
+				edge.key.waiterTail = edge
+			}
+			edge.key.waiterHead = edge
+		} else {
+			edge.prev = previous
+			edge.next = previous.next
+			previous.next = edge
+			if edge.next != nil {
+				edge.next.prev = edge
+			} else {
+				edge.key.waiterTail = edge
+			}
+		}
+		edge.key.yieldWaiterTail = edge
 	} else {
-		edge.key.waiterHead = edge
+		edge.prev = edge.key.waiterTail
+		if edge.key.waiterTail != nil {
+			edge.key.waiterTail.next = edge
+		} else {
+			edge.key.waiterHead = edge
+		}
+		edge.key.waiterTail = edge
 	}
-	edge.key.waiterTail = edge
 	ca.waiterCount++
 	ca.refreshSettlement(edge.key)
 }
@@ -279,6 +400,13 @@ func (ca *claimAuthority) removeWaiter(edge *authorityClaimEdge) error {
 	} else {
 		return errors.New("jobmgr claims: waiter tail mismatch")
 	}
+	if edge.key.yieldWaiterTail == edge {
+		if edge.prev != nil && edge.prev.yielded {
+			edge.key.yieldWaiterTail = edge.prev
+		} else {
+			edge.key.yieldWaiterTail = nil
+		}
+	}
 	edge.waiting = false
 	edge.prev = nil
 	edge.next = nil
@@ -298,21 +426,41 @@ func (ca *claimAuthority) serviceSettlements(quantum int) ([]*commandOperation, 
 		if !claimSettlementEligible(key) {
 			return nil, false, errors.New("jobmgr claims: ineligible settlement key")
 		}
-		operation := key.waiterHead.operation
-		if operation == nil || !operation.claimWaiting || operation.claimCursor >= len(operation.authorityClaimEdges) {
+		operation, reserved := claimSettlementCandidate(key)
+		if operation == nil || !operation.claimWaiting {
 			return nil, false, errors.New("jobmgr claims: invalid wake operation")
 		}
-		edge := &operation.authorityClaimEdges[operation.claimCursor]
-		if edge.key != key || key.waiterHead != edge || key.holder != nil {
-			return nil, false, errors.New("jobmgr claims: settlement head differs")
+		if reserved {
+			if operation.claimCursor != 0 || operation.claimReservationKey != key {
+				return nil, false, errors.New("jobmgr claims: invalid reservation wake")
+			}
+			if err := ca.removeReservation(operation); err != nil {
+				return nil, false, err
+			}
+			operation.claimWaiting = false
+			if conflict := compositeYieldConflictEdge(operation); conflict != nil {
+				ca.enqueueReservation(conflict.key, operation)
+				operation.claimWaiting = true
+				continue
+			}
+		} else {
+			if operation.claimCursor >= len(operation.authorityClaimEdges) {
+				return nil, false, errors.New("jobmgr claims: invalid wake cursor")
+			}
+			edge := &operation.authorityClaimEdges[operation.claimCursor]
+			if edge.key != key || key.holder != nil {
+				return nil, false, errors.New("jobmgr claims: settlement waiter differs")
+			}
+			if err := ca.removeWaiter(edge); err != nil {
+				return nil, false, err
+			}
+			operation.claimWaiting = false
+			if err := holdEdge(edge); err != nil {
+				return nil, false, err
+			}
+			ca.refreshSettlement(key)
+			operation.claimCursor++
 		}
-		if err := ca.removeWaiter(edge); err != nil {
-			return nil, false, err
-		}
-		operation.claimWaiting = false
-		holdEdge(edge)
-		ca.refreshSettlement(key)
-		operation.claimCursor++
 		granted, err := ca.acquireFromCursor(operation)
 		if err != nil {
 			return nil, false, err
@@ -391,7 +539,171 @@ func (ca *claimAuthority) refreshSettlement(key *authorityClaimKey) {
 }
 
 func claimSettlementEligible(key *authorityClaimKey) bool {
-	return key != nil && key.holder == nil && key.waiterHead != nil
+	return claimSettlementOperation(key) != nil
+}
+
+func claimSettlementOperation(key *authorityClaimKey) *commandOperation {
+	operation, _ := claimSettlementCandidate(key)
+	return operation
+}
+
+func claimSettlementCandidate(key *authorityClaimKey) (*commandOperation, bool) {
+	if key == nil || key.holder != nil {
+		return nil, false
+	}
+	var waiter *commandOperation
+	for edge := key.waiterHead; edge != nil; edge = edge.next {
+		if !compositeClaimBorrowerBlocked(edge) {
+			waiter = edge.operation
+			break
+		}
+	}
+	var reserved *commandOperation
+	for operation := key.reservationHead; operation != nil; operation = operation.claimReservationNext {
+		if !compositeConflictsWithYieldedLanes(operation, key) {
+			reserved = operation
+			break
+		}
+	}
+	switch {
+	case waiter == nil:
+		return reserved, reserved != nil
+	case reserved == nil || waiter.claimTicket < reserved.claimTicket:
+		return waiter, false
+	default:
+		return reserved, true
+	}
+}
+
+func compositeClaimBorrowerBlocked(edge *authorityClaimEdge) bool {
+	return edge != nil && edge.key != nil && !edge.yielded &&
+		compositeConflictsWithYieldedLanes(edge.operation, edge.key)
+}
+
+func compositeYieldConflictEdge(operation *commandOperation) *authorityClaimEdge {
+	if operation == nil || operation.claimsYielded ||
+		operation.plan.Transaction == nil ||
+		operation.plan.Transaction.PrepareComposite == nil {
+		return nil
+	}
+	for index := range operation.authorityClaimEdges {
+		edge := &operation.authorityClaimEdges[index]
+		if compositeConflictsWithYieldedLanes(operation, edge.key) {
+			return edge
+		}
+	}
+	return nil
+}
+
+func compositeConflictsWithYieldedLanes(operation *commandOperation, key *authorityClaimKey) bool {
+	if operation == nil || key == nil || key.yielded == 0 ||
+		operation.plan.Transaction == nil ||
+		operation.plan.Transaction.PrepareComposite == nil {
+		return false
+	}
+	conflicts := operation.plan.Transaction.CompositeChildLaneConflict
+	if conflicts == nil {
+		return true
+	}
+	for lane := range key.yieldLanes {
+		if callCompositeChildLaneConflict(conflicts, lane) {
+			return true
+		}
+	}
+	return false
+}
+
+func callCompositeChildLaneConflict(conflicts func(string) bool, lane string) (result bool) {
+	result = true
+	defer func() {
+		_ = recover()
+	}()
+	return conflicts(lane)
+}
+
+func (ca *claimAuthority) demoteYieldConflictedWaiters(key *authorityClaimKey) error {
+	if key == nil || key.yielded == 0 {
+		return errors.New("jobmgr claims: invalid yield-conflict demotion")
+	}
+	for edge := key.waiterHead; edge != nil; {
+		next := edge.next
+		if compositeClaimBorrowerBlocked(edge) {
+			operation := edge.operation
+			if operation == nil || operation.claimCursor >= len(operation.authorityClaimEdges) ||
+				&operation.authorityClaimEdges[operation.claimCursor] != edge {
+				return errors.New("jobmgr claims: invalid conflicted waiter")
+			}
+			if err := ca.removeWaiter(edge); err != nil {
+				return err
+			}
+			operation.claimWaiting = false
+			for index := operation.claimCursor - 1; index >= 0; index-- {
+				if err := ca.releaseEdge(&operation.authorityClaimEdges[index]); err != nil {
+					return err
+				}
+			}
+			operation.claimCursor = 0
+			ca.enqueueReservation(key, operation)
+			operation.claimWaiting = true
+		}
+		edge = next
+	}
+	return nil
+}
+
+func (ca *claimAuthority) enqueueReservation(key *authorityClaimKey, operation *commandOperation) {
+	operation.claimReservationKey = key
+	cursor := key.reservationTail
+	for cursor != nil && cursor.claimTicket > operation.claimTicket {
+		cursor = cursor.claimReservationPrevious
+	}
+	if cursor == nil {
+		operation.claimReservationNext = key.reservationHead
+		if key.reservationHead != nil {
+			key.reservationHead.claimReservationPrevious = operation
+		} else {
+			key.reservationTail = operation
+		}
+		key.reservationHead = operation
+	} else {
+		operation.claimReservationPrevious = cursor
+		operation.claimReservationNext = cursor.claimReservationNext
+		cursor.claimReservationNext = operation
+		if operation.claimReservationNext != nil {
+			operation.claimReservationNext.claimReservationPrevious = operation
+		} else {
+			key.reservationTail = operation
+		}
+	}
+	ca.waiterCount++
+	ca.refreshSettlement(key)
+}
+
+func (ca *claimAuthority) removeReservation(operation *commandOperation) error {
+	if operation == nil || operation.claimReservationKey == nil {
+		return errors.New("jobmgr claims: remove of non-reservation")
+	}
+	key := operation.claimReservationKey
+	if operation.claimReservationPrevious != nil {
+		operation.claimReservationPrevious.claimReservationNext = operation.claimReservationNext
+	} else if key.reservationHead == operation {
+		key.reservationHead = operation.claimReservationNext
+	} else {
+		return errors.New("jobmgr claims: reservation head mismatch")
+	}
+	if operation.claimReservationNext != nil {
+		operation.claimReservationNext.claimReservationPrevious = operation.claimReservationPrevious
+	} else if key.reservationTail == operation {
+		key.reservationTail = operation.claimReservationPrevious
+	} else {
+		return errors.New("jobmgr claims: reservation tail mismatch")
+	}
+	operation.claimReservationKey = nil
+	operation.claimReservationPrevious = nil
+	operation.claimReservationNext = nil
+	ca.waiterCount--
+	ca.refreshSettlement(key)
+	return nil
 }
 
 func (ca *claimAuthority) forget(operation *commandOperation) error {
@@ -401,11 +713,15 @@ func (ca *claimAuthority) forget(operation *commandOperation) error {
 	}
 	for index := range operation.authorityClaimEdges {
 		edge := &operation.authorityClaimEdges[index]
-		if edge.held || edge.waiting || edge.key == nil || edge.key.references <= 0 {
+		if edge.held || edge.waiting || edge.yielded || edge.key == nil || edge.key.references <= 0 ||
+			operation.claimReservationKey != nil || operation.claimYieldLane != "" {
 			return errors.New("jobmgr claims: invalid terminal edge")
 		}
 		edge.key.references--
-		if edge.key.references == 0 && edge.key.holder == nil && edge.key.waiterHead == nil {
+		if edge.key.references == 0 && edge.key.holder == nil && edge.key.waiterHead == nil &&
+			edge.key.yielded == 0 && edge.key.yieldWaiterTail == nil &&
+			edge.key.reservationHead == nil && edge.key.reservationTail == nil &&
+			len(edge.key.yieldLanes) == 0 {
 			if edge.key.settlementIndex >= 0 {
 				return errors.New("jobmgr claims: terminal key remains settlement-eligible")
 			}

--- a/src/go/plugin/agent/jobmgr/claim_authority_test.go
+++ b/src/go/plugin/agent/jobmgr/claim_authority_test.go
@@ -83,6 +83,119 @@ func TestClaimAuthorityLexicographicOrderRetainsAndReleasesPrefix(t *testing.T) 
 
 }
 
+func TestClaimAuthorityYieldConflictDoesNotRetainPrefixOrBlockUnrelatedWork(t *testing.T) {
+	authority := newClaimAuthority()
+	probe := claimTestOperation(t, authority, 1, "probe", []string{"graph"})
+	probe.request.LaneKey = "job-a"
+	probe.plan = WorkPlan{
+		YieldClaimOnPrepare: "graph",
+		Transaction: &ResourceTransactionPlan{
+			ID:      "job-a",
+			Prepare: unusedClaimYieldPrepare,
+		},
+	}
+	granted, err := authority.acquire(probe)
+	require.True(t, granted)
+	require.NoError(t, err)
+	woken, err := authority.yield(probe, "graph", probe.request.LaneKey)
+	require.Empty(t, woken)
+	require.NoError(t, err)
+
+	parent := claimTestOperation(t, authority, 2, "parent", []string{"dependency", "graph"})
+	parent.plan = WorkPlan{
+		Transaction: &ResourceTransactionPlan{
+			ID:               "secret",
+			PrepareComposite: unusedCompositeClaimYieldPrepare,
+			CompositeChildLaneConflict: func(lane string) bool {
+				return lane == "job-a"
+			},
+		},
+	}
+	granted, err = authority.acquire(parent)
+	require.False(t, granted)
+	require.NoError(t, err)
+	require.Zero(t, parent.claimCursor, "a yield-conflicted composite must not retain prefix claims")
+
+	unrelated := claimTestOperation(t, authority, 3, "unrelated", []string{"graph"})
+	granted, err = authority.acquire(unrelated)
+	require.True(t, granted, "unrelated work must use the otherwise-free yielded claim")
+	require.NoError(t, err)
+	woken, err = authority.release(unrelated)
+	require.Empty(t, woken)
+	require.NoError(t, err)
+
+	granted, err = authority.acquire(probe)
+	require.True(t, granted)
+	require.NoError(t, err)
+	woken, err = authority.release(probe)
+	require.NoError(t, err)
+	require.Equal(t, []*commandOperation{parent}, woken)
+
+	woken, err = authority.release(parent)
+	require.Empty(t, woken)
+	require.NoError(t, err)
+	require.Zero(t, authority.waitingCount())
+	require.Empty(t, authority.keys)
+}
+
+func TestClaimAuthorityYieldDemotesAndCancelsConflictedComposite(t *testing.T) {
+	authority := newClaimAuthority()
+	probe := claimTestOperation(t, authority, 1, "probe", []string{"graph"})
+	probe.request.LaneKey = "job-a"
+	granted, err := authority.acquire(probe)
+	require.True(t, granted)
+	require.NoError(t, err)
+
+	parent := claimTestOperation(t, authority, 2, "parent", []string{"dependency", "graph"})
+	parent.plan = WorkPlan{
+		Transaction: &ResourceTransactionPlan{
+			ID:               "secret",
+			PrepareComposite: unusedCompositeClaimYieldPrepare,
+			CompositeChildLaneConflict: func(lane string) bool {
+				return lane == "job-a"
+			},
+		},
+	}
+	granted, err = authority.acquire(parent)
+	require.False(t, granted)
+	require.NoError(t, err)
+	require.Equal(t, 1, parent.claimCursor)
+
+	unrelatedGraph := claimTestOperation(t, authority, 3, "job-c", []string{"graph"})
+	granted, err = authority.acquire(unrelatedGraph)
+	require.False(t, granted)
+	require.NoError(t, err)
+
+	woken, err := authority.yield(probe, "graph", probe.request.LaneKey)
+	require.NoError(t, err)
+	require.Equal(t, []*commandOperation{unrelatedGraph}, woken)
+	require.Zero(t, parent.claimCursor)
+	require.NotNil(t, parent.claimReservationKey)
+	woken, err = authority.release(unrelatedGraph)
+	require.Empty(t, woken)
+	require.NoError(t, err)
+
+	unrelated := claimTestOperation(t, authority, 4, "unrelated-secret", []string{"dependency"})
+	granted, err = authority.acquire(unrelated)
+	require.True(t, granted, "demotion must release the composite prefix")
+	require.NoError(t, err)
+	woken, err = authority.release(unrelated)
+	require.Empty(t, woken)
+	require.NoError(t, err)
+
+	woken, err = authority.cancel(parent)
+	require.Empty(t, woken)
+	require.NoError(t, err)
+	granted, err = authority.acquire(probe)
+	require.True(t, granted)
+	require.NoError(t, err)
+	woken, err = authority.release(probe)
+	require.Empty(t, woken)
+	require.NoError(t, err)
+	require.Zero(t, authority.waitingCount())
+	require.Empty(t, authority.keys)
+}
+
 func TestClaimAuthorityCancelAndReleaseAllocateNothing(t *testing.T) {
 	measure := func(cancel bool) float64 {
 		fixtures := [2]claimAllocationFixture{}

--- a/src/go/plugin/agent/jobmgr/claim_yield.go
+++ b/src/go/plugin/agent/jobmgr/claim_yield.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"errors"
+)
+
+type claimYieldLease interface {
+	release(context.Context) error
+	reacquire(context.Context) error
+}
+
+type claimYieldContextKey struct{}
+
+func withClaimYieldLease(ctx context.Context, lease claimYieldLease) context.Context {
+	return context.WithValue(ctx, claimYieldContextKey{}, lease)
+}
+
+// RunWithoutClaims temporarily releases the current transaction's configured
+// acquisition-suffix claim while work runs, then reacquires it before returning.
+func RunWithoutClaims(ctx context.Context, work func(context.Context) error) (workErr, claimErr error) {
+	if ctx == nil || work == nil {
+		return nil, errors.New("jobmgr claims: invalid yielded work")
+	}
+	lease, ok := ctx.Value(claimYieldContextKey{}).(claimYieldLease)
+	if !ok || lease == nil {
+		return nil, errors.New("jobmgr claims: yielded work is unavailable")
+	}
+	if err := lease.release(ctx); err != nil {
+		return nil, err
+	}
+	defer func() {
+		claimErr = lease.reacquire(context.WithoutCancel(ctx))
+	}()
+	workErr = work(ctx)
+	return workErr, claimErr
+}

--- a/src/go/plugin/agent/jobmgr/claim_yield_kernel.go
+++ b/src/go/plugin/agent/jobmgr/claim_yield_kernel.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"errors"
+)
+
+type claimYieldAction uint8
+
+const (
+	claimYieldRelease claimYieldAction = iota + 1
+	claimYieldReacquire
+)
+
+type claimYieldRequest struct {
+	operation *commandOperation
+	action    claimYieldAction
+	result    chan error
+}
+
+type kernelClaimYieldLease struct {
+	kernel    *CommandKernel
+	operation *commandOperation
+}
+
+func (lease kernelClaimYieldLease) release(ctx context.Context) error {
+	return lease.request(ctx, claimYieldRelease)
+}
+
+func (lease kernelClaimYieldLease) reacquire(ctx context.Context) error {
+	return lease.request(ctx, claimYieldReacquire)
+}
+
+func (lease kernelClaimYieldLease) request(ctx context.Context, action claimYieldAction) error {
+	if lease.kernel == nil || lease.operation == nil || ctx == nil {
+		return errors.New("jobmgr claims: invalid yield lease")
+	}
+	result := make(chan error, 1)
+	request := claimYieldRequest{
+		operation: lease.operation,
+		action:    action,
+		result:    result,
+	}
+	select {
+	case lease.kernel.claimYields <- request:
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-lease.kernel.done:
+		return ErrStopped
+	}
+	select {
+	case err := <-result:
+		return err
+	case <-lease.kernel.done:
+		return ErrStopped
+	}
+}
+
+func (ck *CommandKernel) serviceClaimYields(quantum int) bool {
+	if ck == nil || quantum <= 0 {
+		return false
+	}
+	for range quantum {
+		select {
+		case request := <-ck.claimYields:
+			ck.serviceClaimYield(request)
+		default:
+			return false
+		}
+	}
+	return len(ck.claimYields) != 0
+}
+
+func (ck *CommandKernel) serviceClaimYield(request claimYieldRequest) {
+	operation := request.operation
+	if operation == nil || request.result == nil ||
+		ck.operations[operation.UID] != operation ||
+		operation.lane == nil || operation.lane.active != operation ||
+		operation.plan.YieldClaimOnPrepare == "" {
+		request.result <- errors.New("jobmgr claims: invalid yield request")
+		return
+	}
+	owner := operation
+	if operation.claimsInherited {
+		owner = operation.parent
+	}
+	if owner == nil ||
+		ck.operations[owner.UID] != owner ||
+		owner.lane == nil || owner.lane.active != owner ||
+		(operation.claimsInherited && owner.activeChild != operation) {
+		request.result <- errors.New("jobmgr claims: invalid yield owner")
+		return
+	}
+	switch request.action {
+	case claimYieldRelease:
+		if owner.claimsYielded || owner.claimYieldBorrower != nil ||
+			owner.claimYieldResult != nil || !owner.claimsHeld {
+			request.result <- errors.New("jobmgr claims: invalid release request")
+			return
+		}
+		fenceSuspended := false
+		if owner.composite != nil && owner.composite.fenced {
+			if err := ck.suspendCompositeFenceClaim(owner, operation.plan.YieldClaimOnPrepare); err != nil {
+				request.result <- err
+				return
+			}
+			fenceSuspended = true
+		}
+		granted, err := ck.claims.yield(
+			owner,
+			operation.plan.YieldClaimOnPrepare,
+			operation.request.LaneKey,
+		)
+		if err != nil {
+			if fenceSuspended {
+				err = errors.Join(err, ck.restoreCompositeFenceClaim(owner, operation.plan.YieldClaimOnPrepare))
+			}
+			request.result <- err
+			return
+		}
+		owner.claimsYielded = true
+		owner.claimYieldBorrower = operation
+		for _, grantedOperation := range granted {
+			ck.completeClaimGrant(grantedOperation)
+		}
+		request.result <- nil
+	case claimYieldReacquire:
+		if !owner.claimsYielded || owner.claimYieldBorrower != operation ||
+			owner.claimYieldResult != nil || owner.claimsHeld || ck.claims.waiting(owner) {
+			request.result <- errors.New("jobmgr claims: invalid reacquire request")
+			return
+		}
+		granted, err := ck.claims.acquire(owner)
+		if err != nil {
+			request.result <- err
+			return
+		}
+		if granted {
+			if owner.claimYieldFence {
+				if err := ck.restoreCompositeFenceClaim(owner, operation.plan.YieldClaimOnPrepare); err != nil {
+					request.result <- err
+					return
+				}
+			}
+			owner.claimsYielded = false
+			owner.claimYieldBorrower = nil
+			request.result <- nil
+			return
+		}
+		owner.claimYieldResult = request.result
+	default:
+		request.result <- errors.New("jobmgr claims: unknown yield action")
+	}
+}
+
+func (ck *CommandKernel) completeClaimGrant(operation *commandOperation) {
+	if operation == nil {
+		ck.run.Dirty(errors.New("jobmgr claims: nil granted operation"))
+		return
+	}
+	if operation.claimYieldResult == nil {
+		ck.markReady(operation.lane)
+		return
+	}
+	if !operation.claimsYielded || operation.claimYieldBorrower == nil ||
+		!operation.claimsHeld || ck.claims.waiting(operation) {
+		ck.run.Dirty(errors.New("jobmgr claims: invalid yielded claim grant"))
+		return
+	}
+	result := operation.claimYieldResult
+	borrower := operation.claimYieldBorrower
+	if operation.claimYieldFence {
+		if err := ck.restoreCompositeFenceClaim(operation, borrower.plan.YieldClaimOnPrepare); err != nil {
+			ck.run.Dirty(err)
+			result <- err
+			return
+		}
+	}
+	operation.claimYieldResult = nil
+	operation.claimsYielded = false
+	operation.claimYieldBorrower = nil
+	result <- nil
+}

--- a/src/go/plugin/agent/jobmgr/claim_yield_test.go
+++ b/src/go/plugin/agent/jobmgr/claim_yield_test.go
@@ -1,0 +1,572 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionProbeYieldsClaimsUntilPreparationResumes(t *testing.T) {
+	kernel, run := newKernel(t)
+	require.NoError(t, run.OpenAdmission())
+	startKernelLoop(t, kernel)
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	probeDone := make(chan error, 1)
+
+	probePlan := WorkPlan{
+		Claims:              []string{"graph"},
+		NoResponse:          true,
+		YieldClaimOnPrepare: "graph",
+		Transaction: &ResourceTransactionPlan{
+			ID: "job-a",
+			Prepare: func(
+				ctx context.Context,
+				_ lifecycle.ReadyResource,
+				scope lifecycle.ResourceTransactionScope,
+				permit lifecycle.LongLivedPermit,
+			) (lifecycle.PreparedResourceTransaction, error) {
+				workErr, claimErr := RunWithoutClaims(ctx, func(context.Context) error {
+					close(probeStarted)
+					<-releaseProbe
+					return nil
+				})
+				if err := errors.Join(workErr, claimErr); err != nil {
+					return nil, err
+				}
+				return &simpleCompositeChildTransaction{scope: scope, permit: permit}, nil
+			},
+		},
+	}
+	go func() {
+		probeDone <- kernel.SubmitPreparedAndWait(
+			context.Background(),
+			Request{
+				UID:     "probe",
+				LaneKey: "job-a",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/probe",
+			},
+			probePlan,
+		)
+	}()
+	select {
+	case <-probeStarted:
+	case err := <-probeDone:
+		require.NoError(t, err)
+		require.FailNow(t, "probe transaction completed before probing")
+	case <-time.After(time.Second):
+		require.FailNow(t, "probe did not start")
+	}
+
+	sameLaneApplied := make(chan struct{})
+	sameLaneDone := make(chan error, 1)
+	go func() {
+		sameLaneDone <- kernel.SubmitPreparedAndWait(
+			context.Background(),
+			Request{
+				UID:     "same-lane",
+				LaneKey: "job-a",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/same-lane",
+			},
+			compositeTestPlan("job-a", []string{"graph"}, func() {
+				close(sameLaneApplied)
+			}),
+		)
+	}()
+
+	otherApplied := make(chan struct{})
+	otherPlan := compositeTestPlan("job-b", []string{"graph"}, func() {
+		close(otherApplied)
+	})
+	otherCtx, cancelOther := context.WithTimeout(context.Background(), time.Second)
+	defer cancelOther()
+	require.NoError(t, kernel.SubmitPreparedAndWait(
+		otherCtx,
+		Request{
+			UID:     "other",
+			LaneKey: "job-b",
+			Source:  lifecycle.SourceJobManager,
+			Route:   "internal/test/other",
+		},
+		otherPlan,
+	))
+	select {
+	case <-otherApplied:
+	default:
+		require.FailNow(t, "other transaction did not apply while probe was blocked")
+	}
+	select {
+	case <-sameLaneApplied:
+		require.FailNow(t, "same-resource transaction overlapped the active probe")
+	default:
+	}
+
+	close(releaseProbe)
+	select {
+	case err := <-probeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "probe transaction did not resume")
+	}
+	select {
+	case err := <-sameLaneDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "same-resource transaction did not resume after the probe")
+	}
+
+	stopCompositeTestKernel(t, kernel)
+}
+
+func TestCompositeProbeYieldsJobGraphClaimButRetainsDependencyClaim(t *testing.T) {
+	kernel, run := newKernel(t)
+	require.NoError(t, run.OpenAdmission())
+	startKernelLoop(t, kernel)
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	parentDone := make(chan error, 1)
+
+	childPlan := WorkPlan{
+		Claims:              []string{"graph"},
+		NoResponse:          true,
+		YieldClaimOnPrepare: "graph",
+		Transaction: &ResourceTransactionPlan{
+			ID: "job",
+			Prepare: func(
+				ctx context.Context,
+				_ lifecycle.ReadyResource,
+				scope lifecycle.ResourceTransactionScope,
+				permit lifecycle.LongLivedPermit,
+			) (lifecycle.PreparedResourceTransaction, error) {
+				workErr, claimErr := RunWithoutClaims(ctx, func(context.Context) error {
+					close(probeStarted)
+					<-releaseProbe
+					return nil
+				})
+				if err := errors.Join(workErr, claimErr); err != nil {
+					return nil, err
+				}
+				return &simpleCompositeChildTransaction{scope: scope, permit: permit}, nil
+			},
+		},
+	}
+	parentPlan := compositeParentTestPlan(
+		"secret",
+		[]string{"dependency", "graph"},
+		func(ctx context.Context, commands CompositeCommandScope) error {
+			return commands.SubmitPreparedAndWait(
+				ctx,
+				Request{
+					UID:     "child",
+					LaneKey: "job",
+					Source:  lifecycle.SourceJobManager,
+					Route:   "internal/test/child",
+				},
+				childPlan,
+			)
+		},
+	)
+	go func() {
+		parentDone <- kernel.SubmitPreparedAndWait(
+			context.Background(),
+			Request{
+				UID:     "parent",
+				LaneKey: "secret",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/parent",
+			},
+			parentPlan,
+		)
+	}()
+	select {
+	case <-probeStarted:
+	case err := <-parentDone:
+		require.NoError(t, err)
+		require.FailNow(t, "parent completed before child probing")
+	case <-time.After(time.Second):
+		require.FailNow(t, "child probe did not start")
+	}
+
+	graphCtx, cancelGraph := context.WithTimeout(context.Background(), time.Second)
+	defer cancelGraph()
+	require.NoError(t, kernel.SubmitPreparedAndWait(
+		graphCtx,
+		Request{
+			UID:     "graph-only",
+			LaneKey: "other-job",
+			Source:  lifecycle.SourceJobManager,
+			Route:   "internal/test/graph-only",
+		},
+		compositeTestPlan("other-job", []string{"graph"}, nil),
+	))
+
+	dependencyDone := make(chan error, 1)
+	go func() {
+		dependencyDone <- kernel.SubmitPreparedAndWait(
+			context.Background(),
+			Request{
+				UID:     "dependency-only",
+				LaneKey: "other-secret",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/dependency-only",
+			},
+			compositeTestPlan("other-secret", []string{"dependency"}, nil),
+		)
+	}()
+	select {
+	case err := <-dependencyDone:
+		require.NoError(t, err)
+		require.FailNow(t, "retained dependency claim was released during child probe")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseProbe)
+	select {
+	case err := <-parentDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "parent did not resume after child probe")
+	}
+	select {
+	case err := <-dependencyDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "dependency claim did not release after parent completion")
+	}
+
+	stopCompositeTestKernel(t, kernel)
+}
+
+func TestClaimYieldAcknowledgementSettlesAfterEnqueueCancellation(t *testing.T) {
+	tests := map[string]struct {
+		setup func(*testing.T, *testCommandKernel) (*commandOperation, *commandOperation)
+	}{
+		"direct owner": {
+			setup: func(t *testing.T, kernel *testCommandKernel) (*commandOperation, *commandOperation) {
+				t.Helper()
+				operation := activeClaimYieldTestOperation(t, kernel, 1, "direct", []string{"graph"})
+				operation.plan = WorkPlan{
+					YieldClaimOnPrepare: "graph",
+					Transaction:         &ResourceTransactionPlan{ID: "direct", Prepare: unusedClaimYieldPrepare},
+				}
+				return operation, operation
+			},
+		},
+		"composite owner": {
+			setup: func(t *testing.T, kernel *testCommandKernel) (*commandOperation, *commandOperation) {
+				t.Helper()
+				parent := activeClaimYieldTestOperation(t, kernel, 1, "parent", []string{"dependency", "graph"})
+				parent.plan = WorkPlan{
+					Transaction: &ResourceTransactionPlan{
+						ID:               "parent",
+						PrepareComposite: unusedCompositeClaimYieldPrepare,
+					},
+				}
+				parent.composite = newKernelCompositeScope(kernel.CommandKernel, parent)
+				require.NoError(t, kernel.beginCompositeFence(parent))
+
+				generation, err := lifecycle.NewOperation(2, "child", lifecycle.SourceJobManager, "child", true)
+				require.NoError(t, err)
+				child := &commandOperation{
+					OperationGeneration: generation,
+					plan: WorkPlan{
+						YieldClaimOnPrepare: "graph",
+						Transaction:         &ResourceTransactionPlan{ID: "child", Prepare: unusedClaimYieldPrepare},
+					},
+					parent:          parent,
+					claimsInherited: true,
+				}
+				child.lane = &commandLane{active: child}
+				parent.activeChild = child
+				kernel.operations[child.UID] = child
+				return parent, child
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			kernel, _ := newKernel(t)
+			owner, borrower := test.setup(t, kernel)
+			ctx, cancel := context.WithCancel(context.Background())
+			released := make(chan error, 1)
+			go func() {
+				released <- (kernelClaimYieldLease{
+					kernel:    kernel.CommandKernel,
+					operation: borrower,
+				}).release(ctx)
+			}()
+			require.Eventually(t, func() bool {
+				return len(kernel.claimYields) == 1
+			}, time.Second, time.Millisecond)
+			cancel()
+			select {
+			case err := <-released:
+				require.NoError(t, err)
+				require.FailNow(t, "yield release returned before its queued acknowledgement")
+			case <-time.After(20 * time.Millisecond):
+			}
+			kernel.serviceClaimYields(1)
+			require.NoError(t, <-released)
+			require.True(t, owner.claimsYielded)
+
+			reacquired := make(chan error, 1)
+			go func() {
+				reacquired <- (kernelClaimYieldLease{
+					kernel:    kernel.CommandKernel,
+					operation: borrower,
+				}).reacquire(context.Background())
+			}()
+			require.Eventually(t, func() bool {
+				return len(kernel.claimYields) == 1
+			}, time.Second, time.Millisecond)
+			kernel.serviceClaimYields(1)
+			require.NoError(t, <-reacquired)
+			require.True(t, owner.claimsHeld)
+			require.False(t, owner.claimsYielded)
+		})
+	}
+}
+
+func TestRunWithoutClaimsReacquiresAfterPanic(t *testing.T) {
+	lease := &claimYieldPanicTestLease{}
+	ctx := withClaimYieldLease(context.Background(), lease)
+	require.PanicsWithValue(t, "probe panic", func() {
+		_, _ = RunWithoutClaims(ctx, func(context.Context) error {
+			panic("probe panic")
+		})
+	})
+	require.EqualValues(t, 1, lease.releases)
+	require.EqualValues(t, 1, lease.reacquires)
+}
+
+func TestCompositeClaimWaitsForSameResourceProbeReacquisition(t *testing.T) {
+	kernel, run := newKernel(t)
+	require.NoError(t, run.OpenAdmission())
+	startKernelLoop(t, kernel)
+
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- kernel.SubmitPreparedAndWait(
+			context.Background(),
+			Request{
+				UID:     "probe",
+				LaneKey: "job",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/probe",
+			},
+			WorkPlan{
+				Claims:              []string{"graph"},
+				NoResponse:          true,
+				YieldClaimOnPrepare: "graph",
+				Transaction: &ResourceTransactionPlan{
+					ID: "job",
+					Prepare: func(
+						ctx context.Context,
+						_ lifecycle.ReadyResource,
+						scope lifecycle.ResourceTransactionScope,
+						permit lifecycle.LongLivedPermit,
+					) (lifecycle.PreparedResourceTransaction, error) {
+						workErr, claimErr := RunWithoutClaims(ctx, func(context.Context) error {
+							close(probeStarted)
+							<-releaseProbe
+							return nil
+						})
+						if err := errors.Join(workErr, claimErr); err != nil {
+							return nil, err
+						}
+						return &simpleCompositeChildTransaction{scope: scope, permit: permit}, nil
+					},
+				},
+			},
+		)
+	}()
+	select {
+	case <-probeStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "probe did not yield its graph claim")
+	}
+
+	parentEntered := make(chan struct{})
+	parentDone := make(chan error, 1)
+	go func() {
+		parentDone <- kernel.SubmitPreparedAndWait(
+			context.Background(),
+			Request{
+				UID:     "parent",
+				LaneKey: "secret",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/secret-parent",
+			},
+			compositeParentTestPlan(
+				"secret",
+				[]string{"dependency", "graph"},
+				func(ctx context.Context, commands CompositeCommandScope) error {
+					close(parentEntered)
+					return commands.SubmitPreparedAndWait(
+						ctx,
+						Request{
+							UID:     "child",
+							LaneKey: "job",
+							Source:  lifecycle.SourceJobManager,
+							Route:   "internal/test/secret-child",
+						},
+						compositeTestPlan("job", []string{"graph"}, nil),
+					)
+				},
+			),
+		)
+	}()
+
+	select {
+	case <-parentEntered:
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseProbe)
+	select {
+	case err := <-probeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "probe could not reacquire the graph claim")
+	}
+	select {
+	case err := <-parentDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "composite did not settle after the probe")
+	}
+
+	stopCompositeTestKernel(t, kernel)
+}
+
+func TestUnrelatedCompositeSettlesWhileResourceProbeIsYielded(t *testing.T) {
+	kernel, run := newKernel(t)
+	require.NoError(t, run.OpenAdmission())
+	startKernelLoop(t, kernel)
+
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- kernel.SubmitPreparedAndWait(
+			context.Background(),
+			Request{
+				UID:     "probe",
+				LaneKey: "job-a",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/probe",
+			},
+			WorkPlan{
+				Claims:              []string{"graph"},
+				NoResponse:          true,
+				YieldClaimOnPrepare: "graph",
+				Transaction: &ResourceTransactionPlan{
+					ID: "job-a",
+					Prepare: func(
+						ctx context.Context,
+						_ lifecycle.ReadyResource,
+						scope lifecycle.ResourceTransactionScope,
+						permit lifecycle.LongLivedPermit,
+					) (lifecycle.PreparedResourceTransaction, error) {
+						workErr, claimErr := RunWithoutClaims(ctx, func(context.Context) error {
+							close(probeStarted)
+							<-releaseProbe
+							return nil
+						})
+						if err := errors.Join(workErr, claimErr); err != nil {
+							return nil, err
+						}
+						return &simpleCompositeChildTransaction{scope: scope, permit: permit}, nil
+					},
+				},
+			},
+		)
+	}()
+	select {
+	case <-probeStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "probe did not yield its graph claim")
+	}
+
+	parentPlan := compositeParentTestPlan(
+		"unrelated-secret",
+		[]string{"dependency", "graph"},
+		nil,
+	)
+	parentPlan.Transaction.CompositeChildLaneConflict = func(string) bool { return false }
+	parentCtx, cancelParent := context.WithTimeout(context.Background(), time.Second)
+	defer cancelParent()
+	require.NoError(t, kernel.SubmitPreparedAndWait(
+		parentCtx,
+		Request{
+			UID:     "unrelated-parent",
+			LaneKey: "unrelated-secret",
+			Source:  lifecycle.SourceJobManager,
+			Route:   "internal/test/unrelated-parent",
+		},
+		parentPlan,
+	))
+
+	close(releaseProbe)
+	require.NoError(t, <-probeDone)
+	stopCompositeTestKernel(t, kernel)
+}
+
+func activeClaimYieldTestOperation(
+	t *testing.T,
+	kernel *testCommandKernel,
+	id lifecycle.OperationID,
+	uid string,
+	claims []string,
+) *commandOperation {
+	t.Helper()
+	operation := claimTestOperation(t, kernel.claims, id, uid, claims)
+	operation.lane = &commandLane{active: operation}
+	kernel.operations[operation.UID] = operation
+	granted, err := kernel.claims.acquire(operation)
+	require.NoError(t, err)
+	require.True(t, granted)
+	return operation
+}
+
+func unusedClaimYieldPrepare(
+	context.Context,
+	lifecycle.ReadyResource,
+	lifecycle.ResourceTransactionScope,
+	lifecycle.LongLivedPermit,
+) (lifecycle.PreparedResourceTransaction, error) {
+	return nil, errors.New("unused test preparation")
+}
+
+func unusedCompositeClaimYieldPrepare(
+	context.Context,
+	lifecycle.ReadyResource,
+	lifecycle.ResourceTransactionScope,
+	lifecycle.LongLivedPermit,
+) (PreparedCompositeResourceTransaction, error) {
+	return nil, errors.New("unused test preparation")
+}
+
+type claimYieldPanicTestLease struct {
+	releases   int
+	reacquires int
+}
+
+func (lease *claimYieldPanicTestLease) release(context.Context) error {
+	lease.releases++
+	return nil
+}
+
+func (lease *claimYieldPanicTestLease) reacquire(context.Context) error {
+	lease.reacquires++
+	return nil
+}

--- a/src/go/plugin/agent/jobmgr/composite.go
+++ b/src/go/plugin/agent/jobmgr/composite.go
@@ -4,9 +4,14 @@ package jobmgr
 
 import (
 	"context"
+	"errors"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 )
+
+// ErrCompositeRecoveryUnresolved reports recovery work that did not reach a
+// terminal ownership state after its bounded context was cancelled.
+var ErrCompositeRecoveryUnresolved = errors.New("jobmgr composite: recovery child remained unresolved after cancellation")
 
 // PreparedCompositeResourceTransaction is a resource transaction whose Apply
 // phase may execute acknowledged child commands inside the parent's ordering
@@ -28,10 +33,9 @@ type CompositeResourceTransactionWork func(
 
 // CompositeCommandScope owns acknowledged child execution for one running
 // parent transaction. SubmitPreparedAndWait follows caller/parent
-// cancellation. SubmitRollbackAndWait and RollbackContext use one lazily
-// created, run-owned bounded rollback context.
+// cancellation. SubmitRecoveryAndWait uses the adapter-owned bounded recovery
+// context and remains eligible as an ownership continuation after cancellation.
 type CompositeCommandScope interface {
 	SubmitPreparedAndWait(context.Context, Request, WorkPlan) error
-	SubmitRollbackAndWait(Request, WorkPlan) error
-	RollbackContext() (context.Context, error)
+	SubmitRecoveryAndWait(context.Context, Request, WorkPlan) error
 }

--- a/src/go/plugin/agent/jobmgr/composite_kernel.go
+++ b/src/go/plugin/agent/jobmgr/composite_kernel.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"slices"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -18,11 +17,9 @@ type kernelCompositeScope struct {
 	parent *commandOperation // parent composite operation
 	closed atomic.Bool       // scope closed to new child submissions
 	fenced bool              // the composite fence is installed
-
-	rollbackMu     sync.Mutex         // guards the lazily-created rollback context
-	rollbackCtx    context.Context    // run-owned bounded rollback context
-	rollbackCancel context.CancelFunc // cancels rollbackCtx
 }
+
+const compositeRecoverySettlementTimeout = time.Second
 
 func newKernelCompositeScope(kernel *CommandKernel, parent *commandOperation) *kernelCompositeScope {
 	return &kernelCompositeScope{
@@ -35,53 +32,25 @@ func (kcs *kernelCompositeScope) SubmitPreparedAndWait(ctx context.Context, requ
 	return kcs.submitAndWait(ctx, request, plan, false)
 }
 
-func (kcs *kernelCompositeScope) SubmitRollbackAndWait(request Request, plan WorkPlan) error {
-	ctx, err := kcs.RollbackContext()
-	if err != nil {
-		return err
-	}
+func (kcs *kernelCompositeScope) SubmitRecoveryAndWait(
+	ctx context.Context,
+	request Request,
+	plan WorkPlan,
+) error {
 	return kcs.submitAndWait(ctx, request, plan, true)
-}
-
-func (kcs *kernelCompositeScope) RollbackContext() (context.Context, error) {
-	if kcs == nil || kcs.kernel == nil || kcs.parent == nil || kcs.closed.Load() {
-		return nil, errors.New("jobmgr composite: rollback outside active parent")
-	}
-	kcs.rollbackMu.Lock()
-	defer kcs.rollbackMu.Unlock()
-	if kcs.closed.Load() {
-		return nil, errors.New("jobmgr composite: rollback outside active parent")
-	}
-	if kcs.rollbackCtx != nil {
-		return kcs.rollbackCtx, nil
-	}
-	ctx, cancel, err := kcs.kernel.run.NewRollbackContext()
-	if err != nil {
-		return nil, err
-	}
-	kcs.rollbackCtx = ctx
-	kcs.rollbackCancel = cancel
-	return ctx, nil
 }
 
 func (kcs *kernelCompositeScope) close() {
 	if kcs == nil || !kcs.closed.CompareAndSwap(false, true) {
 		return
 	}
-	kcs.rollbackMu.Lock()
-	if kcs.rollbackCancel != nil {
-		kcs.rollbackCancel()
-	}
-	kcs.rollbackCtx = nil
-	kcs.rollbackCancel = nil
-	kcs.rollbackMu.Unlock()
 }
 
 func (kcs *kernelCompositeScope) submitAndWait(
 	ctx context.Context,
 	request Request,
 	plan WorkPlan,
-	rollback bool,
+	recovery bool,
 ) error {
 	if kcs == nil || kcs.kernel == nil || kcs.parent == nil || kcs.closed.Load() || ctx == nil {
 		return errors.New("jobmgr composite: invalid child submission")
@@ -93,7 +62,7 @@ func (kcs *kernelCompositeScope) submitAndWait(
 		return errors.New("jobmgr composite: child must be a response-free Job Manager command")
 	}
 	request.Deadline = earliestDeadline(request.Deadline, contextDeadline(ctx))
-	if !rollback {
+	if !recovery {
 		request.Deadline = earliestDeadline(request.Deadline, kcs.parent.request.Deadline)
 	}
 	if err := request.Validate(); err != nil {
@@ -114,7 +83,7 @@ func (kcs *kernelCompositeScope) submitAndWait(
 			plan:      owned,
 			context:   ctx,
 			composite: kcs,
-			rollback:  rollback,
+			recovery:  recovery,
 			result:    result,
 			terminal:  terminal,
 		},
@@ -126,7 +95,7 @@ func (kcs *kernelCompositeScope) submitAndWait(
 	if !accepted {
 		return err
 	}
-	return errors.Join(err, kcs.waitChildTerminal(ctx, request.UID, terminal, rollback))
+	return errors.Join(err, kcs.waitChildTerminal(ctx, request.UID, terminal, recovery))
 }
 
 func (kcs *kernelCompositeScope) waitChildAdmission(
@@ -161,7 +130,7 @@ func (kcs *kernelCompositeScope) waitChildTerminal(
 	ctx context.Context,
 	uid string,
 	terminal <-chan error,
-	rollback bool,
+	recovery bool,
 ) error {
 	var cancellation error
 	done := ctx.Done()
@@ -172,12 +141,6 @@ func (kcs *kernelCompositeScope) waitChildTerminal(
 		case <-done:
 			cancellation = context.Cause(ctx)
 			done = nil
-			if rollback {
-				kcs.kernel.run.Dirty(
-					errors.Join(errors.New("jobmgr composite: rollback deadline exceeded"), cancellation),
-				)
-				kcs.kernel.NotifyControlReady()
-			}
 			select {
 			case kcs.kernel.cancel <- uid:
 			case err := <-terminal:
@@ -185,8 +148,35 @@ func (kcs *kernelCompositeScope) waitChildTerminal(
 			case <-kcs.kernel.done:
 				return errors.Join(cancellation, ErrStopped)
 			}
+			if recovery {
+				timer := time.NewTimer(compositeRecoverySettlementTimeout)
+				select {
+				case err := <-terminal:
+					stopCompositeRecoveryTimer(timer)
+					return errors.Join(cancellation, err)
+				case <-timer.C:
+					cancellation = errors.Join(
+						cancellation,
+						ErrCompositeRecoveryUnresolved,
+					)
+					kcs.kernel.run.Dirty(cancellation)
+					kcs.kernel.NotifyControlReady()
+				case <-kcs.kernel.done:
+					stopCompositeRecoveryTimer(timer)
+					return errors.Join(cancellation, ErrStopped)
+				}
+			}
 		case <-kcs.kernel.done:
 			return errors.Join(cancellation, ErrStopped)
+		}
+	}
+}
+
+func stopCompositeRecoveryTimer(timer *time.Timer) {
+	if timer != nil && !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
 		}
 	}
 }
@@ -241,7 +231,7 @@ func (pcb *preparedCompositeBridge) Dispose(ctx context.Context) (lifecycle.Read
 func (ck *CommandKernel) validateCompositeAdmission(
 	scope *kernelCompositeScope,
 	plan WorkPlan,
-	rollback bool,
+	recovery bool,
 ) (*commandOperation, error) {
 	if scope == nil || scope.kernel != ck || scope.parent == nil || scope.closed.Load() {
 		return nil, errors.New("jobmgr composite: stale parent scope")
@@ -260,7 +250,7 @@ func (ck *CommandKernel) validateCompositeAdmission(
 			!parent.ownershipChain) {
 		return nil, errors.New("jobmgr composite: continuation authority is closed")
 	}
-	if !rollback && (parent.cancelled || parent.TimedOut()) && !parent.ownershipChain {
+	if !recovery && (parent.cancelled || parent.TimedOut()) && !parent.ownershipChain {
 		return nil, errors.New("jobmgr composite: cancelled parent rejected normal child")
 	}
 	childClaims, err := normalizeAuthorityClaims(plan.Claims)
@@ -269,6 +259,10 @@ func (ck *CommandKernel) validateCompositeAdmission(
 	}
 	if !claimsCoveredByParent(parent.claims, childClaims) {
 		return nil, errors.New("jobmgr composite: child claim is outside parent scope")
+	}
+	if plan.YieldClaimOnPrepare != "" &&
+		parent.claims[len(parent.claims)-1] != plan.YieldClaimOnPrepare {
+		return nil, errors.New("jobmgr composite: yielded child claim is not the parent acquisition suffix")
 	}
 	return parent, nil
 }
@@ -335,6 +329,9 @@ func (ck *CommandKernel) endCompositeFence(parent *commandOperation) error {
 	if ck == nil || parent == nil || parent.composite == nil || !parent.composite.fenced {
 		return nil
 	}
+	if parent.claimYieldFence {
+		return errors.New("jobmgr composite: ended with a yielded fence claim")
+	}
 	for _, claim := range parent.claims {
 		use := ck.compositeFenceClaims[claim] - 1
 		if use < 0 {
@@ -352,6 +349,37 @@ func (ck *CommandKernel) endCompositeFence(parent *commandOperation) error {
 		return errors.New("jobmgr composite: admission fence generation wrapped")
 	}
 	ck.compositeFenceRecheck = ck.compositeFenceHead != nil
+	return nil
+}
+
+func (ck *CommandKernel) suspendCompositeFenceClaim(parent *commandOperation, claim string) error {
+	if ck == nil || parent == nil || parent.composite == nil ||
+		!parent.composite.fenced || parent.claimYieldFence ||
+		ck.compositeFenceClaims[claim] <= 0 {
+		return errors.New("jobmgr composite: invalid yielded fence claim")
+	}
+	use := ck.compositeFenceClaims[claim] - 1
+	if use == 0 {
+		delete(ck.compositeFenceClaims, claim)
+	} else {
+		ck.compositeFenceClaims[claim] = use
+	}
+	parent.claimYieldFence = true
+	ck.compositeFenceGeneration++
+	if ck.compositeFenceGeneration == 0 {
+		return errors.New("jobmgr composite: admission fence generation wrapped")
+	}
+	ck.compositeFenceRecheck = ck.compositeFenceHead != nil
+	return nil
+}
+
+func (ck *CommandKernel) restoreCompositeFenceClaim(parent *commandOperation, claim string) error {
+	if ck == nil || parent == nil || parent.composite == nil ||
+		!parent.composite.fenced || !parent.claimYieldFence {
+		return errors.New("jobmgr composite: invalid yielded fence restoration")
+	}
+	ck.compositeFenceClaims[claim]++
+	parent.claimYieldFence = false
 	return nil
 }
 

--- a/src/go/plugin/agent/jobmgr/composite_kernel_test.go
+++ b/src/go/plugin/agent/jobmgr/composite_kernel_test.go
@@ -304,6 +304,86 @@ func TestCompositeChildBypassesParentClaimWaiterOnTargetLane(t *testing.T) {
 	require.False(t, err != nil && !errors.Is(err, ErrStopped))
 }
 
+func TestCompositeChildMovesAlreadyReadyLaneToItsSchedulingSource(t *testing.T) {
+	kernel, run, uids, tasks := newKernelWithPlanner(t, stoppedKernelPlanner{})
+	require.NoError(t, run.OpenAdmission())
+	setTestFunctionResource(t, kernel, func(FunctionLookup) string { return "job" })
+
+	functionRequest := Request{
+		UID:    "ready-function",
+		Source: lifecycle.SourceFunction,
+		Route:  "route",
+	}
+	require.NoError(t, kernel.admit(functionRequest, WorkPlan{}))
+	require.Equal(t, 0, kernel.ready[0].len)
+	require.Equal(t, 1, kernel.ready[1].len)
+
+	parentEntered := make(chan struct{})
+	childPlan := compositeTestPlan("job", []string{"graph"}, nil)
+	parentPlan := compositeParentTestPlan(
+		"parent",
+		[]string{"graph"},
+		func(ctx context.Context, commands CompositeCommandScope) error {
+			close(parentEntered)
+			return commands.SubmitPreparedAndWait(
+				ctx,
+				Request{
+					UID:     "ready-composite-child",
+					LaneKey: "job",
+					Source:  lifecycle.SourceJobManager,
+					Route:   "internal/test/ready-child",
+				},
+				childPlan,
+			)
+		},
+	)
+	require.NoError(t, kernel.admit(
+		Request{
+			UID:     "ready-composite-parent",
+			LaneKey: "parent",
+			Source:  lifecycle.SourceJobManager,
+			Route:   "internal/test/ready-parent",
+		},
+		parentPlan,
+	))
+
+	require.False(t, kernel.serviceClaimSettlements(maximumClaimSettlementQuantum))
+	require.Equal(t, 1, kernel.ready[0].len)
+	kernel.nextSource = lifecycle.SourceJobManager
+	require.True(t, kernel.scheduleTasks(1))
+	require.False(t, kernel.serviceTaskStarts(1))
+	select {
+	case completion := <-tasks.CompletionCh():
+		kernel.completeTask(completion)
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "composite parent preparation did not complete")
+	}
+	select {
+	case <-parentEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "composite parent did not begin child submission")
+	}
+	require.Eventually(t, func() bool {
+		kernel.serviceSubmissions(4)
+		return kernel.operations["ready-composite-child"] != nil
+	}, time.Second, time.Millisecond)
+
+	lane := kernel.lanes[resourceCommandLaneKey("job")]
+	require.NotNil(t, lane)
+	require.Equal(t, lifecycle.SourceJobManager, lane.head.Source)
+	require.Equal(t, 1, kernel.ready[0].len)
+	require.Same(t, lane, kernel.ready[0].head)
+	require.Equal(t, 0, kernel.ready[1].len)
+
+	startKernelLoop(t, kernel)
+	kernel.Stop()
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := kernel.Wait(waitCtx)
+	require.False(t, err != nil && !errors.Is(err, ErrStopped))
+	closeUIDLedger(t, uids)
+}
+
 func TestCompositeChildCancelledBeforeApplyReportsTerminalCause(t *testing.T) {
 	tests := map[string]struct {
 		deadline bool
@@ -422,10 +502,10 @@ func TestCompositeActionSubmitsChildAfterShutdownCut(t *testing.T) {
 				return commands.SubmitPreparedAndWait(ctx, request, plan)
 			},
 		},
-		"rollback child": {
-			suffix: "rollback",
+		"recovery child": {
+			suffix: "recovery",
 			submit: func(_ context.Context, commands CompositeCommandScope, request Request, plan WorkPlan) error {
-				return commands.SubmitRollbackAndWait(request, plan)
+				return commands.SubmitRecoveryAndWait(context.Background(), request, plan)
 			},
 		},
 	}
@@ -511,6 +591,161 @@ func TestCompositeActionSubmitsChildAfterShutdownCut(t *testing.T) {
 			require.NoError(t, run.DirtyCause())
 		})
 	}
+}
+
+func TestCompositeRecoveryTimeoutStaysCleanAfterChildSettles(t *testing.T) {
+	kernel, run := newKernel(t)
+	require.NoError(t, run.OpenAdmission())
+	startKernelLoop(t, kernel)
+
+	recoveryResult := make(chan error, 1)
+	parentPlan := compositeParentTestPlan(
+		"parent",
+		[]string{"graph"},
+		func(_ context.Context, commands CompositeCommandScope) error {
+			recoveryCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			defer cancel()
+			recoveryResult <- commands.SubmitRecoveryAndWait(
+				recoveryCtx,
+				Request{
+					UID:     "child",
+					LaneKey: "child",
+					Source:  lifecycle.SourceJobManager,
+					Route:   "internal/test/recovery-child",
+				},
+				WorkPlan{
+					Claims:     []string{"graph"},
+					NoResponse: true,
+					Transaction: &ResourceTransactionPlan{
+						ID: "child",
+						Prepare: func(
+							ctx context.Context,
+							_ lifecycle.ReadyResource,
+							_ lifecycle.ResourceTransactionScope,
+							_ lifecycle.LongLivedPermit,
+						) (lifecycle.PreparedResourceTransaction, error) {
+							<-ctx.Done()
+							return nil, context.Cause(ctx)
+						},
+					},
+				},
+			)
+			return nil
+		},
+	)
+	parentDone := make(chan error, 1)
+	go func() {
+		parentDone <- kernel.SubmitPreparedAndWait(
+			context.Background(),
+			Request{
+				UID:     "parent",
+				LaneKey: "parent",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/recovery-parent",
+			},
+			parentPlan,
+		)
+	}()
+
+	select {
+	case err := <-recoveryResult:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.NotErrorIs(t, err, ErrCompositeRecoveryUnresolved)
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "bounded recovery child did not settle")
+	}
+	select {
+	case err := <-parentDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "parent did not settle after bounded recovery")
+	}
+	require.NoError(t, run.DirtyCause())
+	stopCompositeTestKernel(t, kernel)
+}
+
+func TestCompositeRecoveryMarksDirtyOnlyWhenChildRemainsUnresolved(t *testing.T) {
+	kernel, run := newKernel(t)
+	require.NoError(t, run.OpenAdmission())
+	startKernelLoop(t, kernel)
+
+	childEntered := make(chan struct{})
+	releaseChild := make(chan struct{})
+	recoveryResult := make(chan error, 1)
+	parentPlan := compositeParentTestPlan(
+		"parent",
+		[]string{"graph"},
+		func(_ context.Context, commands CompositeCommandScope) error {
+			recoveryCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+			defer cancel()
+			recoveryResult <- commands.SubmitRecoveryAndWait(
+				recoveryCtx,
+				Request{
+					UID:     "child",
+					LaneKey: "child",
+					Source:  lifecycle.SourceJobManager,
+					Route:   "internal/test/unresolved-recovery-child",
+				},
+				WorkPlan{
+					Claims:     []string{"graph"},
+					NoResponse: true,
+					Transaction: &ResourceTransactionPlan{
+						ID: "child",
+						Prepare: func(
+							_ context.Context,
+							_ lifecycle.ReadyResource,
+							scope lifecycle.ResourceTransactionScope,
+							permit lifecycle.LongLivedPermit,
+						) (lifecycle.PreparedResourceTransaction, error) {
+							close(childEntered)
+							<-releaseChild
+							return &simpleCompositeChildTransaction{scope: scope, permit: permit}, nil
+						},
+					},
+				},
+			)
+			return nil
+		},
+	)
+	parentDone := make(chan error, 1)
+	go func() {
+		parentDone <- kernel.SubmitPreparedAndWait(
+			context.Background(),
+			Request{
+				UID:     "parent",
+				LaneKey: "parent",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/unresolved-recovery-parent",
+			},
+			parentPlan,
+		)
+	}()
+	select {
+	case <-childEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "unresolved recovery child did not start")
+	}
+	require.Eventually(t, func() bool {
+		return errors.Is(run.DirtyCause(), ErrCompositeRecoveryUnresolved)
+	}, 2*time.Second, time.Millisecond)
+	close(releaseChild)
+
+	select {
+	case err := <-recoveryResult:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorIs(t, err, ErrCompositeRecoveryUnresolved)
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "unresolved recovery child did not fail closed")
+	}
+	select {
+	case err := <-parentDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "parent did not settle after dirty recovery")
+	}
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), time.Second)
+	defer cancelWait()
+	require.ErrorIs(t, kernel.Wait(waitCtx), ErrCompositeRecoveryUnresolved)
 }
 
 func TestCompositeChildRejectsActiveParentLane(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/composition/discovery.go
+++ b/src/go/plugin/agent/jobmgr/composition/discovery.go
@@ -45,18 +45,23 @@ func (rg *runGeneration) startDiscovery(ctx context.Context) error {
 	}
 	decisions, err := jobmgrdiscovery.NewDecisionIndex(
 		jobmgrdiscovery.DecisionConfig{
-			Generation: rg.run.Generation(),
-			RunJob:     rg.discovery.RunJob,
-			AutoEnable: rg.discovery.AutoEnable,
-			Commands:   rg.kernel,
+			Generation:  rg.run.Generation(),
+			RunJob:      rg.discovery.RunJob,
+			AutoEnable:  rg.discovery.AutoEnable,
+			Commands:    rg.kernel,
+			Diagnostics: rg.diagnostics,
 			Plan: func(change jobmgrdiscovery.DiscoveredChange) (jobmgr.WorkPlan, error) {
-				return rg.dyncfg.PlanDiscovered(
+				plan, err := rg.dyncfg.PlanDiscovered(
 					joboutput.DiscoveredJobChange{
 						Config: change.Config,
 						Status: change.Status,
 						Remove: change.Remove,
 					},
 				)
+				if err != nil {
+					return jobmgr.WorkPlan{}, jobmgr.RejectProposal(err)
+				}
+				return plan, nil
 			},
 		},
 	)

--- a/src/go/plugin/agent/jobmgr/composition/dyncfg.go
+++ b/src/go/plugin/agent/jobmgr/composition/dyncfg.go
@@ -82,10 +82,11 @@ func newDynCfgJobInitialRoute(
 				Handler: binding.handle,
 			},
 			Transaction: &functionadapter.ResourceTransactionDeclaration{
-				Prepare:         binding.prepare,
-				Permit:          permit,
-				CommandArgument: 1,
-				GlobalClaim:     joboutput.DynCfgJobGraphClaim,
+				Prepare:                   binding.prepare,
+				Permit:                    permit,
+				CommandArgument:           1,
+				GlobalClaim:               joboutput.DynCfgJobGraphClaim,
+				YieldGlobalClaimOnPrepare: true,
 				Commands: []functionadapter.ResourceTransactionCommand{
 					{Name: string(dyncfg.CommandAdd)},
 					{Name: string(dyncfg.CommandUpdate), AllocateSuccessor: true},

--- a/src/go/plugin/agent/jobmgr/composition/public.go
+++ b/src/go/plugin/agent/jobmgr/composition/public.go
@@ -20,7 +20,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore/backends"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/runtimecomp"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnoderegistry"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
@@ -107,6 +106,9 @@ func NewProcess(config Config) (*Process, error) {
 		}
 		initialVnodes[id] = vnode.Copy()
 	}
+	if err := validateInitialVNodeSet(initialVnodes); err != nil {
+		return nil, err
+	}
 	build := config.DiscoveryBuildContext
 	if build.Identity.Name == "" {
 		build.Identity.Name = config.PluginName
@@ -115,7 +117,7 @@ func NewProcess(config Config) (*Process, error) {
 		return nil, errors.New("jobmgr composition: discovery identity differs from plugin")
 	}
 	build.Registry = defaults
-	build.DyncfgOutput = dyncfg.NewProtocolOutput(config.Output)
+	build.DyncfgOutput = nil
 	build.FnReg = nil
 	shutdownTimeout := config.ShutdownTimeout
 	if shutdownTimeout == 0 {

--- a/src/go/plugin/agent/jobmgr/composition/public_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/public_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +25,87 @@ func TestProductionProcessRejectsInvalidInitialVnodes(t *testing.T) {
 		vnodes map[string]*vnodes.VirtualNode
 	}{
 		"nil vnode": {vnodes: map[string]*vnodes.VirtualNode{"missing": nil}},
+		"source type with separator": {
+			vnodes: map[string]*vnodes.VirtualNode{
+				"node": {
+					Name:       "node",
+					Hostname:   "node",
+					GUID:       "11111111-1111-1111-1111-111111111111",
+					SourceType: "user type",
+					Source:     "file=/etc/netdata/vnodes.conf",
+				},
+			},
+		},
+		"hostname unsafe for host emission": {
+			vnodes: map[string]*vnodes.VirtualNode{
+				"node": {
+					Name:       "node",
+					Hostname:   "operator's-node",
+					GUID:       "11111111-1111-1111-1111-111111111111",
+					SourceType: confgroup.TypeUser,
+					Source:     "file=/etc/netdata/vnodes.conf",
+				},
+			},
+		},
+		"unsupported GUID spelling": {
+			vnodes: map[string]*vnodes.VirtualNode{
+				"node": {
+					Name:       "node",
+					Hostname:   "node",
+					GUID:       "urn:uuid:11111111-1111-1111-1111-111111111111",
+					SourceType: confgroup.TypeUser,
+					Source:     "file=/etc/netdata/vnodes.conf",
+				},
+			},
+		},
+		"semantically duplicate GUID": {
+			vnodes: map[string]*vnodes.VirtualNode{
+				"first": {
+					Name:       "first",
+					Hostname:   "first",
+					GUID:       "11111111-1111-1111-1111-111111111111",
+					SourceType: confgroup.TypeUser,
+					Source:     "file=/etc/netdata/vnodes.conf",
+				},
+				"second": {
+					Name:       "second",
+					Hostname:   "second",
+					GUID:       "11111111111111111111111111111111",
+					SourceType: confgroup.TypeUser,
+					Source:     "file=/etc/netdata/vnodes.conf",
+				},
+			},
+		},
+		"host label with trailing escape": {
+			vnodes: map[string]*vnodes.VirtualNode{
+				"node": {
+					Name:       "node",
+					Hostname:   "node",
+					GUID:       "11111111-1111-1111-1111-111111111111",
+					Labels:     map[string]string{"site": `value\`},
+					SourceType: confgroup.TypeUser,
+					Source:     "file=/etc/netdata/vnodes.conf",
+				},
+			},
+		},
+		"hostnames collide after host emission preparation": {
+			vnodes: map[string]*vnodes.VirtualNode{
+				"first": {
+					Name:       "first",
+					Hostname:   "host",
+					GUID:       "11111111-1111-1111-1111-111111111111",
+					SourceType: confgroup.TypeUser,
+					Source:     "file=/etc/netdata/vnodes.conf",
+				},
+				"second": {
+					Name:       "second",
+					Hostname:   " host ",
+					GUID:       "22222222-2222-2222-2222-222222222222",
+					SourceType: confgroup.TypeUser,
+					Source:     "file=/etc/netdata/vnodes.conf",
+				},
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -33,6 +116,57 @@ func TestProductionProcessRejectsInvalidInitialVnodes(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestProductionProcessAcceptsIndividuallyValidatedVNodeLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vnodes.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+- hostname: valid
+  guid: 11111111-1111-1111-1111-111111111111
+- hostname: bad=name
+  guid: 22222222-2222-2222-2222-222222222222
+`), 0o644))
+
+	initial := vnodes.Load(dir)
+	require.Len(t, initial, 1)
+	config := testProductionProcessConfig(strings.NewReader(""), io.Discard)
+	config.InitialVnodes = initial
+
+	_, err := NewProcess(config)
+	require.NoError(t, err)
+}
+
+func TestProductionProcessAcceptsCompactInitialVNodeGUID(t *testing.T) {
+	config := testProductionProcessConfig(strings.NewReader(""), io.Discard)
+	config.InitialVnodes = map[string]*vnodes.VirtualNode{
+		"node": {
+			Name:       "node",
+			Hostname:   "node",
+			GUID:       "11111111111111111111111111111111",
+			SourceType: confgroup.TypeUser,
+			Source:     "file=/etc/netdata/vnodes.conf",
+		},
+	}
+
+	_, err := NewProcess(config)
+	require.NoError(t, err)
+}
+
+func TestProductionProcessAcceptsWindowsInitialVNodeSource(t *testing.T) {
+	config := testProductionProcessConfig(strings.NewReader(""), io.Discard)
+	config.InitialVnodes = map[string]*vnodes.VirtualNode{
+		"node": {
+			Name:       "node",
+			Hostname:   "node",
+			GUID:       "11111111-1111-1111-1111-111111111111",
+			SourceType: confgroup.TypeUser,
+			Source:     `file=C:\Program Files\Netdata\vnodes.conf`,
+		},
+	}
+
+	_, err := NewProcess(config)
+	require.NoError(t, err)
 }
 
 func TestProductionProcessIsSingleUse(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/composition/run.go
+++ b/src/go/plugin/agent/jobmgr/composition/run.go
@@ -51,19 +51,18 @@ type runGenerationConfig struct {
 }
 
 type runGeneration struct {
-	diagnostics       jobmgr.DiagnosticObserver      // operational log sink
-	run               *lifecycle.RunSupervisor       // run supervisor for this generation
-	tasks             *lifecycle.TaskSupervisor      // task supervisor
-	functions         *FunctionAssembly              // Function assembly (catalog + controller + publication)
-	scheduler         *joboutput.Scheduler           // tick + retry scheduler
-	dyncfg            *joboutput.DynCfgJobController // dyncfg job controller
-	secrets           *secretadapter.Controller      // secret store controller
-	vnodes            *vnodeBinding                  // dyncfg vnode binding
-	discovery         runDiscoveryServices           // discovery services
-	kernel            *jobmgr.CommandKernel          // the command kernel
-	metrics           *runMetrics                    // jobmgr.runtime metrics projection (nil when runtime charts off)
-	runtime           runtimecomp.Service            // runtime service
-	runtimeRegistered bool                           // guards double-unregister of jobmgr.runtime
+	diagnostics         jobmgr.DiagnosticObserver      // operational log sink
+	run                 *lifecycle.RunSupervisor       // run supervisor for this generation
+	tasks               *lifecycle.TaskSupervisor      // task supervisor
+	functions           *FunctionAssembly              // Function assembly (catalog + controller + publication)
+	scheduler           *joboutput.Scheduler           // tick + retry scheduler
+	dyncfg              *joboutput.DynCfgJobController // dyncfg job controller
+	secrets             *secretadapter.Controller      // secret store controller
+	vnodes              *vnodeBinding                  // dyncfg vnode binding
+	discovery           runDiscoveryServices           // discovery services
+	kernel              *jobmgr.CommandKernel          // the command kernel
+	metrics             *runMetrics                    // jobmgr.runtime metrics projection (nil when runtime charts off)
+	metricsRegistration *runMetricsRegistration        // synchronous runtime-writer lease
 
 	mu               sync.Mutex // guards started/startedAttempted
 	started          bool       // start succeeded
@@ -100,6 +99,7 @@ func newRunGeneration(config runGenerationConfig) (generation *runGeneration, re
 	if config.Jobs.Runtime != nil {
 		metrics = newRunMetrics()
 	}
+	metricsRegistration := newRunMetricsRegistration(metrics, config.Jobs.Runtime)
 	tasks, err := lifecycle.NewTaskSupervisor(config.Frames)
 	if err != nil {
 		return nil, err
@@ -245,8 +245,9 @@ func newRunGeneration(config runGenerationConfig) (generation *runGeneration, re
 		lifecycle.RealClock{},
 		functions,
 		joinedRunFinalizer{
-			functions: functions,
-			secrets:   secretController,
+			functions:           functions,
+			secrets:             secretController,
+			metricsRegistration: metricsRegistration,
 		},
 		functions.Catalog(),
 	)
@@ -270,24 +271,23 @@ func newRunGeneration(config runGenerationConfig) (generation *runGeneration, re
 		if err := kernel.BindRuntimeObserver(metrics); err != nil {
 			return nil, err
 		}
-		if err := metrics.register(config.Jobs.Runtime); err != nil {
+		if err := metricsRegistration.register(); err != nil {
 			return nil, err
 		}
 	}
 	return &runGeneration{
-		diagnostics:       config.Diagnostics,
-		run:               run,
-		tasks:             tasks,
-		functions:         functions,
-		dyncfg:            dynCfgJobs,
-		scheduler:         scheduler,
-		secrets:           secretController,
-		vnodes:            vnodeBinding,
-		discovery:         config.Discovery,
-		kernel:            kernel,
-		metrics:           metrics,
-		runtime:           config.Jobs.Runtime,
-		runtimeRegistered: metrics != nil,
+		diagnostics:         config.Diagnostics,
+		run:                 run,
+		tasks:               tasks,
+		functions:           functions,
+		dyncfg:              dynCfgJobs,
+		scheduler:           scheduler,
+		secrets:             secretController,
+		vnodes:              vnodeBinding,
+		discovery:           config.Discovery,
+		kernel:              kernel,
+		metrics:             metrics,
+		metricsRegistration: metricsRegistration,
 	}, nil
 }
 
@@ -387,7 +387,7 @@ func (rg *runGeneration) abortConstruction() error {
 	if started {
 		return errors.New("jobmgr composition: run construction abort after start")
 	}
-	return errors.Join(rg.releaseRuntimeMetrics(), abortRunConstruction(rg.functions, rg.secrets, nil))
+	return errors.Join(rg.metricsRegistration.release(), abortRunConstruction(rg.functions, rg.secrets, nil))
 }
 
 func (rg *runGeneration) Stop() {
@@ -414,36 +414,71 @@ func (rg *runGeneration) Wait(ctx context.Context) error {
 		if !retryJoined {
 			return errors.Join(waitErr, retryErr)
 		}
-		return errors.Join(waitErr, retryErr, rg.releaseRuntimeMetrics())
+		return errors.Join(waitErr, retryErr)
 	default:
 		return errors.Join(waitErr, retryErr)
 	}
 }
 
-func (rg *runGeneration) releaseRuntimeMetrics() error {
-	if rg == nil {
+type runMetricsRegistration struct {
+	mu         sync.Mutex
+	metrics    *runMetrics
+	service    runtimecomp.Service
+	registered bool
+}
+
+func newRunMetricsRegistration(metrics *runMetrics, service runtimecomp.Service) *runMetricsRegistration {
+	return &runMetricsRegistration{
+		metrics: metrics,
+		service: service,
+	}
+}
+
+func (rmr *runMetricsRegistration) register() error {
+	if rmr == nil || rmr.metrics == nil || rmr.service == nil {
 		return nil
 	}
-	rg.mu.Lock()
-	if !rg.runtimeRegistered {
-		rg.mu.Unlock()
+	rmr.mu.Lock()
+	defer rmr.mu.Unlock()
+	if rmr.registered {
+		return errors.New("jobmgr composition: runtime metrics registered twice")
+	}
+	if err := rmr.metrics.register(rmr.service); err != nil {
+		return err
+	}
+	rmr.registered = true
+	return nil
+}
+
+func (rmr *runMetricsRegistration) release() error {
+	if rmr == nil {
 		return nil
 	}
-	rg.runtimeRegistered = false
-	metrics := rg.metrics
-	service := rg.runtime
-	rg.mu.Unlock()
+	rmr.mu.Lock()
+	if !rmr.registered {
+		rmr.mu.Unlock()
+		return nil
+	}
+	rmr.registered = false
+	metrics := rmr.metrics
+	service := rmr.service
+	rmr.mu.Unlock()
 	return metrics.unregister(service)
 }
 
 type joinedRunFinalizer struct {
-	functions *FunctionAssembly
-	secrets   *secretadapter.Controller
+	functions           *FunctionAssembly
+	secrets             *secretadapter.Controller
+	metricsRegistration *runMetricsRegistration
 }
 
 func (jrf joinedRunFinalizer) FinalizeRun(ctx context.Context, generation uint64) error {
 	if jrf.functions == nil || jrf.secrets == nil {
 		return errors.New("jobmgr composition: incomplete run finalizer")
 	}
-	return errors.Join(jrf.functions.FinalizeRun(ctx, generation), jrf.secrets.Close(ctx))
+	return errors.Join(
+		jrf.metricsRegistration.release(),
+		jrf.functions.FinalizeRun(ctx, generation),
+		jrf.secrets.Close(ctx),
+	)
 }

--- a/src/go/plugin/agent/jobmgr/composition/run_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/run_test.go
@@ -62,6 +62,58 @@ func TestRunGenerationPublishesPerJobTemplatesInModuleOrder(t *testing.T) {
 	closeRunTestUIDs(t, uids)
 }
 
+func TestRunGenerationQuarantinesUnpublishableDiscoveredConfigAndContinues(t *testing.T) {
+	config := func(name string) confgroup.Config {
+		cfg := confgroup.Config{
+			"module":       "module",
+			"name":         name,
+			"update_every": 1,
+		}
+		cfg.SetProvider(confgroup.TypeUser)
+		cfg.SetSourceType(confgroup.TypeUser)
+		cfg.SetSource("file=test")
+		return cfg
+	}
+	invalid := config("bad=name")
+	valid := config("good")
+	output := newProcessSynchronizedBuffer()
+	frames, err := lifecycle.NewFrameOwner(output)
+	require.NoError(t, err)
+	uids := lifecycle.NewUIDLedger()
+	generation, err := newRunGeneration(runGenerationConfig{
+		Generation:      1,
+		ShutdownTimeout: time.Second,
+		UIDs:            uids,
+		Frames:          frames,
+		Modules: collectorapi.Registry{
+			"module": {},
+		},
+		Jobs:      testRunJobServices(t),
+		Discovery: testRunDiscoveryServicesAccepted(t, invalid, valid),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		generation.Stop()
+		require.NoError(t, generation.Wait(context.Background()))
+		closeRunTestUIDs(t, uids)
+	})
+
+	require.NoError(t, generation.start(context.Background()))
+	validFrame := "CONFIG go.d:collector:module:good create accepted job"
+	require.Eventually(t, func() bool {
+		record, ok := generation.vnodes.graph.Lookup(valid.FullName())
+		return ok &&
+			record.Status == dyncfg.StatusAccepted.String() &&
+			strings.Contains(output.String(), validFrame)
+	}, time.Second, time.Millisecond)
+
+	_, invalidPublished := generation.vnodes.graph.Lookup(invalid.FullName())
+	require.False(t, invalidPublished)
+	require.Contains(t, output.String(), validFrame)
+	require.NotContains(t, output.String(), "bad=name")
+	require.NoError(t, generation.run.DirtyCause())
+}
+
 func TestRunGenerationGrowsBeyondFormerJobLimitWithDiscoveredJobs(t *testing.T) {
 	tests := map[string]struct {
 		jobs int
@@ -318,7 +370,7 @@ func TestRunGenerationKeepsDynCfgRoutePrivateAndUsesSameNamePerJobProtocolID(t *
 	closeRunTestUIDs(t, uids)
 }
 
-func TestRunGenerationShutdownDrainsJobActivationAndFunctionPublication(t *testing.T) {
+func TestRunGenerationShutdownRejectsInFlightJobProbeBeforePublication(t *testing.T) {
 	checkEntered := make(chan struct{})
 	checkRelease := make(chan struct{})
 	var cleanupCalls atomic.Int32
@@ -414,10 +466,8 @@ func TestRunGenerationShutdownDrainsJobActivationAndFunctionPublication(t *testi
 	require.NoError(t, probe.waitSettlement(shutdownCtx))
 	require.NoError(t, generation.run.DirtyCause())
 
-	publishedAt := bytes.Index(output.Bytes(), []byte(`FUNCTION GLOBAL "module:method"`))
-	withdrawnAt := bytes.Index(output.Bytes(), []byte(`FUNCTION_DEL GLOBAL "module:method"`))
-	require.GreaterOrEqual(t, publishedAt, 0)
-	require.Greater(t, withdrawnAt, publishedAt)
+	require.NotContains(t, output.String(), `FUNCTION GLOBAL "module:method"`)
+	require.NotContains(t, output.String(), `FUNCTION_DEL GLOBAL "module:method"`)
 	require.EqualValues(t, 1, cleanupCalls.Load())
 	require.Zero(t, generation.tasks.InheritedActive())
 	require.Equal(t, lifecycle.LongLivedCensus{}, generation.tasks.LongLivedCensus())

--- a/src/go/plugin/agent/jobmgr/composition/runtime_metrics_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/runtime_metrics_test.go
@@ -27,6 +27,8 @@ type runMetricsService struct {
 	producers          map[string]func() error
 	producerRemovals   []string
 	producerErr        error
+	finalizeEntered    chan<- struct{}
+	finalizeRelease    <-chan struct{}
 }
 
 func (rms *runMetricsService) RegisterComponent(config runtimecomp.ComponentConfig) error {
@@ -46,8 +48,18 @@ func (*runMetricsService) QuarantineComponent(string) {}
 
 func (rms *runMetricsService) FinalizeComponent(name string) {
 	rms.mu.Lock()
-	defer rms.mu.Unlock()
+	entered := rms.finalizeEntered
+	release := rms.finalizeRelease
+	rms.mu.Unlock()
+	if entered != nil {
+		close(entered)
+	}
+	if release != nil {
+		<-release
+	}
+	rms.mu.Lock()
 	rms.componentFinalized = append(rms.componentFinalized, name)
+	rms.mu.Unlock()
 }
 
 func (rms *runMetricsService) RegisterProducer(name string, producer func() error) error {
@@ -234,5 +246,47 @@ func TestRunGenerationRuntimeMetricsLifecycle(t *testing.T) {
 	got, ok := reader.Value(runtimeMetricPrefix+".dirty_runs_total", nil)
 	require.False(t, !ok || got != 1)
 
+	closeRunTestUIDs(t, uids)
+}
+
+func TestRunGenerationFinalizerStopsRuntimeWriterBeforeTerminalCensus(t *testing.T) {
+	finalizeEntered := make(chan struct{})
+	finalizeRelease := make(chan struct{})
+	service := &runMetricsService{
+		finalizeEntered: finalizeEntered,
+		finalizeRelease: finalizeRelease,
+	}
+	jobs := testRunJobServices(t)
+	jobs.Runtime = service
+	frames, err := lifecycle.NewFrameOwner(&bytes.Buffer{})
+	require.NoError(t, err)
+	uids := lifecycle.NewUIDLedger()
+	generation, err := newRunGeneration(runGenerationConfig{
+		Generation:      1,
+		ShutdownTimeout: time.Second,
+		UIDs:            uids,
+		Frames:          frames,
+		Modules:         collectorapi.Registry{},
+		Jobs:            jobs,
+		Discovery:       testRunDiscoveryServices(t),
+	})
+	require.NoError(t, err)
+	require.NoError(t, generation.start(context.Background()))
+
+	generation.Stop()
+	waited := make(chan error, 1)
+	go func() { waited <- generation.Wait(context.Background()) }()
+	select {
+	case <-finalizeEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "runtime component did not enter finalization")
+	}
+	select {
+	case <-generation.kernel.Done():
+		require.FailNow(t, "test failed", "kernel reached terminal before runtime writer stopped")
+	default:
+	}
+	close(finalizeRelease)
+	require.NoError(t, <-waited)
 	closeRunTestUIDs(t, uids)
 }

--- a/src/go/plugin/agent/jobmgr/composition/secret_adapter.go
+++ b/src/go/plugin/agent/jobmgr/composition/secret_adapter.go
@@ -49,7 +49,11 @@ func newSecretInitialRoute(
 		return functionadapter.InitialRoute{}, errors.New("jobmgr composition: invalid secret route")
 	}
 	commands := []functionadapter.ResourceTransactionCommand{
-		{Name: string(dyncfg.CommandAdd), AllocateSuccessor: true},
+		{
+			Name:              string(dyncfg.CommandAdd),
+			AllocateSuccessor: true,
+			Claims:            []string{joboutput.DynCfgJobGraphClaim},
+		},
 		{Name: string(dyncfg.CommandSchema)},
 		{Name: string(dyncfg.CommandGet)},
 		{
@@ -73,6 +77,12 @@ func newSecretInitialRoute(
 				},
 			},
 			Transaction: &functionadapter.ResourceTransactionDeclaration{
+				CompositeChildLaneConflict: func(
+					input functionadapter.HandlerInput,
+					lane string,
+				) bool {
+					return controller.CompositeChildLaneConflict(secretCommandInput(input), lane)
+				},
 				PrepareComposite: func(
 					ctx context.Context,
 					input functionadapter.HandlerInput,

--- a/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -17,8 +19,127 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRunGenerationStartsWithIndividuallyValidatedFileSecretConfigs(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "etc", "netdata", "go.d")
+	path := filepath.Join(root, "ss", "custom.conf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`
+jobs:
+  - name: valid
+    kind: vault
+    value: initial
+  - name: inferred_unknown
+    value: ignored
+  - name: non_string_kind
+    kind: 123
+    value: ignored
+`), 0o644))
+
+	initial, loadErrs := secretstore.LoadFileConfigs([]string{root})
+	started := make(chan struct{}, 1)
+	modules := collectorapi.Registry{
+		"module": {
+			Create: func() collectorapi.CollectorV1 {
+				return &collectorapi.MockCollectorV1{
+					InitFunc: func(context.Context) error {
+						started <- struct{}{}
+						return nil
+					},
+					ChartsFunc: func() *collectorapi.Charts {
+						return &collectorapi.Charts{
+							&collectorapi.Chart{
+								ID:    "chart",
+								Title: "chart",
+								Units: "value",
+								Dims: collectorapi.Dims{&collectorapi.Dim{
+									ID: "value",
+								}},
+							},
+						}
+					},
+					CollectFunc: func(context.Context) map[string]int64 {
+						return map[string]int64{"value": 1}
+					},
+				}
+			},
+			Config: func() any {
+				return &collectorapi.MockConfiguration{}
+			},
+			JobConfigSchema: collectorapi.MockConfigSchema,
+		},
+	}
+	jobConfig := confgroup.Config{
+		"module":        "module",
+		"name":          "unrelated",
+		"update_every":  1,
+		"function_only": false,
+		"option_str":    "work",
+		"option_int":    1,
+	}
+	jobConfig.SetProvider(confgroup.TypeUser)
+	jobConfig.SetSourceType(confgroup.TypeUser)
+	jobConfig.SetSource("file=test")
+	creators, err := secretstore.NewCreatorCatalog(
+		[]secretstore.Creator{{
+			Kind:   secretstore.KindVault,
+			Schema: `{}`,
+			Create: func() secretstore.Store {
+				return &processSecretStore{}
+			},
+		}},
+	)
+	require.NoError(t, err)
+	jobs := testRunJobServices(t)
+	jobs.Defaults = confgroup.Registry{
+		"module": {UpdateEvery: 1},
+	}
+	jobs.StoreCreators = creators
+	output := newProcessSynchronizedBuffer()
+	frames, err := lifecycle.NewFrameOwner(output)
+	require.NoError(t, err)
+	uids := lifecycle.NewUIDLedger()
+	generation, err := newRunGeneration(runGenerationConfig{
+		Generation:      1,
+		ShutdownTimeout: time.Second,
+		UIDs:            uids,
+		Frames:          frames,
+		Modules:         modules,
+		Jobs:            jobs,
+		Secrets: runSecretServices{
+			Initial: initial,
+		},
+		Discovery: testRunDiscoveryServices(t, jobConfig),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		generation.Stop()
+		require.NoError(t, generation.Wait(context.Background()))
+		closeRunTestUIDs(t, uids)
+	})
+
+	require.NoError(t, generation.start(context.Background()))
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "unrelated collector did not start")
+	}
+	require.Eventually(t, func() bool {
+		record, ok := generation.vnodes.graph.Lookup(jobConfig.FullName())
+		return ok && record.Status == dyncfg.StatusRunning.String()
+	}, time.Second, time.Millisecond)
+
+	require.Len(t, initial, 1)
+	require.Len(t, loadErrs, 2)
+	require.Contains(t, output.String(), "CONFIG go.d:secretstore:vault:valid create running job")
+	require.Contains(t, output.String(), "CONFIG go.d:collector:module:unrelated create running job")
+	require.NotContains(t, output.String(), "inferred_unknown")
+	require.NotContains(t, output.String(), "non_string_kind")
+	require.NoError(t, generation.run.DirtyCause())
+}
 
 func TestProcessCoreSecretUpdateDependentRestart(t *testing.T) {
 	tests := map[string]struct {
@@ -32,12 +153,20 @@ func TestProcessCoreSecretUpdateDependentRestart(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			testProcessCoreSecretUpdateDependentRestart(t, test.restartErr)
+			testProcessCoreSecretMutationDependentRestart(t, "update", test.restartErr)
 		})
 	}
 }
 
-func testProcessCoreSecretUpdateDependentRestart(t *testing.T, restartErr error) {
+func TestProcessCoreSecretAddReplayDependentRestart(t *testing.T) {
+	testProcessCoreSecretMutationDependentRestart(t, "add", nil)
+}
+
+func testProcessCoreSecretMutationDependentRestart(
+	t *testing.T,
+	command string,
+	restartErr error,
+) {
 	t.Helper()
 	starts := make(chan string, 4)
 	var cleanups atomic.Int32
@@ -49,10 +178,12 @@ func testProcessCoreSecretUpdateDependentRestart(t *testing.T, restartErr error)
 						cleanups.Add(1)
 					},
 				}
-				collector.InitFunc = func(context.Context) error {
+				collector.InitFunc = func(ctx context.Context) error {
 					starts <- collector.Config.OptionStr
-					if collector.Config.OptionStr == "replacement" && restartErr != nil {
-						return restartErr
+					if collector.Config.OptionStr == "replacement" {
+						if restartErr != nil {
+							return restartErr
+						}
 					}
 					return nil
 				}
@@ -142,10 +273,15 @@ func testProcessCoreSecretUpdateDependentRestart(t *testing.T, restartErr error)
 		require.FailNowf(t, "test failed", "collector did not start with initial secret; output=%q", output.String())
 	}
 
+	uid := "secret-" + command
+	target := "go.d:secretstore:vault:main update"
+	if command == "add" {
+		target = "go.d:secretstore:vault add main"
+	}
 	_, writeStringErr := io.WriteString(
 		writer,
-		"FUNCTION_PAYLOAD secret-update 30 "+
-			"\"config go.d:secretstore:vault:main update\" "+
+		"FUNCTION_PAYLOAD "+uid+" 30 "+
+			"\"config "+target+"\" "+
 			"0xFFFF \"user=test\" application/json\n"+
 			"{\"value\":\"replacement\"}\n"+
 			"FUNCTION_PAYLOAD_END\n",
@@ -153,7 +289,7 @@ func testProcessCoreSecretUpdateDependentRestart(t *testing.T, restartErr error)
 	require.NoError(t, writeStringErr)
 
 	waitSecretStart(t, starts, "replacement")
-	output.waitContains(t, "FUNCTION_RESULT_BEGIN secret-update 200 application/json")
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN "+uid+" 200 application/json")
 	if restartErr == nil {
 		require.EqualValues(t, 1, cleanups.Load())
 	} else {
@@ -161,6 +297,11 @@ func testProcessCoreSecretUpdateDependentRestart(t *testing.T, restartErr error)
 		wire := output.String()
 		require.Contains(t, wire, "dependent collector restarts failed for jobs: module:job")
 		require.NotContains(t, wire, "backend-sensitive-detail")
+	}
+	select {
+	case err := <-done:
+		require.FailNowf(t, "test failed", "process stopped after operational restart failure: %v", err)
+	default:
 	}
 
 	commands <- testProcessControl(processTerminate)
@@ -411,7 +552,7 @@ func TestProcessCoreSecretCRUDAndValidationRedaction(t *testing.T) {
 	}
 }
 
-func TestProcessCoreSecretUpdateHoldsJobGraphThroughRestart(t *testing.T) {
+func TestProcessCoreSecretUpdateYieldsJobGraphDuringRestartProbe(t *testing.T) {
 	restartEntered := make(chan struct{})
 	releaseRestart := make(chan struct{})
 	var releaseOnce sync.Once
@@ -528,14 +669,11 @@ func TestProcessCoreSecretUpdateHoldsJobGraphThroughRestart(t *testing.T) {
 	)
 	require.NoError(t, writeStringErr2)
 
-	waitActiveUIDs(t, process.uids, 2)
-
-	require.NotContains(t, output.String(), "FUNCTION_RESULT_BEGIN job-add")
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN job-add 202 application/json")
+	output.waitContains(t, "CONFIG go.d:collector:module:other create accepted job")
 
 	releaseOnce.Do(func() { close(releaseRestart) })
 	output.waitContains(t, "FUNCTION_RESULT_BEGIN secret-rotation 200 application/json")
-	output.waitContains(t, "FUNCTION_RESULT_BEGIN job-add 202 application/json")
-	output.waitContains(t, "CONFIG go.d:collector:module:other create accepted job")
 
 	commands <- testProcessControl(processTerminate)
 	select {
@@ -543,25 +681,6 @@ func TestProcessCoreSecretUpdateHoldsJobGraphThroughRestart(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(3 * time.Second):
 		require.FailNow(t, "test failed", "process did not terminate")
-	}
-}
-
-func waitActiveUIDs(t *testing.T, uids *lifecycle.UIDLedger, want int) {
-	t.Helper()
-	timeout := time.NewTimer(3 * time.Second)
-	defer timeout.Stop()
-	tick := time.NewTicker(time.Millisecond)
-	defer tick.Stop()
-	for {
-		active, _, _ := uids.Census()
-		if active >= want {
-			return
-		}
-		select {
-		case <-tick.C:
-		case <-timeout.C:
-			require.FailNowf(t, "test failed", "active UIDs=%d want at least %d", active, want)
-		}
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/composition/vnodes.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnodes.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	agentdiscovery "github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/discovery"
@@ -187,8 +186,6 @@ func (vb *vnodeBinding) prepareAdd(
 	}
 	prepared, err := vb.config.PrepareUpsert(name, expected, next)
 	if errors.Is(err, agentdiscovery.ErrVNodeNoChange) {
-		// Unlike prepareUpdate, add re-emits the CONFIG CREATE on a no-op: an
-		// idempotent re-declaration of an already-identical vnode entry.
 		return vb.noop(scope, mustDynCfgMessage(202, ""), vb.configCreateCleanup(next))
 	}
 	if err != nil {
@@ -355,18 +352,14 @@ func (vb *vnodeBinding) parseVNode(
 		)
 		return nil, &result
 	}
-	if err := uuid.Validate(config.GUID); err != nil {
+	normalizeVNode(&config, name, input.CallerSource)
+	if err := vnodes.ValidateConfigured(&config); err != nil {
 		result := mustDynCfgMessage(
 			400,
-			fmt.Sprintf("Failed to create configuration from payload. Invalid guid format: %v.", err),
+			fmt.Sprintf("Failed to create configuration from payload. Invalid vnode configuration: %v.", err),
 		)
 		return nil, &result
 	}
-	if !validVNodeQuotedProtocolField(input.CallerSource) {
-		result := mustDynCfgMessage(400, "Failed to create configuration from payload. Invalid Function source.")
-		return nil, &result
-	}
-	normalizeVNode(&config, name, input.CallerSource)
 	if err := vb.validateUnique(&config); err != nil {
 		result := mustDynCfgMessage(400, fmt.Sprintf("Failed to create configuration from payload: %v.", err))
 		return nil, &result
@@ -383,6 +376,10 @@ func (vb *vnodeBinding) configName(input functionadapter.HandlerInput) (string, 
 }
 
 func (vb *vnodeBinding) validateUnique(next *vnodes.VirtualNode) error {
+	nextGUID, err := vnodes.ConfiguredGUIDKey(next.GUID)
+	if err != nil {
+		return err
+	}
 	for _, entry := range vb.config.Entries() {
 		current := entry.Snapshot.Vnode
 		if entry.ID == next.Name {
@@ -391,7 +388,11 @@ func (vb *vnodeBinding) validateUnique(next *vnodes.VirtualNode) error {
 		if current.Hostname == next.Hostname {
 			return fmt.Errorf("duplicate virtual node hostname detected (job '%s')", entry.ID)
 		}
-		if current.GUID == next.GUID {
+		currentGUID, err := vnodes.ConfiguredGUIDKey(current.GUID)
+		if err != nil {
+			return fmt.Errorf("invalid existing virtual node guid (job '%s'): %w", entry.ID, err)
+		}
+		if currentGUID == nextGUID {
 			return fmt.Errorf("duplicate virtual node guid detected (job '%s')", entry.ID)
 		}
 	}
@@ -399,31 +400,16 @@ func (vb *vnodeBinding) validateUnique(next *vnodes.VirtualNode) error {
 }
 
 func (vb *vnodeBinding) validateInitial() error {
-	seenHostnames := make(map[string]string)
-	seenGUIDs := make(map[string]string)
+	initial := make(map[string]*vnodes.VirtualNode)
 	for _, entry := range vb.config.Entries() {
-		vnode := entry.Snapshot.Vnode
-		if vnode == nil || vnode.Name != entry.ID ||
-			vnode.Hostname == "" ||
-			uuid.Validate(vnode.GUID) != nil ||
-			dyncfg.JobNameRuleAllowDots(entry.ID) != nil ||
-			!validVNodeTokenProtocolField(vnode.SourceType) ||
-			!validVNodeQuotedProtocolField(vnode.Source) {
-			return errors.New("jobmgr composition: invalid initial vnode configuration")
-		}
-		if other := seenHostnames[vnode.Hostname]; other != "" {
-			return fmt.Errorf(
-				"jobmgr composition: duplicate vnode hostname %q (%s and %s)",
-				vnode.Hostname,
-				other,
-				entry.ID,
-			)
-		}
-		if other := seenGUIDs[vnode.GUID]; other != "" {
-			return fmt.Errorf("jobmgr composition: duplicate vnode GUID (%s and %s)", other, entry.ID)
-		}
-		seenHostnames[vnode.Hostname] = entry.ID
-		seenGUIDs[vnode.GUID] = entry.ID
+		initial[entry.ID] = entry.Snapshot.Vnode
+	}
+	return validateInitialVNodeSet(initial)
+}
+
+func validateInitialVNodeSet(initial map[string]*vnodes.VirtualNode) error {
+	if err := vnodes.ValidateConfiguredSet(initial); err != nil {
+		return fmt.Errorf("jobmgr composition: invalid initial vnode configuration: %w", err)
 	}
 	return nil
 }
@@ -457,7 +443,7 @@ func (vb *vnodeBinding) noop(
 
 // configCreateVNodeJob emits the CONFIG CREATE that declares one vnode as a
 // dyncfg job entry, with the removable command added for dyncfg-sourced vnodes.
-func (vb *vnodeBinding) configCreateVNodeJob(api *netdataapi.API, vnode *vnodes.VirtualNode) {
+func (vb *vnodeBinding) configCreateVNodeJob(api *netdataapi.API, vnode *vnodes.VirtualNode) error {
 	commands := dyncfg.JoinCommands(
 		dyncfg.CommandUserconfig,
 		dyncfg.CommandSchema,
@@ -468,7 +454,7 @@ func (vb *vnodeBinding) configCreateVNodeJob(api *netdataapi.API, vnode *vnodes.
 	if vnode.SourceType == confgroup.TypeDyncfg {
 		commands += " " + string(dyncfg.CommandRemove)
 	}
-	api.CONFIGCREATE(netdataapi.ConfigOpts{
+	return api.TryCONFIGCREATE(netdataapi.ConfigOpts{
 		ID:                vb.prefix() + ":" + vnode.Name,
 		Status:            dyncfg.StatusRunning.String(),
 		ConfigType:        dyncfg.ConfigTypeJob.String(),
@@ -480,20 +466,20 @@ func (vb *vnodeBinding) configCreateVNodeJob(api *netdataapi.API, vnode *vnodes.
 }
 
 func (vb *vnodeBinding) configCreateCleanup(vnode *vnodes.VirtualNode) lifecycle.TaskCleanup {
-	return vb.protocolCleanup(func(api *netdataapi.API) {
-		vb.configCreateVNodeJob(api, vnode)
+	return vb.protocolCleanup(func(api *netdataapi.API) error {
+		return vb.configCreateVNodeJob(api, vnode)
 	})
 }
 
 func (vb *vnodeBinding) configDeleteCleanup(name string) lifecycle.TaskCleanup {
-	return vb.protocolCleanup(func(api *netdataapi.API) {
-		api.CONFIGDELETE(vb.prefix() + ":" + name)
+	return vb.protocolCleanup(func(api *netdataapi.API) error {
+		return api.TryCONFIGDELETE(vb.prefix() + ":" + name)
 	})
 }
 
 func (vb *vnodeBinding) initialCleanup() lifecycle.TaskCleanup {
-	return vb.protocolCleanup(func(api *netdataapi.API) {
-		api.CONFIGCREATE(netdataapi.ConfigOpts{
+	return vb.protocolCleanup(func(api *netdataapi.API) error {
+		if err := api.TryCONFIGCREATE(netdataapi.ConfigOpts{
 			ID:         vb.prefix(),
 			Status:     dyncfg.StatusAccepted.String(),
 			ConfigType: dyncfg.ConfigTypeTemplate.String(),
@@ -506,16 +492,23 @@ func (vb *vnodeBinding) initialCleanup() lifecycle.TaskCleanup {
 				dyncfg.CommandUserconfig,
 				dyncfg.CommandTest,
 			),
-		})
-		for _, entry := range vb.config.Entries() {
-			vb.configCreateVNodeJob(api, entry.Snapshot.Vnode)
+		}); err != nil {
+			return err
 		}
+		for _, entry := range vb.config.Entries() {
+			if err := vb.configCreateVNodeJob(api, entry.Snapshot.Vnode); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 }
 
-func (vb *vnodeBinding) protocolCleanup(build func(*netdataapi.API)) lifecycle.TaskCleanup {
+func (vb *vnodeBinding) protocolCleanup(build func(*netdataapi.API) error) lifecycle.TaskCleanup {
 	var payload bytes.Buffer
-	build(netdataapi.New(&payload))
+	if err := build(netdataapi.New(&payload)); err != nil {
+		return func() error { return err }
+	}
 	prepared, err := lifecycle.PrepareProtocolFrame(payload.Bytes())
 	if err != nil {
 		return func() error { return err }
@@ -680,27 +673,6 @@ func vnodeCommand(input functionadapter.HandlerInput) dyncfg.Command {
 
 func vnodeJobName(value string) string {
 	return dyncfg.NormalizeJobName(value)
-}
-
-func validVNodeTokenProtocolField(value string) bool {
-	if value == "" {
-		return false
-	}
-	for _, char := range value {
-		if char <= ' ' || char == 0x7f || char == '\'' {
-			return false
-		}
-	}
-	return true
-}
-
-func validVNodeQuotedProtocolField(value string) bool {
-	for _, char := range value {
-		if char < ' ' || char == 0x7f || char == '\'' {
-			return false
-		}
-	}
-	return true
 }
 
 func normalizeVNode(vnode *vnodes.VirtualNode, name string, source string) {

--- a/src/go/plugin/agent/jobmgr/composition/vnodes_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnodes_test.go
@@ -37,6 +37,14 @@ func TestVNodeBindingPreparesUpdates(t *testing.T) {
 			payload: `{"hostname":"changed","guid":"` + testVNodeGUID + `"}`,
 		},
 		"invalid payload": {args: []string{"go.d:vnode:db", string(dyncfg.CommandUpdate)}, payload: `{`},
+		"hostname unsafe for host emission": {
+			args:    []string{"go.d:vnode:db", string(dyncfg.CommandUpdate)},
+			payload: `{"hostname":"operator's-db","guid":"` + testVNodeGUID + `"}`,
+		},
+		"hostname with trailing escape": {
+			args:    []string{"go.d:vnode:db", string(dyncfg.CommandUpdate)},
+			payload: `{"hostname":"operator\\","guid":"` + testVNodeGUID + `"}`,
+		},
 		"unchanged vnode": {
 			args:    []string{"go.d:vnode:db", string(dyncfg.CommandUpdate)},
 			payload: `{"hostname":"db","guid":"` + testVNodeGUID + `"}`,
@@ -90,6 +98,63 @@ func TestVNodeBindingPreparesUpdates(t *testing.T) {
 				require.Equal(t, "db", snapshot.Vnode.Hostname)
 				require.EqualValues(t, 1, snapshot.Revision)
 			}
+		})
+	}
+}
+
+func TestVNodeBindingRejectsSemanticallyDuplicateGUID(t *testing.T) {
+	binding, configured := newTestVNodeBinding(t, confgroup.TypeDyncfg, nil)
+	transaction, err := binding.prepare(
+		context.Background(),
+		functionadapter.HandlerInput{
+			Args:         []string{"go.d:vnode", string(dyncfg.CommandAdd), "second"},
+			Payload:      []byte(`{"hostname":"second","guid":"11111111111111111111111111111111"}`),
+			ContentType:  "application/json",
+			CallerSource: "user=test",
+			HasPayload:   true,
+		},
+		nil,
+		lifecycle.ResourceTransactionScope{ID: "vnode:second"},
+		lifecycle.LongLivedPermit{},
+	)
+	require.NoError(t, err)
+
+	applied, err := transaction.Apply(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 400, applied.ResultStatus())
+	_, exists := configured.Lookup("second")
+	require.False(t, exists)
+}
+
+func TestVNodeBindingAddCollisionIsReplayUpsert(t *testing.T) {
+	for _, sourceType := range []string{confgroup.TypeDyncfg, confgroup.TypeUser} {
+		t.Run(sourceType, func(t *testing.T) {
+			binding, configured := newTestVNodeBinding(t, sourceType, nil)
+			transaction, err := binding.prepare(
+				context.Background(),
+				functionadapter.HandlerInput{
+					Args: []string{"go.d:vnode", string(dyncfg.CommandAdd), "db"},
+					Payload: []byte(
+						`{"hostname":"replacement","guid":"` + testVNodeGUID + `"}`,
+					),
+					ContentType:  "application/json",
+					CallerSource: "user=test",
+					HasPayload:   true,
+				},
+				nil,
+				lifecycle.ResourceTransactionScope{ID: "vnode:db"},
+				lifecycle.LongLivedPermit{},
+			)
+			require.NoError(t, err)
+
+			applied, err := transaction.Apply(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, 202, applied.ResultStatus())
+			snapshot, exists := configured.Lookup("db")
+			require.True(t, exists)
+			require.Equal(t, "replacement", snapshot.Vnode.Hostname)
+			require.Equal(t, confgroup.TypeDyncfg, snapshot.Vnode.SourceType)
+			require.EqualValues(t, 2, snapshot.Revision)
 		})
 	}
 }

--- a/src/go/plugin/agent/jobmgr/composition/vnodes_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnodes_test.go
@@ -27,6 +27,7 @@ func TestVNodeBindingPreparesUpdates(t *testing.T) {
 		payload      string
 		wantMutation bool
 		wantHostname string
+		wantStatus   int
 	}{
 		"invalid config ID": {
 			args:    []string{"other:vnode:db", string(dyncfg.CommandUpdate)},
@@ -44,6 +45,11 @@ func TestVNodeBindingPreparesUpdates(t *testing.T) {
 		"hostname with trailing escape": {
 			args:    []string{"go.d:vnode:db", string(dyncfg.CommandUpdate)},
 			payload: `{"hostname":"operator\\","guid":"` + testVNodeGUID + `"}`,
+		},
+		"label value changes during host emission preparation": {
+			args:       []string{"go.d:vnode:db", string(dyncfg.CommandUpdate)},
+			payload:    `{"hostname":"db","guid":"` + testVNodeGUID + `","labels":{"site":"operator's"}}`,
+			wantStatus: 400,
 		},
 		"unchanged vnode": {
 			args:    []string{"go.d:vnode:db", string(dyncfg.CommandUpdate)},
@@ -86,8 +92,11 @@ func TestVNodeBindingPreparesUpdates(t *testing.T) {
 			} else {
 				require.IsType(t, &joboutput.PreparedNoopResourceTransaction{}, transaction)
 			}
-			_, err = transaction.Apply(context.Background())
+			applied, err := transaction.Apply(context.Background())
 			require.NoError(t, err)
+			if test.wantStatus != 0 {
+				require.Equal(t, test.wantStatus, applied.ResultStatus())
+			}
 
 			snapshot, ok := configured.Lookup("db")
 			require.True(t, ok)

--- a/src/go/plugin/agent/jobmgr/discovery/decision.go
+++ b/src/go/plugin/agent/jobmgr/discovery/decision.go
@@ -16,25 +16,28 @@ import (
 )
 
 type DecisionConfig struct {
-	Generation uint64              // run generation
-	RunJob     []string            // allow-list filter of job names (empty = allow all)
-	AutoEnable bool                // publish discovered jobs as Running vs Accepted
-	Plan       PlanDiscovered      // builds a WorkPlan for a discovered change
-	Commands   PreparedCommandPort // prepared-command port for submitting decisions
+	Generation  uint64                    // run generation
+	RunJob      []string                  // allow-list filter of job names (empty = allow all)
+	AutoEnable  bool                      // publish discovered jobs as Running vs Accepted
+	Plan        PlanDiscovered            // builds a WorkPlan for a discovered change
+	Commands    PreparedCommandPort       // prepared-command port for submitting decisions
+	Diagnostics jobmgr.DiagnosticObserver // operational rejection observer
 }
 
 // DecisionIndex owns one run generation's desired and acknowledged discovery
 // selections.
 type DecisionIndex struct {
-	generation uint64              // run generation
-	runJob     map[string]struct{} // allow-list filter set (empty = allow all)
-	autoEnable bool                // publish discovered jobs as Running vs Accepted
-	plan       PlanDiscovered      // builds a WorkPlan for a discovered change
-	commands   PreparedCommandPort // prepared-command port for submitting decisions
+	generation  uint64                    // run generation
+	runJob      map[string]struct{}       // allow-list filter set (empty = allow all)
+	autoEnable  bool                      // publish discovered jobs as Running vs Accepted
+	plan        PlanDiscovered            // builds a WorkPlan for a discovered change
+	commands    PreparedCommandPort       // prepared-command port for submitting decisions
+	diagnostics jobmgr.DiagnosticObserver // operational rejection observer
 
 	sources      map[string]map[uint64]confgroup.Config               // per-source config sets (authoritative full set per source)
 	candidates   map[string]map[decisionCandidateKey]confgroup.Config // per-job candidate configs by key
 	acknowledged map[string]confgroup.Config                          // last acknowledged config per job full name
+	pending      map[string]struct{}                                  // rejected selections/removals to retry on a later batch
 	revision     uint64                                               // monotonic decision revision
 }
 
@@ -60,9 +63,11 @@ func NewDecisionIndex(config DecisionConfig) (*DecisionIndex, error) {
 		autoEnable:   config.AutoEnable,
 		plan:         config.Plan,
 		commands:     config.Commands,
+		diagnostics:  config.Diagnostics,
 		sources:      make(map[string]map[uint64]confgroup.Config),
 		candidates:   make(map[string]map[decisionCandidateKey]confgroup.Config),
 		acknowledged: make(map[string]confgroup.Config),
+		pending:      make(map[string]struct{}),
 	}, nil
 }
 
@@ -70,19 +75,103 @@ func (di *DecisionIndex) Apply(ctx context.Context, batch []*confgroup.Group) er
 	if di == nil || ctx == nil || batch == nil {
 		return errors.New("jobmgr discovery: invalid decision batch")
 	}
+	affected := make(map[string]struct{}, len(di.pending))
+	maps.Copy(affected, di.pending)
 	for _, group := range batch {
-		if err := di.applyGroup(ctx, group); err != nil {
+		changed, err := di.applyGroup(group)
+		if err != nil {
 			return err
 		}
+		maps.Copy(affected, changed)
+	}
+	names := slices.Sorted(maps.Keys(affected))
+	for _, name := range names {
+		err := di.reconcile(ctx, name)
+		if err == nil {
+			delete(di.pending, name)
+			continue
+		}
+		if ctx.Err() != nil {
+			return errors.Join(ctx.Err(), err)
+		}
+		if !jobmgr.IsProposalRejection(err) {
+			return err
+		}
+		di.quarantine(name, err)
 	}
 	return nil
 }
 
-func (di *DecisionIndex) applyGroup(ctx context.Context, group *confgroup.Group) error {
-	if di == nil || ctx == nil || group == nil || group.Source == "" {
-		return errors.New("jobmgr discovery: invalid group")
+func (di *DecisionIndex) quarantine(name string, err error) {
+	di.pending[name] = struct{}{}
+	di.observeRejection(name, err)
+}
+
+func (di *DecisionIndex) observeRejection(name string, err error) {
+	jobmgr.ObserveDiagnostic(di.diagnostics, jobmgr.DiagnosticEvent{
+		Level:      jobmgr.DiagnosticWarning,
+		Name:       "discovered collector proposal quarantined",
+		Resource:   name,
+		State:      "quarantined",
+		Generation: di.generation,
+		Err:        err,
+	})
+}
+
+func (di *DecisionIndex) applyGroup(
+	group *confgroup.Group,
+) (map[string]struct{}, error) {
+	if di == nil || group == nil || group.Source == "" {
+		return nil, errors.New("jobmgr discovery: invalid group")
 	}
 	affected := make(map[string]struct{})
+	next := make(map[uint64]confgroup.Config, len(group.Configs))
+	rejected := make(map[string]error)
+	validNames := make(map[string]struct{})
+	for _, config := range group.Configs {
+		if config == nil || !di.allowed(config) {
+			continue
+		}
+		cloned, err := config.Clone()
+		if err != nil {
+			fullName := config.FullName()
+			if fullName != "" {
+				affected[fullName] = struct{}{}
+				rejected[fullName] = jobmgr.RejectProposal(fmt.Errorf(
+					"jobmgr discovery: clone config %q: %w",
+					fullName,
+					err,
+				))
+			} else {
+				jobmgr.ObserveDiagnostic(di.diagnostics, jobmgr.DiagnosticEvent{
+					Level:      jobmgr.DiagnosticWarning,
+					Name:       "discovered collector proposal quarantined",
+					Resource:   group.Source,
+					State:      "invalid identity",
+					Generation: di.generation,
+					Err:        jobmgr.RejectProposal(fmt.Errorf("jobmgr discovery: clone config: %w", err)),
+				})
+			}
+			continue
+		}
+		hash := cloned.Hash()
+		next[hash] = cloned
+		fullName := cloned.FullName()
+		affected[fullName] = struct{}{}
+		validNames[fullName] = struct{}{}
+	}
+	for fullName, err := range rejected {
+		di.observeRejection(fullName, err)
+		if _, valid := validNames[fullName]; valid {
+			continue
+		}
+		for hash, previous := range di.sources[group.Source] {
+			if previous.FullName() == fullName {
+				next[hash] = previous
+			}
+		}
+	}
+
 	for hash, config := range di.sources[group.Source] {
 		fullName := config.FullName()
 		affected[fullName] = struct{}{}
@@ -95,20 +184,8 @@ func (di *DecisionIndex) applyGroup(ctx context.Context, group *confgroup.Group)
 			delete(di.candidates, fullName)
 		}
 	}
-
-	next := make(map[uint64]confgroup.Config, len(group.Configs))
-	for _, config := range group.Configs {
-		if config == nil || !di.allowed(config) {
-			continue
-		}
-		cloned, err := config.Clone()
-		if err != nil {
-			return err
-		}
-		hash := cloned.Hash()
-		next[hash] = cloned
+	for hash, cloned := range next {
 		fullName := cloned.FullName()
-		affected[fullName] = struct{}{}
 		candidates := di.candidates[fullName]
 		if candidates == nil {
 			candidates = make(map[decisionCandidateKey]confgroup.Config)
@@ -124,14 +201,7 @@ func (di *DecisionIndex) applyGroup(ctx context.Context, group *confgroup.Group)
 	} else {
 		di.sources[group.Source] = next
 	}
-
-	names := slices.Sorted(maps.Keys(affected))
-	for _, name := range names {
-		if err := di.reconcile(ctx, name); err != nil {
-			return err
-		}
-	}
-	return nil
+	return affected, nil
 }
 
 func (di *DecisionIndex) allowed(config confgroup.Config) bool {
@@ -145,6 +215,9 @@ func (di *DecisionIndex) allowed(config confgroup.Config) bool {
 func (di *DecisionIndex) reconcile(ctx context.Context, fullName string) error {
 	current, hasCurrent := di.acknowledged[fullName]
 	next, hasNext := di.selectConfig(fullName, current, hasCurrent)
+	if !hasCurrent && !hasNext {
+		return nil
+	}
 	if hasCurrent && hasNext && current.UID() == next.UID() {
 		return nil
 	}
@@ -167,6 +240,7 @@ func (di *DecisionIndex) reconcile(ctx context.Context, fullName string) error {
 		return errors.New("jobmgr discovery: decision revision wrapped")
 	}
 	revision := di.revision + 1
+	di.revision = revision
 	if err := di.commands.SubmitPreparedAndWait(
 		ctx,
 		jobmgr.Request{
@@ -179,7 +253,6 @@ func (di *DecisionIndex) reconcile(ctx context.Context, fullName string) error {
 	); err != nil {
 		return err
 	}
-	di.revision = revision
 	if hasNext {
 		di.acknowledged[fullName] = next
 	} else {

--- a/src/go/plugin/agent/jobmgr/discovery/decision_test.go
+++ b/src/go/plugin/agent/jobmgr/discovery/decision_test.go
@@ -18,6 +18,7 @@ type decisionTestCensus struct {
 	sources      int
 	candidates   int
 	acknowledged int
+	pending      int
 	revision     uint64
 }
 
@@ -25,12 +26,135 @@ func decisionIndexCensus(index *DecisionIndex) decisionTestCensus {
 	census := decisionTestCensus{
 		sources:      len(index.sources),
 		acknowledged: len(index.acknowledged),
+		pending:      len(index.pending),
 		revision:     index.revision,
 	}
 	for _, candidates := range index.candidates {
 		census.candidates += len(candidates)
 	}
 	return census
+}
+
+func TestDecisionIndexQuarantinesTypedProposalAndContinuesBatch(t *testing.T) {
+	commands := &decisionTestCommands{}
+	index := newDecisionTestIndex(
+		t,
+		commands,
+		func(change DiscoveredChange) (jobmgr.WorkPlan, error) {
+			if change.Config.Name() == "bad" {
+				return jobmgr.WorkPlan{}, jobmgr.RejectProposal(errors.New("unsupported discovered config"))
+			}
+			return jobmgr.WorkPlan{}, nil
+		},
+	)
+	bad := decisionTestConfig("bad", confgroup.TypeStock, "source")
+	good := decisionTestConfig("good", confgroup.TypeStock, "source")
+
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{
+		Source:  "source",
+		Configs: []confgroup.Config{bad, good},
+	}}))
+	require.Len(t, commands.requests, 1)
+	require.Equal(t, good.FullName(), commands.requests[0].LaneKey)
+	require.Equal(t, good.UID(), index.acknowledged[good.FullName()].UID())
+	require.EqualValues(t, decisionTestCensus{
+		sources:      1,
+		candidates:   2,
+		acknowledged: 1,
+		pending:      1,
+		revision:     1,
+	}, decisionIndexCensus(index))
+}
+
+func TestDecisionIndexQuarantinesCloneFailureAndContinuesBatch(t *testing.T) {
+	commands := &decisionTestCommands{}
+	index := newDecisionTestIndex(
+		t,
+		commands,
+		func(DiscoveredChange) (jobmgr.WorkPlan, error) {
+			return jobmgr.WorkPlan{}, nil
+		},
+	)
+	bad := decisionTestConfig("bad", confgroup.TypeStock, "source").
+		Set("unsupported", make(chan struct{}))
+	good := decisionTestConfig("good", confgroup.TypeStock, "source")
+
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{
+		Source:  "source",
+		Configs: []confgroup.Config{bad, good},
+	}}))
+	require.Len(t, commands.requests, 1)
+	require.Equal(t, good.FullName(), commands.requests[0].LaneKey)
+	require.NotContains(t, index.pending, bad.FullName())
+
+	fixed := decisionTestConfig("bad", confgroup.TypeStock, "source")
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{
+		Source:  "source",
+		Configs: []confgroup.Config{fixed, good},
+	}}))
+	require.Len(t, commands.requests, 2)
+	require.Equal(t, fixed.FullName(), commands.requests[1].LaneKey)
+	require.NotContains(t, index.pending, bad.FullName())
+}
+
+func TestDecisionIndexCloneFailureDoesNotSuppressValidSameNameCandidate(t *testing.T) {
+	good := decisionTestConfig("job", confgroup.TypeStock, "good")
+	bad := decisionTestConfig("job", confgroup.TypeUser, "bad").
+		Set("unsupported", make(chan struct{}))
+	groups := map[string]*confgroup.Group{
+		"good": {Source: "good", Configs: []confgroup.Config{good}},
+		"bad":  {Source: "bad", Configs: []confgroup.Config{bad}},
+	}
+	for _, order := range [][]string{{"good", "bad"}, {"bad", "good"}} {
+		t.Run(order[0]+" before "+order[1], func(t *testing.T) {
+			commands := &decisionTestCommands{}
+			index := newDecisionTestIndex(
+				t,
+				commands,
+				func(DiscoveredChange) (jobmgr.WorkPlan, error) {
+					return jobmgr.WorkPlan{}, nil
+				},
+			)
+
+			require.NoError(t, index.Apply(
+				context.Background(),
+				[]*confgroup.Group{groups[order[0]], groups[order[1]]},
+			))
+			require.Len(t, commands.requests, 1)
+			require.Equal(t, good.FullName(), commands.requests[0].LaneKey)
+			require.Equal(t, good.UID(), index.acknowledged[good.FullName()].UID())
+		})
+	}
+}
+
+func TestDecisionIndexRetainsAndRetriesRejectedRemoval(t *testing.T) {
+	commands := &decisionTestCommands{}
+	index := newDecisionTestIndex(
+		t,
+		commands,
+		func(DiscoveredChange) (jobmgr.WorkPlan, error) {
+			return jobmgr.WorkPlan{}, nil
+		},
+	)
+	config := decisionTestConfig("job", confgroup.TypeStock, "source")
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{
+		Source:  "source",
+		Configs: []confgroup.Config{config},
+	}}))
+
+	commands.err = jobmgr.RejectProposal(errors.New("temporary proposal rejection"))
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{Source: "source"}}))
+	require.Contains(t, index.acknowledged, config.FullName())
+	require.EqualValues(t, decisionTestCensus{
+		acknowledged: 1,
+		pending:      1,
+		revision:     2,
+	}, decisionIndexCensus(index))
+
+	commands.err = nil
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{Source: "tick"}}))
+	require.NotContains(t, index.acknowledged, config.FullName())
+	require.EqualValues(t, decisionTestCensus{revision: 3}, decisionIndexCensus(index))
 }
 
 func TestDecisionIndexAcknowledgesSelectionAndFallback(t *testing.T) {
@@ -90,8 +214,44 @@ func TestDecisionIndexFailureKeepsLastAcknowledgedSelection(t *testing.T) {
 		sources:      2,
 		candidates:   2,
 		acknowledged: 1,
-		revision:     1,
+		revision:     2,
 	}, decisionIndexCensus(index))
+}
+
+func TestDecisionIndexRejectedHigherPrioritySelectionKeepsIncumbent(t *testing.T) {
+	rejectUser := true
+	commands := &decisionTestCommands{}
+	index := newDecisionTestIndex(
+		t,
+		commands,
+		func(change DiscoveredChange) (jobmgr.WorkPlan, error) {
+			if rejectUser && change.Config.SourceType() == confgroup.TypeUser {
+				return jobmgr.WorkPlan{}, jobmgr.RejectProposal(errors.New("invalid user config"))
+			}
+			return jobmgr.WorkPlan{}, nil
+		},
+	)
+	stock := decisionTestConfig("job", confgroup.TypeStock, "stock")
+	user := decisionTestConfig("job", confgroup.TypeUser, "user")
+
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{
+		Source:  "stock",
+		Configs: []confgroup.Config{stock},
+	}}))
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{
+		Source:  "user",
+		Configs: []confgroup.Config{user},
+	}}))
+	require.Equal(t, stock.UID(), index.acknowledged[stock.FullName()].UID())
+	require.Contains(t, index.pending, stock.FullName())
+
+	rejectUser = false
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{Source: "tick"}}))
+	require.Equal(t, user.UID(), index.acknowledged[user.FullName()].UID())
+	require.NotContains(t, index.pending, user.FullName())
+
+	require.NoError(t, index.Apply(context.Background(), []*confgroup.Group{{Source: "user"}}))
+	require.Equal(t, stock.UID(), index.acknowledged[stock.FullName()].UID())
 }
 
 func TestDecisionIndexConfigurationPolicy(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/functions/catalog.go
+++ b/src/go/plugin/agent/jobmgr/functions/catalog.go
@@ -515,6 +515,8 @@ func validateResourceTransactionDeclaration(declaration *ResourceTransactionDecl
 			if claim == "" || len(claim) > maximumDeclarationMetadataBytes || claim == declaration.GlobalClaim {
 				return errors.New("jobmgr Function catalog: invalid command claim")
 			}
+			// Claim acquisition follows normalized lexical order, so only its
+			// final claim can be yielded.
 			if declaration.YieldGlobalClaimOnPrepare && claim > declaration.GlobalClaim {
 				return errors.New("jobmgr Function catalog: yielded global claim is not the acquisition suffix")
 			}

--- a/src/go/plugin/agent/jobmgr/functions/catalog.go
+++ b/src/go/plugin/agent/jobmgr/functions/catalog.go
@@ -515,6 +515,9 @@ func validateResourceTransactionDeclaration(declaration *ResourceTransactionDecl
 			if claim == "" || len(claim) > maximumDeclarationMetadataBytes || claim == declaration.GlobalClaim {
 				return errors.New("jobmgr Function catalog: invalid command claim")
 			}
+			if declaration.YieldGlobalClaimOnPrepare && claim > declaration.GlobalClaim {
+				return errors.New("jobmgr Function catalog: yielded global claim is not the acquisition suffix")
+			}
 			for previous := range claimIndex {
 				if command.Claims[previous] == claim {
 					return errors.New("jobmgr Function catalog: duplicate command claim")

--- a/src/go/plugin/agent/jobmgr/functions/catalog.go
+++ b/src/go/plugin/agent/jobmgr/functions/catalog.go
@@ -54,6 +54,8 @@ type CompositeResourceTransactionHandler func(
 	lifecycle.LongLivedPermit,
 ) (jobmgr.PreparedCompositeResourceTransaction, error)
 
+type CompositeChildLaneConflictHandler func(HandlerInput, string) bool
+
 type ResourceTransactionCommand struct {
 	Name              string
 	AllocateSuccessor bool
@@ -61,12 +63,14 @@ type ResourceTransactionCommand struct {
 }
 
 type ResourceTransactionDeclaration struct {
-	Prepare          ResourceTransactionHandler          // prepares a plain resource transaction
-	PrepareComposite CompositeResourceTransactionHandler // prepares a composite resource transaction (child commands)
-	Permit           lifecycle.LongLivedPlan             // long-lived plan for the successor
-	CommandArgument  uint16                              // argument index carrying the dyncfg command
-	GlobalClaim      string                              // claim key held for the whole transaction domain
-	Commands         []ResourceTransactionCommand        // accepted transaction commands
+	Prepare                    ResourceTransactionHandler          // prepares a plain resource transaction
+	PrepareComposite           CompositeResourceTransactionHandler // prepares a composite resource transaction (child commands)
+	CompositeChildLaneConflict CompositeChildLaneConflictHandler   // identifies resource lanes a composite may submit to
+	Permit                     lifecycle.LongLivedPlan             // long-lived plan for the successor
+	CommandArgument            uint16                              // argument index carrying the dyncfg command
+	GlobalClaim                string                              // claim key held for the whole transaction domain
+	YieldGlobalClaimOnPrepare  bool                                // plain preparation may temporarily yield GlobalClaim
+	Commands                   []ResourceTransactionCommand        // accepted transaction commands
 }
 
 // HandlerGenerationDeclaration describes one job- or module-owned handler
@@ -297,6 +301,20 @@ func (is *invocationSlot) prepareCompositeResourceTransaction(
 	return is.resolved.transaction.PrepareComposite(ctx, is.input, current, scope, permit)
 }
 
+func (is *invocationSlot) compositeChildLaneConflict(lane string) (conflicts bool) {
+	conflicts = true
+	defer func() {
+		_ = recover()
+	}()
+	if is == nil ||
+		is.resolved == nil ||
+		is.resolved.transaction == nil ||
+		is.resolved.transaction.CompositeChildLaneConflict == nil {
+		return true
+	}
+	return is.resolved.transaction.CompositeChildLaneConflict(is.input, lane)
+}
+
 type catalogSnapshot struct {
 	version uint64
 	routes  map[string]routeSet
@@ -478,10 +496,15 @@ func validateResourceTransactionDeclaration(declaration *ResourceTransactionDecl
 	}
 	if (declaration.Prepare == nil) ==
 		(declaration.PrepareComposite == nil) ||
+		(declaration.PrepareComposite != nil &&
+			declaration.CompositeChildLaneConflict == nil) ||
 		declaration.GlobalClaim == "" ||
 		len(declaration.GlobalClaim) > maximumDeclarationMetadataBytes ||
 		len(declaration.Commands) == 0 {
 		return errors.New("jobmgr Function catalog: invalid resource transaction declaration")
+	}
+	if declaration.YieldGlobalClaimOnPrepare && declaration.Prepare == nil {
+		return errors.New("jobmgr Function catalog: composite transaction cannot yield its global claim")
 	}
 	hasSuccessor := false
 	for index, command := range declaration.Commands {
@@ -637,6 +660,7 @@ func (c *Catalog) ResolveAndAcquire(lookup jobmgr.FunctionLookup) (jobmgr.Functi
 		}
 		if resolved.transaction.PrepareComposite != nil {
 			slot.transactionPlan.PrepareComposite = slot.prepareCompositeResourceTransaction
+			slot.transactionPlan.CompositeChildLaneConflict = slot.compositeChildLaneConflict
 		} else {
 			slot.transactionPlan.Prepare = slot.prepareResourceTransaction
 		}
@@ -648,6 +672,9 @@ func (c *Catalog) ResolveAndAcquire(lookup jobmgr.FunctionLookup) (jobmgr.Functi
 			Transaction:         &slot.transactionPlan,
 			CooperativeCancel:   resolved.cooperativeCancel,
 			CooperativeDeadline: resolved.cooperativeDeadline,
+		}
+		if resolved.transaction.YieldGlobalClaimOnPrepare {
+			plan.YieldClaimOnPrepare = resolved.transaction.GlobalClaim
 		}
 	}
 	return jobmgr.FunctionCatalogDecision{

--- a/src/go/plugin/agent/jobmgr/functions/catalog_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/catalog_test.go
@@ -224,6 +224,32 @@ func TestFunctionCatalogResourceTransactionHasNoArbitraryCountLimits(t *testing.
 	require.NoError(t, err)
 }
 
+func TestFunctionCatalogRejectsYieldedGlobalClaimBeforeCommandClaim(t *testing.T) {
+	declaration := testDeclaration("config", "", DynCfgJobResource(0, "job:"))
+	declaration.Transaction = &ResourceTransactionDeclaration{
+		Prepare: func(
+			context.Context,
+			HandlerInput,
+			lifecycle.ReadyResource,
+			lifecycle.ResourceTransactionScope,
+			lifecycle.LongLivedPermit,
+		) (lifecycle.PreparedResourceTransaction, error) {
+			return nil, nil
+		},
+		GlobalClaim:               "global",
+		YieldGlobalClaimOnPrepare: true,
+		Commands: []ResourceTransactionCommand{
+			{
+				Name:   "update",
+				Claims: []string{"z-resource"},
+			},
+		},
+	}
+
+	_, err := NewCatalog([]Declaration{declaration})
+	require.ErrorContains(t, err, "yielded global claim")
+}
+
 func TestFunctionCatalogMutationLifecycle(t *testing.T) {
 	tests := map[string]struct {
 		change        func() RouteChange

--- a/src/go/plugin/agent/jobmgr/functions/catalog_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/catalog_test.go
@@ -196,9 +196,10 @@ func TestFunctionCatalogResourceTransactionHasNoArbitraryCountLimits(t *testing.
 		) (lifecycle.PreparedResourceTransaction, error) {
 			return nil, nil
 		},
-		CommandArgument: commandArgument,
-		GlobalClaim:     "global",
-		Commands:        commands,
+		CommandArgument:           commandArgument,
+		GlobalClaim:               "global",
+		YieldGlobalClaimOnPrepare: true,
+		Commands:                  commands,
 	}
 	catalog, err := NewCatalog([]Declaration{declaration})
 	require.NoError(t, err)
@@ -218,6 +219,7 @@ func TestFunctionCatalogResourceTransactionHasNoArbitraryCountLimits(t *testing.
 	assert.Equal(t, "global", decision.Plan.Claims[0])
 	assert.True(t, decision.Plan.CooperativeCancel)
 	assert.True(t, decision.Plan.CooperativeDeadline)
+	assert.Equal(t, "global", decision.Plan.YieldClaimOnPrepare)
 	_, err = catalog.ReleaseInvocation(decision.Lease)
 	require.NoError(t, err)
 }

--- a/src/go/plugin/agent/jobmgr/functions/protocol.go
+++ b/src/go/plugin/agent/jobmgr/functions/protocol.go
@@ -78,6 +78,9 @@ func encodeFunctionRegistration(record PublicationRecord) ([]byte, error) {
 	payload = strconv.AppendInt(payload, int64(record.Priority), 10)
 	payload = append(payload, ' ')
 	payload = strconv.AppendInt(payload, int64(record.Version), 10)
+	if len(payload) > maximumDeclarationMetadataBytes {
+		return nil, errors.New("jobmgr Function protocol: registration exceeds line limit")
+	}
 	payload = append(payload, '\n', '\n')
 	return payload, nil
 }
@@ -89,6 +92,9 @@ func encodeFunctionWithdrawal(name string) ([]byte, error) {
 	payload := make([]byte, 0, len(name)+24)
 	payload = append(payload, "FUNCTION_DEL GLOBAL "...)
 	payload = appendQuotedFunctionName(payload, name)
+	if len(payload) > maximumDeclarationMetadataBytes {
+		return nil, errors.New("jobmgr Function protocol: withdrawal exceeds line limit")
+	}
 	payload = append(payload, '\n', '\n')
 	return payload, nil
 }

--- a/src/go/plugin/agent/jobmgr/functions/protocol_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/protocol_test.go
@@ -5,6 +5,7 @@ package functions
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
@@ -103,6 +104,35 @@ func TestFunctionPublicationFrameRejectsInjection(t *testing.T) {
 			require.EqualValues(t, 0, output.Len())
 		})
 	}
+}
+
+func TestFunctionPublicationFramesRespectPluginsDLineLimit(t *testing.T) {
+	registration := PublicationRecord{
+		Name:       "module:method",
+		Generation: 1,
+		Timeout:    1,
+		Tags:       "top",
+		Access:     "0x0000",
+	}
+	base, err := encodeFunctionRegistration(registration)
+	require.NoError(t, err)
+	registration.Help = strings.Repeat("h", maximumDeclarationMetadataBytes-(len(base)-2))
+	exact, err := encodeFunctionRegistration(registration)
+	require.NoError(t, err)
+	require.Len(t, exact, maximumDeclarationMetadataBytes+2)
+
+	registration.Help += "h"
+	_, err = encodeFunctionRegistration(registration)
+	require.Error(t, err)
+
+	const withdrawalOverhead = len(`FUNCTION_DEL GLOBAL ""`)
+	name := strings.Repeat("n", maximumDeclarationMetadataBytes-withdrawalOverhead)
+	exact, err = encodeFunctionWithdrawal(name)
+	require.NoError(t, err)
+	require.Len(t, exact, maximumDeclarationMetadataBytes+2)
+
+	_, err = encodeFunctionWithdrawal(name + "n")
+	require.Error(t, err)
 }
 
 func TestFunctionPublicationFrameCommitFailurePoisonsOwner(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/joboutput/config_factory.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/config_factory.go
@@ -90,17 +90,22 @@ func (cmf *ConfigModuleFactory) Test(ctx context.Context, config confgroup.Confi
 		err = errors.Join(err, probe.cleanup(context.WithoutCancel(ctx)))
 	}()
 	setModuleJobName(probe.module, config.Name())
-	if err := cmf.applyResolved(ctx, config, probe.module); err != nil {
+	redactLifecycle, err := cmf.applyResolved(ctx, config, probe.module)
+	probe.redact = redactLifecycle
+	if err != nil {
 		return err
 	}
-	probe.module.GetBase().Logger = cmf.logger.With(
-		slog.String("collector", config.Module()),
-		slog.String("job", config.Name()),
-	)
+	probe.module.GetBase().Logger = cmf.moduleLogger(config, redactLifecycle)
 	if err := probe.module.Init(ctx); err != nil {
+		if redactLifecycle {
+			err = redactResolvedLifecycleError(err)
+		}
 		return fmt.Errorf("job output: collector initialization: %w", err)
 	}
 	if err := probe.module.Check(ctx); err != nil {
+		if redactLifecycle {
+			err = redactResolvedLifecycleError(err)
+		}
 		return fmt.Errorf("job output: collector check: %w", err)
 	}
 	return nil
@@ -118,7 +123,9 @@ func (cmf *ConfigModuleFactory) Validate(ctx context.Context, config confgroup.C
 		err = errors.Join(err, probe.cleanup(context.WithoutCancel(ctx)))
 	}()
 	setModuleJobName(probe.module, config.Name())
-	return cmf.applyResolved(ctx, config, probe.module)
+	redactLifecycle, err := cmf.applyResolved(ctx, config, probe.module)
+	probe.redact = redactLifecycle
+	return err
 }
 
 func (cmf *ConfigModuleFactory) construct(module string) (probe constructedConfigModule, err error) {
@@ -150,30 +157,86 @@ func (cmf *ConfigModuleFactory) construct(module string) (probe constructedConfi
 	}, nil
 }
 
-func (cmf *ConfigModuleFactory) applyResolved(ctx context.Context, config confgroup.Config, module any) error {
+func (cmf *ConfigModuleFactory) applyResolved(
+	ctx context.Context,
+	config confgroup.Config,
+	module any,
+) (redactLifecycle bool, resultErr error) {
+	hasReferences := false
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if hasReferences {
+				redactLifecycle = true
+				resultErr = invalidJobConfiguration(errors.New(
+					"job output: applying resolved configuration failed; details redacted",
+				))
+				return
+			}
+			redactLifecycle = false
+			resultErr = invalidJobConfiguration(
+				errors.New("job output: applying configuration panicked"),
+			)
+		}
+	}()
 	resolveCtx := logger.ContextWithLogger(
 		ctx,
 		cmf.logger.With(slog.String("collector", config.Module()), slog.String("job", config.Name())),
 	)
-	resolved, err := cmf.config.Resolver.Resolve(resolveCtx, map[string]any(config), cmf.config.StoreScope)
+	resolved, references, err :=
+		cmf.config.Resolver.ResolveWithReferences(resolveCtx, map[string]any(config), cmf.config.StoreScope)
+	hasReferences = references
 	if err != nil {
-		return fmt.Errorf("job output: resolving configuration secrets: %w", err)
+		err = fmt.Errorf("job output: resolving configuration secrets: %w", err)
+		if hasReferences {
+			return true, redactResolvedLifecycleError(err)
+		}
+		return false, err
+	}
+	if hasReferences {
+		if configured, ok := module.(interface{ GetBase() *collectorapi.Base }); ok && configured.GetBase() != nil {
+			configured.GetBase().Logger = cmf.moduleLogger(config, true)
+		}
 	}
 	payload, err := yaml.Marshal(resolved)
 	if err != nil {
-		return fmt.Errorf("job output: marshaling resolved configuration: %w", err)
+		return false, invalidJobConfiguration(
+			fmt.Errorf("job output: marshaling resolved configuration: %w", err),
+		)
 	}
 	if len(payload) > secretresolver.MaximumAtomicResolvedBytes {
-		return errors.New("job output: serialized configuration exceeds maximum size")
+		return false, invalidJobConfiguration(
+			errors.New("job output: serialized configuration exceeds maximum size"),
+		)
 	}
 	if err := yaml.Unmarshal(payload, module); err != nil {
-		return fmt.Errorf("job output: applying resolved configuration: %w", err)
+		if hasReferences {
+			return true, invalidJobConfiguration(
+				errors.New("job output: applying resolved configuration failed; details redacted"),
+			)
+		}
+		return false, invalidJobConfiguration(
+			fmt.Errorf("job output: applying resolved configuration: %w", err),
+		)
 	}
-	return nil
+	return hasReferences, nil
+}
+
+func (cmf *ConfigModuleFactory) moduleLogger(config confgroup.Config, redact bool) *logger.Logger {
+	log := cmf.logger.With(
+		slog.String("collector", config.Module()),
+		slog.String("job", config.Name()),
+	)
+	if !redact {
+		return log
+	}
+	return log.WithMessageSanitizer(func(message string) string {
+		return redactResolvedLifecycleError(errors.New(message)).Error()
+	})
 }
 
 type constructedConfigModule struct {
 	module configModule
+	redact bool
 	once   sync.Once
 	err    error
 }
@@ -190,6 +253,9 @@ func (ccm *constructedConfigModule) cleanup(ctx context.Context) error {
 				return nil
 			},
 		)
+		if ccm.redact {
+			ccm.err = redactResolvedLifecycleError(ccm.err)
+		}
 	})
 	return ccm.err
 }

--- a/src/go/plugin/agent/jobmgr/joboutput/config_factory_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/config_factory_test.go
@@ -3,13 +3,19 @@
 package joboutput
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,4 +80,271 @@ func TestConfigModuleFactoryCleansEveryAttemptAndPrefersV2(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestConfigModuleFactoryRedactsResolvedValuesFromDecodeErrors(t *testing.T) {
+	const resolvedFixture = "resolved-sensitive-fixture"
+	resolver, err := secretresolver.NewAtomicResolver(map[string]secretresolver.AtomicProvider{
+		"fixture": secretresolver.AtomicProviderFunc(
+			func(context.Context, string) ([]byte, error) {
+				return []byte(resolvedFixture), nil
+			},
+		),
+	})
+	require.NoError(t, err)
+	factory, err := NewConfigModuleFactory(ConfigModuleFactoryConfig{
+		Modules: collectorapi.Registry{
+			"module": {
+				Create: func() collectorapi.CollectorV1 {
+					return &collectorapi.MockCollectorV1{}
+				},
+			},
+		},
+		Resolver:   resolver,
+		StoreScope: unavailableStoreScope,
+	})
+	require.NoError(t, err)
+	config := factoryTestConfig(false)
+	config["option_int"] = "${fixture:value}"
+
+	err = factory.Validate(context.Background(), config)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), resolvedFixture)
+	require.True(t, strings.Contains(err.Error(), "resolved") && strings.Contains(err.Error(), "redacted"))
+}
+
+func TestConfigModuleFactoryRedactsReferenceResolutionFailures(t *testing.T) {
+	const (
+		resolverSensitive = "resolver-sensitive-fixture"
+		cleanupSensitive  = "cleanup-sensitive-fixture"
+	)
+	tests := map[string]struct {
+		resolver   func(*testing.T) *secretresolver.AtomicResolver
+		storeScope secretresolver.AtomicScopeAcquirer
+		reference  string
+	}{
+		"provider error": {
+			resolver: func(t *testing.T) *secretresolver.AtomicResolver {
+				resolver, err := secretresolver.NewAtomicResolver(map[string]secretresolver.AtomicProvider{
+					"fixture": secretresolver.AtomicProviderFunc(func(context.Context, string) ([]byte, error) {
+						return nil, errors.New(resolverSensitive)
+					}),
+				})
+				require.NoError(t, err)
+				return resolver
+			},
+			storeScope: unavailableStoreScope,
+			reference:  "${fixture:value}",
+		},
+		"provider panic": {
+			resolver: func(t *testing.T) *secretresolver.AtomicResolver {
+				resolver, err := secretresolver.NewAtomicResolver(map[string]secretresolver.AtomicProvider{
+					"fixture": secretresolver.AtomicProviderFunc(func(context.Context, string) ([]byte, error) {
+						panic(resolverSensitive)
+					}),
+				})
+				require.NoError(t, err)
+				return resolver
+			},
+			storeScope: unavailableStoreScope,
+			reference:  "${fixture:value}",
+		},
+		"store acquire error": {
+			resolver: func(t *testing.T) *secretresolver.AtomicResolver {
+				resolver, err := secretresolver.NewAtomicResolver(nil)
+				require.NoError(t, err)
+				return resolver
+			},
+			storeScope: func([]string) (secretresolver.AtomicScope, error) {
+				return nil, errors.New(resolverSensitive)
+			},
+			reference: "${store:vault:main:key}",
+		},
+		"store resolve error": {
+			resolver: func(t *testing.T) *secretresolver.AtomicResolver {
+				resolver, err := secretresolver.NewAtomicResolver(nil)
+				require.NoError(t, err)
+				return resolver
+			},
+			storeScope: func([]string) (secretresolver.AtomicScope, error) {
+				return &sensitiveConfigFactoryScope{resolveErr: errors.New(resolverSensitive)}, nil
+			},
+			reference: "${store:vault:main:key}",
+		},
+		"store release error": {
+			resolver: func(t *testing.T) *secretresolver.AtomicResolver {
+				resolver, err := secretresolver.NewAtomicResolver(nil)
+				require.NoError(t, err)
+				return resolver
+			},
+			storeScope: func([]string) (secretresolver.AtomicScope, error) {
+				return &sensitiveConfigFactoryScope{releaseErr: errors.New(resolverSensitive)}, nil
+			},
+			reference: "${store:vault:main:key}",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			factory, err := NewConfigModuleFactory(ConfigModuleFactoryConfig{
+				Modules: collectorapi.Registry{
+					"module": {
+						Create: func() collectorapi.CollectorV1 {
+							return &collectorapi.MockCollectorV1{
+								CleanupFunc: func(context.Context) {
+									panic(cleanupSensitive)
+								},
+							}
+						},
+					},
+				},
+				Resolver:   test.resolver(t),
+				StoreScope: test.storeScope,
+			})
+			require.NoError(t, err)
+			config := factoryTestConfig(false)
+			config["option_str"] = test.reference
+			config["option_int"] = 1
+
+			err = factory.Validate(context.Background(), config)
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), resolverSensitive)
+			require.NotContains(t, err.Error(), cleanupSensitive)
+			require.Contains(t, err.Error(), "redacted")
+		})
+	}
+}
+
+func TestConfigModuleFactoryRedactsResolvedValuesFromCollectorLifecycle(t *testing.T) {
+	const resolvedFixture = "resolved-sensitive-fixture"
+	for _, phase := range []string{"init", "check", "cleanup"} {
+		t.Run(phase, func(t *testing.T) {
+			resolver, err := secretresolver.NewAtomicResolver(map[string]secretresolver.AtomicProvider{
+				"fixture": secretresolver.AtomicProviderFunc(
+					func(context.Context, string) ([]byte, error) {
+						return []byte(resolvedFixture), nil
+					},
+				),
+			})
+			require.NoError(t, err)
+			var module *collectorapi.MockCollectorV1
+			factory, err := NewConfigModuleFactory(ConfigModuleFactoryConfig{
+				Modules: collectorapi.Registry{
+					"module": {
+						Create: func() collectorapi.CollectorV1 {
+							module = &collectorapi.MockCollectorV1{}
+							if phase == "init" {
+								module.InitFunc = func(context.Context) error {
+									return fmt.Errorf("init exposed %s", module.Config.OptionStr)
+								}
+							}
+							if phase == "check" {
+								module.CheckFunc = func(context.Context) error {
+									return fmt.Errorf("check exposed %s", module.Config.OptionStr)
+								}
+							}
+							if phase == "cleanup" {
+								module.CleanupFunc = func(context.Context) {
+									panic("cleanup exposed " + module.Config.OptionStr)
+								}
+							}
+							return module
+						},
+					},
+				},
+				Resolver:   resolver,
+				StoreScope: unavailableStoreScope,
+			})
+			require.NoError(t, err)
+			config := factoryTestConfig(false)
+			config["option_str"] = "${fixture:value}"
+			config["option_int"] = 1
+
+			err = factory.Test(context.Background(), config)
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), resolvedFixture)
+			require.Contains(t, err.Error(), "redacted")
+		})
+	}
+}
+
+func TestConfigModuleFactoryRedactsCollectorInternalLogsAfterResolution(t *testing.T) {
+	const resolvedFixture = "resolved-config-module-log-fixture"
+	resolver, err := secretresolver.NewAtomicResolver(map[string]secretresolver.AtomicProvider{
+		"fixture": secretresolver.AtomicProviderFunc(
+			func(context.Context, string) ([]byte, error) {
+				return []byte(resolvedFixture), nil
+			},
+		),
+	})
+	require.NoError(t, err)
+	var module *collectorapi.MockCollectorV1
+	factory, err := NewConfigModuleFactory(ConfigModuleFactoryConfig{
+		Modules: collectorapi.Registry{
+			"module": {
+				Create: func() collectorapi.CollectorV1 {
+					module = &collectorapi.MockCollectorV1{
+						CheckFunc: func(context.Context) error {
+							module.Warningf("collector log exposed %s", module.Config.OptionStr)
+							return nil
+						},
+					}
+					return module
+				},
+			},
+		},
+		Resolver:   resolver,
+		StoreScope: unavailableStoreScope,
+	})
+	require.NoError(t, err)
+	var logs bytes.Buffer
+	factory.logger = logger.NewWithWriter(&logs)
+	config := factoryTestConfig(false)
+	config["option_str"] = "${fixture:value}"
+	config["option_int"] = 1
+
+	require.NoError(t, factory.Test(context.Background(), config))
+	require.NotContains(t, logs.String(), resolvedFixture)
+	require.Contains(t, logs.String(), "redacted")
+}
+
+type sensitiveCodedRetryableError struct{}
+
+func (sensitiveCodedRetryableError) Error() string         { return "resolved-sensitive-fixture" }
+func (sensitiveCodedRetryableError) DyncfgCode() int       { return 429 }
+func (sensitiveCodedRetryableError) DyncfgRetryable() bool { return true }
+
+func TestResolvedLifecycleRedactionPreservesControlClassifications(t *testing.T) {
+	err := lifecycle.RetainOwnership(errors.Join(
+		lifecycle.ErrTaskPanic,
+		context.Canceled,
+		sensitiveCodedRetryableError{},
+	))
+
+	redacted := redactResolvedLifecycleError(err)
+
+	require.NotContains(t, redacted.Error(), "resolved-sensitive-fixture")
+	require.Contains(t, redacted.Error(), "redacted")
+	require.ErrorIs(t, redacted, lifecycle.ErrTaskPanic)
+	require.ErrorIs(t, redacted, context.Canceled)
+	require.True(t, lifecycle.OwnershipRetained(redacted))
+	require.True(t, dyncfg.IsRetryableError(redacted))
+	coded, ok := errors.AsType[dyncfg.CodedError](redacted)
+	require.True(t, ok)
+	require.Equal(t, 429, coded.DyncfgCode())
+}
+
+type sensitiveConfigFactoryScope struct {
+	resolveErr error
+	releaseErr error
+}
+
+func (scope *sensitiveConfigFactoryScope) Resolve(context.Context, string, string) ([]byte, error) {
+	if scope.resolveErr != nil {
+		return nil, scope.resolveErr
+	}
+	return []byte("resolved"), nil
+}
+
+func (scope *sensitiveConfigFactoryScope) Release(context.Context) error {
+	return scope.releaseErr
 }

--- a/src/go/plugin/agent/jobmgr/joboutput/construction_error.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/construction_error.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package joboutput
+
+import (
+	"errors"
+
+	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+)
+
+type constructionErrorClass uint8
+
+const (
+	constructionErrorOperational constructionErrorClass = iota
+	constructionErrorProposal
+	constructionErrorTransient
+)
+
+type invalidJobConfigurationError struct {
+	cause error
+}
+
+func (err *invalidJobConfigurationError) Error() string {
+	return err.cause.Error()
+}
+
+func (err *invalidJobConfigurationError) Unwrap() error {
+	return err.cause
+}
+
+type transientJobConstructionError struct {
+	cause error
+}
+
+func (err *transientJobConstructionError) Error() string {
+	return err.cause.Error()
+}
+
+func (err *transientJobConstructionError) Unwrap() error {
+	return err.cause
+}
+
+func invalidJobConfiguration(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &invalidJobConfigurationError{cause: err}
+}
+
+func transientJobConstruction(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &transientJobConstructionError{cause: err}
+}
+
+func classifyConstructionError(err error) constructionErrorClass {
+	var transient *transientJobConstructionError
+	if errors.As(err, &transient) {
+		return constructionErrorTransient
+	}
+
+	var resolveErr *secretresolver.AtomicResolveError
+	if errors.As(err, &resolveErr) {
+		switch resolveErr.Kind {
+		case secretresolver.AtomicErrorProvider, secretresolver.AtomicErrorScope:
+			return constructionErrorTransient
+		default:
+			return constructionErrorProposal
+		}
+	}
+
+	var invalid *invalidJobConfigurationError
+	if errors.As(err, &invalid) {
+		return constructionErrorProposal
+	}
+	return constructionErrorOperational
+}
+
+func transientActivationFailure(config confgroup.Config, err error) *autoDetectionFailure {
+	return &autoDetectionFailure{
+		cause:      err,
+		retry:      true,
+		retryAfter: config.AutoDetectionRetry(),
+	}
+}

--- a/src/go/plugin/agent/jobmgr/joboutput/discovery.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/discovery.go
@@ -5,7 +5,9 @@ package joboutput
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
@@ -44,20 +46,37 @@ func (dcjc *DynCfgJobController) PlanDiscovered(change DiscoveredJobChange) (job
 	}
 	config, err := change.Config.Clone()
 	if err != nil {
-		return jobmgr.WorkPlan{}, err
+		return jobmgr.WorkPlan{}, jobmgr.RejectProposal(fmt.Errorf(
+			"job output: clone discovered config: %w",
+			err,
+		))
+	}
+	if config.Module() == "" || config.Name() == "" {
+		return jobmgr.WorkPlan{}, jobmgr.RejectProposal(
+			errors.New("job output: discovered config has no identity"),
+		)
+	}
+	if err := dyncfg.JobNameRuleStrict(config.Name()); err != nil {
+		return jobmgr.WorkPlan{}, jobmgr.RejectProposal(fmt.Errorf(
+			"job output: discovered config has an unpublishable name %q: %w",
+			config.Name(),
+			err,
+		))
 	}
 	creator, ok := dcjc.modules.Lookup(config.Module())
 	if !ok {
-		return jobmgr.WorkPlan{}, errors.New("job output: discovered module is not registered")
+		return jobmgr.WorkPlan{}, jobmgr.RejectProposal(
+			errors.New("job output: discovered module is not registered"),
+		)
 	}
 	if err := validateFactoryConfigIdentity(config, creator); err != nil {
-		return jobmgr.WorkPlan{}, err
+		return jobmgr.WorkPlan{}, jobmgr.RejectProposal(err)
 	}
-	if config.FullName() == "" {
-		return jobmgr.WorkPlan{}, errors.New("job output: discovered config has no identity")
-	}
-	if !validDynCfgProtocolField(config.Source()) || !validDynCfgProtocolField(config.SourceType()) {
-		return jobmgr.WorkPlan{}, errors.New("job output: discovered config has invalid protocol metadata")
+	if !netdataapi.ValidSingleQuotedProtocolField(config.Source()) ||
+		!netdataapi.ValidBareProtocolField(config.SourceType()) {
+		return jobmgr.WorkPlan{}, jobmgr.RejectProposal(
+			errors.New("job output: discovered config has invalid protocol metadata"),
+		)
 	}
 	if change.Remove {
 		if change.Restart {
@@ -76,8 +95,9 @@ func (dcjc *DynCfgJobController) PlanDiscovered(change DiscoveredJobChange) (job
 	}
 	change.Config = config
 	return jobmgr.WorkPlan{
-		Claims:     []string{DynCfgJobGraphClaim},
-		NoResponse: true,
+		Claims:              []string{DynCfgJobGraphClaim},
+		NoResponse:          true,
+		YieldClaimOnPrepare: DynCfgJobGraphClaim,
 		Transaction: &jobmgr.ResourceTransactionPlan{
 			ID:                config.FullName(),
 			AllocateSuccessor: change.Status == dyncfg.StatusRunning,
@@ -135,7 +155,24 @@ func (dcjc *DynCfgJobController) prepareDiscovered(
 			)
 		}
 	}
+	var incumbent confgroup.Config
+	if exists {
+		var err error
+		incumbent, err = graphRecordConfig(record)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if change.Remove {
+		if !exists || incumbent.UID() != change.Config.UID() {
+			return dcjc.noopWithAfterApply(
+				scope,
+				current,
+				permit,
+				result,
+				dcjc.retrySettlement(scope.ID, change.retry),
+			)
+		}
 		return dcjc.prepareMutationWithRetry(
 			scope,
 			current,
@@ -148,10 +185,21 @@ func (dcjc *DynCfgJobController) prepareDiscovered(
 			change.retry,
 		)
 	}
+	if exists &&
+		confgroup.SourceTypePriority(incumbent.SourceType()) >
+			confgroup.SourceTypePriority(change.Config.SourceType()) {
+		return dcjc.noopWithAfterApply(
+			scope,
+			current,
+			permit,
+			result,
+			dcjc.retrySettlement(scope.ID, change.retry),
+		)
+	}
 
 	payload, err := yaml.Marshal(change.Config)
 	if err != nil {
-		return nil, err
+		return nil, jobmgr.RejectProposal(fmt.Errorf("job output: marshal discovered config: %w", err))
 	}
 	postimage := dyncfg.GraphConfig{
 		ID:      scope.ID,
@@ -194,10 +242,67 @@ func (dcjc *DynCfgJobController) prepareDiscovered(
 	}
 	successor, err := dcjc.factory.Prepare(ctx, change.Config, scope.Successor, permit)
 	if err != nil {
-		return nil, err
+		if ctx.Err() != nil || lifecycle.OwnershipRetained(err) {
+			return nil, err
+		}
+		switch classifyConstructionError(err) {
+		case constructionErrorTransient:
+			failedPostimage := postimage
+			failedPostimage.Status = dyncfg.StatusFailed.String()
+			return dcjc.prepareTransientConstructionFailure(
+				scope,
+				current,
+				permit,
+				failedPostimage,
+				result,
+				dcjc.configCreateCleanup(
+					failedPostimage,
+					change.Config.SourceType(),
+					change.Config.Source(),
+					dcjc.configType(dcjc.modules[change.Config.Module()]),
+				),
+				change.retry,
+				change.Config,
+				err,
+			)
+		case constructionErrorProposal:
+			return nil, jobmgr.RejectProposal(err)
+		default:
+			return nil, err
+		}
 	}
 	failedPostimage := postimage
 	failedPostimage.Status = dyncfg.StatusFailed.String()
+	probeFailure, err := dcjc.factory.Probe(ctx, successor)
+	if err != nil {
+		return nil, err
+	}
+	if probeFailure != nil {
+		return dcjc.prepareProbeFailure(
+			scope,
+			current,
+			permit,
+			change.retry,
+			probeFailure,
+			probeFailurePlan{
+				postimage: failedPostimage,
+				failedCleanup: dcjc.configCreateCleanup(
+					failedPostimage,
+					change.Config.SourceType(),
+					change.Config.Source(),
+					dcjc.configType(dcjc.modules[change.Config.Module()]),
+				),
+				removedCleanup: dcjc.configDeleteCleanup(
+					dcjc.configID(change.Config.Module(), change.Config.Name()),
+				),
+				result: func(*autoDetectionFailure) lifecycle.SealedResult {
+					return result
+				},
+				afterApply:       dcjc.scheduleRetryAfterApply(change.Config),
+				removePlainStock: change.Config.SourceType() == confgroup.TypeStock,
+			},
+		)
+	}
 	return dcjc.prepareMutationWithRetry(
 		scope,
 		current,
@@ -208,21 +313,5 @@ func (dcjc *DynCfgJobController) prepareDiscovered(
 		result,
 		cleanup,
 		change.retry,
-		successorFailurePlan{
-			postimage: failedPostimage,
-			failedCleanup: dcjc.configCreateCleanup(
-				failedPostimage,
-				change.Config.SourceType(),
-				change.Config.Source(),
-				dcjc.configType(dcjc.modules[change.Config.Module()]),
-			),
-			removedCleanup: dcjc.configDeleteCleanup(dcjc.configID(change.Config.Module(), change.Config.Name())),
-			result: func(*autoDetectionFailure) lifecycle.SealedResult {
-				return result
-			},
-			afterApply: dcjc.scheduleRetryAfterApply(change.Config),
-			removePlainStock: change.Config.SourceType() ==
-				confgroup.TypeStock,
-		},
 	)
 }

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_cleanup.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_cleanup.go
@@ -32,8 +32,8 @@ func (dcjc *DynCfgJobController) configCreateCleanup(
 	if sourceType == confgroup.TypeDyncfg && configType == dyncfg.ConfigTypeJob {
 		commands += " " + string(dyncfg.CommandRemove)
 	}
-	return dcjc.protocolCleanup(func(api *netdataapi.API) {
-		api.CONFIGCREATE(
+	return dcjc.protocolCleanup(func(api *netdataapi.API) error {
+		return api.TryCONFIGCREATE(
 			netdataapi.ConfigOpts{
 				ID:                id,
 				Status:            config.Status,
@@ -48,25 +48,27 @@ func (dcjc *DynCfgJobController) configCreateCleanup(
 }
 
 func (dcjc *DynCfgJobController) configStatusCleanup(id string, status dyncfg.Status) lifecycle.TaskCleanup {
-	return dcjc.protocolCleanup(func(api *netdataapi.API) {
-		api.CONFIGSTATUS(dcjc.externalID(id), status.String())
+	return dcjc.protocolCleanup(func(api *netdataapi.API) error {
+		return api.TryCONFIGSTATUS(dcjc.externalID(id), status.String())
 	})
 }
 
 func (dcjc *DynCfgJobController) configDeleteCleanup(externalID string) lifecycle.TaskCleanup {
-	return dcjc.protocolCleanup(func(api *netdataapi.API) {
-		api.CONFIGDELETE(externalID)
+	return dcjc.protocolCleanup(func(api *netdataapi.API) error {
+		return api.TryCONFIGDELETE(externalID)
 	})
 }
 
-func (dcjc *DynCfgJobController) protocolCleanup(build func(*netdataapi.API)) lifecycle.TaskCleanup {
+func (dcjc *DynCfgJobController) protocolCleanup(build func(*netdataapi.API) error) lifecycle.TaskCleanup {
 	if dcjc == nil || build == nil {
 		return func() error {
 			return errors.New("job output: invalid DynCfg protocol cleanup")
 		}
 	}
 	var payload bytes.Buffer
-	build(netdataapi.New(&payload))
+	if err := build(netdataapi.New(&payload)); err != nil {
+		return func() error { return err }
+	}
 	prepared, err := lifecycle.PrepareProtocolFrame(payload.Bytes())
 	if err != nil {
 		return func() error { return err }

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs.go
@@ -321,15 +321,6 @@ func validateGraphResourcePair(
 	return nil
 }
 
-func validDynCfgProtocolField(value string) bool {
-	for _, char := range value {
-		if char < ' ' || char == 0x7f || char == '\'' {
-			return false
-		}
-	}
-	return true
-}
-
 func joinDynCfgCleanups(cleanups ...lifecycle.TaskCleanup) lifecycle.TaskCleanup {
 	joined := make([]lifecycle.TaskCleanup, 0, len(cleanups))
 	for _, cleanup := range cleanups {

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
@@ -159,6 +159,265 @@ func TestDynCfgAddCommitsOrDisposesOneGraphTransaction(t *testing.T) {
 	}
 }
 
+func TestPlanDiscoveredClassifiesOnlyExternalProposalErrors(t *testing.T) {
+	controller, _, _, _, _ := newDynCfgJobTestHarness(t)
+	discoveredConfig := func() confgroup.Config {
+		return factoryTestConfig(false).
+			SetSourceType(confgroup.TypeUser).
+			SetSource("file=/etc/netdata/go.d/job.conf")
+	}
+	tests := map[string]struct {
+		change DiscoveredJobChange
+		want   bool
+	}{
+		"clone failure": {
+			change: DiscoveredJobChange{
+				Config: discoveredConfig().Set("unsupported", make(chan struct{})),
+				Status: dyncfg.StatusRunning,
+			},
+			want: true,
+		},
+		"unregistered module": {
+			change: DiscoveredJobChange{
+				Config: discoveredConfig().SetModule("missing"),
+				Status: dyncfg.StatusRunning,
+			},
+			want: true,
+		},
+		"invalid identity": {
+			change: DiscoveredJobChange{
+				Config: discoveredConfig().SetName(""),
+				Status: dyncfg.StatusRunning,
+			},
+			want: true,
+		},
+		"unpublishable job name": {
+			change: DiscoveredJobChange{
+				Config: discoveredConfig().SetName("bad=name"),
+				Status: dyncfg.StatusRunning,
+			},
+			want: true,
+		},
+		"invalid protocol metadata": {
+			change: DiscoveredJobChange{
+				Config: discoveredConfig().SetSource("file=/etc/netdata/go.d/operator's.conf"),
+				Status: dyncfg.StatusRunning,
+			},
+			want: true,
+		},
+		"invalid source type token": {
+			change: DiscoveredJobChange{
+				Config: discoveredConfig().SetSourceType("user type"),
+				Status: dyncfg.StatusRunning,
+			},
+			want: true,
+		},
+		"invalid internal status": {
+			change: DiscoveredJobChange{
+				Config: discoveredConfig(),
+				Status: dyncfg.StatusFailed,
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := controller.PlanDiscovered(test.change)
+			require.Error(t, err)
+			require.Equal(t, test.want, jobmgr.IsProposalRejection(err))
+		})
+	}
+}
+
+func TestPlanDiscoveredAcceptsWindowsConfigSource(t *testing.T) {
+	controller, _, _, _, _ := newDynCfgJobTestHarness(t)
+	config := factoryTestConfig(false).
+		SetSourceType(confgroup.TypeUser).
+		SetSource(`discoverer=file_reader,file=C:\Program Files\Netdata\go.d\job.conf`)
+
+	_, err := controller.PlanDiscovered(DiscoveredJobChange{
+		Config: config,
+		Status: dyncfg.StatusRunning,
+	})
+	require.NoError(t, err)
+}
+
+func TestDynCfgAddCollisionIsReplayUpsert(t *testing.T) {
+	controller, graph, _, _, _ := newDynCfgJobTestHarness(t)
+	config := factoryTestConfig(false)
+	config.SetSourceType(confgroup.TypeUser)
+	config.SetSource("file=test")
+	config.SetProvider(confgroup.TypeUser)
+	payload, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	mutation, err := graph.PrepareMutation([]dyncfg.GraphChange{{
+		ID: config.FullName(),
+		Config: &dyncfg.GraphConfig{
+			ID:      config.FullName(),
+			Module:  config.Module(),
+			Name:    config.Name(),
+			Status:  dyncfg.StatusRunning.String(),
+			Payload: payload,
+		},
+	}})
+	require.NoError(t, err)
+	require.NoError(t, graph.Commit(mutation))
+
+	identity := lifecycle.ResourceIdentity{ID: config.FullName(), Generation: 1}
+	current := &transactionTestReadyResource{
+		identity: identity,
+		prefix:   "current",
+		events:   new([]string),
+	}
+	transaction, err := controller.Prepare(
+		context.Background(),
+		DynCfgJobRequest{
+			Args:         []string{"go.d:collector:module", "add", "job"},
+			Payload:      []byte(`{"option":"replacement"}`),
+			ContentType:  "application/json",
+			CallerSource: "user=test",
+			HasPayload:   true,
+		},
+		current,
+		lifecycle.ResourceTransactionScope{
+			ID:      config.FullName(),
+			Current: identity,
+		},
+		lifecycle.LongLivedPermit{},
+	)
+	require.NoError(t, err)
+
+	applied, err := transaction.Apply(context.Background())
+	require.NoError(t, err)
+	_, disposition, owned := applied.Ownership()
+	require.Equal(t, lifecycle.ResourceTransactionRemoved, disposition)
+	require.Nil(t, owned)
+	require.Equal(t, 202, applied.ResultStatus())
+
+	record, exists := graph.Lookup(config.FullName())
+	require.True(t, exists)
+	require.Equal(t, dyncfg.StatusAccepted.String(), record.Status)
+	replayed, err := graphRecordConfig(record)
+	require.NoError(t, err)
+	require.Equal(t, confgroup.TypeDyncfg, replayed.SourceType())
+	require.Equal(t, "replacement", replayed.Get("option"))
+	require.NotEmpty(t, *current.events)
+}
+
+func TestDiscoveredChangeCannotReplaceHigherPriorityGraphOwner(t *testing.T) {
+	controller, graph, supervisor, _, _ := newDynCfgJobTestHarness(t)
+	winner := factoryTestConfig(false).
+		Set("option", "dyncfg").
+		SetSourceType(confgroup.TypeDyncfg).
+		SetSource("user=operator").
+		SetProvider(confgroup.TypeDyncfg)
+	seedDynCfgJobGraphRecord(t, graph, winner, dyncfg.StatusRunning)
+
+	lower := factoryTestConfig(false).
+		Set("option", "changed-file").
+		SetSourceType(confgroup.TypeUser).
+		SetSource("file=/etc/netdata/go.d/module.conf").
+		SetProvider(confgroup.TypeUser)
+	currentIdentity := lifecycle.ResourceIdentity{ID: winner.FullName(), Generation: 1}
+	current := &transactionTestReadyResource{
+		identity: currentIdentity,
+		prefix:   "current",
+		events:   new([]string),
+	}
+	successorIdentity := lifecycle.ResourceIdentity{ID: winner.FullName(), Generation: 2}
+	permit, err := supervisor.IssueLongLivedPermit(
+		successorIdentity,
+		lifecycle.NewJobLongLivedPlan(),
+	)
+	require.NoError(t, err)
+	transaction, err := controller.prepareDiscovered(
+		context.Background(),
+		DiscoveredJobChange{
+			Config: lower,
+			Status: dyncfg.StatusRunning,
+		},
+		current,
+		lifecycle.ResourceTransactionScope{
+			ID:        winner.FullName(),
+			Current:   currentIdentity,
+			Successor: successorIdentity,
+		},
+		permit,
+	)
+	require.NoError(t, err)
+
+	applied, err := transaction.Apply(context.Background())
+	require.NoError(t, err)
+	_, disposition, owned := applied.Ownership()
+	require.Equal(t, lifecycle.ResourceTransactionUnchanged, disposition)
+	require.Same(t, current, owned)
+	require.Empty(t, *current.events)
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, supervisor.LongLivedCensus())
+
+	record, exists := graph.Lookup(winner.FullName())
+	require.True(t, exists)
+	active, err := graphRecordConfig(record)
+	require.NoError(t, err)
+	require.Equal(t, winner.UID(), active.UID())
+}
+
+func TestDiscoveredRemovalCannotDeleteDifferentGraphOwner(t *testing.T) {
+	tests := map[string]struct {
+		winner  confgroup.Config
+		removed confgroup.Config
+	}{
+		"lower source cannot remove dyncfg": {
+			winner: factoryTestConfig(false).
+				Set("option", "dyncfg").
+				SetSourceType(confgroup.TypeDyncfg).
+				SetSource("user=operator").
+				SetProvider(confgroup.TypeDyncfg),
+			removed: factoryTestConfig(false).
+				Set("option", "file").
+				SetSourceType(confgroup.TypeUser).
+				SetSource("file=/etc/netdata/go.d/module.conf").
+				SetProvider(confgroup.TypeUser),
+		},
+		"stale same-priority candidate cannot remove current candidate": {
+			winner: factoryTestConfig(false).
+				Set("option", "current").
+				SetSourceType(confgroup.TypeUser).
+				SetSource("file=/etc/netdata/go.d/current.conf").
+				SetProvider(confgroup.TypeUser),
+			removed: factoryTestConfig(false).
+				Set("option", "stale").
+				SetSourceType(confgroup.TypeUser).
+				SetSource("file=/etc/netdata/go.d/stale.conf").
+				SetProvider(confgroup.TypeUser),
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			controller, graph, _, _, _ := newDynCfgJobTestHarness(t)
+			seedDynCfgJobGraphRecord(t, graph, test.winner, dyncfg.StatusAccepted)
+
+			transaction, err := controller.prepareDiscovered(
+				context.Background(),
+				DiscoveredJobChange{
+					Config: test.removed,
+					Remove: true,
+				},
+				nil,
+				lifecycle.ResourceTransactionScope{ID: test.winner.FullName()},
+				lifecycle.LongLivedPermit{},
+			)
+			require.NoError(t, err)
+			_, err = transaction.Apply(context.Background())
+			require.NoError(t, err)
+
+			record, exists := graph.Lookup(test.winner.FullName())
+			require.True(t, exists)
+			active, err := graphRecordConfig(record)
+			require.NoError(t, err)
+			require.Equal(t, test.winner.UID(), active.UID())
+		})
+	}
+}
+
 func TestDynCfgProtocolIDsMatchDeclaredConfigType(t *testing.T) {
 	tests := map[string]struct {
 		policy       collectorapi.InstancePolicy
@@ -255,7 +514,7 @@ func TestManualDynCfgAutoDetectionFailureResponseContracts(t *testing.T) {
 			current:         true,
 			payload:         []byte(`{"option":"replacement"}`),
 			wantCode:        200,
-			wantCleanup:     2,
+			wantCleanup:     1,
 			wantDisposition: lifecycle.ResourceTransactionRemoved,
 			wantMessage:     "config update failed: check failed",
 		},
@@ -400,9 +659,8 @@ func TestDynCfgCommandsPropagateRetainedConstructionFailure(t *testing.T) {
 		lifecycle.LongLivedPermit,
 	) (lifecycle.PreparedResourceTransaction, error)
 	tests := map[string]struct {
-		status        dyncfg.Status
-		validateFirst bool
-		prepare       prepareCommand
+		status  dyncfg.Status
+		prepare prepareCommand
 	}{
 		"enable": {
 			status: dyncfg.StatusDisabled,
@@ -431,8 +689,7 @@ func TestDynCfgCommandsPropagateRetainedConstructionFailure(t *testing.T) {
 			},
 		},
 		"update": {
-			status:        dyncfg.StatusRunning,
-			validateFirst: true,
+			status: dyncfg.StatusRunning,
 			prepare: func(
 				ctx context.Context,
 				controller *DynCfgJobController,
@@ -461,14 +718,9 @@ func TestDynCfgCommandsPropagateRetainedConstructionFailure(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			controller, graph, _, _, state := newDynCfgJobTestHarness(t)
+			controller, graph, _, _, _ := newDynCfgJobTestHarness(t)
 			creator := controller.modules["module"]
-			var constructions int
 			creator.Create = func() collectorapi.CollectorV1 {
-				constructions++
-				if test.validateFirst && constructions == 1 {
-					return state.module(nil, false)
-				}
 				panic("construction failed")
 			}
 			controller.modules["module"] = creator
@@ -634,7 +886,7 @@ func TestFailedAutoDetectionCommitsFailedStateAndSchedulesRetry(t *testing.T) {
 	require.NoError(t, err)
 	_, err = transaction.Apply(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, []string{"current-stop", "current-finalize", "autodetection"}, events)
+	require.Equal(t, []string{"autodetection", "current-stop", "current-finalize"}, events)
 
 	record, ok := graph.Lookup(config.FullName())
 	require.True(t, ok)
@@ -681,7 +933,7 @@ func TestFailedAutoDetectionCommitsFailedStateAndSchedulesRetry(t *testing.T) {
 	require.NoError(t, err)
 	_, err = retryTransaction.Apply(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, []string{"current-stop", "current-finalize", "autodetection"}, events)
+	require.Equal(t, []string{"autodetection", "current-stop", "current-finalize"}, events)
 	require.EqualValues(t, lifecycle.LongLivedCensus{}, retryTasks.LongLivedCensus())
 
 	controller.scheduler.StopAutoDetectionRetries()
@@ -759,6 +1011,243 @@ func TestNonRetryableAutoDetectionFailureSettlesExistingRetry(t *testing.T) {
 	require.True(t, exists)
 	require.Equal(t, dyncfg.StatusFailed.String(), record.Status)
 	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+}
+
+func TestDiscoveredTransientConstructionFailureCommitsFailedAndSchedulesRetry(t *testing.T) {
+	controller, graph, _, _, state := newDynCfgJobTestHarness(t)
+	installFailingFixtureResolver(t, controller)
+	commands := &autoDetectionRetryTestCommands{}
+	require.NoError(t, controller.BindAutoDetectionRetries(commands, 1, func(error) {}))
+
+	config := factoryTestConfig(false)
+	config.Set("option", "${fixture:value}")
+	config.Set("autodetection_retry", 1)
+	config.SetSourceType(confgroup.TypeDiscovered)
+	config.SetSource("discovery-source")
+	config.SetProvider("discovery")
+	permit, tasks := issueTestJobPermit(t, config.FullName(), 1)
+	scope := lifecycle.ResourceTransactionScope{
+		ID: config.FullName(),
+		Successor: lifecycle.ResourceIdentity{
+			ID:         config.FullName(),
+			Generation: 1,
+		},
+	}
+
+	transaction, err := controller.prepareDiscovered(
+		context.Background(),
+		DiscoveredJobChange{
+			Config: config,
+			Status: dyncfg.StatusRunning,
+		},
+		nil,
+		scope,
+		permit,
+	)
+	require.NoError(t, err)
+	_, err = transaction.Apply(context.Background())
+	require.NoError(t, err)
+
+	record, ok := graph.Lookup(config.FullName())
+	require.True(t, ok)
+	require.Equal(t, dyncfg.StatusFailed.String(), record.Status)
+	require.EqualValues(t, 1, state.collectorCleanup)
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+
+	require.NoError(t, controller.scheduler.Tick(context.Background(), 0))
+	require.NoError(t, controller.scheduler.Tick(context.Background(), 1))
+	commands.waitForSubmissions(t, 1)
+}
+
+func TestDiscoveredInvalidConfigurationIsProposalRejection(t *testing.T) {
+	controller, _, _, _, _ := newDynCfgJobTestHarness(t)
+	config := factoryTestConfig(false)
+	config.Set("option_int", "not-an-integer")
+	config.SetSourceType(confgroup.TypeDiscovered)
+	config.SetSource("discovery-source")
+	config.SetProvider("discovery")
+	permit, tasks := issueTestJobPermit(t, config.FullName(), 1)
+	scope := lifecycle.ResourceTransactionScope{
+		ID: config.FullName(),
+		Successor: lifecycle.ResourceIdentity{
+			ID:         config.FullName(),
+			Generation: 1,
+		},
+	}
+
+	transaction, err := controller.prepareDiscovered(
+		context.Background(),
+		DiscoveredJobChange{
+			Config: config,
+			Status: dyncfg.StatusRunning,
+		},
+		nil,
+		scope,
+		permit,
+	)
+	require.Nil(t, transaction)
+	require.True(t, jobmgr.IsProposalRejection(err), "error: %v", err)
+	require.NoError(t, permit.AbortUnused())
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+}
+
+func TestManualEnableTransientConstructionFailureCommitsFailedAndSchedulesRetry(t *testing.T) {
+	controller, graph, _, _, _ := newDynCfgJobTestHarness(t)
+	installFailingFixtureResolver(t, controller)
+	commands := &autoDetectionRetryTestCommands{}
+	require.NoError(t, controller.BindAutoDetectionRetries(commands, 1, func(error) {}))
+
+	config := factoryTestConfig(false)
+	config.Set("option", "${fixture:value}")
+	config.Set("autodetection_retry", 1)
+	config.SetSourceType(confgroup.TypeDyncfg)
+	config.SetSource("user=test")
+	config.SetProvider("dyncfg")
+	payload, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	mutation, err := graph.PrepareMutation([]dyncfg.GraphChange{{
+		ID: config.FullName(),
+		Config: &dyncfg.GraphConfig{
+			ID:      config.FullName(),
+			Module:  config.Module(),
+			Name:    config.Name(),
+			Status:  dyncfg.StatusDisabled.String(),
+			Payload: payload,
+		},
+	}})
+	require.NoError(t, err)
+	require.NoError(t, graph.Commit(mutation))
+	record, ok := graph.Lookup(config.FullName())
+	require.True(t, ok)
+	permit, tasks := issueTestJobPermit(t, config.FullName(), 1)
+	scope := lifecycle.ResourceTransactionScope{
+		ID: config.FullName(),
+		Successor: lifecycle.ResourceIdentity{
+			ID:         config.FullName(),
+			Generation: 1,
+		},
+	}
+	target := dynCfgTarget{
+		module:     config.Module(),
+		name:       config.Name(),
+		resourceID: config.FullName(),
+		creator:    controller.modules[config.Module()],
+	}
+
+	transaction, err := controller.prepareEnable(context.Background(), target, record, true, nil, scope, permit)
+	require.NoError(t, err)
+	_, err = transaction.Apply(context.Background())
+	require.NoError(t, err)
+
+	record, ok = graph.Lookup(config.FullName())
+	require.True(t, ok)
+	require.Equal(t, dyncfg.StatusFailed.String(), record.Status)
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+
+	require.NoError(t, controller.scheduler.Tick(context.Background(), 0))
+	require.NoError(t, controller.scheduler.Tick(context.Background(), 1))
+	commands.waitForSubmissions(t, 1)
+}
+
+func TestRunningUpdateTransientConstructionFailureCommitsFailedAndSchedulesRetry(t *testing.T) {
+	controller, graph, _, _, _ := newDynCfgJobTestHarness(t)
+	installFailingFixtureResolver(t, controller)
+	commands := &autoDetectionRetryTestCommands{}
+	require.NoError(t, controller.BindAutoDetectionRetries(commands, 1, func(error) {}))
+
+	config := factoryTestConfig(false)
+	config.Set("autodetection_retry", 1)
+	config.SetSourceType(confgroup.TypeDyncfg)
+	config.SetSource("user=test")
+	config.SetProvider("dyncfg")
+	payload, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	mutation, err := graph.PrepareMutation([]dyncfg.GraphChange{{
+		ID: config.FullName(),
+		Config: &dyncfg.GraphConfig{
+			ID:      config.FullName(),
+			Module:  config.Module(),
+			Name:    config.Name(),
+			Status:  dyncfg.StatusRunning.String(),
+			Payload: payload,
+		},
+	}})
+	require.NoError(t, err)
+	require.NoError(t, graph.Commit(mutation))
+	record, ok := graph.Lookup(config.FullName())
+	require.True(t, ok)
+
+	var events []string
+	currentIdentity := lifecycle.ResourceIdentity{
+		ID:         config.FullName(),
+		Generation: 1,
+	}
+	current := &transactionTestReadyResource{
+		identity: currentIdentity,
+		prefix:   "current",
+		events:   &events,
+	}
+	permit, tasks := issueTestJobPermit(t, config.FullName(), 2)
+	scope := lifecycle.ResourceTransactionScope{
+		ID:      config.FullName(),
+		Current: currentIdentity,
+		Successor: lifecycle.ResourceIdentity{
+			ID:         config.FullName(),
+			Generation: 2,
+		},
+	}
+	target := dynCfgTarget{
+		module:     config.Module(),
+		name:       config.Name(),
+		resourceID: config.FullName(),
+		creator:    controller.modules[config.Module()],
+	}
+	request := DynCfgJobRequest{
+		Payload: []byte(`{
+			"option":"${fixture:value}",
+			"autodetection_retry":1
+		}`),
+		ContentType:  "application/json",
+		CallerSource: "user=test",
+		HasPayload:   true,
+	}
+
+	transaction, err := controller.prepareUpdate(
+		context.Background(),
+		request,
+		target,
+		record,
+		true,
+		current,
+		scope,
+		permit,
+	)
+	require.NoError(t, err)
+	_, err = transaction.Apply(context.Background())
+	require.NoError(t, err)
+
+	record, ok = graph.Lookup(config.FullName())
+	require.True(t, ok)
+	require.Equal(t, dyncfg.StatusFailed.String(), record.Status)
+	require.Equal(t, []string{"current-stop", "current-finalize"}, events)
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+
+	require.NoError(t, controller.scheduler.Tick(context.Background(), 0))
+	require.NoError(t, controller.scheduler.Tick(context.Background(), 1))
+	commands.waitForSubmissions(t, 1)
+}
+
+func installFailingFixtureResolver(t *testing.T, controller *DynCfgJobController) {
+	t.Helper()
+	resolver, err := secretresolver.NewAtomicResolver(map[string]secretresolver.AtomicProvider{
+		"fixture": secretresolver.AtomicProviderFunc(
+			func(context.Context, string) ([]byte, error) {
+				return nil, errors.New("fixture provider unavailable")
+			},
+		),
+	})
+	require.NoError(t, err)
+	controller.factory.config.ConfigModules.config.Resolver = resolver
 }
 
 type nonRetryableAutoDetectionError struct{}
@@ -1109,13 +1598,14 @@ func newDynCfgJobTestHarnessWithDiagnostics(
 	require.NoError(t, err)
 	factory, err := NewFactory(
 		FactoryConfig{
-			PluginName:    "go.d",
-			Modules:       modules,
-			Tasks:         supervisor,
-			Frames:        frames,
-			ConfigModules: configModules,
-			Vnodes:        vnoderegistry.New(),
-			Scheduler:     newTestScheduler(t),
+			PluginName:       "go.d",
+			Modules:          modules,
+			Tasks:            supervisor,
+			Frames:           frames,
+			ConfigModules:    configModules,
+			Vnodes:           vnoderegistry.New(),
+			Scheduler:        newTestScheduler(t),
+			RunWithoutClaims: testRunWithoutClaims,
 		},
 	)
 	require.NoError(t, err)
@@ -1138,6 +1628,29 @@ func newDynCfgJobTestHarnessWithDiagnostics(
 	)
 	require.NoError(t, err)
 	return controller, graph, supervisor, output, state
+}
+
+func seedDynCfgJobGraphRecord(
+	t *testing.T,
+	graph *dyncfg.Graph,
+	config confgroup.Config,
+	status dyncfg.Status,
+) {
+	t.Helper()
+	payload, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	mutation, err := graph.PrepareMutation([]dyncfg.GraphChange{{
+		ID: config.FullName(),
+		Config: &dyncfg.GraphConfig{
+			ID:      config.FullName(),
+			Module:  config.Module(),
+			Name:    config.Name(),
+			Status:  status.String(),
+			Payload: payload,
+		},
+	}})
+	require.NoError(t, err)
+	require.NoError(t, graph.Commit(mutation))
 }
 
 type jobDependencyIndexFunc func(string, *dyncfg.GraphConfig) (func(), error)

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
@@ -21,7 +21,6 @@ func (dcjc *DynCfgJobController) prepareMutation(
 	postimage *dyncfg.GraphConfig,
 	result lifecycle.SealedResult,
 	cleanup lifecycle.TaskCleanup,
-	failurePlans ...successorFailurePlan,
 ) (lifecycle.PreparedResourceTransaction, error) {
 	return dcjc.prepareMutationWithRetry(
 		scope,
@@ -33,7 +32,6 @@ func (dcjc *DynCfgJobController) prepareMutation(
 		result,
 		cleanup,
 		autoDetectionRetryToken{},
-		failurePlans...,
 	)
 }
 
@@ -47,18 +45,35 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetry(
 	result lifecycle.SealedResult,
 	cleanup lifecycle.TaskCleanup,
 	retry autoDetectionRetryToken,
-	failurePlans ...successorFailurePlan,
 ) (lifecycle.PreparedResourceTransaction, error) {
-	if len(failurePlans) > 1 || len(failurePlans) == 1 && successor == nil {
-		return nil, errors.New("job output: invalid successor-failure plan")
-	}
-	var failurePlan *successorFailurePlan
-	if len(failurePlans) == 1 {
-		failurePlan = &failurePlans[0]
-	}
+	return dcjc.prepareMutationWithRetryAfterApply(
+		scope,
+		current,
+		successor,
+		unusedPermit,
+		disposition,
+		postimage,
+		result,
+		cleanup,
+		retry,
+		nil,
+	)
+}
+
+func (dcjc *DynCfgJobController) prepareMutationWithRetryAfterApply(
+	scope lifecycle.ResourceTransactionScope,
+	current lifecycle.ReadyResource,
+	successor lifecycle.PreparedResource,
+	unusedPermit lifecycle.LongLivedPermit,
+	disposition lifecycle.ResourceTransactionDisposition,
+	postimage *dyncfg.GraphConfig,
+	result lifecycle.SealedResult,
+	cleanup lifecycle.TaskCleanup,
+	retry autoDetectionRetryToken,
+	afterApply func(),
+) (lifecycle.PreparedResourceTransaction, error) {
+	afterApply = composeAfterApply(dcjc.retrySettlement(scope.ID, retry), afterApply)
 	var dependencyCommit func()
-	var failedDependencyCommit func()
-	var removedDependencyCommit func()
 	if dcjc.dependencies != nil {
 		var err error
 		dependencyCommit, err = dcjc.dependencies.PrepareJobChange(scope.ID, postimage)
@@ -67,15 +82,6 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetry(
 				err = rollbackSuccessorMutation(successor, err)
 			}
 			return nil, err
-		}
-		if failurePlan != nil {
-			failedDependencyCommit, err = dcjc.dependencies.PrepareJobChange(scope.ID, &failurePlan.postimage)
-			if err == nil && failurePlan.removePlainStock {
-				removedDependencyCommit, err = dcjc.dependencies.PrepareJobChange(scope.ID, nil)
-			}
-			if err != nil {
-				return nil, rollbackSuccessorMutation(successor, err)
-			}
 		}
 	}
 	mutation, err := dcjc.graph.PrepareMutation([]dyncfg.GraphChange{{ID: scope.ID, Config: postimage}})
@@ -89,14 +95,9 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetry(
 					Successor:        successor,
 					Graph:            dcjc.graph,
 					AfterGraphCommit: dependencyCommit,
-					AfterApply:       dcjc.retrySettlement(scope.ID, retry),
+					AfterApply:       afterApply,
 					Result:           result,
 					Cleanup:          cleanup,
-					SuccessorFailure: successorFailureResolver(
-						failurePlan,
-						failedDependencyCommit,
-						removedDependencyCommit,
-					),
 				},
 			)
 		}
@@ -105,7 +106,7 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetry(
 			current,
 			unusedPermit,
 			result,
-			dcjc.retrySettlement(scope.ID, retry),
+			afterApply,
 			cleanup,
 		)
 	}
@@ -126,10 +127,9 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetry(
 			Mutation:         mutation,
 			MutationPrepared: true,
 			AfterGraphCommit: dependencyCommit,
-			AfterApply:       dcjc.retrySettlement(scope.ID, retry),
+			AfterApply:       afterApply,
 			Result:           result,
 			Cleanup:          cleanup,
-			SuccessorFailure: successorFailureResolver(failurePlan, failedDependencyCommit, removedDependencyCommit),
 		},
 	)
 }
@@ -173,7 +173,78 @@ func (dcjc *DynCfgJobController) scheduleAutoDetectionRetry(config confgroup.Con
 	dcjc.scheduler.retries.schedule(config, failure.retryAfter)
 }
 
-type successorFailurePlan struct {
+func (dcjc *DynCfgJobController) prepareTransientConstructionFailure(
+	scope lifecycle.ResourceTransactionScope,
+	current lifecycle.ReadyResource,
+	permit lifecycle.LongLivedPermit,
+	postimage dyncfg.GraphConfig,
+	result lifecycle.SealedResult,
+	cleanup lifecycle.TaskCleanup,
+	retry autoDetectionRetryToken,
+	config confgroup.Config,
+	err error,
+) (lifecycle.PreparedResourceTransaction, error) {
+	failure := transientActivationFailure(config, err)
+	return dcjc.prepareMutationWithRetryAfterApply(
+		scope,
+		current,
+		nil,
+		permit,
+		resourceRemovalDisposition(current),
+		&postimage,
+		result,
+		cleanup,
+		retry,
+		func() {
+			dcjc.scheduleAutoDetectionRetry(config, failure)
+		},
+	)
+}
+
+func (dcjc *DynCfgJobController) prepareProbeFailure(
+	scope lifecycle.ResourceTransactionScope,
+	current lifecycle.ReadyResource,
+	permit lifecycle.LongLivedPermit,
+	retry autoDetectionRetryToken,
+	failure *autoDetectionFailure,
+	plan probeFailurePlan,
+) (lifecycle.PreparedResourceTransaction, error) {
+	if failure == nil {
+		return nil, errors.New("job output: nil probe failure")
+	}
+	removed := plan.removePlainStock && !failure.coded
+	var postimage *dyncfg.GraphConfig
+	cleanup := plan.failedCleanup
+	if removed {
+		cleanup = plan.removedCleanup
+	} else {
+		postimage = &plan.postimage
+	}
+	result := lifecycle.SealedResult{}
+	if plan.result != nil {
+		result = plan.result(failure)
+	}
+	var afterApply func()
+	if plan.afterApply != nil {
+		afterApply = func() {
+			plan.afterApply(failure)
+		}
+	}
+	return dcjc.prepareMutationWithRetryAfterApply(
+		scope,
+		current,
+		nil,
+		permit,
+		resourceRemovalDisposition(current),
+		postimage,
+		result,
+		cleanup,
+		retry,
+		afterApply,
+	)
+}
+
+type probeFailurePlan struct {
 	postimage        dyncfg.GraphConfig                                 // graph postimage to commit as StatusFailed
 	failedCleanup    lifecycle.TaskCleanup                              // protocol cleanup for the failed status
 	removedCleanup   lifecycle.TaskCleanup                              // protocol cleanup when a plain stock job is removed instead
@@ -182,43 +253,7 @@ type successorFailurePlan struct {
 	removePlainStock bool                                               // remove instead of fail for a stock + non-coded failure
 }
 
-func successorFailureResolver(
-	plan *successorFailurePlan,
-	failedDependencyCommit func(),
-	removedDependencyCommit func(),
-) func(*autoDetectionFailure) (SuccessorFailureResolution, error) {
-	if plan == nil {
-		return nil
-	}
-	return func(failure *autoDetectionFailure) (SuccessorFailureResolution, error) {
-		if failure == nil {
-			return SuccessorFailureResolution{}, errors.New("job output: nil autodetection failure")
-		}
-		removed := plan.removePlainStock && !failure.coded
-		postimage := plan.postimage
-		resolution := SuccessorFailureResolution{
-			Postimage:        &postimage,
-			AfterGraphCommit: failedDependencyCommit,
-			Cleanup:          plan.failedCleanup,
-		}
-		if removed {
-			resolution.Postimage = nil
-			resolution.AfterGraphCommit = removedDependencyCommit
-			resolution.Cleanup = plan.removedCleanup
-		}
-		if plan.result != nil {
-			resolution.Result = plan.result(failure)
-		}
-		if plan.afterApply != nil {
-			resolution.AfterApply = func() {
-				plan.afterApply(failure)
-			}
-		}
-		return resolution, nil
-	}
-}
-
-// autoDetectionFailureResultFunc builds a successorFailurePlan.result closure
+// autoDetectionFailureResultFunc builds a probeFailurePlan.result closure
 // with a fixed default code and message; the failure's own code overrides the
 // default when present.
 func autoDetectionFailureResultFunc(
@@ -235,7 +270,7 @@ func autoDetectionFailureResultFunc(
 }
 
 // scheduleRetryAfterApply adapts scheduleAutoDetectionRetry into a
-// successorFailurePlan.afterApply closure that reschedules the given config.
+// probeFailurePlan.afterApply closure that reschedules the given config.
 func (dcjc *DynCfgJobController) scheduleRetryAfterApply(config confgroup.Config) func(*autoDetectionFailure) {
 	return func(failure *autoDetectionFailure) {
 		dcjc.scheduleAutoDetectionRetry(config, failure)

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_prepare.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_prepare.go
@@ -96,15 +96,6 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 	if failure.valid {
 		return dcjc.noop(scope, current, permit, failure.result)
 	}
-	if err := dcjc.factory.ValidateConfig(ctx, config); err != nil {
-		return dcjc.noop(
-			scope,
-			current,
-			permit,
-			mustDynCfgMessage(400, err.Error()),
-			dcjc.configStatusCleanup(target.resourceID, dyncfg.Status(record.Status)),
-		)
-	}
 	if record.Status == dyncfg.StatusAccepted.String() {
 		return dcjc.noop(
 			scope,
@@ -141,6 +132,25 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 		Payload: payload,
 	}
 	if record.Status == dyncfg.StatusDisabled.String() {
+		if err := dcjc.factory.ValidateConfig(ctx, config); err != nil {
+			if ctx.Err() != nil || lifecycle.OwnershipRetained(err) {
+				return nil, err
+			}
+			if classifyConstructionError(err) == constructionErrorOperational {
+				return nil, err
+			}
+			code := 400
+			if classifyConstructionError(err) == constructionErrorTransient {
+				code = 503
+			}
+			return dcjc.noop(
+				scope,
+				current,
+				permit,
+				mustDynCfgMessage(code, err.Error()),
+				dcjc.configStatusCleanup(target.resourceID, dyncfg.StatusDisabled),
+			)
+		}
 		cleanup := dcjc.updateCleanup(target, request, oldConfig, postimage, dyncfg.StatusDisabled)
 		return dcjc.prepareMutation(
 			scope,
@@ -158,19 +168,59 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 		if ctx.Err() != nil || lifecycle.OwnershipRetained(err) {
 			return nil, err
 		}
-		return dcjc.noop(
-			scope,
-			current,
-			permit,
-			mustDynCfgMessage(200, err.Error()),
-			dcjc.configStatusCleanup(target.resourceID, dyncfg.Status(record.Status)),
-		)
+		switch classifyConstructionError(err) {
+		case constructionErrorTransient:
+			failedPostimage := postimage
+			failedPostimage.Status = dyncfg.StatusFailed.String()
+			return dcjc.prepareTransientConstructionFailure(
+				scope,
+				current,
+				permit,
+				failedPostimage,
+				mustDynCfgMessage(200, fmt.Sprintf("config update failed: %v", err)),
+				dcjc.updateCleanup(target, request, oldConfig, failedPostimage, dyncfg.StatusFailed),
+				autoDetectionRetryToken{},
+				config,
+				err,
+			)
+		case constructionErrorProposal:
+			return dcjc.noop(
+				scope,
+				current,
+				permit,
+				mustDynCfgMessage(200, err.Error()),
+				dcjc.configStatusCleanup(target.resourceID, dyncfg.Status(record.Status)),
+			)
+		default:
+			return nil, err
+		}
 	}
 	postimage.Status = dyncfg.StatusRunning.String()
 	cleanup := dcjc.updateCleanup(target, request, oldConfig, postimage, dyncfg.StatusRunning)
 	failedPostimage := postimage
 	failedPostimage.Status = dyncfg.StatusFailed.String()
 	failedCleanup := dcjc.updateCleanup(target, request, oldConfig, failedPostimage, dyncfg.StatusFailed)
+	probeFailure, err := dcjc.factory.Probe(ctx, successor)
+	if err != nil {
+		return nil, err
+	}
+	if probeFailure != nil {
+		return dcjc.prepareProbeFailure(
+			scope,
+			current,
+			permit,
+			autoDetectionRetryToken{},
+			probeFailure,
+			probeFailurePlan{
+				postimage:        failedPostimage,
+				failedCleanup:    failedCleanup,
+				removedCleanup:   dcjc.configDeleteCleanup(dcjc.configID(target.module, target.name)),
+				result:           autoDetectionFailureResultFunc(200, "config update failed: %v"),
+				afterApply:       dcjc.scheduleRetryAfterApply(config),
+				removePlainStock: config.SourceType() == confgroup.TypeStock,
+			},
+		)
+	}
 	return dcjc.prepareMutation(
 		scope,
 		current,
@@ -180,15 +230,6 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 		&postimage,
 		mustDynCfgMessage(200, ""),
 		cleanup,
-		successorFailurePlan{
-			postimage:      failedPostimage,
-			failedCleanup:  failedCleanup,
-			removedCleanup: dcjc.configDeleteCleanup(dcjc.configID(target.module, target.name)),
-			result:         autoDetectionFailureResultFunc(200, "config update failed: %v"),
-			afterApply:     dcjc.scheduleRetryAfterApply(config),
-			removePlainStock: config.SourceType() ==
-				confgroup.TypeStock,
-		},
 	)
 }
 
@@ -275,9 +316,9 @@ func (dcjc *DynCfgJobController) prepareRestart(
 
 // prepareRunningTransition drives the shared enable/restart body: build the
 // successor from the record and, on success, prepare the install/replace
-// mutation to StatusRunning with the standard failure plan. A prepare failure
+// mutation to StatusRunning. A prepare failure
 // that is not context-cancelled or ownership-retained is handed to
-// onPrepareFailure; an apply-time autodetection failure uses the caller's
+// onPrepareFailure; a managed-probe failure uses the caller's
 // command-specific default code unless the collector supplies its own.
 func (dcjc *DynCfgJobController) prepareRunningTransition(
 	ctx context.Context,
@@ -300,10 +341,50 @@ func (dcjc *DynCfgJobController) prepareRunningTransition(
 		if ctx.Err() != nil || lifecycle.OwnershipRetained(err) {
 			return nil, err
 		}
-		return onPrepareFailure(err)
+		switch classifyConstructionError(err) {
+		case constructionErrorTransient:
+			failedPostimage := graphConfig(record, dyncfg.StatusFailed)
+			failure := transientActivationFailure(config, err)
+			return dcjc.prepareTransientConstructionFailure(
+				scope,
+				current,
+				permit,
+				failedPostimage,
+				autoDetectionFailureResultFunc(autoDetectionFailureCode, failureMessage)(failure),
+				dcjc.configStatusCleanup(target.resourceID, dyncfg.StatusFailed),
+				autoDetectionRetryToken{},
+				config,
+				err,
+			)
+		case constructionErrorProposal:
+			return onPrepareFailure(err)
+		default:
+			return nil, err
+		}
 	}
 	postimage := graphConfig(record, dyncfg.StatusRunning)
 	failedPostimage := graphConfig(record, dyncfg.StatusFailed)
+	probeFailure, err := dcjc.factory.Probe(ctx, successor)
+	if err != nil {
+		return nil, err
+	}
+	if probeFailure != nil {
+		return dcjc.prepareProbeFailure(
+			scope,
+			current,
+			permit,
+			autoDetectionRetryToken{},
+			probeFailure,
+			probeFailurePlan{
+				postimage:        failedPostimage,
+				failedCleanup:    dcjc.configStatusCleanup(target.resourceID, dyncfg.StatusFailed),
+				removedCleanup:   dcjc.configDeleteCleanup(dcjc.externalID(target.resourceID)),
+				result:           autoDetectionFailureResultFunc(autoDetectionFailureCode, failureMessage),
+				afterApply:       dcjc.scheduleRetryAfterApply(config),
+				removePlainStock: config.SourceType() == confgroup.TypeStock,
+			},
+		)
+	}
 	return dcjc.prepareMutation(
 		scope,
 		current,
@@ -313,15 +394,6 @@ func (dcjc *DynCfgJobController) prepareRunningTransition(
 		&postimage,
 		mustDynCfgMessage(200, ""),
 		dcjc.configStatusCleanup(target.resourceID, dyncfg.StatusRunning),
-		successorFailurePlan{
-			postimage:      failedPostimage,
-			failedCleanup:  dcjc.configStatusCleanup(target.resourceID, dyncfg.StatusFailed),
-			removedCleanup: dcjc.configDeleteCleanup(dcjc.externalID(target.resourceID)),
-			result:         autoDetectionFailureResultFunc(autoDetectionFailureCode, failureMessage),
-			afterApply:     dcjc.scheduleRetryAfterApply(config),
-			removePlainStock: config.SourceType() ==
-				confgroup.TypeStock,
-		},
 	)
 }
 

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_request.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_request.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
@@ -124,7 +125,7 @@ func (dcjc *DynCfgJobController) parseConfig(
 	if config == nil {
 		return nil, newDynCfgFailure(400, "invalid configuration format: payload contains no configuration object")
 	}
-	if !validDynCfgProtocolField(request.CallerSource) {
+	if !netdataapi.ValidSingleQuotedProtocolField(request.CallerSource) {
 		return nil, newDynCfgFailure(400, "invalid Function source")
 	}
 	config.SetProvider(confgroup.TypeDyncfg)

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_request_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_request_test.go
@@ -5,6 +5,7 @@ package joboutput
 import (
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,5 +40,19 @@ func TestDynCfgResolveRequestReportsArgumentErrors(t *testing.T) {
 			})
 			require.Equal(t, test.wantFailure, failure)
 		})
+	}
+}
+
+func TestDynCfgRequestSourceUsesQuotedProtocolGrammar(t *testing.T) {
+	tests := map[string]bool{
+		"safe":          true,
+		"user=test":     true,
+		`trailing\`:     false,
+		`embedded\path`: true,
+		"single'quote":  false,
+		"line\nbreak":   false,
+	}
+	for value, want := range tests {
+		require.Equal(t, want, netdataapi.ValidSingleQuotedProtocolField(value), value)
 	}
 }

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_request_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_request_test.go
@@ -53,6 +53,8 @@ func TestDynCfgRequestSourceUsesQuotedProtocolGrammar(t *testing.T) {
 		"line\nbreak":   false,
 	}
 	for value, want := range tests {
-		require.Equal(t, want, netdataapi.ValidSingleQuotedProtocolField(value), value)
+		t.Run(value, func(t *testing.T) {
+			require.Equal(t, want, netdataapi.ValidSingleQuotedProtocolField(value))
+		})
 	}
 }

--- a/src/go/plugin/agent/jobmgr/joboutput/factory.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/factory.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
@@ -50,17 +51,18 @@ type jobNamedModule interface {
 }
 
 type FactoryConfig struct {
-	PluginName    string                                        // owning plugin name stamped into job config
-	Modules       ModuleCatalog                                 // collector creator registry
-	Tasks         *lifecycle.TaskSupervisor                     // supervisor owning inherited run-loop goroutines
-	Frames        *lifecycle.FrameOwner                         // frame owner used as the collector output sink
-	ConfigModules *ConfigModuleFactory                          // resolved config application and short-lived probes
-	Runtime       runtimecomp.Service                           // V2 runtime service dependency
-	Vnodes        *vnoderegistry.Registry                       // vnode registry for V2 jobs
-	Vnode         func(string) (jobruntime.VnodeSnapshot, bool) // vnode snapshot lookup by name
-	Hooks         JobHooks                                      // handler-lifecycle preparation for Function-bearing jobs
-	Scheduler     *Scheduler                                    // tick/registration scheduler
-	Observer      lifecycle.RuntimeObserver                     // runtime gauge sink
+	PluginName       string                                                            // owning plugin name stamped into job config
+	Modules          ModuleCatalog                                                     // collector creator registry
+	Tasks            *lifecycle.TaskSupervisor                                         // supervisor owning inherited run-loop goroutines
+	Frames           *lifecycle.FrameOwner                                             // frame owner used as the collector output sink
+	ConfigModules    *ConfigModuleFactory                                              // resolved config application and short-lived probes
+	Runtime          runtimecomp.Service                                               // V2 runtime service dependency
+	Vnodes           *vnoderegistry.Registry                                           // vnode registry for V2 jobs
+	Vnode            func(string) (jobruntime.VnodeSnapshot, bool)                     // vnode snapshot lookup by name
+	Hooks            JobHooks                                                          // handler-lifecycle preparation for Function-bearing jobs
+	Scheduler        *Scheduler                                                        // tick/registration scheduler
+	Observer         lifecycle.RuntimeObserver                                         // runtime gauge sink
+	RunWithoutClaims func(context.Context, func(context.Context) error) (error, error) // claim-yield adapter for probes
 }
 
 // Factory owns collector construction, validation, and transfer. It does not
@@ -79,6 +81,9 @@ func NewFactory(config FactoryConfig) (*Factory, error) {
 		config.Scheduler == nil {
 		return nil, errors.New("job output: incomplete factory configuration")
 	}
+	if config.RunWithoutClaims == nil {
+		config.RunWithoutClaims = jobmgr.RunWithoutClaims
+	}
 	return &Factory{
 		config: config,
 	}, nil
@@ -96,7 +101,9 @@ func (f *Factory) ValidateConfig(ctx context.Context, config confgroup.Config) e
 		return err
 	}
 	if config.FunctionOnly() && !creatorDeclaresFunctions(creator) {
-		return fmt.Errorf("job output: function_only is set but module %q declares no Functions", config.Module())
+		return invalidJobConfiguration(
+			fmt.Errorf("job output: function_only is set but module %q declares no Functions", config.Module()),
+		)
 	}
 	if _, err := f.lookupVNode(config); err != nil {
 		return err
@@ -104,7 +111,11 @@ func (f *Factory) ValidateConfig(ctx context.Context, config confgroup.Config) e
 	return f.config.ConfigModules.Validate(ctx, config)
 }
 
-func (f *Factory) build(ctx context.Context, config confgroup.Config, generation uint64) (ConstructedJob, error) {
+func (f *Factory) build(
+	ctx context.Context,
+	config confgroup.Config,
+	generation uint64,
+) (constructed ConstructedJob, resultErr error) {
 	if f == nil || ctx == nil || config == nil || generation == 0 {
 		return ConstructedJob{}, errors.New("job output: invalid factory build")
 	}
@@ -118,9 +129,11 @@ func (f *Factory) build(ctx context.Context, config confgroup.Config, generation
 	functionOnly := creator.FunctionOnly || config.FunctionOnly()
 	hasFunctions := creatorDeclaresFunctions(creator)
 	if functionOnly && !hasFunctions {
-		return ConstructedJob{}, fmt.Errorf(
-			"job output: function_only is set but module %q declares no Functions",
-			config.Module(),
+		return ConstructedJob{}, invalidJobConfiguration(
+			fmt.Errorf(
+				"job output: function_only is set but module %q declares no Functions",
+				config.Module(),
+			),
 		)
 	}
 	vnode, err := f.lookupVNode(config)
@@ -133,26 +146,35 @@ func (f *Factory) build(ctx context.Context, config confgroup.Config, generation
 	}
 	var job RuntimeJob
 	var variant JobVariant
+	var redactLifecycle bool
+	defer func() {
+		if redactLifecycle && resultErr != nil {
+			resultErr = redactResolvedLifecycleError(resultErr)
+		}
+	}()
 	if creator.CreateV2 != nil {
-		job, err = f.buildV2(ctx, config, creator, functionOnly, vnode)
+		job, redactLifecycle, err = f.buildV2(ctx, config, creator, functionOnly, vnode)
 		variant = JobVariantV2
 	} else {
-		job, err = f.buildV1(ctx, config, creator, functionOnly, vnode)
+		job, redactLifecycle, err = f.buildV1(ctx, config, creator, functionOnly, vnode)
 		variant = JobVariantV1
 	}
 	if err != nil {
 		return ConstructedJob{}, err
 	}
 	cleanup := &factoryJobCleanup{
-		job: job,
+		job:    job,
+		redact: redactLifecycle,
 	}
-	constructed, err := newManagedJob(variant, job, f.config.Tasks, identity, f.config.Scheduler, cleanup.reject)
+	constructed, err = newManagedJob(variant, job, f.config.Tasks, identity, f.config.Scheduler, cleanup.reject)
 	if err != nil {
 		return ConstructedJob{
-			Variant:          variant,
-			CollectorCleanup: cleanup.reject,
+			Variant:            variant,
+			CollectorCleanup:   cleanup.reject,
+			resolvedReferences: redactLifecycle,
 		}, err
 	}
+	constructed.resolvedReferences = redactLifecycle
 	if hasFunctions && f.config.Hooks == nil {
 		return constructed, errors.New("job output: function-bearing job has no handler lifecycle")
 	}
@@ -183,9 +205,9 @@ func (f *Factory) Prepare(
 	config confgroup.Config,
 	identity lifecycle.ResourceIdentity,
 	permit lifecycle.LongLivedPermit,
-) (lifecycle.PreparedResource, error) {
+) (PreparedJob, error) {
 	if f == nil || ctx == nil || config == nil || !identity.Valid() || identity.ID != config.FullName() {
-		return nil, errors.New("job output: invalid factory preparation")
+		return PreparedJob{}, errors.New("job output: invalid factory preparation")
 	}
 	return prepareJob(
 		ctx,
@@ -198,10 +220,54 @@ func (f *Factory) Prepare(
 	)
 }
 
+func (f *Factory) Probe(ctx context.Context, prepared PreparedJob) (*autoDetectionFailure, error) {
+	if f == nil || ctx == nil || !prepared.Valid() {
+		return nil, errors.New("job output: invalid factory probe")
+	}
+	var failure *autoDetectionFailure
+	var rejectErr error
+	rejected := false
+	probeErr, claimErr := f.config.RunWithoutClaims(ctx, func(probeParent context.Context) error {
+		err := prepared.Probe(probeParent)
+		if err == nil {
+			return nil
+		}
+		_ = errors.As(err, &failure)
+		rejectErr = prepared.reject(context.WithoutCancel(probeParent))
+		rejected = true
+		return err
+	})
+	if claimErr != nil {
+		if !rejected {
+			rejectErr = prepared.reject(context.WithoutCancel(ctx))
+		}
+		err := errors.Join(claimErr, probeErr, rejectErr)
+		if rejectErr != nil {
+			err = lifecycle.RetainOwnership(err)
+		}
+		return nil, err
+	}
+	if probeErr == nil {
+		return nil, nil
+	}
+	if failure == nil {
+		err := errors.Join(probeErr, rejectErr)
+		if rejectErr != nil {
+			err = lifecycle.RetainOwnership(err)
+		}
+		return nil, err
+	}
+	if rejectErr != nil {
+		return nil, lifecycle.RetainOwnership(errors.Join(probeErr, rejectErr))
+	}
+	return failure, nil
+}
+
 type factoryJobCleanup struct {
-	once sync.Once
-	job  RuntimeJob
-	err  error
+	once   sync.Once
+	job    RuntimeJob
+	redact bool
+	err    error
 }
 
 func (fjc *factoryJobCleanup) reject(context.Context) error {
@@ -210,6 +276,9 @@ func (fjc *factoryJobCleanup) reject(context.Context) error {
 			fjc.job.CleanupRejected()
 			return nil
 		})
+		if fjc.redact {
+			fjc.err = redactResolvedLifecycleError(fjc.err)
+		}
 	})
 	return fjc.err
 }
@@ -220,6 +289,9 @@ func (fjc *factoryJobCleanup) final(context.Context) error {
 			fjc.job.Cleanup()
 			return nil
 		})
+		if fjc.redact {
+			fjc.err = redactResolvedLifecycleError(fjc.err)
+		}
 	})
 	return fjc.err
 }
@@ -244,9 +316,9 @@ func (f *Factory) buildV1(
 	creator collectorapi.Creator,
 	functionOnly bool,
 	vnode jobruntime.VnodeSnapshot,
-) (job RuntimeJob, err error) {
+) (job RuntimeJob, redactLifecycle bool, err error) {
 	if creator.Create == nil {
-		return nil, fmt.Errorf("job output: module %q has no V1 creator", config.Module())
+		return nil, false, fmt.Errorf("job output: module %q has no V1 creator", config.Module())
 	}
 	var module collectorapi.CollectorV1
 	defer func() {
@@ -260,19 +332,26 @@ func (f *Factory) buildV1(
 		}
 		if err != nil && module != nil {
 			cleanupErr := callFactoryModuleCleanup(ctx, module.Cleanup)
+			if redactLifecycle {
+				cleanupErr = redactResolvedLifecycleError(cleanupErr)
+			}
 			err = errors.Join(err, cleanupErr)
 			if cleanupErr != nil {
 				err = lifecycle.RetainOwnership(err)
 			}
 		}
+		if redactLifecycle && err != nil {
+			err = redactResolvedLifecycleError(err)
+		}
 	}()
 	module = creator.Create()
 	if module == nil {
-		return nil, fmt.Errorf("job output: module %q returned a nil V1 collector", config.Module())
+		return nil, false, fmt.Errorf("job output: module %q returned a nil V1 collector", config.Module())
 	}
 	setModuleJobName(module, config.Name())
-	if err := f.config.ConfigModules.applyResolved(ctx, config, module); err != nil {
-		return nil, err
+	redactLifecycle, err = f.config.ConfigModules.applyResolved(ctx, config, module)
+	if err != nil {
+		return nil, redactLifecycle, err
 	}
 	jobConfig := jobruntime.JobConfig{
 		PluginName: f.config.PluginName,
@@ -291,6 +370,9 @@ func (f *Factory) buildV1(
 		IsStock:         config.SourceType() == confgroup.TypeStock,
 		FunctionOnly:    functionOnly,
 	}
+	if redactLifecycle {
+		jobConfig.LifecycleErrorSanitizer = redactResolvedLifecycleError
+	}
 	if vnode.Vnode != nil {
 		jobConfig.Vnode = *vnode.Vnode.Copy()
 		jobConfig.VnodeName = config.Vnode()
@@ -298,7 +380,7 @@ func (f *Factory) buildV1(
 		jobConfig.VnodeMetadataRevision = vnode.MetadataRevision
 		jobConfig.VnodeLookup = f.config.Vnode
 	}
-	return jobruntime.NewJob(jobConfig), nil
+	return jobruntime.NewJob(jobConfig), redactLifecycle, nil
 }
 
 func (f *Factory) buildV2(
@@ -307,7 +389,7 @@ func (f *Factory) buildV2(
 	creator collectorapi.Creator,
 	functionOnly bool,
 	vnode jobruntime.VnodeSnapshot,
-) (job RuntimeJob, err error) {
+) (job RuntimeJob, redactLifecycle bool, err error) {
 	var module collectorapi.CollectorV2
 	defer func() {
 		if recovered := recover(); recovered != nil {
@@ -320,19 +402,26 @@ func (f *Factory) buildV2(
 		}
 		if err != nil && module != nil {
 			cleanupErr := callFactoryModuleCleanup(ctx, module.Cleanup)
+			if redactLifecycle {
+				cleanupErr = redactResolvedLifecycleError(cleanupErr)
+			}
 			err = errors.Join(err, cleanupErr)
 			if cleanupErr != nil {
 				err = lifecycle.RetainOwnership(err)
 			}
 		}
+		if redactLifecycle && err != nil {
+			err = redactResolvedLifecycleError(err)
+		}
 	}()
 	module = creator.CreateV2()
 	if module == nil {
-		return nil, fmt.Errorf("job output: module %q returned a nil V2 collector", config.Module())
+		return nil, false, fmt.Errorf("job output: module %q returned a nil V2 collector", config.Module())
 	}
 	setModuleJobName(module, config.Name())
-	if err := f.config.ConfigModules.applyResolved(ctx, config, module); err != nil {
-		return nil, err
+	redactLifecycle, err = f.config.ConfigModules.applyResolved(ctx, config, module)
+	if err != nil {
+		return nil, redactLifecycle, err
 	}
 	jobConfig := jobruntime.JobV2Config{
 		PluginName: f.config.PluginName,
@@ -352,6 +441,9 @@ func (f *Factory) buildV2(
 		RuntimeService:  f.config.Runtime,
 		VnodeRegistry:   f.config.Vnodes,
 	}
+	if redactLifecycle {
+		jobConfig.LifecycleErrorSanitizer = redactResolvedLifecycleError
+	}
 	if vnode.Vnode != nil {
 		jobConfig.Vnode = *vnode.Vnode.Copy()
 		jobConfig.VnodeName = config.Vnode()
@@ -359,7 +451,7 @@ func (f *Factory) buildV2(
 		jobConfig.VnodeMetadataRevision = vnode.MetadataRevision
 		jobConfig.VnodeLookup = f.config.Vnode
 	}
-	return jobruntime.NewJobV2(jobConfig), nil
+	return jobruntime.NewJobV2(jobConfig), redactLifecycle, nil
 }
 
 func callFactoryModuleCleanup(ctx context.Context, cleanup func(context.Context)) error {
@@ -374,11 +466,15 @@ func (f *Factory) lookupVNode(config confgroup.Config) (jobruntime.VnodeSnapshot
 		return jobruntime.VnodeSnapshot{}, nil
 	}
 	if f.config.Vnode == nil {
-		return jobruntime.VnodeSnapshot{}, fmt.Errorf("job output: vnode %q is unavailable", config.Vnode())
+		return jobruntime.VnodeSnapshot{}, transientJobConstruction(
+			fmt.Errorf("job output: vnode %q is unavailable", config.Vnode()),
+		)
 	}
 	vnode, ok := f.config.Vnode(config.Vnode())
 	if !ok || vnode.Vnode == nil {
-		return jobruntime.VnodeSnapshot{}, fmt.Errorf("job output: vnode %q is not registered", config.Vnode())
+		return jobruntime.VnodeSnapshot{}, transientJobConstruction(
+			fmt.Errorf("job output: vnode %q is not registered", config.Vnode()),
+		)
 	}
 	return vnode, nil
 }
@@ -387,11 +483,13 @@ func validateFactoryConfigIdentity(config confgroup.Config, creator collectorapi
 	if creator.InstancePolicy != collectorapi.InstancePolicySingle || config.Name() == config.Module() {
 		return nil
 	}
-	return fmt.Errorf(
-		"job output: single-instance module %q requires config name %q, got %q",
-		config.Module(),
-		config.Module(),
-		config.Name(),
+	return invalidJobConfiguration(
+		fmt.Errorf(
+			"job output: single-instance module %q requires config name %q, got %q",
+			config.Module(),
+			config.Module(),
+			config.Name(),
+		),
 	)
 }
 

--- a/src/go/plugin/agent/jobmgr/joboutput/factory_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/factory_test.go
@@ -161,7 +161,14 @@ func TestFactoryRejectsWithExactlyOneCollectorCleanup(t *testing.T) {
 				permit,
 			)
 			if err == nil {
-				_, err = prepared.AcceptStart(context.Background(), 1)
+				var failure *autoDetectionFailure
+				failure, err = factory.Probe(context.Background(), prepared)
+				if err == nil && failure != nil {
+					err = errors.Join(failure, permit.Return())
+				}
+				if err == nil {
+					_, err = prepared.AcceptStart(context.Background(), 1)
+				}
 			} else {
 				err = errors.Join(err, permit.AbortUnused())
 			}
@@ -216,7 +223,14 @@ func TestFactoryV2RejectsWithExactlyOneCollectorCleanup(t *testing.T) {
 				permit,
 			)
 			if err == nil {
-				_, err = prepared.AcceptStart(context.Background(), 1)
+				var failure *autoDetectionFailure
+				failure, err = factory.Probe(context.Background(), prepared)
+				if err == nil && failure != nil {
+					err = errors.Join(failure, permit.Return())
+				}
+				if err == nil {
+					_, err = prepared.AcceptStart(context.Background(), 1)
+				}
 			} else {
 				err = errors.Join(err, permit.AbortUnused())
 			}
@@ -229,7 +243,7 @@ func TestFactoryV2RejectsWithExactlyOneCollectorCleanup(t *testing.T) {
 	}
 }
 
-func TestFactoryDefersAutoDetectionUntilPreparedJobAcceptance(t *testing.T) {
+func TestFactoryProbesAndRejectsBeforePreparedJobAcceptance(t *testing.T) {
 	state := &factoryTestState{}
 	creator := collectorapi.Creator{
 		Create: func() collectorapi.CollectorV1 {
@@ -255,12 +269,212 @@ func TestFactoryDefersAutoDetectionUntilPreparedJobAcceptance(t *testing.T) {
 	require.Zero(t, state.autoDetection)
 	require.Zero(t, state.collectorCleanup)
 
-	_, err = prepared.AcceptStart(context.Background(), 1)
-	require.Error(t, err)
+	failure, err := factory.Probe(context.Background(), prepared)
+	require.NoError(t, err)
+	require.Error(t, failure)
+	require.NoError(t, permit.Return())
 	require.EqualValues(t, 1, state.autoDetection)
 	require.EqualValues(t, 1, state.collectorCleanup)
 	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
 
+}
+
+func TestFactoryProbeUsesYieldedContextWithoutInventingDeadline(t *testing.T) {
+	state := &factoryTestState{}
+	probeFailure := errors.New("probe failed")
+	var received context.Context
+	creator := collectorapi.Creator{
+		Create: func() collectorapi.CollectorV1 {
+			return state.module(func(ctx context.Context) error {
+				received = ctx
+				return probeFailure
+			}, false)
+		},
+	}
+	factory, _ := newFactoryTestHarness(t, creator, nil)
+	type contextKey struct{}
+	parent := context.Background()
+	yielded := context.WithValue(parent, contextKey{}, "yielded")
+	factory.config.RunWithoutClaims = func(
+		ctx context.Context,
+		work func(context.Context) error,
+	) (error, error) {
+		require.Equal(t, parent, ctx)
+		return work(yielded), nil
+	}
+	permit, tasks := issueTestJobPermit(t, "module_job", 1)
+	prepared, err := factory.Prepare(
+		parent,
+		factoryTestConfig(false),
+		lifecycle.ResourceIdentity{
+			ID:         "module_job",
+			Generation: 1,
+		},
+		permit,
+	)
+	require.NoError(t, err)
+
+	failure, err := factory.Probe(parent, prepared)
+	require.NoError(t, err)
+	require.ErrorIs(t, failure, probeFailure)
+	require.Equal(t, yielded, received)
+	require.EqualValues(t, "yielded", received.Value(contextKey{}))
+	_, hasDeadline := received.Deadline()
+	require.False(t, hasDeadline)
+	require.EqualValues(t, 1, state.collectorCleanup)
+	require.NoError(t, permit.Return())
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+}
+
+func TestFactoryProbePropagatesCallerCancellation(t *testing.T) {
+	state := &factoryTestState{}
+	cancellation := errors.New("caller canceled")
+	creator := collectorapi.Creator{
+		Create: func() collectorapi.CollectorV1 {
+			return state.module(func(ctx context.Context) error {
+				<-ctx.Done()
+				return context.Cause(ctx)
+			}, false)
+		},
+	}
+	factory, _ := newFactoryTestHarness(t, creator, nil)
+	permit, tasks := issueTestJobPermit(t, "module_job", 1)
+	parent, cancel := context.WithCancelCause(context.Background())
+	cancel(cancellation)
+	prepared, err := factory.Prepare(
+		context.Background(),
+		factoryTestConfig(false),
+		lifecycle.ResourceIdentity{
+			ID:         "module_job",
+			Generation: 1,
+		},
+		permit,
+	)
+	require.NoError(t, err)
+
+	failure, err := factory.Probe(parent, prepared)
+	require.NoError(t, err)
+	require.ErrorIs(t, failure, cancellation)
+	require.EqualValues(t, 1, state.collectorCleanup)
+	require.NoError(t, permit.Return())
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+}
+
+func TestFactoryProbeRejectsFailedCandidateBeforeClaimReacquisition(t *testing.T) {
+	cleanupDuringYield := make(chan bool, 1)
+	yielded := false
+	creator := collectorapi.Creator{
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				CheckFunc: func(context.Context) error {
+					return errors.New("check failed")
+				},
+				CleanupFunc: func(context.Context) {
+					cleanupDuringYield <- yielded
+				},
+			}
+		},
+	}
+	factory, _ := newFactoryTestHarness(t, creator, nil)
+	factory.config.RunWithoutClaims = func(
+		ctx context.Context,
+		work func(context.Context) error,
+	) (error, error) {
+		yielded = true
+		workErr := work(ctx)
+		yielded = false
+		return workErr, nil
+	}
+	permit, tasks := issueTestJobPermit(t, "module_job", 1)
+	prepared, err := factory.Prepare(
+		context.Background(),
+		factoryTestConfig(false),
+		lifecycle.ResourceIdentity{
+			ID:         "module_job",
+			Generation: 1,
+		},
+		permit,
+	)
+	require.NoError(t, err)
+
+	failure, err := factory.Probe(context.Background(), prepared)
+	require.NoError(t, err)
+	require.Error(t, failure)
+	require.True(t, <-cleanupDuringYield)
+	require.NoError(t, permit.Return())
+	require.Equal(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+}
+
+func TestFactoryProbeRedactsResolvedValuesFromCollectorFailure(t *testing.T) {
+	const resolvedFixture = "resolved-sensitive-fixture"
+	for _, variant := range []string{"V1", "V2"} {
+		for _, failureMode := range []string{"error", "panic"} {
+			t.Run(variant+"/"+failureMode, func(t *testing.T) {
+				var module *collectorapi.MockCollectorV1
+				creator := collectorapi.Creator{}
+				if variant == "V1" {
+					creator.Create = func() collectorapi.CollectorV1 {
+						module = &collectorapi.MockCollectorV1{}
+						module.CheckFunc = func(context.Context) error {
+							message := "check exposed " + module.Config.OptionStr
+							if failureMode == "panic" {
+								panic(message)
+							}
+							return errors.New(message)
+						}
+						return module
+					}
+				} else {
+					creator.CreateV2 = func() collectorapi.CollectorV2 {
+						return &factoryTestV2{
+							state:          &factoryTestState{},
+							exposeResolved: true,
+							panicCheck:     failureMode == "panic",
+						}
+					}
+				}
+				factory, _ := newFactoryTestHarness(t, creator, nil)
+				resolver, err := secretresolver.NewAtomicResolver(map[string]secretresolver.AtomicProvider{
+					"fixture": secretresolver.AtomicProviderFunc(
+						func(context.Context, string) ([]byte, error) {
+							return []byte(resolvedFixture), nil
+						},
+					),
+				})
+				require.NoError(t, err)
+				factory.config.ConfigModules.config.Resolver = resolver
+				permit, tasks := issueTestJobPermit(t, "module_job", 1)
+				config := factoryTestConfig(false)
+				config["option_str"] = "${fixture:value}"
+				config["option_int"] = 1
+				prepared, err := factory.Prepare(
+					context.Background(),
+					config,
+					lifecycle.ResourceIdentity{
+						ID:         "module_job",
+						Generation: 1,
+					},
+					permit,
+				)
+				require.NoError(t, err)
+
+				failure, err := factory.Probe(context.Background(), prepared)
+				require.NoError(t, err)
+				require.Error(t, failure)
+				require.NotContains(t, failure.Error(), resolvedFixture)
+				require.Contains(t, failure.Error(), "redacted")
+				require.NoError(t, permit.Return())
+				require.Equal(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+			})
+		}
+	}
+}
+
+func testRunWithoutClaims(
+	ctx context.Context,
+	work func(context.Context) error,
+) (error, error) {
+	return work(ctx), nil
 }
 
 func TestFactorySuccessfulCollectorCleanupIsExactlyOnce(t *testing.T) {
@@ -301,13 +515,25 @@ type factoryTestState struct {
 
 type factoryTestV2 struct {
 	collectorapi.Base
-	state    *factoryTestState
-	checkErr error
+	OptionStr      string `yaml:"option_str"`
+	state          *factoryTestState
+	checkErr       error
+	exposeResolved bool
+	panicCheck     bool
 }
 
 func (*factoryTestV2) Init(context.Context) error { return nil }
 
-func (ft2 *factoryTestV2) Check(context.Context) error { return ft2.checkErr }
+func (ft2 *factoryTestV2) Check(context.Context) error {
+	if ft2.exposeResolved {
+		message := "check exposed " + ft2.OptionStr
+		if ft2.panicCheck {
+			panic(message)
+		}
+		return errors.New(message)
+	}
+	return ft2.checkErr
+}
 
 func (*factoryTestV2) Collect(context.Context) error { return nil }
 
@@ -379,12 +605,13 @@ func newFactoryTestHarness(t *testing.T, creator collectorapi.Creator, hooks Job
 		Modules: collectorapi.Registry{
 			"module": creator,
 		},
-		Tasks:         tasks,
-		Frames:        frames,
-		ConfigModules: configModules,
-		Vnodes:        vnoderegistry.New(),
-		Hooks:         hooks,
-		Scheduler:     newTestScheduler(t),
+		Tasks:            tasks,
+		Frames:           frames,
+		ConfigModules:    configModules,
+		Vnodes:           vnoderegistry.New(),
+		Hooks:            hooks,
+		Scheduler:        newTestScheduler(t),
+		RunWithoutClaims: testRunWithoutClaims,
 	})
 	require.NoError(t, err)
 	return factory, output

--- a/src/go/plugin/agent/jobmgr/joboutput/generation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation.go
@@ -241,7 +241,7 @@ func (pj PreparedJob) Accept(ctx context.Context, generation uint64) (*JobGenera
 	}, nil
 }
 
-func (pj PreparedJob) Probe(ctx context.Context) error {
+func (pj PreparedJob) Probe(ctx context.Context) (result error) {
 	if ctx == nil || pj.state == nil {
 		return errors.New("job output: invalid prepared job probe")
 	}
@@ -259,26 +259,27 @@ func (pj PreparedJob) Probe(ctx context.Context) error {
 	probe := state.constructed.autoDetection
 	state.mu.Unlock()
 
-	var err error
+	defer func() {
+		state.mu.Lock()
+		state.probing = false
+		if result == nil {
+			state.probed = true
+		}
+		state.mu.Unlock()
+	}()
+
 	if probe != nil {
-		err = callJobLifecycle("collector autodetection", func() error {
+		result = callJobLifecycle("collector autodetection", func() error {
 			return probe(ctx)
 		})
 	}
-
-	state.mu.Lock()
-	state.probing = false
-	if err == nil {
-		state.probed = true
-	}
-	state.mu.Unlock()
-	if err == nil {
+	if result == nil {
 		return nil
 	}
 	if state.constructed.resolvedReferences {
-		err = redactResolvedLifecycleError(err)
+		result = redactResolvedLifecycleError(result)
 	}
-	return autoDetectionFailureFor(state.constructed, err)
+	return autoDetectionFailureFor(state.constructed, result)
 }
 
 func (pj PreparedJob) Dispose(ctx context.Context) error {

--- a/src/go/plugin/agent/jobmgr/joboutput/generation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	ErrPreparedJobConsumed   = errors.New("job output: prepared job consumed")
+	ErrPreparedJobUnprobed   = errors.New("job output: prepared job was not probed")
 	ErrJobGenerationMismatch = errors.New("job output: job generation mismatch")
 )
 
@@ -96,10 +97,11 @@ type ConstructedJob struct {
 	Observer           lifecycle.RuntimeObserver   // runtime gauge sink for active-job accounting
 	CollectorCleanup   func(context.Context) error // opaque collector teardown; swapped reject->final on Accept
 	Variant            JobVariant                  // V1 or V2 collector shape
-	autoDetection      func(context.Context) error // managed auto-detection probe run during Accept
+	autoDetection      func(context.Context) error // managed auto-detection probe run before acceptance
 	autoDetectionEvery func() int                  // retry cadence (seconds) reported by the collector
 	finalCleanup       func(context.Context) error // Cleanup() variant installed once the job is accepted
 	retryAutoDetection func() bool                 // whether a failed auto-detection should be rescheduled
+	resolvedReferences bool                        // lifecycle failures may contain resolved secret values
 }
 
 func (cj ConstructedJob) validate() error {
@@ -116,6 +118,8 @@ type PreparedJob struct {
 type preparedJobState struct {
 	mu          sync.Mutex                // guards consumed
 	consumed    bool                      // the prepared job has been taken (accept/dispose/reject)
+	probing     bool                      // managed auto-detection is currently running
+	probed      bool                      // managed auto-detection completed successfully
 	id          string                    // job full name
 	generation  uint64                    // job generation this candidate targets
 	constructed ConstructedJob            // the assembled but not-yet-started job
@@ -224,33 +228,6 @@ func (pj PreparedJob) Accept(ctx context.Context, generation uint64) (*JobGenera
 	if err != nil {
 		return nil, err
 	}
-	if state.constructed.autoDetection != nil {
-		if err := callJobLifecycle("collector autodetection", func() error {
-			return state.constructed.autoDetection(ctx)
-		}); err != nil {
-			failure := &autoDetectionFailure{
-				cause: err,
-			}
-			if state.constructed.retryAutoDetection != nil {
-				failure.retry = state.constructed.retryAutoDetection()
-			}
-			if state.constructed.autoDetectionEvery != nil {
-				failure.retryAfter = state.constructed.autoDetectionEvery()
-			}
-			if coded, ok := errors.AsType[dyncfg.CodedError](err); ok {
-				failure.coded = true
-				failure.code = coded.DyncfgCode()
-				if !dyncfg.IsRetryableError(err) {
-					failure.retry = false
-				}
-			}
-			cleanupErr := disposeConstructed(context.WithoutCancel(ctx), state.constructed, state.permit)
-			if cleanupErr != nil || ctx.Err() != nil {
-				return nil, errors.Join(err, cleanupErr)
-			}
-			return nil, failure
-		}
-	}
 	if state.constructed.finalCleanup != nil {
 		state.constructed.CollectorCleanup = state.constructed.finalCleanup
 	}
@@ -262,6 +239,46 @@ func (pj PreparedJob) Accept(ctx context.Context, generation uint64) (*JobGenera
 		stopDone:   make(chan struct{}),
 		permit:     state.permit,
 	}, nil
+}
+
+func (pj PreparedJob) Probe(ctx context.Context) error {
+	if ctx == nil || pj.state == nil {
+		return errors.New("job output: invalid prepared job probe")
+	}
+	state := pj.state
+	state.mu.Lock()
+	if state.consumed {
+		state.mu.Unlock()
+		return ErrPreparedJobConsumed
+	}
+	if state.probing || state.probed {
+		state.mu.Unlock()
+		return errors.New("job output: prepared job probe already started")
+	}
+	state.probing = true
+	probe := state.constructed.autoDetection
+	state.mu.Unlock()
+
+	var err error
+	if probe != nil {
+		err = callJobLifecycle("collector autodetection", func() error {
+			return probe(ctx)
+		})
+	}
+
+	state.mu.Lock()
+	state.probing = false
+	if err == nil {
+		state.probed = true
+	}
+	state.mu.Unlock()
+	if err == nil {
+		return nil
+	}
+	if state.constructed.resolvedReferences {
+		err = redactResolvedLifecycleError(err)
+	}
+	return autoDetectionFailureFor(state.constructed, err)
 }
 
 func (pj PreparedJob) Dispose(ctx context.Context) error {
@@ -289,6 +306,9 @@ func (pj PreparedJob) validateLivePermit() error {
 	if pj.state.consumed {
 		return ErrPreparedJobConsumed
 	}
+	if pj.state.probing || !pj.state.probed {
+		return ErrPreparedJobUnprobed
+	}
 	return pj.state.permit.ValidateLive()
 }
 
@@ -300,6 +320,9 @@ func (pj PreparedJob) take() (*preparedJobState, error) {
 	defer pj.state.mu.Unlock()
 	if pj.state.consumed {
 		return nil, ErrPreparedJobConsumed
+	}
+	if pj.state.probing {
+		return nil, errors.New("job output: prepared job probe is active")
 	}
 	pj.state.consumed = true
 	return pj.state, nil
@@ -314,11 +337,37 @@ func (pj PreparedJob) takeForGeneration(generation uint64) (*preparedJobState, e
 	if pj.state.consumed {
 		return nil, ErrPreparedJobConsumed
 	}
+	if pj.state.probing {
+		return nil, errors.New("job output: prepared job probe is active")
+	}
 	if generation != pj.state.generation {
 		return nil, ErrJobGenerationMismatch
 	}
+	if !pj.state.probed {
+		return nil, ErrPreparedJobUnprobed
+	}
 	pj.state.consumed = true
 	return pj.state, nil
+}
+
+func autoDetectionFailureFor(constructed ConstructedJob, err error) *autoDetectionFailure {
+	failure := &autoDetectionFailure{
+		cause: err,
+	}
+	if constructed.retryAutoDetection != nil {
+		failure.retry = constructed.retryAutoDetection()
+	}
+	if constructed.autoDetectionEvery != nil {
+		failure.retryAfter = constructed.autoDetectionEvery()
+	}
+	if coded, ok := errors.AsType[dyncfg.CodedError](err); ok {
+		failure.coded = true
+		failure.code = coded.DyncfgCode()
+		if !dyncfg.IsRetryableError(err) {
+			failure.retry = false
+		}
+	}
+	return failure
 }
 
 type JobGeneration struct {
@@ -362,6 +411,9 @@ func (jg *JobGeneration) Start(ctx context.Context) error {
 	if err := callJobLifecycle("runtime Start", func() error {
 		return jg.resources.Runtime.Start(ctx)
 	}); err != nil {
+		if jg.resources.resolvedReferences {
+			err = redactResolvedLifecycleError(err)
+		}
 		cleanupErr := disposeConstructed(context.WithoutCancel(ctx), jg.resources, jg.permit)
 		state := JobAborted
 		if cleanupErr != nil {
@@ -390,6 +442,9 @@ func (jg *JobGeneration) Publish() error {
 	jg.mu.Unlock()
 	if handlers != nil {
 		if err := callJobLifecycle("job publication", handlers.Publish); err != nil {
+			if jg.resources.resolvedReferences {
+				err = redactResolvedLifecycleError(err)
+			}
 			jg.mu.Lock()
 			jg.state = JobReady
 			jg.mu.Unlock()
@@ -472,22 +527,34 @@ func (jg *JobGeneration) Stop(ctx context.Context) error {
 		if err := callJobLifecycle("handler close/drain", func() error {
 			return jg.resources.Handlers.CloseAndDrain(ctx)
 		}); err != nil {
+			if jg.resources.resolvedReferences {
+				err = redactResolvedLifecycleError(err)
+			}
 			return jg.finishStop(JobRetained, err)
 		}
 	}
 	if err := callJobLifecycle("runtime Stop", func() error {
 		return jg.resources.Runtime.Stop(ctx)
 	}); err != nil {
+		if jg.resources.resolvedReferences {
+			err = redactResolvedLifecycleError(err)
+		}
 		return jg.finishStop(JobRetained, err)
 	}
 	if err := callJobLifecycle("runtime post-cleanup release", func() error {
 		return jg.resources.Runtime.ReleaseAfterCleanup(ctx)
 	}); err != nil {
+		if jg.resources.resolvedReferences {
+			err = redactResolvedLifecycleError(err)
+		}
 		return jg.finishStop(JobRetained, err)
 	}
 	if err := callJobLifecycle("collector Cleanup", func() error {
 		return jg.resources.CollectorCleanup(ctx)
 	}); err != nil {
+		if jg.resources.resolvedReferences {
+			err = redactResolvedLifecycleError(err)
+		}
 		return jg.finishStop(JobRetained, err)
 	}
 	if err := callJobLifecycle("job external resource release", func() error {
@@ -576,10 +643,15 @@ func rejectConstructed(ctx context.Context, constructed ConstructedJob, permit l
 	return nil
 }
 
-func cleanupConstructed(ctx context.Context, constructed ConstructedJob) error {
+func cleanupConstructed(ctx context.Context, constructed ConstructedJob) (err error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	defer func() {
+		if constructed.resolvedReferences {
+			err = redactResolvedLifecycleError(err)
+		}
+	}()
 	if constructed.Handlers != nil {
 		if err := callJobLifecycle("handler close/drain", func() error {
 			return constructed.Handlers.CloseAndDrain(ctx)

--- a/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
@@ -136,6 +136,7 @@ func TestJobGenerationV1V2(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
+			require.NoError(t, prepared.Probe(context.Background()))
 			generation, err := prepared.Accept(context.Background(), 7)
 			require.NoError(t, err)
 
@@ -186,6 +187,7 @@ func TestJobGenerationPermitReturnLast(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+	require.NoError(t, prepared.Probe(context.Background()))
 	generation, err := prepared.Accept(context.Background(), 1)
 	require.NoError(t, err)
 
@@ -250,6 +252,7 @@ func TestJobGenerationRetainsAfterIrrecoverableFailure(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
+			require.NoError(t, prepared.Probe(context.Background()))
 			generation, err := prepared.Accept(context.Background(), 1)
 			require.NoError(t, err)
 			startErr := generation.Start(context.Background())

--- a/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
@@ -291,6 +291,60 @@ func TestJobLifecyclePanicsPreserveTaskClassification(t *testing.T) {
 	}
 }
 
+func TestPreparedJobProbeOwnsResourcesThroughFailureClassification(t *testing.T) {
+	events := &jobEventLog{}
+	permit, tasks := issueTestJobPermit(t, "job", 1)
+	retryEntered := make(chan struct{})
+	allowRetry := make(chan struct{})
+	var releaseRetry sync.Once
+	release := func() {
+		releaseRetry.Do(func() {
+			close(allowRetry)
+		})
+	}
+	defer release()
+
+	prepared, err := prepareJob(
+		context.Background(),
+		"job",
+		1,
+		permit,
+		func(context.Context) (ConstructedJob, error) {
+			constructed := testConstructedJob(t, JobVariantV1, events)
+			constructed.autoDetection = func(context.Context) error {
+				return errors.New("probe failed")
+			}
+			constructed.retryAutoDetection = func() bool {
+				close(retryEntered)
+				<-allowRetry
+				return true
+			}
+			return constructed, nil
+		},
+	)
+	require.NoError(t, err)
+
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- prepared.Probe(context.Background())
+	}()
+
+	select {
+	case <-retryEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "probe did not enter failure classification")
+	}
+	disposeErr := prepared.Dispose(context.Background())
+	release()
+	probeErr := <-probeDone
+
+	require.ErrorContains(t, disposeErr, "probe is active")
+	require.ErrorContains(t, probeErr, "probe failed")
+	require.NoError(t, prepared.Dispose(context.Background()))
+	require.Equal(t, []string{"handler-close", "runtime-abort", "collector"}, events.snapshot())
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+}
+
 func BenchmarkBJobFactoryCold(b *testing.B) {
 	for b.Loop() {
 		events := &jobEventLog{}

--- a/src/go/plugin/agent/jobmgr/joboutput/initial.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/initial.go
@@ -96,7 +96,7 @@ func (dcjc *DynCfgJobController) templatePublicationCleanup() lifecycle.TaskClea
 	var payload bytes.Buffer
 	api := netdataapi.New(&payload)
 	for _, name := range names {
-		api.CONFIGCREATE(netdataapi.ConfigOpts{
+		if err := api.TryCONFIGCREATE(netdataapi.ConfigOpts{
 			ID:         dcjc.prefix + name,
 			Status:     dyncfg.StatusAccepted.String(),
 			ConfigType: dyncfg.ConfigTypeTemplate.String(),
@@ -111,7 +111,9 @@ func (dcjc *DynCfgJobController) templatePublicationCleanup() lifecycle.TaskClea
 				dyncfg.CommandTest,
 				dyncfg.CommandUserconfig,
 			),
-		})
+		}); err != nil {
+			return func() error { return err }
+		}
 	}
 	prepared, err := lifecycle.PrepareProtocolFrame(payload.Bytes())
 	if err != nil {

--- a/src/go/plugin/agent/jobmgr/joboutput/secret_redaction.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/secret_redaction.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package joboutput
+
+import (
+	"context"
+	"errors"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+)
+
+var errResolvedLifecycleRedacted = errors.New(
+	"job output: collector lifecycle failed; resolved configuration details redacted",
+)
+
+type redactedResolvedCodedError struct {
+	cause     error
+	code      int
+	retryable bool
+}
+
+func (err *redactedResolvedCodedError) Error() string         { return err.cause.Error() }
+func (err *redactedResolvedCodedError) Unwrap() error         { return err.cause }
+func (err *redactedResolvedCodedError) DyncfgCode() int       { return err.code }
+func (err *redactedResolvedCodedError) DyncfgRetryable() bool { return err.retryable }
+
+type redactedResolvedRetryableError struct {
+	cause error
+}
+
+func (err *redactedResolvedRetryableError) Error() string         { return err.cause.Error() }
+func (err *redactedResolvedRetryableError) Unwrap() error         { return err.cause }
+func (err *redactedResolvedRetryableError) DyncfgRetryable() bool { return true }
+
+func redactResolvedLifecycleError(err error) error {
+	if err == nil {
+		return nil
+	}
+	safe := error(errResolvedLifecycleRedacted)
+	if errors.Is(err, context.Canceled) {
+		safe = errors.Join(safe, context.Canceled)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		safe = errors.Join(safe, context.DeadlineExceeded)
+	}
+	if errors.Is(err, lifecycle.ErrTaskPanic) {
+		safe = errors.Join(safe, lifecycle.ErrTaskPanic)
+	}
+	var resolveErr *secretresolver.AtomicResolveError
+	if errors.As(err, &resolveErr) {
+		safe = &secretresolver.AtomicResolveError{Kind: resolveErr.Kind, Cause: safe}
+	}
+	if coded, ok := errors.AsType[dyncfg.CodedError](err); ok {
+		safe = &redactedResolvedCodedError{
+			cause:     safe,
+			code:      coded.DyncfgCode(),
+			retryable: dyncfg.IsRetryableError(err),
+		}
+	} else if dyncfg.IsRetryableError(err) {
+		safe = &redactedResolvedRetryableError{cause: safe}
+	}
+	var invalid *invalidJobConfigurationError
+	if errors.As(err, &invalid) {
+		safe = invalidJobConfiguration(safe)
+	}
+	var transient *transientJobConstructionError
+	if errors.As(err, &transient) {
+		safe = transientJobConstruction(safe)
+	}
+	if lifecycle.OwnershipRetained(err) {
+		safe = lifecycle.RetainOwnership(safe)
+	}
+	return safe
+}

--- a/src/go/plugin/agent/jobmgr/joboutput/secret_restart.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/secret_restart.go
@@ -63,9 +63,10 @@ func (dcjc *DynCfgJobController) PlanSecretDependentStop(id string) (jobmgr.Work
 		return jobmgr.WorkPlan{}, nil, errors.New("job output: invalid dependent stop")
 	}
 	state := &SecretDependentStop{}
-	// The enclosing secret mutation owns DynCfgJobGraphClaim. Reacquiring it
-	// here would deadlock the nested acknowledged command.
+	// The child declares the parent's job-graph claim so the composite kernel
+	// can verify and inherit the authority.
 	return jobmgr.WorkPlan{
+		Claims:     []string{DynCfgJobGraphClaim},
 		NoResponse: true,
 		Transaction: &jobmgr.ResourceTransactionPlan{
 			ID: id,
@@ -111,7 +112,9 @@ func (dcjc *DynCfgJobController) PlanSecretDependentStart(
 	// The enclosing secret mutation keeps the dependency graph stable through
 	// this acknowledged restart.
 	return jobmgr.WorkPlan{
-		NoResponse: true,
+		Claims:              []string{DynCfgJobGraphClaim},
+		NoResponse:          true,
+		YieldClaimOnPrepare: DynCfgJobGraphClaim,
 		Transaction: &jobmgr.ResourceTransactionPlan{
 			ID:                id,
 			AllocateSuccessor: true,
@@ -156,6 +159,32 @@ func (dcjc *DynCfgJobController) PlanSecretDependentStart(
 				}
 				postimage := graphConfig(record, dyncfg.StatusRunning)
 				failedPostimage := graphConfig(record, dyncfg.StatusFailed)
+				probeFailure, probeErr := dcjc.factory.Probe(ctx, successor)
+				if probeErr != nil {
+					return nil, probeErr
+				}
+				if probeFailure != nil {
+					return dcjc.prepareProbeFailure(
+						scope,
+						nil,
+						permit,
+						autoDetectionRetryToken{},
+						probeFailure,
+						probeFailurePlan{
+							postimage:      failedPostimage,
+							failedCleanup:  dcjc.configStatusCleanup(id, dyncfg.StatusFailed),
+							removedCleanup: dcjc.configDeleteCleanup(dcjc.externalID(id)),
+							result: func(*autoDetectionFailure) lifecycle.SealedResult {
+								return mustDynCfgMessage(204, "")
+							},
+							afterApply: func(failure *autoDetectionFailure) {
+								state.setError(failure.cause)
+								dcjc.scheduleAutoDetectionRetry(cloned, failure)
+							},
+							removePlainStock: cloned.SourceType() == confgroup.TypeStock,
+						},
+					)
+				}
 				return dcjc.prepareMutation(
 					scope,
 					nil,
@@ -165,20 +194,6 @@ func (dcjc *DynCfgJobController) PlanSecretDependentStart(
 					&postimage,
 					mustDynCfgMessage(204, ""),
 					dcjc.configStatusCleanup(id, dyncfg.StatusRunning),
-					successorFailurePlan{
-						postimage:      failedPostimage,
-						failedCleanup:  dcjc.configStatusCleanup(id, dyncfg.StatusFailed),
-						removedCleanup: dcjc.configDeleteCleanup(dcjc.externalID(id)),
-						result: func(*autoDetectionFailure) lifecycle.SealedResult {
-							return mustDynCfgMessage(204, "")
-						},
-						afterApply: func(failure *autoDetectionFailure) {
-							state.setError(failure.cause)
-							dcjc.scheduleAutoDetectionRetry(cloned, failure)
-						},
-						removePlainStock: cloned.SourceType() ==
-							confgroup.TypeStock,
-					},
 				)
 			},
 		},

--- a/src/go/plugin/agent/jobmgr/joboutput/transaction.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/transaction.go
@@ -5,6 +5,7 @@ package joboutput
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
@@ -24,17 +25,6 @@ type ResourceTransactionSpec struct {
 	AfterApply       func()                                   // fires after the whole transaction applies
 	Result           lifecycle.SealedResult                   // sealed dyncfg response for the caller
 	Cleanup          lifecycle.TaskCleanup                    // protocol-frame cleanup emitted on success
-	SuccessorFailure func(                                    // resolves an auto-detection failure into a fallback outcome
-		*autoDetectionFailure,
-	) (SuccessorFailureResolution, error)
-}
-
-type SuccessorFailureResolution struct {
-	Postimage        *dyncfg.GraphConfig    // graph postimage to commit (nil = remove)
-	AfterGraphCommit func()                 // fires after the graph commit
-	AfterApply       func()                 // fires after apply (e.g. schedule a retry)
-	Result           lifecycle.SealedResult // sealed dyncfg response
-	Cleanup          lifecycle.TaskCleanup  // protocol-frame cleanup
 }
 
 func resourceRemovalDisposition(current lifecycle.ReadyResource) lifecycle.ResourceTransactionDisposition {
@@ -220,9 +210,31 @@ func (prt *PreparedResourceTransaction) Apply(
 		return lifecycle.AppliedResourceTransaction{}, err
 	}
 	mutationOwned := spec.Graph != nil && spec.MutationPrepared
+	ownershipDisposition := lifecycle.ResourceTransactionUnchanged
+	ownershipCurrent := spec.Current
+	appliedSealed := false
 	defer func() {
+		if recovered := recover(); recovered != nil {
+			resultErr = errors.Join(
+				resultErr,
+				fmt.Errorf("%w in prepared resource transaction apply: %v", lifecycle.ErrTaskPanic, recovered),
+			)
+		}
 		if mutationOwned {
 			resultErr = errors.Join(resultErr, spec.Graph.Abort(spec.Mutation))
+		}
+		if resultErr != nil && !appliedSealed {
+			failed, ownershipErr := lifecycle.NewAppliedResourceTransaction(
+				spec.Scope,
+				ownershipDisposition,
+				ownershipCurrent,
+				spec.Result,
+				spec.Cleanup,
+			)
+			resultErr = errors.Join(resultErr, ownershipErr)
+			if ownershipErr == nil {
+				applied = failed
+			}
 		}
 	}()
 	if ctx == nil {
@@ -232,24 +244,35 @@ func (prt *PreparedResourceTransaction) Apply(
 	switch spec.Disposition {
 	case lifecycle.ResourceTransactionUnchanged,
 		lifecycle.ResourceTransactionInstalled:
-	case lifecycle.ResourceTransactionRemoved,
-		lifecycle.ResourceTransactionReplaced:
+	case lifecycle.ResourceTransactionRemoved:
+		if spec.UnusedPermit.Valid() {
+			if err := spec.UnusedPermit.AbortUnused(); err != nil {
+				return lifecycle.AppliedResourceTransaction{}, err
+			}
+		}
 		if err := spec.Current.Stop(ctx); err != nil {
 			return lifecycle.AppliedResourceTransaction{}, err
 		}
 		if err := spec.Current.Finalize(); err != nil {
 			return lifecycle.AppliedResourceTransaction{}, err
 		}
+		ownershipCurrent = nil
+		ownershipDisposition = lifecycle.ResourceTransactionRemoved
+	case lifecycle.ResourceTransactionReplaced:
+		if err := spec.Current.Stop(ctx); err != nil {
+			return lifecycle.AppliedResourceTransaction{}, err
+		}
+		if err := spec.Current.Finalize(); err != nil {
+			return lifecycle.AppliedResourceTransaction{}, err
+		}
+		ownershipCurrent = nil
+		ownershipDisposition = lifecycle.ResourceTransactionRemoved
 	default:
 		return lifecycle.AppliedResourceTransaction{}, errors.New("job output: invalid transaction disposition")
 	}
 
 	var current lifecycle.ReadyResource
 	disposition := spec.Disposition
-	result := spec.Result
-	cleanup := spec.Cleanup
-	afterApply := spec.AfterApply
-	graphCommitted := false
 	switch spec.Disposition {
 	case lifecycle.ResourceTransactionUnchanged:
 		if spec.UnusedPermit.Valid() {
@@ -261,52 +284,16 @@ func (prt *PreparedResourceTransaction) Apply(
 	case lifecycle.ResourceTransactionInstalled,
 		lifecycle.ResourceTransactionReplaced:
 		current, err = spec.Successor.AcceptStart(ctx, spec.Scope.Successor.Generation)
+		if current != nil {
+			ownershipCurrent = current
+			ownershipDisposition = spec.Disposition
+		}
 		if err != nil {
-			var failure *autoDetectionFailure
-			if !errors.As(err, &failure) || spec.SuccessorFailure == nil {
-				return lifecycle.AppliedResourceTransaction{}, err
-			}
-			if spec.Graph != nil && spec.MutationPrepared {
-				if abortErr := spec.Graph.Abort(spec.Mutation); abortErr != nil {
-					return lifecycle.AppliedResourceTransaction{}, errors.Join(err, abortErr)
-				}
-				mutationOwned = false
-			}
-			resolution, resolveErr := spec.SuccessorFailure(failure)
-			if resolveErr != nil {
-				return lifecycle.AppliedResourceTransaction{}, errors.Join(err, resolveErr)
-			}
-			if resolution.Cleanup == nil {
-				return lifecycle.AppliedResourceTransaction{},
-					errors.Join(err, errors.New("job output: autodetection failure has no cleanup"))
-			}
-			if spec.Graph != nil {
-				mutation, prepareErr := spec.Graph.PrepareMutation(
-					[]dyncfg.GraphChange{{ID: spec.Scope.ID, Config: resolution.Postimage}},
-				)
-				if errors.Is(prepareErr, dyncfg.ErrGraphNoChange) {
-					graphCommitted = true
-				} else if prepareErr != nil {
-					return lifecycle.AppliedResourceTransaction{}, errors.Join(err, prepareErr)
-				} else {
-					if commitErr := commitGraphMutation(spec.Graph, mutation); commitErr != nil {
-						return lifecycle.AppliedResourceTransaction{}, errors.Join(err, commitErr)
-					}
-					graphCommitted = true
-					if resolution.AfterGraphCommit != nil {
-						resolution.AfterGraphCommit()
-					}
-				}
-			}
-			if spec.Scope.Current.Valid() {
-				disposition = lifecycle.ResourceTransactionRemoved
-			} else {
-				disposition = lifecycle.ResourceTransactionUnchanged
-			}
-			result = resolution.Result
-			cleanup = resolution.Cleanup
-			afterApply = composeAfterApply(afterApply, resolution.AfterApply)
-			break
+			return lifecycle.AppliedResourceTransaction{}, err
+		}
+		if current == nil {
+			return lifecycle.AppliedResourceTransaction{},
+				errors.New("job output: accepted transaction successor is nil")
 		}
 		if err := current.Publish(); err != nil {
 			return lifecycle.AppliedResourceTransaction{}, err
@@ -315,7 +302,7 @@ func (prt *PreparedResourceTransaction) Apply(
 	default:
 		return lifecycle.AppliedResourceTransaction{}, errors.New("job output: invalid transaction disposition")
 	}
-	if spec.Graph != nil && spec.MutationPrepared && !graphCommitted {
+	if spec.Graph != nil && spec.MutationPrepared {
 		mutationOwned = false
 		if err := commitGraphMutation(spec.Graph, spec.Mutation); err != nil {
 			return lifecycle.AppliedResourceTransaction{}, err
@@ -324,12 +311,19 @@ func (prt *PreparedResourceTransaction) Apply(
 			spec.AfterGraphCommit()
 		}
 	}
-	applied, err = lifecycle.NewAppliedResourceTransaction(spec.Scope, disposition, current, result, cleanup)
+	applied, err = lifecycle.NewAppliedResourceTransaction(
+		spec.Scope,
+		disposition,
+		current,
+		spec.Result,
+		spec.Cleanup,
+	)
 	if err != nil {
 		return lifecycle.AppliedResourceTransaction{}, err
 	}
-	if afterApply != nil {
-		afterApply()
+	appliedSealed = true
+	if spec.AfterApply != nil {
+		spec.AfterApply()
 	}
 	return applied, nil
 }
@@ -439,8 +433,7 @@ func validateResourceTransactionSpec(spec ResourceTransactionSpec) error {
 		if spec.Current == nil ||
 			!spec.Scope.Current.Valid() ||
 			spec.Successor != nil ||
-			spec.UnusedPermit.Valid() ||
-			spec.Scope.Successor.Valid() {
+			spec.UnusedPermit.Valid() != spec.Scope.Successor.Valid() {
 			return errors.New("job output: invalid remove transaction")
 		}
 	case lifecycle.ResourceTransactionInstalled:

--- a/src/go/plugin/agent/jobmgr/joboutput/transaction_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/transaction_test.go
@@ -121,6 +121,8 @@ func TestPreparedResourceTransactionCommitsOrRestoresWholePostimage(t *testing.T
 func TestPreparedResourceTransactionAbortsGraphMutationOnPrecommitFailure(t *testing.T) {
 	tests := map[string]struct {
 		configure func(*transactionTestReadyResource, *transactionTestPreparedResource, *transactionTestReadyResource, error)
+		want      lifecycle.ResourceTransactionDisposition
+		successor bool
 	}{
 		"current stop": {
 			configure: func(
@@ -131,6 +133,7 @@ func TestPreparedResourceTransactionAbortsGraphMutationOnPrecommitFailure(t *tes
 			) {
 				current.stopErr = failure
 			},
+			want: lifecycle.ResourceTransactionUnchanged,
 		},
 		"current finalize": {
 			configure: func(
@@ -141,6 +144,7 @@ func TestPreparedResourceTransactionAbortsGraphMutationOnPrecommitFailure(t *tes
 			) {
 				current.finalizeErr = failure
 			},
+			want: lifecycle.ResourceTransactionUnchanged,
 		},
 		"successor accept": {
 			configure: func(
@@ -151,6 +155,8 @@ func TestPreparedResourceTransactionAbortsGraphMutationOnPrecommitFailure(t *tes
 			) {
 				successor.acceptErr = failure
 			},
+			want:      lifecycle.ResourceTransactionReplaced,
+			successor: true,
 		},
 		"successor publish": {
 			configure: func(
@@ -161,6 +167,8 @@ func TestPreparedResourceTransactionAbortsGraphMutationOnPrecommitFailure(t *tes
 			) {
 				successor.publishErr = failure
 			},
+			want:      lifecycle.ResourceTransactionReplaced,
+			successor: true,
 		},
 	}
 	for name, test := range tests {
@@ -208,12 +216,13 @@ func TestPreparedResourceTransactionAbortsGraphMutationOnPrecommitFailure(t *tes
 			require.NoError(t, err)
 			result, err := lifecycle.NewSealedResult(200, "application/json", []byte(`{"accepted":true}`))
 			require.NoError(t, err)
+			transactionScope := lifecycle.ResourceTransactionScope{
+				ID:        "job",
+				Current:   currentIdentity,
+				Successor: successorIdentity,
+			}
 			transaction, err := PrepareResourceTransaction(ResourceTransactionSpec{
-				Scope: lifecycle.ResourceTransactionScope{
-					ID:        "job",
-					Current:   currentIdentity,
-					Successor: successorIdentity,
-				},
+				Scope:            transactionScope,
 				Disposition:      lifecycle.ResourceTransactionReplaced,
 				Current:          current,
 				Successor:        successor,
@@ -225,8 +234,16 @@ func TestPreparedResourceTransactionAbortsGraphMutationOnPrecommitFailure(t *tes
 			})
 			require.NoError(t, err)
 
-			_, err = transaction.Apply(context.Background())
+			applied, err := transaction.Apply(context.Background())
 			require.ErrorIs(t, err, failure)
+			scope, disposition, owned := applied.Ownership()
+			require.Equal(t, transactionScope, scope)
+			require.Equal(t, test.want, disposition)
+			if test.successor {
+				require.Same(t, successorReady, owned)
+			} else {
+				require.Same(t, current, owned)
+			}
 			record, ok := graph.Lookup("job")
 			require.True(t, ok)
 			require.Equal(t, `{"version":1}`, record.Payload())
@@ -286,59 +303,16 @@ func TestPreparedResourceTransactionAbortsGraphMutationOnPanic(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Panics(t, func() {
-		_, _ = transaction.Apply(context.Background())
-	})
+	applied, err := transaction.Apply(context.Background())
+	require.ErrorIs(t, err, lifecycle.ErrTaskPanic)
+	scope, disposition, owned := applied.Ownership()
+	require.Equal(t, lifecycle.ResourceTransactionScope{ID: "job", Successor: successorIdentity}, scope)
+	require.Equal(t, lifecycle.ResourceTransactionUnchanged, disposition)
+	require.Nil(t, owned)
 
 	next, err := graph.PrepareMutation([]dyncfg.GraphChange{change})
 	require.NoError(t, err)
 	require.NoError(t, graph.Abort(next))
-}
-
-func TestPreparedResourceTransactionSettlesBeforeFailureResolution(t *testing.T) {
-	var events []string
-	successorIdentity := lifecycle.ResourceIdentity{
-		ID:         "job",
-		Generation: 1,
-	}
-	successor := &transactionTestPreparedResource{
-		identity: successorIdentity,
-		events:   &events,
-		acceptErr: &autoDetectionFailure{
-			cause: errors.New("autodetection failed"),
-		},
-	}
-	result, err := lifecycle.NewSealedResult(422, "application/json", []byte(`{"accepted":false}`))
-	require.NoError(t, err)
-	transaction, err := PrepareResourceTransaction(
-		ResourceTransactionSpec{
-			Scope: lifecycle.ResourceTransactionScope{
-				ID:        "job",
-				Successor: successorIdentity,
-			},
-			Disposition: lifecycle.ResourceTransactionInstalled,
-			Successor:   successor,
-			AfterApply: func() {
-				events = append(events, "settle")
-			},
-			Result:  result,
-			Cleanup: func() error { return nil },
-			SuccessorFailure: func(*autoDetectionFailure) (SuccessorFailureResolution, error) {
-				return SuccessorFailureResolution{
-					Result:  result,
-					Cleanup: func() error { return nil },
-					AfterApply: func() {
-						events = append(events, "resolve")
-					},
-				}, nil
-			},
-		},
-	)
-	require.NoError(t, err)
-
-	_, err = transaction.Apply(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, []string{"successor-accept", "settle", "resolve"}, events)
 }
 
 type transactionTestPreparedResource struct {
@@ -363,7 +337,7 @@ func (ttpr *transactionTestPreparedResource) AcceptStart(
 		panic(ttpr.acceptPanic)
 	}
 	if ttpr.acceptErr != nil {
-		return nil, ttpr.acceptErr
+		return ttpr.ready, ttpr.acceptErr
 	}
 	if expected != ttpr.identity.Generation {
 		return nil, ErrJobGenerationMismatch

--- a/src/go/plugin/agent/jobmgr/kernel.go
+++ b/src/go/plugin/agent/jobmgr/kernel.go
@@ -28,7 +28,7 @@ type submission struct {
 	plan          WorkPlan                // prepared work for the command
 	context       context.Context         // caller context
 	composite     *kernelCompositeScope   // parent composite scope for a child submission
-	rollback      bool                    // submission is a composite rollback
+	recovery      bool                    // submission is a composite recovery continuation
 	controlStatus lifecycle.ControlStatus // pre-decided control status (rejections)
 	result        chan error              // channel released once admitted
 	terminal      chan error              // channel delivering the terminal disposition
@@ -120,6 +120,10 @@ type commandOperation struct {
 	claimWaitPrevious              *commandOperation                  // previous op in the claim wait list
 	claimWaitNext                  *commandOperation                  // next op in the claim wait list
 	claimWaitListed                bool                               // linked into the claim wait list
+	claimReservationKey            *authorityClaimKey                 // yielded key parking this composite before acquisition
+	claimReservationPrevious       *commandOperation                  // previous op in the yielded-key reservation list
+	claimReservationNext           *commandOperation                  // next op in the yielded-key reservation list
+	claimYieldLane                 string                             // borrower resource lane protected by the active yield
 	lane                           *commandLane                       // owning lane
 	previous                       *commandOperation                  // previous op in the lane FIFO
 	next                           *commandOperation                  // next op in the lane FIFO
@@ -154,7 +158,11 @@ type commandOperation struct {
 	fenceChecked                   uint64                             // fence generation last checked against
 	deferredCompletion             *lifecycle.TaskCompletion          // task completion deferred until the op can accept it
 	claimsInherited                bool                               // claims inherited from the parent composite (not self-registered)
-	compositeRollback              bool                               // op is executing a composite rollback
+	claimsYielded                  bool                               // active transaction temporarily released one owned claim
+	claimYieldBorrower             *commandOperation                  // transaction whose preparation borrowed the owner's claim authority
+	claimYieldResult               chan error                         // pending claim-reacquisition acknowledgement
+	claimYieldFence                bool                               // composite fence excludes the temporarily yielded claim
+	compositeRecovery              bool                               // op is executing a composite recovery continuation
 	ownershipChain                 bool                               // part of a protected ownership chain (survives the first shutdown cut)
 	shutdownChild                  bool                               // child spawned during shutdown drain
 }
@@ -166,12 +174,11 @@ type commandLane struct {
 	owners             int                        // refcount of operations currently referencing the lane
 	freeNext           *commandLane               // next recycled lane while on the freelist
 	key                string                     // resource/invocation identity this lane serializes
-	source             lifecycle.Source           // ingress source (JobManager vs Function) that owns the lane
 	head               *commandOperation          // first queued operation (FIFO head)
 	tail               *commandOperation          // last queued operation (FIFO tail)
 	active             *commandOperation          // operation currently dispatched as a task; nil when idle
 	continuationTail   *commandOperation          // insertion anchor for composite child continuations
-	ready              bool                       // lane is enqueued in a ready queue awaiting scheduling
+	readyQueue         *readyQueue                // exact ready queue containing this lane; nil when not queued
 	readyPrev          *commandLane               // previous lane in the ready queue
 	readyNext          *commandLane               // next lane in the ready queue
 	allPrevious        *commandLane               // previous lane in the all-lanes list
@@ -223,6 +230,7 @@ type CommandKernel struct {
 	functionCleanupRequests  map[lifecycle.TaskRequestRef]FunctionCleanupRef // in-flight Function cleanup requests by request ref
 	functionCleanupBacklog   functionCleanupQueue                            // queued Function cleanup work awaiting dispatch
 	functionMutations        chan functionMutationSubmission                 // inbound Function catalog mutation submissions
+	claimYields              chan claimYieldRequest                          // task-child claim release/reacquire requests
 	functionMutationStopped  chan struct{}                                   // closed when mutation ingress is drained
 	functionMutation         functionMutationSubmission                      // the mutation currently being applied
 	functionMutationActive   bool                                            // a catalog mutation is in progress
@@ -266,6 +274,7 @@ type CommandKernel struct {
 	shutdownPhase            commandShutdownPhase                            // current shutdown phase
 	shutdownCancelCursor     *commandOperation                               // cursor sweeping operations to cancel during shutdown
 	ownershipChains          int                                             // count of protected ownership chains still running
+	abandoned                lifecycle.TaskAbandonmentCensus                 // dirty-run outcomes explicitly forfeited to join children
 	shutdownLaneCursor       *commandLane                                    // cursor sweeping lanes to stop during shutdown
 	functionCatalog          FunctionCatalogPort                             // Function catalog port (routing + lifecycle drain)
 	runtimeObserver          lifecycle.RuntimeObserver                       // sink for jobmgr.runtime metric atomics
@@ -313,6 +322,7 @@ func NewCommandKernel(
 		shutdownRequests:        make(map[lifecycle.TaskRequestRef]*commandLane),
 		shutdownTasks:           make(map[lifecycle.TaskRef]*commandLane),
 		functionMutations:       make(chan functionMutationSubmission),
+		claimYields:             make(chan claimYieldRequest, lifecycle.TaskStartServiceQuantum),
 		functionMutationStopped: make(chan struct{}),
 		lanes:                   make(map[commandLaneKey]*commandLane),
 		compositeFenceClaims:    make(map[string]int),
@@ -429,7 +439,11 @@ func (ck *CommandKernel) beginResultEncode(operation *commandOperation, ref life
 	}
 	operation.resultExpiry = expiry
 	if err := ck.sendEncodeAction(operation); err != nil {
-		ck.run.Dirty(err)
+		sequence := uint8(2)
+		if operation.plan.Transaction != nil {
+			sequence = 3
+		}
+		ck.failTaskClosed(operation, ref, sequence, err)
 	}
 	return true
 }
@@ -451,6 +465,10 @@ func (ck *CommandKernel) completeTask(completion lifecycle.TaskCompletion) {
 				completion.Err,
 				errors.New("jobmgr kernel: invalid Function cleanup completion"),
 			)
+			cleanup.err = completion.Err
+			ck.functionCleanupTasks[completion.Ref] = cleanup
+			ck.abandonTask(completion.Ref, completion.Sequence+1, completion.Err)
+			return
 		}
 		cleanup.err = completion.Err
 		ck.functionCleanupTasks[completion.Ref] = cleanup
@@ -459,7 +477,7 @@ func (ck *CommandKernel) completeTask(completion lifecycle.TaskCompletion) {
 			Sequence: 2,
 			Kind:     lifecycle.TaskActionTerminate,
 		}); err != nil {
-			ck.run.Dirty(err)
+			ck.abandonTask(completion.Ref, 2, err)
 		}
 		return
 	}
@@ -478,7 +496,12 @@ func (ck *CommandKernel) completeTask(completion lifecycle.TaskCompletion) {
 	}
 	if operation.composite != nil && operation.activeChild != nil {
 		if operation.deferredCompletion != nil {
-			ck.run.Dirty(errors.New("jobmgr composite: parent completed twice with a live child"))
+			ck.failTaskClosed(
+				operation,
+				completion.Ref,
+				completion.Sequence+1,
+				errors.New("jobmgr composite: parent completed twice with a live child"),
+			)
 			return
 		}
 		pending := completion
@@ -486,7 +509,7 @@ func (ck *CommandKernel) completeTask(completion lifecycle.TaskCompletion) {
 		return
 	}
 	if _, err := ck.tasks.ClearRetainedTimeout(operation.Task); err != nil {
-		ck.run.Dirty(err)
+		ck.failTaskClosed(operation, completion.Ref, completion.Sequence+1, err)
 		return
 	}
 	var resultErr error
@@ -496,7 +519,7 @@ func (ck *CommandKernel) completeTask(completion lifecycle.TaskCompletion) {
 		resultErr = operation.ResultReady(completion.Ref, completion.Sequence)
 	}
 	if resultErr != nil {
-		ck.run.Dirty(resultErr)
+		ck.failTaskClosed(operation, completion.Ref, completion.Sequence+1, resultErr)
 		return
 	}
 	ck.markOperationDeadlineIfDue(operation)
@@ -519,13 +542,14 @@ func (ck *CommandKernel) completeTask(completion lifecycle.TaskCompletion) {
 		status := lifecycle.ControlUnavailable
 		if errors.Is(completion.Err, lifecycle.ErrFunctionResultTooLarge) {
 			status = lifecycle.ControlPayloadTooLarge
-		} else if errors.Is(completion.Err, lifecycle.ErrTaskPanic) {
+		} else if errors.Is(completion.Err, lifecycle.ErrTaskPanic) ||
+			errors.Is(completion.Err, lifecycle.ErrUnsafeFunctionResult) {
 			status = lifecycle.ControlInternal
 		}
 		ck.enqueueControl(operation, status)
 	}
 	if err := ck.sendOperationAction(operation, action); err != nil {
-		ck.run.Dirty(err)
+		ck.failTaskClosed(operation, action.Ref, action.Sequence, err)
 	}
 }
 
@@ -542,7 +566,7 @@ func (ck *CommandKernel) completeResourceTransactionTask(
 				operation.transactionScope,
 			)
 			if err != nil {
-				ck.run.Dirty(errors.Join(
+				ck.failTaskClosed(operation, completion.Ref, completion.Sequence+1, errors.Join(
 					errors.New("jobmgr kernel: failed transaction preparation lost current resource"),
 					completion.Err,
 					err,
@@ -550,7 +574,12 @@ func (ck *CommandKernel) completeResourceTransactionTask(
 				return
 			}
 			if err := ck.restoreTransactionCurrent(operation, current); err != nil {
-				ck.run.Dirty(errors.Join(completion.Err, err))
+				ck.failTaskClosed(
+					operation,
+					completion.Ref,
+					completion.Sequence+1,
+					errors.Join(completion.Err, err),
+				)
 				return
 			}
 			if lifecycle.OwnershipRetained(completion.Err) {
@@ -570,7 +599,12 @@ func (ck *CommandKernel) completeResourceTransactionTask(
 			return
 		}
 		if completion.Kind != lifecycle.TaskOutcomePreparedResourceTransaction {
-			ck.run.Dirty(errors.New("jobmgr kernel: transaction preparation returned the wrong outcome"))
+			ck.failTaskClosed(
+				operation,
+				completion.Ref,
+				completion.Sequence+1,
+				errors.New("jobmgr kernel: transaction preparation returned the wrong outcome"),
+			)
 			return
 		}
 		ownershipAllowed := ck.ownershipActionAllowed(operation)
@@ -591,25 +625,55 @@ func (ck *CommandKernel) completeResourceTransactionTask(
 		ck.sendTransactionAction(operation, completion.Ref, completion.Sequence+1, action)
 	case 2:
 		if completion.Err != nil {
-			operation.terminalErr = errors.Join(operation.terminalErr, completion.Err)
-			ck.run.Dirty(errors.Join(
+			if completion.Kind == lifecycle.TaskOutcomeAppliedResourceTransaction {
+				disposition, current, err := ck.tasks.TakeAppliedResourceTransaction(
+					completion.Ref,
+					completion.Sequence,
+					operation.transactionScope,
+				)
+				if err == nil {
+					err = ck.applyTransactionDisposition(operation, disposition, current)
+				}
+				if err == nil {
+					operation.transactionApplied = true
+					ck.recordAbandonment(operation.request.LaneKey, completion.Ref, lifecycle.TaskAbandonment{
+						Outcome: lifecycle.TaskOutcomeAppliedResourceTransaction,
+					})
+				} else if current != nil {
+					ck.recordAbandonment(operation.request.LaneKey, completion.Ref, lifecycle.TaskAbandonment{
+						Outcome: lifecycle.TaskOutcomeReadyResource,
+					})
+				}
+				completion.Err = errors.Join(completion.Err, err)
+			}
+			ck.failTaskClosed(operation, completion.Ref, completion.Sequence+1, errors.Join(
 				errors.New("jobmgr kernel: resource transaction apply left unprovable state"),
 				completion.Err,
 			))
 			return
 		}
 		if completion.Kind != lifecycle.TaskOutcomeAppliedResourceTransaction {
-			ck.run.Dirty(errors.New("jobmgr kernel: transaction apply returned the wrong outcome"))
+			ck.failTaskClosed(
+				operation,
+				completion.Ref,
+				completion.Sequence+1,
+				errors.New("jobmgr kernel: transaction apply returned the wrong outcome"),
+			)
 			return
 		}
 		disposition, current, err :=
 			ck.tasks.TakeAppliedResourceTransaction(completion.Ref, completion.Sequence, operation.transactionScope)
 		if err != nil {
-			ck.run.Dirty(err)
+			ck.failTaskClosed(operation, completion.Ref, completion.Sequence+1, err)
 			return
 		}
 		if err := ck.applyTransactionDisposition(operation, disposition, current); err != nil {
-			ck.run.Dirty(err)
+			if current != nil {
+				ck.recordAbandonment(operation.request.LaneKey, completion.Ref, lifecycle.TaskAbandonment{
+					Outcome: lifecycle.TaskOutcomeReadyResource,
+				})
+			}
+			ck.failTaskClosed(operation, completion.Ref, completion.Sequence+1, err)
 			return
 		}
 		operation.transactionApplied = true
@@ -622,7 +686,12 @@ func (ck *CommandKernel) completeResourceTransactionTask(
 		}
 		ck.sendTransactionAction(operation, completion.Ref, completion.Sequence+1, lifecycle.TaskActionDispose)
 	default:
-		ck.run.Dirty(errors.New("jobmgr kernel: unexpected transaction completion"))
+		ck.failTaskClosed(
+			operation,
+			completion.Ref,
+			completion.Sequence+1,
+			errors.New("jobmgr kernel: unexpected transaction completion"),
+		)
 	}
 }
 
@@ -638,7 +707,7 @@ func (ck *CommandKernel) sendTransactionAction(
 		Kind:     kind,
 	}
 	if err := ck.sendOperationAction(operation, action); err != nil {
-		ck.run.Dirty(err)
+		ck.failTaskClosed(operation, action.Ref, action.Sequence, err)
 	}
 }
 
@@ -664,6 +733,50 @@ func (ck *CommandKernel) sendOperationAction(operation *commandOperation, action
 		ck.ownershipChains++
 	}
 	return ck.tasks.SendAction(action)
+}
+
+func (ck *CommandKernel) failTaskClosed(
+	operation *commandOperation,
+	ref lifecycle.TaskRef,
+	sequence uint8,
+	cause error,
+) {
+	if cause == nil {
+		cause = errors.New("jobmgr kernel: task failed closed without a cause")
+	}
+	ck.run.Dirty(cause)
+	if operation == nil || !ref.Valid() {
+		return
+	}
+	operation.terminalErr = errors.Join(operation.terminalErr, cause)
+	operation.PoisonResponse()
+	ck.observe(DiagnosticEvent{
+		Level:      DiagnosticError,
+		Name:       "job manager task abandoned after dirty failure",
+		Resource:   operation.LaneKey,
+		State:      "dirty-abandon",
+		Generation: ck.run.Generation(),
+		Task:       ref,
+		Sequence:   sequence,
+		Err:        cause,
+	})
+	if err := operation.AbandonChild(ref, sequence); err != nil {
+		ck.run.Dirty(errors.Join(cause, err))
+		return
+	}
+	if err := ck.tasks.Abandon(ref, sequence); err != nil {
+		ck.run.Dirty(errors.Join(cause, err))
+	}
+}
+
+func (ck *CommandKernel) abandonTask(ref lifecycle.TaskRef, sequence uint8, cause error) {
+	if cause == nil {
+		cause = errors.New("jobmgr kernel: task abandoned without a cause")
+	}
+	ck.run.Dirty(cause)
+	if err := ck.tasks.Abandon(ref, sequence); err != nil {
+		ck.run.Dirty(errors.Join(cause, err))
+	}
 }
 
 func (ck *CommandKernel) ownershipActionAllowed(operation *commandOperation) bool {
@@ -785,15 +898,25 @@ func (ck *CommandKernel) completeShutdownTask(completion lifecycle.TaskCompletio
 	lane := ck.shutdownTasks[completion.Ref]
 	if lane == nil || lane.shutdownTask != completion.Ref || lane.shutdownAction != 0 || completion.Sequence != 1 ||
 		!lane.currentStopping || lane.current != nil || !lane.currentIdentity.Valid() || lane.retiringIdentity.Valid() {
-		ck.run.Dirty(errors.New("jobmgr kernel: completion for unknown or invalid shutdown task"))
+		cause := errors.New("jobmgr kernel: completion for unknown or invalid shutdown task")
+		if lane != nil {
+			ck.abandonShutdownTask(lane, completion.Ref, completion.Sequence+1, cause)
+		} else {
+			ck.run.Dirty(cause)
+		}
 		return
 	}
 	if completion.Err != nil {
-		ck.run.Dirty(completion.Err)
+		ck.abandonShutdownTask(lane, completion.Ref, completion.Sequence+1, completion.Err)
 		return
 	}
 	if completion.Kind != lifecycle.TaskOutcomeReadyResource {
-		ck.run.Dirty(errors.New("jobmgr kernel: shutdown Stop task returned the wrong outcome"))
+		ck.abandonShutdownTask(
+			lane,
+			completion.Ref,
+			completion.Sequence+1,
+			errors.New("jobmgr kernel: shutdown Stop task returned the wrong outcome"),
+		)
 		return
 	}
 	ck.sendShutdownAction(lane, lifecycle.TaskActionStopResource, 2)
@@ -809,6 +932,23 @@ func (ck *CommandKernel) acknowledgeShutdownTask(ack lifecycle.TaskAcknowledgeme
 		ck.run.Dirty(errors.New("jobmgr kernel: acknowledgement for unknown or invalid shutdown task"))
 		return
 	}
+	if ack.Kind == lifecycle.TaskActionAbandon {
+		ck.recordAbandonment(lane.key, ack.Ref, ack.Abandoned)
+		if err := ck.tasks.Release(ack.Ref); err != nil {
+			ck.run.Dirty(errors.Join(ack.Err, err))
+			return
+		}
+		delete(ck.shutdownTasks, ack.Ref)
+		lane.shutdownTask = lifecycle.TaskRef{}
+		lane.shutdownAction = 0
+		lane.current = nil
+		lane.currentIdentity = lifecycle.ResourceIdentity{}
+		lane.currentStopping = false
+		lane.retiringIdentity = lifecycle.ResourceIdentity{}
+		lane.resourceSource = 0
+		ck.releaseUnusedLane(lane)
+		return
+	}
 	wantSequence := uint8(0)
 	switch ack.Kind {
 	case lifecycle.TaskActionStopResource:
@@ -822,11 +962,16 @@ func (ck *CommandKernel) acknowledgeShutdownTask(ack lifecycle.TaskAcknowledgeme
 		return
 	}
 	if ack.Sequence != wantSequence {
-		ck.run.Dirty(errors.New("jobmgr kernel: stale shutdown task acknowledgement"))
+		ck.abandonShutdownTask(
+			lane,
+			ack.Ref,
+			ack.Sequence+1,
+			errors.New("jobmgr kernel: stale shutdown task acknowledgement"),
+		)
 		return
 	}
 	if ack.Err != nil && ack.Kind != lifecycle.TaskActionTerminate {
-		ck.run.Dirty(ack.Err)
+		ck.abandonShutdownTask(lane, ack.Ref, ack.Sequence+1, ack.Err)
 		return
 	}
 	lane.shutdownAction = 0
@@ -834,7 +979,12 @@ func (ck *CommandKernel) acknowledgeShutdownTask(ack lifecycle.TaskAcknowledgeme
 	case lifecycle.TaskActionStopResource:
 		identity := lane.currentIdentity
 		if !lane.currentStopping || lane.current != nil || !identity.Valid() || lane.retiringIdentity.Valid() {
-			ck.run.Dirty(errors.New("jobmgr kernel: shutdown stopped resource differs from current slot"))
+			ck.abandonShutdownTask(
+				lane,
+				ack.Ref,
+				ack.Sequence+1,
+				errors.New("jobmgr kernel: shutdown stopped resource differs from current slot"),
+			)
 			return
 		}
 		lane.currentIdentity = lifecycle.ResourceIdentity{}
@@ -844,7 +994,12 @@ func (ck *CommandKernel) acknowledgeShutdownTask(ack lifecycle.TaskAcknowledgeme
 	case lifecycle.TaskActionFinalizeResource:
 		if lane.current != nil || lane.currentIdentity.Valid() || lane.currentStopping ||
 			!lane.retiringIdentity.Valid() {
-			ck.run.Dirty(errors.New("jobmgr kernel: shutdown finalized resource differs from retiring slot"))
+			ck.abandonShutdownTask(
+				lane,
+				ack.Ref,
+				ack.Sequence+1,
+				errors.New("jobmgr kernel: shutdown finalized resource differs from retiring slot"),
+			)
 			return
 		}
 		lane.retiringIdentity = lifecycle.ResourceIdentity{}
@@ -880,7 +1035,26 @@ func (ck *CommandKernel) sendShutdownAction(lane *commandLane, kind lifecycle.Ta
 			Kind:     kind,
 		},
 	); err != nil {
-		ck.run.Dirty(err)
+		ck.abandonShutdownTask(lane, lane.shutdownTask, sequence, err)
+	}
+}
+
+func (ck *CommandKernel) abandonShutdownTask(
+	lane *commandLane,
+	ref lifecycle.TaskRef,
+	sequence uint8,
+	cause error,
+) {
+	if cause == nil {
+		cause = errors.New("jobmgr kernel: shutdown task abandoned without a cause")
+	}
+	ck.run.Dirty(cause)
+	if lane == nil || lane.shutdownTask != ref {
+		return
+	}
+	lane.shutdownAction = lifecycle.TaskActionAbandon
+	if err := ck.tasks.Abandon(ref, sequence); err != nil {
+		ck.run.Dirty(errors.Join(cause, err))
 	}
 }
 
@@ -910,9 +1084,13 @@ func (ck *CommandKernel) sendEncodeAction(operation *commandOperation) error {
 
 func (ck *CommandKernel) acknowledgeTask(ack lifecycle.TaskAcknowledgement) {
 	if cleanup, ok := ck.functionCleanupTasks[ack.Ref]; ok {
-		if ack.Kind != lifecycle.TaskActionTerminate || ack.Sequence != 2 {
+		if (ack.Kind != lifecycle.TaskActionTerminate && ack.Kind != lifecycle.TaskActionAbandon) ||
+			ack.Sequence != 2 {
 			ck.run.Dirty(errors.New("jobmgr kernel: invalid Function cleanup acknowledgement"))
 			return
+		}
+		if ack.Kind == lifecycle.TaskActionAbandon {
+			ck.recordAbandonment("function-cleanup", ack.Ref, ack.Abandoned)
 		}
 		if err := ck.tasks.Release(ack.Ref); err != nil {
 			ck.run.Dirty(err)
@@ -939,6 +1117,25 @@ func (ck *CommandKernel) acknowledgeTask(ack lifecycle.TaskAcknowledgement) {
 		ck.acknowledgeShutdownTask(ack)
 		return
 	}
+	if ack.Kind == lifecycle.TaskActionAbandon {
+		if err := operation.ChildExited(ack.Ref, ack.Sequence); err != nil {
+			ck.run.Dirty(errors.Join(ack.Err, err))
+			return
+		}
+		ck.recordAbandonment(operation.request.LaneKey, ack.Ref, ack.Abandoned)
+		if operation.plan.Transaction != nil &&
+			!operation.transactionApplied &&
+			!operation.transactionRestored {
+			ck.abandonTransactionOwnership(operation)
+		}
+		if err := ck.tasks.Release(ack.Ref); err != nil {
+			ck.run.Dirty(errors.Join(ack.Err, err))
+			return
+		}
+		delete(ck.tasksByRef, ack.Ref)
+		ck.tryDispose(operation)
+		return
+	}
 	if ack.Kind == lifecycle.TaskActionTerminate {
 		if err := operation.ChildExited(ack.Ref, ack.Sequence); err != nil {
 			ck.run.Dirty(err)
@@ -958,7 +1155,7 @@ func (ck *CommandKernel) acknowledgeTask(ack lifecycle.TaskAcknowledgement) {
 	}
 	ck.markOperationDeadlineIfDue(operation)
 	if err := operation.ActionAcknowledged(ack.Ref, ack.Sequence); err != nil {
-		ck.run.Dirty(err)
+		ck.failTaskClosed(operation, ack.Ref, ack.Sequence+1, err)
 		return
 	}
 	if operation.plan.Transaction != nil {
@@ -973,7 +1170,7 @@ func (ck *CommandKernel) acknowledgeTask(ack lifecycle.TaskAcknowledgement) {
 			ck.run.Dirty(err)
 		}
 		if err := ck.completeOperationUID(operation, false); err != nil {
-			ck.run.Dirty(err)
+			ck.failTaskClosed(operation, ack.Ref, ack.Sequence+1, err)
 			return
 		}
 	}
@@ -983,7 +1180,7 @@ func (ck *CommandKernel) acknowledgeTask(ack lifecycle.TaskAcknowledgement) {
 		Kind:     lifecycle.TaskActionTerminate,
 	}
 	if err := ck.sendOperationAction(operation, termination); err != nil {
-		ck.run.Dirty(err)
+		ck.failTaskClosed(operation, termination.Ref, termination.Sequence, err)
 	}
 }
 
@@ -991,23 +1188,33 @@ func (ck *CommandKernel) acknowledgeResourceTransactionTask(
 	operation *commandOperation,
 	ack lifecycle.TaskAcknowledgement,
 ) {
+	if ack.Kind == lifecycle.TaskActionDispose &&
+		!operation.transactionApplied &&
+		!operation.transactionRestored {
+		current, err := ck.tasks.TakeDisposedResourceTransaction(
+			ack.Ref,
+			ack.Sequence,
+			operation.transactionScope,
+		)
+		if err == nil {
+			err = ck.restoreTransactionCurrent(operation, current)
+		}
+		if err != nil {
+			ack.Err = errors.Join(ack.Err, err)
+		}
+	}
 	if ack.Err != nil {
 		operation.terminalErr = errors.Join(operation.terminalErr, ack.Err)
 		if ack.Kind == lifecycle.TaskActionEncodeWrite {
 			operation.PoisonResponse()
 		}
-		ck.run.Dirty(ack.Err)
-		if ack.Kind == lifecycle.TaskActionDispose && !operation.transactionApplied {
-			return
-		}
+		ck.failTaskClosed(operation, ack.Ref, ack.Sequence+1, ack.Err)
+		return
 	}
 
 	switch ack.Kind {
 	case lifecycle.TaskActionDispose:
 		if !operation.transactionApplied {
-			if ack.Err != nil {
-				return
-			}
 			if !operation.transactionRestored {
 				current, err := ck.tasks.TakeDisposedResourceTransaction(
 					ack.Ref,
@@ -1015,11 +1222,11 @@ func (ck *CommandKernel) acknowledgeResourceTransactionTask(
 					operation.transactionScope,
 				)
 				if err != nil {
-					ck.run.Dirty(err)
+					ck.failTaskClosed(operation, ack.Ref, ack.Sequence+1, err)
 					return
 				}
 				if err := ck.restoreTransactionCurrent(operation, current); err != nil {
-					ck.run.Dirty(err)
+					ck.failTaskClosed(operation, ack.Ref, ack.Sequence+1, err)
 					return
 				}
 			}
@@ -1030,18 +1237,23 @@ func (ck *CommandKernel) acknowledgeResourceTransactionTask(
 	case lifecycle.TaskActionEncodeWrite:
 		if ack.Err == nil {
 			if err := operation.CommitResponse(); err != nil {
-				ck.run.Dirty(err)
+				ck.failTaskClosed(operation, ack.Ref, ack.Sequence+1, err)
 				return
 			}
 			if err := ck.completeOperationUID(operation, false); err != nil {
-				ck.run.Dirty(err)
+				ck.failTaskClosed(operation, ack.Ref, ack.Sequence+1, err)
 				return
 			}
 		}
 	case lifecycle.TaskActionCleanup:
 		operation.cleanupDone = true
 	default:
-		ck.run.Dirty(errors.New("jobmgr kernel: unexpected resource transaction acknowledgement"))
+		ck.failTaskClosed(
+			operation,
+			ack.Ref,
+			ack.Sequence+1,
+			errors.New("jobmgr kernel: unexpected resource transaction acknowledgement"),
+		)
 		return
 	}
 
@@ -1052,7 +1264,7 @@ func (ck *CommandKernel) acknowledgeResourceTransactionTask(
 			Kind:     lifecycle.TaskActionCleanup,
 		}
 		if err := ck.sendOperationAction(operation, cleanup); err != nil {
-			ck.run.Dirty(err)
+			ck.failTaskClosed(operation, cleanup.Ref, cleanup.Sequence, err)
 		}
 		return
 	}
@@ -1066,8 +1278,26 @@ func (ck *CommandKernel) sendResourceTermination(operation *commandOperation, re
 		Kind:     lifecycle.TaskActionTerminate,
 	}
 	if err := ck.sendOperationAction(operation, termination); err != nil {
-		ck.run.Dirty(err)
+		ck.failTaskClosed(operation, termination.Ref, termination.Sequence, err)
 	}
+}
+
+func (ck *CommandKernel) abandonTransactionOwnership(operation *commandOperation) {
+	if operation == nil || operation.plan.Transaction == nil ||
+		operation.transactionApplied || operation.transactionRestored {
+		return
+	}
+	lane := operation.lane
+	scope := operation.transactionScope
+	if lane != nil && scope.Current.Valid() &&
+		lane.current == nil &&
+		lane.currentStopping &&
+		lane.currentIdentity == scope.Current {
+		lane.currentIdentity = lifecycle.ResourceIdentity{}
+		lane.currentStopping = false
+		lane.resourceSource = 0
+	}
+	operation.transactionRestored = true
 }
 
 func (ck *CommandKernel) beginShutdown(deadline time.Time) error {
@@ -1259,7 +1489,7 @@ func (ck *CommandKernel) enqueueShutdownStop(lane *commandLane) error {
 	if lane.owners != 0 {
 		return nil
 	}
-	if lane.head != nil || lane.tail != nil || lane.active != nil || lane.ready {
+	if lane.head != nil || lane.tail != nil || lane.active != nil || lane.readyQueue != nil {
 		return errors.New("jobmgr kernel: owner-free resource lane retains operation state")
 	}
 	identity := lane.currentIdentity
@@ -1344,7 +1574,10 @@ func (ck *CommandKernel) completeShutdownBarrier(completion lifecycle.TaskComple
 		ck.shutdownBarrierAction != 0 ||
 		ck.shutdownBarrierDone ||
 		ck.shutdownBarrierFailed {
-		ck.run.Dirty(errors.New("jobmgr kernel: invalid shutdown barrier completion"))
+		cause := errors.New("jobmgr kernel: invalid shutdown barrier completion")
+		ck.shutdownBarrierFailed = true
+		ck.shutdownBarrierAction = lifecycle.TaskActionAbandon
+		ck.abandonTask(completion.Ref, completion.Sequence+1, cause)
 		return
 	}
 	if completion.Err != nil {
@@ -1357,14 +1590,16 @@ func (ck *CommandKernel) completeShutdownBarrier(completion lifecycle.TaskComple
 		Sequence: 2,
 		Kind:     lifecycle.TaskActionTerminate,
 	}); err != nil {
-		ck.run.Dirty(err)
+		ck.shutdownBarrierFailed = true
+		ck.shutdownBarrierAction = lifecycle.TaskActionAbandon
+		ck.abandonTask(completion.Ref, 2, err)
 	}
 }
 
 func (ck *CommandKernel) acknowledgeShutdownBarrier(ack lifecycle.TaskAcknowledgement) {
 	if ack.Sequence != 2 ||
-		ack.Kind != lifecycle.TaskActionTerminate ||
-		ck.shutdownBarrierAction != lifecycle.TaskActionTerminate ||
+		(ack.Kind != lifecycle.TaskActionTerminate && ack.Kind != lifecycle.TaskActionAbandon) ||
+		ck.shutdownBarrierAction != ack.Kind ||
 		ck.shutdownBarrierDone {
 		ck.run.Dirty(errors.New("jobmgr kernel: invalid shutdown barrier acknowledgement"))
 		return
@@ -1372,6 +1607,10 @@ func (ck *CommandKernel) acknowledgeShutdownBarrier(ack lifecycle.TaskAcknowledg
 	if ack.Err != nil {
 		ck.shutdownBarrierFailed = true
 		ck.run.Dirty(ack.Err)
+	}
+	if ack.Kind == lifecycle.TaskActionAbandon {
+		ck.shutdownBarrierFailed = true
+		ck.recordAbandonment("shutdown-barrier", ack.Ref, ack.Abandoned)
 	}
 	if err := ck.tasks.Release(ack.Ref); err != nil {
 		ck.shutdownBarrierFailed = true
@@ -1448,7 +1687,10 @@ func (ck *CommandKernel) completeRunFinalizer(completion lifecycle.TaskCompletio
 	if completion.Sequence != 1 || completion.Kind != lifecycle.TaskOutcomeNone || ck.finalizerAction != 0 ||
 		ck.finalizerDone ||
 		ck.finalizerFailed {
-		ck.run.Dirty(errors.New("jobmgr kernel: invalid run finalizer completion"))
+		cause := errors.New("jobmgr kernel: invalid run finalizer completion")
+		ck.finalizerFailed = true
+		ck.finalizerAction = lifecycle.TaskActionAbandon
+		ck.abandonTask(completion.Ref, completion.Sequence+1, cause)
 		return
 	}
 	if completion.Err != nil {
@@ -1463,13 +1705,16 @@ func (ck *CommandKernel) completeRunFinalizer(completion lifecycle.TaskCompletio
 			Kind:     lifecycle.TaskActionTerminate,
 		},
 	); err != nil {
-		ck.run.Dirty(err)
+		ck.finalizerFailed = true
+		ck.finalizerAction = lifecycle.TaskActionAbandon
+		ck.abandonTask(completion.Ref, 2, err)
 	}
 }
 
 func (ck *CommandKernel) acknowledgeRunFinalizer(ack lifecycle.TaskAcknowledgement) {
-	if ack.Sequence != 2 || ack.Kind != lifecycle.TaskActionTerminate ||
-		ck.finalizerAction != lifecycle.TaskActionTerminate ||
+	if ack.Sequence != 2 ||
+		(ack.Kind != lifecycle.TaskActionTerminate && ack.Kind != lifecycle.TaskActionAbandon) ||
+		ck.finalizerAction != ack.Kind ||
 		ck.finalizerDone {
 		ck.run.Dirty(errors.New("jobmgr kernel: invalid run finalizer acknowledgement"))
 		return
@@ -1477,6 +1722,10 @@ func (ck *CommandKernel) acknowledgeRunFinalizer(ack lifecycle.TaskAcknowledgeme
 	if ack.Err != nil {
 		ck.finalizerFailed = true
 		ck.run.Dirty(ack.Err)
+	}
+	if ack.Kind == lifecycle.TaskActionAbandon {
+		ck.finalizerFailed = true
+		ck.recordAbandonment("run-finalizer", ack.Ref, ack.Abandoned)
 	}
 	if err := ck.tasks.Release(ack.Ref); err != nil {
 		ck.finalizerFailed = true
@@ -1495,7 +1744,7 @@ func (ck *CommandKernel) runFinalizerFailedTerminal() bool {
 }
 
 func (ck *CommandKernel) shutdownQuiescent() bool {
-	return ck.runCensus().Quiescent()
+	return ck.runCensus().Drained()
 }
 
 func (ck *CommandKernel) kernelOwnershipDrained() bool {
@@ -1554,6 +1803,7 @@ func (ck *CommandKernel) runCensus() lifecycle.RunCensus {
 		InheritedActive:        ck.tasks.InheritedActive(),
 		LongLived:              ck.tasks.LongLivedCensus(),
 		Frame:                  ck.frames.Census(),
+		Abandoned:              ck.abandoned,
 		RunFinalizerComplete:   ck.finalizerDone && !ck.finalizerFailed,
 	}
 }

--- a/src/go/plugin/agent/jobmgr/kernel_admission.go
+++ b/src/go/plugin/agent/jobmgr/kernel_admission.go
@@ -32,17 +32,17 @@ func (ck *CommandKernel) admitSubmission(
 	submissionResult,
 	terminalResult chan error,
 	composite *kernelCompositeScope,
-	rollback bool,
+	recovery bool,
 ) error {
 	var parent *commandOperation
 	if composite != nil {
 		var err error
-		parent, err = ck.validateCompositeAdmission(composite, plan, rollback)
+		parent, err = ck.validateCompositeAdmission(composite, plan, recovery)
 		if err != nil {
 			return err
 		}
-	} else if rollback {
-		return errors.New("jobmgr kernel: rollback child has no parent")
+	} else if recovery {
+		return errors.New("jobmgr kernel: recovery child has no parent")
 	} else if !ck.run.Admitting() {
 		return ck.rejectClosedAdmission()
 	}
@@ -169,7 +169,7 @@ func (ck *CommandKernel) admitSubmission(
 		terminalResult:    terminalResult,
 		parent:            parent,
 		claimsInherited:   parent != nil,
-		compositeRollback: rollback,
+		compositeRecovery: recovery,
 		shutdownChild: parent != nil &&
 			ck.shutdownPhase == commandShutdownActionDrain,
 		runtimeStarted: now,

--- a/src/go/plugin/agent/jobmgr/kernel_diagnostics.go
+++ b/src/go/plugin/agent/jobmgr/kernel_diagnostics.go
@@ -2,6 +2,8 @@
 
 package jobmgr
 
+import "github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+
 func (ck *CommandKernel) observe(event DiagnosticEvent) {
 	if ck == nil {
 		return
@@ -10,4 +12,29 @@ func (ck *CommandKernel) observe(event DiagnosticEvent) {
 		event.Generation = ck.run.Generation()
 	}
 	ObserveDiagnostic(ck.diagnosticObserver, event)
+}
+
+func (ck *CommandKernel) recordAbandonment(
+	resource string,
+	ref lifecycle.TaskRef,
+	abandonment lifecycle.TaskAbandonment,
+) {
+	ck.abandoned.Record(abandonment)
+	state := abandonment.Outcome.String()
+	if abandonment.Outcome == lifecycle.TaskOutcomeNone && abandonment.Cleanup {
+		state = "cleanup"
+	}
+	if abandonment.Outcome == lifecycle.TaskOutcomeNone &&
+		!abandonment.Cleanup &&
+		abandonment.LongLivedPermits != 0 {
+		state = "long-lived permit"
+	}
+	ck.observe(DiagnosticEvent{
+		Level:    DiagnosticError,
+		Name:     "job manager task ownership abandoned",
+		Resource: resource,
+		State:    state,
+		Task:     ref,
+		Count:    abandonment.OwnershipCount(),
+	})
 }

--- a/src/go/plugin/agent/jobmgr/kernel_dispatch.go
+++ b/src/go/plugin/agent/jobmgr/kernel_dispatch.go
@@ -117,6 +117,21 @@ func (ck *CommandKernel) scheduleTasks(quantum int) bool {
 					}, prepareErr
 				}
 			}
+			if operation.plan.YieldClaimOnPrepare != "" {
+				prepare := transactionWork
+				lease := kernelClaimYieldLease{
+					kernel:    ck,
+					operation: operation,
+				}
+				transactionWork = func(
+					ctx context.Context,
+					current lifecycle.ReadyResource,
+					scope lifecycle.ResourceTransactionScope,
+					permit lifecycle.LongLivedPermit,
+				) (lifecycle.PreparedResourceTransaction, error) {
+					return prepare(withClaimYieldLease(ctx, lease), current, scope, permit)
+				}
+			}
 			var err error
 			if scope.Successor.Valid() {
 				taskPlan, err = lifecycle.NewResourceTransactionPermitTaskPlan(
@@ -146,7 +161,7 @@ func (ck *CommandKernel) scheduleTasks(quantum int) bool {
 		requestRef, err := ck.tasks.Enqueue(taskClassForOperation(operation, lane), taskPlan)
 		if err != nil {
 			for _, grantedOperation := range ck.releaseClaims(operation) {
-				ck.markReady(grantedOperation.lane)
+				ck.completeClaimGrant(grantedOperation)
 			}
 			ck.markReady(lane)
 			return false

--- a/src/go/plugin/agent/jobmgr/kernel_disposal.go
+++ b/src/go/plugin/agent/jobmgr/kernel_disposal.go
@@ -17,7 +17,7 @@ func (ck *CommandKernel) cancelOperation(uid string) {
 
 func (ck *CommandKernel) cancelOperationWithCause(uid string, cause error) {
 	operation := ck.operations[uid]
-	if operation != nil && operation.activeChild != nil && !operation.activeChild.compositeRollback {
+	if operation != nil && operation.activeChild != nil && !operation.activeChild.compositeRecovery {
 		ck.cancelOperationWithCause(operation.activeChild.UID, cause)
 	}
 	if operation == nil || operation.Response == lifecycle.ResponseCommitted ||
@@ -66,7 +66,7 @@ func (ck *CommandKernel) serviceDeadlines(now time.Time, quantum int) bool {
 			continue
 		}
 		ck.markOperationTimedOut(operation)
-		if operation.activeChild != nil && !operation.activeChild.compositeRollback {
+		if operation.activeChild != nil && !operation.activeChild.compositeRecovery {
 			ck.cancelOperationWithCause(operation.activeChild.UID, context.DeadlineExceeded)
 		}
 		deferControl := defersDeadlineControl(operation)
@@ -282,7 +282,7 @@ func (ck *CommandKernel) tryDispose(operation *commandOperation) {
 		heap.Remove(&ck.deadlines, operation.deadline.index)
 	}
 	for _, granted := range ck.releaseClaims(operation) {
-		ck.markReady(granted.lane)
+		ck.completeClaimGrant(granted)
 	}
 	lane := operation.lane
 	if lane.active == operation {
@@ -413,6 +413,9 @@ func (ck *CommandKernel) unlinkOperation(operation *commandOperation) {
 		ck.run.Dirty(errors.New("jobmgr kernel: invalid operation-list removal"))
 		return
 	}
+	if ck.shutdownCancelCursor == operation {
+		ck.shutdownCancelCursor = operation.allNext
+	}
 	if operation.allPrevious != nil {
 		operation.allPrevious.allNext = operation.allNext
 	} else {
@@ -445,8 +448,8 @@ func (ck *CommandKernel) unlinkQueued(operation *commandOperation) {
 		return
 	}
 	lane := operation.lane
-	if lane.ready {
-		ck.ready[sourceIndex(lane.source)].remove(lane)
+	if lane.readyQueue != nil {
+		lane.readyQueue.remove(lane)
 	}
 	if operation.fenceBlocked {
 		if err := ck.removeCompositeFenceBlocked(operation); err != nil {
@@ -475,7 +478,7 @@ func (ck *CommandKernel) unlinkQueued(operation *commandOperation) {
 		operation.claimsHeld = false
 	} else if operation.claimsHeld {
 		for _, granted := range ck.releaseClaims(operation) {
-			ck.markReady(granted.lane)
+			ck.completeClaimGrant(granted)
 		}
 	} else if ck.claims.waiting(operation) {
 		granted, err := ck.claims.cancel(operation)
@@ -483,7 +486,7 @@ func (ck *CommandKernel) unlinkQueued(operation *commandOperation) {
 			ck.run.Dirty(err)
 		}
 		for _, grantedOperation := range granted {
-			ck.markReady(grantedOperation.lane)
+			ck.completeClaimGrant(grantedOperation)
 		}
 	} else if operation.claimRegistered {
 		if err := ck.claims.abandon(operation); err != nil {
@@ -566,8 +569,7 @@ func (ck *CommandKernel) markReady(lane *commandLane) {
 	if lane == nil || lane.active != nil || lane.head == nil || lane.head.fenceBlocked || ck.claims.waiting(lane.head) {
 		return
 	}
-	lane.source = lane.head.Source
-	index := sourceIndex(lane.source)
+	index := sourceIndex(lane.head.Source)
 	ck.ready[index].push(lane)
 }
 
@@ -579,7 +581,7 @@ func (ck *CommandKernel) nextReadyLane() *commandLane {
 		return lane
 	}
 	if lane := ck.ready[second].pop(); lane != nil {
-		ck.nextSource = otherSource(lane.source)
+		ck.nextSource = otherSource(sourceForIndex(second))
 		return lane
 	}
 	return nil

--- a/src/go/plugin/agent/jobmgr/kernel_fairness_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_fairness_test.go
@@ -71,9 +71,8 @@ func TestKernelReadyLaneFairnessAtBoundaries(t *testing.T) {
 						OperationGeneration: generation,
 					}
 					lane := &commandLane{
-						key:    uid,
-						source: source,
-						head:   operation,
+						key:  uid,
+						head: operation,
 					}
 					expected[sourceIndex] = append(expected[sourceIndex], lane)
 					kernel.markReady(lane)
@@ -83,7 +82,7 @@ func TestKernelReadyLaneFairnessAtBoundaries(t *testing.T) {
 			for decision := 0; decision < 2*population; decision++ {
 				lane := kernel.nextReadyLane()
 				require.NotNil(t, lane)
-				source := sourceIndex(lane.source)
+				source := sourceIndex(lane.head.Source)
 				want := expected[source][positions[source]]
 				require.EqualValues(t, want, lane)
 				positions[source]++

--- a/src/go/plugin/agent/jobmgr/kernel_function_cleanup_queue_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_function_cleanup_queue_test.go
@@ -43,8 +43,10 @@ func TestFunctionCleanupQueuePreservesFIFOAndReleasesReferences(t *testing.T) {
 		queue.pop()
 	}
 	require.Zero(t, queue.count)
-	require.Nil(t, queue.head)
-	require.Nil(t, queue.tail)
+	require.NotNil(t, queue.head)
+	require.Same(t, queue.head, queue.tail)
+	require.Zero(t, queue.head.head)
+	require.Zero(t, queue.head.tail)
 
 	plan := queue.front()
 	require.False(t, plan.Valid() || plan.Work() != nil)
@@ -104,8 +106,22 @@ func TestFunctionCleanupQueueReleasesConsumedChunks(t *testing.T) {
 	assert.Equal(t, FunctionCleanupRef(population+1), queue.front().Ref())
 	queue.pop()
 	require.Zero(t, queue.count)
-	require.Nil(t, queue.head)
-	require.Nil(t, queue.tail)
+	require.NotNil(t, queue.head)
+	require.Same(t, queue.head, queue.tail)
+	require.Zero(t, queue.head.head)
+	require.Zero(t, queue.head.tail)
+}
+
+func TestFixedChunkQueueReusesItsDrainedChunk(t *testing.T) {
+	var queue fixedChunkQueue[int]
+	queue.push(1)
+	queue.pop()
+
+	allocations := testing.AllocsPerRun(1_000, func() {
+		queue.push(1)
+		queue.pop()
+	})
+	require.Zero(t, allocations)
 }
 
 func TestAbortFunctionMutationReturnsCatalogError(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/kernel_hotpath_bench_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_hotpath_bench_test.go
@@ -9,9 +9,7 @@ import (
 
 func BenchmarkBCommandKernelLaneOps(b *testing.B) {
 	var ring readyQueue
-	lane := &commandLane{
-		source: lifecycle.SourceJobManager,
-	}
+	lane := &commandLane{}
 	b.ReportAllocs()
 	for b.Loop() {
 		ring.push(lane)
@@ -25,16 +23,12 @@ func BenchmarkBKernelMixedTurn(b *testing.B) {
 	kernel := &CommandKernel{
 		nextSource: lifecycle.SourceJobManager,
 	}
-	jobManagerLane := &commandLane{
-		source: lifecycle.SourceJobManager,
-	}
-	functionLane := &commandLane{
-		source: lifecycle.SourceFunction,
-	}
+	jobManagerLane := &commandLane{}
+	functionLane := &commandLane{}
 	b.ReportAllocs()
 	for b.Loop() {
-		kernel.ready[sourceIndex(jobManagerLane.source)].push(jobManagerLane)
-		kernel.ready[sourceIndex(functionLane.source)].push(functionLane)
+		kernel.ready[sourceIndex(lifecycle.SourceJobManager)].push(jobManagerLane)
+		kernel.ready[sourceIndex(lifecycle.SourceFunction)].push(functionLane)
 		if kernel.nextReadyLane() == nil || kernel.nextReadyLane() == nil {
 			require.FailNow(b, "benchmark failed", "mixed turn lost a ready lane")
 		}

--- a/src/go/plugin/agent/jobmgr/kernel_lanes.go
+++ b/src/go/plugin/agent/jobmgr/kernel_lanes.go
@@ -16,7 +16,6 @@ func (ck *CommandKernel) allocateLane(mapKey commandLaneKey, request Request) *c
 	*lane = commandLane{
 		mapKey: mapKey,
 		key:    request.LaneKey,
-		source: request.Source,
 	}
 	ck.lanes[mapKey] = lane
 	ck.appendLane(lane)
@@ -33,7 +32,7 @@ func resourceCommandLaneKey(id string) commandLaneKey {
 func (ck *CommandKernel) releaseUnusedLane(lane *commandLane) {
 	if lane == nil || lane.owners != 0 || lane.head != nil ||
 		lane.tail != nil || lane.active != nil ||
-		lane.continuationTail != nil || lane.ready ||
+		lane.continuationTail != nil || lane.readyQueue != nil ||
 		lane.current != nil || lane.currentIdentity.Valid() || lane.currentStopping || lane.retiringIdentity.Valid() ||
 		lane.shutdownRequest.Valid() || lane.shutdownTask.Valid() || lane.shutdownAction != 0 {
 		return
@@ -68,6 +67,9 @@ func (ck *CommandKernel) unlinkLane(lane *commandLane) {
 	if lane == nil || !lane.allListed {
 		ck.run.Dirty(errors.New("jobmgr kernel: invalid lane-list removal"))
 		return
+	}
+	if ck.shutdownLaneCursor == lane {
+		ck.shutdownLaneCursor = lane.allNext
 	}
 	if lane.allPrevious != nil {
 		lane.allPrevious.allNext = lane.allNext

--- a/src/go/plugin/agent/jobmgr/kernel_lifecycle_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -56,6 +57,41 @@ func TestKernelCompletionBroadcastsToAllCallers(t *testing.T) {
 		require.True(t, ok)
 		require.EqualValues(t, 1, stopping.Generation)
 	})
+}
+
+func TestKernelShutdownBudgetStartFailureTerminatesLoop(t *testing.T) {
+	const helperEnv = "NETDATA_JOBMGR_SHUTDOWN_START_FAILURE_HELPER"
+	if os.Getenv(helperEnv) != "1" {
+		executable, err := os.Executable()
+		require.NoError(t, err)
+		cmd := exec.Command(executable, "-test.run=^TestKernelShutdownBudgetStartFailureTerminatesLoop$")
+		cmd.Env = append(os.Environ(), helperEnv+"=1")
+		output, runErr := cmd.CombinedOutput()
+		require.NoError(t, runErr, string(output))
+		return
+	}
+
+	kernel, run, uids, tasks := newKernelWithPlannerAndTimeout(t, stoppedKernelPlanner{}, time.Second)
+	require.NoError(t, run.Terminal(lifecycle.RunCensus{
+		KernelDrained:          true,
+		FunctionCatalogDrained: true,
+		RunFinalizerComplete:   true,
+	}))
+	startKernelLoop(t, kernel)
+	kernel.Stop()
+	waitCtx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	waitErr := kernel.Wait(waitCtx)
+	require.Error(t, waitErr)
+	require.NotErrorIs(t, waitErr, context.DeadlineExceeded)
+	select {
+	case <-kernel.Done():
+	default:
+		require.FailNow(t, "test failed", "shutdown-start failure left kernel loop running")
+	}
+	require.Zero(t, tasks.Active())
+	require.Zero(t, tasks.Pending())
+	closeUIDLedger(t, uids)
 }
 
 func TestKernelStopCutRejectsCancellationBeforeShutdownCompletes(t *testing.T) {
@@ -965,6 +1001,178 @@ func TestKernelDisposesCancelledPreparedResourceTransaction(t *testing.T) {
 			closeUIDLedger(t, uids)
 		})
 	}
+}
+
+func TestKernelDirtyApplyFailureJoinsChildWithoutWaitingForShutdownBudget(t *testing.T) {
+	var events []string
+	failure := errors.New("apply failed after ownership changed")
+	current := newKernelTestReadyResource("resource", nil, nil)
+	successor := newKernelTestReadyResource("resource", nil, nil)
+	planner := kernelTestTransactionPlanner{
+		permitPlan: lifecycle.NewJobLongLivedPlan(),
+		current:    current,
+		successor:  successor,
+		applyErr:   failure,
+		events:     &events,
+	}
+	kernel, run, uids, tasks := newKernelWithPlannerAndTimeout(t, planner, time.Second)
+	diagnostics := &recordingDiagnosticObserver{}
+	require.NoError(t, kernel.BindDiagnosticObserver(diagnostics))
+	require.NoError(t, run.OpenAdmission())
+	startKernelLoop(t, kernel)
+	require.NoError(t, kernel.submitAndWait(context.Background(), Request{
+		UID:     "install-before-failed-replace",
+		LaneKey: "resource",
+		Source:  lifecycle.SourceJobManager,
+		Route:   "install",
+	}))
+	require.ErrorIs(t, kernel.submitAndWait(context.Background(), Request{
+		UID:     "failed-replace",
+		LaneKey: "resource",
+		Source:  lifecycle.SourceJobManager,
+		Route:   "replace",
+	}), failure)
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, kernel.Wait(waitCtx), failure)
+	require.Zero(t, tasks.Active())
+	require.Zero(t, tasks.Pending())
+	require.NotZero(t, kernel.runCensus().Abandoned.AppliedResourceTransactions)
+	require.False(t, run.TerminalState().Quiescent)
+	diagnosticEvents := diagnostics.snapshot()
+	require.True(t, slices.ContainsFunc(diagnosticEvents, func(event DiagnosticEvent) bool {
+		return event.Name == "job manager task ownership abandoned" &&
+			event.Level == DiagnosticError &&
+			event.Resource == "resource" &&
+			event.State == lifecycle.TaskOutcomeAppliedResourceTransaction.String() &&
+			event.Task.Valid() &&
+			event.Count > 0
+	}), "%+v", diagnosticEvents)
+	closeUIDLedger(t, uids)
+}
+
+func TestKernelDirtyShutdownResourceFailureJoinsChild(t *testing.T) {
+	tests := map[string]func(*kernelTestReadyResource, error){
+		"stop":     func(resource *kernelTestReadyResource, err error) { resource.stopErr = err },
+		"finalize": func(resource *kernelTestReadyResource, err error) { resource.finalizeErr = err },
+	}
+	for name, configure := range tests {
+		t.Run(name, func(t *testing.T) {
+			failure := errors.New(name + " failed")
+			resource := newKernelTestReadyResource("resource", nil, nil)
+			configure(resource, failure)
+			planner := kernelTestResourcePlanner{
+				permitPlan: lifecycle.NewJobLongLivedPlan(),
+				resource:   resource,
+			}
+			kernel, run, uids, tasks :=
+				newKernelWithPlannerAndTimeout(t, planner, time.Second)
+			require.NoError(t, run.OpenAdmission())
+			startKernelLoop(t, kernel)
+			require.NoError(t, kernel.submitAndWait(context.Background(), Request{
+				UID:     "install-before-" + name + "-failure",
+				LaneKey: "resource",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "install",
+			}))
+
+			kernel.Stop()
+			waitCtx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+			defer cancel()
+			require.ErrorIs(t, kernel.Wait(waitCtx), failure)
+			require.Zero(t, tasks.Active())
+			require.Equal(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+			require.NotZero(t, kernel.runCensus().Abandoned.ReadyResources)
+			require.False(t, run.TerminalState().Quiescent)
+			closeUIDLedger(t, uids)
+		})
+	}
+}
+
+func TestKernelDirtyDisposeFailureRestoresCurrentAndJoinsChild(t *testing.T) {
+	var events []string
+	failure := errors.New("dispose failed after returning current")
+	prepareEntered := make(chan struct{})
+	current := newKernelTestReadyResource("resource", nil, nil)
+	successor := newKernelTestReadyResource("resource", nil, nil)
+	planner := kernelTestTransactionPlanner{
+		permitPlan:          lifecycle.NewJobLongLivedPlan(),
+		current:             current,
+		successor:           successor,
+		disposeErr:          failure,
+		prepareEntered:      prepareEntered,
+		waitForCancellation: true,
+		cooperativeCancel:   true,
+		events:              &events,
+	}
+	kernel, run, uids, tasks := newKernelWithPlannerAndTimeout(t, planner, time.Second)
+	require.NoError(t, run.OpenAdmission())
+	startKernelLoop(t, kernel)
+	require.NoError(t, kernel.submitAndWait(context.Background(), Request{
+		UID:     "install-before-failed-dispose",
+		LaneKey: "resource",
+		Source:  lifecycle.SourceJobManager,
+		Route:   "install",
+	}))
+	result := make(chan error, 1)
+	go func() {
+		result <- kernel.submitAndWait(context.Background(), Request{
+			UID:     "failed-dispose",
+			LaneKey: "resource",
+			Source:  lifecycle.SourceJobManager,
+			Route:   "replace",
+		})
+	}()
+	select {
+	case <-prepareEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "transaction preparation did not start")
+	}
+	require.NoError(t, kernel.Cancel(context.Background(), "failed-dispose"))
+	require.ErrorIs(t, <-result, failure)
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, kernel.Wait(waitCtx), failure)
+	require.Zero(t, tasks.Active())
+	require.Equal(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+	closeUIDLedger(t, uids)
+}
+
+func TestKernelUnsafeFunctionResultReturnsInternalControl(t *testing.T) {
+	planner := plannerFunc(func(context.Context, string, []string) (WorkPlan, error) {
+		return WorkPlan{
+			Work: frameTaskWork(func(context.Context) (lifecycle.SealedResult, error) {
+				return lifecycle.NewSealedResult(
+					200,
+					"text/plain",
+					[]byte("FUNCTION_RESULT_END"),
+				)
+			}),
+		}, nil
+	})
+	var output bytes.Buffer
+	kernel, run, uids, tasks := newKernelWithPlannerAndWriter(t, planner, &output)
+	setTestFunctionResource(t, kernel, func(FunctionLookup) string { return "unsafe-result" })
+	require.NoError(t, run.OpenAdmission())
+	startKernelLoop(t, kernel)
+	require.NoError(t, kernel.submitAndWait(context.Background(), Request{
+		UID:    "unsafe-result",
+		Source: lifecycle.SourceFunction,
+		Route:  "unsafe-result",
+	}))
+	require.Contains(
+		t,
+		output.String(),
+		"FUNCTION_RESULT_BEGIN unsafe-result 500 application/json",
+	)
+	require.NotContains(t, output.String(), "\nFUNCTION_RESULT_END\nFUNCTION_RESULT_END")
+
+	kernel.Stop()
+	require.NoError(t, kernel.Wait(context.Background()))
+	require.Zero(t, tasks.Active())
+	closeUIDLedger(t, uids)
 }
 
 func TestKernelDoesNotStartQueuedExpiredResourceTransaction(t *testing.T) {
@@ -2830,6 +3038,48 @@ func TestKernelShutdownCancelsOperationsInBoundedTurns(t *testing.T) {
 	require.False(t, len(kernel.lanes) != 0 || kernel.laneHead != nil || kernel.laneTail != nil)
 }
 
+func TestKernelShutdownCursorAdvancesWhenItsNextOperationIsCancelled(t *testing.T) {
+	kernel, run := newKernel(t)
+	require.NoError(t, run.OpenAdmission())
+
+	plan := WorkPlan{
+		Work:       frameTaskWork(plannerPlanWork),
+		NoResponse: true,
+	}
+	for _, uid := range []string{"cursor-first", "cursor-next", "cursor-last"} {
+		require.NoError(t, kernel.admit(
+			Request{
+				UID:     uid,
+				LaneKey: "shared",
+				Source:  lifecycle.SourceJobManager,
+				Route:   "internal/test/shutdown-cursor",
+			},
+			plan,
+		))
+	}
+
+	require.NoError(t, kernel.beginShutdown(time.Now().Add(time.Second)))
+	more, err := kernel.serviceShutdownCancellation(1)
+	require.NoError(t, err)
+	require.True(t, more)
+	require.Same(t, kernel.operations["cursor-next"], kernel.shutdownCancelCursor)
+
+	// Composite continuations admitted during the action-drain phase unlink as
+	// soon as they terminalize, even before the shutdown cursor visits them.
+	kernel.operations["cursor-next"].shutdownChild = true
+	kernel.cancelOperation("cursor-next")
+	require.Same(t, kernel.operations["cursor-last"], kernel.shutdownCancelCursor)
+
+	for {
+		more, err = kernel.serviceShutdownCancellation(1)
+		require.NoError(t, err)
+		if !more {
+			break
+		}
+	}
+	require.Empty(t, kernel.operations)
+}
+
 func TestKernelShutdownVisitsLiveLanesOnceInBoundedTurns(t *testing.T) {
 	populations := map[string]int{"one": 1, "thirty-two": 32, "two-hundred-fifty-seven": 257}
 	const quantum = 4
@@ -3791,6 +4041,8 @@ type kernelTestTransactionPlanner struct {
 	current             *kernelTestReadyResource
 	successor           *kernelTestReadyResource
 	prepareErr          error
+	applyErr            error
+	disposeErr          error
 	prepareEntered      chan<- struct{}
 	disposeEntered      chan<- struct{}
 	disposeRelease      <-chan struct{}
@@ -3839,6 +4091,8 @@ func (kttp kernelTestTransactionPlanner) Plan(request Request) (WorkPlan, error)
 						scope:          scope,
 						current:        kttp.current,
 						successor:      kttp.successor,
+						applyErr:       kttp.applyErr,
+						disposeErr:     kttp.disposeErr,
 						permit:         permit,
 						disposeEntered: kttp.disposeEntered,
 						disposeRelease: kttp.disposeRelease,
@@ -3856,6 +4110,8 @@ type kernelTestPreparedResourceTransaction struct {
 	scope          lifecycle.ResourceTransactionScope
 	current        *kernelTestReadyResource
 	successor      *kernelTestReadyResource
+	applyErr       error
+	disposeErr     error
 	permit         lifecycle.LongLivedPermit
 	disposeEntered chan<- struct{}
 	disposeRelease <-chan struct{}
@@ -3908,7 +4164,7 @@ func (ktprt *kernelTestPreparedResourceTransaction) Apply(
 	if err != nil {
 		return lifecycle.AppliedResourceTransaction{}, err
 	}
-	return lifecycle.NewAppliedResourceTransaction(
+	applied, err := lifecycle.NewAppliedResourceTransaction(
 		ktprt.scope,
 		lifecycle.ResourceTransactionReplaced,
 		ktprt.successor,
@@ -3918,6 +4174,7 @@ func (ktprt *kernelTestPreparedResourceTransaction) Apply(
 			return nil
 		},
 	)
+	return applied, errors.Join(err, ktprt.applyErr)
 }
 
 func (ktprt *kernelTestPreparedResourceTransaction) Dispose(context.Context) (lifecycle.ReadyResource, error) {
@@ -3928,7 +4185,7 @@ func (ktprt *kernelTestPreparedResourceTransaction) Dispose(context.Context) (li
 	if ktprt.disposeRelease != nil {
 		<-ktprt.disposeRelease
 	}
-	return ktprt.current, ktprt.permit.AbortUnused()
+	return ktprt.current, errors.Join(ktprt.permit.AbortUnused(), ktprt.disposeErr)
 }
 
 func (ktrp kernelTestResourcePlanner) Plan(request Request) (WorkPlan, error) {
@@ -4094,6 +4351,8 @@ type kernelTestReadyResource struct {
 	publishRelease <-chan struct{}
 	stopEntered    chan struct{}
 	stopRelease    <-chan struct{}
+	stopErr        error
+	finalizeErr    error
 	publishOnce    sync.Once
 	stopOnce       sync.Once
 }
@@ -4119,11 +4378,11 @@ func (ktrr *kernelTestReadyResource) Stop(context.Context) error {
 	if ktrr.stopRelease != nil {
 		<-ktrr.stopRelease
 	}
-	return ktrr.permit.ReleaseExternal()
+	return errors.Join(ktrr.permit.ReleaseExternal(), ktrr.stopErr)
 }
 
 func (ktrr *kernelTestReadyResource) Finalize() error {
-	return ktrr.permit.Return()
+	return errors.Join(ktrr.permit.Return(), ktrr.finalizeErr)
 }
 
 type stoppedKernelPlanner struct{}

--- a/src/go/plugin/agent/jobmgr/kernel_plan.go
+++ b/src/go/plugin/agent/jobmgr/kernel_plan.go
@@ -4,6 +4,7 @@ package jobmgr
 
 import (
 	"errors"
+	"slices"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 )
@@ -15,14 +16,16 @@ type WorkPlan struct {
 	NoResponse          bool                     // the command produces no terminal response frame
 	CooperativeCancel   bool                     // work honors cooperative cancellation
 	CooperativeDeadline bool                     // work honors the caller deadline
+	YieldClaimOnPrepare string                   // preparation may temporarily yield this acquisition-suffix claim
 }
 
 type ResourceTransactionPlan struct {
-	ID                string                                    // resource ID the transaction targets
-	AllocateSuccessor bool                                      // whether a successor resource is prepared
-	Permit            lifecycle.LongLivedPlan                   // long-lived permit for the successor
-	Prepare           lifecycle.PreparedResourceTransactionWork // single-resource transaction work
-	PrepareComposite  CompositeResourceTransactionWork          // composite (multi-resource) transaction work
+	ID                         string                                    // resource ID the transaction targets
+	AllocateSuccessor          bool                                      // whether a successor resource is prepared
+	Permit                     lifecycle.LongLivedPlan                   // long-lived permit for the successor
+	Prepare                    lifecycle.PreparedResourceTransactionWork // single-resource transaction work
+	PrepareComposite           CompositeResourceTransactionWork          // composite (multi-resource) transaction work
+	CompositeChildLaneConflict func(string) bool                         // whether a resource lane may be used by a child
 }
 
 func (wp WorkPlan) validate() error {
@@ -49,6 +52,19 @@ func (wp WorkPlan) validate() error {
 	}
 	if wp.Transaction.ID == "" || (wp.Transaction.Prepare == nil) == (wp.Transaction.PrepareComposite == nil) {
 		return errors.New("jobmgr kernel: invalid resource transaction plan")
+	}
+	if wp.Transaction.PrepareComposite == nil && wp.Transaction.CompositeChildLaneConflict != nil {
+		return errors.New("jobmgr kernel: plain transaction declares composite child lanes")
+	}
+	if wp.YieldClaimOnPrepare != "" &&
+		(wp.Transaction.Prepare == nil || !slices.Contains(wp.Claims, wp.YieldClaimOnPrepare)) {
+		return errors.New("jobmgr kernel: invalid claim-yielding transaction plan")
+	}
+	if wp.YieldClaimOnPrepare != "" {
+		claims, err := normalizeAuthorityClaims(wp.Claims)
+		if err != nil || len(claims) == 0 || claims[len(claims)-1] != wp.YieldClaimOnPrepare {
+			return errors.New("jobmgr kernel: yielded claim must be the acquisition suffix")
+		}
 	}
 	if wp.Transaction.AllocateSuccessor {
 		if err := wp.Transaction.Permit.Validate(); err != nil {

--- a/src/go/plugin/agent/jobmgr/kernel_runloop.go
+++ b/src/go/plugin/agent/jobmgr/kernel_runloop.go
@@ -51,6 +51,7 @@ func (ck *CommandKernel) runLoop(ctx context.Context) {
 	stopC := (<-chan struct{})(ck.stop)
 	contextC := ctx.Done()
 	shuttingDown := false
+	shutdownStartFailed := false
 	beginShutdown := func(cause error) {
 		if shuttingDown {
 			terminal = errors.Join(terminal, cause)
@@ -72,6 +73,7 @@ func (ck *CommandKernel) runLoop(ctx context.Context) {
 		if err != nil {
 			ck.run.Dirty(err)
 			terminal = errors.Join(terminal, err)
+			shutdownStartFailed = true
 			return
 		}
 		shutdownBudget = budget
@@ -91,6 +93,10 @@ func (ck *CommandKernel) runLoop(ctx context.Context) {
 		close(ck.done)
 	}()
 	for {
+		if shutdownStartFailed {
+			terminal = errors.Join(terminal, ck.run.Terminal(ck.runCensus()))
+			return
+		}
 		if !shuttingDown {
 			if cause := ck.run.DirtyCause(); cause != nil {
 				beginShutdown(cause)
@@ -124,6 +130,7 @@ func (ck *CommandKernel) runLoop(ctx context.Context) {
 			}
 		}
 		moreFunctionCleanups = moreFunctionCleanups || ck.functionCleanupBacklog.count != 0
+		moreClaimYields := ck.serviceClaimYields(lifecycle.TaskStartServiceQuantum)
 		moreClaimSettlements := ck.serviceClaimSettlements(maximumClaimSettlementQuantum)
 		moreCompositeFenceRechecks := false
 		moreTasks := false
@@ -192,6 +199,7 @@ func (ck *CommandKernel) runLoop(ctx context.Context) {
 		}
 		if moreDeadlines || moreControls || moreSubmissions || moreFunctionCleanups ||
 			moreFunctionMutation || moreFunctionClose || moreClaimSettlements ||
+			moreClaimYields ||
 			moreCompositeFenceRechecks ||
 			moreTasks || moreTaskStarts ||
 			servicedAsyncEvents > 0 || moreShutdownCancellation ||
@@ -236,6 +244,8 @@ func (ck *CommandKernel) runLoop(ctx context.Context) {
 			ck.completeTask(completion)
 		case acknowledgement := <-ck.tasks.AcknowledgementCh():
 			ck.acknowledgeTask(acknowledgement)
+		case request := <-ck.claimYields:
+			ck.serviceClaimYield(request)
 		case <-deadlineC:
 			deadlineC = nil
 			cancelDeadline = nil
@@ -260,13 +270,13 @@ func (ck *CommandKernel) serviceClaimSettlements(quantum int) bool {
 		return false
 	}
 	for _, operation := range granted {
-		ck.markReady(operation.lane)
+		ck.completeClaimGrant(operation)
 	}
 	return more
 }
 
 func (ck *CommandKernel) serviceOneAsyncEvent() bool {
-	const sources = 4
+	const sources = 5
 	for offset := range sources {
 		source := (int(ck.nextAsyncEvent) + offset) % sources
 		switch source {
@@ -303,6 +313,14 @@ func (ck *CommandKernel) serviceOneAsyncEvent() bool {
 			select {
 			case submitted := <-ck.functionMutations:
 				ck.beginFunctionMutation(submitted)
+				ck.nextAsyncEvent = 4
+				return true
+			default:
+			}
+		case 4:
+			select {
+			case request := <-ck.claimYields:
+				ck.serviceClaimYield(request)
 				ck.nextAsyncEvent = 0
 				return true
 			default:
@@ -378,7 +396,7 @@ func (ck *CommandKernel) serviceSubmissions(quantum int) bool {
 					submitted.result,
 					submitted.terminal,
 					submitted.composite,
-					submitted.rollback,
+					submitted.recovery,
 				)
 			}
 		}

--- a/src/go/plugin/agent/jobmgr/kernel_structures.go
+++ b/src/go/plugin/agent/jobmgr/kernel_structures.go
@@ -62,11 +62,13 @@ func (fcq *fixedChunkQueue[T]) pop() {
 	if chunk.head != chunk.tail {
 		return
 	}
+	if chunk.next == nil {
+		chunk.head = 0
+		chunk.tail = 0
+		return
+	}
 	fcq.head = chunk.next
 	chunk.next = nil
-	if fcq.head == nil {
-		fcq.tail = nil
-	}
 }
 
 type functionCleanupQueue struct {
@@ -87,10 +89,13 @@ type readyQueue struct {
 }
 
 func (rq *readyQueue) push(lane *commandLane) {
-	if lane.ready {
-		return
+	if owner := lane.readyQueue; owner != nil {
+		if owner == rq {
+			return
+		}
+		owner.remove(lane)
 	}
-	lane.ready = true
+	lane.readyQueue = rq
 	lane.readyPrev = rq.tail
 	if rq.tail != nil {
 		rq.tail.readyNext = lane
@@ -112,7 +117,7 @@ func (rq *readyQueue) pop() *commandLane {
 	} else {
 		rq.tail = nil
 	}
-	lane.ready = false
+	lane.readyQueue = nil
 	lane.readyPrev = nil
 	lane.readyNext = nil
 	rq.len--
@@ -120,7 +125,7 @@ func (rq *readyQueue) pop() *commandLane {
 }
 
 func (rq *readyQueue) remove(lane *commandLane) {
-	if !lane.ready {
+	if lane.readyQueue != rq {
 		return
 	}
 	if lane.readyPrev != nil {
@@ -133,7 +138,7 @@ func (rq *readyQueue) remove(lane *commandLane) {
 	} else {
 		rq.tail = lane.readyPrev
 	}
-	lane.ready = false
+	lane.readyQueue = nil
 	lane.readyPrev = nil
 	lane.readyNext = nil
 	rq.len--

--- a/src/go/plugin/agent/jobmgr/lifecycle/contracts.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/contracts.go
@@ -5,7 +5,6 @@ package lifecycle
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 )
 
@@ -14,10 +13,30 @@ const MaximumUIDBytes = 128
 
 // ValidateUID checks whether uid is safe for line-oriented Function framing.
 func ValidateUID(uid string) error {
-	if uid == "" || len(uid) > MaximumUIDBytes || strings.ContainsAny(uid, " \t\r\n\x00") {
+	if uid == "" || len(uid) > MaximumUIDBytes || !validPluginsDBareField(uid) {
 		return errors.New("jobmgr lifecycle: invalid UID")
 	}
 	return nil
+}
+
+func validPluginsDBareField(value string) bool {
+	for index := 0; index < len(value); index++ {
+		char := value[index]
+		if char <= ' ' || char == 0x7f || char == '=' ||
+			char == '\'' || char == '"' || char == '\\' {
+			return false
+		}
+	}
+	return true
+}
+
+func pluginsDSeparator(char byte) bool {
+	switch char {
+	case ' ', '\t', '\r', '\n', '\f', '\v', '=':
+		return true
+	default:
+		return false
+	}
 }
 
 // Source identifies the ingress and lifecycle origin of an operation.

--- a/src/go/plugin/agent/jobmgr/lifecycle/contracts.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/contracts.go
@@ -19,7 +19,13 @@ func ValidateUID(uid string) error {
 	return nil
 }
 
+// validPluginsDBareField stays local because lifecycle is deliberately
+// standard-library-only. TestValidPluginsDBareFieldParity pins its semantics to
+// netdataapi.ValidBareProtocolField.
 func validPluginsDBareField(value string) bool {
+	if value == "" {
+		return false
+	}
 	for index := 0; index < len(value); index++ {
 		char := value[index]
 		if char <= ' ' || char == 0x7f || char == '=' ||

--- a/src/go/plugin/agent/jobmgr/lifecycle/contracts_test.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/contracts_test.go
@@ -73,6 +73,10 @@ func TestValidateUID(t *testing.T) {
 		"carriage return": {uid: "request\r1", wantErr: true},
 		"line feed":       {uid: "request\n1", wantErr: true},
 		"NUL":             {uid: "request\x001", wantErr: true},
+		"equals":          {uid: "request=1", wantErr: true},
+		"double quote":    {uid: `request"1`, wantErr: true},
+		"single quote":    {uid: "request'1", wantErr: true},
+		"backslash":       {uid: `request\1`, wantErr: true},
 	}
 
 	for name, tc := range tests {

--- a/src/go/plugin/agent/jobmgr/lifecycle/contracts_test.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/contracts_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -83,6 +84,23 @@ func TestValidateUID(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.wantErr, ValidateUID(tc.uid) != nil)
 		})
+	}
+}
+
+func TestValidPluginsDBareFieldParity(t *testing.T) {
+	assert.Equal(t, netdataapi.ValidBareProtocolField(""), validPluginsDBareField(""))
+	for value := range 256 {
+		field := string([]byte{byte(value)})
+		assert.Equal(
+			t,
+			netdataapi.ValidBareProtocolField(field),
+			validPluginsDBareField(field),
+			"byte 0x%02x",
+			value,
+		)
+	}
+	for _, field := range []string{"ascii", "κόσμος", "世 界", "é=west", string([]byte{0xff, 'x'})} {
+		assert.Equal(t, netdataapi.ValidBareProtocolField(field), validPluginsDBareField(field), "%q", field)
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/lifecycle/frame.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/frame.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 )
@@ -136,6 +135,8 @@ func (fo *FrameOwner) ReleaseRunNotifications(generation uint64) error {
 	fo.onControlReady = nil
 	fo.onPoisoned = nil
 	fo.runtimeObserver = nil
+	fo.pendingControl = false
+	fo.available.Broadcast()
 	return nil
 }
 
@@ -520,7 +521,7 @@ func resultFrameSize(
 	payloadBytes, frameLimit, envelopeLimit, payloadLimit int,
 ) (frameBytes, envelopeBytes int, err error) {
 	if ValidateUID(uid) != nil || contentType == "" ||
-		strings.ContainsAny(contentType, " \t\r\n\x00") ||
+		!validPluginsDBareField(contentType) ||
 		status < 100 ||
 		status > 599 ||
 		expiry <= 0 {
@@ -606,5 +607,8 @@ func controlPayload(status ControlStatus) []byte {
 }
 
 func ExpiryAt(now time.Time) int64 {
-	return now.Unix()
+	if expiry := now.Unix(); expiry > 0 {
+		return expiry
+	}
+	return 1
 }

--- a/src/go/plugin/agent/jobmgr/lifecycle/lifecycle_test.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/lifecycle_test.go
@@ -1009,6 +1009,38 @@ func TestFrameOwnerLateControlReadyBindingReplaysPendingWake(t *testing.T) {
 	require.Error(t, owner.BindRunNotifications(2, func() {}, func(error) {}, nil))
 }
 
+func TestFrameOwnerRunReleaseAbandonsPendingControlReservation(t *testing.T) {
+	writer := newStepWriter()
+	owner, err := NewFrameOwner(writer)
+	require.NoError(t, err)
+	require.NoError(t, owner.BindRunNotifications(1, func() {}, func(error) {}, nil))
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- owner.CommitBorrowedProtocolFrame([]byte("first")) }()
+	require.Equal(t, []byte("first"), <-writer.offered)
+	require.ErrorIs(t, owner.TryCommitControl(ControlFramePlan{
+		UID:    "control",
+		Status: ControlInternal,
+		Expiry: 1,
+	}), ErrFrameOwnerBusy)
+
+	require.NoError(t, owner.ReleaseRunNotifications(1))
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- owner.CommitBorrowedProtocolFrame([]byte("second")) }()
+	writer.release <- struct{}{}
+	require.NoError(t, <-firstDone)
+
+	select {
+	case payload := <-writer.offered:
+		require.Equal(t, []byte("second"), payload)
+	case <-time.After(100 * time.Millisecond):
+		require.FailNow(t, "test failed", "retired run left ordinary writer behind pending control")
+	}
+	writer.release <- struct{}{}
+	require.NoError(t, <-secondDone)
+	require.False(t, owner.Census().PendingControl)
+}
+
 func TestFrameOwnerShortWritePoisonsAndRetains(t *testing.T) {
 	owner, err := NewFrameOwner(shortWriter{})
 	require.NoError(t, err)
@@ -1186,6 +1218,65 @@ func TestClosedControlResults(t *testing.T) {
 
 	_, err := NewControlResult(418)
 	require.Error(t, err)
+}
+
+func TestSealedResultRejectsPluginsDTerminatorPayload(t *testing.T) {
+	tests := map[string]struct {
+		payload []byte
+		unsafe  bool
+	}{
+		"payload start":      {payload: []byte("FUNCTION_RESULT_END"), unsafe: true},
+		"space":              {payload: []byte(" FUNCTION_RESULT_END"), unsafe: true},
+		"tab":                {payload: []byte("\tFUNCTION_RESULT_END"), unsafe: true},
+		"carriage return":    {payload: []byte("\rFUNCTION_RESULT_END"), unsafe: true},
+		"form feed":          {payload: []byte("\fFUNCTION_RESULT_END"), unsafe: true},
+		"vertical tab":       {payload: []byte("\vFUNCTION_RESULT_END"), unsafe: true},
+		"equals":             {payload: []byte("=FUNCTION_RESULT_END"), unsafe: true},
+		"later line":         {payload: []byte("safe\n FUNCTION_RESULT_END"), unsafe: true},
+		"trailing token":     {payload: []byte("FUNCTION_RESULT_END ignored"), unsafe: true},
+		"keyword suffix":     {payload: []byte("FUNCTION_RESULT_END_extra")},
+		"not first token":    {payload: []byte("safe FUNCTION_RESULT_END")},
+		"ordinary multiline": {payload: []byte("first\nsecond")},
+		"empty":              {},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewSealedResult(200, "text/plain", test.payload)
+			if test.unsafe {
+				require.ErrorIs(t, err, ErrUnsafeFunctionResult)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFunctionResultTerminatorValidationDoesNotAllocate(t *testing.T) {
+	payload := bytes.Repeat([]byte("safe payload\n"), 100)
+	allocations := testing.AllocsPerRun(1_000, func() {
+		require.False(t, functionResultPayloadHasTerminator(payload))
+	})
+	require.Zero(t, allocations)
+}
+
+func TestSealedResultRejectsUnsafeContentType(t *testing.T) {
+	for name, contentType := range map[string]string{
+		"equals":       "application/json=shift",
+		"double quote": `application/"json`,
+		"single quote": "application/'json",
+		"backslash":    `application/json\`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewSealedResult(200, contentType, nil)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestExpiryAtIsPositiveWithoutARealTimeClock(t *testing.T) {
+	require.EqualValues(t, 1, ExpiryAt(time.Unix(0, 0)))
+	require.EqualValues(t, 1, ExpiryAt(time.Unix(-1, 0)))
+	require.EqualValues(t, 2, ExpiryAt(time.Unix(2, 0)))
 }
 
 func TestFunctionPayloadAndFrameCapacityAreSeparateFromControlReserve(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/lifecycle/long_lived.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/long_lived.go
@@ -353,6 +353,30 @@ func (ts *TaskSupervisor) returnLongLivedPermit(ref LongLivedPermitRef, owner Re
 	return nil
 }
 
+func (ts *TaskSupervisor) abandonLongLivedOwner(owner ResourceIdentity) int {
+	if ts == nil || !owner.Valid() {
+		return 0
+	}
+	registry := &ts.longLived
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	ref := registry.owners[owner]
+	if !ref.valid() {
+		return 0
+	}
+	slot := registry.slots[ref]
+	if slot == nil || slot.owner != owner {
+		return 0
+	}
+	delete(registry.owners, owner)
+	delete(registry.slots, ref)
+	registry.census.Active--
+	if slot.class == LongLivedSecretStore {
+		registry.census.SecretStores--
+	}
+	return 1
+}
+
 func (ts *TaskSupervisor) releaseReservedLongLivedFacets(ref LongLivedPermitRef, owner ResourceIdentity) error {
 	registry := &ts.longLived
 	registry.mu.Lock()

--- a/src/go/plugin/agent/jobmgr/lifecycle/operation.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/operation.go
@@ -155,6 +155,38 @@ func (og *OperationGeneration) TerminationPending(ref TaskRef, sequence uint8) e
 	return nil
 }
 
+// AbandonChild is the dirty-run-only route that joins a parked child without
+// pretending its normal action protocol completed.
+func (og *OperationGeneration) AbandonChild(ref TaskRef, sequence uint8) error {
+	if og.Task != ref || !ref.Valid() || sequence == 0 ||
+		og.Child < ChildExecuting || og.Child > ChildTerminationPending {
+		return errors.New("jobmgr operation: invalid child abandonment")
+	}
+	switch og.Child {
+	case ChildExecuting:
+		if sequence <= og.childPhase || sequence > og.childPhase+2 {
+			return errors.New("jobmgr operation: invalid executing-child abandonment sequence")
+		}
+	case ChildResultReady, ChildActionAcknowledged:
+		if sequence != og.childPhase+1 {
+			return errors.New("jobmgr operation: invalid parked-child abandonment sequence")
+		}
+	case ChildActionPending:
+		if sequence != og.childPhase && sequence != og.childPhase+1 {
+			return errors.New("jobmgr operation: invalid pending-child abandonment sequence")
+		}
+	case ChildTerminationPending:
+		if sequence != og.childPhase {
+			return errors.New("jobmgr operation: invalid terminating-child abandonment sequence")
+		}
+	default:
+		return errors.New("jobmgr operation: invalid child abandonment state")
+	}
+	og.Child = ChildTerminationPending
+	og.childPhase = sequence
+	return nil
+}
+
 func (og *OperationGeneration) ChildExited(ref TaskRef, sequence uint8) error {
 	if og.Child != ChildTerminationPending || og.Task != ref || sequence != og.childPhase {
 		return errors.New("jobmgr operation: stale child exit")

--- a/src/go/plugin/agent/jobmgr/lifecycle/operation_test.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/operation_test.go
@@ -92,3 +92,16 @@ func TestOperationResponseTerminalStatesRemainTerminalWhenPoisoned(t *testing.T)
 		})
 	}
 }
+
+func TestOperationDirtyAbandonmentHasADistinctTerminationTransition(t *testing.T) {
+	operation, err := NewOperation(1, "uid", SourceFunction, "lane", true)
+	require.NoError(t, err)
+	ref := TaskRef{Slot: 1, Generation: 1}
+	require.NoError(t, operation.StartChild(ref))
+	require.NoError(t, operation.ResultReady(ref, 1))
+
+	require.Error(t, operation.TerminationPending(ref, 2))
+	require.NoError(t, operation.AbandonChild(ref, 2))
+	require.Equal(t, ChildTerminationPending, operation.Child)
+	require.NoError(t, operation.ChildExited(ref, 2))
+}

--- a/src/go/plugin/agent/jobmgr/lifecycle/resource.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/resource.go
@@ -17,6 +17,23 @@ const (
 	TaskOutcomeAppliedResourceTransaction
 )
 
+func (kind TaskOutcomeKind) String() string {
+	switch kind {
+	case TaskOutcomeNone:
+		return "none"
+	case TaskOutcomeFrame:
+		return "frame"
+	case TaskOutcomeReadyResource:
+		return "ready resource"
+	case TaskOutcomePreparedResourceTransaction:
+		return "prepared resource transaction"
+	case TaskOutcomeAppliedResourceTransaction:
+		return "applied resource transaction"
+	default:
+		return "invalid"
+	}
+}
+
 type TaskOutcome struct {
 	kind        TaskOutcomeKind                // discriminant selecting which payload field is set
 	frame       SealedResult                   // sealed result (Frame / applied transaction) payload

--- a/src/go/plugin/agent/jobmgr/lifecycle/run.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/run.go
@@ -3,7 +3,6 @@
 package lifecycle
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -56,10 +55,11 @@ type RunCensus struct {
 	InheritedActive        int
 	LongLived              LongLivedCensus
 	Frame                  FrameCensus
+	Abandoned              TaskAbandonmentCensus
 	RunFinalizerComplete   bool
 }
 
-func (census RunCensus) Quiescent() bool {
+func (census RunCensus) Drained() bool {
 	frameDrained := !census.Frame.Poisoned && !census.Frame.Busy &&
 		!census.Frame.PendingControl && census.Frame.RetainedBytes == 0
 	return census.KernelDrained &&
@@ -68,6 +68,10 @@ func (census RunCensus) Quiescent() bool {
 		census.InheritedActive == 0 &&
 		census.LongLived == (LongLivedCensus{}) && frameDrained &&
 		census.RunFinalizerComplete
+}
+
+func (census RunCensus) Quiescent() bool {
+	return census.Drained() && census.Abandoned.Empty()
 }
 
 type RunTerminalState struct {
@@ -241,27 +245,4 @@ func (rs *RunSupervisor) TerminalState() RunTerminalState {
 
 func (rs *RunSupervisor) Generation() uint64 {
 	return rs.generation
-}
-
-// NewRollbackContext returns one run-owned context bounded by the configured
-// shutdown budget. It deliberately does not inherit a cancelled command
-// context.
-func (rs *RunSupervisor) NewRollbackContext() (context.Context, context.CancelFunc, error) {
-	if rs == nil {
-		return nil, nil, errors.New("jobmgr run supervisor: nil rollback owner")
-	}
-	rs.mu.Lock()
-	if rs.terminal {
-		rs.mu.Unlock()
-		return nil, nil, errors.New("jobmgr run supervisor: rollback after terminal")
-	}
-	timeout := rs.timeout
-	shutdown := rs.shutdown
-	rs.mu.Unlock()
-	if shutdown != nil {
-		ctx, cancel := context.WithDeadline(context.Background(), shutdown.Deadline())
-		return ctx, cancel, nil
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	return ctx, cancel, nil
 }

--- a/src/go/plugin/agent/jobmgr/lifecycle/shutdown_test.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/shutdown_test.go
@@ -253,6 +253,9 @@ func TestRunCensusQuiescenceRequiresExplicitOwnershipProofs(t *testing.T) {
 		"active UID ownership": {
 			mutate: func(census *RunCensus) { census.UIDActive = 1 },
 		},
+		"abandoned ownership": {
+			mutate: func(census *RunCensus) { census.Abandoned.ReadyResources = 1 },
+		},
 	}
 
 	require.True(t, base.Quiescent())
@@ -261,6 +264,9 @@ func TestRunCensusQuiescenceRequiresExplicitOwnershipProofs(t *testing.T) {
 			census := base
 			test.mutate(&census)
 			require.False(t, census.Quiescent())
+			if name == "abandoned ownership" {
+				require.True(t, census.Drained())
+			}
 		})
 	}
 }

--- a/src/go/plugin/agent/jobmgr/lifecycle/task.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/task.go
@@ -51,6 +51,7 @@ const (
 	TaskActionDispose
 	TaskActionCleanup
 	TaskActionTerminate
+	TaskActionAbandon
 )
 
 type TaskAction struct {
@@ -62,10 +63,63 @@ type TaskAction struct {
 }
 
 type TaskAcknowledgement struct {
-	Ref      TaskRef
-	Sequence uint8
-	Kind     TaskActionKind
-	Err      error
+	Ref       TaskRef
+	Sequence  uint8
+	Kind      TaskActionKind
+	Err       error
+	Abandoned TaskAbandonment
+}
+
+// TaskAbandonment records outcome ownership intentionally forfeited while a
+// dirty run joins a child that cannot complete its normal action protocol.
+type TaskAbandonment struct {
+	Outcome          TaskOutcomeKind
+	Cleanup          bool
+	LongLivedPermits int
+}
+
+type TaskAbandonmentCensus struct {
+	Results                      int
+	ReadyResources               int
+	PreparedResourceTransactions int
+	AppliedResourceTransactions  int
+	Cleanups                     int
+	LongLivedPermits             int
+}
+
+func (tac *TaskAbandonmentCensus) Record(abandonment TaskAbandonment) {
+	if tac == nil {
+		return
+	}
+	switch abandonment.Outcome {
+	case TaskOutcomeFrame:
+		tac.Results++
+	case TaskOutcomeReadyResource:
+		tac.ReadyResources++
+	case TaskOutcomePreparedResourceTransaction:
+		tac.PreparedResourceTransactions++
+	case TaskOutcomeAppliedResourceTransaction:
+		tac.AppliedResourceTransactions++
+	}
+	if abandonment.Cleanup {
+		tac.Cleanups++
+	}
+	tac.LongLivedPermits += abandonment.LongLivedPermits
+}
+
+func (tac TaskAbandonmentCensus) Empty() bool {
+	return tac == (TaskAbandonmentCensus{})
+}
+
+func (abandonment TaskAbandonment) OwnershipCount() int {
+	count := abandonment.LongLivedPermits
+	if abandonment.Outcome != TaskOutcomeNone {
+		count++
+	}
+	if abandonment.Cleanup {
+		count++
+	}
+	return count
 }
 
 type taskSlot struct {
@@ -91,6 +145,7 @@ type taskRequest struct {
 	previous   uint32      // previous request in its class queue
 	next       uint32      // next request in its class queue
 	active     bool        // request slot is in use
+	queued     bool        // request is linked in a runnable class queue
 	class      TaskClass   // task class (framework-control / generic Function)
 	plan       TaskPlan    // the task plan to run
 	initial    TaskOutcome // seed outcome carried into the child
@@ -213,6 +268,7 @@ func (ts *TaskSupervisor) Enqueue(class TaskClass, plan TaskPlan) (TaskRequestRe
 		slot:       slot,
 		generation: generation,
 		active:     true,
+		queued:     true,
 		class:      class,
 		plan:       plan,
 		initial:    initial,
@@ -306,7 +362,9 @@ func (ts *TaskSupervisor) Dispatch(
 		}
 		taskRef, err := ts.start(parent, record.plan, record.initial)
 		if err != nil {
-			return count, true, err
+			ts.unlinkRequest(record)
+			ts.observeRuntimeState()
+			return count, ts.Pending() > 0, err
 		}
 		ts.removeRequest(record)
 		started[count] = TaskStart{
@@ -560,6 +618,34 @@ func (ts *TaskSupervisor) SendAction(action TaskAction) error {
 	}
 }
 
+func (ts *TaskSupervisor) Abandon(ref TaskRef, sequence uint8) error {
+	if !ref.Valid() || sequence == 0 {
+		return errors.New("jobmgr task supervisor: invalid task abandonment")
+	}
+	if ts.run == nil || ts.run.DirtyCause() == nil {
+		return errors.New("jobmgr task supervisor: abandonment requires a dirty run")
+	}
+	slot, err := ts.slot(ref)
+	if err != nil {
+		return err
+	}
+	if slot.joined || slot.actionPending || sequence != slot.sequence+1 {
+		return errors.New("jobmgr task supervisor: stale or duplicate task abandonment")
+	}
+	slot.actionPending = true
+	select {
+	case slot.action <- TaskAction{
+		Ref:      ref,
+		Sequence: sequence,
+		Kind:     TaskActionAbandon,
+	}:
+		return nil
+	default:
+		slot.actionPending = false
+		return errors.New("jobmgr task supervisor: full abandonment mailbox")
+	}
+}
+
 func (ts *TaskSupervisor) Cancel(ref TaskRef) error {
 	return ts.CancelWithCause(ref, context.Canceled)
 }
@@ -582,7 +668,8 @@ func (ts *TaskSupervisor) Release(ref TaskRef) error {
 	if err != nil {
 		return err
 	}
-	if !slot.joined || slot.actionPending || len(slot.action) != 0 || !slot.outcome.empty() || slot.retainedTimeout {
+	if !slot.joined || slot.actionPending || len(slot.action) != 0 ||
+		!slot.outcome.empty() || slot.cleanup != nil || slot.retainedTimeout {
 		return errors.New("jobmgr task supervisor: release before empty joined acknowledgement")
 	}
 	slot.cancel(context.Canceled)
@@ -747,7 +834,8 @@ func (ts *TaskSupervisor) runChild(
 			Sequence: action.Sequence,
 			Kind:     action.Kind,
 		}
-		if action.Ref != ref || action.Sequence != slot.sequence+1 || action.Sequence > slot.maxPhaseTransitions {
+		if action.Ref != ref || action.Sequence != slot.sequence+1 ||
+			action.Kind != TaskActionAbandon && action.Sequence > slot.maxPhaseTransitions {
 			ack.Err = errors.New("jobmgr task child: stale or wrong-sequence phase action")
 			slot.actionPending = false
 			slot.joined = true
@@ -793,13 +881,14 @@ func (ts *TaskSupervisor) runChild(
 				transaction := slot.outcome.transaction
 				scope := slot.outcome.scope
 				applied, applyErr := runPreparedResourceTransactionApply(context.WithoutCancel(ctx), transaction)
-				if applyErr != nil {
-					ack.Err = applyErr
-				} else if applied.scope != scope {
-					ack.Err = errors.New("jobmgr task child: applied resource transaction changed scope")
+				if applied.scope != scope {
+					ack.Err = errors.Join(
+						applyErr,
+						errors.New("jobmgr task child: applied resource transaction changed scope"),
+					)
 				} else {
 					next, outcomeErr := appliedResourceTransactionOutcome(applied)
-					ack.Err = outcomeErr
+					ack.Err = errors.Join(applyErr, outcomeErr)
 					if outcomeErr == nil {
 						slot.outcome = next
 						slot.cleanup = applied.cleanup
@@ -825,16 +914,19 @@ func (ts *TaskSupervisor) runChild(
 					transaction,
 				)
 				ack.Err = disposeErr
-				if disposeErr == nil {
-					if scope.Current.Valid() {
-						slot.outcome, ack.Err = readyResourceOutcome(current, scope.Current)
-					} else if current != nil {
-						ack.Err = errors.New(
-							"jobmgr task child: graph-only transaction disposal returned a resource",
-						)
-					} else {
-						slot.outcome = TaskOutcome{}
+				if scope.Current.Valid() {
+					next, outcomeErr := readyResourceOutcome(current, scope.Current)
+					ack.Err = errors.Join(ack.Err, outcomeErr)
+					if outcomeErr == nil {
+						slot.outcome = next
 					}
+				} else if current != nil {
+					ack.Err = errors.Join(
+						ack.Err,
+						errors.New("jobmgr task child: graph-only transaction disposal returned a resource"),
+					)
+				} else {
+					slot.outcome = TaskOutcome{}
 				}
 			} else {
 				ack.Err = disposeTaskOutcome(ctx, slot.outcome, slot.preserveDisposeContext)
@@ -855,12 +947,29 @@ func (ts *TaskSupervisor) runChild(
 			if !slot.outcome.empty() {
 				ack.Err = errors.New("jobmgr task child: terminate with published result")
 			}
+		case TaskActionAbandon:
+			ack.Abandoned = TaskAbandonment{
+				Outcome: slot.outcome.kind,
+				Cleanup: slot.cleanup != nil,
+			}
+			switch slot.outcome.kind {
+			case TaskOutcomeReadyResource, TaskOutcomeAppliedResourceTransaction:
+				ack.Abandoned.LongLivedPermits +=
+					ts.abandonLongLivedOwner(slot.outcome.identity)
+			case TaskOutcomePreparedResourceTransaction:
+				ack.Abandoned.LongLivedPermits +=
+					ts.abandonLongLivedOwner(slot.outcome.scope.Current)
+				ack.Abandoned.LongLivedPermits +=
+					ts.abandonLongLivedOwner(slot.outcome.scope.Successor)
+			}
+			slot.outcome = TaskOutcome{}
+			slot.cleanup = nil
 		default:
 			ack.Err = errors.New("jobmgr task child: unsupported phase action")
 		}
 		slot.sequence = action.Sequence
 		slot.actionPending = false
-		if action.Kind == TaskActionTerminate {
+		if action.Kind == TaskActionTerminate || action.Kind == TaskActionAbandon {
 			slot.joined = true
 			ts.acks <- ack
 			return
@@ -998,6 +1107,24 @@ func (ts *TaskSupervisor) request(ref TaskRequestRef) (*taskRequest, error) {
 }
 
 func (ts *TaskSupervisor) removeRequest(record *taskRequest) {
+	if record.queued {
+		ts.unlinkRequest(record)
+	}
+	slot := record.slot
+	generation := record.generation
+	*record = taskRequest{
+		slot:       slot,
+		generation: generation,
+		freeNext:   ts.freeRequest,
+	}
+	ts.freeRequest = slot
+	ts.observeRuntimeState()
+}
+
+func (ts *TaskSupervisor) unlinkRequest(record *taskRequest) {
+	if record == nil || !record.active || !record.queued {
+		return
+	}
 	queue := &ts.pending[taskClassIndex(record.class)]
 	if record.previous != 0 {
 		ts.requests[record.previous].next = record.next
@@ -1010,15 +1137,9 @@ func (ts *TaskSupervisor) removeRequest(record *taskRequest) {
 		queue.tail = record.previous
 	}
 	queue.count--
-	slot := record.slot
-	generation := record.generation
-	*record = taskRequest{
-		slot:       slot,
-		generation: generation,
-		freeNext:   ts.freeRequest,
-	}
-	ts.freeRequest = slot
-	ts.observeRuntimeState()
+	record.previous = 0
+	record.next = 0
+	record.queued = false
 }
 
 func (ts *TaskSupervisor) observeRuntimeState() {

--- a/src/go/plugin/agent/jobmgr/lifecycle/task_resource_test.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/task_resource_test.go
@@ -315,6 +315,30 @@ func TestTaskSupervisorRetainsReadyResourceWhenAbortFails(t *testing.T) {
 	require.Error(t, supervisor.Release(ref))
 }
 
+func TestTaskSupervisorDirtyAbandonmentReportsAndClearsOwnedOutcome(t *testing.T) {
+	supervisor := newResourceTaskSupervisor(t)
+	run, err := NewRunSupervisor(1, RealClock{}, time.Second)
+	require.NoError(t, err)
+	require.NoError(t, supervisor.BindRun(run, func() {}))
+	ready := &recordingReadyResource{
+		identity: ResourceIdentity{ID: "job", Generation: 1},
+		events:   new([]string),
+	}
+	_, ref := enqueueAndDispatchTask(t, supervisor, readyTaskPlan(t, SourceJobManager, time.Time{}, ready))
+	<-supervisor.CompletionCh()
+
+	require.Error(t, supervisor.Abandon(ref, 2))
+	run.Dirty(errors.New("test dirty run"))
+	require.NoError(t, supervisor.Abandon(ref, 2))
+	ack := <-supervisor.AcknowledgementCh()
+	require.Equal(t, TaskActionAbandon, ack.Kind)
+	require.NoError(t, ack.Err)
+	require.Equal(t, TaskOutcomeReadyResource, ack.Abandoned.Outcome)
+	require.False(t, ack.Abandoned.Cleanup)
+	require.NoError(t, supervisor.Release(ref))
+	require.Zero(t, supervisor.Active())
+}
+
 func newResourceTaskSupervisor(t *testing.T) *TaskSupervisor {
 	t.Helper()
 	frame, err := NewFrameOwner(io.Discard)

--- a/src/go/plugin/agent/jobmgr/lifecycle/task_transaction_test.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/task_transaction_test.go
@@ -4,6 +4,7 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -215,6 +216,160 @@ func TestTaskSupervisorDisposesPreparedTransactionAndRestoresCurrent(t *testing.
 	require.Equal(t, want, events)
 }
 
+func TestTaskSupervisorPreservesDisposedCurrentAlongsideError(t *testing.T) {
+	supervisor := newResourceTaskSupervisor(t)
+	failure := errors.New("dispose failed")
+	current := &recordingReadyResource{
+		identity: ResourceIdentity{ID: "job", Generation: 7},
+		events:   new([]string),
+	}
+	scope := ResourceTransactionScope{ID: "job", Current: current.identity}
+	prepared := &recordingPreparedResourceTransaction{
+		scope:      scope,
+		current:    current,
+		events:     new([]string),
+		disposeErr: failure,
+	}
+	plan, err := NewResourceTransactionTaskPlan(
+		SourceJobManager,
+		time.Time{},
+		TransactionTaskPhases,
+		current,
+		scope,
+		func(
+			context.Context,
+			ReadyResource,
+			ResourceTransactionScope,
+			LongLivedPermit,
+		) (PreparedResourceTransaction, error) {
+			return prepared, nil
+		},
+	)
+	require.NoError(t, err)
+	_, ref := enqueueAndDispatchTask(t, supervisor, plan)
+	<-supervisor.CompletionCh()
+
+	require.NoError(t, supervisor.SendAction(TaskAction{
+		Ref:      ref,
+		Sequence: 2,
+		Kind:     TaskActionDispose,
+	}))
+	require.ErrorIs(t, (<-supervisor.AcknowledgementCh()).Err, failure)
+
+	restored, err := supervisor.TakeDisposedResourceTransaction(ref, 2, scope)
+	require.NoError(t, err)
+	require.Same(t, current, restored)
+}
+
+func TestTaskSupervisorPreservesAppliedOwnershipAlongsideError(t *testing.T) {
+	supervisor := newResourceTaskSupervisor(t)
+	failure := errors.New("apply failed after ownership changed")
+	owned := &recordingReadyResource{
+		identity: ResourceIdentity{ID: "job", Generation: 1},
+		events:   new([]string),
+	}
+	scope := ResourceTransactionScope{
+		ID:      "job",
+		Current: owned.identity,
+	}
+	result, err := NewSealedResult(200, "application/json", []byte(`{}`))
+	require.NoError(t, err)
+	applied, err := NewAppliedResourceTransaction(
+		scope,
+		ResourceTransactionUnchanged,
+		owned,
+		result,
+		func() error { return nil },
+	)
+	require.NoError(t, err)
+	prepared := &recordingPreparedResourceTransaction{
+		scope:    scope,
+		applied:  applied,
+		events:   new([]string),
+		applyErr: failure,
+	}
+	plan, err := NewResourceTransactionTaskPlan(
+		SourceJobManager,
+		time.Time{},
+		TransactionTaskPhases,
+		owned,
+		scope,
+		func(
+			context.Context,
+			ReadyResource,
+			ResourceTransactionScope,
+			LongLivedPermit,
+		) (PreparedResourceTransaction, error) {
+			return prepared, nil
+		},
+	)
+	require.NoError(t, err)
+	_, ref := enqueueAndDispatchTask(t, supervisor, plan)
+	<-supervisor.CompletionCh()
+
+	require.NoError(t, supervisor.SendAction(TaskAction{
+		Ref:      ref,
+		Sequence: 2,
+		Kind:     TaskActionApplyResourceTransaction,
+	}))
+	completion := <-supervisor.CompletionCh()
+	require.ErrorIs(t, completion.Err, failure)
+	require.Equal(t, TaskOutcomeAppliedResourceTransaction, completion.Kind)
+
+	disposition, current, err := supervisor.TakeAppliedResourceTransaction(ref, 2, scope)
+	require.NoError(t, err)
+	require.Equal(t, ResourceTransactionUnchanged, disposition)
+	require.Same(t, owned, current)
+}
+
+func TestTaskSupervisorParksStartFailureOutsideRunnableQueue(t *testing.T) {
+	supervisor := newResourceTaskSupervisor(t)
+	owner := ResourceIdentity{ID: "job", Generation: 1}
+	scope := ResourceTransactionScope{ID: owner.ID, Successor: owner}
+	plan, err := NewResourceTransactionPermitTaskPlan(
+		SourceJobManager,
+		time.Time{},
+		TransactionTaskPhases,
+		nil,
+		scope,
+		NewJobLongLivedPlan(),
+		func(
+			context.Context,
+			ReadyResource,
+			ResourceTransactionScope,
+			LongLivedPermit,
+		) (PreparedResourceTransaction, error) {
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	first, err := supervisor.Enqueue(TaskClassFrameworkControl, plan)
+	require.NoError(t, err)
+	second, err := supervisor.Enqueue(TaskClassFrameworkControl, plan)
+	require.NoError(t, err)
+
+	var started [TaskStartServiceQuantum]TaskStart
+	count, more, err := supervisor.Dispatch(context.Background(), 2, &started)
+	require.Error(t, err)
+	require.Equal(t, 1, count)
+	require.False(t, more)
+	require.Zero(t, supervisor.Pending())
+
+	_, err = supervisor.CancelPendingOutcome(second)
+	require.NoError(t, err)
+	_, err = supervisor.CancelPendingOutcome(first)
+	require.Error(t, err)
+
+	completion := <-supervisor.CompletionCh()
+	require.NoError(t, supervisor.SendAction(TaskAction{
+		Ref:      completion.Ref,
+		Sequence: completion.Sequence + 1,
+		Kind:     TaskActionTerminate,
+	}))
+	<-supervisor.AcknowledgementCh()
+	require.NoError(t, supervisor.Release(completion.Ref))
+}
+
 func TestResourceTransactionPermitPlanRejectsPipelineReplacement(t *testing.T) {
 	plan, err := NewPipelineLongLivedPlan([]string{"provider"})
 	require.NoError(t, err)
@@ -254,6 +409,8 @@ type recordingPreparedResourceTransaction struct {
 	applied         AppliedResourceTransaction
 	events          *[]string
 	applyContextErr error
+	applyErr        error
+	disposeErr      error
 }
 
 func (rprt *recordingPreparedResourceTransaction) Scope() ResourceTransactionScope {
@@ -263,10 +420,10 @@ func (rprt *recordingPreparedResourceTransaction) Scope() ResourceTransactionSco
 func (rprt *recordingPreparedResourceTransaction) Apply(ctx context.Context) (AppliedResourceTransaction, error) {
 	rprt.applyContextErr = ctx.Err()
 	*rprt.events = append(*rprt.events, "apply")
-	return rprt.applied, nil
+	return rprt.applied, rprt.applyErr
 }
 
 func (rprt *recordingPreparedResourceTransaction) Dispose(context.Context) (ReadyResource, error) {
 	*rprt.events = append(*rprt.events, "dispose")
-	return rprt.current, nil
+	return rprt.current, rprt.disposeErr
 }

--- a/src/go/plugin/agent/jobmgr/lifecycle/transaction.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/transaction.go
@@ -75,6 +75,16 @@ func (art AppliedResourceTransaction) ResultStatus() int {
 	return art.result.status
 }
 
+// Ownership returns the exact resource ownership described by the applied
+// transaction, including when Apply returned it alongside an error.
+func (art AppliedResourceTransaction) Ownership() (
+	ResourceTransactionScope,
+	ResourceTransactionDisposition,
+	ReadyResource,
+) {
+	return art.scope, art.disposition, art.current
+}
+
 func NewAppliedResourceTransaction(
 	scope ResourceTransactionScope,
 	disposition ResourceTransactionDisposition,

--- a/src/go/plugin/agent/jobmgr/lifecycle/types.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/types.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"strings"
 	"time"
 )
 
-var ErrFunctionResultTooLarge = errors.New("jobmgr lifecycle: Function result exceeds bound")
+var (
+	ErrFunctionResultTooLarge = errors.New("jobmgr lifecycle: Function result exceeds bound")
+	ErrUnsafeFunctionResult   = errors.New("jobmgr lifecycle: unsafe Function result payload")
+)
 
 const (
 	TaskStartServiceQuantum             = 4
@@ -68,10 +70,38 @@ func (sr SealedResult) validate() error {
 	if sr.status < 100 || sr.status > 599 {
 		return errors.New("jobmgr lifecycle: invalid result status")
 	}
-	if sr.contentType == "" || strings.ContainsAny(sr.contentType, " \t\r\n\x00") {
+	if sr.contentType == "" || !validPluginsDBareField(sr.contentType) {
 		return errors.New("jobmgr lifecycle: invalid result content type")
 	}
+	if functionResultPayloadHasTerminator(sr.payload) {
+		return ErrUnsafeFunctionResult
+	}
 	return validateFunctionPayloadSize(len(sr.payload))
+}
+
+func functionResultPayloadHasTerminator(payload []byte) bool {
+	const terminator = "FUNCTION_RESULT_END"
+	for lineStart := 0; lineStart <= len(payload); {
+		lineEnd := lineStart
+		for lineEnd < len(payload) && payload[lineEnd] != '\n' {
+			lineEnd++
+		}
+		tokenStart := lineStart
+		for tokenStart < lineEnd && pluginsDSeparator(payload[tokenStart]) {
+			tokenStart++
+		}
+		tokenEnd := tokenStart + len(terminator)
+		if tokenEnd <= lineEnd &&
+			string(payload[tokenStart:tokenEnd]) == terminator &&
+			(tokenEnd == lineEnd || payload[tokenEnd] == 0 || pluginsDSeparator(payload[tokenEnd])) {
+			return true
+		}
+		if lineEnd == len(payload) {
+			return false
+		}
+		lineStart = lineEnd + 1
+	}
+	return false
 }
 
 type TaskWork func(context.Context) (TaskOutcome, error)

--- a/src/go/plugin/agent/jobmgr/proposal.go
+++ b/src/go/plugin/agent/jobmgr/proposal.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import "errors"
+
+// ProposalRejection marks an external proposal that this run cannot apply.
+// It is not a kernel, ownership, cancellation, or infrastructure failure.
+type ProposalRejection struct {
+	cause error
+}
+
+func (pr *ProposalRejection) Error() string {
+	if pr == nil || pr.cause == nil {
+		return "jobmgr: proposal rejected"
+	}
+	return "jobmgr: proposal rejected: " + pr.cause.Error()
+}
+
+func (pr *ProposalRejection) Unwrap() error {
+	if pr == nil {
+		return nil
+	}
+	return pr.cause
+}
+
+func RejectProposal(cause error) error {
+	if cause == nil {
+		cause = errors.New("unspecified proposal rejection")
+	}
+	if _, ok := errors.AsType[*ProposalRejection](cause); ok {
+		return cause
+	}
+	return &ProposalRejection{cause: cause}
+}
+
+func IsProposalRejection(err error) bool {
+	_, ok := errors.AsType[*ProposalRejection](err)
+	return ok
+}

--- a/src/go/plugin/agent/jobmgr/secrets/commands.go
+++ b/src/go/plugin/agent/jobmgr/secrets/commands.go
@@ -156,21 +156,33 @@ func (c *Controller) prepareAdd(
 	input CommandInput,
 	target secretTarget,
 ) (lifecycle.PreparedResourceTransaction, error) {
-	_, exists := c.entry(target.key)
-	if current != nil || scope.Current.Valid() || exists {
-		return c.noopMessageWithPermit(
-			scope,
-			current,
-			permit,
-			409,
-			fmt.Sprintf("The specified secretstore '%s' already exists.", target.key),
-		)
-	}
 	config, err := c.configFromPayload(input, target)
 	if err != nil {
 		return c.noopMessageWithPermit(scope, current, permit, 400, msgInvalidSecretStoreConfig)
 	}
-	return c.prepareStoreMutation(ctx, scope, current, permit, config, 0, true)
+	entry, exists := c.entry(target.key)
+	expected := c.store.Generation(target.key)
+	if expected != 0 {
+		if !exists || current == nil || !scope.Current.Valid() {
+			return nil, errors.New("jobmgr secrets: active Store differs from command resource")
+		}
+	} else if current != nil || scope.Current.Valid() {
+		return nil, errors.New("jobmgr secrets: command resource has no active Store")
+	}
+	if expected != 0 &&
+		entry.status == dyncfg.StatusRunning &&
+		entry.config.SourceType() == confgroup.TypeDyncfg &&
+		entry.config.Hash() == config.Hash() {
+		return c.noop(
+			scope,
+			current,
+			permit,
+			mustSecretMessage(200, ""),
+			nil,
+			c.configCreateCleanup(entry),
+		)
+	}
+	return c.prepareStoreMutation(ctx, scope, current, permit, config, expected, expected == 0)
 }
 
 func (c *Controller) prepareUpdate(

--- a/src/go/plugin/agent/jobmgr/secrets/controller.go
+++ b/src/go/plugin/agent/jobmgr/secrets/controller.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	SecretGraphClaim = "dyncfg:secretstores"
+	SecretGraphClaim = "dyncfg:dependency-graph"
 	dynCfgSecretPath = "/collectors/%s/SecretStores"
 )
 
@@ -40,20 +40,20 @@ type ControllerConfig struct {
 }
 
 type Controller struct {
-	mu sync.Mutex // guards entries, published, restarts, and initial
+	mu sync.Mutex // guards entries, commandsReady, restarts, and initial
 
-	epoch        uint64                      // run generation
-	prefix       string                      // "<plugin>:secretstore:" ID prefix
-	path         string                      // "/collectors/<plugin>/SecretStores" config path
-	frames       *lifecycle.FrameOwner       // protocol frame sink
-	store        *secretstore.SecretStore    // per-run secret store
-	creators     *secretstore.CreatorCatalog // frozen creator catalog
-	dependencies *SecretDependencyIndex      // secret dependency index
-	diagnostics  jobmgr.DiagnosticObserver   // operational log sink
-	initial      []secretstore.Config        // initial secret store configs
-	entries      map[string]secretEntry      // published store entries by key
-	restarts     *SecretRestartCommand       // dependent-job restart command (bound at Bind)
-	published    bool                        // initial snapshot has been published
+	epoch         uint64                      // run generation
+	prefix        string                      // "<plugin>:secretstore:" ID prefix
+	path          string                      // "/collectors/<plugin>/SecretStores" config path
+	frames        *lifecycle.FrameOwner       // protocol frame sink
+	store         *secretstore.SecretStore    // per-run secret store
+	creators      *secretstore.CreatorCatalog // frozen creator catalog
+	dependencies  *SecretDependencyIndex      // secret dependency index
+	diagnostics   jobmgr.DiagnosticObserver   // operational log sink
+	initial       []secretstore.Config        // initial secret store configs
+	entries       map[string]secretEntry      // published store entries by key
+	restarts      *SecretRestartCommand       // dependent-job restart command (bound at Bind)
+	commandsReady bool                        // templates are visible and commands may execute
 }
 
 type secretEntry struct {
@@ -90,7 +90,7 @@ func (c *Controller) Bind(jobs DependentJobPort) error {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.restarts != nil || c.published {
+	if c.restarts != nil || c.commandsReady {
 		return errors.New("jobmgr secrets: duplicate or late controller binding")
 	}
 	restarts, err := NewSecretRestartCommand(c.epoch, c.dependencies, jobs, c.diagnostics)
@@ -119,9 +119,9 @@ func (c *Controller) Prepare(
 		return nil, errors.New("jobmgr secrets: invalid transaction preparation")
 	}
 	c.mu.Lock()
-	published := c.published
+	commandsReady := c.commandsReady
 	c.mu.Unlock()
-	if !published {
+	if !commandsReady {
 		return c.noopMessageWithPermit(
 			scope,
 			current,
@@ -162,6 +162,22 @@ func (c *Controller) Prepare(
 		)
 	}
 	return c.observeTransaction(target, transaction, err)
+}
+
+func (c *Controller) CompositeChildLaneConflict(input CommandInput, lane string) bool {
+	if c == nil || lane == "" {
+		return false
+	}
+	target, failure := c.resolveTarget(input)
+	if failure != nil {
+		return false
+	}
+	switch target.command {
+	case dyncfg.CommandAdd, dyncfg.CommandUpdate:
+	default:
+		return false
+	}
+	return c.dependencies.Affects(target.key, lane, true)
 }
 
 type secretTarget struct {
@@ -304,14 +320,16 @@ func mustSecretMessage(code int, message string) lifecycle.SealedResult {
 	return result
 }
 
-func (c *Controller) protocolCleanup(build func(*netdataapi.API)) lifecycle.TaskCleanup {
+func (c *Controller) protocolCleanup(build func(*netdataapi.API) error) lifecycle.TaskCleanup {
 	if c == nil || build == nil {
 		return func() error {
 			return errors.New("jobmgr secrets: invalid protocol cleanup")
 		}
 	}
 	var payload bytes.Buffer
-	build(netdataapi.New(&payload))
+	if err := build(netdataapi.New(&payload)); err != nil {
+		return func() error { return err }
+	}
 	prepared, err := lifecycle.PrepareProtocolFrame(payload.Bytes())
 	if err != nil {
 		return func() error { return err }
@@ -332,8 +350,8 @@ func (c *Controller) configCreateCleanup(entry secretEntry) lifecycle.TaskCleanu
 	if entry.config.SourceType() == confgroup.TypeDyncfg {
 		commands += " " + string(dyncfg.CommandRemove)
 	}
-	return c.protocolCleanup(func(api *netdataapi.API) {
-		api.CONFIGCREATE(netdataapi.ConfigOpts{
+	return c.protocolCleanup(func(api *netdataapi.API) error {
+		return api.TryCONFIGCREATE(netdataapi.ConfigOpts{
 			ID:                c.prefix + entry.config.ExposedKey(),
 			Status:            entry.status.String(),
 			ConfigType:        dyncfg.ConfigTypeJob.String(),
@@ -346,19 +364,22 @@ func (c *Controller) configCreateCleanup(entry secretEntry) lifecycle.TaskCleanu
 }
 
 func (c *Controller) configDeleteCleanup(key string) lifecycle.TaskCleanup {
-	return c.protocolCleanup(func(api *netdataapi.API) {
-		api.CONFIGDELETE(c.prefix + key)
+	return c.protocolCleanup(func(api *netdataapi.API) error {
+		return api.TryCONFIGDELETE(c.prefix + key)
 	})
 }
 
 func (c *Controller) templateCleanup() lifecycle.TaskCleanup {
 	kinds := c.creators.Kinds()
 	if len(kinds) == 0 {
-		return func() error { return nil }
+		return func() error {
+			c.setCommandsReady(true)
+			return nil
+		}
 	}
-	return c.protocolCleanup(func(api *netdataapi.API) {
+	emit := c.protocolCleanup(func(api *netdataapi.API) error {
 		for _, kind := range kinds {
-			api.CONFIGCREATE(netdataapi.ConfigOpts{
+			if err := api.TryCONFIGCREATE(netdataapi.ConfigOpts{
 				ID:         c.prefix + string(kind),
 				Status:     dyncfg.StatusAccepted.String(),
 				ConfigType: dyncfg.ConfigTypeTemplate.String(),
@@ -370,9 +391,26 @@ func (c *Controller) templateCleanup() lifecycle.TaskCleanup {
 					dyncfg.CommandSchema,
 					dyncfg.CommandUserconfig,
 				),
-			})
+			}); err != nil {
+				return err
+			}
 		}
+		return nil
 	})
+	return func() error {
+		c.setCommandsReady(true)
+		if err := emit(); err != nil {
+			c.setCommandsReady(false)
+			return err
+		}
+		return nil
+	}
+}
+
+func (c *Controller) setCommandsReady(ready bool) {
+	c.mu.Lock()
+	c.commandsReady = ready
+	c.mu.Unlock()
 }
 
 func parseSecretPayload(input CommandInput, target any) error {

--- a/src/go/plugin/agent/jobmgr/secrets/dependency.go
+++ b/src/go/plugin/agent/jobmgr/secrets/dependency.go
@@ -97,6 +97,19 @@ func (sdi *SecretDependencyIndex) Affected(storeKey string, runningOnly bool) []
 	return refs
 }
 
+func (sdi *SecretDependencyIndex) Affects(storeKey, id string, runningOnly bool) bool {
+	if sdi == nil || storeKey == "" || id == "" {
+		return false
+	}
+	sdi.mu.RLock()
+	defer sdi.mu.RUnlock()
+	if _, ok := sdi.byStore[storeKey][id]; !ok {
+		return false
+	}
+	dependency, ok := sdi.jobs[id]
+	return ok && (!runningOnly || dependency.running)
+}
+
 func (sdi *SecretDependencyIndex) commitJobChange(id string, next *jobDependency) {
 	sdi.mu.Lock()
 	defer sdi.mu.Unlock()

--- a/src/go/plugin/agent/jobmgr/secrets/dependency_test.go
+++ b/src/go/plugin/agent/jobmgr/secrets/dependency_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -97,6 +98,38 @@ func TestSecretDependencyIndexTracksAcknowledgedPostimages(t *testing.T) {
 
 	refs := index.Affected("vault:main", true)
 	require.False(t, len(refs) != 1 || refs[0].ID != "module_one")
+	require.True(t, index.Affects("vault:main", "module_one", true))
+	require.False(t, index.Affects("vault:main", "module_two", true))
+	require.True(t, index.Affects("vault:main", "module_two", false))
+
+	creators, err := secretstore.NewCreatorCatalog([]secretstore.Creator{{
+		Kind: secretstore.KindVault,
+		Create: func() secretstore.Store {
+			return &transactionTestStore{}
+		},
+	}})
+	require.NoError(t, err)
+	controller := &Controller{
+		prefix:       "go.d:secretstore:",
+		creators:     creators,
+		dependencies: index,
+	}
+	require.True(t, controller.CompositeChildLaneConflict(
+		CommandInput{Args: []string{"go.d:secretstore:vault:main", "update"}},
+		"module_one",
+	))
+	require.True(t, controller.CompositeChildLaneConflict(
+		CommandInput{Args: []string{"go.d:secretstore:vault", "add", "main"}},
+		"module_one",
+	))
+	require.False(t, controller.CompositeChildLaneConflict(
+		CommandInput{Args: []string{"go.d:secretstore:vault:main", "update"}},
+		"module_two",
+	))
+	require.False(t, controller.CompositeChildLaneConflict(
+		CommandInput{Args: []string{"go.d:secretstore:vault:main", "remove"}},
+		"module_one",
+	))
 
 	commit, err := index.PrepareJobChange("module_one", nil)
 	require.NoError(t, err)
@@ -106,6 +139,36 @@ func TestSecretDependencyIndexTracksAcknowledgedPostimages(t *testing.T) {
 
 	refs = index.Affected("vault:main", false)
 	require.False(t, len(refs) != 1 || refs[0].ID != "module_two")
+}
+
+func TestSecretDependencyIndexAcceptsMixedReferenceProviders(t *testing.T) {
+	index := NewSecretDependencyIndex()
+	payload, err := yaml.Marshal(map[string]any{
+		"module": "module",
+		"name":   "mixed",
+		"token":  "${store:vault:main:value}",
+		"host":   "${HOST:-localhost}",
+		"path":   "${file:/run/config}",
+		"custom": "${custom:operand}",
+	})
+	require.NoError(t, err)
+
+	commit, err := index.PrepareJobChange(
+		"module_mixed",
+		&dyncfg.GraphConfig{
+			ID:      "module_mixed",
+			Module:  "module",
+			Name:    "mixed",
+			Status:  dyncfg.StatusRunning.String(),
+			Payload: payload,
+		},
+	)
+	require.NoError(t, err)
+	commit()
+
+	refs := index.Affected("vault:main", true)
+	require.Len(t, refs, 1)
+	require.Equal(t, "module_mixed", refs[0].ID)
 }
 
 func BenchmarkBSecretDependencyLookup(b *testing.B) {

--- a/src/go/plugin/agent/jobmgr/secrets/initial.go
+++ b/src/go/plugin/agent/jobmgr/secrets/initial.go
@@ -22,19 +22,21 @@ func (c *Controller) PublishInitial(ctx context.Context, commands jobmgr.Prepare
 		return errors.New("jobmgr secrets: invalid initial publication")
 	}
 	c.mu.Lock()
-	if c.restarts == nil || c.published {
+	if c.restarts == nil || c.commandsReady {
 		c.mu.Unlock()
 		return errors.New("jobmgr secrets: unbound or duplicate initial publication")
 	}
 	initial := sortedInitialConfigs(c.initial)
 	c.mu.Unlock()
-	if err := c.publishTemplates(ctx, commands); err != nil {
-		return err
-	}
 	for index, config := range initial {
 		if config == nil || config.ExposedKey() == "" || config.Validate() != nil {
 			return fmt.Errorf("jobmgr secrets: invalid initial configuration %d", index)
 		}
+	}
+	if err := c.publishTemplates(ctx, commands); err != nil {
+		return err
+	}
+	for index, config := range initial {
 		plan, err := c.planInitial(config)
 		if err != nil {
 			return err
@@ -54,7 +56,6 @@ func (c *Controller) PublishInitial(ctx context.Context, commands jobmgr.Prepare
 	}
 	c.mu.Lock()
 	c.initial = nil
-	c.published = true
 	c.mu.Unlock()
 	return nil
 }
@@ -150,8 +151,6 @@ func (c *Controller) Close(ctx context.Context) error {
 	if c == nil || ctx == nil {
 		return errors.New("jobmgr secrets: invalid controller close")
 	}
-	c.mu.Lock()
-	c.published = false
-	c.mu.Unlock()
+	c.setCommandsReady(false)
 	return c.store.Close(ctx)
 }

--- a/src/go/plugin/agent/jobmgr/secrets/initial_test.go
+++ b/src/go/plugin/agent/jobmgr/secrets/initial_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package secrets
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplatePublicationAcceptsReplayBeforeFrameBecomesVisible(t *testing.T) {
+	resourceID := secretResourceID("vault:replay")
+	successor := lifecycle.ResourceIdentity{ID: resourceID, Generation: 1}
+	var controller *Controller
+	var permit lifecycle.LongLivedPermit
+	var owned lifecycle.ReadyResource
+	status := 0
+	writer := secretTestWriteFunc(func(payload []byte) (int, error) {
+		if bytes.Contains(payload, []byte("CONFIG go.d:secretstore:vault create accepted template")) {
+			transaction, err := controller.Prepare(
+				t.Context(),
+				CommandInput{
+					Args:        []string{"go.d:secretstore:vault", "add", "replay"},
+					Payload:     []byte(`{"value":"restored"}`),
+					ContentType: "application/json",
+					HasPayload:  true,
+				},
+				nil,
+				lifecycle.ResourceTransactionScope{
+					ID:        resourceID,
+					Successor: successor,
+				},
+				permit,
+			)
+			require.NoError(t, err)
+			applied, err := transaction.Apply(t.Context())
+			require.NoError(t, err)
+			_, _, owned = applied.Ownership()
+			status = applied.ResultStatus()
+		}
+		return len(payload), nil
+	})
+	var store *secretstore.SecretStore
+	var supervisor *lifecycle.TaskSupervisor
+	controller, store, supervisor = newSecretControllerTestHarnessWithWriter(t, nil, writer)
+	require.NoError(t, controller.Bind(restartTestJobs{}))
+	issuedPermit, err := supervisor.IssueLongLivedPermit(successor, lifecycle.NewSecretStoreLongLivedPlan())
+	require.NoError(t, err)
+	permit = issuedPermit
+
+	require.NoError(t, controller.templateCleanup()())
+	if owned != nil {
+		require.NoError(t, owned.Finalize())
+	}
+	require.NoError(t, store.Close(t.Context()))
+	require.Equal(t, 200, status)
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, supervisor.LongLivedCensus())
+}
+
+func TestConfigPublicationPreservesWindowsSourcePath(t *testing.T) {
+	const source = `file=C:\Program Files\Netdata\etc\netdata\ss\vault.conf`
+	var output bytes.Buffer
+	controller, store, _ := newSecretControllerTestHarnessWithWriter(t, nil, &output)
+	config := secretstore.Config{
+		"name":            "main",
+		"kind":            string(secretstore.KindVault),
+		"__source__":      source,
+		"__source_type__": confgroup.TypeUser,
+	}
+
+	require.NoError(t, controller.configCreateCleanup(secretEntry{
+		config: config,
+		status: dyncfg.StatusRunning,
+	})())
+	require.Contains(t, output.String(), `'`+source+`'`)
+	require.NoError(t, store.Close(t.Context()))
+}
+
+func TestSecretAddCollisionIsReplayUpsert(t *testing.T) {
+	controller, store, supervisor := newSecretControllerTestHarness(t, nil)
+	require.NoError(t, controller.Bind(restartTestJobs{}))
+	controller.setCommandsReady(true)
+
+	existing := secretTestConfig(confgroup.TypeUser, "original")
+	carrier := &transactionTestCarrier{}
+	mutation, err := store.PrepareMutation(t.Context(), controller.creators, carrier, existing, 0)
+	require.NoError(t, err)
+	result, err := mutation.Commit(t.Context())
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+	controller.commitEntry(existing.ExposedKey(), &secretEntry{
+		config: existing,
+		status: dyncfg.StatusRunning,
+	})
+
+	resourceID := secretResourceID(existing.ExposedKey())
+	currentIdentity := lifecycle.ResourceIdentity{ID: resourceID, Generation: 1}
+	current, err := newStoreGenerationResource(
+		currentIdentity,
+		store,
+		existing.ExposedKey(),
+		result.Generation,
+	)
+	require.NoError(t, err)
+	successorIdentity := lifecycle.ResourceIdentity{ID: resourceID, Generation: 2}
+	permit, err := supervisor.IssueLongLivedPermit(
+		successorIdentity,
+		lifecycle.NewSecretStoreLongLivedPlan(),
+	)
+	require.NoError(t, err)
+
+	add := CommandInput{
+		Args:        []string{"go.d:secretstore:vault", "add", "main"},
+		Payload:     []byte(`{"value":"replacement"}`),
+		ContentType: "application/json",
+		HasPayload:  true,
+	}
+	transaction, err := controller.Prepare(
+		t.Context(),
+		add,
+		current,
+		lifecycle.ResourceTransactionScope{
+			ID:        resourceID,
+			Current:   currentIdentity,
+			Successor: successorIdentity,
+		},
+		permit,
+	)
+	require.NoError(t, err)
+	applied, err := transaction.Apply(t.Context())
+	require.NoError(t, err)
+	_, disposition, owned := applied.Ownership()
+	active, ok := store.Config(existing.ExposedKey())
+	require.True(t, ok)
+	require.NotNil(t, owned)
+	require.Equal(t, 200, applied.ResultStatus())
+	require.Equal(t, lifecycle.ResourceTransactionReplaced, disposition)
+	require.Equal(t, confgroup.TypeDyncfg, active.SourceType())
+	require.Equal(t, "replacement", active["value"])
+
+	repeatSuccessor := lifecycle.ResourceIdentity{ID: resourceID, Generation: 3}
+	repeatPermit, err := supervisor.IssueLongLivedPermit(
+		repeatSuccessor,
+		lifecycle.NewSecretStoreLongLivedPlan(),
+	)
+	require.NoError(t, err)
+	repeat, err := controller.Prepare(
+		t.Context(),
+		add,
+		owned,
+		lifecycle.ResourceTransactionScope{
+			ID:        resourceID,
+			Current:   successorIdentity,
+			Successor: repeatSuccessor,
+		},
+		repeatPermit,
+	)
+	require.NoError(t, err)
+	repeated, err := repeat.Apply(t.Context())
+	require.NoError(t, err)
+	_, repeatDisposition, repeatOwned := repeated.Ownership()
+	require.Equal(t, 200, repeated.ResultStatus())
+	require.Equal(t, lifecycle.ResourceTransactionUnchanged, repeatDisposition)
+	require.Same(t, owned, repeatOwned)
+
+	require.NoError(t, repeatOwned.Finalize())
+	require.NoError(t, store.Close(t.Context()))
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, supervisor.LongLivedCensus())
+}
+
+func newSecretControllerTestHarness(
+	t *testing.T,
+	initial []secretstore.Config,
+) (*Controller, *secretstore.SecretStore, *lifecycle.TaskSupervisor) {
+	return newSecretControllerTestHarnessWithWriter(t, initial, io.Discard)
+}
+
+func newSecretControllerTestHarnessWithWriter(
+	t *testing.T,
+	initial []secretstore.Config,
+	writer io.Writer,
+) (*Controller, *secretstore.SecretStore, *lifecycle.TaskSupervisor) {
+	t.Helper()
+	resolver, err := secretresolver.NewAtomicResolver(nil)
+	require.NoError(t, err)
+	store, err := secretstore.NewSecretStore(resolver)
+	require.NoError(t, err)
+	catalog, err := secretstore.NewCreatorCatalog([]secretstore.Creator{{
+		Kind:   secretstore.KindVault,
+		Schema: `{}`,
+		Create: func() secretstore.Store {
+			return &transactionTestStore{}
+		},
+	}})
+	require.NoError(t, err)
+	frames, err := lifecycle.NewFrameOwner(writer)
+	require.NoError(t, err)
+	supervisor, err := lifecycle.NewTaskSupervisor(frames)
+	require.NoError(t, err)
+	controller, err := NewController(ControllerConfig{
+		Epoch:        1,
+		PluginName:   "go.d",
+		Frames:       frames,
+		Store:        store,
+		Creators:     catalog,
+		Dependencies: NewSecretDependencyIndex(),
+		Initial:      initial,
+	})
+	require.NoError(t, err)
+	return controller, store, supervisor
+}
+
+type secretTestWriteFunc func([]byte) (int, error)
+
+func (fn secretTestWriteFunc) Write(payload []byte) (int, error) {
+	return fn(payload)
+}
+
+func secretTestConfig(sourceType, value string) secretstore.Config {
+	return secretstore.Config{
+		"name":            "main",
+		"kind":            string(secretstore.KindVault),
+		"value":           value,
+		"__source__":      sourceType + "=test",
+		"__source_type__": sourceType,
+	}
+}

--- a/src/go/plugin/agent/jobmgr/secrets/restart.go
+++ b/src/go/plugin/agent/jobmgr/secrets/restart.go
@@ -7,10 +7,16 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+)
+
+const (
+	defaultDependentRestartChildTimeout = 20 * time.Second
+	maximumDependentRestartBudget       = 2 * time.Minute
 )
 
 // SecretRestartCommand serializes acknowledged dependent stop, Store commit,
@@ -23,6 +29,8 @@ type SecretRestartCommand struct {
 	jobs         DependentJobPort          // port used to stop/start dependent jobs
 	diagnostics  jobmgr.DiagnosticObserver // operational log sink
 	nextUID      uint64                    // next child-command UID to assign
+	childTimeout time.Duration             // maximum recovery work time for one dependent
+	budgetLimit  time.Duration             // aggregate recovery budget ceiling
 }
 
 func NewSecretRestartCommand(
@@ -39,6 +47,8 @@ func NewSecretRestartCommand(
 		dependencies: dependencies,
 		jobs:         jobs,
 		diagnostics:  diagnostics,
+		childTimeout: defaultDependentRestartChildTimeout,
+		budgetLimit:  maximumDependentRestartBudget,
 	}, nil
 }
 
@@ -122,7 +132,15 @@ func (src *SecretRestartCommand) start(
 	failures := make([]string, 0)
 	var integrityErr error
 	var operationalErr error
-	for _, id := range ids {
+	if len(ids) == 0 {
+		return failures, nil, nil
+	}
+	recoveryCtx, cancelRecovery := context.WithTimeout(
+		context.Background(),
+		src.aggregateRestartBudget(len(ids)),
+	)
+	defer cancelRecovery()
+	for index, id := range ids {
 		display := displayByID[id]
 		if display == "" {
 			display = id
@@ -133,8 +151,16 @@ func (src *SecretRestartCommand) start(
 			failures = append(failures, display)
 			continue
 		}
-		if err := src.submit(context.Background(), commands, id, "start", plan, true); err != nil {
-			integrityErr = errors.Join(integrityErr, err)
+		childCtx, cancelChild := src.childRestartContext(recoveryCtx, len(ids)-index)
+		err = src.submit(childCtx, commands, id, "start", plan, true)
+		cancelChild()
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) &&
+				!errors.Is(err, jobmgr.ErrCompositeRecoveryUnresolved) {
+				operationalErr = errors.Join(operationalErr, err)
+			} else {
+				integrityErr = errors.Join(integrityErr, err)
+			}
 			failures = append(failures, display)
 			continue
 		}
@@ -146,13 +172,40 @@ func (src *SecretRestartCommand) start(
 	return failures, integrityErr, operationalErr
 }
 
+func (src *SecretRestartCommand) aggregateRestartBudget(count int) time.Duration {
+	if src == nil || count <= 0 || src.childTimeout <= 0 || src.budgetLimit <= 0 {
+		return 0
+	}
+	if count > int(src.budgetLimit/src.childTimeout) {
+		return src.budgetLimit
+	}
+	return min(time.Duration(count)*src.childTimeout, src.budgetLimit)
+}
+
+func (src *SecretRestartCommand) childRestartContext(
+	parent context.Context,
+	remainingChildren int,
+) (context.Context, context.CancelFunc) {
+	timeout := src.childTimeout
+	if deadline, ok := parent.Deadline(); ok && remainingChildren > 0 {
+		fairShare := time.Until(deadline) / time.Duration(remainingChildren)
+		timeout = min(timeout, fairShare)
+	}
+	if timeout <= 0 {
+		ctx, cancel := context.WithCancel(parent)
+		cancel()
+		return ctx, cancel
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
 func (src *SecretRestartCommand) submit(
 	ctx context.Context,
 	commands jobmgr.CompositeCommandScope,
 	id string,
 	phase string,
 	plan jobmgr.WorkPlan,
-	rollback bool,
+	recovery bool,
 ) error {
 	src.mu.Lock()
 	src.nextUID++
@@ -167,8 +220,8 @@ func (src *SecretRestartCommand) submit(
 		Source:  lifecycle.SourceJobManager,
 		Route:   "internal/secrets/" + phase,
 	}
-	if rollback {
-		return commands.SubmitRollbackAndWait(request, plan)
+	if recovery {
+		return commands.SubmitRecoveryAndWait(ctx, request, plan)
 	}
 	return commands.SubmitPreparedAndWait(ctx, request, plan)
 }

--- a/src/go/plugin/agent/jobmgr/secrets/restart_test.go
+++ b/src/go/plugin/agent/jobmgr/secrets/restart_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
@@ -18,26 +19,28 @@ import (
 )
 
 type restartTestCommandScope struct {
-	normalErr          error
-	rollbackErr        error
-	rollbackContextErr error
-	rollbackCalls      int
+	normalErr     error
+	recoveryErr   error
+	recovery      func(context.Context) error
+	recoveryCalls int
+	recoveryCtx   []context.Context
 }
 
 func (rtcs *restartTestCommandScope) SubmitPreparedAndWait(context.Context, jobmgr.Request, jobmgr.WorkPlan) error {
 	return rtcs.normalErr
 }
 
-func (rtcs *restartTestCommandScope) SubmitRollbackAndWait(jobmgr.Request, jobmgr.WorkPlan) error {
-	rtcs.rollbackCalls++
-	return rtcs.rollbackErr
-}
-
-func (rtcs *restartTestCommandScope) RollbackContext() (context.Context, error) {
-	if rtcs.rollbackContextErr != nil {
-		return nil, rtcs.rollbackContextErr
+func (rtcs *restartTestCommandScope) SubmitRecoveryAndWait(
+	ctx context.Context,
+	_ jobmgr.Request,
+	_ jobmgr.WorkPlan,
+) error {
+	rtcs.recoveryCalls++
+	rtcs.recoveryCtx = append(rtcs.recoveryCtx, ctx)
+	if rtcs.recovery != nil {
+		return rtcs.recovery(ctx)
 	}
-	return context.Background(), nil
+	return rtcs.recoveryErr
 }
 
 type restartTestStop struct {
@@ -185,8 +188,84 @@ func TestSecretRestartCommandRestoresStopAcknowledgedDuringCancellation(t *testi
 	)
 	require.ErrorIs(t, err, context.Canceled)
 	require.True(t, restored)
-	require.EqualValues(t, 1, scope.rollbackCalls)
+	require.EqualValues(t, 1, scope.recoveryCalls)
 	require.False(t, commitCalled)
+}
+
+func TestSecretRestartTimeoutAfterAppliedMutationIsOperational(t *testing.T) {
+	index := NewSecretDependencyIndex()
+	config := confgroup.Config{
+		"module": "module",
+		"name":   "one",
+		"secret": "${store:vault:main:value}",
+	}
+	payload, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	commitDependency, err := index.PrepareJobChange(
+		config.FullName(),
+		&dyncfg.GraphConfig{
+			ID:      config.FullName(),
+			Module:  config.Module(),
+			Name:    config.Name(),
+			Status:  dyncfg.StatusRunning.String(),
+			Payload: payload,
+		},
+	)
+	require.NoError(t, err)
+	commitDependency()
+
+	command, err := NewSecretRestartCommand(1, index, restartTestJobs{}, nil)
+	require.NoError(t, err)
+	command.childTimeout = 10 * time.Millisecond
+	command.budgetLimit = 20 * time.Millisecond
+	scope := &restartTestCommandScope{
+		recovery: func(ctx context.Context) error {
+			<-ctx.Done()
+			return context.Cause(ctx)
+		},
+	}
+	result, message, restored, err := command.Apply(
+		context.Background(),
+		scope,
+		"vault:main",
+		func(context.Context) (secretstore.SecretMutationResult, error) {
+			return secretstore.SecretMutationResult{
+				Generation: 1,
+				Applied:    true,
+			}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+	require.False(t, restored)
+	require.Contains(t, message, "module:one")
+	require.EqualValues(t, 1, scope.recoveryCalls)
+	require.ErrorIs(t, scope.recoveryCtx[0].Err(), context.DeadlineExceeded)
+}
+
+func TestSecretRestartBudgetsCapAggregateAndFairShareChildren(t *testing.T) {
+	command := &SecretRestartCommand{
+		childTimeout: 100 * time.Millisecond,
+		budgetLimit:  150 * time.Millisecond,
+	}
+	require.Equal(t, 100*time.Millisecond, command.aggregateRestartBudget(1))
+	require.Equal(t, 150*time.Millisecond, command.aggregateRestartBudget(2))
+	require.Equal(t, 150*time.Millisecond, command.aggregateRestartBudget(100))
+
+	aggregate, cancelAggregate := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancelAggregate()
+	first, cancelFirst := command.childRestartContext(aggregate, 2)
+	defer cancelFirst()
+	second, cancelSecond := command.childRestartContext(aggregate, 1)
+	defer cancelSecond()
+	firstDeadline, firstOK := first.Deadline()
+	secondDeadline, secondOK := second.Deadline()
+	require.True(t, firstOK && secondOK)
+	aggregateDeadline, aggregateOK := aggregate.Deadline()
+	require.True(t, aggregateOK)
+	require.WithinDuration(t, aggregateDeadline.Add(-75*time.Millisecond), firstDeadline, 10*time.Millisecond)
+	require.WithinDuration(t, aggregateDeadline.Add(-50*time.Millisecond), secondDeadline, 10*time.Millisecond)
 }
 
 func TestSecretRestartCommandRedactsAppliedRestartFailure(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/secrets/transaction.go
+++ b/src/go/plugin/agent/jobmgr/secrets/transaction.go
@@ -148,10 +148,6 @@ func (pst *preparedSecretTransaction) apply(
 	if !result.Applied {
 		var abortErr error
 		if !commitCalled {
-			if commands != nil {
-				_, rollbackErr := commands.RollbackContext()
-				postCommitErr = errors.Join(postCommitErr, rollbackErr)
-			}
 			abortErr = spec.mutation.Abort()
 		}
 		if predecessorRestored && abortErr == nil {

--- a/src/go/plugin/agent/jobmgr/secrets/transaction_test.go
+++ b/src/go/plugin/agent/jobmgr/secrets/transaction_test.go
@@ -73,7 +73,6 @@ func TestCancelledStoreCommitWithoutDependentsIsSafeUnchanged(t *testing.T) {
 }
 
 func TestSecretTransactionAlwaysAbortsUncommittedMutation(t *testing.T) {
-	rollbackErr := errors.New("rollback context unavailable")
 	stopErr := errors.New("dependent stop failed")
 	resolver, err := secretresolver.NewAtomicResolver(nil)
 	require.NoError(t, err)
@@ -126,9 +125,7 @@ func TestSecretTransactionAlwaysAbortsUncommittedMutation(t *testing.T) {
 		controller: &Controller{},
 	})
 	require.NoError(t, err)
-	commands := &restartTestCommandScope{
-		rollbackContextErr: rollbackErr,
-	}
+	commands := &restartTestCommandScope{}
 
 	_, applyErr := transaction.ApplyComposite(t.Context(), commands)
 

--- a/src/go/plugin/agent/secrets/resolver/atomic.go
+++ b/src/go/plugin/agent/secrets/resolver/atomic.go
@@ -145,23 +145,38 @@ func (resolver *AtomicResolver) Resolve(
 	input any,
 	acquire AtomicScopeAcquirer,
 ) (any, error) {
+	resolved, _, err := resolver.ResolveWithReferences(ctx, input, acquire)
+	return resolved, err
+}
+
+// ResolveWithReferences resolves one value and reports whether its resolvable
+// surface contained any provider or Store reference. Callers use the flag to
+// avoid exposing errors derived from resolved values.
+func (resolver *AtomicResolver) ResolveWithReferences(
+	ctx context.Context,
+	input any,
+	acquire AtomicScopeAcquirer,
+) (any, bool, error) {
 	if resolver == nil {
-		return nil, errors.New("secret resolver: nil atomic resolver")
+		return nil, false, errors.New("secret resolver: nil atomic resolver")
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	compiler := atomicCompiler{
-		resolver: resolver, active: make(map[atomicContainerIdentity]struct{}),
-		storeKeys: make(map[string]struct{}),
+		providers:         resolver.providers,
+		validateProviders: true,
+		active:            make(map[atomicContainerIdentity]struct{}),
+		storeKeys:         make(map[string]struct{}),
 	}
 	cloned, err := compiler.clone(input, 0, true)
 	if err != nil {
-		return nil, err
+		return nil, compiler.references != 0, err
 	}
+	hasReferences := compiler.references != 0
 	keys := make([]string, 0, len(compiler.storeKeys))
 	for key := range compiler.storeKeys {
 		keys = append(keys, key)
@@ -171,7 +186,7 @@ func (resolver *AtomicResolver) Resolve(
 	var scope AtomicScope
 	if len(keys) != 0 {
 		if acquire == nil {
-			return nil, &AtomicResolveError{
+			return nil, hasReferences, &AtomicResolveError{
 				Kind: AtomicErrorScope, Cause: errors.New("no Store scope acquirer"),
 			}
 		}
@@ -180,10 +195,10 @@ func (resolver *AtomicResolver) Resolve(
 			if scope != nil {
 				err = errors.Join(err, callAtomicRelease(ctx, scope))
 			}
-			return nil, &AtomicResolveError{Kind: AtomicErrorScope, Cause: err}
+			return nil, hasReferences, &AtomicResolveError{Kind: AtomicErrorScope, Cause: err}
 		}
 		if scope == nil {
-			return nil, &AtomicResolveError{
+			return nil, hasReferences, &AtomicResolveError{
 				Kind: AtomicErrorScope, Cause: errors.New("acquirer returned nil scope"),
 			}
 		}
@@ -202,9 +217,9 @@ func (resolver *AtomicResolver) Resolve(
 		}
 	}
 	if resolveErr != nil || releaseErr != nil {
-		return nil, errors.Join(resolveErr, releaseErr)
+		return nil, hasReferences, errors.Join(resolveErr, releaseErr)
 	}
-	return resolved, nil
+	return resolved, hasReferences, nil
 }
 
 func callAtomicAcquire(
@@ -235,10 +250,12 @@ type atomicContainerIdentity struct {
 }
 
 type atomicCompiler struct {
-	resolver    *AtomicResolver
-	active      map[atomicContainerIdentity]struct{}
-	storeKeys   map[string]struct{}
-	resultBytes int
+	providers         map[string]AtomicProvider
+	active            map[atomicContainerIdentity]struct{}
+	storeKeys         map[string]struct{}
+	resultBytes       int
+	references        int
+	validateProviders bool
 }
 
 const (
@@ -467,6 +484,7 @@ func (compiler *atomicCompiler) compileReferences(value string) error {
 		if !reference.active {
 			return nil
 		}
+		compiler.references++
 		if err := compiler.addResultBytes(start - last); err != nil {
 			return err
 		}
@@ -475,7 +493,7 @@ func (compiler *atomicCompiler) compileReferences(value string) error {
 			compiler.storeKeys[reference.storeKey] = struct{}{}
 			return nil
 		}
-		if compiler.resolver.providers[reference.scheme] == nil {
+		if compiler.validateProviders && compiler.providers[reference.scheme] == nil {
 			return &AtomicResolveError{
 				Kind:  AtomicErrorReference,
 				Cause: boundedAtomicSchemeError("unknown provider", reference.scheme),

--- a/src/go/plugin/agent/secrets/resolver/atomic_test.go
+++ b/src/go/plugin/agent/secrets/resolver/atomic_test.go
@@ -253,6 +253,26 @@ func TestResolverStoreScopeLinear(t *testing.T) {
 	}
 }
 
+func TestStoreReferencesIgnoresNonStoreProviderReferences(t *testing.T) {
+	input := map[string]any{
+		"store":   "${store:vault:main:key}",
+		"env":     "${env:HOST}",
+		"file":    "${file:/run/secret}",
+		"cmd":     "${cmd:printf value}",
+		"custom":  "${custom:operand}",
+		"shell":   "${HOST:-localhost}",
+		"literal": "plain",
+	}
+
+	keys, err := StoreReferences(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(keys, []string{"vault:main"}) {
+		t.Fatalf("keys=%v", keys)
+	}
+}
+
 func BenchmarkBResolverTraversal(b *testing.B) {
 	resolver, err := NewAtomicResolver(map[string]AtomicProvider{
 		"test": AtomicProviderFunc(func(context.Context, string) ([]byte, error) {

--- a/src/go/plugin/agent/secrets/secretstore/fileconfig.go
+++ b/src/go/plugin/agent/secrets/secretstore/fileconfig.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"gopkg.in/yaml.v2"
@@ -55,12 +56,28 @@ func LoadFileConfigs(roots []string) ([]Config, []error) {
 			sourceType := fileConfigSourceType(path)
 			source := "file=" + path
 			for i, job := range jobs {
-				cfg := Config(job)
-				if strings.TrimSpace(cfg.Name()) == "" {
-					errs = append(errs, fmt.Errorf("secretstore file config '%s' job %d: store name is required", path, i+1))
+				if job == nil {
+					errs = append(
+						errs,
+						fmt.Errorf("secretstore file config '%s' job %d: store config is nil", path, i+1),
+					)
 					continue
 				}
-				if cfg.Kind() == "" {
+				cfg := Config(job)
+				rawKind, hasKind := job[keyKind]
+				if hasKind {
+					kind, ok := rawKind.(string)
+					if !ok {
+						errs = append(
+							errs,
+							fmt.Errorf("secretstore file config '%s' job %d: store kind must be a string", path, i+1),
+						)
+						continue
+					}
+					if strings.TrimSpace(kind) == "" {
+						cfg.SetKind(StoreKind(stem))
+					}
+				} else {
 					cfg.SetKind(StoreKind(stem))
 				}
 				cfg.SetSource(source)
@@ -99,20 +116,11 @@ func fileConfigSourceType(path string) string {
 }
 
 func validateFileConfig(cfg Config) error {
-	if cfg == nil {
-		return fmt.Errorf("store config is nil")
+	if err := cfg.Validate(); err != nil {
+		return err
 	}
-	if strings.TrimSpace(cfg.Name()) == "" {
-		return fmt.Errorf("store name is required")
-	}
-	if err := validateStoreName(cfg.Name()); err != nil {
-		return fmt.Errorf("invalid store name '%s': %w", cfg.Name(), err)
-	}
-	if strings.TrimSpace(string(cfg.Kind())) == "" {
-		return fmt.Errorf("store kind is required")
-	}
-	if strings.TrimSpace(cfg.Source()) == "" {
-		return fmt.Errorf("store source is required")
+	if !netdataapi.ValidSingleQuotedProtocolField(cfg.Source()) {
+		return fmt.Errorf("store source cannot be represented in the plugins.d CONFIG protocol")
 	}
 	switch cfg.SourceType() {
 	case confgroup.TypeUser, confgroup.TypeStock:

--- a/src/go/plugin/agent/secrets/secretstore/fileconfig_internal_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/fileconfig_internal_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package secretstore
+
+import (
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateFileConfigAcceptsWindowsSourcePath(t *testing.T) {
+	config := Config{
+		"name":            "main",
+		"kind":            string(KindVault),
+		"__source__":      `file=C:\Program Files\Netdata\etc\netdata\ss\vault.conf`,
+		"__source_type__": confgroup.TypeUser,
+	}
+
+	require.NoError(t, validateFileConfig(config))
+}
+
+func TestValidateFileConfigRefusesUnsafeSource(t *testing.T) {
+	config := Config{
+		"name":            "main",
+		"kind":            string(KindVault),
+		"__source__":      `file=C:\`,
+		"__source_type__": confgroup.TypeUser,
+	}
+
+	require.Error(t, validateFileConfig(config))
+}

--- a/src/go/plugin/agent/secrets/secretstore/fileconfig_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/fileconfig_test.go
@@ -63,7 +63,7 @@ jobs:
 		assert.Equal(t, confgroup.TypeStock, cfgs[3].SourceType())
 	})
 
-	t.Run("keeps explicit kind and allows unknown file stem", func(t *testing.T) {
+	t.Run("keeps explicit kind and rejects invalid inferred or typed kinds", func(t *testing.T) {
 		base := t.TempDir()
 		userRoot := filepath.Join(base, "etc", "netdata", "go.d")
 
@@ -80,13 +80,40 @@ jobs:
     mode_token:
       token: custom-token
     addr: https://vault.example
+  - name: non_string_kind
+    kind: 123
+    mode: token
+    mode_token:
+      token: custom-token
+    addr: https://vault.example
+`)
+
+		cfgs, errs := secretstore.LoadFileConfigs([]string{userRoot})
+		require.Len(t, cfgs, 1)
+		require.Len(t, errs, 2)
+		assert.Equal(t, secretstore.KindVault, cfgs[0].Kind())
+		assert.Contains(t, errs[0].Error(), "invalid store kind 'custom'")
+		assert.Contains(t, errs[1].Error(), "store kind must be a string")
+	})
+
+	t.Run("infers supported filename kind from an explicit empty string", func(t *testing.T) {
+		base := t.TempDir()
+		userRoot := filepath.Join(base, "etc", "netdata", "go.d")
+
+		mustWriteSecretStoreConfigFile(t, filepath.Join(userRoot, "ss", "vault.conf"), `
+jobs:
+  - name: explicit_empty
+    kind: ""
+    mode: token
+    mode_token:
+      token: vault-token
+    addr: https://vault.example
 `)
 
 		cfgs, errs := secretstore.LoadFileConfigs([]string{userRoot})
 		require.Empty(t, errs)
-		require.Len(t, cfgs, 2)
+		require.Len(t, cfgs, 1)
 		assert.Equal(t, secretstore.KindVault, cfgs[0].Kind())
-		assert.Equal(t, secretstore.StoreKind("custom"), cfgs[1].Kind())
 	})
 
 	t.Run("skips malformed files and non-keyable jobs", func(t *testing.T) {
@@ -123,6 +150,24 @@ jobs:
 		assert.Contains(t, joined, "store name is required")
 		assert.Contains(t, joined, "secretstore file config")
 	})
+
+	t.Run("skips null jobs without losing valid siblings", func(t *testing.T) {
+		base := t.TempDir()
+		userRoot := filepath.Join(base, "etc", "netdata", "go.d")
+
+		mustWriteSecretStoreConfigFile(t, filepath.Join(userRoot, "ss", "vault.conf"), `
+jobs:
+  - null
+  - name: valid
+    value: accepted
+`)
+
+		cfgs, errs := secretstore.LoadFileConfigs([]string{userRoot})
+		require.Len(t, cfgs, 1)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "valid", cfgs[0].Name())
+	})
+
 }
 
 func mustWriteSecretStoreConfigFile(t *testing.T, path, content string) {

--- a/src/go/plugin/agent/secrets/secretstore/raw_config.go
+++ b/src/go/plugin/agent/secrets/secretstore/raw_config.go
@@ -101,16 +101,7 @@ func (c Config) UID() string {
 }
 
 func (c Config) SourceTypePriority() int {
-	switch c.SourceType() {
-	case confgroup.TypeDyncfg:
-		return 16
-	case confgroup.TypeUser:
-		return 8
-	case confgroup.TypeStock:
-		return 2
-	default:
-		return 0
-	}
+	return confgroup.SourceTypePriority(c.SourceType())
 }
 
 func (c Config) HashIncludeMap(_ string, k, _ any) (bool, error) {

--- a/src/go/plugin/framework/confgroup/config.go
+++ b/src/go/plugin/framework/confgroup/config.go
@@ -3,6 +3,7 @@
 package confgroup
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -71,8 +72,8 @@ func (c Config) SetSource(v string) Config     { return c.Set(ikeySource, v) }
 func (c Config) SetSourceType(v string) Config { return c.Set(ikeySourceType, v) }
 func (c Config) SetProvider(v string) Config   { return c.Set(ikeyProvider, v) }
 
-func (c Config) SourceTypePriority() int {
-	switch c.SourceType() {
+func SourceTypePriority(sourceType string) int {
+	switch sourceType {
 	default:
 		return 0
 	case TypeStock:
@@ -86,17 +87,26 @@ func (c Config) SourceTypePriority() int {
 	}
 }
 
-func (c Config) Clone() (Config, error) {
+func (c Config) SourceTypePriority() int {
+	return SourceTypePriority(c.SourceType())
+}
+
+func (c Config) Clone() (cloned Config, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			cloned = nil
+			err = errors.New("confgroup: clone config: YAML marshal panic")
+		}
+	}()
 	type plain Config
 	bytes, err := yaml.Marshal((plain)(c))
 	if err != nil {
 		return nil, err
 	}
-	var newConfig Config
-	if err := yaml.Unmarshal(bytes, &newConfig); err != nil {
+	if err := yaml.Unmarshal(bytes, &cloned); err != nil {
 		return nil, err
 	}
-	return newConfig, nil
+	return cloned, nil
 }
 
 func (c Config) ApplyDefaults(def Default) {

--- a/src/go/plugin/framework/confgroup/config_test.go
+++ b/src/go/plugin/framework/confgroup/config_test.go
@@ -119,6 +119,14 @@ func TestConfig_Priority(t *testing.T) {
 	}
 }
 
+func TestSourceTypePriority(t *testing.T) {
+	assert.Equal(t, 16, SourceTypePriority(TypeDyncfg))
+	assert.Equal(t, 8, SourceTypePriority(TypeUser))
+	assert.Equal(t, 4, SourceTypePriority(TypeDiscovered))
+	assert.Equal(t, 2, SourceTypePriority(TypeStock))
+	assert.Equal(t, 0, SourceTypePriority("other"))
+}
+
 func TestConfig_Hash(t *testing.T) {
 	tests := map[string]struct {
 		one, two Config
@@ -188,6 +196,15 @@ func TestConfig_SetProvider(t *testing.T) {
 	cfg.SetProvider("name")
 
 	assert.Equal(t, cfg.Provider(), "name")
+}
+
+func TestConfigCloneReturnsUnsupportedValueFailure(t *testing.T) {
+	config := Config{"unsupported": make(chan struct{})}
+
+	cloned, err := config.Clone()
+
+	assert.Nil(t, cloned)
+	assert.ErrorContains(t, err, "YAML marshal panic")
 }
 
 func TestConfig_Apply(t *testing.T) {

--- a/src/go/plugin/framework/dyncfg/cache.go
+++ b/src/go/plugin/framework/dyncfg/cache.go
@@ -6,12 +6,11 @@ import "sync"
 
 // Config is the constraint interface for configs stored in handler caches.
 type Config interface {
-	UID() string             // SeenCache key (globally unique per source)
-	ExposedKey() string      // ExposedCache key (one per logical name)
-	SourceType() string      // "dyncfg", "user", "stock"
-	SourceTypePriority() int // dyncfg=16, user=8, stock=2
-	Source() string          // source identifier
-	Hash() uint64            // content hash for change detection
+	UID() string        // SeenCache key (globally unique per source)
+	ExposedKey() string // ExposedCache key (one per logical name)
+	SourceType() string // "dyncfg", "user", "stock"
+	Source() string     // source identifier
+	Hash() uint64       // content hash for change detection
 }
 
 // Entry pairs a config with its current dyncfg status.

--- a/src/go/plugin/framework/dyncfg/cache_test.go
+++ b/src/go/plugin/framework/dyncfg/cache_test.go
@@ -13,17 +13,15 @@ type testConfig struct {
 	uid        string
 	key        string
 	sourceType string
-	priority   int
 	source     string
 	hash       uint64
 }
 
-func (c testConfig) UID() string             { return c.uid }
-func (c testConfig) ExposedKey() string      { return c.key }
-func (c testConfig) SourceType() string      { return c.sourceType }
-func (c testConfig) SourceTypePriority() int { return c.priority }
-func (c testConfig) Source() string          { return c.source }
-func (c testConfig) Hash() uint64            { return c.hash }
+func (c testConfig) UID() string        { return c.uid }
+func (c testConfig) ExposedKey() string { return c.key }
+func (c testConfig) SourceType() string { return c.sourceType }
+func (c testConfig) Source() string     { return c.source }
+func (c testConfig) Hash() uint64       { return c.hash }
 
 func seenCacheCount(c *SeenCache[testConfig]) int {
 	c.mux.RLock()

--- a/src/go/plugin/framework/dyncfg/handler.go
+++ b/src/go/plugin/framework/dyncfg/handler.go
@@ -251,8 +251,17 @@ func (h *Handler[C]) SyncDecision(fn Function) {
 
 // NotifyConfigCreate registers/updates a config in the dyncfg API (upsert).
 func (h *Handler[C]) NotifyConfigCreate(cfg C, status Status) {
+	h.api.ConfigCreate(h.configCreateOpts(cfg, status))
+}
+
+// ValidateConfigCreate checks the exact CONFIG create frame generated for cfg.
+func (h *Handler[C]) ValidateConfigCreate(cfg C, status Status) error {
+	return h.configCreateOpts(cfg, status).Validate()
+}
+
+func (h *Handler[C]) configCreateOpts(cfg C, status Status) netdataapi.ConfigOpts {
 	isDyncfg := cfg.SourceType() == "dyncfg"
-	h.api.ConfigCreate(netdataapi.ConfigOpts{
+	return netdataapi.ConfigOpts{
 		ID:                h.cb.ConfigID(cfg),
 		Status:            status.String(),
 		ConfigType:        h.cb.ConfigType(cfg).String(),
@@ -260,7 +269,7 @@ func (h *Handler[C]) NotifyConfigCreate(cfg C, status Status) {
 		SourceType:        cfg.SourceType(),
 		Source:            cfg.Source(),
 		SupportedCommands: h.configSupportedCommands(cfg, isDyncfg),
-	})
+	}
 }
 
 // NotifyConfigStatus sends a status update for a config.
@@ -302,6 +311,10 @@ func (h *Handler[C]) CmdAdd(fn Function) {
 	}
 	if h.cb.ConfigType(newCfg) != ConfigTypeJob {
 		h.api.SendCodef(fn, 405, "adding configurations of type '%s' is not supported, only 'job' configurations can be added.", h.cb.ConfigType(newCfg))
+		return
+	}
+	if err := h.ValidateConfigCreate(newCfg, StatusAccepted); err != nil {
+		h.api.SendCodef(fn, 400, "configuration cannot be represented in the plugins.d CONFIG protocol: %v", err)
 		return
 	}
 
@@ -440,6 +453,11 @@ func (h *Handler[C]) CmdUpdate(fn Function) {
 	newCfg, err := h.cb.ParseAndValidate(fn, name)
 	if err != nil {
 		h.api.SendCodef(fn, 400, "%v", err)
+		h.NotifyConfigStatus(entry.Cfg, entry.Status)
+		return
+	}
+	if err := h.ValidateConfigCreate(newCfg, StatusAccepted); err != nil {
+		h.api.SendCodef(fn, 400, "configuration cannot be represented in the plugins.d CONFIG protocol: %v", err)
 		h.NotifyConfigStatus(entry.Cfg, entry.Status)
 		return
 	}

--- a/src/go/plugin/framework/dyncfg/handler_test.go
+++ b/src/go/plugin/framework/dyncfg/handler_test.go
@@ -1121,6 +1121,11 @@ func TestJobNameRuleStrict(t *testing.T) {
 		"tab":                {input: "my\tjob", wantErr: true},
 		"dot":                {input: "my.job", wantErr: true},
 		"colon":              {input: "my:job", wantErr: true},
+		"equals":             {input: "my=job", wantErr: true},
+		"single quote":       {input: "my'job", wantErr: true},
+		"double quote":       {input: `my"job`, wantErr: true},
+		"backslash":          {input: `my\job`, wantErr: true},
+		"NUL":                {input: "my\x00job", wantErr: true},
 		"empty":              {input: ""},
 	}
 
@@ -1149,6 +1154,11 @@ func TestJobNameRuleAllowDots(t *testing.T) {
 		"space":              {input: "my job", wantErr: true},
 		"tab":                {input: "my\tjob", wantErr: true},
 		"colon":              {input: "my:job", wantErr: true},
+		"equals":             {input: "my=job", wantErr: true},
+		"single quote":       {input: "my'job", wantErr: true},
+		"double quote":       {input: `my"job`, wantErr: true},
+		"backslash":          {input: `my\job`, wantErr: true},
+		"NUL":                {input: "my\x00job", wantErr: true},
 		"empty":              {input: ""},
 	}
 

--- a/src/go/plugin/framework/dyncfg/validate.go
+++ b/src/go/plugin/framework/dyncfg/validate.go
@@ -6,13 +6,16 @@ import (
 	"errors"
 	"fmt"
 	"unicode"
+
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 )
 
-// JobNameRuleStrict rejects spaces, dots, and colons.
+// JobNameRuleStrict rejects characters that cannot be emitted safely as an
+// unquoted plugins.d protocol field, plus dots.
 // Use for collector job names, which must not conflict with dyncfg template/job
 // ID separators (':') or module hierarchy ('.').
 func JobNameRuleStrict(name string) error {
-	if err := rejectSpacesAndColons(name); err != nil {
+	if err := rejectUnsafeJobName(name); err != nil {
 		return err
 	}
 	for _, r := range name {
@@ -23,21 +26,42 @@ func JobNameRuleStrict(name string) error {
 	return nil
 }
 
-// JobNameRuleAllowDots rejects spaces and colons but allows dots.
+// JobNameRuleAllowDots rejects characters that cannot be emitted safely as an
+// unquoted plugins.d protocol field but allows dots.
 // Use for service discovery, vnode, and secretstore names where dotted identifiers
 // are legitimate (e.g. hostnames, FQDNs).
 func JobNameRuleAllowDots(name string) error {
-	return rejectSpacesAndColons(name)
+	return rejectUnsafeJobName(name)
 }
 
-func rejectSpacesAndColons(name string) error {
+func rejectUnsafeJobName(name string) error {
 	for _, r := range name {
 		if unicode.IsSpace(r) {
 			return errors.New("contains spaces")
 		}
-		if r == ':' {
+		if r < ' ' || r == 0x7f {
+			return errors.New("contains control characters")
+		}
+		switch r {
+		case ':', '=', '\'', '"', '\\':
 			return fmt.Errorf("contains '%c'", r)
 		}
 	}
 	return nil
+}
+
+// ValidBareProtocolField reports whether value can be emitted as one unquoted
+// plugins.d protocol field.
+//
+// Deprecated: use netdataapi.ValidBareProtocolField.
+func ValidBareProtocolField(value string) bool {
+	return netdataapi.ValidBareProtocolField(value)
+}
+
+// ValidSingleQuotedProtocolField reports whether value can be emitted inside
+// one single-quoted plugins.d protocol field.
+//
+// Deprecated: use netdataapi.ValidSingleQuotedProtocolField.
+func ValidSingleQuotedProtocolField(value string) bool {
+	return netdataapi.ValidSingleQuotedProtocolField(value)
 }

--- a/src/go/plugin/framework/dyncfg/validate_test.go
+++ b/src/go/plugin/framework/dyncfg/validate_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dyncfg
+
+import (
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtocolFieldCompatibilityWrappers(t *testing.T) {
+	values := []string{
+		"source",
+		`C:\Program Files\Netdata`,
+		`file=C:\`,
+		"operator's",
+		"line\nbreak",
+	}
+	for _, value := range values {
+		require.Equal(t, netdataapi.ValidBareProtocolField(value), ValidBareProtocolField(value), value)
+		require.Equal(t, netdataapi.ValidSingleQuotedProtocolField(value), ValidSingleQuotedProtocolField(value), value)
+	}
+}

--- a/src/go/plugin/framework/functions/capsule.go
+++ b/src/go/plugin/framework/functions/capsule.go
@@ -298,30 +298,40 @@ func (capsule *InputCapsule) handlePayloadSegment(ctx context.Context, consumer 
 			}
 			return true, consumer.HandleQuit(ctx)
 		case bytes.HasPrefix(content, []byte("FUNCTION_CANCEL")):
-			fields := strings.Fields(string(content))
-			if len(fields) != 2 || fields[0] != "FUNCTION_CANCEL" {
-				return false, errors.New("function ingress: invalid payload cancel")
-			}
-			if fields[1] == state.call.UID {
-				uid := state.call.UID
-				if err := capsule.abortPayload(); err != nil {
-					return false, err
+			fields, err := tokenize(string(content))
+			if err == nil && len(fields) == 2 && fields[0] == "FUNCTION_CANCEL" {
+				if fields[1] == state.call.UID {
+					uid := state.call.UID
+					if err := capsule.abortPayload(); err != nil {
+						return false, err
+					}
+					return false, consumer.HandleReject(ctx, uid, 499)
 				}
-				return false, consumer.HandleReject(ctx, uid, 499)
+				return false, consumer.HandleCancel(ctx, fields[1])
 			}
-			return false, consumer.HandleCancel(ctx, fields[1])
 		case bytes.HasPrefix(content, []byte("FUNCTION_PROGRESS")):
-			return false, nil
-		case isPayloadInterruptCommand(content):
-			if state.overflow {
-				if err := consumer.HandleReject(ctx, state.call.UID, 413); err != nil {
-					return false, err
-				}
+			fields, err := tokenize(string(content))
+			if err == nil && len(fields) == 2 && fields[0] == "FUNCTION_PROGRESS" {
+				return false, nil
 			}
+		}
+		if call, payload, ok := parsePayloadReplacement(content); ok {
+			status := 400
+			if state.overflow {
+				status = 413
+			}
+			abandonedUID := state.call.UID
 			if err := capsule.abortPayload(); err != nil {
 				return false, err
 			}
-			return capsule.handleCommandLine(ctx, consumer, string(content))
+			if err := consumer.HandleReject(ctx, abandonedUID, status); err != nil {
+				return false, err
+			}
+			if payload {
+				capsule.payload = &payloadState{call: call}
+				return false, nil
+			}
+			return false, consumer.HandleCall(ctx, call)
 		}
 	}
 	if state.overflow {
@@ -347,12 +357,14 @@ func (capsule *InputCapsule) handlePayloadSegment(ctx context.Context, consumer 
 	return false, nil
 }
 
-func isPayloadInterruptCommand(line []byte) bool {
-	return bytes.Equal(line, []byte("FUNCTION")) ||
-		bytes.Equal(line, []byte("FUNCTION_PAYLOAD")) ||
-		bytes.HasPrefix(line, []byte("FUNCTION ")) ||
-		bytes.HasPrefix(line, []byte("FUNCTION_PAYLOAD ")) ||
-		bytes.HasPrefix(line, []byte("FUNCTION_"))
+func parsePayloadReplacement(line []byte) (Call, bool, bool) {
+	fields, err := tokenize(string(line))
+	if err != nil || len(fields) == 0 ||
+		(fields[0] != "FUNCTION" && fields[0] != "FUNCTION_PAYLOAD") {
+		return Call{}, false, false
+	}
+	call, payload, err := parseCapsuleCall(fields)
+	return call, payload, err == nil
 }
 
 func (capsule *InputCapsule) appendPayload(ctx context.Context, value []byte) error {

--- a/src/go/plugin/framework/functions/capsule_test.go
+++ b/src/go/plugin/framework/functions/capsule_test.go
@@ -210,6 +210,55 @@ func TestInputCapsulePayloadBoundariesAndResynchronization(t *testing.T) {
 	}
 }
 
+func TestInputCapsuleKeepsUnknownOrMalformedFunctionTextInPayload(t *testing.T) {
+	consumer := &recordingCapsuleConsumer{}
+	input := "FUNCTION_PAYLOAD raw 30 \"raw:echo\" 0xFFFF \"source\" application/yaml\n" +
+		"FUNCTION_X: value\n" +
+		"FUNCTION_CANCEL raw extra\n" +
+		"FUNCTION_PROGRESS raw extra\n" +
+		"FUNCTION malformed\n" +
+		"tail\nFUNCTION_PAYLOAD_END\n" +
+		"FUNCTION successor 30 \"perf:work\" 0xFFFF \"source\"\nQUIT\n"
+	capsule, err := NewInputCapsule(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := capsule.Run(context.Background(), consumer); err != nil {
+		t.Fatal(err)
+	}
+	if len(consumer.calls) != 2 {
+		t.Fatalf("payload flow stopped: calls=%#v rejections=%#v", consumer.calls, consumer.rejections)
+	}
+	wantPayload := "FUNCTION_X: value\n" +
+		"FUNCTION_CANCEL raw extra\n" +
+		"FUNCTION_PROGRESS raw extra\n" +
+		"FUNCTION malformed\n" +
+		"tail"
+	if consumer.calls[0].UID != "raw" || string(consumer.calls[0].Payload) != wantPayload ||
+		consumer.calls[1].UID != "successor" || len(consumer.rejections) != 0 || !consumer.quit {
+		t.Fatalf("payload flow differs: calls=%#v rejections=%#v quit=%v", consumer.calls, consumer.rejections, consumer.quit)
+	}
+}
+
+func TestInputCapsuleRejectsAbandonedPayloadBeforeValidResynchronization(t *testing.T) {
+	consumer := &recordingCapsuleConsumer{}
+	input := "FUNCTION_PAYLOAD abandoned 30 \"raw:echo\" 0xFFFF \"source\" application/octet-stream\n" +
+		"partial\n" +
+		"FUNCTION successor 30 \"perf:work\" 0xFFFF \"source\"\nQUIT\n"
+	capsule, err := NewInputCapsule(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := capsule.Run(context.Background(), consumer); err != nil {
+		t.Fatal(err)
+	}
+	if len(consumer.rejections) != 1 ||
+		consumer.rejections[0] != (recordedCapsuleRejection{uid: "abandoned", status: 400}) ||
+		len(consumer.calls) != 1 || consumer.calls[0].UID != "successor" || !consumer.quit {
+		t.Fatalf("resynchronization differs: calls=%#v rejections=%#v quit=%v", consumer.calls, consumer.rejections, consumer.quit)
+	}
+}
+
 type recordingCapsuleConsumer struct {
 	calls      []Call
 	rejections []recordedCapsuleRejection

--- a/src/go/plugin/framework/jobruntime/job_common.go
+++ b/src/go/plugin/framework/jobruntime/job_common.go
@@ -3,6 +3,7 @@
 package jobruntime
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -76,6 +77,31 @@ func disableAutoDetection(autoDetectEvery *int) {
 
 func isRetryableError(err error) bool {
 	return dyncfg.IsRetryableError(err)
+}
+
+func sanitizeLifecycleError(sanitize func(error) error, err error) (sanitized error) {
+	if err == nil || sanitize == nil {
+		return err
+	}
+	defer func() {
+		if recover() != nil {
+			sanitized = errors.New("jobruntime: lifecycle error sanitizer panicked")
+		}
+	}()
+	sanitized = sanitize(err)
+	if sanitized == nil {
+		return errors.New("jobruntime: lifecycle error sanitizer discarded a failure")
+	}
+	return sanitized
+}
+
+func lifecycleLogMessageSanitizer(sanitize func(error) error) func(string) string {
+	if sanitize == nil {
+		return nil
+	}
+	return func(message string) string {
+		return sanitizeLifecycleError(sanitize, errors.New(message)).Error()
+	}
 }
 
 func consumeAutoDetectTry(autoDetectTries *int) {

--- a/src/go/plugin/framework/jobruntime/job_common_test.go
+++ b/src/go/plugin/framework/jobruntime/job_common_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobruntime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLifecycleErrorSanitizerFailsClosed(t *testing.T) {
+	source := errors.New("source failure")
+	require.ErrorIs(t, sanitizeLifecycleError(nil, source), source)
+	require.ErrorContains(t, sanitizeLifecycleError(func(error) error { return nil }, source), "discarded")
+	require.ErrorContains(t, sanitizeLifecycleError(func(error) error { panic("failed") }, source), "panicked")
+}

--- a/src/go/plugin/framework/jobruntime/job_v1.go
+++ b/src/go/plugin/framework/jobruntime/job_v1.go
@@ -56,24 +56,25 @@ func newCollectDurationChart(pluginName string) *collectorapi.Chart {
 }
 
 type JobConfig struct {
-	PluginName            string
-	Name                  string
-	ModuleName            string
-	FullName              string
-	Source                string
-	Module                collectorapi.CollectorV1
-	Labels                map[string]string
-	Out                   io.Writer
-	UpdateEvery           int
-	AutoDetectEvery       int
-	Priority              int
-	IsStock               bool
-	Vnode                 vnodes.VirtualNode
-	VnodeName             string
-	VnodeRevision         uint64
-	VnodeMetadataRevision uint64
-	VnodeLookup           VnodeLookup
-	FunctionOnly          bool
+	PluginName              string
+	Name                    string
+	ModuleName              string
+	FullName                string
+	Source                  string
+	Module                  collectorapi.CollectorV1
+	Labels                  map[string]string
+	Out                     io.Writer
+	UpdateEvery             int
+	AutoDetectEvery         int
+	Priority                int
+	IsStock                 bool
+	Vnode                   vnodes.VirtualNode
+	VnodeName               string
+	VnodeRevision           uint64
+	VnodeMetadataRevision   uint64
+	VnodeLookup             VnodeLookup
+	FunctionOnly            bool
+	LifecycleErrorSanitizer func(error) error
 }
 
 func NewJob(cfg JobConfig) *Job {
@@ -87,35 +88,40 @@ func NewJob(cfg JobConfig) *Job {
 		autoDetectEvery: cfg.AutoDetectEvery,
 		autoDetectTries: infTries,
 
-		pluginName:            cfg.PluginName,
-		name:                  cfg.Name,
-		moduleName:            cfg.ModuleName,
-		fullName:              cfg.FullName,
-		updateEvery:           cfg.UpdateEvery,
-		priority:              cfg.Priority,
-		isStock:               cfg.IsStock,
-		functionOnly:          cfg.FunctionOnly,
-		module:                cfg.Module,
-		labels:                cfg.Labels,
-		out:                   cfg.Out,
-		collectStatusChart:    newCollectStatusChart(cfg.PluginName),
-		collectDurationChart:  newCollectDurationChart(cfg.PluginName),
-		stopCtrl:              newStopController(),
-		tick:                  make(chan int),
-		buf:                   &buf,
-		api:                   netdataapi.New(&buf),
-		vnode:                 cfg.Vnode,
-		vnodeName:             cfg.VnodeName,
-		vnodeRevision:         cfg.VnodeRevision,
-		vnodeMetadataRevision: cfg.VnodeMetadataRevision,
-		vnodeLookup:           cfg.VnodeLookup,
+		pluginName:              cfg.PluginName,
+		name:                    cfg.Name,
+		moduleName:              cfg.ModuleName,
+		fullName:                cfg.FullName,
+		updateEvery:             cfg.UpdateEvery,
+		priority:                cfg.Priority,
+		isStock:                 cfg.IsStock,
+		functionOnly:            cfg.FunctionOnly,
+		module:                  cfg.Module,
+		labels:                  cfg.Labels,
+		out:                     cfg.Out,
+		collectStatusChart:      newCollectStatusChart(cfg.PluginName),
+		collectDurationChart:    newCollectDurationChart(cfg.PluginName),
+		stopCtrl:                newStopController(),
+		tick:                    make(chan int),
+		buf:                     &buf,
+		api:                     netdataapi.New(&buf),
+		vnode:                   cfg.Vnode,
+		vnodeName:               cfg.VnodeName,
+		vnodeRevision:           cfg.VnodeRevision,
+		vnodeMetadataRevision:   cfg.VnodeMetadataRevision,
+		vnodeLookup:             cfg.VnodeLookup,
+		lifecycleErrorSanitizer: cfg.LifecycleErrorSanitizer,
 	}
 
 	log := logger.New().With(jobLoggerAttrs(j.ModuleName(), j.Name(), cfg.Source)...)
 
 	j.Logger = log
 	if j.module != nil {
-		j.module.GetBase().Logger = log
+		moduleLog := log
+		if sanitize := lifecycleLogMessageSanitizer(cfg.LifecycleErrorSanitizer); sanitize != nil {
+			moduleLog = moduleLog.WithMessageSanitizer(sanitize)
+		}
+		j.module.GetBase().Logger = moduleLog
 	}
 
 	return j
@@ -139,7 +145,8 @@ type Job struct {
 	isStock      bool
 	functionOnly bool
 
-	module collectorapi.CollectorV1
+	module                  collectorapi.CollectorV1
+	lifecycleErrorSanitizer func(error) error
 
 	// running tracks whether the managed job loop is active.
 	running atomic.Bool
@@ -225,11 +232,11 @@ func (j *Job) AutoDetectionManaged(ctx context.Context) (err error) {
 func (j *Job) autoDetection(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic %v", r)
+			err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, fmt.Errorf("panic %v", r))
 			j.panicked.Store(true)
 			j.disableAutoDetection()
 
-			j.Errorf("PANIC %v", r)
+			j.Errorf("PANIC %v", err)
 			if logger.Level.Enabled(slog.LevelDebug) {
 				j.Errorf("STACK: %s", debug.Stack())
 			}
@@ -240,16 +247,18 @@ func (j *Job) autoDetection(ctx context.Context) (err error) {
 		j.Mute()
 	}
 
-	if err = j.init(ctx); err != nil {
-		j.Errorf("init failed: %v", err)
-		j.Unmute()
-		if !isRetryableError(err) {
+	if rawErr := j.init(ctx); rawErr != nil {
+		if !isRetryableError(rawErr) {
 			j.disableAutoDetection()
 		}
+		err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, rawErr)
+		j.Errorf("init failed: %v", err)
+		j.Unmute()
 		return err
 	}
 
-	if err = j.check(ctx); err != nil {
+	if rawErr := j.check(ctx); rawErr != nil {
+		err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, rawErr)
 		j.Errorf("check failed: %v", err)
 		j.Unmute()
 		return err
@@ -258,7 +267,8 @@ func (j *Job) autoDetection(ctx context.Context) (err error) {
 	j.Unmute()
 	j.Info("check success")
 
-	if err = j.postCheck(); err != nil {
+	if rawErr := j.postCheck(); rawErr != nil {
+		err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, rawErr)
 		j.Errorf("postCheck failed: %v", err)
 		j.disableAutoDetection()
 		return err
@@ -471,7 +481,6 @@ func (j *Job) postCheck() error {
 	}
 	if j.charts != nil {
 		if err := collectorapi.CheckCharts(*j.charts...); err != nil {
-			j.Errorf("charts check: %v", err)
 			return err
 		}
 	}
@@ -508,7 +517,8 @@ func (j *Job) collect() collectedMetrics {
 	defer func() {
 		if r := recover(); r != nil {
 			j.panicked.Store(true)
-			j.Errorf("PANIC: %v", r)
+			err := sanitizeLifecycleError(j.lifecycleErrorSanitizer, fmt.Errorf("panic %v", r))
+			j.Errorf("PANIC: %v", err)
 			if logger.Level.Enabled(slog.LevelDebug) {
 				j.Errorf("STACK: %s", debug.Stack())
 			}

--- a/src/go/plugin/framework/jobruntime/job_v1_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v1_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 	"github.com/stretchr/testify/assert"
@@ -359,6 +360,59 @@ func TestJob_MainLoop_Panic(t *testing.T) {
 	assert.False(t, m.CleanupDone)
 	job.Cleanup()
 	assert.True(t, m.CleanupDone)
+}
+
+func TestJobSteadyStateCollectorPanicIsSanitizedBeforeLogging(t *testing.T) {
+	const marker = "resolved-v1-runtime-marker"
+	mod := &collectorapi.MockCollectorV1{
+		CollectFunc: func(context.Context) map[string]int64 {
+			panic(marker)
+		},
+	}
+	job := NewJob(JobConfig{
+		PluginName: pluginName, Name: jobName, ModuleName: modName,
+		FullName: modName + "_" + jobName, Module: mod, Out: io.Discard,
+		LifecycleErrorSanitizer: func(error) error {
+			return errors.New("sanitized collector failure")
+		},
+	})
+	var logs bytes.Buffer
+	captured := logger.NewWithWriter(&logs)
+	job.Logger = captured
+	mod.GetBase().Logger = captured
+
+	_ = job.collect()
+
+	require.NotContains(t, logs.String(), marker)
+	require.Contains(t, logs.String(), "sanitized collector failure")
+}
+
+func TestJobPostCheckFailureIsSanitizedBeforeEveryLog(t *testing.T) {
+	const marker = "resolved-v1-chart-marker"
+	mod := &collectorapi.MockCollectorV1{
+		ChartsFunc: func() *collectorapi.Charts {
+			return &collectorapi.Charts{
+				&collectorapi.Chart{
+					ID: marker + " invalid", Title: "title", Units: "units",
+				},
+			}
+		},
+	}
+	job := NewJob(JobConfig{
+		PluginName: pluginName, Name: jobName, ModuleName: modName,
+		FullName: modName + "_" + jobName, Module: mod, Out: io.Discard,
+		LifecycleErrorSanitizer: func(error) error {
+			return errors.New("sanitized chart failure")
+		},
+	})
+	var logs bytes.Buffer
+	captured := logger.NewWithWriter(&logs)
+	job.Logger = captured
+	mod.GetBase().Logger = captured
+
+	require.Error(t, job.AutoDetectionManaged(context.Background()))
+	require.NotContains(t, logs.String(), marker)
+	require.Contains(t, logs.String(), "sanitized chart failure")
 }
 
 func TestJob_OutputFailureDoesNotReportCollectorPanic(t *testing.T) {

--- a/src/go/plugin/framework/jobruntime/job_v2.go
+++ b/src/go/plugin/framework/jobruntime/job_v2.go
@@ -28,25 +28,26 @@ import (
 )
 
 type JobV2Config struct {
-	PluginName            string
-	Name                  string
-	ModuleName            string
-	FullName              string
-	Source                string
-	Module                collectorapi.CollectorV2
-	Labels                map[string]string
-	Out                   io.Writer
-	UpdateEvery           int
-	AutoDetectEvery       int
-	IsStock               bool
-	Vnode                 vnodes.VirtualNode
-	VnodeName             string
-	VnodeRevision         uint64
-	VnodeMetadataRevision uint64
-	VnodeLookup           VnodeLookup
-	VnodeRegistry         *vnoderegistry.Registry
-	FunctionOnly          bool
-	RuntimeService        runtimecomp.Service
+	PluginName              string
+	Name                    string
+	ModuleName              string
+	FullName                string
+	Source                  string
+	Module                  collectorapi.CollectorV2
+	Labels                  map[string]string
+	Out                     io.Writer
+	UpdateEvery             int
+	AutoDetectEvery         int
+	IsStock                 bool
+	Vnode                   vnodes.VirtualNode
+	VnodeName               string
+	VnodeRevision           uint64
+	VnodeMetadataRevision   uint64
+	VnodeLookup             VnodeLookup
+	VnodeRegistry           *vnoderegistry.Registry
+	FunctionOnly            bool
+	RuntimeService          runtimecomp.Service
+	LifecycleErrorSanitizer func(error) error
 }
 
 func NewJobV2(cfg JobV2Config) *JobV2 {
@@ -60,29 +61,30 @@ func NewJobV2(cfg JobV2Config) *JobV2 {
 	}
 
 	j := &JobV2{
-		pluginName:            cfg.PluginName,
-		name:                  cfg.Name,
-		moduleName:            cfg.ModuleName,
-		fullName:              cfg.FullName,
-		updateEvery:           cfg.UpdateEvery,
-		autoDetectEvery:       cfg.AutoDetectEvery,
-		autoDetectTries:       infTries,
-		isStock:               cfg.IsStock,
-		functionOnly:          cfg.FunctionOnly,
-		module:                cfg.Module,
-		labels:                cloneLabels(cfg.Labels),
-		out:                   cfg.Out,
-		stopCtrl:              newStopController(),
-		tick:                  make(chan int),
-		buf:                   &buf,
-		api:                   netdataapi.New(&buf),
-		vnode:                 cfg.Vnode,
-		vnodeName:             cfg.VnodeName,
-		vnodeRevision:         cfg.VnodeRevision,
-		vnodeMetadataRevision: cfg.VnodeMetadataRevision,
-		vnodeLookup:           cfg.VnodeLookup,
-		vnodeRegistry:         registry,
-		runtimeService:        cfg.RuntimeService,
+		pluginName:              cfg.PluginName,
+		name:                    cfg.Name,
+		moduleName:              cfg.ModuleName,
+		fullName:                cfg.FullName,
+		updateEvery:             cfg.UpdateEvery,
+		autoDetectEvery:         cfg.AutoDetectEvery,
+		autoDetectTries:         infTries,
+		isStock:                 cfg.IsStock,
+		functionOnly:            cfg.FunctionOnly,
+		module:                  cfg.Module,
+		labels:                  cloneLabels(cfg.Labels),
+		out:                     cfg.Out,
+		stopCtrl:                newStopController(),
+		tick:                    make(chan int),
+		buf:                     &buf,
+		api:                     netdataapi.New(&buf),
+		vnode:                   cfg.Vnode,
+		vnodeName:               cfg.VnodeName,
+		vnodeRevision:           cfg.VnodeRevision,
+		vnodeMetadataRevision:   cfg.VnodeMetadataRevision,
+		vnodeLookup:             cfg.VnodeLookup,
+		vnodeRegistry:           registry,
+		runtimeService:          cfg.RuntimeService,
+		lifecycleErrorSanitizer: cfg.LifecycleErrorSanitizer,
 	}
 	if j.out == nil {
 		j.out = io.Discard
@@ -91,7 +93,11 @@ func NewJobV2(cfg JobV2Config) *JobV2 {
 	log := logger.New().With(jobLoggerAttrs(j.ModuleName(), j.Name(), cfg.Source)...)
 	j.Logger = log
 	if j.module != nil {
-		j.module.GetBase().Logger = log
+		moduleLog := log
+		if sanitize := lifecycleLogMessageSanitizer(cfg.LifecycleErrorSanitizer); sanitize != nil {
+			moduleLog = moduleLog.WithMessageSanitizer(sanitize)
+		}
+		j.module.GetBase().Logger = moduleLog
 		if vnode := j.module.VirtualNode(); vnode != nil {
 			*vnode = *cfg.Vnode.Copy()
 		}
@@ -113,7 +119,8 @@ type JobV2 struct {
 
 	*logger.Logger
 
-	module collectorapi.CollectorV2
+	module                  collectorapi.CollectorV2
+	lifecycleErrorSanitizer func(error) error
 
 	running atomic.Bool
 
@@ -328,10 +335,10 @@ func (j *JobV2) AutoDetectionManaged(ctx context.Context) (err error) {
 func (j *JobV2) autoDetection(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic %v", r)
+			err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, fmt.Errorf("panic %v", r))
 			j.panicked.Store(true)
 			j.disableAutoDetection()
-			j.Errorf("PANIC %v", r)
+			j.Errorf("PANIC %v", err)
 			if logger.Level.Enabled(slog.LevelDebug) {
 				j.Errorf("STACK: %s", debug.Stack())
 			}
@@ -341,22 +348,25 @@ func (j *JobV2) autoDetection(ctx context.Context) (err error) {
 		j.Mute()
 	}
 
-	if err = j.init(ctx); err != nil {
-		j.Errorf("init failed: %v", err)
-		j.Unmute()
-		if !isRetryableError(err) {
+	if rawErr := j.init(ctx); rawErr != nil {
+		if !isRetryableError(rawErr) {
 			j.disableAutoDetection()
 		}
+		err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, rawErr)
+		j.Errorf("init failed: %v", err)
+		j.Unmute()
 		return err
 	}
-	if err = j.check(ctx); err != nil {
+	if rawErr := j.check(ctx); rawErr != nil {
+		err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, rawErr)
 		j.Errorf("check failed: %v", err)
 		j.Unmute()
 		return err
 	}
 	j.Unmute()
 	j.Info("check success")
-	if err = j.postCheck(); err != nil {
+	if rawErr := j.postCheck(); rawErr != nil {
+		err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, rawErr)
 		j.Errorf("postCheck failed: %v", err)
 		j.disableAutoDetection()
 		return err
@@ -434,8 +444,8 @@ func (j *JobV2) runCollectorRunner(ctx context.Context, runner collectorapi.Coll
 	defer func() {
 		if r := recover(); r != nil {
 			j.panicked.Store(true)
-			err = fmt.Errorf("panic %v", r)
-			j.Errorf("PANIC: %v", r)
+			err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, fmt.Errorf("panic %v", r))
+			j.Errorf("PANIC: %v", err)
 			if logger.Level.Enabled(slog.LevelDebug) {
 				j.Errorf("STACK: %s", debug.Stack())
 			}
@@ -446,7 +456,7 @@ func (j *JobV2) runCollectorRunner(ctx context.Context, runner collectorapi.Coll
 	if err != nil && ctx.Err() != nil && errors.Is(err, ctx.Err()) {
 		return nil
 	}
-	return err
+	return sanitizeLifecycleError(j.lifecycleErrorSanitizer, err)
 }
 
 func (j *JobV2) waitCollectorRunner(ctx context.Context, done <-chan error) {
@@ -603,7 +613,8 @@ func (j *JobV2) collectAndEmit(sinceLastRun int) (prepared jobV2PreparedEmission
 			}
 			j.abortPreparedEmission(prepared)
 			j.panicked.Store(true)
-			j.Errorf("PANIC: %v", r)
+			err := sanitizeLifecycleError(j.lifecycleErrorSanitizer, fmt.Errorf("panic %v", r))
+			j.Errorf("PANIC: %v", err)
 			if logger.Level.Enabled(slog.LevelDebug) {
 				j.Errorf("STACK: %s", debug.Stack())
 			}
@@ -615,6 +626,7 @@ func (j *JobV2) collectAndEmit(sinceLastRun int) (prepared jobV2PreparedEmission
 	if err := j.module.Collect(j.moduleContext()); err != nil {
 		j.cycle.AbortCycle()
 		cycleOpen = false
+		err = sanitizeLifecycleError(j.lifecycleErrorSanitizer, err)
 		j.Warningf("collect failed: %v", err)
 		return jobV2PreparedEmission{}, false
 	}

--- a/src/go/plugin/framework/jobruntime/job_v2_test.go
+++ b/src/go/plugin/framework/jobruntime/job_v2_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartemit"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine"
@@ -479,6 +480,97 @@ func TestJobV2RunnerPanicRecovered(t *testing.T) {
 	case <-stopped:
 	case <-time.After(time.Second):
 		t.Fatal("job did not stop")
+	}
+}
+
+func TestJobV2SteadyStateCollectorFailuresAreSanitizedBeforeLogging(t *testing.T) {
+	tests := []struct {
+		name    string
+		collect func(context.Context) error
+	}{
+		{
+			name: "error",
+			collect: func(context.Context) error {
+				return errors.New("resolved-v2-collect-error-marker")
+			},
+		},
+		{
+			name: "panic",
+			collect: func(context.Context) error {
+				panic("resolved-v2-collect-panic-marker")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const safeMarker = "sanitized v2 collect failure"
+			mod := &mockModuleV2{
+				store:       metrix.NewCollectorStore(),
+				template:    chartTemplateV2(),
+				collectFunc: test.collect,
+			}
+			job := NewJobV2(JobV2Config{
+				PluginName: pluginName, Name: jobName, ModuleName: modName,
+				FullName: modName + "_" + jobName, Module: mod, Out: &bytes.Buffer{},
+				LifecycleErrorSanitizer: func(error) error { return errors.New(safeMarker) },
+			})
+			require.NoError(t, job.AutoDetectionManaged(context.Background()))
+			var logs bytes.Buffer
+			captured := logger.NewWithWriter(&logs)
+			job.Logger = captured
+			mod.GetBase().Logger = captured
+
+			_, _ = job.collectAndEmit(0)
+
+			require.NotContains(t, logs.String(), "resolved-v2-collect-error-marker")
+			require.NotContains(t, logs.String(), "resolved-v2-collect-panic-marker")
+			require.Contains(t, logs.String(), safeMarker)
+		})
+	}
+}
+
+func TestJobV2RunnerFailuresAreSanitizedBeforeLogging(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context) error
+	}{
+		{
+			name: "error",
+			run: func(context.Context) error {
+				return errors.New("resolved-v2-runner-error-marker")
+			},
+		},
+		{
+			name: "panic",
+			run: func(context.Context) error {
+				panic("resolved-v2-runner-panic-marker")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const safeMarker = "sanitized v2 runner failure"
+			mod := &mockRunnerModuleV2{
+				mockModuleV2: &mockModuleV2{},
+				runFunc:      test.run,
+			}
+			job := NewJobV2(JobV2Config{
+				PluginName: pluginName, Name: jobName, ModuleName: modName,
+				FullName: modName + "_" + jobName, Module: mod, Out: &bytes.Buffer{},
+				LifecycleErrorSanitizer: func(error) error { return errors.New(safeMarker) },
+			})
+			var logs bytes.Buffer
+			captured := logger.NewWithWriter(&logs)
+			job.Logger = captured
+			mod.GetBase().Logger = captured
+
+			err := job.runCollectorRunner(context.Background(), mod)
+			job.handleCollectorRunnerExit(context.Background(), err)
+
+			require.NotContains(t, logs.String(), "resolved-v2-runner-error-marker")
+			require.NotContains(t, logs.String(), "resolved-v2-runner-panic-marker")
+			require.Contains(t, logs.String(), safeMarker)
+		})
 	}
 }
 

--- a/src/go/plugin/framework/vnodes/configured.go
+++ b/src/go/plugin/framework/vnodes/configured.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package vnodes
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartemit"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+)
+
+// ValidateConfigured validates a vnode supplied by file configuration or
+// DynCfg against every protocol consumer used for configured vnodes.
+func ValidateConfigured(vnode *VirtualNode) error {
+	_, err := validateConfigured(vnode)
+	return err
+}
+
+func validateConfigured(vnode *VirtualNode) (string, error) {
+	if vnode == nil {
+		return "", fmt.Errorf("configured vnode is nil")
+	}
+	if vnode.Name == "" {
+		return "", fmt.Errorf("configured vnode name is required")
+	}
+	if err := dyncfg.JobNameRuleAllowDots(vnode.Name); err != nil {
+		return "", fmt.Errorf("invalid configured vnode name %q: %w", vnode.Name, err)
+	}
+	if !netdataapi.ValidBareProtocolField(vnode.SourceType) {
+		return "", fmt.Errorf("configured vnode source type cannot be represented in the CONFIG protocol")
+	}
+	if !netdataapi.ValidSingleQuotedProtocolField(vnode.Source) {
+		return "", fmt.Errorf("configured vnode source cannot be represented in the CONFIG protocol")
+	}
+	guidKey, err := ConfiguredGUIDKey(vnode.GUID)
+	if err != nil {
+		return "", err
+	}
+	prepared, err := chartemit.PrepareHostInfo(netdataapi.HostInfo{
+		GUID:     vnode.GUID,
+		Hostname: vnode.Hostname,
+		Labels:   vnode.Labels,
+	})
+	if err != nil {
+		return "", fmt.Errorf("invalid configured vnode host metadata: %w", err)
+	}
+	if prepared.Hostname != vnode.Hostname {
+		return "", fmt.Errorf("configured vnode hostname changes during host emission preparation")
+	}
+	if !netdataapi.ValidSingleQuotedProtocolField(prepared.Hostname) {
+		return "", fmt.Errorf("configured vnode hostname cannot be represented in the host protocol")
+	}
+	for key, value := range prepared.Labels {
+		if !netdataapi.ValidSingleQuotedProtocolField(key) ||
+			!netdataapi.ValidSingleQuotedProtocolField(value) {
+			return "", fmt.Errorf("configured vnode labels cannot be represented in the host protocol")
+		}
+	}
+	return guidKey, nil
+}
+
+// ConfiguredGUIDKey returns the canonical comparison key for a configured
+// vnode GUID while leaving the caller's spelling unchanged.
+func ConfiguredGUIDKey(value string) (string, error) {
+	switch len(value) {
+	case 32, 36:
+	default:
+		return "", fmt.Errorf("configured vnode GUID must use canonical or compact UUID syntax")
+	}
+	parsed, err := uuid.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid configured vnode GUID: %w", err)
+	}
+	canonical := parsed.String()
+	switch len(value) {
+	case 32:
+		if !strings.EqualFold(value, strings.ReplaceAll(canonical, "-", "")) {
+			return "", fmt.Errorf("configured vnode GUID must use compact UUID syntax")
+		}
+	case 36:
+		if !strings.EqualFold(value, canonical) {
+			return "", fmt.Errorf("configured vnode GUID must use canonical UUID syntax")
+		}
+	}
+	return canonical, nil
+}
+
+// ValidateConfiguredSet validates configured vnodes and their set-wide
+// hostname and GUID uniqueness deterministically.
+func ValidateConfiguredSet(initial map[string]*VirtualNode) error {
+	seenHostnames := make(map[string]string)
+	seenGUIDs := make(map[string]string)
+	for _, id := range slices.Sorted(maps.Keys(initial)) {
+		vnode := initial[id]
+		if vnode == nil {
+			return fmt.Errorf("configured vnode %q is nil", id)
+		}
+		if vnode.Name != id {
+			return fmt.Errorf("configured vnode %q identity differs from its map key", id)
+		}
+		guidKey, err := validateConfigured(vnode)
+		if err != nil {
+			return fmt.Errorf("configured vnode %q: %w", id, err)
+		}
+		if other, ok := seenHostnames[vnode.Hostname]; ok {
+			return fmt.Errorf("duplicate configured vnode hostname %q (%s and %s)", vnode.Hostname, other, id)
+		}
+		if other, ok := seenGUIDs[guidKey]; ok {
+			return fmt.Errorf("duplicate configured vnode GUID (%s and %s)", other, id)
+		}
+		seenHostnames[vnode.Hostname] = id
+		seenGUIDs[guidKey] = id
+	}
+	return nil
+}

--- a/src/go/plugin/framework/vnodes/configured.go
+++ b/src/go/plugin/framework/vnodes/configured.go
@@ -56,9 +56,13 @@ func validateConfigured(vnode *VirtualNode) (string, error) {
 	if !netdataapi.ValidSingleQuotedProtocolField(prepared.Hostname) {
 		return "", fmt.Errorf("configured vnode hostname cannot be represented in the host protocol")
 	}
-	for key := range vnode.Labels {
-		if _, ok := prepared.Labels[key]; !ok {
+	for key, value := range vnode.Labels {
+		preparedValue, ok := prepared.Labels[key]
+		if !ok {
 			return "", fmt.Errorf("configured vnode label key %q changes during host emission preparation", key)
+		}
+		if preparedValue != value {
+			return "", fmt.Errorf("configured vnode label value for %q changes during host emission preparation", key)
 		}
 	}
 	for key, value := range prepared.Labels {

--- a/src/go/plugin/framework/vnodes/configured.go
+++ b/src/go/plugin/framework/vnodes/configured.go
@@ -56,6 +56,11 @@ func validateConfigured(vnode *VirtualNode) (string, error) {
 	if !netdataapi.ValidSingleQuotedProtocolField(prepared.Hostname) {
 		return "", fmt.Errorf("configured vnode hostname cannot be represented in the host protocol")
 	}
+	for key := range vnode.Labels {
+		if _, ok := prepared.Labels[key]; !ok {
+			return "", fmt.Errorf("configured vnode label key %q changes during host emission preparation", key)
+		}
+	}
 	for key, value := range prepared.Labels {
 		if !netdataapi.ValidSingleQuotedProtocolField(key) ||
 			!netdataapi.ValidSingleQuotedProtocolField(value) {

--- a/src/go/plugin/framework/vnodes/vnodes.go
+++ b/src/go/plugin/framework/vnodes/vnodes.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/uuid"
 	"gopkg.in/yaml.v2"
 
 	"github.com/netdata/netdata/go/plugins/logger"
@@ -67,6 +66,7 @@ func (v *VirtualNode) Equal(vn *VirtualNode) bool {
 
 func readConfDir(dir string) map[string]*VirtualNode {
 	vnodes := make(map[string]*VirtualNode)
+	guids := make(map[string]string)
 
 	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -113,20 +113,6 @@ func readConfDir(dir string) map[string]*VirtualNode {
 		}
 
 		for _, v := range cfg {
-			if v.Hostname == "" || v.GUID == "" {
-				log.Warningf("skipping virtual node '%+v': required fields are missing (%s)", v, path)
-				continue
-			}
-			if err := uuid.Validate(v.GUID); err != nil {
-				log.Warningf("skipping virtual node '%+v': invalid GUID: %v (%s)", v, err, path)
-				continue
-			}
-			if _, ok := vnodes[v.Hostname]; ok {
-				log.Warningf("skipping virtual node '%+v': duplicate node (%s)", v, path)
-				continue
-			}
-
-			v := v
 
 			if v.Name != "" && v.Name != v.Hostname {
 				log.Warningf(
@@ -141,9 +127,26 @@ func readConfDir(dir string) map[string]*VirtualNode {
 			} else {
 				v.SourceType = "user"
 			}
+			guidKey, err := validateConfigured(&v)
+			if err != nil {
+				log.Warningf("skipping virtual node '%+v': %v (%s)", v, err, path)
+				continue
+			}
+			if _, ok := vnodes[v.Hostname]; ok {
+				log.Warningf("skipping virtual node '%+v': duplicate hostname (%s)", v, path)
+				continue
+			}
+			if other, ok := guids[guidKey]; ok {
+				log.Warningf(
+					"skipping virtual node '%+v': duplicate GUID already used by '%s' (%s)",
+					v, other, path,
+				)
+				continue
+			}
 
 			log.Debugf("adding virtual node'%+v' (%s)", v, path)
 			vnodes[v.Hostname] = &v
+			guids[guidKey] = v.Hostname
 		}
 
 		return nil

--- a/src/go/plugin/framework/vnodes/vnodes_test.go
+++ b/src/go/plugin/framework/vnodes/vnodes_test.go
@@ -42,3 +42,42 @@ func TestLoad_IgnoresCustomNameInFileAndUsesHostnameIdentity(t *testing.T) {
 	assert.Equal(t, "host-a", nodes["host-a"].Name)
 	assert.Equal(t, "host-a", nodes["host-a"].Hostname)
 }
+
+func TestLoad_SkipsInvalidConfiguredVnodesIndividually(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "vnodes.yaml")
+	cfg := `
+- hostname: first
+  guid: 11111111-2222-3333-4444-555555555555
+- hostname: compact
+  guid: 22222222333344445555666666666666
+- hostname: bad=name
+  guid: 33333333-4444-5555-6666-777777777777
+- hostname: unsupported-guid-form
+  guid: urn:uuid:44444444-5555-6666-7777-888888888888
+- hostname: duplicate-guid
+  guid: 11111111222233334444555555555555
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o644))
+
+	nodes := Load(dir)
+
+	require.Len(t, nodes, 2)
+	require.Contains(t, nodes, "first")
+	require.Contains(t, nodes, "compact")
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", nodes["first"].GUID)
+	assert.Equal(t, "22222222333344445555666666666666", nodes["compact"].GUID)
+}
+
+func TestLoad_SkipsVNodeWhoseSourceCannotBePublished(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "operator's")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	cfgPath := filepath.Join(dir, "vnodes.yaml")
+	cfg := `
+- hostname: host-a
+  guid: 11111111-2222-3333-4444-555555555555
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o644))
+
+	require.Empty(t, Load(dir))
+}

--- a/src/go/plugin/framework/vnodes/vnodes_test.go
+++ b/src/go/plugin/framework/vnodes/vnodes_test.go
@@ -57,6 +57,10 @@ func TestLoad_SkipsInvalidConfiguredVnodesIndividually(t *testing.T) {
   guid: urn:uuid:44444444-5555-6666-7777-888888888888
 - hostname: duplicate-guid
   guid: 11111111222233334444555555555555
+- hostname: changed-label-value
+  guid: 55555555-6666-7777-8888-999999999999
+  labels:
+    site: "operator's"
 `
 	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o644))
 
@@ -82,29 +86,49 @@ func TestLoad_SkipsVNodeWhoseSourceCannotBePublished(t *testing.T) {
 	require.Empty(t, Load(dir))
 }
 
-func TestValidateConfiguredRejectsLabelKeyNormalization(t *testing.T) {
-	tests := map[string]map[string]string{
+func TestValidateConfiguredRejectsLabelNormalization(t *testing.T) {
+	tests := map[string]struct {
+		labels  map[string]string
+		wantErr string
+	}{
 		"trimmed key": {
-			" region ": "east",
+			labels:  map[string]string{" region ": "east"},
+			wantErr: "label key",
 		},
 		"normalization collision": {
-			" region ": "east",
-			"region":   "west",
+			labels:  map[string]string{" region ": "east", "region": "west"},
+			wantErr: "label key",
+		},
+		"single quote value": {
+			labels:  map[string]string{"site": "operator's"},
+			wantErr: "label value",
+		},
+		"line feed value": {
+			labels:  map[string]string{"site": "east\nwest"},
+			wantErr: "label value",
+		},
+		"carriage return value": {
+			labels:  map[string]string{"site": "east\rwest"},
+			wantErr: "label value",
+		},
+		"NUL value": {
+			labels:  map[string]string{"site": "east\x00west"},
+			wantErr: "label value",
 		},
 	}
 
-	for name, labels := range tests {
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			vnode := &VirtualNode{
 				Name:       "host-a",
 				Hostname:   "host-a",
 				GUID:       "11111111-2222-3333-4444-555555555555",
-				Labels:     labels,
+				Labels:     test.labels,
 				Source:     "file=/etc/netdata/vnodes/vnodes.yaml",
 				SourceType: "user",
 			}
 
-			require.ErrorContains(t, ValidateConfigured(vnode), "label key")
+			require.ErrorContains(t, ValidateConfigured(vnode), test.wantErr)
 		})
 	}
 }

--- a/src/go/plugin/framework/vnodes/vnodes_test.go
+++ b/src/go/plugin/framework/vnodes/vnodes_test.go
@@ -81,3 +81,30 @@ func TestLoad_SkipsVNodeWhoseSourceCannotBePublished(t *testing.T) {
 
 	require.Empty(t, Load(dir))
 }
+
+func TestValidateConfiguredRejectsLabelKeyNormalization(t *testing.T) {
+	tests := map[string]map[string]string{
+		"trimmed key": {
+			" region ": "east",
+		},
+		"normalization collision": {
+			" region ": "east",
+			"region":   "west",
+		},
+	}
+
+	for name, labels := range tests {
+		t.Run(name, func(t *testing.T) {
+			vnode := &VirtualNode{
+				Name:       "host-a",
+				Hostname:   "host-a",
+				GUID:       "11111111-2222-3333-4444-555555555555",
+				Labels:     labels,
+				Source:     "file=/etc/netdata/vnodes/vnodes.yaml",
+				SourceType: "user",
+			}
+
+			require.ErrorContains(t, ValidateConfigured(vnode), "label key")
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/init_test.go
+++ b/src/go/plugin/go.d/collector/init_test.go
@@ -3,16 +3,58 @@
 package collector
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
+	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/pipeline"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 	snmptraps "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
+
+var serviceModulePattern = regexp.MustCompile(`(?m)^\s*(?:-\s*)?module:\s*([A-Za-z0-9_.-]+)\s*$`)
+
+func TestStockServiceDiscoveryRulesTargetRegisteredCollectors(t *testing.T) {
+	files, err := filepath.Glob("../config/go.d/sd/*.conf")
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	for _, file := range files {
+		bs, err := os.ReadFile(file)
+		require.NoError(t, err, file)
+
+		var cfg pipeline.Config
+		require.NoError(t, yaml.Unmarshal(bs, &cfg), file)
+
+		for _, rule := range cfg.Services {
+			if strings.TrimSpace(rule.ConfigTemplate) == "" {
+				continue
+			}
+			if strings.Contains(rule.ConfigTemplate, "toYaml") {
+				// Pass-through templates provide the complete job, including module,
+				// from the discovered item.
+				continue
+			}
+
+			modules := serviceModulePattern.FindAllStringSubmatch(rule.ConfigTemplate, -1)
+			if len(modules) == 0 {
+				modules = [][]string{{"", rule.ID}}
+			}
+			for _, match := range modules {
+				_, ok := collectorapi.DefaultRegistry.Lookup(match[1])
+				assert.Truef(t, ok, "%s service rule %q targets unregistered collector %q", filepath.Base(file), rule.ID, match[1])
+			}
+		}
+	}
+}
 
 func TestSNMPFamilyRegistrationUsesSharedDependencies(t *testing.T) {
 	snmpCreator := requireCreator(t, "snmp")

--- a/src/go/plugin/go.d/config/go.d/sd/net_listeners.conf
+++ b/src/go/plugin/go.d/config/go.d/sd/net_listeners.conf
@@ -410,6 +410,7 @@ services:
   - id: "riak"
     match: '{{ and (eq .Port "8098") (glob .Cmdline "*riak*") }}'
     config_template: |
+      module: riakkv
       name: local
       url: http://{{.Address}}/stats
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the job manager lifecycle and configuration reconciliation for safer, more resilient operation. Adds claim-yielding during prepare, centralized CONFIG protocol validation (incl. Windows paths), secret/log redaction, and stronger shutdown/recovery with better diagnostics.

- **New Features**
  - Claim yielding in the kernel: transactions can temporarily yield an acquisition-suffix claim during prepare; composites inherit authority and reacquisition has priority to avoid head-of-line blocking.
  - Safer config and protocol handling: `netdataapi` adds `TryCONFIGCREATE`/`TryCONFIGSTATUS` and shared validators for plugins.d fields (incl. Windows paths); discovery, dyncfg, vnode/secret file configs use them and classify proposal errors, quarantining bad configs instead of failing the batch.
  - Secret and log hygiene: resolved secret values are redacted from decode/lifecycle errors and dyncfg responses; the logger sanitizes messages and attributes (persists across `With`); dependent restarts run as bounded recovery with per-child timeouts and an overall budget.
  - Job output robustness: enforce probe-before-accept for jobs; Function registration/withdrawal respect plugins.d line limits; safe Function result payloads (no embedded terminators).

- **Bug Fixes**
  - Fairness and scheduling: fixed ready-queue ownership/management and lane bookkeeping to prevent starvation; improved composite child scheduling and lane sourcing.
  - Lifecycle and framing: stricter UID/content-type grammar; ensure nonzero expiries; release pending-control reservations on run release.
  - Shutdown and observability: kernel terminates cleanly if shutdown budget fails to start; quiescence now accounts for abandoned ownership; added abandonment tracking and diagnostics; SD rejects unrepresentable sources and preserves Windows paths.
  - VNodes: validate host-emission rules and reject normalized configured label values to avoid silent drift.

<sup>Written for commit 788e361e49aff5df7bfb553d2b5b5778dc914d79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

