### PR TITLE
fix(go.d/prometheus): preserve typed counters ending in info

### DIFF
--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -476,18 +476,21 @@ test_drop{label1="value1"} 22
 				assert.False(t, ok, "a metric not matched by the selector must be dropped")
 			},
 		},
-		"_info family is skipped": {
+		"gauge _info family is skipped and counter is kept": {
 			prepare: New,
 			input: `
 # TYPE test_metric gauge
 test_metric{label1="value1"} 11
 # TYPE test_metric_info gauge
 test_metric_info{version="1.2.3"} 1
+# TYPE test_pg_info counter
+test_pg_info 7
 `,
 			want: func(t *testing.T, fr metrix.Reader) {
 				assert.InDelta(t, 11, value(t, fr, "test_metric", metrix.Labels{"label1": "value1"}), 1e-9)
 				_, ok := fr.Value("test_metric_info", metrix.Labels{"version": "1.2.3"})
-				assert.False(t, ok, "an _info family must be skipped")
+				assert.False(t, ok, "a gauge _info family must be skipped")
+				assert.InDelta(t, 7, value(t, fr, "test_pg_info", nil), 1e-9)
 			},
 		},
 		"per-metric series limit skips the family": {

--- a/src/go/plugin/go.d/collector/prometheus/writer.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer.go
@@ -233,7 +233,8 @@ func (w *metricFamilyWriter) reconcileHandles() {
 }
 
 func (w *metricFamilyWriter) skipMetricFamily(mf *prompkg.MetricFamily) bool {
-	if strings.HasSuffix(mf.Name(), "_info") {
+	// Info exposition is gauge-valued; preserve an explicit non-gauge type when an exporter reuses the suffix.
+	if mf.Type() == commonmodel.MetricTypeGauge && strings.HasSuffix(mf.Name(), "_info") {
 		return true
 	}
 	if w.policy.maxTSPerMetric > 0 && len(mf.Metrics()) > w.policy.maxTSPerMetric {

--- a/src/go/plugin/go.d/collector/prometheus/writer_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/writer_test.go
@@ -265,13 +265,23 @@ app_latency_count 1
 				assert.Equal(t, 0, written, "summary with an infinite quantile value must be skipped")
 			},
 		},
-		"skips _info family": {
+		"skips gauge _info family": {
 			exposition: `
 # TYPE app_build_info gauge
 app_build_info{version="1.2.3"} 1
 `,
 			assert: func(t *testing.T, fr metrix.Reader, written int) {
-				assert.Equal(t, 0, written, "_info family must be skipped entirely")
+				assert.Equal(t, 0, written, "gauge _info family must be skipped entirely")
+			},
+		},
+		"writes typed counter ending in _info": {
+			exposition: `
+# TYPE app_pg_info counter
+app_pg_info 42
+`,
+			assert: func(t *testing.T, fr metrix.Reader, written int) {
+				assert.Equal(t, 1, written)
+				assert.InDelta(t, 42, value(t, fr, "app_pg_info", nil), 1e-9)
 			},
 		},
 		"skips family exceeding maxTSPerMetric": {
@@ -547,7 +557,7 @@ func mustMeta(t *testing.T, fr metrix.Reader, name string) metrix.MetricMeta {
 }
 
 func TestMetricFamilyWriterEdgeCases(t *testing.T) {
-	t.Run("countWritable counts writable series and skips _info", func(t *testing.T) {
+	t.Run("countWritable counts typed counter and skips gauge _info", func(t *testing.T) {
 		store := metrix.NewCollectorStore()
 		w := newMetricFamilyWriter(store, metricFamilyWriterPolicy{}, logger.New())
 		mfs := scrape(t, `
@@ -556,8 +566,10 @@ app_a{x="1"} 1
 app_a{x="2"} 2
 # TYPE app_b_info gauge
 app_b_info{v="x"} 1
+# TYPE app_pg_info counter
+app_pg_info 3
 `)
-		assert.Equal(t, 2, w.countWritable(mfs))
+		assert.Equal(t, 3, w.countWritable(mfs))
 	})
 
 	t.Run("countWritable accepts a summary without quantiles", func(t *testing.T) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Prometheus writer to keep typed counters that end with `_info`, while still skipping gauge-based `_info` families. This prevents valid counters (e.g., `app_pg_info`) from being dropped and fixes writable series counts.

- **Bug Fixes**
  - Updated `skipMetricFamily` to only skip `_info` when the family type is `gauge`.
  - Extended tests in `collector_test.go` and `writer_test.go` to verify counters with `_info` are written and counted.

<sup>Written for commit a08e85a6b186699b65bff5f1ed6d8df6cdbfb9c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

