### PR TITLE
feat(go.d/discovery): test HTTP configurations operationally

### DIFF
--- a/integrations/gen_doc_service_discovery_page.py
+++ b/integrations/gen_doc_service_discovery_page.py
@@ -27,6 +27,7 @@ SD_PAGE = {
     "jump_to": [
         {"label": "How it works", "anchor": "how-it-works"},
         {"label": "Configuration file structure", "anchor": "configuration-file-structure"},
+        {"label": "Testing configurations", "anchor": "testing-configurations"},
         {"label": "Rule evaluation semantics", "anchor": "rule-evaluation-semantics"},
         {"label": "Template helper reference", "anchor": "template-helper-reference"},
         {"label": "config_template rendering", "anchor": "config_template-rendering"},
@@ -85,6 +86,14 @@ services:
             "`disabled: yes` keeps the file on disk but turns the pipeline off.",
             "Editing a stock file requires restarting the agent. UI-managed pipelines apply live.",
             "Where each discoverer's stock conf ships (with the Netdata package, with the Helm chart, or not at all) is documented on its per-discoverer page.",
+        ],
+    },
+    "testing": {
+        "heading": "## Testing configurations",
+        "body": [
+            "Testing a UI-managed pipeline builds a complete temporary pipeline but does not publish targets, install jobs, or make the configuration persistent. The response says explicitly when only configuration validation was possible.",
+            "Operational guarantees depend on the discoverer. Docker runs one bounded container-list query. Local-listener discovery runs and parses one helper snapshot. HTTP discovery runs one complete production fetch only when `method` is empty/default or exactly `GET`; it uses the configured authentication, headers, TLS, proxy, redirects, and timeout, requires HTTP 200, enforces the 10 MiB response limit, and parses every returned item. Redirect handling can issue at most 10 requests.",
+            "The HTTP test discards the parsed targets. It does not evaluate `services:` rules, render or validate collector jobs, publish targets, or install jobs. A non-empty HTTP method other than exact `GET`, plus Kubernetes and SNMP, is intentionally validation-only.",
         ],
     },
     "rule_eval": {
@@ -358,6 +367,7 @@ def build_page_context() -> Dict[str, Any]:
         ),
         "how_it_works": SD_PAGE["how_it_works"],
         "config_file": SD_PAGE["config_file"],
+        "testing": SD_PAGE["testing"],
         "rule_eval": SD_PAGE["rule_eval"],
         "helpers": SD_PAGE["helpers"],
         "config_template": SD_PAGE["config_template"],

--- a/integrations/templates/service_discovery.md
+++ b/integrations/templates/service_discovery.md
@@ -36,6 +36,14 @@
 [% endfor %]
 
 
+[[ page.testing.heading ]]
+
+[% for paragraph in page.testing.body %]
+[[ paragraph ]]
+
+[% endfor %]
+
+
 [[ page.rule_eval.heading ]]
 
 [% for paragraph in page.rule_eval.intro %]

--- a/src/collectors/SERVICE-DISCOVERY.md
+++ b/src/collectors/SERVICE-DISCOVERY.md
@@ -6,7 +6,7 @@ Each SD pipeline is a `discoverer:` (where to look) plus a list of `services:` r
 
 ### Jump To
 
-[How it works](#how-it-works) • [Configuration file structure](#configuration-file-structure) • [Rule evaluation semantics](#rule-evaluation-semantics) • [Template helper reference](#template-helper-reference) • [config_template rendering](#config_template-rendering) • [Supported discoverers](#supported-discoverers) • [Mixing discoverers](#mixing-discoverers) • [Troubleshooting](#troubleshooting)
+[How it works](#how-it-works) • [Configuration file structure](#configuration-file-structure) • [Testing configurations](#testing-configurations) • [Rule evaluation semantics](#rule-evaluation-semantics) • [Template helper reference](#template-helper-reference) • [config_template rendering](#config_template-rendering) • [Supported discoverers](#supported-discoverers) • [Mixing discoverers](#mixing-discoverers) • [Troubleshooting](#troubleshooting)
 
 
 ## How it works
@@ -43,6 +43,16 @@ services:
 - `disabled: yes` keeps the file on disk but turns the pipeline off.
 - Editing a stock file requires restarting the agent. UI-managed pipelines apply live.
 - Where each discoverer's stock conf ships (with the Netdata package, with the Helm chart, or not at all) is documented on its per-discoverer page.
+
+
+## Testing configurations
+
+Testing a UI-managed pipeline builds a complete temporary pipeline but does not publish targets, install jobs, or make the configuration persistent. The response says explicitly when only configuration validation was possible.
+
+Operational guarantees depend on the discoverer. Docker runs one bounded container-list query. Local-listener discovery runs and parses one helper snapshot. HTTP discovery runs one complete production fetch only when `method` is empty/default or exactly `GET`; it uses the configured authentication, headers, TLS, proxy, redirects, and timeout, requires HTTP 200, enforces the 10 MiB response limit, and parses every returned item. Redirect handling can issue at most 10 requests.
+
+The HTTP test discards the parsed targets. It does not evaluate `services:` rules, render or validate collector jobs, publish targets, or install jobs. A non-empty HTTP method other than exact `GET`, plus Kubernetes and SNMP, is intentionally validation-only.
+
 
 
 ## Rule evaluation semantics

--- a/src/go/pkg/safefile/open_other.go
+++ b/src/go/pkg/safefile/open_other.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !unix
+
+package safefile
+
+import "os"
+
+func open(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/src/go/pkg/safefile/open_unix.go
+++ b/src/go/pkg/safefile/open_unix.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build unix
+
+package safefile
+
+import (
+	"os"
+	"syscall"
+)
+
+func open(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}

--- a/src/go/pkg/safefile/read.go
+++ b/src/go/pkg/safefile/read.go
@@ -5,6 +5,7 @@
 package safefile
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -66,14 +67,30 @@ func Read(path string) (data []byte, err error) {
 		return nil, newFileError("read", path, ErrTooLarge)
 	}
 
-	data, err = io.ReadAll(io.LimitReader(file, MaxSize+1))
+	data, err = readBounded(file, info.Size())
 	if err != nil {
 		return nil, newFileError("read", path, err)
 	}
-	if int64(len(data)) > MaxSize {
-		return nil, newFileError("read", path, ErrTooLarge)
-	}
 	return data, nil
+}
+
+func readBounded(r io.Reader, size int64) ([]byte, error) {
+	if size < 0 {
+		size = 0
+	}
+	if size > MaxSize {
+		size = MaxSize
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, int(size)+bytes.MinRead))
+	n, err := buf.ReadFrom(io.LimitReader(r, MaxSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if n > MaxSize {
+		return nil, ErrTooLarge
+	}
+	return buf.Bytes(), nil
 }
 
 func newFileError(op, path string, err error) error {

--- a/src/go/pkg/safefile/read.go
+++ b/src/go/pkg/safefile/read.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package safefile reads small configured files through a bounded,
+// regular-file-only path.
+package safefile
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MaxSize is the maximum number of bytes Read accepts.
+const MaxSize int64 = 1 << 20
+
+var (
+	// ErrFile identifies every failure returned by Read.
+	ErrFile = errors.New("safe file read failed")
+	// ErrNotRegular identifies a path whose opened object is not a regular file.
+	ErrNotRegular = errors.New("file is not regular")
+	// ErrTooLarge identifies a regular file larger than MaxSize.
+	ErrTooLarge = errors.New("file exceeds size limit")
+)
+
+type fileError struct {
+	op   string
+	path string
+	err  error
+}
+
+func (e *fileError) Error() string {
+	return fmt.Sprintf("%s %q: %v", e.op, e.path, e.err)
+}
+
+func (e *fileError) Unwrap() error {
+	return e.err
+}
+
+func (e *fileError) Is(target error) bool {
+	return target == ErrFile || errors.Is(e.err, target)
+}
+
+// Read returns the contents of a configured regular file no larger than
+// MaxSize. The opened object is checked so a path replacement cannot bypass
+// the object-type validation.
+func Read(path string) (data []byte, err error) {
+	file, err := open(path)
+	if err != nil {
+		return nil, newFileError("open", path, err)
+	}
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			data = nil
+			err = newFileError("close", path, closeErr)
+		}
+	}()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, newFileError("stat", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, newFileError("read", path, ErrNotRegular)
+	}
+	if info.Size() > MaxSize {
+		return nil, newFileError("read", path, ErrTooLarge)
+	}
+
+	data, err = io.ReadAll(io.LimitReader(file, MaxSize+1))
+	if err != nil {
+		return nil, newFileError("read", path, err)
+	}
+	if int64(len(data)) > MaxSize {
+		return nil, newFileError("read", path, ErrTooLarge)
+	}
+	return data, nil
+}
+
+func newFileError(op, path string, err error) error {
+	return &fileError{op: op, path: path, err: err}
+}

--- a/src/go/pkg/safefile/read_test.go
+++ b/src/go/pkg/safefile/read_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package safefile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRead(t *testing.T) {
+	t.Run("reads a regular file at the limit", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "value")
+		want := make([]byte, MaxSize)
+		require.NoError(t, os.WriteFile(path, want, 0o600))
+
+		got, err := Read(path)
+
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("rejects a regular file over the limit", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "value")
+		require.NoError(t, os.WriteFile(path, make([]byte, MaxSize+1), 0o600))
+
+		_, err := Read(path)
+
+		require.ErrorIs(t, err, ErrFile)
+		require.ErrorIs(t, err, ErrTooLarge)
+	})
+
+	t.Run("rejects a non-regular opened object", func(t *testing.T) {
+		path := t.TempDir()
+
+		_, err := Read(path)
+
+		require.ErrorIs(t, err, ErrFile)
+		require.ErrorIs(t, err, ErrNotRegular)
+	})
+
+	t.Run("follows a symlink to a regular file", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target")
+		link := filepath.Join(dir, "link")
+		require.NoError(t, os.WriteFile(target, []byte("value"), 0o600))
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlinks are unavailable: %v", err)
+		}
+
+		got, err := Read(link)
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("value"), got)
+	})
+
+	t.Run("preserves the private filesystem cause", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing")
+
+		_, err := Read(path)
+
+		require.ErrorIs(t, err, ErrFile)
+		require.True(t, errors.Is(err, os.ErrNotExist))
+		require.Contains(t, err.Error(), path)
+	})
+}

--- a/src/go/pkg/safefile/read_test.go
+++ b/src/go/pkg/safefile/read_test.go
@@ -4,7 +4,6 @@ package safefile
 
 import (
 	"bytes"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,76 +13,107 @@ import (
 )
 
 func TestRead(t *testing.T) {
-	t.Run("reads a regular file at the limit", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "value")
-		want := make([]byte, MaxSize)
-		require.NoError(t, os.WriteFile(path, want, 0o600))
+	tests := map[string]struct {
+		prepare         func(t *testing.T) string
+		want            []byte
+		wantErrs        []error
+		wantCap         int
+		wantPathInError bool
+	}{
+		"reads a regular file at the limit": {
+			prepare: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "value")
+				require.NoError(t, os.WriteFile(path, make([]byte, MaxSize), 0o600))
+				return path
+			},
+			want:    make([]byte, MaxSize),
+			wantCap: int(MaxSize) + bytes.MinRead,
+		},
+		"rejects a regular file over the limit": {
+			prepare: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "value")
+				require.NoError(t, os.WriteFile(path, make([]byte, MaxSize+1), 0o600))
+				return path
+			},
+			wantErrs: []error{ErrFile, ErrTooLarge},
+		},
+		"rejects a non-regular opened object": {
+			prepare:  func(t *testing.T) string { return t.TempDir() },
+			wantErrs: []error{ErrFile, ErrNotRegular},
+		},
+		"follows a symlink to a regular file": {
+			prepare: func(t *testing.T) string {
+				dir := t.TempDir()
+				target := filepath.Join(dir, "target")
+				link := filepath.Join(dir, "link")
+				require.NoError(t, os.WriteFile(target, []byte("value"), 0o600))
+				if err := os.Symlink(target, link); err != nil {
+					t.Skipf("symlinks are unavailable: %v", err)
+				}
+				return link
+			},
+			want: []byte("value"),
+		},
+		"preserves the private filesystem cause": {
+			prepare: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing")
+			},
+			wantErrs:        []error{ErrFile, os.ErrNotExist},
+			wantPathInError: true,
+		},
+	}
 
-		got, err := Read(path)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := tc.prepare(t)
 
-		require.NoError(t, err)
-		require.Equal(t, want, got)
-		require.Equal(t, int(MaxSize)+bytes.MinRead, cap(got))
-	})
+			got, err := Read(path)
 
-	t.Run("rejects a regular file over the limit", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "value")
-		require.NoError(t, os.WriteFile(path, make([]byte, MaxSize+1), 0o600))
-
-		_, err := Read(path)
-
-		require.ErrorIs(t, err, ErrFile)
-		require.ErrorIs(t, err, ErrTooLarge)
-	})
-
-	t.Run("rejects a non-regular opened object", func(t *testing.T) {
-		path := t.TempDir()
-
-		_, err := Read(path)
-
-		require.ErrorIs(t, err, ErrFile)
-		require.ErrorIs(t, err, ErrNotRegular)
-	})
-
-	t.Run("follows a symlink to a regular file", func(t *testing.T) {
-		dir := t.TempDir()
-		target := filepath.Join(dir, "target")
-		link := filepath.Join(dir, "link")
-		require.NoError(t, os.WriteFile(target, []byte("value"), 0o600))
-		if err := os.Symlink(target, link); err != nil {
-			t.Skipf("symlinks are unavailable: %v", err)
-		}
-
-		got, err := Read(link)
-
-		require.NoError(t, err)
-		require.Equal(t, []byte("value"), got)
-	})
-
-	t.Run("preserves the private filesystem cause", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "missing")
-
-		_, err := Read(path)
-
-		require.ErrorIs(t, err, ErrFile)
-		require.True(t, errors.Is(err, os.ErrNotExist))
-		require.Contains(t, err.Error(), path)
-	})
+			if len(tc.wantErrs) > 0 {
+				require.Error(t, err)
+				for _, wantErr := range tc.wantErrs {
+					require.ErrorIs(t, err, wantErr)
+				}
+				if tc.wantPathInError {
+					require.Contains(t, err.Error(), path)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+			if tc.wantCap > 0 {
+				require.Equal(t, tc.wantCap, cap(got))
+			}
+		})
+	}
 }
 
 func TestReadBoundedUnderreportedSize(t *testing.T) {
-	t.Run("grows within the bound", func(t *testing.T) {
-		want := strings.Repeat("x", 2048)
+	tests := map[string]struct {
+		value   string
+		want    string
+		wantErr error
+	}{
+		"grows within the bound": {
+			value: strings.Repeat("x", 2048),
+			want:  strings.Repeat("x", 2048),
+		},
+		"rejects growth over the bound": {
+			value:   strings.Repeat("x", int(MaxSize+1)),
+			wantErr: ErrTooLarge,
+		},
+	}
 
-		got, err := readBounded(strings.NewReader(want), 0)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := readBounded(strings.NewReader(tc.value), 0)
 
-		require.NoError(t, err)
-		require.Equal(t, want, string(got))
-	})
-
-	t.Run("rejects growth over the bound", func(t *testing.T) {
-		_, err := readBounded(strings.NewReader(strings.Repeat("x", int(MaxSize+1))), 0)
-
-		require.ErrorIs(t, err, ErrTooLarge)
-	})
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got))
+		})
+	}
 }

--- a/src/go/pkg/safefile/read_test.go
+++ b/src/go/pkg/safefile/read_test.go
@@ -3,9 +3,11 @@
 package safefile
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,6 +23,7 @@ func TestRead(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, want, got)
+		require.Equal(t, int(MaxSize)+bytes.MinRead, cap(got))
 	})
 
 	t.Run("rejects a regular file over the limit", func(t *testing.T) {
@@ -65,5 +68,22 @@ func TestRead(t *testing.T) {
 		require.ErrorIs(t, err, ErrFile)
 		require.True(t, errors.Is(err, os.ErrNotExist))
 		require.Contains(t, err.Error(), path)
+	})
+}
+
+func TestReadBoundedUnderreportedSize(t *testing.T) {
+	t.Run("grows within the bound", func(t *testing.T) {
+		want := strings.Repeat("x", 2048)
+
+		got, err := readBounded(strings.NewReader(want), 0)
+
+		require.NoError(t, err)
+		require.Equal(t, want, string(got))
+	})
+
+	t.Run("rejects growth over the bound", func(t *testing.T) {
+		_, err := readBounded(strings.NewReader(strings.Repeat("x", int(MaxSize+1))), 0)
+
+		require.ErrorIs(t, err, ErrTooLarge)
 	})
 }

--- a/src/go/pkg/safefile/read_unix_test.go
+++ b/src/go/pkg/safefile/read_unix_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build unix
+
+package safefile
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestReadRejectsFIFOWithoutBlocking(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "value")
+	require.NoError(t, unix.Mkfifo(path, 0o600))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := Read(path)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, ErrFile)
+		require.ErrorIs(t, err, ErrNotRegular)
+	case <-time.After(time.Second):
+		t.Fatal("reading a FIFO blocked")
+	}
+}

--- a/src/go/pkg/tlscfg/config.go
+++ b/src/go/pkg/tlscfg/config.go
@@ -5,9 +5,30 @@ package tlscfg
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
-	"os"
+
+	"github.com/netdata/netdata/go/plugins/pkg/safefile"
 )
