### PR TITLE
Improve node manifest delivery reliability and pacing

### DIFF
--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -1055,7 +1055,7 @@ void aclk_send_node_instances()
 
 void aclk_send_bin_msg(char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname)
 {
-    aclk_send_bin_message_subtopic_pid(mqttwss_client, msg, msg_len, subtopic, msgname);
+    (void)aclk_send_bin_message_subtopic_pid(mqttwss_client, msg, msg_len, subtopic, msgname, NULL);
 }
 
 static void fill_alert_status_for_host(BUFFER *wb, RRDHOST *host)

--- a/src/aclk/aclk_contexts_api.c
+++ b/src/aclk/aclk_contexts_api.c
@@ -41,17 +41,19 @@ void aclk_update_node_info(struct update_node_info *info, struct aclk_sync_compl
     QUEUE_IF_PAYLOAD_PRESENT(query);
 }
 
-// `machine_guid` identifies the host whose config records `suppression_key` once this message is
-// really published; they are carried on the query instead of being applied by the caller, because
-// the caller only enqueues - see aclk_node_manifest_publish_result().
+// The caller has already recorded `suppression_key` under `token` on the host identified by
+// `machine_guid`. They are carried on the query so that a message which never reaches the mqtt layer
+// can have that record invalidated again - see aclk_node_manifest_publish_result().
 void aclk_update_node_instance_manifest(
     struct update_node_instance_manifest *manifest,
     const char *machine_guid,
-    uint64_t suppression_key)
+    uint64_t suppression_key,
+    uint64_t token)
 {
     aclk_query_t *query = aclk_query_new(UPDATE_NODE_MANIFEST);
     strncpyz(query->manifest.machine_guid, machine_guid, sizeof(query->manifest.machine_guid) - 1);
     query->manifest.key = suppression_key;
+    query->manifest.token = token;
     query->data.bin_payload.topic = ACLK_TOPICID_NODE_MANIFEST;
     query->data.bin_payload.payload =
         generate_update_node_instance_manifest_message(&query->data.bin_payload.size, manifest);

--- a/src/aclk/aclk_contexts_api.c
+++ b/src/aclk/aclk_contexts_api.c
@@ -41,9 +41,17 @@ void aclk_update_node_info(struct update_node_info *info, struct aclk_sync_compl
     QUEUE_IF_PAYLOAD_PRESENT(query);
 }
 
-void aclk_update_node_instance_manifest(struct update_node_instance_manifest *manifest)
+// `machine_guid` identifies the host whose config records `suppression_key` once this message is
+// really published; they are carried on the query instead of being applied by the caller, because
+// the caller only enqueues - see aclk_node_manifest_publish_result().
+void aclk_update_node_instance_manifest(
+    struct update_node_instance_manifest *manifest,
+    const char *machine_guid,
+    uint64_t suppression_key)
 {
     aclk_query_t *query = aclk_query_new(UPDATE_NODE_MANIFEST);
+    strncpyz(query->manifest.machine_guid, machine_guid, sizeof(query->manifest.machine_guid) - 1);
+    query->manifest.key = suppression_key;
     query->data.bin_payload.topic = ACLK_TOPICID_NODE_MANIFEST;
     query->data.bin_payload.payload =
         generate_update_node_instance_manifest_message(&query->data.bin_payload.size, manifest);

--- a/src/aclk/aclk_contexts_api.h
+++ b/src/aclk/aclk_contexts_api.h
@@ -14,7 +14,8 @@ void aclk_update_node_info(struct update_node_info *info, struct aclk_sync_compl
 void aclk_update_node_instance_manifest(
     struct update_node_instance_manifest *manifest,
     const char *machine_guid,
-    uint64_t suppression_key);
+    uint64_t suppression_key,
+    uint64_t token);
 
 #endif /* ACLK_CONTEXTS_API_H */
 

--- a/src/aclk/aclk_contexts_api.h
+++ b/src/aclk/aclk_contexts_api.h
@@ -11,7 +11,10 @@ void aclk_send_contexts_snapshot(contexts_snapshot_t data);
 void aclk_send_contexts_updated(contexts_updated_t data);
 void aclk_update_node_collectors(struct update_node_collectors *collectors);
 void aclk_update_node_info(struct update_node_info *info, struct aclk_sync_completion *sync_completion);
-void aclk_update_node_instance_manifest(struct update_node_instance_manifest *manifest);
+void aclk_update_node_instance_manifest(
+    struct update_node_instance_manifest *manifest,
+    const char *machine_guid,
+    uint64_t suppression_key);
 
 #endif /* ACLK_CONTEXTS_API_H */
 

--- a/src/aclk/aclk_query.c
+++ b/src/aclk/aclk_query.c
@@ -213,9 +213,14 @@ cleanup:
     return retval;
 }
 
-// Returns 0 when the message was handed to the mqtt layer, non-zero when it was dropped. The
-// payload is consumed either way. Callers that keep state describing what the cloud has been told
-// MUST update it from this result rather than from the enqueue - see build_node_manifest().
+// Returns 0 when the message was handed to the mqtt layer, non-zero when it was dropped. The payload
+// is consumed either way.
+//
+// Callers that keep state describing what the cloud has been told MUST reconcile it with this result.
+// The node manifest does that by recording the state as it enqueues and undoing the record when this
+// reports a drop - see build_node_manifest() and aclk_node_manifest_publish_result(). Recording only
+// on success would be wrong for it: the record is what suppresses later identical builds, and it has
+// to be in place for as long as the message is in flight.
 int send_bin_msg(mqtt_wss_client client, aclk_query_t *query)
 {
     // this will be simplified when legacy support is removed

--- a/src/aclk/aclk_query.c
+++ b/src/aclk/aclk_query.c
@@ -213,15 +213,19 @@ cleanup:
     return retval;
 }
 
+// Returns 0 when the message was handed to the mqtt layer, non-zero when it was dropped. The
+// payload is consumed either way. Callers that keep state describing what the cloud has been told
+// MUST update it from this result rather than from the enqueue - see build_node_manifest().
 int send_bin_msg(mqtt_wss_client client, aclk_query_t *query)
 {
     // this will be simplified when legacy support is removed
-    aclk_send_bin_message_subtopic_pid(
+    int rc = aclk_send_bin_message_subtopic_pid(
         client,
         query->data.bin_payload.payload,
         query->data.bin_payload.size,
         query->data.bin_payload.topic,
-        query->data.bin_payload.msg_name);
+        query->data.bin_payload.msg_name,
+        NULL);
     query->data.bin_payload.payload = NULL;
-    return 0;
+    return rc;
 }

--- a/src/aclk/aclk_query_queue.c
+++ b/src/aclk/aclk_query_queue.c
@@ -114,6 +114,12 @@ void aclk_query_free(aclk_query_t *query)
             break;
     }
 
+    // Every query reaches this function on every path - executed, dropped before execution, or
+    // dropped during shutdown - so reporting the manifest outcome here covers every way a manifest
+    // can fail to reach the cloud without each of those sites having to know about it.
+    if (query->type == UPDATE_NODE_MANIFEST)
+        aclk_node_manifest_publish_result(&query->manifest);
+
     freez(query->dedup_id);
     freez(query->callback_topic);
     freez(query->msg_id);

--- a/src/aclk/aclk_query_queue.h
+++ b/src/aclk/aclk_query_queue.h
@@ -52,6 +52,7 @@ struct aclk_bin_payload {
 struct aclk_manifest_publication {
     char machine_guid[GUID_LEN + 1]; // the host whose config recorded this send
     uint64_t key;                    // suppression key of this payload; 0 when not a manifest query
+    uint64_t token;                  // identifies THIS enqueue, so a drop cannot invalidate a later one
     bool published;                  // set once the message reached the mqtt layer
 };
 

--- a/src/aclk/aclk_query_queue.h
+++ b/src/aclk/aclk_query_queue.h
@@ -41,10 +41,10 @@ struct aclk_bin_payload {
     const char *msg_name;
 };
 
-// UPDATE_NODE_MANIFEST only: what the host config should record once this message is really
-// published. The producer cannot record it itself - it only enqueues, and the message can still be
-// dropped below it - and recording an unpublished manifest suppresses every later identical build
-// for the rest of the ACLK session. See aclk_node_manifest_publish_result().
+// UPDATE_NODE_MANIFEST only: what the host config recorded when this message was enqueued, so the
+// record can be undone if the message never reaches the mqtt layer. Without that, an unsent manifest
+// keeps suppressing every later identical build for the rest of the ACLK session.
+// See aclk_node_manifest_publish_result().
 //
 // The host is identified by machine_guid, not by the node_id the manifest is keyed under at the
 // cloud: node_id is mutable and host->node_id can disagree with the ACLK config's copy, so it does

--- a/src/aclk/aclk_query_queue.h
+++ b/src/aclk/aclk_query_queue.h
@@ -133,9 +133,10 @@ void aclk_query_free(aclk_query_t *query);
 void aclk_execute_query(aclk_query_t *query);
 void aclk_add_job(aclk_query_t *query);
 
-// Applies the outcome of a manifest publication to the host config: records the suppression key
-// when the message went out, re-arms the request when it was dropped. Implemented on the sqlite
-// side (sqlite_aclk_node.c), which owns that state - same split as aclk_execute_query() above.
+// Applies the outcome of a manifest publication to the host config. A message that went out needs
+// nothing - it was recorded when it was enqueued; a dropped one has that record invalidated and its
+// request re-armed. Implemented on the sqlite side (sqlite_aclk_node.c), which owns that state - same
+// split as aclk_execute_query() above.
 void aclk_node_manifest_publish_result(const struct aclk_manifest_publication *publication);
 
 #define QUEUE_IF_PAYLOAD_PRESENT(query)                                                                                \

--- a/src/aclk/aclk_query_queue.h
+++ b/src/aclk/aclk_query_queue.h
@@ -41,6 +41,20 @@ struct aclk_bin_payload {
     const char *msg_name;
 };
 
+// UPDATE_NODE_MANIFEST only: what the host config should record once this message is really
+// published. The producer cannot record it itself - it only enqueues, and the message can still be
+// dropped below it - and recording an unpublished manifest suppresses every later identical build
+// for the rest of the ACLK session. See aclk_node_manifest_publish_result().
+//
+// The host is identified by machine_guid, not by the node_id the manifest is keyed under at the
+// cloud: node_id is mutable and host->node_id can disagree with the ACLK config's copy, so it does
+// not identify the config to write back to. machine_guid is immutable for the host's lifetime.
+struct aclk_manifest_publication {
+    char machine_guid[GUID_LEN + 1]; // the host whose config recorded this send
+    uint64_t key;                    // suppression key of this payload; 0 when not a manifest query
+    bool published;                  // set once the message reached the mqtt layer
+};
+
 // ----------------------------------------------------------------------------
 // Reference-counted completion for safe timed waits
 // Both waiter and query hold a reference; last one to release frees the structure
@@ -108,6 +122,7 @@ typedef struct {
         void *payload;
         char *node_id;
     } data;
+    struct aclk_manifest_publication manifest;
     struct aclk_sync_completion *sync_completion;
 } aclk_query_t;
 
@@ -116,6 +131,11 @@ void aclk_query_free(aclk_query_t *query);
 
 void aclk_execute_query(aclk_query_t *query);
 void aclk_add_job(aclk_query_t *query);
