### PR TITLE
Fix macOS NVMe SMART IOKit lifecycle

### DIFF
--- a/src/collectors/macos.plugin/macos_nvme.c
+++ b/src/collectors/macos.plugin/macos_nvme.c
@@ -51,6 +51,11 @@ struct macos_nvme_metrics {
     collected_number critical_warning_persistent_memory;
 };
 
+struct macos_nvme_session {
+    IOCFPlugInInterface **plugin;
+    IONVMeSMARTInterface **smart;
+};
+
 struct macos_nvme_device {
     uint64_t registry_id;
     io_service_t service;
@@ -163,73 +168,90 @@ static bool macos_nvme_service_is_smart_capable(io_registry_entry_t entry)
     return capable;
 }
 
-static bool macos_nvme_open_interface(io_service_t service, IONVMeSMARTInterface ***smart_interface)
+static bool macos_nvme_close_session(struct macos_nvme_session *session)
 {
-    *smart_interface = NULL;
+    if (!session)
+        return true;
 
-    IOCFPlugInInterface **plugin = NULL;
+    if (session->smart) {
+        (*session->smart)->Release(session->smart);
+        session->smart = NULL;
+    }
+
+    bool success = true;
+    if (session->plugin) {
+        success = IODestroyPlugInInterface(session->plugin) == kIOReturnSuccess;
+        session->plugin = NULL;
+    }
+
+    return success;
+}
+
+static bool macos_nvme_open_session(io_service_t service, struct macos_nvme_session *session)
+{
+    if (!session)
+        return false;
+
+    *session = (struct macos_nvme_session){0};
+
     SInt32 score = 0;
     IOReturn kr = IOCreatePlugInInterfaceForService(
         service,
         kIONVMeSMARTUserClientTypeID,
         kIOCFPlugInInterfaceID,
-        &plugin,
+        &session->plugin,
         &score);
-    if (kr != kIOReturnSuccess || !plugin)
+    if (kr != kIOReturnSuccess || !session->plugin) {
+        macos_nvme_close_session(session);
         return false;
+    }
 
-    IONVMeSMARTInterface **smart = NULL;
-    HRESULT hres = (*plugin)->QueryInterface(
-        plugin,
+    HRESULT hres = (*session->plugin)->QueryInterface(
+        session->plugin,
         CFUUIDGetUUIDBytes(kIONVMeSMARTInterfaceID),
-        (LPVOID *)&smart);
+        (LPVOID *)&session->smart);
 
-    (*plugin)->Release(plugin);
-
-    if (hres != S_OK || !smart)
+    if (hres != S_OK || !session->smart) {
+        macos_nvme_close_session(session);
         return false;
+    }
 
-    *smart_interface = smart;
     return true;
 }
 
-static void macos_nvme_close_interface(IONVMeSMARTInterface **smart)
+static bool macos_nvme_read_device(
+    io_service_t service,
+    struct macos_nvme_metrics *metrics,
+    char *model,
+    size_t model_size)
 {
-    if (smart)
-        (*smart)->Release(smart);
-}
-
-static bool macos_nvme_read_model(io_service_t service, char *dst, size_t dst_size)
-{
-    IONVMeSMARTInterface **smart = NULL;
-    if (!macos_nvme_open_interface(service, &smart))
+    if (!metrics)
         return false;
 
-    NVMeIdentifyControllerStruct identify;
-    memset(&identify, 0, sizeof(identify));
-    IOReturn kr = (*smart)->GetIdentifyData(smart, &identify, 0);
-    macos_nvme_close_interface(smart);
+    if (model && model_size)
+        model[0] = '\0';
 
-    if (kr != kIOReturnSuccess)
-        return false;
-
-    macos_nvme_trim_ascii_field(identify.MODEL_NUMBER, sizeof(identify.MODEL_NUMBER), dst, dst_size);
-    return dst && dst[0] != '\0';
-}
-
-static bool macos_nvme_read_metrics(io_service_t service, struct macos_nvme_metrics *metrics)
-{
-    IONVMeSMARTInterface **smart = NULL;
-    if (!macos_nvme_open_interface(service, &smart))
+    struct macos_nvme_session session = {0};
+    if (!macos_nvme_open_session(service, &session))
         return false;
 
     NVMeSMARTData data;
     memset(&data, 0, sizeof(data));
-    IOReturn kr = (*smart)->SMARTReadData(smart, &data);
-    macos_nvme_close_interface(smart);
+    IOReturn smart_kr = (*session.smart)->SMARTReadData(session.smart, &data);
 
-    if (kr != kIOReturnSuccess)
+    NVMeIdentifyControllerStruct identify;
+    IOReturn identify_kr = kIOReturnUnsupported;
+    if (smart_kr == kIOReturnSuccess && model && model_size) {
+        memset(&identify, 0, sizeof(identify));
+        identify_kr = (*session.smart)->GetIdentifyData(session.smart, &identify, 0);
+    }
+
+    bool closed = macos_nvme_close_session(&session);
+    if (smart_kr != kIOReturnSuccess || !closed)
         return false;
+
+    if (identify_kr == kIOReturnSuccess)
+        macos_nvme_trim_ascii_field(identify.MODEL_NUMBER, sizeof(identify.MODEL_NUMBER), model, model_size);
 
     uint16_t kelvin = OSSwapLittleToHostInt16(data.TEMPERATURE);
     uint8_t warnings = data.CRITICAL_WARNING;
@@ -367,7 +389,8 @@ static unsigned macos_nvme_discover_devices(void)
         }
 
         struct macos_nvme_metrics probe = {0};
