### PR TITLE
fix(build): restrict eBPF plugin to 64-bit userlands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,17 @@ cmake_dependent_option(ENABLE_CGROUPS_LOOKUP_SERVER "Enable cgroups.plugin CGROU
 cmake_dependent_option(ENABLE_CGROUPS_LOOKUP_TEST_CLIENT "Build cgroups.plugin CGROUPS_LOOKUP test client" False "ENABLE_CGROUPS_LOOKUP_SERVER" False)
 cmake_dependent_option(ENABLE_CGROUP_NAME "Build the cgroup-name helper" True "OS_LINUX;ENABLE_PLUGIN_GO" False)
 cmake_dependent_option(ENABLE_PLUGIN_DEBUGFS "Enable Linux DebugFS metric collection" ${DEFAULT_FEATURE_STATE} "OS_LINUX" False)
-cmake_dependent_option(ENABLE_PLUGIN_EBPF "Enable Linux eBPF metric collection" ${DEFAULT_FEATURE_STATE} "OS_LINUX" False)
+# eBPF support is 64-bit only: the legacy BPF objects we ship are fetched with no
+# architecture dimension (see NetdataEBPFLegacy.cmake - only libc varies), 32-bit
+# kernels provide no BTF to build CO-RE programs from, and the loaders share struct
+# layouts with the BPF side. On a 32-bit userland the plugin builds and installs but
+# cannot load a single program - it exits 1 and netdata disables it.
+cmake_dependent_option(ENABLE_PLUGIN_EBPF "Enable Linux eBPF metric collection" ${DEFAULT_FEATURE_STATE} "OS_LINUX;CMAKE_SIZEOF_VOID_P EQUAL 8" False)
+
+if(OS_LINUX AND NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(STATUS "eBPF plugin disabled: requires a 64-bit userland (pointer size is ${CMAKE_SIZEOF_VOID_P} bytes)")
+endif()
+
 cmake_dependent_option(ENABLE_LEGACY_EBPF_PROGRAMS "Enable eBPF programs for kernels without BTF support" True "ENABLE_PLUGIN_EBPF" False)
 mark_as_advanced(ENABLE_LEGACY_EBPF_PROGRAMS)
 cmake_dependent_option(ENABLE_PLUGIN_LOCAL_LISTENERS "Enable local listening socket tracking (including service auto-discovery support)" ${DEFAULT_FEATURE_STATE} "OS_LINUX" False)
@@ -481,7 +491,13 @@ if(ENABLE_PLUGIN_GO OR ENABLE_PLUGIN_EBPF OR ENABLE_PLUGIN_IBM OR ENABLE_PLUGIN_
     endif()
 
     if(GO_FOUND)
-        set(ENABLE_PLUGIN_EBPF_GO ON)
+        # The BPF side is always LP64, and the loader shares struct layouts with it,
+        # so this plugin is only built for 64-bit userlands.
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            set(ENABLE_PLUGIN_EBPF_GO ON)
+        else()
+            message(STATUS "eBPF Go plugin disabled: requires a 64-bit userland (pointer size is ${CMAKE_SIZEOF_VOID_P} bytes)")
+        endif()
     endif()
 endif()
 

--- a/packaging/check-for-go-toolchain.sh
+++ b/packaging/check-for-go-toolchain.sh
@@ -52,8 +52,20 @@ check_go_version() {
 userland_machine() {
   ULM_KERNEL_MACHINE="$(uname -m)"
 
+  # Only 64-bit kernel types that install_go_toolchain can resolve to an archive
+  # need the userland check: every other machine type either cannot host a
+  # narrower userland, or has no Go archive at all and already fails cleanly.
+  case "${ULM_KERNEL_MACHINE}" in
+    x86_64|amd64|aarch64|arm64|ppc64le|riscv64|s390x) ;;
+    *)
+      printf '%s\n' "${ULM_KERNEL_MACHINE}"
+      return 0
+      ;;
+  esac
+
   # Userland word size. getconf is not present everywhere (notably minimal musl
-  # systems), so fall back to the ELF class byte of our own interpreter:
+  # systems), so fall back to the ELF class byte of a userland binary - od's own
+  # executable, which /proc/self/exe resolves to inside the substitution below:
   # byte 4 of the ELF header is 1 for 32-bit objects and 2 for 64-bit ones.
   ULM_BITS=''
   if command -v getconf > /dev/null 2>&1; then
@@ -67,17 +79,28 @@ userland_machine() {
     esac
   fi
 
-  # Unknown word size: keep the historical behaviour rather than guess.
-  if [ "${ULM_BITS}" != "32" ]; then
-    printf '%s\n' "${ULM_KERNEL_MACHINE}"
-    return 0
-  fi
-
-  # 32-bit userland: map 64-bit kernel types to their 32-bit counterparts.
-  case "${ULM_KERNEL_MACHINE}" in
-    x86_64|amd64) printf '%s\n' i686 ;;
-    aarch64|arm64) printf '%s\n' armv7l ;;
-    *) printf '%s\n' "${ULM_KERNEL_MACHINE}" ;;
+  case "${ULM_BITS}" in
+    32)
+      # Map the 64-bit kernel type to the 32-bit userland we are building for. A
+      # kernel type with no 32-bit Go toolchain (Go ships none for ppc64le,
+      # s390x or riscv64 userlands) gets a marker that makes the caller fail
+      # cleanly, instead of installing a 64-bit toolchain that cannot run here.
+      case "${ULM_KERNEL_MACHINE}" in
+        x86_64|amd64) printf '%s\n' i686 ;;
+        aarch64|arm64) printf '%s\n' armv7l ;;
+        *) printf '%s\n' "32-bit userland on ${ULM_KERNEL_MACHINE}" ;;
+      esac
+      ;;
+    64)
+      printf '%s\n' "${ULM_KERNEL_MACHINE}"
+      ;;
+    *)
+      # Word size undetermined (no getconf, and no readable ELF header to fall
+      # back to). Assume the userland matches the kernel, but say so: if it does
+      # not, the toolchain we are about to install will not run.
+      printf '%s\n' "WARNING: cannot determine the userland word size (getconf and od are both unavailable), assuming a 64-bit userland on this ${ULM_KERNEL_MACHINE} kernel. If the userland is 32-bit, install a Go ${GOLANG_MIN_VERSION} toolchain for it manually before building." >&2
+      printf '%s\n' "${ULM_KERNEL_MACHINE}"
+      ;;
   esac
 }
 
