### PR TITLE
feat(go.d/secretstore): add AWS operational test

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -706,6 +706,14 @@ fresh Store epoch, but the process owns that epoch's preparations, generations, 
      that an intermediary preserved the namespace header. It buffers at most 1 MiB plus one size-detection byte of a
      classified 403 body. When the request reaches Vault, it creates audit/activity evidence and can consume the final use
      of a limited-use service token. Vault token files use the shared regular-file-only 1 MiB configured-file reader.
+   - AWS Secrets Manager Test calls the exact production credential-source dispatcher and discards the credentials. `env`
+     performs no network I/O; ECS performs one logical task-metadata GET; IMDS performs token PUT, role GET, and credential
+     GET sequentially. Metadata redirects and proxies are disabled. The bodyless GETs preserve Go's transparent retry after
+     a qualifying reused-connection failure; Test adds no application retry. Each response is strictly capped at 1 MiB,
+     each request uses the configured/default three-second client timeout, and IMDS can approach three sequential timeout
+     periods before the outer caller bound. Success proves only non-empty access-key and secret-key acquisition; session
+     tokens remain optional. It does not call Secrets Manager, STS, or KMS and therefore does not prove AWS acceptance,
+     credential freshness, region correctness, secret access, or KMS permission.
 2. **Restart dependents as one composite command.** If any running jobs depend on that store key: stop dependents →
    commit the new generation → start dependents. The parent retains `dyncfg:dependency-graph` throughout, and each
    start child temporarily yields only the `dyncfg:jobs` acquisition suffix while its probe runs, so unrelated

--- a/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+	awsbackend "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore/backends/aws"
 	vaultbackend "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore/backends/vault"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
