### PR TITLE
test(go.d): stabilize jobmgr secret lifecycle tests

### DIFF
--- a/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
@@ -366,27 +366,28 @@ func testProcessCoreSecretMutationDependentRestart(
 
 func TestProcessCoreCancelledSecretUpdateCompletesStartedReplacement(t *testing.T) {
 	starts := make(chan string, 4)
-	stopEntered := make(chan struct{})
-	releaseStop := make(chan struct{})
+	replacementEntered := make(chan struct{})
+	releaseReplacement := make(chan struct{})
+	var replacementEnteredOnce sync.Once
 	var releaseOnce sync.Once
 	t.Cleanup(func() {
-		releaseOnce.Do(func() { close(releaseStop) })
+		releaseOnce.Do(func() { close(releaseReplacement) })
 	})
 	var cleanups atomic.Int32
-	var armStop atomic.Bool
 	modules := collectorapi.Registry{
 		"module": {
 			Create: func() collectorapi.CollectorV1 {
 				collector := &collectorapi.MockCollectorV1{}
 				collector.InitFunc = func(context.Context) error {
 					starts <- collector.Config.OptionStr
+					if collector.Config.OptionStr == "replacement" {
+						replacementEnteredOnce.Do(func() { close(replacementEntered) })
+						<-releaseReplacement
+					}
 					return nil
 				}
 				collector.CleanupFunc = func(context.Context) {
-					if armStop.Load() && cleanups.Add(1) == 1 {
-						close(stopEntered)
-						<-releaseStop
-					}
+					cleanups.Add(1)
 				}
 				return collector
 			},
@@ -473,7 +474,9 @@ func TestProcessCoreCancelledSecretUpdateCompletesStartedReplacement(t *testing.
 	case <-time.After(3 * time.Second):
 		require.FailNowf(t, "test failed", "collector did not start with initial secret; output=%q", output.String())
 	}
-	armStop.Store(true)
+	// Collector Init precedes graph publication and dependency acknowledgement.
+	// The Running frame makes the initial dependent authoritative before update.
+	output.waitContains(t, "CONFIG go.d:collector:module:job create running job")
 
 	_, writeStringErr := io.WriteString(
 		writer,
@@ -486,9 +489,9 @@ func TestProcessCoreCancelledSecretUpdateCompletesStartedReplacement(t *testing.
 	require.NoError(t, writeStringErr)
 
 	select {
-	case <-stopEntered:
+	case <-replacementEntered:
 	case <-time.After(3 * time.Second):
-		require.FailNow(t, "test failed", "dependent stop did not reach collector cleanup")
+		require.FailNow(t, "test failed", "replacement collector did not enter initialization")
 	}
 
 	_, writeStringErr2 := io.WriteString(
@@ -501,8 +504,11 @@ func TestProcessCoreCancelledSecretUpdateCompletesStartedReplacement(t *testing.
 	// command is the barrier that makes the preceding cancellation authoritative.
 	output.waitContains(t, "FUNCTION_RESULT_BEGIN secret-cancel-barrier 400 application/json")
 
-	releaseOnce.Do(func() { close(releaseStop) })
+	// Replacement Init belongs to the protected recovery child. Releasing it
+	// completes the already-started replacement after parent cancellation.
+	releaseOnce.Do(func() { close(releaseReplacement) })
 	waitSecretStart(t, starts, "replacement")
+	output.waitContains(t, "CONFIG go.d:collector:module:job status running")
 	output.waitContains(t, "FUNCTION_RESULT_BEGIN secret-cancel 499 application/json")
 	require.NotContains(t, output.String(), "FUNCTION_RESULT_BEGIN secret-cancel 200 application/json")
 

--- a/src/go/plugin/agent/jobmgr/secrets/initial_test.go
+++ b/src/go/plugin/agent/jobmgr/secrets/initial_test.go
@@ -764,7 +764,7 @@ func TestFailedStoreUpdateReplacesFailedProjectionWhenNoActiveGenerationExists(t
 
 func TestStoreTestIdentityDoesNotBlockMutationsOrDifferentTests(t *testing.T) {
 	gate := make(chan struct{})
-	entered := make(chan struct{})
+	entered := make(chan struct{}, 1)
 	var releaseOnce sync.Once
 	t.Cleanup(func() {
 		releaseOnce.Do(func() { close(gate) })


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes `jobmgr` secret lifecycle tests by synchronizing on replacement collector initialization and adding explicit log barriers to remove race conditions. This makes the `go.d` secret update/cancel flow tests reliable in CI.

- **Bug Fixes**
  - Gate on replacement collector Init (`replacementEntered`/`releaseReplacement`) instead of Cleanup.
  - Add waits for "create running job" and response barrier logs to enforce event ordering.
  - Buffer the `entered` channel in `TestStoreTestIdentityDoesNotBlockMutationsOrDifferentTests` to avoid blocking.
  - Remove unused stop/cleanup gating and assert final "status running" to confirm completion.

<sup>Written for commit 5c395460f9cee34967416aab970ee2942549cdb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

