### PR TITLE
Fix NetFlow filtering and facet retention

### DIFF
--- a/docs/netdata-ai/skills/query-netdata-agents/query-flows.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/query-flows.md
@@ -20,7 +20,11 @@ for the Function to be available.
 The direct endpoint has the same CIDR behavior as Cloud: the six
 IP address facets accept exact IPv4/IPv6 addresses or canonical
 CIDRs, and autocomplete terms containing `/` generate canonical
-CIDR candidates from loose input such as `10/8`.
+CIDR candidates from loose input such as `10/8`. Only candidates
+containing an address in that field's retention-wide vocabulary are
+returned. One trailing dot before `/` is tolerated after one through
+three IPv4 octets, so `10./` is equivalent to `10/`. Suggestions are
+not recalculated for the current time window or other active filters.
 
 ---
 

--- a/docs/netdata-ai/skills/query-netdata-agents/query-flows.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/query-flows.md
@@ -17,6 +17,11 @@ Today only `flows:netflow` is registered (covers NetFlow v5/v9,
 IPFIX, sFlow). The agent must run the netflow-plugin Rust crate
 for the Function to be available.
 
+The direct endpoint has the same CIDR behavior as Cloud: the six
+IP address facets accept exact IPv4/IPv6 addresses or canonical
+CIDRs, and autocomplete terms containing `/` generate canonical
+CIDR candidates from loose input such as `10/8`.
+
 ---
 
 ## Endpoint (agent v3)

--- a/docs/netdata-ai/skills/query-netdata-cloud/query-flows.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/query-flows.md
@@ -77,13 +77,13 @@ Verified against `src/crates/netflow-plugin/src/api/flows/handler.rs`:
 | `after` | flows | Unix seconds, lower bound. Negative = relative seconds from `before` |
 | `before` | flows | Unix seconds, upper bound. `0` = now |
 | `query` | flows | Free-text filter |
-| `selections` | flows | Pre-applied facet filters as `{ "FIELD_NAME": ["val", "val2"] }`. Common fields: `SRC_ADDR`, `DST_ADDR`, `SRC_PORT`, `DST_PORT`, `PROTOCOL`, `SRC_AS_NAME`, `DST_AS_NAME`, `SRC_COUNTRY`, `DST_COUNTRY`, `INTERFACE`, ... |
+| `selections` | flows | Pre-applied facet filters as `{ "FIELD_NAME": ["val", "val2"] }`. Values within a field are ORed; fields are ANDed. `EXPORTER_IP`, `SRC_ADDR`, `DST_ADDR`, `NEXT_HOP`, `SRC_ADDR_NAT`, and `DST_ADDR_NAT` accept exact IPv4/IPv6 addresses or canonical CIDRs. |
 | `facets` | flows | Array of requested facet fields. Fields with no retained values are omitted unless they have an active selection. |
 | `group_by` | flows | Up to 10 tuple-key field names (e.g. `["SRC_ADDR","DST_ADDR","PROTOCOL"]`) -- order defines the aggregation tuple |
 | `sort_by` | flows | `bytes` or `packets` |
 | `top_n` | flows | One of `25`, `50`, `100`, `200`, `500` |
 | `field` | autocomplete | Facet field to autocomplete (`SRC_ADDR`, etc.) |
-| `term` | autocomplete | Search prefix |
+| `term` | autocomplete | Search term. For an IP address field, a term containing `/` generates canonical IPv4/IPv6 CIDR candidates from loose input. |
 
 ---
 
@@ -116,7 +116,7 @@ envelope (same shape as topology and logs):
 | `stats` | Counters: `flows_total`, `packets_total`, `bytes_total`, etc. |
 | `metrics` | Optional metric block |
 | `warnings[]` | Optional non-fatal diagnostics |
-| `facets` | Retention-wide vocabularies for requested fields. Empty unselected fields are omitted; selected fields remain. Fields with up to 256 retained values return the complete static list; larger fields set `autocomplete: true`. The mode can change as retained values enter or leave retention. `auto.facets` echoes the requested field list and `auto.selections` echoes selections. |
+| `facets` | Retention-wide vocabularies for requested fields. Empty unselected fields are omitted; selected fields remain. Non-IP fields with up to 256 retained values return the complete static list; larger fields set `autocomplete: true` and omit inline values. IP address fields always set `autocomplete: true` for CIDR generation, but still return their complete inline list through 256 values. `truncated` states whether inline values were omitted. `auto.facets` echoes the requested field list and `auto.selections` echoes selections. |
 
 ### `data` object -- mode `flows`, view `timeseries`
 
@@ -136,7 +136,7 @@ totals) suitable for map rendering.
 | `mode` | `autocomplete` |
 | `field` | Echo of requested field |
 | `term` | Echo of requested search term |
-| `values[]` | Matching values for the field |
+| `values[]` | Matching retained values, or canonical CIDR candidates when an IP-field term contains `/` |
 | `stats` / `warnings` | Same as flows mode |
 
 ---
@@ -214,6 +214,31 @@ read -r -d '' PAYLOAD <<'EOF'
 EOF
 ```
 
+For CIDR autocomplete, loose address and prefix-length fragments are accepted:
+
+```json
+{
+  "mode":  "autocomplete",
+  "field": "DST_ADDR",
+  "term":  "10.1/1"
+}
+```
+
+The first candidate is the naturally implied `10.1.0.0/16`; all returned values are canonical CIDRs. Use one of those canonical values in `selections`:
+
+```json
+{
+  "mode":       "flows",
+  "view":       "timeseries",
+  "after":      -86400,
+  "before":     0,
+  "selections": {"DST_ADDR": ["10.1.0.0/16", "2001:db8::7"]},
+  "group_by":   ["SRC_ADDR"],
+  "sort_by":    "bytes",
+  "top_n":      25
+}
+```
+
 ### Example 5: discover the live parameter set first
 
 ```bash
@@ -240,6 +265,13 @@ curl -sS -X POST \
   100, 200, 500. Other integers are rejected.
 - **`group_by` accepts up to 10 fields.** The order matters --
   it's the tuple ordering for the aggregation key.
+- **CIDR shorthand is autocomplete-only.** Direct selections must
+  contain a complete IPv4/IPv6 address and prefix such as
+  `10.0.0.0/8`, not `10/8`. Valid non-network addresses are
+  normalized before matching. Address-field CIDRs use the same
+  raw-tier availability as exact address filters.
+- **Negative selections are not supported.** The current contract
+  is OR between values of one field and AND between fields.
 - **AS names depend on the configured GeoIP/AS database.** If the
   collector has no AS database, `SRC_AS_NAME` / `DST_AS_NAME`
   will be empty strings. Same for country/city fields.

--- a/docs/netdata-ai/skills/query-netdata-cloud/query-flows.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/query-flows.md
@@ -78,7 +78,7 @@ Verified against `src/crates/netflow-plugin/src/api/flows/handler.rs`:
 | `before` | flows | Unix seconds, upper bound. `0` = now |
 | `query` | flows | Free-text filter |
 | `selections` | flows | Pre-applied facet filters as `{ "FIELD_NAME": ["val", "val2"] }`. Common fields: `SRC_ADDR`, `DST_ADDR`, `SRC_PORT`, `DST_PORT`, `PROTOCOL`, `SRC_AS_NAME`, `DST_AS_NAME`, `SRC_COUNTRY`, `DST_COUNTRY`, `INTERFACE`, ... |
-| `facets` | flows | Array of facet field names whose value-distributions should appear in the response |
+| `facets` | flows | Array of requested facet fields. Fields with no retained values are omitted unless they have an active selection. |
 | `group_by` | flows | Up to 10 tuple-key field names (e.g. `["SRC_ADDR","DST_ADDR","PROTOCOL"]`) -- order defines the aggregation tuple |
 | `sort_by` | flows | `bytes` or `packets` |
 | `top_n` | flows | One of `25`, `50`, `100`, `200`, `500` |
@@ -116,7 +116,7 @@ envelope (same shape as topology and logs):
 | `stats` | Counters: `flows_total`, `packets_total`, `bytes_total`, etc. |
 | `metrics` | Optional metric block |
 | `warnings[]` | Optional non-fatal diagnostics |
-| `facets` | When `facets` was requested in body, per-field value-counts plus `selections` echo |
+| `facets` | Retention-wide vocabularies for requested fields. Empty unselected fields are omitted; selected fields remain. Fields with up to 256 retained values return the complete static list; larger fields set `autocomplete: true`. The mode can change as retained values enter or leave retention. `auto.facets` echoes the requested field list and `auto.selections` echoes selections. |
 
 ### `data` object -- mode `flows`, view `timeseries`
 

--- a/docs/netdata-ai/skills/query-netdata-cloud/query-flows.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/query-flows.md
@@ -215,8 +215,10 @@ EOF
 ```
 
 For CIDR autocomplete, loose address and prefix-length fragments are accepted.
-One trailing dot before `/` is also tolerated after one through three complete
-IPv4 octets, so `10.1./1` is equivalent to `10.1/1`:
+Digits after `/` are an autocomplete fragment, not a completed selection:
+`/1` considers `/1` and `/10` through `/19`. One trailing dot before `/` is
+also tolerated after one through three complete IPv4 octets, so `10.1./1` is
+equivalent to `10.1/1`:
 
 ```json
 {
@@ -226,10 +228,11 @@ IPv4 octets, so `10.1./1` is equivalent to `10.1/1`:
 }
 ```
 
-The naturally implied `10.1.0.0/16` is ranked first when the retained
-`DST_ADDR` vocabulary contains an address in it. Candidates containing no
-retained destination address are omitted, so another canonical network may be
-first. Use one of the returned canonical values in `selections`:
+The two complete address octets naturally imply `10.1.0.0/16`, so that
+candidate is ranked first when the retained `DST_ADDR` vocabulary contains an
+address in it. Candidates containing no retained destination address are
+omitted, so another canonical network may be first. Use one of the returned
+canonical values in `selections`:
 
 ```json
 {

--- a/docs/netdata-ai/skills/query-netdata-cloud/query-flows.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/query-flows.md
@@ -83,7 +83,7 @@ Verified against `src/crates/netflow-plugin/src/api/flows/handler.rs`:
 | `sort_by` | flows | `bytes` or `packets` |
 | `top_n` | flows | One of `25`, `50`, `100`, `200`, `500` |
 | `field` | autocomplete | Facet field to autocomplete (`SRC_ADDR`, etc.) |
-| `term` | autocomplete | Search term. For an IP address field, a term containing `/` generates canonical IPv4/IPv6 CIDR candidates from loose input. |
+| `term` | autocomplete | Search term. For an IP address field, a term containing `/` generates canonical IPv4/IPv6 CIDR candidates from loose input and returns only candidates containing an address in that field's retention-wide vocabulary. |
 
 ---
 
@@ -136,7 +136,7 @@ totals) suitable for map rendering.
 | `mode` | `autocomplete` |
 | `field` | Echo of requested field |
 | `term` | Echo of requested search term |
-| `values[]` | Matching retained values, or canonical CIDR candidates when an IP-field term contains `/` |
+| `values[]` | Matching retained values, or canonical CIDR candidates containing at least one retained address for that IP field when the term contains `/` |
 | `stats` / `warnings` | Same as flows mode |
 
 ---
@@ -214,7 +214,9 @@ read -r -d '' PAYLOAD <<'EOF'
 EOF
 ```
 
-For CIDR autocomplete, loose address and prefix-length fragments are accepted:
+For CIDR autocomplete, loose address and prefix-length fragments are accepted.
+One trailing dot before `/` is also tolerated after one through three complete
+IPv4 octets, so `10.1./1` is equivalent to `10.1/1`:
 
 ```json
 {
@@ -224,7 +226,10 @@ For CIDR autocomplete, loose address and prefix-length fragments are accepted:
 }
 ```
 
-The first candidate is the naturally implied `10.1.0.0/16`; all returned values are canonical CIDRs. Use one of those canonical values in `selections`:
+The naturally implied `10.1.0.0/16` is ranked first when the retained
+`DST_ADDR` vocabulary contains an address in it. Candidates containing no
+retained destination address are omitted, so another canonical network may be
+first. Use one of the returned canonical values in `selections`:
 
 ```json
 {
@@ -270,6 +275,10 @@ curl -sS -X POST \
   `10.0.0.0/8`, not `10/8`. Valid non-network addresses are
   normalized before matching. Address-field CIDRs use the same
   raw-tier availability as exact address filters.
+- **CIDR suggestions are retention-wide.** They prove that the
+  selected field contains a matching address somewhere in retained
+  data. The current time window and other selections can still make
+  the selected CIDR return no rows.
 - **Negative selections are not supported.** The current contract
   is OR between values of one field and AND between fields.
 - **AS names depend on the configured GeoIP/AS database.** If the

--- a/docs/npm/network-flows/README.md
+++ b/docs/npm/network-flows/README.md
@@ -85,7 +85,7 @@ Each flow record is enriched at ingestion with:
 - **Live BGP attributes** (AS path, communities, next-hop) — from BMP, BioRIS, or static prefix configuration
 - **Decapsulated inner-packet fields** for SRv6 / VXLAN traffic
 
-Flow records land in a four-tier journal: raw + 1-minute + 5-minute + 1-hour rollups, with independent retention per tier. Rollup tiers drop a few high-cardinality fields (IPs, ports, city/coordinates) to stay compact, so any query that filters or groups by those fields is served from the raw tier; everything else can use a coarser tier. The dashboard auto-picks the best tier for each query.
+Flow records land in a four-tier journal: raw + 1-minute + 5-minute + 1-hour rollups, with independent retention per tier. Rollup tiers drop high-cardinality and protocol-specific details such as addresses, prefixes, ports, cities/coordinates, MACs, BGP paths/communities, NAT fields, fragmentation details, and MPLS labels. Any query that filters or groups by a field absent from rollups is served from the raw tier; everything else can use a coarser tier. The dashboard auto-picks the best tier for each query.
 
 ## What sampling does to your numbers
 

--- a/docs/npm/network-flows/configuration.md
+++ b/docs/npm/network-flows/configuration.md
@@ -186,7 +186,7 @@ Per-tier values:
 
 | Key | Default per tier | Notes |
 |---|---|---|
-| `size_of_journal_files` | `10GB` | Retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Minimum `100MB`. Set to `null` to disable size-based retention on this tier. |
+| `size_of_journal_files` | `10GB` | Retained-artifact budget for journal data and finalized per-journal facet sidecars. Minimum `100MB`. Set to `null` to disable size-based retention on this tier. |
 | `duration_of_journal_files` | `null` | Optional time budget for this tier. The default disables time-based eviction; set a duration such as `24h` or `14d` to add an age cap. |
 
 Either configured limit can evict old files. The tier expires whichever configured limit is hit first. At least one of the two must be set per tier (validation enforces this).

--- a/docs/npm/network-flows/configuration.md
+++ b/docs/npm/network-flows/configuration.md
@@ -186,12 +186,14 @@ Per-tier values:
 
 | Key | Default per tier | Notes |
 |---|---|---|
-| `size_of_journal_files` | `10GB` | Disk budget for this tier. Minimum `100MB`. Set to `null` to disable size-based retention on this tier. |
+| `size_of_journal_files` | `10GB` | Retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Minimum `100MB`. Set to `null` to disable size-based retention on this tier. |
 | `duration_of_journal_files` | `null` | Optional time budget for this tier. The default disables time-based eviction; set a duration such as `24h` or `14d` to add an age cap. |
 
 Either configured limit can evict old files. The tier expires whichever configured limit is hit first. At least one of the two must be set per tier (validation enforces this).
 
 If you omit a tier entry entirely, that tier uses the built-in defaults (`10GB` / no time limit). If you provide a tier entry but omit one of the two knobs, the omitted knob falls back to its built-in default. Setting either to `null` explicitly disables that limit on that tier.
+
+The size budget is not a strict filesystem quota. The active journal counts toward the budget but is protected from deletion, so a tier can temporarily exceed its limit until rotation. Shared `facet-state.bin`, temporary sidecar files, and unrelated files are not charged to an individual tier.
 
 Standalone CLI runs still accept the legacy uniform retention flags:
 `--netflow-retention-size-of-journal-files` and

--- a/docs/npm/network-flows/field-reference.md
+++ b/docs/npm/network-flows/field-reference.md
@@ -278,20 +278,20 @@ Column legend:
 
 | Field | Type | v5 | v7 | v9 | IPFIX | sFlow | Source | Tiers | Selectivity | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| `BYTES` | uint64 | ✓ | ✓ | ✓ | ✓ | ✓ | decoder | all | metric, filter | Canonical byte counter, scaled by `SAMPLING_RATE` at ingest. Ordinary v9/IPFIX prefer IEs 1/2 and fall back to IEs 23/24 as a matched family. Cisco ASA NSEL event 5 uses initiator/responder IEs 231/232. sFlow derives it from decoded L3 length |
+| `BYTES` | uint64 | ✓ | ✓ | ✓ | ✓ | ✓ | decoder | all | metric | Canonical byte counter, scaled by `SAMPLING_RATE` at ingest. Ordinary v9/IPFIX prefer IEs 1/2 and fall back to IEs 23/24 as a matched family. Cisco ASA NSEL event 5 uses initiator/responder IEs 231/232. sFlow derives it from decoded L3 length |
 | `DIRECTION` | string | — | — | ◐ | ◐ | — | decoder | all | facet, group-by, filter | v9 IE 61, IPFIX IE 61/239. sFlow has no native direction |
 | `DST_ADDR` | IP | ✓ | ✓ | ◐ | ◐ | ◐ | decoder | raw | facet, group-by, filter | v9/IPFIX IE 12/28; sFlow `SampledHeader`/`SampledIPv4`/`SampledIPv6`. Raw-only |
 | `DST_ADDR_NAT` | IP | — | — | ◐ | ◐ | — | decoder | raw | facet, group-by, filter | v9 IE 226/282; IPFIX `postNATdestinationIPv4/IPv6Address` |
 | `DST_AS` | uint32 | ✓ | ✓ | ◐ | ◐ | ◐ | both | all | facet, group-by, filter | decoder IE 17 / sFlow `ExtendedGateway` last AS in path. Enrichment chain: `asn_providers` (default `[flow, routing, geoip]`); per-CIDR `enrichment.networks.<cidr>.asn` overrides |
 | `DST_AS_NAME` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | `format_as_name(DST_AS, attrs.asn_name)` → `AS{n} {name}`; falls back to `AS0 Unknown ASN` or `AS0 Private IP Address Space` |
-| `DST_AS_PATH` | string | — | — | — | — | ◐ | both | raw | filter | sFlow `ExtendedGateway` BGP path. Routing enrichment overlay (BMP / BioRIS) for non-sFlow exporters |
-| `DST_COMMUNITIES` | string | — | — | — | — | ◐ | both | raw | filter | sFlow `ExtendedGateway` communities. Routing enrichment overlay (BMP / BioRIS) |
+| `DST_AS_PATH` | string | — | — | — | — | ◐ | both | raw | facet, group-by, filter | sFlow `ExtendedGateway` BGP path. Routing enrichment overlay (BMP / BioRIS) for non-sFlow exporters |
+| `DST_COMMUNITIES` | string | — | — | — | — | ◐ | both | raw | facet, group-by, filter | sFlow `ExtendedGateway` communities. Routing enrichment overlay (BMP / BioRIS) |
 | `DST_COUNTRY` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | GeoIP MMDB on `DST_ADDR` → optional override from `enrichment.networks.<cidr>.country` |
 | `DST_GEO_CITY` | string | — | — | — | — | — | enrichment | raw | facet, group-by, filter | GeoIP city MMDB. Raw-only (dropped at rollup) |
 | `DST_GEO_LATITUDE` | string | — | — | — | — | — | enrichment | raw | filter, hidden | GeoIP coordinates. Raw-only; hidden in default table view |
 | `DST_GEO_LONGITUDE` | string | — | — | — | — | — | enrichment | raw | filter, hidden | GeoIP coordinates. Raw-only; hidden in default table view |
 | `DST_GEO_STATE` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | GeoIP subdivision. Preserved in rollups |
-| `DST_LARGE_COMMUNITIES` | string | — | — | — | — | — | enrichment | raw | filter | RFC 8092 large communities from routing enrichment (BMP / BioRIS) |
+| `DST_LARGE_COMMUNITIES` | string | — | — | — | — | — | enrichment | raw | facet, group-by, filter | RFC 8092 large communities from routing enrichment (BMP / BioRIS) |
 | `DST_MAC` | MAC | — | — | ◐ | ◐ | ◐ | decoder | raw | facet, group-by, filter | v9 IE 80/57; IPFIX same. sFlow from `SampledHeader` datalink or `SampledEthernet` |
 | `DST_MASK` | uint8 | ✓ | ✓ | ◐ | ◐ | ◐ | both | raw | facet, group-by, filter | v9 IE 13/29; sFlow `ExtendedRouter`. Enrichment overlay via `net_providers` (default `[flow, routing]`) plus per-CIDR overrides |
 | `DST_NET_NAME` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | `enrichment.networks.<cidr>.name` (static) merged with network sources by ascending prefix length |
@@ -301,7 +301,7 @@ Column legend:
 | `DST_NET_TENANT` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | `enrichment.networks.<cidr>.tenant` from static + network sources |
 | `DST_PORT` | uint16 | ✓ | ✓ | ◐ | ◐ | ◐ | decoder | raw | facet, group-by, filter | v9/IPFIX IE 11. sFlow from `SampledIPv4`/`SampledIPv6` or `SampledHeader` transport parse. Raw-only |
 | `DST_PORT_NAT` | uint16 | — | — | ◐ | ◐ | — | decoder | raw | facet, group-by, filter | v9 IE 228; IPFIX `postNAPTdestinationTransportPort` |
-| `DST_PREFIX` | IP | ✓ | ✓ | ◐ | — | — | decoder | raw | filter | v5/v7 derived from `DST_ADDR` & `DST_MASK`. v9 IE 45 (`Ipv4DstPrefix`). IPFIX has no canonical mapping; sFlow none |
+| `DST_PREFIX` | IP | ✓ | ✓ | ◐ | — | — | decoder | raw | facet, group-by, filter | v5/v7 derived from `DST_ADDR` & `DST_MASK`. v9 IE 45 (`Ipv4DstPrefix`). IPFIX has no canonical mapping; sFlow none |
 | `DST_VLAN` | uint16 | — | — | ◐ | ◐ | ◐ | decoder | all | facet, group-by, filter | v9 IE 59; IPFIX IE 254 (`PostVlanId`/`PostDot1qVlanId`). sFlow only via `ExtendedSwitch` (NOT from 802.1Q tag in `SampledHeader`) |
 | `ETYPE` | uint16 | ✓ (IPv4) | ✓ (IPv4) | ◐ | ◐ | ◐ | decoder | all | facet, group-by, filter | v5/v7 hardcoded to 2048. v9/IPFIX IE 60 `IpProtocolVersion` (4→2048, 6→34525). sFlow from sampled L2 etype |
 | `EXPORTER_GROUP` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | `metadata_static.exporters.<ip>.group`. Classifiers fill it when static metadata didn't |
@@ -312,7 +312,7 @@ Column legend:
 | `EXPORTER_ROLE` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | `metadata_static.exporters.<ip>.role`. Classifiers may fill |
 | `EXPORTER_SITE` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | `metadata_static.exporters.<ip>.site`. Classifiers may fill |
 | `EXPORTER_TENANT` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | `metadata_static.exporters.<ip>.tenant`. Classifiers may fill |
-| `FLOWS` | uint64 | ✓ | ✓ | ✓ | ✓ | ✓ | decoder | all | metric, filter | Always 1 for raw records; sums during rollup aggregation |
+| `FLOWS` | uint64 | ✓ | ✓ | ✓ | ✓ | ✓ | decoder | raw | metric | Always 1 for raw records; not stored in rollups |
 | `FLOW_END_USEC` | uint64 | ✓ | ✓ | ◐ | ◐ | — | decoder | raw | hidden | v5/v7 from header `sysUpTime` + `LastSwitched`. v9 `LastSwitched` is relative to system init; `flowEndMilliseconds` is an absolute Unix timestamp. IPFIX uses the flow-end time family. Not populated for sFlow |
 | `FLOW_START_USEC` | uint64 | ✓ | ✓ | ◐ | ◐ | — | decoder | raw | hidden | v5/v7 from header `sysUpTime` + `FirstSwitched`. v9 `FirstSwitched` is relative to system init; `flowStartMilliseconds` is an absolute Unix timestamp. IPFIX uses the flow-start time family. Not populated for sFlow |
 | `FLOW_VERSION` | string | ✓ | ✓ | ✓ | ✓ | ✓ | decoder | all | facet, group-by, filter | One of `v5`, `v7`, `v9`, `ipfix`, `sflow` |
@@ -333,7 +333,7 @@ Column legend:
 | `IPV6_FLOW_LABEL` | uint32 | — | — | ◐ | ◐ | ◐ | decoder | raw | facet, group-by, filter | v9/IPFIX IE 31 `FlowLabelIpv6`. sFlow from parsed IPv6 header |
 | `IP_FRAGMENT_ID` | uint32 | — | — | ◐ | ◐ | ◐ | decoder | raw | facet, group-by, filter | v9 IE 54 `Ipv4Ident`. IPFIX IE 54 `FragmentIdentification`. sFlow from parsed IPv4 header |
 | `IP_FRAGMENT_OFFSET` | uint16 | — | — | ◐ | ◐ | ◐ | decoder | raw | facet, group-by, filter | v9/IPFIX IE 88 `FragmentOffset`. sFlow from parsed IPv4 header |
-| `MPLS_LABELS` | string | — | — | ◐ | ◐ | ◐ | decoder | raw | filter | v9 IE 70-79 `MplsLabel1..10`. IPFIX IE 70 `MplsTopLabelStackSection` + 71-79 `MplsLabelStackSection2..10`. sFlow from MPLS in `SampledHeader`. Comma-separated decimal labels |
+| `MPLS_LABELS` | string | — | — | ◐ | ◐ | ◐ | decoder | raw | facet, group-by, filter | v9 IE 70-79 `MplsLabel1..10`. IPFIX IE 70 `MplsTopLabelStackSection` + 71-79 `MplsLabelStackSection2..10`. sFlow from MPLS in `SampledHeader`. Comma-separated decimal labels |
 | `NEXT_HOP` | IP | ✓ | ✓ | ◐ | ◐ | ◐ | both | all | facet, group-by, filter | v9 IE 15/18/62/63; IPFIX same. sFlow `ExtendedRouter`/`ExtendedGateway`. Enrichment overlay via `net_providers` chain (default `[flow, routing]`) |
 | `OBSERVATION_TIME_MILLIS` | uint64 | — | — | ◐ | — | — | decoder | raw | hidden | v9 IE 323 `ObservationTimeMilliseconds`. For Cisco ASA NSEL this remains metadata; collector receive time determines journal/query placement. IPFIX observation-time fields are not exposed |
 | `OUT_IF` | uint32 | ✓ | ✓ | ◐ | ◐ | ◐ | decoder | all | facet, group-by, filter | v9 IE 14 `OutputSnmp`; IPFIX IE 14/253. sFlow flow-sample `output` (single index only; LOCAL→0) |
@@ -343,7 +343,7 @@ Column legend:
 | `OUT_IF_NAME` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | `metadata_static.exporters.<ip>.if_indexes.<idx>.name` |
 | `OUT_IF_PROVIDER` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | Static metadata or interface classifier provider tag |
 | `OUT_IF_SPEED` | uint64 | — | — | — | — | — | enrichment | all | facet, group-by, filter | `metadata_static.exporters.<ip>.if_indexes.<idx>.speed` (bps) |
-| `PACKETS` | uint64 | ✓ | ✓ | ✓ | ✓ | ✓ | decoder | all | metric, filter | Canonical packet counter, selected with `BYTES` from the same family and scaled by `SAMPLING_RATE`. Cisco ASA NSEL event 5 uses initiator/responder IEs 298/299 without sampling. sFlow always 1 per sample |
+| `PACKETS` | uint64 | ✓ | ✓ | ✓ | ✓ | ✓ | decoder | all | metric | Canonical packet counter, selected with `BYTES` from the same family and scaled by `SAMPLING_RATE`. Cisco ASA NSEL event 5 uses initiator/responder IEs 298/299 without sampling. sFlow always 1 per sample |
 | `PROTOCOL` | uint8 | ✓ | ✓ | ✓ | ✓ | ◐ | decoder | all | facet, group-by, filter | IP protocol number: v5/v7 protocol_number; v9 IE 4; IPFIX IE 4 `ProtocolIdentifier`. sFlow from `SampledIPv4`/`SampledIPv6` or parsed L3. Zero (`HOPOPT`) is retained explicitly |
 | `RAW_BYTES` | uint64 | ✓ | ✓ | ✓ | ✓ | ✓ | decoder | raw | metric | Unscaled byte value from the selected canonical counter family; the non-selected family is discarded. Equal to `BYTES` for Cisco ASA NSEL |
 | `RAW_PACKETS` | uint64 | ✓ | ✓ | ✓ | ✓ | ✓ | decoder | raw | metric | Unscaled packet value from the selected canonical counter family; the non-selected family is discarded. Equal to `PACKETS` for Cisco ASA NSEL |
@@ -366,7 +366,7 @@ Column legend:
 | `SRC_NET_TENANT` | string | — | — | — | — | — | enrichment | all | facet, group-by, filter | `enrichment.networks.<cidr>.tenant` from static + network sources |
 | `SRC_PORT` | uint16 | ✓ | ✓ | ◐ | ◐ | ◐ | decoder | raw | facet, group-by, filter | v9/IPFIX IE 7. sFlow from `SampledIPv4`/`SampledIPv6` or transport parse. Raw-only |
 | `SRC_PORT_NAT` | uint16 | — | — | ◐ | ◐ | — | decoder | raw | facet, group-by, filter | v9 IE 227; IPFIX `postNAPTsourceTransportPort` |
-| `SRC_PREFIX` | IP | ✓ | ✓ | ◐ | — | — | decoder | raw | filter | v5/v7 derived from `SRC_ADDR` & `SRC_MASK`. v9 IE 44 (`Ipv4SrcPrefix`). IPFIX has no canonical mapping; sFlow none |
+| `SRC_PREFIX` | IP | ✓ | ✓ | ◐ | — | — | decoder | raw | facet, group-by, filter | v5/v7 derived from `SRC_ADDR` & `SRC_MASK`. v9 IE 44 (`Ipv4SrcPrefix`). IPFIX has no canonical mapping; sFlow none |
 | `SRC_VLAN` | uint16 | — | — | ◐ | ◐ | ◐ | decoder | all | facet, group-by, filter | v9 IE 58; IPFIX IE 58/243 (`VlanId`/`Dot1qVlanId`). sFlow only via `ExtendedSwitch` (NOT from 802.1Q tag in `SampledHeader`) |
 | `TCP_FLAGS` | uint8 | ✓ | ✓ | ◐ | ◐ | ◐ | decoder | all | facet, group-by, filter | OR of all TCP control bits seen in the flow. v9/IPFIX IE 6. sFlow from parsed TCP header in `SampledHeader` |
 

--- a/docs/npm/network-flows/retention-querying.md
+++ b/docs/npm/network-flows/retention-querying.md
@@ -95,7 +95,7 @@ If you see the time depth in your dashboard suddenly shrink after you applied a 
 
 ## Default retention and the most common misconfiguration
 
-Each tier has its own `size_of_journal_files` and `duration_of_journal_files`. The built-in defaults are uniform: `10GB` on every tier with no time-based age limit. The size budget includes committed journal data and finalized per-journal facet sidecars. The protected active journal can temporarily exceed it, and shared facet state is outside the per-tier budget. Production deployments should usually set tier-specific size and duration budgets; the whole point of having rollup tiers is to keep them around longer than raw.
+Each tier has its own `size_of_journal_files` and `duration_of_journal_files`. The built-in defaults are uniform: `10GB` on every tier with no time-based age limit. The size budget includes journal data and finalized per-journal facet sidecars. The protected active journal can temporarily exceed it, and shared facet state is outside the per-tier budget. Production deployments should usually set tier-specific size and duration budgets; the whole point of having rollup tiers is to keep them around longer than raw.
 
 A more useful production profile:
 

--- a/docs/npm/network-flows/retention-querying.md
+++ b/docs/npm/network-flows/retention-querying.md
@@ -31,15 +31,13 @@ Rollup tiers (1m, 5m, 1h) deliberately drop the high-cardinality and protocol-sp
 
 **Forced to the raw tier** (any query that filters on, groups by, or runs full-text search against these fields is rerouted to the raw tier — see [Field Reference](/docs/npm/network-flows/field-reference.md) for the per-field matrix):
 
-- `SRC_ADDR`, `DST_ADDR`, `SRC_PORT`, `DST_PORT`
+- Addresses and prefixes: `SRC_ADDR`, `DST_ADDR`, `SRC_PREFIX`, `DST_PREFIX`, `SRC_MASK`, `DST_MASK`
+- NAT: `SRC_ADDR_NAT`, `DST_ADDR_NAT`, `SRC_PORT_NAT`, `DST_PORT_NAT`
+- Transport and link details: `SRC_PORT`, `DST_PORT`, `SRC_MAC`, `DST_MAC`
 - `SRC_GEO_CITY`, `DST_GEO_CITY`, `SRC_GEO_LATITUDE`, `DST_GEO_LATITUDE`, `SRC_GEO_LONGITUDE`, `DST_GEO_LONGITUDE`
+- Routing and encapsulation: `DST_AS_PATH`, `DST_COMMUNITIES`, `DST_LARGE_COMMUNITIES`, `MPLS_LABELS`
+- IP header details: `IPTTL`, `IPV6_FLOW_LABEL`, `IP_FRAGMENT_ID`, `IP_FRAGMENT_OFFSET`
 - All `V9_*` and `IPFIX_*` raw-protocol fields.
-
-**Dropped from rollup output but do not switch tier** (the field comes back as null on rollup tiers; the planner does not reroute the query to raw):
-
-- AS path, BGP community fields (`SRC_COMMUNITIES`, `DST_COMMUNITIES`, etc.), MPLS labels, MAC addresses, NAT / post-NAT addresses, and any other field not in the preserved set below.
-
-If you need any of these fields populated in the result, force the raw tier explicitly (open a city map, add a port filter, type something into the search ribbon, or pick a window that fits inside raw-tier retention).
 
 **Preserved in rollup tiers** (these queries can use coarser tiers):
 
@@ -49,9 +47,9 @@ If you need any of these fields populated in the result, force the raw tier expl
 - Network: `SRC_NET_*` / `DST_NET_*` (name / role / site / region / tenant), `SRC_COUNTRY` / `DST_COUNTRY`, `SRC_GEO_STATE` / `DST_GEO_STATE`, `NEXT_HOP`, `SRC_VLAN` / `DST_VLAN`.
 - Aggregates: bytes / packets / flow-count sums per bucket.
 
-So rollups are fine for most country / state / ASN / interface / VLAN / protocol questions, but useless if you need to ask "which IP", "which port", "which AS path", "which MPLS label", or "where in the city".
+So rollups are fine for most country / state / ASN / interface / VLAN / protocol questions, but cannot answer "which IP", "which port", "which AS path", "which MPLS label", or "where in the city".
 
-This is why filtering or grouping by IP/port/city/lat/lon forces the query to the raw tier — there is no other tier that has those fields.
+This is why filtering or grouping by any field absent from the preserved set forces the query to the raw tier — there is no other tier that can answer it correctly.
 
 For the per-field tier-preservation matrix, see [Field Reference](/docs/npm/network-flows/field-reference.md).
 
@@ -61,7 +59,7 @@ For every query the dashboard sends to the plugin, the planner makes a single de
 
 **Rules:**
 
-1. **Any raw-only field used as a filter or group-by → raw tier.** No exception. See the "Forced to the raw tier" list above. Selecting the city map or filtering on any IP / port / city / lat / lon field (plus the `V9_*` / `IPFIX_*` raw protocol fields) falls in this category.
+1. **Any raw-only field used as a filter or group-by → raw tier.** No exception. See the complete "Forced to the raw tier" list above.
 2. **A non-empty full-text search → raw tier.** Full-text search runs as a regex against the raw journal payload, which only the raw tier carries.
 3. **Otherwise, pick the coarsest tier that satisfies the time range alignment.**
    - **Time-Series view** additionally needs at least 100 buckets in the window. The planner walks the tiers from coarsest to finest and picks the first that delivers ≥100 buckets, falling back to 1-minute when no tier qualifies:
@@ -79,7 +77,7 @@ The plugin reports the chosen tier in the response stats (`query_tier` = `0`, `1
 
 If you ask for a 30-day window with an IP filter and raw-tier retention is 24 hours, you get an empty response. No error, no banner reading "data has expired" — just an empty result set. The dashboard renders this as "No data".
 
-The planner does not fall back to a coarser tier for raw-only queries. When a span requires the raw tier (because the query filters or groups on an IP / port / city / lat / lon / V9_* / IPFIX_* field, or runs a full-text search) and that span's raw-tier files have been rotated out, the planner returns no flows for that span. Rollups never carry raw-only fields, so they cannot satisfy the query anyway. Conversely, when a span only needs preserved fields (country, ASN, exporter, interface, protocol…), the planner can fall back from a coarser tier to a finer one if the coarser files have rotated out — finer tiers are supersets of coarser tiers for the preserved fields.
+The planner does not fall back to a coarser tier for raw-only queries. When a span requires the raw tier (because the query filters or groups on any field absent from rollups, or runs a full-text search) and that span's raw-tier files have been rotated out, the planner returns no flows for that span. Rollups never carry raw-only fields, so they cannot satisfy the query anyway. Conversely, when a span only needs preserved fields (country, ASN, exporter, interface, protocol…), the planner can fall back from a coarser tier to a finer one if the coarser files have rotated out — finer tiers are supersets of coarser tiers for the preserved fields.
 
 Other spans within the same query that don't need raw data may still return flows. So it's also possible to see partial coverage — half the time range filled, half empty.
 
@@ -89,8 +87,7 @@ For Time-Series, "no data" appears as zero values in the affected buckets, not a
 
 Quick reference for "why is my query slow / showing less time?":
 
-- Adding `SRC_ADDR`, `DST_ADDR`, `SRC_PORT`, or `DST_PORT` as a filter
-- Adding any of those fields to the group-by
+- Adding any field from the raw-only list above as a filter or group-by
 - Switching to the city map (it uses `SRC_GEO_CITY`/`DST_GEO_CITY` plus latitudes/longitudes)
 - Typing anything into the global search ribbon
 
@@ -98,7 +95,7 @@ If you see the time depth in your dashboard suddenly shrink after you applied a 
 
 ## Default retention and the most common misconfiguration
 
-Each tier has its own `size_of_journal_files` and `duration_of_journal_files`. The built-in defaults are uniform: `10GB` on every tier with no time-based age limit. That is safe for first validation because disk is still capped, but production deployments should usually set tier-specific size and duration budgets; the whole point of having rollup tiers is to keep them around longer than raw.
+Each tier has its own `size_of_journal_files` and `duration_of_journal_files`. The built-in defaults are uniform: `10GB` on every tier with no time-based age limit. The size budget includes committed journal data and finalized per-journal facet sidecars. The protected active journal can temporarily exceed it, and shared facet state is outside the per-tier budget. Production deployments should usually set tier-specific size and duration budgets; the whole point of having rollup tiers is to keep them around longer than raw.
 
 A more useful production profile:
 

--- a/docs/npm/network-flows/sizing-capacity.md
+++ b/docs/npm/network-flows/sizing-capacity.md
@@ -86,7 +86,7 @@ journal:
     hour_1:   { size_of_journal_files: 20GB,  duration_of_journal_files: 365d }
 ```
 
-For lighter loads, scale `size_of_journal_files` on the raw tier down proportionally — at 10 000 flow records/s ~350 GB / 24 h is enough; at 1 000 flow records/s ~35 GB / 24 h is enough. The size budget covers committed journal data and finalized per-journal facet sidecars. Whichever limit (size or duration) is hit first triggers rotation; size your raw tier so the **duration limit fires first** under normal load and the size budget is a safety net for traffic surges.
+For lighter loads, scale `size_of_journal_files` on the raw tier down proportionally — at 10 000 flow records/s ~350 GB / 24 h is enough; at 1 000 flow records/s ~35 GB / 24 h is enough. The size budget covers journal data and finalized per-journal facet sidecars. Whichever limit (size or duration) is hit first triggers rotation; size your raw tier so the **duration limit fires first** under normal load and the size budget is a safety net for traffic surges.
 
 ### Use fast NVMe for the raw tier
 

--- a/docs/npm/network-flows/sizing-capacity.md
+++ b/docs/npm/network-flows/sizing-capacity.md
@@ -86,7 +86,7 @@ journal:
     hour_1:   { size_of_journal_files: 20GB,  duration_of_journal_files: 365d }
 ```
 
-For lighter loads, scale `size_of_journal_files` on the raw tier down proportionally — at 10 000 flow records/s ~350 GB / 24 h is enough; at 1 000 flow records/s ~35 GB / 24 h is enough. Whichever limit (size or duration) is hit first triggers rotation; size your raw tier so the **duration limit fires first** under normal load and the size cap is a safety net for traffic surges.
+For lighter loads, scale `size_of_journal_files` on the raw tier down proportionally — at 10 000 flow records/s ~350 GB / 24 h is enough; at 1 000 flow records/s ~35 GB / 24 h is enough. The size budget covers committed journal data and finalized per-journal facet sidecars. Whichever limit (size or duration) is hit first triggers rotation; size your raw tier so the **duration limit fires first** under normal load and the size budget is a safety net for traffic surges.
 
 ### Use fast NVMe for the raw tier
 

--- a/docs/npm/network-flows/troubleshooting.md
+++ b/docs/npm/network-flows/troubleshooting.md
@@ -225,7 +225,7 @@ Note: the live (open) tier rows shown by queries refresh on a 1-second cadence, 
 sudo du -sh /var/cache/netdata/flows/*
 ```
 
-Default retention is `10GB` per tier with no time-based age limit. The default is applied separately to raw, 1m, 5m, and 1h tiers, and each budget includes committed journals plus finalized per-journal facet sidecars. Retained artifacts therefore target roughly 40 GB total. Protected active journals can temporarily push usage above that target, and shared facet state is outside the per-tier budgets. If your collector is busy, expect to hit the size budget quickly; quiet collectors may keep data for longer than seven days. See [Configuration](/docs/npm/network-flows/configuration.md) for per-tier overrides — most production deployments need them.
+Default retention is `10GB` per tier with no time-based age limit. The default is applied separately to raw, 1m, 5m, and 1h tiers, and each budget includes journal files plus finalized per-journal facet sidecars. Retained artifacts therefore target roughly 40 GB total. Protected active journals can temporarily push usage above that target, and shared facet state is outside the per-tier budgets. If your collector is busy, expect to hit the size budget quickly; quiet collectors may keep data for longer than seven days. See [Configuration](/docs/npm/network-flows/configuration.md) for per-tier overrides — most production deployments need them.
 
 ## Things that look like bugs but aren't
 

--- a/docs/npm/network-flows/troubleshooting.md
+++ b/docs/npm/network-flows/troubleshooting.md
@@ -225,7 +225,7 @@ Note: the live (open) tier rows shown by queries refresh on a 1-second cadence, 
 sudo du -sh /var/cache/netdata/flows/*
 ```
 
-Default retention is `10GB` per tier with no time-based age limit. The default is applied separately to raw, 1m, 5m, and 1h tiers, so total can reach roughly 40 GB plus some. If your config left this default and your collector is busy, expect to hit the size cap quickly; quiet collectors may keep data for longer than seven days. See [Configuration](/docs/npm/network-flows/configuration.md) for per-tier overrides — most production deployments need them.
+Default retention is `10GB` per tier with no time-based age limit. The default is applied separately to raw, 1m, 5m, and 1h tiers, and each budget includes committed journals plus finalized per-journal facet sidecars. Retained artifacts therefore target roughly 40 GB total. Protected active journals can temporarily push usage above that target, and shared facet state is outside the per-tier budgets. If your collector is busy, expect to hit the size budget quickly; quiet collectors may keep data for longer than seven days. See [Configuration](/docs/npm/network-flows/configuration.md) for per-tier overrides — most production deployments need them.
 
 ## Things that look like bugs but aren't
 

--- a/docs/npm/network-flows/visualization/filters-facets.md
+++ b/docs/npm/network-flows/visualization/filters-facets.md
@@ -29,7 +29,7 @@ Across different fields: **AND**. Adding `SRC_COUNTRY = US` to the above shows T
 
 ## No negative match
 
-You cannot directly say "everything except X". The workaround is to select all values and remove the unwanted one — works for low-cardinality fields like `PROTOCOL` (a handful of values). For high-cardinality fields like `SRC_AS_NAME`, the autocomplete only surfaces the top 100 values, so there's no practical way to "select all and remove".
+You cannot directly say "everything except X". The workaround is to select all values and remove the unwanted one — works for low-cardinality fields like `PROTOCOL` (a handful of values). For high-cardinality fields like `SRC_AS_NAME`, the autocomplete only surfaces the top 256 values, so there's no practical way to "select all and remove".
 
 Negative matching is not supported.
 
@@ -37,7 +37,8 @@ Negative matching is not supported.
 
 Type into a facet field and the dashboard suggests existing values from your live data. The list:
 
-- Shows up to **100 matching values**, sorted alphabetically.
+- Shows up to **256 matching values**, sorted alphabetically.
+- High-cardinality fields always use autocomplete, even while the collector has observed only a few values. Fixed categorical fields stay inline while they fit within the separate 100-value inline limit.
 - Matching policy is per-field. Free-form text fields (`SRC_AS_NAME`, `EXPORTER_NAME`, `IN_IF_DESCRIPTION`, MAC addresses, AS paths, BGP communities, country/city/state names) match by **substring**, so typing `Akamai` finds `AS20940 Akamai International`. IPs and short numeric fields (ports, protocols, ASN numbers, interface speeds) match by **prefix**, so typing `10.0.` narrows to that range.
 - Runs against an **in-memory snapshot of the live journal** plus on-disk FST sidecars for promoted high-cardinality fields. Autocomplete never reads the raw flow tiers, and is fast even on busy collectors.
 - The autocomplete `term` is hard-capped at 256 bytes; longer requests are rejected.

--- a/docs/npm/network-flows/visualization/filters-facets.md
+++ b/docs/npm/network-flows/visualization/filters-facets.md
@@ -56,12 +56,13 @@ For high-cardinality fields, autocomplete is the only practical way to discover 
 
 ### CIDR autocomplete
 
-Typing `/` in an IP address facet switches that request from retained-value lookup to CIDR generation. This path is bounded and does not scan the facet vocabulary or flow tiers.
+Typing `/` in an IP address facet switches that request from retained-value lookup to CIDR generation. The backend generates a bounded candidate set, then returns only networks containing at least one address in that field's compact retention-wide vocabulary. It does not scan journal rows or flow tiers.
 
-- Loose IPv4 input fills missing octets: `10/8` suggests `10.0.0.0/8`; `10.1/` suggests `10.1.0.0/16`.
-- Loose IPv6 input fills omitted trailing groups: `2001:db8/32` suggests `2001:db8::/32`.
-- Digits after `/` are an autocomplete fragment. `10.1/1` ranks the naturally implied `10.1.0.0/16` first, then the exact prefix-length match `0.0.0.0/1`, followed by the other canonical matches `/10` through `/19`.
+- Loose IPv4 input fills missing octets: `10/8` can suggest `10.0.0.0/8`; `10.1/` can suggest `10.1.0.0/16`. One trailing dot before `/` is tolerated after one through three octets, so `10./`, `10.1./`, and `10.1.2./` behave like the same inputs without that dot.
+- Loose IPv6 input fills omitted trailing groups: `2001:db8/32` can suggest `2001:db8::/32`.
+- Digits after `/` are an autocomplete fragment. `10.1/1` generates the naturally implied `10.1.0.0/16` first, then the exact prefix-length match `0.0.0.0/1`, followed by the other canonical matches `/10` through `/19`. Candidates with no retained address in the selected facet are omitted, so the first returned value may differ.
 - Suggestions are always canonical IPv4 or IPv6 CIDRs. Loose forms are accepted only while searching; a direct Function selection must contain a complete address and prefix length. The backend normalizes a valid non-network address such as `10.1.2.99/24` to its network before matching.
+- Candidate validation is retention-wide, like ordinary facet discovery. A suggested CIDR can still have no data in the current time window or after other filters are applied.
 
 **Autocomplete and regular filtering are different paths.** The dropdown uses prefix or substring matching only to discover retained values. A selected non-IP value uses exact equality. A selected IP value uses exact-address or CIDR containment, never substring matching over flow data.
 
@@ -90,6 +91,7 @@ A practical note: filters use a structured representation (per-field IN-list) th
 - **Time depth shrinks unexpectedly after typing in search.** Full-text search forces raw tier. Clear the search to use rollup tiers and longer time ranges.
 - **Negative match is unsupported.** Workaround: select-all-minus-one for low-cardinality fields. For high-cardinality fields, use a positive filter that narrows the result set instead.
 - **A loose CIDR works in autocomplete but fails as a direct selection.** Send a complete address and prefix such as `10.0.0.0/8`, not `10/8`.
+- **A suggested CIDR returns no data in the current view.** Suggestions prove that the selected field contains a matching address somewhere in retained data. They are not recalculated for the current time window or other active filters.
 - **Filter on an ICMP virtual facet seems slower than expected.** `ICMPV4` / `ICMPV6` virtual facets aren't optimised by the journal index — they're evaluated per-record. The query still returns; the cost shows up as longer wall time on busy collectors.
 - **`query_max_groups` exceeded.** Result rows after the limit fold into `__overflow__`. Narrow the filter or reduce group-by depth.
 - **GET-style args don't carry selections.** When integrating the function call yourself, send a JSON payload — the dashboard does this automatically.

--- a/docs/npm/network-flows/visualization/filters-facets.md
+++ b/docs/npm/network-flows/visualization/filters-facets.md
@@ -29,6 +29,12 @@ Within a single field: **OR**. Selecting `PROTOCOL = TCP` and `PROTOCOL = UDP` s
 
 Across different fields: **AND**. Adding `SRC_COUNTRY = US` to the above shows TCP-or-UDP from the US.
 
+The six address fields — `EXPORTER_IP`, `SRC_ADDR`, `DST_ADDR`, `NEXT_HOP`, `SRC_ADDR_NAT`, and `DST_ADDR_NAT` — accept either exact IPv4/IPv6 addresses or CIDRs. Exact addresses and CIDRs selected in the same field are ORed together. For example, selecting `10.0.0.0/8` and `2001:db8::7` on `SRC_ADDR`, plus `PROTOCOL = TCP`, means:
+
+`(source is inside 10.0.0.0/8 OR source is 2001:db8::7) AND protocol is TCP`.
+
+CIDR selection does not change these Boolean rules. `SRC_PREFIX` and `DST_PREFIX` are stored labels and continue to use exact-value filtering; they do not mean "address overlaps this network."
+
 ## No negative match
 
 You cannot directly say "everything except X". The workaround is to select all values and remove the unwanted one — works for low-cardinality fields like `PROTOCOL` (a handful of values). For high-cardinality fields like `SRC_AS_NAME`, the autocomplete only surfaces the top 256 values, so there's no practical way to "select all and remove".
@@ -39,15 +45,27 @@ Negative matching is not supported.
 
 Type into a facet field and the dashboard suggests existing values from your live data. The list:
 
-- Shows up to **256 matching values**, sorted alphabetically.
-- Every facet uses the same retention-wide vocabulary. Facets with up to **256 retained values** return the complete static list; facets with 257 or more values switch to autocomplete. A facet can switch back to a static list when older values leave retention.
+- Shows up to **256 results**. Retained values are sorted alphabetically; generated CIDRs use the ranking described below.
+- Retained values for every facet come from the same retention-wide vocabulary. Non-IP facets with up to **256 retained values** return the complete static list; facets with 257 or more values switch to autocomplete. A facet can switch back to a static list when older values leave retention.
+- IP address facets keep autocomplete enabled so `/` can suggest CIDRs. They still return their complete inline value list while the retained vocabulary has at most 256 values; above that limit, the inline list is omitted.
 - Matching policy is per-field. Free-form text fields (`SRC_AS_NAME`, `EXPORTER_NAME`, `IN_IF_DESCRIPTION`, MAC addresses, AS paths, BGP communities, country/city/state names) match by **substring**, so typing `Akamai` finds `AS20940 Akamai International`. IPs and short numeric fields (ports, protocols, ASN numbers, interface speeds) match by **prefix**, so typing `10.0.` narrows to that range.
 - Runs against an **in-memory snapshot of the live journal** plus on-disk FST sidecars for promoted high-cardinality fields. Autocomplete never reads the raw flow tiers, and is fast even on busy collectors.
 - The autocomplete `term` is hard-capped at 256 bytes; longer requests are rejected.
 
 For high-cardinality fields, autocomplete is the only practical way to discover values. You can't scroll a list of millions of IP addresses, but you can find one by typing what you remember.
 
-**Autocomplete and regular filtering are different paths.** When you select a value from the dropdown, the resulting filter is **exact equality**, not substring. The dropdown only helps you discover values; the filter that gets applied is `key = value` (or `key in [values]`) and uses indexes — never a substring scan over flow data.
+### CIDR autocomplete
+
+Typing `/` in an IP address facet switches that request from retained-value lookup to CIDR generation. This path is bounded and does not scan the facet vocabulary or flow tiers.
+
+- Loose IPv4 input fills missing octets: `10/8` suggests `10.0.0.0/8`; `10.1/` suggests `10.1.0.0/16`.
+- Loose IPv6 input fills omitted trailing groups: `2001:db8/32` suggests `2001:db8::/32`.
+- Digits after `/` are an autocomplete fragment. `10.1/1` ranks the naturally implied `10.1.0.0/16` first, then the exact prefix-length match `0.0.0.0/1`, followed by the other canonical matches `/10` through `/19`.
+- Suggestions are always canonical IPv4 or IPv6 CIDRs. Loose forms are accepted only while searching; a direct Function selection must contain a complete address and prefix length. The backend normalizes a valid non-network address such as `10.1.2.99/24` to its network before matching.
+
+**Autocomplete and regular filtering are different paths.** The dropdown uses prefix or substring matching only to discover retained values. A selected non-IP value uses exact equality. A selected IP value uses exact-address or CIDR containment, never substring matching over flow data.
+
+Small IP networks containing at most 256 addresses can be represented as exact indexed matches. Broader networks are checked by the typed CIDR matcher after any other exact filters have narrowed the scan. Exact addresses and CIDRs return the same results in table, Sankey, and time-series views.
 
 ## Full-text search
 
@@ -58,7 +76,7 @@ The search box at the top of the filter ribbon performs a regex match against th
 - Any non-empty search **forces raw tier**. The full-text search only works against the raw journal — it doesn't apply to the rollup tiers. Time depth is therefore bounded by raw-tier retention.
 - The plugin's "fast aggregation" path is also disabled when full-text search is active, because aggregation needs to scan every record. Expect somewhat slower responses than tier-based aggregation queries.
 
-For "find anything containing this string in any field", the search is the right tool. For "filter by an exact value of a specific field", use the facet on that field — it's faster and doesn't trigger raw-tier mode.
+For "find anything containing this string in any field", the search is the right tool. For an exact value or IP network, use the facet on that field. Facet filters follow that field's tier availability: source, destination, and NAT address fields are currently raw-tier-only; exporter IP and next hop are available in rollups.
 
 ## URL preservation
 
@@ -71,6 +89,7 @@ A practical note: filters use a structured representation (per-field IN-list) th
 - **Search for `192.168.1.1` matches unrelated rows.** Regex semantics: each `.` is "any byte". Escape: `192\.168\.1\.1`.
 - **Time depth shrinks unexpectedly after typing in search.** Full-text search forces raw tier. Clear the search to use rollup tiers and longer time ranges.
 - **Negative match is unsupported.** Workaround: select-all-minus-one for low-cardinality fields. For high-cardinality fields, use a positive filter that narrows the result set instead.
+- **A loose CIDR works in autocomplete but fails as a direct selection.** Send a complete address and prefix such as `10.0.0.0/8`, not `10/8`.
 - **Filter on an ICMP virtual facet seems slower than expected.** `ICMPV4` / `ICMPV6` virtual facets aren't optimised by the journal index — they're evaluated per-record. The query still returns; the cost shows up as longer wall time on busy collectors.
 - **`query_max_groups` exceeded.** Result rows after the limit fold into `__overflow__`. Narrow the filter or reduce group-by depth.
 - **GET-style args don't carry selections.** When integrating the function call yourself, send a JSON payload — the dashboard does this automatically.

--- a/docs/npm/network-flows/visualization/filters-facets.md
+++ b/docs/npm/network-flows/visualization/filters-facets.md
@@ -21,6 +21,8 @@ Around 80 fields are available as facets. They're a subset of the full 91-field 
 
 Everything else — IPs, ports, protocol, AS numbers and names, country, state, city, exporter labels, interfaces, MACs, VLANs, NAT addresses, TCP flags, ToS, etc. — is filterable.
 
+The filter ribbon shows only fields that have at least one value in the collector's retained facet vocabulary. A field appears after its first value is retained and disappears after its last value ages out. An actively selected field remains visible even when its retained vocabulary is empty, so you can clear the filter. This availability is collector-retention-wide, not limited to the time window currently shown.
+
 ## Filter logic
 
 Within a single field: **OR**. Selecting `PROTOCOL = TCP` and `PROTOCOL = UDP` shows TCP-or-UDP.
@@ -38,7 +40,7 @@ Negative matching is not supported.
 Type into a facet field and the dashboard suggests existing values from your live data. The list:
 
 - Shows up to **256 matching values**, sorted alphabetically.
-- High-cardinality fields always use autocomplete, even while the collector has observed only a few values. Fixed categorical fields stay inline while they fit within the separate 100-value inline limit.
+- Every facet uses the same retention-wide vocabulary. Facets with up to **256 retained values** return the complete static list; facets with 257 or more values switch to autocomplete. A facet can switch back to a static list when older values leave retention.
 - Matching policy is per-field. Free-form text fields (`SRC_AS_NAME`, `EXPORTER_NAME`, `IN_IF_DESCRIPTION`, MAC addresses, AS paths, BGP communities, country/city/state names) match by **substring**, so typing `Akamai` finds `AS20940 Akamai International`. IPs and short numeric fields (ports, protocols, ASN numbers, interface speeds) match by **prefix**, so typing `10.0.` narrows to that range.
 - Runs against an **in-memory snapshot of the live journal** plus on-disk FST sidecars for promoted high-cardinality fields. Autocomplete never reads the raw flow tiers, and is fast even on busy collectors.
 - The autocomplete `term` is hard-capped at 256 bytes; longer requests are rejected.

--- a/docs/npm/network-flows/visualization/maps-globe.md
+++ b/docs/npm/network-flows/visualization/maps-globe.md
@@ -50,7 +50,7 @@ The country map and state map can use the rollup tiers. They're cheap over long 
 The city map and the globe **need raw-tier data**. City, latitude, and longitude are dropped from the rollup tiers (1m / 5m / 1h) to keep cardinality manageable. So:
 
 - Country / state map over the last 30 days — fine, uses the 1-hour tier.
-- City map over the last 30 days — likely empty on busy collectors. Raw-tier retention defaults to its own 10GB size cap with no time-based age limit, so high flow volume can exhaust raw history quickly.
+- City map over the last 30 days — likely empty on busy collectors. Raw-tier retention defaults to its own 10GB retained-artifact budget with no time-based age limit, so high flow volume can exhaust raw history quickly.
 
 If your city map looks empty over a long window, try the country map first to confirm data is arriving, then narrow the time range until the city map fills in.
 

--- a/docs/npm/network-flows/visualization/overview.md
+++ b/docs/npm/network-flows/visualization/overview.md
@@ -17,7 +17,7 @@ The Network Flows view exposes the same query engine through five panel types: S
 The dashboard sends one of two query modes to the plugin:
 
 - **`flows`** — the normal aggregation request. Returns top-N groups, sums of bytes and packets, optional facet counts.
-- **`autocomplete`** — for the filter ribbon. Returns up to 100 facet values matching the user's term. Matching policy is per-field: text fields use substring matching, IP and numeric fields use prefix. Term is capped at 256 bytes. Runs against in-memory facet snapshots and on-disk FST sidecars; never scans tier files. Resulting filters apply as exact equality, not substring.
+- **`autocomplete`** — for the filter ribbon. Returns up to 256 facet values matching the user's term. Matching policy is per-field: text fields use substring matching, IP and numeric fields use prefix. Term is capped at 256 bytes. Runs against in-memory facet snapshots and on-disk FST sidecars; never scans tier files. Resulting filters apply as exact equality, not substring.
 
 A `flows` query carries:
 

--- a/docs/npm/network-flows/visualization/overview.md
+++ b/docs/npm/network-flows/visualization/overview.md
@@ -17,7 +17,7 @@ The Network Flows view exposes the same query engine through five panel types: S
 The dashboard sends one of two query modes to the plugin:
 
 - **`flows`** — the normal aggregation request. Returns top-N groups, sums of bytes and packets, optional facet counts.
-- **`autocomplete`** — for the filter ribbon. Returns up to 256 retained facet values or generated CIDR candidates. Matching policy for retained values is per-field: text fields use substring matching, IP and numeric fields use prefix. For IP address fields, `/` generates canonical IPv4/IPv6 CIDR suggestions without scanning retained values. Term is capped at 256 bytes. Retained-value lookup runs against in-memory facet snapshots and on-disk FST sidecars; neither autocomplete path scans tier files. Selected non-IP values use exact equality; selected IP values use exact-address or CIDR containment.
+- **`autocomplete`** — for the filter ribbon. Returns up to 256 retained facet values or generated CIDR candidates. Matching policy for retained values is per-field: text fields use substring matching, IP and numeric fields use prefix. For IP address fields, `/` generates canonical IPv4/IPv6 CIDRs and returns only networks containing an address in that field's compact retention-wide vocabulary. Term is capped at 256 bytes. Retained-value lookup runs against in-memory facet snapshots and on-disk FST sidecars; CIDR validation uses only the in-memory typed IP vocabulary. Neither path scans flow tiers. Selected non-IP values use exact equality; selected IP values use exact-address or CIDR containment.
 
 A `flows` query carries:
 

--- a/docs/npm/network-flows/visualization/overview.md
+++ b/docs/npm/network-flows/visualization/overview.md
@@ -17,13 +17,13 @@ The Network Flows view exposes the same query engine through five panel types: S
 The dashboard sends one of two query modes to the plugin:
 
 - **`flows`** — the normal aggregation request. Returns top-N groups, sums of bytes and packets, optional facet counts.
-- **`autocomplete`** — for the filter ribbon. Returns up to 256 facet values matching the user's term. Matching policy is per-field: text fields use substring matching, IP and numeric fields use prefix. Term is capped at 256 bytes. Runs against in-memory facet snapshots and on-disk FST sidecars; never scans tier files. Resulting filters apply as exact equality, not substring.
+- **`autocomplete`** — for the filter ribbon. Returns up to 256 retained facet values or generated CIDR candidates. Matching policy for retained values is per-field: text fields use substring matching, IP and numeric fields use prefix. For IP address fields, `/` generates canonical IPv4/IPv6 CIDR suggestions without scanning retained values. Term is capped at 256 bytes. Retained-value lookup runs against in-memory facet snapshots and on-disk FST sidecars; neither autocomplete path scans tier files. Selected non-IP values use exact equality; selected IP values use exact-address or CIDR containment.
 
 A `flows` query carries:
 
 - A time range (`after` / `before`). If you omit both, the plugin uses the last 15 minutes.
 - A list of `group_by` fields (up to 10).
-- A list of `selections` — per-field IN-lists for filtering.
+- A list of `selections` — per-field IN-lists for filtering. The six IP address facets accept exact IPv4/IPv6 addresses and canonical CIDRs.
 - Optional `facets` to enrich the response with per-facet value counts.
 - A `top_n` (one of 25, 50, 100, 200, 500).
 - A `sort_by` (`bytes` or `packets`).

--- a/docs/npm/network-flows/visualization/summary-sankey.md
+++ b/docs/npm/network-flows/visualization/summary-sankey.md
@@ -77,7 +77,7 @@ A filter strip sits between the Sankey and the table. Three things you can do he
 
 Filter logic is "AND across fields, OR within a field". Selecting `PROTOCOL = TCP` and `PROTOCOL = UDP` shows TCP-or-UDP. Selecting `PROTOCOL = TCP` plus `SRC_COUNTRY = US` shows only US-source TCP.
 
-There is no negative match. To exclude a value, select all values and remove the unwanted one — works for low-cardinality fields, becomes impractical for high-cardinality ones (the autocomplete cap is 100).
+There is no negative match. To exclude a value, select all values and remove the unwanted one — works for low-cardinality fields, becomes impractical for high-cardinality ones (the autocomplete cap is 256).
 
 See [Filters and Facets](/docs/npm/network-flows/visualization/filters-facets.md) for the full mechanics.
 

--- a/docs/npm/network-flows/visualization/time-series.md
+++ b/docs/npm/network-flows/visualization/time-series.md
@@ -51,10 +51,10 @@ The minimum bucket size is **60 seconds**. Zoom in past one minute and the chart
 
 Some queries can't use the rollup tiers. They drop to raw tier and inherit raw-tier retention:
 
-- Filtering or grouping by `SRC_ADDR`, `DST_ADDR`, `SRC_PORT`, `DST_PORT`, or any geo city / latitude / longitude field
+- Filtering or grouping by any [raw-only field](../retention-querying.md#what-survives-the-rollup)
 - Any non-empty full-text search
 
-In those cases the 100-bucket rule still applies, but the source tier is raw tier. Time depth is bounded by raw-tier retention (default: the raw tier has a 10GB size cap and no time-based age limit, so busy collectors can exhaust raw history quickly).
+In those cases the 100-bucket rule still applies, but the source tier is raw tier. Time depth is bounded by raw-tier retention (default: the raw tier has a 10GB retained-artifact budget and no time-based age limit, so busy collectors can exhaust raw history quickly).
 
 If you've been working at a higher tier and add an IP filter, the time depth on your chart may suddenly shrink — that's the tier switch.
 

--- a/src/crates/netflow-plugin/Cargo.toml
+++ b/src/crates/netflow-plugin/Cargo.toml
@@ -53,7 +53,9 @@ netgauze-bmp-pkt = { workspace = true, features = ["codec"] }
 notify = { workspace = true }
 roaring = { workspace = true, features = ["allocative"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+# The Function contract uses object key order for grouped columns and labels.
+# Declare this here so the plugin does not rely on another crate unifying it.
+serde_json = { workspace = true, features = ["preserve_order"] }
 serde_yaml = { workspace = true }
 sflow-parser = { workspace = true }
 tokio = { workspace = true }

--- a/src/crates/netflow-plugin/README.md
+++ b/src/crates/netflow-plugin/README.md
@@ -366,7 +366,7 @@ If a tier is omitted, it uses the built-in tier default (`10GB` with no
 time-based age limit). There are no top-level journal retention knobs; set
 retention on each tier you want to tune.
 
-`size_of_journal_files` budgets committed journal data plus finalized
+`size_of_journal_files` budgets journal data plus finalized
 per-journal facet sidecars. The active journal counts but is protected from
 deletion, so usage can temporarily exceed the budget until rotation. Shared
 `facet-state.bin`, temporary sidecars, and unrelated files are outside the

--- a/src/crates/netflow-plugin/README.md
+++ b/src/crates/netflow-plugin/README.md
@@ -366,6 +366,12 @@ If a tier is omitted, it uses the built-in tier default (`10GB` with no
 time-based age limit). There are no top-level journal retention knobs; set
 retention on each tier you want to tune.
 
+`size_of_journal_files` budgets committed journal data plus finalized
+per-journal facet sidecars. The active journal counts but is protected from
+deletion, so usage can temporarily exceed the budget until rotation. Shared
+`facet-state.bin`, temporary sidecars, and unrelated files are outside the
+per-tier budget.
+
 To make a tier time-only, set `size_of_journal_files: null`.
 To make a tier size-only, set `duration_of_journal_files: null`.
 

--- a/src/crates/netflow-plugin/configs/netflow.yaml
+++ b/src/crates/netflow-plugin/configs/netflow.yaml
@@ -50,12 +50,14 @@ journal:
   # With the default Netdata cache dir this becomes /var/cache/netdata/flows.
   journal_dir: flows
 
-  # Per-tier retention. Each tier has its own size_of_journal_files (hard
-  # cap; minimum 100MB; null disables size-based retention) and
-  # duration_of_journal_files (optional time cap; null disables time-based
-  # retention). The stock default is size-only retention: 10GB per tier
-  # with no age-based eviction. Validation requires at least one positive
-  # limit per tier.
+  # Per-tier retention. size_of_journal_files is the retained-artifact budget
+  # for committed journal data plus finalized per-journal facet sidecars
+  # (minimum 100MB; null disables size-based retention). The protected active
+  # journal can temporarily exceed this budget; shared facet state and
+  # temporary files are outside it. duration_of_journal_files is the optional
+  # time cap (null disables it). The stock default is 10GB per tier with no
+  # age-based eviction. Validation requires at least one positive limit per
+  # tier.
   # Internal rotation size derives from size_of_journal_files:
   # clamp(size_of_journal_files / 20, 5MB, 200MB). When size is null,
   # internal rotation defaults to 100MB and retention is controlled only

--- a/src/crates/netflow-plugin/configs/netflow.yaml
+++ b/src/crates/netflow-plugin/configs/netflow.yaml
@@ -51,7 +51,7 @@ journal:
   journal_dir: flows
 
   # Per-tier retention. size_of_journal_files is the retained-artifact budget
-  # for committed journal data plus finalized per-journal facet sidecars
+  # for journal data plus finalized per-journal facet sidecars
   # (minimum 100MB; null disables size-based retention). The protected active
   # journal can temporarily exceed this budget; shared facet state and
   # temporary files are outside it. duration_of_journal_files is the optional

--- a/src/crates/netflow-plugin/integrations/ipfix.md
+++ b/src/crates/netflow-plugin/integrations/ipfix.md
@@ -88,7 +88,7 @@ Enable IPFIX via the `protocols.ipfix` option.
 | protocols.sampling_cache_max_entries | Maximum learned NetFlow v9/IPFIX sampling-rate entries across all exporter streams. Must be positive. | 100000 | no |
 | protocols.sampling_cache_max_entries_per_stream | Maximum learned sampling-rate entries for one exporter stream. Must be positive; values above the global limit are clamped. | 65536 | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
-| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention. | 10GB | no |
+| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier retained-artifact budget for journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention. | 10GB | no |
 | journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap. | null | no |
 
 

--- a/src/crates/netflow-plugin/integrations/ipfix.md
+++ b/src/crates/netflow-plugin/integrations/ipfix.md
@@ -88,7 +88,7 @@ Enable IPFIX via the `protocols.ipfix` option.
 | protocols.sampling_cache_max_entries | Maximum learned NetFlow v9/IPFIX sampling-rate entries across all exporter streams. Must be positive. | 100000 | no |
 | protocols.sampling_cache_max_entries_per_stream | Maximum learned sampling-rate entries for one exporter stream. Must be positive; values above the global limit are clamped. | 65536 | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
-| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention. | 10GB | no |
+| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention. | 10GB | no |
 | journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap. | null | no |
 
 

--- a/src/crates/netflow-plugin/integrations/netflow.md
+++ b/src/crates/netflow-plugin/integrations/netflow.md
@@ -96,7 +96,7 @@ The plugin is configured via `netflow.yaml` in the Netdata configuration directo
 | protocols.sampling_cache_max_entries | Maximum learned NetFlow v9/IPFIX sampling-rate entries across all exporter streams. Must be positive. | 100000 | no |
 | protocols.sampling_cache_max_entries_per_stream | Maximum learned sampling-rate entries for one exporter stream. Must be positive; values above the global limit are clamped. | 65536 | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
-| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention. | 10GB | no |
+| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier retained-artifact budget for journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention. | 10GB | no |
 | journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap. | null | no |
 
 

--- a/src/crates/netflow-plugin/integrations/netflow.md
+++ b/src/crates/netflow-plugin/integrations/netflow.md
@@ -96,7 +96,7 @@ The plugin is configured via `netflow.yaml` in the Netdata configuration directo
 | protocols.sampling_cache_max_entries | Maximum learned NetFlow v9/IPFIX sampling-rate entries across all exporter streams. Must be positive. | 100000 | no |
 | protocols.sampling_cache_max_entries_per_stream | Maximum learned sampling-rate entries for one exporter stream. Must be positive; values above the global limit are clamped. | 65536 | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
-| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention. | 10GB | no |
+| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention. | 10GB | no |
 | journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap. | null | no |
 
 

--- a/src/crates/netflow-plugin/integrations/netflow.md
+++ b/src/crates/netflow-plugin/integrations/netflow.md
@@ -61,7 +61,7 @@ Operational limits are driven by sustained flow records/s, exporter batching, ca
 
 #### Performance Impact
 
-Disabled until exporters send traffic. Once active, CPU and disk I/O scale with flow-record rate and cardinality; size retention and storage from observed flow records/s.
+Disabled until exporters send traffic. Once active, CPU and disk I/O scale with flow-record rate, template volume, and cardinality; size retention and storage from observed flow records/s.
 
 ## Setup
 

--- a/src/crates/netflow-plugin/integrations/sflow.md
+++ b/src/crates/netflow-plugin/integrations/sflow.md
@@ -87,7 +87,7 @@ Enable sFlow via the `protocols.sflow` option.
 | listener.listen | UDP listener endpoints for NetFlow/IPFIX and sFlow datagrams. YAML accepts either a scalar endpoint or a list of endpoints; CLI accepts repeated `--netflow-listen` flags or comma-delimited values. | 0.0.0.0:2055, 0.0.0.0:6343 | no |
 | protocols.sflow | Enable sFlow decoding. | yes | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
-| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention. | 10GB | no |
+| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention. | 10GB | no |
 | journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap. | null | no |
 
 

--- a/src/crates/netflow-plugin/integrations/sflow.md
+++ b/src/crates/netflow-plugin/integrations/sflow.md
@@ -87,7 +87,7 @@ Enable sFlow via the `protocols.sflow` option.
 | listener.listen | UDP listener endpoints for NetFlow/IPFIX and sFlow datagrams. YAML accepts either a scalar endpoint or a list of endpoints; CLI accepts repeated `--netflow-listen` flags or comma-delimited values. | 0.0.0.0:2055, 0.0.0.0:6343 | no |
 | protocols.sflow | Enable sFlow decoding. | yes | no |
 | journal.journal_dir | Directory for journal files (relative to NETDATA_CACHE_DIR). | flows | no |
-| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention. | 10GB | no |
+| journal.tiers.&lt;tier&gt;.size_of_journal_files | Per-tier retained-artifact budget for journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention. | 10GB | no |
 | journal.tiers.&lt;tier&gt;.duration_of_journal_files | Per-tier maximum age. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The default `null` disables time-based eviction; set a duration to add an age cap. | null | no |
 
 

--- a/src/crates/netflow-plugin/metadata.yaml
+++ b/src/crates/netflow-plugin/metadata.yaml
@@ -114,7 +114,7 @@ modules:
               default_value: flows
               required: false
             - name: journal.tiers.&lt;tier&gt;.size_of_journal_files
-              description: Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention.
+              description: Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention.
               default_value: "10GB"
               required: false
             - name: journal.tiers.&lt;tier&gt;.duration_of_journal_files
@@ -418,7 +418,7 @@ modules:
               default_value: flows
               required: false
             - name: journal.tiers.&lt;tier&gt;.size_of_journal_files
-              description: Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention.
+              description: Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention.
               default_value: "10GB"
               required: false
             - name: journal.tiers.&lt;tier&gt;.duration_of_journal_files
@@ -556,7 +556,7 @@ modules:
               default_value: flows
               required: false
             - name: journal.tiers.&lt;tier&gt;.size_of_journal_files
-              description: Per-tier hard size cap. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. Set to `null` for time-only retention.
+              description: Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention.
               default_value: "10GB"
               required: false
             - name: journal.tiers.&lt;tier&gt;.duration_of_journal_files

--- a/src/crates/netflow-plugin/metadata.yaml
+++ b/src/crates/netflow-plugin/metadata.yaml
@@ -114,7 +114,7 @@ modules:
               default_value: flows
               required: false
             - name: journal.tiers.&lt;tier&gt;.size_of_journal_files
-              description: Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention.
+              description: Per-tier retained-artifact budget for journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention.
               default_value: "10GB"
               required: false
             - name: journal.tiers.&lt;tier&gt;.duration_of_journal_files
@@ -418,7 +418,7 @@ modules:
               default_value: flows
               required: false
             - name: journal.tiers.&lt;tier&gt;.size_of_journal_files
-              description: Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention.
+              description: Per-tier retained-artifact budget for journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention.
               default_value: "10GB"
               required: false
             - name: journal.tiers.&lt;tier&gt;.duration_of_journal_files
@@ -556,7 +556,7 @@ modules:
               default_value: flows
               required: false
             - name: journal.tiers.&lt;tier&gt;.size_of_journal_files
-              description: Per-tier retained-artifact budget for committed journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention.
+              description: Per-tier retained-artifact budget for journal data and finalized per-journal facet sidecars. Replace `<tier>` with `raw`, `minute_1`, `minute_5`, or `hour_1`. The protected active journal can temporarily exceed the budget. Set to `null` for time-only retention.
               default_value: "10GB"
               required: false
             - name: journal.tiers.&lt;tier&gt;.duration_of_journal_files

--- a/src/crates/netflow-plugin/metadata.yaml
+++ b/src/crates/netflow-plugin/metadata.yaml
@@ -63,7 +63,7 @@ modules:
         limits:
           description: "Operational limits are driven by sustained flow records/s, exporter batching, cardinality, retention, storage speed, and enrichment. On modern hardware with fast storage, plan around 50k-100k sustained flow records/s per well-provisioned agent for the full raw + rollup pipeline, provided the underlying disks can sustain the required journal write activity; use distributed agents for larger deployments."
         performance_impact:
-          description: "Disabled until exporters send traffic. Once active, CPU and disk I/O scale with flow-record rate and cardinality; size retention and storage from observed flow records/s."
+          description: "Disabled until exporters send traffic. Once active, CPU and disk I/O scale with flow-record rate, template volume, and cardinality; size retention and storage from observed flow records/s."
     setup:
       prerequisites:
         list:

--- a/src/crates/netflow-plugin/src/api/flows/handler.rs
+++ b/src/crates/netflow-plugin/src/api/flows/handler.rs
@@ -366,4 +366,20 @@ mod tests {
             "expected invalid request error payload"
         );
     }
+
+    #[test]
+    fn parse_request_rejects_metric_selections_as_bad_request() {
+        for field in ["BYTES", "PACKETS", "FLOWS"] {
+            let payload = format!(r#"{{"selections":{{"{field}":["1"]}}}}"#);
+            let err = parse_flows_request(&test_call(&[], Some(&payload)))
+                .expect_err("metric selection should fail");
+            let response = String::from_utf8_lossy(&err.payload);
+
+            assert_eq!(err.status, 400);
+            assert!(
+                response.contains(&format!("unsupported selection field `{field}`")),
+                "unexpected response for {field}: {response}"
+            );
+        }
+    }
 }

--- a/src/crates/netflow-plugin/src/facet_catalog.rs
+++ b/src/crates/netflow-plugin/src/facet_catalog.rs
@@ -14,9 +14,9 @@ pub(crate) enum FacetValueKind {
 
 /// How the autocomplete dropdown matches user input against stored values.
 ///
-/// This is exclusively about the autocomplete/dropdown UX. Regular facet
-/// matching (selections / `key in [values]`) is always exact equality and
-/// uses indexes — never a substring scan.
+/// This is exclusively about the autocomplete/dropdown UX. Regular non-IP
+/// selections use exact equality; address facets additionally accept typed CIDR
+/// containment. Neither path uses substring matching over flow rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AutocompleteMatchKind {
     /// `value.starts_with(term)`. Cheap on FST sidecars (automaton-driven).

--- a/src/crates/netflow-plugin/src/facet_catalog.rs
+++ b/src/crates/netflow-plugin/src/facet_catalog.rs
@@ -12,6 +12,12 @@ pub(crate) enum FacetValueKind {
     IpAddr,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FacetPresentation {
+    Inline,
+    Autocomplete,
+}
+
 /// How the autocomplete dropdown matches user input against stored values.
 ///
 /// This is exclusively about the autocomplete/dropdown UX. Regular facet
@@ -31,7 +37,7 @@ pub(crate) enum AutocompleteMatchKind {
 pub(crate) struct FacetFieldSpec {
     pub(crate) name: &'static str,
     pub(crate) kind: FacetValueKind,
-    pub(crate) supports_autocomplete: bool,
+    pub(crate) presentation: FacetPresentation,
     pub(crate) uses_sidecar: bool,
     pub(crate) autocomplete_match: AutocompleteMatchKind,
 }
@@ -40,14 +46,14 @@ const VIRTUAL_FACET_FIELDS: &[FacetFieldSpec] = &[
     FacetFieldSpec {
         name: "ICMPV4",
         kind: FacetValueKind::Text,
-        supports_autocomplete: true,
+        presentation: FacetPresentation::Inline,
         uses_sidecar: false,
         autocomplete_match: AutocompleteMatchKind::Substring,
     },
     FacetFieldSpec {
         name: "ICMPV6",
         kind: FacetValueKind::Text,
-        supports_autocomplete: true,
+        presentation: FacetPresentation::Inline,
         uses_sidecar: false,
         autocomplete_match: AutocompleteMatchKind::Substring,
     },
@@ -134,9 +140,9 @@ fn facet_field_spec_for_name(field: &'static str) -> Option<FacetFieldSpec> {
         }
         "EXPORTER_PORT" | "ETYPE" | "SRC_PORT" | "DST_PORT" | "SRC_PORT_NAT" | "DST_PORT_NAT"
         | "SRC_VLAN" | "DST_VLAN" | "IP_FRAGMENT_OFFSET" => FacetValueKind::DenseU16,
-        "PROTOCOL" | "FORWARDING_STATUS" | "DIRECTION" | "SRC_MASK" | "DST_MASK"
-        | "IN_IF_BOUNDARY" | "OUT_IF_BOUNDARY" | "IPTTL" | "IPTOS" | "TCP_FLAGS"
-        | "ICMPV4_TYPE" | "ICMPV4_CODE" | "ICMPV6_TYPE" | "ICMPV6_CODE" => FacetValueKind::DenseU8,
+        "PROTOCOL" | "FORWARDING_STATUS" | "SRC_MASK" | "DST_MASK" | "IN_IF_BOUNDARY"
+        | "OUT_IF_BOUNDARY" | "IPTTL" | "IPTOS" | "TCP_FLAGS" | "ICMPV4_TYPE" | "ICMPV4_CODE"
+        | "ICMPV6_TYPE" | "ICMPV6_CODE" => FacetValueKind::DenseU8,
         "SRC_AS" | "DST_AS" | "IN_IF" | "OUT_IF" | "IPV6_FLOW_LABEL" | "IP_FRAGMENT_ID" => {
             FacetValueKind::SparseU32
         }
@@ -144,30 +150,39 @@ fn facet_field_spec_for_name(field: &'static str) -> Option<FacetFieldSpec> {
         _ => FacetValueKind::Text,
     };
 
-    let autocomplete_match = match kind {
-        FacetValueKind::Text => AutocompleteMatchKind::Substring,
+    let presentation = match field {
+        "FLOW_VERSION" | "ETYPE" | "PROTOCOL" | "FORWARDING_STATUS" | "DIRECTION"
+        | "IN_IF_BOUNDARY" | "OUT_IF_BOUNDARY" | "IPTOS" | "TCP_FLAGS" | "ICMPV4_TYPE"
+        | "ICMPV4_CODE" | "ICMPV6_TYPE" | "ICMPV6_CODE" => FacetPresentation::Inline,
+        _ => FacetPresentation::Autocomplete,
+    };
+    let autocomplete_match = match field {
+        "SRC_PREFIX" | "DST_PREFIX" => AutocompleteMatchKind::Prefix,
+        _ if matches!(kind, FacetValueKind::Text) => AutocompleteMatchKind::Substring,
         _ => AutocompleteMatchKind::Prefix,
     };
 
     Some(FacetFieldSpec {
         name: field,
         kind,
-        supports_autocomplete: true,
-        uses_sidecar: matches!(
-            kind,
-            FacetValueKind::Text
-                | FacetValueKind::IpAddr
-                | FacetValueKind::SparseU32
-                | FacetValueKind::SparseU64
-                | FacetValueKind::DenseU16
-        ),
+        presentation,
+        uses_sidecar: field != "DIRECTION"
+            && matches!(
+                kind,
+                FacetValueKind::Text
+                    | FacetValueKind::IpAddr
+                    | FacetValueKind::SparseU32
+                    | FacetValueKind::SparseU64
+                    | FacetValueKind::DenseU16
+            ),
         autocomplete_match,
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{FacetValueKind, facet_field_spec};
+    use super::{FACET_FIELD_SPECS, FacetPresentation, FacetValueKind, facet_field_spec};
+    use std::collections::BTreeSet;
 
     #[test]
     fn facet_field_spec_trims_and_matches_case_insensitively() {
@@ -194,6 +209,62 @@ mod tests {
         assert_eq!(
             facet_field_spec("IP_FRAGMENT_ID").map(|spec| spec.kind),
             Some(FacetValueKind::SparseU32)
+        );
+    }
+
+    #[test]
+    fn direction_uses_its_logical_text_representation() {
+        let direction = facet_field_spec("DIRECTION").expect("direction facet");
+        assert_eq!(direction.kind, FacetValueKind::Text);
+        assert!(!direction.uses_sidecar);
+    }
+
+    #[test]
+    fn network_prefixes_use_prefix_autocomplete() {
+        for field in ["SRC_PREFIX", "DST_PREFIX"] {
+            assert_eq!(
+                facet_field_spec(field).map(|spec| spec.autocomplete_match),
+                Some(super::AutocompleteMatchKind::Prefix),
+                "{field}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_fixed_categorical_fields_prefer_inline_values() {
+        let actual = FACET_FIELD_SPECS
+            .iter()
+            .filter(|spec| spec.presentation == FacetPresentation::Inline)
+            .map(|spec| spec.name)
+            .collect::<BTreeSet<_>>();
+        let expected = [
+            "DIRECTION",
+            "ETYPE",
+            "FLOW_VERSION",
+            "FORWARDING_STATUS",
+            "ICMPV4",
+            "ICMPV4_CODE",
+            "ICMPV4_TYPE",
+            "ICMPV6",
+            "ICMPV6_CODE",
+            "ICMPV6_TYPE",
+            "IN_IF_BOUNDARY",
+            "IPTOS",
+            "OUT_IF_BOUNDARY",
+            "PROTOCOL",
+            "TCP_FLAGS",
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+        assert_eq!(actual, expected);
+        assert_eq!(FACET_FIELD_SPECS.len(), 80);
+        assert_eq!(
+            FACET_FIELD_SPECS
+                .iter()
+                .filter(|spec| spec.presentation == FacetPresentation::Autocomplete)
+                .count(),
+            65
         );
     }
 }

--- a/src/crates/netflow-plugin/src/facet_catalog.rs
+++ b/src/crates/netflow-plugin/src/facet_catalog.rs
@@ -12,12 +12,6 @@ pub(crate) enum FacetValueKind {
     IpAddr,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum FacetPresentation {
-    Inline,
-    Autocomplete,
-}
-
 /// How the autocomplete dropdown matches user input against stored values.
 ///
 /// This is exclusively about the autocomplete/dropdown UX. Regular facet
@@ -37,7 +31,6 @@ pub(crate) enum AutocompleteMatchKind {
 pub(crate) struct FacetFieldSpec {
     pub(crate) name: &'static str,
     pub(crate) kind: FacetValueKind,
-    pub(crate) presentation: FacetPresentation,
     pub(crate) uses_sidecar: bool,
     pub(crate) autocomplete_match: AutocompleteMatchKind,
 }
@@ -46,14 +39,12 @@ const VIRTUAL_FACET_FIELDS: &[FacetFieldSpec] = &[
     FacetFieldSpec {
         name: "ICMPV4",
         kind: FacetValueKind::Text,
-        presentation: FacetPresentation::Inline,
         uses_sidecar: false,
         autocomplete_match: AutocompleteMatchKind::Substring,
     },
     FacetFieldSpec {
         name: "ICMPV6",
         kind: FacetValueKind::Text,
-        presentation: FacetPresentation::Inline,
         uses_sidecar: false,
         autocomplete_match: AutocompleteMatchKind::Substring,
     },
@@ -150,12 +141,6 @@ fn facet_field_spec_for_name(field: &'static str) -> Option<FacetFieldSpec> {
         _ => FacetValueKind::Text,
     };
 
-    let presentation = match field {
-        "FLOW_VERSION" | "ETYPE" | "PROTOCOL" | "FORWARDING_STATUS" | "DIRECTION"
-        | "IN_IF_BOUNDARY" | "OUT_IF_BOUNDARY" | "IPTOS" | "TCP_FLAGS" | "ICMPV4_TYPE"
-        | "ICMPV4_CODE" | "ICMPV6_TYPE" | "ICMPV6_CODE" => FacetPresentation::Inline,
-        _ => FacetPresentation::Autocomplete,
-    };
     let autocomplete_match = match field {
         "SRC_PREFIX" | "DST_PREFIX" => AutocompleteMatchKind::Prefix,
         _ if matches!(kind, FacetValueKind::Text) => AutocompleteMatchKind::Substring,
@@ -165,7 +150,6 @@ fn facet_field_spec_for_name(field: &'static str) -> Option<FacetFieldSpec> {
     Some(FacetFieldSpec {
         name: field,
         kind,
-        presentation,
         uses_sidecar: field != "DIRECTION"
             && matches!(
                 kind,
@@ -181,7 +165,7 @@ fn facet_field_spec_for_name(field: &'static str) -> Option<FacetFieldSpec> {
 
 #[cfg(test)]
 mod tests {
-    use super::{FACET_FIELD_SPECS, FacetPresentation, FacetValueKind, facet_field_spec};
+    use super::{FACET_FIELD_SPECS, FacetValueKind, facet_field_spec};
     use std::collections::BTreeSet;
 
     #[test]
@@ -231,40 +215,13 @@ mod tests {
     }
 
     #[test]
-    fn only_fixed_categorical_fields_prefer_inline_values() {
-        let actual = FACET_FIELD_SPECS
+    fn facet_catalog_has_expected_unique_fields() {
+        let names = FACET_FIELD_SPECS
             .iter()
-            .filter(|spec| spec.presentation == FacetPresentation::Inline)
             .map(|spec| spec.name)
             .collect::<BTreeSet<_>>();
-        let expected = [
-            "DIRECTION",
-            "ETYPE",
-            "FLOW_VERSION",
-            "FORWARDING_STATUS",
-            "ICMPV4",
-            "ICMPV4_CODE",
-            "ICMPV4_TYPE",
-            "ICMPV6",
-            "ICMPV6_CODE",
-            "ICMPV6_TYPE",
-            "IN_IF_BOUNDARY",
-            "IPTOS",
-            "OUT_IF_BOUNDARY",
-            "PROTOCOL",
-            "TCP_FLAGS",
-        ]
-        .into_iter()
-        .collect::<BTreeSet<_>>();
 
-        assert_eq!(actual, expected);
         assert_eq!(FACET_FIELD_SPECS.len(), 80);
-        assert_eq!(
-            FACET_FIELD_SPECS
-                .iter()
-                .filter(|spec| spec.presentation == FacetPresentation::Autocomplete)
-                .count(),
-            65
-        );
+        assert_eq!(names.len(), FACET_FIELD_SPECS.len());
     }
 }

--- a/src/crates/netflow-plugin/src/facet_runtime.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime.rs
@@ -47,7 +47,7 @@ const FACET_STATE_SCHEMA_VERSION: u32 = 1;
 const FACET_STATE_HEADER_LEN: usize = 4 + 4 + 8 + 8;
 const MAX_FACET_STATE_PAYLOAD_LEN: usize = 128 * 1024 * 1024;
 const MAX_FACET_STATE_FILE_LEN: usize = FACET_STATE_HEADER_LEN + MAX_FACET_STATE_PAYLOAD_LEN;
-const FACET_AUTOCOMPLETE_LIMIT: usize = 256;
+pub(crate) const FACET_AUTOCOMPLETE_LIMIT: usize = 256;
 #[cfg(test)]
 static FACET_BEFORE_DISK_WRITE_HOOK: Mutex<Option<Arc<dyn Fn(&Path) + Send + Sync>>> =
     Mutex::new(None);

--- a/src/crates/netflow-plugin/src/facet_runtime.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime.rs
@@ -4,7 +4,7 @@ mod store;
 
 use crate::facet_catalog::{
     AutocompleteMatchKind, FACET_ALLOWED_OPTIONS, FACET_FIELD_SPECS, FacetFieldSpec,
-    facet_field_spec, facet_field_spec_static,
+    FacetValueKind, facet_field_spec, facet_field_spec_static,
 };
 use crate::flow::FlowRecord;
 use crate::memory_estimation::btree_container_overhead_bytes;
@@ -31,20 +31,22 @@ pub(crate) use contribution::{
     FacetFileContribution, FacetValueSink, append_record_facet_values,
     facet_contribution_from_flow_fields,
 };
-use sidecar::{delete_sidecar_files, search_sidecar, sidecar_path, write_sidecar_files};
+pub(crate) use sidecar::sidecar_path;
+use sidecar::{delete_sidecar_files, search_sidecar, write_sidecar_files};
 use store::{FacetStore, FacetStoreValueRef, PersistedFacetStore};
 
-// Version 6 invalidates state built with the old 16-bit IP_FRAGMENT_ID catalog.
-// Archived per-file contributions are not persisted, so retained journals must
-// be rescanned to reconstruct the global value set and its sidecars correctly.
-const FACET_STATE_VERSION: u32 = 6;
+// Version 7 changes DIRECTION from its unusable numeric store to text. Version
+// 6 remains a valid migration source: all compatible fields are retained while
+// archived DIRECTION values are rebuilt after listener startup.
+const FACET_STATE_VERSION: u32 = 7;
+const DIRECTION_MIGRATION_SOURCE_VERSION: u32 = 6;
 const FACET_STATE_FILE_NAME: &str = "facet-state.bin";
 const FACET_STATE_MAGIC: &[u8; 4] = b"NFFS";
 const FACET_STATE_SCHEMA_VERSION: u32 = 1;
 const FACET_STATE_HEADER_LEN: usize = 4 + 4 + 8 + 8;
 const MAX_FACET_STATE_PAYLOAD_LEN: usize = 128 * 1024 * 1024;
 const MAX_FACET_STATE_FILE_LEN: usize = FACET_STATE_HEADER_LEN + MAX_FACET_STATE_PAYLOAD_LEN;
-const FACET_AUTOCOMPLETE_LIMIT: usize = 100;
+const FACET_AUTOCOMPLETE_LIMIT: usize = 256;
 #[cfg(test)]
 static FACET_BEFORE_DISK_WRITE_HOOK: Mutex<Option<Arc<dyn Fn(&Path) + Send + Sync>>> =
     Mutex::new(None);
@@ -94,12 +96,16 @@ struct FacetState {
     published: FacetPublishedSnapshot,
     dirty: bool,
     dirty_generation: u64,
+    topology_generation: u64,
     rebuild_archived: bool,
+    direction_migration_pending: bool,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct FacetReconcilePlan {
+    pub(crate) topology_generation: u64,
     pub(crate) current_archived_paths: BTreeSet<String>,
+    pub(crate) current_active_paths: BTreeSet<String>,
     pub(crate) archived_files_to_scan: Vec<FileInfo>,
     pub(crate) active_files_to_scan: Vec<FileInfo>,
     pub(crate) rebuild_archived: bool,
@@ -112,6 +118,12 @@ pub(crate) struct FacetRuntime {
     ready: AtomicBool,
     state_path: PathBuf,
     persistence: FacetPersistence,
+}
+
+impl journal_sdk_log_writer::LogArtifactSizer for FacetRuntime {
+    fn journal_artifact_size(&self, journal_path: &Path) -> journal_sdk_log_writer::Result<u64> {
+        sidecar::journal_sidecar_bytes(journal_path)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -154,8 +166,16 @@ impl FacetRuntime {
         }
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn is_ready(&self) -> bool {
         self.ready.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn direction_migration_pending(&self) -> bool {
+        self.state
+            .lock()
+            .map(|state| state.direction_migration_pending)
+            .unwrap_or(false)
     }
 
     pub(crate) fn snapshot(&self) -> Arc<FacetPublishedSnapshot> {
@@ -187,14 +207,21 @@ impl FacetRuntime {
     }
 
     pub(crate) fn build_reconcile_plan(&self, registry_files: &[FileInfo]) -> FacetReconcilePlan {
-        let current_archived_paths = registry_files
+        let registry_active_paths = registry_files
             .iter()
-            .filter(|file_info| file_info.file.is_archived())
+            .filter(|file_info| file_info.file.is_active())
             .map(|file_info| file_info.file.path().to_string())
             .collect::<BTreeSet<_>>();
         let Some(state) = self.state.lock().ok() else {
+            let current_archived_paths = registry_files
+                .iter()
+                .filter(|file_info| file_info.file.is_archived())
+                .map(|file_info| file_info.file.path().to_string())
+                .collect::<BTreeSet<_>>();
             return FacetReconcilePlan {
+                topology_generation: 0,
                 current_archived_paths,
+                current_active_paths: registry_active_paths,
                 archived_files_to_scan: registry_files
                     .iter()
                     .filter(|file_info| file_info.file.is_archived())
@@ -209,6 +236,20 @@ impl FacetRuntime {
             };
         };
 
+        // The writer's non-strict filenames look archived to the registry even
+        // while they are active. Lifecycle state is authoritative for those paths.
+        let current_active_paths = registry_active_paths
+            .into_iter()
+            .chain(state.active_contributions.keys().cloned())
+            .collect::<BTreeSet<_>>();
+        let current_archived_paths = registry_files
+            .iter()
+            .filter(|file_info| {
+                file_info.file.is_archived()
+                    && !current_active_paths.contains(file_info.file.path())
+            })
+            .map(|file_info| file_info.file.path().to_string())
+            .collect::<BTreeSet<_>>();
         let rebuild_archived = state.rebuild_archived
             || !state
                 .indexed_archived_paths
@@ -217,6 +258,7 @@ impl FacetRuntime {
             .iter()
             .filter(|file_info| {
                 file_info.file.is_archived()
+                    && !current_active_paths.contains(file_info.file.path())
                     && (rebuild_archived
                         || !state.indexed_archived_paths.contains(file_info.file.path()))
             })
@@ -224,12 +266,14 @@ impl FacetRuntime {
             .collect::<Vec<_>>();
         let active_files_to_scan = registry_files
             .iter()
-            .filter(|file_info| file_info.file.is_active())
+            .filter(|file_info| current_active_paths.contains(file_info.file.path()))
             .cloned()
             .collect::<Vec<_>>();
 
         FacetReconcilePlan {
+            topology_generation: state.topology_generation,
             current_archived_paths,
+            current_active_paths,
             archived_files_to_scan,
             active_files_to_scan,
             rebuild_archived,
@@ -241,14 +285,29 @@ impl FacetRuntime {
         plan: FacetReconcilePlan,
         archived_scans: BTreeMap<String, FacetFileContribution>,
         active_scans: BTreeMap<String, FacetFileContribution>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let (sidecar_deletes, sidecar_writes, persist_snapshot) = {
             let mut state = self
                 .state
                 .lock()
                 .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
+            if state.topology_generation != plan.topology_generation
+                || (state.rebuild_archived && !plan.rebuild_archived)
+            {
+                return Ok(false);
+            }
+            if plan_omits_existing_runtime_path(&state, &plan)? {
+                return Ok(false);
+            }
+
             let mut sidecar_deletes = Vec::new();
             let mut sidecar_writes = Vec::new();
+            let previous_archived_paths = state.indexed_archived_paths.clone();
+            let previous_active_paths = state
+                .active_contributions
+                .keys()
+                .cloned()
+                .collect::<BTreeSet<_>>();
 
             let removed_archived = state
                 .indexed_archived_paths
@@ -280,13 +339,38 @@ impl FacetRuntime {
                 }
             }
 
-            if !state.active_contributions.is_empty() {
+            state
+                .active_contributions
+                .retain(|path, _| plan.current_active_paths.contains(path));
+            for (path, contribution) in active_scans {
+                if !plan.current_active_paths.contains(&path) {
+                    continue;
+                }
+                match state.active_contributions.entry(path) {
+                    std::collections::btree_map::Entry::Occupied(mut entry) => {
+                        if entry.get_mut().merge_from(&contribution) {
+                            mark_dirty(&mut state);
+                        }
+                    }
+                    std::collections::btree_map::Entry::Vacant(entry) => {
+                        entry.insert(contribution);
+                        mark_dirty(&mut state);
+                    }
+                }
+            }
+            let current_active_paths = state
+                .active_contributions
+                .keys()
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            if previous_active_paths != current_active_paths {
                 mark_dirty(&mut state);
             }
-            state.active_contributions.clear();
-            for (path, contribution) in active_scans {
-                state.active_contributions.insert(path, contribution);
-                mark_dirty(&mut state);
+
+            if previous_archived_paths != state.indexed_archived_paths
+                || previous_active_paths != current_active_paths
+            {
+                mark_topology_changed(&mut state);
             }
             rebuild_published_fields(&mut state);
             state.rebuild_archived = false;
@@ -306,7 +390,7 @@ impl FacetRuntime {
         }
         self.persist_snapshot(persist_snapshot)?;
         self.mark_ready();
-        Ok(())
+        Ok(true)
     }
 
     pub(crate) fn observe_active_contribution(
@@ -331,6 +415,21 @@ impl FacetRuntime {
         Ok(())
     }
 
+    pub(crate) fn observe_active_path_created(&self, path: &Path) -> Result<()> {
+        let Some(path_str) = path.to_str() else {
+            return Ok(());
+        };
+
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
+        if ensure_active_contribution_entry(&mut state, path_str) {
+            mark_topology_changed(&mut state);
+        }
+        Ok(())
+    }
+
     pub(crate) fn observe_active_record(&self, path: &Path, record: &FlowRecord) -> Result<()> {
         let Some(path_str) = path.to_str() else {
             return Ok(());
@@ -340,7 +439,9 @@ impl FacetRuntime {
             .state
             .lock()
             .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
-        ensure_active_contribution_entry(&mut state, path_str);
+        if ensure_active_contribution_entry(&mut state, path_str) {
+            mark_topology_changed(&mut state);
+        }
         let changed = {
             let mut sink = ActiveContributionSink::new(&mut state, path_str);
             append_record_facet_values(&mut sink, record);
@@ -362,11 +463,13 @@ impl FacetRuntime {
                 .state
                 .lock()
                 .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
+            mark_topology_changed(&mut state);
 
             let contribution = state
                 .active_contributions
                 .remove(&archived_path_str)
                 .or_else(|| state.active_contributions.remove(&active_path_str));
+            ensure_active_contribution_entry(&mut state, &active_path_str);
             if let Some(contribution) = contribution {
                 merge_global_contribution(&mut state.archived_fields, &contribution);
                 rebuild_published_fields(&mut state);
@@ -400,6 +503,9 @@ impl FacetRuntime {
                 .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
             let mut changed = false;
             let mut sidecar_deletes = Vec::new();
+            if !deleted_paths.is_empty() {
+                mark_topology_changed(&mut state);
+            }
 
             for path in deleted_paths {
                 let Some(path_str) = path.to_str() else {
@@ -447,6 +553,79 @@ impl FacetRuntime {
             self.prepare_persist_snapshot_locked(&mut state)?
         };
         self.persist_snapshot(persist_snapshot)
+    }
+
+    /// Refresh only active journals while a compatible v6 archived state waits
+    /// for its post-listener DIRECTION migration.
+    pub(crate) fn apply_active_scan_before_direction_migration(
+        &self,
+        active_scans: BTreeMap<String, FacetFileContribution>,
+    ) -> Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
+        if !state.direction_migration_pending {
+            return Ok(());
+        }
+
+        state.active_contributions = active_scans;
+        rebuild_published_fields(&mut state);
+        mark_dirty(&mut state);
+        publish_locked(&self.snapshot, &state);
+        Ok(())
+    }
+
+    /// Replace only the archived DIRECTION store after proving that the
+    /// retained journal set did not change while it was scanned.
+    ///
+    /// Returns `false` when a concurrent rotation or deletion requires a retry.
+    /// Active contributions and every compatible archived field remain intact.
+    pub(crate) fn complete_direction_migration(
+        &self,
+        expected_archived_paths: &BTreeSet<String>,
+        archived_scans: BTreeMap<String, FacetFileContribution>,
+    ) -> Result<bool> {
+        let persist_snapshot = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
+            if !state.direction_migration_pending {
+                return Ok(true);
+            }
+            if state.rebuild_archived {
+                return Ok(false);
+            }
+            if state.indexed_archived_paths != *expected_archived_paths
+                || archived_scans.len() != expected_archived_paths.len()
+                || archived_scans
+                    .keys()
+                    .any(|path| !expected_archived_paths.contains(path))
+            {
+                return Ok(false);
+            }
+
+            let mut archived_direction = FacetStore::new(FacetValueKind::Text);
+            for contribution in archived_scans.into_values() {
+                let Some(direction) = contribution.field("DIRECTION") else {
+                    continue;
+                };
+                let _ = archived_direction.merge_from(direction);
+            }
+            state
+                .archived_fields
+                .insert("DIRECTION".to_string(), archived_direction);
+
+            state.direction_migration_pending = false;
+            rebuild_published_fields(&mut state);
+            mark_dirty(&mut state);
+            publish_locked(&self.snapshot, &state);
+            self.prepare_persist_snapshot_locked(&mut state)?
+        };
+
+        self.persist_snapshot(persist_snapshot)?;
+        Ok(true)
     }
 
     pub(crate) fn autocomplete(&self, field: &str, term: &str) -> Result<Vec<String>> {
@@ -543,7 +722,7 @@ impl FacetRuntime {
         &self,
         state: &mut FacetState,
     ) -> Result<Option<FacetPersistSnapshot>> {
-        if !state.dirty {
+        if !state.dirty || state.rebuild_archived || state.direction_migration_pending {
             return Ok(None);
         }
         if !self.persistence.writes_enabled() {
@@ -602,17 +781,24 @@ impl FacetState {
             active_contributions: BTreeMap::new(),
             dirty: false,
             dirty_generation: 0,
+            topology_generation: 0,
             rebuild_archived: false,
+            direction_migration_pending: false,
         }
     }
 
     fn from_persisted(persisted: PersistedFacetState) -> Self {
         let PersistedFacetState {
+            version,
             indexed_archived_paths,
-            archived_fields: persisted_archived_fields,
-            published,
-            ..
+            archived_fields: mut persisted_archived_fields,
+            mut published,
         } = persisted;
+        let direction_migration_pending = version == DIRECTION_MIGRATION_SOURCE_VERSION;
+        if direction_migration_pending {
+            persisted_archived_fields.remove("DIRECTION");
+            published.remove("DIRECTION");
+        }
         let mut archived_fields = empty_field_stores();
         for (field, saved) in persisted_archived_fields {
             let Some(spec) = facet_field_spec(field.as_str()) else {
@@ -624,21 +810,31 @@ impl FacetState {
             );
         }
 
+        let mut published = if published.is_empty() {
+            published_snapshot_from_archived_and_active_contributions(
+                &archived_fields,
+                &BTreeMap::new(),
+            )
+        } else {
+            FacetPublishedSnapshot { fields: published }
+        };
+        if direction_migration_pending {
+            published.fields.insert(
+                "DIRECTION".to_string(),
+                published_field_from_store(archived_fields.get("DIRECTION")),
+            );
+        }
+
         Self {
             indexed_archived_paths,
-            published: if published.is_empty() {
-                published_snapshot_from_archived_and_active_contributions(
-                    &archived_fields,
-                    &BTreeMap::new(),
-                )
-            } else {
-                FacetPublishedSnapshot { fields: published }
-            },
+            published,
             archived_fields,
             active_contributions: BTreeMap::new(),
             dirty: false,
             dirty_generation: 0,
+            topology_generation: 0,
             rebuild_archived: false,
+            direction_migration_pending,
         }
     }
 }
@@ -651,7 +847,13 @@ struct FacetPersistSnapshot {
 pub(crate) fn scan_registry_file_contribution(
     file_info: &FileInfo,
 ) -> Result<FacetFileContribution> {
-    let requested_fields = FACET_ALLOWED_OPTIONS.clone();
+    scan_registry_file_contribution_for_fields(file_info, FACET_ALLOWED_OPTIONS.as_slice())
+}
+
+pub(crate) fn scan_registry_file_contribution_for_fields(
+    file_info: &FileInfo,
+    requested_fields: &[String],
+) -> Result<FacetFileContribution> {
     let simple_fields = requested_fields
         .iter()
         .filter(|field| !facet_field_requires_protocol_scan(field))
@@ -742,7 +944,7 @@ fn published_snapshot_from_archived_and_active_contributions(
         for spec in FACET_FIELD_SPECS.iter() {
             fields.insert(
                 spec.name.to_string(),
-                published_field_from_store(*spec, archived_fields.get(spec.name)),
+                published_field_from_store(archived_fields.get(spec.name)),
             );
         }
         return FacetPublishedSnapshot { fields };
@@ -759,7 +961,7 @@ fn published_snapshot_from_archived_and_active_contributions(
             }
         }
         let total_values = combined.len();
-        let autocomplete = spec.supports_autocomplete && total_values > FACET_VALUE_LIMIT;
+        let autocomplete = total_values > FACET_VALUE_LIMIT;
         let values = if autocomplete {
             Vec::new()
         } else {
@@ -778,12 +980,9 @@ fn published_snapshot_from_archived_and_active_contributions(
     FacetPublishedSnapshot { fields }
 }
 
-fn published_field_from_store(
-    spec: FacetFieldSpec,
-    store: Option<&FacetStore>,
-) -> FacetPublishedField {
+fn published_field_from_store(store: Option<&FacetStore>) -> FacetPublishedField {
     let total_values = store.map(FacetStore::len).unwrap_or_default();
-    let autocomplete = spec.supports_autocomplete && total_values > FACET_VALUE_LIMIT;
+    let autocomplete = total_values > FACET_VALUE_LIMIT;
     let values = if autocomplete {
         Vec::new()
     } else {
@@ -817,7 +1016,7 @@ fn apply_new_active_value_to_published(
         .or_insert_with(FacetPublishedField::default);
 
     entry.total_values = entry.total_values.saturating_add(1);
-    if spec.supports_autocomplete && entry.total_values > FACET_VALUE_LIMIT {
+    if entry.total_values > FACET_VALUE_LIMIT {
         entry.autocomplete = true;
         entry.values.clear();
         return;
@@ -835,7 +1034,9 @@ fn apply_active_contribution(
     contribution: &FacetFileContribution,
 ) -> bool {
     let mut changed = false;
-    ensure_active_contribution_entry(state, path_str);
+    if ensure_active_contribution_entry(state, path_str) {
+        mark_topology_changed(state);
+    }
 
     for (field, store) in contribution.iter() {
         store.visit_values(|value| {
@@ -846,12 +1047,14 @@ fn apply_active_contribution(
     changed
 }
 
-fn ensure_active_contribution_entry(state: &mut FacetState, path_str: &str) {
+fn ensure_active_contribution_entry(state: &mut FacetState, path_str: &str) -> bool {
     if !state.active_contributions.contains_key(path_str) {
         state
             .active_contributions
             .insert(path_str.to_string(), FacetFileContribution::default());
+        return true;
     }
+    false
 }
 
 fn apply_active_value(
@@ -947,6 +1150,10 @@ impl FacetValueSink for ActiveContributionSink<'_> {
         if value == 0 {
             return;
         }
+        self.insert_u16_present_static(field, value);
+    }
+
+    fn insert_u16_present_static(&mut self, field: &'static str, value: u16) {
         self.changed |= apply_active_value(
             self.state,
             self.path_str,
@@ -959,6 +1166,10 @@ impl FacetValueSink for ActiveContributionSink<'_> {
         if value == 0 {
             return;
         }
+        self.insert_u32_present_static(field, value);
+    }
+
+    fn insert_u32_present_static(&mut self, field: &'static str, value: u32) {
         self.changed |= apply_active_value(
             self.state,
             self.path_str,
@@ -967,10 +1178,7 @@ impl FacetValueSink for ActiveContributionSink<'_> {
         );
     }
 
-    fn insert_u64_static(&mut self, field: &'static str, value: u64) {
-        if value == 0 {
-            return;
-        }
+    fn insert_u64_present_static(&mut self, field: &'static str, value: u64) {
         self.changed |= apply_active_value(
             self.state,
             self.path_str,
@@ -1038,6 +1246,33 @@ fn before_facet_disk_write_for_test(_path: &Path) {}
 fn mark_dirty(state: &mut FacetState) {
     state.dirty = true;
     state.dirty_generation = state.dirty_generation.wrapping_add(1);
+}
+
+fn mark_topology_changed(state: &mut FacetState) {
+    state.topology_generation = state.topology_generation.wrapping_add(1);
+}
+
+fn plan_omits_existing_runtime_path(state: &FacetState, plan: &FacetReconcilePlan) -> Result<bool> {
+    let omitted_paths = state
+        .indexed_archived_paths
+        .iter()
+        .filter(|path| !plan.current_archived_paths.contains(*path))
+        .chain(
+            state
+                .active_contributions
+                .keys()
+                .filter(|path| !plan.current_active_paths.contains(*path)),
+        );
+
+    for path in omitted_paths {
+        if Path::new(path)
+            .try_exists()
+            .with_context(|| format!("failed to verify retained netflow journal path {path}"))?
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn persisted_state_from_runtime_state(state: &FacetState) -> PersistedFacetState {
@@ -1244,7 +1479,10 @@ fn load_persisted_state(state_path: &Path) -> Option<PersistedFacetState> {
             return None;
         }
     };
-    if persisted.version != FACET_STATE_VERSION {
+    if !matches!(
+        persisted.version,
+        FACET_STATE_VERSION | DIRECTION_MIGRATION_SOURCE_VERSION
+    ) {
         tracing::warn!(
             "ignoring persisted netflow facet state {} due to version mismatch {} != {}",
             state_path.display(),
@@ -1252,6 +1490,13 @@ fn load_persisted_state(state_path: &Path) -> Option<PersistedFacetState> {
             FACET_STATE_VERSION
         );
         return None;
+    }
+    if persisted.version == DIRECTION_MIGRATION_SOURCE_VERSION {
+        tracing::info!(
+            "loaded netflow facet state version {} for background DIRECTION migration to version {}",
+            persisted.version,
+            FACET_STATE_VERSION
+        );
     }
     Some(persisted)
 }
@@ -1317,7 +1562,7 @@ fn merge_autocomplete_values(left: Vec<String>, right: Vec<String>) -> Vec<Strin
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flow::FlowFields;
+    use crate::flow::{FlowDirection, FlowFields};
     use allocative::size_of_unique_allocated_data;
     use journal_sdk_core::file::{JournalState, Mmap};
     use journal_sdk_core::repository::File as JournalRepositoryFile;
@@ -1417,6 +1662,64 @@ mod tests {
         }
     }
 
+    fn write_archived_direction_journal(base_dir: &Path, directions: &[FlowDirection]) -> FileInfo {
+        let machine_dir = base_dir.join("11111111-1111-1111-1111-111111111111");
+        fs::create_dir_all(&machine_dir).expect("create journal machine directory");
+        let path = machine_dir.join(
+            "system@33333333333333333333333333333333-0000000000000001-00000000000f4240.journal",
+        );
+        let repository_file =
+            JournalRepositoryFile::from_path(&path).expect("parse archived journal path");
+        let test_uuid = |seed: u8| uuid::Uuid::from_bytes([seed; 16]);
+        let mut journal_file = JournalFile::create(
+            &repository_file,
+            JournalFileOptions::new(test_uuid(1), test_uuid(2), test_uuid(3)),
+        )
+        .expect("create archived direction journal");
+        let mut writer = JournalWriter::new(&mut journal_file, 1, test_uuid(4))
+            .expect("create archived direction journal writer");
+        let mut encoded = Vec::new();
+        let mut fields = Vec::new();
+        let mut value_starts = Vec::new();
+
+        for (index, direction) in directions.iter().copied().enumerate() {
+            let mut record = FlowRecord {
+                flow_version: "netflow9",
+                protocol: 17,
+                ..FlowRecord::default()
+            };
+            record.set_direction(direction);
+            record.encode_to_journal_buf(&mut encoded, &mut fields, &mut value_starts);
+            let realtime_usec = 1_000_000 + index as u64;
+            let source_realtime = format!("_SOURCE_REALTIME_TIMESTAMP={realtime_usec}");
+            let mut payloads = fields
+                .iter()
+                .map(|field| &encoded[field.clone()])
+                .collect::<Vec<_>>();
+            payloads.push(source_realtime.as_bytes());
+            writer
+                .add_entry(
+                    &mut journal_file,
+                    &payloads,
+                    realtime_usec,
+                    1 + index as u64,
+                )
+                .expect("write archived direction journal entry");
+        }
+        drop(writer);
+        journal_file.journal_header_mut().state = JournalState::Archived as u8;
+        journal_file
+            .sync()
+            .expect("sync archived direction journal state");
+        drop(journal_file);
+
+        FileInfo {
+            file: journal_sdk_registry::repository::File::from_path(&path)
+                .expect("parse archived registry path"),
+            time_range: TimeRange::Unknown,
+        }
+    }
+
     #[test]
     fn runtime_rebuilds_global_values_after_archived_deletion() {
         let tmp = tempfile::tempdir().expect("create temp dir");
@@ -1439,10 +1742,17 @@ mod tests {
         runtime
             .observe_deleted_paths(&[PathBuf::from("/tmp/flows-a.journal")])
             .expect("delete first file");
+        let topology_generation = runtime
+            .state
+            .lock()
+            .expect("lock facet state")
+            .topology_generation;
         runtime
             .apply_reconcile_plan(
                 FacetReconcilePlan {
+                    topology_generation,
                     current_archived_paths: BTreeSet::new(),
+                    current_active_paths: BTreeSet::from([String::from("/tmp/flows-b.journal")]),
                     archived_files_to_scan: Vec::new(),
                     active_files_to_scan: Vec::new(),
                     rebuild_archived: true,
@@ -1458,6 +1768,187 @@ mod tests {
         assert!(
             !protocol.autocomplete,
             "small protocol domains should stay inline"
+        );
+    }
+
+    #[test]
+    fn reconcile_merges_scanned_active_values_with_live_updates() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new(tmp.path());
+        let active_path = tmp.path().join("flows-active.journal");
+        let active_path_str = active_path.to_string_lossy().to_string();
+        let scanned = facet_contribution_from_flow_fields(&fields_with_protocol("6"));
+        let live = facet_contribution_from_flow_fields(&fields_with_protocol("17"));
+        runtime
+            .observe_active_path_created(&active_path)
+            .expect("observe active path before reconcile scan");
+        let topology_generation = runtime
+            .state
+            .lock()
+            .expect("lock facet state")
+            .topology_generation;
+        let plan = FacetReconcilePlan {
+            topology_generation,
+            current_archived_paths: BTreeSet::new(),
+            current_active_paths: BTreeSet::from([active_path_str.clone()]),
+            archived_files_to_scan: Vec::new(),
+            active_files_to_scan: Vec::new(),
+            rebuild_archived: false,
+        };
+
+        runtime
+            .observe_active_contribution(&active_path, &live)
+            .expect("observe live update during reconcile scan");
+        assert!(
+            runtime
+                .apply_reconcile_plan(
+                    plan,
+                    BTreeMap::new(),
+                    BTreeMap::from([(active_path_str, scanned)]),
+                )
+                .expect("apply current reconcile plan")
+        );
+
+        assert_eq!(
+            runtime
+                .snapshot()
+                .fields
+                .get("PROTOCOL")
+                .expect("protocol field")
+                .values,
+            vec!["6".to_string(), "17".to_string()],
+            "a scan result must merge with values received while the scan was running"
+        );
+    }
+
+    #[test]
+    fn reconcile_rejects_a_plan_that_predates_a_new_active_path() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new(tmp.path());
+        let stale_plan = runtime.build_reconcile_plan(&[]);
+        let active_path = tmp.path().join("flows-created-during-scan.journal");
+        let live = facet_contribution_from_flow_fields(&fields_with_protocol("17"));
+
+        runtime
+            .observe_active_path_created(&active_path)
+            .expect("observe active path created during reconcile scan");
+        runtime
+            .observe_active_contribution(&active_path, &live)
+            .expect("observe first live contribution");
+        assert!(
+            !runtime
+                .apply_reconcile_plan(stale_plan, BTreeMap::new(), BTreeMap::new())
+                .expect("reject stale reconcile plan")
+        );
+
+        assert_eq!(
+            runtime
+                .snapshot()
+                .fields
+                .get("PROTOCOL")
+                .expect("protocol field")
+                .values,
+            vec!["17".to_string()],
+            "a stale scan must not remove a newly created active path"
+        );
+    }
+
+    #[test]
+    fn reconcile_preserves_lifecycle_active_path_during_registry_skew() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new(tmp.path());
+        let active_path = tmp.path().join("flows-created-before-plan.journal");
+        fs::File::create(&active_path).expect("create active journal placeholder");
+        runtime
+            .observe_active_path_created(&active_path)
+            .expect("observe active path before stale registry plan");
+        let stale_plan = runtime.build_reconcile_plan(&[]);
+        let live = facet_contribution_from_flow_fields(&fields_with_protocol("17"));
+
+        runtime
+            .observe_active_contribution(&active_path, &live)
+            .expect("observe first live contribution during scan");
+        assert!(
+            runtime
+                .apply_reconcile_plan(stale_plan, BTreeMap::new(), BTreeMap::new())
+                .expect("apply registry-skewed reconcile plan")
+        );
+
+        assert_eq!(
+            runtime
+                .snapshot()
+                .fields
+                .get("PROTOCOL")
+                .expect("protocol field")
+                .values,
+            vec!["17".to_string()],
+            "a registry snapshot older than lifecycle state must not remove the active path"
+        );
+    }
+
+    #[test]
+    fn reconcile_plan_uses_lifecycle_state_for_non_strict_active_filename() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new(tmp.path());
+        let active_path = tmp.path().join(
+            "system@22222222222222222222222222222222-\
+             0000000000000001-00000000000f4240.journal",
+        );
+        runtime
+            .observe_active_path_created(&active_path)
+            .expect("observe writer active path");
+        let file_info = FileInfo {
+            file: journal_sdk_registry::repository::File::from_path(&active_path)
+                .expect("parse non-strict writer path"),
+            time_range: TimeRange::Unknown,
+        };
+        assert!(file_info.file.is_archived(), "filename parser control");
+
+        let plan = runtime.build_reconcile_plan(&[file_info]);
+        let active_path = active_path.to_string_lossy().to_string();
+        assert!(plan.current_active_paths.contains(&active_path));
+        assert!(!plan.current_archived_paths.contains(&active_path));
+        assert_eq!(plan.active_files_to_scan.len(), 1);
+        assert!(plan.archived_files_to_scan.is_empty());
+    }
+
+    #[test]
+    fn stale_reconcile_does_not_clear_a_newer_archived_rebuild() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new(tmp.path());
+        let archived_path = tmp.path().join("flows-archived.journal");
+        let active_path = tmp.path().join("flows-active.journal");
+        let contribution = facet_contribution_from_flow_fields(&fields_with_protocol("17"));
+
+        runtime
+            .observe_active_contribution(&archived_path, &contribution)
+            .expect("observe active contribution");
+        runtime
+            .observe_rotation(&archived_path, &active_path)
+            .expect("promote archived contribution");
+        let stale_plan = runtime.build_reconcile_plan(&[]);
+
+        runtime
+            .observe_deleted_paths(std::slice::from_ref(&archived_path))
+            .expect("delete archived path during reconcile scan");
+        assert!(
+            !runtime
+                .apply_reconcile_plan(stale_plan, BTreeMap::new(), BTreeMap::new())
+                .expect("reject stale reconcile plan")
+        );
+
+        let state = runtime.state.lock().expect("lock facet state");
+        assert!(
+            state.rebuild_archived,
+            "a stale scan must not clear a newer rebuild request"
+        );
+        drop(state);
+        assert!(
+            load_persisted_state(&runtime.state_path)
+                .expect("load last clean state")
+                .indexed_archived_paths
+                .contains(archived_path.to_str().expect("UTF-8 test path")),
+            "a stale scan must not replace the last clean state on disk"
         );
     }
 
@@ -1846,6 +2337,46 @@ mod tests {
     }
 
     #[test]
+    fn pending_archived_rebuild_is_not_persisted_as_clean_state() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new(tmp.path());
+        let archived_path = tmp.path().join("deleted-before-rebuild.journal");
+        let active_path = tmp.path().join("next-active.journal");
+        let contribution = facet_contribution_from_flow_fields(&fields_with_protocol("17"));
+
+        runtime
+            .observe_active_contribution(&archived_path, &contribution)
+            .expect("observe active contribution");
+        runtime
+            .observe_rotation(&archived_path, &active_path)
+            .expect("persist archived contribution");
+        assert!(
+            load_persisted_state(&runtime.state_path)
+                .expect("load pre-deletion state")
+                .indexed_archived_paths
+                .contains(archived_path.to_str().expect("UTF-8 test path"))
+        );
+
+        runtime
+            .observe_deleted_paths(std::slice::from_ref(&archived_path))
+            .expect("mark archived path deleted");
+        let disk_state = load_persisted_state(&runtime.state_path)
+            .expect("previous clean state must remain on disk");
+        assert!(
+            disk_state
+                .indexed_archived_paths
+                .contains(archived_path.to_str().expect("UTF-8 test path")),
+            "an intermediate store containing deleted values must not replace the last clean state"
+        );
+
+        let restarted = FacetRuntime::new(tmp.path());
+        assert!(
+            restarted.build_reconcile_plan(&[]).rebuild_archived,
+            "the previous state must force a rebuild after restart"
+        );
+    }
+
+    #[test]
     fn runtime_reconcile_persists_cleared_active_contributions() {
         let tmp = tempfile::tempdir().expect("create temp dir");
         let runtime = FacetRuntime::new(tmp.path());
@@ -1864,10 +2395,17 @@ mod tests {
             "setup should persist the active published facet"
         );
 
+        let topology_generation = runtime
+            .state
+            .lock()
+            .expect("lock facet state")
+            .topology_generation;
         runtime
             .apply_reconcile_plan(
                 FacetReconcilePlan {
+                    topology_generation,
                     current_archived_paths: BTreeSet::new(),
+                    current_active_paths: BTreeSet::new(),
                     archived_files_to_scan: Vec::new(),
                     active_files_to_scan: Vec::new(),
                     rebuild_archived: false,
@@ -2005,11 +2543,8 @@ mod tests {
     fn runtime_rebuilds_legacy_fragment_facets_once() {
         const LEGACY_FACET_STATE_VERSION: u32 = 5;
 
-        assert_eq!(
-            FACET_STATE_VERSION,
-            LEGACY_FACET_STATE_VERSION + 1,
-            "the fixture must represent the immediately preceding facet-state format"
-        );
+        assert_eq!(LEGACY_FACET_STATE_VERSION, 5);
+        assert!(LEGACY_FACET_STATE_VERSION < FACET_STATE_VERSION);
 
         let tmp = tempfile::tempdir().expect("create temp dir");
         let file_info = write_archived_fragment_journal(tmp.path(), &[42, 70_000]);
@@ -2136,6 +2671,256 @@ mod tests {
                 .expect("reloaded fragment ID field")
                 .values,
             vec!["42".to_string(), "70000".to_string()]
+        );
+    }
+
+    #[test]
+    fn runtime_migrates_only_v6_direction_from_a_real_archived_journal() {
+        const NUMERIC_DIRECTION_STATE_VERSION: u32 = 6;
+
+        assert_eq!(
+            FACET_STATE_VERSION,
+            NUMERIC_DIRECTION_STATE_VERSION + 1,
+            "direction's facet-kind change requires one state-version bump"
+        );
+
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let file_info = write_archived_direction_journal(
+            tmp.path(),
+            &[FlowDirection::Ingress, FlowDirection::Egress],
+        );
+        let archived_path = file_info.file.path().to_string();
+        let state_path = tmp.path().join(FACET_STATE_FILE_NAME);
+        let old_state = PersistedFacetState {
+            version: NUMERIC_DIRECTION_STATE_VERSION,
+            indexed_archived_paths: BTreeSet::from([archived_path.clone()]),
+            archived_fields: BTreeMap::from([
+                (
+                    "DIRECTION".to_string(),
+                    PersistedFacetStore::DenseU8(vec![0]),
+                ),
+                (
+                    "PROTOCOL".to_string(),
+                    PersistedFacetStore::DenseU8(vec![17]),
+                ),
+            ]),
+            published: BTreeMap::from([
+                (
+                    "DIRECTION".to_string(),
+                    FacetPublishedField {
+                        total_values: 1,
+                        autocomplete: false,
+                        values: vec!["0".to_string()],
+                    },
+                ),
+                (
+                    "PROTOCOL".to_string(),
+                    FacetPublishedField {
+                        total_values: 1,
+                        autocomplete: false,
+                        values: vec!["17".to_string()],
+                    },
+                ),
+            ]),
+        };
+        persist_state_snapshot(
+            &state_path,
+            &encode_persisted_facet_state(&old_state).expect("encode v6 facet state"),
+        )
+        .expect("persist v6 facet state");
+
+        let runtime = FacetRuntime::new(tmp.path());
+        assert!(
+            runtime.is_ready(),
+            "compatible v6 state must remain queryable during migration"
+        );
+        assert!(runtime.direction_migration_pending());
+        assert_eq!(
+            runtime
+                .snapshot()
+                .fields
+                .get("DIRECTION")
+                .expect("direction field")
+                .total_values,
+            0
+        );
+        assert_eq!(
+            runtime
+                .snapshot()
+                .fields
+                .get("PROTOCOL")
+                .expect("preserved protocol field")
+                .values,
+            vec!["17".to_string()]
+        );
+        let plan = runtime.build_reconcile_plan(std::slice::from_ref(&file_info));
+        assert!(
+            plan.archived_files_to_scan.is_empty(),
+            "the compatible archived fields must not be rebuilt at startup"
+        );
+
+        let mut active_fields = FlowFields::new();
+        active_fields.insert("DIRECTION", "egress".to_string());
+        active_fields.insert("PROTOCOL", "6".to_string());
+        active_fields.insert("SRC_AS_NAME", "AS64512 EXAMPLE".to_string());
+        runtime
+            .observe_active_contribution(
+                Path::new("/tmp/active-during-direction-migration.journal"),
+                &facet_contribution_from_flow_fields(&active_fields),
+            )
+            .expect("observe live contribution during migration");
+        runtime
+            .persist_if_dirty()
+            .expect("skip persistence while migration is pending");
+        assert_eq!(
+            load_persisted_state(&state_path)
+                .expect("reload original v6 state")
+                .version,
+            NUMERIC_DIRECTION_STATE_VERSION,
+            "v7 must not be persisted before the archived scan succeeds"
+        );
+
+        let direction_scan =
+            scan_registry_file_contribution_for_fields(&file_info, &["DIRECTION".to_string()])
+                .expect("scan archived DIRECTION through the production reader");
+        assert!(
+            runtime
+                .complete_direction_migration(
+                    &BTreeSet::from([archived_path.clone()]),
+                    BTreeMap::from([(archived_path.clone(), direction_scan)]),
+                )
+                .expect("apply DIRECTION migration")
+        );
+
+        let migrated = runtime.snapshot();
+        assert_eq!(
+            migrated
+                .fields
+                .get("DIRECTION")
+                .expect("migrated direction")
+                .values,
+            vec!["egress".to_string(), "ingress".to_string()]
+        );
+        assert_eq!(
+            migrated
+                .fields
+                .get("PROTOCOL")
+                .expect("compatible and live protocols")
+                .values,
+            vec!["6".to_string(), "17".to_string()]
+        );
+        assert_eq!(
+            migrated
+                .fields
+                .get("SRC_AS_NAME")
+                .expect("live field")
+                .values,
+            vec!["AS64512 EXAMPLE".to_string()],
+            "targeted migration must preserve live contributions"
+        );
+        let persisted = load_persisted_state(&state_path).expect("load migrated v7 state");
+        assert_eq!(persisted.version, FACET_STATE_VERSION);
+        assert!(matches!(
+            persisted.archived_fields.get("PROTOCOL"),
+            Some(PersistedFacetStore::DenseU8(values)) if values == &[17]
+        ));
+
+        let restarted = FacetRuntime::new(tmp.path());
+        assert!(restarted.is_ready());
+        assert!(!restarted.direction_migration_pending());
+        assert!(
+            restarted
+                .build_reconcile_plan(&[file_info])
+                .archived_files_to_scan
+                .is_empty(),
+            "v7 restart must not scan the retained journal again"
+        );
+    }
+
+    #[test]
+    fn direction_migration_retries_when_archived_paths_change() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let state_path = tmp.path().join(FACET_STATE_FILE_NAME);
+        let original_path = "/tmp/original-direction.journal".to_string();
+        let old_state = PersistedFacetState {
+            version: DIRECTION_MIGRATION_SOURCE_VERSION,
+            indexed_archived_paths: BTreeSet::from([original_path.clone()]),
+            archived_fields: BTreeMap::from([(
+                "PROTOCOL".to_string(),
+                PersistedFacetStore::DenseU8(vec![17]),
+            )]),
+            published: BTreeMap::new(),
+        };
+        persist_state_snapshot(
+            &state_path,
+            &encode_persisted_facet_state(&old_state).expect("encode v6 facet state"),
+        )
+        .expect("persist v6 facet state");
+        let runtime = FacetRuntime::new(tmp.path());
+        let original_scan = facet_contribution_from_flow_fields(&FlowFields::from([(
+            "DIRECTION",
+            "ingress".to_string(),
+        )]));
+
+        let rotated_path = Path::new("/tmp/rotated-direction.journal");
+        runtime
+            .observe_active_contribution(
+                rotated_path,
+                &facet_contribution_from_flow_fields(&FlowFields::from([(
+                    "DIRECTION",
+                    "egress".to_string(),
+                )])),
+            )
+            .expect("observe concurrent active journal");
+        runtime
+            .observe_rotation(rotated_path, Path::new("/tmp/next-direction.journal"))
+            .expect("rotate journal during migration");
+
+        assert!(
+            !runtime
+                .complete_direction_migration(
+                    &BTreeSet::from([original_path.clone()]),
+                    BTreeMap::from([(original_path, original_scan)]),
+                )
+                .expect("reject stale migration scan")
+        );
+        assert!(runtime.direction_migration_pending());
+        assert_eq!(
+            load_persisted_state(&state_path)
+                .expect("reload original state after retry")
+                .version,
+            DIRECTION_MIGRATION_SOURCE_VERSION
+        );
+    }
+
+    #[test]
+    fn empty_v6_direction_migration_persists_v7_without_a_journal_scan() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let state_path = tmp.path().join(FACET_STATE_FILE_NAME);
+        let old_state = PersistedFacetState {
+            version: DIRECTION_MIGRATION_SOURCE_VERSION,
+            indexed_archived_paths: BTreeSet::new(),
+            archived_fields: BTreeMap::new(),
+            published: BTreeMap::new(),
+        };
+        persist_state_snapshot(
+            &state_path,
+            &encode_persisted_facet_state(&old_state).expect("encode empty v6 facet state"),
+        )
+        .expect("persist empty v6 facet state");
+        let runtime = FacetRuntime::new(tmp.path());
+
+        assert!(
+            runtime
+                .complete_direction_migration(&BTreeSet::new(), BTreeMap::new())
+                .expect("complete empty DIRECTION migration")
+        );
+        assert!(!runtime.direction_migration_pending());
+        assert_eq!(
+            load_persisted_state(&state_path)
+                .expect("load empty migrated state")
+                .version,
+            FACET_STATE_VERSION
         );
     }
 
@@ -2348,7 +3133,7 @@ mod tests {
 
         // Two journals, each promoted to sidecar by inserting >FACET_VALUE_LIMIT
         // distinct values. Each sidecar has only 30 entries that match the
-        // search term, so neither alone can fill FACET_AUTOCOMPLETE_LIMIT (100)
+        // search term, so neither alone can fill FACET_AUTOCOMPLETE_LIMIT (256)
         // and the loop must reach both sidecars.
         let paths = [
             Path::new("/tmp/flows-multi-a.journal"),
@@ -2419,6 +3204,33 @@ mod tests {
             5,
             "empty term must surface every value (limited by FACET_AUTOCOMPLETE_LIMIT); got {results:?}"
         );
+    }
+
+    #[test]
+    fn runtime_autocomplete_returns_up_to_256_unique_values() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new(tmp.path());
+        let active_path = Path::new("/tmp/flows-autocomplete-limit.journal");
+
+        for asn in 0..300u32 {
+            let mut fields = FlowFields::new();
+            fields.insert("SRC_AS_NAME", format!("AS{asn:05} Provider-{asn:03}"));
+            runtime
+                .observe_active_contribution(
+                    active_path,
+                    &facet_contribution_from_flow_fields(&fields),
+                )
+                .expect("observe contribution");
+        }
+
+        let results = runtime
+            .autocomplete("SRC_AS_NAME", "")
+            .expect("autocomplete values");
+        let unique = results.iter().collect::<BTreeSet<_>>();
+
+        assert_eq!(FACET_AUTOCOMPLETE_LIMIT, 256);
+        assert_eq!(results.len(), FACET_AUTOCOMPLETE_LIMIT);
+        assert_eq!(unique.len(), FACET_AUTOCOMPLETE_LIMIT);
     }
 
     #[test]
@@ -2630,5 +3442,82 @@ mod tests {
                 field, kind, len, estimated, allocative_bytes
             );
         }
+    }
+
+    #[test]
+    #[ignore = "manual production-data sidecar retention metadata benchmark"]
+    fn stress_profile_live_sidecar_retention_metadata() {
+        let base_dir = std::env::var_os("NETFLOW_PROFILE_BASE_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/var/cache/netdata/flows"));
+        let rounds = std::env::var("NETFLOW_SIDECAR_BENCH_ROUNDS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|rounds| *rounds > 0)
+            .unwrap_or(10);
+        let mut pending = vec![base_dir];
+        let mut journal_paths = Vec::new();
+        while let Some(directory) = pending.pop() {
+            for entry in fs::read_dir(&directory)
+                .unwrap_or_else(|error| panic!("read {}: {error}", directory.display()))
+            {
+                let entry = entry.expect("read directory entry");
+                let file_type = entry.file_type().expect("read directory entry type");
+                let path = entry.path();
+                if file_type.is_dir() {
+                    pending.push(path);
+                } else if path
+                    .extension()
+                    .is_some_and(|extension| extension == "journal")
+                {
+                    journal_paths.push(path);
+                }
+            }
+        }
+        assert!(!journal_paths.is_empty(), "no journal files to benchmark");
+
+        let sidecar_fields = FACET_FIELD_SPECS
+            .iter()
+            .filter(|spec| spec.uses_sidecar)
+            .count();
+        let metadata_calls = journal_paths.len().saturating_mul(sidecar_fields);
+        let mut elapsed = Vec::with_capacity(rounds);
+        let mut measured_bytes = None;
+        for _ in 0..rounds {
+            let started = std::time::Instant::now();
+            let bytes = journal_paths.iter().fold(0_u64, |total, path| {
+                total.saturating_add(
+                    sidecar::journal_sidecar_bytes(path).expect("measure journal sidecars"),
+                )
+            });
+            elapsed.push(started.elapsed());
+            match measured_bytes {
+                Some(previous) => assert_eq!(bytes, previous, "sidecar bytes changed during run"),
+                None => measured_bytes = Some(bytes),
+            }
+        }
+        elapsed.sort_unstable();
+        let min = elapsed[0];
+        let median = elapsed[elapsed.len() / 2];
+        let max = elapsed[elapsed.len() - 1];
+        let median_ns_per_call = if metadata_calls == 0 {
+            0
+        } else {
+            median.as_nanos() / metadata_calls as u128
+        };
+
+        eprintln!(
+            "sidecar retention metadata: journals={} fields={} calls_per_round={} \
+             artifact_bytes={} rounds={} min_us={} median_us={} max_us={} median_ns_per_call={}",
+            journal_paths.len(),
+            sidecar_fields,
+            metadata_calls,
+            measured_bytes.unwrap_or(0),
+            rounds,
+            min.as_micros(),
+            median.as_micros(),
+            max.as_micros(),
+            median_ns_per_call,
+        );
     }
 }

--- a/src/crates/netflow-plugin/src/facet_runtime.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime.rs
@@ -24,6 +24,7 @@ use std::mem::size_of;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
+use tokio_util::sync::CancellationToken;
 use twox_hash::XxHash64;
 
 #[allow(unused_imports)]
@@ -890,6 +891,33 @@ pub(crate) fn scan_registry_file_contribution_for_fields(
     file_info: &FileInfo,
     requested_fields: &[String],
 ) -> Result<FacetFileContribution> {
+    scan_registry_file_contribution_for_fields_with_check(file_info, requested_fields, &mut || {
+        Ok(())
+    })
+}
+
+pub(crate) fn scan_registry_file_contribution_for_fields_cancellable(
+    file_info: &FileInfo,
+    requested_fields: &[String],
+    cancellation: &CancellationToken,
+) -> Result<FacetFileContribution> {
+    scan_registry_file_contribution_for_fields_with_check(file_info, requested_fields, &mut || {
+        if cancellation.is_cancelled() {
+            bail!("facet contribution scan cancelled");
+        }
+        Ok(())
+    })
+}
+
+fn scan_registry_file_contribution_for_fields_with_check<F>(
+    file_info: &FileInfo,
+    requested_fields: &[String],
+    check_cancelled: &mut F,
+) -> Result<FacetFileContribution>
+where
+    F: FnMut() -> Result<()>,
+{
+    check_cancelled()?;
     let simple_fields = requested_fields
         .iter()
         .filter(|field| !facet_field_requires_protocol_scan(field))
@@ -904,13 +932,18 @@ pub(crate) fn scan_registry_file_contribution_for_fields(
                 file_info.file.path()
             )
         })?;
-    accumulate_simple_closed_file_facet_values(&journal, &simple_fields, &mut values)
-        .with_context(|| {
-            format!(
-                "failed to enumerate simple facet values from {}",
-                file_info.file.path()
-            )
-        })?;
+    accumulate_simple_closed_file_facet_values(
+        &journal,
+        &simple_fields,
+        &mut values,
+        check_cancelled,
+    )
+    .with_context(|| {
+        format!(
+            "failed to enumerate simple facet values from {}",
+            file_info.file.path()
+        )
+    })?;
     if requested_fields.iter().any(|field| field == "ICMPV4") {
         accumulate_targeted_facet_values(
             std::slice::from_ref(&file_path),
@@ -918,6 +951,7 @@ pub(crate) fn scan_registry_file_contribution_for_fields(
             &[("PROTOCOL".to_string(), "1".to_string())],
             virtual_flow_field_dependencies("ICMPV4"),
             &mut values,
+            check_cancelled,
         )
         .with_context(|| {
             format!(
@@ -933,6 +967,7 @@ pub(crate) fn scan_registry_file_contribution_for_fields(
             &[("PROTOCOL".to_string(), "58".to_string())],
             virtual_flow_field_dependencies("ICMPV6"),
             &mut values,
+            check_cancelled,
         )
         .with_context(|| {
             format!(
@@ -1604,6 +1639,7 @@ mod tests {
     use journal_sdk_core::repository::File as JournalRepositoryFile;
     use journal_sdk_core::{JournalFile, JournalFileOptions, JournalWriter};
     use journal_sdk_registry::TimeRange;
+    use std::cell::Cell;
     use std::sync::Arc;
     use std::sync::MutexGuard;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1754,6 +1790,36 @@ mod tests {
                 .expect("parse archived registry path"),
             time_range: TimeRange::Unknown,
         }
+    }
+
+    #[test]
+    fn archived_facet_scan_checks_cancellation_inside_a_journal() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let file_info = write_archived_direction_journal(
+            tmp.path(),
+            &[FlowDirection::Ingress, FlowDirection::Egress],
+        );
+        let checks = Cell::new(0);
+
+        let err = scan_registry_file_contribution_for_fields_with_check(
+            &file_info,
+            &["DIRECTION".to_string()],
+            &mut || {
+                let next = checks.get() + 1;
+                checks.set(next);
+                if next >= 4 {
+                    bail!("test cancellation");
+                }
+                Ok(())
+            },
+        )
+        .expect_err("the scan should stop between field data objects");
+
+        assert_eq!(checks.get(), 4);
+        assert!(
+            format!("{err:#}").contains("test cancellation"),
+            "the cancellation error should escape the journal scan: {err:#}"
+        );
     }
 
     #[test]

--- a/src/crates/netflow-plugin/src/facet_runtime.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime.rs
@@ -9,9 +9,9 @@ use crate::facet_catalog::{
 use crate::flow::FlowRecord;
 use crate::memory_estimation::btree_container_overhead_bytes;
 use crate::query::{
-    FACET_CACHE_JOURNAL_WINDOW_SIZE, FACET_VALUE_LIMIT, accumulate_simple_closed_file_facet_values,
-    accumulate_targeted_facet_values, facet_field_requires_protocol_scan,
-    virtual_flow_field_dependencies,
+    FACET_CACHE_JOURNAL_WINDOW_SIZE, FACET_STATIC_VALUE_LIMIT,
+    accumulate_simple_closed_file_facet_values, accumulate_targeted_facet_values,
+    facet_field_requires_protocol_scan, virtual_flow_field_dependencies,
 };
 use anyhow::{Context, Result, bail};
 use journal_sdk_core::file::JournalFileMap;
@@ -792,12 +792,12 @@ impl FacetState {
             version,
             indexed_archived_paths,
             archived_fields: mut persisted_archived_fields,
-            mut published,
+            published: mut persisted_published,
         } = persisted;
         let direction_migration_pending = version == DIRECTION_MIGRATION_SOURCE_VERSION;
         if direction_migration_pending {
             persisted_archived_fields.remove("DIRECTION");
-            published.remove("DIRECTION");
+            persisted_published.remove("DIRECTION");
         }
         let mut archived_fields = empty_field_stores();
         for (field, saved) in persisted_archived_fields {
@@ -810,19 +810,55 @@ impl FacetState {
             );
         }
 
-        let mut published = if published.is_empty() {
-            published_snapshot_from_archived_and_active_contributions(
-                &archived_fields,
-                &BTreeMap::new(),
-            )
-        } else {
-            FacetPublishedSnapshot { fields: published }
-        };
-        if direction_migration_pending {
-            published.fields.insert(
-                "DIRECTION".to_string(),
-                published_field_from_store(archived_fields.get("DIRECTION")),
-            );
+        // Published values include active journals, whose contributions are
+        // rebuilt immediately after startup. Reuse only internally complete
+        // persisted fields, and derive everything else from archived stores so
+        // presentation-threshold changes take effect safely after an upgrade.
+        let mut published = published_snapshot_from_archived_and_active_contributions(
+            &archived_fields,
+            &BTreeMap::new(),
+        );
+        for (field, saved) in persisted_published {
+            if facet_field_spec(field.as_str()).is_none() {
+                continue;
+            }
+            let Some(archived) = published.fields.get(field.as_str()) else {
+                continue;
+            };
+            if saved.total_values < archived.total_values {
+                continue;
+            }
+
+            if saved.total_values > FACET_STATIC_VALUE_LIMIT {
+                published.fields.insert(
+                    field,
+                    FacetPublishedField {
+                        total_values: saved.total_values,
+                        autocomplete: true,
+                        values: Vec::new(),
+                    },
+                );
+                continue;
+            }
+
+            let mut values = saved.values;
+            values.sort_unstable();
+            values.dedup();
+            let complete = values.len() == saved.total_values
+                && archived
+                    .values
+                    .iter()
+                    .all(|value| values.binary_search(value).is_ok());
+            if complete {
+                published.fields.insert(
+                    field,
+                    FacetPublishedField {
+                        total_values: saved.total_values,
+                        autocomplete: false,
+                        values,
+                    },
+                );
+            }
         }
 
         Self {
@@ -961,7 +997,7 @@ fn published_snapshot_from_archived_and_active_contributions(
             }
         }
         let total_values = combined.len();
-        let autocomplete = total_values > FACET_VALUE_LIMIT;
+        let autocomplete = total_values > FACET_STATIC_VALUE_LIMIT;
         let values = if autocomplete {
             Vec::new()
         } else {
@@ -982,7 +1018,7 @@ fn published_snapshot_from_archived_and_active_contributions(
 
 fn published_field_from_store(store: Option<&FacetStore>) -> FacetPublishedField {
     let total_values = store.map(FacetStore::len).unwrap_or_default();
-    let autocomplete = total_values > FACET_VALUE_LIMIT;
+    let autocomplete = total_values > FACET_STATIC_VALUE_LIMIT;
     let values = if autocomplete {
         Vec::new()
     } else {
@@ -1016,7 +1052,7 @@ fn apply_new_active_value_to_published(
         .or_insert_with(FacetPublishedField::default);
 
     entry.total_values = entry.total_values.saturating_add(1);
-    if entry.total_values > FACET_VALUE_LIMIT {
+    if entry.total_values > FACET_STATIC_VALUE_LIMIT {
         entry.autocomplete = true;
         entry.values.clear();
         return;
@@ -2008,7 +2044,7 @@ mod tests {
             )
             .expect("observe protocol contribution");
 
-        for asn in 0..=FACET_VALUE_LIMIT {
+        for asn in 0..=FACET_STATIC_VALUE_LIMIT {
             let mut fields = FlowFields::new();
             fields.insert("SRC_AS_NAME", format!("AS{asn:05} Provider-{asn:03}"));
             runtime
@@ -2023,7 +2059,7 @@ mod tests {
             runtime.cardinality_snapshot(),
             FacetCardinalitySnapshot {
                 populated_fields: 2,
-                total_values: (FACET_VALUE_LIMIT as u64) + 2,
+                total_values: (FACET_STATIC_VALUE_LIMIT as u64) + 2,
                 exposed_values: 1,
                 autocomplete_fields: 1,
             }
@@ -2034,7 +2070,7 @@ mod tests {
     fn archive_only_published_rebuild_uses_archived_values_and_autocomplete_threshold() {
         let mut archived_fields = empty_field_stores();
 
-        for asn in 0..=FACET_VALUE_LIMIT {
+        for asn in 0..=FACET_STATIC_VALUE_LIMIT {
             let mut fields = FlowFields::new();
             fields.insert("SRC_AS_NAME", format!("AS{asn:05} Provider-{asn:03}"));
             merge_global_contribution(
@@ -2052,7 +2088,7 @@ mod tests {
             .get("SRC_AS_NAME")
             .expect("src as name field");
 
-        assert_eq!(src_as_name.total_values, FACET_VALUE_LIMIT + 1);
+        assert_eq!(src_as_name.total_values, FACET_STATIC_VALUE_LIMIT + 1);
         assert!(
             src_as_name.autocomplete,
             "archive-only rebuild must preserve autocomplete promotion"
@@ -2061,6 +2097,106 @@ mod tests {
             src_as_name.values.is_empty(),
             "autocomplete-promoted archive-only fields must not publish inline values"
         );
+    }
+
+    #[test]
+    fn persisted_state_rebuilds_derived_presentation_metadata() {
+        const ARCHIVED_VALUES: usize = 100;
+        let retained_values = (0..ARCHIVED_VALUES)
+            .map(|asn| format!("AS{asn:05} Provider-{asn:03}"))
+            .collect::<Vec<_>>();
+        let mut state = FacetState::from_persisted(PersistedFacetState {
+            version: FACET_STATE_VERSION,
+            indexed_archived_paths: BTreeSet::new(),
+            archived_fields: BTreeMap::from([(
+                "SRC_AS_NAME".to_string(),
+                PersistedFacetStore::Text(retained_values),
+            )]),
+            published: BTreeMap::from([(
+                "SRC_AS_NAME".to_string(),
+                FacetPublishedField {
+                    total_values: FACET_STATIC_VALUE_LIMIT,
+                    autocomplete: true,
+                    values: Vec::new(),
+                },
+            )]),
+        });
+
+        let src_as_name = state
+            .published
+            .fields
+            .get("SRC_AS_NAME")
+            .expect("src as name field");
+        assert_eq!(src_as_name.total_values, ARCHIVED_VALUES);
+        assert!(!src_as_name.autocomplete);
+        assert_eq!(src_as_name.values.len(), ARCHIVED_VALUES);
+
+        let mut active_contribution = FacetFileContribution::default();
+        for asn in ARCHIVED_VALUES..FACET_STATIC_VALUE_LIMIT {
+            active_contribution
+                .insert_text_static("SRC_AS_NAME", &format!("AS{asn:05} Provider-{asn:03}"));
+        }
+        state.active_contributions.insert(
+            "/tmp/flows-threshold-active.journal".to_string(),
+            active_contribution,
+        );
+        rebuild_published_fields(&mut state);
+
+        let rebuilt = state
+            .published
+            .fields
+            .get("SRC_AS_NAME")
+            .expect("rebuilt src as name field");
+        assert_eq!(rebuilt.total_values, FACET_STATIC_VALUE_LIMIT);
+        assert!(!rebuilt.autocomplete);
+        assert_eq!(rebuilt.values.len(), FACET_STATIC_VALUE_LIMIT);
+    }
+
+    #[test]
+    fn published_snapshot_promotes_and_demotes_with_retained_cardinality() {
+        let mut promoted_contribution = FacetFileContribution::default();
+        for asn in 0..=FACET_STATIC_VALUE_LIMIT {
+            promoted_contribution
+                .insert_text_static("SRC_AS_NAME", &format!("AS{asn:05} Provider-{asn:03}"));
+        }
+        let mut active_contributions = BTreeMap::from([(
+            "/tmp/flows-threshold.journal".to_string(),
+            promoted_contribution,
+        )]);
+
+        let promoted = published_snapshot_from_archived_and_active_contributions(
+            &empty_field_stores(),
+            &active_contributions,
+        );
+        let promoted_field = promoted
+            .fields
+            .get("SRC_AS_NAME")
+            .expect("promoted src as name");
+        assert_eq!(promoted_field.total_values, FACET_STATIC_VALUE_LIMIT + 1);
+        assert!(promoted_field.autocomplete);
+        assert!(promoted_field.values.is_empty());
+
+        let mut demoted_contribution = FacetFileContribution::default();
+        for asn in 0..FACET_STATIC_VALUE_LIMIT {
+            demoted_contribution
+                .insert_text_static("SRC_AS_NAME", &format!("AS{asn:05} Provider-{asn:03}"));
+        }
+        active_contributions.insert(
+            "/tmp/flows-threshold.journal".to_string(),
+            demoted_contribution,
+        );
+
+        let demoted = published_snapshot_from_archived_and_active_contributions(
+            &empty_field_stores(),
+            &active_contributions,
+        );
+        let demoted_field = demoted
+            .fields
+            .get("SRC_AS_NAME")
+            .expect("demoted src as name");
+        assert_eq!(demoted_field.total_values, FACET_STATIC_VALUE_LIMIT);
+        assert!(!demoted_field.autocomplete);
+        assert_eq!(demoted_field.values.len(), FACET_STATIC_VALUE_LIMIT);
     }
 
     #[test]
@@ -2431,19 +2567,20 @@ mod tests {
     fn runtime_autocomplete_reads_promoted_archived_sidecar_values() {
         let tmp = tempfile::tempdir().expect("create temp dir");
         let runtime = FacetRuntime::new(tmp.path());
-        let archived_path = Path::new("/tmp/flows-promoted.journal");
+        let archived_path = tmp.path().join("flows-promoted.journal");
+        let active_path = tmp.path().join("flows-promoted-next.journal");
 
-        for value in 0..120 {
+        for value in 0..=FACET_STATIC_VALUE_LIMIT {
             let mut fields = FlowFields::new();
             fields.insert("SRC_AS_NAME", format!("AS{value:03} EXAMPLE"));
             let contribution = facet_contribution_from_flow_fields(&fields);
             runtime
-                .observe_active_contribution(archived_path, &contribution)
+                .observe_active_contribution(&archived_path, &contribution)
                 .expect("observe contribution");
         }
 
         runtime
-            .observe_rotation(archived_path, Path::new("/tmp/flows-promoted-next.journal"))
+            .observe_rotation(&archived_path, &active_path)
             .expect("rotate file");
 
         let results = runtime
@@ -2970,7 +3107,7 @@ mod tests {
         let runtime = FacetRuntime::new_read_only(tmp.path());
         let archived_path = tmp.path().join("flows-promoted.journal");
 
-        for value in 0..120 {
+        for value in 0..=FACET_STATIC_VALUE_LIMIT {
             let mut fields = FlowFields::new();
             fields.insert("SRC_AS_NAME", format!("AS{value:03} EXAMPLE"));
             let contribution = facet_contribution_from_flow_fields(&fields);
@@ -3011,7 +3148,7 @@ mod tests {
         let archived_path = tmp.path().join("flows-promoted.journal");
         let runtime = FacetRuntime::new(tmp.path());
 
-        for value in 0..120 {
+        for value in 0..=FACET_STATIC_VALUE_LIMIT {
             let mut fields = FlowFields::new();
             fields.insert("SRC_AS_NAME", format!("AS{value:03} EXAMPLE"));
             let contribution = facet_contribution_from_flow_fields(&fields);
@@ -3092,24 +3229,22 @@ mod tests {
     fn runtime_autocomplete_text_substring_survives_archive_promotion() {
         let tmp = tempfile::tempdir().expect("create temp dir");
         let runtime = FacetRuntime::new(tmp.path());
-        let archived_path = Path::new("/tmp/flows-substring-archived.journal");
+        let archived_path = tmp.path().join("flows-substring-archived.journal");
+        let active_path = tmp.path().join("flows-substring-archived-next.journal");
 
-        for asn in 0..120u32 {
+        for asn in 0..=FACET_STATIC_VALUE_LIMIT as u32 {
             let mut fields = FlowFields::new();
             fields.insert("SRC_AS_NAME", format!("AS{asn:05} Akamai-{asn:03}"));
             runtime
                 .observe_active_contribution(
-                    archived_path,
+                    &archived_path,
                     &facet_contribution_from_flow_fields(&fields),
                 )
                 .expect("observe contribution");
         }
 
         runtime
-            .observe_rotation(
-                archived_path,
-                Path::new("/tmp/flows-substring-archived-next.journal"),
-            )
+            .observe_rotation(&archived_path, &active_path)
             .expect("rotate file");
 
         let results = runtime
@@ -3131,16 +3266,16 @@ mod tests {
         let tmp = tempfile::tempdir().expect("create temp dir");
         let runtime = FacetRuntime::new(tmp.path());
 
-        // Two journals, each promoted to sidecar by inserting >FACET_VALUE_LIMIT
+        // Two journals, each promoted to sidecar by exceeding the static-value limit.
         // distinct values. Each sidecar has only 30 entries that match the
         // search term, so neither alone can fill FACET_AUTOCOMPLETE_LIMIT (256)
         // and the loop must reach both sidecars.
         let paths = [
-            Path::new("/tmp/flows-multi-a.journal"),
-            Path::new("/tmp/flows-multi-b.journal"),
+            tmp.path().join("flows-multi-a.journal"),
+            tmp.path().join("flows-multi-b.journal"),
         ];
         for (idx, journal_path) in paths.iter().enumerate() {
-            for asn in 0..120u32 {
+            for asn in 0..=FACET_STATIC_VALUE_LIMIT as u32 {
                 let mut fields = FlowFields::new();
                 let unique_asn = asn + (idx as u32) * 1000;
                 let label = if asn < 30 {
@@ -3156,11 +3291,9 @@ mod tests {
                     )
                     .expect("observe contribution");
             }
+            let active_path = tmp.path().join(format!("flows-multi-{idx}-rot.journal"));
             runtime
-                .observe_rotation(
-                    journal_path,
-                    Path::new(&format!("/tmp/flows-multi-{idx}-rot.journal")),
-                )
+                .observe_rotation(journal_path, &active_path)
                 .expect("rotate file");
         }
 
@@ -3260,9 +3393,8 @@ mod tests {
         let runtime = FacetRuntime::new(tmp.path());
         let archived_path = Path::new("/tmp/flows-threshold.journal");
 
-        // FACET_VALUE_LIMIT == 100; promotion fires only when total_values > 100.
-        // Insert exactly 100 values: should NOT promote, archived in-memory store wins.
-        for asn in 0..100u32 {
+        // Promotion fires only after the complete static vocabulary no longer fits.
+        for asn in 0..FACET_STATIC_VALUE_LIMIT as u32 {
             let mut fields = FlowFields::new();
             fields.insert("SRC_AS_NAME", format!("AS{asn:05} Provider-{asn:03}"));
             runtime

--- a/src/crates/netflow-plugin/src/facet_runtime.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime.rs
@@ -14,6 +14,7 @@ use crate::query::{
     facet_field_requires_protocol_scan, virtual_flow_field_dependencies,
 };
 use anyhow::{Context, Result, bail};
+use ipnet::IpNet;
 use journal_sdk_core::file::JournalFileMap;
 use journal_sdk_registry::FileInfo;
 use serde::{Deserialize, Serialize};
@@ -715,6 +716,41 @@ impl FacetRuntime {
 
         Ok(matches)
     }
+
+    /// Returns per-network presence in the retention-wide typed facet vocabulary.
+    /// This path must remain independent of journal and tier scans.
+    pub(crate) fn retained_ip_network_presence(
+        &self,
+        field: &str,
+        networks: &[IpNet],
+    ) -> Result<Vec<bool>> {
+        if networks.is_empty() {
+            return Ok(Vec::new());
+        }
+        let normalized = field.trim().to_ascii_uppercase();
+        if !facet_field_spec(&normalized).is_some_and(|spec| spec.kind == FacetValueKind::IpAddr) {
+            return Ok(vec![false; networks.len()]);
+        }
+
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("facet runtime lock poisoned"))?;
+        let mut matched = vec![false; networks.len()];
+        if let Some(store) = state.archived_fields.get(normalized.as_str()) {
+            store.mark_matching_ip_networks(networks, &mut matched);
+        }
+        for contribution in state.active_contributions.values() {
+            if matched.iter().all(|matched| *matched) {
+                break;
+            }
+            if let Some(store) = contribution.field(normalized.as_str()) {
+                store.mark_matching_ip_networks(networks, &mut matched);
+            }
+        }
+        Ok(matched)
+    }
+
     fn mark_ready(&self) {
         self.ready.store(true, Ordering::Release);
     }
@@ -3514,6 +3550,84 @@ mod tests {
         assert!(
             middle_octet_miss.is_empty(),
             "IP autocomplete must remain prefix-only; got {middle_octet_miss:?}"
+        );
+    }
+
+    #[test]
+    fn runtime_retained_ip_network_presence_matches_active_and_archived_values_by_field_and_family()
+    {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new(tmp.path());
+        let archived_path = tmp.path().join("flows-ip-networks.journal");
+        let active_path = tmp.path().join("flows-ip-networks-next.journal");
+
+        let mut archived_fields = FlowFields::new();
+        archived_fields.insert("SRC_ADDR", "10.42.1.9".to_string());
+        archived_fields.insert("DST_ADDR", "2001:db8:1::9".to_string());
+        runtime
+            .observe_active_contribution(
+                &archived_path,
+                &facet_contribution_from_flow_fields(&archived_fields),
+            )
+            .expect("observe archived IP contribution");
+        runtime
+            .observe_rotation(&archived_path, &active_path)
+            .expect("rotate IP contribution");
+
+        let mut active_fields = FlowFields::new();
+        active_fields.insert("SRC_ADDR", "2001:db8:2::7".to_string());
+        active_fields.insert("DST_ADDR", "192.0.2.20".to_string());
+        runtime
+            .observe_active_contribution(
+                &active_path,
+                &facet_contribution_from_flow_fields(&active_fields),
+            )
+            .expect("observe active IP contribution");
+
+        let networks = [
+            "10.0.0.0/8",
+            "192.0.2.0/24",
+            "2001:db8:1::/48",
+            "2001:db8:2::/48",
+            "0.0.0.0/0",
+            "::/0",
+        ]
+        .map(|network| network.parse::<IpNet>().expect("valid test network"));
+
+        assert_eq!(
+            runtime
+                .retained_ip_network_presence("SRC_ADDR", &networks)
+                .expect("match source networks"),
+            [true, false, false, true, true, true]
+        );
+        assert_eq!(
+            runtime
+                .retained_ip_network_presence("DST_ADDR", &networks)
+                .expect("match destination networks"),
+            [false, true, true, false, true, true]
+        );
+        assert_eq!(
+            runtime
+                .retained_ip_network_presence("PROTOCOL", &networks)
+                .expect("reject non-IP facet"),
+            [false; 6]
+        );
+    }
+
+    #[test]
+    fn runtime_retained_ip_network_presence_returns_no_match_for_an_empty_facet() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let runtime = FacetRuntime::new(tmp.path());
+        let networks = [
+            "0.0.0.0/0".parse::<IpNet>().expect("valid IPv4 network"),
+            "::/0".parse::<IpNet>().expect("valid IPv6 network"),
+        ];
+
+        assert_eq!(
+            runtime
+                .retained_ip_network_presence("NEXT_HOP", &networks)
+                .expect("match empty facet"),
+            [false, false]
         );
     }
 

--- a/src/crates/netflow-plugin/src/facet_runtime/contribution.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime/contribution.rs
@@ -15,8 +15,10 @@ pub(crate) trait FacetValueSink {
     fn insert_u8_static(&mut self, field: &'static str, value: u8);
     fn insert_u8_present_static(&mut self, field: &'static str, value: u8);
     fn insert_u16_static(&mut self, field: &'static str, value: u16);
+    fn insert_u16_present_static(&mut self, field: &'static str, value: u16);
     fn insert_u32_static(&mut self, field: &'static str, value: u32);
-    fn insert_u64_static(&mut self, field: &'static str, value: u64);
+    fn insert_u32_present_static(&mut self, field: &'static str, value: u32);
+    fn insert_u64_present_static(&mut self, field: &'static str, value: u64);
     fn insert_ip_static(&mut self, field: &'static str, value: Option<IpAddr>);
 }
 
@@ -32,6 +34,22 @@ impl FacetFileContribution {
 
     pub(super) fn iter(&self) -> impl Iterator<Item = (&'static str, &FacetStore)> + '_ {
         self.fields.iter().map(|(field, store)| (*field, store))
+    }
+
+    pub(super) fn merge_from(&mut self, other: &Self) -> bool {
+        let mut changed = false;
+        for (field, store) in other.iter() {
+            match self.fields.entry(field) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    changed |= entry.get_mut().merge_from(store);
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(store.clone());
+                    changed = true;
+                }
+            }
+        }
+        changed
     }
 
     pub(super) fn from_scanned_values(values: BTreeMap<String, BTreeSet<String>>) -> Self {
@@ -130,13 +148,6 @@ impl FacetFileContribution {
         let _ = store.insert_u32(value);
     }
 
-    pub(crate) fn insert_u64_static(&mut self, field: &'static str, value: u64) {
-        if value == 0 {
-            return;
-        }
-        self.insert_u64_present_static(field, value);
-    }
-
     pub(crate) fn insert_u64_present_static(&mut self, field: &'static str, value: u64) {
         let Some(spec) = facet_field_spec_static(field) else {
             return;
@@ -205,12 +216,20 @@ impl FacetValueSink for FacetFileContribution {
         FacetFileContribution::insert_u16_static(self, field, value);
     }
 
+    fn insert_u16_present_static(&mut self, field: &'static str, value: u16) {
+        FacetFileContribution::insert_u16_present_static(self, field, value);
+    }
+
     fn insert_u32_static(&mut self, field: &'static str, value: u32) {
         FacetFileContribution::insert_u32_static(self, field, value);
     }
 
-    fn insert_u64_static(&mut self, field: &'static str, value: u64) {
-        FacetFileContribution::insert_u64_static(self, field, value);
+    fn insert_u32_present_static(&mut self, field: &'static str, value: u32) {
+        FacetFileContribution::insert_u32_present_static(self, field, value);
+    }
+
+    fn insert_u64_present_static(&mut self, field: &'static str, value: u64) {
+        FacetFileContribution::insert_u64_present_static(self, field, value);
     }
 
     fn insert_ip_static(&mut self, field: &'static str, value: Option<IpAddr>) {
@@ -289,22 +308,17 @@ where
             continue;
         }
 
+        if let Some(spec) = facet_field_spec(field) {
+            contribution.insert_raw_spec(*spec, value.as_ref());
+        }
+
         match field {
-            "PROTOCOL" => {
-                if let Some(spec) = facet_field_spec(field) {
-                    contribution.insert_raw_spec(*spec, value.as_ref());
-                }
-                protocol = Some(value.into_owned());
-            }
+            "PROTOCOL" => protocol = Some(value.into_owned()),
             "ICMPV4_TYPE" => icmpv4_type = Some(value.into_owned()),
             "ICMPV4_CODE" => icmpv4_code = Some(value.into_owned()),
             "ICMPV6_TYPE" => icmpv6_type = Some(value.into_owned()),
             "ICMPV6_CODE" => icmpv6_code = Some(value.into_owned()),
-            _ => {
-                if let Some(spec) = facet_field_spec(field) {
-                    contribution.insert_raw_spec(*spec, value.as_ref());
-                }
-            }
+            _ => {}
         }
     }
 
@@ -340,10 +354,10 @@ fn append_record_core_fields(sink: &mut impl FacetValueSink, record: &FlowRecord
     sink.insert_text_static("EXPORTER_TENANT", &record.exporter_tenant);
     sink.insert_u8_present_static("PROTOCOL", record.protocol);
     if record.has_etype() {
-        sink.insert_u16_static("ETYPE", record.etype);
+        sink.insert_u16_present_static("ETYPE", record.etype);
     }
     if record.has_forwarding_status() {
-        sink.insert_u8_static("FORWARDING_STATUS", record.forwarding_status);
+        sink.insert_u8_present_static("FORWARDING_STATUS", record.forwarding_status);
     }
     if record.has_direction() {
         sink.insert_text_static("DIRECTION", record.direction.as_str());
@@ -394,20 +408,20 @@ fn append_record_interface_fields(sink: &mut impl FacetValueSink, record: &FlowR
     sink.insert_text_static("IN_IF_DESCRIPTION", &record.in_if_description);
     sink.insert_text_static("OUT_IF_DESCRIPTION", &record.out_if_description);
     if record.has_in_if_speed() {
-        sink.insert_u64_static("IN_IF_SPEED", record.in_if_speed);
+        sink.insert_u64_present_static("IN_IF_SPEED", record.in_if_speed);
     }
     if record.has_out_if_speed() {
-        sink.insert_u64_static("OUT_IF_SPEED", record.out_if_speed);
+        sink.insert_u64_present_static("OUT_IF_SPEED", record.out_if_speed);
     }
     sink.insert_text_static("IN_IF_PROVIDER", &record.in_if_provider);
     sink.insert_text_static("OUT_IF_PROVIDER", &record.out_if_provider);
     sink.insert_text_static("IN_IF_CONNECTIVITY", &record.in_if_connectivity);
     sink.insert_text_static("OUT_IF_CONNECTIVITY", &record.out_if_connectivity);
     if record.has_in_if_boundary() {
-        sink.insert_u8_static("IN_IF_BOUNDARY", record.in_if_boundary);
+        sink.insert_u8_present_static("IN_IF_BOUNDARY", record.in_if_boundary);
     }
     if record.has_out_if_boundary() {
-        sink.insert_u8_static("OUT_IF_BOUNDARY", record.out_if_boundary);
+        sink.insert_u8_present_static("OUT_IF_BOUNDARY", record.out_if_boundary);
     }
 }
 
@@ -420,10 +434,10 @@ fn append_record_transport_fields(sink: &mut impl FacetValueSink, record: &FlowR
     sink.insert_u16_static("SRC_PORT_NAT", record.src_port_nat);
     sink.insert_u16_static("DST_PORT_NAT", record.dst_port_nat);
     if record.has_src_vlan() {
-        sink.insert_u16_static("SRC_VLAN", record.src_vlan);
+        sink.insert_u16_present_static("SRC_VLAN", record.src_vlan);
     }
     if record.has_dst_vlan() {
-        sink.insert_u16_static("DST_VLAN", record.dst_vlan);
+        sink.insert_u16_present_static("DST_VLAN", record.dst_vlan);
     }
     if let Some(mac) = format_mac(record.src_mac) {
         sink.insert_text_static("SRC_MAC", &mac);
@@ -436,14 +450,26 @@ fn append_record_transport_fields(sink: &mut impl FacetValueSink, record: &FlowR
 fn append_record_header_fields(sink: &mut impl FacetValueSink, record: &FlowRecord) {
     sink.insert_u8_static("IPTTL", record.ipttl);
     if record.has_iptos() {
-        sink.insert_u8_static("IPTOS", record.iptos);
+        sink.insert_u8_present_static("IPTOS", record.iptos);
     }
     sink.insert_u32_static("IPV6_FLOW_LABEL", record.ipv6_flow_label);
     if record.has_tcp_flags() {
-        sink.insert_u8_static("TCP_FLAGS", record.tcp_flags);
+        sink.insert_u8_present_static("TCP_FLAGS", record.tcp_flags);
     }
     sink.insert_u32_static("IP_FRAGMENT_ID", record.ip_fragment_id);
     sink.insert_u16_static("IP_FRAGMENT_OFFSET", record.ip_fragment_offset);
+    if record.has_icmpv4_type() {
+        sink.insert_u8_present_static("ICMPV4_TYPE", record.icmpv4_type);
+    }
+    if record.has_icmpv4_code() {
+        sink.insert_u8_present_static("ICMPV4_CODE", record.icmpv4_code);
+    }
+    if record.has_icmpv6_type() {
+        sink.insert_u8_present_static("ICMPV6_TYPE", record.icmpv6_type);
+    }
+    if record.has_icmpv6_code() {
+        sink.insert_u8_present_static("ICMPV6_CODE", record.icmpv6_code);
+    }
     sink.insert_text_static("MPLS_LABELS", &record.mpls_labels);
 }
 
@@ -567,6 +593,19 @@ mod tests {
             Some(&vec!["6".to_string()]),
             "protocol must survive direct and encoded contribution paths"
         );
+        assert_eq!(
+            contribution_strings(&direct).get("DIRECTION"),
+            Some(&vec!["ingress".to_string()]),
+            "direction must use its logical text representation"
+        );
+        assert_eq!(
+            contribution_strings(&direct).get("ICMPV4_TYPE"),
+            Some(&vec!["8".to_string()])
+        );
+        assert_eq!(
+            contribution_strings(&direct).get("ICMPV4_CODE"),
+            Some(&vec!["0".to_string()])
+        );
     }
 
     #[test]
@@ -598,5 +637,61 @@ mod tests {
             Some(&vec!["0".to_string()]),
             "protocol zero is a journaled value, not an absent optional field"
         );
+    }
+
+    #[test]
+    fn record_and_encoded_contributions_preserve_present_numeric_zeroes() {
+        let mut record = FlowRecord {
+            flow_version: "v9",
+            protocol: 17,
+            ..FlowRecord::default()
+        };
+        record.set_etype(0);
+        record.set_forwarding_status(0);
+        record.set_in_if_speed(0);
+        record.set_out_if_speed(0);
+        record.set_in_if_boundary(0);
+        record.set_out_if_boundary(0);
+        record.set_src_vlan(0);
+        record.set_dst_vlan(0);
+        record.set_iptos(0);
+        record.set_tcp_flags(0);
+        record.set_icmpv4_type(0);
+        record.set_icmpv4_code(0);
+        record.set_icmpv6_type(0);
+        record.set_icmpv6_code(0);
+
+        let mut data = Vec::new();
+        let mut refs = Vec::new();
+        let mut value_starts = Vec::new();
+        record.encode_to_journal_buf(&mut data, &mut refs, &mut value_starts);
+
+        let encoded = facet_contribution_from_encoded_fields(refs.iter().map(|r| &data[r.clone()]));
+        let direct = facet_contribution_from_record(&record);
+        let direct_values = contribution_strings(&direct);
+
+        assert_eq!(direct_values, contribution_strings(&encoded));
+        for field in [
+            "ETYPE",
+            "FORWARDING_STATUS",
+            "IN_IF_SPEED",
+            "OUT_IF_SPEED",
+            "IN_IF_BOUNDARY",
+            "OUT_IF_BOUNDARY",
+            "SRC_VLAN",
+            "DST_VLAN",
+            "IPTOS",
+            "TCP_FLAGS",
+            "ICMPV4_TYPE",
+            "ICMPV4_CODE",
+            "ICMPV6_TYPE",
+            "ICMPV6_CODE",
+        ] {
+            assert_eq!(
+                direct_values.get(field),
+                Some(&vec!["0".to_string()]),
+                "{field} must distinguish present zero from missing"
+            );
+        }
     }
 }

--- a/src/crates/netflow-plugin/src/facet_runtime/sidecar.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime/sidecar.rs
@@ -26,16 +26,38 @@ pub(crate) fn write_sidecar_files(
 pub(crate) fn delete_sidecar_files(journal_path: &Path) {
     for spec in FACET_FIELD_SPECS.iter().filter(|spec| spec.uses_sidecar) {
         let path = sidecar_path(journal_path, spec.name);
-        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(path.with_extension("fst.tmp"));
     }
 }
 
 pub(crate) fn sidecar_path(journal_path: &Path, field: &str) -> PathBuf {
-    PathBuf::from(format!(
-        "{}.facet.{}.fst",
-        journal_path.display(),
-        field.to_ascii_uppercase()
-    ))
+    let mut path = journal_path.as_os_str().to_os_string();
+    path.push(format!(".facet.{}.fst", field.to_ascii_uppercase()));
+    PathBuf::from(path)
+}
+
+pub(super) fn journal_sidecar_bytes(journal_path: &Path) -> journal_sdk_log_writer::Result<u64> {
+    let mut total = 0_u64;
+
+    for spec in FACET_FIELD_SPECS.iter().filter(|spec| spec.uses_sidecar) {
+        let path = sidecar_path(journal_path, spec.name);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_file() => {
+                total = total.saturating_add(metadata.len());
+            }
+            Ok(_) => {
+                return Err(journal_sdk_log_writer::WriterError::InvalidPath(format!(
+                    "facet sidecar is not a regular file: {}",
+                    path.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    Ok(total)
 }
 
 pub(crate) fn search_sidecar(
@@ -133,4 +155,130 @@ fn write_field_sidecar(journal_path: &Path, field: &str, values: &[String]) -> R
     })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sidecar_fields() -> Vec<&'static str> {
+        FACET_FIELD_SPECS
+            .iter()
+            .filter(|spec| spec.uses_sidecar)
+            .map(|spec| spec.name)
+            .collect()
+    }
+
+    #[test]
+    fn journal_sidecar_bytes_counts_only_catalog_owned_final_files() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let journal_path = tmp.path().join("flow.journal");
+        let fields = sidecar_fields();
+        assert!(
+            fields.len() >= 2,
+            "test requires at least two sidecar fields"
+        );
+
+        fs::write(sidecar_path(&journal_path, fields[0]), vec![0_u8; 13])
+            .expect("write first owned sidecar");
+        fs::write(sidecar_path(&journal_path, fields[1]), vec![0_u8; 29])
+            .expect("write second owned sidecar");
+        fs::write(
+            sidecar_path(&journal_path, fields[0]).with_extension("fst.tmp"),
+            vec![0_u8; 101],
+        )
+        .expect("write temporary sidecar");
+        fs::write(
+            sidecar_path(&journal_path, "UNKNOWN_FIELD"),
+            vec![0_u8; 103],
+        )
+        .expect("write unknown sidecar");
+        fs::write(tmp.path().join("facet-state.bin"), vec![0_u8; 107])
+            .expect("write shared facet state");
+        fs::write(
+            sidecar_path(&tmp.path().join("flow.journal.backup"), fields[0]),
+            vec![0_u8; 109],
+        )
+        .expect("write prefix-collision sidecar");
+
+        assert_eq!(
+            journal_sidecar_bytes(&journal_path).expect("measure owned sidecars"),
+            42
+        );
+    }
+
+    #[test]
+    fn journal_sidecar_bytes_handles_missing_and_rejects_non_regular_paths() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let journal_path = tmp.path().join("flow.journal");
+        let field = sidecar_fields().into_iter().next().expect("sidecar field");
+        let path = sidecar_path(&journal_path, field);
+
+        assert_eq!(
+            journal_sidecar_bytes(&journal_path).expect("measure missing sidecars"),
+            0
+        );
+
+        fs::create_dir(&path).expect("create directory at exact sidecar path");
+        let error = journal_sidecar_bytes(&journal_path)
+            .expect_err("directory at exact sidecar path must fail");
+        assert!(matches!(
+            error,
+            journal_sdk_log_writer::WriterError::InvalidPath(_)
+        ));
+        fs::remove_dir(&path).expect("remove exact sidecar directory");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+
+            let target = tmp.path().join("target");
+            fs::write(&target, b"target").expect("write symlink target");
+            symlink(&target, &path).expect("create sidecar symlink");
+            let error = journal_sidecar_bytes(&journal_path)
+                .expect_err("symlink at exact sidecar path must fail");
+            assert!(matches!(
+                error,
+                journal_sdk_log_writer::WriterError::InvalidPath(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn delete_sidecar_files_removes_owned_final_and_temporary_files() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let journal_path = tmp.path().join("flow.journal");
+        let field = sidecar_fields().into_iter().next().expect("sidecar field");
+        let final_path = sidecar_path(&journal_path, field);
+        let temporary_path = final_path.with_extension("fst.tmp");
+        let unknown_path = sidecar_path(&journal_path, "UNKNOWN_FIELD");
+
+        fs::write(&final_path, b"final").expect("write final sidecar");
+        fs::write(&temporary_path, b"temporary").expect("write temporary sidecar");
+        fs::write(&unknown_path, b"unknown").expect("write unknown sidecar");
+
+        delete_sidecar_files(&journal_path);
+
+        assert!(!final_path.exists());
+        assert!(!temporary_path.exists());
+        assert!(unknown_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sidecar_path_preserves_non_utf8_journal_paths() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let mut expected = b"flow-\xff.journal".to_vec();
+        let journal_path = PathBuf::from(OsString::from_vec(expected.clone()));
+        expected.extend_from_slice(b".facet.SRC_ADDR.fst");
+
+        assert_eq!(
+            sidecar_path(&journal_path, "src_addr")
+                .as_os_str()
+                .as_bytes(),
+            expected
+        );
+    }
 }

--- a/src/crates/netflow-plugin/src/facet_runtime/store.rs
+++ b/src/crates/netflow-plugin/src/facet_runtime/store.rs
@@ -2,6 +2,7 @@ use crate::facet_catalog::{AutocompleteMatchKind, FacetValueKind};
 use allocative::{Allocative, Key, Visitor};
 use bitvec::prelude::*;
 use hashbrown::HashTable;
+use ipnet::IpNet;
 use roaring::RoaringTreemap;
 use serde::{Deserialize, Serialize};
 use std::hash::Hasher;
@@ -286,6 +287,13 @@ impl FacetStore {
             Self::SparseU32(store) => autocomplete_match_roaring(store, term, limit, match_kind),
             Self::SparseU64(store) => autocomplete_match_roaring(store, term, limit, match_kind),
             Self::IpAddr(store) => store.autocomplete_matches(term, limit, match_kind),
+        }
+    }
+
+    pub(super) fn mark_matching_ip_networks(&self, networks: &[IpNet], matched: &mut [bool]) {
+        debug_assert_eq!(networks.len(), matched.len());
+        if let Self::IpAddr(store) = self {
+            store.mark_matching_networks(networks, matched);
         }
     }
 
@@ -708,6 +716,60 @@ impl IpValueStore {
         values.sort_unstable();
         values.truncate(limit);
         values
+    }
+
+    fn mark_matching_networks(&self, networks: &[IpNet], matched: &mut [bool]) {
+        for (index, network) in networks.iter().enumerate() {
+            if matched[index] {
+                continue;
+            }
+            let IpNet::V4(network) = network else {
+                continue;
+            };
+            let start = u32::from(network.network());
+            let end = u32::from(network.broadcast());
+            let before = if start == 0 {
+                0
+            } else {
+                self.v4_values.rank(u64::from(start - 1))
+            };
+            matched[index] = self.v4_values.rank(u64::from(end)) > before;
+        }
+
+        let v6_ranges = networks
+            .iter()
+            .enumerate()
+            .filter_map(|(index, network)| {
+                if matched[index] {
+                    return None;
+                }
+                let IpNet::V6(network) = network else {
+                    return None;
+                };
+                Some((
+                    index,
+                    u128::from(network.network()),
+                    u128::from(network.broadcast()),
+                ))
+            })
+            .collect::<Vec<_>>();
+        if v6_ranges.is_empty() {
+            return;
+        }
+
+        let mut remaining = v6_ranges.len();
+        for value in &self.v6_values {
+            let value = u128::from_be_bytes(*value);
+            for &(index, start, end) in &v6_ranges {
+                if !matched[index] && (start..=end).contains(&value) {
+                    matched[index] = true;
+                    remaining -= 1;
+                }
+            }
+            if remaining == 0 {
+                break;
+            }
+        }
     }
 
     fn merge_from(&mut self, other: &Self) -> bool {

--- a/src/crates/netflow-plugin/src/flow/record/core.rs
+++ b/src/crates/netflow-plugin/src/flow/record/core.rs
@@ -60,7 +60,7 @@ impl std::fmt::Display for FlowDirection {
 }
 
 /// Flat, typed representation of a canonical flow record.
-/// All 89 canonical fields stored with native types. Only enrichment-derived
+/// All 91 canonical fields stored with native types. Only enrichment-derived
 /// text fields remain as String (36 fields, most empty by default).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct FlowRecord {

--- a/src/crates/netflow-plugin/src/flow/record/journal.rs
+++ b/src/crates/netflow-plugin/src/flow/record/journal.rs
@@ -19,7 +19,7 @@ impl FlowRecord {
     /// their default value (0, empty string, None) are skipped; required fields
     /// such as `PROTOCOL` are retained even when zero. The reader (`from_fields`)
     /// defaults missing optional fields to the same values, so the round-trip is
-    /// lossless. This reduces typical per-entry item counts from 87 to ~20-25.
+    /// lossless. This reduces typical per-entry item counts from 91 to ~20-25.
     pub(crate) fn encode_to_journal_buf(
         &self,
         data: &mut Vec<u8>,

--- a/src/crates/netflow-plugin/src/ingest/encode.rs
+++ b/src/crates/netflow-plugin/src/ingest/encode.rs
@@ -1,6 +1,8 @@
 use std::io::Write;
 use std::net::IpAddr;
 
+const MAX_CANONICAL_JOURNAL_FIELDS: usize = crate::flow::CANONICAL_FLOW_DEFAULTS.len();
+
 /// Reusable buffer for encoding flow fields into journal entries.
 /// Avoids ~60 Vec<u8> allocations per flow by writing all fields into
 /// a single contiguous buffer and tracking offsets.
@@ -34,11 +36,18 @@ impl JournalEncodeBuffer {
         debug_assert_eq!(self.refs.len(), self.value_starts.len());
         self.debug_assert_unique_payloads();
 
-        // 87 canonical fields — stack array avoids heap allocation. The flow
+        // The schema-derived stack array avoids a heap allocation. The flow
         // encoder already split each canonical field, so do not make the
         // journal writer scan every `KEY=value` payload again.
-        let mut fields = [journal_sdk_log_writer::StructuredField::new(&[], &[]); 87];
-        let n = self.refs.len().min(87);
+        let mut fields =
+            [journal_sdk_log_writer::StructuredField::new(&[], &[]); MAX_CANONICAL_JOURNAL_FIELDS];
+        let n = self.refs.len();
+        if n > fields.len() {
+            return Err(journal_sdk_log_writer::WriterError::Serialization(format!(
+                "canonical journal encoder emitted {n} fields, schema capacity is {}",
+                fields.len()
+            )));
+        }
         for (i, (range, value_start)) in self.refs[..n]
             .iter()
             .zip(&self.value_starts[..n])
@@ -154,5 +163,175 @@ impl JournalEncodeBuffer {
         self.data
             .extend_from_slice(self.ibuf.format(value).as_bytes());
         self.refs.push(start..self.data.len());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JournalEncodeBuffer, MAX_CANONICAL_JOURNAL_FIELDS};
+    use crate::flow::{CANONICAL_FLOW_DEFAULTS, FlowFields, FlowRecord};
+    use journal_sdk_core::file::Mmap;
+    use journal_sdk_core::repository::File as JournalRepositoryFile;
+    use journal_sdk_core::{Direction, JournalFile, JournalReader, Location};
+    use journal_sdk_log_writer::{
+        Compression, Config, EntryTimestamps, Log, RetentionPolicy, RotationPolicy,
+    };
+    use journal_sdk_registry::{Origin, Source};
+    use std::collections::BTreeSet;
+    use std::num::NonZeroU64;
+    use std::path::PathBuf;
+
+    #[test]
+    fn fully_populated_record_encodes_every_canonical_field() {
+        let fields = CANONICAL_FLOW_DEFAULTS
+            .iter()
+            .map(|&(field, _)| (field, populated_value(field).to_string()))
+            .collect::<FlowFields>();
+        let record = FlowRecord::from_fields(&fields);
+        let mut data = Vec::new();
+        let mut refs = Vec::new();
+        let mut value_starts = Vec::new();
+
+        record.encode_to_journal_buf(&mut data, &mut refs, &mut value_starts);
+
+        assert_eq!(MAX_CANONICAL_JOURNAL_FIELDS, 91);
+        assert_eq!(refs.len(), MAX_CANONICAL_JOURNAL_FIELDS);
+        assert_eq!(refs.len(), value_starts.len());
+
+        let encoded_fields = refs
+            .iter()
+            .zip(&value_starts)
+            .map(|(range, value_start)| {
+                std::str::from_utf8(&data[range.start..(*value_start - 1)])
+                    .expect("field name should be UTF-8")
+            })
+            .collect::<BTreeSet<_>>();
+        let expected_fields = CANONICAL_FLOW_DEFAULTS
+            .iter()
+            .map(|&(field, _)| field)
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(encoded_fields, expected_fields);
+        for field in ["MPLS_LABELS", "RAW_BYTES", "RAW_PACKETS", "SAMPLING_RATE"] {
+            assert!(
+                encoded_fields.contains(field),
+                "{field} was previously beyond the stale 87-field write limit"
+            );
+        }
+    }
+
+    #[test]
+    fn production_writer_persists_every_canonical_field() {
+        let tmp = tempfile::tempdir().expect("create journal directory");
+        let machine_id = uuid::Uuid::from_bytes([1; 16]);
+        let boot_id = uuid::Uuid::from_bytes([2; 16]);
+        let origin = Origin {
+            machine_id: Some(machine_id),
+            namespace: None,
+            source: Source::System,
+        };
+        let mut journal = Log::new(
+            tmp.path(),
+            Config::new(
+                origin,
+                RotationPolicy::default().with_size_of_journal_file(1024 * 1024),
+                RetentionPolicy::default(),
+            )
+            .with_boot_id(boot_id)
+            .with_compact(true)
+            .with_compression(Compression::None)
+            .with_live_publish_every_entries(0),
+        )
+        .expect("create production journal writer");
+        let fields = CANONICAL_FLOW_DEFAULTS
+            .iter()
+            .map(|&(field, _)| (field, populated_value(field).to_string()))
+            .collect::<FlowFields>();
+        let record = FlowRecord::from_fields(&fields);
+        let mut encode_buf = JournalEncodeBuffer::new();
+
+        encode_buf
+            .encode_record_and_write(
+                &record,
+                &mut journal,
+                EntryTimestamps::default()
+                    .with_source_realtime_usec(1_000_000)
+                    .with_entry_realtime_usec(1_000_000)
+                    .with_entry_monotonic_usec(1),
+            )
+            .expect("write fully populated record through production boundary");
+        journal.sync().expect("sync production journal");
+
+        let active_path = PathBuf::from(
+            journal
+                .active_file()
+                .expect("active journal")
+                .path()
+                .to_string(),
+        );
+        let repository_file =
+            JournalRepositoryFile::from_path(&active_path).expect("parse active journal path");
+        let journal_file = JournalFile::<Mmap>::open(&repository_file, 8 * 1024 * 1024)
+            .expect("open production journal");
+        let mut reader = JournalReader::default();
+        reader.set_location(Location::Head);
+        assert!(
+            reader
+                .step(&journal_file, Direction::Forward)
+                .expect("step production journal"),
+            "production journal must contain the written entry"
+        );
+        let mut data_offsets = Vec::<NonZeroU64>::new();
+        reader
+            .entry_data_offsets(&journal_file, &mut data_offsets)
+            .expect("enumerate production journal fields");
+        let mut decompress_buf = Vec::new();
+        let mut persisted_fields = BTreeSet::new();
+        crate::query::visit_journal_payloads(
+            &journal_file,
+            &active_path,
+            &data_offsets,
+            &mut decompress_buf,
+            |payload| {
+                if let Some(eq_pos) = payload.iter().position(|byte| *byte == b'=') {
+                    persisted_fields.insert(
+                        std::str::from_utf8(&payload[..eq_pos])
+                            .expect("journal field name should be UTF-8")
+                            .to_string(),
+                    );
+                }
+                Ok(())
+            },
+        )
+        .expect("read production journal fields");
+
+        let expected_fields = CANONICAL_FLOW_DEFAULTS
+            .iter()
+            .map(|&(field, _)| field)
+            .collect::<BTreeSet<_>>();
+        let persisted_canonical_fields = persisted_fields
+            .iter()
+            .map(String::as_str)
+            .filter(|field| expected_fields.contains(field))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(persisted_canonical_fields, expected_fields);
+        for field in ["MPLS_LABELS", "RAW_BYTES", "RAW_PACKETS", "SAMPLING_RATE"] {
+            assert!(
+                persisted_fields.contains(field),
+                "{field} was previously truncated at the production writer boundary"
+            );
+        }
+    }
+
+    fn populated_value(field: &str) -> &'static str {
+        match field {
+            "FLOW_VERSION" => "v9",
+            "DIRECTION" => "ingress",
+            "EXPORTER_IP" | "SRC_ADDR" | "DST_ADDR" | "NEXT_HOP" | "SRC_ADDR_NAT"
+            | "DST_ADDR_NAT" => "192.0.2.1",
+            "SRC_PREFIX" | "DST_PREFIX" => "192.0.2.0/24",
+            "SRC_MAC" | "DST_MAC" => "00:00:00:00:00:01",
+            _ => "1",
+        }
     }
 }

--- a/src/crates/netflow-plugin/src/ingest/service.rs
+++ b/src/crates/netflow-plugin/src/ingest/service.rs
@@ -20,10 +20,17 @@ struct FacetLifecycleObserver {
 impl LogLifecycleObserver for FacetLifecycleObserver {
     fn on_event(&self, event: &LogLifecycleEvent) {
         match event {
-            // A newly created active file carries no entries the facet runtime
-            // must reconcile: active files are discovered at query time and
-            // rotation is handled below. Nothing to do (matches pre-SDK behavior).
-            LogLifecycleEvent::Created { .. } => {}
+            LogLifecycleEvent::Created { active, .. } => {
+                if let Err(err) = self
+                    .runtime
+                    .observe_active_path_created(Path::new(active.path()))
+                {
+                    self.metrics
+                        .facet_lifecycle_errors
+                        .fetch_add(1, Ordering::Relaxed);
+                    tracing::warn!("facet runtime active-file update failed: {}", err);
+                }
+            }
             LogLifecycleEvent::Rotated { archived, active } => {
                 let archived_path = Path::new(archived.path());
                 let active_path = Path::new(active.path());

--- a/src/crates/netflow-plugin/src/ingest/service/init.rs
+++ b/src/crates/netflow-plugin/src/ingest/service/init.rs
@@ -33,6 +33,8 @@ impl IngestService {
                 runtime: Arc::clone(&facet_runtime),
                 metrics: Arc::clone(&metrics),
             });
+        let artifact_sizer: Arc<dyn journal_sdk_log_writer::LogArtifactSizer> =
+            facet_runtime.clone();
         let build_journal_cfg = |tier: TierKind| {
             let origin = Origin {
                 machine_id: Some(machine_id),
@@ -63,13 +65,26 @@ impl IngestService {
                 .with_boot_id(boot_id)
                 .with_live_publish_every_entries(0)
         };
-        let raw_journal =
-            Self::build_raw_journal(&cfg, &build_journal_cfg, Arc::clone(&lifecycle_observer))?;
+        let raw_journal = Self::build_raw_journal(
+            &cfg,
+            &build_journal_cfg,
+            Arc::clone(&lifecycle_observer),
+            Arc::clone(&artifact_sizer),
+        )?;
         let tier_writers = Self::build_materialized_tier_writers(
             &cfg,
             &build_journal_cfg,
             Arc::clone(&lifecycle_observer),
+            Arc::clone(&artifact_sizer),
         )?;
+        Self::register_open_active_journal(&facet_runtime, &raw_journal)?;
+        for writer in [
+            &tier_writers.minute_1,
+            &tier_writers.minute_5,
+            &tier_writers.hour_1,
+        ] {
+            Self::register_open_active_journal(&facet_runtime, writer)?;
+        }
         let tier_accumulators = Self::build_tier_accumulators();
         let (decoders, routing_runtime, network_sources_runtime) = Self::build_decoder_stack(&cfg)?;
         let decoder_state_dir = cfg.journal.decoder_state_dir();
@@ -113,56 +128,91 @@ impl IngestService {
         self.network_sources_runtime.clone()
     }
 
+    fn register_open_active_journal(
+        facet_runtime: &crate::facet_runtime::FacetRuntime,
+        journal: &Log,
+    ) -> Result<()> {
+        let Some(active_file) = journal.active_file() else {
+            return Ok(());
+        };
+        facet_runtime
+            .observe_active_path_created(Path::new(active_file.path()))
+            .with_context(|| {
+                format!(
+                    "failed to register reopened active journal {}",
+                    active_file.path()
+                )
+            })
+    }
+
     fn build_raw_journal(
         cfg: &PluginConfig,
         build_journal_cfg: &impl Fn(TierKind) -> Config,
         lifecycle_observer: Arc<dyn journal_sdk_log_writer::LogLifecycleObserver>,
+        artifact_sizer: Arc<dyn journal_sdk_log_writer::LogArtifactSizer>,
     ) -> Result<Log> {
         let raw_dir = cfg.journal.raw_tier_dir();
-        Log::new(&raw_dir, build_journal_cfg(TierKind::Raw))
-            .map(|log| log.with_lifecycle_observer(lifecycle_observer))
-            .with_context(|| {
-                format!(
-                    "failed to create journal writer in directory {}",
-                    raw_dir.display()
-                )
-            })
+        Log::new_with_hooks(
+            &raw_dir,
+            build_journal_cfg(TierKind::Raw),
+            Some(lifecycle_observer),
+            Some(artifact_sizer),
+        )
+        .with_context(|| {
+            format!(
+                "failed to create journal writer in directory {}",
+                raw_dir.display()
+            )
+        })
     }
 
     fn build_materialized_tier_writers(
         cfg: &PluginConfig,
         build_journal_cfg: &impl Fn(TierKind) -> Config,
         lifecycle_observer: Arc<dyn journal_sdk_log_writer::LogLifecycleObserver>,
+        artifact_sizer: Arc<dyn journal_sdk_log_writer::LogArtifactSizer>,
     ) -> Result<MaterializedTierWriters> {
         let minute_1_dir = cfg.journal.minute_1_tier_dir();
         let minute_5_dir = cfg.journal.minute_5_tier_dir();
         let hour_1_dir = cfg.journal.hour_1_tier_dir();
 
         Ok(MaterializedTierWriters {
-            minute_1: Log::new(&minute_1_dir, build_journal_cfg(TierKind::Minute1))
-                .map(|log| log.with_lifecycle_observer(Arc::clone(&lifecycle_observer)))
-                .with_context(|| {
-                    format!(
-                        "failed to create 1m tier writer in directory {}",
-                        minute_1_dir.display()
-                    )
-                })?,
-            minute_5: Log::new(&minute_5_dir, build_journal_cfg(TierKind::Minute5))
-                .map(|log| log.with_lifecycle_observer(Arc::clone(&lifecycle_observer)))
-                .with_context(|| {
-                    format!(
-                        "failed to create 5m tier writer in directory {}",
-                        minute_5_dir.display()
-                    )
-                })?,
-            hour_1: Log::new(&hour_1_dir, build_journal_cfg(TierKind::Hour1))
-                .map(|log| log.with_lifecycle_observer(Arc::clone(&lifecycle_observer)))
-                .with_context(|| {
-                    format!(
-                        "failed to create 1h tier writer in directory {}",
-                        hour_1_dir.display()
-                    )
-                })?,
+            minute_1: Log::new_with_hooks(
+                &minute_1_dir,
+                build_journal_cfg(TierKind::Minute1),
+                Some(Arc::clone(&lifecycle_observer)),
+                Some(Arc::clone(&artifact_sizer)),
+            )
+            .with_context(|| {
+                format!(
+                    "failed to create 1m tier writer in directory {}",
+                    minute_1_dir.display()
+                )
+            })?,
+            minute_5: Log::new_with_hooks(
+                &minute_5_dir,
+                build_journal_cfg(TierKind::Minute5),
+                Some(Arc::clone(&lifecycle_observer)),
+                Some(Arc::clone(&artifact_sizer)),
+            )
+            .with_context(|| {
+                format!(
+                    "failed to create 5m tier writer in directory {}",
+                    minute_5_dir.display()
+                )
+            })?,
+            hour_1: Log::new_with_hooks(
+                &hour_1_dir,
+                build_journal_cfg(TierKind::Hour1),
+                Some(Arc::clone(&lifecycle_observer)),
+                Some(Arc::clone(&artifact_sizer)),
+            )
+            .with_context(|| {
+                format!(
+                    "failed to create 1h tier writer in directory {}",
+                    hour_1_dir.display()
+                )
+            })?,
         })
     }
 
@@ -230,5 +280,386 @@ impl IngestService {
         decoders.set_enricher(enricher);
 
         Ok((decoders, routing_runtime, network_sources_runtime))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct InflatingLifecycleObserver {
+        inner: FacetLifecycleObserver,
+        sidecar_field: &'static str,
+        sidecar_bytes: u64,
+        archived_path: Arc<Mutex<Option<PathBuf>>>,
+    }
+
+    impl journal_sdk_log_writer::LogLifecycleObserver for InflatingLifecycleObserver {
+        fn on_event(&self, event: &journal_sdk_log_writer::LogLifecycleEvent) {
+            self.inner.on_event(event);
+            if let journal_sdk_log_writer::LogLifecycleEvent::Rotated { archived, .. } = event {
+                let archived_path = PathBuf::from(archived.path());
+                let sidecar =
+                    crate::facet_runtime::sidecar_path(&archived_path, self.sidecar_field);
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&sidecar)
+                    .and_then(|file| file.set_len(self.sidecar_bytes))
+                    .expect("inflate finalized sidecar before retention");
+                *self.archived_path.lock().expect("lock archived path") = Some(archived_path);
+            }
+        }
+    }
+
+    fn journal_paths_under(root: &Path) -> Vec<PathBuf> {
+        let mut pending = vec![root.to_path_buf()];
+        let mut paths = Vec::new();
+
+        while let Some(directory) = pending.pop() {
+            for entry in std::fs::read_dir(&directory)
+                .unwrap_or_else(|error| panic!("read {}: {error}", directory.display()))
+            {
+                let entry = entry.expect("read directory entry");
+                let file_type = entry.file_type().expect("read directory entry type");
+                let path = entry.path();
+                if file_type.is_dir() {
+                    pending.push(path);
+                } else if path
+                    .extension()
+                    .is_some_and(|extension| extension == "journal")
+                {
+                    paths.push(path);
+                }
+            }
+        }
+
+        paths.sort();
+        paths
+    }
+
+    fn committed_journal_size(path: &Path) -> u64 {
+        let repository_file =
+            journal_sdk_core::repository::File::from_path(path).expect("parse journal path");
+        let journal = journal_sdk_core::JournalFile::<journal_sdk_core::file::Mmap>::open(
+            &repository_file,
+            4096,
+        )
+        .expect("open journal");
+        let tail_offset = journal
+            .journal_header_ref()
+            .tail_object_offset
+            .expect("journal tail offset");
+        let tail = journal
+            .object_header_ref(tail_offset)
+            .expect("read journal tail object");
+        tail_offset
+            .get()
+            .saturating_add(tail.size)
+            .saturating_add(7)
+            & !7
+    }
+
+    fn writer_config(
+        machine_id: uuid::Uuid,
+        boot_id: uuid::Uuid,
+        retention_size: Option<u64>,
+        eager: bool,
+    ) -> Config {
+        let retention = retention_size.map_or_else(RetentionPolicy::default, |size| {
+            RetentionPolicy::default().with_size_of_journal_files(size)
+        });
+        let config = Config::new(
+            Origin {
+                machine_id: Some(machine_id),
+                namespace: None,
+                source: Source::System,
+            },
+            RotationPolicy::default()
+                .with_number_of_entries(1)
+                .with_size_of_journal_file(5_000_000),
+            retention,
+        )
+        .with_boot_id(boot_id)
+        .with_compact(true)
+        .with_compression(Compression::None)
+        .with_live_publish_every_entries(0);
+
+        if eager {
+            config.with_open_mode(journal_sdk_log_writer::LogOpenMode::Eager)
+        } else {
+            config
+        }
+    }
+
+    #[test]
+    fn reopened_non_strict_active_journal_is_registered_for_facets() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let machine_id = uuid::Uuid::from_bytes([1; 16]);
+        let boot_id = uuid::Uuid::from_bytes([2; 16]);
+        let config = || {
+            Config::new(
+                Origin {
+                    machine_id: Some(machine_id),
+                    namespace: None,
+                    source: Source::System,
+                },
+                RotationPolicy::default().with_size_of_journal_file(5_000_000),
+                RetentionPolicy::default(),
+            )
+            .with_boot_id(boot_id)
+            .with_compact(true)
+            .with_compression(Compression::None)
+            .with_live_publish_every_entries(0)
+        };
+
+        let active_path = {
+            let mut journal = Log::new(tmp.path(), config()).expect("create journal");
+            journal
+                .write_entry_with_timestamps(
+                    &[b"MESSAGE=test"],
+                    EntryTimestamps::default()
+                        .with_entry_realtime_usec(1_000_000)
+                        .with_entry_monotonic_usec(1),
+                )
+                .expect("write journal entry");
+            journal.sync().expect("sync journal");
+            journal
+                .active_file()
+                .expect("active journal")
+                .path()
+                .to_string()
+        };
+
+        // A clean drop archives the journal. Restore the Online state left by
+        // an unclean shutdown so startup exercises the reopen path.
+        let repository_file =
+            journal_sdk_core::repository::File::from_path(Path::new(&active_path))
+                .expect("parse journal path");
+        let mut journal_file =
+            journal_sdk_core::JournalFile::<journal_sdk_core::file::MmapMut>::open_for_append(
+                &repository_file,
+                8 * 1024 * 1024,
+            )
+            .expect("open journal for state update");
+        journal_file.journal_header_mut().state =
+            journal_sdk_core::file::JournalState::Online as u8;
+        journal_file.sync().expect("persist online state");
+        drop(journal_file);
+
+        let reopened = Log::new(tmp.path(), config()).expect("reopen journal");
+        assert_eq!(
+            reopened.active_file().expect("reopened active").path(),
+            active_path
+        );
+        let facet_runtime = crate::facet_runtime::FacetRuntime::new(tmp.path());
+        IngestService::register_open_active_journal(&facet_runtime, &reopened)
+            .expect("register reopened journal");
+
+        assert!(
+            facet_runtime
+                .build_reconcile_plan(&[])
+                .current_active_paths
+                .contains(&active_path)
+        );
+    }
+
+    #[test]
+    fn all_tier_lazy_writer_builders_count_sidecars_on_first_write() {
+        const SIDECAR_BYTES: u64 = 32_000_000;
+        const ACTIVE_FILE_MARGIN_BYTES: u64 = 8_000_000;
+
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let mut cfg = PluginConfig::default();
+        cfg.journal.journal_dir = tmp.path().join("flows").to_string_lossy().to_string();
+        let machine_id = uuid::Uuid::from_bytes([3; 16]);
+        let boot_id = uuid::Uuid::from_bytes([4; 16]);
+        let sidecar_field = crate::facet_catalog::FACET_FIELD_SPECS
+            .iter()
+            .find(|spec| spec.uses_sidecar)
+            .expect("sidecar-enabled facet field")
+            .name;
+        let tiers = [
+            (TierKind::Raw, cfg.journal.raw_tier_dir()),
+            (TierKind::Minute1, cfg.journal.minute_1_tier_dir()),
+            (TierKind::Minute5, cfg.journal.minute_5_tier_dir()),
+            (TierKind::Hour1, cfg.journal.hour_1_tier_dir()),
+        ];
+        let mut retained_sizes = HashMap::new();
+        let mut seeded_paths = HashMap::new();
+
+        for (tier, directory) in &tiers {
+            let mut journal = Log::new(directory, writer_config(machine_id, boot_id, None, false))
+                .expect("create seed journal");
+            for index in 0..3_u64 {
+                journal
+                    .write_entry_with_timestamps(
+                        &[b"MESSAGE=sidecar-retention"],
+                        EntryTimestamps::default()
+                            .with_entry_realtime_usec(1_000_000 + index)
+                            .with_entry_monotonic_usec(1 + index),
+                    )
+                    .expect("write seed journal entry");
+            }
+            journal.close().expect("close seed journal");
+
+            let paths = journal_paths_under(directory);
+            assert_eq!(paths.len(), 3, "expected three seed files for {tier:?}");
+            let journal_bytes = paths
+                .iter()
+                .map(|path| committed_journal_size(path))
+                .sum::<u64>();
+            for path in &paths {
+                let sidecar = crate::facet_runtime::sidecar_path(path, sidecar_field);
+                std::fs::File::create(&sidecar)
+                    .and_then(|file| file.set_len(SIDECAR_BYTES))
+                    .expect("create sparse facet sidecar");
+            }
+            retained_sizes.insert(*tier, journal_bytes + ACTIVE_FILE_MARGIN_BYTES);
+            seeded_paths.insert(*tier, paths);
+        }
+
+        let facet_runtime = Arc::new(crate::facet_runtime::FacetRuntime::new(
+            &cfg.journal.base_dir(),
+        ));
+        let observer: Arc<dyn journal_sdk_log_writer::LogLifecycleObserver> =
+            Arc::new(FacetLifecycleObserver {
+                runtime: Arc::clone(&facet_runtime),
+                metrics: Arc::new(IngestMetrics::default()),
+            });
+        let artifact_sizer: Arc<dyn journal_sdk_log_writer::LogArtifactSizer> =
+            facet_runtime.clone();
+        let build_config =
+            |tier| writer_config(machine_id, boot_id, Some(retained_sizes[&tier]), false);
+
+        let mut raw = IngestService::build_raw_journal(
+            &cfg,
+            &build_config,
+            Arc::clone(&observer),
+            Arc::clone(&artifact_sizer),
+        )
+        .expect("open artifact-aware raw writer");
+        let mut materialized = IngestService::build_materialized_tier_writers(
+            &cfg,
+            &build_config,
+            Arc::clone(&observer),
+            Arc::clone(&artifact_sizer),
+        )
+        .expect("open artifact-aware materialized writers");
+
+        // Production uses the SDK's lazy open mode. The first write creates the
+        // protected active journal and runs retention with both hooks installed.
+        for (index, writer) in [
+            &mut raw,
+            &mut materialized.minute_1,
+            &mut materialized.minute_5,
+            &mut materialized.hour_1,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            writer
+                .write_entry_with_timestamps(
+                    &[b"MESSAGE=activate-lazy-writer"],
+                    EntryTimestamps::default()
+                        .with_entry_realtime_usec(10_000_000 + index as u64)
+                        .with_entry_monotonic_usec(10 + index as u64),
+                )
+                .expect("activate lazy writer");
+        }
+
+        for (tier, paths) in seeded_paths {
+            for path in paths {
+                assert!(
+                    !path.exists(),
+                    "artifact-aware startup retention kept seeded {tier:?} journal {}",
+                    path.display()
+                );
+                assert!(
+                    !crate::facet_runtime::sidecar_path(&path, sidecar_field).exists(),
+                    "retention observer kept seeded {tier:?} sidecar for {}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rotation_retention_counts_newly_finalized_sidecars() {
+        const RETENTION_BYTES: u64 = 64_000_000;
+        const SIDECAR_BYTES: u64 = 128_000_000;
+
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let facet_runtime = Arc::new(crate::facet_runtime::FacetRuntime::new(tmp.path()));
+        let archived_path = Arc::new(Mutex::new(None));
+        let observer: Arc<dyn journal_sdk_log_writer::LogLifecycleObserver> =
+            Arc::new(InflatingLifecycleObserver {
+                inner: FacetLifecycleObserver {
+                    runtime: Arc::clone(&facet_runtime),
+                    metrics: Arc::new(IngestMetrics::default()),
+                },
+                sidecar_field: "SRC_AS_NAME",
+                sidecar_bytes: SIDECAR_BYTES,
+                archived_path: Arc::clone(&archived_path),
+            });
+        let artifact_sizer: Arc<dyn journal_sdk_log_writer::LogArtifactSizer> =
+            facet_runtime.clone();
+        let mut journal = Log::new_with_hooks(
+            tmp.path(),
+            writer_config(
+                uuid::Uuid::from_bytes([5; 16]),
+                uuid::Uuid::from_bytes([6; 16]),
+                Some(RETENTION_BYTES),
+                false,
+            ),
+            Some(observer),
+            Some(artifact_sizer),
+        )
+        .expect("create artifact-aware writer");
+
+        journal
+            .write_entry_with_timestamps(
+                &[b"MESSAGE=first"],
+                EntryTimestamps::default()
+                    .with_entry_realtime_usec(1_000_000)
+                    .with_entry_monotonic_usec(1),
+            )
+            .expect("write first entry");
+        let active_path =
+            PathBuf::from(journal.active_file().expect("first active journal").path());
+        facet_runtime
+            .observe_active_record(
+                &active_path,
+                &crate::flow::FlowRecord {
+                    src_as_name: "example-as".to_string(),
+                    ..Default::default()
+                },
+            )
+            .expect("record active facet contribution");
+
+        journal
+            .write_entry_with_timestamps(
+                &[b"MESSAGE=second"],
+                EntryTimestamps::default()
+                    .with_entry_realtime_usec(2_000_000)
+                    .with_entry_monotonic_usec(2),
+            )
+            .expect("rotate and write second entry");
+
+        let archived_path = archived_path
+            .lock()
+            .expect("lock archived path")
+            .clone()
+            .expect("rotation event archived path");
+        assert!(
+            !archived_path.exists(),
+            "artifact-aware rotation retention kept {}",
+            archived_path.display()
+        );
+        assert!(
+            !crate::facet_runtime::sidecar_path(&archived_path, "SRC_AS_NAME").exists(),
+            "retention observer kept sidecar for {}",
+            archived_path.display()
+        );
     }
 }

--- a/src/crates/netflow-plugin/src/ingest/service/runtime.rs
+++ b/src/crates/netflow-plugin/src/ingest/service/runtime.rs
@@ -45,8 +45,18 @@ async fn recv_from_any_listener(
 }
 
 impl IngestService {
+    #[allow(dead_code)]
     pub(crate) async fn run(self, shutdown: CancellationToken) -> Result<()> {
         self.run_with_listener_ready(shutdown, |_| {}).await
+    }
+
+    pub(crate) async fn run_with_listener_ready_signal(
+        self,
+        shutdown: CancellationToken,
+        listener_ready: CancellationToken,
+    ) -> Result<()> {
+        self.run_with_listener_ready(shutdown, move |_| listener_ready.cancel())
+            .await
     }
 
     async fn run_with_listener_ready(

--- a/src/crates/netflow-plugin/src/main.rs
+++ b/src/crates/netflow-plugin/src/main.rs
@@ -155,11 +155,6 @@ async fn async_main() -> i32 {
             }
         };
     let query_service = Arc::new(query_service);
-    if let Err(err) = query_service.initialize_facets().await {
-        tracing::error!("failed to initialize facet runtime: {err:#}");
-        return 1;
-    }
-
     let ingest_service = match ingest::IngestService::new_with_facet_runtime(
         config.clone(),
         Arc::clone(&metrics),
@@ -173,6 +168,10 @@ async fn async_main() -> i32 {
             return 1;
         }
     };
+    if let Err(err) = query_service.initialize_facets_before_ingest().await {
+        tracing::error!("failed to initialize facet runtime: {err:#}");
+        return 1;
+    }
     let routing_runtime = ingest_service.routing_runtime();
     let network_sources_runtime = ingest_service.network_sources_runtime();
 
@@ -199,9 +198,18 @@ async fn async_main() -> i32 {
         shutdown.clone(),
     );
 
+    let listener_ready = CancellationToken::new();
+    let direction_migration_pending = facet_runtime.direction_migration_pending();
     let query_service_for_events = Arc::clone(&query_service);
+    let notify_listener_ready = listener_ready.clone();
+    let notify_shutdown = shutdown.clone();
     tokio::spawn(async move {
         let mut notify_rx = notify_rx;
+        if direction_migration_pending
+            && !wait_for_listener_ready(&notify_listener_ready, &notify_shutdown).await
+        {
+            return;
+        }
         while let Some(event) = notify_rx.recv().await {
             let mut reconcile_required = query_service_for_events.process_notify_event(event);
             while let Ok(event) = notify_rx.try_recv() {
@@ -218,7 +226,51 @@ async fn async_main() -> i32 {
     });
 
     let ingest_shutdown = shutdown.clone();
-    let ingest_task = tokio::spawn(async move { ingest_service.run(ingest_shutdown).await });
+    let ingest_listener_ready = listener_ready.clone();
+    let ingest_task = tokio::spawn(async move {
+        ingest_service
+            .run_with_listener_ready_signal(ingest_shutdown, ingest_listener_ready)
+            .await
+    });
+    let direction_migration_task = if direction_migration_pending {
+        let migration_query_service = Arc::clone(&query_service);
+        let migration_listener_ready = listener_ready;
+        let migration_shutdown = shutdown.clone();
+        Some(tokio::spawn(async move {
+            if !wait_for_listener_ready(&migration_listener_ready, &migration_shutdown).await {
+                return;
+            }
+            tracing::info!("starting background netflow DIRECTION facet migration");
+            loop {
+                match migration_query_service
+                    .migrate_direction_facets(migration_shutdown.clone())
+                    .await
+                {
+                    Ok(true) => {
+                        tracing::info!("completed background netflow DIRECTION facet migration");
+                        return;
+                    }
+                    Ok(false) if migration_shutdown.is_cancelled() => return,
+                    Ok(false) => {
+                        tracing::warn!(
+                            "retained journals changed during DIRECTION facet migration; retrying"
+                        );
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            "background netflow DIRECTION facet migration failed; retrying: {err:#}"
+                        );
+                    }
+                }
+                tokio::select! {
+                    _ = migration_shutdown.cancelled() => return,
+                    _ = tokio::time::sleep(Duration::from_secs(30)) => {}
+                }
+            }
+        }))
+    } else {
+        None
+    };
     let mut bmp_task = None;
     if config.enrichment.routing_dynamic.bmp.enabled {
         if let Some(runtime_state) = routing_runtime.clone() {
@@ -348,6 +400,16 @@ async fn async_main() -> i32 {
             Err(_) => {}
         }
     }
+    if let Some(task) = direction_migration_task {
+        match task.await {
+            Ok(()) => {}
+            Err(err) if !err.is_cancelled() => {
+                tracing::error!("DIRECTION migration task join error: {err}");
+                exit_code = 1;
+            }
+            Err(_) => {}
+        }
+    }
     if let Some(task) = bmp_task {
         match task.await {
             Ok(()) => {}
@@ -380,6 +442,16 @@ async fn async_main() -> i32 {
     }
 
     exit_code
+}
+
+async fn wait_for_listener_ready(
+    listener_ready: &CancellationToken,
+    shutdown: &CancellationToken,
+) -> bool {
+    tokio::select! {
+        _ = listener_ready.cancelled() => true,
+        _ = shutdown.cancelled() => false,
+    }
 }
 
 fn runtime_worker_threads() -> usize {

--- a/src/crates/netflow-plugin/src/main.rs
+++ b/src/crates/netflow-plugin/src/main.rs
@@ -203,23 +203,40 @@ async fn async_main() -> i32 {
     let query_service_for_events = Arc::clone(&query_service);
     let notify_listener_ready = listener_ready.clone();
     let notify_shutdown = shutdown.clone();
-    tokio::spawn(async move {
+    let notify_task = tokio::spawn(async move {
         let mut notify_rx = notify_rx;
         if direction_migration_pending
             && !wait_for_listener_ready(&notify_listener_ready, &notify_shutdown).await
         {
             return;
         }
-        while let Some(event) = notify_rx.recv().await {
+        loop {
+            let event = tokio::select! {
+                biased;
+                _ = notify_shutdown.cancelled() => break,
+                event = notify_rx.recv() => event,
+            };
+            let Some(event) = event else {
+                break;
+            };
             let mut reconcile_required = query_service_for_events.process_notify_event(event);
             while let Ok(event) = notify_rx.try_recv() {
                 reconcile_required |= query_service_for_events.process_notify_event(event);
             }
 
-            if reconcile_required
-                && let Err(err) = query_service_for_events.initialize_facets().await
-            {
-                tracing::warn!("netflow facet reconcile after file notification failed: {err:#}");
+            if reconcile_required {
+                match query_service_for_events
+                    .initialize_facets_cancellable(notify_shutdown.clone())
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => break,
+                    Err(err) => {
+                        tracing::warn!(
+                            "netflow facet reconcile after file notification failed: {err:#}"
+                        );
+                    }
+                }
             }
         }
         tracing::info!("netflow journal notify event task terminated");
@@ -410,6 +427,14 @@ async fn async_main() -> i32 {
             Err(_) => {}
         }
     }
+    match notify_task.await {
+        Ok(()) => {}
+        Err(err) if !err.is_cancelled() => {
+            tracing::error!("journal notify event task join error: {err}");
+            exit_code = 1;
+        }
+        Err(_) => {}
+    }
     if let Some(task) = bmp_task {
         match task.await {
             Ok(()) => {}
@@ -449,8 +474,9 @@ async fn wait_for_listener_ready(
     shutdown: &CancellationToken,
 ) -> bool {
     tokio::select! {
-        _ = listener_ready.cancelled() => true,
+        biased;
         _ = shutdown.cancelled() => false,
+        _ = listener_ready.cancelled() => true,
     }
 }
 

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -31,13 +31,18 @@ async fn background_facet_work_waits_for_udp_listener_readiness() {
     let task_listener_ready = listener_ready.clone();
     let task_shutdown = shutdown.clone();
     let task_started = Arc::clone(&started);
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
     let task = tokio::spawn(async move {
+        let _ = entered_tx.send(());
         if wait_for_listener_ready(&task_listener_ready, &task_shutdown).await {
             task_started.store(true, Ordering::Release);
         }
     });
 
-    tokio::task::yield_now().await;
+    tokio::time::timeout(Duration::from_secs(1), entered_rx)
+        .await
+        .expect("listener gate task should start promptly")
+        .expect("listener gate task should report entry");
     assert!(
         !started.load(Ordering::Acquire),
         "background facet work must not begin before the UDP listener is ready"
@@ -55,6 +60,12 @@ async fn background_facet_work_waits_for_udp_listener_readiness() {
     assert!(
         !wait_for_listener_ready(&listener_ready, &shutdown).await,
         "shutdown must not be mistaken for listener readiness"
+    );
+
+    listener_ready.cancel();
+    assert!(
+        !wait_for_listener_ready(&listener_ready, &shutdown).await,
+        "shutdown must win when readiness and shutdown are both signalled"
     );
 }
 

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -1805,13 +1805,50 @@ async fn e2e_flows_function_supports_autocomplete_mode() {
         FlowsFunctionResponse::Table(_) => panic!("expected autocomplete response"),
         FlowsFunctionResponse::Metrics(_) => panic!("expected autocomplete response"),
     };
-    assert_eq!(cidr_response.data.values[0]["value"], "10.1.0.0/16");
-    assert_eq!(cidr_response.data.values[1]["value"], "0.0.0.0/1");
+    assert!(
+        cidr_response
+            .data
+            .values
+            .iter()
+            .any(|entry| entry["value"] == "0.0.0.0/1"),
+        "a generated CIDR containing a retained source address must be returned"
+    );
+    assert!(
+        cidr_response
+            .data
+            .values
+            .iter()
+            .all(|entry| entry["value"] != "10.1.0.0/16"),
+        "a generated CIDR containing no retained source address must be omitted"
+    );
+    assert_eq!(
+        cidr_response.data.values[0]["value"], "0.0.0.0/1",
+        "filtering must preserve the generated CIDR ranking"
+    );
     assert!(
         cidr_response.data.values.iter().all(|entry| entry["value"]
             .as_str()
             .is_some_and(|value| value.contains('/'))),
         "slash autocomplete must return only canonical CIDR candidates"
+    );
+
+    let trailing_dot_response = handler
+        .handle_request(query::FlowsRequest {
+            mode: query::RequestMode::Autocomplete,
+            field: Some("SRC_ADDR".to_string()),
+            term: "10.1./1".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("trailing-dot CIDR autocomplete function call");
+    let trailing_dot_response = match trailing_dot_response {
+        FlowsFunctionResponse::Autocomplete(response) => response,
+        FlowsFunctionResponse::Table(_) => panic!("expected autocomplete response"),
+        FlowsFunctionResponse::Metrics(_) => panic!("expected autocomplete response"),
+    };
+    assert_eq!(
+        trailing_dot_response.data.values, cidr_response.data.values,
+        "one trailing IPv4 dot before slash must preserve CIDR candidates"
     );
 }
 

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -1,20 +1,20 @@
 use super::{
     FLOWS_FUNCTION_VERSION, FLOWS_UPDATE_EVERY_SECONDS, FlowsFunctionResponse, NetflowFlowsHandler,
-    flows_required_params, ingest, plugin_config, query, tiering,
+    flows_required_params, ingest, plugin_config, query, tiering, wait_for_listener_ready,
 };
 use chrono::Utc;
 use etherparse::{SlicedPacket, TransportSlice};
-use journal_sdk_core::file::Mmap;
+use journal_sdk_core::file::{JournalState, Mmap, MmapMut};
 use journal_sdk_core::repository::File as RepoFile;
 use journal_sdk_core::{Direction, JournalFile, JournalReader, Location};
 use pcap_file::pcap::PcapReader;
 use rt::ProgressState;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::net::UdpSocket as StdUdpSocket;
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -22,6 +22,160 @@ use tokio::net::UdpSocket;
 use tokio_util::sync::CancellationToken;
 
 const E2E_INGEST_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[tokio::test]
+async fn background_facet_work_waits_for_udp_listener_readiness() {
+    let listener_ready = CancellationToken::new();
+    let shutdown = CancellationToken::new();
+    let started = Arc::new(AtomicBool::new(false));
+    let task_listener_ready = listener_ready.clone();
+    let task_shutdown = shutdown.clone();
+    let task_started = Arc::clone(&started);
+    let task = tokio::spawn(async move {
+        if wait_for_listener_ready(&task_listener_ready, &task_shutdown).await {
+            task_started.store(true, Ordering::Release);
+        }
+    });
+
+    tokio::task::yield_now().await;
+    assert!(
+        !started.load(Ordering::Acquire),
+        "background facet work must not begin before the UDP listener is ready"
+    );
+    listener_ready.cancel();
+    tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .expect("listener gate should open promptly")
+        .expect("listener gate task should finish");
+    assert!(started.load(Ordering::Acquire));
+
+    let listener_ready = CancellationToken::new();
+    let shutdown = CancellationToken::new();
+    shutdown.cancel();
+    assert!(
+        !wait_for_listener_ready(&listener_ready, &shutdown).await,
+        "shutdown must not be mistaken for listener readiness"
+    );
+}
+
+#[tokio::test]
+async fn startup_reconciles_reopened_online_journal_as_active_across_restarts() {
+    let (mut cfg, _tmp) = offline_journal_cfg();
+    cfg.listener.sync_every_entries = 1;
+    let raw_dir = cfg.journal.raw_tier_dir();
+    let first_record = crate::flow::FlowRecord {
+        flow_version: "ipfix",
+        protocol: 6,
+        bytes: 100,
+        packets: 1,
+        flows: 1,
+        ..Default::default()
+    };
+
+    let first_runtime = Arc::new(crate::facet_runtime::FacetRuntime::new(
+        &cfg.journal.base_dir(),
+    ));
+    let mut first_ingest = offline_ingest_with_facet_runtime(&cfg, Arc::clone(&first_runtime));
+    assert_eq!(
+        first_ingest.handle_decoded_batch_raw_only_for_test(
+            1_000_000,
+            std::slice::from_ref(&first_record),
+            0,
+        ),
+        0,
+        "the first record should be synced"
+    );
+    drop(first_ingest);
+    drop(first_runtime);
+
+    let journal_paths = journal_files(&raw_dir);
+    assert_eq!(journal_paths.len(), 1, "expected one raw journal");
+    let active_path = journal_paths[0].clone();
+    set_journal_state(&active_path, JournalState::Online);
+
+    // Production startup order: start watching, construct writers so they
+    // register reopened files, then reconcile from a fresh disk inventory.
+    let second_runtime = Arc::new(crate::facet_runtime::FacetRuntime::new(
+        &cfg.journal.base_dir(),
+    ));
+    let (second_query, _notify_rx) =
+        query::FlowQueryService::new_with_facet_runtime(&cfg, Arc::clone(&second_runtime))
+            .await
+            .expect("create second query service");
+    let mut second_ingest = offline_ingest_with_facet_runtime(&cfg, Arc::clone(&second_runtime));
+    second_query
+        .initialize_facets_before_ingest()
+        .await
+        .expect("reconcile reopened journal");
+    assert_eq!(
+        second_runtime
+            .snapshot()
+            .fields
+            .get("PROTOCOL")
+            .expect("protocol facet after first restart")
+            .values
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["6".to_string()])
+    );
+
+    let second_record = crate::flow::FlowRecord {
+        protocol: 17,
+        ..first_record
+    };
+    assert_eq!(
+        second_ingest.handle_decoded_batch_raw_only_for_test(
+            2_000_000,
+            std::slice::from_ref(&second_record),
+            0,
+        ),
+        0,
+        "the post-restart record should be synced"
+    );
+    assert_eq!(
+        second_runtime
+            .snapshot()
+            .fields
+            .get("PROTOCOL")
+            .expect("protocol facet after append")
+            .values
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["6".to_string(), "17".to_string()])
+    );
+    drop(second_ingest);
+    drop(second_query);
+    drop(second_runtime);
+    set_journal_state(&active_path, JournalState::Online);
+
+    let third_runtime = Arc::new(crate::facet_runtime::FacetRuntime::new(
+        &cfg.journal.base_dir(),
+    ));
+    let (third_query, _notify_rx) =
+        query::FlowQueryService::new_with_facet_runtime(&cfg, Arc::clone(&third_runtime))
+            .await
+            .expect("create third query service");
+    let third_ingest = offline_ingest_with_facet_runtime(&cfg, Arc::clone(&third_runtime));
+    third_query
+        .initialize_facets_before_ingest()
+        .await
+        .expect("reconcile journal after second restart");
+    assert_eq!(
+        third_runtime
+            .snapshot()
+            .fields
+            .get("PROTOCOL")
+            .expect("protocol facet after second restart")
+            .values
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["6".to_string(), "17".to_string()])
+    );
+    drop(third_ingest);
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn e2e_ingest_writes_journals_and_query_reads_flows() {
@@ -843,6 +997,29 @@ fn offline_journal_cfg() -> (plugin_config::PluginConfig, TempDir) {
     let mut cfg = plugin_config::PluginConfig::default();
     cfg.journal.journal_dir = tmp.path().join("flows").to_string_lossy().to_string();
     (cfg, tmp)
+}
+
+fn offline_ingest_with_facet_runtime(
+    cfg: &plugin_config::PluginConfig,
+    facet_runtime: Arc<crate::facet_runtime::FacetRuntime>,
+) -> ingest::IngestService {
+    ingest::IngestService::new_with_facet_runtime(
+        cfg.clone(),
+        Arc::new(ingest::IngestMetrics::default()),
+        Arc::new(RwLock::new(tiering::OpenTierState::default())),
+        Arc::new(RwLock::new(tiering::TierFlowIndexStore::default())),
+        facet_runtime,
+    )
+    .expect("create offline ingest service")
+}
+
+fn set_journal_state(path: &Path, state: JournalState) {
+    let repository_file = RepoFile::from_path(path).expect("parse journal path");
+    let mut journal_file =
+        JournalFile::<MmapMut>::open_for_append(&repository_file, 8 * 1024 * 1024)
+            .expect("open journal for state update");
+    journal_file.journal_header_mut().state = state as u8;
+    journal_file.sync().expect("persist journal state");
 }
 
 /// Start of a fully closed 5m bucket ~20-25 minutes in the past: 1m and 5m
@@ -1671,6 +1848,61 @@ async fn e2e_aggregated_safe_group_by_falls_back_to_on_disk_lower_tiers() {
         materialized_tier_files > 0,
         "expected function response query tier to reflect on-disk materialized-tier availability"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_fields_absent_from_rollups_force_raw_tier() {
+    let (cfg, _metrics, _open_tiers, _tier_flow_indexes, _tmp) =
+        ingest_fixture_with_timestamp_source("nfv5.pcap", plugin_config::TimestampSource::Input)
+            .await;
+    let (query_service, _notify_rx) = query::FlowQueryService::new(&cfg)
+        .await
+        .expect("create query service");
+    let before = Utc::now().timestamp().max(1).saturating_add(3600);
+
+    let requests = [
+        (
+            "group-by",
+            query::FlowsRequest {
+                view: query::ViewMode::TableSankey,
+                after: Some(1),
+                before: Some(before),
+                group_by: vec!["DST_AS_PATH".to_string()],
+                ..Default::default()
+            },
+        ),
+        (
+            "selection",
+            query::FlowsRequest {
+                view: query::ViewMode::TableSankey,
+                after: Some(1),
+                before: Some(before),
+                group_by: vec!["PROTOCOL".to_string()],
+                selections: HashMap::from([(
+                    "MPLS_LABELS".to_string(),
+                    vec!["synthetic-no-match".to_string()],
+                )]),
+                ..Default::default()
+            },
+        ),
+    ];
+
+    for (case, request) in requests {
+        let output = query_service
+            .query_flows(&request)
+            .await
+            .unwrap_or_else(|error| panic!("{case} raw-tier query failed: {error}"));
+        assert_eq!(
+            output.stats.get("query_forced_raw_tier").copied(),
+            Some(1),
+            "{case} on a field absent from rollups must force the raw tier"
+        );
+        assert_eq!(
+            output.stats.get("query_tier").copied(),
+            Some(0),
+            "{case} on a field absent from rollups must execute on raw data"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -23,6 +23,37 @@ use tokio_util::sync::CancellationToken;
 
 const E2E_INGEST_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 
+fn assert_json_object_key_order(value: &serde_json::Value, expected: &[&str]) {
+    let actual = value
+        .as_object()
+        .expect("JSON object")
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+
+    let serialized = serde_json::to_string(value).expect("serialize JSON object");
+    let mut cursor = 0;
+    for key in expected {
+        let needle = format!("\"{key}\":");
+        let offset = serialized[cursor..]
+            .find(&needle)
+            .unwrap_or_else(|| panic!("missing {key} in {serialized}"));
+        cursor += offset + needle.len();
+    }
+}
+
+fn assert_group_description_order(description: &str, expected: &[&str]) {
+    let mut cursor = 0;
+    for field in expected {
+        let needle = format!("{field}=");
+        let offset = description[cursor..]
+            .find(&needle)
+            .unwrap_or_else(|| panic!("missing {field} in {description}"));
+        cursor += offset + needle.len();
+    }
+}
+
 #[tokio::test]
 async fn background_facet_work_waits_for_udp_listener_readiness() {
     let listener_ready = CancellationToken::new();
@@ -1431,8 +1462,15 @@ async fn e2e_projected_timeseries_tolerates_torn_raw_tail() {
 }
 
 #[test]
-fn default_group_by_required_param_preserves_selected_field_order() {
-    let request = query::FlowsRequest::default();
+fn group_by_required_param_preserves_selected_field_order() {
+    let request = query::FlowsRequest {
+        group_by: vec![
+            "DST_ADDR".to_string(),
+            "PROTOCOL".to_string(),
+            "SRC_ADDR".to_string(),
+        ],
+        ..Default::default()
+    };
     let params = flows_required_params(
         request.normalized_view(),
         &request.normalized_group_by(),
@@ -1452,10 +1490,7 @@ fn default_group_by_required_param_preserves_selected_field_order() {
         .map(|option| option.id.as_str())
         .collect();
 
-    assert_eq!(
-        selected_fields,
-        vec!["SRC_AS_NAME", "PROTOCOL", "DST_AS_NAME"]
-    );
+    assert_eq!(selected_fields, vec!["DST_ADDR", "PROTOCOL", "SRC_ADDR"]);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1469,17 +1504,20 @@ async fn e2e_flows_function_returns_expected_response_sections() {
         .expect("create query service");
     let handler = NetflowFlowsHandler::new(Arc::clone(&metrics), Arc::new(query_service));
     let before = Utc::now().timestamp().max(1).saturating_add(3600);
+    let expected_group_by = vec![
+        "SRC_ADDR".to_string(),
+        "PROTOCOL".to_string(),
+        "DST_AS_NAME".to_string(),
+        "SRC_AS_NAME".to_string(),
+        "DST_ADDR".to_string(),
+    ];
 
     let response = handler
         .handle_request(query::FlowsRequest {
             view: query::ViewMode::TableSankey,
             after: Some(1),
             before: Some(before),
-            group_by: vec![
-                "SRC_ADDR".to_string(),
-                "DST_ADDR".to_string(),
-                "PROTOCOL".to_string(),
-            ],
+            group_by: expected_group_by.clone(),
             top_n: query::TopN::N100,
             ..Default::default()
         })
@@ -1496,6 +1534,7 @@ async fn e2e_flows_function_returns_expected_response_sections() {
     assert_eq!(response.update_every, FLOWS_UPDATE_EVERY_SECONDS);
     assert_eq!(response.response_type, "flows");
     assert_eq!(response.data.view, "table-sankey");
+    assert_eq!(response.data.group_by, expected_group_by);
     assert_eq!(
         response
             .data
@@ -1503,8 +1542,20 @@ async fn e2e_flows_function_returns_expected_response_sections() {
             .as_object()
             .map(|columns| columns.len())
             .unwrap_or_default(),
-        5,
+        7,
         "expected grouped table columns to include only group_by fields plus bytes and packets"
+    );
+    assert_json_object_key_order(
+        &response.data.columns,
+        &[
+            "SRC_ADDR",
+            "PROTOCOL",
+            "DST_AS_NAME",
+            "SRC_AS_NAME",
+            "DST_ADDR",
+            "bytes",
+            "packets",
+        ],
     );
     assert!(response.data.columns.get("timestamp").is_none());
     assert!(response.data.columns.get("durationSec").is_none());
@@ -1517,6 +1568,16 @@ async fn e2e_flows_function_returns_expected_response_sections() {
         "expected non-empty flows data section"
     );
     let first = response.data.flows.first().expect("first grouped flow");
+    assert_json_object_key_order(
+        &first["key"],
+        &[
+            "SRC_ADDR",
+            "PROTOCOL",
+            "DST_AS_NAME",
+            "SRC_AS_NAME",
+            "DST_ADDR",
+        ],
+    );
     assert!(first.get("timestamp").is_none());
     assert!(first.get("duration_sec").is_none());
     assert!(first.get("exporter").is_none());
@@ -1862,6 +1923,11 @@ async fn e2e_flows_metrics_function_returns_top_n_chart_with_on_disk_tier_fallba
     let handler = NetflowFlowsHandler::new(Arc::clone(&metrics), Arc::new(query_service));
     let before = Utc::now().timestamp().max(1).saturating_add(3600);
     let after = before.saturating_sub(3600);
+    let expected_group_by = vec![
+        "SRC_AS_NAME".to_string(),
+        "PROTOCOL".to_string(),
+        "DST_AS_NAME".to_string(),
+    ];
     let materialized_tier_files = tier_file_count(&cfg.journal.hour_1_tier_dir())
         + tier_file_count(&cfg.journal.minute_5_tier_dir())
         + tier_file_count(&cfg.journal.minute_1_tier_dir());
@@ -1871,7 +1937,7 @@ async fn e2e_flows_metrics_function_returns_top_n_chart_with_on_disk_tier_fallba
             view: query::ViewMode::TimeSeries,
             after: Some(after),
             before: Some(before),
-            group_by: vec!["PROTOCOL".to_string()],
+            group_by: expected_group_by.clone(),
             sort_by: query::SortBy::Bytes,
             top_n: query::TopN::N50,
             ..Default::default()
@@ -1890,7 +1956,11 @@ async fn e2e_flows_metrics_function_returns_top_n_chart_with_on_disk_tier_fallba
     assert_eq!(response.response_type, "flows");
     assert_eq!(response.data.view, "timeseries");
     assert_eq!(response.data.metric, "bytes");
-    assert_eq!(response.data.group_by, vec!["PROTOCOL".to_string()]);
+    assert_eq!(response.data.group_by, expected_group_by);
+    assert_json_object_key_order(
+        &response.data.columns,
+        &["SRC_AS_NAME", "PROTOCOL", "DST_AS_NAME"],
+    );
     assert_eq!(response.data.columns["PROTOCOL"]["name"], "Protocol");
     assert_eq!(response.data.chart["view"]["units"], "bytes/s");
     assert_eq!(
@@ -1940,6 +2010,25 @@ async fn e2e_flows_metrics_function_returns_top_n_chart_with_on_disk_tier_fallba
             .unwrap_or(false),
         "expected Top-N chart dimensions limited by request"
     );
+    for id in response.data.chart["view"]["dimensions"]["ids"]
+        .as_array()
+        .expect("timeseries dimension ids")
+    {
+        let labels: serde_json::Value =
+            serde_json::from_str(id.as_str().expect("dimension id string"))
+                .expect("dimension id object");
+        assert_json_object_key_order(&labels, &["SRC_AS_NAME", "PROTOCOL", "DST_AS_NAME"]);
+    }
+    for name in response.data.chart["view"]["dimensions"]["names"]
+        .as_array()
+        .expect("timeseries dimension names")
+    {
+        let name = name.as_str().expect("dimension name string");
+        assert_group_description_order(
+            name,
+            &["Source AS Name", "Protocol", "Destination AS Name"],
+        );
+    }
     assert!(
         response.data.chart["result"]["data"]
             .as_array()
@@ -1969,6 +2058,38 @@ async fn e2e_flows_metrics_function_returns_top_n_chart_with_on_disk_tier_fallba
             .and_then(|param| param.options.iter().find(|option| option.id == "PROTOCOL"))
             .map(|option| option.name.as_str()),
         Some("Protocol")
+    );
+
+    let generic_response = handler
+        .handle_request(query::FlowsRequest {
+            view: query::ViewMode::TimeSeries,
+            after: Some(after),
+            before: Some(before),
+            query: "FLOW_VERSION=v5".to_string(),
+            group_by: expected_group_by,
+            sort_by: query::SortBy::Bytes,
+            top_n: query::TopN::N50,
+            ..Default::default()
+        })
+        .await
+        .expect("generic flow metrics function call");
+    let generic_response = match generic_response {
+        FlowsFunctionResponse::Metrics(response) => response,
+        FlowsFunctionResponse::Table(_) => panic!("expected metrics response"),
+        FlowsFunctionResponse::Autocomplete(_) => panic!("expected metrics response"),
+    };
+    let generic_id = generic_response.data.chart["view"]["dimensions"]["ids"][0]
+        .as_str()
+        .expect("generic dimension id");
+    let generic_labels: serde_json::Value =
+        serde_json::from_str(generic_id).expect("generic dimension id object");
+    assert_json_object_key_order(&generic_labels, &["SRC_AS_NAME", "PROTOCOL", "DST_AS_NAME"]);
+    let generic_name = generic_response.data.chart["view"]["dimensions"]["names"][0]
+        .as_str()
+        .expect("generic dimension name");
+    assert_group_description_order(
+        generic_name,
+        &["Source AS Name", "Protocol", "Destination AS Name"],
     );
 }
 
@@ -2180,6 +2301,10 @@ async fn e2e_country_map_reuses_tuple_table_shape_with_country_keys() {
         4,
         "expected country-map columns to include only country keys plus bytes and packets"
     );
+    assert_json_object_key_order(
+        &response.data.columns,
+        &["SRC_COUNTRY", "DST_COUNTRY", "bytes", "packets"],
+    );
     assert!(response.data.columns.get("timestamp").is_none());
     assert!(response.data.columns.get("durationSec").is_none());
     assert!(response.data.columns.get("exporterIp").is_none());
@@ -2188,6 +2313,7 @@ async fn e2e_country_map_reuses_tuple_table_shape_with_country_keys() {
     assert!(response.data.columns.get("samplingRate").is_none());
 
     let first = response.data.flows.first().expect("first flow row");
+    assert_json_object_key_order(&first["key"], &["SRC_COUNTRY", "DST_COUNTRY"]);
     assert!(
         first["key"].get("SRC_COUNTRY").is_some(),
         "expected country-map rows to expose SRC_COUNTRY"
@@ -2249,6 +2375,26 @@ async fn e2e_state_map_reuses_tuple_table_shape_with_state_keys() {
     assert!(
         !response.data.flows.is_empty(),
         "expected non-empty state-map rows"
+    );
+    assert_json_object_key_order(
+        &response.data.columns,
+        &[
+            "SRC_COUNTRY",
+            "SRC_GEO_STATE",
+            "DST_COUNTRY",
+            "DST_GEO_STATE",
+            "bytes",
+            "packets",
+        ],
+    );
+    assert_json_object_key_order(
+        &response.data.flows[0]["key"],
+        &[
+            "SRC_COUNTRY",
+            "SRC_GEO_STATE",
+            "DST_COUNTRY",
+            "DST_GEO_STATE",
+        ],
     );
     assert!(
         !response
@@ -2332,6 +2478,38 @@ async fn e2e_city_map_reuses_tuple_table_shape_with_city_and_coordinate_keys() {
     assert!(
         !response.data.flows.is_empty(),
         "expected non-empty city-map rows"
+    );
+    assert_json_object_key_order(
+        &response.data.columns,
+        &[
+            "SRC_COUNTRY",
+            "SRC_GEO_STATE",
+            "SRC_GEO_CITY",
+            "SRC_GEO_LATITUDE",
+            "SRC_GEO_LONGITUDE",
+            "DST_COUNTRY",
+            "DST_GEO_STATE",
+            "DST_GEO_CITY",
+            "DST_GEO_LATITUDE",
+            "DST_GEO_LONGITUDE",
+            "bytes",
+            "packets",
+        ],
+    );
+    assert_json_object_key_order(
+        &response.data.flows[0]["key"],
+        &[
+            "SRC_COUNTRY",
+            "SRC_GEO_STATE",
+            "SRC_GEO_CITY",
+            "SRC_GEO_LATITUDE",
+            "SRC_GEO_LONGITUDE",
+            "DST_COUNTRY",
+            "DST_GEO_STATE",
+            "DST_GEO_CITY",
+            "DST_GEO_LATITUDE",
+            "DST_GEO_LONGITUDE",
+        ],
     );
     assert!(
         response

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -414,6 +414,38 @@ async fn e2e_sflow_fixture_persists_expected_raw_journal_fields_and_query_reads_
         output.metrics.get("bytes").copied().unwrap_or(0) > 0,
         "expected selected FLOW_VERSION=sflow query to aggregate bytes"
     );
+
+    let ipv6_network = "2a0c:8880:2::/48"
+        .parse::<ipnet::IpNet>()
+        .expect("fixture IPv6 network");
+    let ipv6_output = query_service
+        .query_flows(&query::FlowsRequest {
+            view: query::ViewMode::TableSankey,
+            after: Some(1),
+            before: Some(before),
+            selections: HashMap::from([("SRC_ADDR".to_string(), vec![ipv6_network.to_string()])]),
+            group_by: vec!["SRC_ADDR".to_string(), "DST_ADDR".to_string()],
+            top_n: query::TopN::N100,
+            ..Default::default()
+        })
+        .await
+        .expect("query sFlow rows with IPv6 CIDR selection");
+
+    assert!(
+        ipv6_output
+            .stats
+            .get("query_matched_entries")
+            .copied()
+            .unwrap_or_default()
+            > 0,
+        "expected IPv6 CIDR to match a persisted sFlow row"
+    );
+    assert!(ipv6_output.flows.iter().all(|row| {
+        row["key"]["SRC_ADDR"]
+            .as_str()
+            .and_then(|value| value.parse::<std::net::IpAddr>().ok())
+            .is_some_and(|address| ipv6_network.contains(&address))
+    }));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1758,6 +1790,29 @@ async fn e2e_flows_function_supports_autocomplete_mode() {
             .contains_key("query_facet_autocomplete_values"),
         "expected autocomplete response stats to include query-specific counters"
     );
+
+    let cidr_response = handler
+        .handle_request(query::FlowsRequest {
+            mode: query::RequestMode::Autocomplete,
+            field: Some("SRC_ADDR".to_string()),
+            term: "10.1/1".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("CIDR autocomplete function call");
+    let cidr_response = match cidr_response {
+        FlowsFunctionResponse::Autocomplete(response) => response,
+        FlowsFunctionResponse::Table(_) => panic!("expected autocomplete response"),
+        FlowsFunctionResponse::Metrics(_) => panic!("expected autocomplete response"),
+    };
+    assert_eq!(cidr_response.data.values[0]["value"], "10.1.0.0/16");
+    assert_eq!(cidr_response.data.values[1]["value"], "0.0.0.0/1");
+    assert!(
+        cidr_response.data.values.iter().all(|entry| entry["value"]
+            .as_str()
+            .is_some_and(|value| value.contains('/'))),
+        "slash autocomplete must return only canonical CIDR candidates"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1917,6 +1972,39 @@ async fn e2e_aggregated_safe_group_by_falls_back_to_on_disk_lower_tiers() {
         output.stats.get("query_tier").copied().unwrap_or(0) > 0,
         materialized_tier_files > 0,
         "expected grouped query tier to reflect on-disk materialized-tier availability"
+    );
+
+    let exporter_cidr_output = query_service
+        .query_flows(&query::FlowsRequest {
+            selections: HashMap::from([(
+                "EXPORTER_IP".to_string(),
+                vec!["127.0.0.0/8".to_string()],
+            )]),
+            ..request.clone()
+        })
+        .await
+        .expect("query rollup-safe exporter CIDR");
+    assert_eq!(
+        exporter_cidr_output
+            .stats
+            .get("query_forced_raw_tier")
+            .copied(),
+        Some(0),
+        "CIDR must not add a raw-tier requirement to a rollup-safe address field"
+    );
+    assert_eq!(
+        exporter_cidr_output
+            .stats
+            .get("query_tier")
+            .copied()
+            .unwrap_or(0)
+            > 0,
+        materialized_tier_files > 0,
+        "exporter CIDR must retain the same on-disk tier availability"
+    );
+    assert_eq!(
+        exporter_cidr_output.metrics, output.metrics,
+        "the fixture's exporter CIDR must match every aggregated row"
     );
 
     let handler = NetflowFlowsHandler::new(Arc::clone(&metrics), Arc::new(query_service));
@@ -2249,7 +2337,7 @@ async fn e2e_selection_filter_uses_streaming_reader_path() {
     };
     let request_match = query::FlowsRequest {
         selections: HashMap::from([("FLOW_VERSION".to_string(), vec!["v5".to_string()])]),
-        ..request_base
+        ..request_base.clone()
     };
     let matched = query_service
         .query_flows(&request_match)
@@ -2316,6 +2404,88 @@ async fn e2e_selection_filter_uses_streaming_reader_path() {
                 .unwrap_or(false)
         }),
         "expected every returned row to respect the multi-value protocol filter"
+    );
+
+    let selected_row = matched.flows.first().expect("matching fixture row");
+    let selected_src = selected_row["key"]["SRC_ADDR"]
+        .as_str()
+        .expect("source address in grouped key");
+    let selected_protocol = selected_row["key"]["PROTOCOL"]
+        .as_str()
+        .expect("protocol in grouped key");
+    let selected_address = selected_src
+        .parse::<std::net::IpAddr>()
+        .expect("fixture source address");
+    let broad_prefix = if selected_address.is_ipv4() { 23 } else { 119 };
+    let broad_network = ipnet::IpNet::new(selected_address, broad_prefix)
+        .expect("valid broad prefix")
+        .trunc();
+    let exact_address = if selected_address.is_ipv4() {
+        "2001:db8::dead"
+    } else {
+        "203.0.113.255"
+    };
+    let cidr_selections = HashMap::from([
+        (
+            "SRC_ADDR".to_string(),
+            vec![exact_address.to_string(), broad_network.to_string()],
+        ),
+        ("PROTOCOL".to_string(), vec![selected_protocol.to_string()]),
+    ]);
+    let request_cidr = query::FlowsRequest {
+        selections: cidr_selections,
+        ..request_base.clone()
+    };
+    let cidr_table = query_service
+        .query_flows(&request_cidr)
+        .await
+        .expect("projected table query with mixed exact and CIDR selection");
+    let cidr_matches = cidr_table
+        .stats
+        .get("query_matched_entries")
+        .copied()
+        .unwrap_or_default();
+    assert!(
+        cidr_matches > 0,
+        "broad CIDR must not be lost when its field also contains an exact address"
+    );
+    assert!(cidr_table.flows.iter().all(|row| {
+        row["key"]["SRC_ADDR"]
+            .as_str()
+            .and_then(|value| value.parse::<std::net::IpAddr>().ok())
+            .is_some_and(|address| {
+                broad_network.contains(&address) || address.to_string() == exact_address
+            })
+            && row["key"]["PROTOCOL"].as_str() == Some(selected_protocol)
+    }));
+
+    let cidr_timeseries = query_service
+        .query_flow_metrics(&query::FlowsRequest {
+            view: query::ViewMode::TimeSeries,
+            ..request_cidr.clone()
+        })
+        .await
+        .expect("projected time-series query with CIDR selection");
+    assert_eq!(
+        cidr_timeseries
+            .stats
+            .get("query_pass_1_matched_entries")
+            .copied(),
+        Some(cidr_matches),
+        "projected table and time-series pass one must apply the same CIDR matcher"
+    );
+
+    let cidr_generic = query_service
+        .query_flows(&query::FlowsRequest {
+            query: "FLOW_VERSION=v5".to_string(),
+            ..request_cidr
+        })
+        .await
+        .expect("generic table query with CIDR selection");
+    assert_eq!(
+        cidr_generic.stats.get("query_matched_entries").copied(),
+        Some(cidr_matches),
+        "generic and projected scans must apply the same CIDR matcher"
     );
 
     let request_miss = query::FlowsRequest {

--- a/src/crates/netflow-plugin/src/main_tests.rs
+++ b/src/crates/netflow-plugin/src/main_tests.rs
@@ -114,6 +114,13 @@ async fn startup_reconciles_reopened_online_journal_as_active_across_restarts() 
             .await
             .expect("create second query service");
     let mut second_ingest = offline_ingest_with_facet_runtime(&cfg, Arc::clone(&second_runtime));
+    assert_eq!(
+        second_runtime
+            .build_reconcile_plan(&[])
+            .current_active_paths,
+        BTreeSet::from([active_path.to_string_lossy().into_owned()]),
+        "the first restart must reopen and register the original journal as the sole active path"
+    );
     second_query
         .initialize_facets_before_ingest()
         .await
@@ -169,6 +176,11 @@ async fn startup_reconciles_reopened_online_journal_as_active_across_restarts() 
             .await
             .expect("create third query service");
     let third_ingest = offline_ingest_with_facet_runtime(&cfg, Arc::clone(&third_runtime));
+    assert_eq!(
+        third_runtime.build_reconcile_plan(&[]).current_active_paths,
+        BTreeSet::from([active_path.to_string_lossy().into_owned()]),
+        "the second restart must reopen and register the original journal as the sole active path"
+    );
     third_query
         .initialize_facets_before_ingest()
         .await
@@ -1305,7 +1317,7 @@ fn truncate_newest_journal_mid_last_entry(dir: &Path) {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn e2e_query_service_timeseries_path_returns_chart_data() {
+async fn e2e_query_service_timeseries_paths_return_chart_data() {
     let (cfg, _metrics, _open_tiers, _tier_flow_indexes, _tmp) = ingest_fixture("nfv5.pcap").await;
     let (query_service, _notify_rx) = query::FlowQueryService::new(&cfg)
         .await
@@ -1313,28 +1325,77 @@ async fn e2e_query_service_timeseries_path_returns_chart_data() {
     let before = Utc::now().timestamp().max(1).saturating_add(3600);
     let after = before.saturating_sub(3600);
 
+    for query in ["", "PROTOCOL="] {
+        let output = query_service
+            .query_flow_metrics(&query::FlowsRequest {
+                view: query::ViewMode::TimeSeries,
+                after: Some(after),
+                before: Some(before),
+                query: query.to_string(),
+                group_by: vec!["PROTOCOL".to_string()],
+                sort_by: query::SortBy::Bytes,
+                top_n: query::TopN::N25,
+                ..Default::default()
+            })
+            .await
+            .expect("query timeseries metrics");
+
+        assert_eq!(output.metric, "bytes");
+        assert_eq!(output.group_by, vec!["PROTOCOL".to_string()]);
+        assert!(
+            output.chart["result"]["data"]
+                .as_array()
+                .map(|rows| !rows.is_empty())
+                .unwrap_or(false),
+            "expected timeseries chart rows from query service"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_projected_timeseries_tolerates_torn_raw_tail() {
+    let (cfg, _tmp) = offline_journal_cfg();
+    for tier_dir in [
+        cfg.journal.raw_tier_dir(),
+        cfg.journal.minute_1_tier_dir(),
+        cfg.journal.minute_5_tier_dir(),
+        cfg.journal.hour_1_tier_dir(),
+    ] {
+        fs::create_dir_all(&tier_dir)
+            .unwrap_or_else(|err| panic!("create tier dir {}: {}", tier_dir.display(), err));
+    }
+    let base = closed_5m_base();
+    write_raw_flows(
+        &cfg,
+        0x42,
+        1,
+        &[
+            (base + 1_000_000, 1),
+            (base + 61_000_000, 2),
+            (base + 121_000_000, 3),
+        ],
+    );
+    truncate_newest_journal_mid_last_entry(&cfg.journal.raw_tier_dir());
+
+    let (query_service, _notify_rx) = query::FlowQueryService::new(&cfg)
+        .await
+        .expect("create query service over torn raw journal");
     let output = query_service
         .query_flow_metrics(&query::FlowsRequest {
             view: query::ViewMode::TimeSeries,
-            after: Some(after),
-            before: Some(before),
-            group_by: vec!["PROTOCOL".to_string()],
+            after: Some((base / 1_000_000) as i64),
+            before: Some((base / 1_000_000) as i64 + 180),
+            group_by: vec!["SRC_ADDR".to_string()],
             sort_by: query::SortBy::Bytes,
             top_n: query::TopN::N25,
             ..Default::default()
         })
         .await
-        .expect("query timeseries metrics");
+        .expect("projected time-series query must tolerate the torn raw tail");
 
-    assert_eq!(output.metric, "bytes");
-    assert_eq!(output.group_by, vec!["PROTOCOL".to_string()]);
-    assert!(
-        output.chart["result"]["data"]
-            .as_array()
-            .map(|rows| !rows.is_empty())
-            .unwrap_or(false),
-        "expected timeseries chart rows from query service"
-    );
+    assert_eq!(output.stats.get("query_pass_1_matched_entries"), Some(&2));
+    assert_eq!(output.stats.get("query_pass_2_matched_entries"), Some(&2));
+    assert_eq!(output.stats.get("query_returned_dimensions"), Some(&2));
 }
 
 #[test]
@@ -1502,44 +1563,47 @@ async fn e2e_flows_function_returns_expected_response_sections() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn e2e_flows_function_marks_progress_complete_with_execution_context() {
+async fn e2e_flows_function_marks_table_and_timeseries_progress_complete() {
     let (cfg, metrics, _open_tiers, _tier_flow_indexes, _tmp) = ingest_fixture("nfv5.pcap").await;
     let (query_service, _notify_rx) = query::FlowQueryService::new(&cfg)
         .await
         .expect("create query service");
     let handler = NetflowFlowsHandler::new(Arc::clone(&metrics), Arc::new(query_service));
     let before = Utc::now().timestamp().max(1).saturating_add(3600);
-    let progress = ProgressState::default();
-    let execution = query::QueryExecutionContext::new(progress.clone(), CancellationToken::new());
+    for view in [query::ViewMode::TableSankey, query::ViewMode::TimeSeries] {
+        let progress = ProgressState::default();
+        let execution =
+            query::QueryExecutionContext::new(progress.clone(), CancellationToken::new());
 
-    let response = handler
-        .handle_request_with_execution(
-            Some(execution),
-            query::FlowsRequest {
-                view: query::ViewMode::TableSankey,
-                after: Some(1),
-                before: Some(before),
-                group_by: vec![
-                    "SRC_ADDR".to_string(),
-                    "DST_ADDR".to_string(),
-                    "PROTOCOL".to_string(),
-                ],
-                top_n: query::TopN::N100,
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("flows function call with execution");
+        let response = handler
+            .handle_request_with_execution(
+                Some(execution),
+                query::FlowsRequest {
+                    view,
+                    after: Some(1),
+                    before: Some(before),
+                    group_by: vec![
+                        "SRC_ADDR".to_string(),
+                        "DST_ADDR".to_string(),
+                        "PROTOCOL".to_string(),
+                    ],
+                    top_n: query::TopN::N100,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("flows function call with execution");
 
-    match response {
-        FlowsFunctionResponse::Table(_) => {}
-        FlowsFunctionResponse::Metrics(_) => panic!("expected table response"),
-        FlowsFunctionResponse::Autocomplete(_) => panic!("expected table response"),
+        match (view, response) {
+            (query::ViewMode::TableSankey, FlowsFunctionResponse::Table(_))
+            | (query::ViewMode::TimeSeries, FlowsFunctionResponse::Metrics(_)) => {}
+            _ => panic!("response type did not match the requested view"),
+        }
+
+        let (done, total) = progress.snapshot();
+        assert!(total > 0, "expected progress total to be initialized");
+        assert_eq!(done, total, "expected completed progress after response");
     }
-
-    let (done, total) = progress.snapshot();
-    assert!(total > 0, "expected progress total to be initialized");
-    assert_eq!(done, total, "expected completed progress after response");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1604,41 +1668,43 @@ async fn e2e_flows_function_marks_progress_complete_for_empty_projected_query() 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn e2e_flows_function_honors_cancelled_execution_context() {
+async fn e2e_flows_function_honors_cancelled_table_and_timeseries_contexts() {
     let (cfg, metrics, _open_tiers, _tier_flow_indexes, _tmp) = ingest_fixture("nfv5.pcap").await;
     let (query_service, _notify_rx) = query::FlowQueryService::new(&cfg)
         .await
         .expect("create query service");
     let handler = NetflowFlowsHandler::new(Arc::clone(&metrics), Arc::new(query_service));
     let before = Utc::now().timestamp().max(1).saturating_add(3600);
-    let cancellation = CancellationToken::new();
-    cancellation.cancel();
-    let execution = query::QueryExecutionContext::new(ProgressState::default(), cancellation);
+    for view in [query::ViewMode::TableSankey, query::ViewMode::TimeSeries] {
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let execution = query::QueryExecutionContext::new(ProgressState::default(), cancellation);
 
-    let err = handler
-        .handle_request_with_execution(
-            Some(execution),
-            query::FlowsRequest {
-                view: query::ViewMode::TableSankey,
-                after: Some(1),
-                before: Some(before),
-                group_by: vec![
-                    "SRC_ADDR".to_string(),
-                    "DST_ADDR".to_string(),
-                    "PROTOCOL".to_string(),
-                ],
-                top_n: query::TopN::N100,
-                ..Default::default()
-            },
-        )
-        .await
-        .expect_err("cancelled execution should fail");
+        let err = handler
+            .handle_request_with_execution(
+                Some(execution),
+                query::FlowsRequest {
+                    view,
+                    after: Some(1),
+                    before: Some(before),
+                    group_by: vec![
+                        "SRC_ADDR".to_string(),
+                        "DST_ADDR".to_string(),
+                        "PROTOCOL".to_string(),
+                    ],
+                    top_n: query::TopN::N100,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("cancelled execution should fail");
 
-    let message = err.to_string();
-    assert!(
-        message.contains("cancelled"),
-        "expected cancellation error, got: {message}"
-    );
+        let message = err.to_string();
+        assert!(
+            message.contains("cancelled"),
+            "expected cancellation error, got: {message}"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1743,6 +1809,32 @@ async fn e2e_flows_metrics_function_returns_top_n_chart_with_on_disk_tier_fallba
     assert_eq!(
         response.data.stats.get("query_bucket_seconds").copied(),
         Some(60)
+    );
+    assert_eq!(
+        response
+            .data
+            .stats
+            .get("query_pass_1_streamed_entries")
+            .copied(),
+        response
+            .data
+            .stats
+            .get("query_pass_2_streamed_entries")
+            .copied(),
+        "expected both time-series passes to scan the same planned source rows"
+    );
+    assert_eq!(
+        response
+            .data
+            .stats
+            .get("query_pass_1_matched_entries")
+            .copied(),
+        response
+            .data
+            .stats
+            .get("query_pass_2_matched_entries")
+            .copied(),
+        "expected both time-series passes to apply the same filters"
     );
     assert_eq!(
         response.data.stats.get("decoded_parse_attempts").copied(),

--- a/src/crates/netflow-plugin/src/plugin_config/types/journal.rs
+++ b/src/crates/netflow-plugin/src/plugin_config/types/journal.rs
@@ -52,9 +52,11 @@ pub(crate) struct JournalConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct JournalTierRetentionConfig {
-    /// Hard size cap. Unset (`null`) disables the size limit; the tier
-    /// is then bounded only by `duration_of_journal_files`. Defaults to
-    /// the tier-default size if the field is omitted.
+    /// Retained journal and per-journal facet-sidecar budget. The active journal
+    /// is protected and may temporarily exceed it. Unset (`null`) disables the
+    /// size limit; the tier is then bounded only by
+    /// `duration_of_journal_files`. Defaults to the tier-default size if the
+    /// field is omitted.
     #[serde(
         default = "default_retention_size_of_journal_files_opt",
         deserialize_with = "deserialize_opt_bytesize",

--- a/src/crates/netflow-plugin/src/query.rs
+++ b/src/crates/netflow-plugin/src/query.rs
@@ -16,7 +16,9 @@ use journal_sdk_core::file::{JournalFileMap, Mmap};
 use journal_sdk_core::{
     Direction as JournalDirection, JournalCursor, JournalFile, JournalReader, Location,
 };
-use journal_sdk_registry::{FileInfo, Monitor, Registry, repository::File as RegistryFile};
+use journal_sdk_registry::{
+    FileInfo, Monitor, Registry, TimeRange, repository::File as RegistryFile,
+};
 use notify::Event;
 use regex::Regex;
 use serde::de::Error as _;

--- a/src/crates/netflow-plugin/src/query/facets/cache.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache.rs
@@ -1,9 +1,11 @@
 use super::super::*;
+mod cidr;
 mod payload;
 mod scan;
 mod service;
 mod vocabulary;
 
+pub(crate) use cidr::*;
 pub(crate) use payload::*;
 pub(crate) use scan::*;
 pub(crate) use vocabulary::*;

--- a/src/crates/netflow-plugin/src/query/facets/cache/cidr.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/cidr.rs
@@ -1,0 +1,253 @@
+use crate::facet_catalog::{FacetValueKind, facet_field_spec};
+use ipnet::IpNet;
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use crate::facet_runtime::FACET_AUTOCOMPLETE_LIMIT;
+
+struct LooseIpAddress {
+    address: IpAddr,
+    natural_prefix: u8,
+    max_prefix: u8,
+}
+
+pub(crate) fn cidr_autocomplete_values(field: &str, term: &str) -> Option<Vec<String>> {
+    let spec = facet_field_spec(field)?;
+    if spec.kind != FacetValueKind::IpAddr || !term.contains('/') {
+        return None;
+    }
+
+    Some(generate_cidr_candidates(term))
+}
+
+fn generate_cidr_candidates(term: &str) -> Vec<String> {
+    let Some((address_fragment, prefix_fragment)) = term.split_once('/') else {
+        return Vec::new();
+    };
+    if address_fragment.is_empty()
+        || prefix_fragment.contains('/')
+        || (!prefix_fragment.is_empty()
+            && !prefix_fragment.bytes().all(|byte| byte.is_ascii_digit()))
+    {
+        return Vec::new();
+    }
+
+    let Some(loose) = parse_loose_ip_address(address_fragment) else {
+        return Vec::new();
+    };
+    let prefixes = matching_prefix_lengths(prefix_fragment, loose.natural_prefix, loose.max_prefix);
+    let mut seen = HashSet::with_capacity(prefixes.len());
+    let mut values = Vec::with_capacity(prefixes.len().min(FACET_AUTOCOMPLETE_LIMIT));
+
+    for prefix in prefixes {
+        let Ok(network) = IpNet::new(loose.address, prefix) else {
+            continue;
+        };
+        let value = network.trunc().to_string();
+        if seen.insert(value.clone()) {
+            values.push(value);
+            if values.len() >= FACET_AUTOCOMPLETE_LIMIT {
+                break;
+            }
+        }
+    }
+    values
+}
+
+fn parse_loose_ip_address(fragment: &str) -> Option<LooseIpAddress> {
+    if fragment.contains(':') {
+        parse_loose_ipv6(fragment)
+    } else {
+        parse_loose_ipv4(fragment)
+    }
+}
+
+fn parse_loose_ipv4(fragment: &str) -> Option<LooseIpAddress> {
+    let octets = fragment.split('.').collect::<Vec<_>>();
+    if octets.is_empty() || octets.len() > 4 {
+        return None;
+    }
+
+    let mut address = [0_u8; 4];
+    for (index, octet) in octets.iter().enumerate() {
+        if octet.is_empty() || !octet.bytes().all(|byte| byte.is_ascii_digit()) {
+            return None;
+        }
+        address[index] = octet.parse().ok()?;
+    }
+
+    Some(LooseIpAddress {
+        address: IpAddr::V4(Ipv4Addr::from(address)),
+        natural_prefix: (octets.len() * 8) as u8,
+        max_prefix: 32,
+    })
+}
+
+fn parse_loose_ipv6(fragment: &str) -> Option<LooseIpAddress> {
+    if let Ok(address) = fragment.parse::<Ipv6Addr>() {
+        let natural_prefix = if fragment.ends_with("::") {
+            fragment
+                .trim_end_matches("::")
+                .split(':')
+                .filter(|component| !component.is_empty())
+                .count()
+                .saturating_mul(16) as u8
+        } else {
+            128
+        };
+        return Some(LooseIpAddress {
+            address: IpAddr::V6(address),
+            natural_prefix,
+            max_prefix: 128,
+        });
+    }
+
+    if fragment.contains("::") {
+        return None;
+    }
+    let hextets = fragment.split(':').collect::<Vec<_>>();
+    if hextets.is_empty() || hextets.len() >= 8 {
+        return None;
+    }
+    if hextets.iter().any(|hextet| {
+        hextet.is_empty()
+            || hextet.len() > 4
+            || !hextet.bytes().all(|byte| byte.is_ascii_hexdigit())
+    }) {
+        return None;
+    }
+
+    let address = format!("{fragment}::").parse::<Ipv6Addr>().ok()?;
+    Some(LooseIpAddress {
+        address: IpAddr::V6(address),
+        natural_prefix: (hextets.len() * 16) as u8,
+        max_prefix: 128,
+    })
+}
+
+fn matching_prefix_lengths(fragment: &str, natural: u8, max: u8) -> Vec<u8> {
+    if fragment.is_empty() {
+        return vec![natural];
+    }
+
+    let mut matching = (0..=max)
+        .filter(|prefix| prefix.to_string().starts_with(fragment))
+        .collect::<Vec<_>>();
+    if matching.is_empty() {
+        return matching;
+    }
+
+    let mut ranked = Vec::with_capacity(matching.len());
+    if matching.contains(&natural) {
+        ranked.push(natural);
+    }
+    if let Ok(exact) = fragment.parse::<u8>()
+        && matching.contains(&exact)
+        && !ranked.contains(&exact)
+    {
+        ranked.push(exact);
+    }
+    for prefix in matching.drain(..) {
+        if !ranked.contains(&prefix) {
+            ranked.push(prefix);
+        }
+    }
+    ranked
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slash_is_required_and_only_ip_fields_are_synthetic() {
+        assert_eq!(cidr_autocomplete_values("SRC_ADDR", "10"), None);
+        assert_eq!(cidr_autocomplete_values("PROTOCOL", "10/8"), None);
+        assert_eq!(cidr_autocomplete_values("SRC_PREFIX", "10/8"), None);
+        for field in [
+            "EXPORTER_IP",
+            "SRC_ADDR",
+            "DST_ADDR",
+            "NEXT_HOP",
+            "SRC_ADDR_NAT",
+            "DST_ADDR_NAT",
+        ] {
+            assert_eq!(
+                cidr_autocomplete_values(field, "10/8"),
+                Some(vec!["10.0.0.0/8".to_string()]),
+                "{field}"
+            );
+        }
+    }
+
+    #[test]
+    fn loose_ipv4_completion_returns_canonical_networks() {
+        for (term, expected) in [
+            ("10/", "10.0.0.0/8"),
+            ("10/8", "10.0.0.0/8"),
+            ("10.1/", "10.1.0.0/16"),
+            ("10.1.2.3/24", "10.1.2.0/24"),
+        ] {
+            assert_eq!(
+                generate_cidr_candidates(term).first().map(String::as_str),
+                Some(expected),
+                "{term}"
+            );
+        }
+    }
+
+    #[test]
+    fn prefix_fragments_rank_natural_then_exact_and_only_return_canonical_values() {
+        let values = generate_cidr_candidates("10.1/1");
+        assert_eq!(values.first().map(String::as_str), Some("10.1.0.0/16"));
+        assert_eq!(values.get(1).map(String::as_str), Some("0.0.0.0/1"));
+        assert!(values.contains(&"10.0.0.0/10".to_string()));
+        assert!(values.contains(&"10.1.0.0/19".to_string()));
+        assert!(!values.contains(&"10.1.0.0/1".to_string()));
+    }
+
+    #[test]
+    fn loose_ipv6_completion_returns_canonical_networks() {
+        for (term, expected) in [
+            ("2001:db8/", "2001:db8::/32"),
+            ("2001:db8/32", "2001:db8::/32"),
+            ("2001:db8:1/48", "2001:db8:1::/48"),
+            ("2001:db8::1/64", "2001:db8::/64"),
+            ("2001:DB8::/32", "2001:db8::/32"),
+        ] {
+            assert_eq!(
+                generate_cidr_candidates(term).first().map(String::as_str),
+                Some(expected),
+                "{term}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_or_incomplete_cidr_fragments_return_no_candidates() {
+        for term in [
+            "/8",
+            "10./8",
+            "10.300/8",
+            "10/33",
+            "10/a",
+            "10/8/9",
+            "2001::db8::/32",
+            "2001:db8:/32",
+            "2001:db8/129",
+        ] {
+            assert!(generate_cidr_candidates(term).is_empty(), "{term}");
+        }
+    }
+
+    #[test]
+    fn boundary_prefixes_are_supported_for_both_families() {
+        assert_eq!(generate_cidr_candidates("10.1.2.3/0"), ["0.0.0.0/0"]);
+        assert_eq!(generate_cidr_candidates("10.1.2.3/32"), ["10.1.2.3/32"]);
+        assert_eq!(generate_cidr_candidates("2001:db8::1/0"), ["::/0"]);
+        assert_eq!(
+            generate_cidr_candidates("2001:db8::1/128"),
+            ["2001:db8::1/128"]
+        );
+    }
+}

--- a/src/crates/netflow-plugin/src/query/facets/cache/cidr.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/cidr.rs
@@ -11,16 +11,16 @@ struct LooseIpAddress {
     max_prefix: u8,
 }
 
-pub(crate) fn cidr_autocomplete_values(field: &str, term: &str) -> Option<Vec<String>> {
+pub(crate) fn cidr_autocomplete_networks(field: &str, term: &str) -> Option<Vec<IpNet>> {
     let spec = facet_field_spec(field)?;
     if spec.kind != FacetValueKind::IpAddr || !term.contains('/') {
         return None;
     }
 
-    Some(generate_cidr_candidates(term))
+    Some(generate_cidr_candidate_networks(term))
 }
 
-fn generate_cidr_candidates(term: &str) -> Vec<String> {
+fn generate_cidr_candidate_networks(term: &str) -> Vec<IpNet> {
     let Some((address_fragment, prefix_fragment)) = term.split_once('/') else {
         return Vec::new();
     };
@@ -43,9 +43,9 @@ fn generate_cidr_candidates(term: &str) -> Vec<String> {
         let Ok(network) = IpNet::new(loose.address, prefix) else {
             continue;
         };
-        let value = network.trunc().to_string();
-        if seen.insert(value.clone()) {
-            values.push(value);
+        let network = network.trunc();
+        if seen.insert(network) {
+            values.push(network);
             if values.len() >= FACET_AUTOCOMPLETE_LIMIT {
                 break;
             }
@@ -63,8 +63,12 @@ fn parse_loose_ip_address(fragment: &str) -> Option<LooseIpAddress> {
 }
 
 fn parse_loose_ipv4(fragment: &str) -> Option<LooseIpAddress> {
+    let (fragment, trailing_dot) = match fragment.strip_suffix('.') {
+        Some(fragment) => (fragment, true),
+        None => (fragment, false),
+    };
     let octets = fragment.split('.').collect::<Vec<_>>();
-    if octets.is_empty() || octets.len() > 4 {
+    if octets.is_empty() || octets.len() > 4 || (trailing_dot && octets.len() == 4) {
         return None;
     }
 
@@ -159,11 +163,18 @@ fn matching_prefix_lengths(fragment: &str, natural: u8, max: u8) -> Vec<u8> {
 mod tests {
     use super::*;
 
+    fn generate_cidr_candidates(term: &str) -> Vec<String> {
+        generate_cidr_candidate_networks(term)
+            .into_iter()
+            .map(|network| network.to_string())
+            .collect()
+    }
+
     #[test]
     fn slash_is_required_and_only_ip_fields_are_synthetic() {
-        assert_eq!(cidr_autocomplete_values("SRC_ADDR", "10"), None);
-        assert_eq!(cidr_autocomplete_values("PROTOCOL", "10/8"), None);
-        assert_eq!(cidr_autocomplete_values("SRC_PREFIX", "10/8"), None);
+        assert_eq!(cidr_autocomplete_networks("SRC_ADDR", "10"), None);
+        assert_eq!(cidr_autocomplete_networks("PROTOCOL", "10/8"), None);
+        assert_eq!(cidr_autocomplete_networks("SRC_PREFIX", "10/8"), None);
         for field in [
             "EXPORTER_IP",
             "SRC_ADDR",
@@ -173,8 +184,8 @@ mod tests {
             "DST_ADDR_NAT",
         ] {
             assert_eq!(
-                cidr_autocomplete_values(field, "10/8"),
-                Some(vec!["10.0.0.0/8".to_string()]),
+                cidr_autocomplete_networks(field, "10/8"),
+                Some(vec!["10.0.0.0/8".parse().expect("valid network")]),
                 "{field}"
             );
         }
@@ -184,8 +195,11 @@ mod tests {
     fn loose_ipv4_completion_returns_canonical_networks() {
         for (term, expected) in [
             ("10/", "10.0.0.0/8"),
+            ("10./", "10.0.0.0/8"),
             ("10/8", "10.0.0.0/8"),
             ("10.1/", "10.1.0.0/16"),
+            ("10.1./", "10.1.0.0/16"),
+            ("10.1.2./", "10.1.2.0/24"),
             ("10.1.2.3/24", "10.1.2.0/24"),
         ] {
             assert_eq!(
@@ -227,7 +241,9 @@ mod tests {
     fn invalid_or_incomplete_cidr_fragments_return_no_candidates() {
         for term in [
             "/8",
-            "10./8",
+            "10../8",
+            "10..1/8",
+            "10.1.2.3./24",
             "10.300/8",
             "10/33",
             "10/a",

--- a/src/crates/netflow-plugin/src/query/facets/cache/payload.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/payload.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::facet_catalog::{FacetValueKind, facet_field_spec};
 use std::borrow::Cow;
 use std::collections::HashSet;
 
@@ -21,14 +22,16 @@ pub(crate) fn build_facet_vocabulary_payload(
             continue;
         }
 
-        let autocomplete = total_values > FACET_STATIC_VALUE_LIMIT;
+        let truncated = total_values > FACET_STATIC_VALUE_LIMIT;
+        let autocomplete = truncated
+            || facet_field_spec(field).is_some_and(|spec| spec.kind == FacetValueKind::IpAddr);
         debug_assert_eq!(
             published
                 .map(|field| field.autocomplete)
                 .unwrap_or_default(),
-            autocomplete
+            truncated
         );
-        let published_values = if autocomplete {
+        let published_values = if truncated {
             &[]
         } else {
             published
@@ -51,7 +54,7 @@ pub(crate) fn build_facet_vocabulary_payload(
             "field": field,
             "name": presentation::field_display_name(field),
             "total_values": total_values,
-            "truncated": autocomplete,
+            "truncated": truncated,
             "autocomplete": autocomplete,
             "overflowed": false,
             "overflow_records": 0,

--- a/src/crates/netflow-plugin/src/query/facets/cache/payload.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/payload.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::facet_catalog::{FacetPresentation, facet_field_spec};
 use std::borrow::Cow;
 use std::collections::{BinaryHeap, HashSet};
 
@@ -22,10 +23,13 @@ pub(crate) fn build_facet_vocabulary_payload(
             .map(|field| field.total_values)
             .unwrap_or_default()
             .max(row_count);
-        let autocomplete = published
+        let promoted_to_autocomplete = published
             .map(|field| field.autocomplete)
             .unwrap_or_default();
-        let truncated = autocomplete || total_values > FACET_VALUE_LIMIT;
+        let autocomplete = facet_field_spec(field)
+            .is_some_and(|spec| spec.presentation == FacetPresentation::Autocomplete)
+            || promoted_to_autocomplete;
+        let truncated = promoted_to_autocomplete || total_values > FACET_VALUE_LIMIT;
 
         let values = rows
             .into_iter()

--- a/src/crates/netflow-plugin/src/query/facets/cache/payload.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/payload.rs
@@ -2,6 +2,8 @@ use super::*;
 use std::borrow::Cow;
 use std::collections::HashSet;
 
+const FACET_INLINE_SELECTION_LIMIT: usize = 256;
+
 pub(crate) fn build_facet_vocabulary_payload(
     requested_fields: &[String],
     selections: &HashMap<String, Vec<String>>,
@@ -93,21 +95,28 @@ fn facet_payload_rows<'a>(
     published_values: &'a [String],
     selected_values: &'a [String],
 ) -> Vec<FacetPayloadRow<'a>> {
-    let mut selected_ranks = HashMap::with_capacity(selected_values.len());
+    let mut selected_ranks =
+        HashMap::with_capacity(selected_values.len().min(FACET_INLINE_SELECTION_LIMIT));
+    let mut inline_selected = Vec::with_capacity(selected_ranks.capacity());
     for (rank, value) in selected_values.iter().enumerate() {
-        selected_ranks.entry(value.as_str()).or_insert(rank);
+        if selected_ranks.contains_key(value.as_str()) {
+            continue;
+        }
+        if selected_ranks.len() >= FACET_INLINE_SELECTION_LIMIT {
+            break;
+        }
+        selected_ranks.insert(value.as_str(), rank);
+        inline_selected.push(value.as_str());
     }
 
     let mut missing_selected = Vec::new();
-    if !selected_values.is_empty() {
+    if !inline_selected.is_empty() {
         let published_value_set = published_values
             .iter()
             .map(String::as_str)
             .collect::<HashSet<_>>();
-        let mut missing_selected_seen = HashSet::with_capacity(selected_values.len());
-        for selected in selected_values {
-            let selected = selected.as_str();
-            if published_value_set.contains(selected) || !missing_selected_seen.insert(selected) {
+        for selected in inline_selected {
+            if published_value_set.contains(selected) {
                 continue;
             }
             missing_selected.push(selected);
@@ -175,5 +184,77 @@ mod tests {
 
         assert_ne!(alpha, beta);
         assert_ne!(alpha.cmp(&beta), Ordering::Equal);
+    }
+
+    #[test]
+    fn facet_payload_rows_bound_inline_selections_without_dropping_static_vocabulary() {
+        let published_values = (0..FACET_STATIC_VALUE_LIMIT)
+            .map(|index| format!("published-{index:03}"))
+            .collect::<Vec<_>>();
+        let exact_limit_selected = (0..FACET_INLINE_SELECTION_LIMIT)
+            .map(|index| format!("selected-{index:03}"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            facet_payload_rows("SRC_ADDR", &[], &exact_limit_selected).len(),
+            FACET_INLINE_SELECTION_LIMIT
+        );
+
+        let mut selected_values = vec!["selected-000".to_string()];
+        selected_values
+            .extend((0..=FACET_INLINE_SELECTION_LIMIT).map(|index| format!("selected-{index:03}")));
+
+        let static_rows = facet_payload_rows("SRC_AS_NAME", &published_values, &selected_values);
+        assert_eq!(
+            static_rows.len(),
+            FACET_STATIC_VALUE_LIMIT + FACET_INLINE_SELECTION_LIMIT
+        );
+        assert!(
+            published_values
+                .iter()
+                .all(|value| static_rows.iter().any(|row| row.value == value.as_str()))
+        );
+        assert_eq!(static_rows[0].value, "selected-000");
+        assert_eq!(
+            static_rows[FACET_INLINE_SELECTION_LIMIT - 1].value,
+            format!("selected-{:03}", FACET_INLINE_SELECTION_LIMIT - 1)
+        );
+        assert!(
+            !static_rows
+                .iter()
+                .any(|row| { row.value == format!("selected-{FACET_INLINE_SELECTION_LIMIT:03}") })
+        );
+
+        let autocomplete_rows = facet_payload_rows("SRC_ADDR", &[], &selected_values);
+        assert_eq!(autocomplete_rows.len(), FACET_INLINE_SELECTION_LIMIT);
+        assert_eq!(autocomplete_rows[0].value, "selected-000");
+        assert_eq!(
+            autocomplete_rows[FACET_INLINE_SELECTION_LIMIT - 1].value,
+            format!("selected-{:03}", FACET_INLINE_SELECTION_LIMIT - 1)
+        );
+
+        let selections = HashMap::from([("SRC_ADDR".to_string(), selected_values.clone())]);
+        let payload = build_facet_vocabulary_payload(
+            &["SRC_ADDR".to_string()],
+            &selections,
+            &BTreeMap::from([(
+                "SRC_ADDR".to_string(),
+                crate::facet_runtime::FacetPublishedField {
+                    total_values: FACET_STATIC_VALUE_LIMIT + 1,
+                    autocomplete: true,
+                    values: Vec::new(),
+                },
+            )]),
+        );
+        assert_eq!(
+            payload["fields"][0]["values"]
+                .as_array()
+                .expect("facet values")
+                .len(),
+            FACET_INLINE_SELECTION_LIMIT
+        );
+        assert_eq!(
+            payload["auto"]["selections"]["SRC_ADDR"],
+            json!(selected_values)
+        );
     }
 }

--- a/src/crates/netflow-plugin/src/query/facets/cache/payload.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/payload.rs
@@ -1,7 +1,6 @@
 use super::*;
-use crate::facet_catalog::{FacetPresentation, facet_field_spec};
 use std::borrow::Cow;
-use std::collections::{BinaryHeap, HashSet};
+use std::collections::HashSet;
 
 pub(crate) fn build_facet_vocabulary_payload(
     requested_fields: &[String],
@@ -13,23 +12,28 @@ pub(crate) fn build_facet_vocabulary_payload(
     for field in requested_fields {
         let selected_values = selections.get(field).map(Vec::as_slice).unwrap_or_default();
         let published = snapshot_fields.get(field);
-        let published_values = published
-            .map(|field| field.values.as_slice())
-            .unwrap_or_default();
-        let (rows, row_count) =
-            limited_facet_payload_rows(field, published_values, selected_values);
-
         let total_values = published
             .map(|field| field.total_values)
-            .unwrap_or_default()
-            .max(row_count);
-        let promoted_to_autocomplete = published
-            .map(|field| field.autocomplete)
             .unwrap_or_default();
-        let autocomplete = facet_field_spec(field)
-            .is_some_and(|spec| spec.presentation == FacetPresentation::Autocomplete)
-            || promoted_to_autocomplete;
-        let truncated = promoted_to_autocomplete || total_values > FACET_VALUE_LIMIT;
+        if selected_values.is_empty() && total_values == 0 {
+            continue;
+        }
+
+        let autocomplete = total_values > FACET_STATIC_VALUE_LIMIT;
+        debug_assert_eq!(
+            published
+                .map(|field| field.autocomplete)
+                .unwrap_or_default(),
+            autocomplete
+        );
+        let published_values = if autocomplete {
+            &[]
+        } else {
+            published
+                .map(|field| field.values.as_slice())
+                .unwrap_or_default()
+        };
+        let rows = facet_payload_rows(field, published_values, selected_values);
 
         let values = rows
             .into_iter()
@@ -45,7 +49,7 @@ pub(crate) fn build_facet_vocabulary_payload(
             "field": field,
             "name": presentation::field_display_name(field),
             "total_values": total_values,
-            "truncated": truncated,
+            "truncated": autocomplete,
             "autocomplete": autocomplete,
             "overflowed": false,
             "overflow_records": 0,
@@ -54,7 +58,7 @@ pub(crate) fn build_facet_vocabulary_payload(
     }
 
     json!({
-        "value_limit": FACET_VALUE_LIMIT,
+        "value_limit": FACET_STATIC_VALUE_LIMIT,
         "overflowed_fields": 0,
         "overflowed_records": 0,
         "fields": fields,
@@ -84,11 +88,11 @@ impl PartialOrd for FacetPayloadRow<'_> {
     }
 }
 
-fn limited_facet_payload_rows<'a>(
+fn facet_payload_rows<'a>(
     field: &str,
     published_values: &'a [String],
     selected_values: &'a [String],
-) -> (Vec<FacetPayloadRow<'a>>, usize) {
+) -> Vec<FacetPayloadRow<'a>> {
     let mut selected_ranks = HashMap::with_capacity(selected_values.len());
     for (rank, value) in selected_values.iter().enumerate() {
         selected_ranks.entry(value.as_str()).or_insert(rank);
@@ -110,34 +114,20 @@ fn limited_facet_payload_rows<'a>(
         }
     }
 
-    let row_count = published_values.len() + missing_selected.len();
-
-    if row_count <= FACET_VALUE_LIMIT {
-        let mut rows = Vec::with_capacity(row_count);
-        rows.extend(
-            published_values
-                .iter()
-                .map(|value| facet_payload_row(field, value, &selected_ranks)),
-        );
-        rows.extend(
-            missing_selected
-                .iter()
-                .copied()
-                .map(|value| facet_payload_row(field, value, &selected_ranks)),
-        );
-        rows.sort();
-        return (rows, row_count);
-    }
-
-    let mut rows = BinaryHeap::with_capacity(FACET_VALUE_LIMIT);
-    for value in published_values {
-        push_limited_facet_payload_row(&mut rows, facet_payload_row(field, value, &selected_ranks));
-    }
-    for value in missing_selected {
-        push_limited_facet_payload_row(&mut rows, facet_payload_row(field, value, &selected_ranks));
-    }
-
-    (rows.into_sorted_vec(), row_count)
+    let mut rows = Vec::with_capacity(published_values.len() + missing_selected.len());
+    rows.extend(
+        published_values
+            .iter()
+            .map(|value| facet_payload_row(field, value, &selected_ranks)),
+    );
+    rows.extend(
+        missing_selected
+            .iter()
+            .copied()
+            .map(|value| facet_payload_row(field, value, &selected_ranks)),
+    );
+    rows.sort();
+    rows
 }
 
 fn facet_payload_row<'a>(
@@ -151,25 +141,6 @@ fn facet_payload_row<'a>(
             .map(Cow::Owned)
             .unwrap_or(Cow::Borrowed(value)),
         selected_rank: selected_ranks.get(value).copied(),
-    }
-}
-
-fn push_limited_facet_payload_row<'a>(
-    rows: &mut BinaryHeap<FacetPayloadRow<'a>>,
-    row: FacetPayloadRow<'a>,
-) {
-    if rows.len() < FACET_VALUE_LIMIT {
-        rows.push(row);
-        return;
-    }
-
-    let replaces_worst = rows
-        .peek()
-        .map(|worst| compare_facet_payload_rows(&row, worst) == Ordering::Less)
-        .unwrap_or(false);
-    if replaces_worst {
-        let _ = rows.pop();
-        rows.push(row);
     }
 }
 

--- a/src/crates/netflow-plugin/src/query/facets/cache/scan.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/scan.rs
@@ -78,7 +78,7 @@ where
         .map(|(field, index)| (field.as_bytes().to_vec(), *index))
         .collect::<FastHashMap<_, _>>();
     let prefilter_matches = build_prefilter_matches(prefilter_pairs);
-    scan_journal_files_forward(
+    scan_journal_files_forward_with_checkpoint(
         file_paths,
         None,
         None,
@@ -87,7 +87,8 @@ where
         0,
         &prefilter_matches,
         "targeted facet vocabulary scan",
-        |file_path, journal, _timestamp_usec, data_offsets, decompress_buf| {
+        check_cancelled,
+        |file_path, journal, _timestamp_usec, data_offsets, decompress_buf, check_cancelled| {
             check_cancelled()?;
             for value in &mut captured_values {
                 let _ = value.take();

--- a/src/crates/netflow-plugin/src/query/facets/cache/scan.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/scan.rs
@@ -1,17 +1,26 @@
 use super::*;
 
-pub(crate) fn accumulate_simple_closed_file_facet_values(
+pub(crate) fn accumulate_simple_closed_file_facet_values<F>(
     journal: &JournalFileMap,
     requested_fields: &[String],
     by_field: &mut BTreeMap<String, BTreeSet<String>>,
-) -> Result<()> {
+    check_cancelled: &mut F,
+) -> Result<()>
+where
+    F: FnMut() -> Result<()>,
+{
     let mut decompress_buf = Vec::new();
 
     for field in requested_fields {
+        check_cancelled()?;
         let mut iter = journal
             .field_data_objects(field.as_bytes())
             .with_context(|| format!("failed to enumerate field {}", field))?;
-        while let Some(data_guard) = iter.next().transpose()? {
+        loop {
+            check_cancelled()?;
+            let Some(data_guard) = iter.next().transpose()? else {
+                break;
+            };
             let payload = if data_guard.is_compressed() {
                 data_guard.decompress(&mut decompress_buf)?;
                 decompress_buf.as_slice()
@@ -35,16 +44,21 @@ pub(crate) fn accumulate_simple_closed_file_facet_values(
     Ok(())
 }
 
-pub(crate) fn accumulate_targeted_facet_values(
+pub(crate) fn accumulate_targeted_facet_values<F>(
     file_paths: &[PathBuf],
     requested_field: &str,
     prefilter_pairs: &[(String, String)],
     dependency_fields: &[&str],
     by_field: &mut BTreeMap<String, BTreeSet<String>>,
-) -> Result<()> {
+    check_cancelled: &mut F,
+) -> Result<()>
+where
+    F: FnMut() -> Result<()>,
+{
     if file_paths.is_empty() || dependency_fields.is_empty() {
         return Ok(());
     }
+    check_cancelled()?;
 
     let mut captured_fields = dependency_fields
         .iter()
@@ -74,6 +88,7 @@ pub(crate) fn accumulate_targeted_facet_values(
         &prefilter_matches,
         "targeted facet vocabulary scan",
         |file_path, journal, _timestamp_usec, data_offsets, decompress_buf| {
+            check_cancelled()?;
             for value in &mut captured_values {
                 let _ = value.take();
             }
@@ -84,6 +99,7 @@ pub(crate) fn accumulate_targeted_facet_values(
                 data_offsets,
                 decompress_buf,
                 |payload| {
+                    check_cancelled()?;
                     let Some((key_bytes, value_bytes)) = split_payload_bytes(payload) else {
                         return Ok(());
                     };

--- a/src/crates/netflow-plugin/src/query/facets/cache/service.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/service.rs
@@ -21,8 +21,18 @@ impl FlowQueryService {
             .context("autocomplete mode requires a field")?;
         let term = request.normalized_autocomplete_term().to_string();
         let started = Instant::now();
-        let values = match cidr_autocomplete_values(&field, &term) {
-            Some(values) => values,
+        let values = match cidr_autocomplete_networks(&field, &term) {
+            Some(networks) => {
+                let retained = self
+                    .facet_runtime
+                    .retained_ip_network_presence(&field, &networks)?;
+                networks
+                    .into_iter()
+                    .zip(retained)
+                    .filter(|(_, retained)| *retained)
+                    .map(|(network, _)| network.to_string())
+                    .collect()
+            }
             None => self.facet_runtime.autocomplete(&field, &term)?,
         };
         let elapsed = started.elapsed().as_millis() as u64;

--- a/src/crates/netflow-plugin/src/query/facets/cache/service.rs
+++ b/src/crates/netflow-plugin/src/query/facets/cache/service.rs
@@ -21,7 +21,10 @@ impl FlowQueryService {
             .context("autocomplete mode requires a field")?;
         let term = request.normalized_autocomplete_term().to_string();
         let started = Instant::now();
-        let values = self.facet_runtime.autocomplete(&field, &term)?;
+        let values = match cidr_autocomplete_values(&field, &term) {
+            Some(values) => values,
+            None => self.facet_runtime.autocomplete(&field, &term)?,
+        };
         let elapsed = started.elapsed().as_millis() as u64;
 
         let rows = values

--- a/src/crates/netflow-plugin/src/query/facets/render.rs
+++ b/src/crates/netflow-plugin/src/query/facets/render.rs
@@ -106,9 +106,9 @@ pub(crate) fn build_facets_from_accumulator(
         });
 
         let total_values = rows.len();
-        let truncated = total_values > FACET_VALUE_LIMIT;
+        let truncated = total_values > FACET_STATIC_VALUE_LIMIT;
         if truncated {
-            rows.truncate(FACET_VALUE_LIMIT);
+            rows.truncate(FACET_STATIC_VALUE_LIMIT);
         }
 
         let values = rows
@@ -139,7 +139,7 @@ pub(crate) fn build_facets_from_accumulator(
     }
 
     json!({
-        "value_limit": FACET_VALUE_LIMIT,
+        "value_limit": FACET_STATIC_VALUE_LIMIT,
         "accumulator_value_limit": facet_max_values_per_field,
         "overflowed_fields": overflowed_fields,
         "overflowed_records": overflowed_records,

--- a/src/crates/netflow-plugin/src/query/fields/capture.rs
+++ b/src/crates/netflow-plugin/src/query/fields/capture.rs
@@ -1,8 +1,7 @@
 use crate::presentation;
-use crate::query::{FACET_ALLOWED_OPTIONS, FlowsRequest};
+use crate::query::{CompiledSelections, FACET_ALLOWED_OPTIONS, FlowsRequest};
 use hashbrown::HashMap as FastHashMap;
 use std::borrow::Cow;
-use std::collections::HashMap;
 
 pub(crate) fn captured_stored_facet_field_value<'a>(
     field: &str,
@@ -40,23 +39,12 @@ pub(crate) fn captured_facet_field_value<'a>(
 
 pub(crate) fn captured_facet_matches_selections_except(
     ignored_field: Option<&str>,
-    selections: &HashMap<String, Vec<String>>,
+    selections: &CompiledSelections,
     capture_positions: &FastHashMap<String, usize>,
     captured_values: &[Option<String>],
 ) -> bool {
-    selections.iter().all(|(field, values)| {
-        if ignored_field.is_some_and(|ignored| ignored.eq_ignore_ascii_case(field)) {
-            return true;
-        }
-        if values.is_empty() {
-            return true;
-        }
-        let Some(record_value) =
-            captured_facet_field_value(field, capture_positions, captured_values)
-        else {
-            return false;
-        };
-        values.iter().any(|value| value == record_value.as_ref())
+    selections.matches(ignored_field, |field| {
+        captured_facet_field_value(field, capture_positions, captured_values)
     })
 }
 

--- a/src/crates/netflow-plugin/src/query/fields/rules.rs
+++ b/src/crates/netflow-plugin/src/query/fields/rules.rs
@@ -29,12 +29,17 @@ pub(crate) fn facet_field_requested(field: &str) -> bool {
     facet_field_enabled(field)
 }
 
+pub(crate) fn field_is_metric(field: &str) -> bool {
+    matches!(
+        field.to_ascii_uppercase().as_str(),
+        "BYTES" | "PACKETS" | "RAW_BYTES" | "RAW_PACKETS" | "FLOWS" | "SAMPLING_RATE"
+    )
+}
+
 pub(crate) fn field_is_groupable(field: &str) -> bool {
     let normalized = field.to_ascii_uppercase();
-    !matches!(
-        normalized.as_str(),
-        "BYTES" | "PACKETS" | "RAW_BYTES" | "RAW_PACKETS" | "FLOWS" | "SAMPLING_RATE"
-    ) && !normalized.starts_with('_')
+    !field_is_metric(&normalized)
+        && !normalized.starts_with('_')
         && !normalized.starts_with("V9_")
         && !normalized.starts_with("IPFIX_")
 }

--- a/src/crates/netflow-plugin/src/query/fields/rules.rs
+++ b/src/crates/netflow-plugin/src/query/fields/rules.rs
@@ -1,13 +1,16 @@
 use crate::facet_catalog::facet_field_enabled;
-use crate::query::RAW_ONLY_FIELDS;
+use crate::query::virtual_flow_field_dependencies;
+use crate::tiering::rollup_field_available;
 use std::collections::HashMap;
 
 pub(crate) fn field_is_raw_only(field: &str) -> bool {
-    RAW_ONLY_FIELDS
-        .iter()
-        .any(|raw_only| field.eq_ignore_ascii_case(raw_only))
-        || field.to_ascii_uppercase().starts_with("V9_")
-        || field.to_ascii_uppercase().starts_with("IPFIX_")
+    if is_virtual_flow_field(field) {
+        return !virtual_flow_field_dependencies(field)
+            .iter()
+            .all(|dependency| rollup_field_available(dependency));
+    }
+
+    !rollup_field_available(field)
 }
 
 pub(crate) fn is_virtual_flow_field(field: &str) -> bool {

--- a/src/crates/netflow-plugin/src/query/flows/build.rs
+++ b/src/crates/netflow-plugin/src/query/flows/build.rs
@@ -36,13 +36,19 @@ impl FlowQueryService {
             let materialized =
                 self.materialize_compact_aggregate(&setup.effective_group_by, &index, agg)?;
             totals.add(materialized.metrics);
-            flows.push(flow_value_from_aggregate(materialized));
+            flows.push(flow_value_from_aggregate(
+                materialized,
+                &setup.effective_group_by,
+            ));
         }
 
         if let Some(other_agg) = other {
             let materialized = synthetic_aggregate_from_compact(other_agg)?;
             totals.add(materialized.metrics);
-            flows.push(flow_value_from_aggregate(materialized));
+            flows.push(flow_value_from_aggregate(
+                materialized,
+                &setup.effective_group_by,
+            ));
         }
 
         Ok(CompactBuildResult {
@@ -93,13 +99,19 @@ impl FlowQueryService {
                 agg,
             )?;
             totals.add(materialized.metrics);
-            flows.push(flow_value_from_aggregate(materialized));
+            flows.push(flow_value_from_aggregate(
+                materialized,
+                &setup.effective_group_by,
+            ));
         }
 
         if let Some(other_agg) = other {
             let materialized = synthetic_aggregate_from_compact(other_agg)?;
             totals.add(materialized.metrics);
-            flows.push(flow_value_from_aggregate(materialized));
+            flows.push(flow_value_from_aggregate(
+                materialized,
+                &setup.effective_group_by,
+            ));
         }
 
         Ok(CompactBuildResult {

--- a/src/crates/netflow-plugin/src/query/flows/materialize.rs
+++ b/src/crates/netflow-plugin/src/query/flows/materialize.rs
@@ -24,7 +24,7 @@ impl FlowQueryService {
         })
     }
 
-    pub(super) fn materialize_projected_compact_aggregate(
+    pub(crate) fn materialize_projected_compact_aggregate(
         &self,
         group_by: &[String],
         fields: &ProjectedFieldTable,

--- a/src/crates/netflow-plugin/src/query/grouping/build/output.rs
+++ b/src/crates/netflow-plugin/src/query/grouping/build/output.rs
@@ -34,13 +34,14 @@ pub(crate) fn build_grouped_flows(
             DEFAULT_GROUP_ACCUMULATOR_MAX_GROUPS,
         );
     }
-    build_grouped_flows_from_aggregates(aggregates, overflow.aggregate, sort_by, limit)
+    build_grouped_flows_from_aggregates(aggregates, overflow.aggregate, group_by, sort_by, limit)
 }
 
 #[cfg(test)]
 pub(crate) fn build_grouped_flows_from_aggregates(
     aggregates: HashMap<GroupKey, AggregatedFlow>,
     overflow: Option<AggregatedFlow>,
+    group_by: &[String],
     sort_by: SortBy,
     limit: usize,
 ) -> BuildResult {
@@ -51,12 +52,12 @@ pub(crate) fn build_grouped_flows_from_aggregates(
 
     for agg in ranked.rows {
         totals.add(agg.metrics);
-        flows.push(flow_value_from_aggregate(agg));
+        flows.push(flow_value_from_aggregate(agg, group_by));
     }
 
     if let Some(other_agg) = ranked.other {
         totals.add(other_agg.metrics);
-        flows.push(flow_value_from_aggregate(other_agg));
+        flows.push(flow_value_from_aggregate(other_agg, group_by));
     }
 
     BuildResult {
@@ -85,13 +86,16 @@ pub(crate) fn synthetic_aggregate_from_compact(
     })
 }
 
-pub(crate) fn flow_value_from_aggregate(agg: AggregatedFlow) -> Value {
+pub(crate) fn flow_value_from_aggregate(agg: AggregatedFlow, group_by: &[String]) -> Value {
     let mut flow_obj = Map::new();
     let mut labels = agg.labels;
     if let Some(folded_labels) = &agg.folded_labels {
         folded_labels.render_into(&mut labels);
     }
-    flow_obj.insert("key".to_string(), json!(labels));
+    flow_obj.insert(
+        "key".to_string(),
+        Value::Object(ordered_group_labels(&labels, group_by)),
+    );
     flow_obj.insert("metrics".to_string(), agg.metrics.to_value());
     Value::Object(flow_obj)
 }

--- a/src/crates/netflow-plugin/src/query/grouping/build/rank.rs
+++ b/src/crates/netflow-plugin/src/query/grouping/build/rank.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[cfg(test)]
 pub(crate) fn rank_aggregates(
     aggregates: HashMap<GroupKey, AggregatedFlow>,
     overflow: Option<AggregatedFlow>,
@@ -7,7 +8,36 @@ pub(crate) fn rank_aggregates(
     limit: usize,
 ) -> RankedAggregates {
     let grouped_total = aggregates.len();
-    let mut grouped: Vec<AggregatedFlow> = aggregates.into_values().collect();
+    let grouped = aggregates.into_values().collect();
+    rank_aggregate_rows(grouped, overflow, sort_by, limit, grouped_total)
+}
+
+pub(crate) fn rank_aggregates_with_retained_keys(
+    aggregates: HashMap<GroupKey, AggregatedFlow>,
+    overflow: Option<AggregatedFlow>,
+    sort_by: SortBy,
+    limit: usize,
+) -> (RankedAggregates, HashSet<GroupKey>) {
+    let grouped_total = aggregates.len();
+    let mut grouped = Vec::with_capacity(grouped_total);
+    let mut retained_group_keys = HashSet::with_capacity(grouped_total);
+    for (key, row) in aggregates {
+        retained_group_keys.insert(key);
+        grouped.push(row);
+    }
+    (
+        rank_aggregate_rows(grouped, overflow, sort_by, limit, grouped_total),
+        retained_group_keys,
+    )
+}
+
+fn rank_aggregate_rows(
+    mut grouped: Vec<AggregatedFlow>,
+    overflow: Option<AggregatedFlow>,
+    sort_by: SortBy,
+    limit: usize,
+    grouped_total: usize,
+) -> RankedAggregates {
     if let Some(overflow_row) = overflow {
         grouped.push(overflow_row);
     }
@@ -128,6 +158,35 @@ pub(crate) fn rank_projected_compact_aggregates(
         truncated,
         other_count,
     })
+}
+
+pub(crate) fn rank_compact_top_aggregates(
+    aggregates: Vec<CompactAggregatedFlow>,
+    overflow: Option<CompactAggregatedFlow>,
+    sort_by: SortBy,
+    limit: usize,
+) -> RankedCompactAggregates {
+    let mut rows = aggregates;
+    if let Some(overflow_row) = overflow {
+        rows.push(overflow_row);
+    }
+    rows.sort_by(|a, b| compare_compact_aggregated(a, b, sort_by));
+
+    let limit = sanitize_explicit_limit(limit);
+    let truncated = rows.len() > limit;
+    let other_count = if truncated {
+        let rest = rows.split_off(limit);
+        rest.len()
+    } else {
+        0
+    };
+
+    RankedCompactAggregates {
+        rows,
+        other: None,
+        truncated,
+        other_count,
+    }
 }
 
 #[cfg(test)]

--- a/src/crates/netflow-plugin/src/query/grouping/labels.rs
+++ b/src/crates/netflow-plugin/src/query/grouping/labels.rs
@@ -5,6 +5,27 @@ pub(crate) fn synthetic_bucket_labels(bucket_label: &'static str) -> BTreeMap<St
     BTreeMap::from([(String::from("_bucket"), String::from(bucket_label))])
 }
 
+pub(crate) fn ordered_group_labels(
+    labels: &BTreeMap<String, String>,
+    group_by: &[String],
+) -> Map<String, Value> {
+    let mut ordered = Map::new();
+
+    for field in group_by {
+        if let Some(value) = labels.get(field) {
+            ordered.insert(field.clone(), Value::String(value.clone()));
+        }
+    }
+
+    for (field, value) in labels {
+        if !ordered.contains_key(field) {
+            ordered.insert(field.clone(), Value::String(value.clone()));
+        }
+    }
+
+    ordered
+}
+
 pub(crate) fn new_bucket_aggregate(bucket_label: &'static str) -> AggregatedFlow {
     AggregatedFlow {
         labels: synthetic_bucket_labels(bucket_label),

--- a/src/crates/netflow-plugin/src/query/metrics.rs
+++ b/src/crates/netflow-plugin/src/query/metrics.rs
@@ -1,5 +1,31 @@
 use super::*;
 
+struct TimeseriesScanResult {
+    pass1_counts: ScanCounts,
+    pass2_counts: ScanCounts,
+    top_rows: Vec<AggregatedFlow>,
+    series_buckets: Vec<Vec<u64>>,
+    grouped_total: usize,
+    truncated: bool,
+    other_count: usize,
+    overflow_records: u64,
+}
+
+pub(crate) fn materialized_timeseries_dimension(
+    key: &GroupKey,
+    top_group_keys: &HashMap<GroupKey, usize>,
+    retained_group_keys: &HashSet<GroupKey>,
+    overflow_dimension: Option<usize>,
+) -> Option<usize> {
+    top_group_keys.get(key).copied().or_else(|| {
+        if retained_group_keys.contains(key) {
+            None
+        } else {
+            overflow_dimension
+        }
+    })
+}
+
 impl FlowQueryService {
     #[allow(dead_code)]
     pub(crate) async fn query_flow_metrics(
@@ -20,67 +46,19 @@ impl FlowQueryService {
             .timeseries_layout
             .context("timeseries query missing aligned layout")?;
 
-        let mut grouped_aggregates: HashMap<GroupKey, AggregatedFlow> = HashMap::new();
-        let mut group_overflow = GroupOverflow::default();
-        let pass1_counts = self.scan_matching_records(
-            &setup,
-            request,
-            |record, _| {
-                let metrics = sampled_metrics_from_fields(&record.fields);
-                accumulate_grouped_record(
-                    record,
-                    metrics,
-                    &setup.effective_group_by,
-                    &mut grouped_aggregates,
-                    &mut group_overflow,
-                    self.max_groups,
-                );
-            },
-            execution.as_ref(),
-            0,
-        )?;
-
-        let ranked = rank_aggregates(
-            grouped_aggregates,
-            group_overflow.aggregate.take(),
-            setup.sort_by,
-            setup.limit,
-        );
-        let top_rows = ranked.rows;
-        let mut series_buckets = vec![vec![0_u64; top_rows.len()]; layout.bucket_count];
-        let top_keys: HashMap<GroupKey, usize> = top_rows
-            .iter()
-            .enumerate()
-            .map(|(idx, row)| (group_key_from_labels(&row.labels), idx))
-            .collect();
-
-        let pass2_counts = if top_keys.is_empty() {
-            ScanCounts::default()
+        let TimeseriesScanResult {
+            pass1_counts,
+            pass2_counts,
+            top_rows,
+            series_buckets,
+            grouped_total,
+            truncated,
+            other_count,
+            overflow_records,
+        } = if planner::grouped_query_can_use_projected_scan(request) {
+            self.scan_projected_timeseries(&setup, request, layout, execution.as_ref())?
         } else {
-            self.scan_matching_records(
-                &setup,
-                request,
-                |record, _| {
-                    let labels = labels_for_group(record, &setup.effective_group_by);
-                    let key = group_key_from_labels(&labels);
-                    let Some(index) = top_keys.get(&key).copied() else {
-                        return;
-                    };
-
-                    let metric_value = sampled_metric_value(setup.sort_by, &record.fields);
-                    accumulate_series_bucket(
-                        &mut series_buckets,
-                        chart_timestamp_usec(record),
-                        layout.after,
-                        layout.before,
-                        layout.bucket_seconds,
-                        index,
-                        metric_value,
-                    );
-                },
-                execution.as_ref(),
-                1,
-            )?
+            self.scan_materialized_timeseries(&setup, request, layout, execution.as_ref())?
         };
 
         let mut stats = setup.stats;
@@ -109,25 +87,16 @@ impl FlowQueryService {
             "query_pass_2_matched_entries".to_string(),
             pass2_counts.matched_entries as u64,
         );
-        stats.insert(
-            "query_grouped_rows".to_string(),
-            ranked.grouped_total as u64,
-        );
+        stats.insert("query_grouped_rows".to_string(), grouped_total as u64);
         stats.insert(
             "query_returned_dimensions".to_string(),
             top_rows.len() as u64,
         );
-        stats.insert("query_truncated".to_string(), u64::from(ranked.truncated));
-        stats.insert(
-            "query_other_grouped_rows".to_string(),
-            ranked.other_count as u64,
-        );
-        stats.insert(
-            "query_group_overflow_records".to_string(),
-            group_overflow.dropped_records,
-        );
+        stats.insert("query_truncated".to_string(), u64::from(truncated));
+        stats.insert("query_other_grouped_rows".to_string(), other_count as u64);
+        stats.insert("query_group_overflow_records".to_string(), overflow_records);
 
-        let warnings = build_query_warnings(group_overflow.dropped_records, 0, 0);
+        let warnings = build_query_warnings(overflow_records, 0, 0);
         let chart = metrics_chart_from_top_groups(
             layout.after,
             layout.before,
@@ -148,6 +117,185 @@ impl FlowQueryService {
             chart,
             stats,
             warnings,
+        })
+    }
+
+    fn scan_projected_timeseries(
+        &self,
+        setup: &QuerySetup,
+        request: &FlowsRequest,
+        layout: TimeseriesLayout,
+        execution: Option<&QueryExecutionPlan>,
+    ) -> Result<TimeseriesScanResult> {
+        let mut grouped_aggregates = ProjectedGroupAccumulator::new(&setup.effective_group_by);
+        let pass1_counts = self.scan_matching_grouped_records_projected(
+            setup,
+            request,
+            &mut grouped_aggregates,
+            execution,
+            0,
+        )?;
+
+        let grouped_total = grouped_aggregates.grouped_total();
+        let overflow_records = grouped_aggregates.overflow.dropped_records;
+        let ProjectedGroupAccumulator {
+            fields,
+            rows,
+            row_indexes: retained_group_keys,
+            overflow,
+            ..
+        } = grouped_aggregates;
+        let RankedCompactAggregates {
+            rows,
+            truncated,
+            other_count,
+            ..
+        } = rank_compact_top_aggregates(rows, overflow.aggregate, setup.sort_by, setup.limit);
+
+        let top_group_keys = rows
+            .iter()
+            .enumerate()
+            .filter_map(|(dimension_index, row)| {
+                row.group_field_ids
+                    .as_ref()
+                    .map(|group_key| (group_key.clone(), dimension_index))
+            })
+            .collect::<FastHashMap<_, _>>();
+        let overflow_dimension = rows
+            .iter()
+            .position(|row| row.bucket_label == Some(OVERFLOW_BUCKET_LABEL));
+        let top_rows = rows
+            .into_iter()
+            .map(|row| {
+                self.materialize_projected_compact_aggregate(
+                    &setup.effective_group_by,
+                    &fields,
+                    row,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut series_buckets = vec![vec![0_u64; top_rows.len()]; layout.bucket_count];
+
+        let pass2_counts = if top_rows.is_empty() {
+            ScanCounts::default()
+        } else {
+            self.scan_matching_timeseries_records_projected(
+                setup,
+                request,
+                &fields,
+                &retained_group_keys,
+                &top_group_keys,
+                overflow_dimension,
+                layout,
+                setup.sort_by,
+                &mut series_buckets,
+                execution,
+                1,
+            )?
+        };
+
+        Ok(TimeseriesScanResult {
+            pass1_counts,
+            pass2_counts,
+            top_rows,
+            series_buckets,
+            grouped_total,
+            truncated,
+            other_count,
+            overflow_records,
+        })
+    }
+
+    fn scan_materialized_timeseries(
+        &self,
+        setup: &QuerySetup,
+        request: &FlowsRequest,
+        layout: TimeseriesLayout,
+        execution: Option<&QueryExecutionPlan>,
+    ) -> Result<TimeseriesScanResult> {
+        let mut grouped_aggregates: HashMap<GroupKey, AggregatedFlow> = HashMap::new();
+        let mut group_overflow = GroupOverflow::default();
+        let pass1_counts = self.scan_matching_records(
+            setup,
+            request,
+            |record, _| {
+                let metrics = sampled_metrics_from_fields(&record.fields);
+                accumulate_grouped_record(
+                    record,
+                    metrics,
+                    &setup.effective_group_by,
+                    &mut grouped_aggregates,
+                    &mut group_overflow,
+                    self.max_groups,
+                );
+            },
+            execution,
+            0,
+        )?;
+
+        let overflow_records = group_overflow.dropped_records;
+        let (ranked, retained_group_keys) = rank_aggregates_with_retained_keys(
+            grouped_aggregates,
+            group_overflow.aggregate.take(),
+            setup.sort_by,
+            setup.limit,
+        );
+        let overflow_dimension = ranked.rows.iter().position(|row| {
+            row.labels.get("_bucket").map(String::as_str) == Some(OVERFLOW_BUCKET_LABEL)
+        });
+        let top_rows = ranked.rows;
+        let mut series_buckets = vec![vec![0_u64; top_rows.len()]; layout.bucket_count];
+        let top_keys = top_rows
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| !row.labels.contains_key("_bucket"))
+            .map(|(index, row)| (group_key_from_labels(&row.labels), index))
+            .collect::<HashMap<_, _>>();
+
+        let pass2_counts = if top_rows.is_empty() {
+            ScanCounts::default()
+        } else {
+            self.scan_matching_records(
+                setup,
+                request,
+                |record, _| {
+                    let labels = labels_for_group(record, &setup.effective_group_by);
+                    let key = group_key_from_labels(&labels);
+                    let dimension_index = materialized_timeseries_dimension(
+                        &key,
+                        &top_keys,
+                        &retained_group_keys,
+                        overflow_dimension,
+                    );
+                    let Some(dimension_index) = dimension_index else {
+                        return;
+                    };
+
+                    let metric_value = sampled_metric_value(setup.sort_by, &record.fields);
+                    accumulate_series_bucket(
+                        &mut series_buckets,
+                        chart_timestamp_usec(record),
+                        layout.after,
+                        layout.before,
+                        layout.bucket_seconds,
+                        dimension_index,
+                        metric_value,
+                    );
+                },
+                execution,
+                1,
+            )?
+        };
+
+        Ok(TimeseriesScanResult {
+            pass1_counts,
+            pass2_counts,
+            top_rows,
+            series_buckets,
+            grouped_total: ranked.grouped_total,
+            truncated: ranked.truncated,
+            other_count: ranked.other_count,
+            overflow_records,
         })
     }
 }

--- a/src/crates/netflow-plugin/src/query/metrics.rs
+++ b/src/crates/netflow-plugin/src/query/metrics.rs
@@ -102,6 +102,7 @@ impl FlowQueryService {
             layout.before,
             layout.bucket_seconds,
             setup.sort_by,
+            &setup.effective_group_by,
             &top_rows,
             &series_buckets,
         );

--- a/src/crates/netflow-plugin/src/query/planner/prepare.rs
+++ b/src/crates/netflow-plugin/src/query/planner/prepare.rs
@@ -41,6 +41,10 @@ impl FlowQueryService {
 
     pub(crate) fn prepare_query(&self, request: &FlowsRequest) -> Result<QuerySetup> {
         let sort_by = request.normalized_sort_by();
+        let selections = CompiledSelections::compile(&request.selections)
+            .map_err(anyhow::Error::msg)
+            .context("invalid NetFlow selections")?;
+        let prefilter_matches = build_prefilter_matches(selections.prefilter_pairs());
         let (requested_after, requested_before) = resolve_time_bounds(request);
         let effective_group_by = resolve_effective_group_by(request);
         let force_raw_tier =
@@ -161,6 +165,8 @@ impl FlowQueryService {
             sort_by,
             timeseries_layout,
             effective_group_by,
+            selections,
+            prefilter_matches,
             limit,
             spans,
             stats,

--- a/src/crates/netflow-plugin/src/query/projected.rs
+++ b/src/crates/netflow-plugin/src/query/projected.rs
@@ -3,9 +3,13 @@ use super::*;
 mod apply;
 #[cfg(test)]
 mod bench_support;
+mod plan;
 mod prefix;
+mod sink;
 
 pub(crate) use apply::*;
 #[cfg(test)]
 pub(crate) use bench_support::*;
+pub(crate) use plan::*;
 pub(crate) use prefix::*;
+pub(crate) use sink::*;

--- a/src/crates/netflow-plugin/src/query/projected/apply.rs
+++ b/src/crates/netflow-plugin/src/query/projected/apply.rs
@@ -17,14 +17,11 @@ fn apply_projected_metric(
 }
 
 #[inline(always)]
-fn apply_projected_action(
+fn apply_projected_action<S: ProjectedRowSink + ?Sized>(
     action: &ProjectedPayloadAction,
     value_bytes: &[u8],
-    grouped_aggregates: &ProjectedGroupAccumulator,
-    row_group_field_ids: &mut [Option<u32>],
-    row_missing_values: &mut [Option<String>],
+    sink: &mut S,
     projected_captured_values: &mut [Option<String>],
-    max_groups: usize,
 ) {
     if *action == ProjectedPayloadAction::default() {
         return;
@@ -43,26 +40,17 @@ fn apply_projected_action(
     }
 
     if let Some(field_index) = action.group_slot {
-        match grouped_aggregates.find_field_value(field_index, value_ref) {
-            Some(field_id) => row_group_field_ids[field_index] = Some(field_id),
-            None if grouped_aggregates.grouped_total() < max_groups => {
-                row_missing_values[field_index] = Some(value_ref.to_string());
-            }
-            None => {}
-        }
+        sink.observe_group_value(field_index, value_ref);
     }
 }
 
 #[inline(always)]
-fn apply_projected_match(
+fn apply_projected_match<S: ProjectedRowSink + ?Sized>(
     spec: &ProjectedFieldSpec,
     value_bytes: &[u8],
     metrics: &mut QueryFlowMetrics,
-    grouped_aggregates: &ProjectedGroupAccumulator,
-    row_group_field_ids: &mut [Option<u32>],
-    row_missing_values: &mut [Option<String>],
+    sink: &mut S,
     projected_captured_values: &mut [Option<String>],
-    max_groups: usize,
 ) {
     if let Some(metric_field) = spec.targets.metric {
         apply_projected_metric(metrics, metric_field, value_bytes);
@@ -71,26 +59,20 @@ fn apply_projected_match(
     apply_projected_action(
         &spec.targets.action,
         value_bytes,
-        grouped_aggregates,
-        row_group_field_ids,
-        row_missing_values,
+        sink,
         projected_captured_values,
-        max_groups,
     );
 }
 
 #[inline(always)]
-pub(crate) fn apply_projected_payload(
+pub(crate) fn apply_projected_payload<S: ProjectedRowSink + ?Sized>(
     payload: &[u8],
     projected_field_specs: &[ProjectedFieldSpec],
     pending_spec_indexes: &mut [usize],
     remaining: &mut usize,
     metrics: &mut QueryFlowMetrics,
-    grouped_aggregates: &ProjectedGroupAccumulator,
-    row_group_field_ids: &mut [Option<u32>],
-    row_missing_values: &mut [Option<String>],
+    sink: &mut S,
     projected_captured_values: &mut [Option<String>],
-    max_groups: usize,
 ) -> Option<usize> {
     if *remaining == 0 {
         return None;
@@ -106,16 +88,7 @@ pub(crate) fn apply_projected_payload(
             continue;
         };
 
-        apply_projected_match(
-            spec,
-            value_bytes,
-            metrics,
-            grouped_aggregates,
-            row_group_field_ids,
-            row_missing_values,
-            projected_captured_values,
-            max_groups,
-        );
+        apply_projected_match(spec, value_bytes, metrics, sink, projected_captured_values);
 
         *remaining -= 1;
         pending_spec_indexes.swap(pending_index, *remaining);
@@ -126,17 +99,14 @@ pub(crate) fn apply_projected_payload(
 }
 
 #[inline(always)]
-pub(crate) fn apply_projected_payload_planned(
+pub(crate) fn apply_projected_payload_planned<S: ProjectedRowSink + ?Sized>(
     payload: &[u8],
     projected_match_plan: &ProjectedFieldMatchPlan,
     projected_field_specs: &[ProjectedFieldSpec],
     remaining_mask: &mut u64,
     metrics: &mut QueryFlowMetrics,
-    grouped_aggregates: &ProjectedGroupAccumulator,
-    row_group_field_ids: &mut [Option<u32>],
-    row_missing_values: &mut [Option<String>],
+    sink: &mut S,
     projected_captured_values: &mut [Option<String>],
-    max_groups: usize,
 ) -> Option<usize> {
     if *remaining_mask == 0 || payload.is_empty() {
         return None;
@@ -162,16 +132,7 @@ pub(crate) fn apply_projected_payload_planned(
             continue;
         };
 
-        apply_projected_match(
-            spec,
-            value_bytes,
-            metrics,
-            grouped_aggregates,
-            row_group_field_ids,
-            row_missing_values,
-            projected_captured_values,
-            max_groups,
-        );
+        apply_projected_match(spec, value_bytes, metrics, sink, projected_captured_values);
 
         *remaining_mask &= !(1_u64 << spec_index);
         return Some(spec_index);

--- a/src/crates/netflow-plugin/src/query/projected/plan.rs
+++ b/src/crates/netflow-plugin/src/query/projected/plan.rs
@@ -4,39 +4,33 @@ pub(crate) struct ProjectedScanPlan {
     pub(crate) capture_positions: FastHashMap<String, usize>,
     pub(crate) field_specs: Vec<ProjectedFieldSpec>,
     pub(crate) match_plan: Option<ProjectedFieldMatchPlan>,
-    pub(crate) prefilter_matches: Vec<Vec<u8>>,
 }
 
 impl ProjectedScanPlan {
-    pub(crate) fn for_group_totals(setup: &QuerySetup, request: &FlowsRequest) -> Self {
+    pub(crate) fn for_group_totals(setup: &QuerySetup, _request: &FlowsRequest) -> Self {
         Self::new(
             setup,
-            request,
             &[ProjectedMetricField::Bytes, ProjectedMetricField::Packets],
         )
     }
 
     pub(crate) fn for_timeseries(
         setup: &QuerySetup,
-        request: &FlowsRequest,
+        _request: &FlowsRequest,
         sort_by: SortBy,
     ) -> Self {
         let metric = match sort_by {
             SortBy::Bytes => ProjectedMetricField::Bytes,
             SortBy::Packets => ProjectedMetricField::Packets,
         };
-        Self::new(setup, request, &[metric])
+        Self::new(setup, &[metric])
     }
 
-    fn new(
-        setup: &QuerySetup,
-        request: &FlowsRequest,
-        metric_fields: &[ProjectedMetricField],
-    ) -> Self {
-        let mut captured_fields = request
+    fn new(setup: &QuerySetup, metric_fields: &[ProjectedMetricField]) -> Self {
+        let mut captured_fields = setup
             .selections
-            .keys()
-            .map(|field| field.to_ascii_uppercase())
+            .field_names()
+            .map(str::to_string)
             .collect::<Vec<_>>();
         captured_fields.sort_unstable();
         captured_fields.dedup();
@@ -68,14 +62,10 @@ impl ProjectedScanPlan {
         }
 
         let match_plan = ProjectedFieldMatchPlan::new(&field_specs);
-        let prefilter_matches =
-            build_prefilter_matches(&cursor_prefilter_pairs(&request.selections));
-
         Self {
             capture_positions,
             field_specs,
             match_plan,
-            prefilter_matches,
         }
     }
 }

--- a/src/crates/netflow-plugin/src/query/projected/plan.rs
+++ b/src/crates/netflow-plugin/src/query/projected/plan.rs
@@ -1,0 +1,81 @@
+use super::*;
+
+pub(crate) struct ProjectedScanPlan {
+    pub(crate) capture_positions: FastHashMap<String, usize>,
+    pub(crate) field_specs: Vec<ProjectedFieldSpec>,
+    pub(crate) match_plan: Option<ProjectedFieldMatchPlan>,
+    pub(crate) prefilter_matches: Vec<Vec<u8>>,
+}
+
+impl ProjectedScanPlan {
+    pub(crate) fn for_group_totals(setup: &QuerySetup, request: &FlowsRequest) -> Self {
+        Self::new(
+            setup,
+            request,
+            &[ProjectedMetricField::Bytes, ProjectedMetricField::Packets],
+        )
+    }
+
+    pub(crate) fn for_timeseries(
+        setup: &QuerySetup,
+        request: &FlowsRequest,
+        sort_by: SortBy,
+    ) -> Self {
+        let metric = match sort_by {
+            SortBy::Bytes => ProjectedMetricField::Bytes,
+            SortBy::Packets => ProjectedMetricField::Packets,
+        };
+        Self::new(setup, request, &[metric])
+    }
+
+    fn new(
+        setup: &QuerySetup,
+        request: &FlowsRequest,
+        metric_fields: &[ProjectedMetricField],
+    ) -> Self {
+        let mut captured_fields = request
+            .selections
+            .keys()
+            .map(|field| field.to_ascii_uppercase())
+            .collect::<Vec<_>>();
+        captured_fields.sort_unstable();
+        captured_fields.dedup();
+        let capture_positions = captured_fields
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(index, field)| (field, index))
+            .collect::<FastHashMap<_, _>>();
+
+        let mut field_specs = Vec::with_capacity(
+            metric_fields.len() + setup.effective_group_by.len() + capture_positions.len() + 2,
+        );
+        for metric_field in metric_fields {
+            let metric_key = match metric_field {
+                ProjectedMetricField::Bytes => b"BYTES".as_slice(),
+                ProjectedMetricField::Packets => b"PACKETS".as_slice(),
+            };
+            let spec_index = projected_field_spec_index(&mut field_specs, metric_key);
+            field_specs[spec_index].targets.metric = Some(*metric_field);
+        }
+        for (index, field) in setup.effective_group_by.iter().enumerate() {
+            let spec_index = projected_field_spec_index(&mut field_specs, field.as_bytes());
+            field_specs[spec_index].targets.action.group_slot = Some(index);
+        }
+        for (field, field_index) in &capture_positions {
+            let spec_index = projected_field_spec_index(&mut field_specs, field.as_bytes());
+            field_specs[spec_index].targets.action.capture_slot = Some(*field_index);
+        }
+
+        let match_plan = ProjectedFieldMatchPlan::new(&field_specs);
+        let prefilter_matches =
+            build_prefilter_matches(&cursor_prefilter_pairs(&request.selections));
+
+        Self {
+            capture_positions,
+            field_specs,
+            match_plan,
+            prefilter_matches,
+        }
+    }
+}

--- a/src/crates/netflow-plugin/src/query/projected/sink.rs
+++ b/src/crates/netflow-plugin/src/query/projected/sink.rs
@@ -1,0 +1,165 @@
+use super::*;
+
+pub(crate) trait ProjectedRowSink {
+    fn reset_row(&mut self);
+    fn observe_group_value(&mut self, field_index: usize, value: &str);
+    fn consume_row(
+        &mut self,
+        timestamp_usec: u64,
+        handle: RecordHandle,
+        metrics: QueryFlowMetrics,
+    ) -> Result<()>;
+}
+
+pub(crate) struct ProjectedGroupingSink<'a> {
+    grouped_aggregates: &'a mut ProjectedGroupAccumulator,
+    group_by: &'a [String],
+    row_group_field_ids: &'a mut [Option<u32>],
+    row_missing_values: &'a mut [Option<String>],
+    max_groups: usize,
+}
+
+impl<'a> ProjectedGroupingSink<'a> {
+    pub(crate) fn new(
+        grouped_aggregates: &'a mut ProjectedGroupAccumulator,
+        group_by: &'a [String],
+        row_group_field_ids: &'a mut [Option<u32>],
+        row_missing_values: &'a mut [Option<String>],
+        max_groups: usize,
+    ) -> Self {
+        Self {
+            grouped_aggregates,
+            group_by,
+            row_group_field_ids,
+            row_missing_values,
+            max_groups,
+        }
+    }
+}
+
+impl ProjectedRowSink for ProjectedGroupingSink<'_> {
+    fn reset_row(&mut self) {
+        self.row_group_field_ids.fill(None);
+        for value in self.row_missing_values.iter_mut() {
+            let _ = value.take();
+        }
+    }
+
+    fn observe_group_value(&mut self, field_index: usize, value: &str) {
+        match self.grouped_aggregates.find_field_value(field_index, value) {
+            Some(field_id) => self.row_group_field_ids[field_index] = Some(field_id),
+            None => {
+                // Keep an observed value distinct from a missing field after
+                // the group cap is full so the row reaches overflow.
+                self.row_missing_values[field_index] = Some(value.to_string());
+            }
+        }
+    }
+
+    fn consume_row(
+        &mut self,
+        timestamp_usec: u64,
+        handle: RecordHandle,
+        metrics: QueryFlowMetrics,
+    ) -> Result<()> {
+        self.grouped_aggregates.accumulate_projected(
+            self.group_by,
+            timestamp_usec,
+            handle,
+            metrics,
+            self.row_group_field_ids,
+            self.row_missing_values,
+            self.max_groups,
+        )
+    }
+}
+
+pub(crate) struct ProjectedTimeseriesSink<'a> {
+    fields: &'a ProjectedFieldTable,
+    retained_group_keys: &'a FastHashMap<Vec<u32>, usize>,
+    top_group_keys: &'a FastHashMap<Vec<u32>, usize>,
+    overflow_dimension: Option<usize>,
+    sort_by: SortBy,
+    layout: TimeseriesLayout,
+    series_buckets: &'a mut [Vec<u64>],
+    row_group_field_ids: Vec<u32>,
+    row_values_known: bool,
+}
+
+impl<'a> ProjectedTimeseriesSink<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        fields: &'a ProjectedFieldTable,
+        retained_group_keys: &'a FastHashMap<Vec<u32>, usize>,
+        top_group_keys: &'a FastHashMap<Vec<u32>, usize>,
+        overflow_dimension: Option<usize>,
+        sort_by: SortBy,
+        layout: TimeseriesLayout,
+        series_buckets: &'a mut [Vec<u64>],
+        group_by_len: usize,
+    ) -> Self {
+        Self {
+            fields,
+            retained_group_keys,
+            top_group_keys,
+            overflow_dimension,
+            sort_by,
+            layout,
+            series_buckets,
+            row_group_field_ids: vec![0; group_by_len],
+            row_values_known: true,
+        }
+    }
+}
+
+impl ProjectedRowSink for ProjectedTimeseriesSink<'_> {
+    fn reset_row(&mut self) {
+        self.row_group_field_ids.fill(0);
+        self.row_values_known = true;
+    }
+
+    fn observe_group_value(&mut self, field_index: usize, value: &str) {
+        match self.fields.find_field_value(field_index, value) {
+            Some(field_id) => self.row_group_field_ids[field_index] = field_id,
+            None => self.row_values_known = false,
+        }
+    }
+
+    fn consume_row(
+        &mut self,
+        timestamp_usec: u64,
+        _handle: RecordHandle,
+        metrics: QueryFlowMetrics,
+    ) -> Result<()> {
+        let dimension_index = if self.row_values_known {
+            self.top_group_keys
+                .get(self.row_group_field_ids.as_slice())
+                .copied()
+                .or_else(|| {
+                    if self
+                        .retained_group_keys
+                        .contains_key(self.row_group_field_ids.as_slice())
+                    {
+                        None
+                    } else {
+                        self.overflow_dimension
+                    }
+                })
+        } else {
+            self.overflow_dimension
+        };
+
+        if let Some(dimension_index) = dimension_index {
+            accumulate_series_bucket(
+                self.series_buckets,
+                timestamp_usec,
+                self.layout.after,
+                self.layout.before,
+                self.layout.bucket_seconds,
+                dimension_index,
+                self.sort_by.metric(metrics),
+            );
+        }
+        Ok(())
+    }
+}

--- a/src/crates/netflow-plugin/src/query/request/constants.rs
+++ b/src/crates/netflow-plugin/src/query/request/constants.rs
@@ -7,7 +7,7 @@ pub(crate) const MAX_QUERY_LIMIT: usize = 500;
 pub(crate) const MAX_GROUP_BY_FIELDS: usize = 10;
 #[cfg(test)]
 pub(crate) const DEFAULT_GROUP_ACCUMULATOR_MAX_GROUPS: usize = 50_000;
-pub(crate) const FACET_VALUE_LIMIT: usize = 100;
+pub(crate) const FACET_STATIC_VALUE_LIMIT: usize = 256;
 /// Hard cap on the autocomplete `term` to prevent runaway substring scans
 /// on large vocabularies. AS names, MAC addresses, IPv6 strings, CIDRs all
 /// fit comfortably under this; longer terms get rejected at deserialize.
@@ -74,8 +74,11 @@ pub(crate) static GROUP_BY_ALLOWED_FIELDS: LazyLock<HashSet<&'static str>> = Laz
         .collect()
 });
 
-pub(crate) static SELECTION_ALLOWED_FIELDS: LazyLock<HashSet<&'static str>> =
-    LazyLock::new(|| supported_flow_field_names().collect());
+pub(crate) static SELECTION_ALLOWED_FIELDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    supported_flow_field_names()
+        .filter(|field| !field_is_metric(field))
+        .collect()
+});
 
 pub(crate) static GROUP_BY_ALLOWED_OPTIONS: LazyLock<Vec<String>> = LazyLock::new(|| {
     supported_flow_field_names()

--- a/src/crates/netflow-plugin/src/query/request/constants.rs
+++ b/src/crates/netflow-plugin/src/query/request/constants.rs
@@ -43,19 +43,6 @@ pub(crate) const CITY_MAP_GROUP_BY_FIELDS: &[&str] = &[
     "DST_GEO_LONGITUDE",
 ];
 
-pub(crate) const RAW_ONLY_FIELDS: &[&str] = &[
-    "SRC_ADDR",
-    "DST_ADDR",
-    "SRC_PORT",
-    "DST_PORT",
-    "SRC_GEO_CITY",
-    "DST_GEO_CITY",
-    "SRC_GEO_LATITUDE",
-    "DST_GEO_LATITUDE",
-    "SRC_GEO_LONGITUDE",
-    "DST_GEO_LONGITUDE",
-];
-
 pub(crate) fn default_group_by() -> Vec<String> {
     DEFAULT_GROUP_BY_FIELDS
         .iter()

--- a/src/crates/netflow-plugin/src/query/request/model/deserialize.rs
+++ b/src/crates/netflow-plugin/src/query/request/model/deserialize.rs
@@ -76,6 +76,7 @@ impl<'de> Deserialize<'de> for FlowsRequest {
         let term = trimmed_term.to_string();
 
         validate_selection_fields(&raw.selections).map_err(D::Error::custom)?;
+        validate_ip_selection_values(&raw.selections).map_err(D::Error::custom)?;
 
         Ok(Self {
             mode,

--- a/src/crates/netflow-plugin/src/query/request/output.rs
+++ b/src/crates/netflow-plugin/src/query/request/output.rs
@@ -34,6 +34,8 @@ pub(crate) struct QuerySetup {
     pub(crate) sort_by: SortBy,
     pub(crate) timeseries_layout: Option<TimeseriesLayout>,
     pub(crate) effective_group_by: Vec<String>,
+    pub(crate) selections: CompiledSelections,
+    pub(crate) prefilter_matches: Vec<Vec<u8>>,
     pub(crate) limit: usize,
     pub(crate) spans: Vec<PreparedQuerySpan>,
     pub(crate) stats: HashMap<String, u64>,

--- a/src/crates/netflow-plugin/src/query/request/selection.rs
+++ b/src/crates/netflow-plugin/src/query/request/selection.rs
@@ -1,8 +1,10 @@
+mod compiled;
 mod decode;
 mod extract;
 mod normalize;
 mod types;
 
+pub(crate) use compiled::*;
 pub(crate) use decode::*;
 pub(crate) use extract::*;
 pub(crate) use normalize::*;

--- a/src/crates/netflow-plugin/src/query/request/selection/compiled.rs
+++ b/src/crates/netflow-plugin/src/query/request/selection/compiled.rs
@@ -1,0 +1,376 @@
+use crate::facet_catalog::{FacetValueKind, facet_field_spec};
+use crate::query::is_virtual_flow_field;
+use ipnet::IpNet;
+use ipnet_trie::IpnetTrie;
+use std::borrow::Cow;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+const IP_PREFILTER_EXPANSION_LIMIT: usize = 256;
+
+#[derive(Default)]
+pub(crate) struct CompiledSelections {
+    fields: Vec<CompiledSelectionField>,
+    prefilter_pairs: Vec<(String, String)>,
+}
+
+struct CompiledSelectionField {
+    name: String,
+    matcher: SelectionMatcher,
+}
+
+enum SelectionMatcher {
+    Exact(HashSet<String>),
+    Ip(IpSelectionMatcher),
+}
+
+struct IpSelectionMatcher {
+    prefixes: IpnetTrie<()>,
+    fallback_exact: HashSet<String>,
+}
+
+impl CompiledSelections {
+    pub(crate) fn compile(selections: &HashMap<String, Vec<String>>) -> Result<Self, String> {
+        let mut selected_fields = selections.iter().collect::<Vec<_>>();
+        selected_fields.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+
+        let mut fields = Vec::with_capacity(selected_fields.len());
+        let mut prefilter_pairs = Vec::new();
+        for (field, values) in selected_fields {
+            let values = values
+                .iter()
+                .filter(|value| !value.is_empty())
+                .cloned()
+                .collect::<Vec<_>>();
+            if values.is_empty() {
+                continue;
+            }
+
+            let normalized = field.to_ascii_uppercase();
+            if is_ip_address_facet(&normalized) {
+                let (matcher, exact_prefilter_values) = compile_ip_selection(&normalized, &values)?;
+                if let Some(values) = exact_prefilter_values {
+                    prefilter_pairs
+                        .extend(values.into_iter().map(|value| (normalized.clone(), value)));
+                }
+                fields.push(CompiledSelectionField {
+                    name: normalized,
+                    matcher: SelectionMatcher::Ip(matcher),
+                });
+            } else {
+                let exact = values.into_iter().collect::<HashSet<_>>();
+                if !is_virtual_flow_field(&normalized) {
+                    prefilter_pairs.extend(
+                        exact
+                            .iter()
+                            .cloned()
+                            .map(|value| (normalized.clone(), value)),
+                    );
+                }
+                fields.push(CompiledSelectionField {
+                    name: normalized,
+                    matcher: SelectionMatcher::Exact(exact),
+                });
+            }
+        }
+
+        prefilter_pairs.sort_unstable();
+        Ok(Self {
+            fields,
+            prefilter_pairs,
+        })
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    pub(crate) fn field_names(&self) -> impl Iterator<Item = &str> {
+        self.fields.iter().map(|field| field.name.as_str())
+    }
+
+    pub(crate) fn prefilter_pairs(&self) -> &[(String, String)] {
+        &self.prefilter_pairs
+    }
+
+    pub(crate) fn matches<'a>(
+        &self,
+        ignored_field: Option<&str>,
+        mut field_value: impl FnMut(&str) -> Option<Cow<'a, str>>,
+    ) -> bool {
+        self.fields.iter().all(|field| {
+            if ignored_field.is_some_and(|ignored| field.name.eq_ignore_ascii_case(ignored)) {
+                return true;
+            }
+
+            let Some(value) = field_value(&field.name) else {
+                return false;
+            };
+            field.matcher.matches(value.as_ref())
+        })
+    }
+}
+
+impl SelectionMatcher {
+    fn matches(&self, value: &str) -> bool {
+        match self {
+            Self::Exact(values) => values.contains(value),
+            Self::Ip(matcher) => matcher.matches(value),
+        }
+    }
+}
+
+impl IpSelectionMatcher {
+    fn matches(&self, value: &str) -> bool {
+        if self.fallback_exact.contains(value) {
+            return true;
+        }
+
+        let Ok(address) = value.parse::<IpAddr>() else {
+            return false;
+        };
+        self.prefixes.longest_match(&IpNet::from(address)).is_some()
+    }
+}
+
+pub(crate) fn validate_ip_selection_values(
+    selections: &HashMap<String, Vec<String>>,
+) -> Result<(), String> {
+    for (field, values) in selections {
+        if !is_ip_address_facet(field) {
+            continue;
+        }
+        for value in values {
+            if value.contains('/') {
+                parse_selected_cidr(field, value)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_ip_address_facet(field: &str) -> bool {
+    facet_field_spec(field).is_some_and(|spec| spec.kind == FacetValueKind::IpAddr)
+}
+
+fn compile_ip_selection(
+    field: &str,
+    values: &[String],
+) -> Result<(IpSelectionMatcher, Option<Vec<String>>), String> {
+    let mut prefixes = IpnetTrie::new();
+    let mut fallback_exact = HashSet::new();
+    let mut prefilter_networks = Vec::new();
+
+    for value in values {
+        if value.contains('/') {
+            let network = parse_selected_cidr(field, value)?;
+            prefixes.insert(network, ());
+            prefilter_networks.push(network);
+        } else if let Ok(address) = value.parse::<IpAddr>() {
+            let network = IpNet::from(address);
+            prefixes.insert(network, ());
+            prefilter_networks.push(network);
+        } else {
+            fallback_exact.insert(value.clone());
+        }
+    }
+
+    let exact_prefilter_values = bounded_exact_ip_values(&prefilter_networks, &fallback_exact);
+    Ok((
+        IpSelectionMatcher {
+            prefixes,
+            fallback_exact,
+        },
+        exact_prefilter_values,
+    ))
+}
+
+fn parse_selected_cidr(field: &str, value: &str) -> Result<IpNet, String> {
+    value.parse::<IpNet>().map(|network| network.trunc()).map_err(|_| {
+        format!(
+            "invalid CIDR selection `{value}` for field `{field}`; expected an IPv4 or IPv6 address with a valid prefix length"
+        )
+    })
+}
+
+fn bounded_exact_ip_values(
+    networks: &[IpNet],
+    fallback_exact: &HashSet<String>,
+) -> Option<Vec<String>> {
+    let mut values = fallback_exact.iter().cloned().collect::<BTreeSet<_>>();
+    if values.len() > IP_PREFILTER_EXPANSION_LIMIT {
+        return None;
+    }
+
+    for network in networks {
+        let count = network_address_count(network)?;
+        if count > IP_PREFILTER_EXPANSION_LIMIT {
+            return None;
+        }
+        extend_network_addresses(&mut values, network, count);
+        if values.len() > IP_PREFILTER_EXPANSION_LIMIT {
+            return None;
+        }
+    }
+
+    Some(values.into_iter().collect())
+}
+
+fn network_address_count(network: &IpNet) -> Option<usize> {
+    let address_bits = match network {
+        IpNet::V4(_) => 32,
+        IpNet::V6(_) => 128,
+    };
+    let host_bits = address_bits - usize::from(network.prefix_len());
+    (host_bits <= 8).then(|| 1_usize << host_bits)
+}
+
+fn extend_network_addresses(values: &mut BTreeSet<String>, network: &IpNet, count: usize) {
+    match network {
+        IpNet::V4(network) => {
+            let start = u32::from(network.network());
+            values
+                .extend((0..count).map(|offset| Ipv4Addr::from(start + offset as u32).to_string()));
+        }
+        IpNet::V6(network) => {
+            let start = u128::from(network.network());
+            values.extend(
+                (0..count).map(|offset| Ipv6Addr::from(start + offset as u128).to_string()),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn selections(field: &str, values: &[&str]) -> HashMap<String, Vec<String>> {
+        HashMap::from([(
+            field.to_string(),
+            values.iter().map(|value| (*value).to_string()).collect(),
+        )])
+    }
+
+    #[test]
+    fn cidr_selection_matches_ipv4_and_ipv6_by_family() {
+        let compiled = CompiledSelections::compile(&HashMap::from([
+            ("SRC_ADDR".to_string(), vec!["10.1.2.99/24".to_string()]),
+            (
+                "DST_ADDR".to_string(),
+                vec!["2001:db8:1::abcd/48".to_string()],
+            ),
+        ]))
+        .expect("compile selections");
+
+        assert!(compiled.matches(None, |field| match field {
+            "SRC_ADDR" => Some(Cow::Borrowed("10.1.2.3")),
+            "DST_ADDR" => Some(Cow::Borrowed("2001:db8:1::5")),
+            _ => None,
+        }));
+        assert!(!compiled.matches(None, |field| match field {
+            "SRC_ADDR" => Some(Cow::Borrowed("10.1.2.3")),
+            "DST_ADDR" => Some(Cow::Borrowed("10.1.2.3")),
+            _ => None,
+        }));
+    }
+
+    #[test]
+    fn cidr_selection_ors_exact_addresses_and_networks() {
+        let compiled =
+            CompiledSelections::compile(&selections("SRC_ADDR", &["192.0.2.1", "10.0.0.0/8"]))
+                .expect("compile selections");
+
+        for address in ["192.0.2.1", "10.20.30.40"] {
+            assert!(compiled.matches(None, |_| Some(Cow::Borrowed(address))));
+        }
+        assert!(!compiled.matches(None, |_| Some(Cow::Borrowed("192.0.2.2"))));
+    }
+
+    #[test]
+    fn cidr_selection_supports_prefix_boundaries_without_crossing_families() {
+        let any_ipv4 = CompiledSelections::compile(&selections("SRC_ADDR", &["0.0.0.0/0"]))
+            .expect("compile IPv4 selection");
+        assert!(any_ipv4.matches(None, |_| Some(Cow::Borrowed("203.0.113.7"))));
+        assert!(!any_ipv4.matches(None, |_| Some(Cow::Borrowed("2001:db8::7"))));
+
+        let ipv6_host = CompiledSelections::compile(&selections("SRC_ADDR", &["2001:db8::7/128"]))
+            .expect("compile IPv6 selection");
+        assert!(ipv6_host.matches(None, |_| Some(Cow::Borrowed("2001:db8::7"))));
+        assert!(!ipv6_host.matches(None, |_| Some(Cow::Borrowed("2001:db8::8"))));
+    }
+
+    #[test]
+    fn cidr_prefilter_expands_complete_small_field() {
+        let compiled = CompiledSelections::compile(&selections("SRC_ADDR", &["192.0.2.0/24"]))
+            .expect("compile selections");
+
+        assert_eq!(compiled.prefilter_pairs().len(), 256);
+        assert_eq!(
+            compiled.prefilter_pairs().first(),
+            Some(&("SRC_ADDR".to_string(), "192.0.2.0".to_string()))
+        );
+        assert!(
+            compiled
+                .prefilter_pairs()
+                .contains(&("SRC_ADDR".to_string(), "192.0.2.255".to_string()))
+        );
+
+        let ipv6 = CompiledSelections::compile(&selections("DST_ADDR", &["2001:db8::/120"]))
+            .expect("compile IPv6 selections");
+        assert_eq!(ipv6.prefilter_pairs().len(), 256);
+        assert!(
+            ipv6.prefilter_pairs()
+                .contains(&("DST_ADDR".to_string(), "2001:db8::ff".to_string()))
+        );
+    }
+
+    #[test]
+    fn cidr_prefilter_omits_whole_unbounded_field_but_keeps_other_fields() {
+        let compiled = CompiledSelections::compile(&HashMap::from([
+            ("SRC_ADDR".to_string(), vec!["10.0.0.0/8".to_string()]),
+            ("PROTOCOL".to_string(), vec!["6".to_string()]),
+        ]))
+        .expect("compile selections");
+
+        assert_eq!(
+            compiled.prefilter_pairs(),
+            &[("PROTOCOL".to_string(), "6".to_string())]
+        );
+
+        let ipv6 = CompiledSelections::compile(&selections("DST_ADDR", &["2001:db8::/119"]))
+            .expect("compile IPv6 selections");
+        assert!(ipv6.prefilter_pairs().is_empty());
+    }
+
+    #[test]
+    fn cidr_prefilter_limit_applies_to_the_complete_ip_field_union() {
+        let compiled = CompiledSelections::compile(&HashMap::from([
+            (
+                "SRC_ADDR".to_string(),
+                vec!["192.0.2.0/24".to_string(), "198.51.100.7".to_string()],
+            ),
+            ("PROTOCOL".to_string(), vec!["17".to_string()]),
+        ]))
+        .expect("compile selections");
+
+        assert_eq!(
+            compiled.prefilter_pairs(),
+            &[("PROTOCOL".to_string(), "17".to_string())]
+        );
+        assert!(compiled.matches(None, |field| match field {
+            "SRC_ADDR" => Some(Cow::Borrowed("198.51.100.7")),
+            "PROTOCOL" => Some(Cow::Borrowed("17")),
+            _ => None,
+        }));
+    }
+
+    #[test]
+    fn invalid_slash_selection_is_rejected() {
+        let error = CompiledSelections::compile(&selections("SRC_ADDR", &["10/8"]))
+            .err()
+            .expect("invalid CIDR");
+        assert!(error.contains("invalid CIDR selection"));
+        assert!(error.contains("SRC_ADDR"));
+    }
+}

--- a/src/crates/netflow-plugin/src/query/scan/bench.rs
+++ b/src/crates/netflow-plugin/src/query/scan/bench.rs
@@ -206,6 +206,13 @@ impl FlowQueryService {
             .collect::<Vec<_>>();
         let mut data_offsets = Vec::new();
         let mut decompress_buf = Vec::new();
+        let mut sink = ProjectedGroupingSink::new(
+            grouped_aggregates,
+            &setup.effective_group_by,
+            row_group_field_ids,
+            row_missing_values,
+            self.max_groups,
+        );
 
         for span in &setup.spans {
             if span.files.is_empty() {
@@ -266,10 +273,7 @@ impl FlowQueryService {
                         continue;
                     }
 
-                    row_group_field_ids.fill(None);
-                    for value in row_missing_values.iter_mut() {
-                        let _ = value.take();
-                    }
+                    sink.reset_row();
                     for value in projected_captured_values.iter_mut() {
                         let _ = value.take();
                     }
@@ -402,11 +406,8 @@ impl FlowQueryService {
                                         projected_field_specs,
                                         &mut remaining_mask,
                                         &mut metrics,
-                                        grouped_aggregates,
-                                        row_group_field_ids,
-                                        row_missing_values,
+                                        &mut sink,
                                         projected_captured_values,
-                                        self.max_groups,
                                     );
                                 } else {
                                     apply_projected_payload(
@@ -415,11 +416,8 @@ impl FlowQueryService {
                                         pending_spec_indexes,
                                         &mut remaining,
                                         &mut metrics,
-                                        grouped_aggregates,
-                                        row_group_field_ids,
-                                        row_missing_values,
+                                        &mut sink,
                                         projected_captured_values,
-                                        self.max_groups,
                                     );
                                 }
                             }
@@ -444,17 +442,13 @@ impl FlowQueryService {
                                 continue;
                             }
 
-                            grouped_aggregates.accumulate_projected(
-                                &setup.effective_group_by,
+                            sink.consume_row(
                                 timestamp_usec,
                                 RecordHandle::JournalRealtime {
                                     tier: span.span.tier,
                                     timestamp_usec,
                                 },
                                 metrics,
-                                row_group_field_ids,
-                                row_missing_values,
-                                self.max_groups,
                             )?;
                             result.matched_entries = result.matched_entries.saturating_add(1);
                         }

--- a/src/crates/netflow-plugin/src/query/scan/bench.rs
+++ b/src/crates/netflow-plugin/src/query/scan/bench.rs
@@ -9,7 +9,6 @@ impl FlowQueryService {
         request: &FlowsRequest,
     ) -> Result<RawScanBenchResult> {
         let setup = self.prepare_query(request)?;
-        let prefilter_pairs = cursor_prefilter_pairs(&request.selections);
         let started = Instant::now();
         let mut result = RawScanBenchResult {
             files_opened: 0,
@@ -46,9 +45,8 @@ impl FlowQueryService {
 
                 let mut reader = JournalReader::default();
                 reader.set_location(Location::Head);
-                for pair in &prefilter_pairs {
-                    let match_expr = format!("{}={}", pair.0, pair.1);
-                    reader.add_match(match_expr.as_bytes());
+                for pair in &setup.prefilter_matches {
+                    reader.add_match(pair);
                 }
 
                 loop {
@@ -131,7 +129,6 @@ impl FlowQueryService {
             "raw projected stage benchmark requires projected raw grouped query support"
         );
 
-        let prefilter_pairs = cursor_prefilter_pairs(&request.selections);
         let mut grouped_aggregates = ProjectedGroupAccumulator::new(&setup.effective_group_by);
         let mut row_group_field_ids = vec![None; setup.effective_group_by.len()];
         let mut row_missing_values = std::iter::repeat_with(|| None)
@@ -159,7 +156,7 @@ impl FlowQueryService {
             &setup,
             request,
             &mut grouped_aggregates,
-            &prefilter_pairs,
+            &setup.prefilter_matches,
             &projected_capture_positions,
             &projected_field_specs,
             &mut row_group_field_ids,
@@ -176,9 +173,9 @@ impl FlowQueryService {
     pub(crate) fn benchmark_scan_matching_grouped_records_projected_raw_direct(
         &self,
         setup: &QuerySetup,
-        request: &FlowsRequest,
+        _request: &FlowsRequest,
         grouped_aggregates: &mut ProjectedGroupAccumulator,
-        prefilter_pairs: &[(String, String)],
+        prefilter_matches: &[Vec<u8>],
         projected_capture_positions: &FastHashMap<String, usize>,
         projected_field_specs: &[ProjectedFieldSpec],
         row_group_field_ids: &mut [Option<u32>],
@@ -200,10 +197,6 @@ impl FlowQueryService {
             work_checksum: 0,
             elapsed_usec: 0,
         };
-        let prefilter_matches = prefilter_pairs
-            .iter()
-            .map(|(field, value)| format!("{field}={value}").into_bytes())
-            .collect::<Vec<_>>();
         let mut data_offsets = Vec::new();
         let mut decompress_buf = Vec::new();
         let mut sink = ProjectedGroupingSink::new(
@@ -241,7 +234,7 @@ impl FlowQueryService {
 
                 let mut reader = JournalReader::default();
                 reader.set_location(Location::Head);
-                for pair in &prefilter_matches {
+                for pair in prefilter_matches {
                     reader.add_match(pair);
                 }
 
@@ -431,10 +424,10 @@ impl FlowQueryService {
                             result.matched_entries = result.matched_entries.saturating_add(1);
                         }
                         RawProjectedBenchStage::GroupAndAccumulate => {
-                            if !request.selections.is_empty()
+                            if !setup.selections.is_empty()
                                 && !captured_facet_matches_selections_except(
                                     None,
-                                    &request.selections,
+                                    &setup.selections,
                                     projected_capture_positions,
                                     projected_captured_values,
                                 )

--- a/src/crates/netflow-plugin/src/query/scan/direct.rs
+++ b/src/crates/netflow-plugin/src/query/scan/direct.rs
@@ -22,6 +22,47 @@ pub(crate) fn scan_journal_files_forward<F>(
 where
     F: FnMut(&Path, &JournalFile<Mmap>, u64, &[NonZeroU64], &mut Vec<u8>) -> Result<bool>,
 {
+    let mut checkpoint = || Ok(());
+    scan_journal_files_forward_with_checkpoint(
+        file_paths,
+        after_usec,
+        before_usec,
+        execution,
+        pass_index,
+        span_index,
+        prefilter_matches,
+        purpose,
+        &mut checkpoint,
+        |file_path, journal, timestamp_usec, data_offsets, decompress_buf, _checkpoint| {
+            on_entry(
+                file_path,
+                journal,
+                timestamp_usec,
+                data_offsets,
+                decompress_buf,
+            )
+        },
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn scan_journal_files_forward_with_checkpoint<C, F>(
+    file_paths: &[PathBuf],
+    after_usec: Option<u64>,
+    before_usec: Option<u64>,
+    execution: Option<&QueryExecutionPlan>,
+    pass_index: usize,
+    span_index: usize,
+    prefilter_matches: &[Vec<u8>],
+    purpose: &str,
+    checkpoint: &mut C,
+    mut on_entry: F,
+) -> Result<ScanCounts>
+where
+    C: FnMut() -> Result<()>,
+    F: FnMut(&Path, &JournalFile<Mmap>, u64, &[NonZeroU64], &mut Vec<u8>, &mut C) -> Result<bool>,
+{
+    checkpoint()?;
     let mut counts = ScanCounts::default();
     let mut data_offsets = Vec::new();
     let mut decompress_buf = Vec::new();
@@ -41,6 +82,7 @@ where
     files.sort_by(|left, right| left.0.cmp(&right.0));
 
     for (registry_file, file_path) in files {
+        checkpoint()?;
         // Journal read failures below are treated per journald semantics: a
         // torn tail (power loss mid-write) makes everything from the tear
         // onward unrecoverable, but must not fail the whole scan — that would
@@ -87,6 +129,7 @@ where
         });
 
         loop {
+            checkpoint()?;
             let has_entry = match cursor.step(&journal, JournalDirection::Forward) {
                 Ok(has_entry) => has_entry,
                 Err(err) => {
@@ -99,6 +142,7 @@ where
                     break;
                 }
             };
+            checkpoint()?;
             if !has_entry {
                 break;
             }
@@ -151,6 +195,7 @@ where
                 timestamp_usec,
                 &data_offsets,
                 &mut decompress_buf,
+                checkpoint,
             )? {
                 counts.matched_entries = counts.matched_entries.saturating_add(1);
             }
@@ -534,6 +579,59 @@ mod tests {
 
         assert!(!seen_any);
         assert_eq!(counts.matched_entries, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn non_matching_exact_filter_checks_cancellation_after_cursor_step() -> TestResult {
+        let dir = TempDir::new()?;
+        let path = archived_journal_path(&dir, 0x21, 1, 1_000_000);
+        write_archived_journal(
+            &path,
+            0x31,
+            &[TestEntry {
+                realtime: 1_000_000,
+                monotonic: 100,
+                fields: &["MESSAGE=only-entry", "FLOW_VERSION=9"],
+            }],
+        )?;
+
+        let prefilter_matches =
+            build_prefilter_matches(&[("FLOW_VERSION".to_string(), "999".to_string())]);
+        let mut checkpoint_calls = 0;
+        let mut checkpoint = || {
+            checkpoint_calls += 1;
+            if checkpoint_calls == 4 {
+                return Err(anyhow::anyhow!("test scan cancelled"));
+            }
+            Ok(())
+        };
+        let mut seen_any = false;
+        let result = scan_journal_files_forward_with_checkpoint(
+            &[path],
+            None,
+            None,
+            None,
+            0,
+            0,
+            &prefilter_matches,
+            "test filtered cursor cancellation",
+            &mut checkpoint,
+            |_file_path, _journal, _timestamp_usec, _data_offsets, _decompress_buf, _checkpoint| {
+                seen_any = true;
+                Ok(true)
+            },
+        );
+
+        let error = match result {
+            Ok(_) => panic!("the post-step checkpoint must cancel the scan"),
+            Err(error) => error,
+        };
+        assert_eq!(error.to_string(), "test scan cancelled");
+        assert!(
+            !seen_any,
+            "the filter must not yield the non-matching entry"
+        );
         Ok(())
     }
 }

--- a/src/crates/netflow-plugin/src/query/scan/raw.rs
+++ b/src/crates/netflow-plugin/src/query/scan/raw.rs
@@ -1,12 +1,4 @@
 use super::*;
-use std::path::Path;
-
-struct ProjectedRowBuffers<'a> {
-    row_group_field_ids: &'a mut [Option<u32>],
-    row_missing_values: &'a mut [Option<String>],
-    projected_captured_values: &'a mut [Option<String>],
-    pending_spec_indexes: &'a mut Vec<usize>,
-}
 
 struct ProjectedRawEntryState {
     metrics: QueryFlowMetrics,
@@ -16,24 +8,18 @@ struct ProjectedRawEntryState {
 
 impl FlowQueryService {
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn scan_matching_grouped_records_projected_raw_direct(
+    pub(crate) fn scan_matching_records_projected_raw_direct<S: ProjectedRowSink + ?Sized>(
         &self,
         setup: &QuerySetup,
         request: &FlowsRequest,
-        grouped_aggregates: &mut ProjectedGroupAccumulator,
+        plan: &ProjectedScanPlan,
+        sink: &mut S,
         execution: Option<&QueryExecutionPlan>,
         pass_index: usize,
-        prefilter_pairs: &[(String, String)],
-        projected_capture_positions: &FastHashMap<String, usize>,
-        projected_field_specs: &[ProjectedFieldSpec],
-        row_group_field_ids: &mut [Option<u32>],
-        row_missing_values: &mut [Option<String>],
         projected_captured_values: &mut [Option<String>],
         pending_spec_indexes: &mut Vec<usize>,
-        projected_match_plan: Option<&ProjectedFieldMatchPlan>,
     ) -> Result<ScanCounts> {
         let mut counts = ScanCounts::default();
-        let prefilter_matches = build_prefilter_matches(prefilter_pairs);
 
         for (span_index, span) in setup.spans.iter().enumerate() {
             if let Some(execution) = execution {
@@ -46,35 +32,59 @@ impl FlowQueryService {
                 continue;
             }
 
-            for file_path in &span.files {
-                let mut buffers = ProjectedRowBuffers {
-                    row_group_field_ids,
-                    row_missing_values,
-                    projected_captured_values,
-                    pending_spec_indexes,
-                };
-                let file_counts = self.scan_projected_raw_file(
-                    setup,
-                    span,
-                    file_path,
-                    request,
-                    grouped_aggregates,
-                    execution,
-                    pass_index,
-                    span_index,
-                    &prefilter_matches,
-                    projected_capture_positions,
-                    projected_field_specs,
-                    &mut buffers,
-                    projected_match_plan,
-                )?;
-                counts.streamed_entries = counts
-                    .streamed_entries
-                    .saturating_add(file_counts.streamed_entries);
-                counts.matched_entries = counts
-                    .matched_entries
-                    .saturating_add(file_counts.matched_entries);
-            }
+            let span_counts = scan_journal_files_forward(
+                &span.files,
+                Some((span.span.after as u64).saturating_mul(1_000_000)),
+                Some((span.span.before as u64).saturating_mul(1_000_000)),
+                execution,
+                pass_index,
+                span_index,
+                &plan.prefilter_matches,
+                "projected raw grouped query scan",
+                |file_path, journal, timestamp_usec, data_offsets, decompress_buf| {
+                    let mut entry_state = reset_projected_raw_entry(
+                        plan,
+                        sink,
+                        projected_captured_values,
+                        pending_spec_indexes,
+                    );
+                    apply_projected_raw_payloads(
+                        journal,
+                        file_path,
+                        data_offsets,
+                        decompress_buf,
+                        plan,
+                        &mut entry_state,
+                        sink,
+                        projected_captured_values,
+                        pending_spec_indexes,
+                    )?;
+
+                    if !projected_raw_entry_matches(
+                        request,
+                        &plan.capture_positions,
+                        projected_captured_values,
+                    ) {
+                        return Ok(false);
+                    }
+
+                    sink.consume_row(
+                        timestamp_usec,
+                        RecordHandle::JournalRealtime {
+                            tier: span.span.tier,
+                            timestamp_usec,
+                        },
+                        entry_state.metrics,
+                    )?;
+                    Ok(true)
+                },
+            )?;
+            counts.streamed_entries = counts
+                .streamed_entries
+                .saturating_add(span_counts.streamed_entries);
+            counts.matched_entries = counts
+                .matched_entries
+                .saturating_add(span_counts.matched_entries);
 
             if let Some(execution) = execution {
                 execution.finish_span(pass_index, span_index)?;
@@ -83,180 +93,46 @@ impl FlowQueryService {
 
         Ok(counts)
     }
-
-    #[allow(clippy::too_many_arguments)]
-    fn scan_projected_raw_file(
-        &self,
-        setup: &QuerySetup,
-        span: &PreparedQuerySpan,
-        file_path: &Path,
-        request: &FlowsRequest,
-        grouped_aggregates: &mut ProjectedGroupAccumulator,
-        execution: Option<&QueryExecutionPlan>,
-        pass_index: usize,
-        span_index: usize,
-        prefilter_matches: &[Vec<u8>],
-        projected_capture_positions: &FastHashMap<String, usize>,
-        projected_field_specs: &[ProjectedFieldSpec],
-        buffers: &mut ProjectedRowBuffers<'_>,
-        projected_match_plan: Option<&ProjectedFieldMatchPlan>,
-    ) -> Result<ScanCounts> {
-        let registry_file = RegistryFile::from_path(file_path).with_context(|| {
-            format!(
-                "failed to parse raw journal repository metadata for {}",
-                file_path.display()
-            )
-        })?;
-        let journal = JournalFile::<Mmap>::open(&registry_file, FACET_CACHE_JOURNAL_WINDOW_SIZE)
-            .with_context(|| {
-                format!(
-                    "failed to open raw journal file {} for projected grouped query",
-                    file_path.display()
-                )
-            })?;
-
-        let mut reader = JournalReader::default();
-        reader.set_location(Location::Head);
-        for pair in prefilter_matches {
-            reader.add_match(pair);
-        }
-
-        let after_usec = (span.span.after as u64).saturating_mul(1_000_000);
-        let before_usec = (span.span.before as u64).saturating_mul(1_000_000);
-        let mut counts = ScanCounts::default();
-        let mut data_offsets = Vec::new();
-        let mut decompress_buf = Vec::new();
-
-        loop {
-            let has_entry = reader
-                .step(&journal, JournalDirection::Forward)
-                .with_context(|| {
-                    format!(
-                        "failed to step raw journal reader for {}",
-                        file_path.display()
-                    )
-                })?;
-            if !has_entry {
-                break;
-            }
-
-            counts.streamed_entries = counts.streamed_entries.saturating_add(1);
-            let entry_offset = reader.get_entry_offset().with_context(|| {
-                format!(
-                    "failed to read current entry offset from {}",
-                    file_path.display()
-                )
-            })?;
-            let entry_guard = journal.entry_ref(entry_offset).with_context(|| {
-                format!("failed to read current entry from {}", file_path.display())
-            })?;
-            let timestamp_usec = entry_guard.header.realtime;
-            if let Some(execution) = execution {
-                execution.checkpoint(
-                    pass_index,
-                    span_index,
-                    counts.streamed_entries,
-                    timestamp_usec,
-                )?;
-            }
-            if timestamp_usec < after_usec || timestamp_usec >= before_usec {
-                continue;
-            }
-
-            let mut entry_state =
-                reset_projected_raw_entry(projected_field_specs, projected_match_plan, buffers);
-            data_offsets.clear();
-            entry_guard
-                .collect_offsets(&mut data_offsets)
-                .with_context(|| {
-                    format!(
-                        "failed to collect payload offsets from current entry in {}",
-                        file_path.display()
-                    )
-                })?;
-            drop(entry_guard);
-
-            apply_projected_raw_payloads(
-                &journal,
-                file_path,
-                &data_offsets,
-                &mut decompress_buf,
-                projected_match_plan,
-                projected_field_specs,
-                &mut entry_state,
-                grouped_aggregates,
-                buffers,
-                self.max_groups,
-            )?;
-
-            if !projected_raw_entry_matches(
-                request,
-                projected_capture_positions,
-                buffers.projected_captured_values,
-            ) {
-                continue;
-            }
-
-            grouped_aggregates.accumulate_projected(
-                &setup.effective_group_by,
-                timestamp_usec,
-                RecordHandle::JournalRealtime {
-                    tier: span.span.tier,
-                    timestamp_usec,
-                },
-                entry_state.metrics,
-                buffers.row_group_field_ids,
-                buffers.row_missing_values,
-                self.max_groups,
-            )?;
-            counts.matched_entries = counts.matched_entries.saturating_add(1);
-        }
-
-        Ok(counts)
-    }
 }
 
-fn reset_projected_raw_entry(
-    projected_field_specs: &[ProjectedFieldSpec],
-    projected_match_plan: Option<&ProjectedFieldMatchPlan>,
-    buffers: &mut ProjectedRowBuffers<'_>,
+fn reset_projected_raw_entry<S: ProjectedRowSink + ?Sized>(
+    plan: &ProjectedScanPlan,
+    sink: &mut S,
+    projected_captured_values: &mut [Option<String>],
+    pending_spec_indexes: &mut Vec<usize>,
 ) -> ProjectedRawEntryState {
-    buffers.row_group_field_ids.fill(None);
-    for value in buffers.row_missing_values.iter_mut() {
+    sink.reset_row();
+    for value in projected_captured_values.iter_mut() {
         let _ = value.take();
     }
-    for value in buffers.projected_captured_values.iter_mut() {
-        let _ = value.take();
-    }
-    buffers.pending_spec_indexes.clear();
-    buffers
-        .pending_spec_indexes
-        .extend(0..projected_field_specs.len());
+    pending_spec_indexes.clear();
+    pending_spec_indexes.extend(0..plan.field_specs.len());
 
     ProjectedRawEntryState {
         metrics: QueryFlowMetrics::default(),
-        remaining: buffers.pending_spec_indexes.len(),
-        remaining_mask: projected_match_plan
+        remaining: pending_spec_indexes.len(),
+        remaining_mask: plan
+            .match_plan
+            .as_ref()
             .map(|plan| plan.all_mask)
             .unwrap_or_default(),
     }
 }
 
 #[allow(clippy::too_many_arguments)]
-fn apply_projected_raw_payloads(
+fn apply_projected_raw_payloads<S: ProjectedRowSink + ?Sized>(
     journal: &JournalFile<Mmap>,
     file_path: &Path,
     data_offsets: &[NonZeroU64],
     decompress_buf: &mut Vec<u8>,
-    projected_match_plan: Option<&ProjectedFieldMatchPlan>,
-    projected_field_specs: &[ProjectedFieldSpec],
+    plan: &ProjectedScanPlan,
     entry_state: &mut ProjectedRawEntryState,
-    grouped_aggregates: &ProjectedGroupAccumulator,
-    buffers: &mut ProjectedRowBuffers<'_>,
-    max_groups: usize,
+    sink: &mut S,
+    projected_captured_values: &mut [Option<String>],
+    pending_spec_indexes: &mut [usize],
 ) -> Result<()> {
     for data_offset in data_offsets.iter().copied() {
-        if projected_raw_scan_complete(projected_match_plan, entry_state) {
+        if projected_raw_scan_complete(plan.match_plan.as_ref(), entry_state) {
             continue;
         }
 
@@ -270,31 +146,25 @@ fn apply_projected_raw_payloads(
             data_guard.raw_payload()
         };
 
-        if let Some(match_plan) = projected_match_plan {
+        if let Some(match_plan) = plan.match_plan.as_ref() {
             let _ = apply_projected_payload_planned(
                 payload,
                 match_plan,
-                projected_field_specs,
+                &plan.field_specs,
                 &mut entry_state.remaining_mask,
                 &mut entry_state.metrics,
-                grouped_aggregates,
-                buffers.row_group_field_ids,
-                buffers.row_missing_values,
-                buffers.projected_captured_values,
-                max_groups,
+                sink,
+                projected_captured_values,
             );
         } else {
             let _ = apply_projected_payload(
                 payload,
-                projected_field_specs,
-                buffers.pending_spec_indexes,
+                &plan.field_specs,
+                pending_spec_indexes,
                 &mut entry_state.remaining,
                 &mut entry_state.metrics,
-                grouped_aggregates,
-                buffers.row_group_field_ids,
-                buffers.row_missing_values,
-                buffers.projected_captured_values,
-                max_groups,
+                sink,
+                projected_captured_values,
             );
         }
     }

--- a/src/crates/netflow-plugin/src/query/scan/raw.rs
+++ b/src/crates/netflow-plugin/src/query/scan/raw.rs
@@ -11,7 +11,7 @@ impl FlowQueryService {
     pub(crate) fn scan_matching_records_projected_raw_direct<S: ProjectedRowSink + ?Sized>(
         &self,
         setup: &QuerySetup,
-        request: &FlowsRequest,
+        _request: &FlowsRequest,
         plan: &ProjectedScanPlan,
         sink: &mut S,
         execution: Option<&QueryExecutionPlan>,
@@ -39,7 +39,7 @@ impl FlowQueryService {
                 execution,
                 pass_index,
                 span_index,
-                &plan.prefilter_matches,
+                &setup.prefilter_matches,
                 "projected raw grouped query scan",
                 |file_path, journal, timestamp_usec, data_offsets, decompress_buf| {
                     let mut entry_state = reset_projected_raw_entry(
@@ -61,7 +61,7 @@ impl FlowQueryService {
                     )?;
 
                     if !projected_raw_entry_matches(
-                        request,
+                        &setup.selections,
                         &plan.capture_positions,
                         projected_captured_values,
                     ) {
@@ -182,14 +182,14 @@ fn projected_raw_scan_complete(
 }
 
 fn projected_raw_entry_matches(
-    request: &FlowsRequest,
+    selections: &CompiledSelections,
     projected_capture_positions: &FastHashMap<String, usize>,
     projected_captured_values: &[Option<String>],
 ) -> bool {
-    request.selections.is_empty()
+    selections.is_empty()
         || captured_facet_matches_selections_except(
             None,
-            &request.selections,
+            selections,
             projected_capture_positions,
             projected_captured_values,
         )

--- a/src/crates/netflow-plugin/src/query/scan/selection.rs
+++ b/src/crates/netflow-plugin/src/query/scan/selection.rs
@@ -2,42 +2,27 @@ use super::*;
 
 pub(crate) fn record_matches_selections(
     record: &QueryFlowRecord,
-    selections: &HashMap<String, Vec<String>>,
+    selections: &CompiledSelections,
 ) -> bool {
     record_matches_selections_except(record, selections, None)
 }
 
 pub(crate) fn record_matches_selections_except(
     record: &QueryFlowRecord,
-    selections: &HashMap<String, Vec<String>>,
+    selections: &CompiledSelections,
     ignored_field: Option<&str>,
 ) -> bool {
-    selections.iter().all(|(field, values)| {
-        if ignored_field.is_some_and(|ignored| field.eq_ignore_ascii_case(ignored)) {
-            return true;
-        }
-        if values.is_empty() {
-            return true;
-        }
-        let normalized = field.to_ascii_uppercase();
-        let record_value = normalized_record_field_value(record, &normalized);
-        values.iter().any(|value| value == record_value.as_ref())
+    selections.matches(ignored_field, |field| {
+        Some(normalized_record_field_value(record, field))
     })
 }
 
+#[cfg(test)]
 pub(crate) fn cursor_prefilter_pairs(
     selections: &HashMap<String, Vec<String>>,
 ) -> Vec<(String, String)> {
-    let mut pairs = selections
-        .iter()
-        .filter(|(field, _)| !is_virtual_flow_field(field))
-        .flat_map(|(field, values)| {
-            values
-                .iter()
-                .filter(|value| !value.is_empty())
-                .map(|value| (field.to_ascii_uppercase(), value.clone()))
-        })
-        .collect::<Vec<_>>();
-    pairs.sort_unstable();
-    pairs
+    CompiledSelections::compile(selections)
+        .expect("test selections should compile")
+        .prefilter_pairs()
+        .to_vec()
 }

--- a/src/crates/netflow-plugin/src/query/scan/session/projected.rs
+++ b/src/crates/netflow-plugin/src/query/scan/session/projected.rs
@@ -109,7 +109,7 @@ impl FlowQueryService {
                 execution,
                 pass_index,
                 span_index,
-                &plan.prefilter_matches,
+                &setup.prefilter_matches,
                 "projected grouped query scan",
                 |file_path, journal, timestamp_usec, data_offsets, decompress_buf| {
                     sink.reset_row();
@@ -139,10 +139,10 @@ impl FlowQueryService {
                         },
                     )?;
 
-                    if !request.selections.is_empty()
+                    if !setup.selections.is_empty()
                         && !captured_facet_matches_selections_except(
                             None,
-                            &request.selections,
+                            &setup.selections,
                             &plan.capture_positions,
                             &projected_captured_values,
                         )

--- a/src/crates/netflow-plugin/src/query/scan/session/projected.rs
+++ b/src/crates/netflow-plugin/src/query/scan/session/projected.rs
@@ -9,77 +9,85 @@ impl FlowQueryService {
         execution: Option<&QueryExecutionPlan>,
         pass_index: usize,
     ) -> Result<ScanCounts> {
+        let plan = ProjectedScanPlan::for_group_totals(setup, request);
+        let mut row_group_field_ids = vec![None; setup.effective_group_by.len()];
+        let mut row_missing_values = std::iter::repeat_with(|| None)
+            .take(setup.effective_group_by.len())
+            .collect::<Vec<Option<String>>>();
+        let mut sink = ProjectedGroupingSink::new(
+            grouped_aggregates,
+            &setup.effective_group_by,
+            &mut row_group_field_ids,
+            &mut row_missing_values,
+            self.max_groups,
+        );
+        self.scan_matching_records_projected(
+            setup, request, &plan, &mut sink, execution, pass_index,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn scan_matching_timeseries_records_projected(
+        &self,
+        setup: &QuerySetup,
+        request: &FlowsRequest,
+        fields: &ProjectedFieldTable,
+        retained_group_keys: &FastHashMap<Vec<u32>, usize>,
+        top_group_keys: &FastHashMap<Vec<u32>, usize>,
+        overflow_dimension: Option<usize>,
+        layout: TimeseriesLayout,
+        sort_by: SortBy,
+        series_buckets: &mut [Vec<u64>],
+        execution: Option<&QueryExecutionPlan>,
+        pass_index: usize,
+    ) -> Result<ScanCounts> {
+        let plan = ProjectedScanPlan::for_timeseries(setup, request, sort_by);
+        let mut sink = ProjectedTimeseriesSink::new(
+            fields,
+            retained_group_keys,
+            top_group_keys,
+            overflow_dimension,
+            sort_by,
+            layout,
+            series_buckets,
+            setup.effective_group_by.len(),
+        );
+        self.scan_matching_records_projected(
+            setup, request, &plan, &mut sink, execution, pass_index,
+        )
+    }
+
+    fn scan_matching_records_projected<S: ProjectedRowSink + ?Sized>(
+        &self,
+        setup: &QuerySetup,
+        request: &FlowsRequest,
+        plan: &ProjectedScanPlan,
+        sink: &mut S,
+        execution: Option<&QueryExecutionPlan>,
+        pass_index: usize,
+    ) -> Result<ScanCounts> {
         let mut counts = ScanCounts::default();
 
         if setup.spans.iter().all(|span| span.files.is_empty()) {
             return Ok(counts);
         }
-        let prefilter_pairs = cursor_prefilter_pairs(&request.selections);
-        let prefilter_matches = build_prefilter_matches(&prefilter_pairs);
-
-        let mut row_group_field_ids = vec![None; setup.effective_group_by.len()];
-        let mut row_missing_values = std::iter::repeat_with(|| None)
-            .take(setup.effective_group_by.len())
-            .collect::<Vec<Option<String>>>();
-        let mut captured_fields = request
-            .selections
-            .keys()
-            .map(|field| field.to_ascii_uppercase())
-            .collect::<Vec<_>>();
-        captured_fields.sort_unstable();
-        captured_fields.dedup();
-        let projected_capture_positions = captured_fields
-            .iter()
-            .cloned()
-            .enumerate()
-            .map(|(index, field)| (field, index))
-            .collect::<FastHashMap<_, _>>();
-        let mut projected_captured_values = vec![None; captured_fields.len()];
-        let mut projected_field_specs = Vec::with_capacity(
-            2 + setup.effective_group_by.len() + projected_capture_positions.len() + 2,
-        );
-        for (metric_key, metric_field) in [
-            (b"BYTES".as_slice(), ProjectedMetricField::Bytes),
-            (b"PACKETS".as_slice(), ProjectedMetricField::Packets),
-        ] {
-            let spec_index = projected_field_spec_index(&mut projected_field_specs, metric_key);
-            projected_field_specs[spec_index].targets.metric = Some(metric_field);
-        }
-        for (index, field) in setup.effective_group_by.iter().enumerate() {
-            let spec_index =
-                projected_field_spec_index(&mut projected_field_specs, field.as_bytes());
-            projected_field_specs[spec_index].targets.action.group_slot = Some(index);
-        }
-        for (field, field_index) in &projected_capture_positions {
-            let spec_index =
-                projected_field_spec_index(&mut projected_field_specs, field.as_bytes());
-            projected_field_specs[spec_index]
-                .targets
-                .action
-                .capture_slot = Some(*field_index);
-        }
-        let projected_match_plan = ProjectedFieldMatchPlan::new(&projected_field_specs);
-        let mut pending_spec_indexes = (0..projected_field_specs.len()).collect::<Vec<_>>();
+        let mut projected_captured_values = vec![None; plan.capture_positions.len()];
+        let mut pending_spec_indexes = (0..plan.field_specs.len()).collect::<Vec<_>>();
 
         if setup
             .spans
             .iter()
             .all(|span| span.span.tier == TierKind::Raw)
         {
-            return self.scan_matching_grouped_records_projected_raw_direct(
+            return self.scan_matching_records_projected_raw_direct(
                 setup,
                 request,
-                grouped_aggregates,
+                plan,
+                sink,
                 execution,
                 pass_index,
-                &prefilter_pairs,
-                &projected_capture_positions,
-                &projected_field_specs,
-                &mut row_group_field_ids,
-                &mut row_missing_values,
                 &mut projected_captured_values,
                 &mut pending_spec_indexes,
-                projected_match_plan.as_ref(),
             );
         }
 
@@ -101,19 +109,16 @@ impl FlowQueryService {
                 execution,
                 pass_index,
                 span_index,
-                &prefilter_matches,
+                &plan.prefilter_matches,
                 "projected grouped query scan",
                 |file_path, journal, timestamp_usec, data_offsets, decompress_buf| {
-                    row_group_field_ids.fill(None);
-                    for value in &mut row_missing_values {
-                        let _ = value.take();
-                    }
+                    sink.reset_row();
                     for value in &mut projected_captured_values {
                         let _ = value.take();
                     }
                     let mut metrics = QueryFlowMetrics::default();
                     pending_spec_indexes.clear();
-                    pending_spec_indexes.extend(0..projected_field_specs.len());
+                    pending_spec_indexes.extend(0..plan.field_specs.len());
                     let mut remaining = pending_spec_indexes.len();
                     visit_journal_payloads(
                         journal,
@@ -123,15 +128,12 @@ impl FlowQueryService {
                         |payload| {
                             let _ = apply_projected_payload(
                                 payload,
-                                &projected_field_specs,
+                                &plan.field_specs,
                                 &mut pending_spec_indexes,
                                 &mut remaining,
                                 &mut metrics,
-                                grouped_aggregates,
-                                &mut row_group_field_ids,
-                                &mut row_missing_values,
+                                sink,
                                 &mut projected_captured_values,
-                                self.max_groups,
                             );
                             Ok(())
                         },
@@ -141,24 +143,20 @@ impl FlowQueryService {
                         && !captured_facet_matches_selections_except(
                             None,
                             &request.selections,
-                            &projected_capture_positions,
+                            &plan.capture_positions,
                             &projected_captured_values,
                         )
                     {
                         return Ok(false);
                     }
 
-                    grouped_aggregates.accumulate_projected(
-                        &setup.effective_group_by,
+                    sink.consume_row(
                         timestamp_usec,
                         RecordHandle::JournalRealtime {
                             tier: span.span.tier,
                             timestamp_usec,
                         },
                         metrics,
-                        &mut row_group_field_ids,
-                        &mut row_missing_values,
-                        self.max_groups,
                     )?;
                     Ok(true)
                 },

--- a/src/crates/netflow-plugin/src/query/scan/session/records.rs
+++ b/src/crates/netflow-plugin/src/query/scan/session/records.rs
@@ -22,8 +22,6 @@ impl FlowQueryService {
         };
 
         let mut counts = ScanCounts::default();
-        let prefilter_matches =
-            build_prefilter_matches(&cursor_prefilter_pairs(&request.selections));
 
         for (span_index, span) in setup.spans.iter().enumerate() {
             if let Some(execution) = execution {
@@ -43,7 +41,7 @@ impl FlowQueryService {
                 execution,
                 pass_index,
                 span_index,
-                &prefilter_matches,
+                &setup.prefilter_matches,
                 "selected tier scan",
                 |file_path, journal, timestamp_usec, data_offsets, decompress_buf| {
                     let mut fields = BTreeMap::new();
@@ -85,7 +83,7 @@ impl FlowQueryService {
                     }
 
                     let record = QueryFlowRecord::new(timestamp_usec, fields);
-                    if !record_matches_selections(&record, &request.selections) {
+                    if !record_matches_selections(&record, &setup.selections) {
                         return Ok(false);
                     }
                     on_record(

--- a/src/crates/netflow-plugin/src/query/service.rs
+++ b/src/crates/netflow-plugin/src/query/service.rs
@@ -78,13 +78,33 @@ impl FlowQueryService {
     }
 
     pub(crate) async fn initialize_facets(&self) -> Result<()> {
-        self.initialize_facets_with_inventory(false).await
+        self.initialize_facets_with_inventory(false, None)
+            .await
+            .map(|_| ())
     }
 
-    async fn initialize_facets_with_inventory(&self, disk_first: bool) -> Result<()> {
+    pub(crate) async fn initialize_facets_cancellable(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<bool> {
+        self.initialize_facets_with_inventory(false, Some(cancellation))
+            .await
+    }
+
+    async fn initialize_facets_with_inventory(
+        &self,
+        disk_first: bool,
+        cancellation: Option<CancellationToken>,
+    ) -> Result<bool> {
         const MAX_RECONCILE_ATTEMPTS: usize = 3;
 
         for attempt in 1..=MAX_RECONCILE_ATTEMPTS {
+            if cancellation
+                .as_ref()
+                .is_some_and(CancellationToken::is_cancelled)
+            {
+                return Ok(false);
+            }
             let registry_files = if attempt == 1 && !disk_first {
                 self.registry
                     .find_files_in_range(Seconds(0), Seconds(u32::MAX))
@@ -97,14 +117,38 @@ impl FlowQueryService {
             let plan = self.facet_runtime.build_reconcile_plan(&registry_files);
             let archived_files = plan.archived_files_to_scan.clone();
             let active_files = plan.active_files_to_scan.clone();
-            let (archived_scans, active_scans) = tokio::task::spawn_blocking(move || {
+            let scan_cancellation = cancellation.clone();
+            let scans = tokio::task::spawn_blocking(move || {
                 Ok::<_, anyhow::Error>((
-                    scan_facet_contributions(&archived_files)?,
-                    scan_facet_contributions(&active_files)?,
+                    scan_facet_contributions_with_cancellation(
+                        &archived_files,
+                        scan_cancellation.as_ref(),
+                    )?,
+                    scan_facet_contributions_with_cancellation(
+                        &active_files,
+                        scan_cancellation.as_ref(),
+                    )?,
                 ))
             })
             .await
-            .context("facet initialization task join failed")??;
+            .context("facet initialization task join failed")?;
+            let (archived_scans, active_scans) = match scans {
+                Ok(scans) => scans,
+                Err(_)
+                    if cancellation
+                        .as_ref()
+                        .is_some_and(CancellationToken::is_cancelled) =>
+                {
+                    return Ok(false);
+                }
+                Err(err) => return Err(err),
+            };
+            if cancellation
+                .as_ref()
+                .is_some_and(CancellationToken::is_cancelled)
+            {
+                return Ok(false);
+            }
 
             if self
                 .facet_runtime
@@ -119,7 +163,7 @@ impl FlowQueryService {
                         "trimmed glibc heap after netflow facet reconciliation"
                     );
                 }
-                return Ok(());
+                return Ok(true);
             }
 
             tracing::debug!(
@@ -160,7 +204,10 @@ impl FlowQueryService {
 
     pub(crate) async fn initialize_facets_before_ingest(&self) -> Result<()> {
         if !self.facet_runtime.direction_migration_pending() {
-            return self.initialize_facets_with_inventory(true).await;
+            return self
+                .initialize_facets_with_inventory(true, None)
+                .await
+                .map(|_| ());
         }
 
         let retained_files = self.enumerate_facet_files_from_disk()?;
@@ -190,7 +237,12 @@ impl FlowQueryService {
         let retained_files = self.enumerate_facet_files_from_disk()?;
         let plan = self.facet_runtime.build_reconcile_plan(&retained_files);
         if plan.rebuild_archived || !plan.archived_files_to_scan.is_empty() {
-            self.initialize_facets().await?;
+            if !self
+                .initialize_facets_with_inventory(false, Some(cancellation.clone()))
+                .await?
+            {
+                return Ok(false);
+            }
             if !self.facet_runtime.direction_migration_pending() {
                 return Ok(true);
             }
@@ -281,11 +333,34 @@ fn is_journal_notify_path(path: &Path) -> bool {
 fn scan_facet_contributions(
     files: &[FileInfo],
 ) -> Result<BTreeMap<String, crate::facet_runtime::FacetFileContribution>> {
+    scan_facet_contributions_with_cancellation(files, None)
+}
+
+fn scan_facet_contributions_with_cancellation(
+    files: &[FileInfo],
+    cancellation: Option<&CancellationToken>,
+) -> Result<BTreeMap<String, crate::facet_runtime::FacetFileContribution>> {
     let mut contributions = BTreeMap::new();
     for file_info in files {
+        if cancellation.is_some_and(CancellationToken::is_cancelled) {
+            anyhow::bail!("facet contribution scan cancelled");
+        }
         let path = file_info.file.path().to_string();
-        let contribution = match crate::facet_runtime::scan_registry_file_contribution(file_info) {
+        let scan = match cancellation {
+            Some(cancellation) => {
+                crate::facet_runtime::scan_registry_file_contribution_for_fields_cancellable(
+                    file_info,
+                    crate::facet_catalog::FACET_ALLOWED_OPTIONS.as_slice(),
+                    cancellation,
+                )
+            }
+            None => crate::facet_runtime::scan_registry_file_contribution(file_info),
+        };
+        let contribution = match scan {
             Ok(contribution) => contribution,
+            Err(err) if cancellation.is_some_and(CancellationToken::is_cancelled) => {
+                return Err(err);
+            }
             Err(err) => {
                 if is_not_found_error(&err) {
                     tracing::debug!(
@@ -319,16 +394,18 @@ fn scan_facet_contributions_for_fields_strict(
             anyhow::bail!("DIRECTION facet migration cancelled");
         }
         let path = file_info.file.path().to_string();
-        let contribution = crate::facet_runtime::scan_registry_file_contribution_for_fields(
-            file_info,
-            requested_fields,
-        )
-        .with_context(|| {
-            format!(
-                "failed to scan retained journal {} during DIRECTION migration",
-                path
+        let contribution =
+            crate::facet_runtime::scan_registry_file_contribution_for_fields_cancellable(
+                file_info,
+                requested_fields,
+                cancellation,
             )
-        })?;
+            .with_context(|| {
+                format!(
+                    "failed to scan retained journal {} during DIRECTION migration",
+                    path
+                )
+            })?;
         contributions.insert(path, contribution);
     }
     Ok(contributions)

--- a/src/crates/netflow-plugin/src/query/service.rs
+++ b/src/crates/netflow-plugin/src/query/service.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::local_journal_host::load_local_journal_provider;
 use crate::memory_allocator::trim_allocator_if_worthwhile;
+use tokio_util::sync::CancellationToken;
 
 pub(crate) struct FlowQueryService {
     pub(super) registry: Registry,
@@ -77,45 +78,164 @@ impl FlowQueryService {
     }
 
     pub(crate) async fn initialize_facets(&self) -> Result<()> {
-        let registry_files = self
-            .registry
-            .find_files_in_range(Seconds(0), Seconds(u32::MAX))
-            .context(
-                "failed to enumerate retained netflow journal files for facet initialization",
-            )?;
-        let plan = self.facet_runtime.build_reconcile_plan(&registry_files);
-        if self.facet_runtime.is_ready()
-            && plan.archived_files_to_scan.is_empty()
-            && plan.active_files_to_scan.is_empty()
-        {
-            return Ok(());
+        self.initialize_facets_with_inventory(false).await
+    }
+
+    async fn initialize_facets_with_inventory(&self, disk_first: bool) -> Result<()> {
+        const MAX_RECONCILE_ATTEMPTS: usize = 3;
+
+        for attempt in 1..=MAX_RECONCILE_ATTEMPTS {
+            let registry_files = if attempt == 1 && !disk_first {
+                self.registry
+                    .find_files_in_range(Seconds(0), Seconds(u32::MAX))
+                    .context(
+                        "failed to enumerate retained netflow journal files for facet initialization",
+                    )?
+            } else {
+                self.enumerate_facet_files_from_disk()?
+            };
+            let plan = self.facet_runtime.build_reconcile_plan(&registry_files);
+            let archived_files = plan.archived_files_to_scan.clone();
+            let active_files = plan.active_files_to_scan.clone();
+            let (archived_scans, active_scans) = tokio::task::spawn_blocking(move || {
+                Ok::<_, anyhow::Error>((
+                    scan_facet_contributions(&archived_files)?,
+                    scan_facet_contributions(&active_files)?,
+                ))
+            })
+            .await
+            .context("facet initialization task join failed")??;
+
+            if self
+                .facet_runtime
+                .apply_reconcile_plan(plan, archived_scans, active_scans)?
+            {
+                if let Some(trimmed) = trim_allocator_if_worthwhile() {
+                    tracing::info!(
+                        before_heap_free = trimmed.before.heap_free_bytes,
+                        after_heap_free = trimmed.after.heap_free_bytes,
+                        before_heap_arena = trimmed.before.heap_arena_bytes,
+                        after_heap_arena = trimmed.after.heap_arena_bytes,
+                        "trimmed glibc heap after netflow facet reconciliation"
+                    );
+                }
+                return Ok(());
+            }
+
+            tracing::debug!(
+                attempt,
+                "retained journals changed during netflow facet reconciliation; retrying"
+            );
+            tokio::task::yield_now().await;
         }
 
-        let archived_files = plan.archived_files_to_scan.clone();
-        let active_files = plan.active_files_to_scan.clone();
-        let (archived_scans, active_scans) = tokio::task::spawn_blocking(move || {
-            Ok::<_, anyhow::Error>((
-                scan_facet_contributions(&archived_files)?,
-                scan_facet_contributions(&active_files)?,
-            ))
+        anyhow::bail!(
+            "retained journals changed during all {} netflow facet reconciliation attempts",
+            MAX_RECONCILE_ATTEMPTS
+        )
+    }
+
+    fn enumerate_facet_files_from_disk(&self) -> Result<Vec<FileInfo>> {
+        let mut tier_dirs = self.tier_dirs.values().collect::<Vec<_>>();
+        tier_dirs.sort();
+        let mut files = Vec::new();
+
+        for tier_dir in tier_dirs {
+            let tier_dir = tier_dir
+                .to_str()
+                .context("netflow tier directory contains invalid UTF-8")?;
+            let discovered = journal_sdk_registry::repository::file::scan_journal_files(tier_dir)
+                .with_context(|| {
+                format!("failed to rescan netflow tier directory {tier_dir}")
+            })?;
+            files.extend(discovered.into_iter().map(|file| FileInfo {
+                file,
+                time_range: TimeRange::Unknown,
+            }));
+        }
+        files.sort_by(|left, right| left.file.path().cmp(right.file.path()));
+        files.dedup_by(|left, right| left.file.path() == right.file.path());
+        Ok(files)
+    }
+
+    pub(crate) async fn initialize_facets_before_ingest(&self) -> Result<()> {
+        if !self.facet_runtime.direction_migration_pending() {
+            return self.initialize_facets_with_inventory(true).await;
+        }
+
+        let retained_files = self.enumerate_facet_files_from_disk()?;
+        let active_files = self
+            .facet_runtime
+            .build_reconcile_plan(&retained_files)
+            .active_files_to_scan;
+        let active_scans =
+            tokio::task::spawn_blocking(move || scan_facet_contributions(&active_files))
+                .await
+                .context("active facet initialization task join failed")??;
+        self.facet_runtime
+            .apply_active_scan_before_direction_migration(active_scans)
+    }
+
+    /// Rebuild archived DIRECTION after ingestion is listening. Returns `false`
+    /// when the retained journal set changed during the scan and a retry is
+    /// required.
+    pub(crate) async fn migrate_direction_facets(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<bool> {
+        if !self.facet_runtime.direction_migration_pending() {
+            return Ok(true);
+        }
+
+        let retained_files = self.enumerate_facet_files_from_disk()?;
+        let plan = self.facet_runtime.build_reconcile_plan(&retained_files);
+        if plan.rebuild_archived || !plan.archived_files_to_scan.is_empty() {
+            self.initialize_facets().await?;
+            if !self.facet_runtime.direction_migration_pending() {
+                return Ok(true);
+            }
+        }
+
+        if cancellation.is_cancelled() {
+            return Ok(false);
+        }
+        let retained_files = self.enumerate_facet_files_from_disk()?;
+        let plan = self.facet_runtime.build_reconcile_plan(&retained_files);
+        if plan.rebuild_archived || !plan.archived_files_to_scan.is_empty() {
+            return Ok(false);
+        }
+        let expected_archived_paths = plan.current_archived_paths;
+        let archived_files = retained_files
+            .into_iter()
+            .filter(|file_info| expected_archived_paths.contains(file_info.file.path()))
+            .collect::<Vec<_>>();
+        let scan_cancellation = cancellation.clone();
+        let archived_scans = tokio::task::spawn_blocking(move || {
+            scan_facet_contributions_for_fields_strict(
+                &archived_files,
+                &["DIRECTION".to_string()],
+                &scan_cancellation,
+            )
         })
         .await
-        .context("facet initialization task join failed")??;
+        .context("DIRECTION facet migration task join failed")?;
+        let archived_scans = match archived_scans {
+            Ok(scans) => scans,
+            Err(_) if cancellation.is_cancelled() => return Ok(false),
+            Err(err) => return Err(err),
+        };
 
-        self.facet_runtime
-            .apply_reconcile_plan(plan, archived_scans, active_scans)?;
-
-        if let Some(trimmed) = trim_allocator_if_worthwhile() {
+        let applied = self
+            .facet_runtime
+            .complete_direction_migration(&expected_archived_paths, archived_scans)?;
+        if applied && let Some(trimmed) = trim_allocator_if_worthwhile() {
             tracing::info!(
                 before_heap_free = trimmed.before.heap_free_bytes,
                 after_heap_free = trimmed.after.heap_free_bytes,
-                before_heap_arena = trimmed.before.heap_arena_bytes,
-                after_heap_arena = trimmed.after.heap_arena_bytes,
-                "trimmed glibc heap after netflow facet reconciliation"
+                "trimmed glibc heap after netflow DIRECTION migration"
             );
         }
-
-        Ok(())
+        Ok(applied)
     }
 }
 
@@ -188,6 +308,32 @@ fn scan_facet_contributions(
     Ok(contributions)
 }
 
+fn scan_facet_contributions_for_fields_strict(
+    files: &[FileInfo],
+    requested_fields: &[String],
+    cancellation: &CancellationToken,
+) -> Result<BTreeMap<String, crate::facet_runtime::FacetFileContribution>> {
+    let mut contributions = BTreeMap::new();
+    for file_info in files {
+        if cancellation.is_cancelled() {
+            anyhow::bail!("DIRECTION facet migration cancelled");
+        }
+        let path = file_info.file.path().to_string();
+        let contribution = crate::facet_runtime::scan_registry_file_contribution_for_fields(
+            file_info,
+            requested_fields,
+        )
+        .with_context(|| {
+            format!(
+                "failed to scan retained journal {} during DIRECTION migration",
+                path
+            )
+        })?;
+        contributions.insert(path, contribution);
+    }
+    Ok(contributions)
+}
+
 fn is_not_found_error(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         cause
@@ -203,6 +349,7 @@ mod tests {
         Event,
         event::{CreateKind, EventKind, ModifyKind, RemoveKind, RenameMode},
     };
+    use std::fs;
 
     fn path(value: &str) -> PathBuf {
         PathBuf::from(value)
@@ -288,6 +435,23 @@ mod tests {
     }
 
     #[test]
+    fn direction_migration_fails_when_any_journal_cannot_be_scanned() {
+        let missing = "/tmp/netflow-missing-direction-migration-test/system.journal";
+
+        let err = scan_facet_contributions_for_fields_strict(
+            &[file_info(missing)],
+            &["DIRECTION".to_string()],
+            &CancellationToken::new(),
+        )
+        .expect_err("strict migration scan must not skip a missing journal");
+
+        assert!(
+            err.to_string().contains(missing),
+            "migration error should identify the unreadable journal: {err:#}"
+        );
+    }
+
+    #[test]
     fn not_found_errors_are_classified_through_context_layers() {
         let not_found = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::NotFound))
             .context("outer context");
@@ -297,5 +461,74 @@ mod tests {
 
         assert!(is_not_found_error(&not_found));
         assert!(!is_not_found_error(&permission_denied));
+    }
+
+    #[tokio::test]
+    async fn facet_reconcile_recovers_from_registry_lag_without_dropping_live_values() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let tier_dirs = HashMap::from([
+            (TierKind::Raw, tmp.path().join("raw")),
+            (TierKind::Minute1, tmp.path().join("1m")),
+            (TierKind::Minute5, tmp.path().join("5m")),
+            (TierKind::Hour1, tmp.path().join("1h")),
+        ]);
+        for tier_dir in tier_dirs.values() {
+            fs::create_dir_all(tier_dir).expect("create tier directory");
+        }
+        let raw_dir = tier_dirs.get(&TierKind::Raw).expect("raw tier");
+        let archived_path = raw_dir.join(
+            "system@22222222222222222222222222222222-\
+             0000000000000001-00000000000f4240.journal",
+        );
+        let active_path = raw_dir.join("system.journal");
+        fs::File::create(&archived_path).expect("create archived journal placeholder");
+        fs::File::create(&active_path).expect("create active journal placeholder");
+
+        let facet_runtime = Arc::new(crate::facet_runtime::FacetRuntime::new(tmp.path()));
+        let mut archived_fields = crate::flow::FlowFields::new();
+        archived_fields.insert("PROTOCOL", "6".to_string());
+        facet_runtime
+            .observe_active_contribution(
+                &archived_path,
+                &crate::facet_runtime::facet_contribution_from_flow_fields(&archived_fields),
+            )
+            .expect("observe contribution before rotation");
+        facet_runtime
+            .observe_rotation(&archived_path, &active_path)
+            .expect("observe rotation before registry catches up");
+        facet_runtime
+            .observe_active_path_created(&active_path)
+            .expect("observe active path before registry catches up");
+        let mut fields = crate::flow::FlowFields::new();
+        fields.insert("PROTOCOL", "17".to_string());
+        facet_runtime
+            .observe_active_contribution(
+                &active_path,
+                &crate::facet_runtime::facet_contribution_from_flow_fields(&fields),
+            )
+            .expect("observe live value");
+
+        let (monitor, _notify_rx) = Monitor::new().expect("create registry monitor");
+        let service = FlowQueryService {
+            registry: Registry::new(monitor),
+            agent_id: "test-agent".to_string(),
+            tier_dirs,
+            max_groups: 100,
+            facet_runtime: Arc::clone(&facet_runtime),
+        };
+        service
+            .initialize_facets()
+            .await
+            .expect("retry reconciliation from a fresh disk inventory");
+
+        assert_eq!(
+            facet_runtime
+                .snapshot()
+                .fields
+                .get("PROTOCOL")
+                .expect("protocol field")
+                .values,
+            vec!["6".to_string(), "17".to_string()]
+        );
     }
 }

--- a/src/crates/netflow-plugin/src/query/tests.rs
+++ b/src/crates/netflow-plugin/src/query/tests.rs
@@ -718,6 +718,38 @@ fn request_deserialization_supports_autocomplete_mode() {
 }
 
 #[test]
+fn request_deserialization_accepts_ipv4_and_ipv6_cidr_selections() {
+    let request = serde_json::from_str::<FlowsRequest>(
+        r#"{
+            "selections": {
+                "src_addr": ["10.1.2.99/24", "2001:db8:1::abcd/48"],
+                "src_prefix": ["10.0.0.0/8"]
+            }
+        }"#,
+    )
+    .expect("CIDR selections should deserialize");
+
+    assert_eq!(
+        request.selections["SRC_ADDR"],
+        ["10.1.2.99/24", "2001:db8:1::abcd/48"]
+    );
+    assert_eq!(request.selections["SRC_PREFIX"], ["10.0.0.0/8"]);
+}
+
+#[test]
+fn request_deserialization_rejects_invalid_cidr_on_ip_address_facets_only() {
+    let error = serde_json::from_str::<FlowsRequest>(r#"{"selections":{"src_addr":["10/8"]}}"#)
+        .expect_err("loose CIDR shorthand must be autocomplete-only");
+    assert!(
+        error.to_string().contains("invalid CIDR selection `10/8`"),
+        "unexpected error: {error}"
+    );
+
+    serde_json::from_str::<FlowsRequest>(r#"{"selections":{"src_prefix":["10/8"]}}"#)
+        .expect("stored prefix facets keep exact string selection semantics");
+}
+
+#[test]
 fn request_deserialization_rejects_oversized_autocomplete_term() {
     let term = "x".repeat(257);
     let payload = format!(r#"{{"mode":"autocomplete","field":"src_as_name","term":"{term}"}}"#);
@@ -1112,7 +1144,8 @@ fn facet_vocabularies_keep_selected_values_without_retained_vocabulary() {
         .find(|entry| entry["field"] == "SRC_ADDR")
         .expect("source address facet");
     assert_eq!(src_addr["total_values"], 0);
-    assert_eq!(src_addr["autocomplete"], false);
+    assert_eq!(src_addr["truncated"], false);
+    assert_eq!(src_addr["autocomplete"], true);
     assert_eq!(
         src_addr["values"][0],
         json!({
@@ -1227,6 +1260,38 @@ fn facet_vocabularies_keep_exact_value_limit_untruncated() {
     assert_eq!(values.len(), super::FACET_STATIC_VALUE_LIMIT);
     assert_eq!(values.first().copied(), Some("AS00000 PROVIDER"));
     assert_eq!(values.last().copied(), Some(expected_last.as_str()));
+}
+
+#[test]
+fn ip_facets_keep_complete_inline_values_while_advertising_autocomplete() {
+    let requested_fields = vec!["SRC_ADDR".to_string()];
+    let published_values = (0..super::FACET_STATIC_VALUE_LIMIT)
+        .map(|index| std::net::Ipv4Addr::from(0xc000_0200_u32 + index as u32).to_string())
+        .collect::<Vec<_>>();
+    let facets = super::build_facet_vocabulary_payload(
+        &requested_fields,
+        &HashMap::new(),
+        &BTreeMap::from([(
+            "SRC_ADDR".to_string(),
+            crate::facet_runtime::FacetPublishedField {
+                total_values: published_values.len(),
+                autocomplete: false,
+                values: published_values,
+            },
+        )]),
+    );
+
+    let src_addr = &facets["fields"][0];
+    assert_eq!(src_addr["total_values"], super::FACET_STATIC_VALUE_LIMIT);
+    assert_eq!(src_addr["truncated"], false);
+    assert_eq!(src_addr["autocomplete"], true);
+    assert_eq!(
+        src_addr["values"]
+            .as_array()
+            .expect("complete inline IP values")
+            .len(),
+        super::FACET_STATIC_VALUE_LIMIT
+    );
 }
 
 #[test]
@@ -1365,15 +1430,21 @@ fn captured_facet_helpers_resolve_virtual_values_and_ignore_self_selection() {
             vec!["AS4333 NETDATA".to_string()],
         ),
     ]);
+    let compiled = super::CompiledSelections::compile(&selections).expect("compile selections");
     assert!(super::captured_facet_matches_selections_except(
         Some("ICMPV4"),
-        &selections,
+        &compiled,
         &capture_positions,
         &captured_values,
     ));
+    let mismatched = super::CompiledSelections::compile(&HashMap::from([(
+        "ICMPV4".to_string(),
+        vec!["Echo Request".to_string()],
+    )]))
+    .expect("compile selections");
     assert!(!super::captured_facet_matches_selections_except(
         Some("SRC_AS_NAME"),
-        &HashMap::from([("ICMPV4".to_string(), vec!["Echo Request".to_string()])]),
+        &mismatched,
         &capture_positions,
         &captured_values,
     ));
@@ -2436,10 +2507,15 @@ fn projected_timeseries_plan_reads_only_the_selected_pass_two_metric() {
         group_by: vec!["SRC_AS_NAME".to_string()],
         ..super::FlowsRequest::default()
     };
+    let selections =
+        super::CompiledSelections::compile(&request.selections).expect("compile selections");
+    let prefilter_matches = super::build_prefilter_matches(selections.prefilter_pairs());
     let setup = super::QuerySetup {
         sort_by: SortBy::Packets,
         timeseries_layout: None,
         effective_group_by: request.group_by.clone(),
+        selections,
+        prefilter_matches,
         limit: 25,
         spans: Vec::new(),
         stats: HashMap::new(),

--- a/src/crates/netflow-plugin/src/query/tests.rs
+++ b/src/crates/netflow-plugin/src/query/tests.rs
@@ -2161,7 +2161,6 @@ fn consume_projected_test_record<S: super::ProjectedRowSink + ?Sized>(
     sink: &mut S,
     record: &super::QueryFlowRecord,
     group_by: &[String],
-    tier: super::TierKind,
 ) {
     sink.reset_row();
     for (field_index, field) in group_by.iter().enumerate() {
@@ -2172,7 +2171,7 @@ fn consume_projected_test_record<S: super::ProjectedRowSink + ?Sized>(
     sink.consume_row(
         record.timestamp_usec,
         super::RecordHandle::JournalRealtime {
-            tier,
+            tier: super::TierKind::Raw,
             timestamp_usec: record.timestamp_usec,
         },
         super::sampled_metrics_from_fields(&record.fields),
@@ -2182,13 +2181,11 @@ fn consume_projected_test_record<S: super::ProjectedRowSink + ?Sized>(
 
 fn materialized_test_timeseries(
     records: &[super::QueryFlowRecord],
-    tiers: &[super::TierKind],
     group_by: &[String],
     sort_by: SortBy,
     max_groups: usize,
     limit: usize,
 ) -> TestTimeseriesResult {
-    assert_eq!(records.len(), tiers.len());
     let mut aggregates: HashMap<super::GroupKey, super::AggregatedFlow> = HashMap::new();
     let mut overflow = super::GroupOverflow::default();
     for record in records {
@@ -2218,7 +2215,7 @@ fn materialized_test_timeseries(
     let layout = test_timeseries_layout();
     let mut buckets = vec![vec![0_u64; ranked.rows.len()]; layout.bucket_count];
 
-    for (record, _) in records.iter().zip(tiers) {
+    for record in records {
         let key = super::group_key_from_labels(&super::labels_for_group(record, group_by));
         let Some(dimension_index) = super::materialized_timeseries_dimension(
             &key,
@@ -2256,13 +2253,11 @@ fn materialized_test_timeseries(
 
 fn projected_test_timeseries(
     records: &[super::QueryFlowRecord],
-    tiers: &[super::TierKind],
     group_by: &[String],
     sort_by: SortBy,
     max_groups: usize,
     limit: usize,
 ) -> TestTimeseriesResult {
-    assert_eq!(records.len(), tiers.len());
     let mut aggregates = super::ProjectedGroupAccumulator::new(group_by);
     let mut row_group_field_ids = vec![None; group_by.len()];
     let mut row_missing_values = std::iter::repeat_with(|| None)
@@ -2276,8 +2271,8 @@ fn projected_test_timeseries(
             &mut row_missing_values,
             max_groups,
         );
-        for (record, tier) in records.iter().zip(tiers) {
-            consume_projected_test_record(&mut sink, record, group_by, *tier);
+        for record in records {
+            consume_projected_test_record(&mut sink, record, group_by);
         }
     }
 
@@ -2338,8 +2333,8 @@ fn projected_test_timeseries(
             &mut buckets,
             group_by.len(),
         );
-        for (record, tier) in records.iter().zip(tiers) {
-            consume_projected_test_record(&mut sink, record, group_by, *tier);
+        for record in records {
+            consume_projected_test_record(&mut sink, record, group_by);
         }
     }
 
@@ -2383,26 +2378,14 @@ fn timeseries_test_records() -> Vec<super::QueryFlowRecord> {
 }
 
 #[test]
-fn projected_timeseries_accumulation_matches_materialized_for_raw_rollup_and_mixed_handles() {
+fn projected_timeseries_accumulation_matches_materialized() {
     let records = timeseries_test_records();
     let group_by = vec!["PROTOCOL".to_string()];
-    let tier_cases = [
-        vec![super::TierKind::Raw; records.len()],
-        vec![super::TierKind::Minute5; records.len()],
-        vec![
-            super::TierKind::Raw,
-            super::TierKind::Minute1,
-            super::TierKind::Minute5,
-        ],
-    ];
 
-    for tiers in tier_cases {
-        for sort_by in [SortBy::Bytes, SortBy::Packets] {
-            let materialized =
-                materialized_test_timeseries(&records, &tiers, &group_by, sort_by, 100, 2);
-            let projected = projected_test_timeseries(&records, &tiers, &group_by, sort_by, 100, 2);
-            assert_eq!(projected, materialized);
-        }
+    for sort_by in [SortBy::Bytes, SortBy::Packets] {
+        let materialized = materialized_test_timeseries(&records, &group_by, sort_by, 100, 2);
+        let projected = projected_test_timeseries(&records, &group_by, sort_by, 100, 2);
+        assert_eq!(projected, materialized);
     }
 }
 
@@ -2434,12 +2417,11 @@ fn projected_and_materialized_timeseries_populate_ranked_overflow() {
             ]),
         },
     ];
-    let tiers = vec![super::TierKind::Raw; records.len()];
     let group_by = vec!["PROTOCOL".to_string()];
 
     for (sort_by, expected_total) in [(SortBy::Bytes, 300), (SortBy::Packets, 30)] {
-        let materialized = materialized_test_timeseries(&records, &tiers, &group_by, sort_by, 1, 1);
-        let projected = projected_test_timeseries(&records, &tiers, &group_by, sort_by, 1, 1);
+        let materialized = materialized_test_timeseries(&records, &group_by, sort_by, 1, 1);
+        let projected = projected_test_timeseries(&records, &group_by, sort_by, 1, 1);
         assert_eq!(projected, materialized);
         assert_eq!(
             projected.rows[0].0.get("_bucket").map(String::as_str),
@@ -2476,12 +2458,10 @@ fn projected_timeseries_keeps_unseen_value_distinct_from_retained_missing_group(
             ]),
         },
     ];
-    let tiers = vec![super::TierKind::Raw; records.len()];
     let group_by = vec!["PROTOCOL".to_string()];
 
-    let materialized =
-        materialized_test_timeseries(&records, &tiers, &group_by, SortBy::Bytes, 1, 1);
-    let projected = projected_test_timeseries(&records, &tiers, &group_by, SortBy::Bytes, 1, 1);
+    let materialized = materialized_test_timeseries(&records, &group_by, SortBy::Bytes, 1, 1);
+    let projected = projected_test_timeseries(&records, &group_by, SortBy::Bytes, 1, 1);
 
     assert_eq!(projected, materialized);
     assert_eq!(

--- a/src/crates/netflow-plugin/src/query/tests.rs
+++ b/src/crates/netflow-plugin/src/query/tests.rs
@@ -2067,6 +2067,412 @@ fn metrics_chart_uses_only_discovered_top_n_groups() {
     assert_eq!(total, 2.5);
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct TestTimeseriesResult {
+    rows: Vec<(BTreeMap<String, String>, u64, u64)>,
+    buckets: Vec<Vec<u64>>,
+    grouped_total: usize,
+    truncated: bool,
+    other_count: usize,
+    overflow_records: u64,
+}
+
+fn test_timeseries_layout() -> super::TimeseriesLayout {
+    super::TimeseriesLayout {
+        after: 0,
+        before: 180,
+        bucket_seconds: 60,
+        bucket_count: 3,
+    }
+}
+
+fn consume_projected_test_record<S: super::ProjectedRowSink + ?Sized>(
+    sink: &mut S,
+    record: &super::QueryFlowRecord,
+    group_by: &[String],
+    tier: super::TierKind,
+) {
+    sink.reset_row();
+    for (field_index, field) in group_by.iter().enumerate() {
+        if let Some(value) = record.fields.get(field) {
+            sink.observe_group_value(field_index, value);
+        }
+    }
+    sink.consume_row(
+        record.timestamp_usec,
+        super::RecordHandle::JournalRealtime {
+            tier,
+            timestamp_usec: record.timestamp_usec,
+        },
+        super::sampled_metrics_from_fields(&record.fields),
+    )
+    .expect("consume projected test record");
+}
+
+fn materialized_test_timeseries(
+    records: &[super::QueryFlowRecord],
+    tiers: &[super::TierKind],
+    group_by: &[String],
+    sort_by: SortBy,
+    max_groups: usize,
+    limit: usize,
+) -> TestTimeseriesResult {
+    assert_eq!(records.len(), tiers.len());
+    let mut aggregates: HashMap<super::GroupKey, super::AggregatedFlow> = HashMap::new();
+    let mut overflow = super::GroupOverflow::default();
+    for record in records {
+        super::accumulate_grouped_record(
+            record,
+            super::sampled_metrics_from_fields(&record.fields),
+            group_by,
+            &mut aggregates,
+            &mut overflow,
+            max_groups,
+        );
+    }
+
+    let retained_group_keys = aggregates.keys().cloned().collect::<HashSet<_>>();
+    let overflow_records = overflow.dropped_records;
+    let ranked = super::rank_aggregates(aggregates, overflow.aggregate.take(), sort_by, limit);
+    let overflow_dimension = ranked.rows.iter().position(|row| {
+        row.labels.get("_bucket").map(String::as_str) == Some(super::OVERFLOW_BUCKET_LABEL)
+    });
+    let top_group_keys = ranked
+        .rows
+        .iter()
+        .enumerate()
+        .filter(|(_, row)| !row.labels.contains_key("_bucket"))
+        .map(|(index, row)| (super::group_key_from_labels(&row.labels), index))
+        .collect::<HashMap<_, _>>();
+    let layout = test_timeseries_layout();
+    let mut buckets = vec![vec![0_u64; ranked.rows.len()]; layout.bucket_count];
+
+    for (record, _) in records.iter().zip(tiers) {
+        let key = super::group_key_from_labels(&super::labels_for_group(record, group_by));
+        let Some(dimension_index) = super::materialized_timeseries_dimension(
+            &key,
+            &top_group_keys,
+            &retained_group_keys,
+            overflow_dimension,
+        ) else {
+            continue;
+        };
+        super::accumulate_series_bucket(
+            &mut buckets,
+            record.timestamp_usec,
+            layout.after,
+            layout.before,
+            layout.bucket_seconds,
+            dimension_index,
+            super::sampled_metric_value(sort_by, &record.fields),
+        );
+    }
+
+    let rows = ranked
+        .rows
+        .iter()
+        .map(|row| (row.labels.clone(), row.metrics.bytes, row.metrics.packets))
+        .collect();
+    TestTimeseriesResult {
+        rows,
+        buckets,
+        grouped_total: ranked.grouped_total,
+        truncated: ranked.truncated,
+        other_count: ranked.other_count,
+        overflow_records,
+    }
+}
+
+fn projected_test_timeseries(
+    records: &[super::QueryFlowRecord],
+    tiers: &[super::TierKind],
+    group_by: &[String],
+    sort_by: SortBy,
+    max_groups: usize,
+    limit: usize,
+) -> TestTimeseriesResult {
+    assert_eq!(records.len(), tiers.len());
+    let mut aggregates = super::ProjectedGroupAccumulator::new(group_by);
+    let mut row_group_field_ids = vec![None; group_by.len()];
+    let mut row_missing_values = std::iter::repeat_with(|| None)
+        .take(group_by.len())
+        .collect::<Vec<Option<String>>>();
+    {
+        let mut sink = super::ProjectedGroupingSink::new(
+            &mut aggregates,
+            group_by,
+            &mut row_group_field_ids,
+            &mut row_missing_values,
+            max_groups,
+        );
+        for (record, tier) in records.iter().zip(tiers) {
+            consume_projected_test_record(&mut sink, record, group_by, *tier);
+        }
+    }
+
+    let grouped_total = aggregates.grouped_total();
+    let overflow_records = aggregates.overflow.dropped_records;
+    let super::ProjectedGroupAccumulator {
+        fields,
+        rows,
+        row_indexes: retained_group_keys,
+        overflow,
+        ..
+    } = aggregates;
+    let ranked = super::rank_compact_top_aggregates(rows, overflow.aggregate, sort_by, limit);
+    let top_group_keys = ranked
+        .rows
+        .iter()
+        .enumerate()
+        .filter_map(|(dimension_index, row)| {
+            row.group_field_ids
+                .as_ref()
+                .map(|group_key| (group_key.clone(), dimension_index))
+        })
+        .collect::<hashbrown::HashMap<_, _>>();
+    let overflow_dimension = ranked
+        .rows
+        .iter()
+        .position(|row| row.bucket_label == Some(super::OVERFLOW_BUCKET_LABEL));
+    let rows = ranked
+        .rows
+        .iter()
+        .map(|row| {
+            let labels = if let Some(bucket_label) = row.bucket_label {
+                super::synthetic_bucket_labels(bucket_label)
+            } else {
+                super::labels_for_projected_compact_flow(
+                    &fields,
+                    group_by,
+                    row.group_field_ids
+                        .as_deref()
+                        .expect("projected group field ids"),
+                )
+                .expect("materialize projected labels")
+            };
+            (labels, row.metrics.bytes, row.metrics.packets)
+        })
+        .collect();
+
+    let layout = test_timeseries_layout();
+    let mut buckets = vec![vec![0_u64; ranked.rows.len()]; layout.bucket_count];
+    {
+        let mut sink = super::ProjectedTimeseriesSink::new(
+            &fields,
+            &retained_group_keys,
+            &top_group_keys,
+            overflow_dimension,
+            sort_by,
+            layout,
+            &mut buckets,
+            group_by.len(),
+        );
+        for (record, tier) in records.iter().zip(tiers) {
+            consume_projected_test_record(&mut sink, record, group_by, *tier);
+        }
+    }
+
+    TestTimeseriesResult {
+        rows,
+        buckets,
+        grouped_total,
+        truncated: ranked.truncated,
+        other_count: ranked.other_count,
+        overflow_records,
+    }
+}
+
+fn timeseries_test_records() -> Vec<super::QueryFlowRecord> {
+    vec![
+        super::QueryFlowRecord {
+            timestamp_usec: 10_000_000,
+            fields: BTreeMap::from([
+                ("PROTOCOL".to_string(), "6".to_string()),
+                ("BYTES".to_string(), "100".to_string()),
+                ("PACKETS".to_string(), "5".to_string()),
+            ]),
+        },
+        super::QueryFlowRecord {
+            timestamp_usec: 70_000_000,
+            fields: BTreeMap::from([
+                ("PROTOCOL".to_string(), "17".to_string()),
+                ("BYTES".to_string(), "80".to_string()),
+                ("PACKETS".to_string(), "20".to_string()),
+            ]),
+        },
+        super::QueryFlowRecord {
+            timestamp_usec: 130_000_000,
+            fields: BTreeMap::from([
+                ("PROTOCOL".to_string(), "6".to_string()),
+                ("BYTES".to_string(), "50".to_string()),
+                ("PACKETS".to_string(), "10".to_string()),
+            ]),
+        },
+    ]
+}
+
+#[test]
+fn projected_timeseries_accumulation_matches_materialized_for_raw_rollup_and_mixed_handles() {
+    let records = timeseries_test_records();
+    let group_by = vec!["PROTOCOL".to_string()];
+    let tier_cases = [
+        vec![super::TierKind::Raw; records.len()],
+        vec![super::TierKind::Minute5; records.len()],
+        vec![
+            super::TierKind::Raw,
+            super::TierKind::Minute1,
+            super::TierKind::Minute5,
+        ],
+    ];
+
+    for tiers in tier_cases {
+        for sort_by in [SortBy::Bytes, SortBy::Packets] {
+            let materialized =
+                materialized_test_timeseries(&records, &tiers, &group_by, sort_by, 100, 2);
+            let projected = projected_test_timeseries(&records, &tiers, &group_by, sort_by, 100, 2);
+            assert_eq!(projected, materialized);
+        }
+    }
+}
+
+#[test]
+fn projected_and_materialized_timeseries_populate_ranked_overflow() {
+    let records = vec![
+        super::QueryFlowRecord {
+            timestamp_usec: 10_000_000,
+            fields: BTreeMap::from([
+                ("PROTOCOL".to_string(), "6".to_string()),
+                ("BYTES".to_string(), "1".to_string()),
+                ("PACKETS".to_string(), "1".to_string()),
+            ]),
+        },
+        super::QueryFlowRecord {
+            timestamp_usec: 70_000_000,
+            fields: BTreeMap::from([
+                ("PROTOCOL".to_string(), "17".to_string()),
+                ("BYTES".to_string(), "100".to_string()),
+                ("PACKETS".to_string(), "10".to_string()),
+            ]),
+        },
+        super::QueryFlowRecord {
+            timestamp_usec: 130_000_000,
+            fields: BTreeMap::from([
+                ("PROTOCOL".to_string(), "1".to_string()),
+                ("BYTES".to_string(), "200".to_string()),
+                ("PACKETS".to_string(), "20".to_string()),
+            ]),
+        },
+    ];
+    let tiers = vec![super::TierKind::Raw; records.len()];
+    let group_by = vec!["PROTOCOL".to_string()];
+
+    for (sort_by, expected_total) in [(SortBy::Bytes, 300), (SortBy::Packets, 30)] {
+        let materialized = materialized_test_timeseries(&records, &tiers, &group_by, sort_by, 1, 1);
+        let projected = projected_test_timeseries(&records, &tiers, &group_by, sort_by, 1, 1);
+        assert_eq!(projected, materialized);
+        assert_eq!(
+            projected.rows[0].0.get("_bucket").map(String::as_str),
+            Some(super::OVERFLOW_BUCKET_LABEL)
+        );
+        assert_eq!(
+            projected
+                .buckets
+                .iter()
+                .map(|bucket| bucket[0])
+                .sum::<u64>(),
+            expected_total
+        );
+        assert_eq!(projected.overflow_records, 2);
+    }
+}
+
+#[test]
+fn projected_timeseries_keeps_unseen_value_distinct_from_retained_missing_group() {
+    let records = vec![
+        super::QueryFlowRecord {
+            timestamp_usec: 10_000_000,
+            fields: BTreeMap::from([
+                ("BYTES".to_string(), "1".to_string()),
+                ("PACKETS".to_string(), "1".to_string()),
+            ]),
+        },
+        super::QueryFlowRecord {
+            timestamp_usec: 70_000_000,
+            fields: BTreeMap::from([
+                ("PROTOCOL".to_string(), "17".to_string()),
+                ("BYTES".to_string(), "100".to_string()),
+                ("PACKETS".to_string(), "10".to_string()),
+            ]),
+        },
+    ];
+    let tiers = vec![super::TierKind::Raw; records.len()];
+    let group_by = vec!["PROTOCOL".to_string()];
+
+    let materialized =
+        materialized_test_timeseries(&records, &tiers, &group_by, SortBy::Bytes, 1, 1);
+    let projected = projected_test_timeseries(&records, &tiers, &group_by, SortBy::Bytes, 1, 1);
+
+    assert_eq!(projected, materialized);
+    assert_eq!(
+        projected.rows[0].0.get("_bucket").map(String::as_str),
+        Some(super::OVERFLOW_BUCKET_LABEL)
+    );
+    assert_eq!(projected.rows[0].1, 100);
+    assert_eq!(
+        projected
+            .buckets
+            .iter()
+            .map(|bucket| bucket[0])
+            .sum::<u64>(),
+        100
+    );
+    assert_eq!(projected.overflow_records, 1);
+}
+
+#[test]
+fn projected_timeseries_plan_reads_only_the_selected_pass_two_metric() {
+    let request = super::FlowsRequest {
+        selections: HashMap::from([("PROTOCOL".to_string(), vec!["6".to_string()])]),
+        group_by: vec!["SRC_AS_NAME".to_string()],
+        ..super::FlowsRequest::default()
+    };
+    let setup = super::QuerySetup {
+        sort_by: SortBy::Packets,
+        timeseries_layout: None,
+        effective_group_by: request.group_by.clone(),
+        limit: 25,
+        spans: Vec::new(),
+        stats: HashMap::new(),
+    };
+
+    let pass1 = super::ProjectedScanPlan::for_group_totals(&setup, &request);
+    let pass2 = super::ProjectedScanPlan::for_timeseries(&setup, &request, SortBy::Packets);
+    let metric_targets = |plan: &super::ProjectedScanPlan| {
+        plan.field_specs
+            .iter()
+            .filter_map(|spec| spec.targets.metric)
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(
+        metric_targets(&pass1),
+        vec![
+            super::ProjectedMetricField::Bytes,
+            super::ProjectedMetricField::Packets
+        ]
+    );
+    assert_eq!(
+        metric_targets(&pass2),
+        vec![super::ProjectedMetricField::Packets]
+    );
+    assert!(pass2.capture_positions.contains_key("PROTOCOL"));
+    assert!(
+        pass2.field_specs.iter().any(|spec| {
+            spec.key == b"SRC_AS_NAME" && spec.targets.action.group_slot == Some(0)
+        })
+    );
+}
+
 fn synthetic_rollup_record(group: usize, timestamp_usec: u64) -> super::QueryFlowRecord {
     let protocol = if group % 2 == 0 { "6" } else { "17" };
     let src_as = 64_512 + (group % 4_096);

--- a/src/crates/netflow-plugin/src/query/tests.rs
+++ b/src/crates/netflow-plugin/src/query/tests.rs
@@ -2,10 +2,10 @@ use super::planner::{grouped_query_can_use_projected_scan, resolve_effective_gro
 use super::scan::cursor_prefilter_pairs;
 use super::{
     FlowsRequest, SortBy, build_aggregated_flows, build_facets, build_grouped_flows,
-    dimensions_from_fields, metrics_from_fields, requires_raw_tier_for_fields,
+    dimensions_from_fields, field_is_raw_only, metrics_from_fields, requires_raw_tier_for_fields,
 };
 use crate::rollup::build_rollup_key;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::Instant;
 
 #[test]
@@ -90,6 +90,103 @@ fn raw_tier_is_required_for_city_fields() {
     let group_by = vec!["SRC_GEO_CITY".to_string(), "DST_GEO_STATE".to_string()];
     let selections = HashMap::new();
     assert!(requires_raw_tier_for_fields(&group_by, &selections, ""));
+}
+
+#[test]
+fn raw_tier_capabilities_cover_every_supported_grouping_field() {
+    const EXPECTED_RAW_ONLY_FIELDS: &[&str] = &[
+        "DST_ADDR",
+        "DST_ADDR_NAT",
+        "DST_AS_PATH",
+        "DST_COMMUNITIES",
+        "DST_GEO_CITY",
+        "DST_LARGE_COMMUNITIES",
+        "DST_MAC",
+        "DST_MASK",
+        "DST_PORT",
+        "DST_PORT_NAT",
+        "DST_PREFIX",
+        "IPTTL",
+        "IPV6_FLOW_LABEL",
+        "IP_FRAGMENT_ID",
+        "IP_FRAGMENT_OFFSET",
+        "MPLS_LABELS",
+        "SRC_ADDR",
+        "SRC_ADDR_NAT",
+        "SRC_GEO_CITY",
+        "SRC_MAC",
+        "SRC_MASK",
+        "SRC_PORT",
+        "SRC_PORT_NAT",
+        "SRC_PREFIX",
+    ];
+
+    let actual = super::supported_group_by_fields()
+        .iter()
+        .filter(|field| field_is_raw_only(field))
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let expected = EXPECTED_RAW_ONLY_FIELDS
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(actual, expected);
+    assert_eq!(
+        super::supported_group_by_fields().len(),
+        80,
+        "public grouping field count changed"
+    );
+    assert_eq!(
+        super::supported_group_by_fields()
+            .iter()
+            .filter(|field| !field_is_raw_only(field))
+            .count(),
+        56,
+        "54 physical rollup fields plus two virtual fields should remain rollup-safe"
+    );
+
+    for field in super::supported_group_by_fields() {
+        let group_by = vec![field.clone()];
+        let selections = HashMap::from([(field.clone(), vec!["value".to_string()])]);
+        assert_eq!(
+            requires_raw_tier_for_fields(&group_by, &HashMap::new(), ""),
+            field_is_raw_only(field),
+            "grouping capability drifted for {field}"
+        );
+        assert_eq!(
+            requires_raw_tier_for_fields(&[], &selections, ""),
+            field_is_raw_only(field),
+            "selection capability drifted for {field}"
+        );
+    }
+}
+
+#[test]
+fn hidden_city_coordinates_and_metric_selections_force_raw() {
+    for field in [
+        "SRC_GEO_LATITUDE",
+        "SRC_GEO_LONGITUDE",
+        "DST_GEO_LATITUDE",
+        "DST_GEO_LONGITUDE",
+        "BYTES",
+        "PACKETS",
+        "FLOWS",
+        "V9_VENDOR_FIELD",
+        "IPFIX_VENDOR_FIELD",
+    ] {
+        assert!(field_is_raw_only(field), "{field} must force raw");
+        assert!(requires_raw_tier_for_fields(
+            &[field.to_string()],
+            &HashMap::new(),
+            ""
+        ));
+        assert!(requires_raw_tier_for_fields(
+            &[],
+            &HashMap::from([(field.to_string(), vec!["value".to_string()])]),
+            ""
+        ));
+    }
 }
 
 #[test]
@@ -885,6 +982,9 @@ fn facet_vocabularies_ignore_active_filters_and_do_not_return_metrics() {
         .find(|entry| entry["field"] == "SRC_AS_NAME")
         .expect("src facet");
 
+    assert_eq!(protocol["autocomplete"], false);
+    assert_eq!(src_as["autocomplete"], true);
+    assert_eq!(src_as["truncated"], false);
     assert_eq!(
         protocol["values"]
             .as_array()
@@ -914,6 +1014,39 @@ fn facet_vocabularies_ignore_active_filters_and_do_not_return_metrics() {
         facets.get("excluded_fields").is_none(),
         "facet payload should not advertise exposed raw-only fields as excluded"
     );
+}
+
+#[test]
+fn high_cardinality_facets_prefer_autocomplete_without_observed_values() {
+    let requested_fields = vec![
+        "SRC_ADDR".to_string(),
+        "SRC_AS_NAME".to_string(),
+        "PROTOCOL".to_string(),
+        "DIRECTION".to_string(),
+    ];
+    let facets =
+        super::build_facet_vocabulary_payload(&requested_fields, &HashMap::new(), &BTreeMap::new());
+    let fields = facets["fields"].as_array().expect("fields array");
+
+    for (field, expected) in [
+        ("SRC_ADDR", true),
+        ("SRC_AS_NAME", true),
+        ("PROTOCOL", false),
+        ("DIRECTION", false),
+    ] {
+        let facet = fields
+            .iter()
+            .find(|entry| entry["field"] == field)
+            .unwrap_or_else(|| panic!("missing {field} facet"));
+        assert_eq!(
+            facet["autocomplete"], expected,
+            "semantic autocomplete policy drifted for {field}"
+        );
+        assert_eq!(
+            facet["truncated"], false,
+            "an empty semantic autocomplete facet is not truncated"
+        );
+    }
 }
 
 #[test]

--- a/src/crates/netflow-plugin/src/query/tests.rs
+++ b/src/crates/netflow-plugin/src/query/tests.rs
@@ -5,6 +5,7 @@ use super::{
     dimensions_from_fields, field_is_raw_only, metrics_from_fields, requires_raw_tier_for_fields,
 };
 use crate::rollup::build_rollup_key;
+use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::Instant;
 
@@ -163,15 +164,12 @@ fn raw_tier_capabilities_cover_every_supported_grouping_field() {
 }
 
 #[test]
-fn hidden_city_coordinates_and_metric_selections_force_raw() {
+fn hidden_city_coordinates_and_vendor_fields_force_raw() {
     for field in [
         "SRC_GEO_LATITUDE",
         "SRC_GEO_LONGITUDE",
         "DST_GEO_LATITUDE",
         "DST_GEO_LONGITUDE",
-        "BYTES",
-        "PACKETS",
-        "FLOWS",
         "V9_VENDOR_FIELD",
         "IPFIX_VENDOR_FIELD",
     ] {
@@ -574,6 +572,32 @@ fn request_deserialization_rejects_removed_internal_timestamp_selection_field() 
             .contains("unsupported selection field `FLOW_END_USEC`"),
         "unexpected error: {error}"
     );
+}
+
+#[test]
+fn request_deserialization_rejects_metric_selection_fields() {
+    for (input, expected) in [
+        ("bytes", "BYTES"),
+        ("PACKETS", "PACKETS"),
+        ("Flows", "FLOWS"),
+    ] {
+        let payload = format!(
+            r#"{{
+                "view":"table-sankey",
+                "group_by":["PROTOCOL"],
+                "selections":{{"{input}":["1"]}}
+            }}"#
+        );
+        let error = serde_json::from_str::<FlowsRequest>(&payload)
+            .expect_err("metric selections must be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("unsupported selection field `{expected}`")),
+            "unexpected error for {input}: {error}"
+        );
+    }
 }
 
 #[test]
@@ -983,7 +1007,7 @@ fn facet_vocabularies_ignore_active_filters_and_do_not_return_metrics() {
         .expect("src facet");
 
     assert_eq!(protocol["autocomplete"], false);
-    assert_eq!(src_as["autocomplete"], true);
+    assert_eq!(src_as["autocomplete"], false);
     assert_eq!(src_as["truncated"], false);
     assert_eq!(
         protocol["values"]
@@ -1017,56 +1041,55 @@ fn facet_vocabularies_ignore_active_filters_and_do_not_return_metrics() {
 }
 
 #[test]
-fn high_cardinality_facets_prefer_autocomplete_without_observed_values() {
+fn facet_vocabularies_omit_unselected_fields_without_retained_values() {
     let requested_fields = vec![
         "SRC_ADDR".to_string(),
         "SRC_AS_NAME".to_string(),
         "PROTOCOL".to_string(),
         "DIRECTION".to_string(),
     ];
-    let facets =
-        super::build_facet_vocabulary_payload(&requested_fields, &HashMap::new(), &BTreeMap::new());
-    let fields = facets["fields"].as_array().expect("fields array");
+    let selections = HashMap::from([("SRC_ADDR".to_string(), Vec::new())]);
+    let snapshot = BTreeMap::from([
+        (
+            "SRC_ADDR".to_string(),
+            crate::facet_runtime::FacetPublishedField::default(),
+        ),
+        (
+            "PROTOCOL".to_string(),
+            crate::facet_runtime::FacetPublishedField::default(),
+        ),
+    ]);
 
-    for (field, expected) in [
-        ("SRC_ADDR", true),
-        ("SRC_AS_NAME", true),
-        ("PROTOCOL", false),
-        ("DIRECTION", false),
-    ] {
-        let facet = fields
-            .iter()
-            .find(|entry| entry["field"] == field)
-            .unwrap_or_else(|| panic!("missing {field} facet"));
-        assert_eq!(
-            facet["autocomplete"], expected,
-            "semantic autocomplete policy drifted for {field}"
-        );
-        assert_eq!(
-            facet["truncated"], false,
-            "an empty semantic autocomplete facet is not truncated"
-        );
-    }
+    let facets = super::build_facet_vocabulary_payload(&requested_fields, &selections, &snapshot);
+
+    assert_eq!(facets["fields"], json!([]));
+    assert_eq!(facets["auto"]["facets"], json!(requested_fields));
+    assert_eq!(facets["auto"]["selections"], json!(selections));
 }
 
 #[test]
-fn facet_vocabularies_keep_selected_values_for_missing_published_field() {
-    let requested_fields = vec!["PROTOCOL".to_string()];
-    let selections = HashMap::from([(
-        "PROTOCOL".to_string(),
-        vec!["6".to_string(), "17".to_string()],
+fn facet_vocabularies_keep_selected_values_without_retained_vocabulary() {
+    let requested_fields = vec!["PROTOCOL".to_string(), "SRC_ADDR".to_string()];
+    let selections = HashMap::from([
+        (
+            "PROTOCOL".to_string(),
+            vec!["6".to_string(), "17".to_string()],
+        ),
+        ("SRC_ADDR".to_string(), vec!["192.0.2.1".to_string()]),
+    ]);
+    let snapshot = BTreeMap::from([(
+        "SRC_ADDR".to_string(),
+        crate::facet_runtime::FacetPublishedField::default(),
     )]);
 
-    let facets =
-        super::build_facet_vocabulary_payload(&requested_fields, &selections, &BTreeMap::new());
+    let facets = super::build_facet_vocabulary_payload(&requested_fields, &selections, &snapshot);
 
-    let protocol = facets["fields"]
-        .as_array()
-        .expect("fields array")
+    let fields = facets["fields"].as_array().expect("fields array");
+    let protocol = fields
         .iter()
         .find(|entry| entry["field"] == "PROTOCOL")
         .expect("protocol facet");
-    assert_eq!(protocol["total_values"], 2);
+    assert_eq!(protocol["total_values"], 0);
     assert_eq!(protocol["truncated"], false);
     assert_eq!(protocol["autocomplete"], false);
     assert_eq!(
@@ -1083,48 +1106,90 @@ fn facet_vocabularies_keep_selected_values_for_missing_published_field() {
             .collect::<Vec<_>>(),
         vec![("6", "TCP"), ("17", "UDP")]
     );
+
+    let src_addr = fields
+        .iter()
+        .find(|entry| entry["field"] == "SRC_ADDR")
+        .expect("source address facet");
+    assert_eq!(src_addr["total_values"], 0);
+    assert_eq!(src_addr["autocomplete"], false);
+    assert_eq!(
+        src_addr["values"][0],
+        json!({
+            "value": "192.0.2.1",
+            "name": "192.0.2.1",
+        })
+    );
 }
 
 #[test]
-fn facet_vocabularies_mark_autocomplete_payloads_truncated_without_extra_values() {
-    let requested_fields = vec!["PROTOCOL".to_string()];
+fn facet_vocabularies_follow_retained_vocabulary_transitions() {
+    let requested_fields = vec!["SRC_AS_NAME".to_string()];
+    let empty_snapshot = BTreeMap::from([(
+        "SRC_AS_NAME".to_string(),
+        crate::facet_runtime::FacetPublishedField::default(),
+    )]);
+    let populated_snapshot = BTreeMap::from([(
+        "SRC_AS_NAME".to_string(),
+        crate::facet_runtime::FacetPublishedField {
+            total_values: 1,
+            autocomplete: false,
+            values: vec!["AS15169 GOOGLE".to_string()],
+        },
+    )]);
+
+    let before =
+        super::build_facet_vocabulary_payload(&requested_fields, &HashMap::new(), &empty_snapshot);
+    let after_first_value = super::build_facet_vocabulary_payload(
+        &requested_fields,
+        &HashMap::new(),
+        &populated_snapshot,
+    );
+    let after_last_value =
+        super::build_facet_vocabulary_payload(&requested_fields, &HashMap::new(), &empty_snapshot);
+
+    assert_eq!(before["fields"], json!([]));
+    assert_eq!(after_first_value["fields"][0]["field"], "SRC_AS_NAME");
+    assert_eq!(after_first_value["fields"][0]["total_values"], 1);
+    assert_eq!(after_first_value["fields"][0]["autocomplete"], false);
+    assert_eq!(
+        after_first_value["fields"][0]["values"][0]["value"],
+        "AS15169 GOOGLE"
+    );
+    assert_eq!(after_last_value["fields"], json!([]));
+}
+
+#[test]
+fn facet_vocabularies_keep_published_autocomplete_fields_without_inline_values() {
+    let requested_fields = vec!["SRC_ADDR".to_string()];
     let facets = super::build_facet_vocabulary_payload(
         &requested_fields,
         &HashMap::new(),
         &BTreeMap::from([(
-            "PROTOCOL".to_string(),
+            "SRC_ADDR".to_string(),
             crate::facet_runtime::FacetPublishedField {
-                total_values: 2,
+                total_values: super::FACET_STATIC_VALUE_LIMIT + 1,
                 autocomplete: true,
-                values: vec!["17".to_string(), "6".to_string()],
+                values: Vec::new(),
             },
         )]),
     );
 
-    let protocol = facets["fields"]
-        .as_array()
-        .expect("fields array")
-        .iter()
-        .find(|entry| entry["field"] == "PROTOCOL")
-        .expect("protocol facet");
-    assert_eq!(protocol["total_values"], 2);
-    assert_eq!(protocol["truncated"], true);
-    assert_eq!(protocol["autocomplete"], true);
+    let src_addr = &facets["fields"][0];
+    assert_eq!(src_addr["field"], "SRC_ADDR");
     assert_eq!(
-        protocol["values"]
-            .as_array()
-            .expect("protocol values")
-            .iter()
-            .map(|entry| entry["value"].as_str().unwrap_or_default())
-            .collect::<Vec<_>>(),
-        vec!["6", "17"]
+        src_addr["total_values"],
+        super::FACET_STATIC_VALUE_LIMIT + 1
     );
+    assert_eq!(src_addr["autocomplete"], true);
+    assert_eq!(src_addr["truncated"], true);
+    assert_eq!(src_addr["values"], json!([]));
 }
 
 #[test]
 fn facet_vocabularies_keep_exact_value_limit_untruncated() {
     let requested_fields = vec!["SRC_AS_NAME".to_string()];
-    let published_values = (0..super::FACET_VALUE_LIMIT)
+    let published_values = (0..super::FACET_STATIC_VALUE_LIMIT)
         .rev()
         .map(|index| format!("AS{index:05} PROVIDER"))
         .collect::<Vec<_>>();
@@ -1148,8 +1213,9 @@ fn facet_vocabularies_keep_exact_value_limit_untruncated() {
         .iter()
         .find(|entry| entry["field"] == "SRC_AS_NAME")
         .expect("src_as facet");
-    assert_eq!(src_as["total_values"], super::FACET_VALUE_LIMIT);
+    assert_eq!(src_as["total_values"], super::FACET_STATIC_VALUE_LIMIT);
     assert_eq!(src_as["truncated"], false);
+    assert_eq!(src_as["autocomplete"], false);
 
     let values = src_as["values"]
         .as_array()
@@ -1157,14 +1223,14 @@ fn facet_vocabularies_keep_exact_value_limit_untruncated() {
         .iter()
         .map(|entry| entry["value"].as_str().unwrap_or_default())
         .collect::<Vec<_>>();
-    let expected_last = format!("AS{:05} PROVIDER", super::FACET_VALUE_LIMIT - 1);
-    assert_eq!(values.len(), super::FACET_VALUE_LIMIT);
+    let expected_last = format!("AS{:05} PROVIDER", super::FACET_STATIC_VALUE_LIMIT - 1);
+    assert_eq!(values.len(), super::FACET_STATIC_VALUE_LIMIT);
     assert_eq!(values.first().copied(), Some("AS00000 PROVIDER"));
     assert_eq!(values.last().copied(), Some(expected_last.as_str()));
 }
 
 #[test]
-fn facet_vocabularies_keep_selected_values_and_sorted_limited_prefix_for_high_cardinality() {
+fn facet_vocabularies_keep_stale_selection_separate_from_static_vocabulary() {
     let requested_fields = vec!["SRC_AS_NAME".to_string()];
     let selections = HashMap::from([(
         "SRC_AS_NAME".to_string(),
@@ -1175,7 +1241,7 @@ fn facet_vocabularies_keep_selected_values_and_sorted_limited_prefix_for_high_ca
             "AS00103 PROVIDER".to_string(),
         ],
     )]);
-    let published_values = (0..(super::FACET_VALUE_LIMIT + 5))
+    let published_values = (0..super::FACET_STATIC_VALUE_LIMIT)
         .rev()
         .map(|index| format!("AS{index:05} PROVIDER"))
         .collect::<Vec<_>>();
@@ -1198,8 +1264,9 @@ fn facet_vocabularies_keep_selected_values_and_sorted_limited_prefix_for_high_ca
         .iter()
         .find(|entry| entry["field"] == "SRC_AS_NAME")
         .expect("src_as facet");
-    assert_eq!(src_as["total_values"], super::FACET_VALUE_LIMIT + 6);
-    assert_eq!(src_as["truncated"], true);
+    assert_eq!(src_as["total_values"], super::FACET_STATIC_VALUE_LIMIT);
+    assert_eq!(src_as["truncated"], false);
+    assert_eq!(src_as["autocomplete"], false);
 
     let values = src_as["values"]
         .as_array()
@@ -1207,24 +1274,12 @@ fn facet_vocabularies_keep_selected_values_and_sorted_limited_prefix_for_high_ca
         .iter()
         .map(|entry| entry["value"].as_str().unwrap_or_default())
         .collect::<Vec<_>>();
-    assert_eq!(values.len(), super::FACET_VALUE_LIMIT);
-    assert_eq!(
-        &values[..4],
-        &[
-            "AS99999 SELECTED",
-            "AS00103 PROVIDER",
-            "AS00000 PROVIDER",
-            "AS00001 PROVIDER",
-        ]
-    );
-    assert!(
-        values.contains(&"AS00097 PROVIDER"),
-        "expected the sorted prefix to fill the remaining response slots"
-    );
-    assert!(
-        !values.contains(&"AS00098 PROVIDER"),
-        "expected values after the response limit to be omitted"
-    );
+    assert_eq!(values.len(), super::FACET_STATIC_VALUE_LIMIT + 1);
+    assert_eq!(&values[..2], &["AS99999 SELECTED", "AS00103 PROVIDER"]);
+    assert!((0..super::FACET_STATIC_VALUE_LIMIT).all(|index| {
+        let value = format!("AS{index:05} PROVIDER");
+        values.contains(&value.as_str())
+    }));
     assert_eq!(
         values
             .iter()
@@ -1240,6 +1295,47 @@ fn facet_vocabularies_keep_selected_values_and_sorted_limited_prefix_for_high_ca
             .count(),
         1,
         "selected missing values must not be duplicated"
+    );
+}
+
+#[test]
+fn facet_vocabularies_keep_only_selections_inline_after_autocomplete_promotion() {
+    let requested_fields = vec!["SRC_AS_NAME".to_string()];
+    let selections = HashMap::from([(
+        "SRC_AS_NAME".to_string(),
+        vec![
+            "AS99999 SELECTED".to_string(),
+            "AS00103 PROVIDER".to_string(),
+            "AS99999 SELECTED".to_string(),
+            "AS00103 PROVIDER".to_string(),
+        ],
+    )]);
+
+    let facets = super::build_facet_vocabulary_payload(
+        &requested_fields,
+        &selections,
+        &BTreeMap::from([(
+            "SRC_AS_NAME".to_string(),
+            crate::facet_runtime::FacetPublishedField {
+                total_values: super::FACET_STATIC_VALUE_LIMIT + 5,
+                autocomplete: true,
+                values: Vec::new(),
+            },
+        )]),
+    );
+
+    let src_as = &facets["fields"][0];
+    assert_eq!(src_as["total_values"], super::FACET_STATIC_VALUE_LIMIT + 5);
+    assert_eq!(src_as["truncated"], true);
+    assert_eq!(src_as["autocomplete"], true);
+    assert_eq!(
+        src_as["values"]
+            .as_array()
+            .expect("src_as values")
+            .iter()
+            .map(|entry| entry["value"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>(),
+        vec!["AS99999 SELECTED", "AS00103 PROVIDER"]
     );
 }
 

--- a/src/crates/netflow-plugin/src/query/tests.rs
+++ b/src/crates/netflow-plugin/src/query/tests.rs
@@ -243,7 +243,7 @@ fn grouped_other_bucket_preserves_single_group_values_and_summarizes_mixed_field
 
     let result = build_grouped_flows(
         &records,
-        &["PROTOCOL".to_string(), "SRC_AS_NAME".to_string()],
+        &["SRC_AS_NAME".to_string(), "PROTOCOL".to_string()],
         SortBy::Bytes,
         1,
     );
@@ -254,6 +254,15 @@ fn grouped_other_bucket_preserves_single_group_values_and_summarizes_mixed_field
     assert_eq!(result.flows[1]["key"]["_bucket"], "__other__");
     assert_eq!(result.flows[1]["key"]["PROTOCOL"], "6");
     assert_eq!(result.flows[1]["key"]["SRC_AS_NAME"], "Other (2)");
+    assert_eq!(
+        result.flows[1]["key"]
+            .as_object()
+            .expect("other key")
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["SRC_AS_NAME", "PROTOCOL", "_bucket"]
+    );
 }
 
 #[test]
@@ -397,6 +406,25 @@ fn normalized_group_by_is_capped_to_ten_fields() {
             "SRC_PORT".to_string(),
             "DST_PORT".to_string(),
             "SRC_AS_NAME".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn normalized_group_by_keeps_first_occurrence_order() {
+    let request = serde_json::from_str::<FlowsRequest>(
+        r#"{
+            "group_by":["DST_ADDR","PROTOCOL","DST_ADDR","SRC_ADDR","PROTOCOL"]
+        }"#,
+    )
+    .expect("request should deserialize");
+
+    assert_eq!(
+        request.normalized_group_by(),
+        vec![
+            "DST_ADDR".to_string(),
+            "PROTOCOL".to_string(),
+            "SRC_ADDR".to_string(),
         ]
     );
 }
@@ -922,6 +950,87 @@ fn labels_for_group_uses_stored_as_name_values() {
     assert_eq!(
         labels.get("DST_AS_NAME").map(String::as_str),
         Some("AS0 Unknown ASN")
+    );
+}
+
+#[test]
+fn grouped_response_objects_preserve_group_by_order() {
+    let group_by = vec![
+        "SRC_AS_NAME".to_string(),
+        "PROTOCOL".to_string(),
+        "DST_AS_NAME".to_string(),
+    ];
+    let record = super::QueryFlowRecord::new(
+        42,
+        BTreeMap::from([
+            ("SRC_AS_NAME".to_string(), "Source".to_string()),
+            ("PROTOCOL".to_string(), "6".to_string()),
+            ("DST_AS_NAME".to_string(), "Destination".to_string()),
+            ("BYTES".to_string(), "100".to_string()),
+            ("PACKETS".to_string(), "10".to_string()),
+        ]),
+    );
+
+    let result = super::build_grouped_flows(&[record], &group_by, SortBy::Bytes, 25);
+    let key = result.flows[0]["key"].as_object().expect("grouped key");
+    assert_eq!(
+        key.keys().map(String::as_str).collect::<Vec<_>>(),
+        vec!["SRC_AS_NAME", "PROTOCOL", "DST_AS_NAME"]
+    );
+
+    let columns = crate::presentation::build_table_columns(&group_by);
+    assert_eq!(
+        columns
+            .as_object()
+            .expect("table columns")
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["SRC_AS_NAME", "PROTOCOL", "DST_AS_NAME", "bytes", "packets"]
+    );
+}
+
+#[test]
+fn timeseries_dimension_ids_and_names_preserve_group_by_order() {
+    let group_by = vec![
+        "SRC_AS_NAME".to_string(),
+        "PROTOCOL".to_string(),
+        "DST_AS_NAME".to_string(),
+    ];
+    let row = super::AggregatedFlow {
+        labels: BTreeMap::from([
+            ("DST_AS_NAME".to_string(), "Destination".to_string()),
+            ("PROTOCOL".to_string(), "6".to_string()),
+            ("SRC_AS_NAME".to_string(), "Source".to_string()),
+        ]),
+        metrics: super::QueryFlowMetrics {
+            bytes: 100,
+            packets: 10,
+        },
+        ..super::AggregatedFlow::default()
+    };
+
+    let chart = super::metrics_chart_from_top_groups(
+        0,
+        60,
+        60,
+        SortBy::Bytes,
+        &group_by,
+        &[row],
+        &[vec![100]],
+    );
+
+    assert_eq!(
+        chart["view"]["dimensions"]["ids"][0],
+        r#"{"SRC_AS_NAME":"Source","PROTOCOL":"6","DST_AS_NAME":"Destination"}"#
+    );
+    assert_eq!(
+        chart["view"]["dimensions"]["names"][0],
+        "Source AS Name=Source, Protocol=TCP, Destination AS Name=Destination"
+    );
+    assert_eq!(
+        chart["result"]["labels"][1],
+        "Source AS Name=Source, Protocol=TCP, Destination AS Name=Destination"
     );
 }
 
@@ -1769,7 +1878,7 @@ fn grouped_accumulator_routes_new_groups_to_overflow_after_cap() {
 
 #[test]
 fn grouped_overflow_bucket_preserves_single_group_values_and_summarizes_mixed_fields() {
-    let group_by = vec!["PROTOCOL".to_string(), "SRC_AS_NAME".to_string()];
+    let group_by = vec!["SRC_AS_NAME".to_string(), "PROTOCOL".to_string()];
     let records = vec![
         super::QueryFlowRecord {
             timestamp_usec: 1,
@@ -1813,10 +1922,20 @@ fn grouped_overflow_bucket_preserves_single_group_values_and_summarizes_mixed_fi
         );
     }
 
-    let flow = super::flow_value_from_aggregate(overflow.aggregate.expect("overflow row"));
+    let flow =
+        super::flow_value_from_aggregate(overflow.aggregate.expect("overflow row"), &group_by);
     assert_eq!(flow["key"]["_bucket"], "__overflow__");
     assert_eq!(flow["key"]["PROTOCOL"], "6");
     assert_eq!(flow["key"]["SRC_AS_NAME"], "Other (2)");
+    assert_eq!(
+        flow["key"]
+            .as_object()
+            .expect("overflow key")
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["SRC_AS_NAME", "PROTOCOL", "_bucket"]
+    );
 }
 
 #[test]
@@ -1883,7 +2002,7 @@ fn compact_grouped_accumulator_routes_new_groups_to_overflow_after_cap() {
 
 #[test]
 fn compact_other_bucket_preserves_single_group_values_and_summarizes_mixed_fields() {
-    let group_by = vec!["PROTOCOL".to_string(), "SRC_AS_NAME".to_string()];
+    let group_by = vec!["SRC_AS_NAME".to_string(), "PROTOCOL".to_string()];
     let mut aggregates =
         super::CompactGroupAccumulator::new(&group_by).expect("compact accumulator");
 
@@ -1933,10 +2052,20 @@ fn compact_other_bucket_preserves_single_group_values_and_summarizes_mixed_field
     let other = ranked.other.expect("other bucket");
     let flow = super::flow_value_from_aggregate(
         super::synthetic_aggregate_from_compact(other).expect("materialize compact other"),
+        &group_by,
     );
     assert_eq!(flow["key"]["_bucket"], "__other__");
     assert_eq!(flow["key"]["PROTOCOL"], "6");
     assert_eq!(flow["key"]["SRC_AS_NAME"], "Other (2)");
+    assert_eq!(
+        flow["key"]
+            .as_object()
+            .expect("compact other key")
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["SRC_AS_NAME", "PROTOCOL", "_bucket"]
+    );
 }
 
 #[test]
@@ -1979,6 +2108,7 @@ fn compact_overflow_bucket_preserves_single_group_values_and_summarizes_mixed_fi
         .expect("compact overflow aggregate");
     let flow = super::flow_value_from_aggregate(
         super::synthetic_aggregate_from_compact(overflow).expect("materialize compact overflow"),
+        &group_by,
     );
     assert_eq!(flow["key"]["_bucket"], "__overflow__");
     assert_eq!(flow["key"]["PROTOCOL"], "6");
@@ -2116,6 +2246,7 @@ fn metrics_chart_uses_only_discovered_top_n_groups() {
         layout.before,
         layout.bucket_seconds,
         SortBy::Bytes,
+        &group_by,
         &ranked.rows,
         &series_buckets,
     );

--- a/src/crates/netflow-plugin/src/query/timeseries.rs
+++ b/src/crates/netflow-plugin/src/query/timeseries.rs
@@ -30,20 +30,27 @@ pub(crate) fn metrics_chart_from_top_groups(
     before: u32,
     bucket_seconds: u32,
     sort_by: SortBy,
+    group_by: &[String],
     top_rows: &[AggregatedFlow],
     series_buckets: &[Vec<u64>],
 ) -> Value {
     let rate_units = timeseries_units(sort_by);
-    let ids: Vec<String> = top_rows
+    let ordered_labels: Vec<Map<String, Value>> = top_rows
         .iter()
-        .map(|row| serde_json::to_string(&row.labels).unwrap_or_default())
+        .map(|row| ordered_group_labels(&row.labels, group_by))
         .collect();
-    let names: Vec<String> = top_rows
+    let ids: Vec<String> = ordered_labels
         .iter()
-        .map(|row| {
-            row.labels
+        .map(|labels| serde_json::to_string(labels).unwrap_or_default())
+        .collect();
+    let names: Vec<String> = ordered_labels
+        .iter()
+        .map(|labels| {
+            labels
                 .iter()
-                .map(|(key, value)| presentation::format_group_name(key, value))
+                .map(|(key, value)| {
+                    presentation::format_group_name(key, value.as_str().unwrap_or_default())
+                })
                 .collect::<Vec<_>>()
                 .join(", ")
         })

--- a/src/crates/netflow-plugin/src/startup_memory_tests.rs
+++ b/src/crates/netflow-plugin/src/startup_memory_tests.rs
@@ -187,12 +187,6 @@ async fn profile_live_startup_memory() -> anyhow::Result<StartupMemoryReport> {
         snapshot: current_process_memory()?,
     });
 
-    query_service.initialize_facets().await?;
-    phases.push(StartupMemoryPhase {
-        name: "initialize_facets",
-        snapshot: current_process_memory()?,
-    });
-
     let metrics = Arc::new(ingest::IngestMetrics::default());
     let open_tiers = Arc::new(std::sync::RwLock::new(tiering::OpenTierState::default()));
     let tier_flow_indexes = Arc::new(std::sync::RwLock::new(
@@ -207,6 +201,12 @@ async fn profile_live_startup_memory() -> anyhow::Result<StartupMemoryReport> {
     )?;
     phases.push(StartupMemoryPhase {
         name: "ingest_service_new",
+        snapshot: current_process_memory()?,
+    });
+
+    query_service.initialize_facets_before_ingest().await?;
+    phases.push(StartupMemoryPhase {
+        name: "initialize_facets",
         snapshot: current_process_memory()?,
     });
 

--- a/src/crates/netflow-plugin/src/tiering.rs
+++ b/src/crates/netflow-plugin/src/tiering.rs
@@ -6,6 +6,7 @@ pub(crate) use index::*;
 pub(crate) use model::*;
 #[cfg(test)]
 pub(crate) use rollup::dimensions_for_rollup;
+pub(crate) use rollup::rollup_field_available;
 
 #[cfg(test)]
 #[path = "tiering/tests.rs"]

--- a/src/crates/netflow-plugin/src/tiering/rollup.rs
+++ b/src/crates/netflow-plugin/src/tiering/rollup.rs
@@ -26,3 +26,7 @@ pub(crate) use schema::{
     HOUR_BUCKET_USEC, INTERNAL_DIRECTION_PRESENT, INTERNAL_EXPORTER_IP_PRESENT,
     INTERNAL_NEXT_HOP_PRESENT, build_rollup_flow_index, direction_from_u8,
 };
+
+pub(crate) fn rollup_field_available(field: &str) -> bool {
+    schema::rollup_field_index(field).is_some()
+}

--- a/src/crates/netflow-plugin/src/tiering/rollup/emit.rs
+++ b/src/crates/netflow-plugin/src/tiering/rollup/emit.rs
@@ -665,6 +665,11 @@ mod tests {
             contribution_debug_map(&actual_contribution),
             contribution_debug_map(&expected_contribution)
         );
+        assert_eq!(
+            actual_contribution.debug_string_map().get("DIRECTION"),
+            Some(&vec!["ingress".to_string()]),
+            "rollup facets must expose materialized direction text"
+        );
     }
 
     #[test]


### PR DESCRIPTION
##### Summary

Fix the NetFlow filtering, facet retention, facet presentation, and time-series
query performance problems that fit the existing Function request/response
shape.

Implemented:

- Derive rollup eligibility from the materialized rollup schema. A selected or
  grouped field missing from rollups intentionally forces the raw tier.
- Preserve all 91 canonical fields in raw journals and keep live facet
  contributions consistent with archived-journal scans for present-zero numeric
  values and ICMP fields.
- Store textual `DIRECTION` values correctly and migrate compatible persisted
  facet state from version 6 to version 7 after UDP listeners are ready.
- Include finalized catalog-owned per-journal facet sidecars in each tier's
  retention budget through the systemd-journal SDK artifact hook.
- Omit empty unselected facets dynamically while retaining selected fields so
  filters remain removable.
- Use one retention-wide vocabulary for both presentation modes: return the
  complete static list through 256 retained values and switch dynamically to
  autocomplete at 257.
- Return at most 256 autocomplete matches and at most 256 supplemental inline
  selected values. Prefix fields use prefix matching.
- Accept exact IPv4/IPv6 addresses and CIDRs on the six typed address facets.
  Slash-triggered autocomplete generates bounded canonical CIDRs from loose
  address and prefix-length fragments, including one trailing IPv4 dot, then
  returns only candidates containing an address in that field's compact
  retention-wide vocabulary. It scans neither journal rows nor flow tiers.
- Keep complete inline IP vocabularies through 256 values while advertising
  autocomplete capability for CIDR entry; `truncated` remains independent.
- Reject `BYTES`, `PACKETS`, and `FLOWS` as selection filters because they are
  measures.
- Make background facet reconciliation and `DIRECTION` migration
  shutdown-cancellable inside journal scans, and make shutdown win
  deterministically over listener readiness.
- Keep the intentional two-pass time-series algorithm while making both passes
  projected: pass 1 determines top-N and pass 2 builds chart values without
  materializing complete flow rows.
- Decode only the group/filter/metric fields each time-series pass needs.
  Queries using regex or virtual fields retain the generic compatibility path.
- Fix time-series overflow classification so retained non-top groups are not
  folded into overflow and unseen groups at the cardinality cap are not treated
  as missing fields.
- Preserve tolerant torn-journal-tail handling, cancellation checkpoints,
  progress statistics, tier selection, filters, and response output on the
  projected path.
- Preserve first-seen `group_by` order in response metadata, table/Sankey
  and map columns and row keys, plus projected and materialized time-series
  dimension IDs and descriptions.
- Update configuration metadata, generated NetFlow/IPFIX/sFlow integration
  pages, the stock configuration, and end-user documentation.

Intentionally unchanged in this stage:

- The Boolean contract remains AND between fields and OR between values of one
  field.
- `NOT IN`/negative expressions and arbitrary Boolean nesting still need a
  versioned expression contract. CIDR matching fits the existing string-list
  contract and is included.
- Remaining dashboard filter lifecycle and duplicate-search cleanup stays after
  the existing-contract backend work.
- Protocol field-mapping corrections remain a separate pending change outside
  this PR.

##### Test Plan

- `cargo test -p netflow-plugin`
  - 739 passed
  - 0 failed
  - 39 intentional manual/profile tests ignored
  - vendored-protobuf integration check passed
- `cargo fmt -p netflow-plugin -- --check`
- Integration metadata/document generator tests: 44 passed
- Integration taxonomy validation and generated pages passed
- Optimized CMake release build passed
- `git diff --check`
- Repository SOW and sensitive-data audit passed
- Paired-dashboard order-path tests: 35 passed; request and response arrays
  preserve order
- Independent whole-PR review found no remaining material defect

Focused regressions cover:

- exhaustive raw-versus-rollup field capability
- all 91 canonical raw journal fields
- active/archived facet contribution parity
- dynamic facet omission and 256/257 presentation transitions
- bounded supplemental selected values without losing static vocabulary
- version-6 direction migration, cancellation, restart, and lifecycle races
- deterministic listener-readiness/shutdown behavior
- exact sidecar accounting, path safety, lazy first-write retention, and
  rotation-time finalization on all four tiers
- projected-versus-materialized parity for raw, rollup, and mixed-tier scans
- bytes and packets metrics, top-N, overflow, and retained non-top groups
- exact two-pass on-disk tier counts, progress, cancellation, and generic
  regex fallback
- torn raw journal tails and cancellation when an exact filter yields no entry
- IPv4/IPv6 CIDR boundaries, mixed exact/CIDR OR, field-level AND, bounded
  journal pushdown, broad-CIDR fallback, and raw/rollup/table/time-series parity
- first-occurrence `group_by` normalization, required-parameter order, table/map
  wire order, generic and projected time-series order, and synthetic
  other/overflow rows
- slash-triggered loose CIDR completion, ambiguous prefix fragments, canonical
  ranking, trailing-dot IPv4 input, retained-vocabulary candidate validation,
  and IP facet inline/autocomplete independence

##### Performance

For the reported 24-hour time-series query on the local Athens dataset:

- The original generic path took 43.14 seconds.
- The initial projected implementation took 8.28 seconds: 5.21x faster and
  80.8% less wall time, with both passes scanning the same 2,635,243 entries
  and matching the same 2,635,242 entries.
- A final behavior-preserving scanner refactor was compared under later heavy
  workstation load: 18.95 seconds before versus 19.20 seconds after, with
  identical counts. The 1.3% difference is within run-to-run load noise.
- Under that same later load, the original path took 51.28 seconds versus
  19.20 seconds for the final implementation: 2.67x faster.

The two timing groups are not compared directly because workstation load
changed between them.

CIDR candidate validation uses only the compact typed facet vocabulary:

- A live vocabulary of about 130,000 IPv4 addresses with 12 absent candidates
  took 0.16 ms median.
- A synthetic worst case with 130,000 IPv6 addresses and 40 absent candidates
  took 5.3 ms median and 6.4 ms maximum over 25 rounds.

##### Integration consistency

- Updated: runtime code, `metadata.yaml`, stock `netflow.yaml`, the hand-written
  README, and generated NetFlow/IPFIX/sFlow integration pages.
- Taxonomy is unchanged because no chart context changed.
- `config_schema.json` is unchanged because no configuration key, type, or
  default changed.
- Health configuration is unchanged because no metric or alert changed.

##### Additional Information

- No Function request or response field changed.
- No dashboard source changed. The audit confirmed request/response array order
  and recorded expanded-detail plus stale Sankey-drag presentation defects for
  the later frontend stage.
- Direct API requests that select `BYTES`, `PACKETS`, or `FLOWS` now receive a
  validation error.
- Address selections accept exact IPv4/IPv6 values or complete CIDRs. Loose
  forms such as `10/8` are autocomplete input; returned candidates are canonical.
- CIDR suggestions are retention-wide, not current-query-aware. They prove that
  the selected field has a matching retained address somewhere, but the current
  time window or other active filters can still produce no rows.
- The configured size is a retained-artifact budget, not a strict filesystem
  quota: protected active journals, shared facet state, temporary files, and
  unrelated/orphan files remain outside per-journal accounting.

<details>
<summary>For users: How does this change affect me?</summary>

NetFlow filters select the correct storage tier. Empty fields disappear until
data exists, facets with up to 256 values provide a complete list, and larger
facets use autocomplete. IPv4/IPv6 CIDRs can be discovered by typing `/` and
selected without a new request contract; empty generated networks are not
suggested. Retention includes finalized facet sidecars. Compatible time-series
queries keep the same result while avoiding full-row materialization in both
passes. Group-by fields now keep the selected order in Sankey paths, flow
descriptions, row keys, columns, and time-series labels.

Negative filters and arbitrary Boolean expressions are not added by this stage.

</details>


