### PR TITLE
packaging: remove obsolete otel-signal-viewer artifacts on static upgrade

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -200,6 +200,17 @@ if [ -e "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/cgroup-name.sh" ] ||
   run rm -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/cgroup-name.sh"
 fi
 
+# The otel-signal-viewer plugin was removed in favour of otel-plugin plus the
+# read-only legacy-otel-logs function. Native packages drop its files via
+# Obsoletes/Replaces, but an overlay upgrade only stops shipping them, so both
+# artifacts linger here. Only stock paths are touched, never user config.
+for x in usr/libexec/netdata/plugins.d/otel-signal-viewer-plugin \
+  usr/lib/netdata/conf.d/otel-signal-viewer.yaml; do
+  if [ -e "${NETDATA_PREFIX}/${x}" ] || [ -L "${NETDATA_PREFIX}/${x}" ]; then
+    run rm -f "${NETDATA_PREFIX}/${x}"
+  fi
+done
+
 # -----------------------------------------------------------------------------
 
 progress "changing plugins ownership and permissions"


### PR DESCRIPTION
## Summary

The `otel-signal-viewer` plugin was removed in #22720 in favour of `otel-plugin` plus the read-only `legacy-otel-logs` function. Native packages already drop its files through the `Obsoletes:`/`Replaces:` metadata on `netdata-plugin-otel`, but the static installer extracts the new tarball *over* `/opt/netdata` and never prunes paths the build stopped shipping — so the plugin's artifacts lingered indefinitely after a static upgrade.

This removes both of them during static install/update:

- `usr/libexec/netdata/plugins.d/otel-signal-viewer-plugin`
- `usr/lib/netdata/conf.d/otel-signal-viewer.yaml`

Only stock paths are touched, so a user's own copy of the config under `etc/netdata/` is left alone. The block follows the existing `cgroup-name.sh` leftover-removal precedent immediately above it.

## Notes on scope

Two corrections to #22728, which was filed before #22720 merged and has gone partly stale:

- **The rpm and deb legs are already done.** #22720 itself added `Obsoletes:` (`netdata.spec.in:3324`) and `Conflicts:`/`Replaces:` (`packaging/cmake/Modules/Packaging.cmake:918-919`), carried into CPack by #23194 (`:931`). Removal is reachable on both channels because `netdata-plugin-otel` is a hard dependency of the main `netdata` package (`Packaging.cmake:245`, `:314`), so an upgrade pulls it in and triggers dpkg/dnf removal of the old sub-package. Docker needs no work — images build from scratch.
- **The plugin shipped two artifacts, not one.** The issue mentions only the binary; the stock config is the second (`9e447641aa^:CMakeLists.txt:3825-3828` and `:4025-4027`). A diff of the full CMake install-`COMPONENT` set across `9e447641aa^..9e447641aa` confirms `plugin-otel-signal-viewer` is the only component that disappeared, so these two paths are the complete set for this channel.

**Source installs are intentionally not changed.** They keep relying on the daemon-side deny (`src/plugins.d/plugins_d.c:281-293`), which is the intended mechanism there.

This is hygiene, not a functional fix — the daemon already refuses to launch the stale binary by name, and nothing reads the orphaned config.

## Testing

- `bash -n` clean; `shellcheck` findings identical before and after (two pre-existing SC2034 warnings on unused vars at lines 16-17).
- Simulated-prefix runs of the block, all passing:
  - upgrade with both leftovers present → both removed; a seeded `etc/netdata/otel-signal-viewer.yaml` and `plugins.d/otel-plugin` both survived;
  - clean install → no-op, exit 0, zero output (no install-log noise);
  - dangling symlink → removed via the `-L` arm where `-e` is false.
- Not exercised end-to-end: a real upgrade from a pre-#22720 static install, which needs a static-builder run to produce a new `.gz.run`.

Partially addresses #22728.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes leftover `otel-signal-viewer` files during static installs/upgrades so obsolete artifacts don’t linger under `/opt/netdata`. Brings the static installer in line with native packages that already clean these up via `Obsoletes`/`Replaces` in `netdata-plugin-otel`.

- **Bug Fixes**
  - Delete `usr/libexec/netdata/plugins.d/otel-signal-viewer-plugin` and `usr/lib/netdata/conf.d/otel-signal-viewer.yaml` if present (including symlinks).
  - Only touches stock paths; user config under `etc/netdata/` is not changed.

<sup>Written for commit 59fef2b28c0e3954d62cc46d9af6c4d457605c05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

