### PR TITLE
fix(go.d): test Docker discovery connectivity

### DIFF
--- a/src/go/plugin/agent/discovery/sd/dyncfg.go
+++ b/src/go/plugin/agent/discovery/sd/dyncfg.go
@@ -273,12 +273,28 @@ func (d *ServiceDiscovery) dyncfgCmdTest(fn dyncfg.Function) {
 		return
 	}
 
-	// Parse and validate the config without storing it
-	_, err := parseDyncfgPayload(fn.Payload(), dt, name, d.configDefaults, d.discovererRegistry(), true)
+	// Parse and validate the config without storing it.
+	reg := d.discovererRegistry()
+	cfg, err := parseDyncfgPayload(fn.Payload(), dt, name, d.configDefaults, reg, true)
 	if err != nil {
 		d.Warningf("dyncfg: test: failed to parse config for '%s': %v", dt, err)
 		d.dyncfgApi.SendCodef(fn, 400, "Failed to parse config: %v", err)
 		return
+	}
+
+	desc, _ := reg.Get(dt)
+	if desc.TestConfig != nil {
+		discovererCfg, err := desc.ParseJSONConfig(cfg.Discoverer.Config)
+		if err != nil {
+			d.Warningf("dyncfg: test: failed to parse config for '%s': %v", dt, err)
+			d.dyncfgApi.SendCodef(fn, 400, "Failed to parse config: %v", err)
+			return
+		}
+		if err := desc.TestConfig(d.ctx, discovererCfg); err != nil {
+			d.Warningf("dyncfg: test: config test failed for '%s': %v", dt, err)
+			d.dyncfgApi.SendCodef(fn, 400, "Failed to test config: %v", err)
+			return
+		}
 	}
 
 	if isJob {

--- a/src/go/plugin/agent/discovery/sd/dyncfg_test.go
+++ b/src/go/plugin/agent/discovery/sd/dyncfg_test.go
@@ -82,6 +82,7 @@ func newTestSNMPConfig(name string, cfg testSNMPConfig, services []pipeline.Serv
 type dyncfgSim struct {
 	do func(sd *ServiceDiscovery)
 
+	discoverers    Registry
 	wantExposed    []wantExposedConfig
 	wantRunning    []string
 	wantDyncfg     string
@@ -101,6 +102,11 @@ func (s *dyncfgSim) run(t *testing.T) {
 	require.NotNil(t, s.do, "s.do is nil")
 
 	var buf bytes.Buffer
+	discoverers := s.discoverers
+	if discoverers == nil {
+		discoverers = testDiscovererRegistry()
+	}
+
 	sd := &ServiceDiscovery{
 		Logger:      logger.New(),
 		pluginName:  testPluginName,
@@ -108,7 +114,7 @@ func (s *dyncfgSim) run(t *testing.T) {
 		seen:        dyncfg.NewSeenCache[sdConfig](),
 		exposed:     dyncfg.NewExposedCache[sdConfig](),
 		dyncfgCh:    make(chan dyncfg.Function, 1),
-		discoverers: testDiscovererRegistry(),
+		discoverers: discoverers,
 		newPipeline: func(cfg pipeline.Config) (sdPipeline, error) {
 			return newTestPipeline(cfg.Name), nil
 		},
@@ -1540,6 +1546,38 @@ FUNCTION_RESULT_END
 					wantDyncfg: `
 FUNCTION_RESULT_BEGIN 1-test 200 application/json
 {"status":200,"message":""}
+FUNCTION_RESULT_END
+`,
+				}
+			},
+		},
+		"test docker connectivity failure": {
+			createSim: func() *dyncfgSim {
+				cfg := newTestDockerConfig("docker-test", "unix:///missing/docker.sock", 0, defaultTestServices())
+				payload, _ := json.Marshal(cfg)
+
+				reg := NewRegistry(NewDescriptorWithTest(
+					testDiscovererTypeDocker,
+					testDiscovererSchema,
+					parseJSONTestConfig[testDockerConfig],
+					func(context.Context, testDockerConfig) error {
+						return errors.New("docker endpoint is unreachable")
+					},
+					newTestDiscoverers[testDockerConfig],
+				))
+
+				return &dyncfgSim{
+					discoverers: reg,
+					do: func(sd *ServiceDiscovery) {
+						sendDyncfgCmd(sd, "1-test",
+							[]string{sd.dyncfgTemplateID(testDiscovererTypeDocker), "test"},
+							payload, "")
+					},
+					wantExposed: []wantExposedConfig{},
+					wantRunning: []string{},
+					wantDyncfg: `
+FUNCTION_RESULT_BEGIN 1-test 400 application/json
+{"status":400,"errorMessage":"Failed to test config: docker endpoint is unreachable"}
 FUNCTION_RESULT_END
 `,
 				}

--- a/src/go/plugin/agent/discovery/sd/registry.go
+++ b/src/go/plugin/agent/discovery/sd/registry.go
@@ -3,6 +3,7 @@
 package sd
 
 import (
+	"context"
 	"encoding/json"
 	"slices"
 
@@ -13,6 +14,7 @@ type Descriptor struct {
 	Type            string
 	Schema          string
 	ParseJSONConfig func(raw json.RawMessage) (any, error)
+	TestConfig      func(ctx context.Context, cfg any) error
 	NewDiscoverers  func(cfg any, source string) ([]model.Discoverer, error)
 }
 
@@ -71,6 +73,23 @@ func NewDescriptor[T any](
 			return newDiscs(v, source)
 		},
 	}
+}
+
+func NewDescriptorWithTest[T any](
+	typ, schema string,
+	parseJSON func(raw json.RawMessage) (T, error),
+	testConfig func(ctx context.Context, cfg T) error,
+	newDiscs func(cfg T, source string) ([]model.Discoverer, error),
+) Descriptor {
+	desc := NewDescriptor(typ, schema, parseJSON, newDiscs)
+	desc.TestConfig = func(ctx context.Context, cfg any) error {
+		v, ok := cfg.(T)
+		if !ok {
+			return &typedConfigError{typ: typ}
+		}
+		return testConfig(ctx, v)
+	}
+	return desc
 }
 
 type typedConfigError struct {

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/dockersd/docker.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/dockersd/docker.go
@@ -86,6 +86,30 @@ func (d *Discoverer) String() string {
 	return "sd:docker"
 }
 
+func (d *Discoverer) Test(ctx context.Context) error {
+	client, err := d.newDockerClient(d.addr)
+	if err != nil {
+		return fmt.Errorf("create Docker client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	listCtx, cancel := context.WithTimeout(ctx, d.timeout)
+	defer cancel()
+
+	if _, err := client.ContainerList(listCtx, docker.ContainerListOptions{}); err != nil {
+		return fmt.Errorf("list Docker containers: %w", err)
+	}
+	return nil
+}
+
+func TestConfig(ctx context.Context, cfg Config) error {
+	d, err := NewDiscoverer(cfg)
+	if err != nil {
+		return err
+	}
+	return d.Test(ctx)
+}
+
 func (d *Discoverer) Discover(ctx context.Context, in chan<- []model.TargetGroup) {
 	d.Info("instance is started")
 	defer func() { d.cleanup(); d.Info("instance is stopped") }()

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/dockersd/docker_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/dockersd/docker_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dockersd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+
+	docker "github.com/moby/moby/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverer_Test(t *testing.T) {
+	tests := map[string]struct {
+		listErr error
+		wantErr string
+	}{
+		"reachable endpoint": {},
+		"unreachable endpoint": {
+			listErr: errors.New("connection refused"),
+			wantErr: "list Docker containers: connection refused",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			d, err := NewDiscoverer(Config{Timeout: confopt.Duration(100 * time.Millisecond)})
+			require.NoError(t, err)
+
+			client := &testDockerClient{listErr: test.listErr}
+			d.newDockerClient = func(string) (dockerClient, error) {
+				return client, nil
+			}
+
+			err = d.Test(context.Background())
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, test.wantErr)
+			}
+			assert.True(t, client.hadDeadline, "ContainerList context has a deadline")
+			assert.True(t, client.closed, "Docker client is closed")
+		})
+	}
+}
+
+func TestDiscoverer_Test_ClientCreationFailure(t *testing.T) {
+	d, err := NewDiscoverer(Config{})
+	require.NoError(t, err)
+
+	d.newDockerClient = func(string) (dockerClient, error) {
+		return nil, errors.New("invalid endpoint")
+	}
+
+	require.EqualError(t, d.Test(context.Background()), "create Docker client: invalid endpoint")
+}
+
+func TestConfig_UnreachableEndpoint(t *testing.T) {
+	socket, err := os.CreateTemp("/tmp", "netdata-missing-docker-*.sock")
+	require.NoError(t, err)
+	socketPath := socket.Name()
+	require.NoError(t, socket.Close())
+	require.NoError(t, os.Remove(socketPath))
+
+	cfg := Config{
+		Address: "unix://" + socketPath,
+		Timeout: confopt.Duration(100 * time.Millisecond),
+	}
+
+	err = TestConfig(context.Background(), cfg)
+	require.ErrorContains(t, err, "list Docker containers:")
+}
+
+type testDockerClient struct {
+	listErr     error
+	hadDeadline bool
+	closed      bool
+}
+
+func (c *testDockerClient) ContainerList(ctx context.Context, _ docker.ContainerListOptions) (docker.ContainerListResult, error) {
+	_, c.hadDeadline = ctx.Deadline()
+	return docker.ContainerListResult{}, c.listErr
+}
+
+func (c *testDockerClient) Close() error {
+	c.closed = true
+	return nil
+}

--- a/src/go/plugin/go.d/discovery/sdext/registry.go
+++ b/src/go/plugin/go.d/discovery/sdext/registry.go
@@ -51,10 +51,11 @@ func Registry(includeDocker bool) sd.Registry {
 		),
 	}
 	if includeDocker {
-		descs = append(descs, sd.NewDescriptor(
+		descs = append(descs, sd.NewDescriptorWithTest(
 			discovererDocker,
 			schemaDocker,
 			parseJSONConfig[dockersd.Config],
+			dockersd.TestConfig,
 			newDockerDiscoverers,
 		))
 	}


### PR DESCRIPTION
## Summary

- add an optional typed connectivity-test hook to service-discovery descriptors
- make Docker dyncfg tests call `ContainerList` with the configured timeout
- close the temporary Docker client and preserve parse-only behavior for other discoverers

Fixes #23295

## Validation

- `go test -count=1 ./plugin/agent/discovery/sd/... ./plugin/go.d/discovery/sdext/...`
- `go vet ./plugin/agent/discovery/sd/... ./plugin/go.d/discovery/sdext/...`
- `gofmt`
- `git diff --check`

## Artifact consistency

No schema, generated integration metadata, stock configuration, health, or documentation changes are needed. The existing Docker integration documentation already states that discovery uses `ContainerList` and describes endpoint/permission failures.

## AI assistance

This change was developed with AI assistance. I reviewed the implementation and ran the validation listed above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a typed config-test hook for service discovery and use it to check Docker connectivity during dyncfg "test" using the configured timeout. This returns clear errors when Docker is unreachable and ensures temporary clients are closed. Fixes #23295.

- **Bug Fixes**
  - `go.d` dyncfg "test" for Docker calls ContainerList with the configured timeout and closes the temporary client.
  - Clear 400 responses when the Docker endpoint cannot be reached.

- **New Features**
  - Optional `TestConfig` hook on `sd.Descriptor`; implemented for Docker via `dockersd.TestConfig` and `Discoverer.Test`.
  - Keeps parse-only behavior for other discoverers; only Docker runs a live connectivity check.

<sup>Written for commit 5c20d9366ee1af150286b02446f1fca66dac3f53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