+
+// Applies the outcome of a manifest publication to the host config: records the suppression key
+// when the message went out, re-arms the request when it was dropped. Implemented on the sqlite
+// side (sqlite_aclk_node.c), which owns that state - same split as aclk_execute_query() above.
+void aclk_node_manifest_publish_result(const struct aclk_manifest_publication *publication);
 
 #define QUEUE_IF_PAYLOAD_PRESENT(query)                                                                                \
     do {                                                                                                               \

--- a/src/aclk/aclk_tx_msgs.c
+++ b/src/aclk/aclk_tx_msgs.c
@@ -26,18 +26,30 @@ static bool aclk_size_add_overflow(size_t *total, size_t add)
 
 #define ACLK_HEADER_VERSION (2)
 
-uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname)
+// Returns MQTT_WSS_OK (0) when the message was handed to the mqtt layer, non-zero otherwise -
+// mqtt_wss_publish5()'s error code where it produced one, and 1 for a message that never reached
+// it. Either way the message has been freed. `packet_id` is optional and reports the assigned id
+// (0 when none was assigned).
+//
+// Callers that must know whether the message really went out MUST test the return code: the send
+// can fail for reasons that carry no packet id at all - an offline or disconnecting client, a full
+// mqtt buffer, a message the server rejects as too big - and a caller that does not want the id
+// passes NULL. The id is informational, for matching a later PUBACK.
+int aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname, uint16_t *packet_id)
 {
 #ifndef ACLK_LOG_CONVERSATION_DIR
     UNUSED(msgname);
 #endif
-    uint16_t packet_id = 0;
+    uint16_t pid = 0;
     const char *topic = aclk_get_topic(subtopic);
+
+    if (packet_id)
+        *packet_id = 0;
 
     if (unlikely(!topic)) {
         netdata_log_error("Couldn't get topic. Aborting message send.");
         freez(msg);
-        return 0;
+        return 1;
     }
 
     if (aclklog_enabled) {
@@ -46,11 +58,14 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
         freez(json);
     }
 
-    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish_msg, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
+    int rc = mqtt_wss_publish5(client, (char *)topic, NULL, msg, &freez_aclk_publish_msg, msg_len, MQTT_WSS_PUB_QOS1, &pid);
     if (rc != MQTT_WSS_OK)
-        packet_id = 0;
+        return rc;
 
-    return packet_id;
+    if (packet_id)
+        *packet_id = pid;
+
+    return MQTT_WSS_OK;
 }
 
 #define V2_BIN_PAYLOAD_SEPARATOR "\x0D\x0A\x0D\x0A"
@@ -324,7 +339,8 @@ uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable
         return 0;
     }
 
-    pid = aclk_send_bin_message_subtopic_pid(client, msg, len, ACLK_TOPICID_AGENT_CONN, "UpdateAgentConnection");
+    // a failed publish leaves pid at 0, which is what this returned before it reported the code
+    (void)aclk_send_bin_message_subtopic_pid(client, msg, len, ACLK_TOPICID_AGENT_CONN, "UpdateAgentConnection", &pid);
     if (claim_id_is_set(previous_claim_id))
         claim_id_clear_previous_working();
 

--- a/src/aclk/aclk_tx_msgs.h
+++ b/src/aclk/aclk_tx_msgs.h
@@ -9,7 +9,7 @@
 #include "aclk_util.h"
 
 // Consumes msg on every return path.
-uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname);
+int aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname, uint16_t *packet_id);
 
 void aclk_http_msg_v2_err(mqtt_wss_client client, const char *topic, const char *msg_id, int http_code, int ec, const char* emsg, const char *payload, size_t payload_len);
 short aclk_http_msg_v2(mqtt_wss_client client, const char *topic, const char *msg_id, usec_t t_exec, usec_t created,

--- a/src/database/rrd.h
+++ b/src/database/rrd.h
@@ -77,6 +77,10 @@ extern netdata_rwlock_t rrd_rwlock;
 #define rrd_rdunlock() netdata_rwlock_rdunlock(&rrd_rwlock)
 #define rrd_wrunlock() netdata_rwlock_wrunlock(&rrd_rwlock)
 
+// returns 0 when the read lock was taken. For threads that MUST NOT block on it - a writer can hold
+// rrd_wrlock() while waiting on another thread, so blocking here can close a cycle.
+#define rrd_tryrdlock() netdata_rwlock_tryrdlock(&rrd_rwlock)
+
 // --------------------------------------------------------------------------------------------------------------------
 
 STRING *rrd_string_strdupz(const char *s);

--- a/src/database/rrdfunctions-unittest.c
+++ b/src/database/rrdfunctions-unittest.c
@@ -276,11 +276,14 @@ int rrdfunctions_manifest_unittest(void) {
     //    standalone dictionaries keep this independent of whatever live functions localhost has.
     //    The other half of the suppression - scoping the record to one ACLK session - is folded
     //    into the same value by manifest_publication_key(), covered at the end of this block.
-    //    What is NOT covered here is the recording side: build_node_manifest() stores the key as it
-    //    enqueues, and aclk_node_manifest_publish_result() clears it again if the message was
-    //    dropped. That clear is pure atomics on the host's ACLK config, so it does NOT need a live
-    //    ACLK connection to exercise - it needs a host with a config, which this test has. It is
-    //    untested; see the SOW for the tracked gap.
+    //    What is NOT covered here is the recording side: build_node_manifest() records the key under a
+    //    per-enqueue token as it enqueues, and aclk_node_manifest_publish_result() invalidates that
+    //    token if the message was dropped. Invalidation is pure atomics on the host's ACLK config, so
+    //    it does NOT need a live ACLK connection - but it does need a host that HAS a config, and this
+    //    test's localhost does not: sql_load_node_id() calls set_host_node_id(host, NULL) when there is
+    //    no stored node_id, and that returns before create_aclk_config(), which is the only place
+    //    host->aclk_host_config is ever set. A test would have to call create_aclk_config() itself
+    //    (it is a plain callocz plus a publish CAS, no ACLK thread needed). Untested; tracked in the SOW.
     {
         int hash_errors_before = errors;
         const char *node1 = "11111111-2222-3333-4444-555555555555";
@@ -395,11 +398,9 @@ int rrdfunctions_manifest_unittest(void) {
             errors++;
         }
 
-        // the ACLK session is folded into the same 64-bit value, so that one atomic store carries
-        // the whole suppression key (see node_manifest_sent_key). Determinism for identical inputs is
-        // not asserted: the key is a pure function of them, so such a check cannot fail. The
-        // never-returns-0 sentinel invariant is not asserted either - it would need a digest preimage
-        // of 0, which cannot be constructed here; manifest_publication_key() enforces it directly.
+        // the ACLK session is folded into the same value, so one comparison covers both content and
+        // session (see node_manifest_sent_key). Determinism for identical inputs is not asserted: the
+        // key is a pure function of them, so such a check cannot fail.
         usec_t s1 = 1700000000000000ULL, s2 = 1700000000000001ULL;
         if(manifest_publication_key(ha, s1) == manifest_publication_key(ha, s2)) {
             fprintf(stderr, "  FAILED key: a new ACLK session did not change the key\n");

--- a/src/database/rrdfunctions-unittest.c
+++ b/src/database/rrdfunctions-unittest.c
@@ -442,6 +442,12 @@ int rrdfunctions_manifest_unittest(void) {
         // An unregistered host has no ACLK config - sql_load_node_id() only reaches
         // create_aclk_config() for a host the cloud has registered - so make one here. A NULL
         // node_id keeps create_aclk_config() from also writing host->node_id.
+        //
+        // Remember whether this test is the one that created it, so the cleanup below can put the
+        // host back exactly as it was found: this binary runs several tests in-process against the
+        // same localhost, and leaving an ACLK config attached would hand them mutable state (and a
+        // leaked allocation) they never asked for.
+        bool config_created_here = (__atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE) == NULL);
         create_aclk_config(host, &host->host_id.uuid, NULL);
         aclk_sync_cfg_t *cfg = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
 
@@ -515,11 +521,21 @@ int rrdfunctions_manifest_unittest(void) {
                 errors++;
             }
 
-            // leave nothing recorded or armed behind for the rest of the process
+            // leave nothing recorded or armed behind for the rest of the process. Redundant when the
+            // config is destroyed below, but this is also the path taken when the config pre-existed
+            // and must survive - and after destroy_aclk_config() cfg is freed, so it happens here.
             __atomic_store_n(&cfg->node_manifest_sent_token, 0, __ATOMIC_RELEASE);
             __atomic_store_n(&cfg->node_manifest_sent_key, 0, __ATOMIC_RELEASE);
             aclk_send_timestamp_set(&cfg->node_manifest_send_time, 0);
         }
+
+        // Detach and free the config if this test created it. With no ACLK sync thread running in the
+        // unittest binary, destroy_aclk_config() skips its event-loop round trip (it is gated on
+        // aclk_sync_config.initialized, set only inside aclk_synchronization_event_loop()) and reduces
+        // to an atomic exchange plus freez - no thread, no timer, no database. cfg is dangling after
+        // this point.
+        if(config_created_here)
+            destroy_aclk_config(host);
 
         if(errors == record_errors_before)
             fprintf(stderr, "  OK record: a drop invalidates its own token, a stale drop does not, "

--- a/src/database/rrdfunctions-unittest.c
+++ b/src/database/rrdfunctions-unittest.c
@@ -274,8 +274,11 @@ int rrdfunctions_manifest_unittest(void) {
     //    content, independent of dictionary traversal order, and sensitive to every transmitted
     //    field including the node_id and claim_id the manifest is keyed under at the cloud. Local
     //    standalone dictionaries keep this independent of whatever live functions localhost has.
-    //    The other half of the suppression - scoping the record to one ACLK session - lives in
-    //    build_node_manifest(), not in the hash, so it is not covered here.
+    //    The other half of the suppression - scoping the record to one ACLK session - is folded
+    //    into the same value by manifest_publication_key(), covered at the end of this block.
+    //    What is NOT covered here is which side records it: the key is written only by a
+    //    publication that reached the mqtt layer (aclk_node_manifest_publish_result()), which needs
+    //    a live ACLK connection to exercise.
     {
         int hash_errors_before = errors;
         const char *node1 = "11111111-2222-3333-4444-555555555555";
@@ -390,8 +393,24 @@ int rrdfunctions_manifest_unittest(void) {
             errors++;
         }
 
+        // the ACLK session is folded into the same 64-bit value, so that one atomic store carries
+        // the whole suppression key (see node_manifest_sent_key)
+        usec_t s1 = 1700000000000000ULL, s2 = 1700000000000001ULL;
+        if(manifest_publication_key(ha, s1) != manifest_publication_key(ha, s1)) {
+            fprintf(stderr, "  FAILED key: identical content and session produced different keys\n");
+            errors++;
+        }
+        if(manifest_publication_key(ha, s1) == manifest_publication_key(ha, s2)) {
+            fprintf(stderr, "  FAILED key: a new ACLK session did not change the key\n");
+            errors++;
+        }
+        if(manifest_publication_key(ha, s1) == manifest_publication_key(manifest_dict_hash(empty, node1, claim), s1)) {
+            fprintf(stderr, "  FAILED key: content change did not survive folding the session in\n");
+            errors++;
+        }
+
         if(errors == hash_errors_before)
-            fprintf(stderr, "  OK hash: determinism, order independence, field, node_id and claim_id sensitivity\n");
+            fprintf(stderr, "  OK hash: determinism, order independence, field, node_id, claim_id and session sensitivity\n");
 
         dictionary_destroy(a);
         dictionary_destroy(b);

--- a/src/database/rrdfunctions-unittest.c
+++ b/src/database/rrdfunctions-unittest.c
@@ -3,6 +3,7 @@
 #include "rrd.h"
 #include "rrdfunctions-internals.h"
 #include "sqlite/sqlite_aclk_node.h"
+#include "aclk/aclk_query_queue.h"
 
 // ----------------------------------------------------------------------------
 // Regression test for GHSA-6628-vxm3-4g8g.
@@ -280,10 +281,11 @@ int rrdfunctions_manifest_unittest(void) {
     //    per-enqueue token as it enqueues, and aclk_node_manifest_publish_result() invalidates that
     //    token if the message was dropped. Invalidation is pure atomics on the host's ACLK config, so
     //    it does NOT need a live ACLK connection - but it does need a host that HAS a config, and this
-    //    test's localhost does not: sql_load_node_id() calls set_host_node_id(host, NULL) when there is
-    //    no stored node_id, and that returns before create_aclk_config(), which is the only place
-    //    host->aclk_host_config is ever set. A test would have to call create_aclk_config() itself
-    //    (it is a plain callocz plus a publish CAS, no ACLK thread needed). Untested; tracked in the SOW.
+    //    test's localhost does not: sql_load_node_id() only calls set_host_node_id() when the query
+    //    returns a row, so an unregistered host reaches neither it nor create_aclk_config(), the only
+    //    place host->aclk_host_config is ever set. A test would have to call create_aclk_config()
+    //    itself (a plain callocz plus a publish CAS, no ACLK thread needed) and include
+    //    aclk/aclk_query_queue.h for struct aclk_manifest_publication. Untested; tracked in the SOW.
     {
         int hash_errors_before = errors;
         const char *node1 = "11111111-2222-3333-4444-555555555555";
@@ -419,6 +421,109 @@ int rrdfunctions_manifest_unittest(void) {
         dictionary_destroy(empty);
         dictionary_destroy(c1);
         dictionary_destroy(c2);
+    }
+
+    // 5. The publication record - what stops a manifest that never reached the mqtt layer from
+    //    suppressing every later identical build. build_node_manifest() records (key, token) as it
+    //    enqueues; aclk_node_manifest_publish_result() invalidates that record when the message was
+    //    dropped, by CASing the TOKEN it carried and never the key. The token is why that is safe:
+    //    a manifest enqueued after this one holds a different token, so it keeps its record even
+    //    when its content - and therefore its key - is identical, which is exactly the case a
+    //    content-keyed clear would get wrong (content published, changed, then changed back while
+    //    the first publication is still in flight).
+    //
+    //    Pinned directly because none of it is observable from the message stream. It needs no ACLK
+    //    connection and no ACLK thread: the invalidation is atomics on the host's ACLK config, and
+    //    with no sync thread running aclk_sync_on_event_loop_thread() is false, so the write-back
+    //    takes an uncontended rrd_rdlock() and resolves localhost from rrdhost_root_index normally.
+    {
+        int record_errors_before = errors;
+
+        // An unregistered host has no ACLK config - sql_load_node_id() only reaches
+        // create_aclk_config() for a host the cloud has registered - so make one here. A NULL
+        // node_id keeps create_aclk_config() from also writing host->node_id.
+        create_aclk_config(host, &host->host_id.uuid, NULL);
+        aclk_sync_cfg_t *cfg = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
+
+        if(!cfg) {
+            fprintf(stderr, "  FAILED record: could not create an ACLK config for localhost\n");
+            errors++;
+        }
+        else {
+            const uint64_t K = 0x0123456789abcdefULL; // any content key; the record is content-blind
+            const uint64_t T1 = 1111, T2 = 2222, T3 = 3333;
+
+            struct aclk_manifest_publication pub = { .key = K, .token = T1, .published = false };
+            strncpyz(pub.machine_guid, host->machine_guid, sizeof(pub.machine_guid) - 1);
+
+            // a dropped manifest invalidates its own record and re-arms, so the content is rebuilt
+            __atomic_store_n(&cfg->node_manifest_sent_key, K, __ATOMIC_RELEASE);
+            __atomic_store_n(&cfg->node_manifest_sent_token, T1, __ATOMIC_RELEASE);
+            aclk_send_timestamp_set(&cfg->node_manifest_send_time, 0);
+
+            aclk_node_manifest_publish_result(&pub);
+
+            if(__atomic_load_n(&cfg->node_manifest_sent_token, __ATOMIC_ACQUIRE) != 0) {
+                fprintf(stderr, "  FAILED record: a dropped manifest did not invalidate its own token\n");
+                errors++;
+            }
+            if(aclk_send_timestamp_get(&cfg->node_manifest_send_time) == 0) {
+                fprintf(stderr, "  FAILED record: a dropped manifest did not re-arm the request\n");
+                errors++;
+            }
+
+            // the same drop must NOT touch a later enqueue's record, even though the content, and
+            // so the key, is identical - only the token distinguishes them
+            __atomic_store_n(&cfg->node_manifest_sent_key, K, __ATOMIC_RELEASE);
+            __atomic_store_n(&cfg->node_manifest_sent_token, T2, __ATOMIC_RELEASE);
+            aclk_send_timestamp_set(&cfg->node_manifest_send_time, 0);
+
+            aclk_node_manifest_publish_result(&pub); // still carries the stale T1
+
+            if(__atomic_load_n(&cfg->node_manifest_sent_token, __ATOMIC_ACQUIRE) != T2) {
+                fprintf(stderr, "  FAILED record: a stale drop cleared a later enqueue's token\n");
+                errors++;
+            }
+            if(aclk_send_timestamp_get(&cfg->node_manifest_send_time) != 0) {
+                fprintf(stderr, "  FAILED record: a stale drop re-armed a request it does not own\n");
+                errors++;
+            }
+
+            // a manifest that reached the mqtt layer was already accounted for at enqueue time, so
+            // reporting it must change nothing at all
+            __atomic_store_n(&cfg->node_manifest_sent_token, T3, __ATOMIC_RELEASE);
+            aclk_send_timestamp_set(&cfg->node_manifest_send_time, 0);
+            pub.token = T3;
+            pub.published = true;
+
+            aclk_node_manifest_publish_result(&pub);
+
+            if(__atomic_load_n(&cfg->node_manifest_sent_token, __ATOMIC_ACQUIRE) != T3 ||
+               aclk_send_timestamp_get(&cfg->node_manifest_send_time) != 0) {
+                fprintf(stderr, "  FAILED record: a published manifest changed the record\n");
+                errors++;
+            }
+
+            // a host that no longer resolves is a no-op, not a crash and not someone else's record
+            pub.published = false;
+            strncpyz(pub.machine_guid, "00000000-0000-0000-0000-000000000000", sizeof(pub.machine_guid) - 1);
+
+            aclk_node_manifest_publish_result(&pub);
+
+            if(__atomic_load_n(&cfg->node_manifest_sent_token, __ATOMIC_ACQUIRE) != T3) {
+                fprintf(stderr, "  FAILED record: a publication for an unknown host touched this config\n");
+                errors++;
+            }
+
+            // leave nothing recorded or armed behind for the rest of the process
+            __atomic_store_n(&cfg->node_manifest_sent_token, 0, __ATOMIC_RELEASE);
+            __atomic_store_n(&cfg->node_manifest_sent_key, 0, __ATOMIC_RELEASE);
+            aclk_send_timestamp_set(&cfg->node_manifest_send_time, 0);
+        }
+
+        if(errors == record_errors_before)
+            fprintf(stderr, "  OK record: a drop invalidates its own token, a stale drop does not, "
+                            "a publish is a no-op, an unknown host is a no-op\n");
     }
 
     fprintf(stderr, "%s() %s (%d error%s)\n\n",

--- a/src/database/rrdfunctions-unittest.c
+++ b/src/database/rrdfunctions-unittest.c
@@ -277,8 +277,10 @@ int rrdfunctions_manifest_unittest(void) {
     //    The other half of the suppression - scoping the record to one ACLK session - is folded
     //    into the same value by manifest_publication_key(), covered at the end of this block.
     //    What is NOT covered here is which side records it: the key is written only by a
-    //    publication that reached the mqtt layer (aclk_node_manifest_publish_result()), which needs
-    //    a live ACLK connection to exercise.
+    //    publication that reached the mqtt layer (aclk_node_manifest_publish_result()). That
+    //    write-back is itself pure atomics on the host's ACLK config, so it does NOT need a live
+    //    ACLK connection to exercise - it needs a host with a config, which this test has. It is
+    //    untested; see the SOW for the tracked gap.
     {
         int hash_errors_before = errors;
         const char *node1 = "11111111-2222-3333-4444-555555555555";
@@ -394,12 +396,11 @@ int rrdfunctions_manifest_unittest(void) {
         }
 
         // the ACLK session is folded into the same 64-bit value, so that one atomic store carries
-        // the whole suppression key (see node_manifest_sent_key)
+        // the whole suppression key (see node_manifest_sent_key). Determinism for identical inputs is
+        // not asserted: the key is a pure function of them, so such a check cannot fail. The
+        // never-returns-0 sentinel invariant is not asserted either - it would need a digest preimage
+        // of 0, which cannot be constructed here; manifest_publication_key() enforces it directly.
         usec_t s1 = 1700000000000000ULL, s2 = 1700000000000001ULL;
-        if(manifest_publication_key(ha, s1) != manifest_publication_key(ha, s1)) {
-            fprintf(stderr, "  FAILED key: identical content and session produced different keys\n");
-            errors++;
-        }
         if(manifest_publication_key(ha, s1) == manifest_publication_key(ha, s2)) {
             fprintf(stderr, "  FAILED key: a new ACLK session did not change the key\n");
             errors++;

--- a/src/database/rrdfunctions-unittest.c
+++ b/src/database/rrdfunctions-unittest.c
@@ -276,9 +276,9 @@ int rrdfunctions_manifest_unittest(void) {
     //    standalone dictionaries keep this independent of whatever live functions localhost has.
     //    The other half of the suppression - scoping the record to one ACLK session - is folded
     //    into the same value by manifest_publication_key(), covered at the end of this block.
-    //    What is NOT covered here is which side records it: the key is written only by a
-    //    publication that reached the mqtt layer (aclk_node_manifest_publish_result()). That
-    //    write-back is itself pure atomics on the host's ACLK config, so it does NOT need a live
+    //    What is NOT covered here is the recording side: build_node_manifest() stores the key as it
+    //    enqueues, and aclk_node_manifest_publish_result() clears it again if the message was
+    //    dropped. That clear is pure atomics on the host's ACLK config, so it does NOT need a live
     //    ACLK connection to exercise - it needs a host with a config, which this test has. It is
     //    untested; see the SOW for the tracked gap.
     {

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -35,38 +35,47 @@ RRDHOST *rrdhost_find_by_node_id(const char *node_id) {
     return ret;
 }
 
-// Runs `cb` on the host with this machine_guid, under rrd_rdlock(), so the host stays allocated for
-// the duration of the callback.
+// Runs `cb` on the host with this machine_guid while holding the rrd read lock, so the host and
+// everything hanging off it stay allocated for the duration of the callback. For callers that hold
+// no reference to the host and cannot afford to block for it.
 //
-// rrd_rdlock() - NOT the host index lock - is what provides that. The index lock does not:
-// dict_item_del() takes only the index write lock, and for an item a traversal is referencing it
-// merely flags it deleted and returns without waiting (dictionary-item.h). rrdhost_root_index is
+// The rrd read lock - NOT the host index lock - is what provides the lifetime. The index lock does
+// not: dict_item_del() takes only the index write lock, and for an item a traversal is referencing
+// it merely flags it deleted and returns without waiting (dictionary-item.h). rrdhost_root_index is
 // also DICT_OPTION_VALUE_LINK_DONT_CLONE with no delete callback, so the dictionary never owns the
-// RRDHOST and freez(host) is not serialized by it at all. What every host teardown does hold is
-// rrd_wrlock(): rrdhost_free___while_having_rrd_wrlock() and rrdhost_free_all() unlink and free
-// under it.
+// RRDHOST and freez(host) is not serialized by it at all.
 //
-// Residual exposure, pre-existing and shared with the rest of this subsystem:
-// rrdhost_free___consume_metadata_lifetime_writelock() drops rrd_wrlock() before calling
-// rrdhost_free_unlinked(), so a host being freed by that path is not covered here either. That is
-// the same exposure build_node_info(), build_node_collectors() and build_node_manifest() already
-// carry when they dereference a host under rrd_rdlock() (see sqlite_aclk_node.c).
+// What makes the rrd read lock sufficient is that every teardown removes the host from
+// rrdhost_root_index under rrd_wrlock() before freeing it
+// (rrdhost_unlink___while_having_rrd_wrlock(), then rrdhost_free_unlinked()). So a lookup performed
+// while holding this read lock either happens before the unlink - and then the read lock blocks the
+// writer from unlinking and freeing until `cb` returns - or after it, and finds nothing. That covers
+// rrdhost_free___consume_metadata_lifetime_writelock() too, which frees with no lock held: by the
+// time it gets there the host is already out of the index, so it can no longer be found here.
+//
+// TRYLOCK, deliberately: this must never block. A host teardown calls destroy_aclk_config() while
+// holding rrd_wrlock(), which blocks on the ACLK sync event loop - and that same event loop can
+// reach this function when it drops a query. Waiting for the read lock would close that cycle and
+// wedge the agent with rrd_wrlock() held. Losing the race instead skips the callback, so callers
+// MUST treat "not applied" as a normal outcome and MUST NOT rely on it for correctness.
 //
 // Keyed by machine_guid, which is immutable for the host's lifetime and is this index's key, so the
 // lookup is exact. Do NOT key such a callback on node_id: host->node_id and the ACLK config's
 // node_id can disagree (command-nodeid.c assigns host->node_id from the parent without touching the
 // config), so a node_id resolves to the wrong host or to none.
 //
-// `cb` runs with rrd_rdlock() held: keep it short, and do not take a lock from it that an
+// `cb` runs with the rrd read lock held: keep it short, and do not take a lock from it that an
 // rrd_wrlock() holder may be waiting behind.
 //
-// Returns whether a host matched.
-bool rrdhost_apply_by_machine_guid(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data) {
+// Returns whether `cb` ran - false both when no host matched and when the lock was unavailable.
+bool rrdhost_apply_by_machine_guid_trylock(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data) {
 
     if (unlikely(!machine_guid || !*machine_guid || !cb))
         return false;
 
-    rrd_rdlock();
+    if (rrd_tryrdlock() != 0)
+        return false;
+
     RRDHOST *host = rrdhost_find_by_guid(machine_guid);
     if (host)
         cb(host, data);

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -36,8 +36,8 @@ RRDHOST *rrdhost_find_by_node_id(const char *node_id) {
 }
 
 // Runs `cb` on the host with this machine_guid while holding the rrd read lock, so the host and
-// everything hanging off it stay allocated for the duration of the callback. For callers that hold
-// no reference to the host and cannot afford to block for it.
+// everything hanging off it stay allocated for the duration of the callback. For callers that hold no
+// reference to the host.
 //
 // The rrd read lock - NOT the host index lock - is what provides the lifetime. The index lock does
 // not: dict_item_del() takes only the index write lock, and for an item a traversal is referencing
@@ -53,11 +53,15 @@ RRDHOST *rrdhost_find_by_node_id(const char *node_id) {
 // rrdhost_free___consume_metadata_lifetime_writelock() too, which frees with no lock held: by the
 // time it gets there the host is already out of the index, so it can no longer be found here.
 //
-// TRYLOCK, deliberately: this must never block. A host teardown calls destroy_aclk_config() while
-// holding rrd_wrlock(), which blocks on the ACLK sync event loop - and that same event loop can
-// reach this function when it drops a query. Waiting for the read lock would close that cycle and
-// wedge the agent with rrd_wrlock() held. Losing the race instead skips the callback, so callers
-// MUST treat "not applied" as a normal outcome and MUST NOT rely on it for correctness.
+// `may_block` selects how the read lock is taken, and a caller that can run on more than one thread
+// MUST decide it per call rather than once:
+//   true  - wait for the lock. Correct for any thread nobody can be waiting on while holding
+//           rrd_wrlock().
+//   false - take it only if it is free, and skip the callback otherwise. Required on a thread that
+//           an rrd_wrlock() holder may be blocked on: the ACLK sync event loop is one, because a host
+//           teardown calls destroy_aclk_config() under rrd_wrlock() and waits for that loop. Waiting
+//           for the read lock there would close the cycle and wedge the agent.
+// With false, "not applied" is a normal outcome the caller MUST tolerate.
 //
 // Keyed by machine_guid, which is immutable for the host's lifetime and is this index's key, so the
 // lookup is exact. Do NOT key such a callback on node_id: host->node_id and the ACLK config's
@@ -67,13 +71,15 @@ RRDHOST *rrdhost_find_by_node_id(const char *node_id) {
 // `cb` runs with the rrd read lock held: keep it short, and do not take a lock from it that an
 // rrd_wrlock() holder may be waiting behind.
 //
-// Returns whether `cb` ran - false both when no host matched and when the lock was unavailable.
-bool rrdhost_apply_by_machine_guid_trylock(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data) {
+// Returns whether `cb` ran - false when no host matched, and also when the lock was skipped.
+bool rrdhost_apply_by_machine_guid(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data, bool may_block) {
 
     if (unlikely(!machine_guid || !*machine_guid || !cb))
         return false;
 
-    if (rrd_tryrdlock() != 0)
+    if (may_block)
+        rrd_rdlock();
+    else if (rrd_tryrdlock() != 0)
         return false;
 
     RRDHOST *host = rrdhost_find_by_guid(machine_guid);

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -35,6 +35,46 @@ RRDHOST *rrdhost_find_by_node_id(const char *node_id) {
     return ret;
 }
 
+// Runs `cb` on the host with this machine_guid, under rrd_rdlock(), so the host stays allocated for
+// the duration of the callback.
+//
+// rrd_rdlock() - NOT the host index lock - is what provides that. The index lock does not:
+// dict_item_del() takes only the index write lock, and for an item a traversal is referencing it
+// merely flags it deleted and returns without waiting (dictionary-item.h). rrdhost_root_index is
+// also DICT_OPTION_VALUE_LINK_DONT_CLONE with no delete callback, so the dictionary never owns the
+// RRDHOST and freez(host) is not serialized by it at all. What every host teardown does hold is
+// rrd_wrlock(): rrdhost_free___while_having_rrd_wrlock() and rrdhost_free_all() unlink and free
+// under it.
+//
+// Residual exposure, pre-existing and shared with the rest of this subsystem:
+// rrdhost_free___consume_metadata_lifetime_writelock() drops rrd_wrlock() before calling
+// rrdhost_free_unlinked(), so a host being freed by that path is not covered here either. That is
+// the same exposure build_node_info(), build_node_collectors() and build_node_manifest() already
+// carry when they dereference a host under rrd_rdlock() (see sqlite_aclk_node.c).
+//
+// Keyed by machine_guid, which is immutable for the host's lifetime and is this index's key, so the
+// lookup is exact. Do NOT key such a callback on node_id: host->node_id and the ACLK config's
+// node_id can disagree (command-nodeid.c assigns host->node_id from the parent without touching the
+// config), so a node_id resolves to the wrong host or to none.
+//
+// `cb` runs with rrd_rdlock() held: keep it short, and do not take a lock from it that an
+// rrd_wrlock() holder may be waiting behind.
+//
+// Returns whether a host matched.
+bool rrdhost_apply_by_machine_guid(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data) {
+
+    if (unlikely(!machine_guid || !*machine_guid || !cb))
+        return false;
+
+    rrd_rdlock();
+    RRDHOST *host = rrdhost_find_by_guid(machine_guid);
+    if (host)
+        cb(host, data);
+    rrd_rdunlock();
+
+    return host != NULL;
+}
+
 RRDHOST *rrdhost_find_by_hostname(const char *hostname) {
     if(unlikely(!hostname))
         return NULL;

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -474,10 +474,11 @@ RRDHOST *rrdhost_find_by_hostname(const char *hostname);
 RRDHOST *rrdhost_find_by_guid(const char *guid);
 RRDHOST *rrdhost_find_by_node_id(const char *node_id);
 
-// lifetime-safe host lookup for callers that do not otherwise keep the host alive: resolves by
-// machine_guid and runs `cb` under rrd_rdlock() - see the definition for what that does and does not
-// guarantee, and for why this is not keyed on node_id
-bool rrdhost_apply_by_machine_guid(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data);
+// lifetime-safe, non-blocking host lookup for callers that hold no reference to the host: resolves
+// by machine_guid and runs `cb` under the rrd read lock, skipping the callback entirely rather than
+// waiting for it - see the definition for the lifetime argument, why it must not block, and why it
+// is not keyed on node_id
+bool rrdhost_apply_by_machine_guid_trylock(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data);
 
 #ifdef RRDHOST_INTERNALS
 RRDHOST *rrdhost_create(

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -474,6 +474,11 @@ RRDHOST *rrdhost_find_by_hostname(const char *hostname);
 RRDHOST *rrdhost_find_by_guid(const char *guid);
 RRDHOST *rrdhost_find_by_node_id(const char *node_id);
 
+// lifetime-safe host lookup for callers that do not otherwise keep the host alive: resolves by
+// machine_guid and runs `cb` under rrd_rdlock() - see the definition for what that does and does not
+// guarantee, and for why this is not keyed on node_id
+bool rrdhost_apply_by_machine_guid(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data);
+
 #ifdef RRDHOST_INTERNALS
 RRDHOST *rrdhost_create(
     const char *hostname,

--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -474,11 +474,11 @@ RRDHOST *rrdhost_find_by_hostname(const char *hostname);
 RRDHOST *rrdhost_find_by_guid(const char *guid);
 RRDHOST *rrdhost_find_by_node_id(const char *node_id);
 
-// lifetime-safe, non-blocking host lookup for callers that hold no reference to the host: resolves
-// by machine_guid and runs `cb` under the rrd read lock, skipping the callback entirely rather than
-// waiting for it - see the definition for the lifetime argument, why it must not block, and why it
-// is not keyed on node_id
-bool rrdhost_apply_by_machine_guid_trylock(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data);
+// lifetime-safe host lookup for callers that hold no reference to the host: resolves by machine_guid
+// and runs `cb` under the rrd read lock. `may_block` false skips the callback instead of waiting for
+// the lock, which threads an rrd_wrlock() holder can be blocked on MUST use - see the definition for
+// the lifetime argument, that constraint, and why this is not keyed on node_id
+bool rrdhost_apply_by_machine_guid(const char *machine_guid, void (*cb)(RRDHOST *host, void *data), void *data, bool may_block);
 
 #ifdef RRDHOST_INTERNALS
 RRDHOST *rrdhost_create(

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -409,8 +409,10 @@ static void aclk_run_query(struct aclk_sync_config_s *config, aclk_query_t *quer
     }
 
     if (ok_to_send) {
+        // aclk_query_free() reports the outcome to whoever tracks what the cloud has been told;
+        // leaving it unset here is what makes a dropped message recoverable.
         if (client)
-            send_bin_msg(client, query);
+            query->manifest.published = (send_bin_msg(client, query) == 0);
         else
             nd_log_daemon(NDLP_ERR, "No client to send message %u", query->type);
     }

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -37,6 +37,7 @@ static void create_node_instance_result_job(const char *machine_guid, const char
 
 struct aclk_sync_config_s {
     ND_THREAD *thread;
+    pid_t event_loop_tid; // atomic: the event loop publishes it, other threads compare against it
     uv_loop_t loop;
     uv_timer_t timer_req;
     uv_async_t async;
@@ -622,6 +623,12 @@ static void aclk_synchronization_event_loop(void *arg)
 {
     struct aclk_sync_config_s *config = arg;
     uv_thread_set_name_np("ACLKSYNC");
+
+    // published so code that can run on either this thread or a worker can tell which it is on -
+    // this thread must never block on a lock a host teardown may be holding while it waits here
+    // (destroy_aclk_config()). See aclk_sync_on_event_loop_thread().
+    __atomic_store_n(&config->event_loop_tid, gettid_cached(), __ATOMIC_RELEASE);
+
     init_cmd_pool(&config->cmd_pool, CMD_POOL_SIZE);
 
     worker_register("ACLKSYNC");
@@ -1251,6 +1258,19 @@ void aclk_push_alert_config(const char *node_id, const char *config_hash)
         freez(node_id_dup);
         freez(config_hash_dup);
     }
+}
+
+// Whether the caller is running on the ACLK sync event loop. That thread has one hard constraint the
+// workers do not: a host teardown can be blocked inside destroy_aclk_config() waiting for it while
+// holding rrd_wrlock(), so anything reachable from this thread that waits for rrd_rdlock() closes a
+// cycle. A worker blocking on it is safe - the event loop stays free to satisfy that wait.
+//
+// Returns false before the loop has published its id, which is the safe answer: nothing can be
+// waiting on a loop that has not started.
+bool aclk_sync_on_event_loop_thread(void)
+{
+    pid_t tid = __atomic_load_n(&aclk_sync_config.event_loop_tid, __ATOMIC_ACQUIRE);
+    return tid != 0 && tid == gettid_cached();
 }
 
 void aclk_execute_query(aclk_query_t *query)

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -70,23 +70,26 @@ typedef struct aclk_sync_cfg_t {
     SPINLOCK node_id_spinlock;
     char node_id[UUID_STR_LEN];
 
-    // What was last published for this config, so build_node_manifest() can drop an identical
-    // manifest. Atomic: written by whichever ACLK query worker published the message, read by the
-    // alert-push worker that builds the next one.
+    // The newest manifest SENT for this config, so build_node_manifest() can drop an identical one.
+    // Atomic: stored by the alert-push worker as it enqueues, cleared by whichever ACLK query worker
+    // finds that the message was dropped, read by the next build.
     //
-    // It is only ever written for a message that reached the mqtt layer. Recording it at build time
-    // would make a dropped manifest - no mqtt client left by the time the query ran, an offline
-    // client, a full mqtt buffer - suppress every later identical build for the rest of the
-    // session, which is a lost update the cloud cannot ask for. A drop re-arms the request instead
-    // (aclk_node_manifest_publish_result()).
+    // "Sent" and not "delivered", deliberately. It is stored when the manifest is handed to the ACLK
+    // queue, because that is the state a later build must compare against: publication is
+    // asynchronous, so a field holding only confirmed publications lags reality for as long as a
+    // message is in flight, and a build inside that window compares against a key the in-flight
+    // message is about to replace. A dropped message clears it again
+    // (aclk_node_manifest_publish_result()), so an unsent manifest never keeps suppressing later
+    // builds - that was the original defect here, and the clear is a CAS on the key it stored, so a
+    // newer manifest enqueued meanwhile keeps its own.
     //
-    // One value rather than a (session, hash) pair so the stamp is a single atomic store: a torn
-    // pair could match a build that neither half came from, and suppress a manifest that was never
-    // published. It folds the ACLK session into the content hash because publishing is still
-    // unacked - a new session re-publishes once, which is also what a cloud that lost the manifest
-    // needs. callocz() starts it at 0 and manifest_publication_key() never returns 0, so 0
-    // unambiguously means "nothing published yet" and the first manifest of a config always sends.
-    uint64_t node_manifest_sent_key; // manifest_publication_key() of the last published manifest
+    // One value rather than a (session, hash) pair so both the store and the clear are single atomic
+    // operations: a torn pair could match a build that neither half came from, and suppress a
+    // manifest that was never sent. It folds the ACLK session into the content hash because
+    // publishing is never acked - a new session re-sends once, which is also what a cloud that lost
+    // the manifest needs. callocz() starts it at 0 and manifest_publication_key() never returns 0, so
+    // 0 unambiguously means "nothing recorded" and the first manifest of a config always sends.
+    uint64_t node_manifest_sent_key; // manifest_publication_key() of the newest manifest enqueued
 } aclk_sync_cfg_t;
 
 static inline void aclk_node_id_copy(aclk_sync_cfg_t *aclk_host_config, char dst[UUID_STR_LEN])

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -209,6 +209,10 @@ static inline void aclk_alert_streaming_set(aclk_sync_cfg_t *aclk_host_config, b
 
 void create_aclk_config(RRDHOST *host, nd_uuid_t *host_uuid, nd_uuid_t *node_id);
 void destroy_aclk_config(RRDHOST *host);
+
+// true when the caller runs on the ACLK sync event loop, which must never wait for a lock a host
+// teardown may hold while blocked on that loop - see the definition
+bool aclk_sync_on_event_loop_thread(void);
 void aclk_synchronization_init(void);
 void aclk_synchronization_shutdown(void);
 void aclk_push_alert_config(const char *node_id, const char *config_hash);

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -84,7 +84,8 @@ typedef struct aclk_sync_cfg_t {
     // pair could match a build that neither half came from, and suppress a manifest that was never
     // published. It folds the ACLK session into the content hash because publishing is still
     // unacked - a new session re-publishes once, which is also what a cloud that lost the manifest
-    // needs. callocz() starts it at 0, so the first manifest of a config always sends.
+    // needs. callocz() starts it at 0 and manifest_publication_key() never returns 0, so 0
+    // unambiguously means "nothing published yet" and the first manifest of a config always sends.
     uint64_t node_manifest_sent_key; // manifest_publication_key() of the last published manifest
 } aclk_sync_cfg_t;
 

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -86,12 +86,16 @@ typedef struct aclk_sync_cfg_t {
     // rejected, the alert-push worker for a drop that happens inside the enqueue call, or the ACLK sync
     // event loop for a query it could not park and for the shutdown drain.
     //
-    // The split is what keeps every update a single atomic operation: the key never has to be written
-    // together with the token, so the pair cannot be observed half-updated. The token identifies an
-    // ENQUEUE, which the key cannot - identical content yields an identical key - so invalidating by
-    // token cannot clear a record a later manifest has taken over, whatever its content. A 0 token
-    // means nothing is outstanding, which is what callocz() leaves and what a drop restores, so the
-    // first manifest of a config always sends.
+    // The split is what keeps the CROSS-THREAD update a single atomic operation: a drop writes only
+    // the token, so it never has to update the pair. The pair IS written together - by the scan pass,
+    // as two stores - which leaves a window where the key is the new one and the token is still the
+    // previous one. Nothing reads the pair in that window: the scan pass is its only reader and is
+    // serialized against itself, and the drop path reads neither field, it only CASes the token.
+    //
+    // The token identifies an ENQUEUE, which the key cannot - identical content yields an identical
+    // key - so invalidating by token cannot clear a record a later manifest has taken over, whatever
+    // its content. A 0 token means nothing is outstanding, which is what callocz() leaves and what a
+    // drop restores, so the first manifest of a config always sends.
     //
     // The key folds the ACLK session into the content hash because publishing is never acked - a new
     // session re-sends once, which is also what a cloud that lost the manifest needs.

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -71,25 +71,32 @@ typedef struct aclk_sync_cfg_t {
     char node_id[UUID_STR_LEN];
 
     // The newest manifest SENT for this config, so build_node_manifest() can drop an identical one.
-    // Atomic: stored by the alert-push worker as it enqueues, cleared by whichever ACLK query worker
-    // finds that the message was dropped, read by the next build.
     //
-    // "Sent" and not "delivered", deliberately. It is stored when the manifest is handed to the ACLK
-    // queue, because that is the state a later build must compare against: publication is
-    // asynchronous, so a field holding only confirmed publications lags reality for as long as a
-    // message is in flight, and a build inside that window compares against a key the in-flight
-    // message is about to replace. A dropped message clears it again
+    // "Sent" and not "delivered", deliberately. Both fields are written when the manifest is handed to
+    // the ACLK queue, because that is the state a later build must compare against: publication is
+    // asynchronous, so a record holding only confirmed publications lags reality for as long as a
+    // message is in flight, and a build inside that window compares against content the in-flight
+    // message is about to replace. A dropped message invalidates the record instead
     // (aclk_node_manifest_publish_result()), so an unsent manifest never keeps suppressing later
-    // builds - that was the original defect here, and the clear is a CAS on the key it stored, so a
-    // newer manifest enqueued meanwhile keeps its own.
+    // builds - that was the original defect here.
     //
-    // One value rather than a (session, hash) pair so both the store and the clear are single atomic
-    // operations: a torn pair could match a build that neither half came from, and suppress a
-    // manifest that was never sent. It folds the ACLK session into the content hash because
-    // publishing is never acked - a new session re-sends once, which is also what a cloud that lost
-    // the manifest needs. callocz() starts it at 0 and manifest_publication_key() never returns 0, so
-    // 0 unambiguously means "nothing recorded" and the first manifest of a config always sends.
-    uint64_t node_manifest_sent_key; // manifest_publication_key() of the newest manifest enqueued
+    // Atomic, because the writers are on different threads. Both fields are STORED only by the scan
+    // pass in build_node_manifest() (the alert-push worker, one pass at a time), while the token alone
+    // is CLEARED by whichever thread reports a drop - an ACLK query worker for anything the mqtt layer
+    // rejected, the alert-push worker for a drop that happens inside the enqueue call, or the ACLK sync
+    // event loop for a query it could not park and for the shutdown drain.
+    //
+    // The split is what keeps every update a single atomic operation: the key never has to be written
+    // together with the token, so the pair cannot be observed half-updated. The token identifies an
+    // ENQUEUE, which the key cannot - identical content yields an identical key - so invalidating by
+    // token cannot clear a record a later manifest has taken over, whatever its content. A 0 token
+    // means nothing is outstanding, which is what callocz() leaves and what a drop restores, so the
+    // first manifest of a config always sends.
+    //
+    // The key folds the ACLK session into the content hash because publishing is never acked - a new
+    // session re-sends once, which is also what a cloud that lost the manifest needs.
+    uint64_t node_manifest_sent_key;   // manifest_publication_key() of the newest manifest enqueued
+    uint64_t node_manifest_sent_token; // its per-enqueue token; 0 when nothing is outstanding
 } aclk_sync_cfg_t;
 
 static inline void aclk_node_id_copy(aclk_sync_cfg_t *aclk_host_config, char dst[UUID_STR_LEN])

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -71,18 +71,21 @@ typedef struct aclk_sync_cfg_t {
     char node_id[UUID_STR_LEN];
 
     // What was last published for this config, so build_node_manifest() can drop an identical
-    // manifest. Written only by the alert-push worker (the single build_node_manifest() caller,
-    // serialized by alert_push_running), read nowhere else - no atomics needed.
+    // manifest. Atomic: written by whichever ACLK query worker published the message, read by the
+    // alert-push worker that builds the next one.
     //
-    // Scoped to the ACLK session it was published in, because publishing is fire-and-forget: the
-    // message can still be dropped after the send call - no mqtt client left by the time the query
-    // executes, or shutdown reached before it ran - and nothing acks it. A new session therefore
-    // re-publishes once, which is also what a cloud that lost the manifest needs.
+    // It is only ever written for a message that reached the mqtt layer. Recording it at build time
+    // would make a dropped manifest - no mqtt client left by the time the query ran, an offline
+    // client, a full mqtt buffer - suppress every later identical build for the rest of the
+    // session, which is a lost update the cloud cannot ask for. A drop re-arms the request instead
+    // (aclk_node_manifest_publish_result()).
     //
-    // callocz() starts the session at 0 and aclk_session_load() is never 0 here (connecting stores
-    // a timestamp before the scan can run at all), so the first manifest of a config always sends.
-    usec_t node_manifest_sent_session; // aclk_session_load() when the last manifest was published
-    uint64_t node_manifest_sent_hash;  // manifest_dict_hash() of the last published manifest
+    // One value rather than a (session, hash) pair so the stamp is a single atomic store: a torn
+    // pair could match a build that neither half came from, and suppress a manifest that was never
+    // published. It folds the ACLK session into the content hash because publishing is still
+    // unacked - a new session re-publishes once, which is also what a cloud that lost the manifest
+    // needs. callocz() starts it at 0, so the first manifest of a config always sends.
+    uint64_t node_manifest_sent_key; // manifest_publication_key() of the last published manifest
 } aclk_sync_cfg_t;
 
 static inline void aclk_node_id_copy(aclk_sync_cfg_t *aclk_host_config, char dst[UUID_STR_LEN])

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -58,6 +58,16 @@ static bool aclk_node_id_snapshot(aclk_sync_cfg_t *aclk_host_config, char dst[UU
     return uuid_parse(dst, parsed) == 0 && !uuid_is_null(parsed);
 }
 
+// Hands out the per-enqueue token that identifies one manifest publication. Monotonic and never
+// reused, so it identifies an ENQUEUE, which the content key cannot: identical content produces an
+// identical key, and content that is published, changed, and changed back records the same key twice.
+// Never returns 0, which node_manifest_sent_token uses to mean "nothing outstanding".
+static uint64_t manifest_publication_token_next(void)
+{
+    static uint64_t seq = 0;
+    return __atomic_add_fetch(&seq, 1, __ATOMIC_RELAXED);
+}
+
 // Undoes the record build_node_manifest() made for a manifest that never went out. Runs under the
 // rrd read lock - see rrdhost_apply_by_machine_guid() - so everything it does is one atomic CAS and
 // one atomic arm, which is all it may do while that lock is held.
@@ -69,24 +79,19 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
     if (!aclk_host_config)
         return;
 
-    // Clear the record only while it still holds the key this publication carried. A manifest
-    // enqueued after this one records a different key and so survives, which is what makes the
-    // outcomes order-insensitive: publications for one host can be in flight together and complete
-    // in any order without a later one losing its record to an earlier drop.
+    // Invalidate the record only while it is still THIS enqueue's, which is what the token is for:
+    // the CAS fails if a later manifest has been enqueued since, whatever its content, so publications
+    // for one host can be in flight together and complete in any order without a later one losing its
+    // record to an earlier drop - including when the later one carries identical content and therefore
+    // an identical key.
     //
-    // The key identifies CONTENT, not a particular enqueue, so this is not a per-enqueue token: if
-    // the content is published, then changed, then changed back, all while the first publication is
-    // still in flight, the later enqueue records the same key and a drop of that first one clears it.
-    // The cost is bounded and is the direction this design accepts everywhere else - a record cleared
-    // to 0 can only cause another publish, never a suppression, so the next build re-sends unchanged
-    // content once and stops. Making the clear exact would mean carrying a per-enqueue token
-    // alongside the key, and a (token, key) pair cannot be stored or cleared in one atomic operation
-    // - it needs a lock on a path that is lock-free today, and packing a generation into this word
-    // instead would shrink the content hash, trading a redundant publish for a worse collision risk
-    // in the direction that loses updates.
-    uint64_t expected = publication->key;
-    (void)__atomic_compare_exchange_n(
-        &aclk_host_config->node_manifest_sent_key, &expected, 0, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+    // Clearing the token, not the key, is what makes this a single atomic operation. The key stays as
+    // it was; a 0 token is what stops it from suppressing anything (see build_node_manifest()), so the
+    // pair never has to be written together and cannot be observed half-updated.
+    uint64_t expected = publication->token;
+    if (!__atomic_compare_exchange_n(
+            &aclk_host_config->node_manifest_sent_token, &expected, 0, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED))
+        return; // a later manifest owns the record - it is the one the cloud needs, and it will report itself
 
     // Re-arm with now, not with the deadline this send was claimed from: a failure that repeats for
     // the same payload (a manifest the server refuses as too big) would otherwise come due on every
@@ -196,8 +201,8 @@ static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config
     // clears this record instead (aclk_node_manifest_publish_result()), so nothing stays suppressed on
     // the strength of a manifest that never went out.
     //
-    // A stored 0 means nothing is recorded for this config, and manifest_publication_key() never
-    // returns 0, so that comparison is unambiguous without a separate guard.
+    // A 0 token means nothing is outstanding for this config - it has published nothing yet, or its
+    // last manifest was dropped and invalidated - so the key beside it must not suppress anything.
     //
     // Deliberately NOT suppressed: the first manifest of a config, the first manifest of every ACLK
     // session (the session is folded into the key, because a publication is still never acked), and
@@ -205,16 +210,22 @@ static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config
     // not an absence of information.
     uint64_t key = manifest_publication_key(
         manifest_dict_hash(manifest.functions, node_id, manifest.claim_id), aclk_session_load());
-    bool suppressed = __atomic_load_n(&aclk_host_config->node_manifest_sent_key, __ATOMIC_ACQUIRE) == key;
+    bool suppressed = __atomic_load_n(&aclk_host_config->node_manifest_sent_token, __ATOMIC_ACQUIRE) != 0 &&
+                      __atomic_load_n(&aclk_host_config->node_manifest_sent_key, __ATOMIC_ACQUIRE) == key;
 
     if (!suppressed) {
-        // Record BEFORE enqueueing, never after: the drop path clears this field with a CAS on this
-        // exact key, and a query that is dropped synchronously (a payload that fails to generate)
-        // completes inside the call below. Storing afterwards would let that CAS run first, find the
-        // old value, change nothing - and then this store would leave the dropped manifest recorded
-        // as sent.
+        // Record BEFORE enqueueing, never after: a query can be dropped SYNCHRONOUSLY inside the call
+        // below (a payload that fails to generate), and its invalidating CAS would then run against a
+        // token this build has not stored yet - it would fail, and the store that followed would leave
+        // the dropped manifest recorded as outstanding.
+        //
+        // Key first, then token: the token is what licenses the key to suppress, so publishing it last
+        // means no reader can act on a key that is not yet in place. Both are written only here, by the
+        // one serialized scan pass; the drop path only ever clears the token.
+        uint64_t token = manifest_publication_token_next();
         __atomic_store_n(&aclk_host_config->node_manifest_sent_key, key, __ATOMIC_RELEASE);
-        aclk_update_node_instance_manifest(&manifest, host->machine_guid, key);
+        __atomic_store_n(&aclk_host_config->node_manifest_sent_token, token, __ATOMIC_RELEASE);
+        aclk_update_node_instance_manifest(&manifest, host->machine_guid, key, token);
     }
 
     dictionary_destroy(manifest.functions);

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -58,11 +58,63 @@ static bool aclk_node_id_snapshot(aclk_sync_cfg_t *aclk_host_config, char dst[UU
     return uuid_parse(dst, parsed) == 0 && !uuid_is_null(parsed);
 }
 
+// Runs under rrd_rdlock() - see rrdhost_apply_by_machine_guid(). Everything it does is an atomic
+// load, store, or CAS, which is all it may do while that lock is held.
+static void manifest_publication_apply(RRDHOST *host, void *data)
+{
+    const struct aclk_manifest_publication *publication = data;
+
+    aclk_sync_cfg_t *aclk_host_config = __atomic_load_n(&host->aclk_host_config, __ATOMIC_ACQUIRE);
+    if (!aclk_host_config)
+        return;
+
+    if (publication->published) {
+        __atomic_store_n(&aclk_host_config->node_manifest_sent_key, publication->key, __ATOMIC_RELEASE);
+        return;
+    }
+
+    // Dropped on the way out, so the cloud never saw this manifest and nothing may be recorded for
+    // it. Re-arm with now, not with the deadline this send was claimed from: a failure that repeats
+    // for the same payload (a manifest the server refuses as too big) would otherwise come due on
+    // every pass and take a pacer slot each time, while arming with now retries one coalescing
+    // window later. aclk_send_timestamp_arm() only ever lowers a pending deadline, so a request
+    // armed meanwhile keeps its earlier one.
+    aclk_send_timestamp_arm(&aclk_host_config->node_manifest_send_time, now_realtime_sec());
+}
+
+// Applies the outcome of a publication to the host config. Runs on the ACLK query worker that
+// executed the send, or on whichever thread dropped the query before it got that far.
+//
+// The host is resolved rather than carried as a pointer, because the host and its config can be
+// freed between the enqueue and the outcome; and it is resolved through
+// rrdhost_apply_by_machine_guid() rather than any find-then-dereference helper, because only the
+// former holds the host allocated while the callback runs.
+//
+// Resolved by machine_guid, NOT by the node_id this manifest was keyed under at the cloud, even
+// though the node_id is what identifies the message. host->node_id and the ACLK config's node_id are
+// allowed to disagree - command-nodeid.c assigns host->node_id from the parent without touching the
+// config, and set_host_node_id() documents the divergence - so a node_id lookup can miss the host
+// whose config must be written, or find a different one. Missing it would leave the send neither
+// recorded nor re-armed; finding the wrong host would record a manifest that host never published,
+// which is exactly the lost update this whole path exists to prevent. machine_guid is immutable for
+// the host's lifetime, and is also rrdhost_root_index's key, so the lookup is exact.
+//
+// The two drop sites that run before the query is handed off - a payload that failed to generate,
+// and a sync queue that is not accepting - reach this from inside
+// aclk_check_node_info_collectors_and_manifest()'s walk, which holds no rrd lock in its body:
+// build_node_manifest() releases rrd_rdlock() before enqueueing.
+void aclk_node_manifest_publish_result(const struct aclk_manifest_publication *publication)
+{
+    (void)rrdhost_apply_by_machine_guid(publication->machine_guid, manifest_publication_apply, (void *)publication);
+}
+
 // node_id is the caller's validated snapshot, not the shared buffer - see aclk_node_id_snapshot().
 // aclk_host_config is the caller's, already loaded and non-NULL for this host.
 //
-// Returns whether a manifest was actually published, so the caller's per-scan budget is spent on
-// messages rather than on suppressed builds - see MAX_NODE_MANIFESTS_PER_SCAN.
+// Returns whether a manifest was enqueued for publication, so the caller's per-scan budget is spent
+// on messages rather than on suppressed builds - see MAX_NODE_MANIFESTS_PER_SCAN. The budget paces
+// what this pass hands to the mqtt layer, so it is charged here rather than on the publication that
+// follows asynchronously.
 static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config, char *node_id)
 {
     struct update_node_instance_manifest manifest;
@@ -89,20 +141,22 @@ static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config
     // chokepoint compares content instead. The hash covers everything generate_..._message()
     // transmits, including the node_id it is keyed under at the cloud, but not updated_at.
     //
+    // The key is recorded by the publication itself, not here: this function only enqueues, and a
+    // message that is dropped below it must not suppress anything (see node_manifest_sent_key and
+    // aclk_node_manifest_publish_result()). A key of 0 means nothing has been published for this
+    // config yet, so a content that happens to hash to 0 publishes once more than needed - the
+    // direction that costs a message rather than losing one.
+    //
     // Deliberately NOT suppressed: the first manifest of a config, the first manifest of every ACLK
-    // session (see node_manifest_sent_session - a send is only an attempt, it is never acked), and
+    // session (the session is folded into the key, because a publication is still never acked), and
     // empty manifests - an empty list is meaningful to the cloud ("this node has no functions"),
     // not an absence of information.
-    usec_t session = aclk_session_load();
-    uint64_t hash = manifest_dict_hash(manifest.functions, node_id, manifest.claim_id);
-    bool suppressed = aclk_host_config->node_manifest_sent_session == session &&
-                      aclk_host_config->node_manifest_sent_hash == hash;
+    uint64_t key = manifest_publication_key(
+        manifest_dict_hash(manifest.functions, node_id, manifest.claim_id), aclk_session_load());
+    bool suppressed = key && __atomic_load_n(&aclk_host_config->node_manifest_sent_key, __ATOMIC_ACQUIRE) == key;
 
-    if (!suppressed) {
-        aclk_update_node_instance_manifest(&manifest);
-        aclk_host_config->node_manifest_sent_session = session;
-        aclk_host_config->node_manifest_sent_hash = hash;
-    }
+    if (!suppressed)
+        aclk_update_node_instance_manifest(&manifest, host->machine_guid, key);
 
     dictionary_destroy(manifest.functions);
 
@@ -247,8 +301,8 @@ static inline void hostname_snapshot_update(STRING **snapshot, RRDHOST *host)
 // sqlite_aclk_node.h so it can be unit tested; see MANIFEST_PACER there for why it exists.
 //
 // Only the alert-push worker reaches this, serialized by alert_push_running, and libuv's threadpool
-// hand-off gives each pass a happens-before edge on the previous one - the same reason
-// node_manifest_sent_hash needs no synchronization.
+// hand-off gives each pass a happens-before edge on the previous one, so the pacer itself needs no
+// synchronization. node_manifest_sent_key does, because the ACLK query workers write it.
 static MANIFEST_PACER manifest_pacer = { 0 };
 
 void aclk_check_node_info_collectors_and_manifest(void)

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -58,8 +58,9 @@ static bool aclk_node_id_snapshot(aclk_sync_cfg_t *aclk_host_config, char dst[UU
     return uuid_parse(dst, parsed) == 0 && !uuid_is_null(parsed);
 }
 
-// Runs under the rrd read lock - see rrdhost_apply_by_machine_guid_trylock(). Everything it does is
-// an atomic load, store, or CAS, which is all it may do while that lock is held.
+// Undoes the record build_node_manifest() made for a manifest that never went out. Runs under the
+// rrd read lock - see rrdhost_apply_by_machine_guid_trylock() - so everything it does is one atomic
+// CAS and one atomic arm, which is all it may do while that lock is held.
 static void manifest_publication_apply(RRDHOST *host, void *data)
 {
     const struct aclk_manifest_publication *publication = data;
@@ -68,22 +69,33 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
     if (!aclk_host_config)
         return;
 
-    if (publication->published) {
-        __atomic_store_n(&aclk_host_config->node_manifest_sent_key, publication->key, __ATOMIC_RELEASE);
-        return;
-    }
+    // Clear the record only while it is still THIS publication's. A manifest enqueued after it
+    // supersedes it - the cloud needs that newer content, not this dropped older one - so its key
+    // must survive. The CAS is what makes the outcomes order-insensitive: publications for one host
+    // can be in flight together and complete in any order, and whichever key is current is by
+    // definition the newest one enqueued.
+    uint64_t expected = publication->key;
+    (void)__atomic_compare_exchange_n(
+        &aclk_host_config->node_manifest_sent_key, &expected, 0, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 
-    // Dropped on the way out, so the cloud never saw this manifest and nothing may be recorded for
-    // it. Re-arm with now, not with the deadline this send was claimed from: a failure that repeats
-    // for the same payload (a manifest the server refuses as too big) would otherwise come due on
-    // every pass and take a pacer slot each time, while arming with now retries one coalescing
-    // window later. aclk_send_timestamp_arm() only ever lowers a pending deadline, so a request
-    // armed meanwhile keeps its earlier one.
+    // Re-arm with now, not with the deadline this send was claimed from: a failure that repeats for
+    // the same payload (a manifest the server refuses as too big) would otherwise come due on every
+    // pass and take a pacer slot each time, while arming with now retries one coalescing window
+    // later. aclk_send_timestamp_arm() only ever lowers a pending deadline, so a request armed
+    // meanwhile keeps its earlier one.
     aclk_send_timestamp_arm(&aclk_host_config->node_manifest_send_time, now_realtime_sec());
 }
 
-// Applies the outcome of a publication to the host config. Runs on the ACLK query worker that
-// executed the send, or on whichever thread dropped the query before it got that far.
+// Applies the outcome of a publication. Runs on the ACLK query worker that executed the send, or on
+// whichever thread dropped the query before it got that far.
+//
+// Only a DROP does anything. A publication that reached the mqtt layer is already accounted for: the
+// key was recorded when the manifest was enqueued, which is what the suppression in
+// build_node_manifest() must compare against. Recording it here instead would compare builds against
+// the last CONFIRMED manifest rather than the last SENT one, and those differ for as long as a
+// publication is in flight - long enough for a content revert inside that window to be suppressed
+// against a key the in-flight message is about to replace, leaving the cloud with content the node no
+// longer has and nothing armed to correct it.
 //
 // The host is resolved rather than carried as a pointer, because the host and its config can be
 // freed between the enqueue and the outcome; and it is resolved through
@@ -93,18 +105,19 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
 // That helper never blocks, and this path must not need it to. One of the drop sites below runs on
 // the ACLK sync event loop, and a host teardown can be holding rrd_wrlock() while blocked on that
 // same loop inside destroy_aclk_config() - so waiting for the read lock here would wedge the agent.
-// Losing that race is harmless in both directions: nothing is recorded, so no manifest is ever
-// suppressed unpublished, and the request is simply left for the next arming event. Correctness
-// depends only on the key never being recorded for a message that did not go out.
+// Losing that race leaves the dropped manifest's key recorded as if it had been sent, so that content
+// is not re-sent until it changes again or the ACLK session does - the original defect, now narrowed
+// to a dropped publication that also loses this race. The dominant drop causes are an offline or
+// disconnecting mqtt client, and those bring a new session with them, which changes every key anyway.
 //
 // Resolved by machine_guid, NOT by the node_id this manifest was keyed under at the cloud, even
 // though the node_id is what identifies the message. host->node_id and the ACLK config's node_id are
 // allowed to disagree - command-nodeid.c assigns host->node_id from the parent without touching the
 // config, and set_host_node_id() documents the divergence - so a node_id lookup can miss the host
-// whose config must be written, or find a different one. Missing it would leave the send neither
-// recorded nor re-armed; finding the wrong host would record a manifest that host never published,
-// which is exactly the lost update this whole path exists to prevent. machine_guid is immutable for
-// the host's lifetime, and is also rrdhost_root_index's key, so the lookup is exact.
+// whose config must be written, or find a different one. Missing it would leave a dropped manifest
+// recorded as sent; finding the wrong host would clear a key that host is still relying on, forcing a
+// redundant publish. machine_guid is immutable for the host's lifetime, and is also
+// rrdhost_root_index's key, so the lookup is exact.
 //
 // The two drop sites that run before the query is handed off - a payload that failed to generate,
 // and a sync queue that is not accepting - reach this from inside
@@ -112,6 +125,9 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
 // build_node_manifest() releases rrd_rdlock() before enqueueing.
 void aclk_node_manifest_publish_result(const struct aclk_manifest_publication *publication)
 {
+    if (publication->published)
+        return;
+
     (void)rrdhost_apply_by_machine_guid_trylock(
         publication->machine_guid, manifest_publication_apply, (void *)publication);
 }
@@ -155,11 +171,16 @@ static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config
     // chokepoint compares content instead. The hash covers everything generate_..._message()
     // transmits, including the node_id it is keyed under at the cloud, but not updated_at.
     //
-    // The key is recorded by the publication itself, not here: this function only enqueues, and a
-    // message that is dropped below it must not suppress anything (see node_manifest_sent_key and
-    // aclk_node_manifest_publish_result()). A stored 0 means nothing has been published for this
-    // config yet, and manifest_publication_key() never returns 0, so that comparison is unambiguous
-    // without a separate guard.
+    // The comparison is against the newest manifest SENT, not the newest confirmed delivered, which
+    // is why the key is recorded here rather than by the publication. A publication is asynchronous,
+    // so "confirmed" lags "sent" by however long the query takes; comparing against it would let a
+    // content revert inside that window be suppressed against a key the in-flight message is about to
+    // replace, leaving the cloud with content the node no longer has. A message that is then dropped
+    // clears this record instead (aclk_node_manifest_publish_result()), so nothing stays suppressed on
+    // the strength of a manifest that never went out.
+    //
+    // A stored 0 means nothing is recorded for this config, and manifest_publication_key() never
+    // returns 0, so that comparison is unambiguous without a separate guard.
     //
     // Deliberately NOT suppressed: the first manifest of a config, the first manifest of every ACLK
     // session (the session is folded into the key, because a publication is still never acked), and
@@ -169,8 +190,15 @@ static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config
         manifest_dict_hash(manifest.functions, node_id, manifest.claim_id), aclk_session_load());
     bool suppressed = __atomic_load_n(&aclk_host_config->node_manifest_sent_key, __ATOMIC_ACQUIRE) == key;
 
-    if (!suppressed)
+    if (!suppressed) {
+        // Record BEFORE enqueueing, never after: the drop path clears this field with a CAS on this
+        // exact key, and a query that is dropped synchronously (a payload that fails to generate)
+        // completes inside the call below. Storing afterwards would let that CAS run first, find the
+        // old value, change nothing - and then this store would leave the dropped manifest recorded
+        // as sent.
+        __atomic_store_n(&aclk_host_config->node_manifest_sent_key, key, __ATOMIC_RELEASE);
         aclk_update_node_instance_manifest(&manifest, host->machine_guid, key);
+    }
 
     dictionary_destroy(manifest.functions);
 
@@ -316,7 +344,8 @@ static inline void hostname_snapshot_update(STRING **snapshot, RRDHOST *host)
 //
 // Only the alert-push worker reaches this, serialized by alert_push_running, and libuv's threadpool
 // hand-off gives each pass a happens-before edge on the previous one, so the pacer itself needs no
-// synchronization. node_manifest_sent_key does, because the ACLK query workers write it.
+// synchronization. node_manifest_sent_key does: this worker stores it, and the ACLK query workers
+// clear it when a manifest turns out to have been dropped.
 static MANIFEST_PACER manifest_pacer = { 0 };
 
 void aclk_check_node_info_collectors_and_manifest(void)

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -136,9 +136,10 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
 // allowed to disagree - command-nodeid.c assigns host->node_id from the parent without touching the
 // config, and set_host_node_id() documents the divergence - so a node_id lookup can miss the host
 // whose config must be written, or find a different one. Missing it would leave a dropped manifest
-// recorded as sent; finding the wrong host would clear a key that host is still relying on, forcing a
-// redundant publish. machine_guid is immutable for the host's lifetime, and is also
-// rrdhost_root_index's key, so the lookup is exact.
+// recorded as sent; finding the wrong host would invalidate a record that host is still relying on -
+// harmless beyond a redundant publish, since only its token can be cleared and only when the CAS
+// matches. machine_guid is immutable for the host's lifetime, and is also rrdhost_root_index's key,
+// so the lookup is exact.
 //
 // The two drop sites that run before the query is handed off - a payload that failed to generate,
 // and a sync queue that is not accepting - reach this from inside
@@ -372,8 +373,11 @@ static inline void hostname_snapshot_update(STRING **snapshot, RRDHOST *host)
 //
 // Only the alert-push worker reaches this, serialized by alert_push_running, and libuv's threadpool
 // hand-off gives each pass a happens-before edge on the previous one, so the pacer itself needs no
-// synchronization. node_manifest_sent_key does: this worker stores it, and the ACLK query workers
-// clear it when a manifest turns out to have been dropped.
+// synchronization. The publication record does: this worker stores both node_manifest_sent_key and
+// node_manifest_sent_token, and the token alone is cleared - by whichever thread reports that a
+// manifest was dropped, which is an ACLK query worker for anything the mqtt layer rejected, this
+// same worker for a drop inside the enqueue call, or the ACLK sync event loop for a query it could
+// not park and for the shutdown drain.
 static MANIFEST_PACER manifest_pacer = { 0 };
 
 void aclk_check_node_info_collectors_and_manifest(void)

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -59,8 +59,8 @@ static bool aclk_node_id_snapshot(aclk_sync_cfg_t *aclk_host_config, char dst[UU
 }
 
 // Undoes the record build_node_manifest() made for a manifest that never went out. Runs under the
-// rrd read lock - see rrdhost_apply_by_machine_guid_trylock() - so everything it does is one atomic
-// CAS and one atomic arm, which is all it may do while that lock is held.
+// rrd read lock - see rrdhost_apply_by_machine_guid() - so everything it does is one atomic CAS and
+// one atomic arm, which is all it may do while that lock is held.
 static void manifest_publication_apply(RRDHOST *host, void *data)
 {
     const struct aclk_manifest_publication *publication = data;
@@ -69,11 +69,21 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
     if (!aclk_host_config)
         return;
 
-    // Clear the record only while it is still THIS publication's. A manifest enqueued after it
-    // supersedes it - the cloud needs that newer content, not this dropped older one - so its key
-    // must survive. The CAS is what makes the outcomes order-insensitive: publications for one host
-    // can be in flight together and complete in any order, and whichever key is current is by
-    // definition the newest one enqueued.
+    // Clear the record only while it still holds the key this publication carried. A manifest
+    // enqueued after this one records a different key and so survives, which is what makes the
+    // outcomes order-insensitive: publications for one host can be in flight together and complete
+    // in any order without a later one losing its record to an earlier drop.
+    //
+    // The key identifies CONTENT, not a particular enqueue, so this is not a per-enqueue token: if
+    // the content is published, then changed, then changed back, all while the first publication is
+    // still in flight, the later enqueue records the same key and a drop of that first one clears it.
+    // The cost is bounded and is the direction this design accepts everywhere else - a record cleared
+    // to 0 can only cause another publish, never a suppression, so the next build re-sends unchanged
+    // content once and stops. Making the clear exact would mean carrying a per-enqueue token
+    // alongside the key, and a (token, key) pair cannot be stored or cleared in one atomic operation
+    // - it needs a lock on a path that is lock-free today, and packing a generation into this word
+    // instead would shrink the content hash, trading a redundant publish for a worse collision risk
+    // in the direction that loses updates.
     uint64_t expected = publication->key;
     (void)__atomic_compare_exchange_n(
         &aclk_host_config->node_manifest_sent_key, &expected, 0, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
@@ -99,16 +109,22 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
 //
 // The host is resolved rather than carried as a pointer, because the host and its config can be
 // freed between the enqueue and the outcome; and it is resolved through
-// rrdhost_apply_by_machine_guid_trylock() rather than any find-then-dereference helper, because only
+// rrdhost_apply_by_machine_guid() rather than any find-then-dereference helper, because only
 // the former holds the host allocated while the callback runs.
 //
-// That helper never blocks, and this path must not need it to. One of the drop sites below runs on
-// the ACLK sync event loop, and a host teardown can be holding rrd_wrlock() while blocked on that
-// same loop inside destroy_aclk_config() - so waiting for the read lock here would wedge the agent.
-// Losing that race leaves the dropped manifest's key recorded as if it had been sent, so that content
-// is not re-sent until it changes again or the ACLK session does - the original defect, now narrowed
-// to a dropped publication that also loses this race. The dominant drop causes are an offline or
-// disconnecting mqtt client, and those bring a new session with them, which changes every key anyway.
+// Whether it may wait for the read lock depends on the thread, so it is decided per call. Every
+// mqtt-level drop - an offline or disconnecting client, a full mqtt buffer, a payload the server
+// refuses - is reported from an ACLK query worker, and a payload that fails to generate is reported
+// from the alert-push worker; both may block, so for them the clear below always happens. Only the
+// event loop must not wait: a host teardown can be blocked on it inside destroy_aclk_config() while
+// holding rrd_wrlock(), so waiting there would wedge the agent. It reaches this path when it drops a
+// query it could not park (a Judy allocation failure) or when it drains queries at shutdown.
+//
+// On the event loop, then, a lost race leaves the dropped manifest's key recorded as if it had been
+// sent, so that content is not re-sent until it changes again or the ACLK session does. That is the
+// original defect of this SOW, reduced to: an allocation failure that drops a manifest, on the one
+// thread that cannot wait, while a teardown happens to hold rrd_wrlock(). At shutdown it is moot -
+// the next start is a new session, and every key carries the session.
 //
 // Resolved by machine_guid, NOT by the node_id this manifest was keyed under at the cloud, even
 // though the node_id is what identifies the message. host->node_id and the ACLK config's node_id are
@@ -128,8 +144,9 @@ void aclk_node_manifest_publish_result(const struct aclk_manifest_publication *p
     if (publication->published)
         return;
 
-    (void)rrdhost_apply_by_machine_guid_trylock(
-        publication->machine_guid, manifest_publication_apply, (void *)publication);
+    (void)rrdhost_apply_by_machine_guid(
+        publication->machine_guid, manifest_publication_apply, (void *)publication,
+        !aclk_sync_on_event_loop_thread());
 }
 
 // node_id is the caller's validated snapshot, not the shared buffer - see aclk_node_id_snapshot().

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -58,8 +58,8 @@ static bool aclk_node_id_snapshot(aclk_sync_cfg_t *aclk_host_config, char dst[UU
     return uuid_parse(dst, parsed) == 0 && !uuid_is_null(parsed);
 }
 
-// Runs under rrd_rdlock() - see rrdhost_apply_by_machine_guid(). Everything it does is an atomic
-// load, store, or CAS, which is all it may do while that lock is held.
+// Runs under the rrd read lock - see rrdhost_apply_by_machine_guid_trylock(). Everything it does is
+// an atomic load, store, or CAS, which is all it may do while that lock is held.
 static void manifest_publication_apply(RRDHOST *host, void *data)
 {
     const struct aclk_manifest_publication *publication = data;
@@ -87,8 +87,15 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
 //
 // The host is resolved rather than carried as a pointer, because the host and its config can be
 // freed between the enqueue and the outcome; and it is resolved through
-// rrdhost_apply_by_machine_guid() rather than any find-then-dereference helper, because only the
-// former holds the host allocated while the callback runs.
+// rrdhost_apply_by_machine_guid_trylock() rather than any find-then-dereference helper, because only
+// the former holds the host allocated while the callback runs.
+//
+// That helper never blocks, and this path must not need it to. One of the drop sites below runs on
+// the ACLK sync event loop, and a host teardown can be holding rrd_wrlock() while blocked on that
+// same loop inside destroy_aclk_config() - so waiting for the read lock here would wedge the agent.
+// Losing that race is harmless in both directions: nothing is recorded, so no manifest is ever
+// suppressed unpublished, and the request is simply left for the next arming event. Correctness
+// depends only on the key never being recorded for a message that did not go out.
 //
 // Resolved by machine_guid, NOT by the node_id this manifest was keyed under at the cloud, even
 // though the node_id is what identifies the message. host->node_id and the ACLK config's node_id are
@@ -105,16 +112,23 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
 // build_node_manifest() releases rrd_rdlock() before enqueueing.
 void aclk_node_manifest_publish_result(const struct aclk_manifest_publication *publication)
 {
-    (void)rrdhost_apply_by_machine_guid(publication->machine_guid, manifest_publication_apply, (void *)publication);
+    (void)rrdhost_apply_by_machine_guid_trylock(
+        publication->machine_guid, manifest_publication_apply, (void *)publication);
 }
 
 // node_id is the caller's validated snapshot, not the shared buffer - see aclk_node_id_snapshot().
 // aclk_host_config is the caller's, already loaded and non-NULL for this host.
 //
 // Returns whether a manifest was enqueued for publication, so the caller's per-scan budget is spent
-// on messages rather than on suppressed builds - see MAX_NODE_MANIFESTS_PER_SCAN. The budget paces
-// what this pass hands to the mqtt layer, so it is charged here rather than on the publication that
-// follows asynchronously.
+// on messages rather than on suppressed builds - see MAX_NODE_MANIFESTS_PER_SCAN.
+//
+// The budget counts what this pass ENQUEUES, not what reaches the mqtt layer, because the publication
+// completes asynchronously and the pass cannot wait for it. A message dropped between here and the
+// mqtt layer therefore still spends a slot. That is deliberate: the alternative is reporting the
+// queue-accept status back through aclk_execute_query() to every caller of QUEUE_IF_PAYLOAD_PRESENT,
+// and the only paths it would recover a slot on are ACLK sync not accepting work and a payload that
+// failed to generate - both of which cost at most this pass's remaining slots, and both of which
+// re-arm, so the effect is under-scheduling by one window, never a lost manifest.
 static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config, char *node_id)
 {
     struct update_node_instance_manifest manifest;
@@ -143,9 +157,9 @@ static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config
     //
     // The key is recorded by the publication itself, not here: this function only enqueues, and a
     // message that is dropped below it must not suppress anything (see node_manifest_sent_key and
-    // aclk_node_manifest_publish_result()). A key of 0 means nothing has been published for this
-    // config yet, so a content that happens to hash to 0 publishes once more than needed - the
-    // direction that costs a message rather than losing one.
+    // aclk_node_manifest_publish_result()). A stored 0 means nothing has been published for this
+    // config yet, and manifest_publication_key() never returns 0, so that comparison is unambiguous
+    // without a separate guard.
     //
     // Deliberately NOT suppressed: the first manifest of a config, the first manifest of every ACLK
     // session (the session is folded into the key, because a publication is still never acked), and
@@ -153,7 +167,7 @@ static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config
     // not an absence of information.
     uint64_t key = manifest_publication_key(
         manifest_dict_hash(manifest.functions, node_id, manifest.claim_id), aclk_session_load());
-    bool suppressed = key && __atomic_load_n(&aclk_host_config->node_manifest_sent_key, __ATOMIC_ACQUIRE) == key;
+    bool suppressed = __atomic_load_n(&aclk_host_config->node_manifest_sent_key, __ATOMIC_ACQUIRE) == key;
 
     if (!suppressed)
         aclk_update_node_instance_manifest(&manifest, host->machine_guid, key);
@@ -429,9 +443,11 @@ void aclk_check_node_info_collectors_and_manifest(void)
 
         // The budget and the cutoff are both tested before the claim, so a host denied a slot keeps
         // its armed request instead of having it consumed and dropped. The budget is charged only
-        // when a message really went out, so a run of suppressed (unchanged) manifests cannot
+        // when a message was really enqueued, so a run of suppressed (unchanged) manifests cannot
         // exhaust it for the hosts behind them - but a suppressed host still consumed its claim, so
-        // it counts as served and is not carried into the cutoff below.
+        // it counts as served and is not carried into the cutoff below. A manifest dropped after
+        // this point still spent its slot: the budget paces what this pass hands to the mqtt layer,
+        // and the retry comes back through a re-arm on a later pass.
         bool manifest_served = false;
         if (manifest_due && manifest_pacer_admit(&manifest_pacer, node_manifest_send_time) &&
             aclk_send_timestamp_claim(&aclk_host_config->node_manifest_send_time, node_manifest_send_time)) {

--- a/src/database/sqlite/sqlite_aclk_node.h
+++ b/src/database/sqlite/sqlite_aclk_node.h
@@ -15,9 +15,16 @@ void send_node_update_with_wait(RRDHOST *host, int live, int queryable);
 // key - see node_manifest_sent_key for why it is one value and not a pair. A collision would
 // suppress a manifest that was never published, at the same ~2^-64 manifest_dict_hash() already
 // accepts for the content itself. Here (rather than beside its caller) so it can be unit tested.
+//
+// Never returns 0, because 0 is node_manifest_sent_key's "nothing published yet" sentinel. A payload
+// whose digest happened to be 0 would otherwise never compare equal to the stored key, so it would
+// republish on every arm for the rest of the session instead of once. Mapping it to 1 costs nothing:
+// it only makes two digests out of 2^64 share a key, which is the collision the note above already
+// accepts.
 static inline uint64_t manifest_publication_key(uint64_t hash, usec_t session)
 {
-    return XXH3_64bits_withSeed(&session, sizeof(session), hash);
+    uint64_t key = XXH3_64bits_withSeed(&session, sizeof(session), hash);
+    return key ? key : 1;
 }
 
 // How many manifests one scan pass may publish. The manifest is the only one of the three messages

--- a/src/database/sqlite/sqlite_aclk_node.h
+++ b/src/database/sqlite/sqlite_aclk_node.h
@@ -11,20 +11,16 @@ void send_node_update_with_wait(RRDHOST *host, int live, int queryable);
 // published, so a burst of function registrations becomes one message.
 #define NODE_MANIFEST_WINDOW_S (30)
 
-// Folds the ACLK session into the manifest content hash so one value carries the whole suppression
-// key - see node_manifest_sent_key for why it is one value and not a pair. A collision would
-// suppress a manifest that was never published, at the same ~2^-64 manifest_dict_hash() already
-// accepts for the content itself. Here (rather than beside its caller) so it can be unit tested.
+// Folds the ACLK session into the manifest content hash, so one value describes everything that must
+// force a re-publish. A collision would suppress a manifest the cloud never received, at the same
+// ~2^-64 manifest_dict_hash() already accepts for the content itself. Here (rather than beside its
+// caller) so it can be unit tested.
 //
-// Never returns 0, because 0 is node_manifest_sent_key's "nothing recorded" sentinel. A payload
-// whose digest happened to be 0 would otherwise never compare equal to the stored key, so it would
-// republish on every arm for the rest of the session instead of once. Mapping it to 1 costs nothing:
-// it only makes two digests out of 2^64 share a key, which is the collision the note above already
-// accepts.
+// Every value including 0 is a valid key: what marks a config as having nothing outstanding is
+// node_manifest_sent_token being 0, not the key, so this needs no reserved value.
 static inline uint64_t manifest_publication_key(uint64_t hash, usec_t session)
 {
-    uint64_t key = XXH3_64bits_withSeed(&session, sizeof(session), hash);
-    return key ? key : 1;
+    return XXH3_64bits_withSeed(&session, sizeof(session), hash);
 }
 
 // How many manifests one scan pass may publish. The manifest is the only one of the three messages

--- a/src/database/sqlite/sqlite_aclk_node.h
+++ b/src/database/sqlite/sqlite_aclk_node.h
@@ -16,7 +16,7 @@ void send_node_update_with_wait(RRDHOST *host, int live, int queryable);
 // suppress a manifest that was never published, at the same ~2^-64 manifest_dict_hash() already
 // accepts for the content itself. Here (rather than beside its caller) so it can be unit tested.
 //
-// Never returns 0, because 0 is node_manifest_sent_key's "nothing published yet" sentinel. A payload
+// Never returns 0, because 0 is node_manifest_sent_key's "nothing recorded" sentinel. A payload
 // whose digest happened to be 0 would otherwise never compare equal to the stored key, so it would
 // republish on every arm for the rest of the session instead of once. Mapping it to 1 costs nothing:
 // it only makes two digests out of 2^64 share a key, which is the collision the note above already

--- a/src/database/sqlite/sqlite_aclk_node.h
+++ b/src/database/sqlite/sqlite_aclk_node.h
@@ -11,6 +11,15 @@ void send_node_update_with_wait(RRDHOST *host, int live, int queryable);
 // published, so a burst of function registrations becomes one message.
 #define NODE_MANIFEST_WINDOW_S (30)
 
+// Folds the ACLK session into the manifest content hash so one value carries the whole suppression
+// key - see node_manifest_sent_key for why it is one value and not a pair. A collision would
+// suppress a manifest that was never published, at the same ~2^-64 manifest_dict_hash() already
+// accepts for the content itself. Here (rather than beside its caller) so it can be unit tested.
+static inline uint64_t manifest_publication_key(uint64_t hash, usec_t session)
+{
+    return XXH3_64bits_withSeed(&session, sizeof(session), hash);
+}
+
 // How many manifests one scan pass may publish. The manifest is the only one of the three messages
 // aclk_check_node_info_collectors_and_manifest() sends that can be armed for the whole fleet at a
 // single instant (aclk_arm_node_manifest_all_hosts(), on every SendNodeInstances), and a new ACLK
@@ -70,7 +79,7 @@ static inline bool manifest_pacer_admit(const MANIFEST_PACER *pacer, time_t dead
     return pacer->published < MAX_NODE_MANIFESTS_PER_SCAN && (!pacer->cutoff || deadline <= pacer->cutoff);
 }
 
-// Charges the budget. Called only when a message really went out, so a run of suppressed
+// Charges the budget. Called only when a message was really enqueued, so a run of suppressed
 // (unchanged) manifests cannot exhaust the budget for the hosts behind them.
 static inline void manifest_pacer_published(MANIFEST_PACER *pacer)
 {


### PR DESCRIPTION
##### Summary
- Add delivery-result tracking, safe host resolution, retry re-arming, session-aware suppression, and bounded manifest pacing to prevent stale updates and message flooding.