-        if (!macos_nvme_read_metrics(entry, &probe)) {
+        char model[MACOS_NVME_MODEL_MAX + 1] = "";
+        if (!macos_nvme_read_device(entry, &probe, model, sizeof(model))) {
             if (!nvme_logged_unreadable_service) {
                 collector_error(
                     "MACOS: found an NVMe SMART-capable IORegistry service, but cannot read native SMART data from it; "
@@ -393,8 +416,7 @@ static unsigned macos_nvme_discover_devices(void)
         d->seen = true;
         found++;
 
-        char model[sizeof(d->model)] = "";
-        if (macos_nvme_read_model(d->service, model, sizeof(model)))
+        if (model[0])
             snprintfz(d->model, sizeof(d->model), "%s", model);
     }
 
@@ -744,7 +766,7 @@ int do_macos_nvme_smart(int update_every __maybe_unused, usec_t dt __maybe_unuse
         devices++;
 
         struct macos_nvme_metrics metrics = {0};
-        if (!macos_nvme_read_metrics(d->service, &metrics))
+        if (!macos_nvme_read_device(d->service, &metrics, NULL, 0))
             continue;
 
         macos_nvme_update_charts(d, &metrics, sample_every_s);

--- a/src/collectors/macos.plugin/macos_nvme.c
+++ b/src/collectors/macos.plugin/macos_nvme.c
@@ -351,8 +351,9 @@ static void macos_nvme_free_devices(void)
     }
 }
 
-static void macos_nvme_prune_missing_devices(void)
+static unsigned macos_nvme_prune_missing_devices(void)
 {
+    unsigned tracked = 0;
     struct macos_nvme_device **pp = &nvme_devices_root;
     while (*pp) {
         struct macos_nvme_device *d = *pp;
@@ -360,19 +361,20 @@ static void macos_nvme_prune_missing_devices(void)
             *pp = d->next;
             macos_nvme_free_device(d);
         } else {
+            tracked++;
             pp = &d->next;
         }
     }
+
+    return tracked;
 }
 
-static unsigned macos_nvme_discover_devices(void)
+static bool macos_nvme_scan_registry(
+    unsigned *tracked,
+    unsigned *found,
+    bool admission_only,
+    bool *skipped_at_cap)
 {
-    unsigned tracked = 0;
-    for (struct macos_nvme_device *d = nvme_devices_root; d; d = d->next) {
-        d->seen = false;
-        tracked++;
-    }
-
     io_iterator_t iter = IO_OBJECT_NULL;
     IOReturn kr = IORegistryCreateIterator(kIOMainPortDefault, kIOServicePlane, kIORegistryIterateRecursively, &iter);
     if (unlikely(kr != kIOReturnSuccess || iter == IO_OBJECT_NULL)) {
@@ -380,10 +382,9 @@ static unsigned macos_nvme_discover_devices(void)
             collector_error("MACOS: cannot scan IORegistry for NVMe SMART-capable services");
             nvme_logged_registry_error = true;
         }
-        return 0;
+        return false;
     }
 
-    unsigned found = 0;
     io_registry_entry_t entry;
     while ((entry = IOIteratorNext(iter)) != IO_OBJECT_NULL) {
         if (!macos_nvme_service_is_smart_capable(entry)) {
@@ -398,7 +399,14 @@ static unsigned macos_nvme_discover_devices(void)
         }
 
         struct macos_nvme_device *d = macos_nvme_find_device(registry_id);
-        if (!d && tracked >= MACOS_NVME_MAX_DEVICES) {
+        if (admission_only && d) {
+            IOObjectRelease(entry);
+            continue;
+        }
+
+        if (!d && *tracked >= MACOS_NVME_MAX_DEVICES) {
+            if (skipped_at_cap)
+                *skipped_at_cap = true;
             IOObjectRelease(entry);
             continue;
         }
@@ -422,18 +430,38 @@ static unsigned macos_nvme_discover_devices(void)
             d->service = entry;
         } else {
             d = macos_nvme_add_device(registry_id, entry);
-            tracked++;
+            (*tracked)++;
         }
 
         d->seen = true;
-        found++;
+        (*found)++;
 
         if (model[0])
             snprintfz(d->model, sizeof(d->model), "%s", model);
     }
 
     IOObjectRelease(iter);
-    macos_nvme_prune_missing_devices();
+    return true;
+}
+
+static unsigned macos_nvme_discover_devices(void)
+{
+    unsigned tracked = 0;
+    for (struct macos_nvme_device *d = nvme_devices_root; d; d = d->next) {
+        d->seen = false;
+        tracked++;
+    }
+
+    unsigned found = 0;
+    bool skipped_at_cap = false;
+    if (!macos_nvme_scan_registry(&tracked, &found, false, &skipped_at_cap))
+        return 0;
+
+    tracked = macos_nvme_prune_missing_devices();
+
+    // A stale entry can occupy a slot until pruning. Revisit only untracked services if that hid available capacity.
+    if (skipped_at_cap && tracked < MACOS_NVME_MAX_DEVICES)
+        macos_nvme_scan_registry(&tracked, &found, true, NULL);
 
     return found;
 }