@@ -773,6 +774,108 @@ func TestProcessCoreVaultOperationalTest(t *testing.T) {
 	require.NotContains(t, wire, restrictedToken)
 	require.NotContains(t, wire, invalidToken)
 	require.NotContains(t, wire, srv.URL)
+
+	controls.sendTerminate(testProcessControl())
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "test failed", "process did not terminate")
+	}
+}
+
+func TestProcessCoreAWSOperationalTest(t *testing.T) {
+	const (
+		accessKey = "synthetic-access-key"
+		secretKey = "synthetic-secret-key"
+	)
+	t.Setenv("AWS_ACCESS_KEY_ID", accessKey)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", secretKey)
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+
+	creators, err := secretstore.NewCreatorCatalog([]secretstore.Creator{awsbackend.New()})
+	require.NoError(t, err)
+	jobs := testRunJobServices(t)
+	jobs.StoreCreators = creators
+	reader, writer := io.Pipe()
+	defer func() { require.NoError(t, writer.Close()) }()
+	output := newProcessSynchronizedBuffer()
+	process, err := newProcessCore(processCoreConfig{
+		Input:           reader,
+		Output:          output,
+		ShutdownTimeout: time.Second,
+		Modules:         collectorapi.Registry{},
+		Jobs:            jobs,
+		Discovery:       testRunDiscoveryServices(t),
+		Diagnostics:     testProcessDiagnostics(),
+	})
+	require.NoError(t, err)
+	controls := newTestProcessControls(1)
+	done := make(chan error, 1)
+	go func() {
+		done <- process.run(context.Background(), controls)
+	}()
+	output.waitContains(t, "CONFIG go.d:secretstore:aws-sm create accepted template")
+
+	storedPayload := `{"auth_mode":"env","region":"us-east-1"}`
+	temporaryECSPayload := `{"auth_mode":"ecs","region":"us-east-1"}`
+	steps := []struct {
+		uid     string
+		command string
+		payload string
+		status  int
+	}{
+		{
+			uid:     "aws-add",
+			command: "config go.d:secretstore:aws-sm add main",
+			payload: storedPayload,
+			status:  200,
+		},
+		{
+			uid:     "aws-test-stored",
+			command: "config go.d:secretstore:aws-sm:main test",
+			status:  202,
+		},
+		{
+			uid:     "aws-test-temporary-ecs",
+			command: "config go.d:secretstore:aws-sm:main test",
+			payload: temporaryECSPayload,
+			status:  422,
+		},
+		{
+			uid:     "aws-test-stored-again",
+			command: "config go.d:secretstore:aws-sm:main test",
+			status:  202,
+		},
+	}
+	for _, step := range steps {
+		if step.payload == "" {
+			_, err = io.WriteString(
+				writer,
+				"FUNCTION "+step.uid+" 30 \""+step.command+"\" 0xFFFF \"user=test\"\n",
+			)
+		} else {
+			_, err = io.WriteString(
+				writer,
+				"FUNCTION_PAYLOAD "+step.uid+" 30 \""+
+					step.command+"\" 0xFFFF \"user=test\" application/json\n"+
+					step.payload+"\nFUNCTION_PAYLOAD_END\n",
+			)
+		}
+		require.NoError(t, err)
+		output.waitContains(
+			t,
+			"FUNCTION_RESULT_BEGIN "+step.uid+" "+strconv.Itoa(step.status)+" application/json",
+		)
+	}
+
+	wire := output.String()
+	require.Contains(t, wire, "Secretstore operational test failed: AWS credentials are unavailable")
+	require.Contains(t, wire, "Stored configuration is valid. No jobs are currently using this secretstore.")
+	require.NotContains(t, wire, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+	require.NotContains(t, wire, accessKey)
+	require.NotContains(t, wire, secretKey)
 
 	controls.sendTerminate(testProcessControl())
 	select {

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/integrations/aws-sm.md
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/integrations/aws-sm.md
@@ -33,6 +33,8 @@ The Dynamic Configuration **Test** action runs the configured production credent
 
 Operational success proves only that the selected source returned non-empty access-key and secret-key values at that time. The session token remains optional and is not part of the guarantee. Test does not contact AWS Secrets Manager, STS, KMS, or another AWS data-plane endpoint, so it does not prove that AWS accepts the credentials, that they are current or temporary, that the configured region is correct, or that the identity can read or decrypt any secret.
 
+Test requires no additional AWS IAM permission beyond the configured credential source and does not mutate an AWS resource or policy. IMDS mode creates only the normal short-lived metadata-service token and can produce ordinary metadata-service telemetry.
+
 Each credential-source response is limited to 1 MiB. Every request uses the configured `timeout`; IMDS can consume approximately three sequential timeout periods, while an earlier Dynamic Configuration caller deadline or cancellation wins.
 
 

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/integrations/aws-sm.md
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/integrations/aws-sm.md
@@ -29,6 +29,12 @@ This page covers AWS Secrets Manager specific setup. For the full resolver overv
 
 Netdata reads existing secrets from AWS Secrets Manager. It does not create, rotate, or manage those secrets. If you use `secret-name#key`, the secret value must be stored as a JSON `SecretString`.
 
+The Dynamic Configuration **Test** action runs the configured production credential-source path and discards the result. In `env` mode it reads the Netdata process environment without network access. In `ecs` mode it performs one logical request to the ECS task credential endpoint. In `imds` mode it performs the IMDSv2 token, role-name, and credential requests sequentially. Metadata redirects and proxies are disabled. Go can transparently retransmit a bodyless metadata GET once after a qualifying reused-connection failure; the Test does not add application retries.
+
+Operational success proves only that the selected source returned non-empty access-key and secret-key values at that time. The session token remains optional and is not part of the guarantee. Test does not contact AWS Secrets Manager, STS, KMS, or another AWS data-plane endpoint, so it does not prove that AWS accepts the credentials, that they are current or temporary, that the configured region is correct, or that the identity can read or decrypt any secret.
+
+Each credential-source response is limited to 1 MiB. Every request uses the configured `timeout`; IMDS can consume approximately three sequential timeout periods, while an earlier Dynamic Configuration caller deadline or cancellation wins.
+
 
 ## Setup
 
@@ -218,6 +224,17 @@ Check the selected `auth_mode`.
 - For `env`, make sure the Netdata service has `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 - For `ecs`, make sure Netdata runs in ECS and `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is available.
 - For `imds`, make sure the EC2 instance profile is attached and IMDSv2 is reachable.
+
+
+### The Dynamic Configuration Test fails
+
+The Test action exercises only the configured credential source. It does not call AWS Secrets Manager or test a secret path.
+
+- For `env`, verify that the Netdata service environment contains non-empty `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values.
+- For `ecs`, verify that `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is present and is a valid path-style relative URI supplied by ECS.
+- For `imds`, verify that IMDSv2 is reachable, returns a non-empty token, and exposes one valid IAM role name and its credentials.
+
+A successful Test does not prove that AWS accepts the returned credentials or that they have permission to access a particular secret. Check the configured region, `secretsmanager:GetSecretValue`, and any required `kms:Decrypt` permission separately.
 
 
 ### Access denied or wrong region

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/metadata.yaml
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/metadata.yaml
@@ -24,6 +24,8 @@ overview:
 
     Operational success proves only that the selected source returned non-empty access-key and secret-key values at that time. The session token remains optional and is not part of the guarantee. Test does not contact AWS Secrets Manager, STS, KMS, or another AWS data-plane endpoint, so it does not prove that AWS accepts the credentials, that they are current or temporary, that the configured region is correct, or that the identity can read or decrypt any secret.
 
+    Test requires no additional AWS IAM permission beyond the configured credential source and does not mutate an AWS resource or policy. IMDS mode creates only the normal short-lived metadata-service token and can produce ordinary metadata-service telemetry.
+
     Each credential-source response is limited to 1 MiB. Every request uses the configured `timeout`; IMDS can consume approximately three sequential timeout periods, while an earlier Dynamic Configuration caller deadline or cancellation wins.
 setup:
   prerequisites:

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/metadata.yaml
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/metadata.yaml
@@ -19,6 +19,12 @@ overview:
     This page covers AWS Secrets Manager specific setup. For the full resolver overview and syntax reference, including simpler alternatives like `${env:...}`, `${file:...}`, and `${cmd:...}`, see [Secrets Management](/src/collectors/SECRETS.md).
   limitations: |
     Netdata reads existing secrets from AWS Secrets Manager. It does not create, rotate, or manage those secrets. If you use `secret-name#key`, the secret value must be stored as a JSON `SecretString`.
+
+    The Dynamic Configuration **Test** action runs the configured production credential-source path and discards the result. In `env` mode it reads the Netdata process environment without network access. In `ecs` mode it performs one logical request to the ECS task credential endpoint. In `imds` mode it performs the IMDSv2 token, role-name, and credential requests sequentially. Metadata redirects and proxies are disabled. Go can transparently retransmit a bodyless metadata GET once after a qualifying reused-connection failure; the Test does not add application retries.
+
+    Operational success proves only that the selected source returned non-empty access-key and secret-key values at that time. The session token remains optional and is not part of the guarantee. Test does not contact AWS Secrets Manager, STS, KMS, or another AWS data-plane endpoint, so it does not prove that AWS accepts the credentials, that they are current or temporary, that the configured region is correct, or that the identity can read or decrypt any secret.
+
+    Each credential-source response is limited to 1 MiB. Every request uses the configured `timeout`; IMDS can consume approximately three sequential timeout periods, while an earlier Dynamic Configuration caller deadline or cancellation wins.
 setup:
   prerequisites:
     list:
@@ -155,6 +161,15 @@ troubleshooting:
           - For `env`, make sure the Netdata service has `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
           - For `ecs`, make sure Netdata runs in ECS and `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is available.
           - For `imds`, make sure the EC2 instance profile is attached and IMDSv2 is reachable.
+      - name: 'The Dynamic Configuration Test fails'
+        description: |
+          The Test action exercises only the configured credential source. It does not call AWS Secrets Manager or test a secret path.
+
+          - For `env`, verify that the Netdata service environment contains non-empty `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values.
+          - For `ecs`, verify that `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is present and is a valid path-style relative URI supplied by ECS.
+          - For `imds`, verify that IMDSv2 is reachable, returns a non-empty token, and exposes one valid IAM role name and its credentials.
+
+          A successful Test does not prove that AWS accepts the returned credentials or that they have permission to access a particular secret. Check the configured region, `secretsmanager:GetSecretValue`, and any required `kms:Decrypt` permission separately.
       - name: 'Access denied or wrong region'
         description: |
           Confirm the configured `region` and make sure the AWS identity used by Netdata can read the referenced secret in that region.

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/operational_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/operational_test.go
@@ -50,7 +50,7 @@ func TestECSCredentialsEndpoint(t *testing.T) {
 			wantErr:     true,
 		},
 		"authority-shaped value": {
-			relativeURI: "@metadata.example/credentials",
+			relativeURI: "//metadata.example/credentials",
 			wantErr:     true,
 		},
 		"fragment": {
@@ -84,6 +84,7 @@ func TestECSCredentialsResponses(t *testing.T) {
 		status          int
 		body            string
 		reader          io.Reader
+		wantToken       string
 		wantErrContains string
 		wantTooLarge    bool
 	}{
@@ -92,8 +93,9 @@ func TestECSCredentialsResponses(t *testing.T) {
 			body:   `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret"}`,
 		},
 		"session token is accepted": {
-			status: http.StatusOK,
-			body:   `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret","Token":"test-token"}`,
+			status:    http.StatusOK,
+			body:      `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret","Token":"test-token"}`,
+			wantToken: "test-token",
 		},
 		"missing required key fails": {
 			status:          http.StatusOK,
@@ -145,6 +147,7 @@ func TestECSCredentialsResponses(t *testing.T) {
 				require.NotNil(t, creds)
 				assert.Equal(t, "test-access", creds.accessKeyID)
 				assert.Equal(t, "test-secret", creds.secretAccessKey)
+				assert.Equal(t, tc.wantToken, creds.sessionToken)
 				return
 			}
 			require.ErrorContains(t, err, tc.wantErrContains)
@@ -161,6 +164,7 @@ func TestIMDSCredentialsRequestPath(t *testing.T) {
 		role            string
 		credentials     string
 		wantRole        string
+		wantToken       string
 		wantRequests    int64
 		wantErrContains string
 	}{
@@ -176,6 +180,7 @@ func TestIMDSCredentialsRequestPath(t *testing.T) {
 			role:         strings.Repeat("a", 64),
 			credentials:  `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret","Token":"test-token"}`,
 			wantRole:     strings.Repeat("a", 64),
+			wantToken:    "test-token",
 			wantRequests: 3,
 		},
 		"empty token fails": {
@@ -220,6 +225,7 @@ func TestIMDSCredentialsRequestPath(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var requests atomic.Int64
+			var tokenBody, roleBody, credentialBody *trackingReadCloser
 			s := publishedWithMetadataTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 				request := requests.Add(1)
 				switch request {
@@ -227,17 +233,19 @@ func TestIMDSCredentialsRequestPath(t *testing.T) {
 					assert.Equal(t, http.MethodPut, req.Method)
 					assert.Equal(t, "/latest/api/token", req.URL.Path)
 					assert.Equal(t, "21600", req.Header.Get("X-aws-ec2-metadata-token-ttl-seconds"))
-					return awsHTTPResponse(http.StatusOK, tc.token), nil
+					return trackedAWSHTTPResponse(http.StatusOK, tc.token, &tokenBody), nil
 				case 2:
+					require.True(t, tokenBody.closed.Load(), "token response must close before role request")
 					assert.Equal(t, http.MethodGet, req.Method)
 					assert.Equal(t, "/latest/meta-data/iam/security-credentials/", req.URL.Path)
 					assert.Equal(t, "imds-token", req.Header.Get("X-aws-ec2-metadata-token"))
-					return awsHTTPResponse(http.StatusOK, tc.role), nil
+					return trackedAWSHTTPResponse(http.StatusOK, tc.role, &roleBody), nil
 				case 3:
+					require.True(t, roleBody.closed.Load(), "role response must close before credential request")
 					assert.Equal(t, http.MethodGet, req.Method)
 					assert.Equal(t, "/latest/meta-data/iam/security-credentials/"+tc.wantRole, req.URL.Path)
 					assert.Equal(t, "imds-token", req.Header.Get("X-aws-ec2-metadata-token"))
-					return awsHTTPResponse(http.StatusOK, tc.credentials), nil
+					return trackedAWSHTTPResponse(http.StatusOK, tc.credentials, &credentialBody), nil
 				default:
 					return nil, fmt.Errorf("unexpected IMDS request %d", request)
 				}
@@ -246,6 +254,11 @@ func TestIMDSCredentialsRequestPath(t *testing.T) {
 			creds, err := s.imdsCredentials(t.Context())
 
 			assert.Equal(t, tc.wantRequests, requests.Load())
+			for _, body := range []*trackingReadCloser{tokenBody, roleBody, credentialBody} {
+				if body != nil {
+					assert.True(t, body.closed.Load())
+				}
+			}
 			if tc.wantErrContains != "" {
 				require.ErrorContains(t, err, tc.wantErrContains)
 				return
@@ -254,6 +267,107 @@ func TestIMDSCredentialsRequestPath(t *testing.T) {
 			require.NotNil(t, creds)
 			assert.Equal(t, "test-access", creds.accessKeyID)
 			assert.Equal(t, "test-secret", creds.secretAccessKey)
+			assert.Equal(t, tc.wantToken, creds.sessionToken)
+		})
+	}
+}
+
+func TestIMDSCredentialsStageFailures(t *testing.T) {
+	readErr := errors.New("response read failed")
+	tests := map[string]struct {
+		stage           int64
+		status          int
+		body            string
+		reader          io.Reader
+		wantErrContains string
+		wantTooLarge    bool
+	}{
+		"token HTTP failure": {
+			stage:           1,
+			status:          http.StatusInternalServerError,
+			body:            "private token failure",
+			wantErrContains: "IMDS token request returned HTTP 500",
+		},
+		"token oversized response": {
+			stage:           1,
+			body:            strings.Repeat("x", responseBodyLimit+1),
+			wantErrContains: "reading IMDS token request response",
+			wantTooLarge:    true,
+		},
+		"role HTTP failure": {
+			stage:           2,
+			status:          http.StatusInternalServerError,
+			body:            "private role failure",
+			wantErrContains: "IMDS role request returned HTTP 500",
+		},
+		"role read failure": {
+			stage:           2,
+			reader:          errorReader{err: readErr},
+			wantErrContains: "reading IMDS role request response",
+		},
+		"credential HTTP failure": {
+			stage:           3,
+			status:          http.StatusInternalServerError,
+			body:            "private credential failure",
+			wantErrContains: "IMDS credentials request returned HTTP 500",
+		},
+		"credential oversized response": {
+			stage:           3,
+			body:            strings.Repeat("x", responseBodyLimit+1),
+			wantErrContains: "reading IMDS credentials request response",
+			wantTooLarge:    true,
+		},
+		"credential malformed JSON": {
+			stage:           3,
+			body:            `{"AccessKeyId":`,
+			wantErrContains: "parsing IMDS credentials response",
+		},
+	}
+
+	normalBodies := map[int64]string{
+		1: "imds-token",
+		2: "test-role",
+		3: `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret"}`,
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var requests atomic.Int64
+			var bodies []*trackingReadCloser
+			s := publishedWithMetadataTransport(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				stage := requests.Add(1)
+				for _, body := range bodies {
+					require.True(t, body.closed.Load(), "previous IMDS response must close before request %d", stage)
+				}
+
+				status := http.StatusOK
+				reader := io.Reader(strings.NewReader(normalBodies[stage]))
+				if stage == tc.stage {
+					if tc.status != 0 {
+						status = tc.status
+					}
+					switch {
+					case tc.reader != nil:
+						reader = tc.reader
+					case tc.body != "":
+						reader = strings.NewReader(tc.body)
+					}
+				}
+				body := &trackingReadCloser{Reader: reader}
+				bodies = append(bodies, body)
+				return &http.Response{StatusCode: status, Body: body, Header: make(http.Header)}, nil
+			}))
+
+			_, err := s.imdsCredentials(t.Context())
+
+			assert.Equal(t, tc.stage, requests.Load())
+			for _, body := range bodies {
+				assert.True(t, body.closed.Load())
+			}
+			require.ErrorContains(t, err, tc.wantErrContains)
+			if tc.wantTooLarge {
+				require.ErrorIs(t, err, httpx.ErrResponseTooLarge)
+			}
 		})
 	}
 }
@@ -530,6 +644,15 @@ func awsHTTPResponse(status int, body string) *http.Response {
 	return &http.Response{
 		StatusCode: status,
 		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func trackedAWSHTTPResponse(status int, body string, tracked **trackingReadCloser) *http.Response {
+	*tracked = &trackingReadCloser{Reader: strings.NewReader(body)}
+	return &http.Response{
+		StatusCode: status,
+		Body:       *tracked,
 		Header:     make(http.Header),
 	}
 }

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/operational_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/operational_test.go
@@ -1,0 +1,575 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore/internal/httpx"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ dyncfg.Testable = (*store)(nil)
+
+func TestECSCredentialsEndpoint(t *testing.T) {
+	tests := map[string]struct {
+		relativeURI string
+		want        string
+		wantErr     bool
+	}{
+		"path": {
+			relativeURI: "/v2/credentials/test-id",
+			want:        ecsMetadataEndpoint + "/v2/credentials/test-id",
+		},
+		"path and query": {
+			relativeURI: "/v2/credentials/test-id?version=1",
+			want:        ecsMetadataEndpoint + "/v2/credentials/test-id?version=1",
+		},
+		"missing leading slash": {
+			relativeURI: "v2/credentials/test-id",
+			wantErr:     true,
+		},
+		"absolute URI": {
+			relativeURI: "http://metadata.example/credentials",
+			wantErr:     true,
+		},
+		"authority-shaped value": {
+			relativeURI: "@metadata.example/credentials",
+			wantErr:     true,
+		},
+		"fragment": {
+			relativeURI: "/v2/credentials/test-id#fragment",
+			wantErr:     true,
+		},
+		"invalid escape": {
+			relativeURI: "/v2/credentials/%zz",
+			wantErr:     true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ecsCredentialsEndpoint(tc.relativeURI)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestECSCredentialsResponses(t *testing.T) {
+	readErr := errors.New("response read failed")
+	tests := map[string]struct {
+		status          int
+		body            string
+		reader          io.Reader
+		wantErrContains string
+		wantTooLarge    bool
+	}{
+		"tokenless credentials succeed": {
+			status: http.StatusOK,
+			body:   `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret"}`,
+		},
+		"session token is accepted": {
+			status: http.StatusOK,
+			body:   `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret","Token":"test-token"}`,
+		},
+		"missing required key fails": {
+			status:          http.StatusOK,
+			body:            `{"AccessKeyId":"test-access"}`,
+			wantErrContains: "missing required fields",
+		},
+		"malformed JSON fails": {
+			status:          http.StatusOK,
+			body:            `{"AccessKeyId":`,
+			wantErrContains: "parsing ECS credentials response",
+		},
+		"oversized success response fails": {
+			status:          http.StatusOK,
+			body:            strings.Repeat("x", responseBodyLimit+1),
+			wantErrContains: "reading ECS credentials response",
+			wantTooLarge:    true,
+		},
+		"status wins over oversized diagnostic body": {
+			status:          http.StatusForbidden,
+			body:            strings.Repeat("x", responseBodyLimit+1),
+			wantErrContains: "ECS credentials returned HTTP 403",
+		},
+		"read failure fails": {
+			status:          http.StatusOK,
+			reader:          errorReader{err: readErr},
+			wantErrContains: "reading ECS credentials response",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			reader := tc.reader
+			if reader == nil {
+				reader = strings.NewReader(tc.body)
+			}
+			body := &trackingReadCloser{Reader: reader}
+			s := publishedWithMetadataTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "169.254.170.2", req.URL.Host)
+				assert.Equal(t, "/v2/credentials/test-id", req.URL.Path)
+				return &http.Response{StatusCode: tc.status, Body: body, Header: make(http.Header)}, nil
+			}))
+
+			creds, err := s.ecsCredentials(t.Context(), "/v2/credentials/test-id")
+
+			assert.True(t, body.closed.Load())
+			if tc.wantErrContains == "" {
+				require.NoError(t, err)
+				require.NotNil(t, creds)
+				assert.Equal(t, "test-access", creds.accessKeyID)
+				assert.Equal(t, "test-secret", creds.secretAccessKey)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErrContains)
+			if tc.wantTooLarge {
+				require.ErrorIs(t, err, httpx.ErrResponseTooLarge)
+			}
+		})
+	}
+}
+
+func TestIMDSCredentialsRequestPath(t *testing.T) {
+	tests := map[string]struct {
+		token           string
+		role            string
+		credentials     string
+		wantRole        string
+		wantRequests    int64
+		wantErrContains string
+	}{
+		"legal role is used unchanged": {
+			token:        "imds-token",
+			role:         "team,prod\n",
+			credentials:  `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret"}`,
+			wantRole:     "team,prod",
+			wantRequests: 3,
+		},
+		"maximum length role succeeds": {
+			token:        "imds-token",
+			role:         strings.Repeat("a", 64),
+			credentials:  `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret","Token":"test-token"}`,
+			wantRole:     strings.Repeat("a", 64),
+			wantRequests: 3,
+		},
+		"empty token fails": {
+			token:           " \n",
+			wantRequests:    1,
+			wantErrContains: "empty token",
+		},
+		"empty role fails": {
+			token:           "imds-token",
+			role:            " \n",
+			wantRequests:    2,
+			wantErrContains: "invalid role name",
+		},
+		"path separator in role fails": {
+			token:           "imds-token",
+			role:            "team/prod",
+			wantRequests:    2,
+			wantErrContains: "invalid role name",
+		},
+		"multi-line role fails": {
+			token:           "imds-token",
+			role:            "team\nprod",
+			wantRequests:    2,
+			wantErrContains: "invalid role name",
+		},
+		"overlong role fails": {
+			token:           "imds-token",
+			role:            strings.Repeat("a", 65),
+			wantRequests:    2,
+			wantErrContains: "invalid role name",
+		},
+		"missing credential key fails": {
+			token:           "imds-token",
+			role:            "test-role",
+			credentials:     `{"AccessKeyId":"test-access"}`,
+			wantRole:        "test-role",
+			wantRequests:    3,
+			wantErrContains: "missing required fields",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var requests atomic.Int64
+			s := publishedWithMetadataTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				request := requests.Add(1)
+				switch request {
+				case 1:
+					assert.Equal(t, http.MethodPut, req.Method)
+					assert.Equal(t, "/latest/api/token", req.URL.Path)
+					assert.Equal(t, "21600", req.Header.Get("X-aws-ec2-metadata-token-ttl-seconds"))
+					return awsHTTPResponse(http.StatusOK, tc.token), nil
+				case 2:
+					assert.Equal(t, http.MethodGet, req.Method)
+					assert.Equal(t, "/latest/meta-data/iam/security-credentials/", req.URL.Path)
+					assert.Equal(t, "imds-token", req.Header.Get("X-aws-ec2-metadata-token"))
+					return awsHTTPResponse(http.StatusOK, tc.role), nil
+				case 3:
+					assert.Equal(t, http.MethodGet, req.Method)
+					assert.Equal(t, "/latest/meta-data/iam/security-credentials/"+tc.wantRole, req.URL.Path)
+					assert.Equal(t, "imds-token", req.Header.Get("X-aws-ec2-metadata-token"))
+					return awsHTTPResponse(http.StatusOK, tc.credentials), nil
+				default:
+					return nil, fmt.Errorf("unexpected IMDS request %d", request)
+				}
+			}))
+
+			creds, err := s.imdsCredentials(t.Context())
+
+			assert.Equal(t, tc.wantRequests, requests.Load())
+			if tc.wantErrContains != "" {
+				require.ErrorContains(t, err, tc.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, creds)
+			assert.Equal(t, "test-access", creds.accessKeyID)
+			assert.Equal(t, "test-secret", creds.secretAccessKey)
+		})
+	}
+}
+
+func TestStoreTestModesAndCleanup(t *testing.T) {
+	tests := map[string]struct {
+		mode         string
+		setupEnv     func(t *testing.T)
+		wantRequests int64
+		wantErr      bool
+	}{
+		"environment credentials are operational": {
+			mode: "env",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("AWS_ACCESS_KEY_ID", "test-access")
+				t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+			},
+		},
+		"missing environment credentials fail safely": {
+			mode:    "env",
+			wantErr: true,
+		},
+		"ECS credential source is operational": {
+			mode: "ecs",
+			setupEnv: func(t *testing.T) {
+				t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials/test-id")
+			},
+			wantRequests: 1,
+		},
+		"IMDS credential source is operational": {
+			mode:         "imds",
+			wantRequests: 3,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("AWS_ACCESS_KEY_ID", "")
+			t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+			t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+			if tc.setupEnv != nil {
+				tc.setupEnv(t)
+			}
+
+			s := newAWSOperationalStore(t, Config{AuthMode: tc.mode, Region: "us-east-1"})
+			metadataTransport := &trackingTransport{roundTrip: func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/v2/credentials/test-id":
+					return awsHTTPResponse(http.StatusOK, `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret"}`), nil
+				case "/latest/api/token":
+					return awsHTTPResponse(http.StatusOK, "imds-token"), nil
+				case "/latest/meta-data/iam/security-credentials/":
+					return awsHTTPResponse(http.StatusOK, "test-role"), nil
+				case "/latest/meta-data/iam/security-credentials/test-role":
+					return awsHTTPResponse(http.StatusOK, `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret"}`), nil
+				default:
+					return nil, fmt.Errorf("unexpected metadata path %q", req.URL.Path)
+				}
+			}}
+			apiTransport := &trackingTransport{roundTrip: func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("unexpected AWS API request")
+			}}
+			s.runtime.imdsClient.Transport = metadataTransport
+			s.runtime.apiClient.Transport = apiTransport
+
+			err := s.Test(t.Context())
+
+			assert.Equal(t, tc.wantRequests, metadataTransport.requests.Load())
+			assert.EqualValues(t, 1, metadataTransport.closeIdleCalls.Load())
+			assert.Zero(t, apiTransport.requests.Load())
+			assert.Zero(t, apiTransport.closeIdleCalls.Load())
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			requireAWSPublicError(t, err)
+			assert.NotContains(t, err.Error(), "AWS_ACCESS_KEY_ID")
+		})
+	}
+}
+
+func TestStoreTestUsesProductionMetadataTransport(t *testing.T) {
+	tests := map[string]struct {
+		timeout      confopt.Duration
+		handler      func(t *testing.T, w http.ResponseWriter, req *http.Request)
+		ctx          func(t *testing.T) context.Context
+		wantRequests int64
+		wantErr      bool
+		wantErrIs    error
+	}{
+		"success keeps the fixed metadata host": {
+			handler: func(t *testing.T, w http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, "169.254.170.2", req.Host)
+				assert.Equal(t, "/v2/credentials/test-id", req.URL.Path)
+				_, _ = io.WriteString(w, `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret"}`)
+			},
+			wantRequests: 1,
+		},
+		"redirect is rejected at the first response": {
+			handler: func(_ *testing.T, w http.ResponseWriter, req *http.Request) {
+				http.Redirect(w, req, "/redirected", http.StatusTemporaryRedirect)
+			},
+			wantRequests: 1,
+			wantErr:      true,
+		},
+		"caller cancellation stops before metadata I/O": {
+			handler: func(t *testing.T, _ http.ResponseWriter, _ *http.Request) {
+				require.FailNow(t, "test failed", "canceled Test reached the metadata server")
+			},
+			ctx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			wantErr:   true,
+			wantErrIs: context.Canceled,
+		},
+		"configured timeout interrupts a stalled body": {
+			timeout: confopt.Duration(30 * time.Millisecond),
+			handler: func(_ *testing.T, w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, `{"AccessKeyId":`)
+				w.(http.Flusher).Flush()
+				<-req.Context().Done()
+			},
+			wantRequests: 1,
+			wantErr:      true,
+			wantErrIs:    context.DeadlineExceeded,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var requests atomic.Int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				requests.Add(1)
+				tc.handler(t, w, req)
+			}))
+			defer srv.Close()
+
+			t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials/test-id")
+			s := newAWSOperationalStore(t, Config{
+				AuthMode: "ecs",
+				Region:   "us-east-1",
+				Timeout:  tc.timeout,
+			})
+			transport, ok := s.runtime.imdsClient.Transport.(*http.Transport)
+			require.True(t, ok)
+			target := srv.Listener.Addr().String()
+			transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+				var dialer net.Dialer
+				return dialer.DialContext(ctx, network, target)
+			}
+
+			ctx := t.Context()
+			if tc.ctx != nil {
+				ctx = tc.ctx(t)
+			}
+			err := s.Test(ctx)
+
+			assert.Equal(t, tc.wantRequests, requests.Load())
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			requireAWSPublicError(t, err)
+			if tc.wantErrIs != nil {
+				require.ErrorIs(t, err, tc.wantErrIs)
+			}
+		})
+	}
+}
+
+func TestStoreTestRejectsInvalidState(t *testing.T) {
+	tests := map[string]func() error{
+		"nil Store": func() error {
+			var s *store
+			return s.Test(t.Context())
+		},
+		"nil context": func() error {
+			s := newAWSOperationalStore(t, Config{AuthMode: "env", Region: "us-east-1"})
+			return s.Test(nil)
+		},
+		"uninitialized Store": func() error {
+			return (&store{}).Test(t.Context())
+		},
+		"published runtime without metadata client": func() error {
+			s := newAWSOperationalStore(t, Config{AuthMode: "env", Region: "us-east-1"})
+			s.published.runtime = &runtime{}
+			return s.Test(t.Context())
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.EqualError(t, test(), "invalid AWS operational test")
+		})
+	}
+}
+
+func TestSecretStoreTestUsesAWSOperationalCapability(t *testing.T) {
+	tests := map[string]struct {
+		accessKey  string
+		secretKey  string
+		wantTested bool
+		wantErr    bool
+	}{
+		"valid environment source is operational": {
+			accessKey:  "test-access",
+			secretKey:  "test-secret",
+			wantTested: true,
+		},
+		"missing environment source is an operational failure": {
+			wantTested: true,
+			wantErr:    true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("AWS_ACCESS_KEY_ID", tc.accessKey)
+			t.Setenv("AWS_SECRET_ACCESS_KEY", tc.secretKey)
+
+			resolver, err := secretresolver.NewAtomicResolver(nil)
+			require.NoError(t, err)
+			authority, err := secretstore.NewSecretStore(resolver)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, authority.Close(context.Background()))
+			})
+			catalog, err := secretstore.NewCreatorCatalog([]secretstore.Creator{New()})
+			require.NoError(t, err)
+			config := secretstore.Config{
+				"name":            "main",
+				"kind":            string(secretstore.KindAWSSM),
+				"auth_mode":       "env",
+				"region":          "us-east-1",
+				"__source__":      confgroup.TypeDyncfg,
+				"__source_type__": confgroup.TypeDyncfg,
+			}
+
+			tested, err := authority.Test(t.Context(), catalog, config)
+
+			assert.Equal(t, tc.wantTested, tested)
+			assert.Equal(t, secretstore.SecretStoreCensus{}, authority.Census())
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			requireAWSPublicError(t, err)
+		})
+	}
+}
+
+func newAWSOperationalStore(t *testing.T, config Config) *store {
+	t.Helper()
+	s := &store{Config: config}
+	require.NoError(t, s.Init(t.Context()))
+	return s
+}
+
+func publishedWithMetadataTransport(t *testing.T, transport http.RoundTripper) *publishedStore {
+	t.Helper()
+	return &publishedStore{
+		runtime: &runtime{
+			imdsClient: &http.Client{Transport: transport},
+		},
+		mode:        "ecs",
+		regionValue: "us-east-1",
+	}
+}
+
+func awsHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func requireAWSPublicError(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	message, ok := dyncfg.PublicMessage(err)
+	require.True(t, ok)
+	assert.Equal(t, publicErrCredentials, message)
+	assert.Equal(t, publicErrCredentials, err.Error())
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed.Store(true)
+	return nil
+}
+
+type trackingTransport struct {
+	roundTrip      roundTripFunc
+	requests       atomic.Int64
+	closeIdleCalls atomic.Int64
+}
+
+func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.requests.Add(1)
+	return t.roundTrip(req)
+}
+
+func (t *trackingTransport) CloseIdleConnections() {
+	t.closeIdleCalls.Add(1)
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) { return 0, r.err }

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/operational_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/operational_test.go
@@ -372,6 +372,85 @@ func TestIMDSCredentialsStageFailures(t *testing.T) {
 	}
 }
 
