### PR TITLE
fix(go.d/chartengine): resolve authored algorithms from runtime metric kinds

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -115,9 +115,14 @@ source files for evidence.
   dimension in that chart. This is also REQUIRED when differently typed series
   are deliberately aggregated into the same rendered dimension; otherwise,
   contributors to one rendered dimension MUST have the same runtime kind.
+  Chartengine does not diagnose violations at runtime, so real-path collector
+  tests MUST enforce this authoring rule.
 - Mixed counter and gauge dimensions MAY share one authored chart when they
   render as distinct dimensions; each omitted algorithm is resolved from that
   dimension's matched series kind.
+- A live metric identity MUST keep a stable runtime kind while its dimension is
+  materialized. A kind change does not redefine an existing Netdata dimension;
+  its creation-time wire algorithm remains until expiry and recreation.
 - Histogram bucket charts use range bucket values from `metrix.ReadFlatten()`
   and chartengine forces them to `heatmap`. Bucket dimensions are named by the
   bare `le` upper-bound value and ordered numerically with `+Inf` last. Do NOT

--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -105,16 +105,19 @@ source files for evidence.
   `Counter.ObserveTotal()` for source counters, and `StateSet` for fixed
   one-active-state values.
 - Metric names MUST be stable and selected by `charts.yaml`.
-- In `charts.yaml`: use `version: v1`, `context_namespace`, `instances.by_labels`,
-  `label_promotion`, and an explicit `algorithm` on every chart:
-  `incremental` for counters and `absolute` for gauges.
-- `Counter.ObserveTotal()` only records monotonic values in `metrix`; it does
-  NOT set the chart `DIMENSION` algorithm by itself. Every chart that presents
-  a counter as a rate MUST explicitly set `algorithm: incremental`, including
-  dynamically built `charttpl.Chart` values.
-- Do NOT rely on chartengine's metric-name suffix inference for generated
-  Netdata metrics. Suffix inference is only a fallback and MUST NOT be used as
-  the correctness mechanism for V2 collector charts.
+- In `charts.yaml`, use `version: v1`, `context_namespace`, `instances.by_labels`,
+  and `label_promotion` where their operator-facing behavior is needed.
+- Charts SHOULD omit `algorithm` for normal type-driven behavior. At runtime,
+  chartengine maps `metrix` counters to `incremental` dimensions and gauges or
+  other kinds to `absolute`, including dynamically built `charttpl.Chart`
+  values. Metric names and suffixes do not determine the algorithm.
+- A chart MAY set `algorithm` to intentionally override runtime kind for every
+  dimension in that chart. This is also REQUIRED when differently typed series
+  are deliberately aggregated into the same rendered dimension; otherwise,
+  contributors to one rendered dimension MUST have the same runtime kind.
+- Mixed counter and gauge dimensions MAY share one authored chart when they
+  render as distinct dimensions; each omitted algorithm is resolved from that
+  dimension's matched series kind.
 - Histogram bucket charts use range bucket values from `metrix.ReadFlatten()`
   and chartengine forces them to `heatmap`. Bucket dimensions are named by the
   bare `le` upper-bound value and ordered numerically with `+Inf` last. Do NOT

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -159,9 +159,10 @@ format's [aggregation section](../charttpl/README.md#aggregation) for semantics 
 
 ### Algorithm Resolution
 
-- An omitted authored `algorithm` remains unresolved in the immutable program and route cache.
-- After route lookup, the planner resolves the local route copy from the current `SeriesMeta.Kind`: counters use
-  `incremental`; gauges and every other or unknown kind use `absolute`.
+- An omitted authored `algorithm` remains `AlgorithmAuto` in the immutable program, route cache, and chart-level action
+  metadata.
+- After route lookup, the planner resolves the local route's dimension algorithm from the current `SeriesMeta.Kind`:
+  counters use `incremental`; gauges and every other or unknown kind use `absolute`.
 - An explicit authored `absolute` or `incremental` value overrides the runtime kind for every dimension in that chart.
 - Authored and autogen routes use the same runtime resolver. Metric-name suffixes do not determine chart algorithms.
 - Flattened structured families use their emitted scalar `Kind`. `SourceKind` and `FlattenRole` still control chart shape
@@ -169,10 +170,14 @@ format's [aggregation section](../charttpl/README.md#aggregation) for semantics 
   gauges; MeasureSet fields follow their declared semantics.
 - Different kinds may coexist in distinct rendered dimensions. Series aggregated into one rendered dimension must have
   the same kind when the chart omits `algorithm`; use an explicit chart algorithm for an intentional mixed-kind collapse.
+  Chartengine does not diagnose a violation at runtime, so authoring validation and real-path tests must enforce this rule;
+  the resulting dimension metadata is otherwise unspecified.
+- A live metric identity must keep the same kind while its dimension is materialized. Kind changes are resolved for route
+  planning, but an existing Netdata dimension keeps its creation-time wire algorithm until it expires and is recreated.
 
 Route-cache entries are immutable discovery results. Algorithm resolution happens after cache lookup, so a cached route
 cannot retain the effective algorithm from an earlier series kind. Only concrete algorithms reach accumulated dimension
-state and emitted actions.
+state and dimension actions; chart-level metadata retains the configured policy.
 
 ## Lifecycle Defaults and Policy
 

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -157,6 +157,23 @@ Authored charts can set one reducer for all their dimensions. Supported values a
 `absolute`/`incremental` chart processing. Autogen routes retain their existing sum behavior. See the chart-template
 format's [aggregation section](../charttpl/README.md#aggregation) for semantics and metric-type constraints.
 
+### Algorithm Resolution
+
+- An omitted authored `algorithm` remains unresolved in the immutable program and route cache.
+- After route lookup, the planner resolves the local route copy from the current `SeriesMeta.Kind`: counters use
+  `incremental`; gauges and every other or unknown kind use `absolute`.
+- An explicit authored `absolute` or `incremental` value overrides the runtime kind for every dimension in that chart.
+- Authored and autogen routes use the same runtime resolver. Metric-name suffixes do not determine chart algorithms.
+- Flattened structured families use their emitted scalar `Kind`. `SourceKind` and `FlattenRole` still control chart shape
+  and identity: histogram buckets/count/sum and summary count/sum are counters; summary quantiles and StateSet states are
+  gauges; MeasureSet fields follow their declared semantics.
+- Different kinds may coexist in distinct rendered dimensions. Series aggregated into one rendered dimension must have
+  the same kind when the chart omits `algorithm`; use an explicit chart algorithm for an intentional mixed-kind collapse.
+
+Route-cache entries are immutable discovery results. Algorithm resolution happens after cache lookup, so a cached route
+cannot retain the effective algorithm from an earlier series kind. Only concrete algorithms reach accumulated dimension
+state and emitted actions.
+
 ## Lifecycle Defaults and Policy
 
 Default lifecycle policy when template omits lifecycle:

--- a/src/go/plugin/framework/chartengine/algorithm.go
+++ b/src/go/plugin/framework/chartengine/algorithm.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartengine
+
+import (
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine/internal/program"
+)
+
+func resolveRuntimeAlgorithm(configured program.Algorithm, kind metrix.MetricKind) program.Algorithm {
+	if configured != program.AlgorithmAuto {
+		return configured
+	}
+	if kind == metrix.MetricKindCounter {
+		return program.AlgorithmIncremental
+	}
+	return program.AlgorithmAbsolute
+}
+
+func finalizeRouteAlgorithm(route routeBinding, kind metrix.MetricKind) routeBinding {
+	route.Algorithm = resolveRuntimeAlgorithm(route.Algorithm, kind)
+	route.Meta.Algorithm = route.Algorithm
+	return route
+}

