### PR TITLE
feat(go.d/prometheus): add profile-owned metric relabeling

### DIFF
--- a/.agents/skills/project-writing-collectors/SKILL.md
+++ b/.agents/skills/project-writing-collectors/SKILL.md
@@ -395,10 +395,18 @@ The generic Prometheus scraper (`src/go/plugin/go.d/collector/prometheus/`) auto
 Operator controls (profiles documented in `src/go/plugin/go.d/collector/prometheus/profile-format.md`, relabeling in
 `src/go/plugin/go.d/collector/prometheus/relabel/README.md`):
 
-- **Scoping**: the time-series `selector` job option (allow/deny on metric name and label values, syntax in `src/go/pkg/prometheus/selector/README.md`) and `fallback_type` glob patterns for untyped metrics.
-- **Shaping**: the job-level `relabeling` option (Prometheus-compatible `metric_relabel_configs`; it replaced
-  the removed `label_prefix`) renames metrics and rewrites labels before charts are built. **Chart profiles**
-  (`match`/`app`/`autogen.selector`/`template` YAMLs, stock under
+- **Scoping**: the time-series `selector` job option (allow/deny on metric name and label values, syntax in
+  `src/go/pkg/prometheus/selector/README.md`) and `fallback_type` glob patterns for untyped metrics.
+- **Shaping**: job-level `relabeling` is operator policy and runs before profile selection. Profile-root `relabeling`
+  uses the same Prometheus-compatible block/rule format after selection and owns stable exporter normalization required
+  by that profile's charts. Do not duplicate profile-required normalization as an optional job recipe.
+- **Ordering**: the fixed namespace lifecycle is `selector -> job relabeling/safety -> fallback type + profile
+  selection -> selected profile relabeling/safety -> final gates -> charts`. A profile cannot normalize itself into
+  selection. Untyped classification is bound before profile relabeling, so a final rename cannot create or change it.
+- **Profile ownership**: selected profile relabel pipelines are not chained. A source family must have at most one
+  matching owner, and every output family must remain inside that profile's root `match`; overlaps or scope escapes are
+  configuration defects, not catalog-order precedence.
+- **Charts**: chart profiles (`match`/`app`/`relabeling`/`autogen.selector`/`template` YAMLs, stock under
   `src/go/plugin/go.d/config/go.d/prometheus.profiles/default/`, user under
   `/etc/netdata/go.d/prometheus.profiles/`) ship curated per-exporter dashboards — the Prometheus analog of
   statsd `synthetic_charts`. Metrics not covered by an authored profile chart keep their autogen charts unless an
@@ -435,8 +443,9 @@ A collector is *production-quality* when it satisfies all of:
 8. For remote targets: is vnode wiring done?
 9. For SNMP: did I extend a profile rather than hardcode OIDs?
 10. For statsd / OTEL: did I document and ship the operator-side config (synthetic_charts file or OTEL mapping YAML)?
-11. For Prometheus scraping: are selectors and relabeling rules correct? Are untyped metrics handled? Should the
-    exporter get a stock chart profile (`profile-format.md`), and should that profile suppress unmatched fallback
+11. For Prometheus scraping: are selectors and job relabeling correct? Is exporter-required normalization owned by the
+    profile instead of duplicated in job examples? Are untyped metrics handled before profile normalization? Should
+    the exporter get a stock chart profile (`profile-format.md`), and should that profile suppress unmatched fallback
     charts with a scoped `autogen.selector` while retaining their samples?
 12. For cross-plugin enrichment: am I using netipc?
 13. For Functions: does the response conform to one of the six shapes? Non-blocking with respect to the collection loop? Schema-validated?

--- a/.agents/skills/project-writing-collectors/SKILL.md
+++ b/.agents/skills/project-writing-collectors/SKILL.md
@@ -403,9 +403,12 @@ Operator controls (profiles documented in `src/go/plugin/go.d/collector/promethe
 - **Ordering**: the fixed namespace lifecycle is `selector -> job relabeling/safety -> fallback type + profile
   selection -> selected profile relabeling/safety -> final gates -> charts`. A profile cannot normalize itself into
   selection. Untyped classification is bound before profile relabeling, so a final rename cannot create or change it.
-- **Profile ownership**: selected profile relabel pipelines are not chained. A source family must have at most one
-  matching owner, and every output family must remain inside that profile's root `match`; overlaps or scope escapes are
-  configuration defects, not catalog-order precedence.
+- **Profile precedence**: selected profiles share one final metric stream. For each original source family, only the
+  first applicable selected profile's complete pipeline runs; later profiles do not see that family or names produced by
+  the first pipeline. Precedence is profile-name order in `auto`, configured entry order in `exact`, and configured
+  entries followed by the remaining name-ordered auto profiles in `combined`. Root `match` and block matchers classify
+  original source names; rule results and output names do not affect dispatch. All selected templates consume the final
+  names and labels, so authors must account for cross-profile interactions.
 - **Charts**: chart profiles (`match`/`app`/`relabeling`/`autogen.selector`/`template` YAMLs, stock under
   `src/go/plugin/go.d/config/go.d/prometheus.profiles/default/`, user under
   `/etc/netdata/go.d/prometheus.profiles/`) ship curated per-exporter dashboards — the Prometheus analog of

--- a/src/go/plugin/go.d/collector/prometheus/chart_template_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/chart_template_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
@@ -188,6 +189,40 @@ http_request_duration_seconds_count 4
 	assert.Equal(t, "heatmap", string(created[0].Meta.Type))
 	assert.NotContains(t, created[0].ChartID, "_sum")
 	assert.NotContains(t, created[0].ChartID, "_count")
+}
+
+func TestBuildMergedChartTemplateCrossNamespaceRenameLeavesProfileAutogenScope(t *testing.T) {
+	profile := testRelabelProfilePatternYAML("app_*", "app_raw", "app_raw", "other_final", "app_never")
+	profile = strings.Replace(profile, "template:\n", `autogen:
+  selector:
+    deny: ["*"]
+template:
+`, 1)
+	catalog := loadTestCatalog(t, map[string]string{"app": profile})
+	collector, srv := newProfileRelabelCollector(t, catalog, "# TYPE app_raw gauge\napp_raw 1\n", "app")
+	defer srv.Close()
+	require.NoError(t, collector.Init(context.Background()))
+	require.NoError(t, collector.Check(context.Background()))
+	collectProfileRelabelOnce(t, collector)
+
+	reader := collector.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 1, value(t, reader, "other_final", nil), 1e-9)
+
+	engine, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, engine.LoadYAML([]byte(collector.ChartTemplateYAML()), 1))
+	attempt, err := engine.PreparePlan(reader)
+	require.NoError(t, err)
+	defer attempt.Abort()
+
+	var created []chartengine.CreateChartAction
+	for _, action := range attempt.Plan().Actions {
+		if create, ok := action.(chartengine.CreateChartAction); ok {
+			created = append(created, create)
+		}
+	}
+	require.Len(t, created, 1)
+	assert.Equal(t, "prometheus.other_final", created[0].Meta.Context)
 }
 
 func TestBuildMergedChartTemplateAggregatesProjectedPrometheusSeries(t *testing.T) {

--- a/src/go/plugin/go.d/collector/prometheus/collect.go
+++ b/src/go/plugin/go.d/collector/prometheus/collect.go
@@ -54,9 +54,11 @@ func (c *Collector) check(ctx context.Context) error {
 			return fmt.Errorf("'%s' num of time series (%d) > limit (%d)", c.URL, n, c.MaxTS)
 		}
 	}
-	writable := c.writer.countWritable(mfs)
+	var writable int
 	if typesBound {
 		writable = c.writer.countBoundWritable(mfs)
+	} else {
+		writable = c.writer.countWritable(mfs)
 	}
 	if writable == 0 {
 		return fmt.Errorf("endpoint '%s' exposes no usable metrics", c.URL)
@@ -98,9 +100,6 @@ func (c *Collector) checkRuntimeCandidate(ctx context.Context) (*promRuntime, pr
 	if err != nil {
 		return nil, nil, false, err
 	}
-	// Bind job-owned fallback policy on post-job names before profile selection
-	// and normalization. It is used only if a selected profile relabels samples.
-	c.writer.bindFallbackTypes(&postJob)
 	if err := c.validateNonEmpty(postJobFamilies); err != nil {
 		return nil, nil, false, err
 	}
@@ -121,6 +120,10 @@ func (c *Collector) checkRuntimeCandidate(ctx context.Context) (*promRuntime, pr
 		return candidate, postJobFamilies, false, nil
 	}
 
+	// Bind job-owned fallback policy on post-job names before profile
+	// normalization. Jobs without an active normalizer keep normal type
+	// resolution on the assembled families.
+	c.writer.bindFallbackTypes(&postJob)
 	finalFamilies, err := c.profileRelabelAndAssemble(postJob, candidate.normalizers, true)
 	if err != nil {
 		return nil, nil, false, err

--- a/src/go/plugin/go.d/collector/prometheus/collect.go
+++ b/src/go/plugin/go.d/collector/prometheus/collect.go
@@ -121,7 +121,7 @@ func (c *Collector) checkRuntimeCandidate(ctx context.Context) (*promRuntime, pr
 		return candidate, postJobFamilies, false, nil
 	}
 
-	_, finalFamilies, err := c.profileRelabelAndAssemble(postJob, candidate.normalizers, true)
+	finalFamilies, err := c.profileRelabelAndAssemble(postJob, candidate.normalizers, true)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -141,13 +141,13 @@ func (c *Collector) scrapeProfileNormalized(
 		return nil, err
 	}
 	if c.jobRelabel != nil {
-		batch, _, err = c.relabelAndAssemble(batch, c.jobRelabel, jobRelabelStage, checking)
+		batch, err = c.relabelAndValidateBatch(batch, c.jobRelabel, jobRelabelStage, checking)
 		if err != nil {
 			return nil, err
 		}
 	}
 	c.writer.bindFallbackTypes(&batch)
-	_, mfs, err := c.profileRelabelAndAssemble(batch, normalizers, checking)
+	mfs, err := c.profileRelabelAndAssemble(batch, normalizers, checking)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/plugin/go.d/collector/prometheus/collect.go
+++ b/src/go/plugin/go.d/collector/prometheus/collect.go
@@ -112,7 +112,8 @@ func (c *Collector) checkRuntimeCandidate(ctx context.Context) (*promRuntime, pr
 	if err != nil {
 		return nil, nil, false, err
 	}
-	candidate.normalizers, err = compileProfileNormalizers(candidate.profiles)
+	normalizationOrder := profilesInNormalizationOrder(candidate.profiles, c.Profiles)
+	candidate.normalizers, err = compileProfileNormalizers(normalizationOrder)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/src/go/plugin/go.d/collector/prometheus/collect.go
+++ b/src/go/plugin/go.d/collector/prometheus/collect.go
@@ -14,11 +14,30 @@ import (
 // store cycle (begin/commit) is driven by the framework around Collect, so this only
 // writes observations and returns an error to abort the cycle.
 func (c *Collector) collect(ctx context.Context) error {
-	mfs, err := c.scrape(ctx, false)
+	runtime := c.runtime
+	if runtime == nil {
+		return fmt.Errorf("prometheus collector runtime is unavailable: successful Check is required before Collect")
+	}
+
+	var (
+		mfs        prometheus.MetricFamilies
+		typesBound bool
+		err        error
+	)
+	if len(runtime.normalizers) == 0 {
+		mfs, err = c.scrape(ctx, false)
+	} else {
+		mfs, err = c.scrapeProfileNormalized(ctx, runtime.normalizers, false)
+		typesBound = true
+	}
 	if err != nil {
 		return err
 	}
-	c.writer.writeMetricFamilies(mfs)
+	if typesBound {
+		c.writer.writeBoundMetricFamilies(mfs)
+	} else {
+		c.writer.writeMetricFamilies(mfs)
+	}
 	return nil
 }
 
@@ -26,25 +45,115 @@ func (c *Collector) collect(ctx context.Context) error {
 // the expected-prefix guard and the total time-series limit. Unlike V1 these are read-only
 // (V1 mutated Config to make them one-shot); they run only at Check, i.e. autodetection.
 func (c *Collector) check(ctx context.Context) error {
-	mfs, err := c.scrape(ctx, true)
+	candidate, mfs, typesBound, err := c.checkRuntimeCandidate(ctx)
 	if err != nil {
 		return err
-	}
-	if c.ExpectedPrefix != "" && !hasPrefix(mfs, c.ExpectedPrefix) {
-		return fmt.Errorf("'%s' metrics have no expected prefix (%s)", c.URL, c.ExpectedPrefix)
 	}
 	if c.MaxTS > 0 {
 		if n := calcMetrics(mfs); n > c.MaxTS {
 			return fmt.Errorf("'%s' num of time series (%d) > limit (%d)", c.URL, n, c.MaxTS)
 		}
 	}
-	if c.writer.countWritable(mfs) == 0 {
+	writable := c.writer.countWritable(mfs)
+	if typesBound {
+		writable = c.writer.countBoundWritable(mfs)
+	}
+	if writable == 0 {
 		return fmt.Errorf("endpoint '%s' exposes no usable metrics", c.URL)
 	}
-	if err := c.ensureChartTemplate(mfs); err != nil {
+	tmpl, err := buildMergedChartTemplate(c.resolveApp(candidate.profiles), candidate.profiles)
+	if err != nil {
 		return err
 	}
+	candidate.chartTemplate = tmpl
+	c.runtime = candidate
 	return nil
+}
+
+func (c *Collector) checkRuntimeCandidate(ctx context.Context) (*promRuntime, prometheus.MetricFamilies, bool, error) {
+	candidate := &promRuntime{}
+	if c.Profiles.effectiveMode() == profilesModeNone {
+		mfs, err := c.scrape(ctx, true)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		if err := c.validateExpectedPrefix(mfs); err != nil {
+			return nil, nil, false, err
+		}
+		return candidate, mfs, false, nil
+	}
+
+	batch, err := c.prom.ScrapeSamples(ctx)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	postJob := batch
+	var postJobFamilies prometheus.MetricFamilies
+	if c.jobRelabel == nil {
+		postJobFamilies, err = prometheus.Assemble(postJob)
+	} else {
+		postJob, postJobFamilies, err = c.relabelAndAssemble(postJob, c.jobRelabel, jobRelabelStage, true)
+	}
+	if err != nil {
+		return nil, nil, false, err
+	}
+	// Bind job-owned fallback policy on post-job names before profile selection
+	// and normalization. It is used only if a selected profile relabels samples.
+	c.writer.bindFallbackTypes(&postJob)
+	if err := c.validateNonEmpty(postJobFamilies); err != nil {
+		return nil, nil, false, err
+	}
+	if err := c.validateExpectedPrefix(postJobFamilies); err != nil {
+		return nil, nil, false, err
+	}
+
+	candidate.profiles, err = c.selectProfiles(postJobFamilies)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	candidate.normalizers, err = compileProfileNormalizers(candidate.profiles)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if len(candidate.normalizers) == 0 {
+		return candidate, postJobFamilies, false, nil
+	}
+
+	_, finalFamilies, err := c.profileRelabelAndAssemble(postJob, candidate.normalizers, true)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if err := c.validateNonEmpty(finalFamilies); err != nil {
+		return nil, nil, false, err
+	}
+	return candidate, finalFamilies, true, nil
+}
+
+func (c *Collector) scrapeProfileNormalized(
+	ctx context.Context,
+	normalizers []profileNormalizer,
+	checking bool,
+) (prometheus.MetricFamilies, error) {
+	batch, err := c.prom.ScrapeSamples(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if c.jobRelabel != nil {
+		batch, _, err = c.relabelAndAssemble(batch, c.jobRelabel, jobRelabelStage, checking)
+		if err != nil {
+			return nil, err
+		}
+	}
+	c.writer.bindFallbackTypes(&batch)
+	_, mfs, err := c.profileRelabelAndAssemble(batch, normalizers, checking)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.validateNonEmpty(mfs); err != nil {
+		return nil, err
+	}
+	return mfs, nil
 }
 
 // scrape fetches the endpoint and enforces the empty-scrape contract: an empty scrape is
@@ -55,10 +164,24 @@ func (c *Collector) scrape(ctx context.Context, checking bool) (prometheus.Metri
 	if err != nil {
 		return nil, err
 	}
-	if mfs.Len() == 0 {
-		return nil, fmt.Errorf("endpoint '%s' returned 0 metric families", c.URL)
+	if err := c.validateNonEmpty(mfs); err != nil {
+		return nil, err
 	}
 	return mfs, nil
+}
+
+func (c *Collector) validateNonEmpty(mfs prometheus.MetricFamilies) error {
+	if mfs.Len() == 0 {
+		return fmt.Errorf("endpoint '%s' returned 0 metric families", c.URL)
+	}
+	return nil
+}
+
+func (c *Collector) validateExpectedPrefix(mfs prometheus.MetricFamilies) error {
+	if c.ExpectedPrefix != "" && !hasPrefix(mfs, c.ExpectedPrefix) {
+		return fmt.Errorf("'%s' metrics have no expected prefix (%s)", c.URL, c.ExpectedPrefix)
+	}
+	return nil
 }
 
 // scrapeMetricFamilies fetches and assembles. With no relabel rules it uses the direct,
@@ -74,7 +197,8 @@ func (c *Collector) scrapeMetricFamilies(ctx context.Context, checking bool) (pr
 	if err != nil {
 		return nil, err
 	}
-	return c.relabelAndAssemble(batch, checking)
+	_, mfs, err := c.relabelAndAssemble(batch, c.jobRelabel, jobRelabelStage, checking)
+	return mfs, err
 }
 
 func hasPrefix(mfs prometheus.MetricFamilies, prefix string) bool {

--- a/src/go/plugin/go.d/collector/prometheus/collect.go
+++ b/src/go/plugin/go.d/collector/prometheus/collect.go
@@ -66,7 +66,7 @@ func (c *Collector) scrape(ctx context.Context, checking bool) (prometheus.Metri
 // classified sample stream and runs the relabel pipeline (relabel, assemble, curate typed
 // families) in relabelAndAssemble.
 func (c *Collector) scrapeMetricFamilies(ctx context.Context, checking bool) (prometheus.MetricFamilies, error) {
-	if len(c.relabelBlocks) == 0 {
+	if c.jobRelabel == nil {
 		return c.prom.ScrapeContext(ctx)
 	}
 

--- a/src/go/plugin/go.d/collector/prometheus/collector.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/web"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
 
 //go:embed "config_schema.json"
@@ -51,11 +52,11 @@ type Collector struct {
 	collectorapi.Base
 	Config `yaml:",inline" json:""`
 
-	prom          prometheus.Prometheus
-	relabelBlocks []relabelBlock
-	store         metrix.CollectorStore
-	writer        *metricFamilyWriter
-	runtime       *promRuntime
+	prom       prometheus.Prometheus
+	jobRelabel *relabel.Pipeline
+	store      metrix.CollectorStore
+	writer     *metricFamilyWriter
+	runtime    *promRuntime
 
 	// loadProfileCatalog resolves the profile catalog; a field so tests inject a fake.
 	loadProfileCatalog func() (promprofiles.Catalog, error)
@@ -78,11 +79,11 @@ func (c *Collector) Init(context.Context) error {
 
 	// With no relabeling blocks the scrape keeps the direct, no-buffering Scrape fast
 	// path; invalid rules or match patterns fail Init here.
-	blocks, err := c.initRelabelBlocks()
+	pipeline, err := relabel.NewPipeline(c.Relabeling)
 	if err != nil {
 		return fmt.Errorf("init relabeling: %v", err)
 	}
-	c.relabelBlocks = blocks
+	c.jobRelabel = pipeline
 
 	gaugeFallback, err := c.initFallbackTypeMatcher(c.FallbackType.Gauge)
 	if err != nil {

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -64,7 +64,7 @@ func TestCollector_Init(t *testing.T) {
 			wantFail: false,
 			config: Config{
 				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
-				Relabeling: []RelabelBlock{{
+				Relabeling: []relabel.Block{{
 					Match:                "app_*",
 					MetricRelabelConfigs: []relabel.Config{{SourceLabels: []string{"__name__"}, Regex: relabel.MustNewRegexp("x"), Action: relabel.Drop}},
 				}},
@@ -74,7 +74,7 @@ func TestCollector_Init(t *testing.T) {
 			wantFail: true,
 			config: Config{
 				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
-				Relabeling: []RelabelBlock{{
+				Relabeling: []relabel.Block{{
 					Match:                "[a-",
 					MetricRelabelConfigs: []relabel.Config{{SourceLabels: []string{"__name__"}, Regex: relabel.MustNewRegexp("x"), Action: relabel.Drop}},
 				}},
@@ -84,21 +84,21 @@ func TestCollector_Init(t *testing.T) {
 			wantFail: true,
 			config: Config{
 				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
-				Relabeling: []RelabelBlock{{Match: "*", MetricRelabelConfigs: []relabel.Config{{Action: "bogus"}}}},
+				Relabeling: []relabel.Block{{Match: "*", MetricRelabelConfigs: []relabel.Config{{Action: "bogus"}}}},
 			},
 		},
 		"relabeling block with no match": {
 			wantFail: true,
 			config: Config{
 				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
-				Relabeling: []RelabelBlock{{MetricRelabelConfigs: []relabel.Config{{SourceLabels: []string{"__name__"}, Regex: relabel.MustNewRegexp("x"), Action: relabel.Drop}}}},
+				Relabeling: []relabel.Block{{MetricRelabelConfigs: []relabel.Config{{SourceLabels: []string{"__name__"}, Regex: relabel.MustNewRegexp("x"), Action: relabel.Drop}}}},
 			},
 		},
 		"relabeling block with no rules": {
 			wantFail: true,
 			config: Config{
 				HTTPConfig: web.HTTPConfig{RequestConfig: web.RequestConfig{URL: "http://127.0.0.1:9090/metric"}},
-				Relabeling: []RelabelBlock{{Match: "app_*"}},
+				Relabeling: []relabel.Block{{Match: "app_*"}},
 			},
 		},
 		"profiles mode none": {
@@ -461,7 +461,7 @@ test_gauge_metric{label1="value2"} 12
 		"relabel applies before assembly (drop + rename via __name__)": {
 			prepare: func() *Collector {
 				c := New()
-				c.Relabeling = []RelabelBlock{{Match: "*", MetricRelabelConfigs: []relabel.Config{
+				c.Relabeling = []relabel.Block{{Match: "*", MetricRelabelConfigs: []relabel.Config{
 					{
 						SourceLabels: []string{"__name__"},
 						Regex:        relabel.MustNewRegexp("test_drop_me"),
@@ -496,7 +496,7 @@ test_drop_me{label1="value1"} 22
 		"relabel rewrites a regular label (copy via Replace)": {
 			prepare: func() *Collector {
 				c := New()
-				c.Relabeling = []RelabelBlock{{Match: "*", MetricRelabelConfigs: []relabel.Config{
+				c.Relabeling = []relabel.Block{{Match: "*", MetricRelabelConfigs: []relabel.Config{
 					{
 						SourceLabels: []string{"method"},
 						Regex:        relabel.MustNewRegexp("(.+)"),

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -334,16 +334,17 @@ test_counter_no_meta_metric_1_total{label1="value2"} 11
 	}
 }
 
-// TestCollector_Collect drives the real V2 collector (Init, then a framework-style store
-// cycle around Collect) and asserts the metrics it wrote into the metrix store, by metric
+// TestCollector_Collect drives the real V2 collector (Init → Check, then a framework-style
+// store cycle around Collect) and asserts the metrics it wrote into the metrix store, by metric
 // name + flattened labels. Per-type correctness is exercised exhaustively in writer_test.go;
 // this checks the collector's end-to-end wiring (client/selector/fallback built in Init →
 // scrape → writer → store) plus the config-driven behaviors.
 func TestCollector_Collect(t *testing.T) {
 	tests := map[string]struct {
-		prepare func() *Collector
-		input   string
-		want    func(t *testing.T, fr metrix.Reader)
+		prepare    func() *Collector
+		checkInput string
+		input      string
+		want       func(t *testing.T, fr metrix.Reader)
 	}{
 		"gauge and counter values": {
 			prepare: New,
@@ -453,6 +454,10 @@ test_metric_info{version="1.2.3"} 1
 test_gauge_metric{label1="value1"} 11
 test_gauge_metric{label1="value2"} 12
 `,
+			checkInput: `
+# TYPE test_gauge_metric gauge
+test_gauge_metric{label1="value1"} 11
+`,
 			want: func(t *testing.T, fr metrix.Reader) {
 				_, ok := fr.Value("test_gauge_metric", metrix.Labels{"label1": "value1"})
 				assert.False(t, ok, "a family over the per-metric series limit must be skipped entirely")
@@ -520,15 +525,21 @@ test_requests_total{method="get"} 5
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			currentInput := tc.checkInput
+			if currentInput == "" {
+				currentInput = tc.input
+			}
 			srv := httptest.NewServer(http.HandlerFunc(
-				func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(tc.input)) }))
+				func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(currentInput)) }))
 			defer srv.Close()
 
 			collr := tc.prepare()
 			collr.URL = srv.URL
 			require.NoError(t, collr.Init(context.Background()))
+			require.NoError(t, collr.Check(context.Background()))
+			currentInput = tc.input
 
-			// Drive Collect exactly as the framework does: one store cycle around it.
+			// Drive Collect exactly as the framework does after successful Check.
 			cc := cycle(t, collr.MetricStore())
 			cc.BeginCycle()
 			require.NoError(t, collr.Collect(context.Background()))