--- a/src/collectors/macos.plugin/macos_nvme.c
+++ b/src/collectors/macos.plugin/macos_nvme.c
@@ -367,8 +367,11 @@ static void macos_nvme_prune_missing_devices(void)
 
 static unsigned macos_nvme_discover_devices(void)
 {
-    for (struct macos_nvme_device *d = nvme_devices_root; d; d = d->next)
+    unsigned tracked = 0;
+    for (struct macos_nvme_device *d = nvme_devices_root; d; d = d->next) {
         d->seen = false;
+        tracked++;
+    }
 
     io_iterator_t iter = IO_OBJECT_NULL;
     IOReturn kr = IORegistryCreateIterator(kIOMainPortDefault, kIOServicePlane, kIORegistryIterateRecursively, &iter);
@@ -394,6 +397,12 @@ static unsigned macos_nvme_discover_devices(void)
             continue;
         }
 
+        struct macos_nvme_device *d = macos_nvme_find_device(registry_id);
+        if (!d && tracked >= MACOS_NVME_MAX_DEVICES) {
+            IOObjectRelease(entry);
+            continue;
+        }
+
         struct macos_nvme_metrics probe = {0};
         char model[MACOS_NVME_MODEL_MAX + 1] = "";
         if (!macos_nvme_read_device(entry, &probe, model, sizeof(model))) {
@@ -407,16 +416,13 @@ static unsigned macos_nvme_discover_devices(void)
             continue;
         }
 
-        struct macos_nvme_device *d = macos_nvme_find_device(registry_id);
         if (d) {
             if (d->service)
                 IOObjectRelease(d->service);
             d->service = entry;
-        } else if (found < MACOS_NVME_MAX_DEVICES) {
-            d = macos_nvme_add_device(registry_id, entry);
         } else {
-            IOObjectRelease(entry);
-            continue;
+            d = macos_nvme_add_device(registry_id, entry);
+            tracked++;
         }
 
         d->seen = true;

