### PR TITLE
test(go.d/azure_monitor): assert schema behavior instead of restating the file

### DIFF
--- a/.agents/skills/integrations-lifecycle/consistency.md
+++ b/.agents/skills/integrations-lifecycle/consistency.md
@@ -125,10 +125,15 @@ When reviewing a PR that touches a collector, verify:
    - List tabs in the order the doc lists the groups.
    - Most collectors predate this rule and still disagree, so do
      NOT copy grouping from a neighbouring collector; derive it
-     from that collector's own keys. `cloudwatch` is the worked
-     example, guarded by
-     `cloudwatch/config_test.go`
-     `TestConfigSchema_TabsMatchMetadataGroups`.
+     from that collector's own keys.
+   - Once a collector's two artifacts agree, keep them that way
+     by calling
+     `collecttest.AssertConfigSchemaMatchesMetadata(t, "config_schema.json", "metadata.yaml")`
+     from its tests. It checks per option that the tab listing
+     the option's root property is the first segment of its
+     group, and that every tab is named by some group. The call
+     is opt-in because most collectors would fail it today;
+     `cloudwatch` and `azure_monitor` are the worked examples.
 
 4. **Alert changes have matching `metadata.yaml.alerts`
    entries.** If `health.d/<plugin>.conf` adds, removes, or

--- a/.agents/skills/project-writing-collectors/SKILL.md
+++ b/.agents/skills/project-writing-collectors/SKILL.md
@@ -219,6 +219,13 @@ collector's own `validate()`. Write it for the operator filling the form:
   `src/go/plugin/go.d/collector/config_schema_test.go`
   (`TestConfigSchemasDoNotMaterializeOptionalArrays`). Express "non-empty when
   present" in `validate()` instead.
+- A key revealed by a `dependencies` branch MUST NOT also be declared as a
+  plain sibling property. The branch exists so the form shows that key only for
+  the selected discriminator value; declaring it twice makes the form show it
+  for every value, and leaves the runtime deciding what a field from an
+  unselected branch means. Enforced for every collector by
+  `src/go/plugin/go.d/collector/config_schema_test.go`
+  (`TestConfigSchemasDoNotDeclareBranchKeysAsProperties`).
 - Type an optional array or object to match the Go field, which is nil-able:
   `["array", "null"]` / `["object", "null"]`. A YAML key written with no value
   decodes to nil, which the runtime reads as "absent" and accepts, so a bare

--- a/src/go/plugin/go.d/collector/azure_monitor/collector_test.go
+++ b/src/go/plugin/go.d/collector/azure_monitor/collector_test.go
@@ -4,7 +4,6 @@ package azure_monitor
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"maps"
 	"os"
@@ -50,98 +49,8 @@ func Test_testDataIsValid(t *testing.T) {
 	}
 }
 