@@ -85,19 +108,19 @@ install_go_toolchain() {
   GOLANG_ARCHIVE_NAME="${GOLANG_TEMP_PATH}/golang.tar.gz"
   GOLANG_CHECKSUM_FILE="${GOLANG_TEMP_PATH}/golang.sha256sums"
 
-  # The toolchain we download has to *run* here, so this is the host userland,
-  # spelled the way Linux `uname -m` spells it; only the Linux branch below
-  # consults it. FreeBSD keeps `uname -m` because its case labels
-  # (386/amd64/arm/arm64) are a different vocabulary.
-  #
-  # Deliberately not derived from GOARCH: that is Go's *output* target, and
-  # honouring it here would install a toolchain the builder cannot execute
-  # whenever someone genuinely cross-builds. Once a runnable toolchain exists,
-  # GOARCH does its job unaided.
-  GOLANG_HOST_MACHINE="$(userland_machine)"
-
   case "$(uname -s)" in
     Linux)
+      # The toolchain we download has to *run* here, so this is the host
+      # userland, spelled the way Linux `uname -m` spells it. FreeBSD keeps
+      # `uname -m` because its case labels (386/amd64/arm/arm64) are a different
+      # vocabulary.
+      #
+      # Deliberately not derived from GOARCH: that is Go's *output* target, and
+      # honouring it here would install a toolchain the builder cannot execute
+      # whenever someone genuinely cross-builds. Once a runnable toolchain
+      # exists, GOARCH does its job unaided.
+      GOLANG_HOST_MACHINE="$(userland_machine)"
+
       case "${GOLANG_HOST_MACHINE}" in
         i?86)
           GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.linux-386.tar.gz"

--- a/packaging/check-for-go-toolchain.sh
+++ b/packaging/check-for-go-toolchain.sh
@@ -43,13 +43,62 @@ check_go_version() {
   return 1
 }
 
+# Report the machine type of the *userland* we are building for.
+#
+# `uname -m` reports the kernel's architecture, which is not the same thing: a
+# 32-bit userland on a 64-bit kernel (i386 on x86_64, armhf on aarch64 - the
+# default on 32-bit Raspberry Pi OS) reports the 64-bit kernel type. Installing a
+# 64-bit Go toolchain there makes cgo build for the wrong architecture.
+userland_machine() {
+  ULM_KERNEL_MACHINE="$(uname -m)"
+
+  # Userland word size. getconf is not present everywhere (notably minimal musl
+  # systems), so fall back to the ELF class byte of our own interpreter:
+  # byte 4 of the ELF header is 1 for 32-bit objects and 2 for 64-bit ones.
+  ULM_BITS=''
+  if command -v getconf > /dev/null 2>&1; then
+    ULM_BITS="$(getconf LONG_BIT 2>/dev/null)"
+  fi
+
+  if [ -z "${ULM_BITS}" ] && [ -r /proc/self/exe ] && command -v od > /dev/null 2>&1; then
+    case "$(od -An -t x1 -j 4 -N 1 /proc/self/exe 2>/dev/null | tr -d ' \n')" in
+      01) ULM_BITS=32 ;;
+      02) ULM_BITS=64 ;;
+    esac
+  fi
+
+  # Unknown word size: keep the historical behaviour rather than guess.
+  if [ "${ULM_BITS}" != "32" ]; then
+    printf '%s\n' "${ULM_KERNEL_MACHINE}"
+    return 0
+  fi
+
+  # 32-bit userland: map 64-bit kernel types to their 32-bit counterparts.
+  case "${ULM_KERNEL_MACHINE}" in
+    x86_64|amd64) printf '%s\n' i686 ;;
+    aarch64|arm64) printf '%s\n' armv7l ;;
+    *) printf '%s\n' "${ULM_KERNEL_MACHINE}" ;;
+  esac
+}
+
 install_go_toolchain() {
   GOLANG_ARCHIVE_NAME="${GOLANG_TEMP_PATH}/golang.tar.gz"
   GOLANG_CHECKSUM_FILE="${GOLANG_TEMP_PATH}/golang.sha256sums"
 
+  # The toolchain we download has to *run* here, so this is the host userland,
+  # spelled the way Linux `uname -m` spells it; only the Linux branch below
+  # consults it. FreeBSD keeps `uname -m` because its case labels
+  # (386/amd64/arm/arm64) are a different vocabulary.
+  #
+  # Deliberately not derived from GOARCH: that is Go's *output* target, and
+  # honouring it here would install a toolchain the builder cannot execute
+  # whenever someone genuinely cross-builds. Once a runnable toolchain exists,
+  # GOARCH does its job unaided.
+  GOLANG_HOST_MACHINE="$(userland_machine)"
+
   case "$(uname -s)" in
     Linux)