+func TestIMDSCredentialsContextDuringBodyRead(t *testing.T) {
+	tests := map[string]struct {
+		stage        int64
+		timeout      time.Duration
+		cancelCaller bool
+		wantErr      error
+	}{
+		"caller cancellation during role response": {
+			stage:        2,
+			cancelCaller: true,
+			wantErr:      context.Canceled,
+		},
+		"configured timeout during credential response": {
+			stage:   3,
+			timeout: 30 * time.Millisecond,
+			wantErr: context.DeadlineExceeded,
+		},
+	}
+
+	normalBodies := map[int64]string{
+		1: "imds-token",
+		2: "test-role",
+		3: `{"AccessKeyId":"test-access","SecretAccessKey":"test-secret"}`,
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			started := make(chan struct{}, 1)
+			var requests atomic.Int64
+			var bodies []*trackingReadCloser
+			s := publishedWithMetadataTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				stage := requests.Add(1)
+				for _, body := range bodies {
+					if !body.closed.Load() {
+						return nil, fmt.Errorf("previous IMDS response remained open before request %d", stage)
+					}
+				}
+
+				reader := io.Reader(strings.NewReader(normalBodies[stage]))
+				if stage == tc.stage {
+					reader = contextBlockingReader{ctx: req.Context(), started: started}
+				}
+				body := &trackingReadCloser{Reader: reader}
+				bodies = append(bodies, body)
+				return &http.Response{StatusCode: http.StatusOK, Body: body, Header: make(http.Header)}, nil
+			}))
+			s.runtime.imdsClient.Timeout = tc.timeout
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			result := make(chan error, 1)
+			go func() {
+				_, err := s.imdsCredentials(ctx)
+				result <- err
+			}()
+
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				require.FailNow(t, "test failed", "IMDS response body read did not start")
+			}
+			if tc.cancelCaller {
+				cancel()
+			}
+
+			select {
+			case err := <-result:
+				require.ErrorIs(t, err, tc.wantErr)
+			case <-time.After(time.Second):
+				require.FailNow(t, "test failed", "IMDS response body read did not stop")
+			}
+			assert.Equal(t, tc.stage, requests.Load())
+			for _, body := range bodies {
+				assert.True(t, body.closed.Load())
+			}
+		})
+	}
+}
+
 func TestStoreTestModesAndCleanup(t *testing.T) {
 	tests := map[string]struct {
 		mode         string
@@ -696,3 +775,17 @@ type errorReader struct {
 }
 
 func (r errorReader) Read([]byte) (int, error) { return 0, r.err }
+
+type contextBlockingReader struct {
+	ctx     context.Context
+	started chan<- struct{}
+}
+
+func (r contextBlockingReader) Read([]byte) (int, error) {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-r.ctx.Done()
+	return 0, r.ctx.Err()
+}

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/provider.go
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/provider.go
@@ -15,6 +15,8 @@ import (
 //go:embed config_schema.json
 var configSchema string
 
+const responseBodyLimit = 1 << 20
+
 var defaultTimeout = confopt.Duration(3 * time.Second)
 
 type Config struct {

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/resolve.go
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/resolve.go
@@ -8,10 +8,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -21,6 +22,13 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore/internal/envx"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore/internal/httpx"
 )
+
+const (
+	ecsMetadataEndpoint  = "http://169.254.170.2"
+	imdsMetadataEndpoint = "http://169.254.169.254"
+)
+
+var imdsRoleNamePattern = regexp.MustCompile(`^[A-Za-z0-9_+=,.@-]{1,64}$`)
 
 func (s *publishedStore) Resolve(ctx context.Context, req secretstore.ResolveRequest) (string, error) {
 	return s.resolve(ctx, req)
@@ -122,7 +130,11 @@ func envCredentials() (*credentials, error) {
 }
 
 func (s *publishedStore) ecsCredentials(ctx context.Context, relativeURI string) (*credentials, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.170.2"+relativeURI, nil)
+	endpoint, err := ecsCredentialsEndpoint(relativeURI)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating ECS credentials request: %w", err)
 	}
@@ -131,12 +143,9 @@ func (s *publishedStore) ecsCredentials(ctx context.Context, relativeURI string)
 		return nil, fmt.Errorf("ECS credentials request failed: %w", err)
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := readAWSResponse(resp, "ECS credentials", true)
 	if err != nil {
-		return nil, fmt.Errorf("reading ECS credentials response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("ECS credentials returned HTTP %d: %s", resp.StatusCode, httpx.TruncateBody(body))
+		return nil, err
 	}
 	var result struct {
 		AccessKeyID     string `json:"AccessKeyId"`
@@ -157,7 +166,7 @@ func (s *publishedStore) ecsCredentials(ctx context.Context, relativeURI string)
 }
 
 func (s *publishedStore) imdsCredentials(ctx context.Context) (*credentials, error) {
-	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://169.254.169.254/latest/api/token", nil)
+	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPut, imdsMetadataEndpoint+"/latest/api/token", nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating IMDS token request: %w", err)
 	}
@@ -167,16 +176,16 @@ func (s *publishedStore) imdsCredentials(ctx context.Context) (*credentials, err
 		return nil, fmt.Errorf("IMDS token request failed: %w", err)
 	}
 	defer tokenResp.Body.Close()
-	tokenBody, err := io.ReadAll(io.LimitReader(tokenResp.Body, 1<<20))
+	tokenBody, err := readAWSResponse(tokenResp, "IMDS token request", false)
 	if err != nil {
-		return nil, fmt.Errorf("reading IMDS token response: %w", err)
-	}
-	if tokenResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("IMDS token request returned HTTP %d", tokenResp.StatusCode)
+		return nil, err
 	}
 	imdsToken := strings.TrimSpace(string(tokenBody))
+	if imdsToken == "" {
+		return nil, fmt.Errorf("IMDS returned empty token")
+	}
 
-	roleReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/meta-data/iam/security-credentials/", nil)
+	roleReq, err := http.NewRequestWithContext(ctx, http.MethodGet, imdsMetadataEndpoint+"/latest/meta-data/iam/security-credentials/", nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating IMDS role request: %w", err)
 	}
@@ -186,19 +195,16 @@ func (s *publishedStore) imdsCredentials(ctx context.Context) (*credentials, err
 		return nil, fmt.Errorf("IMDS role request failed: %w", err)
 	}
 	defer roleResp.Body.Close()
-	roleBody, err := io.ReadAll(io.LimitReader(roleResp.Body, 1<<20))
+	roleBody, err := readAWSResponse(roleResp, "IMDS role request", false)
 	if err != nil {
-		return nil, fmt.Errorf("reading IMDS role response: %w", err)
-	}
-	if roleResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("IMDS role request returned HTTP %d", roleResp.StatusCode)
+		return nil, err
 	}
 	role := strings.TrimSpace(string(roleBody))
-	if role == "" {
-		return nil, fmt.Errorf("IMDS returned empty role name")
+	if !imdsRoleNamePattern.MatchString(role) {
+		return nil, fmt.Errorf("IMDS returned invalid role name")
 	}
 
-	credReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://169.254.169.254/latest/meta-data/iam/security-credentials/"+role, nil)
+	credReq, err := http.NewRequestWithContext(ctx, http.MethodGet, imdsMetadataEndpoint+"/latest/meta-data/iam/security-credentials/"+role, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating IMDS credentials request: %w", err)
 	}
@@ -208,12 +214,9 @@ func (s *publishedStore) imdsCredentials(ctx context.Context) (*credentials, err
 		return nil, fmt.Errorf("IMDS credentials request failed: %w", err)
 	}
 	defer credResp.Body.Close()
-	credBody, err := io.ReadAll(io.LimitReader(credResp.Body, 1<<20))
+	credBody, err := readAWSResponse(credResp, "IMDS credentials request", false)
 	if err != nil {
-		return nil, fmt.Errorf("reading IMDS credentials response: %w", err)
-	}
-	if credResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("IMDS credentials request returned HTTP %d", credResp.StatusCode)
+		return nil, err
 	}
 	var result struct {
 		AccessKeyID     string `json:"AccessKeyId"`
@@ -268,12 +271,9 @@ func (s *publishedStore) secretValue(ctx context.Context, creds *credentials, re
 		return "", fmt.Errorf("resolving secret '%s': request failed: %w", original, err)
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := readAWSResponse(resp, "AWS Secrets Manager", true)
 	if err != nil {
-		return "", fmt.Errorf("resolving secret '%s': reading response: %w", original, err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("resolving secret '%s': AWS Secrets Manager returned HTTP %d: %s", original, resp.StatusCode, httpx.TruncateBody(body))
+		return "", fmt.Errorf("resolving secret '%s': %w", original, err)
 	}
 	var result struct {
 		SecretString *string `json:"SecretString"`
@@ -285,6 +285,40 @@ func (s *publishedStore) secretValue(ctx context.Context, creds *credentials, re
 		return "", fmt.Errorf("resolving secret '%s': SecretString is empty (binary secrets are not supported)", original)
 	}
 	return *result.SecretString, nil
+}
+
+func ecsCredentialsEndpoint(relativeURI string) (string, error) {
+	if !strings.HasPrefix(relativeURI, "/") {
+		return "", fmt.Errorf("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is invalid")
+	}
+	relative, err := url.Parse(relativeURI)
+	if err != nil || relative.IsAbs() || relative.Host != "" || relative.User != nil || relative.Fragment != "" {
+		return "", fmt.Errorf("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is invalid")
+	}
+
+	endpoint := ecsMetadataEndpoint + relativeURI
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme != "http" || parsed.Host != "169.254.170.2" || parsed.User != nil {
+		return "", fmt.Errorf("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is invalid")
+	}
+	return endpoint, nil
+}
+
+func readAWSResponse(resp *http.Response, operation string, includeErrorBody bool) ([]byte, error) {
+	body, err := httpx.ReadResponseBody(resp.Body, responseBodyLimit)
+	if resp.StatusCode != http.StatusOK {
+		if err != nil && !errors.Is(err, httpx.ErrResponseTooLarge) {
+			return nil, fmt.Errorf("reading %s response: %w", operation, err)
+		}
+		if includeErrorBody {
+			return nil, fmt.Errorf("%s returned HTTP %d: %s", operation, resp.StatusCode, httpx.TruncateBody(body))
+		}
+		return nil, fmt.Errorf("%s returned HTTP %d", operation, resp.StatusCode)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading %s response: %w", operation, err)
+	}
+	return body, nil
 }
 
 func secretsManagerHost(region string) string {

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/resolve.go
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/resolve.go
@@ -142,8 +142,7 @@ func (s *publishedStore) ecsCredentials(ctx context.Context, relativeURI string)
 	if err != nil {
 		return nil, fmt.Errorf("ECS credentials request failed: %w", err)
 	}
-	defer resp.Body.Close()
-	body, err := readAWSResponse(resp, "ECS credentials", true)
+	body, err := readAndCloseAWSResponse(resp, "ECS credentials", true)
 	if err != nil {
 		return nil, err
 	}
@@ -175,8 +174,7 @@ func (s *publishedStore) imdsCredentials(ctx context.Context) (*credentials, err
 	if err != nil {
 		return nil, fmt.Errorf("IMDS token request failed: %w", err)
 	}
-	defer tokenResp.Body.Close()
-	tokenBody, err := readAWSResponse(tokenResp, "IMDS token request", false)
+	tokenBody, err := readAndCloseAWSResponse(tokenResp, "IMDS token request", false)
 	if err != nil {
 		return nil, err
 	}
@@ -194,8 +192,7 @@ func (s *publishedStore) imdsCredentials(ctx context.Context) (*credentials, err
 	if err != nil {
 		return nil, fmt.Errorf("IMDS role request failed: %w", err)
 	}
-	defer roleResp.Body.Close()
-	roleBody, err := readAWSResponse(roleResp, "IMDS role request", false)
+	roleBody, err := readAndCloseAWSResponse(roleResp, "IMDS role request", false)
 	if err != nil {
 		return nil, err
 	}
@@ -213,8 +210,7 @@ func (s *publishedStore) imdsCredentials(ctx context.Context) (*credentials, err
 	if err != nil {
 		return nil, fmt.Errorf("IMDS credentials request failed: %w", err)
 	}
-	defer credResp.Body.Close()
-	credBody, err := readAWSResponse(credResp, "IMDS credentials request", false)
+	credBody, err := readAndCloseAWSResponse(credResp, "IMDS credentials request", false)
 	if err != nil {
 		return nil, err
 	}
@@ -270,8 +266,7 @@ func (s *publishedStore) secretValue(ctx context.Context, creds *credentials, re
 	if err != nil {
 		return "", fmt.Errorf("resolving secret '%s': request failed: %w", original, err)
 	}
-	defer resp.Body.Close()
-	body, err := readAWSResponse(resp, "AWS Secrets Manager", true)
+	body, err := readAndCloseAWSResponse(resp, "AWS Secrets Manager", true)
 	if err != nil {
 		return "", fmt.Errorf("resolving secret '%s': %w", original, err)
 	}
@@ -304,7 +299,9 @@ func ecsCredentialsEndpoint(relativeURI string) (string, error) {
 	return endpoint, nil
 }
 
-func readAWSResponse(resp *http.Response, operation string, includeErrorBody bool) ([]byte, error) {
+func readAndCloseAWSResponse(resp *http.Response, operation string, includeErrorBody bool) ([]byte, error) {
+	defer func() { _ = resp.Body.Close() }()
+
 	body, err := httpx.ReadResponseBody(resp.Body, responseBodyLimit)
 	if resp.StatusCode != http.StatusOK {
 		if err != nil && !errors.Is(err, httpx.ErrResponseTooLarge) {

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/resolve_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/resolve_test.go
@@ -5,12 +5,15 @@ package aws
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore/internal/httpx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -79,6 +82,78 @@ func TestSecretValue_UsesSignedHostHeader(t *testing.T) {
 			}, tc.region, "db/password", "${store:aws-sm:aws_prod:db/password}")
 			require.NoError(t, err)
 			assert.Equal(t, "value", value)
+		})
+	}
+}
+
+func TestSecretValueResponseHandling(t *testing.T) {
+	readErr := errors.New("response read failed")
+	exactValue := strings.Repeat("x", responseBodyLimit-len(`{"SecretString":""}`))
+	tests := map[string]struct {
+		status          int
+		body            string
+		reader          io.Reader
+		wantValueLen    int
+		wantErrContains string
+		wantTooLarge    bool
+	}{
+		"response at limit succeeds": {
+			status:       http.StatusOK,
+			body:         `{"SecretString":"` + exactValue + `"}`,
+			wantValueLen: len(exactValue),
+		},
+		"response above limit fails": {
+			status:          http.StatusOK,
+			body:            strings.Repeat("x", responseBodyLimit+1),
+			wantErrContains: "reading AWS Secrets Manager response",
+			wantTooLarge:    true,
+		},
+		"HTTP status wins over oversized diagnostic body": {
+			status:          http.StatusForbidden,
+			body:            strings.Repeat("x", responseBodyLimit+1),
+			wantErrContains: "AWS Secrets Manager returned HTTP 403",
+		},
+		"read failure fails": {
+			status:          http.StatusOK,
+			reader:          errorReader{err: readErr},
+			wantErrContains: "reading AWS Secrets Manager response",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			reader := tc.reader
+			if reader == nil {
+				reader = strings.NewReader(tc.body)
+			}
+			store := &publishedStore{
+				runtime: &runtime{
+					apiClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: tc.status,
+							Body:       io.NopCloser(reader),
+							Header:     make(http.Header),
+						}, nil
+					})},
+				},
+			}
+
+			value, err := store.secretValue(context.Background(), &credentials{
+				accessKeyID:     "AKID",
+				secretAccessKey: "SECRET",
+			}, "us-east-1", "db/password", "${store:aws-sm:aws_prod:db/password}")
+
+			if tc.wantErrContains == "" {
+				require.NoError(t, err)
+				assert.Len(t, value, tc.wantValueLen)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErrContains)
+			if tc.wantTooLarge {
+				require.ErrorIs(t, err, httpx.ErrResponseTooLarge)
+				return
+			}
+			require.NotErrorIs(t, err, httpx.ErrResponseTooLarge)
 		})
 	}
 }

--- a/src/go/plugin/agent/secrets/secretstore/backends/aws/test.go
+++ b/src/go/plugin/agent/secrets/secretstore/backends/aws/test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+)
+
+const publicErrCredentials = "AWS credentials are unavailable"
+
+func (s *store) Test(ctx context.Context) error {
+	if s == nil || ctx == nil || s.runtime == nil || s.runtime.imdsClient == nil ||
+		s.published == nil || s.published.runtime == nil || s.published.runtime.imdsClient == nil {
+		return errors.New("invalid AWS operational test")
+	}
+	defer s.runtime.imdsClient.CloseIdleConnections()
+
+	if _, err := s.published.credentials(ctx); err != nil {
+		return dyncfg.NewPublicError(publicErrCredentials, fmt.Errorf("AWS credential acquisition failed: %w", err))
+	}
+	return nil
+}

--- a/src/go/plugin/agent/secrets/secretstore/internal/httpx/httpx.go
+++ b/src/go/plugin/agent/secrets/secretstore/internal/httpx/httpx.go
@@ -4,10 +4,14 @@ package httpx
 
 import (
 	"crypto/tls"
+	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 )
+
+var ErrResponseTooLarge = errors.New("HTTP response exceeds size limit")
 
 func noRedirect(*http.Request, []*http.Request) error {
 	return http.ErrUseLastResponse
@@ -22,8 +26,9 @@ func NoProxyClient(timeout time.Duration) *http.Client {
 	transport.Proxy = nil
 
 	return &http.Client{
-		Timeout:   timeout,
-		Transport: transport,
+		Timeout:       timeout,
+		Transport:     transport,
+		CheckRedirect: noRedirect,
 	}
 }
 
@@ -65,4 +70,18 @@ func TruncateBody(body []byte) string {
 		return s[:maxLen] + "..."
 	}
 	return s
+}
+
+func ReadResponseBody(r io.Reader, limit int64) ([]byte, error) {
+	if limit < 0 {
+		return nil, errors.New("HTTP response size limit cannot be negative")
+	}
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return body[:limit], ErrResponseTooLarge
+	}
+	return body, nil
 }

--- a/src/go/plugin/agent/secrets/secretstore/internal/httpx/httpx.go
+++ b/src/go/plugin/agent/secrets/secretstore/internal/httpx/httpx.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -75,6 +76,9 @@ func TruncateBody(body []byte) string {
 func ReadResponseBody(r io.Reader, limit int64) ([]byte, error) {
 	if limit < 0 {
 		return nil, errors.New("HTTP response size limit cannot be negative")
+	}
+	if limit == math.MaxInt64 {
+		return nil, errors.New("HTTP response size limit is too large")
 	}
 	body, err := io.ReadAll(io.LimitReader(r, limit+1))
 	if err != nil {

--- a/src/go/plugin/agent/secrets/secretstore/internal/httpx/httpx_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/internal/httpx/httpx_test.go
@@ -5,6 +5,7 @@ package httpx
 import (
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -137,6 +138,11 @@ func TestReadResponseBody(t *testing.T) {
 			reader:  strings.NewReader("abc"),
 			limit:   -1,
 			wantErr: errors.New("HTTP response size limit cannot be negative"),
+		},
+		"maximum integer limit": {
+			reader:  strings.NewReader("abc"),
+			limit:   math.MaxInt64,
+			wantErr: errors.New("HTTP response size limit is too large"),
 		},
 	}
 

--- a/src/go/plugin/agent/secrets/secretstore/internal/httpx/httpx_test.go
+++ b/src/go/plugin/agent/secrets/secretstore/internal/httpx/httpx_test.go
@@ -3,8 +3,11 @@
 package httpx
 
 import (
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,33 +38,47 @@ func TestVaultInsecureClient_PreservesDefaultTransportBehavior(t *testing.T) {
 	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 }
 
-func TestVaultClient_DoesNotFollowTemporaryRedirects(t *testing.T) {
-	tokenSeen := make(chan string, 1)
-	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tokenSeen <- r.Header.Get("X-Vault-Token")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer target.Close()
+func TestClientsDoNotFollowTemporaryRedirects(t *testing.T) {
+	tests := map[string]struct {
+		client func(time.Duration) *http.Client
+	}{
+		"Vault client": {
+			client: VaultClient,
+		},
+		"no-proxy client": {
+			client: NoProxyClient,
+		},
+	}
 
-	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
-	}))
-	defer redirect.Close()
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tokenSeen := make(chan string, 1)
+			target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tokenSeen <- r.Header.Get("X-Test-Token")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer target.Close()
 
-	client := VaultClient(5 * time.Second)
-	req, err := http.NewRequest(http.MethodGet, redirect.URL, nil)
-	require.NoError(t, err)
-	req.Header.Set("X-Vault-Token", "vault-token")
+			redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+			}))
+			defer redirect.Close()
 
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
+			req, err := http.NewRequest(http.MethodGet, redirect.URL, nil)
+			require.NoError(t, err)
+			req.Header.Set("X-Test-Token", "test-token")
 
-	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
-	select {
-	case seen := <-tokenSeen:
-		t.Fatalf("unexpected redirected request carrying token %q", seen)
-	default:
+			resp, err := tc.client(5 * time.Second).Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+			select {
+			case seen := <-tokenSeen:
+				t.Fatalf("unexpected redirected request carrying token %q", seen)
+			default:
+			}
+		})
 	}
 }
 
