### PR TITLE
fix(config): ignore a UTF-8 BOM at the start of config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -986,6 +986,7 @@ set(INICFG_FILES
         src/libnetdata/inicfg/inicfg_migrate.c
         src/libnetdata/inicfg/inicfg_traversal.c
         src/libnetdata/inicfg/inicfg_api.c
+        src/libnetdata/inicfg/inicfg-unittest.c
         src/libnetdata/inicfg/dyncfg.c
         src/libnetdata/inicfg/dyncfg.h
 )

--- a/src/collectors/statsd.plugin/statsd.c
+++ b/src/collectors/statsd.plugin/statsd.c
@@ -1264,6 +1264,9 @@ static int statsd_readfile(const char *filename, STATSD_APP *app, STATSD_APP_CHA
         buffer[STATSD_CONF_LINE_MAX] = '\0';
         line++;
 
+        if(line == 1)
+            remove_utf8_bom(buffer);
+
         s = trim(buffer);
         if (!s || *s == '#') {
             netdata_log_debug(D_STATSD, "STATSD: ignoring line %zu of file '%s', it is empty.", line, filename);

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -510,6 +510,7 @@ int netdata_main(int argc, char **argv) {
                             if (mcp_execute_function_access_unittest()) return 1;
                             if (eval_unittest()) return 1;
                             if (duration_unittest()) return 1;
+                            if (inicfg_unittest()) return 1;
                             if (statistical_unittest()) return 1;
                             if (utf8_sanitizer_unittest()) return 1;
                             if (health_config_unittest()) return 1;

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -645,6 +645,10 @@ int health_readfile(const char *filename, void *data __maybe_unused, bool stock_
     while((s = fgets(&buffer[append], (int)(HEALTH_CONF_MAX_LINE - append), fp)) || append) {
         int stop_appending = !s;
         line++;
+
+        if(line == 1)
+            remove_utf8_bom(buffer);
+
         s = trim(buffer);
         if(!s || *s == '#') continue;
 

--- a/src/libnetdata/inicfg/inicfg-unittest.c
+++ b/src/libnetdata/inicfg/inicfg-unittest.c
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "inicfg_internals.h"
+
+// the UTF-8 BOM, kept as its own string literal so the hex escapes cannot
+// swallow the characters that follow it when it is concatenated
+#define UTF8_BOM "\xEF\xBB\xBF"
+
+#define INICFG_UT_SECTION "unittest"
+
+typedef struct {
+    const char *description;
+    const char *content;         // the file inicfg_load() is given
+    const char *name;            // the option to look up in INICFG_UT_SECTION
+    const char *expected;        // NULL = the option must not exist
+} inicfg_test_case_t;
+
+static const inicfg_test_case_t test_cases[] = {
+    {
+        .description = "a file without a BOM parses (control)",
+        .content = "[" INICFG_UT_SECTION "]\nkey = value\n",
+        .name = "key",
+        .expected = "value",
+    },
+    {
+        .description = "a UTF-8 BOM before the first section is ignored",
+        .content = UTF8_BOM "[" INICFG_UT_SECTION "]\nkey = value\n",
+        .name = "key",
+        .expected = "value",
+    },
+    {
+        .description = "a UTF-8 BOM before a first-line comment is ignored",
+        .content = UTF8_BOM "# a comment\n[" INICFG_UT_SECTION "]\nkey = value\n",
+        .name = "key",
+        .expected = "value",
+    },
+    {
+        .description = "a UTF-8 BOM alone on the first line is ignored",
+        .content = UTF8_BOM "\n[" INICFG_UT_SECTION "]\nkey = value\n",
+        .name = "key",
+        .expected = "value",
+    },
+    {
+        .description = "a BOM sequence inside a value is preserved",
+        .content = "[" INICFG_UT_SECTION "]\nkey = " UTF8_BOM "value\n",
+        .name = "key",
+        .expected = UTF8_BOM "value",
+    },
+    {
+        .description = "a truncated BOM prefix is not stripped",
+        .content = "\xEF" "\xBB" "[" INICFG_UT_SECTION "]\nkey = value\n",
+        .name = "key",
+        .expected = NULL,
+    },
+};
+
+// writes content to a fresh temporary file; filename receives the path created
+static bool inicfg_unittest_write_file(char *filename, size_t filename_size, const char *content) {
+    const char *tmp = getenv("TMPDIR");
+    if(!tmp || !*tmp) tmp = "/tmp";
+
+    snprintfz(filename, filename_size, "%s/netdata-inicfg-unittest.XXXXXX", tmp);
+
+    int fd = mkstemp(filename);
+    if(fd == -1) {
+        fprintf(stderr, "  cannot create a temporary file at '%s'\n", filename);
+        return false;
+    }
+
+    size_t len = strlen(content);
+    ssize_t written = write(fd, content, len);
+    close(fd);
+
+    if(written != (ssize_t)len) {
+        fprintf(stderr, "  cannot write %zu bytes to '%s'\n", len, filename);
+        unlink(filename);
+        return false;
+    }
+
+    return true;
+}
+
+static int inicfg_unittest_run_case(const inicfg_test_case_t *tc) {
+    char filename[FILENAME_MAX + 1];
+
+    if(!inicfg_unittest_write_file(filename, sizeof(filename), tc->content))
+        return 1;
+
+    struct config cfg = APPCONFIG_INITIALIZER;
+    int failed = 0;
+
+    if(!inicfg_load(&cfg, filename, 1, NULL)) {
+        fprintf(stderr, "  FAILED: inicfg_load() could not read '%s'\n", filename);
+        failed = 1;
+    }
+    else {
+        int exists = inicfg_exists(&cfg, INICFG_UT_SECTION, tc->name);
+
+        if(!tc->expected) {
+            if(exists) {
+                fprintf(stderr, "  FAILED: [%s].%s should not exist\n", INICFG_UT_SECTION, tc->name);
+                failed = 1;
+            }
+        }
+        else if(!exists) {
+            fprintf(stderr, "  FAILED: [%s].%s is missing\n", INICFG_UT_SECTION, tc->name);
+            failed = 1;
+        }
+        else {
+            const char *value = inicfg_get(&cfg, INICFG_UT_SECTION, tc->name, "");
+            if(!value || strcmp(value, tc->expected) != 0) {
+                fprintf(stderr, "  FAILED: [%s].%s is '%s', expected '%s'\n",
+                        INICFG_UT_SECTION, tc->name, value ? value : "(null)", tc->expected);
+                failed = 1;
+            }
+        }
+    }
+
+    inicfg_free(&cfg);
+    unlink(filename);
+
+    return failed;
+}
+
+typedef struct {
+    const char *description;
+    const char *input;
+    const char *expected;        // what the buffer must hold afterwards
+} inicfg_bom_test_case_t;
+
+static const inicfg_bom_test_case_t bom_test_cases[] = {
+    { "a BOM is removed", UTF8_BOM "text", "text" },
+    { "a string without a BOM is left alone", "text", "text" },
+    { "a BOM with nothing after it empties the string", UTF8_BOM, "" },
+    { "an empty string is left alone", "", "" },
+    { "a truncated BOM is left alone", "\xEF" "\xBB", "\xEF" "\xBB" },
+    { "a single 0xEF is left alone", "\xEF", "\xEF" },
+    { "a BOM that is not at the start is left alone", "x" UTF8_BOM, "x" UTF8_BOM },
+};
+
+// remove_utf8_bom() must edit the buffer in place and return that same buffer.
+// health_readfile() depends on this: it joins continuation lines with offsets
+// relative to the start of its buffer, so a BOM skipped by returning a shifted
+// pointer would reappear on the next line it parses.
+static int inicfg_unittest_remove_utf8_bom(void) {
+    int failed = 0;
+
+    for(size_t i = 0; i < _countof(bom_test_cases); i++) {
+        const inicfg_bom_test_case_t *tc = &bom_test_cases[i];
+        char buffer[64];
+
+        fprintf(stderr, "  %s\n", tc->description);
+        strncpyz(buffer, tc->input, sizeof(buffer) - 1);
+
+        char *result = remove_utf8_bom(buffer);
+
+        if(result != buffer) {
+            fprintf(stderr, "  FAILED: remove_utf8_bom() did not return its own buffer\n");
+            failed++;
+        }
+
+        if(strcmp(buffer, tc->expected) != 0) {
+            fprintf(stderr, "  FAILED: the buffer holds '%s', expected '%s'\n", buffer, tc->expected);
+            failed++;
+        }
+    }
+
+    return failed;
+}
+
+int inicfg_unittest(void) {
+    fprintf(stderr, "\n%s() running...\n", __FUNCTION__);
+
+    int failed = inicfg_unittest_remove_utf8_bom();
+
+    for(size_t i = 0; i < _countof(test_cases); i++) {
+        const inicfg_test_case_t *tc = &test_cases[i];
+
+        fprintf(stderr, "  %s\n", tc->description);
+        failed += inicfg_unittest_run_case(tc);
+    }
+
+    fprintf(stderr, "inicfg tests completed: %zu run, %d failed\n",
+            _countof(bom_test_cases) + _countof(test_cases), failed);
+
+    return failed;
+}

--- a/src/libnetdata/inicfg/inicfg-unittest.c
+++ b/src/libnetdata/inicfg/inicfg-unittest.c
@@ -56,7 +56,12 @@ static const inicfg_test_case_t test_cases[] = {
 
 // writes content to a fresh temporary file; filename receives the path created
 static bool inicfg_unittest_write_file(char *filename, size_t filename_size, const char *content) {
+    // TMPDIR is the POSIX spelling; TEMP and TMP are the Windows ones and are
+    // always set there, which matters because the native Windows build has no
+    // /tmp. /tmp is the last resort: POSIX guarantees it, Windows never reaches it.
     const char *tmp = getenv("TMPDIR");
+    if(!tmp || !*tmp) tmp = getenv("TEMP");
+    if(!tmp || !*tmp) tmp = getenv("TMP");
     if(!tmp || !*tmp) tmp = "/tmp";
 
     snprintfz(filename, filename_size, "%s/netdata-inicfg-unittest.XXXXXX", tmp);

--- a/src/libnetdata/inicfg/inicfg.h
+++ b/src/libnetdata/inicfg/inicfg.h
@@ -226,4 +226,6 @@ time_t inicfg_set_duration_seconds(struct config *root, const char *section, con
 
 time_t inicfg_get_duration_days_to_seconds(struct config *root, const char *section, const char *name, unsigned default_value_seconds);
 
+int inicfg_unittest(void);
+
 #endif // LIBNETDATA_INICFG_H

--- a/src/libnetdata/inicfg/inicfg_conf_file.c
+++ b/src/libnetdata/inicfg/inicfg_conf_file.c
@@ -189,6 +189,9 @@ int inicfg_load(struct config *root, char *filename, int overwrite_used, const c
         buffer[CONFIG_FILE_LINE_MAX] = '\0';
         line++;
 
+        if(line == 1)
+            remove_utf8_bom(buffer);
+
         s = trim(buffer);
         if(!s || !*s || *s == '#') {
             netdata_log_debug(D_CONFIG, "CONFIG: ignoring line %d of file '%s', it is empty.", line, filename);

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -758,6 +758,16 @@ static char *strsep_skip_consecutive_separators(char **ptr, char *s) {
     return (p);
 }
 
+// remove a leading UTF-8 BOM, in place; returns s
+// text editors on Windows prepend it when saving a config file as UTF-8
+ALWAYS_INLINE
+static char *remove_utf8_bom(char *s) {
+    if((uint8_t)s[0] == 0xEF && (uint8_t)s[1] == 0xBB && (uint8_t)s[2] == 0xBF)
+        memmove(s, &s[3], strlen(&s[3]) + 1);
+
+    return s;
+}
+
 // remove leading and trailing spaces; may return NULL
 ALWAYS_INLINE
 static char *trim(char *s) {


### PR DESCRIPTION
##### Summary
- Config files saved as UTF-8 by Windows editors start with a BOM that made the first line unparseable in all three config parsers; a shared helper now strips it, with unit tests.