### PR TITLE
Build RPM packages through CPack in CI

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -53,7 +53,7 @@ default_sentry: &default_sentry # Default configuration for Sentry usage
   armhfp: false
   arm64: false
   aarch64: false
-default_builder_rev: &def_builder_rev v1
+default_builder_rev: &def_builder_rev v2
 include:
   - &alpine
     distro: alpine

--- a/packaging/building-native-packages-locally.md
+++ b/packaging/building-native-packages-locally.md
@@ -25,9 +25,13 @@ podman run -it --rm -e VERSION=0.1 -v $PWD:/netdata netdata/package-builders:<ta
 ```
 
 The `<tag>` should be the lowercase distribution name with no spaces, followed by the
-release of that distribution and then a `-v1` or `-v2` depending on the distro (DEB based distros use `-v2` currently, RPM based distros use `-v1` currently). For example, `centos7-v1` to build on CentOS 7, or `ubuntu20.04-v2`
+release of that distribution and then the builder revision, which is `-v2` for every distribution we build
+packages for. For example, `centos7-v2` to build on CentOS 7, or `ubuntu20.04-v2`
 to build on Ubuntu 20.04. Note that we use Rocky Linux for builds on CentOS/RHEL 8 or newer. See
 [netdata/package-builders](https://hub.docker.com/r/netdata/package-builders/tags) for all available tags.
+
+The `-v1` tags for RPM based distributions are still published, but they build from `netdata.spec.in` instead of
+CMake and CPack. They are retained only as a fallback and no longer match what CI builds.
 
 The value passed in the `VERSION` environment variable can be any version number accepted by the type of package
 being built. As a general rule, it needs to start with a digit, and must include a `.` somewhere.


### PR DESCRIPTION
## Summary

Flips every RPM distro to the `v2` package-builder images, so RPMs are built by `cpack -G RPM` from the CMake
install rules instead of by `rpmbuild` from `netdata.spec.in`. DEB distros have been built this way for a while.
This is the switch-over step for the migration merged in #23194 — that PR deliberately landed the CPack RPM path
unused, gated behind exactly this one value.

```diff
-default_builder_rev: &def_builder_rev v1
+default_builder_rev: &def_builder_rev v2
```

Nine RPM distro entries reference that anchor; the DEB entries keep their own explicit `builder_rev: v2` so a
rollback of this PR cannot drag them backwards. Effect on the generated matrix: 29 RPM jobs move from `v1` to
`v2`, `builder_rev` is the only field that changes, and the 23 DEB jobs are untouched.

## Why

The spec file and the CMake install rules are two definitions of one product, and they drift. The
`ebpf-code-legacy` component was gated on a misspelled option name for years, so the DEB sub-package silently
stopped being built while the spec-driven RPM kept shipping it. After this PR the CMake install rules are the
only definition for both formats.

## Validation

- #23194 shipped a parity harness (`packaging/tests/rpm-parity/`) that compares the spec-built and CPack-built
  RPM sets — package set, header metadata, all dependency classes including weak deps, per-file
  modes/owners/flags/capabilities, scriptlets, changelog. Full parity was proven on an eight-distro sample
  covering every tier (CentOS Stream 9, Rocky Linux 8, Fedora 42, Fedora 44, openSUSE 15.6, Amazon Linux 2023,
  CentOS 7, Amazon Linux 2), with CentOS Stream 10 validated by direct inspection.
- Since that merge, one commit touched the packaging surface: #23157 added `netdata-support-bundle` to both
  `netdata.spec.in` and `CMakeLists.txt` — same path (`/usr/sbin`), same package (main `netdata`), same
  attributes on both paths. The go.d `sensors` removal (#23237) needs no packaging change: both paths take that
  config directory wholesale.
- Every explicit file entry in the `CPACK_RPM_*_USER_FILELIST` lists still resolves to a current install rule,
  and the RPM scriptlet set is intact.
- All `-v2` RPM builder tags are published and current; they carry CMake 4.1.6, which CPack needs to emit RPM
  weak dependencies.
- This PR's own `Packages` run is the functional gate: `.github/data/distros.yml` is a watched path, so the full
  RPM matrix builds on `x86_64` and `aarch64` and each result is install-and-run tested by
  `.github/scripts/pkg-test.sh`. This is the first functional coverage of the CPack RPMs on `aarch64` — the
  parity work was done on `x86_64`.

## Rollback

Set `default_builder_rev` back to `v1`; the next build uses the spec again. `netdata.spec.in`, the `v1` images,
and the parity harness all stay in place until the CPack-built RPMs have shipped in a stable release.

## Open for a maintainer call

Two cosmetic divergences from the spec output are known and deliberately not papered over. Neither changes a
packaged file, dependency, or scriptlet:

1. CPack prepends a summary line to `%description` bodies, which the spec's descriptions do not have.
2. CPack stamps a `Vendor:` tag where the spec leaves none.

Either is fine to accept, but the call should be explicit rather than made by default. Say which and I will
align them exactly or leave them.

## Follow-up

Retiring the old path — `netdata.spec.in` here, plus `fedora-build.sh`, `suse-build.sh`, and the `v1`
Dockerfiles in `netdata/helper-images` — is deliberately not in this PR. It should happen after the CPack RPMs
survive one stable release. Until then any change to the package payload has to be applied to both paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch RPM builds in CI to CPack (CMake) by moving all RPM distros to `v2` package-builder images. This unifies package contents across RPM and DEB using the CMake install rules and updates local build docs.

- **Refactors**
  - Set `default_builder_rev` to `v2` in `.github/data/distros.yml`, switching RPM builds from `rpmbuild` + `netdata.spec.in` to `cpack -G RPM`. DEB builds unchanged.
  - Update `packaging/building-native-packages-locally.md` to use `-v2` tags and note `-v1` RPM tags are fallback only.
  - Rollback: set `default_builder_rev` back to `v1` to restore spec-based builds.

<sup>Written for commit 8e5fad63478eb6204073a8c107ebec0f23cf5891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

