### PR TITLE
feat(go.d): add DynCfg operational test for local listeners

### DIFF
--- a/docs/netdata-ai/skills/query-netdata-cloud/query-dyncfg.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/query-dyncfg.md
@@ -246,8 +246,13 @@ curl -sS -X POST \
   -d "$PAYLOAD"
 ```
 
-A successful response (200/202) means the configuration would
-work; the test does NOT make the change persistent.
+A successful response means the resource accepted its supported test, not
+necessarily that the configuration will work in production. Inspect the
+response message: some resources provide only validation, while others run a
+resource-specific operational check. For service discovery, an empty successful
+message means every configured discoverer completed its operational test; an
+explicit validation-only message means no operational check was available. The
+test does NOT make the change persistent.
 
 ### Example 6: enable / disable a configuration
 

--- a/src/go/plugin/agent/discovery/sd/pipeline/pipeline.go
+++ b/src/go/plugin/agent/discovery/sd/pipeline/pipeline.go
@@ -91,8 +91,8 @@ func (p *Pipeline) Test(ctx context.Context) (bool, error) {
 	if p == nil || ctx == nil {
 		return false, errors.New("service discovery pipeline: invalid test")
 	}
-	if err := ctx.Err(); err != nil {
-		return false, err
+	if cause := context.Cause(ctx); cause != nil {
+		return false, cause
 	}
 	fullyTested := len(p.discoverers) != 0
 	for _, discoverer := range p.discoverers {
@@ -101,10 +101,15 @@ func (p *Pipeline) Test(ctx context.Context) (bool, error) {
 			fullyTested = false
 			continue
 		}
-		if err := ctx.Err(); err != nil {
-			return false, err
+		if cause := context.Cause(ctx); cause != nil {
+			return false, cause
 		}
-		if err := testable.Test(ctx); err != nil {
+		err := testable.Test(ctx)
+		// Caller cancellation wins even when it races a resource failure.
+		if cause := context.Cause(ctx); cause != nil {
+			return false, cause
+		}
+		if err != nil {
 			return false, fmt.Errorf("discoverer operational test: %w", err)
 		}
 	}

--- a/src/go/plugin/agent/discovery/sd/pipeline/pipeline_test.go
+++ b/src/go/plugin/agent/discovery/sd/pipeline/pipeline_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 
 	"github.com/gohugoio/hashstructure"
 	"github.com/stretchr/testify/assert"
@@ -127,8 +128,9 @@ func TestPipeline_Test(t *testing.T) {
 	})
 
 	t.Run("honors caller cancellation before testing", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
+		cancelCause := errors.New("test request superseded")
+		ctx, cancel := context.WithCancelCause(t.Context())
+		cancel(cancelCause)
 		var calls []string
 		p := &Pipeline{discoverers: []model.Discoverer{
 			&pipelineTestDiscoverer{name: "first", calls: &calls},
@@ -137,8 +139,37 @@ func TestPipeline_Test(t *testing.T) {
 		fullyTested, err := p.Test(ctx)
 
 		require.False(t, fullyTested)
-		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorIs(t, err, cancelCause)
 		require.Empty(t, calls)
+	})
+
+	t.Run("caller cancellation wins a resource operational failure", func(t *testing.T) {
+		cancelCause := errors.New("test request superseded")
+		resourceErr := dyncfg.NewPublicError(
+			"resource operation timed out",
+			context.DeadlineExceeded,
+		)
+		ctx, cancel := context.WithCancelCause(t.Context())
+		var calls []string
+		p := &Pipeline{discoverers: []model.Discoverer{
+			&pipelineTestDiscoverer{
+				name:  "first",
+				calls: &calls,
+				test: func(context.Context) error {
+					cancel(cancelCause)
+					return resourceErr
+				},
+			},
+		}}
+
+		fullyTested, err := p.Test(ctx)
+
+		require.False(t, fullyTested)
+		require.ErrorIs(t, err, cancelCause)
+		require.NotErrorIs(t, err, resourceErr)
+		_, hasPublicMessage := dyncfg.PublicMessage(err)
+		require.False(t, hasPublicMessage)
+		require.Equal(t, []string{"first"}, calls)
 	})
 }
 
@@ -355,13 +386,17 @@ type pipelineTestDiscoverer struct {
 	name  string
 	calls *[]string
 	err   error
+	test  func(context.Context) error
 }
 
 func (d *pipelineTestDiscoverer) Discover(context.Context, chan<- []model.TargetGroup) {
 }
 
-func (d *pipelineTestDiscoverer) Test(context.Context) error {
+func (d *pipelineTestDiscoverer) Test(ctx context.Context) error {
 	*d.calls = append(*d.calls, d.name)
+	if d.test != nil {
+		return d.test(ctx)
+	}
 	return d.err
 }
 

--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -688,9 +688,9 @@ fresh Store epoch, but the process owns that epoch's preparations, generations, 
    against the expected generation.
    - A DynCfg `test` creates the same temporary configured Store but never publishes it. If the Store implements
      `dyncfg.Testable`, its context-aware operational check runs inside the test's config-hash-specific contained
-     attempt. After the callback returns, the shared Store Test boundary makes the caller's cancellation cause take
-     precedence over any provider result. Providers classify their configured timeouts but need not repeat caller
-     cancellation checks.
+     attempt. The shared Store Test boundary rejects caller cancellation before temporary construction and makes its
+     cause take precedence after configuration/`Init` and after the optional provider Test callback. Providers classify
+     their configured timeouts but need not repeat caller cancellation checks.
    - A Store without that optional capability remains configuration-valid, and the response explicitly says that the
      result was validation-only. Configuration failures return 400, operational failures return 422, and
      busy/contained attempts return 503.

--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -899,6 +899,11 @@ manager accepts only an already-prepared pipeline through `StartPrepared`/`Resta
   configuration or endpoint material.
 - A discoverer without the capability produces an explicit validation-only success. Configuration/construction
   failures return 400, operational failures return 422, and busy/contained attempts return 503.
+- Operational guarantees are discoverer-specific. Docker performs a one-item container-list query. `net_listeners`
+  executes and parses one production helper snapshot, then discards the targets without rule rendering, cache
+  reconciliation, publication, or installation. Its process count and elapsed time are bounded to one invocation and the
+  caller/configured timeout; work and buffered output still scale with the host socket/process inventory. Other shipped
+  discoverers currently remain validation-only.
 - File-backed stock/user state keeps one latest pending retry after a busy/contained result; synchronous DynCfg
   commands do not.
 - The complete service-discovery DynCfg Function is also contained, so a non-cooperative command cannot pin the

--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -688,7 +688,9 @@ fresh Store epoch, but the process owns that epoch's preparations, generations, 
    against the expected generation.
    - A DynCfg `test` creates the same temporary configured Store but never publishes it. If the Store implements
      `dyncfg.Testable`, its context-aware operational check runs inside the test's config-hash-specific contained
-     attempt.
+     attempt. After the callback returns, the shared Store Test boundary makes the caller's cancellation cause take
+     precedence over any provider result. Providers classify their configured timeouts but need not repeat caller
+     cancellation checks.
    - A Store without that optional capability remains configuration-valid, and the response explicitly says that the
      result was validation-only. Configuration failures return 400, operational failures return 422, and
      busy/contained attempts return 503.