@@ -80,4 +97,69 @@ func TestNoProxyClient_PreservesDefaultTransportBehavior(t *testing.T) {
 	assert.Equal(t, defaultTransport.MaxIdleConns, transport.MaxIdleConns)
 	assert.Equal(t, defaultTransport.IdleConnTimeout, transport.IdleConnTimeout)
 	assert.Equal(t, defaultTransport.TLSHandshakeTimeout, transport.TLSHandshakeTimeout)
+	assert.NotNil(t, client.CheckRedirect)
 }
+
+func TestReadResponseBody(t *testing.T) {
+	readErr := errors.New("read failed")
+	tests := map[string]struct {
+		reader  io.Reader
+		limit   int64
+		want    string
+		wantErr error
+	}{
+		"empty body": {
+			reader: strings.NewReader(""),
+			limit:  4,
+		},
+		"body below limit": {
+			reader: strings.NewReader("abc"),
+			limit:  4,
+			want:   "abc",
+		},
+		"body at limit": {
+			reader: strings.NewReader("abcd"),
+			limit:  4,
+			want:   "abcd",
+		},
+		"body above limit": {
+			reader:  strings.NewReader("abcde"),
+			limit:   4,
+			want:    "abcd",
+			wantErr: ErrResponseTooLarge,
+		},
+		"read failure": {
+			reader:  failingReader{err: readErr},
+			limit:   4,
+			wantErr: readErr,
+		},
+		"negative limit": {
+			reader:  strings.NewReader("abc"),
+			limit:   -1,
+			wantErr: errors.New("HTTP response size limit cannot be negative"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			body, err := ReadResponseBody(tc.reader, tc.limit)
+
+			assert.Equal(t, tc.want, string(body))
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			if errors.Is(tc.wantErr, ErrResponseTooLarge) || errors.Is(tc.wantErr, readErr) {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.EqualError(t, err, tc.wantErr.Error())
+		})
+	}
+}
+
+type failingReader struct {
+	err error
+}
+
+func (r failingReader) Read([]byte) (int, error) { return 0, r.err }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an operational Test for the AWS Secrets Manager backend that verifies credential acquisition from `env`, `ecs`, or `imds` using real metadata clients with strict limits and safe public errors. Tightens HTTP handling and metadata validation, and expands tests and docs.

- **New Features**
  - Dynamic Config Test for `aws-sm` runs the configured credential source and discards results.
  - Supports `env`, `ecs` (relative URI only), and `imds` (token → role → creds); never calls Secrets Manager, STS, or KMS.
  - Uses configured timeout; closes idle connections; returns a concise public error when credentials are unavailable.

- **Hardening**
  - Added `httpx.ReadResponseBody` with a 1 MiB cap and unified read-and-close handling; status errors win over oversized diagnostic bodies.
  - `httpx.NoProxyClient` and Vault clients reject redirects; metadata proxies disabled.
  - ECS endpoint parsing and IMDS role-name/empty-token validation improved; all AWS responses are closed promptly.
  - Tests cover IMDS cancellation/timeout during body reads, size-limit paths, and composition flow; docs updated with behavior and limits.

<sup>Written for commit dc1785fbb404e3d7cf7c43b12505e348cabc7040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

