### PR TITLE
perf(go.d/chartengine): skip disabled lifecycle cap work

### DIFF
--- a/src/go/plugin/framework/chartengine/planner_lifecycle.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle.go
@@ -87,9 +87,18 @@ func enforceChartInstanceCaps(
 	chartsByID map[string]*chartState,
 	state *materializedState,
 ) []RemoveChartAction {
-	observedByTemplate := make(map[string][]string)
+	var observedByTemplate map[string][]string
 	for chartID, cs := range chartsByID {
+		if cs.lifecycle.MaxInstances <= 0 {
+			continue
+		}
+		if observedByTemplate == nil {
+			observedByTemplate = make(map[string][]string)
+		}
 		observedByTemplate[cs.templateID] = append(observedByTemplate[cs.templateID], chartID)
+	}
+	if len(observedByTemplate) == 0 {
+		return nil
 	}
 	for templateID := range observedByTemplate {
 		sort.Strings(observedByTemplate[templateID])
@@ -97,10 +106,10 @@ func enforceChartInstanceCaps(
 
 	existingByTemplate := make(map[string][]string)
 	for chartID, matChart := range state.charts {
+		if _, enabled := observedByTemplate[matChart.templateID]; !enabled {
+			continue
+		}
 		existingByTemplate[matChart.templateID] = append(existingByTemplate[matChart.templateID], chartID)
-	}
-	for templateID := range existingByTemplate {
-		sort.Strings(existingByTemplate[templateID])
 	}
 
 	removeCharts := make([]RemoveChartAction, 0)
@@ -120,9 +129,6 @@ func enforceChartInstanceCaps(
 		// max_instances is a soft cap:
 		// currently active chart instances are never evicted in the same successful cycle.
 		maxInstances := lifecycle.MaxInstances
-		if maxInstances <= 0 {
-			continue
-		}
 
 		existingIDs := existingByTemplate[templateID]
 		existingSet := make(map[string]struct{}, len(existingIDs))
@@ -204,36 +210,42 @@ func enforceDimensionCaps(
 	state *materializedState,
 ) []RemoveDimensionAction {
 	// Per-chart dimension caps: evict least-recently-seen inactive dims first, then drop new dims.
-	removeDims := make([]RemoveDimensionAction, 0)
-	chartIDs := make([]string, 0, len(chartsByID))
-	for chartID := range chartsByID {
+	var chartIDs []string
+	for chartID, cs := range chartsByID {
+		if cs.lifecycle.Dimensions.MaxDims <= 0 {
+			continue
+		}
+		if chartIDs == nil {
+			chartIDs = make([]string, 0, len(chartsByID))
+		}
 		chartIDs = append(chartIDs, chartID)
 	}
+	if len(chartIDs) == 0 {
+		return nil
+	}
 	sort.Strings(chartIDs)
+
+	removeDims := make([]RemoveDimensionAction, 0)
 	for _, chartID := range chartIDs {
 		cs := chartsByID[chartID]
 		maxDims := cs.lifecycle.Dimensions.MaxDims
-		if maxDims <= 0 {
-			continue
-		}
 		matChart := state.charts[chartID]
 		existingCount := 0
 		if matChart != nil {
 			existingCount = len(matChart.dimensions)
 		}
 
-		newNames := make([]string, 0, cs.observedCount)
+		newCount := 0
 		for name, entry := range cs.entries {
 			if entry == nil || entry.seenSeq != cs.currentBuildSeq {
 				continue
 			}
 			if matChart == nil || matChart.dimensions[name] == nil {
-				newNames = append(newNames, name)
+				newCount++
 			}
 		}
-		sort.Strings(newNames)
 
-		total := existingCount + len(newNames)
+		total := existingCount + newCount
 		if total <= maxDims {
 			continue
 		}

--- a/src/go/plugin/framework/chartengine/planner_lifecycle_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle_bench_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine/internal/program"
+)
+
+var benchmarkLifecycleRemovalCount int
+
+func BenchmarkEnforceLifecycleCaps(b *testing.B) {
+	tests := map[string]struct {
+		chartCount int
+		dimCount   int
+		chartCaps  int
+		dimCaps    int
+	}{
+		"disabled/charts_512": {
+			chartCount: 512,
+			dimCount:   8,
+		},
+		"disabled/charts_4096": {
+			chartCount: 4096,
+			dimCount:   8,
+		},
+		"chart_only/charts_512": {
+			chartCount: 512,
+			dimCount:   8,
+			chartCaps:  512,
+		},
+		"chart_only/charts_4096": {
+			chartCount: 4096,
+			dimCount:   8,
+			chartCaps:  4096,
+		},
+		"dimension_only/charts_512": {
+			chartCount: 512,
+			dimCount:   8,
+			dimCaps:    512,
+		},
+		"dimension_only/charts_4096": {
+			chartCount: 4096,
+			dimCount:   8,
+			dimCaps:    4096,
+		},
+		"mixed/charts_512_enabled_8": {
+			chartCount: 512,
+			dimCount:   8,
+			chartCaps:  8,
+			dimCaps:    8,
+		},
+		"mixed/charts_4096_enabled_64": {
+			chartCount: 4096,
+			dimCount:   8,
+			chartCaps:  64,
+			dimCaps:    64,
+		},
+		"both_enabled/charts_512": {
+			chartCount: 512,
+			dimCount:   8,
+			chartCaps:  512,
+			dimCaps:    512,
+		},
+		"both_enabled/charts_4096": {
+			chartCount: 4096,
+			dimCount:   8,
+			chartCaps:  4096,
+			dimCaps:    4096,
+		},
+	}
+
+	for name, tc := range tests {
+		b.Run(name, func(b *testing.B) {
+			const currentSeq = uint64(10)
+			chartsByID, state := benchmarkLifecycleCapFixture(
+				currentSeq,
+				tc.chartCount,
+				tc.dimCount,
+				tc.chartCaps,
+				tc.dimCaps,
+			)
+
+			removeDims, removeCharts := enforceLifecycleCaps(currentSeq, chartsByID, &state)
+			if len(removeDims) != 0 || len(removeCharts) != 0 {
+				b.Fatalf("unexpected lifecycle removals: dimensions=%d charts=%d", len(removeDims), len(removeCharts))
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			var removalCount int
+			for range b.N {
+				removeDims, removeCharts := enforceLifecycleCaps(currentSeq, chartsByID, &state)
+				removalCount = len(removeDims) + len(removeCharts)
+			}
+			benchmarkLifecycleRemovalCount = removalCount
+		})
+	}
+}
+
+func benchmarkLifecycleCapFixture(
+	currentSeq uint64,
+	chartCount int,
+	dimCount int,
+	chartCaps int,
+	dimCaps int,
+) (map[string]*chartState, materializedState) {
+	chartsByID := make(map[string]*chartState, chartCount)
+	state := newMaterializedState()
+	meta := program.ChartMeta{Title: "Benchmark", Context: "benchmark", Units: "units"}
+
+	for chartIndex := range chartCount {
+		chartID := fmt.Sprintf("chart_%04d", chartIndex)
+		templateID := "template_disabled"
+		lifecycle := program.LifecyclePolicy{}
+		if chartIndex < chartCaps {
+			templateID = "template_chart_cap"
+			lifecycle.MaxInstances = chartCaps
+		}
+		if chartIndex < dimCaps {
+			lifecycle.Dimensions.MaxDims = dimCount
+		}
+
+		entries := make(map[string]*dimBuildEntry, dimCount)
+		for dimIndex := range dimCount {
+			name := fmt.Sprintf("dimension_%02d", dimIndex)
+			entries[name] = observedDimensionEntry(currentSeq)
+		}
+		chartsByID[chartID] = &chartState{
+			templateID:      templateID,
+			chartID:         chartID,
+			meta:            meta,
+			lifecycle:       lifecycle,
+			entries:         entries,
+			observedCount:   dimCount,
+			currentBuildSeq: currentSeq,
+		}
+
+		matChart, _ := state.ensureChart(chartID, templateID, meta, lifecycle)
+		matChart.lastSeenSuccessSeq = currentSeq
+		for dimIndex := range dimCount {
+			name := fmt.Sprintf("dimension_%02d", dimIndex)
+			dim, _ := matChart.ensureDimension(name, dimensionState{
+				algorithm:  program.AlgorithmAbsolute,
+				multiplier: 1,
+				divisor:    1,
+			})
+			dim.lastSeenSuccessSeq = currentSeq
+		}
+	}
+
+	return chartsByID, state
+}

--- a/src/go/plugin/framework/chartengine/planner_lifecycle_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle_bench_test.go
@@ -11,6 +11,12 @@ import (
 
 var benchmarkLifecycleRemovalCount int
 
+// BenchmarkEnforceLifecycleCaps measures the stable no-overflow planner path; fixture construction is outside the
+// timer. Timings are machine-specific trend evidence, while TestEnforceLifecycleCapsAllocationEnvelope is the portable
+// regression gate. With all caps disabled, enforcement retains two O(charts) map scans but allocates no cap-specific
+// memory. Enabled chart caps scan observed and materialized charts, then sort only enabled templates, instances, and
+// eviction candidates. Enabled dimension caps scan all charts, sort enabled chart IDs, and scan or sort dimensions only
+// for enabled charts. The dimension chart-ID slice reserves O(total charts) capacity; no lifecycle-cap path is quadratic.
 func BenchmarkEnforceLifecycleCaps(b *testing.B) {
 	tests := map[string]struct {
 		chartCount int
@@ -96,6 +102,69 @@ func BenchmarkEnforceLifecycleCaps(b *testing.B) {
 				removalCount = len(removeDims) + len(removeCharts)
 			}
 			benchmarkLifecycleRemovalCount = removalCount
+		})
+	}
+}
+
+func TestEnforceLifecycleCapsAllocationEnvelope(t *testing.T) {
+	tests := map[string]struct {
+		chartCount int
+		dimCount   int
+		chartCaps  int
+		dimCaps    int
+		maxAllocs  float64
+	}{
+		"disabled/charts_4096": {
+			chartCount: 4096,
+			dimCount:   8,
+			maxAllocs:  0,
+		},
+		"sparse/charts_4096_enabled_8": {
+			chartCount: 4096,
+			dimCount:   8,
+			chartCaps:  8,
+			dimCaps:    8,
+			maxAllocs:  16,
+		},
+		"dimension_only/charts_4096": {
+			chartCount: 4096,
+			dimCount:   8,
+			dimCaps:    4096,
+			maxAllocs:  2,
+		},
+		"both_enabled/charts_4096": {
+			chartCount: 4096,
+			dimCount:   8,
+			chartCaps:  4096,
+			dimCaps:    4096,
+			maxAllocs:  64,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			const currentSeq = uint64(10)
+			chartsByID, state := benchmarkLifecycleCapFixture(
+				currentSeq,
+				tc.chartCount,
+				tc.dimCount,
+				tc.chartCaps,
+				tc.dimCaps,
+			)
+
+			allocs := testing.AllocsPerRun(25, func() {
+				removeDims, removeCharts := enforceLifecycleCaps(currentSeq, chartsByID, &state)
+				if len(removeDims) != 0 || len(removeCharts) != 0 {
+					t.Fatalf(
+						"unexpected lifecycle removals: dimensions=%d charts=%d",
+						len(removeDims),
+						len(removeCharts),
+					)
+				}
+			})
+			if allocs > tc.maxAllocs {
+				t.Fatalf("allocation envelope exceeded: got %.0f allocs, want <= %.0f", allocs, tc.maxAllocs)
+			}
 		})
 	}
 }

--- a/src/go/plugin/framework/chartengine/planner_lifecycle_test.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle_test.go
@@ -3,8 +3,10 @@
 package chartengine
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine/internal/program"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +18,12 @@ func TestPlannerLifecycleScenarios(t *testing.T) {
 	}{
 		"enforce lifecycle caps dimension cap evicts lru": {
 			run: runTestEnforceLifecycleCapsDimensionCapEvictsLRU,
+		},
+		"enforce lifecycle caps mixed policies": {
+			run: runTestEnforceLifecycleCapsMixedPolicies,
+		},
+		"dimension cap removal retries after abort": {
+			run: runTestDimensionCapRemovalRetriesAfterAbort,
 		},
 		"collect expiry removals dimension and chart expiry": {
 			run: runTestCollectExpiryRemovalsDimensionAndChartExpiry,
@@ -97,6 +105,208 @@ func runTestEnforceLifecycleCapsDimensionCapEvictsLRU(t *testing.T) {
 			assert.Contains(t, matChart.dimensions, "old_b")
 			assert.Contains(t, chartsByID["chart_a"].entries, "new_c")
 		})
+	}
+}
+
+func runTestEnforceLifecycleCapsMixedPolicies(t *testing.T) {
+	const currentSeq = uint64(10)
+
+	meta := program.ChartMeta{Title: "Requests", Context: "requests", Units: "requests/s"}
+	state := newMaterializedState()
+
+	disabledLifecycle := program.LifecyclePolicy{}
+	disabledActive, created := state.ensureChart(
+		"disabled_active",
+		"tpl.disabled",
+		meta,
+		program.LifecyclePolicy{
+			MaxInstances: 1,
+			Dimensions:   program.DimensionLifecyclePolicy{MaxDims: 1},
+		},
+	)
+	require.True(t, created)
+	disabledActive.lastSeenSuccessSeq = 1
+	for _, name := range []string{"old_a", "old_b"} {
+		dim, created := disabledActive.ensureDimension(name, dimensionState{
+			algorithm:  program.AlgorithmAbsolute,
+			multiplier: 1,
+			divisor:    1,
+		})
+		require.True(t, created)
+		dim.lastSeenSuccessSeq = 1
+	}
+	disabledStale, created := state.ensureChart(
+		"disabled_stale",
+		"tpl.disabled",
+		meta,
+		program.LifecyclePolicy{MaxInstances: 1},
+	)
+	require.True(t, created)
+	disabledStale.lastSeenSuccessSeq = 1
+
+	enabledOld, created := state.ensureChart(
+		"enabled_old",
+		"tpl.enabled",
+		meta,
+		program.LifecyclePolicy{MaxInstances: 1},
+	)
+	require.True(t, created)
+	enabledOld.lastSeenSuccessSeq = 1
+
+	dimsLifecycle := program.LifecyclePolicy{
+		Dimensions: program.DimensionLifecyclePolicy{MaxDims: 1},
+	}
+	dimsActive, created := state.ensureChart("dims_active", "tpl.dims", meta, dimsLifecycle)
+	require.True(t, created)
+	dimsActive.lastSeenSuccessSeq = currentSeq
+	oldDim, created := dimsActive.ensureDimension("old", dimensionState{
+		algorithm:  program.AlgorithmAbsolute,
+		multiplier: 1,
+		divisor:    1,
+	})
+	require.True(t, created)
+	oldDim.lastSeenSuccessSeq = 1
+
+	chartsByID := map[string]*chartState{
+		"disabled_active": {
+			templateID:      "tpl.disabled",
+			chartID:         "disabled_active",
+			meta:            meta,
+			lifecycle:       disabledLifecycle,
+			currentBuildSeq: currentSeq,
+			observedCount:   1,
+			entries: map[string]*dimBuildEntry{
+				"new": observedDimensionEntry(currentSeq),
+			},
+		},
+		"enabled_new": {
+			templateID:      "tpl.enabled",
+			chartID:         "enabled_new",
+			meta:            meta,
+			lifecycle:       program.LifecyclePolicy{MaxInstances: 1},
+			currentBuildSeq: currentSeq,
+			observedCount:   1,
+			entries: map[string]*dimBuildEntry{
+				"value": observedDimensionEntry(currentSeq),
+			},
+		},
+		"dims_active": {
+			templateID:      "tpl.dims",
+			chartID:         "dims_active",
+			meta:            meta,
+			lifecycle:       dimsLifecycle,
+			currentBuildSeq: currentSeq,
+			observedCount:   1,
+			entries: map[string]*dimBuildEntry{
+				"new": observedDimensionEntry(currentSeq),
+			},
+		},
+	}
+
+	removeDims, removeCharts := enforceLifecycleCaps(currentSeq, chartsByID, &state)
+
+	require.Len(t, removeCharts, 1)
+	assert.Equal(t, "enabled_old", removeCharts[0].ChartID)
+	require.Len(t, removeDims, 1)
+	assert.Equal(t, "dims_active", removeDims[0].ChartID)
+	assert.Equal(t, "old", removeDims[0].Name)
+
+	assert.Contains(t, state.charts, "disabled_active")
+	assert.Contains(t, state.charts, "disabled_stale")
+	assert.Len(t, disabledActive.dimensions, 2)
+	assert.Contains(t, chartsByID["disabled_active"].entries, "new")
+}
+
+func runTestDimensionCapRemovalRetriesAfterAbort(t *testing.T) {
+	engine, err := New()
+	require.NoError(t, err)
+
+	require.NoError(t, engine.LoadYAML([]byte(maxDimsTemplateYAML(1)), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	sm := store.Write().SnapshotMeter("")
+	gauge := sm.Gauge("svc_mode")
+	modeA := sm.LabelSet(metrix.Label{Key: "mode", Value: "a"})
+	modeB := sm.LabelSet(metrix.Label{Key: "mode", Value: "b"})
+
+	cc.BeginCycle()
+	gauge.Observe(1, modeA)
+	require.NoError(t, cc.CommitCycleSuccess())
+	_, err = buildPlan(engine, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	materialized := engine.state.materialized.charts["service_mode"]
+	require.NotNil(t, materialized)
+	assert.Contains(t, materialized.dimensions, "a")
+
+	cc.BeginCycle()
+	gauge.Observe(1, modeB)
+	require.NoError(t, cc.CommitCycleSuccess())
+	reader := store.Read(metrix.ReadFlatten())
+
+	attempt, err := engine.PreparePlan(reader)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]ActionKind{ActionRemoveDimension, ActionCreateDimension, ActionUpdateChart},
+		actionKinds(attempt.Plan().Actions),
+	)
+	removeDim := findRemoveDimensionAction(attempt.Plan())
+	require.NotNil(t, removeDim)
+	assert.Equal(t, "a", removeDim.Name)
+	attempt.Abort()
+
+	materialized = engine.state.materialized.charts["service_mode"]
+	require.NotNil(t, materialized)
+	assert.Contains(t, materialized.dimensions, "a")
+	assert.NotContains(t, materialized.dimensions, "b")
+
+	retry, err := engine.PreparePlan(reader)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]ActionKind{ActionRemoveDimension, ActionCreateDimension, ActionUpdateChart},
+		actionKinds(retry.Plan().Actions),
+	)
+	removeDim = findRemoveDimensionAction(retry.Plan())
+	require.NotNil(t, removeDim)
+	assert.Equal(t, "a", removeDim.Name)
+	require.NoError(t, retry.Commit())
+
+	materialized = engine.state.materialized.charts["service_mode"]
+	require.NotNil(t, materialized)
+	assert.NotContains(t, materialized.dimensions, "a")
+	assert.Contains(t, materialized.dimensions, "b")
+}
+
+func maxDimsTemplateYAML(maxDims int) string {
+	return fmt.Sprintf(`
+version: v1
+groups:
+  - family: Service
+    metrics:
+      - svc_mode
+    charts:
+      - id: service_mode
+        title: Service mode
+        context: service_mode
+        units: state
+        lifecycle:
+          dimensions:
+            max_dims: %d
+        dimensions:
+          - selector: svc_mode
+            name_from_label: mode
+`, maxDims)
+}
+
+func observedDimensionEntry(seenSeq uint64) *dimBuildEntry {
+	return &dimBuildEntry{
+		seenSeq: seenSeq,
+		dimensionState: dimensionState{
+			algorithm:  program.AlgorithmAbsolute,
+			multiplier: 1,
+			divisor:    1,
+		},
 	}
 }
 

--- a/src/go/plugin/framework/chartengine/planner_lifecycle_test.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle_test.go
@@ -119,10 +119,7 @@ func runTestEnforceLifecycleCapsMixedPolicies(t *testing.T) {
 		"disabled_active",
 		"tpl.disabled",
 		meta,
-		program.LifecyclePolicy{
-			MaxInstances: 1,
-			Dimensions:   program.DimensionLifecyclePolicy{MaxDims: 1},
-		},
+		disabledLifecycle,
 	)
 	require.True(t, created)
 	disabledActive.lastSeenSuccessSeq = 1
@@ -139,7 +136,7 @@ func runTestEnforceLifecycleCapsMixedPolicies(t *testing.T) {
 		"disabled_stale",
 		"tpl.disabled",
 		meta,
-		program.LifecyclePolicy{MaxInstances: 1},
+		disabledLifecycle,
 	)
 	require.True(t, created)
 	disabledStale.lastSeenSuccessSeq = 1

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -948,25 +948,7 @@ func runTestBuildPlanEnforcesMaxDimsDeterministically(t *testing.T) {
 	e, err := New()
 	require.NoError(t, err)
 
-	yaml := `
-version: v1
-groups:
-  - family: Service
-    metrics:
-      - svc_mode
-    charts:
-      - id: service_mode
-        title: Service mode
-        context: service_mode
-        units: state
-        lifecycle:
-          dimensions:
-            max_dims: 2
-        dimensions:
-          - selector: svc_mode
-            name_from_label: mode
-`
-	require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+	require.NoError(t, e.LoadYAML([]byte(maxDimsTemplateYAML(2)), 1))
 
 	store := metrix.NewCollectorStore()
 	cc := mustCycleController(t, store)


### PR DESCRIPTION
## Summary

- skip chart-instance lifecycle work when no observed template enables `max_instances`
- sort and process only charts that enable `max_dims`
- remove two redundant enabled-path sorts/counting allocations
- add mixed-policy, abort/retry, and low/high-cardinality benchmark coverage

## Why

Lifecycle-cap enforcement runs after every successful chartengine scan. Both caps default to disabled, but the previous implementation still grouped and sorted the complete observed chart set before discovering that there was no cap to enforce.

The optimized path filters policies while building the existing working sets and returns early when those sets are empty. Expiry processing remains independent and unchanged.

## Performance

Median of seven alternating baseline/current runs with `GOMAXPROCS=1`:

| Policy shape | Charts | Time | Allocated bytes | Allocations |
|---|---:|---:|---:|---:|
| disabled | 512 | -96.3% | -100% | 21 -> 0 |
| disabled | 4,096 | -96.3% | -100% | 31 -> 0 |
| mixed | 512 | -83.6% | -78.5% | 38 -> 12 |
| mixed | 4,096 | -87.3% | -86.7% | 113 -> 21 |
| dimension-only | 512 | -57.9% | -91.6% | 533 -> 1 |
| dimension-only | 4,096 | -59.5% | -93.9% | 4,127 -> 1 |
| both enabled | 512 | -22.8% | -43.6% | 537 -> 27 |
| both enabled | 4,096 | -20.8% | -38.7% | 4,145 -> 51 |
| chart-only | 512 | -41.2% | -10.8% | 25 -> 26 |
| chart-only | 4,096 | -39.3% | -7.9% | 49 -> 50 |

The chart-only shape trades one additional small allocation for lower total allocated bytes and substantially lower CPU time. No measured policy shape regressed in time or allocated bytes.

## Behavior and risk

- chart-cap enforcement still precedes dimension-cap enforcement
- deterministic observed/template/drop and eviction ordering is preserved
- current observed policy remains authoritative
- staged mutations retain commit/abort atomicity
- lifecycle expiry, configuration, schema, and collector behavior are unchanged

## Validation

- `go fix ./...`
- `go vet ./plugin/framework/chartengine/...`
- `go test -count=1 ./plugin/framework/chartengine/...`
- `go test -race -count=1 ./plugin/framework/chartengine/...`
- `go test -count=1 ./plugin/framework/jobruntime/... ./plugin/framework/runtimecomp/...`
- `go test -race -count=1 ./plugin/agent/jobmgr/...`
- `go test -count=1 ./plugin/go.d/collector/vsphere/...`
- `go test -count=1 ./plugin/go.d/collector/snmp_traps/...`
- `go test -count=1 ./plugin/go.d/collector/prometheus/...`
- seven alternating baseline/current runs of every permanent lifecycle-cap benchmark
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips lifecycle-cap work when caps are disabled and limits sorting/processing to charts that enable `max_instances` or `max_dims`. This cuts CPU and allocations without changing ordering or expiry behavior.

- **Performance**
  - Filter policies while building working sets; allocate lazily and return early when no caps are enabled.
  - For `max_instances`, handle only enabled templates and drop the redundant sort of existing instances.
  - For `max_dims`, consider only capped charts and count new dims without building/sorting name lists.
  - Benchmarks show up to ~96% faster with disabled caps and ~58–59% faster in dimension-only cases; zero allocations on disabled paths.

- **Tests**
  - Added allocation-envelope test covering disabled, sparse, dimension-only, and both-enabled cases.
  - Added unit tests for mixed policies and abort/retry of dimension-cap removals.
  - Added lifecycle-cap benchmarks using a reachable fixture across disabled, mixed, dimension-only, both-enabled, and chart-only shapes.
  - Refactored tests to reuse a YAML helper for dimension-cap plans.

<sup>Written for commit 3dafc13557641205ed0c94357e19378ac6a7206a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