@@ -891,7 +893,9 @@ manager accepts only an already-prepared pipeline through `StartPrepared`/`Resta
   beyond its logical containment deadline.
 - DynCfg `test` builds a complete temporary pipeline under a payload-specific test identity and never submits it to the
   pipeline manager. It invokes `dyncfg.Testable.Test(ctx)` sequentially on every discoverer that provides the optional
-  capability.
+  capability. After each callback returns, the shared Pipeline Test boundary makes the caller's cancellation cause take
+  precedence over the discoverer result. Discoverers classify their configured timeouts but need not repeat caller
+  cancellation checks.
 - Resource-authored parsing, construction, and operational failures retain their causes internally but cross one
   sanitized response/diagnostic boundary. Unmarked failures render only their generic phase. A `dyncfg.PublicError`
   may add static, code-authored detail; its public message must never derive from submitted/resolved values, endpoints,

--- a/src/go/plugin/agent/secrets/secretstore/mutation.go
+++ b/src/go/plugin/agent/secrets/secretstore/mutation.go
@@ -159,8 +159,14 @@ func (store *SecretStore) Test(
 	if store == nil || ctx == nil || catalog == nil {
 		return false, errors.New("secretstore: invalid test")
 	}
+	if cause := context.Cause(ctx); cause != nil {
+		return false, cause
+	}
 	// Atomic resolution rejects cancellation before Store construction or Init.
 	configured, err := configureStore(ctx, store.resolver, cfg, catalog.New)
+	if cause := context.Cause(ctx); cause != nil {
+		return false, cause
+	}
 	if err != nil {
 		return false, err
 	}
@@ -174,7 +180,12 @@ func (store *SecretStore) Test(
 	if !ok {
 		return false, nil
 	}
-	if err := testable.Test(ctx); err != nil {
+	err = testable.Test(ctx)
+	// Caller cancellation wins even when it races a provider failure.
+	if cause := context.Cause(ctx); cause != nil {
+		return true, cause
+	}
+	if err != nil {
 		return true, err
 	}
 	return true, nil

--- a/src/go/plugin/agent/secrets/secretstore/mutation.go
+++ b/src/go/plugin/agent/secrets/secretstore/mutation.go
@@ -162,8 +162,8 @@ func (store *SecretStore) Test(
 	if cause := context.Cause(ctx); cause != nil {
 		return false, cause
 	}
-	// Atomic resolution rejects cancellation before Store construction or Init.
 	configured, err := configureStore(ctx, store.resolver, cfg, catalog.New)
+	// Configuration and Init may reduce a custom cause to a standard context error.
 	if cause := context.Cause(ctx); cause != nil {
 		return false, cause
 	}

--- a/src/go/plugin/agent/secrets/secretstore/test_capability_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/test_capability_test.go
@@ -10,6 +10,7 @@ import (
 	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,19 +61,48 @@ func TestSecretStoreTestCapability(t *testing.T) {
 	})
 
 	t.Run("rejects an already-canceled request before Store creation", func(t *testing.T) {
+		cancelCause := errors.New("test request superseded")
 		var creates int
 		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
 			creates++
 			return &testValidationOnlyStore{}
 		})
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
+		ctx, cancel := context.WithCancelCause(t.Context())
+		cancel(cancelCause)
 
 		tested, err := store.Test(ctx, catalog, testCapabilityConfig())
 
 		require.False(t, tested)
-		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorIs(t, err, cancelCause)
 		require.Zero(t, creates)
+		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
+	})
+
+	t.Run("caller cancellation wins a provider operational failure", func(t *testing.T) {
+		cancelCause := errors.New("test request superseded")
+		providerErr := dyncfg.NewPublicError(
+			"provider operation timed out",
+			context.DeadlineExceeded,
+		)
+		ctx, cancel := context.WithCancelCause(t.Context())
+		state := &testCapabilityState{
+			test: func(context.Context) error {
+				cancel(cancelCause)
+				return providerErr
+			},
+		}
+		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
+			return &testCapableStore{state: state}
+		})
+
+		tested, err := store.Test(ctx, catalog, testCapabilityConfig())
+
+		require.True(t, tested)
+		require.ErrorIs(t, err, cancelCause)
+		require.NotErrorIs(t, err, providerErr)
+		_, hasPublicMessage := dyncfg.PublicMessage(err)
+		require.False(t, hasPublicMessage)
+		require.Equal(t, 1, state.calls)
 		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
 	})
 }
@@ -111,6 +141,7 @@ func testCapabilityConfig() secretstore.Config {
 type testCapabilityState struct {
 	calls int
 	err   error
+	test  func(context.Context) error
 	value string
 }
 
@@ -133,9 +164,12 @@ func (s *testCapableStore) Publish() secretstore.PublishedStore {
 	return testCapabilityPublished(s.config.Value)
 }
 
-func (s *testCapableStore) Test(context.Context) error {
+func (s *testCapableStore) Test(ctx context.Context) error {
 	s.state.calls++
 	s.state.value = s.config.Value
+	if s.state.test != nil {
+		return s.state.test(ctx)
+	}
 	return s.state.err
 }
 

--- a/src/go/plugin/agent/secrets/secretstore/test_capability_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/test_capability_test.go
@@ -78,6 +78,29 @@ func TestSecretStoreTestCapability(t *testing.T) {
 		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
 	})
 
+	t.Run("caller cancellation wins a Store initialization failure", func(t *testing.T) {
+		cancelCause := errors.New("test request superseded")
+		initErr := errors.New("provider initialization failed")
+		ctx, cancel := context.WithCancelCause(t.Context())
+		state := &testCapabilityState{
+			init: func(context.Context) error {
+				cancel(cancelCause)
+				return initErr
+			},
+		}
+		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
+			return &testCapableStore{state: state}
+		})
+
+		tested, err := store.Test(ctx, catalog, testCapabilityConfig())
+
+		require.False(t, tested)
+		require.ErrorIs(t, err, cancelCause)
+		require.NotErrorIs(t, err, initErr)
+		require.Zero(t, state.calls)
+		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
+	})
+
 	t.Run("caller cancellation wins a provider operational failure", func(t *testing.T) {
 		cancelCause := errors.New("test request superseded")
 		providerErr := dyncfg.NewPublicError(
@@ -141,6 +164,7 @@ func testCapabilityConfig() secretstore.Config {
 type testCapabilityState struct {
 	calls int
 	err   error
+	init  func(context.Context) error
 	test  func(context.Context) error
 	value string
 }
@@ -156,7 +180,10 @@ func (s *testCapableStore) Configuration() any {
 	return &s.config
 }
 
-func (s *testCapableStore) Init(context.Context) error {
+func (s *testCapableStore) Init(ctx context.Context) error {
+	if s.state.init != nil {
+		return s.state.init(ctx)
+	}
 	return nil
 }
 

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/dockersd/docker.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/dockersd/docker.go
@@ -111,8 +111,6 @@ func (d *Discoverer) Test(ctx context.Context) error {
 	if _, err := client.ContainerList(testCtx, docker.ContainerListOptions{Limit: 1}); err != nil {
 		cause := fmt.Errorf("list docker containers: %w", err)
 		switch {
-		case ctx.Err() != nil:
-			return cause
 		case errors.Is(testCtx.Err(), context.DeadlineExceeded):
 			return dyncfg.NewPublicError(
 				"the configured Docker endpoint did not respond before the timeout",

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/integrations/net_listeners.md
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/integrations/net_listeners.md
@@ -29,7 +29,7 @@ This page covers `net_listeners`-specific setup. For the broader Service Discove
 
 Each discovery cycle, the discoverer:
 
-1. **Reads the kernel's TCP/UDP listening-socket table** via the bundled `local-listeners` helper (which reads `/proc` on Linux, `netstat`-equivalents elsewhere).
+1. **Reads the kernel's TCP/UDP listening-socket table** via the bundled `local-listeners` helper, which reads Linux procfs socket and process data.
 2. **Builds one target per `(protocol, IP, port, process)` tuple**, exposing `.Protocol`, `.IPAddress`, `.Port`, `.Comm` (process basename), `.Cmdline` (full command line), and `.Address` (the convenience `IPAddress:Port`).
 3. **Caches** each target for 10 minutes so a brief disappearance (process restart) does not churn collector jobs.
 4. **Runs the `services:` rules** against each target. The stock conf carries ~100 curated rules covering the bulk of go.d modules (databases, web servers, caches, message queues, exporters).
@@ -40,6 +40,7 @@ Each discovery cycle, the discoverer:
 
 - Only **local** listeners are visible. Discovering services on other hosts requires another discoverer (`http`, `snmp`, `k8s`, or a custom one).
 - The discoverer needs to **read kernel socket information**. On Linux this works for processes owned by other users only when Netdata can read the appropriate `/proc/<pid>/net` files; the Netdata installer configures this via the `local-listeners` setuid helper.
+- The bundled `local-listeners` helper is currently built for Linux. A missing or non-executable helper makes both normal discovery and the DynCfg operational test fail.
 - **Containerised services in `host` networking** appear as listeners and are picked up here, not by the Docker discoverer. Services in private container networks must be discovered by the Docker discoverer instead.
 - The discoverer does not introspect process runtime — anything beyond port/`comm`/`cmdline` (e.g. config-file path, version, runtime URL prefix) must be inferred via service rules or known by convention.
 
@@ -239,6 +240,13 @@ The last rule in the stock conf catches generic Prometheus exporters by port. `p
 
 After enabling the discoverer, confirm it is finding listeners and producing jobs.
 
