### PR TITLE
test(go.d/jobmgr): stabilize task start failure parking

### DIFF
--- a/src/go/plugin/agent/jobmgr/lifecycle/task_transaction_test.go
+++ b/src/go/plugin/agent/jobmgr/lifecycle/task_transaction_test.go
@@ -5,6 +5,7 @@ package lifecycle
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -342,6 +343,12 @@ func TestTaskSupervisorPreservesAppliedOwnershipAlongsideError(t *testing.T) {
 
 func TestTaskSupervisorParksStartFailureOutsideRunnableQueue(t *testing.T) {
 	supervisor := newResourceTaskSupervisor(t)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWork := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	t.Cleanup(releaseWork)
 	owner := ResourceIdentity{ID: "job", Generation: 1}
 	scope := ResourceTransactionScope{ID: owner.ID, Successor: owner}
 	plan, err := NewResourceTransactionPermitTaskPlan(
@@ -357,6 +364,7 @@ func TestTaskSupervisorParksStartFailureOutsideRunnableQueue(t *testing.T) {
 			ResourceTransactionScope,
 			LongLivedPermit,
 		) (PreparedResourceTransaction, error) {
+			<-release
 			return nil, nil
 		},
 	)
@@ -368,7 +376,7 @@ func TestTaskSupervisorParksStartFailureOutsideRunnableQueue(t *testing.T) {
 
 	var started [TaskStartServiceQuantum]TaskStart
 	count, more, err := supervisor.Dispatch(context.Background(), 2, &started)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate owner")
 	require.Equal(t, 1, count)
 	require.False(t, more)
 	require.Zero(t, supervisor.Pending())
@@ -378,6 +386,7 @@ func TestTaskSupervisorParksStartFailureOutsideRunnableQueue(t *testing.T) {
 	_, err = supervisor.CancelPendingOutcome(first)
 	require.Error(t, err)
 
+	releaseWork()
 	completion := <-supervisor.CompletionCh()
 	require.NoError(t, supervisor.SendAction(TaskAction{
 		Ref:      completion.Ref,


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the task start failure parking test in `jobmgr` to remove flakiness by synchronizing preparation and tightening the error assertion.

- **Bug Fixes**
  - Added a release channel with `sync.Once` to gate `Prepare` and avoid races during `Dispatch`.
  - Replaced `require.Error` with `require.ErrorContains(..., "duplicate owner")` for precise, deterministic checks.
  - Released work before reading `CompletionCh()` to prevent goroutine leaks and timing issues.

<sup>Written for commit fb88e4100690e76ddd5945d87c2c9e44c928a340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