-func TestConfigSchema_RuntimeContract(t *testing.T) {
-	raw, err := os.ReadFile("config_schema.json")
-	require.NoError(t, err)
-
-	var doc map[string]any
-	require.NoError(t, json.Unmarshal(raw, &doc))
-
-	schema := requireMapField(t, doc, "jsonSchema")
-	assert.ElementsMatch(t, []string{"subscription_ids", "auth"}, requireStringSliceField(t, schema, "required"))
-
-	properties := requireMapField(t, schema, "properties")
-
-	discovery := requireMapField(t, properties, "discovery")
-	assert.NotContains(t, discovery, "required")
-	discoveryProps := requireMapField(t, discovery, "properties")
-	assert.Contains(t, discoveryProps, "refresh_every")
-	assert.Contains(t, discoveryProps, "mode")
-	assert.NotContains(t, discoveryProps, "mode_filters")
-	assert.NotContains(t, discoveryProps, "mode_query")
-
-	profiles := requireMapField(t, properties, "profiles")
-	assert.NotContains(t, profiles, "required")
-	profileProps := requireMapField(t, profiles, "properties")
-	assert.Contains(t, profileProps, "mode")
-	assert.NotContains(t, profileProps, "mode_exact")
-	assert.NotContains(t, profileProps, "mode_combined")
-
-	virtualNodes := requireMapField(t, properties, "virtual_nodes")
-	assert.NotContains(t, virtualNodes, "required")
-	virtualNodeProps := requireMapField(t, virtualNodes, "properties")
-	byResourceTag := requireMapField(t, virtualNodeProps, "by_resource_tag")
-	assert.Equal(t, "string", byResourceTag["type"])
-
-	uiSchema := requireMapField(t, doc, "uiSchema")
-	uiProfiles := requireMapField(t, uiSchema, "profiles")
-	_, hasIDs := uiProfiles["ids"]
-	assert.False(t, hasIDs)
-	_, hasNames := uiProfiles["names"]
-	assert.False(t, hasNames)
-	_, hasModeAuto := uiProfiles["mode_auto"]
-	assert.True(t, hasModeAuto)
-	_, hasModeExact := uiProfiles["mode_exact"]
-	assert.True(t, hasModeExact)
-	_, hasModeCombined := uiProfiles["mode_combined"]
-	assert.True(t, hasModeCombined)
-
-	tabs := requireArrayField(t, requireMapField(t, uiSchema, "ui:options"), "tabs")
-	var baseFields, vnodeFields []string
-	for _, item := range tabs {
-		tab, ok := item.(map[string]any)
-		require.True(t, ok)
-		switch tab["title"] {
-		case "Base":
-			baseFields = requireStringSliceField(t, tab, "fields")
-		case "Virtual Node":
-			vnodeFields = requireStringSliceField(t, tab, "fields")
-		}
-	}
-	assert.NotContains(t, baseFields, "vnode")
-	assert.NotContains(t, baseFields, "virtual_nodes")
-	assert.ElementsMatch(t, []string{"vnode", "virtual_nodes"}, vnodeFields)
-}
-
-func TestConfigSchema_ProfileTagHelpText(t *testing.T) {
-	raw, err := os.ReadFile("config_schema.json")
-	require.NoError(t, err)
-
-	var doc map[string]any
-	require.NoError(t, json.Unmarshal(raw, &doc))
-
-	schema := requireMapField(t, doc, "jsonSchema")
-	assert.NotContains(t, schema, "allOf")
-
-	uiSchema := requireMapField(t, doc, "uiSchema")
-	discovery := requireMapField(t, uiSchema, "discovery")
-	modeQuery := requireMapField(t, discovery, "mode_query")
-	kql := requireMapField(t, modeQuery, "kql")
-	help, ok := kql["ui:help"].(string)
-	require.True(t, ok)
-	assert.Contains(t, help, "project `tags`")
-
-	uiProfiles := requireMapField(t, uiSchema, "profiles")
-	for _, mode := range []string{"mode_auto", "mode_exact", "mode_combined"} {
-		modeUI := requireMapField(t, uiProfiles, mode)
-		entries := requireMapField(t, modeUI, "entries")
-		items := requireMapField(t, entries, "items")
-		filters := requireMapField(t, items, "filters")
-		tags := requireMapField(t, filters, "tags")
-		help, ok := tags["ui:help"].(string)
-		require.True(t, ok)
-		assert.Contains(t, help, "Only supported when `discovery.mode` is `filters`")
-	}
+func TestConfigSchema_MatchesMetadataGroups(t *testing.T) {
+	collecttest.AssertConfigSchemaMatchesMetadata(t, "config_schema.json", "metadata.yaml")
 }
 
 func TestAzureMonitorStaticArtifacts_WorkloadVirtualNodes(t *testing.T) {
@@ -388,43 +297,6 @@ func TestParseStrictQueryDiscoveryRow_OptionalTags(t *testing.T) {
 			assert.Equal(t, tc.wantTags, resource.Tags)
 		})
 	}
