### PR TITLE
Explicitly trigger daemon-reload in RPM packages when needed.

### DIFF
--- a/packaging/cmake/pkg-files/rpm/netdata/postun.suse
+++ b/packaging/cmake/pkg-files/rpm/netdata/postun.suse
@@ -1,2 +1,17 @@
+if [ $1 -ge 1 ]; then
+  need_reload=0
+
+  for unit in netdata.service netdata-updater.service netdata-updater.timer; do
+    if systemctl --system show --property=NeedDaemonReload --value "${unit}" 2>/dev/null | grep -q 'yes' ; then
+      need_reload=1
+      break
+    fi
+  done
+
+  if [ "${need_reload}" -eq 1 ]; then
+    systemctl --system daemon-reload || :
+  fi
+fi
+
 %service_del_postun netdata.service
 %service_del_postun netdata-updater.timer

--- a/packaging/cmake/pkg-files/rpm/netdata/postun.systemd
+++ b/packaging/cmake/pkg-files/rpm/netdata/postun.systemd
@@ -1,2 +1,17 @@
+if [ $1 -ge 1 ]; then
+  need_reload=0
+
+  for unit in netdata.service netdata-updater.service netdata-updater.timer; do
+    if systemctl --system show --property=NeedDaemonReload --value "${unit}" 2>/dev/null | grep -q 'yes' ; then
+      need_reload=1
+      break
+    fi
+  done
+
+  if [ "${need_reload}" -eq 1 ]; then
+    systemctl --system daemon-reload || :
+  fi
+fi
+
 %systemd_postun_with_restart netdata.service
 %systemd_postun_with_restart netdata-updater.timer

--- a/packaging/cmake/pkg-files/rpm/netdata/postun.systemd
+++ b/packaging/cmake/pkg-files/rpm/netdata/postun.systemd
@@ -2,7 +2,7 @@ if [ $1 -ge 1 ]; then
   need_reload=0
 
   for unit in netdata.service netdata-updater.service netdata-updater.timer; do
-    if systemctl --system show --property=NeedDaemonReload --value "${unit}" 2>/dev/null | grep -q 'yes' ; then
+    if systemctl --system show --property=NeedDaemonReload "${unit}" 2>/dev/null | grep -q '=yes' ; then
       need_reload=1
       break
     fi


### PR DESCRIPTION
##### Summary

At least some RPM-based systems don’t have an explicit file watcher set up to queue a trigger for a call to `systemctl --system daemon-reload` when unit files are updated during a package transaction.

This causes issues when our unit files change and the user doesn’t explicitly reload or reboot.

Given this, add a check during the postuninstall hook for the main Netdata package to check all of our unit files to see if a reload is needed, and if so just trigger a reload prior to queueing restarts of the changed services.

##### Test Plan

n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure systemd reloads Netdata unit files during RPM post-uninstall when needed, including on older distros. Fixes stale unit configs so restarts pick up changes without a reboot.

- **Bug Fixes**
  - In RPM postun scripts, check `NeedDaemonReload` for `netdata.service`, `netdata-updater.service`, and `netdata-updater.timer`; if any need it, run `systemctl --system daemon-reload`. Compatible with CentOS 7 and Amazon Linux 2.
  - Runs only on upgrades (`$1 -ge 1`) and applies to both `postun.suse` and `postun.systemd`.

<sup>Written for commit c32f7f12fa4562dac4517b348e6416b4472e82fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