--- a/src/go/plugin/framework/chartengine/algorithm.go
+++ b/src/go/plugin/framework/chartengine/algorithm.go
@@ -19,6 +19,5 @@ func resolveRuntimeAlgorithm(configured program.Algorithm, kind metrix.MetricKin
 
 func finalizeRouteAlgorithm(route routeBinding, kind metrix.MetricKind) routeBinding {
 	route.Algorithm = resolveRuntimeAlgorithm(route.Algorithm, kind)
-	route.Meta.Algorithm = route.Algorithm
 	return route
 }

--- a/src/go/plugin/framework/chartengine/algorithm_resolution_test.go
+++ b/src/go/plugin/framework/chartengine/algorithm_resolution_test.go
@@ -86,7 +86,11 @@ groups:
 			require.NoError(t, err)
 			dim := findOnlyCreateDimension(t, plan)
 			assert.Equal(t, tc.want, dim.Algorithm)
-			assert.Equal(t, tc.want, dim.ChartMeta.Algorithm)
+			wantPolicy := program.AlgorithmAuto
+			if tc.algorithm != "" {
+				wantPolicy = program.Algorithm(tc.algorithm)
+			}
+			assert.Equal(t, wantPolicy, dim.ChartMeta.Algorithm)
 		})
 	}
 }
