### PR TITLE
fix: handle alarm log statement preparation

### DIFF
--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -1073,11 +1073,11 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, time_t after, const ch
 {
      unsigned int max = host->health_log.max;
 
-     sqlite3_stmt *stmt_query;
+     sqlite3_stmt *stmt_query = NULL;
 
      int rc;
-
      BUFFER *command = buffer_create(MAX_HEALTH_SQL_SIZE, NULL);
+
      buffer_sprintf(command, SQL_SELECT_HEALTH_LOG);
 
      if (chart)
@@ -1085,13 +1085,12 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, time_t after, const ch
 
      buffer_strcat(command, " ORDER BY hld.unique_id DESC LIMIT @limit");
 
-     rc = PREPARE_STATEMENT(db_meta, buffer_tostring(command), &stmt_query);
-     buffer_free(command);
-
-     if (unlikely(rc != SQLITE_OK)) {
+     if (unlikely(!PREPARE_STATEMENT(db_meta, buffer_tostring(command), &stmt_query))) {
+        buffer_free(command);
         error_report("Failed to prepare statement SQL_SELECT_HEALTH_LOG");
         return;
      }
+     buffer_free(command);
 
      int param = 0;
      rc = sqlite3_bind_blob(stmt_query, ++param, &host->host_id.uuid, sizeof(host->host_id.uuid), SQLITE_STATIC);


### PR DESCRIPTION
## Summary

Fixes #23364.

`PREPARE_STATEMENT()` returns true on success, but `sql_health_alarm_log2json()` was storing that boolean in `rc` and comparing it with `SQLITE_OK` (`0`). That inverted the success path and made `/api/v1/alarm_log` return early after a successful prepare.

This updates the caller to use the same boolean check as the other `PREPARE_STATEMENT()` call sites in `sqlite_health.c`, while keeping the existing bind/step error handling unchanged.

## Testing

- `git diff --check`
- `cmake -S . -B /tmp/oss-pr-pipeline/netdata-23364-build-nogo -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=OFF -DENABLE_PLUGIN_GO=OFF -DENABLE_PLUGIN_IBM=OFF -DENABLE_PLUGIN_SCRIPTS=OFF -DENABLE_PLUGIN_NETFLOW=OFF -DENABLE_PLUGIN_EBPF=OFF -DENABLE_ND_MCP=OFF -DENABLE_PLUGIN_FREEIPMI=OFF -DENABLE_PLUGIN_NFACCT=OFF` *(environment stopped at missing optional `xenstat`; prior dependency checks passed after installing local build prerequisites)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #23364 by correcting the `PREPARE_STATEMENT()` check in `sql_health_alarm_log2json()`, which inverted success/failure and made `/api/v1/alarm_log` return early after a successful prepare. The function now uses the boolean return like other call sites and frees the command buffer in the right place; bind/step error handling is unchanged.

<sup>Written for commit 4adb7a0e8faa672721a63e2dbf518e1f5d0d6092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

