### PR TITLE
feat(codeql): filter out build results from CodeQL analysis

### DIFF
--- a/.github/codeql/c-cpp-config.yml
+++ b/.github/codeql/c-cpp-config.yml
@@ -1,7 +1,10 @@
 queries:
   - uses: security-extended
 
+# Note: for C/C++, paths-ignore only applies when analyzing without building.
+# This workflow builds the code, so these entries do not filter the analysis.
+# Results under build/ are dropped from the SARIF in .github/workflows/codeql.yml
+# instead.
 paths-ignore:
-  - build/**
   - externaldeps/**
   - "**/vendored/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -121,6 +121,29 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:cpp"
+          output: ${{ runner.temp }}/codeql-sarif
+          upload: failure-only
+      # CodeQL indexes everything the compiler traces, which for a real build
+      # includes FetchContent-fetched protobuf/abseil and protoc-generated
+      # .pb.cc under build/. The config's paths-ignore cannot exclude them:
+      # for C/C++ it only applies when analyzing without building. Drop those
+      # results here instead, keeping full-build accuracy on our own sources.
+      - name: Drop results from build/ (vendored + generated code)
+        run: |
+          for f in "${RUNNER_TEMP}"/codeql-sarif/*.sarif; do
+            before=$(jq '[.runs[].results[]] | length' "$f")
+            jq '.runs[].results |= map(select(
+                  (.locations[0].physicalLocation.artifactLocation.uri // "")
+                  | startswith("build/") | not))' "$f" > "$f.tmp"
+            mv "$f.tmp" "$f"
+            after=$(jq '[.runs[].results[]] | length' "$f")
+            echo "$(basename "$f"): ${before} results, ${after} kept after dropping build/"
+          done
+      - name: Upload filtered results
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ runner.temp }}/codeql-sarif
+          category: "/language:cpp"
 
   analyze-python:
     name: Analyze Python


### PR DESCRIPTION
##### Summary
- Filter CodeQL results under build/ out of the SARIF before upload — 
- paths-ignore: build/** never worked (it's inert for C/C++ when the workflow builds the code), 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter CodeQL results under `build/` (vendored and generated code) before upload to cut noise while keeping full-build accuracy for our sources. `paths-ignore` doesn’t apply to C/C++ when building, so filtering is done in the workflow.

- **Bug Fixes**
  - Write SARIF to `${{ runner.temp }}/codeql-sarif` and set `upload: failure-only` on `github/codeql-action/analyze@v4`.
  - Drop results with artifact paths starting `build/`, then upload via `github/codeql-action/upload-sarif@v4`.
  - Remove `build/**` from `paths-ignore` and document the C/C++ limitation in `c-cpp-config.yml`.

<sup>Written for commit f91f0d9473495d9dfd8017504db44020f71b44b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