+### Test a candidate configuration without applying it
+
+A DynCfg `test` runs the same installed `nd-run` and `local-listeners` path once, with the production flags and configured `timeout`, then parses the complete snapshot and discards it. Success proves that this one helper invocation and parse worked on the local host at that instant.
+
+The test does not start discovery, cache or publish targets, evaluate `services:` rules, create collector jobs, or prove that a generated job can connect to its service. It requires no permissions beyond normal local-listener discovery. Work and buffered output scale with the host's socket/process inventory; caller cancellation and `timeout` bound elapsed time, not the number of inspected entries.
+
+
 ### Confirm listeners are being scanned
 
 Watch the agent log for `discoverer=net_listeners` messages. With systemd:
@@ -287,4 +295,4 @@ The stock `exporter` catch-all rule (last in the file) is greedy by design — a
 
 ### Generated jobs fail to start
 
-The discoverer creates jobs but does not run them. Common causes: the rendered template assumes credentials the local service rejects (e.g. RabbitMQ default `guest:guest`); `0.0.0.0` listeners produce `0.0.0.0:port` addresses that the collector cannot connect to (use `127.0.0.1` in the template if appropriate); the service has TLS but the template uses HTTP.
+The discoverer creates jobs but does not run them. Common causes: the rendered template assumes credentials the local service rejects (e.g. RabbitMQ default `guest:guest`); a rule renders the wrong port or protocol; or the service has TLS but the template uses HTTP.

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/ll.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/ll.go
@@ -47,5 +47,13 @@ func (e *localListenersExec) discover(ctx context.Context) ([]byte, error) {
 		"no-namespaces",
 	}
 
-	return ndexec.RunUnprivileged(nil, e.timeout, e.binPath, args...)
+	out, _, _, err := ndexec.RunUnprivilegedWithOptionsUsageContext(
+		ctx,
+		nil,
+		e.timeout,
+		ndexec.RunOptions{},
+		e.binPath,
+		args...,
+	)
+	return out, err
 }

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/metadata.yaml
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/metadata.yaml
@@ -21,7 +21,7 @@ overview:
   how_it_works: |
     Each discovery cycle, the discoverer:
 
-    1. **Reads the kernel's TCP/UDP listening-socket table** via the bundled `local-listeners` helper (which reads `/proc` on Linux, `netstat`-equivalents elsewhere).
+    1. **Reads the kernel's TCP/UDP listening-socket table** via the bundled `local-listeners` helper, which reads Linux procfs socket and process data.
     2. **Builds one target per `(protocol, IP, port, process)` tuple**, exposing `.Protocol`, `.IPAddress`, `.Port`, `.Comm` (process basename), `.Cmdline` (full command line), and `.Address` (the convenience `IPAddress:Port`).
     3. **Caches** each target for 10 minutes so a brief disappearance (process restart) does not churn collector jobs.
     4. **Runs the `services:` rules** against each target. The stock conf carries ~100 curated rules covering the bulk of go.d modules (databases, web servers, caches, message queues, exporters).
@@ -29,6 +29,7 @@ overview:
   limitations: |
     - Only **local** listeners are visible. Discovering services on other hosts requires another discoverer (`http`, `snmp`, `k8s`, or a custom one).
     - The discoverer needs to **read kernel socket information**. On Linux this works for processes owned by other users only when Netdata can read the appropriate `/proc/<pid>/net` files; the Netdata installer configures this via the `local-listeners` setuid helper.
+    - The bundled `local-listeners` helper is currently built for Linux. A missing or non-executable helper makes both normal discovery and the DynCfg operational test fail.
     - **Containerised services in `host` networking** appear as listeners and are picked up here, not by the Docker discoverer. Services in private container networks must be discovered by the Docker discoverer instead.
     - The discoverer does not introspect process runtime — anything beyond port/`comm`/`cmdline` (e.g. config-file path, version, runtime URL prefix) must be inferred via service rules or known by convention.
 setup:
@@ -182,6 +183,11 @@ verify:
   description: 'After enabling the discoverer, confirm it is finding listeners and producing jobs.'
   checks:
     list:
+      - name: 'Test a candidate configuration without applying it'
+        description: |
+          A DynCfg `test` runs the same installed `nd-run` and `local-listeners` path once, with the production flags and configured `timeout`, then parses the complete snapshot and discards it. Success proves that this one helper invocation and parse worked on the local host at that instant.
+
+          The test does not start discovery, cache or publish targets, evaluate `services:` rules, create collector jobs, or prove that a generated job can connect to its service. It requires no permissions beyond normal local-listener discovery. Work and buffered output scale with the host's socket/process inventory; caller cancellation and `timeout` bound elapsed time, not the number of inspected entries.
       - name: 'Confirm listeners are being scanned'
         description: |
           Watch the agent log for `discoverer=net_listeners` messages. With systemd:
@@ -219,4 +225,4 @@ troubleshooting:
           The stock `exporter` catch-all rule (last in the file) is greedy by design — anything on a known Prometheus port gets the `prometheus` module. Add a more specific rule above it if you want a different module to win.
       - name: 'Generated jobs fail to start'
         description: |
-          The discoverer creates jobs but does not run them. Common causes: the rendered template assumes credentials the local service rejects (e.g. RabbitMQ default `guest:guest`); `0.0.0.0` listeners produce `0.0.0.0:port` addresses that the collector cannot connect to (use `127.0.0.1` in the template if appropriate); the service has TLS but the template uses HTTP.
+          The discoverer creates jobs but does not run them. Common causes: the rendered template assumes credentials the local service rejects (e.g. RabbitMQ default `guest:guest`); a rule renders the wrong port or protocol; or the service has TLS but the template uses HTTP.

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/netlisteners.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/netlisteners.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	shortName                   = "net_listeners"
-	fullName                    = fmt.Sprintf("sd:%s", shortName)
-	errInvalidLocalListenerData = errors.New("invalid local listener data")
+	shortName                          = "net_listeners"
+	fullName                           = fmt.Sprintf("sd:%s", shortName)
+	errInvalidLocalListenerData        = errors.New("invalid local listener data")
+	errLocalListenerInspectionCanceled = errors.New("local listener inspection canceled")
 )
 
 type Config struct {
@@ -98,17 +99,12 @@ func (d *Discoverer) Test(ctx context.Context) error {
 
 	_, err := d.inspectLocalListeners(ctx)
 	if err == nil {
-		if cause := callerCancellationCause(ctx); cause != nil {
-			return fmt.Errorf("inspect local network listeners: %w", cause)
-		}
 		return nil
 	}
 
-	if cause := callerCancellationCause(ctx); cause != nil {
-		return fmt.Errorf("inspect local network listeners: %w", cause)
-	}
-
 	switch {
+	case errors.Is(err, errLocalListenerInspectionCanceled):
+		return err
 	case errors.Is(err, context.DeadlineExceeded):
 		return dyncfg.NewPublicError("local listener inspection did not complete before the timeout", err)
 	case errors.Is(err, errInvalidLocalListenerData):
@@ -153,7 +149,7 @@ func (d *Discoverer) Discover(ctx context.Context, in chan<- []model.TargetGroup
 func (d *Discoverer) discoverLocalListeners(ctx context.Context, in chan<- []model.TargetGroup) error {
 	tgts, err := d.inspectLocalListeners(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
+		if errors.Is(err, errLocalListenerInspectionCanceled) {
 			return nil
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -166,9 +162,6 @@ func (d *Discoverer) discoverLocalListeners(ctx context.Context, in chan<- []mod
 			return nil
 		}
 		return err
-	}
-	if ctx.Err() != nil {
-		return nil
 	}
 
 	d.successRuns++
@@ -184,19 +177,12 @@ func (d *Discoverer) discoverLocalListeners(ctx context.Context, in chan<- []mod
 }
 
 func (d *Discoverer) inspectLocalListeners(ctx context.Context) ([]model.Target, error) {
-	if cause := callerCancellationCause(ctx); cause != nil {
-		return nil, fmt.Errorf("inspect local network listeners: %w", cause)
-	}
-
 	bs, err := d.ll.discover(ctx)
 	if err != nil {
 		if cause := callerCancellationCause(ctx); cause != nil {
-			return nil, fmt.Errorf("inspect local network listeners: %w", cause)
+			return nil, fmt.Errorf("%w: %w", errLocalListenerInspectionCanceled, cause)
 		}
 		return nil, fmt.Errorf("execute local listener inspection: %w", err)
-	}
-	if cause := callerCancellationCause(ctx); cause != nil {
-		return nil, fmt.Errorf("inspect local network listeners: %w", cause)
 	}
 
 	tgts, err := d.parseLocalListeners(bs)
@@ -204,7 +190,7 @@ func (d *Discoverer) inspectLocalListeners(ctx context.Context) ([]model.Target,
 		return nil, fmt.Errorf("%w: %w", errInvalidLocalListenerData, err)
 	}
 	if cause := callerCancellationCause(ctx); cause != nil {
-		return nil, fmt.Errorf("inspect local network listeners: %w", cause)
+		return nil, fmt.Errorf("%w: %w", errLocalListenerInspectionCanceled, cause)
 	}
 	return tgts, nil
 }

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/netlisteners.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/netlisteners.go
@@ -19,11 +19,13 @@ import (
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 )
 
 var (
-	shortName = "net_listeners"
-	fullName  = fmt.Sprintf("sd:%s", shortName)
+	shortName                   = "net_listeners"
+	fullName                    = fmt.Sprintf("sd:%s", shortName)
+	errInvalidLocalListenerData = errors.New("invalid local listener data")
 )
 
 type Config struct {
@@ -89,6 +91,33 @@ func (d *Discoverer) String() string {
 	return fullName
 }
 
+func (d *Discoverer) Test(ctx context.Context) error {
+	if d == nil || ctx == nil {
+		return errors.New("invalid local listener discovery test")
+	}
+
+	_, err := d.inspectLocalListeners(ctx)
+	if err == nil {
+		if cause := callerCancellationCause(ctx); cause != nil {
+			return fmt.Errorf("inspect local network listeners: %w", cause)
+		}
+		return nil
+	}
+
+	if cause := callerCancellationCause(ctx); cause != nil {
+		return fmt.Errorf("inspect local network listeners: %w", cause)
+	}
+
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return dyncfg.NewPublicError("local listener inspection did not complete before the timeout", err)
+	case errors.Is(err, errInvalidLocalListenerData):
+		return dyncfg.NewPublicError("local listener inspection returned invalid data", err)
+	default:
+		return dyncfg.NewPublicError("cannot inspect local network listeners", err)
+	}
+}
+
 func (d *Discoverer) Discover(ctx context.Context, in chan<- []model.TargetGroup) {
 	d.Info("instance is started")
 	d.Debugf("used config: interval: %s, timeout: %s, cache expiration time: %s", d.interval, d.timeout, d.expiryTime)
@@ -122,8 +151,11 @@ func (d *Discoverer) Discover(ctx context.Context, in chan<- []model.TargetGroup
 }
 
 func (d *Discoverer) discoverLocalListeners(ctx context.Context, in chan<- []model.TargetGroup) error {
-	bs, err := d.ll.discover(ctx)
+	tgts, err := d.inspectLocalListeners(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
 		if errors.Is(err, context.DeadlineExceeded) {
 			// there is no point in continuing pointless attempts/use cpu
 			// https://github.com/netdata/netdata/discussions/18751#discussioncomment-10908472
@@ -135,13 +167,11 @@ func (d *Discoverer) discoverLocalListeners(ctx context.Context, in chan<- []mod
 		}
 		return err
 	}
+	if ctx.Err() != nil {
+		return nil
+	}
 
 	d.successRuns++
-
-	tgts, err := d.parseLocalListeners(bs)
-	if err != nil {
-		return err
-	}
 
 	tggs := d.processTargets(tgts)
 
@@ -151,6 +181,42 @@ func (d *Discoverer) discoverLocalListeners(ctx context.Context, in chan<- []mod
 	}
 
 	return nil
+}
+
+func (d *Discoverer) inspectLocalListeners(ctx context.Context) ([]model.Target, error) {
+	if cause := callerCancellationCause(ctx); cause != nil {
+		return nil, fmt.Errorf("inspect local network listeners: %w", cause)
+	}
+
+	bs, err := d.ll.discover(ctx)
+	if err != nil {
+		if cause := callerCancellationCause(ctx); cause != nil {
+			return nil, fmt.Errorf("inspect local network listeners: %w", cause)
+		}
+		return nil, fmt.Errorf("execute local listener inspection: %w", err)
+	}
+	if cause := callerCancellationCause(ctx); cause != nil {
+		return nil, fmt.Errorf("inspect local network listeners: %w", cause)
+	}
+
+	tgts, err := d.parseLocalListeners(bs)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidLocalListenerData, err)
+	}
+	if cause := callerCancellationCause(ctx); cause != nil {
+		return nil, fmt.Errorf("inspect local network listeners: %w", cause)
+	}
+	return tgts, nil
+}
+
+func callerCancellationCause(ctx context.Context) error {
+	if ctx == nil || ctx.Err() == nil {
+		return nil
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	return ctx.Err()
 }
 
 func (d *Discoverer) processTargets(tgts []model.Target) []model.TargetGroup {

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/netlisteners.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/netlisteners.go
@@ -280,12 +280,15 @@ func (d *Discoverer) parseLocalListeners(bs []byte) ([]model.Target, error) {
 
 		hash, err := model.CalcHash(tgt)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("hash target: %w", err)
 		}
 
 		tgt.hash = hash
 
 		targets = append(targets, tgt)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("scan local listener data: %w", err)
 	}
 
 	// order: TCP, TCP6, UDP, UDP6

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/netlisteners.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/netlisteners.go
@@ -179,7 +179,7 @@ func (d *Discoverer) discoverLocalListeners(ctx context.Context, in chan<- []mod
 func (d *Discoverer) inspectLocalListeners(ctx context.Context) ([]model.Target, error) {
 	bs, err := d.ll.discover(ctx)
 	if err != nil {
-		if cause := callerCancellationCause(ctx); cause != nil {
+		if cause := context.Cause(ctx); cause != nil {
 			return nil, fmt.Errorf("%w: %w", errLocalListenerInspectionCanceled, cause)
 		}
 		return nil, fmt.Errorf("execute local listener inspection: %w", err)
@@ -189,20 +189,10 @@ func (d *Discoverer) inspectLocalListeners(ctx context.Context) ([]model.Target,
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidLocalListenerData, err)
 	}
-	if cause := callerCancellationCause(ctx); cause != nil {
+	if cause := context.Cause(ctx); cause != nil {
 		return nil, fmt.Errorf("%w: %w", errLocalListenerInspectionCanceled, cause)
 	}
 	return tgts, nil
-}
-
-func callerCancellationCause(ctx context.Context) error {
-	if ctx == nil || ctx.Err() == nil {
-		return nil
-	}
-	if cause := context.Cause(ctx); cause != nil {
-		return cause
-	}
-	return ctx.Err()
 }
 
 func (d *Discoverer) processTargets(tgts []model.Target) []model.TargetGroup {

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/operational_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/operational_test.go
@@ -93,7 +93,7 @@ func TestDiscovererTest(t *testing.T) {
 		require.Equal(t, "local listener inspection did not complete before the timeout", err.Error())
 	})
 
-	t.Run("preserves preexisting caller cancellation cause without invoking helper", func(t *testing.T) {
+	t.Run("preserves preexisting caller cancellation cause after entering helper path", func(t *testing.T) {
 		cancelCause := errors.New("test attempt superseded")
 		ctx, cancel := context.WithCancelCause(t.Context())
 		cancel(cancelCause)
@@ -111,7 +111,7 @@ func TestDiscovererTest(t *testing.T) {
 		require.ErrorIs(t, err, cancelCause)
 		_, public := dyncfg.PublicMessage(err)
 		require.False(t, public)
-		require.Zero(t, calls)
+		require.Equal(t, 1, calls)
 	})
 
 	t.Run("preserves inflight caller cancellation cause", func(t *testing.T) {
@@ -131,6 +131,24 @@ func TestDiscovererTest(t *testing.T) {
 		require.ErrorIs(t, err, cancelCause)
 		_, public := dyncfg.PublicMessage(err)
 		require.False(t, public)
+	})
+
+	t.Run("parser failure wins over cancellation racing the fast parse", func(t *testing.T) {
+		cancelCause := errors.New("test attempt superseded")
+		ctx, cancel := context.WithCancelCause(t.Context())
+
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			cancel(cancelCause)
+			return []byte("invalid [REDACTED_SECRET]\n"), nil
+		})
+
+		err = d.Test(ctx)
+
+		require.Equal(t, "local listener inspection returned invalid data", err.Error())
+		require.NotContains(t, err.Error(), "[REDACTED_SECRET]")
+		require.NotErrorIs(t, err, cancelCause)
 	})
 
 	t.Run("does not classify the caller deadline as the configured helper timeout", func(t *testing.T) {

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/operational_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/operational_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netlistensd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/stretchr/testify/require"
+)
+
+var _ dyncfg.Testable = (*Discoverer)(nil)
+
+func TestDiscovererTest(t *testing.T) {
+	t.Run("runs and parses exactly one snapshot without runtime side effects", func(t *testing.T) {
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+
+		var calls int
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			calls++
+			return []byte("TCP|127.0.0.1|19999|/usr/bin/example\n"), nil
+		})
+		d.successRuns = 3
+		d.timeoutRuns = 2
+		d.cache[42] = &cacheItem{}
+
+		require.NoError(t, d.Test(t.Context()))
+		require.Equal(t, 1, calls)
+		require.EqualValues(t, 3, d.successRuns)
+		require.EqualValues(t, 2, d.timeoutRuns)
+		require.Len(t, d.cache, 1)
+		require.Contains(t, d.cache, uint64(42))
+	})
+
+	t.Run("accepts an empty snapshot", func(t *testing.T) {
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+
+		var calls int
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			calls++
+			return nil, nil
+		})
+
+		require.NoError(t, d.Test(t.Context()))
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("sanitizes helper failures", func(t *testing.T) {
+		privateErr := errors.New("helper failed at [PRIVATE_ENDPOINT]")
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			return nil, privateErr
+		})
+
+		err = d.Test(t.Context())
+
+		require.ErrorIs(t, err, privateErr)
+		require.Equal(t, "cannot inspect local network listeners", err.Error())
+		require.NotContains(t, err.Error(), "[PRIVATE_ENDPOINT]")
+	})
+
+	t.Run("sanitizes invalid helper output", func(t *testing.T) {
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			return []byte("invalid [REDACTED_SECRET]\n"), nil
+		})
+
+		err = d.Test(t.Context())
+
+		require.Error(t, err)
+		require.Equal(t, "local listener inspection returned invalid data", err.Error())
+		require.NotContains(t, err.Error(), "[REDACTED_SECRET]")
+	})
+
+	t.Run("classifies configured helper timeout", func(t *testing.T) {
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			return nil, context.DeadlineExceeded
+		})
+
+		err = d.Test(t.Context())
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Equal(t, "local listener inspection did not complete before the timeout", err.Error())
+	})
+
+	t.Run("preserves preexisting caller cancellation cause without invoking helper", func(t *testing.T) {
+		cancelCause := errors.New("test attempt superseded")
+		ctx, cancel := context.WithCancelCause(t.Context())
+		cancel(cancelCause)
+
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		var calls int
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			calls++
+			return nil, nil
+		})
+
+		err = d.Test(ctx)
+
+		require.ErrorIs(t, err, cancelCause)
+		_, public := dyncfg.PublicMessage(err)
+		require.False(t, public)
+		require.Zero(t, calls)
+	})
+
+	t.Run("preserves inflight caller cancellation cause", func(t *testing.T) {
+		cancelCause := errors.New("test attempt superseded")
+		ctx, cancel := context.WithCancelCause(t.Context())
+
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		d.ll = localListenersFunc(func(ctx context.Context) ([]byte, error) {
+			cancel(cancelCause)
+			<-ctx.Done()
+			return nil, context.Cause(ctx)
+		})
+
+		err = d.Test(ctx)
+
+		require.ErrorIs(t, err, cancelCause)
+		_, public := dyncfg.PublicMessage(err)
+		require.False(t, public)
+	})
+
+	t.Run("does not classify the caller deadline as the configured helper timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+		defer cancel()
+
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		d.ll = localListenersFunc(func(ctx context.Context) ([]byte, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+
+		err = d.Test(ctx)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		_, public := dyncfg.PublicMessage(err)
+		require.False(t, public)
+	})
+}
+
+func TestDiscoverLocalListenersCancellationAndTimeoutClassification(t *testing.T) {
+	t.Run("caller cancellation is a clean stop without runtime side effects", func(t *testing.T) {
+		cancelCause := errors.New("discovery attempt superseded")
+		ctx, cancel := context.WithCancelCause(t.Context())
+
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		d.ll = localListenersFunc(func(ctx context.Context) ([]byte, error) {
+			cancel(cancelCause)
+			<-ctx.Done()
+			return nil, context.Cause(ctx)
+		})
+		d.cache[42] = &cacheItem{}
+
+		require.NoError(t, d.discoverLocalListeners(ctx, make(chan []model.TargetGroup, 1)))
+		require.Zero(t, d.successRuns)
+		require.Zero(t, d.timeoutRuns)
+		require.Len(t, d.cache, 1)
+		require.Contains(t, d.cache, uint64(42))
+	})
+
+	t.Run("sixth configured timeout stops discovery before any success", func(t *testing.T) {
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			return nil, context.DeadlineExceeded
+		})
+
+		for range 5 {
+			require.NoError(t, d.discoverLocalListeners(t.Context(), make(chan []model.TargetGroup, 1)))
+		}
+		err = d.discoverLocalListeners(t.Context(), make(chan []model.TargetGroup, 1))
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Zero(t, d.successRuns)
+		require.EqualValues(t, 6, d.timeoutRuns)
+	})
+
+	t.Run("a successful snapshot keeps later configured timeouts nonfatal", func(t *testing.T) {
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		var calls int
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil
+			}
+			return nil, context.DeadlineExceeded
+		})
+
+		require.NoError(t, d.discoverLocalListeners(t.Context(), make(chan []model.TargetGroup, 1)))
+		for range 6 {
+			require.NoError(t, d.discoverLocalListeners(t.Context(), make(chan []model.TargetGroup, 1)))
+		}
+
+		require.EqualValues(t, 1, d.successRuns)
+		require.EqualValues(t, 6, d.timeoutRuns)
+	})
+}
+
+type localListenersFunc func(context.Context) ([]byte, error)
+
+func (fn localListenersFunc) discover(ctx context.Context) ([]byte, error) {
+	return fn(ctx)
+}

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/operational_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/netlistensd/operational_test.go
@@ -3,8 +3,10 @@
 package netlistensd
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,6 +80,20 @@ func TestDiscovererTest(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, "local listener inspection returned invalid data", err.Error())
 		require.NotContains(t, err.Error(), "[REDACTED_SECRET]")
