### PR TITLE
test(go.d): stabilize jobmgr lifecycle integrations

### DIFF
--- a/src/go/plugin/agent/jobmgr/composition/run_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/run_test.go
@@ -323,8 +323,8 @@ func TestRunGenerationKeepsDynCfgRoutePrivateAndUsesSameNamePerJobProtocolID(t *
 		"module": {UpdateEvery: 1},
 	}
 
-	var output bytes.Buffer
-	frames, err := lifecycle.NewFrameOwner(&output)
+	output := newProcessSynchronizedBuffer()
+	frames, err := lifecycle.NewFrameOwner(output)
 	require.NoError(t, err)
 	uids := lifecycle.NewUIDLedger()
 	generation, err := newTestRunGeneration(t, runGenerationConfig{
@@ -364,10 +364,10 @@ func TestRunGenerationKeepsDynCfgRoutePrivateAndUsesSameNamePerJobProtocolID(t *
 
 	require.NoError(t, generation.Wait(context.Background()))
 	wire := output.String()
-	templateAt := bytes.Index(output.Bytes(), []byte("CONFIG go.d:collector:module create accepted template"))
-	createAt := bytes.Index(output.Bytes(), []byte("CONFIG go.d:collector:module:module create accepted job"))
-	resultAt := bytes.Index(output.Bytes(), []byte("FUNCTION_RESULT_BEGIN enable 200 application/json"))
-	statusAt := bytes.Index(output.Bytes(), []byte("CONFIG go.d:collector:module:module status running"))
+	templateAt := strings.Index(wire, "CONFIG go.d:collector:module create accepted template")
+	createAt := strings.Index(wire, "CONFIG go.d:collector:module:module create accepted job")
+	resultAt := strings.Index(wire, "FUNCTION_RESULT_BEGIN enable 200 application/json")
+	statusAt := strings.Index(wire, "CONFIG go.d:collector:module:module status running")
 	require.NotContains(t, wire, `FUNCTION GLOBAL "config"`)
 	require.NotContains(t, wire, `FUNCTION_DEL GLOBAL "config"`)
 	require.False(

--- a/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
@@ -488,12 +488,20 @@ func TestProcessCoreCancelledSecretUpdateCompletesStartedReplacement(t *testing.
 		require.FailNow(t, "test failed", "dependent stop did not reach collector cleanup")
 	}
 
-	_, writeStringErr2 := io.WriteString(writer, "FUNCTION_CANCEL secret-cancel\n")
+	_, writeStringErr2 := io.WriteString(
+		writer,
+		"FUNCTION_CANCEL secret-cancel\n"+
+			"FUNCTION secret-cancel-barrier invalid \"missing:route\" 0xFFFF \"user=test\"\n",
+	)
 	require.NoError(t, writeStringErr2)
+	// Pipe writes acknowledge byte consumption, so a following processed
+	// command is the barrier that makes the preceding cancellation authoritative.
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN secret-cancel-barrier 400 application/json")
 
 	releaseOnce.Do(func() { close(releaseStop) })
 	waitSecretStart(t, starts, "replacement")
 	output.waitContains(t, "FUNCTION_RESULT_BEGIN secret-cancel 499 application/json")
+	require.NotContains(t, output.String(), "FUNCTION_RESULT_BEGIN secret-cancel 200 application/json")
 
 	require.EqualValues(t, 1, cleanups.Load())
 

--- a/src/go/plugin/agent/jobmgr/kernel_function_catalog_external_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_function_catalog_external_test.go
@@ -30,16 +30,25 @@ func (fn runFinalizerFunc) FinalizeRun(ctx context.Context, generation uint64) e
 	return fn(ctx, generation)
 }
 
+type externalHoldingFrameWriter struct {
+	offered chan []byte
+	release chan struct{}
+}
+
+func (w *externalHoldingFrameWriter) Write(payload []byte) (int, error) {
+	w.offered <- bytes.Clone(payload)
+	<-w.release
+	return len(payload), nil
+}
+
 func TestFunctionCatalogKernelIntegration(t *testing.T) {
 	var cleanupCalls atomic.Int32
-	handled := make(chan struct{})
 	catalog, err := functionadapter.NewCatalog([]functionadapter.Declaration{
 		{
 			ID: "method", PublicName: "direct",
 			Generation: &functionadapter.HandlerGenerationDeclaration{
 				ID: "external-test",
 				Handler: func(context.Context, functionadapter.HandlerInput) (lifecycle.SealedResult, error) {
-					close(handled)
 					return lifecycle.NewControlResult(lifecycle.ControlInternal)
 				},
 				Cleanup: func(context.Context) error {
@@ -55,8 +64,12 @@ func TestFunctionCatalogKernelIntegration(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = run.FinishShutdown() })
 	uids := lifecycle.NewUIDLedger()
-	var output bytes.Buffer
-	frames, err := lifecycle.NewFrameOwner(&output)
+	writer := &externalHoldingFrameWriter{
+		offered: make(chan []byte, 1),
+		release: make(chan struct{}),
+	}
+	var releaseFrame sync.Once
+	frames, err := lifecycle.NewFrameOwner(writer)
 	require.NoError(t, err)
 	tasks, err := lifecycle.NewTaskSupervisor(frames)
 	require.NoError(t, err)
@@ -67,6 +80,13 @@ func TestFunctionCatalogKernelIntegration(t *testing.T) {
 		catalog,
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		kernel.Stop()
+		releaseFrame.Do(func() { close(writer.release) })
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer waitCancel()
+		_ = kernel.Wait(waitCtx)
+	})
 
 	require.NoError(t, run.OpenAdmission())
 	require.NoError(t, kernel.Start(context.Background()))
@@ -77,18 +97,19 @@ func TestFunctionCatalogKernelIntegration(t *testing.T) {
 		Route:  "direct",
 	}),
 	)
+	var frame []byte
 	select {
-	case <-handled:
+	case frame = <-writer.offered:
 	case <-time.After(time.Second):
-		require.FailNow(t, "test failed", "Function handler did not run")
+		require.FailNow(t, "test failed", "Function result frame was not offered")
 	}
+	require.Contains(t, string(frame), "FUNCTION_RESULT_BEGIN concrete-catalog 500 application/json ")
 	kernel.Stop()
+	releaseFrame.Do(func() { close(writer.release) })
 
-	require.NoError(t, kernel.Wait(context.Background()))
-	require.True(
-		t,
-		bytes.Contains(output.Bytes(), []byte("FUNCTION_RESULT_BEGIN concrete-catalog 500 application/json ")),
-	)
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer waitCancel()
+	require.NoError(t, kernel.Wait(waitCtx))
 
 	require.True(t, catalog.LifecycleDrained())
 	require.EqualValues(t, 1, cleanupCalls.Load())

--- a/src/go/plugin/scripts.d/collector/nagios/job_v2_integration_test.go
+++ b/src/go/plugin/scripts.d/collector/nagios/job_v2_integration_test.go
@@ -67,14 +67,9 @@ func TestNagiosCollectorJobV2(t *testing.T) {
 			},
 			run: func(t *testing.T, state jobCaseState) {
 				t.Helper()
-				state.job.Tick(1)
-				deadline := time.Now().Add(2 * time.Second)
-				for time.Now().Before(deadline) {
-					if state.out.Len() > 0 {
-						break
-					}
-					time.Sleep(10 * time.Millisecond)
-				}
+				tickJobUntil(t, state.job, func() bool {
+					return state.out.Len() > 0
+				}, "timed out waiting for emitted metrics")
 
 				wire := state.out.String()
 				assert.Contains(t, wire, "CHART '")
@@ -107,16 +102,10 @@ func TestNagiosCollectorJobV2(t *testing.T) {
 			},
 			run: func(t *testing.T, state jobCaseState) {
 				t.Helper()
-				state.job.Tick(1)
-				deadline := time.Now().Add(2 * time.Second)
-				for time.Now().Before(deadline) {
-					if _, err := os.Stat(state.startedFile); err == nil {
-						break
-					}
-					time.Sleep(10 * time.Millisecond)
-				}
-				_, err := os.Stat(state.startedFile)
-				require.NoError(t, err, "timed out waiting for in-flight script start")
+				tickJobUntil(t, state.job, func() bool {
+					_, err := os.Stat(state.startedFile)
+					return err == nil
+				}, "timed out waiting for in-flight script start")
 				stopStarted := time.Now()
 				state.job.Stop()
 				assert.LessOrEqual(t, time.Since(stopStarted), 3*time.Second)
@@ -151,6 +140,26 @@ func TestNagiosCollectorJobV2(t *testing.T) {
 				state.job.Cleanup()
 			}
 		})
+	}
+}
+
+func tickJobUntil(t *testing.T, job *jobruntime.JobV2, observed func() bool, failureMessage string) {
+	t.Helper()
+	timeout := time.NewTimer(2 * time.Second)
+	defer timeout.Stop()
+	retry := time.NewTicker(10 * time.Millisecond)
+	defer retry.Stop()
+
+	for {
+		job.Tick(1)
+		if observed() {
+			return
+		}
+		select {
+		case <-retry.C:
+		case <-timeout.C:
+			require.FailNow(t, failureMessage)
+		}
 	}
 }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized flaky jobmgr lifecycle and scripts.d Nagios job tests by enforcing deterministic frame handling, synchronized output checks, authoritative cancellation, and retrying lossy ticks. This reduces CI flakes and makes test outcomes reliable.

- **Bug Fixes**
  - secret_flow: send a barrier after `FUNCTION_CANCEL` so the cancel is authoritative; expect `499`, not `200`.
  - kernel_function_catalog: hold the result frame and release it after `Stop`; then `Wait` with a timeout to ensure cleanup/drain.
  - composition/run: use a process-synchronized buffer and string-based search on the final output to avoid racey inspection.
  - scripts.d/nagios: introduce `tickJobUntil` to retry lossy job ticks and wait for observable state instead of fixed sleeps.

<sup>Written for commit cb975b5547886e2544958e686070e6ad5b38e1a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

