### PR TITLE
apps.plugin: skip macOS zombies instead of logging an error every cycle

### DIFF
--- a/src/collectors/apps.plugin/apps_os_macos.c
+++ b/src/collectors/apps.plugin/apps_os_macos.c
@@ -427,8 +427,6 @@ bool apps_os_read_pid_stat_macos(struct pid_stat *p, void *ptr) {
 }
 
 bool apps_os_collect_all_pids_macos(void) {
-    // Mark all processes as unread before collecting new data
-    struct pid_stat *p;
     static pid_t *pids = NULL;
     static int allocatedProcessCount = 0;
 
@@ -473,6 +471,12 @@ bool apps_os_collect_all_pids_macos(void) {
             continue;
         }
         if(procSize == 0) // no such process
+            continue;
+
+        // zombies have no Mach task and proc_pidinfo() resolves pids via proc_find(),
+        // which skips SZOMB entries - so every proc_pidinfo() flavor below returns
+        // ESRCH for them, for as long as the parent does not reap them.
+        if(pi.proc.kp_proc.p_stat == SZOMB)
             continue;
 
         int st = proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pi.taskinfo, sizeof(pi.taskinfo));


### PR DESCRIPTION
## Problem

On macOS, `apps.plugin` logs an error for **every zombie process on every collection cycle**:

```
comm=apps.plugin level=error errno="3, No such process" msg="Failed to get task info for PID <N>"
```

A zombie persists until its parent reaps it, so the line repeats indefinitely and `collector.log` grows
without bound. One reported host reached 3 GB, ~99.5% of it this single line. Log flood protection fires
continuously but the file still grows.

## Root cause

`apps_os_collect_all_pids_macos()` calls `proc_pidinfo(pid, PROC_PIDTASKINFO, ...)` for every PID. macOS
resolves the PID inside `proc_pidinfo()` through `proc_find()`, which skips `SZOMB` entries — so the call
fails with `ESRCH` for a zombie, and the failure is logged at error level before the loop has any chance to
learn the process is a zombie.

Note for anyone comparing against the issue's suggested remedy: reading `PROC_PIDTBSDINFO` first and testing
`pbi_status == SZOMB` does **not** work. Because the skip happens in `proc_find()`, *every* `proc_pidinfo()`
flavor fails with `ESRCH` for a zombie. Verified against a real zombie:

```
sysctl KERN_PROC_PID   -> ok, p_stat = 5 (SZOMB)
proc_pidinfo TASKINFO  -> 0, errno 3 (No such process)
proc_pidinfo TBSDINFO  -> 0, errno 3 (No such process)   <- so reordering only relabels the line
```

## Fix

The `struct kinfo_proc` the loop already fetches via `sysctl(CTL_KERN, KERN_PROC, KERN_PROC_PID, pid)` *does*
report `SZOMB` for zombies. Test it there and skip the PID before any `proc_pidinfo()` call — no extra
syscall, and it removes up to three failing syscalls plus a log write per zombie per cycle.

## Impact on collected data: none

Zombies were already excluded from collection: the `PROC_PIDTASKINFO` failure path `continue`d before
`incrementally_collect_data_for_pid()`, which is the only path that records a PID on macOS. The new branch
skips exactly the same set of PIDs, just earlier and silently. There is no stale-data risk either —
`collect_data_for_all_pids()` clears every `pid_stat.updated` flag before OS collection and aggregation
ignores non-updated entries.

No chart, dimension, metric, configuration, or API changes.

The commit also drops an unused local in the same function, which the compiler flags as
`-Wunused-variable`.

## Testing

Built and run on macOS against a live process table containing a confirmed zombie (`ps` state `Z`), for 6
collection cycles:

- lines referencing the zombie PID: **0**
- `Failed to get task info` errno breakdown: 220x errno 1 (`EPERM`), **0x errno 3 (`ESRCH`)**

The `EPERM` lines are an artifact of running the test binary unprivileged — 220 of 549 PIDs belong to other
users. `apps.plugin` is installed setuid root, and the reported flood is errno 3, which is now gone.

## Follow-up

macOS still has no way to *see* zombies, because `system.processes_state` is Linux-only
(`PROCESSES_HAVE_STATE` is 0 for macOS). The state data is already available in `kp_proc.p_stat`. Tracked
separately in #23296.

Fixes #23293


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip zombie PIDs on macOS in `apps.plugin` before any `proc_pidinfo()` calls to stop per-cycle ESRCH errors and log growth; metrics are unchanged.

- **Bug Fixes**
  - Detect `SZOMB` via `kinfo_proc` and skip the PID, avoiding repeated "Failed to get task info" errno 3 logs and unnecessary syscalls.
  - No data changes (zombies were already excluded). Also removed an unused local variable.

<sup>Written for commit 624b32488fe6a4f976e81ee0aabdba96415ef364. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

