### PR TITLE
fix(query): preserve totals, timestamps, and storage gap evidence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1386,6 +1386,8 @@ set(DAEMON_FILES
         src/daemon/pipename.h
         src/daemon/unit_test.c
         src/daemon/unit_test.h
+        src/daemon/unit_test_bridge.c
+        src/daemon/unit_test_bridge.h
         src/daemon/dyncfg/dyncfg.c
         src/daemon/dyncfg/dyncfg.h
         src/daemon/dyncfg/dyncfg-files.c
@@ -1874,6 +1876,8 @@ if(ENABLE_DBENGINE)
             src/database/engine/pagecache.c
             src/database/engine/pagecache.h
             src/database/engine/page_test.cc
+            src/database/engine/page_test_bridge.cc
+            src/database/engine/page_test_bridge.h
             src/database/engine/page.c
             src/database/engine/page.h
             src/database/engine/cache.c
@@ -3166,6 +3170,22 @@ add_executable(stream-replay-endpoints-test EXCLUDE_FROM_ALL
 target_link_libraries(stream-replay-endpoints-test libnetdata)
 
 if(OS_LINUX)
+        add_executable(rrddim-collection-test EXCLUDE_FROM_ALL
+                src/database/tests/rrddim-collection-test.c)
+        target_compile_options(rrddim-collection-test PRIVATE -ffunction-sections -fdata-sections)
+        target_link_options(rrddim-collection-test PRIVATE -Wl,--no-export-dynamic -Wl,--gc-sections)
+        target_link_libraries(rrddim-collection-test libnetdata)
+endif()
+
+if(ENABLE_DBENGINE AND OS_LINUX)
+        add_executable(stream-replication-query-test EXCLUDE_FROM_ALL
+                src/streaming/tests/stream-replication-query-test.c)
+        target_compile_options(stream-replication-query-test PRIVATE -ffunction-sections -fdata-sections)
+        target_link_options(stream-replication-query-test PRIVATE -Wl,--no-export-dynamic -Wl,--gc-sections)
+        target_link_libraries(stream-replication-query-test libnetdata)
+endif()
+
+if(OS_LINUX)
         add_executable(http-auth-bearer-test EXCLUDE_FROM_ALL
                 src/web/api/tests/http-auth-bearer-test.c)
         target_compile_options(http-auth-bearer-test PRIVATE -ffunction-sections -fdata-sections)
@@ -3585,6 +3605,28 @@ if(OS_WINDOWS)
         configure_file(packaging/windows/Top.bmp Top.bmp COPYONLY)
         configure_file(packaging/windows/BackGround.bmp BackGround.bmp COPYONLY)
         configure_file(src/collectors/windows.plugin/driver/netdata_driver.inf netdata_driver.inf COPYONLY)
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$" AND
+   NOT CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+        set_property(
+                SOURCE src/daemon/unit_test_bridge.c
+                APPEND PROPERTY COMPILE_OPTIONS "-fno-lto" "-fvisibility=hidden")
+elseif(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        message(WARNING
+                "Netdata test bridge cannot disable IPO for unsupported C compiler '${CMAKE_C_COMPILER_ID}'")
+endif()
+
+if(ENABLE_DBENGINE)
+        if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$" AND
+           NOT CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+                set_property(
+                        SOURCE src/database/engine/page_test_bridge.cc
+                        APPEND PROPERTY COMPILE_OPTIONS "-fno-lto" "-fvisibility=hidden")
+        elseif(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+                message(WARNING
+                        "Netdata page-test bridge cannot disable IPO for unsupported C++ compiler '${CMAKE_CXX_COMPILER_ID}'")
+        endif()
 endif()
 
 add_executable(netdata

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "common.h"
+#include "unit_test_bridge.h"
 #include "web/api/formatters/rrd2json.h"
 #include "web/api/queries/query-internal.h"
 #include "database/contexts/rrdcontext-internal.h"
@@ -587,19 +588,19 @@ static size_t test_rrddim_storage_point_contract_mode(RRD_DB_MODE mode, const ch
     STORAGE_POINT_EXPECT(rd->tiers[0].seb == STORAGE_ENGINE_BACKEND_RRDDIM);
 
     const time_t t = 1700000000;
-    storage_engine_store_metric(rd->tiers[0].sch, (usec_t)t * USEC_PER_SEC,
-                                10, 10, 10, 1, 0, SN_DEFAULT_FLAGS);
-    storage_engine_store_metric(rd->tiers[0].sch, (usec_t)(t + 1) * USEC_PER_SEC,
-                                NAN, NAN, NAN, 0, 0, SN_EMPTY_SLOT);
-    storage_engine_store_metric(rd->tiers[0].sch, (usec_t)(t + 2) * USEC_PER_SEC,
-                                -20, -20, -20, 1, 1, SN_FLAG_RESET);
+    unittest_storage_engine_store_metric(rd->tiers[0].sch, (usec_t)t * USEC_PER_SEC,
+                                         10, 10, 10, 1, 0, SN_DEFAULT_FLAGS);
+    unittest_storage_engine_store_metric(rd->tiers[0].sch, (usec_t)(t + 1) * USEC_PER_SEC,
+                                         NAN, NAN, NAN, 0, 0, SN_EMPTY_SLOT);
+    unittest_storage_engine_store_metric(rd->tiers[0].sch, (usec_t)(t + 2) * USEC_PER_SEC,
+                                         -20, -20, -20, 1, 1, SN_FLAG_RESET);
 
     struct storage_engine_query_handle seqh = { 0 };
-    storage_engine_query_init(rd->tiers[0].seb, rd->tiers[0].smh, &seqh,
-                              t - 1, t + 3, STORAGE_PRIORITY_SYNCHRONOUS);
+    unittest_storage_engine_query_init(rd->tiers[0].seb, rd->tiers[0].smh, &seqh,
+                                       t - 1, t + 3, STORAGE_PRIORITY_SYNCHRONOUS);
 
     for(time_t end_time_s = t - 1; end_time_s <= t + 3; end_time_s++) {
-        STORAGE_POINT sp = storage_engine_query_next_metric(&seqh);
+        STORAGE_POINT sp = unittest_storage_engine_query_next_metric(&seqh);
         STORAGE_POINT_EXPECT(sp.start_time_s == end_time_s - 1);
         STORAGE_POINT_EXPECT(sp.end_time_s == end_time_s);
 
@@ -624,8 +625,8 @@ static size_t test_rrddim_storage_point_contract_mode(RRD_DB_MODE mode, const ch
         }
     }
 
-    STORAGE_POINT_EXPECT(storage_engine_query_is_finished(&seqh));
-    storage_engine_query_finalize(&seqh);
+    STORAGE_POINT_EXPECT(unittest_storage_engine_query_is_finished(&seqh));
+    unittest_storage_engine_query_finalize(&seqh);
     rrdset_free(st);
     return errors;
 }
@@ -826,6 +827,56 @@ static int test_jsonwrap_v2_partial_data_trimming_raw_metadata(void) {
     qt.window.options = 0;
     if(query_target_aggregatable(&qt)) {
         fprintf(stderr, "query_target_aggregatable() unexpectedly true without RRDR_OPTION_RETURN_RAW\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+static int test_rrdr_group_by_partial_data_trimming(void) {
+    time_t timestamps[] = { 10, 20, 30, 40, 50, 60 };
+    RRDR_DIMENSION_FLAGS dimensions[] = { RRDR_DIMENSION_QUERIED, RRDR_DIMENSION_QUERIED };
+    uint32_t complete_gbc[] = {
+        1, 1,
+        1, 1,
+        1, 1,
+        1, 1,
+        1, 1,
+        1, 1,
+    };
+    uint32_t partial_gbc[] = {
+        1, 1,
+        1, 1,
+        1, 1,
+        1, 1,
+        1, 0,
+        1, 0,
+    };
+    RRDR r = {
+        .d = 2,
+        .n = 6,
+        .rows = 6,
+        .od = dimensions,
+        .t = timestamps,
+        .gbc = complete_gbc,
+        .partial_data_trimming = {
+            .expected_after = 40,
+            .trimmed_after = 60,
+        },
+    };
+
+    rrdr2rrdr_group_by_partial_trimming(&r);
+    if(r.rows != 6 || r.partial_data_trimming.trimmed_after != 60) {
+        fprintf(stderr, "complete contributor rows were unexpectedly trimmed to %zu at %jd\n",
+                r.rows, (intmax_t)r.partial_data_trimming.trimmed_after);
+        return 1;
+    }
+
+    r.gbc = partial_gbc;
+    rrdr2rrdr_group_by_partial_trimming(&r);
+    if(r.rows != 4 || r.partial_data_trimming.trimmed_after != 50) {
+        fprintf(stderr, "partial contributor suffix was trimmed to %zu at %jd, expected 4 at 50\n",
+                r.rows, (intmax_t)r.partial_data_trimming.trimmed_after);
         return 1;
     }
 
@@ -2178,7 +2229,7 @@ static int test_rrdset_rejects_invalid_update_every(void) {
         }
     }
 
-    const time_t valid_update_every = 7;
+    const time_t valid_update_every = INT32_MAX;
     previous = rrdset_set_update_every_s(st, valid_update_every);
     if(previous != original_update_every || st->update_every != valid_update_every) {
         fprintf(stderr, "%s: valid update every did not change chart from %ld to %ld; current %d\n",
@@ -2489,6 +2540,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(test_jsonwrap_v2_partial_data_trimming_raw_metadata())
+        return 1;
+
+    if(test_rrdr_group_by_partial_data_trimming())
         return 1;
 
     if(check_rrdcalc_comparisons())

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -403,8 +403,247 @@ static int check_storage_number_exists() {
     return 0;
 }
 
+#define STORAGE_POINT_EXPECT(condition) do {                                                                           \
+    if(!(condition)) {                                                                                                  \
+        fprintf(stderr, "Storage-point unittest failed at %s:%d: %s\n", __FILE__, __LINE__, #condition);              \
+        errors++;                                                                                                       \
+    }                                                                                                                   \
+} while(0)
+
+static STORAGE_POINT unittest_numeric_storage_point(
+    time_t start_time_s, time_t end_time_s,
+    NETDATA_DOUBLE min, NETDATA_DOUBLE max, NETDATA_DOUBLE sum,
+    uint32_t count, uint32_t gap_count, uint32_t anomaly_count, SN_FLAGS flags) {
+    return (STORAGE_POINT) {
+        .min = min,
+        .max = max,
+        .sum = sum,
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .count = count,
+        .anomaly_count = anomaly_count,
+        .flags = flags,
+        .gap_count = gap_count,
+    };
+}
+
+static size_t test_storage_point_contract(void) {
+    size_t errors = 0;
+
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    STORAGE_POINT_EXPECT(storage_point_is_unset(sp));
+    STORAGE_POINT_EXPECT(!storage_point_has_value(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_gap(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_complete(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_partial(sp));
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 0);
+    STORAGE_POINT_EXPECT(storage_point_is_zero(sp));
+    STORAGE_POINT_EXPECT(storage_point_average_value(sp) == 0);
+    STORAGE_POINT_EXPECT(storage_point_anomaly_rate(sp) == 0);
+    STORAGE_POINT_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+                         !netdata_double_isnumber(sp.sum));
+    STORAGE_POINT_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 0);
+    STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 0 && sp.anomaly_count == 0);
+    STORAGE_POINT_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    sp = unittest_numeric_storage_point(10, 20, 1, 2, 3, 2, 3, 1, SN_FLAG_RESET);
+    storage_point_unset(sp);
+    STORAGE_POINT_EXPECT(storage_point_is_unset(sp));
+    STORAGE_POINT_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+                         !netdata_double_isnumber(sp.sum));
+    STORAGE_POINT_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 0);
+    STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 0 && sp.anomaly_count == 0);
+    STORAGE_POINT_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    storage_point_empty_slots(sp, 10, 20, 0);
+    STORAGE_POINT_EXPECT(!storage_point_is_unset(sp));
+    STORAGE_POINT_EXPECT(storage_point_is_gap(sp));
+    STORAGE_POINT_EXPECT(!storage_point_has_value(sp));
+    STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 1);
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 1);
+    STORAGE_POINT_EXPECT(!netdata_double_isnumber(storage_point_average_value(sp)));
+    STORAGE_POINT_EXPECT(storage_point_anomaly_rate(sp) == 0);
+
+    storage_point_empty_slots(sp, 20, 30, 65536);
+    STORAGE_POINT_EXPECT(storage_point_is_gap(sp));
+    STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 65536);
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 65536);
+
+    sp.count = UINT32_MAX;
+    sp.gap_count = UINT32_MAX;
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 2ULL * UINT32_MAX);
+
+    sp = unittest_numeric_storage_point(10, 20, 1, 2, 3, 2, 0, 1, SN_FLAG_NONE);
+    STORAGE_POINT_EXPECT(storage_point_has_value(sp));
+    STORAGE_POINT_EXPECT(storage_point_is_complete(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_partial(sp));
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 2);
+    STORAGE_POINT_EXPECT(storage_point_average_value(sp) == 1.5);
+    STORAGE_POINT_EXPECT(storage_point_anomaly_rate(sp) == 50);
+
+    sp.gap_count = 3;
+    STORAGE_POINT_EXPECT(storage_point_has_value(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_complete(sp));
+    STORAGE_POINT_EXPECT(storage_point_is_partial(sp));
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 5);
+    STORAGE_POINT_EXPECT(storage_point_average_value(sp) == 1.5);
+
+    sp = unittest_numeric_storage_point(0, 1, 0, 0, 0, 1, 0, 0, SN_DEFAULT_FLAGS);
+    STORAGE_POINT_EXPECT(storage_point_is_zero(sp));
+    sp.anomaly_count = 1;
+    STORAGE_POINT_EXPECT(!storage_point_is_zero(sp));
+
+    STORAGE_POINT numeric = unittest_numeric_storage_point(10, 20, 2, 5, 7, 2, 1, 1, SN_FLAG_RESET);
+    STORAGE_POINT merged = STORAGE_POINT_UNSET;
+    storage_point_merge_to(merged, numeric);
+    STORAGE_POINT_EXPECT(merged.min == 2 && merged.max == 5 && merged.sum == 7);
+    STORAGE_POINT_EXPECT(merged.start_time_s == 10 && merged.end_time_s == 20);
+    STORAGE_POINT_EXPECT(merged.count == 2 && merged.gap_count == 1 && merged.anomaly_count == 1);
+    STORAGE_POINT_EXPECT(merged.flags & SN_FLAG_RESET);
+
+    STORAGE_POINT unset = STORAGE_POINT_UNSET;
+    storage_point_merge_to(merged, unset);
+    STORAGE_POINT_EXPECT(merged.min == 2 && merged.max == 5 && merged.sum == 7);
+    STORAGE_POINT_EXPECT(merged.count == 2 && merged.gap_count == 1 && merged.anomaly_count == 1);
+
+    STORAGE_POINT gap;
+    storage_point_empty(gap, 0, 10);
+    STORAGE_POINT gap_first = gap;
+    storage_point_merge_to(gap_first, numeric);
+    STORAGE_POINT_EXPECT(gap_first.start_time_s == 0 && gap_first.end_time_s == 20);
+    STORAGE_POINT_EXPECT(gap_first.min == 2 && gap_first.max == 5 && gap_first.sum == 7);
+    STORAGE_POINT_EXPECT(gap_first.count == 2 && gap_first.gap_count == 2 && gap_first.anomaly_count == 1);
+    STORAGE_POINT_EXPECT(storage_point_is_partial(gap_first));
+
+    STORAGE_POINT numeric_first = numeric;
+    storage_point_merge_to(numeric_first, gap);
+    STORAGE_POINT_EXPECT(numeric_first.start_time_s == gap_first.start_time_s &&
+                         numeric_first.end_time_s == gap_first.end_time_s);
+    STORAGE_POINT_EXPECT(numeric_first.min == gap_first.min && numeric_first.max == gap_first.max &&
+                         numeric_first.sum == gap_first.sum);
+    STORAGE_POINT_EXPECT(numeric_first.count == gap_first.count &&
+                         numeric_first.gap_count == gap_first.gap_count &&
+                         numeric_first.anomaly_count == gap_first.anomaly_count &&
+                         numeric_first.flags == gap_first.flags);
+
+    STORAGE_POINT second_gap;
+    storage_point_empty(second_gap, 20, 30);
+    storage_point_merge_to(gap, second_gap);
+    STORAGE_POINT_EXPECT(storage_point_is_gap(gap));
+    STORAGE_POINT_EXPECT(gap.start_time_s == 0 && gap.end_time_s == 30 && gap.gap_count == 2);
+
+    STORAGE_POINT second_numeric =
+        unittest_numeric_storage_point(20, 30, 1, 7, 11, 3, 2, 2, SN_FLAG_NONE);
+    storage_point_merge_to(numeric, second_numeric);
+    STORAGE_POINT_EXPECT(numeric.start_time_s == 10 && numeric.end_time_s == 30);
+    STORAGE_POINT_EXPECT(numeric.min == 1 && numeric.max == 7 && numeric.sum == 18);
+    STORAGE_POINT_EXPECT(numeric.count == 5 && numeric.gap_count == 3 && numeric.anomaly_count == 3);
+    STORAGE_POINT_EXPECT(numeric.flags & SN_FLAG_RESET);
+
+    STORAGE_POINT added = unittest_numeric_storage_point(0, 10, 2, 5, 7, 2, 1, 1, SN_FLAG_NONE);
+    second_numeric = unittest_numeric_storage_point(10, 20, 3, 7, 11, 3, 2, 2, SN_FLAG_RESET);
+    storage_point_add_to(added, second_numeric);
+    STORAGE_POINT_EXPECT(added.start_time_s == 0 && added.end_time_s == 20);
+    STORAGE_POINT_EXPECT(added.min == 5 && added.max == 12 && added.sum == 18);
+    STORAGE_POINT_EXPECT(added.count == 5 && added.gap_count == 3 && added.anomaly_count == 3);
+    STORAGE_POINT_EXPECT(added.flags & SN_FLAG_RESET);
+    storage_point_empty(gap, 20, 30);
+    storage_point_add_to(added, gap);
+    STORAGE_POINT_EXPECT(added.sum == 18 && added.count == 5 && added.gap_count == 4);
+
+    storage_point_empty(gap, 0, 10);
+    STORAGE_POINT gap_added = gap;
+    storage_point_add_to(gap_added, added);
+    STORAGE_POINT_EXPECT(gap_added.start_time_s == 0 && gap_added.end_time_s == 30);
+    STORAGE_POINT_EXPECT(gap_added.min == 5 && gap_added.max == 12 && gap_added.sum == 18);
+    STORAGE_POINT_EXPECT(gap_added.count == 5 && gap_added.gap_count == 5 && gap_added.anomaly_count == 3);
+    STORAGE_POINT_EXPECT(gap_added.flags & SN_FLAG_RESET);
+
+    STORAGE_POINT absolute =
+        unittest_numeric_storage_point(10, 20, -5, -2, -7, 2, 1, 1, SN_FLAG_RESET);
+    storage_point_make_positive(absolute);
+    STORAGE_POINT_EXPECT(absolute.min == 2 && absolute.max == 5 && absolute.sum == 7);
+    STORAGE_POINT_EXPECT(absolute.start_time_s == 10 && absolute.end_time_s == 20);
+    STORAGE_POINT_EXPECT(absolute.count == 2 && absolute.gap_count == 1 && absolute.anomaly_count == 1);
+    STORAGE_POINT_EXPECT(absolute.flags & SN_FLAG_RESET);
+    storage_point_empty(gap, 20, 30);
+    storage_point_make_positive(gap);
+    STORAGE_POINT_EXPECT(storage_point_is_gap(gap) && gap.gap_count == 1);
+
+    fprintf(stderr, "Storage-point contract unittests: %s\n", errors ? "FAILED" : "PASSED");
+    return errors;
+}
+
+static size_t test_rrddim_storage_point_contract_mode(RRD_DB_MODE mode, const char *id) {
+    size_t errors = 0;
+
+    RRDSET *st = rrdset_create_custom(
+        localhost, "unittest-storage", id, id, "unittest", "unittest.storage",
+        "Storage Point Unit Testing", "value", "unittest", id,
+        1, 1, RRDSET_TYPE_LINE, mode, 8);
+    RRDDIM *rd = rrddim_add(st, "dim", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+    STORAGE_POINT_EXPECT(rd->rrd_memory_mode == mode);
+    STORAGE_POINT_EXPECT(rd->tiers[0].seb == STORAGE_ENGINE_BACKEND_RRDDIM);
+
+    const time_t t = 1700000000;
+    storage_engine_store_metric(rd->tiers[0].sch, (usec_t)t * USEC_PER_SEC,
+                                10, 10, 10, 1, 0, SN_DEFAULT_FLAGS);
+    storage_engine_store_metric(rd->tiers[0].sch, (usec_t)(t + 1) * USEC_PER_SEC,
+                                NAN, NAN, NAN, 0, 0, SN_EMPTY_SLOT);
+    storage_engine_store_metric(rd->tiers[0].sch, (usec_t)(t + 2) * USEC_PER_SEC,
+                                -20, -20, -20, 1, 1, SN_FLAG_RESET);
+
+    struct storage_engine_query_handle seqh = { 0 };
+    storage_engine_query_init(rd->tiers[0].seb, rd->tiers[0].smh, &seqh,
+                              t - 1, t + 3, STORAGE_PRIORITY_SYNCHRONOUS);
+
+    for(time_t end_time_s = t - 1; end_time_s <= t + 3; end_time_s++) {
+        STORAGE_POINT sp = storage_engine_query_next_metric(&seqh);
+        STORAGE_POINT_EXPECT(sp.start_time_s == end_time_s - 1);
+        STORAGE_POINT_EXPECT(sp.end_time_s == end_time_s);
+
+        if(end_time_s == t) {
+            STORAGE_POINT_EXPECT(storage_point_is_complete(sp));
+            STORAGE_POINT_EXPECT(sp.min == 10 && sp.max == 10 && sp.sum == 10);
+            STORAGE_POINT_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 0);
+            STORAGE_POINT_EXPECT(sp.flags & SN_FLAG_NOT_ANOMALOUS);
+        }
+        else if(end_time_s == t + 2) {
+            STORAGE_POINT_EXPECT(storage_point_is_complete(sp));
+            STORAGE_POINT_EXPECT(sp.min == -20 && sp.max == -20 && sp.sum == -20);
+            STORAGE_POINT_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 1);
+            STORAGE_POINT_EXPECT((sp.flags & SN_FLAG_RESET) && !(sp.flags & SN_FLAG_NOT_ANOMALOUS));
+        }
+        else {
+            STORAGE_POINT_EXPECT(storage_point_is_gap(sp));
+            STORAGE_POINT_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+                                 !netdata_double_isnumber(sp.sum));
+            STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
+            STORAGE_POINT_EXPECT(sp.flags == SN_FLAG_NONE);
+        }
+    }
+
+    STORAGE_POINT_EXPECT(storage_engine_query_is_finished(&seqh));
+    storage_engine_query_finalize(&seqh);
+    rrdset_free(st);
+    return errors;
+}
+
+static size_t test_rrddim_storage_point_contract(void) {
+    size_t errors = 0;
+    errors += test_rrddim_storage_point_contract_mode(RRD_DB_MODE_RAM, "storage-point-ram");
+    errors += test_rrddim_storage_point_contract_mode(RRD_DB_MODE_ALLOC, "storage-point-alloc");
+    fprintf(stderr, "RAM/ALLOC storage-point unittests: %s\n", errors ? "FAILED" : "PASSED");
+    return errors;
+}
+
+#undef STORAGE_POINT_EXPECT
+
 int unit_test_storage() {
-    if(check_storage_number_exists()) return 0;
+    if(test_storage_point_contract()) return 1;
+    if(test_rrddim_storage_point_contract()) return 1;
+    if(check_storage_number_exists()) return 1;
 
     NETDATA_DOUBLE storage_number_positive_min = unpack_storage_number(STORAGE_NUMBER_POSITIVE_MIN_RAW);
     NETDATA_DOUBLE storage_number_negative_max = unpack_storage_number(STORAGE_NUMBER_NEGATIVE_MAX_RAW);

--- a/src/daemon/unit_test_bridge.c
+++ b/src/daemon/unit_test_bridge.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "unit_test_bridge.h"
+
+NOINLINE void unittest_storage_engine_store_metric(
+    STORAGE_COLLECT_HANDLE *sch,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags) {
+    storage_engine_store_metric(
+        sch, point_in_time_ut, n, min_value, max_value, count, anomaly_count, flags);
+}
+
+NOINLINE void unittest_storage_engine_store_change_collection_frequency(
+    STORAGE_COLLECT_HANDLE *sch, int update_every) {
+    storage_engine_store_change_collection_frequency(sch, update_every);
+}
+
+NOINLINE void unittest_storage_engine_store_flush(STORAGE_COLLECT_HANDLE *sch) {
+    storage_engine_store_flush(sch);
+}
+
+NOINLINE void unittest_storage_engine_query_init(
+    STORAGE_ENGINE_BACKEND seb,
+    STORAGE_METRIC_HANDLE *smh,
+    struct storage_engine_query_handle *seqh,
+    time_t start_time_s,
+    time_t end_time_s,
+    STORAGE_PRIORITY priority) {
+    storage_engine_query_init(seb, smh, seqh, start_time_s, end_time_s, priority);
+}
+
+NOINLINE STORAGE_POINT unittest_storage_engine_query_next_metric(
+    struct storage_engine_query_handle *seqh) {
+    return storage_engine_query_next_metric(seqh);
+}
+
+NOINLINE int unittest_storage_engine_query_is_finished(
+    struct storage_engine_query_handle *seqh) {
+    return storage_engine_query_is_finished(seqh);
+}
+
+NOINLINE time_t unittest_storage_engine_align_to_optimal_before(
+    struct storage_engine_query_handle *seqh) {
+    return storage_engine_align_to_optimal_before(seqh);
+}
+
+NOINLINE void unittest_storage_engine_query_finalize(
+    struct storage_engine_query_handle *seqh) {
+    storage_engine_query_finalize(seqh);
+}

--- a/src/daemon/unit_test_bridge.h
+++ b/src/daemon/unit_test_bridge.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_UNIT_TEST_BRIDGE_H
+#define NETDATA_UNIT_TEST_BRIDGE_H
+
+#include "common.h"
+
+void unittest_storage_engine_store_metric(
+    STORAGE_COLLECT_HANDLE *sch,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags);
+
+void unittest_storage_engine_store_change_collection_frequency(STORAGE_COLLECT_HANDLE *sch, int update_every);
+void unittest_storage_engine_store_flush(STORAGE_COLLECT_HANDLE *sch);
+
+void unittest_storage_engine_query_init(
+    STORAGE_ENGINE_BACKEND seb,
+    STORAGE_METRIC_HANDLE *smh,
+    struct storage_engine_query_handle *seqh,
+    time_t start_time_s,
+    time_t end_time_s,
+    STORAGE_PRIORITY priority);
+
+STORAGE_POINT unittest_storage_engine_query_next_metric(struct storage_engine_query_handle *seqh);
+int unittest_storage_engine_query_is_finished(struct storage_engine_query_handle *seqh);
+time_t unittest_storage_engine_align_to_optimal_before(struct storage_engine_query_handle *seqh);
+void unittest_storage_engine_query_finalize(struct storage_engine_query_handle *seqh);
+
+#endif // NETDATA_UNIT_TEST_BRIDGE_H

--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -2,6 +2,7 @@
 
 #include "database/rrd.h"
 #include "database/rrddim-collection.h"
+#include "page_test.h"
 
 #ifdef ENABLE_DBENGINE
 
@@ -476,6 +477,7 @@ int test_dbengine(void) {
     if(!host)
         fatal("Failed to initialize host");
 
+    errors += (size_t)pgd_storage_point_unittest();
     errors += test_dbengine_burst_retention(host);
 
     RRDSET *st[CHARTS] = { 0 };

--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -471,17 +471,126 @@ typedef struct dbengine_expected_point {
     bool is_gap;
 } DBENGINE_EXPECTED_POINT;
 
-static RRDDIM *dbengine_test_create_metric(RRDHOST *host, const char *id, int update_every) {
+static RRDDIM *dbengine_test_create_metric(RRDHOST *host, const char *id_prefix, int update_every) {
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "%s-%d", id_prefix, getpid());
+
     RRDSET *st = rrdset_create(
         host, "netdata", id, id, "netdata", NULL, "Unit Testing", "a value", "unittest",
         NULL, 1, update_every, RRDSET_TYPE_LINE);
-    return rrddim_add(st, "dim", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    RRDDIM *rd = rrddim_add(st, "dim", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: %s metric initialization failed\n", id);
+        return NULL;
+    }
+
+    return rd;
 }
 
 static void dbengine_test_store_point(RRDDIM *rd, time_t end_time_s, NETDATA_DOUBLE value) {
     unittest_storage_engine_store_metric(
         rd->tiers[0].sch, (usec_t)end_time_s * USEC_PER_SEC,
         value, value, value, 1, 0, SN_DEFAULT_FLAGS);
+}
+
+static Word_t dbengine_test_metric_id(RRDDIM *rd) {
+    return mrg_metric_id(main_mrg, (METRIC *)rd->tiers[0].smh);
+}
+
+static bool dbengine_test_evict_page(RRDHOST *host, Word_t metric_id, time_t start_time_s, const char *id) {
+    PGC_PAGE *page = pgc_page_get_and_acquire(
+        main_cache, (Word_t)host->db[0].si, metric_id, start_time_s, PGC_SEARCH_EXACT);
+    if(!page) {
+        fprintf(stderr, " >>> DBENGINE: %s page is not cached\n", id);
+        return false;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, page)) {
+        fprintf(stderr, " >>> DBENGINE: %s page could not be evicted\n", id);
+        return false;
+    }
+
+    return true;
+}
+
+static bool dbengine_test_add_empty_page(
+    RRDHOST *host,
+    Word_t metric_id,
+    time_t start_time_s,
+    time_t end_time_s,
+    uint32_t update_every_s,
+    const char *id) {
+    PGC_ENTRY entry = {
+        .section = (Word_t)host->db[0].si,
+        .metric_id = metric_id,
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .size = 0,
+        .data = PGD_EMPTY,
+        .update_every_s = update_every_s,
+        .hot = false,
+    };
+    bool added = false;
+    PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, entry, &added);
+    if(!page || !added) {
+        fprintf(stderr, " >>> DBENGINE: failed to insert %s page\n", id);
+        if(page)
+            pgc_page_release(main_cache, page);
+        return false;
+    }
+
+    pgc_page_release(main_cache, page);
+    return true;
+}
+
+typedef struct dbengine_test_cache_stats {
+    size_t open_lookups;
+    size_t journal_lookups;
+    size_t planned_gaps;
+} DBENGINE_TEST_CACHE_STATS;
+
+static DBENGINE_TEST_CACHE_STATS dbengine_test_cache_stats(void) {
+    struct rrdeng_cache_efficiency_stats stats = rrdeng_get_cache_efficiency_stats();
+    return (DBENGINE_TEST_CACHE_STATS){
+        .open_lookups = stats.prep_time_in_open_cache_lookup.count,
+        .journal_lookups = stats.prep_time_in_journal_v2_lookup.count,
+        .planned_gaps = stats.queries_planned_with_gaps,
+    };
+}
+
+#define DBENGINE_TEST_STAT_UNCHECKED SIZE_MAX
+
+static size_t dbengine_test_expect_stat_delta(
+    const char *id,
+    const char *stat,
+    size_t before,
+    size_t after,
+    size_t expected) {
+    if(expected == DBENGINE_TEST_STAT_UNCHECKED || after == before + expected)
+        return 0;
+
+    fprintf(stderr,
+            " >>> DBENGINE: %s used %zu %s, expected %zu\n",
+            id, after - before, stat, expected);
+    return 1;
+}
+
+static size_t dbengine_test_expect_cache_deltas(
+    const char *id,
+    DBENGINE_TEST_CACHE_STATS before,
+    DBENGINE_TEST_CACHE_STATS after,
+    size_t expected_open,
+    size_t expected_journal,
+    size_t expected_planned_gaps) {
+    size_t errors = 0;
+    errors += dbengine_test_expect_stat_delta(
+        id, "open-cache lookups", before.open_lookups, after.open_lookups, expected_open);
+    errors += dbengine_test_expect_stat_delta(
+        id, "journal lookups", before.journal_lookups, after.journal_lookups, expected_journal);
+    errors += dbengine_test_expect_stat_delta(
+        id, "planner gaps", before.planned_gaps, after.planned_gaps, expected_planned_gaps);
+    return errors;
 }
 
 static size_t dbengine_test_query_points(
@@ -573,16 +682,30 @@ static size_t dbengine_test_query_points(
     return errors;
 }
 
+static size_t dbengine_test_query_points_with_cache_deltas(
+    RRDDIM *rd,
+    time_t start_time_s,
+    time_t end_time_s,
+    const DBENGINE_EXPECTED_POINT *expected,
+    size_t expected_points,
+    const char *id,
+    size_t expected_open,
+    size_t expected_journal,
+    size_t expected_planned_gaps) {
+    DBENGINE_TEST_CACHE_STATS before = dbengine_test_cache_stats();
+    size_t errors = dbengine_test_query_points(
+        rd, start_time_s, end_time_s, expected, expected_points, id);
+    DBENGINE_TEST_CACHE_STATS after = dbengine_test_cache_stats();
+    errors += dbengine_test_expect_cache_deltas(
+        id, before, after, expected_open, expected_journal, expected_planned_gaps);
+    return errors;
+}
+
 static size_t test_dbengine_cadence_page_transitions(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 1000000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-cadence-page-transitions-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: cadence page-transition metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-cadence-page-transitions", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -623,19 +746,9 @@ static size_t test_dbengine_cadence_page_transitions(RRDHOST *host) {
         { t + 290, t + 300, 14 },
     };
 
-    size_t errors = 0;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 200, narrow, _countof(narrow), "cadence-page-narrow");
-    size_t journal_after_narrow =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    if(journal_after_narrow != journal_before) {
-        fprintf(stderr,
-                " >>> DBENGINE: continuous cadence query used %zu journal lookups, expected 0\n",
-                journal_after_narrow - journal_before);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 200, narrow, _countof(narrow),
+        "cadence-page-narrow", DBENGINE_TEST_STAT_UNCHECKED, 0, DBENGINE_TEST_STAT_UNCHECKED);
 
     struct storage_engine_query_handle seqh = { 0 };
     unittest_storage_engine_query_init(
@@ -652,60 +765,21 @@ static size_t test_dbengine_cadence_page_transitions(RRDHOST *host) {
     }
     unittest_storage_engine_query_finalize(&seqh);
 
-    struct rrdeng_cache_efficiency_stats stats_before_wide = rrdeng_get_cache_efficiency_stats();
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 300, wide, _countof(wide), "cadence-page-wide");
-    struct rrdeng_cache_efficiency_stats stats_after_wide = rrdeng_get_cache_efficiency_stats();
-
-    if(stats_after_wide.prep_time_in_journal_v2_lookup.count !=
-       stats_before_wide.prep_time_in_journal_v2_lookup.count + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: cadence-page-wide query used %zu journal lookups, expected 1\n",
-                stats_after_wide.prep_time_in_journal_v2_lookup.count -
-                    stats_before_wide.prep_time_in_journal_v2_lookup.count);
-        errors++;
-    }
-
-    if(stats_after_wide.queries_planned_with_gaps != stats_before_wide.queries_planned_with_gaps + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: cadence-page-wide query reported %zu planner gaps, expected 1\n",
-                stats_after_wide.queries_planned_with_gaps - stats_before_wide.queries_planned_with_gaps);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 300, wide, _countof(wide), "cadence-page-wide-repeat");
-    struct rrdeng_cache_efficiency_stats stats_after_wide_repeat = rrdeng_get_cache_efficiency_stats();
-
-    if(stats_after_wide_repeat.prep_time_in_journal_v2_lookup.count !=
-       stats_after_wide.prep_time_in_journal_v2_lookup.count) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated cadence-page-wide query used %zu journal lookups, expected 0\n",
-                stats_after_wide_repeat.prep_time_in_journal_v2_lookup.count -
-                    stats_after_wide.prep_time_in_journal_v2_lookup.count);
-        errors++;
-    }
-
-    if(stats_after_wide_repeat.queries_planned_with_gaps != stats_after_wide.queries_planned_with_gaps) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated cadence-page-wide query reported %zu planner gaps, expected 0\n",
-                stats_after_wide_repeat.queries_planned_with_gaps - stats_after_wide.queries_planned_with_gaps);
-        errors++;
-    }
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 300, wide, _countof(wide),
+        "cadence-page-wide", DBENGINE_TEST_STAT_UNCHECKED, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 300, wide, _countof(wide),
+        "cadence-page-wide-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_negative_page_reuse_across_cadence(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2000000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-negative-page-cadence-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 1);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: negative-page cadence metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-negative-page-cadence", 1);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 101, 2);
@@ -729,94 +803,29 @@ static size_t test_dbengine_negative_page_reuse_across_cadence(RRDHOST *host) {
         { t + 191, t + 201, 10 },
     };
 
-    size_t errors = 0;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 201, expected, _countof(expected), "negative-page-first");
-    size_t journal_after_first =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_first =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_first != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first negative-page query used %zu journal lookups, expected 1\n",
-                journal_after_first - journal_before);
-        errors++;
-    }
-
-    if(planned_gaps_after_first != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first negative-page query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after_first - planned_gaps_before);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 201, expected, _countof(expected),
+        "negative-page-first", DBENGINE_TEST_STAT_UNCHECKED, 1, 1);
 
     const DBENGINE_EXPECTED_POINT inside_gap[] = {
         { t + 121, t + 131, 3 },
         { t + 131, t + 141, 4 },
     };
-    errors += dbengine_test_query_points(
-        rd, t + 125, t + 141,
-        inside_gap, _countof(inside_gap), "negative-page-inside-gap");
-    size_t journal_after_inside_gap =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_inside_gap =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_inside_gap != journal_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: query inside cached negative range used %zu journal lookups, expected 0\n",
-                journal_after_inside_gap - journal_after_first);
-        errors++;
-    }
-
-
-    if(planned_gaps_after_inside_gap != planned_gaps_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: query inside cached negative range reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_inside_gap - planned_gaps_after_first);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 201, expected, _countof(expected), "negative-page-repeat");
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_repeat != journal_after_inside_gap) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated negative-page query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after_inside_gap);
-        errors++;
-    }
-
-
-    if(planned_gaps_after_repeat != planned_gaps_after_inside_gap) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated negative-page query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after_inside_gap);
-        errors++;
-    }
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 125, t + 141, inside_gap, _countof(inside_gap),
+        "negative-page-inside-gap", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 201, expected, _countof(expected),
+        "negative-page-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_continuous_slowdown(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2500000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-continuous-slowdown-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 1);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: continuous-slowdown metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-continuous-slowdown", 1);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 101, 2);
@@ -834,60 +843,21 @@ static size_t test_dbengine_continuous_slowdown(RRDHOST *host) {
         { t + 111, t + 121, 4 },
     };
 
-    struct rrdeng_cache_efficiency_stats stats_before = rrdeng_get_cache_efficiency_stats();
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 121, expected, _countof(expected), "continuous-slowdown");
-    struct rrdeng_cache_efficiency_stats stats_after_first = rrdeng_get_cache_efficiency_stats();
-
-    if(stats_after_first.prep_time_in_journal_v2_lookup.count !=
-       stats_before.prep_time_in_journal_v2_lookup.count + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first continuous slowdown query used %zu journal lookups, expected 1\n",
-                stats_after_first.prep_time_in_journal_v2_lookup.count -
-                    stats_before.prep_time_in_journal_v2_lookup.count);
-        errors++;
-    }
-
-    if(stats_after_first.queries_planned_with_gaps != stats_before.queries_planned_with_gaps + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first continuous slowdown query reported %zu planner gaps, expected 1\n",
-                stats_after_first.queries_planned_with_gaps - stats_before.queries_planned_with_gaps);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 121, expected, _countof(expected), "continuous-slowdown-repeat");
-    struct rrdeng_cache_efficiency_stats stats_after_repeat = rrdeng_get_cache_efficiency_stats();
-
-    if(stats_after_repeat.prep_time_in_journal_v2_lookup.count !=
-       stats_after_first.prep_time_in_journal_v2_lookup.count) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated continuous slowdown query used %zu journal lookups, expected 0\n",
-                stats_after_repeat.prep_time_in_journal_v2_lookup.count -
-                    stats_after_first.prep_time_in_journal_v2_lookup.count);
-        errors++;
-    }
-
-    if(stats_after_repeat.queries_planned_with_gaps != stats_after_first.queries_planned_with_gaps) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated continuous slowdown query reported %zu planner gaps, expected 0\n",
-                stats_after_repeat.queries_planned_with_gaps - stats_after_first.queries_planned_with_gaps);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 121, expected, _countof(expected),
+        "continuous-slowdown", DBENGINE_TEST_STAT_UNCHECKED, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 121, expected, _countof(expected),
+        "continuous-slowdown-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_candidate_coverage_finds_real_gap(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2600000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-candidate-real-gap-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: candidate real-gap metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-candidate-real-gap", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -907,64 +877,21 @@ static size_t test_dbengine_candidate_coverage_finds_real_gap(RRDHOST *host) {
         { t + 210, t + 220, 5 },
     };
 
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 220, expected, _countof(expected), "candidate-real-gap");
-    size_t journal_after_first =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_first =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_first != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first candidate real-gap query used %zu journal lookups, expected 1\n",
-                journal_after_first - journal_before);
-        errors++;
-    }
-
-    if(planned_gaps_after_first != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first candidate real-gap query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after_first - planned_gaps_before);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 220, expected, _countof(expected), "candidate-real-gap-repeat");
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_repeat != journal_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated candidate real-gap query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after_first);
-        errors++;
-    }
-    if(planned_gaps_after_repeat != planned_gaps_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated candidate real-gap query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after_first);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 220, expected, _countof(expected),
+        "candidate-real-gap", DBENGINE_TEST_STAT_UNCHECKED, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 220, expected, _countof(expected),
+        "candidate-real-gap-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_candidate_tail_requires_authoritative_lookup(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2606250;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-candidate-tail-gap-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 100);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: candidate tail-gap metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-candidate-tail-gap", 100);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 200, 2);
@@ -982,23 +909,9 @@ static size_t test_dbengine_candidate_tail_requires_authoritative_lookup(RRDHOST
 
     pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    Word_t metric_id = mrg_metric_id(main_mrg, metric);
-    PGC_PAGE *tail = pgc_page_get_and_acquire(
-        main_cache,
-        (Word_t)host->db[0].si,
-        metric_id,
-        t + 210,
-        PGC_SEARCH_EXACT);
-    if(!tail) {
-        fprintf(stderr, " >>> DBENGINE: candidate tail page is not cached\n");
+    Word_t metric_id = dbengine_test_metric_id(rd);
+    if(!dbengine_test_evict_page(host, metric_id, t + 210, "candidate tail"))
         return 1;
-    }
-
-    if(!pgc_page_to_clean_evict_or_release(main_cache, tail)) {
-        fprintf(stderr, " >>> DBENGINE: candidate tail page could not be evicted\n");
-        return 1;
-    }
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t,       t + 100, 1 },
@@ -1008,78 +921,21 @@ static size_t test_dbengine_candidate_tail_requires_authoritative_lookup(RRDHOST
         { t + 240, t + 250, NAN, true },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 250,
-        expected, _countof(expected), "candidate-tail-gap");
-    size_t open_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(open_after != open_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: candidate tail-gap query used %zu open-cache lookups, expected 1\n",
-                open_after - open_before);
-        errors++;
-    }
-
-    if(planned_gaps_after != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: candidate tail-gap query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after - planned_gaps_before);
-        errors++;
-    }
-
-    if(journal_after != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: candidate tail-gap query used %zu journal lookups, expected 1\n",
-                journal_after - journal_before);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 250,
-        expected, _countof(expected), "candidate-tail-gap-repeat");
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_repeat != journal_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated candidate tail-gap query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after);
-        errors++;
-    }
-
-    if(planned_gaps_after_repeat != planned_gaps_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated candidate tail-gap query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 250, expected, _countof(expected),
+        "candidate-tail-gap", 1, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 250, expected, _countof(expected),
+        "candidate-tail-gap-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_candidate_terminal_equality_is_gap(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2607812;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-candidate-terminal-equality-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: candidate terminal-equality metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-candidate-terminal-equality", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -1106,62 +962,21 @@ static size_t test_dbengine_candidate_terminal_equality_is_gap(RRDHOST *host) {
         { t + 190, t + 200, NAN, true },
     };
 
-    struct rrdeng_cache_efficiency_stats stats_before = rrdeng_get_cache_efficiency_stats();
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 200,
-        expected, _countof(expected), "candidate-terminal-equality");
-    struct rrdeng_cache_efficiency_stats stats_after_first = rrdeng_get_cache_efficiency_stats();
-
-    if(stats_after_first.prep_time_in_journal_v2_lookup.count !=
-       stats_before.prep_time_in_journal_v2_lookup.count + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: candidate terminal-equality query used %zu journal lookups, expected 1\n",
-                stats_after_first.prep_time_in_journal_v2_lookup.count -
-                    stats_before.prep_time_in_journal_v2_lookup.count);
-        errors++;
-    }
-
-    if(stats_after_first.queries_planned_with_gaps != stats_before.queries_planned_with_gaps + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: candidate terminal-equality query reported %zu planner gaps, expected 1\n",
-                stats_after_first.queries_planned_with_gaps - stats_before.queries_planned_with_gaps);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 200,
-        expected, _countof(expected), "candidate-terminal-equality-repeat");
-    struct rrdeng_cache_efficiency_stats stats_after_repeat = rrdeng_get_cache_efficiency_stats();
-
-    if(stats_after_repeat.prep_time_in_journal_v2_lookup.count !=
-       stats_after_first.prep_time_in_journal_v2_lookup.count) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated candidate terminal-equality query used %zu journal lookups, expected 0\n",
-                stats_after_repeat.prep_time_in_journal_v2_lookup.count -
-                    stats_after_first.prep_time_in_journal_v2_lookup.count);
-        errors++;
-    }
-
-    if(stats_after_repeat.queries_planned_with_gaps != stats_after_first.queries_planned_with_gaps) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated candidate terminal-equality query reported %zu planner gaps, expected 0\n",
-                stats_after_repeat.queries_planned_with_gaps - stats_after_first.queries_planned_with_gaps);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 200, expected, _countof(expected),
+        "candidate-terminal-equality", DBENGINE_TEST_STAT_UNCHECKED, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 200, expected, _countof(expected),
+        "candidate-terminal-equality-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_tail_before_next_sample_is_not_gap(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2609375;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-tail-before-next-sample-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: tail-before-next-sample metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-tail-before-next-sample", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -1176,41 +991,18 @@ static size_t test_dbengine_tail_before_next_sample_is_not_gap(RRDHOST *host) {
         { t + 100, t + 160, 2 },
     };
 
-    struct rrdeng_cache_efficiency_stats stats_before = rrdeng_get_cache_efficiency_stats();
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 200,
-        expected, _countof(expected), "tail-before-next-sample");
-    struct rrdeng_cache_efficiency_stats stats_after = rrdeng_get_cache_efficiency_stats();
-
-    if(stats_after.prep_time_in_journal_v2_lookup.count !=
-       stats_before.prep_time_in_journal_v2_lookup.count + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: tail-before-next-sample query used %zu journal lookups, expected 1\n",
-                stats_after.prep_time_in_journal_v2_lookup.count -
-                    stats_before.prep_time_in_journal_v2_lookup.count);
-        errors++;
-    }
-
-    if(stats_after.queries_planned_with_gaps != stats_before.queries_planned_with_gaps) {
-        fprintf(stderr,
-                " >>> DBENGINE: tail-before-next-sample query reported %zu planner gaps, expected 0\n",
-                stats_after.queries_planned_with_gaps - stats_before.queries_planned_with_gaps);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 200, expected, _countof(expected),
+        "tail-before-next-sample", DBENGINE_TEST_STAT_UNCHECKED, 1, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_legacy_cursor_includes_equal_page_end(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2612500;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-legacy-equal-end-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: legacy equal-end metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-legacy-equal-end", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -1232,44 +1024,18 @@ static size_t test_dbengine_legacy_cursor_includes_equal_page_end(RRDHOST *host)
         { t + 320, t + 420, 5 },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 420, expected, _countof(expected), "legacy-equal-end");
-    size_t open_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-
-    if(open_after != open_before) {
-        fprintf(stderr,
-                " >>> DBENGINE: legacy equal-end query used %zu open-cache lookups, expected 0\n",
-                open_after - open_before);
-        errors++;
-    }
-
-    if(journal_after != journal_before) {
-        fprintf(stderr,
-                " >>> DBENGINE: legacy equal-end query used %zu journal lookups, expected 0\n",
-                journal_after - journal_before);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 420, expected, _countof(expected),
+        "legacy-equal-end", 0, 0, DBENGINE_TEST_STAT_UNCHECKED);
 
     return errors;
 }
 
 static size_t test_dbengine_legacy_completion_equality_requires_authority(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2618750;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-legacy-completion-equality-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: legacy completion-equality metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-legacy-completion-equality", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -1290,22 +1056,9 @@ static size_t test_dbengine_legacy_completion_equality_requires_authority(RRDHOS
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
     pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    PGC_PAGE *middle = pgc_page_get_and_acquire(
-        main_cache,
-        (Word_t)host->db[0].si,
-        mrg_metric_id(main_mrg, metric),
-        t + 180,
-        PGC_SEARCH_EXACT);
-    if(!middle) {
-        fprintf(stderr, " >>> DBENGINE: legacy completion-equality middle page is not cached\n");
+    if(!dbengine_test_evict_page(
+           host, dbengine_test_metric_id(rd), t + 180, "legacy completion-equality middle"))
         return 1;
-    }
-
-    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
-        fprintf(stderr, " >>> DBENGINE: legacy completion-equality middle page could not be evicted\n");
-        return 1;
-    }
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t + 40,  t + 100, 1 },
@@ -1315,71 +1068,21 @@ static size_t test_dbengine_legacy_completion_equality_requires_authority(RRDHOS
         { t + 180, t + 210, 5 },
     };
 
-    struct rrdeng_cache_efficiency_stats stats_before = rrdeng_get_cache_efficiency_stats();
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 220,
-        expected, _countof(expected), "legacy-completion-equality");
-    struct rrdeng_cache_efficiency_stats stats_after_first = rrdeng_get_cache_efficiency_stats();
-
-    if(stats_after_first.prep_time_in_open_cache_lookup.count !=
-       stats_before.prep_time_in_open_cache_lookup.count + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: legacy completion-equality query used %zu open-cache lookups, expected 1\n",
-                stats_after_first.prep_time_in_open_cache_lookup.count -
-                    stats_before.prep_time_in_open_cache_lookup.count);
-        errors++;
-    }
-
-    if(stats_after_first.prep_time_in_journal_v2_lookup.count !=
-       stats_before.prep_time_in_journal_v2_lookup.count + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: legacy completion-equality query used %zu journal lookups, expected 1\n",
-                stats_after_first.prep_time_in_journal_v2_lookup.count -
-                    stats_before.prep_time_in_journal_v2_lookup.count);
-        errors++;
-    }
-
-    if(stats_after_first.queries_planned_with_gaps != stats_before.queries_planned_with_gaps + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: legacy completion-equality query reported %zu planner gaps, expected 1\n",
-                stats_after_first.queries_planned_with_gaps - stats_before.queries_planned_with_gaps);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 220,
-        expected, _countof(expected), "legacy-completion-equality-repeat");
-    struct rrdeng_cache_efficiency_stats stats_after_repeat = rrdeng_get_cache_efficiency_stats();
-
-    if(stats_after_repeat.prep_time_in_journal_v2_lookup.count !=
-       stats_after_first.prep_time_in_journal_v2_lookup.count) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated legacy completion-equality query used %zu journal lookups, expected 0\n",
-                stats_after_repeat.prep_time_in_journal_v2_lookup.count -
-                    stats_after_first.prep_time_in_journal_v2_lookup.count);
-        errors++;
-    }
-
-    if(stats_after_repeat.queries_planned_with_gaps != stats_after_first.queries_planned_with_gaps) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated legacy completion-equality query reported %zu planner gaps, expected 0\n",
-                stats_after_repeat.queries_planned_with_gaps - stats_after_first.queries_planned_with_gaps);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 220, expected, _countof(expected),
+        "legacy-completion-equality", 1, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 220, expected, _countof(expected),
+        "legacy-completion-equality-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_cadence_overlap_does_not_hide_intermediate_page(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2625000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-cadence-overlap-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: cadence-overlap metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-cadence-overlap", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -1396,22 +1099,8 @@ static size_t test_dbengine_cadence_overlap_does_not_hide_intermediate_page(RRDH
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
     pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    PGC_PAGE *middle = pgc_page_get_and_acquire(
-        main_cache,
-        (Word_t)host->db[0].si,
-        mrg_metric_id(main_mrg, metric),
-        t + 170,
-        PGC_SEARCH_EXACT);
-    if(!middle) {
-        fprintf(stderr, " >>> DBENGINE: cadence-overlap middle page is not cached\n");
+    if(!dbengine_test_evict_page(host, dbengine_test_metric_id(rd), t + 170, "cadence-overlap middle"))
         return 1;
-    }
-
-    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
-        fprintf(stderr, " >>> DBENGINE: cadence-overlap middle page could not be evicted\n");
-        return 1;
-    }
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t + 40,  t + 100, 1 },
@@ -1424,78 +1113,21 @@ static size_t test_dbengine_cadence_overlap_does_not_hide_intermediate_page(RRDH
         { t + 260, t + 360, 8 },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 360,
-        expected, _countof(expected), "cadence-overlap-hidden-page");
-    size_t open_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(open_after != open_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: cadence-overlap query used %zu open-cache lookups, expected 1\n",
-                open_after - open_before);
-        errors++;
-    }
-
-    if(planned_gaps_after != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: cadence-overlap query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after - planned_gaps_before);
-        errors++;
-    }
-
-    if(journal_after != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: cadence-overlap query used %zu journal lookups, expected 1\n",
-                journal_after - journal_before);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 360,
-        expected, _countof(expected), "cadence-overlap-hidden-page-repeat");
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_repeat != journal_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated cadence-overlap query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after);
-        errors++;
-    }
-
-    if(planned_gaps_after_repeat != planned_gaps_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated cadence-overlap query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 360, expected, _countof(expected),
+        "cadence-overlap-hidden-page", 1, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 360, expected, _countof(expected),
+        "cadence-overlap-hidden-page-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_singleton_bridge_does_not_hide_intermediate_page(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2650000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-singleton-bridge-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: singleton-bridge metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-singleton-bridge", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -1516,22 +1148,9 @@ static size_t test_dbengine_singleton_bridge_does_not_hide_intermediate_page(RRD
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
     pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    PGC_PAGE *middle = pgc_page_get_and_acquire(
-        main_cache,
-        (Word_t)host->db[0].si,
-        mrg_metric_id(main_mrg, metric),
-        t + 180,
-        PGC_SEARCH_EXACT);
-    if(!middle) {
-        fprintf(stderr, " >>> DBENGINE: singleton-bridge intermediate page is not cached\n");
+    if(!dbengine_test_evict_page(
+           host, dbengine_test_metric_id(rd), t + 180, "singleton-bridge intermediate"))
         return 1;
-    }
-
-    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
-        fprintf(stderr, " >>> DBENGINE: singleton-bridge intermediate page could not be evicted\n");
-        return 1;
-    }
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t + 40,  t + 100, 1 },
@@ -1544,78 +1163,21 @@ static size_t test_dbengine_singleton_bridge_does_not_hide_intermediate_page(RRD
         { t + 250, t + 350, 8 },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 350,
-        expected, _countof(expected), "singleton-bridge-hidden-page");
-    size_t open_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(open_after != open_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: singleton-bridge query used %zu open-cache lookups, expected 1\n",
-                open_after - open_before);
-        errors++;
-    }
-
-    if(planned_gaps_after != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: singleton-bridge query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after - planned_gaps_before);
-        errors++;
-    }
-
-    if(journal_after != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: singleton-bridge query used %zu journal lookups, expected 1\n",
-                journal_after - journal_before);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 350,
-        expected, _countof(expected), "singleton-bridge-hidden-page-repeat");
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_repeat != journal_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated singleton-bridge query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after);
-        errors++;
-    }
-
-    if(planned_gaps_after_repeat != planned_gaps_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated singleton-bridge query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 350, expected, _countof(expected),
+        "singleton-bridge-hidden-page", 1, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 350, expected, _countof(expected),
+        "singleton-bridge-hidden-page-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_empty_suffix_does_not_hide_intermediate_page(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2675000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-empty-suffix-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: EMPTY-suffix metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-empty-suffix", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -1632,43 +1194,12 @@ static size_t test_dbengine_empty_suffix_does_not_hide_intermediate_page(RRDHOST
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
     pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    Word_t metric_id = mrg_metric_id(main_mrg, metric);
-    PGC_PAGE *middle = pgc_page_get_and_acquire(
-        main_cache,
-        (Word_t)host->db[0].si,
-        metric_id,
-        t + 210,
-        PGC_SEARCH_EXACT);
-    if(!middle) {
-        fprintf(stderr, " >>> DBENGINE: EMPTY-suffix intermediate page is not cached\n");
+    Word_t metric_id = dbengine_test_metric_id(rd);
+    if(!dbengine_test_evict_page(host, metric_id, t + 210, "EMPTY-suffix intermediate"))
         return 1;
-    }
 
-    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
-        fprintf(stderr, " >>> DBENGINE: EMPTY-suffix intermediate page could not be evicted\n");
+    if(!dbengine_test_add_empty_page(host, metric_id, t + 161, t + 200, 0, "EMPTY-suffix"))
         return 1;
-    }
-
-    PGC_ENTRY empty = {
-        .section = (Word_t)host->db[0].si,
-        .metric_id = metric_id,
-        .start_time_s = t + 161,
-        .end_time_s = t + 200,
-        .size = 0,
-        .data = PGD_EMPTY,
-        .update_every_s = 0,
-        .hot = false,
-    };
-    bool added = false;
-    PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
-    if(!page || !added) {
-        fprintf(stderr, " >>> DBENGINE: failed to insert EMPTY-suffix page\n");
-        if(page)
-            pgc_page_release(main_cache, page);
-        return 1;
-    }
-    pgc_page_release(main_cache, page);
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t + 40,  t + 100, 1 },
@@ -1681,78 +1212,21 @@ static size_t test_dbengine_empty_suffix_does_not_hide_intermediate_page(RRDHOST
         { t + 260, t + 360, 8 },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 360,
-        expected, _countof(expected), "empty-suffix-hidden-page");
-    size_t open_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(open_after != open_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: EMPTY-suffix query used %zu open-cache lookups, expected 1\n",
-                open_after - open_before);
-        errors++;
-    }
-
-    if(planned_gaps_after != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: EMPTY-suffix query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after - planned_gaps_before);
-        errors++;
-    }
-
-    if(journal_after != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: EMPTY-suffix query used %zu journal lookups, expected 1\n",
-                journal_after - journal_before);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 360,
-        expected, _countof(expected), "empty-suffix-hidden-page-repeat");
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_repeat != journal_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated EMPTY-suffix query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after);
-        errors++;
-    }
-
-    if(planned_gaps_after_repeat != planned_gaps_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated EMPTY-suffix query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 360, expected, _countof(expected),
+        "empty-suffix-hidden-page", 1, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 360, expected, _countof(expected),
+        "empty-suffix-hidden-page-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_empty_cadence_advances_legacy_cursor(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2700000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-empty-cadence-shadow-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: EMPTY-cadence shadow metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-empty-cadence-shadow", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -1769,26 +1243,9 @@ static size_t test_dbengine_empty_cadence_advances_legacy_cursor(RRDHOST *host) 
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
     pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    PGC_ENTRY empty = {
-        .section = (Word_t)host->db[0].si,
-        .metric_id = mrg_metric_id(main_mrg, metric),
-        .start_time_s = t + 161,
-        .end_time_s = t + 240,
-        .size = 0,
-        .data = PGD_EMPTY,
-        .update_every_s = 10,
-        .hot = false,
-    };
-    bool added = false;
-    PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
-    if(!page || !added) {
-        fprintf(stderr, " >>> DBENGINE: failed to insert EMPTY-cadence shadow page\n");
-        if(page)
-            pgc_page_release(main_cache, page);
+    if(!dbengine_test_add_empty_page(
+           host, dbengine_test_metric_id(rd), t + 161, t + 240, 10, "EMPTY-cadence shadow"))
         return 1;
-    }
-    pgc_page_release(main_cache, page);
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t + 40,  t + 100, 1 },
@@ -1800,44 +1257,18 @@ static size_t test_dbengine_empty_cadence_advances_legacy_cursor(RRDHOST *host) 
         { t + 310, t + 330, 7 },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 330, expected, _countof(expected), "empty-cadence-shadow");
-    size_t open_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-
-    if(open_after != open_before) {
-        fprintf(stderr,
-                " >>> DBENGINE: EMPTY-cadence shadow query used %zu open-cache lookups, expected 0\n",
-                open_after - open_before);
-        errors++;
-    }
-
-    if(journal_after != journal_before) {
-        fprintf(stderr,
-                " >>> DBENGINE: EMPTY-cadence shadow query used %zu journal lookups, expected 0\n",
-                journal_after - journal_before);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 330, expected, _countof(expected),
+        "empty-cadence-shadow", 0, 0, DBENGINE_TEST_STAT_UNCHECKED);
 
     return errors;
 }
 
 static size_t test_dbengine_single_missing_sample_reuse(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 2750000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-single-missing-sample-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 1);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: single-missing-sample metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-single-missing-sample", 1);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 101, 2);
@@ -1852,68 +1283,21 @@ static size_t test_dbengine_single_missing_sample_reuse(RRDHOST *host) {
         { t + 102, t + 103, 3 },
     };
 
-    size_t errors = 0;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 103, expected, _countof(expected), "single-missing-sample-first");
-    size_t journal_after_first =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_first =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_first != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first single-missing-sample query used %zu journal lookups, expected 1\n",
-                journal_after_first - journal_before);
-        errors++;
-    }
-
-
-    if(planned_gaps_after_first != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first single-missing-sample query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after_first - planned_gaps_before);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 103, expected, _countof(expected), "single-missing-sample-repeat");
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_repeat != journal_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated single-missing-sample query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after_first);
-        errors++;
-    }
-
-
-    if(planned_gaps_after_repeat != planned_gaps_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated single-missing-sample query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after_first);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 103, expected, _countof(expected),
+        "single-missing-sample-first", DBENGINE_TEST_STAT_UNCHECKED, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 103, expected, _countof(expected),
+        "single-missing-sample-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_existing_negative_page_continuity(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 3000000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-existing-negative-page-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: existing negative-page metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-existing-negative-page", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -1923,26 +1307,9 @@ static size_t test_dbengine_existing_negative_page_continuity(RRDHOST *host) {
     dbengine_test_store_point(rd, t + 420, 4);
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    PGC_ENTRY empty = {
-        .section = (Word_t)host->db[0].si,
-        .metric_id = mrg_metric_id(main_mrg, metric),
-        .start_time_s = t + 220,
-        .end_time_s = t + 300,
-        .size = 0,
-        .data = PGD_EMPTY,
-        .update_every_s = 0,
-        .hot = false,
-    };
-    bool added = false;
-    PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
-    if(!page || !added) {
-        fprintf(stderr, " >>> DBENGINE: failed to insert existing negative page\n");
-        if(page)
-            pgc_page_release(main_cache, page);
+    if(!dbengine_test_add_empty_page(
+           host, dbengine_test_metric_id(rd), t + 220, t + 300, 0, "existing negative"))
         return 1;
-    }
-    pgc_page_release(main_cache, page);
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t + 40,  t + 100, 1 },
@@ -1951,65 +1318,21 @@ static size_t test_dbengine_existing_negative_page_continuity(RRDHOST *host) {
         { t + 360, t + 420, 4 },
     };
 
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 420, expected, _countof(expected), "existing-negative-page-first");
-    size_t journal_after_first =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_first =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_first != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first existing negative-page query used %zu journal lookups, expected 1\n",
-                journal_after_first - journal_before);
-        errors++;
-    }
-
-    if(planned_gaps_after_first != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first existing negative-page query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after_first - planned_gaps_before);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 420, expected, _countof(expected), "existing-negative-page-repeat");
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_repeat != journal_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated existing negative-page query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after_first);
-        errors++;
-    }
-
-    if(planned_gaps_after_repeat != planned_gaps_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated existing negative-page query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after_first);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 420, expected, _countof(expected),
+        "existing-negative-page-first", DBENGINE_TEST_STAT_UNCHECKED, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 420, expected, _countof(expected),
+        "existing-negative-page-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_negative_page_does_not_hide_fine_page(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 3125000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-negative-before-fine-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: negative-before-fine metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-negative-before-fine", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -2025,23 +1348,9 @@ static size_t test_dbengine_negative_page_does_not_hide_fine_page(RRDHOST *host)
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
     pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    Word_t metric_id = mrg_metric_id(main_mrg, metric);
-    PGC_PAGE *fine = pgc_page_get_and_acquire(
-        main_cache,
-        (Word_t)host->db[0].si,
-        metric_id,
-        t + 170,
-        PGC_SEARCH_EXACT);
-    if(!fine) {
-        fprintf(stderr, " >>> DBENGINE: negative-before-fine page is not cached\n");
+    Word_t metric_id = dbengine_test_metric_id(rd);
+    if(!dbengine_test_evict_page(host, metric_id, t + 170, "negative-before-fine"))
         return 1;
-    }
-
-    if(!pgc_page_to_clean_evict_or_release(main_cache, fine)) {
-        fprintf(stderr, " >>> DBENGINE: negative-before-fine page could not be evicted\n");
-        return 1;
-    }
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t + 40,  t + 100, 1 },
@@ -2056,104 +1365,25 @@ static size_t test_dbengine_negative_page_does_not_hide_fine_page(RRDHOST *host)
         { t + 250, t + 260, 10 },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 260,
-        expected, _countof(expected), "negative-before-fine-first");
-    size_t open_after_first =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after_first =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_first =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 260, expected, _countof(expected),
+        "negative-before-fine-first", 1, 1, 1);
 
-    if(open_after_first != open_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first negative-before-fine query used %zu open-cache lookups, expected 1\n",
-                open_after_first - open_before);
-        errors++;
-    }
-
-    if(journal_after_first != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first negative-before-fine query used %zu journal lookups, expected 1\n",
-                journal_after_first - journal_before);
-        errors++;
-    }
-
-    if(planned_gaps_after_first != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first negative-before-fine query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after_first - planned_gaps_before);
-        errors++;
-    }
-
-    fine = pgc_page_get_and_acquire(
-        main_cache,
-        (Word_t)host->db[0].si,
-        metric_id,
-        t + 170,
-        PGC_SEARCH_EXACT);
-    if(!fine) {
-        fprintf(stderr, " >>> DBENGINE: recovered negative-before-fine page is not cached\n");
+    if(!dbengine_test_evict_page(host, metric_id, t + 170, "recovered negative-before-fine"))
         return errors + 1;
-    }
 
-    if(!pgc_page_to_clean_evict_or_release(main_cache, fine)) {
-        fprintf(stderr, " >>> DBENGINE: recovered negative-before-fine page could not be evicted\n");
-        return errors + 1;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 260,
-        expected, _countof(expected), "negative-before-fine-repeat");
-    size_t open_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(open_after_repeat != open_after_first + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated negative-before-fine query used %zu open-cache lookups, expected 1\n",
-                open_after_repeat - open_after_first);
-        errors++;
-    }
-
-
-    if(journal_after_repeat != journal_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated negative-before-fine query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after_first);
-        errors++;
-    }
-
-    if(planned_gaps_after_repeat != planned_gaps_after_first) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated negative-before-fine query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after_first);
-        errors++;
-    }
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 260, expected, _countof(expected),
+        "negative-before-fine-repeat", 1, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_cadence_bearing_empty_pages(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 3250000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-cadence-bearing-empty-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: cadence-bearing EMPTY metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-cadence-bearing-empty", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -2169,23 +1399,9 @@ static size_t test_dbengine_cadence_bearing_empty_pages(RRDHOST *host) {
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
     pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    Word_t metric_id = mrg_metric_id(main_mrg, metric);
-    PGC_PAGE *middle = pgc_page_get_and_acquire(
-        main_cache,
-        (Word_t)host->db[0].si,
-        metric_id,
-        t + 210,
-        PGC_SEARCH_EXACT);
-    if(!middle) {
-        fprintf(stderr, " >>> DBENGINE: cadence-bearing EMPTY middle page is not cached\n");
+    Word_t metric_id = dbengine_test_metric_id(rd);
+    if(!dbengine_test_evict_page(host, metric_id, t + 210, "cadence-bearing EMPTY middle"))
         return 1;
-    }
-
-    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
-        fprintf(stderr, " >>> DBENGINE: cadence-bearing EMPTY middle page could not be evicted\n");
-        return 1;
-    }
 
     const struct {
         time_t first;
@@ -2196,25 +1412,10 @@ static size_t test_dbengine_cadence_bearing_empty_pages(RRDHOST *host) {
     };
 
     for(size_t i = 0; i < _countof(empty_ranges); i++) {
-        PGC_ENTRY empty = {
-            .section = (Word_t)host->db[0].si,
-            .metric_id = metric_id,
-            .start_time_s = empty_ranges[i].first,
-            .end_time_s = empty_ranges[i].last,
-            .size = 0,
-            .data = PGD_EMPTY,
-            .update_every_s = 10,
-            .hot = false,
-        };
-        bool added = false;
-        PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
-        if(!page || !added) {
-            fprintf(stderr, " >>> DBENGINE: failed to insert cadence-bearing EMPTY page %zu\n", i);
-            if(page)
-                pgc_page_release(main_cache, page);
+        if(!dbengine_test_add_empty_page(
+               host, metric_id, empty_ranges[i].first, empty_ranges[i].last, 10,
+               "cadence-bearing EMPTY"))
             return 1;
-        }
-        pgc_page_release(main_cache, page);
     }
 
     const DBENGINE_EXPECTED_POINT expected[] = {
@@ -2226,79 +1427,21 @@ static size_t test_dbengine_cadence_bearing_empty_pages(RRDHOST *host) {
         { t + 270, t + 280, 6 },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_before =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 100, t + 280,
-        expected, _countof(expected), "cadence-bearing-empty-pages");
-    size_t open_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(open_after != open_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: cadence-bearing EMPTY query used %zu open-cache lookups, expected 1\n",
-                open_after - open_before);
-        errors++;
-    }
-
-
-    if(journal_after != journal_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: cadence-bearing EMPTY query used %zu journal lookups, expected 1\n",
-                journal_after - journal_before);
-        errors++;
-    }
-
-    if(planned_gaps_after != planned_gaps_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: cadence-bearing EMPTY query reported %zu planner gaps, expected 1\n",
-                planned_gaps_after - planned_gaps_before);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
-        rd, t + 100, t + 280,
-        expected, _countof(expected), "cadence-bearing-empty-pages-repeat");
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(journal_after_repeat != journal_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated cadence-bearing EMPTY query used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after);
-        errors++;
-    }
-
-    if(planned_gaps_after_repeat != planned_gaps_after) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated cadence-bearing EMPTY query reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 280, expected, _countof(expected),
+        "cadence-bearing-empty-pages", 1, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
+        rd, t + 100, t + 280, expected, _countof(expected),
+        "cadence-bearing-empty-pages-repeat", DBENGINE_TEST_STAT_UNCHECKED, 0, 0);
 
     return errors;
 }
 
 static size_t test_dbengine_inclusive_cache_frontier(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 3500000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-inclusive-cache-frontier-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: inclusive cache-frontier metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-inclusive-cache-frontier", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -2310,22 +1453,9 @@ static size_t test_dbengine_inclusive_cache_frontier(RRDHOST *host) {
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
     pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    PGC_PAGE *first = pgc_page_get_and_acquire(
-        main_cache,
-        (Word_t)host->db[0].si,
-        mrg_metric_id(main_mrg, metric),
-        t + 100,
-        PGC_SEARCH_EXACT);
-    if(!first) {
-        fprintf(stderr, " >>> DBENGINE: inclusive cache-frontier first page is not cached\n");
+    if(!dbengine_test_evict_page(
+           host, dbengine_test_metric_id(rd), t + 100, "inclusive cache-frontier first"))
         return 1;
-    }
-
-    if(!pgc_page_to_clean_evict_or_release(main_cache, first)) {
-        fprintf(stderr, " >>> DBENGINE: inclusive cache-frontier first page could not be evicted\n");
-        return 1;
-    }
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t + 100, t + 160, 2 },
@@ -2335,30 +1465,9 @@ static size_t test_dbengine_inclusive_cache_frontier(RRDHOST *host) {
         { t + 190, t + 200, 6 },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t errors = dbengine_test_query_points(
-        rd, t + 160, t + 200, expected, _countof(expected), "inclusive-cache-frontier");
-    size_t open_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-
-    if(open_after != open_before + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: inclusive cache-frontier query used %zu open-cache lookups, expected 1\n",
-                open_after - open_before);
-        errors++;
-    }
-
-    if(journal_after != journal_before) {
-        fprintf(stderr,
-                " >>> DBENGINE: inclusive cache-frontier query used %zu journal lookups, expected 0\n",
-                journal_after - journal_before);
-        errors++;
-    }
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
+        rd, t + 160, t + 200, expected, _countof(expected),
+        "inclusive-cache-frontier", 1, 0, DBENGINE_TEST_STAT_UNCHECKED);
 
     return errors;
 }
@@ -2366,14 +1475,9 @@ static size_t test_dbengine_inclusive_cache_frontier(RRDHOST *host) {
 static size_t test_dbengine_long_collection_cadence(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 4000000;
     const uint32_t update_every = 90000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-long-cadence-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, (int)update_every);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: long-cadence metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-long-cadence", (int)update_every);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + update_every, 1);
     dbengine_test_store_point(rd, t + 2 * update_every, 2);
@@ -2404,14 +1508,9 @@ static size_t test_dbengine_long_collection_cadence(RRDHOST *host) {
 
 static size_t test_dbengine_zero_page_cadence_is_repaired(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 4250000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-zero-page-cadence-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 10);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: zero-page-cadence metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-zero-page-cadence", 10);
+    if(!rd)
         return 1;
-    }
 
     unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 0);
     dbengine_test_store_point(rd, t + 100, 1);
@@ -2468,14 +1567,9 @@ static size_t test_dbengine_zero_page_cadence_is_repaired(RRDHOST *host) {
 
 static size_t test_dbengine_finish_skips_negative_page(RRDHOST *host) {
     const time_t t = START_TIMESTAMP + 4500000;
-    char id[128];
-    snprintfz(id, sizeof(id) - 1, "dbengine-finish-skips-negative-%d", getpid());
-    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
-    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
-       !rd->tiers[0].smh || !rd->tiers[0].sch) {
-        fprintf(stderr, " >>> DBENGINE: finish-skips-negative metric initialization failed\n");
+    RRDDIM *rd = dbengine_test_create_metric(host, "dbengine-finish-skips-negative", 60);
+    if(!rd)
         return 1;
-    }
 
     dbengine_test_store_point(rd, t + 100, 1);
     dbengine_test_store_point(rd, t + 160, 2);
@@ -2485,125 +1579,25 @@ static size_t test_dbengine_finish_skips_negative_page(RRDHOST *host) {
     dbengine_test_store_point(rd, t + 320, 4);
     unittest_storage_engine_store_flush(rd->tiers[0].sch);
 
-    METRIC *metric = (METRIC *)rd->tiers[0].smh;
-    PGC_ENTRY empty = {
-        .section = (Word_t)host->db[0].si,
-        .metric_id = mrg_metric_id(main_mrg, metric),
-        .start_time_s = t + 161,
-        .end_time_s = t + 200,
-        .size = 0,
-        .data = PGD_EMPTY,
-        .update_every_s = 0,
-        .hot = false,
-    };
-    bool added = false;
-    PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
-    if(!page || !added) {
-        fprintf(stderr, " >>> DBENGINE: failed to insert terminal negative page\n");
-        if(page)
-            pgc_page_release(main_cache, page);
+    if(!dbengine_test_add_empty_page(
+           host, dbengine_test_metric_id(rd), t + 161, t + 200, 0, "terminal negative"))
         return 1;
-    }
-    pgc_page_release(main_cache, page);
 
     const DBENGINE_EXPECTED_POINT expected[] = {
         { t + 40,  t + 100, 1 },
         { t + 100, t + 160, 2 },
     };
 
-    size_t open_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_before =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t errors = dbengine_test_query_points(
+    size_t errors = dbengine_test_query_points_with_cache_deltas(
         rd, t + 100, t + 200,
-        expected, _countof(expected), "finish-skips-negative-page");
-    size_t open_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-
-    if(open_after != open_before) {
-        fprintf(stderr,
-                " >>> DBENGINE: terminal negative-page query used %zu open-cache lookups, expected 0\n",
-                open_after - open_before);
-        errors++;
-    }
-
-    if(journal_after != journal_before) {
-        fprintf(stderr,
-                " >>> DBENGINE: terminal negative-page query used %zu journal lookups, expected 0\n",
-                journal_after - journal_before);
-        errors++;
-    }
-
-    size_t open_before_extended = open_after;
-    size_t journal_before_extended = journal_after;
-    size_t planned_gaps_before_extended =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-    errors += dbengine_test_query_points(
+        expected, _countof(expected), "finish-skips-negative-page",
+        0, 0, DBENGINE_TEST_STAT_UNCHECKED);
+    errors += dbengine_test_query_points_with_cache_deltas(
         rd, t + 100, t + 202,
-        expected, _countof(expected), "finish-after-negative-page");
-    size_t open_after_extended =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after_extended =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_extended =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(open_after_extended != open_before_extended + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first query after terminal negative page used %zu open-cache lookups, expected 1\n",
-                open_after_extended - open_before_extended);
-        errors++;
-    }
-
-    if(journal_after_extended != journal_before_extended + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first query after terminal negative page used %zu journal lookups, expected 1\n",
-                journal_after_extended - journal_before_extended);
-        errors++;
-    }
-
-
-    if(planned_gaps_after_extended != planned_gaps_before_extended + 1) {
-        fprintf(stderr,
-                " >>> DBENGINE: first query after terminal negative page reported %zu planner gaps, expected 1\n",
-                planned_gaps_after_extended - planned_gaps_before_extended);
-        errors++;
-    }
-
-    errors += dbengine_test_query_points(
+        expected, _countof(expected), "finish-after-negative-page", 1, 1, 1);
+    errors += dbengine_test_query_points_with_cache_deltas(
         rd, t + 100, t + 202,
-        expected, _countof(expected), "finish-after-negative-page-repeat");
-    size_t open_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
-    size_t journal_after_repeat =
-        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
-    size_t planned_gaps_after_repeat =
-        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
-
-    if(open_after_repeat != open_after_extended) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated query after terminal negative page used %zu open-cache lookups, expected 0\n",
-                open_after_repeat - open_after_extended);
-        errors++;
-    }
-
-    if(journal_after_repeat != journal_after_extended) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated query after terminal negative page used %zu journal lookups, expected 0\n",
-                journal_after_repeat - journal_after_extended);
-        errors++;
-    }
-
-
-    if(planned_gaps_after_repeat != planned_gaps_after_extended) {
-        fprintf(stderr,
-                " >>> DBENGINE: repeated query after terminal negative page reported %zu planner gaps, expected 0\n",
-                planned_gaps_after_repeat - planned_gaps_after_extended);
-        errors++;
-    }
+        expected, _countof(expected), "finish-after-negative-page-repeat", 0, 0, 0);
 
     return errors;
 }

--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -2,6 +2,8 @@
 
 #include "database/rrd.h"
 #include "database/rrddim-collection.h"
+#include "daemon/unit_test_bridge.h"
+#include "pagecache.h"
 #include "page_test.h"
 
 #ifdef ENABLE_DBENGINE
@@ -462,6 +464,2176 @@ static size_t test_dbengine_burst_retention(RRDHOST *host) {
     return errors;
 }
 
+typedef struct dbengine_expected_point {
+    time_t start_time_s;
+    time_t end_time_s;
+    NETDATA_DOUBLE value;
+    bool is_gap;
+} DBENGINE_EXPECTED_POINT;
+
+static RRDDIM *dbengine_test_create_metric(RRDHOST *host, const char *id, int update_every) {
+    RRDSET *st = rrdset_create(
+        host, "netdata", id, id, "netdata", NULL, "Unit Testing", "a value", "unittest",
+        NULL, 1, update_every, RRDSET_TYPE_LINE);
+    return rrddim_add(st, "dim", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+}
+
+static void dbengine_test_store_point(RRDDIM *rd, time_t end_time_s, NETDATA_DOUBLE value) {
+    unittest_storage_engine_store_metric(
+        rd->tiers[0].sch, (usec_t)end_time_s * USEC_PER_SEC,
+        value, value, value, 1, 0, SN_DEFAULT_FLAGS);
+}
+
+static size_t dbengine_test_query_points(
+    RRDDIM *rd,
+    time_t start_time_s,
+    time_t end_time_s,
+    const DBENGINE_EXPECTED_POINT *expected,
+    size_t expected_points,
+    const char *id) {
+    size_t errors = 0;
+    struct storage_engine_query_handle seqh = { 0 };
+    unittest_storage_engine_query_init(
+        rd->tiers[0].seb, rd->tiers[0].smh, &seqh,
+        start_time_s, end_time_s, STORAGE_PRIORITY_SYNCHRONOUS);
+
+    size_t points = 0;
+    bool finished = false;
+    for(size_t safety = 0; safety < 32; safety++) {
+        if(unittest_storage_engine_query_is_finished(&seqh)) {
+            finished = true;
+            break;
+        }
+
+        STORAGE_POINT sp = unittest_storage_engine_query_next_metric(&seqh);
+        if(points >= expected_points) {
+            fprintf(stderr,
+                    " >>> DBENGINE: %s returned unexpected point %zu: %ld-%ld, value %f\n",
+                    id, points, sp.start_time_s, sp.end_time_s, sp.sum);
+            errors++;
+            points++;
+            continue;
+        }
+
+        const DBENGINE_EXPECTED_POINT *ep = &expected[points];
+        if(sp.start_time_s != ep->start_time_s || sp.end_time_s != ep->end_time_s) {
+            fprintf(stderr,
+                    " >>> DBENGINE: %s point %zu timestamps are %ld-%ld, expected %ld-%ld\n",
+                    id, points, sp.start_time_s, sp.end_time_s, ep->start_time_s, ep->end_time_s);
+            errors++;
+        }
+
+        if(ep->is_gap) {
+            if(!storage_point_is_gap(sp) || isfinite(sp.min) || isfinite(sp.max) || isfinite(sp.sum) ||
+               sp.count != 0 || sp.gap_count != 1 || sp.anomaly_count != 0 || sp.flags != SN_FLAG_NONE) {
+                fprintf(stderr,
+                        " >>> DBENGINE: %s point %zu is not the expected gap: "
+                        "min=%f max=%f sum=%f count=%u gaps=%u anomalies=%u flags=0x%x\n",
+                        id, points, sp.min, sp.max, sp.sum, sp.count, sp.gap_count,
+                        sp.anomaly_count, (unsigned)sp.flags);
+                errors++;
+            }
+        }
+        else {
+            if(sp.min != ep->value || sp.max != ep->value || sp.sum != ep->value) {
+                fprintf(stderr,
+                        " >>> DBENGINE: %s point %zu value is min=%f max=%f sum=%f, expected %f\n",
+                        id, points, sp.min, sp.max, sp.sum, ep->value);
+                errors++;
+            }
+
+            if(!storage_point_is_complete(sp) || sp.count != 1 || sp.gap_count != 0 ||
+               sp.anomaly_count != 0 || sp.flags != SN_DEFAULT_FLAGS) {
+                fprintf(stderr,
+                        " >>> DBENGINE: %s point %zu metadata is count=%u gaps=%u anomalies=%u flags=0x%x\n",
+                        id, points, sp.count, sp.gap_count, sp.anomaly_count, (unsigned)sp.flags);
+                errors++;
+            }
+        }
+
+        points++;
+    }
+
+    if(!finished && unittest_storage_engine_query_is_finished(&seqh))
+        finished = true;
+
+    if(!finished) {
+        fprintf(stderr, " >>> DBENGINE: %s query did not finish within 32 points\n", id);
+        errors++;
+    }
+
+    if(points != expected_points) {
+        fprintf(stderr,
+                " >>> DBENGINE: %s returned %zu points, expected %zu\n",
+                id, points, expected_points);
+        errors++;
+    }
+
+    unittest_storage_engine_query_finalize(&seqh);
+    return errors;
+}
+
+static size_t test_dbengine_cadence_page_transitions(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 1000000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-cadence-page-transitions-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: cadence page-transition metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    for(size_t i = 0; i < 4; i++)
+        dbengine_test_store_point(rd, t + 170 + (time_t)i * 10, 3 + (NETDATA_DOUBLE)i);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    for(size_t i = 0; i < 8; i++)
+        dbengine_test_store_point(rd, t + 230 + (time_t)i * 10, 7 + (NETDATA_DOUBLE)i);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    const DBENGINE_EXPECTED_POINT narrow[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 160, t + 170, 3 },
+        { t + 170, t + 180, 4 },
+        { t + 180, t + 190, 5 },
+        { t + 190, t + 200, 6 },
+    };
+
+    const DBENGINE_EXPECTED_POINT wide[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 160, t + 170, 3 },
+        { t + 170, t + 180, 4 },
+        { t + 180, t + 190, 5 },
+        { t + 190, t + 200, 6 },
+        { t + 220, t + 230, 7 },
+        { t + 230, t + 240, 8 },
+        { t + 240, t + 250, 9 },
+        { t + 250, t + 260, 10 },
+        { t + 260, t + 270, 11 },
+        { t + 270, t + 280, 12 },
+        { t + 280, t + 290, 13 },
+        { t + 290, t + 300, 14 },
+    };
+
+    size_t errors = 0;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 200, narrow, _countof(narrow), "cadence-page-narrow");
+    size_t journal_after_narrow =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    if(journal_after_narrow != journal_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: continuous cadence query used %zu journal lookups, expected 0\n",
+                journal_after_narrow - journal_before);
+        errors++;
+    }
+
+    struct storage_engine_query_handle seqh = { 0 };
+    unittest_storage_engine_query_init(
+        rd->tiers[0].seb, rd->tiers[0].smh, &seqh,
+        t + 100, t + 175, STORAGE_PRIORITY_SYNCHRONOUS);
+    time_t original_start_time_s = seqh.start_time_s;
+    time_t aligned_end_time_s = unittest_storage_engine_align_to_optimal_before(&seqh);
+    if(original_start_time_s != t + 100 || seqh.start_time_s != original_start_time_s ||
+       aligned_end_time_s != t + 200 || seqh.end_time_s != aligned_end_time_s) {
+        fprintf(stderr,
+                " >>> DBENGINE: cadence-page optimal range is %ld-%ld, expected %ld-%ld\n",
+                seqh.start_time_s, seqh.end_time_s, t + 100, t + 200);
+        errors++;
+    }
+    unittest_storage_engine_query_finalize(&seqh);
+
+    struct rrdeng_cache_efficiency_stats stats_before_wide = rrdeng_get_cache_efficiency_stats();
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 300, wide, _countof(wide), "cadence-page-wide");
+    struct rrdeng_cache_efficiency_stats stats_after_wide = rrdeng_get_cache_efficiency_stats();
+
+    if(stats_after_wide.prep_time_in_journal_v2_lookup.count !=
+       stats_before_wide.prep_time_in_journal_v2_lookup.count + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: cadence-page-wide query used %zu journal lookups, expected 1\n",
+                stats_after_wide.prep_time_in_journal_v2_lookup.count -
+                    stats_before_wide.prep_time_in_journal_v2_lookup.count);
+        errors++;
+    }
+
+    if(stats_after_wide.queries_planned_with_gaps != stats_before_wide.queries_planned_with_gaps + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: cadence-page-wide query reported %zu planner gaps, expected 1\n",
+                stats_after_wide.queries_planned_with_gaps - stats_before_wide.queries_planned_with_gaps);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 300, wide, _countof(wide), "cadence-page-wide-repeat");
+    struct rrdeng_cache_efficiency_stats stats_after_wide_repeat = rrdeng_get_cache_efficiency_stats();
+
+    if(stats_after_wide_repeat.prep_time_in_journal_v2_lookup.count !=
+       stats_after_wide.prep_time_in_journal_v2_lookup.count) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated cadence-page-wide query used %zu journal lookups, expected 0\n",
+                stats_after_wide_repeat.prep_time_in_journal_v2_lookup.count -
+                    stats_after_wide.prep_time_in_journal_v2_lookup.count);
+        errors++;
+    }
+
+    if(stats_after_wide_repeat.queries_planned_with_gaps != stats_after_wide.queries_planned_with_gaps) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated cadence-page-wide query reported %zu planner gaps, expected 0\n",
+                stats_after_wide_repeat.queries_planned_with_gaps - stats_after_wide.queries_planned_with_gaps);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_negative_page_reuse_across_cadence(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2000000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-negative-page-cadence-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 1);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: negative-page cadence metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 101, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    for(size_t i = 0; i < 8; i++)
+        dbengine_test_store_point(rd, t + 131 + (time_t)i * 10, 3 + (NETDATA_DOUBLE)i);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 99,  t + 100, 1 },
+        { t + 100, t + 101, 2 },
+        { t + 121, t + 131, 3 },
+        { t + 131, t + 141, 4 },
+        { t + 141, t + 151, 5 },
+        { t + 151, t + 161, 6 },
+        { t + 161, t + 171, 7 },
+        { t + 171, t + 181, 8 },
+        { t + 181, t + 191, 9 },
+        { t + 191, t + 201, 10 },
+    };
+
+    size_t errors = 0;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 201, expected, _countof(expected), "negative-page-first");
+    size_t journal_after_first =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_first =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_first != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first negative-page query used %zu journal lookups, expected 1\n",
+                journal_after_first - journal_before);
+        errors++;
+    }
+
+    if(planned_gaps_after_first != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first negative-page query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after_first - planned_gaps_before);
+        errors++;
+    }
+
+    const DBENGINE_EXPECTED_POINT inside_gap[] = {
+        { t + 121, t + 131, 3 },
+        { t + 131, t + 141, 4 },
+    };
+    errors += dbengine_test_query_points(
+        rd, t + 125, t + 141,
+        inside_gap, _countof(inside_gap), "negative-page-inside-gap");
+    size_t journal_after_inside_gap =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_inside_gap =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_inside_gap != journal_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: query inside cached negative range used %zu journal lookups, expected 0\n",
+                journal_after_inside_gap - journal_after_first);
+        errors++;
+    }
+
+
+    if(planned_gaps_after_inside_gap != planned_gaps_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: query inside cached negative range reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_inside_gap - planned_gaps_after_first);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 201, expected, _countof(expected), "negative-page-repeat");
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_repeat != journal_after_inside_gap) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated negative-page query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after_inside_gap);
+        errors++;
+    }
+
+
+    if(planned_gaps_after_repeat != planned_gaps_after_inside_gap) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated negative-page query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after_inside_gap);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_continuous_slowdown(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2500000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-continuous-slowdown-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 1);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: continuous-slowdown metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 101, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    dbengine_test_store_point(rd, t + 111, 3);
+    dbengine_test_store_point(rd, t + 121, 4);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 99,  t + 100, 1 },
+        { t + 100, t + 101, 2 },
+        { t + 101, t + 111, 3 },
+        { t + 111, t + 121, 4 },
+    };
+
+    struct rrdeng_cache_efficiency_stats stats_before = rrdeng_get_cache_efficiency_stats();
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 121, expected, _countof(expected), "continuous-slowdown");
+    struct rrdeng_cache_efficiency_stats stats_after_first = rrdeng_get_cache_efficiency_stats();
+
+    if(stats_after_first.prep_time_in_journal_v2_lookup.count !=
+       stats_before.prep_time_in_journal_v2_lookup.count + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first continuous slowdown query used %zu journal lookups, expected 1\n",
+                stats_after_first.prep_time_in_journal_v2_lookup.count -
+                    stats_before.prep_time_in_journal_v2_lookup.count);
+        errors++;
+    }
+
+    if(stats_after_first.queries_planned_with_gaps != stats_before.queries_planned_with_gaps + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first continuous slowdown query reported %zu planner gaps, expected 1\n",
+                stats_after_first.queries_planned_with_gaps - stats_before.queries_planned_with_gaps);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 121, expected, _countof(expected), "continuous-slowdown-repeat");
+    struct rrdeng_cache_efficiency_stats stats_after_repeat = rrdeng_get_cache_efficiency_stats();
+
+    if(stats_after_repeat.prep_time_in_journal_v2_lookup.count !=
+       stats_after_first.prep_time_in_journal_v2_lookup.count) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated continuous slowdown query used %zu journal lookups, expected 0\n",
+                stats_after_repeat.prep_time_in_journal_v2_lookup.count -
+                    stats_after_first.prep_time_in_journal_v2_lookup.count);
+        errors++;
+    }
+
+    if(stats_after_repeat.queries_planned_with_gaps != stats_after_first.queries_planned_with_gaps) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated continuous slowdown query reported %zu planner gaps, expected 0\n",
+                stats_after_repeat.queries_planned_with_gaps - stats_after_first.queries_planned_with_gaps);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_candidate_coverage_finds_real_gap(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2600000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-candidate-real-gap-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: candidate real-gap metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    dbengine_test_store_point(rd, t + 200, 3);
+    dbengine_test_store_point(rd, t + 210, 4);
+    dbengine_test_store_point(rd, t + 220, 5);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 190, t + 200, 3 },
+        { t + 200, t + 210, 4 },
+        { t + 210, t + 220, 5 },
+    };
+
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 220, expected, _countof(expected), "candidate-real-gap");
+    size_t journal_after_first =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_first =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_first != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first candidate real-gap query used %zu journal lookups, expected 1\n",
+                journal_after_first - journal_before);
+        errors++;
+    }
+
+    if(planned_gaps_after_first != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first candidate real-gap query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after_first - planned_gaps_before);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 220, expected, _countof(expected), "candidate-real-gap-repeat");
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_repeat != journal_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated candidate real-gap query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after_first);
+        errors++;
+    }
+    if(planned_gaps_after_repeat != planned_gaps_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated candidate real-gap query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after_first);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_candidate_tail_requires_authoritative_lookup(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2606250;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-candidate-tail-gap-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 100);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: candidate tail-gap metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 200, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    dbengine_test_store_point(rd, t + 210, 3);
+    dbengine_test_store_point(rd, t + 220, 4);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 100);
+    dbengine_test_store_point(rd, t + 300, 5);
+    dbengine_test_store_point(rd, t + 400, 6);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    Word_t metric_id = mrg_metric_id(main_mrg, metric);
+    PGC_PAGE *tail = pgc_page_get_and_acquire(
+        main_cache,
+        (Word_t)host->db[0].si,
+        metric_id,
+        t + 210,
+        PGC_SEARCH_EXACT);
+    if(!tail) {
+        fprintf(stderr, " >>> DBENGINE: candidate tail page is not cached\n");
+        return 1;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, tail)) {
+        fprintf(stderr, " >>> DBENGINE: candidate tail page could not be evicted\n");
+        return 1;
+    }
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t,       t + 100, 1 },
+        { t + 100, t + 200, 2 },
+        { t + 200, t + 210, 3 },
+        { t + 210, t + 220, 4 },
+        { t + 240, t + 250, NAN, true },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 250,
+        expected, _countof(expected), "candidate-tail-gap");
+    size_t open_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(open_after != open_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: candidate tail-gap query used %zu open-cache lookups, expected 1\n",
+                open_after - open_before);
+        errors++;
+    }
+
+    if(planned_gaps_after != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: candidate tail-gap query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after - planned_gaps_before);
+        errors++;
+    }
+
+    if(journal_after != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: candidate tail-gap query used %zu journal lookups, expected 1\n",
+                journal_after - journal_before);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 250,
+        expected, _countof(expected), "candidate-tail-gap-repeat");
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_repeat != journal_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated candidate tail-gap query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after);
+        errors++;
+    }
+
+    if(planned_gaps_after_repeat != planned_gaps_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated candidate tail-gap query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_candidate_terminal_equality_is_gap(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2607812;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-candidate-terminal-equality-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: candidate terminal-equality metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    dbengine_test_store_point(rd, t + 170, 3);
+    dbengine_test_store_point(rd, t + 180, 4);
+    dbengine_test_store_point(rd, t + 190, 5);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 100);
+    dbengine_test_store_point(rd, t + 260, 6);
+    dbengine_test_store_point(rd, t + 360, 7);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 160, t + 170, 3 },
+        { t + 170, t + 180, 4 },
+        { t + 180, t + 190, 5 },
+        { t + 190, t + 200, NAN, true },
+    };
+
+    struct rrdeng_cache_efficiency_stats stats_before = rrdeng_get_cache_efficiency_stats();
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 200,
+        expected, _countof(expected), "candidate-terminal-equality");
+    struct rrdeng_cache_efficiency_stats stats_after_first = rrdeng_get_cache_efficiency_stats();
+
+    if(stats_after_first.prep_time_in_journal_v2_lookup.count !=
+       stats_before.prep_time_in_journal_v2_lookup.count + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: candidate terminal-equality query used %zu journal lookups, expected 1\n",
+                stats_after_first.prep_time_in_journal_v2_lookup.count -
+                    stats_before.prep_time_in_journal_v2_lookup.count);
+        errors++;
+    }
+
+    if(stats_after_first.queries_planned_with_gaps != stats_before.queries_planned_with_gaps + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: candidate terminal-equality query reported %zu planner gaps, expected 1\n",
+                stats_after_first.queries_planned_with_gaps - stats_before.queries_planned_with_gaps);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 200,
+        expected, _countof(expected), "candidate-terminal-equality-repeat");
+    struct rrdeng_cache_efficiency_stats stats_after_repeat = rrdeng_get_cache_efficiency_stats();
+
+    if(stats_after_repeat.prep_time_in_journal_v2_lookup.count !=
+       stats_after_first.prep_time_in_journal_v2_lookup.count) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated candidate terminal-equality query used %zu journal lookups, expected 0\n",
+                stats_after_repeat.prep_time_in_journal_v2_lookup.count -
+                    stats_after_first.prep_time_in_journal_v2_lookup.count);
+        errors++;
+    }
+
+    if(stats_after_repeat.queries_planned_with_gaps != stats_after_first.queries_planned_with_gaps) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated candidate terminal-equality query reported %zu planner gaps, expected 0\n",
+                stats_after_repeat.queries_planned_with_gaps - stats_after_first.queries_planned_with_gaps);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_tail_before_next_sample_is_not_gap(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2609375;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-tail-before-next-sample-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: tail-before-next-sample metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    dbengine_test_store_point(rd, t + 260, 3);
+    dbengine_test_store_point(rd, t + 320, 4);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+    };
+
+    struct rrdeng_cache_efficiency_stats stats_before = rrdeng_get_cache_efficiency_stats();
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 200,
+        expected, _countof(expected), "tail-before-next-sample");
+    struct rrdeng_cache_efficiency_stats stats_after = rrdeng_get_cache_efficiency_stats();
+
+    if(stats_after.prep_time_in_journal_v2_lookup.count !=
+       stats_before.prep_time_in_journal_v2_lookup.count + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: tail-before-next-sample query used %zu journal lookups, expected 1\n",
+                stats_after.prep_time_in_journal_v2_lookup.count -
+                    stats_before.prep_time_in_journal_v2_lookup.count);
+        errors++;
+    }
+
+    if(stats_after.queries_planned_with_gaps != stats_before.queries_planned_with_gaps) {
+        fprintf(stderr,
+                " >>> DBENGINE: tail-before-next-sample query reported %zu planner gaps, expected 0\n",
+                stats_after.queries_planned_with_gaps - stats_before.queries_planned_with_gaps);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_legacy_cursor_includes_equal_page_end(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2612500;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-legacy-equal-end-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: legacy equal-end metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 100);
+    dbengine_test_store_point(rd, t + 220, 3);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    dbengine_test_store_point(rd, t + 320, 4);
+    dbengine_test_store_point(rd, t + 420, 5);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 120, t + 220, 3 },
+        { t + 220, t + 320, 4 },
+        { t + 320, t + 420, 5 },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 420, expected, _countof(expected), "legacy-equal-end");
+    size_t open_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+
+    if(open_after != open_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: legacy equal-end query used %zu open-cache lookups, expected 0\n",
+                open_after - open_before);
+        errors++;
+    }
+
+    if(journal_after != journal_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: legacy equal-end query used %zu journal lookups, expected 0\n",
+                journal_after - journal_before);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_legacy_completion_equality_requires_authority(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2618750;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-legacy-completion-equality-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: legacy completion-equality metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 100);
+    dbengine_test_store_point(rd, t + 170, 3);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 30);
+    dbengine_test_store_point(rd, t + 180, 4);
+    dbengine_test_store_point(rd, t + 210, 5);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 100);
+    dbengine_test_store_point(rd, t + 250, 6);
+    dbengine_test_store_point(rd, t + 350, 7);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    PGC_PAGE *middle = pgc_page_get_and_acquire(
+        main_cache,
+        (Word_t)host->db[0].si,
+        mrg_metric_id(main_mrg, metric),
+        t + 180,
+        PGC_SEARCH_EXACT);
+    if(!middle) {
+        fprintf(stderr, " >>> DBENGINE: legacy completion-equality middle page is not cached\n");
+        return 1;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
+        fprintf(stderr, " >>> DBENGINE: legacy completion-equality middle page could not be evicted\n");
+        return 1;
+    }
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 70,  t + 170, 3 },
+        { t + 150, t + 180, 4 },
+        { t + 180, t + 210, 5 },
+    };
+
+    struct rrdeng_cache_efficiency_stats stats_before = rrdeng_get_cache_efficiency_stats();
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 220,
+        expected, _countof(expected), "legacy-completion-equality");
+    struct rrdeng_cache_efficiency_stats stats_after_first = rrdeng_get_cache_efficiency_stats();
+
+    if(stats_after_first.prep_time_in_open_cache_lookup.count !=
+       stats_before.prep_time_in_open_cache_lookup.count + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: legacy completion-equality query used %zu open-cache lookups, expected 1\n",
+                stats_after_first.prep_time_in_open_cache_lookup.count -
+                    stats_before.prep_time_in_open_cache_lookup.count);
+        errors++;
+    }
+
+    if(stats_after_first.prep_time_in_journal_v2_lookup.count !=
+       stats_before.prep_time_in_journal_v2_lookup.count + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: legacy completion-equality query used %zu journal lookups, expected 1\n",
+                stats_after_first.prep_time_in_journal_v2_lookup.count -
+                    stats_before.prep_time_in_journal_v2_lookup.count);
+        errors++;
+    }
+
+    if(stats_after_first.queries_planned_with_gaps != stats_before.queries_planned_with_gaps + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: legacy completion-equality query reported %zu planner gaps, expected 1\n",
+                stats_after_first.queries_planned_with_gaps - stats_before.queries_planned_with_gaps);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 220,
+        expected, _countof(expected), "legacy-completion-equality-repeat");
+    struct rrdeng_cache_efficiency_stats stats_after_repeat = rrdeng_get_cache_efficiency_stats();
+
+    if(stats_after_repeat.prep_time_in_journal_v2_lookup.count !=
+       stats_after_first.prep_time_in_journal_v2_lookup.count) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated legacy completion-equality query used %zu journal lookups, expected 0\n",
+                stats_after_repeat.prep_time_in_journal_v2_lookup.count -
+                    stats_after_first.prep_time_in_journal_v2_lookup.count);
+        errors++;
+    }
+
+    if(stats_after_repeat.queries_planned_with_gaps != stats_after_first.queries_planned_with_gaps) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated legacy completion-equality query reported %zu planner gaps, expected 0\n",
+                stats_after_repeat.queries_planned_with_gaps - stats_after_first.queries_planned_with_gaps);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_cadence_overlap_does_not_hide_intermediate_page(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2625000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-cadence-overlap-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: cadence-overlap metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    for(size_t i = 0; i < 4; i++)
+        dbengine_test_store_point(rd, t + 170 + (time_t)i * 10, 3 + (NETDATA_DOUBLE)i);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 100);
+    dbengine_test_store_point(rd, t + 260, 7);
+    dbengine_test_store_point(rd, t + 360, 8);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    PGC_PAGE *middle = pgc_page_get_and_acquire(
+        main_cache,
+        (Word_t)host->db[0].si,
+        mrg_metric_id(main_mrg, metric),
+        t + 170,
+        PGC_SEARCH_EXACT);
+    if(!middle) {
+        fprintf(stderr, " >>> DBENGINE: cadence-overlap middle page is not cached\n");
+        return 1;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
+        fprintf(stderr, " >>> DBENGINE: cadence-overlap middle page could not be evicted\n");
+        return 1;
+    }
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 160, t + 170, 3 },
+        { t + 170, t + 180, 4 },
+        { t + 180, t + 190, 5 },
+        { t + 190, t + 200, 6 },
+        { t + 160, t + 260, 7 },
+        { t + 260, t + 360, 8 },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 360,
+        expected, _countof(expected), "cadence-overlap-hidden-page");
+    size_t open_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(open_after != open_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: cadence-overlap query used %zu open-cache lookups, expected 1\n",
+                open_after - open_before);
+        errors++;
+    }
+
+    if(planned_gaps_after != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: cadence-overlap query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after - planned_gaps_before);
+        errors++;
+    }
+
+    if(journal_after != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: cadence-overlap query used %zu journal lookups, expected 1\n",
+                journal_after - journal_before);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 360,
+        expected, _countof(expected), "cadence-overlap-hidden-page-repeat");
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_repeat != journal_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated cadence-overlap query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after);
+        errors++;
+    }
+
+    if(planned_gaps_after_repeat != planned_gaps_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated cadence-overlap query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_singleton_bridge_does_not_hide_intermediate_page(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2650000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-singleton-bridge-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: singleton-bridge metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 100);
+    dbengine_test_store_point(rd, t + 170, 3);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    for(size_t i = 0; i < 3; i++)
+        dbengine_test_store_point(rd, t + 180 + (time_t)i * 10, 4 + (NETDATA_DOUBLE)i);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 100);
+    dbengine_test_store_point(rd, t + 250, 7);
+    dbengine_test_store_point(rd, t + 350, 8);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    PGC_PAGE *middle = pgc_page_get_and_acquire(
+        main_cache,
+        (Word_t)host->db[0].si,
+        mrg_metric_id(main_mrg, metric),
+        t + 180,
+        PGC_SEARCH_EXACT);
+    if(!middle) {
+        fprintf(stderr, " >>> DBENGINE: singleton-bridge intermediate page is not cached\n");
+        return 1;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
+        fprintf(stderr, " >>> DBENGINE: singleton-bridge intermediate page could not be evicted\n");
+        return 1;
+    }
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 70,  t + 170, 3 },
+        { t + 170, t + 180, 4 },
+        { t + 180, t + 190, 5 },
+        { t + 190, t + 200, 6 },
+        { t + 150, t + 250, 7 },
+        { t + 250, t + 350, 8 },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 350,
+        expected, _countof(expected), "singleton-bridge-hidden-page");
+    size_t open_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(open_after != open_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: singleton-bridge query used %zu open-cache lookups, expected 1\n",
+                open_after - open_before);
+        errors++;
+    }
+
+    if(planned_gaps_after != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: singleton-bridge query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after - planned_gaps_before);
+        errors++;
+    }
+
+    if(journal_after != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: singleton-bridge query used %zu journal lookups, expected 1\n",
+                journal_after - journal_before);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 350,
+        expected, _countof(expected), "singleton-bridge-hidden-page-repeat");
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_repeat != journal_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated singleton-bridge query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after);
+        errors++;
+    }
+
+    if(planned_gaps_after_repeat != planned_gaps_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated singleton-bridge query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_empty_suffix_does_not_hide_intermediate_page(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2675000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-empty-suffix-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: EMPTY-suffix metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    for(size_t i = 0; i < 4; i++)
+        dbengine_test_store_point(rd, t + 210 + (time_t)i * 10, 3 + (NETDATA_DOUBLE)i);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 100);
+    dbengine_test_store_point(rd, t + 260, 7);
+    dbengine_test_store_point(rd, t + 360, 8);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    Word_t metric_id = mrg_metric_id(main_mrg, metric);
+    PGC_PAGE *middle = pgc_page_get_and_acquire(
+        main_cache,
+        (Word_t)host->db[0].si,
+        metric_id,
+        t + 210,
+        PGC_SEARCH_EXACT);
+    if(!middle) {
+        fprintf(stderr, " >>> DBENGINE: EMPTY-suffix intermediate page is not cached\n");
+        return 1;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
+        fprintf(stderr, " >>> DBENGINE: EMPTY-suffix intermediate page could not be evicted\n");
+        return 1;
+    }
+
+    PGC_ENTRY empty = {
+        .section = (Word_t)host->db[0].si,
+        .metric_id = metric_id,
+        .start_time_s = t + 161,
+        .end_time_s = t + 200,
+        .size = 0,
+        .data = PGD_EMPTY,
+        .update_every_s = 0,
+        .hot = false,
+    };
+    bool added = false;
+    PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
+    if(!page || !added) {
+        fprintf(stderr, " >>> DBENGINE: failed to insert EMPTY-suffix page\n");
+        if(page)
+            pgc_page_release(main_cache, page);
+        return 1;
+    }
+    pgc_page_release(main_cache, page);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 200, t + 210, 3 },
+        { t + 210, t + 220, 4 },
+        { t + 220, t + 230, 5 },
+        { t + 230, t + 240, 6 },
+        { t + 160, t + 260, 7 },
+        { t + 260, t + 360, 8 },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 360,
+        expected, _countof(expected), "empty-suffix-hidden-page");
+    size_t open_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(open_after != open_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: EMPTY-suffix query used %zu open-cache lookups, expected 1\n",
+                open_after - open_before);
+        errors++;
+    }
+
+    if(planned_gaps_after != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: EMPTY-suffix query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after - planned_gaps_before);
+        errors++;
+    }
+
+    if(journal_after != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: EMPTY-suffix query used %zu journal lookups, expected 1\n",
+                journal_after - journal_before);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 360,
+        expected, _countof(expected), "empty-suffix-hidden-page-repeat");
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_repeat != journal_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated EMPTY-suffix query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after);
+        errors++;
+    }
+
+    if(planned_gaps_after_repeat != planned_gaps_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated EMPTY-suffix query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_empty_cadence_advances_legacy_cursor(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2700000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-empty-cadence-shadow-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: EMPTY-cadence shadow metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 20);
+    dbengine_test_store_point(rd, t + 250, 3);
+    dbengine_test_store_point(rd, t + 270, 4);
+    dbengine_test_store_point(rd, t + 290, 5);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    dbengine_test_store_point(rd, t + 310, 6);
+    dbengine_test_store_point(rd, t + 330, 7);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    PGC_ENTRY empty = {
+        .section = (Word_t)host->db[0].si,
+        .metric_id = mrg_metric_id(main_mrg, metric),
+        .start_time_s = t + 161,
+        .end_time_s = t + 240,
+        .size = 0,
+        .data = PGD_EMPTY,
+        .update_every_s = 10,
+        .hot = false,
+    };
+    bool added = false;
+    PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
+    if(!page || !added) {
+        fprintf(stderr, " >>> DBENGINE: failed to insert EMPTY-cadence shadow page\n");
+        if(page)
+            pgc_page_release(main_cache, page);
+        return 1;
+    }
+    pgc_page_release(main_cache, page);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 230, t + 250, 3 },
+        { t + 250, t + 270, 4 },
+        { t + 270, t + 290, 5 },
+        { t + 290, t + 310, 6 },
+        { t + 310, t + 330, 7 },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 330, expected, _countof(expected), "empty-cadence-shadow");
+    size_t open_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+
+    if(open_after != open_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: EMPTY-cadence shadow query used %zu open-cache lookups, expected 0\n",
+                open_after - open_before);
+        errors++;
+    }
+
+    if(journal_after != journal_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: EMPTY-cadence shadow query used %zu journal lookups, expected 0\n",
+                journal_after - journal_before);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_single_missing_sample_reuse(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 2750000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-single-missing-sample-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 1);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: single-missing-sample metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 101, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    dbengine_test_store_point(rd, t + 103, 3);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 99,  t + 100, 1 },
+        { t + 100, t + 101, 2 },
+        { t + 102, t + 103, 3 },
+    };
+
+    size_t errors = 0;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 103, expected, _countof(expected), "single-missing-sample-first");
+    size_t journal_after_first =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_first =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_first != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first single-missing-sample query used %zu journal lookups, expected 1\n",
+                journal_after_first - journal_before);
+        errors++;
+    }
+
+
+    if(planned_gaps_after_first != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first single-missing-sample query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after_first - planned_gaps_before);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 103, expected, _countof(expected), "single-missing-sample-repeat");
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_repeat != journal_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated single-missing-sample query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after_first);
+        errors++;
+    }
+
+
+    if(planned_gaps_after_repeat != planned_gaps_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated single-missing-sample query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after_first);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_existing_negative_page_continuity(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 3000000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-existing-negative-page-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: existing negative-page metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    dbengine_test_store_point(rd, t + 360, 3);
+    dbengine_test_store_point(rd, t + 420, 4);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    PGC_ENTRY empty = {
+        .section = (Word_t)host->db[0].si,
+        .metric_id = mrg_metric_id(main_mrg, metric),
+        .start_time_s = t + 220,
+        .end_time_s = t + 300,
+        .size = 0,
+        .data = PGD_EMPTY,
+        .update_every_s = 0,
+        .hot = false,
+    };
+    bool added = false;
+    PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
+    if(!page || !added) {
+        fprintf(stderr, " >>> DBENGINE: failed to insert existing negative page\n");
+        if(page)
+            pgc_page_release(main_cache, page);
+        return 1;
+    }
+    pgc_page_release(main_cache, page);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 300, t + 360, 3 },
+        { t + 360, t + 420, 4 },
+    };
+
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 420, expected, _countof(expected), "existing-negative-page-first");
+    size_t journal_after_first =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_first =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_first != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first existing negative-page query used %zu journal lookups, expected 1\n",
+                journal_after_first - journal_before);
+        errors++;
+    }
+
+    if(planned_gaps_after_first != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first existing negative-page query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after_first - planned_gaps_before);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 420, expected, _countof(expected), "existing-negative-page-repeat");
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_repeat != journal_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated existing negative-page query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after_first);
+        errors++;
+    }
+
+    if(planned_gaps_after_repeat != planned_gaps_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated existing negative-page query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after_first);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_negative_page_does_not_hide_fine_page(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 3125000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-negative-before-fine-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: negative-before-fine metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    for(size_t i = 0; i < 4; i++)
+        dbengine_test_store_point(rd, t + 170 + (time_t)i * 10, 3 + (NETDATA_DOUBLE)i);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    for(size_t i = 0; i < 4; i++)
+        dbengine_test_store_point(rd, t + 230 + (time_t)i * 10, 7 + (NETDATA_DOUBLE)i);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    Word_t metric_id = mrg_metric_id(main_mrg, metric);
+    PGC_PAGE *fine = pgc_page_get_and_acquire(
+        main_cache,
+        (Word_t)host->db[0].si,
+        metric_id,
+        t + 170,
+        PGC_SEARCH_EXACT);
+    if(!fine) {
+        fprintf(stderr, " >>> DBENGINE: negative-before-fine page is not cached\n");
+        return 1;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, fine)) {
+        fprintf(stderr, " >>> DBENGINE: negative-before-fine page could not be evicted\n");
+        return 1;
+    }
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 160, t + 170, 3 },
+        { t + 170, t + 180, 4 },
+        { t + 180, t + 190, 5 },
+        { t + 190, t + 200, 6 },
+        { t + 220, t + 230, 7 },
+        { t + 230, t + 240, 8 },
+        { t + 240, t + 250, 9 },
+        { t + 250, t + 260, 10 },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 260,
+        expected, _countof(expected), "negative-before-fine-first");
+    size_t open_after_first =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after_first =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_first =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(open_after_first != open_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first negative-before-fine query used %zu open-cache lookups, expected 1\n",
+                open_after_first - open_before);
+        errors++;
+    }
+
+    if(journal_after_first != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first negative-before-fine query used %zu journal lookups, expected 1\n",
+                journal_after_first - journal_before);
+        errors++;
+    }
+
+    if(planned_gaps_after_first != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first negative-before-fine query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after_first - planned_gaps_before);
+        errors++;
+    }
+
+    fine = pgc_page_get_and_acquire(
+        main_cache,
+        (Word_t)host->db[0].si,
+        metric_id,
+        t + 170,
+        PGC_SEARCH_EXACT);
+    if(!fine) {
+        fprintf(stderr, " >>> DBENGINE: recovered negative-before-fine page is not cached\n");
+        return errors + 1;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, fine)) {
+        fprintf(stderr, " >>> DBENGINE: recovered negative-before-fine page could not be evicted\n");
+        return errors + 1;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 260,
+        expected, _countof(expected), "negative-before-fine-repeat");
+    size_t open_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(open_after_repeat != open_after_first + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated negative-before-fine query used %zu open-cache lookups, expected 1\n",
+                open_after_repeat - open_after_first);
+        errors++;
+    }
+
+
+    if(journal_after_repeat != journal_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated negative-before-fine query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after_first);
+        errors++;
+    }
+
+    if(planned_gaps_after_repeat != planned_gaps_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated negative-before-fine query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after_first);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_cadence_bearing_empty_pages(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 3250000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-cadence-bearing-empty-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: cadence-bearing EMPTY metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    dbengine_test_store_point(rd, t + 210, 3);
+    dbengine_test_store_point(rd, t + 220, 4);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    dbengine_test_store_point(rd, t + 270, 5);
+    dbengine_test_store_point(rd, t + 280, 6);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    Word_t metric_id = mrg_metric_id(main_mrg, metric);
+    PGC_PAGE *middle = pgc_page_get_and_acquire(
+        main_cache,
+        (Word_t)host->db[0].si,
+        metric_id,
+        t + 210,
+        PGC_SEARCH_EXACT);
+    if(!middle) {
+        fprintf(stderr, " >>> DBENGINE: cadence-bearing EMPTY middle page is not cached\n");
+        return 1;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, middle)) {
+        fprintf(stderr, " >>> DBENGINE: cadence-bearing EMPTY middle page could not be evicted\n");
+        return 1;
+    }
+
+    const struct {
+        time_t first;
+        time_t last;
+    } empty_ranges[] = {
+        { t + 170, t + 200 },
+        { t + 230, t + 260 },
+    };
+
+    for(size_t i = 0; i < _countof(empty_ranges); i++) {
+        PGC_ENTRY empty = {
+            .section = (Word_t)host->db[0].si,
+            .metric_id = metric_id,
+            .start_time_s = empty_ranges[i].first,
+            .end_time_s = empty_ranges[i].last,
+            .size = 0,
+            .data = PGD_EMPTY,
+            .update_every_s = 10,
+            .hot = false,
+        };
+        bool added = false;
+        PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
+        if(!page || !added) {
+            fprintf(stderr, " >>> DBENGINE: failed to insert cadence-bearing EMPTY page %zu\n", i);
+            if(page)
+                pgc_page_release(main_cache, page);
+            return 1;
+        }
+        pgc_page_release(main_cache, page);
+    }
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+        { t + 200, t + 210, 3 },
+        { t + 210, t + 220, 4 },
+        { t + 260, t + 270, 5 },
+        { t + 270, t + 280, 6 },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_before =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 280,
+        expected, _countof(expected), "cadence-bearing-empty-pages");
+    size_t open_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(open_after != open_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: cadence-bearing EMPTY query used %zu open-cache lookups, expected 1\n",
+                open_after - open_before);
+        errors++;
+    }
+
+
+    if(journal_after != journal_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: cadence-bearing EMPTY query used %zu journal lookups, expected 1\n",
+                journal_after - journal_before);
+        errors++;
+    }
+
+    if(planned_gaps_after != planned_gaps_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: cadence-bearing EMPTY query reported %zu planner gaps, expected 1\n",
+                planned_gaps_after - planned_gaps_before);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 280,
+        expected, _countof(expected), "cadence-bearing-empty-pages-repeat");
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(journal_after_repeat != journal_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated cadence-bearing EMPTY query used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after);
+        errors++;
+    }
+
+    if(planned_gaps_after_repeat != planned_gaps_after) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated cadence-bearing EMPTY query reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_inclusive_cache_frontier(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 3500000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-inclusive-cache-frontier-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: inclusive cache-frontier metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 10);
+    for(size_t i = 0; i < 4; i++)
+        dbengine_test_store_point(rd, t + 170 + (time_t)i * 10, 3 + (NETDATA_DOUBLE)i);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    pgc_flush_dirty_pages(main_cache, (Word_t)host->db[0].si);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    PGC_PAGE *first = pgc_page_get_and_acquire(
+        main_cache,
+        (Word_t)host->db[0].si,
+        mrg_metric_id(main_mrg, metric),
+        t + 100,
+        PGC_SEARCH_EXACT);
+    if(!first) {
+        fprintf(stderr, " >>> DBENGINE: inclusive cache-frontier first page is not cached\n");
+        return 1;
+    }
+
+    if(!pgc_page_to_clean_evict_or_release(main_cache, first)) {
+        fprintf(stderr, " >>> DBENGINE: inclusive cache-frontier first page could not be evicted\n");
+        return 1;
+    }
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 100, t + 160, 2 },
+        { t + 160, t + 170, 3 },
+        { t + 170, t + 180, 4 },
+        { t + 180, t + 190, 5 },
+        { t + 190, t + 200, 6 },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 160, t + 200, expected, _countof(expected), "inclusive-cache-frontier");
+    size_t open_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+
+    if(open_after != open_before + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: inclusive cache-frontier query used %zu open-cache lookups, expected 1\n",
+                open_after - open_before);
+        errors++;
+    }
+
+    if(journal_after != journal_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: inclusive cache-frontier query used %zu journal lookups, expected 0\n",
+                journal_after - journal_before);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_long_collection_cadence(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 4000000;
+    const uint32_t update_every = 90000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-long-cadence-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, (int)update_every);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: long-cadence metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + update_every, 1);
+    dbengine_test_store_point(rd, t + 2 * update_every, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t,                t + update_every,     1 },
+        { t + update_every, t + 2 * update_every, 2 },
+    };
+
+    size_t invalid_before =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+    size_t errors = dbengine_test_query_points(
+        rd, t + update_every, t + 2 * update_every,
+        expected, _countof(expected), "long-cadence");
+    size_t invalid_after =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+
+    if(invalid_after != invalid_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: valid long-cadence query reported %zu invalid page durations, expected 0\n",
+                invalid_after - invalid_before);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_zero_page_cadence_is_repaired(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 4250000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-zero-page-cadence-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 10);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: zero-page-cadence metric initialization failed\n");
+        return 1;
+    }
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 0);
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 110, 2);
+
+    struct rrdeng_collect_handle *handle = (struct rrdeng_collect_handle *)rd->tiers[0].sch;
+    if(!handle->pgc_page || pgc_page_data(handle->pgc_page) == PGD_EMPTY ||
+       pgd_slots_used(pgc_page_data(handle->pgc_page)) != 2 ||
+       pgc_page_start_time_s(handle->pgc_page) != t + 100 ||
+       pgc_page_end_time_s(handle->pgc_page) != t + 110 ||
+       pgc_page_update_every_s(handle->pgc_page) != 0) {
+        fprintf(stderr,
+                " >>> DBENGINE: zero-page-cadence fixture did not retain a nonempty 0-second page\n");
+        unittest_storage_engine_store_flush(rd->tiers[0].sch);
+        return 1;
+    }
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 90,  t + 100, 1 },
+        { t + 100, t + 110, 2 },
+    };
+
+    size_t invalid_before =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 110, expected, _countof(expected), "zero-page-cadence-first");
+    size_t invalid_after_first =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+
+    if(invalid_after_first != invalid_before + 1 ||
+       pgc_page_update_every_s(handle->pgc_page) != 10) {
+        fprintf(stderr,
+                " >>> DBENGINE: zero page cadence repairs=%zu cadence=%u, expected 1 and 10\n",
+                invalid_after_first - invalid_before,
+                pgc_page_update_every_s(handle->pgc_page));
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 110, expected, _countof(expected), "zero-page-cadence-repeat");
+    size_t invalid_after_repeat =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+
+    if(invalid_after_repeat != invalid_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated zero-page-cadence query reported %zu repairs, expected 0\n",
+                invalid_after_repeat - invalid_after_first);
+        errors++;
+    }
+
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    return errors;
+}
+
+static size_t test_dbengine_finish_skips_negative_page(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 4500000;
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "dbengine-finish-skips-negative-%d", getpid());
+    RRDDIM *rd = dbengine_test_create_metric(host, id, 60);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: finish-skips-negative metric initialization failed\n");
+        return 1;
+    }
+
+    dbengine_test_store_point(rd, t + 100, 1);
+    dbengine_test_store_point(rd, t + 160, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    dbengine_test_store_point(rd, t + 260, 3);
+    dbengine_test_store_point(rd, t + 320, 4);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    METRIC *metric = (METRIC *)rd->tiers[0].smh;
+    PGC_ENTRY empty = {
+        .section = (Word_t)host->db[0].si,
+        .metric_id = mrg_metric_id(main_mrg, metric),
+        .start_time_s = t + 161,
+        .end_time_s = t + 200,
+        .size = 0,
+        .data = PGD_EMPTY,
+        .update_every_s = 0,
+        .hot = false,
+    };
+    bool added = false;
+    PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, empty, &added);
+    if(!page || !added) {
+        fprintf(stderr, " >>> DBENGINE: failed to insert terminal negative page\n");
+        if(page)
+            pgc_page_release(main_cache, page);
+        return 1;
+    }
+    pgc_page_release(main_cache, page);
+
+    const DBENGINE_EXPECTED_POINT expected[] = {
+        { t + 40,  t + 100, 1 },
+        { t + 100, t + 160, 2 },
+    };
+
+    size_t open_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_before =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t errors = dbengine_test_query_points(
+        rd, t + 100, t + 200,
+        expected, _countof(expected), "finish-skips-negative-page");
+    size_t open_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+
+    if(open_after != open_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: terminal negative-page query used %zu open-cache lookups, expected 0\n",
+                open_after - open_before);
+        errors++;
+    }
+
+    if(journal_after != journal_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: terminal negative-page query used %zu journal lookups, expected 0\n",
+                journal_after - journal_before);
+        errors++;
+    }
+
+    size_t open_before_extended = open_after;
+    size_t journal_before_extended = journal_after;
+    size_t planned_gaps_before_extended =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 202,
+        expected, _countof(expected), "finish-after-negative-page");
+    size_t open_after_extended =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after_extended =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_extended =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(open_after_extended != open_before_extended + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first query after terminal negative page used %zu open-cache lookups, expected 1\n",
+                open_after_extended - open_before_extended);
+        errors++;
+    }
+
+    if(journal_after_extended != journal_before_extended + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first query after terminal negative page used %zu journal lookups, expected 1\n",
+                journal_after_extended - journal_before_extended);
+        errors++;
+    }
+
+
+    if(planned_gaps_after_extended != planned_gaps_before_extended + 1) {
+        fprintf(stderr,
+                " >>> DBENGINE: first query after terminal negative page reported %zu planner gaps, expected 1\n",
+                planned_gaps_after_extended - planned_gaps_before_extended);
+        errors++;
+    }
+
+    errors += dbengine_test_query_points(
+        rd, t + 100, t + 202,
+        expected, _countof(expected), "finish-after-negative-page-repeat");
+    size_t open_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_open_cache_lookup.count;
+    size_t journal_after_repeat =
+        rrdeng_get_cache_efficiency_stats().prep_time_in_journal_v2_lookup.count;
+    size_t planned_gaps_after_repeat =
+        rrdeng_get_cache_efficiency_stats().queries_planned_with_gaps;
+
+    if(open_after_repeat != open_after_extended) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated query after terminal negative page used %zu open-cache lookups, expected 0\n",
+                open_after_repeat - open_after_extended);
+        errors++;
+    }
+
+    if(journal_after_repeat != journal_after_extended) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated query after terminal negative page used %zu journal lookups, expected 0\n",
+                journal_after_repeat - journal_after_extended);
+        errors++;
+    }
+
+
+    if(planned_gaps_after_repeat != planned_gaps_after_extended) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated query after terminal negative page reported %zu planner gaps, expected 0\n",
+                planned_gaps_after_repeat - planned_gaps_after_extended);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_query_page_transitions(RRDHOST *host) {
+    size_t errors = 0;
+    errors += test_dbengine_cadence_page_transitions(host);
+    errors += test_dbengine_negative_page_reuse_across_cadence(host);
+    errors += test_dbengine_continuous_slowdown(host);
+    errors += test_dbengine_candidate_coverage_finds_real_gap(host);
+    errors += test_dbengine_candidate_tail_requires_authoritative_lookup(host);
+    errors += test_dbengine_candidate_terminal_equality_is_gap(host);
+    errors += test_dbengine_tail_before_next_sample_is_not_gap(host);
+    errors += test_dbengine_legacy_cursor_includes_equal_page_end(host);
+    errors += test_dbengine_legacy_completion_equality_requires_authority(host);
+    errors += test_dbengine_cadence_overlap_does_not_hide_intermediate_page(host);
+    errors += test_dbengine_singleton_bridge_does_not_hide_intermediate_page(host);
+    errors += test_dbengine_empty_suffix_does_not_hide_intermediate_page(host);
+    errors += test_dbengine_empty_cadence_advances_legacy_cursor(host);
+    errors += test_dbengine_single_missing_sample_reuse(host);
+    errors += test_dbengine_existing_negative_page_continuity(host);
+    errors += test_dbengine_negative_page_does_not_hide_fine_page(host);
+    errors += test_dbengine_cadence_bearing_empty_pages(host);
+    errors += test_dbengine_inclusive_cache_frontier(host);
+    errors += test_dbengine_long_collection_cadence(host);
+    errors += test_dbengine_zero_page_cadence_is_repaired(host);
+    errors += test_dbengine_finish_skips_negative_page(host);
+    return errors;
+}
+
 int test_dbengine(void) {
     // provide enough threads to dbengine
     setenv("UV_THREADPOOL_SIZE", "48", 1);
@@ -518,6 +2690,8 @@ int test_dbengine(void) {
     for (size_t current_region = 0 ; current_region < REGIONS ; current_region++) {
         errors += dbengine_test_rrdr_single_region(st, rd, current_region, time_start[current_region], time_end[current_region]);
     }
+
+    errors += test_dbengine_query_page_transitions(host);
 
     // prevent closing the database before the test is finished
     sleep(5);

--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -327,11 +327,17 @@ static size_t dbengine_test_rrdr_single_region(
                 RRDR_VALUE_FLAGS *co = &r->o[ p * r->d ];
                 NETDATA_DOUBLE *cn = &r->v[ p * r->d ];
 
+                time_t end_time_s = r->t[p];
+                time_t start_time_s = end_time_s - r->view.update_every;
                 STORAGE_POINT sp = STORAGE_POINT_UNSET;
-                sp.min = sp.max = sp.sum = (co[d] & RRDR_VALUE_EMPTY) ? NAN :cn[d];
-                sp.count = 1;
-                sp.end_time_s = r->t[p];
-                sp.start_time_s = sp.end_time_s - r->view.update_every;
+                if(co[d] & RRDR_VALUE_EMPTY)
+                    storage_point_empty(sp, start_time_s, end_time_s);
+                else {
+                    sp.min = sp.max = sp.sum = cn[d];
+                    sp.count = 1;
+                    sp.start_time_s = start_time_s;
+                    sp.end_time_s = end_time_s;
+                }
 
                 storage_point_check(current_region, c, d, p, time_now, update_every, sp, &value_errors, &time_errors, &update_every_errors);
                 d++;

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -1090,15 +1090,22 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             storage_number_tier1_t *array = (storage_number_tier1_t *) pgdc->pgd->raw.data;
             storage_number_tier1_t n = array[pgdc->position++];
 
-            if(likely(n.count && netdata_double_isnumber(n.sum_value))) {
+            // V1 stores count in 16 bits. A complete 65536-slot numeric rollup
+            // wraps to zero; finite payload distinguishes it from an empty slot.
+            uint32_t count = n.count;
+            if(unlikely(!count && pgdc->slots_per_point == (uint32_t)UINT16_MAX + 1 &&
+                        netdata_double_isnumber(n.sum_value)))
+                count = pgdc->slots_per_point;
+
+            if(likely(count && netdata_double_isnumber(n.sum_value))) {
                 sp->flags = n.anomaly_count ? SN_FLAG_NONE : SN_FLAG_NOT_ANOMALOUS;
-                sp->count = n.count;
+                sp->count = count;
                 sp->anomaly_count = n.anomaly_count;
                 sp->min = n.min_value;
                 sp->max = n.max_value;
                 sp->sum = n.sum_value;
                 // V1 records omit gaps; the active grouping is the best available estimate.
-                sp->gap_count = pgdc->slots_per_point > n.count ? pgdc->slots_per_point - n.count : 0;
+                sp->gap_count = pgdc->slots_per_point > count ? pgdc->slots_per_point - count : 0;
             }
             else
                 storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -1075,16 +1075,14 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             uint32_t n = 666666666;
             bool ok = gorilla_reader_read(&pgdc->gr, &n);
 
-            if (ok) {
+            if (ok && likely(does_storage_number_exist(n))) {
                 sp->min = sp->max = sp->sum = unpack_storage_number(n);
                 sp->flags = (SN_FLAGS)(n & SN_USER_FLAGS);
-                bool exists = does_storage_number_exist(n);
-                sp->count = exists ? 1 : 0;
-                sp->anomaly_count = exists && is_storage_number_anomalous(n) ? 1 : 0;
-                sp->gap_count = exists ? 0 : 1;
-            } else {
+                sp->count = 1;
+                sp->gap_count = 0;
+                sp->anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
+            } else
                 storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
-            }
 
             return ok;
         }
@@ -1092,14 +1090,18 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             storage_number_tier1_t *array = (storage_number_tier1_t *) pgdc->pgd->raw.data;
             storage_number_tier1_t n = array[pgdc->position++];
 
-            sp->flags = n.anomaly_count ? SN_FLAG_NONE : SN_FLAG_NOT_ANOMALOUS;
-            sp->count = n.count;
-            sp->anomaly_count = n.anomaly_count;
-            sp->min = n.min_value;
-            sp->max = n.max_value;
-            sp->sum = n.sum_value;
-            sp->gap_count = 0;
-            storage_point_normalize_legacy_slots(*sp, pgdc->slots_per_point);
+            if(likely(n.count && netdata_double_isnumber(n.sum_value))) {
+                sp->flags = n.anomaly_count ? SN_FLAG_NONE : SN_FLAG_NOT_ANOMALOUS;
+                sp->count = n.count;
+                sp->anomaly_count = n.anomaly_count;
+                sp->min = n.min_value;
+                sp->max = n.max_value;
+                sp->sum = n.sum_value;
+                // V1 records omit gaps; the active grouping is the best available estimate.
+                sp->gap_count = pgdc->slots_per_point > n.count ? pgdc->slots_per_point - n.count : 0;
+            }
+            else
+                storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
 
             return true;
         }
@@ -1107,12 +1109,14 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             storage_number *array = (storage_number *) pgdc->pgd->raw.data;
             storage_number n = array[pgdc->position++];
 
-            sp->min = sp->max = sp->sum = unpack_storage_number(n);
-            sp->flags = (SN_FLAGS)(n & SN_USER_FLAGS);
-            bool exists = does_storage_number_exist(n);
-            sp->count = exists ? 1 : 0;
-            sp->anomaly_count = exists && is_storage_number_anomalous(n) ? 1 : 0;
-            sp->gap_count = exists ? 0 : 1;
+            if(likely(does_storage_number_exist(n))) {
+                sp->min = sp->max = sp->sum = unpack_storage_number(n);
+                sp->flags = (SN_FLAGS)(n & SN_USER_FLAGS);
+                sp->count = 1;
+                sp->gap_count = 0;
+                sp->anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
+            } else
+                storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
 
             return true;
         }

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -1036,12 +1036,13 @@ static void pgdc_seek(PGDC *pgdc, uint32_t position)
     }
 }
 
-void pgdc_reset(PGDC *pgdc, PGD *pgd, uint32_t position)
+void pgdc_reset(PGDC *pgdc, PGD *pgd, uint32_t position, uint32_t slots_per_point)
 {
     // pgd might be null and position equal to UINT32_MAX
 
     pgdc->pgd = pgd;
     pgdc->position = position;
+    pgdc->slots_per_point = slots_per_point ? slots_per_point : 1;
 
     if (!pgd)
         return;
@@ -1060,7 +1061,7 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
 {
     if (!pgdc->pgd || pgdc->pgd == PGD_EMPTY || pgdc->position >= pgdc->slots)
     {
-        storage_point_empty(*sp, sp->start_time_s, sp->end_time_s);
+        storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
         return false;
     }
 
@@ -1077,10 +1078,12 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             if (ok) {
                 sp->min = sp->max = sp->sum = unpack_storage_number(n);
                 sp->flags = (SN_FLAGS)(n & SN_USER_FLAGS);
-                sp->count = 1;
-                sp->anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
+                bool exists = does_storage_number_exist(n);
+                sp->count = exists ? 1 : 0;
+                sp->anomaly_count = exists && is_storage_number_anomalous(n) ? 1 : 0;
+                sp->gap_count = exists ? 0 : 1;
             } else {
-                storage_point_empty(*sp, sp->start_time_s, sp->end_time_s);
+                storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
             }
 
             return ok;
@@ -1095,6 +1098,8 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             sp->min = n.min_value;
             sp->max = n.max_value;
             sp->sum = n.sum_value;
+            sp->gap_count = 0;
+            storage_point_normalize_legacy_slots(*sp, pgdc->slots_per_point);
 
             return true;
         }
@@ -1104,8 +1109,10 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
 
             sp->min = sp->max = sp->sum = unpack_storage_number(n);
             sp->flags = (SN_FLAGS)(n & SN_USER_FLAGS);
-            sp->count = 1;
-            sp->anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
+            bool exists = does_storage_number_exist(n);
+            sp->count = exists ? 1 : 0;
+            sp->anomaly_count = exists && is_storage_number_anomalous(n) ? 1 : 0;
+            sp->gap_count = exists ? 0 : 1;
 
             return true;
         }
@@ -1118,7 +1125,7 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
                 logged = true;
             }
 
-            storage_point_empty(*sp, sp->start_time_s, sp->end_time_s);
+            storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
             return false;
         }
     }

--- a/src/database/engine/page.h
+++ b/src/database/engine/page.h
@@ -13,6 +13,7 @@ typedef struct pgd_cursor {
     struct pgd *pgd;
     uint32_t position;
     uint32_t slots;
+    uint32_t slots_per_point;
 
     gorilla_reader_t gr;
 } PGDC;
@@ -53,7 +54,7 @@ size_t pgd_append_point(PGD *pg,
                       SN_FLAGS flags,
                       uint32_t expected_slot);
 
-void pgdc_reset(PGDC *pgdc, PGD *pgd, uint32_t position);
+void pgdc_reset(PGDC *pgdc, PGD *pgd, uint32_t position, uint32_t slots_per_point);
 bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position, STORAGE_POINT *sp);
 
 void *dbengine_extent_alloc(size_t size);

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -65,7 +65,7 @@ static size_t pgd_unittest_tier0(uint8_t page_type) {
 static size_t pgd_unittest_tier1(void) {
     size_t errors = 0;
 
-    PGD *gap_pg = pgd_unittest_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 1);
+    PGD *gap_pg = pgd_unittest_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 2);
     pgd_unittest_append_point(gap_pg, 60, NAN, NAN, NAN, 0, 0, SN_FLAG_NONE, 0);
     PGD_EXPECT(pgd_unittest_slots_used(gap_pg) == 1);
     PGD_EXPECT(pgd_unittest_is_empty(gap_pg));
@@ -151,7 +151,7 @@ static size_t pgd_unittest_tier1(void) {
     PGD_EXPECT(sp.count == 0 && sp.gap_count == 64);
     PGD_EXPECT(sp.flags == SN_FLAG_NONE);
 
-    PGD *wrapped_count_pg = pgd_unittest_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 1);
+    PGD *wrapped_count_pg = pgd_unittest_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 2);
     pgd_unittest_append_point(wrapped_count_pg, 65536, 65536, 1, 1, 0, 0, SN_DEFAULT_FLAGS, 0);
     pgd_unittest_cursor_reset(&cursor, wrapped_count_pg, 0, 65536);
     sp.start_time_s = 0;

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -1,4 +1,4 @@
-#include "page.h"
+#include "page_test_bridge.h"
 #include "page_test.h"
 
 static size_t pgd_unittest_tier0(uint8_t page_type) {
@@ -11,18 +11,18 @@ static size_t pgd_unittest_tier0(uint8_t page_type) {
     }                                                                                                                   \
 } while(0)
 
-    PGD *pg = pgd_create(page_type, 4);
-    pgd_append_point(pg, 1, 42, 42, 42, 1, 0, SN_DEFAULT_FLAGS, 0);
-    pgd_append_point(pg, 2, NAN, NAN, NAN, 0, 0, SN_EMPTY_SLOT, 1);
-    pgd_append_point(pg, 3, -7, -7, -7, 1, 0, SN_FLAG_RESET, 2);
+    PGD *pg = pgd_unittest_create(page_type, 4);
+    pgd_unittest_append_point(pg, 1, 42, 42, 42, 1, 0, SN_DEFAULT_FLAGS, 0);
+    pgd_unittest_append_point(pg, 2, NAN, NAN, NAN, 0, 0, SN_EMPTY_SLOT, 1);
+    pgd_unittest_append_point(pg, 3, -7, -7, -7, 1, 0, SN_FLAG_RESET, 2);
 
     PGDC cursor = {};
-    pgdc_reset(&cursor, pg, 0, 1);
+    pgd_unittest_cursor_reset(&cursor, pg, 0, 1);
 
     STORAGE_POINT sp = STORAGE_POINT_UNSET;
     sp.start_time_s = 0;
     sp.end_time_s = 1;
-    PGD_EXPECT(pgdc_get_next_point(&cursor, 0, &sp));
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 0, &sp));
     PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 1);
     PGD_EXPECT(storage_point_is_complete(sp));
     PGD_EXPECT(sp.min == 42 && sp.max == 42 && sp.sum == 42);
@@ -31,7 +31,7 @@ static size_t pgd_unittest_tier0(uint8_t page_type) {
 
     sp.start_time_s = 1;
     sp.end_time_s = 2;
-    PGD_EXPECT(pgdc_get_next_point(&cursor, 1, &sp));
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 1, &sp));
     PGD_EXPECT(sp.start_time_s == 1 && sp.end_time_s == 2);
     PGD_EXPECT(storage_point_is_gap(sp));
     PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
@@ -41,7 +41,7 @@ static size_t pgd_unittest_tier0(uint8_t page_type) {
 
     sp.start_time_s = 2;
     sp.end_time_s = 3;
-    PGD_EXPECT(pgdc_get_next_point(&cursor, 2, &sp));
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 2, &sp));
     PGD_EXPECT(sp.start_time_s == 2 && sp.end_time_s == 3);
     PGD_EXPECT(storage_point_is_complete(sp));
     PGD_EXPECT(sp.min == -7 && sp.max == -7 && sp.sum == -7);
@@ -50,7 +50,7 @@ static size_t pgd_unittest_tier0(uint8_t page_type) {
 
     sp.start_time_s = 3;
     sp.end_time_s = 4;
-    PGD_EXPECT(!pgdc_get_next_point(&cursor, 3, &sp));
+    PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 3, &sp));
     PGD_EXPECT(sp.start_time_s == 3 && sp.end_time_s == 4);
     PGD_EXPECT(storage_point_is_gap(sp));
     PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
@@ -58,26 +58,33 @@ static size_t pgd_unittest_tier0(uint8_t page_type) {
     PGD_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
     PGD_EXPECT(sp.flags == SN_FLAG_NONE);
 
-    pgd_free(pg);
+    pgd_unittest_free(pg);
     return errors;
 }
 
 static size_t pgd_unittest_tier1(void) {
     size_t errors = 0;
 
-    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 5);
-    pgd_append_point(pg, 60, 400, 9, 11, 40, 4, SN_DEFAULT_FLAGS, 0);
-    pgd_append_point(pg, 120, 800, 9, 11, 80, 0, SN_DEFAULT_FLAGS, 1);
-    pgd_append_point(pg, 180, 300, 9, 11, 0, 0, SN_DEFAULT_FLAGS, 2);
-    pgd_append_point(pg, 240, NAN, NAN, NAN, 7, 1, SN_DEFAULT_FLAGS, 3);
+    PGD *gap_pg = pgd_unittest_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 1);
+    pgd_unittest_append_point(gap_pg, 60, NAN, NAN, NAN, 0, 0, SN_FLAG_NONE, 0);
+    PGD_EXPECT(pgd_unittest_slots_used(gap_pg) == 1);
+    PGD_EXPECT(pgd_unittest_is_empty(gap_pg));
+    pgd_unittest_free(gap_pg);
+
+    PGD *pg = pgd_unittest_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 6);
+    pgd_unittest_append_point(pg, 60, 400, 9, 11, 40, 4, SN_DEFAULT_FLAGS, 0);
+    pgd_unittest_append_point(pg, 120, 800, 9, 11, 80, 0, SN_DEFAULT_FLAGS, 1);
+    pgd_unittest_append_point(pg, 180, 300, 9, 11, 0, 0, SN_DEFAULT_FLAGS, 2);
+    pgd_unittest_append_point(pg, 240, NAN, NAN, NAN, 7, 1, SN_DEFAULT_FLAGS, 3);
+    pgd_unittest_append_point(pg, 300, INFINITY, 9, 11, 7, 1, SN_DEFAULT_FLAGS, 4);
 
     PGDC cursor = {};
-    pgdc_reset(&cursor, pg, 0, 60);
+    pgd_unittest_cursor_reset(&cursor, pg, 0, 60);
 
     STORAGE_POINT sp = STORAGE_POINT_UNSET;
     sp.start_time_s = 0;
     sp.end_time_s = 60;
-    PGD_EXPECT(pgdc_get_next_point(&cursor, 0, &sp));
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 0, &sp));
     PGD_EXPECT(storage_point_is_partial(sp));
     PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 60);
     PGD_EXPECT(sp.min == 9 && sp.max == 11 && sp.sum == 400);
@@ -86,7 +93,7 @@ static size_t pgd_unittest_tier1(void) {
 
     sp.start_time_s = 60;
     sp.end_time_s = 120;
-    PGD_EXPECT(pgdc_get_next_point(&cursor, 1, &sp));
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 1, &sp));
     PGD_EXPECT(storage_point_is_complete(sp));
     PGD_EXPECT(sp.start_time_s == 60 && sp.end_time_s == 120);
     PGD_EXPECT(sp.min == 9 && sp.max == 11 && sp.sum == 800);
@@ -95,7 +102,7 @@ static size_t pgd_unittest_tier1(void) {
 
     sp.start_time_s = 120;
     sp.end_time_s = 180;
-    PGD_EXPECT(pgdc_get_next_point(&cursor, 2, &sp));
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 2, &sp));
     PGD_EXPECT(storage_point_is_gap(sp));
     PGD_EXPECT(sp.start_time_s == 120 && sp.end_time_s == 180);
     PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
@@ -105,7 +112,7 @@ static size_t pgd_unittest_tier1(void) {
 
     sp.start_time_s = 180;
     sp.end_time_s = 240;
-    PGD_EXPECT(pgdc_get_next_point(&cursor, 3, &sp));
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 3, &sp));
     PGD_EXPECT(storage_point_is_gap(sp));
     PGD_EXPECT(sp.start_time_s == 180 && sp.end_time_s == 240);
     PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
@@ -115,7 +122,7 @@ static size_t pgd_unittest_tier1(void) {
 
     sp.start_time_s = 240;
     sp.end_time_s = 300;
-    PGD_EXPECT(!pgdc_get_next_point(&cursor, 4, &sp));
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 4, &sp));
     PGD_EXPECT(storage_point_is_gap(sp));
     PGD_EXPECT(sp.start_time_s == 240 && sp.end_time_s == 300);
     PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
@@ -123,47 +130,70 @@ static size_t pgd_unittest_tier1(void) {
     PGD_EXPECT(sp.count == 0 && sp.gap_count == 60 && sp.anomaly_count == 0);
     PGD_EXPECT(sp.flags == SN_FLAG_NONE);
 
-    pgdc_reset(&cursor, pg, 2, 65536);
-    sp.start_time_s = 0;
-    sp.end_time_s = 65536;
-    PGD_EXPECT(pgdc_get_next_point(&cursor, 2, &sp));
+    sp.start_time_s = 300;
+    sp.end_time_s = 360;
+    PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 5, &sp));
     PGD_EXPECT(storage_point_is_gap(sp));
-    PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 65536);
+    PGD_EXPECT(sp.start_time_s == 300 && sp.end_time_s == 360);
     PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
                !netdata_double_isnumber(sp.sum));
-    PGD_EXPECT(sp.count == 0 && sp.gap_count == 65536);
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 60 && sp.anomaly_count == 0);
     PGD_EXPECT(sp.flags == SN_FLAG_NONE);
 
-    pgd_free(pg);
+    pgd_unittest_cursor_reset(&cursor, pg, 2, 64);
+    sp.start_time_s = 0;
+    sp.end_time_s = 64;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 2, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 64);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 64);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    PGD *wrapped_count_pg = pgd_unittest_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 1);
+    pgd_unittest_append_point(wrapped_count_pg, 65536, 65536, 1, 1, 0, 0, SN_DEFAULT_FLAGS, 0);
+    pgd_unittest_cursor_reset(&cursor, wrapped_count_pg, 0, 65536);
+    sp.start_time_s = 0;
+    sp.end_time_s = 65536;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 2, &sp));
+    PGD_EXPECT(storage_point_is_complete(sp));
+    PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 65536);
+    PGD_EXPECT(sp.min == 1 && sp.max == 1 && sp.sum == 65536);
+    PGD_EXPECT(sp.count == 65536 && sp.gap_count == 0 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags & SN_FLAG_NOT_ANOMALOUS);
+    pgd_unittest_free(wrapped_count_pg);
+
+    pgd_unittest_free(pg);
     return errors;
 }
 
 static size_t pgd_unittest_corrupt_gorilla_entries(void) {
     size_t errors = 0;
 
-    PGD *pg_collector = pgd_create(RRDENG_PAGE_TYPE_GORILLA_32BIT, 2);
-    pgd_append_point(pg_collector, 1, 666, 666, 666, 1, 0, SN_DEFAULT_FLAGS, 0);
+    PGD *pg_collector = pgd_unittest_create(RRDENG_PAGE_TYPE_GORILLA_32BIT, 2);
+    pgd_unittest_append_point(pg_collector, 1, 666, 666, 666, 1, 0, SN_DEFAULT_FLAGS, 0);
 
-    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    uint32_t size_in_bytes = pgd_unittest_disk_footprint(pg_collector);
     auto *disk_buffer = static_cast<uint32_t *>(mallocz(size_in_bytes));
-    pgd_copy_to_extent(pg_collector, reinterpret_cast<uint8_t *>(disk_buffer), size_in_bytes);
+    pgd_unittest_copy_to_extent(pg_collector, reinterpret_cast<uint8_t *>(disk_buffer), size_in_bytes);
 
     auto *gbuf = reinterpret_cast<gorilla_buffer_t *>(disk_buffer);
     gbuf->header.entries++;
 
-    PGD *pg_disk = pgd_create_from_disk_data(
+    PGD *pg_disk = pgd_unittest_create_from_disk_data(
         RRDENG_PAGE_TYPE_GORILLA_32BIT, disk_buffer, size_in_bytes);
     PGD_EXPECT(pg_disk != PGD_EMPTY);
-    PGD_EXPECT(pgd_slots_used(pg_disk) == 2);
+    PGD_EXPECT(pgd_unittest_slots_used(pg_disk) == 2);
 
     if(pg_disk != PGD_EMPTY) {
         PGDC cursor = {};
-        pgdc_reset(&cursor, pg_disk, 0, 1);
+        pgd_unittest_cursor_reset(&cursor, pg_disk, 0, 1);
 
         STORAGE_POINT sp = STORAGE_POINT_UNSET;
         sp.start_time_s = 0;
         sp.end_time_s = 1;
-        PGD_EXPECT(pgdc_get_next_point(&cursor, 0, &sp));
+        PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 0, &sp));
         PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 1);
         PGD_EXPECT(storage_point_is_complete(sp));
         PGD_EXPECT(sp.min == 666 && sp.max == 666 && sp.sum == 666);
@@ -172,7 +202,7 @@ static size_t pgd_unittest_corrupt_gorilla_entries(void) {
 
         sp.start_time_s = 1;
         sp.end_time_s = 2;
-        PGD_EXPECT(!pgdc_get_next_point(&cursor, 1, &sp));
+        PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 1, &sp));
         PGD_EXPECT(sp.start_time_s == 1 && sp.end_time_s == 2);
         PGD_EXPECT(storage_point_is_gap(sp));
         PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
@@ -180,10 +210,10 @@ static size_t pgd_unittest_corrupt_gorilla_entries(void) {
         PGD_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
         PGD_EXPECT(sp.flags == SN_FLAG_NONE);
 
-        pgd_free(pg_disk);
+        pgd_unittest_free(pg_disk);
     }
 
-    pgd_free(pg_collector);
+    pgd_unittest_free(pg_collector);
     freez(disk_buffer);
     return errors;
 }
@@ -195,16 +225,16 @@ int pgd_storage_point_unittest(void) {
     STORAGE_POINT sp = STORAGE_POINT_UNSET;
     sp.start_time_s = 10;
     sp.end_time_s = 11;
-    pgdc_reset(&cursor, nullptr, UINT32_MAX, 0);
+    pgd_unittest_cursor_reset(&cursor, nullptr, UINT32_MAX, 0);
     PGD_EXPECT(cursor.slots_per_point == 1);
-    PGD_EXPECT(!pgdc_get_next_point(&cursor, 0, &sp));
+    PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 0, &sp));
     PGD_EXPECT(storage_point_is_gap(sp) && sp.gap_count == 1);
 
     sp.start_time_s = 10;
     sp.end_time_s = 65546;
-    pgdc_reset(&cursor, nullptr, UINT32_MAX, 65536);
+    pgd_unittest_cursor_reset(&cursor, nullptr, UINT32_MAX, 65536);
     PGD_EXPECT(cursor.slots_per_point == 65536);
-    PGD_EXPECT(!pgdc_get_next_point(&cursor, 0, &sp));
+    PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 0, &sp));
     PGD_EXPECT(storage_point_is_gap(sp) && sp.gap_count == 65536);
 
     errors += pgd_unittest_tier0(RRDENG_PAGE_TYPE_GORILLA_32BIT);

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -26,6 +26,12 @@ bool operator==(const STORAGE_POINT lhs, const STORAGE_POINT rhs) {
     if (lhs.count != rhs.count)
         return false;
 
+    if (lhs.gap_count != rhs.gap_count)
+        return false;
+
+    if (lhs.anomaly_count != rhs.anomaly_count)
+        return false;
+
     if (lhs.flags != rhs.flags)
         return false;
 
@@ -35,6 +41,190 @@ bool operator==(const STORAGE_POINT lhs, const STORAGE_POINT rhs) {
 // TODO: use value-parameterized tests
 // http://google.github.io/googletest/advanced.html#value-parameterized-tests
 static uint8_t page_type = PAGE_GORILLA_METRICS;
+
+static STORAGE_POINT numeric_point(
+    time_t start_time_s,
+    time_t end_time_s,
+    NETDATA_DOUBLE min,
+    NETDATA_DOUBLE max,
+    NETDATA_DOUBLE sum,
+    uint32_t count,
+    uint32_t gap_count,
+    uint32_t anomaly_count,
+    SN_FLAGS flags = SN_FLAG_NONE) {
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    sp.min = min;
+    sp.max = max;
+    sp.sum = sum;
+    sp.start_time_s = start_time_s;
+    sp.end_time_s = end_time_s;
+    sp.count = count;
+    sp.anomaly_count = anomaly_count;
+    sp.flags = flags;
+    sp.gap_count = gap_count;
+    return sp;
+}
+
+TEST(StoragePoint, StateContractAndSize) {
+#if UINTPTR_MAX == UINT64_MAX
+    EXPECT_EQ(sizeof(STORAGE_POINT), 56u);
+#endif
+
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    EXPECT_TRUE(storage_point_is_unset(sp));
+    EXPECT_FALSE(storage_point_has_value(sp));
+    EXPECT_FALSE(storage_point_is_gap(sp));
+    EXPECT_FALSE(storage_point_is_partial(sp));
+    EXPECT_EQ(storage_point_slots(sp), 0u);
+
+    storage_point_empty(sp, 10, 20);
+    EXPECT_FALSE(storage_point_is_unset(sp));
+    EXPECT_FALSE(storage_point_has_value(sp));
+    EXPECT_TRUE(storage_point_is_gap(sp));
+    EXPECT_FALSE(storage_point_is_partial(sp));
+    EXPECT_EQ(sp.count, 0u);
+    EXPECT_EQ(sp.gap_count, 1u);
+    EXPECT_EQ(storage_point_slots(sp), 1u);
+
+    sp = numeric_point(10, 20, 1, 2, 3, 2, 0, 1);
+    EXPECT_TRUE(storage_point_has_value(sp));
+    EXPECT_TRUE(storage_point_is_complete(sp));
+    EXPECT_FALSE(storage_point_is_partial(sp));
+    EXPECT_EQ(storage_point_slots(sp), 2u);
+
+    sp.gap_count = 3;
+    EXPECT_TRUE(storage_point_has_value(sp));
+    EXPECT_FALSE(storage_point_is_complete(sp));
+    EXPECT_TRUE(storage_point_is_partial(sp));
+    EXPECT_EQ(storage_point_slots(sp), 5u);
+}
+
+TEST(StoragePoint, MergePreservesGapEvidenceInEitherOrder) {
+    STORAGE_POINT gap;
+    storage_point_empty(gap, 0, 10);
+    STORAGE_POINT numeric = numeric_point(10, 20, 2, 5, 7, 2, 1, 1, SN_FLAG_RESET);
+
+    STORAGE_POINT gap_first = gap;
+    storage_point_merge_to(gap_first, numeric);
+    EXPECT_EQ(gap_first.start_time_s, 0);
+    EXPECT_EQ(gap_first.end_time_s, 20);
+    EXPECT_EQ(gap_first.min, 2);
+    EXPECT_EQ(gap_first.max, 5);
+    EXPECT_EQ(gap_first.sum, 7);
+    EXPECT_EQ(gap_first.count, 2u);
+    EXPECT_EQ(gap_first.gap_count, 2u);
+    EXPECT_EQ(gap_first.anomaly_count, 1u);
+    EXPECT_TRUE(gap_first.flags & SN_FLAG_RESET);
+    EXPECT_TRUE(storage_point_is_partial(gap_first));
+
+    STORAGE_POINT numeric_first = numeric;
+    storage_point_merge_to(numeric_first, gap);
+    EXPECT_EQ(numeric_first, gap_first);
+
+    STORAGE_POINT second_gap;
+    storage_point_empty(second_gap, 20, 30);
+    storage_point_merge_to(gap, second_gap);
+    EXPECT_TRUE(storage_point_is_gap(gap));
+    EXPECT_EQ(gap.start_time_s, 0);
+    EXPECT_EQ(gap.end_time_s, 30);
+    EXPECT_EQ(gap.gap_count, 2u);
+}
+
+TEST(StoragePoint, AddPreservesGapEvidence) {
+    STORAGE_POINT dst = numeric_point(0, 10, 2, 5, 7, 2, 1, 1);
+    STORAGE_POINT src = numeric_point(10, 20, 3, 7, 11, 3, 2, 2);
+    storage_point_add_to(dst, src);
+
+    EXPECT_EQ(dst.start_time_s, 0);
+    EXPECT_EQ(dst.end_time_s, 20);
+    EXPECT_EQ(dst.min, 5);
+    EXPECT_EQ(dst.max, 12);
+    EXPECT_EQ(dst.sum, 18);
+    EXPECT_EQ(dst.count, 5u);
+    EXPECT_EQ(dst.gap_count, 3u);
+    EXPECT_EQ(dst.anomaly_count, 3u);
+    EXPECT_TRUE(storage_point_is_partial(dst));
+
+    STORAGE_POINT gap;
+    storage_point_empty(gap, 20, 30);
+    storage_point_add_to(dst, gap);
+    EXPECT_EQ(dst.sum, 18);
+    EXPECT_EQ(dst.count, 5u);
+    EXPECT_EQ(dst.gap_count, 4u);
+}
+
+TEST(StoragePoint, LegacyTierSlotNormalization) {
+    STORAGE_POINT partial = numeric_point(0, 60, 10, 10, 400, 40, 0, 0);
+    storage_point_normalize_legacy_slots(partial, 60);
+    EXPECT_EQ(partial.count, 40u);
+    EXPECT_EQ(partial.gap_count, 20u);
+    EXPECT_TRUE(storage_point_is_partial(partial));
+
+    STORAGE_POINT overfull = numeric_point(0, 60, 10, 10, 800, 80, 0, 0);
+    storage_point_normalize_legacy_slots(overfull, 60);
+    EXPECT_EQ(overfull.count, 80u);
+    EXPECT_EQ(overfull.gap_count, 0u);
+    EXPECT_TRUE(storage_point_is_complete(overfull));
+
+    STORAGE_POINT gap;
+    storage_point_empty(gap, 0, 60);
+    storage_point_normalize_legacy_slots(gap, 60);
+    EXPECT_EQ(gap.count, 0u);
+    EXPECT_EQ(gap.gap_count, 60u);
+    EXPECT_TRUE(storage_point_is_gap(gap));
+}
+
+TEST(PGD, DecodesTier0PointStatesExactly) {
+    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_GORILLA_32BIT, 2);
+    pgd_append_point(pg, 1, 42, 42, 42, 1, 0, SN_FLAG_NOT_ANOMALOUS, 0);
+    pgd_append_point(pg, 2, NAN, NAN, NAN, 0, 0, SN_FLAG_NONE, 1);
+
+    PGDC cursor;
+    pgdc_reset(&cursor, pg, 0, 1);
+
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    sp.start_time_s = 0;
+    sp.end_time_s = 1;
+    EXPECT_TRUE(pgdc_get_next_point(&cursor, 0, &sp));
+    EXPECT_TRUE(storage_point_is_complete(sp));
+    EXPECT_EQ(sp.count, 1u);
+    EXPECT_EQ(sp.gap_count, 0u);
+
+    sp.start_time_s = 1;
+    sp.end_time_s = 2;
+    EXPECT_TRUE(pgdc_get_next_point(&cursor, 1, &sp));
+    EXPECT_TRUE(storage_point_is_gap(sp));
+    EXPECT_EQ(sp.count, 0u);
+    EXPECT_EQ(sp.gap_count, 1u);
+
+    pgd_free(pg);
+}
+
+TEST(PGD, ReconstructsLegacyTierGapCount) {
+    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 2);
+    pgd_append_point(pg, 60, 400, 10, 10, 40, 0, SN_FLAG_NOT_ANOMALOUS, 0);
+    pgd_append_point(pg, 120, NAN, NAN, NAN, 0, 0, SN_FLAG_NONE, 1);
+
+    PGDC cursor;
+    pgdc_reset(&cursor, pg, 0, 60);
+
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    sp.start_time_s = 0;
+    sp.end_time_s = 60;
+    EXPECT_TRUE(pgdc_get_next_point(&cursor, 0, &sp));
+    EXPECT_TRUE(storage_point_is_partial(sp));
+    EXPECT_EQ(sp.count, 40u);
+    EXPECT_EQ(sp.gap_count, 20u);
+
+    sp.start_time_s = 60;
+    sp.end_time_s = 120;
+    EXPECT_TRUE(pgdc_get_next_point(&cursor, 1, &sp));
+    EXPECT_TRUE(storage_point_is_gap(sp));
+    EXPECT_EQ(sp.count, 0u);
+    EXPECT_EQ(sp.gap_count, 60u);
+
+    pgd_free(pg);
+}
 
 static size_t slots_for_page(size_t n) {
     switch (page_type) {
@@ -58,7 +248,7 @@ TEST(PGD, EmptyOrNull) {
     EXPECT_EQ(pgd_memory_footprint(pg), 0);
     EXPECT_EQ(pgd_disk_footprint(pg), 0);
 
-    pgdc_reset(&cursor, pg, 0);
+    pgdc_reset(&cursor, pg, 0, 1);
     EXPECT_FALSE(pgdc_get_next_point(&cursor, 0, &sp));
 
     pgd_free(pg);
@@ -71,7 +261,7 @@ TEST(PGD, EmptyOrNull) {
     EXPECT_EQ(pgd_disk_footprint(pg), 0);
     EXPECT_FALSE(pgdc_get_next_point(&cursor, 0, &sp));
 
-    pgdc_reset(&cursor, pg, 0);
+    pgdc_reset(&cursor, pg, 0, 1);
     EXPECT_FALSE(pgdc_get_next_point(&cursor, 0, &sp));
 
     pgd_free(pg);
@@ -108,7 +298,7 @@ TEST(PGD, CursorFullPage) {
 
     for (size_t i = 0; i != 2; i++) {
         PGDC cursor;
-        pgdc_reset(&cursor, pg, 0);
+        pgdc_reset(&cursor, pg, 0, 1);
 
         STORAGE_POINT sp;
         for (size_t slot = 0; slot != slots; slot++) {
@@ -126,7 +316,7 @@ TEST(PGD, CursorFullPage) {
 
     for (size_t i = 0; i != 2; i++) {
         PGDC cursor;
-        pgdc_reset(&cursor, pg, slots / 2);
+        pgdc_reset(&cursor, pg, slots / 2, 1);
 
         STORAGE_POINT sp;
         for (size_t slot = slots / 2; slot != slots; slot++) {
@@ -145,7 +335,7 @@ TEST(PGD, CursorFullPage) {
     // out of bounds seek
     {
         PGDC cursor;
-        pgdc_reset(&cursor, pg, 2 * slots);
+        pgdc_reset(&cursor, pg, 2 * slots, 1);
 
         STORAGE_POINT sp;
         EXPECT_FALSE(pgdc_get_next_point(&cursor, 2 * slots, &sp));
@@ -165,7 +355,7 @@ TEST(PGD, CursorHalfPage) {
     for (size_t slot = 0; slot != slots / 2; slot++)
         pgd_append_point(pg, slot, slot, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
 
-    pgdc_reset(&cursor, pg, 0);
+    pgdc_reset(&cursor, pg, 0, 1);
 
     for (size_t slot = 0; slot != slots / 2; slot++) {
         EXPECT_TRUE(pgdc_get_next_point(&cursor, slot, &sp));
@@ -181,7 +371,7 @@ TEST(PGD, CursorHalfPage) {
     // reset pgdc to the end of the page, we should not be getting more
     // points even if the page has grown in between.
 
-    pgdc_reset(&cursor, pg, slots / 2);
+    pgdc_reset(&cursor, pg, slots / 2, 1);
 
     for (size_t slot = slots / 2; slot != slots; slot++)
         pgd_append_point(pg, slot, slot, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
@@ -356,8 +546,8 @@ TEST(PGD, Roundtrip) {
         PGDC cursor_collector;
         PGDC cursor_disk;
 
-        pgdc_reset(&cursor_collector, pg_collector, i * 1024);
-        pgdc_reset(&cursor_disk, pg_disk, i * 1024);
+        pgdc_reset(&cursor_collector, pg_collector, i * 1024, 1);
+        pgdc_reset(&cursor_disk, pg_disk, i * 1024, 1);
 
         STORAGE_POINT sp_collector = {};
         STORAGE_POINT sp_disk = {};
@@ -418,7 +608,7 @@ TEST(PGD, StopCorruptGorillaDiskEntriesAtEncodedBits) {
     EXPECT_EQ(pgd_slots_used(pg_disk), 2);
 
     PGDC cursor;
-    pgdc_reset(&cursor, pg_disk, 0);
+    pgdc_reset(&cursor, pg_disk, 0, 1);
 
     STORAGE_POINT sp = {};
     EXPECT_TRUE(pgdc_get_next_point(&cursor, 0, &sp));

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -1,6 +1,223 @@
 #include "page.h"
 #include "page_test.h"
 
+static size_t pgd_unittest_tier0(uint8_t page_type) {
+    size_t errors = 0;
+
+#define PGD_EXPECT(condition) do {                                                                                       \
+    if(!(condition)) {                                                                                                  \
+        fprintf(stderr, "PGD storage-point unittest failed at %s:%d: %s\n", __FILE__, __LINE__, #condition);           \
+        errors++;                                                                                                       \
+    }                                                                                                                   \
+} while(0)
+
+    PGD *pg = pgd_create(page_type, 4);
+    pgd_append_point(pg, 1, 42, 42, 42, 1, 0, SN_DEFAULT_FLAGS, 0);
+    pgd_append_point(pg, 2, NAN, NAN, NAN, 0, 0, SN_EMPTY_SLOT, 1);
+    pgd_append_point(pg, 3, -7, -7, -7, 1, 0, SN_FLAG_RESET, 2);
+
+    PGDC cursor = {};
+    pgdc_reset(&cursor, pg, 0, 1);
+
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    sp.start_time_s = 0;
+    sp.end_time_s = 1;
+    PGD_EXPECT(pgdc_get_next_point(&cursor, 0, &sp));
+    PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 1);
+    PGD_EXPECT(storage_point_is_complete(sp));
+    PGD_EXPECT(sp.min == 42 && sp.max == 42 && sp.sum == 42);
+    PGD_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags & SN_FLAG_NOT_ANOMALOUS);
+
+    sp.start_time_s = 1;
+    sp.end_time_s = 2;
+    PGD_EXPECT(pgdc_get_next_point(&cursor, 1, &sp));
+    PGD_EXPECT(sp.start_time_s == 1 && sp.end_time_s == 2);
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    sp.start_time_s = 2;
+    sp.end_time_s = 3;
+    PGD_EXPECT(pgdc_get_next_point(&cursor, 2, &sp));
+    PGD_EXPECT(sp.start_time_s == 2 && sp.end_time_s == 3);
+    PGD_EXPECT(storage_point_is_complete(sp));
+    PGD_EXPECT(sp.min == -7 && sp.max == -7 && sp.sum == -7);
+    PGD_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 1);
+    PGD_EXPECT((sp.flags & SN_FLAG_RESET) && !(sp.flags & SN_FLAG_NOT_ANOMALOUS));
+
+    sp.start_time_s = 3;
+    sp.end_time_s = 4;
+    PGD_EXPECT(!pgdc_get_next_point(&cursor, 3, &sp));
+    PGD_EXPECT(sp.start_time_s == 3 && sp.end_time_s == 4);
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    pgd_free(pg);
+    return errors;
+}
+
+static size_t pgd_unittest_tier1(void) {
+    size_t errors = 0;
+
+    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 5);
+    pgd_append_point(pg, 60, 400, 9, 11, 40, 4, SN_DEFAULT_FLAGS, 0);
+    pgd_append_point(pg, 120, 800, 9, 11, 80, 0, SN_DEFAULT_FLAGS, 1);
+    pgd_append_point(pg, 180, 300, 9, 11, 0, 0, SN_DEFAULT_FLAGS, 2);
+    pgd_append_point(pg, 240, NAN, NAN, NAN, 7, 1, SN_DEFAULT_FLAGS, 3);
+
+    PGDC cursor = {};
+    pgdc_reset(&cursor, pg, 0, 60);
+
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    sp.start_time_s = 0;
+    sp.end_time_s = 60;
+    PGD_EXPECT(pgdc_get_next_point(&cursor, 0, &sp));
+    PGD_EXPECT(storage_point_is_partial(sp));
+    PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 60);
+    PGD_EXPECT(sp.min == 9 && sp.max == 11 && sp.sum == 400);
+    PGD_EXPECT(sp.count == 40 && sp.gap_count == 20 && sp.anomaly_count == 4);
+    PGD_EXPECT(!(sp.flags & SN_FLAG_NOT_ANOMALOUS));
+
+    sp.start_time_s = 60;
+    sp.end_time_s = 120;
+    PGD_EXPECT(pgdc_get_next_point(&cursor, 1, &sp));
+    PGD_EXPECT(storage_point_is_complete(sp));
+    PGD_EXPECT(sp.start_time_s == 60 && sp.end_time_s == 120);
+    PGD_EXPECT(sp.min == 9 && sp.max == 11 && sp.sum == 800);
+    PGD_EXPECT(sp.count == 80 && sp.gap_count == 0 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags & SN_FLAG_NOT_ANOMALOUS);
+
+    sp.start_time_s = 120;
+    sp.end_time_s = 180;
+    PGD_EXPECT(pgdc_get_next_point(&cursor, 2, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 120 && sp.end_time_s == 180);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 60 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    sp.start_time_s = 180;
+    sp.end_time_s = 240;
+    PGD_EXPECT(pgdc_get_next_point(&cursor, 3, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 180 && sp.end_time_s == 240);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 60 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    sp.start_time_s = 240;
+    sp.end_time_s = 300;
+    PGD_EXPECT(!pgdc_get_next_point(&cursor, 4, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 240 && sp.end_time_s == 300);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 60 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    pgdc_reset(&cursor, pg, 2, 65536);
+    sp.start_time_s = 0;
+    sp.end_time_s = 65536;
+    PGD_EXPECT(pgdc_get_next_point(&cursor, 2, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 65536);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 65536);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    pgd_free(pg);
+    return errors;
+}
+
+static size_t pgd_unittest_corrupt_gorilla_entries(void) {
+    size_t errors = 0;
+
+    PGD *pg_collector = pgd_create(RRDENG_PAGE_TYPE_GORILLA_32BIT, 2);
+    pgd_append_point(pg_collector, 1, 666, 666, 666, 1, 0, SN_DEFAULT_FLAGS, 0);
+
+    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    auto *disk_buffer = static_cast<uint32_t *>(mallocz(size_in_bytes));
+    pgd_copy_to_extent(pg_collector, reinterpret_cast<uint8_t *>(disk_buffer), size_in_bytes);
+
+    auto *gbuf = reinterpret_cast<gorilla_buffer_t *>(disk_buffer);
+    gbuf->header.entries++;
+
+    PGD *pg_disk = pgd_create_from_disk_data(
+        RRDENG_PAGE_TYPE_GORILLA_32BIT, disk_buffer, size_in_bytes);
+    PGD_EXPECT(pg_disk != PGD_EMPTY);
+    PGD_EXPECT(pgd_slots_used(pg_disk) == 2);
+
+    if(pg_disk != PGD_EMPTY) {
+        PGDC cursor = {};
+        pgdc_reset(&cursor, pg_disk, 0, 1);
+
+        STORAGE_POINT sp = STORAGE_POINT_UNSET;
+        sp.start_time_s = 0;
+        sp.end_time_s = 1;
+        PGD_EXPECT(pgdc_get_next_point(&cursor, 0, &sp));
+        PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 1);
+        PGD_EXPECT(storage_point_is_complete(sp));
+        PGD_EXPECT(sp.min == 666 && sp.max == 666 && sp.sum == 666);
+        PGD_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 0);
+        PGD_EXPECT(sp.flags & SN_FLAG_NOT_ANOMALOUS);
+
+        sp.start_time_s = 1;
+        sp.end_time_s = 2;
+        PGD_EXPECT(!pgdc_get_next_point(&cursor, 1, &sp));
+        PGD_EXPECT(sp.start_time_s == 1 && sp.end_time_s == 2);
+        PGD_EXPECT(storage_point_is_gap(sp));
+        PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+                   !netdata_double_isnumber(sp.sum));
+        PGD_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
+        PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+        pgd_free(pg_disk);
+    }
+
+    pgd_free(pg_collector);
+    freez(disk_buffer);
+    return errors;
+}
+
+int pgd_storage_point_unittest(void) {
+    size_t errors = 0;
+
+    PGDC cursor = {};
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    sp.start_time_s = 10;
+    sp.end_time_s = 11;
+    pgdc_reset(&cursor, nullptr, UINT32_MAX, 0);
+    PGD_EXPECT(cursor.slots_per_point == 1);
+    PGD_EXPECT(!pgdc_get_next_point(&cursor, 0, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp) && sp.gap_count == 1);
+
+    sp.start_time_s = 10;
+    sp.end_time_s = 65546;
+    pgdc_reset(&cursor, nullptr, UINT32_MAX, 65536);
+    PGD_EXPECT(cursor.slots_per_point == 65536);
+    PGD_EXPECT(!pgdc_get_next_point(&cursor, 0, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp) && sp.gap_count == 65536);
+
+    errors += pgd_unittest_tier0(RRDENG_PAGE_TYPE_GORILLA_32BIT);
+    errors += pgd_unittest_tier0(RRDENG_PAGE_TYPE_ARRAY_32BIT);
+    errors += pgd_unittest_tier1();
+    errors += pgd_unittest_corrupt_gorilla_entries();
+
+    fprintf(stderr, "PGD storage-point unittests: %s\n", errors ? "FAILED" : "PASSED");
+    return (int)errors;
+}
+
+#undef PGD_EXPECT
+
 #ifdef HAVE_GTEST
 
 #include <gtest/gtest.h>
@@ -41,189 +258,6 @@ bool operator==(const STORAGE_POINT lhs, const STORAGE_POINT rhs) {
 // TODO: use value-parameterized tests
 // http://google.github.io/googletest/advanced.html#value-parameterized-tests
 static uint8_t page_type = PAGE_GORILLA_METRICS;
-
-static STORAGE_POINT numeric_point(
-    time_t start_time_s,
-    time_t end_time_s,
-    NETDATA_DOUBLE min,
-    NETDATA_DOUBLE max,
-    NETDATA_DOUBLE sum,
-    uint32_t count,
-    uint32_t gap_count,
-    uint32_t anomaly_count,
-    SN_FLAGS flags = SN_FLAG_NONE) {
-    STORAGE_POINT sp = STORAGE_POINT_UNSET;
-    sp.min = min;
-    sp.max = max;
-    sp.sum = sum;
-    sp.start_time_s = start_time_s;
-    sp.end_time_s = end_time_s;
-    sp.count = count;
-    sp.anomaly_count = anomaly_count;
-    sp.flags = flags;
-    sp.gap_count = gap_count;
-    return sp;
-}
-
-TEST(StoragePoint, StateContractAndSize) {
-#if UINTPTR_MAX == UINT64_MAX
-    EXPECT_EQ(sizeof(STORAGE_POINT), 56u);
-    EXPECT_EQ(sizeof(PGDC), 80u);
-#endif
-
-    PGDC cursor;
-    pgdc_reset(&cursor, nullptr, UINT32_MAX, 0);
-    EXPECT_EQ(cursor.slots_per_point, 1u);
-    pgdc_reset(&cursor, nullptr, UINT32_MAX, 65536);
-    EXPECT_EQ(cursor.slots_per_point, 65536u);
-
-    STORAGE_POINT sp = STORAGE_POINT_UNSET;
-    EXPECT_TRUE(storage_point_is_unset(sp));
-    EXPECT_FALSE(storage_point_has_value(sp));
-    EXPECT_FALSE(storage_point_is_gap(sp));
-    EXPECT_FALSE(storage_point_is_partial(sp));
-    EXPECT_EQ(storage_point_slots(sp), 0u);
-
-    storage_point_empty(sp, 10, 20);
-    EXPECT_FALSE(storage_point_is_unset(sp));
-    EXPECT_FALSE(storage_point_has_value(sp));
-    EXPECT_TRUE(storage_point_is_gap(sp));
-    EXPECT_FALSE(storage_point_is_partial(sp));
-    EXPECT_EQ(sp.count, 0u);
-    EXPECT_EQ(sp.gap_count, 1u);
-    EXPECT_EQ(storage_point_slots(sp), 1u);
-
-    sp = numeric_point(10, 20, 1, 2, 3, 2, 0, 1);
-    EXPECT_TRUE(storage_point_has_value(sp));
-    EXPECT_TRUE(storage_point_is_complete(sp));
-    EXPECT_FALSE(storage_point_is_partial(sp));
-    EXPECT_EQ(storage_point_slots(sp), 2u);
-
-    sp.gap_count = 3;
-    EXPECT_TRUE(storage_point_has_value(sp));
-    EXPECT_FALSE(storage_point_is_complete(sp));
-    EXPECT_TRUE(storage_point_is_partial(sp));
-    EXPECT_EQ(storage_point_slots(sp), 5u);
-}
-
-TEST(StoragePoint, MergePreservesGapEvidenceInEitherOrder) {
-    STORAGE_POINT gap;
-    storage_point_empty(gap, 0, 10);
-    STORAGE_POINT numeric = numeric_point(10, 20, 2, 5, 7, 2, 1, 1, SN_FLAG_RESET);
-
-    STORAGE_POINT gap_first = gap;
-    storage_point_merge_to(gap_first, numeric);
-    EXPECT_EQ(gap_first.start_time_s, 0);
-    EXPECT_EQ(gap_first.end_time_s, 20);
-    EXPECT_EQ(gap_first.min, 2);
-    EXPECT_EQ(gap_first.max, 5);
-    EXPECT_EQ(gap_first.sum, 7);
-    EXPECT_EQ(gap_first.count, 2u);
-    EXPECT_EQ(gap_first.gap_count, 2u);
-    EXPECT_EQ(gap_first.anomaly_count, 1u);
-    EXPECT_TRUE(gap_first.flags & SN_FLAG_RESET);
-    EXPECT_TRUE(storage_point_is_partial(gap_first));
-
-    STORAGE_POINT numeric_first = numeric;
-    storage_point_merge_to(numeric_first, gap);
-    EXPECT_EQ(numeric_first, gap_first);
-
-    STORAGE_POINT second_gap;
-    storage_point_empty(second_gap, 20, 30);
-    storage_point_merge_to(gap, second_gap);
-    EXPECT_TRUE(storage_point_is_gap(gap));
-    EXPECT_EQ(gap.start_time_s, 0);
-    EXPECT_EQ(gap.end_time_s, 30);
-    EXPECT_EQ(gap.gap_count, 2u);
-}
-
-TEST(StoragePoint, AddPreservesGapEvidence) {
-    STORAGE_POINT dst = numeric_point(0, 10, 2, 5, 7, 2, 1, 1);
-    STORAGE_POINT src = numeric_point(10, 20, 3, 7, 11, 3, 2, 2);
-    storage_point_add_to(dst, src);
-
-    EXPECT_EQ(dst.start_time_s, 0);
-    EXPECT_EQ(dst.end_time_s, 20);
-    EXPECT_EQ(dst.min, 5);
-    EXPECT_EQ(dst.max, 12);
-    EXPECT_EQ(dst.sum, 18);
-    EXPECT_EQ(dst.count, 5u);
-    EXPECT_EQ(dst.gap_count, 3u);
-    EXPECT_EQ(dst.anomaly_count, 3u);
-    EXPECT_TRUE(storage_point_is_partial(dst));
-
-    STORAGE_POINT gap;
-    storage_point_empty(gap, 20, 30);
-    storage_point_add_to(dst, gap);
-    EXPECT_EQ(dst.sum, 18);
-    EXPECT_EQ(dst.count, 5u);
-    EXPECT_EQ(dst.gap_count, 4u);
-}
-
-TEST(PGD, DecodesTier0PointStatesExactly) {
-    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_GORILLA_32BIT, 2);
-    pgd_append_point(pg, 1, 42, 42, 42, 1, 0, SN_FLAG_NOT_ANOMALOUS, 0);
-    pgd_append_point(pg, 2, NAN, NAN, NAN, 0, 0, SN_FLAG_NONE, 1);
-
-    PGDC cursor;
-    pgdc_reset(&cursor, pg, 0, 1);
-
-    STORAGE_POINT sp = STORAGE_POINT_UNSET;
-    sp.start_time_s = 0;
-    sp.end_time_s = 1;
-    EXPECT_TRUE(pgdc_get_next_point(&cursor, 0, &sp));
-    EXPECT_TRUE(storage_point_is_complete(sp));
-    EXPECT_EQ(sp.count, 1u);
-    EXPECT_EQ(sp.gap_count, 0u);
-
-    sp.start_time_s = 1;
-    sp.end_time_s = 2;
-    EXPECT_TRUE(pgdc_get_next_point(&cursor, 1, &sp));
-    EXPECT_TRUE(storage_point_is_gap(sp));
-    EXPECT_EQ(sp.count, 0u);
-    EXPECT_EQ(sp.gap_count, 1u);
-
-    pgd_free(pg);
-}
-
-TEST(PGD, ReconstructsLegacyTierGapCount) {
-    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 3);
-    pgd_append_point(pg, 60, 400, 10, 10, 40, 0, SN_FLAG_NOT_ANOMALOUS, 0);
-    pgd_append_point(pg, 120, 800, 10, 10, 80, 0, SN_FLAG_NOT_ANOMALOUS, 1);
-    pgd_append_point(pg, 180, NAN, NAN, NAN, 1, 0, SN_FLAG_NONE, 2);
-
-    PGDC cursor;
-    pgdc_reset(&cursor, pg, 0, 60);
-
-    STORAGE_POINT sp = STORAGE_POINT_UNSET;
-    sp.start_time_s = 0;
-    sp.end_time_s = 60;
-    EXPECT_TRUE(pgdc_get_next_point(&cursor, 0, &sp));
-    EXPECT_TRUE(storage_point_is_partial(sp));
-    EXPECT_EQ(sp.count, 40u);
-    EXPECT_EQ(sp.gap_count, 20u);
-
-    sp.start_time_s = 60;
-    sp.end_time_s = 120;
-    EXPECT_TRUE(pgdc_get_next_point(&cursor, 1, &sp));
-    EXPECT_TRUE(storage_point_is_complete(sp));
-    EXPECT_EQ(sp.count, 80u);
-    EXPECT_EQ(sp.gap_count, 0u);
-
-    sp.start_time_s = 120;
-    sp.end_time_s = 180;
-    EXPECT_TRUE(pgdc_get_next_point(&cursor, 2, &sp));
-    EXPECT_TRUE(storage_point_is_gap(sp));
-    EXPECT_EQ(sp.count, 0u);
-    EXPECT_EQ(sp.gap_count, 60u);
-
-    pgdc_reset(&cursor, pg, 2, 65536);
-    EXPECT_TRUE(pgdc_get_next_point(&cursor, 2, &sp));
-    EXPECT_TRUE(storage_point_is_gap(sp));
-    EXPECT_EQ(sp.gap_count, 65536u);
-
-    pgd_free(pg);
-}
 
 static size_t slots_for_page(size_t n) {
     switch (page_type) {

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -156,7 +156,7 @@ static size_t pgd_unittest_tier1(void) {
     pgd_unittest_cursor_reset(&cursor, wrapped_count_pg, 0, 65536);
     sp.start_time_s = 0;
     sp.end_time_s = 65536;
-    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 2, &sp));
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 0, &sp));
     PGD_EXPECT(storage_point_is_complete(sp));
     PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 65536);
     PGD_EXPECT(sp.min == 1 && sp.max == 1 && sp.sum == 65536);

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -68,7 +68,14 @@ static STORAGE_POINT numeric_point(
 TEST(StoragePoint, StateContractAndSize) {
 #if UINTPTR_MAX == UINT64_MAX
     EXPECT_EQ(sizeof(STORAGE_POINT), 56u);
+    EXPECT_EQ(sizeof(PGDC), 80u);
 #endif
+
+    PGDC cursor;
+    pgdc_reset(&cursor, nullptr, UINT32_MAX, 0);
+    EXPECT_EQ(cursor.slots_per_point, 1u);
+    pgdc_reset(&cursor, nullptr, UINT32_MAX, 65536);
+    EXPECT_EQ(cursor.slots_per_point, 65536u);
 
     STORAGE_POINT sp = STORAGE_POINT_UNSET;
     EXPECT_TRUE(storage_point_is_unset(sp));
@@ -153,27 +160,6 @@ TEST(StoragePoint, AddPreservesGapEvidence) {
     EXPECT_EQ(dst.gap_count, 4u);
 }
 
-TEST(StoragePoint, LegacyTierSlotNormalization) {
-    STORAGE_POINT partial = numeric_point(0, 60, 10, 10, 400, 40, 0, 0);
-    storage_point_normalize_legacy_slots(partial, 60);
-    EXPECT_EQ(partial.count, 40u);
-    EXPECT_EQ(partial.gap_count, 20u);
-    EXPECT_TRUE(storage_point_is_partial(partial));
-
-    STORAGE_POINT overfull = numeric_point(0, 60, 10, 10, 800, 80, 0, 0);
-    storage_point_normalize_legacy_slots(overfull, 60);
-    EXPECT_EQ(overfull.count, 80u);
-    EXPECT_EQ(overfull.gap_count, 0u);
-    EXPECT_TRUE(storage_point_is_complete(overfull));
-
-    STORAGE_POINT gap;
-    storage_point_empty(gap, 0, 60);
-    storage_point_normalize_legacy_slots(gap, 60);
-    EXPECT_EQ(gap.count, 0u);
-    EXPECT_EQ(gap.gap_count, 60u);
-    EXPECT_TRUE(storage_point_is_gap(gap));
-}
-
 TEST(PGD, DecodesTier0PointStatesExactly) {
     PGD *pg = pgd_create(RRDENG_PAGE_TYPE_GORILLA_32BIT, 2);
     pgd_append_point(pg, 1, 42, 42, 42, 1, 0, SN_FLAG_NOT_ANOMALOUS, 0);
@@ -201,9 +187,10 @@ TEST(PGD, DecodesTier0PointStatesExactly) {
 }
 
 TEST(PGD, ReconstructsLegacyTierGapCount) {
-    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 2);
+    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 3);
     pgd_append_point(pg, 60, 400, 10, 10, 40, 0, SN_FLAG_NOT_ANOMALOUS, 0);
-    pgd_append_point(pg, 120, NAN, NAN, NAN, 0, 0, SN_FLAG_NONE, 1);
+    pgd_append_point(pg, 120, 800, 10, 10, 80, 0, SN_FLAG_NOT_ANOMALOUS, 1);
+    pgd_append_point(pg, 180, NAN, NAN, NAN, 1, 0, SN_FLAG_NONE, 2);
 
     PGDC cursor;
     pgdc_reset(&cursor, pg, 0, 60);
@@ -219,9 +206,21 @@ TEST(PGD, ReconstructsLegacyTierGapCount) {
     sp.start_time_s = 60;
     sp.end_time_s = 120;
     EXPECT_TRUE(pgdc_get_next_point(&cursor, 1, &sp));
+    EXPECT_TRUE(storage_point_is_complete(sp));
+    EXPECT_EQ(sp.count, 80u);
+    EXPECT_EQ(sp.gap_count, 0u);
+
+    sp.start_time_s = 120;
+    sp.end_time_s = 180;
+    EXPECT_TRUE(pgdc_get_next_point(&cursor, 2, &sp));
     EXPECT_TRUE(storage_point_is_gap(sp));
     EXPECT_EQ(sp.count, 0u);
     EXPECT_EQ(sp.gap_count, 60u);
+
+    pgdc_reset(&cursor, pg, 2, 65536);
+    EXPECT_TRUE(pgdc_get_next_point(&cursor, 2, &sp));
+    EXPECT_TRUE(storage_point_is_gap(sp));
+    EXPECT_EQ(sp.gap_count, 65536u);
 
     pgd_free(pg);
 }

--- a/src/database/engine/page_test.h
+++ b/src/database/engine/page_test.h
@@ -6,6 +6,9 @@ extern "C" {
 #endif
 
 int pgd_test(int argc, char *argv[]);
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
 int pgd_storage_point_unittest(void);
 
 #ifdef __cplusplus

--- a/src/database/engine/page_test.h
+++ b/src/database/engine/page_test.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 int pgd_test(int argc, char *argv[]);
+int pgd_storage_point_unittest(void);
 
 #ifdef __cplusplus
 }

--- a/src/database/engine/page_test_bridge.cc
+++ b/src/database/engine/page_test_bridge.cc
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "page_test_bridge.h"
+
+NOINLINE PGD *pgd_unittest_create(uint8_t type, uint32_t slots) {
+    return pgd_create(type, slots);
+}
+
+NOINLINE PGD *pgd_unittest_create_from_disk_data(uint8_t type, void *base, uint32_t size) {
+    return pgd_create_from_disk_data(type, base, size);
+}
+
+NOINLINE void pgd_unittest_free(PGD *pg) {
+    pgd_free(pg);
+}
+
+NOINLINE uint32_t pgd_unittest_slots_used(PGD *pg) {
+    return pgd_slots_used(pg);
+}
+
+NOINLINE bool pgd_unittest_is_empty(PGD *pg) {
+    return pgd_is_empty(pg);
+}
+
+NOINLINE uint32_t pgd_unittest_disk_footprint(PGD *pg) {
+    return pgd_disk_footprint(pg);
+}
+
+NOINLINE void pgd_unittest_copy_to_extent(PGD *pg, uint8_t *dst, uint32_t dst_size) {
+    pgd_copy_to_extent(pg, dst, dst_size);
+}
+
+NOINLINE size_t pgd_unittest_append_point(
+    PGD *pg,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags,
+    uint32_t expected_slot) {
+    return pgd_append_point(
+        pg, point_in_time_ut, n, min_value, max_value, count, anomaly_count, flags, expected_slot);
+}
+
+NOINLINE void pgd_unittest_cursor_reset(
+    PGDC *pgdc, PGD *pgd, uint32_t position, uint32_t slots_per_point) {
+    pgdc_reset(pgdc, pgd, position, slots_per_point);
+}
+
+NOINLINE bool pgd_unittest_cursor_next(
+    PGDC *pgdc, uint32_t expected_position, STORAGE_POINT *sp) {
+    return pgdc_get_next_point(pgdc, expected_position, sp);
+}

--- a/src/database/engine/page_test_bridge.h
+++ b/src/database/engine/page_test_bridge.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_DBENGINE_PAGE_TEST_BRIDGE_H
+#define NETDATA_DBENGINE_PAGE_TEST_BRIDGE_H
+
+#include "page.h"
+
+PGD *pgd_unittest_create(uint8_t type, uint32_t slots);
+PGD *pgd_unittest_create_from_disk_data(uint8_t type, void *base, uint32_t size);
+void pgd_unittest_free(PGD *pg);
+uint32_t pgd_unittest_slots_used(PGD *pg);
+bool pgd_unittest_is_empty(PGD *pg);
+uint32_t pgd_unittest_disk_footprint(PGD *pg);
+void pgd_unittest_copy_to_extent(PGD *pg, uint8_t *dst, uint32_t dst_size);
+
+size_t pgd_unittest_append_point(
+    PGD *pg,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags,
+    uint32_t expected_slot);
+
+void pgd_unittest_cursor_reset(PGDC *pgdc, PGD *pgd, uint32_t position, uint32_t slots_per_point);
+bool pgd_unittest_cursor_next(PGDC *pgdc, uint32_t expected_position, STORAGE_POINT *sp);
+
+#endif // NETDATA_DBENGINE_PAGE_TEST_BRIDGE_H

--- a/src/database/engine/page_test_bridge.h
+++ b/src/database/engine/page_test_bridge.h
@@ -5,6 +5,10 @@
 
 #include "page.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 PGD *pgd_unittest_create(uint8_t type, uint32_t slots);
 PGD *pgd_unittest_create_from_disk_data(uint8_t type, void *base, uint32_t size);
 void pgd_unittest_free(PGD *pg);
@@ -26,5 +30,9 @@ size_t pgd_unittest_append_point(
 
 void pgd_unittest_cursor_reset(PGDC *pgdc, PGD *pgd, uint32_t position, uint32_t slots_per_point);
 bool pgd_unittest_cursor_next(PGDC *pgdc, uint32_t expected_position, STORAGE_POINT *sp);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // NETDATA_DBENGINE_PAGE_TEST_BRIDGE_H

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -345,7 +345,7 @@ static void pgc_inject_gap(struct rrdengine_instance *ctx, METRIC *metric, time_
             .data = PGD_EMPTY,
     };
 
-    if(page_entry.start_time_s >= page_entry.end_time_s)
+    if(page_entry.start_time_s > page_entry.end_time_s)
         return;
 
     PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, page_entry, NULL);
@@ -399,9 +399,63 @@ static ALWAYS_INLINE_HOT size_t list_has_time_gaps(
         dt_s = nd_profile.update_every;
 
     size_t pages_pass2 = 0, pages_pass3 = 0;
-    while((pd = pdc_find_page_for_time(
-            JudyL_page_array, now_s, &gaps,
-            PDC_PAGE_PREPROCESSED, 0))) {
+    time_t covered_until_s = wanted_start_time_s;
+    bool have_page = false, last_page_is_empty = false, candidate_reached_end = false;
+
+    // Exhaustive selection must not weaken the supported metadata lookup the previous planner required.
+    time_t legacy_now_s = wanted_start_time_s;
+    uint32_t legacy_dt_s = dt_s;
+    bool legacy_done = false;
+
+    while(true) {
+        size_t ignored_lookup_gaps = 0;
+        pd = pdc_find_page_for_time(
+            JudyL_page_array, now_s, &ignored_lookup_gaps,
+            PDC_PAGE_PREPROCESSED, 0);
+        if(!pd)
+            break;
+
+        PDC_PAGE_STATUS status = __atomic_load_n(&pd->status, __ATOMIC_ACQUIRE);
+        uint32_t page_update_every_s = pd->update_every_s;
+        if(!page_update_every_s)
+            page_update_every_s = dt_s;
+
+        bool page_is_empty = status & PDC_PAGE_EMPTY;
+        bool candidate_gap = false;
+        if(have_page) {
+            if(page_is_empty) {
+                time_t expected_start_time_s = nd_time_t_add_saturating(covered_until_s, 1);
+                candidate_gap = pd->first_time_s > expected_start_time_s;
+            }
+            else {
+                candidate_gap = nd_time_t_add_compare(
+                    covered_until_s, page_update_every_s, pd->first_time_s) < 0;
+            }
+        }
+
+        bool legacy_gap = false;
+        if(!legacy_done && pd->last_time_s >= legacy_now_s) {
+            legacy_gap = pd->first_time_s > legacy_now_s;
+
+            if(pd->update_every_s)
+                legacy_dt_s = pd->update_every_s;
+
+            if(nd_time_t_add_compare(pd->last_time_s, legacy_dt_s, wanted_end_time_s) > 0)
+                legacy_done = true;
+            else
+                legacy_now_s = nd_time_t_add_saturating(pd->last_time_s, legacy_dt_s);
+        }
+
+        if(candidate_gap || legacy_gap) {
+            gaps++;
+
+            if(populate_gaps) {
+                time_t gap_start_time_s = have_page ?
+                    nd_time_t_add_saturating(covered_until_s, 1) : wanted_start_time_s;
+                time_t gap_end_time_s = nd_time_t_add_saturating(pd->first_time_s, -1);
+                pgc_inject_gap(ctx, metric, gap_start_time_s, gap_end_time_s);
+            }
+        }
 
         pd->status |= PDC_PAGE_PREPROCESSED;
         pages_pass2++;
@@ -409,18 +463,36 @@ static ALWAYS_INLINE_HOT size_t list_has_time_gaps(
         if(pd->update_every_s)
             dt_s = pd->update_every_s;
 
-        if(populate_gaps && pd->first_time_s > now_s)
-            pgc_inject_gap(ctx, metric, now_s, pd->first_time_s);
+        covered_until_s = pd->last_time_s;
+        have_page = true;
+        last_page_is_empty = page_is_empty;
 
-        now_s = pd->last_time_s + dt_s;
-        if(now_s > wanted_end_time_s) {
+        if(covered_until_s >= wanted_end_time_s) {
             *optimal_end_time_s = pd->last_time_s;
+            candidate_reached_end = true;
             break;
         }
+
+        now_s = nd_time_t_add_saturating(covered_until_s, 1);
     }
 
-    if(populate_gaps && now_s < wanted_end_time_s)
-        pgc_inject_gap(ctx, metric, now_s, wanted_end_time_s);
+    if(!candidate_reached_end) {
+        bool candidate_terminal_gap =
+            last_page_is_empty ||
+            nd_time_t_add_compare(covered_until_s, dt_s, wanted_end_time_s) <= 0;
+
+        if(candidate_terminal_gap || !legacy_done) {
+            gaps++;
+
+            if(populate_gaps) {
+                time_t gap_start_time_s = have_page ?
+                    nd_time_t_add_saturating(covered_until_s, 1) : wanted_start_time_s;
+                pgc_inject_gap(ctx, metric, gap_start_time_s, wanted_end_time_s);
+            }
+        }
+        else
+            *optimal_end_time_s = covered_until_s;
+    }
 
     // ------------------------------------------------------------------------
     // PASS 3: mark as skipped all the pages not useful
@@ -1005,7 +1077,7 @@ struct pgc_page *pg_cache_lookup_next(
             continue;
         }
         else {
-            if (unlikely(page_update_every_s <= 0 || page_update_every_s > 86400)) {
+            if (unlikely(!page_update_every_s)) {
                 __atomic_add_fetch(&rrdeng_cache_efficiency_stats.pages_invalid_update_every_fixed, 1, __ATOMIC_RELAXED);
                 page_update_every_s = pgc_page_fix_update_every(page, last_update_every_s);
                 pd->update_every_s = page_update_every_s;

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -785,6 +785,8 @@ ALWAYS_INLINE_HOT void rrdeng_load_metric_init(
     handle->ctx = ctx;
     handle->metric = metric;
     handle->priority = priority;
+    size_t tier_grouping = get_tier_grouping(ctx->config.tier);
+    handle->pgdc.slots_per_point = tier_grouping > UINT32_MAX ? UINT32_MAX : (uint32_t)tier_grouping;
 
     // IMPORTANT!
     // It is crucial not to exceed the db boundaries, because dbengine
@@ -839,7 +841,7 @@ static ALWAYS_INLINE_HOT bool rrdeng_load_page_next(struct storage_engine_query_
         // we have a page to release
         pgc_page_release(main_cache, handle->page);
         handle->page = NULL;
-        pgdc_reset(&handle->pgdc, NULL, UINT32_MAX);
+        pgdc_reset(&handle->pgdc, NULL, UINT32_MAX, handle->pgdc.slots_per_point);
     }
 
     if (unlikely(handle->now_s > seqh->end_time_s))
@@ -894,7 +896,8 @@ static ALWAYS_INLINE_HOT bool rrdeng_load_page_next(struct storage_engine_query_
     handle->position = position;
     handle->dt_s = page_update_every_s;
 
-    pgdc_reset(&handle->pgdc, pgc_page_data(handle->page), handle->position);
+    pgdc_reset(
+        &handle->pgdc, pgc_page_data(handle->page), handle->position, handle->pgdc.slots_per_point);
 
     return true;
 }
@@ -907,7 +910,8 @@ ALWAYS_INLINE_HOT STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_qu
     STORAGE_POINT sp;
 
     if (unlikely(handle->now_s > seqh->end_time_s)) {
-        storage_point_empty(sp, handle->now_s - handle->dt_s, handle->now_s);
+        storage_point_empty_slots(
+            sp, handle->now_s - handle->dt_s, handle->now_s, handle->pgdc.slots_per_point);
         goto prepare_for_next_iteration;
     }
 
@@ -916,7 +920,8 @@ ALWAYS_INLINE_HOT STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_qu
 
         if (!rrdeng_load_page_next(seqh, false)) {
             handle->now_s = seqh->end_time_s;
-            storage_point_empty(sp, handle->now_s - handle->dt_s, handle->now_s);
+            storage_point_empty_slots(
+                sp, handle->now_s - handle->dt_s, handle->now_s, handle->pgdc.slots_per_point);
             goto prepare_for_next_iteration;
         }
     }
@@ -950,7 +955,7 @@ ALWAYS_INLINE void rrdeng_load_metric_finalize(struct storage_engine_query_handl
 
     if (handle->page) {
         pgc_page_release(main_cache, handle->page);
-        pgdc_reset(&handle->pgdc, NULL, UINT32_MAX);
+        pgdc_reset(&handle->pgdc, NULL, UINT32_MAX, handle->pgdc.slots_per_point);
     }
 
     if(handle->pdc) {

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -840,7 +840,7 @@ static ALWAYS_INLINE_HOT bool rrdeng_load_page_next(struct storage_engine_query_
     if (likely(handle->page)) {
         // we have a page to release
         // The next page may have a different cadence, so search strictly after the last returned timestamp.
-        handle->now_s = pgc_page_end_time_s(handle->page) + 1;
+        handle->now_s = nd_time_t_add_saturating(pgc_page_end_time_s(handle->page), 1);
         pgc_page_release(main_cache, handle->page);
         handle->page = NULL;
         pgdc_reset(&handle->pgdc, NULL, UINT32_MAX, handle->pgdc.slots_per_point);
@@ -943,9 +943,42 @@ prepare_for_next_iteration:
     return sp;
 }
 
+static NOINLINE bool rrdeng_load_metric_continue_at_page_boundary(
+    struct storage_engine_query_handle *seqh, struct rrdeng_query_handle *handle) {
+    if(!handle->page || handle->position < handle->entries)
+        return false;
+
+    time_t page_end_time_s = pgc_page_end_time_s(handle->page);
+    if(page_end_time_s >= seqh->end_time_s)
+        return false;
+
+    Word_t page_start_time = (Word_t)pgc_page_start_time_s(handle->page);
+    Pvoid_t *PValue;
+    while((PValue = PDCJudyLNext(handle->pdc->page_list_JudyL, &page_start_time, PJE0))) {
+        struct page_details *pd = *PValue;
+
+        PDC_PAGE_STATUS status = __atomic_load_n(&pd->status, __ATOMIC_ACQUIRE);
+        if(status & (PDC_PAGE_QUERY_GLOBAL_SKIP_LIST | PDC_PAGE_EMPTY | PDC_PAGE_PROCESSED))
+            continue;
+
+        if(pd->last_time_s <= page_end_time_s)
+            continue;
+
+        // Consumers check is_finished() before next(); make the existing page transition reachable.
+        handle->now_s = page_end_time_s;
+        return true;
+    }
+
+    return false;
+}
+
 ALWAYS_INLINE int rrdeng_load_metric_is_finished(struct storage_engine_query_handle *seqh) {
     struct rrdeng_query_handle *handle = (struct rrdeng_query_handle *)seqh->handle;
-    return (handle->now_s > seqh->end_time_s);
+
+    if(likely(handle->now_s <= seqh->end_time_s))
+        return false;
+
+    return !rrdeng_load_metric_continue_at_page_boundary(seqh, handle);
 }
 
 /*

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -839,6 +839,8 @@ static ALWAYS_INLINE_HOT bool rrdeng_load_page_next(struct storage_engine_query_
 
     if (likely(handle->page)) {
         // we have a page to release
+        // The next page may have a different cadence, so search strictly after the last returned timestamp.
+        handle->now_s = pgc_page_end_time_s(handle->page) + 1;
         pgc_page_release(main_cache, handle->page);
         handle->page = NULL;
         pgdc_reset(&handle->pgdc, NULL, UINT32_MAX, handle->pgdc.slots_per_point);

--- a/src/database/ram/rrddim_mem.c
+++ b/src/database/ram/rrddim_mem.c
@@ -592,7 +592,6 @@ ALWAYS_INLINE STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query
     size_t slot = h->slot;
 
     STORAGE_POINT sp;
-    sp.count = 1;
 
     time_t this_timestamp = h->next_timestamp;
     h->next_timestamp += h->dt;
@@ -617,9 +616,12 @@ ALWAYS_INLINE STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query
     h->slot = slot;
     h->slot_timestamp += h->dt;
 
-    sp.anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
     sp.flags = (n & SN_USER_FLAGS);
     sp.min = sp.max = sp.sum = unpack_storage_number(n);
+    bool exists = does_storage_number_exist(n);
+    sp.count = exists ? 1 : 0;
+    sp.anomaly_count = exists && is_storage_number_anomalous(n) ? 1 : 0;
+    sp.gap_count = exists ? 0 : 1;
 
     return sp;
 }

--- a/src/database/rrddim-collection.c
+++ b/src/database/rrddim-collection.c
@@ -13,13 +13,13 @@ static inline time_t tier_next_point_time_s(RRDDIM *rd, struct rrddim_tier *t, t
 
 #define LAST_COMPLETED_POINT_EXISTS(t) (t->last_completed_point.end_time_s != 0)
 
-ALWAYS_INLINE_HOT
-void store_metric_at_tier_flush_last_completed(RRDDIM *rd __maybe_unused, size_t tier, struct rrddim_tier *t) {
+static ALWAYS_INLINE_HOT void store_metric_at_tier_flush_last_completed_inline(
+    RRDDIM *rd __maybe_unused, size_t tier, struct rrddim_tier *t) {
     // when there is no end_time_s we do not have a saved last_completed_point
     if(!LAST_COMPLETED_POINT_EXISTS(t)) return;
 
     STORAGE_POINT *sp = &t->last_completed_point;
-    if(likely(!storage_point_is_unset(t->last_completed_point))) {
+    if(likely(storage_point_has_value(t->last_completed_point))) {
         storage_engine_store_metric(
             t->sch,
             sp->end_time_s * USEC_PER_SEC,
@@ -46,11 +46,11 @@ void store_metric_at_tier_flush_last_completed(RRDDIM *rd __maybe_unused, size_t
     storage_point_unset(t->last_completed_point);
 }
 
-ALWAYS_INLINE_HOT
-static void store_metric_at_tier_save_last_completed(RRDDIM *rd, size_t tier, struct rrddim_tier *t, STORAGE_POINT sp) {
-    // make sure the last_completed_point is empty
-    store_metric_at_tier_flush_last_completed(rd, tier, t);
+NOINLINE void store_metric_at_tier_flush_last_completed(RRDDIM *rd, size_t tier, struct rrddim_tier *t) {
+    store_metric_at_tier_flush_last_completed_inline(rd, tier, t);
+}
 
+static ALWAYS_INLINE_HOT void store_metric_at_tier_set_last_completed(struct rrddim_tier *t, STORAGE_POINT sp) {
     // copy the point
     t->last_completed_point = sp;
 
@@ -58,10 +58,29 @@ static void store_metric_at_tier_save_last_completed(RRDDIM *rd, size_t tier, st
     t->last_completed_point.end_time_s = t->next_point_end_time_s;
 }
 
+static ALWAYS_INLINE_HOT void store_metric_at_tier_save_last_completed(
+    RRDDIM *rd, size_t tier, struct rrddim_tier *t, STORAGE_POINT sp) {
+    // make sure the last_completed_point is empty
+    store_metric_at_tier_flush_last_completed_inline(rd, tier, t);
+    store_metric_at_tier_set_last_completed(t, sp);
+}
+
+void store_metric_at_tier_flush_completed_on_frequency_change(RRDDIM *rd, size_t tier, struct rrddim_tier *t) {
+    // Preserve a point that reached the old grid boundary before switching the storage handle.
+    if(t->next_point_end_time_s && t->virtual_point.end_time_s == t->next_point_end_time_s) {
+        store_metric_at_tier_flush_last_completed(rd, tier, t);
+        store_metric_at_tier_set_last_completed(t, t->virtual_point);
+        storage_point_unset(t->virtual_point);
+        t->next_point_end_time_s = 0;
+    }
+
+    store_metric_at_tier_flush_last_completed(rd, tier, t);
+}
+
 ALWAYS_INLINE_HOT
 void store_metric_at_tier(RRDDIM *rd, size_t tier, struct rrddim_tier *t, STORAGE_POINT sp, usec_t now_ut __maybe_unused) {
     if(LAST_COMPLETED_POINT_EXISTS(t) && sp.start_time_s % t->last_completed_point_flush_modulo == 0)
-        store_metric_at_tier_flush_last_completed(rd, tier, t);
+        store_metric_at_tier_flush_last_completed_inline(rd, tier, t);
 
     if (unlikely(!t->next_point_end_time_s))
         t->next_point_end_time_s = tier_next_point_time_s(rd, t, sp.end_time_s);
@@ -130,18 +149,23 @@ void rrddim_store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
     if(likely(nd_profile.storage_tiers > 1)) {
         time_t now_s = (time_t)(point_end_time_ut / USEC_PER_SEC);
 
-        bool point_has_value = netdata_double_isnumber(n);
-        STORAGE_POINT sp = {
-            .start_time_s = now_s - rd->rrdset->update_every,
-            .end_time_s = now_s,
-            .min = n,
-            .max = n,
-            .sum = n,
-            .count = point_has_value ? 1 : 0,
-            .anomaly_count = point_has_value && !(flags & SN_FLAG_NOT_ANOMALOUS) ? 1 : 0,
-            .flags = flags,
-            .gap_count = point_has_value ? 0 : 1,
-        };
+        time_t start_time_s = now_s - rd->rrdset->update_every;
+        STORAGE_POINT sp;
+        if(likely(netdata_double_isnumber(n))) {
+            sp = (STORAGE_POINT){
+                .start_time_s = start_time_s,
+                .end_time_s = now_s,
+                .min = n,
+                .max = n,
+                .sum = n,
+                .count = 1,
+                .anomaly_count = !(flags & SN_FLAG_NOT_ANOMALOUS) ? 1 : 0,
+                .flags = flags,
+                .gap_count = 0,
+            };
+        }
+        else
+            storage_point_empty(sp, start_time_s, now_s);
 
         size_t tier = 1;
         do {

--- a/src/database/rrddim-collection.c
+++ b/src/database/rrddim-collection.c
@@ -43,9 +43,7 @@ void store_metric_at_tier_flush_last_completed(RRDDIM *rd __maybe_unused, size_t
 
     rrdset_done_statistics_points_stored_per_tier[tier]++;
 
-    // make the point unset
-    t->last_completed_point.count = 0;      // make it unset
-    t->last_completed_point.end_time_s = 0; // make it not saved
+    storage_point_unset(t->last_completed_point);
 }
 
 ALWAYS_INLINE_HOT
@@ -76,35 +74,11 @@ void store_metric_at_tier(RRDDIM *rd, size_t tier, struct rrddim_tier *t, STORAG
         else
             store_metric_at_tier_save_last_completed(rd, tier, t, STORAGE_POINT_UNSET);
 
-        t->virtual_point.count = 0; // make the point unset
+        storage_point_unset(t->virtual_point);
         t->next_point_end_time_s = tier_next_point_time_s(rd, t, sp.end_time_s);
     }
 
-    // merge the dates into our virtual point
-    if (unlikely(sp.start_time_s < t->virtual_point.start_time_s))
-        t->virtual_point.start_time_s = sp.start_time_s;
-
-    if (likely(sp.end_time_s > t->virtual_point.end_time_s))
-        t->virtual_point.end_time_s = sp.end_time_s;
-
-    // merge the values into our virtual point
-    if (likely(!storage_point_is_gap(sp))) {
-        // we aggregate only non NULLs into higher tiers
-
-        if (likely(!storage_point_is_unset(t->virtual_point))) {
-            // merge the collected point to our virtual one
-            t->virtual_point.sum += sp.sum;
-            t->virtual_point.min = MIN(t->virtual_point.min, sp.min);
-            t->virtual_point.max = MAX(t->virtual_point.max, sp.max);
-            t->virtual_point.count += sp.count;
-            t->virtual_point.anomaly_count += sp.anomaly_count;
-            t->virtual_point.flags |= sp.flags;
-        }
-        else {
-            // reset our virtual point to this one
-            t->virtual_point = sp;
-        }
-    }
+    storage_point_merge_to(t->virtual_point, sp);
 }
 
 NOT_INLINE_HOT
@@ -155,15 +129,17 @@ void rrddim_store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
 
     time_t now_s = (time_t)(point_end_time_ut / USEC_PER_SEC);
 
+    bool point_has_value = netdata_double_isnumber(n);
     STORAGE_POINT sp = {
         .start_time_s = now_s - rd->rrdset->update_every,
         .end_time_s = now_s,
         .min = n,
         .max = n,
         .sum = n,
-        .count = 1,
-        .anomaly_count = (flags & SN_FLAG_NOT_ANOMALOUS) ? 0 : 1,
-        .flags = flags
+        .count = point_has_value ? 1 : 0,
+        .anomaly_count = point_has_value && !(flags & SN_FLAG_NOT_ANOMALOUS) ? 1 : 0,
+        .flags = flags,
+        .gap_count = point_has_value ? 0 : 1,
     };
 
     for(size_t tier = 1; tier < nd_profile.storage_tiers;tier++) {

--- a/src/database/rrddim-collection.c
+++ b/src/database/rrddim-collection.c
@@ -127,33 +127,36 @@ void rrddim_store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
 
     rrdset_done_statistics_points_stored_per_tier[0]++;
 
-    time_t now_s = (time_t)(point_end_time_ut / USEC_PER_SEC);
+    if(likely(nd_profile.storage_tiers > 1)) {
+        time_t now_s = (time_t)(point_end_time_ut / USEC_PER_SEC);
 
-    bool point_has_value = netdata_double_isnumber(n);
-    STORAGE_POINT sp = {
-        .start_time_s = now_s - rd->rrdset->update_every,
-        .end_time_s = now_s,
-        .min = n,
-        .max = n,
-        .sum = n,
-        .count = point_has_value ? 1 : 0,
-        .anomaly_count = point_has_value && !(flags & SN_FLAG_NOT_ANOMALOUS) ? 1 : 0,
-        .flags = flags,
-        .gap_count = point_has_value ? 0 : 1,
-    };
+        bool point_has_value = netdata_double_isnumber(n);
+        STORAGE_POINT sp = {
+            .start_time_s = now_s - rd->rrdset->update_every,
+            .end_time_s = now_s,
+            .min = n,
+            .max = n,
+            .sum = n,
+            .count = point_has_value ? 1 : 0,
+            .anomaly_count = point_has_value && !(flags & SN_FLAG_NOT_ANOMALOUS) ? 1 : 0,
+            .flags = flags,
+            .gap_count = point_has_value ? 0 : 1,
+        };
 
-    for(size_t tier = 1; tier < nd_profile.storage_tiers;tier++) {
-        if(unlikely(!rd->tiers[tier].smh)) continue;
+        size_t tier = 1;
+        do {
+            if(unlikely(!rd->tiers[tier].smh)) continue;
 
-        struct rrddim_tier *t = &rd->tiers[tier];
+            struct rrddim_tier *t = &rd->tiers[tier];
 
-        if(!rrddim_option_check(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS)) {
-            // we have not collected this tier before
-            // let's fill any gap that may exist
-            backfill_tier_from_smaller_tiers(rd, tier, now_s);
-        }
+            if(!rrddim_option_check(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS)) {
+                // we have not collected this tier before
+                // let's fill any gap that may exist
+                backfill_tier_from_smaller_tiers(rd, tier, now_s);
+            }
 
-        store_metric_at_tier(rd, tier, t, sp, point_end_time_ut);
+            store_metric_at_tier(rd, tier, t, sp, point_end_time_ut);
+        } while(++tier < nd_profile.storage_tiers);
     }
     rrddim_option_set(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS);
 

--- a/src/database/rrddim-collection.h
+++ b/src/database/rrddim-collection.h
@@ -16,5 +16,6 @@ void rrddim_store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
 #endif
 
 void store_metric_at_tier_flush_last_completed(RRDDIM *rd, size_t tier, struct rrddim_tier *t);
+void store_metric_at_tier_flush_completed_on_frequency_change(RRDDIM *rd, size_t tier, struct rrddim_tier *t);
 
 #endif //NETDATA_RRDDIM_COLLECTION_H

--- a/src/database/rrdset-collection.c
+++ b/src/database/rrdset-collection.c
@@ -25,10 +25,14 @@ time_t rrdset_set_update_every_s(RRDSET *st, time_t update_every_s) {
     RRDDIM *rd;
     rrddim_foreach_read(rd, st) {
         for (size_t tier = 0; tier < nd_profile.storage_tiers; tier++) {
-            if (rd->tiers[tier].sch)
+            if (rd->tiers[tier].sch) {
+                if(tier)
+                    store_metric_at_tier_flush_completed_on_frequency_change(rd, tier, &rd->tiers[tier]);
+
                 storage_engine_store_change_collection_frequency(
                     rd->tiers[tier].sch,
                     (int)(st->rrdhost->db[tier].tier_grouping * st->update_every));
+            }
         }
     }
     rrddim_foreach_done(rd);

--- a/src/database/tests/rrddim-collection-test.c
+++ b/src/database/tests/rrddim-collection-test.c
@@ -1,0 +1,548 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#define rrdeng_store_metric_next collection_test_dbengine_store
+#define rrddim_collect_store_metric collection_test_ram_store
+#define rrdeng_metric_oldest_time collection_test_oldest_time
+#define rrddim_query_oldest_time_s collection_test_oldest_time
+#define rrdeng_metric_latest_time collection_test_latest_time
+#define rrddim_query_latest_time_s collection_test_latest_time
+#define rrdeng_load_metric_init collection_test_query_init
+#define rrddim_query_init collection_test_query_init
+#define rrdeng_load_metric_next collection_test_query_next
+#define rrddim_query_next_metric collection_test_query_next
+#define rrdeng_load_metric_is_finished collection_test_query_is_finished
+#define rrddim_query_is_finished collection_test_query_is_finished
+#define rrdeng_load_metric_finalize collection_test_query_finalize
+#define rrddim_query_finalize collection_test_query_finalize
+#define rrdcontext_collected_rrddim collection_test_context_collected
+#include "../rrddim-collection.c"
+#include "../rrddim-backfill.c"
+#undef rrdcontext_collected_rrddim
+#undef rrddim_query_finalize
+#undef rrdeng_load_metric_finalize
+#undef rrddim_query_is_finished
+#undef rrdeng_load_metric_is_finished
+#undef rrddim_query_next_metric
+#undef rrdeng_load_metric_next
+#undef rrddim_query_init
+#undef rrdeng_load_metric_init
+#undef rrddim_query_latest_time_s
+#undef rrdeng_metric_latest_time
+#undef rrddim_query_oldest_time_s
+#undef rrdeng_metric_oldest_time
+#undef rrddim_collect_store_metric
+#undef rrdeng_store_metric_next
+
+#define TEST_EXPECT(condition) do { \
+    if(!(condition)) { \
+        fprintf(stderr, "%s:%d: %s\n", __FUNCTION__, __LINE__, #condition); \
+        errors++; \
+    } \
+} while(0)
+
+struct nd_profile_t nd_profile = { 0 };
+RRD_BACKFILL default_backfill = RRD_BACKFILL_FULL;
+__thread size_t rrdset_done_statistics_points_stored_per_tier[RRD_STORAGE_TIERS];
+
+struct captured_store {
+    usec_t point_in_time_ut;
+    NETDATA_DOUBLE n;
+    NETDATA_DOUBLE min;
+    NETDATA_DOUBLE max;
+    uint16_t count;
+    uint16_t anomaly_count;
+    SN_FLAGS flags;
+};
+
+static struct captured_store captured_stores[16];
+static size_t captured_store_count;
+static size_t context_collected_count;
+static size_t backfill_started_count;
+static size_t backfill_finished_count;
+static size_t backfill_completed_count;
+static size_t backfill_points_read;
+static size_t collection_completed_count;
+
+static void capture_store(
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min,
+    NETDATA_DOUBLE max,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags) {
+    if(captured_store_count >= _countof(captured_stores))
+        fatal("too many captured stores");
+
+    captured_stores[captured_store_count++] = (struct captured_store){
+        .point_in_time_ut = point_in_time_ut,
+        .n = n,
+        .min = min,
+        .max = max,
+        .count = count,
+        .anomaly_count = anomaly_count,
+        .flags = flags,
+    };
+}
+
+void collection_test_dbengine_store(
+    STORAGE_COLLECT_HANDLE *sch __maybe_unused,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min,
+    NETDATA_DOUBLE max,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags) {
+    capture_store(point_in_time_ut, n, min, max, count, anomaly_count, flags);
+}
+
+void collection_test_ram_store(
+    STORAGE_COLLECT_HANDLE *sch __maybe_unused,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min,
+    NETDATA_DOUBLE max,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags) {
+    capture_store(point_in_time_ut, n, min, max, count, anomaly_count, flags);
+}
+
+void collection_test_context_collected(RRDDIM *rd __maybe_unused) {
+    context_collected_count++;
+}
+
+void stream_control_backfill_query_started(void) {
+    backfill_started_count++;
+}
+
+void stream_control_backfill_query_finished(void) {
+    backfill_finished_count++;
+}
+
+void pulse_queries_backfill_query_completed(size_t points_read) {
+    backfill_completed_count++;
+    backfill_points_read += points_read;
+}
+
+void pulse_queries_rrdset_collection_completed(size_t *points_read_per_tier_array __maybe_unused) {
+    collection_completed_count++;
+}
+
+struct collection_test_metric {
+    const STORAGE_POINT *points;
+    size_t points_count;
+    size_t next_point;
+    time_t oldest_time_s;
+    time_t latest_time_s;
+};
+
+time_t collection_test_oldest_time(STORAGE_METRIC_HANDLE *smh) {
+    return ((struct collection_test_metric *)smh)->oldest_time_s;
+}
+
+time_t collection_test_latest_time(STORAGE_METRIC_HANDLE *smh) {
+    return ((struct collection_test_metric *)smh)->latest_time_s;
+}
+
+void collection_test_query_init(
+    STORAGE_METRIC_HANDLE *smh,
+    struct storage_engine_query_handle *seqh,
+    time_t start_time_s,
+    time_t end_time_s,
+    STORAGE_PRIORITY priority) {
+    struct collection_test_metric *metric = (struct collection_test_metric *)smh;
+    metric->next_point = 0;
+    *seqh = (struct storage_engine_query_handle){
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .priority = priority,
+#ifdef ENABLE_DBENGINE
+        .seb = STORAGE_ENGINE_BACKEND_DBENGINE,
+#else
+        .seb = STORAGE_ENGINE_BACKEND_RRDDIM,
+#endif
+        .handle = (STORAGE_QUERY_HANDLE *)metric,
+    };
+}
+
+STORAGE_POINT collection_test_query_next(struct storage_engine_query_handle *seqh) {
+    struct collection_test_metric *metric = (struct collection_test_metric *)seqh->handle;
+    if(metric->next_point >= metric->points_count)
+        return STORAGE_POINT_UNSET;
+
+    return metric->points[metric->next_point++];
+}
+
+int collection_test_query_is_finished(struct storage_engine_query_handle *seqh) {
+    struct collection_test_metric *metric = (struct collection_test_metric *)seqh->handle;
+    return metric->next_point >= metric->points_count;
+}
+
+void collection_test_query_finalize(struct storage_engine_query_handle *seqh __maybe_unused) {
+}
+
+static STORAGE_POINT numeric_point(
+    time_t start_time_s,
+    time_t end_time_s,
+    NETDATA_DOUBLE min,
+    NETDATA_DOUBLE max,
+    NETDATA_DOUBLE sum,
+    uint32_t count,
+    uint32_t gap_count,
+    uint32_t anomaly_count,
+    SN_FLAGS flags) {
+    return (STORAGE_POINT){
+        .min = min,
+        .max = max,
+        .sum = sum,
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .count = count,
+        .anomaly_count = anomaly_count,
+        .flags = flags,
+        .gap_count = gap_count,
+    };
+}
+
+static STORAGE_POINT gap_point(time_t start_time_s, time_t end_time_s, NETDATA_DOUBLE payload, uint32_t gaps) {
+    return (STORAGE_POINT){
+        .min = payload,
+        .max = payload,
+        .sum = payload,
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .count = 0,
+        .anomaly_count = 0,
+        .flags = SN_FLAG_RESET,
+        .gap_count = gaps,
+    };
+}
+
+static bool point_is_fully_unset(STORAGE_POINT sp) {
+    return storage_point_is_unset(sp) &&
+        isnan(sp.min) && isnan(sp.max) && isnan(sp.sum) &&
+        sp.start_time_s == 0 && sp.end_time_s == 0 &&
+        sp.count == 0 && sp.gap_count == 0 && sp.anomaly_count == 0 &&
+        sp.flags == SN_FLAG_NONE;
+}
+
+static size_t test_completed_point_persistence(void) {
+    size_t errors = 0;
+    STORAGE_COLLECT_HANDLE sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    struct rrddim_tier tier = { .sch = &sch };
+
+    const STORAGE_POINT cases[] = {
+        numeric_point(100, 160, 1, 3, 6, 3, 0, 1, SN_FLAG_RESET),
+        numeric_point(160, 220, 2, 4, 6, 2, 3, 1, SN_DEFAULT_FLAGS),
+        gap_point(220, 280, NAN, 60),
+        gap_point(280, 340, INFINITY, 60),
+        gap_point(340, 400, -INFINITY, 60),
+    };
+
+    captured_store_count = 0;
+    memset(rrdset_done_statistics_points_stored_per_tier, 0,
+           sizeof(rrdset_done_statistics_points_stored_per_tier));
+
+    for(size_t i = 0; i < _countof(cases); i++) {
+        tier.last_completed_point = cases[i];
+        store_metric_at_tier_flush_last_completed(NULL, 1, &tier);
+        TEST_EXPECT(point_is_fully_unset(tier.last_completed_point));
+    }
+
+    TEST_EXPECT(captured_store_count == _countof(cases));
+    TEST_EXPECT(rrdset_done_statistics_points_stored_per_tier[1] == _countof(cases));
+
+    for(size_t i = 0; i < 2 && i < captured_store_count; i++) {
+        TEST_EXPECT(captured_stores[i].point_in_time_ut == (usec_t)cases[i].end_time_s * USEC_PER_SEC);
+        TEST_EXPECT(captured_stores[i].n == cases[i].sum);
+        TEST_EXPECT(captured_stores[i].min == cases[i].min);
+        TEST_EXPECT(captured_stores[i].max == cases[i].max);
+        TEST_EXPECT(captured_stores[i].count == cases[i].count);
+        TEST_EXPECT(captured_stores[i].anomaly_count == cases[i].anomaly_count);
+        TEST_EXPECT(captured_stores[i].flags == cases[i].flags);
+    }
+
+    for(size_t i = 2; i < _countof(cases) && i < captured_store_count; i++) {
+        TEST_EXPECT(captured_stores[i].point_in_time_ut == (usec_t)cases[i].end_time_s * USEC_PER_SEC);
+        TEST_EXPECT(isnan(captured_stores[i].n));
+        TEST_EXPECT(isnan(captured_stores[i].min));
+        TEST_EXPECT(isnan(captured_stores[i].max));
+        TEST_EXPECT(captured_stores[i].count == 0);
+        TEST_EXPECT(captured_stores[i].anomaly_count == 0);
+        TEST_EXPECT(captured_stores[i].flags == SN_FLAG_NONE);
+    }
+
+    return errors;
+}
+
+static size_t test_frequency_change_state(void) {
+    size_t errors = 0;
+    STORAGE_COLLECT_HANDLE sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    struct rrddim_tier tier = { .sch = &sch };
+
+    STORAGE_POINT incomplete = numeric_point(100, 150, 1, 5, 9, 3, 2, 1, SN_FLAG_RESET);
+    storage_point_unset(tier.last_completed_point);
+    tier.virtual_point = incomplete;
+    tier.next_point_end_time_s = 160;
+    captured_store_count = 0;
+    store_metric_at_tier_flush_completed_on_frequency_change(NULL, 1, &tier);
+    TEST_EXPECT(captured_store_count == 0);
+    TEST_EXPECT(tier.virtual_point.start_time_s == incomplete.start_time_s);
+    TEST_EXPECT(tier.virtual_point.end_time_s == incomplete.end_time_s);
+    TEST_EXPECT(tier.virtual_point.min == incomplete.min);
+    TEST_EXPECT(tier.virtual_point.max == incomplete.max);
+    TEST_EXPECT(tier.virtual_point.sum == incomplete.sum);
+    TEST_EXPECT(tier.virtual_point.count == incomplete.count);
+    TEST_EXPECT(tier.virtual_point.gap_count == incomplete.gap_count);
+    TEST_EXPECT(tier.virtual_point.anomaly_count == incomplete.anomaly_count);
+    TEST_EXPECT(tier.virtual_point.flags == incomplete.flags);
+    TEST_EXPECT(tier.next_point_end_time_s == 160);
+
+    STORAGE_POINT delayed = numeric_point(40, 100, 3, 3, 3, 1, 0, 0, SN_DEFAULT_FLAGS);
+    STORAGE_POINT boundary = numeric_point(100, 160, 4, 6, 10, 2, 3, 1, SN_FLAG_RESET);
+    tier.last_completed_point = delayed;
+    tier.virtual_point = boundary;
+    tier.next_point_end_time_s = 160;
+    captured_store_count = 0;
+    store_metric_at_tier_flush_completed_on_frequency_change(NULL, 1, &tier);
+    TEST_EXPECT(captured_store_count == 2);
+    if(captured_store_count == 2) {
+        TEST_EXPECT(captured_stores[0].point_in_time_ut == 100 * USEC_PER_SEC);
+        TEST_EXPECT(captured_stores[0].n == 3);
+        TEST_EXPECT(captured_stores[1].point_in_time_ut == 160 * USEC_PER_SEC);
+        TEST_EXPECT(captured_stores[1].n == 10);
+        TEST_EXPECT(captured_stores[1].count == 2);
+        TEST_EXPECT(captured_stores[1].anomaly_count == 1);
+        TEST_EXPECT(captured_stores[1].flags == SN_FLAG_RESET);
+    }
+    TEST_EXPECT(point_is_fully_unset(tier.last_completed_point));
+    TEST_EXPECT(point_is_fully_unset(tier.virtual_point));
+    TEST_EXPECT(tier.next_point_end_time_s == 0);
+
+    storage_point_unset(tier.last_completed_point);
+    tier.virtual_point = gap_point(160, 220, INFINITY, 60);
+    tier.next_point_end_time_s = 220;
+    captured_store_count = 0;
+    store_metric_at_tier_flush_completed_on_frequency_change(NULL, 1, &tier);
+    TEST_EXPECT(captured_store_count == 1);
+    if(captured_store_count == 1) {
+        TEST_EXPECT(captured_stores[0].point_in_time_ut == 220 * USEC_PER_SEC);
+        TEST_EXPECT(isnan(captured_stores[0].n));
+        TEST_EXPECT(captured_stores[0].count == 0);
+        TEST_EXPECT(captured_stores[0].flags == SN_FLAG_NONE);
+    }
+    TEST_EXPECT(point_is_fully_unset(tier.last_completed_point));
+    TEST_EXPECT(point_is_fully_unset(tier.virtual_point));
+    TEST_EXPECT(tier.next_point_end_time_s == 0);
+
+    return errors;
+}
+
+static size_t test_one_tier_fast_path(void) {
+    size_t errors = 0;
+    STORAGE_COLLECT_HANDLE tier0_sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    STORAGE_COLLECT_HANDLE tier1_sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    RRDSET st = { .update_every = 1 };
+    RRDDIM *rd = callocz(1, sizeof(*rd) + 2 * sizeof(struct rrddim_tier));
+    rd->id = string_strdupz("collection-one-tier");
+    rd->rrdset = &st;
+    rd->tiers[0].sch = &tier0_sch;
+    rd->tiers[1].sch = &tier1_sch;
+    rd->tiers[1].smh = (STORAGE_METRIC_HANDLE *)(uintptr_t)1;
+    rd->tiers[1].tier_grouping = 60;
+    rd->tiers[1].last_completed_point_flush_modulo = 1;
+    storage_point_unset(rd->tiers[1].virtual_point);
+    storage_point_unset(rd->tiers[1].last_completed_point);
+    rrddim_option_set(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS);
+
+    nd_profile.storage_tiers = 1;
+    captured_store_count = 0;
+    context_collected_count = 0;
+    rrddim_store_metric(rd, 200 * USEC_PER_SEC, 42, SN_DEFAULT_FLAGS);
+
+    TEST_EXPECT(captured_store_count == 1);
+    if(captured_store_count == 1) {
+        TEST_EXPECT(captured_stores[0].point_in_time_ut == 200 * USEC_PER_SEC);
+        TEST_EXPECT(captured_stores[0].n == 42);
+        TEST_EXPECT(captured_stores[0].count == 1);
+    }
+    TEST_EXPECT(context_collected_count == 1);
+    TEST_EXPECT(point_is_fully_unset(rd->tiers[1].virtual_point));
+    TEST_EXPECT(point_is_fully_unset(rd->tiers[1].last_completed_point));
+    TEST_EXPECT(rd->tiers[1].next_point_end_time_s == 0);
+
+    string_freez(rd->id);
+    freez(rd);
+    return errors;
+}
+
+static size_t test_ordinary_higher_tier_rollup(void) {
+    size_t errors = 0;
+    STORAGE_COLLECT_HANDLE tier0_sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    STORAGE_COLLECT_HANDLE tier1_sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    RRDSET st = { .update_every = 10 };
+    RRDDIM *rd = callocz(1, sizeof(*rd) + 2 * sizeof(struct rrddim_tier));
+    rd->id = string_strdupz("collection-higher-tier");
+    rd->rrdset = &st;
+    rd->tiers[0].sch = &tier0_sch;
+    rd->tiers[1].sch = &tier1_sch;
+    rd->tiers[1].smh = (STORAGE_METRIC_HANDLE *)(uintptr_t)1;
+    rd->tiers[1].tier_grouping = 3;
+    rd->tiers[1].last_completed_point_flush_modulo = 1;
+    storage_point_unset(rd->tiers[1].virtual_point);
+    storage_point_unset(rd->tiers[1].last_completed_point);
+    rrddim_option_set(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS);
+
+    nd_profile.storage_tiers = 2;
+    captured_store_count = 0;
+    context_collected_count = 0;
+
+    rrddim_store_metric(rd, 70 * USEC_PER_SEC, INFINITY, SN_FLAG_RESET);
+    TEST_EXPECT(storage_point_is_gap(rd->tiers[1].virtual_point));
+    TEST_EXPECT(isnan(rd->tiers[1].virtual_point.min));
+    TEST_EXPECT(isnan(rd->tiers[1].virtual_point.max));
+    TEST_EXPECT(isnan(rd->tiers[1].virtual_point.sum));
+    TEST_EXPECT(rd->tiers[1].virtual_point.flags == SN_FLAG_NONE);
+    rrddim_store_metric(rd, 80 * USEC_PER_SEC, NAN, SN_FLAG_NONE);
+    rrddim_store_metric(rd, 90 * USEC_PER_SEC, -INFINITY, SN_FLAG_NONE);
+
+    struct rrddim_tier *t = &rd->tiers[1];
+    TEST_EXPECT(t->next_point_end_time_s == 90);
+    TEST_EXPECT(storage_point_is_gap(t->virtual_point));
+    TEST_EXPECT(t->virtual_point.start_time_s == 60 && t->virtual_point.end_time_s == 90);
+    TEST_EXPECT(isnan(t->virtual_point.min));
+    TEST_EXPECT(isnan(t->virtual_point.max));
+    TEST_EXPECT(isnan(t->virtual_point.sum));
+    TEST_EXPECT(t->virtual_point.count == 0 && t->virtual_point.gap_count == 3);
+    TEST_EXPECT(t->virtual_point.anomaly_count == 0 && t->virtual_point.flags == SN_FLAG_NONE);
+
+    rrddim_store_metric(rd, 100 * USEC_PER_SEC, 4, SN_DEFAULT_FLAGS);
+    TEST_EXPECT(t->next_point_end_time_s == 120);
+    TEST_EXPECT(storage_point_is_gap(t->last_completed_point));
+    TEST_EXPECT(t->last_completed_point.start_time_s == 60 && t->last_completed_point.end_time_s == 90);
+    TEST_EXPECT(isnan(t->last_completed_point.min));
+    TEST_EXPECT(isnan(t->last_completed_point.max));
+    TEST_EXPECT(isnan(t->last_completed_point.sum));
+    TEST_EXPECT(t->last_completed_point.count == 0 && t->last_completed_point.gap_count == 3);
+    TEST_EXPECT(t->last_completed_point.anomaly_count == 0 && t->last_completed_point.flags == SN_FLAG_NONE);
+    TEST_EXPECT(storage_point_is_complete(t->virtual_point));
+    TEST_EXPECT(t->virtual_point.start_time_s == 90 && t->virtual_point.end_time_s == 100);
+    TEST_EXPECT(t->virtual_point.min == 4 && t->virtual_point.max == 4 && t->virtual_point.sum == 4);
+    TEST_EXPECT(t->virtual_point.count == 1 && t->virtual_point.gap_count == 0);
+    TEST_EXPECT(t->virtual_point.anomaly_count == 0 && t->virtual_point.flags == SN_DEFAULT_FLAGS);
+
+    store_metric_at_tier_flush_last_completed(rd, 1, t);
+    TEST_EXPECT(captured_store_count == 5);
+    if(captured_store_count == 5) {
+        const struct captured_store *gap = &captured_stores[4];
+        TEST_EXPECT(gap->point_in_time_ut == 90 * USEC_PER_SEC);
+        TEST_EXPECT(isnan(gap->n) && isnan(gap->min) && isnan(gap->max));
+        TEST_EXPECT(gap->count == 0 && gap->anomaly_count == 0 && gap->flags == SN_FLAG_NONE);
+    }
+    TEST_EXPECT(point_is_fully_unset(t->last_completed_point));
+
+    rrddim_store_metric(rd, 110 * USEC_PER_SEC, 6, SN_FLAG_RESET);
+    rrddim_store_metric(rd, 120 * USEC_PER_SEC, NAN, SN_FLAG_NONE);
+    rrddim_store_metric(rd, 130 * USEC_PER_SEC, 8, SN_DEFAULT_FLAGS);
+
+    TEST_EXPECT(t->next_point_end_time_s == 150);
+    TEST_EXPECT(storage_point_is_partial(t->last_completed_point));
+    TEST_EXPECT(t->last_completed_point.start_time_s == 90 && t->last_completed_point.end_time_s == 120);
+    TEST_EXPECT(t->last_completed_point.min == 4 && t->last_completed_point.max == 6 &&
+                t->last_completed_point.sum == 10);
+    TEST_EXPECT(t->last_completed_point.count == 2 && t->last_completed_point.gap_count == 1);
+    TEST_EXPECT(t->last_completed_point.anomaly_count == 1 &&
+                t->last_completed_point.flags == (SN_DEFAULT_FLAGS | SN_FLAG_RESET));
+    TEST_EXPECT(storage_point_is_complete(t->virtual_point));
+    TEST_EXPECT(t->virtual_point.start_time_s == 120 && t->virtual_point.end_time_s == 130);
+    TEST_EXPECT(t->virtual_point.min == 8 && t->virtual_point.max == 8 && t->virtual_point.sum == 8);
+    TEST_EXPECT(t->virtual_point.count == 1 && t->virtual_point.gap_count == 0);
+    TEST_EXPECT(t->virtual_point.anomaly_count == 0 && t->virtual_point.flags == SN_DEFAULT_FLAGS);
+
+    store_metric_at_tier_flush_last_completed(rd, 1, t);
+    TEST_EXPECT(captured_store_count == 9);
+    if(captured_store_count == 9) {
+        const struct captured_store *partial = &captured_stores[8];
+        TEST_EXPECT(partial->point_in_time_ut == 120 * USEC_PER_SEC);
+        TEST_EXPECT(partial->n == 10 && partial->min == 4 && partial->max == 6);
+        TEST_EXPECT(partial->count == 2 && partial->anomaly_count == 1 &&
+                    partial->flags == (SN_DEFAULT_FLAGS | SN_FLAG_RESET));
+    }
+    TEST_EXPECT(point_is_fully_unset(t->last_completed_point));
+    TEST_EXPECT(context_collected_count == 7);
+
+    string_freez(rd->id);
+    freez(rd);
+    return errors;
+}
+
+#ifdef ENABLE_DBENGINE
+static size_t test_backfill_gap_composition(void) {
+    size_t errors = 0;
+    const time_t t = 600;
+    const STORAGE_POINT source_points[] = {
+        numeric_point(t, t + 10, 1, 1, 1, 1, 0, 0, SN_DEFAULT_FLAGS),
+        numeric_point(t + 10, t + 20, 2, 2, 2, 1, 0, 0, SN_DEFAULT_FLAGS),
+        numeric_point(t + 20, t + 21, 3, 3, 3, 1, 0, 0, SN_DEFAULT_FLAGS),
+        gap_point(t + 21, t + 22, NAN, 1),
+        numeric_point(t + 22, t + 23, 4, 4, 4, 1, 0, 0, SN_DEFAULT_FLAGS),
+    };
+    struct collection_test_metric source = {
+        .points = source_points,
+        .points_count = _countof(source_points),
+        .oldest_time_s = t + 10,
+        .latest_time_s = t + 23,
+    };
+    struct collection_test_metric target = { .oldest_time_s = 0, .latest_time_s = 0 };
+    RRDSET st = { .update_every = 1 };
+    RRDDIM *rd = callocz(1, sizeof(*rd) + 2 * sizeof(struct rrddim_tier));
+    rd->rrdset = &st;
+    rd->tiers[0].seb = STORAGE_ENGINE_BACKEND_DBENGINE;
+    rd->tiers[0].smh = (STORAGE_METRIC_HANDLE *)&source;
+    rd->tiers[1].seb = STORAGE_ENGINE_BACKEND_DBENGINE;
+    rd->tiers[1].smh = (STORAGE_METRIC_HANDLE *)&target;
+    rd->tiers[1].tier_grouping = 60;
+    rd->tiers[1].last_completed_point_flush_modulo = 1;
+    storage_point_unset(rd->tiers[1].virtual_point);
+    storage_point_unset(rd->tiers[1].last_completed_point);
+
+    nd_profile.storage_tiers = 2;
+    default_backfill = RRD_BACKFILL_FULL;
+    backfill_started_count = 0;
+    backfill_finished_count = 0;
+    backfill_completed_count = 0;
+    backfill_points_read = 0;
+    collection_completed_count = 0;
+
+    bool backfilled = backfill_tier_from_smaller_tiers(rd, 1, t + 120);
+    STORAGE_POINT sp = rd->tiers[1].virtual_point;
+    TEST_EXPECT(backfilled);
+    TEST_EXPECT(sp.start_time_s == t && sp.end_time_s == t + 23);
+    TEST_EXPECT(sp.min == 1 && sp.max == 4 && sp.sum == 10);
+    TEST_EXPECT(sp.count == 4 && sp.gap_count == 1 && sp.anomaly_count == 0);
+    TEST_EXPECT(sp.flags == SN_DEFAULT_FLAGS);
+    TEST_EXPECT(storage_point_is_partial(sp));
+    TEST_EXPECT(storage_point_slots(sp) == 5);
+    TEST_EXPECT(rd->tiers[1].next_point_end_time_s == t + 60);
+    TEST_EXPECT(backfill_started_count == 1 && backfill_finished_count == 1);
+    TEST_EXPECT(backfill_completed_count == 1 && backfill_points_read == _countof(source_points));
+    TEST_EXPECT(collection_completed_count == 1);
+
+    freez(rd);
+    return errors;
+}
+#endif
+
+int main(void) {
+    size_t errors = 0;
+    errors += test_completed_point_persistence();
+    errors += test_frequency_change_state();
+    errors += test_one_tier_fast_path();
+    errors += test_ordinary_higher_tier_rollup();
+#ifdef ENABLE_DBENGINE
+    errors += test_backfill_gap_composition();
+#endif
+    return errors ? 1 : 0;
+}

--- a/src/database/tests/rrddim-collection-test.c
+++ b/src/database/tests/rrddim-collection-test.c
@@ -511,6 +511,7 @@ static size_t test_backfill_gap_composition(void) {
 
     nd_profile.storage_tiers = 2;
     default_backfill = RRD_BACKFILL_FULL;
+    captured_store_count = 0;
     backfill_started_count = 0;
     backfill_finished_count = 0;
     backfill_completed_count = 0;

--- a/src/database/tests/rrddim-collection-test.c
+++ b/src/database/tests/rrddim-collection-test.c
@@ -181,6 +181,7 @@ int collection_test_query_is_finished(struct storage_engine_query_handle *seqh) 
 }
 
 void collection_test_query_finalize(struct storage_engine_query_handle *seqh __maybe_unused) {
+    // The mock query borrows fixture storage and owns no resources.
 }
 
 static STORAGE_POINT numeric_point(

--- a/src/libnetdata/storage-point.h
+++ b/src/libnetdata/storage-point.h
@@ -158,7 +158,8 @@ typedef struct storage_point {
     (NETDATA_DOUBLE)(storage_point_has_value(sp) ? (NETDATA_DOUBLE)((sp).anomaly_count) * 100.0 / (NETDATA_DOUBLE)((sp).count) : 0.0)
 
 #define storage_point_average_value(sp) \
-    ((sp).count ? (sp).sum / (NETDATA_DOUBLE)((sp).count) : 0.0)
+    (storage_point_is_gap(sp) ? NAN : \
+     ((sp).count ? (sp).sum / (NETDATA_DOUBLE)((sp).count) : 0.0))
 
 
 #endif //NETDATA_STORAGE_POINT_H

--- a/src/libnetdata/storage-point.h
+++ b/src/libnetdata/storage-point.h
@@ -18,6 +18,7 @@ typedef struct storage_point {
     uint32_t anomaly_count; // the number of original points found anomalous
 
     SN_FLAGS flags;         // flags stored with the point
+    uint32_t gap_count;     // the number of missing original points
 } STORAGE_POINT;
 
 #define storage_point_unset(x)                     do { \
@@ -25,31 +26,62 @@ typedef struct storage_point {
     (x).count = 0;                                      \
     (x).anomaly_count = 0;                              \
     (x).flags = SN_FLAG_NONE;                           \
+    (x).gap_count = 0;                                  \
     (x).start_time_s = 0;                               \
     (x).end_time_s = 0;                                 \
     } while(0)
 
 #define storage_point_empty(x, start_s, end_s)     do { \
     (x).min = (x).max = (x).sum = NAN;                  \
-    (x).count = 1;                                      \
+    (x).count = 0;                                      \
     (x).anomaly_count = 0;                              \
     (x).flags = SN_FLAG_NONE;                           \
+    (x).gap_count = 1;                                  \
     (x).start_time_s = start_s;                         \
     (x).end_time_s = end_s;                             \
     } while(0)
 
-#define STORAGE_POINT_UNSET (STORAGE_POINT){ .min = NAN, .max = NAN, .sum = NAN, .count = 0, .anomaly_count = 0, .flags = SN_FLAG_NONE, .start_time_s = 0, .end_time_s = 0 }
+#define storage_point_empty_slots(x, start_s, end_s, slots) do { \
+    uint32_t _storage_point_slots = (uint32_t)(slots);         \
+    storage_point_empty(x, start_s, end_s);                    \
+    (x).gap_count = _storage_point_slots ?                     \
+        _storage_point_slots : 1;                              \
+} while(0)
 
-#define storage_point_is_unset(x) (!(x).count)
-#define storage_point_is_gap(x) (!netdata_double_isnumber((x).sum))
-#define storage_point_is_zero(x) (!(x).count || (netdata_double_is_zero((x).min) && netdata_double_is_zero((x).max) && netdata_double_is_zero((x).sum) && (x).anomaly_count == 0))
+#define STORAGE_POINT_UNSET (STORAGE_POINT){ .min = NAN, .max = NAN, .sum = NAN, .count = 0, .anomaly_count = 0, .flags = SN_FLAG_NONE, .gap_count = 0, .start_time_s = 0, .end_time_s = 0 }
+
+#define storage_point_has_value(x) ((x).count != 0)
+#define storage_point_is_unset(x) (!(x).count && !(x).gap_count)
+#define storage_point_is_gap(x) (!(x).count && (x).gap_count)
+#define storage_point_is_complete(x) ((x).count && !(x).gap_count)
+#define storage_point_is_partial(x) ((x).count && (x).gap_count)
+#define storage_point_slots(x) ((uint64_t)(x).count + (uint64_t)(x).gap_count)
+#define storage_point_is_zero(x) (!storage_point_has_value(x) || \
+    (netdata_double_is_zero((x).min) && netdata_double_is_zero((x).max) && \
+     netdata_double_is_zero((x).sum) && (x).anomaly_count == 0))
+
+#define storage_point_normalize_legacy_slots(x, nominal_slots) do { \
+    uint32_t _storage_point_slots = (uint32_t)(nominal_slots);    \
+    if(unlikely(!_storage_point_slots))                           \
+        _storage_point_slots = 1;                                \
+    if(likely((x).count && netdata_double_isnumber((x).sum))) {  \
+        (x).gap_count = _storage_point_slots > (x).count ?       \
+            _storage_point_slots - (x).count : 0;                \
+    }                                                            \
+    else {                                                       \
+        (x).min = (x).max = (x).sum = NAN;                       \
+        (x).count = 0;                                           \
+        (x).anomaly_count = 0;                                   \
+        (x).flags = SN_FLAG_NONE;                                \
+        (x).gap_count = _storage_point_slots;                    \
+    }                                                            \
+} while(0)
 
 #define storage_point_merge_to(dst, src) do {           \
         if(storage_point_is_unset(dst))                 \
             (dst) = (src);                              \
                                                         \
-        else if(!storage_point_is_unset(src) &&         \
-                !storage_point_is_gap(src)) {           \
+        else if(!storage_point_is_unset(src)) {         \
                                                         \
             if((src).start_time_s < (dst).start_time_s) \
                 (dst).start_time_s = (src).start_time_s;\
@@ -57,18 +89,29 @@ typedef struct storage_point {
             if((src).end_time_s > (dst).end_time_s)     \
                 (dst).end_time_s = (src).end_time_s;    \
                                                         \
-            if((src).min < (dst).min)                   \
-                (dst).min = (src).min;                  \
-                                                        \
-            if((src).max > (dst).max)                   \
-                (dst).max = (src).max;                  \
-                                                        \
-            (dst).sum += (src).sum;                     \
-                                                        \
-            (dst).count += (src).count;                 \
-            (dst).anomaly_count += (src).anomaly_count; \
-                                                        \
-            (dst).flags |= (src).flags & SN_FLAG_RESET; \
+            if(storage_point_has_value(src)) {          \
+                if(storage_point_has_value(dst)) {      \
+                    if((src).min < (dst).min)           \
+                        (dst).min = (src).min;          \
+                    if((src).max > (dst).max)           \
+                        (dst).max = (src).max;          \
+                    (dst).sum += (src).sum;             \
+                    (dst).count += (src).count;         \
+                    (dst).anomaly_count +=              \
+                        (src).anomaly_count;             \
+                }                                       \
+                else {                                  \
+                    (dst).min = (src).min;              \
+                    (dst).max = (src).max;              \
+                    (dst).sum = (src).sum;              \
+                    (dst).count = (src).count;          \
+                    (dst).anomaly_count =               \
+                        (src).anomaly_count;             \
+                }                                       \
+                (dst).flags |=                          \
+                    (src).flags & SN_FLAG_RESET;         \
+            }                                           \
+            (dst).gap_count += (src).gap_count;         \
         }                                               \
 } while(0)
 
@@ -76,8 +119,7 @@ typedef struct storage_point {
         if(storage_point_is_unset(dst))                 \
             (dst) = (src);                              \
                                                         \
-        else if(!storage_point_is_unset(src) &&         \
-                !storage_point_is_gap(src)) {           \
+        else if(!storage_point_is_unset(src)) {         \
                                                         \
             if((src).start_time_s < (dst).start_time_s) \
                 (dst).start_time_s = (src).start_time_s;\
@@ -85,20 +127,32 @@ typedef struct storage_point {
             if((src).end_time_s > (dst).end_time_s)     \
                 (dst).end_time_s = (src).end_time_s;    \
                                                         \
-            (dst).min += (src).min;                     \
-            (dst).max += (src).max;                     \
-            (dst).sum += (src).sum;                     \
-                                                        \
-            (dst).count += (src).count;                 \
-            (dst).anomaly_count += (src).anomaly_count; \
-                                                        \
-            (dst).flags |= (src).flags & SN_FLAG_RESET; \
+            if(storage_point_has_value(src)) {          \
+                if(storage_point_has_value(dst)) {      \
+                    (dst).min += (src).min;             \
+                    (dst).max += (src).max;             \
+                    (dst).sum += (src).sum;             \
+                    (dst).count += (src).count;         \
+                    (dst).anomaly_count +=              \
+                        (src).anomaly_count;             \
+                }                                       \
+                else {                                  \
+                    (dst).min = (src).min;              \
+                    (dst).max = (src).max;              \
+                    (dst).sum = (src).sum;              \
+                    (dst).count = (src).count;          \
+                    (dst).anomaly_count =               \
+                        (src).anomaly_count;             \
+                }                                       \
+                (dst).flags |=                          \
+                    (src).flags & SN_FLAG_RESET;         \
+            }                                           \
+            (dst).gap_count += (src).gap_count;         \
         }                                               \
 } while(0)
 
 #define storage_point_make_positive(sp) do {            \
-        if(!storage_point_is_unset(sp) &&               \
-           !storage_point_is_gap(sp)) {                 \
+        if(storage_point_has_value(sp)) {               \
                                                         \
             if(unlikely(signbit((sp).sum)))             \
                 (sp).sum = -(sp).sum;                   \
@@ -118,7 +172,7 @@ typedef struct storage_point {
 } while(0)
 
 #define storage_point_anomaly_rate(sp) \
-    (NETDATA_DOUBLE)(storage_point_is_unset(sp) ? 0.0 : (NETDATA_DOUBLE)((sp).anomaly_count) * 100.0 / (NETDATA_DOUBLE)((sp).count))
+    (NETDATA_DOUBLE)(storage_point_has_value(sp) ? (NETDATA_DOUBLE)((sp).anomaly_count) * 100.0 / (NETDATA_DOUBLE)((sp).count) : 0.0)
 
 #define storage_point_average_value(sp) \
     ((sp).count ? (sp).sum / (NETDATA_DOUBLE)((sp).count) : 0.0)

--- a/src/libnetdata/storage-point.h
+++ b/src/libnetdata/storage-point.h
@@ -60,7 +60,19 @@ typedef struct storage_point {
     (netdata_double_is_zero((x).min) && netdata_double_is_zero((x).max) && \
      netdata_double_is_zero((x).sum) && (x).anomaly_count == 0))
 
-#define storage_point_merge_to(dst, src) do {           \
+#define storage_point_merge_values(dst, src) do {       \
+        if((src).min < (dst).min)                       \
+            (dst).min = (src).min;                      \
+        if((src).max > (dst).max)                       \
+            (dst).max = (src).max;                      \
+} while(0)
+
+#define storage_point_add_values(dst, src) do {         \
+        (dst).min += (src).min;                         \
+        (dst).max += (src).max;                         \
+} while(0)
+
+#define storage_point_accumulate_to(dst, src, values) do { \
         if(storage_point_is_unset(dst))                 \
             (dst) = (src);                              \
                                                         \
@@ -74,10 +86,7 @@ typedef struct storage_point {
                                                         \
             if(storage_point_has_value(src)) {          \
                 if(storage_point_has_value(dst)) {      \
-                    if((src).min < (dst).min)           \
-                        (dst).min = (src).min;          \
-                    if((src).max > (dst).max)           \
-                        (dst).max = (src).max;          \
+                    values(dst, src);                   \
                     (dst).sum += (src).sum;             \
                     (dst).count += (src).count;         \
                     (dst).anomaly_count +=              \
@@ -98,41 +107,11 @@ typedef struct storage_point {
         }                                               \
 } while(0)
 
-#define storage_point_add_to(dst, src) do {             \
-        if(storage_point_is_unset(dst))                 \
-            (dst) = (src);                              \
-                                                        \
-        else if(!storage_point_is_unset(src)) {         \
-                                                        \
-            if((src).start_time_s < (dst).start_time_s) \
-                (dst).start_time_s = (src).start_time_s;\
-                                                        \
-            if((src).end_time_s > (dst).end_time_s)     \
-                (dst).end_time_s = (src).end_time_s;    \
-                                                        \
-            if(storage_point_has_value(src)) {          \
-                if(storage_point_has_value(dst)) {      \
-                    (dst).min += (src).min;             \
-                    (dst).max += (src).max;             \
-                    (dst).sum += (src).sum;             \
-                    (dst).count += (src).count;         \
-                    (dst).anomaly_count +=              \
-                        (src).anomaly_count;             \
-                }                                       \
-                else {                                  \
-                    (dst).min = (src).min;              \
-                    (dst).max = (src).max;              \
-                    (dst).sum = (src).sum;              \
-                    (dst).count = (src).count;          \
-                    (dst).anomaly_count =               \
-                        (src).anomaly_count;             \
-                }                                       \
-                (dst).flags |=                          \
-                    (src).flags & SN_FLAG_RESET;         \
-            }                                           \
-            (dst).gap_count += (src).gap_count;         \
-        }                                               \
-} while(0)
+#define storage_point_merge_to(dst, src) \
+    storage_point_accumulate_to(dst, src, storage_point_merge_values)
+
+#define storage_point_add_to(dst, src) \
+    storage_point_accumulate_to(dst, src, storage_point_add_values)
 
 #define storage_point_make_positive(sp) do {            \
         if(storage_point_has_value(sp)) {               \

--- a/src/libnetdata/storage-point.h
+++ b/src/libnetdata/storage-point.h
@@ -48,7 +48,7 @@ typedef struct storage_point {
         _storage_point_slots : 1;                              \
 } while(0)
 
-#define STORAGE_POINT_UNSET (STORAGE_POINT){ .min = NAN, .max = NAN, .sum = NAN, .count = 0, .anomaly_count = 0, .flags = SN_FLAG_NONE, .gap_count = 0, .start_time_s = 0, .end_time_s = 0 }
+#define STORAGE_POINT_UNSET (STORAGE_POINT){ .min = NAN, .max = NAN, .sum = NAN, .start_time_s = 0, .end_time_s = 0, .count = 0, .anomaly_count = 0, .flags = SN_FLAG_NONE, .gap_count = 0 }
 
 #define storage_point_has_value(x) ((x).count != 0)
 #define storage_point_is_unset(x) (!(x).count && !(x).gap_count)

--- a/src/libnetdata/storage-point.h
+++ b/src/libnetdata/storage-point.h
@@ -60,23 +60,6 @@ typedef struct storage_point {
     (netdata_double_is_zero((x).min) && netdata_double_is_zero((x).max) && \
      netdata_double_is_zero((x).sum) && (x).anomaly_count == 0))
 
-#define storage_point_normalize_legacy_slots(x, nominal_slots) do { \
-    uint32_t _storage_point_slots = (uint32_t)(nominal_slots);    \
-    if(unlikely(!_storage_point_slots))                           \
-        _storage_point_slots = 1;                                \
-    if(likely((x).count && netdata_double_isnumber((x).sum))) {  \
-        (x).gap_count = _storage_point_slots > (x).count ?       \
-            _storage_point_slots - (x).count : 0;                \
-    }                                                            \
-    else {                                                       \
-        (x).min = (x).max = (x).sum = NAN;                       \
-        (x).count = 0;                                           \
-        (x).anomaly_count = 0;                                   \
-        (x).flags = SN_FLAG_NONE;                                \
-        (x).gap_count = _storage_point_slots;                    \
-    }                                                            \
-} while(0)
-
 #define storage_point_merge_to(dst, src) do {           \
         if(storage_point_is_unset(dst))                 \
             (dst) = (src);                              \

--- a/src/streaming/tests/stream-replication-query-test.c
+++ b/src/streaming/tests/stream-replication-query-test.c
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#define rrdeng_load_metric_next stream_replication_test_next
+#define rrdeng_load_metric_is_finished stream_replication_test_is_finished
+#define rrdeng_load_align_to_optimal_before stream_replication_test_align_to_optimal_before
+#include "../stream-replication-sender.c"
+#undef rrdeng_load_align_to_optimal_before
+#undef rrdeng_load_metric_is_finished
+#undef rrdeng_load_metric_next
+
+struct stream_replication_test_query {
+    const STORAGE_POINT *points;
+    size_t points_count;
+    size_t next_point;
+    time_t optimal_before;
+};
+
+static bool stream_replication_test_used_rrddim_backend;
+
+STORAGE_POINT stream_replication_test_next(struct storage_engine_query_handle *seqh) {
+    struct stream_replication_test_query *query = (struct stream_replication_test_query *)seqh->handle;
+    if(query->next_point >= query->points_count)
+        return STORAGE_POINT_UNSET;
+
+    return query->points[query->next_point++];
+}
+
+int stream_replication_test_is_finished(struct storage_engine_query_handle *seqh) {
+    struct stream_replication_test_query *query = (struct stream_replication_test_query *)seqh->handle;
+    return query->next_point >= query->points_count;
+}
+
+time_t stream_replication_test_align_to_optimal_before(struct storage_engine_query_handle *seqh) {
+    struct stream_replication_test_query *query = (struct stream_replication_test_query *)seqh->handle;
+    return query->optimal_before;
+}
+
+STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *seqh __maybe_unused) {
+    stream_replication_test_used_rrddim_backend = true;
+    return STORAGE_POINT_UNSET;
+}
+
+int rrddim_query_is_finished(struct storage_engine_query_handle *seqh __maybe_unused) {
+    stream_replication_test_used_rrddim_backend = true;
+    return 1;
+}
+
+time_t rrddim_query_align_to_optimal_before(struct storage_engine_query_handle *seqh) {
+    stream_replication_test_used_rrddim_backend = true;
+    return seqh->end_time_s;
+}
+
+static STORAGE_POINT stream_replication_test_point(
+    time_t start_time_s, time_t end_time_s, NETDATA_DOUBLE value) {
+    return (STORAGE_POINT){
+        .min = value,
+        .max = value,
+        .sum = value,
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .count = 1,
+        .anomaly_count = 0,
+        .flags = SN_DEFAULT_FLAGS,
+        .gap_count = 0,
+    };
+}
+
+static STORAGE_POINT stream_replication_test_gap(time_t start_time_s, time_t end_time_s) {
+    STORAGE_POINT sp;
+    storage_point_empty(sp, start_time_s, end_time_s);
+    return sp;
+}
+
+int main(void) {
+    const STORAGE_POINT points_a[] = {
+        stream_replication_test_point(100, 160, 1),
+        stream_replication_test_point(160, 170, 2),
+        stream_replication_test_point(170, 180, 3),
+        stream_replication_test_point(180, 190, 4),
+        stream_replication_test_point(190, 200, 5),
+    };
+    const STORAGE_POINT points_b[] = {
+        stream_replication_test_point(100, 160, 11),
+        stream_replication_test_point(160, 170, 12),
+        stream_replication_test_gap(170, 180),
+        stream_replication_test_point(180, 190, 14),
+        stream_replication_test_point(190, 200, 15),
+        stream_replication_test_point(200, 210, 16),
+    };
+
+    struct stream_replication_test_query query_a = {
+        .points = points_a,
+        .points_count = _countof(points_a),
+        .optimal_before = 200,
+    };
+    struct stream_replication_test_query query_b = {
+        .points = points_b,
+        .points_count = _countof(points_b),
+        .optimal_before = 210,
+    };
+
+    RRDSET st = { 0 };
+    st.update_every = 10;
+    st.last_updated.tv_sec = 300;
+
+    RRDDIM *rd_a = callocz(1, sizeof(*rd_a));
+    RRDDIM *rd_b = callocz(1, sizeof(*rd_b));
+    rd_a->id = string_strdupz("a");
+    rd_b->id = string_strdupz("b");
+
+    struct replication_query *q = callocz(
+        1, sizeof(*q) + 2 * sizeof(struct replication_dimension));
+    q->st = &st;
+    q->query.after = 100;
+    q->query.before = 175;
+    q->query.execute = true;
+    q->query.enable_streaming = false;
+    q->wall_clock_time = 1000;
+    q->dimensions = 2;
+
+    q->data[0].enabled = true;
+    q->data[0].rd = rd_a;
+    q->data[0].handle.seb = STORAGE_ENGINE_BACKEND_DBENGINE;
+    q->data[0].handle.handle = (STORAGE_QUERY_HANDLE *)&query_a;
+
+    q->data[1].enabled = true;
+    q->data[1].rd = rd_b;
+    q->data[1].handle.seb = STORAGE_ENGINE_BACKEND_DBENGINE;
+    q->data[1].handle.handle = (STORAGE_QUERY_HANDLE *)&query_b;
+
+    BUFFER *wb = buffer_create(0, NULL);
+    bool finished_with_gap = replication_query_execute(wb, q, SIZE_MAX);
+
+    static const char expected[] =
+        "RBEGIN '' 100 160 1000\n"
+        "RSET \"a\" 1 ''\n"
+        "RSET \"b\" 11 ''\n"
+        "RBEGIN '' 160 170 1000\n"
+        "RSET \"a\" 2 ''\n"
+        "RSET \"b\" 12 ''\n"
+        "RBEGIN '' 170 180 1000\n"
+        "RSET \"a\" 3 ''\n"
+        "RBEGIN '' 180 190 1000\n"
+        "RSET \"a\" 4 ''\n"
+        "RSET \"b\" 14 ''\n"
+        "RBEGIN '' 190 200 1000\n"
+        "RSET \"a\" 5 ''\n"
+        "RSET \"b\" 15 ''\n";
+
+    int errors = 0;
+    if(stream_replication_test_used_rrddim_backend || finished_with_gap ||
+       q->query.after != 100 || q->query.before != 200 ||
+       q->points_read != 10 || q->points_generated != 9 ||
+       strcmp(buffer_tostring(wb), expected) != 0) {
+        fprintf(stderr,
+                "stream replication result: rrddim=%d gap=%d after=%ld before=%ld read=%zu generated=%zu\n"
+                "expected:\n%sactual:\n%s",
+                stream_replication_test_used_rrddim_backend, finished_with_gap,
+                q->query.after, q->query.before,
+                q->points_read, q->points_generated,
+                expected, buffer_tostring(wb));
+        errors++;
+    }
+
+    buffer_free(wb);
+    freez(q);
+    string_freez(rd_a->id);
+    string_freez(rd_b->id);
+    freez(rd_a);
+    freez(rd_b);
+
+    return errors ? 1 : 0;
+}

--- a/src/streaming/tests/stream-replication-query-test.c
+++ b/src/streaming/tests/stream-replication-query-test.c
@@ -153,10 +153,11 @@ int main(void) {
        q->points_read != 10 || q->points_generated != 9 ||
        strcmp(buffer_tostring(wb), expected) != 0) {
         fprintf(stderr,
-                "stream replication result: rrddim=%d gap=%d after=%ld before=%ld read=%zu generated=%zu\n"
+                "stream replication result: rrddim=%d gap=%d after=%" PRIdMAX " before=%" PRIdMAX
+                " read=%zu generated=%zu\n"
                 "expected:\n%sactual:\n%s",
                 stream_replication_test_used_rrddim_backend, finished_with_gap,
-                q->query.after, q->query.before,
+                (intmax_t)q->query.after, (intmax_t)q->query.before,
                 q->points_read, q->points_generated,
                 expected, buffer_tostring(wb));
         errors++;

--- a/src/web/api/queries/incremental_sum/incremental_sum.h
+++ b/src/web/api/queries/incremental_sum/incremental_sum.h
@@ -59,9 +59,9 @@ static inline NETDATA_DOUBLE tg_incremental_sum_flush(RRDR *r, RRDR_VALUE_FLAGS 
     }
     else {
         value = g->last - g->first;
+        g->first = g->last;
     }
 
-    g->first = g->last;
     g->last = NAN;
     g->count = 0;
 

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -74,13 +74,18 @@ static NETDATA_DOUBLE query_point_grouping_value(
         }                                                               \
 } while(0)
 
-#define query_add_point_to_group(r, point, ops, add_flush)        do {  \
+#define query_add_point_to_group(r, point, ops, add_flush, now_end_time, source_end_time) do { \
     if(likely(netdata_double_isnumber((point).value))) {                \
         if(likely(fpclassify((point).value) != FP_ZERO))                \
             (ops)->group_points_non_zero++;                             \
                                                                         \
-        if(unlikely((point).sp.flags & SN_FLAG_RESET))                  \
-            (ops)->group_value_flags |= RRDR_VALUE_RESET;               \
+        if(unlikely((point).sp.flags & SN_FLAG_RESET)) {                \
+            time_t _row_start =                                        \
+                (now_end_time) - (ops)->view_update_every;              \
+            if((source_end_time) > _row_start &&                        \
+               (source_end_time) <= (now_end_time))                     \
+                (ops)->group_value_flags |= RRDR_VALUE_RESET;           \
+        }                                                               \
                                                                         \
         NETDATA_DOUBLE grouping_value =                                    \
             query_point_grouping_value(point, ops, add_flush);             \
@@ -350,7 +355,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 if(likely(new_point.sp.end_time_s > now_start_time)) { // likely to favor tier0
                     // this db point ends after our now_start time
 
-                    query_add_point_to_group(r, new_point, ops, add_flush);
+                    query_add_point_to_group(
+                        r, new_point, ops, add_flush, now_end_time, new_point.sp.end_time_s);
                     new_point.added = true;
                 }
                 else {
@@ -415,10 +421,12 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             // but, we don't need it
 
             QUERY_POINT current_point;
+            time_t source_end_time;
 
             if(likely(now_end_time > new_point.sp.start_time_s)) {
                 // it is time for our NEW point to be used
                 current_point = new_point;
+                source_end_time = new_point.sp.end_time_s;
                 new_point.added = true; // first copy, then set it, so that new_point will not be added again
                 query_interpolate_point(current_point, last1_point, now_end_time);
 
@@ -438,6 +446,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             else if(likely(now_end_time <= last1_point.sp.end_time_s)) {
                 // our LAST point is still valid
                 current_point = last1_point;
+                source_end_time = last1_point.sp.end_time_s;
                 last1_point.added = true; // first copy, then set it, so that last1_point will not be added again
                 query_interpolate_point(current_point, last2_point, now_end_time);
 
@@ -456,9 +465,11 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             else {
                 // a GAP, we don't have a value this time
                 current_point = QUERY_POINT_EMPTY;
+                source_end_time = 0;
             }
 
-            query_add_point_to_group(r, current_point, ops, add_flush);
+            query_add_point_to_group(
+                r, current_point, ops, add_flush, now_end_time, source_end_time);
 
             rrdr_line = rrdr_line_init(r, now_end_time, rrdr_line);
             size_t rrdr_o_v_index = rrdr_line * r->d + dim_id_in_rrdr;

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -79,19 +79,19 @@ static NETDATA_DOUBLE query_point_grouping_value(
         if(likely(fpclassify((point).value) != FP_ZERO))                \
             (ops)->group_points_non_zero++;                             \
                                                                         \
-        if(unlikely((point).sp.flags & SN_FLAG_RESET)) {                \
-            time_t _row_start =                                        \
-                (now_end_time) - (ops)->view_update_every;              \
-            if((source_end_time) > _row_start &&                        \
-               (source_end_time) <= (now_end_time))                     \
-                (ops)->group_value_flags |= RRDR_VALUE_RESET;           \
-        }                                                               \
+        time_t _row_start = (now_end_time) - (ops)->view_update_every;  \
+        bool _sample_in_row = (source_end_time) > _row_start &&         \
+                              (source_end_time) <= (now_end_time);       \
+                                                                        \
+        if(unlikely((point).sp.flags & SN_FLAG_RESET) && _sample_in_row) \
+            (ops)->group_value_flags |= RRDR_VALUE_RESET;               \
                                                                         \
         NETDATA_DOUBLE grouping_value =                                    \
             query_point_grouping_value(point, ops, add_flush);             \
         time_grouping_add(r, grouping_value, add_flush);                   \
                                                                         \
-        storage_point_merge_to((ops)->group_point, (point).sp);         \
+        if((point).tier != 0 || _sample_in_row)                          \
+            storage_point_merge_to((ops)->group_point, (point).sp);     \
         if(!(point).added)                                              \
             storage_point_merge_to((ops)->query_point, (point).sp);     \
     }                                                                   \
@@ -187,6 +187,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     // when we switch plans, we read-ahead a point from the next plan
     // to join them smoothly at the exact time the next plan begins
     STORAGE_POINT next1_point = STORAGE_POINT_UNSET;
+    uint8_t next1_tier = 0;
 
     time_t now_start_time = after_wanted - ops->query_granularity;
     time_t now_end_time   = after_wanted + (ops->view_update_every - ops->query_granularity);
@@ -202,6 +203,13 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s);
             db_points_read_since_plan_switch = 0;
         }
+
+        // Interpolation can consume a tier-0 point before the row that owns its metadata.
+        if(new_point.added && new_point.tier == 0 &&
+           new_point.sp.end_time_s > now_start_time &&
+           new_point.sp.end_time_s <= now_end_time &&
+           netdata_double_isnumber(new_point.value))
+            storage_point_merge_to(ops->group_point, new_point.sp);
 
         // read all the points of the db, prior to the time we need (now_end_time)
 
@@ -233,8 +241,10 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             // fetch the new point
             {
                 STORAGE_POINT sp;
+                uint8_t sp_tier;
                 if(likely(storage_point_is_unset(next1_point))) {
                     db_points_read_since_plan_switch++;
+                    sp_tier = (uint8_t)ops->tier;
                     sp = storage_engine_query_next_metric(ops->seqh);
                     ops->db_points_read_per_tier[ops->tier]++;
                     ops->db_total_points_read++;
@@ -245,6 +255,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 else {
                     // ONE POINT READ-AHEAD
                     sp = next1_point;
+                    sp_tier = next1_tier;
                     storage_point_unset(next1_point);
                     db_points_read_since_plan_switch = 1;
                 }
@@ -262,23 +273,29 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                     // B. part of the point of the previous plan overlaps with the point from the next plan
 
                     STORAGE_POINT sp2 = storage_engine_query_next_metric(ops->seqh);
+                    uint8_t sp2_tier = (uint8_t)ops->tier;
                     ops->db_points_read_per_tier[ops->tier]++;
                     ops->db_total_points_read++;
 
                     if(unlikely(options & RRDR_OPTION_ABSOLUTE))
                         storage_point_make_positive(sp2);
 
-                    if(sp.start_time_s > sp2.start_time_s)
+                    if(sp.start_time_s > sp2.start_time_s) {
                         // the point from the previous plan is useless
                         sp = sp2;
-                    else
+                        sp_tier = sp2_tier;
+                    }
+                    else {
                         // let the query run from the previous plan
                         // but setting this will also cut off the interpolation
                         // of the point from the previous plan
                         next1_point = sp2;
+                        next1_tier = sp2_tier;
+                    }
                 }
 
                 new_point.sp = sp;
+                new_point.tier = sp_tier;
                 new_point.added = false;
                 query_point_set_id(new_point, ops->db_total_points_read);
 

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -626,12 +626,12 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             }
 
             if(likely(netdata_double_isnumber(carried_value))) {
+                if(unlikely(new_point.sp.flags & SN_FLAG_RESET))
+                    ops->group_value_flags |= RRDR_VALUE_RESET;
+
                 if(settle_value) {
                     if(likely(fpclassify(carried_value) != FP_ZERO))
                         ops->group_points_non_zero++;
-
-                    if(unlikely(new_point.sp.flags & SN_FLAG_RESET))
-                        ops->group_value_flags |= RRDR_VALUE_RESET;
 
                     r->time_grouping.add(r, carried_value);
                     if(!new_point.added)

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -84,6 +84,14 @@ static NETDATA_DOUBLE query_point_total_projection(
             &(point), (now) - (view_update_every), (now));                           \
 } while(0)
 
+#define query_merge_point_evidence(point, ops, sample_in_row) do {       \
+    bool _evidence_sample_in_row = (sample_in_row);                      \
+    if((point).tier != 0 || _evidence_sample_in_row)                     \
+        storage_point_merge_to((ops)->group_point, (point).sp);          \
+    if(!(point).added)                                                   \
+        storage_point_merge_to((ops)->query_point, (point).sp);          \
+} while(0)
+
 #define query_add_point_to_group(r, point, ops, add_flush, sample_in_row) do { \
     if(likely(netdata_double_isnumber((point).value))) {                \
         if(likely(fpclassify((point).value) != FP_ZERO))                \
@@ -96,11 +104,10 @@ static NETDATA_DOUBLE query_point_total_projection(
                                                                         \
         time_grouping_add(r, (point).value, add_flush);                  \
                                                                         \
-        if((point).tier != 0 || _sample_in_row)                          \
-            storage_point_merge_to((ops)->group_point, (point).sp);     \
-        if(!(point).added)                                              \
-            storage_point_merge_to((ops)->query_point, (point).sp);     \
+        query_merge_point_evidence(point, ops, _sample_in_row);         \
     }                                                                   \
+    else if(unlikely(storage_point_is_gap((point).sp)))                 \
+        query_merge_point_evidence(point, ops, sample_in_row);          \
                                                                         \
     (ops)->group_points_added++;                                        \
 } while(0)
@@ -317,7 +324,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
 //                         new_point.id, new_point.start_time, new_point.end_time, now_start_time, now_end_time, after_wanted, before_wanted);
 //
                 // get the right value from the point we got
-                if(likely(!storage_point_is_unset(sp) && !storage_point_is_gap(sp))) {
+                if(likely(storage_point_has_value(sp))) {
 
                     if(unlikely(use_anomaly_bit_as_value))
                         new_point.value = storage_point_anomaly_rate(sp);
@@ -540,6 +547,9 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             // update the dimension options
             if(likely(ops->group_points_non_zero))
                 r->od[dim_id_in_rrdr] |= RRDR_DIMENSION_NONZERO;
+
+            if(unlikely(storage_point_is_partial(ops->group_point)))
+                ops->group_value_flags |= RRDR_VALUE_PARTIAL;
 
             // store the specific point options
             *rrdr_value_options_ptr = ops->group_value_flags;

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -284,7 +284,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
 
                 // ONE POINT READ-AHEAD
                 if(unlikely(query_plan_should_switch_plan(ops, sp.end_time_s) &&
-                    query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s))) {
+                    query_planer_next_plan(
+                        ops, now_end_time - ops->plan_switch_time_offset, new_point.sp.end_time_s))) {
 
                     // The end time of the current point, crosses our plans (tiers)
                     // so, we switched plan (tier)

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -84,10 +84,17 @@ static NETDATA_DOUBLE query_point_total_projection(
             &(point), (now) - (view_update_every), (now));                           \
 } while(0)
 
+// Numeric values are owned by time grouping; row metadata only needs contributor evidence.
+#define query_merge_evidence_to_group(ops, sp) do {                      \
+    (ops)->group_point.count += (sp).count;                              \
+    (ops)->group_point.anomaly_count += (sp).anomaly_count;              \
+    (ops)->group_point.gap_count += (sp).gap_count;                      \
+} while(0)
+
 #define query_merge_point_evidence(point, ops, sample_in_row) do {       \
     bool _evidence_sample_in_row = (sample_in_row);                      \
     if((point).tier != 0 || _evidence_sample_in_row)                     \
-        storage_point_merge_to((ops)->group_point, (point).sp);          \
+        query_merge_evidence_to_group((ops), (point).sp);                \
     if(!(point).added)                                                   \
         storage_point_merge_to((ops)->query_point, (point).sp);          \
 } while(0)
@@ -213,7 +220,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
         // A gap projected before its timestamp still belongs to the row containing that timestamp.
         if(unlikely(new_point.added && new_point.tier == 0 && storage_point_is_gap(new_point.sp) &&
                     new_point.sp.end_time_s > now_start_time && new_point.sp.end_time_s <= now_end_time)) {
-            storage_point_merge_to(ops->group_point, new_point.sp);
+            query_merge_evidence_to_group(ops, new_point.sp);
         }
 
         if(unlikely(query_result_plan_should_switch_plan(ops, now_end_time))) {
@@ -554,8 +561,9 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             if(likely(ops->group_points_non_zero))
                 r->od[dim_id_in_rrdr] |= RRDR_DIMENSION_NONZERO;
 
-            if(unlikely(storage_point_is_partial(ops->group_point)))
-                ops->group_value_flags |= RRDR_VALUE_PARTIAL;
+            // This runs for every result row, so materialize PARTIAL without a hot-path branch.
+            ops->group_value_flags |= (RRDR_VALUE_FLAGS)(
+                ((!!ops->group_point.count) & (!!ops->group_point.gap_count)) * RRDR_VALUE_PARTIAL);
 
             // store the specific point options
             *rrdr_value_options_ptr = ops->group_value_flags;
@@ -626,7 +634,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                         storage_point_merge_to(ops->query_point, new_point.sp);
                 }
 
-                storage_point_merge_to(ops->group_point, new_point.sp);
+                query_merge_evidence_to_group(ops, new_point.sp);
             }
 
             if(settle_value) {

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -210,6 +210,12 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     for( ; points_added < points_wanted && query_is_finished_counter <= 10 ;
         now_start_time = now_end_time, now_end_time += ops->view_update_every) {
 
+        // A gap projected before its timestamp still belongs to the row containing that timestamp.
+        if(unlikely(new_point.added && new_point.tier == 0 && storage_point_is_gap(new_point.sp) &&
+                    new_point.sp.end_time_s > now_start_time && new_point.sp.end_time_s <= now_end_time)) {
+            storage_point_merge_to(ops->group_point, new_point.sp);
+        }
+
         if(unlikely(query_result_plan_should_switch_plan(ops, now_end_time))) {
             query_planer_next_plan(
                 ops, now_end_time - ops->plan_switch_time_offset, new_point.sp.end_time_s);

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -261,7 +261,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                     ops->db_total_points_read++;
 
                     if(unlikely(options & RRDR_OPTION_ABSOLUTE))
-                        storage_point_make_positive(sp);
+                        storage_point_make_positive(sp2);
 
                     if(sp.start_time_s > sp2.start_time_s)
                         // the point from the previous plan is useless

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -280,6 +280,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                     db_points_read_since_plan_switch = 1;
                 }
 
+                NETDATA_DOUBLE prepared_sum = sp.sum;
+
                 // ONE POINT READ-AHEAD
                 if(unlikely(query_plan_should_switch_plan(ops, sp.end_time_s) &&
                     query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s))) {
@@ -309,6 +311,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                         // the point from the previous plan is useless
                         sp = sp2;
                         sp_tier = sp2_tier;
+                        prepared_sum = sp2.sum;
                     }
                     else {
                         // let the query run from the previous plan
@@ -321,7 +324,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                             time_t duration = sp.end_time_s - sp.start_time_s;
                             time_t retained = sp2.start_time_s - sp.start_time_s;
                             if(!qm->values_stored_as_rates && duration > 0)
-                                sp.sum *= (NETDATA_DOUBLE)retained / (NETDATA_DOUBLE)duration;
+                                prepared_sum *= (NETDATA_DOUBLE)retained / (NETDATA_DOUBLE)duration;
                             sp.end_time_s = sp2.start_time_s;
                         }
                     }
@@ -357,7 +360,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                                 break;
 
                             case TIER_QUERY_FETCH_SUM:
-                                new_point.value = sp.sum;
+                                new_point.value = prepared_sum;
                                 if(unlikely(sp.start_time_s < now_start_time && sp.end_time_s < now_end_time))
                                     new_point.value = query_point_total_projection(
                                         &new_point, now_start_time, now_end_time);
@@ -367,7 +370,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                                 time_t duration = sp.end_time_s - sp.start_time_s;
                                 uint64_t slots = storage_point_slots(sp);
                                 new_point.value = likely(duration > 0 && slots) ?
-                                    sp.sum * (NETDATA_DOUBLE)duration / (NETDATA_DOUBLE)slots : sp.sum;
+                                    prepared_sum * (NETDATA_DOUBLE)duration / (NETDATA_DOUBLE)slots : prepared_sum;
                                 if(unlikely(sp.start_time_s < now_start_time && sp.end_time_s < now_end_time))
                                     new_point.value = query_point_total_projection(
                                         &new_point, now_start_time, now_end_time);

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -37,22 +37,6 @@ static long rrdr_line_init(RRDR *r __maybe_unused, time_t t __maybe_unused, long
     return rrdr_line;
 }
 
-ALWAYS_INLINE
-static NETDATA_DOUBLE query_point_grouping_value(
-    QUERY_POINT point, QUERY_ENGINE_OPS *ops, RRDR_TIME_GROUPING add_flush) {
-    if(likely(add_flush != RRDR_GROUPING_SUM || !ops->qm->values_stored_as_rates))
-        return point.value;
-
-    if(unlikely(storage_point_is_unset(point.sp) || storage_point_is_gap(point.sp) || !point.sp.count))
-        return point.value;
-
-    time_t duration = point.sp.end_time_s - point.sp.start_time_s;
-    if(unlikely(duration <= 0))
-        return point.value;
-
-    return point.value * (NETDATA_DOUBLE)duration / (NETDATA_DOUBLE)point.sp.count;
-}
-
 // ----------------------------------------------------------------------------
 // dimension level query engine
 
@@ -74,21 +58,43 @@ static NETDATA_DOUBLE query_point_grouping_value(
         }                                                               \
 } while(0)
 
-#define query_add_point_to_group(r, point, ops, add_flush, now_end_time, source_end_time) do { \
+ALWAYS_INLINE
+static NETDATA_DOUBLE query_point_total_projection(
+    const QUERY_POINT *point, time_t row_start_time, time_t row_end_time) {
+    time_t duration = point->sp.end_time_s - point->sp.start_time_s;
+    if(unlikely(duration <= 0))
+        return point->value;
+
+    time_t overlap_start = MAX(point->sp.start_time_s, row_start_time);
+    time_t overlap_end = MIN(point->sp.end_time_s, row_end_time);
+    if(unlikely(overlap_end <= overlap_start))
+        return NAN;
+
+    if(likely(overlap_start == point->sp.start_time_s && overlap_end == point->sp.end_time_s))
+        return point->value;
+
+    return point->value * (NETDATA_DOUBLE)(overlap_end - overlap_start) / (NETDATA_DOUBLE)duration;
+}
+
+#define query_project_point(point, previous, now, view_update_every, point_mode) do { \
+    if(likely((point_mode) == QUERY_POINT_MODE_LINEAR))                              \
+        query_interpolate_point(point, previous, now);                               \
+    else if(unlikely((point_mode) == QUERY_POINT_MODE_TOTAL))                        \
+        (point).value = query_point_total_projection(                                \
+            &(point), (now) - (view_update_every), (now));                           \
+} while(0)
+
+#define query_add_point_to_group(r, point, ops, add_flush, sample_in_row) do { \
     if(likely(netdata_double_isnumber((point).value))) {                \
         if(likely(fpclassify((point).value) != FP_ZERO))                \
             (ops)->group_points_non_zero++;                             \
                                                                         \
-        time_t _row_start = (now_end_time) - (ops)->view_update_every;  \
-        bool _sample_in_row = (source_end_time) > _row_start &&         \
-                              (source_end_time) <= (now_end_time);       \
+        bool _sample_in_row = (sample_in_row);                          \
                                                                         \
         if(unlikely((point).sp.flags & SN_FLAG_RESET) && _sample_in_row) \
             (ops)->group_value_flags |= RRDR_VALUE_RESET;               \
                                                                         \
-        NETDATA_DOUBLE grouping_value =                                    \
-            query_point_grouping_value(point, ops, add_flush);             \
-        time_grouping_add(r, grouping_value, add_flush);                   \
+        time_grouping_add(r, (point).value, add_flush);                  \
                                                                         \
         if((point).tier != 0 || _sample_in_row)                          \
             storage_point_merge_to((ops)->group_point, (point).sp);     \
@@ -159,11 +165,11 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     }
 
     const RRDR_TIME_GROUPING add_flush = r->time_grouping.add_flush;
-
     ops->group_point = STORAGE_POINT_UNSET;
     ops->query_point = STORAGE_POINT_UNSET;
 
     RRDR_OPTIONS options = qt->window.options;
+    bool use_anomaly_bit_as_value = options & RRDR_OPTION_ANOMALY_BIT;
     size_t points_wanted = qt->window.points;
     time_t after_wanted = qt->window.after;
     time_t before_wanted = qt->window.before; (void)before_wanted;
@@ -175,8 +181,6 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     size_t points_added = 0;
 
     long rrdr_line = -1;
-    bool use_anomaly_bit_as_value = (r->internal.qt->window.options & RRDR_OPTION_ANOMALY_BIT) ? true : false;
-
     NETDATA_DOUBLE min = r->view.min, max = r->view.max;
 
     QUERY_POINT last2_point = QUERY_POINT_EMPTY;
@@ -199,17 +203,11 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     for( ; points_added < points_wanted && query_is_finished_counter <= 10 ;
         now_start_time = now_end_time, now_end_time += ops->view_update_every) {
 
-        if(unlikely(query_plan_should_switch_plan(ops, now_end_time))) {
-            query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s);
+        if(unlikely(query_result_plan_should_switch_plan(ops, now_end_time))) {
+            query_planer_next_plan(
+                ops, now_end_time - ops->plan_switch_time_offset, new_point.sp.end_time_s);
             db_points_read_since_plan_switch = 0;
         }
-
-        // Interpolation can consume a tier-0 point before the row that owns its metadata.
-        if(new_point.added && new_point.tier == 0 &&
-           new_point.sp.end_time_s > now_start_time &&
-           new_point.sp.end_time_s <= now_end_time &&
-           netdata_double_isnumber(new_point.value))
-            storage_point_merge_to(ops->group_point, new_point.sp);
 
         // read all the points of the db, prior to the time we need (now_end_time)
 
@@ -220,29 +218,29 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 last1_point = new_point;
             }
 
-            if(unlikely(storage_engine_query_is_finished(ops->seqh))) {
-                query_is_finished_counter++;
-
-                if(count_same_end_time != 0) {
-                    last2_point = last1_point;
-                    last1_point = new_point;
-                }
-                new_point = QUERY_POINT_EMPTY;
-                new_point.sp.start_time_s = last1_point.sp.end_time_s;
-                new_point.sp.end_time_s   = now_end_time;
-//
-//                if(debug_this) netdata_log_info("QUERY: is finished() returned true");
-//
-                break;
-            }
-            else
-                query_is_finished_counter = 0;
-
             // fetch the new point
             {
                 STORAGE_POINT sp;
                 uint8_t sp_tier;
+
                 if(likely(storage_point_is_unset(next1_point))) {
+                    if(unlikely(storage_engine_query_is_finished(ops->seqh))) {
+                        query_is_finished_counter++;
+
+                        if(count_same_end_time != 0) {
+                            last2_point = last1_point;
+                            last1_point = new_point;
+                        }
+                        new_point = QUERY_POINT_EMPTY;
+                        new_point.sp.start_time_s = last1_point.sp.end_time_s;
+                        new_point.sp.end_time_s   = now_end_time;
+//
+//                      if(debug_this) netdata_log_info("QUERY: is finished() returned true");
+//
+                        break;
+                    }
+
+                    query_is_finished_counter = 0;
                     db_points_read_since_plan_switch++;
                     sp_tier = (uint8_t)ops->tier;
                     sp = storage_engine_query_next_metric(ops->seqh);
@@ -253,6 +251,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                         storage_point_make_positive(sp);
                 }
                 else {
+                    query_is_finished_counter = 0;
+
                     // ONE POINT READ-AHEAD
                     sp = next1_point;
                     sp_tier = next1_tier;
@@ -280,7 +280,12 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                     if(unlikely(options & RRDR_OPTION_ABSOLUTE))
                         storage_point_make_positive(sp2);
 
-                    if(sp.start_time_s > sp2.start_time_s) {
+                    bool finer_total_overlap =
+                        ops->point_mode == QUERY_POINT_MODE_TOTAL &&
+                        sp2_tier < sp_tier && sp2.start_time_s < sp.end_time_s;
+
+                    if(sp.start_time_s > sp2.start_time_s ||
+                       (finer_total_overlap && sp2.start_time_s <= sp.start_time_s)) {
                         // the point from the previous plan is useless
                         sp = sp2;
                         sp_tier = sp2_tier;
@@ -291,6 +296,14 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                         // of the point from the previous plan
                         next1_point = sp2;
                         next1_tier = sp2_tier;
+
+                        if(unlikely(finer_total_overlap)) {
+                            time_t duration = sp.end_time_s - sp.start_time_s;
+                            time_t retained = sp2.start_time_s - sp.start_time_s;
+                            if(!qm->values_stored_as_rates && duration > 0)
+                                sp.sum *= (NETDATA_DOUBLE)retained / (NETDATA_DOUBLE)duration;
+                            sp.end_time_s = sp2.start_time_s;
+                        }
                     }
                 }
 
@@ -307,8 +320,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 if(likely(!storage_point_is_unset(sp) && !storage_point_is_gap(sp))) {
 
                     if(unlikely(use_anomaly_bit_as_value))
-                        new_point.value = storage_point_anomaly_rate(new_point.sp);
-
+                        new_point.value = storage_point_anomaly_rate(sp);
                     else {
                         switch (ops->tier_query_fetch) {
                             default:
@@ -326,6 +338,15 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
 
                             case TIER_QUERY_FETCH_SUM:
                                 new_point.value = sp.sum;
+                                if(unlikely(qm->values_stored_as_rates)) {
+                                    time_t duration = sp.end_time_s - sp.start_time_s;
+                                    if(likely(duration > 0))
+                                        new_point.value *=
+                                            (NETDATA_DOUBLE)duration / (NETDATA_DOUBLE)sp.count;
+                                }
+                                if(unlikely(sp.start_time_s < now_start_time && sp.end_time_s < now_end_time))
+                                    new_point.value = query_point_total_projection(
+                                        &new_point, now_start_time, now_end_time);
                                 break;
                         }
                     }
@@ -373,7 +394,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                     // this db point ends after our now_start time
 
                     query_add_point_to_group(
-                        r, new_point, ops, add_flush, now_end_time, new_point.sp.end_time_s);
+                        r, new_point, ops, add_flush, true);
                     new_point.added = true;
                 }
                 else {
@@ -433,6 +454,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             "QUERY: first part of query provides invalid point to interpolate (now_end_time %ld, stop_time %ld",
             now_end_time, stop_time);
 
+        NETDATA_DOUBLE new_point_total_remaining = NAN;
+
         do {
             // now_start_time is wrong in this loop
             // but, we don't need it
@@ -445,7 +468,16 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 current_point = new_point;
                 source_end_time = new_point.sp.end_time_s;
                 new_point.added = true; // first copy, then set it, so that new_point will not be added again
-                query_interpolate_point(current_point, last1_point, now_end_time);
+                query_project_point(
+                    current_point, last1_point, now_end_time, ops->view_update_every, ops->point_mode);
+
+                if(unlikely(ops->point_mode == QUERY_POINT_MODE_TOTAL &&
+                            netdata_double_isnumber(current_point.value))) {
+                    if(unlikely(!netdata_double_isnumber(new_point_total_remaining)))
+                        new_point_total_remaining = new_point.value;
+
+                    new_point_total_remaining -= current_point.value;
+                }
 
 //                internal_error(current_point.id > 0
 //                                && last1_point.id == 0
@@ -465,7 +497,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 current_point = last1_point;
                 source_end_time = last1_point.sp.end_time_s;
                 last1_point.added = true; // first copy, then set it, so that last1_point will not be added again
-                query_interpolate_point(current_point, last2_point, now_end_time);
+                query_project_point(
+                    current_point, last2_point, now_end_time, ops->view_update_every, ops->point_mode);
 
 //                internal_error(current_point.id > 0
 //                                && last2_point.id == 0
@@ -486,7 +519,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             }
 
             query_add_point_to_group(
-                r, current_point, ops, add_flush, now_end_time, source_end_time);
+                r, current_point, ops, add_flush,
+                source_end_time > now_end_time - ops->view_update_every && source_end_time <= now_end_time);
 
             rrdr_line = rrdr_line_init(r, now_end_time, rrdr_line);
             size_t rrdr_o_v_index = rrdr_line * r->d + dim_id_in_rrdr;
@@ -532,6 +566,49 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
 
         if(points_added >= points_wanted)
             break;
+
+        time_t next_row_start_time = now_end_time - ops->view_update_every;
+        if(unlikely(new_point.sp.end_time_s > next_row_start_time &&
+                    netdata_double_isnumber(new_point.value) &&
+                    ((new_point.added &&
+                      (ops->point_mode == QUERY_POINT_MODE_TOTAL ||
+                       (new_point.tier == 0 &&
+                        new_point.sp.start_time_s < next_row_start_time))) ||
+                     (!new_point.added &&
+                      ops->point_mode == QUERY_POINT_MODE_TOTAL &&
+                      storage_point_is_unset(next1_point))))) {
+            bool settle_value = ops->point_mode == QUERY_POINT_MODE_TOTAL ||
+                                new_point.sp.end_time_s >= qm->tiers[0].db_last_time_s;
+            NETDATA_DOUBLE carried_value = new_point.value;
+            if(ops->point_mode == QUERY_POINT_MODE_TOTAL && new_point.sp.end_time_s < now_end_time) {
+                if(likely(netdata_double_isnumber(new_point_total_remaining)))
+                    carried_value = new_point_total_remaining;
+                else
+                    carried_value = query_point_total_projection(
+                        &new_point, next_row_start_time, now_end_time);
+            }
+
+            if(likely(netdata_double_isnumber(carried_value))) {
+                if(settle_value) {
+                    if(likely(fpclassify(carried_value) != FP_ZERO))
+                        ops->group_points_non_zero++;
+
+                    if(unlikely(new_point.sp.flags & SN_FLAG_RESET))
+                        ops->group_value_flags |= RRDR_VALUE_RESET;
+
+                    r->time_grouping.add(r, carried_value);
+                    if(!new_point.added)
+                        storage_point_merge_to(ops->query_point, new_point.sp);
+                }
+
+                storage_point_merge_to(ops->group_point, new_point.sp);
+            }
+
+            if(settle_value) {
+                ops->group_points_added++;
+                new_point.added = true;
+            }
+        }
 
         // the loop above increased "now" by ops->view_update_every,
         // but the main loop will increase it too,

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -473,10 +473,14 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
 
                 if(unlikely(ops->point_mode == QUERY_POINT_MODE_TOTAL &&
                             netdata_double_isnumber(current_point.value))) {
-                    if(unlikely(!netdata_double_isnumber(new_point_total_remaining)))
-                        new_point_total_remaining = new_point.value;
-
-                    new_point_total_remaining -= current_point.value;
+                    if(unlikely(!netdata_double_isnumber(new_point_total_remaining))) {
+                        time_t duration = new_point.sp.end_time_s - new_point.sp.start_time_s;
+                        new_point_total_remaining = likely(duration > 0) ?
+                            new_point.value * (NETDATA_DOUBLE)(new_point.sp.end_time_s - now_end_time) /
+                                (NETDATA_DOUBLE)duration : 0.0;
+                    }
+                    else
+                        new_point_total_remaining -= current_point.value;
                 }
 
 //                internal_error(current_point.id > 0

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -338,16 +338,21 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
 
                             case TIER_QUERY_FETCH_SUM:
                                 new_point.value = sp.sum;
-                                if(unlikely(qm->values_stored_as_rates)) {
-                                    time_t duration = sp.end_time_s - sp.start_time_s;
-                                    if(likely(duration > 0))
-                                        new_point.value *=
-                                            (NETDATA_DOUBLE)duration / (NETDATA_DOUBLE)sp.count;
-                                }
                                 if(unlikely(sp.start_time_s < now_start_time && sp.end_time_s < now_end_time))
                                     new_point.value = query_point_total_projection(
                                         &new_point, now_start_time, now_end_time);
                                 break;
+
+                            case TIER_QUERY_FETCH_RATE_SUM: {
+                                time_t duration = sp.end_time_s - sp.start_time_s;
+                                uint64_t slots = storage_point_slots(sp);
+                                new_point.value = likely(duration > 0 && slots) ?
+                                    sp.sum * (NETDATA_DOUBLE)duration / (NETDATA_DOUBLE)slots : sp.sum;
+                                if(unlikely(sp.start_time_s < now_start_time && sp.end_time_s < now_end_time))
+                                    new_point.value = query_point_total_projection(
+                                        &new_point, now_start_time, now_end_time);
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -179,7 +179,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     }
 
     const RRDR_TIME_GROUPING add_flush = r->time_grouping.add_flush;
-    ops->group_point = STORAGE_POINT_UNSET;
+    ops->group_point = (QUERY_ROW_EVIDENCE){ 0 };
     ops->query_point = STORAGE_POINT_UNSET;
 
     RRDR_OPTIONS options = qt->window.options;
@@ -591,7 +591,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             ops->group_points_added = 0;
             ops->group_value_flags = RRDR_VALUE_NOTHING;
             ops->group_points_non_zero = 0;
-            ops->group_point = STORAGE_POINT_UNSET;
+            ops->group_point = (QUERY_ROW_EVIDENCE){ 0 };
 
             if(points_added < points_wanted)
                 now_end_time += ops->view_update_every;

--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -7,9 +7,26 @@
 #define HGBC_PARTIAL_FLAG (1U << 31)
 #define HGBC_COUNT_MASK   (~HGBC_PARTIAL_FLAG)
 
-void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
-                                         RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
-                                         STORAGE_POINT *query_points, size_t pass __maybe_unused) {
+static bool group_by_pass_propagates_raw_contributor_counts(const QUERY_TARGET *qt, size_t pass) {
+    // Raw count is an Agent-Cloud contract and needs an explicit capability before it can change.
+    if(query_target_aggregatable(qt))
+        return false;
+
+    for(size_t p = 0; p <= pass; p++) {
+        RRDR_GROUP_BY_FUNCTION aggregation = qt->request.group_by[p].aggregation;
+        if(aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE ||
+           aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE ||
+           (qt->request.group_by[p].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE))
+            return false;
+    }
+
+    return true;
+}
+
+static ALWAYS_INLINE void rrd2rrdr_group_by_add_metric_internal(
+    RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
+    RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
+    STORAGE_POINT *query_points, bool propagate_raw_contributor_counts) {
     if(!r_tmp || r_dst == r_tmp || !(r_tmp->od[d_tmp] & RRDR_DIMENSION_QUERIED))
         return;
 
@@ -75,7 +92,7 @@ void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t
             *co &= ~RRDR_VALUE_EMPTY;
             *co |= (o_tmp & (RRDR_VALUE_RESET | RRDR_VALUE_PARTIAL));
             *ar += ar_tmp;
-            (*gbc)++;
+            *gbc += propagate_raw_contributor_counts ? r_tmp->gbc[idx_tmp] : 1;
         }
         else if(r_dst->hgbc) {
             // count the hidden (denominator) contributions too, so that
@@ -88,6 +105,21 @@ void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t
                 r_dst->hgbc[idx_dst] |= HGBC_PARTIAL_FLAG;
         }
     }
+}
+
+void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
+                                  RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
+                                  STORAGE_POINT *query_points, size_t pass __maybe_unused) {
+    rrd2rrdr_group_by_add_metric_internal(
+        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points, false);
+}
+
+NEVER_INLINE
+static void rrd2rrdr_group_by_add_metric_with_raw_contributor_counts(
+    RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
+    RRDR_GROUP_BY_FUNCTION group_by_aggregate_function, STORAGE_POINT *query_points) {
+    rrd2rrdr_group_by_add_metric_internal(
+        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points, true);
 }
 
 // stamp RRDR_VALUE_PARTIAL on every point that received fewer contributions
@@ -256,11 +288,12 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
     RRDR *last_r = r_tmp->group_by.r;
 
     // how many sources are expected to contribute to every point of each
-    // dimension, in the units gbc counts at each pass: metrics at the first
-    // pass, prior-pass groups at later passes; dgbc cannot be this comparand
-    // - it counts metrics at every pass, including the hidden ones - so
-    // complete data would flag PARTIAL; the split between expected_gbc and
-    // expected_hgbc mirrors the routing rule of
+    // dimension, in the units gbc uses at that pass: metrics at the first
+    // pass; raw metrics in eligible later passes; prior-pass groups at held
+    // boundaries and on the raw wire. dgbc is used only by the eligible
+    // non-raw result path; the predicate rejects both the raw wire and paths
+    // with hidden percentage contributors.
+    // The split between expected_gbc and expected_hgbc mirrors the routing rule of
     // rrd2rrdr_group_by_add_metric(): hidden sources feed the percentage
     // denominator (vh) and are counted by hgbc, never by gbc
     ONEWAYALLOC *owa = last_r->internal.owa;
@@ -284,6 +317,7 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
     size_t pass = 0;
     while(r) {
         pass++;
+        bool propagate_raw_contributor_counts = group_by_pass_propagates_raw_contributor_counts(qt, pass);
         onewayalloc_freez(owa, expected_gbc);
         onewayalloc_freez(owa, expected_hgbc);
         expected_gbc = onewayalloc_callocz(owa, r->d, sizeof(*expected_gbc));
@@ -293,11 +327,16 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             if((last_r->od[d] & RRDR_DIMENSION_HIDDEN) && r->vh)
                 expected_hgbc[last_r->dgbs[d]]++;
             else
-                expected_gbc[last_r->dgbs[d]]++;
+                expected_gbc[last_r->dgbs[d]] += propagate_raw_contributor_counts ? last_r->dgbc[d] : 1;
 
-            rrd2rrdr_group_by_add_metric(r, last_r->dgbs[d], last_r, d,
-                                         qt->request.group_by[pass].aggregation,
-                                         &last_r->dqp[d], pass);
+            if(propagate_raw_contributor_counts)
+                rrd2rrdr_group_by_add_metric_with_raw_contributor_counts(
+                    r, last_r->dgbs[d], last_r, d,
+                    qt->request.group_by[pass].aggregation, &last_r->dqp[d]);
+            else
+                rrd2rrdr_group_by_add_metric(
+                    r, last_r->dgbs[d], last_r, d,
+                    qt->request.group_by[pass].aggregation, &last_r->dqp[d], pass);
         }
         rrd2rrdr_group_by_stamp_partial(r, expected_gbc, expected_hgbc);
         rrdr2rrdr_group_by_calculate_percentage_of_group(r);

--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -23,6 +23,11 @@ static bool group_by_pass_propagates_raw_contributor_counts(const QUERY_TARGET *
     return true;
 }
 
+static bool group_by_pass_calculates_percentage(const QUERY_TARGET *qt, size_t pass) {
+    return qt->request.group_by[pass].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE ||
+           (qt->request.group_by[pass].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE);
+}
+
 static ALWAYS_INLINE void rrd2rrdr_group_by_add_metric_internal(
     RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
     RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
@@ -59,6 +64,7 @@ static ALWAYS_INLINE void rrd2rrdr_group_by_add_metric_internal(
         RRDR_VALUE_FLAGS *co = &r_dst->o[ idx_dst ];
         NETDATA_DOUBLE *ar = &r_dst->ar[ idx_dst ];
         uint32_t *gbc = &r_dst->gbc[ idx_dst ];
+        uint32_t *arc = r_dst->arc ? &r_dst->arc[idx_dst] : NULL;
 
         switch(group_by_aggregate_function) {
             default:
@@ -93,6 +99,8 @@ static ALWAYS_INLINE void rrd2rrdr_group_by_add_metric_internal(
             *co |= (o_tmp & (RRDR_VALUE_RESET | RRDR_VALUE_PARTIAL));
             *ar += ar_tmp;
             *gbc += propagate_raw_contributor_counts ? r_tmp->gbc[idx_tmp] : 1;
+            if(arc)
+                *arc += r_tmp->arc ? r_tmp->arc[idx_tmp] : 1;
         }
         else if(r_dst->hgbc) {
             // count the hidden (denominator) contributions too, so that
@@ -145,6 +153,39 @@ static void rrd2rrdr_group_by_stamp_partial(RRDR *r, const uint32_t *expected_gb
                (hgbc & HGBC_PARTIAL_FLAG))
                 r->o[idx] |= RRDR_VALUE_PARTIAL;
         }
+    }
+}
+
+void rrdr2rrdr_group_by_partial_trimming(RRDR *r) {
+    time_t trimmable_after = r->partial_data_trimming.expected_after;
+
+    // find the point just before the trimmable ones
+    ssize_t i = (ssize_t)r->n - 1;
+    for( ; i >= 0 ;i--) {
+        if (r->t[i] < trimmable_after)
+            break;
+    }
+
+    if(unlikely(i < 0))
+        return;
+
+    size_t last_row_gbc = 0;
+    for (; i < (ssize_t)r->n; i++) {
+        size_t row_gbc = 0;
+        for (size_t d = 0; d < r->d; d++) {
+            if (unlikely(!(r->od[d] & RRDR_DIMENSION_QUERIED)))
+                continue;
+
+            row_gbc += r->gbc[i * r->d + d];
+        }
+
+        if (unlikely(r->t[i] >= trimmable_after && (row_gbc < last_row_gbc || !row_gbc))) {
+            r->partial_data_trimming.trimmed_after = r->t[i];
+            r->rows = i;
+            break;
+        }
+        else
+            last_row_gbc = row_gbc;
     }
 }
 
@@ -311,7 +352,8 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
     }
     rrd2rrdr_group_by_stamp_partial(last_r, expected_gbc, expected_hgbc);
 
-    rrdr2rrdr_group_by_calculate_percentage_of_group(last_r);
+    if(group_by_pass_calculates_percentage(qt, 0))
+        rrdr2rrdr_group_by_calculate_percentage_of_group(last_r);
 
     RRDR *r = last_r->group_by.r;
     size_t pass = 0;
@@ -339,7 +381,8 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
                     qt->request.group_by[pass].aggregation, &last_r->dqp[d], pass);
         }
         rrd2rrdr_group_by_stamp_partial(r, expected_gbc, expected_hgbc);
-        rrdr2rrdr_group_by_calculate_percentage_of_group(r);
+        if(group_by_pass_calculates_percentage(qt, pass))
+            rrdr2rrdr_group_by_calculate_percentage_of_group(r);
 
         last_r = r;
         r = last_r->group_by.r;
@@ -364,9 +407,17 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
 
     // find the final aggregation
     RRDR_GROUP_BY_FUNCTION aggregation = qt->request.group_by[0].aggregation;
+    size_t final_pass = 0;
     for(size_t g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++)
-        if(qt->request.group_by[g].group_by != RRDR_GROUP_BY_NONE)
+        if(qt->request.group_by[g].group_by != RRDR_GROUP_BY_NONE) {
             aggregation = qt->request.group_by[g].aggregation;
+            final_pass = g;
+        }
+
+    bool final_percentage = group_by_pass_calculates_percentage(qt, final_pass);
+
+    if(!query_target_aggregatable(qt) && r->partial_data_trimming.expected_after < qt->window.before)
+        rrdr2rrdr_group_by_partial_trimming(r);
 
     // for every aggregation except AVERAGE the plotted value is already the
     // final group aggregate (the percentage, the sum, the min, the max), so
@@ -397,6 +448,9 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             RRDR_VALUE_FLAGS *co = &r->o[ idx ];
             NETDATA_DOUBLE *ar = &r->ar[ idx ];
             uint32_t gbc = r->gbc[ idx ];
+            uint32_t arc = r->arc ? r->arc[idx] : gbc;
+            uint32_t anomaly_contributors =
+                aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE || final_percentage ? arc : gbc;
 
             if(likely(gbc)) {
                 *co &= ~RRDR_VALUE_EMPTY;
@@ -407,7 +461,7 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
 
                 // when the sts pair is per-row, the anomaly rate must also be
                 // accumulated per-row (the row mean), not per-contribution
-                ars += stats_by_rows ? (*ar / (NETDATA_DOUBLE)gbc) : *ar;
+                ars += stats_by_rows ? (*ar / (NETDATA_DOUBLE)anomaly_contributors) : *ar;
 
                 if(aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE && !query_target_aggregatable(qt))
                     n = (*cn /= gbc);
@@ -415,7 +469,7 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
                     n = *cn;
 
                 if(!query_target_aggregatable(qt))
-                    *ar /= gbc;
+                    *ar /= anomaly_contributors;
 
                 if(islessgreater(n, 0.0))
                     points_nonzero++;
@@ -457,6 +511,11 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             .anomaly_count = (size_t)(ars * RRDR_DVIEW_ANOMALY_COUNT_MULTIPLIER / 100.0),
         };
     }
+
+
+    // Anomaly contributor counts are only needed while finalizing group-by.
+    onewayalloc_freez(owa, r->arc);
+    r->arc = NULL;
 
     r->view.min = global_min;
     r->view.max = global_max;

--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -31,7 +31,8 @@ static bool group_by_pass_calculates_percentage(const QUERY_TARGET *qt, size_t p
 static ALWAYS_INLINE void rrd2rrdr_group_by_add_metric_internal(
     RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
     RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
-    STORAGE_POINT *query_points, bool propagate_raw_contributor_counts) {
+    STORAGE_POINT *query_points, bool propagate_raw_contributor_counts,
+    bool track_raw_anomaly_contributors, const uint32_t *source_anomaly_contributors) {
     if(!r_tmp || r_dst == r_tmp || !(r_tmp->od[d_tmp] & RRDR_DIMENSION_QUERIED))
         return;
 
@@ -64,7 +65,6 @@ static ALWAYS_INLINE void rrd2rrdr_group_by_add_metric_internal(
         RRDR_VALUE_FLAGS *co = &r_dst->o[ idx_dst ];
         NETDATA_DOUBLE *ar = &r_dst->ar[ idx_dst ];
         uint32_t *gbc = &r_dst->gbc[ idx_dst ];
-        uint32_t *arc = r_dst->arc ? &r_dst->arc[idx_dst] : NULL;
 
         switch(group_by_aggregate_function) {
             default:
@@ -99,8 +99,8 @@ static ALWAYS_INLINE void rrd2rrdr_group_by_add_metric_internal(
             *co |= (o_tmp & (RRDR_VALUE_RESET | RRDR_VALUE_PARTIAL));
             *ar += ar_tmp;
             *gbc += propagate_raw_contributor_counts ? r_tmp->gbc[idx_tmp] : 1;
-            if(arc)
-                *arc += r_tmp->arc ? r_tmp->arc[idx_tmp] : 1;
+            if(track_raw_anomaly_contributors)
+                r_dst->arc[idx_dst] += source_anomaly_contributors[idx_tmp];
         }
         else if(r_dst->hgbc) {
             // count the hidden (denominator) contributions too, so that
@@ -119,7 +119,7 @@ void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t
                                   RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
                                   STORAGE_POINT *query_points, size_t pass __maybe_unused) {
     rrd2rrdr_group_by_add_metric_internal(
-        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points, false);
+        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points, false, false, NULL);
 }
 
 NEVER_INLINE
@@ -127,7 +127,16 @@ static void rrd2rrdr_group_by_add_metric_with_raw_contributor_counts(
     RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
     RRDR_GROUP_BY_FUNCTION group_by_aggregate_function, STORAGE_POINT *query_points) {
     rrd2rrdr_group_by_add_metric_internal(
-        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points, true);
+        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points, true, false, NULL);
+}
+
+NEVER_INLINE
+static void rrd2rrdr_group_by_add_metric_with_raw_anomaly_contributors(
+    RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
+    RRDR_GROUP_BY_FUNCTION group_by_aggregate_function, STORAGE_POINT *query_points) {
+    rrd2rrdr_group_by_add_metric_internal(
+        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points,
+        false, true, r_tmp->gbc);
 }
 
 // stamp RRDR_VALUE_PARTIAL on every point that received fewer contributions
@@ -371,7 +380,11 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             else
                 expected_gbc[last_r->dgbs[d]] += propagate_raw_contributor_counts ? last_r->dgbc[d] : 1;
 
-            if(propagate_raw_contributor_counts)
+            if(r->arc)
+                rrd2rrdr_group_by_add_metric_with_raw_anomaly_contributors(
+                    r, last_r->dgbs[d], last_r, d,
+                    qt->request.group_by[pass].aggregation, &last_r->dqp[d]);
+            else if(propagate_raw_contributor_counts)
                 rrd2rrdr_group_by_add_metric_with_raw_contributor_counts(
                     r, last_r->dgbs[d], last_r, d,
                     qt->request.group_by[pass].aggregation, &last_r->dqp[d]);
@@ -415,6 +428,8 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
         }
 
     bool final_percentage = group_by_pass_calculates_percentage(qt, final_pass);
+    uint32_t *anomaly_contributor_counts =
+        (aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE || final_percentage) && r->arc ? r->arc : r->gbc;
 
     if(!query_target_aggregatable(qt) && r->partial_data_trimming.expected_after < qt->window.before)
         rrdr2rrdr_group_by_partial_trimming(r);
@@ -448,9 +463,7 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             RRDR_VALUE_FLAGS *co = &r->o[ idx ];
             NETDATA_DOUBLE *ar = &r->ar[ idx ];
             uint32_t gbc = r->gbc[ idx ];
-            uint32_t arc = r->arc ? r->arc[idx] : gbc;
-            uint32_t anomaly_contributors =
-                aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE || final_percentage ? arc : gbc;
+            uint32_t anomaly_contributors = anomaly_contributor_counts[idx];
 
             if(likely(gbc)) {
                 *co &= ~RRDR_VALUE_EMPTY;

--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -116,45 +116,6 @@ static void rrd2rrdr_group_by_stamp_partial(RRDR *r, const uint32_t *expected_gb
     }
 }
 
-void rrdr2rrdr_group_by_partial_trimming(RRDR *r) {
-    time_t trimmable_after = r->partial_data_trimming.expected_after;
-
-    // find the point just before the trimmable ones
-    ssize_t i = (ssize_t)r->n - 1;
-    for( ; i >= 0 ;i--) {
-        if (r->t[i] < trimmable_after)
-            break;
-    }
-
-    if(unlikely(i < 0))
-        return;
-
-    // internal_error(true, "Found trimmable index %zd (from 0 to %zu)", i, r->n - 1);
-
-    size_t last_row_gbc = 0;
-    for (; i < (ssize_t)r->n; i++) {
-        size_t row_gbc = 0;
-        for (size_t d = 0; d < r->d; d++) {
-            if (unlikely(!(r->od[d] & RRDR_DIMENSION_QUERIED)))
-                continue;
-
-            row_gbc += r->gbc[ i * r->d + d ];
-        }
-
-        // internal_error(true, "GBC of index %zd is %zu", i, row_gbc);
-
-        if (unlikely(r->t[i] >= trimmable_after && (row_gbc < last_row_gbc || !row_gbc))) {
-            // discard the rest of the points
-            // internal_error(true, "Discarding points %zd to %zu", i, r->n - 1);
-            r->partial_data_trimming.trimmed_after = r->t[i];
-            r->rows = i;
-            break;
-        }
-        else
-            last_row_gbc = row_gbc;
-    }
-}
-
 void rrdr2rrdr_group_by_calculate_percentage_of_group(RRDR *r) {
     if(!r->vh)
         return;
@@ -367,9 +328,6 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
     for(size_t g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++)
         if(qt->request.group_by[g].group_by != RRDR_GROUP_BY_NONE)
             aggregation = qt->request.group_by[g].aggregation;
-
-    if(!query_target_aggregatable(qt) && r->partial_data_trimming.expected_after < qt->window.before)
-        rrdr2rrdr_group_by_partial_trimming(r);
 
     // for every aggregation except AVERAGE the plotted value is already the
     // final group aggregate (the percentage, the sum, the min, the max), so

--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -463,6 +463,8 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             RRDR_VALUE_FLAGS *co = &r->o[ idx ];
             NETDATA_DOUBLE *ar = &r->ar[ idx ];
             uint32_t gbc = r->gbc[ idx ];
+            // Keep this load here to preserve the optimized hot-path code shape.
+            // cppcheck-suppress variableScope
             uint32_t anomaly_contributors = anomaly_contributor_counts[idx];
 
             if(likely(gbc)) {

--- a/src/web/api/queries/query-group-by-init.c
+++ b/src/web/api/queries/query-group-by-init.c
@@ -510,6 +510,10 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
                 r->gbc = onewayalloc_callocz(
                     owa, onewayalloc_mul_or_fatal(r->n, r->d, "RRDR group-by counts"), sizeof(*r->gbc));
 
+                if(!query_target_aggregatable(qt))
+                    r->arc = onewayalloc_callocz(
+                        owa, onewayalloc_mul_or_fatal(r->n, r->d, "RRDR anomaly-rate contributors"), sizeof(*r->arc));
+
                 if(hidden_dimensions && ((group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) || (aggregation_method == RRDR_GROUP_BY_FUNCTION_PERCENTAGE))) {
                     // this is where we are going to group the hidden dimensions
                     r->vh = onewayalloc_mallocz(

--- a/src/web/api/queries/query-group-by-init.c
+++ b/src/web/api/queries/query-group-by-init.c
@@ -314,16 +314,25 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
     // so a percentage aggregation on a NONE pass resolves to NORMAL mode
     // everywhere - the same behavior such a query had before this scan
     ssize_t percentage_of_group_pass = -1;
+    size_t final_group_by_pass = 0;
     for(size_t g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++) {
         if(qt->request.group_by[g].group_by == RRDR_GROUP_BY_NONE)
             break;
 
-        if((qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) ||
-            qt->request.group_by[g].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE) {
+        final_group_by_pass = g;
+
+        if(percentage_of_group_pass < 0 &&
+           ((qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) ||
+            qt->request.group_by[g].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE)) {
             percentage_of_group_pass = (ssize_t)g;
-            break;
         }
     }
+
+    bool final_pass_needs_raw_anomaly_contributors =
+        !query_target_aggregatable(qt) && final_group_by_pass > 0 &&
+        (qt->request.group_by[final_group_by_pass].aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE ||
+         qt->request.group_by[final_group_by_pass].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE ||
+         (qt->request.group_by[final_group_by_pass].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE));
 
     size_t added = 0;
     RRDR *first_r = NULL, *last_r = NULL;
@@ -510,7 +519,7 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
                 r->gbc = onewayalloc_callocz(
                     owa, onewayalloc_mul_or_fatal(r->n, r->d, "RRDR group-by counts"), sizeof(*r->gbc));
 
-                if(!query_target_aggregatable(qt))
+                if(final_grouping && final_pass_needs_raw_anomaly_contributors)
                     r->arc = onewayalloc_callocz(
                         owa, onewayalloc_mul_or_fatal(r->n, r->d, "RRDR anomaly-rate contributors"), sizeof(*r->arc));
 

--- a/src/web/api/queries/query-group-over-time.c
+++ b/src/web/api/queries/query-group-over-time.c
@@ -54,6 +54,7 @@ static struct {
     NETDATA_DOUBLE (*flush)(struct rrdresult *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
     TIER_QUERY_FETCH tier_query_fetch;
+    QUERY_POINT_MODE point_mode;
 } api_v1_data_groups[] = {
     {.name = "average",
      .hash  = 0,
@@ -497,7 +498,8 @@ static struct {
      .free  = tg_sum_free,
      .add   = tg_sum_add,
      .flush = tg_sum_flush,
-     .tier_query_fetch = TIER_QUERY_FETCH_SUM
+     .tier_query_fetch = TIER_QUERY_FETCH_SUM,
+     .point_mode = QUERY_POINT_MODE_TOTAL
     },
 
     // standard deviation
@@ -722,6 +724,7 @@ void rrdr_set_grouping_function(RRDR *r, RRDR_TIME_GROUPING group_method) {
             r->time_grouping.add     = api_v1_data_groups[i].add;
             r->time_grouping.flush   = api_v1_data_groups[i].flush;
             r->time_grouping.tier_query_fetch = api_v1_data_groups[i].tier_query_fetch;
+            r->time_grouping.point_mode = api_v1_data_groups[i].point_mode;
             r->time_grouping.add_flush = api_v1_data_groups[i].add_flush;
             found = 1;
         }
@@ -735,6 +738,7 @@ void rrdr_set_grouping_function(RRDR *r, RRDR_TIME_GROUPING group_method) {
         r->time_grouping.add     = tg_average_add;
         r->time_grouping.flush   = tg_average_flush;
         r->time_grouping.tier_query_fetch = TIER_QUERY_FETCH_AVERAGE;
+        r->time_grouping.point_mode = QUERY_POINT_MODE_LINEAR;
         r->time_grouping.add_flush = RRDR_GROUPING_AVERAGE;
     }
 }

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -13,6 +13,7 @@
 typedef struct query_point {
     STORAGE_POINT sp;
     NETDATA_DOUBLE value;
+    uint8_t tier;
     bool added;
 #ifdef NETDATA_INTERNAL_CHECKS
     size_t id;

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -80,6 +80,8 @@ typedef struct query_engine_ops {
     size_t db_total_points_read;
     size_t db_points_read_per_tier[RRD_STORAGE_TIERS];
 
+    bool result_plan_expire_time_overflow;
+
     // the LATEST grouping with a single output point covering the metric's
     // last stored sample is answered from the collector's cached value,
     // without querying the storage engine (no query plan is built)
@@ -104,7 +106,8 @@ typedef struct query_engine_ops_cache {
 
 // query planner
 #define query_plan_should_switch_plan(ops, now) ((now) >= (ops)->current_plan_expire_time)
-#define query_result_plan_should_switch_plan(ops, now) ((now) >= (ops)->result_plan_expire_time)
+#define query_result_plan_should_switch_plan(ops, now) \
+    ((now) >= (ops)->result_plan_expire_time && !(ops)->result_plan_expire_time_overflow)
 bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point_end_time);
 void query_planer_finalize_remaining_plans(QUERY_ENGINE_OPS *ops);
 QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache, size_t query_metric_id);
@@ -131,6 +134,7 @@ void group_by_label_key_delete_cb(const DICTIONARY_ITEM *item __maybe_unused, vo
 int rrdlabels_traversal_cb_to_group_by_label_key(const char *name, const char *value, RRDLABEL_SRC ls __maybe_unused, void *data);
 void rrd2rrdr_set_timestamps(RRDR *r);
 RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt);
+void rrdr2rrdr_group_by_partial_trimming(RRDR *r);
 void rrdr2rrdr_group_by_calculate_percentage_of_group(RRDR *r);
 void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
                                   RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -82,8 +82,8 @@ typedef struct query_engine_ops {
 
     bool result_plan_expire_time_overflow;
 
-    // the LATEST grouping with a single output point covering the metric's
-    // last stored sample is answered from the collector's cached value,
+    // the LATEST grouping with a single output point reached by the metric's
+    // latest collection interval is answered from the collector's cached value,
     // without querying the storage engine (no query plan is built)
     bool latest_fast_path;
     NETDATA_DOUBLE latest_fast_path_value;

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -66,7 +66,7 @@ typedef struct query_engine_ops {
     // aggregating points over time
     size_t group_points_non_zero;
     size_t group_points_added;
-    STORAGE_POINT group_point;          // aggregates min, max, sum, count, anomaly count for each group point
+    STORAGE_POINT group_point;          // aggregates sample, anomaly, and gap evidence for each result row
     STORAGE_POINT query_point;          // aggregates min, max, sum, count, anomaly count across the whole query
     RRDR_VALUE_FLAGS group_value_flags;
 

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -48,10 +48,13 @@ typedef struct query_engine_ops {
     time_t view_update_every;
     time_t query_granularity;
     TIER_QUERY_FETCH tier_query_fetch;
+    QUERY_POINT_MODE point_mode;
 
     // query planer
     size_t current_plan;
     time_t current_plan_expire_time;
+    time_t result_plan_expire_time;
+    time_t plan_switch_time_offset;
     time_t plan_expanded_after;
     time_t plan_expanded_before;
 
@@ -95,6 +98,7 @@ typedef struct query_engine_ops_cache {
 
 // query planner
 #define query_plan_should_switch_plan(ops, now) ((now) >= (ops)->current_plan_expire_time)
+#define query_result_plan_should_switch_plan(ops, now) ((now) >= (ops)->result_plan_expire_time)
 bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point_end_time);
 void query_planer_finalize_remaining_plans(QUERY_ENGINE_OPS *ops);
 QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache, size_t query_metric_id);

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -126,7 +126,6 @@ int rrdlabels_traversal_cb_to_group_by_label_key(const char *name, const char *v
 void rrd2rrdr_set_timestamps(RRDR *r);
 RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt);
 void rrdr2rrdr_group_by_calculate_percentage_of_group(RRDR *r);
-void rrdr2rrdr_group_by_partial_trimming(RRDR *r);
 void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
                                   RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
                                   STORAGE_POINT *query_points, size_t pass);

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -20,6 +20,12 @@ typedef struct query_point {
 #endif
 } QUERY_POINT;
 
+typedef struct query_row_evidence {
+    uint32_t count;
+    uint32_t anomaly_count;
+    uint32_t gap_count;
+} QUERY_ROW_EVIDENCE;
+
 #ifdef NETDATA_INTERNAL_CHECKS
 #define QUERY_POINT_EMPTY (QUERY_POINT){ \
     .sp = STORAGE_POINT_UNSET, \
@@ -66,7 +72,7 @@ typedef struct query_engine_ops {
     // aggregating points over time
     size_t group_points_non_zero;
     size_t group_points_added;
-    STORAGE_POINT group_point;          // aggregates sample, anomaly, and gap evidence for each result row
+    QUERY_ROW_EVIDENCE group_point;     // aggregates sample, anomaly, and gap evidence for each result row
     STORAGE_POINT query_point;          // aggregates min, max, sum, count, anomaly count across the whole query
     RRDR_VALUE_FLAGS group_value_flags;
 

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -285,7 +285,10 @@ static bool query_planer_plan_can_be_activated(QUERY_ENGINE_OPS *ops, size_t pla
 
 static void query_planer_set_expire_time(QUERY_ENGINE_OPS *ops, time_t expire_time) {
     ops->current_plan_expire_time = expire_time;
-    ops->result_plan_expire_time = nd_time_t_add_saturating(expire_time, ops->plan_switch_time_offset);
+    ops->result_plan_expire_time_overflow = __builtin_add_overflow(
+        expire_time, ops->plan_switch_time_offset, &ops->result_plan_expire_time);
+    if(unlikely(ops->result_plan_expire_time_overflow))
+        ops->result_plan_expire_time = nd_time_t_max();
 }
 
 static void query_planer_set_active_plan(QUERY_ENGINE_OPS *ops, size_t plan_id, time_t overwrite_after __maybe_unused) {
@@ -775,6 +778,61 @@ static int query_plan_unittest_expect_ops_cache_is_local(void) {
     return 1;
 }
 
+static int query_plan_unittest_expect_result_expiry(void) {
+    QUERY_ENGINE_OPS ops = {
+        .plan_switch_time_offset = 60,
+    };
+
+    query_planer_set_expire_time(&ops, 100);
+    if(ops.current_plan_expire_time != 100 || ops.result_plan_expire_time != 160 ||
+       ops.result_plan_expire_time_overflow ||
+       query_result_plan_should_switch_plan(&ops, 159) ||
+       !query_result_plan_should_switch_plan(&ops, 160) ||
+       !query_result_plan_should_switch_plan(&ops, 161)) {
+        fprintf(stderr,
+                "FAILED query plan result expiry: expected 100/160/non-overflow with switch from 160 onward, "
+                "got %" PRIdMAX "/%" PRIdMAX "/%d and switches %d/%d/%d at 159/160/161\n",
+                (intmax_t)ops.current_plan_expire_time, (intmax_t)ops.result_plan_expire_time,
+                ops.result_plan_expire_time_overflow,
+                query_result_plan_should_switch_plan(&ops, 159),
+                query_result_plan_should_switch_plan(&ops, 160),
+                query_result_plan_should_switch_plan(&ops, 161));
+        return 1;
+    }
+
+    time_t maximum = nd_time_t_max();
+    query_planer_set_expire_time(&ops, maximum - 30);
+    if(ops.current_plan_expire_time != maximum - 30 || ops.result_plan_expire_time != maximum ||
+       !ops.result_plan_expire_time_overflow ||
+       query_result_plan_should_switch_plan(&ops, maximum)) {
+        fprintf(stderr,
+                "FAILED query plan unreachable result expiry: expected %" PRIdMAX "/%" PRIdMAX
+                "/overflow without switch, got %" PRIdMAX "/%" PRIdMAX "/%d with switch=%d\n",
+                (intmax_t)(maximum - 30), (intmax_t)maximum,
+                (intmax_t)ops.current_plan_expire_time, (intmax_t)ops.result_plan_expire_time,
+                ops.result_plan_expire_time_overflow,
+                query_result_plan_should_switch_plan(&ops, maximum));
+        return 1;
+    }
+
+    query_planer_set_expire_time(&ops, maximum - ops.plan_switch_time_offset);
+    if(ops.current_plan_expire_time != maximum - ops.plan_switch_time_offset ||
+       ops.result_plan_expire_time != maximum || ops.result_plan_expire_time_overflow ||
+       !query_result_plan_should_switch_plan(&ops, maximum)) {
+        fprintf(stderr,
+                "FAILED query plan exact-maximum result expiry: expected %" PRIdMAX "/%" PRIdMAX
+                "/non-overflow with switch, got %" PRIdMAX "/%" PRIdMAX "/%d with switch=%d\n",
+                (intmax_t)(maximum - ops.plan_switch_time_offset), (intmax_t)maximum,
+                (intmax_t)ops.current_plan_expire_time, (intmax_t)ops.result_plan_expire_time,
+                ops.result_plan_expire_time_overflow,
+                query_result_plan_should_switch_plan(&ops, maximum));
+        return 1;
+    }
+
+    fprintf(stderr, "OK query plan result expiry\n");
+    return 0;
+}
+
 int query_plan_unittest(void) {
     size_t old_storage_tiers = nd_profile.storage_tiers;
     time_t old_update_every = nd_profile.update_every;
@@ -1037,6 +1095,7 @@ int query_plan_unittest(void) {
     }
 
     errors += query_plan_unittest_expect_ops_cache_is_local();
+    errors += query_plan_unittest_expect_result_expiry();
 
     nd_profile.storage_tiers = old_storage_tiers;
     nd_profile.update_every = old_update_every;

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -574,6 +574,9 @@ QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache
     if(qt->window.options & RRDR_OPTION_ANOMALY_BIT) {
         ops->point_mode = QUERY_POINT_MODE_HOLD;
     }
+    else if(ops->tier_query_fetch == TIER_QUERY_FETCH_SUM && ops->qm->values_stored_as_rates) {
+        ops->tier_query_fetch = TIER_QUERY_FETCH_RATE_SUM;
+    }
 
     ops->plan_switch_time_offset =
         ops->point_mode == QUERY_POINT_MODE_TOTAL ? ops->view_update_every : 0;

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -520,10 +520,10 @@ static QUERY_ENGINE_OPS *rrd2rrdr_query_ops_get(RRDR *r, QUERY_ENGINE_OPS_CACHE 
 }
 
 // the LATEST grouping asks for the most recent collected value; when the
-// query wants a single point and its window covers the metric's last stored
-// sample, the answer is the collector's cached last_stored_value - serve it
-// without building a query plan, so the storage engine is never touched.
-// options that change the value semantics (anomaly-bit, natural points,
+// query wants a single point and the metric's latest collection interval
+// reaches its window, the answer is the collector's cached last_stored_value -
+// serve it without building a query plan, so storage is never touched.
+// options that change the value semantics (anomaly-bit, resampling,
 // a pinned tier) fall back to the normal execution path.
 static bool query_latest_fast_path(RRDR *r, QUERY_ENGINE_OPS *ops) {
     QUERY_TARGET *qt = r->internal.qt;
@@ -537,9 +537,13 @@ static bool query_latest_fast_path(RRDR *r, QUERY_ENGINE_OPS *ops) {
         (qt->window.options & (RRDR_OPTION_SELECTED_TIER|RRDR_OPTION_ANOMALY_BIT)))
         return false;
 
-    // the single output bucket spans (after, before]
+    // The single output bucket spans (after, before]. LATEST may use the live
+    // last observation until its next expected collection interval reaches
+    // the window, even when the stored endpoint itself precedes `after`.
     time_t db_last = ops->qm->tiers[0].db_last_time_s;
-    if(db_last <= qt->window.after || db_last > qt->window.before)
+    time_t db_update_every = ops->qm->tiers[0].db_update_every_s;
+    if(db_last > qt->window.before ||
+       nd_time_t_add_compare(db_last, db_update_every, qt->window.after) < 0)
         return false;
 
     // NAN when there is no live dimension (archived metric), or when the

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -283,6 +283,11 @@ static bool query_planer_plan_can_be_activated(QUERY_ENGINE_OPS *ops, size_t pla
     return query_plan_tier_is_valid(qm, qm->plan.array[plan_id].tier);
 }
 
+static void query_planer_set_expire_time(QUERY_ENGINE_OPS *ops, time_t expire_time) {
+    ops->current_plan_expire_time = expire_time;
+    ops->result_plan_expire_time = nd_time_t_add_saturating(expire_time, ops->plan_switch_time_offset);
+}
+
 static void query_planer_set_active_plan(QUERY_ENGINE_OPS *ops, size_t plan_id, time_t overwrite_after __maybe_unused) {
     QUERY_METRIC *qm = ops->qm;
 
@@ -292,9 +297,9 @@ static void query_planer_set_active_plan(QUERY_ENGINE_OPS *ops, size_t plan_id, 
     ops->current_plan = plan_id;
 
     if(plan_id + 1 < qm->plan.used && qm->plan.array[plan_id + 1].after < qm->plan.array[plan_id].before)
-        ops->current_plan_expire_time = qm->plan.array[plan_id + 1].after;
+        query_planer_set_expire_time(ops, qm->plan.array[plan_id + 1].after);
     else
-        ops->current_plan_expire_time = qm->plan.array[plan_id].before;
+        query_planer_set_expire_time(ops, qm->plan.array[plan_id].before);
 
     ops->plan_expanded_after = ops->plans[plan_id].expanded_after;
     ops->plan_expanded_before = ops->plans[plan_id].expanded_before;
@@ -319,7 +324,7 @@ bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point
 
         if (ops->current_plan >= qm->plan.used) {
             ops->current_plan = old_plan;
-            ops->current_plan_expire_time = ops->r->internal.qt->window.before;
+            query_planer_set_expire_time(ops, ops->r->internal.qt->window.before);
             // let the query run with current plan
             // we will not switch it
             return false;
@@ -330,7 +335,7 @@ bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point
 
     if(!query_planer_plan_can_be_activated(ops, ops->current_plan)) {
         ops->current_plan = old_plan;
-        ops->current_plan_expire_time = ops->r->internal.qt->window.before;
+        query_planer_set_expire_time(ops, ops->r->internal.qt->window.before);
         return false;
     }
 
@@ -560,10 +565,18 @@ QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache
         .r = r,
         .qm = query_metric(qt, query_metric_id),
         .tier_query_fetch = r->time_grouping.tier_query_fetch,
+        .point_mode = r->time_grouping.point_mode,
         .view_update_every = r->view.update_every,
         .query_granularity = (time_t)(r->view.update_every / r->view.group),
         .group_value_flags = RRDR_VALUE_NOTHING,
     };
+
+    if(qt->window.options & RRDR_OPTION_ANOMALY_BIT) {
+        ops->point_mode = QUERY_POINT_MODE_HOLD;
+    }
+
+    ops->plan_switch_time_offset =
+        ops->point_mode == QUERY_POINT_MODE_TOTAL ? ops->view_update_every : 0;
 
     if(query_latest_fast_path(r, ops))
         return ops;

--- a/src/web/api/queries/query-window.c
+++ b/src/web/api/queries/query-window.c
@@ -147,8 +147,7 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
     }
 
     // convert our before_wanted and after_wanted to absolute
-    time_t query_now_s = 0;
-    rrdr_relative_window_to_absolute_query(&after_wanted, &before_wanted, &query_now_s, unittest_running);
+    rrdr_relative_window_to_absolute_query(&after_wanted, &before_wanted, NULL, unittest_running);
     query_debug_log(":relative2absolute after %ld, before %ld", after_wanted, before_wanted);
 
     if (natural_points && (options & RRDR_OPTION_SELECTED_TIER) &&
@@ -307,32 +306,20 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
         query_debug_log(":resampling divisor " NETDATA_DOUBLE_FORMAT, resampling_divisor);
     }
 
-    // the LATEST grouping with a single point asking for the hot edge
-    // (the requested before resolves to zero or to within one
-    // update_every of now) anchors the window end at the newest stored
-    // sample - the clamp to now-1 above would exclude an end-stamped
-    // sample that already exists, making the hot edge a race against
-    // the collector. The anchored end needs no re-alignment: collectors
-    // end-stamp samples on update_every boundaries.
-    bool latest_hot_edge = false;
-    if (group_method == RRDR_GROUPING_LATEST && points_requested == 1 && qt->db.last_time_s > 0) {
-        // resolve the requested before against the SAME now snapshot the
-        // conversion above used, so the hot-edge classification and the
-        // window math cannot disagree on a boundary request
-        time_t before_resolved = before_requested;
-        if (rrdr_relative_window_value_is_relative(before_requested))
-            before_resolved = query_now_s + ((before_requested > 0) ? -before_requested : before_requested);
-
-        if (before_requested == 0 || before_resolved >= query_now_s - update_every) {
-            latest_hot_edge = true;
-            before_wanted = qt->db.last_time_s;
-            query_debug_log(":latest hot edge before_wanted %ld", before_wanted);
-        }
+    // before=0 explicitly asks for the database end. Restore that exact end
+    // after granularity rounding and keep it unaligned; explicit and relative
+    // windows must never derive their result grid from stored timestamps.
+    bool latest_database_end = group_method == RRDR_GROUPING_LATEST &&
+                               points_requested == 1 && before_requested == 0 &&
+                               qt->db.last_time_s > 0;
+    if (latest_database_end) {
+        before_wanted = qt->db.last_time_s;
+        query_debug_log(":latest database end before_wanted %ld", before_wanted);
     }
 
     // now that we have group, align the requested timeframe to fit it.
     // The product is proven representable above; retain the original conversions for negative timestamps.
-    bool alignment_needed = aligned && !latest_hot_edge && before_wanted % (group * query_granularity);
+    bool alignment_needed = aligned && !latest_database_end && before_wanted % (group * query_granularity);
     time_t alignment = aligned ? before_wanted % view_update_every : 0;
     if (alignment_needed) {
         if (before_is_aligned_to_db_end) {

--- a/src/web/api/queries/rrdr.c
+++ b/src/web/api/queries/rrdr.c
@@ -82,6 +82,7 @@ inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r) {
     onewayalloc_freez(owa, r->dqp);
     onewayalloc_freez(owa, r->ar);
     onewayalloc_freez(owa, r->gbc);
+    onewayalloc_freez(owa, r->arc);
     onewayalloc_freez(owa, r->hgbc);
     onewayalloc_freez(owa, r->dgbc);
     onewayalloc_freez(owa, r->dgbs);

--- a/src/web/api/queries/rrdr.h
+++ b/src/web/api/queries/rrdr.h
@@ -17,6 +17,12 @@ typedef enum tier_query_fetch {
     TIER_QUERY_FETCH_AVERAGE
 } TIER_QUERY_FETCH;
 
+typedef enum query_point_mode {
+    QUERY_POINT_MODE_LINEAR,
+    QUERY_POINT_MODE_HOLD,
+    QUERY_POINT_MODE_TOTAL,
+} QUERY_POINT_MODE;
+
 typedef enum __attribute__ ((__packed__)) rrdr_value_flag {
 
     // IMPORTANT:
@@ -104,6 +110,7 @@ typedef struct rrdresult {
         NETDATA_DOUBLE (*flush)(struct rrdresult *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
         TIER_QUERY_FETCH tier_query_fetch;  // which value to use from STORAGE_POINT
+        QUERY_POINT_MODE point_mode;
 
         size_t points_wanted;               // used by SES and DES
         size_t resampling_group;            // used by AVERAGE

--- a/src/web/api/queries/rrdr.h
+++ b/src/web/api/queries/rrdr.h
@@ -12,6 +12,7 @@ extern "C" {
 
 typedef enum tier_query_fetch {
     TIER_QUERY_FETCH_SUM,
+    TIER_QUERY_FETCH_RATE_SUM,
     TIER_QUERY_FETCH_MIN,
     TIER_QUERY_FETCH_MAX,
     TIER_QUERY_FETCH_AVERAGE

--- a/src/web/api/queries/rrdr.h
+++ b/src/web/api/queries/rrdr.h
@@ -82,6 +82,7 @@ typedef struct rrdresult {
     RRDR_VALUE_FLAGS *o;      // array n x d options for each value returned
     NETDATA_DOUBLE *ar;       // array n x d of anomaly rates (0 - 100)
     uint32_t *gbc;            // array n x d of group by count - NOT ALLOCATED when RRDR is created
+    uint32_t *arc;            // array n x d of anomaly-rate contributors, internal to group-by - NOT ALLOCATED when RRDR is created
     uint32_t *hgbc;           // array n x d of hidden (vh) group by count, internal to group-by - NOT ALLOCATED when RRDR is created
 
     struct {

--- a/tests/run-unit-tests.sh
+++ b/tests/run-unit-tests.sh
@@ -25,6 +25,47 @@ c_unit_tests() {
   "$HOME"/netdata/usr/sbin/netdata -W unittest
 }
 
+rrddim_collection_test() {
+  echo "Running RRD dimension collection component test"
+
+  local build_dir="${NETDATA_BUILD_DIR:-./build}"
+  local config_h="${build_dir}/config.h"
+
+  if [[ ! -r "${config_h}" ]]; then
+    echo >&2 "Cannot read CMake configuration: ${config_h}"
+    return 1
+  fi
+
+  if ! grep -Fqx '#define OS_LINUX' "${config_h}"; then
+    echo "Skipping RRD dimension collection component test (requires Linux)"
+    return 0
+  fi
+
+  cmake --build "${build_dir}" --target rrddim-collection-test || return 1
+  "${build_dir}"/rrddim-collection-test
+}
+
+stream_replication_query_test() {
+  echo "Running stream replication query component test"
+
+  local build_dir="${NETDATA_BUILD_DIR:-./build}"
+  local config_h="${build_dir}/config.h"
+
+  if [[ ! -r "${config_h}" ]]; then
+    echo >&2 "Cannot read CMake configuration: ${config_h}"
+    return 1
+  fi
+
+  if ! grep -Fqx '#define OS_LINUX' "${config_h}" ||
+     ! grep -Fqx '#define ENABLE_DBENGINE' "${config_h}"; then
+    echo "Skipping stream replication query component test (requires Linux with DBENGINE)"
+    return 0
+  fi
+
+  cmake --build "${build_dir}" --target stream-replication-query-test || return 1
+  "${build_dir}"/stream-replication-query-test
+}
+
 spawn_server_unit_tests() {
   echo "Running spawn-server unit tests"
 
@@ -43,5 +84,9 @@ spawn_server_unit_tests() {
 install_netdata || exit 1
 
 c_unit_tests || exit 1
+
+rrddim_collection_test || exit 1
+
+stream_replication_query_test || exit 1
 
 spawn_server_unit_tests || exit 1


### PR DESCRIPTION
## Purpose

Fix corpus-proven query-engine defects without changing the Agent -> Cloud -> UI timestamp contract. This PR is the bug-fix stage after the query contract corpus in #23130; it no longer depends on the time-grouping feature PR #23281.

## Fixes

Each concern is isolated in its own commit:

1. Apply `absolute` to points as they enter each query plan.
2. Emit `RESET` only on the result row that owns the stored reset timestamp.
3. Scope tier-0 metadata to result rows instead of leaking it across rows.
4. Preserve incremental-sum baselines at the collection interval.
5. Apportion a stored SUM record by its exact overlap with each result row.
6. Keep API response timestamps request-derived and independent of retention/data availability.
7. Retain empty rows on that immutable API timestamp grid.
8. Preserve contributor counts through multipass group-by.
9. Exclude expired prefixes from SUM carry.
10. Expose storage gap evidence as `STORAGE_POINT.gap_count`.
11. Integrate stored rates from the point's own duration and stored slots, never current/latest `update_every`.
12. Propagate partial source evidence to every numeric derived row.
13. Return every tier-0 point across adjacent DBENGINE pages whose collection cadence changes.
14. Keep tier-0 gap evidence on the result row that owns its stored timestamp.
15. Specialize V1/tier-0 storage-point normalization in the DBENGINE decoder.
16. Merge only the count/anomaly/gap evidence used by each result row.
17. Compact that private row evidence from a full 56-byte `STORAGE_POINT` to 12 bytes.
18. Keep gap-only database averages null while preserving the unset-point zero fallback.
19. Single-source merge/add accumulation at compile time without changing generated runtime code.
20. Keep an active sparse metric's one-point LATEST cached value eligible while its latest collection interval reaches the requested window.

## Storage-point contract

The query/storage boundary now distinguishes four states from `count` and `gap_count`:

- unset: `count == 0 && gap_count == 0`
- gap-only: `count == 0 && gap_count > 0`
- complete numeric: `count > 0 && gap_count == 0`
- partial numeric: `count > 0 && gap_count > 0`

Tier 0 is exact. Existing V1 higher-tier pages do not persist gaps, so DBENGINE reconstructs the best available evidence as `max(active_grouping - count, 0)`. A future page format is still required for exact mixed-cadence historical rollups; this PR does not claim gap ordering or exact historical grouping from data the old format never stored.

Rate SUM uses the stored point itself:

`sum * (end_time - start_time) / (count + gap_count)`

No current chart/database `update_every` participates in value arithmetic.

## Timestamp invariant

For a given API request, synchronized Agents must return the same timestamp grid regardless of retention, collection frequency, gaps, or metric status. The fixes preserve and corpus-pin that invariant. Storage timestamps decide value/reset/gap ownership only; they never reshape the API response grid.

## Correctness evidence

The focused supported corpus is green on the committed binary. Mutation proofs include:

- removing V1 gap reconstruction fails CASE-028 and higher-tier PARTIAL cases;
- dividing rate SUM by `count` instead of stored slots fails CASE-028 by exactly 2x;
- removing PARTIAL propagation fails tier-1 and wide-partial cases;
- using current cadence fails both CASE-030 directions by exactly 10x;
- restoring the adjacent-page skip fails CASE-035 by 900;
- timestamp-grid mutations fail CASE-022/034;
- CASE-039 pins sparse active LATEST values through one-day collection intervals, including the exact inclusive endpoint and one-second expiry;
- a dedicated gap-only database-statistics case fails on numeric average zero and passes only with null min/avg/max;
- the expanded interior/tail RESET case proves exact timestamp-owner placement on 5s, 30s, and 35s grids for average and SUM;
- every earlier surgical fix has its corresponding corpus regression case in #23130.

The complete corpus evaluates all 127 contracts and all 162 required scopes. It reports the same ordered 35 honest failures as the preceding 126-contract run. Those failures remain visible for #23281, public-contract work, existing query defects, and the future DBENGINE page format; they are not expected-failure exemptions.

Additional validation:

- full optimized `netdata -W unittest`: pass;
- `netdata -W queryplantest`: pass;
- corpus fixture/canonicalizer/stream/daemon packages: pass;
- manifest parity and component validation: pass;
- `go vet ./...`: pass;
- `git diff --check`: pass;
- local build has no GTest support, so CI must compile/run the guarded PGD C++ tests.

## Hot-path review

The complete diff was audited line by line. The final row-evidence optimization:

- reduces `QUERY_ENGINE_OPS` from 608 to 568 bytes;
- removes 38 bytes and 18 decoded instructions from the executor;
- adds no executor conditional jump or call.

Pinned-core, crossed A/B plus role-swapped B/A measurements against source-exact master report:

- tier-0 gauge average: **-1.27%**
- tier-0 gauge SUM: **-1.90%**
- tier-0 rate SUM: **-3.77%**
- tier-1 rate SUM: **-4.60%**
- automatic gauge average: **-0.13%**
- one-point/alert-like gauge average (preceding comprehensive run): **-0.64%**
- multipass group-by SUM (preceding comprehensive run): **-2.78%**

Forced tier-1 gauge-average timings are below the harness's stable resolution: direct repetitions range from +1.46% to a non-repeating +7.11%, while the same-binary control itself reports +1.77%, the preceding full crossed run reports +3.03%, and automatic selection over the same dense tier path is neutral. The outlier is retained in the audit evidence, but it is not repeatable. Two attempted decoder simplifications were both slower and were rejected.

The final compile-time merge/add factoring was rebuilt in both directions in the same worktree. Baseline and candidate executable `.text` sections are byte-identical, as are their `.rodata` sections; it adds no runtime instruction, branch, call, or data.

Hardware counters are unavailable to the unprivileged test user (`perf_event_paranoid=4`); no host setting was changed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing, partial, grouped, and anomalous metric data in charts and API results.
  - Corrected gap detection, page boundaries, tier transitions, and long-interval query behavior.
  - Improved total, sum, grouping, interpolation, and anomaly-rate calculations.
  - Fixed latest-value queries near the current time and incremental-sum handling for empty intervals.
  - Improved metric collection-frequency changes and preservation of boundary data.
  - Improved query behavior across linear, hold, and total point modes.

- **Tests**
  - Expanded coverage for database pages, tiered collection, storage points, and stream replication.
  - Added automated validation for collection, query, gap, and replication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
