### PR TITLE
fix: update time format to use int64_t for consistency in logging

### DIFF
--- a/src/streaming/stream-parents.c
+++ b/src/streaming/stream-parents.c
@@ -544,11 +544,11 @@ static bool stream_info_fetch(STREAM_PARENT *d, const char *uuid, int default_po
 
     nd_log(NDLS_DAEMON, NDLP_DEBUG,
            "STREAM PARENTS '%s': received stream_info data from '%s': "
-           "status: %d, nodes: %zu, receivers: %zu, first_time_s: %ld, last_time_s: %ld, "
+           "status: %d, nodes: %zu, receivers: %zu, first_time_s: %" PRId64 ", last_time_s: %" PRId64 ", "
            "db status: %s, db liveness: %s, ingest type: %s, ingest status: %s",
            hostname, string2str(d->destination),
            d->remote.status, d->remote.nodes, d->remote.receivers,
-           d->remote.db_first_time_s, d->remote.db_last_time_s,
+           (int64_t)d->remote.db_first_time_s, (int64_t)d->remote.db_last_time_s,
            RRDHOST_DB_STATUS_2str(d->remote.db_status),
            RRDHOST_DB_LIVENESS_2str(d->remote.db_liveness),
            RRDHOST_INGEST_TYPE_2str(d->remote.ingest_type),
@@ -636,10 +636,10 @@ bool stream_parent_connect_to_one_unsafe(
             potential++;
             host->stream.snd.status.reason = d->reason;
             nd_log(NDLS_DAEMON, NDLP_DEBUG,
-                   "STREAM PARENTS '%s': skipping useful parent '%s': POSTPONED FOR %ld SECS MORE: %s",
+                   "STREAM PARENTS '%s': skipping useful parent '%s': POSTPONED FOR %" PRId64 " SECS MORE: %s",
                    rrdhost_hostname(host),
                    string2str(d->destination),
-                   (time_t)((d->postpone_until_ut - now_ut) / USEC_PER_SEC),
+                   (int64_t)((d->postpone_until_ut - now_ut) / USEC_PER_SEC),
                    stream_handshake_error_to_string(d->reason));
             continue;
         }

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -1074,10 +1074,10 @@ void stream_receiver_check_all_nodes_from_poll(struct stream_thread *sth, usec_t
                 size_snprintf(pending, sizeof(pending), stats.bytes_outstanding, "B", false);
 
             nd_log(NDLS_DAEMON, NDLP_ERR,
-                   "STREAM RCV[%zu] '%s' [from %s]: there was not traffic for %ld seconds - closing connection - "
+                   "STREAM RCV[%zu] '%s' [from %s]: there was not traffic for %" PRId64 " seconds - closing connection - "
                    "we have sent %zu bytes in %zu operations, it is idle for %s, and we have %s pending to send "
                    "(buffer is used %.2f%%).",
-                   sth->id, rrdhost_hostname(rpt->host), rpt->remote_ip, timeout_s,
+                   sth->id, rrdhost_hostname(rpt->host), rpt->remote_ip, (int64_t)timeout_s,
                    stats.bytes_sent, stats.sends, duration, pending, stats.buffer_ratio);
 
             stream_receiver_remove(sth, rpt, STREAM_HANDSHAKE_DISCONNECT_TIMEOUT);

--- a/src/streaming/stream-replication-receiver.c
+++ b/src/streaming/stream-replication-receiver.c
@@ -50,19 +50,19 @@ static void replicate_log_request(struct replication_request_details *r, const c
     nd_log_limit(&erl, NDLS_DAEMON, NDLP_NOTICE,
 #endif
                    "STREAM SND REPLAY ERROR: 'host:%s/chart:%s' child sent: "
-                   "db from %ld to %ld%s, wall clock time %ld, "
-                   "last request from %ld to %ld, "
+                   "db from %" PRId64 " to %" PRId64 "%s, wall clock time %" PRId64 ", "
+                   "last request from %" PRId64 " to %" PRId64 ", "
                    "issue: %s - "
-                   "sending replication request from %ld to %ld, start streaming %s",
+                   "sending replication request from %" PRId64 " to %" PRId64 ", start streaming %s",
                    rrdhost_hostname(r->st->rrdhost), rrdset_id(r->st),
-                   r->child_db.first_entry_t,
-                   r->child_db.last_entry_t, r->child_db.fixed_last_entry ? " (fixed)" : "",
-                   r->child_db.wall_clock_time,
-                   r->last_request.after,
-                   r->last_request.before,
+                   (int64_t)r->child_db.first_entry_t,
+                   (int64_t)r->child_db.last_entry_t, r->child_db.fixed_last_entry ? " (fixed)" : "",
+                   (int64_t)r->child_db.wall_clock_time,
+                   (int64_t)r->last_request.after,
+                   (int64_t)r->last_request.before,
                    msg,
-                   r->wanted.after,
-                   r->wanted.before,
+                   (int64_t)r->wanted.after,
+                   (int64_t)r->wanted.before,
                    r->wanted.start_streaming ? "true" : "false");
 }
 
@@ -87,19 +87,20 @@ static bool send_replay_chart_cmd(struct replication_request_details *r, const c
         log_date(wanted_before_buf, LOG_DATE_LENGTH, r->wanted.before);
 
     internal_error(true,
-                   "STREAM SND REPLAY: 'host:%s/chart:%s' sending replication request %ld [%s] to %ld [%s], start streaming '%s': %s: "
-                   "last[%ld - %ld] child[%ld - %ld, now %ld %s] local[%ld - %ld, now %ld] gap[%ld - %ld %s] %s"
+                   "STREAM SND REPLAY: 'host:%s/chart:%s' sending replication request %" PRId64 " [%s] to %" PRId64 " [%s], start streaming '%s': %s: "
+                   "last[%" PRId64 " - %" PRId64 "] child[%" PRId64 " - %" PRId64 ", now %" PRId64 " %s] "
+                   "local[%" PRId64 " - %" PRId64 ", now %" PRId64 "] gap[%" PRId64 " - %" PRId64 " %s] %s"
                    , rrdhost_hostname(r->host), rrdset_id(r->st)
-                       , r->wanted.after, wanted_after_buf
-                   , r->wanted.before, wanted_before_buf
+                       , (int64_t)r->wanted.after, wanted_after_buf
+                   , (int64_t)r->wanted.before, wanted_before_buf
                    , r->wanted.start_streaming ? "YES" : "NO"
                    , msg
-                   , r->last_request.after, r->last_request.before
-                   , r->child_db.first_entry_t, r->child_db.last_entry_t
-                   , r->child_db.wall_clock_time, (r->child_db.wall_clock_time == r->local_db.wall_clock_time) ? "SAME" : (r->child_db.wall_clock_time < r->local_db.wall_clock_time) ? "BEHIND" : "AHEAD"
-                   , r->local_db.first_entry_t, r->local_db.last_entry_t
-                   , r->local_db.wall_clock_time
-                   , r->gap.from, r->gap.to
+                   , (int64_t)r->last_request.after, (int64_t)r->last_request.before
+                   , (int64_t)r->child_db.first_entry_t, (int64_t)r->child_db.last_entry_t
+                   , (int64_t)r->child_db.wall_clock_time, (r->child_db.wall_clock_time == r->local_db.wall_clock_time) ? "SAME" : (r->child_db.wall_clock_time < r->local_db.wall_clock_time) ? "BEHIND" : "AHEAD"
+                   , (int64_t)r->local_db.first_entry_t, (int64_t)r->local_db.last_entry_t
+                   , (int64_t)r->local_db.wall_clock_time
+                   , (int64_t)r->gap.from, (int64_t)r->gap.to
                    , (r->gap.from == r->wanted.after) ? "FULL" : "PARTIAL"
                    , (st->replay.after != 0 || st->replay.before != 0) ? "OVERLAPPING" : ""
     );

--- a/src/streaming/stream-replication-sender.c
+++ b/src/streaming/stream-replication-sender.c
@@ -419,17 +419,17 @@ static bool replication_query_execute(BUFFER *wb, struct replication_query *q, s
             nd_log_limit_static_global_var(erl, 1, 0);
             nd_log_limit(&erl,  NDLS_DAEMON, NDLP_WARNING,
                          "STREAM SND REPLAY WARNING: 'host:%s/chart:%s' misaligned dimensions, "
-                         "update every (min: %ld, max: %ld), "
-                         "start time (min: %ld, max: %ld), "
-                         "end time (min %ld, max %ld), "
-                         "now %ld, last end time sent %ld, "
-                         "min start time is fixed to %ld",
+                         "update every (min: %" PRId64 ", max: %" PRId64 "), "
+                         "start time (min: %" PRId64 ", max: %" PRId64 "), "
+                         "end time (min %" PRId64 ", max %" PRId64 "), "
+                         "now %" PRId64 ", last end time sent %" PRId64 ", "
+                         "min start time is fixed to %" PRId64,
                         rrdhost_hostname(q->st->rrdhost), rrdset_id(q->st),
-                        min_update_every, max_update_every,
-                        min_start_time, max_start_time,
-                        min_end_time, max_end_time,
-                        now, last_end_time_in_buffer,
-                        fix_min_start_time
+                        (int64_t)min_update_every, (int64_t)max_update_every,
+                        (int64_t)min_start_time, (int64_t)max_start_time,
+                        (int64_t)min_end_time, (int64_t)max_end_time,
+                        (int64_t)now, (int64_t)last_end_time_in_buffer,
+                        (int64_t)fix_min_start_time
                         );
 #endif
 
@@ -467,10 +467,11 @@ static bool replication_query_execute(BUFFER *wb, struct replication_query *q, s
                     true,
                     "STREAM SND REPLAY: current remaining sender buffer of %zu bytes cannot fit the "
                     "message size %zu bytes for chart '%s' of host '%s'. "
-                    "Sending partial replication response %ld to %ld, %s (original: %ld to %ld, %s).",
+                    "Sending partial replication response %" PRId64 " to %" PRId64 ", %s "
+                    "(original: %" PRId64 " to %" PRId64 ", %s).",
                     buffer_strlen(wb), max_msg_size, rrdset_id(q->st), rrdhost_hostname(q->st->rrdhost),
-                    q->query.after, q->query.before, q->query.enable_streaming?"true":"false",
-                    q->request.after, q->request.before, q->request.enable_streaming?"true":"false");
+                    (int64_t)q->query.after, (int64_t)q->query.before, q->query.enable_streaming?"true":"false",
+                    (int64_t)q->request.after, (int64_t)q->request.before, q->request.enable_streaming?"true":"false");
 
                 q->query.interrupted = true;
 
@@ -1045,8 +1046,8 @@ static void replication_sort_entry_del(struct replication_request *rq, bool buff
         }
 
         if (!rse_to_delete)
-            fatal("STREAM SND REPLAY: 'host:%s/chart:%s' Cannot find sort entry to delete for time %ld.",
-                  rrdhost_hostname(rq->sender->host), string2str(rq->chart_id), rq->after);
+            fatal("STREAM SND REPLAY: 'host:%s/chart:%s' Cannot find sort entry to delete for time %" PRId64 ".",
+                  rrdhost_hostname(rq->sender->host), string2str(rq->chart_id), (int64_t)rq->after);
 
     }
 

--- a/src/streaming/stream-sender.c
+++ b/src/streaming/stream-sender.c
@@ -545,10 +545,10 @@ void stream_sender_check_all_nodes_from_poll(struct stream_thread *sth, usec_t n
                 size_snprintf(pending, sizeof(pending), stats.bytes_outstanding, "B", false);
 
             nd_log(NDLS_DAEMON, NDLP_ERR,
-                   "STREAM SND[%zu] '%s' [to %s]: there was not traffic for %ld seconds - closing connection - "
+                   "STREAM SND[%zu] '%s' [to %s]: there was not traffic for %" PRId64 " seconds - closing connection - "
                    "we have sent %zu bytes in %zu operations, it is idle for %s, and we have %s pending to send "
                    "(buffer is used %.2f%%).",
-                   sth->id, rrdhost_hostname(s->host), s->remote_ip, stream_send.parents.timeout_s,
+                   sth->id, rrdhost_hostname(s->host), s->remote_ip, (int64_t)stream_send.parents.timeout_s,
                    stats.bytes_sent, stats.sends,
                    duration, pending, stats.buffer_ratio);
 


### PR DESCRIPTION
##### Summary
- Fix SIGSEGV in streaming on 32-bit platforms: time_t values were formatted with %ld, which desynchronizes varargs on ILP32 (where long is 32-bit but time_t is 64-bit) and makes %s dereference a byte counter as a pointer 
  - switch all 9 affected sites in src/streaming/ to %" PRId64 " with an (int64_t) cast.


