### PR TITLE
fix(go.d/jobmgr): settle pre-activation retirement races

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -320,9 +320,10 @@ loud and success is quiet: entering `Contained`, releasing a contained worker, q
 panic each emit a diagnostic event, while an attempt that admits or returns in time emits none. In long-lived mode,
 `jobmgr.runtime` also projects the current census as aggregate process-attempt gauges.
 
-Containment fences execute synchronously before settlement becomes visible. They stay under the authority lock to
-preserve that ordering, but cross a panic boundary: a panic is redacted as `ErrProcessAttemptFencePanic`, joined with
-the original cut cause, and cannot strand the authority mutex.
+Containment fences receive the raw cut cause and execute synchronously before settlement becomes visible. They stay under
+the authority lock to preserve that ordering, so they perform only bounded in-memory state changes: they never re-enter
+the authority or wait for a worker, I/O, or external cleanup. A panic is redacted as `ErrProcessAttemptFencePanic`, joined
+with the original cut cause, and cannot strand the authority mutex.
 
 Terminal outcomes quarantine an identity when an admitted worker fails, ownership remains retained, the worker
 panics, or the containment fence panics. Ordinary pre-admission validation failures release the identity normally.
@@ -565,6 +566,10 @@ flowchart TD
    `Stop`, Function drain, and collector cleanup remain process-owned until they return.
 5. **Promote, attach, and start** — the candidate acquires the separate `job-runtime` identity only after logical
    retirement. Candidate `Init`/`Check` may overlap the incumbent, but two installed runtimes for one job cannot.
+   - Promotion publishes its owner transition before entering the attempt authority, then releases the owner lock for
+     runtime-identity start, supersession, and admission. This removes the reverse edge against the authority's synchronous
+     containment callback. Successful admission transfers process ownership even when containment wins before promotion
+     settlement; pre-admission failure remains candidate-owned.
    - Attachment reports whether ownership transferred. The process owner adopts every transferred wrapper and partial or
      completed Function lifecycle even when retirement already won, so rejection finalizes them exactly once. A
      no-transfer failure is never inferred from cleanup fields and never triggers adoption.
@@ -573,7 +578,12 @@ flowchart TD
    - Retirement before an otherwise-valid attachment bind returns the exact process-attempt cause even when that
      retirement already finalized the candidate. Independent duplicate, decided, or invalid transitions remain
      fail-closed.
-   - Once output and permit acceptance wins, the managed loop starts.
+   - Runtime-attempt containment synchronously records the first retirement cause and revokes new output admission before
+     the authority cut returns. The worker later drains output leases and performs detach/cleanup outside the authority
+     lock. A later stopped/retired cut never overwrites an earlier structural failure.
+   - Start eligibility and retirement arbitrate under the process owner. The worker rechecks that decision after receiving
+     the start request, so a ready channel send cannot launch `StartManaged` after containment has won.
+   - Once output and permit acceptance wins and start remains eligible, the managed loop starts.
    - The resource transaction owns this successor until installation acknowledgement. An apply failure aborts it when
      possible, or returns the still-live retained generation to the kernel for fail-closed ownership.
    - If the old runtime does not release within the supersession grace, the candidate is rejected and the
@@ -589,10 +599,11 @@ flowchart TD
 
    Only a pure target-retired/process-stopped error tree counts as normal cancellation. Any mixed, cleanup, graph,
    panic, or ownership error stays fail-closed.
-6. **Emit** — installation activates the generation output gate. Two capabilities exist, and both serialize whole
+6. **Emit** — resource acceptance activates the generation output gate. Two capabilities exist, and both serialize whole
    frames through the process's one `FrameOwner` (`joboutput/output_gate.go`):
-   - **Ordinary collection output** is run-owned. Retirement permanently fences it before detaching projections, so a
-     retained old runtime cannot interleave late collection frames with its successor.
+   - **Ordinary collection output** is run-owned. Retirement first atomically revokes new write admission, then drains
+     write leases outside the attempt-authority lock before detaching projections. A write admitted before the cut may
+     finish; a write presented after the revocation cannot interleave with the successor.
    - **Accepted V1/V2 cleanup output** is process-owned, because physical cleanup may outlive a rotation. It emits
      terminal chart-obsoletion frames only after the managed loop and Function handlers physically quiesce.
    - The `job-runtime` identity stays occupied through cleanup, so a same-job successor cannot start before those

--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -565,8 +565,15 @@ flowchart TD
    `Stop`, Function drain, and collector cleanup remain process-owned until they return.
 5. **Promote, attach, and start** — the candidate acquires the separate `job-runtime` identity only after logical
    retirement. Candidate `Init`/`Check` may overlap the incumbent, but two installed runtimes for one job cannot.
-   - After promotion the staged runtime/vnode/Function projections attach, the permit and output gate activate, and
-     the managed loop starts.
+   - Attachment reports whether ownership transferred. The process owner adopts every transferred wrapper and partial or
+     completed Function lifecycle even when retirement already won, so rejection finalizes them exactly once. A
+     no-transfer failure is never inferred from cleanup fields and never triggers adoption.
+   - Runtime/vnode projections attach outside the staged-owner lock because they call external registries. The owner then
+     linearizes retirement against output-gate activation, permit activation, and accepted-cleanup freezing in that order.
+   - Retirement before an otherwise-valid attachment bind returns the exact process-attempt cause even when that
+     retirement already finalized the candidate. Independent duplicate, decided, or invalid transitions remain
+     fail-closed.
+   - Once output and permit acceptance wins, the managed loop starts.
    - The resource transaction owns this successor until installation acknowledgement. An apply failure aborts it when
      possible, or returns the still-live retained generation to the kernel for fail-closed ownership.
    - If the old runtime does not release within the supersession grace, the candidate is rejected and the

