### PR TITLE
feat(go.d/chartengine): support optional instance labels

### DIFF
--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -227,6 +227,8 @@ source files for evidence.
   provides that view.
 - Optional-label presence or value transitions create a new chart while the old chart follows normal lifecycle expiry.
   A template MUST choose lifecycle limits appropriate for the source's observed churn.
+- A present optional identity contributes both its key and value to the chart-ID suffix (for example,
+  `pid="1234"` becomes `_pid_1234`); missing or blank optional identities contribute nothing.
 - `label_promotion` defines non-identity chart metadata. Chartengine reconciles
   its effective intersection across every routed contributor, including an
   empty source-label set, and emits a complete replacement only when it changes.

--- a/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
+++ b/.agents/skills/project-writing-go-modules-framework-v2/SKILL.md
@@ -106,7 +106,7 @@ source files for evidence.
   one-active-state values.
 - Metric names MUST be stable and selected by `charts.yaml`.
 - In `charts.yaml`, use `version: v1`, `context_namespace`, `instances.by_labels`,
-  and `label_promotion` where their operator-facing behavior is needed.
+  `instances.optional_by_labels`, and `label_promotion` where their operator-facing behavior is needed.
 - Charts SHOULD omit `algorithm` for normal type-driven behavior. At runtime,
   chartengine maps `metrix` counters to `incremental` dimensions and gauges or
   other kinds to `absolute`, including dynamically built `charttpl.Chart`
@@ -130,9 +130,9 @@ source files for evidence.
   option for V2 charts.
 - Put multipliers, divisors, hidden flags, and float formatting in the chart
   template, not ad hoc chart-emission code.
-- When `instances.by_labels` omits labels so multiple source series can map to
-  one rendered dimension, the effective `aggregation` MUST match the metric
-  meaning. Set it on the chart; it applies to every dimension. Absence means
+- When instance identity omits labels—either because `instances.by_labels` does not select them or an
+  `instances.optional_by_labels` key is absent—multiple source series can map to one rendered dimension. The effective
+  `aggregation` MUST match the metric meaning. Set it on the chart; it applies to every dimension. Absence means
   `sum`; available reducers are `sum`, `min`, `max`, and unweighted `avg`
   (`avg` forces floating-point emission). Use separate charts when metrics need
   different reducers. Metric kind is not enough to infer this policy: gauges
@@ -218,9 +218,15 @@ source files for evidence.
 
 ## Chart Label Identity
 
-- Labels used by `instances.by_labels` or a dimension `name_from_label` define
-  chart or dimension identity. Changing one creates a new chart or dimension;
-  collectors MUST NOT use identity churn merely to refresh metadata.
+- Labels used by `instances.by_labels`, a present nonblank `instances.optional_by_labels` key, or a dimension
+  `name_from_label` define chart or dimension identity. Changing one creates a new chart or dimension; collectors MUST
+  NOT use identity churn merely to refresh metadata.
+- Use `instances.optional_by_labels` only when a source conditionally exposes a bounded, sufficiently stable,
+  operator-useful identity axis. Missing and blank values are omitted; present values create refined instances. Authors
+  MUST assess value count and churn, and MUST NOT create a duplicate aggregate chart when NIDL/query aggregation already
+  provides that view.
+- Optional-label presence or value transitions create a new chart while the old chart follows normal lifecycle expiry.
+  A template MUST choose lifecycle limits appropriate for the source's observed churn.
 - `label_promotion` defines non-identity chart metadata. Chartengine reconciles
   its effective intersection across every routed contributor, including an
   empty source-label set, and emits a complete replacement only when it changes.

--- a/src/go/pkg/metrix/labels.go
+++ b/src/go/pkg/metrix/labels.go
@@ -20,10 +20,9 @@ type labelView struct {
 func (v labelView) Len() int { return len(v.items) }
 
 func (v labelView) Get(key string) (string, bool) {
-	for _, l := range v.items {
-		if l.Key == key {
-			return l.Value, true
-		}
+	i := sort.Search(len(v.items), func(i int) bool { return v.items[i].Key >= key })
+	if i < len(v.items) && v.items[i].Key == key {
+		return v.items[i].Value, true
 	}
 	return "", false
 }

--- a/src/go/pkg/metrix/labels_view_test.go
+++ b/src/go/pkg/metrix/labels_view_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package metrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLabelViewGetUsesCanonicalKeyOrder(t *testing.T) {
+	view := labelView{items: []Label{
+		{Key: "alpha", Value: "one"},
+		{Key: "middle", Value: "two"},
+		{Key: "zulu", Value: "three"},
+	}}
+
+	tests := map[string]struct {
+		key       string
+		wantValue string
+		wantOK    bool
+	}{
+		"first":             {key: "alpha", wantValue: "one", wantOK: true},
+		"middle":            {key: "middle", wantValue: "two", wantOK: true},
+		"last":              {key: "zulu", wantValue: "three", wantOK: true},
+		"missing before":    {key: "aardvark"},
+		"missing between":   {key: "beta"},
+		"missing after":     {key: "zzzz"},
+		"missing from empty": {key: "alpha"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidate := view
+			if name == "missing from empty" {
+				candidate = labelView{}
+			}
+			got, ok := candidate.Get(tc.key)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantValue, got)
+		})
+	}
+}

--- a/src/go/pkg/metrix/labels_view_test.go
+++ b/src/go/pkg/metrix/labels_view_test.go
@@ -20,12 +20,12 @@ func TestLabelViewGetUsesCanonicalKeyOrder(t *testing.T) {
 		wantValue string
 		wantOK    bool
 	}{
-		"first":             {key: "alpha", wantValue: "one", wantOK: true},
-		"middle":            {key: "middle", wantValue: "two", wantOK: true},
-		"last":              {key: "zulu", wantValue: "three", wantOK: true},
-		"missing before":    {key: "aardvark"},
-		"missing between":   {key: "beta"},
-		"missing after":     {key: "zzzz"},
+		"first":              {key: "alpha", wantValue: "one", wantOK: true},
+		"middle":             {key: "middle", wantValue: "two", wantOK: true},
+		"last":               {key: "zulu", wantValue: "three", wantOK: true},
+		"missing before":     {key: "aardvark"},
+		"missing between":    {key: "beta"},
+		"missing after":      {key: "zzzz"},
 		"missing from empty": {key: "alpha"},
 	}
 

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -166,6 +166,20 @@ format's [aggregation section](../charttpl/README.md#aggregation) for semantics 
 - A changed intersection emits a complete replacement label set through `UpdateChartLabelsAction`; chart identity and
   dimensions are not recreated.
 
+### Instance Identity Resolution
+
+- `instances.by_labels` defines required identity. A missing explicit label rejects that series from the chart.
+- `instances.optional_by_labels` defines declaration-ordered explicit keys that participate only when their value is
+  present and nonblank. Missing or blank optional values retain the base/required chart identity.
+- Required values render before optional values in the chart-ID suffix. Every participating key is emitted as an identity
+  chart label.
+- Optional identity is resolved independently for each series. Present and absent source shapes can therefore materialize
+  refined and base chart instances in the same plan; a series is routed once, never copied into an aggregate view.
+- Presence/value changes are ordinary identity changes. Existing lifecycle policy expires the old chart; the engine keeps
+  no migration or alias state.
+- Explicit required/optional lookup is O(configured keys). The existing `by_labels: ["*"]` path additionally scans and
+  sorts visible labels; wildcard identity cannot be combined with optional keys.
+
 ### Algorithm Resolution
 
 - An omitted authored `algorithm` remains `AlgorithmAuto` in the immutable program, route cache, and chart-level action

--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -171,14 +171,15 @@ format's [aggregation section](../charttpl/README.md#aggregation) for semantics 
 - `instances.by_labels` defines required identity. A missing explicit label rejects that series from the chart.
 - `instances.optional_by_labels` defines declaration-ordered explicit keys that participate only when their value is
   present and nonblank. Missing or blank optional values retain the base/required chart identity.
-- Required values render before optional values in the chart-ID suffix. Every participating key is emitted as an identity
-  chart label.
+- Required values render before optional key/value pairs in the chart-ID suffix. For example, present `pid="1234"`
+  contributes `_pid_1234`. Every participating key is emitted as an identity chart label.
 - Optional identity is resolved independently for each series. Present and absent source shapes can therefore materialize
   refined and base chart instances in the same plan; a series is routed once, never copied into an aggregate view.
 - Presence/value changes are ordinary identity changes. Existing lifecycle policy expires the old chart; the engine keeps
   no migration or alias state.
-- Explicit required/optional lookup is O(configured keys). The existing `by_labels: ["*"]` path additionally scans and
-  sorts visible labels; wildcard identity cannot be combined with optional keys.
+- Explicit required/optional resolution reuses one compiled per-template plan and uses binary search over canonical
+  sorted source labels on a route-cache miss. The existing `by_labels: ["*"]` path scans and sorts visible labels;
+  wildcard identity cannot be combined with optional keys.
 
 ### Algorithm Resolution
 

--- a/src/go/plugin/framework/chartengine/compiler.go
+++ b/src/go/plugin/framework/chartengine/compiler.go
@@ -136,9 +136,9 @@ func (c *compiler) compileChart(chart charttpl.Chart, scope compileScope, templa
 		return program.Chart{}, fmt.Errorf("id: %w", err)
 	}
 
-	instanceByLabels, err := compileInstanceByLabels(chart.Instances)
+	instanceLabels, err := compileInstanceLabels(chart.Instances)
 	if err != nil {
-		return program.Chart{}, fmt.Errorf("instances.by_labels: %w", err)
+		return program.Chart{}, fmt.Errorf("instances: %w", err)
 	}
 
 	labelMode := program.PromotionModeAutoIntersection