-}
-
-func requireMapField(t *testing.T, m map[string]any, key string) map[string]any {
-	t.Helper()
-
-	value, ok := m[key]
-	require.Truef(t, ok, "missing key %q", key)
-	out, ok := value.(map[string]any)
-	require.Truef(t, ok, "key %q is not an object", key)
-	return out
-}
-
-func requireStringSliceField(t *testing.T, m map[string]any, key string) []string {
-	t.Helper()
-
-	value, ok := m[key]
-	require.Truef(t, ok, "missing key %q", key)
-	items, ok := value.([]any)
-	require.Truef(t, ok, "key %q is not an array", key)
-
-	out := make([]string, 0, len(items))
-	for _, item := range items {
-		s, ok := item.(string)
-		require.Truef(t, ok, "key %q contains a non-string item", key)
-		out = append(out, s)
-	}
-	return out
-}
-
-func requireArrayField(t *testing.T, m map[string]any, key string) []any {
-	t.Helper()
-
-	value, ok := m[key]
-	require.Truef(t, ok, "missing key %q", key)
-	items, ok := value.([]any)
-	require.Truef(t, ok, "key %q is not an array", key)
-	return items
 }
 
 func TestCollector_ConfigurationSerialize(t *testing.T) {

--- a/src/go/plugin/go.d/collector/azure_monitor/config_schema.json
+++ b/src/go/plugin/go.d/collector/azure_monitor/config_schema.json
@@ -731,7 +731,7 @@
     "ui:options": {
       "tabs": [
         {
-          "title": "Base",
+          "title": "Collection",
           "fields": [
             "subscription_ids",
             "cloud",
@@ -742,7 +742,7 @@
           ]
         },
         {
-          "title": "Auth",
+          "title": "Authentication",
           "fields": [
             "auth"
           ]

--- a/src/go/plugin/go.d/collector/cloudwatch/config_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_test.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/awsauth"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 func validBaseConfig() Config {
@@ -101,64 +101,8 @@ func TestConfig_applyDefaults(t *testing.T) {
 	assert.Equal(t, defaultTimeout, cfg.Timeout)
 }
 
-// TestConfigSchema_TabsMatchMetadataGroups is a drift check between the two artifacts an operator
-// reads together: the DynCfg form's tab titles and the Group column of the generated integration doc
-// (metadata.yaml). A tab naming no group, or a group naming no tab, is exactly what leaves someone
-// unable to find in the UI the option they just read about. Tabs can only group whole top-level
-// properties, so a doc group that refines one uses the "Tab / Subgroup" form and matches on its first
-// segment. Neither artifact is asserted against itself — each is the other's expected value.
-func TestConfigSchema_TabsMatchMetadataGroups(t *testing.T) {
-	schemaData, err := os.ReadFile("config_schema.json")
-	require.NoError(t, err)
-	var schema struct {
-		UISchema struct {
-			Options struct {
-				Tabs []struct {
-					Title string `json:"title"`
-				} `json:"tabs"`
-			} `json:"ui:options"`
-		} `json:"uiSchema"`
-	}
-	require.NoError(t, json.Unmarshal(schemaData, &schema))
-	require.NotEmpty(t, schema.UISchema.Options.Tabs)
-
-	metaData, err := os.ReadFile("metadata.yaml")
-	require.NoError(t, err)
-	var meta struct {
-		Modules []struct {
-			Setup struct {
-				Configuration struct {
-					Options struct {
-						List []struct {
-							Name  string `yaml:"name"`
-							Group string `yaml:"group"`
-						} `yaml:"list"`
-					} `yaml:"options"`
-				} `yaml:"configuration"`
-			} `yaml:"setup"`
-		} `yaml:"modules"`
-	}
-	require.NoError(t, yaml.Unmarshal(metaData, &meta))
-	require.Len(t, meta.Modules, 1)
-	options := meta.Modules[0].Setup.Configuration.Options.List
-	require.NotEmpty(t, options)
-
-	tabs := make(map[string]bool, len(schema.UISchema.Options.Tabs))
-	for _, tab := range schema.UISchema.Options.Tabs {
-		tabs[tab.Title] = false
-	}
-
-	for _, option := range options {
-		require.NotEmptyf(t, option.Group, "metadata option %q has no group", option.Name)
-		tab, _, _ := strings.Cut(option.Group, " / ")
-		if _, ok := tabs[tab]; !assert.Truef(t, ok, "metadata option %q is in group %q, which names no schema tab", option.Name, option.Group) {
-			continue
-		}
-		tabs[tab] = true
-	}
-	for tab, used := range tabs {
-		assert.Truef(t, used, "schema tab %q names no metadata group, so the doc cannot point an operator at it", tab)
-	}
+func TestConfigSchema_MatchesMetadataGroups(t *testing.T) {
+	collecttest.AssertConfigSchemaMatchesMetadata(t, "config_schema.json", "metadata.yaml")
 }
 
 func TestConfig_validateResourceTagConfiguration(t *testing.T) {

--- a/src/go/plugin/go.d/collector/config_schema_test.go
+++ b/src/go/plugin/go.d/collector/config_schema_test.go
@@ -84,6 +84,83 @@ func TestConfigSchemasDoNotMaterializeOptionalArrays(t *testing.T) {
 	}
 }
 
+// TestConfigSchemasDoNotDeclareBranchKeysAsProperties forbids the second way a schema can make the
+// DynCfg form show something the operator did not ask for.
+//
+// A `dependencies` entry reveals extra fields only for the selected value of its discriminator --
+// `discovery.mode: filters` reveals `mode_filters`, and so on. Declaring one of those revealed keys
+// as a plain sibling property as well makes the form render it unconditionally, for every mode, and
+// the runtime then has to decide what a field belonging to an unselected branch means.
+func TestConfigSchemasDoNotDeclareBranchKeysAsProperties(t *testing.T) {
+	files, err := filepath.Glob("*/config_schema.json")
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		require.NoError(t, err, file)
+		var doc struct {
+			JSONSchema map[string]any `json:"jsonSchema"`
+		}
+		require.NoError(t, json.Unmarshal(data, &doc), file)
+
+		var walk func(node any, path string)
+		walk = func(node any, path string) {
+			obj, ok := node.(map[string]any)
+			if !ok {
+				return
+			}
+			properties, _ := obj["properties"].(map[string]any)
+			for discriminator, raw := range mapField(obj["dependencies"]) {
+				for _, branch := range schemaBranches(raw) {
+					for key := range mapField(branch["properties"]) {
+						if key == discriminator {
+							continue // the discriminator itself is a real property
+						}
+						assert.NotContainsf(t, properties, key,
+							"%s: %s declares %q both as a %q-dependent branch field and as a plain property; the form would always show it",
+							file, path, key, discriminator)
+					}
+				}
+			}
+			for key, child := range properties {
+				walk(child, path+"."+key)
+			}
+			walk(obj["items"], path+"[]")
+		}
+		walk(doc.JSONSchema, "")
+	}
+}
+
+// mapField returns node as an object, or nil when it is absent or another type.
+func mapField(node any) map[string]any {
+	obj, _ := node.(map[string]any)
+	return obj
+}
+
+// schemaBranches returns a dependency's oneOf/anyOf alternatives, or the dependency itself when it
+// applies unconditionally.
+func schemaBranches(node any) []map[string]any {
+	obj := mapField(node)
+	if obj == nil {
+		return nil
+	}
+	for _, keyword := range []string{"oneOf", "anyOf"} {
+		raw, ok := obj[keyword].([]any)
+		if !ok {
+			continue
+		}
+		branches := make([]map[string]any, 0, len(raw))
+		for _, branch := range raw {
+			if b := mapField(branch); b != nil {
+				branches = append(branches, b)
+			}
+		}
+		return branches
+	}
+	return []map[string]any{obj}
+}
+
 func schemaAllowsArray(schemaType any) bool {
 	switch value := schemaType.(type) {
 	case string:

--- a/src/go/plugin/go.d/pkg/collecttest/configschema.go
+++ b/src/go/plugin/go.d/pkg/collecttest/configschema.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package collecttest
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// AssertConfigSchemaMatchesMetadata checks that the DynCfg form and the generated integration doc
+// group a collector's options the same way, so an operator who reads about an option in the doc can
+// find where to set it in the UI.
+//
+// metadata.yaml `group` becomes the doc's Group column, and config_schema.json
+// `uiSchema.ui:options.tabs[].title` becomes the UI tab. For every documented option, the tab
+// listing that option's root property must be the first segment of its group, and every tab must be
+// named by at least one group. Tabs can only list whole top-level properties, so a group that
+// refines a nested concern takes the "Tab / Subgroup" form and matches on its first segment.
+//
+// Neither artifact is asserted against itself: each supplies the other's expected value.
+//
+// This is opt-in per collector because most collectors still group the two artifacts independently.
+// Call it from a collector whose artifacts agree, to keep them that way.
+func AssertConfigSchemaMatchesMetadata(t testing.TB, schemaPath, metadataPath string) {
+	t.Helper()
+
+	tabOfProperty, tabs := readSchemaTabs(t, schemaPath)
+	options := readMetadataOptionGroups(t, metadataPath)
+
+	for _, option := range options {
+		root := rootProperty(option.Name)
+		tab, ok := tabOfProperty[root]
+		if !assert.Truef(t, ok, "%s: option %q has group %q, but no tab lists its %q property",
+			metadataPath, option.Name, option.Group, root) {
+			continue
+		}
+		group, _, _ := strings.Cut(option.Group, " / ")
+		assert.Equalf(t, tab, group, "%s: option %q is in group %q, but %q is on the %q tab",
+			metadataPath, option.Name, option.Group, root, tab)
+		tabs[tab] = true
+	}
+
+	for tab, named := range tabs {
+		assert.Truef(t, named, "%s: tab %q is named by no option group, so the doc cannot point at it",
+			schemaPath, tab)
+	}
+}
+
+// readSchemaTabs returns the tab title owning each top-level property, plus a per-tab "was named by
+// a group" ledger for the caller to fill in.
+func readSchemaTabs(t testing.TB, schemaPath string) (map[string]string, map[string]bool) {
+	t.Helper()
+
+	data, err := os.ReadFile(schemaPath)
+	require.NoError(t, err)
+	var doc struct {
+		UISchema struct {
+			Options struct {
+				Tabs []struct {
+					Title  string   `json:"title"`
+					Fields []string `json:"fields"`
+				} `json:"tabs"`
+			} `json:"ui:options"`
+		} `json:"uiSchema"`
+	}
+	require.NoError(t, json.Unmarshal(data, &doc))
+	require.NotEmptyf(t, doc.UISchema.Options.Tabs, "%s declares no uiSchema tabs", schemaPath)
+
+	tabOfProperty := make(map[string]string)
+	tabs := make(map[string]bool, len(doc.UISchema.Options.Tabs))
+	for _, tab := range doc.UISchema.Options.Tabs {
+		require.NotEmptyf(t, tab.Title, "%s has a tab with no title", schemaPath)
+		tabs[tab.Title] = false
+		for _, field := range tab.Fields {
+			require.NotContainsf(t, tabOfProperty, field, "%s lists property %q on more than one tab", schemaPath, field)
+			tabOfProperty[field] = tab.Title
+		}
+	}
+	return tabOfProperty, tabs
+}
+
+type metadataOption struct {
+	Name  string `yaml:"name"`
+	Group string `yaml:"group"`
+}
+
+func readMetadataOptionGroups(t testing.TB, metadataPath string) []metadataOption {
+	t.Helper()
+
+	data, err := os.ReadFile(metadataPath)
+	require.NoError(t, err)
+	var doc struct {
+		Modules []struct {
+			Setup struct {
+				Configuration struct {
+					Options struct {
+						List []metadataOption `yaml:"list"`
+					} `yaml:"options"`
+				} `yaml:"configuration"`
+			} `yaml:"setup"`
+		} `yaml:"modules"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &doc))
+	require.NotEmptyf(t, doc.Modules, "%s describes no modules", metadataPath)
+
+	// A collector with several documented integrations repeats the option list per module, and they
+	// all share the one config_schema.json, so every module's groups must map to the same tabs.
+	var options []metadataOption
+	for _, module := range doc.Modules {
+		options = append(options, module.Setup.Configuration.Options.List...)
+	}
+	require.NotEmptyf(t, options, "%s documents no config options", metadataPath)
+	for _, option := range options {
+		require.NotEmptyf(t, option.Group, "%s: option %q has no group", metadataPath, option.Name)
+	}
+	return options
+}
+
+// rootProperty reduces a documented option name to the top-level property a tab can list:
+// "rules[].query.period" and "limits.max_instances" become "rules" and "limits".
+func rootProperty(option string) string {
+	if i := strings.IndexAny(option, ".["); i >= 0 {
+		return option[:i]
+	}
+	return option
+}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces brittle schema-restatement tests with behavior checks and a shared helper to keep DynCfg tabs aligned with `metadata.yaml`. Also enforces a repo-wide rule that dependency-branch keys cannot be declared as top-level properties, and renames Azure Monitor tabs to match the docs.

- **Refactors**
  - Added `collecttest.AssertConfigSchemaMatchesMetadata` and adopted it in `azure_monitor` and `cloudwatch`.
  - Added repo-wide `TestConfigSchemasDoNotDeclareBranchKeysAsProperties` to prevent declaring dependency-branch keys as plain `properties`.
  - Removed Azure Monitor tests that restated `config_schema.json`; replaced with the metadata/tabs assertion.
  - Renamed Azure Monitor tabs: "Base" → "Collection", "Auth" → "Authentication".
  - Updated internal guidelines to document the new checks and how to keep schema and docs in sync.

<sup>Written for commit e69dbfdfc84b3b5b4bd04f805dea536a6b8ba0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

