### PR TITLE
refactor(go.d/snmp-traps): establish ownership foundations

### DIFF
--- a/src/go/plugin/agent/jobmgr/joboutput/config_factory.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/config_factory.go
@@ -89,7 +89,6 @@ func (cmf *ConfigModuleFactory) Test(ctx context.Context, config confgroup.Confi
 	defer func() {
 		err = errors.Join(err, probe.cleanup(context.WithoutCancel(ctx)))
 	}()
-	setModuleJobName(probe.module, config.Name())
 	redactLifecycle, err := cmf.applyResolved(ctx, config, probe.module)
 	probe.redact = redactLifecycle
 	if err != nil {
@@ -122,7 +121,6 @@ func (cmf *ConfigModuleFactory) Validate(ctx context.Context, config confgroup.C
 	defer func() {
 		err = errors.Join(err, probe.cleanup(context.WithoutCancel(ctx)))
 	}()
-	setModuleJobName(probe.module, config.Name())
 	redactLifecycle, err := cmf.applyResolved(ctx, config, probe.module)
 	probe.redact = redactLifecycle
 	return err

--- a/src/go/plugin/agent/jobmgr/joboutput/config_factory_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/config_factory_test.go
@@ -34,6 +34,7 @@ func TestConfigModuleFactoryCleansEveryAttemptAndPrefersV2(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			state := &factoryTestState{}
+			var module *factoryTestV2
 			v1Creates := 0
 			v2Creates := 0
 			resolver, err := secretresolver.NewAtomicResolver(nil)
@@ -48,10 +49,11 @@ func TestConfigModuleFactoryCleansEveryAttemptAndPrefersV2(t *testing.T) {
 							},
 							CreateV2: func() collectorapi.CollectorV2 {
 								v2Creates++
-								return &factoryTestV2{
+								module = &factoryTestV2{
 									state:    state,
 									checkErr: test.checkErr,
 								}
+								return module
 							},
 						},
 					},
@@ -74,6 +76,7 @@ func TestConfigModuleFactoryCleansEveryAttemptAndPrefersV2(t *testing.T) {
 				require.FailNowf(t, "test failed", "unknown operation %q", test.operation)
 			}
 			require.EqualValues(t, test.wantErr, err != nil)
+			require.Equal(t, config.Name(), module.Name)
 			require.False(
 				t,
 				v1Creates != 0 || v2Creates != test.wantCreates || state.collectorCleanup != test.wantCreates,

--- a/src/go/plugin/agent/jobmgr/joboutput/factory.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/factory.go
@@ -59,10 +59,6 @@ type JobHandlerAttacher interface {
 	Attach(lifecycle.ResourceIdentity, StagedHandlerLifecycle) (ProcessHandlerLifecycle, error)
 }
 
-type jobNamedModule interface {
-	SetJobName(string)
-}
-
 type FactoryConfig struct {
 	Epoch           uint64                                        // target run generation
 	PluginName      string                                        // owning plugin name stamped into job config
@@ -481,7 +477,6 @@ func (f *Factory) buildV1(
 	if module == nil {
 		return nil, nil, false, fmt.Errorf("job output: module %q returned a nil V1 collector", config.Module())
 	}
-	setModuleJobName(module, config.Name())
 	redactLifecycle, storeSnapshot, err =
 		f.config.ConfigModules.applyResolvedWithSnapshot(ctx, config, module)
 	if err != nil {
@@ -560,7 +555,6 @@ func (f *Factory) buildV2(
 	if module == nil {
 		return nil, nil, nil, false, fmt.Errorf("job output: module %q returned a nil V2 collector", config.Module())
 	}
-	setModuleJobName(module, config.Name())
 	redactLifecycle, storeSnapshot, err =
 		f.config.ConfigModules.applyResolvedWithSnapshot(ctx, config, module)
 	if err != nil {
@@ -667,10 +661,4 @@ func factoryLabels(config confgroup.Config) map[string]string {
 
 func creatorDeclaresFunctions(creator collectorapi.Creator) bool {
 	return creator.SharedFunctions != nil || creator.AgentFunctions != nil || creator.InstanceFunctions != nil
-}
-
-func setModuleJobName(module any, name string) {
-	if named, ok := module.(jobNamedModule); ok {
-		named.SetJobName(name)
-	}
 }

--- a/src/go/plugin/agent/jobmgr/joboutput/factory_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/factory_test.go
@@ -71,6 +71,38 @@ func TestCreatorDeclaresFunctions(t *testing.T) {
 	}
 }
 
+func TestFactoryDecodesJobNameIntoCollector(t *testing.T) {
+	state := &factoryTestState{}
+	var module *factoryTestV2
+	creator := collectorapi.Creator{
+		CreateV2: func() collectorapi.CollectorV2 {
+			module = &factoryTestV2{
+				state:    state,
+				store:    metrix.NewCollectorStore(),
+				template: factoryTestChartTemplate,
+			}
+			return module
+		},
+	}
+	factory, _ := newFactoryTestHarness(t, creator, nil)
+	permit, tasks := issueTestJobPermit(t, "module_job", 1)
+
+	prepared, failure, err := prepareFactoryTestCandidate(
+		context.Background(),
+		factory,
+		factoryTestConfig(false),
+		lifecycle.ResourceIdentity{ID: "module_job", Generation: 1},
+		permit,
+	)
+	require.NoError(t, err)
+	require.Nil(t, failure)
+	require.Equal(t, "job", module.Name)
+
+	require.NoError(t, prepared.Dispose(context.Background()))
+	requireFactoryAttemptsIdle(t, factory)
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+}
+
 func TestFactoryStagesFunctionsAfterManagedProbe(t *testing.T) {
 	tests := map[string]func(*factoryTestState) collectorapi.Creator{
 		"V1": func(state *factoryTestState) collectorapi.Creator {
@@ -1482,6 +1514,7 @@ type factoryTestState struct {
 
 type factoryTestV2 struct {
 	collectorapi.Base
+	Name           string `yaml:"name"`
 	OptionStr      string `yaml:"option_str"`
 	state          *factoryTestState
 	init           func(context.Context) error

--- a/src/go/plugin/agent/jobmgr/joboutput/factory_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/factory_test.go
@@ -71,7 +71,7 @@ func TestCreatorDeclaresFunctions(t *testing.T) {
 	}
 }
 
-func TestFactoryDecodesJobNameIntoCollector(t *testing.T) {
+func TestFactoryDecodesJobNameAndIgnoresUnknownCollectorFields(t *testing.T) {
 	state := &factoryTestState{}
 	var module *factoryTestV2
 	creator := collectorapi.Creator{
@@ -86,11 +86,14 @@ func TestFactoryDecodesJobNameIntoCollector(t *testing.T) {
 	}
 	factory, _ := newFactoryTestHarness(t, creator, nil)
 	permit, tasks := issueTestJobPermit(t, "module_job", 1)
+	config := factoryTestConfig(false)
+	config["unknown_top_level"] = true
+	config["unknown_nested"] = map[string]any{"field": true}
 
 	prepared, failure, err := prepareFactoryTestCandidate(
 		context.Background(),
 		factory,
-		factoryTestConfig(false),
+		config,
 		lifecycle.ResourceIdentity{ID: "module_job", Generation: 1},
 		permit,
 	)

--- a/src/go/plugin/go.d/collector/snmp_traps/benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/benchmark_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gosnmp/gosnmp"
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/pkg/multipath"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 // ---------------------------------------------------------------------------
@@ -27,8 +28,8 @@ func buildBenchV2cTrap(b testing.TB, community, trapOID string, extra ...gosnmp.
 	b.Helper()
 	x := &gosnmp.GoSNMP{Version: gosnmp.Version2c, Community: community}
 	pdus := []gosnmp.SnmpPDU{
-		{Name: sysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
-		{Name: snmpTrapOIDOID, Type: gosnmp.ObjectIdentifier, Value: trapOID},
+		{Name: model.SysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
+		{Name: model.SNMPTrapOID, Type: gosnmp.ObjectIdentifier, Value: trapOID},
 	}
 	pdus = append(pdus, extra...)
 	data, err := x.MkSnmpPacket(gosnmp.SNMPv2Trap, pdus, 0, 0).MarshalMsg()
@@ -137,7 +138,7 @@ func BenchmarkPacketTrap(b *testing.B) {
 
 	writer := &countingWriter{}
 	c := &Collector{
-		jobName:    jobName,
+		Config:     Config{Name: jobName},
 		trapWriter: writer,
 		versions:   map[SnmpVersion]struct{}{SnmpVersionV2c: {}},
 		allowlist:  NewAllowlist(nil, []string{"public"}),
@@ -191,7 +192,7 @@ func BenchmarkMultiJob(b *testing.B) {
 				peers[i] = net.ParseIP(fmt.Sprintf("10.1.2.%d", i+1))
 				writers[i] = &countingWriter{}
 				collectors[i] = &Collector{
-					jobName:    jn,
+					Config:     Config{Name: jn},
 					trapWriter: writers[i],
 					versions:   map[SnmpVersion]struct{}{SnmpVersionV2c: {}},
 					allowlist:  NewAllowlist(nil, []string{"public"}),
@@ -277,7 +278,7 @@ func BenchmarkProfileMetricRuntimeUpdateAndCollect(b *testing.B) {
 	if err != nil {
 		b.Fatalf("normalizeProfileMetricsConfig: %v", err)
 	}
-	rt, _, err := newProfileMetricRuntime(cfg, idx)
+	rt, _, err := newProfileMetricRuntime(cfg, idx, "benchmark")
 	if err != nil {
 		b.Fatalf("newProfileMetricRuntime: %v", err)
 	}
@@ -408,8 +409,8 @@ func benchmarkProfileMetricIndex(b testing.TB) *ProfileIndex {
 						"4": "aux",
 					},
 				},
-				sysUpTimeOID: {
-					OID:     sysUpTimeOID,
+				model.SysUpTimeOID: {
+					OID:     model.SysUpTimeOID,
 					Type:    "TimeTicks",
 					rawName: "sysUpTime.0",
 				},
@@ -496,7 +497,7 @@ func benchmarkProfileMetricConfigTrapEntry(jobName, sourceIP string, terminalTyp
 		}},
 		Varbinds: []VarbindValue{
 			{OID: testCiscoTerminalTypeOID, Type: "INTEGER", Value: terminalType},
-			{OID: sysUpTimeOID, Type: "TimeTicks", Value: uint64(12345)},
+			{OID: model.SysUpTimeOID, Type: "TimeTicks", Value: uint64(12345)},
 		},
 	}
 }
@@ -631,7 +632,7 @@ func BenchmarkFullPacketToJournal(b *testing.B) {
 	}
 	tw := newJournalTrapWriter(w, 1<<20)
 	c := &Collector{
-		jobName:    "bench-full",
+		Config:     Config{Name: "bench-full"},
 		trapWriter: tw,
 		versions:   map[SnmpVersion]struct{}{SnmpVersionV2c: {}},
 		allowlist:  NewAllowlist(nil, []string{"public"}),
@@ -750,7 +751,7 @@ func newUDPPacketToJournalBenchmark(b *testing.B) *udpPacketToJournalBenchmark {
 	})
 
 	c := &Collector{
-		jobName:    "bench-udp",
+		Config:     Config{Name: "bench-udp"},
 		trapWriter: tw,
 		versions:   map[SnmpVersion]struct{}{SnmpVersionV2c: {}},
 		allowlist:  NewAllowlist(nil, []string{"public"}),

--- a/src/go/plugin/go.d/collector/snmp_traps/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/collector.go
@@ -19,6 +19,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/hostidentity"
 )
 
 //go:embed "config_schema.json"
@@ -54,12 +55,15 @@ func newCreator(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.
 	if topologyEnricher == nil {
 		panic("snmp_traps Register requires a non-nil trap enrichment handle")
 	}
+	hostIdentity := newHostIdentityService()
 	return collectorapi.Creator{
 		JobConfigSchema: configSchema,
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 1,
 		},
-		CreateV2:       func() collectorapi.CollectorV2 { return New(deviceStore, topologyEnricher) },
+		CreateV2: func() collectorapi.CollectorV2 {
+			return newCollector(deviceStore, topologyEnricher, hostIdentity, netdataEngineStateRoot)
+		},
 		Config:         func() any { return &Config{} },
 		AgentFunctions: snmpTrapsMethods,
 		MethodHandler:  snmpTrapsMethodHandler,
@@ -74,6 +78,15 @@ func New(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.TrapEnr
 	if topologyEnricher == nil {
 		panic("snmp_traps New requires a non-nil trap enrichment handle")
 	}
+	return newCollector(deviceStore, topologyEnricher, newHostIdentityService(), netdataEngineStateRoot)
+}
+
+func newCollector(
+	deviceStore *ddsnmp.DeviceStore,
+	topologyEnricher *snmptopology.TrapEnrichmentHandle,
+	hostIdentity *hostidentity.Service,
+	engineStateRoot func() string,
+) *Collector {
 	store := metrix.NewCollectorStore()
 
 	return &Collector{
@@ -86,6 +99,8 @@ func New(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.TrapEnr
 		store:            store,
 		deviceLookup:     deviceStore,
 		topologyEnricher: topologyEnricher,
+		hostIdentity:     hostIdentity,
+		engineStateRoot:  engineStateRoot,
 	}
 }
 
@@ -100,7 +115,8 @@ type Collector struct {
 	store              metrix.CollectorStore
 	deviceLookup       deviceLookup
 	topologyEnricher   trapTopologyEnricher
-	jobName            string
+	hostIdentity       *hostidentity.Service
+	engineStateRoot    func() string
 	vnode              string
 	versions           map[SnmpVersion]struct{}
 	allowlist          *Allowlist
@@ -129,85 +145,15 @@ func (c *Collector) Configuration() any {
 	return c.Config
 }
 
-func (c *Collector) SetJobName(name string) {
-	c.jobName = name
-}
-
 func (c *Collector) Init(ctx context.Context) error {
-	if err := validateJobName(c.jobName); err != nil {
+	if err := c.Config.Validate(); err != nil {
 		return dyncfgConfigError(err)
 	}
-
-	if err := validateListenConfig(c.Listen); err != nil {
-		return dyncfgConfigError(err)
-	}
-
-	versions, err := validateVersions(c.Versions)
+	validated, err := validateConfig(c.Config)
 	if err != nil {
 		return dyncfgConfigError(err)
 	}
-	v3Enabled := versionListContains(versions, "v3")
-
-	if err := validateUSMUsers(c.USMUsers, c.DynamicEngineID); err != nil {
-		return dyncfgConfigError(err)
-	}
-
-	if err := validateEngineIDWhitelist(c.EngineIDWhitelist); err != nil {
-		return dyncfgConfigError(err)
-	}
-
-	if err := validateLocalEngineID(c.LocalEngineID); err != nil {
-		return dyncfgConfigError(err)
-	}
-
-	allowlistPrefixes, err := validateAllowlist(c.Allowlist)
-	if err != nil {
-		return dyncfgConfigError(err)
-	}
-	trustedRelays, err := validateTrustedRelays(c.Source)
-	if err != nil {
-		return dyncfgConfigError(err)
-	}
-	c.warnCatchAllTrustedRelays(trustedRelays)
-
-	if err := validateRateLimit(c.RateLimit); err != nil {
-		return dyncfgConfigError(err)
-	}
-	if err := validateDedupConfig(c.Dedup); err != nil {
-		return dyncfgConfigError(err)
-	}
-	otlpRuntime, err := validateOTLPConfig(c.OTLP)
-	if err != nil {
-		return dyncfgConfigError(err)
-	}
-	journalEnabled := c.Journal.enabled()
-	if !journalEnabled && !c.OTLP.Enabled {
-		return dyncfgConfigError(errors.New("at least one SNMP trap output backend must be enabled: journal.enabled or otlp.enabled"))
-	}
-
-	if err := validateOverrides(c.Overrides); err != nil {
-		return dyncfgConfigError(err)
-	}
-	if err := validateDeferredConfig(c.Config); err != nil {
-		return dyncfgConfigError(err)
-	}
-	if v3Enabled {
-		if len(c.USMUsers) == 0 {
-			return dyncfgConfigError(errors.New("SNMPv3 requires at least one usm_users entry"))
-		}
-		if !c.DynamicEngineID && len(c.EngineIDWhitelist) == 0 {
-			return dyncfgConfigError(errors.New("SNMPv3 requires engine_id_whitelist when dynamic_engine_id_discovery is disabled"))
-		}
-	}
-
-	var retCfg RetentionConfig
-	if journalEnabled {
-		ret, err := parseRetentionConfig(c.Retention)
-		if err != nil {
-			return dyncfgConfigError(err)
-		}
-		retCfg = ret
-	}
+	c.warnCatchAllTrustedRelays(validated.trustedRelays)
 
 	if c.listener != nil {
 		return nil
@@ -231,13 +177,8 @@ func (c *Collector) Init(ctx context.Context) error {
 		releaseProfiles()
 		return dyncfgConfigError(errors.New("profile index not available"))
 	}
-	profileMetricCfg, err := normalizeProfileMetricsConfig(c.ProfileMetrics)
-	if err != nil {
-		releaseProfiles()
-		return dyncfgConfigError(err)
-	}
-	if profileMetricCfg.enabled {
-		rt, tmpl, err := newProfileMetricRuntime(profileMetricCfg, idx)
+	if validated.profileMetrics.enabled {
+		rt, tmpl, err := newProfileMetricRuntime(validated.profileMetrics, idx, c.sourceHashSalt())
 		if err != nil {
 			releaseProfiles()
 			return dyncfgConfigError(err)
@@ -247,22 +188,26 @@ func (c *Collector) Init(ctx context.Context) error {
 	}
 
 	var journalWriter *JournalWriter
-	if journalEnabled {
+	if validated.journalEnabled {
 		if err := validateNetdataLogRoot(); err != nil {
 			releaseProfiles()
 			return dyncfgStartupError(err)
 		}
-		dir := journalRoot(c.jobName)
-		journalCfg := retCfg.makeJournalConfig()
-		var err error
-		journalWriter, err = NewJournalWriter(dir, journalCfg)
+		dir := journalRoot(c.Name)
+		journalCfg := validated.retention.makeJournalConfig()
+		host, err := c.hostIdentity.FreshJournal()
+		if err != nil {
+			releaseProfiles()
+			return dyncfgStartupError(err)
+		}
+		journalWriter, err = newJournalWriterWithHostProvider(dir, journalCfg, host)
 		if err != nil {
 			releaseProfiles()
 			return dyncfgStartupError(err)
 		}
 	}
 
-	listener, err := newListener(c.jobName, c.Listen)
+	listener, err := newListener(c.Name, c.Listen)
 	if err != nil {
 		releaseProfiles()
 		if journalWriter != nil {
@@ -282,27 +227,33 @@ func (c *Collector) Init(ctx context.Context) error {
 	var lid *LocalEngineID
 	var v3Table *gosnmp.SnmpV3SecurityParametersTable
 	var engineIDWhitelist map[string]struct{}
+	var enginePaths engineStatePaths
 	cleanupCreatedState := func() {
 		// No engine-state files exist unless SNMPv3 setup below creates them.
 	}
-	if v3Enabled {
-		engineBootsExisted, err := engineStatePathExistsChecked(engineBootsPath(c.jobName))
+	if validated.v3Enabled {
+		if c.engineStateRoot == nil {
+			cleanupPreflight()
+			return dyncfgStartupError(errors.New("SNMP engine state root is not configured"))
+		}
+		enginePaths = newEngineStatePaths(c.engineStateRoot(), c.Name)
+		engineBootsExisted, err := engineStatePathExistsChecked(enginePaths.engineBoots)
 		if err != nil {
 			cleanupPreflight()
 			return dyncfgStartupError(err)
 		}
-		localEngineIDExisted, err := engineStatePathExistsChecked(localEngineIDPath(c.jobName))
+		localEngineIDExisted, err := engineStatePathExistsChecked(enginePaths.localEngineID)
 		if err != nil {
 			cleanupPreflight()
 			return dyncfgStartupError(err)
 		}
-		engineStateDirExisted, err := engineStatePathExistsChecked(engineBootsDir(c.jobName))
+		engineStateDirExisted, err := engineStatePathExistsChecked(enginePaths.dir)
 		if err != nil {
 			cleanupPreflight()
 			return dyncfgStartupError(err)
 		}
 		cleanupCreatedState = func() {
-			cleanupCreatedEngineState(c.jobName, !engineBootsExisted, !localEngineIDExisted, !engineStateDirExisted)
+			cleanupCreatedEngineState(enginePaths, !engineBootsExisted, !localEngineIDExisted, !engineStateDirExisted)
 		}
 
 		v3Table, err = buildSnmpV3SecurityTable(c.USMUsers, c.DynamicEngineID)
@@ -318,7 +269,7 @@ func (c *Collector) Init(ctx context.Context) error {
 			return dyncfgConfigError(err)
 		}
 
-		lid, err = NewLocalEngineID(c.jobName, c.LocalEngineID)
+		lid, err = NewLocalEngineID(enginePaths, c.LocalEngineID)
 		if err != nil {
 			cleanupCreatedState()
 			cleanupPreflight()
@@ -330,7 +281,7 @@ func (c *Collector) Init(ctx context.Context) error {
 			return dyncfgConfigError(err)
 		}
 
-		eb, err = NewEngineBoots(c.jobName)
+		eb, err = NewEngineBoots(enginePaths)
 		if err != nil {
 			cleanupCreatedState()
 			cleanupPreflight()
@@ -339,16 +290,17 @@ func (c *Collector) Init(ctx context.Context) error {
 	}
 
 	overrides := buildOverrideMap(c.Overrides)
-	metrics := getJobMetrics(c.jobName)
+	metrics := getJobMetrics(c.Name)
+	metrics.setSourceHashSaltProvider(c.sourceHashSalt)
 	listener.metrics = metrics
 	listener.onReadError = c.logListenerReadError
 	c.reportListenerReceiveBufferWarnings(listener.receiveBufferWarnings)
 	var secondaryWriter TrapWriter
 	if c.OTLP.Enabled {
-		c.warnPlaintextOTLP(otlpRuntime)
-		secondaryWriter, err = newOTLPTrapWriterWithRuntimeConfig(ctx, c.jobName, otlpRuntime, metrics, journalWriter == nil)
+		c.warnPlaintextOTLP(validated.otlp)
+		secondaryWriter, err = newOTLPTrapWriterWithRuntimeConfig(ctx, c.Name, validated.otlp, metrics, journalWriter == nil)
 		if err != nil {
-			removeJobMetrics(c.jobName)
+			removeJobMetrics(c.Name)
 			cleanupCreatedState()
 			cleanupPreflight()
 			return dyncfgStartupError(err)
@@ -358,7 +310,7 @@ func (c *Collector) Init(ctx context.Context) error {
 	writeFailureDim := trapWriteFailureJournal
 	if journalWriter != nil {
 		primaryWriter = newJournalTrapWriter(journalWriter, defaultQueueCapacity, func(err error) {
-			c.warnf("SNMP trap journal writer stopped for job %q: %v", c.jobName, err)
+			c.warnf("SNMP trap journal writer stopped for job %q: %v", c.Name, err)
 		})
 	}
 	trapWriter := newFanoutTrapWriter(primaryWriter, secondaryWriter, metrics)
@@ -366,13 +318,13 @@ func (c *Collector) Init(ctx context.Context) error {
 		writeFailureDim = trapWriteFailureOTLP
 	}
 	metrics.setDedupEnabled(c.Dedup.Enabled)
-	deduper := newTrapDeduper(c.jobName, c.Dedup, trapWriter, metrics, writeFailureDim, c.monotonicUsec)
+	deduper := newTrapDeduper(c.Name, c.Dedup, trapWriter, metrics, writeFailureDim, c.monotonicUsec)
 
-	c.Versions = versions
+	c.Versions = validated.versions
 	c.vnode = c.Vnode
-	c.versions = versionSet(versions)
-	c.allowlist = NewAllowlist(allowlistPrefixes, c.Communities)
-	c.trustedRelays = trustedRelays
+	c.versions = versionSet(validated.versions)
+	c.allowlist = NewAllowlist(validated.allowlist, c.Communities)
+	c.trustedRelays = validated.trustedRelays
 	c.rateLimiter = newRateLimiter(c.RateLimit.Enabled, c.RateLimit.PerSourcePPS, c.RateLimit.Mode)
 	c.engineBoots = eb
 	c.localEngineID = lid
@@ -459,7 +411,7 @@ func (c *Collector) Cleanup(ctx context.Context) {
 	if c.journalDir != "" {
 		activeDirectJournalJobs.Add(-1)
 	}
-	removeJobMetrics(c.jobName)
+	removeJobMetrics(c.Name)
 	c.metrics = nil
 	c.profileMetrics = nil
 	c.dynamicChartYAML = ""
@@ -499,9 +451,9 @@ func (c *Collector) collect(ctx context.Context) error {
 			c.metrics.setBinaryEncoded(w.BinaryEncodedFields())
 		}
 	}
-	collectMetrics(c.store, c.jobName)
+	collectMetrics(c.store, c.Name)
 	if c.profileMetrics != nil {
-		c.profileMetrics.collect(c.store, c.jobName)
+		c.profileMetrics.collect(c.store, c.Name)
 	}
 	return nil
 }
@@ -661,7 +613,7 @@ func (c *Collector) handlePacket(data []byte, peerIP net.IP, conn *net.UDPConn, 
 		td = c.applyOverrides(td)
 	}
 
-	entry := trapEntryFromPDU(c.jobName, pdu, td, time.Now().UnixMicro(), c.monotonicUsec())
+	entry := trapEntryFromPDU(c.Name, pdu, td, time.Now().UnixMicro(), c.monotonicUsec())
 	entry.PacketSequence = packetSequence
 	c.enrichTrapEntry(entry, c.reverseDNSEnabled, c.reverseDNS)
 	renderTrapEntryTemplates(entry, td)

--- a/src/go/plugin/go.d/collector/snmp_traps/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/collector.go
@@ -269,7 +269,7 @@ func (c *Collector) Init(ctx context.Context) error {
 			return dyncfgConfigError(err)
 		}
 
-		lid, err = NewLocalEngineID(enginePaths, c.LocalEngineID)
+		lid, err = newLocalEngineID(enginePaths, c.LocalEngineID)
 		if err != nil {
 			cleanupCreatedState()
 			cleanupPreflight()
@@ -281,7 +281,7 @@ func (c *Collector) Init(ctx context.Context) error {
 			return dyncfgConfigError(err)
 		}
 
-		eb, err = NewEngineBoots(enginePaths)
+		eb, err = newEngineBoots(enginePaths)
 		if err != nil {
 			cleanupCreatedState()
 			cleanupPreflight()

--- a/src/go/plugin/go.d/collector/snmp_traps/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/collector.go
@@ -146,9 +146,6 @@ func (c *Collector) Configuration() any {
 }
 
 func (c *Collector) Init(ctx context.Context) error {
-	if err := c.Config.Validate(); err != nil {
-		return dyncfgConfigError(err)
-	}
 	validated, err := validateConfig(c.Config)
 	if err != nil {
 		return dyncfgConfigError(err)

--- a/src/go/plugin/go.d/collector/snmp_traps/collector_e2e_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/collector_e2e_test.go
@@ -18,7 +18,7 @@ func TestCollectorReplayPcapThroughListenerToJournal(t *testing.T) {
 
 	port := freeUDPPort(t)
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("e2e")
+	c.Name = "e2e"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 	c.Versions = []string{"v2c"}
 	c.Communities = []string{"public"}

--- a/src/go/plugin/go.d/collector/snmp_traps/config.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/config.go
@@ -2,8 +2,6 @@
 
 package snmp_traps
 
-import "fmt"
-
 type EndpointConfig struct {
 	Protocol string `yaml:"protocol" json:"protocol"`
 	Address  string `yaml:"address" json:"address"`
@@ -70,6 +68,7 @@ type ReverseDNSConfig struct {
 }
 
 type Config struct {
+	Name               string               `yaml:"name,omitempty" json:"name"`
 	Vnode              string               `yaml:"vnode,omitempty" json:"vnode"`
 	ReverseDNS         ReverseDNSConfig     `yaml:"reverse_dns,omitempty" json:"reverse_dns"`
 	UpdateEvery        int                  `yaml:"update_every,omitempty" json:"update_every"`
@@ -95,152 +94,4 @@ type Config struct {
 type ListenConfig struct {
 	Endpoints     []EndpointConfig `yaml:"endpoints" json:"endpoints"`
 	ReceiveBuffer int              `yaml:"receive_buffer,omitempty" json:"receive_buffer"`
-}
-
-type yamlKeySpec struct {
-	children map[string]yamlKeySpec
-	elem     *yamlKeySpec
-	allowAny bool
-}
-
-var (
-	endpointYAMLSpec = yamlKeySpec{children: map[string]yamlKeySpec{
-		"protocol": {},
-		"address":  {},
-		"port":     {},
-	}}
-
-	usmUserYAMLSpec = yamlKeySpec{children: map[string]yamlKeySpec{
-		"username":   {},
-		"engine_id":  {},
-		"auth_proto": {},
-		"auth_key":   {},
-		"priv_proto": {},
-		"priv_key":   {},
-	}}
-
-	overrideYAMLSpec = yamlKeySpec{children: map[string]yamlKeySpec{
-		"oid":      {},
-		"category": {},
-		"severity": {},
-		"labels":   {allowAny: true},
-	}}
-
-	profileMetricIdentityConfigYAMLSpec = yamlKeySpec{children: map[string]yamlKeySpec{
-		"device":            {},
-		"unresolved_source": {},
-		"source_id_privacy": {},
-	}}
-
-	profileMetricLimitsConfigYAMLSpec = yamlKeySpec{children: map[string]yamlKeySpec{
-		"max_rules":                {},
-		"max_sources":              {},
-		"max_resources_per_source": {},
-		"max_instances_per_job":    {},
-		"overflow":                 {},
-	}}
-
-	profileMetricsConfigYAMLSpec = yamlKeySpec{children: map[string]yamlKeySpec{
-		"enabled":  {},
-		"mode":     {},
-		"include":  {},
-		"identity": profileMetricIdentityConfigYAMLSpec,
-		"limits":   profileMetricLimitsConfigYAMLSpec,
-	}}
-
-	configYAMLSpec = yamlKeySpec{children: map[string]yamlKeySpec{
-		"__provider__":                {},
-		"__source__":                  {},
-		"__source_type__":             {},
-		"autodetection_retry":         {},
-		"function_only":               {},
-		"labels":                      {allowAny: true},
-		"module":                      {},
-		"name":                        {},
-		"priority":                    {},
-		"vnode":                       {},
-		"reverse_dns":                 {children: map[string]yamlKeySpec{"enabled": {}}},
-		"update_every":                {},
-		"listen":                      {children: map[string]yamlKeySpec{"endpoints": {elem: &endpointYAMLSpec}, "receive_buffer": {}}},
-		"versions":                    {},
-		"communities":                 {},
-		"usm_users":                   {elem: &usmUserYAMLSpec},
-		"engine_id_whitelist":         {},
-		"local_engine_id":             {},
-		"dynamic_engine_id_discovery": {},
-		"dynamic_engine_id_max_pairs": {},
-		"allowlist":                   {children: map[string]yamlKeySpec{"source_cidrs": {}}},
-		"source":                      {children: map[string]yamlKeySpec{"trusted_relays": {}}},
-		"rate_limit":                  {children: map[string]yamlKeySpec{"enabled": {}, "per_source_pps": {}, "mode": {}}},
-		"dedup":                       {children: map[string]yamlKeySpec{"enabled": {}, "window_sec": {}, "cache_max_entries": {}, "key_varbinds": {}}},
-		"journal":                     {children: map[string]yamlKeySpec{"enabled": {}}},
-		"otlp":                        {children: map[string]yamlKeySpec{"enabled": {}, "endpoint": {}, "headers": {allowAny: true}, "request_timeout": {}, "flush_interval": {}, "batch_size": {}, "queue_capacity": {}}},
-		"retention":                   {children: map[string]yamlKeySpec{"max_size": {}, "max_duration": {}, "rotation_size": {}, "rotation_duration": {}}},
-		"overrides":                   {elem: &overrideYAMLSpec},
-		"profile_metrics":             profileMetricsConfigYAMLSpec,
-	}}
-)
-
-func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
-	var raw any
-	if err := unmarshal(&raw); err != nil {
-		return err
-	}
-	if err := rejectUnknownYAMLKeys(raw, configYAMLSpec, ""); err != nil {
-		return err
-	}
-
-	type plain Config
-	return unmarshal((*plain)(c))
-}
-
-func rejectUnknownYAMLKeys(node any, spec yamlKeySpec, path string) error {
-	if spec.allowAny || node == nil {
-		return nil
-	}
-
-	switch v := node.(type) {
-	case map[any]any:
-		if spec.children == nil {
-			return nil
-		}
-		for rawKey, rawValue := range v {
-			key, ok := rawKey.(string)
-			if !ok {
-				if path == "" {
-					return fmt.Errorf("config key %v is not a string", rawKey)
-				}
-				return fmt.Errorf("%s: config key %v is not a string", path, rawKey)
-			}
-			child, ok := spec.children[key]
-			if !ok {
-				if path == "" {
-					if key == "metrics" {
-						return fmt.Errorf("job-level metrics is not supported; define trap metric rules in profiles and enable them with profile_metrics")
-					}
-					return fmt.Errorf("unknown config key %q", key)
-				}
-				return fmt.Errorf("%s: unknown config key %q", path, key)
-			}
-			childPath := key
-			if path != "" {
-				childPath = path + "." + key
-			}
-			if err := rejectUnknownYAMLKeys(rawValue, child, childPath); err != nil {
-				return err
-			}
-		}
-	case []any:
-		if spec.elem == nil {
-			return nil
-		}
-		for i, item := range v {
-			itemPath := fmt.Sprintf("%s[%d]", path, i)
-			if err := rejectUnknownYAMLKeys(item, *spec.elem, itemPath); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
 }

--- a/src/go/plugin/go.d/collector/snmp_traps/decode.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/decode.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 const (
@@ -28,11 +29,6 @@ const (
 
 	snmpV1TrapTypeEnterpriseSpec = 6
 
-	sysUpTimeOID          = "1.3.6.1.2.1.1.3.0"
-	snmpTrapOIDOID        = "1.3.6.1.6.3.1.1.4.1.0"
-	snmpTrapAddressOID    = "1.3.6.1.6.3.18.1.3.0"
-	snmpTrapCommunityOID  = "1.3.6.1.6.3.18.1.4.0"
-	snmpTrapEnterpriseOID = "1.3.6.1.6.3.1.1.4.3.0"
 	maxVarbinds           = 256
 	maxNestingDepth       = 8
 	maxOIDEncodedLen      = 128
@@ -44,18 +40,6 @@ const (
 var (
 	trapDecodeLogger = gosnmp.NewLogger(log.New(io.Discard, "", 0))
 )
-
-type TrapPDU struct {
-	OID         string
-	SourceIP    string
-	PeerIP      string
-	Community   string
-	Version     SnmpVersion
-	PduType     PduType
-	Varbinds    []VarbindValue
-	RequestID   uint32
-	SourceAudit *TrapSourceAudit
-}
 
 type TrapPacketContext struct {
 	Packet *gosnmp.SnmpPacket
@@ -352,13 +336,13 @@ func packetVarbinds(pkt *gosnmp.SnmpPacket) ([]VarbindValue, error) {
 	}
 
 	synthetic := []VarbindValue{
-		{Name: "sysUpTime.0", OID: sysUpTimeOID, Type: "TimeTicks", Value: uint64(pkt.Timestamp)},
-		{Name: "snmpTrapOID.0", OID: snmpTrapOIDOID, Type: "ObjectIdentifier", Value: trapOID},
+		{Name: "sysUpTime.0", OID: model.SysUpTimeOID, Type: "TimeTicks", Value: uint64(pkt.Timestamp)},
+		{Name: "snmpTrapOID.0", OID: model.SNMPTrapOID, Type: "ObjectIdentifier", Value: trapOID},
 	}
 	if pkt.AgentAddress != "" {
 		synthetic = append(synthetic, VarbindValue{
 			Name:  "snmpTrapAddress.0",
-			OID:   snmpTrapAddressOID,
+			OID:   model.SNMPTrapAddressOID,
 			Type:  "IPAddress",
 			Value: pkt.AgentAddress,
 		})
@@ -366,7 +350,7 @@ func packetVarbinds(pkt *gosnmp.SnmpPacket) ([]VarbindValue, error) {
 	if pkt.Community != "" {
 		synthetic = append(synthetic, VarbindValue{
 			Name:  "snmpTrapCommunity.0",
-			OID:   snmpTrapCommunityOID,
+			OID:   model.SNMPTrapCommunityOID,
 			Type:  "OctetString",
 			Value: pkt.Community,
 		})
@@ -374,9 +358,9 @@ func packetVarbinds(pkt *gosnmp.SnmpPacket) ([]VarbindValue, error) {
 	if pkt.Enterprise != "" {
 		synthetic = append(synthetic, VarbindValue{
 			Name:  "snmpTrapEnterprise.0",
-			OID:   snmpTrapEnterpriseOID,
+			OID:   model.SNMPTrapEnterpriseOID,
 			Type:  "ObjectIdentifier",
-			Value: normalizeOID(pkt.Enterprise),
+			Value: model.NormalizeOID(pkt.Enterprise),
 		})
 	}
 
@@ -388,10 +372,10 @@ func convertVarbinds(pdus []gosnmp.SnmpPDU) ([]VarbindValue, error) {
 	for _, pdu := range pdus {
 		val, err := normalizePDUValue(pdu)
 		if err != nil {
-			return nil, fmt.Errorf("varbind %s: %w", normalizeOID(pdu.Name), err)
+			return nil, fmt.Errorf("varbind %s: %w", model.NormalizeOID(pdu.Name), err)
 		}
 		vbs = append(vbs, VarbindValue{
-			OID:   normalizeOID(pdu.Name),
+			OID:   model.NormalizeOID(pdu.Name),
 			Type:  ASN1Type(pdu.Type.String()),
 			Value: val,
 		})
@@ -405,7 +389,7 @@ func normalizePDUValue(pdu gosnmp.SnmpPDU) (any, error) {
 		return nil, nil
 	case string:
 		if pdu.Type == gosnmp.ObjectIdentifier {
-			return normalizeOID(v), nil
+			return model.NormalizeOID(v), nil
 		}
 		if pdu.Type == gosnmp.OctetString && len(v) > maxOctetStringLen {
 			return nil, fmt.Errorf("OctetString too long: %d > %d", len(v), maxOctetStringLen)
@@ -451,11 +435,11 @@ func normalizePDUValue(pdu gosnmp.SnmpPDU) (any, error) {
 
 func trapOIDFromVarbinds(vbs []VarbindValue) string {
 	for _, vb := range vbs {
-		if vb.OID != snmpTrapOIDOID {
+		if vb.OID != model.SNMPTrapOID {
 			continue
 		}
 		if oid, ok := vb.Value.(string); ok {
-			return normalizeOID(oid)
+			return model.NormalizeOID(oid)
 		}
 		return ""
 	}
@@ -469,7 +453,7 @@ type trapSourceSelection struct {
 
 func selectTrapSource(vbs []VarbindValue, udpPeer net.IP, trustedRelay bool) trapSourceSelection {
 	peer := validIPString(ipString(udpPeer))
-	trapAddr, trapAddrReject := sourceFromVarbindWithRejectReason(vbs, snmpTrapAddressOID)
+	trapAddr, trapAddrReject := sourceFromVarbindWithRejectReason(vbs, model.SNMPTrapAddressOID)
 
 	audit := &TrapSourceAudit{
 		UDPPeer:         peer,
@@ -592,13 +576,9 @@ func snmpPDUType(t gosnmp.PDUType) (PduType, error) {
 	}
 }
 
-func normalizeOID(oid string) string {
-	return strings.TrimPrefix(oid, ".")
-}
-
 func v1TrapOID(enterprise string, genericTrap, specificTrap int) string {
 	if genericTrap == snmpV1TrapTypeEnterpriseSpec {
-		enterprise = normalizeOID(enterprise)
+		enterprise = model.NormalizeOID(enterprise)
 		if enterprise == "" || specificTrap < 0 || specificTrap > maxSNMPv1SpecificTrap {
 			return ""
 		}

--- a/src/go/plugin/go.d/collector/snmp_traps/decode_error.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/decode_error.go
@@ -44,7 +44,7 @@ func (c *Collector) writeDecodeErrorEntry(rec decodeErrorRecord) {
 		}
 	}
 
-	entry := newDecodeErrorEntry(c.jobName, rec, c.monotonicUsec())
+	entry := newDecodeErrorEntry(c.Name, rec, c.monotonicUsec())
 	if err := c.trapWriter.Write(entry); err != nil {
 		c.incTrapError(c.trapWriteFailureDim())
 	}

--- a/src/go/plugin/go.d/collector/snmp_traps/decode_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/decode_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 const testEngineIDHex = "80001f888077dfe44faa700258"
@@ -36,8 +37,8 @@ func buildV3Trap(t *testing.T, user string, trapOID string, extra ...gosnmp.Snmp
 		Logger: trapDecodeLogger,
 	}
 	pdus := []gosnmp.SnmpPDU{
-		{Name: sysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
-		{Name: snmpTrapOIDOID, Type: gosnmp.ObjectIdentifier, Value: trapOID},
+		{Name: model.SysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
+		{Name: model.SNMPTrapOID, Type: gosnmp.ObjectIdentifier, Value: trapOID},
 	}
 	pdus = append(pdus, extra...)
 	data, err := g.SnmpEncodePacket(gosnmp.SNMPv2Trap, pdus, 0, 0)
@@ -109,8 +110,8 @@ func buildV3SecuredPDU(t *testing.T, pduType gosnmp.PDUType, spec v3SecuredTrapS
 		Logger:             trapDecodeLogger,
 	}
 	pdus := []gosnmp.SnmpPDU{
-		{Name: sysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
-		{Name: snmpTrapOIDOID, Type: gosnmp.ObjectIdentifier, Value: spec.trapOID},
+		{Name: model.SysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
+		{Name: model.SNMPTrapOID, Type: gosnmp.ObjectIdentifier, Value: spec.trapOID},
 	}
 	pdus = append(pdus, spec.extra...)
 	data, err := g.SnmpEncodePacket(pduType, pdus, 0, 0)
@@ -142,8 +143,8 @@ func buildV2cPDU(t *testing.T, pduType gosnmp.PDUType, community, trapOID string
 	t.Helper()
 	x := &gosnmp.GoSNMP{Version: gosnmp.Version2c, Community: community}
 	pdus := []gosnmp.SnmpPDU{
-		{Name: sysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
-		{Name: snmpTrapOIDOID, Type: gosnmp.ObjectIdentifier, Value: trapOID},
+		{Name: model.SysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
+		{Name: model.SNMPTrapOID, Type: gosnmp.ObjectIdentifier, Value: trapOID},
 	}
 	pdus = append(pdus, extra...)
 	return marshalPacket(t, x.MkSnmpPacket(pduType, pdus, 0, 0))
@@ -357,9 +358,9 @@ func TestValidateBERLimitsAcceptsMaxDepth(t *testing.T) {
 
 func TestSourceFromVarbind(t *testing.T) {
 	vbs := []VarbindValue{
-		{OID: snmpTrapAddressOID, Value: "10.0.0.1", Type: "IPAddress"},
+		{OID: model.SNMPTrapAddressOID, Value: "10.0.0.1", Type: "IPAddress"},
 	}
-	addr, _ := sourceFromVarbindWithRejectReason(vbs, snmpTrapAddressOID)
+	addr, _ := sourceFromVarbindWithRejectReason(vbs, model.SNMPTrapAddressOID)
 	if addr != "10.0.0.1" {
 		t.Errorf("expected 10.0.0.1, got %q", addr)
 	}
@@ -372,9 +373,9 @@ func TestSourceFromVarbind(t *testing.T) {
 
 func TestSourceFromVarbindNotString(t *testing.T) {
 	vbs := []VarbindValue{
-		{OID: snmpTrapAddressOID, Value: int64(42), Type: "INTEGER"},
+		{OID: model.SNMPTrapAddressOID, Value: int64(42), Type: "INTEGER"},
 	}
-	addr, _ := sourceFromVarbindWithRejectReason(vbs, snmpTrapAddressOID)
+	addr, _ := sourceFromVarbindWithRejectReason(vbs, model.SNMPTrapAddressOID)
 	if addr != "" {
 		t.Errorf("expected empty for non-IP value, got %q", addr)
 	}
@@ -382,9 +383,9 @@ func TestSourceFromVarbindNotString(t *testing.T) {
 
 func TestSourceFromVarbindNetIP(t *testing.T) {
 	vbs := []VarbindValue{
-		{OID: snmpTrapAddressOID, Value: net.ParseIP("192.0.2.1"), Type: "IPAddress"},
+		{OID: model.SNMPTrapAddressOID, Value: net.ParseIP("192.0.2.1"), Type: "IPAddress"},
 	}
-	addr, _ := sourceFromVarbindWithRejectReason(vbs, snmpTrapAddressOID)
+	addr, _ := sourceFromVarbindWithRejectReason(vbs, model.SNMPTrapAddressOID)
 	if addr != "192.0.2.1" {
 		t.Errorf("expected 192.0.2.1, got %q", addr)
 	}
@@ -392,9 +393,9 @@ func TestSourceFromVarbindNetIP(t *testing.T) {
 
 func TestSourceFromVarbindNotIP(t *testing.T) {
 	vbs := []VarbindValue{
-		{OID: snmpTrapAddressOID, Value: "not-an-ip", Type: "OctetString"},
+		{OID: model.SNMPTrapAddressOID, Value: "not-an-ip", Type: "OctetString"},
 	}
-	addr, _ := sourceFromVarbindWithRejectReason(vbs, snmpTrapAddressOID)
+	addr, _ := sourceFromVarbindWithRejectReason(vbs, model.SNMPTrapAddressOID)
 	if addr != "" {
 		t.Errorf("expected empty for non-IP value, got %q", addr)
 	}
@@ -404,7 +405,7 @@ func TestIdentifySourceCascade(t *testing.T) {
 	peer := net.ParseIP("10.0.0.5")
 
 	vbsWithSource := []VarbindValue{
-		{OID: snmpTrapAddressOID, Value: "192.168.1.1", Type: "IPAddress"},
+		{OID: model.SNMPTrapAddressOID, Value: "192.168.1.1", Type: "IPAddress"},
 	}
 	addr := selectTrapSource(vbsWithSource, peer, false).sourceIP
 	if addr != "10.0.0.5" {
@@ -412,7 +413,7 @@ func TestIdentifySourceCascade(t *testing.T) {
 	}
 
 	vbsNoSource := []VarbindValue{
-		{OID: sysUpTimeOID, Value: uint64(10), Type: "TimeTicks"},
+		{OID: model.SysUpTimeOID, Value: uint64(10), Type: "TimeTicks"},
 	}
 	addr = selectTrapSource(vbsNoSource, peer, false).sourceIP
 	if addr != "10.0.0.5" {
@@ -434,7 +435,7 @@ func TestIdentifySourceCascade(t *testing.T) {
 	}
 
 	vbsUnspecifiedSource := []VarbindValue{
-		{OID: snmpTrapAddressOID, Value: "0.0.0.0", Type: "IPAddress"},
+		{OID: model.SNMPTrapAddressOID, Value: "0.0.0.0", Type: "IPAddress"},
 	}
 	addr = selectTrapSource(vbsUnspecifiedSource, peer, false).sourceIP
 	if addr != "10.0.0.5" {
@@ -460,7 +461,7 @@ func TestIdentifySourceCascade(t *testing.T) {
 func TestSelectTrapSourceTrustedRelay(t *testing.T) {
 	peer := net.ParseIP("10.0.0.5")
 	vbsWithSource := []VarbindValue{
-		{OID: snmpTrapAddressOID, Value: "192.168.1.1", Type: "IPAddress"},
+		{OID: model.SNMPTrapAddressOID, Value: "192.168.1.1", Type: "IPAddress"},
 	}
 
 	selected := selectTrapSource(vbsWithSource, peer, true)
@@ -484,14 +485,14 @@ func TestSelectTrapSourceTrustedRelay(t *testing.T) {
 		t.Fatalf("sourceIP = %q, want relayed snmpTrapAddress.0 when caller marks peer as trusted", selected.sourceIP)
 	}
 
-	vbsNoSource := []VarbindValue{{OID: sysUpTimeOID, Value: uint64(10), Type: "TimeTicks"}}
+	vbsNoSource := []VarbindValue{{OID: model.SysUpTimeOID, Value: uint64(10), Type: "TimeTicks"}}
 	selected = selectTrapSource(vbsNoSource, peer, true)
 	if selected.sourceIP != "10.0.0.5" {
 		t.Fatalf("sourceIP = %q, want UDP peer when trusted relay has no snmpTrapAddress.0", selected.sourceIP)
 	}
 
 	vbsUnspecifiedSource := []VarbindValue{
-		{OID: snmpTrapAddressOID, Value: "0.0.0.0", Type: "IPAddress"},
+		{OID: model.SNMPTrapAddressOID, Value: "0.0.0.0", Type: "IPAddress"},
 	}
 	selected = selectTrapSource(vbsUnspecifiedSource, peer, true)
 	if selected.sourceIP != "10.0.0.5" {
@@ -574,7 +575,7 @@ func TestV1DecodeConvertsAgentAddressAndSyntheticVarbinds(t *testing.T) {
 	if len(pdu.Varbinds) < 5 {
 		t.Fatalf("expected synthetic varbinds, got %d", len(pdu.Varbinds))
 	}
-	if pdu.Varbinds[2].OID != snmpTrapAddressOID || pdu.Varbinds[2].Value != "192.0.2.10" {
+	if pdu.Varbinds[2].OID != model.SNMPTrapAddressOID || pdu.Varbinds[2].Value != "192.0.2.10" {
 		t.Errorf("snmpTrapAddress.0 mismatch: %+v", pdu.Varbinds[2])
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_traps/dedup.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/dedup.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 const (
@@ -342,8 +344,8 @@ func dedupFingerprint(entry *TrapEntry, td *TrapDef, jobKeys []string) dedupKey 
 		buf = appendFingerprintPart(buf, dedupVarbindPresent)
 		buf = appendFingerprintPart(buf, vb.OID)
 		buf = appendFingerprintPart(buf, string(vb.Type))
-		if isSensitiveTrapVarbind(vb) {
-			buf = appendFingerprintValue(buf, redactedTrapVarbind)
+		if model.IsSensitiveVarbind(vb) {
+			buf = appendFingerprintValue(buf, model.RedactedVarbindValue)
 			continue
 		}
 		buf = appendFingerprintValue(buf, vb.Value)
@@ -382,13 +384,11 @@ func dedupVarbind(entry *TrapEntry, name string) (VarbindValue, bool) {
 	if entry == nil {
 		return VarbindValue{}, false
 	}
-	for _, vb := range entry.Varbinds {
-		if vb.Name == name {
-			return vb, true
-		}
+	if value, ok := model.FindVarbindByName(entry.Varbinds, name); ok {
+		return value, true
 	}
-	if isNumericOID(name) {
-		return findVarbindForProfileOID(entry, name)
+	if model.IsNumericOID(name) {
+		return model.FindVarbindForProfileOID(entry.Varbinds, name)
 	}
 	return VarbindValue{}, false
 }

--- a/src/go/plugin/go.d/collector/snmp_traps/dedup_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/dedup_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 func TestValidateDedupConfig(t *testing.T) {
@@ -485,7 +486,7 @@ func dedupTestEntryWithCommunity(sourceIP, community string) *TrapEntry {
 		TrapOID:  "1.3.6.1.6.3.1.1.5.3",
 		Varbinds: []VarbindValue{{
 			Name:  "snmpTrapCommunity",
-			OID:   snmpTrapCommunityOID,
+			OID:   model.SNMPTrapCommunityOID,
 			Type:  "OctetString",
 			Value: community,
 		}},

--- a/src/go/plugin/go.d/collector/snmp_traps/dynamic_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/dynamic_test.go
@@ -307,17 +307,17 @@ func TestDiscoveryReportRateLimitDropSkipsResponse(t *testing.T) {
 }
 
 func TestSendDiscoveryReportWireFormat(t *testing.T) {
-	withEngineStateDir(t)
+	paths := newEngineStatePaths(t.TempDir(), "test-discovery-report")
 
 	listenerConn, peerConn := informUDPConnPair(t)
 	defer listenerConn.Close()
 	defer peerConn.Close()
 
-	lid, err := NewLocalEngineID("test-discovery-report", testLocalEngineIDHex)
+	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
-	eb, err := NewEngineBoots("test-discovery-report")
+	eb, err := NewEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("NewEngineBoots failed: %v", err)
 	}

--- a/src/go/plugin/go.d/collector/snmp_traps/dynamic_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/dynamic_test.go
@@ -313,11 +313,11 @@ func TestSendDiscoveryReportWireFormat(t *testing.T) {
 	defer listenerConn.Close()
 	defer peerConn.Close()
 
-	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
+	lid, err := newLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
-	eb, err := NewEngineBoots(paths)
+	eb, err := newEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("NewEngineBoots failed: %v", err)
 	}

--- a/src/go/plugin/go.d/collector/snmp_traps/engineboots.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/engineboots.go
@@ -79,7 +79,7 @@ type EngineBoots struct {
 	valid     bool
 }
 
-func NewEngineBoots(paths engineStatePaths) (*EngineBoots, error) {
+func newEngineBoots(paths engineStatePaths) (*EngineBoots, error) {
 	if err := os.MkdirAll(paths.dir, 0750); err != nil {
 		return nil, fmt.Errorf("engine-boots: create directory %s: %w", paths.dir, err)
 	}
@@ -162,7 +162,7 @@ type LocalEngineID struct {
 	valid bool
 }
 
-func NewLocalEngineID(paths engineStatePaths, configuredHex string) (*LocalEngineID, error) {
+func newLocalEngineID(paths engineStatePaths, configuredHex string) (*LocalEngineID, error) {
 	if err := os.MkdirAll(paths.dir, 0750); err != nil {
 		return nil, fmt.Errorf("local-engine-id: create directory %s: %w", paths.dir, err)
 	}

--- a/src/go/plugin/go.d/collector/snmp_traps/engineboots.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/engineboots.go
@@ -15,26 +15,24 @@ import (
 	"time"
 )
 
-var engineBootsDirBase string
-
 const (
 	maxSnmpEngineBoots = 2147483647
 	maxSnmpEngineTime  = uint32(4294967295)
 )
 
-func engineBootsDir(jobName string) string {
-	return filepath.Join(engineBootsBaseDir(), jobName)
+type engineStatePaths struct {
+	dir           string
+	engineBoots   string
+	localEngineID string
 }
 
-func engineBootsBaseDir() string {
-	if engineBootsDirBase != "" {
-		return engineBootsDirBase
+func newEngineStatePaths(root, jobName string) engineStatePaths {
+	dir := filepath.Join(root, jobName)
+	return engineStatePaths{
+		dir:           dir,
+		engineBoots:   filepath.Join(dir, "engine-boots"),
+		localEngineID: filepath.Join(dir, "local-engine-id"),
 	}
-	return filepath.Join(netdataLibDir(), "snmp-trap")
-}
-
-func engineBootsPath(jobName string) string {
-	return filepath.Join(engineBootsDir(jobName), "engine-boots")
 }
 
 func engineStatePathExistsChecked(path string) (bool, error) {
@@ -59,17 +57,17 @@ func engineStatePathExistsChecked(path string) (bool, error) {
 	return false, err
 }
 
-func cleanupCreatedEngineState(jobName string, removeEngineBoots, removeLocalEngineID, removeDir bool) {
+func cleanupCreatedEngineState(paths engineStatePaths, removeEngineBoots, removeLocalEngineID, removeDir bool) {
 	if removeEngineBoots {
-		_ = os.Remove(engineBootsPath(jobName))
-		_ = os.Remove(engineBootsPath(jobName) + ".tmp")
+		_ = os.Remove(paths.engineBoots)
+		_ = os.Remove(paths.engineBoots + ".tmp")
 	}
 	if removeLocalEngineID {
-		_ = os.Remove(localEngineIDPath(jobName))
-		_ = os.Remove(localEngineIDPath(jobName) + ".tmp")
+		_ = os.Remove(paths.localEngineID)
+		_ = os.Remove(paths.localEngineID + ".tmp")
 	}
 	if removeDir {
-		_ = os.Remove(engineBootsDir(jobName))
+		_ = os.Remove(paths.dir)
 	}
 }
 
@@ -81,13 +79,12 @@ type EngineBoots struct {
 	valid     bool
 }
 
-func NewEngineBoots(jobName string) (*EngineBoots, error) {
-	dir := engineBootsDir(jobName)
-	if err := os.MkdirAll(dir, 0750); err != nil {
-		return nil, fmt.Errorf("engine-boots: create directory %s: %w", dir, err)
+func NewEngineBoots(paths engineStatePaths) (*EngineBoots, error) {
+	if err := os.MkdirAll(paths.dir, 0750); err != nil {
+		return nil, fmt.Errorf("engine-boots: create directory %s: %w", paths.dir, err)
 	}
 
-	eb := &EngineBoots{path: engineBootsPath(jobName), startedAt: time.Now()}
+	eb := &EngineBoots{path: paths.engineBoots, startedAt: time.Now()}
 	if err := eb.init(); err != nil {
 		return nil, err
 	}
@@ -158,10 +155,6 @@ func (eb *EngineBoots) engineTimeLocked() uint32 {
 	return uint32(elapsed / time.Second)
 }
 
-func localEngineIDPath(jobName string) string {
-	return filepath.Join(engineBootsDir(jobName), "local-engine-id")
-}
-
 type LocalEngineID struct {
 	mu    sync.Mutex
 	path  string
@@ -169,13 +162,12 @@ type LocalEngineID struct {
 	valid bool
 }
 
-func NewLocalEngineID(jobName string, configuredHex string) (*LocalEngineID, error) {
-	dir := engineBootsDir(jobName)
-	if err := os.MkdirAll(dir, 0750); err != nil {
-		return nil, fmt.Errorf("local-engine-id: create directory %s: %w", dir, err)
+func NewLocalEngineID(paths engineStatePaths, configuredHex string) (*LocalEngineID, error) {
+	if err := os.MkdirAll(paths.dir, 0750); err != nil {
+		return nil, fmt.Errorf("local-engine-id: create directory %s: %w", paths.dir, err)
 	}
 
-	lid := &LocalEngineID{path: localEngineIDPath(jobName)}
+	lid := &LocalEngineID{path: paths.localEngineID}
 	if err := lid.init(configuredHex); err != nil {
 		return nil, err
 	}

--- a/src/go/plugin/go.d/collector/snmp_traps/enrich.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/enrich.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 type reverseDNSResolver struct {
@@ -539,7 +540,7 @@ func isNamedOrOIDPrefixedVarbind(vb VarbindValue, name, oidPrefix string) bool {
 	if vbName == name || strings.HasPrefix(vbName, name+".") {
 		return true
 	}
-	oid := normalizeOID(vb.OID)
+	oid := model.NormalizeOID(vb.OID)
 	return oid == oidPrefix || strings.HasPrefix(oid, oidPrefix+".")
 }
 

--- a/src/go/plugin/go.d/collector/snmp_traps/inform_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/inform_test.go
@@ -71,7 +71,7 @@ func TestCollectorHandlePacketRespondsBeforeRateLimitDrop(t *testing.T) {
 
 	writer := &mockTrapWriter{}
 	c := &Collector{
-		jobName:     jobName,
+		Config:      Config{Name: jobName},
 		trapWriter:  writer,
 		versions:    map[SnmpVersion]struct{}{SnmpVersionV2c: {}},
 		allowlist:   NewAllowlist(nil, []string{"public"}),
@@ -110,7 +110,7 @@ func TestCollectorHandlePacketIncrementsInformResponseFailed(t *testing.T) {
 
 	writer := &mockTrapWriter{}
 	c := &Collector{
-		jobName:    jobName,
+		Config:     Config{Name: jobName},
 		trapWriter: writer,
 		versions:   map[SnmpVersion]struct{}{SnmpVersionV2c: {}},
 		allowlist:  NewAllowlist(nil, []string{"public"}),

--- a/src/go/plugin/go.d/collector/snmp_traps/init.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/init.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 const (
@@ -44,6 +46,110 @@ var validPrivProtos = map[string]bool{
 var validRateLimitModes = map[string]bool{
 	"drop":   true,
 	"sample": true,
+}
+
+type validatedConfig struct {
+	versions       []string
+	v3Enabled      bool
+	allowlist      []netip.Prefix
+	trustedRelays  []netip.Prefix
+	otlp           otlpRuntimeConfig
+	journalEnabled bool
+	retention      RetentionConfig
+	profileMetrics normalizedProfileMetricsConfig
+}
+
+func (c Config) Validate() error {
+	_, err := validateConfig(c)
+	return err
+}
+
+func validateConfig(c Config) (validatedConfig, error) {
+	var validated validatedConfig
+
+	if err := validateJobName(c.Name); err != nil {
+		return validated, err
+	}
+	if err := validateListenConfig(c.Listen); err != nil {
+		return validated, err
+	}
+
+	versions, err := validateVersions(c.Versions)
+	if err != nil {
+		return validated, err
+	}
+	validated.versions = versions
+	validated.v3Enabled = versionListContains(versions, "v3")
+
+	if err := validateUSMUsers(c.USMUsers, c.DynamicEngineID); err != nil {
+		return validated, err
+	}
+	if err := validateEngineIDWhitelist(c.EngineIDWhitelist); err != nil {
+		return validated, err
+	}
+	if err := validateLocalEngineID(c.LocalEngineID); err != nil {
+		return validated, err
+	}
+
+	allowlist, err := validateAllowlist(c.Allowlist)
+	if err != nil {
+		return validated, err
+	}
+	validated.allowlist = allowlist
+
+	trustedRelays, err := validateTrustedRelays(c.Source)
+	if err != nil {
+		return validated, err
+	}
+	validated.trustedRelays = trustedRelays
+
+	if err := validateRateLimit(c.RateLimit); err != nil {
+		return validated, err
+	}
+	if err := validateDedupConfig(c.Dedup); err != nil {
+		return validated, err
+	}
+
+	otlp, err := validateOTLPConfig(c.OTLP)
+	if err != nil {
+		return validated, err
+	}
+	validated.otlp = otlp
+	validated.journalEnabled = c.Journal.enabled()
+	if !validated.journalEnabled && !c.OTLP.Enabled {
+		return validated, errors.New("at least one SNMP trap output backend must be enabled: journal.enabled or otlp.enabled")
+	}
+
+	if err := validateOverrides(c.Overrides); err != nil {
+		return validated, err
+	}
+	if err := validateDeferredConfig(c); err != nil {
+		return validated, err
+	}
+	if validated.v3Enabled {
+		if len(c.USMUsers) == 0 {
+			return validated, errors.New("SNMPv3 requires at least one usm_users entry")
+		}
+		if !c.DynamicEngineID && len(c.EngineIDWhitelist) == 0 {
+			return validated, errors.New("SNMPv3 requires engine_id_whitelist when dynamic_engine_id_discovery is disabled")
+		}
+	}
+
+	if validated.journalEnabled {
+		retention, err := parseRetentionConfig(c.Retention)
+		if err != nil {
+			return validated, err
+		}
+		validated.retention = retention
+	}
+
+	profileMetrics, err := normalizeProfileMetricsConfig(c.ProfileMetrics)
+	if err != nil {
+		return validated, err
+	}
+	validated.profileMetrics = profileMetrics
+
+	return validated, nil
 }
 
 func validateJobName(name string) error {
@@ -297,7 +403,7 @@ func validateOverrides(overrides []OverrideConfig) error {
 		if o.OID == "" {
 			return fmt.Errorf("overrides[%d]: oid is required", i)
 		}
-		if !isNumericOID(o.OID) {
+		if !model.IsNumericOID(o.OID) {
 			return fmt.Errorf("overrides[%d]: invalid oid %q", i, o.OID)
 		}
 		if o.Category != "" && !validCategories[o.Category] {

--- a/src/go/plugin/go.d/collector/snmp_traps/init_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/init_test.go
@@ -302,6 +302,9 @@ func TestConfigValidateIsPure(t *testing.T) {
 }
 
 func TestCollectorInitValidatesBeforeAcquiringResources(t *testing.T) {
+	profileDir := t.TempDir()
+	writeProfileYAML(t, profileDir, "invalid.yaml", "unknown_profile_key: true\n")
+	setTestDirs(t, profileDir)
 	resetProfileCacheForTest()
 	t.Cleanup(resetProfileCacheForTest)
 
@@ -313,6 +316,7 @@ func TestCollectorInitValidatesBeforeAcquiringResources(t *testing.T) {
 	err := c.Init(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "profile_metrics.mode")
+	assert.NotContains(t, err.Error(), "unknown_profile_key")
 	assert.Nil(t, CurrentProfileIndex())
 	assert.Nil(t, c.listener)
 	assert.Nil(t, c.trapWriter)

--- a/src/go/plugin/go.d/collector/snmp_traps/init_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/init_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -27,27 +26,10 @@ var (
 	dataConfigYAML, _ = os.ReadFile("testdata/config.yaml")
 )
 
-func TestCollectorConfigurationSerialize(t *testing.T) {
+func TestCollector_ConfigurationSerialize(t *testing.T) {
 	require.NotEmpty(t, dataConfigJSON)
 	require.NotEmpty(t, dataConfigYAML)
 	collecttest.TestConfigurationSerialize(t, &Collector{}, dataConfigJSON, dataConfigYAML)
-}
-
-func TestConfigUnknownYAMLFieldsAreIgnored(t *testing.T) {
-	var cfg Config
-	err := yaml.Unmarshal([]byte(`
-name: local
-unknown_top_level: true
-listen:
-  endpoints:
-    - protocol: udp
-      address: 127.0.0.1
-      port: 9162
-      unknown_endpoint_field: true
-`), &cfg)
-	require.NoError(t, err)
-	assert.Equal(t, "local", cfg.Name)
-	require.Len(t, cfg.Listen.Endpoints, 1)
 }
 
 func TestCollectorChartTemplateYAML(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_traps/init_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/init_test.go
@@ -15,10 +15,40 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/hostidentity"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
+
+var (
+	dataConfigJSON, _ = os.ReadFile("testdata/config.json")
+	dataConfigYAML, _ = os.ReadFile("testdata/config.yaml")
+)
+
+func TestCollectorConfigurationSerialize(t *testing.T) {
+	require.NotEmpty(t, dataConfigJSON)
+	require.NotEmpty(t, dataConfigYAML)
+	collecttest.TestConfigurationSerialize(t, &Collector{}, dataConfigJSON, dataConfigYAML)
+}
+
+func TestConfigUnknownYAMLFieldsAreIgnored(t *testing.T) {
+	var cfg Config
+	err := yaml.Unmarshal([]byte(`
+name: local
+unknown_top_level: true
+listen:
+  endpoints:
+    - protocol: udp
+      address: 127.0.0.1
+      port: 9162
+      unknown_endpoint_field: true
+`), &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "local", cfg.Name)
+	require.Len(t, cfg.Listen.Endpoints, 1)
+}
 
 func TestCollectorChartTemplateYAML(t *testing.T) {
 	collecttest.AssertChartTemplateSchema(t, newTestSNMPTrapsCollector().ChartTemplateYAML())
@@ -64,7 +94,7 @@ func TestCollectorChartTemplateYAMLIncludesProfileMetricCharts(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rt, tmpl, err := newProfileMetricRuntime(cfg, idx)
+	rt, tmpl, err := newProfileMetricRuntime(cfg, idx, "test")
 	require.NoError(t, err)
 	require.NotNil(t, rt)
 	require.NotEmpty(t, tmpl)
@@ -94,6 +124,24 @@ func TestCollectorChartTemplateYAMLIncludesProfileMetricCharts(t *testing.T) {
 func TestCollectorCreatorDefaults(t *testing.T) {
 	creator := newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle())
 	assert.False(t, creator.Defaults.Disabled)
+}
+
+func TestCollectorCreatorSharesHostIdentityService(t *testing.T) {
+	creator := newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle())
+	first := creator.CreateV2().(*Collector)
+	second := creator.CreateV2().(*Collector)
+
+	assert.Same(t, first.hostIdentity, second.hostIdentity)
+	assert.NotNil(t, first.engineStateRoot)
+}
+
+func TestCollectorNewUsesIndependentHostIdentityService(t *testing.T) {
+	deviceStore := ddsnmp.NewDeviceStore()
+	topologyEnricher := snmptopology.NewTrapEnrichmentHandle()
+	first := New(deviceStore, topologyEnricher)
+	second := New(deviceStore, topologyEnricher)
+
+	assert.NotSame(t, first.hostIdentity, second.hostIdentity)
 }
 
 func TestCollectorCreatorRequiresSharedDependencies(t *testing.T) {
@@ -234,6 +282,41 @@ func TestConfigSchemaDynCfgRetentionDefaultDisablesTimeRotation(t *testing.T) {
 
 func TestCollectorDefaultListenReceiveBuffer(t *testing.T) {
 	assert.Equal(t, defaultListenerReceiveBuffer, newTestSNMPTrapsCollector().Listen.ReceiveBuffer)
+}
+
+func TestConfigValidateIsPure(t *testing.T) {
+	cfg := Config{
+		Name:     "local",
+		Listen:   ListenConfig{Endpoints: []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: 162}}},
+		Versions: []string{" V2C "},
+	}
+	before, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, cfg.Validate())
+
+	after, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(before), string(after))
+	assert.Equal(t, []string{" V2C "}, cfg.Versions)
+}
+
+func TestCollectorInitValidatesBeforeAcquiringResources(t *testing.T) {
+	resetProfileCacheForTest()
+	t.Cleanup(resetProfileCacheForTest)
+
+	c := newTestSNMPTrapsCollector()
+	c.Name = "local"
+	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: 162}}
+	c.ProfileMetrics = ProfileMetricsConfig{Enabled: true, Mode: "invalid"}
+
+	err := c.Init(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "profile_metrics.mode")
+	assert.Nil(t, CurrentProfileIndex())
+	assert.Nil(t, c.listener)
+	assert.Nil(t, c.trapWriter)
+	assert.Nil(t, c.metrics)
 }
 
 func TestConfigSchemaDynCfgTabsRenderAllTopLevelFieldsOnce(t *testing.T) {
@@ -488,12 +571,18 @@ func TestCollectorInit_BindsEndpointsAndCheckIsNoop(t *testing.T) {
 	port := freeUDPPort(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
+	c.Versions = []string{" V1 ", "V2C"}
 
 	startJournalJobs := activeDirectJournalJobs.Load()
 	require.NoError(t, c.Init(context.Background()))
 	require.NotNil(t, c.listener)
+	assert.Equal(t, []string{"v1", "v2c"}, c.Versions)
+	configured, ok := c.Configuration().(Config)
+	require.True(t, ok)
+	assert.Equal(t, "local", configured.Name)
+	assert.Equal(t, []string{"v1", "v2c"}, configured.Versions)
 	require.NotEmpty(t, c.journalDir)
 	require.DirExists(t, c.journalDir)
 	assert.Equal(t, startJournalJobs+1, activeDirectJournalJobs.Load())
@@ -506,13 +595,52 @@ func TestCollectorInit_BindsEndpointsAndCheckIsNoop(t *testing.T) {
 	assert.Equal(t, startJournalJobs, activeDirectJournalJobs.Load())
 }
 
+func TestCollectorInit_JournalHostFailureRetriesFreshProvider(t *testing.T) {
+	setMinimalProfileDir(t)
+	withTestCacheDir(t)
+	provider := newTestJournalHostProvider()
+	loadCalls := 0
+	service := hostidentity.NewWithLoader(
+		func() hostidentity.LoadConfig { return hostidentity.LoadConfig{StateDir: t.TempDir()} },
+		func(hostidentity.LoadConfig) (hostidentity.Provider, error) {
+			loadCalls++
+			if loadCalls == 1 {
+				return nil, errors.New("identity unavailable")
+			}
+			return provider, nil
+		},
+	)
+	c := newCollector(
+		ddsnmp.NewDeviceStore(),
+		snmptopology.NewTrapEnrichmentHandle(),
+		service,
+		func() string { return t.TempDir() },
+	)
+	c.Name = "journal-host-retry"
+	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
+
+	err := c.Init(context.Background())
+	require.Error(t, err)
+	var coded interface{ DyncfgCode() int }
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, 503, coded.DyncfgCode())
+	assert.Nil(t, c.listener)
+
+	require.NoError(t, c.Init(context.Background()))
+	assert.Equal(t, 2, loadCalls)
+	assert.Same(t, provider, c.journalHost)
+	assert.Equal(t, int64(1000), c.monotonicUsec())
+
+	c.Cleanup(context.Background())
+}
+
 func TestCollectorInit_IdempotentDoubleInit(t *testing.T) {
 	setMinimalProfileDir(t)
 	withTestCacheDir(t)
 	port := freeUDPPort(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 
 	require.NoError(t, c.Init(context.Background()))
@@ -529,7 +657,7 @@ func TestCollectorInit_InvalidJobNameIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("../bad")
+	c.Name = "../bad"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: 162}}
 
 	err := c.Init(context.Background())
@@ -547,7 +675,7 @@ func TestCollectorInit_InvalidEndpointsIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "tcp", Address: "127.0.0.1", Port: 162}}
 
 	err := c.Init(context.Background())
@@ -562,7 +690,7 @@ func TestCollectorInit_InvalidReceiveBufferIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Listen.ReceiveBuffer = -1
 
@@ -579,7 +707,7 @@ func TestCollectorInit_TooLargeReceiveBufferIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Listen.ReceiveBuffer = maxListenerReceiveBuffer + 1
 
@@ -595,7 +723,7 @@ func TestCollectorInit_TooLargeReceiveBufferIsCodedError(t *testing.T) {
 func TestCollectorInit_NoOutputBackendIsCodedError(t *testing.T) {
 	disabled := false
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Journal.Enabled = &disabled
 
@@ -614,7 +742,7 @@ func TestCollectorInit_MissingNetdataLogRootIsRetryableCodedError(t *testing.T) 
 	withNetdataLogDir(t, root)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 
 	startJournalJobs := activeDirectJournalJobs.Load()
@@ -642,7 +770,7 @@ func TestCollectorInit_OTELOnlySkipsJournalCreation(t *testing.T) {
 
 	const jobName = "otel-only"
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName(jobName)
+	c.Name = jobName
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Journal.Enabled = &disabled
 	c.Retention.MaxSize = &badRetention
@@ -676,7 +804,7 @@ func TestCollectorInit_OTLPPreflightFailureIsRetryableCodedError(t *testing.T) {
 	require.NoError(t, ln.Close())
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("otlp-preflight")
+	c.Name = "otlp-preflight"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Journal.Enabled = &disabled
 	c.OTLP = OTLPConfig{
@@ -704,7 +832,7 @@ func TestCollectorInit_BindsMultipleEndpoints(t *testing.T) {
 	secondPort := freeUDPPort(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{
 		{Protocol: "udp", Address: "127.0.0.1", Port: firstPort},
 		{Protocol: "udp", Address: "127.0.0.1", Port: secondPort},
@@ -736,7 +864,7 @@ func TestCollectorInit_BindFailureIsRetryableCodedError(t *testing.T) {
 	port := conn.LocalAddr().(*net.UDPAddr).Port
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 
 	err = c.Init(context.Background())
@@ -761,7 +889,7 @@ func TestCollectorInit_ReceiveBufferFailureIsRetryableCodedError(t *testing.T) {
 	}
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Listen.ReceiveBuffer = defaultListenerReceiveBuffer + 1
 
@@ -781,7 +909,7 @@ func TestCollectorInit_InvalidVersionIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: 162}}
 	c.Versions = []string{"v5"}
 
@@ -799,7 +927,7 @@ func TestCollectorInit_ProfileLoadFailureIsCodedError(t *testing.T) {
 	withTestCacheDir(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Versions = []string{" V1 ", "V2C"}
 
@@ -822,7 +950,7 @@ func TestCollectorInit_PartialBindFailureClosesPriorSockets(t *testing.T) {
 	secondPort := secondConn.LocalAddr().(*net.UDPAddr).Port
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{
 		{Protocol: "udp", Address: "127.0.0.1", Port: firstPort},
 		{Protocol: "udp", Address: "127.0.0.1", Port: secondPort},
@@ -850,13 +978,15 @@ func TestEngineStatePathExistsCheckedReturnsStatError(t *testing.T) {
 func TestCollectorInit_EngineStateStatErrorIsRetryableCodedError(t *testing.T) {
 	setMinimalProfileDir(t)
 	withTestCacheDir(t)
-	withEngineStateDir(t)
 
 	const jobName = "engine-state-stat-error"
-	require.NoError(t, os.WriteFile(engineBootsDir(jobName), []byte("not a directory"), 0644))
+	root := t.TempDir()
+	paths := newEngineStatePaths(root, jobName)
+	require.NoError(t, os.WriteFile(paths.dir, []byte("not a directory"), 0644))
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName(jobName)
+	c.engineStateRoot = func() string { return root }
+	c.Name = jobName
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Versions = []string{"v3"}
 	c.USMUsers = []USMUserConfig{{
@@ -878,19 +1008,21 @@ func TestCollectorInit_EngineStateStatErrorIsRetryableCodedError(t *testing.T) {
 	require.ErrorAs(t, err, &retryable)
 	assert.True(t, retryable.DyncfgRetryable())
 	assert.Nil(t, c.listener)
-	assert.FileExists(t, engineBootsDir(jobName), "pre-existing invalid state path must not be removed")
+	assert.FileExists(t, paths.dir, "pre-existing invalid state path must not be removed")
 }
 
 func TestCollectorInit_CleansCreatedV3StateOnEngineBootsFailure(t *testing.T) {
 	setMinimalProfileDir(t)
 	withTestCacheDir(t)
-	withEngineStateDir(t)
 
 	const jobName = "cleanup-v3-state"
-	require.NoError(t, os.MkdirAll(engineBootsPath(jobName), 0750))
+	root := t.TempDir()
+	paths := newEngineStatePaths(root, jobName)
+	require.NoError(t, os.MkdirAll(paths.engineBoots, 0750))
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName(jobName)
+	c.engineStateRoot = func() string { return root }
+	c.Name = jobName
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: freeUDPPort(t)}}
 	c.Versions = []string{"v3"}
 	c.USMUsers = []USMUserConfig{{
@@ -905,8 +1037,8 @@ func TestCollectorInit_CleansCreatedV3StateOnEngineBootsFailure(t *testing.T) {
 
 	err := c.Init(context.Background())
 	require.Error(t, err)
-	assert.NoFileExists(t, localEngineIDPath(jobName))
-	assert.DirExists(t, engineBootsPath(jobName), "pre-existing state path must not be removed")
+	assert.NoFileExists(t, paths.localEngineID)
+	assert.DirExists(t, paths.engineBoots, "pre-existing state path must not be removed")
 	assert.Nil(t, c.listener)
 }
 
@@ -916,7 +1048,7 @@ func TestCollectorCleanupIsIdempotent(t *testing.T) {
 	port := freeUDPPort(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 
 	require.NoError(t, c.Init(context.Background()))

--- a/src/go/plugin/go.d/collector/snmp_traps/internal/hostidentity/service.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/internal/hostidentity/service.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package hostidentity
+
+import (
+	"fmt"
+	"sync"
+
+	sdkjournal "github.com/netdata/systemd-journal-sdk/go/journal"
+	"github.com/netdata/systemd-journal-sdk/go/journalhost"
+)
+
+type Provider interface {
+	MachineID() sdkjournal.UUID
+	BootID() sdkjournal.UUID
+	MonotonicUsec() uint64
+}
+
+type LoadConfig struct {
+	StateDir             string
+	HostFilesystemPrefix string
+}
+
+type ConfigSource func() LoadConfig
+
+type Loader func(LoadConfig) (Provider, error)
+
+type Service struct {
+	configSource ConfigSource
+	loader       Loader
+
+	cached struct {
+		once     sync.Once
+		provider Provider
+		err      error
+	}
+}
+
+func New(configSource ConfigSource) *Service {
+	return NewWithLoader(configSource, load)
+}
+
+func NewWithLoader(configSource ConfigSource, loader Loader) *Service {
+	if configSource == nil {
+		panic("hostidentity: nil config source")
+	}
+	if loader == nil {
+		panic("hostidentity: nil loader")
+	}
+	return &Service{configSource: configSource, loader: loader}
+}
+
+func (s *Service) FreshJournal() (Provider, error) {
+	if s == nil {
+		return nil, fmt.Errorf("hostidentity: nil service")
+	}
+	cfg := s.configSource()
+	provider, err := s.loader(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("load local journal host identity using state directory %s: %w", cfg.StateDir, err)
+	}
+	return provider, nil
+}
+
+func (s *Service) CachedFallback() (Provider, error) {
+	if s == nil {
+		return nil, fmt.Errorf("hostidentity: nil service")
+	}
+	s.cached.once.Do(func() {
+		s.cached.provider, s.cached.err = s.loader(s.configSource())
+	})
+	return s.cached.provider, s.cached.err
+}
+
+func load(cfg LoadConfig) (Provider, error) {
+	return journalhost.Load(journalhost.LoadOptions{
+		StateDir:             cfg.StateDir,
+		HostFilesystemPrefix: cfg.HostFilesystemPrefix,
+	})
+}

--- a/src/go/plugin/go.d/collector/snmp_traps/internal/hostidentity/service_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/internal/hostidentity/service_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package hostidentity
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	sdkjournal "github.com/netdata/systemd-journal-sdk/go/journal"
+)
+
+type testProvider struct{}
+
+func (testProvider) MachineID() sdkjournal.UUID { return sdkjournal.UUID{} }
+func (testProvider) BootID() sdkjournal.UUID    { return sdkjournal.UUID{} }
+func (testProvider) MonotonicUsec() uint64      { return 1 }
+
+func TestServiceIsLazy(t *testing.T) {
+	var configCalls atomic.Int64
+	var loadCalls atomic.Int64
+	_ = NewWithLoader(
+		func() LoadConfig {
+			configCalls.Add(1)
+			return LoadConfig{}
+		},
+		func(LoadConfig) (Provider, error) {
+			loadCalls.Add(1)
+			return testProvider{}, nil
+		},
+	)
+	if configCalls.Load() != 0 || loadCalls.Load() != 0 {
+		t.Fatalf("construction loaded identity: config=%d load=%d", configCalls.Load(), loadCalls.Load())
+	}
+}
+
+func TestFreshJournalLoadsEveryAttempt(t *testing.T) {
+	var calls atomic.Int64
+	service := NewWithLoader(
+		func() LoadConfig { return LoadConfig{StateDir: "/state"} },
+		func(LoadConfig) (Provider, error) {
+			if calls.Add(1) == 1 {
+				return nil, errors.New("unavailable")
+			}
+			return testProvider{}, nil
+		},
+	)
+
+	if _, err := service.FreshJournal(); err == nil || err.Error() != "load local journal host identity using state directory /state: unavailable" {
+		t.Fatalf("first FreshJournal error = %v", err)
+	}
+	if _, err := service.FreshJournal(); err != nil {
+		t.Fatalf("second FreshJournal failed: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("loader calls = %d, want 2", calls.Load())
+	}
+}
+
+func TestCachedFallbackCachesSuccessUnderConcurrency(t *testing.T) {
+	var calls atomic.Int64
+	provider := testProvider{}
+	service := NewWithLoader(
+		func() LoadConfig { return LoadConfig{} },
+		func(LoadConfig) (Provider, error) {
+			calls.Add(1)
+			return provider, nil
+		},
+	)
+
+	var wg sync.WaitGroup
+	for range 64 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := service.CachedFallback()
+			if err != nil || got != provider {
+				t.Errorf("CachedFallback = %v/%v", got, err)
+			}
+		}()
+	}
+	wg.Wait()
+	if calls.Load() != 1 {
+		t.Fatalf("loader calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestCachedFallbackCachesErrorButDoesNotPoisonFresh(t *testing.T) {
+	wantErr := errors.New("cached failure")
+	var calls atomic.Int64
+	service := NewWithLoader(
+		func() LoadConfig { return LoadConfig{} },
+		func(LoadConfig) (Provider, error) {
+			if calls.Add(1) == 1 {
+				return nil, wantErr
+			}
+			return testProvider{}, nil
+		},
+	)
+
+	for range 2 {
+		if _, err := service.CachedFallback(); !errors.Is(err, wantErr) {
+			t.Fatalf("CachedFallback error = %v, want %v", err, wantErr)
+		}
+	}
+	if _, err := service.FreshJournal(); err != nil {
+		t.Fatalf("FreshJournal after cached failure: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("loader calls = %d, want 2", calls.Load())
+	}
+}
+
+func TestFreshFailureDoesNotPoisonCachedFallback(t *testing.T) {
+	wantErr := errors.New("fresh failure")
+	var calls atomic.Int64
+	service := NewWithLoader(
+		func() LoadConfig { return LoadConfig{} },
+		func(LoadConfig) (Provider, error) {
+			if calls.Add(1) == 1 {
+				return nil, wantErr
+			}
+			return testProvider{}, nil
+		},
+	)
+
+	if _, err := service.FreshJournal(); !errors.Is(err, wantErr) {
+		t.Fatalf("FreshJournal error = %v, want %v", err, wantErr)
+	}
+	if _, err := service.CachedFallback(); err != nil {
+		t.Fatalf("CachedFallback after fresh failure: %v", err)
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_traps/internal/hostidentity/service_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/internal/hostidentity/service_test.go
@@ -71,14 +71,12 @@ func TestCachedFallbackCachesSuccessUnderConcurrency(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 64 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			got, err := service.CachedFallback()
 			if err != nil || got != provider {
 				t.Errorf("CachedFallback = %v/%v", got, err)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	if calls.Load() != 1 {

--- a/src/go/plugin/go.d/collector/snmp_traps/internal/model/oid.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/internal/model/oid.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+import "strings"
+
+const (
+	SysUpTimeOID          = "1.3.6.1.2.1.1.3.0"
+	SNMPTrapOID           = "1.3.6.1.6.3.1.1.4.1.0"
+	SNMPTrapAddressOID    = "1.3.6.1.6.3.18.1.3.0"
+	SNMPTrapCommunityOID  = "1.3.6.1.6.3.18.1.4.0"
+	SNMPTrapEnterpriseOID = "1.3.6.1.6.3.1.1.4.3.0"
+)
+
+func NormalizeOID(oid string) string {
+	return strings.TrimPrefix(oid, ".")
+}
+
+func AlternateTrapOID(oid string) string {
+	if len(oid) == 0 || oid[0] == '.' || oid[len(oid)-1] == '.' {
+		return oid
+	}
+
+	dots := 0
+	prevDot := -1
+	lastDot := -1
+	segmentStart := 0
+
+	for i := 0; i < len(oid); i++ {
+		c := oid[i]
+		switch {
+		case c == '.':
+			if i == segmentStart {
+				return oid
+			}
+			dots++
+			prevDot = lastDot
+			lastDot = i
+			segmentStart = i + 1
+		case c < '0' || c > '9':
+			return oid
+		}
+	}
+
+	if dots < 3 || prevDot < 0 || lastDot <= 0 || lastDot >= len(oid)-1 {
+		return oid
+	}
+
+	if oid[prevDot+1:lastDot] == "0" {
+		return oid[:prevDot] + oid[lastDot:]
+	}
+	return oid[:lastDot] + ".0" + oid[lastDot:]
+}
+
+func IsNumericOID(oid string) bool {
+	if oid == "" || oid[0] == '.' || oid[len(oid)-1] == '.' {
+		return false
+	}
+	for part := range strings.SplitSeq(oid, ".") {
+		if part == "" {
+			return false
+		}
+		for _, ch := range part {
+			if ch < '0' || ch > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func OIDMatchesColumn(profileOID, observedOID string) bool {
+	if profileOID == "" || observedOID == "" || profileOID == observedOID {
+		return false
+	}
+	return strings.HasPrefix(observedOID, profileOID+".")
+}

--- a/src/go/plugin/go.d/collector/snmp_traps/internal/model/oid_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/internal/model/oid_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+import "testing"
+
+func TestNormalizeOID(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "plain", in: "1.3.6", want: "1.3.6"},
+		{name: "one leading dot", in: ".1.3.6", want: "1.3.6"},
+		{name: "two leading dots", in: "..1.3.6", want: ".1.3.6"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := NormalizeOID(test.in); got != test.want {
+				t.Fatalf("NormalizeOID(%q) = %q, want %q", test.in, got, test.want)
+			}
+		})
+	}
+}
+
+func TestAlternateTrapOID(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want string
+	}{
+		{in: "1.3.6.1.4.1.9.9.41.2.0.1", want: "1.3.6.1.4.1.9.9.41.2.1"},
+		{in: "1.3.6.1.4.1.9.9.41.2.1", want: "1.3.6.1.4.1.9.9.41.2.0.1"},
+		{in: ""},
+		{in: ".1.3.6"},
+		{in: "1.3.6."},
+		{in: "1..3.6"},
+		{in: "1.3.x.6"},
+		{in: "1.3.6"},
+	} {
+		want := test.want
+		if want == "" {
+			want = test.in
+		}
+		if got := AlternateTrapOID(test.in); got != want {
+			t.Errorf("AlternateTrapOID(%q) = %q, want %q", test.in, got, want)
+		}
+	}
+}
+
+func TestIsNumericOID(t *testing.T) {
+	for _, test := range []struct {
+		oid  string
+		want bool
+	}{
+		{oid: "1", want: true},
+		{oid: "1.3.6.1", want: true},
+		{oid: ""},
+		{oid: ".1.3"},
+		{oid: "1.3."},
+		{oid: "1..3"},
+		{oid: "1.a.3"},
+	} {
+		if got := IsNumericOID(test.oid); got != test.want {
+			t.Errorf("IsNumericOID(%q) = %v, want %v", test.oid, got, test.want)
+		}
+	}
+}
+
+func TestOIDMatchesColumn(t *testing.T) {
+	const column = "1.3.6.1.2.1.2.2.1.8"
+	for _, test := range []struct {
+		observed string
+		want     bool
+	}{
+		{observed: column + ".1", want: true},
+		{observed: column},
+		{observed: column + "0.1"},
+		{observed: ""},
+	} {
+		if got := OIDMatchesColumn(column, test.observed); got != test.want {
+			t.Errorf("OIDMatchesColumn(%q, %q) = %v, want %v", column, test.observed, got, test.want)
+		}
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_traps/internal/model/types.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/internal/model/types.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+type ReportType string
+
+const (
+	ReportTypeTrap         ReportType = "trap"
+	ReportTypeDedupSummary ReportType = "deduplication_summary"
+	ReportTypeDecodeError  ReportType = "decode_error"
+)
+
+type PduType string
+
+const (
+	PduTypeTrap   PduType = "trap"
+	PduTypeInform PduType = "inform"
+)
+
+type SnmpVersion string
+
+const (
+	SnmpVersionV1  SnmpVersion = "v1"
+	SnmpVersionV2c SnmpVersion = "v2c"
+	SnmpVersionV3  SnmpVersion = "v3"
+)
+
+type ASN1Type string
+
+type Category string
+
+type Severity string
+
+type VarbindValue struct {
+	Name  string   `json:"name,omitempty"`
+	OID   string   `json:"oid"`
+	Type  ASN1Type `json:"type"`
+	Value any      `json:"value"`
+	Enum  string   `json:"enum,omitempty"`
+}
+
+type DedupSummary struct {
+	TotalSuppressed int64            `json:"total_suppressed"`
+	PeriodSec       int64            `json:"period_sec"`
+	Fingerprints    int64            `json:"fingerprints"`
+	ByTrap          map[string]int64 `json:"by_trap"`
+}
+
+type DecodeErrorInfo struct {
+	Kind          string `json:"kind"`
+	Error         string `json:"error"`
+	PacketSize    int    `json:"packet_size"`
+	PacketSHA256  string `json:"packet_sha256"`
+	SourceUDPPort int    `json:"source_udp_port,omitempty"`
+	Listener      string `json:"listener,omitempty"`
+	SnmpVersion   string `json:"snmp_version,omitempty"`
+	EngineID      string `json:"engine_id,omitempty"`
+}
+
+type TrapSourceAudit struct {
+	UDPPeer            string   `json:"udp_peer,omitempty"`
+	SnmpTrapAddress    string   `json:"snmp_trap_address,omitempty"`
+	Selected           string   `json:"selected,omitempty"`
+	Method             string   `json:"method,omitempty"`
+	TrustedRelay       bool     `json:"trusted_relay,omitempty"`
+	RejectedCandidates []string `json:"rejected_candidates,omitempty"`
+}
+
+type TrapEnrichmentAudit struct {
+	Source     *TrapSourceAudit      `json:"source,omitempty"`
+	Registry   *TrapEnrichmentLookup `json:"registry,omitempty"`
+	Topology   *TrapEnrichmentLookup `json:"topology,omitempty"`
+	Interface  *TrapEnrichmentLookup `json:"interface,omitempty"`
+	Neighbors  *TrapEnrichmentLookup `json:"neighbors,omitempty"`
+	ReverseDNS *TrapEnrichmentLookup `json:"reverse_dns,omitempty"`
+	Applied    map[string]string     `json:"applied,omitempty"`
+}
+
+type TrapEnrichmentLookup struct {
+	Key     string   `json:"key,omitempty"`
+	Value   string   `json:"value,omitempty"`
+	Status  string   `json:"status,omitempty"`
+	Method  string   `json:"method,omitempty"`
+	Matches int      `json:"matches,omitempty"`
+	Reason  string   `json:"reason,omitempty"`
+	Fields  []string `json:"fields,omitempty"`
+}
+
+type TrapEntry struct {
+	JobName               string
+	ReportType            ReportType
+	ReceivedRealtimeUsec  int64
+	ReceivedMonotonicUsec int64
+	TrapOID               string
+	TrapName              string
+	Category              Category
+	Severity              Severity
+	Message               string
+	SourceIP              string
+	SourceUDPPeer         string
+	ReverseDNS            string
+	DeviceHostname        string
+	DeviceVendor          string
+	PduType               PduType
+	SnmpVersion           SnmpVersion
+	SourceVnodeID         string
+	TopologyInterface     string
+	TopologyNeighbors     string
+	PacketSequence        uint64
+	Labels                map[string]string
+	Varbinds              []VarbindValue
+	Enrichment            *TrapEnrichmentAudit
+	SummaryCounts         *DedupSummary
+	DecodeError           *DecodeErrorInfo
+}
+
+type TrapPDU struct {
+	OID         string
+	SourceIP    string
+	PeerIP      string
+	Community   string
+	Version     SnmpVersion
+	PduType     PduType
+	Varbinds    []VarbindValue
+	RequestID   uint32
+	SourceAudit *TrapSourceAudit
+}

--- a/src/go/plugin/go.d/collector/snmp_traps/internal/model/varbind.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/internal/model/varbind.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+const RedactedVarbindValue = "<redacted>"
+
+func FindVarbindForProfileOID(varbinds []VarbindValue, profileOID string) (VarbindValue, bool) {
+	if profileOID == "" {
+		return VarbindValue{}, false
+	}
+	for _, value := range varbinds {
+		if value.OID == profileOID {
+			return value, true
+		}
+	}
+	for _, value := range varbinds {
+		if OIDMatchesColumn(profileOID, value.OID) {
+			return value, true
+		}
+	}
+	return VarbindValue{}, false
+}
+
+func FindVarbindByName(varbinds []VarbindValue, name string) (VarbindValue, bool) {
+	if name == "" {
+		return VarbindValue{}, false
+	}
+	for _, value := range varbinds {
+		if value.Name == name {
+			return value, true
+		}
+	}
+	return VarbindValue{}, false
+}
+
+func IsSensitiveVarbind(value VarbindValue) bool {
+	oid := NormalizeOID(value.OID)
+	if oid == SNMPTrapCommunityOID || oid == strings.TrimSuffix(SNMPTrapCommunityOID, ".0") {
+		return true
+	}
+	return strings.TrimSuffix(value.Name, ".0") == "snmpTrapCommunity"
+}
+
+func VarbindRawValue(value VarbindValue) string {
+	switch v := value.Value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	case uint64:
+		return fmt.Sprintf("%d", v)
+	case float64:
+		return fmt.Sprintf("%v", v)
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_traps/internal/model/varbind_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/internal/model/varbind_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package model
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestFindVarbindForProfileOID(t *testing.T) {
+	const oid = "1.3.6.1.2.1.2.2.1.8"
+	values := []VarbindValue{
+		{OID: oid + ".2", Value: "second"},
+		{OID: oid, Value: "exact"},
+		{OID: oid + ".1", Value: "first"},
+	}
+
+	got, ok := FindVarbindForProfileOID(values, oid)
+	if !ok || got.Value != "exact" {
+		t.Fatalf("exact lookup = %#v/%v, want exact/true", got, ok)
+	}
+
+	got, ok = FindVarbindForProfileOID(values[:1], oid)
+	if !ok || got.Value != "second" {
+		t.Fatalf("column lookup = %#v/%v, want first observed/true", got, ok)
+	}
+
+	if _, ok := FindVarbindForProfileOID(values, ""); ok {
+		t.Fatal("empty OID matched")
+	}
+	if _, ok := FindVarbindForProfileOID(nil, oid); ok {
+		t.Fatal("nil varbinds matched")
+	}
+}
+
+func TestFindVarbindByName(t *testing.T) {
+	values := []VarbindValue{{Name: "ifIndex.1", Value: 1}, {Name: "ifIndex.2", Value: 2}}
+	got, ok := FindVarbindByName(values, "ifIndex.2")
+	if !ok || got.Value != 2 {
+		t.Fatalf("lookup = %#v/%v, want second value/true", got, ok)
+	}
+	if _, ok := FindVarbindByName(values, ""); ok {
+		t.Fatal("empty name matched")
+	}
+}
+
+func TestIsSensitiveVarbind(t *testing.T) {
+	baseOID := "1.3.6.1.6.3.18.1.4"
+	for _, test := range []struct {
+		name  string
+		value VarbindValue
+		want  bool
+	}{
+		{name: "scalar OID", value: VarbindValue{OID: SNMPTrapCommunityOID}, want: true},
+		{name: "base OID", value: VarbindValue{OID: baseOID}, want: true},
+		{name: "leading dot", value: VarbindValue{OID: "." + SNMPTrapCommunityOID}, want: true},
+		{name: "instance name", value: VarbindValue{Name: "snmpTrapCommunity.0"}, want: true},
+		{name: "base name", value: VarbindValue{Name: "snmpTrapCommunity"}, want: true},
+		{name: "name wins over unrelated OID", value: VarbindValue{Name: "snmpTrapCommunity.0", OID: "1.3.6.1"}, want: true},
+		{name: "neighboring OID", value: VarbindValue{OID: baseOID + "1"}},
+		{name: "neighboring name", value: VarbindValue{Name: "snmpTrapCommunityValue"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsSensitiveVarbind(test.value); got != test.want {
+				t.Fatalf("IsSensitiveVarbind(%#v) = %v, want %v", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestVarbindRawValue(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{name: "nil", value: nil, want: ""},
+		{name: "string", value: "value", want: "value"},
+		{name: "bytes", value: []byte("raw"), want: "raw"},
+		{name: "signed", value: int64(-2), want: "-2"},
+		{name: "unsigned", value: uint64(2), want: "2"},
+		{name: "float", value: float64(1.25), want: "1.25"},
+		{name: "true", value: true, want: "true"},
+		{name: "false", value: false, want: "false"},
+		{name: "fallback", value: []int{1, 2}, want: "[1 2]"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := VarbindRawValue(VarbindValue{Value: test.value}); got != test.want {
+				t.Fatalf("VarbindRawValue(%#v) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+	if RedactedVarbindValue != "<redacted>" {
+		t.Fatalf("RedactedVarbindValue = %q", RedactedVarbindValue)
+	}
+}
+
+func BenchmarkFindVarbindForProfileOID(b *testing.B) {
+	const target = "1.3.6.1.2.1.2.2.1.8"
+	for _, size := range []int{2, 50, 256} {
+		values := make([]VarbindValue, size)
+		for i := range values {
+			values[i].OID = "1.3.6.1.4.1.999.1.1"
+		}
+		values[size-1].OID = target + ".1"
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_, _ = FindVarbindForProfileOID(values, target)
+			}
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_traps/internal/model/varbind_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/internal/model/varbind_test.go
@@ -105,8 +105,13 @@ func BenchmarkFindVarbindForProfileOID(b *testing.B) {
 		values[size-1].OID = target + ".1"
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
+			var got VarbindValue
+			var ok bool
 			for b.Loop() {
-				_, _ = FindVarbindForProfileOID(values, target)
+				got, ok = FindVarbindForProfileOID(values, target)
+			}
+			if !ok || got.OID != target+".1" {
+				b.Fatalf("lookup = %#v/%v, want target instance/true", got, ok)
 			}
 		})
 	}

--- a/src/go/plugin/go.d/collector/snmp_traps/journal_host.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/journal_host.go
@@ -3,17 +3,13 @@
 package snmp_traps
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-
-	sdkjournal "github.com/netdata/systemd-journal-sdk/go/journal"
-	"github.com/netdata/systemd-journal-sdk/go/journalhost"
 
 	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
 	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/hostidentity"
 )
 
 const (
@@ -21,36 +17,14 @@ const (
 	journalHostStateDirName = "systemd-journal-sdk"
 )
 
-type journalHostProvider interface {
-	MachineID() sdkjournal.UUID
-	BootID() sdkjournal.UUID
-	MonotonicUsec() uint64
+type journalHostProvider = hostidentity.Provider
+
+func newHostIdentityService() *hostidentity.Service {
+	return hostidentity.New(journalHostLoadConfig)
 }
 
-var defaultJournalHost struct {
-	once     sync.Once
-	provider journalHostProvider
-	err      error
-}
-
-func loadJournalHostProvider() (journalHostProvider, error) {
-	opts := journalHostLoadOptions()
-	provider, err := journalhost.Load(opts)
-	if err != nil {
-		return nil, fmt.Errorf("load local journal host identity using state directory %s: %w", opts.StateDir, err)
-	}
-	return provider, nil
-}
-
-func defaultJournalHostProvider() (journalHostProvider, error) {
-	defaultJournalHost.once.Do(func() {
-		defaultJournalHost.provider, defaultJournalHost.err = journalhost.Load(journalHostLoadOptions())
-	})
-	return defaultJournalHost.provider, defaultJournalHost.err
-}
-
-func journalHostLoadOptions() journalhost.LoadOptions {
-	return journalhost.LoadOptions{
+func journalHostLoadConfig() hostidentity.LoadConfig {
+	return hostidentity.LoadConfig{
 		StateDir:             netdataJournalHostStateDir(),
 		HostFilesystemPrefix: netdataHostFilesystemPrefix(),
 	}
@@ -80,17 +54,29 @@ func netdataLibDir() string {
 	return filepath.Clean(buildinfo.DefaultVarLibDir)
 }
 
-func defaultMonotonicUsec() int64 {
-	provider, err := defaultJournalHostProvider()
-	if err != nil {
-		return 0
-	}
-	return int64(provider.MonotonicUsec())
+func netdataEngineStateRoot() string {
+	return filepath.Join(netdataLibDir(), "snmp-trap")
 }
 
 func (c *Collector) monotonicUsec() int64 {
 	if c != nil && c.journalHost != nil {
 		return int64(c.journalHost.MonotonicUsec())
 	}
-	return monotonicUsec()
+	if c == nil || c.hostIdentity == nil {
+		return 0
+	}
+	provider, err := c.hostIdentity.CachedFallback()
+	if err != nil {
+		return 0
+	}
+	return int64(provider.MonotonicUsec())
+}
+
+func (c *Collector) sourceHashSalt() string {
+	if c != nil && c.hostIdentity != nil {
+		if provider, err := c.hostIdentity.CachedFallback(); err == nil {
+			return "machine-id:" + provider.MachineID().String()
+		}
+	}
+	return "netdata-agent"
 }

--- a/src/go/plugin/go.d/collector/snmp_traps/journal_host_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/journal_host_test.go
@@ -3,15 +3,18 @@
 package snmp_traps
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	sdkjournal "github.com/netdata/systemd-journal-sdk/go/journal"
 
 	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
 	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/hostidentity"
 )
 
 type staticJournalHostProvider struct {
@@ -110,7 +113,7 @@ func TestNetdataHostFilesystemPrefixIgnoresEmptyNetdataHostPrefix(t *testing.T) 
 	}
 }
 
-func TestJournalHostLoadOptionsIncludesHostFilesystemPrefix(t *testing.T) {
+func TestJournalHostLoadConfigIncludesHostFilesystemPrefix(t *testing.T) {
 	if pluginconfig.VarLibDir() != "" {
 		t.Skip("pluginconfig VarLibDir is already initialized")
 	}
@@ -120,17 +123,17 @@ func TestJournalHostLoadOptionsIncludesHostFilesystemPrefix(t *testing.T) {
 	libDir := filepath.Join(t.TempDir(), "opt", "netdata", "var", "lib", "netdata")
 	withTestBuildinfoVarLibDir(t, libDir)
 
-	opts := journalHostLoadOptions()
+	cfg := journalHostLoadConfig()
 
-	if got, want := opts.StateDir, filepath.Join(libDir, journalHostStateDirName); got != want {
+	if got, want := cfg.StateDir, filepath.Join(libDir, journalHostStateDirName); got != want {
 		t.Fatalf("StateDir = %q, want %q", got, want)
 	}
-	if got, want := opts.HostFilesystemPrefix, "/host"; got != want {
+	if got, want := cfg.HostFilesystemPrefix, "/host"; got != want {
 		t.Fatalf("HostFilesystemPrefix = %q, want %q", got, want)
 	}
 }
 
-func TestEngineBootsBaseDirUsesJournalHostLibDirResolver(t *testing.T) {
+func TestNetdataEngineStateRootUsesNetdataLibDir(t *testing.T) {
 	if pluginconfig.VarLibDir() != "" {
 		t.Skip("pluginconfig VarLibDir is already initialized")
 	}
@@ -140,7 +143,28 @@ func TestEngineBootsBaseDirUsesJournalHostLibDirResolver(t *testing.T) {
 	withTestBuildinfoVarLibDir(t, libDir)
 
 	want := filepath.Join(libDir, "snmp-trap")
-	if got := engineBootsBaseDir(); got != want {
-		t.Fatalf("engineBootsBaseDir() = %q, want %q", got, want)
+	if got := netdataEngineStateRoot(); got != want {
+		t.Fatalf("netdataEngineStateRoot() = %q, want %q", got, want)
+	}
+}
+
+func TestDecodeErrorRealtimeSurvivesCachedHostIdentityFailure(t *testing.T) {
+	service := hostidentity.NewWithLoader(
+		func() hostidentity.LoadConfig { return hostidentity.LoadConfig{} },
+		func(hostidentity.LoadConfig) (hostidentity.Provider, error) {
+			return nil, errors.New("identity unavailable")
+		},
+	)
+	c := &Collector{hostIdentity: service}
+
+	before := time.Now().UnixMicro()
+	entry := newDecodeErrorEntry("test", decodeErrorRecord{kind: "decode_failed", err: errors.New("bad packet")}, c.monotonicUsec())
+	after := time.Now().UnixMicro()
+
+	if entry.ReceivedMonotonicUsec != 0 {
+		t.Fatalf("monotonic timestamp = %d, want 0", entry.ReceivedMonotonicUsec)
+	}
+	if entry.ReceivedRealtimeUsec < before || entry.ReceivedRealtimeUsec > after {
+		t.Fatalf("realtime timestamp = %d, want between %d and %d", entry.ReceivedRealtimeUsec, before, after)
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_traps/journal_writer.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/journal_writer.go
@@ -84,14 +84,6 @@ func validateNetdataLogRoot() error {
 	return nil
 }
 
-func NewJournalWriter(dir string, cfg JournalConfig) (*JournalWriter, error) {
-	host, err := loadJournalHostProvider()
-	if err != nil {
-		return nil, err
-	}
-	return newJournalWriterWithHostProvider(dir, cfg, host)
-}
-
 func newJournalWriterWithHostProvider(dir string, cfg JournalConfig, host journalHostProvider) (*JournalWriter, error) {
 	if host == nil {
 		return nil, errMissingJournalHost

--- a/src/go/plugin/go.d/collector/snmp_traps/listener_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/listener_test.go
@@ -175,7 +175,7 @@ func TestCollectorReportsListenerReceiveBufferWarnings(t *testing.T) {
 	const jobName = "test-listener-buffer-degraded"
 	metrics := withCleanJobMetrics(t, jobName)
 	c := newTestSNMPTrapsCollector()
-	c.jobName = jobName
+	c.Name = jobName
 	c.metrics = metrics
 	var buf bytes.Buffer
 	c.Logger = logger.NewWithWriter(&buf)

--- a/src/go/plugin/go.d/collector/snmp_traps/load.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/load.go
@@ -23,6 +23,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/executable"
 	"github.com/netdata/netdata/go/plugins/pkg/multipath"
 	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 type profileLoadPaths struct {
@@ -1216,7 +1217,7 @@ func (s *stockProfileStore) loadForOID(idx *ProfileIndex, oid string) error {
 }
 
 func (s *stockProfileStore) route(oid string) string {
-	for _, candidate := range []string{oid, alternateTrapOID(oid)} {
+	for _, candidate := range []string{oid, model.AlternateTrapOID(oid)} {
 		if file := s.exactRoutes[candidate]; file != "" {
 			return file
 		}
@@ -1340,6 +1341,51 @@ func mergeStringMaps(base, override map[string]string) map[string]string {
 
 func stacksContains(stack []string, name string) bool {
 	return slices.Contains(stack, name)
+}
+
+type yamlKeySpec struct {
+	children map[string]yamlKeySpec
+	elem     *yamlKeySpec
+	allowAny bool
+}
+
+func rejectUnknownYAMLKeys(node any, spec yamlKeySpec, path string) error {
+	if spec.allowAny || node == nil {
+		return nil
+	}
+
+	switch v := node.(type) {
+	case map[any]any:
+		if spec.children == nil {
+			return nil
+		}
+		for rawKey, rawValue := range v {
+			key, ok := rawKey.(string)
+			if !ok {
+				return fmt.Errorf("%s: config key %v is not a string", path, rawKey)
+			}
+			child, ok := spec.children[key]
+			if !ok {
+				return fmt.Errorf("%s: unknown config key %q", path, key)
+			}
+			childPath := path + "." + key
+			if err := rejectUnknownYAMLKeys(rawValue, child, childPath); err != nil {
+				return err
+			}
+		}
+	case []any:
+		if spec.elem == nil {
+			return nil
+		}
+		for i, item := range v {
+			itemPath := fmt.Sprintf("%s[%d]", path, i)
+			if err := rejectUnknownYAMLKeys(item, *spec.elem, itemPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 var (

--- a/src/go/plugin/go.d/collector/snmp_traps/local_engine_id_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/local_engine_id_test.go
@@ -55,7 +55,7 @@ func buildV3InformWithEngineID(t *testing.T, user, engineIDHex, trapOID string, 
 func TestLocalEngineIDConfiguredAcceptedAndPersisted(t *testing.T) {
 	paths := newEngineStatePaths(withEngineStateDir(t), "test-job")
 
-	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
+	lid, err := newLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID with configured value failed: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestLocalEngineIDConfiguredAcceptedAndPersisted(t *testing.T) {
 		t.Fatalf("local engine ID hex = %q, want %q", lid.Hex(), testLocalEngineIDHex)
 	}
 
-	lid2, err := NewLocalEngineID(paths, "")
+	lid2, err := newLocalEngineID(paths, "")
 	if err != nil {
 		t.Fatalf("NewLocalEngineID reload failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestLocalEngineIDConfiguredAcceptedAndPersisted(t *testing.T) {
 func TestLocalEngineIDOmittedGeneratesPersistsAndReloads(t *testing.T) {
 	paths := newEngineStatePaths(withEngineStateDir(t), "test-job")
 
-	lid, err := NewLocalEngineID(paths, "")
+	lid, err := newLocalEngineID(paths, "")
 	if err != nil {
 		t.Fatalf("NewLocalEngineID generation failed: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestLocalEngineIDOmittedGeneratesPersistsAndReloads(t *testing.T) {
 		t.Fatalf("generated engine ID first bit is set: %x", raw[0])
 	}
 
-	lid2, err := NewLocalEngineID(paths, "")
+	lid2, err := newLocalEngineID(paths, "")
 	if err != nil {
 		t.Fatalf("NewLocalEngineID reload failed: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestLocalEngineIDInitFailsWhenStateCannotBeWritten(t *testing.T) {
 		t.Fatalf("write corrupt local engine id: %v", err)
 	}
 
-	if _, err := NewLocalEngineID(paths, ""); err == nil {
+	if _, err := newLocalEngineID(paths, ""); err == nil {
 		t.Fatal("expected error for corrupt persisted local engine ID")
 	}
 }
@@ -153,7 +153,7 @@ func TestLocalEngineIDInitFailsWhenDirCannotBeCreated(t *testing.T) {
 		t.Fatalf("create blocker file: %v", err)
 	}
 
-	if _, err := NewLocalEngineID(paths, ""); err == nil {
+	if _, err := newLocalEngineID(paths, ""); err == nil {
 		t.Fatal("expected error when engine dir is a file")
 	}
 }
@@ -197,7 +197,7 @@ func TestV3InformAcceptedWithLocalEngineID(t *testing.T) {
 	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
 	withCleanJobMetrics(t, jobName)
 
-	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
+	lid, err := newLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestV3InformRejectedWithNonLocalEngineID(t *testing.T) {
 	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
 	withCleanJobMetrics(t, jobName)
 
-	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
+	lid, err := newLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestV3TrapStillRequiresSenderEngineWhitelist(t *testing.T) {
 	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
 	withCleanJobMetrics(t, jobName)
 
-	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
+	lid, err := newLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestV3InformResponseContainsLocalEngineID(t *testing.T) {
 	defer listenerConn.Close()
 	defer peerConn.Close()
 
-	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
+	lid, err := newLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestV3InformResponseContainsLocalEngineID(t *testing.T) {
 		},
 	}
 
-	eb, err := NewEngineBoots(paths)
+	eb, err := newEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("NewEngineBoots failed: %v", err)
 	}
@@ -350,7 +350,7 @@ func TestSendInformResponseV3AuthPriv(t *testing.T) {
 	defer listenerConn.Close()
 	defer peerConn.Close()
 
-	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
+	lid, err := newLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -379,7 +379,7 @@ func TestSendInformResponseV3AuthPriv(t *testing.T) {
 		t.Fatalf("DecodeTrap failed: %v", err)
 	}
 
-	eb, err := NewEngineBoots(paths)
+	eb, err := newEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("NewEngineBoots failed: %v", err)
 	}
@@ -426,7 +426,7 @@ func TestSendInformResponseV3AuthPriv(t *testing.T) {
 func TestCollectorCleanupWithLocalEngineID(t *testing.T) {
 	const jobName = "test-cleanup-lid"
 	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
-	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
+	lid, err := newLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}

--- a/src/go/plugin/go.d/collector/snmp_traps/local_engine_id_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/local_engine_id_test.go
@@ -9,16 +9,14 @@ import (
 	"testing"
 
 	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 const testLocalEngineIDHex = "86123456789abcdef0123456"
 
-func withEngineStateDir(t *testing.T) {
+func withEngineStateDir(t *testing.T) string {
 	t.Helper()
-	tmpDir := t.TempDir()
-	prev := engineBootsDirBase
-	engineBootsDirBase = tmpDir
-	t.Cleanup(func() { engineBootsDirBase = prev })
+	return t.TempDir()
 }
 
 func buildV3InformWithEngineID(t *testing.T, user, engineIDHex, trapOID string, extra ...gosnmp.SnmpPDU) []byte {
@@ -43,8 +41,8 @@ func buildV3InformWithEngineID(t *testing.T, user, engineIDHex, trapOID string, 
 		Logger:             trapDecodeLogger,
 	}
 	pdus := []gosnmp.SnmpPDU{
-		{Name: sysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
-		{Name: snmpTrapOIDOID, Type: gosnmp.ObjectIdentifier, Value: trapOID},
+		{Name: model.SysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
+		{Name: model.SNMPTrapOID, Type: gosnmp.ObjectIdentifier, Value: trapOID},
 	}
 	pdus = append(pdus, extra...)
 	data, err := g.SnmpEncodePacket(gosnmp.InformRequest, pdus, 0, 0)
@@ -55,9 +53,9 @@ func buildV3InformWithEngineID(t *testing.T, user, engineIDHex, trapOID string, 
 }
 
 func TestLocalEngineIDConfiguredAcceptedAndPersisted(t *testing.T) {
-	withEngineStateDir(t)
+	paths := newEngineStatePaths(withEngineStateDir(t), "test-job")
 
-	lid, err := NewLocalEngineID("test-job", testLocalEngineIDHex)
+	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID with configured value failed: %v", err)
 	}
@@ -65,7 +63,7 @@ func TestLocalEngineIDConfiguredAcceptedAndPersisted(t *testing.T) {
 		t.Fatalf("local engine ID hex = %q, want %q", lid.Hex(), testLocalEngineIDHex)
 	}
 
-	lid2, err := NewLocalEngineID("test-job", "")
+	lid2, err := NewLocalEngineID(paths, "")
 	if err != nil {
 		t.Fatalf("NewLocalEngineID reload failed: %v", err)
 	}
@@ -75,9 +73,9 @@ func TestLocalEngineIDConfiguredAcceptedAndPersisted(t *testing.T) {
 }
 
 func TestLocalEngineIDOmittedGeneratesPersistsAndReloads(t *testing.T) {
-	withEngineStateDir(t)
+	paths := newEngineStatePaths(withEngineStateDir(t), "test-job")
 
-	lid, err := NewLocalEngineID("test-job", "")
+	lid, err := NewLocalEngineID(paths, "")
 	if err != nil {
 		t.Fatalf("NewLocalEngineID generation failed: %v", err)
 	}
@@ -93,7 +91,7 @@ func TestLocalEngineIDOmittedGeneratesPersistsAndReloads(t *testing.T) {
 		t.Fatalf("generated engine ID first bit is set: %x", raw[0])
 	}
 
-	lid2, err := NewLocalEngineID("test-job", "")
+	lid2, err := NewLocalEngineID(paths, "")
 	if err != nil {
 		t.Fatalf("NewLocalEngineID reload failed: %v", err)
 	}
@@ -124,28 +122,28 @@ func TestLocalEngineIDInvalidFailsValidation(t *testing.T) {
 }
 
 func TestLocalEngineIDInitFailsWhenStateCannotBeWritten(t *testing.T) {
-	withEngineStateDir(t)
+	paths := newEngineStatePaths(withEngineStateDir(t), "test-job")
 
-	if err := os.MkdirAll(engineBootsDir("test-job"), 0750); err != nil {
+	if err := os.MkdirAll(paths.dir, 0750); err != nil {
 		t.Fatalf("mkdir engine dir: %v", err)
 	}
-	if err := os.WriteFile(localEngineIDPath("test-job"), []byte("not-hex\n"), 0640); err != nil {
+	if err := os.WriteFile(paths.localEngineID, []byte("not-hex\n"), 0640); err != nil {
 		t.Fatalf("write corrupt local engine id: %v", err)
 	}
 
-	if _, err := NewLocalEngineID("test-job", ""); err == nil {
+	if _, err := NewLocalEngineID(paths, ""); err == nil {
 		t.Fatal("expected error for corrupt persisted local engine ID")
 	}
 }
 
 func TestLocalEngineIDInitFailsWhenDirCannotBeCreated(t *testing.T) {
-	withEngineStateDir(t)
+	paths := newEngineStatePaths(withEngineStateDir(t), "test-job")
 
-	dir := engineBootsDir("test-job")
+	dir := paths.dir
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		t.Fatalf("mkdir engine dir: %v", err)
 	}
-	if err := os.WriteFile(localEngineIDPath("test-job"), []byte("abc\n"), 0640); err != nil {
+	if err := os.WriteFile(paths.localEngineID, []byte("abc\n"), 0640); err != nil {
 		t.Fatalf("create file in place of dir: %v", err)
 	}
 	if err := os.RemoveAll(dir); err != nil {
@@ -155,54 +153,51 @@ func TestLocalEngineIDInitFailsWhenDirCannotBeCreated(t *testing.T) {
 		t.Fatalf("create blocker file: %v", err)
 	}
 
-	if _, err := NewLocalEngineID("test-job", ""); err == nil {
+	if _, err := NewLocalEngineID(paths, ""); err == nil {
 		t.Fatal("expected error when engine dir is a file")
 	}
 }
 
 func TestCleanupCreatedEngineStateKeepsPreExistingDir(t *testing.T) {
-	withEngineStateDir(t)
-
 	const jobName = "test-cleanup-preexisting-dir"
-	if err := os.MkdirAll(engineBootsDir(jobName), 0750); err != nil {
+	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
+	if err := os.MkdirAll(paths.dir, 0750); err != nil {
 		t.Fatalf("mkdir engine dir: %v", err)
 	}
 
-	cleanupCreatedEngineState(jobName, true, true, false)
+	cleanupCreatedEngineState(paths, true, true, false)
 
-	if st, err := os.Stat(engineBootsDir(jobName)); err != nil || !st.IsDir() {
+	if st, err := os.Stat(paths.dir); err != nil || !st.IsDir() {
 		t.Fatalf("pre-existing engine dir should remain, stat=%v err=%v", st, err)
 	}
 }
 
 func TestCleanupCreatedEngineStateRemovesNewDir(t *testing.T) {
-	withEngineStateDir(t)
-
 	const jobName = "test-cleanup-new-dir"
-	if err := os.MkdirAll(engineBootsDir(jobName), 0750); err != nil {
+	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
+	if err := os.MkdirAll(paths.dir, 0750); err != nil {
 		t.Fatalf("mkdir engine dir: %v", err)
 	}
-	if err := os.WriteFile(engineBootsPath(jobName), []byte("1\n"), 0640); err != nil {
+	if err := os.WriteFile(paths.engineBoots, []byte("1\n"), 0640); err != nil {
 		t.Fatalf("write engine boots: %v", err)
 	}
-	if err := os.WriteFile(localEngineIDPath(jobName), []byte(testLocalEngineIDHex+"\n"), 0640); err != nil {
+	if err := os.WriteFile(paths.localEngineID, []byte(testLocalEngineIDHex+"\n"), 0640); err != nil {
 		t.Fatalf("write local engine ID: %v", err)
 	}
 
-	cleanupCreatedEngineState(jobName, true, true, true)
+	cleanupCreatedEngineState(paths, true, true, true)
 
-	if _, err := os.Stat(engineBootsDir(jobName)); !os.IsNotExist(err) {
+	if _, err := os.Stat(paths.dir); !os.IsNotExist(err) {
 		t.Fatalf("new engine dir should be removed, err=%v", err)
 	}
 }
 
 func TestV3InformAcceptedWithLocalEngineID(t *testing.T) {
-	withEngineStateDir(t)
-
 	const jobName = "test-inform-local"
+	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
 	withCleanJobMetrics(t, jobName)
 
-	lid, err := NewLocalEngineID(jobName, testLocalEngineIDHex)
+	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -225,12 +220,11 @@ func TestV3InformAcceptedWithLocalEngineID(t *testing.T) {
 }
 
 func TestV3InformRejectedWithNonLocalEngineID(t *testing.T) {
-	withEngineStateDir(t)
-
 	const jobName = "test-inform-nonlocal"
+	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
 	withCleanJobMetrics(t, jobName)
 
-	lid, err := NewLocalEngineID(jobName, testLocalEngineIDHex)
+	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -256,12 +250,11 @@ func TestV3InformRejectedWithNonLocalEngineID(t *testing.T) {
 }
 
 func TestV3TrapStillRequiresSenderEngineWhitelist(t *testing.T) {
-	withEngineStateDir(t)
-
 	const jobName = "test-trap-sender-whitelist"
+	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
 	withCleanJobMetrics(t, jobName)
 
-	lid, err := NewLocalEngineID(jobName, testLocalEngineIDHex)
+	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -287,13 +280,13 @@ func TestV3TrapStillRequiresSenderEngineWhitelist(t *testing.T) {
 }
 
 func TestV3InformResponseContainsLocalEngineID(t *testing.T) {
-	withEngineStateDir(t)
+	paths := newEngineStatePaths(withEngineStateDir(t), "test-inform-resp")
 
 	listenerConn, peerConn := informUDPConnPair(t)
 	defer listenerConn.Close()
 	defer peerConn.Close()
 
-	lid, err := NewLocalEngineID("test-inform-resp", testLocalEngineIDHex)
+	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -318,12 +311,12 @@ func TestV3InformResponseContainsLocalEngineID(t *testing.T) {
 		PDUType:            gosnmp.InformRequest,
 		RequestID:          42,
 		Variables: []gosnmp.SnmpPDU{
-			{Name: sysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
-			{Name: snmpTrapOIDOID, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.6.3.1.1.5.1"},
+			{Name: model.SysUpTimeOID, Type: gosnmp.TimeTicks, Value: uint32(10)},
+			{Name: model.SNMPTrapOID, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.6.3.1.1.5.1"},
 		},
 	}
 
-	eb, err := NewEngineBoots("test-inform-resp")
+	eb, err := NewEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("NewEngineBoots failed: %v", err)
 	}
@@ -351,14 +344,13 @@ func TestV3InformResponseContainsLocalEngineID(t *testing.T) {
 }
 
 func TestSendInformResponseV3AuthPriv(t *testing.T) {
-	withEngineStateDir(t)
-
 	const jobName = "test-inform-response-authpriv"
+	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
 	listenerConn, peerConn := informUDPConnPair(t)
 	defer listenerConn.Close()
 	defer peerConn.Close()
 
-	lid, err := NewLocalEngineID(jobName, testLocalEngineIDHex)
+	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
@@ -387,7 +379,7 @@ func TestSendInformResponseV3AuthPriv(t *testing.T) {
 		t.Fatalf("DecodeTrap failed: %v", err)
 	}
 
-	eb, err := NewEngineBoots(jobName)
+	eb, err := NewEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("NewEngineBoots failed: %v", err)
 	}
@@ -432,16 +424,15 @@ func TestSendInformResponseV3AuthPriv(t *testing.T) {
 }
 
 func TestCollectorCleanupWithLocalEngineID(t *testing.T) {
-	withEngineStateDir(t)
-
 	const jobName = "test-cleanup-lid"
-	lid, err := NewLocalEngineID(jobName, testLocalEngineIDHex)
+	paths := newEngineStatePaths(withEngineStateDir(t), jobName)
+	lid, err := NewLocalEngineID(paths, testLocalEngineIDHex)
 	if err != nil {
 		t.Fatalf("NewLocalEngineID failed: %v", err)
 	}
 
 	c := &Collector{
-		jobName:       jobName,
+		Config:        Config{Name: jobName},
 		localEngineID: lid,
 	}
 	c.Cleanup(nil)
@@ -450,7 +441,7 @@ func TestCollectorCleanupWithLocalEngineID(t *testing.T) {
 
 func TestCollectorCleanupNilLocalEngineID(t *testing.T) {
 	c := &Collector{
-		jobName: "test-cleanup-nil-lid",
+		Config: Config{Name: "test-cleanup-nil-lid"},
 	}
 
 	c.Cleanup(nil)

--- a/src/go/plugin/go.d/collector/snmp_traps/metrics.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/metrics.go
@@ -87,6 +87,7 @@ type perJobMetrics struct {
 	sourceMu           sync.Mutex
 	sourceCollectCycle uint64
 	sourceHashSalt     string
+	sourceSaltProvider func() string
 	sources            map[trapMetricSourceIdentityKey]*perSourceMetrics
 	sourceRoutes       map[string]string
 	sourceRouteSeen    map[string]time.Time
@@ -190,7 +191,7 @@ func (c *Collector) trapMetrics() *perJobMetrics {
 	if c.metrics != nil {
 		return c.metrics
 	}
-	return getJobMetrics(c.jobName)
+	return getJobMetrics(c.Name)
 }
 
 func (m *perJobMetrics) incEvent(category Category) {
@@ -394,7 +395,10 @@ func (m *perJobMetrics) recordWriteFailure(entry *TrapEntry, dim string) {
 
 func (m *perJobMetrics) initSourceMetricsLocked() {
 	if m.sourceHashSalt == "" {
-		m.sourceHashSalt = profileMetricSourceHashSalt()
+		m.sourceHashSalt = "netdata-agent"
+		if m.sourceSaltProvider != nil {
+			m.sourceHashSalt = m.sourceSaltProvider()
+		}
 	}
 	if m.sources == nil {
 		m.sources = make(map[trapMetricSourceIdentityKey]*perSourceMetrics)
@@ -404,6 +408,17 @@ func (m *perJobMetrics) initSourceMetricsLocked() {
 	}
 	if m.sourceRouteSeen == nil {
 		m.sourceRouteSeen = make(map[string]time.Time)
+	}
+}
+
+func (m *perJobMetrics) setSourceHashSaltProvider(provider func() string) {
+	if m == nil || provider == nil {
+		return
+	}
+	m.sourceMu.Lock()
+	defer m.sourceMu.Unlock()
+	if m.sourceHashSalt == "" {
+		m.sourceSaltProvider = provider
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_traps/monotonic_fallback.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/monotonic_fallback.go
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-
-//go:build !linux
-
-package snmp_traps
-
-func monotonicUsec() int64 {
-	return defaultMonotonicUsec()
-}

--- a/src/go/plugin/go.d/collector/snmp_traps/monotonic_linux.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/monotonic_linux.go
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-
-//go:build linux
-
-package snmp_traps
-
-func monotonicUsec() int64 {
-	return defaultMonotonicUsec()
-}

--- a/src/go/plugin/go.d/collector/snmp_traps/otlp.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/otlp.go
@@ -24,6 +24,8 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 const (
@@ -776,7 +778,7 @@ func otlpVarbindsValue(entry *TrapEntry) *commonpb.AnyValue {
 	seenKeys := make(map[string]int)
 	values := make([]*commonpb.KeyValue, 0, len(entry.Varbinds))
 	for _, vb := range entry.Varbinds {
-		if isSensitiveTrapVarbind(vb) {
+		if model.IsSensitiveVarbind(vb) {
 			continue
 		}
 		key := vb.Name

--- a/src/go/plugin/go.d/collector/snmp_traps/otlp_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/otlp_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
@@ -271,7 +272,7 @@ func TestOTLPTrapEntrySerializationOmitsCommunityVarbind(t *testing.T) {
 		PduType:              PduTypeTrap,
 		SnmpVersion:          SnmpVersionV1,
 		Varbinds: []VarbindValue{
-			{OID: snmpTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
+			{OID: model.SNMPTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
 			{Name: "ifName", OID: "1.3.6.1.2.1.31.1.1.1.1.7", Type: "OctetString", Value: "Gi1/0/1"},
 		},
 	}

--- a/src/go/plugin/go.d/collector/snmp_traps/pipeline_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/pipeline_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
-	"gopkg.in/yaml.v2"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 func setTestProfileIndex(t *testing.T, traps map[string]*TrapDef) {
@@ -395,7 +395,7 @@ func TestCollectorHandlePacketDropsDisallowedVersion(t *testing.T) {
 	packet := readColdStartUDPPacket(t)
 	writer := &mockTrapWriter{}
 	c := &Collector{
-		jobName:    "test",
+		Config:     Config{Name: "test"},
 		trapWriter: writer,
 		versions:   map[SnmpVersion]struct{}{SnmpVersionV3: {}},
 		allowlist:  NewAllowlist(nil, nil),
@@ -433,7 +433,7 @@ func TestCollectorHandlePacketDropsDisallowedV3BeforeDecode(t *testing.T) {
 	data := buildV3Trap(t, "testuser", "1.3.6.1.6.3.1.1.5.1")
 	writer := &mockTrapWriter{}
 	c := &Collector{
-		jobName:    jobName,
+		Config:     Config{Name: jobName},
 		trapWriter: writer,
 		versions:   map[SnmpVersion]struct{}{SnmpVersionV2c: {}},
 		allowlist:  NewAllowlist(nil, nil),
@@ -827,7 +827,7 @@ func TestCollectorHandlePacketUsesSnmpTrapAddressOnlyForTrustedRelay(t *testing.
 	trap := testColdStartTrap("security", "warning", "coldStart from {TRAP_SOURCE_IP}")
 	setSingleTestTrap(t, trap)
 	data := buildV2cTrap(t, "public", "1.3.6.1.6.3.1.1.5.1", gosnmp.SnmpPDU{
-		Name:  snmpTrapAddressOID,
+		Name:  model.SNMPTrapAddressOID,
 		Type:  gosnmp.IPAddress,
 		Value: "192.0.2.20",
 	})
@@ -1267,7 +1267,7 @@ func TestCollectorCollectEmitsBuiltInAndProfileMetrics(t *testing.T) {
 	}
 
 	c := &Collector{
-		jobName:        jobName,
+		Config:         Config{Name: jobName},
 		listener:       &Listener{},
 		trapWriter:     &mockTrapWriter{},
 		metrics:        metrics,
@@ -1305,7 +1305,7 @@ func TestCollectorCollectPublishesBinaryEncodedMetric(t *testing.T) {
 	}
 
 	c := &Collector{
-		jobName:    jobName,
+		Config:     Config{Name: jobName},
 		listener:   &Listener{},
 		trapWriter: &mockTrapWriter{binaryEncodedFields: 2},
 		metrics:    getJobMetrics(jobName),
@@ -1327,14 +1327,10 @@ func TestCollectorCollectPublishesBinaryEncodedMetric(t *testing.T) {
 }
 
 func TestSnmpEngineBootsPersistence(t *testing.T) {
-	tmpDir := t.TempDir()
-	prev := engineBootsDirBase
-	engineBootsDirBase = tmpDir
-	t.Cleanup(func() { engineBootsDirBase = prev })
-
 	jobName := "test-job"
+	paths := newEngineStatePaths(t.TempDir(), jobName)
 
-	eb, err := NewEngineBoots(jobName)
+	eb, err := NewEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("NewEngineBoots failed: %v", err)
 	}
@@ -1342,7 +1338,7 @@ func TestSnmpEngineBootsPersistence(t *testing.T) {
 		t.Errorf("expected first boot value 1, got %d", v)
 	}
 
-	eb, err = NewEngineBoots(jobName)
+	eb, err = NewEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("second NewEngineBoots failed: %v", err)
 	}
@@ -1352,55 +1348,43 @@ func TestSnmpEngineBootsPersistence(t *testing.T) {
 }
 
 func TestSnmpEngineBootsCorruptFileFailsCreation(t *testing.T) {
-	tmpDir := t.TempDir()
-	prev := engineBootsDirBase
-	engineBootsDirBase = tmpDir
-	t.Cleanup(func() { engineBootsDirBase = prev })
-
 	jobName := "test-job"
-	if err := os.MkdirAll(engineBootsDir(jobName), 0750); err != nil {
+	paths := newEngineStatePaths(t.TempDir(), jobName)
+	if err := os.MkdirAll(paths.dir, 0750); err != nil {
 		t.Fatalf("mkdir engine boots dir: %v", err)
 	}
-	if err := os.WriteFile(engineBootsPath(jobName), []byte("not-a-number\n"), 0640); err != nil {
+	if err := os.WriteFile(paths.engineBoots, []byte("not-a-number\n"), 0640); err != nil {
 		t.Fatalf("write engine boots file: %v", err)
 	}
 
-	if _, err := NewEngineBoots(jobName); err == nil {
+	if _, err := NewEngineBoots(paths); err == nil {
 		t.Fatal("expected corrupt engine-boots state to fail job creation")
 	}
 }
 
 func TestSnmpEngineBootsRejectsMaxValue(t *testing.T) {
-	tmpDir := t.TempDir()
-	prev := engineBootsDirBase
-	engineBootsDirBase = tmpDir
-	t.Cleanup(func() { engineBootsDirBase = prev })
-
 	jobName := "test-job"
-	if err := os.MkdirAll(engineBootsDir(jobName), 0750); err != nil {
+	paths := newEngineStatePaths(t.TempDir(), jobName)
+	if err := os.MkdirAll(paths.dir, 0750); err != nil {
 		t.Fatalf("mkdir engine boots dir: %v", err)
 	}
-	if err := os.WriteFile(engineBootsPath(jobName), []byte("2147483647\n"), 0640); err != nil {
+	if err := os.WriteFile(paths.engineBoots, []byte("2147483647\n"), 0640); err != nil {
 		t.Fatalf("write engine boots file: %v", err)
 	}
 
-	if _, err := NewEngineBoots(jobName); err == nil {
+	if _, err := NewEngineBoots(paths); err == nil {
 		t.Fatal("expected error for max engine boots value")
 	}
 }
 
 func TestSnmpEngineBootsReadErrorFails(t *testing.T) {
-	tmpDir := t.TempDir()
-	prev := engineBootsDirBase
-	engineBootsDirBase = tmpDir
-	t.Cleanup(func() { engineBootsDirBase = prev })
-
 	jobName := "test-job"
-	if err := os.MkdirAll(engineBootsPath(jobName), 0750); err != nil {
+	paths := newEngineStatePaths(t.TempDir(), jobName)
+	if err := os.MkdirAll(paths.engineBoots, 0750); err != nil {
 		t.Fatalf("mkdir engine boots file path: %v", err)
 	}
 
-	if _, err := NewEngineBoots(jobName); err == nil {
+	if _, err := NewEngineBoots(paths); err == nil {
 		t.Fatal("expected read error when engine boots path is a directory")
 	}
 }
@@ -1699,81 +1683,6 @@ func TestConfigValidation(t *testing.T) {
 			if err := validateConfigLabelKey(key); err != nil {
 				t.Fatalf("expected %q to be valid: %v", key, err)
 			}
-		}
-	})
-
-	t.Run("unknown config key", func(t *testing.T) {
-		var cfg Config
-		err := yaml.Unmarshal([]byte(`
-listen:
-  endpoints:
-    - protocol: udp
-      address: "127.0.0.1"
-      port: 9162
-unexpected: true
-`), &cfg)
-		if err == nil {
-			t.Fatal("expected error for unknown top-level key")
-		}
-	})
-
-	t.Run("obsolete job-level metrics key", func(t *testing.T) {
-		var cfg Config
-		err := yaml.Unmarshal([]byte(`
-listen:
-  endpoints:
-    - protocol: udp
-      address: "127.0.0.1"
-      port: 9162
-metrics:
-  - oid: "1.3.6.1.4.1.9.9.43.2.0.1"
-`), &cfg)
-		if err == nil {
-			t.Fatal("expected error for obsolete job-level metrics key")
-		}
-		if !strings.Contains(err.Error(), "profile_metrics") {
-			t.Fatalf("expected profile_metrics guidance, got %v", err)
-		}
-	})
-
-	t.Run("framework metadata keys", func(t *testing.T) {
-		var cfg Config
-		err := yaml.Unmarshal([]byte(`
-name: local
-module: snmp_traps
-autodetection_retry: 0
-priority: 70000
-function_only: false
-labels:
-  role: edge
-__provider__: file reader
-__source__: discoverer=file_reader,file=snmp_traps.conf
-__source_type__: user
-listen:
-  endpoints:
-    - protocol: udp
-      address: "127.0.0.1"
-      port: 9162
-versions: [v2c]
-communities: [public]
-`), &cfg)
-		if err != nil {
-			t.Fatalf("expected framework metadata keys to be accepted: %v", err)
-		}
-	})
-
-	t.Run("unknown nested config key", func(t *testing.T) {
-		var cfg Config
-		err := yaml.Unmarshal([]byte(`
-listen:
-  endpoints:
-    - protocol: udp
-      address: "127.0.0.1"
-      port: 9162
-      unexpected: true
-`), &cfg)
-		if err == nil {
-			t.Fatal("expected error for unknown endpoint key")
 		}
 	})
 

--- a/src/go/plugin/go.d/collector/snmp_traps/pipeline_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/pipeline_test.go
@@ -1330,7 +1330,7 @@ func TestSnmpEngineBootsPersistence(t *testing.T) {
 	jobName := "test-job"
 	paths := newEngineStatePaths(t.TempDir(), jobName)
 
-	eb, err := NewEngineBoots(paths)
+	eb, err := newEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("NewEngineBoots failed: %v", err)
 	}
@@ -1338,7 +1338,7 @@ func TestSnmpEngineBootsPersistence(t *testing.T) {
 		t.Errorf("expected first boot value 1, got %d", v)
 	}
 
-	eb, err = NewEngineBoots(paths)
+	eb, err = newEngineBoots(paths)
 	if err != nil {
 		t.Fatalf("second NewEngineBoots failed: %v", err)
 	}
@@ -1357,7 +1357,7 @@ func TestSnmpEngineBootsCorruptFileFailsCreation(t *testing.T) {
 		t.Fatalf("write engine boots file: %v", err)
 	}
 
-	if _, err := NewEngineBoots(paths); err == nil {
+	if _, err := newEngineBoots(paths); err == nil {
 		t.Fatal("expected corrupt engine-boots state to fail job creation")
 	}
 }
@@ -1372,7 +1372,7 @@ func TestSnmpEngineBootsRejectsMaxValue(t *testing.T) {
 		t.Fatalf("write engine boots file: %v", err)
 	}
 
-	if _, err := NewEngineBoots(paths); err == nil {
+	if _, err := newEngineBoots(paths); err == nil {
 		t.Fatal("expected error for max engine boots value")
 	}
 }
@@ -1384,7 +1384,7 @@ func TestSnmpEngineBootsReadErrorFails(t *testing.T) {
 		t.Fatalf("mkdir engine boots file path: %v", err)
 	}
 
-	if _, err := NewEngineBoots(paths); err == nil {
+	if _, err := newEngineBoots(paths); err == nil {
 		t.Fatal("expected read error when engine boots path is a directory")
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_traps/profile.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/profile.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/netdata/netdata/go/plugins/pkg/executable"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 var validCategories = map[string]bool{
@@ -203,46 +204,10 @@ func (idx *ProfileIndex) lookupLoaded(oid string) *TrapDef {
 	if td := idx.trapsByOID[oid]; td != nil {
 		return td
 	}
-	if alt := alternateTrapOID(oid); alt != oid {
+	if alt := model.AlternateTrapOID(oid); alt != oid {
 		return idx.trapsByOID[alt]
 	}
 	return nil
-}
-
-func alternateTrapOID(oid string) string {
-	if len(oid) == 0 || oid[0] == '.' || oid[len(oid)-1] == '.' {
-		return oid
-	}
-
-	dots := 0
-	prevDot := -1
-	lastDot := -1
-	segmentStart := 0
-
-	for i := 0; i < len(oid); i++ {
-		c := oid[i]
-		switch {
-		case c == '.':
-			if i == segmentStart {
-				return oid
-			}
-			dots++
-			prevDot = lastDot
-			lastDot = i
-			segmentStart = i + 1
-		case c < '0' || c > '9':
-			return oid
-		}
-	}
-
-	if dots < 3 || prevDot < 0 || lastDot <= 0 || lastDot >= len(oid)-1 {
-		return oid
-	}
-
-	if oid[prevDot+1:lastDot] == "0" {
-		return oid[:prevDot] + oid[lastDot:]
-	}
-	return oid[:lastDot] + ".0" + oid[lastDot:]
 }
 
 // profileCache holds the plugin-wide shared profile state.
@@ -423,7 +388,7 @@ func validateFileVarbinds(fileVarbinds map[string]VarbindDef, src string) error 
 		if vb.OID == "" {
 			return fmt.Errorf("%s: varbind %q missing required field 'oid'", src, name)
 		}
-		if !isNumericOID(vb.OID) {
+		if !model.IsNumericOID(vb.OID) {
 			return fmt.Errorf("%s: varbind %q has invalid oid %q", src, name, vb.OID)
 		}
 		if vb.Type == "" {
@@ -443,7 +408,7 @@ func validateTrapDef(td *TrapDef, fileVarbinds map[string]VarbindDef) error {
 	if td.OID == "" {
 		return fmt.Errorf("%s: trap entry missing required field 'oid'", src)
 	}
-	if !isNumericOID(td.OID) {
+	if !model.IsNumericOID(td.OID) {
 		return fmt.Errorf("%s: trap entry has invalid oid %q", src, td.OID)
 	}
 	if td.Name == "" {
@@ -521,7 +486,7 @@ func validateLabelTemplates(td *TrapDef, fileVarbinds map[string]VarbindDef) err
 				}
 				return fmt.Errorf("%s: trap entry %s: label %q references unbounded field %q", src, td.OID, key, name)
 			}
-			if isNumericOID(name) {
+			if model.IsNumericOID(name) {
 				return fmt.Errorf("%s: trap entry %s: label %q references raw OID %q without cardinality metadata", src, td.OID, key, name)
 			}
 			vb := fileVarbinds[name]
@@ -643,7 +608,7 @@ func inlineVarbindDef(v map[any]any) (*VarbindDef, error) {
 	if oid == "" {
 		return nil, fmt.Errorf("missing required field 'oid'")
 	}
-	if !isNumericOID(oid) {
+	if !model.IsNumericOID(oid) {
 		return nil, fmt.Errorf("invalid oid %q", oid)
 	}
 	if typ == "" {
@@ -658,23 +623,6 @@ func inlineVarbindDef(v map[any]any) (*VarbindDef, error) {
 		}
 	}
 	return vb, nil
-}
-
-func isNumericOID(oid string) bool {
-	if oid == "" || oid[0] == '.' || oid[len(oid)-1] == '.' {
-		return false
-	}
-	for part := range strings.SplitSeq(oid, ".") {
-		if part == "" {
-			return false
-		}
-		for _, ch := range part {
-			if ch < '0' || ch > '9' {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 func categoryList() []string {

--- a/src/go/plugin/go.d/collector/snmp_traps/profile_metric.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/profile_metric.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 const (
@@ -630,7 +631,7 @@ type profileMetricSeriesSnapshot struct {
 	value  float64
 }
 
-func newProfileMetricRuntime(cfg normalizedProfileMetricsConfig, idx *ProfileIndex) (*profileMetricRuntime, string, error) {
+func newProfileMetricRuntime(cfg normalizedProfileMetricsConfig, idx *ProfileIndex, sourceHashSalt string) (*profileMetricRuntime, string, error) {
 	if !cfg.enabled {
 		return nil, "", nil
 	}
@@ -660,7 +661,7 @@ func newProfileMetricRuntime(cfg normalizedProfileMetricsConfig, idx *ProfileInd
 		chartInstances:  make(map[profileMetricChartInstanceKey]struct{}),
 		chartCounts:     make(map[string]int),
 		rulesByOID:      make(map[string][]*compiledProfileMetricRule),
-		sourceHashSalt:  profileMetricSourceHashSalt(),
+		sourceHashSalt:  sourceHashSalt,
 	}
 	for _, rule := range selected {
 		compiled, err := compileProfileMetricRule(rule, cat, idx)
@@ -774,7 +775,7 @@ func resolveProfileMetricTrap(idx *ProfileIndex, ref string) (*TrapDef, error) {
 	if ref == "" {
 		return nil, errors.New("trap reference is empty")
 	}
-	if isNumericOID(ref) {
+	if model.IsNumericOID(ref) {
 		td, err := idx.LookupWithError(ref)
 		if err != nil {
 			return nil, err
@@ -797,7 +798,7 @@ func metricOIDAliasesFromTrap(td *TrapDef) []string {
 		return nil
 	}
 	aliases := []string{td.OID}
-	if alt := alternateTrapOID(td.OID); alt != td.OID {
+	if alt := model.AlternateTrapOID(td.OID); alt != td.OID {
 		aliases = append(aliases, alt)
 	}
 	return aliases
@@ -1101,7 +1102,7 @@ func (rt *profileMetricRuntime) resourceIdentity(rule *compiledProfileMetricRule
 		rt.diagnostics.extractionFailed++
 		return "", false
 	}
-	v, ok := findVarbindForProfileOID(entry, rule.resourceVarbind.OID)
+	v, ok := model.FindVarbindForProfileOID(entry.Varbinds, rule.resourceVarbind.OID)
 	if !ok {
 		if rule.rule.Missing == profileMetricMissingUnknownDimension {
 			return "unknown", true
@@ -1113,7 +1114,7 @@ func (rt *profileMetricRuntime) resourceIdentity(rule *compiledProfileMetricRule
 		rt.diagnostics.extractionFailed++
 		return "", false
 	}
-	resourceID := strings.TrimSpace(varbindRawValue(v))
+	resourceID := strings.TrimSpace(model.VarbindRawValue(v))
 	if resourceID == "" {
 		if rule.rule.Missing == profileMetricMissingUnknownDimension {
 			return "unknown", true
@@ -1351,7 +1352,7 @@ func profileMetricPredicateValue(pred profileMetricPredicate, entry *TrapEntry, 
 	if vb == nil {
 		return false, VarbindValue{}, nil
 	}
-	v, ok := findVarbindForProfileOID(entry, vb.OID)
+	v, ok := model.FindVarbindForProfileOID(entry.Varbinds, vb.OID)
 	return ok, v, vb
 }
 
@@ -1423,7 +1424,7 @@ func profileMetricPredicateResult(pred profileMetricPredicate, present bool, val
 }
 
 func profileMetricValueEquals(value VarbindValue, vb *VarbindDef, want any) bool {
-	actual := varbindRawValue(value)
+	actual := model.VarbindRawValue(value)
 	if vb != nil && len(vb.Enum) > 0 {
 		if label := resolveEnum(vb, value.Value); label != "" && label == fmt.Sprintf("%v", want) {
 			return true
@@ -1497,7 +1498,7 @@ func profileMetricNumericVarbindValue(entry *TrapEntry, vb *VarbindDef) (float64
 	if vb == nil {
 		return 0, profileMetricValueInvalid
 	}
-	v, ok := findVarbindForProfileOID(entry, vb.OID)
+	v, ok := model.FindVarbindForProfileOID(entry.Varbinds, vb.OID)
 	if !ok {
 		return 0, profileMetricValueMissing
 	}

--- a/src/go/plugin/go.d/collector/snmp_traps/profile_metric_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/profile_metric_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/pkg/multipath"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 )
 
@@ -76,8 +77,8 @@ func testProfileMetricIndex(t *testing.T) *ProfileIndex {
 						"4": "aux",
 					},
 				},
-				sysUpTimeOID: {
-					OID:     sysUpTimeOID,
+				model.SysUpTimeOID: {
+					OID:     model.SysUpTimeOID,
 					Type:    "TimeTicks",
 					rawName: "sysUpTime.0",
 				},
@@ -195,7 +196,7 @@ func newTestProfileMetricRuntimeWithConfig(t *testing.T, idx *ProfileIndex, cfg 
 	if err != nil {
 		t.Fatalf("normalizeProfileMetricsConfig failed: %v", err)
 	}
-	rt, tmpl, err := newProfileMetricRuntime(normalized, idx)
+	rt, tmpl, err := newProfileMetricRuntime(normalized, idx, "test")
 	if err != nil {
 		t.Fatalf("newProfileMetricRuntime failed: %v", err)
 	}
@@ -230,7 +231,7 @@ func ciscoConfigTrapEntry(jobName string) *TrapEntry {
 		Varbinds: []VarbindValue{
 			{OID: testCiscoCommandSourceOID, Type: "INTEGER", Value: 2},
 			{OID: testCiscoTerminalTypeOID, Type: "INTEGER", Value: 2},
-			{OID: sysUpTimeOID, Type: "TimeTicks", Value: uint64(12345)},
+			{OID: model.SysUpTimeOID, Type: "TimeTicks", Value: uint64(12345)},
 		},
 	}
 }
@@ -442,7 +443,7 @@ func TestNewProfileMetricRuntimeRejectsNilProfileIndex(t *testing.T) {
 		t.Fatalf("normalizeProfileMetricsConfig failed: %v", err)
 	}
 
-	if _, _, err := newProfileMetricRuntime(cfg, nil); err == nil || !strings.Contains(err.Error(), "profile index not available") {
+	if _, _, err := newProfileMetricRuntime(cfg, nil, "test"); err == nil || !strings.Contains(err.Error(), "profile index not available") {
 		t.Fatalf("newProfileMetricRuntime nil index error = %v, want profile index not available", err)
 	}
 }
@@ -1402,7 +1403,7 @@ func TestProfileMetricChartTemplateUsesResourceLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("normalizeProfileMetricsConfig failed: %v", err)
 	}
-	_, tmpl, err := newProfileMetricRuntime(cfg, idx)
+	_, tmpl, err := newProfileMetricRuntime(cfg, idx, "test")
 	if err != nil {
 		t.Fatalf("newProfileMetricRuntime failed: %v", err)
 	}
@@ -2386,7 +2387,7 @@ func TestProfileMetricValidationRejectsDuplicateChartDimensions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("normalizeProfileMetricsConfig failed: %v", err)
 	}
-	_, _, err = newProfileMetricRuntime(cfg, idx)
+	_, _, err = newProfileMetricRuntime(cfg, idx, "test")
 	if err == nil ||
 		!strings.Contains(err.Error(), "reuses output.dimension") ||
 		!strings.Contains(err.Error(), "cisco.config.changed") {

--- a/src/go/plugin/go.d/collector/snmp_traps/profile_template.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/profile_template.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"text/template"
 	"text/template/parse"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 func isGoProfileTemplate(tmpl string) bool {
@@ -308,15 +310,15 @@ func resolveTemplateVarbind(name string, entry *TrapEntry, td *TrapDef, raw bool
 	if vb == nil {
 		return ""
 	}
-	v, ok := findVarbindForProfileOID(entry, vb.OID)
+	v, ok := model.FindVarbindForProfileOID(entry.Varbinds, vb.OID)
 	if !ok {
 		return ""
 	}
-	if isSensitiveTrapVarbind(v) {
-		return redactedTrapVarbind
+	if model.IsSensitiveVarbind(v) {
+		return model.RedactedVarbindValue
 	}
 	if raw {
-		return varbindRawValue(v)
+		return model.VarbindRawValue(v)
 	}
 	return varbindDisplayValue(v, vb)
 }

--- a/src/go/plugin/go.d/collector/snmp_traps/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/profile_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/netdata/netdata/go/plugins/pkg/multipath"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -91,7 +92,7 @@ func TestCollectorInitAcquiresProfileCache(t *testing.T) {
 	port := freeUDPPort(t)
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port}}
 
 	err := c.Init(context.Background())
@@ -110,11 +111,11 @@ func TestMultipleCollectorsShareSameCache(t *testing.T) {
 	port2 := freeUDPPort(t)
 
 	c1 := newTestSNMPTrapsCollector()
-	c1.SetJobName("job1")
+	c1.Name = "job1"
 	c1.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port1}}
 
 	c2 := newTestSNMPTrapsCollector()
-	c2.SetJobName("job2")
+	c2.Name = "job2"
 	c2.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: port2}}
 
 	err := c1.Init(context.Background())
@@ -143,7 +144,7 @@ func TestInitBindFailureReleasesProfileRef(t *testing.T) {
 	defer conn.Close()
 
 	c := newTestSNMPTrapsCollector()
-	c.SetJobName("local")
+	c.Name = "local"
 	c.Listen.Endpoints = []EndpointConfig{{Protocol: "udp", Address: "127.0.0.1", Port: conn.LocalAddr().(*net.UDPAddr).Port}}
 
 	err = c.Init(context.Background())
@@ -650,7 +651,7 @@ func TestAlternateTrapOID(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.want, alternateTrapOID(tt.oid))
+			assert.Equal(t, tt.want, model.AlternateTrapOID(tt.oid))
 		})
 	}
 }
@@ -1408,7 +1409,7 @@ func TestRenderMessageAndLabelsRedactSensitiveCommunityVarbind(t *testing.T) {
 	entry := &TrapEntry{
 		SourceIP: "198.51.100.10",
 		Varbinds: []VarbindValue{
-			{OID: snmpTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
+			{OID: model.SNMPTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
 		},
 	}
 	td := testSensitiveCommunityTrapDef(
@@ -1420,15 +1421,15 @@ func TestRenderMessageAndLabelsRedactSensitiveCommunityVarbind(t *testing.T) {
 	labels := renderLabels(entry, td)
 
 	assert.NotContains(t, msg, "private-community")
-	assert.Contains(t, msg, redactedTrapVarbind)
-	assert.Equal(t, redactedTrapVarbind, labels["community"])
+	assert.Contains(t, msg, model.RedactedVarbindValue)
+	assert.Equal(t, model.RedactedVarbindValue, labels["community"])
 }
 
 func TestRenderGoTemplateMessageAndLabelsRedactSensitiveCommunityVarbind(t *testing.T) {
 	entry := &TrapEntry{
 		SourceIP: "198.51.100.10",
 		Varbinds: []VarbindValue{
-			{OID: snmpTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
+			{OID: model.SNMPTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
 		},
 	}
 	td := testSensitiveCommunityTrapDef(
@@ -1440,8 +1441,8 @@ func TestRenderGoTemplateMessageAndLabelsRedactSensitiveCommunityVarbind(t *test
 	labels := renderLabels(entry, td)
 
 	assert.NotContains(t, msg, "private-community")
-	assert.Contains(t, msg, redactedTrapVarbind)
-	assert.Equal(t, redactedTrapVarbind, labels["community"])
+	assert.Contains(t, msg, model.RedactedVarbindValue)
+	assert.Equal(t, model.RedactedVarbindValue, labels["community"])
 }
 
 func TestLoadProfileRejectsGoTemplateIfBlock(t *testing.T) {
@@ -1600,8 +1601,8 @@ func testSensitiveCommunityTrapDef(description string, labels map[string]string)
 		Description: description,
 		Labels:      labels,
 		sharedVarbinds: map[string]*VarbindDef{
-			strings.TrimSuffix(snmpTrapCommunityOID, ".0"): {
-				OID:     strings.TrimSuffix(snmpTrapCommunityOID, ".0"),
+			strings.TrimSuffix(model.SNMPTrapCommunityOID, ".0"): {
+				OID:     strings.TrimSuffix(model.SNMPTrapCommunityOID, ".0"),
 				rawName: "snmpTrapCommunity",
 			},
 		},
@@ -1625,7 +1626,7 @@ func TestFindVarbindForProfileOIDExactMatchWins(t *testing.T) {
 		},
 	}
 
-	got, ok := findVarbindForProfileOID(entry, testIFMIBIfIndexOID)
+	got, ok := model.FindVarbindForProfileOID(entry.Varbinds, testIFMIBIfIndexOID)
 
 	require.True(t, ok)
 	assert.Equal(t, testIFMIBIfIndexOID, got.OID)
@@ -1633,9 +1634,9 @@ func TestFindVarbindForProfileOIDExactMatchWins(t *testing.T) {
 }
 
 func TestOIDMatchesColumnRequiresArcBoundary(t *testing.T) {
-	assert.True(t, oidMatchesColumn(testIFMIBIfOperStatusOID, testIFMIBIfOperStatusOID+".1"))
-	assert.False(t, oidMatchesColumn(testIFMIBIfOperStatusOID, testIFMIBIfOperStatusOID))
-	assert.False(t, oidMatchesColumn(testIFMIBIfOperStatusOID, testIFMIBIfOperStatusOID+"0.1"))
+	assert.True(t, model.OIDMatchesColumn(testIFMIBIfOperStatusOID, testIFMIBIfOperStatusOID+".1"))
+	assert.False(t, model.OIDMatchesColumn(testIFMIBIfOperStatusOID, testIFMIBIfOperStatusOID))
+	assert.False(t, model.OIDMatchesColumn(testIFMIBIfOperStatusOID, testIFMIBIfOperStatusOID+"0.1"))
 }
 
 func TestFindVarbindForProfileOIDFirstMatchingInstanceWins(t *testing.T) {
@@ -1646,7 +1647,7 @@ func TestFindVarbindForProfileOIDFirstMatchingInstanceWins(t *testing.T) {
 		},
 	}
 
-	got, ok := findVarbindForProfileOID(entry, testIFMIBIfIndexOID)
+	got, ok := model.FindVarbindForProfileOID(entry.Varbinds, testIFMIBIfIndexOID)
 
 	require.True(t, ok)
 	assert.Equal(t, testIFMIBIfIndexOID+".2", got.OID)
@@ -1661,7 +1662,7 @@ func TestFindVarbindForProfileOIDMatchesScalarZeroInstance(t *testing.T) {
 		},
 	}
 
-	got, ok := findVarbindForProfileOID(entry, sysNameOID)
+	got, ok := model.FindVarbindForProfileOID(entry.Varbinds, sysNameOID)
 
 	require.True(t, ok)
 	assert.Equal(t, sysNameOID+".0", got.OID)

--- a/src/go/plugin/go.d/collector/snmp_traps/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/profile_test.go
@@ -163,6 +163,16 @@ func TestInitBindFailureReleasesProfileRef(t *testing.T) {
 // Profile loading tests (using temp dir overrides)
 // =============================================================================
 
+func TestProfileLoadRejectsUnknownTopLevelKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	writeProfileYAML(t, dir, "bad.yaml", "unknown_profile_key: true\n")
+
+	_, err := loadProfileBundle(path, multipath.New(dir), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `profile: unknown config key "unknown_profile_key"`)
+}
+
 func TestProfileDirPathBuilders(t *testing.T) {
 	assert.Equal(t, filepath.Join("/etc/netdata/go.d", "snmp.trap-profiles"), trapProfilesUserDir("/etc/netdata/go.d"))
 	assert.Equal(t, filepath.Join("/usr/lib/netdata/conf.d/go.d", "snmp.trap-profiles", "default"), trapProfilesStockDir("/usr/lib/netdata/conf.d/go.d"))

--- a/src/go/plugin/go.d/collector/snmp_traps/reload_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/reload_test.go
@@ -383,7 +383,7 @@ traps:
 
 	writer := &mockTrapWriter{}
 	c := &Collector{
-		jobName:    "reload-packet",
+		Config:     Config{Name: "reload-packet"},
 		trapWriter: writer,
 		versions:   map[SnmpVersion]struct{}{SnmpVersionV2c: {}},
 		allowlist:  NewAllowlist(nil, []string{"public"}),

--- a/src/go/plugin/go.d/collector/snmp_traps/resolver.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/resolver.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 const maxMessageLen = 512
-
-const redactedTrapVarbind = "<redacted>"
 
 // renderMessage renders a trap description template into a human-readable MESSAGE.
 // It resolves {varname}, {varname.raw}, {numeric.oid}, and special vars against the
@@ -121,7 +121,7 @@ func resolveReference(ref string, entry *TrapEntry, td *TrapDef) string {
 	}
 
 	// numeric OID fallback
-	if isNumericOID(ref) {
+	if model.IsNumericOID(ref) {
 		return resolveVarbindByOID(ref, entry, td)
 	}
 
@@ -181,7 +181,7 @@ func resolveVarbindRaw(name string, entry *TrapEntry, td *TrapDef) string {
 			oid = vb.OID
 		}
 	}
-	if oid == "" && isNumericOID(name) {
+	if oid == "" && model.IsNumericOID(name) {
 		oid = name
 	}
 	if oid == "" {
@@ -191,9 +191,12 @@ func resolveVarbindRaw(name string, entry *TrapEntry, td *TrapDef) string {
 }
 
 func resolveVarbindValue(name, oid string, vb *VarbindDef, entry *TrapEntry) string {
-	if v, ok := findVarbindForProfileOID(entry, oid); ok {
-		if isSensitiveTrapVarbind(v) {
-			return redactedTrapVarbind
+	if entry == nil {
+		return "<missing>"
+	}
+	if v, ok := model.FindVarbindForProfileOID(entry.Varbinds, oid); ok {
+		if model.IsSensitiveVarbind(v) {
+			return model.RedactedVarbindValue
 		}
 		return varbindDisplayValue(v, vb)
 	}
@@ -201,49 +204,29 @@ func resolveVarbindValue(name, oid string, vb *VarbindDef, entry *TrapEntry) str
 }
 
 func resolveRawVarbindByName(name string, entry *TrapEntry) string {
-	for _, v := range entry.Varbinds {
-		if v.Name == name {
-			if isSensitiveTrapVarbind(v) {
-				return redactedTrapVarbind
-			}
-			return varbindRawValue(v)
+	if entry == nil {
+		return fmt.Sprintf("<unresolved:%s>", name)
+	}
+	if v, ok := model.FindVarbindByName(entry.Varbinds, name); ok {
+		if model.IsSensitiveVarbind(v) {
+			return model.RedactedVarbindValue
 		}
+		return model.VarbindRawValue(v)
 	}
 	return fmt.Sprintf("<unresolved:%s>", name)
 }
 
 func resolveRawVarbindByOID(oid string, entry *TrapEntry) string {
-	if v, ok := findVarbindForProfileOID(entry, oid); ok {
-		if isSensitiveTrapVarbind(v) {
-			return redactedTrapVarbind
+	if entry == nil {
+		return "<missing>"
+	}
+	if v, ok := model.FindVarbindForProfileOID(entry.Varbinds, oid); ok {
+		if model.IsSensitiveVarbind(v) {
+			return model.RedactedVarbindValue
 		}
-		return varbindRawValue(v)
+		return model.VarbindRawValue(v)
 	}
 	return "<missing>"
-}
-
-func oidMatchesColumn(profileOID, observedOID string) bool {
-	if profileOID == "" || observedOID == "" || profileOID == observedOID {
-		return false
-	}
-	return strings.HasPrefix(observedOID, profileOID+".")
-}
-
-func findVarbindForProfileOID(entry *TrapEntry, profileOID string) (VarbindValue, bool) {
-	if entry == nil || profileOID == "" {
-		return VarbindValue{}, false
-	}
-	for _, v := range entry.Varbinds {
-		if v.OID == profileOID {
-			return v, true
-		}
-	}
-	for _, v := range entry.Varbinds {
-		if oidMatchesColumn(profileOID, v.OID) {
-			return v, true
-		}
-	}
-	return VarbindValue{}, false
 }
 
 func findVarbindDefForObservedOID(td *TrapDef, observedOID string) *VarbindDef {
@@ -264,7 +247,7 @@ func findVarbindDefForObservedOID(td *TrapDef, observedOID string) *VarbindDef {
 		if profileOID == "" {
 			profileOID = oid
 		}
-		if oidMatchesColumn(profileOID, observedOID) && len(profileOID) > bestLen {
+		if model.OIDMatchesColumn(profileOID, observedOID) && len(profileOID) > bestLen {
 			best = vb
 			bestLen = len(profileOID)
 		}
@@ -280,32 +263,7 @@ func varbindDisplayValue(v VarbindValue, vb *VarbindDef) string {
 			return label
 		}
 	}
-	return varbindRawValue(v)
-}
-
-// varbindRawValue renders a varbind value as a plain string.
-func varbindRawValue(v VarbindValue) string {
-	switch val := v.Value.(type) {
-	case nil:
-		return ""
-	case string:
-		return val
-	case []byte:
-		return string(val)
-	case int64:
-		return fmt.Sprintf("%d", val)
-	case uint64:
-		return fmt.Sprintf("%d", val)
-	case float64:
-		return fmt.Sprintf("%v", val)
-	case bool:
-		if val {
-			return "true"
-		}
-		return "false"
-	default:
-		return fmt.Sprintf("%v", val)
-	}
+	return model.VarbindRawValue(v)
 }
 
 func truncateUTF8(s string, maxBytes int) string {

--- a/src/go/plugin/go.d/collector/snmp_traps/serialize.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/serialize.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 var severityToPriority = map[Severity]string{
@@ -224,15 +226,15 @@ func trapVarbindJournalFieldNames(vb VarbindValue, state *trapVarbindFieldState)
 }
 
 func shouldSkipTrapVarbindJournalField(vb VarbindValue) bool {
-	if isSensitiveTrapVarbind(vb) {
+	if model.IsSensitiveVarbind(vb) {
 		return true
 	}
 
-	oid := normalizeOID(vb.OID)
-	if oidMatchesScalar(oid, sysUpTimeOID) ||
-		oidMatchesScalar(oid, snmpTrapOIDOID) ||
-		oidMatchesScalar(oid, snmpTrapAddressOID) ||
-		oidMatchesScalar(oid, snmpTrapEnterpriseOID) {
+	oid := model.NormalizeOID(vb.OID)
+	if oidMatchesScalar(oid, model.SysUpTimeOID) ||
+		oidMatchesScalar(oid, model.SNMPTrapOID) ||
+		oidMatchesScalar(oid, model.SNMPTrapAddressOID) ||
+		oidMatchesScalar(oid, model.SNMPTrapEnterpriseOID) {
 		return true
 	}
 
@@ -252,7 +254,7 @@ func oidMatchesScalar(oid, scalar string) bool {
 func trapVarbindJournalFieldBase(vb VarbindValue) string {
 	source := vb.Name
 	if source == "" {
-		oid := normalizeOID(vb.OID)
+		oid := model.NormalizeOID(vb.OID)
 		if oid == "" {
 			return ""
 		}
@@ -284,7 +286,7 @@ func trapVarbindJournalValue(vb VarbindValue, raw bool) string {
 	if !raw && vb.Enum != "" {
 		return vb.Enum
 	}
-	return varbindRawValue(vb)
+	return model.VarbindRawValue(vb)
 }
 
 type trapVarbindFieldState struct {
@@ -403,7 +405,7 @@ func buildTrapJSON(entry *TrapEntry) ([]byte, error) {
 	}
 
 	for _, vb := range entry.Varbinds {
-		if isSensitiveTrapVarbind(vb) {
+		if model.IsSensitiveVarbind(vb) {
 			continue
 		}
 		key := vb.Name
@@ -477,16 +479,6 @@ func buildTrapEnrichmentJSON(entry *TrapEntry) ([]byte, error) {
 		return nil, nil
 	}
 	return json.Marshal(entry.Enrichment)
-}
-
-func isSensitiveTrapVarbind(vb VarbindValue) bool {
-	oid := normalizeOID(vb.OID)
-	if oid == snmpTrapCommunityOID || oid == strings.TrimSuffix(snmpTrapCommunityOID, ".0") {
-		return true
-	}
-
-	name := strings.TrimSuffix(vb.Name, ".0")
-	return name == "snmpTrapCommunity"
 }
 
 type jsonVarbindEntry struct {
@@ -865,7 +857,7 @@ func (s *journalHotSerializer) appendTrapJSONObject(entry *TrapEntry) error {
 	}
 
 	for _, vb := range entry.Varbinds {
-		if isSensitiveTrapVarbind(vb) {
+		if model.IsSensitiveVarbind(vb) {
 			continue
 		}
 		key := vb.Name

--- a/src/go/plugin/go.d/collector/snmp_traps/serialize_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/serialize_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
 )
 
 func TestSerializeToJournalFields(t *testing.T) {
@@ -443,7 +445,7 @@ func TestSerializeToJournalFieldsTRAPJSONOmitsCommunityVarbind(t *testing.T) {
 		PduType:               PduTypeTrap,
 		SnmpVersion:           SnmpVersionV1,
 		Varbinds: []VarbindValue{
-			{OID: snmpTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
+			{OID: model.SNMPTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
 			{OID: "1.3.6.1.2.1.2.2.1.1", Name: "ifIndex", Type: "INTEGER", Value: int64(1)},
 		},
 	}
@@ -482,11 +484,11 @@ func TestSerializeToJournalFieldsTrapVarbindJournalFields(t *testing.T) {
 		PduType:               PduTypeTrap,
 		SnmpVersion:           SnmpVersionV1,
 		Varbinds: []VarbindValue{
-			{OID: sysUpTimeOID, Name: "sysUpTime.0", Type: "TimeTicks", Value: uint64(129665677)},
-			{OID: snmpTrapOIDOID, Name: "snmpTrapOID.0", Type: "ObjectIdentifier", Value: "1.3.6.1.6.3.1.1.5.3"},
-			{OID: snmpTrapAddressOID, Name: "snmpTrapAddress.0", Type: "IPAddress", Value: "0.0.0.0"},
-			{OID: snmpTrapEnterpriseOID, Name: "snmpTrapEnterprise.0", Type: "ObjectIdentifier", Value: "1.3.6.1.6.3.1.1.5.3"},
-			{OID: snmpTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
+			{OID: model.SysUpTimeOID, Name: "sysUpTime.0", Type: "TimeTicks", Value: uint64(129665677)},
+			{OID: model.SNMPTrapOID, Name: "snmpTrapOID.0", Type: "ObjectIdentifier", Value: "1.3.6.1.6.3.1.1.5.3"},
+			{OID: model.SNMPTrapAddressOID, Name: "snmpTrapAddress.0", Type: "IPAddress", Value: "0.0.0.0"},
+			{OID: model.SNMPTrapEnterpriseOID, Name: "snmpTrapEnterprise.0", Type: "ObjectIdentifier", Value: "1.3.6.1.6.3.1.1.5.3"},
+			{OID: model.SNMPTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
 			{OID: "1.3.6.1.2.1.2.2.1.7.29", Name: "ifAdminStatus", Type: "INTEGER", Value: int64(1), Enum: "up"},
 			{OID: "1.3.6.1.2.1.2.2.1.1.29", Name: "ifIndex", Type: "InterfaceIndex", Value: int64(29)},
 			{OID: "1.3.6.1.2.1.2.2.1.8.29", Name: "ifOperStatus", Type: "INTEGER", Value: int64(2), Enum: "down"},
@@ -742,7 +744,7 @@ func TestJournalHotSerializerMatchesSerializeToJournalFields(t *testing.T) {
 			SnmpVersion:           SnmpVersionV2c,
 			Labels:                map[string]string{"z_key": "z_val", "a_key": "a_val"},
 			Varbinds: []VarbindValue{
-				{OID: snmpTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
+				{OID: model.SNMPTrapCommunityOID, Name: "snmpTrapCommunity.0", Type: "OctetString", Value: "private-community"},
 				{OID: "1.3.6.1.2.1.2.2.1.7", Name: "ifAdminStatus", Type: "INTEGER", Value: int64(1), Enum: "up"},
 				{OID: "1.3.6.1.2.1.2.2.1.1", Name: "ifIndex", Type: "INTEGER", Value: int64(1)},
 				{OID: "1.3.6.1.2.1.2.2.1.2", Name: "ifIndex", Type: "OctetString", Value: "eth0"},

--- a/src/go/plugin/go.d/collector/snmp_traps/source_identity.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/source_identity.go
@@ -130,10 +130,3 @@ func fallbackTrapSourceKind(method string) string {
 		return "other"
 	}
 }
-
-func profileMetricSourceHashSalt() string {
-	if provider, err := defaultJournalHostProvider(); err == nil {
-		return "machine-id:" + provider.MachineID().String()
-	}
-	return "netdata-agent"
-}

--- a/src/go/plugin/go.d/collector/snmp_traps/test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/test_helpers_test.go
@@ -46,7 +46,7 @@ func setSingleTestTrap(t *testing.T, trap *TrapDef) {
 
 func newTestV2Collector(jobName string, writer TrapWriter, prefixes []netip.Prefix, communities []string) *Collector {
 	return &Collector{
-		jobName:     jobName,
+		Config:      Config{Name: jobName},
 		trapWriter:  writer,
 		journalHost: newTestJournalHostProvider(),
 		versions:    map[SnmpVersion]struct{}{SnmpVersionV2c: {}},
@@ -115,7 +115,7 @@ func newDedupTestV2Collector(t *testing.T, jobName string, writer TrapWriter) (*
 	metrics := withCleanJobMetrics(t, jobName)
 	metrics.setDedupEnabled(true)
 	c := newTestV2Collector(jobName, writer, nil, []string{"public"})
-	c.Config = Config{Dedup: DedupConfig{Enabled: true}}
+	c.Dedup = DedupConfig{Enabled: true}
 	c.metrics = metrics
 	c.deduper = newTrapDeduper(jobName, c.Dedup, writer, metrics, "", c.monotonicUsec)
 	return c, metrics
@@ -164,7 +164,7 @@ func newTestV3Collector(
 	engineIDs map[string]struct{},
 ) *Collector {
 	return &Collector{
-		jobName:     jobName,
+		Config:      Config{Name: jobName},
 		trapWriter:  writer,
 		journalHost: newTestJournalHostProvider(),
 		versions:    map[SnmpVersion]struct{}{SnmpVersionV3: {}},
@@ -192,9 +192,8 @@ func newDynamicEngineIDTestCollector(
 	}
 	writer := &mockTrapWriter{}
 	c := &Collector{
-		jobName:            jobName,
+		Config:             Config{Name: jobName, USMUsers: []USMUserConfig{user}},
 		trapWriter:         writer,
-		Config:             Config{USMUsers: []USMUserConfig{user}},
 		versions:           map[SnmpVersion]struct{}{SnmpVersionV3: {}},
 		allowlist:          NewAllowlist(nil, nil),
 		v3SecTable:         secTable,

--- a/src/go/plugin/go.d/collector/snmp_traps/testdata/config.json
+++ b/src/go/plugin/go.d/collector/snmp_traps/testdata/config.json
@@ -1,0 +1,80 @@
+{
+  "name": "ok",
+  "vnode": "",
+  "reverse_dns": {
+    "enabled": false
+  },
+  "update_every": 0,
+  "listen": {
+    "endpoints": [
+      {
+        "protocol": "udp",
+        "address": "127.0.0.1",
+        "port": 9162
+      }
+    ],
+    "receive_buffer": 0
+  },
+  "versions": [
+    "v2c"
+  ],
+  "communities": null,
+  "usm_users": null,
+  "engine_id_whitelist": null,
+  "local_engine_id": "",
+  "dynamic_engine_id_discovery": false,
+  "dynamic_engine_id_max_pairs": 0,
+  "allowlist": {
+    "source_cidrs": null
+  },
+  "source": {
+    "trusted_relays": null
+  },
+  "rate_limit": {
+    "enabled": false,
+    "per_source_pps": 0,
+    "mode": ""
+  },
+  "dedup": {
+    "enabled": false,
+    "window_sec": 0,
+    "cache_max_entries": 0,
+    "key_varbinds": null
+  },
+  "journal": {
+    "enabled": null
+  },
+  "otlp": {
+    "enabled": false,
+    "endpoint": "",
+    "headers": null,
+    "request_timeout": "",
+    "flush_interval": "",
+    "batch_size": 0,
+    "queue_capacity": 0
+  },
+  "retention": {
+    "max_size": null,
+    "max_duration": null,
+    "rotation_size": null,
+    "rotation_duration": null
+  },
+  "overrides": null,
+  "profile_metrics": {
+    "enabled": false,
+    "mode": "",
+    "include": null,
+    "identity": {
+      "device": "",
+      "unresolved_source": "",
+      "source_id_privacy": ""
+    },
+    "limits": {
+      "max_rules": 0,
+      "max_sources": 0,
+      "max_resources_per_source": 0,
+      "max_instances_per_job": 0,
+      "overflow": ""
+    }
+  }
+}

--- a/src/go/plugin/go.d/collector/snmp_traps/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/snmp_traps/testdata/config.yaml
@@ -1,0 +1,8 @@
+name: ok
+listen:
+  endpoints:
+    - protocol: udp
+      address: 127.0.0.1
+      port: 9162
+versions:
+  - v2c

--- a/src/go/plugin/go.d/collector/snmp_traps/trapentry.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/trapentry.go
@@ -2,114 +2,30 @@
 
 package snmp_traps
 
-type ReportType string
+import "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/model"
+
+type ReportType = model.ReportType
+type PduType = model.PduType
+type SnmpVersion = model.SnmpVersion
+type ASN1Type = model.ASN1Type
+type Category = model.Category
+type Severity = model.Severity
+type VarbindValue = model.VarbindValue
+type DedupSummary = model.DedupSummary
+type DecodeErrorInfo = model.DecodeErrorInfo
+type TrapSourceAudit = model.TrapSourceAudit
+type TrapEnrichmentAudit = model.TrapEnrichmentAudit
+type TrapEnrichmentLookup = model.TrapEnrichmentLookup
+type TrapEntry = model.TrapEntry
+type TrapPDU = model.TrapPDU
 
 const (
-	ReportTypeTrap         ReportType = "trap"
-	ReportTypeDedupSummary ReportType = "deduplication_summary"
-	ReportTypeDecodeError  ReportType = "decode_error"
+	ReportTypeTrap         = model.ReportTypeTrap
+	ReportTypeDedupSummary = model.ReportTypeDedupSummary
+	ReportTypeDecodeError  = model.ReportTypeDecodeError
+	PduTypeTrap            = model.PduTypeTrap
+	PduTypeInform          = model.PduTypeInform
+	SnmpVersionV1          = model.SnmpVersionV1
+	SnmpVersionV2c         = model.SnmpVersionV2c
+	SnmpVersionV3          = model.SnmpVersionV3
 )
-
-type PduType string
-
-const (
-	PduTypeTrap   PduType = "trap"
-	PduTypeInform PduType = "inform"
-)
-
-type SnmpVersion string
-
-const (
-	SnmpVersionV1  SnmpVersion = "v1"
-	SnmpVersionV2c SnmpVersion = "v2c"
-	SnmpVersionV3  SnmpVersion = "v3"
-)
-
-type ASN1Type string
-
-type Category string
-
-type Severity string
-
-type VarbindValue struct {
-	Name  string   `json:"name,omitempty"`
-	OID   string   `json:"oid"`
-	Type  ASN1Type `json:"type"`
-	Value any      `json:"value"`
-	Enum  string   `json:"enum,omitempty"`
-}
-
-type DedupSummary struct {
-	TotalSuppressed int64            `json:"total_suppressed"`
-	PeriodSec       int64            `json:"period_sec"`
-	Fingerprints    int64            `json:"fingerprints"`
-	ByTrap          map[string]int64 `json:"by_trap"`
-}
-
-type DecodeErrorInfo struct {
-	Kind          string `json:"kind"`
-	Error         string `json:"error"`
-	PacketSize    int    `json:"packet_size"`
-	PacketSHA256  string `json:"packet_sha256"`
-	SourceUDPPort int    `json:"source_udp_port,omitempty"`
-	Listener      string `json:"listener,omitempty"`
-	SnmpVersion   string `json:"snmp_version,omitempty"`
-	EngineID      string `json:"engine_id,omitempty"`
-}
-
-type TrapSourceAudit struct {
-	UDPPeer            string   `json:"udp_peer,omitempty"`
-	SnmpTrapAddress    string   `json:"snmp_trap_address,omitempty"`
-	Selected           string   `json:"selected,omitempty"`
-	Method             string   `json:"method,omitempty"`
-	TrustedRelay       bool     `json:"trusted_relay,omitempty"`
-	RejectedCandidates []string `json:"rejected_candidates,omitempty"`
-}
-
-type TrapEnrichmentAudit struct {
-	Source     *TrapSourceAudit      `json:"source,omitempty"`
-	Registry   *TrapEnrichmentLookup `json:"registry,omitempty"`
-	Topology   *TrapEnrichmentLookup `json:"topology,omitempty"`
-	Interface  *TrapEnrichmentLookup `json:"interface,omitempty"`
-	Neighbors  *TrapEnrichmentLookup `json:"neighbors,omitempty"`
-	ReverseDNS *TrapEnrichmentLookup `json:"reverse_dns,omitempty"`
-	Applied    map[string]string     `json:"applied,omitempty"`
-}
-
-type TrapEnrichmentLookup struct {
-	Key     string   `json:"key,omitempty"`
-	Value   string   `json:"value,omitempty"`
-	Status  string   `json:"status,omitempty"`
-	Method  string   `json:"method,omitempty"`
-	Matches int      `json:"matches,omitempty"`
-	Reason  string   `json:"reason,omitempty"`
-	Fields  []string `json:"fields,omitempty"`
-}
-
-type TrapEntry struct {
-	JobName               string
-	ReportType            ReportType
-	ReceivedRealtimeUsec  int64
-	ReceivedMonotonicUsec int64
-	TrapOID               string
-	TrapName              string
-	Category              Category
-	Severity              Severity
-	Message               string
-	SourceIP              string
-	SourceUDPPeer         string
-	ReverseDNS            string
-	DeviceHostname        string
-	DeviceVendor          string
-	PduType               PduType
-	SnmpVersion           SnmpVersion
-	SourceVnodeID         string
-	TopologyInterface     string
-	TopologyNeighbors     string
-	PacketSequence        uint64
-	Labels                map[string]string
-	Varbinds              []VarbindValue
-	Enrichment            *TrapEnrichmentAudit
-	SummaryCounts         *DedupSummary
-	DecodeError           *DecodeErrorInfo
-}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `snmp_traps` to establish clear job ownership and identity. Job names now flow from config through the collector, metrics, engine state, and outputs, with centralized OID/varbind helpers and consistent sensitive-data handling.

- **Refactors**
  - Added `Config.Name` and propagated it to `Collector.Name`; removed SetJobName and the job-naming interface in job manager. Factory now decodes the job name from config and ignores unknown fields.
  - Introduced `snmp_traps/internal/model` for OID constants, types, and helpers (e.g., `NormalizeOID`, `AlternateTrapOID`, `FindVarbindByName`, `FindVarbindForProfileOID`, `IsSensitiveVarbind`); updated dedup, resolver, OTLP, serialization, templates, and tests to use it.
  - Added `snmp_traps/internal/hostidentity` service to lazily load machine/boot IDs and provide monotonic time; metrics source-hash salt is injected via this service, replacing the previous global provider.
  - Scoped engine state storage per job with `engineStatePaths` (replacing the previous global dir usage).
  - Consolidated configuration validation into `Config.Validate` and removed duplicate YAML-key checks; kept job decoding tolerant of unknown fields. Added JSON/YAML fixtures and serialization tests.
  - Cleanups: removed redundant monotonic stubs and legacy journal host helpers, and aligned tests/benchmarks with the new ownership and model APIs.

<sup>Written for commit 502ba97f2c7c10d2f2ad4e899ecae96531b911c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

