### PR TITLE
fix(go.d/prometheus): support summaries without quantiles

### DIFF
--- a/.agents/skills/project-writing-collectors/SKILL.md
+++ b/.agents/skills/project-writing-collectors/SKILL.md
@@ -388,7 +388,8 @@ The generic Prometheus scraper (`src/go/plugin/go.d/collector/prometheus/`) auto
 - metric name → chart ID + dimension ID
 - Prometheus labels → Netdata chart labels
 - type (`counter`, `gauge`, `histogram`, `summary`) → chart type and dimension algorithm
-- histograms and summaries explode into 3 charts each (buckets/quantiles, `_sum`, `_count`)
+- histograms produce bucket, `_sum`, and `_count` charts; summaries always produce `_sum` and `_count`, plus a
+  quantile chart when quantiles exist
 - recognized suffixes: `_total` (counter), `_bucket` + `le` label (histogram), `_sum`, `_count`, `quantile` label (summary), `_info` (skipped)
 - unit suffixes drive the units string: `_seconds`, `_bytes`, `_hertz`
 

--- a/src/go/pkg/prometheus/assemble.go
+++ b/src/go/pkg/prometheus/assemble.go
@@ -177,6 +177,7 @@ func (a *assembler) addSummarySum(sample Sample) {
 	mf := a.summaryFamily(name)
 	s := a.summaryFor(mf, assemblyKey{name: name, hash: sample.Labels.Hash()}, sample.Labels)
 	s.sum = sample.Value
+	s.hasSum = true
 }
 
 func (a *assembler) addSummaryCount(sample Sample) {
@@ -184,6 +185,7 @@ func (a *assembler) addSummaryCount(sample Sample) {
 	mf := a.summaryFamily(name)
 	s := a.summaryFor(mf, assemblyKey{name: name, hash: sample.Labels.Hash()}, sample.Labels)
 	s.count = sample.Value
+	s.hasCount = true
 }
 
 func (a *assembler) addHistogramBucket(sample Sample) {
@@ -243,6 +245,8 @@ func (a *assembler) summaryFor(mf *MetricFamily, key assemblyKey, lbs labels.Lab
 	} else {
 		m.summary.sum = 0
 		m.summary.count = 0
+		m.summary.hasSum = false
+		m.summary.hasCount = false
 		m.summary.quantiles = m.summary.quantiles[:0]
 	}
 

--- a/src/go/pkg/prometheus/assemble_test.go
+++ b/src/go/pkg/prometheus/assemble_test.go
@@ -12,7 +12,8 @@ import (
 // TestAssemble_roundTripMatchesScrape proves the new ScrapeSamples+Assemble seam is
 // equivalent to the direct Scrape path (parseToMetricFamilies) when no relabeling is
 // applied — the parity the collector's fast path and relabel executor rely on. It
-// exercises a gauge, a counter with multiple series, a histogram, and a summary.
+// exercises a gauge, a counter with multiple series, a histogram, and both
+// quantile-bearing and quantile-free summaries.
 func TestAssemble_roundTripMatchesScrape(t *testing.T) {
 	text := []byte(`# HELP app_req Total requests.
 # TYPE app_req counter
@@ -31,6 +32,12 @@ app_q{quantile="0.5"} 0.2
 app_q{quantile="0.9"} 0.4
 app_q_sum 1.1
 app_q_count 7
+# HELP app_payload_bytes Payload size.
+# TYPE app_payload_bytes summary
+app_payload_bytes_sum{route="/v1/items"} 12.5
+app_payload_bytes_count{route="/v1/items"} 4
+app_payload_bytes_sum{route="/v2/items"} 7.5
+app_payload_bytes_count{route="/v2/items"} 2
 # HELP app_temp Temperature.
 # TYPE app_temp gauge
 app_temp 42

--- a/src/go/pkg/prometheus/metric_family.go
+++ b/src/go/pkg/prometheus/metric_family.go
@@ -113,11 +113,10 @@ func (s Summary) Quantiles() []Quantile { return s.quantiles }
 // HasCountAndSum reports whether both required summary components were present in the assembled sample stream.
 func (s Summary) HasCountAndSum() bool { return s.hasCount && s.hasSum }
 
-// IsNaN reports whether every quantile value is NaN, which a Prometheus summary emits for an
-// empty observation window. A summary with no quantiles also reports true; this predicate does
-// not inspect the count and sum values that may still form a valid summary point.
-func (s Summary) IsNaN() bool {
-	return !slices.ContainsFunc(s.quantiles, func(q Quantile) bool { return !math.IsNaN(q.value) })
+// AllQuantilesNaN reports whether the summary has quantiles and every quantile value is NaN.
+func (s Summary) AllQuantilesNaN() bool {
+	return len(s.quantiles) > 0 &&
+		!slices.ContainsFunc(s.quantiles, func(q Quantile) bool { return !math.IsNaN(q.value) })
 }
 
 func (q Quantile) Quantile() float64 { return q.quantile }

--- a/src/go/pkg/prometheus/metric_family.go
+++ b/src/go/pkg/prometheus/metric_family.go
@@ -36,6 +36,8 @@ type (
 	Summary struct {
 		sum       float64
 		count     float64
+		hasSum    bool
+		hasCount  bool
 		quantiles []Quantile
 	}
 	Quantile struct {
@@ -108,9 +110,12 @@ func (s Summary) Count() float64        { return s.count }
 func (s Summary) Sum() float64          { return s.sum }
 func (s Summary) Quantiles() []Quantile { return s.quantiles }
 
+// HasCountAndSum reports whether both required summary components were present in the assembled sample stream.
+func (s Summary) HasCountAndSum() bool { return s.hasCount && s.hasSum }
+
 // IsNaN reports whether every quantile value is NaN, which a Prometheus summary emits for an
-// empty observation window (a summary with no quantiles also reports true). Callers skip such
-// a summary so a chart is not created until it carries a real value.
+// empty observation window. A summary with no quantiles also reports true; this predicate does
+// not inspect the count and sum values that may still form a valid summary point.
 func (s Summary) IsNaN() bool {
 	return !slices.ContainsFunc(s.quantiles, func(q Quantile) bool { return !math.IsNaN(q.value) })
 }

--- a/src/go/pkg/prometheus/metric_family_test.go
+++ b/src/go/pkg/prometheus/metric_family_test.go
@@ -350,7 +350,7 @@ func TestSummary_Quantiles(t *testing.T) {
 	)
 }
 
-func TestSummary_IsNaN(t *testing.T) {
+func TestSummary_AllQuantilesNaN(t *testing.T) {
 	tests := map[string]struct {
 		summary Summary
 		want    bool
@@ -361,7 +361,7 @@ func TestSummary_IsNaN(t *testing.T) {
 		},
 		"no quantiles": {
 			summary: Summary{},
-			want:    true,
+			want:    false,
 		},
 		"mix of NaN and real quantiles": {
 			summary: Summary{quantiles: []Quantile{{quantile: 0.5, value: math.NaN()}, {quantile: 0.9, value: 0.4}}},
@@ -375,7 +375,7 @@ func TestSummary_IsNaN(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.want, test.summary.IsNaN())
+			assert.Equal(t, test.want, test.summary.AllQuantilesNaN())
 		})
 	}
 }

--- a/src/go/pkg/prometheus/metric_family_test.go
+++ b/src/go/pkg/prometheus/metric_family_test.go
@@ -318,6 +318,31 @@ func TestSummary_Count(t *testing.T) {
 	assert.Equal(t, Summary{count: 1}.Count(), 1.0)
 }
 
+func TestSummary_HasCountAndSum(t *testing.T) {
+	tests := map[string]struct {
+		summary Summary
+		want    bool
+	}{
+		"both present": {
+			summary: Summary{hasCount: true, hasSum: true},
+			want:    true,
+		},
+		"only count present": {
+			summary: Summary{hasCount: true},
+		},
+		"only sum present": {
+			summary: Summary{hasSum: true},
+		},
+		"neither present": {},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, test.summary.HasCountAndSum())
+		})
+	}
+}
+
 func TestSummary_Quantiles(t *testing.T) {
 	assert.Equal(t,
 		Summary{quantiles: []Quantile{{quantile: 0.1, value: 1}}}.Quantiles(),

--- a/src/go/pkg/prometheus/parse_test.go
+++ b/src/go/pkg/prometheus/parse_test.go
@@ -70,6 +70,8 @@ my_summary{label1="value1",quantile="0.5"} 0.5
 							summary: &Summary{
 								sum:       10,
 								count:     2,
+								hasSum:    true,
+								hasCount:  true,
 								quantiles: []Quantile{{quantile: 0.5, value: 0.5}},
 							},
 						},
@@ -280,8 +282,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value1"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -292,8 +296,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value2"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -304,8 +310,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value3"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -316,8 +324,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value4"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -334,8 +344,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value1"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -346,8 +358,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value2"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -358,8 +372,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value3"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -370,8 +386,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value4"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -605,8 +623,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value1"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -617,8 +637,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value2"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -629,8 +651,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value3"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -641,8 +665,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value4"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -659,8 +685,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value1"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -671,8 +699,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value2"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -683,8 +713,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value3"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -695,8 +727,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value4"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -922,8 +956,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value1"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -934,8 +970,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value2"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -946,8 +984,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value3"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -958,8 +998,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value4"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -976,8 +1018,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value1"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -988,8 +1032,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value2"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -1000,8 +1046,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value3"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -1012,8 +1060,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value4"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -1227,8 +1277,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value1"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -1239,8 +1291,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value2"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -1251,8 +1305,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value3"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -1263,8 +1319,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value4"}},
 							summary: &Summary{
-								sum:   283201.29,
-								count: 31,
+								sum:      283201.29,
+								count:    31,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 4931.921},
 									{quantile: 0.9, value: 4932.921},
@@ -1281,8 +1339,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value1"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -1293,8 +1353,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value2"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -1305,8 +1367,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value3"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -1317,8 +1381,10 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 						{
 							labels: labels.Labels{{Name: "label1", Value: "value4"}},
 							summary: &Summary{
-								sum:   383201.29,
-								count: 41,
+								sum:      383201.29,
+								count:    41,
+								hasSum:   true,
+								hasCount: true,
 								quantiles: []Quantile{
 									{quantile: 0.5, value: 5931.921},
 									{quantile: 0.9, value: 5932.921},
@@ -1454,6 +1520,58 @@ DCGM_FI_DEV_GPU_UTIL{UUID="GPU-aaa",gpu="0"} 80
 					}
 				})
 			}
+		})
+	}
+}
+
+func TestPromTextParser_summaryComponentPresenceResets(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name: "both components present",
+			input: `# TYPE request_size summary
+request_size_sum 0
+request_size_count 0
+`,
+			want: true,
+		},
+		{
+			name: "count absent after both were present",
+			input: `# TYPE request_size summary
+request_size_sum 0
+`,
+		},
+		{
+			name: "both components present again",
+			input: `# TYPE request_size summary
+request_size_sum 0
+request_size_count 0
+`,
+			want: true,
+		},
+		{
+			name: "sum absent after both were present",
+			input: `# TYPE request_size summary
+request_size_count 0
+`,
+		},
+	}
+
+	var p promTextParser
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mfs, err := p.parseToMetricFamilies([]byte(test.input))
+			require.NoError(t, err)
+
+			mf := mfs.GetSummary("request_size")
+			require.NotNil(t, mf)
+			require.Len(t, mf.Metrics(), 1)
+			summary := mf.Metrics()[0].Summary()
+			require.NotNil(t, summary)
+			assert.Equal(t, test.want, summary.HasCountAndSum())
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -222,6 +222,23 @@ func TestCollector_Check(t *testing.T) {
 				return collr, srv.Close
 			},
 		},
+		"success if endpoint exposes only a summary without quantiles": {
+			wantFail: false,
+			prepare: func() (collr *Collector, cleanup func()) {
+				srv := httptest.NewServer(http.HandlerFunc(
+					func(w http.ResponseWriter, _ *http.Request) {
+						_, _ = w.Write([]byte(`
+# TYPE app_payload_bytes summary
+app_payload_bytes_sum 12.5
+app_payload_bytes_count 4
+`))
+					}))
+				collr = New()
+				collr.URL = srv.URL
+
+				return collr, srv.Close
+			},
+		},
 		"fail if the total num of metrics exceeds the limit": {
 			wantFail: true,
 			prepare: func() (collr *Collector, cleanup func()) {
@@ -390,6 +407,21 @@ test_latency_count 42
 				assert.InDelta(t, 0.5, value(t, fr, "test_latency", metrix.Labels{"quantile": "0.99"}), 1e-9)
 				assert.InDelta(t, 12.5, value(t, fr, "test_latency_sum", nil), 1e-9)
 				assert.InDelta(t, 42, value(t, fr, "test_latency_count", nil), 1e-9)
+			},
+		},
+		"summary without quantiles flattens to sum and count": {
+			prepare: New,
+			input: `
+# TYPE test_payload_bytes summary
+test_payload_bytes_sum{handler="/v1/items"} 12.5
+test_payload_bytes_count{handler="/v1/items"} 4
+`,
+			want: func(t *testing.T, fr metrix.Reader) {
+				labels := metrix.Labels{"handler": "/v1/items"}
+				assert.InDelta(t, 12.5, value(t, fr, "test_payload_bytes_sum", labels), 1e-9)
+				assert.InDelta(t, 4, value(t, fr, "test_payload_bytes_count", labels), 1e-9)
+				_, ok := fr.Value("test_payload_bytes", labels)
+				assert.False(t, ok, "a quantile-free summary must not fabricate a base quantile series")
 			},
 		},
 		"histogram flattens to buckets, sum and count": {

--- a/src/go/plugin/go.d/collector/prometheus/writer_lifecycle_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_lifecycle_test.go
@@ -127,6 +127,51 @@ func TestMetricFamilyWriterHandleLifecycle(t *testing.T) {
 		require.Equal(t, []float64{0.5, 0.9}, w.handles["app_lat"].summaryQuantiles, "the handle now carries the new quantile set")
 	})
 
+	for name, test := range map[string]struct {
+		initial       string
+		drift         string
+		wantQuantiles []float64
+	}{
+		"a quantile-free summary re-adopts quantiles after descriptor expiry": {
+			initial:       "# TYPE app_lat summary\napp_lat_sum 1\napp_lat_count 1\n",
+			drift:         "# TYPE app_lat summary\napp_lat{quantile=\"0.5\"} 1\napp_lat_sum 1\napp_lat_count 1\n",
+			wantQuantiles: []float64{0.5},
+		},
+		"a summary with quantiles re-adopts a quantile-free schema after descriptor expiry": {
+			initial: "# TYPE app_lat summary\napp_lat{quantile=\"0.5\"} 1\napp_lat_sum 1\napp_lat_count 1\n",
+			drift:   "# TYPE app_lat summary\napp_lat_sum 1\napp_lat_count 1\n",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := metrix.NewCollectorStore()
+			w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+			cc := cycle(t, store)
+			window := int(store.(metrix.DescriptorRetention).DescriptorRetentionWindow())
+
+			cc.BeginCycle()
+			require.Equal(t, 1, w.writeMetricFamilies(scrape(t, test.initial)))
+			require.NoError(t, cc.CommitCycleSuccess())
+
+			cc.BeginCycle()
+			require.Equal(t, 0, w.writeMetricFamilies(scrape(t, test.drift)),
+				"empty and non-empty quantile sets must remain distinct while the descriptor is live")
+			require.NoError(t, cc.CommitCycleSuccess())
+
+			reAdopted := false
+			for range window * 2 {
+				cc.BeginCycle()
+				if w.writeMetricFamilies(scrape(t, test.drift)) > 0 {
+					reAdopted = true
+				}
+				require.NoError(t, cc.CommitCycleSuccess())
+			}
+
+			require.True(t, reAdopted, "a fully-drifting summary must re-adopt its empty/non-empty quantile schema")
+			require.Contains(t, w.handles, "app_lat")
+			require.Equal(t, test.wantQuantiles, w.handles["app_lat"].summaryQuantiles)
+		})
+	}
+
 	t.Run("a histogram whose series all drift is not refreshed forever and re-adopts the new bounds", func(t *testing.T) {
 		store := metrix.NewCollectorStore()
 		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())

--- a/src/go/plugin/go.d/collector/prometheus/writer_schema.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_schema.go
@@ -135,7 +135,7 @@ func toSummaryPoint(summary *prompkg.Summary) (metrix.SummaryPoint, bool) {
 	// whole summary so a chart is not created until it has a real value (consistent with the
 	// scalar NaN-skip); writing resumes once any quantile is observed. A summary without
 	// configured quantiles still carries valid count and sum values, so this check does not apply.
-	if len(summary.Quantiles()) > 0 && summary.IsNaN() {
+	if summary.AllQuantilesNaN() {
 		return metrix.SummaryPoint{}, false
 	}
 	if !isFinite(summary.Count()) || !isFinite(summary.Sum()) || summary.Count() < 0 {

--- a/src/go/plugin/go.d/collector/prometheus/writer_schema.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_schema.go
@@ -128,13 +128,14 @@ func metricScalarValue(metric prompkg.Metric, typ commonmodel.MetricType, allowU
 }
 
 func toSummaryPoint(summary *prompkg.Summary) (metrix.SummaryPoint, bool) {
-	if summary == nil || len(summary.Quantiles()) == 0 {
+	if summary == nil || !summary.HasCountAndSum() {
 		return metrix.SummaryPoint{}, false
 	}
 	// A Prometheus summary leaves every quantile NaN for an empty observation window. Skip the
 	// whole summary so a chart is not created until it has a real value (consistent with the
-	// scalar NaN-skip); writing resumes once any quantile is observed.
-	if summary.IsNaN() {
+	// scalar NaN-skip); writing resumes once any quantile is observed. A summary without
+	// configured quantiles still carries valid count and sum values, so this check does not apply.
+	if len(summary.Quantiles()) > 0 && summary.IsNaN() {
 		return metrix.SummaryPoint{}, false
 	}
 	if !isFinite(summary.Count()) || !isFinite(summary.Sum()) || summary.Count() < 0 {
@@ -213,8 +214,11 @@ func toHistogramPoint(histogram *prompkg.Histogram) (metrix.HistogramPoint, bool
 }
 
 func summaryQuantiles(summary *prompkg.Summary) ([]float64, bool) {
-	if summary == nil || len(summary.Quantiles()) == 0 {
+	if summary == nil {
 		return nil, false
+	}
+	if len(summary.Quantiles()) == 0 {
+		return nil, true
 	}
 
 	qs := make([]float64, 0, len(summary.Quantiles()))

--- a/src/go/plugin/go.d/collector/prometheus/writer_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_test.go
@@ -68,14 +68,25 @@ app_latency_count 10
 # TYPE app_payload_bytes summary
 app_payload_bytes_sum{route="/v1/items"} 12.5
 app_payload_bytes_count{route="/v1/items"} 4
+app_payload_bytes_sum{route="/v2/items"} 7.5
+app_payload_bytes_count{route="/v2/items"} 2
 `,
 			assert: func(t *testing.T, fr metrix.Reader, written int) {
-				labels := metrix.Labels{"route": "/v1/items"}
-				assert.Equal(t, 1, written)
-				assert.InDelta(t, 12.5, value(t, fr, "app_payload_bytes_sum", labels), 1e-9)
-				assert.InDelta(t, 4, value(t, fr, "app_payload_bytes_count", labels), 1e-9)
-				_, ok := fr.Value("app_payload_bytes", labels)
-				assert.False(t, ok, "a quantile-free summary must not fabricate a base quantile series")
+				assert.Equal(t, 2, written)
+				for _, expected := range []struct {
+					route string
+					sum   float64
+					count float64
+				}{
+					{route: "/v1/items", sum: 12.5, count: 4},
+					{route: "/v2/items", sum: 7.5, count: 2},
+				} {
+					labels := metrix.Labels{"route": expected.route}
+					assert.InDelta(t, expected.sum, value(t, fr, "app_payload_bytes_sum", labels), 1e-9)
+					assert.InDelta(t, expected.count, value(t, fr, "app_payload_bytes_count", labels), 1e-9)
+					_, ok := fr.Value("app_payload_bytes", labels)
+					assert.False(t, ok, "a quantile-free summary must not fabricate a base quantile series")
+				}
 			},
 		},
 		"summary without quantiles writes a zero-observation point": {
@@ -109,6 +120,30 @@ app_payload_bytes_count 0
 			assert: func(t *testing.T, fr metrix.Reader, written int) {
 				assert.Equal(t, 0, written, "a missing sum must not be fabricated as zero")
 				_, ok := fr.Value("app_payload_bytes_count", nil)
+				assert.False(t, ok)
+			},
+		},
+		"summary with quantiles but without count is skipped": {
+			exposition: `
+# TYPE app_latency summary
+app_latency{quantile="0.5"} 0.25
+app_latency_sum 0.25
+`,
+			assert: func(t *testing.T, fr metrix.Reader, written int) {
+				assert.Equal(t, 0, written, "a partial summary must not fabricate count")
+				_, ok := fr.Value("app_latency", metrix.Labels{"quantile": "0.5"})
+				assert.False(t, ok)
+			},
+		},
+		"summary with quantiles but without sum is skipped": {
+			exposition: `
+# TYPE app_latency summary
+app_latency{quantile="0.5"} 0.25
+app_latency_count 1
+`,
+			assert: func(t *testing.T, fr metrix.Reader, written int) {
+				assert.Equal(t, 0, written, "a partial summary must not fabricate sum")
+				_, ok := fr.Value("app_latency", metrix.Labels{"quantile": "0.5"})
 				assert.False(t, ok)
 			},
 		},

--- a/src/go/plugin/go.d/collector/prometheus/writer_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_test.go
@@ -63,6 +63,75 @@ app_latency_count 10
 				assert.InDelta(t, 10, value(t, fr, "app_latency_count", nil), 1e-9)
 			},
 		},
+		"summary without quantiles writes sum and count": {
+			exposition: `
+# TYPE app_payload_bytes summary
+app_payload_bytes_sum{route="/v1/items"} 12.5
+app_payload_bytes_count{route="/v1/items"} 4
+`,
+			assert: func(t *testing.T, fr metrix.Reader, written int) {
+				labels := metrix.Labels{"route": "/v1/items"}
+				assert.Equal(t, 1, written)
+				assert.InDelta(t, 12.5, value(t, fr, "app_payload_bytes_sum", labels), 1e-9)
+				assert.InDelta(t, 4, value(t, fr, "app_payload_bytes_count", labels), 1e-9)
+				_, ok := fr.Value("app_payload_bytes", labels)
+				assert.False(t, ok, "a quantile-free summary must not fabricate a base quantile series")
+			},
+		},
+		"summary without quantiles writes a zero-observation point": {
+			exposition: `
+# TYPE app_payload_bytes summary
+app_payload_bytes_sum 0
+app_payload_bytes_count 0
+`,
+			assert: func(t *testing.T, fr metrix.Reader, written int) {
+				assert.Equal(t, 1, written)
+				assert.InDelta(t, 0, value(t, fr, "app_payload_bytes_sum", nil), 1e-9)
+				assert.InDelta(t, 0, value(t, fr, "app_payload_bytes_count", nil), 1e-9)
+			},
+		},
+		"summary without count is skipped": {
+			exposition: `
+# TYPE app_payload_bytes summary
+app_payload_bytes_sum 0
+`,
+			assert: func(t *testing.T, fr metrix.Reader, written int) {
+				assert.Equal(t, 0, written, "a missing count must not be fabricated as zero")
+				_, ok := fr.Value("app_payload_bytes_sum", nil)
+				assert.False(t, ok)
+			},
+		},
+		"summary without sum is skipped": {
+			exposition: `
+# TYPE app_payload_bytes summary
+app_payload_bytes_count 0
+`,
+			assert: func(t *testing.T, fr metrix.Reader, written int) {
+				assert.Equal(t, 0, written, "a missing sum must not be fabricated as zero")
+				_, ok := fr.Value("app_payload_bytes_count", nil)
+				assert.False(t, ok)
+			},
+		},
+		"summary without quantiles with negative count is skipped": {
+			exposition: `
+# TYPE app_payload_bytes summary
+app_payload_bytes_sum 0
+app_payload_bytes_count -1
+`,
+			assert: func(t *testing.T, _ metrix.Reader, written int) {
+				assert.Equal(t, 0, written)
+			},
+		},
+		"summary without quantiles with infinite sum is skipped": {
+			exposition: `
+# TYPE app_payload_bytes summary
+app_payload_bytes_sum +Inf
+app_payload_bytes_count 1
+`,
+			assert: func(t *testing.T, _ metrix.Reader, written int) {
+				assert.Equal(t, 0, written)
+			},
+		},
 		"summary with all-NaN quantiles (empty window) is skipped": {
 			exposition: `
 # TYPE app_latency summary
@@ -454,6 +523,17 @@ app_a{x="2"} 2
 app_b_info{v="x"} 1
 `)
 		assert.Equal(t, 2, w.countWritable(mfs))
+	})
+
+	t.Run("countWritable accepts a summary without quantiles", func(t *testing.T) {
+		store := metrix.NewCollectorStore()
+		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
+		mfs := scrape(t, `
+# TYPE app_payload_bytes summary
+app_payload_bytes_sum 12.5
+app_payload_bytes_count 4
+`)
+		assert.Equal(t, 1, w.countWritable(mfs))
 	})
 
 	t.Run("metric type drift skips the family after the type changes", func(t *testing.T) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support Prometheus summaries that omit quantiles. We now write only _sum and _count when both exist, and skip partial or invalid summaries. No base quantile series is created for quantile‑free summaries.

- **Bug Fixes**
  - `go/pkg/prometheus`: added `hasSum`/`hasCount` on `Summary`; assembler sets/resets them; added `HasCountAndSum()` and `AllQuantilesNaN()`.
  - `go.d` Prometheus writer: accept summaries without quantiles when `HasCountAndSum()`; skip when `AllQuantilesNaN()`; validate finite sum and non‑negative count; do not fabricate a base series; support empty/non‑empty quantile schema and re‑adopt after descriptor expiry in either direction.
  - Tests updated for parsing, assembler resets, writer schema/counting, lifecycle re‑adoption, and end‑to‑end collector checks for quantile‑free summaries.

<sup>Written for commit e058116337560ac6a340e498cc7678c5ef4a2db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

