### PR TITLE
fix(go.d/chartengine): intersect unlabeled contributors

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -222,8 +222,8 @@ source files for evidence.
   chart or dimension identity. Changing one creates a new chart or dimension;
   collectors MUST NOT use identity churn merely to refresh metadata.
 - `label_promotion` defines non-identity chart metadata. Chartengine reconciles
-  its effective intersection on existing charts and emits a complete
-  replacement only when it changes.
+  its effective intersection across every routed contributor, including an
+  empty source-label set, and emits a complete replacement only when it changes.
 - Collectors MUST continue publishing numeric samples at their required cadence.
   A label-only replacement updates chart metadata; it is not a substitute for
   numeric sample-and-hold output.

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -157,6 +157,15 @@ Authored charts can set one reducer for all their dimensions. Supported values a
 `absolute`/`incremental` chart processing. Autogen routes retain their existing sum behavior. See the chart-template
 format's [aggregation section](../charttpl/README.md#aggregation) for semantics and metric-type constraints.
 
+### Chart Label Intersection
+
+- Promoted non-identity labels are common metadata: a key/value survives only when it is present with the same value on
+  every routed contributor to the chart.
+- An unlabeled contributor participates as an empty label set. If it shares a chart with labeled contributors, no
+  promoted non-identity label can describe the entire chart.
+- A changed intersection emits a complete replacement label set through `UpdateChartLabelsAction`; chart identity and
+  dimensions are not recreated.
+
 ### Algorithm Resolution
 
 - An omitted authored `algorithm` remains `AlgorithmAuto` in the immutable program, route cache, and chart-level action

--- a/src/go/plugin/framework/chartengine/mutable_labels_test.go
+++ b/src/go/plugin/framework/chartengine/mutable_labels_test.go
@@ -71,6 +71,91 @@ func TestBuildPlanUpdatesMutableNonIdentityLabels(t *testing.T) {
 	assert.Equal(t, []ActionKind{ActionUpdateChart}, actionKinds(unchanged.Actions))
 }
 