@@ -149,9 +149,10 @@ func (c *compiler) compileChart(chart charttpl.Chart, scope compileScope, templa
 
 	identity := program.ChartIdentity{
 		IDTemplate:       idTemplate,
-		InstanceByLabels: instanceByLabels,
+		InstanceByLabels: instanceLabels.required,
+		OptionalByLabels: instanceLabels.optional,
 		ContextNamespace: append([]string(nil), scope.contextParts...),
-		Static:           len(instanceByLabels) == 0,
+		Static:           len(instanceLabels.required) == 0 && len(instanceLabels.optional) == 0,
 	}
 	metaFamily := composeFamily(scope.familyParts, chart.Family)
 
@@ -349,25 +350,38 @@ func compileLifecycle(in *charttpl.Lifecycle) program.LifecyclePolicy {
 	return out
 }
 
-func compileInstanceByLabels(instances *charttpl.Instances) ([]program.InstanceLabelSelector, error) {
+type compiledInstanceLabels struct {
+	required []program.InstanceLabelSelector
+	optional []string
+}
+
+func compileInstanceLabels(instances *charttpl.Instances) (compiledInstanceLabels, error) {
 	if instances == nil {
-		return nil, nil
+		return compiledInstanceLabels{}, nil
 	}
-	out := make([]program.InstanceLabelSelector, 0, len(instances.ByLabels))
+
+	out := compiledInstanceLabels{
+		required: make([]program.InstanceLabelSelector, 0, len(instances.ByLabels)),
+		optional: make([]string, 0, len(instances.OptionalByLabels)),
+	}
 	for _, token := range instances.ByLabels {
 		t := strings.TrimSpace(token)
 		switch {
 		case t == "*":
-			out = append(out, program.InstanceLabelSelector{IncludeAll: true})
+			out.required = append(out.required, program.InstanceLabelSelector{IncludeAll: true})
 		case strings.HasPrefix(t, "!"):
 			key := strings.TrimSpace(strings.TrimPrefix(t, "!"))
 			if key == "" {
-				return nil, fmt.Errorf("exclude token must include label key")
+				return compiledInstanceLabels{}, fmt.Errorf("by_labels: exclude token must include label key")
 			}
-			out = append(out, program.InstanceLabelSelector{Exclude: true, Key: key})
+			out.required = append(out.required, program.InstanceLabelSelector{Exclude: true, Key: key})
 		default:
-			out = append(out, program.InstanceLabelSelector{Key: t})
+			out.required = append(out.required, program.InstanceLabelSelector{Key: t})
 		}
+	}
+
+	for _, raw := range instances.OptionalByLabels {
+		out.optional = append(out.optional, strings.TrimSpace(raw))
 	}
 	return out, nil
 }

--- a/src/go/plugin/framework/chartengine/compiler_test.go
+++ b/src/go/plugin/framework/chartengine/compiler_test.go
@@ -370,6 +370,40 @@ func TestCompileScenarios(t *testing.T) {
 				assert.Equal(t, program.AlgorithmAuto, charts[0].Meta.Algorithm)
 			},
 		},
+		"compile required and optional instance labels": {
+			spec: charttpl.Spec{
+				Version: charttpl.VersionV1,
+				Groups: []charttpl.Group{
+					{
+						Family:  "Workers",
+						Metrics: []string{"worker_cpu_seconds"},
+						Charts: []charttpl.Chart{
+							{
+								Title:   "Worker CPU",
+								Context: "worker_cpu",
+								Units:   "seconds",
+								Instances: &charttpl.Instances{
+									ByLabels:         []string{"deployment"},
+									OptionalByLabels: []string{"pid"},
+								},
+								Dimensions: []charttpl.Dimension{
+									{Selector: "worker_cpu_seconds", Name: "cpu"},
+								},
+							},
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, p *program.Program) {
+				t.Helper()
+				charts := p.Charts()
+				require.Len(t, charts, 1)
+				assert.False(t, charts[0].Identity.Static)
+				require.Len(t, charts[0].Identity.InstanceByLabels, 1)
+				assert.Equal(t, "deployment", charts[0].Identity.InstanceByLabels[0].Key)
+				assert.Equal(t, []string{"pid"}, charts[0].Identity.OptionalByLabels)
+			},
+		},
 		"infer stateset dimension naming from runtime series metadata": {
 			rev: 8,
 			spec: charttpl.Spec{

--- a/src/go/plugin/framework/chartengine/identity.go
+++ b/src/go/plugin/framework/chartengine/identity.go
@@ -115,17 +115,37 @@ func renderInstanceSuffix(identity program.ChartIdentity, labels labelAccessor) 
 }
 
 func resolveInstanceLabelValues(identity program.ChartIdentity, labels labelAccessor) ([]instanceLabelValue, bool, error) {
-	if len(identity.InstanceByLabels) == 0 {
+	if len(identity.InstanceByLabels) == 0 && len(identity.OptionalByLabels) == 0 {
 		return nil, true, nil
 	}
 
 	plan := compileInstanceLabelPlan(identity)
-	out := make([]instanceLabelValue, 0, len(plan.explicitKeys))
+	out, _, ok := resolveInstanceLabelValuesWithPlan(plan, labels, nil, nil)
+	return out, ok, nil
+}
+
+func resolveInstanceLabelValuesWithPlan(
+	plan compiledInstanceLabelPlan,
+	labels labelAccessor,
+	out []instanceLabelValue,
+	includeAllScratch []string,
+) ([]instanceLabelValue, []string, bool) {
+	out = out[:0]
 	for _, key := range plan.explicitKeys {
 		value, ok := labels.Get(key)
 		if !ok {
 			// Explicit instance key is required to materialize one instance.
-			return nil, false, nil
+			return out[:0], includeAllScratch[:0], false
+		}
+		out = append(out, instanceLabelValue{
+			Key:   key,
+			Value: value,
+		})
+	}
+	for _, key := range plan.optionalKeys {
+		value, ok := labels.Get(key)
+		if !ok || strings.TrimSpace(value) == "" {
+			continue
 		}
 		out = append(out, instanceLabelValue{
 			Key:   key,
@@ -134,7 +154,7 @@ func resolveInstanceLabelValues(identity program.ChartIdentity, labels labelAcce
 	}
 
 	if plan.includeAll {
-		all := make([]string, 0)
+		all := includeAllScratch[:0]
 		labels.Range(func(key, _ string) bool {
 			if _, excluded := plan.excludeSet[key]; excluded {
 				return true
@@ -149,15 +169,16 @@ func resolveInstanceLabelValues(identity program.ChartIdentity, labels labelAcce
 		for _, key := range all {
 			value, ok := labels.Get(key)
 			if !ok {
-				return nil, false, nil
+				return out[:0], all[:0], false
 			}
 			out = append(out, instanceLabelValue{
 				Key:   key,
 				Value: value,
 			})
 		}
+		includeAllScratch = all
 	}
-	return out, true, nil
+	return out, includeAllScratch, true
 }
 
 var chartIDLabelValueSanitizer = strings.NewReplacer(

--- a/src/go/plugin/framework/chartengine/identity.go
+++ b/src/go/plugin/framework/chartengine/identity.go
@@ -11,8 +11,9 @@ import (
 )
 
 type instanceLabelValue struct {
-	Key   string
-	Value string
+	Key      string
+	Value    string
+	Optional bool
 }
 
 type labelAccessor interface {
@@ -51,11 +52,23 @@ func renderChartInstanceID(identity program.ChartIdentity, labels map[string]str
 	return renderChartInstanceIDWithAccessor(identity, mapLabelAccessor(labels))
 }
 
-func renderChartInstanceIDFromView(identity program.ChartIdentity, labels metrix.LabelView) (string, bool, error) {
-	return renderChartInstanceIDWithAccessor(identity, labelViewAccessor{view: labels})
+func renderChartInstanceIDFromViewWithPlan(
+	identity program.ChartIdentity,
+	plan compiledInstanceLabelPlan,
+	labels metrix.LabelView,
+) (string, bool, error) {
+	return renderChartInstanceIDWithAccessorAndPlan(identity, plan, labelViewAccessor{view: labels})
 }
 
 func renderChartInstanceIDWithAccessor(identity program.ChartIdentity, labels labelAccessor) (string, bool, error) {
+	return renderChartInstanceIDWithAccessorAndPlan(identity, compileInstanceLabelPlan(identity), labels)
+}
+
+func renderChartInstanceIDWithAccessorAndPlan(
+	identity program.ChartIdentity,
+	plan compiledInstanceLabelPlan,
+	labels labelAccessor,
+) (string, bool, error) {
 	baseID, ok, err := renderTemplate(identity.IDTemplate, labels)
 	if err != nil {
 		return "", false, err
@@ -64,7 +77,7 @@ func renderChartInstanceIDWithAccessor(identity program.ChartIdentity, labels la
 		return "", false, nil
 	}
 
-	suffix, ok, err := renderInstanceSuffix(identity, labels)
+	suffix, ok, err := renderInstanceSuffix(plan, labels)
 	if err != nil {
 		return "", false, err
 	}
@@ -81,11 +94,8 @@ func renderTemplate(tpl program.Template, _ labelAccessor) (string, bool, error)
 	return tpl.Raw, true, nil
 }
 
-func renderInstanceSuffix(identity program.ChartIdentity, labels labelAccessor) (string, bool, error) {
-	values, ok, err := resolveInstanceLabelValues(identity, labels)
-	if err != nil {
-		return "", false, err
-	}
+func renderInstanceSuffix(plan compiledInstanceLabelPlan, labels labelAccessor) (string, bool, error) {
+	values, ok := resolveInstanceLabelValuesWithPlan(plan, labels, nil)
 	if !ok {
 		return "", false, nil
 	}
@@ -93,9 +103,12 @@ func renderInstanceSuffix(identity program.ChartIdentity, labels labelAccessor) 
 		return "", true, nil
 	}
 
-	parts := make([]string, 0, len(values))
+	parts := make([]string, 0, len(values)*2)
 	hasNonEmpty := false
 	for _, item := range values {
+		if item.Optional {
+			parts = append(parts, sanitizeChartIDLabelValue(item.Key))
+		}
 		part := sanitizeChartIDLabelValue(item.Value)
 		if strings.TrimSpace(part) != "" {
 			hasNonEmpty = true
@@ -114,71 +127,44 @@ func renderInstanceSuffix(identity program.ChartIdentity, labels labelAccessor) 
 	return "_" + strings.Join(parts, "_"), true, nil
 }
 
-func resolveInstanceLabelValues(identity program.ChartIdentity, labels labelAccessor) ([]instanceLabelValue, bool, error) {
-	if len(identity.InstanceByLabels) == 0 && len(identity.OptionalByLabels) == 0 {
-		return nil, true, nil
-	}
-
-	plan := compileInstanceLabelPlan(identity)
-	out, _, ok := resolveInstanceLabelValuesWithPlan(plan, labels, nil, nil)
-	return out, ok, nil
-}
-
 func resolveInstanceLabelValuesWithPlan(
 	plan compiledInstanceLabelPlan,
 	labels labelAccessor,
 	out []instanceLabelValue,
-	includeAllScratch []string,
-) ([]instanceLabelValue, []string, bool) {
+) ([]instanceLabelValue, bool) {
 	out = out[:0]
 	for _, key := range plan.explicitKeys {
 		value, ok := labels.Get(key)
 		if !ok {
-			// Explicit instance key is required to materialize one instance.
-			return out[:0], includeAllScratch[:0], false
+			// Explicit instance keys are required to materialize an instance.
+			return out[:0], false
 		}
-		out = append(out, instanceLabelValue{
-			Key:   key,
-			Value: value,
-		})
+		out = append(out, instanceLabelValue{Key: key, Value: value})
 	}
 	for _, key := range plan.optionalKeys {
 		value, ok := labels.Get(key)
 		if !ok || strings.TrimSpace(value) == "" {
 			continue
 		}
-		out = append(out, instanceLabelValue{
-			Key:   key,
-			Value: value,
-		})
+		out = append(out, instanceLabelValue{Key: key, Value: value, Optional: true})
 	}
 
 	if plan.includeAll {
-		all := includeAllScratch[:0]
-		labels.Range(func(key, _ string) bool {
+		start := len(out)
+		labels.Range(func(key, value string) bool {
 			if _, excluded := plan.excludeSet[key]; excluded {
 				return true
 			}
 			if _, exists := plan.explicitSet[key]; exists {
 				return true
 			}
-			all = append(all, key)
+			out = append(out, instanceLabelValue{Key: key, Value: value})
 			return true
 		})
-		sort.Strings(all)
-		for _, key := range all {
-			value, ok := labels.Get(key)
-			if !ok {
-				return out[:0], all[:0], false
-			}
-			out = append(out, instanceLabelValue{
-				Key:   key,
-				Value: value,
-			})
-		}
-		includeAllScratch = all
+		extras := out[start:]
+		sort.Slice(extras, func(i, j int) bool { return extras[i].Key < extras[j].Key })
 	}
-	return out, includeAllScratch, true
+	return out, true
 }
 
 var chartIDLabelValueSanitizer = strings.NewReplacer(

--- a/src/go/plugin/framework/chartengine/identity_bench_test.go
+++ b/src/go/plugin/framework/chartengine/identity_bench_test.go
@@ -89,9 +89,17 @@ groups:
 		labels = append(labels, metrix.Label{Key: fmt.Sprintf("unrelated_%03d", i), Value: fmt.Sprintf("value_%03d", i)})
 	}
 	view := labelSliceView{items: labels}
-	identity := metrix.SeriesIdentity{ID: "bench-series", Hash64: 1}
 	meta := metrix.SeriesMeta{Kind: metrix.MetricKindGauge}
 	index := engine.state.matchIndex
+
+	const identityBatchSize = 1024
+	identities := make([]metrix.SeriesIdentity, identityBatchSize)
+	for i := range identities {
+		identities[i] = metrix.SeriesIdentity{
+			ID:     metrix.SeriesID(fmt.Sprintf("bench-series-%04d", i)),
+			Hash64: uint64(i) + 1,
+		}
+	}
 	cache := newRouteCache()
 
 	b.ReportAllocs()
@@ -99,17 +107,22 @@ groups:
 	b.ReportMetric(float64(sourceLabelCount), "source_labels/op")
 	b.ResetTimer()
 	for i := range b.N {
-		revision := uint64(i) + 1
+		if i > 0 && i%identityBatchSize == 0 {
+			b.StopTimer()
+			cache = newRouteCache()
+			b.StartTimer()
+		}
+		buildSeq := uint64(i/identityBatchSize) + 1
 		routes, cached, err := engine.resolveSeriesRoutes(
 			cache,
-			identity,
+			identities[i%identityBatchSize],
 			"bench_metric",
 			view,
 			meta,
 			reader,
 			index,
-			revision,
-			revision,
+			1,
+			buildSeq,
 		)
 		if err != nil {
 			b.Fatalf("resolve cold route: %v", err)

--- a/src/go/plugin/framework/chartengine/identity_bench_test.go
+++ b/src/go/plugin/framework/chartengine/identity_bench_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartengine
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+)
+
+func BenchmarkResolveSeriesRoutesOptionalIdentityCold(b *testing.B) {
+	shapes := []struct {
+		identityKeys int
+		sourceLabels int
+	}{
+		{identityKeys: 1, sourceLabels: 8},
+		{identityKeys: 1, sourceLabels: 128},
+		{identityKeys: 8, sourceLabels: 8},
+		{identityKeys: 8, sourceLabels: 128},
+		{identityKeys: 32, sourceLabels: 32},
+		{identityKeys: 32, sourceLabels: 128},
+	}
+
+	for _, shape := range shapes {
+		for _, present := range []bool{false, true} {
+			name := fmt.Sprintf("keys_%d/labels_%d/present_%t", shape.identityKeys, shape.sourceLabels, present)
+			b.Run(name, func(b *testing.B) {
+				benchmarkResolveSeriesRoutesOptionalIdentityCold(b, shape.identityKeys, shape.sourceLabels, present)
+			})
+		}
+	}
+}
+
+func benchmarkResolveSeriesRoutesOptionalIdentityCold(b *testing.B, identityKeyCount, sourceLabelCount int, present bool) {
+	b.Helper()
+
+	var template strings.Builder
+	template.WriteString(`version: v1
+groups:
+  - family: Bench
+    metrics: [bench_metric]
+    charts:
+      - id: bench
+        title: Bench metric
+        context: bench.metric
+        units: units
+        instances:
+          optional_by_labels:
+`)
+	for i := range identityKeyCount {
+		fmt.Fprintf(&template, "            - identity_%03d\n", i)
+	}
+	template.WriteString(`        dimensions:
+          - selector: bench_metric
+            name: value
+`)
+
+	engine, err := New(WithRuntimeStore(nil))
+	if err != nil {
+		b.Fatalf("new engine: %v", err)
+	}
+	if err := engine.LoadYAML([]byte(template.String()), 1); err != nil {
+		b.Fatalf("load template: %v", err)
+	}
+
+	store := metrix.NewCollectorStore()
+	managed, ok := metrix.AsCycleManagedStore(store)
+	if !ok {
+		b.Fatal("benchmark store is not cycle-managed")
+	}
+	cc := managed.CycleController()
+	gauge := store.Write().SnapshotMeter("").Gauge("bench_metric")
+	cc.BeginCycle()
+	gauge.Observe(1)
+	if err := cc.CommitCycleSuccess(); err != nil {
+		b.Fatalf("commit benchmark metric: %v", err)
+	}
+	reader := store.Read(metrix.ReadFlatten())
+
+	labels := make([]metrix.Label, 0, sourceLabelCount)
+	if present {
+		for i := range identityKeyCount {
+			labels = append(labels, metrix.Label{Key: fmt.Sprintf("identity_%03d", i), Value: fmt.Sprintf("value_%03d", i)})
+		}
+	}
+	for i := len(labels); i < sourceLabelCount; i++ {
+		labels = append(labels, metrix.Label{Key: fmt.Sprintf("unrelated_%03d", i), Value: fmt.Sprintf("value_%03d", i)})
+	}
+	view := labelSliceView{items: labels}
+	identity := metrix.SeriesIdentity{ID: "bench-series", Hash64: 1}
+	meta := metrix.SeriesMeta{Kind: metrix.MetricKindGauge}
+	index := engine.state.matchIndex
+	cache := newRouteCache()
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(identityKeyCount), "identity_keys/op")
+	b.ReportMetric(float64(sourceLabelCount), "source_labels/op")
+	b.ResetTimer()
+	for i := range b.N {
+		revision := uint64(i) + 1
+		routes, cached, err := engine.resolveSeriesRoutes(
+			cache,
+			identity,
+			"bench_metric",
+			view,
+			meta,
+			reader,
+			index,
+			revision,
+			revision,
+		)
+		if err != nil {
+			b.Fatalf("resolve cold route: %v", err)
+		}
+		if cached {
+			b.Fatal("route unexpectedly resolved from cache")
+		}
+		if len(routes) != 1 {
+			b.Fatalf("routes = %d, want 1", len(routes))
+		}
+	}
+}

--- a/src/go/plugin/framework/chartengine/identity_test.go
+++ b/src/go/plugin/framework/chartengine/identity_test.go
@@ -89,6 +89,68 @@ func TestRenderChartInstanceIDScenarios(t *testing.T) {
 			},
 			wantOK: false,
 		},
+		"optional instance label absent keeps base chart": {
+			identity: program.ChartIdentity{
+				IDTemplate:       program.Template{Raw: "worker_cpu"},
+				OptionalByLabels: []string{"pid"},
+			},
+			labels: map[string]string{
+				"service": "api",
+			},
+			wantID: "worker_cpu",
+			wantOK: true,
+		},
+		"optional instance label blank keeps base chart": {
+			identity: program.ChartIdentity{
+				IDTemplate:       program.Template{Raw: "worker_cpu"},
+				OptionalByLabels: []string{"pid"},
+			},
+			labels: map[string]string{
+				"pid": "  ",
+			},
+			wantID: "worker_cpu",
+			wantOK: true,
+		},
+		"optional instance label present appends suffix": {
+			identity: program.ChartIdentity{
+				IDTemplate:       program.Template{Raw: "worker_cpu"},
+				OptionalByLabels: []string{"pid"},
+			},
+			labels: map[string]string{
+				"pid": "1234",
+			},
+			wantID: "worker_cpu_1234",
+			wantOK: true,
+		},
+		"required values precede optional values": {
+			identity: program.ChartIdentity{
+				IDTemplate: program.Template{Raw: "worker_cpu"},
+				InstanceByLabels: []program.InstanceLabelSelector{
+					{Key: "deployment"},
+				},
+				OptionalByLabels: []string{"worker", "pid"},
+			},
+			labels: map[string]string{
+				"deployment": "api",
+				"worker":     "blue",
+				"pid":        "1234",
+			},
+			wantID: "worker_cpu_api_blue_1234",
+			wantOK: true,
+		},
+		"optional value does not satisfy a missing required label": {
+			identity: program.ChartIdentity{
+				IDTemplate: program.Template{Raw: "worker_cpu"},
+				InstanceByLabels: []program.InstanceLabelSelector{
+					{Key: "deployment"},
+				},
+				OptionalByLabels: []string{"pid"},
+			},
+			labels: map[string]string{
+				"pid": "1234",
+			},
+			wantOK: false,
+		},
 	}
 
 	for name, tc := range tests {
@@ -207,6 +269,50 @@ func TestRenderChartInstanceIDExcludeWinsRegardlessOfTokenOrder(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, ok)
 			assert.Equal(t, tc.wantID, got)
+		})
+	}
+}
+
+var benchmarkRenderedChartInstanceID string
+
+func BenchmarkRenderChartInstanceID(b *testing.B) {
+	tests := map[string]struct {
+		identity program.ChartIdentity
+		labels   map[string]string
+	}{
+		"required_present": {
+			identity: program.ChartIdentity{
+				IDTemplate:       program.Template{Raw: "worker_cpu"},
+				InstanceByLabels: []program.InstanceLabelSelector{{Key: "pid"}},
+			},
+			labels: map[string]string{"pid": "1234"},
+		},
+		"optional_present": {
+			identity: program.ChartIdentity{
+				IDTemplate:       program.Template{Raw: "worker_cpu"},
+				OptionalByLabels: []string{"pid"},
+			},
+			labels: map[string]string{"pid": "1234"},
+		},
+		"optional_absent": {
+			identity: program.ChartIdentity{
+				IDTemplate:       program.Template{Raw: "worker_cpu"},
+				OptionalByLabels: []string{"pid"},
+			},
+			labels: map[string]string{"service": "api"},
+		},
+	}
+
+	for name, tc := range tests {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				got, ok, err := renderChartInstanceID(tc.identity, tc.labels)
+				if err != nil || !ok {
+					b.Fatalf("render chart identity: ok=%v err=%v", ok, err)
+				}
+				benchmarkRenderedChartInstanceID = got
+			}
 		})
 	}
 }

--- a/src/go/plugin/framework/chartengine/identity_test.go
+++ b/src/go/plugin/framework/chartengine/identity_test.go
@@ -3,8 +3,10 @@
 package chartengine
 
 import (
+	"sort"
 	"testing"
 
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine/internal/program"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,7 +121,29 @@ func TestRenderChartInstanceIDScenarios(t *testing.T) {
 			labels: map[string]string{
 				"pid": "1234",
 			},
-			wantID: "worker_cpu_1234",
+			wantID: "worker_cpu_pid_1234",
+			wantOK: true,
+		},
+		"partially present optional worker keeps key in suffix": {
+			identity: program.ChartIdentity{
+				IDTemplate:       program.Template{Raw: "worker_cpu"},
+				OptionalByLabels: []string{"worker", "pid"},
+			},
+			labels: map[string]string{
+				"worker": "blue",
+			},
+			wantID: "worker_cpu_worker_blue",
+			wantOK: true,
+		},
+		"partially present optional pid keeps key in suffix": {
+			identity: program.ChartIdentity{
+				IDTemplate:       program.Template{Raw: "worker_cpu"},
+				OptionalByLabels: []string{"worker", "pid"},
+			},
+			labels: map[string]string{
+				"pid": "blue",
+			},
+			wantID: "worker_cpu_pid_blue",
 			wantOK: true,
 		},
 		"required values precede optional values": {
@@ -135,7 +159,7 @@ func TestRenderChartInstanceIDScenarios(t *testing.T) {
 				"worker":     "blue",
 				"pid":        "1234",
 			},
-			wantID: "worker_cpu_api_blue_1234",
+			wantID: "worker_cpu_api_worker_blue_pid_1234",
 			wantOK: true,
 		},
 		"optional value does not satisfy a missing required label": {
@@ -305,9 +329,17 @@ func BenchmarkRenderChartInstanceID(b *testing.B) {
 
 	for name, tc := range tests {
 		b.Run(name, func(b *testing.B) {
+			labels := make([]metrix.Label, 0, len(tc.labels))
+			for key, value := range tc.labels {
+				labels = append(labels, metrix.Label{Key: key, Value: value})
+			}
+			sort.Slice(labels, func(i, j int) bool { return labels[i].Key < labels[j].Key })
+			view := labelSliceView{items: labels}
+			plan := compileInstanceLabelPlan(tc.identity)
+
 			b.ReportAllocs()
 			for range b.N {
-				got, ok, err := renderChartInstanceID(tc.identity, tc.labels)
+				got, ok, err := renderChartInstanceIDFromViewWithPlan(tc.identity, plan, view)
 				if err != nil || !ok {
 					b.Fatalf("render chart identity: ok=%v err=%v", ok, err)
 				}

--- a/src/go/plugin/framework/chartengine/internal/program/chart.go
+++ b/src/go/plugin/framework/chartengine/internal/program/chart.go
@@ -65,6 +65,9 @@ type ChartIdentity struct {
 
 	// InstanceByLabels contains resolved explicit identity selectors (if used).
 	InstanceByLabels []InstanceLabelSelector
+	// OptionalByLabels contains declaration-ordered identity keys that
+	// participate only when their runtime value is nonblank.
+	OptionalByLabels []string
 
 	// ContextNamespace holds normalized namespace fragments that participate in
 	// derived context/id building in namespace-based authoring mode.
@@ -95,7 +98,7 @@ func validateChart(chart Chart) error {
 	default:
 		errs = append(errs, fmt.Errorf("invalid chart type %q", chart.Meta.Type))
 	}
-	if err := validateInstanceLabelSelectors(chart.Identity.InstanceByLabels); err != nil {
+	if err := validateInstanceLabelPolicy(chart.Identity.InstanceByLabels, chart.Identity.OptionalByLabels); err != nil {
 		errs = append(errs, fmt.Errorf("identity: %w", err))
 	}
 	if err := validateLabelPolicy(chart.Labels); err != nil {
@@ -134,6 +137,7 @@ func (i ChartIdentity) clone() ChartIdentity {
 	for _, selector := range i.InstanceByLabels {
 		out.InstanceByLabels = append(out.InstanceByLabels, selector.clone())
 	}
+	out.OptionalByLabels = append([]string(nil), i.OptionalByLabels...)
 	out.ContextNamespace = append([]string(nil), i.ContextNamespace...)
 	return out
 }

--- a/src/go/plugin/framework/chartengine/internal/program/labels.go
+++ b/src/go/plugin/framework/chartengine/internal/program/labels.go
@@ -101,6 +101,51 @@ func validateInstanceLabelSelectors(selectors []InstanceLabelSelector) error {
 	return errors.Join(errs...)
 }
 
+func validateInstanceLabelPolicy(selectors []InstanceLabelSelector, optionalKeys []string) error {
+	if len(optionalKeys) == 0 {
+		return validateInstanceLabelSelectors(selectors)
+	}
+
+	var errs []error
+	if err := validateInstanceLabelSelectors(selectors); err != nil {
+		errs = append(errs, err)
+	}
+
+	requiredKeys := make(map[string]struct{}, len(selectors))
+	includeAll := false
+	for _, selector := range selectors {
+		includeAll = includeAll || selector.IncludeAll
+		if selector.Key != "" {
+			requiredKeys[selector.Key] = struct{}{}
+		}
+	}
+
+	seen := make(map[string]struct{}, len(optionalKeys))
+	for i, key := range optionalKeys {
+		if key == "" {
+			errs = append(errs, fmt.Errorf("optional instance label[%d]: key is required", i))
+			continue
+		}
+		if strings.TrimSpace(key) != key {
+			errs = append(errs, fmt.Errorf("optional instance label[%d]: key must be trimmed", i))
+		}
+		if key == "*" || strings.HasPrefix(key, "!") {
+			errs = append(errs, fmt.Errorf("optional instance label[%d]: key must be explicit", i))
+		}
+		if _, ok := seen[key]; ok {
+			errs = append(errs, fmt.Errorf("optional instance label[%d]: duplicate key %q", i, key))
+		}
+		seen[key] = struct{}{}
+		if includeAll {
+			errs = append(errs, fmt.Errorf("optional instance label[%d]: cannot be combined with include-all", i))
+		}
+		if _, ok := requiredKeys[key]; ok {
+			errs = append(errs, fmt.Errorf("optional instance label[%d]: key %q conflicts with required selectors", i, key))
+		}
+	}
+	return errors.Join(errs...)
+}
+
 // InstanceLabelSelector is a normalized token from instances.by_labels.
 type InstanceLabelSelector struct {
 	// IncludeAll corresponds to token "*".

--- a/src/go/plugin/framework/chartengine/internal/program/program_test.go
+++ b/src/go/plugin/framework/chartengine/internal/program/program_test.go
@@ -25,7 +25,11 @@ func TestNewProgramScenarios(t *testing.T) {
 			version: "v1",
 			metrics: []string{"windows_tx_total", "windows_rx_total", "windows_tx_total"},
 			charts: []Chart{
-				sampleChart("win.nic.traffic"),
+				func() Chart {
+					chart := sampleChart("win.nic.traffic")
+					chart.Identity.OptionalByLabels = []string{"pid"}
+					return chart
+				}(),
 			},
 			assert: func(t *testing.T, p *Program) {
 				t.Helper()
@@ -39,9 +43,11 @@ func TestNewProgramScenarios(t *testing.T) {
 
 				// Mutate returned chart copy and ensure Program internals are unaffected.
 				gotCharts[0].Meta.Title = "mutated-title"
+				gotCharts[0].Identity.OptionalByLabels[0] = "mutated-label"
 				again, ok := p.Chart("win.nic.traffic")
 				require.True(t, ok, "Chart() did not return existing template id")
 				assert.Equal(t, "Network traffic", again.Meta.Title)
+				assert.Equal(t, []string{"pid"}, again.Identity.OptionalByLabels)
 			},
 		},
 		"rejects duplicate chart template IDs": {
@@ -188,6 +194,41 @@ func TestValidateInstanceLabelSelectorsReportsJoinedErrors(t *testing.T) {
 	assert.ErrorContains(t, err, "instance selector[0]: exclude selector key must be trimmed")
 	assert.ErrorContains(t, err, "instance selector[1]: selector is empty")
 	assert.ErrorContains(t, err, "instance selectors must include at least one positive selector")
+}
+
+func TestValidateInstanceLabelPolicyRejectsOptionalConflicts(t *testing.T) {
+	tests := map[string]struct {
+		required []InstanceLabelSelector
+		optional []string
+		wantErr  string
+	}{
+		"wildcard": {
+			required: []InstanceLabelSelector{{IncludeAll: true}},
+			optional: []string{"pid"},
+			wantErr:  "cannot be combined with include-all",
+		},
+		"required overlap": {
+			required: []InstanceLabelSelector{{Key: "pid"}},
+			optional: []string{"pid"},
+			wantErr:  "conflicts with required selectors",
+		},
+		"duplicate": {
+			optional: []string{"pid", "pid"},
+			wantErr:  "duplicate key",
+		},
+		"magic token": {
+			optional: []string{"!pid"},
+			wantErr:  "key must be explicit",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateInstanceLabelPolicy(tc.required, tc.optional)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
 }
 
 func TestValidateDimensionReportsJoinedErrors(t *testing.T) {

--- a/src/go/plugin/framework/chartengine/matcher.go
+++ b/src/go/plugin/framework/chartengine/matcher.go
@@ -124,7 +124,11 @@ func (e *Engine) resolveSeriesRoutes(
 		if !ok {
 			return nil, false, fmt.Errorf("chartengine: route references unknown chart template %q", candidate.chartTemplateID)
 		}
-		chartID, ok, err := renderChartInstanceIDFromView(chart.Identity, labels)
+		labelPolicy, ok := index.labelPolicies[candidate.chartTemplateID]
+		if !ok {
+			return nil, false, fmt.Errorf("chartengine: route references unknown label policy %q", candidate.chartTemplateID)
+		}
+		chartID, ok, err := renderChartInstanceIDFromViewWithPlan(chart.Identity, labelPolicy.instancePlan, labels)
 		if err != nil {
 			return nil, false, err
 		}

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -20,13 +20,9 @@ type labelSliceView struct {
 }
 
 func (v labelSliceView) Get(key string) (string, bool) {
-	for _, item := range v.items {
-		if item.Key == key {
-			return item.Value, true
-		}
-		if item.Key > key {
-			break
-		}
+	i := sort.Search(len(v.items), func(i int) bool { return v.items[i].Key >= key })
+	if i < len(v.items) && v.items[i].Key == key {
+		return v.items[i].Value, true
 	}
 	return "", false
 }

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -3,7 +3,6 @@
 package chartengine
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
@@ -15,6 +14,7 @@ const collectJobLabel = "_collect_job"
 type compiledInstanceLabelPlan struct {
 	explicitKeys []string
 	explicitSet  map[string]struct{}
+	optionalKeys []string
 	excludeSet   map[string]struct{}
 	includeAll   bool
 }
@@ -102,10 +102,10 @@ func newChartLabelAccumulator(policy *chartLabelPolicy) *chartLabelAccumulator {
 	return &chartLabelAccumulator{
 		policy:                 policy,
 		dimensionKeyExclusions: make(map[string]struct{}),
-		instance:               make(map[string]string, len(plan.explicitKeys)),
+		instance:               make(map[string]string, len(plan.explicitKeys)+len(plan.optionalKeys)),
 		selected:               make(map[string]string, len(policy.promoteKeys)),
-		instanceKeys:           make(map[string]struct{}, len(plan.explicitKeys)),
-		resolvedScratch:        make([]instanceLabelValue, 0, len(plan.explicitKeys)),
+		instanceKeys:           make(map[string]struct{}, len(plan.explicitKeys)+len(plan.optionalKeys)),
+		resolvedScratch:        make([]instanceLabelValue, 0, len(plan.explicitKeys)+len(plan.optionalKeys)),
 		includeAllScratch:      make([]string, 0, len(plan.explicitKeys)),
 	}
 }
@@ -227,6 +227,7 @@ func compileInstanceLabelPlan(identity program.ChartIdentity) compiledInstanceLa
 	plan := compiledInstanceLabelPlan{
 		explicitKeys: make([]string, 0, len(identity.InstanceByLabels)),
 		explicitSet:  make(map[string]struct{}, len(identity.InstanceByLabels)),
+		optionalKeys: make([]string, 0, len(identity.OptionalByLabels)),
 		excludeSet:   make(map[string]struct{}),
 	}
 
@@ -258,6 +259,8 @@ func compileInstanceLabelPlan(identity program.ChartIdentity) compiledInstanceLa
 		plan.explicitKeys = append(plan.explicitKeys, key)
 		plan.explicitSet[key] = struct{}{}
 	}
+
+	plan.optionalKeys = append(plan.optionalKeys, identity.OptionalByLabels...)
 	return plan
 }
 
@@ -374,46 +377,27 @@ func (a *chartLabelAccumulator) addInstanceKey(key, value string) {
 
 func (a *chartLabelAccumulator) resolveInstanceLabelsForObserve(labels metrix.LabelView) bool {
 	a.resetInstanceKeys()
-
-	resolved := a.resolvedScratch[:0]
-	for _, key := range a.policy.instancePlan.explicitKeys {
-		value, ok := labels.Get(key)
-		if !ok {
-			a.resolvedScratch = resolved[:0]
-			return false
-		}
-		resolved = append(resolved, instanceLabelValue{Key: key, Value: value})
+	for _, key := range a.policy.instancePlan.optionalKeys {
+		// Optional keys are identity-reserved even when their current value is
+		// blank, so automatic promotion cannot leak a blank identity label.
+		a.instanceKeys[key] = struct{}{}
 	}
 
-	if a.policy.instancePlan.includeAll {
-		extra := a.includeAllScratch[:0]
-		labels.Range(func(key, _ string) bool {
-			if _, excluded := a.policy.instancePlan.excludeSet[key]; excluded {
-				return true
-			}
-			if _, already := a.policy.instancePlan.explicitSet[key]; already {
-				return true
-			}
-			extra = append(extra, key)
-			return true
-		})
-		sort.Strings(extra)
-		for _, key := range extra {
-			value, ok := labels.Get(key)
-			if !ok {
-				a.resolvedScratch = resolved[:0]
-				a.includeAllScratch = extra[:0]
-				return false
-			}
-			resolved = append(resolved, instanceLabelValue{Key: key, Value: value})
-		}
-		a.includeAllScratch = extra
+	resolved, extra, ok := resolveInstanceLabelValuesWithPlan(
+		a.policy.instancePlan,
+		labelViewAccessor{view: labels},
+		a.resolvedScratch,
+		a.includeAllScratch,
+	)
+	a.resolvedScratch = resolved
+	a.includeAllScratch = extra
+	if !ok {
+		return false
 	}
 
 	for _, item := range resolved {
 		a.addInstanceKey(item.Key, item.Value)
 	}
-	a.resolvedScratch = resolved
 	return true
 }
 

--- a/src/go/plugin/framework/chartengine/planner_labels.go
+++ b/src/go/plugin/framework/chartengine/planner_labels.go
@@ -33,9 +33,8 @@ type chartLabelAccumulator struct {
 	selected               map[string]string
 	initialized            bool
 
-	instanceKeys      map[string]struct{}
-	resolvedScratch   []instanceLabelValue
-	includeAllScratch []string
+	instanceKeys    map[string]struct{}
+	resolvedScratch []instanceLabelValue
 }
 
 type chartLabelMembership struct {
@@ -106,7 +105,6 @@ func newChartLabelAccumulator(policy *chartLabelPolicy) *chartLabelAccumulator {
 		selected:               make(map[string]string, len(policy.promoteKeys)),
 		instanceKeys:           make(map[string]struct{}, len(plan.explicitKeys)+len(plan.optionalKeys)),
 		resolvedScratch:        make([]instanceLabelValue, 0, len(plan.explicitKeys)+len(plan.optionalKeys)),
-		includeAllScratch:      make([]string, 0, len(plan.explicitKeys)),
 	}
 }
 
@@ -119,7 +117,6 @@ func (a *chartLabelAccumulator) reset() {
 	clear(a.selected)
 	clear(a.instanceKeys)
 	a.resolvedScratch = a.resolvedScratch[:0]
-	a.includeAllScratch = a.includeAllScratch[:0]
 	a.initialized = false
 }
 
@@ -383,14 +380,12 @@ func (a *chartLabelAccumulator) resolveInstanceLabelsForObserve(labels metrix.La
 		a.instanceKeys[key] = struct{}{}
 	}
 
-	resolved, extra, ok := resolveInstanceLabelValuesWithPlan(
+	resolved, ok := resolveInstanceLabelValuesWithPlan(
 		a.policy.instancePlan,
 		labelViewAccessor{view: labels},
 		a.resolvedScratch,
-		a.includeAllScratch,
 	)
 	a.resolvedScratch = resolved
-	a.includeAllScratch = extra
 	if !ok {
 		return false
 	}

--- a/src/go/plugin/framework/chartengine/planner_labels_test.go
+++ b/src/go/plugin/framework/chartengine/planner_labels_test.go
@@ -139,6 +139,38 @@ func TestChartLabelAccumulatorIntersectsEmptyLabelSet(t *testing.T) {
 	}
 }
 
+func TestChartLabelAccumulatorOptionalIdentityLabels(t *testing.T) {
+	tests := map[string]struct {
+		labels map[string]string
+		want   map[string]string
+	}{
+		"absent optional label": {
+			labels: map[string]string{"region": "eu"},
+			want:   map[string]string{"region": "eu"},
+		},
+		"blank optional label is omitted": {
+			labels: map[string]string{"pid": "  ", "region": "eu"},
+			want:   map[string]string{"region": "eu"},
+		},
+		"present optional label is identity": {
+			labels: map[string]string{"pid": "1234", "region": "eu"},
+			want:   map[string]string{"pid": "1234", "region": "eu"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			chart := program.Chart{
+				Identity: program.ChartIdentity{OptionalByLabels: []string{"pid"}},
+				Labels:   program.LabelPolicy{Mode: program.PromotionModeAutoIntersection},
+			}
+			acc := newChartLabelAccumulator(compileChartLabelPolicy(chart))
+			require.NoError(t, acc.observe(sortedLabelView(tc.labels), ""))
+			assert.Equal(t, tc.want, acc.materialize())
+		})
+	}
+}
+
 func TestCompileInstanceLabelPlanExcludeWinsRegardlessOfTokenOrder(t *testing.T) {
 	tests := map[string]struct {
 		selectors []program.InstanceLabelSelector

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -472,6 +472,7 @@ func TestBuildPlanLegacySingleScenarioCases(t *testing.T) {
 		"BuildPlanLifecycleNoRemovalOnFailedCycle":                     {run: runTestBuildPlanLifecycleNoRemovalOnFailedCycle},
 		"BuildPlanRendersChartIDsFromInstances":                        {run: runTestBuildPlanRendersChartIDsFromInstances},
 		"BuildPlanRendersOptionalInstanceLabels":                       {run: runTestBuildPlanRendersOptionalInstanceLabels},
+		"BuildPlanKeepsPartialOptionalIdentitiesDistinct":              {run: runTestBuildPlanKeepsPartialOptionalIdentitiesDistinct},
 		"BuildPlanEnforcesMaxInstancesDeterministically":               {run: runTestBuildPlanEnforcesMaxInstancesDeterministically},
 		"BuildPlanEnforcesMaxDimsDeterministically":                    {run: runTestBuildPlanEnforcesMaxDimsDeterministically},
 		"BuildPlanComputesChartLabelsIntersectionAndExclusions":        {run: runTestBuildPlanComputesChartLabelsIntersectionAndExclusions},
@@ -939,9 +940,9 @@ groups:
 		}
 	}
 	assert.NotContains(t, createLabels["worker_cpu"], "pid")
-	assert.Equal(t, "1234", createLabels["worker_cpu_1234"]["pid"])
+	assert.Equal(t, "1234", createLabels["worker_cpu_pid_1234"]["pid"])
 	assert.Equal(t, float64(3), updates["worker_cpu"])
-	assert.Equal(t, float64(3), updates["worker_cpu_1234"])
+	assert.Equal(t, float64(3), updates["worker_cpu_pid_1234"])
 
 	cc.BeginCycle()
 	cpu.Observe(4, workerPID)
@@ -952,7 +953,64 @@ groups:
 	assert.Equal(t, []ActionKind{ActionUpdateChart, ActionRemoveChart}, actionKinds(plan2.Actions))
 	update := findUpdateAction(plan2)
 	require.NotNil(t, update)
-	assert.Equal(t, "worker_cpu_1234", update.ChartID)
+	assert.Equal(t, "worker_cpu_pid_1234", update.ChartID)
+}
+
+func runTestBuildPlanKeepsPartialOptionalIdentitiesDistinct(t *testing.T) {
+	e, err := New()
+	require.NoError(t, err)
+
+	yaml := `
+version: v1
+groups:
+  - family: Workers
+    metrics: [worker_cpu_seconds]
+    charts:
+      - id: worker_cpu
+        title: Worker CPU
+        context: worker_cpu
+        units: seconds
+        aggregation: sum
+        instances:
+          optional_by_labels: [worker, pid]
+        dimensions:
+          - selector: worker_cpu_seconds
+            name: cpu
+`
+	require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	sm := store.Write().SnapshotMeter("")
+	cpu := sm.Gauge("worker_cpu_seconds")
+	worker := sm.LabelSet(metrix.Label{Key: "worker", Value: "blue"})
+	pid := sm.LabelSet(metrix.Label{Key: "pid", Value: "blue"})
+
+	cc.BeginCycle()
+	cpu.Observe(1, worker)
+	cpu.Observe(2, pid)
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+
+	createLabels := make(map[string]map[string]string)
+	updates := make(map[string]float64)
+	for _, action := range plan.Actions {
+		switch action := action.(type) {
+		case CreateChartAction:
+			createLabels[action.ChartID] = action.Labels
+		case UpdateChartAction:
+			require.Len(t, action.Values, 1)
+			updates[action.ChartID] = action.Values[0].Float64
+		}
+	}
+
+	require.Len(t, createLabels, 2)
+	assert.Equal(t, map[string]string{"worker": "blue"}, createLabels["worker_cpu_worker_blue"])
+	assert.Equal(t, map[string]string{"pid": "blue"}, createLabels["worker_cpu_pid_blue"])
+	assert.Equal(t, float64(1), updates["worker_cpu_worker_blue"])
+	assert.Equal(t, float64(2), updates["worker_cpu_pid_blue"])
 }
 
 func runTestBuildPlanEnforcesMaxInstancesDeterministically(t *testing.T) {

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -473,6 +473,7 @@ func TestBuildPlanLegacySingleScenarioCases(t *testing.T) {
 		"BuildPlanRendersChartIDsFromInstances":                        {run: runTestBuildPlanRendersChartIDsFromInstances},
 		"BuildPlanRendersOptionalInstanceLabels":                       {run: runTestBuildPlanRendersOptionalInstanceLabels},
 		"BuildPlanKeepsPartialOptionalIdentitiesDistinct":              {run: runTestBuildPlanKeepsPartialOptionalIdentitiesDistinct},
+		"BuildPlanIntersectsUnlabeledContributor":                      {run: runTestBuildPlanIntersectsUnlabeledContributor},
 		"BuildPlanEnforcesMaxInstancesDeterministically":               {run: runTestBuildPlanEnforcesMaxInstancesDeterministically},
 		"BuildPlanEnforcesMaxDimsDeterministically":                    {run: runTestBuildPlanEnforcesMaxDimsDeterministically},
 		"BuildPlanComputesChartLabelsIntersectionAndExclusions":        {run: runTestBuildPlanComputesChartLabelsIntersectionAndExclusions},
@@ -1011,6 +1012,70 @@ groups:
 	assert.Equal(t, map[string]string{"pid": "blue"}, createLabels["worker_cpu_pid_blue"])
 	assert.Equal(t, float64(1), updates["worker_cpu_worker_blue"])
 	assert.Equal(t, float64(2), updates["worker_cpu_pid_blue"])
+}
+
+func runTestBuildPlanIntersectsUnlabeledContributor(t *testing.T) {
+	tests := map[string]struct {
+		instances      string
+		labelPromotion string
+	}{
+		"static with automatic promotion": {},
+		"static with explicit promotion": {
+			labelPromotion: "        label_promotion: [region]\n",
+		},
+		"optional base with automatic promotion": {
+			instances: "        instances:\n          optional_by_labels: [pid]\n",
+		},
+		"optional base with explicit promotion": {
+			instances:      "        instances:\n          optional_by_labels: [pid]\n",
+			labelPromotion: "        label_promotion: [region]\n",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			e, err := New()
+			require.NoError(t, err)
+
+			yaml := `
+version: v1
+groups:
+  - family: Workers
+    metrics: [worker_cpu_seconds]
+    charts:
+      - id: worker_cpu
+        title: Worker CPU
+        context: worker_cpu
+        units: seconds
+        aggregation: sum
+` + tc.instances + tc.labelPromotion + `        dimensions:
+          - selector: worker_cpu_seconds
+            name: cpu
+`
+			require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+
+			store := metrix.NewCollectorStore()
+			cc := mustCycleController(t, store)
+			sm := store.Write().SnapshotMeter("")
+			cpu := sm.Gauge("worker_cpu_seconds")
+			region := sm.LabelSet(metrix.Label{Key: "region", Value: "eu"})
+
+			cc.BeginCycle()
+			cpu.Observe(1)
+			cpu.Observe(2, region)
+			require.NoError(t, cc.CommitCycleSuccess())
+
+			plan, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+			require.NoError(t, err)
+			create := findCreateChartAction(plan)
+			require.NotNil(t, create)
+			assert.Empty(t, create.Labels)
+			update := findUpdateAction(plan)
+			require.NotNil(t, update)
+			require.Len(t, update.Values, 1)
+			assert.Equal(t, float64(3), update.Values[0].Float64)
+		})
+	}
 }
 
 func runTestBuildPlanEnforcesMaxInstancesDeterministically(t *testing.T) {

--- a/src/go/plugin/framework/chartengine/planner_test.go
+++ b/src/go/plugin/framework/chartengine/planner_test.go
@@ -471,6 +471,7 @@ func TestBuildPlanLegacySingleScenarioCases(t *testing.T) {
 		"BuildPlanLifecycleChartExpiry":                                {run: runTestBuildPlanLifecycleChartExpiry},
 		"BuildPlanLifecycleNoRemovalOnFailedCycle":                     {run: runTestBuildPlanLifecycleNoRemovalOnFailedCycle},
 		"BuildPlanRendersChartIDsFromInstances":                        {run: runTestBuildPlanRendersChartIDsFromInstances},
+		"BuildPlanRendersOptionalInstanceLabels":                       {run: runTestBuildPlanRendersOptionalInstanceLabels},
 		"BuildPlanEnforcesMaxInstancesDeterministically":               {run: runTestBuildPlanEnforcesMaxInstancesDeterministically},
 		"BuildPlanEnforcesMaxDimsDeterministically":                    {run: runTestBuildPlanEnforcesMaxDimsDeterministically},
 		"BuildPlanComputesChartLabelsIntersectionAndExclusions":        {run: runTestBuildPlanComputesChartLabelsIntersectionAndExclusions},
@@ -878,6 +879,80 @@ groups:
 	plan2, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
 	require.NoError(t, err)
 	assert.Equal(t, []ActionKind{ActionUpdateChart, ActionUpdateChart}, actionKinds(plan2.Actions))
+}
+
+func runTestBuildPlanRendersOptionalInstanceLabels(t *testing.T) {
+	e, err := New()
+	require.NoError(t, err)
+
+	yaml := `
+version: v1
+groups:
+  - family: Workers
+    metrics:
+      - worker_cpu_seconds
+    charts:
+      - id: worker_cpu
+        title: Worker CPU
+        context: worker_cpu
+        units: seconds
+        aggregation: sum
+        instances:
+          optional_by_labels: [pid]
+        lifecycle:
+          expire_after_cycles: 1
+        dimensions:
+          - selector: worker_cpu_seconds
+            name: cpu
+`
+	require.NoError(t, e.LoadYAML([]byte(yaml), 1))
+
+	store := metrix.NewCollectorStore()
+	cc := mustCycleController(t, store)
+	sm := store.Write().SnapshotMeter("")
+	cpu := sm.Gauge("worker_cpu_seconds")
+	blankPID := sm.LabelSet(metrix.Label{Key: "pid", Value: "  "})
+	workerPID := sm.LabelSet(metrix.Label{Key: "pid", Value: "1234"})
+
+	cc.BeginCycle()
+	cpu.Observe(1)
+	cpu.Observe(2, blankPID)
+	cpu.Observe(3, workerPID)
+	_ = cc.CommitCycleSuccess()
+
+	plan1, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{
+		ActionCreateChart, ActionCreateDimension, ActionUpdateChart,
+		ActionCreateChart, ActionCreateDimension, ActionUpdateChart,
+	}, actionKinds(plan1.Actions))
+
+	createLabels := make(map[string]map[string]string)
+	updates := make(map[string]float64)
+	for _, action := range plan1.Actions {
+		switch action := action.(type) {
+		case CreateChartAction:
+			createLabels[action.ChartID] = action.Labels
+		case UpdateChartAction:
+			require.Len(t, action.Values, 1)
+			updates[action.ChartID] = action.Values[0].Float64
+		}
+	}
+	assert.NotContains(t, createLabels["worker_cpu"], "pid")
+	assert.Equal(t, "1234", createLabels["worker_cpu_1234"]["pid"])
+	assert.Equal(t, float64(3), updates["worker_cpu"])
+	assert.Equal(t, float64(3), updates["worker_cpu_1234"])
+
+	cc.BeginCycle()
+	cpu.Observe(4, workerPID)
+	_ = cc.CommitCycleSuccess()
+
+	plan2, err := buildPlan(e, store.Read(metrix.ReadFlatten()))
+	require.NoError(t, err)
+	assert.Equal(t, []ActionKind{ActionUpdateChart, ActionRemoveChart}, actionKinds(plan2.Actions))
+	update := findUpdateAction(plan2)
+	require.NotNil(t, update)
+	assert.Equal(t, "worker_cpu_1234", update.ChartID)
 }
 
 func runTestBuildPlanEnforcesMaxInstancesDeterministically(t *testing.T) {

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -667,9 +667,9 @@ use strict `!label_key` syntax; `! host` is invalid.
 required/excluded keys, and cannot be combined with `by_labels: ["*"]`. An `instances` object must contain at least one
 required or optional key.
 
-Required values form the chart-ID suffix first, in declaration order. Present nonblank optional values follow in their
-declaration order. Optional keys with missing or whitespace-only values do not affect the chart ID and are not emitted as
-chart identity labels.
+Required values form the chart-ID suffix first, in declaration order. Each present nonblank optional identity then
+contributes its label key followed by its value, also in declaration order. Optional keys with missing or whitespace-only
+values do not affect the chart ID and are not emitted as chart identity labels.
 
 **Example: One chart per host**
 
@@ -702,8 +702,9 @@ instances:
 ```
 
 A single-process source without `pid` uses the base chart ID. A multiprocess source with `pid="1234"` uses the
-`<base>_1234` chart and attaches `pid=1234` as an identity label. If both shapes occur in one snapshot, they route to the
-base and per-PID charts respectively; chartengine does not duplicate either series into a second aggregate view.
+`<base>_pid_1234` chart and attaches `pid=1234` as an identity label. Including the key keeps partially present
+multi-optional identities distinct. If both source shapes occur in one snapshot, they route to the base and per-PID
+charts respectively; chartengine does not duplicate either series into a second aggregate view.
 
 Use optional identity only for a bounded, sufficiently stable axis that is useful to operators. It still multiplies chart
 cardinality by the number of observed values. If an optional label appears, disappears, or changes, that is an identity

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -403,6 +403,7 @@ groups:
       label_promotion: [<label>, ...]
       instances:
         by_labels: [<label>, ...]
+        optional_by_labels: [<label>, ...]
     charts:
       - <chart definition>
     groups:
@@ -535,6 +536,7 @@ charts:
     label_promotion: [<label>, ...]
     instances:
       by_labels: [<label>, ...]
+      optional_by_labels: [<label>, ...]
     lifecycle:
       max_instances: <int>
       expire_after_cycles: <int>
@@ -631,15 +633,25 @@ charts:
 
 #### instances
 
-Instance identity determines how series are grouped into chart instances. When multiple series share the same instance identity label values, they appear as dimensions on the same chart instance.
+Instance identity determines how series are grouped into chart instances. When multiple series share the same instance
+identity label values, they appear as dimensions on the same chart instance.
 
 > [!TIP]
-> Without `instances`, there is one chart instance (all matching series land on the same chart). With `instances`, the engine creates one chart instance per unique combination of the specified label values.
+> Without `instances`, there is one chart instance (all matching series land on the same chart). With `instances`, the
+> engine creates one chart instance per unique combination of the selected required and present optional label values.
 
 ```yaml
 instances:
-  by_labels: [host]
+  by_labels: [deployment]
+  optional_by_labels: [pid]
 ```
+
+| Field                | Meaning                                                                                         |
+|----------------------|-------------------------------------------------------------------------------------------------|
+| `by_labels`          | Required identity selectors. A series missing an explicit required label does not route.        |
+| `optional_by_labels` | Explicit identity keys used only when the series has a nonblank value; missing/blank is omitted. |
+
+`by_labels` supports this selector grammar:
 
 | Token        | Meaning                                                       |
 |--------------|---------------------------------------------------------------|
@@ -647,8 +659,17 @@ instances:
 | `*`          | Include all labels.                                           |
 | `!label_key` | Exclude this label (use with `*` to include all _except_...). |
 
-Excludes are order-independent and always win. For example, both `["host", "!host"]` and `["!host", "host"]` exclude `host`.
-When `instances` is set, `by_labels` must include at least one positive selector: `*` or `label_key`. Exclude tokens use strict `!label_key` syntax; `! host` is invalid.
+Excludes are order-independent and always win. For example, both `["host", "!host"]` and `["!host", "host"]` exclude
+`host`. When `by_labels` is non-empty, it must include at least one positive selector: `*` or `label_key`. Exclude tokens
+use strict `!label_key` syntax; `! host` is invalid.
+
+`optional_by_labels` accepts explicit label keys only—no `*` or `!label_key`. Optional keys cannot duplicate or overlap
+required/excluded keys, and cannot be combined with `by_labels: ["*"]`. An `instances` object must contain at least one
+required or optional key.
+
+Required values form the chart-ID suffix first, in declaration order. Present nonblank optional values follow in their
+declaration order. Optional keys with missing or whitespace-only values do not affect the chart ID and are not emitted as
+chart identity labels.
 
 **Example: One chart per host**
 
@@ -672,6 +693,21 @@ instances:
 instances:
   by_labels: ["*", "!_collect_job"]
 ```
+
+**Example: Per-worker only when the exporter exposes a worker identity**
+
+```yaml
+instances:
+  optional_by_labels: [pid]
+```
+
+A single-process source without `pid` uses the base chart ID. A multiprocess source with `pid="1234"` uses the
+`<base>_1234` chart and attaches `pid=1234` as an identity label. If both shapes occur in one snapshot, they route to the
+base and per-PID charts respectively; chartengine does not duplicate either series into a second aggregate view.
+
+Use optional identity only for a bounded, sufficiently stable axis that is useful to operators. It still multiplies chart
+cardinality by the number of observed values. If an optional label appears, disappears, or changes, that is an identity
+change: the new chart is created and the old chart follows the configured lifecycle expiry.
 
 #### lifecycle
 
@@ -728,7 +764,8 @@ dimensions:
 
 Aggregation applies when multiple source series map to the same rendered chart ID and dimension name during one
 successful collection snapshot. This commonly happens when `instances.by_labels` intentionally omits high-cardinality
-labels. The source series keep their full identity in `metrix`; only their chart output is reduced.
+labels, or when an `instances.optional_by_labels` key is absent. The source series keep their full identity in `metrix`;
+only their chart output is reduced.
 
 | Value | Meaning                                  | Typical use                                                |
 |-------|------------------------------------------|------------------------------------------------------------|
@@ -751,8 +788,8 @@ limits, or averages. Authors must choose from the metric's meaning. Additional c
 - Reduction happens before Netdata applies the dimension multiplier/divisor and chart algorithm. An overall negative
   multiplier/divisor scale reverses the displayed ordering of `min` and `max`. Non-sum reduction of cumulative counter
   totals can produce misleading deltas when source membership changes.
-- `instances.by_labels` controls emitted chart cardinality; `aggregation` only selects the value for collisions created by
-  that projection. Every source series is still collected, stored, and routed.
+- `instances.by_labels` and `instances.optional_by_labels` control emitted chart cardinality; `aggregation` only selects
+  the value for collisions created by that projection. Every source series is still collected, stored, and routed.
 
 #### selectors
 
@@ -1116,10 +1153,12 @@ All rules below produce semantic validation errors unless noted:
 | `name` and `name_from_label` are mutually exclusive                                     | semantic                        |
 | `name` and `name_from_label` must not be whitespace-only                                | semantic                        |
 | Duplicate dimension `name` values within the same chart are rejected                    | semantic                        |
-| `instances.by_labels` must contain at least one token when `instances` is set           | semantic                        |
+| `instances` must contain at least one required or optional label                        | semantic                        |
 | `instances.by_labels` exclude token must use `!label_key` syntax                         | semantic                        |
 | `instances.by_labels` must include at least one positive selector (`*` or `label_key`)   | semantic                        |
 | `instances.by_labels` tokens must not be duplicated                                     | semantic                        |
+| `instances.optional_by_labels` accepts unique explicit label keys only                  | semantic                        |
+| Optional keys must not overlap required/excluded keys or accompany `by_labels: ["*"]`    | semantic                        |
 | `label_promotion[]` entries must not be empty or whitespace-only                        | semantic                        |
 | Lifecycle numeric fields must be `>= 0`                                                 | semantic                        |
 | `engine.autogen.max_type_id_len` must be `0` or `>= 4`                                  | semantic                        |

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -671,6 +671,9 @@ Required values form the chart-ID suffix first, in declaration order. Each prese
 contributes its label key followed by its value, also in declaration order. Optional keys with missing or whitespace-only
 values do not affect the chart ID and are not emitted as chart identity labels.
 
+Chart-ID suffixes use the existing sanitized underscore-joined representation; they are not a reversible serialization.
+Authors should avoid optional identity values deliberately shaped like another configured key/value suffix segment.
+
 **Example: One chart per host**
 
 ```yaml

--- a/src/go/plugin/framework/charttpl/clone_test.go
+++ b/src/go/plugin/framework/charttpl/clone_test.go
@@ -32,9 +32,11 @@ func TestGroupClone(t *testing.T) {
 	clone.Metrics = append(clone.Metrics, "extra")
 	clone.ChartDefaults.LabelPromoted[0] = "mutated"
 	clone.ChartDefaults.Instances.ByLabels[0] = "mutated"
+	clone.ChartDefaults.Instances.OptionalByLabels[0] = "mutated"
 	clone.Charts[0].Title = "MUTATED"
 	clone.Charts[0].LabelPromoted[0] = "mutated"
 	clone.Charts[0].Instances.ByLabels[0] = "mutated"
+	clone.Charts[0].Instances.OptionalByLabels[0] = "mutated"
 	clone.Charts[0].Lifecycle.MaxInstances = 999
 	clone.Charts[0].Lifecycle.Dimensions.MaxDims = 999
 	clone.Charts[0].Dimensions[0].Name = "MUTATED"
@@ -64,7 +66,10 @@ func richGroup() Group {
 		Metrics:          []string{"metric_a"},
 		ChartDefaults: &ChartDefaults{
 			LabelPromoted: []string{"region"},
-			Instances:     &Instances{ByLabels: []string{"resource_uid"}},
+			Instances: &Instances{
+				ByLabels:         []string{"resource_uid"},
+				OptionalByLabels: []string{"pid"},
+			},
 		},
 		Charts: []Chart{
 			{
@@ -74,7 +79,10 @@ func richGroup() Group {
 				Aggregation:   AggregationMax,
 				Type:          "line",
 				LabelPromoted: []string{"zone"},
-				Instances:     &Instances{ByLabels: []string{"id"}},
+				Instances: &Instances{
+					ByLabels:         []string{"id"},
+					OptionalByLabels: []string{"pid"},
+				},
 				Lifecycle: &Lifecycle{
 					MaxInstances:      10,
 					ExpireAfterCycles: 5,

--- a/src/go/plugin/framework/charttpl/config_schema.json
+++ b/src/go/plugin/framework/charttpl/config_schema.json
@@ -281,13 +281,37 @@
     "instances": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "by_labels"
+      "anyOf": [
+        {
+          "required": [
+            "by_labels"
+          ],
+          "properties": {
+            "by_labels": {
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "required": [
+            "optional_by_labels"
+          ],
+          "properties": {
+            "optional_by_labels": {
+              "minItems": 1
+            }
+          }
+        }
       ],
       "properties": {
         "by_labels": {
           "type": "array",
-          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "optional_by_labels": {
+          "type": "array",
           "items": {
             "type": "string"
           }

--- a/src/go/plugin/framework/charttpl/defaults.go
+++ b/src/go/plugin/framework/charttpl/defaults.go
@@ -77,6 +77,7 @@ func cloneInstances(in *Instances) *Instances {
 		return nil
 	}
 	return &Instances{
-		ByLabels: append([]string(nil), in.ByLabels...),
+		ByLabels:         append([]string(nil), in.ByLabels...),
+		OptionalByLabels: append([]string(nil), in.OptionalByLabels...),
 	}
 }

--- a/src/go/plugin/framework/charttpl/marshal_test.go
+++ b/src/go/plugin/framework/charttpl/marshal_test.go
@@ -35,6 +35,17 @@ func TestSpecMarshalTemplate(t *testing.T) {
 				assert.NotContains(t, out, "type:")
 			},
 		},
+		"emits optional-only instance identity without empty by_labels": {
+			spec: func() Spec {
+				spec := validationSpec()
+				spec.Groups[0].Charts[0].Instances = &Instances{OptionalByLabels: []string{"pid"}}
+				return spec
+			}(),
+			check: func(t *testing.T, out string) {
+				assert.Contains(t, out, "optional_by_labels:")
+				assert.NotContains(t, out, "by_labels: []")
+			},
+		},
 		"errors when groups missing": {
 			spec:    Spec{Version: VersionV1},
 			wantErr: true,

--- a/src/go/plugin/framework/charttpl/spec.go
+++ b/src/go/plugin/framework/charttpl/spec.go
@@ -94,7 +94,8 @@ type Chart struct {
 
 // Instances defines chart instance identity labels.
 type Instances struct {
-	ByLabels []string `yaml:"by_labels" json:"by_labels"`
+	ByLabels         []string `yaml:"by_labels,omitempty" json:"by_labels,omitempty"`
+	OptionalByLabels []string `yaml:"optional_by_labels,omitempty" json:"optional_by_labels,omitempty"`
 }
 
 // Lifecycle controls chart and dimension cardinality/expiry limits.

--- a/src/go/plugin/framework/charttpl/spec_test.go
+++ b/src/go/plugin/framework/charttpl/spec_test.go
@@ -120,6 +120,7 @@ groups:
         chart_defaults:
           instances:
             by_labels: [resource_uid, region]
+            optional_by_labels: [pid]
         charts:
           - title: Queries
             context: queries
@@ -149,6 +150,7 @@ groups:
 				assert.Equal(t, []string{"resource_name", "region"}, child.Charts[0].LabelPromoted)
 				require.NotNil(t, child.Charts[0].Instances)
 				assert.Equal(t, []string{"resource_uid", "region"}, child.Charts[0].Instances.ByLabels)
+				assert.Equal(t, []string{"pid"}, child.Charts[0].Instances.OptionalByLabels)
 
 				leaf := child.Groups[0]
 				require.Len(t, leaf.Charts, 1)
@@ -156,6 +158,7 @@ groups:
 				assert.Empty(t, leaf.Charts[0].LabelPromoted)
 				require.NotNil(t, leaf.Charts[0].Instances)
 				assert.Equal(t, []string{"region"}, leaf.Charts[0].Instances.ByLabels)
+				assert.Empty(t, leaf.Charts[0].Instances.OptionalByLabels)
 			},
 		},
 		"rejects unknown yaml field via strict unmarshal": {
@@ -459,6 +462,73 @@ func TestConfigSchemaAutogenRuleEmptyValues(t *testing.T) {
 
 			err = schema.Validate(instance)
 			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestConfigSchemaOptionalInstanceLabels(t *testing.T) {
+	var schemaDoc any
+	require.NoError(t, json.Unmarshal([]byte(ConfigSchemaJSON), &schemaDoc))
+	compiler := jsonschema.NewCompiler()
+	require.NoError(t, compiler.AddResource("charttpl.schema.json", schemaDoc))
+	schema, err := compiler.Compile("charttpl.schema.json")
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		instances map[string]any
+		wantErr   bool
+	}{
+		"required only": {
+			instances: map[string]any{"by_labels": []any{"deployment"}},
+		},
+		"optional only": {
+			instances: map[string]any{"optional_by_labels": []any{"pid"}},
+		},
+		"required and optional": {
+			instances: map[string]any{
+				"by_labels":          []any{"deployment"},
+				"optional_by_labels": []any{"pid"},
+			},
+		},
+		"empty required with optional": {
+			instances: map[string]any{
+				"by_labels":          []any{},
+				"optional_by_labels": []any{"pid"},
+			},
+		},
+		"empty instances": {
+			instances: map[string]any{},
+			wantErr:   true,
+		},
+		"empty required only": {
+			instances: map[string]any{"by_labels": []any{}},
+			wantErr:   true,
+		},
+		"empty optional only": {
+			instances: map[string]any{"optional_by_labels": []any{}},
+			wantErr:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			spec := validationSpec()
+			raw, err := json.Marshal(spec)
+			require.NoError(t, err)
+			var instance map[string]any
+			require.NoError(t, json.Unmarshal(raw, &instance))
+			groups := instance["groups"].([]any)
+			group := groups[0].(map[string]any)
+			charts := group["charts"].([]any)
+			chart := charts[0].(map[string]any)
+			chart["instances"] = tc.instances
+
+			err = schema.Validate(instance)
+			if tc.wantErr {
 				require.Error(t, err)
 				return
 			}

--- a/src/go/plugin/framework/charttpl/validate.go
+++ b/src/go/plugin/framework/charttpl/validate.go
@@ -179,13 +179,21 @@ func validateInstances(instances *Instances, path string) error {
 	if instances == nil {
 		return nil
 	}
-	var errs []error
-	hasPositive := false
-	if len(instances.ByLabels) == 0 {
-		return semErr(path+".instances.by_labels", "must contain at least one token when instances is set")
+	if len(instances.ByLabels) == 0 && len(instances.OptionalByLabels) == 0 {
+		if instances.ByLabels != nil {
+			return semErr(path+".instances.by_labels", "must contain at least one token when instances is set")
+		}
+		if instances.OptionalByLabels != nil {
+			return semErr(path+".instances.optional_by_labels", "must contain at least one label key when instances is set")
+		}
+		return semErr(path+".instances", "must contain at least one required or optional label")
 	}
 
+	var errs []error
+	hasPositive := false
 	seen := make(map[string]struct{}, len(instances.ByLabels))
+	requiredKeys := make(map[string]struct{}, len(instances.ByLabels))
+	includeAll := false
 	for i, token := range instances.ByLabels {
 		token = strings.TrimSpace(token)
 		if token == "" {
@@ -195,6 +203,7 @@ func validateInstances(instances *Instances, path string) error {
 		switch {
 		case token == "*":
 			hasPositive = true
+			includeAll = true
 		case strings.HasPrefix(token, "!"):
 			key := strings.TrimPrefix(token, "!")
 			if key == "" {
@@ -205,16 +214,44 @@ func validateInstances(instances *Instances, path string) error {
 				errs = append(errs, semErr(fmt.Sprintf("%s.instances.by_labels[%d]", path, i), "exclude token must use !label_key syntax"))
 				continue
 			}
+			requiredKeys[key] = struct{}{}
 		default:
 			hasPositive = true
+			requiredKeys[token] = struct{}{}
 		}
 		if _, ok := seen[token]; ok {
 			errs = append(errs, semErr(fmt.Sprintf("%s.instances.by_labels[%d]", path, i), fmt.Sprintf("duplicate token %q", token)))
 		}
 		seen[token] = struct{}{}
 	}
-	if !hasPositive {
+	if len(instances.ByLabels) > 0 && !hasPositive {
 		errs = append(errs, semErr(path+".instances.by_labels", "must include at least one positive selector ('*' or label key)"))
+	}
+
+	seenOptional := make(map[string]struct{}, len(instances.OptionalByLabels))
+	for i, raw := range instances.OptionalByLabels {
+		key := strings.TrimSpace(raw)
+		optionalPath := fmt.Sprintf("%s.instances.optional_by_labels[%d]", path, i)
+		if key == "" {
+			errs = append(errs, semErr(optionalPath, "must not be empty"))
+			continue
+		}
+		if key == "*" || strings.HasPrefix(key, "!") {
+			errs = append(errs, semErr(optionalPath, "must be an explicit label key, not a wildcard or exclusion"))
+			continue
+		}
+		if _, ok := seenOptional[key]; ok {
+			errs = append(errs, semErr(optionalPath, fmt.Sprintf("duplicate label key %q", key)))
+			continue
+		}
+		seenOptional[key] = struct{}{}
+		if includeAll {
+			errs = append(errs, semErr(optionalPath, "cannot be combined with instances.by_labels wildcard"))
+			continue
+		}
+		if _, ok := requiredKeys[key]; ok {
+			errs = append(errs, semErr(optionalPath, fmt.Sprintf("label key %q conflicts with instances.by_labels", key)))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/src/go/plugin/framework/charttpl/validate_test.go
+++ b/src/go/plugin/framework/charttpl/validate_test.go
@@ -1076,6 +1076,66 @@ func TestSpecValidateChartAggregation(t *testing.T) {
 	assert.ErrorContains(t, err, "must be one of [sum min max avg]")
 }
 
+func TestSpecValidateOptionalInstanceLabels(t *testing.T) {
+	tests := map[string]struct {
+		instances *Instances
+		wantErr   string
+	}{
+		"accepts optional-only identity": {
+			instances: &Instances{OptionalByLabels: []string{"pid"}},
+		},
+		"accepts required and optional identity": {
+			instances: &Instances{ByLabels: []string{"deployment"}, OptionalByLabels: []string{"pid"}},
+		},
+		"rejects empty instances": {
+			instances: &Instances{},
+			wantErr:   "instances",
+		},
+		"rejects empty optional key": {
+			instances: &Instances{OptionalByLabels: []string{" "}},
+			wantErr:   "optional_by_labels[0]",
+		},
+		"rejects optional wildcard": {
+			instances: &Instances{OptionalByLabels: []string{"*"}},
+			wantErr:   "optional_by_labels[0]",
+		},
+		"rejects optional exclusion": {
+			instances: &Instances{OptionalByLabels: []string{"!pid"}},
+			wantErr:   "optional_by_labels[0]",
+		},
+		"rejects duplicate optional key": {
+			instances: &Instances{OptionalByLabels: []string{"pid", " pid "}},
+			wantErr:   "duplicate label key",
+		},
+		"rejects required and optional overlap": {
+			instances: &Instances{ByLabels: []string{"pid"}, OptionalByLabels: []string{"pid"}},
+			wantErr:   "conflicts with instances.by_labels",
+		},
+		"rejects excluded optional key": {
+			instances: &Instances{ByLabels: []string{"deployment", "!pid"}, OptionalByLabels: []string{"pid"}},
+			wantErr:   "conflicts with instances.by_labels",
+		},
+		"rejects optional keys with wildcard identity": {
+			instances: &Instances{ByLabels: []string{"*"}, OptionalByLabels: []string{"pid"}},
+			wantErr:   "cannot be combined with instances.by_labels wildcard",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			spec := validationSpec()
+			spec.Groups[0].Charts[0].Instances = tc.instances
+			err := spec.Validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
 func validationSpec() Spec {
 	return Spec{
 		Version: VersionV1,


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional instance labels to `chartengine` so charts can refine identity when certain labels are present without requiring them. Introduces `instances.optional_by_labels` in `charttpl` with safe routing, clear ID suffixes, and better performance.

- **New Features**
  - `charttpl`: add `instances.optional_by_labels` for explicit keys that participate only when the runtime value is nonblank; optional-only identity is supported.
  - Identity: required values render first; present optional keys append `<key>_<value>` to the chart ID (e.g., `_pid_1234`). Missing/blank optional values keep the base chart.
  - Planner/Matcher: resolve required and optional identity via a compiled plan; routing uses one pass per series.
  - Performance: use binary search for label lookups in `metrix` and planner views.
  - Validation/Schema/Docs: forbid combining optional keys with `by_labels: ["*"]`, reject overlaps/duplicates, allow optional-only instances, and document behavior.

- **Bug Fixes**
  - Keep partially present optional identities distinct (each present key/value becomes its own chart).
  - Do not emit blank optional identity labels; no leakage into promoted labels.
  - Correctly intersect unlabeled contributors with optional-base charts.
  - Preserve exclude-vs-include semantics regardless of token order.

<sup>Written for commit ee2ab78f5f6592f5ca5a4fa086846bbd46243c55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