@@ -169,6 +173,7 @@ groups:
 	for _, action := range plan.Actions {
 		if dim, ok := action.(CreateDimensionAction); ok {
 			got[dim.Name] = dim.Algorithm
+			assert.Equal(t, program.AlgorithmAuto, dim.ChartMeta.Algorithm)
 		}
 	}
 	assert.Equal(t, map[string]program.Algorithm{

--- a/src/go/plugin/framework/chartengine/algorithm_resolution_test.go
+++ b/src/go/plugin/framework/chartengine/algorithm_resolution_test.go
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine/internal/program"
+)
+
+func TestBuildPlanAuthoredAlgorithmResolvesFromRuntimeKind(t *testing.T) {
+	tests := map[string]struct {
+		metricName string
+		algorithm  string
+		observe    func(metrix.CollectorStore)
+		want       program.Algorithm
+	}{
+		"counter without conventional suffix defaults to incremental": {
+			metricName: "jobs_processed",
+			observe: func(store metrix.CollectorStore) {
+				store.Write().SnapshotMeter("").Counter("jobs_processed").ObserveTotal(7)
+			},
+			want: program.AlgorithmIncremental,
+		},
+		"gauge with counter-like suffix defaults to absolute": {
+			metricName: "job_execution_cpu_total",
+			observe: func(store metrix.CollectorStore) {
+				store.Write().SnapshotMeter("").Gauge("job_execution_cpu_total").Observe(0.5)
+			},
+			want: program.AlgorithmAbsolute,
+		},
+		"explicit absolute overrides counter kind": {
+			metricName: "jobs_processed",
+			algorithm:  "absolute",
+			observe: func(store metrix.CollectorStore) {
+				store.Write().SnapshotMeter("").Counter("jobs_processed").ObserveTotal(7)
+			},
+			want: program.AlgorithmAbsolute,
+		},
+		"explicit incremental overrides gauge kind": {
+			metricName: "queue_depth",
+			algorithm:  "incremental",
+			observe: func(store metrix.CollectorStore) {
+				store.Write().SnapshotMeter("").Gauge("queue_depth").Observe(3)
+			},
+			want: program.AlgorithmIncremental,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			algorithm := ""
+			if tc.algorithm != "" {
+				algorithm = "\n        algorithm: " + tc.algorithm
+			}
+			yaml := fmt.Sprintf(`
+version: v1
+groups:
+  - family: Test
+    metrics: [%s]
+    charts:
+      - title: Test metric
+        context: test_metric
+        units: value%s
+        dimensions:
+          - selector: %s
+            name: value
+`, tc.metricName, algorithm, tc.metricName)
+
+			e, err := New()
+			require.NoError(t, err)
+			require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+
+			store := metrix.NewCollectorStore()
+			cc := mustCycleController(t, store)
+			cc.BeginCycle()
+			tc.observe(store)
+			require.NoError(t, cc.CommitCycleSuccess())
+
+			plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+			require.NoError(t, err)
+			dim := findOnlyCreateDimension(t, plan)
+			assert.Equal(t, tc.want, dim.Algorithm)
+			assert.Equal(t, tc.want, dim.ChartMeta.Algorithm)
+		})
+	}
+}
+
+func TestBuildPlanAuthoredAlgorithmResolvesAfterRouteCacheLookup(t *testing.T) {
+	const template = `
+version: v1
+groups:
+  - family: Test
+    metrics: [work]
+    charts:
+      - title: Work
+        context: work
+        units: value
+        dimensions:
+          - selector: work
+            name: value
+`
+
+	e, err := New()
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML([]byte(template), 1))
+
+	gaugeStore := metrix.NewCollectorStore()
+	gaugeCC := mustCycleController(t, gaugeStore)
+	gaugeCC.BeginCycle()
+	gaugeStore.Write().SnapshotMeter("").Gauge("work").Observe(3)
+	require.NoError(t, gaugeCC.CommitCycleSuccess())
+
+	first, err := e.PreparePlan(gaugeStore.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, program.AlgorithmAbsolute, findOnlyCreateDimension(t, first.Plan()).Algorithm)
+	first.Abort()
+
+	counterStore := metrix.NewCollectorStore()
+	counterCC := mustCycleController(t, counterStore)
+	counterCC.BeginCycle()
+	counterStore.Write().SnapshotMeter("").Counter("work").ObserveTotal(7)
+	require.NoError(t, counterCC.CommitCycleSuccess())
+
+	second, err := e.PreparePlan(counterStore.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	defer second.Abort()
+	assert.Equal(t, program.AlgorithmIncremental, findOnlyCreateDimension(t, second.Plan()).Algorithm)
+	assert.Equal(t, uint64(1), e.stats().RouteCacheHits)
+}
+
+func TestBuildPlanAuthoredAlgorithmResolvesPerDimension(t *testing.T) {
+	const template = `
+version: v1
+groups:
+  - family: Test
+    metrics: [queue_depth, work_completed]
+    charts:
+      - title: Mixed kinds
+        context: mixed_kinds
+        units: value
+        dimensions:
+          - selector: queue_depth
+            name: depth
+          - selector: work_completed
+            name: completed
+`
+
+	e, err := New()
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML([]byte(template), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	meter := store.Write().SnapshotMeter("")
+	cc.BeginCycle()
+	meter.Gauge("queue_depth").Observe(3)
+	meter.Counter("work_completed").ObserveTotal(7)
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	got := make(map[string]program.Algorithm)
+	for _, action := range plan.Actions {
+		if dim, ok := action.(CreateDimensionAction); ok {
+			got[dim.Name] = dim.Algorithm
+		}
+	}
+	assert.Equal(t, map[string]program.Algorithm{
+		"depth":     program.AlgorithmAbsolute,
+		"completed": program.AlgorithmIncremental,
+	}, got)
+}
+
+func TestBuildPlanAuthoredExplicitAlgorithmControlsMixedKindAggregation(t *testing.T) {
+	const template = `
+version: v1
+groups:
+  - family: Test
+    metrics: [queue_depth, work_completed]
+    charts:
+      - title: Aggregated mixed kinds
+        context: aggregated_mixed_kinds
+        units: value
+        algorithm: absolute
+        dimensions:
+          - selector: queue_depth
+            name_from_label: dimension
+          - selector: work_completed
+            name_from_label: dimension
+`
+
+	e, err := New()
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML([]byte(template), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	meter := store.Write().SnapshotMeter("")
+	dimension := meter.LabelSet(metrix.Label{Key: "dimension", Value: "value"})
+	cc.BeginCycle()
+	meter.Gauge("queue_depth").Observe(3, dimension)
+	meter.Counter("work_completed").ObserveTotal(7, dimension)
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	dim := findOnlyCreateDimension(t, plan)
+	assert.Equal(t, program.AlgorithmAbsolute, dim.Algorithm)
+	update := findUpdateAction(plan)
+	require.NotNil(t, update)
+	require.Len(t, update.Values, 1)
+	assert.Equal(t, int64(10), update.Values[0].Int64)
+}
+
+func TestBuildPlanAuthoredAlgorithmUsesFlattenedSeriesKind(t *testing.T) {
+	const template = `
+version: v1
+groups:
+  - family: Structured
+    metrics:
+      - svc.latency_seconds_bucket
+      - svc.latency_seconds_count
+      - svc.latency_seconds_sum
+      - svc.request_seconds
+      - svc.request_seconds_count
+      - svc.request_seconds_sum
+      - svc.status
+      - svc.capacity_used
+      - svc.operations_ok
+    charts:
+      - id: histogram_bucket
+        title: Histogram bucket
+        context: histogram_bucket
+        units: observations
+        dimensions:
+          - selector: svc.latency_seconds_bucket
+            name: value
+      - id: histogram_count
+        title: Histogram count
+        context: histogram_count
+        units: observations
+        dimensions:
+          - selector: svc.latency_seconds_count
+            name: value
+      - id: histogram_sum
+        title: Histogram sum
+        context: histogram_sum
+        units: seconds
+        dimensions:
+          - selector: svc.latency_seconds_sum
+            name: value
+      - id: summary_quantile
+        title: Summary quantile
+        context: summary_quantile
+        units: seconds
+        dimensions:
+          - selector: svc.request_seconds
+            name: value
+      - id: summary_count
+        title: Summary count
+        context: summary_count
+        units: observations
+        dimensions:
+          - selector: svc.request_seconds_count
+            name: value
+      - id: summary_sum
+        title: Summary sum
+        context: summary_sum
+        units: seconds
+        dimensions:
+          - selector: svc.request_seconds_sum
+            name: value
+      - id: state_set
+        title: State set
+        context: state_set
+        units: state
+        dimensions:
+          - selector: svc.status
+            name: value
+      - id: measure_set_gauge
+        title: Measure set gauge
+        context: measure_set_gauge
+        units: bytes
+        dimensions:
+          - selector: svc.capacity_used
+            name: value
+      - id: measure_set_counter
+        title: Measure set counter
+        context: measure_set_counter
+        units: operations
+        dimensions:
+          - selector: svc.operations_ok
+            name: value
+`
+
+	e, err := New()
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML([]byte(template), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	meter := store.Write().SnapshotMeter("svc")
+	histogram := meter.Histogram("latency_seconds", metrix.WithHistogramBounds(1))
+	summary := meter.Summary("request_seconds", metrix.WithSummaryQuantiles(0.5))
+	stateSet := meter.StateSet("status", metrix.WithStateSetStates("ready", "stopped"), metrix.WithStateSetMode(metrix.ModeEnum))
+	capacity := meter.MeasureSetGauge("capacity", metrix.WithMeasureSetFields(metrix.MeasureFieldSpec{Name: "used"}))
+	operations := meter.MeasureSetCounter("operations", metrix.WithMeasureSetFields(metrix.MeasureFieldSpec{Name: "ok"}))
+
+	cc.BeginCycle()
+	histogram.ObservePoint(metrix.HistogramPoint{
+		Count:   2,
+		Sum:     1.5,
+		Buckets: []metrix.BucketPoint{{UpperBound: 1, CumulativeCount: 1}},
+	})
+	summary.ObservePoint(metrix.SummaryPoint{
+		Count:     2,
+		Sum:       1.2,
+		Quantiles: []metrix.QuantilePoint{{Quantile: 0.5, Value: 0.4}},
+	})
+	stateSet.Enable("ready")
+	capacity.ObservePoint(metrix.MeasureSetPoint{Values: []metrix.SampleValue{10}})
+	operations.ObserveTotalPoint(metrix.MeasureSetPoint{Values: []metrix.SampleValue{7}})
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	got := make(map[string]program.Algorithm)
+	for _, action := range plan.Actions {
+		if dim, ok := action.(CreateDimensionAction); ok {
+			got[dim.ChartID] = dim.Algorithm
+		}
+	}
+	assert.Equal(t, map[string]program.Algorithm{
+		"histogram_bucket":    program.AlgorithmIncremental,
+		"histogram_count":     program.AlgorithmIncremental,
+		"histogram_sum":       program.AlgorithmIncremental,
+		"summary_quantile":    program.AlgorithmAbsolute,
+		"summary_count":       program.AlgorithmIncremental,
+		"summary_sum":         program.AlgorithmIncremental,
+		"state_set":           program.AlgorithmAbsolute,
+		"measure_set_gauge":   program.AlgorithmAbsolute,
+		"measure_set_counter": program.AlgorithmIncremental,
+	}, got)
+}
+
+func findOnlyCreateDimension(t *testing.T, plan Plan) CreateDimensionAction {
+	t.Helper()
+	var got []CreateDimensionAction
+	for _, action := range plan.Actions {
+		if dim, ok := action.(CreateDimensionAction); ok {
+			got = append(got, dim)
+		}
+	}
+	require.Len(t, got, 1)
+	return got[0]
+}
+
+func TestResolveRuntimeAlgorithm(t *testing.T) {
+	tests := map[string]struct {
+		configured program.Algorithm
+		kind       metrix.MetricKind
+		want       program.Algorithm
+	}{
+		"auto counter":          {kind: metrix.MetricKindCounter, want: program.AlgorithmIncremental},
+		"auto gauge":            {kind: metrix.MetricKindGauge, want: program.AlgorithmAbsolute},
+		"auto unknown":          {kind: metrix.MetricKindUnknown, want: program.AlgorithmAbsolute},
+		"absolute counter":      {configured: program.AlgorithmAbsolute, kind: metrix.MetricKindCounter, want: program.AlgorithmAbsolute},
+		"incremental gauge":     {configured: program.AlgorithmIncremental, kind: metrix.MetricKindGauge, want: program.AlgorithmIncremental},
+		"incremental unknown":   {configured: program.AlgorithmIncremental, kind: metrix.MetricKindUnknown, want: program.AlgorithmIncremental},
+		"absolute unknown kind": {configured: program.AlgorithmAbsolute, kind: metrix.MetricKindUnknown, want: program.AlgorithmAbsolute},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveRuntimeAlgorithm(tc.configured, tc.kind))
+		})
+	}
+}

