### PR TITLE
feat(go.d): support chart series aggregation

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -122,6 +122,17 @@ source files for evidence.
   option for V2 charts.
 - Put multipliers, divisors, hidden flags, and float formatting in the chart
   template, not ad hoc chart-emission code.
+- When `instances.by_labels` omits labels so multiple source series can map to
+  one rendered dimension, the effective `aggregation` MUST match the metric
+  meaning. Set it on the chart; it applies to every dimension. Absence means
+  `sum`; available reducers are `sum`, `min`, `max`, and unweighted `avg`
+  (`avg` forces floating-point emission). Use separate charts when metrics need
+  different reducers. Metric kind is not enough to infer this policy: gauges
+  may be additive stocks, states, timestamps, limits, or averages.
+- Histogram buckets/counts/sums are mergeable only with `sum`. Summary
+  quantiles are not globally mergeable with these reducers. Non-sum reduction
+  of cumulative counters happens before Netdata calculates rates and can be
+  misleading when source membership changes.
 - `metrix` keeps ONE descriptor per metric NAME, resolved atomically at commit and
   BOUNDED: a name idle past its retention window (`expireAfterSuccessCycles +
   descriptorGraceCycles`, both configurable on `NewCollectorStore(...)`) is evicted

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -147,10 +147,15 @@ The following rules apply when routing conflicts arise:
 |-----------------------------------------------|------------------------------------------------------------------------------------------------|
 | Template vs autogen chart ID collision        | Template wins; autogen chart is replaced                                                       |
 | Cross-template chart ID collision             | Existing owner keeps ownership; subsequent series are **silently ignored** (see warning below) |
-| Duplicate dimension observations within build | First observed dimension metadata wins; values are reduced (summed)                            |
+| Duplicate dimension observations within build | First observed dimension metadata wins; values use the chart's configured reducer            |
 
 > [!WARNING]
 > Cross-template chart ID collisions cause silent data loss — conflicting series are dropped with no error and no log entry. If metrics are missing, check for duplicate rendered chart IDs across template groups.
+
+Authored charts can set one reducer for all their dimensions. Supported values are `sum` (default), `min`, `max`, and
+`avg`. Reduction is scoped to one successful plan build and happens before multiplier/divisor and
+`absolute`/`incremental` chart processing. Autogen routes retain their existing sum behavior. See the chart-template
+format's [aggregation section](../charttpl/README.md#aggregation) for semantics and metric-type constraints.
 
 ## Lifecycle Defaults and Policy
 

--- a/src/go/plugin/framework/chartengine/compiler.go
+++ b/src/go/plugin/framework/chartengine/compiler.go
@@ -99,7 +99,7 @@ func (c *compiler) compileChart(chart charttpl.Chart, scope compileScope, templa
 
 	metricKinds := make(map[string]bool)
 	for i := range chart.Dimensions {
-		compiledDim, err := compileDimension(chart.Dimensions[i], scope.metrics)
+		compiledDim, err := compileDimension(chart.Dimensions[i], chart.Aggregation, scope.metrics)
 		if err != nil {
 			return program.Chart{}, fmt.Errorf("dimension[%d]: %w", i, err)
 		}
@@ -180,9 +180,8 @@ func (c *compiler) compileChart(chart charttpl.Chart, scope compileScope, templa
 			},
 			Precedence: program.DefaultLabelPrecedence(),
 		},
-		Lifecycle:       compileLifecycle(chart.Lifecycle),
-		Dimensions:      dimensions,
-		CollisionReduce: program.ReduceSum,
+		Lifecycle:  compileLifecycle(chart.Lifecycle),
+		Dimensions: dimensions,
 	}
 
 	return out, nil
@@ -195,7 +194,11 @@ type compiledDimension struct {
 	metricKinds      []string
 }
 