-      case "$(uname -m)" in
+      case "${GOLANG_HOST_MACHINE}" in
         i?86)
           GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.linux-386.tar.gz"
           GOLANG_ARCHIVE_CHECKSUM="88c162b204e6eefcc32499453b492e80209f4a4c78c33092636901c540fb0d05"
@@ -79,7 +128,7 @@ install_go_toolchain() {
           GOLANG_ARCHIVE_CHECKSUM="09ce3c504c0323968b75a717244dca4f25cd4cf0443e5ff6bc0bfa74add89fa7"
           ;;
         *)
-          GOLANG_FAILURE_REASON="Linux $(uname -m) platform is not supported out-of-box by Go, you must install a toolchain for it yourself."
+          GOLANG_FAILURE_REASON="Linux ${GOLANG_HOST_MACHINE} platform is not supported out-of-box by Go, you must install a toolchain for it yourself."
           return 1
           ;;
       esac

--- a/packaging/check-for-go-toolchain.sh
+++ b/packaging/check-for-go-toolchain.sh
@@ -52,11 +52,21 @@ check_go_version() {
 userland_machine() {
   ULM_KERNEL_MACHINE="$(uname -m)"
 
+  # Speak one vocabulary from here on: the Linux archive table below is keyed by
+  # the kernel spellings, so fold the Debian/BSD aliases into them first. A Linux
+  # kernel reports x86_64/aarch64 (i686/armv7l/armv8l for a 32-bit personality),
+  # never these aliases, but folding them once keeps every branch below - the
+  # word-size gate, the 32-bit map, and the messages - consistent.
+  case "${ULM_KERNEL_MACHINE}" in
+    amd64) ULM_KERNEL_MACHINE=x86_64 ;;
+    arm64) ULM_KERNEL_MACHINE=aarch64 ;;
+  esac
+
   # Only 64-bit kernel types that install_go_toolchain can resolve to an archive
   # need the userland check: every other machine type either cannot host a
   # narrower userland, or has no Go archive at all and already fails cleanly.
   case "${ULM_KERNEL_MACHINE}" in
-    x86_64|amd64|aarch64|arm64|ppc64le|riscv64|s390x) ;;
+    x86_64|aarch64|ppc64le|riscv64|s390x) ;;
     *)
       printf '%s\n' "${ULM_KERNEL_MACHINE}"
       return 0
@@ -86,8 +96,8 @@ userland_machine() {
       # s390x or riscv64 userlands) gets a marker that makes the caller fail
       # cleanly, instead of installing a 64-bit toolchain that cannot run here.
       case "${ULM_KERNEL_MACHINE}" in
-        x86_64|amd64) printf '%s\n' i686 ;;
-        aarch64|arm64) printf '%s\n' armv7l ;;
+        x86_64) printf '%s\n' i686 ;;
+        aarch64) printf '%s\n' armv7l ;;
         *) printf '%s\n' "32-bit userland on ${ULM_KERNEL_MACHINE}" ;;
       esac
       ;;


### PR DESCRIPTION
##### Summary
- The eBPF Go loader shares struct layouts with the BPF side, which is always LP64, so gate the plugin on a 64-bit userland and pin the cachestat ring-buffer event alignment.
- Resolve the Go toolchain from the userland machine type instead of `uname -m`, which reports the kernel's architecture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * eBPF support is now enabled only on 64-bit Linux environments.
  * Configuration clearly reports when eBPF is unavailable on 32-bit Linux systems.
  * Go toolchain detection now identifies the userland architecture more accurately across supported environments.

* **Bug Fixes**
  * Improved platform detection prevents incorrect Linux toolchain selection on 32-bit systems.
  * Unsupported-platform messages now display the detected userland architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->