+	})
+
+	t.Run("rejects a snapshot truncated by the scanner", func(t *testing.T) {
+		d, err := NewDiscoverer(Config{})
+		require.NoError(t, err)
+		d.ll = localListenersFunc(func(context.Context) ([]byte, error) {
+			line := "TCP|127.0.0.1|19999|/" + strings.Repeat("x", bufio.MaxScanTokenSize)
+			return []byte(line + "\n"), nil
+		})
+
+		err = d.Test(t.Context())
+
+		require.Error(t, err)
+		require.Equal(t, "local listener inspection returned invalid data", err.Error())
 	})
 
 	t.Run("classifies configured helper timeout", func(t *testing.T) {

--- a/src/go/plugin/go.d/discovery/sdext/dyncfg_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/dyncfg_test.go
@@ -17,9 +17,14 @@ import (
 )
 
 func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
+	prepareNetListenersExecutableFixture(t)
+
 	attempts, err := containment.NewAuthority(nil)
 	require.NoError(t, err)
-	output := &dyncfgTestOutput{results: make(chan dyncfg.Result, 1)}
+	output := &dyncfgTestOutput{
+		results: make(chan dyncfg.Result, 1),
+		creates: make(chan struct{}, 16),
+	}
 	registry := &dyncfgTestRegistry{registered: make(chan functions.Handler, 1)}
 	discovery, err := sd.NewServiceDiscovery(sd.Config{
 		Epoch:        1,
@@ -33,9 +38,10 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan struct{})
+	groups := make(chan []*confgroup.Group, 1)
 	go func() {
 		defer close(done)
-		discovery.Run(ctx, make(chan []*confgroup.Group))
+		discovery.Run(ctx, groups)
 	}()
 	t.Cleanup(func() {
 		cancel()
@@ -56,6 +62,13 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 	case <-time.After(time.Second):
 		require.FailNow(t, "test failed", "service discovery did not register DynCfg")
 	}
+	for range len(Registry(true).Types()) {
+		select {
+		case <-output.creates:
+		case <-time.After(time.Second):
+			require.FailNow(t, "test failed", "service discovery did not expose every DynCfg template")
+		}
+	}
 	tests := []struct {
 		name    string
 		uid     string
@@ -63,6 +76,7 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 		payload string
 		message string
 		code    int
+		mode    string
 	}{
 		{
 			name:    "resource parser",
@@ -96,9 +110,36 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 			message: "service discovery operational test failed: cannot connect to the configured Docker endpoint",
 			code:    422,
 		},
+		{
+			name:    "net listeners operational success",
+			uid:     "test-net-listeners-operational-success",
+			id:      "go.d:sd:net_listeners",
+			payload: `{"discoverer":{"net_listeners":{}},"services":[{"id":"test","match":"true"}]}`,
+			message: `"message":""`,
+			code:    200,
+		},
+		{
+			name:    "net listeners helper failure",
+			uid:     "test-net-listeners-operational-failure",
+			id:      "go.d:sd:net_listeners",
+			payload: `{"discoverer":{"net_listeners":{}},"services":[{"id":"test","match":"true"}]}`,
+			message: "service discovery operational test failed: cannot inspect local network listeners",
+			code:    422,
+			mode:    "failure",
+		},
+		{
+			name:    "net listeners invalid output",
+			uid:     "test-net-listeners-invalid-output",
+			id:      "go.d:sd:net_listeners",
+			payload: `{"discoverer":{"net_listeners":{}},"services":[{"id":"test","match":"true"}]}`,
+			message: "service discovery operational test failed: local listener inspection returned invalid data",
+			code:    422,
+			mode:    "invalid",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("NETDATA_TEST_LOCAL_LISTENER_MODE", test.mode)
 			handler(t.Context(), functions.Function{
 				UID:         test.uid,
 				Args:        []string{test.id, "test", "job"},
@@ -112,8 +153,18 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 				require.Equal(t, test.code, result.Code)
 				require.Contains(t, result.Payload, test.message)
 				require.NotContains(t, result.Payload, "[REDACTED_SECRET]")
-			case <-time.After(time.Second):
+			case <-time.After(10 * time.Second):
 				require.FailNow(t, "test failed", "DynCfg test did not return a result")
+			}
+			select {
+			case <-groups:
+				require.FailNow(t, "test failed", "temporary DynCfg test published discovery groups")
+			default:
+			}
+			select {
+			case <-output.creates:
+				require.FailNow(t, "test failed", "temporary DynCfg test installed configuration")
+			default:
 			}
 		})
 	}
@@ -132,13 +183,18 @@ func (*dyncfgTestRegistry) UnregisterPrefix(string, string) {
 
 type dyncfgTestOutput struct {
 	results chan dyncfg.Result
+	creates chan struct{}
 }
 
 func (o *dyncfgTestOutput) FunctionResult(result dyncfg.Result) {
 	o.results <- result
 }
 
-func (*dyncfgTestOutput) ConfigCreate(netdataapi.ConfigOpts) {
+func (o *dyncfgTestOutput) ConfigCreate(netdataapi.ConfigOpts) {
+	select {
+	case o.creates <- struct{}{}:
+	default:
+	}
 }
 
 func (*dyncfgTestOutput) ConfigStatus(string, dyncfg.Status) {

--- a/src/go/plugin/go.d/discovery/sdext/registry_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/registry_test.go
@@ -3,15 +3,23 @@
 package sdext
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/pipeline"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/dockersd"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/netlistensd"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,4 +71,134 @@ func TestRegistry_DockerOperationalTestRejectsUnreachableEndpoint(t *testing.T) 
 	require.False(t, fullyTested)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "cannot connect to the configured Docker endpoint")
+}
+
+func TestRegistry_NetListenersOperationalTestUsesShippedConstructionPath(t *testing.T) {
+	fixture := prepareNetListenersExecutableFixture(t)
+
+	raw, err := json.Marshal(netlistensd.Config{
+		Timeout: confopt.Duration(5 * time.Second),
+	})
+	require.NoError(t, err)
+	registry := Registry(true)
+	descriptor, ok := registry.Get(discovererNetListeners)
+	require.True(t, ok)
+	config, err := descriptor.ParseJSONConfig(raw)
+	require.NoError(t, err)
+	discoverers, err := descriptor.NewDiscoverers(config, "dyncfg=user=test")
+	require.NoError(t, err)
+	require.Len(t, discoverers, 1)
+	_, ok = discoverers[0].(dyncfg.Testable)
+	require.True(t, ok)
+
+	candidate, err := pipeline.New(
+		pipeline.Config{
+			Name: "net-listeners-test",
+			Discoverer: pipeline.DiscovererPayload{
+				Kind:   discovererNetListeners,
+				Config: raw,
+			},
+			Services: []pipeline.ServiceRuleConfig{{
+				ID:    "test",
+				Match: "true",
+			}},
+		},
+		func(payload pipeline.DiscovererPayload, source string) ([]model.Discoverer, error) {
+			descriptor, ok := registry.Get(payload.Type())
+			require.True(t, ok)
+			config, err := descriptor.ParseJSONConfig(payload.Config)
+			if err != nil {
+				return nil, err
+			}
+			return descriptor.NewDiscoverers(config, source)
+		},
+	)
+	require.NoError(t, err)
+
+	fullyTested, err := candidate.Test(t.Context())
+
+	require.NoError(t, err)
+	require.True(t, fullyTested)
+	invocations, err := os.ReadFile(fixture.invocationsPath)
+	require.NoError(t, err)
+	require.Equal(t, "invoked\n", string(invocations))
+	args, err := os.ReadFile(fixture.argsPath)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"no-udp6 no-local no-inbound no-outbound no-namespaces",
+		strings.TrimSpace(string(args)),
+	)
+}
+
+func TestRegistry_NetListenersOperationalTestHonorsConfiguredTimeout(t *testing.T) {
+	prepareNetListenersExecutableFixture(t)
+	t.Setenv("NETDATA_TEST_LOCAL_LISTENER_MODE", "timeout")
+
+	raw, err := json.Marshal(netlistensd.Config{
+		Timeout: confopt.Duration(100 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	descriptor, ok := Registry(true).Get(discovererNetListeners)
+	require.True(t, ok)
+	config, err := descriptor.ParseJSONConfig(raw)
+	require.NoError(t, err)
+	discoverers, err := descriptor.NewDiscoverers(config, "dyncfg=user=test")
+	require.NoError(t, err)
+	require.Len(t, discoverers, 1)
+	testable, ok := discoverers[0].(dyncfg.Testable)
+	require.True(t, ok)
+
+	err = testable.Test(t.Context())
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, "local listener inspection did not complete before the timeout", err.Error())
+}
+
+type netListenersExecutableFixture struct {
+	invocationsPath string
+	argsPath        string
+}
+
+func prepareNetListenersExecutableFixture(t *testing.T) netListenersExecutableFixture {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("uses shell executable fixtures")
+	}
+
+	tmp := t.TempDir()
+	fixture := netListenersExecutableFixture{
+		invocationsPath: filepath.Join(tmp, "invocations"),
+		argsPath:        filepath.Join(tmp, "args"),
+	}
+	t.Setenv("NETDATA_PLUGINS_DIR", tmp)
+	t.Setenv("NETDATA_TEST_LOCAL_LISTENER_INVOCATIONS", fixture.invocationsPath)
+	t.Setenv("NETDATA_TEST_LOCAL_LISTENER_ARGS", fixture.argsPath)
+
+	localListeners := filepath.Join(tmp, "local-listeners")
+	require.NoError(t, os.WriteFile(localListeners, []byte(`#!/bin/sh
+printf 'invoked\n' >> "$NETDATA_TEST_LOCAL_LISTENER_INVOCATIONS"
+printf '%s\n' "$*" >> "$NETDATA_TEST_LOCAL_LISTENER_ARGS"
+case "$NETDATA_TEST_LOCAL_LISTENER_MODE" in
+failure)
+	printf 'private helper failure [REDACTED_SECRET]\n' >&2
+	exit 1
+	;;
+invalid)
+	printf 'invalid [REDACTED_SECRET]\n'
+	;;
+timeout)
+	sleep 30
+	;;
+*)
+	printf 'TCP|127.0.0.1|19999|/usr/bin/example\n'
+	;;
+esac
+`), 0o755))
+
+	ndRun := filepath.Join(tmp, "nd-run")
+	require.NoError(t, os.WriteFile(ndRun, []byte("#!/bin/sh\nexec \"$@\"\n"), 0o755))
+	t.Cleanup(ndexec.SetRunnerPathsForTests(ndRun, ""))
+
+	return fixture
 }

--- a/src/go/plugin/go.d/discovery/sdext/registry_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/registry_test.go
@@ -121,7 +121,7 @@ func TestRegistry_NetListenersOperationalTestUsesShippedConstructionPath(t *test
 	require.True(t, fullyTested)
 	invocations, err := os.ReadFile(fixture.invocationsPath)
 	require.NoError(t, err)
-	require.Equal(t, "invoked\n", string(invocations))
+	require.Equal(t, "nd-run\ninvoked\n", string(invocations))
 	args, err := os.ReadFile(fixture.argsPath)
 	require.NoError(t, err)
 	require.Equal(
@@ -197,7 +197,10 @@ esac
 `), 0o755))
 
 	ndRun := filepath.Join(tmp, "nd-run")
-	require.NoError(t, os.WriteFile(ndRun, []byte("#!/bin/sh\nexec \"$@\"\n"), 0o755))
+	require.NoError(t, os.WriteFile(ndRun, []byte(`#!/bin/sh
+printf 'nd-run\n' >> "$NETDATA_TEST_LOCAL_LISTENER_INVOCATIONS"
+exec "$@"
+`), 0o755))
 	t.Cleanup(ndexec.SetRunnerPathsForTests(ndRun, ""))
 
 	return fixture

--- a/src/go/plugin/go.d/pkg/ndexec/ndexec.go
+++ b/src/go/plugin/go.d/pkg/ndexec/ndexec.go
@@ -120,13 +120,19 @@ func RunUnprivilegedWithOptionsUsageContext(
 }
 
 // SetRunnerPathsForTests overrides the nd-run and ndsudo helper paths.
-// It is intended for test environments that need to stub the helpers.
-func SetRunnerPathsForTests(ndRunPath, ndSudoPath string) {
+// It returns a function that restores the previous paths.
+func SetRunnerPathsForTests(ndRunPath, ndSudoPath string) func() {
+	previousNDRunPath := defaultRunner.ndRunPath
+	previousNDSudoPath := defaultRunner.ndSudoPath
 	if ndRunPath != "" {
 		defaultRunner.ndRunPath = ndRunPath
 	}
 	if ndSudoPath != "" {
 		defaultRunner.ndSudoPath = ndSudoPath
+	}
+	return func() {
+		defaultRunner.ndRunPath = previousNDRunPath
+		defaultRunner.ndSudoPath = previousNDSudoPath
 	}
 }
 

--- a/src/go/plugin/go.d/pkg/ndexec/ndexec_test.go
+++ b/src/go/plugin/go.d/pkg/ndexec/ndexec_test.go
@@ -4,6 +4,7 @@ package ndexec
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -339,4 +340,66 @@ func TestRunUnprivilegedWithOptionsUsage(t *testing.T) {
 	assert.Equal(t, "foo", string(out))
 	assert.True(t, usage.User >= 0)
 	assert.True(t, usage.System >= 0)
+}
+
+func TestRunUnprivilegedWithOptionsUsageContextCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses Unix process-group cancellation")
+	}
+
+	tmp := t.TempDir()
+	ready := filepath.Join(tmp, "ready")
+	leaked := filepath.Join(tmp, "leaked")
+
+	target := filepath.Join(tmp, "target.sh")
+	require.NoError(t, os.WriteFile(target, []byte(`#!/bin/sh
+touch "$1"
+(
+	sleep 0.4
+	touch "$2"
+) &
+wait
+`), 0o755))
+
+	helper := filepath.Join(tmp, "helper.sh")
+	require.NoError(t, os.WriteFile(helper, []byte("#!/bin/sh\nexec \"$@\"\n"), 0o755))
+	t.Cleanup(SetRunnerPathsForTests(helper, ""))
+
+	cancelCause := errors.New("execution owner stopped")
+	ctx, cancel := context.WithCancelCause(t.Context())
+	result := make(chan error, 1)
+	go func() {
+		_, _, _, err := RunUnprivilegedWithOptionsUsageContext(
+			ctx,
+			nil,
+			3*time.Second,
+			RunOptions{},
+			target,
+			ready,
+			leaked,
+		)
+		result <- err
+	}()
+
+	waitUntil := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(waitUntil) {
+			require.FailNow(t, "target did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel(cancelCause)
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, cancelCause)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "canceled execution did not return")
+	}
+
+	time.Sleep(600 * time.Millisecond)
+	require.NoFileExists(t, leaked)
 }

--- a/src/go/plugin/go.d/pkg/ndexec/ndexec_test.go
+++ b/src/go/plugin/go.d/pkg/ndexec/ndexec_test.go
@@ -353,8 +353,8 @@ func TestRunUnprivilegedWithOptionsUsageContextCancellation(t *testing.T) {
 
 	target := filepath.Join(tmp, "target.sh")
 	require.NoError(t, os.WriteFile(target, []byte(`#!/bin/sh
-touch "$1"
 (
+	touch "$1"
 	sleep 0.4
 	touch "$2"
 ) &
@@ -381,7 +381,7 @@ wait
 		result <- err
 	}()
 
-	waitUntil := time.Now().Add(2 * time.Second)
+	waitUntil := time.Now().Add(10 * time.Second)
 	for {
 		if _, err := os.Stat(ready); err == nil {
 			break
@@ -400,6 +400,6 @@ wait
 		require.FailNow(t, "canceled execution did not return")
 	}
 
-	time.Sleep(600 * time.Millisecond)
+	time.Sleep(2 * time.Second)
 	require.NoFileExists(t, leaked)
 }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DynCfg operational test for `go.d` service discovery `net_listeners`. It runs the installed `nd-run`/`local-listeners` once, honors `timeout`, parses output, and returns sanitized results without creating or publishing config.

- **New Features**
  - Implemented `dyncfg.Testable` for `net_listeners`: single helper invocation, parse-only, no side effects. Classifies configured timeouts, invalid output, and helper failures with public messages; preserves caller cancellation cause; accepts empty snapshots; Linux-only.
  - Uses `ndexec`’s context-aware runner to pass `ctx` to `local-listeners` and cancel the process group; clean failure if the helper is missing or non-executable.
  - Docs: clarified DynCfg `test` semantics and `net_listeners` limitations. For service discovery, an empty successful message means all discoverers completed an operational test; a validation-only message means no operational check was available.

- **Refactors**
  - Centralized cancellation precedence in `pipeline.Test` and `SecretStore.Test`: `context.Cause(ctx)` wins even if it races a resource/provider failure; added tests.
  - `ndexec`: added `RunUnprivilegedWithOptionsUsageContext`; `SetRunnerPathsForTests` now returns a restore function; added a process-group cancellation test.
  - Simplified `net_listeners` cancellation checks and error mapping; `dockersd` timeout classification no longer repeats context checks.

<sup>Written for commit 2dce314112663f4b519376db04d83aeae24ea2cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