+
+// ErrTLSFile identifies TLS file read and parse failures.
+var ErrTLSFile = errors.New("TLS file is invalid")
+
+type fileError struct {
+	err error
+}
+
+func (e *fileError) Error() string {
+	return e.err.Error()
+}
+
+func (e *fileError) Unwrap() error {
+	return e.err
+}
+
+func (e *fileError) Is(target error) bool {
+	return target == ErrTLSFile || errors.Is(e.err, target)
+}
 
 // TLSConfig represents the standard client TLS configuration.
 type TLSConfig struct {
@@ -57,21 +78,34 @@ func NewTLSConfig(cfg TLSConfig) (*tls.Config, error) {
 func loadCertPool(certFiles []string) (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
 	for _, certFile := range certFiles {
-		pem, err := os.ReadFile(certFile)
+		pem, err := safefile.Read(certFile)
 		if err != nil {
-			return nil, fmt.Errorf("could not read certificate %q: %v", certFile, err)
+			return nil, newFileError(fmt.Errorf("could not read certificate %q: %w", certFile, err))
 		}
 		if !pool.AppendCertsFromPEM(pem) {
-			return nil, fmt.Errorf("could not parse any PEM certificates %q: %v", certFile, err)
+			return nil, newFileError(fmt.Errorf("could not parse any PEM certificates %q", certFile))
 		}
 	}
 	return pool, nil
 }
 
 func loadCertificate(certFile, keyFile string) (tls.Certificate, error) {
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	certPEM, err := safefile.Read(certFile)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("could not load keypair %s:%s: %v", certFile, keyFile, err)
+		return tls.Certificate{}, newFileError(fmt.Errorf("could not read certificate %q: %w", certFile, err))
+	}
+	keyPEM, err := safefile.Read(keyFile)
+	if err != nil {
+		return tls.Certificate{}, newFileError(fmt.Errorf("could not read key %q: %w", keyFile, err))
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, newFileError(fmt.Errorf("could not load keypair %s:%s: %w", certFile, keyFile, err))
 	}
 	return cert, nil
+}
+
+func newFileError(err error) error {
+	return &fileError{err: err}
 }

--- a/src/go/pkg/tlscfg/config_test.go
+++ b/src/go/pkg/tlscfg/config_test.go
@@ -2,9 +2,163 @@
 
 package tlscfg
 
-import "testing"
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
 
-// TODO:
-func TestNewClientTLSConfig(t *testing.T) {
+	"github.com/netdata/netdata/go/plugins/pkg/safefile"
+	"github.com/stretchr/testify/require"
+)
 
+func TestNewTLSConfig(t *testing.T) {
+	certPEM, keyPEM := newTestKeyPair(t)
+
+	t.Run("returns nil when TLS is not configured", func(t *testing.T) {
+		cfg, err := NewTLSConfig(TLSConfig{})
+
+		require.NoError(t, err)
+		require.Nil(t, cfg)
+	})
+
+	t.Run("loads a CA and client keypair", func(t *testing.T) {
+		dir := t.TempDir()
+		caPath := writeTLSFile(t, dir, "ca.pem", certPEM)
+		certPath := writeTLSFile(t, dir, "cert.pem", certPEM)
+		keyPath := writeTLSFile(t, dir, "key.pem", keyPEM)
+
+		cfg, err := NewTLSConfig(TLSConfig{
+			TLSCA:   caPath,
+			TLSCert: certPath,
+			TLSKey:  keyPath,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg.RootCAs)
+		require.Len(t, cfg.Certificates, 1)
+	})
+
+	for _, tc := range []struct {
+		name string
+		file string
+	}{
+		{name: "CA", file: "ca"},
+		{name: "certificate", file: "cert"},
+		{name: "key", file: "key"},
+	} {
+		t.Run("accepts "+tc.name+" at the limit", func(t *testing.T) {
+			dir := t.TempDir()
+			ca := certPEM
+			cert := certPEM
+			key := keyPEM
+			switch tc.file {
+			case "ca":
+				ca = padToLimit(t, ca)
+			case "cert":
+				cert = padToLimit(t, cert)
+			case "key":
+				key = padToLimit(t, key)
+			}
+
+			_, err := NewTLSConfig(TLSConfig{
+				TLSCA:   writeTLSFile(t, dir, "ca.pem", ca),
+				TLSCert: writeTLSFile(t, dir, "cert.pem", cert),
+				TLSKey:  writeTLSFile(t, dir, "key.pem", key),
+			})
+
+			require.NoError(t, err)
+		})
+
+		t.Run("rejects "+tc.name+" over the limit", func(t *testing.T) {
+			dir := t.TempDir()
+			ca := certPEM
+			cert := certPEM
+			key := keyPEM
+			tooLarge := make([]byte, safefile.MaxSize+1)
+			switch tc.file {
+			case "ca":
+				ca = tooLarge
+			case "cert":
+				cert = tooLarge
+			case "key":
+				key = tooLarge
+			}
+
+			_, err := NewTLSConfig(TLSConfig{
+				TLSCA:   writeTLSFile(t, dir, "ca.pem", ca),
+				TLSCert: writeTLSFile(t, dir, "cert.pem", cert),
+				TLSKey:  writeTLSFile(t, dir, "key.pem", key),
+			})
+
+			require.ErrorIs(t, err, ErrTLSFile)
+			require.ErrorIs(t, err, safefile.ErrFile)
+			require.ErrorIs(t, err, safefile.ErrTooLarge)
+		})
+	}
+
+	t.Run("rejects a non-regular TLS file", func(t *testing.T) {
+		_, err := NewTLSConfig(TLSConfig{TLSCA: t.TempDir()})
+
+		require.ErrorIs(t, err, ErrTLSFile)
+		require.ErrorIs(t, err, safefile.ErrFile)
+		require.ErrorIs(t, err, safefile.ErrNotRegular)
+	})
+
+	t.Run("classifies invalid PEM as a TLS file error", func(t *testing.T) {
+		path := writeTLSFile(t, t.TempDir(), "ca.pem", []byte("not PEM"))
+
+		_, err := NewTLSConfig(TLSConfig{TLSCA: path})
+
+		require.ErrorIs(t, err, ErrTLSFile)
+		require.NotErrorIs(t, err, safefile.ErrFile)
+	})
+}
+
+func newTestKeyPair(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}
+
+func writeTLSFile(t *testing.T, dir, name string, value []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, value, 0o600))
+	return path
+}
+
+func padToLimit(t *testing.T, value []byte) []byte {
+	t.Helper()
+	require.LessOrEqual(t, int64(len(value)), safefile.MaxSize)
+	out := make([]byte, safefile.MaxSize)
+	copy(out, value)
+	for i := len(value); i < len(out); i++ {
+		out[i] = ' '
+	}
+	return out
 }