--- a/src/go/plugin/agent/jobmgr/containment/authority.go
+++ b/src/go/plugin/agent/jobmgr/containment/authority.go
@@ -88,7 +88,7 @@ type attempt struct {
 	state    attemptState
 	admitted bool
 	result   error
-	fence    func()
+	fence    func(error)
 	fenceErr error
 	settled  chan struct{}
 	released chan struct{}
@@ -192,7 +192,7 @@ func callWork(
 	return work(ctx, admission)
 }
 
-func callContainmentFence(fence func()) (err error) {
+func callContainmentFence(fence func(error), cause error) (err error) {
 	if fence == nil {
 		return nil
 	}
@@ -201,7 +201,7 @@ func callContainmentFence(fence func()) (err error) {
 			err = jobmgr.ErrProcessAttemptFencePanic
 		}
 	}()
-	fence()
+	fence(cause)
 	return nil
 }
 
@@ -269,7 +269,7 @@ func (a *Authority) cut(attempt *attempt, cause error, probingOnly bool) bool {
 	a.census.Contained++
 	attempt.timer.Stop()
 	attempt.cancel(cause)
-	fenceErr := callContainmentFence(attempt.fence)
+	fenceErr := callContainmentFence(attempt.fence, cause)
 	if fenceErr != nil {
 		attempt.fenceErr = fenceErr
 		attempt.result = errors.Join(cause, fenceErr)

--- a/src/go/plugin/agent/jobmgr/containment/authority_test.go
+++ b/src/go/plugin/agent/jobmgr/containment/authority_test.go
@@ -110,7 +110,7 @@ func TestAuthorityFuseWinsLateCompletionAndRedactsDiagnostics(t *testing.T) {
 	attempt, err := authority.start(context.Background(), jobmgr.ProcessAttemptPlan{
 		Identity: identity,
 		Target:   11,
-		OnContainment: func() {
+		OnContainment: func(error) {
 			fenced = true
 		},
 		Work: func(context.Context, jobmgr.ProcessAttemptAdmission) error {
@@ -294,7 +294,7 @@ func TestAuthorityContainsContainmentFencePanics(t *testing.T) {
 	defer releaseWork()
 	attempt, err := authority.start(context.Background(), jobmgr.ProcessAttemptPlan{
 		Identity: testIdentity(jobmgr.ProcessAttemptFunctionPoll, "module/job", "module/job"),
-		OnContainment: func() {
+		OnContainment: func(error) {
 			panic("provider-sensitive-fence-panic")
 		},
 		Work: func(context.Context, jobmgr.ProcessAttemptAdmission) error {
@@ -321,6 +321,34 @@ func TestAuthorityContainsContainmentFencePanics(t *testing.T) {
 	require.Equal(t, Census{Quarantined: 1}, authority.Census())
 	require.Contains(t, diagnostics.String(), jobmgr.ErrProcessAttemptFencePanic.Error())
 	require.NotContains(t, diagnostics.String(), "provider-sensitive-fence-panic")
+}
+
+func TestAuthorityContainmentFenceReceivesRawCause(t *testing.T) {
+	authority := newTestAuthority(t, time.Second, 10*time.Millisecond, nil)
+	release := make(chan struct{})
+	fenced := make(chan error, 1)
+	attempt, err := authority.start(context.Background(), jobmgr.ProcessAttemptPlan{
+		Identity: testIdentity(jobmgr.ProcessAttemptJobRuntime, "module/job", "module/job"),
+		Target:   23,
+		OnContainment: func(cause error) {
+			fenced <- cause
+		},
+		Work: func(context.Context, jobmgr.ProcessAttemptAdmission) error {
+			<-release
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	independent := errors.New("independent failure")
+	cause := errors.Join(jobmgr.ErrProcessAttemptRetired, independent)
+	require.True(t, attempt.Cut(cause))
+	require.Equal(t, cause, <-fenced)
+	require.ErrorIs(t, attempt.Await(context.Background()), jobmgr.ErrProcessAttemptRetired)
+	require.ErrorIs(t, attempt.Await(context.Background()), independent)
+
+	close(release)
+	<-attempt.Released()
 }
 
 func TestAuthorityOrdinaryPreAdmissionErrorDoesNotQuarantine(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/functions/bundle.go
+++ b/src/go/plugin/agent/jobmgr/functions/bundle.go
@@ -194,10 +194,7 @@ func (fb *functionBundle) invoke(
 		},
 		Target:        target,
 		OnContainment: callback.quarantineIfActive,
-		Work: func(
-			attemptCtx context.Context,
-			_ jobmgr.ProcessAttemptAdmission,
-		) error {
+		Work: func(attemptCtx context.Context, _ jobmgr.ProcessAttemptAdmission) error {
 			defer callback.complete()
 			callCtx, cancel := context.WithCancelCause(attemptCtx)
 			stop := context.AfterFunc(ctx, func() {
@@ -231,7 +228,7 @@ func (fb *functionBundle) invoke(
 	return response.result, response.err
 }
 
-func (fc *functionCallback) quarantineIfActive() {
+func (fc *functionCallback) quarantineIfActive(error) {
 	if fc == nil || fc.bundle == nil {
 		return
 	}

--- a/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
@@ -410,23 +410,9 @@ func (sjo *stagedJobOwner) Start(ctx context.Context) error {
 	if sjo == nil || ctx == nil {
 		return errors.New("job output: invalid process-owned job start")
 	}
-	sjo.mu.Lock()
-	if sjo.retiring {
-		err := sjo.retirementErrorLocked("job output: process-owned job is retiring")
-		sjo.mu.Unlock()
+	if err := sjo.reserveStart(); err != nil {
 		return err
 	}
-	if sjo.ownership != stagedJobOwnedByRuntime ||
-		!sjo.attached ||
-		sjo.startRequested ||
-		sjo.started ||
-		sjo.decided ||
-		sjo.finalized {
-		sjo.mu.Unlock()
-		return errors.New("job output: invalid process-owned job start")
-	}
-	sjo.startRequested = true
-	sjo.mu.Unlock()
 	result := make(chan error, 1)
 	request := stagedJobStartRequest{
 		ctx:    ctx,
@@ -453,6 +439,24 @@ func (sjo *stagedJobOwner) Start(ctx context.Context) error {
 		sjo.requestRetirement(cause)
 		return cause
 	}
+}
+
+func (sjo *stagedJobOwner) reserveStart() error {
+	sjo.mu.Lock()
+	defer sjo.mu.Unlock()
+	if sjo.retiring {
+		return sjo.retirementErrorLocked("job output: process-owned job is retiring")
+	}
+	if sjo.ownership != stagedJobOwnedByRuntime ||
+		!sjo.attached ||
+		sjo.startRequested ||
+		sjo.started ||
+		sjo.decided ||
+		sjo.finalized {
+		return errors.New("job output: invalid process-owned job start")
+	}
+	sjo.startRequested = true
+	return nil
 }
 
 func (sjo *stagedJobOwner) Retire() {
@@ -541,23 +545,15 @@ func (sjo *stagedJobOwner) finish(ctx context.Context) (resultErr error) {
 		return sjo.finalize()
 	}
 
-	sjo.mu.Lock()
-	if sjo.started || !sjo.startRequested {
-		sjo.mu.Unlock()
-		request.result <- errors.New("job output: duplicate process-owned job start")
-		return sjo.finalize()
-	}
-	if sjo.retiring {
-		err := sjo.retirementErrorLocked("job output: process-owned job retired before start")
-		sjo.mu.Unlock()
+	resources, retiring, err := sjo.beginManagedStart()
+	if err != nil {
 		request.result <- err
-		sjo.cutBeforeStart(nil)
+		if retiring {
+			sjo.cutBeforeStart(nil)
+		}
 		return sjo.finalize()
 	}
-	sjo.started = true
-	resources := sjo.resources
 	job := resources.candidateJob
-	sjo.mu.Unlock()
 	if job == nil {
 		request.result <- errors.New("job output: missing process-owned runtime job")
 		sjo.requestRetirement(nil)
@@ -617,6 +613,19 @@ func (sjo *stagedJobOwner) finish(ctx context.Context) (resultErr error) {
 		resultErr = errors.Join(resultErr, <-exited)
 	}
 	return errors.Join(resultErr, sjo.finalize())
+}
+
+func (sjo *stagedJobOwner) beginManagedStart() (ConstructedJob, bool, error) {
+	sjo.mu.Lock()
+	defer sjo.mu.Unlock()
+	if sjo.started || !sjo.startRequested {
+		return ConstructedJob{}, false, errors.New("job output: duplicate process-owned job start")
+	}
+	if sjo.retiring {
+		return ConstructedJob{}, true, sjo.retirementErrorLocked("job output: process-owned job retired before start")
+	}
+	sjo.started = true
+	return sjo.resources, false, nil
 }
 
 func (sjo *stagedJobOwner) finishCandidate(ctx context.Context) error {

--- a/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
@@ -60,6 +60,7 @@ type stagedJobOwner struct {
 	installing      bool
 	decided         bool
 	attached        bool
+	startRequested  bool
 	started         bool
 	retiring        bool
 	retirementCause error
@@ -283,11 +284,18 @@ func (sjo *stagedJobOwner) Promote(ctx context.Context) error {
 		return cause
 	}
 	sjo.ownership = stagedJobPromotionActive
+	attempts := sjo.attempts
+	candidateCtx := sjo.candidateCtx
+	runtimeIdentity := sjo.runtimeIdentity
+	target := sjo.target
+	sjo.mu.Unlock()
+
 	start := func() (jobmgr.ProcessAttempt, <-chan error, error) {
 		admitted := make(chan error, 1)
-		attempt, err := sjo.attempts.StartProcessAttempt(ctx, jobmgr.ProcessAttemptPlan{
-			Identity: sjo.runtimeIdentity,
-			Target:   sjo.target,
+		attempt, err := attempts.StartProcessAttempt(ctx, jobmgr.ProcessAttemptPlan{
+			Identity:      runtimeIdentity,
+			Target:        target,
+			OnContainment: sjo.containRuntimeAttempt,
 			Work: func(ctx context.Context, admission jobmgr.ProcessAttemptAdmission) error {
 				admitErr := admission.Admit()
 				admitted <- admitErr
@@ -307,47 +315,65 @@ func (sjo *stagedJobOwner) Promote(ctx context.Context) error {
 		// Resource apply deliberately excludes task cancellation so it cannot
 		// abandon an atomic graph transition. Until a successor exists, the
 		// candidate attempt is the process-owned stop signal for supersession.
-		err = sjo.attempts.SupersedeProcessAttempt(sjo.candidateCtx, sjo.runtimeIdentity)
+		err = attempts.SupersedeProcessAttempt(candidateCtx, runtimeIdentity)
 		if err == nil {
 			_, admitted, err = start()
 		}
 	}
 	if err != nil {
-		resources, ownership, rejected, err := sjo.failPromotionLocked(err)
-		sjo.mu.Unlock()
-		if rejected {
-			sjo.finishRejection(resources, ownership)
-		}
-		return err
+		return sjo.failPromotion(err)
 	}
 	if err := <-admitted; err != nil {
-		resources, ownership, rejected, err := sjo.failPromotionLocked(err)
-		sjo.mu.Unlock()
-		if rejected {
-			sjo.finishRejection(resources, ownership)
-		}
-		return err
+		return sjo.failPromotion(err)
+	}
+
+	sjo.mu.Lock()
+	var structuralErr error
+	if sjo.ownership != stagedJobPromotionActive {
+		structuralErr = errors.New("job output: invalid staged job promotion settlement")
 	}
 	sjo.ownership = stagedJobOwnedByRuntime
 	sjo.candidateCtx = nil
 	sjo.transferOnce.Do(func() {
 		close(sjo.transferred)
 	})
+	var retirementErr error
+	if sjo.retiring {
+		retirementErr = sjo.retirementErrorLocked("job output: staged job retired during promotion")
+	}
 	sjo.mu.Unlock()
-	return nil
+	return errors.Join(structuralErr, retirementErr)
 }
 
-func (sjo *stagedJobOwner) failPromotionLocked(
-	promotionErr error,
-) (ConstructedJob, stagedJobOwnership, bool, error) {
+func (sjo *stagedJobOwner) failPromotion(promotionErr error) error {
+	sjo.mu.Lock()
+	if sjo.ownership != stagedJobPromotionActive {
+		sjo.mu.Unlock()
+		return errors.Join(
+			promotionErr,
+			errors.New("job output: invalid failed staged job promotion settlement"),
+		)
+	}
 	sjo.ownership = stagedJobOwnedByCandidate
-	// The candidate cut may have waited behind the promotion lock. Its context
-	// records the winning cause independently of that lock.
+	if sjo.retiring {
+		cause := sjo.retirementErrorLocked("job output: staged job retired during promotion")
+		resources, ownership, rejected := sjo.rejectLocked(cause, true)
+		sjo.mu.Unlock()
+		if rejected {
+			sjo.finishRejection(resources, ownership)
+		}
+		return errors.Join(promotionErr, cause)
+	}
 	if cause := context.Cause(sjo.candidateCtx); cause != nil {
 		resources, ownership, rejected := sjo.rejectLocked(cause, true)
-		return resources, ownership, rejected, cause
+		sjo.mu.Unlock()
+		if rejected {
+			sjo.finishRejection(resources, ownership)
+		}
+		return cause
 	}
-	return ConstructedJob{}, 0, false, promotionErr
+	sjo.mu.Unlock()
+	return promotionErr
 }
 
 func (sjo *stagedJobOwner) ReserveInstallation() error {
@@ -384,6 +410,23 @@ func (sjo *stagedJobOwner) Start(ctx context.Context) error {
 	if sjo == nil || ctx == nil {
 		return errors.New("job output: invalid process-owned job start")
 	}
+	sjo.mu.Lock()
+	if sjo.retiring {
+		err := sjo.retirementErrorLocked("job output: process-owned job is retiring")
+		sjo.mu.Unlock()
+		return err
+	}
+	if sjo.ownership != stagedJobOwnedByRuntime ||
+		!sjo.attached ||
+		sjo.startRequested ||
+		sjo.started ||
+		sjo.decided ||
+		sjo.finalized {
+		sjo.mu.Unlock()
+		return errors.New("job output: invalid process-owned job start")
+	}
+	sjo.startRequested = true
+	sjo.mu.Unlock()
 	result := make(chan error, 1)
 	request := stagedJobStartRequest{
 		ctx:    ctx,
@@ -435,17 +478,32 @@ func (sjo *stagedJobOwner) Detached() {
 }
 
 func (sjo *stagedJobOwner) requestRetirement(cause error) {
+	resources := sjo.beginRetirement(cause)
+	resources.outputGate.Fence()
+}
+
+// containRuntimeAttempt publishes the authoritative cut without waiting for
+// output leases or external cleanup while the attempt authority is locked.
+func (sjo *stagedJobOwner) containRuntimeAttempt(cause error) {
+	sjo.beginRetirement(cause)
+}
+
+func (sjo *stagedJobOwner) beginRetirement(cause error) ConstructedJob {
+	if sjo == nil {
+		return ConstructedJob{}
+	}
 	sjo.mu.Lock()
 	if !sjo.retiring {
 		sjo.retirementCause = cause
 	}
 	sjo.retiring = true
 	resources := sjo.resources
-	sjo.mu.Unlock()
-	resources.outputGate.Fence()
+	resources.outputGate.RevokeAdmissions()
 	sjo.retireOnce.Do(func() {
 		close(sjo.retire)
 	})
+	sjo.mu.Unlock()
+	return resources
 }
 
 func (sjo *stagedJobOwner) retirementError(fallback string) error {
@@ -476,6 +534,7 @@ func (sjo *stagedJobOwner) finish(ctx context.Context) (resultErr error) {
 	select {
 	case request = <-sjo.startRequests:
 	case <-sjo.retire:
+		sjo.cutBeforeStart(nil)
 		return sjo.finalize()
 	case <-ctx.Done():
 		sjo.cutBeforeStart(context.Cause(ctx))
@@ -483,9 +542,16 @@ func (sjo *stagedJobOwner) finish(ctx context.Context) (resultErr error) {
 	}
 
 	sjo.mu.Lock()
-	if sjo.started {
+	if sjo.started || !sjo.startRequested {
 		sjo.mu.Unlock()
 		request.result <- errors.New("job output: duplicate process-owned job start")
+		return sjo.finalize()
+	}
+	if sjo.retiring {
+		err := sjo.retirementErrorLocked("job output: process-owned job retired before start")
+		sjo.mu.Unlock()
+		request.result <- err
+		sjo.cutBeforeStart(nil)
 		return sjo.finalize()
 	}
 	sjo.started = true
@@ -542,6 +608,7 @@ func (sjo *stagedJobOwner) finish(ctx context.Context) (resultErr error) {
 		}
 	}
 	if !physicalExited {
+		sjo.drainRetirement()
 		stopErr := callJobLifecycle("process-owned managed runtime Stop", func() error {
 			job.Stop()
 			return nil
@@ -583,6 +650,16 @@ func (sjo *stagedJobOwner) cutBeforeStart(cause error) {
 	if !attached {
 		sjo.Detached()
 	}
+}
+
+func (sjo *stagedJobOwner) drainRetirement() {
+	if sjo == nil {
+		return
+	}
+	sjo.mu.Lock()
+	resources := sjo.resources
+	sjo.mu.Unlock()
+	resources.outputGate.Fence()
 }
 
 func (sjo *stagedJobOwner) finalize() error {

--- a/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
@@ -118,9 +118,12 @@ func newStagedJobOwner(
 	}
 }
 
-func (sjo *stagedJobOwner) Replace(resources ConstructedJob) error {
+// AdoptAttachment transfers the process-managed wrapper and any completed or
+// partial handler attachment to the process owner. Adoption remains valid while
+// retiring so rejection can finalize every transferred capability.
+func (sjo *stagedJobOwner) AdoptAttachment(resources ConstructedJob) error {
 	if sjo == nil {
-		return errors.New("job output: nil staged job resource replacement")
+		return errors.New("job output: nil staged job attachment adoption")
 	}
 	sjo.mu.Lock()
 	defer sjo.mu.Unlock()
@@ -128,14 +131,14 @@ func (sjo *stagedJobOwner) Replace(resources ConstructedJob) error {
 		!sjo.attached ||
 		sjo.decided ||
 		sjo.finalized {
-		return errors.New("job output: invalid staged job resource replacement")
+		return errors.New("job output: invalid staged job attachment adoption")
 	}
 	sjo.resources = resources
 	return nil
 }
 
-// AcceptResources linearizes permit activation with freezing the accepted
-// cleanup contract, then returns the same resource value to the generation.
+// AcceptResources linearizes retirement against output and permit activation,
+// then freezes the accepted cleanup contract.
 func (sjo *stagedJobOwner) AcceptResources(permit lifecycle.LongLivedPermit) (ConstructedJob, error) {
 	if sjo == nil {
 		return ConstructedJob{}, errors.New("job output: nil staged job acceptance")
@@ -151,10 +154,13 @@ func (sjo *stagedJobOwner) AcceptResources(permit lifecycle.LongLivedPermit) (Co
 	if sjo.retiring {
 		return ConstructedJob{}, sjo.retirementErrorLocked("job output: invalid staged job acceptance")
 	}
+	resources := sjo.resources
+	if err := resources.outputGate.Activate(); err != nil {
+		return ConstructedJob{}, err
+	}
 	if err := permit.ActivateExternal(); err != nil {
 		return ConstructedJob{}, err
 	}
-	resources := sjo.resources
 	if resources.finalCleanup != nil {
 		resources.CollectorCleanup = resources.finalCleanup
 		resources.finalCleanup = nil
@@ -169,14 +175,14 @@ func (sjo *stagedJobOwner) BindAttachment() error {
 	}
 	sjo.mu.Lock()
 	defer sjo.mu.Unlock()
-	if sjo.ownership != stagedJobOwnedByRuntime ||
-		sjo.attached ||
-		sjo.decided ||
-		sjo.finalized {
+	if sjo.ownership != stagedJobOwnedByRuntime || sjo.attached || sjo.decided {
 		return errors.New("job output: invalid staged job attachment binding")
 	}
 	if sjo.retiring {
 		return sjo.retirementErrorLocked("job output: invalid staged job attachment binding")
+	}
+	if sjo.finalized {
+		return errors.New("job output: invalid staged job attachment binding")
 	}
 	sjo.attached = true
 	return nil

--- a/src/go/plugin/agent/jobmgr/joboutput/factory.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/factory.go
@@ -109,12 +109,12 @@ func (fa factoryAttachment) attach(
 	candidate ConstructedJob,
 	identity lifecycle.ResourceIdentity,
 	owner *stagedJobOwner,
-) (ConstructedJob, error) {
+) (constructedJobAttachment, error) {
 	if !identity.Valid() ||
 		candidate.candidateJob == nil ||
 		owner == nil ||
 		fa.scheduler == nil {
-		return candidate, errors.New("job output: invalid candidate attachment")
+		return constructedJobAttachment{}, errors.New("job output: invalid candidate attachment")
 	}
 	attached, err := newProcessManagedJob(
 		candidate.Variant,
@@ -125,7 +125,7 @@ func (fa factoryAttachment) attach(
 		owner,
 	)
 	if err != nil {
-		return candidate, err
+		return constructedJobAttachment{}, err
 	}
 	attached.Observer = fa.observer
 	attached.resolvedReferences = candidate.resolvedReferences
@@ -134,10 +134,8 @@ func (fa factoryAttachment) attach(
 	attached.vnodeStage = candidate.vnodeStage
 	attached.outputGate = candidate.outputGate
 	attached.StagedHandlers = candidate.StagedHandlers
-	if candidate.runtimeStage != nil ||
-		candidate.vnodeStage != nil ||
-		candidate.outputGate != nil {
-		attached.activateAttachment = func() error {
+	if candidate.runtimeStage != nil || candidate.vnodeStage != nil {
+		attached.attachProjections = func() error {
 			var runtimeErr error
 			if candidate.runtimeStage != nil {
 				runtimeErr = candidate.runtimeStage.attach(fa.runtime)
@@ -150,11 +148,12 @@ func (fa factoryAttachment) attach(
 					return err
 				}
 			}
-			if candidate.outputGate != nil {
-				return candidate.outputGate.Activate()
-			}
 			return nil
 		}
+	}
+	result := constructedJobAttachment{
+		resources:   attached,
+		transferred: true,
 	}
 	if candidate.StagedHandlers != nil {
 		handlers, attachErr := callAttachHandlers(
@@ -167,13 +166,16 @@ func (fa factoryAttachment) attach(
 			attached.StagedHandlers = nil
 		}
 		if attachErr != nil {
-			return attached, attachErr
+			result.resources = attached
+			return result, attachErr
 		}
 		if handlers == nil {
-			return attached, errors.New("job output: nil attached handler lifecycle")
+			result.resources = attached
+			return result, errors.New("job output: nil attached handler lifecycle")
 		}
 	}
-	return attached, nil
+	result.resources = attached
+	return result, nil
 }
 
 func NewFactory(config FactoryConfig) (*Factory, error) {

--- a/src/go/plugin/agent/jobmgr/joboutput/generation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation.go
@@ -105,14 +105,21 @@ type ConstructedJob struct {
 	retryAutoDetection func() bool                 // whether a failed auto-detection should be rescheduled
 	resolvedReferences bool                        // lifecycle failures may contain resolved secret values
 	stageFunctions     bool                        // job Function lifecycle still needs post-probe staging
-	activateAttachment func() error                // binds staged capabilities immediately before acceptance
-	attach             func(lifecycle.ResourceIdentity, *stagedJobOwner) (ConstructedJob, error)
+	attachProjections  func() error                // binds external runtime/vnode projections before acceptance
+	attach             func(lifecycle.ResourceIdentity, *stagedJobOwner) (constructedJobAttachment, error)
 	candidateJob       RuntimeJob
 	runtimeStage       *stagedRuntimeService
 	vnodeStage         *stagedVNodeLookup
 	outputGate         *generationOutputGate
 	storeSnapshot      secretresolver.AtomicScopeSnapshot
 	processOwner       *stagedJobOwner
+}
+
+// constructedJobAttachment reports whether process ownership transferred even
+// when later handler attachment returned an error.
+type constructedJobAttachment struct {
+	resources   ConstructedJob
+	transferred bool
 }
 
 type PreparedJob struct {
@@ -157,7 +164,7 @@ func prepareCandidateJob(
 	candidate.attach = func(
 		identity lifecycle.ResourceIdentity,
 		owner *stagedJobOwner,
-	) (ConstructedJob, error) {
+	) (constructedJobAttachment, error) {
 		return attachment.attach(staged, identity, owner)
 	}
 	return PreparedJob{
@@ -224,27 +231,28 @@ func (pj PreparedJob) Accept(ctx context.Context, generation uint64) (*JobGenera
 		state.owner.Reject()
 		return nil, errors.Join(err, state.permit.AbortUnused())
 	}
-	attached, attachErr := state.constructed.attach(
+	attachment, attachErr := state.constructed.attach(
 		lifecycle.ResourceIdentity{
 			ID:         state.id,
 			Generation: state.generation,
 		},
 		state.owner,
 	)
-	if attachErr != nil {
-		if attached.CollectorCleanup != nil {
-			attachErr = errors.Join(attachErr, state.owner.Replace(attached))
+	if attachment.transferred {
+		state.constructed = attachment.resources
+		if err := state.owner.AdoptAttachment(attachment.resources); err != nil {
+			state.owner.Reject()
+			return nil, errors.Join(attachErr, err, state.permit.AbortUnused())
 		}
+	} else if attachErr == nil {
+		attachErr = errors.New("job output: attachment completed without ownership transfer")
+	}
+	if attachErr != nil {
 		state.owner.Reject()
 		return nil, errors.Join(attachErr, state.permit.AbortUnused())
 	}
-	state.constructed = attached
-	if err := state.owner.Replace(attached); err != nil {
-		state.owner.Reject()
-		return nil, errors.Join(err, state.permit.AbortUnused())
-	}
-	if state.constructed.activateAttachment != nil {
-		if err := callJobLifecycle("attachment activation", state.constructed.activateAttachment); err != nil {
+	if state.constructed.attachProjections != nil {
+		if err := callJobLifecycle("projection attachment", state.constructed.attachProjections); err != nil {
 			state.owner.Reject()
 			return nil, errors.Join(err, state.permit.AbortUnused())
 		}

--- a/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -234,6 +235,120 @@ func TestStagedJobAcceptanceRejectsInvalidOutputGate(t *testing.T) {
 	}
 }
 
+func TestRuntimeContainmentRevokesOutputWithoutWaitingForDrain(t *testing.T) {
+	attempts, err := containment.NewAuthority(nil)
+	require.NoError(t, err)
+	writeEntered := make(chan struct{})
+	releaseWrite := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseWrite) })
+	}
+	defer release()
+	frames, err := lifecycle.NewFrameOwner(frameWriteFunc(func(payload []byte) (int, error) {
+		close(writeEntered)
+		<-releaseWrite
+		return len(payload), nil
+	}))
+	require.NoError(t, err)
+	gate, err := newGenerationOutputGate(frames)
+	require.NoError(t, err)
+	var rejected, final int
+	candidate := ConstructedJob{
+		Variant:          JobVariantV1,
+		CollectorCleanup: func(context.Context) error { rejected++; return nil },
+		finalCleanup:     func(context.Context) error { final++; return nil },
+		outputGate:       gate,
+	}
+	identity := lifecycle.ResourceIdentity{ID: "module_job", Generation: 1}
+	owner := newStagedJobOwner(
+		context.Background(),
+		candidate,
+		attempts,
+		1,
+		jobmgr.ProcessAttemptIdentity{
+			Namespace: jobmgr.ProcessAttemptJobRuntime,
+			Key:       identity.ID,
+			Resource:  identity.ID,
+		},
+	)
+	require.NoError(t, owner.Promote(context.Background()))
+	require.NoError(t, owner.BindAttachment())
+	require.NoError(t, owner.AdoptAttachment(candidate))
+	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
+	_, err = owner.AcceptResources(permit)
+	require.NoError(t, err)
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := gate.Write([]byte("admitted\n"))
+		writeDone <- err
+	}()
+	requireTestSignal(t, writeEntered, "initial output did not acquire its write lease")
+	cutDone := make(chan int, 1)
+	go func() {
+		cutDone <- attempts.CutTarget(1)
+	}()
+	select {
+	case count := <-cutDone:
+		require.EqualValues(t, 1, count)
+	case <-time.After(time.Second):
+		release()
+		t.Fatal("containment waited for the admitted output lease to drain")
+	}
+	lateWriteDone := make(chan error, 1)
+	go func() {
+		_, err := gate.Write([]byte("late\n"))
+		lateWriteDone <- err
+	}()
+	select {
+	case err = <-lateWriteDone:
+		require.ErrorIs(t, err, errGenerationOutputFenced)
+	case <-time.After(time.Second):
+		release()
+		t.Fatal("late output waited for the admitted output lease to drain")
+	}
+
+	release()
+	require.NoError(t, <-writeDone)
+	owner.Reject()
+	requireTestSignal(t, owner.done, "contained runtime owner did not finalize after output drain")
+	require.NoError(t, permit.ReleaseExternal())
+	require.NoError(t, permit.Return())
+	require.Zero(t, rejected)
+	require.EqualValues(t, 1, final)
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+	attempts.BeginShutdown()
+	require.NoError(t, attempts.Shutdown(context.Background()))
+	require.EqualValues(t, containment.Census{}, attempts.Census())
+}
+
+func TestStagedJobRetirementPreservesFirstCause(t *testing.T) {
+	frames, err := lifecycle.NewFrameOwner(&bytes.Buffer{})
+	require.NoError(t, err)
+	gate, err := newGenerationOutputGate(frames)
+	require.NoError(t, err)
+	owner := newStagedJobOwner(
+		context.Background(),
+		ConstructedJob{outputGate: gate},
+		nil,
+		1,
+		jobmgr.ProcessAttemptIdentity{},
+	)
+	structural := errors.New("runtime failed before readiness")
+	owner.beginRetirement(structural)
+	owner.containRuntimeAttempt(jobmgr.ErrProcessAttemptRetired)
+
+	err = owner.retirementError("fallback")
+	require.ErrorIs(t, err, structural)
+	require.NotErrorIs(t, err, jobmgr.ErrProcessAttemptRetired)
+	require.False(t, jobmgr.ContainsOnlyErrorLeaves(
+		err,
+		jobmgr.ErrProcessAttemptRetired,
+		jobmgr.ErrProcessAttemptStopped,
+	))
+}
+
 func TestPreparedJobPreActivationRetirementPreservesCause(t *testing.T) {
 	tests := map[string]struct {
 		variant JobVariant
@@ -320,6 +435,147 @@ func TestPreparedJobRetirementAfterAttachmentAdoptionPreservesCause(t *testing.T
 			fixture.requireSettled(t)
 		})
 	}
+}
+
+func TestPreparedJobRejectsTargetCutBeforeWorkerObservesCancellation(t *testing.T) {
+	tests := map[string]error{
+		"retired": jobmgr.ErrProcessAttemptRetired,
+		"stopped": jobmgr.ErrProcessAttemptStopped,
+	}
+	for name, cause := range tests {
+		t.Run(name, func(t *testing.T) {
+			attempts, err := containment.NewAuthority(nil)
+			require.NoError(t, err)
+			delayed := &delayedRuntimeCancellationAuthority{
+				ProcessAttemptAuthority: attempts,
+				cutObserved:             make(chan struct{}),
+				release:                 make(chan struct{}),
+			}
+			defer delayed.releaseCancellation()
+			fixture := newPreparedAttachmentFixture(
+				t,
+				JobVariantV2,
+				delayed,
+				true,
+				jobHandlerAttacherFunc(func(
+					_ lifecycle.ResourceIdentity,
+					staged StagedHandlerLifecycle,
+				) (ProcessHandlerLifecycle, error) {
+					cutTestAuthority(t, attempts, cause)
+					requireTestSignal(t, delayed.cutObserved, "authority cut did not cancel the runtime attempt")
+					return staged.(ProcessHandlerLifecycle), nil
+				}),
+			)
+
+			generation, err := fixture.prepared.Accept(context.Background(), fixture.identity.Generation)
+			if generation != nil {
+				require.NoError(t, generation.abortProcessOwned(context.Background()))
+			}
+			delayed.releaseCancellation()
+
+			require.ErrorIs(t, err, cause)
+			require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+				err,
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			))
+			requireTestSignal(t, fixture.owner.done, "retired runtime owner did not finalize")
+			require.EqualValues(t, 1, fixture.state.rejected)
+			require.Zero(t, fixture.state.final)
+			require.EqualValues(t, 1, fixture.state.handlerFinalized)
+			require.EqualValues(t, lifecycle.LongLivedCensus{}, fixture.tasks.LongLivedCensus())
+			require.NoError(t, attempts.Shutdown(context.Background()))
+			require.EqualValues(t, containment.Census{}, attempts.Census())
+		})
+	}
+}
+
+func TestProcessOwnedJobDoesNotStartAfterContainment(t *testing.T) {
+	tests := map[string]struct {
+		variant JobVariant
+		cause   error
+	}{
+		"V1 retired": {
+			variant: JobVariantV1,
+			cause:   jobmgr.ErrProcessAttemptRetired,
+		},
+		"V1 stopped": {
+			variant: JobVariantV1,
+			cause:   jobmgr.ErrProcessAttemptStopped,
+		},
+		"V2 retired": {
+			variant: JobVariantV2,
+			cause:   jobmgr.ErrProcessAttemptRetired,
+		},
+		"V2 stopped": {
+			variant: JobVariantV2,
+			cause:   jobmgr.ErrProcessAttemptStopped,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			attempts, err := containment.NewAuthority(nil)
+			require.NoError(t, err)
+			fixture := newPreparedAttachmentFixture(t, test.variant, attempts, false, nil)
+			generation, err := fixture.prepared.Accept(context.Background(), fixture.identity.Generation)
+			require.NoError(t, err)
+			require.NotNil(t, generation)
+
+			cutTestAuthority(t, attempts, test.cause)
+			_, writeErr := fixture.gate.Write([]byte("late\n"))
+			require.ErrorIs(t, writeErr, errGenerationOutputFenced)
+			err = generation.Start(context.Background())
+
+			require.ErrorIs(t, err, test.cause)
+			require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+				err,
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			))
+			select {
+			case <-fixture.job.started:
+				t.Fatal("managed job started after containment")
+			default:
+			}
+			requireTestSignal(t, fixture.owner.done, "contained runtime owner did not finalize")
+			require.Zero(t, fixture.state.rejected)
+			require.EqualValues(t, 1, fixture.state.final)
+			require.EqualValues(t, lifecycle.LongLivedCensus{}, fixture.tasks.LongLivedCensus())
+			require.NoError(t, attempts.Shutdown(context.Background()))
+			require.EqualValues(t, containment.Census{}, attempts.Census())
+		})
+	}
+}
+
+func TestPreparedJobAdoptsPartialHandlerTransferBeforeAttachmentFailure(t *testing.T) {
+	attempts, err := containment.NewAuthority(nil)
+	require.NoError(t, err)
+	attachErr := errors.New("partial handler attachment failed")
+	fixture := newPreparedAttachmentFixture(
+		t,
+		JobVariantV1,
+		attempts,
+		true,
+		jobHandlerAttacherFunc(func(
+			_ lifecycle.ResourceIdentity,
+			staged StagedHandlerLifecycle,
+		) (ProcessHandlerLifecycle, error) {
+			return staged.(ProcessHandlerLifecycle), attachErr
+		}),
+	)
+
+	generation, err := fixture.prepared.Accept(context.Background(), fixture.identity.Generation)
+
+	require.Nil(t, generation)
+	require.ErrorIs(t, err, attachErr)
+	requireTestSignal(t, fixture.owner.done, "partially attached runtime owner did not finalize")
+	require.EqualValues(t, 1, fixture.state.rejected)
+	require.Zero(t, fixture.state.final)
+	require.EqualValues(t, 1, fixture.state.handlerFinalized)
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, fixture.tasks.LongLivedCensus())
+	attempts.BeginShutdown()
+	require.NoError(t, attempts.Shutdown(context.Background()))
+	require.EqualValues(t, containment.Census{}, attempts.Census())
 }
 
 func TestPreparedJobDoesNotHideProjectionFailureDuringRetirement(t *testing.T) {
@@ -609,6 +865,85 @@ func TestCandidateCancellationControlsFailedPromotion(t *testing.T) {
 	require.NoError(t, delegate.Shutdown(context.Background()))
 }
 
+func TestRuntimeContainmentSettlesPromotionOwnership(t *testing.T) {
+	tests := map[string]struct {
+		cutAfterAdmission bool
+		cause             error
+	}{
+		"retired before admission": {
+			cause: jobmgr.ErrProcessAttemptRetired,
+		},
+		"stopped before admission": {
+			cause: jobmgr.ErrProcessAttemptStopped,
+		},
+		"retired after admission": {
+			cutAfterAdmission: true,
+			cause:             jobmgr.ErrProcessAttemptRetired,
+		},
+		"stopped after admission": {
+			cutAfterAdmission: true,
+			cause:             jobmgr.ErrProcessAttemptStopped,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			delegate, err := containment.NewAuthority(nil)
+			require.NoError(t, err)
+			attempts := &promotionAdmissionGateAuthority{
+				ProcessAttemptAuthority: delegate,
+				entered:                 make(chan struct{}),
+				release:                 make(chan struct{}),
+				cutAfterAdmission:       test.cutAfterAdmission,
+			}
+			frames, err := lifecycle.NewFrameOwner(&bytes.Buffer{})
+			require.NoError(t, err)
+			gate, err := newGenerationOutputGate(frames)
+			require.NoError(t, err)
+			var cleanups atomic.Int32
+			owner := newStagedJobOwner(
+				context.Background(),
+				ConstructedJob{
+					Variant:          JobVariantV1,
+					CollectorCleanup: func(context.Context) error { cleanups.Add(1); return nil },
+					outputGate:       gate,
+				},
+				attempts,
+				1,
+				jobmgr.ProcessAttemptIdentity{
+					Namespace: jobmgr.ProcessAttemptJobRuntime,
+					Key:       "module_job",
+					Resource:  "module_job",
+				},
+			)
+			candidateFinished := make(chan error, 1)
+			go func() {
+				candidateFinished <- owner.finishCandidate(context.Background())
+			}()
+			promoted := make(chan error, 1)
+			go func() {
+				promoted <- owner.Promote(context.Background())
+			}()
+			requireTestSignal(t, attempts.entered, "promotion did not reach the admission boundary")
+
+			cutTestAuthority(t, delegate, test.cause)
+			close(attempts.release)
+			err = <-promoted
+			owner.Reject()
+
+			require.ErrorIs(t, err, test.cause)
+			require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+				err,
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			))
+			require.NoError(t, <-candidateFinished)
+			require.NoError(t, delegate.Shutdown(context.Background()))
+			require.EqualValues(t, 1, cleanups.Load())
+			require.EqualValues(t, containment.Census{}, delegate.Census())
+		})
+	}
+}
+
 type promotionGateAuthority struct {
 	jobmgr.ProcessAttemptAuthority
 	entered chan struct{}
@@ -628,6 +963,88 @@ type busyPromotionGateAuthority struct {
 	jobmgr.ProcessAttemptAuthority
 	entered chan struct{}
 	release chan struct{}
+}
+
+type promotionAdmissionGateAuthority struct {
+	jobmgr.ProcessAttemptAuthority
+	entered           chan struct{}
+	release           chan struct{}
+	cutAfterAdmission bool
+}
+
+func (a *promotionAdmissionGateAuthority) StartProcessAttempt(
+	ctx context.Context,
+	plan jobmgr.ProcessAttemptPlan,
+) (jobmgr.ProcessAttempt, error) {
+	work := plan.Work
+	plan.Work = func(
+		ctx context.Context,
+		admission jobmgr.ProcessAttemptAdmission,
+	) error {
+		return work(ctx, promotionAdmissionGate{
+			ProcessAttemptAdmission: admission,
+			entered:                 a.entered,
+			release:                 a.release,
+			cutAfterAdmission:       a.cutAfterAdmission,
+		})
+	}
+	return a.ProcessAttemptAuthority.StartProcessAttempt(ctx, plan)
+}
+
+type promotionAdmissionGate struct {
+	jobmgr.ProcessAttemptAdmission
+	entered           chan struct{}
+	release           chan struct{}
+	cutAfterAdmission bool
+}
+
+func (gate promotionAdmissionGate) Admit() error {
+	if gate.cutAfterAdmission {
+		err := gate.ProcessAttemptAdmission.Admit()
+		close(gate.entered)
+		<-gate.release
+		return err
+	}
+	close(gate.entered)
+	<-gate.release
+	return gate.ProcessAttemptAdmission.Admit()
+}
+
+type delayedRuntimeCancellationAuthority struct {
+	jobmgr.ProcessAttemptAuthority
+	cutObserved chan struct{}
+	release     chan struct{}
+	releaseOnce sync.Once
+}
+
+func (a *delayedRuntimeCancellationAuthority) StartProcessAttempt(
+	ctx context.Context,
+	plan jobmgr.ProcessAttemptPlan,
+) (jobmgr.ProcessAttempt, error) {
+	if plan.Identity.Namespace != jobmgr.ProcessAttemptJobRuntime {
+		return a.ProcessAttemptAuthority.StartProcessAttempt(ctx, plan)
+	}
+	work := plan.Work
+	plan.Work = func(
+		attemptCtx context.Context,
+		admission jobmgr.ProcessAttemptAdmission,
+	) error {
+		delayedCtx, cancel := context.WithCancelCause(context.Background())
+		go func() {
+			<-attemptCtx.Done()
+			close(a.cutObserved)
+			<-a.release
+			cancel(context.Cause(attemptCtx))
+		}()
+		return work(delayedCtx, admission)
+	}
+	return a.ProcessAttemptAuthority.StartProcessAttempt(ctx, plan)
+}
+
+func (a *delayedRuntimeCancellationAuthority) releaseCancellation() {
+	a.releaseOnce.Do(func() {
+		close(a.release)
+	})
 }
 
 func (*busyPromotionGateAuthority) StartProcessAttempt(
@@ -657,6 +1074,81 @@ const (
 	retirementAfterTransfer
 	retirementAfterAdoption
 )
+
+type preparedAttachmentFixture struct {
+	prepared PreparedJob
+	identity lifecycle.ResourceIdentity
+	owner    *stagedJobOwner
+	gate     *generationOutputGate
+	job      *blockingStopManagedJob
+	state    *preActivationRetirementState
+	tasks    *lifecycle.TaskSupervisor
+}
+
+func newPreparedAttachmentFixture(
+	t *testing.T,
+	variant JobVariant,
+	attempts jobmgr.ProcessAttemptAuthority,
+	withHandler bool,
+	attacher JobHandlerAttacher,
+) *preparedAttachmentFixture {
+	t.Helper()
+	frames, err := lifecycle.NewFrameOwner(&bytes.Buffer{})
+	require.NoError(t, err)
+	gate, err := newGenerationOutputGate(frames)
+	require.NoError(t, err)
+	job := newBlockingStopManagedJob()
+	state := &preActivationRetirementState{}
+	candidate := ConstructedJob{
+		Variant:          variant,
+		CollectorCleanup: func(context.Context) error { state.rejected++; return nil },
+		finalCleanup:     func(context.Context) error { state.final++; return nil },
+		candidateJob:     job,
+		outputGate:       gate,
+	}
+	if withHandler {
+		candidate.StagedHandlers = &preActivationRetirementHandler{state: state}
+	}
+	identity := lifecycle.ResourceIdentity{ID: job.FullName(), Generation: 1}
+	owner := newStagedJobOwner(
+		context.Background(),
+		candidate,
+		attempts,
+		1,
+		jobmgr.ProcessAttemptIdentity{
+			Namespace: jobmgr.ProcessAttemptJobRuntime,
+			Key:       identity.ID,
+			Resource:  identity.ID,
+		},
+	)
+	attachment := factoryAttachment{
+		handlerAttacher: attacher,
+		scheduler:       newTestScheduler(t),
+	}
+	staged := candidate
+	candidate.attach = func(
+		identity lifecycle.ResourceIdentity,
+		owner *stagedJobOwner,
+	) (constructedJobAttachment, error) {
+		return attachment.attach(staged, identity, owner)
+	}
+	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
+	return &preparedAttachmentFixture{
+		prepared: PreparedJob{state: &preparedJobState{
+			id:          identity.ID,
+			generation:  identity.Generation,
+			constructed: candidate,
+			permit:      permit,
+			owner:       owner,
+		}},
+		identity: identity,
+		owner:    owner,
+		gate:     gate,
+		job:      job,
+		state:    state,
+		tasks:    tasks,
+	}
+}
 
 type preActivationRetirementFixture struct {
 	prepared     PreparedJob
@@ -744,14 +1236,7 @@ func newPreActivationRetirementFixtureForWindow(
 		},
 	)
 	cut := func() {
-		switch cause {
-		case jobmgr.ErrProcessAttemptRetired:
-			require.EqualValues(t, 1, attempts.CutTarget(1))
-		case jobmgr.ErrProcessAttemptStopped:
-			attempts.BeginShutdown()
-		default:
-			require.FailNow(t, "invalid retirement test cause")
-		}
+		cutTestAuthority(t, attempts, cause)
 	}
 	var attacher JobHandlerAttacher
 	if window == retirementAfterTransfer {
@@ -923,6 +1408,18 @@ func requireTestSignal(t *testing.T, signal <-chan struct{}, message string) {
 	case <-signal:
 	case <-time.After(time.Second):
 		t.Fatal(message)
+	}
+}
+
+func cutTestAuthority(t *testing.T, attempts *containment.Authority, cause error) {
+	t.Helper()
+	switch cause {
+	case jobmgr.ErrProcessAttemptRetired:
+		require.EqualValues(t, 1, attempts.CutTarget(1))
+	case jobmgr.ErrProcessAttemptStopped:
+		attempts.BeginShutdown()
+	default:
+		require.FailNow(t, "invalid retirement test cause")
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
@@ -1144,6 +1144,7 @@ func newPreparedAttachmentFixture(
 	withHandler bool,
 	attacher JobHandlerAttacher,
 ) *preparedAttachmentFixture {
+	t.Helper()
 	return newPreparedAttachmentFixtureWithOptions(t, preparedAttachmentFixtureOptions{
 		variant:     variant,
 		attempts:    attempts,

--- a/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
@@ -547,6 +547,47 @@ func TestProcessOwnedJobDoesNotStartAfterContainment(t *testing.T) {
 	}
 }
 
+func TestProcessOwnedJobRejectsContainmentBetweenStartReservationAndWorkerClaim(t *testing.T) {
+	tests := map[string]error{
+		"retired": jobmgr.ErrProcessAttemptRetired,
+		"stopped": jobmgr.ErrProcessAttemptStopped,
+	}
+	for name, cause := range tests {
+		t.Run(name, func(t *testing.T) {
+			attempts, err := containment.NewAuthority(nil)
+			require.NoError(t, err)
+			fixture := newPreparedAttachmentFixture(t, JobVariantV2, attempts, false, nil)
+			generation, err := fixture.prepared.Accept(context.Background(), fixture.identity.Generation)
+			require.NoError(t, err)
+			require.NotNil(t, generation)
+			require.NoError(t, fixture.owner.reserveStart())
+
+			cutTestAuthority(t, attempts, cause)
+			_, retiring, err := fixture.owner.beginManagedStart()
+
+			require.True(t, retiring)
+			require.ErrorIs(t, err, cause)
+			require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+				err,
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			))
+			select {
+			case <-fixture.job.started:
+				t.Fatal("managed job started after containment won the reserved start")
+			default:
+			}
+			require.NoError(t, generation.abortProcessOwned(context.Background()))
+			requireTestSignal(t, fixture.owner.done, "contained runtime owner did not finalize")
+			require.Zero(t, fixture.state.rejected)
+			require.EqualValues(t, 1, fixture.state.final)
+			require.EqualValues(t, lifecycle.LongLivedCensus{}, fixture.tasks.LongLivedCensus())
+			require.NoError(t, attempts.Shutdown(context.Background()))
+			require.EqualValues(t, containment.Census{}, attempts.Census())
+		})
+	}
+}
+
 func TestPreparedJobAdoptsPartialHandlerTransferBeforeAttachmentFailure(t *testing.T) {
 	attempts, err := containment.NewAuthority(nil)
 	require.NoError(t, err)

--- a/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
@@ -1121,9 +1121,20 @@ type preparedAttachmentFixture struct {
 	identity lifecycle.ResourceIdentity
 	owner    *stagedJobOwner
 	gate     *generationOutputGate
+	output   *bytes.Buffer
 	job      *blockingStopManagedJob
 	state    *preActivationRetirementState
 	tasks    *lifecycle.TaskSupervisor
+}
+
+type preparedAttachmentFixtureOptions struct {
+	variant      JobVariant
+	attempts     jobmgr.ProcessAttemptAuthority
+	withHandler  bool
+	runtimeStage *stagedRuntimeService
+	newRuntime   func(*stagedJobOwner) runtimecomp.Service
+	newAttacher  func(*stagedJobOwner) JobHandlerAttacher
+	beforeAttach func(*stagedJobOwner)
 }
 
 func newPreparedAttachmentFixture(
@@ -1133,28 +1144,44 @@ func newPreparedAttachmentFixture(
 	withHandler bool,
 	attacher JobHandlerAttacher,
 ) *preparedAttachmentFixture {
+	return newPreparedAttachmentFixtureWithOptions(t, preparedAttachmentFixtureOptions{
+		variant:     variant,
+		attempts:    attempts,
+		withHandler: withHandler,
+		newAttacher: func(*stagedJobOwner) JobHandlerAttacher {
+			return attacher
+		},
+	})
+}
+
+func newPreparedAttachmentFixtureWithOptions(
+	t *testing.T,
+	options preparedAttachmentFixtureOptions,
+) *preparedAttachmentFixture {
 	t.Helper()
-	frames, err := lifecycle.NewFrameOwner(&bytes.Buffer{})
+	output := &bytes.Buffer{}
+	frames, err := lifecycle.NewFrameOwner(output)
 	require.NoError(t, err)
 	gate, err := newGenerationOutputGate(frames)
 	require.NoError(t, err)
 	job := newBlockingStopManagedJob()
 	state := &preActivationRetirementState{}
 	candidate := ConstructedJob{
-		Variant:          variant,
+		Variant:          options.variant,
 		CollectorCleanup: func(context.Context) error { state.rejected++; return nil },
 		finalCleanup:     func(context.Context) error { state.final++; return nil },
 		candidateJob:     job,
+		runtimeStage:     options.runtimeStage,
 		outputGate:       gate,
 	}
-	if withHandler {
+	if options.withHandler {
 		candidate.StagedHandlers = &preActivationRetirementHandler{state: state}
 	}
 	identity := lifecycle.ResourceIdentity{ID: job.FullName(), Generation: 1}
 	owner := newStagedJobOwner(
 		context.Background(),
 		candidate,
-		attempts,
+		options.attempts,
 		1,
 		jobmgr.ProcessAttemptIdentity{
 			Namespace: jobmgr.ProcessAttemptJobRuntime,
@@ -1162,7 +1189,16 @@ func newPreparedAttachmentFixture(
 			Resource:  identity.ID,
 		},
 	)
+	var attacher JobHandlerAttacher
+	if options.newAttacher != nil {
+		attacher = options.newAttacher(owner)
+	}
+	var runtimeService runtimecomp.Service
+	if options.newRuntime != nil {
+		runtimeService = options.newRuntime(owner)
+	}
 	attachment := factoryAttachment{
+		runtime:         runtimeService,
 		handlerAttacher: attacher,
 		scheduler:       newTestScheduler(t),
 	}
@@ -1171,6 +1207,9 @@ func newPreparedAttachmentFixture(
 		identity lifecycle.ResourceIdentity,
 		owner *stagedJobOwner,
 	) (constructedJobAttachment, error) {
+		if options.beforeAttach != nil {
+			options.beforeAttach(owner)
+		}
 		return attachment.attach(staged, identity, owner)
 	}
 	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
@@ -1185,6 +1224,7 @@ func newPreparedAttachmentFixture(
 		identity: identity,
 		owner:    owner,
 		gate:     gate,
+		output:   output,
 		job:      job,
 		state:    state,
 		tasks:    tasks,
@@ -1192,13 +1232,7 @@ func newPreparedAttachmentFixture(
 }
 
 type preActivationRetirementFixture struct {
-	prepared     PreparedJob
-	identity     lifecycle.ResourceIdentity
-	owner        *stagedJobOwner
-	gate         *generationOutputGate
-	output       *bytes.Buffer
-	state        *preActivationRetirementState
-	tasks        *lifecycle.TaskSupervisor
+	*preparedAttachmentFixture
 	attempts     *containment.Authority
 	wantHandler  bool
 	shutdownOnce sync.Once
@@ -1242,98 +1276,62 @@ func newPreActivationRetirementFixtureForWindow(
 	t.Helper()
 	attempts, err := containment.NewAuthority(nil)
 	require.NoError(t, err)
-	output := &bytes.Buffer{}
-	frames, err := lifecycle.NewFrameOwner(output)
-	require.NoError(t, err)
-	gate, err := newGenerationOutputGate(frames)
-	require.NoError(t, err)
-	job := newBlockingStopManagedJob()
-	state := &preActivationRetirementState{}
-	handler := &preActivationRetirementHandler{state: state}
-	candidate := ConstructedJob{
-		Variant:          variant,
-		CollectorCleanup: func(context.Context) error { state.rejected++; return nil },
-		finalCleanup:     func(context.Context) error { state.final++; return nil },
-		candidateJob:     job,
-		outputGate:       gate,
-	}
+	var runtimeStage *stagedRuntimeService
 	if runtimeErr != nil || window == retirementAfterAdoption {
-		candidate.runtimeStage = newStagedRuntimeService()
-		require.NoError(t, candidate.runtimeStage.RegisterComponent(runtimecomp.ComponentConfig{Name: "test"}))
+		runtimeStage = newStagedRuntimeService()
+		require.NoError(t, runtimeStage.RegisterComponent(runtimecomp.ComponentConfig{Name: "test"}))
 	}
-	if window == retirementAfterTransfer {
-		candidate.StagedHandlers = handler
-	}
-	identity := lifecycle.ResourceIdentity{ID: job.FullName(), Generation: 1}
-	owner := newStagedJobOwner(
-		context.Background(),
-		candidate,
-		attempts,
-		1,
-		jobmgr.ProcessAttemptIdentity{
-			Namespace: jobmgr.ProcessAttemptJobRuntime,
-			Key:       identity.ID,
-			Resource:  identity.ID,
-		},
-	)
 	cut := func() {
 		cutTestAuthority(t, attempts, cause)
 	}
-	var attacher JobHandlerAttacher
+	var newAttacher func(*stagedJobOwner) JobHandlerAttacher
 	if window == retirementAfterTransfer {
-		attacher = jobHandlerAttacherFunc(func(
-			_ lifecycle.ResourceIdentity,
-			staged StagedHandlerLifecycle,
-		) (ProcessHandlerLifecycle, error) {
-			cut()
-			requireTestSignal(t, owner.retire, "runtime owner did not record retirement")
-			return staged.(ProcessHandlerLifecycle), nil
-		})
+		newAttacher = func(owner *stagedJobOwner) JobHandlerAttacher {
+			return jobHandlerAttacherFunc(func(
+				_ lifecycle.ResourceIdentity,
+				staged StagedHandlerLifecycle,
+			) (ProcessHandlerLifecycle, error) {
+				cut()
+				requireTestSignal(t, owner.retire, "runtime owner did not record retirement")
+				return staged.(ProcessHandlerLifecycle), nil
+			})
+		}
 	}
-	var runtimeService runtimecomp.Service
+	var newRuntime func(*stagedJobOwner) runtimecomp.Service
 	switch {
 	case runtimeErr != nil:
-		runtimeService = projectionFailureRuntimeService{err: runtimeErr}
+		newRuntime = func(*stagedJobOwner) runtimecomp.Service {
+			return projectionFailureRuntimeService{err: runtimeErr}
+		}
 	case window == retirementAfterAdoption:
-		runtimeService = projectionHookRuntimeService{register: func() error {
-			cut()
-			requireTestSignal(t, owner.retire, "runtime owner did not record retirement")
-			return nil
-		}}
+		newRuntime = func(owner *stagedJobOwner) runtimecomp.Service {
+			return projectionHookRuntimeService{register: func() error {
+				cut()
+				requireTestSignal(t, owner.retire, "runtime owner did not record retirement")
+				return nil
+			}}
+		}
 	}
-	attachment := factoryAttachment{
-		runtime:         runtimeService,
-		handlerAttacher: attacher,
-		scheduler:       newTestScheduler(t),
-	}
-	staged := candidate
-	candidate.attach = func(
-		identity lifecycle.ResourceIdentity,
-		owner *stagedJobOwner,
-	) (constructedJobAttachment, error) {
-		if window == retirementBeforeBind {
+	var beforeAttach func(*stagedJobOwner)
+	if window == retirementBeforeBind {
+		beforeAttach = func(owner *stagedJobOwner) {
 			cut()
 			requireTestSignal(t, owner.done, "retired candidate did not finalize before binding")
 		}
-		return attachment.attach(staged, identity, owner)
 	}
-	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
+	prepared := newPreparedAttachmentFixtureWithOptions(t, preparedAttachmentFixtureOptions{
+		variant:      variant,
+		attempts:     attempts,
+		withHandler:  window == retirementAfterTransfer,
+		runtimeStage: runtimeStage,
+		newRuntime:   newRuntime,
+		newAttacher:  newAttacher,
+		beforeAttach: beforeAttach,
+	})
 	fixture := &preActivationRetirementFixture{
-		prepared: PreparedJob{state: &preparedJobState{
-			id:          identity.ID,
-			generation:  identity.Generation,
-			constructed: candidate,
-			permit:      permit,
-			owner:       owner,
-		}},
-		identity:    identity,
-		owner:       owner,
-		gate:        gate,
-		output:      output,
-		state:       state,
-		tasks:       tasks,
-		attempts:    attempts,
-		wantHandler: window == retirementAfterTransfer,
+		preparedAttachmentFixture: prepared,
+		attempts:                  attempts,
+		wantHandler:               window == retirementAfterTransfer,
 	}
 	t.Cleanup(func() {
 		fixture.owner.Reject()

--- a/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation_test.go
@@ -5,12 +5,16 @@ package joboutput
 import (
 	"bytes"
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/containment"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/runtimecomp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,10 +60,15 @@ func TestPreparedJobAcceptanceTransfersFinalCleanupToProcessOwner(t *testing.T) 
 	})
 	var rejected, final int
 	identity := lifecycle.ResourceIdentity{ID: "module_job", Generation: 1}
+	frames, err := lifecycle.NewFrameOwner(&bytes.Buffer{})
+	require.NoError(t, err)
+	gate, err := newGenerationOutputGate(frames)
+	require.NoError(t, err)
 	candidate := ConstructedJob{
 		Variant:          JobVariantV1,
 		CollectorCleanup: func(context.Context) error { rejected++; return nil },
 		finalCleanup:     func(context.Context) error { final++; return nil },
+		outputGate:       gate,
 	}
 	owner := newStagedJobOwner(
 		context.Background(),
@@ -75,9 +84,9 @@ func TestPreparedJobAcceptanceTransfersFinalCleanupToProcessOwner(t *testing.T) 
 	candidate.attach = func(
 		lifecycle.ResourceIdentity,
 		*stagedJobOwner,
-	) (ConstructedJob, error) {
+	) (constructedJobAttachment, error) {
 		require.NoError(t, owner.BindAttachment())
-		return candidate, nil
+		return constructedJobAttachment{resources: candidate, transferred: true}, nil
 	}
 	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
 	prepared := PreparedJob{state: &preparedJobState{
@@ -105,7 +114,7 @@ func TestPreparedJobAcceptanceTransfersFinalCleanupToProcessOwner(t *testing.T) 
 	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
 }
 
-func TestPreparedJobRetirementBeforeResourceAcceptanceLeavesPermitUnused(t *testing.T) {
+func TestStagedJobRetirementBeforeResourceAcceptanceLeavesPermitUnused(t *testing.T) {
 	attempts, err := containment.NewAuthority(nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -113,10 +122,17 @@ func TestPreparedJobRetirementBeforeResourceAcceptanceLeavesPermitUnused(t *test
 		require.NoError(t, attempts.Shutdown(context.Background()))
 	})
 	identity := lifecycle.ResourceIdentity{ID: "module_job", Generation: 1}
+	var output bytes.Buffer
+	frames, err := lifecycle.NewFrameOwner(&output)
+	require.NoError(t, err)
+	gate, err := newGenerationOutputGate(frames)
+	require.NoError(t, err)
+	var cleanups int
 	candidate := ConstructedJob{
 		Variant:          JobVariantV1,
-		CollectorCleanup: func(context.Context) error { return nil },
+		CollectorCleanup: func(context.Context) error { cleanups++; return nil },
 		finalCleanup:     func(context.Context) error { return nil },
+		outputGate:       gate,
 	}
 	owner := newStagedJobOwner(
 		context.Background(),
@@ -129,30 +145,299 @@ func TestPreparedJobRetirementBeforeResourceAcceptanceLeavesPermitUnused(t *test
 			Resource:  identity.ID,
 		},
 	)
-	candidate.attach = func(
-		lifecycle.ResourceIdentity,
-		*stagedJobOwner,
-	) (ConstructedJob, error) {
-		require.NoError(t, owner.BindAttachment())
-		candidate.activateAttachment = func() error {
-			owner.Retire()
-			return nil
-		}
-		return candidate, nil
-	}
+	require.NoError(t, owner.Promote(context.Background()))
+	require.NoError(t, owner.BindAttachment())
+	require.NoError(t, owner.AdoptAttachment(candidate))
 	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
-	prepared := PreparedJob{state: &preparedJobState{
-		id:          identity.ID,
-		generation:  identity.Generation,
-		constructed: candidate,
-		permit:      permit,
-		owner:       owner,
-	}}
+	require.EqualValues(t, 1, attempts.CutTarget(1))
+	requireTestSignal(t, owner.retire, "runtime owner did not record retirement")
 
-	_, err = prepared.Accept(context.Background(), identity.Generation)
-	require.Error(t, err)
+	_, err = owner.AcceptResources(permit)
+	require.ErrorIs(t, err, jobmgr.ErrProcessAttemptRetired)
+	require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+		err,
+		jobmgr.ErrProcessAttemptRetired,
+		jobmgr.ErrProcessAttemptStopped,
+	))
+	require.NoError(t, permit.AbortUnused())
+	owner.Reject()
+	requireTestSignal(t, owner.done, "retired runtime owner did not finalize")
+	_, writeErr := gate.Write([]byte("late\n"))
+	require.ErrorIs(t, writeErr, errGenerationOutputFenced)
+	require.Empty(t, output.Bytes())
+	require.EqualValues(t, 1, cleanups)
 
 	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+}
+
+func TestStagedJobAcceptanceRejectsInvalidOutputGate(t *testing.T) {
+	tests := map[string]struct {
+		gate func(*testing.T) *generationOutputGate
+		want string
+	}{
+		"missing": {
+			gate: func(*testing.T) *generationOutputGate { return nil },
+			want: "job output: nil generation output gate",
+		},
+		"already active": {
+			gate: func(t *testing.T) *generationOutputGate {
+				frames, err := lifecycle.NewFrameOwner(&bytes.Buffer{})
+				require.NoError(t, err)
+				gate, err := newGenerationOutputGate(frames)
+				require.NoError(t, err)
+				require.NoError(t, gate.Activate())
+				return gate
+			},
+			want: "job output: invalid generation output activation",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			attempts, err := containment.NewAuthority(nil)
+			require.NoError(t, err)
+			candidate := ConstructedJob{
+				Variant:          JobVariantV1,
+				CollectorCleanup: func(context.Context) error { return nil },
+				outputGate:       test.gate(t),
+			}
+			owner := newStagedJobOwner(
+				context.Background(),
+				candidate,
+				attempts,
+				1,
+				jobmgr.ProcessAttemptIdentity{
+					Namespace: jobmgr.ProcessAttemptJobRuntime,
+					Key:       "module_job",
+					Resource:  "module_job",
+				},
+			)
+			require.NoError(t, owner.Promote(context.Background()))
+			require.NoError(t, owner.BindAttachment())
+			require.NoError(t, owner.AdoptAttachment(candidate))
+			permit, tasks := issueTestJobPermit(t, "module_job", 1)
+
+			_, err = owner.AcceptResources(permit)
+
+			require.EqualError(t, err, test.want)
+			require.False(t, jobmgr.ContainsOnlyErrorLeaves(
+				err,
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			))
+			require.NoError(t, permit.AbortUnused())
+			owner.Reject()
+			requireTestSignal(t, owner.done, "rejected runtime owner did not finalize")
+			require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+			attempts.BeginShutdown()
+			require.NoError(t, attempts.Shutdown(context.Background()))
+		})
+	}
+}
+
+func TestPreparedJobPreActivationRetirementPreservesCause(t *testing.T) {
+	tests := map[string]struct {
+		variant JobVariant
+		cause   error
+		preBind bool
+	}{
+		"V1 retired before bind": {
+			variant: JobVariantV1,
+			cause:   jobmgr.ErrProcessAttemptRetired,
+			preBind: true,
+		},
+		"V1 stopped before bind": {
+			variant: JobVariantV1,
+			cause:   jobmgr.ErrProcessAttemptStopped,
+			preBind: true,
+		},
+		"V2 retired before bind": {
+			variant: JobVariantV2,
+			cause:   jobmgr.ErrProcessAttemptRetired,
+			preBind: true,
+		},
+		"V2 stopped before bind": {
+			variant: JobVariantV2,
+			cause:   jobmgr.ErrProcessAttemptStopped,
+			preBind: true,
+		},
+		"V1 retired after transfer": {
+			variant: JobVariantV1,
+			cause:   jobmgr.ErrProcessAttemptRetired,
+		},
+		"V1 stopped after transfer": {
+			variant: JobVariantV1,
+			cause:   jobmgr.ErrProcessAttemptStopped,
+		},
+		"V2 retired after transfer": {
+			variant: JobVariantV2,
+			cause:   jobmgr.ErrProcessAttemptRetired,
+		},
+		"V2 stopped after transfer": {
+			variant: JobVariantV2,
+			cause:   jobmgr.ErrProcessAttemptStopped,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := newPreActivationRetirementFixture(t, test.variant, test.cause, test.preBind)
+
+			_, err := fixture.prepared.Accept(context.Background(), fixture.identity.Generation)
+
+			require.ErrorIs(t, err, test.cause)
+			require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+				err,
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			))
+			fixture.requireSettled(t)
+		})
+	}
+}
+
+func TestPreparedJobRetirementAfterAttachmentAdoptionPreservesCause(t *testing.T) {
+	tests := map[string]error{
+		"retired": jobmgr.ErrProcessAttemptRetired,
+		"stopped": jobmgr.ErrProcessAttemptStopped,
+	}
+	for name, cause := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := newPreActivationRetirementFixtureForWindow(
+				t,
+				JobVariantV2,
+				cause,
+				retirementAfterAdoption,
+				nil,
+			)
+
+			_, err := fixture.prepared.Accept(context.Background(), fixture.identity.Generation)
+
+			require.ErrorIs(t, err, cause)
+			require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+				err,
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			))
+			fixture.requireSettled(t)
+		})
+	}
+}
+
+func TestPreparedJobDoesNotHideProjectionFailureDuringRetirement(t *testing.T) {
+	projectionErr := errors.New("projection failed")
+	tests := map[string]error{
+		"retired": jobmgr.ErrProcessAttemptRetired,
+		"stopped": jobmgr.ErrProcessAttemptStopped,
+	}
+	for name, cause := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := newPreActivationRetirementFixtureWithRuntimeError(
+				t,
+				JobVariantV2,
+				cause,
+				false,
+				errors.Join(cause, projectionErr),
+			)
+			result, err := lifecycle.NewSealedResult(500, "application/json", nil)
+			require.NoError(t, err)
+			transaction, err := PrepareResourceTransaction(ResourceTransactionSpec{
+				Scope: lifecycle.ResourceTransactionScope{
+					ID:        fixture.identity.ID,
+					Successor: fixture.identity,
+				},
+				Disposition: lifecycle.ResourceTransactionInstalled,
+				Successor:   fixture.prepared,
+				Result:      result,
+				Cleanup:     func() error { return nil },
+			})
+			require.NoError(t, err)
+
+			applied, err := transaction.Apply(context.Background())
+
+			require.ErrorIs(t, err, cause)
+			require.ErrorIs(t, err, projectionErr)
+			require.False(t, jobmgr.ContainsOnlyErrorLeaves(
+				err,
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			))
+			_, disposition, current := applied.Ownership()
+			require.Equal(t, lifecycle.ResourceTransactionUnchanged, disposition)
+			require.Nil(t, current)
+			fixture.requireSettled(t)
+		})
+	}
+}
+
+func TestPreparedResourceTransactionSettlesPreActivationRetirement(t *testing.T) {
+	tests := map[string]struct {
+		variant JobVariant
+		cause   error
+		preBind bool
+	}{
+		"V1 retired before bind": {
+			variant: JobVariantV1,
+			cause:   jobmgr.ErrProcessAttemptRetired,
+			preBind: true,
+		},
+		"V2 stopped before bind": {
+			variant: JobVariantV2,
+			cause:   jobmgr.ErrProcessAttemptStopped,
+			preBind: true,
+		},
+		"V1 stopped after transfer": {
+			variant: JobVariantV1,
+			cause:   jobmgr.ErrProcessAttemptStopped,
+		},
+		"V2 retired after transfer": {
+			variant: JobVariantV2,
+			cause:   jobmgr.ErrProcessAttemptRetired,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := newPreActivationRetirementFixture(t, test.variant, test.cause, test.preBind)
+			graph, err := dyncfg.NewGraph(nil)
+			require.NoError(t, err)
+			postimage := dyncfg.GraphConfig{
+				ID:     fixture.identity.ID,
+				Module: "module",
+				Name:   "job",
+			}
+			mutation, err := graph.PrepareMutation([]dyncfg.GraphChange{{
+				ID:     fixture.identity.ID,
+				Config: &postimage,
+			}})
+			require.NoError(t, err)
+			result, err := lifecycle.NewSealedResult(200, "application/json", nil)
+			require.NoError(t, err)
+			scope := lifecycle.ResourceTransactionScope{
+				ID:        fixture.identity.ID,
+				Successor: fixture.identity,
+			}
+			transaction, err := PrepareResourceTransaction(ResourceTransactionSpec{
+				Scope:            scope,
+				Disposition:      lifecycle.ResourceTransactionInstalled,
+				Successor:        fixture.prepared,
+				Graph:            graph,
+				Mutation:         mutation,
+				MutationPrepared: true,
+				Result:           result,
+				Cleanup:          func() error { return nil },
+			})
+			require.NoError(t, err)
+
+			applied, err := transaction.Apply(context.Background())
+
+			require.NoError(t, err)
+			gotScope, disposition, current := applied.Ownership()
+			require.Equal(t, scope, gotScope)
+			require.Equal(t, lifecycle.ResourceTransactionUnchanged, disposition)
+			require.Nil(t, current)
+			_, exists := graph.Lookup(fixture.identity.ID)
+			require.False(t, exists)
+			fixture.requireSettled(t)
+		})
+	}
 }
 
 func TestCandidateCancellationBeforePromotionPreservesRetirementCause(t *testing.T) {
@@ -362,6 +647,282 @@ func (a *busyPromotionGateAuthority) SupersedeProcessAttempt(
 		return ctx.Err()
 	case <-a.release:
 		return jobmgr.ErrProcessAttemptBusy
+	}
+}
+
+type preActivationRetirementWindow uint8
+
+const (
+	retirementBeforeBind preActivationRetirementWindow = iota + 1
+	retirementAfterTransfer
+	retirementAfterAdoption
+)
+
+type preActivationRetirementFixture struct {
+	prepared     PreparedJob
+	identity     lifecycle.ResourceIdentity
+	owner        *stagedJobOwner
+	gate         *generationOutputGate
+	output       *bytes.Buffer
+	state        *preActivationRetirementState
+	tasks        *lifecycle.TaskSupervisor
+	attempts     *containment.Authority
+	wantHandler  bool
+	shutdownOnce sync.Once
+	shutdownErr  error
+}
+
+func newPreActivationRetirementFixture(
+	t *testing.T,
+	variant JobVariant,
+	cause error,
+	preBind bool,
+) *preActivationRetirementFixture {
+	window := retirementAfterTransfer
+	if preBind {
+		window = retirementBeforeBind
+	}
+	return newPreActivationRetirementFixtureForWindow(t, variant, cause, window, nil)
+}
+
+func newPreActivationRetirementFixtureWithRuntimeError(
+	t *testing.T,
+	variant JobVariant,
+	cause error,
+	preBind bool,
+	runtimeErr error,
+) *preActivationRetirementFixture {
+	window := retirementAfterTransfer
+	if preBind {
+		window = retirementBeforeBind
+	}
+	return newPreActivationRetirementFixtureForWindow(t, variant, cause, window, runtimeErr)
+}
+
+func newPreActivationRetirementFixtureForWindow(
+	t *testing.T,
+	variant JobVariant,
+	cause error,
+	window preActivationRetirementWindow,
+	runtimeErr error,
+) *preActivationRetirementFixture {
+	t.Helper()
+	attempts, err := containment.NewAuthority(nil)
+	require.NoError(t, err)
+	output := &bytes.Buffer{}
+	frames, err := lifecycle.NewFrameOwner(output)
+	require.NoError(t, err)
+	gate, err := newGenerationOutputGate(frames)
+	require.NoError(t, err)
+	job := newBlockingStopManagedJob()
+	state := &preActivationRetirementState{}
+	handler := &preActivationRetirementHandler{state: state}
+	candidate := ConstructedJob{
+		Variant:          variant,
+		CollectorCleanup: func(context.Context) error { state.rejected++; return nil },
+		finalCleanup:     func(context.Context) error { state.final++; return nil },
+		candidateJob:     job,
+		outputGate:       gate,
+	}
+	if runtimeErr != nil || window == retirementAfterAdoption {
+		candidate.runtimeStage = newStagedRuntimeService()
+		require.NoError(t, candidate.runtimeStage.RegisterComponent(runtimecomp.ComponentConfig{Name: "test"}))
+	}
+	if window == retirementAfterTransfer {
+		candidate.StagedHandlers = handler
+	}
+	identity := lifecycle.ResourceIdentity{ID: job.FullName(), Generation: 1}
+	owner := newStagedJobOwner(
+		context.Background(),
+		candidate,
+		attempts,
+		1,
+		jobmgr.ProcessAttemptIdentity{
+			Namespace: jobmgr.ProcessAttemptJobRuntime,
+			Key:       identity.ID,
+			Resource:  identity.ID,
+		},
+	)
+	cut := func() {
+		switch cause {
+		case jobmgr.ErrProcessAttemptRetired:
+			require.EqualValues(t, 1, attempts.CutTarget(1))
+		case jobmgr.ErrProcessAttemptStopped:
+			attempts.BeginShutdown()
+		default:
+			require.FailNow(t, "invalid retirement test cause")
+		}
+	}
+	var attacher JobHandlerAttacher
+	if window == retirementAfterTransfer {
+		attacher = jobHandlerAttacherFunc(func(
+			_ lifecycle.ResourceIdentity,
+			staged StagedHandlerLifecycle,
+		) (ProcessHandlerLifecycle, error) {
+			cut()
+			requireTestSignal(t, owner.retire, "runtime owner did not record retirement")
+			return staged.(ProcessHandlerLifecycle), nil
+		})
+	}
+	var runtimeService runtimecomp.Service
+	switch {
+	case runtimeErr != nil:
+		runtimeService = projectionFailureRuntimeService{err: runtimeErr}
+	case window == retirementAfterAdoption:
+		runtimeService = projectionHookRuntimeService{register: func() error {
+			cut()
+			requireTestSignal(t, owner.retire, "runtime owner did not record retirement")
+			return nil
+		}}
+	}
+	attachment := factoryAttachment{
+		runtime:         runtimeService,
+		handlerAttacher: attacher,
+		scheduler:       newTestScheduler(t),
+	}
+	staged := candidate
+	candidate.attach = func(
+		identity lifecycle.ResourceIdentity,
+		owner *stagedJobOwner,
+	) (constructedJobAttachment, error) {
+		if window == retirementBeforeBind {
+			cut()
+			requireTestSignal(t, owner.done, "retired candidate did not finalize before binding")
+		}
+		return attachment.attach(staged, identity, owner)
+	}
+	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
+	fixture := &preActivationRetirementFixture{
+		prepared: PreparedJob{state: &preparedJobState{
+			id:          identity.ID,
+			generation:  identity.Generation,
+			constructed: candidate,
+			permit:      permit,
+			owner:       owner,
+		}},
+		identity:    identity,
+		owner:       owner,
+		gate:        gate,
+		output:      output,
+		state:       state,
+		tasks:       tasks,
+		attempts:    attempts,
+		wantHandler: window == retirementAfterTransfer,
+	}
+	t.Cleanup(func() {
+		fixture.owner.Reject()
+		require.NoError(t, fixture.shutdown())
+	})
+	return fixture
+}
+
+func (fixture *preActivationRetirementFixture) requireSettled(t *testing.T) {
+	t.Helper()
+	requireTestSignal(t, fixture.owner.done, "retired runtime owner did not finalize")
+	_, writeErr := fixture.gate.Write([]byte("late\n"))
+	require.ErrorIs(t, writeErr, errGenerationOutputFenced)
+	require.Empty(t, fixture.output.Bytes())
+	require.EqualValues(t, 1, fixture.state.rejected)
+	require.Zero(t, fixture.state.final)
+	if fixture.wantHandler {
+		require.EqualValues(t, 1, fixture.state.handlerFinalized)
+	} else {
+		require.Zero(t, fixture.state.handlerFinalized)
+	}
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, fixture.tasks.LongLivedCensus())
+	require.NoError(t, fixture.shutdown())
+	require.EqualValues(t, containment.Census{}, fixture.attempts.Census())
+}
+
+func (fixture *preActivationRetirementFixture) shutdown() error {
+	fixture.shutdownOnce.Do(func() {
+		fixture.attempts.BeginShutdown()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		fixture.shutdownErr = fixture.attempts.Shutdown(ctx)
+	})
+	return fixture.shutdownErr
+}
+
+type preActivationRetirementState struct {
+	rejected         int
+	final            int
+	handlerFinalized int
+}
+
+type preActivationRetirementHandler struct {
+	state *preActivationRetirementState
+}
+
+func (*preActivationRetirementHandler) Publish() error { return nil }
+
+func (*preActivationRetirementHandler) CloseAndDrain(context.Context) error { return nil }
+
+func (*preActivationRetirementHandler) Detach(context.Context) error { return nil }
+
+func (handler *preActivationRetirementHandler) Finalize(context.Context) error {
+	handler.state.handlerFinalized++
+	return nil
+}
+
+type projectionFailureRuntimeService struct {
+	err error
+}
+
+func (service projectionFailureRuntimeService) RegisterComponent(runtimecomp.ComponentConfig) error {
+	return service.err
+}
+
+func (projectionFailureRuntimeService) UnregisterComponent(string) {}
+
+func (projectionFailureRuntimeService) QuarantineComponent(string) {}
+
+func (projectionFailureRuntimeService) FinalizeComponent(string) {}
+
+func (service projectionFailureRuntimeService) RegisterProducer(string, func() error) error {
+	return service.err
+}
+
+func (projectionFailureRuntimeService) UnregisterProducer(string) {}
+
+type projectionHookRuntimeService struct {
+	register func() error
+}
+
+func (service projectionHookRuntimeService) RegisterComponent(runtimecomp.ComponentConfig) error {
+	return service.register()
+}
+
+func (projectionHookRuntimeService) UnregisterComponent(string) {}
+
+func (projectionHookRuntimeService) QuarantineComponent(string) {}
+
+func (projectionHookRuntimeService) FinalizeComponent(string) {}
+
+func (service projectionHookRuntimeService) RegisterProducer(string, func() error) error {
+	return service.register()
+}
+
+func (projectionHookRuntimeService) UnregisterProducer(string) {}
+
+type jobHandlerAttacherFunc func(
+	lifecycle.ResourceIdentity,
+	StagedHandlerLifecycle,
+) (ProcessHandlerLifecycle, error)
+
+func (attach jobHandlerAttacherFunc) Attach(
+	identity lifecycle.ResourceIdentity,
+	staged StagedHandlerLifecycle,
+) (ProcessHandlerLifecycle, error) {
+	return attach(identity, staged)
+}
+
+func requireTestSignal(t *testing.T, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal(message)
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/joboutput/output_gate.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/output_gate.go
@@ -5,6 +5,7 @@ package joboutput
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/jobruntime"
@@ -32,38 +33,43 @@ const (
 type generationOutputGate struct {
 	mu     sync.RWMutex
 	writer FrameWriter
-	state  generationOutputState
+	state  atomic.Uint32
 }
 
 func newGenerationOutputGate(owner *lifecycle.FrameOwner) (*generationOutputGate, error) {
 	if owner == nil {
 		return nil, errors.New("job output: nil generation output owner")
 	}
-	return &generationOutputGate{
-		writer: FrameWriter{Owner: owner},
-		state:  generationOutputInactive,
-	}, nil
+	gate := &generationOutputGate{writer: FrameWriter{Owner: owner}}
+	gate.state.Store(uint32(generationOutputInactive))
+	return gate, nil
 }
 
 func (gog *generationOutputGate) Activate() error {
 	if gog == nil {
 		return errors.New("job output: nil generation output gate")
 	}
-	gog.mu.Lock()
-	defer gog.mu.Unlock()
-	if gog.state != generationOutputInactive {
+	if !gog.state.CompareAndSwap(uint32(generationOutputInactive), uint32(generationOutputActive)) {
 		return errors.New("job output: invalid generation output activation")
 	}
-	gog.state = generationOutputActive
 	return nil
+}
+
+// RevokeAdmissions synchronously rejects future writes without waiting for a
+// write already holding a lease. Fence performs the corresponding drain.
+func (gog *generationOutputGate) RevokeAdmissions() {
+	if gog == nil {
+		return
+	}
+	gog.state.Store(uint32(generationOutputFenced))
 }
 
 func (gog *generationOutputGate) Fence() {
 	if gog == nil {
 		return
 	}
+	gog.RevokeAdmissions()
 	gog.mu.Lock()
-	gog.state = generationOutputFenced
 	gog.mu.Unlock()
 }
 
@@ -71,9 +77,15 @@ func (gog *generationOutputGate) Write(payload []byte) (int, error) {
 	if gog == nil {
 		return 0, errGenerationOutputInactive
 	}
+	switch generationOutputState(gog.state.Load()) {
+	case generationOutputFenced:
+		return 0, errGenerationOutputFenced
+	case generationOutputInactive:
+		return 0, errGenerationOutputInactive
+	}
 	gog.mu.RLock()
 	defer gog.mu.RUnlock()
-	switch gog.state {
+	switch generationOutputState(gog.state.Load()) {
 	case generationOutputActive:
 		return gog.writer.Write(payload)
 	case generationOutputFenced:
@@ -93,9 +105,15 @@ func (gog *generationOutputGate) CommitJobOutput(
 	if gog == nil {
 		return errors.Join(errGenerationOutputInactive, transaction.Abort())
 	}
+	switch generationOutputState(gog.state.Load()) {
+	case generationOutputFenced:
+		return errors.Join(errGenerationOutputFenced, transaction.Abort())
+	case generationOutputInactive:
+		return errors.Join(errGenerationOutputInactive, transaction.Abort())
+	}
 	gog.mu.RLock()
 	defer gog.mu.RUnlock()
-	switch gog.state {
+	switch generationOutputState(gog.state.Load()) {
 	case generationOutputActive:
 		return gog.writer.CommitJobOutput(payload, transaction)
 	case generationOutputFenced:

--- a/src/go/plugin/agent/jobmgr/joboutput/runtime_adapter_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/runtime_adapter_test.go
@@ -318,6 +318,49 @@ func TestGenerationOutputGateAbortsLateTransactionWithoutPoisoningFrameOwner(t *
 	require.Empty(t, output.Bytes())
 }
 
+func TestGenerationOutputGateRevokesAdmissionsBeforeDrain(t *testing.T) {
+	writeEntered := make(chan struct{})
+	releaseWrite := make(chan struct{})
+	owner, err := lifecycle.NewFrameOwner(frameWriteFunc(func(payload []byte) (int, error) {
+		close(writeEntered)
+		<-releaseWrite
+		return len(payload), nil
+	}))
+	require.NoError(t, err)
+	gate, err := newGenerationOutputGate(owner)
+	require.NoError(t, err)
+	require.NoError(t, gate.Activate())
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := gate.Write([]byte("admitted\n"))
+		writeDone <- err
+	}()
+	requireTestSignal(t, writeEntered, "initial output did not acquire its write lease")
+
+	gate.RevokeAdmissions()
+	_, err = gate.Write([]byte("late\n"))
+	require.ErrorIs(t, err, errGenerationOutputFenced)
+
+	drainStarted := make(chan struct{})
+	drainDone := make(chan struct{})
+	go func() {
+		close(drainStarted)
+		gate.Fence()
+		close(drainDone)
+	}()
+	requireTestSignal(t, drainStarted, "output drain did not start")
+	select {
+	case <-drainDone:
+		t.Fatal("output drain completed before the admitted write released its lease")
+	default:
+	}
+
+	close(releaseWrite)
+	require.NoError(t, <-writeDone)
+	requireTestSignal(t, drainDone, "output drain did not finish after the admitted write")
+}
+
 func TestCleanupOutputGateTerminalFenceRejectsLateOutputWithoutPoisoningFrameOwner(t *testing.T) {
 	var output bytes.Buffer
 	owner, err := lifecycle.NewFrameOwner(&output)
@@ -337,6 +380,24 @@ func TestCleanupOutputGateTerminalFenceRejectsLateOutputWithoutPoisoningFrameOwn
 	gate.PoisonOutput(err)
 	require.False(t, owner.Census().Poisoned)
 	require.Equal(t, payload, output.Bytes())
+}
+
+func BenchmarkGenerationOutputGateWrite(b *testing.B) {
+	owner, err := lifecycle.NewFrameOwner(io.Discard)
+	require.NoError(b, err)
+	gate, err := newGenerationOutputGate(owner)
+	require.NoError(b, err)
+	require.NoError(b, gate.Activate())
+	payload := []byte("BEGIN x\nEND\n\n")
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for range b.N {
+		if _, err := gate.Write(payload); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 type recordingFrameState struct {

--- a/src/go/plugin/agent/jobmgr/joboutput/runtime_adapter_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/runtime_adapter_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -321,6 +323,9 @@ func TestGenerationOutputGateAbortsLateTransactionWithoutPoisoningFrameOwner(t *
 func TestGenerationOutputGateRevokesAdmissionsBeforeDrain(t *testing.T) {
 	writeEntered := make(chan struct{})
 	releaseWrite := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseWrite) }) }
+	t.Cleanup(release)
 	owner, err := lifecycle.NewFrameOwner(frameWriteFunc(func(payload []byte) (int, error) {
 		close(writeEntered)
 		<-releaseWrite
@@ -350,15 +355,93 @@ func TestGenerationOutputGateRevokesAdmissionsBeforeDrain(t *testing.T) {
 		close(drainDone)
 	}()
 	requireTestSignal(t, drainStarted, "output drain did not start")
+	requireGenerationGateDrainQueued(t, gate, drainDone)
 	select {
 	case <-drainDone:
 		t.Fatal("output drain completed before the admitted write released its lease")
 	default:
 	}
 
-	close(releaseWrite)
+	release()
 	require.NoError(t, <-writeDone)
 	requireTestSignal(t, drainDone, "output drain did not finish after the admitted write")
+}
+
+func TestGenerationOutputGateRevokesTransactionAdmissionsBeforeDrain(t *testing.T) {
+	writeEntered := make(chan struct{})
+	releaseWrite := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseWrite) }) }
+	t.Cleanup(release)
+	owner, err := lifecycle.NewFrameOwner(frameWriteFunc(func(payload []byte) (int, error) {
+		close(writeEntered)
+		<-releaseWrite
+		return len(payload), nil
+	}))
+	require.NoError(t, err)
+	gate, err := newGenerationOutputGate(owner)
+	require.NoError(t, err)
+	require.NoError(t, gate.Activate())
+
+	var admittedEvents []string
+	admittedDone := make(chan error, 1)
+	go func() {
+		admittedDone <- gate.CommitJobOutput(
+			[]byte("admitted transaction\n"),
+			&recordingFrameState{events: &admittedEvents},
+		)
+	}()
+	requireTestSignal(t, writeEntered, "initial transaction did not acquire its write lease")
+
+	gate.RevokeAdmissions()
+	drainDone := make(chan struct{})
+	go func() {
+		gate.Fence()
+		close(drainDone)
+	}()
+	requireGenerationGateDrainQueued(t, gate, drainDone)
+
+	var lateEvents []string
+	lateDone := make(chan error, 1)
+	go func() {
+		lateDone <- gate.CommitJobOutput(
+			[]byte("late transaction\n"),
+			&recordingFrameState{events: &lateEvents},
+		)
+	}()
+	select {
+	case err = <-lateDone:
+		require.ErrorIs(t, err, errGenerationOutputFenced)
+	case <-time.After(time.Second):
+		t.Fatal("late transaction waited for the admitted transaction to drain")
+	}
+	require.Equal(t, []string{"abort"}, lateEvents)
+
+	release()
+	require.NoError(t, <-admittedDone)
+	require.Equal(t, []string{"commit"}, admittedEvents)
+	requireTestSignal(t, drainDone, "output drain did not finish after the admitted transaction")
+}
+
+func requireGenerationGateDrainQueued(
+	t *testing.T,
+	gate *generationOutputGate,
+	drainDone <-chan struct{},
+) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for gate.mu.TryRLock() {
+		gate.mu.RUnlock()
+		select {
+		case <-drainDone:
+			t.Fatal("output drain completed before its admitted lease released")
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("output drain did not queue for its write lease")
+		}
+		runtime.Gosched()
+	}
 }
 
 func TestCleanupOutputGateTerminalFenceRejectsLateOutputWithoutPoisoningFrameOwner(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/joboutput/runtime_adapter_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/runtime_adapter_test.go
@@ -61,7 +61,7 @@ func TestProcessOwnedJobRetirementDoesNotWaitForPhysicalStop(t *testing.T) {
 	)
 	require.NoError(t, err)
 	attached.outputGate = gate
-	require.NoError(t, owner.Replace(attached))
+	require.NoError(t, owner.AdoptAttachment(attached))
 
 	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
 	require.NoError(t, permit.ActivateExternal())
@@ -111,7 +111,7 @@ func TestProcessOwnedJobRetirementDoesNotWaitForPhysicalStop(t *testing.T) {
 	require.EqualValues(t, 1, cleanups)
 }
 
-func TestProcessOwnedJobCannotAttachAfterTargetRetirementFinalizesCandidate(t *testing.T) {
+func TestProcessOwnedJobAttachmentPreservesTargetRetirementAfterCandidateFinalizes(t *testing.T) {
 	attempts, err := containment.NewAuthority(nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -159,7 +159,12 @@ func TestProcessOwnedJobCannotAttachAfterTargetRetirementFinalizesCandidate(t *t
 		candidate.CollectorCleanup,
 		owner,
 	)
-	require.Error(t, err)
+	require.ErrorIs(t, err, jobmgr.ErrProcessAttemptRetired)
+	require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+		err,
+		jobmgr.ErrProcessAttemptRetired,
+		jobmgr.ErrProcessAttemptStopped,
+	))
 }
 
 func TestStagedJobPromotionDoesNotStartAfterCallerCancellation(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/joboutput/transaction_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/transaction_test.go
@@ -398,10 +398,15 @@ func newRetainedTransactionSuccessor(
 	t.Helper()
 	attempts, err := containment.NewAuthority(nil)
 	require.NoError(t, err)
+	frames, err := lifecycle.NewFrameOwner(io.Discard)
+	require.NoError(t, err)
+	gate, err := newGenerationOutputGate(frames)
+	require.NoError(t, err)
 	candidate := ConstructedJob{
 		Variant:          JobVariantV1,
 		CollectorCleanup: func(context.Context) error { return nil },
 		finalCleanup:     func(context.Context) error { return nil },
+		outputGate:       gate,
 	}
 	owner := newStagedJobOwner(
 		context.Background(),
@@ -417,9 +422,9 @@ func newRetainedTransactionSuccessor(
 	candidate.attach = func(
 		lifecycle.ResourceIdentity,
 		*stagedJobOwner,
-	) (ConstructedJob, error) {
+	) (constructedJobAttachment, error) {
 		if err := owner.BindAttachment(); err != nil {
-			return ConstructedJob{}, err
+			return constructedJobAttachment{}, err
 		}
 		attached := candidate
 		attached.Runtime = transactionTestRuntime{
@@ -427,7 +432,7 @@ func newRetainedTransactionSuccessor(
 			abortErr: abortErr,
 		}
 		attached.processOwner = owner
-		return attached, nil
+		return constructedJobAttachment{resources: attached, transferred: true}, nil
 	}
 	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
 	prepared := PreparedJob{state: &preparedJobState{
@@ -564,7 +569,6 @@ func applyTargetRetirementTransaction(
 	require.NoError(t, err)
 	gate, err := newGenerationOutputGate(frames)
 	require.NoError(t, err)
-	require.NoError(t, gate.Activate())
 
 	var cleanups int
 	candidate := ConstructedJob{
@@ -602,7 +606,7 @@ func applyTargetRetirementTransaction(
 		retired:   owner.retire,
 		detachErr: detachErr,
 	}
-	require.NoError(t, owner.Replace(attached))
+	require.NoError(t, owner.AdoptAttachment(attached))
 
 	permit, tasks := issueTestJobPermit(t, identity.ID, identity.Generation)
 	accepted, err := owner.AcceptResources(permit)

--- a/src/go/plugin/agent/jobmgr/process_attempt.go
+++ b/src/go/plugin/agent/jobmgr/process_attempt.go
@@ -155,10 +155,11 @@ type ProcessAttemptPlan struct {
 	Target   uint64
 	Work     func(context.Context, ProcessAttemptAdmission) error
 
-	// OnContainment is a synchronous pre-settlement fence. It MUST be
-	// non-blocking and MUST NOT re-enter the attempt authority.
-	// Panics are recovered and reported through ErrProcessAttemptFencePanic.
-	OnContainment func()
+	// OnContainment receives the raw cut cause under the attempt-authority lock.
+	// It MUST perform only bounded in-memory work and MUST NOT re-enter the
+	// authority or wait for a worker, I/O, or external cleanup. Panics are
+	// recovered and reported through ErrProcessAttemptFencePanic.
+	OnContainment func(error)
 }
 
 // ProcessAttemptAdmission is the only attempt control available to its worker.


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Settles pre-activation retirement races in `jobmgr` by synchronizing runtime containment and ownership transitions, and by revoking generation output admissions atomically to block late writes. This prevents double-finalization, preserves the first retirement cause, and makes start decisions race-free.

- **Bug Fixes**
  - Containment fence now receives the raw cut cause and runs under the authority lock without blocking.
  - Promotion publishes owner transition before entering the authority; attachment and cleanup are consistently adopted even if retirement wins.
  - Output gate revokes new write admissions immediately and drains existing leases later, preventing interleaving with a successor.
  - Start requests are reserved and rechecked, so managed jobs cannot start after containment.
  - Retirement preserves the first structural failure cause; later cuts don’t overwrite it.
  - Tests expanded with shared attachment fixtures to pin handoff boundaries, drain behavior, and preserve failure attribution; `ARCHITECTURE.md` updated.

- **Migration**
  - `ProcessAttemptPlan.OnContainment` now has signature `func(error)`.
  - `stagedJobOwner.Replace` renamed to `AdoptAttachment`.
  - `ConstructedJob.activateAttachment` renamed to `attachProjections`; `attach` now returns a `constructedJobAttachment` with a `transferred` flag.
  - Resource acceptance activates the generation output gate before permit activation.
  - Use `generationOutputGate.RevokeAdmissions()` to block new writes on retirement, and `Fence()` to drain existing leases.

<sup>Written for commit 31cffb8ee32b73bb9c9fa5c0e680a5f4833016ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

