### PR TITLE
docs(mcp): describe the account URL field in MCP Connections

### DIFF
--- a/docs/netdata-ai/mcp/mcp-connections.md
+++ b/docs/netdata-ai/mcp/mcp-connections.md
@@ -22,7 +22,9 @@ This is the reverse of connecting an AI client *to* Netdata. Here, **Netdata rea
 
    ![Choose an authentication method](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-auth.png)
 
-4. Provide the required configuration parameters — such as the connection name or account region — then click **Connect & discover tools**.
+4. Provide the required configuration parameters — such as the connection name, or your account URL with the provider — then click **Connect & discover tools**.
+
+   An **account URL** is the address you use to reach the provider, including your organization's subdomain. For PagerDuty that is `https://acme.pagerduty.com`, or `https://acme.eu.pagerduty.com` if your account is hosted in the EU. Netdata derives the correct regional endpoint from it, and refuses the connection if the account you authorize with is not the one configured here.
 
    ![Connection parameters](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-connection.png)
 


### PR DESCRIPTION
##### Summary

Follow-up to #23049. The PagerDuty OAuth integration replaced the admin-selected **region** dropdown with a **PagerDuty account URL** field, so the configuration step on the MCP Connections page described a field that no longer exists.

Step 4 now says "account URL" instead of "account region", and adds a short paragraph explaining what an account URL is — users are unlikely to know the term — with the two forms the field accepts:

- `https://acme.pagerduty.com`
- `https://acme.eu.pagerduty.com` for EU-hosted accounts

It also notes that Netdata derives the regional endpoint from that URL and refuses the connection if the account authorized at the provider is not the one configured.

Screenshots for the connection and authorize steps are replaced in netdata/docs-images#13. The file names are unchanged, so no image URLs change here; this PR is text-only and the two can merge in any order. The other MCP Connections screenshots do not show the changed field and are unaffected.

##### Test Plan

Documentation-only change to `docs/netdata-ai/mcp/mcp-connections.md`. The new paragraph is indented as a continuation of ordered-list item 4, so steps 5 and 6 keep their numbering. Wording verified against the integration schema (field title "PagerDuty account URL" and its accepted examples) and against the backend parser and connection validator.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>

Affects the MCP Connections documentation only. A Space admin configuring the PagerDuty integration now sees instructions matching the UI, and an explanation of which URL to enter, instead of a region selector that was removed.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update MCP Connections docs to match the PagerDuty OAuth UI by replacing the “account region” field with an “account URL” and explaining what to enter. Adds US/EU URL examples and notes that Netdata derives the region from the URL and rejects authorization if it’s for a different account.

<sup>Written for commit faa1d2a56d43c0ed2190b15d542ebcafde087438. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

