### PR TITLE
fix: validate host prefix format to prevent '%' in printf strings

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -520,6 +520,7 @@ int netdata_main(int argc, char **argv) {
                             if (unittest_waiting_queue()) return 1;
                             if (rw_spinlock_unittest()) return 1;
                             if (uuidmap_unittest()) return 1;
+                            if (paths_unittest()) return 1;
 #ifdef HAVE_LIBBACKTRACE
                             if (stacktrace_unittest()) return 1;
 #endif

--- a/src/libnetdata/log/nd_log-init.c
+++ b/src/libnetdata/log/nd_log-init.c
@@ -96,7 +96,10 @@ void nd_log_initialize_for_external_plugins(const char *name) {
 
     if(!netdata_configured_host_prefix) {
         s = getenv("NETDATA_HOST_PREFIX");
-        if(s && *s)
+        // reject a '%' here too - this assignment bypasses
+        // verify_netdata_host_prefix(), and the prefix ends up inside printf
+        // format strings.
+        if(s && *s && !strchr(s, '%'))
             netdata_configured_host_prefix = (char *)s;
     }
 

--- a/src/libnetdata/log/nd_log-init.c
+++ b/src/libnetdata/log/nd_log-init.c
@@ -97,8 +97,8 @@ void nd_log_initialize_for_external_plugins(const char *name) {
     if(!netdata_configured_host_prefix) {
         s = getenv("NETDATA_HOST_PREFIX");
         // reject a '%' here too - this assignment bypasses
-        // verify_netdata_host_prefix(), and the prefix ends up inside printf
-        // format strings.
+        // verify_netdata_host_prefix(); see the call sites listed there for why
+        // a '%' in the prefix is a format-string hazard.
         if(s && *s && !strchr(s, '%'))
             netdata_configured_host_prefix = (char *)s;
     }

--- a/src/libnetdata/log/nd_log-init.c
+++ b/src/libnetdata/log/nd_log-init.c
@@ -96,10 +96,9 @@ void nd_log_initialize_for_external_plugins(const char *name) {
 
     if(!netdata_configured_host_prefix) {
         s = getenv("NETDATA_HOST_PREFIX");
-        // reject a '%' here too - this assignment bypasses
-        // verify_netdata_host_prefix(); see the call sites listed there for why
-        // a '%' in the prefix is a format-string hazard.
-        if(s && *s && !strchr(s, '%'))
+        // this assignment bypasses verify_netdata_host_prefix(), so apply the
+        // same rule here - see netdata_host_prefix_has_format_specifier().
+        if(s && *s && !netdata_host_prefix_has_format_specifier(s))
             netdata_configured_host_prefix = (char *)s;
     }
 

--- a/src/libnetdata/paths/paths.c
+++ b/src/libnetdata/paths/paths.c
@@ -67,6 +67,17 @@ int verify_netdata_host_prefix(bool log_msg) {
 
     strncpyz(path, netdata_configured_host_prefix, sizeof(path) - 1);
 
+    // the host prefix is concatenated into printf format strings (the various
+    // "path to ..." templates), so a '%' in it would be parsed as a conversion
+    // directive. a real host prefix never contains one.
+    // check the original, not the truncated copy in path[] - on success the
+    // untruncated value is what stays in netdata_configured_host_prefix.
+    if(strchr(netdata_configured_host_prefix, '%')) {
+        errno = EINVAL;
+        reason = "contains '%'";
+        goto failed;
+    }
+
     struct stat sb;
     if (stat(path, &sb) == -1) {
         reason = "failed to stat()";
@@ -280,4 +291,91 @@ void recursive_config_double_dir_load(const char *user_path, const char *stock_p
 
     freez(udir);
     freez(sdir);
+}
+
+int paths_unittest(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    // a prefix whose only '%' sits past the FILENAME_MAX truncation that
+    // verify_netdata_host_prefix() applies internally. it must still be
+    // rejected, because the check looks at the original string, not the copy.
+    char long_prefix[FILENAME_MAX + 16];
+    memset(long_prefix, 'a', sizeof(long_prefix));
+    long_prefix[0] = '/';
+    long_prefix[sizeof(long_prefix) - 3] = '%';
+    long_prefix[sizeof(long_prefix) - 2] = 's';
+    long_prefix[sizeof(long_prefix) - 1] = '\0';
+
+    // the host prefix ends up inside printf format strings, so a '%' in it must
+    // never survive verification. "/" is here to prove the '%' check did not
+    // start rejecting working prefixes.
+    const struct {
+        const char *name;
+        const char *prefix;
+        bool accept;
+    } cases[] = {
+        { "empty",            "",           true  },
+#if !defined(OS_WINDOWS)
+        // needs a real procfs+sysfs under the prefix; on macOS/FreeBSD those
+        // checks are compiled out, but native Windows would probe and fail
+        { "root",             "/",          true  },
+#endif
+        { "trailing %s",      "/host%s",    false },
+        { "bare %n",          "%n",         false },
+        { "embedded %",       "/a%b",       false },
+        { "escaped %%",       "/host%%",    false },
+        { "% past truncation", long_prefix, false },
+    };
+
+    const char *saved = netdata_configured_host_prefix;
+    int errors = 0;
+
+    for(size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        netdata_configured_host_prefix = cases[i].prefix;
+        errno_clear();
+        int rc = verify_netdata_host_prefix(false);
+        int err = errno;
+
+        if((rc == 0) != cases[i].accept) {
+            fprintf(stderr, "  FAILED %s: '%s' expected %s, got rc=%d\n",
+                    cases[i].name, cases[i].prefix, cases[i].accept ? "accepted" : "rejected", rc);
+            if(cases[i].accept && *cases[i].prefix)
+                fprintf(stderr, "         (is /proc or /sys mounted? this case needs both)\n");
+            errors++;
+            continue;
+        }
+
+        if(cases[i].accept) {
+            // an accepted prefix must survive untouched
+            if(strcmp(netdata_configured_host_prefix, cases[i].prefix) != 0) {
+                fprintf(stderr, "  FAILED %s: '%s' accepted but prefix changed to '%s'\n",
+                        cases[i].name, cases[i].prefix, netdata_configured_host_prefix);
+                errors++;
+            }
+        }
+        else {
+            // a rejected prefix must be cleared, because runtime-paths.c
+            // discards the return value and relies on this
+            if(*netdata_configured_host_prefix) {
+                fprintf(stderr, "  FAILED %s: '%s' rejected but prefix left as '%s'\n",
+                        cases[i].name, cases[i].prefix, netdata_configured_host_prefix);
+                errors++;
+            }
+
+            // none of these paths exist, so stat() would reject them anyway.
+            // assert the rejection came from the '%' check (EINVAL) and not
+            // from stat() (ENOENT) - without this the whole table still passes
+            // with the '%' check deleted.
+            if(err != EINVAL) {
+                fprintf(stderr, "  FAILED %s: '%s' rejected by errno=%d, expected EINVAL (%d)\n",
+                        cases[i].name, cases[i].prefix, err, EINVAL);
+                errors++;
+            }
+        }
+    }
+
+    netdata_configured_host_prefix = saved;
+
+    fprintf(stderr, "%s() %s\n", __FUNCTION__, errors ? "FAILED" : "passed");
+    return errors;
 }

--- a/src/libnetdata/paths/paths.c
+++ b/src/libnetdata/paths/paths.c
@@ -54,6 +54,33 @@ static int is_sysfs(const char *path, char **reason) {
     return 0;
 }
 
+// most consumers pass the host prefix as a %s argument, where a '%' would be
+// harmless. these do not: they prepend it to a path template that is later
+// used AS the format string, so a '%' in it becomes a conversion directive.
+//
+//   proc_diskstats.c  path_to_sys_block_device        "<prefix>/sys/block/%s"
+//                     path_to_sys_block_device_bcache
+//                     path_to_sys_devices_virtual_block_device
+//                     path_to_sys_dev_block_major_minor_string
+//   proc_stat.c       core_throttle_count_filename, package_throttle_count_filename,
+//                     scaling_cur_freq_filename, time_in_state_filename,
+//                     cpuidle_name_filename, cpuidle_time_filename
+//   proc_net_dev.c    path_to_sys_devices_virtual_net, path_to_sys_class_net_speed,
+//                     and the _duplex/_operstate/_carrier/_mtu variants
+//   proc_mdstat.c     mismatch_cnt_filename
+//
+// each is consumed like snprintfz(buffer, FILENAME_MAX, path_to_sys_block_device, disk).
+// a prefix carrying its own '%s' consumes that single argument early, leaving
+// the template's real '%s' to dereference a vararg that was never passed;
+// '%n' would be a write primitive. even a plain trailing '%' yields an
+// undefined conversion ('%/'), which glibc and musl do not treat alike.
+//
+// a real host prefix never contains a '%'. supporting one would mean escaping
+// '%' -> '%%' at every template site above, not relaxing this rule.
+bool netdata_host_prefix_has_format_specifier(const char *prefix) {
+    return prefix && strchr(prefix, '%') != NULL;
+}
+
 int verify_netdata_host_prefix(bool log_msg) {
     if(!netdata_configured_host_prefix)
         netdata_configured_host_prefix = "";
@@ -67,33 +94,9 @@ int verify_netdata_host_prefix(bool log_msg) {
 
     strncpyz(path, netdata_configured_host_prefix, sizeof(path) - 1);
 
-    // most consumers pass the host prefix as a %s argument, where a '%' would be
-    // harmless. these do not: they prepend it to a path template that is later
-    // used AS the format string, so a '%' in it becomes a conversion directive.
-    //
-    //   proc_diskstats.c  path_to_sys_block_device        "<prefix>/sys/block/%s"
-    //                     path_to_sys_block_device_bcache
-    //                     path_to_sys_devices_virtual_block_device
-    //                     path_to_sys_dev_block_major_minor_string
-    //   proc_stat.c       core_throttle_count_filename, package_throttle_count_filename,
-    //                     scaling_cur_freq_filename, time_in_state_filename,
-    //                     cpuidle_name_filename, cpuidle_time_filename
-    //   proc_net_dev.c    path_to_sys_devices_virtual_net, path_to_sys_class_net_speed,
-    //                     and the _duplex/_operstate/_carrier/_mtu variants
-    //   proc_mdstat.c     mismatch_cnt_filename
-    //
-    // each is consumed like snprintfz(buffer, FILENAME_MAX, path_to_sys_block_device, disk).
-    // a prefix carrying its own '%s' consumes that single argument early, leaving
-    // the template's real '%s' to dereference a vararg that was never passed;
-    // '%n' would be a write primitive. even a plain trailing '%' yields an
-    // undefined conversion ('%/'), which glibc and musl do not treat alike.
-    //
-    // a real host prefix never contains a '%'. supporting one would mean escaping
-    // '%' -> '%%' at every template site above, not relaxing the check here.
-    //
     // check the original, not the truncated copy in path[] - on success the
     // untruncated value is what stays in netdata_configured_host_prefix.
-    if(strchr(netdata_configured_host_prefix, '%')) {
+    if(netdata_host_prefix_has_format_specifier(netdata_configured_host_prefix)) {
         errno = EINVAL;
         reason = "contains '%'";
         goto failed;
@@ -327,40 +330,39 @@ int paths_unittest(void) {
     long_prefix[sizeof(long_prefix) - 2] = 's';
     long_prefix[sizeof(long_prefix) - 1] = '\0';
 
-    // accepting a non-empty prefix requires a real procfs and sysfs under it,
-    // which minimal or chrooted environments may not have. probe with the same
-    // predicates verify_netdata_host_prefix() uses, so such a case is skipped
-    // instead of failing on something unrelated to '%' validation.
+    // "/" is accepted only where a real procfs and sysfs exist under it, which
+    // minimal or chrooted environments may not have. probe with the same
+    // predicates verify_netdata_host_prefix() uses, so the expectation is
+    // computed rather than assumed and the case stays a real assertion in every
+    // environment instead of testing host mount availability.
     bool host_mounts_available = is_procfs("/proc", NULL) == 0 && is_sysfs("/sys", NULL) == 0;
 
     // the host prefix ends up inside printf format strings, so a '%' in it must
     // never survive verification. "/" is here to prove the '%' check did not
     // start rejecting working prefixes.
+    // expect_einval marks the cases that must be rejected by the '%' check
+    // itself: none of those paths exist, so stat() would reject them anyway, and
+    // without asserting the errno the whole table still passes with the '%'
+    // check deleted.
     const struct {
         const char *name;
         const char *prefix;
         bool accept;
-        bool needs_host_mounts;
+        bool expect_einval;
     } cases[] = {
-        { "empty",            "",           true,  false },
-        { "root",             "/",          true,  true  },
-        { "trailing %s",      "/host%s",    false, false },
-        { "bare %n",          "%n",         false, false },
-        { "embedded %",       "/a%b",       false, false },
-        { "escaped %%",       "/host%%",    false, false },
-        { "% past truncation", long_prefix, false, false },
+        { "empty",            "",           true,                  false },
+        { "root",             "/",          host_mounts_available, false },
+        { "trailing %s",      "/host%s",    false,                 true  },
+        { "bare %n",          "%n",         false,                 true  },
+        { "embedded %",       "/a%b",       false,                 true  },
+        { "escaped %%",       "/host%%",    false,                 true  },
+        { "% past truncation", long_prefix, false,                 true  },
     };
 
     const char *saved = netdata_configured_host_prefix;
     int errors = 0;
 
     for(size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
-        if(cases[i].needs_host_mounts && !host_mounts_available) {
-            fprintf(stderr, "  SKIPPED %s: '%s' (no procfs at /proc or sysfs at /sys)\n",
-                    cases[i].name, cases[i].prefix);
-            continue;
-        }
-
         netdata_configured_host_prefix = cases[i].prefix;
         errno_clear();
         int rc = verify_netdata_host_prefix(false);
@@ -390,11 +392,10 @@ int paths_unittest(void) {
                 errors++;
             }
 
-            // none of these paths exist, so stat() would reject them anyway.
             // assert the rejection came from the '%' check (EINVAL) and not
-            // from stat() (ENOENT) - without this the whole table still passes
-            // with the '%' check deleted.
-            if(err != EINVAL) {
+            // from stat() (ENOENT). "/" is exempt: when it lands here it was
+            // rejected by the procfs/sysfs probes, which report their own errno.
+            if(cases[i].expect_einval && err != EINVAL) {
                 fprintf(stderr, "  FAILED %s: '%s' rejected by errno=%d, expected EINVAL (%d)\n",
                         cases[i].name, cases[i].prefix, err, EINVAL);
                 errors++;

--- a/src/libnetdata/paths/paths.c
+++ b/src/libnetdata/paths/paths.c
@@ -67,9 +67,30 @@ int verify_netdata_host_prefix(bool log_msg) {
 
     strncpyz(path, netdata_configured_host_prefix, sizeof(path) - 1);
 
-    // the host prefix is concatenated into printf format strings (the various
-    // "path to ..." templates), so a '%' in it would be parsed as a conversion
-    // directive. a real host prefix never contains one.
+    // most consumers pass the host prefix as a %s argument, where a '%' would be
+    // harmless. these do not: they prepend it to a path template that is later
+    // used AS the format string, so a '%' in it becomes a conversion directive.
+    //
+    //   proc_diskstats.c  path_to_sys_block_device        "<prefix>/sys/block/%s"
+    //                     path_to_sys_block_device_bcache
+    //                     path_to_sys_devices_virtual_block_device
+    //                     path_to_sys_dev_block_major_minor_string
+    //   proc_stat.c       core_throttle_count_filename, package_throttle_count_filename,
+    //                     scaling_cur_freq_filename, time_in_state_filename,
+    //                     cpuidle_name_filename, cpuidle_time_filename
+    //   proc_net_dev.c    path_to_sys_devices_virtual_net, path_to_sys_class_net_speed,
+    //                     and the _duplex/_operstate/_carrier/_mtu variants
+    //   proc_mdstat.c     mismatch_cnt_filename
+    //
+    // each is consumed like snprintfz(buffer, FILENAME_MAX, path_to_sys_block_device, disk).
+    // a prefix carrying its own '%s' consumes that single argument early, leaving
+    // the template's real '%s' to dereference a vararg that was never passed;
+    // '%n' would be a write primitive. even a plain trailing '%' yields an
+    // undefined conversion ('%/'), which glibc and musl do not treat alike.
+    //
+    // a real host prefix never contains a '%'. supporting one would mean escaping
+    // '%' -> '%%' at every template site above, not relaxing the check here.
+    //
     // check the original, not the truncated copy in path[] - on success the
     // untruncated value is what stays in netdata_configured_host_prefix.
     if(strchr(netdata_configured_host_prefix, '%')) {

--- a/src/libnetdata/paths/paths.c
+++ b/src/libnetdata/paths/paths.c
@@ -306,6 +306,12 @@ int paths_unittest(void) {
     long_prefix[sizeof(long_prefix) - 2] = 's';
     long_prefix[sizeof(long_prefix) - 1] = '\0';
 
+    // accepting a non-empty prefix requires a real procfs and sysfs under it,
+    // which minimal or chrooted environments may not have. probe with the same
+    // predicates verify_netdata_host_prefix() uses, so such a case is skipped
+    // instead of failing on something unrelated to '%' validation.
+    bool host_mounts_available = is_procfs("/proc", NULL) == 0 && is_sysfs("/sys", NULL) == 0;
+
     // the host prefix ends up inside printf format strings, so a '%' in it must
     // never survive verification. "/" is here to prove the '%' check did not
     // start rejecting working prefixes.
@@ -313,24 +319,27 @@ int paths_unittest(void) {
         const char *name;
         const char *prefix;
         bool accept;
+        bool needs_host_mounts;
     } cases[] = {
-        { "empty",            "",           true  },
-#if !defined(OS_WINDOWS)
-        // needs a real procfs+sysfs under the prefix; on macOS/FreeBSD those
-        // checks are compiled out, but native Windows would probe and fail
-        { "root",             "/",          true  },
-#endif
-        { "trailing %s",      "/host%s",    false },
-        { "bare %n",          "%n",         false },
-        { "embedded %",       "/a%b",       false },
-        { "escaped %%",       "/host%%",    false },
-        { "% past truncation", long_prefix, false },
+        { "empty",            "",           true,  false },
+        { "root",             "/",          true,  true  },
+        { "trailing %s",      "/host%s",    false, false },
+        { "bare %n",          "%n",         false, false },
+        { "embedded %",       "/a%b",       false, false },
+        { "escaped %%",       "/host%%",    false, false },
+        { "% past truncation", long_prefix, false, false },
     };
 
     const char *saved = netdata_configured_host_prefix;
     int errors = 0;
 
     for(size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        if(cases[i].needs_host_mounts && !host_mounts_available) {
+            fprintf(stderr, "  SKIPPED %s: '%s' (no procfs at /proc or sysfs at /sys)\n",
+                    cases[i].name, cases[i].prefix);
+            continue;
+        }
+
         netdata_configured_host_prefix = cases[i].prefix;
         errno_clear();
         int rc = verify_netdata_host_prefix(false);
@@ -339,8 +348,6 @@ int paths_unittest(void) {
         if((rc == 0) != cases[i].accept) {
             fprintf(stderr, "  FAILED %s: '%s' expected %s, got rc=%d\n",
                     cases[i].name, cases[i].prefix, cases[i].accept ? "accepted" : "rejected", rc);
-            if(cases[i].accept && *cases[i].prefix)
-                fprintf(stderr, "         (is /proc or /sys mounted? this case needs both)\n");
             errors++;
             continue;
         }

--- a/src/libnetdata/paths/paths.h
+++ b/src/libnetdata/paths/paths.h
@@ -23,4 +23,6 @@ void recursive_config_double_dir_load(
     , size_t depth
 );
 
+int paths_unittest(void);
+
 #endif //NETDATA_PATHS_H

--- a/src/libnetdata/paths/paths.h
+++ b/src/libnetdata/paths/paths.h
@@ -23,6 +23,13 @@ void recursive_config_double_dir_load(
     , size_t depth
 );
 
+// true when a host prefix would be unsafe to prepend to a printf format string.
+// verify_netdata_host_prefix() applies this, and every other site that assigns
+// netdata_configured_host_prefix calls that right after. exported for the one
+// site that cannot - nd_log_initialize_for_external_plugins() - so the rule
+// stays defined once, in paths.c, next to the call sites that motivate it.
+bool netdata_host_prefix_has_format_specifier(const char *prefix);
+
 int paths_unittest(void);
 
 #endif //NETDATA_PATHS_H


### PR DESCRIPTION
##### Summary
- Harden NETDATA_HOST_PREFIX validation to block unsafe format specifiers before they reach path templates.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks '%' in host prefix validation to prevent printf format string injection in path templates. Also rejects unsafe `NETDATA_HOST_PREFIX` values from the environment and adds targeted tests.

- **Bug Fixes**
  - Validate `netdata_configured_host_prefix` against '%' (check original string, not truncated); on failure, clear the prefix and set errno to `EINVAL`.
  - Guard env var assignment in `nd_log_initialize_for_external_plugins()` to reject '%' before format strings.

- **New Tests**
  - Added `paths_unittest()` with cases for embedded/escaped '%' and truncation edge cases; wired into `netdata_main()` test runner.

<sup>Written for commit d7d8eff1bbd84c707c19b240a54531ac89958496. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