--- a/src/go/pkg/tlscfg/config_test.go
+++ b/src/go/pkg/tlscfg/config_test.go
@@ -21,105 +21,110 @@ import (
 
 func TestNewTLSConfig(t *testing.T) {
 	certPEM, keyPEM := newTestKeyPair(t)
-
-	t.Run("returns nil when TLS is not configured", func(t *testing.T) {
-		cfg, err := NewTLSConfig(TLSConfig{})
-
-		require.NoError(t, err)
-		require.Nil(t, cfg)
-	})
-
-	t.Run("loads a CA and client keypair", func(t *testing.T) {
-		dir := t.TempDir()
-		caPath := writeTLSFile(t, dir, "ca.pem", certPEM)
-		certPath := writeTLSFile(t, dir, "cert.pem", certPEM)
-		keyPath := writeTLSFile(t, dir, "key.pem", keyPEM)
-
-		cfg, err := NewTLSConfig(TLSConfig{
-			TLSCA:   caPath,
-			TLSCert: certPath,
-			TLSKey:  keyPath,
-		})
-
-		require.NoError(t, err)
-		require.NotNil(t, cfg.RootCAs)
-		require.Len(t, cfg.Certificates, 1)
-	})
-
-	for _, tc := range []struct {
-		name string
-		file string
+	tooLarge := make([]byte, safefile.MaxSize+1)
+	caAtLimit := padToLimit(t, certPEM)
+	certAtLimit := padToLimit(t, certPEM)
+	keyAtLimit := padToLimit(t, keyPEM)
+	tests := map[string]struct {
+		config           func(t *testing.T) TLSConfig
+		wantNil          bool
+		wantRootCAs      bool
+		wantCertificates int
+		wantErrs         []error
+		wantNotErrs      []error
 	}{
-		{name: "CA", file: "ca"},
-		{name: "certificate", file: "cert"},
-		{name: "key", file: "key"},
-	} {
-		t.Run("accepts "+tc.name+" at the limit", func(t *testing.T) {
-			dir := t.TempDir()
-			ca := certPEM
-			cert := certPEM
-			key := keyPEM
-			switch tc.file {
-			case "ca":
-				ca = padToLimit(t, ca)
-			case "cert":
-				cert = padToLimit(t, cert)
-			case "key":
-				key = padToLimit(t, key)
-			}
-
-			_, err := NewTLSConfig(TLSConfig{
-				TLSCA:   writeTLSFile(t, dir, "ca.pem", ca),
-				TLSCert: writeTLSFile(t, dir, "cert.pem", cert),
-				TLSKey:  writeTLSFile(t, dir, "key.pem", key),
-			})
-
-			require.NoError(t, err)
-		})
-
-		t.Run("rejects "+tc.name+" over the limit", func(t *testing.T) {
-			dir := t.TempDir()
-			ca := certPEM
-			cert := certPEM
-			key := keyPEM
-			tooLarge := make([]byte, safefile.MaxSize+1)
-			switch tc.file {
-			case "ca":
-				ca = tooLarge
-			case "cert":
-				cert = tooLarge
-			case "key":
-				key = tooLarge
-			}
-
-			_, err := NewTLSConfig(TLSConfig{
-				TLSCA:   writeTLSFile(t, dir, "ca.pem", ca),
-				TLSCert: writeTLSFile(t, dir, "cert.pem", cert),
-				TLSKey:  writeTLSFile(t, dir, "key.pem", key),
-			})
-
-			require.ErrorIs(t, err, ErrTLSFile)
-			require.ErrorIs(t, err, safefile.ErrFile)
-			require.ErrorIs(t, err, safefile.ErrTooLarge)
-		})
+		"returns nil when TLS is not configured": {
+			config:  func(*testing.T) TLSConfig { return TLSConfig{} },
+			wantNil: true,
+		},
+		"loads a CA and client keypair": {
+			config: func(t *testing.T) TLSConfig {
+				return newTLSFilesConfig(t, certPEM, keyPEM, "", nil)
+			},
+			wantRootCAs:      true,
+			wantCertificates: 1,
+		},
+		"accepts CA at the limit": {
+			config: func(t *testing.T) TLSConfig {
+				return newTLSFilesConfig(t, certPEM, keyPEM, "ca", caAtLimit)
+			},
+			wantRootCAs:      true,
+			wantCertificates: 1,
+		},
+		"accepts certificate at the limit": {
+			config: func(t *testing.T) TLSConfig {
+				return newTLSFilesConfig(t, certPEM, keyPEM, "cert", certAtLimit)
+			},
+			wantRootCAs:      true,
+			wantCertificates: 1,
+		},
+		"accepts key at the limit": {
+			config: func(t *testing.T) TLSConfig {
+				return newTLSFilesConfig(t, certPEM, keyPEM, "key", keyAtLimit)
+			},
+			wantRootCAs:      true,
+			wantCertificates: 1,
+		},
+		"rejects CA over the limit": {
+			config: func(t *testing.T) TLSConfig {
+				return newTLSFilesConfig(t, certPEM, keyPEM, "ca", tooLarge)
+			},
+			wantErrs: []error{ErrTLSFile, safefile.ErrFile, safefile.ErrTooLarge},
+		},
+		"rejects certificate over the limit": {
+			config: func(t *testing.T) TLSConfig {
+				return newTLSFilesConfig(t, certPEM, keyPEM, "cert", tooLarge)
+			},
+			wantErrs: []error{ErrTLSFile, safefile.ErrFile, safefile.ErrTooLarge},
+		},
+		"rejects key over the limit": {
+			config: func(t *testing.T) TLSConfig {
+				return newTLSFilesConfig(t, certPEM, keyPEM, "key", tooLarge)
+			},
+			wantErrs: []error{ErrTLSFile, safefile.ErrFile, safefile.ErrTooLarge},
+		},
+		"rejects a non-regular TLS file": {
+			config: func(t *testing.T) TLSConfig {
+				return TLSConfig{TLSCA: t.TempDir()}
+			},
+			wantErrs: []error{ErrTLSFile, safefile.ErrFile, safefile.ErrNotRegular},
+		},
+		"classifies invalid PEM as a TLS file error": {
+			config: func(t *testing.T) TLSConfig {
+				path := writeTLSFile(t, t.TempDir(), "ca.pem", []byte("not PEM"))
+				return TLSConfig{TLSCA: path}
+			},
+			wantErrs:    []error{ErrTLSFile},
+			wantNotErrs: []error{safefile.ErrFile},
+		},
 	}
 
-	t.Run("rejects a non-regular TLS file", func(t *testing.T) {
-		_, err := NewTLSConfig(TLSConfig{TLSCA: t.TempDir()})
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := NewTLSConfig(tc.config(t))
 
-		require.ErrorIs(t, err, ErrTLSFile)
-		require.ErrorIs(t, err, safefile.ErrFile)
-		require.ErrorIs(t, err, safefile.ErrNotRegular)
-	})
-
-	t.Run("classifies invalid PEM as a TLS file error", func(t *testing.T) {
-		path := writeTLSFile(t, t.TempDir(), "ca.pem", []byte("not PEM"))
-
-		_, err := NewTLSConfig(TLSConfig{TLSCA: path})
-
-		require.ErrorIs(t, err, ErrTLSFile)
-		require.NotErrorIs(t, err, safefile.ErrFile)
-	})
+			if len(tc.wantErrs) > 0 {
+				require.Error(t, err)
+				for _, wantErr := range tc.wantErrs {
+					require.ErrorIs(t, err, wantErr)
+				}
+				for _, notErr := range tc.wantNotErrs {
+					require.NotErrorIs(t, err, notErr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			if tc.wantNil {
+				require.Nil(t, cfg)
+				return
+			}
+			require.NotNil(t, cfg)
+			if tc.wantRootCAs {
+				require.NotNil(t, cfg.RootCAs)
+			}
+			require.Len(t, cfg.Certificates, tc.wantCertificates)
+		})
+	}
 }
 
 func newTestKeyPair(t *testing.T) ([]byte, []byte) {
@@ -150,6 +155,27 @@ func writeTLSFile(t *testing.T, dir, name string, value []byte) string {
 	path := filepath.Join(dir, name)
 	require.NoError(t, os.WriteFile(path, value, 0o600))
 	return path
+}
+
+func newTLSFilesConfig(t *testing.T, certPEM, keyPEM []byte, override string, value []byte) TLSConfig {
+	t.Helper()
+	ca := certPEM
+	cert := certPEM
+	key := keyPEM
+	switch override {
+	case "ca":
+		ca = value
+	case "cert":
+		cert = value
+	case "key":
+		key = value
+	}
+	dir := t.TempDir()
+	return TLSConfig{
+		TLSCA:   writeTLSFile(t, dir, "ca.pem", ca),
+		TLSCert: writeTLSFile(t, dir, "cert.pem", cert),
+		TLSKey:  writeTLSFile(t, dir, "key.pem", key),
+	}
 }
 
 func padToLimit(t *testing.T, value []byte) []byte {

--- a/src/go/pkg/web/request_config.go
+++ b/src/go/pkg/web/request_config.go
@@ -4,8 +4,10 @@ package web
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net/http"
 	"net/url"
@@ -121,8 +123,8 @@ func setAuthentication(req *http.Request, cfg RequestConfig) error {
 func setBearerTokenAuth(req *http.Request, tokenFile string) error {
 	tokenBs, err := safefile.Read(tokenFile)
 	if err != nil {
-		// Ignore K8s service account token errors when running outside the cluster
-		if strings.HasPrefix(tokenFile, "/var/run/secrets/") && !hostinfo.IsInsideK8sCluster() {
+		// A missing mounted service-account token is optional outside Kubernetes.
+		if isOptionalK8sTokenFileError(tokenFile, hostinfo.IsInsideK8sCluster(), err) {
 			return nil
 		}
 		return fmt.Errorf("bearer token file: %w", err)
@@ -135,6 +137,12 @@ func setBearerTokenAuth(req *http.Request, tokenFile string) error {
 
 	req.Header.Set("Authorization", "Bearer "+token)
 	return nil
+}
+
+func isOptionalK8sTokenFileError(tokenFile string, insideK8s bool, err error) bool {
+	return !insideK8s &&
+		strings.HasPrefix(tokenFile, "/var/run/secrets/") &&
+		errors.Is(err, fs.ErrNotExist)
 }
 
 // NewHTTPRequestWithPath creates a new HTTP request with the given path appended to the base URL.

--- a/src/go/pkg/web/request_config.go
+++ b/src/go/pkg/web/request_config.go
@@ -9,12 +9,12 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
 	"github.com/netdata/netdata/go/plugins/pkg/executable"
 	"github.com/netdata/netdata/go/plugins/pkg/hostinfo"
+	"github.com/netdata/netdata/go/plugins/pkg/safefile"
 )
 
 // RequestConfig is the configuration of the HTTP request.
@@ -119,7 +119,7 @@ func setAuthentication(req *http.Request, cfg RequestConfig) error {
 }
 
 func setBearerTokenAuth(req *http.Request, tokenFile string) error {
-	tokenBs, err := os.ReadFile(tokenFile)
+	tokenBs, err := safefile.Read(tokenFile)
 	if err != nil {
 		// Ignore K8s service account token errors when running outside the cluster
 		if strings.HasPrefix(tokenFile, "/var/run/secrets/") && !hostinfo.IsInsideK8sCluster() {

--- a/src/go/pkg/web/request_config_test.go
+++ b/src/go/pkg/web/request_config_test.go
@@ -282,44 +282,52 @@ func TestNewHTTPRequest(t *testing.T) {
 }
 
 func TestBearerTokenFileBounds(t *testing.T) {
-	t.Run("accepts a regular file at the limit", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "token")
-		token := strings.Repeat("t", int(safefile.MaxSize))
-		require.NoError(t, os.WriteFile(path, []byte(token), 0o600))
+	token := strings.Repeat("t", int(safefile.MaxSize))
+	tests := map[string]struct {
+		prepare  func(t *testing.T) string
+		wantAuth string
+		wantErrs []error
+	}{
+		"accepts a regular file at the limit": {
+			prepare: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "token")
+				require.NoError(t, os.WriteFile(path, []byte(token), 0o600))
+				return path
+			},
+			wantAuth: "Bearer " + token,
+		},
+		"rejects a regular file over the limit": {
+			prepare: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "token")
+				require.NoError(t, os.WriteFile(path, make([]byte, safefile.MaxSize+1), 0o600))
+				return path
+			},
+			wantErrs: []error{safefile.ErrFile, safefile.ErrTooLarge},
+		},
+		"rejects a non-regular opened object": {
+			prepare:  func(t *testing.T) string { return t.TempDir() },
+			wantErrs: []error{safefile.ErrFile, safefile.ErrNotRegular},
+		},
+	}
 
-		req, err := NewHTTPRequest(RequestConfig{
-			URL:             "http://example.com",
-			BearerTokenFile: path,
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			req, err := NewHTTPRequest(RequestConfig{
+				URL:             "http://example.com",
+				BearerTokenFile: tc.prepare(t),
+			})
+
+			if len(tc.wantErrs) > 0 {
+				require.Error(t, err)
+				for _, wantErr := range tc.wantErrs {
+					require.ErrorIs(t, err, wantErr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantAuth, req.Header.Get("Authorization"))
 		})
-
-		require.NoError(t, err)
-		require.Equal(t, "Bearer "+token, req.Header.Get("Authorization"))
-	})
-
-	t.Run("rejects a regular file over the limit", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "token")
-		require.NoError(t, os.WriteFile(path, make([]byte, safefile.MaxSize+1), 0o600))
-
-		_, err := NewHTTPRequest(RequestConfig{
-			URL:             "http://example.com",
-			BearerTokenFile: path,
-		})
-
-		require.ErrorIs(t, err, safefile.ErrFile)
-		require.ErrorIs(t, err, safefile.ErrTooLarge)
-	})
-
-	t.Run("rejects a non-regular opened object", func(t *testing.T) {
-		path := t.TempDir()
-
-		_, err := NewHTTPRequest(RequestConfig{
-			URL:             "http://example.com",
-			BearerTokenFile: path,
-		})
-
-		require.ErrorIs(t, err, safefile.ErrFile)
-		require.ErrorIs(t, err, safefile.ErrNotRegular)
-	})
+	}
 }
 
 func TestBearerTokenFileOutsideK8sSuppression(t *testing.T) {

--- a/src/go/pkg/web/request_config_test.go
+++ b/src/go/pkg/web/request_config_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/pkg/hostinfo"
+	"github.com/netdata/netdata/go/plugins/pkg/safefile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +31,7 @@ func TestRequest_Copy(t *testing.T) {
 					"X-Api-Key": "secret",
 				},
 				Username:      "username",
-				Password:      "password",
+				Password:      "test-password",
 				ProxyUsername: "proxy_username",
 				ProxyPassword: "proxy_password",
 			},
@@ -92,7 +94,7 @@ func TestNewHTTPRequest(t *testing.T) {
 	// Create a temporary file for bearer token test
 	tmpDir := t.TempDir()
 	bearerTokenFile := filepath.Join(tmpDir, "token")
-	err := os.WriteFile(bearerTokenFile, []byte("test-bearer-token"), 0644)
+	err := os.WriteFile(bearerTokenFile, []byte("test-token"), 0o644)
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -159,7 +161,7 @@ func TestNewHTTPRequest(t *testing.T) {
 			},
 			validate: func(t *testing.T, req *http.Request, cfg RequestConfig) {
 				auth := req.Header.Get("Authorization")
-				assert.Equal(t, "Bearer test-bearer-token", auth)
+				assert.Equal(t, "Bearer test-token", auth)
 			},
 		},
 		"bearer token file not found": {
@@ -180,7 +182,7 @@ func TestNewHTTPRequest(t *testing.T) {
 			validate: func(t *testing.T, req *http.Request, cfg RequestConfig) {
 				// Should have bearer token, not basic auth
 				auth := req.Header.Get("Authorization")
-				assert.Equal(t, "Bearer test-bearer-token", auth)
+				assert.Equal(t, "Bearer test-token", auth)
 
 				// Basic auth should not be set
 				_, _, ok := req.BasicAuth()
@@ -277,6 +279,61 @@ func TestNewHTTPRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBearerTokenFileBounds(t *testing.T) {
+	t.Run("accepts a regular file at the limit", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token")
+		token := strings.Repeat("t", int(safefile.MaxSize))
+		require.NoError(t, os.WriteFile(path, []byte(token), 0o600))
+
+		req, err := NewHTTPRequest(RequestConfig{
+			URL:             "http://example.com",
+			BearerTokenFile: path,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "Bearer "+token, req.Header.Get("Authorization"))
+	})
+
+	t.Run("rejects a regular file over the limit", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(path, make([]byte, safefile.MaxSize+1), 0o600))
+
+		_, err := NewHTTPRequest(RequestConfig{
+			URL:             "http://example.com",
+			BearerTokenFile: path,
+		})
+
+		require.ErrorIs(t, err, safefile.ErrFile)
+		require.ErrorIs(t, err, safefile.ErrTooLarge)
+	})
+
+	t.Run("rejects a non-regular opened object", func(t *testing.T) {
+		path := t.TempDir()
+
+		_, err := NewHTTPRequest(RequestConfig{
+			URL:             "http://example.com",
+			BearerTokenFile: path,
+		})
+
+		require.ErrorIs(t, err, safefile.ErrFile)
+		require.ErrorIs(t, err, safefile.ErrNotRegular)
+	})
+}
+
+func TestBearerTokenFileOutsideK8sSuppression(t *testing.T) {
+	if hostinfo.IsInsideK8sCluster() {
+		t.Skip("suppression applies only outside Kubernetes")
+	}
+
+	req, err := NewHTTPRequest(RequestConfig{
+		URL:             "http://example.com",
+		BearerTokenFile: "/var/run/secrets/netdata-test-missing-token",
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, req.Header.Get("Authorization"))
 }
 
 func TestNewHTTPRequestWithPath(t *testing.T) {

--- a/src/go/pkg/web/request_config_test.go
+++ b/src/go/pkg/web/request_config_test.go
@@ -336,6 +336,47 @@ func TestBearerTokenFileOutsideK8sSuppression(t *testing.T) {
 	require.Empty(t, req.Header.Get("Authorization"))
 }
 
+func TestOptionalK8sTokenFileError(t *testing.T) {
+	tests := map[string]struct {
+		path      string
+		insideK8s bool
+		err       error
+		want      bool
+	}{
+		"missing secret outside Kubernetes": {
+			path: "/var/run/secrets/netdata-test-missing-token",
+			err:  os.ErrNotExist,
+			want: true,
+		},
+		"missing secret inside Kubernetes": {
+			path:      "/var/run/secrets/netdata-test-missing-token",
+			insideK8s: true,
+			err:       os.ErrNotExist,
+		},
+		"missing file outside the secrets directory": {
+			path: "/tmp/netdata-test-missing-token",
+			err:  os.ErrNotExist,
+		},
+		"permission failure": {
+			path: "/var/run/secrets/netdata-test-token",
+			err:  os.ErrPermission,
+		},
+		"oversized file": {
+			path: "/var/run/secrets/netdata-test-token",
+			err:  safefile.ErrTooLarge,
+		},
+		"non-regular file": {
+			path: "/var/run/secrets/netdata-test-token",
+			err:  safefile.ErrNotRegular,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, isOptionalK8sTokenFileError(tc.path, tc.insideK8s, tc.err))
+		})
+	}
+}
+
 func TestNewHTTPRequestWithPath(t *testing.T) {
 	tests := map[string]struct {
 		config  RequestConfig

--- a/src/go/plugin/agent/discovery/sd/pipeline/pipeline.go
+++ b/src/go/plugin/agent/discovery/sd/pipeline/pipeline.go
@@ -109,6 +109,10 @@ func (p *Pipeline) Test(ctx context.Context) (bool, error) {
 		if cause := context.Cause(ctx); cause != nil {
 			return false, cause
 		}
+		if errors.Is(err, dyncfg.ErrTestUnsupported) {
+			fullyTested = false
+			continue
+		}
 		if err != nil {
 			return false, fmt.Errorf("discoverer operational test: %w", err)
 		}

--- a/src/go/plugin/agent/discovery/sd/pipeline/pipeline_test.go
+++ b/src/go/plugin/agent/discovery/sd/pipeline/pipeline_test.go
@@ -111,6 +111,36 @@ func TestPipeline_Test(t *testing.T) {
 		require.Equal(t, []string{"capable"}, calls)
 	})
 
+	t.Run("continues after a configured discoverer does not support a test", func(t *testing.T) {
+		var calls []string
+		p := &Pipeline{discoverers: []model.Discoverer{
+			&pipelineTestDiscoverer{name: "unsupported", calls: &calls, err: dyncfg.ErrTestUnsupported},
+			&pipelineTestDiscoverer{name: "capable", calls: &calls},
+		}}
+
+		fullyTested, err := p.Test(t.Context())
+
+		require.NoError(t, err)
+		require.False(t, fullyTested)
+		require.Equal(t, []string{"unsupported", "capable"}, calls)
+	})
+
+	t.Run("does not hide a later operational failure after an unsupported test", func(t *testing.T) {
+		testErr := errors.New("unavailable")
+		var calls []string
+		p := &Pipeline{discoverers: []model.Discoverer{
+			&pipelineTestDiscoverer{name: "unsupported", calls: &calls, err: dyncfg.ErrTestUnsupported},
+			&pipelineTestDiscoverer{name: "failure", calls: &calls, err: testErr},
+		}}
+
+		fullyTested, err := p.Test(t.Context())
+
+		require.False(t, fullyTested)
+		require.ErrorIs(t, err, testErr)
+		require.NotErrorIs(t, err, dyncfg.ErrTestUnsupported)
+		require.Equal(t, []string{"unsupported", "failure"}, calls)
+	})
+
 	t.Run("stops at the first operational failure", func(t *testing.T) {
 		testErr := errors.New("unavailable")
 		var calls []string
@@ -169,6 +199,29 @@ func TestPipeline_Test(t *testing.T) {
 		require.NotErrorIs(t, err, resourceErr)
 		_, hasPublicMessage := dyncfg.PublicMessage(err)
 		require.False(t, hasPublicMessage)
+		require.Equal(t, []string{"first"}, calls)
+	})
+
+	t.Run("caller cancellation wins an unsupported result", func(t *testing.T) {
+		cancelCause := errors.New("test request superseded")
+		ctx, cancel := context.WithCancelCause(t.Context())
+		var calls []string
+		p := &Pipeline{discoverers: []model.Discoverer{
+			&pipelineTestDiscoverer{
+				name:  "first",
+				calls: &calls,
+				test: func(context.Context) error {
+					cancel(cancelCause)
+					return dyncfg.ErrTestUnsupported
+				},
+			},
+		}}
+
+		fullyTested, err := p.Test(ctx)
+
+		require.False(t, fullyTested)
+		require.ErrorIs(t, err, cancelCause)
+		require.NotErrorIs(t, err, dyncfg.ErrTestUnsupported)
 		require.Equal(t, []string{"first"}, calls)
 	})
 }

--- a/src/go/plugin/agent/discovery/sd/pipeline/pipeline_test.go
+++ b/src/go/plugin/agent/discovery/sd/pipeline/pipeline_test.go
@@ -83,147 +83,143 @@ func TestNew(t *testing.T) {
 }
 
 func TestPipeline_Test(t *testing.T) {
-	t.Run("tests capable discoverers sequentially", func(t *testing.T) {
-		var calls []string
-		p := &Pipeline{discoverers: []model.Discoverer{
-			&pipelineTestDiscoverer{name: "first", calls: &calls},
-			&pipelineTestDiscoverer{name: "second", calls: &calls},
-		}}
-
-		fullyTested, err := p.Test(t.Context())
-
-		require.NoError(t, err)
-		require.True(t, fullyTested)
-		require.Equal(t, []string{"first", "second"}, calls)
-	})
-
-	t.Run("reports validation only when a discoverer has no test", func(t *testing.T) {
-		var calls []string
-		p := &Pipeline{discoverers: []model.Discoverer{
-			newMockDiscoverer("", newMockTargetGroup("test")),
-			&pipelineTestDiscoverer{name: "capable", calls: &calls},
-		}}
-
-		fullyTested, err := p.Test(t.Context())
-
-		require.NoError(t, err)
-		require.False(t, fullyTested)
-		require.Equal(t, []string{"capable"}, calls)
-	})
-
-	t.Run("continues after a configured discoverer does not support a test", func(t *testing.T) {
-		var calls []string
-		p := &Pipeline{discoverers: []model.Discoverer{
-			&pipelineTestDiscoverer{name: "unsupported", calls: &calls, err: dyncfg.ErrTestUnsupported},
-			&pipelineTestDiscoverer{name: "capable", calls: &calls},
-		}}
-
-		fullyTested, err := p.Test(t.Context())
-
-		require.NoError(t, err)
-		require.False(t, fullyTested)
-		require.Equal(t, []string{"unsupported", "capable"}, calls)
-	})
-
-	t.Run("does not hide a later operational failure after an unsupported test", func(t *testing.T) {
-		testErr := errors.New("unavailable")
-		var calls []string
-		p := &Pipeline{discoverers: []model.Discoverer{
-			&pipelineTestDiscoverer{name: "unsupported", calls: &calls, err: dyncfg.ErrTestUnsupported},
-			&pipelineTestDiscoverer{name: "failure", calls: &calls, err: testErr},
-		}}
-
-		fullyTested, err := p.Test(t.Context())
-
-		require.False(t, fullyTested)
-		require.ErrorIs(t, err, testErr)
-		require.NotErrorIs(t, err, dyncfg.ErrTestUnsupported)
-		require.Equal(t, []string{"unsupported", "failure"}, calls)
-	})
-
-	t.Run("stops at the first operational failure", func(t *testing.T) {
-		testErr := errors.New("unavailable")
-		var calls []string
-		p := &Pipeline{discoverers: []model.Discoverer{
-			&pipelineTestDiscoverer{name: "first", calls: &calls},
-			&pipelineTestDiscoverer{name: "second", calls: &calls, err: testErr},
-			&pipelineTestDiscoverer{name: "third", calls: &calls},
-		}}
-
-		fullyTested, err := p.Test(t.Context())
-
-		require.False(t, fullyTested)
-		require.ErrorIs(t, err, testErr)
-		require.Equal(t, []string{"first", "second"}, calls)
-	})
-
-	t.Run("honors caller cancellation before testing", func(t *testing.T) {
-		cancelCause := errors.New("test request superseded")
-		ctx, cancel := context.WithCancelCause(t.Context())
-		cancel(cancelCause)
-		var calls []string
-		p := &Pipeline{discoverers: []model.Discoverer{
-			&pipelineTestDiscoverer{name: "first", calls: &calls},
-		}}
-
-		fullyTested, err := p.Test(ctx)
-
-		require.False(t, fullyTested)
-		require.ErrorIs(t, err, cancelCause)
-		require.Empty(t, calls)
-	})
-
-	t.Run("caller cancellation wins a resource operational failure", func(t *testing.T) {
-		cancelCause := errors.New("test request superseded")
-		resourceErr := dyncfg.NewPublicError(
-			"resource operation timed out",
-			context.DeadlineExceeded,
-		)
-		ctx, cancel := context.WithCancelCause(t.Context())
-		var calls []string
-		p := &Pipeline{discoverers: []model.Discoverer{
-			&pipelineTestDiscoverer{
-				name:  "first",
-				calls: &calls,
-				test: func(context.Context) error {
-					cancel(cancelCause)
-					return resourceErr
-				},
+	cancelCause := errors.New("test request superseded")
+	testErr := errors.New("unavailable")
+	resourceErr := dyncfg.NewPublicError(
+		"resource operation timed out",
+		context.DeadlineExceeded,
+	)
+	tests := map[string]struct {
+		build               func(t *testing.T, calls *[]string) (context.Context, []model.Discoverer)
+		wantFullyTested     bool
+		wantErr             error
+		wantNotErr          error
+		wantCalls           []string
+		wantNoPublicMessage bool
+	}{
+		"tests capable discoverers sequentially": {
+			build: func(t *testing.T, calls *[]string) (context.Context, []model.Discoverer) {
+				return t.Context(), []model.Discoverer{
+					&pipelineTestDiscoverer{name: "first", calls: calls},
+					&pipelineTestDiscoverer{name: "second", calls: calls},
+				}
 			},
-		}}
-
-		fullyTested, err := p.Test(ctx)
-
-		require.False(t, fullyTested)
-		require.ErrorIs(t, err, cancelCause)
-		require.NotErrorIs(t, err, resourceErr)
-		_, hasPublicMessage := dyncfg.PublicMessage(err)
-		require.False(t, hasPublicMessage)
-		require.Equal(t, []string{"first"}, calls)
-	})
-
-	t.Run("caller cancellation wins an unsupported result", func(t *testing.T) {
-		cancelCause := errors.New("test request superseded")
-		ctx, cancel := context.WithCancelCause(t.Context())
-		var calls []string
-		p := &Pipeline{discoverers: []model.Discoverer{
-			&pipelineTestDiscoverer{
-				name:  "first",
-				calls: &calls,
-				test: func(context.Context) error {
-					cancel(cancelCause)
-					return dyncfg.ErrTestUnsupported
-				},
+			wantFullyTested: true,
+			wantCalls:       []string{"first", "second"},
+		},
+		"reports validation only when a discoverer has no test": {
+			build: func(t *testing.T, calls *[]string) (context.Context, []model.Discoverer) {
+				return t.Context(), []model.Discoverer{
+					newMockDiscoverer("", newMockTargetGroup("test")),
+					&pipelineTestDiscoverer{name: "capable", calls: calls},
+				}
 			},
-		}}
+			wantCalls: []string{"capable"},
+		},
+		"continues after a configured discoverer does not support a test": {
+			build: func(t *testing.T, calls *[]string) (context.Context, []model.Discoverer) {
+				return t.Context(), []model.Discoverer{
+					&pipelineTestDiscoverer{name: "unsupported", calls: calls, err: dyncfg.ErrTestUnsupported},
+					&pipelineTestDiscoverer{name: "capable", calls: calls},
+				}
+			},
+			wantCalls: []string{"unsupported", "capable"},
+		},
+		"does not hide a later operational failure after an unsupported test": {
+			build: func(t *testing.T, calls *[]string) (context.Context, []model.Discoverer) {
+				return t.Context(), []model.Discoverer{
+					&pipelineTestDiscoverer{name: "unsupported", calls: calls, err: dyncfg.ErrTestUnsupported},
+					&pipelineTestDiscoverer{name: "failure", calls: calls, err: testErr},
+				}
+			},
+			wantErr:    testErr,
+			wantNotErr: dyncfg.ErrTestUnsupported,
+			wantCalls:  []string{"unsupported", "failure"},
+		},
+		"stops at the first operational failure": {
+			build: func(t *testing.T, calls *[]string) (context.Context, []model.Discoverer) {
+				return t.Context(), []model.Discoverer{
+					&pipelineTestDiscoverer{name: "first", calls: calls},
+					&pipelineTestDiscoverer{name: "second", calls: calls, err: testErr},
+					&pipelineTestDiscoverer{name: "third", calls: calls},
+				}
+			},
+			wantErr:   testErr,
+			wantCalls: []string{"first", "second"},
+		},
+		"honors caller cancellation before testing": {
+			build: func(t *testing.T, calls *[]string) (context.Context, []model.Discoverer) {
+				ctx, cancel := context.WithCancelCause(t.Context())
+				cancel(cancelCause)
+				return ctx, []model.Discoverer{
+					&pipelineTestDiscoverer{name: "first", calls: calls},
+				}
+			},
+			wantErr: cancelCause,
+		},
+		"caller cancellation wins a resource operational failure": {
+			build: func(t *testing.T, calls *[]string) (context.Context, []model.Discoverer) {
+				ctx, cancel := context.WithCancelCause(t.Context())
+				return ctx, []model.Discoverer{
+					&pipelineTestDiscoverer{
+						name:  "first",
+						calls: calls,
+						test: func(context.Context) error {
+							cancel(cancelCause)
+							return resourceErr
+						},
+					},
+				}
+			},
+			wantErr:             cancelCause,
+			wantNotErr:          resourceErr,
+			wantCalls:           []string{"first"},
+			wantNoPublicMessage: true,
+		},
+		"caller cancellation wins an unsupported result": {
+			build: func(t *testing.T, calls *[]string) (context.Context, []model.Discoverer) {
+				ctx, cancel := context.WithCancelCause(t.Context())
+				return ctx, []model.Discoverer{
+					&pipelineTestDiscoverer{
+						name:  "first",
+						calls: calls,
+						test: func(context.Context) error {
+							cancel(cancelCause)
+							return dyncfg.ErrTestUnsupported
+						},
+					},
+				}
+			},
+			wantErr:    cancelCause,
+			wantNotErr: dyncfg.ErrTestUnsupported,
+			wantCalls:  []string{"first"},
+		},
+	}
 
-		fullyTested, err := p.Test(ctx)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var calls []string
+			ctx, discoverers := tc.build(t, &calls)
+			p := &Pipeline{discoverers: discoverers}
 
-		require.False(t, fullyTested)
-		require.ErrorIs(t, err, cancelCause)
-		require.NotErrorIs(t, err, dyncfg.ErrTestUnsupported)
-		require.Equal(t, []string{"first"}, calls)
-	})
+			fullyTested, err := p.Test(ctx)
+
+			require.Equal(t, tc.wantFullyTested, fullyTested)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+			if tc.wantNotErr != nil {
+				require.NotErrorIs(t, err, tc.wantNotErr)
+			}
+			if tc.wantNoPublicMessage {
+				_, hasPublicMessage := dyncfg.PublicMessage(err)
+				require.False(t, hasPublicMessage)
+			}
+			require.Equal(t, tc.wantCalls, calls)
+		})
+	}
 }
 
 func TestPipeline_Run(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -896,6 +896,9 @@ manager accepts only an already-prepared pipeline through `StartPrepared`/`Resta
   capability. After each callback returns, the shared Pipeline Test boundary makes the caller's cancellation cause take
   precedence over the discoverer result. Discoverers classify their configured timeouts but need not repeat caller
   cancellation checks.
+- A Testable discoverer can return `dyncfg.ErrTestUnsupported` when the resource type has an operational test but the
+  configured instance cannot run it safely. The pipeline continues testing later discoverers and reports the aggregate
+  as validation-only; the sentinel does not turn real failures into success.
 - Resource-authored parsing, construction, and operational failures retain their causes internally but cross one
   sanitized response/diagnostic boundary. Unmarked failures render only their generic phase. A `dyncfg.PublicError`
   may add static, code-authored detail; its public message must never derive from submitted/resolved values, endpoints,
@@ -904,10 +907,12 @@ manager accepts only an already-prepared pipeline through `StartPrepared`/`Resta
 - A discoverer without the capability produces an explicit validation-only success. Configuration/construction
   failures return 400, operational failures return 422, and busy/contained attempts return 503.
 - Operational guarantees are discoverer-specific. Docker performs a one-item container-list query. `net_listeners`
-  executes and parses one production helper snapshot, then discards the targets without rule rendering, cache
-  reconciliation, publication, or installation. Its process count and elapsed time are bounded to one invocation and the
-  caller/configured timeout; work and buffered output still scale with the host socket/process inventory. Other shipped
-  discoverers currently remain validation-only.
+  executes and parses one production helper snapshot. HTTP performs one production fetch only for empty/default or exact
+  `GET`: it uses the configured request/client path, requires HTTP 200, enforces the 10 MiB response limit, and parses all
+  targets. Redirect handling permits at most ten actual requests. These tests discard targets without rule rendering,
+  cache reconciliation, publication, or installation. A non-empty HTTP method other than exact `GET`, plus Kubernetes
+  and SNMP, remains validation-only. Local-listener process count and elapsed time are bounded to one invocation and the
+  caller/configured timeout; its work and buffered output still scale with the host socket/process inventory.
 - File-backed stock/user state keeps one latest pending retry after a busy/contained result; synchronous DynCfg
   commands do not.
 - The complete service-discovery DynCfg Function is also contained, so a non-cooperative command cannot pin the

--- a/src/go/plugin/agent/secrets/secretstore/mutation.go
+++ b/src/go/plugin/agent/secrets/secretstore/mutation.go
@@ -185,6 +185,9 @@ func (store *SecretStore) Test(
 	if cause := context.Cause(ctx); cause != nil {
 		return true, cause
 	}
+	if errors.Is(err, dyncfg.ErrTestUnsupported) {
+		return false, nil
+	}
 	if err != nil {
 		return true, err
 	}

--- a/src/go/plugin/agent/secrets/secretstore/test_capability_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/test_capability_test.go
@@ -15,156 +15,148 @@ import (
 )
 
 func TestSecretStoreTestCapability(t *testing.T) {
-	t.Run("validation does not run the operational test", func(t *testing.T) {
-		state := &testCapabilityState{}
-		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
-			return &testCapableStore{state: state}
-		})
+	cancelCause := errors.New("test request superseded")
+	testErr := errors.New("provider unavailable")
+	initErr := errors.New("provider initialization failed")
+	providerErr := dyncfg.NewPublicError(
+		"provider operation timed out",
+		context.DeadlineExceeded,
+	)
+	tests := map[string]struct {
+		validationOnly      bool
+		validateFirst       bool
+		storeErr            error
+		initErr             error
+		testResult          error
+		cancelBefore        bool
+		cancelDuringInit    bool
+		cancelDuringTest    bool
+		wantTested          bool
+		wantErr             error
+		wantNotErr          error
+		wantCalls           int
+		wantValue           string
+		wantNoCreates       bool
+		wantNoPublicMessage bool
+	}{
+		"validation does not run the operational test": {
+			validateFirst: true,
+			wantTested:    true,
+			wantCalls:     1,
+			wantValue:     "configured",
+		},
+		"reports validation only for a Store without the capability": {
+			validationOnly: true,
+		},
+		"reports validation only when the configured Store does not support a test": {
+			storeErr:  dyncfg.ErrTestUnsupported,
+			wantCalls: 1,
+			wantValue: "configured",
+		},
+		"returns an operational failure as a tested result": {
+			storeErr:   testErr,
+			wantTested: true,
+			wantErr:    testErr,
+			wantCalls:  1,
+			wantValue:  "configured",
+		},
+		"rejects an already-canceled request before Store creation": {
+			validationOnly: true,
+			cancelBefore:   true,
+			wantErr:        cancelCause,
+			wantNoCreates:  true,
+		},
+		"caller cancellation wins a Store initialization failure": {
+			initErr:          initErr,
+			cancelDuringInit: true,
+			wantErr:          cancelCause,
+			wantNotErr:       initErr,
+		},
+		"caller cancellation wins a provider operational failure": {
+			testResult:          providerErr,
+			cancelDuringTest:    true,
+			wantTested:          true,
+			wantErr:             cancelCause,
+			wantNotErr:          providerErr,
+			wantCalls:           1,
+			wantValue:           "configured",
+			wantNoPublicMessage: true,
+		},
+		"caller cancellation wins an unsupported result": {
+			testResult:       dyncfg.ErrTestUnsupported,
+			cancelDuringTest: true,
+			wantTested:       true,
+			wantErr:          cancelCause,
+			wantNotErr:       dyncfg.ErrTestUnsupported,
+			wantCalls:        1,
+			wantValue:        "configured",
+		},
+	}
 
-		require.NoError(t, store.Validate(t.Context(), catalog, testCapabilityConfig()))
-		require.Zero(t, state.calls)
-
-		tested, err := store.Test(t.Context(), catalog, testCapabilityConfig())
-		require.NoError(t, err)
-		require.True(t, tested)
-		require.Equal(t, 1, state.calls)
-		require.Equal(t, "configured", state.value)
-		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
-	})
-
-	t.Run("reports validation only for a Store without the capability", func(t *testing.T) {
-		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
-			return &testValidationOnlyStore{}
-		})
-
-		tested, err := store.Test(t.Context(), catalog, testCapabilityConfig())
-
-		require.NoError(t, err)
-		require.False(t, tested)
-		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
-	})
-
-	t.Run("reports validation only when the configured Store does not support a test", func(t *testing.T) {
-		state := &testCapabilityState{err: dyncfg.ErrTestUnsupported}
-		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
-			return &testCapableStore{state: state}
-		})
-
-		tested, err := store.Test(t.Context(), catalog, testCapabilityConfig())
-
-		require.NoError(t, err)
-		require.False(t, tested)
-		require.Equal(t, 1, state.calls)
-		require.Equal(t, "configured", state.value)
-		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
-	})
-
-	t.Run("returns an operational failure as a tested result", func(t *testing.T) {
-		testErr := errors.New("provider unavailable")
-		state := &testCapabilityState{err: testErr}
-		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
-			return &testCapableStore{state: state}
-		})
-
-		tested, err := store.Test(t.Context(), catalog, testCapabilityConfig())
-
-		require.True(t, tested)
-		require.ErrorIs(t, err, testErr)
-		require.Equal(t, 1, state.calls)
-		require.Equal(t, "configured", state.value)
-		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
-	})
-
-	t.Run("rejects an already-canceled request before Store creation", func(t *testing.T) {
-		cancelCause := errors.New("test request superseded")
-		var creates int
-		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
-			creates++
-			return &testValidationOnlyStore{}
-		})
-		ctx, cancel := context.WithCancelCause(t.Context())
-		cancel(cancelCause)
-
-		tested, err := store.Test(ctx, catalog, testCapabilityConfig())
-
-		require.False(t, tested)
-		require.ErrorIs(t, err, cancelCause)
-		require.Zero(t, creates)
-		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
-	})
-
-	t.Run("caller cancellation wins a Store initialization failure", func(t *testing.T) {
-		cancelCause := errors.New("test request superseded")
-		initErr := errors.New("provider initialization failed")
-		ctx, cancel := context.WithCancelCause(t.Context())
-		state := &testCapabilityState{
-			init: func(context.Context) error {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			var cancel context.CancelCauseFunc
+			if tc.cancelBefore || tc.cancelDuringInit || tc.cancelDuringTest {
+				ctx, cancel = context.WithCancelCause(ctx)
+				defer cancel(nil)
+			}
+			state := &testCapabilityState{err: tc.storeErr}
+			if tc.initErr != nil {
+				state.init = func(context.Context) error {
+					if tc.cancelDuringInit {
+						cancel(cancelCause)
+					}
+					return tc.initErr
+				}
+			}
+			if tc.testResult != nil {
+				state.test = func(context.Context) error {
+					if tc.cancelDuringTest {
+						cancel(cancelCause)
+					}
+					return tc.testResult
+				}
+			}
+			var creates int
+			store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
+				creates++
+				if tc.validationOnly {
+					return &testValidationOnlyStore{}
+				}
+				return &testCapableStore{state: state}
+			})
+			if tc.validateFirst {
+				require.NoError(t, store.Validate(ctx, catalog, testCapabilityConfig()))
+				require.Zero(t, state.calls)
+			}
+			if tc.cancelBefore {
 				cancel(cancelCause)
-				return initErr
-			},
-		}
-		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
-			return &testCapableStore{state: state}
+			}
+
+			tested, err := store.Test(ctx, catalog, testCapabilityConfig())
+
+			require.Equal(t, tc.wantTested, tested)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+			if tc.wantNotErr != nil {
+				require.NotErrorIs(t, err, tc.wantNotErr)
+			}
+			if tc.wantNoPublicMessage {
+				_, hasPublicMessage := dyncfg.PublicMessage(err)
+				require.False(t, hasPublicMessage)
+			}
+			require.Equal(t, tc.wantCalls, state.calls)
+			require.Equal(t, tc.wantValue, state.value)
+			if tc.wantNoCreates {
+				require.Zero(t, creates)
+			}
+			require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
 		})
