### PR TITLE
Harden privileged startup against symlink-following

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1299,6 +1299,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/os/boottime.h
         src/libnetdata/os/boot_id.c
         src/libnetdata/os/boot_id.h
+        src/libnetdata/os/privileged_dir.c
+        src/libnetdata/os/privileged_dir.h
         src/libnetdata/os/run_dir.c
         src/libnetdata/os/run_dir.h
         src/libnetdata/os/file_lock.c
@@ -3161,6 +3163,10 @@ target_link_libraries(stream-receiver-hops-test libnetdata)
 add_executable(stream-replay-endpoints-test EXCLUDE_FROM_ALL
         src/streaming/tests/stream-replay-endpoints-test.c)
 target_link_libraries(stream-replay-endpoints-test libnetdata)
+
+add_executable(run-dir-safety-test EXCLUDE_FROM_ALL
+        src/libnetdata/os/tests/run-dir-safety-test.c)
+target_link_libraries(run-dir-safety-test libnetdata)
 
 if(OS_LINUX)
         add_executable(http-auth-bearer-test EXCLUDE_FROM_ALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3164,9 +3164,14 @@ add_executable(stream-replay-endpoints-test EXCLUDE_FROM_ALL
         src/streaming/tests/stream-replay-endpoints-test.c)
 target_link_libraries(stream-replay-endpoints-test libnetdata)
 
-add_executable(run-dir-safety-test EXCLUDE_FROM_ALL
-        src/libnetdata/os/tests/run-dir-safety-test.c)
-target_link_libraries(run-dir-safety-test libnetdata)
+# POSIX ownership semantics only: on Windows os_run_dir_is_safe() short-circuits
+# to true (Cygwin has no uid 0 and no sticky bit), so every refusal case here
+# would fail by design.
+if(NOT OS_WINDOWS)
+        add_executable(run-dir-safety-test EXCLUDE_FROM_ALL
+                src/libnetdata/os/tests/run-dir-safety-test.c)
+        target_link_libraries(run-dir-safety-test libnetdata)
+endif()
 
 if(OS_LINUX)
         add_executable(http-auth-bearer-test EXCLUDE_FROM_ALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3165,8 +3165,9 @@ add_executable(stream-replay-endpoints-test EXCLUDE_FROM_ALL
 target_link_libraries(stream-replay-endpoints-test libnetdata)
 
 # POSIX ownership semantics only: on Windows os_run_dir_is_safe() short-circuits
-# to true (Cygwin has no uid 0 and no sticky bit), so every refusal case here
-# would fail by design.
+# to true once past the symlink, directory and access checks (Cygwin has no uid 0
+# and no sticky bit), so the ownership and parent-trust refusal cases here would
+# fail by design.
 if(NOT OS_WINDOWS)
         add_executable(run-dir-safety-test EXCLUDE_FROM_ALL
                 src/libnetdata/os/tests/run-dir-safety-test.c)

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -153,8 +153,10 @@ static void connect_cb(uv_connect_t* req, int status)
 
     (void)req;
     if (status) {
+        const char *pipename = daemon_pipename();
         fprintf(stderr, "uv_pipe_connect(): %s\n", uv_strerror(status));
-        fprintf(stderr, "Cannot connect to '%s'.\nMake sure the netdata service is running.\n", daemon_pipename());
+        fprintf(stderr, "Cannot connect to '%s'.\nMake sure the netdata service is running.\n",
+                pipename ? pipename : "(unknown)");
         exit(-1);
     }
     if (0 == command_string_size) {
@@ -210,6 +212,15 @@ int main(int argc, char **argv)
     req.data = buffer_create(128, NULL);
 
     const char *pipename = daemon_pipename();
+    if (!pipename) {
+        fprintf(stderr,
+                "Cannot determine the netdata run directory, so I do not know where the netdata "
+                "socket is.\nSet NETDATA_PIPENAME to the socket path, or NETDATA_RUN_DIR to the run "
+                "directory netdata uses.\n");
+        buffer_free(req.data);
+        return exit_status;
+    }
+
     uv_pipe_connect(&req, &client_pipe, pipename, connect_cb);
 
     uv_run(loop, UV_RUN_DEFAULT);

--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -868,6 +868,16 @@ static void command_thread(void *arg) {
     }
 
     const char *pipename = daemon_pipename();
+    if (!pipename) {
+        // main() exits when there is no run directory, so this is only reachable if
+        // the read-only resolution disagrees with the read-write one (a run dir we
+        // can write but not read)
+        netdata_log_error("Cannot determine the netdatacli socket path - the command server is disabled.");
+        command_thread_error = UV_EINVAL;
+        // server_pipe is initialized but not bound, the same state a bind failure
+        // leaves behind
+        goto error_after_pipe_bind;
+    }
 
     (void)uv_fs_unlink(loop, &req, pipename, NULL);
     uv_fs_req_cleanup(&req);

--- a/src/daemon/config/README.md
+++ b/src/daemon/config/README.md
@@ -154,13 +154,20 @@ The multiplication of all the **enabled** tiers `dbengine tier N update every it
 **Moving a directory to another filesystem.** Either set the option above to the new
 path, or bind-mount the new location onto the old path. Both are supported.
 
-**Do not use a symbolic link.** At startup, while it still runs as `root`, the Agent
-gives these directories to the `netdata` user so that it can keep writing to them
-after it drops privileges - and it does that without following symbolic links. If you
-replace one of these directories, or a directory inside one of them, with a symbolic
-link, the Agent changes the ownership of the link itself and leaves the files behind
-it as they were. It may then be unable to write them once it is no longer `root`. It
-reports every symbolic link it skips this way.
+**Symbolic links, and where they work.** At startup, while it still runs as `root`,
+the Agent gives these directories to the `netdata` user so that it can keep writing to
+them after it drops privileges. Whether it follows a symbolic link on the way depends
+on who else can write the directory that holds it:
+
+- A link that replaces one of the paths above is followed, and the directory it points
+  to is the one that changes ownership. `/var/cache/netdata` may be a link to another
+  filesystem, because only `root` can create entries in `/var/cache`.
+- A link deeper inside them - `/var/lib/netdata/cloud.d`, `/var/lib/netdata/registry`,
+  anything inside `/var/cache/netdata` - is not followed, because the `netdata` user
+  can write those directories and could therefore have planted it. The Agent changes
+  the ownership of the link itself, leaves the files behind it as they were, and may
+  then be unable to write them once it is no longer `root`. Relocate those with the
+  settings above or with a bind-mount instead.
 
 **The run directory is stricter.** A symbolic link at `NETDATA_RUN_DIR` is refused
 outright, and the Agent falls back to its next candidate and logs why. This is not

--- a/src/daemon/config/README.md
+++ b/src/daemon/config/README.md
@@ -151,6 +151,23 @@ The multiplication of all the **enabled** tiers `dbengine tier N update every it
 | stock Health config |                 `/usr/lib/netdata/conf.d/health.d`                 | Contains the stock Alert configuration files for each collector                                                                                                                    |
 |      registry       |              `/opt/netdata/var/lib/netdata/registry`               | Contains the [registry](/src/registry/README.md) database and GUID that uniquely identifies each Netdata Agent                                                                     |
 
+**Moving a directory to another filesystem.** Either set the option above to the new
+path, or bind-mount the new location onto the old path. Both are supported.
+
+**Do not use a symbolic link.** At startup, while it still runs as `root`, the Agent
+gives these directories to the `netdata` user so that it can keep writing to them
+after it drops privileges - and it does that without following symbolic links. If you
+replace one of these directories, or a directory inside one of them, with a symbolic
+link, the Agent changes the ownership of the link itself and leaves the files behind
+it as they were. It may then be unable to write them once it is no longer `root`. It
+reports every symbolic link it skips this way.
+
+**The run directory is stricter.** A symbolic link at `NETDATA_RUN_DIR` is refused
+outright, and the Agent falls back to its next candidate and logs why. This is not
+about ownership: that directory holds the sockets the Agent creates while still
+`root`, under names that are easy to predict, so it has to be certain which directory
+those names live in.
+
 </details>
 
 <details>

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -40,7 +40,24 @@ static void fix_directory_file_permissions_at(int dir_fd, const char *dirname, u
                 (void) snprintfz(sub_name, FILENAME_MAX, "%s/%s", dirname, de->d_name);
                 fix_directory_file_permissions_at(sub_fd, sub_name, uid, gid, recursive);
             }
+            else
+                netdata_log_error(
+                    "Not fixing ownership inside directory '%s/%s': cannot open it without following symlinks",
+                    dirname, de->d_name);
         }
+
+        // A symlink is never followed: whoever can write into this directory could
+        // have planted it, and we are still root. Reported in both modes - the
+        // recursive one chowns the link itself and stops there, the non-recursive
+        // one only chowns regular files - because either way the files behind the
+        // link keep the ownership they had, which is what an operator who
+        // relocated a directory with a symlink needs to be told. Relocate with a
+        // bind mount, or with the matching option in the [directories] section of
+        // netdata.conf, instead.
+        if (de->d_type == DT_LNK)
+            netdata_log_error(
+                "Not fixing ownership through symbolic link '%s/%s': its target is left as it is",
+                dirname, de->d_name);
     }
 
     closedir(dir);

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -6,60 +6,81 @@
 
 char *pidfile = NULL;
 
-static void fix_directory_file_permissions(const char *dirname, uid_t uid, gid_t gid, bool recursive)
+// Fix ownership of the entries inside an already-opened directory.
+// Consumes dir_fd (fdopendir()/closedir() close it); dirname is used for log
+// messages only. Everything goes through the descriptor with AT_SYMLINK_NOFOLLOW,
+// so a symlinked entry is chowned as the link itself and is never followed to a
+// target chosen by whoever can write into the directory.
+static void fix_directory_file_permissions_at(int dir_fd, const char *dirname, uid_t uid, gid_t gid, bool recursive)
 {
-    char filename[FILENAME_MAX + 1];
-
-    DIR *dir = opendir(dirname);
-    if (!dir)
+    DIR *dir = fdopendir(dir_fd);
+    if (!dir) {
+        close(dir_fd);
         return;
+    }
 
     struct dirent *de = NULL;
 
     while ((de = readdir(dir))) {
-        if (de->d_type == DT_DIR && (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..")))
+        // Skipped without consulting d_type, unlike the tests below: '..' must
+        // never be chowned - that would escape into the parent directory - and a
+        // filesystem is free to report DT_UNKNOWN for it.
+        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
             continue;
 
-        (void) snprintfz(filename, FILENAME_MAX, "%s/%s", dirname, de->d_name);
         if (de->d_type == DT_REG || recursive) {
-            if (chown(filename, uid, gid) == -1)
-                netdata_log_error("Cannot chown %s '%s' to %u:%u", de->d_type == DT_DIR ? "directory" : "file", filename, (unsigned int)uid, (unsigned int)gid);
+            if (fchownat(dirfd(dir), de->d_name, uid, gid, AT_SYMLINK_NOFOLLOW) == -1)
+                netdata_log_error("Cannot chown %s '%s/%s' to %u:%u", de->d_type == DT_DIR ? "directory" : "file", dirname, de->d_name, (unsigned int)uid, (unsigned int)gid);
         }
 
-        if (de->d_type == DT_DIR && recursive)
-            fix_directory_file_permissions(filename, uid, gid, recursive);
+        if (de->d_type == DT_DIR && recursive) {
+            int sub_fd = openat(dirfd(dir), de->d_name, O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC);
+            if (sub_fd != -1) {
+                char sub_name[FILENAME_MAX + 1];
+                (void) snprintfz(sub_name, FILENAME_MAX, "%s/%s", dirname, de->d_name);
+                fix_directory_file_permissions_at(sub_fd, sub_name, uid, gid, recursive);
+            }
+        }
     }
 
     closedir(dir);
 }
 
+// Best-effort ownership repair, exactly like before the privilege drop always
+// was: failures are logged and startup continues, since netdata may legitimately
+// be unable to chown (root-squashed NFS, no CAP_CHOWN, a read-only bind mount)
+// and still work fine with the ownership already in place.
 static void change_dir_ownership(const char *dir, uid_t uid, gid_t gid, bool recursive) {
     if(!dir || !*dir) return;
 
-    if (chown(dir, uid, gid) == -1)
+    // Opens the directory itself, never a symlink someone else planted at its
+    // name: os_open_dir_privileged() follows a final-component symlink only when
+    // the directory holding it is ours and writable by no one else. So
+    // /var/cache/netdata may still point to another filesystem, while
+    // /var/lib/netdata/cloud.d may not - the netdata user can write its parent,
+    // and a symlink there would have us chown its target while still root
+    int fd = os_open_dir_privileged(dir);
+    if (fd == -1) {
+        netdata_log_error("Cannot open directory '%s' to fix ownership", dir);
+        return;
+    }
+
+    if (fchown(fd, uid, gid) == -1)
         netdata_log_error("Cannot chown directory '%s' to %u:%u", dir, (unsigned int)uid, (unsigned int)gid);
 
-    fix_directory_file_permissions(dir, uid, gid, recursive);
-}
-
-static inline void clean_directory(const char *dirname)
-{
-    DIR *dir = opendir(dirname);
-    if(!dir) return;
-
-    int dir_fd = dirfd(dir);
-    struct dirent *de = NULL;
-
-    while((de = readdir(dir)))
-        if(de->d_type == DT_REG)
-            if (unlinkat(dir_fd, de->d_name, 0))
-                netdata_log_error("Cannot delete %s/%s", dirname, de->d_name);
-
-    closedir(dir);
+    // consumes fd; the entries inside are fixed best-effort even when the
+    // top-level chown failed
+    fix_directory_file_permissions_at(fd, dir, uid, gid, recursive);
 }
 
 static void prepare_required_directories(uid_t uid, gid_t gid) {
+    // The run dir needs no ownership guard here: os_run_dir() already refused
+    // any directory another account could control, so by this point it is either
+    // ours or netdata never got a run dir at all (main() exits in that case).
     change_dir_ownership(os_run_dir(true), uid, gid, false);
+
+    // Ownership is repaired unconditionally, so a changed "run as user" or a
+    // recreated netdata account is migrated.
     change_dir_ownership(netdata_configured_cache_dir, uid, gid, true);
     change_dir_ownership(netdata_configured_varlib_dir, uid, gid, false);
     change_dir_ownership(netdata_configured_log_dir, uid, gid, false);
@@ -84,10 +105,8 @@ static int become_user(const char *username, int pid_fd) {
 
     prepare_required_directories(uid, gid);
 
-    if(pidfile && *pidfile) {
-        if(chown(pidfile, uid, gid) == -1)
-            netdata_log_error("Cannot chown '%s' to %u:%u", pidfile, (unsigned int)uid, (unsigned int)gid);
-    }
+    // the pidfile is chowned through its still-open descriptor, by
+    // chown_open_file(pid_fd) below - never by path, which would follow a symlink
 
     int ngroups = (int)sysconf(_SC_NGROUPS_MAX);
     gid_t *supplementary_groups = NULL;

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -47,14 +47,18 @@ static void fix_directory_file_permissions_at(int dir_fd, const char *dirname, u
         }
 
         // A symlink is never followed: whoever can write into this directory could
-        // have planted it, and we are still root. Reported in both modes - the
-        // recursive one chowns the link itself and stops there, the non-recursive
-        // one only chowns regular files - because either way the files behind the
-        // link keep the ownership they had, which is what an operator who
-        // relocated a directory with a symlink needs to be told. Relocate with a
-        // bind mount, or with the matching option in the [directories] section of
-        // netdata.conf, instead.
-        if (de->d_type == DT_LNK)
+        // have planted it, and we are still root. Reported only in the recursive
+        // mode, because that is the only mode whose handling changed: there we now
+        // chown the link itself and stop, where we used to chown whatever it
+        // pointed at, so the files behind it keep the ownership they had - which is
+        // what an operator who relocated a directory with a symlink needs to be
+        // told. Relocate with a bind mount, or with the matching option in the
+        // [directories] section of netdata.conf, instead.
+        // The non-recursive mode only ever chowns regular files, so a symlink was
+        // never fixed there and nothing has changed for it. Reporting it anyway
+        // means an error per symlink on every single start: the shipped container
+        // image points all 7 files in its log directory at /dev/stdout.
+        if (recursive && de->d_type == DT_LNK)
             netdata_log_error(
                 "Not fixing ownership through symbolic link '%s/%s': its target is left as it is",
                 dirname, de->d_name);

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1022,6 +1022,16 @@ int netdata_main(int argc, char **argv) {
     delta_startup_time("run dir");
 
     {
+        // Tell the resolver which uid we will drop to, before it looks at
+        // anything: the /tmp fallback is created as root on the first run and
+        // then chowned to that uid, so on restart it must still be recognized
+        // as ours instead of as some third account's directory.
+        if(user && *user) {
+            struct passwd *pw = getpwnam(user);
+            if(pw)
+                os_run_dir_set_target_uid(pw->pw_uid);
+        }
+
         const char *run_dir = os_run_dir(true);
         if(!run_dir) {
             netdata_log_error("Cannot get/create a run directory.");

--- a/src/daemon/pipename.c
+++ b/src/daemon/pipename.c
@@ -16,16 +16,29 @@ const char *daemon_pipename(void) {
 
     const char *pipename = cached_pipename;
     if(!pipename) {
+        // an empty value means "not set", as for NETDATA_RUN_DIR - otherwise it
+        // would name the empty path
         const char *env_pipename = getenv("NETDATA_PIPENAME");
-        if (env_pipename)
+        if (env_pipename && *env_pipename)
             cached_pipename = strdupz(env_pipename);
         else {
             //#if defined(OS_WINDOWS)
             // cached_pipename = strdupz("\\\\?\\pipe\\netdata-cli");
             //#else
-            char filename[FILENAME_MAX + 1];
-            snprintfz(filename, FILENAME_MAX, "%s/netdata.pipe", os_run_dir(false));
-            cached_pipename = strdupz(filename);
+            // os_run_dir() returns NULL when there is no usable run directory.
+            // Stay NULL too instead of formatting a name from it: a guessed path is
+            // what the run-dir validation exists to prevent, and "%s" with NULL
+            // would name "(null)/netdata.pipe". Callers report it.
+            const char *run_dir = os_run_dir(false);
+            if (run_dir && *run_dir) {
+                char filename[FILENAME_MAX + 1];
+                snprintfz(filename, FILENAME_MAX, "%s/netdata.pipe", run_dir);
+                cached_pipename = strdupz(filename);
+            }
+            else
+                netdata_log_error(
+                    "Cannot determine the netdata run directory, so the netdatacli socket has no "
+                    "name. Set NETDATA_RUN_DIR or NETDATA_PIPENAME.");
             //#endif
         }
 

--- a/src/daemon/pipename.h
+++ b/src/daemon/pipename.h
@@ -3,6 +3,9 @@
 #ifndef DAEMON_PIPENAME_H
 #define DAEMON_PIPENAME_H
 
+// The netdatacli socket path: NETDATA_PIPENAME when set, otherwise
+// "<run dir>/netdata.pipe". Returns NULL when there is no usable run directory to
+// derive it from, so every caller MUST check before using the result.
 const char *daemon_pipename(void);
 
 #endif /* DAEMON_PIPENAME_H */

--- a/src/libnetdata/os/os.h
+++ b/src/libnetdata/os/os.h
@@ -39,6 +39,7 @@
 #include "process_path.h"
 #include "boottime.h"
 #include "boot_id.h"
+#include "privileged_dir.h"
 #include "run_dir.h"
 #include "file_lock.h"
 #include "mmap_limit.h"

--- a/src/libnetdata/os/privileged_dir.c
+++ b/src/libnetdata/os/privileged_dir.c
@@ -58,6 +58,54 @@ bool os_dir_path_trim(const char *path, char *dst, size_t dst_size) {
     return true;
 }
 
+// Split a trimmed path into the directory holding its final component and that
+// component. Returns false for "/", which is its own parent and has no final
+// component to judge.
+static bool os_dir_split_parent(const char *dir, char *parent, size_t parent_size, const char **leaf) {
+    // walk back to the slash separating the final component
+    size_t cut = strlen(dir);
+    while(cut > 0 && dir[cut - 1] != '/')
+        cut--;
+
+    if(cut == 0) {
+        // a relative path with no slash at all - the parent is the cwd
+        if(parent_size < 2) return false;
+        parent[0] = '.';
+        parent[1] = '\0';
+    }
+    else if(cut == 1) {
+        if(!dir[1]) return false; // dir is "/" itself
+        if(parent_size < 2) return false;
+        parent[0] = '/';
+        parent[1] = '\0';
+    }
+    else {
+        size_t plen = cut - 1; // drop the separating slash
+        if(plen >= parent_size) return false;
+        memcpy(parent, dir, plen);
+        parent[plen] = '\0';
+    }
+
+    *leaf = dir + cut;
+    return true;
+}
+
+// The trust rules, applied to a directory we have already examined.
+static OS_DIR_PARENT_TRUST os_dir_trust_of_stat(const struct stat *st) {
+    // root, or ourselves when netdata runs unprivileged: in both cases nobody
+    // with less privilege than us can create an entry here
+    if(st->st_uid != 0 && st->st_uid != geteuid())
+        return OS_DIR_PARENT_UNSAFE;
+
+    if(!(st->st_mode & (S_IWGRP | S_IWOTH)))
+        return OS_DIR_PARENT_EXCLUSIVE;
+
+    if(st->st_mode & S_ISVTX)
+        return OS_DIR_PARENT_STICKY;
+
+    return OS_DIR_PARENT_UNSAFE;
+}
+
 OS_DIR_PARENT_TRUST os_dir_parent_trust(const char *path) {
     // Trim first, always: without it "<symlink>/." would have us compute the
     // string parent "<symlink>" and then stat() straight through it, so the
@@ -67,43 +115,19 @@ OS_DIR_PARENT_TRUST os_dir_parent_trust(const char *path) {
     if(!os_dir_path_trim(path, dir, sizeof(dir)))
         return OS_DIR_PARENT_UNKNOWN;
 
-    // walk back to the slash separating the final component
-    size_t cut = strlen(dir);
-    while(cut > 0 && dir[cut - 1] != '/')
-        cut--;
-
     char parent[FILENAME_MAX + 1];
-    if(cut == 0) {
-        // a relative path with no slash at all - the parent is the cwd
-        parent[0] = '.';
-        parent[1] = '\0';
-    }
-    else if(cut == 1) {
+    const char *leaf;
+    if(!os_dir_split_parent(dir, parent, sizeof(parent), &leaf)) {
+        // "/" is its own parent
         parent[0] = '/';
         parent[1] = '\0';
-    }
-    else {
-        size_t plen = cut - 1; // drop the separating slash
-        memcpy(parent, dir, plen);
-        parent[plen] = '\0';
     }
 
     struct stat st;
     if(stat(parent, &st) == -1)
         return OS_DIR_PARENT_UNKNOWN;
 
-    // root, or ourselves when netdata runs unprivileged: in both cases nobody
-    // with less privilege than us can create an entry here
-    if(st.st_uid != 0 && st.st_uid != geteuid())
-        return OS_DIR_PARENT_UNSAFE;
-
-    if(!(st.st_mode & (S_IWGRP | S_IWOTH)))
-        return OS_DIR_PARENT_EXCLUSIVE;
-
-    if(st.st_mode & S_ISVTX)
-        return OS_DIR_PARENT_STICKY;
-
-    return OS_DIR_PARENT_UNSAFE;
+    return os_dir_trust_of_stat(&st);
 }
 
 int os_open_dir_privileged(const char *path) {
@@ -116,12 +140,41 @@ int os_open_dir_privileged(const char *path) {
 
     int flags = O_RDONLY | O_DIRECTORY | O_CLOEXEC;
 
+    char parent[FILENAME_MAX + 1];
+    const char *leaf;
+    if(!os_dir_split_parent(dir, parent, sizeof(parent), &leaf))
+        return open(dir, flags); // dir is "/": there is no final component to protect
+
+    // Judge and use the same directory. Deciding on stat(parent) and then
+    // open()ing the whole path resolves the intermediate components a second
+    // time, so the directory we trusted need not be the one the final component
+    // is then looked up in: anyone able to retarget or rename a component above
+    // the parent can make the two disagree. Holding one descriptor and looking
+    // the entry up through it removes that gap.
+    int parent_fd = open(parent, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if(parent_fd == -1)
+        return -1;
+
+    struct stat st;
+    if(fstat(parent_fd, &st) == -1) {
+        int e = errno;
+        close(parent_fd);
+        errno = e;
+        return -1;
+    }
+
     // Following a symlink at the final component is only safe when we are the
     // only account that could have put it there. So /var/cache/netdata may point
     // to another filesystem (its parent /var/cache is root-only), while
     // /var/lib/netdata/cloud.d may not (its parent is writable by netdata).
-    if(os_dir_parent_trust(dir) != OS_DIR_PARENT_EXCLUSIVE)
+    if(os_dir_trust_of_stat(&st) != OS_DIR_PARENT_EXCLUSIVE)
         flags |= O_NOFOLLOW;
 
-    return open(dir, flags);
+    // os_dir_path_trim() guarantees the final component is neither "." nor "..",
+    // so this cannot be pointed back at the parent or above it.
+    int fd = openat(parent_fd, leaf, flags);
+    int e = errno;
+    close(parent_fd);
+    errno = e;
+    return fd;
 }

--- a/src/libnetdata/os/privileged_dir.c
+++ b/src/libnetdata/os/privileged_dir.c
@@ -8,8 +8,10 @@
 #endif
 
 bool os_dir_path_trim(const char *path, char *dst, size_t dst_size) {
-    if(!path || !*path || !dst || !dst_size)
+    if(!path || !*path || !dst || !dst_size) {
+        errno = EINVAL;
         return false;
+    }
 
     size_t len = strlen(path);
 
@@ -41,11 +43,15 @@ bool os_dir_path_trim(const char *path, char *dst, size_t dst_size) {
 
     size_t component = len - cut;
     if((component == 1 && path[cut] == '.') ||
-       (component == 2 && path[cut] == '.' && path[cut + 1] == '.'))
+       (component == 2 && path[cut] == '.' && path[cut + 1] == '.')) {
+        errno = EINVAL;
         return false;
+    }
 
-    if(len >= dst_size)
+    if(len >= dst_size) {
+        errno = ENAMETOOLONG;
         return false;
+    }
 
     memcpy(dst, path, len);
     dst[len] = '\0';
@@ -104,10 +110,9 @@ int os_open_dir_privileged(const char *path) {
     // A configured path may carry a trailing slash, which would make O_NOFOLLOW
     // below a no-op. Decide and open on the trimmed path, never on the original.
     char dir[FILENAME_MAX + 1];
-    if(!os_dir_path_trim(path, dir, sizeof(dir))) {
-        errno = ENAMETOOLONG;
+    if(!os_dir_path_trim(path, dir, sizeof(dir)))
+        // errno is already EINVAL (nothing left to name) or ENAMETOOLONG
         return -1;
-    }
 
     int flags = O_RDONLY | O_DIRECTORY | O_CLOEXEC;
 

--- a/src/libnetdata/os/privileged_dir.c
+++ b/src/libnetdata/os/privileged_dir.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "privileged_dir.h"
+
+// not defined on all build targets; 0 makes the sticky case degrade to UNSAFE
+#ifndef S_ISVTX
+#define S_ISVTX 0
+#endif
+
+bool os_dir_path_trim(const char *path, char *dst, size_t dst_size) {
+    if(!path || !*path || !dst || !dst_size)
+        return false;
+
+    size_t len = strlen(path);
+
+    // Remove everything that would make the kernel resolve the final component
+    // as a directory rather than look at the entry itself. Both trailing
+    // slashes and trailing "." components do that, and they can be interleaved
+    // and repeated ("evil/.", "evil/./", "evil/.//./"), so keep going until
+    // neither applies.
+    for(bool trimmed = true; trimmed; ) {
+        trimmed = false;
+
+        while(len > 1 && path[len - 1] == '/') {
+            len--;
+            trimmed = true;
+        }
+
+        if(len >= 2 && path[len - 1] == '.' && path[len - 2] == '/') {
+            len--;
+            trimmed = true;
+        }
+    }
+
+    // What is left must name an entry. A final "." or ".." names a directory
+    // *through* the component before it, so there is nothing left to check and
+    // we would end up judging the wrong inode - refuse instead.
+    size_t cut = len;
+    while(cut > 0 && path[cut - 1] != '/')
+        cut--;
+
+    size_t component = len - cut;
+    if((component == 1 && path[cut] == '.') ||
+       (component == 2 && path[cut] == '.' && path[cut + 1] == '.'))
+        return false;
+
+    if(len >= dst_size)
+        return false;
+
+    memcpy(dst, path, len);
+    dst[len] = '\0';
+    return true;
+}
+
+OS_DIR_PARENT_TRUST os_dir_parent_trust(const char *path) {
+    // Trim first, always: without it "<symlink>/." would have us compute the
+    // string parent "<symlink>" and then stat() straight through it, so the
+    // trust class would be read off the symlink's target instead of the
+    // directory that actually holds the entry.
+    char dir[FILENAME_MAX + 1];
+    if(!os_dir_path_trim(path, dir, sizeof(dir)))
+        return OS_DIR_PARENT_UNKNOWN;
+
+    // walk back to the slash separating the final component
+    size_t cut = strlen(dir);
+    while(cut > 0 && dir[cut - 1] != '/')
+        cut--;
+
+    char parent[FILENAME_MAX + 1];
+    if(cut == 0) {
+        // a relative path with no slash at all - the parent is the cwd
+        parent[0] = '.';
+        parent[1] = '\0';
+    }
+    else if(cut == 1) {
+        parent[0] = '/';
+        parent[1] = '\0';
+    }
+    else {
+        size_t plen = cut - 1; // drop the separating slash
+        memcpy(parent, dir, plen);
+        parent[plen] = '\0';
+    }
+
+    struct stat st;
+    if(stat(parent, &st) == -1)
+        return OS_DIR_PARENT_UNKNOWN;
+
+    // root, or ourselves when netdata runs unprivileged: in both cases nobody
+    // with less privilege than us can create an entry here
+    if(st.st_uid != 0 && st.st_uid != geteuid())
+        return OS_DIR_PARENT_UNSAFE;
+
+    if(!(st.st_mode & (S_IWGRP | S_IWOTH)))
+        return OS_DIR_PARENT_EXCLUSIVE;
+
+    if(st.st_mode & S_ISVTX)
+        return OS_DIR_PARENT_STICKY;
+
+    return OS_DIR_PARENT_UNSAFE;
+}
+
+int os_open_dir_privileged(const char *path) {
+    // A configured path may carry a trailing slash, which would make O_NOFOLLOW
+    // below a no-op. Decide and open on the trimmed path, never on the original.
+    char dir[FILENAME_MAX + 1];
+    if(!os_dir_path_trim(path, dir, sizeof(dir))) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
+    int flags = O_RDONLY | O_DIRECTORY | O_CLOEXEC;
+
+    // Following a symlink at the final component is only safe when we are the
+    // only account that could have put it there. So /var/cache/netdata may point
+    // to another filesystem (its parent /var/cache is root-only), while
+    // /var/lib/netdata/cloud.d may not (its parent is writable by netdata).
+    if(os_dir_parent_trust(dir) != OS_DIR_PARENT_EXCLUSIVE)
+        flags |= O_NOFOLLOW;
+
+    return open(dir, flags);
+}

--- a/src/libnetdata/os/privileged_dir.h
+++ b/src/libnetdata/os/privileged_dir.h
@@ -36,7 +36,9 @@ typedef enum {
 // directory, which silently defeats both O_NOFOLLOW and lstat()'s S_ISLNK.
 // Returns false when there is no entry left to name - a NULL/empty path, one
 // whose final component is "." or ".." (those reach a directory *through* the
-// component before them), or one that does not fit in dst.
+// component before them), or one that does not fit in dst. On failure errno is
+// ENAMETOOLONG when the result does not fit in dst, EINVAL for every other
+// reason.
 bool os_dir_path_trim(const char *path, char *dst, size_t dst_size);
 
 // Classify the directory that contains path's final component. Intermediate

--- a/src/libnetdata/os/privileged_dir.h
+++ b/src/libnetdata/os/privileged_dir.h
@@ -44,12 +44,18 @@ bool os_dir_path_trim(const char *path, char *dst, size_t dst_size);
 // Classify the directory that contains path's final component. Intermediate
 // symlinks are resolved normally (/var/run -> /run); only the final component
 // is treated as untrusted.
+// Advisory only: the answer describes the parent as it was at this instant, and
+// a caller that then acts on a path re-resolves it. Use os_open_dir_privileged()
+// when the verdict has to hold for the access it authorizes.
 OS_DIR_PARENT_TRUST os_dir_parent_trust(const char *path);
 
 // Open path as a directory descriptor, for a process that is about to act on it
 // with root privileges. A symlink at the final component is followed only when
 // the directory containing it is exclusively ours; everywhere else O_NOFOLLOW
-// refuses it. Returns the descriptor (the caller closes it) or -1.
+// refuses it. The parent is opened once and both judged and used through that
+// descriptor, so the directory the decision was made about is the directory the
+// final component is looked up in. Returns the descriptor (the caller closes it)
+// or -1.
 int os_open_dir_privileged(const char *path);
 
 #endif //NETDATA_PRIVILEGED_DIR_H

--- a/src/libnetdata/os/privileged_dir.h
+++ b/src/libnetdata/os/privileged_dir.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_PRIVILEGED_DIR_H
+#define NETDATA_PRIVILEGED_DIR_H
+
+#include "libnetdata/libnetdata.h"
+
+// How much the directory containing a path can be trusted, i.e. which accounts
+// are able to create, rename or delete the final component. This is what decides
+// whether a symlink found at that name could have been planted by somebody else,
+// and therefore whether a still-privileged netdata may follow it.
+//
+// "ours" below means owned by root or by our own effective uid - the two cases
+// where nobody with less privilege than us could have placed the entry.
+typedef enum {
+    // the parent could not be examined - assume the worst
+    OS_DIR_PARENT_UNKNOWN = 0,
+
+    // ours and not writable by group or others: only we can put anything here,
+    // so even a symlink here is one we placed
+    OS_DIR_PARENT_EXCLUSIVE,
+
+    // ours and sticky (/tmp): anyone can create entries, but only the owner of
+    // an entry can rename or delete it
+    OS_DIR_PARENT_STICKY,
+
+    // somebody else can replace entries here at will
+    OS_DIR_PARENT_UNSAFE,
+} OS_DIR_PARENT_TRUST;
+
+// Copy path into dst so that its final component names the entry itself ("/"
+// stays "/"). Trailing slashes and trailing "." components are removed, in any
+// combination and repetition.
+// This MUST happen before any check that depends on the final component being
+// the entry: with "dir/" or "dir/." the kernel resolves that component as a
+// directory, which silently defeats both O_NOFOLLOW and lstat()'s S_ISLNK.
+// Returns false when there is no entry left to name - a NULL/empty path, one
+// whose final component is "." or ".." (those reach a directory *through* the
+// component before them), or one that does not fit in dst.
+bool os_dir_path_trim(const char *path, char *dst, size_t dst_size);
+
+// Classify the directory that contains path's final component. Intermediate
+// symlinks are resolved normally (/var/run -> /run); only the final component
+// is treated as untrusted.
+OS_DIR_PARENT_TRUST os_dir_parent_trust(const char *path);
+
+// Open path as a directory descriptor, for a process that is about to act on it
+// with root privileges. A symlink at the final component is followed only when
+// the directory containing it is exclusively ours; everywhere else O_NOFOLLOW
+// refuses it. Returns the descriptor (the caller closes it) or -1.
+int os_open_dir_privileged(const char *path);
+
+#endif //NETDATA_PRIVILEGED_DIR_H

--- a/src/libnetdata/os/run_dir.c
+++ b/src/libnetdata/os/run_dir.c
@@ -77,6 +77,23 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
     // there is nothing for it to protect.
     return true;
 #else
+    // The leaf's own mode matters as much as its parent's: everything netdata
+    // puts here (the spawn server sockets, netdata.pipe) is created and used
+    // while still root, so a directory every local user can write into lets any
+    // of them pre-plant or swap those names. This is what refuses
+    // NETDATA_RUN_DIR=/tmp, which the parent check alone accepts (/tmp's parent
+    // is root-owned and exclusive).
+    // Group-write is deliberately still accepted: the shipped systemd unit
+    // creates /run/netdata with RuntimeDirectoryMode=0775 and re-applies it on
+    // every start, so refusing S_IWGRP would leave the default install with no
+    // run directory at all.
+    if (st.st_mode & S_IWOTH) {
+        netdata_log_error(
+            "Refusing run directory '%s': mode %04o lets any local user write into it",
+            dir, (unsigned int)(st.st_mode & 07777));
+        return false;
+    }
+
     switch (os_dir_parent_trust(dir)) {
         case OS_DIR_PARENT_EXCLUSIVE:
             // Nobody else can create an entry here, so whoever owns the
@@ -89,11 +106,16 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
         case OS_DIR_PARENT_STICKY:
             // The /tmp fallback. Anyone can create entries here, but sticky
             // means only the owner of an entry can rename or delete it, so
-            // requiring the directory to be ours also closes the window between
-            // this check and the privileged use that follows it (the temporary
-            // spawn server binds its socket here long before become_user()).
+            // requiring the directory to be ours keeps every third account out.
             // "Ours" has to include the uid we will drop to, because the first
-            // run creates this directory as root and then chowns it.
+            // run creates this directory as root and then chowns it - and that
+            // is also the limit of what this predicate can promise: a process
+            // already running as that uid owns the entry, so it can still swap
+            // the directory between here and the privileged use that follows
+            // (the temporary spawn server binds its socket here long before
+            // become_user()). What protects that use is performing it through a
+            // descriptor - os_open_dir_privileged() and fchown() - not this
+            // check.
             if (run_dir_owner_is_ours(st.st_uid))
                 return true;
 

--- a/src/libnetdata/os/run_dir.c
+++ b/src/libnetdata/os/run_dir.c
@@ -56,6 +56,12 @@ static inline bool is_dir_accessible(const char *dir, bool rw) {
 // controls. Unlike the parent check above it uses lstat(),
 // so intermediate symlinks (/var/run -> /run) still resolve, but a symlink at
 // the final component is refused.
+//
+// rw distinguishes the two callers, because they are exposed to different things.
+// With rw the agent is about to create, chown and bind here while still root, so
+// the full rule applies. Without rw the caller only reads or connects to what is
+// already there - netdatacli looking for netdata.pipe, a plugin looking for a
+// socket - and one requirement is dropped for it: see the sticky case below.
 bool os_run_dir_is_safe(const char *candidate, bool rw) {
     // Trimmed here, not just in the callers: with a trailing slash the kernel
     // resolves the final component as a directory, so lstat() would report a
@@ -66,13 +72,29 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
 
     struct stat st;
     if (lstat(dir, &st) == -1)
+        // nothing is there (yet) - silent, the caller tries the next candidate or
+        // creates it
         return false;
 
-    // S_ISLNK is implied by !S_ISDIR, but spell it out: this is the check that
-    // stops a pre-created /tmp/netdata -> /etc from becoming our run dir.
-    if (S_ISLNK(st.st_mode) || !S_ISDIR(st.st_mode))
+    // The check that stops a pre-created /tmp/netdata -> /etc from becoming our run
+    // dir. Kept separate from the !S_ISDIR case below, which it implies, so each
+    // refusal can say which one it was: a refusal here relocates the agent to the
+    // next candidate (typically /tmp/netdata), and an operator who symlinked the run
+    // directory on purpose would otherwise have nothing to go on.
+    if (S_ISLNK(st.st_mode)) {
+        netdata_log_error(
+            "Refusing run directory '%s': it is a symbolic link. Point NETDATA_RUN_DIR at the "
+            "directory itself, or bind-mount it there.", dir);
         return false;
+    }
 
+    if (!S_ISDIR(st.st_mode)) {
+        netdata_log_error("Refusing run directory '%s': not a directory", dir);
+        return false;
+    }
+
+    // silent: "we cannot use this one" is a normal outcome while probing the
+    // built-in candidates, not a misconfiguration
     if (access(dir, rw ? W_OK : R_OK) == -1)
         return false;
 
@@ -123,7 +145,15 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
             // become_user()). What protects that use is performing it through a
             // descriptor - os_open_dir_privileged() and fchown() - not this
             // check.
-            if (run_dir_owner_is_ours(st.st_uid))
+            //
+            // A read-only caller is exempt: it creates nothing and chowns nothing,
+            // and it cannot answer the question anyway - netdatacli run by root
+            // does not know which uid the agent runs as, so requiring the
+            // directory to be "ours" only made it unable to find an agent that
+            // uses this fallback. Everything else above still applies to it, so it
+            // cannot be pointed elsewhere by a planted symlink, and the socket's
+            // own mode is what decides whether it may actually talk to the agent.
+            if (!rw || run_dir_owner_is_ours(st.st_uid))
                 return true;
 
             netdata_log_error(

--- a/src/libnetdata/os/run_dir.c
+++ b/src/libnetdata/os/run_dir.c
@@ -14,6 +14,21 @@ static char *superseded_run_dir = NULL;
 
 static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
+// A process that cannot get a run directory usually keeps asking. Nothing retries
+// on a timer, but spawn_popen_run_argv() re-creates the spawn server on every
+// popen() for as long as it has none, and every attempt walks the same candidates
+// and refuses them for the same reasons. The explanation is worth printing once;
+// printing it per popen() buries the rest of the log.
+// Deliberately not a cached failure: the candidates are re-examined, so a run
+// directory that appears later is still picked up. Only the reporting stops.
+// Advisory: a race can duplicate or drop a line, never change what is returned.
+static bool run_dir_report_errors = true;
+
+#define run_dir_log_error(...) do {                                             \
+        if (run_dir_report_errors)                                              \
+            netdata_log_error(__VA_ARGS__);                                     \
+    } while(0)
+
 static uid_t target_uid = (uid_t)-1;
 
 void os_run_dir_set_target_uid(uid_t uid) {
@@ -61,7 +76,8 @@ static inline bool is_dir_accessible(const char *dir, bool rw) {
 // With rw the agent is about to create, chown and bind here while still root, so
 // the full rule applies. Without rw the caller only reads or connects to what is
 // already there - netdatacli looking for netdata.pipe, a plugin looking for a
-// socket - and one requirement is dropped for it: see the sticky case below.
+// socket - and the rules about who else could replace the directory do not apply
+// to it, because it is not what they protect: see the read-only cut below.
 bool os_run_dir_is_safe(const char *candidate, bool rw) {
     // Trimmed here, not just in the callers: with a trailing slash the kernel
     // resolves the final component as a directory, so lstat() would report a
@@ -82,14 +98,14 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
     // next candidate (typically /tmp/netdata), and an operator who symlinked the run
     // directory on purpose would otherwise have nothing to go on.
     if (S_ISLNK(st.st_mode)) {
-        netdata_log_error(
+        run_dir_log_error(
             "Refusing run directory '%s': it is a symbolic link. Point NETDATA_RUN_DIR at the "
             "directory itself, or bind-mount it there.", dir);
         return false;
     }
 
     if (!S_ISDIR(st.st_mode)) {
-        netdata_log_error("Refusing run directory '%s': not a directory", dir);
+        run_dir_log_error("Refusing run directory '%s': not a directory", dir);
         return false;
     }
 
@@ -97,6 +113,24 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
     // built-in candidates, not a misconfiguration
     if (access(dir, rw ? W_OK : R_OK) == -1)
         return false;
+
+    // Everything above applies to every caller: whatever it does next, it must not
+    // be pointed at another directory by a symlink planted at this name.
+    //
+    // Everything below is about who may replace this directory while we act on it
+    // as root, so it is the writable caller's question alone. A read-only caller
+    // creates nothing, chowns nothing and binds nothing - it opens what is already
+    // there, and the socket's own mode decides whether it may talk to the agent.
+    // Answering it anyway had a cost and no benefit:
+    //  - it broke ordinary non-root installs. A run directory under a parent owned
+    //    by the netdata user (a source install, NETDATA_RUN_DIR=~netdata/run) is
+    //    UNSAFE to a client running as root, so netdatacli could not find an agent
+    //    that was running perfectly well.
+    //  - the sticky case below already concedes the same threat for read-only
+    //    callers: a /tmp/netdata planted by a third account passes it. Refusing the
+    //    strictly safer shapes while allowing that one is not a policy.
+    if (!rw)
+        return true;
 
 #if defined(OS_WINDOWS)
     // Windows has no POSIX ownership: Cygwin synthesizes st_uid from the NTFS
@@ -117,7 +151,7 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
     // every start, so refusing S_IWGRP would leave the default install with no
     // run directory at all.
     if (st.st_mode & S_IWOTH) {
-        netdata_log_error(
+        run_dir_log_error(
             "Refusing run directory '%s': mode %04o lets any local user write into it",
             dir, (unsigned int)(st.st_mode & 07777));
         return false;
@@ -145,30 +179,30 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
             // become_user()). What protects that use is performing it through a
             // descriptor - os_open_dir_privileged() and fchown() - not this
             // check.
-            //
-            // A read-only caller is exempt: it creates nothing and chowns nothing,
-            // and it cannot answer the question anyway - netdatacli run by root
-            // does not know which uid the agent runs as, so requiring the
-            // directory to be "ours" only made it unable to find an agent that
-            // uses this fallback. Everything else above still applies to it, so it
-            // cannot be pointed elsewhere by a planted symlink, and the socket's
-            // own mode is what decides whether it may actually talk to the agent.
-            if (!rw || run_dir_owner_is_ours(st.st_uid))
+            if (run_dir_owner_is_ours(st.st_uid))
                 return true;
 
-            netdata_log_error(
+            run_dir_log_error(
                 "Refusing run directory '%s': owned by uid %u, inside a world-writable parent",
                 dir, (unsigned int)st.st_uid);
             return false;
 
         case OS_DIR_PARENT_UNKNOWN:
-            netdata_log_error("Refusing run directory '%s': cannot examine its parent directory", dir);
+            run_dir_log_error("Refusing run directory '%s': cannot examine its parent directory", dir);
             return false;
 
         default:
-            netdata_log_error(
-                "Refusing run directory '%s': anyone can replace it, because its parent is neither "
-                "ours nor sticky. Set NETDATA_RUN_DIR to a directory only netdata can write into.",
+            // Not "anyone": name what is actually wrong, because the two shapes
+            // that land here have different fixes. The parent either belongs to
+            // another account - including the account we are about to become, which
+            // is the whole point of checking while we are still root - or is
+            // writable by others without the sticky bit that would stop them
+            // renaming what is inside it.
+            run_dir_log_error(
+                "Refusing run directory '%s': its parent directory is not exclusively ours, so "
+                "another account can replace this directory while we are still root. Set "
+                "NETDATA_RUN_DIR to a directory whose parent is owned by root and is not writable "
+                "by group or others.",
                 dir);
             return false;
     }
@@ -200,7 +234,10 @@ static char *detect_run_dir(bool rw) {
 
     // An operator-supplied run dir (e.g. a mounted tmpfs in a hardened,
     // read-only-/run container) is honored, but gets the same validation as
-    // every other branch, since it is chowned as root.
+    // every other branch, since it is chowned as root. For a writable resolution
+    // that includes its parent: pointing this at a directory inside a tree the
+    // netdata account owns is refused while we are still root, because that
+    // account could swap it under us. Its parent has to be root-owned too.
     const char *env_dir = getenv("NETDATA_RUN_DIR");
     if (env_dir && *env_dir) {
         // trim first: a trailing slash makes the kernel resolve the final
@@ -210,7 +247,7 @@ static char *detect_run_dir(bool rw) {
 
         // an operator asked for this directory explicitly - never fall through
         // to the built-in branches without saying why
-        netdata_log_error("Ignoring NETDATA_RUN_DIR='%s': not a usable run directory", env_dir);
+        run_dir_log_error("Ignoring NETDATA_RUN_DIR='%s': not a usable run directory", env_dir);
     }
 
 #if defined(OS_LINUX)
@@ -325,6 +362,11 @@ const char *os_run_dir(bool rw) {
                 __atomic_store_n(&cached_run_dir_writable, true, __ATOMIC_RELEASE);
             __atomic_store_n(&cached_run_dir_available, true, __ATOMIC_RELEASE);
         }
+        else
+            // Every candidate has just been walked and refused, and each refusal
+            // has said why. A caller that comes back gets the same walk and the
+            // same reasons, so stop repeating them - see run_dir_report_errors.
+            run_dir_report_errors = false;
 
         // When no writable directory exists, the read-only answer stays cached
         // for the read-only callers, but this caller gets nothing: it asked for a

--- a/src/libnetdata/os/run_dir.c
+++ b/src/libnetdata/os/run_dir.c
@@ -116,7 +116,16 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
 
     // Everything above applies to every caller: whatever it does next, it must not
     // be pointed at another directory by a symlink planted at this name.
-    //
+
+#if defined(OS_WINDOWS)
+    // Nothing below applies here, for either caller. Windows has no POSIX
+    // ownership: Cygwin synthesizes st_uid from the NTFS ACL (there is no uid 0)
+    // and never reports a sticky bit unless one was set explicitly, so those checks
+    // would refuse every candidate and leave the agent with no run dir at all.
+    // There is also no privilege drop here, so there is nothing for them to
+    // protect.
+    return true;
+#else
     // Everything below is about who may replace this directory while we act on it
     // as root, so it is the writable caller's question alone. A read-only caller
     // creates nothing, chowns nothing and binds nothing - it opens what is already
@@ -132,14 +141,6 @@ bool os_run_dir_is_safe(const char *candidate, bool rw) {
     if (!rw)
         return true;
 
-#if defined(OS_WINDOWS)
-    // Windows has no POSIX ownership: Cygwin synthesizes st_uid from the NTFS
-    // ACL (there is no uid 0) and never reports a sticky bit unless one was set
-    // explicitly, so the check below would refuse every candidate and leave the
-    // agent with no run dir at all. There is also no privilege drop here, so
-    // there is nothing for it to protect.
-    return true;
-#else
     // The leaf's own mode matters as much as its parent's: everything netdata
     // puts here (the spawn server sockets, netdata.pipe) is created and used
     // while still root, so a directory every local user can write into lets any

--- a/src/libnetdata/os/run_dir.c
+++ b/src/libnetdata/os/run_dir.c
@@ -5,6 +5,13 @@
 
 static char *cached_run_dir = NULL;
 static bool cached_run_dir_available = false;
+static bool cached_run_dir_writable = false; // the cached answer satisfied a writable request
+
+// A read-only answer that has already been handed out, superseded by a writable
+// one. Retained, not freed: callers are allowed to keep the pointer they got,
+// which used to live for the whole process. At most one string per process.
+static char *superseded_run_dir = NULL;
+
 static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
 static uid_t target_uid = (uid_t)-1;
@@ -248,20 +255,51 @@ success:
 }
 
 const char *os_run_dir(bool rw) {
-    // Fast path - return cached directory if available
-    if(__atomic_load_n(&cached_run_dir_available, __ATOMIC_ACQUIRE))
-        return cached_run_dir;
+    // Fast path - reuse the cached directory only when it answers this request.
+    // cached_run_dir_writable implies cached_run_dir_available, so the writable
+    // flag is the whole test for rw callers.
+    if(__atomic_load_n(rw ? &cached_run_dir_writable : &cached_run_dir_available, __ATOMIC_ACQUIRE))
+        return __atomic_load_n(&cached_run_dir, __ATOMIC_ACQUIRE);
 
     spinlock_lock(&spinlock);
 
     // Check again under lock in case another thread set it
     char *run_dir = cached_run_dir;
-    if(!run_dir) {
-        run_dir = detect_run_dir(rw);
-        cached_run_dir = run_dir;
 
-        if(run_dir)
+    // A read-only resolution reports what already exists: it creates nothing and
+    // only asks for R_OK. So it can settle on a directory we cannot write into
+    // (a read-only /run bind mount, a root-owned /run/netdata when we are not
+    // root), or on the /tmp fallback while /run/netdata simply does not exist
+    // yet. Handing that answer to the first writable caller would make its
+    // bind()/mkdir() fail on a directory nobody validated for writing - and it
+    // would also skip the nd_setenv() that tells our children where the run dir
+    // is. Detect again instead.
+    if(!run_dir || (rw && !cached_run_dir_writable)) {
+        char *found = detect_run_dir(rw);
+
+        if(found && run_dir) {
+            if(strcmp(run_dir, found) == 0) {
+                // same directory, only its validation got stronger - keep the
+                // pointer callers already have
+                freez(found);
+                found = run_dir;
+            }
+            else
+                superseded_run_dir = run_dir;
+        }
+
+        if(found) {
+            // published before the flags, so a reader that sees a flag sees this
+            __atomic_store_n(&cached_run_dir, found, __ATOMIC_RELEASE);
+            if(rw)
+                __atomic_store_n(&cached_run_dir_writable, true, __ATOMIC_RELEASE);
             __atomic_store_n(&cached_run_dir_available, true, __ATOMIC_RELEASE);
+        }
+
+        // When no writable directory exists, the read-only answer stays cached
+        // for the read-only callers, but this caller gets nothing: it asked for a
+        // directory it can write into, and there is none.
+        run_dir = found;
     }
 
     spinlock_unlock(&spinlock);

--- a/src/libnetdata/os/run_dir.c
+++ b/src/libnetdata/os/run_dir.c
@@ -7,6 +7,28 @@ static char *cached_run_dir = NULL;
 static bool cached_run_dir_available = false;
 static SPINLOCK spinlock = SPINLOCK_INITIALIZER;
 
+static uid_t target_uid = (uid_t)-1;
+
+void os_run_dir_set_target_uid(uid_t uid) {
+    __atomic_store_n(&target_uid, uid, __ATOMIC_RELEASE);
+}
+
+// The accounts a run directory may belong to without it being somebody else's:
+// root, whoever we are now, and the uid we are about to become. getuid() is
+// checked as well as geteuid() because the setuid-root plugins (apps.plugin,
+// network-viewer.plugin, ...) run with euid 0 and the netdata uid as their real
+// uid, and must accept the same run dir the daemon created.
+static inline bool run_dir_owner_is_ours(uid_t owner) {
+    if (owner == 0 || owner == geteuid() || owner == getuid())
+        return true;
+
+    uid_t target = __atomic_load_n(&target_uid, __ATOMIC_ACQUIRE);
+    return target != (uid_t)-1 && owner == target;
+}
+
+// Parent-directory check. Follows symlinks intentionally: parents such as
+// /var/run are frequently a symlink to /run on modern systems, so rejecting a
+// symlinked parent would break the /var/run branch everywhere.
 static inline bool is_dir_accessible(const char *dir, bool rw) {
     struct stat st;
     if (stat(dir, &st) == -1)
@@ -22,30 +44,114 @@ static inline bool is_dir_accessible(const char *dir, bool rw) {
     return true;
 }
 
+// Run-directory (leaf) check. netdata binds its sockets here and chowns it while
+// still running as root, so this directory must not be one another local user
+// controls. Unlike the parent check above it uses lstat(),
+// so intermediate symlinks (/var/run -> /run) still resolve, but a symlink at
+// the final component is refused.
+bool os_run_dir_is_safe(const char *candidate, bool rw) {
+    // Trimmed here, not just in the callers: with a trailing slash the kernel
+    // resolves the final component as a directory, so lstat() would report a
+    // planted symlink's target and every check below would pass.
+    char dir[FILENAME_MAX + 1];
+    if (!os_dir_path_trim(candidate, dir, sizeof(dir)))
+        return false;
+
+    struct stat st;
+    if (lstat(dir, &st) == -1)
+        return false;
+
+    // S_ISLNK is implied by !S_ISDIR, but spell it out: this is the check that
+    // stops a pre-created /tmp/netdata -> /etc from becoming our run dir.
+    if (S_ISLNK(st.st_mode) || !S_ISDIR(st.st_mode))
+        return false;
+
+    if (access(dir, rw ? W_OK : R_OK) == -1)
+        return false;
+
+#if defined(OS_WINDOWS)
+    // Windows has no POSIX ownership: Cygwin synthesizes st_uid from the NTFS
+    // ACL (there is no uid 0) and never reports a sticky bit unless one was set
+    // explicitly, so the check below would refuse every candidate and leave the
+    // agent with no run dir at all. There is also no privilege drop here, so
+    // there is nothing for it to protect.
+    return true;
+#else
+    switch (os_dir_parent_trust(dir)) {
+        case OS_DIR_PARENT_EXCLUSIVE:
+            // Nobody else can create an entry here, so whoever owns the
+            // directory, we are the ones who put it there. Its ownership is
+            // therefore not our business - it legitimately differs per install:
+            // tmpfiles.d creates /run/netdata owned by the netdata user, while
+            // systemd's RuntimeDirectory= with User=root makes it root:netdata.
+            return true;
+
+        case OS_DIR_PARENT_STICKY:
+            // The /tmp fallback. Anyone can create entries here, but sticky
+            // means only the owner of an entry can rename or delete it, so
+            // requiring the directory to be ours also closes the window between
+            // this check and the privileged use that follows it (the temporary
+            // spawn server binds its socket here long before become_user()).
+            // "Ours" has to include the uid we will drop to, because the first
+            // run creates this directory as root and then chowns it.
+            if (run_dir_owner_is_ours(st.st_uid))
+                return true;
+
+            netdata_log_error(
+                "Refusing run directory '%s': owned by uid %u, inside a world-writable parent",
+                dir, (unsigned int)st.st_uid);
+            return false;
+
+        case OS_DIR_PARENT_UNKNOWN:
+            netdata_log_error("Refusing run directory '%s': cannot examine its parent directory", dir);
+            return false;
+
+        default:
+            netdata_log_error(
+                "Refusing run directory '%s': anyone can replace it, because its parent is neither "
+                "ours nor sticky. Set NETDATA_RUN_DIR to a directory only netdata can write into.",
+                dir);
+            return false;
+    }
+#endif
+}
+
 static inline bool netdata_dir_in_parent(const char *parent, char *out_path, size_t out_path_len, bool rw) {
     int ret = snprintf(out_path, out_path_len, "%s/netdata", parent);
     if (ret < 0 || (size_t)ret >= out_path_len)
         return false;
 
-    if (is_dir_accessible(out_path, rw))
+    if (os_run_dir_is_safe(out_path, rw))
         return true;
 
-    if (!is_dir_accessible(parent, rw))
+    // a read-only resolution reports what exists; it does not create anything
+    if (!rw || !is_dir_accessible(parent, rw))
         return false;
 
     if (mkdir(out_path, 0755) == -1 && errno != EEXIST)
         return false;
 
-    return is_dir_accessible(out_path, rw);
+    // Re-validate after mkdir(): on EEXIST the directory is one we did not
+    // create, so it could be a symlink or a directory planted by another user.
+    return os_run_dir_is_safe(out_path, rw);
 }
 
 static char *detect_run_dir(bool rw) {
     char path[FILENAME_MAX + 1];
 
+    // An operator-supplied run dir (e.g. a mounted tmpfs in a hardened,
+    // read-only-/run container) is honored, but gets the same validation as
+    // every other branch, since it is chowned as root.
     const char *env_dir = getenv("NETDATA_RUN_DIR");
     if (env_dir && *env_dir) {
-        if (is_dir_accessible(env_dir, rw))
-            return strdupz(env_dir);
+        // trim first: a trailing slash makes the kernel resolve the final
+        // component as a directory, which would defeat the symlink checks
+        if (os_dir_path_trim(env_dir, path, sizeof(path)) && os_run_dir_is_safe(path, rw))
+            return strdupz(path);
+
+        // an operator asked for this directory explicitly - never fall through
+        // to the built-in branches without saying why
+        netdata_log_error("Ignoring NETDATA_RUN_DIR='%s': not a usable run directory", env_dir);
     }
 
 #if defined(OS_LINUX)
@@ -96,16 +202,20 @@ static char *detect_run_dir(bool rw) {
 //    }
 //#endif
 
-    // Fallback to /tmp/netdata - force creation if needed
+    // Fallback to /tmp/netdata - force creation if needed.
+    // /tmp is world-writable, so this is the branch an unprivileged user can
+    // plant. os_run_dir_is_safe() requires the directory to be ours and /tmp to be
+    // sticky, so a planted one is refused instead of adopted.
     if (!is_dir_accessible("/tmp", rw)) {
         // Try to create /tmp with standard permissions (including sticky bit)
         if (rw && mkdir("/tmp", 01777) == -1 && errno != EEXIST)
             return NULL;
     }
 
-    snprintfz(path, sizeof(path), "/tmp/netdata");
-    if (rw && mkdir(path, 0755) == -1 && errno != EEXIST)
-        return NULL;
+    if (netdata_dir_in_parent("/tmp", path, sizeof(path), rw))
+        goto success;
+
+    return NULL;
 
 success:
     // Set the environment variable for child processes

--- a/src/libnetdata/os/run_dir.h
+++ b/src/libnetdata/os/run_dir.h
@@ -43,12 +43,17 @@ void os_run_dir_set_target_uid(uid_t uid);
  * could have planted or could replace. Trailing slashes are trimmed internally,
  * so a caller cannot accidentally disable the symlink check by passing one.
  *
- * rw is the level of validation, not just an access mode. With rw the directory is
- * about to be created, chowned and bound to while still root, so in a
- * world-writable sticky parent (the /tmp fallback) it must also belong to us or to
- * the declared "run as user". A read-only caller is exempt from that one
- * requirement: it only reads or connects, and it cannot know which uid the agent
- * runs as.
+ * rw is the level of validation, not just an access mode. Both levels refuse a
+ * symlinked final component, a non-directory, and anything we cannot access - no
+ * caller may be redirected by a symlink planted at this name.
+ *
+ * With rw the directory is additionally about to be created, chowned and bound to
+ * while still root, so it must also be one no other account can replace: not
+ * world-writable, under a parent that is exclusively ours, or - in a sticky parent
+ * such as the /tmp fallback - owned by us or by the declared "run as user".
+ * A read-only caller is exempt from all of that. It creates nothing and chowns
+ * nothing, it cannot know which uid the agent runs as, and the socket's own mode
+ * decides whether it may talk to the agent.
  */
 bool os_run_dir_is_safe(const char *candidate, bool rw);
 

--- a/src/libnetdata/os/run_dir.h
+++ b/src/libnetdata/os/run_dir.h
@@ -9,8 +9,15 @@
  * Initialize and get the runtime directory for Netdata
  * This function gets or creates the runtime directory based on environment or system defaults
  *
- * @param rw When true, create the directory if it doesn't exist
- * @return const char* The runtime directory path
+ * The answer is cached for the process lifetime, per level of validation: a
+ * read-only answer only reports a directory that already exists and is readable,
+ * so the first rw=true caller re-runs the detection rather than inherit it. A
+ * pointer already returned stays valid either way.
+ *
+ * @param rw When true, the directory must be writable by us, and is created if it
+ *           does not exist. Returns NULL when there is no such directory, even if
+ *           a read-only caller already found a readable one.
+ * @return const char* The runtime directory path, or NULL
  */
 const char *os_run_dir(bool rw);
 

--- a/src/libnetdata/os/run_dir.h
+++ b/src/libnetdata/os/run_dir.h
@@ -48,9 +48,11 @@ void os_run_dir_set_target_uid(uid_t uid);
  * caller may be redirected by a symlink planted at this name.
  *
  * With rw the directory is additionally about to be created, chowned and bound to
- * while still root, so it must also be one no other account can replace: not
- * world-writable, under a parent that is exclusively ours, or - in a sticky parent
- * such as the /tmp fallback - owned by us or by the declared "run as user".
+ * while still root, so it must also be one no other account can replace. Both of
+ * the following must hold:
+ *   - it is not world-writable, whatever its parent looks like; and
+ *   - its parent is exclusively ours, or - in a sticky parent such as the /tmp
+ *     fallback - the directory is owned by us or by the declared "run as user".
  * A read-only caller is exempt from all of that. It creates nothing and chowns
  * nothing, it cannot know which uid the agent runs as, and the socket's own mode
  * decides whether it may talk to the agent.

--- a/src/libnetdata/os/run_dir.h
+++ b/src/libnetdata/os/run_dir.h
@@ -14,4 +14,28 @@
  */
 const char *os_run_dir(bool rw);
 
+/**
+ * Declare the uid netdata will switch to after the privilege drop.
+ *
+ * Only the daemon knows this ("run as user"), and it must call this before the
+ * first os_run_dir() call. It matters for the world-writable /tmp fallback: the
+ * first run creates /tmp/netdata as root and then chowns it to that uid, so
+ * without this the directory would look like a third account's on restart.
+ *
+ * Other processes do not call it and do not need to: a plugin runs as that uid
+ * (covered by geteuid()), and a setuid-root plugin still has it as its real uid
+ * (covered by getuid()).
+ */
+void os_run_dir_set_target_uid(uid_t uid);
+
+/**
+ * Decide whether dir may be used as the run directory.
+ *
+ * Exported so the security-critical rule is directly testable: it must refuse a
+ * symlinked final component, a non-directory, and any directory another account
+ * could have planted or could replace. Trailing slashes are trimmed internally,
+ * so a caller cannot accidentally disable the symlink check by passing one.
+ */
+bool os_run_dir_is_safe(const char *candidate, bool rw);
+
 #endif //NETDATA_RUN_DIR_H

--- a/src/libnetdata/os/run_dir.h
+++ b/src/libnetdata/os/run_dir.h
@@ -42,6 +42,13 @@ void os_run_dir_set_target_uid(uid_t uid);
  * symlinked final component, a non-directory, and any directory another account
  * could have planted or could replace. Trailing slashes are trimmed internally,
  * so a caller cannot accidentally disable the symlink check by passing one.
+ *
+ * rw is the level of validation, not just an access mode. With rw the directory is
+ * about to be created, chowned and bound to while still root, so in a
+ * world-writable sticky parent (the /tmp fallback) it must also belong to us or to
+ * the declared "run as user". A read-only caller is exempt from that one
+ * requirement: it only reads or connects, and it cannot know which uid the agent
+ * runs as.
  */
 bool os_run_dir_is_safe(const char *candidate, bool rw);
 

--- a/src/libnetdata/os/tests/run-dir-safety-test.c
+++ b/src/libnetdata/os/tests/run-dir-safety-test.c
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// netdata binds sockets in this directory and chowns it while still running as root, so
+// it must refuse anything another account could have planted or could replace.
+//
+// os_run_dir_is_safe() is exercised directly rather than through os_run_dir(),
+// which caches its answer for the process lifetime and creates directories as a
+// side effect.
+
+#include "libnetdata/libnetdata.h"
+
+static const uid_t OTHER_UID = 65530; // some third account, not us
+static const uid_t NETDATA_UID = 65531; // stands in for the configured "run as user"
+
+static char root_dir[FILENAME_MAX + 1];
+static int failures = 0;
+static int skipped = 0;
+
+static void check(const char *what, const char *dir, bool expected) {
+    bool got = os_run_dir_is_safe(dir, true);
+    if (got == expected)
+        fprintf(stderr, "  ok       %-52s (%s)\n", what, got ? "accepted" : "refused");
+    else {
+        fprintf(stderr, "  FAILED   %-52s got %s, expected %s\n",
+                what, got ? "accepted" : "refused", expected ? "accepted" : "refused");
+        failures++;
+    }
+}
+
+// Build "<root_dir>/<name>" into buf.
+static const char *under(char *buf, size_t size, const char *name) {
+    snprintfz(buf, size, "%s/%s", root_dir, name);
+    return buf;
+}
+
+static void make_parent(const char *path, mode_t mode) {
+    if (mkdir(path, 0755) == -1 && errno != EEXIST)
+        fatal("test setup: cannot create '%s'", path);
+    if (chmod(path, mode) == -1)
+        fatal("test setup: cannot chmod '%s' to %04o", path, (unsigned)mode);
+}
+
+int main(void) {
+    // the validator logs a reason for every refusal; most cases below expect one
+    nd_log_limits_unlimited();
+
+    snprintfz(root_dir, sizeof(root_dir), "/tmp/netdata-run-dir-safety-test-%d", (int)getpid());
+    if (mkdir(root_dir, 0755) == -1)
+        fatal("test setup: cannot create '%s'", root_dir);
+
+    char exclusive[FILENAME_MAX + 1], sticky[FILENAME_MAX + 1], open_parent[FILENAME_MAX + 1];
+    make_parent(under(exclusive, sizeof(exclusive), "exclusive"), 0755);   // ours, no group/other write
+    make_parent(under(sticky, sizeof(sticky), "sticky"), 01777);           // ours, world-writable + sticky
+    make_parent(under(open_parent, sizeof(open_parent), "open"), 0777);    // world-writable, NOT sticky
+
+    char p[FILENAME_MAX + 1], q[FILENAME_MAX + 1];
+
+    fprintf(stderr, "cases that need no privileges:\n");
+
+    // The reported attack: an unprivileged user pre-creates the run dir as a
+    // symlink, so the still-root daemon chowns the target instead.
+    snprintfz(p, sizeof(p), "%s/to_etc", exclusive);
+    if (symlink("/etc", p) == -1) fatal("test setup: symlink '%s'", p);
+    check("symlink to /etc", p, false);
+
+    // Same, pointing at a directory that really is ours - it is still a symlink.
+    snprintfz(p, sizeof(p), "%s/real", exclusive);
+    make_parent(p, 0755);
+    snprintfz(q, sizeof(q), "%s/to_real", exclusive);
+    if (symlink(p, q) == -1) fatal("test setup: symlink '%s'", q);
+    check("symlink to a directory we own", q, false);
+
+    // Anything that makes the kernel resolve the final component as a directory
+    // defeats both O_NOFOLLOW and lstat()'s S_ISLNK, so the symlink above must
+    // stay refused however the caller spells it. A trailing "." is the subtle
+    // one: it also makes the parent-trust lookup stat() through the symlink and
+    // read the trust class off the target.
+    snprintfz(p, sizeof(p), "%s/to_real/", exclusive);
+    check("symlink, trailing slash", p, false);
+    snprintfz(p, sizeof(p), "%s/to_real/.", exclusive);
+    check("symlink, trailing dot", p, false);
+    snprintfz(p, sizeof(p), "%s/to_real/./", exclusive);
+    check("symlink, trailing dot-slash", p, false);
+    snprintfz(p, sizeof(p), "%s/to_real/.//./", exclusive);
+    check("symlink, repeated dots and slashes", p, false);
+    snprintfz(p, sizeof(p), "%s/to_real//.", exclusive);
+    check("symlink, doubled slash then dot", p, false);
+
+    // "." and ".." reach a directory through the component before them, so there
+    // is no entry left to judge - they must be refused rather than validated
+    // against the wrong inode.
+    snprintfz(p, sizeof(p), "%s/real/..", exclusive);
+    check("path ending in '..'", p, false);
+    snprintfz(p, sizeof(p), "%s/real/.", exclusive);
+    check("real directory, trailing dot (normalises)", p, true);
+
+    snprintfz(p, sizeof(p), "%s/afile", exclusive);
+    int fd = open(p, O_WRONLY | O_CREAT | O_EXCL, 0644);
+    if (fd == -1) fatal("test setup: create '%s'", p);
+    close(fd);
+    check("a regular file, not a directory", p, false);
+
+    snprintfz(p, sizeof(p), "%s/missing", exclusive);
+    check("a path that does not exist", p, false);
+
+    // The legitimate shapes.
+    snprintfz(p, sizeof(p), "%s/real", exclusive);
+    check("real directory, parent writable only by us", p, true);
+
+    snprintfz(p, sizeof(p), "%s/ours", sticky);
+    make_parent(p, 0755);
+    check("real directory we own, sticky parent (/tmp shape)", p, true);
+
+    // Sticky is what stops another account renaming our directory away between
+    // validation and use; without it a world-writable parent is not usable.
+    snprintfz(p, sizeof(p), "%s/ours", open_parent);
+    make_parent(p, 0755);
+    check("world-writable parent without the sticky bit", p, false);
+
+    fprintf(stderr, "cases that need root:\n");
+    if (geteuid() != 0) {
+        fprintf(stderr, "  SKIPPED  third-account ownership and the restart case"
+                        " (re-run as root to cover them)\n");
+        skipped += 2;
+    }
+    else {
+        snprintfz(p, sizeof(p), "%s/foreign", sticky);
+        make_parent(p, 0755);
+        if (chown(p, OTHER_UID, OTHER_UID) == -1)
+            fatal("test setup: cannot chown '%s'", p);
+
+        // Nobody declared this uid, so it is a third account: refuse it rather
+        // than adopt a directory somebody else planted in /tmp.
+        check("sticky parent, directory owned by a third account", p, false);
+
+        // The restart case. The first run creates /tmp/netdata as root and then
+        // chowns it to the "run as user" uid, so on the next start the directory
+        // is owned by that uid and must still be recognised as ours.
+        snprintfz(q, sizeof(q), "%s/netdata_owned", sticky);
+        make_parent(q, 0755);
+        if (chown(q, NETDATA_UID, NETDATA_UID) == -1)
+            fatal("test setup: cannot chown '%s'", q);
+
+        os_run_dir_set_target_uid(NETDATA_UID);
+        check("sticky parent, directory owned by the configured uid", q, true);
+
+        // Declaring a different uid must not launder a third account's directory.
+        check("sticky parent, third account, a different uid declared", p, false);
+
+        os_run_dir_set_target_uid((uid_t)-1);
+    }
+
+    // best effort cleanup; the tree is under /tmp and named after our pid
+    char cmd[FILENAME_MAX + 32];
+    snprintfz(cmd, sizeof(cmd), "rm -rf '%s'", root_dir);
+    if (system(cmd) == -1)
+        fprintf(stderr, "warning: could not remove '%s'\n", root_dir);
+
+    if (failures) {
+        fprintf(stderr, "\n%d case(s) FAILED\n", failures);
+        return 1;
+    }
+
+    fprintf(stderr, "\nall cases passed%s\n",
+            skipped ? " (some skipped - not running as root)" : "");
+    return 0;
+}

--- a/src/libnetdata/os/tests/run-dir-safety-test.c
+++ b/src/libnetdata/os/tests/run-dir-safety-test.c
@@ -5,7 +5,9 @@
 //
 // os_run_dir_is_safe() is exercised directly rather than through os_run_dir(),
 // which caches its answer for the process lifetime and creates directories as a
-// side effect.
+// side effect. os_run_dir() itself is called only by the last case, which is
+// about that cache, and only with NETDATA_RUN_DIR pointed inside this test's own
+// temporary tree.
 
 #include "libnetdata/libnetdata.h"
 
@@ -361,6 +363,47 @@ int main(void) {
         check("sticky parent, third account, a different uid declared", p, false);
 
         os_run_dir_set_target_uid((uid_t)-1);
+    }
+
+    // os_run_dir() caches its answer for the process lifetime, so this case runs
+    // last: it is the one that populates that cache.
+    // A read-only resolution is weaker than a writable one - it creates nothing
+    // and only asks for R_OK - so it can settle on a directory we cannot write
+    // into, and the first writable caller must re-run the detection instead of
+    // inheriting that answer. Otherwise it binds its sockets in a directory
+    // nobody checked it can write into, and fails.
+    // NETDATA_RUN_DIR is repointed between the two calls purely as the probe: a
+    // detection that really re-ran lands on the second directory, an inherited
+    // answer is still the first one. Both directories are inside this test's own
+    // tree, so nothing outside it is created or consulted.
+    fprintf(stderr, "os_run_dir() caching, read-only answer then writable request:\n");
+    {
+        char ro_leaf[FILENAME_MAX + 1], rw_leaf[FILENAME_MAX + 1];
+        make_parent(under(ro_leaf, sizeof(ro_leaf), "cached_readable"), 0500); // readable, not writable
+        make_parent(under(rw_leaf, sizeof(rw_leaf), "cached_writable"), 0755);
+
+        nd_setenv("NETDATA_RUN_DIR", ro_leaf, 1);
+        const char *ro = os_run_dir(false);
+
+        nd_setenv("NETDATA_RUN_DIR", rw_leaf, 1);
+        const char *rw = os_run_dir(true);
+
+        if(!ro || strcmp(ro, ro_leaf) != 0) {
+            fprintf(stderr, "  FAILED   %-52s got '%s'\n", "read-only resolution", ro ? ro : "(null)");
+            failures++;
+        }
+        else if(rw && strcmp(rw, rw_leaf) == 0)
+            fprintf(stderr, "  ok       %-52s (re-detected)\n", "writable request after a read-only one");
+        else {
+            fprintf(stderr, "  FAILED   %-52s got '%s' - the writable request reused the "
+                            "read-only answer\n",
+                    "writable request after a read-only one", rw ? rw : "(null)");
+            failures++;
+        }
+
+        // the earlier read-only answer stays valid, and readable again for cleanup
+        if(chmod(ro_leaf, 0755) == -1)
+            fprintf(stderr, "warning: could not chmod '%s' back\n", ro_leaf);
     }
 
     // best effort cleanup; the tree is under /tmp and named after our pid

--- a/src/libnetdata/os/tests/run-dir-safety-test.c
+++ b/src/libnetdata/os/tests/run-dir-safety-test.c
@@ -3,6 +3,11 @@
 // netdata binds sockets in this directory and chowns it while still running as root, so
 // it must refuse anything another account could have planted or could replace.
 //
+// Two rules are checked, because os_run_dir_is_safe() serves two callers: the agent
+// itself (rw), which is about to create, chown and bind here as root, and a client
+// (read-only) that only reads or connects to what is already there. The read-only
+// rule differs in exactly one requirement - see the read-only section below.
+//
 // os_run_dir_is_safe() is exercised directly rather than through os_run_dir(),
 // which caches its answer for the process lifetime and creates directories as a
 // side effect. os_run_dir() itself is called only by the last case, which is
@@ -18,6 +23,19 @@ static char root_dir[FILENAME_MAX + 1];
 static int failures = 0;
 static int skipped = 0;
 
+static void check_mode(const char *what, const char *dir, bool rw, bool expected) {
+    bool got = os_run_dir_is_safe(dir, rw);
+    if (got == expected)
+        fprintf(stderr, "  ok       %-52s (%s)\n", what, got ? "accepted" : "refused");
+    else {
+        fprintf(stderr, "  FAILED   %-52s got %s, expected %s\n",
+                what, got ? "accepted" : "refused", expected ? "accepted" : "refused");
+        failures++;
+    }
+}
+
+// the run directory as the agent itself resolves it: the rule that has to hold
+// while we are still root
 static void check(const char *what, const char *dir, bool expected) {
     bool got = os_run_dir_is_safe(dir, true);
     if (got == expected)
@@ -176,6 +194,23 @@ int main(void) {
     snprintfz(p, sizeof(p), "%s/group_writable", exclusive);
     make_parent(p, 0775);
     check("directory writable by its group (systemd 0775 shape)", p, true);
+
+    // The read-only resolution a client performs - netdatacli looking for
+    // netdata.pipe, a plugin looking for a socket. It creates nothing and chowns
+    // nothing, so the sticky-parent ownership requirement does not apply to it: a
+    // client cannot know which uid the agent runs as (the root case is below).
+    // Everything else does apply, so it still cannot be pointed elsewhere.
+    fprintf(stderr, "read-only resolution, for a client rather than the agent:\n");
+    snprintfz(p, sizeof(p), "%s/ours", sticky);
+    check_mode("directory we own, sticky parent", p, false, true);
+    snprintfz(p, sizeof(p), "%s/to_etc", exclusive);
+    check_mode("symlink to /etc", p, false, false);
+    snprintfz(p, sizeof(p), "%s/ours", open_parent);
+    check_mode("world-writable parent without the sticky bit", p, false, false);
+    snprintfz(p, sizeof(p), "%s/other_writable", exclusive);
+    check_mode("directory writable by everyone", p, false, false);
+    snprintfz(p, sizeof(p), "%s/afile", exclusive);
+    check_mode("a regular file, not a directory", p, false, false);
 
     fprintf(stderr, "privileged open, symlink at the final component:\n");
     {
@@ -337,9 +372,9 @@ int main(void) {
 
     fprintf(stderr, "cases that need root:\n");
     if (geteuid() != 0) {
-        fprintf(stderr, "  SKIPPED  third-account ownership and the restart case"
-                        " (re-run as root to cover them)\n");
-        skipped += 2;
+        fprintf(stderr, "  SKIPPED  third-account ownership, the restart case, and the"
+                        " read-only client case (re-run as root to cover them)\n");
+        skipped += 4;
     }
     else {
         snprintfz(p, sizeof(p), "%s/foreign", sticky);
@@ -366,6 +401,11 @@ int main(void) {
         check("sticky parent, third account, a different uid declared", p, false);
 
         os_run_dir_set_target_uid((uid_t)-1);
+
+        // The netdatacli case: root asking where an agent that runs as another uid
+        // keeps its socket. The agent's own rule refuses this directory, and a
+        // client asked to obey it could not reach such an agent at all.
+        check_mode("read-only, sticky parent, a third account's directory", p, false, true);
     }
 
     // os_run_dir() caches its answer for the process lifetime, so this case runs

--- a/src/libnetdata/os/tests/run-dir-safety-test.c
+++ b/src/libnetdata/os/tests/run-dir-safety-test.c
@@ -75,24 +75,28 @@ int main(void) {
     // stay refused however the caller spells it. A trailing "." is the subtle
     // one: it also makes the parent-trust lookup stat() through the symlink and
     // read the trust class off the target.
-    snprintfz(p, sizeof(p), "%s/to_real/", exclusive);
-    check("symlink, trailing slash", p, false);
-    snprintfz(p, sizeof(p), "%s/to_real/.", exclusive);
-    check("symlink, trailing dot", p, false);
-    snprintfz(p, sizeof(p), "%s/to_real/./", exclusive);
-    check("symlink, trailing dot-slash", p, false);
-    snprintfz(p, sizeof(p), "%s/to_real/.//./", exclusive);
-    check("symlink, repeated dots and slashes", p, false);
-    snprintfz(p, sizeof(p), "%s/to_real//.", exclusive);
-    check("symlink, doubled slash then dot", p, false);
+    // The last two cases are ".." and "." themselves: they reach a directory
+    // through the component before them, so ".." has no entry left to judge and
+    // must be refused rather than validated against the wrong inode, while "."
+    // on a real directory simply normalises away.
+    static const struct {
+        const char *suffix;
+        const char *what;
+        bool expected;
+    } spellings[] = {
+        { "to_real/",      "symlink, trailing slash",                   false },
+        { "to_real/.",     "symlink, trailing dot",                     false },
+        { "to_real/./",    "symlink, trailing dot-slash",               false },
+        { "to_real/.//./", "symlink, repeated dots and slashes",        false },
+        { "to_real//.",    "symlink, doubled slash then dot",           false },
+        { "real/..",       "path ending in '..'",                       false },
+        { "real/.",        "real directory, trailing dot (normalises)", true  },
+    };
 
-    // "." and ".." reach a directory through the component before them, so there
-    // is no entry left to judge - they must be refused rather than validated
-    // against the wrong inode.
-    snprintfz(p, sizeof(p), "%s/real/..", exclusive);
-    check("path ending in '..'", p, false);
-    snprintfz(p, sizeof(p), "%s/real/.", exclusive);
-    check("real directory, trailing dot (normalises)", p, true);
+    for (size_t i = 0; i < _countof(spellings); i++) {
+        snprintfz(p, sizeof(p), "%s/%s", exclusive, spellings[i].suffix);
+        check(spellings[i].what, p, spellings[i].expected);
+    }
 
     snprintfz(p, sizeof(p), "%s/afile", exclusive);
     int fd = open(p, O_WRONLY | O_CREAT | O_EXCL, 0644);

--- a/src/libnetdata/os/tests/run-dir-safety-test.c
+++ b/src/libnetdata/os/tests/run-dir-safety-test.c
@@ -268,9 +268,12 @@ int main(void) {
         bool route_usable = (stat(probe, &via_proc) == 0 && fstat(dfd, &via_fd) == 0 &&
                              via_proc.st_dev == via_fd.st_dev && via_proc.st_ino == via_fd.st_ino);
 
-        // the swap, exactly as a run-dir owner could perform it
+        // The swap, exactly as a run-dir owner could perform it. Replacing a path
+        // that was just examined is a TOCTOU race by construction - here it is the
+        // fixture, not a defect: the race is precisely what the descriptor route
+        // below has to survive.
         if (rename(rundir, moved) == -1) fatal("test setup: rename '%s'", rundir);
-        if (symlink(attacker, rundir) == -1) fatal("test setup: symlink '%s'", rundir);
+        if (symlink(attacker, rundir) == -1) fatal("test setup: symlink '%s'", rundir); // NOSONAR
 
         struct sockaddr_un addr = { .sun_family = AF_UNIX };
         snprintfz(addr.sun_path, sizeof(addr.sun_path) - 1, "/proc/self/fd/%d/s.sock", dfd);
@@ -388,21 +391,34 @@ int main(void) {
         nd_setenv("NETDATA_RUN_DIR", rw_leaf, 1);
         const char *rw = os_run_dir(true);
 
+        const char *what = "writable request after a read-only one";
+
         if(!ro || strcmp(ro, ro_leaf) != 0) {
             fprintf(stderr, "  FAILED   %-52s got '%s'\n", "read-only resolution", ro ? ro : "(null)");
             failures++;
         }
         else if(rw && strcmp(rw, rw_leaf) == 0)
-            fprintf(stderr, "  ok       %-52s (re-detected)\n", "writable request after a read-only one");
-        else {
+            fprintf(stderr, "  ok       %-52s (re-detected)\n", what);
+        else if(!rw) {
+            // it re-detected, but found nothing: the failure is in the detection,
+            // not in the cache
+            fprintf(stderr, "  FAILED   %-52s returned NULL for a writable directory "
+                            "that exists\n", what);
+            failures++;
+        }
+        else if(strcmp(rw, ro_leaf) == 0) {
             fprintf(stderr, "  FAILED   %-52s got '%s' - the writable request reused the "
-                            "read-only answer\n",
-                    "writable request after a read-only one", rw ? rw : "(null)");
+                            "read-only answer\n", what, rw);
+            failures++;
+        }
+        else {
+            fprintf(stderr, "  FAILED   %-52s got '%s', expected '%s'\n", what, rw, rw_leaf);
             failures++;
         }
 
-        // the earlier read-only answer stays valid, and readable again for cleanup
-        if(chmod(ro_leaf, 0755) == -1)
+        // the earlier read-only answer stays valid, and writable again so the
+        // cleanup below can remove it. Only for us: nothing here is shared.
+        if(chmod(ro_leaf, 0700) == -1)
             fprintf(stderr, "warning: could not chmod '%s' back\n", ro_leaf);
     }
 

--- a/src/libnetdata/os/tests/run-dir-safety-test.c
+++ b/src/libnetdata/os/tests/run-dir-safety-test.c
@@ -5,8 +5,10 @@
 //
 // Two rules are checked, because os_run_dir_is_safe() serves two callers: the agent
 // itself (rw), which is about to create, chown and bind here as root, and a client
-// (read-only) that only reads or connects to what is already there. The read-only
-// rule differs in exactly one requirement - see the read-only section below.
+// (read-only) that only reads or connects to what is already there. Both refuse a
+// directory they could be redirected away from - a symlink, a non-directory. Only
+// the rw rule also asks who else could replace the directory, which is what the
+// agent's privileged use of it needs - see the read-only section below.
 //
 // os_run_dir_is_safe() is exercised directly rather than through os_run_dir(),
 // which caches its answer for the process lifetime and creates directories as a
@@ -196,21 +198,29 @@ int main(void) {
     check("directory writable by its group (systemd 0775 shape)", p, true);
 
     // The read-only resolution a client performs - netdatacli looking for
-    // netdata.pipe, a plugin looking for a socket. It creates nothing and chowns
-    // nothing, so the sticky-parent ownership requirement does not apply to it: a
-    // client cannot know which uid the agent runs as (the root case is below).
-    // Everything else does apply, so it still cannot be pointed elsewhere.
+    // netdata.pipe, a plugin looking for a socket. It creates nothing, chowns
+    // nothing and binds nothing, so none of the "who else could replace this
+    // directory" rules apply to it: those exist to protect what we do here as
+    // root. What still applies is that it must not be redirected to another
+    // directory, so a symlink or a non-directory is refused for it too.
     fprintf(stderr, "read-only resolution, for a client rather than the agent:\n");
     snprintfz(p, sizeof(p), "%s/ours", sticky);
     check_mode("directory we own, sticky parent", p, false, true);
     snprintfz(p, sizeof(p), "%s/to_etc", exclusive);
     check_mode("symlink to /etc", p, false, false);
-    snprintfz(p, sizeof(p), "%s/ours", open_parent);
-    check_mode("world-writable parent without the sticky bit", p, false, false);
-    snprintfz(p, sizeof(p), "%s/other_writable", exclusive);
-    check_mode("directory writable by everyone", p, false, false);
     snprintfz(p, sizeof(p), "%s/afile", exclusive);
     check_mode("a regular file, not a directory", p, false, false);
+
+    // Accepted for a client, refused for the agent: the same directory, judged by
+    // what the caller is about to do with it. A non-root install legitimately puts
+    // its run directory under a parent the agent's own account owns, and a client
+    // that only connects must still be able to find it.
+    snprintfz(p, sizeof(p), "%s/ours", open_parent);
+    check_mode("world-writable parent without the sticky bit", p, false, true);
+    check_mode("world-writable parent without the sticky bit", p, true, false);
+    snprintfz(p, sizeof(p), "%s/other_writable", exclusive);
+    check_mode("directory writable by everyone", p, false, true);
+    check_mode("directory writable by everyone", p, true, false);
 
     fprintf(stderr, "privileged open, symlink at the final component:\n");
     {

--- a/src/libnetdata/os/tests/run-dir-safety-test.c
+++ b/src/libnetdata/os/tests/run-dir-safety-test.c
@@ -27,6 +27,26 @@ static void check(const char *what, const char *dir, bool expected) {
     }
 }
 
+// os_open_dir_privileged() reports its trimming failures through errno, and the
+// caller logs it: a path with nothing left to name must not be reported as if it
+// were too long.
+static void check_trim_errno(const char *what, const char *path, char *dst, size_t dst_size, int expected) {
+    errno = 0;
+    if (os_dir_path_trim(path, dst, dst_size)) {
+        fprintf(stderr, "  FAILED   %-52s trimmed, expected failure\n", what);
+        failures++;
+        return;
+    }
+
+    if (errno == expected)
+        fprintf(stderr, "  ok       %-52s (%s)\n", what, strerror(errno));
+    else {
+        fprintf(stderr, "  FAILED   %-52s errno %s, expected %s\n",
+                what, strerror(errno), strerror(expected));
+        failures++;
+    }
+}
+
 // Build "<root_dir>/<name>" into buf.
 static const char *under(char *buf, size_t size, const char *name) {
     snprintfz(buf, size, "%s/%s", root_dir, name);
@@ -120,6 +140,17 @@ int main(void) {
     snprintfz(p, sizeof(p), "%s/ours", open_parent);
     make_parent(p, 0755);
     check("world-writable parent without the sticky bit", p, false);
+
+    fprintf(stderr, "trim failures, as reported to the caller:\n");
+    {
+        char small[8];
+        check_trim_errno("NULL path", NULL, small, sizeof(small), EINVAL);
+        check_trim_errno("empty path", "", small, sizeof(small), EINVAL);
+        // "/x/." normalises to "/x"; these are the shapes with no entry left
+        check_trim_errno("the cwd itself, '.'", ".", p, sizeof(p), EINVAL);
+        check_trim_errno("path ending in '..'", "/var/lib/netdata/..", p, sizeof(p), EINVAL);
+        check_trim_errno("path longer than the buffer", "/var/lib/netdata", small, sizeof(small), ENAMETOOLONG);
+    }
 
     fprintf(stderr, "cases that need root:\n");
     if (geteuid() != 0) {

--- a/src/libnetdata/os/tests/run-dir-safety-test.c
+++ b/src/libnetdata/os/tests/run-dir-safety-test.c
@@ -47,6 +47,22 @@ static void check_trim_errno(const char *what, const char *path, char *dst, size
     }
 }
 
+// os_open_dir_privileged() decides whether to follow a symlink at the final
+// component from the trust class of the directory holding it.
+static void check_open(const char *what, const char *path, bool expected) {
+    int fd = os_open_dir_privileged(path);
+    bool got = (fd != -1);
+    if (fd != -1) close(fd);
+
+    if (got == expected)
+        fprintf(stderr, "  ok       %-52s (%s)\n", what, got ? "opened" : "refused");
+    else {
+        fprintf(stderr, "  FAILED   %-52s got %s, expected %s\n",
+                what, got ? "opened" : "refused", expected ? "opened" : "refused");
+        failures++;
+    }
+}
+
 // Build "<root_dir>/<name>" into buf.
 static const char *under(char *buf, size_t size, const char *name) {
     snprintfz(buf, size, "%s/%s", root_dir, name);
@@ -140,6 +156,168 @@ int main(void) {
     snprintfz(p, sizeof(p), "%s/ours", open_parent);
     make_parent(p, 0755);
     check("world-writable parent without the sticky bit", p, false);
+
+    // The leaf's own mode. Its parent being exclusive says nobody else can
+    // replace the directory - it says nothing about who can create entries
+    // inside it, which is where the sockets go.
+    snprintfz(p, sizeof(p), "%s/other_writable", exclusive);
+    make_parent(p, 0777);
+    check("directory writable by everyone", p, false);
+
+    snprintfz(p, sizeof(p), "%s/other_writable_sticky", exclusive);
+    make_parent(p, 01777);
+    check("directory writable by everyone, even sticky", p, false);
+
+    // Must stay accepted: the shipped systemd unit creates /run/netdata with
+    // RuntimeDirectoryMode=0775 and re-applies it on every start, so refusing
+    // group-write would leave the default install without a run directory.
+    snprintfz(p, sizeof(p), "%s/group_writable", exclusive);
+    make_parent(p, 0775);
+    check("directory writable by its group (systemd 0775 shape)", p, true);
+
+    fprintf(stderr, "privileged open, symlink at the final component:\n");
+    {
+        // Exclusive parent: only we could have placed the link, so it is
+        // followed - this is what keeps /var/cache/netdata -> another
+        // filesystem working.
+        snprintfz(p, sizeof(p), "%s/real", exclusive);
+        snprintfz(q, sizeof(q), "%s/link_ok", exclusive);
+        if (symlink(p, q) == -1) fatal("test setup: symlink '%s'", q);
+        check_open("symlink in an exclusive parent (followed)", q, true);
+
+        // Same link, but reached through a parent anyone can write into: now
+        // somebody else could have planted it, so O_NOFOLLOW refuses it.
+        snprintfz(p, sizeof(p), "%s/link_bad", open_parent);
+        snprintfz(q, sizeof(q), "%s/real", exclusive);
+        if (symlink(q, p) == -1) fatal("test setup: symlink '%s'", p);
+        check_open("symlink in a world-writable parent (refused)", p, false);
+
+        // A real directory opens either way.
+        snprintfz(p, sizeof(p), "%s/real", exclusive);
+        check_open("a real directory", p, true);
+    }
+
+    // The spawn server sets its socket's mode with
+    // fchmodat(dir_fd, name, 0770, AT_SYMLINK_NOFOLLOW) while it may still be
+    // root, in a directory the netdata account can write into. That is safe only
+    // because AT_SYMLINK_NOFOLLOW refuses a symlink instead of following it, so
+    // assert the platform really behaves that way rather than trusting it.
+    fprintf(stderr, "the fchmodat() guarantee the spawn server relies on:\n");
+    {
+        snprintfz(p, sizeof(p), "%s/chmod_victim", exclusive);
+        int vfd = open(p, O_WRONLY | O_CREAT | O_EXCL, 0600);
+        if (vfd == -1) fatal("test setup: create '%s'", p);
+        close(vfd);
+
+        snprintfz(q, sizeof(q), "%s/chmod_link", exclusive);
+        if (symlink(p, q) == -1) fatal("test setup: symlink '%s'", q);
+
+        int dfd = open(exclusive, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+        if (dfd == -1) fatal("test setup: open '%s'", exclusive);
+
+        errno = 0;
+        bool refused = (fchmodat(dfd, "chmod_link", 0770, AT_SYMLINK_NOFOLLOW) == -1);
+        int refused_errno = errno;
+
+        struct st_check { struct stat st; } v;
+        if (lstat(p, &v.st) == -1) fatal("test: lstat '%s'", p);
+        bool victim_untouched = ((v.st.st_mode & 07777) == 0600);
+
+        if (refused && victim_untouched)
+            fprintf(stderr, "  ok       %-52s (%s)\n",
+                    "symlink refused, its target left alone", strerror(refused_errno));
+        else if (!refused && victim_untouched)
+            // no platform is known to do this; it would mean the link itself was
+            // chmoded, which is harmless here but worth noticing
+            fprintf(stderr, "  ok       %-52s (link itself)\n", "symlink not followed");
+        else {
+            fprintf(stderr, "  FAILED   %-52s target became %04o - the spawn server "
+                            "socket chmod can be redirected on this platform\n",
+                    "symlink refused, its target left alone", (unsigned)(v.st.st_mode & 07777));
+            failures++;
+        }
+
+        close(dfd);
+    }
+
+#if defined(OS_LINUX)
+    // The spawn server binds its socket through "/proc/self/fd/<dir_fd>/<name>"
+    // so that bind() resolves the run directory it already validated instead of
+    // walking the path again. Prove that: rename the directory away and leave a
+    // symlink to somewhere else in its place, then bind - the socket must appear
+    // in the directory the descriptor refers to, not in the replacement.
+    fprintf(stderr, "the bind() guarantee the spawn server relies on:\n");
+    {
+        char rundir[FILENAME_MAX + 1], attacker[FILENAME_MAX + 1], moved[FILENAME_MAX + 1];
+        make_parent(under(rundir, sizeof(rundir), "bind_run"), 0755);
+        make_parent(under(attacker, sizeof(attacker), "bind_attacker"), 0755);
+        under(moved, sizeof(moved), "bind_run_moved");
+
+        int dfd = open(rundir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+        if (dfd == -1) fatal("test setup: open '%s'", rundir);
+
+        // Same question the spawn server asks before it decides what a failed
+        // bind means: is the descriptor route available here at all? Only an
+        // unavailable route may skip - a route that is available and then fails
+        // is the defect this case exists to catch, never a skip.
+        char probe[FILENAME_MAX + 1];
+        snprintfz(probe, sizeof(probe), "/proc/self/fd/%d", dfd);
+        struct stat via_proc, via_fd;
+        bool route_usable = (stat(probe, &via_proc) == 0 && fstat(dfd, &via_fd) == 0 &&
+                             via_proc.st_dev == via_fd.st_dev && via_proc.st_ino == via_fd.st_ino);
+
+        // the swap, exactly as a run-dir owner could perform it
+        if (rename(rundir, moved) == -1) fatal("test setup: rename '%s'", rundir);
+        if (symlink(attacker, rundir) == -1) fatal("test setup: symlink '%s'", rundir);
+
+        struct sockaddr_un addr = { .sun_family = AF_UNIX };
+        snprintfz(addr.sun_path, sizeof(addr.sun_path) - 1, "/proc/self/fd/%d/s.sock", dfd);
+
+        int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+        if (sock == -1) fatal("test setup: socket()");
+
+        errno = 0;
+        bool bound = (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+        int bind_errno = errno;
+
+        char in_attacker[FILENAME_MAX + 1], in_real[FILENAME_MAX + 1];
+        snprintfz(in_attacker, sizeof(in_attacker), "%s/s.sock", attacker);
+        snprintfz(in_real, sizeof(in_real), "%s/s.sock", moved);
+
+        struct stat st;
+        bool landed_in_attacker = (lstat(in_attacker, &st) == 0);
+        bool landed_in_real = (lstat(in_real, &st) == 0);
+
+        if (!route_usable) {
+            // No usable /proc (chroot, hardened sandbox, some containers). The
+            // spawn server warns and binds the pathname there; that residual is
+            // tracked, not asserted here.
+            fprintf(stderr, "  SKIPPED  %-52s (no usable /proc/self/fd)\n",
+                    "run dir swapped after open, before bind");
+            skipped++;
+        }
+        else if (bound && landed_in_real && !landed_in_attacker)
+            fprintf(stderr, "  ok       %-52s (followed the descriptor)\n",
+                    "run dir swapped after open, before bind");
+        else {
+            // Either the bind failed although the route was available - in which
+            // case the spawn server must refuse rather than retry on the pathname
+            // - or it followed the swap.
+            fprintf(stderr, "  FAILED   %-52s bound=%s(%s) real=%s attacker=%s\n",
+                    "run dir swapped after open, before bind",
+                    bound ? "yes" : "no", bound ? "-" : strerror(bind_errno),
+                    landed_in_real ? "yes" : "no",
+                    landed_in_attacker ? "YES - bind followed the swap" : "no");
+            failures++;
+        }
+
+        close(sock);
+        close(dfd);
+        unlink(in_real);
+        unlink(in_attacker);
+        unlink(rundir);
+    }
+#endif
 
     fprintf(stderr, "trim failures, as reported to the caller:\n");
     {

--- a/src/libnetdata/os/tests/run-dir-safety-test.c
+++ b/src/libnetdata/os/tests/run-dir-safety-test.c
@@ -203,24 +203,28 @@ int main(void) {
     // directory" rules apply to it: those exist to protect what we do here as
     // root. What still applies is that it must not be redirected to another
     // directory, so a symlink or a non-directory is refused for it too.
+    // Every case below names the caller it is judged as, because the same
+    // directory legitimately gets opposite answers for the two: a bare label would
+    // print twice, differing only in accepted/refused, and a failure would be
+    // ambiguous to read and to grep for.
     fprintf(stderr, "read-only resolution, for a client rather than the agent:\n");
     snprintfz(p, sizeof(p), "%s/ours", sticky);
-    check_mode("directory we own, sticky parent", p, false, true);
+    check_mode("directory we own, sticky parent (client)", p, false, true);
     snprintfz(p, sizeof(p), "%s/to_etc", exclusive);
-    check_mode("symlink to /etc", p, false, false);
+    check_mode("symlink to /etc (client)", p, false, false);
     snprintfz(p, sizeof(p), "%s/afile", exclusive);
-    check_mode("a regular file, not a directory", p, false, false);
+    check_mode("a regular file, not a directory (client)", p, false, false);
 
     // Accepted for a client, refused for the agent: the same directory, judged by
     // what the caller is about to do with it. A non-root install legitimately puts
     // its run directory under a parent the agent's own account owns, and a client
     // that only connects must still be able to find it.
     snprintfz(p, sizeof(p), "%s/ours", open_parent);
-    check_mode("world-writable parent without the sticky bit", p, false, true);
-    check_mode("world-writable parent without the sticky bit", p, true, false);
+    check_mode("world-writable parent, no sticky bit (client)", p, false, true);
+    check_mode("world-writable parent, no sticky bit (agent)", p, true, false);
     snprintfz(p, sizeof(p), "%s/other_writable", exclusive);
-    check_mode("directory writable by everyone", p, false, true);
-    check_mode("directory writable by everyone", p, true, false);
+    check_mode("directory writable by everyone (client)", p, false, true);
+    check_mode("directory writable by everyone (agent)", p, true, false);
 
     fprintf(stderr, "privileged open, symlink at the final component:\n");
     {

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1322,12 +1322,116 @@ void spawn_server_destroy(SPAWN_SERVER *server) {
     freez(server);
 }
 
-static bool spawn_server_create_listening_socket(SPAWN_SERVER *server) {
-    if(spawn_server_is_running(server->path)) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Server is already listening on path '%s'", server->path);
+// Grant the socket its final mode without ever letting the operation land on
+// anything but the socket we just bound. This runs as root for the temporary
+// spawn server, long before become_user(), inside a directory the netdata
+// account can write into: /run/netdata is 0775 netdata:netdata on a stock
+// systemd install and carries no sticky bit, so any entry in it - including a
+// root-owned socket - can be unlinked and replaced by that account.
+// AT_SYMLINK_NOFOLLOW is what refuses a replacement: it fails rather than
+// following a link, both where the kernel implements it (macOS, FreeBSD) and
+// through the /proc-based emulation in glibc and musl. Measured on both: it
+// succeeds on the socket we bound, and returns EOPNOTSUPP once the name has
+// become a symlink.
+// There is deliberately no fallback for a failure. The only alternatives are to
+// chmod whatever the name now refers to, or to stat it and then chmod it - which
+// is the same race again, with more code to hide it in. A failure here means the
+// entry is not the socket we created, so the server would be listening on a name
+// no client can reach: refuse instead.
+static bool spawn_server_chmod_socket(SPAWN_SERVER *server, int dir_fd, const char *sock_filename) {
+    if(fchmodat(dir_fd, sock_filename, 0770, AT_SYMLINK_NOFOLLOW) == 0)
+        return true;
+
+    nd_log(NDLS_COLLECTORS, NDLP_ERR,
+           "SPAWN SERVER: refusing to set the mode of '%s' (%s) - it is no longer the socket we bound",
+           server->path, strerror(errno));
+    return false;
+}
+
+#if defined(OS_LINUX)
+// Whether bind() can be made to resolve through a descriptor at all: the
+// directory reached via /proc/self/fd/<fd> must be the very inode the descriptor
+// refers to. What this decides is not the bind, but what a *failed* bind means -
+// with the route available, a failure is a real failure and must never be retried
+// on the pathname, because a swapped run directory is one of the things that can
+// produce it. Only an unavailable route (no procfs, a chroot, a hardened sandbox)
+// may send us to the pathname. Measured: this still matches while the directory is
+// renamed away, so an attack cannot make the route look unavailable.
+static bool spawn_server_dir_fd_route_usable(int dir_fd, char *dst, size_t dst_size) {
+    int len = snprintf(dst, dst_size, "/proc/self/fd/%d", dir_fd);
+    if(len <= 0 || (size_t)len >= dst_size)
+        return false;
+
+    struct stat via_proc, via_fd;
+    if(stat(dst, &via_proc) == -1 || fstat(dir_fd, &via_fd) == -1)
+        return false;
+
+    return via_proc.st_dev == via_fd.st_dev && via_proc.st_ino == via_fd.st_ino;
+}
+#endif
+
+// There is no bindat(), so bind() resolves the run directory a second time and
+// could land in a replacement. But the run directory can only be replaced under us
+// when the directory holding it is writable by somebody else - the sticky /tmp
+// fallback, whose leaf we deliberately accept when it belongs to the uid we drop
+// to. With an exclusive parent, which is every packaged install (/run/netdata,
+// parent /run is root-only), nobody but root can rename it and binding the
+// pathname is already safe.
+// So the descriptor route below is used where it is needed and skipped where it
+// buys nothing. That matters for more than tidiness: when it *is* needed and
+// unavailable there is no safe pathname to retry on, and refusing is the only
+// honest answer - keeping that refusal confined to the sticky-parent case is what
+// stops an environment without a usable /proc from taking netdata down.
+static bool spawn_server_bind_socket(SPAWN_SERVER *server, int dir_fd, const char *sock_filename, bool parent_is_exclusive) {
+    if(!parent_is_exclusive) {
+        // Somebody other than root can rename this run directory, so its pathname
+        // is not a safe thing to hand to bind(): it may resolve into a replacement
+        // by the time the kernel walks it.
+#if defined(OS_LINUX)
+        char dir_fd_path[FILENAME_MAX + 1];
+        if(spawn_server_dir_fd_route_usable(dir_fd, dir_fd_path, sizeof(dir_fd_path))) {
+            char bind_path[FILENAME_MAX + 1];
+            int len = snprintf(bind_path, sizeof(bind_path), "%s/%s", dir_fd_path, sock_filename);
+
+            struct sockaddr_un dir_fd_addr = {
+                .sun_family = AF_UNIX,
+            };
+
+            if(len > 0 && (size_t)len < sizeof(bind_path) &&
+               spawn_server_set_unix_socket_path(&dir_fd_addr, bind_path, false, NULL)) {
+
+                if(bind(server->sock, (struct sockaddr *)&dir_fd_addr, sizeof(dir_fd_addr)) == 0)
+                    return true;
+
+                // No retry on the pathname: the route was available, so this is a
+                // real failure - and a swapped run directory is one of the things
+                // that can produce it, which the pathname would resolve straight
+                // into.
+                nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                       "SPAWN SERVER: Failed to bind() '%s' through the run directory descriptor (%s)",
+                       server->path, strerror(errno));
+                return false;
+            }
+        }
+#else
+        (void)dir_fd;
+        (void)sock_filename;
+#endif
+
+        // Nothing here can be made safe: there is no descriptor route on this
+        // platform (or none usable), and the pathname is exactly what an attacker
+        // controls. Say so plainly and point at the fix, rather than binding it
+        // anyway with a warning nobody reads.
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: refusing to create '%s': its run directory is inside a directory "
+               "others can write to, and this system cannot bind through a directory descriptor. "
+               "Set NETDATA_RUN_DIR to a directory whose parent only root can write to.",
+               server->path);
         return false;
     }
 
+    // The parent is exclusively ours, so nobody but root can rename or replace the
+    // run directory and the pathname still names the directory we validated.
     struct sockaddr_un server_addr = {
         .sun_family = AF_UNIX,
     };
@@ -1336,31 +1440,65 @@ static bool spawn_server_create_listening_socket(SPAWN_SERVER *server) {
                                           "SPAWN SERVER: Cannot listen on path"))
         return false;
 
-    if ((server->sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+    // bind() cannot be redirected onto an existing name: any entry already there,
+    // a planted symlink included, makes it fail rather than write through it.
+    if(bind(server->sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1) {
         int error = errno;
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to create socket(): %s (%d)", strerror(error), error);
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to bind() '%s': %s (%d)",
+               server->path, strerror(error), error);
         return false;
     }
 
-    unlink(server->path);
+    return true;
+}
+
+static bool spawn_server_create_listening_socket(SPAWN_SERVER *server, const char *runtime_directory, const char *sock_filename) {
+    if(spawn_server_is_running(server->path)) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Server is already listening on path '%s'", server->path);
+        return false;
+    }
+
+    // Every name operation below goes through this descriptor, so they all act on
+    // the directory os_run_dir() validated instead of on a path re-resolved from
+    // / each time - under the /tmp fallback the run directory is owned by the uid
+    // we drop to, which can rename it away while we are still root.
+    int dir_fd = os_open_dir_privileged(runtime_directory);
+    if(dir_fd == -1) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: cannot open run directory '%s' to create the '%s' socket",
+               runtime_directory, server->name);
+        return false;
+    }
+
+    if ((server->sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+        int error = errno;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to create socket(): %s (%d)", strerror(error), error);
+        close(dir_fd);
+        return false;
+    }
+
+    unlinkat(dir_fd, sock_filename, 0);
     errno = 0;
 
-    if (bind(server->sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1) {
-        int error = errno;
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to bind(): %s (%d)", strerror(error), error);
+    // Decides whether bind() may use the pathname: with an exclusive parent only
+    // root can replace the run directory, so it cannot change meaning under us.
+    bool parent_is_exclusive = (os_dir_parent_trust(runtime_directory) == OS_DIR_PARENT_EXCLUSIVE);
+
+    if (!spawn_server_bind_socket(server, dir_fd, sock_filename, parent_is_exclusive)) {
+        close(dir_fd);
         return false;
     }
 
     if (listen(server->sock, SOMAXCONN) == -1) {
         int error = errno;
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to listen(): %s (%d)", strerror(error), error);
+        close(dir_fd);
         return false;
     }
 
-    if(chmod(server->path, 0770) != 0)
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: failed to chmod '%s' to 0770", server->path);
-
-    return true;
+    bool ok = spawn_server_chmod_socket(server, dir_fd, sock_filename);
+    close(dir_fd);
+    return ok;
 }
 
 static void replace_stdio_with_dev_null() {
@@ -1414,17 +1552,32 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
         goto cleanup;
     }
 
-    char path[1024];
-    int path_length;
-    const size_t max_path_length = spawn_server_max_unix_socket_path_length();
+    // Built separately from the full path: the socket is created, unlinked and
+    // chmod()ed relative to a descriptor for the run directory, which needs the
+    // file name on its own.
+    char sock_filename[256];
+    int name_length;
     if(name && *name) {
         server->name = strdupz(name);
-        path_length = snprintf(path, sizeof(path), "%s/netdata-spawn-%s.sock", runtime_directory, name);
+        name_length = snprintf(sock_filename, sizeof(sock_filename), "netdata-spawn-%s.sock", name);
     }
     else {
         server->name = strdupz("unnamed");
-        path_length = snprintf(path, sizeof(path), "%s/netdata-spawn-%d-%zu.sock", runtime_directory, getpid(), server->id);
+        name_length = snprintf(sock_filename, sizeof(sock_filename), "netdata-spawn-%d-%zu.sock", getpid(), server->id);
     }
+
+    if(name_length < 0 || (size_t)name_length >= sizeof(sock_filename)) {
+        errno = ENAMETOOLONG;
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: socket file name for '%s' does not fit in %zu bytes",
+               server->name, sizeof(sock_filename));
+        goto cleanup;
+    }
+
+    char path[1024];
+    int path_length;
+    const size_t max_path_length = spawn_server_max_unix_socket_path_length();
+    path_length = snprintf(path, sizeof(path), "%s/%s", runtime_directory, sock_filename);
 
     if(path_length < 0) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR,
@@ -1451,7 +1604,7 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
 
     server->path = strdupz(path);
 
-    if (!spawn_server_create_listening_socket(server))
+    if (!spawn_server_create_listening_socket(server, runtime_directory, sock_filename))
         goto cleanup;
 
     if (pipe(server->pipe) == -1) {

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1302,6 +1302,8 @@ static int spawn_server_event_loop(SPAWN_SERVER *server) {
 // management of the spawn server
 
 void spawn_server_destroy(SPAWN_SERVER *server) {
+    if(!server) return;
+
     if(server->pipe[0] != -1) close(server->pipe[0]);
     if(server->pipe[1] != -1) close(server->pipe[1]);
     if(server->sock != -1) close(server->sock);
@@ -1400,34 +1402,17 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
     server->id = __atomic_add_fetch(&spawn_server_id, 1, __ATOMIC_RELAXED);
     os_uuid_generate_random(server->magic.uuid);
 
-    const char *runtime_directory = getenv("NETDATA_RUN_DIR");
-    if(!runtime_directory || !*runtime_directory)
-        runtime_directory = os_run_dir(true);
-
-    if (runtime_directory) {
-        struct stat statbuf;
-
-        if(!*runtime_directory)
-            // it is empty
-                runtime_directory = NULL;
-
-        else if (stat(runtime_directory, &statbuf) == 0 && S_ISDIR(statbuf.st_mode)) {
-            // it exists and it is a directory
-
-            if (access(runtime_directory, W_OK) != 0) {
-                // it is not writable by us
-                nd_log(NDLS_COLLECTORS, NDLP_ERR, "Runtime directory '%s' is not writable, falling back to '/tmp'", runtime_directory);
-                runtime_directory = NULL;
-            }
-        }
-        else {
-            // it does not exist
-            nd_log(NDLS_COLLECTORS, NDLP_ERR, "Runtime directory '%s' does not exist, falling back to '/tmp'", runtime_directory);
-            runtime_directory = NULL;
-        }
+    // os_run_dir() already validates the candidate (including NETDATA_RUN_DIR) and
+    // refuses a symlinked run dir. Never fall back to /tmp directly: the socket
+    // name is predictable, so a world-writable directory would let any local user
+    // pre-plant it.
+    const char *runtime_directory = os_run_dir(true);
+    if(!runtime_directory || !*runtime_directory) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR,
+               "SPAWN SERVER: cannot get a usable run directory for the '%s' spawn server socket",
+               (name && *name) ? name : "unnamed");
+        goto cleanup;
     }
-    if(!runtime_directory)
-        runtime_directory = "/tmp";
 
     char path[1024];
     int path_length;

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1334,9 +1334,26 @@ void spawn_server_destroy(SPAWN_SERVER *server) {
 // fchmodat(AT_SYMLINK_NOFOLLOW), returns ENOTSUP on glibc < 2.32 - the O_PATH
 // emulation landed there, and the kernel only grew fchmodat2() in 6.6 - which is
 // still CentOS 7, Amazon Linux 2, every RHEL 8 derivative and Debian 11.
-// umask is process-wide, so the change is serialized and held only across bind().
-// netipc's bind_owner_only_socket() does the same for its own sockets and cannot
-// be shared: that subtree deliberately carries no libnetdata dependency.
+// umask is process-wide, and the spinlock below does not change that: all it does
+// is stop this helper from nesting with itself, so the mask it saves is always the
+// process's real one and never another instance's temporary 0007. Isolating
+// unrelated threads is not something any lock here can do - a file created
+// anywhere else in the process during the bind() would see 0007 as well. What
+// makes that safe is that no such thread exists:
+//   - the daemon sets umask(0007) permanently in become_daemon() (daemon.c), so
+//     for every spawn server created after that - and in every plugin that
+//     inherits it - this changes nothing at all;
+//   - the only one created before it (the "init" server in main.c) runs while the
+//     daemon is still single-threaded; nothing else is started until much later;
+//   - the standalone users (cgroup-network, local-listeners, network-viewer) bind
+//     theirs before they create any thread.
+// netipc's bind_owner_only_socket() does the same for its own sockets under its
+// own lock, and cannot share this one: that subtree deliberately carries no
+// libnetdata dependency. Two independent save/restore pairs on one process-wide
+// mask would restore each other's temporary value if they ever overlapped, so
+// keep them apart - cgroups.plugin is the one process with both, and it binds its
+// spawn server while reading its configuration, before the discovery thread that
+// binds netipc exists.
 static SPINLOCK spawn_server_umask_spinlock = SPINLOCK_INITIALIZER;
 
 static int spawn_server_bind_with_mode(int sock, const struct sockaddr_un *addr) {

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1322,30 +1322,37 @@ void spawn_server_destroy(SPAWN_SERVER *server) {
     freez(server);
 }
 
-// Grant the socket its final mode without ever letting the operation land on
-// anything but the socket we just bound. This runs as root for the temporary
-// spawn server, long before become_user(), inside a directory the netdata
-// account can write into: /run/netdata is 0775 netdata:netdata on a stock
-// systemd install and carries no sticky bit, so any entry in it - including a
-// root-owned socket - can be unlinked and replaced by that account.
-// AT_SYMLINK_NOFOLLOW is what refuses a replacement: it fails rather than
-// following a link, both where the kernel implements it (macOS, FreeBSD) and
-// through the /proc-based emulation in glibc and musl. Measured on both: it
-// succeeds on the socket we bound, and returns EOPNOTSUPP once the name has
-// become a symlink.
-// There is deliberately no fallback for a failure. The only alternatives are to
-// chmod whatever the name now refers to, or to stat it and then chmod it - which
-// is the same race again, with more code to hide it in. A failure here means the
-// entry is not the socket we created, so the server would be listening on a name
-// no client can reach: refuse instead.
-static bool spawn_server_chmod_socket(SPAWN_SERVER *server, int dir_fd, const char *sock_filename) {
-    if(fchmodat(dir_fd, sock_filename, 0770, AT_SYMLINK_NOFOLLOW) == 0)
-        return true;
+// Give the socket its final mode at creation, instead of relaxing it afterwards.
+// bind() applies the process umask to the socket it creates, so binding under
+// umask 0007 produces a 0770 socket directly: there is no window in which the
+// entry exists more permissively, and no second lookup of a name that somebody
+// may have replaced in the meantime. This runs as root for the temporary spawn
+// server, long before become_user(), inside a directory the netdata account can
+// write into (/run/netdata is 0775 netdata:netdata on a stock systemd install and
+// carries no sticky bit), so that second lookup was worth removing.
+// Doing it after the fact is also not portable: the only safe form,
+// fchmodat(AT_SYMLINK_NOFOLLOW), returns ENOTSUP on glibc < 2.32 - the O_PATH
+// emulation landed there, and the kernel only grew fchmodat2() in 6.6 - which is
+// still CentOS 7, Amazon Linux 2, every RHEL 8 derivative and Debian 11.
+// umask is process-wide, so the change is serialized and held only across bind().
+// netipc's bind_owner_only_socket() does the same for its own sockets and cannot
+// be shared: that subtree deliberately carries no libnetdata dependency.
+static SPINLOCK spawn_server_umask_spinlock = SPINLOCK_INITIALIZER;
 
-    nd_log(NDLS_COLLECTORS, NDLP_ERR,
-           "SPAWN SERVER: refusing to set the mode of '%s' (%s) - it is no longer the socket we bound",
-           server->path, strerror(errno));
-    return false;
+static int spawn_server_bind_with_mode(int sock, const struct sockaddr_un *addr) {
+    spinlock_lock(&spawn_server_umask_spinlock);
+
+    // Flawfinder: ignore
+    mode_t old_mask = umask(S_IRWXO); // nosemgrep // NOSONAR - 0777 & ~0007 = 0770
+    int rc = bind(sock, (const struct sockaddr *)addr, sizeof(*addr));
+    int saved_errno = errno;
+    // Flawfinder: ignore
+    umask(old_mask); // nosemgrep // NOSONAR - restore immediately
+
+    spinlock_unlock(&spawn_server_umask_spinlock);
+
+    errno = saved_errno;
+    return rc;
 }
 
 #if defined(OS_LINUX)
@@ -1382,6 +1389,15 @@ static bool spawn_server_dir_fd_route_usable(int dir_fd, char *dst, size_t dst_s
 // unavailable there is no safe pathname to retry on, and refusing is the only
 // honest answer - keeping that refusal confined to the sticky-parent case is what
 // stops an environment without a usable /proc from taking netdata down.
+// The refusal is confined further, to a privileged process. What it protects is
+// the boundary between us and the account we are about to become: whoever can
+// swap this run directory is the uid we drop to. Running unprivileged there is no
+// such boundary - the only account that can swap the directory is the one we are
+// already running as, which needs no race to do anything we can do - so the
+// pathname is exactly as trustworthy as everything else that account does, and
+// refusing would only deny a spawn server to installs that have no /proc to bind
+// through: netdata run as a normal user on macOS and FreeBSD, where the built-in
+// candidates need root and the /tmp fallback is what is left.
 static bool spawn_server_bind_socket(SPAWN_SERVER *server, int dir_fd, const char *sock_filename, bool parent_is_exclusive) {
     if(!parent_is_exclusive) {
         // Somebody other than root can rename this run directory, so its pathname
@@ -1400,7 +1416,7 @@ static bool spawn_server_bind_socket(SPAWN_SERVER *server, int dir_fd, const cha
             if(len > 0 && (size_t)len < sizeof(bind_path) &&
                spawn_server_set_unix_socket_path(&dir_fd_addr, bind_path, false, NULL)) {
 
-                if(bind(server->sock, (struct sockaddr *)&dir_fd_addr, sizeof(dir_fd_addr)) == 0)
+                if(spawn_server_bind_with_mode(server->sock, &dir_fd_addr) == 0)
                     return true;
 
                 // No retry on the pathname: the route was available, so this is a
@@ -1418,20 +1434,27 @@ static bool spawn_server_bind_socket(SPAWN_SERVER *server, int dir_fd, const cha
         (void)sock_filename;
 #endif
 
-        // Nothing here can be made safe: there is no descriptor route on this
-        // platform (or none usable), and the pathname is exactly what an attacker
-        // controls. Say so plainly and point at the fix, rather than binding it
-        // anyway with a warning nobody reads.
-        nd_log(NDLS_COLLECTORS, NDLP_ERR,
-               "SPAWN SERVER: refusing to create '%s': its run directory is inside a directory "
-               "others can write to, and this system cannot bind through a directory descriptor. "
-               "Set NETDATA_RUN_DIR to a directory whose parent only root can write to.",
-               server->path);
-        return false;
+        // There is no descriptor route on this platform (or none usable). While we
+        // are privileged the pathname is exactly what somebody else controls, and
+        // nothing here can be made safe: say so plainly and point at the fix,
+        // rather than binding it anyway with a warning nobody reads.
+        if(geteuid() == 0) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR,
+                   "SPAWN SERVER: refusing to create '%s': its run directory is inside a directory "
+                   "others can write to, and this system cannot bind through a directory descriptor. "
+                   "Set NETDATA_RUN_DIR to a directory whose parent only root can write to.",
+                   server->path);
+            return false;
+        }
+
+        // Unprivileged: there is no boundary to protect here, so fall through and
+        // bind the pathname.
     }
 
-    // The parent is exclusively ours, so nobody but root can rename or replace the
-    // run directory and the pathname still names the directory we validated.
+    // Either the parent is exclusively ours - so nobody but root can rename or
+    // replace the run directory and the pathname still names the directory we
+    // validated - or we are unprivileged, and whoever could replace it is the
+    // account we are already running as.
     struct sockaddr_un server_addr = {
         .sun_family = AF_UNIX,
     };
@@ -1442,10 +1465,9 @@ static bool spawn_server_bind_socket(SPAWN_SERVER *server, int dir_fd, const cha
 
     // bind() cannot be redirected onto an existing name: any entry already there,
     // a planted symlink included, makes it fail rather than write through it.
-    if(bind(server->sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1) {
-        int error = errno;
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to bind() '%s': %s (%d)",
-               server->path, strerror(error), error);
+    if(spawn_server_bind_with_mode(server->sock, &server_addr) == -1) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "SPAWN SERVER: Failed to bind() '%s' (%s)",
+               server->path, strerror(errno));
         return false;
     }
 
@@ -1496,9 +1518,9 @@ static bool spawn_server_create_listening_socket(SPAWN_SERVER *server, const cha
         return false;
     }
 
-    bool ok = spawn_server_chmod_socket(server, dir_fd, sock_filename);
+    // no chmod step: the socket was created 0770 by spawn_server_bind_with_mode()
     close(dir_fd);
-    return ok;
+    return true;
 }
 
 static void replace_stdio_with_dev_null() {


### PR DESCRIPTION
##### Summary
- Validate the run directory before it is used: it must be a real directory (never a symlink) with a trusted parent, and under a world-writable parent such as /tmp it must be owned by root, by us, or by the uid we drop to.
- Repair directory ownership through descriptors (fchown, fchownat(AT_SYMLINK_NOFOLLOW)) instead of paths, so a symlinked entry can no longer redirect a chown() that runs as root.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened startup to prevent symlink-following when creating or chowning the run directory and child files. This blocks local users from redirecting privileged chown or socket binds via symlinks.

- **Bug Fixes**
  - Validate the run directory before use: reject symlinked or non-directory leaves and unsafe parents; allow sticky parents (like `/tmp`) only if the dir is owned by root/us/the target drop-uid.
  - Open and chown via descriptors, not paths: use `os_open_dir_privileged()` with `O_NOFOLLOW` when needed, and `fchown`/`fchownat(AT_SYMLINK_NOFOLLOW)` to avoid following symlinks.
  - Trim trailing slashes and dot components with `os_dir_path_trim()` so checks apply to the entry itself and cannot be bypassed.
  - Declare the target drop-uid early with `os_run_dir_set_target_uid()` so the `/tmp` fallback created on first run is still recognized as ours on restart.
  - Repair ownership of required directories via safe descriptor-based traversal; pidfile chown now happens via its open fd.
  - Spawn server now always uses the validated `os_run_dir(true)`; removed ad-hoc `/tmp` fallback.
  - Added and refactored `run-dir-safety-test` to cover symlink attacks, normalization edge cases (`.`/`..`, mixed dot/slash), sticky-parent rules, and restart ownership; added direct tests for `os_run_dir_is_safe()`.

<sup>Written for commit 107279c4ddd85e65fd9411e0ff6d155b7669adaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

