### PR TITLE
feat(go.d/cloudwatch): add per-selection query policies

### DIFF
--- a/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
@@ -10,9 +10,9 @@ not here.
 The one rule that shapes most of what follows:
 
 > `GetMetricData` is billed by requested metrics, so the collector normally queries
-> each series only when its next aligned effective-period window is eligible and re-emits cached values in between.
-> Transient failures use bounded per-query backoff; `update_every` therefore affects failure-time retry cost, not the
-> normal successful cadence.
+> each series on the first shared `update_every` tick that observes a newer aligned effective-period window, and
+> re-emits cached values in between. Transient failures use bounded per-query backoff. When `period < update_every`,
+> collection ticks also quantize successful execution and intermediate eligible windows can be skipped.
 
 ## What It Does
 
@@ -170,15 +170,17 @@ compiler state, and installed execution plan:
   default-enabled series. Profiles without a metric group keep those defaults. A
   group includes defaults unless `defaults: false`, then adds its exact included
   MetricNames; statistics resolve from the metric entry, group, or profile in that
-  order.
+  order. Group query overrides attach only to explicit `include[]` expansions;
+  item query overrides attach only to that item's expanded metric/statistic series.
 - `rule_defaults.filters.resource_tags` is inherited when a rule omits
   `filters.resource_tags`; a present list replaces the default and `[]` disables it.
   Predicates are canonicalized once: exact case-sensitive keys are ANDed and the
   exact values for one key are ORed.
 - `compileConfig` coordinates a private staged compiler that resolves every reference, rejects unused credential/target
   definitions, applies profile defaults/include/exclude semantics, rejects duplicate
-  profile groups/MetricNames/normalized statistics, resolves inherited and replaced
-  statistics into canonical exact exported-series descriptors, intersects
+  profile groups and normalized statistics, pre-indexes profile MetricNames/statistics,
+  resolves inherited and replaced statistics into canonical exact exported-series
+  descriptors, rejects overlap between repeated explicit-item expansions, intersects
   intrinsic supported regions, enforces target/role partition consistency, and
   emits immutable ordered scopes.
 - Ordered policy scopes and tag-membership identities are separate. Scopes with the
@@ -349,6 +351,12 @@ The rolling window is `end = align_down(now - publication_delay, period)` and
 collection cycles after terminal completion re-emit the retained presentation
 without another AWS query.
 
+This deliberately differs from YACE's align-then-subtract ordering. With a six-hour period, five-minute delay, and
+`now=12:02`, this collector computes `align_down(11:57, 6h) = 06:00`; an align-then-subtract implementation computes
+`align_down(12:02, 6h) - 5m = 11:55`. The collector waits for the first shared collection tick at or after `12:05`
+before the `12:00` boundary is eligible. Increasing lookback searches more older buckets for sparse or late data; it
+does not change this end boundary or repair alignment.
+
 One batch can contain queries that finish differently. Outcomes update each
 stable query independently:
 
@@ -387,10 +395,12 @@ stable query independently:
   dirty flag remains set so a later cycle can rebuild from corrected inputs. There
   is no first-N truncation.
 - Each `plannedQuery` contains a fully resolved `{period, lookback,
-  publication_delay}` policy. Resolution is field-by-field: rule, rule defaults,
-  profile metric, profile defaults, then the built-in lookback/publication-delay
-  fallbacks. Profile `query.period` is required; the lookback fallback follows the
-  resolved period.
+  publication_delay}` policy. Resolution is field-by-field, from highest to lowest
+  precedence: job metric item, job metric group, rule, rule defaults, profile metric,
+  profile defaults, then the built-in lookback/publication-delay fallbacks. A group
+  source applies only to explicit `include[]` expansions; an item source applies
+  only to that item's expanded series. Profile `query.period` is required; the
+  lookback fallback follows the resolved period.
   Publication delay is collector scheduling policy, not an AWS SLA. In particular,
   the stock S3 storage profile's `1d` is a conservative choice; AWS documents that
   storage metrics are reported once per day but does not guarantee delivery within
@@ -409,6 +419,9 @@ observation state per stable query.
   end is newer than its last terminal completion. Adding a sibling query never
   makes completed siblings due, and clock jumps query only the current rolling
   window rather than backfilling missed buckets.
+- Eligibility has no independent timer. `dueQueries` runs only inside the shared
+  Netdata collection loop. If multiple period boundaries become eligible between
+  two `update_every` ticks, the next tick queries only the newest rolling window.
 - A transient attempt leaves completion unchanged and starts retry state for that
   stable query and eligible window. The first retry waits one `update_every`; each
   later delay doubles and is capped at the effective period. A new eligible window
@@ -449,8 +462,9 @@ observation state per stable query.
   fractional values render at full precision without a per-dimension
   `options.float`.
 - **Retention re-emit (sample-and-hold).** This decouples two cadences: the
-  **query cadence** follows each series' aligned effective period, while the **write cadence** is the collect loop
-  (`update_every`, free `metrix` writes). Netdata expects a value per dimension
+  **query eligibility** follows each series' aligned effective period, while both
+  request execution and the **write cadence** occur on the collect loop
+  (`update_every`; `metrix` writes are free). Netdata expects a value per dimension
   per collect cycle, so a stable query that is not due, or whose current attempt
   is transient, is re-written from its last cached value—a long-period metric
   (e.g. daily S3) renders as a continuous step line instead of gaps, at no extra
@@ -597,8 +611,9 @@ Each instance exports seven series across five CloudWatch MetricNames. Mixed
 `Average` and `Sum` entries are intentional: `Average` remains the raw gauge,
 while `rate: true` normalizes only the `Sum` sibling to a per-second value. Stock
 timing is `period=5m`, `lookback=5m`, and `publication_delay=5m`. Exact
-metric/statistic rules can assign one-minute Average and six-hour Sum policies
-without either rule shadowing the other's series.
+metric/statistic items in one profile group can assign one-minute Average and
+six-hour Sum policies. Repeating a MetricName is valid only when the expanded
+statistic sets are disjoint.
 
 ### PrivateLink service grains
 
@@ -625,7 +640,7 @@ bytes, new connections, and sent reset packets. Stock timing is 5m/5m/5m.
 `EndpointsCount` is a five-minute service-only gauge that records zero when AWS
 returns no datapoint; absent traffic gauges remain gaps. Exact rules can select
 one-minute traffic Average, five-minute endpoint count, and six-hour byte Sum as
-independent query policies.
+independent per-selection query policies in one rule.
 
 ## Credentials, Targets, And Account Identity
 
@@ -688,11 +703,12 @@ The two CloudWatch APIs bill differently, and the design leans on that:
   Point-aware batching keeps each AWS billing unit of up to five statistics for
   one structural metric in a single request, avoiding duplicate billing at a
   batch boundary.
-- **Per-query aligned-window completion is the governor** — a metric is queried
-  once per effective period (a 300s metric every aligned 300s window, a daily metric every ~24h),
-  not every collect cycle, so cost tracks each series' effective query period rather than
-  `update_every`. Between queries, values are re-emitted from cache at zero AWS
-  cost (see Emission And Sample-And-Hold).
+- **Per-query aligned-window completion is the governor** — on each collect tick,
+  a metric is queried only if that tick observes a newer eligible window. When
+  `update_every <= period`, successful steady-state frequency follows the period;
+  when `update_every > period`, execution is limited by `update_every` and skipped
+  intermediate windows are not backfilled. Between queries, values are re-emitted
+  from cache at zero AWS cost (see Emission And Sample-And-Hold).
 
 Narrow the bill with focused rule target/profile/region selections or longer effective
 periods configured through rule/default query timing; nested profile query defaults are the fallback.
@@ -744,7 +760,8 @@ billing semantics.
 - **Instance identity = exact dimension-name match** — a metric joins a profile
   only if its dimension-name set equals the profile's exactly.
 - **Query window is policy-driven** — `end = align_down(now - publication_delay,
-  period)` and `start = end - lookback`; the newest fully eligible finite bucket wins.
+  period)` and `start = end - lookback`; `end` is exclusive and the newest fully
+  eligible finite bucket wins. The policy is evaluated on shared collection ticks.
 - **No-data policy is per-metric** — a successfully-queried empty result records
   0 (`nil_as_zero`, defaulting on only for `rate: true` `sum`/`sample_count`) or
   gaps after a terminal successful window expires the retained datapoint.

--- a/src/go/plugin/go.d/collector/cloudwatch/collector_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/collector_test.go
@@ -102,11 +102,20 @@ func setSingleTargetPlan(c *Collector, account string, regions []string, profile
 }
 
 func testCompiledSeries(profile cwprofiles.ResolvedProfile) []compiledSeries {
-	series, err := resolveSeriesPolicies("test", nil, nil, profile, compileProfileSeries(profile))
+	series, err := resolveSeriesPolicies("test", nil, nil, profile, testSelectedProfileSeries(profile))
 	if err != nil {
 		panic(err)
 	}
 	return series
+}
+
+func testSelectedProfileSeries(profile cwprofiles.ResolvedProfile) []selectedSeriesSpec {
+	base := compileProfileSeries(profile)
+	selected := make([]selectedSeriesSpec, len(base))
+	for i, item := range base {
+		selected[i] = selectedSeriesSpec{profileSeriesSpec: item}
+	}
+	return selected
 }
 
 func resolvedTargetNames(c *Collector) []string {

--- a/src/go/plugin/go.d/collector/cloudwatch/config.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config.go
@@ -81,6 +81,7 @@ type ProfileMetricSelectorConfig struct {
 	Profile    string                  `yaml:"profile" json:"profile"`
 	Defaults   *bool                   `yaml:"defaults,omitempty" json:"defaults,omitempty"`
 	Statistics []string                `yaml:"statistics,omitempty" json:"statistics,omitempty"`
+	Query      *cwquery.Config         `yaml:"query,omitempty" json:"query,omitempty"`
 	Include    []MetricSelectionConfig `yaml:"include" json:"include"`
 }
 
@@ -89,8 +90,9 @@ func (c ProfileMetricSelectorConfig) includesDefaults() bool {
 }
 
 type MetricSelectionConfig struct {
-	Name       string   `yaml:"name" json:"name"`
-	Statistics []string `yaml:"statistics,omitempty" json:"statistics,omitempty"`
+	Name       string          `yaml:"name" json:"name"`
+	Statistics []string        `yaml:"statistics,omitempty" json:"statistics,omitempty"`
+	Query      *cwquery.Config `yaml:"query,omitempty" json:"query,omitempty"`
 }
 
 type RuleDefaultsConfig struct {

--- a/src/go/plugin/go.d/collector/cloudwatch/config_schema.json
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_schema.json
@@ -6,7 +6,7 @@
     "properties": {
       "update_every": {
         "title": "Update every",
-        "description": "Data collection interval, measured in seconds. CloudWatch's minimum period is 60s.",
+        "description": "Shared Netdata collection interval, measured in seconds. Per-series CloudWatch eligibility is evaluated on these ticks; a shorter metric period does not create an independent timer.",
         "type": "integer",
         "minimum": 60,
         "default": 60
@@ -287,9 +287,37 @@
                       "pattern": "^\\S(?:.*\\S)?$"
                     }
                   },
+                  "query": {
+                    "title": "Included-metric query policy",
+                    "description": "Optional field-by-field query timing applied only to series expanded from this group's include list. Unlisted profile defaults do not receive it. Omitted fields inherit the rule and lower-precedence values.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "period": {
+                        "title": "Aggregation period",
+                        "description": "CloudWatch aggregation period for explicitly included series. Must be from 1m through 1d and an exact multiple of 1m.",
+                        "type": "string",
+                        "pattern": "^[0-9]+(?:s|m|h|d|w|mo|y)$"
+                      },
+                      "lookback": {
+                        "title": "Rolling lookback",
+                        "description": "Rolling query horizon. Must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap.",
+                        "type": "string",
+                        "pattern": "^[0-9]+(?:s|m|h|d|w|mo|y)$"
+                      },
+                      "publication_delay": {
+                        "title": "Publication delay",
+                        "description": "Collector policy for how long to wait after a bucket closes before querying explicitly included series. This is not an AWS publication guarantee.",
+                        "type": "string",
+                        "pattern": "^[0-9]+(?:s|m|h|d|w|mo|y)$"
+                      }
+                    }
+                  },
                   "include": {
                     "title": "Included metrics",
-                    "description": "Exact, case-sensitive AWS MetricNames added by this group. A metric-level statistics list replaces the group statistics; when neither is set, the profile-declared statistics are inherited.",
+                    "description": "Exact, case-sensitive AWS MetricNames added by this group. A metric-level statistics list replaces the group statistics; when neither is set, the profile-declared statistics are inherited. Repeated MetricNames are allowed only when their expanded statistic sets are disjoint.",
                     "type": "array",
                     "minItems": 1,
                     "maxItems": 256,
@@ -315,6 +343,34 @@
                           "items": {
                             "type": "string",
                             "pattern": "^\\S(?:.*\\S)?$"
+                          }
+                        },
+                        "query": {
+                          "title": "Metric/statistic query policy",
+                          "description": "Optional field-by-field query timing for this item's expanded metric/statistic series. This overrides the enclosing metric-group query.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "period": {
+                              "title": "Aggregation period",
+                              "description": "CloudWatch aggregation period for this item's expanded series. Must be from 1m through 1d and an exact multiple of 1m.",
+                              "type": "string",
+                              "pattern": "^[0-9]+(?:s|m|h|d|w|mo|y)$"
+                            },
+                            "lookback": {
+                              "title": "Rolling lookback",
+                              "description": "Rolling query horizon. Must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap.",
+                              "type": "string",
+                              "pattern": "^[0-9]+(?:s|m|h|d|w|mo|y)$"
+                            },
+                            "publication_delay": {
+                              "title": "Publication delay",
+                              "description": "Collector policy for how long to wait after a bucket closes before querying this item's expanded series. This is not an AWS publication guarantee.",
+                              "type": "string",
+                              "pattern": "^[0-9]+(?:s|m|h|d|w|mo|y)$"
+                            }
                           }
                         }
                       },
@@ -387,7 +443,7 @@
             },
             "query": {
               "title": "Query policy",
-              "description": "Optional CloudWatch query timing overrides for this rule. Omitted fields inherit rule defaults and profile values.",
+              "description": "Optional CloudWatch query timing overrides for this rule. Omitted fields inherit rule defaults and profile values; explicit metric-group and item values take precedence.",
               "type": [
                 "object",
                 "null"
@@ -401,7 +457,7 @@
                 },
                 "lookback": {
                   "title": "Rolling lookback",
-                  "description": "Rolling query horizon. Must be at least the effective period, an exact period multiple, and no more than 1,440 buckets.",
+                  "description": "Rolling query horizon. Must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap.",
                   "type": "string",
                   "pattern": "^[0-9]+(?:s|m|h|d|w|mo|y)$"
                 },
@@ -718,9 +774,24 @@
                 "ui:placeholder": "Average"
               }
             },
