### PR TITLE
docs(agents): bound review iteration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -676,15 +676,23 @@ When user decisions are needed:
 Review findings are leads until they are verified against the shipped code and
 its contracts.
 
-- A merge blocker MUST identify a production-reachable trigger, the violated
+- A shipping blocker MUST identify a production-reachable trigger, the violated
   contract or invariant, the concrete consequence, and supporting code or test
   evidence.
+- Failing required validation or an unmet explicit acceptance criterion is also
+  a shipping blocker, regardless of the reviewer's severity label.
 - An unreachable defensive scenario, optional refactor, style preference, or
   speculative future risk MUST NOT be promoted to a blocker. Reject it with
   evidence, or track it separately when it has independent value.
-- After a validated material correction, repeat the required full review scope.
-  Stop when no verified material correctness, security, deadlock, leak,
-  protocol, resource-consumption, or test-coverage defect remains. Nits alone
+- Optional test expansion, documentation polish, and maintainability suggestions
+  without a concrete current defect MUST NOT extend the review cycle by
+  themselves.
+- One complete review round is the default. Repeat the same full scope only when
+  a verified shipping blocker required a material change to shipped
+  implementation or behavior, or when the prior review could not assess the
+  complete change.
+- Stop when no verified shipping blocker remains. Reviewer unanimity, exact
+  readiness phrases, and zero optional suggestions are NOT required. Nits alone
   MUST NOT keep a review cycle open.
 
 ### Followup Discipline


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound review iteration and clarified when to stop reviews in `AGENTS.md`. Renames “merge blocker” to “shipping blocker,” defines blocker criteria (including failed validations/acceptance), sets one full review round by default with repeats only after material changes, and states that optional suggestions/nits must not extend the cycle.

<sup>Written for commit 2cf73babd19080dee0ca50ccf53d6169e8a0e621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