+func TestBuildPlanIntersectsUnlabeledContributor(t *testing.T) {
+	tests := map[string]string{
+		"automatic promotion": "",
+		"explicit promotion":  "        label_promotion: [region]\n",
+	}
+
+	for name, labelPromotion := range tests {
+		t.Run(name, func(t *testing.T) {
+			engine, err := New(WithRuntimeStore(nil))
+			require.NoError(t, err)
+			require.NoError(t, engine.LoadYAML([]byte("version: v1\n"+
+				"groups:\n"+
+				"  - family: Requests\n"+
+				"    metrics: [requests_success_total, requests_failed_total]\n"+
+				"    charts:\n"+
+				"      - id: requests\n"+
+				"        title: Requests\n"+
+				"        context: requests\n"+
+				"        units: requests/s\n"+
+				labelPromotion+
+				"        dimensions:\n"+
+				"          - selector: requests_success_total\n"+
+				"            name: successful\n"+
+				"          - selector: requests_failed_total\n"+
+				"            name: failed\n"), 1))
+
+			store := metrix.NewCollectorStore()
+			cycle := mustCycleController(t, store)
+			meter := store.Write().SnapshotMeter("")
+			successful := meter.Counter("requests_success_total")
+			failed := meter.Counter("requests_failed_total")
+			regionEU := meter.LabelSet(metrix.Label{Key: "region", Value: "eu"})
+
+			cycle.BeginCycle()
+			successful.ObserveTotal(10, regionEU)
+			require.NoError(t, cycle.CommitCycleSuccess())
+
+			initial, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+			require.NoError(t, err)
+			create := findCreateChartAction(initial)
+			require.NotNil(t, create)
+			assert.Equal(t, map[string]string{"region": "eu"}, create.Labels)
+
+			cycle.BeginCycle()
+			successful.ObserveTotal(11, regionEU)
+			failed.ObserveTotal(2)
+			require.NoError(t, cycle.CommitCycleSuccess())
+
+			withUnlabeled, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+			require.NoError(t, err)
+			assert.NotContains(t, actionKinds(withUnlabeled.Actions), ActionCreateChart)
+			labelsRemoved := findUpdateChartLabelsAction(withUnlabeled)
+			require.NotNil(t, labelsRemoved)
+			assert.Empty(t, labelsRemoved.Labels)
+			update := findUpdateAction(withUnlabeled)
+			require.NotNil(t, update)
+			require.Len(t, update.Values, 2)
+			assert.Equal(t, map[string]float64{
+				"failed":     2,
+				"successful": 11,
+			}, updateValuesByName(update.Values))
+
+			cycle.BeginCycle()
+			successful.ObserveTotal(12, regionEU)
+			require.NoError(t, cycle.CommitCycleSuccess())
+
+			withoutUnlabeled, err := buildPlan(engine, store.Read(metrix.ReadFlatten()))
+			require.NoError(t, err)
+			assert.NotContains(t, actionKinds(withoutUnlabeled.Actions), ActionCreateChart)
+			assert.NotContains(t, actionKinds(withoutUnlabeled.Actions), ActionCreateDimension)
+			labelsRestored := findUpdateChartLabelsAction(withoutUnlabeled)
+			require.NotNil(t, labelsRestored)
+			assert.Equal(t, map[string]string{"region": "eu"}, labelsRestored.Labels)
+		})
+	}
+}
+
+func updateValuesByName(values []UpdateDimensionValue) map[string]float64 {
+	out := make(map[string]float64, len(values))
+	for _, value := range values {
+		out[value.Name] = value.Float64
+	}
+	return out
+}
+
 func TestBuildPlanIdentityLabelChangeCreatesNewChart(t *testing.T) {
 	engine, store, cycle, meter, gauge := newMutableLabelsTestState(t)
 

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -27,12 +27,11 @@ type chartLabelPolicy struct {
 }
 
 type chartLabelAccumulator struct {
-	policy                    *chartLabelPolicy
-	dimensionKeyExclusions    map[string]struct{}
-	instance                  map[string]string
-	selected                  map[string]string
-	initialized               bool
-	promotedIntersectionEmpty bool
+	policy                 *chartLabelPolicy
+	dimensionKeyExclusions map[string]struct{}
+	instance               map[string]string
+	selected               map[string]string
+	initialized            bool
 
 	instanceKeys      map[string]struct{}
 	resolvedScratch   []instanceLabelValue
@@ -122,7 +121,6 @@ func (a *chartLabelAccumulator) reset() {
 	a.resolvedScratch = a.resolvedScratch[:0]
 	a.includeAllScratch = a.includeAllScratch[:0]
 	a.initialized = false
-	a.promotedIntersectionEmpty = false
 }
 
 func newChartLabelTracker(previous *materializedChartPresentation) chartLabelTracker {
@@ -273,22 +271,16 @@ func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLab
 	}
 
 	if labels.Len() == 0 {
-		a.resetInstanceKeys()
 		if len(a.policy.instancePlan.explicitKeys) > 0 {
 			return nil
 		}
-		// Retain the workspace map so an empty witness stays O(1); materialization
-		// ignores it until the accumulator is reset.
-		a.promotedIntersectionEmpty = true
+		clear(a.selected)
 		a.initialized = true
 		return nil
 	}
 
 	ok := a.resolveInstanceLabelsForObserve(labels)
 	if !ok {
-		return nil
-	}
-	if a.promotedIntersectionEmpty {
 		return nil
 	}
 
@@ -434,18 +426,14 @@ func (a *chartLabelAccumulator) materialize() map[string]string {
 	if a == nil {
 		return nil
 	}
-	selected := a.selected
-	if a.promotedIntersectionEmpty {
-		selected = nil
-	}
-	out := make(map[string]string, len(a.instance)+len(selected))
+	out := make(map[string]string, len(a.instance)+len(a.selected))
 	for key, value := range a.instance {
 		if strings.TrimSpace(key) == "" {
 			continue
 		}
 		out[key] = value
 	}
-	for key, value := range selected {
+	for key, value := range a.selected {
 		if strings.TrimSpace(key) == "" {
 			continue
 		}
@@ -460,22 +448,17 @@ func (a *chartLabelAccumulator) materializedEquals(values map[string]string) boo
 		return len(values) == 0
 	}
 
-	selected := a.selected
-	if a.promotedIntersectionEmpty {
-		selected = nil
-	}
-
 	count := 0
 	for key := range a.instance {
 		if strings.TrimSpace(key) == "" || key == collectJobLabel {
 			continue
 		}
-		if _, overridden := selected[key]; overridden {
+		if _, overridden := a.selected[key]; overridden {
 			continue
 		}
 		count++
 	}
-	for key := range selected {
+	for key := range a.selected {
 		if strings.TrimSpace(key) == "" || key == collectJobLabel {
 			continue
 		}
@@ -486,7 +469,7 @@ func (a *chartLabelAccumulator) materializedEquals(values map[string]string) boo
 	}
 
 	for key, want := range values {
-		got, ok := selected[key]
+		got, ok := a.selected[key]
 		if !ok {
 			got, ok = a.instance[key]
 		}

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -27,11 +27,12 @@ type chartLabelPolicy struct {
 }
 
 type chartLabelAccumulator struct {
-	policy                 *chartLabelPolicy
-	dimensionKeyExclusions map[string]struct{}
-	instance               map[string]string
-	selected               map[string]string
-	initialized            bool
+	policy                    *chartLabelPolicy
+	dimensionKeyExclusions    map[string]struct{}
+	instance                  map[string]string
+	selected                  map[string]string
+	initialized               bool
+	promotedIntersectionEmpty bool
 
 	instanceKeys      map[string]struct{}
 	resolvedScratch   []instanceLabelValue
@@ -121,6 +122,7 @@ func (a *chartLabelAccumulator) reset() {
 	a.resolvedScratch = a.resolvedScratch[:0]
 	a.includeAllScratch = a.includeAllScratch[:0]
 	a.initialized = false
+	a.promotedIntersectionEmpty = false
 }
 
 func newChartLabelTracker(previous *materializedChartPresentation) chartLabelTracker {
@@ -270,13 +272,23 @@ func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLab
 		a.dimensionKeyExclusions[key] = struct{}{}
 	}
 
+	if labels.Len() == 0 {
+		a.resetInstanceKeys()
+		if len(a.policy.instancePlan.explicitKeys) > 0 {
+			return nil
+		}
+		// Retain the workspace map so an empty witness stays O(1); materialization
+		// ignores it until the accumulator is reset.
+		a.promotedIntersectionEmpty = true
+		a.initialized = true
+		return nil
+	}
+
 	ok := a.resolveInstanceLabelsForObserve(labels)
 	if !ok {
 		return nil
 	}
-	if labels.Len() == 0 {
-		clear(a.selected)
-		a.initialized = true
+	if a.promotedIntersectionEmpty {
 		return nil
 	}
 
@@ -422,14 +434,18 @@ func (a *chartLabelAccumulator) materialize() map[string]string {
 	if a == nil {
 		return nil
 	}
-	out := make(map[string]string, len(a.instance)+len(a.selected))
+	selected := a.selected
+	if a.promotedIntersectionEmpty {
+		selected = nil
+	}
+	out := make(map[string]string, len(a.instance)+len(selected))
 	for key, value := range a.instance {
 		if strings.TrimSpace(key) == "" {
 			continue
 		}
 		out[key] = value
 	}
-	for key, value := range a.selected {
+	for key, value := range selected {
 		if strings.TrimSpace(key) == "" {
 			continue
 		}
@@ -444,17 +460,22 @@ func (a *chartLabelAccumulator) materializedEquals(values map[string]string) boo
 		return len(values) == 0
 	}
 
+	selected := a.selected
+	if a.promotedIntersectionEmpty {
+		selected = nil
+	}
+
 	count := 0
 	for key := range a.instance {
 		if strings.TrimSpace(key) == "" || key == collectJobLabel {
 			continue
 		}
-		if _, overridden := a.selected[key]; overridden {
+		if _, overridden := selected[key]; overridden {
 			continue
 		}
 		count++
 	}
-	for key := range a.selected {
+	for key := range selected {
 		if strings.TrimSpace(key) == "" || key == collectJobLabel {
 			continue
 		}
@@ -465,7 +486,7 @@ func (a *chartLabelAccumulator) materializedEquals(values map[string]string) boo
 	}
 
 	for key, want := range values {
-		got, ok := a.selected[key]
+		got, ok := selected[key]
 		if !ok {
 			got, ok = a.instance[key]
 		}

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -262,7 +262,7 @@ func compileInstanceLabelPlan(identity program.ChartIdentity) compiledInstanceLa
 }
 
 func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLabel string) error {
-	if a == nil || labels.Len() == 0 {
+	if a == nil {
 		return nil
 	}
 
@@ -272,6 +272,11 @@ func (a *chartLabelAccumulator) observe(labels metrix.LabelView, dimensionKeyLab
 
 	ok := a.resolveInstanceLabelsForObserve(labels)
 	if !ok {
+		return nil
+	}
+	if labels.Len() == 0 {
+		clear(a.selected)
+		a.initialized = true
 		return nil
 	}
 

--- a/src/go/plugin/framework/chartengine/planner_labels_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_labels_bench_test.go
@@ -9,24 +9,28 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine/internal/program"
 )
 
-var benchmarkPromotedIntersectionEmptySink bool
+var benchmarkChartLabelAccumulatorSink *chartLabelAccumulator
 
 func BenchmarkChartLabelAccumulatorObserveEmpty(b *testing.B) {
 	tests := map[string]struct {
-		chart     program.Chart
-		populated map[string]string
+		chart            program.Chart
+		populated        map[string]string
+		wantSelected     int
+		wantInstanceKeys int
 	}{
 		"automatic_1": {
 			chart: program.Chart{
 				Labels: program.LabelPolicy{Mode: program.PromotionModeAutoIntersection},
 			},
-			populated: benchmarkLabelValues(1),
+			populated:    benchmarkLabelValues(1),
+			wantSelected: 1,
 		},
 		"automatic_64": {
 			chart: program.Chart{
 				Labels: program.LabelPolicy{Mode: program.PromotionModeAutoIntersection},
 			},
-			populated: benchmarkLabelValues(64),
+			populated:    benchmarkLabelValues(64),
+			wantSelected: 64,
 		},
 		"explicit_64": {
 			chart: program.Chart{
@@ -35,7 +39,8 @@ func BenchmarkChartLabelAccumulatorObserveEmpty(b *testing.B) {
 					PromoteKeys: benchmarkPromotedLabelKeys(64),
 				},
 			},
-			populated: benchmarkLabelValues(64),
+			populated:    benchmarkLabelValues(64),
+			wantSelected: 64,
 		},
 		"wildcard_identity": {
 			chart: program.Chart{
@@ -44,32 +49,39 @@ func BenchmarkChartLabelAccumulatorObserveEmpty(b *testing.B) {
 				},
 				Labels: program.LabelPolicy{Mode: program.PromotionModeAutoIntersection},
 			},
+			populated:        benchmarkEmptyLabelValues(64),
+			wantInstanceKeys: 64,
 		},
 	}
 	empty := sortedLabelView(nil)
 
 	for name, tc := range tests {
 		b.Run(name, func(b *testing.B) {
-			acc := newChartLabelAccumulator(compileChartLabelPolicy(tc.chart))
-			if len(tc.populated) > 0 {
-				if err := acc.observe(sortedLabelView(tc.populated), ""); err != nil {
-					b.Fatal(err)
-				}
-				if len(acc.selected) != len(tc.populated) {
-					b.Fatalf("prepopulate selected: got %d entries, want %d", len(acc.selected), len(tc.populated))
-				}
+			policy := compileChartLabelPolicy(tc.chart)
+			populated := sortedLabelView(tc.populated)
+			probe := newChartLabelAccumulator(policy)
+			if err := probe.observe(populated, ""); err != nil {
+				b.Fatal(err)
+			}
+			if len(probe.selected) != tc.wantSelected {
+				b.Fatalf("prepopulate selected: got %d entries, want %d", len(probe.selected), tc.wantSelected)
+			}
+			if len(probe.instanceKeys) != tc.wantInstanceKeys {
+				b.Fatalf("prepopulate instance keys: got %d entries, want %d", len(probe.instanceKeys), tc.wantInstanceKeys)
 			}
 
+			acc := newChartLabelAccumulator(policy)
 			b.ReportAllocs()
 			for b.Loop() {
-				// Re-arm only the semantic witness so the benchmark isolates the
-				// populated-to-empty observation without rebuilding its map.
-				acc.promotedIntersectionEmpty = false
+				acc.reset()
+				if err := acc.observe(populated, ""); err != nil {
+					b.Fatal(err)
+				}
 				if err := acc.observe(empty, ""); err != nil {
 					b.Fatal(err)
 				}
 			}
-			benchmarkPromotedIntersectionEmptySink = acc.promotedIntersectionEmpty
+			benchmarkChartLabelAccumulatorSink = acc
 		})
 	}
 }
@@ -86,6 +98,14 @@ func benchmarkLabelValues(count int) map[string]string {
 	labels := make(map[string]string, count)
 	for i := range count {
 		labels[fmt.Sprintf("label_%02d", i)] = fmt.Sprintf("value_%02d", i)
+	}
+	return labels
+}
+
+func benchmarkEmptyLabelValues(count int) map[string]string {
+	labels := make(map[string]string, count)
+	for i := range count {
+		labels[fmt.Sprintf("label_%02d", i)] = ""
 	}
 	return labels
 }

--- a/src/go/plugin/framework/chartengine/planner_labels_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_labels_bench_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine/internal/program"
+)
+
+func BenchmarkChartLabelAccumulatorObserveEmpty(b *testing.B) {
+	tests := map[string]program.LabelPolicy{
+		"automatic": {
+			Mode: program.PromotionModeAutoIntersection,
+		},
+		"explicit_64": {
+			Mode:        program.PromotionModeExplicitIntersection,
+			PromoteKeys: benchmarkPromotedLabelKeys(64),
+		},
+	}
+	empty := sortedLabelView(nil)
+
+	for name, labels := range tests {
+		b.Run(name, func(b *testing.B) {
+			policy := compileChartLabelPolicy(program.Chart{Labels: labels})
+
+			b.Run("steady", func(b *testing.B) {
+				acc := newChartLabelAccumulator(policy)
+				if err := acc.observe(empty, ""); err != nil {
+					b.Fatal(err)
+				}
+				b.ReportAllocs()
+				for b.Loop() {
+					if err := acc.observe(empty, ""); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+
+			b.Run("after_reset", func(b *testing.B) {
+				acc := newChartLabelAccumulator(policy)
+				b.ReportAllocs()
+				for b.Loop() {
+					acc.reset()
+					if err := acc.observe(empty, ""); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func benchmarkPromotedLabelKeys(count int) []string {
+	keys := make([]string, count)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("label_%02d", i)
+	}
+	return keys
+}

--- a/src/go/plugin/framework/chartengine/planner_labels_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_labels_bench_test.go
@@ -9,45 +9,67 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine/internal/program"
 )
 
+var benchmarkPromotedIntersectionEmptySink bool
+
 func BenchmarkChartLabelAccumulatorObserveEmpty(b *testing.B) {
-	tests := map[string]program.LabelPolicy{
-		"automatic": {
-			Mode: program.PromotionModeAutoIntersection,
+	tests := map[string]struct {
+		chart     program.Chart
+		populated map[string]string
+	}{
+		"automatic_1": {
+			chart: program.Chart{
+				Labels: program.LabelPolicy{Mode: program.PromotionModeAutoIntersection},
+			},
+			populated: benchmarkLabelValues(1),
+		},
+		"automatic_64": {
+			chart: program.Chart{
+				Labels: program.LabelPolicy{Mode: program.PromotionModeAutoIntersection},
+			},
+			populated: benchmarkLabelValues(64),
 		},
 		"explicit_64": {
-			Mode:        program.PromotionModeExplicitIntersection,
-			PromoteKeys: benchmarkPromotedLabelKeys(64),
+			chart: program.Chart{
+				Labels: program.LabelPolicy{
+					Mode:        program.PromotionModeExplicitIntersection,
+					PromoteKeys: benchmarkPromotedLabelKeys(64),
+				},
+			},
+			populated: benchmarkLabelValues(64),
+		},
+		"wildcard_identity": {
+			chart: program.Chart{
+				Identity: program.ChartIdentity{
+					InstanceByLabels: []program.InstanceLabelSelector{{IncludeAll: true}},
+				},
+				Labels: program.LabelPolicy{Mode: program.PromotionModeAutoIntersection},
+			},
 		},
 	}
 	empty := sortedLabelView(nil)
 
-	for name, labels := range tests {
+	for name, tc := range tests {
 		b.Run(name, func(b *testing.B) {
-			policy := compileChartLabelPolicy(program.Chart{Labels: labels})
+			acc := newChartLabelAccumulator(compileChartLabelPolicy(tc.chart))
+			if len(tc.populated) > 0 {
+				if err := acc.observe(sortedLabelView(tc.populated), ""); err != nil {
+					b.Fatal(err)
+				}
+				if len(acc.selected) != len(tc.populated) {
+					b.Fatalf("prepopulate selected: got %d entries, want %d", len(acc.selected), len(tc.populated))
+				}
+			}
 
-			b.Run("steady", func(b *testing.B) {
-				acc := newChartLabelAccumulator(policy)
+			b.ReportAllocs()
+			for b.Loop() {
+				// Re-arm only the semantic witness so the benchmark isolates the
+				// populated-to-empty observation without rebuilding its map.
+				acc.promotedIntersectionEmpty = false
 				if err := acc.observe(empty, ""); err != nil {
 					b.Fatal(err)
 				}
-				b.ReportAllocs()
-				for b.Loop() {
-					if err := acc.observe(empty, ""); err != nil {
-						b.Fatal(err)
-					}
-				}
-			})
-
-			b.Run("after_reset", func(b *testing.B) {
-				acc := newChartLabelAccumulator(policy)
-				b.ReportAllocs()
-				for b.Loop() {
-					acc.reset()
-					if err := acc.observe(empty, ""); err != nil {
-						b.Fatal(err)
-					}
-				}
-			})
+			}
+			benchmarkPromotedIntersectionEmptySink = acc.promotedIntersectionEmpty
 		})
 	}
 }
@@ -58,4 +80,12 @@ func benchmarkPromotedLabelKeys(count int) []string {
 		keys[i] = fmt.Sprintf("label_%02d", i)
 	}
 	return keys
+}
+
+func benchmarkLabelValues(count int) map[string]string {
+	labels := make(map[string]string, count)
+	for i := range count {
+		labels[fmt.Sprintf("label_%02d", i)] = fmt.Sprintf("value_%02d", i)
+	}
+	return labels
 }

--- a/src/go/plugin/framework/chartengine/planner_labels_test.go
+++ b/src/go/plugin/framework/chartengine/planner_labels_test.go
@@ -82,6 +82,63 @@ func TestChartLabelAccumulatorIntersectsLabels(t *testing.T) {
 	}
 }
 
+func TestChartLabelAccumulatorIntersectsEmptyLabelSet(t *testing.T) {
+	tests := map[string]struct {
+		mode     program.PromotionMode
+		promoted []string
+		observed []map[string]string
+	}{
+		"automatic labeled then empty": {
+			mode: program.PromotionModeAutoIntersection,
+			observed: []map[string]string{
+				{"region": "eu"},
+				{},
+			},
+		},
+		"automatic empty then labeled": {
+			mode: program.PromotionModeAutoIntersection,
+			observed: []map[string]string{
+				{},
+				{"region": "eu"},
+			},
+		},
+		"explicit labeled then empty": {
+			mode:     program.PromotionModeExplicitIntersection,
+			promoted: []string{"region"},
+			observed: []map[string]string{
+				{"region": "eu"},
+				{},
+			},
+		},
+		"explicit empty then labeled": {
+			mode:     program.PromotionModeExplicitIntersection,
+			promoted: []string{"region"},
+			observed: []map[string]string{
+				{},
+				{"region": "eu"},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			chart := program.Chart{
+				Labels: program.LabelPolicy{
+					Mode:        tc.mode,
+					PromoteKeys: tc.promoted,
+				},
+			}
+			acc := newChartLabelAccumulator(compileChartLabelPolicy(chart))
+
+			for _, labels := range tc.observed {
+				require.NoError(t, acc.observe(sortedLabelView(labels), ""))
+			}
+
+			assert.Empty(t, acc.materialize())
+		})
+	}
+}
+
 func TestCompileInstanceLabelPlanExcludeWinsRegardlessOfTokenOrder(t *testing.T) {
 	tests := map[string]struct {
 		selectors []program.InstanceLabelSelector

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -562,8 +562,10 @@ charts:
 | `dimensions`      | array         | **yes**  |                        | At least one dimension required (see [dimensions](#6-dimensions)).           |
 
 Chart and dimension identity labels are immutable routing inputs: changing one creates a new chart or dimension
-ID. Promoted labels are non-identity metadata. When their effective intersection changes, chartengine updates the
-existing chart with a complete replacement label set; it does not recreate the chart or its dimensions.
+ID. Promoted labels are non-identity metadata. They are the intersection across every routed contributor to the chart,
+including contributors with no source labels. Therefore, one unlabeled contributor makes the promoted intersection empty.
+When the effective intersection changes, chartengine updates the existing chart with a complete replacement label set;
+it does not recreate the chart or its dimensions.
 
 > [!TIP]
 > Omit `algorithm` for the normal case. The engine uses `incremental` for a matched runtime counter and `absolute` for a


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix label intersection in `chartengine`: unlabeled contributors are treated as empty sets. When an unlabeled metric shares a chart, promoted non-identity labels drop to empty and the engine sends a labels-only update without recreating charts or dimensions.

- **Bug Fixes**
  - Simplified the empty-intersection path to stay constant-time and avoid map churn; added benchmarks.
  - Expanded tests to cover automatic and explicit promotion; updated `chartengine`/`charttpl` docs on unlabeled intersection and label-only resets.

<sup>Written for commit 85cb47ad9dbe52abf5bf792ea591f4b25a1ab69c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