+            "query": {
+              "ui:help": "Override CloudWatch timing only for series expanded from this group's include list. Unlisted default-selected series keep rule/profile timing.",
+              "period": {
+                "ui:help": "Aggregation period for explicitly included series. Eligibility is still evaluated only on shared update_every ticks.",
+                "ui:placeholder": "5m"
+              },
+              "lookback": {
+                "ui:help": "Rolling window searched for the newest eligible datapoint.",
+                "ui:placeholder": "30m"
+              },
+              "publication_delay": {
+                "ui:help": "Collector wait after a period closes. This is not an AWS publication guarantee.",
+                "ui:placeholder": "10m"
+              }
+            },
             "include": {
               "ui:listFlavour": "list",
-              "ui:help": "Exact AWS MetricNames to add. A metric-level statistics list replaces the group list; if both are omitted, the profile-declared statistics are used.",
+              "ui:help": "Exact AWS MetricNames to add. A metric-level statistics list replaces the group list; if both are omitted, the profile-declared statistics are used. Repeat a MetricName only for disjoint statistics.",
               "items": {
                 "name": {
                   "ui:help": "Exact, case-sensitive AWS MetricName from the profile.",
@@ -731,6 +802,21 @@
                   "ui:help": "Optional replacement statistics for this metric. Leave empty with no group statistics to inherit the profile declaration.",
                   "items": {
                     "ui:placeholder": "Maximum"
+                  }
+                },
+                "query": {
+                  "ui:help": "Override CloudWatch timing for this item's expanded metric/statistic series. Omitted fields inherit the group, rule, and profile chain.",
+                  "period": {
+                    "ui:help": "CloudWatch aggregation period for this item. Execution remains quantized to update_every ticks.",
+                    "ui:placeholder": "1m"
+                  },
+                  "lookback": {
+                    "ui:help": "Rolling window searched for the newest eligible datapoint.",
+                    "ui:placeholder": "5m"
+                  },
+                  "publication_delay": {
+                    "ui:help": "Collector wait after a period closes. Explicit 0s is allowed.",
+                    "ui:placeholder": "5m"
                   }
                 }
               }

--- a/src/go/plugin/go.d/collector/cloudwatch/config_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/awsauth"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/cwquery"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 
 	"github.com/stretchr/testify/assert"
@@ -201,6 +202,14 @@ func TestConfig_validateMetricSelector(t *testing.T) {
 				},
 			}},
 		},