-func compileDimension(dim charttpl.Dimension, visibleMetrics map[string]struct{}) (compiledDimension, error) {
+func compileDimension(
+	dim charttpl.Dimension,
+	chartAggregation charttpl.Aggregation,
+	visibleMetrics map[string]struct{},
+) (compiledDimension, error) {
 	compiledSel, err := metrixselector.ParseCompiled(dim.Selector)
 	if err != nil {
 		return compiledDimension{}, fmt.Errorf("selector: %w", err)
@@ -234,6 +237,10 @@ func compileDimension(dim charttpl.Dimension, visibleMetrics map[string]struct{}
 
 	metricKinds := metricKindsFromNames(meta.MetricNames)
 	options := compileDimensionOptions(dim.Options)
+	aggregation, err := compileAggregation(chartAggregation)
+	if err != nil {
+		return compiledDimension{}, err
+	}
 
 	return compiledDimension{
 		dimension: program.Dimension{
@@ -246,6 +253,7 @@ func compileDimension(dim charttpl.Dimension, visibleMetrics map[string]struct{}
 			NameTemplate:            nameTemplate,
 			NameFromLabel:           nameFromLabel,
 			InferNameFromSeriesMeta: inferFromSeriesMeta,
+			Aggregation:             aggregation,
 			Hidden:                  options.hidden,
 			Multiplier:              options.multiplier,
 			Divisor:                 options.divisor,
@@ -258,10 +266,25 @@ func compileDimension(dim charttpl.Dimension, visibleMetrics map[string]struct{}
 	}, nil
 }
 
+func compileAggregation(raw charttpl.Aggregation) (program.Aggregation, error) {
+	switch raw {
+	case "", charttpl.AggregationSum:
+		return program.AggregationSum, nil
+	case charttpl.AggregationMin:
+		return program.AggregationMin, nil
+	case charttpl.AggregationMax:
+		return program.AggregationMax, nil
+	case charttpl.AggregationAvg:
+		return program.AggregationAvg, nil
+	default:
+		return 0, fmt.Errorf("aggregation: unsupported value %q", raw)
+	}
+}
+
 type compiledDimensionOptions struct {
-	hidden     bool
 	multiplier int
 	divisor    int
+	hidden     bool
 	float      bool
 }
 

--- a/src/go/plugin/framework/chartengine/compiler_test.go
+++ b/src/go/plugin/framework/chartengine/compiler_test.go
@@ -53,9 +53,10 @@ func TestCompileScenarios(t *testing.T) {
 						Metrics: []string{"svc_requests_total"},
 						Charts: []charttpl.Chart{
 							{
-								Title:   "Requests",
-								Context: "requests",
-								Units:   "requests/s",
+								Title:       "Requests",
+								Context:     "requests",
+								Units:       "requests/s",
+								Aggregation: charttpl.AggregationMin,
 								Dimensions: []charttpl.Dimension{
 									{
 										Selector: "svc_requests_total",
@@ -67,6 +68,10 @@ func TestCompileScenarios(t *testing.T) {
 											Divisor:    1000,
 										},
 									},
+									{
+										Selector: "svc_requests_total",
+										Name:     "inherited",
+									},
 								},
 							},
 						},
@@ -77,11 +82,13 @@ func TestCompileScenarios(t *testing.T) {
 				t.Helper()
 				charts := p.Charts()
 				require.Len(t, charts, 1)
-				require.Len(t, charts[0].Dimensions, 1)
+				require.Len(t, charts[0].Dimensions, 2)
 				assert.True(t, charts[0].Dimensions[0].Hidden)
 				assert.True(t, charts[0].Dimensions[0].Float)
 				assert.Equal(t, -8, charts[0].Dimensions[0].Multiplier)
 				assert.Equal(t, 1000, charts[0].Dimensions[0].Divisor)
+				assert.Equal(t, program.AggregationMin, charts[0].Dimensions[0].Aggregation)
+				assert.Equal(t, program.AggregationMin, charts[0].Dimensions[1].Aggregation)
 			},
 		},
 		"applies default lifecycle when omitted": {
@@ -112,6 +119,7 @@ func TestCompileScenarios(t *testing.T) {
 				assert.Equal(t, 5, charts[0].Lifecycle.ExpireAfterCycles)
 				assert.Equal(t, 0, charts[0].Lifecycle.Dimensions.MaxDims)
 				assert.Equal(t, 0, charts[0].Lifecycle.Dimensions.ExpireAfterCycles)
+				assert.Equal(t, program.AggregationSum, charts[0].Dimensions[0].Aggregation)
 			},
 		},
 		"defaults chart priority when omitted": {

--- a/src/go/plugin/framework/chartengine/internal/program/chart.go
+++ b/src/go/plugin/framework/chartengine/internal/program/chart.go
@@ -27,14 +27,6 @@ const (
 	ChartTypeHeatmap ChartType = "heatmap"
 )
 
-// ReduceOp defines aggregation for series collisions mapped to one dimension.
-type ReduceOp string
-
-const (
-	// ReduceSum is the phase-1 collision reduction rule.
-	ReduceSum ReduceOp = "sum"
-)
-
 // Chart is one compiled chart template in immutable program IR.
 type Chart struct {
 	// TemplateID is compiler-assigned stable ID inside one Program revision.
@@ -47,9 +39,6 @@ type Chart struct {
 
 	// Dimensions are declaration-ordered templates.
 	Dimensions []Dimension
-
-	// CollisionReduce is currently fixed to ReduceSum in phase-1.
-	CollisionReduce ReduceOp
 }
 
 // ChartMeta carries user-facing chart metadata after normalization/defaulting.
@@ -106,9 +95,6 @@ func validateChart(chart Chart) error {
 	}
 	if err := validateLabelPolicy(chart.Labels); err != nil {
 		errs = append(errs, fmt.Errorf("labels: %w", err))
-	}
-	if chart.CollisionReduce == "" {
-		errs = append(errs, fmt.Errorf("collision reduce op is required"))
 	}
 	if len(chart.Dimensions) == 0 {
 		errs = append(errs, fmt.Errorf("at least one dimension is required"))

--- a/src/go/plugin/framework/chartengine/internal/program/dimension.go
+++ b/src/go/plugin/framework/chartengine/internal/program/dimension.go
@@ -22,6 +22,16 @@ type SelectorLabels interface {
 	Range(fn func(key, value string) bool)
 }
 
+// Aggregation defines how source observations mapped to one dimension combine.
+type Aggregation uint8
+
+const (
+	AggregationSum Aggregation = iota
+	AggregationMin
+	AggregationMax
+	AggregationAvg
+)
+
 // SelectorBinding stores selector expression + compiled runtime matcher metadata.
 type SelectorBinding struct {
 	// Expression is original selector text (for diagnostics/debugging).
@@ -45,6 +55,7 @@ type Dimension struct {
 	// InferNameFromSeriesMeta requests runtime inference based on series origin
 	// metadata (e.g. histogram/state-set flatten semantics).
 	InferNameFromSeriesMeta bool
+	Aggregation             Aggregation
 
 	// Hidden maps to DIMENSION hidden option.
 	Hidden bool
@@ -68,6 +79,11 @@ func validateDimension(dimension Dimension) error {
 	}
 	if dimension.NameTemplate.Raw == "" && dimension.NameFromLabel == "" && !dimension.InferNameFromSeriesMeta {
 		errs = append(errs, fmt.Errorf("dimension name is required (name template or name_from_label)"))
+	}
+	switch dimension.Aggregation {
+	case AggregationSum, AggregationMin, AggregationMax, AggregationAvg:
+	default:
+		errs = append(errs, fmt.Errorf("invalid aggregation %d", dimension.Aggregation))
 	}
 	return errors.Join(errs...)
 }

--- a/src/go/plugin/framework/chartengine/internal/program/program_test.go
+++ b/src/go/plugin/framework/chartengine/internal/program/program_test.go
@@ -83,8 +83,7 @@ func TestNewProgramScenarios(t *testing.T) {
 						Mode:       PromotionModeAutoIntersection,
 						Precedence: DefaultLabelPrecedence(),
 					},
-					Lifecycle:       LifecyclePolicy{},
-					CollisionReduce: ReduceSum,
+					Lifecycle: LifecyclePolicy{},
 					Dimensions: []Dimension{
 						{
 							Selector: SelectorBinding{
@@ -104,6 +103,18 @@ func TestNewProgramScenarios(t *testing.T) {
 				func() Chart {
 					chart := sampleChart("invalid-type")
 					chart.Meta.Type = ChartType("bars")
+					return chart
+				}(),
+			},
+			wantErr: true,
+		},
+		"rejects invalid dimension aggregation": {
+			version: "v1",
+			metrics: []string{"windows_rx_total"},
+			charts: []Chart{
+				func() Chart {
+					chart := sampleChart("invalid-aggregation")
+					chart.Dimensions[0].Aggregation = Aggregation(255)
 					return chart
 				}(),
 			},
@@ -195,7 +206,6 @@ func TestNewProgramReportsJoinedChartErrors(t *testing.T) {
 	chart.Identity.InstanceByLabels = []InstanceLabelSelector{
 		{Exclude: true, Key: "nic"},
 	}
-	chart.CollisionReduce = ""
 	chart.Dimensions = []Dimension{{}}
 
 	_, err := New("v1", 42, []string{"windows_rx_total"}, []Chart{chart})
@@ -203,7 +213,6 @@ func TestNewProgramReportsJoinedChartErrors(t *testing.T) {
 	assert.ErrorContains(t, err, "context is required")
 	assert.ErrorContains(t, err, "units is required")
 	assert.ErrorContains(t, err, "identity: instance selectors must include at least one positive selector")
-	assert.ErrorContains(t, err, "collision reduce op is required")
 	assert.ErrorContains(t, err, "dimension[0]: selector expression is required")
 	assert.ErrorContains(t, err, "selector matcher is required")
 	assert.ErrorContains(t, err, "dimension name is required")
@@ -243,7 +252,6 @@ func sampleChart(templateID string) Chart {
 				ExpireAfterCycles: 10,
 			},
 		},
-		CollisionReduce: ReduceSum,
 		Dimensions: []Dimension{
 			{
 				Selector: SelectorBinding{

--- a/src/go/plugin/framework/chartengine/lifecycle.go
+++ b/src/go/plugin/framework/chartengine/lifecycle.go
@@ -135,6 +135,7 @@ func (s *materializedState) ensureChart(
 }
 
 func (c *materializedChartState) ensureDimension(name string, state dimensionState) (*materializedDimensionState, bool) {
+	algorithm := state.algorithm.programAlgorithm()
 	dim, ok := c.dimensions[name]
 	if ok {
 		if dim.static != state.static || dim.order != state.order || dim.sortKey != state.sortKey {
@@ -145,7 +146,7 @@ func (c *materializedChartState) ensureDimension(name string, state dimensionSta
 		dim.static = state.static
 		dim.order = state.order
 		dim.sortKey = state.sortKey
-		dim.algorithm = state.algorithm
+		dim.algorithm = algorithm
 		dim.multiplier = state.multiplier
 		dim.divisor = state.divisor
 		return dim, false
@@ -156,7 +157,7 @@ func (c *materializedChartState) ensureDimension(name string, state dimensionSta
 		static:     state.static,
 		order:      state.order,
 		sortKey:    state.sortKey,
-		algorithm:  state.algorithm,
+		algorithm:  algorithm,
 		multiplier: state.multiplier,
 		divisor:    state.divisor,
 	}

--- a/src/go/plugin/framework/chartengine/matcher.go
+++ b/src/go/plugin/framework/chartengine/matcher.go
@@ -26,6 +26,7 @@ type routeBinding struct {
 	Static            bool
 	Inferred          bool
 	Autogen           bool
+	Aggregation       program.Aggregation
 	Meta              program.ChartMeta
 	Lifecycle         program.LifecyclePolicy
 }
@@ -137,17 +138,20 @@ func (e *Engine) resolveSeriesRoutes(
 		if !ok {
 			continue
 		}
+		dimensionFloat := candidate.dimension.Float || metricFloat ||
+			candidate.dimension.Aggregation == program.AggregationAvg
 		routes = append(routes, routeBinding{
 			ChartTemplateID:   candidate.chartTemplateID,
 			ChartID:           chartID,
 			DimensionIndex:    candidate.dimensionIndex,
 			DimensionName:     dimName,
 			DimensionKeyLabel: dimKeyLabel,
+			Aggregation:       candidate.dimension.Aggregation,
 			Algorithm:         chart.Meta.Algorithm,
 			Hidden:            candidate.dimension.Hidden,
 			Multiplier:        candidate.dimension.Multiplier,
 			Divisor:           candidate.dimension.Divisor,
-			Float:             candidate.dimension.Float || metricFloat,
+			Float:             dimensionFloat,
 			Static:            !candidate.dimension.Dynamic,
 			Inferred:          candidate.dimension.InferNameFromSeriesMeta,
 			Autogen:           false,

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -71,14 +71,15 @@ type InferredDimension struct {
 }
 
 type dimensionState struct {
-	hidden     bool
-	float      bool
-	static     bool
-	order      int
-	sortKey    dimensionSortKey
-	algorithm  program.Algorithm
-	multiplier int
-	divisor    int
+	algorithm   program.Algorithm
+	sortKey     dimensionSortKey
+	order       int
+	multiplier  int
+	divisor     int
+	hidden      bool
+	float       bool
+	static      bool
+	aggregation program.Aggregation
 }
 
 type dimensionSortKind uint8
@@ -94,9 +95,52 @@ type dimensionSortKey struct {
 }
 
 type dimBuildEntry struct {
-	seenSeq uint64
-	value   metrix.SampleValue
+	seenSeq      uint64
+	observations uint64
+	value        metrix.SampleValue
 	dimensionState
+}
+
+func (e *dimBuildEntry) aggregate(value metrix.SampleValue) {
+	if e.aggregation == program.AggregationSum {
+		e.value += value
+		return
+	}
+	e.aggregateNonSum(value)
+}
+
+func (e *dimBuildEntry) aggregateNonSum(value metrix.SampleValue) {
+	switch e.aggregation {
+	case program.AggregationMin:
+		if math.IsNaN(e.value) || (!math.IsNaN(value) && value < e.value) {
+			e.value = value
+		}
+	case program.AggregationMax:
+		if math.IsNaN(e.value) || (!math.IsNaN(value) && value > e.value) {
+			e.value = value
+		}
+	case program.AggregationAvg:
+		e.observations++
+		e.value = runningAverage(e.value, value, e.observations)
+	}
+}
+
+func runningAverage(current, value metrix.SampleValue, observations uint64) metrix.SampleValue {
+	if math.IsNaN(current) || math.IsNaN(value) {
+		return math.NaN()
+	}
+	if math.IsInf(current, 0) {
+		if math.IsInf(value, 0) && math.Signbit(current) != math.Signbit(value) {
+			return math.NaN()
+		}
+		return current
+	}
+	if math.IsInf(value, 0) {
+		return value
+	}
+
+	n := metrix.SampleValue(observations)
+	return current*((n-1)/n) + value/n
 }
 
 type chartState struct {
@@ -560,16 +604,18 @@ func (ctx *planBuildContext) accumulateRoute(
 	}
 	if entry.seenSeq != cs.currentBuildSeq {
 		entry.seenSeq = cs.currentBuildSeq
+		entry.observations = 1
 		entry.value = value
 		entry.dimensionState = dimensionState{
-			hidden:     route.Hidden,
-			float:      route.Float,
-			static:     route.Static,
-			order:      route.DimensionIndex,
-			sortKey:    sortKey,
-			algorithm:  route.Algorithm,
-			multiplier: route.Multiplier,
-			divisor:    route.Divisor,
+			hidden:      route.Hidden,
+			float:       route.Float,
+			static:      route.Static,
+			order:       route.DimensionIndex,
+			sortKey:     sortKey,
+			aggregation: route.Aggregation,
+			algorithm:   route.Algorithm,
+			multiplier:  route.Multiplier,
+			divisor:     route.Divisor,
 		}
 		cs.observedCount++
 	} else {
@@ -579,7 +625,7 @@ func (ctx *planBuildContext) accumulateRoute(
 		if entry.float != route.Float {
 			// First-observed float flag wins within one build; conflicting routes are ignored.
 		}
-		entry.value += value
+		entry.aggregate(value)
 	}
 
 	if cs.labelTracker.observeMembership(identity, route.DimensionKeyLabel) {

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -70,12 +70,33 @@ type InferredDimension struct {
 	Name            string
 }
 
+type dimensionAlgorithm uint8
+
+const (
+	dimensionAlgorithmAbsolute dimensionAlgorithm = iota
+	dimensionAlgorithmIncremental
+)
+
+func compactDimensionAlgorithm(algorithm program.Algorithm) dimensionAlgorithm {
+	if algorithm == program.AlgorithmIncremental {
+		return dimensionAlgorithmIncremental
+	}
+	return dimensionAlgorithmAbsolute
+}
+
+func (a dimensionAlgorithm) programAlgorithm() program.Algorithm {
+	if a == dimensionAlgorithmIncremental {
+		return program.AlgorithmIncremental
+	}
+	return program.AlgorithmAbsolute
+}
+
 type dimensionState struct {
-	algorithm   program.Algorithm
 	sortKey     dimensionSortKey
 	order       int
 	multiplier  int
 	divisor     int
+	algorithm   dimensionAlgorithm
 	hidden      bool
 	float       bool
 	static      bool
@@ -95,8 +116,9 @@ type dimensionSortKey struct {
 }
 
 type dimBuildEntry struct {
-	seenSeq uint64
-	value   metrix.SampleValue
+	seenSeq      uint64
+	observations uint64
+	value        metrix.SampleValue
 	dimensionState
 }
 
@@ -118,11 +140,10 @@ func (e *dimBuildEntry) aggregateNonSum(value metrix.SampleValue) {
 		if math.IsNaN(e.value) || (!math.IsNaN(value) && value > e.value) {
 			e.value = value
 		}
+	case program.AggregationAvg:
+		e.observations++
+		e.value = runningAverage(e.value, value, e.observations)
 	}
-}
-
-func (e *dimBuildEntry) aggregateAverage(value metrix.SampleValue, observations uint64) {
-	e.value = runningAverage(e.value, value, observations)
 }
 
 func runningAverage(current, value metrix.SampleValue, observations uint64) metrix.SampleValue {
@@ -173,24 +194,10 @@ type planBuildContext struct {
 	chartsByID       map[string]*chartState
 	chartOwners      map[string]string
 	dimCapHints      map[string]int
-	avgObservations  map[*dimBuildEntry]uint64
 	materialized     *materializedState
 	materializedByID map[string]*materializedChartState
 
 	planRouteStats
-}
-
-func (ctx *planBuildContext) aggregateAverage(entry *dimBuildEntry, value metrix.SampleValue) {
-	if ctx.avgObservations == nil {
-		ctx.avgObservations = make(map[*dimBuildEntry]uint64)
-	}
-	observations := ctx.avgObservations[entry]
-	if observations == 0 {
-		observations = 1
-	}
-	observations++
-	ctx.avgObservations[entry] = observations
-	entry.aggregateAverage(value, observations)
 }
 
 type flattenedReadChecker interface {
@@ -623,6 +630,7 @@ func (ctx *planBuildContext) accumulateRoute(
 	}
 	if entry.seenSeq != cs.currentBuildSeq {
 		entry.seenSeq = cs.currentBuildSeq
+		entry.observations = 1
 		entry.value = value
 		entry.dimensionState = dimensionState{
 			hidden:      route.Hidden,
@@ -631,7 +639,7 @@ func (ctx *planBuildContext) accumulateRoute(
 			order:       route.DimensionIndex,
 			sortKey:     sortKey,
 			aggregation: route.Aggregation,
-			algorithm:   route.Algorithm,
+			algorithm:   compactDimensionAlgorithm(route.Algorithm),
 			multiplier:  route.Multiplier,
 			divisor:     route.Divisor,
 		}
@@ -643,11 +651,7 @@ func (ctx *planBuildContext) accumulateRoute(
 		if entry.float != route.Float {
 			// First-observed float flag wins within one build; conflicting routes are ignored.
 		}
-		if entry.aggregation == program.AggregationAvg {
-			ctx.aggregateAverage(entry, value)
-		} else {
-			entry.aggregate(value)
-		}
+		entry.aggregate(value)
 	}
 
 	if cs.labelTracker.observeMembership(identity, route.DimensionKeyLabel) {
@@ -744,7 +748,7 @@ func (e *Engine) materializePlanCharts(ctx *planBuildContext) error {
 					Name:       name,
 					Hidden:     entry.hidden,
 					Float:      entry.float,
-					Algorithm:  entry.algorithm,
+					Algorithm:  entry.algorithm.programAlgorithm(),
 					Multiplier: entry.multiplier,
 					Divisor:    entry.divisor,
 				})

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -95,9 +95,8 @@ type dimensionSortKey struct {
 }
 
 type dimBuildEntry struct {
-	seenSeq      uint64
-	observations uint64
-	value        metrix.SampleValue
+	seenSeq uint64
+	value   metrix.SampleValue
 	dimensionState
 }
 
@@ -119,10 +118,11 @@ func (e *dimBuildEntry) aggregateNonSum(value metrix.SampleValue) {
 		if math.IsNaN(e.value) || (!math.IsNaN(value) && value > e.value) {
 			e.value = value
 		}
-	case program.AggregationAvg:
-		e.observations++
-		e.value = runningAverage(e.value, value, e.observations)
 	}
+}
+
+func (e *dimBuildEntry) aggregateAverage(value metrix.SampleValue, observations uint64) {
+	e.value = runningAverage(e.value, value, observations)
 }
 
 func runningAverage(current, value metrix.SampleValue, observations uint64) metrix.SampleValue {
@@ -139,7 +139,12 @@ func runningAverage(current, value metrix.SampleValue, observations uint64) metr
 		return value
 	}
 
-	n := metrix.SampleValue(observations)
+	n := float64(observations)
+	delta := value - current
+	if !math.IsInf(delta, 0) {
+		return math.FMA(delta, 1/n, current)
+	}
+
 	return current*((n-1)/n) + value/n
 }
 
@@ -168,10 +173,24 @@ type planBuildContext struct {
 	chartsByID       map[string]*chartState
 	chartOwners      map[string]string
 	dimCapHints      map[string]int
+	avgObservations  map[*dimBuildEntry]uint64
 	materialized     *materializedState
 	materializedByID map[string]*materializedChartState
 
 	planRouteStats
+}
+
+func (ctx *planBuildContext) aggregateAverage(entry *dimBuildEntry, value metrix.SampleValue) {
+	if ctx.avgObservations == nil {
+		ctx.avgObservations = make(map[*dimBuildEntry]uint64)
+	}
+	observations := ctx.avgObservations[entry]
+	if observations == 0 {
+		observations = 1
+	}
+	observations++
+	ctx.avgObservations[entry] = observations
+	entry.aggregateAverage(value, observations)
 }
 
 type flattenedReadChecker interface {
@@ -604,7 +623,6 @@ func (ctx *planBuildContext) accumulateRoute(
 	}
 	if entry.seenSeq != cs.currentBuildSeq {
 		entry.seenSeq = cs.currentBuildSeq
-		entry.observations = 1
 		entry.value = value
 		entry.dimensionState = dimensionState{
 			hidden:      route.Hidden,
@@ -625,7 +643,11 @@ func (ctx *planBuildContext) accumulateRoute(
 		if entry.float != route.Float {
 			// First-observed float flag wins within one build; conflicting routes are ignored.
 		}
-		entry.aggregate(value)
+		if entry.aggregation == program.AggregationAvg {
+			ctx.aggregateAverage(entry, value)
+		} else {
+			entry.aggregate(value)
+		}
 	}
 
 	if cs.labelTracker.observeMembership(identity, route.DimensionKeyLabel) {

--- a/src/go/plugin/framework/chartengine/planner_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_bench_test.go
@@ -3,7 +3,9 @@
 package chartengine
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
@@ -35,6 +37,23 @@ groups:
         dimensions:
           - selector: unused_metric
             name: unused
+`
+
+const benchAggregationTemplateYAML = `
+version: v1
+groups:
+  - family: "Bench"
+    metrics: ["bench_metric"]
+    charts:
+      - title: "Bench metric"
+        context: "bench.metric"
+        units: "units"
+        aggregation: AGGREGATION
+        instances:
+          by_labels: [team]
+        dimensions:
+          - selector: bench_metric
+            name: value
 `
 
 func BenchmarkBuildPlanBySeriesCardinality(b *testing.B) {
@@ -99,6 +118,61 @@ func BenchmarkBuildPlanAutogenUnmatchedBaseline(b *testing.B) {
 	}
 }
 
+func BenchmarkBuildPlanAggregationFanIn(b *testing.B) {
+	seriesCounts := []int{100, 1000, 10000}
+	aggregations := []struct {
+		name  string
+		value string
+	}{
+		{name: "default_sum"},
+		{name: "sum", value: "sum"},
+		{name: "min", value: "min"},
+		{name: "max", value: "max"},
+		{name: "avg", value: "avg"},
+	}
+	fanIns := []struct {
+		name       string
+		chartCount func(seriesCount int) int
+	}{
+		{name: "full_fan_in", chartCount: func(_ int) int { return 1 }},
+		{name: "mixed_10_per_chart", chartCount: func(seriesCount int) int {
+			return max(1, seriesCount/10)
+		}},
+	}
+
+	for _, aggregation := range aggregations {
+		for _, fanIn := range fanIns {
+			for _, seriesCount := range seriesCounts {
+				name := fmt.Sprintf("%s/%s/series_%d", aggregation.name, fanIn.name, seriesCount)
+				b.Run(name, func(b *testing.B) {
+					reader := benchmarkAggregationReader(b, seriesCount, fanIn.chartCount(seriesCount))
+
+					engine, err := New()
+					if err != nil {
+						b.Fatalf("new engine: %v", err)
+					}
+					aggregationLine := ""
+					if aggregation.value != "" {
+						aggregationLine = "aggregation: " + aggregation.value
+					}
+					tmpl := strings.ReplaceAll(benchAggregationTemplateYAML, "aggregation: AGGREGATION", aggregationLine)
+					if err := engine.LoadYAML([]byte(tmpl), 1); err != nil {
+						b.Fatalf("load template: %v", err)
+					}
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if _, err := buildPlan(engine, reader); err != nil {
+							b.Fatalf("build plan: %v", err)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
 func benchmarkCollectorReader(b *testing.B, seriesCount int) metrix.Reader {
 	b.Helper()
 
@@ -116,6 +190,30 @@ func benchmarkCollectorReader(b *testing.B, seriesCount int) metrix.Reader {
 	for i := range seriesCount {
 		g.Observe(metrix.SampleValue(i), meter.LabelSet(
 			metrix.Label{Key: "id", Value: strconv.Itoa(i)},
+		))
+	}
+	cc.CommitCycleSuccess()
+	return store.Read(metrix.ReadRaw())
+}
+
+func benchmarkAggregationReader(b *testing.B, seriesCount, chartCount int) metrix.Reader {
+	b.Helper()
+
+	store := metrix.NewCollectorStore()
+	managed, ok := metrix.AsCycleManagedStore(store)
+	if !ok {
+		b.Fatalf("collector store is not cycle-managed")
+	}
+	cc := managed.CycleController()
+
+	meter := store.Write().SnapshotMeter("")
+	g := meter.Gauge("bench_metric")
+
+	cc.BeginCycle()
+	for i := range seriesCount {
+		g.Observe(metrix.SampleValue(i), meter.LabelSet(
+			metrix.Label{Key: "team", Value: strconv.Itoa(i % chartCount)},
+			metrix.Label{Key: "api_key", Value: strconv.Itoa(i)},
 		))
 	}
 	cc.CommitCycleSuccess()

--- a/src/go/plugin/framework/chartengine/planner_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_bench_test.go
@@ -153,6 +153,7 @@ func BenchmarkBuildPlanAggregationFanIn(b *testing.B) {
 				for _, seriesCount := range seriesCounts {
 					name := fmt.Sprintf("%s/%s/%s/series_%d", mode.name, aggregation.name, fanIn.name, seriesCount)
 					b.Run(name, func(b *testing.B) {
+						b.StopTimer()
 						reader := benchmarkAggregationReader(b, seriesCount, fanIn.chartCount(seriesCount))
 						aggregationLine := ""
 						if aggregation.value != "" {
@@ -167,6 +168,7 @@ func BenchmarkBuildPlanAggregationFanIn(b *testing.B) {
 								b.Fatalf("warm build plan: %v", err)
 							}
 							b.ResetTimer()
+							b.StartTimer()
 							for i := 0; i < b.N; i++ {
 								if _, err := buildPlan(engine, reader); err != nil {
 									b.Fatalf("build plan: %v", err)
@@ -175,7 +177,7 @@ func BenchmarkBuildPlanAggregationFanIn(b *testing.B) {
 							return
 						}
 
-						b.StopTimer()
+						b.ResetTimer()
 						for i := 0; i < b.N; i++ {
 							engine := benchmarkAggregationEngine(b, tmpl)
 							b.StartTimer()

--- a/src/go/plugin/framework/chartengine/planner_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_bench_test.go
@@ -120,6 +120,13 @@ func BenchmarkBuildPlanAutogenUnmatchedBaseline(b *testing.B) {
 
 func BenchmarkBuildPlanAggregationFanIn(b *testing.B) {
 	seriesCounts := []int{100, 1000, 10000}
+	modes := []struct {
+		name string
+		warm bool
+	}{
+		{name: "warm", warm: true},
+		{name: "cold"},
+	}
 	aggregations := []struct {
 		name  string
 		value string
@@ -140,37 +147,60 @@ func BenchmarkBuildPlanAggregationFanIn(b *testing.B) {
 		}},
 	}
 
-	for _, aggregation := range aggregations {
-		for _, fanIn := range fanIns {
-			for _, seriesCount := range seriesCounts {
-				name := fmt.Sprintf("%s/%s/series_%d", aggregation.name, fanIn.name, seriesCount)
-				b.Run(name, func(b *testing.B) {
-					reader := benchmarkAggregationReader(b, seriesCount, fanIn.chartCount(seriesCount))
-
-					engine, err := New()
-					if err != nil {
-						b.Fatalf("new engine: %v", err)
-					}
-					aggregationLine := ""
-					if aggregation.value != "" {
-						aggregationLine = "aggregation: " + aggregation.value
-					}
-					tmpl := strings.ReplaceAll(benchAggregationTemplateYAML, "aggregation: AGGREGATION", aggregationLine)
-					if err := engine.LoadYAML([]byte(tmpl), 1); err != nil {
-						b.Fatalf("load template: %v", err)
-					}
-
-					b.ReportAllocs()
-					b.ResetTimer()
-					for i := 0; i < b.N; i++ {
-						if _, err := buildPlan(engine, reader); err != nil {
-							b.Fatalf("build plan: %v", err)
+	for _, mode := range modes {
+		for _, aggregation := range aggregations {
+			for _, fanIn := range fanIns {
+				for _, seriesCount := range seriesCounts {
+					name := fmt.Sprintf("%s/%s/%s/series_%d", mode.name, aggregation.name, fanIn.name, seriesCount)
+					b.Run(name, func(b *testing.B) {
+						reader := benchmarkAggregationReader(b, seriesCount, fanIn.chartCount(seriesCount))
+						aggregationLine := ""
+						if aggregation.value != "" {
+							aggregationLine = "aggregation: " + aggregation.value
 						}
-					}
-				})
+						tmpl := strings.ReplaceAll(benchAggregationTemplateYAML, "aggregation: AGGREGATION", aggregationLine)
+
+						b.ReportAllocs()
+						if mode.warm {
+							engine := benchmarkAggregationEngine(b, tmpl)
+							if _, err := buildPlan(engine, reader); err != nil {
+								b.Fatalf("warm build plan: %v", err)
+							}
+							b.ResetTimer()
+							for i := 0; i < b.N; i++ {
+								if _, err := buildPlan(engine, reader); err != nil {
+									b.Fatalf("build plan: %v", err)
+								}
+							}
+							return
+						}
+
+						b.StopTimer()
+						for i := 0; i < b.N; i++ {
+							engine := benchmarkAggregationEngine(b, tmpl)
+							b.StartTimer()
+							if _, err := buildPlan(engine, reader); err != nil {
+								b.Fatalf("build plan: %v", err)
+							}
+							b.StopTimer()
+						}
+					})
+				}
 			}
 		}
 	}
+}
+
+func benchmarkAggregationEngine(b *testing.B, tmpl string) *Engine {
+	b.Helper()
+	engine, err := New(WithRuntimePlannerMode())
+	if err != nil {
+		b.Fatalf("new engine: %v", err)
+	}
+	if err := engine.LoadYAML([]byte(tmpl), 1); err != nil {
+		b.Fatalf("load template: %v", err)
+	}
+	return engine
 }
 
 func benchmarkCollectorReader(b *testing.B, seriesCount int) metrix.Reader {

--- a/src/go/plugin/framework/chartengine/planner_lifecycle_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle_bench_test.go
@@ -212,7 +212,7 @@ func benchmarkLifecycleCapFixture(
 		for dimIndex := range dimCount {
 			name := fmt.Sprintf("dimension_%02d", dimIndex)
 			dim, _ := matChart.ensureDimension(name, dimensionState{
-				algorithm:  program.AlgorithmAbsolute,
+				algorithm:  dimensionAlgorithmAbsolute,
 				multiplier: 1,
 				divisor:    1,
 			})

--- a/src/go/plugin/framework/chartengine/planner_lifecycle_test.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle_test.go
@@ -56,7 +56,7 @@ func runTestEnforceLifecycleCapsDimensionCapEvictsLRU(t *testing.T) {
 			require.True(t, created)
 
 			oldA, created := matChart.ensureDimension("old_a", dimensionState{
-				algorithm:  program.AlgorithmAbsolute,
+				algorithm:  dimensionAlgorithmAbsolute,
 				multiplier: 1,
 				divisor:    1,
 			})
@@ -64,7 +64,7 @@ func runTestEnforceLifecycleCapsDimensionCapEvictsLRU(t *testing.T) {
 			oldA.lastSeenSuccessSeq = 1
 
 			oldB, created := matChart.ensureDimension("old_b", dimensionState{
-				algorithm:  program.AlgorithmAbsolute,
+				algorithm:  dimensionAlgorithmAbsolute,
 				multiplier: 1,
 				divisor:    1,
 			})
@@ -85,7 +85,7 @@ func runTestEnforceLifecycleCapsDimensionCapEvictsLRU(t *testing.T) {
 							dimensionState: dimensionState{
 								static:     false,
 								order:      0,
-								algorithm:  program.AlgorithmAbsolute,
+								algorithm:  dimensionAlgorithmAbsolute,
 								multiplier: 1,
 								divisor:    1,
 							},
@@ -125,7 +125,7 @@ func runTestEnforceLifecycleCapsMixedPolicies(t *testing.T) {
 	disabledActive.lastSeenSuccessSeq = 1
 	for _, name := range []string{"old_a", "old_b"} {
 		dim, created := disabledActive.ensureDimension(name, dimensionState{
-			algorithm:  program.AlgorithmAbsolute,
+			algorithm:  dimensionAlgorithmAbsolute,
 			multiplier: 1,
 			divisor:    1,
 		})
@@ -157,7 +157,7 @@ func runTestEnforceLifecycleCapsMixedPolicies(t *testing.T) {
 	require.True(t, created)
 	dimsActive.lastSeenSuccessSeq = currentSeq
 	oldDim, created := dimsActive.ensureDimension("old", dimensionState{
-		algorithm:  program.AlgorithmAbsolute,
+		algorithm:  dimensionAlgorithmAbsolute,
 		multiplier: 1,
 		divisor:    1,
 	})
@@ -300,7 +300,7 @@ func observedDimensionEntry(seenSeq uint64) *dimBuildEntry {
 	return &dimBuildEntry{
 		seenSeq: seenSeq,
 		dimensionState: dimensionState{
-			algorithm:  program.AlgorithmAbsolute,
+			algorithm:  dimensionAlgorithmAbsolute,
 			multiplier: 1,
 			divisor:    1,
 		},
@@ -335,7 +335,7 @@ func runTestCollectExpiryRemovalsDimensionAndChartExpiry(t *testing.T) {
 			liveChart.lastSeenSuccessSeq = tc.currentSeq
 
 			staleDim, created := liveChart.ensureDimension("stale_dim", dimensionState{
-				algorithm:  program.AlgorithmAbsolute,
+				algorithm:  dimensionAlgorithmAbsolute,
 				multiplier: 1,
 				divisor:    1,
 			})
@@ -343,7 +343,7 @@ func runTestCollectExpiryRemovalsDimensionAndChartExpiry(t *testing.T) {
 			staleDim.lastSeenSuccessSeq = 2
 
 			freshDim, created := liveChart.ensureDimension("fresh_dim", dimensionState{
-				algorithm:  program.AlgorithmAbsolute,
+				algorithm:  dimensionAlgorithmAbsolute,
 				multiplier: 1,
 				divisor:    1,
 			})

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -4,6 +4,7 @@ package chartengine
 
 import (
 	"math"
+	"strconv"
 	"strings"
 	"testing"
 	"unsafe"
@@ -2372,12 +2373,13 @@ groups:
 		want              float64
 		wantFloat         bool
 		checkScratchReset bool
+		highFanIn         bool
 	}{
 		"default sum": {want: 300},
 		"chart sum":   {chartAggregation: "aggregation: sum", want: 300},
 		"chart min":   {chartAggregation: "aggregation: min", want: 100},
 		"chart max":   {chartAggregation: "aggregation: max", want: 200},
-		"chart avg":   {chartAggregation: "aggregation: avg", want: 150, wantFloat: true, checkScratchReset: true},
+		"chart avg":   {chartAggregation: "aggregation: avg", want: 4999.5, wantFloat: true, checkScratchReset: true, highFanIn: true},
 	}
 
 	for name, tc := range tests {
@@ -2394,14 +2396,23 @@ groups:
 			lastUsed := m.Gauge("api_key_last_used_timestamp")
 
 			cc.BeginCycle()
-			lastUsed.Observe(100, m.LabelSet(
-				metrix.Label{Key: "team", Value: "team-a"},
-				metrix.Label{Key: "api_key", Value: "key-1"},
-			))
-			lastUsed.Observe(200, m.LabelSet(
-				metrix.Label{Key: "team", Value: "team-a"},
-				metrix.Label{Key: "api_key", Value: "key-2"},
-			))
+			if tc.highFanIn {
+				for i := range 10_000 {
+					lastUsed.Observe(metrix.SampleValue(i), m.LabelSet(
+						metrix.Label{Key: "team", Value: "team-a"},
+						metrix.Label{Key: "api_key", Value: "key-" + strconv.Itoa(i)},
+					))
+				}
+			} else {
+				lastUsed.Observe(100, m.LabelSet(
+					metrix.Label{Key: "team", Value: "team-a"},
+					metrix.Label{Key: "api_key", Value: "key-1"},
+				))
+				lastUsed.Observe(200, m.LabelSet(
+					metrix.Label{Key: "team", Value: "team-a"},
+					metrix.Label{Key: "api_key", Value: "key-2"},
+				))
+			}
 			cc.CommitCycleSuccess()
 
 			plan, err := buildPlan(e, store.Read())
@@ -2411,7 +2422,11 @@ groups:
 			require.NotNil(t, update)
 			require.Len(t, update.Values, 1)
 			assert.Equal(t, "last_used", update.Values[0].Name)
-			assert.Equal(t, tc.want, update.Values[0].Float64)
+			if tc.highFanIn {
+				assert.InDelta(t, tc.want, update.Values[0].Float64, 1e-9)
+			} else {
+				assert.Equal(t, tc.want, update.Values[0].Float64)
+			}
 			assert.Equal(t, tc.wantFloat, update.Values[0].IsFloat)
 
 			if tc.checkScratchReset {
@@ -2465,17 +2480,14 @@ func TestDimBuildEntryAggregation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require.NotEmpty(t, tc.values)
 			entry := dimBuildEntry{
-				value: tc.values[0],
+				observations: 1,
+				value:        tc.values[0],
 				dimensionState: dimensionState{
 					aggregation: tc.aggregation,
 				},
 			}
-			for i, value := range tc.values[1:] {
-				if tc.aggregation == program.AggregationAvg {
-					entry.aggregateAverage(value, uint64(i+2))
-				} else {
-					entry.aggregate(value)
-				}
+			for _, value := range tc.values[1:] {
+				entry.aggregate(value)
 			}
 
 			switch {
@@ -2497,32 +2509,26 @@ func TestDimBuildEntry64BitSizeBudget(t *testing.T) {
 	assert.LessOrEqual(t, unsafe.Sizeof(dimBuildEntry{}), uintptr(80))
 }
 
-func TestDimBuildEntryAggregationHighFanIn(t *testing.T) {
-	entries := map[program.Aggregation]*dimBuildEntry{}
-	for _, aggregation := range []program.Aggregation{
-		program.AggregationSum,
-		program.AggregationMin,
-		program.AggregationMax,
-		program.AggregationAvg,
+func TestDimBuildEntryAggregationDoesNotAllocate(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		aggregation program.Aggregation
+	}{
+		{name: "sum", aggregation: program.AggregationSum},
+		{name: "min", aggregation: program.AggregationMin},
+		{name: "max", aggregation: program.AggregationMax},
+		{name: "avg", aggregation: program.AggregationAvg},
 	} {
-		entries[aggregation] = &dimBuildEntry{
-			dimensionState: dimensionState{aggregation: aggregation},
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			entry := dimBuildEntry{dimensionState: dimensionState{aggregation: tc.aggregation}}
+			allocs := testing.AllocsPerRun(100, func() {
+				entry.observations = 1
+				entry.value = 1
+				entry.aggregate(2)
+			})
+			assert.Zero(t, allocs)
+		})
 	}
-
-	const observations = 10_000
-	for i := 1; i < observations; i++ {
-		value := metrix.SampleValue(i)
-		entries[program.AggregationSum].aggregate(value)
-		entries[program.AggregationMin].aggregate(value)
-		entries[program.AggregationMax].aggregate(value)
-		entries[program.AggregationAvg].aggregateAverage(value, uint64(i+1))
-	}
-
-	assert.Equal(t, float64(49_995_000), entries[program.AggregationSum].value)
-	assert.Equal(t, float64(0), entries[program.AggregationMin].value)
-	assert.Equal(t, float64(9_999), entries[program.AggregationMax].value)
-	assert.InDelta(t, 4_999.5, entries[program.AggregationAvg].value, 1e-9)
 }
 
 func runTestBuildPlanEmptyEmissionAndScratchReusePruneAcrossCycles(t *testing.T) {
@@ -2904,7 +2910,7 @@ groups:
 			liveDim, dimCreated := liveChart.ensureDimension("stale_mode", dimensionState{
 				static:     false,
 				order:      1,
-				algorithm:  program.AlgorithmAbsolute,
+				algorithm:  dimensionAlgorithmAbsolute,
 				multiplier: 1,
 				divisor:    1,
 			})

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -113,7 +113,7 @@ groups:
 	cc.BeginCycle()
 	authored.Observe(1)
 	excluded.Observe(2)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadRaw()))
 	require.NoError(t, err)
@@ -363,7 +363,7 @@ groups:
 						{UpperBound: 10, CumulativeCount: 3},
 					},
 				})
-				cc.CommitCycleSuccess()
+				_ = cc.CommitCycleSuccess()
 			},
 			wantNames:      []string{"1", "2", "10", "+Inf"},
 			wantKinds:      []ActionKind{ActionCreateChart, ActionCreateDimension, ActionCreateDimension, ActionCreateDimension, ActionCreateDimension, ActionUpdateChart},
@@ -398,7 +398,7 @@ groups:
 						{Quantile: 0.9, Value: 1.2},
 					},
 				})
-				cc.CommitCycleSuccess()
+				_ = cc.CommitCycleSuccess()
 			},
 			wantNames: []string{"0.5", "0.9"},
 			wantKinds: []ActionKind{ActionCreateChart, ActionCreateDimension, ActionCreateDimension, ActionUpdateChart},
@@ -427,7 +427,7 @@ groups:
 				)
 				cc.BeginCycle()
 				ss.Enable("ok")
-				cc.CommitCycleSuccess()
+				_ = cc.CommitCycleSuccess()
 			},
 			wantNames: []string{"failed", "ok"},
 			wantKinds: []ActionKind{ActionCreateChart, ActionCreateDimension, ActionCreateDimension, ActionUpdateChart},
@@ -548,7 +548,7 @@ groups:
 		},
 	})
 	ss.Enable("3")
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -603,7 +603,7 @@ groups:
 
 	cc.BeginCycle()
 	ss.Enable("ok")
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	_, err = buildPlan(e, store.Read())
 	require.Error(t, err)
@@ -639,7 +639,7 @@ groups:
 
 	cc.BeginCycle()
 	c.ObserveTotal(10)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan1, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -652,7 +652,7 @@ groups:
 
 	cc.BeginCycle()
 	c.ObserveTotal(20)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan2, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -700,7 +700,7 @@ groups:
 	cc.BeginCycle()
 	total.Observe(100)
 	modeMetric.Observe(1, modeOK)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan1, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -708,7 +708,7 @@ groups:
 
 	cc.BeginCycle()
 	total.Observe(101)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan2, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -746,14 +746,14 @@ groups:
 
 	cc.BeginCycle()
 	c.ObserveTotal(10)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan1, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
 	assert.Equal(t, []ActionKind{ActionCreateChart, ActionCreateDimension, ActionUpdateChart}, actionKinds(plan1.Actions))
 
 	cc.BeginCycle()
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan2, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -788,7 +788,7 @@ groups:
 
 	cc.BeginCycle()
 	c.ObserveTotal(10)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan1, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -802,7 +802,7 @@ groups:
 	assert.Empty(t, plan2.Actions)
 
 	cc.BeginCycle()
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan3, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -843,7 +843,7 @@ groups:
 	cc.BeginCycle()
 	rx.ObserveTotal(10, eth1)
 	rx.ObserveTotal(20, eth0)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan1, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -872,7 +872,7 @@ groups:
 	cc.BeginCycle()
 	rx.ObserveTotal(21, eth0)
 	rx.ObserveTotal(11, eth1)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan2, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -914,7 +914,7 @@ groups:
 
 	cc.BeginCycle()
 	rx.ObserveTotal(10, eth0)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan1, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -923,7 +923,7 @@ groups:
 	cc.BeginCycle()
 	rx.ObserveTotal(11, eth0)
 	rx.ObserveTotal(20, eth1)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan2, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -935,7 +935,7 @@ groups:
 
 	cc.BeginCycle()
 	rx.ObserveTotal(21, eth1)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan3, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -965,7 +965,7 @@ func runTestBuildPlanEnforcesMaxDimsDeterministically(t *testing.T) {
 	cc.BeginCycle()
 	g.Observe(1, modeA)
 	g.Observe(1, modeB)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan1, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -975,7 +975,7 @@ func runTestBuildPlanEnforcesMaxDimsDeterministically(t *testing.T) {
 	g.Observe(1, modeA)
 	g.Observe(1, modeB)
 	g.Observe(1, modeC)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan2, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -988,7 +988,7 @@ func runTestBuildPlanEnforcesMaxDimsDeterministically(t *testing.T) {
 	cc.BeginCycle()
 	g.Observe(1, modeB)
 	g.Observe(1, modeC)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan3, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1042,7 +1042,7 @@ groups:
 	cc.BeginCycle()
 	m.ObserveTotal(10, in)
 	m.ObserveTotal(20, out)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1087,7 +1087,7 @@ groups:
 
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1130,7 +1130,7 @@ groups:
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10, methodGET)
 	unmatched.ObserveTotal(20, methodPOST)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1174,7 +1174,7 @@ groups:
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10, methodGET)
 	unmatched.ObserveTotal(20, methodPOST)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1218,7 +1218,7 @@ groups:
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10, methodGET)
 	unmatched.ObserveTotal(20, methodPOST)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1256,7 +1256,7 @@ groups:
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10, methodGET)
 	unmatched.ObserveTotal(20, methodPOST)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1295,7 +1295,7 @@ groups:
 
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10, methodGET)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1346,7 +1346,7 @@ groups:
 
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10, methodGET)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1379,7 +1379,7 @@ groups:
 
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10, methodGET)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1420,7 +1420,7 @@ groups:
 
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1465,7 +1465,7 @@ groups:
 
 	cc.BeginCycle()
 	unmatched.ObserveTotal(10)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1514,7 +1514,7 @@ groups:
 			{UpperBound: 2, CumulativeCount: 3},
 		},
 	})
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1562,7 +1562,7 @@ groups:
 
 	cc.BeginCycle()
 	unmatched.Observe(10.5)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1619,7 +1619,7 @@ groups:
 		Count: 4,
 		Sum:   8,
 	})
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1660,7 +1660,7 @@ groups:
 
 	cc.BeginCycle()
 	m.ObserveTotal(10, methodGET)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1727,7 +1727,7 @@ groups:
 	cc.BeginCycle()
 	floaty.ObserveTotal(3, ls)
 	inty.ObserveTotal(7, ls)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1778,7 +1778,7 @@ groups:
 
 	cc.BeginCycle()
 	metric.ObserveTotal(10, ls)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1821,7 +1821,7 @@ groups:
 			{UpperBound: 10, CumulativeCount: 3},
 		},
 	}, method)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1893,7 +1893,7 @@ groups:
 
 	cc.BeginCycle()
 	g.Observe(7, queueMain)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -1943,7 +1943,7 @@ groups:
 
 	cc.BeginCycle()
 	ss.Enable("operational")
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -2006,7 +2006,7 @@ groups:
 
 	cc.BeginCycle()
 	ss.Enable("operational")
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -2054,7 +2054,7 @@ groups:
 
 	cc.BeginCycle()
 	ms.ObservePoint(metrix.MeasureSetPoint{Values: []metrix.SampleValue{1.5, 0.5}})
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -2136,7 +2136,7 @@ groups:
 
 	cc.BeginCycle()
 	ms.ObserveTotalPoint(metrix.MeasureSetPoint{Values: []metrix.SampleValue{10, 2}})
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -2214,7 +2214,7 @@ groups:
 	cc.BeginCycle()
 	errorsTotal.ObserveTotal(10, methodGET)
 	fooTotal.ObserveTotal(7, methodGET)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -2261,14 +2261,14 @@ groups:
 
 	cc.BeginCycle()
 	c.ObserveTotal(10)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan1, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
 	assert.Equal(t, []ActionKind{ActionCreateChart, ActionCreateDimension, ActionUpdateChart}, actionKinds(plan1.Actions))
 
 	cc.BeginCycle()
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan2, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -2315,7 +2315,7 @@ groups:
 	cc.BeginCycle()
 	a.Observe(5, total)
 	b.Observe(3, total)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read())
 	require.NoError(t, err)
@@ -2413,7 +2413,7 @@ groups:
 					metrix.Label{Key: "api_key", Value: "key-2"},
 				))
 			}
-			cc.CommitCycleSuccess()
+			_ = cc.CommitCycleSuccess()
 
 			plan, err := buildPlan(e, store.Read())
 			require.NoError(t, err)
@@ -2439,7 +2439,7 @@ groups:
 					metrix.Label{Key: "team", Value: "team-a"},
 					metrix.Label{Key: "api_key", Value: "key-2"},
 				))
-				cc.CommitCycleSuccess()
+				_ = cc.CommitCycleSuccess()
 
 				nextPlan, err := buildPlan(e, store.Read())
 				require.NoError(t, err)
@@ -2496,7 +2496,7 @@ func TestDimBuildEntryAggregation(t *testing.T) {
 			case tc.wantPosInf:
 				assert.True(t, math.IsInf(entry.value, 1))
 			default:
-				assert.Equal(t, tc.want, float64(entry.value))
+				assert.Equal(t, tc.want, entry.value)
 			}
 		})
 	}
@@ -2565,7 +2565,7 @@ groups:
 	cc.BeginCycle()
 	mode.Observe(1, okSet)
 	mode.Observe(2, warnSet)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan1, err := buildPlan(e, store.Read())
 	require.NoError(t, err)
@@ -2579,7 +2579,7 @@ groups:
 
 	cc.BeginCycle()
 	mode.Observe(3, okSet)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan2, err := buildPlan(e, store.Read())
 	require.NoError(t, err)
@@ -2604,7 +2604,7 @@ groups:
 
 	cc.BeginCycle()
 	mode.Observe(4, okSet)
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan3, err := buildPlan(e, store.Read())
 	require.NoError(t, err)
@@ -2649,7 +2649,7 @@ groups:
 
 				cc.BeginCycle()
 				g.Observe(5)
-				cc.CommitCycleSuccess()
+				_ = cc.CommitCycleSuccess()
 
 				plan1, err := buildPlan(e, store.Read())
 				require.NoError(t, err)
@@ -2754,7 +2754,7 @@ groups:
 			cc.BeginCycle()
 			mode.Observe(1, a)
 			mode.Observe(2, b)
-			cc.CommitCycleSuccess()
+			_ = cc.CommitCycleSuccess()
 
 			out := Plan{
 				Actions:            make([]EngineAction, 0),
@@ -2805,7 +2805,7 @@ groups:
 
 			cc.BeginCycle()
 			mode.Observe(1, okLabel)
-			cc.CommitCycleSuccess()
+			_ = cc.CommitCycleSuccess()
 
 			out := Plan{
 				Actions:            make([]EngineAction, 0),
@@ -2975,7 +2975,7 @@ groups:
 			{Quantile: 0.9, Value: metrix.SampleValue(math.NaN())},
 		},
 	})
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
@@ -3022,7 +3022,7 @@ groups:
 			{Quantile: 0.9, Value: metrix.SampleValue(math.NaN())},
 		},
 	})
-	cc.CommitCycleSuccess()
+	_ = cc.CommitCycleSuccess()
 
 	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2454,6 +2455,7 @@ func TestDimBuildEntryAggregation(t *testing.T) {
 		"max ignores trailing NaN":    {aggregation: program.AggregationMax, values: []metrix.SampleValue{5, metrix.SampleValue(math.NaN())}, want: 5},
 		"max replaces leading NaN":    {aggregation: program.AggregationMax, values: []metrix.SampleValue{metrix.SampleValue(math.NaN()), 5}, want: 5},
 		"avg preserves fraction":      {aggregation: program.AggregationAvg, values: []metrix.SampleValue{1, 2}, want: 1.5},
+		"avg preserves subnormal":     {aggregation: program.AggregationAvg, values: []metrix.SampleValue{math.SmallestNonzeroFloat64, math.SmallestNonzeroFloat64}, want: math.SmallestNonzeroFloat64},
 		"avg avoids finite overflow":  {aggregation: program.AggregationAvg, values: []metrix.SampleValue{math.MaxFloat64, math.MaxFloat64}, want: math.MaxFloat64},
 		"avg keeps positive infinity": {aggregation: program.AggregationAvg, values: []metrix.SampleValue{metrix.SampleValue(math.Inf(1)), 5}, wantPosInf: true},
 		"avg opposite infinities":     {aggregation: program.AggregationAvg, values: []metrix.SampleValue{metrix.SampleValue(math.Inf(1)), metrix.SampleValue(math.Inf(-1))}, wantNaN: true},
@@ -2463,14 +2465,17 @@ func TestDimBuildEntryAggregation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require.NotEmpty(t, tc.values)
 			entry := dimBuildEntry{
-				observations: 1,
-				value:        tc.values[0],
+				value: tc.values[0],
 				dimensionState: dimensionState{
 					aggregation: tc.aggregation,
 				},
 			}
-			for _, value := range tc.values[1:] {
-				entry.aggregate(value)
+			for i, value := range tc.values[1:] {
+				if tc.aggregation == program.AggregationAvg {
+					entry.aggregateAverage(value, uint64(i+2))
+				} else {
+					entry.aggregate(value)
+				}
 			}
 
 			switch {
@@ -2483,6 +2488,41 @@ func TestDimBuildEntryAggregation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDimBuildEntry64BitSizeBudget(t *testing.T) {
+	if unsafe.Sizeof(uintptr(0)) != 8 {
+		t.Skip("64-bit hot-path size budget")
+	}
+	assert.LessOrEqual(t, unsafe.Sizeof(dimBuildEntry{}), uintptr(80))
+}
+
+func TestDimBuildEntryAggregationHighFanIn(t *testing.T) {
+	entries := map[program.Aggregation]*dimBuildEntry{}
+	for _, aggregation := range []program.Aggregation{
+		program.AggregationSum,
+		program.AggregationMin,
+		program.AggregationMax,
+		program.AggregationAvg,
+	} {
+		entries[aggregation] = &dimBuildEntry{
+			dimensionState: dimensionState{aggregation: aggregation},
+		}
+	}
+
+	const observations = 10_000
+	for i := 1; i < observations; i++ {
+		value := metrix.SampleValue(i)
+		entries[program.AggregationSum].aggregate(value)
+		entries[program.AggregationMin].aggregate(value)
+		entries[program.AggregationMax].aggregate(value)
+		entries[program.AggregationAvg].aggregateAverage(value, uint64(i+1))
+	}
+
+	assert.Equal(t, float64(49_995_000), entries[program.AggregationSum].value)
+	assert.Equal(t, float64(0), entries[program.AggregationMin].value)
+	assert.Equal(t, float64(9_999), entries[program.AggregationMax].value)
+	assert.InDelta(t, 4_999.5, entries[program.AggregationAvg].value, 1e-9)
 }
 
 func runTestBuildPlanEmptyEmissionAndScratchReusePruneAcrossCycles(t *testing.T) {

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -495,6 +495,7 @@ func TestBuildPlanLegacySingleScenarioCases(t *testing.T) {
 		"BuildPlanTemplateWinsOnAutogenChartIDCollisionAcrossSeries":   {run: runTestBuildPlanTemplateWinsOnAutogenChartIDCollisionAcrossSeries},
 		"BuildPlanAutogenRemovalLifecycleExpiry":                       {run: runTestBuildPlanAutogenRemovalLifecycleExpiry},
 		"BuildPlanFirstWriterWinsAndAccumulatesRepeatedRoutes":         {run: runTestBuildPlanFirstWriterWinsAndAccumulatesRepeatedRoutes},
+		"BuildPlanAggregatesProjectedSeriesByDimensionPolicy":          {run: runTestBuildPlanAggregatesProjectedSeriesByDimensionPolicy},
 		"BuildPlanEmptyEmissionAndScratchReusePruneAcrossCycles":       {run: runTestBuildPlanEmptyEmissionAndScratchReusePruneAcrossCycles},
 		"BuildPlanAutogenContextNamespacePrefixesContext":              {run: runTestBuildPlanAutogenContextNamespacePrefixesContext},
 		"BuildPlanAutogenContextNamespaceStubGroupOnly":                {run: runTestBuildPlanAutogenContextNamespaceStubGroupOnly},
@@ -2343,6 +2344,145 @@ groups:
 	assert.True(t, update.Values[0].IsFloat)
 	assert.Equal(t, "total", update.Values[0].Name)
 	assert.Equal(t, float64(8), update.Values[0].Float64)
+}
+
+func runTestBuildPlanAggregatesProjectedSeriesByDimensionPolicy(t *testing.T) {
+	const tmpl = `
+version: v1
+groups:
+  - family: LiteLLM
+    metrics:
+      - api_key_last_used_timestamp
+    charts:
+      - id: api_key_last_used
+        title: API key last used
+        context: api_key_last_used
+        units: seconds
+        CHART_AGGREGATION
+        instances:
+          by_labels: [team]
+        dimensions:
+          - selector: api_key_last_used_timestamp
+            name: last_used
+`
+
+	tests := map[string]struct {
+		chartAggregation  string
+		want              float64
+		wantFloat         bool
+		checkScratchReset bool
+	}{
+		"default sum": {want: 300},
+		"chart sum":   {chartAggregation: "aggregation: sum", want: 300},
+		"chart min":   {chartAggregation: "aggregation: min", want: 100},
+		"chart max":   {chartAggregation: "aggregation: max", want: 200},
+		"chart avg":   {chartAggregation: "aggregation: avg", want: 150, wantFloat: true, checkScratchReset: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			e, err := New()
+			require.NoError(t, err)
+
+			yaml := strings.ReplaceAll(tmpl, "CHART_AGGREGATION", tc.chartAggregation)
+			require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+
+			store := metrix.NewCollectorStore()
+			cc := mustCycleController(t, store)
+			m := store.Write().SnapshotMeter("")
+			lastUsed := m.Gauge("api_key_last_used_timestamp")
+
+			cc.BeginCycle()
+			lastUsed.Observe(100, m.LabelSet(
+				metrix.Label{Key: "team", Value: "team-a"},
+				metrix.Label{Key: "api_key", Value: "key-1"},
+			))
+			lastUsed.Observe(200, m.LabelSet(
+				metrix.Label{Key: "team", Value: "team-a"},
+				metrix.Label{Key: "api_key", Value: "key-2"},
+			))
+			cc.CommitCycleSuccess()
+
+			plan, err := buildPlan(e, store.Read())
+			require.NoError(t, err)
+
+			update := findUpdateAction(plan)
+			require.NotNil(t, update)
+			require.Len(t, update.Values, 1)
+			assert.Equal(t, "last_used", update.Values[0].Name)
+			assert.Equal(t, tc.want, update.Values[0].Float64)
+			assert.Equal(t, tc.wantFloat, update.Values[0].IsFloat)
+
+			if tc.checkScratchReset {
+				cc.BeginCycle()
+				lastUsed.Observe(10, m.LabelSet(
+					metrix.Label{Key: "team", Value: "team-a"},
+					metrix.Label{Key: "api_key", Value: "key-1"},
+				))
+				lastUsed.Observe(20, m.LabelSet(
+					metrix.Label{Key: "team", Value: "team-a"},
+					metrix.Label{Key: "api_key", Value: "key-2"},
+				))
+				cc.CommitCycleSuccess()
+
+				nextPlan, err := buildPlan(e, store.Read())
+				require.NoError(t, err)
+				nextUpdate := findUpdateAction(nextPlan)
+				require.NotNil(t, nextUpdate)
+				require.Len(t, nextUpdate.Values, 1)
+				assert.Equal(t, float64(15), nextUpdate.Values[0].Float64,
+					"scratch aggregation state must reset between successful snapshots")
+			}
+		})
+	}
+}
+
+func TestDimBuildEntryAggregation(t *testing.T) {
+	tests := map[string]struct {
+		aggregation program.Aggregation
+		values      []metrix.SampleValue
+		want        float64
+		wantNaN     bool
+		wantPosInf  bool
+	}{
+		"sum":                         {aggregation: program.AggregationSum, values: []metrix.SampleValue{5, 3, -1}, want: 7},
+		"sum propagates NaN":          {aggregation: program.AggregationSum, values: []metrix.SampleValue{5, metrix.SampleValue(math.NaN())}, wantNaN: true},
+		"min":                         {aggregation: program.AggregationMin, values: []metrix.SampleValue{5, -1, 3}, want: -1},
+		"min ignores trailing NaN":    {aggregation: program.AggregationMin, values: []metrix.SampleValue{5, metrix.SampleValue(math.NaN())}, want: 5},
+		"min replaces leading NaN":    {aggregation: program.AggregationMin, values: []metrix.SampleValue{metrix.SampleValue(math.NaN()), 5}, want: 5},
+		"max":                         {aggregation: program.AggregationMax, values: []metrix.SampleValue{5, 9, 3}, want: 9},
+		"max ignores trailing NaN":    {aggregation: program.AggregationMax, values: []metrix.SampleValue{5, metrix.SampleValue(math.NaN())}, want: 5},
+		"max replaces leading NaN":    {aggregation: program.AggregationMax, values: []metrix.SampleValue{metrix.SampleValue(math.NaN()), 5}, want: 5},
+		"avg preserves fraction":      {aggregation: program.AggregationAvg, values: []metrix.SampleValue{1, 2}, want: 1.5},
+		"avg avoids finite overflow":  {aggregation: program.AggregationAvg, values: []metrix.SampleValue{math.MaxFloat64, math.MaxFloat64}, want: math.MaxFloat64},
+		"avg keeps positive infinity": {aggregation: program.AggregationAvg, values: []metrix.SampleValue{metrix.SampleValue(math.Inf(1)), 5}, wantPosInf: true},
+		"avg opposite infinities":     {aggregation: program.AggregationAvg, values: []metrix.SampleValue{metrix.SampleValue(math.Inf(1)), metrix.SampleValue(math.Inf(-1))}, wantNaN: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NotEmpty(t, tc.values)
+			entry := dimBuildEntry{
+				observations: 1,
+				value:        tc.values[0],
+				dimensionState: dimensionState{
+					aggregation: tc.aggregation,
+				},
+			}
+			for _, value := range tc.values[1:] {
+				entry.aggregate(value)
+			}
+
+			switch {
+			case tc.wantNaN:
+				assert.True(t, math.IsNaN(entry.value))
+			case tc.wantPosInf:
+				assert.True(t, math.IsInf(entry.value, 1))
+			default:
+				assert.Equal(t, tc.want, float64(entry.value))
+			}
+		})
+	}
 }
 
 func runTestBuildPlanEmptyEmissionAndScratchReusePruneAcrossCycles(t *testing.T) {

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -528,6 +528,7 @@ charts:
     context: <chart context>
     units: <units string>
     algorithm: <absolute|incremental>
+    aggregation: <sum|min|max|avg>
     type: <line|area|stacked|heatmap>
     priority: <int>
     label_promotion: [<label>, ...]
@@ -551,6 +552,7 @@ charts:
 | `context`         | string        | **yes**  |                        | Chart context leaf. Combined with context namespaces.                        |
 | `units`           | string        | **yes**  |                        | Chart units (e.g., `queries/s`, `bytes`, `percentage`).                      |
 | `algorithm`       | string        | no       | inferred from metrics  | `absolute` or `incremental`. If omitted, inferred from metric suffixes.      |
+| `aggregation`     | string        | no       | `sum`                  | Reducer applied to every dimension in the chart.                             |
 | `type`            | string        | no       | `line`                 | `line`, `area`, `stacked`, or `heatmap`. Histogram bucket charts are forced to `heatmap`. |
 | `priority`        | int           | no       | `70000`                | Chart ordering priority in the dashboard (`0` = use engine default `70000`). |
 | `label_promotion` | array[string] | no       | from `chart_defaults`  | Labels to promote as chart labels (for filtering/grouping in UI). Entries must be non-empty label keys. |
@@ -713,6 +715,35 @@ dimensions:
 > - **Omit both** — the engine infers the name automatically for histogram buckets (`le`), summary quantiles (`quantile`), and statesets.
 >
 > `name` and `name_from_label` are mutually exclusive. Duplicate static `name` values within the same chart are rejected.
+
+#### aggregation
+
+Aggregation applies when multiple source series map to the same rendered chart ID and dimension name during one
+successful collection snapshot. This commonly happens when `instances.by_labels` intentionally omits high-cardinality
+labels. The source series keep their full identity in `metrix`; only their chart output is reduced.
+
+| Value | Meaning                                  | Typical use                                                |
+|-------|------------------------------------------|------------------------------------------------------------|
+| `sum` | Add all observations.                   | Additive counters, totals, histogram buckets/counts/sums.  |
+| `min` | Keep the smallest non-NaN observation.  | Oldest timestamp, lowest limit, "all" for 0/1 states.      |
+| `max` | Keep the largest non-NaN observation.   | Latest timestamp, highest limit, "any" for 0/1 states.     |
+| `avg` | Compute the unweighted arithmetic mean. | Typical gauge value, fraction active for 0/1 states.       |
+
+Set `aggregation` on the chart; it applies to every dimension in that chart. When omitted, the effective reducer is
+`sum`, preserving historical behavior. A chart cannot mix reducers; use separate charts when dimensions require different
+aggregation semantics. `avg` always emits floating-point dimensions, even when all inputs are integers. `sum` and `avg`
+propagate NaN; `min` and `max` ignore NaN when a finite observation exists. All non-finite final values render as gaps.
+
+The engine cannot infer aggregation from the metric kind: gauges can represent additive stocks, states, timestamps,
+limits, or averages. Authors must choose from the metric's meaning. Additional constraints:
+
+- `avg` is unweighted. Averaging pre-aggregated averages does not produce a global weighted average.
+- Histogram buckets, counts, and sums are mergeable with `sum`; other reducers do not produce a merged histogram.
+- Summary quantiles cannot be merged into a global quantile with these reducers.
+- Reduction happens before Netdata applies the dimension multiplier/divisor and chart algorithm. A negative multiplier
+  reverses the displayed ordering of `min` and `max`. Non-sum reduction of cumulative counter totals can produce
+  misleading deltas when source membership changes.
+- Aggregation reduces emitted chart cardinality only. Every source series is still collected, stored, and routed.
 
 #### selectors
 
@@ -1069,6 +1100,7 @@ All rules below produce semantic validation errors unless noted:
 | `group.metrics[]` entries must not be empty; no duplicates within same group            | semantic                        |
 | `chart.title`, `chart.context`, `chart.units` must be non-empty                         | semantic                        |
 | `chart.algorithm` must be `absolute` or `incremental` (when specified)                  | semantic                        |
+| `chart.aggregation` must be `sum`, `min`, `max`, or `avg` (when specified)               | semantic                        |
 | `chart.type` must be `line`, `area`, `stacked`, or `heatmap` (when specified)           | semantic                        |
 | `dimension.selector` must include explicit metric name (prefix before `{`)              | semantic                        |
 | Selector metric must be visible in current group metric scope                           | semantic                        |

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -740,10 +740,11 @@ limits, or averages. Authors must choose from the metric's meaning. Additional c
 - `avg` is unweighted. Averaging pre-aggregated averages does not produce a global weighted average.
 - Histogram buckets, counts, and sums are mergeable with `sum`; other reducers do not produce a merged histogram.
 - Summary quantiles cannot be merged into a global quantile with these reducers.
-- Reduction happens before Netdata applies the dimension multiplier/divisor and chart algorithm. A negative multiplier
-  reverses the displayed ordering of `min` and `max`. Non-sum reduction of cumulative counter totals can produce
+- Reduction happens before Netdata applies the dimension multiplier/divisor and chart algorithm. A negative multiplier or
+  divisor reverses the displayed ordering of `min` and `max`. Non-sum reduction of cumulative counter totals can produce
   misleading deltas when source membership changes.
-- Aggregation reduces emitted chart cardinality only. Every source series is still collected, stored, and routed.
+- `instances.by_labels` controls emitted chart cardinality; `aggregation` only selects the value for collisions created by
+  that projection. Every source series is still collected, stored, and routed.
 
 #### selectors
 

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -740,9 +740,9 @@ limits, or averages. Authors must choose from the metric's meaning. Additional c
 - `avg` is unweighted. Averaging pre-aggregated averages does not produce a global weighted average.
 - Histogram buckets, counts, and sums are mergeable with `sum`; other reducers do not produce a merged histogram.
 - Summary quantiles cannot be merged into a global quantile with these reducers.
-- Reduction happens before Netdata applies the dimension multiplier/divisor and chart algorithm. A negative multiplier or
-  divisor reverses the displayed ordering of `min` and `max`. Non-sum reduction of cumulative counter totals can produce
-  misleading deltas when source membership changes.
+- Reduction happens before Netdata applies the dimension multiplier/divisor and chart algorithm. An overall negative
+  multiplier/divisor scale reverses the displayed ordering of `min` and `max`. Non-sum reduction of cumulative counter
+  totals can produce misleading deltas when source membership changes.
 - `instances.by_labels` controls emitted chart cardinality; `aggregation` only selects the value for collisions created by
   that projection. Every source series is still collected, stored, and routed.
 

--- a/src/go/plugin/framework/charttpl/clone_test.go
+++ b/src/go/plugin/framework/charttpl/clone_test.go
@@ -71,6 +71,7 @@ func richGroup() Group {
 				Title:         "Chart A",
 				Context:       "chart_a",
 				Units:         "units/s",
+				Aggregation:   AggregationMax,
 				Type:          "line",
 				LabelPromoted: []string{"zone"},
 				Instances:     &Instances{ByLabels: []string{"id"}},

--- a/src/go/plugin/framework/charttpl/config_schema.json
+++ b/src/go/plugin/framework/charttpl/config_schema.json
@@ -219,6 +219,15 @@
             "incremental"
           ]
         },
+        "aggregation": {
+          "type": "string",
+          "enum": [
+            "sum",
+            "min",
+            "max",
+            "avg"
+          ]
+        },
         "type": {
           "type": "string",
           "enum": [

--- a/src/go/plugin/framework/charttpl/spec.go
+++ b/src/go/plugin/framework/charttpl/spec.go
@@ -9,6 +9,16 @@ import (
 // VersionV1 is the supported chart-template schema version.
 const VersionV1 = "v1"
 
+// Aggregation defines how source series that map to one chart dimension combine.
+type Aggregation string
+
+const (
+	AggregationSum Aggregation = "sum"
+	AggregationMin Aggregation = "min"
+	AggregationMax Aggregation = "max"
+	AggregationAvg Aggregation = "avg"
+)
+
 // Spec is the user-facing chart template file.
 type Spec struct {
 	Version          string  `yaml:"version" json:"version"`
@@ -64,15 +74,16 @@ type ChartDefaults struct {
 
 // Chart describes one chart template in compact DSL form.
 type Chart struct {
-	ID            string   `yaml:"id,omitempty" json:"id,omitempty"`
-	Title         string   `yaml:"title" json:"title"`
-	Family        string   `yaml:"family,omitempty" json:"family,omitempty"`
-	Context       string   `yaml:"context" json:"context"`
-	Units         string   `yaml:"units" json:"units"`
-	Algorithm     string   `yaml:"algorithm,omitempty" json:"algorithm,omitempty"`
-	Type          string   `yaml:"type,omitempty" json:"type,omitempty"`
-	Priority      int      `yaml:"priority,omitempty" json:"priority,omitempty"`
-	LabelPromoted []string `yaml:"label_promotion,omitempty" json:"label_promotion,omitempty"`
+	ID            string      `yaml:"id,omitempty" json:"id,omitempty"`
+	Title         string      `yaml:"title" json:"title"`
+	Family        string      `yaml:"family,omitempty" json:"family,omitempty"`
+	Context       string      `yaml:"context" json:"context"`
+	Units         string      `yaml:"units" json:"units"`
+	Algorithm     string      `yaml:"algorithm,omitempty" json:"algorithm,omitempty"`
+	Aggregation   Aggregation `yaml:"aggregation,omitempty" json:"aggregation,omitempty"`
+	Type          string      `yaml:"type,omitempty" json:"type,omitempty"`
+	Priority      int         `yaml:"priority,omitempty" json:"priority,omitempty"`
+	LabelPromoted []string    `yaml:"label_promotion,omitempty" json:"label_promotion,omitempty"`
 
 	Instances *Instances `yaml:"instances,omitempty" json:"instances,omitempty"`
 

--- a/src/go/plugin/framework/charttpl/spec_test.go
+++ b/src/go/plugin/framework/charttpl/spec_test.go
@@ -71,6 +71,7 @@ groups:
         context: queries_total
         units: queries/s
         algorithm: incremental
+        aggregation: min
         dimensions:
           - selector: mysql_queries_total
             name: total
@@ -85,6 +86,7 @@ groups:
 				require.Len(t, spec.Groups, 1)
 				require.Len(t, spec.Groups[0].Charts, 1)
 				assert.Equal(t, "line", spec.Groups[0].Charts[0].Type)
+				assert.Equal(t, AggregationMin, spec.Groups[0].Charts[0].Aggregation)
 				require.Len(t, spec.Groups[0].Charts[0].Dimensions, 1)
 				require.NotNil(t, spec.Groups[0].Charts[0].Dimensions[0].Options)
 				assert.Equal(t, -8, spec.Groups[0].Charts[0].Dimensions[0].Options.Multiplier)
@@ -384,6 +386,9 @@ func TestConfigSchemaJSON(t *testing.T) {
 	chartLabelPromotionItems, ok := chartLabelPromotion["items"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, `\S`, chartLabelPromotionItems["pattern"])
+	chartAggregation, ok := chartProps["aggregation"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"sum", "min", "max", "avg"}, chartAggregation["enum"])
 
 	chartDefaults, ok := defs["chart_defaults"].(map[string]any)
 	require.True(t, ok)

--- a/src/go/plugin/framework/charttpl/validate.go
+++ b/src/go/plugin/framework/charttpl/validate.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	validAlgorithms = []string{"absolute", "incremental"}
-	validChartTypes = []string{"line", "area", "stacked", "heatmap"}
+	validAlgorithms   = []string{"absolute", "incremental"}
+	validChartTypes   = []string{"line", "area", "stacked", "heatmap"}
+	validAggregations = []Aggregation{AggregationSum, AggregationMin, AggregationMax, AggregationAvg}
 )
 
 // Validation contains immutable runtime artifacts derived while validating a
@@ -143,6 +144,9 @@ func validateChartCore(chart Chart, path string) error {
 	if chart.Algorithm != "" && !slices.Contains(validAlgorithms, chart.Algorithm) {
 		errs = append(errs, semErr(path+".algorithm", fmt.Sprintf("must be one of %v", validAlgorithms)))
 	}
+	if err := validateAggregation(chart.Aggregation, path+".aggregation"); err != nil {
+		errs = append(errs, err)
+	}
 	if chart.Type != "" && !slices.Contains(validChartTypes, chart.Type) {
 		errs = append(errs, semErr(path+".type", fmt.Sprintf("must be one of %v", validChartTypes)))
 	}
@@ -256,6 +260,13 @@ func validateDimensions(dimensions []Dimension, path string, effectiveMetrics ma
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func validateAggregation(aggregation Aggregation, path string) error {
+	if aggregation == "" || slices.Contains(validAggregations, aggregation) {
+		return nil
+	}
+	return semErr(path, fmt.Sprintf("must be one of %v", validAggregations))
 }
 
 func validateEngine(engine *Engine) ([]ValidatedAutogenRule, error) {

--- a/src/go/plugin/framework/charttpl/validate_test.go
+++ b/src/go/plugin/framework/charttpl/validate_test.go
@@ -1058,3 +1058,39 @@ func TestSpecValidateRejectsNegationOnlyInstances(t *testing.T) {
 		})
 	}
 }
+
+func TestSpecValidateChartAggregation(t *testing.T) {
+	for _, aggregation := range []Aggregation{"", AggregationSum, AggregationMin, AggregationMax, AggregationAvg} {
+		t.Run("accepts_"+string(aggregation), func(t *testing.T) {
+			spec := validationSpec()
+			spec.Groups[0].Charts[0].Aggregation = aggregation
+			require.NoError(t, spec.Validate())
+		})
+	}
+
+	spec := validationSpec()
+	spec.Groups[0].Charts[0].Aggregation = Aggregation("median")
+	err := spec.Validate()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "groups[0].charts[0].aggregation")
+	assert.ErrorContains(t, err, "must be one of [sum min max avg]")
+}
+
+func validationSpec() Spec {
+	return Spec{
+		Version: VersionV1,
+		Groups: []Group{{
+			Family:  "Service",
+			Metrics: []string{"service_metric"},
+			Charts: []Chart{{
+				Title:   "Service metric",
+				Context: "service_metric",
+				Units:   "value",
+				Dimensions: []Dimension{{
+					Selector: "service_metric",
+					Name:     "value",
+				}},
+			}},
+		}},
+	}
+}

--- a/src/go/plugin/go.d/collector/prometheus/chart_template_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/chart_template_test.go
@@ -189,3 +189,84 @@ http_request_duration_seconds_count 4
 	assert.NotContains(t, created[0].ChartID, "_sum")
 	assert.NotContains(t, created[0].ChartID, "_count")
 }
+
+func TestBuildMergedChartTemplateAggregatesProjectedPrometheusSeries(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"litellm": `
+match: "litellm_api_key_last_used_timestamp_seconds"
+template:
+  family: LiteLLM
+  metrics:
+    - litellm_api_key_last_used_timestamp_seconds
+  charts:
+    - id: api_key_last_used
+      title: API key last used
+      context: api_key_last_used
+      units: seconds
+      aggregation: max
+      instances:
+        by_labels: [team]
+      dimensions:
+        - selector: litellm_api_key_last_used_timestamp_seconds
+          name: latest
+`,
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`
+# TYPE litellm_api_key_last_used_timestamp_seconds gauge
+litellm_api_key_last_used_timestamp_seconds{team="team-a",api_key="key-1"} 100
+litellm_api_key_last_used_timestamp_seconds{team="team-a",api_key="key-2"} 200
+`))
+	}))
+	defer srv.Close()
+
+	collector := New()
+	collector.URL = srv.URL
+	collector.Profiles = ProfilesConfig{
+		Mode: profilesModeExact,
+		ModeExact: &ProfilesModeConfig{
+			Entries: []ProfileEntryConfig{{Name: "litellm"}},
+		},
+	}
+	collector.loadProfileCatalog = func() (promprofiles.Catalog, error) {
+		return catalog, nil
+	}
+	require.NoError(t, collector.Init(context.Background()))
+	require.NoError(t, collector.Check(context.Background()))
+
+	cc, ok := metrix.AsCycleManagedStore(collector.MetricStore())
+	require.True(t, ok)
+	cc.CycleController().BeginCycle()
+	require.NoError(t, collector.Collect(context.Background()))
+	require.NoError(t, cc.CycleController().CommitCycleSuccess())
+
+	reader := collector.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	_, ok = reader.Value("litellm_api_key_last_used_timestamp_seconds", metrix.Labels{
+		"team": "team-a", "api_key": "key-1",
+	})
+	assert.True(t, ok, "the first full-label source series must remain in metrix")
+	_, ok = reader.Value("litellm_api_key_last_used_timestamp_seconds", metrix.Labels{
+		"team": "team-a", "api_key": "key-2",
+	})
+	assert.True(t, ok, "the second full-label source series must remain in metrix")
+
+	engine, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, engine.LoadYAML([]byte(collector.ChartTemplateYAML()), 1))
+
+	attempt, err := engine.PreparePlan(reader)
+	require.NoError(t, err)
+	defer attempt.Abort()
+	plan := attempt.Plan()
+
+	var updates []chartengine.UpdateChartAction
+	for _, action := range plan.Actions {
+		if update, ok := action.(chartengine.UpdateChartAction); ok {
+			updates = append(updates, update)
+		}
+	}
+	require.Len(t, updates, 1)
+	require.Len(t, updates[0].Values, 1)
+	assert.Equal(t, "latest", updates[0].Values[0].Name)
+	assert.Equal(t, float64(200), updates[0].Values[0].Float64)
+}

--- a/src/go/plugin/go.d/collector/prometheus/profile-format.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-format.md
@@ -63,6 +63,7 @@ template:                   # REQUIRED. One chart-template group; at least one c
                                         # segment is dropped -- see "How profiles work")
           units: requests/s
           algorithm: incremental        # counters are charted as rates
+          aggregation: sum              # omitted labels are additive for this chart
           instances:
             by_labels: [listener]       # one chart instance per "listener" label value
           dimensions:
@@ -264,6 +265,20 @@ dimension, presentation, and selector field. Prometheus profiles add these rules
   - a summary `bar` is selectable as `bar` (per-`quantile` dimensions), `bar_count`, and `bar_sum`;
   - series keep their scraped labels, which is what `instances.by_labels`, `name_from_label`, and label selectors work
     on.
+- **Choose `aggregation` when an instance identity omits labels.** Multiple full-label series can then map to the same
+  rendered chart and dimension. Set it on the chart; it applies to all dimensions in that chart. When omitted, the reducer
+  is `sum`. Use separate charts when metrics require different reducers. Use `min`, `max`, or `avg` when the metric is not
+  additive:
+  - `sum`: additive counters/gauges and histogram buckets, counts, or sums;
+  - `max`: latest timestamp or "any source active" for a 0/1 state;
+  - `min`: oldest timestamp, lowest limit, or "all sources active" for a 0/1 state;
+  - `avg`: unweighted arithmetic mean or fraction active for a 0/1 state; it emits floating-point values.
+
+  Metric type does not determine the right reducer: Prometheus gauges can be stocks, states, timestamps, limits, or
+  averages. Summary quantiles cannot be merged into a global quantile; `avg` is not a weighted mean; and non-sum
+  reduction of cumulative counters can produce misleading rates when source membership changes. Aggregation lowers
+  emitted chart cardinality, but every scraped series is still processed and retained in the collector's metric store.
+  This chart reduction is separate from Prometheus relabeling: it does not remove or rewrite stored series labels.
 - **Only collected series can be charted.** `*_info` families are skipped. Untyped families are collected only when the
   name ends in `_total` (treated as a counter) or the job's `fallback_type` option maps them to a gauge or counter
   (`fallback_type.gauge` takes precedence, so a `_total`-suffixed name mapped to gauge is charted as a gauge). A profile

--- a/src/go/plugin/go.d/collector/prometheus/profile-format.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-format.md
@@ -276,9 +276,10 @@ dimension, presentation, and selector field. Prometheus profiles add these rules
 
   Metric type does not determine the right reducer: Prometheus gauges can be stocks, states, timestamps, limits, or
   averages. Summary quantiles cannot be merged into a global quantile; `avg` is not a weighted mean; and non-sum
-  reduction of cumulative counters can produce misleading rates when source membership changes. Aggregation lowers
-  emitted chart cardinality, but every scraped series is still processed and retained in the collector's metric store.
-  This chart reduction is separate from Prometheus relabeling: it does not remove or rewrite stored series labels.
+  reduction of cumulative counters can produce misleading rates when source membership changes. `instances.by_labels`
+  lowers emitted chart cardinality; `aggregation` only selects the value for resulting collisions. Every scraped series is
+  still processed and retained in the collector's metric store. This chart reduction is separate from Prometheus
+  relabeling: it does not remove or rewrite stored series labels.
 - **Only collected series can be charted.** `*_info` families are skipped. Untyped families are collected only when the
   name ends in `_total` (treated as a counter) or the job's `fallback_type` option maps them to a gauge or counter
   (`fallback_type.gauge` takes precedence, so a `_total`-suffixed name mapped to gauge is charted as a gauge). A profile

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile_test.go
@@ -49,6 +49,56 @@ template:
           name: d0
 `,
 		},
+		"valid chart aggregation": {
+			yaml: `match: "a_*"
+template:
+  family: fam
+  metrics:
+    - a_timestamp
+  charts:
+    - title: Title
+      context: ctx
+      units: seconds
+      aggregation: max
+      dimensions:
+        - selector: a_timestamp
+          name: latest
+`,
+		},
+		"rejects dimension-level aggregation": {
+			yaml: `match: "a_*"
+template:
+  family: fam
+  metrics:
+    - a_timestamp
+  charts:
+    - title: Title
+      context: ctx
+      units: seconds
+      dimensions:
+        - selector: a_timestamp
+          name: latest
+          aggregation: max
+`,
+			wantErr: true,
+		},
+		"invalid chart aggregation": {
+			yaml: `match: "a_*"
+template:
+  family: fam
+  metrics:
+    - a_timestamp
+  charts:
+    - title: Title
+      context: ctx
+      units: seconds
+      aggregation: median
+      dimensions:
+        - selector: a_timestamp
+          name: latest
+`,
+			wantErr: true,
+		},
 		"invalid app format": {
 			yaml: `match: "a_*"
 app: "Bad App!"


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds chart-level series aggregation to the `go.d` chart engine so charts can reduce many source series into one dimension using `sum`, `min`, `max`, or `avg`. Improves performance and correctness with an allocation-free path and a numerically stable `avg` that handles NaN/Inf and always emits floats.

- **New Features**
  - Template: new `aggregation` on charts (`sum|min|max|avg`), applied to all dimensions; default `sum`.
  - Compiler/Runtime: aggregation carried per dimension; matcher forces float for `avg`.
  - Planner: reduces collisions per successful build; `avg` is unweighted, stable, NaN/Inf-aware; `min`/`max` ignore NaN when finite exists.
  - Semantics: reduction runs before multiplier/divisor and algorithm; negative scaling reverses `min`/`max`; autogen routes stay `sum`.
  - Validation/Schema/Docs: `aggregation` added to schema and docs; dimension-level aggregation is rejected; Prometheus profile format updated with guidance.
  - Tests/Benchmarks: coverage for reducers, NaN/Inf, zero-allocation and 64-bit size budget checks, and high fan-in aggregation benchmarks.

- **Migration**
  - No action needed; existing charts keep `sum`.
  - Set `aggregation` when `instances.by_labels` collapses labels and metrics aren’t additive.
  - Constraints: histogram buckets/counts/sums merge only with `sum`; quantiles aren’t mergeable; non-`sum` on counters can skew rates if membership changes.

<sup>Written for commit 8495e7e2b66b5c0ca28388ca813802a86263e45c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