--- a/src/go/plugin/go.d/collector/prometheus/config.go
+++ b/src/go/plugin/go.d/collector/prometheus/config.go
@@ -18,27 +18,18 @@ type Config struct {
 	UpdateEvery        int    `yaml:"update_every,omitempty" json:"update_every"`
 	AutoDetectionRetry int    `yaml:"autodetection_retry,omitempty" json:"autodetection_retry"`
 	web.HTTPConfig     `yaml:",inline" json:""`
-	Name               string         `yaml:"name,omitempty" json:"name"`
-	Application        string         `yaml:"app,omitempty" json:"app"`
-	Selector           selector.Expr  `yaml:"selector,omitempty" json:"selector"`
-	Relabeling         []RelabelBlock `yaml:"relabeling,omitempty" json:"relabeling,omitempty"`
-	Profiles           ProfilesConfig `yaml:"profiles" json:"profiles"`
-	ExpectedPrefix     string         `yaml:"expected_prefix,omitempty" json:"expected_prefix"`
-	MaxTS              int            `yaml:"max_time_series" json:"max_time_series"`
-	MaxTSPerMetric     int            `yaml:"max_time_series_per_metric" json:"max_time_series_per_metric"`
+	Name               string          `yaml:"name,omitempty" json:"name"`
+	Application        string          `yaml:"app,omitempty" json:"app"`
+	Selector           selector.Expr   `yaml:"selector,omitempty" json:"selector"`
+	Relabeling         []relabel.Block `yaml:"relabeling,omitempty" json:"relabeling,omitempty"`
+	Profiles           ProfilesConfig  `yaml:"profiles" json:"profiles"`
+	ExpectedPrefix     string          `yaml:"expected_prefix,omitempty" json:"expected_prefix"`
+	MaxTS              int             `yaml:"max_time_series" json:"max_time_series"`
+	MaxTSPerMetric     int             `yaml:"max_time_series_per_metric" json:"max_time_series_per_metric"`
 	FallbackType       struct {
 		Gauge   []string `yaml:"gauge,omitempty" json:"gauge"`
 		Counter []string `yaml:"counter,omitempty" json:"counter"`
 	} `yaml:"fallback_type,omitempty" json:"fallback_type"`
-}
-
-// RelabelBlock is one job-level metric-relabeling block: a required metric-name
-// match that scopes a list of Prometheus relabel rules to a metric-name subset.
-// Use match "*" to target every metric. Rules run pre-assembly on the sample
-// stream, in block order.
-type RelabelBlock struct {
-	Match                string           `yaml:"match" json:"match"`
-	MetricRelabelConfigs []relabel.Config `yaml:"metric_relabel_configs" json:"metric_relabel_configs"`
 }
 
 const (

--- a/src/go/plugin/go.d/collector/prometheus/config_schema.json
+++ b/src/go/plugin/go.d/collector/prometheus/config_schema.json
@@ -38,7 +38,7 @@
       },
       "expected_prefix": {
         "title": "Expected prefix",
-        "description": "If set, the job's check passes only when at least one scraped metric name starts with this prefix. Guards against scraping an unexpected endpoint.",
+        "description": "If set, the job's check passes only when at least one post-job, pre-profile metric name starts with this prefix. Guards against scraping an unexpected endpoint; profile-owned relabeling cannot satisfy it.",
         "type": "string"
       },
       "app": {
@@ -89,7 +89,7 @@
       },
       "relabeling": {
         "title": "Metric relabeling",
-        "description": "Prometheus-compatible metric relabeling applied before charts are built. Each block scopes its rules to the metrics whose name matches `match`. See the [relabeling reference](https://github.com/netdata/netdata/tree/master/src/go/plugin/go.d/collector/prometheus/relabel#readme) for the full syntax and examples.",
+        "description": "Job-owned Prometheus-compatible metric relabeling, applied after `selector` and before profile selection. Each block scopes its rules to metrics whose name matches `match`. Profiles may own the same block format for exporter normalization after selection. See the [relabeling reference](https://github.com/netdata/netdata/tree/master/src/go/plugin/go.d/collector/prometheus/relabel#readme) for ordering, syntax, and examples.",
         "type": [
           "array",
           "null"
@@ -182,7 +182,7 @@
       },
       "profiles": {
         "title": "Profiles",
-        "description": "Curated, exporter-specific chart profiles. `auto` (default) selects every profile whose match hits a scraped metric; `exact` selects only the named profiles (each must match); `combined` is auto plus the named profiles; `none` disables profiles (generic autogen charts only). A selected profile may use profile-root `autogen.selector` to constrain fallback charts inside its own `match` scope while retaining samples; all applicable selectors must accept a series.",
+        "description": "Curated, exporter-specific chart profiles. `auto` (default) selects every profile whose match hits a post-job metric; `exact` selects only the named profiles (each must match); `combined` is auto plus the named profiles; `none` disables profiles (generic autogen charts only). After selection, a profile may apply profile-owned `relabeling` before charts and use `autogen.selector` to constrain fallback charts inside its own `match` scope.",
         "type": "object",
         "properties": {
           "mode": {
@@ -299,21 +299,21 @@
       },
       "max_time_series": {
         "title": "Time series limit",
-        "description": "If an endpoint returns more time series than this limit, the data is not processed. Set to 0 for no limit.",
+        "description": "If the final output after job and profile relabeling contains more time series than this limit, the data is not processed. Set to 0 for no limit.",
         "type": "integer",
         "minimum": 0,
         "default": 2000
       },
       "max_time_series_per_metric": {
         "title": "Time series per metric limit",
-        "description": "Metrics with more time series than this limit are skipped. Set to 0 for no limit.",
+        "description": "Final metric families with more time series than this limit are skipped. Set to 0 for no limit.",
         "type": "integer",
         "minimum": 0,
         "default": 200
       },
       "fallback_type": {
         "title": "Untyped metrics fallback",
-        "description": "Process Untyped metrics as Counter or Gauge instead of ignoring them.",
+        "description": "Process untyped metrics as Counter or Gauge instead of ignoring them. Classification uses the post-job, pre-profile metric name; profile relabeling preserves the decision but cannot create or change it.",
         "type": [
           "object",
           "null"

--- a/src/go/plugin/go.d/collector/prometheus/config_schema.json
+++ b/src/go/plugin/go.d/collector/prometheus/config_schema.json
@@ -182,7 +182,7 @@
       },
       "profiles": {
         "title": "Profiles",
-        "description": "Curated, exporter-specific chart profiles. `auto` (default) selects every profile whose match hits a post-job metric; `exact` selects only the named profiles (each must match); `combined` is auto plus the named profiles; `none` disables profiles (generic autogen charts only). After selection, a profile may apply profile-owned `relabeling` before charts and use `autogen.selector` to constrain fallback charts inside its own `match` scope.",
+        "description": "Curated, exporter-specific chart profiles. `auto` (default) selects every profile whose match hits a post-job metric; `exact` selects only the named profiles (each must match); `combined` is auto plus the named profiles; `none` disables profiles (generic autogen charts only). After selection, a profile may apply profile-owned `relabeling` before charts and use `autogen.selector` to constrain fallback charts inside its own `match` scope. Each source family is normalized only by the first applicable profile: profile-name order in `auto`, entry order in `exact`, and configured entries followed by remaining name-ordered auto profiles in `combined`. All selected templates consume the shared final metric stream.",
         "type": "object",
         "properties": {
           "mode": {
@@ -226,7 +226,7 @@
                     "properties": {
                       "entries": {
                         "title": "Profile entries",
-                        "description": "Profiles to select. Each must match at least one scraped metric or the job fails its check.",
+                        "description": "Profiles to select, in profile-normalizer precedence order. Each must match at least one scraped metric or the job fails its check.",
                         "type": "array",
                         "minItems": 1,
                         "items": {
@@ -265,7 +265,7 @@
                     "properties": {
                       "entries": {
                         "title": "Profile entries",
-                        "description": "Profiles to select in addition to the auto-selected ones.",
+                        "description": "Profiles to select in addition to the auto-selected ones. Their entry order defines profile-normalizer precedence before remaining auto profiles.",
                         "type": "array",
                         "minItems": 1,
                         "items": {

--- a/src/go/plugin/go.d/collector/prometheus/init.go
+++ b/src/go/plugin/go.d/collector/prometheus/init.go
@@ -5,12 +5,10 @@ package prometheus
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/netdata/netdata/go/plugins/pkg/matcher"
 	"github.com/netdata/netdata/go/plugins/pkg/prometheus"
 	"github.com/netdata/netdata/go/plugins/pkg/web"
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
 
 func (c *Collector) validateConfig() error {
@@ -40,38 +38,6 @@ func (c *Collector) initPrometheusClient() (prometheus.Prometheus, error) {
 		return prometheus.NewWithSelector(httpClient, req, sr), nil
 	}
 	return prometheus.New(httpClient, req), nil
-}
-
-// initRelabelBlocks compiles each configured relabeling block into a name matcher
-// and a validated relabel processor. Every block must declare a non-empty match,
-// so its rules are always scoped to a metric-name subset (use "*" for all metrics).
-func (c *Collector) initRelabelBlocks() ([]relabelBlock, error) {
-	if len(c.Relabeling) == 0 {
-		return nil, nil
-	}
-
-	blocks := make([]relabelBlock, 0, len(c.Relabeling))
-	for i, b := range c.Relabeling {
-		if strings.TrimSpace(b.Match) == "" {
-			return nil, fmt.Errorf("relabeling[%d]: 'match' is required", i)
-		}
-		if len(b.MetricRelabelConfigs) == 0 {
-			return nil, fmt.Errorf("relabeling[%d]: 'metric_relabel_configs' is empty", i)
-		}
-
-		m, err := matcher.NewSimplePatternsMatcher(b.Match)
-		if err != nil {
-			return nil, fmt.Errorf("relabeling[%d]: invalid 'match' (%q): %v", i, b.Match, err)
-		}
-		proc, err := relabel.New(b.MetricRelabelConfigs)
-		if err != nil {
-			return nil, fmt.Errorf("relabeling[%d]: %v", i, err)
-		}
-
-		blocks = append(blocks, relabelBlock{match: m, proc: proc})
-	}
-
-	return blocks, nil
 }
 
 func (c *Collector) initFallbackTypeMatcher(expr []string) (matcher.Matcher, error) {

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -74,7 +74,7 @@ modules:
               required: false
               group: Target
             - name: expected_prefix
-              description: If set, the job's check passes only when at least one post-job, pre-profile metric name starts with this prefix. Guards against scraping an unexpected endpoint.
+              description: If set, the job's check passes only when at least one post-job, pre-profile metric name starts with this prefix. Guards against scraping an unexpected endpoint; profile-owned relabeling cannot satisfy it.
               default_value: ""
               required: false
               group: Target

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -192,10 +192,11 @@ modules:
                 - `none`: no profiles — generic autogen charts only (the pre-profile behavior).
 
                 Selection uses post-job, pre-profile family names. A selected profile may carry `relabeling` blocks
-                that normalize its owned metric families automatically before chart routing. Profile relabeling cannot
-                select its own profile, cannot move output outside the profile's root `match`, and is never chained
-                across profiles. Conflicting owners fail checking; a conflict or scope escape that first appears at
-                runtime drops the affected source family while unrelated families continue.
+                that normalize matching source families automatically before chart routing. Each original family is
+                processed only by the first applicable profile normalizer: profile-name order in `auto`, configured
+                entry order in `exact`, and configured entries followed by remaining auto profiles in name order in
+                `combined`. Later profile pipelines do not see the family. All selected templates consume the same
+                final names and labels; the collector does not create a private metric stream per profile.
 
                 Only the block matching the selected mode (`mode_exact` or `mode_combined`) is read; entries under the
                 other block are ignored. Metrics not covered by an authored profile chart keep their generic autogen

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -74,7 +74,7 @@ modules:
               required: false
               group: Target
             - name: expected_prefix
-              description: If set, the job's check passes only when at least one scraped metric name starts with this prefix. Guards against scraping an unexpected endpoint.
+              description: If set, the job's check passes only when at least one post-job, pre-profile metric name starts with this prefix. Guards against scraping an unexpected endpoint.
               default_value: ""
               required: false
               group: Target
@@ -108,13 +108,13 @@ modules:
                 ```
 
             - name: max_time_series
-              description: Global time series limit. If an endpoint returns more time series than this, the data is not processed.
+              description: Global time series limit applied after job and profile relabeling. If the final output exceeds it, the data is not processed.
               default_value: 2000
               required: false
               group: Limits
 
             - name: max_time_series_per_metric
-              description: Per-metric time series limit. Metrics with more time series than this are skipped.
+              description: Per-metric time series limit applied to final metric families. Metrics exceeding it are skipped.
               default_value: 200
               required: false
               group: Limits
@@ -126,6 +126,8 @@ modules:
               group: Customization
               detailed_description: |
                 This option allows you to process Untyped metrics as Counter or Gauge instead of ignoring them.
+                Classification uses the post-job, pre-profile metric name. Profile relabeling preserves the selected
+                type but cannot create or change it by renaming the final metric.
 
                 - Metric name pattern syntax: [shell file name pattern](https://golang.org/pkg/path/filepath/#Match).
                 - Option syntax:
@@ -141,13 +143,14 @@ modules:
                 ```
 
             - name: relabeling
-              description: Prometheus-compatible metric relabeling, applied before charts are built.
+              description: Job-owned Prometheus-compatible metric relabeling, applied before profile selection.
               default_value: ""
               required: false
               group: Customization
               detailed_description: |
-                A list of relabeling blocks. Each block applies a list of Prometheus `metric_relabel_configs` rules to
-                the metrics whose name matches `match`. See the
+                A list of job-owned relabeling blocks, applied after `selector` and before profile selection. Each block
+                applies a list of Prometheus `metric_relabel_configs` rules to the metrics whose name matches `match`.
+                Profiles may own the same block format for exporter normalization after selection. See the
                 [relabeling reference](/src/go/plugin/go.d/collector/prometheus/relabel/README.md) for
                 the full action set and more examples.
 
@@ -173,7 +176,7 @@ modules:
                 ```
 
             - name: profiles
-              description: Curated, exporter-specific chart profiles. Profiles may constrain unmatched fallback charts with scoped `autogen.selector` rules; disable profiles with mode `none`.
+              description: Curated, exporter-specific chart profiles with optional profile-owned normalization and scoped fallback-chart policy; disable profiles with mode `none`.
               default_value: auto
               required: false
               group: Customization
@@ -187,6 +190,12 @@ modules:
                   check).
                 - `combined`: `auto` plus the profiles named in `mode_combined.entries`.
                 - `none`: no profiles — generic autogen charts only (the pre-profile behavior).
+
+                Selection uses post-job, pre-profile family names. A selected profile may carry `relabeling` blocks
+                that normalize its owned metric families automatically before chart routing. Profile relabeling cannot
+                select its own profile, cannot move output outside the profile's root `match`, and is never chained
+                across profiles. Conflicting owners fail checking; a conflict or scope escape that first appears at
+                runtime drops the affected source family while unrelated families continue.
 
                 Only the block matching the selected mode (`mode_exact` or `mode_combined`) is read; entries under the
                 other block are ignored. Metrics not covered by an authored profile chart keep their generic autogen

--- a/src/go/plugin/go.d/collector/prometheus/profile-format.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-format.md
@@ -155,9 +155,9 @@ At runtime the collector uses profiles in six ordered steps:
    order) wins and the rest are logged -- set the job's `app` to disambiguate.
 6. **Charts** -- the selected profiles' templates are merged on top of the autogeneration base. Every series first gets
    a chance to route to every authored template dimension. If no route matches, each selected profile's
-   `autogen.selector` is evaluated only when that profile's `match` applies to the source family. Every applicable
-   selector must accept the series; one rejection suppresses fallback, independent of profile order. If no selector
-   applies, the series keeps its generic autogen chart. A selector never removes samples from the metric store.
+   `autogen.selector` is evaluated only when that profile's `match` applies to the final post-profile family. Every
+   applicable selector must accept the series; one rejection suppresses fallback, independent of profile order. If no
+   selector applies, the series keeps its generic autogen chart. A selector never removes samples from the metric store.
 
 Chart contexts compose as `prometheus.<app>.<template context_namespace>.<chart context>` -- in the example above,
 `prometheus.example.example.http_requests`. When the resolved app equals the profile's `context_namespace` (the common
@@ -245,7 +245,7 @@ operator-owned type policy independent of profile naming.
 
 `autogen.selector` uses the existing metric selector `allow`/`deny` shape to control fallback charts. It runs only
 after no authored chart-template dimension matched the flattened series, and only when this profile's `match` applies
-to the resolved source family.
+to the final post-profile family that reaches the chart engine.
 
 - `allow` alone keeps fallback only for selected series.
 - `deny` alone keeps fallback for everything except selected series.
@@ -253,7 +253,7 @@ to the resolved source family.
 - At least one non-empty `allow` or `deny` entry is required. Empty `autogen`, null or empty `selector`, both lists
   absent or empty, whitespace-only entries, and invalid selector expressions are rejected.
 - Each entry accepts the same metric-name and label expression syntax as other metric selectors. The selector receives
-  the source family as `__name__` plus all current series labels.
+  the final post-profile family as `__name__` plus the relabeled series' current labels.
 - When multiple selected profile scopes apply, every applicable selector must accept the series. One rejection
   suppresses fallback, and profile order cannot change the result. Profiles without `autogen.selector` add no rule.
 - Histograms and summaries use their base family as `__name__`: `foo_bucket`, `foo_sum`, and `foo_count` all evaluate

--- a/src/go/plugin/go.d/collector/prometheus/profile-format.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-format.md
@@ -5,9 +5,10 @@ renders one chart per scraped metric (autogeneration). A profile replaces that f
 a designed dashboard menu: named sections, per-instance charts, meaningful dimensions, units, and heatmaps. You are not
 limited to the stock library -- you can author a profile for your own application's metrics too.
 
-This page documents the profile file format. The job-level
-[metric relabeling](/src/go/plugin/go.d/collector/prometheus/relabel/README.md) option, which reshapes scraped metrics
-before profiles and charts see them, is documented separately.
+This page documents the profile file format. Profiles may also own
+[metric relabeling](/src/go/plugin/go.d/collector/prometheus/relabel/README.md) that normalizes an exporter's metrics
+after the profile is selected and before its chart template sees them. Jobs use the same rule format for
+operator-specific filtering and normalization before profile selection.
 
 Profiles reshape metrics an existing job already scrapes --
 [set up the Prometheus collector job](/src/go/plugin/go.d/collector/prometheus/integrations/prometheus_endpoint.md)
@@ -28,10 +29,10 @@ because the catalog is cached for the plugin's lifetime.
 
 ## Complete example
 
-A profile is a YAML file with two required top-level keys (`match` and `template`) plus optional `app` and `autogen`
-policy. `match` selects the profile by scraped metric names, `app` names the application the charts belong to,
-`autogen.selector` controls fallback charts within the profile's match scope, and `template` defines the curated
-charts. Everything below `template` is Netdata's
+A profile is a YAML file with two required top-level keys (`match` and `template`) plus optional `app`, `relabeling`,
+and `autogen` policy. `match` selects the profile by scraped metric names, `app` names the application the charts
+belong to, `relabeling` normalizes metrics owned by the selected profile, `autogen.selector` controls fallback charts
+within the profile's match scope, and `template` defines the curated charts. Everything below `template` is Netdata's
 [Chart Template Format](/src/go/plugin/framework/charttpl/README.md); inline comments explain each field.
 
 ```yaml
@@ -42,6 +43,15 @@ app: example                # optional. Application identity: charts appear unde
                             # the prometheus.<app>.* contexts and the app's own
                             # Applications section in the UI, unless the job
                             # config sets its own `app`.
+
+relabeling:                 # optional. Normalize this exporter's metrics after
+                            # profile selection and before template routing.
+  - match: example_legacy_http_requests_total
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: example_legacy_http_requests_total
+        target_label: __name__
+        replacement: example_http_requests_total
 
 autogen:                    # optional. Controls fallback charts inside this
   selector:                 # profile's match scope after authored routing fails.
@@ -127,20 +137,23 @@ template:
 
 ## How profiles work
 
-At runtime the collector uses profiles in four steps:
+At runtime the collector uses profiles in six ordered steps:
 
 1. **Scrape** -- the job scrapes the endpoint. The `selector` job option filters unwanted series
-   ([selector syntax](/src/go/pkg/prometheus/selector/README.md)), and
-   [relabeling](/src/go/plugin/go.d/collector/prometheus/relabel/README.md) rewrites metric names and labels. Profiles
-   and charts only ever see the result.
-2. **Selection** -- once, at job autodetection, each profile's `match` is tested against the scraped metric family
+   ([selector syntax](/src/go/pkg/prometheus/selector/README.md)).
+2. **Job normalization** -- the job's
+   [relabeling](/src/go/plugin/go.d/collector/prometheus/relabel/README.md) rewrites names and labels. Histogram and
+   summary integrity is checked before continuing.
+3. **Selection** -- once, at job autodetection, each profile's `match` is tested against the post-job metric family
    names, per the job's `profiles.mode` (see
    [Selecting profiles in job configuration](#selecting-profiles-in-job-configuration)). The selection is cached until
-   the job restarts.
-3. **App resolution** -- the job's `app` option wins; when unset, the first selected profile that declares an `app`
+   the job restarts. Profile-owned relabeling cannot select its own profile because it runs after this step.
+4. **Profile normalization** -- each selected profile's `relabeling` is applied automatically to the source metric
+   families it owns. The resulting namespace and typed-family integrity are checked again.
+5. **App resolution** -- the job's `app` option wins; when unset, the first selected profile that declares an `app`
    provides it; the job name is the last resort. If selected profiles declare different apps, the first (in selection
    order) wins and the rest are logged -- set the job's `app` to disambiguate.
-4. **Charts** -- the selected profiles' templates are merged on top of the autogeneration base. Every series first gets
+6. **Charts** -- the selected profiles' templates are merged on top of the autogeneration base. Every series first gets
    a chance to route to every authored template dimension. If no route matches, each selected profile's
    `autogen.selector` is evaluated only when that profile's `match` applies to the source family. Every applicable
    selector must accept the series; one rejection suppresses fallback, independent of profile order. If no selector
@@ -154,12 +167,13 @@ contexts.
 
 ## Top-level fields
 
-| Field      | Required | Description                                                                                                                                            |
-|:-----------|:--------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `match`    |   yes    | [Netdata simple pattern](/src/libnetdata/simple_pattern/README.md) tested against scraped metric family names. One hit makes the profile applicable.  |
-| `app`      |    no    | Application identity used as the `app` segment of chart contexts when the job does not set one. Must match `^[a-z][a-z0-9_]*$`.                       |
-| `autogen`  |    no    | Fallback-chart policy. `autogen.selector` constrains generic charts inside this profile's `match` scope while retaining samples.                    |
-| `template` |   yes    | Chart template group defining the curated charts. At least one chart.                                                                                 |
+| Field        | Required | Description                                                                                                                                           |
+|:-------------|:--------:|:------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `match`      |   yes    | [Netdata simple pattern](/src/libnetdata/simple_pattern/README.md) tested against post-job metric family names. One hit makes the profile applicable. |
+| `app`        |    no    | Application identity used as the `app` segment of chart contexts when the job does not set one. Must match `^[a-z][a-z0-9_]*$`.                      |
+| `relabeling` |    no    | Profile-owned metric normalization, applied automatically after selection and before charts.                                                         |
+| `autogen`    |    no    | Fallback-chart policy. `autogen.selector` constrains generic charts inside this profile's `match` scope while retaining samples.                     |
+| `template`   |   yes    | Chart template group defining the curated charts. At least one chart.                                                                                |
 
 The filename must match `^[a-z][a-z0-9_]*$` (plus the `.yaml` or `.yml` extension): lowercase, starting with a letter,
 using only letters, digits, and underscores -- `my_app.yaml`, not `my-app.yaml` or `MyApp.yaml`. The basename is the
@@ -177,12 +191,55 @@ profile name used everywhere else -- in `profiles.mode_exact`/`mode_combined` en
   [Chart template rules](#chart-template-rules) and [the relabeling block `match`](/src/go/plugin/go.d/collector/prometheus/relabel/README.md#match).)
 - It sees the names **after** the job's `selector` and `relabeling` have been applied, so a rename can bring an
   endpoint's metrics into (or out of) a profile's match.
+- It sees names **before** this profile's own `relabeling`. A profile cannot rename an otherwise non-matching metric
+  into its own selection scope; use job relabeling when normalization is required to select the profile itself.
 - Syntax is a Netdata [simple pattern](/src/libnetdata/simple_pattern/README.md): a space-separated list of globs where
   `*` matches any sequence, `?` matches any single character, and a leading `!` negates a term.
 
 Keep the pattern narrow -- anchored to the exporter's metric prefix, such as `haproxy_*`. In the default `auto` mode
 every catalog profile whose `match` hits at least one scraped metric family is selected, so an over-broad pattern
 attaches the profile to unrelated jobs.
+
+### `relabeling`
+
+`relabeling` stores normalization required by the exporter profile itself. It uses the exact same ordered block and
+rule format as job-level [metric relabeling](/src/go/plugin/go.d/collector/prometheus/relabel/README.md), including the
+full action set. Use it when the profile's template needs a stable metric or label shape across exporter versions. Use
+job-level relabeling for deployment-specific policy, filtering, or normalization needed before profile selection.
+
+```yaml
+match: 'example_*'
+relabeling:
+  - match: example_requests
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: example_requests
+        target_label: __name__
+        replacement: example_http_requests_total
+template:
+  # Select example_http_requests_total here.
+  # ...
+```
+
+Profile relabeling has explicit ownership and namespace rules:
+
+- It runs only for selected profiles and cannot affect profile selection.
+- A source family is owned when the profile's root `match` covers its base family name and at least one profile
+  relabeling block matches one of its physical series names. All series in that source family are then processed by
+  that one profile pipeline.
+- Two selected profiles cannot own the same source family. An overlap fails job checking with the family and profile
+  names. If a new overlap appears later because an exporter changes at runtime, that source family is dropped while
+  unrelated families continue.
+- Output family names must remain inside the owning profile's root `match`. An escape fails job checking; a new
+  runtime-only escape drops that source family. This prevents unexpected generic charts outside the profile namespace.
+- Profiles are never chained. One source family has at most one profile normalizer, regardless of catalog order.
+- Histogram and summary integrity is validated independently after job and profile relabeling. Partial component
+  renames/drops, structural `le`/`quantile` changes, splits, and merges are rejected during checking and contained by
+  dropping the corrupted family if they first appear at runtime.
+
+Untyped fallback classification is decided from the post-job, pre-profile name. A profile rename preserves that
+decision, but cannot create a counter merely by adding `_total` or make a final name match `fallback_type`. This keeps
+operator-owned type policy independent of profile naming.
 
 ### `autogen.selector`
 

--- a/src/go/plugin/go.d/collector/prometheus/profile-format.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-format.md
@@ -235,6 +235,9 @@ Profile relabeling uses first-applicable precedence over the shared metric strea
   to every selected profile; profiles do not receive private copies of the source metrics.
 - The root `match` constrains source applicability, not output names. Profile authors are responsible for making the
   produced names and labels agree with every selected template that consumes them.
+- If a produced family no longer matches the profile's root `match`, that profile's `autogen.selector` no longer applies
+  to it either. An uncovered output family therefore keeps generic autogen unless another applicable profile scope
+  rejects it.
 - Histogram and summary integrity is validated independently after job and profile relabeling. Partial component
   renames/drops, structural `le`/`quantile` changes, splits, and merges are rejected during checking and contained by
   dropping the corrupted family if they first appear at runtime.

--- a/src/go/plugin/go.d/collector/prometheus/profile-format.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-format.md
@@ -5,7 +5,7 @@ renders one chart per scraped metric (autogeneration). A profile replaces that f
 a designed dashboard menu: named sections, per-instance charts, meaningful dimensions, units, and heatmaps. You are not
 limited to the stock library -- you can author a profile for your own application's metrics too.
 
-This page documents the profile file format. Profiles may also own
+This page documents the profile file format. Profiles may also provide
 [metric relabeling](/src/go/plugin/go.d/collector/prometheus/relabel/README.md) that normalizes an exporter's metrics
 after the profile is selected and before its chart template sees them. Jobs use the same rule format for
 operator-specific filtering and normalization before profile selection.
@@ -31,7 +31,7 @@ because the catalog is cached for the plugin's lifetime.
 
 A profile is a YAML file with two required top-level keys (`match` and `template`) plus optional `app`, `relabeling`,
 and `autogen` policy. `match` selects the profile by scraped metric names, `app` names the application the charts
-belong to, `relabeling` normalizes metrics owned by the selected profile, `autogen.selector` controls fallback charts
+belong to, `relabeling` normalizes matching metrics after selection, `autogen.selector` controls fallback charts
 within the profile's match scope, and `template` defines the curated charts. Everything below `template` is Netdata's
 [Chart Template Format](/src/go/plugin/framework/charttpl/README.md); inline comments explain each field.
 
@@ -148,8 +148,8 @@ At runtime the collector uses profiles in six ordered steps:
    names, per the job's `profiles.mode` (see
    [Selecting profiles in job configuration](#selecting-profiles-in-job-configuration)). The selection is cached until
    the job restarts. Profile-owned relabeling cannot select its own profile because it runs after this step.
-4. **Profile normalization** -- each selected profile's `relabeling` is applied automatically to the source metric
-   families it owns. The resulting namespace and typed-family integrity are checked again.
+4. **Profile normalization** -- each source family is processed by the first applicable selected profile's `relabeling`.
+   Later profiles do not process that family. The resulting typed-family integrity is checked again.
 5. **App resolution** -- the job's `app` option wins; when unset, the first selected profile that declares an `app`
    provides it; the job name is the last resort. If selected profiles declare different apps, the first (in selection
    order) wins and the rest are logged -- set the job's `app` to disambiguate.
@@ -221,18 +221,20 @@ template:
   # ...
 ```
 
-Profile relabeling has explicit ownership and namespace rules:
+Profile relabeling uses first-applicable precedence over the shared metric stream:
 
 - It runs only for selected profiles and cannot affect profile selection.
-- A source family is owned when the profile's root `match` covers its base family name and at least one profile
-  relabeling block matches one of its physical series names. All series in that source family are then processed by
-  that one profile pipeline.
-- Two selected profiles cannot own the same source family. An overlap fails job checking with the family and profile
-  names. If a new overlap appears later because an exporter changes at runtime, that source family is dropped while
-  unrelated families continue.
-- Output family names must remain inside the owning profile's root `match`. An escape fails job checking; a new
-  runtime-only escape drops that source family. This prevents unexpected generic charts outside the profile namespace.
-- Profiles are never chained. One source family has at most one profile normalizer, regardless of catalog order.
+- A profile is applicable to an original source family when its root `match` covers the base family name and at least
+  one of its relabeling blocks matches an original physical series name. Rule results and output names do not affect
+  this decision.
+- The first applicable profile processes every series in that source family through its complete pipeline. Later
+  profile pipelines do not see the family, including names produced by the first pipeline.
+- Normalizer precedence is profile-name order in `auto`; configured entry order in `exact`; and configured entries
+  first followed by remaining auto-selected profiles in profile-name order in `combined`.
+- All selected templates consume the same final stream. A first profile's name or label changes are therefore visible
+  to every selected profile; profiles do not receive private copies of the source metrics.
+- The root `match` constrains source applicability, not output names. Profile authors are responsible for making the
+  produced names and labels agree with every selected template that consumes them.
 - Histogram and summary integrity is validated independently after job and profile relabeling. Partial component
   renames/drops, structural `le`/`quantile` changes, splits, and merges are rejected during checking and contained by
   dropping the corrupted family if they first appear at runtime.
@@ -371,6 +373,11 @@ the stock nor the user catalog is a configuration error in both modes. Scraped m
 profile keep their generic autogen charts unless an applicable profile `autogen.selector` rejects them. Use
 `autogen.selector` to constrain fallback charts while retaining samples; use the job's `selector` or a `relabeling`
 drop rule to discard samples.
+
+When selected profiles contain relabeling, the mode also determines normalizer precedence: `auto` uses profile-name
+order, `exact` uses entry order, and `combined` tries its configured entries first and then the remaining auto-selected
+profiles in profile-name order. This precedence affects normalization only; profile selection, app fallback, and template
+composition retain their existing behavior.
 
 `profiles`, `relabeling`, `selector`, `fallback_type`, and `app` are all job options in `go.d/prometheus.conf` -- edit
 it with `sudo ./edit-config go.d/prometheus.conf` from your

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
@@ -4,6 +4,7 @@ package prometheus
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -114,11 +115,8 @@ func resolveProfileOwners(batch prompkg.SampleBatch, normalizers []profileNormal
 			if !normalizer.root.MatchString(base) {
 				continue
 			}
-			for _, physicalName := range physicalNames {
-				if normalizer.pipeline.Matches(physicalName) {
-					candidates = append(candidates, normalizer)
-					break
-				}
+			if slices.ContainsFunc(physicalNames, normalizer.pipeline.Matches) {
+				candidates = append(candidates, normalizer)
 			}
 		}
 

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
@@ -32,23 +32,54 @@ func (c *Collector) profileRelabelAndAssemble(
 // applicable profile normalizer. Applicability is evaluated only from original
 // names, so profile pipelines never chain through names produced by one another.
 func selectProfileNormalizers(batch prompkg.SampleBatch, normalizers []profileNormalizer) map[string]int {
+	type sourceName struct {
+		family   string
+		physical string
+	}
+	type checkedSource struct {
+		name    sourceName
+		matched int
+		valid   bool
+	}
+
 	selected := make(map[string]int)
+	// Labeled series for one physical metric normally arrive consecutively. Cache
+	// only that name: a family-level miss would be wrong when a later component
+	// (for example _sum after _bucket) makes a profile applicable.
+	var last checkedSource
 	for _, sample := range batch.Samples {
 		base := helpFamilyName(sample)
 		limit := len(normalizers)
 		if idx, ok := selected[base]; ok {
 			limit = idx
 		}
+		if limit == 0 {
+			continue
+		}
+
+		key := sourceName{family: base, physical: sample.Name}
+		if last.valid && last.name == key {
+			if last.matched < limit {
+				selected[base] = last.matched
+			}
+			continue
+		}
+
+		matched := limit
 		for i := range normalizers[:limit] {
 			normalizer := &normalizers[i]
 			if !normalizer.root.MatchString(base) {
 				continue
 			}
 			if normalizer.pipeline.Matches(sample.Name) {
-				selected[base] = i
+				matched = i
 				break
 			}
 		}
+		if matched < limit {
+			selected[base] = matched
+		}
+		last = checkedSource{name: key, matched: matched, valid: true}
 	}
 	return selected
 }

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
@@ -105,22 +105,16 @@ func resolveProfileOwners(batch prompkg.SampleBatch, normalizers []profileNormal
 		families[base] = append(families[base], sample.Name)
 	}
 
-	baseNames := make([]string, 0, len(families))
-	for base := range families {
-		baseNames = append(baseNames, base)
-	}
-	sort.Strings(baseNames)
-
 	owners := make(map[string]*profileNormalizer, len(families))
 	var conflicts []profileOwnerConflict
-	for _, base := range baseNames {
+	for base, physicalNames := range families {
 		var candidates []*profileNormalizer
 		for i := range normalizers {
 			normalizer := &normalizers[i]
 			if !normalizer.root.MatchString(base) {
 				continue
 			}
-			for _, physicalName := range families[base] {
+			for _, physicalName := range physicalNames {
 				if normalizer.pipeline.Matches(physicalName) {
 					candidates = append(candidates, normalizer)
 					break
@@ -141,6 +135,7 @@ func resolveProfileOwners(batch prompkg.SampleBatch, normalizers []profileNormal
 			conflicts = append(conflicts, profileOwnerConflict{family: base, profiles: names})
 		}
 	}
+	sort.Slice(conflicts, func(i, j int) bool { return conflicts[i].family < conflicts[j].family })
 	return owners, conflicts
 }
 

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
@@ -8,21 +8,24 @@ func (c *Collector) profileRelabelAndAssemble(
 	batch prompkg.SampleBatch,
 	normalizers []profileNormalizer,
 	checking bool,
-) (prompkg.SampleBatch, prompkg.MetricFamilies, error) {
+) (prompkg.MetricFamilies, error) {
 	normalizerIndexByFamily := selectProfileNormalizers(batch, normalizers)
 
-	results := make([]relabelResult, 0, len(batch.Samples))
+	t := newRelabelTracking()
+	help := newHelpRemap()
+	processed := prompkg.SampleBatch{Samples: make([]prompkg.Sample, 0, len(batch.Samples))}
 	for _, raw := range batch.Samples {
 		source := helpFamilyName(raw)
 		result := relabelResult{raw: raw, sample: raw}
 		if idx, ok := normalizerIndexByFamily[source]; ok {
 			result.sample, result.drop = normalizers[idx].pipeline.Apply(raw)
 		}
-		results = append(results, result)
+		c.appendRelabelResult(&processed, t, help, profileRelabelStage, result)
 	}
+	processed.Help = help.remap(batch.Help)
 
-	processed, tracking := c.materializeRelabel(batch.Help, results, profileRelabelStage)
-	return c.assembleRelabeled(processed, tracking, profileRelabelStage, checking)
+	_, mfs, err := c.finishRelabel(processed, t, profileRelabelStage, checking, true)
+	return mfs, err
 }
 
 // selectProfileNormalizers assigns each original source family to the first

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
@@ -2,164 +2,50 @@
 
 package prometheus
 
-import (
-	"fmt"
-	"slices"
-	"sort"
-	"strings"
-	"time"
-
-	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
-)
-
-type profileOwnerConflict struct {
-	family   string
-	profiles []string
-}
-
-type profileScopeEscape struct {
-	profile string
-	source  string
-	target  string
-}
+import prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
 
 func (c *Collector) profileRelabelAndAssemble(
 	batch prompkg.SampleBatch,
 	normalizers []profileNormalizer,
 	checking bool,
 ) (prompkg.SampleBatch, prompkg.MetricFamilies, error) {
-	owners, conflicts := resolveProfileOwners(batch, normalizers)
-	if checking && len(conflicts) > 0 {
-		return prompkg.SampleBatch{}, nil, profileConflictError(conflicts)
-	}
-
-	conflictSources := make(map[string]struct{}, len(conflicts))
-	invalidSources := make(map[string]struct{}, len(conflicts))
-	if len(conflicts) > 0 {
-		for _, conflict := range conflicts {
-			conflictSources[conflict.family] = struct{}{}
-			invalidSources[conflict.family] = struct{}{}
-		}
-		c.Limit("profile-relabel-ownership-conflict", 1, 10*time.Minute).
-			Warningf("profile relabeling found %d ownership conflict(s); dropped the affected source families (enable debug for names)", len(conflicts))
-		for _, conflict := range conflicts {
-			c.Debugf("profile relabeling dropped source family %q: matched profiles %s", conflict.family, strings.Join(conflict.profiles, ", "))
-		}
-	}
+	normalizerIndexByFamily := selectProfileNormalizers(batch, normalizers)
 
 	results := make([]relabelResult, 0, len(batch.Samples))
-	sourceFamilies := make([]string, 0, len(batch.Samples))
-	escapeSet := make(map[profileScopeEscape]struct{})
 	for _, raw := range batch.Samples {
 		source := helpFamilyName(raw)
 		result := relabelResult{raw: raw, sample: raw}
-		if _, conflict := conflictSources[source]; conflict {
-			result.discard = true
-			results = append(results, result)
-			sourceFamilies = append(sourceFamilies, source)
-			continue
-		}
-
-		if owner := owners[source]; owner != nil {
-			result.sample, result.drop = owner.pipeline.Apply(raw)
-			if !result.drop.Dropped() {
-				target := helpFamilyName(result.sample)
-				if !owner.root.MatchString(target) {
-					escape := profileScopeEscape{profile: owner.name, source: source, target: target}
-					escapeSet[escape] = struct{}{}
-					invalidSources[source] = struct{}{}
-				}
-			}
+		if idx, ok := normalizerIndexByFamily[source]; ok {
+			result.sample, result.drop = normalizers[idx].pipeline.Apply(raw)
 		}
 		results = append(results, result)
-		sourceFamilies = append(sourceFamilies, source)
-	}
-
-	escapes := sortedProfileScopeEscapes(escapeSet)
-	if checking && len(escapes) > 0 {
-		return prompkg.SampleBatch{}, nil, profileScopeError(escapes)
-	}
-	if len(escapes) > 0 {
-		c.Limit("profile-relabel-scope-escape", 1, 10*time.Minute).
-			Warningf("profile relabeling produced %d namespace escape(s); dropped the affected source families (enable debug for names)", len(escapes))
-		for _, escape := range escapes {
-			c.Debugf("profile %q relabeling dropped source family %q: output family %q is outside its match", escape.profile, escape.source, escape.target)
-		}
-	}
-
-	if len(invalidSources) > 0 {
-		for i, source := range sourceFamilies {
-			if _, invalid := invalidSources[source]; invalid {
-				results[i].discard = true
-			}
-		}
 	}
 
 	processed, tracking := c.materializeRelabel(batch.Help, results, profileRelabelStage)
 	return c.assembleRelabeled(processed, tracking, profileRelabelStage, checking)
 }
 
-func resolveProfileOwners(batch prompkg.SampleBatch, normalizers []profileNormalizer) (map[string]*profileNormalizer, []profileOwnerConflict) {
-	families := make(map[string][]string)
+// selectProfileNormalizers assigns each original source family to the first
+// applicable profile normalizer. Applicability is evaluated only from original
+// names, so profile pipelines never chain through names produced by one another.
+func selectProfileNormalizers(batch prompkg.SampleBatch, normalizers []profileNormalizer) map[string]int {
+	selected := make(map[string]int)
 	for _, sample := range batch.Samples {
 		base := helpFamilyName(sample)
-		families[base] = append(families[base], sample.Name)
-	}
-
-	owners := make(map[string]*profileNormalizer, len(families))
-	var conflicts []profileOwnerConflict
-	for base, physicalNames := range families {
-		var candidates []*profileNormalizer
-		for i := range normalizers {
+		limit := len(normalizers)
+		if idx, ok := selected[base]; ok {
+			limit = idx
+		}
+		for i := range normalizers[:limit] {
 			normalizer := &normalizers[i]
 			if !normalizer.root.MatchString(base) {
 				continue
 			}
-			if slices.ContainsFunc(physicalNames, normalizer.pipeline.Matches) {
-				candidates = append(candidates, normalizer)
+			if normalizer.pipeline.Matches(sample.Name) {
+				selected[base] = i
+				break
 			}
 		}
-
-		switch len(candidates) {
-		case 0:
-		case 1:
-			owners[base] = candidates[0]
-		default:
-			names := make([]string, len(candidates))
-			for i, candidate := range candidates {
-				names[i] = candidate.name
-			}
-			sort.Strings(names)
-			conflicts = append(conflicts, profileOwnerConflict{family: base, profiles: names})
-		}
 	}
-	sort.Slice(conflicts, func(i, j int) bool { return conflicts[i].family < conflicts[j].family })
-	return owners, conflicts
-}
-
-func profileConflictError(conflicts []profileOwnerConflict) error {
-	conflict := conflicts[0]
-	return fmt.Errorf("profile relabeling ownership conflict for source family %q: profiles %s", conflict.family, strings.Join(conflict.profiles, ", "))
-}
-
-func sortedProfileScopeEscapes(set map[profileScopeEscape]struct{}) []profileScopeEscape {
-	escapes := make([]profileScopeEscape, 0, len(set))
-	for escape := range set {
-		escapes = append(escapes, escape)
-	}
-	sort.Slice(escapes, func(i, j int) bool {
-		if escapes[i].source != escapes[j].source {
-			return escapes[i].source < escapes[j].source
-		}
-		if escapes[i].profile != escapes[j].profile {
-			return escapes[i].profile < escapes[j].profile
-		}
-		return escapes[i].target < escapes[j].target
-	})
-	return escapes
-}
-
-func profileScopeError(escapes []profileScopeEscape) error {
-	escape := escapes[0]
-	return fmt.Errorf("profile %q relabeling moves source family %q to output family %q outside profile match", escape.profile, escape.source, escape.target)
+	return selected
 }

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
+)
+
+type profileOwnerConflict struct {
+	family   string
+	profiles []string
+}
+
+type profileScopeEscape struct {
+	profile string
+	source  string
+	target  string
+}
+
+func (c *Collector) profileRelabelAndAssemble(
+	batch prompkg.SampleBatch,
+	normalizers []profileNormalizer,
+	checking bool,
+) (prompkg.SampleBatch, prompkg.MetricFamilies, error) {
+	owners, conflicts := resolveProfileOwners(batch, normalizers)
+	if checking && len(conflicts) > 0 {
+		return prompkg.SampleBatch{}, nil, profileConflictError(conflicts)
+	}
+
+	conflictSources := make(map[string]struct{}, len(conflicts))
+	invalidSources := make(map[string]struct{}, len(conflicts))
+	if len(conflicts) > 0 {
+		for _, conflict := range conflicts {
+			conflictSources[conflict.family] = struct{}{}
+			invalidSources[conflict.family] = struct{}{}
+		}
+		c.Limit("profile-relabel-ownership-conflict", 1, 10*time.Minute).
+			Warningf("profile relabeling found %d ownership conflict(s); dropped the affected source families (enable debug for names)", len(conflicts))
+		for _, conflict := range conflicts {
+			c.Debugf("profile relabeling dropped source family %q: matched profiles %s", conflict.family, strings.Join(conflict.profiles, ", "))
+		}
+	}
+
+	results := make([]relabelResult, 0, len(batch.Samples))
+	sourceFamilies := make([]string, 0, len(batch.Samples))
+	escapeSet := make(map[profileScopeEscape]struct{})
+	for _, raw := range batch.Samples {
+		source := helpFamilyName(raw)
+		result := relabelResult{raw: raw, sample: raw}
+		if _, conflict := conflictSources[source]; conflict {
+			result.discard = true
+			results = append(results, result)
+			sourceFamilies = append(sourceFamilies, source)
+			continue
+		}
+
+		if owner := owners[source]; owner != nil {
+			result.sample, result.drop = owner.pipeline.Apply(raw)
+			if !result.drop.Dropped() {
+				target := helpFamilyName(result.sample)
+				if !owner.root.MatchString(target) {
+					escape := profileScopeEscape{profile: owner.name, source: source, target: target}
+					escapeSet[escape] = struct{}{}
+					invalidSources[source] = struct{}{}
+				}
+			}
+		}
+		results = append(results, result)
+		sourceFamilies = append(sourceFamilies, source)
+	}
+
+	escapes := sortedProfileScopeEscapes(escapeSet)
+	if checking && len(escapes) > 0 {
+		return prompkg.SampleBatch{}, nil, profileScopeError(escapes)
+	}
+	if len(escapes) > 0 {
+		c.Limit("profile-relabel-scope-escape", 1, 10*time.Minute).
+			Warningf("profile relabeling produced %d namespace escape(s); dropped the affected source families (enable debug for names)", len(escapes))
+		for _, escape := range escapes {
+			c.Debugf("profile %q relabeling dropped source family %q: output family %q is outside its match", escape.profile, escape.source, escape.target)
+		}
+	}
+
+	if len(invalidSources) > 0 {
+		for i, source := range sourceFamilies {
+			if _, invalid := invalidSources[source]; invalid {
+				results[i].discard = true
+			}
+		}
+	}
+
+	processed, tracking := c.materializeRelabel(batch.Help, results, profileRelabelStage)
+	return c.assembleRelabeled(processed, tracking, profileRelabelStage, checking)
+}
+
+func resolveProfileOwners(batch prompkg.SampleBatch, normalizers []profileNormalizer) (map[string]*profileNormalizer, []profileOwnerConflict) {
+	families := make(map[string][]string)
+	for _, sample := range batch.Samples {
+		base := helpFamilyName(sample)
+		families[base] = append(families[base], sample.Name)
+	}
+
+	baseNames := make([]string, 0, len(families))
+	for base := range families {
+		baseNames = append(baseNames, base)
+	}
+	sort.Strings(baseNames)
+
+	owners := make(map[string]*profileNormalizer, len(families))
+	var conflicts []profileOwnerConflict
+	for _, base := range baseNames {
+		var candidates []*profileNormalizer
+		for i := range normalizers {
+			normalizer := &normalizers[i]
+			if !normalizer.root.MatchString(base) {
+				continue
+			}
+			for _, physicalName := range families[base] {
+				if normalizer.pipeline.Matches(physicalName) {
+					candidates = append(candidates, normalizer)
+					break
+				}
+			}
+		}
+
+		switch len(candidates) {
+		case 0:
+		case 1:
+			owners[base] = candidates[0]
+		default:
+			names := make([]string, len(candidates))
+			for i, candidate := range candidates {
+				names[i] = candidate.name
+			}
+			sort.Strings(names)
+			conflicts = append(conflicts, profileOwnerConflict{family: base, profiles: names})
+		}
+	}
+	return owners, conflicts
+}
+
+func profileConflictError(conflicts []profileOwnerConflict) error {
+	conflict := conflicts[0]
+	return fmt.Errorf("profile relabeling ownership conflict for source family %q: profiles %s", conflict.family, strings.Join(conflict.profiles, ", "))
+}
+
+func sortedProfileScopeEscapes(set map[profileScopeEscape]struct{}) []profileScopeEscape {
+	escapes := make([]profileScopeEscape, 0, len(set))
+	for escape := range set {
+		escapes = append(escapes, escape)
+	}
+	sort.Slice(escapes, func(i, j int) bool {
+		if escapes[i].source != escapes[j].source {
+			return escapes[i].source < escapes[j].source
+		}
+		if escapes[i].profile != escapes[j].profile {
+			return escapes[i].profile < escapes[j].profile
+		}
+		return escapes[i].target < escapes[j].target
+	})
+	return escapes
+}
+
+func profileScopeError(escapes []profileScopeEscape) error {
+	escape := escapes[0]
+	return fmt.Errorf("profile %q relabeling moves source family %q to output family %q outside profile match", escape.profile, escape.source, escape.target)
+}

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
@@ -104,6 +104,27 @@ func TestCollector_ProfileRelabelingRejectsConflictingOwners(t *testing.T) {
 	assert.Nil(t, collr.runtime)
 }
 
+func TestResolveProfileOwnersSortsConflictDiagnostics(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"first":  testRelabelProfilePatternYAML("app_*", "app_*", "app_(.*)", "app_${1}", "app_a"),
+		"second": testRelabelProfilePatternYAML("app_*", "app_*", "app_(.*)", "app_${1}", "app_z"),
+	})
+	profiles, err := catalog.Resolve([]string{"second", "first"})
+	require.NoError(t, err)
+	normalizers, err := compileProfileNormalizers(profiles)
+	require.NoError(t, err)
+	batch := scrapeSamples(t, "# TYPE app_z gauge\napp_z 1\n# TYPE app_a gauge\napp_a 2\n")
+
+	for range 100 {
+		_, conflicts := resolveProfileOwners(batch, normalizers)
+		require.Len(t, conflicts, 2)
+		assert.Equal(t, "app_a", conflicts[0].family)
+		assert.Equal(t, []string{"first", "second"}, conflicts[0].profiles)
+		assert.Equal(t, "app_z", conflicts[1].family)
+		assert.Equal(t, []string{"first", "second"}, conflicts[1].profiles)
+	}
+}
+
 func TestCollector_ProfileRelabelingRejectsOutputOutsideProfileNamespace(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
 		"app": testRelabelProfileYAML("app_*", "app_raw", "other_final"),

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
@@ -1,0 +1,701 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package prometheus
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	commonmodel "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
+)
+
+func TestCollector_ProfileRelabelingAppliesAutomatically(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_raw", "app_final"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, `
+# TYPE app_raw gauge
+app_raw{id="1"} 7
+`, "app")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+
+	require.NoError(t, collr.Check(context.Background()))
+	require.Contains(t, collr.ChartTemplateYAML(), "app_final")
+	collectProfileRelabelOnce(t, collr)
+
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 7, value(t, got, "app_final", metrix.Labels{"id": "1"}), 1e-9)
+	noSeries(t, got, "app_raw", metrix.Labels{"id": "1"})
+}
+
+func TestCollector_ProfileRelabelingRunsAfterJobRelabeling(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_raw", "app_final"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, `
+# TYPE source_raw gauge
+source_raw 7
+`, "app")
+	defer srv.Close()
+	collr.Relabeling = []relabel.Block{{
+		Match: "source_*",
+		MetricRelabelConfigs: []relabel.Config{{
+			SourceLabels: []string{"__name__"},
+			Regex:        relabel.MustNewRegexp("source_raw"),
+			TargetLabel:  "__name__",
+			Replacement:  "app_raw",
+			Action:       relabel.Replace,
+		}},
+	}}
+	require.NoError(t, collr.Init(context.Background()))
+
+	require.NoError(t, collr.Check(context.Background()))
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 7, value(t, got, "app_final", nil), 1e-9)
+	noSeries(t, got, "app_raw", nil)
+}
+
+func TestCollector_ProfileRelabelingRemapsHelp(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_raw", "app_final"),
+	})
+	profiles, err := catalog.Resolve([]string{"app"})
+	require.NoError(t, err)
+	normalizers, err := compileProfileNormalizers(profiles)
+	require.NoError(t, err)
+
+	batch := scrapeSamples(t, "# HELP app_raw Application value.\n# TYPE app_raw gauge\napp_raw 1\n")
+	_, mfs, err := New().profileRelabelAndAssemble(batch, normalizers, true)
+	require.NoError(t, err)
+	renamed := mfs.Get("app_final")
+	require.NotNil(t, renamed)
+	assert.Equal(t, "Application value.", renamed.Help())
+}
+
+func TestCollector_ProfileRelabelingRejectsConflictingOwners(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"first":  testRelabelProfileYAML("app_*", "app_raw", "app_first"),
+		"second": testRelabelProfileYAML("app_*", "app_raw", "app_second"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, "app_raw 1\n", "first", "second")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+
+	err := collr.Check(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "app_raw")
+	assert.Contains(t, err.Error(), "first")
+	assert.Contains(t, err.Error(), "second")
+	assert.Nil(t, collr.runtime)
+}
+
+func TestCollector_ProfileRelabelingRejectsOutputOutsideProfileNamespace(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_raw", "other_final"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, "app_raw 1\n", "app")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+
+	err := collr.Check(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "app_raw")
+	assert.Contains(t, err.Error(), "other_final")
+	assert.Nil(t, collr.runtime)
+}
+
+func TestCollector_ProfileRelabelingPreservesPreProfileFallbackType(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_value_total", "app_value"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, "app_value_total 7\n", "app")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+
+	require.NoError(t, collr.Check(context.Background()))
+	collectProfileRelabelOnce(t, collr)
+	require.Contains(t, collr.writer.handles, "app_value")
+	assert.Equal(t, commonmodel.MetricTypeCounter, collr.writer.handles["app_value"].typ)
+}
+
+func TestCollector_ProfileRelabelingPreservesConfiguredGaugePrecedence(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_value_total", "app_value"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, "app_value_total 7\n", "app")
+	defer srv.Close()
+	collr.FallbackType.Gauge = []string{"app_value_total"}
+	require.NoError(t, collr.Init(context.Background()))
+
+	require.NoError(t, collr.Check(context.Background()))
+	collectProfileRelabelOnce(t, collr)
+	require.Contains(t, collr.writer.handles, "app_value")
+	assert.Equal(t, commonmodel.MetricTypeGauge, collr.writer.handles["app_value"].typ)
+}
+
+func TestCollector_ProfileRelabelingCannotCreateFallbackType(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_value", "app_value_total"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, "app_value 7\n", "app")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+
+	err := collr.Check(context.Background())
+	require.ErrorContains(t, err, "exposes no usable metrics")
+	assert.Nil(t, collr.runtime)
+}
+
+func TestCollector_ProfileRelabelingAllowsDisjointOwners(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"first":  testRelabelProfileYAML("app_*", "app_first_raw", "app_first_final"),
+		"second": testRelabelProfileYAML("app_*", "app_second_raw", "app_second_final"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, `
+# TYPE app_first_raw gauge
+app_first_raw 1
+# TYPE app_second_raw gauge
+app_second_raw 2
+`, "first", "second")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+
+	require.NoError(t, collr.Check(context.Background()))
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 1, value(t, got, "app_first_final", nil), 1e-9)
+	assert.InDelta(t, 2, value(t, got, "app_second_final", nil), 1e-9)
+}
+
+func TestCollector_ProfileRelabelingDropsRuntimeOnlyConflict(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"first":  testRelabelProfileYAML("app_*", "app_dynamic", "app_first"),
+		"second": testRelabelProfileYAML("app_*", "app_dynamic", "app_second"),
+	})
+	input := "# TYPE app_safe gauge\napp_safe 1\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: profilesModeExact, ModeExact: &ProfilesModeConfig{
+		Entries: profileEntries("first", "second"),
+	}}
+	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) { return catalog, nil }
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+
+	input = `
+# TYPE app_safe gauge
+app_safe 2
+# TYPE app_dynamic gauge
+app_dynamic 3
+`
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 2, value(t, got, "app_safe", nil), 1e-9)
+	noSeries(t, got, "app_dynamic", nil)
+	noSeries(t, got, "app_first", nil)
+	noSeries(t, got, "app_second", nil)
+}
+
+func TestCollector_ProfileRelabelingDropsRuntimeOnlyScopeEscape(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_dynamic", "other_dynamic"),
+	})
+	input := "# TYPE app_safe gauge\napp_safe 1\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: profilesModeExact, ModeExact: &ProfilesModeConfig{
+		Entries: profileEntries("app"),
+	}}
+	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) { return catalog, nil }
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+
+	input = `
+# TYPE app_safe gauge
+app_safe 2
+# TYPE app_dynamic gauge
+app_dynamic 3
+`
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 2, value(t, got, "app_safe", nil), 1e-9)
+	noSeries(t, got, "app_dynamic", nil)
+	noSeries(t, got, "other_dynamic", nil)
+}
+
+func TestCollector_ProfileRelabelingTypedFamilyCorruptionFailsCheck(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_lat_sum", "app_other_sum"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, `
+# TYPE app_lat histogram
+app_lat_bucket{le="+Inf"} 6
+app_lat_sum 2.5
+app_lat_count 6
+`, "app")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+
+	err := collr.Check(context.Background())
+	require.ErrorContains(t, err, "profile relabeling corrupts typed metric families")
+	assert.Nil(t, collr.runtime)
+}
+
+func TestCollector_ProfileRelabelingTypedFamilyRuntimeDriftIsContained(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_lat_sum", "app_other_sum"),
+	})
+	input := "# TYPE app_safe gauge\napp_safe 1\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: profilesModeExact, ModeExact: &ProfilesModeConfig{
+		Entries: profileEntries("app"),
+	}}
+	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) { return catalog, nil }
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+
+	input = `
+# TYPE app_safe gauge
+app_safe 2
+# TYPE app_lat histogram
+app_lat_bucket{le="+Inf"} 6
+app_lat_sum 2.5
+app_lat_count 6
+`
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 2, value(t, got, "app_safe", nil), 1e-9)
+	noSeries(t, got, "app_lat_bucket", metrix.Labels{"le": "+Inf"})
+	noSeries(t, got, "app_other_sum", nil)
+}
+
+func TestCollector_ProfileRelabelingCleanTypedFamilyRename(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfilePatternYAML("app_*", "app_lat*", "app_lat(.*)", "app_renamed${1}", "app_renamed"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, `
+# TYPE app_lat histogram
+app_lat_bucket{le="+Inf"} 6
+app_lat_sum 2.5
+app_lat_count 6
+`, "app")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+
+	require.NoError(t, collr.Check(context.Background()))
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 6, value(t, got, "app_renamed_bucket", metrix.Labels{"le": "+Inf"}), 1e-9)
+	assert.InDelta(t, 2.5, value(t, got, "app_renamed_sum", nil), 1e-9)
+	assert.InDelta(t, 6, value(t, got, "app_renamed_count", nil), 1e-9)
+}
+
+func TestCollector_CombinedRelabelingDoesNotResurrectJobCorruption(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_safe", "app_safe_final"),
+	})
+	input := "# TYPE app_safe gauge\napp_safe 1\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: profilesModeExact, ModeExact: &ProfilesModeConfig{
+		Entries: profileEntries("app"),
+	}}
+	collr.Relabeling = []relabel.Block{{
+		Match: "*",
+		MetricRelabelConfigs: []relabel.Config{{
+			SourceLabels: []string{"__name__"},
+			Regex:        relabel.MustNewRegexp("app_lat_sum"),
+			TargetLabel:  "__name__",
+			Replacement:  "app_other_sum",
+			Action:       relabel.Replace,
+		}},
+	}}
+	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) { return catalog, nil }
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+
+	input = `
+# TYPE app_safe gauge
+app_safe 2
+# TYPE app_lat histogram
+app_lat_bucket{le="+Inf"} 6
+app_lat_sum 2.5
+app_lat_count 6
+`
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 2, value(t, got, "app_safe_final", nil), 1e-9)
+	noSeries(t, got, "app_lat_bucket", metrix.Labels{"le": "+Inf"})
+	noSeries(t, got, "app_other_sum", nil)
+}
+
+func TestCollector_ProfileRelabelingFinalGatesUseNormalizedOutput(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testDropProfileYAML("app_*", "app_drop", "app_drop", "app_keep"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, `
+# TYPE app_keep gauge
+app_keep 1
+# TYPE app_drop gauge
+app_drop 2
+`, "app")
+	defer srv.Close()
+	collr.MaxTS = 1
+	require.NoError(t, collr.Init(context.Background()))
+
+	require.NoError(t, collr.Check(context.Background()), "the final one-series output must satisfy MaxTS")
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 1, value(t, got, "app_keep", nil), 1e-9)
+	noSeries(t, got, "app_drop", nil)
+}
+
+func TestCollector_ProfileRelabelingEmptyFinalOutputFailsCheck(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testDropProfileYAML("app_*", "app_drop", "app_drop", "app_drop"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, "# TYPE app_drop gauge\napp_drop 2\n", "app")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+
+	err := collr.Check(context.Background())
+	require.ErrorContains(t, err, "returned 0 metric families")
+	assert.Nil(t, collr.runtime)
+}
+
+func TestCollector_ProfilesModeNoneSkipsCatalogAndProfileRelabeling(t *testing.T) {
+	var catalogLoads atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("# TYPE app_raw gauge\napp_raw 1\n"))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: profilesModeNone}
+	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) {
+		catalogLoads.Add(1)
+		return promprofiles.Catalog{}, fmt.Errorf("must not load")
+	}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	collectProfileRelabelOnce(t, collr)
+
+	assert.Zero(t, catalogLoads.Load())
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 1, value(t, got, "app_raw", nil), 1e-9)
+}
+
+func TestCollector_UnselectedProfileRelabelingDoesNotApply(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"other": testRelabelProfileYAML("other_*", "app_raw", "other_final"),
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("# TYPE app_raw gauge\napp_raw 1\n"))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) { return catalog, nil }
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	collectProfileRelabelOnce(t, collr)
+
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 1, value(t, got, "app_raw", nil), 1e-9)
+	noSeries(t, got, "other_final", nil)
+}
+
+func TestCollector_ProfileRelabelingCheckRetryIsTransactional(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_raw", "other_final"),
+	})
+	input := "# TYPE app_raw gauge\napp_raw 1\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: profilesModeExact, ModeExact: &ProfilesModeConfig{
+		Entries: profileEntries("app"),
+	}}
+	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) { return catalog, nil }
+	require.NoError(t, collr.Init(context.Background()))
+
+	require.Error(t, collr.Check(context.Background()))
+	assert.Nil(t, collr.runtime)
+	assert.Empty(t, collr.ChartTemplateYAML())
+
+	input = "# TYPE app_safe gauge\napp_safe 2\n"
+	require.NoError(t, collr.Check(context.Background()))
+	assert.NotNil(t, collr.runtime)
+	assert.NotEmpty(t, collr.ChartTemplateYAML())
+}
+
+func TestCollector_ProfileRelabelingCannotSatisfyExpectedPrefix(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_raw", "app_final"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, "# TYPE app_raw gauge\napp_raw 1\n", "app")
+	defer srv.Close()
+	collr.ExpectedPrefix = "app_final"
+	require.NoError(t, collr.Init(context.Background()))
+
+	err := collr.Check(context.Background())
+	require.ErrorContains(t, err, "no expected prefix")
+	assert.Nil(t, collr.runtime)
+}
+
+func TestCollector_CollectRequiresPublishedRuntime(t *testing.T) {
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte("# TYPE app_raw gauge\napp_raw 1\n"))
+	}))
+	defer srv.Close()
+
+	var catalogLoads atomic.Int64
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: profilesModeNone}
+	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) {
+		catalogLoads.Add(1)
+		return promprofiles.Catalog{}, nil
+	}
+	require.NoError(t, collr.Init(context.Background()))
+
+	err := collr.Collect(context.Background())
+	require.ErrorContains(t, err, "successful Check")
+	assert.Zero(t, requests.Load())
+	assert.Zero(t, catalogLoads.Load())
+
+	require.NoError(t, collr.Check(context.Background()))
+	collr.Cleanup(context.Background())
+	requests.Store(0)
+	err = collr.Collect(context.Background())
+	require.ErrorContains(t, err, "successful Check")
+	assert.Zero(t, requests.Load())
+}
+
+func TestCollector_ProfileRelabelingScrapeDispatch(t *testing.T) {
+	plainCatalog := loadTestCatalog(t, map[string]string{"app": testProfileYAML("app_*")})
+	relabelCatalog := loadTestCatalog(t, map[string]string{
+		"app": testRelabelProfileYAML("app_*", "app_raw", "app_final"),
+	})
+
+	tests := map[string]struct {
+		prepare         func(*Collector)
+		hasCatalog      bool
+		catalog         promprofiles.Catalog
+		wantFamilyCalls int
+		wantSampleCalls int
+	}{
+		"no profiles and no job rules stays direct": {
+			prepare:         func(c *Collector) { c.Profiles = ProfilesConfig{Mode: profilesModeNone} },
+			wantFamilyCalls: 2,
+		},
+		"job rules use samples": {
+			prepare: func(c *Collector) {
+				c.Profiles = ProfilesConfig{Mode: profilesModeNone}
+				c.Relabeling = []relabel.Block{{Match: "*", MetricRelabelConfigs: []relabel.Config{{
+					SourceLabels: []string{"__name__"},
+					Regex:        relabel.MustNewRegexp("does_not_match"),
+					Action:       relabel.Drop,
+				}}}}
+			},
+			wantSampleCalls: 2,
+		},
+		"profile selection buffers Check but recurring no-rules Collect stays direct": {
+			prepare: func(c *Collector) {
+				c.Profiles = ProfilesConfig{Mode: profilesModeExact, ModeExact: &ProfilesModeConfig{Entries: profileEntries("app")}}
+			},
+			hasCatalog:      true,
+			catalog:         plainCatalog,
+			wantFamilyCalls: 1,
+			wantSampleCalls: 1,
+		},
+		"selected profile rules use samples": {
+			prepare: func(c *Collector) {
+				c.Profiles = ProfilesConfig{Mode: profilesModeExact, ModeExact: &ProfilesModeConfig{Entries: profileEntries("app")}}
+			},
+			hasCatalog:      true,
+			catalog:         relabelCatalog,
+			wantSampleCalls: 2,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			batch := scrapeSamples(t, "# TYPE app_raw gauge\napp_raw 1\n")
+			mfs, err := prompkg.Assemble(batch)
+			require.NoError(t, err)
+			fake := &countingPrometheus{batch: batch, mfs: mfs}
+
+			collr := New()
+			collr.URL = "http://127.0.0.1:1"
+			tc.prepare(collr)
+			if tc.hasCatalog {
+				collr.loadProfileCatalog = func() (promprofiles.Catalog, error) { return tc.catalog, nil }
+			}
+			require.NoError(t, collr.Init(context.Background()))
+			collr.prom = fake
+			require.NoError(t, collr.Check(context.Background()))
+			collectProfileRelabelOnce(t, collr)
+
+			assert.Equal(t, tc.wantFamilyCalls, fake.familyCalls)
+			assert.Equal(t, tc.wantSampleCalls, fake.sampleCalls)
+		})
+	}
+}
+
+type countingPrometheus struct {
+	batch       prompkg.SampleBatch
+	mfs         prompkg.MetricFamilies
+	familyCalls int
+	sampleCalls int
+}
+
+func (p *countingPrometheus) ScrapeSeries() (prompkg.Series, error) { return nil, nil }
+
+func (p *countingPrometheus) Scrape() (prompkg.MetricFamilies, error) {
+	return p.ScrapeContext(context.Background())
+}
+
+func (p *countingPrometheus) ScrapeContext(context.Context) (prompkg.MetricFamilies, error) {
+	p.familyCalls++
+	return p.mfs, nil
+}
+
+func (p *countingPrometheus) ScrapeSamples(context.Context) (prompkg.SampleBatch, error) {
+	p.sampleCalls++
+	return prompkg.SampleBatch{
+		Help:    slices.Clone(p.batch.Help),
+		Samples: slices.Clone(p.batch.Samples),
+	}, nil
+}
+
+func (p *countingPrometheus) HTTPClient() *http.Client { return nil }
+
+func newProfileRelabelCollector(t *testing.T, catalog promprofiles.Catalog, input string, profiles ...string) (*Collector, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input))
+	}))
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{
+		Mode:      profilesModeExact,
+		ModeExact: &ProfilesModeConfig{Entries: profileEntries(profiles...)},
+	}
+	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) { return catalog, nil }
+	return collr, srv
+}
+
+func collectProfileRelabelOnce(t *testing.T, collr *Collector) {
+	t.Helper()
+	cc := cycle(t, collr.MetricStore())
+	cc.BeginCycle()
+	require.NoError(t, collr.Collect(context.Background()))
+	require.NoError(t, cc.CommitCycleSuccess())
+}
+
+func profileEntries(names ...string) []ProfileEntryConfig {
+	out := make([]ProfileEntryConfig, len(names))
+	for i, name := range names {
+		out[i] = ProfileEntryConfig{Name: name}
+	}
+	return out
+}
+
+func testRelabelProfileYAML(rootMatch, source, target string) string {
+	return testRelabelProfilePatternYAML(rootMatch, source, source, target, target)
+}
+
+func testRelabelProfilePatternYAML(rootMatch, blockMatch, regex, replacement, chartMetric string) string {
+	return strings.Join([]string{
+		fmt.Sprintf("match: %q", rootMatch),
+		"relabeling:",
+		fmt.Sprintf("  - match: %q", blockMatch),
+		"    metric_relabel_configs:",
+		"      - source_labels: [__name__]",
+		fmt.Sprintf("        regex: %q", regex),
+		"        target_label: __name__",
+		fmt.Sprintf("        replacement: %q", replacement),
+		"        action: replace",
+		"template:",
+		"  family: Test",
+		"  context_namespace: test",
+		"  metrics:",
+		"    - " + chartMetric,
+		"  charts:",
+		"    - title: Relabeled",
+		"      context: " + chartMetric,
+		"      units: value",
+		"      dimensions:",
+		"        - selector: " + chartMetric,
+		"          name: value",
+	}, "\n") + "\n"
+}
+
+func testDropProfileYAML(rootMatch, blockMatch, regex, chartMetric string) string {
+	return strings.Join([]string{
+		fmt.Sprintf("match: %q", rootMatch),
+		"relabeling:",
+		fmt.Sprintf("  - match: %q", blockMatch),
+		"    metric_relabel_configs:",
+		"      - source_labels: [__name__]",
+		fmt.Sprintf("        regex: %q", regex),
+		"        action: drop",
+		"template:",
+		"  family: Test",
+		"  context_namespace: test",
+		"  metrics:",
+		"    - " + chartMetric,
+		"  charts:",
+		"    - title: Relabeled",
+		"      context: " + chartMetric,
+		"      units: value",
+		"      dimensions:",
+		"        - selector: " + chartMetric,
+		"          name: value",
+	}, "\n") + "\n"
+}

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
@@ -80,7 +80,7 @@ func TestCollector_ProfileRelabelingRemapsHelp(t *testing.T) {
 	require.NoError(t, err)
 
 	batch := scrapeSamples(t, "# HELP app_raw Application value.\n# TYPE app_raw gauge\napp_raw 1\n")
-	_, mfs, err := New().profileRelabelAndAssemble(batch, normalizers, true)
+	mfs, err := New().profileRelabelAndAssemble(batch, normalizers, true)
 	require.NoError(t, err)
 	renamed := mfs.Get("app_final")
 	require.NotNil(t, renamed)

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
@@ -128,8 +129,8 @@ func TestCollector_ProfileRelabelingUsesFirstApplicableNormalizer(t *testing.T) 
 
 func TestCollector_ProfileRelabelingCombinedEntriesPrecedeAutoProfiles(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
-		"alpha": testRelabelProfileYAML("app_*", "app_raw", "app_alpha"),
-		"zeta":  testRelabelProfileYAML("app_*", "app_raw", "app_zeta"),
+		"alpha": strings.Replace(testRelabelProfileYAML("app_*", "app_raw", "app_alpha"), "template:\n", "app: alpha\ntemplate:\n", 1),
+		"zeta":  strings.Replace(testRelabelProfileYAML("app_*", "app_raw", "app_zeta"), "template:\n", "app: zeta\ntemplate:\n", 1),
 	})
 	collr, srv := newProfileRelabelCollector(t, catalog, "# TYPE app_raw gauge\napp_raw 1\n")
 	defer srv.Close()
@@ -144,6 +145,41 @@ func TestCollector_ProfileRelabelingCombinedEntriesPrecedeAutoProfiles(t *testin
 	assert.InDelta(t, 1, value(t, got, "app_zeta", nil), 1e-9)
 	noSeries(t, got, "app_alpha", nil)
 	noSeries(t, got, "app_raw", nil)
+
+	spec, err := charttpl.DecodeYAML([]byte(collr.ChartTemplateYAML()))
+	require.NoError(t, err)
+	assert.Equal(t, "prometheus.alpha", spec.ContextNamespace)
+	require.Len(t, spec.Groups, 3)
+	assert.Equal(t, []string{"app_alpha"}, spec.Groups[1].Metrics)
+	assert.Equal(t, []string{"app_zeta"}, spec.Groups[2].Metrics)
+}
+
+func TestCollector_ProfileRelabelingAutoNameOrderDoesNotChangeProfileSelectionOrder(t *testing.T) {
+	catalog := loadTestCatalogFromOrderedDirs(t,
+		map[string]string{
+			"zeta": strings.Replace(testRelabelProfileYAML("app_*", "app_raw", "app_zeta"), "template:\n", "app: zeta\ntemplate:\n", 1),
+		},
+		map[string]string{
+			"alpha": strings.Replace(testRelabelProfileYAML("app_*", "app_raw", "app_alpha"), "template:\n", "app: alpha\ntemplate:\n", 1),
+		},
+	)
+	collr, srv := newProfileRelabelCollector(t, catalog, "# TYPE app_raw gauge\napp_raw 1\n")
+	defer srv.Close()
+	collr.Profiles = ProfilesConfig{Mode: profilesModeAuto}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 1, value(t, got, "app_alpha", nil), 1e-9)
+	noSeries(t, got, "app_zeta", nil)
+
+	spec, err := charttpl.DecodeYAML([]byte(collr.ChartTemplateYAML()))
+	require.NoError(t, err)
+	assert.Equal(t, "prometheus.zeta", spec.ContextNamespace)
+	require.Len(t, spec.Groups, 3)
+	assert.Equal(t, []string{"app_zeta"}, spec.Groups[1].Metrics)
+	assert.Equal(t, []string{"app_alpha"}, spec.Groups[2].Metrics)
 }
 
 func TestSelectProfileNormalizersSkipsProfilesWhoseBlocksDoNotMatch(t *testing.T) {
@@ -165,23 +201,38 @@ func TestSelectProfileNormalizersSkipsProfilesWhoseBlocksDoNotMatch(t *testing.T
 func TestSelectProfileNormalizersUsesFamilyPrecedenceAcrossPhysicalSamples(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
 		"first":  testRelabelProfileYAML("app_*", "app_lat_sum", "app_first_sum"),
-		"second": testRelabelProfileYAML("app_*", "app_lat_bucket", "app_second_bucket"),
+		"middle": testRelabelProfileYAML("app_*", "app_lat_count", "app_middle_count"),
+		"last":   testRelabelProfileYAML("app_*", "app_lat_bucket", "app_last_bucket"),
 	})
-	profiles, err := catalog.Resolve([]string{"first", "second"})
+	profiles, err := catalog.Resolve([]string{"first", "middle", "last"})
 	require.NoError(t, err)
 	normalizers, err := compileProfileNormalizers(profiles)
 	require.NoError(t, err)
-	batch := scrapeSamples(t, `
+
+	inputs := map[string]string{
+		"lower precedence components first": `
 # TYPE app_lat histogram
 app_lat_bucket{le="0.5"} 4
 app_lat_bucket{le="+Inf"} 6
+app_lat_count 6
+app_lat_sum 2.5
+`,
+		"highest precedence component first": `
+# TYPE app_lat histogram
 app_lat_sum 2.5
 app_lat_count 6
-`)
+app_lat_bucket{le="0.5"} 4
+app_lat_bucket{le="+Inf"} 6
+`,
+	}
 
-	selected := selectProfileNormalizers(batch, normalizers)
-	require.Contains(t, selected, "app_lat")
-	assert.Equal(t, 0, selected["app_lat"])
+	for name, input := range inputs {
+		t.Run(name, func(t *testing.T) {
+			selected := selectProfileNormalizers(scrapeSamples(t, input), normalizers)
+			require.Contains(t, selected, "app_lat")
+			assert.Equal(t, 0, selected["app_lat"])
+		})
+	}
 }
 
 func TestCollector_ProfileRelabelingDoesNotChainProfiles(t *testing.T) {

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
@@ -87,57 +87,131 @@ func TestCollector_ProfileRelabelingRemapsHelp(t *testing.T) {
 	assert.Equal(t, "Application value.", renamed.Help())
 }
 
-func TestCollector_ProfileRelabelingRejectsConflictingOwners(t *testing.T) {
+func TestCollector_ProfileRelabelingUsesFirstApplicableNormalizer(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
 		"first":  testRelabelProfileYAML("app_*", "app_raw", "app_first"),
 		"second": testRelabelProfileYAML("app_*", "app_raw", "app_second"),
 	})
-	collr, srv := newProfileRelabelCollector(t, catalog, "app_raw 1\n", "first", "second")
-	defer srv.Close()
-	require.NoError(t, collr.Init(context.Background()))
 
-	err := collr.Check(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "app_raw")
-	assert.Contains(t, err.Error(), "first")
-	assert.Contains(t, err.Error(), "second")
-	assert.Nil(t, collr.runtime)
-}
+	tests := map[string]struct {
+		profiles []string
+		want     string
+		shadowed string
+	}{
+		"configured first profile wins": {
+			profiles: []string{"first", "second"},
+			want:     "app_first",
+			shadowed: "app_second",
+		},
+		"reversing configured order changes precedence": {
+			profiles: []string{"second", "first"},
+			want:     "app_second",
+			shadowed: "app_first",
+		},
+	}
 
-func TestResolveProfileOwnersSortsConflictDiagnostics(t *testing.T) {
-	catalog := loadTestCatalog(t, map[string]string{
-		"first":  testRelabelProfilePatternYAML("app_*", "app_*", "app_(.*)", "app_${1}", "app_a"),
-		"second": testRelabelProfilePatternYAML("app_*", "app_*", "app_(.*)", "app_${1}", "app_z"),
-	})
-	profiles, err := catalog.Resolve([]string{"second", "first"})
-	require.NoError(t, err)
-	normalizers, err := compileProfileNormalizers(profiles)
-	require.NoError(t, err)
-	batch := scrapeSamples(t, "# TYPE app_z gauge\napp_z 1\n# TYPE app_a gauge\napp_a 2\n")
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			collr, srv := newProfileRelabelCollector(t, catalog, "# TYPE app_raw gauge\napp_raw 1\n", tc.profiles...)
+			defer srv.Close()
+			require.NoError(t, collr.Init(context.Background()))
+			require.NoError(t, collr.Check(context.Background()))
 
-	for range 100 {
-		_, conflicts := resolveProfileOwners(batch, normalizers)
-		require.Len(t, conflicts, 2)
-		assert.Equal(t, "app_a", conflicts[0].family)
-		assert.Equal(t, []string{"first", "second"}, conflicts[0].profiles)
-		assert.Equal(t, "app_z", conflicts[1].family)
-		assert.Equal(t, []string{"first", "second"}, conflicts[1].profiles)
+			collectProfileRelabelOnce(t, collr)
+			got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+			assert.InDelta(t, 1, value(t, got, tc.want, nil), 1e-9)
+			noSeries(t, got, tc.shadowed, nil)
+			noSeries(t, got, "app_raw", nil)
+		})
 	}
 }
 
-func TestCollector_ProfileRelabelingRejectsOutputOutsideProfileNamespace(t *testing.T) {
+func TestCollector_ProfileRelabelingCombinedEntriesPrecedeAutoProfiles(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"alpha": testRelabelProfileYAML("app_*", "app_raw", "app_alpha"),
+		"zeta":  testRelabelProfileYAML("app_*", "app_raw", "app_zeta"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, "# TYPE app_raw gauge\napp_raw 1\n")
+	defer srv.Close()
+	collr.Profiles = ProfilesConfig{Mode: profilesModeCombined, ModeCombined: &ProfilesModeConfig{
+		Entries: profileEntries("zeta"),
+	}}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 1, value(t, got, "app_zeta", nil), 1e-9)
+	noSeries(t, got, "app_alpha", nil)
+	noSeries(t, got, "app_raw", nil)
+}
+
+func TestSelectProfileNormalizersSkipsProfilesWhoseBlocksDoNotMatch(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"first":  testRelabelProfileYAML("app_*", "app_other", "app_first"),
+		"second": testRelabelProfileYAML("app_*", "app_raw", "app_second"),
+	})
+	profiles, err := catalog.Resolve([]string{"first", "second"})
+	require.NoError(t, err)
+	normalizers, err := compileProfileNormalizers(profiles)
+	require.NoError(t, err)
+	batch := scrapeSamples(t, "# TYPE app_raw gauge\napp_raw 1\n")
+
+	selected := selectProfileNormalizers(batch, normalizers)
+	require.Contains(t, selected, "app_raw")
+	assert.Equal(t, 1, selected["app_raw"])
+}
+
+func TestSelectProfileNormalizersUsesFamilyPrecedenceAcrossPhysicalSamples(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"first":  testRelabelProfileYAML("app_*", "app_lat_sum", "app_first_sum"),
+		"second": testRelabelProfileYAML("app_*", "app_lat_bucket", "app_second_bucket"),
+	})
+	profiles, err := catalog.Resolve([]string{"first", "second"})
+	require.NoError(t, err)
+	normalizers, err := compileProfileNormalizers(profiles)
+	require.NoError(t, err)
+	batch := scrapeSamples(t, `
+# TYPE app_lat histogram
+app_lat_bucket{le="+Inf"} 6
+app_lat_sum 2.5
+app_lat_count 6
+`)
+
+	selected := selectProfileNormalizers(batch, normalizers)
+	require.Contains(t, selected, "app_lat")
+	assert.Equal(t, 0, selected["app_lat"])
+}
+
+func TestCollector_ProfileRelabelingDoesNotChainProfiles(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"first":  testRelabelProfileYAML("app_*", "app_raw", "app_mid"),
+		"second": testRelabelProfileYAML("app_*", "app_mid", "app_final"),
+	})
+	collr, srv := newProfileRelabelCollector(t, catalog, "# TYPE app_raw gauge\napp_raw 1\n", "first", "second")
+	defer srv.Close()
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 1, value(t, got, "app_mid", nil), 1e-9)
+	noSeries(t, got, "app_final", nil)
+}
+
+func TestCollector_ProfileRelabelingAllowsOutputOutsideProfileMatch(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
 		"app": testRelabelProfileYAML("app_*", "app_raw", "other_final"),
 	})
-	collr, srv := newProfileRelabelCollector(t, catalog, "app_raw 1\n", "app")
+	collr, srv := newProfileRelabelCollector(t, catalog, "# TYPE app_raw gauge\napp_raw 1\n", "app")
 	defer srv.Close()
 	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
 
-	err := collr.Check(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "app_raw")
-	assert.Contains(t, err.Error(), "other_final")
-	assert.Nil(t, collr.runtime)
+	collectProfileRelabelOnce(t, collr)
+	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	assert.InDelta(t, 1, value(t, got, "other_final", nil), 1e-9)
+	noSeries(t, got, "app_raw", nil)
 }
 
 func TestCollector_ProfileRelabelingPreservesPreProfileFallbackType(t *testing.T) {
@@ -182,7 +256,7 @@ func TestCollector_ProfileRelabelingCannotCreateFallbackType(t *testing.T) {
 	assert.Nil(t, collr.runtime)
 }
 
-func TestCollector_ProfileRelabelingAllowsDisjointOwners(t *testing.T) {
+func TestCollector_ProfileRelabelingDispatchesDisjointFamilies(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
 		"first":  testRelabelProfileYAML("app_*", "app_first_raw", "app_first_final"),
 		"second": testRelabelProfileYAML("app_*", "app_second_raw", "app_second_final"),
@@ -203,7 +277,7 @@ app_second_raw 2
 	assert.InDelta(t, 2, value(t, got, "app_second_final", nil), 1e-9)
 }
 
-func TestCollector_ProfileRelabelingDropsRuntimeOnlyConflict(t *testing.T) {
+func TestCollector_ProfileRelabelingUsesFirstNormalizerForNewRuntimeFamily(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
 		"first":  testRelabelProfileYAML("app_*", "app_dynamic", "app_first"),
 		"second": testRelabelProfileYAML("app_*", "app_dynamic", "app_second"),
@@ -233,40 +307,8 @@ app_dynamic 3
 	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
 	assert.InDelta(t, 2, value(t, got, "app_safe", nil), 1e-9)
 	noSeries(t, got, "app_dynamic", nil)
-	noSeries(t, got, "app_first", nil)
+	assert.InDelta(t, 3, value(t, got, "app_first", nil), 1e-9)
 	noSeries(t, got, "app_second", nil)
-}
-
-func TestCollector_ProfileRelabelingDropsRuntimeOnlyScopeEscape(t *testing.T) {
-	catalog := loadTestCatalog(t, map[string]string{
-		"app": testRelabelProfileYAML("app_*", "app_dynamic", "other_dynamic"),
-	})
-	input := "# TYPE app_safe gauge\napp_safe 1\n"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(input))
-	}))
-	defer srv.Close()
-
-	collr := New()
-	collr.URL = srv.URL
-	collr.Profiles = ProfilesConfig{Mode: profilesModeExact, ModeExact: &ProfilesModeConfig{
-		Entries: profileEntries("app"),
-	}}
-	collr.loadProfileCatalog = func() (promprofiles.Catalog, error) { return catalog, nil }
-	require.NoError(t, collr.Init(context.Background()))
-	require.NoError(t, collr.Check(context.Background()))
-
-	input = `
-# TYPE app_safe gauge
-app_safe 2
-# TYPE app_dynamic gauge
-app_dynamic 3
-`
-	collectProfileRelabelOnce(t, collr)
-	got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
-	assert.InDelta(t, 2, value(t, got, "app_safe", nil), 1e-9)
-	noSeries(t, got, "app_dynamic", nil)
-	noSeries(t, got, "other_dynamic", nil)
 }
 
 func TestCollector_ProfileRelabelingTypedFamilyCorruptionFailsCheck(t *testing.T) {
@@ -466,9 +508,14 @@ func TestCollector_UnselectedProfileRelabelingDoesNotApply(t *testing.T) {
 
 func TestCollector_ProfileRelabelingCheckRetryIsTransactional(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
-		"app": testRelabelProfileYAML("app_*", "app_raw", "other_final"),
+		"app": testRelabelProfileYAML("app_*", "app_lat_sum", "app_other_sum"),
 	})
-	input := "# TYPE app_raw gauge\napp_raw 1\n"
+	input := `
+# TYPE app_lat histogram
+app_lat_bucket{le="+Inf"} 6
+app_lat_sum 2.5
+app_lat_count 6
+`
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(input))
 	}))

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
@@ -308,6 +308,81 @@ func TestCollector_ProfileRelabelingCannotCreateFallbackType(t *testing.T) {
 	assert.Nil(t, collr.runtime)
 }
 
+func TestCollector_ProfileRelabelingDoesNotShareFallbackEligibilityAcrossMergedFamily(t *testing.T) {
+	tests := map[string]struct {
+		boundName    string
+		boundType    string
+		unboundFirst bool
+		configure    func(*Collector)
+		wantType     commonmodel.MetricType
+	}{
+		"configured gauge": {
+			boundName: "app_bound",
+			configure: func(c *Collector) {
+				c.FallbackType.Gauge = []string{"app_bound"}
+			},
+			wantType: commonmodel.MetricTypeGauge,
+		},
+		"configured counter": {
+			boundName:    "app_bound",
+			unboundFirst: true,
+			configure: func(c *Collector) {
+				c.FallbackType.Counter = []string{"app_bound"}
+			},
+			wantType: commonmodel.MetricTypeCounter,
+		},
+		"implicit total counter": {
+			boundName: "app_bound_total",
+			wantType:  commonmodel.MetricTypeCounter,
+		},
+		"declared gauge": {
+			boundName: "app_bound",
+			boundType: "gauge",
+			wantType:  commonmodel.MetricTypeGauge,
+		},
+		"declared counter": {
+			boundName: "app_bound",
+			boundType: "counter",
+			wantType:  commonmodel.MetricTypeCounter,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			catalog := loadTestCatalog(t, map[string]string{
+				"app": testRelabelProfilePatternYAML("app_*", "app_*", "app_.+", "app_final", "app_final"),
+			})
+			bound := fmt.Sprintf("%s{eligibility=\"bound\"} 7\n", tc.boundName)
+			unbound := "app_unbound{eligibility=\"unbound\"} 9\n"
+			if tc.unboundFirst {
+				bound, unbound = unbound, bound
+			}
+			input := bound + unbound
+			if tc.boundType != "" {
+				input = fmt.Sprintf("# TYPE %s %s\n", tc.boundName, tc.boundType) + input
+			}
+			collr, srv := newProfileRelabelCollector(t, catalog, input, "app")
+			defer srv.Close()
+			if tc.configure != nil {
+				tc.configure(collr)
+			}
+			require.NoError(t, collr.Init(context.Background()))
+
+			require.NoError(t, collr.Check(context.Background()))
+			mfs, err := collr.scrapeProfileNormalized(context.Background(), collr.runtime.normalizers, true)
+			require.NoError(t, err)
+			assert.Equal(t, 1, collr.writer.countBoundWritable(mfs), "Check must count only the pre-profile bound sample")
+
+			collectProfileRelabelOnce(t, collr)
+			got := collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten())
+			assert.InDelta(t, 7, value(t, got, "app_final", metrix.Labels{"eligibility": "bound"}), 1e-9)
+			noSeries(t, got, "app_final", metrix.Labels{"eligibility": "unbound"})
+			require.Contains(t, collr.writer.handles, "app_final")
+			assert.Equal(t, tc.wantType, collr.writer.handles["app_final"].typ)
+		})
+	}
+}
+
 func TestCollector_ProfileRelabelingDispatchesDisjointFamilies(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
 		"first":  testRelabelProfileYAML("app_*", "app_first_raw", "app_first_final"),

--- a/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/profile_relabel_test.go
@@ -173,6 +173,7 @@ func TestSelectProfileNormalizersUsesFamilyPrecedenceAcrossPhysicalSamples(t *te
 	require.NoError(t, err)
 	batch := scrapeSamples(t, `
 # TYPE app_lat histogram
+app_lat_bucket{le="0.5"} 4
 app_lat_bucket{le="+Inf"} 6
 app_lat_sum 2.5
 app_lat_count 6

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog.go
@@ -4,6 +4,7 @@ package promprofiles
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -71,37 +72,40 @@ func LoadFromDirs(specs []DirSpec) (Catalog, error) {
 	return Catalog{core: core}, nil
 }
 
-// decodeProfile strict-decodes the profile header (match, app, and the template
-// as an un-decoded node), retains the raw bytes for lazy hydration, and
-// validates the header. A user profile additionally validates its template at
-// load, so a broken user profile is skipped (the stock profile of the same name
-// survives); stock template validation is deferred to first use.
+// decodeProfile strict-decodes the one top-level profile document, retaining
+// template and relabeling nodes for lazy stock hydration. User profiles hydrate
+// both fields eagerly so a broken override is skipped and valid stock survives.
 func decodeProfile(data []byte, baseName string, isStock bool) (Profile, error) {
-	var hdr profileHeader
+	var doc profileDocument
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
-	if err := dec.Decode(&hdr); err != nil {
+	if err := dec.Decode(&doc); err != nil {
 		return Profile{}, fmt.Errorf("unmarshal profile %q: %w", baseName, err)
 	}
 
 	p := Profile{
 		Name:            baseName,
-		Match:           hdr.Match,
-		App:             hdr.App,
+		Match:           doc.Match,
+		App:             doc.App,
 		autogenSelector: nil,
-		lazy:            &lazyTemplate{raw: data},
+		lazy: &lazyProfile{
+			template:   doc.Template,
+			relabeling: doc.Relabeling,
+		},
 	}
-	if hdr.Autogen != nil {
-		if hdr.Autogen.Selector == nil {
+	if doc.Autogen != nil {
+		if doc.Autogen.Selector == nil {
 			return Profile{}, fmt.Errorf("profile %q: 'autogen.selector' is required when 'autogen' is set", baseName)
 		}
-		p.autogenSelector = cloneSelectorExpr(hdr.Autogen.Selector)
+		p.autogenSelector = cloneSelectorExpr(doc.Autogen.Selector)
 	}
 	if err := p.validateHeader(); err != nil {
 		return Profile{}, err
 	}
 	if !isStock {
-		if _, err := p.Template(); err != nil {
+		_, templateErr := p.Template()
+		_, relabelingErr := p.Relabeling()
+		if err := errors.Join(templateErr, relabelingErr); err != nil {
 			return Profile{}, err
 		}
 	}

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog.go
@@ -73,10 +73,11 @@ func LoadFromDirs(specs []DirSpec) (Catalog, error) {
 }
 
 // decodeProfile strict-decodes the one top-level profile document, retaining
-// template and relabeling nodes for lazy stock hydration. User profiles hydrate
-// both fields eagerly so a broken override is skipped and valid stock survives.
+// immutable raw bytes and a cheap relabel-presence signal for lazy stock
+// hydration. User profiles hydrate both fields eagerly so a broken override is
+// skipped and valid stock survives.
 func decodeProfile(data []byte, baseName string, isStock bool) (Profile, error) {
-	var doc profileDocument
+	var doc profileDocument[yaml.Node, yaml.Node]
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	if err := dec.Decode(&doc); err != nil {
@@ -89,8 +90,8 @@ func decodeProfile(data []byte, baseName string, isStock bool) (Profile, error) 
 		App:             doc.App,
 		autogenSelector: nil,
 		lazy: &lazyProfile{
-			template:   doc.Template,
-			relabeling: doc.Relabeling,
+			raw:           bytes.Clone(data),
+			hasRelabeling: doc.Relabeling.Kind != 0,
 		},
 	}
 	if doc.Autogen != nil {

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog_test.go
@@ -94,6 +94,19 @@ template:
 `, match)
 }
 
+func profileYAMLWithRelabeling(match, relabeling string) string {
+	return strings.Replace(profileYAML(match), "template:\n", "relabeling:\n"+relabeling+"template:\n", 1)
+}
+
+const validRelabeling = `  - match: "app_*"
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: "app_(.*)"
+        target_label: __name__
+        replacement: "app_normalized_${1}"
+        action: replace
+`
+
 func loadCatalog(t *testing.T, files ...fileSpec) (Catalog, error) {
 	t.Helper()
 
@@ -286,6 +299,168 @@ func TestLoadFromDirs_userBadTemplateSkippedStockSurvives(t *testing.T) {
 	tmpl, err := got[0].Template()
 	require.NoError(t, err, "the surviving stock template must hydrate")
 	assert.NotEmpty(t, tmpl.Charts)
+}
+
+func TestLoadFromDirs_stockRelabelingHydratesLazily(t *testing.T) {
+	tests := map[string]struct {
+		relabeling string
+		wantBlocks int
+		wantErr    string
+	}{
+		"valid": {
+			relabeling: validRelabeling,
+			wantBlocks: 1,
+		},
+		"null": {
+			relabeling: "  null\n",
+			wantErr:    "'relabeling' must not be empty",
+		},
+		"empty": {
+			relabeling: "  []\n",
+			wantErr:    "'relabeling' must not be empty",
+		},
+		"invalid block field": {
+			relabeling: strings.Replace(validRelabeling, "    metric_relabel_configs:", "    unknown: true\n    metric_relabel_configs:", 1),
+			wantErr:    "field unknown not found",
+		},
+		"invalid rule field": {
+			relabeling: strings.Replace(validRelabeling, "        action: replace", "        unknown: true\n        action: replace", 1),
+			wantErr:    "field unknown not found",
+		},
+		"invalid rule": {
+			relabeling: strings.Replace(validRelabeling, "action: replace", "action: bogus", 1),
+			wantErr:    "unknown relabel action",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cat, err := loadCatalog(t, fileSpec{
+				stock:   true,
+				name:    "app.yaml",
+				content: profileYAMLWithRelabeling("app_*", tc.relabeling),
+			})
+			require.NoError(t, err, "stock relabeling must remain lazy")
+
+			p, ok := cat.Get("app")
+			require.True(t, ok)
+			assert.True(t, p.HasRelabeling(), "a present relabeling key must be visible without hydration")
+
+			blocks, err1 := p.Relabeling()
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err1, tc.wantErr)
+				_, err2 := p.Relabeling()
+				assert.Equal(t, err1, err2, "the hydration error must be memoized")
+				return
+			}
+			require.NoError(t, err1)
+			assert.Len(t, blocks, tc.wantBlocks)
+
+			tmpl, err := p.Template()
+			require.NoError(t, err, "relabeling must not break template hydration")
+			assert.NotEmpty(t, tmpl.Charts)
+		})
+	}
+}
+
+func TestProfile_RelabelingAbsent(t *testing.T) {
+	cat, err := loadCatalog(t, fileSpec{stock: true, name: "app.yaml", content: profileYAML("app_*")})
+	require.NoError(t, err)
+	p, ok := cat.Get("app")
+	require.True(t, ok)
+
+	assert.False(t, p.HasRelabeling())
+	blocks, err := p.Relabeling()
+	require.NoError(t, err)
+	assert.Nil(t, blocks)
+}
+
+func TestLoadFromDirs_userBadRelabelingSkippedStockSurvives(t *testing.T) {
+	bad := strings.Replace(validRelabeling, "action: replace", "action: bogus", 1)
+	cat, err := loadCatalog(t,
+		fileSpec{stock: true, name: "app.yaml", content: profileYAML("stock_*")},
+		fileSpec{stock: false, name: "app.yaml", content: profileYAMLWithRelabeling("user_*", bad)},
+	)
+	require.NoError(t, err)
+
+	p, ok := cat.Get("app")
+	require.True(t, ok)
+	assert.Equal(t, "stock_*", p.Match)
+	assert.False(t, p.HasRelabeling())
+}
+
+func TestProfile_RelabelingReturnsIndependentCopies(t *testing.T) {
+	cat, err := loadCatalog(t, fileSpec{
+		stock:   true,
+		name:    "app.yaml",
+		content: profileYAMLWithRelabeling("app_*", validRelabeling),
+	})
+	require.NoError(t, err)
+
+	assertIndependent := func(t *testing.T, p Profile) {
+		t.Helper()
+		first, err := p.Relabeling()
+		require.NoError(t, err)
+		require.Len(t, first, 1)
+		require.Len(t, first[0].MetricRelabelConfigs, 1)
+		firstRegex := first[0].MetricRelabelConfigs[0].Regex.Regexp
+		first[0].Match = "changed_*"
+		first[0].MetricRelabelConfigs[0].SourceLabels[0] = "changed"
+		firstRegex.Longest()
+
+		second, err := p.Relabeling()
+		require.NoError(t, err)
+		require.Len(t, second, 1)
+		assert.Equal(t, "app_*", second[0].Match)
+		assert.Equal(t, []string{"__name__"}, second[0].MetricRelabelConfigs[0].SourceLabels)
+		assert.NotSame(t, firstRegex, second[0].MetricRelabelConfigs[0].Regex.Regexp)
+	}
+
+	fromGet, ok := cat.Get("app")
+	require.True(t, ok)
+	assertIndependent(t, fromGet)
+
+	ordered := cat.OrderedProfiles()
+	require.Len(t, ordered, 1)
+	assertIndependent(t, ordered[0])
+
+	resolved, err := cat.Resolve([]string{"app"})
+	require.NoError(t, err)
+	require.Len(t, resolved, 1)
+	assertIndependent(t, resolved[0])
+}
+
+func TestProfile_RelabelingConcurrent(t *testing.T) {
+	for name, relabeling := range map[string]string{
+		"success": validRelabeling,
+		"error":   strings.Replace(validRelabeling, "action: replace", "action: bogus", 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			cat, err := loadCatalog(t, fileSpec{
+				stock:   true,
+				name:    "app.yaml",
+				content: profileYAMLWithRelabeling("app_*", relabeling),
+			})
+			require.NoError(t, err)
+			p, ok := cat.Get("app")
+			require.True(t, ok)
+
+			var wg sync.WaitGroup
+			for range 16 {
+				wg.Go(func() {
+					blocks, err := p.Relabeling()
+					if name == "error" {
+						assert.Error(t, err)
+						assert.Nil(t, blocks)
+					} else {
+						assert.NoError(t, err)
+						assert.Len(t, blocks, 1)
+					}
+				})
+			}
+			wg.Wait()
+		})
+	}
 }
 
 // TestProfile_TemplateConcurrent exercises concurrent hydration of a shared

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/catalog_test.go
@@ -210,6 +210,61 @@ func TestLoadFromDirs_headerDecodeAndValidation(t *testing.T) {
 	}
 }
 
+func TestProfileTemplateHydrationPreservesCrossFieldYAMLAnchors(t *testing.T) {
+	content := `match: &metric app_metric
+template:
+  family: test
+  metrics: [*metric]
+  charts:
+    - title: Test Metric
+      context: test_metric
+      units: count
+      dimensions:
+        - selector: *metric
+          name: value
+`
+
+	cat, err := loadCatalog(t, fileSpec{name: "app.yaml", content: content})
+	require.NoError(t, err)
+	profile, ok := cat.Get("app")
+	require.True(t, ok)
+	_, err = profile.Template()
+	require.NoError(t, err)
+}
+
+func TestProfileRelabelHydrationPreservesCrossFieldYAMLAnchors(t *testing.T) {
+	content := `match: app_*
+app: &target app_normalized
+relabeling:
+  - match: app_raw
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: app_raw
+        target_label: __name__
+        replacement: *target
+template:
+  family: test
+  metrics: [app_normalized]
+  charts:
+    - title: Test Metric
+      context: test_metric
+      units: count
+      dimensions:
+        - selector: app_normalized
+          name: value
+`
+
+	cat, err := loadCatalog(t, fileSpec{name: "app.yaml", content: content})
+	require.NoError(t, err)
+	profile, ok := cat.Get("app")
+	require.True(t, ok)
+	blocks, err := profile.Relabeling()
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Len(t, blocks[0].MetricRelabelConfigs, 1)
+	assert.Equal(t, "app_normalized", blocks[0].MetricRelabelConfigs[0].Replacement)
+}
+
 func TestProfileAutogenSelectorOwnership(t *testing.T) {
 	cat, err := loadCatalog(t, fileSpec{
 		stock: true,

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/default_catalog_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/default_catalog_test.go
@@ -11,12 +11,10 @@ import (
 // Catalog caching (load-once, retry-after-failure, disabled-under-test) is now
 // provided and tested by pkg/profilecatalog (Cached); it is not re-tested here.
 
-// TestDefaultCatalog_AllStockTemplatesValidate hydrates and validates every stock
-// profile's template. Templates are parsed lazily at runtime (only when a job
-// selects a profile), so this test is what keeps a broken stock template from
-// slipping through CI — it would otherwise surface only when a job happens to
-// select that profile.
-func TestDefaultCatalog_AllStockTemplatesValidate(t *testing.T) {
+// TestDefaultCatalog_AllStockProfilesHydrate hydrates and validates every stock
+// profile's lazy fields. Production hydrates only selected profiles, so the regular
+// test suite is what keeps a broken unselected stock profile from shipping.
+func TestDefaultCatalog_AllStockProfilesHydrate(t *testing.T) {
 	catalog, err := LoadFromDefaultDirs()
 	require.NoError(t, err)
 
@@ -26,5 +24,7 @@ func TestDefaultCatalog_AllStockTemplatesValidate(t *testing.T) {
 	for _, p := range profiles {
 		_, err := p.Template()
 		require.NoErrorf(t, err, "stock profile %q template must be valid", p.Name)
+		_, err = p.Relabeling()
+		require.NoErrorf(t, err, "stock profile %q relabeling must be valid", p.Name)
 	}
 }

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
@@ -17,15 +17,16 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
 
-// profileDocument is the single strict top-level profile shape. Heavy fields are
-// retained as nodes and typed-decoded only when hydrated, avoiding a second
-// top-level schema that could drift as fields are added.
-type profileDocument struct {
-	Match      string    `yaml:"match"`
-	App        string    `yaml:"app,omitempty"`
-	Autogen    *autogen  `yaml:"autogen,omitempty"`
-	Relabeling yaml.Node `yaml:"relabeling,omitempty"`
-	Template   yaml.Node `yaml:"template"`
+// profileDocument is the single strict top-level profile shape. Its heavy field
+// types vary by decode: yaml.Node for the cheap header pass and concrete types
+// for one lazy hydration. Decoding the complete raw document each time preserves
+// YAML anchors referenced across top-level fields without duplicating this list.
+type profileDocument[R, T any] struct {
+	Match      string   `yaml:"match"`
+	App        string   `yaml:"app,omitempty"`
+	Autogen    *autogen `yaml:"autogen,omitempty"`
+	Relabeling R        `yaml:"relabeling,omitempty"`
+	Template   T        `yaml:"template"`
 }
 
 type autogen struct {
@@ -51,12 +52,13 @@ type Profile struct {
 // lazyProfile holds deferred stock-profile fields. It is referenced by pointer so
 // Profile value copies share hydration and sync.Once values are never copied.
 type lazyProfile struct {
-	template     yaml.Node
+	raw           []byte
+	hasRelabeling bool
+
 	templateOnce sync.Once
 	tmpl         charttpl.Group
 	templateErr  error
 
-	relabeling     yaml.Node
 	relabelingOnce sync.Once
 	blocks         []relabel.Block
 	relabelingErr  error
@@ -71,7 +73,7 @@ func (p Profile) Template() (charttpl.Group, error) {
 		return charttpl.Group{}, fmt.Errorf("profile %q: no template loaded", p.Name)
 	}
 	p.lazy.templateOnce.Do(func() {
-		p.lazy.tmpl, p.lazy.templateErr = parseTemplate(p.Name, p.lazy.template)
+		p.lazy.tmpl, p.lazy.templateErr = parseTemplate(p.Name, p.lazy.raw)
 	})
 	if p.lazy.templateErr != nil {
 		return charttpl.Group{}, p.lazy.templateErr
@@ -83,7 +85,7 @@ func (p Profile) Template() (charttpl.Group, error) {
 // without hydrating it. Present null and empty values return true so their
 // validation errors cannot silently take the no-relabel fast path.
 func (p Profile) HasRelabeling() bool {
-	return p.lazy != nil && p.lazy.relabeling.Kind != 0
+	return p.lazy != nil && p.lazy.hasRelabeling
 }
 
 // Relabeling hydrates and validates profile-owned relabel blocks on first use.
@@ -93,7 +95,7 @@ func (p Profile) Relabeling() ([]relabel.Block, error) {
 		return nil, nil
 	}
 	p.lazy.relabelingOnce.Do(func() {
-		p.lazy.blocks, p.lazy.relabelingErr = parseRelabeling(p.Name, p.lazy.relabeling)
+		p.lazy.blocks, p.lazy.relabelingErr = parseRelabeling(p.Name, p.lazy.raw)
 	})
 	if p.lazy.relabelingErr != nil {
 		return nil, p.lazy.relabelingErr
@@ -156,16 +158,17 @@ func (p *Profile) validateHeader() error {
 	return nil
 }
 
-// parseTemplate typed-decodes and validates the retained chart-template node.
-func parseTemplate(name string, node yaml.Node) (charttpl.Group, error) {
-	if node.Kind == 0 {
-		return charttpl.Group{}, fmt.Errorf("profile %q: 'template' is required", name)
-	}
-
-	var group charttpl.Group
-	if err := decodeNodeStrict(node, &group); err != nil {
+// parseTemplate typed-decodes and validates the chart template from the complete
+// document so aliases may reference anchors declared in another top-level field.
+func parseTemplate(name string, raw []byte) (charttpl.Group, error) {
+	var doc profileDocument[yaml.Node, *charttpl.Group]
+	if err := decodeDocumentStrict(raw, &doc); err != nil {
 		return charttpl.Group{}, fmt.Errorf("profile %q: unmarshal 'template': %w", name, err)
 	}
+	if doc.Template == nil {
+		return charttpl.Group{}, fmt.Errorf("profile %q: 'template' is required", name)
+	}
+	group := *doc.Template
 
 	if !groupHasChart(group) {
 		return charttpl.Group{}, fmt.Errorf("profile %q: 'template' must contain at least one chart", name)
@@ -182,11 +185,12 @@ func parseTemplate(name string, node yaml.Node) (charttpl.Group, error) {
 	return group, nil
 }
 
-func parseRelabeling(name string, node yaml.Node) ([]relabel.Block, error) {
-	var blocks []relabel.Block
-	if err := decodeNodeStrict(node, &blocks); err != nil {
+func parseRelabeling(name string, raw []byte) ([]relabel.Block, error) {
+	var doc profileDocument[[]relabel.Block, yaml.Node]
+	if err := decodeDocumentStrict(raw, &doc); err != nil {
 		return nil, fmt.Errorf("profile %q: unmarshal 'relabeling': %w", name, err)
 	}
+	blocks := doc.Relabeling
 	if len(blocks) == 0 {
 		return nil, fmt.Errorf("profile %q: 'relabeling' must not be empty", name)
 	}
@@ -196,11 +200,7 @@ func parseRelabeling(name string, node yaml.Node) ([]relabel.Block, error) {
 	return blocks, nil
 }
 
-func decodeNodeStrict(node yaml.Node, dst any) error {
-	raw, err := yaml.Marshal(&node)
-	if err != nil {
-		return err
-	}
+func decodeDocumentStrict(raw []byte, dst any) error {
 	dec := yaml.NewDecoder(bytes.NewReader(raw))
 	dec.KnownFields(true)
 	return dec.Decode(dst)

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile.go
@@ -14,18 +14,18 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/matcher"
 	metrixselector "github.com/netdata/netdata/go/plugins/pkg/metrix/selector"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
 
-// profileHeader is the eagerly-decoded part of a profile: everything except the
-// chart template. Template is captured as an un-decoded yaml.Node so a strict
-// decode (KnownFields) still accepts the legitimate `template:` key and rejects
-// unknown keys, without typed-decoding or validating the heavy chart tree at
-// load time.
-type profileHeader struct {
-	Match    string    `yaml:"match"`
-	App      string    `yaml:"app,omitempty"`
-	Autogen  *autogen  `yaml:"autogen,omitempty"`
-	Template yaml.Node `yaml:"template"`
+// profileDocument is the single strict top-level profile shape. Heavy fields are
+// retained as nodes and typed-decoded only when hydrated, avoiding a second
+// top-level schema that could drift as fields are added.
+type profileDocument struct {
+	Match      string    `yaml:"match"`
+	App        string    `yaml:"app,omitempty"`
+	Autogen    *autogen  `yaml:"autogen,omitempty"`
+	Relabeling yaml.Node `yaml:"relabeling,omitempty"`
+	Template   yaml.Node `yaml:"template"`
 }
 
 type autogen struct {
@@ -36,26 +36,30 @@ type autogen struct {
 // basename (Name). Match selects the profile by scraped metric names; App, when
 // set, is the application identity used as the chart-context "app" segment
 // (prometheus.<app>.…) when a job has no `app` set (by the user or service
-// discovery). The chart template is parsed and validated lazily on the first
-// Template() call — matching needs only Match, so a large stock library is
-// neither typed-decoded nor held parsed in memory until a profile is selected.
+// discovery). Heavy template and relabeling fields are parsed and validated
+// lazily on first use — matching needs only Match, so a large stock library is
+// not fully materialized until profiles are selected.
 type Profile struct {
 	Name  string
 	Match string
 	App   string
 
 	autogenSelector *metrixselector.Expr
-	lazy            *lazyTemplate
+	lazy            *lazyProfile
 }
 
-// lazyTemplate holds the deferred chart template. It is referenced by pointer so
-// Profile value copies (catalog map values, selection slices) share one
-// hydration and the sync.Once is never copied.
-type lazyTemplate struct {
-	raw  []byte
-	once sync.Once
-	tmpl charttpl.Group
-	err  error
+// lazyProfile holds deferred stock-profile fields. It is referenced by pointer so
+// Profile value copies share hydration and sync.Once values are never copied.
+type lazyProfile struct {
+	template     yaml.Node
+	templateOnce sync.Once
+	tmpl         charttpl.Group
+	templateErr  error
+
+	relabeling     yaml.Node
+	relabelingOnce sync.Once
+	blocks         []relabel.Block
+	relabelingErr  error
 }
 
 // Template parses and validates the chart template on first call and memoizes
@@ -66,13 +70,35 @@ func (p Profile) Template() (charttpl.Group, error) {
 	if p.lazy == nil {
 		return charttpl.Group{}, fmt.Errorf("profile %q: no template loaded", p.Name)
 	}
-	p.lazy.once.Do(func() {
-		p.lazy.tmpl, p.lazy.err = parseTemplate(p.Name, p.lazy.raw)
+	p.lazy.templateOnce.Do(func() {
+		p.lazy.tmpl, p.lazy.templateErr = parseTemplate(p.Name, p.lazy.template)
 	})
-	if p.lazy.err != nil {
-		return charttpl.Group{}, p.lazy.err
+	if p.lazy.templateErr != nil {
+		return charttpl.Group{}, p.lazy.templateErr
 	}
 	return p.lazy.tmpl.Clone(), nil
+}
+
+// HasRelabeling reports whether the profile document contains a relabeling key
+// without hydrating it. Present null and empty values return true so their
+// validation errors cannot silently take the no-relabel fast path.
+func (p Profile) HasRelabeling() bool {
+	return p.lazy != nil && p.lazy.relabeling.Kind != 0
+}
+
+// Relabeling hydrates and validates profile-owned relabel blocks on first use.
+// It returns an independent deep copy so callers cannot mutate catalog state.
+func (p Profile) Relabeling() ([]relabel.Block, error) {
+	if !p.HasRelabeling() {
+		return nil, nil
+	}
+	p.lazy.relabelingOnce.Do(func() {
+		p.lazy.blocks, p.lazy.relabelingErr = parseRelabeling(p.Name, p.lazy.relabeling)
+	})
+	if p.lazy.relabelingErr != nil {
+		return nil, p.lazy.relabelingErr
+	}
+	return relabel.CloneBlocks(p.lazy.blocks), nil
 }
 
 // AutogenSelector returns an independent copy of the profile-scoped fallback
@@ -97,8 +123,8 @@ func cloneSelectorExpr(expr *metrixselector.Expr) *metrixselector.Expr {
 	return &out
 }
 
-// validateHeader validates the always-loaded fields (match + app). Template
-// structure is validated separately, at hydrate time.
+// validateHeader validates the always-loaded fields. Deferred template and
+// relabeling structure is validated separately at hydration time.
 func (p *Profile) validateHeader() error {
 	if strings.TrimSpace(p.Match) == "" {
 		return fmt.Errorf("profile %q: 'match' must not be empty", p.Name)
@@ -130,35 +156,54 @@ func (p *Profile) validateHeader() error {
 	return nil
 }
 
-// parseTemplate typed-decodes and validates the chart template from the raw
-// profile bytes. Strict decoding keeps parity with the header decode (unknown
-// keys rejected). It is the deferred half of profile validation.
-func parseTemplate(name string, raw []byte) (charttpl.Group, error) {
-	var doc struct {
-		Match    string         `yaml:"match"`
-		App      string         `yaml:"app,omitempty"`
-		Autogen  *autogen       `yaml:"autogen,omitempty"`
-		Template charttpl.Group `yaml:"template"`
+// parseTemplate typed-decodes and validates the retained chart-template node.
+func parseTemplate(name string, node yaml.Node) (charttpl.Group, error) {
+	if node.Kind == 0 {
+		return charttpl.Group{}, fmt.Errorf("profile %q: 'template' is required", name)
 	}
-	dec := yaml.NewDecoder(bytes.NewReader(raw))
-	dec.KnownFields(true)
-	if err := dec.Decode(&doc); err != nil {
+
+	var group charttpl.Group
+	if err := decodeNodeStrict(node, &group); err != nil {
 		return charttpl.Group{}, fmt.Errorf("profile %q: unmarshal 'template': %w", name, err)
 	}
 
-	if !groupHasChart(doc.Template) {
+	if !groupHasChart(group) {
 		return charttpl.Group{}, fmt.Errorf("profile %q: 'template' must contain at least one chart", name)
 	}
 
 	spec := charttpl.Spec{
 		Version: charttpl.VersionV1,
-		Groups:  []charttpl.Group{doc.Template},
+		Groups:  []charttpl.Group{group},
 	}
 	if err := spec.Validate(); err != nil {
 		return charttpl.Group{}, fmt.Errorf("profile %q: 'template': %w", name, err)
 	}
 
-	return doc.Template, nil
+	return group, nil
+}
+
+func parseRelabeling(name string, node yaml.Node) ([]relabel.Block, error) {
+	var blocks []relabel.Block
+	if err := decodeNodeStrict(node, &blocks); err != nil {
+		return nil, fmt.Errorf("profile %q: unmarshal 'relabeling': %w", name, err)
+	}
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("profile %q: 'relabeling' must not be empty", name)
+	}
+	if _, err := relabel.NewPipeline(blocks); err != nil {
+		return nil, fmt.Errorf("profile %q: invalid 'relabeling': %w", name, err)
+	}
+	return blocks, nil
+}
+
+func decodeNodeStrict(node yaml.Node, dst any) error {
+	raw, err := yaml.Marshal(&node)
+	if err != nil {
+		return err
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	return dec.Decode(dst)
 }
 
 func groupHasChart(group charttpl.Group) bool {

--- a/src/go/plugin/go.d/collector/prometheus/relabel/README.md
+++ b/src/go/plugin/go.d/collector/prometheus/relabel/README.md
@@ -1,9 +1,15 @@
 # Metric relabeling
 
-Relabeling rewrites, adds, drops, or filters a scraped metric -- its name and its labels -- **before**
-[chart profiles](/src/go/plugin/go.d/collector/prometheus/profile-format.md) are matched and charts are built. It is a
-job-level configuration option (`relabeling`), not a profile field: it works with or without profiles, and profiles see
-the relabeled result. The rule shape is Prometheus-compatible: it mirrors
+Relabeling rewrites, adds, drops, or filters a scraped metric -- its name and its labels -- before charts are built.
+The same `relabeling` block format has two ownership levels:
+
+- **Job relabeling** is operator policy. It runs after the job's `selector` and before
+  [chart profiles](/src/go/plugin/go.d/collector/prometheus/profile-format.md) are selected, so it can bring an
+  endpoint into a profile's expected namespace.
+- **Profile relabeling** is exporter/profile policy. It is stored at the profile root, applies automatically only after
+  that profile is selected, and normalizes the metrics its template sees. It cannot cause its own selection.
+
+Both levels use the same validation and execution path. The rule shape is Prometheus-compatible: it mirrors
 Prometheus
 [`metric_relabel_configs`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs),
 so rules you already use in Prometheus carry over -- with these deliberate exceptions: the `__name__` handling of the
@@ -11,12 +17,12 @@ label-name actions (see [Actions](#actions)), and the histogram/summary integrit
 such as thinning buckets by `le` -- that Prometheus allows (see
 [Histogram and summary safety](#histogram-and-summary-safety)). When porting, wrap your flat `metric_relabel_configs`
 list in a `relabeling` block with a required `match` (use `'*'` for all metrics). The job's `selector` option runs
-first, on the original scraped names -- relabeling sees only what the selector kept, so a rename cannot recover a series
-the selector dropped under its old name.
+first, on the original scraped names -- neither relabeling stage can recover a series the selector dropped.
 
-Use it to keep noisy metrics out of your dashboards, fold high-cardinality labels away, derive new labels, rename
-metrics, normalize label casing -- or rename an exporter's metrics so a stock profile recognizes them -- without
-touching the application you are scraping.
+Use job relabeling to keep noisy metrics out of your dashboards, fold high-cardinality labels away, derive deployment
+labels, or rename an endpoint so a profile recognizes it. Put stable exporter normalization required by a curated
+profile in the profile itself, so every job that selects that profile gets the same metric contract without duplicating
+an optional job policy.
 
 > **Note:** The removed `label_prefix` option prefixed every label key. Relabeling covers its practical use case --
 > avoiding collisions with the labels Netdata adds when re-exporting -- with a targeted `labelmap` rule (see the
@@ -69,8 +75,8 @@ The drop and label-deriving techniques are explained step by step under [Relabel
 
 `relabeling` is a **list of blocks**. Each block has a `match` and a list of rules; the rules apply only to metrics
 whose name matches the block's `match`. Grouping rules under a block lets you scope a set of rules to a subset of
-metrics by name, instead of repeating a name match in every rule. Relabeling is opt-in -- jobs without a `relabeling`
-section are unaffected.
+metrics by name, instead of repeating a name match in every rule. Relabeling is opt-in at both ownership levels -- a
+job or profile without a `relabeling` section adds no rules at that stage.
 
 ```yaml
 jobs:
@@ -86,6 +92,22 @@ jobs:
             target_label: '<label>'         # or __name__ to target the metric name
             replacement: '$1'
             action: <action>
+```
+
+The same field may appear at the root of a profile. The profile's root `match` still controls selection and ownership;
+the relabeling block `match` controls which physical series names its rules process:
+
+```yaml
+match: 'myapp_*'
+relabeling:
+  - match: 'myapp_legacy_*'
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'myapp_legacy_(.+)'
+        target_label: __name__
+        replacement: 'myapp_${1}'
+template:
+  # ...
 ```
 
 ### `match`
@@ -143,7 +165,17 @@ Inside a block, `metric_relabel_configs` is a list of rules applied **in order**
 
 ## How relabeling runs
 
-1. For each scraped metric, every block whose `match` matches the metric's **current** name runs, in order.
+The stage order is fixed:
+
+1. The job `selector` filters original scraped series.
+2. Job relabeling runs and its result is assembled and checked.
+3. Untyped fallback classification and profile selection use the post-job, pre-profile names.
+4. Selected profile relabeling runs and its result is assembled and checked independently.
+5. Final size/writer checks run, then charts see the normalized result.
+
+Inside either relabeling stage:
+
+1. For each metric, every block whose `match` matches the metric's **current** name runs, in order.
 2. Within a block, rules run in order. Each rule joins `source_labels` into an input string and applies its `action`.
 3. A rule can rename the metric (write `__name__`), so a later block or rule sees the new name.
 4. If any rule drops the metric, the remaining rules and blocks are skipped for it.
@@ -159,9 +191,9 @@ will **not** let relabeling silently corrupt one. A rule that would:
 - merge two metric families together, or
 - duplicate a component,
 
-is rejected. The job **fails at autodetection**, so a bad rule is caught immediately; if the exposition changes at
-runtime, the affected metric family is **dropped** (rather than charted with wrong values) and the rest of the job keeps
-working.
+is rejected independently at each stage. The job **fails at autodetection**, so a bad rule is caught immediately; if
+the exposition changes at runtime, the affected metric family is **dropped** (rather than charted with wrong values)
+and the rest of the job keeps working. A later profile stage cannot hide corruption introduced by the job stage.
 
 This also covers the common Prometheus technique of thinning histogram buckets: a `keep`/`drop` rule on the `le` (or
 `quantile`) label is treated as corrupting the metric family, never as thinning it -- the job fails its check when the
@@ -170,6 +202,20 @@ drifts into corruption later at runtime. Reduce histogram cardinality at the exp
 option instead.
 
 Plain gauges and counters have no such restriction -- you can rename, relabel, split, or drop them freely.
+
+### Profile ownership and namespace safety
+
+Selected profiles do not run as an order-dependent chain. A profile owns a source family only when its root `match`
+covers that family and one of its relabeling block matchers covers at least one physical series in the family. More than
+one owner is a conflict: it fails autodetection, or drops that source family if a new conflict first appears at runtime.
+
+A profile's output family must still match that profile's root `match`. An out-of-scope rename fails autodetection; a
+runtime-only escape drops the affected source family. These rules prevent profile order from changing results and
+prevent malformed normalization from creating unexpected generic charts. See the profile format's
+[`relabeling` section](/src/go/plugin/go.d/collector/prometheus/profile-format.md#relabeling) for authoring guidance.
+
+Untyped fallback type is bound from the post-job, pre-profile name. Profile relabeling preserves that decision but
+cannot create one by adding `_total` or renaming a final metric into a configured `fallback_type` pattern.
 
 ## Examples
 

--- a/src/go/plugin/go.d/collector/prometheus/relabel/README.md
+++ b/src/go/plugin/go.d/collector/prometheus/relabel/README.md
@@ -1,7 +1,7 @@
 # Metric relabeling
 
 Relabeling rewrites, adds, drops, or filters a scraped metric -- its name and its labels -- before charts are built.
-The same `relabeling` block format has two ownership levels:
+The same `relabeling` block format has two configuration levels:
 
 - **Job relabeling** is operator policy. It runs after the job's `selector` and before
   [chart profiles](/src/go/plugin/go.d/collector/prometheus/profile-format.md) are selected, so it can bring an
@@ -75,7 +75,7 @@ The drop and label-deriving techniques are explained step by step under [Relabel
 
 `relabeling` is a **list of blocks**. Each block has a `match` and a list of rules; the rules apply only to metrics
 whose name matches the block's `match`. Grouping rules under a block lets you scope a set of rules to a subset of
-metrics by name, instead of repeating a name match in every rule. Relabeling is opt-in at both ownership levels -- a
+metrics by name, instead of repeating a name match in every rule. Relabeling is opt-in at both levels -- a
 job or profile without a `relabeling` section adds no rules at that stage.
 
 ```yaml
@@ -94,7 +94,8 @@ jobs:
             action: <action>
 ```
 
-The same field may appear at the root of a profile. The profile's root `match` still controls selection and ownership;
+The same field may appear at the root of a profile. The profile's root `match` controls selection and source-family
+applicability;
 the relabeling block `match` controls which physical series names its rules process:
 
 ```yaml
@@ -203,16 +204,22 @@ option instead.
 
 Plain gauges and counters have no such restriction -- you can rename, relabel, split, or drop them freely.
 
-### Profile ownership and namespace safety
+### Profile precedence on the shared stream
 
-Selected profiles do not run as an order-dependent chain. A profile owns a source family only when its root `match`
-covers that family and one of its relabeling block matchers covers at least one physical series in the family. More than
-one owner is a conflict: it fails autodetection, or drops that source family if a new conflict first appears at runtime.
+Selected profiles share one final metric stream; the collector does not copy source metrics per profile. For each
+original source family, it chooses the first selected profile whose root `match` covers the base family and whose
+relabeling block matcher covers at least one original physical series. That profile's complete pipeline receives every
+series in the family. Later profile pipelines do not process the family and do not see names produced by the first one.
 
-A profile's output family must still match that profile's root `match`. An out-of-scope rename fails autodetection; a
-runtime-only escape drops the affected source family. These rules prevent profile order from changing results and
-prevent malformed normalization from creating unexpected generic charts. See the profile format's
-[`relabeling` section](/src/go/plugin/go.d/collector/prometheus/profile-format.md#relabeling) for authoring guidance.
+Normalizer precedence is profile-name order in `auto`, configured entry order in `exact`, and configured entries first
+followed by the remaining auto-selected profiles in profile-name order in `combined`. Block and rule order inside the
+chosen profile remains the YAML order described above.
+
+Dispatch does not predict rule results or output names. The root `match` constrains the original source family only, and
+the chosen pipeline may produce a different namespace. Every selected chart template sees those final names and labels,
+so profile authors must account for interactions between profiles selected for the same endpoint. See the profile
+format's [`relabeling` section](/src/go/plugin/go.d/collector/prometheus/profile-format.md#relabeling) for authoring
+guidance.
 
 Untyped fallback type is bound from the post-job, pre-profile name. Profile relabeling preserves that decision but
 cannot create one by adding `_total` or renaming a final metric into a configured `fallback_type` pattern.

--- a/src/go/plugin/go.d/collector/prometheus/relabel/README.md
+++ b/src/go/plugin/go.d/collector/prometheus/relabel/README.md
@@ -95,8 +95,7 @@ jobs:
 ```
 
 The same field may appear at the root of a profile. The profile's root `match` controls selection and source-family
-applicability;
-the relabeling block `match` controls which physical series names its rules process:
+applicability; the relabeling block `match` controls which physical series names its rules process:
 
 ```yaml
 match: 'myapp_*'
@@ -219,7 +218,8 @@ Dispatch does not predict rule results or output names. The root `match` constra
 the chosen pipeline may produce a different namespace. Every selected chart template sees those final names and labels,
 so profile authors must account for interactions between profiles selected for the same endpoint. See the profile
 format's [`relabeling` section](/src/go/plugin/go.d/collector/prometheus/profile-format.md#relabeling) for authoring
-guidance.
+guidance. A family renamed outside the profile's root `match` also leaves that profile's `autogen.selector` scope, so an
+uncovered output keeps generic autogen unless another applicable profile scope rejects it.
 
 Untyped fallback type is bound from the post-job, pre-profile name. Profile relabeling preserves that decision but
 cannot create one by adding `_total` or renaming a final metric into a configured `fallback_type` pattern.

--- a/src/go/plugin/go.d/collector/prometheus/relabel/block.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel/block.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package relabel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/pkg/matcher"
+	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
+)
+
+// Block scopes an ordered list of metric relabel rules to matching metric names.
+// Blocks themselves run in list order and match the sample name produced by the
+// preceding block.
+type Block struct {
+	Match                string   `yaml:"match" json:"match"`
+	MetricRelabelConfigs []Config `yaml:"metric_relabel_configs" json:"metric_relabel_configs"`
+}
+
+// CloneBlocks returns an ownership-independent copy of blocks, including rule
+// slices and compiled regular expressions.
+func CloneBlocks(blocks []Block) []Block {
+	if blocks == nil {
+		return nil
+	}
+	out := make([]Block, len(blocks))
+	for i, block := range blocks {
+		out[i] = block
+		if block.MetricRelabelConfigs != nil {
+			out[i].MetricRelabelConfigs = make([]Config, len(block.MetricRelabelConfigs))
+			for j, cfg := range block.MetricRelabelConfigs {
+				out[i].MetricRelabelConfigs[j] = cfg.clone()
+			}
+		}
+	}
+	return out
+}
+
+type compiledBlock struct {
+	match matcher.Matcher
+	proc  *Processor
+}
+
+// Pipeline is a compiled block list. Its processors reuse buffers, so a Pipeline
+// belongs to one collector job and is not goroutine-safe.
+type Pipeline struct {
+	blocks []compiledBlock
+}
+
+// NewPipeline validates and compiles relabel blocks. An empty block list returns
+// a nil pipeline so callers can preserve their no-relabel fast path.
+func NewPipeline(blocks []Block) (*Pipeline, error) {
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+
+	compiled := make([]compiledBlock, 0, len(blocks))
+	for i, block := range blocks {
+		if strings.TrimSpace(block.Match) == "" {
+			return nil, fmt.Errorf("relabeling[%d]: 'match' is required", i)
+		}
+		if len(block.MetricRelabelConfigs) == 0 {
+			return nil, fmt.Errorf("relabeling[%d]: 'metric_relabel_configs' is empty", i)
+		}
+
+		m, err := matcher.NewSimplePatternsMatcher(block.Match)
+		if err != nil {
+			return nil, fmt.Errorf("relabeling[%d]: invalid 'match' (%q): %v", i, block.Match, err)
+		}
+		proc, err := New(block.MetricRelabelConfigs)
+		if err != nil {
+			return nil, fmt.Errorf("relabeling[%d]: %v", i, err)
+		}
+		compiled = append(compiled, compiledBlock{match: m, proc: proc})
+	}
+
+	return &Pipeline{blocks: compiled}, nil
+}
+
+// Matches reports whether any block matcher accepts name. It does not execute
+// rules and is safe for determining which selected profile owns an input family.
+func (p *Pipeline) Matches(name string) bool {
+	if p == nil {
+		return false
+	}
+	for i := range p.blocks {
+		if p.blocks[i].match.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// Apply runs matching blocks in order. Each block matches the current sample
+// name, including a name produced by an earlier block.
+func (p *Pipeline) Apply(sample prompkg.Sample) (prompkg.Sample, DropInfo) {
+	if p == nil {
+		return sample, DropInfo{}
+	}
+	for i := range p.blocks {
+		block := &p.blocks[i]
+		if !block.match.MatchString(sample.Name) {
+			continue
+		}
+		out, drop := block.proc.Apply(sample)
+		if drop.Dropped() {
+			return sample, drop
+		}
+		sample = out
+	}
+	return sample, DropInfo{}
+}

--- a/src/go/plugin/go.d/collector/prometheus/relabel/block_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel/block_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package relabel
+
+import (
+	"testing"
+
+	commonmodel "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
+)
+
+func TestNewPipeline_ValidatesBlocks(t *testing.T) {
+	tests := map[string]struct {
+		blocks  []Block
+		wantErr string
+	}{
+		"no blocks": {},
+		"valid": {
+			blocks: []Block{{
+				Match:                "app_*",
+				MetricRelabelConfigs: []Config{{SourceLabels: []string{"__name__"}, Regex: MustNewRegexp("x"), Action: Drop}},
+			}},
+		},
+		"missing match": {
+			blocks:  []Block{{MetricRelabelConfigs: []Config{{Action: Drop}}}},
+			wantErr: "relabeling[0]: 'match' is required",
+		},
+		"invalid match": {
+			blocks: []Block{{
+				Match:                "[a-",
+				MetricRelabelConfigs: []Config{{Action: Drop}},
+			}},
+			wantErr: "relabeling[0]: invalid 'match'",
+		},
+		"missing rules": {
+			blocks:  []Block{{Match: "app_*"}},
+			wantErr: "relabeling[0]: 'metric_relabel_configs' is empty",
+		},
+		"invalid rule": {
+			blocks: []Block{{
+				Match:                "app_*",
+				MetricRelabelConfigs: []Config{{Action: "bogus"}},
+			}},
+			wantErr: "relabeling[0]: rule 0:",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pipeline, err := NewPipeline(tc.blocks)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				assert.Nil(t, pipeline)
+				return
+			}
+			require.NoError(t, err)
+			if len(tc.blocks) == 0 {
+				assert.Nil(t, pipeline)
+			} else {
+				assert.NotNil(t, pipeline)
+			}
+		})
+	}
+}
+
+func TestPipeline_ApplyUsesCurrentNameInBlockOrder(t *testing.T) {
+	pipeline, err := NewPipeline([]Block{
+		{
+			Match: "app_*",
+			MetricRelabelConfigs: []Config{{
+				SourceLabels: []string{commonmodel.MetricNameLabel},
+				Regex:        MustNewRegexp("app_(.*)"),
+				TargetLabel:  commonmodel.MetricNameLabel,
+				Replacement:  "renamed_${1}",
+				Action:       Replace,
+			}},
+		},
+		{
+			Match: "renamed_*",
+			MetricRelabelConfigs: []Config{{
+				SourceLabels: []string{commonmodel.MetricNameLabel},
+				TargetLabel:  "seen_name",
+				Action:       Replace,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	in := sample("app_requests_total", map[string]string{"method": "GET"}, 7, prompkg.SampleKindScalar, commonmodel.MetricTypeCounter)
+	want := sample("renamed_requests_total", map[string]string{
+		"method":    "GET",
+		"seen_name": "renamed_requests_total",
+	}, 7, prompkg.SampleKindScalar, commonmodel.MetricTypeCounter)
+
+	got, drop := pipeline.Apply(in)
+	require.False(t, drop.Dropped())
+	assert.Equal(t, want, got)
+}
+
+func TestPipeline_Matches(t *testing.T) {
+	pipeline, err := NewPipeline([]Block{
+		{Match: "app_*", MetricRelabelConfigs: []Config{{Action: Drop}}},
+		{Match: "db_*", MetricRelabelConfigs: []Config{{Action: Drop}}},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, pipeline.Matches("app_requests_total"))
+	assert.True(t, pipeline.Matches("db_queries_total"))
+	assert.False(t, pipeline.Matches("other_metric"))
+}
+
+func TestCloneBlocks_IsIndependent(t *testing.T) {
+	original := []Block{{
+		Match: "app_*",
+		MetricRelabelConfigs: []Config{{
+			SourceLabels: []string{"method"},
+			Regex:        MustNewRegexp("(.+)"),
+			TargetLabel:  "verb",
+			Action:       Replace,
+		}},
+	}}
+
+	cloned := CloneBlocks(original)
+	require.NotSame(t, original[0].MetricRelabelConfigs[0].Regex.Regexp, cloned[0].MetricRelabelConfigs[0].Regex.Regexp)
+	cloned[0].Match = "changed_*"
+	cloned[0].MetricRelabelConfigs[0].SourceLabels[0] = "changed"
+	cloned[0].MetricRelabelConfigs[0].Regex.Regexp.Longest()
+
+	assert.Equal(t, "app_*", original[0].Match)
+	assert.Equal(t, []string{"method"}, original[0].MetricRelabelConfigs[0].SourceLabels)
+
+	empty := CloneBlocks([]Block{{MetricRelabelConfigs: []Config{{SourceLabels: []string{}}}}})
+	require.NotNil(t, empty)
+	require.NotNil(t, empty[0].MetricRelabelConfigs)
+	require.NotNil(t, empty[0].MetricRelabelConfigs[0].SourceLabels)
+	assert.Nil(t, CloneBlocks(nil))
+}
+
+func TestNewPipeline_OwnsRuleConfiguration(t *testing.T) {
+	blocks := []Block{{
+		Match: "app_*",
+		MetricRelabelConfigs: []Config{{
+			SourceLabels: []string{"method"},
+			Regex:        MustNewRegexp("(.+)"),
+			TargetLabel:  "verb",
+			Action:       Replace,
+		}},
+	}}
+
+	pipeline, err := NewPipeline(blocks)
+	require.NoError(t, err)
+	require.NotSame(t, blocks[0].MetricRelabelConfigs[0].Regex.Regexp, pipeline.blocks[0].proc.cfgs[0].Regex.Regexp)
+
+	blocks[0].MetricRelabelConfigs[0].SourceLabels[0] = "changed"
+	in := sample("app_requests_total", map[string]string{"method": "GET"}, 7, prompkg.SampleKindScalar, commonmodel.MetricTypeCounter)
+	got, drop := pipeline.Apply(in)
+	require.False(t, drop.Dropped())
+	assert.Equal(t, "GET", got.Labels.Get("verb"))
+}

--- a/src/go/plugin/go.d/collector/prometheus/relabel/relabel.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel/relabel.go
@@ -121,6 +121,18 @@ type Config struct {
 	sourceLabelsSet bool
 }
 
+func (c Config) clone() Config {
+	out := c
+	if c.SourceLabels != nil {
+		out.SourceLabels = make([]string, len(c.SourceLabels))
+		copy(out.SourceLabels, c.SourceLabels)
+	}
+	if c.Regex.Regexp != nil {
+		out.Regex.Regexp = c.Regex.Regexp.Copy()
+	}
+	return out
+}
+
 // UnmarshalYAML loads a rule from YAML, starting from the rule defaults and
 // recording which optional fields the document set (so an explicit empty
 // separator/replacement/source_labels survives withDefaults). Validation happens
@@ -313,6 +325,7 @@ func normalizeAndValidateConfigs(cfgs []Config) ([]Config, error) {
 	compiled := make([]Config, 0, len(cfgs))
 	for i, cfg := range cfgs {
 		cfg = withDefaults(cfg)
+		cfg = cfg.clone()
 		if err := cfg.validate(); err != nil {
 			return nil, fmt.Errorf("rule %d: %w", i, err)
 		}

--- a/src/go/plugin/go.d/collector/prometheus/relabel/relabel.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel/relabel.go
@@ -463,7 +463,7 @@ func (re Regexp) MarshalJSON() ([]byte, error) {
 // IsZero reports whether the regex is unset or the shared default "(.*)", so
 // omitempty drops it from marshaled output.
 func (re Regexp) IsZero() bool {
-	return re.Regexp == nil || re.Regexp == defaultConfig.Regex.Regexp
+	return re.Regexp == nil || re.original == defaultConfig.Regex.original
 }
 
 // Apply runs the rules against one sample. It returns the (possibly mutated)

--- a/src/go/plugin/go.d/collector/prometheus/relabel/relabel_config_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel/relabel_config_test.go
@@ -156,6 +156,21 @@ func TestConfig_explicitEmptyRoundTrip(t *testing.T) {
 	}
 }
 
+func TestConfig_clonePreservesDefaultRegexOmission(t *testing.T) {
+	var original Config
+	require.NoError(t, yaml.Unmarshal([]byte("action: drop\n"), &original))
+	cloned := original.clone()
+	require.NotSame(t, original.Regex.Regexp, cloned.Regex.Regexp)
+
+	for name, cfg := range map[string]Config{"original": original, "clone": cloned} {
+		t.Run(name, func(t *testing.T) {
+			b, err := yaml.Marshal(cfg)
+			require.NoError(t, err)
+			assert.NotContains(t, string(b), "regex:")
+		})
+	}
+}
+
 // TestConfig_unmarshalThenNew confirms an unmarshaled rule validates and applies.
 func TestConfig_unmarshalThenNew(t *testing.T) {
 	var cfg Config

--- a/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
@@ -131,7 +131,7 @@ func BenchmarkRelabelScrapeModes(b *testing.B) {
 
 			var normalizers []profileNormalizer
 			if tc.profileRules {
-				normalizers = []profileNormalizer{benchmarkProfileNormalizer(b, "all", "*", "*", "profile_stage")}
+				normalizers = []profileNormalizer{benchmarkProfileNormalizer(b, "*", "*", "profile_stage")}
 			}
 
 			b.ReportAllocs()
@@ -152,21 +152,24 @@ func BenchmarkRelabelScrapeModes(b *testing.B) {
 	}
 }
 
-// BenchmarkProfileRelabelDispatch isolates ownership resolution. The sixteen-
-// profile case gives every source family one disjoint owner and guards against
-// accidental pairwise profile composition or an unbounded dispatch cache. The
-// 2026-08-05 run measured 6,767 ns/op for one profile, 7,856 ns/op for sixteen
-// disjoint roots, and 22,591 ns/op for sixteen overlapping roots with disjoint
-// block ownership; all used 16,216 B/op and 93 allocations.
+// BenchmarkProfileRelabelDispatch isolates first-applicable family dispatch.
+// The sixteen-profile case gives every source family one applicable normalizer
+// and guards against accidental profile chaining or an unbounded dispatch cache.
+// The 2026-08-05 baseline measured 6,462-6,517 ns/op for one profile,
+// 7,582-7,813 ns/op for sixteen disjoint roots, and 23,870-24,008 ns/op for
+// sixteen overlapping roots with disjoint blocks; all used 16,216 B/op and 93
+// allocations. First-applicable dispatch measured 2,455-2,560 ns/op,
+// 4,807-4,865 ns/op, and 7,066-7,145 ns/op respectively, with 1,640 B/op and
+// 7 allocations in all three cases.
 func BenchmarkProfileRelabelDispatch(b *testing.B) {
 	batch := scrapeSamples(b, benchExposition())
 
 	b.Run("one_profile", func(b *testing.B) {
-		normalizers := []profileNormalizer{benchmarkProfileNormalizer(b, "all", "*", "*", "profile_stage")}
+		normalizers := []profileNormalizer{benchmarkProfileNormalizer(b, "*", "*", "profile_stage")}
 		b.ReportAllocs()
 		b.ResetTimer()
 		for range b.N {
-			resolveProfileOwners(batch, normalizers)
+			selectProfileNormalizers(batch, normalizers)
 		}
 	})
 
@@ -176,7 +179,7 @@ func BenchmarkProfileRelabelDispatch(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for range b.N {
-			resolveProfileOwners(batch, normalizers)
+			selectProfileNormalizers(batch, normalizers)
 		}
 	})
 
@@ -186,7 +189,7 @@ func BenchmarkProfileRelabelDispatch(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for range b.N {
-			resolveProfileOwners(batch, normalizers)
+			selectProfileNormalizers(batch, normalizers)
 		}
 	})
 }
@@ -198,18 +201,17 @@ func benchmarkDisjointNormalizers(tb testing.TB, overlappingRoots bool) []profil
 	for i := range 15 {
 		patterns = append(patterns, fmt.Sprintf("lat_%d_seconds", i))
 	}
-	for i, base := range patterns {
+	for _, base := range patterns {
 		root := base
 		if overlappingRoots {
 			root = "*"
 		}
-		normalizers = append(normalizers,
-			benchmarkProfileNormalizer(tb, fmt.Sprintf("profile_%d", i), root, base+"*", "profile_stage"))
+		normalizers = append(normalizers, benchmarkProfileNormalizer(tb, root, base+"*", "profile_stage"))
 	}
 	return normalizers
 }
 
-func benchmarkProfileNormalizer(tb testing.TB, name, rootPattern, blockPattern, label string) profileNormalizer {
+func benchmarkProfileNormalizer(tb testing.TB, rootPattern, blockPattern, label string) profileNormalizer {
 	tb.Helper()
 	root, err := matcher.NewSimplePatternsMatcher(rootPattern)
 	if err != nil {
@@ -219,7 +221,7 @@ func benchmarkProfileNormalizer(tb testing.TB, name, rootPattern, blockPattern, 
 	if err != nil {
 		tb.Fatal(err)
 	}
-	return profileNormalizer{name: name, root: root, pipeline: pipeline}
+	return profileNormalizer{root: root, pipeline: pipeline}
 }
 
 func benchmarkRelabelBlocks(label string) []relabel.Block {

--- a/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
@@ -31,10 +31,10 @@ import (
 //	go test ./plugin/go.d/collector/prometheus -run '^$' -bench RelabelExecutor -benchmem
 //
 // Measured on a developer laptop (Apple M4 Pro), 165 series (150 counters + 15
-// histograms), not CI — compare relative deltas, not absolutes (captured 2026-06-10):
+// histograms), not CI — compare relative deltas, not absolutes (captured 2026-08-05):
 //
-//	assemble_only                13545 ns/op    38272 B/op    414 allocs/op
-//	relabel_assemble_validate   118776 ns/op   119949 B/op   1577 allocs/op
+//	assemble_only                13511 ns/op    38272 B/op    414 allocs/op
+//	relabel_assemble_validate   121398 ns/op   119950 B/op   1577 allocs/op
 //
 // The executor adds ~105us per scrape in this near worst case (a rule rewriting every
 // series, so every typed family is validated). It is paid only on jobs that configure
@@ -83,6 +83,22 @@ func BenchmarkRelabelExecutor(b *testing.B) {
 // BenchmarkRelabelScrapeModes measures the complete steady-state fetch and parse
 // path for each supported stage combination. Unlike BenchmarkRelabelExecutor,
 // this includes the direct parser versus buffered-sample parser difference.
+// The same 2026-08-05 run measured:
+//
+//	no_rules                 96251 ns/op    46839 B/op    584 allocs/op
+//	job_rules               206978 ns/op   216616 B/op   1695 allocs/op
+//	profile_rules           240713 ns/op   288084 B/op   1794 allocs/op
+//	job_and_profile_rules   363555 ns/op   416780 B/op   2743 allocs/op
+//
+// A three-run comparison against the pre-feature master snapshot, using this
+// same fetch/parse fixture, found no material existing-path regression:
+//
+//	mode        pre-feature master                              current branch
+//	no_rules    93.2-94.3 us, 46.8-46.9 KB, 584 allocs/op       93.5-95.9 us, 46.8-47.0 KB, 584 allocs/op
+//	job_rules   208-239 us, 217.3-217.6 KB, 1696-1697 allocs    212-243 us, 217.4-217.9 KB, 1696-1697 allocs
+//
+// Profile-only and combined modes did not exist before this feature, so their
+// pre-change result is not applicable; the absolute opt-in costs are above.
 func BenchmarkRelabelScrapeModes(b *testing.B) {
 	exposition := benchExposition()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -138,7 +154,10 @@ func BenchmarkRelabelScrapeModes(b *testing.B) {
 
 // BenchmarkProfileRelabelDispatch isolates ownership resolution. The sixteen-
 // profile case gives every source family one disjoint owner and guards against
-// accidental pairwise profile composition or an unbounded dispatch cache.
+// accidental pairwise profile composition or an unbounded dispatch cache. The
+// 2026-08-05 run measured 6,767 ns/op for one profile, 7,856 ns/op for sixteen
+// disjoint roots, and 22,591 ns/op for sixteen overlapping roots with disjoint
+// block ownership; all used 16,216 B/op and 93 allocations.
 func BenchmarkProfileRelabelDispatch(b *testing.B) {
 	batch := scrapeSamples(b, benchExposition())
 
@@ -152,14 +171,7 @@ func BenchmarkProfileRelabelDispatch(b *testing.B) {
 	})
 
 	b.Run("sixteen_disjoint_profiles", func(b *testing.B) {
-		normalizers := make([]profileNormalizer, 0, 16)
-		normalizers = append(normalizers,
-			benchmarkProfileNormalizer(b, "http", "http_requests_total", "http_requests_total", "profile_stage"))
-		for i := range 15 {
-			base := fmt.Sprintf("lat_%d_seconds", i)
-			normalizers = append(normalizers,
-				benchmarkProfileNormalizer(b, fmt.Sprintf("lat_%d", i), base, base+"*", "profile_stage"))
-		}
+		normalizers := benchmarkDisjointNormalizers(b, false)
 
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -167,6 +179,34 @@ func BenchmarkProfileRelabelDispatch(b *testing.B) {
 			resolveProfileOwners(batch, normalizers)
 		}
 	})
+
+	b.Run("sixteen_overlapping_roots_disjoint_blocks", func(b *testing.B) {
+		normalizers := benchmarkDisjointNormalizers(b, true)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			resolveProfileOwners(batch, normalizers)
+		}
+	})
+}
+
+func benchmarkDisjointNormalizers(tb testing.TB, overlappingRoots bool) []profileNormalizer {
+	tb.Helper()
+	normalizers := make([]profileNormalizer, 0, 16)
+	patterns := []string{"http_requests_total"}
+	for i := range 15 {
+		patterns = append(patterns, fmt.Sprintf("lat_%d_seconds", i))
+	}
+	for i, base := range patterns {
+		root := base
+		if overlappingRoots {
+			root = "*"
+		}
+		normalizers = append(normalizers,
+			benchmarkProfileNormalizer(tb, fmt.Sprintf("profile_%d", i), root, base+"*", "profile_stage"))
+	}
+	return normalizers
 }
 
 func benchmarkProfileNormalizer(tb testing.TB, name, rootPattern, blockPattern, label string) profileNormalizer {

--- a/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/netdata/netdata/go/plugins/pkg/matcher"
 	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
@@ -17,7 +16,7 @@ import (
 // batch, so HTTP and parsing are excluded and the delta is purely the executor:
 //
 //   - assemble_only: prompkg.Assemble — what the no-rules fast path does after parse.
-//   - relabel_assemble_validate: applyBlocks + Assemble + typed-family validation.
+//   - relabel_assemble_validate: Pipeline.Apply + Assemble + typed-family validation.
 //
 // The relabel block adds a static label to every series, so every typed family is
 // touched and the full validation pass runs (a near worst case). Parsing's own
@@ -52,17 +51,20 @@ func BenchmarkRelabelExecutor(b *testing.B) {
 	})
 
 	b.Run("relabel_assemble_validate", func(b *testing.B) {
-		proc, err := relabel.New([]relabel.Config{{
-			SourceLabels: []string{"__name__"},
-			Regex:        relabel.MustNewRegexp("(.+)"),
-			TargetLabel:  "env",
-			Replacement:  "prod",
-			Action:       relabel.Replace,
+		pipeline, err := relabel.NewPipeline([]relabel.Block{{
+			Match: "*",
+			MetricRelabelConfigs: []relabel.Config{{
+				SourceLabels: []string{"__name__"},
+				Regex:        relabel.MustNewRegexp("(.+)"),
+				TargetLabel:  "env",
+				Replacement:  "prod",
+				Action:       relabel.Replace,
+			}},
 		}})
 		if err != nil {
 			b.Fatal(err)
 		}
-		c := &Collector{relabelBlocks: []relabelBlock{{match: matcher.TRUE(), proc: proc}}}
+		c := &Collector{jobRelabel: pipeline}
 
 		b.ReportAllocs()
 		b.ResetTimer()

--- a/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
@@ -153,14 +153,17 @@ func BenchmarkRelabelScrapeModes(b *testing.B) {
 }
 
 // BenchmarkProfileRelabelDispatch isolates first-applicable family dispatch.
-// The sixteen-profile case gives every source family one applicable normalizer
-// and guards against accidental profile chaining or an unbounded dispatch cache.
+// The sixteen-profile cases guard against accidental profile chaining,
+// repeated matcher work for labeled series, or an unbounded dispatch cache.
 // The 2026-08-05 baseline measured 6,462-6,517 ns/op for one profile,
 // 7,582-7,813 ns/op for sixteen disjoint roots, and 23,870-24,008 ns/op for
 // sixteen overlapping roots with disjoint blocks; all used 16,216 B/op and 93
-// allocations. First-applicable dispatch measured 2,455-2,560 ns/op,
-// 4,807-4,865 ns/op, and 7,066-7,145 ns/op respectively, with 1,640 B/op and
-// 7 allocations in all three cases.
+// allocations. Before physical-name caching, first-applicable dispatch measured
+// 2,455-2,560 ns/op, 4,807-4,865 ns/op, and 7,066-7,145 ns/op respectively;
+// the sixteen-profile all-miss case measured 24,166-24,685 ns/op. The bounded
+// one-entry cache measured 2,497-2,564 ns/op, 4,074-4,212 ns/op,
+// 5,459-5,684 ns/op, and 6,604-6,658 ns/op respectively. The first three use
+// 1,640 B/op and 7 allocations; all-miss uses 48 B/op and 1 allocation.
 func BenchmarkProfileRelabelDispatch(b *testing.B) {
 	batch := scrapeSamples(b, benchExposition())
 
@@ -192,6 +195,16 @@ func BenchmarkProfileRelabelDispatch(b *testing.B) {
 			selectProfileNormalizers(batch, normalizers)
 		}
 	})
+
+	b.Run("sixteen_overlapping_roots_nonmatching_blocks", func(b *testing.B) {
+		normalizers := benchmarkNonmatchingNormalizers(b, 16)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			selectProfileNormalizers(batch, normalizers)
+		}
+	})
 }
 
 func benchmarkDisjointNormalizers(tb testing.TB, overlappingRoots bool) []profileNormalizer {
@@ -207,6 +220,16 @@ func benchmarkDisjointNormalizers(tb testing.TB, overlappingRoots bool) []profil
 			root = "*"
 		}
 		normalizers = append(normalizers, benchmarkProfileNormalizer(tb, root, base+"*", "profile_stage"))
+	}
+	return normalizers
+}
+
+func benchmarkNonmatchingNormalizers(tb testing.TB, count int) []profileNormalizer {
+	tb.Helper()
+	normalizers := make([]profileNormalizer, 0, count)
+	for i := range count {
+		normalizers = append(normalizers,
+			benchmarkProfileNormalizer(tb, "*", fmt.Sprintf("missing_%d*", i), "profile_stage"))
 	}
 	return normalizers
 }

--- a/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_bench_test.go
@@ -3,10 +3,14 @@
 package prometheus
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/pkg/matcher"
 	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
@@ -69,11 +73,128 @@ func BenchmarkRelabelExecutor(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for range b.N {
-			if _, err := c.relabelAndAssemble(batch, false); err != nil {
+			if _, _, err := c.relabelAndAssemble(batch, c.jobRelabel, jobRelabelStage, false); err != nil {
 				b.Fatal(err)
 			}
 		}
 	})
+}
+
+// BenchmarkRelabelScrapeModes measures the complete steady-state fetch and parse
+// path for each supported stage combination. Unlike BenchmarkRelabelExecutor,
+// this includes the direct parser versus buffered-sample parser difference.
+func BenchmarkRelabelScrapeModes(b *testing.B) {
+	exposition := benchExposition()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(exposition))
+	}))
+	b.Cleanup(srv.Close)
+
+	tests := []struct {
+		name         string
+		jobRules     bool
+		profileRules bool
+	}{
+		{name: "no_rules"},
+		{name: "job_rules", jobRules: true},
+		{name: "profile_rules", profileRules: true},
+		{name: "job_and_profile_rules", jobRules: true, profileRules: true},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.name, func(b *testing.B) {
+			collr := New()
+			collr.URL = srv.URL
+			collr.Profiles = ProfilesConfig{Mode: profilesModeNone}
+			if tc.jobRules {
+				collr.Relabeling = benchmarkRelabelBlocks("job_stage")
+			}
+			if err := collr.Init(context.Background()); err != nil {
+				b.Fatal(err)
+			}
+
+			var normalizers []profileNormalizer
+			if tc.profileRules {
+				normalizers = []profileNormalizer{benchmarkProfileNormalizer(b, "all", "*", "*", "profile_stage")}
+			}
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(exposition)))
+			b.ResetTimer()
+			for range b.N {
+				var err error
+				if len(normalizers) == 0 {
+					_, err = collr.scrape(context.Background(), false)
+				} else {
+					_, err = collr.scrapeProfileNormalized(context.Background(), normalizers, false)
+				}
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkProfileRelabelDispatch isolates ownership resolution. The sixteen-
+// profile case gives every source family one disjoint owner and guards against
+// accidental pairwise profile composition or an unbounded dispatch cache.
+func BenchmarkProfileRelabelDispatch(b *testing.B) {
+	batch := scrapeSamples(b, benchExposition())
+
+	b.Run("one_profile", func(b *testing.B) {
+		normalizers := []profileNormalizer{benchmarkProfileNormalizer(b, "all", "*", "*", "profile_stage")}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			resolveProfileOwners(batch, normalizers)
+		}
+	})
+
+	b.Run("sixteen_disjoint_profiles", func(b *testing.B) {
+		normalizers := make([]profileNormalizer, 0, 16)
+		normalizers = append(normalizers,
+			benchmarkProfileNormalizer(b, "http", "http_requests_total", "http_requests_total", "profile_stage"))
+		for i := range 15 {
+			base := fmt.Sprintf("lat_%d_seconds", i)
+			normalizers = append(normalizers,
+				benchmarkProfileNormalizer(b, fmt.Sprintf("lat_%d", i), base, base+"*", "profile_stage"))
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			resolveProfileOwners(batch, normalizers)
+		}
+	})
+}
+
+func benchmarkProfileNormalizer(tb testing.TB, name, rootPattern, blockPattern, label string) profileNormalizer {
+	tb.Helper()
+	root, err := matcher.NewSimplePatternsMatcher(rootPattern)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	pipeline, err := relabel.NewPipeline(benchmarkRelabelBlocksForMatch(blockPattern, label))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return profileNormalizer{name: name, root: root, pipeline: pipeline}
+}
+
+func benchmarkRelabelBlocks(label string) []relabel.Block {
+	return benchmarkRelabelBlocksForMatch("*", label)
+}
+
+func benchmarkRelabelBlocksForMatch(match, label string) []relabel.Block {
+	return []relabel.Block{{
+		Match: match,
+		MetricRelabelConfigs: []relabel.Config{{
+			TargetLabel: label,
+			Replacement: "true",
+			Action:      relabel.Replace,
+		}},
+	}}
 }
 
 // benchExposition builds a representative scrape: many labeled counters plus a set

--- a/src/go/plugin/go.d/collector/prometheus/relabel_exec.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_exec.go
@@ -39,10 +39,9 @@ var (
 )
 
 type relabelResult struct {
-	raw     prompkg.Sample
-	sample  prompkg.Sample
-	drop    relabel.DropInfo
-	discard bool
+	raw    prompkg.Sample
+	sample prompkg.Sample
+	drop   relabel.DropInfo
 }
 
 // relabelAndAssemble runs the job-level relabel pipeline: relabel every sample,
@@ -65,16 +64,32 @@ func (c *Collector) relabelAndAssemble(
 	checking bool,
 ) (prompkg.SampleBatch, prompkg.MetricFamilies, error) {
 	processed, tracking := c.applyPipelineRelabel(batch, pipeline, stage)
-	return c.assembleRelabeled(processed, tracking, stage, checking)
+	return c.finishRelabel(processed, tracking, stage, checking, true)
 }
 
-func (c *Collector) assembleRelabeled(
+// relabelAndValidateBatch runs relabeling and typed-family safety when the caller
+// needs the resulting sample batch but not an intermediate family assembly.
+func (c *Collector) relabelAndValidateBatch(
+	batch prompkg.SampleBatch,
+	pipeline *relabel.Pipeline,
+	stage relabelStage,
+	checking bool,
+) (prompkg.SampleBatch, error) {
+	processed, tracking := c.applyPipelineRelabel(batch, pipeline, stage)
+	processed, _, err := c.finishRelabel(processed, tracking, stage, checking, false)
+	return processed, err
+}
+
+func (c *Collector) finishRelabel(
 	processed prompkg.SampleBatch,
 	tracking *relabelTracking,
 	stage relabelStage,
 	checking bool,
+	needFamilies bool,
 ) (prompkg.SampleBatch, prompkg.MetricFamilies, error) {
-
+	if !tracking.anyTypedTouched && !needFamilies {
+		return processed, nil, nil
+	}
 	mfs, err := prompkg.Assemble(processed)
 	if err != nil {
 		return prompkg.SampleBatch{}, nil, err
@@ -87,6 +102,9 @@ func (c *Collector) assembleRelabeled(
 
 	invalid, violations := validateTypedFamilies(tracking, mfs)
 	if len(invalid) == 0 {
+		if !needFamilies {
+			mfs = nil
+		}
 		return processed, mfs, nil
 	}
 
@@ -106,6 +124,9 @@ func (c *Collector) assembleRelabeled(
 	// Closed invalid set computed in one pass, so a single re-filter + reassembly
 	// terminates: dropping samples can only remove corruption, never add it.
 	filtered := filterInvalidTypedFamilies(processed, invalid)
+	if !needFamilies {
+		return filtered, nil, nil
+	}
 	mfs, err = prompkg.Assemble(filtered)
 	return filtered, mfs, err
 }
@@ -125,27 +146,6 @@ func (c *Collector) applyPipelineRelabel(
 	out.Help = help.remap(batch.Help)
 	return out, t
 }
-
-// materializeRelabel builds the kept sample batch, HELP remap, and shared typed-
-// family provenance from relabel outcomes. Policy-discarded results are omitted
-// as complete source families and do not look like rule-level partial drops.
-func (c *Collector) materializeRelabel(
-	helpEntries []prompkg.HelpEntry,
-	results []relabelResult,
-	stage relabelStage,
-) (prompkg.SampleBatch, *relabelTracking) {
-	t := newRelabelTracking()
-	help := newHelpRemap()
-	out := prompkg.SampleBatch{Samples: make([]prompkg.Sample, 0, len(results))}
-
-	for _, result := range results {
-		c.appendRelabelResult(&out, t, help, stage, result)
-	}
-
-	out.Help = help.remap(helpEntries)
-	return out, t
-}
-
 func (c *Collector) appendRelabelResult(
 	out *prompkg.SampleBatch,
 	t *relabelTracking,
@@ -153,9 +153,6 @@ func (c *Collector) appendRelabelResult(
 	stage relabelStage,
 	result relabelResult,
 ) {
-	if result.discard {
-		return
-	}
 	raw := result.raw
 	sample := result.sample
 	rawKey, isTyped := typedFamilyKeyOf(raw)

--- a/src/go/plugin/go.d/collector/prometheus/relabel_exec.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_exec.go
@@ -12,35 +12,9 @@ import (
 	commonmodel "github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/netdata/netdata/go/plugins/pkg/matcher"
 	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
-
-// relabelBlock is a compiled relabeling block: a metric-name matcher (required,
-// never nil) and the relabel processor for its rules.
-type relabelBlock struct {
-	match matcher.Matcher
-	proc  *relabel.Processor
-}
-
-// applyBlocks runs each block whose match matches the sample's current name, in
-// order, threading the sample through. It returns the relabeled sample, or the
-// sample as it stood when a rule dropped it plus that drop.
-func (c *Collector) applyBlocks(sample prompkg.Sample) (prompkg.Sample, relabel.DropInfo) {
-	for i := range c.relabelBlocks {
-		b := &c.relabelBlocks[i]
-		if !b.match.MatchString(sample.Name) {
-			continue
-		}
-		out, drop := b.proc.Apply(sample)
-		if drop.Dropped() {
-			return sample, drop
-		}
-		sample = out
-	}
-	return sample, relabel.DropInfo{}
-}
 
 // Structural label names and family-name suffixes that bind the components of a
 // typed family (histogram/summary) together. Defined locally because the
@@ -115,7 +89,7 @@ func (c *Collector) applyJobRelabel(batch prompkg.SampleBatch) (prompkg.SampleBa
 	for _, raw := range batch.Samples {
 		rawKey, isTyped := typedFamilyKeyOf(raw)
 
-		sample, drop := c.applyBlocks(raw)
+		sample, drop := c.jobRelabel.Apply(raw)
 		if drop.Dropped() {
 			// Log the sample as it stood when the drop happened — an earlier block may
 			// have renamed it. (rawKey stays keyed on the original for family tracking.)

--- a/src/go/plugin/go.d/collector/prometheus/relabel_exec.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_exec.go
@@ -28,6 +28,23 @@ const (
 	suffixBucket  = "_bucket"
 )
 
+type relabelStage struct {
+	name       string
+	limiterKey string
+}
+
+var (
+	jobRelabelStage     = relabelStage{name: "job relabeling", limiterKey: "job-relabel-typed-family-corruption"}
+	profileRelabelStage = relabelStage{name: "profile relabeling", limiterKey: "profile-relabel-typed-family-corruption"}
+)
+
+type relabelResult struct {
+	raw     prompkg.Sample
+	sample  prompkg.Sample
+	drop    relabel.DropInfo
+	discard bool
+}
+
 // relabelAndAssemble runs the job-level relabel pipeline: relabel every sample,
 // assemble, then curate typed families so relabeling cannot silently corrupt a
 // histogram/summary. A histogram/summary is a set of physical samples
@@ -41,86 +58,135 @@ const (
 // so a broken rule fails fast. Under Collect it is false: corrupted families are
 // dropped and the rest reassembled once, with a warning, so a transient
 // exposition change cannot take the whole job down.
-func (c *Collector) relabelAndAssemble(batch prompkg.SampleBatch, checking bool) (prompkg.MetricFamilies, error) {
-	processed, tracking := c.applyJobRelabel(batch)
+func (c *Collector) relabelAndAssemble(
+	batch prompkg.SampleBatch,
+	pipeline *relabel.Pipeline,
+	stage relabelStage,
+	checking bool,
+) (prompkg.SampleBatch, prompkg.MetricFamilies, error) {
+	processed, tracking := c.applyPipelineRelabel(batch, pipeline, stage)
+	return c.assembleRelabeled(processed, tracking, stage, checking)
+}
+
+func (c *Collector) assembleRelabeled(
+	processed prompkg.SampleBatch,
+	tracking *relabelTracking,
+	stage relabelStage,
+	checking bool,
+) (prompkg.SampleBatch, prompkg.MetricFamilies, error) {
 
 	mfs, err := prompkg.Assemble(processed)
 	if err != nil {
-		return nil, err
+		return prompkg.SampleBatch{}, nil, err
 	}
 
 	// No typed family was altered (or dropped) by relabeling: nothing to curate.
 	if !tracking.anyTypedTouched {
-		return mfs, nil
+		return processed, mfs, nil
 	}
 
 	invalid, violations := validateTypedFamilies(tracking, mfs)
 	if len(invalid) == 0 {
-		return mfs, nil
+		return processed, mfs, nil
 	}
 
 	if checking {
-		return nil, fmt.Errorf("relabeling corrupts typed metric families: %s", violations[0])
+		return prompkg.SampleBatch{}, nil, fmt.Errorf("%s corrupts typed metric families: %s", stage.name, violations[0])
 	}
 
 	// Runtime: drop the corrupted families and reassemble. This can recur every scrape
 	// if a rule stays bad or the exporter changed, so rate-limit the warning to avoid
 	// flooding the log; the per-family detail stays at debug.
-	c.Limit("relabel-typed-family-corruption", 1, 10*time.Minute).
-		Warningf("relabeling produced %d typed-family corruption(s); dropped the affected families (enable debug for names)", len(violations))
+	c.Limit(stage.limiterKey, 1, 10*time.Minute).
+		Warningf("%s produced %d typed-family corruption(s); dropped the affected families (enable debug for names)", stage.name, len(violations))
 	for _, v := range violations {
-		c.Debugf("relabeling dropped corrupted typed family: %s", v)
+		c.Debugf("%s dropped corrupted typed family: %s", stage.name, v)
 	}
 
 	// Closed invalid set computed in one pass, so a single re-filter + reassembly
 	// terminates: dropping samples can only remove corruption, never add it.
 	filtered := filterInvalidTypedFamilies(processed, invalid)
-	return prompkg.Assemble(filtered)
+	mfs, err = prompkg.Assemble(filtered)
+	return filtered, mfs, err
 }
 
-// applyJobRelabel runs the relabel processor over every sample, building the
-// processed batch (kept samples + HELP remapped from raw family name to final
-// family name) and the typed-family tracking the validator consumes.
-func (c *Collector) applyJobRelabel(batch prompkg.SampleBatch) (prompkg.SampleBatch, *relabelTracking) {
+func (c *Collector) applyPipelineRelabel(
+	batch prompkg.SampleBatch,
+	pipeline *relabel.Pipeline,
+	stage relabelStage,
+) (prompkg.SampleBatch, *relabelTracking) {
 	t := newRelabelTracking()
 	help := newHelpRemap()
 	out := prompkg.SampleBatch{Samples: make([]prompkg.Sample, 0, len(batch.Samples))}
-
 	for _, raw := range batch.Samples {
-		rawKey, isTyped := typedFamilyKeyOf(raw)
-
-		sample, drop := c.jobRelabel.Apply(raw)
-		if drop.Dropped() {
-			// Log the sample as it stood when the drop happened — an earlier block may
-			// have renamed it. (rawKey stays keyed on the original for family tracking.)
-			c.onRelabelDrop(sample, drop)
-			if isTyped {
-				t.recordDropped(rawKey)
-			}
-			continue
-		}
-
-		touched := sample.Name != raw.Name || !labels.Equal(sample.Labels, raw.Labels)
-		if isTyped {
-			finalKey, _ := typedFamilyKeyOf(sample) // Kind is preserved by relabeling, so still typed
-			t.recordKept(rawKey, finalKey, raw, sample, touched)
-		}
-
-		out.Samples = append(out.Samples, sample)
-		help.add(helpFamilyName(raw), helpFamilyName(sample))
+		sample, drop := pipeline.Apply(raw)
+		c.appendRelabelResult(&out, t, help, stage, relabelResult{raw: raw, sample: sample, drop: drop})
 	}
-
 	out.Help = help.remap(batch.Help)
 	return out, t
 }
 
+// materializeRelabel builds the kept sample batch, HELP remap, and shared typed-
+// family provenance from relabel outcomes. Policy-discarded results are omitted
+// as complete source families and do not look like rule-level partial drops.
+func (c *Collector) materializeRelabel(
+	helpEntries []prompkg.HelpEntry,
+	results []relabelResult,
+	stage relabelStage,
+) (prompkg.SampleBatch, *relabelTracking) {
+	t := newRelabelTracking()
+	help := newHelpRemap()
+	out := prompkg.SampleBatch{Samples: make([]prompkg.Sample, 0, len(results))}
+
+	for _, result := range results {
+		c.appendRelabelResult(&out, t, help, stage, result)
+	}
+
+	out.Help = help.remap(helpEntries)
+	return out, t
+}
+
+func (c *Collector) appendRelabelResult(
+	out *prompkg.SampleBatch,
+	t *relabelTracking,
+	help *helpRemap,
+	stage relabelStage,
+	result relabelResult,
+) {
+	if result.discard {
+		return
+	}
+	raw := result.raw
+	sample := result.sample
+	rawKey, isTyped := typedFamilyKeyOf(raw)
+
+	if result.drop.Dropped() {
+		// Log the sample as it stood when the drop happened — an earlier block may
+		// have renamed it. (rawKey stays keyed on the original for family tracking.)
+		c.onRelabelDrop(stage, sample, result.drop)
+		if isTyped {
+			t.recordDropped(rawKey)
+		}
+		return
+	}
+
+	touched := sample.Name != raw.Name || !labels.Equal(sample.Labels, raw.Labels)
+	if isTyped {
+		finalKey, _ := typedFamilyKeyOf(sample) // Kind is preserved by relabeling, so still typed
+		t.recordKept(rawKey, finalKey, raw, sample, touched)
+	}
+
+	out.Samples = append(out.Samples, sample)
+	help.add(helpFamilyName(raw), helpFamilyName(sample))
+}
+
 // onRelabelDrop logs why a relabel rule dropped a sample, at debug level. It logs
 // the metric name and the rule outcome, never label values (cardinality/PII).
-func (c *Collector) onRelabelDrop(s prompkg.Sample, d relabel.DropInfo) {
+func (c *Collector) onRelabelDrop(stage relabelStage, s prompkg.Sample, d relabel.DropInfo) {
 	c.When(d.RuleIndex >= 0).
-		Debugf("relabel dropped metric %q: %s (rule %d, action %q)", s.Name, d.Reason, d.RuleIndex, d.Action).
+		Debugf("%s dropped metric %q: %s (rule %d, action %q)", stage.name, s.Name, d.Reason, d.RuleIndex, d.Action).
 		Else().
-		Debugf("relabel dropped metric %q: %s", s.Name, d.Reason)
+		Debugf("%s dropped metric %q: %s", stage.name, s.Name, d.Reason)
 }
 
 // typedFamilyKey identifies one logical histogram/summary instance: the base

--- a/src/go/plugin/go.d/collector/prometheus/relabel_exec_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_exec_test.go
@@ -58,8 +58,8 @@ app_lat_count{inst="b"} 5
 ` + relabelSibling
 )
 
-// TestCollector_relabelTypedFamilyIntegrity drives the real collector (Init → Check,
-// Init → Collect) and asserts that relabeling which would silently corrupt a
+// TestCollector_relabelTypedFamilyIntegrity drives the real collector (Init → Check →
+// Collect) and asserts that relabeling which would silently corrupt a
 // histogram/summary is a hard error under Check and a drop-and-reassemble under
 // Collect, while clean relabeling and the unrelated sibling are preserved.
 func TestCollector_relabelTypedFamilyIntegrity(t *testing.T) {
@@ -162,8 +162,9 @@ func TestCollector_relabelTypedFamilyIntegrity(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			currentInput := tc.input
 			srv := httptest.NewServer(http.HandlerFunc(
-				func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(tc.input)) }))
+				func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(currentInput)) }))
 			defer srv.Close()
 
 			newCollr := func() *Collector {
@@ -175,6 +176,7 @@ func TestCollector_relabelTypedFamilyIntegrity(t *testing.T) {
 			}
 
 			// Check: corruption fails autodetection.
+			currentInput = tc.input
 			checkErr := newCollr().Check(context.Background())
 			if tc.wantCheckErr {
 				assert.Error(t, checkErr)
@@ -182,8 +184,12 @@ func TestCollector_relabelTypedFamilyIntegrity(t *testing.T) {
 				assert.NoError(t, checkErr)
 			}
 
-			// Collect: corruption is dropped, survivors written.
+			// Runtime behavior is tested only after a successful Check, then an
+			// exporter-shape drift introduces the corrupt family.
+			currentInput = "# TYPE startup gauge\nstartup 1\n"
 			collr := newCollr()
+			require.NoError(t, collr.Check(context.Background()))
+			currentInput = tc.input
 			cc := cycle(t, collr.MetricStore())
 			cc.BeginCycle()
 			require.NoError(t, collr.Collect(context.Background()))
@@ -212,7 +218,7 @@ app_lat_count 6
 	require.NoError(t, err)
 	c := &Collector{jobRelabel: pipeline}
 
-	mfs, err := c.relabelAndAssemble(batch, false)
+	_, mfs, err := c.relabelAndAssemble(batch, c.jobRelabel, jobRelabelStage, false)
 	require.NoError(t, err)
 
 	renamed := mfs.GetHistogram("renamed_lat")
@@ -241,6 +247,7 @@ other_requests_total{code="200"} 9
 		MetricRelabelConfigs: setLabel([]string{"code"}, "(.+)", "verb", "${1}"),
 	}}
 	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
 
 	cc := cycle(t, collr.MetricStore())
 	cc.BeginCycle()

--- a/src/go/plugin/go.d/collector/prometheus/relabel_exec_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/relabel_exec_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/netdata/netdata/go/plugins/pkg/matcher"
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	prompkg "github.com/netdata/netdata/go/plugins/pkg/prometheus"
 	"github.com/netdata/netdata/go/plugins/pkg/web"
@@ -170,7 +169,7 @@ func TestCollector_relabelTypedFamilyIntegrity(t *testing.T) {
 			newCollr := func() *Collector {
 				c := New()
 				c.URL = srv.URL
-				c.Relabeling = []RelabelBlock{{Match: "*", MetricRelabelConfigs: tc.rules}}
+				c.Relabeling = []relabel.Block{{Match: "*", MetricRelabelConfigs: tc.rules}}
 				require.NoError(t, c.Init(context.Background()))
 				return c
 			}
@@ -206,9 +205,12 @@ app_lat_sum 2.5
 app_lat_count 6
 `)
 
-	proc, err := relabel.New(renameMetric("app_lat(.*)", "renamed_lat${1}"))
+	pipeline, err := relabel.NewPipeline([]relabel.Block{{
+		Match:                "*",
+		MetricRelabelConfigs: renameMetric("app_lat(.*)", "renamed_lat${1}"),
+	}})
 	require.NoError(t, err)
-	c := &Collector{relabelBlocks: []relabelBlock{{match: matcher.TRUE(), proc: proc}}}
+	c := &Collector{jobRelabel: pipeline}
 
 	mfs, err := c.relabelAndAssemble(batch, false)
 	require.NoError(t, err)
@@ -234,7 +236,7 @@ other_requests_total{code="200"} 9
 
 	collr := New()
 	collr.URL = srv.URL
-	collr.Relabeling = []RelabelBlock{{
+	collr.Relabeling = []relabel.Block{{
 		Match:                "app_*",
 		MetricRelabelConfigs: setLabel([]string{"code"}, "(.+)", "verb", "${1}"),
 	}}

--- a/src/go/plugin/go.d/collector/prometheus/runtime.go
+++ b/src/go/plugin/go.d/collector/prometheus/runtime.go
@@ -23,7 +23,6 @@ type promRuntime struct {
 }
 
 type profileNormalizer struct {
-	name     string
 	root     matcher.Matcher
 	pipeline *relabel.Pipeline
 }
@@ -46,7 +45,7 @@ func compileProfileNormalizers(profiles []promprofiles.Profile) ([]profileNormal
 		if err != nil {
 			return nil, fmt.Errorf("profile %q: invalid match %q: %w", profile.Name, profile.Match, err)
 		}
-		normalizers = append(normalizers, profileNormalizer{name: profile.Name, root: root, pipeline: pipeline})
+		normalizers = append(normalizers, profileNormalizer{root: root, pipeline: pipeline})
 	}
 	return normalizers, nil
 }
@@ -175,6 +174,40 @@ func combinedSelectProfiles(catalog promprofiles.Catalog, names []string, mfs pr
 		out = append(out, p)
 	}
 	return out, nil
+}
+
+// profilesInNormalizationOrder preserves the selected profile order used by
+// chart/app composition while deriving the separate precedence used for sample
+// normalization.
+func profilesInNormalizationOrder(profiles []promprofiles.Profile, config ProfilesConfig) []promprofiles.Profile {
+	if len(profiles) < 2 || config.effectiveMode() == profilesModeExact {
+		return profiles
+	}
+
+	remaining := make(map[string]promprofiles.Profile, len(profiles))
+	for _, profile := range profiles {
+		remaining[promprofiles.NormalizeProfileKey(profile.Name)] = profile
+	}
+
+	ordered := make([]promprofiles.Profile, 0, len(profiles))
+	if config.effectiveMode() == profilesModeCombined {
+		for _, name := range entryNames(config.ModeCombined) {
+			key := promprofiles.NormalizeProfileKey(name)
+			if profile, ok := remaining[key]; ok {
+				ordered = append(ordered, profile)
+				delete(remaining, key)
+			}
+		}
+	}
+
+	rest := make([]promprofiles.Profile, 0, len(remaining))
+	for _, profile := range remaining {
+		rest = append(rest, profile)
+	}
+	sort.Slice(rest, func(i, j int) bool {
+		return promprofiles.NormalizeProfileKey(rest[i].Name) < promprofiles.NormalizeProfileKey(rest[j].Name)
+	})
+	return append(ordered, rest...)
 }
 
 // profileMatchesFamilies reports whether the profile's match pattern hits at

--- a/src/go/plugin/go.d/collector/prometheus/runtime.go
+++ b/src/go/plugin/go.d/collector/prometheus/runtime.go
@@ -10,6 +10,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/matcher"
 	"github.com/netdata/netdata/go/plugins/pkg/prometheus"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 )
 
 // promRuntime is the per-job state built once at Check and reused afterwards:
@@ -17,31 +18,37 @@ import (
 // (autogen, or autogen merged with the selected profiles' curated groups).
 type promRuntime struct {
 	profiles      []promprofiles.Profile
+	normalizers   []profileNormalizer
 	chartTemplate string
 }
 
-// ensureChartTemplate selects the profiles that apply to this job against the
-// scraped families and builds the per-job chart template, caching both on the
-// runtime on the first Check. Later cycles reuse it; Cleanup (job restart)
-// clears it so the next Check rebuilds. Building at Check (not Init) is what
-// lets selection depend on what the endpoint actually exposes.
-func (c *Collector) ensureChartTemplate(mfs prometheus.MetricFamilies) error {
-	if c.runtime != nil {
-		return nil
-	}
+type profileNormalizer struct {
+	name     string
+	root     matcher.Matcher
+	pipeline *relabel.Pipeline
+}
 
-	profiles, err := c.selectProfiles(mfs)
-	if err != nil {
-		return err
+func compileProfileNormalizers(profiles []promprofiles.Profile) ([]profileNormalizer, error) {
+	var normalizers []profileNormalizer
+	for _, profile := range profiles {
+		if !profile.HasRelabeling() {
+			continue
+		}
+		blocks, err := profile.Relabeling()
+		if err != nil {
+			return nil, err
+		}
+		pipeline, err := relabel.NewPipeline(blocks)
+		if err != nil {
+			return nil, fmt.Errorf("profile %q: compile relabeling: %w", profile.Name, err)
+		}
+		root, err := matcher.NewSimplePatternsMatcher(profile.Match)
+		if err != nil {
+			return nil, fmt.Errorf("profile %q: invalid match %q: %w", profile.Name, profile.Match, err)
+		}
+		normalizers = append(normalizers, profileNormalizer{name: profile.Name, root: root, pipeline: pipeline})
 	}
-
-	tmpl, err := buildMergedChartTemplate(c.resolveApp(profiles), profiles)
-	if err != nil {
-		return err
-	}
-
-	c.runtime = &promRuntime{profiles: profiles, chartTemplate: tmpl}
-	return nil
+	return normalizers, nil
 }
 
 // resolveApp is the chart-context "app" segment — the per-job identity the UI

--- a/src/go/plugin/go.d/collector/prometheus/runtime_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/runtime_test.go
@@ -219,6 +219,49 @@ func Test_combinedSelectProfiles(t *testing.T) {
 	}
 }
 
+func Test_profilesInNormalizationOrder(t *testing.T) {
+	profiles := func(names ...string) []promprofiles.Profile {
+		out := make([]promprofiles.Profile, len(names))
+		for i, name := range names {
+			out[i] = promprofiles.Profile{Name: name}
+		}
+		return out
+	}
+
+	tests := map[string]struct {
+		profiles []promprofiles.Profile
+		config   ProfilesConfig
+		want     []string
+	}{
+		"auto sorts by normalized profile name": {
+			profiles: profiles("zeta", "alpha", "beta"),
+			config:   ProfilesConfig{Mode: profilesModeAuto},
+			want:     []string{"alpha", "beta", "zeta"},
+		},
+		"exact preserves configured selection order": {
+			profiles: profiles("zeta", "alpha", "beta"),
+			config: ProfilesConfig{Mode: profilesModeExact, ModeExact: &ProfilesModeConfig{
+				Entries: profileEntries("zeta", "alpha", "beta"),
+			}},
+			want: []string{"zeta", "alpha", "beta"},
+		},
+		"combined puts entries first and sorts the auto remainder": {
+			profiles: profiles("beta", "alpha", "zeta", "gamma"),
+			config: ProfilesConfig{Mode: profilesModeCombined, ModeCombined: &ProfilesModeConfig{
+				Entries: profileEntries("zeta", "alpha"),
+			}},
+			want: []string{"zeta", "alpha", "beta", "gamma"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := profilesInNormalizationOrder(tc.profiles, tc.config)
+			assert.Equal(t, tc.want, profileNames(got))
+		})
+	}
+}
+
 // testMetricFamilies builds a MetricFamilies whose only meaningful content is the
 // set of family names (selection matches on the keys).
 func testMetricFamilies(names ...string) prometheus.MetricFamilies {

--- a/src/go/plugin/go.d/collector/prometheus/runtime_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/runtime_test.go
@@ -288,13 +288,22 @@ func profileNames(profiles []promprofiles.Profile) []string {
 // stock catalog.
 func loadTestCatalog(t *testing.T, profiles map[string]string) promprofiles.Catalog {
 	t.Helper()
+	return loadTestCatalogFromOrderedDirs(t, profiles)
+}
 
-	dir := t.TempDir()
-	for name, data := range profiles {
-		require.NoError(t, os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(data), 0o600))
+func loadTestCatalogFromOrderedDirs(t *testing.T, profileSets ...map[string]string) promprofiles.Catalog {
+	t.Helper()
+
+	var specs []promprofiles.DirSpec
+	for _, profiles := range profileSets {
+		dir := t.TempDir()
+		for name, data := range profiles {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(data), 0o600))
+		}
+		specs = append(specs, promprofiles.DirSpec{Path: dir, IsStock: true})
 	}
 
-	catalog, err := promprofiles.LoadFromDirs([]promprofiles.DirSpec{{Path: dir, IsStock: true}})
+	catalog, err := promprofiles.LoadFromDirs(specs)
 	require.NoError(t, err)
 	return catalog
 }

--- a/src/go/plugin/go.d/collector/prometheus/writer.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer.go
@@ -133,13 +133,13 @@ func (w *metricFamilyWriter) countWritableWithFallback(mfs prompkg.MetricFamilie
 			continue
 		}
 
-		schema, ok := deriveMetricFamilySchema(mf, typ)
+		schema, ok := deriveMetricFamilySchema(mf, typ, allowFallback)
 		if !ok {
 			continue
 		}
 
 		for _, metric := range mf.Metrics() {
-			if metricIsWritable(metric, typ, schema) {
+			if metricIsWritable(metric, typ, schema, allowFallback) {
 				count++
 			}
 		}
@@ -170,7 +170,7 @@ func (w *metricFamilyWriter) writeMetricFamiliesWithFallback(mfs prompkg.MetricF
 			continue
 		}
 
-		handle, ok := w.ensureHandle(mf, typ)
+		handle, ok := w.ensureHandle(mf, typ, allowFallback)
 		if !ok {
 			continue
 		}
@@ -181,7 +181,7 @@ func (w *metricFamilyWriter) writeMetricFamiliesWithFallback(mfs prompkg.MetricF
 		// re-adopt the new schema after metrix evicts the descriptor. Partial drift (some canonical
 		// series still write) does refresh, keeping the live family.
 		for _, metric := range mf.Metrics() {
-			if w.observeMetric(handle, metric) {
+			if w.observeMetric(handle, metric, allowFallback) {
 				written++
 				handle.staged = true
 			}
@@ -280,7 +280,11 @@ func (w *metricFamilyWriter) resolveType(name string, declared commonmodel.Metri
 	}
 }
 
-func (w *metricFamilyWriter) ensureHandle(mf *prompkg.MetricFamily, typ commonmodel.MetricType) (*metricFamilyHandle, bool) {
+func (w *metricFamilyWriter) ensureHandle(
+	mf *prompkg.MetricFamily,
+	typ commonmodel.MetricType,
+	allowFallback bool,
+) (*metricFamilyHandle, bool) {
 	if handle, ok := w.handles[mf.Name()]; ok {
 		if handle.typ != typ {
 			w.Debugf("skip metric family '%s': metric type drift (%s -> %s)", mf.Name(), handle.typ, typ)
@@ -289,7 +293,7 @@ func (w *metricFamilyWriter) ensureHandle(mf *prompkg.MetricFamily, typ commonmo
 		return handle, true
 	}
 
-	schema, ok := deriveMetricFamilySchema(mf, typ)
+	schema, ok := deriveMetricFamilySchema(mf, typ, allowFallback)
 	if !ok {
 		return nil, false
 	}
@@ -327,8 +331,8 @@ func (w *metricFamilyWriter) ensureHandle(mf *prompkg.MetricFamily, typ commonmo
 	return handle, true
 }
 
-func (w *metricFamilyWriter) observeMetric(handle *metricFamilyHandle, metric prompkg.Metric) bool {
-	schema, ok := deriveMetricSchema(metric, handle.typ)
+func (w *metricFamilyWriter) observeMetric(handle *metricFamilyHandle, metric prompkg.Metric, allowFallback bool) bool {
+	schema, ok := deriveMetricSchema(metric, handle.typ, allowFallback)
 	if !ok {
 		return false
 	}
@@ -341,7 +345,7 @@ func (w *metricFamilyWriter) observeMetric(handle *metricFamilyHandle, metric pr
 
 	switch handle.typ {
 	case commonmodel.MetricTypeGauge:
-		value, ok := metricScalarValue(metric, commonmodel.MetricTypeGauge)
+		value, ok := metricScalarValue(metric, commonmodel.MetricTypeGauge, allowFallback)
 		if !ok {
 			return false
 		}
@@ -351,7 +355,7 @@ func (w *metricFamilyWriter) observeMetric(handle *metricFamilyHandle, metric pr
 		inst.Observe(value)
 		return true
 	case commonmodel.MetricTypeCounter:
-		value, ok := metricScalarValue(metric, commonmodel.MetricTypeCounter)
+		value, ok := metricScalarValue(metric, commonmodel.MetricTypeCounter, allowFallback)
 		if !ok {
 			return false
 		}

--- a/src/go/plugin/go.d/collector/prometheus/writer.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer.go
@@ -114,13 +114,21 @@ func newMetricFamilyWriter(store metrix.CollectorStore, policy metricFamilyWrite
 // countWritable reports how many series across all families could be written. Used at Check to
 // confirm the endpoint exposes usable metrics, before any cycle has run.
 func (w *metricFamilyWriter) countWritable(mfs prompkg.MetricFamilies) int {
+	return w.countWritableWithFallback(mfs, true)
+}
+
+func (w *metricFamilyWriter) countBoundWritable(mfs prompkg.MetricFamilies) int {
+	return w.countWritableWithFallback(mfs, false)
+}
+
+func (w *metricFamilyWriter) countWritableWithFallback(mfs prompkg.MetricFamilies, allowFallback bool) int {
 	count := 0
 	for _, mf := range mfs {
 		if w.skipMetricFamily(mf) {
 			continue
 		}
 
-		typ, ok := w.resolveFamilyType(mf)
+		typ, ok := w.resolveFamilyType(mf, allowFallback)
 		if !ok {
 			continue
 		}
@@ -140,6 +148,14 @@ func (w *metricFamilyWriter) countWritable(mfs prompkg.MetricFamilies) int {
 }
 
 func (w *metricFamilyWriter) writeMetricFamilies(mfs prompkg.MetricFamilies) int {
+	return w.writeMetricFamiliesWithFallback(mfs, true)
+}
+
+func (w *metricFamilyWriter) writeBoundMetricFamilies(mfs prompkg.MetricFamilies) int {
+	return w.writeMetricFamiliesWithFallback(mfs, false)
+}
+
+func (w *metricFamilyWriter) writeMetricFamiliesWithFallback(mfs prompkg.MetricFamilies, allowFallback bool) int {
 	w.cycle++
 	w.reconcileHandles()
 
@@ -149,7 +165,7 @@ func (w *metricFamilyWriter) writeMetricFamilies(mfs prompkg.MetricFamilies) int
 			continue
 		}
 
-		typ, ok := w.resolveFamilyType(mf)
+		typ, ok := w.resolveFamilyType(mf, allowFallback)
 		if !ok {
 			continue
 		}
@@ -228,18 +244,34 @@ func (w *metricFamilyWriter) skipMetricFamily(mf *prompkg.MetricFamily) bool {
 	return false
 }
 
-func (w *metricFamilyWriter) resolveFamilyType(mf *prompkg.MetricFamily) (commonmodel.MetricType, bool) {
-	switch mf.Type() {
+func (w *metricFamilyWriter) bindFallbackTypes(batch *prompkg.SampleBatch) {
+	for i := range batch.Samples {
+		sample := &batch.Samples[i]
+		if typ, ok := w.resolveType(sample.Name, sample.FamilyType, true); ok {
+			sample.FamilyType = typ
+		}
+	}
+}
+
+func (w *metricFamilyWriter) resolveFamilyType(mf *prompkg.MetricFamily, allowFallback bool) (commonmodel.MetricType, bool) {
+	return w.resolveType(mf.Name(), mf.Type(), allowFallback)
+}
+
+func (w *metricFamilyWriter) resolveType(name string, declared commonmodel.MetricType, allowFallback bool) (commonmodel.MetricType, bool) {
+	switch declared {
 	case commonmodel.MetricTypeGauge,
 		commonmodel.MetricTypeCounter,
 		commonmodel.MetricTypeSummary,
 		commonmodel.MetricTypeHistogram:
-		return mf.Type(), true
+		return declared, true
 	case commonmodel.MetricTypeUnknown:
-		if w.policy.isFallbackTypeGauge.MatchString(mf.Name()) {
+		if !allowFallback {
+			return "", false
+		}
+		if w.policy.isFallbackTypeGauge.MatchString(name) {
 			return commonmodel.MetricTypeGauge, true
 		}
-		if w.policy.isFallbackTypeCounter.MatchString(mf.Name()) || strings.HasSuffix(mf.Name(), "_total") {
+		if w.policy.isFallbackTypeCounter.MatchString(name) || strings.HasSuffix(name, "_total") {
 			return commonmodel.MetricTypeCounter, true
 		}
 		return "", false

--- a/src/go/plugin/go.d/collector/prometheus/writer_schema.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_schema.go
@@ -21,9 +21,13 @@ type metricFamilySchema struct {
 	histogramBounds  []float64
 }
 
-func deriveMetricFamilySchema(mf *prompkg.MetricFamily, typ commonmodel.MetricType) (metricFamilySchema, bool) {
+func deriveMetricFamilySchema(
+	mf *prompkg.MetricFamily,
+	typ commonmodel.MetricType,
+	allowUntypedFallback bool,
+) (metricFamilySchema, bool) {
 	for _, metric := range mf.Metrics() {
-		schema, ok := deriveMetricSchema(metric, typ)
+		schema, ok := deriveMetricSchema(metric, typ, allowUntypedFallback)
 		if ok {
 			return schema, true
 		}
@@ -32,16 +36,20 @@ func deriveMetricFamilySchema(mf *prompkg.MetricFamily, typ commonmodel.MetricTy
 	return metricFamilySchema{}, false
 }
 
-func deriveMetricSchema(metric prompkg.Metric, typ commonmodel.MetricType) (metricFamilySchema, bool) {
+func deriveMetricSchema(
+	metric prompkg.Metric,
+	typ commonmodel.MetricType,
+	allowUntypedFallback bool,
+) (metricFamilySchema, bool) {
 	var schema metricFamilySchema
 
 	switch typ {
 	case commonmodel.MetricTypeGauge:
-		if _, ok := metricScalarValue(metric, commonmodel.MetricTypeGauge); !ok {
+		if _, ok := metricScalarValue(metric, commonmodel.MetricTypeGauge, allowUntypedFallback); !ok {
 			return metricFamilySchema{}, false
 		}
 	case commonmodel.MetricTypeCounter:
-		if _, ok := metricScalarValue(metric, commonmodel.MetricTypeCounter); !ok {
+		if _, ok := metricScalarValue(metric, commonmodel.MetricTypeCounter, allowUntypedFallback); !ok {
 			return metricFamilySchema{}, false
 		}
 	case commonmodel.MetricTypeSummary:
@@ -80,8 +88,13 @@ func deriveMetricSchema(metric prompkg.Metric, typ commonmodel.MetricType) (metr
 // metricIsWritable reports whether a series can be written under the family's canonical schema.
 // Only the distribution schema must match (metrix keys hist/summary schema by metric name); label
 // keys may differ between series and are written per-series.
-func metricIsWritable(metric prompkg.Metric, typ commonmodel.MetricType, schema metricFamilySchema) bool {
-	metricSchema, ok := deriveMetricSchema(metric, typ)
+func metricIsWritable(
+	metric prompkg.Metric,
+	typ commonmodel.MetricType,
+	schema metricFamilySchema,
+	allowUntypedFallback bool,
+) bool {
+	metricSchema, ok := deriveMetricSchema(metric, typ, allowUntypedFallback)
 	if !ok {
 		return false
 	}
@@ -89,7 +102,7 @@ func metricIsWritable(metric prompkg.Metric, typ commonmodel.MetricType, schema 
 		slices.Equal(schema.histogramBounds, metricSchema.histogramBounds)
 }
 
-func metricScalarValue(metric prompkg.Metric, typ commonmodel.MetricType) (float64, bool) {
+func metricScalarValue(metric prompkg.Metric, typ commonmodel.MetricType, allowUntypedFallback bool) (float64, bool) {
 	switch typ {
 	case commonmodel.MetricTypeGauge:
 		if gauge := metric.Gauge(); gauge != nil && isFinite(gauge.Value()) {
@@ -101,9 +114,12 @@ func metricScalarValue(metric prompkg.Metric, typ commonmodel.MetricType) (float
 		}
 	}
 
-	// Untyped fallthrough: a family resolved to gauge/counter via fallback_type carries its value in
-	// Untyped() (a real typed gauge/counter already returned from the switch). This is the only way a
-	// gauge/counter-typed family reaches here.
+	// Ordinary family-level fallback resolves after assembly, so its value remains in Untyped(). The
+	// profile-normalized path binds eligible samples before relabeling; bound mode must reject an
+	// ineligible untyped sample merged into the same final family as a bound gauge/counter sample.
+	if !allowUntypedFallback {
+		return 0, false
+	}
 	if untyped := metric.Untyped(); untyped != nil && isFinite(untyped.Value()) {
 		return untyped.Value(), true
 	}


### PR DESCRIPTION
##### Summary

Needed for #23330.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds profile-owned metric relabeling to the `go.d/prometheus` collector. Profiles can now ship normalization rules that run automatically after profile selection and before chart templating, reducing job-level config and making exporter normalization reusable.

- **New Features**
  - Profile-level `relabeling` at the profile root; auto-applied to matched families after selection, before templates; same rule format as job `relabeling`.
  - Unified relabel pipeline (`relabel.Block` + `Pipeline`) shared by job and profile relabeling with upfront validation; validation removed from the hot path.
  - Runtime builds ordered profile “normalizers” and runs a single normalized scrape/assemble path; profile dispatch remains linear with bounded matcher work.
  - Writer adds bound-type write/count paths to keep histogram/summary typing intact after profile normalization while preserving untyped fallback eligibility where appropriate.
  - Docs updated (profile format and relabel guide) to explain job vs profile relabeling order and scope; clarified `expected_prefix` (checked post-job, pre-profile) and `max_time_series` (enforced after job and profile relabeling).

- **Refactors**
  - Replaced custom `RelabelBlock` with centralized `relabel.Block`; collector stores a job-level `Pipeline`; profile pipelines hydrated lazily.
  - Streamlined profile relabel execution and normalized scrape path; typed-family binding preserved when writing.
  - Profile loader preserves YAML anchors; stock profiles hydrate lazily, user overrides eagerly; tests cover precedence boundaries, autogen scope, YAML anchors, and normalization order.

<sup>Written for commit 7e0081e461d4bdf3ec0d7dc85f44f5a8b8ade8e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