+		"valid group and metric query overrides": {
+			selectors: []ProfileMetricSelectorConfig{{
+				Profile: "ec2", Query: &cwquery.Config{Period: longDuration(5 * time.Minute)},
+				Include: []MetricSelectionConfig{{
+					Name: "CPUUtilization", Query: &cwquery.Config{PublicationDelay: longDuration(0)},
+				}},
+			}},
+		},
 		"empty group statistics": {
 			selectors: []ProfileMetricSelectorConfig{{
 				Profile: "ec2", Statistics: []string{},
@@ -235,12 +244,25 @@ func TestConfig_validateMetricSelector(t *testing.T) {
 			selectors: []ProfileMetricSelectorConfig{{Profile: "ec2", Statistics: []string{"Average"}, Include: []MetricSelectionConfig{{}}}},
 			wantErr:   ".name must not be empty",
 		},
-		"duplicate metric": {
+		"repeated metric with potentially disjoint statistics is validated after profile expansion": {
 			selectors: []ProfileMetricSelectorConfig{{
-				Profile: "ec2", Statistics: []string{"Average"},
-				Include: []MetricSelectionConfig{{Name: "CPUUtilization"}, {Name: "CPUUtilization", Statistics: []string{"Maximum"}}},
+				Profile: "ec2",
+				Include: []MetricSelectionConfig{{Name: "CPUUtilization", Statistics: []string{"Average"}}, {Name: "CPUUtilization", Statistics: []string{"Maximum"}}},
 			}},
-			wantErr: "duplicate metric",
+		},
+		"invalid group query": {
+			selectors: []ProfileMetricSelectorConfig{{
+				Profile: "ec2", Query: &cwquery.Config{Period: longDuration(30 * time.Second)},
+				Include: []MetricSelectionConfig{{Name: "CPUUtilization"}},
+			}},
+			wantErr: "rules[0].metrics[0].query.period",
+		},
+		"invalid metric query": {
+			selectors: []ProfileMetricSelectorConfig{{
+				Profile: "ec2",
+				Include: []MetricSelectionConfig{{Name: "CPUUtilization", Query: &cwquery.Config{PublicationDelay: longDuration(-time.Second)}}},
+			}},
+			wantErr: "rules[0].metrics[0].include[0].query.publication_delay",
 		},
 		"metric name surrounding whitespace": {
 			selectors: []ProfileMetricSelectorConfig{{Profile: "ec2", Statistics: []string{"Average"}, Include: []MetricSelectionConfig{{Name: " CPUUtilization"}}}},
@@ -288,12 +310,14 @@ func TestConfigSchema_FormContract(t *testing.T) {
 	var doc map[string]any
 	require.NoError(t, json.Unmarshal(data, &doc))
 
-	// Query timing resolves rule -> rule_defaults -> profile -> built-in. A schema default makes
+	// Query timing resolves item -> group -> rule -> rule_defaults -> profile -> built-in. A schema default makes
 	// the form emit a value the operator never chose, collapsing that chain.
 	ruleQuery := schemaObjectAt(t, doc, "jsonSchema", "properties", "rules", "items", "properties", "query", "properties")
 	defaultQuery := schemaObjectAt(t, doc, "jsonSchema", "properties", "rule_defaults", "properties", "query", "properties")
+	groupQuery := schemaObjectAt(t, doc, "jsonSchema", "properties", "rules", "items", "properties", "metrics", "items", "properties", "query", "properties")
+	itemQuery := schemaObjectAt(t, doc, "jsonSchema", "properties", "rules", "items", "properties", "metrics", "items", "properties", "include", "items", "properties", "query", "properties")
 	for _, field := range []string{"period", "lookback", "publication_delay"} {
-		for _, query := range []map[string]any{ruleQuery, defaultQuery} {
+		for _, query := range []map[string]any{ruleQuery, defaultQuery, groupQuery, itemQuery} {
 			assert.NotContainsf(t, schemaObjectAt(t, query, field), "default",
 				"%s must stay omitted so runtime precedence resolves it", field)
 		}

--- a/src/go/plugin/go.d/collector/cloudwatch/config_validate.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/config_validate.go
@@ -244,24 +244,21 @@ func validateMetricSelectors(path string, selectors []ProfileMetricSelectorConfi
 			seenProfiles[selector.Profile] = struct{}{}
 		}
 		errs = append(errs, validateMetricStatistics(groupPath+".statistics", selector.Statistics))
+		errs = append(errs, cwquery.Validate(groupPath+".query", selector.Query))
 		if len(selector.Include) == 0 {
 			errs = append(errs, fmt.Errorf("%s.include must contain at least one metric", groupPath))
 			continue
 		}
 
-		seenMetrics := make(map[string]struct{}, len(selector.Include))
 		for j, metric := range selector.Include {
 			metricPath := fmt.Sprintf("%s.include[%d]", groupPath, j)
 			if err := validateCanonicalString(metricPath+".name", metric.Name); err != nil {
 				errs = append(errs, err)
 			} else if metric.Name == "" {
 				errs = append(errs, fmt.Errorf("%s.name must not be empty", metricPath))
-			} else if _, ok := seenMetrics[metric.Name]; ok {
-				errs = append(errs, fmt.Errorf("%s.include contains duplicate metric %q", groupPath, metric.Name))
-			} else {
-				seenMetrics[metric.Name] = struct{}{}
 			}
 			errs = append(errs, validateMetricStatistics(metricPath+".statistics", metric.Statistics))
+			errs = append(errs, cwquery.Validate(metricPath+".query", metric.Query))
 		}
 	}
 	return errors.Join(errs...)

--- a/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/integrations/amazon_cloudwatch.md
@@ -106,6 +106,7 @@ The defaults are designed so a minimal configuration collects something useful:
 - A rule that omits `metrics` collects the default-enabled metrics from those profiles.
 - A metric group changes only its named profile; other selected profiles keep their defaults. The group keeps the profile's defaults unless `defaults: false`; either way, it adds the exact AWS MetricNames it lists.
 - Statistics resolve from the metric entry, then the group, then the profile declaration.
+- Query timing resolves field-by-field from the metric item, metric group, rule, rule defaults, profile metric, and profile defaults. A group query applies only to its explicit `include[]` expansions; unlisted defaults keep lower-precedence timing.
 - Charts appear only for profiles with live metrics.
 - Discovery and the query blueprint are cached; discovery refreshes every `discovery.refresh_every` seconds (default 300).
 
@@ -114,8 +115,10 @@ The defaults are designed so a minimal configuration collects something useful:
 
 **Timing**
 
-- The minimum collection interval is 60 seconds (CloudWatch's minimum metric period).
-- Query timing resolves field-by-field: `rules[].query`, then `rule_defaults.query`, then metric and profile defaults, then the built-in 10-minute publication delay. The combined `publication_delay + lookback + period` horizon cannot exceed 14 days.
+- The minimum collection interval is 60 seconds. Every per-series policy is evaluated on the job's shared `update_every` ticks; there are no independent per-selection timers.
+- Query timing resolves field-by-field, from highest to lowest precedence: `rules[].metrics[].include[].query`, `rules[].metrics[].query`, `rules[].query`, `rule_defaults.query`, profile metric query, profile query, then built-in fallbacks. The combined `publication_delay + lookback + period` horizon cannot exceed 14 days.
+- The rolling window is `end = align_down(now - publication_delay, period)` and `start = end - lookback`; `end` is exclusive. One-period lookback is valid. Longer lookback tolerates sparse or late data but increases response work.
+- If `period < update_every`, period still controls CloudWatch aggregation and rate normalization, but the first available collection tick queries only the newest eligible window; intermediate windows may be skipped.
 - The stock S3 storage profile uses a conservative one-day delay policy: AWS documents that S3 storage metrics are reported once per day, without guaranteeing publication within one day.
 - A successful sparse query can replay its newest eligible CloudWatch value for up to `lookback`. During transient AWS failures, the retained value can be replayed longer, until a successful query replaces or expires it.
 
@@ -145,19 +148,19 @@ AWS bills CloudWatch API usage. `GetMetricData` is the cost driver -- roughly $0
 To estimate a job's normal daily cost:
 
 ```text
-billable metric requests/day ≈ instances × billable metrics per instance × (86,400 / period seconds)
+billable metric requests/day ≈ Σ effective-policy groups (instances × calculated metric-request units per instance × 86,400 / max(period seconds, update_every seconds))
 ```
 
-For example, one Billing series at the stock 10-minute period is 86,400 / 600 = 144 requests per day. For a running job, skip the arithmetic and read the **CloudWatch Metric Requests** chart described below -- it reports the billable metric requests actually submitted.
+This is a healthy steady-state estimate; retries add work, and alignment near the observation boundary can shift a short sample. For example, one Billing series at the stock 10-minute period with `update_every <= 600` is 86,400 / 600 = 144 requests per day. For a running job, skip the arithmetic and read the **CloudWatch Metric Requests** chart described below -- it reports the billable metric requests actually submitted.
 
 **How the collector keeps cost down**
 
-- Each series is queried once per newly eligible period window, not once per Netdata collection cycle.
+- Each series is queried on the first shared collection tick that observes a newer eligible period window. If several windows become eligible between ticks, only the newest is queried.
 - Curated profiles, exact metric/statistic/resource-tag selection, and single-statistic defaults keep the selected set small.
 - Compatible rules and profiles share discovery scans; discovery and query plans are cached; `recently_active_only` narrows scans to active resources.
-- A transient failure retries after one `update_every`, then doubles the delay within the same eligible window, capped at the effective period. Retries are billable, so `update_every` affects failure-time cost even though it does not set the normal query cadence.
+- A transient failure retries after one `update_every`, then doubles the delay within the same eligible window, capped at the effective period. Retries are billable. `update_every` also limits successful request frequency when it is longer than the effective period.
 
-Cost scales with selected targets, instances, metrics, statistics beyond AWS's grouping, periods, and lookback length. Longer lookbacks increase requested datapoints and can disable CloudWatch's three-hour recently-active discovery filter. To reduce cost, narrow `rules[].targets`, `rules[].profiles`, `rules[].metrics`, `rules[].regions`, or configure resource tag filters.
+Cost scales with selected targets, instances, metrics, statistics beyond AWS's grouping, effective request frequency, and lookback length. Statistics of one structural metric can share a calculated request unit only when their complete effective policies match; per-selection differences split the group and can increase cost. Longer lookbacks increase requested datapoints and can disable CloudWatch's three-hour recently-active discovery filter. To reduce cost, narrow `rules[].targets`, `rules[].profiles`, `rules[].metrics`, `rules[].regions`, or configure resource tag filters.
 
 **Watching collector-issued work**
 
@@ -274,7 +277,7 @@ A user profile file with the same basename as a stock profile overrides it.
 
 | Group | Option | Description | Default | Required |
 |:------|:-----|:------------|:--------|:---------:|
-| **Collection** | update_every | Data collection interval (seconds). Must be at least 60 (CloudWatch's minimum period). | 60 | no |
+| **Collection** | update_every | Shared Netdata collection interval (seconds), minimum 60. Every per-series policy is evaluated on these ticks; a shorter period does not create an independent timer and intermediate eligible windows may be skipped. | 60 | no |
 |  | autodetection_retry | Recheck interval (seconds) when the job fails to start. Default `0` means no retry; set a positive value to keep retrying. | 0 | no |
 |  | timeout | AWS operation timeout (seconds). Identity, resource-tag, and query operations use it for their operation scope; discovery shares one timeout across its whole refresh stage. | 30 | no |
 | **Credentials** | credentials | Up to 64 named credential sources. Every source has a `type` of `default` (AWS SDK default chain) or `static` (explicit access/session credentials in `type_static`). Multiple targets can share one credential source. |  | yes |
@@ -299,17 +302,25 @@ A user profile file with the same basename as a stock profile overrides it.
 |  | rules[].metrics[].profile | Profile basename. It must already be selected by `rules[].profiles` and may appear in only one metrics group per rule. Other selected profiles keep their default-enabled metrics. |  | yes |
 |  | rules[].metrics[].defaults | Include this profile's default-enabled metrics before adding the exact MetricNames below. Set `false` for an exact-only selection. | yes | no |
 |  | rules[].metrics[].statistics | Optional non-empty AWS statistics inherited by included metrics that omit their own list. When both lists are omitted, the profile-declared statistics are used. Named statistics are case-insensitive. |  | no |
-|  | rules[].metrics[].include | Non-empty list of exact, case-sensitive AWS CloudWatch MetricNames added by this group. Duplicate names are rejected. |  | yes |
+| **Rules / Query Policy** | rules[].metrics[].query | Optional field-by-field timing override applied only to series expanded from this group's explicit `include[]` items. Unlisted default-selected series keep rule/profile timing. |  | no |
+|  | rules[].metrics[].query.period | CloudWatch aggregation period for explicitly included series, from `1m` through `24h` as an exact multiple of `1m`. Eligibility is still evaluated only on shared `update_every` ticks. |  | no |
+|  | rules[].metrics[].query.lookback | Rolling window for explicitly included series. It must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap. |  | no |
+|  | rules[].metrics[].query.publication_delay | Collector wait after a bucket closes for explicitly included series. This is a scheduling policy, not an AWS publication guarantee; explicit `0s` is allowed. |  | no |
+| **Rules** | rules[].metrics[].include | Non-empty list of exact, case-sensitive AWS CloudWatch MetricNames added by this group. A MetricName may repeat only when the items expand to disjoint statistic sets. |  | yes |
 |  | rules[].metrics[].include[].name | Exact, case-sensitive AWS CloudWatch MetricName exported by the profile. |  | yes |
 |  | rules[].metrics[].include[].statistics | Optional non-empty replacement for the group statistics. When both are omitted, inherit every statistic declared for the metric by the profile. Use `Average`, `Minimum`, `Maximum`, `Sum`, `SampleCount`, or `p<N>`; named statistics are case-insensitive. |  | no |
-|  | rules[].regions | Canonical lowercase AWS region codes selected by this rule. The compiler intersects them with intrinsic profile restrictions; CloudFront and the Billing profiles support only `us-east-1`. |  | yes |
+| **Rules / Query Policy** | rules[].metrics[].include[].query | Optional field-by-field timing override for this item's expanded metric/statistic series. It overrides the enclosing metric-group query; omitted fields inherit independently. |  | no |
+|  | rules[].metrics[].include[].query.period | CloudWatch aggregation period for this item's expanded series, from `1m` through `24h` as an exact multiple of `1m`. It remains the aggregation and rate divisor when shorter than `update_every`. |  | no |
+|  | rules[].metrics[].include[].query.lookback | Rolling window for this item's expanded series. It must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap. |  | no |
+|  | rules[].metrics[].include[].query.publication_delay | Collector wait after a bucket closes for this item's expanded series. This is a scheduling policy, not an AWS publication guarantee; explicit `0s` is allowed. |  | no |
+| **Rules** | rules[].regions | Canonical lowercase AWS region codes selected by this rule. The compiler intersects them with intrinsic profile restrictions; CloudFront and the Billing profiles support only `us-east-1`. |  | yes |
 | **Rules / Query Policy** | rule_defaults.query | Shared query timing inherited field-by-field by collection rules. Omitted fields fall through to profile or built-in fallbacks. The resolved `publication_delay + lookback + period` horizon cannot exceed 14 days. |  | no |
-|  | rule_defaults.query.period | Default CloudWatch aggregation period from `1m` through `24h`, as an exact multiple of `1m`. An omitted rule period inherits this value before nested metric and profile query defaults. |  | no |
-|  | rule_defaults.query.lookback | Default rolling window searched for the newest eligible datapoint. It must be at least the effective period, an exact period multiple, and no more than 1,440 buckets (a bucket is one period). |  | no |
+|  | rule_defaults.query.period | Default CloudWatch aggregation period from `1m` through `24h`, as an exact multiple of `1m`. It overrides profile timing and is inherited unless a rule, metric group, or metric item replaces it. |  | no |
+|  | rule_defaults.query.lookback | Default rolling window searched for the newest eligible datapoint. It must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap. |  | no |
 |  | rule_defaults.query.publication_delay | Default collector wait after a bucket closes before it becomes eligible. This is a scheduling policy, not an AWS publication guarantee. Omission falls through to the profile value and then the built-in `10m` fallback. Setting this option overrides profile-specific delays for every inheriting rule, including the stock S3 storage profile's conservative `1d`; AWS documents only that S3 storage metrics are reported once per day, so use a shorter default only after verifying each workload's publication timing. |  | no |
-|  | rules[].query | Optional query timing overrides for this rule. Each omitted field independently inherits `rule_defaults.query`, then the relevant profile or built-in fallback. |  | no |
-|  | rules[].query.period | CloudWatch aggregation period for every series selected by this rule, from `1m` through `24h` as an exact multiple of `1m`. Rate metrics are normalized using this effective period. |  | no |
-|  | rules[].query.lookback | Rolling window searched for the newest complete finite datapoint. It must be at least the effective period, an exact period multiple, and no more than 1,440 buckets (a bucket is one period). Successful queries may present the retained datapoint as current for up to this duration; longer lookbacks increase response work. |  | no |
+|  | rules[].query | Optional query timing overrides for this rule. Each omitted field independently inherits `rule_defaults.query`, then the relevant profile or built-in fallback; explicit metric-group and item values take precedence. |  | no |
+|  | rules[].query.period | CloudWatch aggregation period for series selected by this rule, from `1m` through `24h` as an exact multiple of `1m`; metric-group and item values can replace it. Rate metrics are normalized using the final effective period. |  | no |
+|  | rules[].query.lookback | Rolling window searched for the newest complete finite datapoint. It must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap. Successful queries may present the retained datapoint as current for up to this duration; longer lookbacks increase response work. |  | no |
 |  | rules[].query.publication_delay | Collector wait after a bucket closes before querying it. This is a scheduling policy, not an AWS publication guarantee. Explicit `0s` is allowed for metrics known to publish immediately. |  | no |
 | **Rules / Resource Filters** | rule_defaults.filters.resource_tags | Job-wide list of exact, case-sensitive AWS resource tag predicates inherited by rules that omit `rules[].filters.resource_tags`. All keys must match; any listed value for one key may match. The Resource Groups Tagging API performs the focused lookup and requires `tag:GetResources`. |  | no |
 |  | rule_defaults.filters.resource_tags[].key | Exact AWS resource tag key. A filter list supports at most 50 distinct keys. |  | yes |
@@ -456,7 +467,7 @@ jobs:
 
 ###### Different timing for metrics in one profile
 
-Use disjoint exact metric selections when one service needs different query timing. Earlier rules own only the metric/statistic series they select, so these two Lambda rules do not shadow each other.
+Use one profile metric group with disjoint statistic items when one AWS MetricName needs different timing. The group query is the default for its explicit items; the p90 item overrides it. Repeated MetricNames whose expanded statistic sets overlap are rejected.
 
 <details open><summary>Config</summary>
 
@@ -470,7 +481,7 @@ jobs:
       - name: base
         credentials: sdk_default
     rules:
-      - name: lambda-activity
+      - name: lambda-duration
         targets: [base]
         profiles:
           defaults: false
@@ -478,37 +489,27 @@ jobs:
         metrics:
           - profile: lambda
             defaults: false
-            statistics: [Sum]
-            include:
-              - name: Invocations
-        regions: [us-east-1]
-        query:
-          period: 5m
-          lookback: 30m
-          publication_delay: 10m
-      - name: lambda-latency
-        targets: [base]
-        profiles:
-          defaults: false
-          include: [lambda]
-        metrics:
-          - profile: lambda
-            defaults: false
-            statistics: [Average, p90]
+            query:
+              period: 5m
+              lookback: 30m
+              publication_delay: 10m
             include:
               - name: Duration
+                statistics: [Average]
+              - name: Duration
+                statistics: [p90]
+                query:
+                  period: 1m
+                  lookback: 5m
+                  publication_delay: 5m
         regions: [us-east-1]
-        query:
-          period: 1m
-          lookback: 5m
-          publication_delay: 5m
 
 ```
 </details>
 
 ###### Lower resolution to reduce cost
 
-Collect the default profiles at five-minute resolution and refresh discovery less often. `rule_defaults.query` applies field-by-field to every rule that does not override it, replacing profile timing defaults -- the daily S3 storage profile is excluded here so the job-wide five-minute policy does not query it before AWS publishes. `update_every` controls how often charts update and the failure-retry cadence, not the normal query cost.
+Collect the default profiles at five-minute resolution and refresh discovery less often. `rule_defaults.query` applies field-by-field to every rule that does not override it, replacing profile timing defaults -- the daily S3 storage profile is excluded here so the job-wide five-minute policy does not query it before AWS publishes. Matching `update_every` to the period lets every newly eligible window be observed without extra cached-only collection ticks.
 
 <details open><summary>Config</summary>
 
@@ -540,7 +541,7 @@ jobs:
 
 ###### AWS Billing estimated charges
 
-Collect each available exact Billing grain independently. Billing metrics must be enabled first, are published only in `us-east-1`, and do not support resource-tag filters or resource-tag-derived labels. The stock profiles use a 10-minute period and 24-hour retrieval window; a `rules[].query` block would override only the fields it sets.
+Collect each available exact Billing grain independently. Billing metrics must be enabled first, are published only in `us-east-1`, and do not support resource-tag filters or resource-tag-derived labels. The stock profiles use a 10-minute period and 24-hour retrieval window; job query blocks override only the fields they set according to selection precedence.
 
 <details open><summary>Config</summary>
 
@@ -593,7 +594,7 @@ jobs:
           - key: environment
             values: [production]
     rules:
-      - name: endpoint-averages
+      - name: endpoint-split-timing
         targets: [base]
         profiles:
           defaults: false
@@ -601,32 +602,24 @@ jobs:
         metrics:
           - profile: privatelink_endpoint
             defaults: false
-            statistics: [Average]
+            query:
+              period: 1m
+              lookback: 5m
+              publication_delay: 5m
             include:
               - name: ActiveConnections
+                statistics: [Average]
               - name: BytesProcessed
+                statistics: [Average]
               - name: NewConnections
-        regions: [us-east-1]
-        query:
-          period: 1m
-          lookback: 5m
-          publication_delay: 5m
-      - name: endpoint-six-hour-bytes
-        targets: [base]
-        profiles:
-          defaults: false
-          include: [privatelink_endpoint]
-        metrics:
-          - profile: privatelink_endpoint
-            defaults: false
-            include:
+                statistics: [Average]
               - name: BytesProcessed
                 statistics: [Sum]
+                query:
+                  period: 6h
+                  lookback: 6h
+                  publication_delay: 5m
         regions: [us-east-1]
-        query:
-          period: 6h
-          lookback: 6h
-          publication_delay: 5m
       - name: endpoint-subnets
         targets: [base]
         profiles:
@@ -661,7 +654,7 @@ jobs:
           - key: environment
             values: [production]
     rules:
-      - name: service-traffic-averages
+      - name: service-split-timing
         targets: [base]
         profiles:
           defaults: false
@@ -669,49 +662,32 @@ jobs:
         metrics:
           - profile: privatelink_service
             defaults: false
-            statistics: [Average]
+            query:
+              period: 1m
+              lookback: 5m
+              publication_delay: 5m
             include:
               - name: ActiveConnections
+                statistics: [Average]
               - name: BytesProcessed
+                statistics: [Average]
               - name: NewConnections
+                statistics: [Average]
               - name: RstPacketsSent
-        regions: [us-east-1]
-        query:
-          period: 1m
-          lookback: 5m
-          publication_delay: 5m
-      - name: service-endpoint-count
-        targets: [base]
-        profiles:
-          defaults: false
-          include: [privatelink_service]
-        metrics:
-          - profile: privatelink_service
-            defaults: false
-            include:
+                statistics: [Average]
               - name: EndpointsCount
                 statistics: [Average]
-        regions: [us-east-1]
-        query:
-          period: 5m
-          lookback: 5m
-          publication_delay: 5m
-      - name: service-six-hour-bytes
-        targets: [base]
-        profiles:
-          defaults: false
-          include: [privatelink_service]
-        metrics:
-          - profile: privatelink_service
-            defaults: false
-            include:
+                query:
+                  period: 5m
+                  lookback: 5m
+                  publication_delay: 5m
               - name: BytesProcessed
                 statistics: [Sum]
+                query:
+                  period: 6h
+                  lookback: 6h
+                  publication_delay: 5m
         regions: [us-east-1]
-        query:
-          period: 6h
-          lookback: 6h
-          publication_delay: 5m
     labels:
       resource_tags:
         - key: Name
@@ -966,7 +942,7 @@ These disabled opt-in profiles are collected when a rule names them in `profiles
 
 **PrivateLink service grains.** The default `privatelink_service` profile identifies the provider service by `service_id` and is the only grain that exports `EndpointsCount`. The opt-in profiles split by `availability_zone`, `load_balancer_arn`, both, or consumer `vpc_endpoint_id`. All five share one `AWS/PrivateLinkServices` discovery scan and join tags through the parent endpoint service (`ec2:vpc-endpoint-service`). The collector deliberately does not attach endpoint or load-balancer tags to detailed children -- a `vpc_endpoint_id` can identify a consumer endpoint outside the service-owning account. `EndpointsCount` is read on its documented five-minute cadence and records zero when no datapoint is published; traffic gauges show gaps when absent.
 
-**PrivateLink cost.** At stock timing (five-minute period, lookback, and publication delay), an endpoint, subnet, or default service instance has five structural CloudWatch metrics: (86,400 / 300) × 5 = 1,440 billable metric requests per day before retries. Each opt-in detailed service instance has four, or 1,152 per day. A one-minute override runs its selected metrics five times as often; narrow profiles, metrics, regions, grains, and resource tags when that freshness is not required.
+**PrivateLink cost.** At stock timing (five-minute period, lookback, and publication delay) and `update_every <= 300`, an endpoint, subnet, or default service instance has five structural CloudWatch metrics: (86,400 / 300) × 5 = 1,440 billable metric requests per day before retries. Each opt-in detailed service instance has four, or 1,152 per day. With `update_every <= 60`, a one-minute override runs its selected metrics five times as often; a slower collection interval limits execution and skips intermediate windows. Narrow profiles, metrics, regions, grains, and resource tags when that freshness is not required.
 
 **Cardinality warning.** These opt-in profiles include potentially high-cardinality data. **S3 Request Metrics** additionally require per-bucket request-metrics configuration in AWS and are billed at CloudWatch custom-metric rates; they collect nothing until enabled on the bucket. PrivateLink cardinality grows with endpoint subnets, service Availability Zones, load balancers, and consumer endpoints; the combined Availability Zone/load-balancer grain multiplies those dimensions. The Billing service/account grains grow with the payer's services and linked accounts.
 
@@ -1128,10 +1104,10 @@ Check the following:
 
 CloudWatch publishes metrics with a delay.
 
-- Keep `rules[].query.period` at or above the metric's real publication cadence. A shorter override increases billed query frequency but cannot make AWS publish more often, so it can create empty windows.
-- Set `rules[].query.publication_delay` when a workload publishes completed buckets later than its profile or the built-in `10m` fallback.
+- Keep the effective query `period` at or above the metric's real publication cadence. A shorter override can increase billed query frequency but cannot make AWS publish more often, so it can create empty windows. When it is also shorter than `update_every`, request execution remains limited to shared collection ticks and intermediate windows may be skipped.
+- Set a rule, metric-group, or metric-item `publication_delay` when a workload publishes completed buckets later than its profile or the built-in `10m` fallback.
 - Check `rule_defaults.query.publication_delay` before overriding an individual rule. A job-wide value replaces profile-specific delays for inheriting rules, including the stock S3 storage profile's conservative `1d`, and a shorter value can query daily data before it is published.
-- Set `rules[].query.lookback` to search a wider rolling window for sparse datapoints. It must be an exact multiple of the effective period.
+- Set `lookback` at the narrowest applicable query level to search a wider rolling window for sparse datapoints. It must be at least one effective period and an exact period multiple; one period is valid.
 - **Stale-looking values** -- a successful query presents its newest eligible datapoint on every Netdata collection cycle, so an old CloudWatch value can appear current for up to `lookback`. During transient AWS failures, replay can continue longer until a successful query replaces or expires it.
 - Longer lookbacks increase response work and may disable `recently_active_only` for the shared discovery scan.
 - Transient query failures preserve the retained value and retry after one `update_every`; later delays double within the same eligible window up to the effective period. A newly eligible window resets the backoff.

--- a/src/go/plugin/go.d/collector/cloudwatch/internal/cwquery/config.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/internal/cwquery/config.go
@@ -18,7 +18,8 @@ const (
 )
 
 // Config defines optional CloudWatch query defaults. Callers compose profile,
-// metric, job-default, and rule values field by field through Resolve.
+// metric, job-default, rule, and job-selection values field by field through
+// Resolve.
 type Config struct {
 	Period           *confopt.LongDuration `yaml:"period,omitempty" json:"period,omitempty"`
 	Lookback         *confopt.LongDuration `yaml:"lookback,omitempty" json:"lookback,omitempty"`
@@ -38,6 +39,8 @@ type Resolution struct {
 	Metric       Source
 	RuleDefaults Source
 	Rule         Source
+	Group        Source
+	Item         Source
 }
 
 // Policy is the fully resolved timing contract for one exported series.
@@ -89,14 +92,14 @@ func ValidateProfile(path string, cfg Config) error {
 	return Validate(path, &cfg)
 }
 
-// Resolve applies field precedence rule > rule defaults > metric > profile,
-// then validates the effective policy. Lookback falls back to the resolved
-// period and publication delay to the collector-wide default.
+// Resolve applies field precedence item > group > rule > rule defaults > metric
+// > profile, then validates the effective policy. Lookback falls back to the
+// resolved period and publication delay to the collector-wide default.
 func Resolve(input Resolution) (Policy, error) {
 	if input.Profile.Config == nil || input.Profile.Config.Period == nil {
 		return Policy{}, fmt.Errorf("%s.period is required", sourcePath(input.Profile, "profile query"))
 	}
-	sources := []Source{input.Profile, input.Metric, input.RuleDefaults, input.Rule}
+	sources := []Source{input.Profile, input.Metric, input.RuleDefaults, input.Rule, input.Group, input.Item}
 	period, periodPath, _ := resolveDuration(sources, "period", func(cfg *Config) *confopt.LongDuration { return cfg.Period })
 
 	lookback, lookbackPath := period, periodPath

--- a/src/go/plugin/go.d/collector/cloudwatch/internal/cwquery/config_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/internal/cwquery/config_test.go
@@ -84,6 +84,20 @@ func TestResolve_Precedence(t *testing.T) {
 	}
 }
 
+func TestResolve_SelectionPrecedence(t *testing.T) {
+	got, err := Resolve(Resolution{
+		Path:         "rules[0]",
+		Profile:      Source{Config: &Config{Period: testDuration(5 * time.Minute), Lookback: testDuration(10 * time.Minute), PublicationDelay: testDuration(15 * time.Minute)}, Path: "profile.query"},
+		Metric:       Source{Config: &Config{Period: testDuration(10 * time.Minute)}, Path: "profile.metrics[0].query"},
+		RuleDefaults: Source{Config: &Config{Lookback: testDuration(20 * time.Minute)}, Path: "rule_defaults.query"},
+		Rule:         Source{Config: &Config{PublicationDelay: testDuration(30 * time.Minute)}, Path: "rules[0].query"},
+		Group:        Source{Config: &Config{Period: testDuration(15 * time.Minute), PublicationDelay: testDuration(0)}, Path: "rules[0].metrics[0].query"},
+		Item:         Source{Config: &Config{Lookback: testDuration(45 * time.Minute)}, Path: "rules[0].metrics[0].include[0].query"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, Policy{Period: 15 * time.Minute, Lookback: 45 * time.Minute, PublicationDelay: 0}, got)
+}
+
 func TestResolve_Validation(t *testing.T) {
 	maxWholeSecondDuration := (time.Duration(1<<63-1) / time.Second) * time.Second
 	tests := map[string]struct {
@@ -171,6 +185,35 @@ func TestResolve_ReportsSelectedSourcePath(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, err := resolveForTest(tc.rule, tc.defaults, tc.metric, tc.profile)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.wantPath)
+		})
+	}
+}
+
+func TestResolve_ReportsSelectionSourcePath(t *testing.T) {
+	tests := map[string]struct {
+		group, item *Config
+		wantPath    string
+	}{
+		"group": {
+			group:    &Config{Period: testDuration(90 * time.Second)},
+			wantPath: "rules[0].metrics[0].query.period",
+		},
+		"item": {
+			item:     &Config{Lookback: testDuration(6 * time.Minute)},
+			wantPath: "rules[0].metrics[0].include[0].query.lookback",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := Resolve(Resolution{
+				Path:    "rules[0]",
+				Profile: Source{Config: &Config{Period: testDuration(5 * time.Minute)}, Path: "profile.query"},
+				Group:   Source{Config: tc.group, Path: "rules[0].metrics[0].query"},
+				Item:    Source{Config: tc.item, Path: "rules[0].metrics[0].include[0].query"},
+			})
 
 			require.Error(t, err)
 			assert.ErrorContains(t, err, tc.wantPath)

--- a/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
+++ b/src/go/plugin/go.d/collector/cloudwatch/metadata.yaml
@@ -147,14 +147,17 @@ modules:
             - A rule that omits `metrics` collects the default-enabled metrics from those profiles.
             - A metric group changes only its named profile; other selected profiles keep their defaults. The group keeps the profile's defaults unless `defaults: false`; either way, it adds the exact AWS MetricNames it lists.
             - Statistics resolve from the metric entry, then the group, then the profile declaration.
+            - Query timing resolves field-by-field from the metric item, metric group, rule, rule defaults, profile metric, and profile defaults. A group query applies only to its explicit `include[]` expansions; unlisted defaults keep lower-precedence timing.
             - Charts appear only for profiles with live metrics.
             - Discovery and the query blueprint are cached; discovery refreshes every `discovery.refresh_every` seconds (default 300).
         limits:
           description: |
             **Timing**
 
-            - The minimum collection interval is 60 seconds (CloudWatch's minimum metric period).
-            - Query timing resolves field-by-field: `rules[].query`, then `rule_defaults.query`, then metric and profile defaults, then the built-in 10-minute publication delay. The combined `publication_delay + lookback + period` horizon cannot exceed 14 days.
+            - The minimum collection interval is 60 seconds. Every per-series policy is evaluated on the job's shared `update_every` ticks; there are no independent per-selection timers.
+            - Query timing resolves field-by-field, from highest to lowest precedence: `rules[].metrics[].include[].query`, `rules[].metrics[].query`, `rules[].query`, `rule_defaults.query`, profile metric query, profile query, then built-in fallbacks. The combined `publication_delay + lookback + period` horizon cannot exceed 14 days.
+            - The rolling window is `end = align_down(now - publication_delay, period)` and `start = end - lookback`; `end` is exclusive. One-period lookback is valid. Longer lookback tolerates sparse or late data but increases response work.
+            - If `period < update_every`, period still controls CloudWatch aggregation and rate normalization, but the first available collection tick queries only the newest eligible window; intermediate windows may be skipped.
             - The stock S3 storage profile uses a conservative one-day delay policy: AWS documents that S3 storage metrics are reported once per day, without guaranteeing publication within one day.
             - A successful sparse query can replay its newest eligible CloudWatch value for up to `lookback`. During transient AWS failures, the retained value can be replayed longer, until a successful query replaces or expires it.
 
@@ -182,19 +185,19 @@ modules:
             To estimate a job's normal daily cost:
 
             ```text
-            billable metric requests/day ≈ instances × billable metrics per instance × (86,400 / period seconds)
+            billable metric requests/day ≈ Σ effective-policy groups (instances × calculated metric-request units per instance × 86,400 / max(period seconds, update_every seconds))
             ```
 
-            For example, one Billing series at the stock 10-minute period is 86,400 / 600 = 144 requests per day. For a running job, skip the arithmetic and read the **CloudWatch Metric Requests** chart described below -- it reports the billable metric requests actually submitted.
+            This is a healthy steady-state estimate; retries add work, and alignment near the observation boundary can shift a short sample. For example, one Billing series at the stock 10-minute period with `update_every <= 600` is 86,400 / 600 = 144 requests per day. For a running job, skip the arithmetic and read the **CloudWatch Metric Requests** chart described below -- it reports the billable metric requests actually submitted.
 
             **How the collector keeps cost down**
 
-            - Each series is queried once per newly eligible period window, not once per Netdata collection cycle.
+            - Each series is queried on the first shared collection tick that observes a newer eligible period window. If several windows become eligible between ticks, only the newest is queried.
             - Curated profiles, exact metric/statistic/resource-tag selection, and single-statistic defaults keep the selected set small.
             - Compatible rules and profiles share discovery scans; discovery and query plans are cached; `recently_active_only` narrows scans to active resources.
-            - A transient failure retries after one `update_every`, then doubles the delay within the same eligible window, capped at the effective period. Retries are billable, so `update_every` affects failure-time cost even though it does not set the normal query cadence.
+            - A transient failure retries after one `update_every`, then doubles the delay within the same eligible window, capped at the effective period. Retries are billable. `update_every` also limits successful request frequency when it is longer than the effective period.
 
-            Cost scales with selected targets, instances, metrics, statistics beyond AWS's grouping, periods, and lookback length. Longer lookbacks increase requested datapoints and can disable CloudWatch's three-hour recently-active discovery filter. To reduce cost, narrow `rules[].targets`, `rules[].profiles`, `rules[].metrics`, `rules[].regions`, or configure resource tag filters.
+            Cost scales with selected targets, instances, metrics, statistics beyond AWS's grouping, effective request frequency, and lookback length. Statistics of one structural metric can share a calculated request unit only when their complete effective policies match; per-selection differences split the group and can increase cost. Longer lookbacks increase requested datapoints and can disable CloudWatch's three-hour recently-active discovery filter. To reduce cost, narrow `rules[].targets`, `rules[].profiles`, `rules[].metrics`, `rules[].regions`, or configure resource tag filters.
 
             **Watching collector-issued work**
 
@@ -286,7 +289,7 @@ modules:
             enabled: true
           list:
             - name: update_every
-              description: Data collection interval (seconds). Must be at least 60 (CloudWatch's minimum period).
+              description: Shared Netdata collection interval (seconds), minimum 60. Every per-series policy is evaluated on these ticks; a shorter period does not create an independent timer and intermediate eligible windows may be skipped.
               default_value: 60
               required: false
               group: Collection
@@ -410,8 +413,28 @@ modules:
               default_value: ""
               required: false
               group: Rules
+            - name: rules[].metrics[].query
+              description: Optional field-by-field timing override applied only to series expanded from this group's explicit `include[]` items. Unlisted default-selected series keep rule/profile timing.
+              default_value: ""
+              required: false
+              group: Rules / Query Policy
+            - name: rules[].metrics[].query.period
+              description: CloudWatch aggregation period for explicitly included series, from `1m` through `24h` as an exact multiple of `1m`. Eligibility is still evaluated only on shared `update_every` ticks.
+              default_value: ""
+              required: false
+              group: Rules / Query Policy
+            - name: rules[].metrics[].query.lookback
+              description: Rolling window for explicitly included series. It must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap.
+              default_value: ""
+              required: false
+              group: Rules / Query Policy
+            - name: rules[].metrics[].query.publication_delay
+              description: Collector wait after a bucket closes for explicitly included series. This is a scheduling policy, not an AWS publication guarantee; explicit `0s` is allowed.
+              default_value: ""
+              required: false
+              group: Rules / Query Policy
             - name: rules[].metrics[].include
-              description: Non-empty list of exact, case-sensitive AWS CloudWatch MetricNames added by this group. Duplicate names are rejected.
+              description: Non-empty list of exact, case-sensitive AWS CloudWatch MetricNames added by this group. A MetricName may repeat only when the items expand to disjoint statistic sets.
               default_value: ""
               required: true
               group: Rules
@@ -425,6 +448,26 @@ modules:
               default_value: ""
               required: false
               group: Rules
+            - name: rules[].metrics[].include[].query
+              description: Optional field-by-field timing override for this item's expanded metric/statistic series. It overrides the enclosing metric-group query; omitted fields inherit independently.
+              default_value: ""
+              required: false
+              group: Rules / Query Policy
+            - name: rules[].metrics[].include[].query.period
+              description: CloudWatch aggregation period for this item's expanded series, from `1m` through `24h` as an exact multiple of `1m`. It remains the aggregation and rate divisor when shorter than `update_every`.
+              default_value: ""
+              required: false
+              group: Rules / Query Policy
+            - name: rules[].metrics[].include[].query.lookback
+              description: Rolling window for this item's expanded series. It must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap.
+              default_value: ""
+              required: false
+              group: Rules / Query Policy
+            - name: rules[].metrics[].include[].query.publication_delay
+              description: Collector wait after a bucket closes for this item's expanded series. This is a scheduling policy, not an AWS publication guarantee; explicit `0s` is allowed.
+              default_value: ""
+              required: false
+              group: Rules / Query Policy
             - name: rules[].regions
               description: Canonical lowercase AWS region codes selected by this rule. The compiler intersects them with intrinsic profile restrictions; CloudFront and the Billing profiles support only `us-east-1`.
               default_value: ""
@@ -436,12 +479,12 @@ modules:
               required: false
               group: Rules / Query Policy
             - name: rule_defaults.query.period
-              description: Default CloudWatch aggregation period from `1m` through `24h`, as an exact multiple of `1m`. An omitted rule period inherits this value before nested metric and profile query defaults.
+              description: Default CloudWatch aggregation period from `1m` through `24h`, as an exact multiple of `1m`. It overrides profile timing and is inherited unless a rule, metric group, or metric item replaces it.
               default_value: ""
               required: false
               group: Rules / Query Policy
             - name: rule_defaults.query.lookback
-              description: Default rolling window searched for the newest eligible datapoint. It must be at least the effective period, an exact period multiple, and no more than 1,440 buckets (a bucket is one period).
+              description: Default rolling window searched for the newest eligible datapoint. It must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap.
               default_value: ""
               required: false
               group: Rules / Query Policy
@@ -451,17 +494,17 @@ modules:
               required: false
               group: Rules / Query Policy
             - name: rules[].query
-              description: Optional query timing overrides for this rule. Each omitted field independently inherits `rule_defaults.query`, then the relevant profile or built-in fallback.
+              description: Optional query timing overrides for this rule. Each omitted field independently inherits `rule_defaults.query`, then the relevant profile or built-in fallback; explicit metric-group and item values take precedence.
               default_value: ""
               required: false
               group: Rules / Query Policy
             - name: rules[].query.period
-              description: CloudWatch aggregation period for every series selected by this rule, from `1m` through `24h` as an exact multiple of `1m`. Rate metrics are normalized using this effective period.
+              description: CloudWatch aggregation period for series selected by this rule, from `1m` through `24h` as an exact multiple of `1m`; metric-group and item values can replace it. Rate metrics are normalized using the final effective period.
               default_value: ""
               required: false
               group: Rules / Query Policy
             - name: rules[].query.lookback
-              description: Rolling window searched for the newest complete finite datapoint. It must be at least the effective period, an exact period multiple, and no more than 1,440 buckets (a bucket is one period). Successful queries may present the retained datapoint as current for up to this duration; longer lookbacks increase response work.
+              description: Rolling window searched for the newest complete finite datapoint. It must be at least the effective period, an exact period multiple, and no more than the collector's 1,440-bucket safety cap. Successful queries may present the retained datapoint as current for up to this duration; longer lookbacks increase response work.
               default_value: ""
               required: false
               group: Rules / Query Policy
@@ -609,7 +652,7 @@ modules:
                               - name: CPUCreditBalance
                         regions: [us-east-1]
             - name: Different timing for metrics in one profile
-              description: Use disjoint exact metric selections when one service needs different query timing. Earlier rules own only the metric/statistic series they select, so these two Lambda rules do not shadow each other.
+              description: Use one profile metric group with disjoint statistic items when one AWS MetricName needs different timing. The group query is the default for its explicit items; the p90 item overrides it. Repeated MetricNames whose expanded statistic sets overlap are rejected.
               config: |
                 jobs:
                   - name: lambda_split_policy
@@ -620,7 +663,7 @@ modules:
                       - name: base
                         credentials: sdk_default
                     rules:
-                      - name: lambda-activity
+                      - name: lambda-duration
                         targets: [base]
                         profiles:
                           defaults: false
@@ -628,32 +671,22 @@ modules:
                         metrics:
                           - profile: lambda
                             defaults: false
-                            statistics: [Sum]
-                            include:
-                              - name: Invocations
-                        regions: [us-east-1]
-                        query:
-                          period: 5m
-                          lookback: 30m
-                          publication_delay: 10m
-                      - name: lambda-latency
-                        targets: [base]
-                        profiles:
-                          defaults: false
-                          include: [lambda]
-                        metrics:
-                          - profile: lambda
-                            defaults: false
-                            statistics: [Average, p90]
+                            query:
+                              period: 5m
+                              lookback: 30m
+                              publication_delay: 10m
                             include:
                               - name: Duration
+                                statistics: [Average]
+                              - name: Duration
+                                statistics: [p90]
+                                query:
+                                  period: 1m
+                                  lookback: 5m
+                                  publication_delay: 5m
                         regions: [us-east-1]
-                        query:
-                          period: 1m
-                          lookback: 5m
-                          publication_delay: 5m
             - name: Lower resolution to reduce cost
-              description: Collect the default profiles at five-minute resolution and refresh discovery less often. `rule_defaults.query` applies field-by-field to every rule that does not override it, replacing profile timing defaults -- the daily S3 storage profile is excluded here so the job-wide five-minute policy does not query it before AWS publishes. `update_every` controls how often charts update and the failure-retry cadence, not the normal query cost.
+              description: Collect the default profiles at five-minute resolution and refresh discovery less often. `rule_defaults.query` applies field-by-field to every rule that does not override it, replacing profile timing defaults -- the daily S3 storage profile is excluded here so the job-wide five-minute policy does not query it before AWS publishes. Matching `update_every` to the period lets every newly eligible window be observed without extra cached-only collection ticks.
               config: |
                 jobs:
                   - name: low_resolution
@@ -677,7 +710,7 @@ modules:
                     discovery:
                       refresh_every: 900
             - name: AWS Billing estimated charges
-              description: Collect each available exact Billing grain independently. Billing metrics must be enabled first, are published only in `us-east-1`, and do not support resource-tag filters or resource-tag-derived labels. The stock profiles use a 10-minute period and 24-hour retrieval window; a `rules[].query` block would override only the fields it sets.
+              description: Collect each available exact Billing grain independently. Billing metrics must be enabled first, are published only in `us-east-1`, and do not support resource-tag filters or resource-tag-derived labels. The stock profiles use a 10-minute period and 24-hour retrieval window; job query blocks override only the fields they set according to selection precedence.
               config: |
                 jobs:
                   - name: billing_estimated_charges
@@ -719,7 +752,7 @@ modules:
                           - key: environment
                             values: [production]
                     rules:
-                      - name: endpoint-averages
+                      - name: endpoint-split-timing
                         targets: [base]
                         profiles:
                           defaults: false
@@ -727,32 +760,24 @@ modules:
                         metrics:
                           - profile: privatelink_endpoint
                             defaults: false
-                            statistics: [Average]
+                            query:
+                              period: 1m
+                              lookback: 5m
+                              publication_delay: 5m
                             include:
                               - name: ActiveConnections
+                                statistics: [Average]
                               - name: BytesProcessed
+                                statistics: [Average]
                               - name: NewConnections
-                        regions: [us-east-1]
-                        query:
-                          period: 1m
-                          lookback: 5m
-                          publication_delay: 5m
-                      - name: endpoint-six-hour-bytes
-                        targets: [base]
-                        profiles:
-                          defaults: false
-                          include: [privatelink_endpoint]
-                        metrics:
-                          - profile: privatelink_endpoint
-                            defaults: false
-                            include:
+                                statistics: [Average]
                               - name: BytesProcessed
                                 statistics: [Sum]
+                                query:
+                                  period: 6h
+                                  lookback: 6h
+                                  publication_delay: 5m
                         regions: [us-east-1]
-                        query:
-                          period: 6h
-                          lookback: 6h
-                          publication_delay: 5m
                       - name: endpoint-subnets
                         targets: [base]
                         profiles:
@@ -779,7 +804,7 @@ modules:
                           - key: environment
                             values: [production]
                     rules:
-                      - name: service-traffic-averages
+                      - name: service-split-timing
                         targets: [base]
                         profiles:
                           defaults: false
@@ -787,49 +812,32 @@ modules:
                         metrics:
                           - profile: privatelink_service
                             defaults: false
-                            statistics: [Average]
+                            query:
+                              period: 1m
+                              lookback: 5m
+                              publication_delay: 5m
                             include:
                               - name: ActiveConnections
+                                statistics: [Average]
                               - name: BytesProcessed
+                                statistics: [Average]
                               - name: NewConnections
+                                statistics: [Average]
                               - name: RstPacketsSent
-                        regions: [us-east-1]
-                        query:
-                          period: 1m
-                          lookback: 5m
-                          publication_delay: 5m
-                      - name: service-endpoint-count
-                        targets: [base]
-                        profiles:
-                          defaults: false
-                          include: [privatelink_service]
-                        metrics:
-                          - profile: privatelink_service
-                            defaults: false
-                            include:
+                                statistics: [Average]
                               - name: EndpointsCount
                                 statistics: [Average]
-                        regions: [us-east-1]
-                        query:
-                          period: 5m
-                          lookback: 5m
-                          publication_delay: 5m
-                      - name: service-six-hour-bytes
-                        targets: [base]
-                        profiles:
-                          defaults: false
-                          include: [privatelink_service]
-                        metrics:
-                          - profile: privatelink_service
-                            defaults: false
-                            include:
+                                query:
+                                  period: 5m
+                                  lookback: 5m
+                                  publication_delay: 5m
                               - name: BytesProcessed
                                 statistics: [Sum]
+                                query:
+                                  period: 6h
+                                  lookback: 6h
+                                  publication_delay: 5m
                         regions: [us-east-1]
-                        query:
-                          period: 6h
-                          lookback: 6h
-                          publication_delay: 5m
                     labels:
                       resource_tags:
                         - key: Name
@@ -947,10 +955,10 @@ modules:
             description: |
               CloudWatch publishes metrics with a delay.
 
-              - Keep `rules[].query.period` at or above the metric's real publication cadence. A shorter override increases billed query frequency but cannot make AWS publish more often, so it can create empty windows.
-              - Set `rules[].query.publication_delay` when a workload publishes completed buckets later than its profile or the built-in `10m` fallback.
+              - Keep the effective query `period` at or above the metric's real publication cadence. A shorter override can increase billed query frequency but cannot make AWS publish more often, so it can create empty windows. When it is also shorter than `update_every`, request execution remains limited to shared collection ticks and intermediate windows may be skipped.
+              - Set a rule, metric-group, or metric-item `publication_delay` when a workload publishes completed buckets later than its profile or the built-in `10m` fallback.
               - Check `rule_defaults.query.publication_delay` before overriding an individual rule. A job-wide value replaces profile-specific delays for inheriting rules, including the stock S3 storage profile's conservative `1d`, and a shorter value can query daily data before it is published.
-              - Set `rules[].query.lookback` to search a wider rolling window for sparse datapoints. It must be an exact multiple of the effective period.
+              - Set `lookback` at the narrowest applicable query level to search a wider rolling window for sparse datapoints. It must be at least one effective period and an exact period multiple; one period is valid.
               - **Stale-looking values** -- a successful query presents its newest eligible datapoint on every Netdata collection cycle, so an old CloudWatch value can appear current for up to `lookback`. During transient AWS failures, replay can continue longer until a successful query replaces or expires it.
               - Longer lookbacks increase response work and may disable `recently_active_only` for the shared discovery scan.
               - Transient query failures preserve the retained value and retry after one `update_every`; later delays double within the same eligible window up to the effective period. A newly eligible window resets the backoff.
@@ -1208,7 +1216,7 @@ modules:
 
         **PrivateLink service grains.** The default `privatelink_service` profile identifies the provider service by `service_id` and is the only grain that exports `EndpointsCount`. The opt-in profiles split by `availability_zone`, `load_balancer_arn`, both, or consumer `vpc_endpoint_id`. All five share one `AWS/PrivateLinkServices` discovery scan and join tags through the parent endpoint service (`ec2:vpc-endpoint-service`). The collector deliberately does not attach endpoint or load-balancer tags to detailed children -- a `vpc_endpoint_id` can identify a consumer endpoint outside the service-owning account. `EndpointsCount` is read on its documented five-minute cadence and records zero when no datapoint is published; traffic gauges show gaps when absent.
 
-        **PrivateLink cost.** At stock timing (five-minute period, lookback, and publication delay), an endpoint, subnet, or default service instance has five structural CloudWatch metrics: (86,400 / 300) × 5 = 1,440 billable metric requests per day before retries. Each opt-in detailed service instance has four, or 1,152 per day. A one-minute override runs its selected metrics five times as often; narrow profiles, metrics, regions, grains, and resource tags when that freshness is not required.
+        **PrivateLink cost.** At stock timing (five-minute period, lookback, and publication delay) and `update_every <= 300`, an endpoint, subnet, or default service instance has five structural CloudWatch metrics: (86,400 / 300) × 5 = 1,440 billable metric requests per day before retries. Each opt-in detailed service instance has four, or 1,152 per day. With `update_every <= 60`, a one-minute override runs its selected metrics five times as often; a slower collection interval limits execution and skips intermediate windows. Narrow profiles, metrics, regions, grains, and resource tags when that freshness is not required.
 
         **Cardinality warning.** These opt-in profiles include potentially high-cardinality data. **S3 Request Metrics** additionally require per-bucket request-metrics configuration in AWS and are billed at CloudWatch custom-metric rates; they collect nothing until enabled on the bucket. PrivateLink cardinality grows with endpoint subnets, service Availability Zones, load balancers, and consumer endpoints; the combined Availability Zone/load-balancer grain multiplies those dimensions. The Billing service/account grains grow with the payer's services and linked accounts.
       availability: []

--- a/src/go/plugin/go.d/collector/cloudwatch/plan.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan.go
@@ -5,12 +5,12 @@ package cloudwatch
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/cwprofiles"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/cwquery"
 )
 
 const (
@@ -122,20 +122,53 @@ func compileProfileSeries(profile cwprofiles.ResolvedProfile) []profileSeriesSpe
 	return series
 }
 
-func resolveRuleMetrics(path string, selectors []ProfileMetricSelectorConfig, profiles []cwprofiles.ResolvedProfile, seriesByProfile map[string][]profileSeriesSpec) (map[string][]profileSeriesSpec, map[string]struct{}, error) {
-	selected := make(map[string][]profileSeriesSpec, len(profiles))
+type profileSeriesCatalog struct {
+	series            []profileSeriesSpec
+	metricByName      map[string]int
+	seriesByMetric    [][]profileSeriesSpec
+	seriesByStatistic []map[string]profileSeriesSpec
+}
+
+type resolvedSeriesSelection struct {
+	series   selectedSeriesSpec
+	selected bool
+}
+
+func indexProfileSeries(profile cwprofiles.ResolvedProfile) profileSeriesCatalog {
+	series := compileProfileSeries(profile)
+	catalog := profileSeriesCatalog{
+		series:            series,
+		metricByName:      make(map[string]int, len(profile.Config.Metrics)),
+		seriesByMetric:    make([][]profileSeriesSpec, len(profile.Config.Metrics)),
+		seriesByStatistic: make([]map[string]profileSeriesSpec, len(profile.Config.Metrics)),
+	}
+	for i, metric := range profile.Config.Metrics {
+		catalog.metricByName[metric.MetricName] = i
+		catalog.seriesByStatistic[i] = make(map[string]profileSeriesSpec, len(metric.Statistics))
+	}
+	for _, item := range series {
+		catalog.seriesByMetric[item.MetricIndex] = append(catalog.seriesByMetric[item.MetricIndex], item)
+		catalog.seriesByStatistic[item.MetricIndex][item.Statistic] = item
+	}
+	return catalog
+}
+
+func resolveRuleMetrics(path string, selectors []ProfileMetricSelectorConfig, profiles []cwprofiles.ResolvedProfile, seriesByProfile map[string]profileSeriesCatalog) (map[string][]selectedSeriesSpec, map[string]struct{}, error) {
+	selected := make(map[string][]selectedSeriesSpec, len(profiles))
 	explicitProfiles := make(map[string]struct{})
 	profilesByName := make(map[string]cwprofiles.ResolvedProfile, len(profiles))
-	selectedOrdinals := make(map[string]map[int]struct{}, len(profiles))
+	seriesSelections := make(map[string][]resolvedSeriesSelection, len(profiles))
 	for _, profile := range profiles {
 		profilesByName[profile.Name] = profile
-		ordinals := make(map[int]struct{})
-		for _, series := range seriesByProfile[profile.Name] {
-			if !profile.Config.Metrics[series.MetricIndex].Disabled {
-				ordinals[series.Ordinal] = struct{}{}
+		catalog := seriesByProfile[profile.Name]
+		selections := make([]resolvedSeriesSelection, len(catalog.series))
+		for i, series := range catalog.series {
+			selections[i] = resolvedSeriesSelection{
+				series:   selectedSeriesSpec{profileSeriesSpec: series},
+				selected: !profile.Config.Metrics[series.MetricIndex].Disabled,
 			}
 		}
-		selectedOrdinals[profile.Name] = ordinals
+		seriesSelections[profile.Name] = selections
 	}
 
 	explicitSelections := 0
@@ -146,12 +179,13 @@ func resolveRuleMetrics(path string, selectors []ProfileMetricSelectorConfig, pr
 			return nil, nil, fmt.Errorf("%s.profile references profile %q not selected by this rule", groupPath, selector.Profile)
 		}
 		explicitProfiles[profile.Name] = struct{}{}
-		ordinals := selectedOrdinals[profile.Name]
+		selections := seriesSelections[profile.Name]
 		if !selector.includesDefaults() {
-			ordinals = make(map[int]struct{})
-			selectedOrdinals[profile.Name] = ordinals
+			for i := range selections {
+				selections[i] = resolvedSeriesSelection{series: selectedSeriesSpec{profileSeriesSpec: selections[i].series.profileSeriesSpec}}
+			}
 		}
-		count, err := resolveMetricGroup(groupPath, selector, profile, seriesByProfile[profile.Name], ordinals)
+		count, err := resolveMetricGroup(groupPath, selector, profile, seriesByProfile[profile.Name], selections)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -162,24 +196,22 @@ func resolveRuleMetrics(path string, selectors []ProfileMetricSelectorConfig, pr
 	}
 
 	for _, profile := range profiles {
-		ordinals := selectedOrdinals[profile.Name]
-		for _, series := range seriesByProfile[profile.Name] {
-			if _, ok := ordinals[series.Ordinal]; ok {
-				selected[profile.Name] = append(selected[profile.Name], series)
+		for _, selection := range seriesSelections[profile.Name] {
+			if selection.selected {
+				selected[profile.Name] = append(selected[profile.Name], selection.series)
 			}
 		}
 	}
 	return selected, explicitProfiles, nil
 }
 
-func resolveMetricGroup(path string, selector ProfileMetricSelectorConfig, profile cwprofiles.ResolvedProfile, available []profileSeriesSpec, selected map[int]struct{}) (int, error) {
+func resolveMetricGroup(path string, selector ProfileMetricSelectorConfig, profile cwprofiles.ResolvedProfile, catalog profileSeriesCatalog, selected []resolvedSeriesSelection) (int, error) {
 	expanded := 0
+	explicitOwners := make([]string, len(catalog.series))
 	for i, entry := range selector.Include {
 		metricPath := fmt.Sprintf("%s.include[%d]", path, i)
-		metricIndex := slices.IndexFunc(profile.Config.Metrics, func(metric cwprofiles.Metric) bool {
-			return metric.MetricName == entry.Name
-		})
-		if metricIndex < 0 {
+		metricIndex, ok := catalog.metricByName[entry.Name]
+		if !ok {
 			return 0, fmt.Errorf("%s.name references unknown MetricName %q in profile %q", metricPath, entry.Name, profile.Name)
 		}
 		statistics := entry.Statistics
@@ -188,35 +220,37 @@ func resolveMetricGroup(path string, selector ProfileMetricSelectorConfig, profi
 			statistics = selector.Statistics
 			statisticsPath = path + ".statistics"
 		}
+		var expandedSeries []profileSeriesSpec
 		if statistics == nil {
-			for _, series := range available {
-				if series.MetricIndex == metricIndex {
-					selected[series.Ordinal] = struct{}{}
-					expanded++
+			expandedSeries = catalog.seriesByMetric[metricIndex]
+		} else {
+			expandedSeries = make([]profileSeriesSpec, 0, len(statistics))
+			for j, raw := range statistics {
+				statistic := normalizeMetricStatistic(raw)
+				series, ok := catalog.seriesByStatistic[metricIndex][statistic]
+				if !ok {
+					return 0, fmt.Errorf("%s[%d] %q is not exported for MetricName %q in profile %q", statisticsPath, j, raw, entry.Name, profile.Name)
 				}
+				expandedSeries = append(expandedSeries, series)
 			}
-			continue
 		}
-		for j, raw := range statistics {
-			statistic := normalizeMetricStatistic(raw)
-			series, ok := findProfileSeries(available, metricIndex, statistic)
-			if !ok {
-				return 0, fmt.Errorf("%s[%d] %q is not exported for MetricName %q in profile %q", statisticsPath, j, raw, entry.Name, profile.Name)
+		for _, series := range expandedSeries {
+			if owner := explicitOwners[series.Ordinal]; owner != "" {
+				return 0, fmt.Errorf("%s selects MetricName %q statistic %q already selected by %s", metricPath, entry.Name, cwprofiles.StatString(series.Statistic), owner)
 			}
-			selected[series.Ordinal] = struct{}{}
+			explicitOwners[series.Ordinal] = metricPath
+			selected[series.Ordinal] = resolvedSeriesSelection{
+				selected: true,
+				series: selectedSeriesSpec{
+					profileSeriesSpec: series,
+					groupQuery:        cwquery.Source{Config: selector.Query, Path: path + ".query"},
+					itemQuery:         cwquery.Source{Config: entry.Query, Path: metricPath + ".query"},
+				},
+			}
 			expanded++
 		}
 	}
 	return expanded, nil
-}
-
-func findProfileSeries(series []profileSeriesSpec, metricIndex int, statistic string) (profileSeriesSpec, bool) {
-	for _, candidate := range series {
-		if candidate.MetricIndex == metricIndex && candidate.Statistic == statistic {
-			return candidate, true
-		}
-	}
-	return profileSeriesSpec{}, false
 }
 
 func normalizeMetricStatistic(raw string) string {

--- a/src/go/plugin/go.d/collector/cloudwatch/plan.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan.go
@@ -3,6 +3,7 @@
 package cloudwatch
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -125,8 +126,8 @@ func compileProfileSeries(profile cwprofiles.ResolvedProfile) []profileSeriesSpe
 type profileSeriesCatalog struct {
 	series            []profileSeriesSpec
 	metricByName      map[string]int
-	seriesByMetric    [][]profileSeriesSpec
-	seriesByStatistic []map[string]profileSeriesSpec
+	seriesByMetric    [][]int
+	seriesByStatistic []map[string]int
 }
 
 type resolvedSeriesSelection struct {
@@ -139,16 +140,16 @@ func indexProfileSeries(profile cwprofiles.ResolvedProfile) profileSeriesCatalog
 	catalog := profileSeriesCatalog{
 		series:            series,
 		metricByName:      make(map[string]int, len(profile.Config.Metrics)),
-		seriesByMetric:    make([][]profileSeriesSpec, len(profile.Config.Metrics)),
-		seriesByStatistic: make([]map[string]profileSeriesSpec, len(profile.Config.Metrics)),
+		seriesByMetric:    make([][]int, len(profile.Config.Metrics)),
+		seriesByStatistic: make([]map[string]int, len(profile.Config.Metrics)),
 	}
 	for i, metric := range profile.Config.Metrics {
 		catalog.metricByName[metric.MetricName] = i
-		catalog.seriesByStatistic[i] = make(map[string]profileSeriesSpec, len(metric.Statistics))
+		catalog.seriesByStatistic[i] = make(map[string]int, len(metric.Statistics))
 	}
-	for _, item := range series {
-		catalog.seriesByMetric[item.MetricIndex] = append(catalog.seriesByMetric[item.MetricIndex], item)
-		catalog.seriesByStatistic[item.MetricIndex][item.Statistic] = item
+	for ordinal, item := range series {
+		catalog.seriesByMetric[item.MetricIndex] = append(catalog.seriesByMetric[item.MetricIndex], ordinal)
+		catalog.seriesByStatistic[item.MetricIndex][item.Statistic] = ordinal
 	}
 	return catalog
 }
@@ -208,6 +209,7 @@ func resolveRuleMetrics(path string, selectors []ProfileMetricSelectorConfig, pr
 func resolveMetricGroup(path string, selector ProfileMetricSelectorConfig, profile cwprofiles.ResolvedProfile, catalog profileSeriesCatalog, selected []resolvedSeriesSelection) (int, error) {
 	expanded := 0
 	explicitOwners := make([]string, len(catalog.series))
+	var overlapErrs []error
 	for i, entry := range selector.Include {
 		metricPath := fmt.Sprintf("%s.include[%d]", path, i)
 		metricIndex, ok := catalog.metricByName[entry.Name]
@@ -220,26 +222,28 @@ func resolveMetricGroup(path string, selector ProfileMetricSelectorConfig, profi
 			statistics = selector.Statistics
 			statisticsPath = path + ".statistics"
 		}
-		var expandedSeries []profileSeriesSpec
+		var expandedOrdinals []int
 		if statistics == nil {
-			expandedSeries = catalog.seriesByMetric[metricIndex]
+			expandedOrdinals = catalog.seriesByMetric[metricIndex]
 		} else {
-			expandedSeries = make([]profileSeriesSpec, 0, len(statistics))
+			expandedOrdinals = make([]int, 0, len(statistics))
 			for j, raw := range statistics {
 				statistic := normalizeMetricStatistic(raw)
-				series, ok := catalog.seriesByStatistic[metricIndex][statistic]
+				ordinal, ok := catalog.seriesByStatistic[metricIndex][statistic]
 				if !ok {
 					return 0, fmt.Errorf("%s[%d] %q is not exported for MetricName %q in profile %q", statisticsPath, j, raw, entry.Name, profile.Name)
 				}
-				expandedSeries = append(expandedSeries, series)
+				expandedOrdinals = append(expandedOrdinals, ordinal)
 			}
 		}
-		for _, series := range expandedSeries {
-			if owner := explicitOwners[series.Ordinal]; owner != "" {
-				return 0, fmt.Errorf("%s selects MetricName %q statistic %q already selected by %s", metricPath, entry.Name, cwprofiles.StatString(series.Statistic), owner)
+		for _, ordinal := range expandedOrdinals {
+			series := catalog.series[ordinal]
+			if owner := explicitOwners[ordinal]; owner != "" {
+				overlapErrs = append(overlapErrs, fmt.Errorf("%s selects MetricName %q statistic %q already selected by %s", metricPath, entry.Name, cwprofiles.StatString(series.Statistic), owner))
+				continue
 			}
-			explicitOwners[series.Ordinal] = metricPath
-			selected[series.Ordinal] = resolvedSeriesSelection{
+			explicitOwners[ordinal] = metricPath
+			selected[ordinal] = resolvedSeriesSelection{
 				selected: true,
 				series: selectedSeriesSpec{
 					profileSeriesSpec: series,
@@ -250,7 +254,7 @@ func resolveMetricGroup(path string, selector ProfileMetricSelectorConfig, profi
 			expanded++
 		}
 	}
-	return expanded, nil
+	return expanded, errors.Join(overlapErrs...)
 }
 
 func normalizeMetricStatistic(raw string) string {

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_compiler.go
@@ -22,7 +22,7 @@ type planCompiler struct {
 	targetRoleARN     map[string]string
 	profiles          []cwprofiles.ResolvedProfile
 	profilesByName    map[string]cwprofiles.ResolvedProfile
-	seriesByProfile   map[string][]profileSeriesSpec
+	seriesByProfile   map[string]profileSeriesCatalog
 	tagJoinErrors     map[string]error
 
 	usedCredentials  map[string]struct{}
@@ -58,10 +58,10 @@ type shadowSample struct {
 func newPlanCompiler(cfg Config, catalog cwprofiles.Catalog) *planCompiler {
 	profiles := catalog.AllProfiles()
 	profilesByName := make(map[string]cwprofiles.ResolvedProfile, len(profiles))
-	seriesByProfile := make(map[string][]profileSeriesSpec, len(profiles))
+	seriesByProfile := make(map[string]profileSeriesCatalog, len(profiles))
 	for _, profile := range profiles {
 		profilesByName[profile.Name] = profile
-		seriesByProfile[profile.Name] = compileProfileSeries(profile)
+		seriesByProfile[profile.Name] = indexProfileSeries(profile)
 	}
 	credentialsByName := make(map[string]awsauth.CredentialConfig, len(cfg.Credentials))
 	for _, source := range cfg.Credentials {
@@ -283,7 +283,7 @@ func (pc *planCompiler) addScope(path, ruleName string, target *collectionTarget
 	return nil
 }
 
-func resolveSeriesPolicies(path string, rule, defaults *cwquery.Config, profile cwprofiles.ResolvedProfile, series []profileSeriesSpec) ([]compiledSeries, error) {
+func resolveSeriesPolicies(path string, rule, defaults *cwquery.Config, profile cwprofiles.ResolvedProfile, series []selectedSeriesSpec) ([]compiledSeries, error) {
 	out := make([]compiledSeries, len(series))
 	for i, item := range series {
 		metric := profile.Config.Metrics[item.MetricIndex]
@@ -299,6 +299,8 @@ func resolveSeriesPolicies(path string, rule, defaults *cwquery.Config, profile 
 			},
 			RuleDefaults: cwquery.Source{Config: defaults, Path: "rule_defaults.query"},
 			Rule:         cwquery.Source{Config: rule, Path: path + ".query"},
+			Group:        item.groupQuery,
+			Item:         item.itemQuery,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("%s profile %q MetricName %q statistic %q: %w", path, profile.Name, metric.MetricName, item.Statistic, err)

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/awsauth"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/cwprofiles"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/cloudwatch/internal/cwquery"
@@ -73,9 +74,9 @@ func TestResolveRuleMetrics_DefaultAndExplicitSelection(t *testing.T) {
 			}},
 		},
 	}
-	seriesByProfile := make(map[string][]profileSeriesSpec, len(profiles))
+	seriesByProfile := make(map[string]profileSeriesCatalog, len(profiles))
 	for _, profile := range profiles {
-		seriesByProfile[profile.Name] = compileProfileSeries(profile)
+		seriesByProfile[profile.Name] = indexProfileSeries(profile)
 	}
 
 	tests := map[string]struct {
@@ -314,6 +315,330 @@ func TestCompileConfig_MetricSelectionExpandsMultipleStatistics(t *testing.T) {
 		"lambda.duration_maximum",
 		"lambda.duration_p90",
 	}, compiledSeriesNames(plan.Scopes[0].SelectedSeries))
+}
+
+func TestCompileConfig_PerSelectionQueryPolicy(t *testing.T) {
+	defaults := false
+	cfg := validBaseConfig()
+	cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"lambda"}}
+	cfg.Rules[0].Query = &cwquery.Config{
+		Period: longDuration(5 * time.Minute), Lookback: longDuration(10 * time.Minute), PublicationDelay: longDuration(15 * time.Minute),
+	}
+	cfg.Rules[0].Metrics = []ProfileMetricSelectorConfig{{
+		Profile: "lambda", Defaults: &defaults,
+		Query: &cwquery.Config{Period: longDuration(10 * time.Minute), PublicationDelay: longDuration(0)},
+		Include: []MetricSelectionConfig{
+			{Name: "Duration", Statistics: []string{"Average"}, Query: &cwquery.Config{Lookback: longDuration(20 * time.Minute)}},
+			{Name: "Duration", Statistics: []string{"Maximum"}, Query: &cwquery.Config{Period: longDuration(15 * time.Minute), Lookback: longDuration(45 * time.Minute)}},
+		},
+	}}
+
+	plan, _, err := compileTestConfig(t, cfg)
+	require.NoError(t, err)
+	require.Len(t, plan.Scopes, 1)
+	got := make(map[string]cwquery.Policy)
+	for _, series := range plan.Scopes[0].SelectedSeries {
+		got[series.Name] = series.Policy
+	}
+	assert.Equal(t, map[string]cwquery.Policy{
+		"lambda.duration_average": {Period: 10 * time.Minute, Lookback: 20 * time.Minute, PublicationDelay: 0},
+		"lambda.duration_maximum": {Period: 15 * time.Minute, Lookback: 45 * time.Minute, PublicationDelay: 0},
+	}, got)
+}
+
+func TestCompileConfig_GroupQueryAppliesOnlyToExplicitIncludes(t *testing.T) {
+	defaults := false
+	cfg := validBaseConfig()
+	cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"ec2"}}
+	cfg.Rules[0].Query = &cwquery.Config{Period: longDuration(5 * time.Minute)}
+	cfg.Rules[0].Metrics = []ProfileMetricSelectorConfig{{
+		Profile: "ec2", Query: &cwquery.Config{Period: longDuration(15 * time.Minute)},
+		Include: []MetricSelectionConfig{{Name: "NetworkIn", Statistics: []string{"Sum"}}},
+	}}
+
+	plan, _, err := compileTestConfig(t, cfg)
+	require.NoError(t, err)
+	require.Len(t, plan.Scopes, 1)
+	got := make(map[string]time.Duration)
+	for _, series := range plan.Scopes[0].SelectedSeries {
+		got[series.Name] = series.Policy.Period
+	}
+	assert.Equal(t, 5*time.Minute, got["ec2.cpu_utilization_average"], "unlisted default-selected series keeps rule policy")
+	assert.Equal(t, 15*time.Minute, got["ec2.network_in_sum"], "explicit include receives group policy")
+}
+
+func TestCompileConfig_AllowsPeriodShorterThanUpdateEvery(t *testing.T) {
+	defaults := false
+	cfg := validBaseConfig()
+	cfg.UpdateEvery = 300
+	cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"ec2"}}
+	cfg.Rules[0].Metrics = []ProfileMetricSelectorConfig{{
+		Profile: "ec2", Defaults: &defaults,
+		Include: []MetricSelectionConfig{{
+			Name: "CPUUtilization", Query: &cwquery.Config{Period: longDuration(time.Minute), Lookback: longDuration(time.Minute)},
+		}},
+	}}
+
+	plan, _, err := compileTestConfig(t, cfg)
+	require.NoError(t, err)
+	require.Len(t, plan.Scopes, 1)
+	require.Len(t, plan.Scopes[0].SelectedSeries, 1)
+	assert.Equal(t, time.Minute, plan.Scopes[0].SelectedSeries[0].Policy.Period)
+}
+
+func TestCompileConfig_RepeatedMetricNameRequiresDisjointStatistics(t *testing.T) {
+	defaults := false
+	tests := map[string]struct {
+		statistics []string
+		include    []MetricSelectionConfig
+		wantErr    bool
+	}{
+		"disjoint explicit statistics": {
+			include: []MetricSelectionConfig{
+				{Name: "Duration", Statistics: []string{"Average"}},
+				{Name: "Duration", Statistics: []string{"Maximum"}},
+			},
+		},
+		"overlapping explicit statistics": {
+			include: []MetricSelectionConfig{
+				{Name: "Duration", Statistics: []string{"Average"}},
+				{Name: "Duration", Statistics: []string{"Average", "Maximum"}},
+			},
+			wantErr: true,
+		},
+		"overlap inherited from group statistics": {
+			statistics: []string{"Average"},
+			include:    []MetricSelectionConfig{{Name: "Duration"}, {Name: "Duration"}},
+			wantErr:    true,
+		},
+		"all profile statistics overlap explicit statistic": {
+			include: []MetricSelectionConfig{
+				{Name: "Duration"},
+				{Name: "Duration", Statistics: []string{"Maximum"}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := validBaseConfig()
+			cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"lambda"}}
+			cfg.Rules[0].Metrics = []ProfileMetricSelectorConfig{{
+				Profile: "lambda", Defaults: &defaults, Statistics: tc.statistics, Include: tc.include,
+			}}
+
+			plan, _, err := compileTestConfig(t, cfg)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				require.Len(t, plan.Scopes, 1)
+				assert.Equal(t, []string{"lambda.duration_average", "lambda.duration_maximum"}, compiledSeriesNames(plan.Scopes[0].SelectedSeries))
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "rules[0].metrics[0].include[0]")
+			assert.ErrorContains(t, err, "rules[0].metrics[0].include[1]")
+		})
+	}
+}
+
+func TestCompileConfig_OneRuleSelectionPolicyMatchesDisjointRules(t *testing.T) {
+	defaults := false
+	profile := &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"lambda"}}
+	average := &cwquery.Config{
+		Period: longDuration(5 * time.Minute), Lookback: longDuration(10 * time.Minute), PublicationDelay: longDuration(0),
+	}
+	maximum := &cwquery.Config{
+		Period: longDuration(15 * time.Minute), Lookback: longDuration(45 * time.Minute), PublicationDelay: longDuration(5 * time.Minute),
+	}
+	metric := func(statistic string) []ProfileMetricSelectorConfig {
+		return []ProfileMetricSelectorConfig{{
+			Profile: "lambda", Defaults: &defaults,
+			Include: []MetricSelectionConfig{{Name: "Duration", Statistics: []string{statistic}}},
+		}}
+	}
+
+	oldConfig := validBaseConfig()
+	oldConfig.Rules = []RuleConfig{
+		{Name: "average", Targets: []string{"base"}, Profiles: profile, Metrics: metric("Average"), Regions: []string{"us-east-1"}, Query: average},
+		{Name: "maximum", Targets: []string{"base"}, Profiles: profile, Metrics: metric("Maximum"), Regions: []string{"us-east-1"}, Query: maximum},
+	}
+	newConfig := validBaseConfig()
+	newConfig.Rules = []RuleConfig{{
+		Name: "duration", Targets: []string{"base"}, Profiles: profile, Regions: []string{"us-east-1"},
+		Metrics: []ProfileMetricSelectorConfig{{
+			Profile: "lambda", Defaults: &defaults, Query: average,
+			Include: []MetricSelectionConfig{
+				{Name: "Duration", Statistics: []string{"Average"}},
+				{Name: "Duration", Statistics: []string{"Maximum"}, Query: maximum},
+			},
+		}},
+	}}
+
+	oldPlan, _, err := compileTestConfig(t, oldConfig)
+	require.NoError(t, err)
+	newPlan, _, err := compileTestConfig(t, newConfig)
+	require.NoError(t, err)
+	oldQueries := buildPlanQueriesForOneInstance(t, oldPlan, "lambda")
+	newQueries := buildPlanQueriesForOneInstance(t, newPlan, "lambda")
+	require.Len(t, oldQueries, 2)
+	require.Len(t, newQueries, 2)
+
+	type queryContract struct {
+		key, billingKey structuralID
+		policy          cwquery.Policy
+		statistic       string
+		period          int32
+	}
+	contract := func(queries []plannedQuery) map[string]queryContract {
+		out := make(map[string]queryContract, len(queries))
+		for _, query := range queries {
+			out[query.seriesName] = queryContract{
+				key: query.key, billingKey: query.billingKey, policy: query.policy,
+				statistic: aws.ToString(query.query.MetricStat.Stat), period: aws.ToInt32(query.query.MetricStat.Period),
+			}
+		}
+		return out
+	}
+	assert.Equal(t, contract(oldQueries), contract(newQueries), "rule shape must not change AWS work or stable identity")
+	assert.Equal(t, calculatedMetricRequestUnits(oldQueries), calculatedMetricRequestUnits(newQueries))
+	assert.Equal(t, 2, calculatedMetricRequestUnits(newQueries), "different policies split one structural metric into two billed groups")
+
+	samePolicyConfig := newConfig
+	samePolicyConfig.Rules = append([]RuleConfig(nil), newConfig.Rules...)
+	samePolicyConfig.Rules[0].Metrics = append([]ProfileMetricSelectorConfig(nil), newConfig.Rules[0].Metrics...)
+	samePolicyConfig.Rules[0].Metrics[0].Include = append([]MetricSelectionConfig(nil), newConfig.Rules[0].Metrics[0].Include...)
+	samePolicyConfig.Rules[0].Metrics[0].Include[1].Query = nil
+	samePlan, _, err := compileTestConfig(t, samePolicyConfig)
+	require.NoError(t, err)
+	sameQueries := buildPlanQueriesForOneInstance(t, samePlan, "lambda")
+	assert.Equal(t, 1, calculatedMetricRequestUnits(sameQueries), "two statistics sharing one policy use one calculated request unit")
+}
+
+func buildPlanQueriesForOneInstance(t *testing.T, plan *collectionPlan, profileName string) []plannedQuery {
+	t.Helper()
+	c := New()
+	c.plan = plan
+	c.resolvedByRef = map[string]resolvedTarget{
+		"base": {target: plan.Targets[0], accountID: "000000000000"},
+	}
+	for _, scope := range plan.Scopes {
+		if scope.Profile.Name != profileName {
+			continue
+		}
+		values := make([]string, len(scope.Profile.Config.Instance.Dimensions))
+		for i, dimension := range scope.Profile.Config.Instance.Dimensions {
+			values[i] = "instance"
+			if dimension.Constant != nil {
+				values[i] = *dimension.Constant
+			}
+		}
+		c.discovery = discoverySnapshot{Instances: map[discoveryKey][]collectionInstance{
+			{Target: "base", Profile: profileName, Region: scope.Region}: {{DimensionValues: values}},
+		}}
+		queries, err := c.buildQueryPlan()
+		require.NoError(t, err)
+		return queries
+	}
+	require.FailNow(t, "profile scope not found", profileName)
+	return nil
+}
+
+func calculatedMetricRequestUnits(queries []plannedQuery) int {
+	clients := map[clientKey]cloudwatchClient{{target: "base", region: "us-east-1"}: &gmdCloudWatch{}}
+	batches := buildQueryBatches(queries, clients, time.Unix(1_000_000_000, 0))
+	units := 0
+	for _, batch := range batches {
+		units += queryMetricRequestUnits(batch.queries)
+	}
+	return units
+}
+
+func TestPerSelectionQueryPolicy_BatchLimitRemainsEnforced(t *testing.T) {
+	const count = maxPlannedQueryBatches + 1
+	defaults := false
+	profile := cwprofiles.ResolvedProfile{Name: "synthetic", Config: cwprofiles.Profile{
+		Namespace: "AWS/Synthetic",
+		Query:     cwquery.Config{Period: longDuration(time.Minute)},
+		Instance: cwprofiles.InstanceSpec{Dimensions: []cwprofiles.InstanceDimension{
+			{Name: "Instance", Label: "instance"},
+		}},
+		Metrics: make([]cwprofiles.Metric, count),
+	}}
+	selector := ProfileMetricSelectorConfig{
+		Profile: "synthetic", Defaults: &defaults, Include: make([]MetricSelectionConfig, count),
+	}
+	for i := range count {
+		profile.Config.Metrics[i] = cwprofiles.Metric{
+			ID: fmt.Sprintf("metric_%d", i), MetricName: fmt.Sprintf("Metric%d", i), Statistics: []string{"average"},
+		}
+		selector.Include[i] = MetricSelectionConfig{
+			Name: fmt.Sprintf("Metric%d", i),
+			Query: &cwquery.Config{
+				PublicationDelay: longDuration(time.Duration(i) * time.Second),
+			},
+		}
+	}
+	selected, _, err := resolveRuleMetrics(
+		"rules[0]",
+		[]ProfileMetricSelectorConfig{selector},
+		[]cwprofiles.ResolvedProfile{profile},
+		map[string]profileSeriesCatalog{"synthetic": indexProfileSeries(profile)},
+	)
+	require.NoError(t, err)
+	series, err := resolveSeriesPolicies("rules[0]", nil, nil, profile, selected[profile.Name])
+	require.NoError(t, err)
+
+	identity := awsauth.NewIdentity("base", awsauth.CredentialConfig{Type: awsauth.CredentialTypeDefault}, nil)
+	target := &collectionTarget{Name: "base", Identity: identity, Regions: []string{"us-east-1"}}
+	c := New()
+	c.plan = &collectionPlan{
+		Targets:  []*collectionTarget{target},
+		Profiles: []cwprofiles.ResolvedProfile{profile},
+		Scopes: []collectionScope{{
+			Target: target, Profile: profile, Region: "us-east-1", SelectedSeries: series,
+		}},
+	}
+	c.resolvedByRef = map[string]resolvedTarget{"base": {target: target, accountID: "000000000000"}}
+	c.discovery = discoverySnapshot{Instances: map[discoveryKey][]collectionInstance{
+		{Target: "base", Profile: "synthetic", Region: "us-east-1"}: {{DimensionValues: []string{"instance"}}},
+	}}
+
+	_, err = c.buildQueryPlan()
+	assert.ErrorContains(t, err, "more than 40 GetMetricData batches")
+}
+
+func BenchmarkResolveRuleMetricsPerSelectionPolicy(b *testing.B) {
+	const metricCount = maxReferencesPerRule / 2
+	defaults := false
+	profile := cwprofiles.ResolvedProfile{Name: "synthetic", Config: cwprofiles.Profile{
+		Metrics: make([]cwprofiles.Metric, metricCount),
+	}}
+	selector := ProfileMetricSelectorConfig{
+		Profile: "synthetic", Defaults: &defaults, Include: make([]MetricSelectionConfig, metricCount),
+	}
+	for i := range metricCount {
+		name := fmt.Sprintf("Metric%d", i)
+		profile.Config.Metrics[i] = cwprofiles.Metric{
+			ID: fmt.Sprintf("metric_%d", i), MetricName: name, Statistics: []string{"average", "maximum"},
+		}
+		selector.Include[i] = MetricSelectionConfig{
+			Name: name, Query: &cwquery.Config{PublicationDelay: longDuration(time.Duration(i) * time.Second)},
+		}
+	}
+	profiles := []cwprofiles.ResolvedProfile{profile}
+	catalogs := map[string]profileSeriesCatalog{"synthetic": indexProfileSeries(profile)}
+
+	b.ReportAllocs()
+	for range b.N {
+		selected, _, err := resolveRuleMetrics("rules[0]", []ProfileMetricSelectorConfig{selector}, profiles, catalogs)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(selected["synthetic"]) != maxReferencesPerRule {
+			b.Fatalf("selected %d series", len(selected["synthetic"]))
+		}
+	}
 }
 
 func TestCompileConfig_MetricSelectionRejectsUnknownOrUnselectedEntries(t *testing.T) {

--- a/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/plan_test.go
@@ -346,6 +346,57 @@ func TestCompileConfig_PerSelectionQueryPolicy(t *testing.T) {
 	}, got)
 }
 
+func TestCompileConfig_PerSelectionQueryPolicyExpandsToEverySelectedStatistic(t *testing.T) {
+	defaults := false
+	tests := map[string]struct {
+		groupStatistics []string
+		wantSeries      []string
+	}{
+		"profile statistics": {
+			wantSeries: []string{
+				"lambda.duration_average",
+				"lambda.duration_maximum",
+				"lambda.duration_p90",
+			},
+		},
+		"inherited group statistics": {
+			groupStatistics: []string{"Average", "Maximum"},
+			wantSeries: []string{
+				"lambda.duration_average",
+				"lambda.duration_maximum",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := validBaseConfig()
+			cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"lambda"}}
+			cfg.Rules[0].Query = &cwquery.Config{PublicationDelay: longDuration(15 * time.Minute)}
+			cfg.Rules[0].Metrics = []ProfileMetricSelectorConfig{{
+				Profile: "lambda", Defaults: &defaults, Statistics: tc.groupStatistics,
+				Query: &cwquery.Config{Period: longDuration(10 * time.Minute)},
+				Include: []MetricSelectionConfig{{
+					Name: "Duration", Query: &cwquery.Config{Lookback: longDuration(20 * time.Minute), PublicationDelay: longDuration(0)},
+				}},
+			}}
+
+			plan, _, err := compileTestConfig(t, cfg)
+			require.NoError(t, err)
+			require.Len(t, plan.Scopes, 1)
+			got := make(map[string]cwquery.Policy)
+			for _, series := range plan.Scopes[0].SelectedSeries {
+				got[series.Name] = series.Policy
+			}
+			want := make(map[string]cwquery.Policy, len(tc.wantSeries))
+			for _, series := range tc.wantSeries {
+				want[series] = cwquery.Policy{Period: 10 * time.Minute, Lookback: 20 * time.Minute, PublicationDelay: 0}
+			}
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
 func TestCompileConfig_GroupQueryAppliesOnlyToExplicitIncludes(t *testing.T) {
 	defaults := false
 	cfg := validBaseConfig()
@@ -440,6 +491,25 @@ func TestCompileConfig_RepeatedMetricNameRequiresDisjointStatistics(t *testing.T
 			assert.ErrorContains(t, err, "rules[0].metrics[0].include[1]")
 		})
 	}
+}
+
+func TestCompileConfig_RepeatedMetricNameReportsAllOverlaps(t *testing.T) {
+	defaults := false
+	cfg := validBaseConfig()
+	cfg.Rules[0].Profiles = &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"lambda"}}
+	cfg.Rules[0].Metrics = []ProfileMetricSelectorConfig{{
+		Profile: "lambda", Defaults: &defaults,
+		Include: []MetricSelectionConfig{
+			{Name: "Duration", Statistics: []string{"Average", "Maximum"}},
+			{Name: "Duration", Statistics: []string{"Average"}},
+			{Name: "Duration", Statistics: []string{"Maximum"}},
+		},
+	}}
+
+	_, _, err := compileTestConfig(t, cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `rules[0].metrics[0].include[1] selects MetricName "Duration" statistic "Average" already selected by rules[0].metrics[0].include[0]`)
+	assert.ErrorContains(t, err, `rules[0].metrics[0].include[2] selects MetricName "Duration" statistic "Maximum" already selected by rules[0].metrics[0].include[0]`)
 }
 
 func TestCompileConfig_OneRuleSelectionPolicyMatchesDisjointRules(t *testing.T) {
@@ -637,6 +707,26 @@ func BenchmarkResolveRuleMetricsPerSelectionPolicy(b *testing.B) {
 		}
 		if len(selected["synthetic"]) != maxReferencesPerRule {
 			b.Fatalf("selected %d series", len(selected["synthetic"]))
+		}
+	}
+}
+
+func BenchmarkIndexProfileSeries(b *testing.B) {
+	const metricCount = maxReferencesPerRule / 2
+	profile := cwprofiles.ResolvedProfile{Name: "synthetic", Config: cwprofiles.Profile{
+		Metrics: make([]cwprofiles.Metric, metricCount),
+	}}
+	for i := range metricCount {
+		profile.Config.Metrics[i] = cwprofiles.Metric{
+			ID: fmt.Sprintf("metric_%d", i), MetricName: fmt.Sprintf("Metric%d", i), Statistics: []string{"average", "maximum"},
+		}
+	}
+
+	b.ReportAllocs()
+	for range b.N {
+		catalog := indexProfileSeries(profile)
+		if len(catalog.series) != maxReferencesPerRule {
+			b.Fatalf("indexed %d series", len(catalog.series))
 		}
 	}
 }

--- a/src/go/plugin/go.d/collector/cloudwatch/privatelink_endpoint_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/privatelink_endpoint_test.go
@@ -206,37 +206,33 @@ func TestPrivateLinkEndpointProfiles_ShareDiscoveryAndMatchExactGrains(t *testin
 	}, instances["privatelink_endpoint_subnet"])
 }
 
-func TestPrivateLinkEndpointProfiles_ExactRulePoliciesRemainDisjoint(t *testing.T) {
+func TestPrivateLinkEndpointProfiles_PerSelectionPoliciesRemainDisjoint(t *testing.T) {
 	catalog, err := cwprofiles.LoadFromDefaultDirs()
 	require.NoError(t, err)
 	defaults := false
 	cfg := validBaseConfig()
-	cfg.Rules = []RuleConfig{
-		{
-			Name: "one-minute-averages", Targets: []string{"base"}, Regions: []string{"us-east-1"},
-			Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"privatelink_endpoint"}},
-			Metrics: []ProfileMetricSelectorConfig{{
-				Profile: "privatelink_endpoint", Defaults: &defaults, Statistics: []string{"Average"},
-				Include: []MetricSelectionConfig{{Name: "ActiveConnections"}, {Name: "BytesProcessed"}, {Name: "NewConnections"}},
-			}},
+	cfg.Rules = []RuleConfig{{
+		Name: "endpoint-split-timing", Targets: []string{"base"}, Regions: []string{"us-east-1"},
+		Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"privatelink_endpoint"}},
+		Metrics: []ProfileMetricSelectorConfig{{
+			Profile: "privatelink_endpoint", Defaults: &defaults,
 			Query: &cwquery.Config{Period: longDuration(time.Minute), Lookback: longDuration(5 * time.Minute), PublicationDelay: longDuration(5 * time.Minute)},
-		},
-		{
-			Name: "six-hour-bytes", Targets: []string{"base"}, Regions: []string{"us-east-1"},
-			Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"privatelink_endpoint"}},
-			Metrics: []ProfileMetricSelectorConfig{{
-				Profile: "privatelink_endpoint", Defaults: &defaults,
-				Include: []MetricSelectionConfig{{Name: "BytesProcessed", Statistics: []string{"Sum"}}},
-			}},
-			Query: &cwquery.Config{Period: longDuration(6 * time.Hour), Lookback: longDuration(6 * time.Hour), PublicationDelay: longDuration(5 * time.Minute)},
-		},
-	}
+			Include: []MetricSelectionConfig{
+				{Name: "ActiveConnections", Statistics: []string{"Average"}},
+				{Name: "BytesProcessed", Statistics: []string{"Average"}},
+				{Name: "NewConnections", Statistics: []string{"Average"}},
+				{Name: "BytesProcessed", Statistics: []string{"Sum"}, Query: &cwquery.Config{
+					Period: longDuration(6 * time.Hour), Lookback: longDuration(6 * time.Hour), PublicationDelay: longDuration(5 * time.Minute),
+				}},
+			},
+		}},
+	}}
 	cfg.applyDefaults()
 
 	plan, diagnostics, err := compileConfig(cfg, catalog)
 	require.NoError(t, err)
 	require.Empty(t, diagnostics)
-	require.Len(t, plan.Scopes, 2)
+	require.Len(t, plan.Scopes, 1)
 	policies := make(map[string]cwquery.Policy)
 	for _, scope := range plan.Scopes {
 		for _, series := range scope.SelectedSeries {

--- a/src/go/plugin/go.d/collector/cloudwatch/privatelink_service_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/privatelink_service_test.go
@@ -242,46 +242,37 @@ func TestPrivateLinkServiceProfiles_ShareDiscoveryAndMatchExactGrains(t *testing
 	assert.Equal(t, []collectionInstance{{DimensionValues: []string{"vpce-svc-1", "vpce-1"}}}, instances["privatelink_service_vpc_endpoint"])
 }
 
-func TestPrivateLinkServiceProfiles_ExactRulePoliciesRemainDisjoint(t *testing.T) {
+func TestPrivateLinkServiceProfiles_PerSelectionPoliciesRemainDisjoint(t *testing.T) {
 	catalog, err := cwprofiles.LoadFromDefaultDirs()
 	require.NoError(t, err)
 	defaults := false
 	cfg := validBaseConfig()
-	cfg.Rules = []RuleConfig{
-		{
-			Name: "one-minute-traffic", Targets: []string{"base"}, Regions: []string{"us-east-1"},
-			Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"privatelink_service"}},
-			Metrics: []ProfileMetricSelectorConfig{{
-				Profile: "privatelink_service", Defaults: &defaults, Statistics: []string{"Average"},
-				Include: []MetricSelectionConfig{{Name: "ActiveConnections"}, {Name: "BytesProcessed"}, {Name: "NewConnections"}, {Name: "RstPacketsSent"}},
-			}},
+	cfg.Rules = []RuleConfig{{
+		Name: "service-split-timing", Targets: []string{"base"}, Regions: []string{"us-east-1"},
+		Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"privatelink_service"}},
+		Metrics: []ProfileMetricSelectorConfig{{
+			Profile: "privatelink_service", Defaults: &defaults,
 			Query: &cwquery.Config{Period: longDuration(time.Minute), Lookback: longDuration(5 * time.Minute), PublicationDelay: longDuration(5 * time.Minute)},
-		},
-		{
-			Name: "five-minute-endpoints", Targets: []string{"base"}, Regions: []string{"us-east-1"},
-			Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"privatelink_service"}},
-			Metrics: []ProfileMetricSelectorConfig{{
-				Profile: "privatelink_service", Defaults: &defaults,
-				Include: []MetricSelectionConfig{{Name: "EndpointsCount", Statistics: []string{"Average"}}},
-			}},
-			Query: &cwquery.Config{Period: longDuration(5 * time.Minute), Lookback: longDuration(5 * time.Minute), PublicationDelay: longDuration(5 * time.Minute)},
-		},
-		{
-			Name: "six-hour-bytes", Targets: []string{"base"}, Regions: []string{"us-east-1"},
-			Profiles: &ProfileSelectorConfig{Defaults: &defaults, Include: []string{"privatelink_service"}},
-			Metrics: []ProfileMetricSelectorConfig{{
-				Profile: "privatelink_service", Defaults: &defaults,
-				Include: []MetricSelectionConfig{{Name: "BytesProcessed", Statistics: []string{"Sum"}}},
-			}},
-			Query: &cwquery.Config{Period: longDuration(6 * time.Hour), Lookback: longDuration(6 * time.Hour), PublicationDelay: longDuration(5 * time.Minute)},
-		},
-	}
+			Include: []MetricSelectionConfig{
+				{Name: "ActiveConnections", Statistics: []string{"Average"}},
+				{Name: "BytesProcessed", Statistics: []string{"Average"}},
+				{Name: "NewConnections", Statistics: []string{"Average"}},
+				{Name: "RstPacketsSent", Statistics: []string{"Average"}},
+				{Name: "EndpointsCount", Statistics: []string{"Average"}, Query: &cwquery.Config{
+					Period: longDuration(5 * time.Minute), Lookback: longDuration(5 * time.Minute), PublicationDelay: longDuration(5 * time.Minute),
+				}},
+				{Name: "BytesProcessed", Statistics: []string{"Sum"}, Query: &cwquery.Config{
+					Period: longDuration(6 * time.Hour), Lookback: longDuration(6 * time.Hour), PublicationDelay: longDuration(5 * time.Minute),
+				}},
+			},
+		}},
+	}}
 	cfg.applyDefaults()
 
 	plan, diagnostics, err := compileConfig(cfg, catalog)
 	require.NoError(t, err)
 	require.Empty(t, diagnostics)
-	require.Len(t, plan.Scopes, 3)
+	require.Len(t, plan.Scopes, 1)
 	policies := make(map[string]cwquery.Policy)
 	for _, scope := range plan.Scopes {
 		for _, series := range scope.SelectedSeries {

--- a/src/go/plugin/go.d/collector/cloudwatch/profile-format.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/profile-format.md
@@ -189,7 +189,7 @@ An explicitly empty list is invalid; omit the field for unrestricted profiles.
 | Field               |       Required       | Description                                                                                                                                                                           |
 |:--------------------|:--------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `period`            | yes at profile level | CloudWatch aggregation period. It must be from `1m` through `24h` and an exact multiple of `1m`.                                                                                      |
-| `lookback`          |          no          | Rolling retrieval horizon. It must be positive, at least one period, an exact multiple of the effective period, and no more than 1,440 buckets. Omission follows the resolved period. |
+| `lookback`          |          no          | Rolling retrieval horizon. It must be positive, at least one period, an exact multiple of the effective period, and no more than the collector's 1,440-bucket safety cap. Omission follows the resolved period. |
 | `publication_delay` |          no          | Delay before querying a closed bucket -- collector scheduling policy, not an AWS publication SLA. Default `10m`; `0` is valid.                                                        |
 
 Durations accept duration strings or numeric seconds and must resolve to whole seconds. Stock profiles use canonical
@@ -198,13 +198,21 @@ strings such as `1m`, `10m`, and `24h`; custom profiles should do the same for r
 Every metric may define an optional `query` object with the same fields. Job configuration resolves each field
 independently in this order, from highest to lowest precedence:
 
-1. `rules[].query` (job configuration)
-2. `rule_defaults.query` (job configuration)
-3. `metrics[].query` (profile)
-4. profile `query`
+1. `rules[].metrics[].include[].query` (job metric/statistic item)
+2. `rules[].metrics[].query` (job profile-metric group, for explicit `include[]` expansions only)
+3. `rules[].query` (job rule)
+4. `rule_defaults.query` (job defaults)
+5. `metrics[].query` (profile metric)
+6. profile `query`
 
 After inheritance, the collector validates the complete policy. The combined `publication_delay + lookback + period`
 horizon must not exceed 14 days.
+
+The query window is `end = align_down(now - publication_delay, period)` and `start = end - lookback`; CloudWatch
+`EndTime` is exclusive. One-period lookback is valid. Longer lookback improves tolerance for sparse or late data but
+increases response work; it is not needed to repair alignment. Policies are evaluated only on the job's shared
+`update_every` ticks. A `period` shorter than `update_every` still controls CloudWatch aggregation and rate
+normalization, but intermediate eligible windows may be skipped.
 
 ## Instance dimensions
 
@@ -284,6 +292,14 @@ metrics:
 Set `defaults: false` when the profile must use only the listed MetricNames. If both the group and metric omit
 `statistics`, the collector uses every statistic declared for that metric in the profile.
 
+A metric group and each included metric may also define `query` with `period`, `lookback`, and/or
+`publication_delay`. The group query applies only to series expanded from `include[]`, even when `defaults: true`;
+unlisted default-selected series keep rule/profile timing. The item query overrides the group field by field.
+
+Repeat one MetricName only to assign policies to disjoint statistic sets. Statistic expansion is item statistics,
+then group statistics, then all profile-declared statistics. For example, separate `Average` and `Sum` items are
+valid; two items that both expand to `Average` are rejected with their configuration paths.
+
 ## Chart template rules
 
 The `template` uses Netdata's dynamic chart-template format. See the complete
@@ -307,4 +323,3 @@ are ignored (see "How profiles work").
 
 The collector divides rate totals by the effective query period before emission and marks all emitted CloudWatch metric
 families as floating-point values.
-

--- a/src/go/plugin/go.d/collector/cloudwatch/query_policy_test.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/query_policy_test.go
@@ -47,6 +47,26 @@ func TestQueryWindow(t *testing.T) {
 	}
 }
 
+func TestDueQueries_PeriodShorterThanCollectionCadenceUsesNewestWindow(t *testing.T) {
+	base := time.Unix(1_000_000_020, 0).UTC()
+	query := plannedQuery{
+		key:    testStructuralID("short-period"),
+		policy: cwquery.Policy{Period: time.Minute, Lookback: time.Minute},
+	}
+	_, completedEnd := queryWindow(base, query.policy)
+	store := observationStore{queries: map[structuralID]queryState{
+		query.key: {lastCompletedEnd: completedEnd},
+	}}
+
+	nextTick := base.Add(5 * time.Minute)
+	due := store.dueQueries([]plannedQuery{query}, nextTick)
+	require.Len(t, due, 1)
+	start, end := queryWindow(nextTick, due[0].policy)
+	assert.Equal(t, nextTick.Truncate(time.Minute), end)
+	assert.Equal(t, end.Add(-time.Minute), start)
+	assert.Equal(t, 5*time.Minute, end.Sub(completedEnd), "intermediate eligible windows are not backfilled")
+}
+
 func TestResolveSeriesPolicies_ProfileMetricAndRulePeriod(t *testing.T) {
 	profile := cwprofiles.ResolvedProfile{Name: "service", Config: cwprofiles.Profile{
 		Query: profileQuery(5 * time.Minute),
@@ -55,7 +75,7 @@ func TestResolveSeriesPolicies_ProfileMetricAndRulePeriod(t *testing.T) {
 			{ID: "normal", MetricName: "Normal", Statistics: []string{"average"}},
 		},
 	}}
-	base := compileProfileSeries(profile)
+	base := testSelectedProfileSeries(profile)
 	require.Len(t, base, 2)
 
 	resolved, err := resolveSeriesPolicies("rules[0]", nil, nil, profile, base)

--- a/src/go/plugin/go.d/collector/cloudwatch/runtime.go
+++ b/src/go/plugin/go.d/collector/cloudwatch/runtime.go
@@ -58,6 +58,14 @@ type profileSeriesSpec struct {
 	Name        string
 }
 
+// selectedSeriesSpec carries the job-selection query sources attached to one
+// profile-defined series. They are resolved once while compiling the plan.
+type selectedSeriesSpec struct {
+	profileSeriesSpec
+	groupQuery cwquery.Source
+	itemQuery  cwquery.Source
+}
+
 type compiledSeries struct {
 	Ordinal     int
 	MetricIndex int

--- a/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
+++ b/src/go/plugin/go.d/collector/cloudwatch/testdata/config.json
@@ -63,9 +63,15 @@
           "statistics": [
             "Average"
           ],
+          "query": {
+            "period": "10m"
+          },
           "include": [
             {
-              "name": "CPUUtilization"
+              "name": "CPUUtilization",
+              "query": {
+                "publication_delay": "0s"
+              }
             }
           ]
         },

--- a/src/go/plugin/go.d/collector/cloudwatch/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/cloudwatch/testdata/config.yaml
@@ -32,8 +32,12 @@ rules:
       - profile: ec2
         defaults: false
         statistics: [Average]
+        query:
+          period: 10m
         include:
           - name: CPUUtilization
+            query:
+              publication_delay: 0s
       - profile: rds
         defaults: false
         statistics: [Average]

--- a/src/go/plugin/go.d/config/go.d/cloudwatch.conf
+++ b/src/go/plugin/go.d/config/go.d/cloudwatch.conf
@@ -43,17 +43,22 @@
 ## filters.resource_tags. A non-empty rule list replaces the default; [] disables
 ## it. Tag keys and values are exact and case-sensitive. All keys are ANDed; values
 ## for one key are ORed.
-## Query timing resolves field-by-field from job rules[].query, job
-## rule_defaults.query, profile-catalog metrics[].query, profile-catalog query
-## defaults, and the built-in 10m publication delay. Profiles use one nested
-## query object; profile query.period is required.
+## Query timing resolves field-by-field from the most specific job metric item,
+## its enclosing job metric group, rules[].query, rule_defaults.query,
+## profile-catalog metrics[].query, profile-catalog query defaults, and the
+## built-in 10m publication delay. A metric-group query applies only to series
+## expanded from its include list; unlisted defaults keep the rule/profile policy.
+## Profiles use one nested query object; profile query.period is required.
 ## period is 1m..1d in whole-minute steps; lookback must be at least period and
 ## an exact period multiple. Do not set period below the metric's real publication
-## cadence: it adds billed queries and can produce empty windows. A successful
-## sparse query can replay its newest eligible value for up to lookback; transient
-## AWS failures can replay it longer. Transient retries start after one
-## update_every, then double within the same eligible window up to period; a new
-## window resets the backoff. Retry calls are billable.
+## cadence: it can add billed queries and produce empty windows. All policies are
+## evaluated on the shared update_every ticks; period remains the CloudWatch
+## aggregation/rate divisor, but period < update_every skips intermediate eligible
+## windows instead of creating an independent timer. A successful sparse query can
+## replay its newest eligible value for up to lookback; transient AWS failures can
+## replay it longer. Transient retries start after one update_every, then double
+## within the same eligible window up to period; a new window resets the backoff.
+## Retry calls are billable.
 ## Query-plan preflight rejects more than 20000 selected series, 600000 all-due
 ## datapoints, or 40 packed GetMetricData requests before allocating AWS query
 ## structures. Up to five statistics for one metric stay in one billing request.
@@ -141,10 +146,21 @@
 #              - name: CPUUtilization
 #          - profile: lambda
 #            defaults: false
-#            statistics: [Sum]
+#            query:
+#              period: 5m
+#              lookback: 15m
+#              publication_delay: 10m
 #            include:
 #              - name: Invocations
+#                statistics: [Sum]
 #              - name: Errors
+#                statistics: [Sum]
+#              - name: Duration
+#                statistics: [p90]
+#                query:
+#                  period: 1m
+#                  lookback: 5m
+#                  publication_delay: 5m
 #        regions: [us-east-1]
 #
 #  - name: resource_tag_filtering_and_labels


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-selection CloudWatch query policies to `go.d/cloudwatch`, letting you set `period`, `lookback`, and `publication_delay` on metric groups and individual metrics. Scheduling is now explicit: eligibility is evaluated on `update_every` ticks; if `period < update_every`, the newest aligned window is used and intermediate windows may be skipped.

- **New Features**
  - New config fields: `rules[].metrics[].query`, `rules[].metrics[].include[].query`.
  - Precedence (per field): item > group > rule > rule_defaults > profile metric > profile defaults.
  - Group query applies only to its `include[]` metrics; unlisted defaults keep lower-precedence timing.
  - Planner/runtime resolve policies per selected series; selections in the same rule stay disjoint. Tests cover selection precedence and short-period scheduling.
  - Schema, validation, examples, docs, and comments updated; `update_every` semantics documented.

<sup>Written for commit 474c0b94ea462d9c6912cd2235e4002e7e6cb112. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