--- a/src/collectors/macos.plugin/macos_nvme.c
+++ b/src/collectors/macos.plugin/macos_nvme.c
@@ -168,23 +168,29 @@ static bool macos_nvme_service_is_smart_capable(io_registry_entry_t entry)
     return capable;
 }
 
-static bool macos_nvme_close_session(struct macos_nvme_session *session)
+static void macos_nvme_close_session(struct macos_nvme_session *session)
 {
     if (!session)
-        return true;
+        return;
 
     if (session->smart) {
         (*session->smart)->Release(session->smart);
         session->smart = NULL;
     }
 
-    bool success = true;
     if (session->plugin) {
-        success = IODestroyPlugInInterface(session->plugin) == kIOReturnSuccess;
+        IOReturn kr = IODestroyPlugInInterface(session->plugin);
+        if (kr != kIOReturnSuccess) {
+            nd_log_limit_static_global_var(erl, 60, 0);
+            nd_log_limit(
+                &erl,
+                NDLS_COLLECTORS,
+                NDLP_ERR,
+                "MACOS: NVMe SMART IOKit plug-in teardown returned error 0x%x",
+                (unsigned)kr);
+        }
         session->plugin = NULL;
     }
-
-    return success;
 }
 
 static bool macos_nvme_open_session(io_service_t service, struct macos_nvme_session *session)
@@ -246,8 +252,8 @@ static bool macos_nvme_read_device(
         identify_kr = (*session.smart)->GetIdentifyData(session.smart, &identify, 0);
     }
 
-    bool closed = macos_nvme_close_session(&session);
-    if (smart_kr != kIOReturnSuccess || !closed)
+    macos_nvme_close_session(&session);
+    if (smart_kr != kIOReturnSuccess)
         return false;
 
     if (identify_kr == kIOReturnSuccess)


### PR DESCRIPTION
## Summary

- retain the IOKit plug-in for the full native NVMe SMART transaction
- release the SMART interface and destroy the plug-in on every success and partial-failure path
- combine discovery SMART and model reads into one short-lived session

Fixes #23443

## Root cause

`IOCreatePlugInInterfaceForService()` returns a plug-in interface that Apple requires callers to deallocate with `IODestroyPlugInInterface()`. The collector instead called the plug-in COM `Release()` method immediately after querying the SMART interface, leaving the native NVMe SMART user client claimed while Netdata remained running.

## Validation

- `cmake --build build --parallel 2 --target netdata`
- 10 native `nvme.*` contexts remained active beyond four collection intervals
- 45/45 `smartctl --scan-open` attempts succeeded while Netdata was running
- `smartctl -H -A` returned success and reported passing device health while Netdata was running
- `git diff --check`

## Collector consistency

- no metric, chart context, configuration, default, taxonomy, alert, or documented contract changed
- metadata, stock configuration, taxonomy, health alerts, and generated integration documentation remain unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the macOS NVMe SMART IOKit lifecycle with a short-lived session and correct teardown, and tighten discovery to respect the device cap and admit replacements after pruning. Prevents leaked user clients, stale NVMe contexts, intermittent smartctl failures, and preserves samples even if teardown errors occur.

- **Bug Fixes**
  - Add a session wrapper to manage `IOCFPlugInInterface` and `IONVMeSMARTInterface` together.
  - Keep the plug-in until the transaction ends; call `Release()` on the SMART interface and `IODestroyPlugInInterface()` on the plug-in on every path.
  - Combine SMART data and model (identify) reads into one short-lived session.
  - Log teardown errors and keep the collected sample to avoid data loss.
  - Bound NVMe discovery before reads to honor `MACOS_NVME_MAX_DEVICES`; re-scan after pruning to admit replacement services.

<sup>Written for commit b7190bbd87a8303f56802e7a18a48294212976b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVMe device monitoring on macOS for more reliable hardware connections.
  * Enhanced device discovery and recovery when the configured device limit is reached.
  * Improved collection of NVMe health metrics and device model information.
  * Added clearer error reporting when hardware resources cannot be released correctly.
  * Increased reliability when devices are added, removed, or temporarily unavailable during monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->