### PR TITLE
fix(go.d/snmp): apply scale factor for arubaWiredTempSensorTemperature

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/aruba-cx-switch.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/aruba-cx-switch.yaml
@@ -33,6 +33,7 @@ metrics:
     symbols:
       - name: arubaWiredTempSensorTemperature
         OID: 1.3.6.1.4.1.47196.4.1.1.3.11.3.1.1.7
+        scale_factor: 0.001
         chart_meta:
           description: Current temperature value read from the temperature sensor
           family: 'Hardware/Sensor/Temperature/Value'


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply a 0.001 scale factor to `arubaWiredTempSensorTemperature` in the Aruba CX SNMP profile to convert milli-degrees to degrees Celsius and fix 1000× inflated readings.

<sup>Written for commit da3d7ad5a639657d6a23cd3034b85d8a2ad60b18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