-
-		tested, err := store.Test(ctx, catalog, testCapabilityConfig())
-
-		require.False(t, tested)
-		require.ErrorIs(t, err, cancelCause)
-		require.NotErrorIs(t, err, initErr)
-		require.Zero(t, state.calls)
-		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
-	})
-
-	t.Run("caller cancellation wins a provider operational failure", func(t *testing.T) {
-		cancelCause := errors.New("test request superseded")
-		providerErr := dyncfg.NewPublicError(
-			"provider operation timed out",
-			context.DeadlineExceeded,
-		)
-		ctx, cancel := context.WithCancelCause(t.Context())
-		state := &testCapabilityState{
-			test: func(context.Context) error {
-				cancel(cancelCause)
-				return providerErr
-			},
-		}
-		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
-			return &testCapableStore{state: state}
-		})
-
-		tested, err := store.Test(ctx, catalog, testCapabilityConfig())
-
-		require.True(t, tested)
-		require.ErrorIs(t, err, cancelCause)
-		require.NotErrorIs(t, err, providerErr)
-		_, hasPublicMessage := dyncfg.PublicMessage(err)
-		require.False(t, hasPublicMessage)
-		require.Equal(t, 1, state.calls)
-		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
-	})
-
-	t.Run("caller cancellation wins an unsupported result", func(t *testing.T) {
-		cancelCause := errors.New("test request superseded")
-		ctx, cancel := context.WithCancelCause(t.Context())
-		state := &testCapabilityState{
-			test: func(context.Context) error {
-				cancel(cancelCause)
-				return dyncfg.ErrTestUnsupported
-			},
-		}
-		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
-			return &testCapableStore{state: state}
-		})
-
-		tested, err := store.Test(ctx, catalog, testCapabilityConfig())
-
-		require.True(t, tested)
-		require.ErrorIs(t, err, cancelCause)
-		require.NotErrorIs(t, err, dyncfg.ErrTestUnsupported)
-		require.Equal(t, 1, state.calls)
-		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
-	})
+	}
 }
 
 func newTestCapabilityAuthority(

--- a/src/go/plugin/agent/secrets/secretstore/test_capability_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/test_capability_test.go
@@ -44,6 +44,21 @@ func TestSecretStoreTestCapability(t *testing.T) {
 		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
 	})
 