--- a/src/go/plugin/framework/chartengine/autogen.go
+++ b/src/go/plugin/framework/chartengine/autogen.go
@@ -22,7 +22,6 @@ type autogenRoute struct {
 	title             string
 	dimensionName     string
 	dimensionKeyLabel string
-	algorithm         program.Algorithm
 	units             string
 	chartType         program.ChartType
 	family            string
@@ -118,7 +117,7 @@ func (e *Engine) resolveAutogenRoute(
 			DimensionIndex:    0,
 			DimensionName:     route.dimensionName,
 			DimensionKeyLabel: route.dimensionKeyLabel,
-			Algorithm:         route.algorithm,
+			Algorithm:         program.AlgorithmAuto,
 			Hidden:            false,
 			Multiplier:        1,
 			Divisor:           1,
@@ -131,7 +130,7 @@ func (e *Engine) resolveAutogenRoute(
 				Family:    route.family,
 				Context:   getAutogenChartContext(namespace, route.contextName),
 				Units:     route.units,
-				Algorithm: route.algorithm,
+				Algorithm: program.AlgorithmAuto,
 				Type:      route.chartType,
 				Priority:  route.priority,
 			},
@@ -250,7 +249,8 @@ func applyAutogenMetricMeta(route autogenRoute, meta metrix.MetricMeta, seriesMe
 		route.priority = meta.ChartPriority
 	}
 	if unit := strings.TrimSpace(meta.Unit); unit != "" && allowAutogenUnitOverride(seriesMeta) {
-		route.units = normalizeAutogenUnitByAlgorithm(unit, route.algorithm)
+		effectiveAlgorithm := resolveRuntimeAlgorithm(program.AlgorithmAuto, seriesMeta.Kind)
+		route.units = normalizeAutogenUnitByAlgorithm(unit, effectiveAlgorithm)
 		route.chartType = chartTypeFromUnits(route.units)
 	}
 	route.float = meta.Float
@@ -339,7 +339,6 @@ func buildHistogramBucketAutogenRoute(
 		chartName:         baseName,
 		dimensionName:     upperBound,
 		dimensionKeyLabel: metrix.HistogramBucketLabel,
-		algorithm:         program.AlgorithmIncremental,
 		units:             "observations/s",
 		chartType:         program.ChartTypeHeatmap,
 		family:            getAutogenChartFamily(baseName),
@@ -395,7 +394,6 @@ func buildSummaryQuantileAutogenRoute(
 		chartName:         source.familyName,
 		dimensionName:     "quantile_" + quantile,
 		dimensionKeyLabel: metrix.SummaryQuantileLabel,
-		algorithm:         program.AlgorithmAbsolute,
 		units:             units,
 		chartType:         chartTypeFromUnits(units),
 		family:            getAutogenChartFamily(source.familyName),
@@ -446,7 +444,6 @@ func buildCounterComponentAutogenRoute(
 		chartID:         chartID,
 		chartName:       baseName,
 		dimensionName:   autogenDimensionName(chartName),
-		algorithm:       program.AlgorithmIncremental,
 		units:           units,
 		chartType:       chartTypeFromUnits(units),
 		family:          getAutogenChartFamily(baseName),
@@ -480,7 +477,6 @@ func buildStateSetAutogenRoute(
 		chartName:         source.familyName,
 		dimensionName:     state,
 		dimensionKeyLabel: source.familyName,
-		algorithm:         program.AlgorithmAbsolute,
 		units:             "state",
 		chartType:         program.ChartTypeLine,
 		family:            getAutogenChartFamily(source.familyName),
@@ -508,10 +504,8 @@ func buildMeasureSetAutogenRoute(
 	if !fitsTypeIDBudget(policy.MaxTypeIDLen, typeIDPrefix, chartID) {
 		return autogenRoute{}, false, nil
 	}
-	algorithm := program.AlgorithmAbsolute
 	units := getAutogenGaugeUnits(source.familyName)
 	if meta.Kind == metrix.MetricKindCounter {
-		algorithm = program.AlgorithmIncremental
 		units = getAutogenCounterUnits(source.familyName)
 	}
 	return autogenRoute{
@@ -519,7 +513,6 @@ func buildMeasureSetAutogenRoute(
 		chartName:         source.familyName,
 		dimensionName:     source.measureField,
 		dimensionKeyLabel: metrix.MeasureSetFieldLabel,
-		algorithm:         algorithm,
 		units:             units,
 		chartType:         chartTypeFromUnits(units),
 		family:            getAutogenChartFamily(source.familyName),
@@ -564,17 +557,14 @@ func buildScalarAutogenRoute(
 	if !fitsTypeIDBudget(policy.MaxTypeIDLen, typeIDPrefix, chartID) {
 		return autogenRoute{}, false, nil
 	}
-	algorithm := program.AlgorithmAbsolute
 	units := getAutogenGaugeUnits(metricName)
 	if meta.Kind == metrix.MetricKindCounter {
-		algorithm = program.AlgorithmIncremental
 		units = getAutogenCounterUnits(metricName)
 	}
 	return autogenRoute{
 		chartID:         chartID,
 		chartName:       metricName,
 		dimensionName:   autogenDimensionName(metricName),
-		algorithm:       algorithm,
 		units:           units,
 		chartType:       chartTypeFromUnits(units),
 		family:          getAutogenChartFamily(metricName),

--- a/src/go/plugin/framework/chartengine/autogen_test.go
+++ b/src/go/plugin/framework/chartengine/autogen_test.go
@@ -338,6 +338,11 @@ func TestResolveAutogenRouteRuleSemantics(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, test.want, ok)
 			assert.Equal(t, test.want, len(routes) > 0)
+			if test.want {
+				require.Len(t, routes, 1)
+				assert.Equal(t, program.AlgorithmAuto, routes[0].Algorithm)
+				assert.Equal(t, program.AlgorithmAuto, routes[0].Meta.Algorithm)
+			}
 		})
 	}
 }
@@ -349,10 +354,9 @@ func runTestBuildScalarAutogenRoute(t *testing.T) {
 		meta       metrix.SeriesMeta
 		wantID     string
 		wantDim    string
-		wantAlg    program.Algorithm
 		wantUnits  string
 	}{
-		"counter metric uses incremental algorithm and static dimension": {
+		"counter metric uses counter units and static dimension": {
 			metricName: "svc.requests_total",
 			labels: map[string]string{
 				"instance": "db1",
@@ -361,10 +365,9 @@ func runTestBuildScalarAutogenRoute(t *testing.T) {
 			meta:      metrix.SeriesMeta{Kind: metrix.MetricKindCounter},
 			wantID:    "svc.requests_total-instance=db1-job=mysql",
 			wantDim:   "requests_total",
-			wantAlg:   program.AlgorithmIncremental,
 			wantUnits: "events/s",
 		},
-		"gauge metric uses absolute algorithm": {
+		"gauge metric uses gauge units": {
 			metricName: "svc.temperature_celsius",
 			labels: map[string]string{
 				"instance": "db1",
@@ -372,7 +375,6 @@ func runTestBuildScalarAutogenRoute(t *testing.T) {
 			meta:      metrix.SeriesMeta{Kind: metrix.MetricKindGauge},
 			wantID:    "svc.temperature_celsius-instance=db1",
 			wantDim:   "temperature_celsius",
-			wantAlg:   program.AlgorithmAbsolute,
 			wantUnits: "celsius",
 		},
 	}
@@ -391,7 +393,6 @@ func runTestBuildScalarAutogenRoute(t *testing.T) {
 
 			assert.Equal(t, tc.wantID, route.chartID)
 			assert.Equal(t, tc.wantDim, route.dimensionName)
-			assert.Equal(t, tc.wantAlg, route.algorithm)
 			assert.Equal(t, tc.wantUnits, route.units)
 			assert.True(t, route.staticDimension)
 		})
@@ -437,7 +438,6 @@ func runTestBuildHistogramBucketAutogenRoute(t *testing.T) {
 			assert.Equal(t, tc.wantID, route.chartID)
 			assert.Equal(t, tc.wantDim, route.dimensionName)
 			assert.Equal(t, metrix.HistogramBucketLabel, route.dimensionKeyLabel)
-			assert.Equal(t, program.AlgorithmIncremental, route.algorithm)
 			assert.Equal(t, program.ChartTypeHeatmap, route.chartType)
 			assert.False(t, route.staticDimension)
 		})
@@ -452,7 +452,7 @@ func runTestBuildSummaryQuantileAutogenRoute(t *testing.T) {
 		wantDim    string
 		wantUnits  string
 	}{
-		"summary quantile excludes quantile label and keeps absolute algorithm": {
+		"summary quantile excludes quantile label": {
 			metricName: "svc.request_duration_seconds",
 			labels: map[string]string{
 				"instance": "db1",
@@ -486,7 +486,6 @@ func runTestBuildSummaryQuantileAutogenRoute(t *testing.T) {
 			assert.Equal(t, tc.wantDim, route.dimensionName)
 			assert.Equal(t, tc.wantUnits, route.units)
 			assert.Equal(t, metrix.SummaryQuantileLabel, route.dimensionKeyLabel)
-			assert.Equal(t, program.AlgorithmAbsolute, route.algorithm)
 			assert.False(t, route.staticDimension)
 		})
 	}
@@ -532,7 +531,6 @@ func runTestBuildStateSetAutogenRoute(t *testing.T) {
 			assert.Equal(t, tc.wantDim, route.dimensionName)
 			assert.Equal(t, "service_status", route.dimensionKeyLabel)
 			assert.Equal(t, "state", route.units)
-			assert.Equal(t, program.AlgorithmAbsolute, route.algorithm)
 			assert.False(t, route.staticDimension)
 		})
 	}
@@ -546,10 +544,9 @@ func runTestBuildMeasureSetAutogenRoute(t *testing.T) {
 		wantOK     bool
 		wantID     string
 		wantDim    string
-		wantAlg    program.Algorithm
 		wantUnits  string
 	}{
-		"MeasureSet gauge uses synthetic field label and absolute algorithm": {
+		"MeasureSet gauge uses synthetic field label and gauge units": {
 			metricName: "service_latency_seconds_value",
 			labels: map[string]string{
 				"instance":                  "db1",
@@ -563,10 +560,9 @@ func runTestBuildMeasureSetAutogenRoute(t *testing.T) {
 			wantOK:    true,
 			wantID:    "service_latency_seconds-instance=db1",
 			wantDim:   "value",
-			wantAlg:   program.AlgorithmAbsolute,
 			wantUnits: "seconds",
 		},
-		"MeasureSet counter uses synthetic field label and incremental algorithm": {
+		"MeasureSet counter uses synthetic field label and counter units": {
 			metricName: "svc_requests_total_ok",
 			labels: map[string]string{
 				"instance":                  "db1",
@@ -580,7 +576,6 @@ func runTestBuildMeasureSetAutogenRoute(t *testing.T) {
 			wantOK:    true,
 			wantID:    "svc_requests_total-instance=db1",
 			wantDim:   "ok",
-			wantAlg:   program.AlgorithmIncremental,
 			wantUnits: "requests/s",
 		},
 		"MeasureSet ignores unrelated matching labels and uses reserved field label": {
@@ -598,7 +593,6 @@ func runTestBuildMeasureSetAutogenRoute(t *testing.T) {
 			wantOK:    true,
 			wantID:    "svc_requests_total-instance=db1-svc_requests=total_ok",
 			wantDim:   "ok",
-			wantAlg:   program.AlgorithmIncremental,
 			wantUnits: "requests/s",
 		},
 		"MeasureSet without reserved field label does not route": {
@@ -652,7 +646,6 @@ func runTestBuildMeasureSetAutogenRoute(t *testing.T) {
 
 			assert.Equal(t, tc.wantID, route.chartID)
 			assert.Equal(t, tc.wantDim, route.dimensionName)
-			assert.Equal(t, tc.wantAlg, route.algorithm)
 			assert.Equal(t, tc.wantUnits, route.units)
 			assert.Equal(t, metrix.MeasureSetFieldLabel, route.dimensionKeyLabel)
 			assert.False(t, route.staticDimension)

--- a/src/go/plugin/framework/chartengine/compiler.go
+++ b/src/go/plugin/framework/chartengine/compiler.go
@@ -97,7 +97,6 @@ func (c *compiler) compileChart(chart charttpl.Chart, scope compileScope, templa
 	selectorKeySet := make(map[string]struct{})
 	dynamicDimensionKeys := make(map[string]struct{})
 
-	metricKinds := make(map[string]bool)
 	for i := range chart.Dimensions {
 		compiledDim, err := compileDimension(chart.Dimensions[i], chart.Aggregation, scope.metrics)
 		if err != nil {
@@ -111,12 +110,9 @@ func (c *compiler) compileChart(chart charttpl.Chart, scope compileScope, templa
 		for _, key := range compiledDim.dynamicLabelKeys {
 			dynamicDimensionKeys[key] = struct{}{}
 		}
-		for _, kind := range compiledDim.metricKinds {
-			metricKinds[kind] = true
-		}
 	}
 
-	algorithm, err := resolveAlgorithm(chart.Algorithm, metricKinds)
+	algorithm, err := compileAlgorithm(chart.Algorithm)
 	if err != nil {
 		return program.Chart{}, err
 	}
@@ -191,7 +187,6 @@ type compiledDimension struct {
 	dimension        program.Dimension
 	selectorKeys     []string
 	dynamicLabelKeys []string
-	metricKinds      []string
 }
 
 func compileDimension(
@@ -235,7 +230,6 @@ func compileDimension(
 		dynamicLabelKeys = append(dynamicLabelKeys, nameFromLabel)
 	}
 
-	metricKinds := metricKindsFromNames(meta.MetricNames)
 	options := compileDimensionOptions(dim.Options)
 	aggregation, err := compileAggregation(chartAggregation)
 	if err != nil {
@@ -262,7 +256,6 @@ func compileDimension(
 		},
 		selectorKeys:     append([]string(nil), meta.ConstrainedLabelKeys...),
 		dynamicLabelKeys: normalizeUnique(dynamicLabelKeys),
-		metricKinds:      metricKinds,
 	}, nil
 }
 
@@ -307,30 +300,18 @@ func compileDimensionOptions(in *charttpl.DimensionOptions) compiledDimensionOpt
 	return out
 }
 
-func resolveAlgorithm(raw string, metricKinds map[string]bool) (program.Algorithm, error) {
+func compileAlgorithm(raw string) (program.Algorithm, error) {
 	normalized := strings.TrimSpace(raw)
-	if normalized != "" {
-		switch normalized {
-		case string(program.AlgorithmAbsolute):
-			return program.AlgorithmAbsolute, nil
-		case string(program.AlgorithmIncremental):
-			return program.AlgorithmIncremental, nil
-		default:
-			return "", fmt.Errorf("invalid algorithm %q", raw)
-		}
-	}
-
-	// Inference baseline:
-	// - counter-like selectors => incremental
-	// - gauge-like selectors => absolute
-	// - mixed inferred kinds must be explicit.
-	if metricKinds["counter_like"] && metricKinds["gauge_like"] {
-		return "", fmt.Errorf("algorithm inference is ambiguous for mixed metric kinds; set algorithm explicitly")
-	}
-	if metricKinds["counter_like"] {
+	switch normalized {
+	case "":
+		return program.AlgorithmAuto, nil
+	case string(program.AlgorithmAbsolute):
+		return program.AlgorithmAbsolute, nil
+	case string(program.AlgorithmIncremental):
 		return program.AlgorithmIncremental, nil
+	default:
+		return program.AlgorithmAuto, fmt.Errorf("invalid algorithm %q", raw)
 	}
-	return program.AlgorithmAbsolute, nil
 }
 
 func resolveChartType(raw string) (program.ChartType, error) {
@@ -389,25 +370,6 @@ func compileInstanceByLabels(instances *charttpl.Instances) ([]program.InstanceL
 		}
 	}
 	return out, nil
-}
-
-func metricKindsFromNames(names []string) []string {
-	seen := make(map[string]struct{})
-	for _, name := range names {
-		switch {
-		case strings.HasSuffix(name, "_total"):
-			seen["counter_like"] = struct{}{}
-		case strings.HasSuffix(name, "_count"):
-			seen["counter_like"] = struct{}{}
-		case strings.HasSuffix(name, "_sum"):
-			seen["counter_like"] = struct{}{}
-		case strings.HasSuffix(name, "_bucket"):
-			seen["counter_like"] = struct{}{}
-		default:
-			seen["gauge_like"] = struct{}{}
-		}
-	}
-	return mapKeysSorted(seen)
 }
 
 func supportsRuntimeInferredDimension(meta metrixselector.Meta) bool {

--- a/src/go/plugin/framework/chartengine/compiler_test.go
+++ b/src/go/plugin/framework/chartengine/compiler_test.go
@@ -277,7 +277,7 @@ func TestCompileScenarios(t *testing.T) {
 				assert.Equal(t, 9, charts[0].Lifecycle.ExpireAfterCycles)
 			},
 		},
-		"compiles nested groups with inherited metric visibility and inferred algorithm": {
+		"compiles nested groups with inherited metric visibility and deferred algorithm": {
 			rev: 42,
 			spec: charttpl.Spec{
 				Version:          charttpl.VersionV1,
@@ -318,7 +318,7 @@ func TestCompileScenarios(t *testing.T) {
 				require.Len(t, charts, 1)
 				assert.Equal(t, "Database/Throughput", charts[0].Meta.Family)
 				assert.Equal(t, "mysql.database.queries_total", charts[0].Meta.Context)
-				assert.Equal(t, program.AlgorithmIncremental, charts[0].Meta.Algorithm)
+				assert.Equal(t, program.AlgorithmAuto, charts[0].Meta.Algorithm)
 				assert.Equal(t, program.ChartTypeLine, charts[0].Meta.Type)
 				assert.True(t, charts[0].Identity.Static)
 
@@ -367,7 +367,7 @@ func TestCompileScenarios(t *testing.T) {
 				assert.Equal(t, "", charts[0].Dimensions[0].NameFromLabel)
 				assert.True(t, charts[0].Dimensions[0].InferNameFromSeriesMeta)
 				assert.True(t, charts[0].Dimensions[0].Dynamic)
-				assert.Equal(t, program.AlgorithmIncremental, charts[0].Meta.Algorithm)
+				assert.Equal(t, program.AlgorithmAuto, charts[0].Meta.Algorithm)
 			},
 		},
 		"infer stateset dimension naming from runtime series metadata": {
@@ -400,7 +400,7 @@ func TestCompileScenarios(t *testing.T) {
 				require.Len(t, charts[0].Dimensions, 1)
 				assert.Equal(t, "", charts[0].Dimensions[0].NameFromLabel)
 				assert.True(t, charts[0].Dimensions[0].InferNameFromSeriesMeta)
-				assert.Equal(t, program.AlgorithmAbsolute, charts[0].Meta.Algorithm)
+				assert.Equal(t, program.AlgorithmAuto, charts[0].Meta.Algorithm)
 			},
 		},
 		"fails runtime inference for omitted naming on non-inferable selector": {
@@ -471,7 +471,7 @@ func TestCompileScenarios(t *testing.T) {
 				assert.Equal(t, []string{"state"}, charts[0].Labels.Exclusions.DimensionKeyLabels)
 			},
 		},
-		"fails on mixed inferred metric kinds without explicit algorithm": {
+		"defers algorithm for selectors with different metric name conventions": {
 			spec: charttpl.Spec{
 				Version: charttpl.VersionV1,
 				Groups: []charttpl.Group{
@@ -495,8 +495,12 @@ func TestCompileScenarios(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
-			errLike: "algorithm inference is ambiguous",
+			assert: func(t *testing.T, p *program.Program) {
+				t.Helper()
+				charts := p.Charts()
+				require.Len(t, charts, 1)
+				assert.Equal(t, program.AlgorithmAuto, charts[0].Meta.Algorithm)
+			},
 		},
 		"treats braces as literal characters in chart id": {
 			spec: charttpl.Spec{

--- a/src/go/plugin/framework/chartengine/internal/program/chart.go
+++ b/src/go/plugin/framework/chartengine/internal/program/chart.go
@@ -11,6 +11,8 @@ import (
 type Algorithm string
 
 const (
+	// AlgorithmAuto defers the default until runtime series kind is available.
+	AlgorithmAuto Algorithm = ""
 	// AlgorithmAbsolute sends direct values.
 	AlgorithmAbsolute Algorithm = "absolute"
 	// AlgorithmIncremental sends monotonic totals (Netdata computes rates/deltas).
@@ -41,7 +43,8 @@ type Chart struct {
 	Dimensions []Dimension
 }
 
-// ChartMeta carries user-facing chart metadata after normalization/defaulting.
+// ChartMeta carries normalized chart metadata. AlgorithmAuto is valid only
+// until a route is finalized against runtime series metadata.
 type ChartMeta struct {
 	Title     string
 	Family    string
@@ -82,7 +85,9 @@ func validateChart(chart Chart) error {
 	if chart.Meta.Units == "" {
 		errs = append(errs, fmt.Errorf("units is required"))
 	}
-	if chart.Meta.Algorithm != AlgorithmAbsolute && chart.Meta.Algorithm != AlgorithmIncremental {
+	if chart.Meta.Algorithm != AlgorithmAuto &&
+		chart.Meta.Algorithm != AlgorithmAbsolute &&
+		chart.Meta.Algorithm != AlgorithmIncremental {
 		errs = append(errs, fmt.Errorf("invalid algorithm %q", chart.Meta.Algorithm))
 	}
 	switch chart.Meta.Type {

--- a/src/go/plugin/framework/chartengine/internal/program/chart.go
+++ b/src/go/plugin/framework/chartengine/internal/program/chart.go
@@ -43,8 +43,8 @@ type Chart struct {
 	Dimensions []Dimension
 }
 
-// ChartMeta carries normalized chart metadata. AlgorithmAuto is valid only
-// until a route is finalized against runtime series metadata.
+// ChartMeta carries normalized chart metadata. Algorithm records the configured
+// chart policy; AlgorithmAuto means dimensions use their runtime series kinds.
 type ChartMeta struct {
 	Title     string
 	Family    string

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -532,6 +532,7 @@ func (e *Engine) forEachPlanSeriesRoute(ctx *planBuildContext, replayLabels bool
 				}
 				continue
 			}
+			route = finalizeRouteAlgorithm(route, meta.Kind)
 			if err := ctx.accumulateRoute(ctx.index, route, identity, meta, labels, v); err != nil {
 				firstErr = err
 				return

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -485,6 +485,7 @@ func TestBuildPlanLegacySingleScenarioCases(t *testing.T) {
 		"BuildPlanAutogenUsesMetricMetadataForHistogram":               {run: runTestBuildPlanAutogenUsesMetricMetadataForHistogram},
 		"BuildPlanAutogenUsesMetricFloatMetadataForScalar":             {run: runTestBuildPlanAutogenUsesMetricFloatMetadataForScalar},
 		"BuildPlanAutogenUsesMetricMetadataForSummaryWithoutQuantiles": {run: runTestBuildPlanAutogenUsesMetricMetadataForSummaryWithoutQuantiles},
+		"BuildPlanAutogenUsesMetricMetadataForSummaryQuantile":         {run: runTestBuildPlanAutogenUsesMetricMetadataForSummaryQuantile},
 		"BuildPlanTemplatePrecedenceOverAutogen":                       {run: runTestBuildPlanTemplatePrecedenceOverAutogen},
 		"BuildPlanAutogenStrictOverflowDrop":                           {run: runTestBuildPlanAutogenStrictOverflowDrop},
 		"BuildPlanAutogenUsesFlattenMetadataForHistogramBuckets":       {run: runTestBuildPlanAutogenUsesFlattenMetadataForHistogramBuckets},
@@ -1631,6 +1632,50 @@ groups:
 	assert.Equal(t, "ms/s", sum.Meta.Units)
 }
 
+func runTestBuildPlanAutogenUsesMetricMetadataForSummaryQuantile(t *testing.T) {
+	e, err := New(WithEnginePolicy(EnginePolicy{Autogen: &AutogenPolicy{Enabled: true}}))
+	require.NoError(t, err)
+
+	require.NoError(t, e.LoadYAML([]byte(`
+version: v1
+groups:
+  - family: Service
+`), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	s := store.Write().SnapshotMeter("svc").Summary(
+		"query_duration_ms",
+		metrix.WithSummaryQuantiles(0.5),
+		metrix.WithUnit("ms"),
+	)
+
+	cc.BeginCycle()
+	s.ObservePoint(metrix.SummaryPoint{
+		Count:     4,
+		Sum:       8,
+		Quantiles: []metrix.QuantilePoint{{Quantile: 0.5, Value: 1.5}},
+	})
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	quantiles := findCreateChartActionByID(plan, "svc.query_duration_ms")
+	require.NotNil(t, quantiles)
+	assert.Equal(t, "ms", quantiles.Meta.Units)
+	assert.Equal(t, program.AlgorithmAuto, quantiles.Meta.Algorithm)
+
+	for _, action := range plan.Actions {
+		dim, ok := action.(CreateDimensionAction)
+		if ok && dim.ChartID == "svc.query_duration_ms" {
+			assert.Equal(t, program.AlgorithmAbsolute, dim.Algorithm)
+			return
+		}
+	}
+	t.Fatal("summary quantile dimension was not created")
+}
+
 func runTestBuildPlanTemplatePrecedenceOverAutogen(t *testing.T) {
 	e, err := New(WithEnginePolicy(EnginePolicy{Autogen: &AutogenPolicy{Enabled: true}}))
 	require.NoError(t, err)
@@ -1904,7 +1949,7 @@ groups:
 	assert.Equal(t, "svc.queue_depth-queue=main", create.ChartID)
 	assert.Equal(t, "svc.queue_depth", create.Meta.Context)
 	assert.Equal(t, "depth", create.Meta.Units)
-	assert.Equal(t, program.AlgorithmAbsolute, create.Meta.Algorithm)
+	assert.Equal(t, program.AlgorithmAuto, create.Meta.Algorithm)
 
 	update := findUpdateAction(plan)
 	require.NotNil(t, update)

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -578,7 +578,13 @@ are named by the bare `le` value and ordered numerically, with `+Inf` last.
 > [!WARNING]
 > Different runtime kinds may share a chart when they render as distinct dimensions. If several series collapse into the
 > same rendered dimension, omit `algorithm` only when those series have the same runtime kind. Otherwise set an explicit
-> chart algorithm so the aggregated dimension has one intentional wire interpretation.
+> chart algorithm so the aggregated dimension has one intentional wire interpretation. Chartengine does not diagnose a
+> violation at runtime; authoring validation and real-path tests must reject it rather than depend on first-observed
+> metadata.
+
+The runtime kind of a live metric identity must remain stable while its dimension is materialized. Changing the kind does
+not redefine an existing Netdata dimension; its creation-time wire algorithm remains until the dimension expires and is
+recreated.
 
 **Example: MySQL queries — incremental counters displayed as rates**
 

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -24,8 +24,9 @@ Each collector has a single `charts.yaml` file that describes all its charts.
 When a collector runs, the chart engine:
 
 1. Reads the collector's `charts.yaml` file.
-2. Compiles it into an immutable program (validates, resolves defaults, infers algorithms).
-3. On each collection cycle, matches incoming metrics against dimension selectors.
+2. Compiles it into an immutable program (validates and resolves static defaults).
+3. On each collection cycle, matches incoming metrics against dimension selectors and resolves omitted algorithms from
+   runtime metric kinds.
 4. Creates chart instances dynamically based on instance identity labels.
 5. Updates dimension values every cycle; removes stale instances based on lifecycle policy.
 
@@ -40,13 +41,13 @@ When a collector runs, the chart engine:
               └──────────┬──────────┘
                          v
               ┌─────────────────────┐
-              │  Compile (engine)   │  selector parsing, algorithm inference,
+              │  Compile (engine)   │  selector parsing, static defaults,
               │                     │  context/family/ID composition
               └──────────┬──────────┘
                          v
               ┌─────────────────────┐
-              │  Runtime (per cycle)│  match series → create/update/remove
-              │                     │  charts and dimensions
+              │  Runtime (per cycle)│  match series → resolve algorithms →
+              │                     │  create/update/remove charts and dimensions
               └─────────────────────┘
 ```
 
@@ -551,7 +552,7 @@ charts:
 | `family`          | string        | no       |                        | Optional chart-level family leaf, appended to the group family.              |
 | `context`         | string        | **yes**  |                        | Chart context leaf. Combined with context namespaces.                        |
 | `units`           | string        | **yes**  |                        | Chart units (e.g., `queries/s`, `bytes`, `percentage`).                      |
-| `algorithm`       | string        | no       | inferred from metrics  | `absolute` or `incremental`. If omitted, inferred from metric suffixes.      |
+| `algorithm`       | string        | no       | runtime metric kind    | `absolute` or `incremental`. If omitted, resolved per dimension from the matched series kind. |
 | `aggregation`     | string        | no       | `sum`                  | Reducer applied to every dimension in the chart.                             |
 | `type`            | string        | no       | `line`                 | `line`, `area`, `stacked`, or `heatmap`. Histogram bucket charts are forced to `heatmap`. |
 | `priority`        | int           | no       | `70000`                | Chart ordering priority in the dashboard (`0` = use engine default `70000`). |
@@ -565,12 +566,9 @@ ID. Promoted labels are non-identity metadata. When their effective intersection
 existing chart with a complete replacement label set; it does not recreate the chart or its dimensions.
 
 > [!TIP]
-> When `algorithm` is omitted, the engine infers it from metric name suffixes. You only need to set it explicitly when the suffix doesn't match the intended behavior (e.g., a gauge metric named `*_total`).
-
-| Suffix                                    | Inferred algorithm |
-|-------------------------------------------|--------------------|
-| `*_total`, `*_count`, `*_sum`, `*_bucket` | `incremental`      |
-| Everything else                           | `absolute`         |
+> Omit `algorithm` for the normal case. The engine uses `incremental` for a matched runtime counter and `absolute` for a
+> gauge or any other kind, regardless of the metric name. Set it explicitly only when every dimension in the chart must
+> intentionally override its runtime kind.
 
 Histogram `_bucket` dimensions receive non-overlapping range bucket totals from
 `metrix.ReadFlatten()`. The `le` label remains the bucket upper bound, but the
@@ -578,7 +576,9 @@ value is no longer cumulative with earlier buckets. Histogram bucket dimensions
 are named by the bare `le` value and ordered numerically, with `+Inf` last.
 
 > [!WARNING]
-> If a chart's dimensions mix counter-like metrics (e.g., `requests_total`) with gauge-like metrics (e.g., `temperature`) and `algorithm` is omitted, the engine fails with a compile error: _"algorithm inference is ambiguous for mixed metric kinds; set algorithm explicitly"_. Set `algorithm` on the chart to resolve this.
+> Different runtime kinds may share a chart when they render as distinct dimensions. If several series collapse into the
+> same rendered dimension, omit `algorithm` only when those series have the same runtime kind. Otherwise set an explicit
+> chart algorithm so the aggregated dimension has one intentional wire interpretation.
 
 **Example: MySQL queries — incremental counters displayed as rates**
 
@@ -1119,15 +1119,16 @@ All rules below produce semantic validation errors unless noted:
 | Every autogen rule selector requires at least one non-empty valid `allow`/`deny` entry  | semantic                        |
 | Unknown YAML fields                                                                     | decode error (strict unmarshal) |
 
-## Compiler-Derived Behavior
+## Engine-Derived Behavior
 
 > [!NOTE]
-> These behaviors are applied by `chartengine` during compilation, not by the template parser. You don't need to configure them — they happen automatically, but knowing about them helps you write simpler templates.
+> These behaviors are applied by `chartengine` during compilation or runtime planning, not by the template parser. You
+> don't need to configure them, but knowing about them helps you write simpler templates.
 
 | Input                                   | Derived behavior                                                                         |
 |-----------------------------------------|------------------------------------------------------------------------------------------|
 | Missing `chart.id`                      | `id` derived from `context` (`.` replaced with `_`).                                     |
-| Missing `chart.algorithm`               | Inferred from metric suffixes (`*_total`, `*_count`, `*_sum`, `*_bucket` = incremental). |
+| Missing `chart.algorithm`               | Resolved per rendered dimension from runtime series kind: counter = `incremental`; every other kind = `absolute`. |
 | `chart.priority = 0`                    | Treated as `70000` (engine default).                                                     |
 | Group family hierarchy + `chart.family` | Composed into `/`-separated chart family.                                                |
 | `options.multiplier = 0`                | Treated as `1`.                                                                          |

--- a/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/cloudwatch/ARCHITECTURE.md
@@ -585,8 +585,9 @@ Profile validation invariants (`profile.go`) — these are load-bearing:
   dimension has no label and is excluded). Chart-instance identity is built solely
   from `by_labels`; a missing label would silently merge distinct AWS resources
   onto one chart instance.
-- Every chart must declare `algorithm: absolute` (CloudWatch aggregates are not
-  cumulative counters; this also blocks incremental suffix inference).
+- Every chart must declare `algorithm: absolute`. CloudWatch aggregates are
+  absolute per-period values, and the explicit declaration makes that profile
+  invariant reviewable and enforced independently of runtime metric metadata.
 - `template.metrics` must be empty — the collector owns the visible-series list
   and fills it at build time.
 - `rate: true` requires a `sum` or `sample_count` statistic (the per-second value

--- a/src/go/plugin/go.d/collector/prometheus/profile-format.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-format.md
@@ -358,8 +358,10 @@ dimension, presentation, and selector field. Prometheus profiles add these rules
   composed context, keeping chart identities aligned with contexts -- every stock profile relies on that. Keep every
   chart's `context` unique within the profile -- when the same measurement exists at several scopes, prefix the context
   with the scope (`process_requests`, `frontend_requests`, `backend_requests`).
-- **`algorithm` is optional.** When omitted, the engine infers it from the metric (see the Chart Template Format); the
-  examples here set it explicitly for readability.
+- **`algorithm` is optional.** When omitted, the engine uses the collected series type for each rendered dimension:
+  counters are incremental and gauges are absolute, regardless of metric name. The examples here set it explicitly for
+  readability. Use an explicit chart algorithm for an intentional type override or when differently typed series are
+  deliberately aggregated into the same rendered dimension.
 - **Dimension selectors address scraped series by their exposition names**, after `selector` filtering and relabeling.
   This is the opposite surface from the profile's `match`: a histogram dimension selector must use the suffixed name
   (`foo_bucket`), and one written with the family name (`foo`) matches nothing -- the curated chart silently never

--- a/src/go/plugin/scripts.d/collector/nagios/v2_gate_test.go
+++ b/src/go/plugin/scripts.d/collector/nagios/v2_gate_test.go
@@ -389,6 +389,36 @@ func TestV2Gate_AutogenPerfdataContextSingleNamespaced(t *testing.T) {
 	require.True(t, found, "expected an autogen create-chart action for the perfdata measureset")
 }
 
+func TestV2Gate_ExecutionCPUUsesGaugeAlgorithm(t *testing.T) {
+	engine, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, engine.LoadYAML([]byte(New().ChartTemplateYAML()), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := gateCycleController(t, store)
+	cc.BeginCycle()
+	meter := store.Write().SnapshotMeter("")
+	labels := meter.LabelSet(metrix.Label{Key: "nagios_job", Value: "check_disk"})
+	meter.Gauge("job.execution_cpu_total", metrix.WithFloat(true)).Observe(0.5, labels)
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	reader := store.Read(metrix.ReadFlatten())
+	assertSeriesKind(t, reader, "job.execution_cpu_total", metrix.Labels{"nagios_job": "check_disk"}, metrix.MetricKindGauge)
+	plan, err := prepareCommittedPlan(engine, reader)
+	require.NoError(t, err)
+
+	var found bool
+	for _, action := range plan.Actions {
+		dim, ok := action.(chartengine.CreateDimensionAction)
+		if !ok || dim.ChartMeta.Context != "nagios.job.execution_cpu" {
+			continue
+		}
+		found = true
+		assert.Equal(t, chartengine.AlgorithmAbsolute, dim.Algorithm)
+	}
+	require.True(t, found, "expected the authored execution CPU dimension")
+}
+
 func countActions[T any](actions []chartengine.EngineAction) int {
 	n := 0
 	for _, action := range actions {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chart algorithms resolve at runtime per dimension when `algorithm` is omitted, based on the matched series kind (counters → incremental; others → absolute). Chart-level policy is preserved in metadata; only dimensions carry the effective algorithm. This replaces name-suffix inference, fixes misclassified gauges (e.g., `*_total`), and keeps authored and autogen consistent.

- **Refactors**
  - Added `AlgorithmAuto` and a resolver; finalize after route-cache lookup. Chart meta keeps the configured policy; dimension actions use the effective algorithm.
  - Compiler drops metric-name inference; omitted `algorithm` compiles as `AlgorithmAuto` instead of failing on mixed name conventions.
  - Autogen routes emit `AlgorithmAuto`; units normalize using the resolved effective algorithm.
  - Structured families resolve from flattened kinds; mixed kinds are allowed across distinct dimensions. Use an explicit chart algorithm to intentionally aggregate differing kinds.
  - Docs updated to cover runtime resolution and cache semantics; `cloudwatch` profiles still require explicit `absolute`.
  - Tests cover resolver behavior, cache interaction, structured types, mixed-kind charts, and a Nagios gauge named `*_total`.

<sup>Written for commit 6c56f91312a0570c7b00b49fa3fa90b23265b1a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

