### PR TITLE
fix(installer): add dev-libs/protobuf to Gentoo dependency check

### DIFF
--- a/packaging/installer/dependencies/gentoo.sh
+++ b/packaging/installer/dependencies/gentoo.sh
@@ -16,6 +16,7 @@ package_tree="
   dev-libs/libuv
   dev-libs/libyaml
   dev-libs/openssl
+  dev-libs/protobuf
   dev-util/cmake
   dev-vcs/git
   net-libs/libmnl


### PR DESCRIPTION
Fixes #23398

The Gentoo dependency list used by the installer/updater was missing `dev-libs/protobuf`, so on Gentoo systems the netdata updater fails with a missing google-protobuf error until the package is installed manually.

Adding it to `packaging/installer/dependencies/gentoo.sh` makes the dependency check install it automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `dev-libs/protobuf` to the Gentoo installer dependency list to fix updater failures on Gentoo caused by a missing `google-protobuf`.

<sup>Written for commit dba1ea1ce5f7cbcf9d3560b5e0fb47da54c08760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