+	t.Run("reports validation only when the configured Store does not support a test", func(t *testing.T) {
+		state := &testCapabilityState{err: dyncfg.ErrTestUnsupported}
+		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
+			return &testCapableStore{state: state}
+		})
+
+		tested, err := store.Test(t.Context(), catalog, testCapabilityConfig())
+
+		require.NoError(t, err)
+		require.False(t, tested)
+		require.Equal(t, 1, state.calls)
+		require.Equal(t, "configured", state.value)
+		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
+	})
+
 	t.Run("returns an operational failure as a tested result", func(t *testing.T) {
 		testErr := errors.New("provider unavailable")
 		state := &testCapabilityState{err: testErr}
@@ -125,6 +140,28 @@ func TestSecretStoreTestCapability(t *testing.T) {
 		require.NotErrorIs(t, err, providerErr)
 		_, hasPublicMessage := dyncfg.PublicMessage(err)
 		require.False(t, hasPublicMessage)
+		require.Equal(t, 1, state.calls)
+		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
+	})
+
+	t.Run("caller cancellation wins an unsupported result", func(t *testing.T) {
+		cancelCause := errors.New("test request superseded")
+		ctx, cancel := context.WithCancelCause(t.Context())
+		state := &testCapabilityState{
+			test: func(context.Context) error {
+				cancel(cancelCause)
+				return dyncfg.ErrTestUnsupported
+			},
+		}
+		store, catalog := newTestCapabilityAuthority(t, func() secretstore.Store {
+			return &testCapableStore{state: state}
+		})
+
+		tested, err := store.Test(ctx, catalog, testCapabilityConfig())
+
+		require.True(t, tested)
+		require.ErrorIs(t, err, cancelCause)
+		require.NotErrorIs(t, err, dyncfg.ErrTestUnsupported)
 		require.Equal(t, 1, state.calls)
 		require.Equal(t, secretstore.SecretStoreCensus{}, store.Census())
 	})

--- a/src/go/plugin/framework/dyncfg/dyncfg.go
+++ b/src/go/plugin/framework/dyncfg/dyncfg.go
@@ -55,8 +55,8 @@ const (
 // They must return failures for caller-side sanitization instead of logging raw
 // user configuration, credentials, or endpoint material. NewPublicError may
 // attach a static, code-authored explanation that is safe to render publicly.
-// ErrTestUnsupported reports that a valid configured instance cannot safely
-// perform an operational test.
+// Test may return ErrTestUnsupported when a valid configured instance cannot
+// safely perform an operational test.
 type Testable interface {
 	Test(ctx context.Context) error
 }

--- a/src/go/plugin/framework/dyncfg/dyncfg.go
+++ b/src/go/plugin/framework/dyncfg/dyncfg.go
@@ -55,9 +55,15 @@ const (
 // They must return failures for caller-side sanitization instead of logging raw
 // user configuration, credentials, or endpoint material. NewPublicError may
 // attach a static, code-authored explanation that is safe to render publicly.
+// ErrTestUnsupported reports that a valid configured instance cannot safely
+// perform an operational test.
 type Testable interface {
 	Test(ctx context.Context) error
 }
+
+// ErrTestUnsupported reports that a Testable resource cannot safely run an
+// operational test for the configured instance.
+var ErrTestUnsupported = errors.New("operational test is not supported")
 
 func JoinCommands(commands ...Command) string {
 	strs := make([]string, len(commands))

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/discoverer.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/discoverer.go
@@ -12,13 +12,22 @@ import (
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/pkg/safefile"
+	"github.com/netdata/netdata/go/plugins/pkg/tlscfg"
 	"github.com/netdata/netdata/go/plugins/pkg/web"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 )
 
 const (
 	shortName = "http"
 	fullName  = "sd:http"
+
+	publicErrRequest = "the configured HTTP discovery request could not be created"
+	publicErrTimeout = "the configured HTTP endpoint did not respond before the timeout"
+	publicErrQuery   = "cannot query the configured HTTP endpoint"
+	publicErrData    = "the configured HTTP endpoint did not return usable discovery data"
+	publicErrFile    = "the configured HTTP credential or TLS file could not be read safely"
 )
 
 func NewDiscoverer(cfg Config) (*Discoverer, error) {
@@ -28,6 +37,9 @@ func NewDiscoverer(cfg Config) (*Discoverer, error) {
 
 	client, err := web.NewHTTPClient(cfg.clientConfig())
 	if err != nil {
+		if errors.Is(err, tlscfg.ErrTLSFile) || errors.Is(err, safefile.ErrFile) {
+			return nil, dyncfg.NewPublicError(publicErrFile, err)
+		}
 		return nil, err
 	}
 
@@ -60,6 +72,42 @@ type Discoverer struct {
 
 func (d *Discoverer) String() string {
 	return fullName
+}
+
+func (d *Discoverer) Test(ctx context.Context) error {
+	if d == nil || ctx == nil {
+		return errors.New("invalid HTTP discovery test")
+	}
+	if d.request.Method != "" && d.request.Method != http.MethodGet {
+		return dyncfg.ErrTestUnsupported
+	}
+
+	defer d.client.CloseIdleConnections()
+
+	_, err := d.fetchTargetGroup(ctx)
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, safefile.ErrFile), errors.Is(err, tlscfg.ErrTLSFile):
+		return dyncfg.NewPublicError(publicErrFile, err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return dyncfg.NewPublicError(publicErrTimeout, err)
+	}
+
+	var fetchErr *fetchError
+	if errors.As(err, &fetchErr) {
+		switch fetchErr.phase {
+		case fetchPhaseRequest:
+			return dyncfg.NewPublicError(publicErrRequest, err)
+		case fetchPhaseQuery:
+			return dyncfg.NewPublicError(publicErrQuery, err)
+		case fetchPhaseResponse:
+			return dyncfg.NewPublicError(publicErrData, err)
+		}
+	}
+	return dyncfg.NewPublicError(publicErrQuery, err)
 }
 
 func (d *Discoverer) Discover(ctx context.Context, in chan<- []model.TargetGroup) {
@@ -101,42 +149,70 @@ func (d *Discoverer) discover(ctx context.Context, in chan<- []model.TargetGroup
 func (d *Discoverer) fetchTargetGroup(ctx context.Context) (model.TargetGroup, error) {
 	req, err := web.NewHTTPRequest(d.request)
 	if err != nil {
-		return nil, fmt.Errorf("create HTTP request: %w", err)
+		return nil, newFetchError(fetchPhaseRequest, fmt.Errorf("create HTTP request: %w", err))
 	}
 	req = req.WithContext(ctx)
 	safeURL := sanitizedURL(req.URL.String())
 
 	resp, err := d.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("HTTP request to %q failed: %w", safeURL, err)
+		return nil, newFetchError(fetchPhaseQuery, fmt.Errorf("HTTP request to %q failed: %w", safeURL, err))
 	}
 	if resp.Body != nil {
 		defer func() { _ = resp.Body.Close() }()
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s %q returned HTTP status code: %d", req.Method, safeURL, resp.StatusCode)
+		return nil, newFetchError(
+			fetchPhaseQuery,
+			fmt.Errorf("%s %q returned HTTP status code: %d", req.Method, safeURL, resp.StatusCode),
+		)
 	}
 
 	bs, err := readResponseBody(resp.Body, responseBodyLimit)
 	if err != nil {
-		return nil, fmt.Errorf("read response from %q: %w", safeURL, err)
+		return nil, newFetchError(fetchPhaseResponse, fmt.Errorf("read response from %q: %w", safeURL, err))
 	}
 
 	items, err := d.parser.parse(bs, resp.Header.Get("Content-Type"))
 	if err != nil {
-		return nil, fmt.Errorf("parse response from %q: %w", safeURL, err)
+		return nil, newFetchError(fetchPhaseResponse, fmt.Errorf("parse response from %q: %w", safeURL, err))
 	}
 
 	targets, err := targetsFromItems(d.source, items)
 	if err != nil {
-		return nil, err
+		return nil, newFetchError(fetchPhaseResponse, err)
 	}
 
 	return &targetGroup{
 		source:  d.source,
 		targets: targets,
 	}, nil
+}
+
+type fetchPhase uint8
+
+const (
+	fetchPhaseRequest fetchPhase = iota + 1
+	fetchPhaseQuery
+	fetchPhaseResponse
+)
+
+type fetchError struct {
+	phase fetchPhase
+	err   error
+}
+
+func newFetchError(phase fetchPhase, err error) error {
+	return &fetchError{phase: phase, err: err}
+}
+
+func (e *fetchError) Error() string {
+	return e.err.Error()
+}
+
+func (e *fetchError) Unwrap() error {
+	return e.err
 }
 
 func readResponseBody(r io.Reader, maxBytes int64) ([]byte, error) {

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/integrations/http.md
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/integrations/http.md
@@ -41,8 +41,10 @@ Each discovery cycle, the discoverer:
 
 - Only **one URL per pipeline**. To pull from multiple sources, configure multiple HTTP discovery pipelines (each as its own UI entry, or split the file into one job per source).
 - **Response size** is capped at 10 MiB.
+- A DynCfg **test** performs one complete fetch only when `method` is empty/default or exactly `GET`. It uses the configured authentication, headers, TLS, proxy, redirects, and timeout; requires HTTP 200; and parses every returned item. Redirects can make up to 10 HTTP requests. The test discards the targets without evaluating `services:` rules or creating jobs. Other configured methods are intentionally validation-only.
 - **One-shot mode** (`interval: 0`) fetches a single time when the pipeline starts. It does **not** refetch on SD reload — recreate the pipeline to refresh.
 - **`bearer_token_file`** under `/var/run/secrets/` is treated as optional when Netdata is **not** running in Kubernetes (so the same config can be used in a Helm deployment without erroring out on dev hosts).
+- Bearer-token, TLS CA, TLS certificate, and TLS key files must resolve to regular files no larger than 1 MiB. Symlinks to regular files are supported.
 - The discoverer does not introspect the items it received — anything beyond what the upstream endpoint provides must be inferred via service rules.
 
 
@@ -107,7 +109,7 @@ With `auto`, the decoder uses `Content-Type` when it is unambiguous (`applicatio
 <a id="option-headers-username-password-bearer-token-file-proxy-url-tls-skip-verify-etc"></a>
 ##### headers / username / password / bearer_token_file / proxy_url / tls_skip_verify / etc.
 
-See any go.d HTTP-based collector (`httpcheck`, `prometheus`, `nginx`, …) for the full set. Notable: when `bearer_token_file` points under `/var/run/secrets/` and Netdata is **not** running inside Kubernetes, missing token files are silently ignored.
+See any go.d HTTP-based collector (`httpcheck`, `prometheus`, `nginx`, …) for the full set. Bearer-token, TLS CA, TLS certificate, and TLS key paths must resolve to regular files no larger than 1 MiB; symlinks to regular files are supported. When `bearer_token_file` points under `/var/run/secrets/` and Netdata is **not** running inside Kubernetes, missing token files are silently ignored.
 
 
 
@@ -305,6 +307,13 @@ Your endpoint mixes shapes — some items target `httpcheck`, some target `prome
 ## Verify discovery worked
 
 After enabling the discoverer, confirm the endpoint is reachable and items are being parsed.
+
+### Test a UI-managed configuration
+
+DynCfg test performs one complete production fetch for an empty/default or exact `GET` method. Success proves that the request could be built, the configured auth/TLS/proxy/redirect path worked at that instant, the endpoint returned HTTP 200 with at most 10 MiB, and every item parsed into a target.
+
+The fetched targets are discarded: the test does not evaluate `services:` rules, render or validate collector jobs, publish targets, or install jobs. Non-GET methods are intentionally reported as validation-only because executing them could mutate the endpoint.
+
 
 ### Confirm the endpoint is being fetched
 

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/integrations/http.md
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/integrations/http.md
@@ -44,7 +44,7 @@ Each discovery cycle, the discoverer:
 - A DynCfg **test** performs one complete fetch only when `method` is empty/default or exactly `GET`. It uses the configured authentication, headers, TLS, proxy, redirects, and timeout; requires HTTP 200; and parses every returned item. Redirects can make up to 10 HTTP requests. The test discards the targets without evaluating `services:` rules or creating jobs. Other configured methods are intentionally validation-only.
 - **One-shot mode** (`interval: 0`) fetches a single time when the pipeline starts. It does **not** refetch on SD reload — recreate the pipeline to refresh.
 - A missing **`bearer_token_file`** under `/var/run/secrets/` is treated as optional when Netdata is **not** running in Kubernetes (so the same config can be used in a Helm deployment without erroring out on dev hosts).
-- Bearer-token and TLS CA files must resolve to regular files no larger than 1 MiB. When both `tls_cert` and `tls_key` are configured, each file has the same requirement. Symlinks to regular files are supported.
+- Configured bearer-token and TLS files have [file-safety requirements](#option-headers-username-password-bearer-token-file-proxy-url-tls-skip-verify-etc).
 - The discoverer does not introspect the items it received — anything beyond what the upstream endpoint provides must be inferred via service rules.
 
 

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/integrations/http.md
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/integrations/http.md
@@ -43,8 +43,8 @@ Each discovery cycle, the discoverer:
 - **Response size** is capped at 10 MiB.
 - A DynCfg **test** performs one complete fetch only when `method` is empty/default or exactly `GET`. It uses the configured authentication, headers, TLS, proxy, redirects, and timeout; requires HTTP 200; and parses every returned item. Redirects can make up to 10 HTTP requests. The test discards the targets without evaluating `services:` rules or creating jobs. Other configured methods are intentionally validation-only.
 - **One-shot mode** (`interval: 0`) fetches a single time when the pipeline starts. It does **not** refetch on SD reload — recreate the pipeline to refresh.
-- **`bearer_token_file`** under `/var/run/secrets/` is treated as optional when Netdata is **not** running in Kubernetes (so the same config can be used in a Helm deployment without erroring out on dev hosts).
-- Bearer-token, TLS CA, TLS certificate, and TLS key files must resolve to regular files no larger than 1 MiB. Symlinks to regular files are supported.
+- A missing **`bearer_token_file`** under `/var/run/secrets/` is treated as optional when Netdata is **not** running in Kubernetes (so the same config can be used in a Helm deployment without erroring out on dev hosts).
+- Bearer-token and TLS CA files must resolve to regular files no larger than 1 MiB. When both `tls_cert` and `tls_key` are configured, each file has the same requirement. Symlinks to regular files are supported.
 - The discoverer does not introspect the items it received — anything beyond what the upstream endpoint provides must be inferred via service rules.
 
 
@@ -109,7 +109,7 @@ With `auto`, the decoder uses `Content-Type` when it is unambiguous (`applicatio
 <a id="option-headers-username-password-bearer-token-file-proxy-url-tls-skip-verify-etc"></a>
 ##### headers / username / password / bearer_token_file / proxy_url / tls_skip_verify / etc.
 
-See any go.d HTTP-based collector (`httpcheck`, `prometheus`, `nginx`, …) for the full set. Bearer-token, TLS CA, TLS certificate, and TLS key paths must resolve to regular files no larger than 1 MiB; symlinks to regular files are supported. When `bearer_token_file` points under `/var/run/secrets/` and Netdata is **not** running inside Kubernetes, missing token files are silently ignored.
+See any go.d HTTP-based collector (`httpcheck`, `prometheus`, `nginx`, …) for the full set. Bearer-token and TLS CA paths must resolve to regular files no larger than 1 MiB. When both `tls_cert` and `tls_key` are configured, each path has the same requirement. Symlinks to regular files are supported. When `bearer_token_file` points under `/var/run/secrets/` and Netdata is **not** running inside Kubernetes, a missing token file is silently ignored.
 
 
 

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/metadata.yaml
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/metadata.yaml
@@ -31,8 +31,10 @@ overview:
   limitations: |
     - Only **one URL per pipeline**. To pull from multiple sources, configure multiple HTTP discovery pipelines (each as its own UI entry, or split the file into one job per source).
     - **Response size** is capped at 10 MiB.
+    - A DynCfg **test** performs one complete fetch only when `method` is empty/default or exactly `GET`. It uses the configured authentication, headers, TLS, proxy, redirects, and timeout; requires HTTP 200; and parses every returned item. Redirects can make up to 10 HTTP requests. The test discards the targets without evaluating `services:` rules or creating jobs. Other configured methods are intentionally validation-only.
     - **One-shot mode** (`interval: 0`) fetches a single time when the pipeline starts. It does **not** refetch on SD reload — recreate the pipeline to refresh.
     - **`bearer_token_file`** under `/var/run/secrets/` is treated as optional when Netdata is **not** running in Kubernetes (so the same config can be used in a Helm deployment without erroring out on dev hosts).
+    - Bearer-token, TLS CA, TLS certificate, and TLS key files must resolve to regular files no larger than 1 MiB. Symlinks to regular files are supported.
     - The discoverer does not introspect the items it received — anything beyond what the upstream endpoint provides must be inferred via service rules.
 setup:
   prerequisites:
@@ -83,7 +85,7 @@ setup:
           default_value: ''
           required: false
           detailed_description: |
-            See any go.d HTTP-based collector (`httpcheck`, `prometheus`, `nginx`, …) for the full set. Notable: when `bearer_token_file` points under `/var/run/secrets/` and Netdata is **not** running inside Kubernetes, missing token files are silently ignored.
+            See any go.d HTTP-based collector (`httpcheck`, `prometheus`, `nginx`, …) for the full set. Bearer-token, TLS CA, TLS certificate, and TLS key paths must resolve to regular files no larger than 1 MiB; symlinks to regular files are supported. When `bearer_token_file` points under `/var/run/secrets/` and Netdata is **not** running inside Kubernetes, missing token files are silently ignored.
     examples:
       folding:
         title: 'Configuration examples'
@@ -227,6 +229,11 @@ verify:
   description: 'After enabling the discoverer, confirm the endpoint is reachable and items are being parsed.'
   checks:
     list:
+      - name: 'Test a UI-managed configuration'
+        description: |
+          DynCfg test performs one complete production fetch for an empty/default or exact `GET` method. Success proves that the request could be built, the configured auth/TLS/proxy/redirect path worked at that instant, the endpoint returned HTTP 200 with at most 10 MiB, and every item parsed into a target.
+
+          The fetched targets are discarded: the test does not evaluate `services:` rules, render or validate collector jobs, publish targets, or install jobs. Non-GET methods are intentionally reported as validation-only because executing them could mutate the endpoint.
       - name: 'Confirm the endpoint is being fetched'
         description: |
           Watch the agent log for `discoverer=http` messages. With systemd:

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/metadata.yaml
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/metadata.yaml
@@ -33,8 +33,8 @@ overview:
     - **Response size** is capped at 10 MiB.
     - A DynCfg **test** performs one complete fetch only when `method` is empty/default or exactly `GET`. It uses the configured authentication, headers, TLS, proxy, redirects, and timeout; requires HTTP 200; and parses every returned item. Redirects can make up to 10 HTTP requests. The test discards the targets without evaluating `services:` rules or creating jobs. Other configured methods are intentionally validation-only.
     - **One-shot mode** (`interval: 0`) fetches a single time when the pipeline starts. It does **not** refetch on SD reload — recreate the pipeline to refresh.
-    - **`bearer_token_file`** under `/var/run/secrets/` is treated as optional when Netdata is **not** running in Kubernetes (so the same config can be used in a Helm deployment without erroring out on dev hosts).
-    - Bearer-token, TLS CA, TLS certificate, and TLS key files must resolve to regular files no larger than 1 MiB. Symlinks to regular files are supported.
+    - A missing **`bearer_token_file`** under `/var/run/secrets/` is treated as optional when Netdata is **not** running in Kubernetes (so the same config can be used in a Helm deployment without erroring out on dev hosts).
+    - Bearer-token and TLS CA files must resolve to regular files no larger than 1 MiB. When both `tls_cert` and `tls_key` are configured, each file has the same requirement. Symlinks to regular files are supported.
     - The discoverer does not introspect the items it received — anything beyond what the upstream endpoint provides must be inferred via service rules.
 setup:
   prerequisites:
@@ -85,7 +85,7 @@ setup:
           default_value: ''
           required: false
           detailed_description: |
-            See any go.d HTTP-based collector (`httpcheck`, `prometheus`, `nginx`, …) for the full set. Bearer-token, TLS CA, TLS certificate, and TLS key paths must resolve to regular files no larger than 1 MiB; symlinks to regular files are supported. When `bearer_token_file` points under `/var/run/secrets/` and Netdata is **not** running inside Kubernetes, missing token files are silently ignored.
+            See any go.d HTTP-based collector (`httpcheck`, `prometheus`, `nginx`, …) for the full set. Bearer-token and TLS CA paths must resolve to regular files no larger than 1 MiB. When both `tls_cert` and `tls_key` are configured, each path has the same requirement. Symlinks to regular files are supported. When `bearer_token_file` points under `/var/run/secrets/` and Netdata is **not** running inside Kubernetes, a missing token file is silently ignored.
     examples:
       folding:
         title: 'Configuration examples'

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/metadata.yaml
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/metadata.yaml
@@ -34,7 +34,7 @@ overview:
     - A DynCfg **test** performs one complete fetch only when `method` is empty/default or exactly `GET`. It uses the configured authentication, headers, TLS, proxy, redirects, and timeout; requires HTTP 200; and parses every returned item. Redirects can make up to 10 HTTP requests. The test discards the targets without evaluating `services:` rules or creating jobs. Other configured methods are intentionally validation-only.
     - **One-shot mode** (`interval: 0`) fetches a single time when the pipeline starts. It does **not** refetch on SD reload — recreate the pipeline to refresh.
     - A missing **`bearer_token_file`** under `/var/run/secrets/` is treated as optional when Netdata is **not** running in Kubernetes (so the same config can be used in a Helm deployment without erroring out on dev hosts).
-    - Bearer-token and TLS CA files must resolve to regular files no larger than 1 MiB. When both `tls_cert` and `tls_key` are configured, each file has the same requirement. Symlinks to regular files are supported.
+    - Configured bearer-token and TLS files have [file-safety requirements](#option-headers-username-password-bearer-token-file-proxy-url-tls-skip-verify-etc).
     - The discoverer does not introspect the items it received — anything beyond what the upstream endpoint provides must be inferred via service rules.
 setup:
   prerequisites:

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/test_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/test_test.go
@@ -28,13 +28,24 @@ import (
 var _ dyncfg.Testable = (*Discoverer)(nil)
 
 func TestDiscovererTestUnsupportedMethodsDoNoOperationalWork(t *testing.T) {
-	for _, method := range []string{"get", http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, "CUSTOM"} {
-		t.Run(method, func(t *testing.T) {
+	tests := map[string]struct {
+		method string
+	}{
+		"lowercase GET": {method: "get"},
+		"POST":          {method: http.MethodPost},
+		"PUT":           {method: http.MethodPut},
+		"PATCH":         {method: http.MethodPatch},
+		"DELETE":        {method: http.MethodDelete},
+		"custom":        {method: "CUSTOM"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			d, err := NewDiscoverer(Config{
 				HTTPConfig: web.HTTPConfig{
 					RequestConfig: web.RequestConfig{
 						URL:             "http://127.0.0.1/discovery",
-						Method:          method,
+						Method:          tc.method,
 						BearerTokenFile: t.TempDir() + "/missing-token",
 					},
 				},
@@ -53,11 +64,14 @@ func TestDiscovererTestUnsupportedMethodsDoNoOperationalWork(t *testing.T) {
 }
 
 func TestDiscovererTestUsesConfiguredGETRequest(t *testing.T) {
-	for _, method := range []string{"", http.MethodGet} {
-		name := method
-		if name == "" {
-			name = "default"
-		}
+	tests := map[string]struct {
+		method string
+	}{
+		"default": {},
+		"GET":     {method: http.MethodGet},
+	}
+
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tokenFile := t.TempDir() + "/token"
 			require.NoError(t, os.WriteFile(tokenFile, []byte("test-token"), 0o600))
@@ -77,7 +91,7 @@ func TestDiscovererTestUsesConfiguredGETRequest(t *testing.T) {
 				HTTPConfig: web.HTTPConfig{
 					RequestConfig: web.RequestConfig{
 						URL:             srv.URL,
-						Method:          method,
+						Method:          tc.method,
 						BearerTokenFile: tokenFile,
 						Headers:         map[string]string{"X-Test": "test-value"},
 					},
@@ -92,206 +106,229 @@ func TestDiscovererTestUsesConfiguredGETRequest(t *testing.T) {
 }
 
 func TestDiscovererTestPublicErrors(t *testing.T) {
-	t.Run("request creation", func(t *testing.T) {
-		tokenFile := t.TempDir() + "/empty-token"
-		require.NoError(t, os.WriteFile(tokenFile, nil, 0o600))
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{
-				URL:             "http://127.0.0.1/discovery",
-				BearerTokenFile: tokenFile,
+	tests := map[string]struct {
+		run         func(t *testing.T) (error, []string)
+		wantMessage string
+		wantErrs    []error
+	}{
+		"request creation": {
+			run: func(t *testing.T) (error, []string) {
+				tokenFile := t.TempDir() + "/empty-token"
+				require.NoError(t, os.WriteFile(tokenFile, nil, 0o600))
+				d := newTestDiscoverer(t, web.HTTPConfig{
+					RequestConfig: web.RequestConfig{
+						URL:             "http://127.0.0.1/discovery",
+						BearerTokenFile: tokenFile,
+					},
+				})
+				return d.Test(t.Context()), nil
 			},
-		})
-
-		err := d.Test(t.Context())
-
-		requirePublicError(t, err, "the configured HTTP discovery request could not be created")
-	})
-
-	t.Run("credential file", func(t *testing.T) {
-		path := t.TempDir() + "/missing-token"
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{
-				URL:             "http://127.0.0.1/discovery",
-				BearerTokenFile: path,
+			wantMessage: "the configured HTTP discovery request could not be created",
+		},
+		"credential file": {
+			run: func(t *testing.T) (error, []string) {
+				path := t.TempDir() + "/missing-token"
+				d := newTestDiscoverer(t, web.HTTPConfig{
+					RequestConfig: web.RequestConfig{
+						URL:             "http://127.0.0.1/discovery",
+						BearerTokenFile: path,
+					},
+				})
+				return d.Test(t.Context()), []string{path}
 			},
-		})
-
-		err := d.Test(t.Context())
-
-		requirePublicError(t, err, "the configured HTTP credential or TLS file could not be read safely")
-		require.ErrorIs(t, err, safefile.ErrFile)
-		assert.NotContains(t, err.Error(), path)
-	})
-
-	t.Run("TLS file", func(t *testing.T) {
-		path := t.TempDir() + "/missing-ca"
-		_, err := NewDiscoverer(Config{
-			HTTPConfig: web.HTTPConfig{
-				RequestConfig: web.RequestConfig{URL: "https://127.0.0.1/discovery"},
-				ClientConfig: web.ClientConfig{
-					TLSConfig: tlscfg.TLSConfig{TLSCA: path},
-				},
+			wantMessage: "the configured HTTP credential or TLS file could not be read safely",
+			wantErrs:    []error{safefile.ErrFile},
+		},
+		"TLS file": {
+			run: func(t *testing.T) (error, []string) {
+				path := t.TempDir() + "/missing-ca"
+				_, err := NewDiscoverer(Config{
+					HTTPConfig: web.HTTPConfig{
+						RequestConfig: web.RequestConfig{URL: "https://127.0.0.1/discovery"},
+						ClientConfig: web.ClientConfig{
+							TLSConfig: tlscfg.TLSConfig{TLSCA: path},
+						},
+					},
+				})
+				return err, []string{path}
 			},
+			wantMessage: "the configured HTTP credential or TLS file could not be read safely",
+			wantErrs:    []error{tlscfg.ErrTLSFile, safefile.ErrFile},
+		},
+		"query": {
+			run: func(t *testing.T) (error, []string) {
+				d := newTestDiscoverer(t, web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://private.example.invalid/discovery"},
+				})
+				d.client.Transport = &testTransport{err: errors.New("private transport response")}
+				return d.Test(t.Context()), []string{"private"}
+			},
+			wantMessage: "cannot query the configured HTTP endpoint",
+		},
+		"status": {
+			run: func(t *testing.T) (error, []string) {
+				d := newTestDiscoverer(t, web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://private.example.invalid/discovery"},
+				})
+				d.client.Transport = &testTransport{
+					statusCode: http.StatusUnauthorized,
+					body:       "private response body",
+				}
+				return d.Test(t.Context()), []string{"private"}
+			},
+			wantMessage: "cannot query the configured HTTP endpoint",
+		},
+		"invalid response": {
+			run: func(t *testing.T) (error, []string) {
+				d := newTestDiscoverer(t, web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://private.example.invalid/discovery"},
+				})
+				d.client.Transport = &testTransport{
+					statusCode:  http.StatusOK,
+					contentType: "application/json",
+					body:        "[private invalid response",
+				}
+				return d.Test(t.Context()), []string{"private"}
+			},
+			wantMessage: "the configured HTTP endpoint did not return usable discovery data",
+		},
+		"oversized response": {
+			run: func(t *testing.T) (error, []string) {
+				d := newTestDiscoverer(t, web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://127.0.0.1/discovery"},
+				})
+				d.client.Transport = &testTransport{
+					statusCode: http.StatusOK,
+					body:       strings.Repeat("x", responseBodyLimit+1),
+				}
+				return d.Test(t.Context()), nil
+			},
+			wantMessage: "the configured HTTP endpoint did not return usable discovery data",
+		},
+		"configured timeout": {
+			run: func(t *testing.T) (error, []string) {
+				d := newTestDiscoverer(t, web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://127.0.0.1/discovery"},
+					ClientConfig:  web.ClientConfig{Timeout: confopt.Duration(20 * time.Millisecond)},
+				})
+				d.client.Transport = &testTransport{waitForContext: true}
+				return d.Test(t.Context()), nil
+			},
+			wantMessage: "the configured HTTP endpoint did not respond before the timeout",
+			wantErrs:    []error{context.DeadlineExceeded},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err, privateValues := tc.run(t)
+
+			requirePublicError(t, err, tc.wantMessage)
+			for _, wantErr := range tc.wantErrs {
+				require.ErrorIs(t, err, wantErr)
+			}
+			for _, privateValue := range privateValues {
+				assert.NotContains(t, err.Error(), privateValue)
+			}
 		})
-
-		requirePublicError(t, err, "the configured HTTP credential or TLS file could not be read safely")
-		require.ErrorIs(t, err, tlscfg.ErrTLSFile)
-		require.ErrorIs(t, err, safefile.ErrFile)
-		assert.NotContains(t, err.Error(), path)
-	})
-
-	t.Run("query", func(t *testing.T) {
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: "http://private.example.invalid/discovery"},
-		})
-		d.client.Transport = &testTransport{err: errors.New("private transport response")}
-
-		err := d.Test(t.Context())
-
-		requirePublicError(t, err, "cannot query the configured HTTP endpoint")
-		assert.NotContains(t, err.Error(), "private")
-	})
-
-	t.Run("status", func(t *testing.T) {
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: "http://private.example.invalid/discovery"},
-		})
-		d.client.Transport = &testTransport{
-			statusCode: http.StatusUnauthorized,
-			body:       "private response body",
-		}
-
-		err := d.Test(t.Context())
-
-		requirePublicError(t, err, "cannot query the configured HTTP endpoint")
-		assert.NotContains(t, err.Error(), "private")
-	})
-
-	t.Run("invalid response", func(t *testing.T) {
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: "http://private.example.invalid/discovery"},
-		})
-		d.client.Transport = &testTransport{
-			statusCode:  http.StatusOK,
-			contentType: "application/json",
-			body:        "[private invalid response",
-		}
-
-		err := d.Test(t.Context())
-
-		requirePublicError(t, err, "the configured HTTP endpoint did not return usable discovery data")
-		assert.NotContains(t, err.Error(), "private")
-	})
-
-	t.Run("oversized response", func(t *testing.T) {
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: "http://127.0.0.1/discovery"},
-		})
-		d.client.Transport = &testTransport{
-			statusCode: http.StatusOK,
-			body:       strings.Repeat("x", responseBodyLimit+1),
-		}
-
-		err := d.Test(t.Context())
-
-		requirePublicError(t, err, "the configured HTTP endpoint did not return usable discovery data")
-	})
-
-	t.Run("configured timeout", func(t *testing.T) {
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: "http://127.0.0.1/discovery"},
-			ClientConfig:  web.ClientConfig{Timeout: confopt.Duration(20 * time.Millisecond)},
-		})
-		d.client.Transport = &testTransport{waitForContext: true}
-
-		err := d.Test(t.Context())
-
-		requirePublicError(t, err, "the configured HTTP endpoint did not respond before the timeout")
-		require.ErrorIs(t, err, context.DeadlineExceeded)
-	})
+	}
 }
 
 func TestDiscovererTestUsesConfiguredTLSAndProxyPaths(t *testing.T) {
-	t.Run("TLS CA", func(t *testing.T) {
-		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprint(w, `[]`)
-		}))
-		defer srv.Close()
+	tests := map[string]struct {
+		run func(t *testing.T) error
+	}{
+		"TLS CA": {
+			run: func(t *testing.T) error {
+				srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = fmt.Fprint(w, `[]`)
+				}))
+				defer srv.Close()
 
-		caFile := t.TempDir() + "/ca.pem"
-		caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
-		require.NoError(t, os.WriteFile(caFile, caPEM, 0o600))
+				caFile := t.TempDir() + "/ca.pem"
+				caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+				require.NoError(t, os.WriteFile(caFile, caPEM, 0o600))
 
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: srv.URL},
-			ClientConfig: web.ClientConfig{
-				TLSConfig: tlscfg.TLSConfig{TLSCA: caFile},
+				d := newTestDiscoverer(t, web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: srv.URL},
+					ClientConfig: web.ClientConfig{
+						TLSConfig: tlscfg.TLSConfig{TLSCA: caFile},
+					},
+				})
+				return d.Test(t.Context())
 			},
+		},
+		"proxy": {
+			run: func(t *testing.T) error {
+				var requests atomic.Int64
+				proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					requests.Add(1)
+					assert.Equal(t, "origin.example.invalid", r.URL.Host)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = fmt.Fprint(w, `[]`)
+				}))
+				defer proxy.Close()
+
+				d := newTestDiscoverer(t, web.HTTPConfig{
+					RequestConfig: web.RequestConfig{URL: "http://origin.example.invalid/discovery"},
+					ClientConfig:  web.ClientConfig{ProxyURL: proxy.URL},
+				})
+				err := d.Test(t.Context())
+				assert.EqualValues(t, 1, requests.Load())
+				return err
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, tc.run(t))
 		})
-
-		require.NoError(t, d.Test(t.Context()))
-	})
-
-	t.Run("proxy", func(t *testing.T) {
-		var requests atomic.Int64
-		proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			requests.Add(1)
-			assert.Equal(t, "origin.example.invalid", r.URL.Host)
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprint(w, `[]`)
-		}))
-		defer proxy.Close()
-
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: "http://origin.example.invalid/discovery"},
-			ClientConfig:  web.ClientConfig{ProxyURL: proxy.URL},
-		})
-
-		require.NoError(t, d.Test(t.Context()))
-		assert.EqualValues(t, 1, requests.Load())
-	})
+	}
 }
 
 func TestDiscovererTestRedirectRequestBound(t *testing.T) {
-	t.Run("ten requests can succeed", func(t *testing.T) {
-		var requests atomic.Int64
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			n := requests.Add(1)
-			if n < 10 {
+	tests := map[string]struct {
+		successAt   int64
+		wantMessage string
+	}{
+		"ten requests can succeed": {
+			successAt: 10,
+		},
+		"eleventh request is not made": {
+			wantMessage: "cannot query the configured HTTP endpoint",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var requests atomic.Int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				n := requests.Add(1)
+				if tc.successAt > 0 && n >= tc.successAt {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = fmt.Fprint(w, `[]`)
+					return
+				}
 				http.Redirect(w, r, fmt.Sprintf("/%d", n), http.StatusFound)
-				return
+			}))
+			defer srv.Close()
+
+			d := newTestDiscoverer(t, web.HTTPConfig{
+				RequestConfig: web.RequestConfig{URL: srv.URL},
+			})
+
+			err := d.Test(t.Context())
+
+			if tc.wantMessage == "" {
+				require.NoError(t, err)
+			} else {
+				requirePublicError(t, err, tc.wantMessage)
 			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprint(w, `[]`)
-		}))
-		defer srv.Close()
-
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: srv.URL},
+			assert.EqualValues(t, 10, requests.Load())
 		})
-
-		require.NoError(t, d.Test(t.Context()))
-		assert.EqualValues(t, 10, requests.Load())
-	})
-
-	t.Run("eleventh request is not made", func(t *testing.T) {
-		var requests atomic.Int64
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			n := requests.Add(1)
-			http.Redirect(w, r, fmt.Sprintf("/%d", n), http.StatusFound)
-		}))
-		defer srv.Close()
-
-		d := newTestDiscoverer(t, web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: srv.URL},
-		})
-
-		err := d.Test(t.Context())
-
-		requirePublicError(t, err, "cannot query the configured HTTP endpoint")
-		assert.EqualValues(t, 10, requests.Load())
-	})
+	}
 }
 
 func TestDiscovererTestClosesResponseAndIdleConnections(t *testing.T) {

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/test_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/test_test.go
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package httpsd
+
+import (
+	"context"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/pkg/safefile"
+	"github.com/netdata/netdata/go/plugins/pkg/tlscfg"
+	"github.com/netdata/netdata/go/plugins/pkg/web"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ dyncfg.Testable = (*Discoverer)(nil)
+
+func TestDiscovererTestUnsupportedMethodsDoNoOperationalWork(t *testing.T) {
+	for _, method := range []string{"get", http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, "CUSTOM"} {
+		t.Run(method, func(t *testing.T) {
+			d, err := NewDiscoverer(Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{
+						URL:             "http://127.0.0.1/discovery",
+						Method:          method,
+						BearerTokenFile: t.TempDir() + "/missing-token",
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			transport := &testTransport{}
+			d.client.Transport = transport
+
+			err = d.Test(t.Context())
+
+			require.ErrorIs(t, err, dyncfg.ErrTestUnsupported)
+			assert.Zero(t, transport.roundTrips.Load())
+		})
+	}
+}
+
+func TestDiscovererTestUsesConfiguredGETRequest(t *testing.T) {
+	for _, method := range []string{"", http.MethodGet} {
+		name := method
+		if name == "" {
+			name = "default"
+		}
+		t.Run(name, func(t *testing.T) {
+			tokenFile := t.TempDir() + "/token"
+			require.NoError(t, os.WriteFile(tokenFile, []byte("test-token"), 0o600))
+
+			var requests atomic.Int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "test-value", r.Header.Get("X-Test"))
+				assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `[{"name":"api","url":"http://127.0.0.1"}]`)
+			}))
+			defer srv.Close()
+
+			d, err := NewDiscoverer(Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{
+						URL:             srv.URL,
+						Method:          method,
+						BearerTokenFile: tokenFile,
+						Headers:         map[string]string{"X-Test": "test-value"},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			require.NoError(t, d.Test(t.Context()))
+			assert.EqualValues(t, 1, requests.Load())
+		})
+	}
+}
+
+func TestDiscovererTestPublicErrors(t *testing.T) {
+	t.Run("request creation", func(t *testing.T) {
+		tokenFile := t.TempDir() + "/empty-token"
+		require.NoError(t, os.WriteFile(tokenFile, nil, 0o600))
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{
+				URL:             "http://127.0.0.1/discovery",
+				BearerTokenFile: tokenFile,
+			},
+		})
+
+		err := d.Test(t.Context())
+
+		requirePublicError(t, err, "the configured HTTP discovery request could not be created")
+	})
+
+	t.Run("credential file", func(t *testing.T) {
+		path := t.TempDir() + "/missing-token"
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{
+				URL:             "http://127.0.0.1/discovery",
+				BearerTokenFile: path,
+			},
+		})
+
+		err := d.Test(t.Context())
+
+		requirePublicError(t, err, "the configured HTTP credential or TLS file could not be read safely")
+		require.ErrorIs(t, err, safefile.ErrFile)
+		assert.NotContains(t, err.Error(), path)
+	})
+
+	t.Run("TLS file", func(t *testing.T) {
+		path := t.TempDir() + "/missing-ca"
+		_, err := NewDiscoverer(Config{
+			HTTPConfig: web.HTTPConfig{
+				RequestConfig: web.RequestConfig{URL: "https://127.0.0.1/discovery"},
+				ClientConfig: web.ClientConfig{
+					TLSConfig: tlscfg.TLSConfig{TLSCA: path},
+				},
+			},
+		})
+
+		requirePublicError(t, err, "the configured HTTP credential or TLS file could not be read safely")
+		require.ErrorIs(t, err, tlscfg.ErrTLSFile)
+		require.ErrorIs(t, err, safefile.ErrFile)
+		assert.NotContains(t, err.Error(), path)
+	})
+
+	t.Run("query", func(t *testing.T) {
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: "http://private.example.invalid/discovery"},
+		})
+		d.client.Transport = &testTransport{err: errors.New("private transport response")}
+
+		err := d.Test(t.Context())
+
+		requirePublicError(t, err, "cannot query the configured HTTP endpoint")
+		assert.NotContains(t, err.Error(), "private")
+	})
+
+	t.Run("status", func(t *testing.T) {
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: "http://private.example.invalid/discovery"},
+		})
+		d.client.Transport = &testTransport{
+			statusCode: http.StatusUnauthorized,
+			body:       "private response body",
+		}
+
+		err := d.Test(t.Context())
+
+		requirePublicError(t, err, "cannot query the configured HTTP endpoint")
+		assert.NotContains(t, err.Error(), "private")
+	})
+
+	t.Run("invalid response", func(t *testing.T) {
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: "http://private.example.invalid/discovery"},
+		})
+		d.client.Transport = &testTransport{
+			statusCode:  http.StatusOK,
+			contentType: "application/json",
+			body:        "[private invalid response",
+		}
+
+		err := d.Test(t.Context())
+
+		requirePublicError(t, err, "the configured HTTP endpoint did not return usable discovery data")
+		assert.NotContains(t, err.Error(), "private")
+	})
+
+	t.Run("oversized response", func(t *testing.T) {
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: "http://127.0.0.1/discovery"},
+		})
+		d.client.Transport = &testTransport{
+			statusCode: http.StatusOK,
+			body:       strings.Repeat("x", responseBodyLimit+1),
+		}
+
+		err := d.Test(t.Context())
+
+		requirePublicError(t, err, "the configured HTTP endpoint did not return usable discovery data")
+	})
+
+	t.Run("configured timeout", func(t *testing.T) {
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: "http://127.0.0.1/discovery"},
+			ClientConfig:  web.ClientConfig{Timeout: confopt.Duration(20 * time.Millisecond)},
+		})
+		d.client.Transport = &testTransport{waitForContext: true}
+
+		err := d.Test(t.Context())
+
+		requirePublicError(t, err, "the configured HTTP endpoint did not respond before the timeout")
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+}
+
+func TestDiscovererTestUsesConfiguredTLSAndProxyPaths(t *testing.T) {
+	t.Run("TLS CA", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		}))
+		defer srv.Close()
+
+		caFile := t.TempDir() + "/ca.pem"
+		caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+		require.NoError(t, os.WriteFile(caFile, caPEM, 0o600))
+
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: srv.URL},
+			ClientConfig: web.ClientConfig{
+				TLSConfig: tlscfg.TLSConfig{TLSCA: caFile},
+			},
+		})
+
+		require.NoError(t, d.Test(t.Context()))
+	})
+
+	t.Run("proxy", func(t *testing.T) {
+		var requests atomic.Int64
+		proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			assert.Equal(t, "origin.example.invalid", r.URL.Host)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		}))
+		defer proxy.Close()
+
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: "http://origin.example.invalid/discovery"},
+			ClientConfig:  web.ClientConfig{ProxyURL: proxy.URL},
+		})
+
+		require.NoError(t, d.Test(t.Context()))
+		assert.EqualValues(t, 1, requests.Load())
+	})
+}
+
+func TestDiscovererTestRedirectRequestBound(t *testing.T) {
+	t.Run("ten requests can succeed", func(t *testing.T) {
+		var requests atomic.Int64
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := requests.Add(1)
+			if n < 10 {
+				http.Redirect(w, r, fmt.Sprintf("/%d", n), http.StatusFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		}))
+		defer srv.Close()
+
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: srv.URL},
+		})
+
+		require.NoError(t, d.Test(t.Context()))
+		assert.EqualValues(t, 10, requests.Load())
+	})
+
+	t.Run("eleventh request is not made", func(t *testing.T) {
+		var requests atomic.Int64
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := requests.Add(1)
+			http.Redirect(w, r, fmt.Sprintf("/%d", n), http.StatusFound)
+		}))
+		defer srv.Close()
+
+		d := newTestDiscoverer(t, web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: srv.URL},
+		})
+
+		err := d.Test(t.Context())
+
+		requirePublicError(t, err, "cannot query the configured HTTP endpoint")
+		assert.EqualValues(t, 10, requests.Load())
+	})
+}
+
+func TestDiscovererTestClosesResponseAndIdleConnections(t *testing.T) {
+	body := &testBody{Reader: strings.NewReader("[]")}
+	transport := &testTransport{
+		statusCode:   http.StatusOK,
+		contentType:  "application/json",
+		responseBody: body,
+	}
+	d := newTestDiscoverer(t, web.HTTPConfig{
+		RequestConfig: web.RequestConfig{URL: "http://127.0.0.1/discovery"},
+	})
+	d.client.Transport = transport
+
+	require.NoError(t, d.Test(t.Context()))
+	assert.True(t, body.closed.Load())
+	assert.True(t, transport.idleClosed.Load())
+}
+
+func newTestDiscoverer(t *testing.T, cfg web.HTTPConfig) *Discoverer {
+	t.Helper()
+	d, err := NewDiscoverer(Config{HTTPConfig: cfg})
+	require.NoError(t, err)
+	return d
+}
+
+func requirePublicError(t *testing.T, err error, want string) {
+	t.Helper()
+	require.Error(t, err)
+	assert.Equal(t, want, err.Error())
+	message, ok := dyncfg.PublicMessage(err)
+	require.True(t, ok)
+	assert.Equal(t, want, message)
+}
+
+type testTransport struct {
+	roundTrips     atomic.Int64
+	idleClosed     atomic.Bool
+	statusCode     int
+	contentType    string
+	body           string
+	responseBody   io.ReadCloser
+	err            error
+	waitForContext bool
+}
+
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.roundTrips.Add(1)
+	if t.waitForContext {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	}
+	if t.err != nil {
+		return nil, t.err
+	}
+	statusCode := t.statusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	body := t.responseBody
+	if body == nil {
+		body = io.NopCloser(strings.NewReader(t.body))
+	}
+	header := make(http.Header)
+	if t.contentType != "" {
+		header.Set("Content-Type", t.contentType)
+	}
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     header,
+		Body:       body,
+		Request:    req,
+	}, nil
+}
+
+func (t *testTransport) CloseIdleConnections() {
+	t.idleClosed.Store(true)
+}
+
+type testBody struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (b *testBody) Close() error {
+	b.closed.Store(true)
+	return nil
+}

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/test_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/httpsd/test_test.go
@@ -311,6 +311,40 @@ func TestDiscovererTestClosesResponseAndIdleConnections(t *testing.T) {
 	assert.True(t, transport.idleClosed.Load())
 }
 
+func TestDiscovererTestHonorsCallerCancellation(t *testing.T) {
+	started := make(chan struct{}, 1)
+	transport := &testTransport{
+		waitForContext: true,
+		started:        started,
+	}
+	d := newTestDiscoverer(t, web.HTTPConfig{
+		RequestConfig: web.RequestConfig{URL: "http://127.0.0.1/discovery"},
+		ClientConfig:  web.ClientConfig{Timeout: confopt.Duration(200 * time.Millisecond)},
+	})
+	d.client.Transport = transport
+
+	ctx, cancel := context.WithCancel(t.Context())
+	result := make(chan error, 1)
+	go func() {
+		result <- d.Test(ctx)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP discovery test did not start its request")
+	}
+	cancel()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+		assert.True(t, transport.idleClosed.Load())
+	case <-time.After(time.Second):
+		t.Fatal("HTTP discovery test did not honor caller cancellation")
+	}
+}
+
 func newTestDiscoverer(t *testing.T, cfg web.HTTPConfig) *Discoverer {
 	t.Helper()
 	d, err := NewDiscoverer(Config{HTTPConfig: cfg})
@@ -336,10 +370,17 @@ type testTransport struct {
 	responseBody   io.ReadCloser
 	err            error
 	waitForContext bool
+	started        chan struct{}
 }
 
 func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.roundTrips.Add(1)
+	if t.started != nil {
+		select {
+		case t.started <- struct{}{}:
+		default:
+		}
+	}
 	if t.waitForContext {
 		<-req.Context().Done()
 		return nil, req.Context().Err()

--- a/src/go/plugin/go.d/discovery/sdext/dyncfg_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/dyncfg_test.go
@@ -4,6 +4,10 @@ package sdext
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +22,20 @@ import (
 
 func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 	prepareNetListenersExecutableFixture(t)
+
+	var httpRequests atomic.Int64
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpRequests.Add(1)
+		if r.URL.Path == "/fail" {
+			http.Error(w, "private backend response", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[]`)
+	}))
+	defer httpServer.Close()
+	missingTokenFile := t.TempDir() + "/missing-token"
+	missingCAFile := t.TempDir() + "/missing-ca"
 
 	attempts, err := containment.NewAuthority(nil)
 	require.NoError(t, err)
@@ -70,13 +88,14 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 		}
 	}
 	tests := []struct {
-		name    string
-		uid     string
-		id      string
-		payload string
-		message string
-		code    int
-		mode    string
+		name     string
+		uid      string
+		id       string
+		payload  string
+		message  string
+		code     int
+		mode     string
+		requests int64
 	}{
 		{
 			name:    "resource parser",
@@ -90,8 +109,16 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 			name:    "resource constructor",
 			uid:     "test-http-constructor",
 			id:      "go.d:sd:http",
-			payload: `{"discoverer":{"http":{"url":"http://example.invalid","proxy_url":"http://user:[REDACTED_SECRET]@%zz"}},"services":[{"id":"test","match":"true"}]}`,
+			payload: `{"discoverer":{"http":{"url":"http://example.invalid","proxy_url":"http://%zz/[REDACTED_SECRET]"}},"services":[{"id":"test","match":"true"}]}`,
 			message: "service discovery resource construction failed",
+			code:    400,
+		},
+		{
+			name:    "HTTP TLS file construction",
+			uid:     "test-http-tls-file",
+			id:      "go.d:sd:http",
+			payload: fmt.Sprintf(`{"discoverer":{"http":{"url":"https://example.invalid","tls_ca":%q}},"services":[{"id":"test","match":"true"}]}`, missingCAFile),
+			message: "service discovery resource construction failed: the configured HTTP credential or TLS file could not be read safely",
 			code:    400,
 		},
 		{
@@ -136,9 +163,44 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 			code:    422,
 			mode:    "invalid",
 		},
+		{
+			name:     "http operational success",
+			uid:      "test-http-operational-success",
+			id:       "go.d:sd:http",
+			payload:  fmt.Sprintf(`{"discoverer":{"http":{"url":%q}},"services":[{"id":"test","match":"true"}]}`, httpServer.URL+"/ok"),
+			message:  `"message":""`,
+			code:     200,
+			requests: 1,
+		},
+		{
+			name:     "http operational failure",
+			uid:      "test-http-operational-failure",
+			id:       "go.d:sd:http",
+			payload:  fmt.Sprintf(`{"discoverer":{"http":{"url":%q}},"services":[{"id":"test","match":"true"}]}`, httpServer.URL+"/fail"),
+			message:  "service discovery operational test failed: cannot query the configured HTTP endpoint",
+			code:     422,
+			requests: 1,
+		},
+		{
+			name:    "http credential file failure",
+			uid:     "test-http-credential-file",
+			id:      "go.d:sd:http",
+			payload: fmt.Sprintf(`{"discoverer":{"http":{"url":%q,"bearer_token_file":%q}},"services":[{"id":"test","match":"true"}]}`, httpServer.URL+"/unexpected", missingTokenFile),
+			message: "service discovery operational test failed: the configured HTTP credential or TLS file could not be read safely",
+			code:    422,
+		},
+		{
+			name:    "http unsafe method is validation only",
+			uid:     "test-http-validation-only",
+			id:      "go.d:sd:http",
+			payload: fmt.Sprintf(`{"discoverer":{"http":{"url":%q,"method":"POST"}},"services":[{"id":"test","match":"true"}]}`, httpServer.URL+"/unexpected"),
+			message: "Configuration is valid; this discoverer does not provide an operational test.",
+			code:    200,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			requestsBefore := httpRequests.Load()
 			t.Setenv("NETDATA_TEST_LOCAL_LISTENER_MODE", test.mode)
 			handler(t.Context(), functions.Function{
 				UID:         test.uid,
@@ -166,6 +228,7 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 				require.FailNow(t, "test failed", "temporary DynCfg test installed configuration")
 			default:
 			}
+			require.Equal(t, test.requests, httpRequests.Load()-requestsBefore)
 		})
 	}
 }

--- a/src/go/plugin/go.d/discovery/sdext/dyncfg_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/dyncfg_test.go
@@ -87,8 +87,7 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 			require.FailNow(t, "test failed", "service discovery did not expose every DynCfg template")
 		}
 	}
-	tests := []struct {
-		name     string
+	tests := map[string]struct {
 		uid      string
 		id       string
 		payload  string
@@ -97,56 +96,49 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 		mode     string
 		requests int64
 	}{
-		{
-			name:    "resource parser",
+		"resource parser": {
 			uid:     "test-docker-parser",
 			id:      "go.d:sd:docker",
 			payload: `{"discoverer":{"docker":{"timeout":"[REDACTED_SECRET]"}},"services":[{"id":"test","match":"true"}]}`,
 			message: "service discovery resource configuration is invalid",
 			code:    400,
 		},
-		{
-			name:    "resource constructor",
+		"resource constructor": {
 			uid:     "test-http-constructor",
 			id:      "go.d:sd:http",
 			payload: `{"discoverer":{"http":{"url":"http://example.invalid","proxy_url":"http://%zz/[REDACTED_SECRET]"}},"services":[{"id":"test","match":"true"}]}`,
 			message: "service discovery resource construction failed",
 			code:    400,
 		},
-		{
-			name:    "HTTP TLS file construction",
+		"HTTP TLS file construction": {
 			uid:     "test-http-tls-file",
 			id:      "go.d:sd:http",
 			payload: fmt.Sprintf(`{"discoverer":{"http":{"url":"https://example.invalid","tls_ca":%q}},"services":[{"id":"test","match":"true"}]}`, missingCAFile),
 			message: "service discovery resource construction failed: the configured HTTP credential or TLS file could not be read safely",
 			code:    400,
 		},
-		{
-			name:    "semantic validation",
+		"semantic validation": {
 			uid:     "test-docker-semantics",
 			id:      "go.d:sd:docker",
 			payload: `{"discoverer":{"docker":{}},"services":[{"id":"[REDACTED_SECRET]","match":""}]}`,
 			message: "service discovery resource configuration is invalid: service discovery service rules are invalid",
 			code:    400,
 		},
-		{
-			name:    "operational connection",
+		"operational connection": {
 			uid:     "test-docker-operational",
 			id:      "go.d:sd:docker",
 			payload: `{"discoverer":{"docker":{"address":"unix:///tmp/netdata-[REDACTED_SECRET].sock","timeout":"50ms"}},"services":[{"id":"test","match":"true"}]}`,
 			message: "service discovery operational test failed: cannot connect to the configured Docker endpoint",
 			code:    422,
 		},
-		{
-			name:    "net listeners operational success",
+		"net listeners operational success": {
 			uid:     "test-net-listeners-operational-success",
 			id:      "go.d:sd:net_listeners",
 			payload: `{"discoverer":{"net_listeners":{}},"services":[{"id":"test","match":"true"}]}`,
 			message: `"message":""`,
 			code:    200,
 		},
-		{
-			name:    "net listeners helper failure",
+		"net listeners helper failure": {
 			uid:     "test-net-listeners-operational-failure",
 			id:      "go.d:sd:net_listeners",
 			payload: `{"discoverer":{"net_listeners":{}},"services":[{"id":"test","match":"true"}]}`,
@@ -154,8 +146,7 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 			code:    422,
 			mode:    "failure",
 		},
-		{
-			name:    "net listeners invalid output",
+		"net listeners invalid output": {
 			uid:     "test-net-listeners-invalid-output",
 			id:      "go.d:sd:net_listeners",
 			payload: `{"discoverer":{"net_listeners":{}},"services":[{"id":"test","match":"true"}]}`,
@@ -163,8 +154,7 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 			code:    422,
 			mode:    "invalid",
 		},
-		{
-			name:     "http operational success",
+		"http operational success": {
 			uid:      "test-http-operational-success",
 			id:       "go.d:sd:http",
 			payload:  fmt.Sprintf(`{"discoverer":{"http":{"url":%q}},"services":[{"id":"test","match":"true"}]}`, httpServer.URL+"/ok"),
@@ -172,8 +162,7 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 			code:     200,
 			requests: 1,
 		},
-		{
-			name:     "http operational failure",
+		"http operational failure": {
 			uid:      "test-http-operational-failure",
 			id:       "go.d:sd:http",
 			payload:  fmt.Sprintf(`{"discoverer":{"http":{"url":%q}},"services":[{"id":"test","match":"true"}]}`, httpServer.URL+"/fail"),
@@ -181,16 +170,14 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 			code:     422,
 			requests: 1,
 		},
-		{
-			name:    "http credential file failure",
+		"http credential file failure": {
 			uid:     "test-http-credential-file",
 			id:      "go.d:sd:http",
 			payload: fmt.Sprintf(`{"discoverer":{"http":{"url":%q,"bearer_token_file":%q}},"services":[{"id":"test","match":"true"}]}`, httpServer.URL+"/unexpected", missingTokenFile),
 			message: "service discovery operational test failed: the configured HTTP credential or TLS file could not be read safely",
 			code:    422,
 		},
-		{
-			name:    "http unsafe method is validation only",
+		"http unsafe method is validation only": {
 			uid:     "test-http-validation-only",
 			id:      "go.d:sd:http",
 			payload: fmt.Sprintf(`{"discoverer":{"http":{"url":%q,"method":"POST"}},"services":[{"id":"test","match":"true"}]}`, httpServer.URL+"/unexpected"),
@@ -198,8 +185,8 @@ func TestShippedRegistryDyncfgTestSanitizesResourceFailures(t *testing.T) {
 			code:    200,
 		},
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
 			requestsBefore := httpRequests.Load()
 			t.Setenv("NETDATA_TEST_LOCAL_LISTENER_MODE", test.mode)
 			handler(t.Context(), functions.Function{

--- a/src/go/plugin/go.d/discovery/sdext/registry_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/registry_test.go
@@ -79,91 +79,85 @@ func TestRegistry_DockerOperationalTestRejectsUnreachableEndpoint(t *testing.T) 
 	require.ErrorContains(t, err, "cannot connect to the configured Docker endpoint")
 }
 
-func TestRegistry_HTTPOperationalTestUsesShippedConstructionPath(t *testing.T) {
-	var requests atomic.Int64
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `[]`)
-	}))
-	defer srv.Close()
-
-	raw, err := json.Marshal(httpsd.Config{
-		HTTPConfig: web.HTTPConfig{
-			RequestConfig: web.RequestConfig{
-				URL:    srv.URL,
-				Method: http.MethodGet,
+func TestRegistry_HTTPOperationalTest(t *testing.T) {
+	tests := map[string]struct {
+		method            string
+		handler           http.HandlerFunc
+		wantFullyTested   bool
+		wantRequests      int64
+		wantPublicMessage string
+		wantAbsent        string
+	}{
+		"uses the shipped construction path": {
+			method: http.MethodGet,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `[]`)
+			},
+			wantFullyTested: true,
+			wantRequests:    1,
+		},
+		"unsafe method is validation only": {
+			method: http.MethodPost,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "unexpected request", http.StatusInternalServerError)
 			},
 		},
-	})
-	require.NoError(t, err)
-	registry := Registry(true)
-	descriptor, ok := registry.Get(discovererHTTP)
-	require.True(t, ok)
-	config, err := descriptor.ParseJSONConfig(raw)
-	require.NoError(t, err)
-	discoverers, err := descriptor.NewDiscoverers(config, "dyncfg=user=test")
-	require.NoError(t, err)
-	require.Len(t, discoverers, 1)
-	_, ok = discoverers[0].(dyncfg.Testable)
-	require.True(t, ok)
-
-	candidate := newHTTPPipelineCandidate(t, registry, raw)
-	fullyTested, err := candidate.Test(t.Context())
-
-	require.NoError(t, err)
-	require.True(t, fullyTested)
-	assert.EqualValues(t, 1, requests.Load())
-}
-
-func TestRegistry_HTTPUnsafeMethodIsValidationOnly(t *testing.T) {
-	var requests atomic.Int64
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests.Add(1)
-		http.Error(w, "unexpected request", http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	raw, err := json.Marshal(httpsd.Config{
-		HTTPConfig: web.HTTPConfig{
-			RequestConfig: web.RequestConfig{
-				URL:    srv.URL,
-				Method: http.MethodPost,
+		"operational failure is public": {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "private backend response", http.StatusInternalServerError)
 			},
+			wantRequests:      1,
+			wantPublicMessage: "cannot query the configured HTTP endpoint",
+			wantAbsent:        "private backend response",
 		},
-	})
-	require.NoError(t, err)
+	}
 
-	candidate := newHTTPPipelineCandidate(t, Registry(true), raw)
-	fullyTested, err := candidate.Test(t.Context())
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var requests atomic.Int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				tc.handler(w, r)
+			}))
+			defer srv.Close()
 
-	require.NoError(t, err)
-	require.False(t, fullyTested)
-	assert.Zero(t, requests.Load())
-}
+			raw, err := json.Marshal(httpsd.Config{
+				HTTPConfig: web.HTTPConfig{
+					RequestConfig: web.RequestConfig{
+						URL:    srv.URL,
+						Method: tc.method,
+					},
+				},
+			})
+			require.NoError(t, err)
+			registry := Registry(true)
+			descriptor, ok := registry.Get(discovererHTTP)
+			require.True(t, ok)
+			config, err := descriptor.ParseJSONConfig(raw)
+			require.NoError(t, err)
+			discoverers, err := descriptor.NewDiscoverers(config, "dyncfg=user=test")
+			require.NoError(t, err)
+			require.Len(t, discoverers, 1)
+			_, ok = discoverers[0].(dyncfg.Testable)
+			require.True(t, ok)
 
-func TestRegistry_HTTPOperationalFailureIsPublic(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "private backend response", http.StatusInternalServerError)
-	}))
-	defer srv.Close()
+			candidate := newHTTPPipelineCandidate(t, registry, raw)
+			fullyTested, err := candidate.Test(t.Context())
 
-	raw, err := json.Marshal(httpsd.Config{
-		HTTPConfig: web.HTTPConfig{
-			RequestConfig: web.RequestConfig{URL: srv.URL},
-		},
-	})
-	require.NoError(t, err)
-
-	candidate := newHTTPPipelineCandidate(t, Registry(true), raw)
-	fullyTested, err := candidate.Test(t.Context())
-
-	require.False(t, fullyTested)
-	require.Error(t, err)
-	message, ok := dyncfg.PublicMessage(err)
-	require.True(t, ok)
-	assert.Equal(t, "cannot query the configured HTTP endpoint", message)
-	assert.NotContains(t, err.Error(), "private backend response")
+			require.Equal(t, tc.wantFullyTested, fullyTested)
+			if tc.wantPublicMessage == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				message, ok := dyncfg.PublicMessage(err)
+				require.True(t, ok)
+				assert.Equal(t, tc.wantPublicMessage, message)
+				assert.NotContains(t, err.Error(), tc.wantAbsent)
+			}
+			assert.Equal(t, tc.wantRequests, requests.Load())
+		})
+	}
 }
 
 func newHTTPPipelineCandidate(t *testing.T, registry sd.Registry, raw json.RawMessage) *pipeline.Pipeline {

--- a/src/go/plugin/go.d/discovery/sdext/registry_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/registry_test.go
@@ -6,18 +6,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/pkg/web"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/model"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery/sd/pipeline"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/dockersd"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/httpsd"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext/discoverer/netlistensd"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/ndexec"
 	"github.com/stretchr/testify/assert"
@@ -71,6 +77,121 @@ func TestRegistry_DockerOperationalTestRejectsUnreachableEndpoint(t *testing.T) 
 	require.False(t, fullyTested)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "cannot connect to the configured Docker endpoint")
+}
+
+func TestRegistry_HTTPOperationalTestUsesShippedConstructionPath(t *testing.T) {
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[]`)
+	}))
+	defer srv.Close()
+
+	raw, err := json.Marshal(httpsd.Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{
+				URL:    srv.URL,
+				Method: http.MethodGet,
+			},
+		},
+	})
+	require.NoError(t, err)
+	registry := Registry(true)
+	descriptor, ok := registry.Get(discovererHTTP)
+	require.True(t, ok)
+	config, err := descriptor.ParseJSONConfig(raw)
+	require.NoError(t, err)
+	discoverers, err := descriptor.NewDiscoverers(config, "dyncfg=user=test")
+	require.NoError(t, err)
+	require.Len(t, discoverers, 1)
+	_, ok = discoverers[0].(dyncfg.Testable)
+	require.True(t, ok)
+
+	candidate := newHTTPPipelineCandidate(t, registry, raw)
+	fullyTested, err := candidate.Test(t.Context())
+
+	require.NoError(t, err)
+	require.True(t, fullyTested)
+	assert.EqualValues(t, 1, requests.Load())
+}
+
+func TestRegistry_HTTPUnsafeMethodIsValidationOnly(t *testing.T) {
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	raw, err := json.Marshal(httpsd.Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{
+				URL:    srv.URL,
+				Method: http.MethodPost,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	candidate := newHTTPPipelineCandidate(t, Registry(true), raw)
+	fullyTested, err := candidate.Test(t.Context())
+
+	require.NoError(t, err)
+	require.False(t, fullyTested)
+	assert.Zero(t, requests.Load())
+}
+
+func TestRegistry_HTTPOperationalFailureIsPublic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "private backend response", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	raw, err := json.Marshal(httpsd.Config{
+		HTTPConfig: web.HTTPConfig{
+			RequestConfig: web.RequestConfig{URL: srv.URL},
+		},
+	})
+	require.NoError(t, err)
+
+	candidate := newHTTPPipelineCandidate(t, Registry(true), raw)
+	fullyTested, err := candidate.Test(t.Context())
+
+	require.False(t, fullyTested)
+	require.Error(t, err)
+	message, ok := dyncfg.PublicMessage(err)
+	require.True(t, ok)
+	assert.Equal(t, "cannot query the configured HTTP endpoint", message)
+	assert.NotContains(t, err.Error(), "private backend response")
+}
+
+func newHTTPPipelineCandidate(t *testing.T, registry sd.Registry, raw json.RawMessage) *pipeline.Pipeline {
+	t.Helper()
+	candidate, err := pipeline.New(
+		pipeline.Config{
+			Name: "http-test",
+			Discoverer: pipeline.DiscovererPayload{
+				Kind:   discovererHTTP,
+				Config: raw,
+			},
+			Services: []pipeline.ServiceRuleConfig{{
+				ID:    "test",
+				Match: "true",
+			}},
+		},
+		func(payload pipeline.DiscovererPayload, source string) ([]model.Discoverer, error) {
+			descriptor, ok := registry.Get(payload.Type())
+			require.True(t, ok)
+			config, err := descriptor.ParseJSONConfig(payload.Config)
+			if err != nil {
+				return nil, err
+			}
+			return descriptor.NewDiscoverers(config, source)
+		},
+	)
+	require.NoError(t, err)
+	return candidate
 }
 
 func TestRegistry_NetListenersOperationalTestUsesShippedConstructionPath(t *testing.T) {

--- a/src/go/plugin/go.d/docs/helper-packages.md
+++ b/src/go/plugin/go.d/docs/helper-packages.md
@@ -21,6 +21,7 @@ already owns the behavior.
 | Duration and tri-state config option types | `src/go/pkg/confopt` |
 | HTTP request/client config | `src/go/pkg/web` |
 | TLS config outside HTTP | `src/go/pkg/tlscfg` |
+| Bounded configured-file reads | `src/go/pkg/safefile` |
 | Prometheus exposition parsing | `src/go/pkg/prometheus` |
 | User selector/matcher grammar | `src/go/pkg/matcher` |
 | Collector logging and log limiting | `src/go/logger` |
@@ -85,6 +86,15 @@ type Config struct {
 
 Use `src/go/pkg/tlscfg` directly only when the collector is not HTTP-based but still needs TLS, such as Redis or
 x509-style checks. HTTP collectors should get TLS behavior through `web.HTTPConfig`.
+
+### Configured credential and TLS files
+
+`web` bearer-token files and `tlscfg` CA, certificate, and key files use `src/go/pkg/safefile`. The helper opens the path
+once, verifies the opened object is a regular file, reads at most 1 MiB, and closes it. Symlinks to regular files are
+supported; non-regular objects and larger files are rejected.
+
+Use `safefile.Read` for new bounded credential or key-material paths that share this contract. Do not add a separate
+preflight followed by `os.ReadFile`: that checks a different filesystem object and leaves the production read unbounded.
 
 ## Prometheus Endpoints
 

--- a/src/go/plugin/go.d/docs/helper-packages.md
+++ b/src/go/plugin/go.d/docs/helper-packages.md
@@ -89,9 +89,9 @@ x509-style checks. HTTP collectors should get TLS behavior through `web.HTTPConf
 
 ### Configured credential and TLS files
 
-`web` bearer-token files and `tlscfg` CA, certificate, and key files use `src/go/pkg/safefile`. The helper opens the path
-once, verifies the opened object is a regular file, reads at most 1 MiB, and closes it. Symlinks to regular files are
-supported; non-regular objects and larger files are rejected.
+`web` bearer-token files and `tlscfg` CA files use `src/go/pkg/safefile`; certificate and key files use it when both are
+configured. The helper opens the path once, verifies the opened object is a regular file, reads at most 1 MiB, and closes
+it. Symlinks to regular files are supported; non-regular objects and larger files are rejected.
 
 Use `safefile.Read` for new bounded credential or key-material paths that share this contract. Do not add a separate
 preflight followed by `os.ReadFile`: that checks a different filesystem object and leaves the production read unbounded.


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an operational test for HTTP service discovery that performs a real GET using the configured auth/TLS/proxy/redirect path with clear, sanitized errors. Enforces safe, bounded reads for bearer-token and TLS files, and consolidates docs to clarify testing behavior and file requirements.

- **New Features**
  - HTTP SD test runs one production fetch only for empty/default or exact `GET`; requires HTTP 200, enforces 10 MiB body limit, follows up to 10 redirects, parses all items, discards targets, and closes response/idle connections.
  - Non-GET methods return validation-only via `dyncfg.ErrTestUnsupported`; pipelines keep testing later discoverers and report partial coverage.
  - Public, sanitized errors for request build, timeout, query, response data, and credential/TLS file issues. Docs: added “Testing configurations,” consolidated HTTP file-safety rules (regular files ≤1 MiB, symlinks allowed, `bearer_token_file` under `/var/run/secrets/` is optional outside Kubernetes), and linked helper guidance.

- **Refactors**
  - Added `safefile` for regular-file-only reads capped at 1 MiB; used by `web` bearer-token auth and `tlscfg` CA/cert/key loading.
  - New `tlscfg.ErrTLSFile` error class; HTTP SD constructor/test map TLS and file failures to public errors.
  - Pipeline and secret store treat `dyncfg.ErrTestUnsupported` as validation-only to keep operational tests moving.

<sup>Written for commit 485d7e36b00560459440c86f5d357cadc4262adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

