### PR TITLE
test(go.d): align chart coverage with fresh series

### DIFF
--- a/src/go/plugin/go.d/pkg/collecttest/chart_coverage.go
+++ b/src/go/plugin/go.d/pkg/collecttest/chart_coverage.go
@@ -307,9 +307,14 @@ func collectExpectedDimensionNames(
 	nameFromLabel := strings.TrimSpace(dim.NameFromLabel)
 	names := make(map[string]struct{})
 	matched := false
+	lastSuccessSeq := reader.CollectMeta().LastSuccessSeq
 
 	reader.ForEachSeriesIdentity(func(_ metrix.SeriesIdentity, meta metrix.SeriesMeta, metricName string, labels metrix.LabelView, _ metrix.SampleValue) {
 		if err != nil {
+			return
+		}
+		// Keep expected coverage aligned with chartengine's default series selection.
+		if meta.LastSeenSuccessSeq != lastSuccessSeq {
 			return
 		}
 		if !sel.Matches(metricName, labels) {

--- a/src/go/plugin/go.d/pkg/collecttest/collecttest_test.go
+++ b/src/go/plugin/go.d/pkg/collecttest/collecttest_test.go
@@ -348,6 +348,49 @@ groups:
 	}
 }
 
+func TestBuildChartCoverage_ExcludesRetainedSeriesNotSeenInLatestSuccess(t *testing.T) {
+	store := metrix.NewCollectorStore()
+	managed, ok := metrix.AsCycleManagedStore(store)
+	require.True(t, ok)
+
+	cc := managed.CycleController()
+	cc.BeginCycle()
+	meter := store.Write().SnapshotMeter("")
+	meter.Gauge("metric_current").Observe(1)
+	meter.Gauge("metric_stale").Observe(2)
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	cc.BeginCycle()
+	meter.Gauge("metric_current").Observe(3)
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	templateYAML := `
+version: v1
+context_namespace: test
+groups:
+  - family: Root
+    metrics: [metric_current, metric_stale]
+    charts:
+      - title: Current
+        context: current
+        units: "1"
+        dimensions:
+          - selector: metric_current
+            name: current
+      - title: Stale
+        context: stale
+        units: "1"
+        dimensions:
+          - selector: metric_stale
+            name: stale
+`
+
+	coverage, err := buildChartCoverage(templateYAML, 1, store.Read(metrix.ReadRaw()), nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{"test.current": {"current"}}, normalizeCoverageDimsList(coverage.ExpectedByContext))
+	require.Equal(t, map[string][]string{"test.current": {"current"}}, normalizeCoverageDims(coverage.ActualByContext))
+}
+
 func TestCollectScalarSeries(t *testing.T) {
 	tests := map[string]struct {
 		collectFn func(ctx context.Context, store metrix.CollectorStore) error


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align `collecttest` chart coverage with the latest successful cycle so tests only expect fresh series. Prevents stale retained series from appearing in expected/actual coverage.

- **Bug Fixes**
  - Filter series to only those with `LastSeenSuccessSeq` equal to the reader’s `LastSuccessSeq` when building coverage.
  - Add `TestBuildChartCoverage_ExcludesRetainedSeriesNotSeenInLatestSuccess` to ensure stale series are excluded from both expected and actual coverage.

<sup>Written for commit 4a39c4ab0e0500f70c5d7967247606005d97c524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

