### PR TITLE
Improve the support bundle: streaming api key, encoding fidelity, Windows ETW logs, permissions

### DIFF
--- a/.github/workflows/netdata-support-bundle.yml
+++ b/.github/workflows/netdata-support-bundle.yml
@@ -211,7 +211,7 @@ jobs:
               if (-not $elEntry) { throw 'the event log capture is missing' }
               $er = New-Object System.IO.StreamReader($elEntry.Open(), $utf8, $true)
               try { $eltext = $er.ReadToEnd() } finally { $er.Dispose() }
-              foreach ($ch in @('Netdata/Daemon', 'Netdata/Collectors', 'Netdata/Access', 'NetdataWEL')) {
+              foreach ($ch in @('Netdata/Daemon', 'Netdata/Collectors', 'Netdata/Health', 'Netdata/Aclk', 'Netdata/Access', 'NetdataWEL')) {
                   if ($eltext -notmatch [regex]::Escape($ch)) { throw "the event log capture never queried $ch" }
               }
               if (-not ($archive.Entries | Where-Object { $_.FullName -match '(^|[\\/])09-permissions[\\/]plugins-d.txt$' })) {

--- a/.github/workflows/netdata-support-bundle.yml
+++ b/.github/workflows/netdata-support-bundle.yml
@@ -103,18 +103,9 @@ jobs:
           sc="$root/04-config/stream.conf"
           grep -qF 'api key = 11111111-2222-3333-4444-555555555555' "$sc"
           grep -qF '[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]' "$sc"
-          if grep -q 'SENTINEL-E2E-STREAMPW' "$sc"; then
-            echo 'a non-api-key secret survived in stream.conf' >&2
-            exit 1
-          fi
-          if [ "$(head -c 3 "$sc" | od -An -tx1 | tr -d ' \n')" != "efbbbf" ]; then
-            echo 'the UTF-8 BOM was not preserved in stream.conf' >&2
-            exit 1
-          fi
-          if [ "$(tr -dc '\r' < "$sc" | wc -c)" -lt 4 ]; then
-            echo 'CRLF line endings were not preserved in stream.conf' >&2
-            exit 1
-          fi
+          grep -q 'SENTINEL-E2E-STREAMPW' "$sc" && { echo 'a non-api-key secret survived in stream.conf' >&2; exit 1; }
+          [ "$(head -c 3 "$sc" | od -An -tx1 | tr -d ' \n')" = efbbbf ] || { echo 'the UTF-8 BOM was not preserved' >&2; exit 1; }
+          [ "$(tr -dc '\r' < "$sc" | wc -c)" -ge 4 ] || { echo 'CRLF line endings were not preserved' >&2; exit 1; }
 
   macos-posix:
     name: macOS POSIX sanitization

--- a/.github/workflows/netdata-support-bundle.yml
+++ b/.github/workflows/netdata-support-bundle.yml
@@ -115,8 +115,6 @@ jobs:
             echo 'CRLF line endings were not preserved in stream.conf' >&2
             exit 1
           fi
-          jq -e '.files[] | select(.path == "04-config/stream.conf")
-                 | .source_encoding | .bom == "utf-8" and .final_newline == false' "$root/MANIFEST.json"
 
   macos-posix:
     name: macOS POSIX sanitization

--- a/.github/workflows/netdata-support-bundle.yml
+++ b/.github/workflows/netdata-support-bundle.yml
@@ -69,6 +69,12 @@ jobs:
           sudo install -d -m 755 /etc/netdata
           sudo sh -c 'printf "%s\n" "KEEP-NONSECRET-CONTENT" "password=SENTINEL-E2E-PASSWORD" > /etc/netdata/netdata.conf'
           sudo chmod 644 /etc/netdata/netdata.conf
+          # stream.conf fixture: a UTF-8 BOM, CRLF endings and NO final newline,
+          # so the encoding-preservation and streaming-api-key contracts are
+          # exercised end to end (netdata/netdata#23448)
+          printf '\357\273\277[stream]\r\n    enabled = yes\r\n    api key = 11111111-2222-3333-4444-555555555555\r\n    password = SENTINEL-E2E-STREAMPW\r\n[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]\r\n    enabled = yes' > /tmp/stream.conf
+          sudo cp /tmp/stream.conf /etc/netdata/stream.conf
+          sudo chmod 644 /etc/netdata/stream.conf
           output=$(mktemp -d)
           extract=$(mktemp -d)
           sh packaging/installer/netdata-support-bundle --timeout 3 --since 1 -o "$output"
@@ -89,6 +95,28 @@ jobs:
           fi
           jq -e '.schema == "netdata-support-bundle/v1" and (.files | length > 0)' "$root/MANIFEST.json"
           jq -e '.files[] | select(.path == "04-config/netdata.conf" and .bytes > 0)' "$root/MANIFEST.json"
+
+          test -s "$root/09-permissions/plugins-d.txt"
+
+          # streaming api key kept verbatim, other stream.conf secrets redacted,
+          # and the source bytes (BOM + CRLF + no final newline) preserved
+          sc="$root/04-config/stream.conf"
+          grep -qF 'api key = 11111111-2222-3333-4444-555555555555' "$sc"
+          grep -qF '[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]' "$sc"
+          if grep -q 'SENTINEL-E2E-STREAMPW' "$sc"; then
+            echo 'a non-api-key secret survived in stream.conf' >&2
+            exit 1
+          fi
+          if [ "$(head -c 3 "$sc" | od -An -tx1 | tr -d ' \n')" != "efbbbf" ]; then
+            echo 'the UTF-8 BOM was not preserved in stream.conf' >&2
+            exit 1
+          fi
+          if [ "$(tr -dc '\r' < "$sc" | wc -c)" -lt 4 ]; then
+            echo 'CRLF line endings were not preserved in stream.conf' >&2
+            exit 1
+          fi
+          jq -e '.files[] | select(.path == "04-config/stream.conf")
+                 | .source_encoding | .bom == "utf-8" and .final_newline == false' "$root/MANIFEST.json"
 
   macos-posix:
     name: macOS POSIX sanitization
@@ -130,6 +158,13 @@ jobs:
               (Join-Path $confDir 'netdata.conf'),
               "KEEP-NONSECRET-CONTENT`npassword=SENTINEL-E2E-PASSWORD`n",
               $utf8)
+          # stream.conf fixture: a UTF-8 BOM, CRLF endings and NO final newline,
+          # so the encoding-preservation and streaming-api-key contracts are
+          # exercised end to end (netdata/netdata#23448)
+          $streamText = "[stream]`r`n    enabled = yes`r`n    api key = 11111111-2222-3333-4444-555555555555`r`n    password = SENTINEL-E2E-STREAMPW`r`n[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]`r`n    enabled = yes"
+          [System.IO.File]::WriteAllBytes(
+              (Join-Path $confDir 'stream.conf'),
+              [byte[]](@(0xEF, 0xBB, 0xBF) + $utf8.GetBytes($streamText)))
           $output = Join-Path $env:RUNNER_TEMP ('netdata-support-bundle-e2e-' + [guid]::NewGuid())
           .\packaging\installer\netdata-support-bundle.ps1 -Output $output -TimeoutSeconds 3 -SinceHours 1
           $zip = Get-ChildItem $output -Filter '*.zip' | Select-Object -First 1
@@ -154,4 +189,32 @@ jobs:
               if ($bytes.Length -ge 2 -and $bytes[0] -eq 0xff -and $bytes[1] -eq 0xfe) { throw 'MANIFEST.json is UTF-16LE' }
               $manifest = $utf8.GetString($bytes) | ConvertFrom-Json
               if ($manifest.schema -ne 'netdata-support-bundle/v1' -or $manifest.files.Count -eq 0) { throw 'manifest contract failed' }
+
+              # streaming api key kept verbatim, other stream.conf secrets redacted,
+              # and the source bytes (BOM + CRLF + no final newline) preserved
+              $streamEntry = $archive.Entries | Where-Object { $_.FullName -match '(^|[\\/])04-config[\\/]stream.conf$' } | Select-Object -First 1
+              if (-not $streamEntry) { throw 'stream.conf was not collected' }
+              $ms = New-Object System.IO.MemoryStream
+              $es = $streamEntry.Open()
+              try { $es.CopyTo($ms) } finally { $es.Dispose() }
+              $sb = $ms.ToArray(); $ms.Dispose()
+              $stext = $utf8.GetString($sb)
+              if ($stext -notmatch 'api key = 11111111-2222-3333-4444-555555555555') { throw 'the streaming api key was redacted' }
+              if ($stext -match 'SENTINEL-E2E-STREAMPW') { throw 'a non-api-key secret survived in stream.conf' }
+              if (-not ($sb.Length -ge 3 -and $sb[0] -eq 0xEF -and $sb[1] -eq 0xBB -and $sb[2] -eq 0xBF)) { throw 'the UTF-8 BOM was not preserved' }
+              if (@([regex]::Matches($stext, "`r`n")).Count -lt 4) { throw 'CRLF line endings were not preserved' }
+              if ($sb[$sb.Length - 1] -eq 10) { throw 'a final newline was added to a source that had none' }
+
+              # the ETW channels are actually queried - they are where a Windows
+              # agent logs by default, and querying only NetdataWEL found nothing
+              $elEntry = $archive.Entries | Where-Object { $_.FullName -match '(^|[\\/])05-logs[\\/]eventlog-netdata.txt$' } | Select-Object -First 1
+              if (-not $elEntry) { throw 'the event log capture is missing' }
+              $er = New-Object System.IO.StreamReader($elEntry.Open(), $utf8, $true)
+              try { $eltext = $er.ReadToEnd() } finally { $er.Dispose() }
+              foreach ($ch in @('Netdata/Daemon', 'Netdata/Collectors', 'Netdata/Access', 'NetdataWEL')) {
+                  if ($eltext -notmatch [regex]::Escape($ch)) { throw "the event log capture never queried $ch" }
+              }
+              if (-not ($archive.Entries | Where-Object { $_.FullName -match '(^|[\\/])09-permissions[\\/]plugins-d.txt$' })) {
+                  throw '09-permissions/plugins-d.txt is missing'
+              }
           } finally { $archive.Dispose() }

--- a/docs/developer-and-contributor-corner/netdata-support-bundle.md
+++ b/docs/developer-and-contributor-corner/netdata-support-bundle.md
@@ -84,10 +84,13 @@ The archive is organized into numbered directories so a person or an automated r
 - `06-state/`, persistent state such as the daemon status file used for crash analysis, database disk usage, and cloud claim state.
 - `07-runtime/`, live agent state read from the local API, collected only when the agent responds.
 - `08-network/`, local connectivity relevant to the agent.
+- `09-permissions/`, file modes, ownership, plugin capabilities, extended attributes, security contexts, and ACLs for the agent's directories and plugins.
 
 ## Privacy and sanitization
 
-- Secrets are always removed. This covers API tokens, passwords, stream API keys, bearer and basic credentials, private key blocks, and credentials embedded in URLs.
+- Secrets are removed. This covers API tokens, passwords, bearer and basic credentials, private key blocks, and credentials embedded in URLs.
+- One deliberate exception: the **streaming API key** is kept as-is in `04-config/stream.conf`, because support needs it to tell whether a child and its parent agree on the same key. Remove or mask that file before sending the bundle if you would rather not share it.
+- Collected files keep their original bytes, including a byte-order mark and CRLF line endings, so an encoding problem in your configuration is still visible. What was found is recorded per file in `MANIFEST.json`, and anything unusual is listed in `summary.txt`.
 - IP addresses and hostnames are replaced with stable pseudonyms by default, so the same address reads as the same pseudonym across the whole bundle. Use `--no-obfuscate` to keep the real values.
 - When pseudonymization is on, the map from real values to pseudonyms is written next to the archive, not inside it. Keep that map private and do not attach it to a ticket.
 - Review the archive before you send it. The tool runs on your own host and you are in control of what leaves it.

--- a/docs/developer-and-contributor-corner/netdata-support-bundle.md
+++ b/docs/developer-and-contributor-corner/netdata-support-bundle.md
@@ -90,7 +90,7 @@ The archive is organized into numbered directories so a person or an automated r
 
 - Secrets are removed. This covers API tokens, passwords, bearer and basic credentials, private key blocks, and credentials embedded in URLs.
 - One deliberate exception: the **streaming API key** is kept as-is in `04-config/stream.conf`, because support needs it to tell whether a child and its parent agree on the same key. Remove or mask that file before sending the bundle if you would rather not share it.
-- Collected files keep their original bytes, including a byte-order mark and CRLF line endings, so an encoding problem in your configuration is still visible. What was found is recorded per file in `MANIFEST.json`, and anything unusual is listed in `summary.txt`.
+- Collected files keep their original bytes, including a byte-order mark and CRLF line endings, so an encoding problem in your configuration is still visible.
 - IP addresses and hostnames are replaced with stable pseudonyms by default, so the same address reads as the same pseudonym across the whole bundle. Use `--no-obfuscate` to keep the real values.
 - When pseudonymization is on, the map from real values to pseudonyms is written next to the archive, not inside it. Keep that map private and do not attach it to a ticket.
 - Review the archive before you send it. The tool runs on your own host and you are in control of what leaves it.

--- a/packaging/installer/SUPPORT-BUNDLE.md
+++ b/packaging/installer/SUPPORT-BUNDLE.md
@@ -56,7 +56,7 @@ document.**
 | Zero system impact | self-demotion to idle CPU/IO priority (`nice -n 19` + `ionice -c 3` / `PriorityClass = Idle`); per-command timeout (10 s default, via `timeout` or a portable watchdog — the watchdog kills the direct child only, a documented limitation); global deadline checked before each collector, so the hard runtime bound is deadline + one command timeout; size caps (5 MiB per log, 1 MiB per file, 2 MiB per command/API output); read-only — writes only its private staging dir and the final artifacts, never restarts or reconfigures anything; artifacts are published with `O_EXCL` so pre-existing files or symlinks in shared tmp dirs are never followed |
 | Works when the agent is dead | no hard dependency on a running agent; the most valuable crash artifacts (status file, logs, buildinfo via the binary) are collected from disk; a `07-runtime/AGENT-WAS-DOWN.txt` marker is written instead of API captures |
 | Secrets always redacted | non-optional single-pass sanitizer; see "Sanitization" below. **One documented exception:** the streaming API key in `stream.conf` is kept verbatim (see "The streaming API key exception") |
-| Source bytes preserved | collected files keep their byte-order mark, their per-line terminators (CRLF/CR/LF, including on redacted lines) and a missing final newline, so an encoding fault in the user's file is still visible in the bundle; what was observed is recorded per file under `source_encoding` in `MANIFEST.json`, and anomalies are listed in `summary.txt` |
+| Source bytes preserved | collected files keep their byte-order mark, their per-line terminators (CRLF/CR/LF, including on lines the sanitizer rewrote) and a missing final newline, so an encoding fault in the user's file is still visible in the bundle |
 | PII pseudonymized by default | IPs (v4+v6), MACs, emails, this host's names, the invoking user, child/mirrored node hostnames and stream destinations are replaced with **stable** pseudonyms (`ip-1`, `private-host-1`) so cross-file correlation still works; the private map is saved **next to** the bundle, never inside it; `--no-obfuscate` / `-NoObfuscate` opts out |
 | Caps cannot expose secrets | all caps cut at LINE boundaries, so a secret can never straddle the cut and dodge the line-based sanitizer; a capped tail with no line break at all is withheld entirely; sanitizer failures withhold the file content (fail closed) |
 | Legible to humans AND AI agents | triage-ordered numbered directories; sanitized file copies have no injected provenance headers; provenance headers only on command captures; `MANIFEST.json` indexes every file with safe origin + sanitization state; `summary.txt` opens with a triage read-order |
@@ -272,23 +272,22 @@ Redaction must not silently rewrite the bytes of a collected file, because the
 encoding *is* sometimes the bug (a BOM in `stream.conf`, a config saved with
 CRLF, a truncated file with no final newline).
 
-Preserved through sanitization on both platforms: the byte-order mark (restored
-byte-for-byte); each line's own terminator — CRLF, bare CR or LF — **including
-on lines the sanitizer rewrote**, which previously lost the CR; and the absence
-of a final newline. UTF-16/32 bodies are still withheld whole, since they carry
-NUL bytes.
+Preserved through sanitization on both platforms: the byte-order mark; each
+line's own terminator — CRLF, bare CR or LF — **including on lines the sanitizer
+rewrote**, which previously lost the CR; and the absence of a final newline.
+UTF-16/32 bodies are still withheld whole, since they carry NUL bytes. On
+Windows a source that is not valid UTF-8 round-trips through ISO-8859-1, so a
+Latin-1 config is not corrupted into U+FFFD.
 
-Reported so a fault is legible without a hex dump: `MANIFEST.json` carries a
-`source_encoding` object per **copied file** (`bom`, `lf`, `crlf`, `cr`,
-`final_newline`, `non_ascii_bytes`, `utf8_valid`), and `summary.txt` lists only
-the files with something notable. Command and API captures get no record —
-those bytes are the tool's own, so they would describe this script, not a source
-file.
+Two encodings need special handling by the POSIX sanitizer, and both are
+covered by `--selftest` vectors:
 
-A BOM used to shift every `^`-anchored rule, so a BOM-prefixed `[<API_KEY>]`
-header did **not** match the section rule and shipped verbatim. The BOM is now
-stripped for the redaction pass and restored afterwards; both selftests carry
-the regression test.
+- a **BOM** used to shift every `^`-anchored rule, so a BOM-prefixed
+  `[<API_KEY>]` header did not match the section rule and shipped verbatim. The
+  BOM is stripped for the redaction pass and restored afterwards.
+- a **CR-only** file is a single record to awk, so only its first key was ever
+  examined and later secrets shipped unredacted. It is translated to LF for the
+  pass and translated back.
 
 ## Redaction philosophy
 
@@ -419,9 +418,9 @@ by these scripts.
    per-command timeout.
 4. If the item can contain credentials or PII of a NEW shape, extend the sanitizer
    in **both** scripts and add the pattern to the Sanitization section above.
-   If the item is a COPIED file, it must go through `collect_file` / `Save-File`
-   so its bytes and its `source_encoding` record are preserved; do not add a
-   collector that reads a user file and writes it out itself.
+   A COPIED file must go through `collect_file` / `Save-File` so its bytes are
+   preserved; do not add a collector that reads a user file and writes it out
+   itself.
 5. Mirror the change in the other script (`.sh` ↔ `.ps1`) or record explicitly
    in your PR why it is platform-specific.
 6. Test the redaction: add a vector to the built-in regression suite and run
@@ -437,9 +436,9 @@ by these scripts.
 
 - Schema id: `netdata-support-bundle/v1` (in `MANIFEST.json`). Bump the suffix on
   breaking layout changes; downstream ticket tooling may parse it. The
-  `09-permissions/` section, the per-file `source_encoding` object and the
-  top-level `streaming_api_key_redacted` flag were added in tool version 1.1.0
-  and are purely additive, so the schema id is unchanged.
+  `09-permissions/` section and the top-level `streaming_api_key_redacted` flag
+  were added in tool version 1.1.0 and are purely additive, so the schema id is
+  unchanged.
 - Command captures are `.txt` files starting with a
   `# netdata-support-bundle v<version> | command: ... | captured: <utc>` header; on POSIX
   they also end with an `# exit: N | duration: Ns` trailer. PowerShell command

--- a/packaging/installer/SUPPORT-BUNDLE.md
+++ b/packaging/installer/SUPPORT-BUNDLE.md
@@ -214,8 +214,8 @@ Tools are feature-detected and a missing one is reported, not passed over.
 `getfattr` ships in the `attr` package, which is **not** installed by default on
 Debian/Ubuntu, so when it is absent the collector falls back to `getcap` (for
 `security.capability`) and `lsattr` (for ext file flags) — the attributes that
-actually break netdata — instead of reporting nothing. macOS uses
-`ls -l@`/`xattr`, FreeBSD uses `lsextattr`.
+actually break netdata — instead of reporting nothing. macOS uses `xattr -l`,
+FreeBSD uses `lsextattr`.
 
 ## What is NEVER collected
 

--- a/packaging/installer/SUPPORT-BUNDLE.md
+++ b/packaging/installer/SUPPORT-BUNDLE.md
@@ -55,7 +55,8 @@ document.**
 |---|---|
 | Zero system impact | self-demotion to idle CPU/IO priority (`nice -n 19` + `ionice -c 3` / `PriorityClass = Idle`); per-command timeout (10 s default, via `timeout` or a portable watchdog — the watchdog kills the direct child only, a documented limitation); global deadline checked before each collector, so the hard runtime bound is deadline + one command timeout; size caps (5 MiB per log, 1 MiB per file, 2 MiB per command/API output); read-only — writes only its private staging dir and the final artifacts, never restarts or reconfigures anything; artifacts are published with `O_EXCL` so pre-existing files or symlinks in shared tmp dirs are never followed |
 | Works when the agent is dead | no hard dependency on a running agent; the most valuable crash artifacts (status file, logs, buildinfo via the binary) are collected from disk; a `07-runtime/AGENT-WAS-DOWN.txt` marker is written instead of API captures |
-| Secrets always redacted | non-optional single-pass sanitizer; see "Sanitization" below |
+| Secrets always redacted | non-optional single-pass sanitizer; see "Sanitization" below. **One documented exception:** the streaming API key in `stream.conf` is kept verbatim (see "The streaming API key exception") |
+| Source bytes preserved | collected files keep their byte-order mark, their per-line terminators (CRLF/CR/LF, including on redacted lines) and a missing final newline, so an encoding fault in the user's file is still visible in the bundle; what was observed is recorded per file under `source_encoding` in `MANIFEST.json`, and anomalies are listed in `summary.txt` |
 | PII pseudonymized by default | IPs (v4+v6), MACs, emails, this host's names, the invoking user, child/mirrored node hostnames and stream destinations are replaced with **stable** pseudonyms (`ip-1`, `private-host-1`) so cross-file correlation still works; the private map is saved **next to** the bundle, never inside it; `--no-obfuscate` / `-NoObfuscate` opts out |
 | Caps cannot expose secrets | all caps cut at LINE boundaries, so a secret can never straddle the cut and dodge the line-based sanitizer; a capped tail with no line break at all is withheld entirely; sanitizer failures withhold the file content (fail closed) |
 | Legible to humans AND AI agents | triage-ordered numbered directories; sanitized file copies have no injected provenance headers; provenance headers only on command captures; `MANIFEST.json` indexes every file with safe origin + sanitization state; `summary.txt` opens with a triage read-order |
@@ -70,7 +71,7 @@ document.**
 | Static builds (`/opt/netdata`) | tested paths | all paths resolved under the prefix |
 | FreeBSD | best effort | `/usr/local/etc/netdata` + `/var/db/netdata` paths, `sockstat` fallback, `ps -H` threads; no `/proc` items |
 | macOS (Homebrew) | best effort | `/usr/local` and `/opt/homebrew` prefixes, `sysctl`/`vm_stat` fallbacks, `ps -M` threads |
-| Windows | tested in CI | Windows PowerShell 5.1 runs the adversarial suite and builds/opens a complete fixture zip; PowerShell 7 runs the same sanitizer suite |
+| Windows | tested in CI | Windows PowerShell 5.1 runs the adversarial suite and builds/opens a complete fixture zip; PowerShell 7 runs the same sanitizer suite. Daemon logs come from the ETW channels (`Netdata/*`), not `NetdataWEL`, on any build with `HAVE_ETW` — which is every `OS_WINDOWS` build |
 
 Portability rules the POSIX script obeys (keep them when editing):
 
@@ -152,7 +153,8 @@ Every item collected maps to a recurring support ask. That mapping is the
 |---|---|
 | systemd journal, **including `--namespace=netdata`** | the agent logs to its own journal namespace on systemd installs — plain `journalctl -u netdata` misses almost everything; support asks for "a complete log from start until the problem" |
 | `/var/log/netdata/*.log` tails (size-capped) | non-systemd installs, static builds, macOS/BSD |
-| Windows Event Log (`NetdataWEL` + Application, Netdata providers) | Windows agents log to the Event Log; Windows is a top-3 support theme |
+| Windows Event Log: the five **ETW channels** (`Netdata/Daemon`, `Netdata/Collectors`, `Netdata/Health`, `Netdata/Aclk`, `Netdata/Access`) plus `NetdataWEL` and Netdata records from `Application`, in one merged file | Windows builds are always compiled with ETW (`CMakeLists.txt` sets `HAVE_ETW` unconditionally for `OS_WINDOWS`) and `netdata-conf-logs.c` then picks `etw` as the default log method, so the daemon logs into the manifest-declared `Netdata/*` channels (`wevt_netdata_mc_generate.c`). Querying only `NetdataWEL` returned **no daemon logs at all** on a default install. Ordered for triage — channel/provider state first, then Daemon and Collectors, with `Netdata/Access` last and on the smallest event budget because it is by far the highest volume |
+| Windows Event Log **channel configuration and provider registration** | a disabled or full channel silently loses events, and if the ETW publisher was never registered the `Netdata/*` channels do not exist at all — both are indistinguishable from "the agent logged nothing" without this |
 | updater service journal | update failures; the updater keeps no persistent log file |
 | **coredump metadata** (`coredumpctl list`, never the dumps) | tells support a dump exists and matches the crash time — the dump itself is fetched later only if needed |
 | docker marker file | in containers the log "files" are symlinks to stdout — history only exists in `docker logs` on the host; the bundle says raw logs must not be attached and gives a private capture/review/redaction workflow using the requested time window |
@@ -194,6 +196,27 @@ proxy, so diagnostic data cannot leave the host through a forced proxy.
 | DNS config, proxy env/config (sanitized) | claiming-behind-proxy is a recurring theme; DNS misconfiguration breaks cloud connectivity |
 | Netdata Cloud reachability (TCP plus certificate-validating HTTPS/TLS probe; no bundle data sent) | separates network problems from agent problems in one step |
 
+### `09-permissions/` — why the agent cannot read/execute something
+
+Mode bits alone do not explain most permission failures on a netdata install:
+plugins rely on **file capabilities** and setuid bits, distributions apply
+**SELinux/AppArmor** confinement, and packagers use **ACLs**. None of that is
+visible in an `ls -la`.
+
+| item | why |
+|---|---|
+| **`plugins.d`**: mode, ownership, setuid/setgid bits and per-file **capabilities** (`getcap`) | a dropped capability or a lost setuid bit is a top cause of "this collector shows no data"; on a stock install seven plugins carry capabilities (`apps.plugin`, `debugfs.plugin`, `go.d.plugin`, `network-viewer.plugin`, `perf.plugin`, `slabinfo.plugin`, `systemd-journal.plugin`) and several more are setuid — none of which an `ls -la` reveals |
+| all netdata paths (config dir, `netdata.conf`, `stream.conf`, `ssl/`, log/lib/cache dirs, `plugins.d`, the binary): mode, owner, **extended attributes**, **security context**, **ACLs**, non-default ext2/3/4 file flags | an immutable (`i`) flag on a state directory silently blocks the agent's own writes, and an SELinux mislabel produces collector failures with no error in the agent log |
+| discovered `plugins.d` locations | derived from the binary prefix, the known install prefixes, **and** the `[directories] plugins` list in `netdata.conf` (a quoted, space-separated list whose default also includes `<config>/custom-plugins.d`), so custom prefixes are not missed |
+| Windows: ACLs with inheritance state, protected-ACL detection, mandatory integrity labels, alternate data streams | a `Zone.Identifier` stream marks a file as downloaded-and-blocked, and a protected (inheritance-disabled) ACL is a common post-restore breakage |
+
+Tools are feature-detected and a missing one is reported, not passed over.
+`getfattr` ships in the `attr` package, which is **not** installed by default on
+Debian/Ubuntu, so when it is absent the collector falls back to `getcap` (for
+`security.capability`) and `lsattr` (for ext file flags) — the attributes that
+actually break netdata — instead of reporting nothing. macOS uses
+`ls -l@`/`xattr`, FreeBSD uses `lsextattr`.
+
 ## What is NEVER collected
 
 These are excluded by design. **Do not add them.**
@@ -207,6 +230,65 @@ These are excluded by design. **Do not add them.**
 - metric values other than netdata's own bounded self-monitoring charts
 - anything outside netdata's own scope (no full system journals, no other
   services' logs, no packet captures)
+
+## The streaming API key exception
+
+The **streaming API key** is the one credential-shaped value the bundle keeps
+verbatim, in `04-config/stream.conf` only. Both forms are preserved: the
+`api key` / `proxy api key` values and the parent-side `[<API_KEY>]` (and
+`[<MACHINE_GUID>]`) section headers.
+
+Why: streaming problems are diagnosed by comparing what the child sends with
+what the parent accepts. With the key redacted, support cannot tell whether the
+two sides agree, and a parent with several key sections collapsed to identical
+`[REDACTED-KEY-SECTION]` lines also made per-key settings unattributable.
+`[MACHINE_GUID]` sections are documented in `stream.conf` itself as *not* a
+security mechanism, and they were being destroyed by the same rule.
+
+Scope and limits, all deliberate:
+
+- **File-scoped and key-exact.** The exemption applies only when the source file
+  is named `stream.conf` (keyed on the source path, never the bundle path) and
+  only to a key normalizing exactly to `api key` or `proxy api key`. Any other
+  secret in `stream.conf` — `password`, `token`, a PEM block — is still redacted,
+  as is a third-party `api key` in any other file.
+- **Not applied to logs.** The same key also appears in access logs: the parent
+  logs `api_key:'<key>'` (`src/streaming/stream-receiver-connection.c`) and
+  children send it as a `key=` query parameter
+  (`src/streaming/stream-connector.c`). Those stay redacted — un-redacting there
+  would loosen rules shared with genuinely secret query parameters such as
+  `claim_token`.
+- **Disclosed to the recipient.** The bundle's `README.md` states the exception,
+  `summary.txt` prints a `streaming key:` line when `stream.conf` was collected,
+  and `MANIFEST.json` carries `"streaming_api_key_redacted": false` next to
+  `"secrets_redacted": true`.
+
+If you disagree with this posture, remove or mask `04-config/stream.conf` before
+sending the bundle.
+
+## Encoding fidelity
+
+Redaction must not silently rewrite the bytes of a collected file, because the
+encoding *is* sometimes the bug (a BOM in `stream.conf`, a config saved with
+CRLF, a truncated file with no final newline).
+
+Preserved through sanitization on both platforms: the byte-order mark (restored
+byte-for-byte); each line's own terminator — CRLF, bare CR or LF — **including
+on lines the sanitizer rewrote**, which previously lost the CR; and the absence
+of a final newline. UTF-16/32 bodies are still withheld whole, since they carry
+NUL bytes.
+
+Reported so a fault is legible without a hex dump: `MANIFEST.json` carries a
+`source_encoding` object per **copied file** (`bom`, `lf`, `crlf`, `cr`,
+`final_newline`, `non_ascii_bytes`, `utf8_valid`), and `summary.txt` lists only
+the files with something notable. Command and API captures get no record —
+those bytes are the tool's own, so they would describe this script, not a source
+file.
+
+A BOM used to shift every `^`-anchored rule, so a BOM-prefixed `[<API_KEY>]`
+header did **not** match the section rule and shipped verbatim. The BOM is now
+stripped for the redaction pass and restored afterwards; both selftests carry
+the regression test.
 
 ## Redaction philosophy
 
@@ -222,7 +304,8 @@ Two facts do the heavy lifting and are why we do not chase completeness:
    bundle before sending it** (`summary.txt` and this document say so).
 
 Concretely, we redact credential-bearing config keys, URL/DSN credentials,
-JWT/Bearer/Basic tokens, PEM key blocks, `stream.conf` API-key sections, and
+JWT/Bearer/Basic tokens, PEM key blocks, `[<UUID>]` API-key sections outside
+`stream.conf` (see "The streaming API key exception"), and
 PII (IPs, MACs, emails, hostnames, usernames); and we never collect files that
 are *pure* secrets at all (the never-collect list). We deliberately do **not**
 try to parse arbitrary nested structure to prove no secret can ever slip
@@ -252,9 +335,11 @@ Two passes, one sweep, applied to **every** collected file:
      no sentence punctuation) so prose containing "token" is not mangled.
      Exemptions are decided by the KEY, never the value: keys ending in
      `file path dir directory protection support mode level port timeout
-     cookies secure log size options format type` describe secrets rather than being
+     cookies secure log size options` describe secrets rather than being
      secrets, so `bearer token protection = no` and `api key file = /path`
      stay readable while `TOKEN=false` and `PASSWORD=/x` are redacted;
+     plus the file-scoped, key-exact streaming API key exemption described in
+     "The streaming API key exception";
    - argv/env-style secrets mid-line (`-token=X`, `--password "X"`,
      `CLAIM_TOKEN=X`, `api key = X` inside captured process command lines),
      including single- and double-quoted values;
@@ -267,8 +352,9 @@ Two passes, one sweep, applied to **every** collected file:
      lines in access logs);
    - private-key PEM blocks — the WHOLE multi-line block is withheld from the
      BEGIN marker through the END marker (fail closed if END never arrives);
-   - `stream.conf` parent-side `[<UUID>]` section headers (they ARE the API
-     keys);
+   - `[<UUID>]` section headers, which are API keys or machine GUIDs — **except
+     in `stream.conf`**, where they are kept (see "The streaming API key
+     exception");
    - `bearer_tokens/` directory listings show a file COUNT only — the
      filenames are the tokens.
 2. **PII — on by default, `--no-obfuscate` / `-NoObfuscate` to disable:**
@@ -285,7 +371,16 @@ Two passes, one sweep, applied to **every** collected file:
      collection, so they pseudonymize consistently in every file) and
      `stream.conf` `destination` hosts regardless of TLD → `private-host-N`;
    - resolv.conf `search`/`domain` values → `[SEARCH-DOMAINS-WITHHELD]`
-     (corporate search domains are rarely under private TLDs).
+     (corporate search domains are rarely under private TLDs);
+   - Windows only: the machine's own Active Directory domain (NetBIOS and DNS
+     form) → `redacted-domain`. The `09-permissions` ACL captures print
+     `DOMAIN\user` throughout, and an AD domain name identifies the customer.
+     Replacement is by exact known value — the same approach used for the
+     hostname and the invoking user — because a generic `DOMAIN\user` pattern
+     cannot be distinguished from a Windows path segment such as
+     `C:\Users\Public`. Built-in authorities (`BUILTIN`, `NT AUTHORITY`,
+     `NT SERVICE`) are untouched. POSIX has no counterpart: `getfacl` there
+     yields local account names only.
 
 The private map is written next to the bundle (`*.pseudonym-map.tsv`) so the
 **user** can decode references if support asks "what is private-host-2?" — it
@@ -322,8 +417,11 @@ by these scripts.
 3. Respect the cost budget: nothing unbounded, nothing that queries metric
    data without a tight window, nothing that can block longer than the
    per-command timeout.
-4. If the item can contain credentials of a NEW shape, extend the sanitizer
+4. If the item can contain credentials or PII of a NEW shape, extend the sanitizer
    in **both** scripts and add the pattern to the Sanitization section above.
+   If the item is a COPIED file, it must go through `collect_file` / `Save-File`
+   so its bytes and its `source_encoding` record are preserved; do not add a
+   collector that reads a user file and writes it out itself.
 5. Mirror the change in the other script (`.sh` ↔ `.ps1`) or record explicitly
    in your PR why it is platform-specific.
 6. Test the redaction: add a vector to the built-in regression suite and run
@@ -338,7 +436,10 @@ by these scripts.
 ## Bundle format contract
 
 - Schema id: `netdata-support-bundle/v1` (in `MANIFEST.json`). Bump the suffix on
-  breaking layout changes; downstream ticket tooling may parse it.
+  breaking layout changes; downstream ticket tooling may parse it. The
+  `09-permissions/` section, the per-file `source_encoding` object and the
+  top-level `streaming_api_key_redacted` flag were added in tool version 1.1.0
+  and are purely additive, so the schema id is unchanged.
 - Command captures are `.txt` files starting with a
   `# netdata-support-bundle v<version> | command: ... | captured: <utc>` header; on POSIX
   they also end with an `# exit: N | duration: Ns` trailer. PowerShell command

--- a/packaging/installer/SUPPORT-BUNDLE.md
+++ b/packaging/installer/SUPPORT-BUNDLE.md
@@ -153,8 +153,7 @@ Every item collected maps to a recurring support ask. That mapping is the
 |---|---|
 | systemd journal, **including `--namespace=netdata`** | the agent logs to its own journal namespace on systemd installs — plain `journalctl -u netdata` misses almost everything; support asks for "a complete log from start until the problem" |
 | `/var/log/netdata/*.log` tails (size-capped) | non-systemd installs, static builds, macOS/BSD |
-| Windows Event Log: the five **ETW channels** (`Netdata/Daemon`, `Netdata/Collectors`, `Netdata/Health`, `Netdata/Aclk`, `Netdata/Access`) plus `NetdataWEL` and Netdata records from `Application`, in one merged file | Windows builds are always compiled with ETW (`CMakeLists.txt` sets `HAVE_ETW` unconditionally for `OS_WINDOWS`) and `netdata-conf-logs.c` then picks `etw` as the default log method, so the daemon logs into the manifest-declared `Netdata/*` channels (`wevt_netdata_mc_generate.c`). Querying only `NetdataWEL` returned **no daemon logs at all** on a default install. Ordered for triage — channel/provider state first, then Daemon and Collectors, with `Netdata/Access` last and on the smallest event budget because it is by far the highest volume |
-| Windows Event Log **channel configuration and provider registration** | a disabled or full channel silently loses events, and if the ETW publisher was never registered the `Netdata/*` channels do not exist at all — both are indistinguishable from "the agent logged nothing" without this |
+| Windows Event Log: the five **ETW channels** (`Netdata/Daemon`, `Netdata/Collectors`, `Netdata/Health`, `Netdata/Aclk`, `Netdata/Access`) plus `NetdataWEL` and Netdata records from `Application`, in one merged file, with channel state | every `OS_WINDOWS` build defines `HAVE_ETW` (`CMakeLists.txt`) and `netdata-conf-logs.c` then picks `etw`, so the daemon logs into the manifest-declared `Netdata/*` channels (`wevt_netdata_mc_generate.c`). Querying only `NetdataWEL` returned **no daemon logs at all** on a default install. Ordered for triage, with `Netdata/Access` last and on the smallest budget since it is by far the highest volume; channel state is included because a disabled or full channel is otherwise indistinguishable from "the agent logged nothing" |
 | updater service journal | update failures; the updater keeps no persistent log file |
 | **coredump metadata** (`coredumpctl list`, never the dumps) | tells support a dump exists and matches the crash time — the dump itself is fetched later only if needed |
 | docker marker file | in containers the log "files" are symlinks to stdout — history only exists in `docker logs` on the host; the bundle says raw logs must not be attached and gives a private capture/review/redaction workflow using the requested time window |
@@ -198,24 +197,26 @@ proxy, so diagnostic data cannot leave the host through a forced proxy.
 
 ### `09-permissions/` — why the agent cannot read/execute something
 
-Mode bits alone do not explain most permission failures on a netdata install:
-plugins rely on **file capabilities** and setuid bits, distributions apply
-**SELinux/AppArmor** confinement, and packagers use **ACLs**. None of that is
-visible in an `ls -la`.
+Mode bits alone explain almost nothing here: plugins rely on **file
+capabilities** and setuid bits, distributions apply **SELinux/AppArmor**
+confinement, and packagers use **ACLs**. None of that shows in an `ls -la`.
 
 | item | why |
 |---|---|
-| **`plugins.d`**: mode, ownership, setuid/setgid bits and per-file **capabilities** (`getcap`) | a dropped capability or a lost setuid bit is a top cause of "this collector shows no data"; on a stock install seven plugins carry capabilities (`apps.plugin`, `debugfs.plugin`, `go.d.plugin`, `network-viewer.plugin`, `perf.plugin`, `slabinfo.plugin`, `systemd-journal.plugin`) and several more are setuid — none of which an `ls -la` reveals |
-| all netdata paths (config dir, `netdata.conf`, `stream.conf`, `ssl/`, log/lib/cache dirs, `plugins.d`, the binary): mode, owner, **extended attributes**, **security context**, **ACLs**, non-default ext2/3/4 file flags | an immutable (`i`) flag on a state directory silently blocks the agent's own writes, and an SELinux mislabel produces collector failures with no error in the agent log |
-| discovered `plugins.d` locations | derived from the binary prefix, the known install prefixes, **and** the `[directories] plugins` list in `netdata.conf` (a quoted, space-separated list whose default also includes `<config>/custom-plugins.d`), so custom prefixes are not missed |
-| Windows: ACLs with inheritance state, protected-ACL detection, mandatory integrity labels, alternate data streams | a `Zone.Identifier` stream marks a file as downloaded-and-blocked, and a protected (inheritance-disabled) ACL is a common post-restore breakage |
+| **`plugins.d`**: mode, ownership, setuid/setgid bits and per-file **capabilities** (`getcap`) | a dropped capability or lost setuid bit is a top cause of "this collector shows no data" — a stock install has seven capability-bearing plugins (`apps.plugin`, `debugfs.plugin`, `go.d.plugin`, `network-viewer.plugin`, `perf.plugin`, `slabinfo.plugin`, `systemd-journal.plugin`) and several setuid ones |
+| all netdata paths (config dir, `netdata.conf`, `stream.conf`, `ssl/`, log/lib/cache dirs, `plugins.d`, the binary): mode, owner, **extended attributes**, **security context**, **ACLs**, non-default ext2/3/4 file flags | an immutable (`i`) flag on a state directory silently blocks the agent's own writes, and an SELinux mislabel fails collectors with nothing in the agent log |
+| Windows: ACLs with inheritance state, protected-ACL detection, integrity labels, alternate data streams | a `Zone.Identifier` stream marks a file downloaded-and-blocked; a protected (inheritance-disabled) ACL is a common post-restore breakage |
 
-Tools are feature-detected and a missing one is reported, not passed over.
-`getfattr` ships in the `attr` package, which is **not** installed by default on
-Debian/Ubuntu, so when it is absent the collector falls back to `getcap` (for
-`security.capability`) and `lsattr` (for ext file flags) — the attributes that
-actually break netdata — instead of reporting nothing. macOS uses `xattr -l`,
-FreeBSD uses `lsextattr`.
+`plugins.d` locations come from the binary prefix, the known install prefixes
+and `<config>/custom-plugins.d`. A `[directories] plugins` override in
+`netdata.conf` is deliberately not read, so no config-derived value is ever
+handed to a collector.
+
+Tools are feature-detected and a missing one is reported rather than skipped.
+`getfattr` ships in the `attr` package, **not** installed by default on
+Debian/Ubuntu, so without it the collector falls back to `getcap` and `lsattr` —
+the attributes that actually break netdata. macOS uses `xattr -l`, FreeBSD
+`lsextattr`.
 
 ## What is NEVER collected
 
@@ -234,37 +235,26 @@ These are excluded by design. **Do not add them.**
 ## The streaming API key exception
 
 The **streaming API key** is the one credential-shaped value the bundle keeps
-verbatim, in `04-config/stream.conf` only. Both forms are preserved: the
-`api key` / `proxy api key` values and the parent-side `[<API_KEY>]` (and
-`[<MACHINE_GUID>]`) section headers.
+verbatim, in `04-config/stream.conf` only — both the `api key` / `proxy api key`
+values and the parent-side `[<API_KEY>]` / `[<MACHINE_GUID>]` section headers.
+Streaming problems are diagnosed by comparing what the child sends with what the
+parent accepts, and redacting it also collapsed every key section to an
+identical placeholder, making per-key settings unattributable.
 
-Why: streaming problems are diagnosed by comparing what the child sends with
-what the parent accepts. With the key redacted, support cannot tell whether the
-two sides agree, and a parent with several key sections collapsed to identical
-`[REDACTED-KEY-SECTION]` lines also made per-key settings unattributable.
-`[MACHINE_GUID]` sections are documented in `stream.conf` itself as *not* a
-security mechanism, and they were being destroyed by the same rule.
+- **File-scoped and key-exact.** Only when the source file is named
+  `stream.conf` (keyed on the source path, never the bundle path), and only for
+  a key normalizing exactly to `api key` or `proxy api key`. Any other secret in
+  that file, and any `api key` elsewhere, is still redacted.
+- **Not applied to logs.** The parent also logs `api_key:'<key>'`
+  (`src/streaming/stream-receiver-connection.c`) and children send it as a
+  `key=` query parameter (`src/streaming/stream-connector.c`). Those stay
+  redacted — un-redacting them would loosen rules shared with genuinely secret
+  parameters such as `claim_token`.
+- **Disclosed to the recipient.** Stated in the bundle's `README.md` and
+  `summary.txt`, and flagged as `"streaming_api_key_redacted": false` in
+  `MANIFEST.json`.
 
-Scope and limits, all deliberate:
-
-- **File-scoped and key-exact.** The exemption applies only when the source file
-  is named `stream.conf` (keyed on the source path, never the bundle path) and
-  only to a key normalizing exactly to `api key` or `proxy api key`. Any other
-  secret in `stream.conf` — `password`, `token`, a PEM block — is still redacted,
-  as is a third-party `api key` in any other file.
-- **Not applied to logs.** The same key also appears in access logs: the parent
-  logs `api_key:'<key>'` (`src/streaming/stream-receiver-connection.c`) and
-  children send it as a `key=` query parameter
-  (`src/streaming/stream-connector.c`). Those stay redacted — un-redacting there
-  would loosen rules shared with genuinely secret query parameters such as
-  `claim_token`.
-- **Disclosed to the recipient.** The bundle's `README.md` states the exception,
-  `summary.txt` prints a `streaming key:` line when `stream.conf` was collected,
-  and `MANIFEST.json` carries `"streaming_api_key_redacted": false` next to
-  `"secrets_redacted": true`.
-
-If you disagree with this posture, remove or mask `04-config/stream.conf` before
-sending the bundle.
+To opt out, remove or mask `04-config/stream.conf` before sending the bundle.
 
 ## Encoding fidelity
 

--- a/packaging/installer/netdata-support-bundle
+++ b/packaging/installer/netdata-support-bundle
@@ -91,10 +91,8 @@ mkdir -p "$WORK"
 MAP_FILE="$STAGING/map.tsv"; : > "$MAP_FILE"
 MANIFEST_ROWS="$STAGING/manifest.rows"; : > "$MANIFEST_ROWS"
 ERRORS="$STAGING/errors.txt"; : > "$ERRORS"
-# encoding facts of the file most recently sanitized; consumed by manifest_add.
-# ENC_NOTES accumulates only the ANOMALIES, which summary.txt surfaces.
-ENC_NOTES="$STAGING/encoding.notes"; : > "$ENC_NOTES"
-ENC_JSON=""; ENC_NOTE=""; ENC_BOM=none; ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_CRONLY=0
+# what the sanitizer must preserve for the file it is currently processing
+ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_CRONLY=0
 
 cleanup() { [ "$KEEP_STAGING" = "1" ] || rm -rf "$STAGING"; }
 trap cleanup EXIT
@@ -172,67 +170,31 @@ RUN_USER=$(id -un 2>/dev/null || echo "")
 case "$RUN_USER" in root|netdata|"") RUN_USER="" ;; *) : ;; esac
 [ ${#RUN_USER} -lt 3 ] && RUN_USER=""
 
-# encoding_probe <staged-file> - record the encoding of a collected file BEFORE
-# redaction touches it, so support can tell a genuine source-file encoding fault
-# (a BOM, mixed line endings, a missing final newline, invalid UTF-8) from an
-# artifact of this tool. Redaction used to normalize these away silently.
+# encoding_probe <staged-file> - work out what the sanitizer must preserve:
+# where the BOM ends, whether the file ends with a terminator, and whether it
+# uses CR-only line endings. Redaction used to silently normalize all three
+# away (netdata/netdata#23448).
 encoding_probe() {
-  _ef="$1"; _erel="${_ef#"$WORK"/}"
-  ENC_BOM=none; ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_CRONLY=0; ENC_JSON=""
-  _esize=$(wc -c < "$_ef" 2>/dev/null | tr -d ' ')
-  _ehex=$(head -c 4 "$_ef" 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')
-  case "$_ehex" in
-    efbbbf*)  ENC_BOM=utf-8;    ENC_BOM_BYTES=3 ;;
-    fffe0000) ENC_BOM=utf-32le; ENC_BOM_BYTES=4 ;;
-    0000feff) ENC_BOM=utf-32be; ENC_BOM_BYTES=4 ;;
-    fffe*)    ENC_BOM=utf-16le; ENC_BOM_BYTES=2 ;;
-    feff*)    ENC_BOM=utf-16be; ENC_BOM_BYTES=2 ;;
+  _ef="$1"
+  ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_CRONLY=0
+  case "$(head -c 4 "$_ef" 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')" in
+    efbbbf*)  ENC_BOM_BYTES=3 ;;
+    fffe0000|0000feff) ENC_BOM_BYTES=4 ;;
+    fffe*|feff*) ENC_BOM_BYTES=2 ;;
     *) : ;;
   esac
-  _elf=$(LC_ALL=C tr -dc '\n' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')
-  _ecr=$(LC_ALL=C tr -dc '\r' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')
-  # records ending in CR are CRLF pairs (awk splits on LF); the rest are bare CRs
-  _ecrlf=$(LC_ALL=C awk '/\r$/ { c++ } END { print c + 0 }' "$_ef" 2>/dev/null)
-  [ -n "${_ecrlf:-}" ] || _ecrlf=0
-  # with no LF anywhere there are no CRLF pairs - awk saw the whole file as one
-  # record and counted its trailing CR as if it were one
-  [ "$_elf" -eq 0 ] && _ecrlf=0
-  _ebarecr=$((_ecr - _ecrlf)); [ "$_ebarecr" -lt 0 ] && _ebarecr=0
-  _ebarelf=$((_elf - _ecrlf)); [ "$_ebarelf" -lt 0 ] && _ebarelf=0
-  # CR is a line terminator too: a CR-terminated file is NOT missing its final
-  # newline, and sanitize_file relies on this to avoid eating that last byte
+  # CR is a line terminator too, so a CR-terminated file is not missing its
+  # final newline - sanitize_file relies on this to not eat that last byte
   case "$(tail -c 1 "$_ef" 2>/dev/null | od -An -tx1 | tr -d ' \n')" in
-    0a|0d) ENC_FINAL=true ;;
+    0a|0d) : ;;
     *) ENC_FINAL=false ;;
   esac
-  # CR-only (classic Mac) endings make the whole file ONE awk record, so only its
-  # first key would ever be examined - sanitize_file translates for the pass
-  ENC_CRONLY=0
-  [ "$_ebarecr" -gt 0 ] && [ "$_elf" -eq 0 ] && ENC_CRONLY=1
-  # exclude the BOM's own bytes: it is reported separately, and counting it here
-  # would make a pure-ASCII file look like it carried non-ASCII content
-  _enonascii=$(LC_ALL=C tr -d '\000-\177' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')
-  _enonascii=$((_enonascii - ENC_BOM_BYTES)); [ "$_enonascii" -lt 0 ] && _enonascii=0
-  # iconv is the only portable UTF-8 validator, and it is absent on some busybox
-  # systems: report null rather than guessing
-  _eutf8=null
-  if command -v iconv >/dev/null 2>&1; then
-    if iconv -f UTF-8 -t UTF-8 "$_ef" >/dev/null 2>&1; then _eutf8=true; else _eutf8=false; fi
+  # CR-only (classic Mac) endings make the whole file ONE awk record, so only
+  # its first key would ever be examined - sanitize_file translates for the pass
+  if [ "$(LC_ALL=C tr -dc '\n' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')" = "0" ] &&
+     [ "$(LC_ALL=C tr -dc '\r' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')" != "0" ]; then
+    ENC_CRONLY=1
   fi
-  ENC_JSON=$(printf '{"bom":"%s","lf":%s,"crlf":%s,"cr":%s,"final_newline":%s,"non_ascii_bytes":%s,"utf8_valid":%s}' \
-    "$ENC_BOM" "$_ebarelf" "$_ecrlf" "$_ebarecr" "$ENC_FINAL" "$_enonascii" "$_eutf8")
-  # Staged for manifest_add to commit, NOT written here: only COPIED files have a
-  # source encoding worth reporting. A command capture's line endings are this
-  # tool's own artifact (our header is CRLF-joined on Windows), so recording them
-  # would fill the report with noise that looks like user-file faults.
-  _enote=""
-  [ "$ENC_BOM" != "none" ] && _enote="$_enote ${ENC_BOM}-BOM"
-  [ "$_ebarecr" -gt 0 ] && _enote="$_enote CR-only-line-endings($_ebarecr)"
-  [ "$_ecrlf" -gt 0 ] && [ "$_ebarelf" -gt 0 ] && _enote="$_enote mixed-line-endings(lf=$_ebarelf,crlf=$_ecrlf)"
-  [ "$ENC_FINAL" = "false" ] && [ "${_esize:-0}" != "0" ] && _enote="$_enote no-final-newline"
-  [ "$_eutf8" = "false" ] && _enote="$_enote invalid-UTF-8"
-  ENC_NOTE=""
-  [ -n "$_enote" ] && ENC_NOTE="$_erel	${_enote# }"
   return 0
 }
 
@@ -242,7 +204,6 @@ encoding_probe() {
 # secret key inside stream.conf, is redacted as before.
 sanitize_file() {
   _f="$1"; _ctx="${2:-}"
-  ENC_JSON=""
   [ -f "$_f" ] || return 0
   encoding_probe "$_f"
   # binary/UTF-16 input would make line-based redaction byte-unsafe: withhold
@@ -682,7 +643,6 @@ sanitize_file() {
     # fail CLOSED: never ship content the sanitizer could not process
     rm -f "$_f.san" "$_f.san2" "$_f.nobom" "$_f.lf" "$_f.out" "$_f.out2"
     echo "[netdata-support-bundle] sanitization failed for this file - content withheld for safety" > "$_f"
-    ENC_JSON=""
   fi
 }
 
@@ -695,25 +655,10 @@ json_str() { # collapse newlines/tabs, escape backslashes and quotes
 manifest_add() {
   _rel="$1"; _kind="$2"; _origin="$3"; _title="$4"
   _bytes=0; [ -f "$WORK/$_rel" ] && _bytes=$(wc -c < "$WORK/$_rel" | tr -d ' ')
-  # source_encoding is recorded for COPIED files only: for command/API captures
-  # the bytes are ours, so the facts would describe this tool, not a source file.
-  # For a capped file it describes the retained tail (see the origin field).
-  _enc="$ENC_JSON"; ENC_JSON=""
-  _encnote="$ENC_NOTE"; ENC_NOTE=""
-  if [ "$_kind" = "file" ]; then
-    [ -n "$_encnote" ] && printf '%s\n' "$_encnote" >> "$ENC_NOTES"
-  else
-    _enc=""
-  fi
-  if [ -n "$_enc" ]; then
-    printf '{"path":"%s","kind":"%s","origin":"%s","title":"%s","bytes":%s,"pii_obfuscated":%s,"source_encoding":%s}\n' \
-      "$(json_str "$_rel")" "$_kind" "$(json_str "$_origin")" "$(json_str "$_title")" "$_bytes" \
-      "$([ "$OBFUSCATE" = "1" ] && echo true || echo false)" "$_enc" >> "$MANIFEST_ROWS"
-  else
-    printf '{"path":"%s","kind":"%s","origin":"%s","title":"%s","bytes":%s,"pii_obfuscated":%s}\n' \
-      "$(json_str "$_rel")" "$_kind" "$(json_str "$_origin")" "$(json_str "$_title")" "$_bytes" \
-      "$([ "$OBFUSCATE" = "1" ] && echo true || echo false)" >> "$MANIFEST_ROWS"
-  fi
+  printf '{"path":"%s","kind":"%s","origin":"%s","title":"%s","bytes":%s,"pii_obfuscated":%s}
+' \
+    "$(json_str "$_rel")" "$_kind" "$(json_str "$_origin")" "$(json_str "$_title")" "$_bytes" \
+    "$([ "$OBFUSCATE" = "1" ] && echo true || echo false)" >> "$MANIFEST_ROWS"
 }
 
 # --- collectors ---------------------------------------------------------------
@@ -753,7 +698,6 @@ collect_cmd() {
 # collect_file <rel-path> <title> <source-file> [cap-bytes]
 collect_file() {
   _rel="$1"; _title="$2"; _src="$3"; _cap="${4:-$FILE_CAP}"
-  ENC_JSON=""
   deadline_exceeded && return 0
   [ -f "$_src" ] && [ -r "$_src" ] || return 0
   # stream.conf is the one file whose streaming API key is kept verbatim; the
@@ -987,10 +931,6 @@ STREAMVEC
     { echo "FAIL: CRLF line endings were lost (including on the redacted line)" >&2; _fails=$((_fails + 1)); }
   [ "$(tail -c 1 "$_ef" | wc -l | tr -d ' ')" = "0" ] || \
     { echo "FAIL: a final newline was added to a source that had none" >&2; _fails=$((_fails + 1)); }
-  case "$ENC_JSON" in
-    *'"bom":"utf-8"'*) : ;;
-    *) echo "FAIL: source_encoding did not record the BOM" >&2; _fails=$((_fails + 1)) ;;
-  esac
   # --- CR-only (classic Mac) endings: awk sees ONE record, so without the
   # --- translation only the first key would be examined and later secrets
   # --- would ship unredacted
@@ -1020,11 +960,6 @@ STREAMVEC
     { echo "FAIL: BOM lost on a CR-only file" >&2; _fails=$((_fails + 1)); }
   grep -q "SENTINEL-BOMCR" "$_cf3" && \
     { echo "FAIL (leak): secret in a BOM'd CR-only file survived" >&2; _fails=$((_fails + 1)); }
-  # a file with no LF has no CRLF pairs, however awk records it
-  case "$ENC_JSON" in
-    *'"crlf":0'*) : ;;
-    *) echo "FAIL: CR-only file reported CRLF pairs in source_encoding" >&2; _fails=$((_fails + 1)) ;;
-  esac
 
   if [ "$_fails" -eq 0 ]; then
     echo "netdata-support-bundle selftest: ALL PASS"
@@ -1395,10 +1330,10 @@ collect_cmd 08-network/cloud-connectivity.txt "Reachability of Netdata Cloud (DN
 # =============================================================================
 info "collecting: permissions"
 # plugins.d discovery: the binary's own prefix, the known install prefixes, and
-# the [directories] plugins list from netdata.conf (a QUOTED, space-separated
-# list whose default also includes <config>/custom-plugins.d - plugins_d.c:26).
-# Read from the SOURCE config, not the staged copy, so paths are not
-# pseudonymized before we use them.
+# <config>/custom-plugins.d, which the agent also searches by default
+# (plugins_d.c). A [directories] plugins override in netdata.conf is not read:
+# it is rare, and keeping every path here out of user-controlled input means
+# nothing config-derived ever reaches a collector.
 PLUGINSD_DIRS=""
 _add_pluginsd() {
   [ -n "${1:-}" ] || return 0
@@ -1420,16 +1355,6 @@ for d in /usr/libexec/netdata/plugins.d /usr/lib/netdata/plugins.d \
   _add_pluginsd "$d"
 done
 [ -n "$CONFDIR" ] && _add_pluginsd "$CONFDIR/custom-plugins.d"
-if [ -n "$CONFDIR" ] && [ -r "$CONFDIR/netdata.conf" ]; then
-  _pdlist=$(awk 'BEGIN { FS = "=" }
-    /^[ \t]*\[/ { insec = ($0 ~ /^[ \t]*\[directories\][ \t\r]*$/); next }
-    insec && $1 ~ /^[ \t]*plugins[ \t]*$/ {
-      v = $2; gsub(/"/, " ", v); sub(/^[ \t]*/, "", v); sub(/[ \t\r]*$/, "", v); print v; exit
-    }' "$CONFDIR/netdata.conf" 2>/dev/null)
-  set -f
-  for _pd in $_pdlist; do _add_pluginsd "$_pd"; done
-  set +f
-fi
 PLUGINSD_DIRS="${PLUGINSD_DIRS# }"
 
 # The directory list reaches the child as positional ARGUMENTS, never as text
@@ -1576,11 +1501,6 @@ CRASH_HINT=""
   [ -n "$CRASH_HINT" ] && echo "last exit reason: $CRASH_HINT   <-- check 06-state/status-file.json"
   [ -n "$ERRCOUNT" ] && echo "error.log 'error' lines: $ERRCOUNT"
   [ "${DOCKER_LOGS_NEEDED:-0}" = "1" ] && echo "NOTE: agent log HISTORY is not in this bundle - it lives in 'docker logs' on the host (see 05-logs/LOGS-ARE-IN-DOCKER.txt)"
-  if [ -s "$ENC_NOTES" ]; then
-    echo
-    echo "SOURCE FILES WITH NOTABLE ENCODING (preserved as-is in this bundle):"
-    sort -u "$ENC_NOTES" | head -40 | awk -F'\t' '{ printf "  %s: %s\n", $1, $2 }'
-  fi
   echo
   echo "READ ORDER FOR TRIAGE:"
   echo "  crashes/won't start -> 06-state/status-file.json, 05-logs/, 01-system/kernel-messages.txt"
@@ -1610,9 +1530,8 @@ mask it in `04-config/stream.conf` before sending the bundle. Note the same key
 IS still redacted in `05-logs/access.log`, where it also appears.
 
 Collected files keep their original bytes: a byte-order mark, CRLF or CR line
-endings and a missing final newline all survive redaction, so encoding faults
-stay visible. What was observed is recorded per file under `source_encoding` in
-`MANIFEST.json`, and anything notable is listed in `summary.txt`.
+endings and a missing final newline all survive redaction, so an encoding fault
+in a config file is still visible here.
 
 ## Layout (triage order)
 
@@ -1635,7 +1554,7 @@ stay visible. What was observed is recorded per file under `source_encoding` in
 - Command captures (`*.txt`) begin with a `# netdata-support-bundle | command: ...`
   provenance header and end with `# exit: N`.
 - Copied files (configs, logs, json) are pristine (no injected headers);
-  their origin and `source_encoding` are recorded in `MANIFEST.json`.
+  their origin is recorded in `MANIFEST.json`.
 - `07-runtime/AGENT-WAS-DOWN.txt` exists when the local API probe failed (the
   agent may be down, or its API bound away from 127.0.0.1 / bearer-protected).
 EOF

--- a/packaging/installer/netdata-support-bundle
+++ b/packaging/installer/netdata-support-bundle
@@ -194,6 +194,9 @@ encoding_probe() {
   # records ending in CR are CRLF pairs (awk splits on LF); the rest are bare CRs
   _ecrlf=$(LC_ALL=C awk '/\r$/ { c++ } END { print c + 0 }' "$_ef" 2>/dev/null)
   [ -n "${_ecrlf:-}" ] || _ecrlf=0
+  # with no LF anywhere there are no CRLF pairs - awk saw the whole file as one
+  # record and counted its trailing CR as if it were one
+  [ "$_elf" -eq 0 ] && _ecrlf=0
   _ebarecr=$((_ecr - _ecrlf)); [ "$_ebarecr" -lt 0 ] && _ebarecr=0
   _ebarelf=$((_elf - _ecrlf)); [ "$_ebarelf" -lt 0 ] && _ebarelf=0
   # CR is a line terminator too: a CR-terminated file is NOT missing its final
@@ -252,9 +255,11 @@ sanitize_file() {
   # A BOM shifts every ^-anchored rule in the sanitizer: a BOM'd "[<API_KEY>]"
   # header did NOT match the section rule and shipped verbatim. Strip the BOM
   # for the redaction pass and restore the exact bytes afterwards.
-  _sanin="$_f"
+  _sanin="$_f"; _bomstripped=0
   if [ "$ENC_BOM_BYTES" -gt 0 ]; then
-    if tail -c "+$((ENC_BOM_BYTES + 1))" "$_f" > "$_f.nobom" 2>>"$ERRORS"; then _sanin="$_f.nobom"; fi
+    if tail -c "+$((ENC_BOM_BYTES + 1))" "$_f" > "$_f.nobom" 2>>"$ERRORS"; then
+      _sanin="$_f.nobom"; _bomstripped=1
+    fi
   fi
   # A CR-only file is a single record to awk, so every rule would see one giant
   # line and only its FIRST key would be examined - later secrets would ship
@@ -656,7 +661,7 @@ sanitize_file() {
     fi
     # restore the exact BOM bytes the source had, so an encoding fault in the
     # user's file is still visible in the bundle
-    if [ "$_sanin" = "$_f.nobom" ]; then
+    if [ "$_bomstripped" = "1" ]; then
       head -c "$ENC_BOM_BYTES" "$_f" > "$_f.out" 2>>"$ERRORS"
     else
       : > "$_f.out"
@@ -666,7 +671,8 @@ sanitize_file() {
     # had no final newline, so a truncated source file still looks truncated
     if [ "$ENC_FINAL" = "false" ]; then
       _osz=$(wc -c < "$_f.out" | tr -d ' ')
-      if [ "${_osz:-0}" -gt 0 ] && [ "$(tail -c 1 "$_f.out" | wc -l | tr -d ' ')" = "1" ]; then
+      _lastout=$(tail -c 1 "$_f.out" 2>/dev/null | od -An -tx1 | tr -d ' \n')
+      if [ "${_osz:-0}" -gt 0 ] && { [ "$_lastout" = "0a" ] || [ "$_lastout" = "0d" ]; }; then
         head -c "$((_osz - 1))" "$_f.out" > "$_f.out2" 2>>"$ERRORS" && mv "$_f.out2" "$_f.out"
       fi
     fi
@@ -997,6 +1003,28 @@ STREAMVEC
     { echo "FAIL: CR-only line endings were not reproduced" >&2; _fails=$((_fails + 1)); }
   [ "$(LC_ALL=C tr -dc '\n' < "$_cf" | wc -c | tr -d ' ')" = "0" ] || \
     { echo "FAIL: CR-only file gained LF terminators" >&2; _fails=$((_fails + 1)); }
+  # a CR-only file that does NOT end in a terminator must not gain one
+  _cf2="$_tf.cronly2"
+  printf 'a = 1\rpassword = SENTINEL-CRONLY2\rlast' > "$_cf2"
+  sanitize_file "$_cf2"
+  grep -q "SENTINEL-CRONLY2" "$_cf2" && \
+    { echo "FAIL (leak): secret in a terminator-less CR-only file survived" >&2; _fails=$((_fails + 1)); }
+  [ "$(tail -c 1 "$_cf2" | od -An -tx1 | tr -d ' \n')" = "0d" ] && \
+    { echo "FAIL: CR-only file without a final terminator gained one" >&2; _fails=$((_fails + 1)); }
+  # a BOM on a CR-only file must still survive (the CR translation must not
+  # bypass the BOM restore)
+  _cf3="$_tf.bomcr"
+  printf '\357\273\277a = 1\rpassword = SENTINEL-BOMCR\r' > "$_cf3"
+  sanitize_file "$_cf3"
+  [ "$(head -c 3 "$_cf3" | od -An -tx1 | tr -d ' \n')" = "efbbbf" ] || \
+    { echo "FAIL: BOM lost on a CR-only file" >&2; _fails=$((_fails + 1)); }
+  grep -q "SENTINEL-BOMCR" "$_cf3" && \
+    { echo "FAIL (leak): secret in a BOM'd CR-only file survived" >&2; _fails=$((_fails + 1)); }
+  # a file with no LF has no CRLF pairs, however awk records it
+  case "$ENC_JSON" in
+    *'"crlf":0'*) : ;;
+    *) echo "FAIL: CR-only file reported CRLF pairs in source_encoding" >&2; _fails=$((_fails + 1)) ;;
+  esac
 
   if [ "$_fails" -eq 0 ]; then
     echo "netdata-support-bundle selftest: ALL PASS"

--- a/packaging/installer/netdata-support-bundle
+++ b/packaging/installer/netdata-support-bundle
@@ -14,8 +14,14 @@
 #   - Works with or without a running agent, with or without root (degrades gracefully).
 #   - Zero system impact: idle CPU/IO priority, per-command timeouts, global deadline,
 #     size caps, strictly read-only outside its own staging dir.
-#   - Secrets are ALWAYS redacted (non-optional). PII (IPs, MACs, emails, hostnames)
-#     pseudonymized by default; --no-obfuscate disables PII pass only.
+#   - Secrets are ALWAYS redacted (non-optional), with ONE documented exception:
+#     the streaming API key in stream.conf is kept verbatim (it is what support
+#     needs to match a child against its parent - netdata/netdata#23448).
+#     PII (IPs, MACs, emails, hostnames) pseudonymized by default;
+#     --no-obfuscate disables PII pass only.
+#   - Collected files keep their original bytes: BOM, line terminators and a
+#     missing final newline survive redaction, and what was observed is recorded
+#     per file in MANIFEST.json, so encoding faults stay diagnosable.
 #   - Bundle is legible to humans AND AI agents: triage-ordered directories, pristine
 #     file copies, provenance in MANIFEST.json, human summary.txt, README.md inside.
 #
@@ -43,7 +49,7 @@ if [ -z "${ND_SUPPORT_BUNDLE_DEMOTED:-}" ]; then
   exec nice -n 19 sh "$0" "$@"
 fi
 
-VERSION="1.0.0"
+VERSION="1.1.0"
 OUTDIR="/tmp"
 SINCE_HOURS=24
 CMD_TIMEOUT=10
@@ -85,6 +91,10 @@ mkdir -p "$WORK"
 MAP_FILE="$STAGING/map.tsv"; : > "$MAP_FILE"
 MANIFEST_ROWS="$STAGING/manifest.rows"; : > "$MANIFEST_ROWS"
 ERRORS="$STAGING/errors.txt"; : > "$ERRORS"
+# encoding facts of the file most recently sanitized; consumed by manifest_add.
+# ENC_NOTES accumulates only the ANOMALIES, which summary.txt surfaces.
+ENC_NOTES="$STAGING/encoding.notes"; : > "$ENC_NOTES"
+ENC_JSON=""; ENC_NOTE=""; ENC_BOM=none; ENC_BOM_BYTES=0; ENC_FINAL=true
 
 cleanup() { [ "$KEEP_STAGING" = "1" ] || rm -rf "$STAGING"; }
 trap cleanup EXIT
@@ -162,9 +172,67 @@ RUN_USER=$(id -un 2>/dev/null || echo "")
 case "$RUN_USER" in root|netdata|"") RUN_USER="" ;; *) : ;; esac
 [ ${#RUN_USER} -lt 3 ] && RUN_USER=""
 
+# encoding_probe <staged-file> - record the encoding of a collected file BEFORE
+# redaction touches it, so support can tell a genuine source-file encoding fault
+# (a BOM, mixed line endings, a missing final newline, invalid UTF-8) from an
+# artifact of this tool. Redaction used to normalize these away silently.
+encoding_probe() {
+  _ef="$1"; _erel="${_ef#"$WORK"/}"
+  ENC_BOM=none; ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_JSON=""
+  _esize=$(wc -c < "$_ef" 2>/dev/null | tr -d ' ')
+  _ehex=$(head -c 4 "$_ef" 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')
+  case "$_ehex" in
+    efbbbf*)  ENC_BOM=utf-8;    ENC_BOM_BYTES=3 ;;
+    fffe0000) ENC_BOM=utf-32le; ENC_BOM_BYTES=4 ;;
+    0000feff) ENC_BOM=utf-32be; ENC_BOM_BYTES=4 ;;
+    fffe*)    ENC_BOM=utf-16le; ENC_BOM_BYTES=2 ;;
+    feff*)    ENC_BOM=utf-16be; ENC_BOM_BYTES=2 ;;
+    *) : ;;
+  esac
+  _elf=$(LC_ALL=C tr -dc '\n' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')
+  _ecr=$(LC_ALL=C tr -dc '\r' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')
+  # records ending in CR are CRLF pairs (awk splits on LF); the rest are bare CRs
+  _ecrlf=$(LC_ALL=C awk '/\r$/ { c++ } END { print c + 0 }' "$_ef" 2>/dev/null)
+  [ -n "${_ecrlf:-}" ] || _ecrlf=0
+  _ebarecr=$((_ecr - _ecrlf)); [ "$_ebarecr" -lt 0 ] && _ebarecr=0
+  _ebarelf=$((_elf - _ecrlf)); [ "$_ebarelf" -lt 0 ] && _ebarelf=0
+  [ "$(tail -c 1 "$_ef" 2>/dev/null | wc -l | tr -d ' ')" = "1" ] || ENC_FINAL=false
+  # exclude the BOM's own bytes: it is reported separately, and counting it here
+  # would make a pure-ASCII file look like it carried non-ASCII content
+  _enonascii=$(LC_ALL=C tr -d '\000-\177' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')
+  _enonascii=$((_enonascii - ENC_BOM_BYTES)); [ "$_enonascii" -lt 0 ] && _enonascii=0
+  # iconv is the only portable UTF-8 validator, and it is absent on some busybox
+  # systems: report null rather than guessing
+  _eutf8=null
+  if command -v iconv >/dev/null 2>&1; then
+    if iconv -f UTF-8 -t UTF-8 "$_ef" >/dev/null 2>&1; then _eutf8=true; else _eutf8=false; fi
+  fi
+  ENC_JSON=$(printf '{"bom":"%s","lf":%s,"crlf":%s,"cr":%s,"final_newline":%s,"non_ascii_bytes":%s,"utf8_valid":%s}' \
+    "$ENC_BOM" "$_ebarelf" "$_ecrlf" "$_ebarecr" "$ENC_FINAL" "$_enonascii" "$_eutf8")
+  # Staged for manifest_add to commit, NOT written here: only COPIED files have a
+  # source encoding worth reporting. A command capture's line endings are this
+  # tool's own artifact (our header is CRLF-joined on Windows), so recording them
+  # would fill the report with noise that looks like user-file faults.
+  _enote=""
+  [ "$ENC_BOM" != "none" ] && _enote="$_enote ${ENC_BOM}-BOM"
+  [ "$_ebarecr" -gt 0 ] && _enote="$_enote CR-only-line-endings($_ebarecr)"
+  [ "$_ecrlf" -gt 0 ] && [ "$_ebarelf" -gt 0 ] && _enote="$_enote mixed-line-endings(lf=$_ebarelf,crlf=$_ecrlf)"
+  [ "$ENC_FINAL" = "false" ] && [ "${_esize:-0}" != "0" ] && _enote="$_enote no-final-newline"
+  [ "$_eutf8" = "false" ] && _enote="$_enote invalid-UTF-8"
+  ENC_NOTE=""
+  [ -n "$_enote" ] && ENC_NOTE="$_erel	${_enote# }"
+  return 0
+}
+
+# sanitize_file <staged-file> [context]
+# context "stream" marks stream.conf, the one file where the streaming API key
+# is kept verbatim (netdata/netdata#23448). Every other file, and every other
+# secret key inside stream.conf, is redacted as before.
 sanitize_file() {
-  _f="$1"
+  _f="$1"; _ctx="${2:-}"
+  ENC_JSON=""
   [ -f "$_f" ] || return 0
+  encoding_probe "$_f"
   # binary/UTF-16 input would make line-based redaction byte-unsafe: withhold
   _b_all=$(wc -c < "$_f")
   _b_txt=$(LC_ALL=C tr -d '\000' < "$_f" | wc -c)
@@ -172,7 +240,14 @@ sanitize_file() {
     echo "[content withheld: file contains NUL bytes (binary or UTF-16?)]" > "$_f"
     return 0
   fi
-  if awk -v obf="$OBFUSCATE" -v mapfile="$MAP_FILE" \
+  # A BOM shifts every ^-anchored rule in the sanitizer: a BOM'd "[<API_KEY>]"
+  # header did NOT match the section rule and shipped verbatim. Strip the BOM
+  # for the redaction pass and restore the exact bytes afterwards.
+  _sanin="$_f"
+  if [ "$ENC_BOM_BYTES" -gt 0 ]; then
+    if tail -c "+$((ENC_BOM_BYTES + 1))" "$_f" > "$_f.nobom" 2>>"$ERRORS"; then _sanin="$_f.nobom"; fi
+  fi
+  if awk -v ctx="$_ctx" -v obf="$OBFUSCATE" -v mapfile="$MAP_FILE" \
       -v host_short="$HOST_SHORT" -v host_fqdn="$HOST_FQDN" -v run_user="$RUN_USER" '
   BEGIN {
     nsec = split("api key,apikey,token,password,passwd,pwd,secret,community,bearer,webhook,license key,auth,credential,cookie,passphrase,proxy user,proxy pass,username,dsn,private key,access key,session,recipient,account sid,priv key", SK, ",");
@@ -196,6 +271,15 @@ sanitize_file() {
     if (lk ~ /(^| )(file|path|dir|directory|protection|support|mode|level|port|timeout|cookies|secure|log|size|options)$/) return 1;
     return 0;
   }
+  function streaming_api_key(lk) {
+    # netdata/netdata#23448: the STREAMING api key is not treated as a secret -
+    # support needs its value to tell whether a child and its parent agree.
+    # Scoped to stream.conf (ctx) and to an EXACT key match, so a third-party
+    # "api key" in any other file, and any other secret key inside stream.conf,
+    # is still redacted. Deliberately NOT applied to access logs, where the same
+    # value appears via stream-receiver-connection.c and a "key=" query param.
+    return (ctx == "stream" && (lk == "api key" || lk == "proxy api key"));
+  }
   function redact_kv(line,   i, k, pos, posc, pose, key, lk) {
     # ini/yaml/env style: <key> = value | <key>: value | KEY=value
     # (JSON-shaped lines are owned by redact_json, which preserves quoting)
@@ -213,6 +297,7 @@ sanitize_file() {
       lk = tolower(key);
       gsub(/[-_]/, " ", lk);
       if (diagnostic_key(lk)) return line;
+      if (streaming_api_key(lk)) return line;
       for (i = 1; i <= nsec; i++) {
         if (index(lk, SK[i]) > 0 && substr(line, pos + 1) ~ /[^ \t]/)
           return substr(line, 1, pos) " [REDACTED]";
@@ -444,14 +529,20 @@ sanitize_file() {
   {
     # NOTE: no {n,m} regex intervals anywhere in this program - older BSD awks
     # treat them as literal braces, which would silently disable redaction.
+    # Split a CRLF terminator off first and re-append it at print time. Two
+    # reasons: redaction rules used to rebuild lines without the CR (silently
+    # converting a CRLF file to mixed endings), and a trailing CR otherwise
+    # becomes part of the matched VALUE ("TOKEN=false\r"), skewing the rules.
+    line = $0; cr = "";
+    if (line ~ /\r$/) { cr = "\r"; sub(/\r$/, "", line); }
     # PEM private keys are multi-line: withhold the WHOLE block, fail closed
     # if the END marker never arrives.
     if (inpem) {
-      if ($0 ~ /-----END [A-Z ]*PRIVATE KEY/) inpem = 0;
+      if (line ~ /-----END [A-Z ]*PRIVATE KEY/) inpem = 0;
       next;
     }
-    if ($0 ~ /-----BEGIN [A-Z ]*PRIVATE KEY/) {
-      print "[REDACTED PRIVATE KEY BLOCK]";
+    if (line ~ /-----BEGIN [A-Z ]*PRIVATE KEY/) {
+      print "[REDACTED PRIVATE KEY BLOCK]" cr;
       inpem = 1;
       next;
     }
@@ -464,10 +555,12 @@ sanitize_file() {
     # are still withheld. This matches typical support-bundle tools: redact the
     # well-defined cases, and rely on the user reviewing the bundle before
     # sending it. See SUPPORT-BUNDLE.md "Redaction philosophy".
-    line = $0;
-    # stream.conf parent side: [<API_KEY>] / [<MACHINE_GUID>] section headers ARE secrets
-    if (line ~ /^[ \t]*\[[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]\][ \t]*$/) {
-      print "[REDACTED-KEY-SECTION]"; next;
+    # [<UUID>] section headers are API keys (or machine GUIDs). In stream.conf
+    # they are kept: support needs to see WHICH key each section configures, and
+    # collapsing them all to one placeholder also made per-key settings
+    # unattributable. Everywhere else they are still withheld.
+    if (ctx != "stream" && line ~ /^[ \t]*\[[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]\][ \t]*$/) {
+      print "[REDACTED-KEY-SECTION]" cr; next;
     }
     line = redact_kv(line);
     if (line ~ /"[^"]+"[ \t]*:[ \t]*/) line = redact_json(line);
@@ -515,7 +608,7 @@ sanitize_file() {
       m = substr(rest, RSTART, RLENGTH);
       sub(/[ ]?=.*/, "", m);
       lk = tolower(m); gsub(/[-_]/, " ", lk);
-      if (diagnostic_key(lk))
+      if (diagnostic_key(lk) || streaming_api_key(lk))
         out = out substr(rest, 1, RSTART + RLENGTH - 1);
       else
         out = out substr(rest, 1, RSTART - 1) m " = [REDACTED]";
@@ -540,13 +633,31 @@ sanitize_file() {
       # other local users appear in mount tables / paths when run as root
       line = gensub_home(line);
     }
-    print line;
-  }' "$_f" > "$_f.san" 2>>"$ERRORS"; then
-    mv "$_f.san" "$_f"
+    print line cr;
+  }' "$_sanin" > "$_f.san" 2>>"$ERRORS"; then
+    # restore the exact BOM bytes the source had, so an encoding fault in the
+    # user's file is still visible in the bundle
+    if [ "$_sanin" = "$_f.nobom" ]; then
+      head -c "$ENC_BOM_BYTES" "$_f" > "$_f.out" 2>>"$ERRORS"
+    else
+      : > "$_f.out"
+    fi
+    cat "$_f.san" >> "$_f.out"
+    # awk always terminates its last line: drop that byte again when the source
+    # had no final newline, so a truncated source file still looks truncated
+    if [ "$ENC_FINAL" = "false" ]; then
+      _osz=$(wc -c < "$_f.out" | tr -d ' ')
+      if [ "${_osz:-0}" -gt 0 ] && [ "$(tail -c 1 "$_f.out" | wc -l | tr -d ' ')" = "1" ]; then
+        head -c "$((_osz - 1))" "$_f.out" > "$_f.out2" 2>>"$ERRORS" && mv "$_f.out2" "$_f.out"
+      fi
+    fi
+    mv "$_f.out" "$_f"
+    rm -f "$_f.san" "$_f.nobom" "$_f.out2"
   else
     # fail CLOSED: never ship content the sanitizer could not process
-    rm -f "$_f.san"
+    rm -f "$_f.san" "$_f.nobom" "$_f.out" "$_f.out2"
     echo "[netdata-support-bundle] sanitization failed for this file - content withheld for safety" > "$_f"
+    ENC_JSON=""
   fi
 }
 
@@ -559,9 +670,25 @@ json_str() { # collapse newlines/tabs, escape backslashes and quotes
 manifest_add() {
   _rel="$1"; _kind="$2"; _origin="$3"; _title="$4"
   _bytes=0; [ -f "$WORK/$_rel" ] && _bytes=$(wc -c < "$WORK/$_rel" | tr -d ' ')
-  printf '{"path":"%s","kind":"%s","origin":"%s","title":"%s","bytes":%s,"pii_obfuscated":%s}\n' \
-    "$(json_str "$_rel")" "$_kind" "$(json_str "$_origin")" "$(json_str "$_title")" "$_bytes" \
-    "$([ "$OBFUSCATE" = "1" ] && echo true || echo false)" >> "$MANIFEST_ROWS"
+  # source_encoding is recorded for COPIED files only: for command/API captures
+  # the bytes are ours, so the facts would describe this tool, not a source file.
+  # For a capped file it describes the retained tail (see the origin field).
+  _enc="$ENC_JSON"; ENC_JSON=""
+  _encnote="$ENC_NOTE"; ENC_NOTE=""
+  if [ "$_kind" = "file" ]; then
+    [ -n "$_encnote" ] && printf '%s\n' "$_encnote" >> "$ENC_NOTES"
+  else
+    _enc=""
+  fi
+  if [ -n "$_enc" ]; then
+    printf '{"path":"%s","kind":"%s","origin":"%s","title":"%s","bytes":%s,"pii_obfuscated":%s,"source_encoding":%s}\n' \
+      "$(json_str "$_rel")" "$_kind" "$(json_str "$_origin")" "$(json_str "$_title")" "$_bytes" \
+      "$([ "$OBFUSCATE" = "1" ] && echo true || echo false)" "$_enc" >> "$MANIFEST_ROWS"
+  else
+    printf '{"path":"%s","kind":"%s","origin":"%s","title":"%s","bytes":%s,"pii_obfuscated":%s}\n' \
+      "$(json_str "$_rel")" "$_kind" "$(json_str "$_origin")" "$(json_str "$_title")" "$_bytes" \
+      "$([ "$OBFUSCATE" = "1" ] && echo true || echo false)" >> "$MANIFEST_ROWS"
+  fi
 }
 
 # --- collectors ---------------------------------------------------------------
@@ -601,8 +728,13 @@ collect_cmd() {
 # collect_file <rel-path> <title> <source-file> [cap-bytes]
 collect_file() {
   _rel="$1"; _title="$2"; _src="$3"; _cap="${4:-$FILE_CAP}"
+  ENC_JSON=""
   deadline_exceeded && return 0
   [ -f "$_src" ] && [ -r "$_src" ] || return 0
+  # stream.conf is the one file whose streaming API key is kept verbatim; the
+  # context is keyed on the SOURCE name, never on the bundle path
+  _fctx=""
+  case "${_src##*/}" in stream.conf) _fctx="stream" ;; *) : ;; esac
   # a symlinked final component is not a real config/log file we chose to
   # collect; refuse it so a swapped link cannot redirect us to another target
   # (symlinked parent DIRECTORIES resolve normally - only the leaf is checked)
@@ -628,7 +760,7 @@ collect_file() {
     cat "$_src" > "$_out" 2>>"$ERRORS"
     _origin="$_src"
   fi
-  sanitize_file "$_out"
+  sanitize_file "$_out" "$_fctx"
   manifest_add "$_rel" "file" "$_origin" "$_title"
 }
 
@@ -777,6 +909,64 @@ VECTORS
   printf 'nul-test \000 password=SENTINEL-NUL\n' > "$_tf.nul"
   sanitize_file "$_tf.nul"
   grep -q "content withheld" "$_tf.nul" || { echo "FAIL: NUL-bearing file was not withheld" >&2; _fails=$((_fails + 1)); }
+
+  # --- stream.conf context (netdata/netdata#23448): the STREAMING api key is
+  # --- kept verbatim, while every other secret in the same file is redacted
+  _sf="$_tf.stream"
+  cat > "$_sf" <<'STREAMVEC'
+[stream]
+    enabled = yes
+    api key = 11111111-2222-3333-4444-555555555555
+    proxy api key = 99999999-8888-7777-6666-555555555555
+    password = SENTINEL-STREAM-PW
+[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]
+    enabled = yes
+STREAMVEC
+  _obf_save3="$OBFUSCATE"; OBFUSCATE=1
+  sanitize_file "$_sf" stream
+  OBFUSCATE="$_obf_save3"
+  s_present() {
+    grep -qF -- "$1" "$_sf" || { echo "FAIL (over-redaction): $2" >&2; _fails=$((_fails + 1)); }
+  }
+  s_present "api key = 11111111-2222-3333-4444-555555555555" "streaming api key was redacted in stream context"
+  s_present "proxy api key = 99999999-8888-7777-6666-555555555555" "proxy api key was redacted in stream context"
+  s_present "[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]" "stream.conf [<API_KEY>] section header was redacted"
+  grep -q "SENTINEL-STREAM-PW" "$_sf" && \
+    { echo "FAIL (leak): a non-api-key secret survived in stream.conf" >&2; _fails=$((_fails + 1)); }
+  # the SAME api key line must still be redacted WITHOUT the stream context
+  _sf2="$_tf.nostream"
+  printf 'api key = 11111111-2222-3333-4444-555555555555\n[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]\n' > "$_sf2"
+  sanitize_file "$_sf2"
+  grep -q "11111111-2222" "$_sf2" && \
+    { echo "FAIL (leak): api key kept outside stream.conf (context leaked)" >&2; _fails=$((_fails + 1)); }
+  grep -q "REDACTED-KEY-SECTION" "$_sf2" || \
+    { echo "FAIL (leak): [<UUID>] section not redacted outside stream.conf" >&2; _fails=$((_fails + 1)); }
+
+  # --- encoding fidelity (netdata/netdata#23448): a BOM, CRLF endings and a
+  # --- missing final newline must all survive redaction, and a BOM must NOT
+  # --- shift the ^-anchored rules (it used to defeat the section redaction)
+  _ef="$_tf.enc"
+  printf '\357\273\277[11111111-2222-3333-4444-555555555555]\r\npassword = SENTINEL-ENC\r\nlast line without newline' > "$_ef"
+  _obf_save4="$OBFUSCATE"; OBFUSCATE=1
+  sanitize_file "$_ef"
+  OBFUSCATE="$_obf_save4"
+  [ "$(head -c 3 "$_ef" 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "efbbbf" ] || \
+    { echo "FAIL: the UTF-8 BOM was stripped by sanitization" >&2; _fails=$((_fails + 1)); }
+  grep -q "REDACTED-KEY-SECTION" "$_ef" || \
+    { echo "FAIL (leak): a BOM defeated the [<UUID>] section redaction" >&2; _fails=$((_fails + 1)); }
+  grep -q "11111111-2222" "$_ef" && \
+    { echo "FAIL (leak): BOM'd api key section survived" >&2; _fails=$((_fails + 1)); }
+  grep -q "SENTINEL-ENC" "$_ef" && \
+    { echo "FAIL (leak): secret survived in the encoding vector" >&2; _fails=$((_fails + 1)); }
+  [ "$(LC_ALL=C tr -dc '\r' < "$_ef" | wc -c | tr -d ' ')" -ge 2 ] || \
+    { echo "FAIL: CRLF line endings were lost (including on the redacted line)" >&2; _fails=$((_fails + 1)); }
+  [ "$(tail -c 1 "$_ef" | wc -l | tr -d ' ')" = "0" ] || \
+    { echo "FAIL: a final newline was added to a source that had none" >&2; _fails=$((_fails + 1)); }
+  case "$ENC_JSON" in
+    *'"bom":"utf-8"'*) : ;;
+    *) echo "FAIL: source_encoding did not record the BOM" >&2; _fails=$((_fails + 1)) ;;
+  esac
+
   if [ "$_fails" -eq 0 ]; then
     echo "netdata-support-bundle selftest: ALL PASS"
     exit 0
@@ -1142,6 +1332,139 @@ collect_cmd 08-network/cloud-connectivity.txt "Reachability of Netdata Cloud (DN
   else echo "neither curl nor wget available"; fi; true'
 
 # =============================================================================
+# 09-permissions
+# =============================================================================
+info "collecting: permissions"
+# plugins.d discovery: the binary's own prefix, the known install prefixes, and
+# the [directories] plugins list from netdata.conf (a QUOTED, space-separated
+# list whose default also includes <config>/custom-plugins.d - plugins_d.c:26).
+# Read from the SOURCE config, not the staged copy, so paths are not
+# pseudonymized before we use them.
+PLUGINSD_DIRS=""
+_add_pluginsd() {
+  [ -n "${1:-}" ] || return 0
+  [ -d "$1" ] || return 0
+  case " $PLUGINSD_DIRS " in *" $1 "*) return 0 ;; *) : ;; esac
+  PLUGINSD_DIRS="$PLUGINSD_DIRS $1"
+}
+if [ -n "${NETDATA_BIN:-}" ]; then
+  case "$NETDATA_BIN" in
+    */usr/sbin/netdata|*/usr/bin/netdata) _add_pluginsd "${NETDATA_BIN%/usr/*}/usr/libexec/netdata/plugins.d" ;;
+    *) : ;;
+  esac
+  _add_pluginsd "$(dirname "$(dirname "$NETDATA_BIN")")/libexec/netdata/plugins.d"
+fi
+for d in /usr/libexec/netdata/plugins.d /usr/lib/netdata/plugins.d \
+         /opt/netdata/usr/libexec/netdata/plugins.d \
+         /usr/local/libexec/netdata/plugins.d \
+         /opt/homebrew/libexec/netdata/plugins.d; do
+  _add_pluginsd "$d"
+done
+[ -n "$CONFDIR" ] && _add_pluginsd "$CONFDIR/custom-plugins.d"
+if [ -n "$CONFDIR" ] && [ -r "$CONFDIR/netdata.conf" ]; then
+  _pdlist=$(awk 'BEGIN { FS = "=" }
+    /^[ \t]*\[/ { insec = ($0 ~ /^[ \t]*\[directories\][ \t\r]*$/); next }
+    insec && $1 ~ /^[ \t]*plugins[ \t]*$/ {
+      v = $2; gsub(/"/, " ", v); sub(/^[ \t]*/, "", v); sub(/[ \t\r]*$/, "", v); print v; exit
+    }' "$CONFDIR/netdata.conf" 2>/dev/null)
+  set -f
+  for _pd in $_pdlist; do _add_pluginsd "$_pd"; done
+  set +f
+fi
+PLUGINSD_DIRS="${PLUGINSD_DIRS# }"
+
+collect_cmd 09-permissions/plugins-d.txt "plugins.d: modes, ownership, setuid/setgid bits, file CAPABILITIES and the parent directory chain (lost capabilities are a top cause of a plugin collecting nothing)" sh -c '
+  dirs="'"$PLUGINSD_DIRS"'"
+  if [ -z "$dirs" ]; then echo "(no plugins.d directory found on this host)"; exit 0; fi
+  for d in $dirs; do
+    echo "===== $d ====="
+    ls -ld "$d" 2>/dev/null
+    echo "-- contents --"
+    ls -la "$d" 2>/dev/null | head -200
+    echo "-- setuid/setgid entries --"
+    s=$(find "$d" -maxdepth 1 -type f \( -perm -4000 -o -perm -2000 \) 2>/dev/null | head -50)
+    if [ -n "$s" ]; then printf "%s\n" "$s"; else echo "(none)"; fi
+    echo "-- file capabilities --"
+    if command -v getcap >/dev/null 2>&1; then
+      c=$(getcap -r "$d" 2>/dev/null | head -50)
+      if [ -n "$c" ]; then printf "%s\n" "$c"; else echo "(no file has capabilities set)"; fi
+    else
+      echo "(getcap not available - file capabilities could NOT be checked)"
+    fi
+    # NOTE: a trailing "+" in the listing means "alternate access method", which
+    # on netdata installs is usually the security.capability xattr shown above,
+    # NOT an ACL. ACLs for the directory itself are in netdata-paths.txt.
+  done
+  true'
+
+# every netdata-owned path worth reporting permissions for; the cache dir stays
+# TOP-LEVEL only (recursing it would enumerate thousands of dbengine files)
+_PERM_PATHS=""
+for _p in "$CONFDIR" "$CONFDIR/netdata.conf" "$CONFDIR/stream.conf" "$CONFDIR/ssl" \
+          "$LOGDIR" "$LIBDIR" "$LIBDIR/cloud.d" "$LIBDIR/registry" "$CACHEDIR" \
+          $PLUGINSD_DIRS "${NETDATA_BIN:-}"; do
+  [ -n "$_p" ] || continue
+  [ -e "$_p" ] || continue
+  case " $_PERM_PATHS " in *" $_p "*) continue ;; *) : ;; esac
+  _PERM_PATHS="$_PERM_PATHS $_p"
+done
+_PERM_PATHS="${_PERM_PATHS# }"
+
+collect_cmd 09-permissions/netdata-paths.txt "Modes, ownership, extended attributes, security contexts (SELinux/AppArmor) and POSIX ACLs for netdata's directories, configs and binary" sh -c '
+  paths="'"$_PERM_PATHS"'"
+  if [ -z "$paths" ]; then echo "(no netdata paths found on this host)"; exit 0; fi
+  has_selinux=0; [ -e /sys/fs/selinux ] && has_selinux=1
+  for p in $paths; do
+    echo "===== $p ====="
+    ls -ld "$p" 2>/dev/null
+    stat -c "mode=%A(%a) owner=%U(%u) group=%G(%g) type=%F" "$p" 2>/dev/null \
+      || stat -f "mode=%Sp(%Lp) owner=%Su group=%Sg" "$p" 2>/dev/null \
+      || true
+    if [ "$has_selinux" = "1" ]; then
+      ls -ldZ "$p" 2>/dev/null || echo "(ls -Z unsupported)"
+    fi
+    if command -v getfattr >/dev/null 2>&1; then
+      # -m - includes the security.* and trusted.* namespaces, which is where
+      # SELinux labels and file capabilities actually live
+      a=$(getfattr -d -m - --absolute-names "$p" 2>/dev/null | grep -v "^#" | grep -v "^$" | head -20)
+      if [ -n "$a" ]; then echo "xattrs:"; printf "%s\n" "$a"; else echo "xattrs: (none set)"; fi
+    elif command -v xattr >/dev/null 2>&1; then
+      a=$(xattr -l "$p" 2>/dev/null | head -20)
+      if [ -n "$a" ]; then echo "xattrs (macOS):"; printf "%s\n" "$a"; else echo "xattrs: (none set)"; fi
+    elif command -v lsextattr >/dev/null 2>&1; then
+      a=$( { lsextattr -q system "$p" 2>/dev/null; lsextattr -q user "$p" 2>/dev/null; } | head -20)
+      if [ -n "$a" ]; then echo "xattrs (FreeBSD):"; printf "%s\n" "$a"; else echo "xattrs: (none set)"; fi
+    else
+      echo "xattrs: (getfattr/xattr/lsextattr absent - the checkable namespaces are reported below)"
+    fi
+    # Reported unconditionally: getfattr lives in the "attr" package, which is
+    # NOT installed by default on Debian/Ubuntu, and these cover the attributes
+    # that actually break netdata - security.capability (a dropped capability
+    # stops a plugin dead) and the ext2/3/4 immutable/append-only flags (which
+    # silently block the agent from writing its own state).
+    if command -v getcap >/dev/null 2>&1; then
+      c=$(getcap "$p" 2>/dev/null)
+      if [ -n "$c" ]; then echo "capabilities: $c"; else echo "capabilities: (none set)"; fi
+    else
+      echo "capabilities: (getcap not available)"
+    fi
+    if command -v lsattr >/dev/null 2>&1; then
+      # lsattr only works on ext-family filesystems; elsewhere it is silent.
+      # "e" (extent) is the ext4 default, so report only NON-default flags -
+      # an immutable ("i") or append-only ("a") flag is the interesting case.
+      l=$(lsattr -d "$p" 2>/dev/null | grep -vE "^-*e-* ")
+      [ -n "$l" ] && echo "file flags (non-default): $l"
+    fi
+    if command -v getfacl >/dev/null 2>&1; then
+      f=$(getfacl -p "$p" 2>/dev/null | grep -v "^#" | grep -v "^$" | head -20)
+      if [ -n "$f" ]; then echo "acl:"; printf "%s\n" "$f"; else echo "acl: (none)"; fi
+    else
+      echo "acl: (getfacl not available)"
+    fi
+  done
+  true'
+
+# =============================================================================
 # summary + manifest + README
 # =============================================================================
 info "writing summary and manifest"
@@ -1167,6 +1490,8 @@ CRASH_HINT=""
   echo "runtime seconds:  $(( $(now_s) - START_TS ))"
   echo "ran as root:      $([ "$(id -u)" = "0" ] && echo yes || echo no)"
   echo "pii obfuscation:  $([ "$OBFUSCATE" = "1" ] && echo on || echo OFF)"
+  [ -f "$WORK/04-config/stream.conf" ] && \
+    echo "streaming key:    PRESENT VERBATIM in 04-config/stream.conf (by design - see README.md)"
   echo
   echo "agent version:    ${AGENT_VERSION:-unknown}"
   _agent_note=""
@@ -1187,13 +1512,19 @@ CRASH_HINT=""
   [ -n "$CRASH_HINT" ] && echo "last exit reason: $CRASH_HINT   <-- check 06-state/status-file.json"
   [ -n "$ERRCOUNT" ] && echo "error.log 'error' lines: $ERRCOUNT"
   [ "${DOCKER_LOGS_NEEDED:-0}" = "1" ] && echo "NOTE: agent log HISTORY is not in this bundle - it lives in 'docker logs' on the host (see 05-logs/LOGS-ARE-IN-DOCKER.txt)"
+  if [ -s "$ENC_NOTES" ]; then
+    echo
+    echo "SOURCE FILES WITH NOTABLE ENCODING (preserved as-is in this bundle):"
+    sort -u "$ENC_NOTES" | head -40 | awk -F'\t' '{ printf "  %s: %s\n", $1, $2 }'
+  fi
   echo
   echo "READ ORDER FOR TRIAGE:"
   echo "  crashes/won't start -> 06-state/status-file.json, 05-logs/, 01-system/kernel-messages.txt"
-  echo "  collector issues    -> 04-config/go.d*, 05-logs/collector.log"
+  echo "  collector issues    -> 04-config/go.d*, 05-logs/collector.log, 09-permissions/plugins-d.txt"
   echo "  streaming issues    -> 04-config/stream.conf, 07-runtime/node-instances.json, 01-system/clock-timesync.txt"
   echo "  cloud/claiming      -> 06-state/cloud-state.txt, 07-runtime/aclk-state.json, 08-network/"
   echo "  performance         -> 03-process/threads-cpu.txt, 06-state/db-disk-usage.txt, 07-runtime/node-instances.json"
+  echo "  permission denied   -> 09-permissions/ (modes, capabilities, xattrs, SELinux/AppArmor, ACLs)"
 } > "$WORK/summary.txt"
 manifest_add summary.txt file generated "Human summary"
 
@@ -1201,11 +1532,23 @@ cat > "$WORK/README.md" <<'EOF'
 # Netdata Support Bundle
 
 Generated by `netdata-support-bundle`. Contents are SANITIZED:
-secrets (tokens, api keys, passwords) are always redacted; by default IPs,
+secrets (tokens, api keys, passwords) are redacted; by default IPs,
 MACs, emails and hostnames are replaced with stable pseudonyms (`ip-1`,
 `redacted-host`, `[EMAIL]`, `[MAC]`) - consistent across all files, so
 cross-referencing still works. The pseudonym map stays on the user's machine,
 next to the tarball - it is NOT in this bundle.
+
+**One deliberate exception:** the **streaming API key** is kept VERBATIM in
+`04-config/stream.conf` (both `api key` values and `[<API_KEY>]` section
+headers). It is the value support needs to tell whether a child and its parent
+agree, so it is not treated as a secret. If your threat model differs, remove or
+mask it in `04-config/stream.conf` before sending the bundle. Note the same key
+IS still redacted in `05-logs/access.log`, where it also appears.
+
+Collected files keep their original bytes: a byte-order mark, CRLF or CR line
+endings and a missing final newline all survive redaction, so encoding faults
+stay visible. What was observed is recorded per file under `source_encoding` in
+`MANIFEST.json`, and anything notable is listed in `summary.txt`.
 
 ## Layout (triage order)
 
@@ -1221,13 +1564,14 @@ next to the tarball - it is NOT in this bundle.
 | `06-state/` | daemon status file (crash record), state/db disk usage, claim state |
 | `07-runtime/` | live API captures: info, node instances, alerts, aclk state, buildinfo |
 | `08-network/` | listening sockets, DNS, proxy, Netdata Cloud reachability |
+| `09-permissions/` | modes, ownership, setuid bits, file capabilities, extended attributes, SELinux/AppArmor contexts and ACLs - including every `plugins.d` |
 
 ## Conventions
 
 - Command captures (`*.txt`) begin with a `# netdata-support-bundle | command: ...`
   provenance header and end with `# exit: N`.
 - Copied files (configs, logs, json) are pristine (no injected headers);
-  their origin is recorded in `MANIFEST.json`.
+  their origin and `source_encoding` are recorded in `MANIFEST.json`.
 - `07-runtime/AGENT-WAS-DOWN.txt` exists when the local API probe failed (the
   agent may be down, or its API bound away from 127.0.0.1 / bearer-protected).
 EOF
@@ -1242,6 +1586,8 @@ manifest_add README.md file generated "Bundle documentation"
   echo "  \"runtime_seconds\": $(( $(now_s) - START_TS )),"
   echo "  \"pii_obfuscated\": $([ "$OBFUSCATE" = "1" ] && echo true || echo false),"
   echo "  \"secrets_redacted\": true,"
+  # the one documented exception to secrets_redacted (netdata/netdata#23448)
+  echo "  \"streaming_api_key_redacted\": false,"
   echo "  \"agent_running\": $([ -n "${NETDATA_PID:-}" ] && echo true || echo false),"
   echo "  \"agent_api_reachable\": $([ "$api_ok" = "1" ] && echo true || echo false),"
   echo "  \"is_container\": $([ "$IS_CONTAINER" = "1" ] && echo true || echo false),"

--- a/packaging/installer/netdata-support-bundle
+++ b/packaging/installer/netdata-support-bundle
@@ -94,7 +94,7 @@ ERRORS="$STAGING/errors.txt"; : > "$ERRORS"
 # encoding facts of the file most recently sanitized; consumed by manifest_add.
 # ENC_NOTES accumulates only the ANOMALIES, which summary.txt surfaces.
 ENC_NOTES="$STAGING/encoding.notes"; : > "$ENC_NOTES"
-ENC_JSON=""; ENC_NOTE=""; ENC_BOM=none; ENC_BOM_BYTES=0; ENC_FINAL=true
+ENC_JSON=""; ENC_NOTE=""; ENC_BOM=none; ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_CRONLY=0
 
 cleanup() { [ "$KEEP_STAGING" = "1" ] || rm -rf "$STAGING"; }
 trap cleanup EXIT
@@ -178,7 +178,7 @@ case "$RUN_USER" in root|netdata|"") RUN_USER="" ;; *) : ;; esac
 # artifact of this tool. Redaction used to normalize these away silently.
 encoding_probe() {
   _ef="$1"; _erel="${_ef#"$WORK"/}"
-  ENC_BOM=none; ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_JSON=""
+  ENC_BOM=none; ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_CRONLY=0; ENC_JSON=""
   _esize=$(wc -c < "$_ef" 2>/dev/null | tr -d ' ')
   _ehex=$(head -c 4 "$_ef" 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')
   case "$_ehex" in
@@ -196,7 +196,16 @@ encoding_probe() {
   [ -n "${_ecrlf:-}" ] || _ecrlf=0
   _ebarecr=$((_ecr - _ecrlf)); [ "$_ebarecr" -lt 0 ] && _ebarecr=0
   _ebarelf=$((_elf - _ecrlf)); [ "$_ebarelf" -lt 0 ] && _ebarelf=0
-  [ "$(tail -c 1 "$_ef" 2>/dev/null | wc -l | tr -d ' ')" = "1" ] || ENC_FINAL=false
+  # CR is a line terminator too: a CR-terminated file is NOT missing its final
+  # newline, and sanitize_file relies on this to avoid eating that last byte
+  case "$(tail -c 1 "$_ef" 2>/dev/null | od -An -tx1 | tr -d ' \n')" in
+    0a|0d) ENC_FINAL=true ;;
+    *) ENC_FINAL=false ;;
+  esac
+  # CR-only (classic Mac) endings make the whole file ONE awk record, so only its
+  # first key would ever be examined - sanitize_file translates for the pass
+  ENC_CRONLY=0
+  [ "$_ebarecr" -gt 0 ] && [ "$_elf" -eq 0 ] && ENC_CRONLY=1
   # exclude the BOM's own bytes: it is reported separately, and counting it here
   # would make a pure-ASCII file look like it carried non-ASCII content
   _enonascii=$(LC_ALL=C tr -d '\000-\177' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')
@@ -246,6 +255,13 @@ sanitize_file() {
   _sanin="$_f"
   if [ "$ENC_BOM_BYTES" -gt 0 ]; then
     if tail -c "+$((ENC_BOM_BYTES + 1))" "$_f" > "$_f.nobom" 2>>"$ERRORS"; then _sanin="$_f.nobom"; fi
+  fi
+  # A CR-only file is a single record to awk, so every rule would see one giant
+  # line and only its FIRST key would be examined - later secrets would ship
+  # unredacted. Translate CR to LF for the pass and translate back after, which
+  # redacts correctly and still reproduces the original bytes.
+  if [ "$ENC_CRONLY" = "1" ]; then
+    if LC_ALL=C tr '\r' '\n' < "$_sanin" > "$_f.lf" 2>>"$ERRORS"; then _sanin="$_f.lf"; fi
   fi
   if awk -v ctx="$_ctx" -v obf="$OBFUSCATE" -v mapfile="$MAP_FILE" \
       -v host_short="$HOST_SHORT" -v host_fqdn="$HOST_FQDN" -v run_user="$RUN_USER" '
@@ -635,6 +651,9 @@ sanitize_file() {
     }
     print line cr;
   }' "$_sanin" > "$_f.san" 2>>"$ERRORS"; then
+    if [ "$ENC_CRONLY" = "1" ]; then
+      LC_ALL=C tr '\n' '\r' < "$_f.san" > "$_f.san2" 2>>"$ERRORS" && mv "$_f.san2" "$_f.san"
+    fi
     # restore the exact BOM bytes the source had, so an encoding fault in the
     # user's file is still visible in the bundle
     if [ "$_sanin" = "$_f.nobom" ]; then
@@ -652,10 +671,10 @@ sanitize_file() {
       fi
     fi
     mv "$_f.out" "$_f"
-    rm -f "$_f.san" "$_f.nobom" "$_f.out2"
+    rm -f "$_f.san" "$_f.nobom" "$_f.lf" "$_f.out2"
   else
     # fail CLOSED: never ship content the sanitizer could not process
-    rm -f "$_f.san" "$_f.nobom" "$_f.out" "$_f.out2"
+    rm -f "$_f.san" "$_f.san2" "$_f.nobom" "$_f.lf" "$_f.out" "$_f.out2"
     echo "[netdata-support-bundle] sanitization failed for this file - content withheld for safety" > "$_f"
     ENC_JSON=""
   fi
@@ -966,6 +985,18 @@ STREAMVEC
     *'"bom":"utf-8"'*) : ;;
     *) echo "FAIL: source_encoding did not record the BOM" >&2; _fails=$((_fails + 1)) ;;
   esac
+  # --- CR-only (classic Mac) endings: awk sees ONE record, so without the
+  # --- translation only the first key would be examined and later secrets
+  # --- would ship unredacted
+  _cf="$_tf.cronly"
+  printf '[stream]\r    enabled = yes\r    password = SENTINEL-CRONLY\r' > "$_cf"
+  sanitize_file "$_cf"
+  grep -q "SENTINEL-CRONLY" "$_cf" && \
+    { echo "FAIL (leak): secret in a CR-only file was not redacted" >&2; _fails=$((_fails + 1)); }
+  [ "$(LC_ALL=C tr -dc '\r' < "$_cf" | wc -c | tr -d ' ')" = "3" ] || \
+    { echo "FAIL: CR-only line endings were not reproduced" >&2; _fails=$((_fails + 1)); }
+  [ "$(LC_ALL=C tr -dc '\n' < "$_cf" | wc -c | tr -d ' ')" = "0" ] || \
+    { echo "FAIL: CR-only file gained LF terminators" >&2; _fails=$((_fails + 1)); }
 
   if [ "$_fails" -eq 0 ]; then
     echo "netdata-support-bundle selftest: ALL PASS"
@@ -1155,7 +1186,7 @@ if [ -n "$CONFDIR" ]; then
       /\.(pem|key)\$/ { next }
       { print }"'
   collect_file 04-config/netdata.conf "On-disk main config" "$CONFDIR/netdata.conf"
-  collect_file 04-config/stream.conf "Streaming config (parent/child; api key redacted)" "$CONFDIR/stream.conf"
+  collect_file 04-config/stream.conf "Streaming config (parent/child; the streaming api key is KEPT VERBATIM - see README.md)" "$CONFDIR/stream.conf"
   collect_file 04-config/exporting.conf "Exporting engine config (credentials redacted)" "$CONFDIR/exporting.conf"
   collect_file 04-config/go.d.conf "go.d orchestrator config (module enable/disable)" "$CONFDIR/go.d.conf"
   # every user-customized config, nested dirs included (go.d/sd/, go.d/ss/,
@@ -1373,10 +1404,14 @@ if [ -n "$CONFDIR" ] && [ -r "$CONFDIR/netdata.conf" ]; then
 fi
 PLUGINSD_DIRS="${PLUGINSD_DIRS# }"
 
-collect_cmd 09-permissions/plugins-d.txt "plugins.d: modes, ownership, setuid/setgid bits, file CAPABILITIES and the parent directory chain (lost capabilities are a top cause of a plugin collecting nothing)" sh -c '
-  dirs="'"$PLUGINSD_DIRS"'"
-  if [ -z "$dirs" ]; then echo "(no plugins.d directory found on this host)"; exit 0; fi
-  for d in $dirs; do
+# The directory list reaches the child as positional ARGUMENTS, never as text
+# spliced into the program: one of these paths can come from the [directories]
+# plugins value in netdata.conf, and a path containing a quote would otherwise
+# close the quoted program and run as shell code with the bundle's privileges.
+# shellcheck disable=SC2086  # deliberate word-split of the discovered dir list
+collect_cmd 09-permissions/plugins-d.txt "plugins.d: modes, ownership, setuid/setgid bits and file CAPABILITIES (lost capabilities are a top cause of a plugin collecting nothing)" sh -c '
+  if [ "$#" -eq 0 ]; then echo "(no plugins.d directory found on this host)"; exit 0; fi
+  for d in "$@"; do
     echo "===== $d ====="
     ls -ld "$d" 2>/dev/null
     echo "-- contents --"
@@ -1395,7 +1430,7 @@ collect_cmd 09-permissions/plugins-d.txt "plugins.d: modes, ownership, setuid/se
     # on netdata installs is usually the security.capability xattr shown above,
     # NOT an ACL. ACLs for the directory itself are in netdata-paths.txt.
   done
-  true'
+  true' sh $PLUGINSD_DIRS
 
 # every netdata-owned path worth reporting permissions for; the cache dir stays
 # TOP-LEVEL only (recursing it would enumerate thousands of dbengine files)
@@ -1410,11 +1445,12 @@ for _p in "$CONFDIR" "$CONFDIR/netdata.conf" "$CONFDIR/stream.conf" "$CONFDIR/ss
 done
 _PERM_PATHS="${_PERM_PATHS# }"
 
+# paths reach the child as positional ARGUMENTS - see the note above
+# shellcheck disable=SC2086  # deliberate word-split of the discovered path list
 collect_cmd 09-permissions/netdata-paths.txt "Modes, ownership, extended attributes, security contexts (SELinux/AppArmor) and POSIX ACLs for netdata's directories, configs and binary" sh -c '
-  paths="'"$_PERM_PATHS"'"
-  if [ -z "$paths" ]; then echo "(no netdata paths found on this host)"; exit 0; fi
+  if [ "$#" -eq 0 ]; then echo "(no netdata paths found on this host)"; exit 0; fi
   has_selinux=0; [ -e /sys/fs/selinux ] && has_selinux=1
-  for p in $paths; do
+  for p in "$@"; do
     echo "===== $p ====="
     ls -ld "$p" 2>/dev/null
     stat -c "mode=%A(%a) owner=%U(%u) group=%G(%g) type=%F" "$p" 2>/dev/null \
@@ -1462,7 +1498,7 @@ collect_cmd 09-permissions/netdata-paths.txt "Modes, ownership, extended attribu
       echo "acl: (getfacl not available)"
     fi
   done
-  true'
+  true' sh $_PERM_PATHS
 
 # =============================================================================
 # summary + manifest + README

--- a/packaging/installer/netdata-support-bundle.ps1
+++ b/packaging/installer/netdata-support-bundle.ps1
@@ -77,6 +77,12 @@ function Show-Info([string]$msg) { Write-Host " [*] $msg" }
 
 # PS 5.1 Set-Content writes UTF-16LE by default; every bundle file must be UTF-8
 $script:Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+# ISO-8859-1 maps bytes 0x00-0xFF one-to-one onto U+0000-U+00FF, so decoding and
+# re-encoding with it reproduces the ORIGINAL bytes exactly. The byte-exact
+# sanitize path uses it instead of UTF-8, whose replacement fallback would turn
+# every invalid sequence in a Latin-1 config into U+FFFD and corrupt the copy.
+# Every sanitizer pattern is ASCII, which this mapping leaves unchanged.
+$script:BytePreserving = [System.Text.Encoding]::GetEncoding(28591)
 function Write-Utf8([string]$path, [string]$text) {
     [System.IO.File]::WriteAllText($path, $text, $script:Utf8NoBom)
 }
@@ -330,6 +336,20 @@ function Invoke-SanitizeLine([string]$line, [bool]$secretScan = $true, [string]$
 }
 
 function Get-FileEncodingFacts([string]$path) {
+    # Large GENERATED captures (the Windows perflib dump, tens of MB) have no
+    # source encoding worth reporting, and a per-byte scan over them would eat
+    # the global deadline. Probe a prefix for NUL only and let the caller take
+    # the line-based path.
+    $len = (Get-Item $path -Force).Length
+    if ($len -gt $script:ByteExactMax) {
+        $probeLen = [Math]::Min($len, 1MB)
+        $probe = New-Object byte[] $probeLen
+        $fs = [System.IO.File]::OpenRead($path)
+        try { [void]$fs.Read($probe, 0, $probeLen) } finally { $fs.Close() }
+        $hasNul = $false
+        for ($i = 0; $i -lt $probeLen; $i++) { if ($probe[$i] -eq 0) { $hasNul = $true; break } }
+        return [pscustomobject]@{ size = $len; bomLen = 0; nul = $hasNul; notes = @(); json = $null }
+    }
     # Record the encoding of a collected file BEFORE redaction touches it, so
     # support can tell a genuine source-file encoding fault (a BOM, mixed line
     # endings, a missing final newline) from an artifact of this tool. The old
@@ -357,7 +377,10 @@ function Get-FileEncodingFacts([string]$path) {
         if ($b -gt 127) { $nonAscii++ }
     }
     $cr = $crAll - $crlf; if ($cr -lt 0) { $cr = 0 }
-    $finalNewline = ($bytes.Length -gt $bomLen -and $bytes[$bytes.Length - 1] -eq 10)
+    # CR is a line terminator too: a CR-terminated file is not missing its
+    # final newline
+    $finalNewline = ($bytes.Length -gt $bomLen -and
+                     ($bytes[$bytes.Length - 1] -eq 10 -or $bytes[$bytes.Length - 1] -eq 13))
     # a strict decoder is the cheapest UTF-8 validator available here
     $utf8Valid = $true
     try {
@@ -438,7 +461,7 @@ function Invoke-SanitizeFile([string]$path, [bool]$secretScan = $true, [string]$
     # byte-exact path: keep the BOM bytes, keep every line's OWN terminator, and
     # never invent a final newline the source did not have
     $bytes = [System.IO.File]::ReadAllBytes($path)
-    $text = $script:Utf8NoBom.GetString($bytes, $facts.bomLen, $bytes.Length - $facts.bomLen)
+    $text = $script:BytePreserving.GetString($bytes, $facts.bomLen, $bytes.Length - $facts.bomLen)
     $sb = New-Object System.Text.StringBuilder
     $inPem = $false
     $pos = 0
@@ -467,7 +490,7 @@ function Invoke-SanitizeFile([string]$path, [bool]$secretScan = $true, [string]$
         }
         [void]$sb.Append((Invoke-SanitizeLine $lineText $secretScan $ctx)).Append($term)
     }
-    $body = $script:Utf8NoBom.GetBytes($sb.ToString())
+    $body = $script:BytePreserving.GetBytes($sb.ToString())
     if ($facts.bomLen -gt 0) {
         $outBytes = New-Object byte[] ($facts.bomLen + $body.Length)
         [System.Array]::Copy($bytes, 0, $outBytes, 0, $facts.bomLen)
@@ -680,10 +703,14 @@ function Invoke-NativeProcess([string]$exe, [string[]]$argList, [int]$timeoutSec
     return $r
 }
 
-function Save-Cmd([string]$rel, [string]$title, [scriptblock]$cmd, [string]$originText, [string]$nativeExe = '', [string[]]$nativeArgs = @(), [long]$cap = 0) {
+function Save-Cmd([string]$rel, [string]$title, [scriptblock]$cmd, [string]$originText, [string]$nativeExe = '', [string[]]$nativeArgs = @(), [long]$cap = 0, [int]$timeoutFloor = 0) {
     # $cap mirrors the POSIX "collect_cmd --cap": journal/event-log captures are
     # documented at 5 MiB while command output defaults to 2 MiB
     if ($cap -le 0) { $cap = 2MB }
+    # a capture that legitimately needs longer than the per-command default can
+    # raise the floor; without it the job is killed and its WHOLE output is
+    # replaced by "TIMEOUT after Ns", losing everything it had already gathered
+    $timeout = if ($timeoutFloor -gt 0) { [Math]::Max($TimeoutSeconds, $timeoutFloor) } else { $TimeoutSeconds }
     $script:EncJson = $null
     if (Test-Deadline) { return }
     $full = Join-Path $Work $rel
@@ -692,16 +719,16 @@ function Save-Cmd([string]$rel, [string]$title, [scriptblock]$cmd, [string]$orig
     if ($nativeExe) {
         # MSYS2 binary: direct launch, never Start-Job (see Invoke-NativeProcess).
         # Text file, so merge stdout+stderr like the old `2>&1`; never silent.
-        $np = Invoke-NativeProcess $nativeExe $nativeArgs $TimeoutSeconds
+        $np = Invoke-NativeProcess $nativeExe $nativeArgs $timeout
         if ($np.LaunchError) { $result = "ERROR: could not launch: $($np.LaunchError)" }
-        elseif ($np.TimedOut) { $result = "TIMEOUT after ${TimeoutSeconds}s" }
+        elseif ($np.TimedOut) { $result = "TIMEOUT after ${timeout}s" }
         elseif ($np.ExitCode -ne 0) { $result = "ERROR: exit $($np.ExitCode)`r`n$($np.StdErr)$($np.StdOut)" }
         else { $result = "$($np.StdOut)$($np.StdErr)" }
     } else {
         try {
             $job = Start-Job -ScriptBlock $cmd
-            $done = Wait-Job $job -Timeout $TimeoutSeconds
-            if ($done) { $result = Receive-Job $job 2>&1 | Select-Object -First 50000 | Out-String } else { $result = "TIMEOUT after ${TimeoutSeconds}s" }
+            $done = Wait-Job $job -Timeout $timeout
+            if ($done) { $result = Receive-Job $job 2>&1 | Select-Object -First 50000 | Out-String } else { $result = "TIMEOUT after ${timeout}s" }
             Stop-Job $job -ErrorAction SilentlyContinue
             Remove-Job $job -Force
         } catch { $result = "ERROR: $_" }
@@ -917,7 +944,7 @@ if ($ApiOk) {
 if (Test-Path $ConfDir) {
     Save-Cmd '04-config\config-tree.txt' 'User config dir tree (files here = user-customized; ssl and key material excluded)' { Get-ChildItem $using:ConfDir -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.FullName -notmatch '[\\/]ssl([\\/]|$)' -and $_.Extension -notin @('.pem', '.key') } | Select-Object -First 2000 | Format-Table Mode, LastWriteTime, Length, FullName -AutoSize } "Get-ChildItem $ConfDir -Recurse (ssl/key material excluded)"
     Save-File '04-config\netdata.conf' 'On-disk main config' (Join-Path $ConfDir 'netdata.conf')
-    Save-File '04-config\stream.conf' 'Streaming config (parent/child; api key redacted)' (Join-Path $ConfDir 'stream.conf')
+    Save-File '04-config\stream.conf' 'Streaming config (parent/child; the streaming api key is KEPT VERBATIM - see README.md)' (Join-Path $ConfDir 'stream.conf')
     Save-File '04-config\claim.conf' 'Cloud claim config (token redacted)' (Join-Path $ConfDir 'claim.conf')
     Save-File '04-config\go.d.conf' 'go.d orchestrator config' (Join-Path $ConfDir 'go.d.conf')
     # every user-customized collector/health config, keeping subdirectory
@@ -985,7 +1012,7 @@ Save-Cmd '05-logs\eventlog-netdata.txt' 'Netdata events from the Windows Event L
             '(no events in this window, or the channel does not exist on this system)'
         }
     }
-} "Get-WinEvent: Netdata/* ETW channels + NetdataWEL + Application (last ${SinceHours}h)" -cap $LogCap
+} "Get-WinEvent: Netdata/* ETW channels + NetdataWEL + Application (last ${SinceHours}h)" -cap $LogCap -timeoutFloor 30
 if (Test-Path $LogDir) {
     Get-ChildItem $LogDir -File -Filter '*.log' | ForEach-Object {
         Save-File "05-logs\$($_.Name)" "Agent log file: $($_.Name)" $_.FullName $LogCap
@@ -1128,7 +1155,7 @@ Save-Cmd '09-permissions\plugins-d.txt' 'plugins.d: ACLs, ownership, inheritance
     $d = $using:PluginsDir
     if (-not (Test-Path $d)) { "(plugins.d not found at $d)"; return }
     "===== $d ====="
-    Get-Acl $d | Format-List Owner, Group, Access, Sddl
+    Get-Acl $d | Format-List Owner, Group, Access
     '-- contents --'
     Get-ChildItem $d -Force -ErrorAction SilentlyContinue |
         Select-Object Mode, LastWriteTime, Length, Name | Format-Table -AutoSize
@@ -1171,7 +1198,6 @@ Save-Cmd '09-permissions\netdata-paths.txt' 'Ownership, ACLs, inheritance and in
             $acl.Access | ForEach-Object {
                 "    {0} {1} {2} (inherited={3})" -f $_.IdentityReference, $_.AccessControlType, $_.FileSystemRights, $_.IsInherited
             }
-            "sddl:  $($acl.Sddl)"
             if ($acl.AreAccessRulesProtected) { 'NOTE: ACL inheritance is DISABLED on this path' }
         } else {
             '(could not read the ACL - insufficient privilege?)'

--- a/packaging/installer/netdata-support-bundle.ps1
+++ b/packaging/installer/netdata-support-bundle.ps1
@@ -461,7 +461,13 @@ function Invoke-SanitizeFile([string]$path, [bool]$secretScan = $true, [string]$
     # byte-exact path: keep the BOM bytes, keep every line's OWN terminator, and
     # never invent a final newline the source did not have
     $bytes = [System.IO.File]::ReadAllBytes($path)
-    $text = $script:BytePreserving.GetString($bytes, $facts.bomLen, $bytes.Length - $facts.bomLen)
+    # Valid UTF-8 is decoded AS UTF-8: it re-encodes to the same bytes, and the
+    # PII rules compare against real .NET strings, so a non-ASCII hostname or
+    # username must not be reduced to Latin-1 mojibake - the replacement would
+    # miss it and the real value would ship. ISO-8859-1 is only the fallback for
+    # sources that are not valid UTF-8, where it is the byte-preserving choice.
+    $enc = if ($facts.json.utf8_valid) { $script:Utf8NoBom } else { $script:BytePreserving }
+    $text = $enc.GetString($bytes, $facts.bomLen, $bytes.Length - $facts.bomLen)
     $sb = New-Object System.Text.StringBuilder
     $inPem = $false
     $pos = 0
@@ -490,7 +496,7 @@ function Invoke-SanitizeFile([string]$path, [bool]$secretScan = $true, [string]$
         }
         [void]$sb.Append((Invoke-SanitizeLine $lineText $secretScan $ctx)).Append($term)
     }
-    $body = $script:BytePreserving.GetBytes($sb.ToString())
+    $body = $enc.GetBytes($sb.ToString())
     if ($facts.bomLen -gt 0) {
         $outBytes = New-Object byte[] ($facts.bomLen + $body.Length)
         [System.Array]::Copy($bytes, 0, $outBytes, 0, $facts.bomLen)

--- a/packaging/installer/netdata-support-bundle.ps1
+++ b/packaging/installer/netdata-support-bundle.ps1
@@ -4,6 +4,12 @@
 # Windows counterpart of netdata-support-bundle. Same bundle layout, same MANIFEST
 # schema (netdata-support-bundle/v1), same sanitization rules.
 #
+# Secrets are always redacted, with ONE documented exception: the streaming API
+# key in stream.conf is kept verbatim (netdata/netdata#23448). Collected files
+# keep their original bytes - BOM, line terminators and a missing final newline
+# all survive redaction - and what was observed is recorded per file in
+# MANIFEST.json, so encoding faults stay diagnosable.
+#
 # What is collected and WHY each item is included is documented in
 # packaging/installer/SUPPORT-BUNDLE.md - read it before adding or changing
 # a collection item, and keep it in sync with this script.
@@ -29,7 +35,7 @@ param(
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = 'SilentlyContinue'
 
-$ToolVersion = '1.0.0'
+$ToolVersion = '1.1.0'
 if ($Version) { Write-Output "netdata-support-bundle $ToolVersion"; exit 0 }
 
 $Obfuscate = -not $NoObfuscate
@@ -55,7 +61,17 @@ $script:PseudoMap = @{}   # original -> pseudonym
 $script:IpCount = 0
 $script:Ip6Count = 0
 $script:FqdnCount = 0
+$script:DomainCount = 0
 $script:SeededHosts = @() # child/mirrored hostnames pre-seeded from the local API
+# encoding facts of the file most recently sanitized; consumed by Add-Manifest.
+# EncNotes keeps only the ANOMALIES, which summary.txt surfaces.
+$script:EncJson = $null
+$script:EncNote = ''
+$script:EncNotes = New-Object System.Collections.ArrayList
+# byte-exact encoding preservation reads the whole file into one string; the
+# Windows perflib dump can be tens of MB, where fidelity is irrelevant (we
+# generated it) and the memory cost is not. Above this, use the line path.
+$script:ByteExactMax = 8MB
 
 function Show-Info([string]$msg) { Write-Host " [*] $msg" }
 
@@ -93,6 +109,23 @@ $HostShort = $env:COMPUTERNAME
 $HostFqdn = try { [System.Net.Dns]::GetHostEntry('').HostName } catch { Write-Verbose "no FQDN: $_"; '' }
 $RunUser = $env:USERNAME
 if ($RunUser -in @('SYSTEM', 'Administrator') -or -not $RunUser -or $RunUser.Length -lt 3) { $RunUser = '' }
+# An Active Directory domain name is a corporate identifier, and the new
+# 09-permissions ACL captures print DOMAIN\user everywhere. Pseudonymize the
+# machine's OWN domain by exact value - the same approach used for the hostname
+# and the invoking user - rather than by pattern: a generic DOMAIN\user regex
+# cannot be told apart from a Windows path segment (C:\Users\Public).
+# POSIX has no counterpart: getfacl there yields local accounts only.
+$UserDomain = $env:USERDOMAIN
+if (-not $UserDomain -or $UserDomain -eq $HostShort -or $UserDomain.Length -lt 3) { $UserDomain = '' }
+$DnsDomain = ''
+try {
+    $cs = Get-CimInstance Win32_ComputerSystem -ErrorAction SilentlyContinue
+    if ($cs -and $cs.PartOfDomain -and $cs.Domain) { $DnsDomain = [string]$cs.Domain }
+} catch { Write-Verbose "could not read the computer domain: $_" }
+if ($DnsDomain -in @('WORKGROUP', $HostShort, $HostFqdn) -or $DnsDomain.Length -lt 4) { $DnsDomain = '' }
+# set per file by Invoke-SanitizeLine; "stream" marks stream.conf, the one file
+# whose streaming API key is kept verbatim (netdata/netdata#23448)
+$script:SanCtx = ''
 
 function Test-SecretKey([string]$key) {
     $k = ($key -replace '[-_]', ' ').ToLower().Trim(' ', '#', "`t")
@@ -113,6 +146,19 @@ function Test-DiagnosticKey([string]$key) {
     return $false
 }
 
+function Test-StreamingApiKey([string]$key) {
+    # netdata/netdata#23448: the STREAMING api key is not treated as a secret -
+    # support needs its value to tell whether a child and its parent agree.
+    # Scoped to stream.conf ($script:SanCtx) and to an EXACT key match, so a
+    # third-party "api key" in any other file, and any other secret key inside
+    # stream.conf, is still redacted. Deliberately NOT applied to access logs,
+    # where the same value also appears (stream-receiver-connection.c logs it,
+    # and children send it as a "key=" query parameter).
+    if ($script:SanCtx -ne 'stream') { return $false }
+    $k = ($key -replace '[-_]', ' ').ToLower().Trim(' ', '#', "`t")
+    return ($k -eq 'api key' -or $k -eq 'proxy api key')
+}
+
 function Get-Pseudonym([string]$orig, [string]$prefix) {
     if (-not $script:PseudoMap.ContainsKey($orig)) {
         # cap: past 4096 mappings, use a constant non-correlating placeholder
@@ -127,8 +173,12 @@ function Get-Pseudonym([string]$orig, [string]$prefix) {
 
 function Invoke-RedactSecretLine([string]$line) {
     # pass 1 (always on): credential redaction
-    # stream.conf-style [<uuid>] section headers are api keys
-    if ($line -match '^\s*\[[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\]\s*$') {
+    # [<uuid>] section headers are api keys (or machine GUIDs). In stream.conf
+    # they are KEPT: support needs to see which key each section configures, and
+    # collapsing them all to one placeholder also made per-key settings
+    # unattributable. Everywhere else they are still withheld.
+    if ($script:SanCtx -ne 'stream' -and
+        $line -match '^\s*\[[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\]\s*$') {
         return '[REDACTED-KEY-SECTION]'
     }
     # ini/yaml/env key = value | key: value
@@ -136,7 +186,8 @@ function Invoke-RedactSecretLine([string]$line) {
     # only plausible config keys: short, no sentence/shell punctuation, no path
     # separators (command lines with paths belong to the argv rule below)
     if ($line -notmatch '^\s*"' -and $line -match '^([^=:]{1,64})([=:])(.+)$' -and $Matches[1] -notmatch '["`;|()/]') {
-        if ((Test-SecretKey $Matches[1]) -and $Matches[3].Trim() -ne '' -and -not (Test-DiagnosticKey $Matches[1])) {
+        if ((Test-SecretKey $Matches[1]) -and $Matches[3].Trim() -ne '' -and
+            -not (Test-DiagnosticKey $Matches[1]) -and -not (Test-StreamingApiKey $Matches[1])) {
             $line = $Matches[1] + $Matches[2] + ' [REDACTED]'
         }
     }
@@ -170,7 +221,8 @@ function Invoke-RedactSecretLine([string]$line) {
     # incl. two-word keys ("api key = X"); diagnostic-noun keys are kept
     $line = [regex]::Replace($line, '(?i)(([\w.-]*(token|password|passwd|secret|apikey|api_key|community|bearer)|(api|license|auth|access) key|proxy (user|pass|password)) ?[=:] ?)([^&"\s\[]+)', {
         param($m)
-        if (Test-DiagnosticKey $m.Groups[2].Value) { $m.Value } else { $m.Groups[1].Value + '[REDACTED]' }
+        if ((Test-DiagnosticKey $m.Groups[2].Value) -or (Test-StreamingApiKey $m.Groups[2].Value)) { $m.Value }
+        else { $m.Groups[1].Value + '[REDACTED]' }
     })
     # NOTE: multiline PEM private-key blocks are handled by Invoke-SanitizeFile,
     # which tracks BEGIN/END state across lines and withholds the whole block.
@@ -254,10 +306,20 @@ function Invoke-ObfuscatePiiLine([string]$line) {
         if (-not $script:PseudoMap.ContainsKey($RunUser)) { $script:PseudoMap[$RunUser] = 'redacted-user' }
         $line = $line -ireplace [regex]::Escape($RunUser), 'redacted-user'
     }
+    # the machine's own AD domain (DOMAIN\user in ACL output, and the DNS domain)
+    if ($DnsDomain) {
+        if (-not $script:PseudoMap.ContainsKey($DnsDomain)) { $script:PseudoMap[$DnsDomain] = 'redacted-domain' }
+        $line = $line -ireplace [regex]::Escape($DnsDomain), 'redacted-domain'
+    }
+    if ($UserDomain) {
+        if (-not $script:PseudoMap.ContainsKey($UserDomain)) { $script:PseudoMap[$UserDomain] = 'redacted-domain' }
+        $line = $line -ireplace [regex]::Escape($UserDomain), 'redacted-domain'
+    }
     return $line
 }
 
-function Invoke-SanitizeLine([string]$line, [bool]$secretScan = $true) {
+function Invoke-SanitizeLine([string]$line, [bool]$secretScan = $true, [string]$ctx = '') {
+    $script:SanCtx = $ctx
     # $secretScan can be disabled for content that structurally cannot hold
     # credentials (the Windows perflib dump: counter/instance metadata only), so
     # the expensive per-"key":"value" credential regexes are not run millions of
@@ -267,25 +329,62 @@ function Invoke-SanitizeLine([string]$line, [bool]$secretScan = $true) {
     return $line
 }
 
-function Test-FileHasNul([string]$path) {
-    # a NUL in the first 1 MiB means binary/UTF-16: line-based redaction would
-    # be byte-unsafe, so the caller withholds the file
-    $fs = [System.IO.File]::OpenRead($path)
+function Get-FileEncodingFacts([string]$path) {
+    # Record the encoding of a collected file BEFORE redaction touches it, so
+    # support can tell a genuine source-file encoding fault (a BOM, mixed line
+    # endings, a missing final newline) from an artifact of this tool. The old
+    # ReadAllLines/WriteAllLines pair normalized every one of these away
+    # silently - netdata/netdata#23448.
+    $bytes = [System.IO.File]::ReadAllBytes($path)
+    $bom = 'none'; $bomLen = 0
+    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+        $bom = 'utf-8'; $bomLen = 3
+    } elseif ($bytes.Length -ge 4 -and $bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE -and $bytes[2] -eq 0 -and $bytes[3] -eq 0) {
+        $bom = 'utf-32le'; $bomLen = 4
+    } elseif ($bytes.Length -ge 4 -and $bytes[0] -eq 0 -and $bytes[1] -eq 0 -and $bytes[2] -eq 0xFE -and $bytes[3] -eq 0xFF) {
+        $bom = 'utf-32be'; $bomLen = 4
+    } elseif ($bytes.Length -ge 2 -and $bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE) {
+        $bom = 'utf-16le'; $bomLen = 2
+    } elseif ($bytes.Length -ge 2 -and $bytes[0] -eq 0xFE -and $bytes[1] -eq 0xFF) {
+        $bom = 'utf-16be'; $bomLen = 2
+    }
+    $lf = 0; $crlf = 0; $crAll = 0; $nonAscii = 0; $nul = $false
+    for ($i = $bomLen; $i -lt $bytes.Length; $i++) {
+        $b = $bytes[$i]
+        if ($b -eq 0) { $nul = $true }
+        elseif ($b -eq 10) { if ($i -gt $bomLen -and $bytes[$i - 1] -eq 13) { $crlf++ } else { $lf++ } }
+        elseif ($b -eq 13) { $crAll++ }
+        if ($b -gt 127) { $nonAscii++ }
+    }
+    $cr = $crAll - $crlf; if ($cr -lt 0) { $cr = 0 }
+    $finalNewline = ($bytes.Length -gt $bomLen -and $bytes[$bytes.Length - 1] -eq 10)
+    # a strict decoder is the cheapest UTF-8 validator available here
+    $utf8Valid = $true
     try {
-        $want = $fs.Length   # staged file is already size-capped before sanitize
-        $probe = New-Object byte[] $want
-        $read = 0
-        while ($read -lt $want) {
-            $n = $fs.Read($probe, $read, $want - $read)
-            if ($n -le 0) { break }
-            $read += $n
+        $strict = New-Object System.Text.UTF8Encoding($false, $true)
+        [void]$strict.GetString($bytes, $bomLen, $bytes.Length - $bomLen)
+    } catch { $utf8Valid = $false }
+    $notes = @()
+    if ($bom -ne 'none') { $notes += "$bom-BOM" }
+    if ($cr -gt 0) { $notes += "CR-only-line-endings($cr)" }
+    if ($crlf -gt 0 -and $lf -gt 0) { $notes += "mixed-line-endings(lf=$lf,crlf=$crlf)" }
+    if (-not $finalNewline -and $bytes.Length -gt 0) { $notes += 'no-final-newline' }
+    if (-not $utf8Valid) { $notes += 'invalid-UTF-8' }
+    return [pscustomobject]@{
+        size  = $bytes.Length
+        bomLen = $bomLen
+        nul   = $nul
+        notes = $notes
+        json  = [ordered]@{
+            bom = $bom; lf = $lf; crlf = $crlf; cr = $cr
+            final_newline = [bool]$finalNewline
+            # the scan starts past the BOM, so its bytes are already excluded
+            non_ascii_bytes = $nonAscii; utf8_valid = [bool]$utf8Valid
         }
-    } finally { $fs.Close() }
-    for ($i = 0; $i -lt $read; $i++) { if ($probe[$i] -eq 0) { return $true } }
-    return $false
+    }
 }
 
-function Convert-SanitizedText([string[]]$lines, [bool]$secretScan = $true) {
+function Convert-SanitizedText([string[]]$lines, [bool]$secretScan = $true, [string]$ctx = '') {
     # per-line redaction, plus whole-block withholding for PEM private keys
     # (clear BEGIN/END markers). Multi-line YAML block scalars are NOT specially
     # withheld - their indentation-based boundary can't be detected robustly by
@@ -304,19 +403,79 @@ function Convert-SanitizedText([string[]]$lines, [bool]$secretScan = $true) {
             [void]$out.Add('[REDACTED PRIVATE KEY BLOCK]')
             continue
         }
-        [void]$out.Add((Invoke-SanitizeLine $l $secretScan))
+        [void]$out.Add((Invoke-SanitizeLine $l $secretScan $ctx))
     }
     return $out
 }
 
-function Invoke-SanitizeFile([string]$path, [bool]$secretScan = $true) {
+function Invoke-SanitizeFile([string]$path, [bool]$secretScan = $true, [string]$ctx = '') {
     if (-not (Test-Path $path)) { return }
-    if (Test-FileHasNul $path) {
+    $script:EncJson = $null
+    $facts = Get-FileEncodingFacts $path
+    if ($facts.nul) {
+        # a NUL means binary/UTF-16: line-based redaction would be byte-unsafe
         Write-Utf8 $path '[content withheld: file contains NUL bytes (binary or UTF-16?)]'
         return
     }
-    $out = Convert-SanitizedText ([System.IO.File]::ReadAllLines($path)) $secretScan
-    [System.IO.File]::WriteAllLines($path, $out, $script:Utf8NoBom)
+    if ($facts.size -gt $script:ByteExactMax) {
+        # large GENERATED capture (the perflib dump): there is no source encoding
+        # to preserve, and holding tens of MB twice is not worth it
+        $out = Convert-SanitizedText ([System.IO.File]::ReadAllLines($path)) $secretScan $ctx
+        [System.IO.File]::WriteAllLines($path, $out, $script:Utf8NoBom)
+        return
+    }
+    $script:EncJson = $facts.json
+    # Staged for Add-Manifest to commit, NOT recorded here: only COPIED files have
+    # a source encoding worth reporting. A command capture's line endings are this
+    # tool's own artifact (the provenance header is CRLF-joined), so recording
+    # them would fill the report with noise that looks like user-file faults.
+    $script:EncNote = ''
+    if ($facts.notes.Count -gt 0) {
+        $encRel = $path
+        if ($path.StartsWith($Work)) { $encRel = $path.Substring($Work.Length).TrimStart('\', '/').Replace('\', '/') }
+        $script:EncNote = "{0}`t{1}" -f $encRel, ($facts.notes -join ' ')
+    }
+    # byte-exact path: keep the BOM bytes, keep every line's OWN terminator, and
+    # never invent a final newline the source did not have
+    $bytes = [System.IO.File]::ReadAllBytes($path)
+    $text = $script:Utf8NoBom.GetString($bytes, $facts.bomLen, $bytes.Length - $facts.bomLen)
+    $sb = New-Object System.Text.StringBuilder
+    $inPem = $false
+    $pos = 0
+    $breaks = [char[]]@("`r", "`n")
+    while ($pos -lt $text.Length) {
+        $nl = $text.IndexOfAny($breaks, $pos)
+        if ($nl -lt 0) {
+            $lineText = $text.Substring($pos); $term = ''; $pos = $text.Length
+        } else {
+            $lineText = $text.Substring($pos, $nl - $pos)
+            if ($text[$nl] -eq "`r" -and ($nl + 1) -lt $text.Length -and $text[$nl + 1] -eq "`n") {
+                $term = "`r`n"; $pos = $nl + 2
+            } else {
+                $term = [string]$text[$nl]; $pos = $nl + 1
+            }
+        }
+        # PEM private key: withhold BEGIN..END; fail closed if END never comes
+        if ($inPem) {
+            if ($lineText -match '-----END [A-Z0-9 ]*PRIVATE KEY') { $inPem = $false }
+            continue
+        }
+        if ($lineText -match '-----BEGIN [A-Z0-9 ]*PRIVATE KEY') {
+            $inPem = $true
+            [void]$sb.Append('[REDACTED PRIVATE KEY BLOCK]').Append($term)
+            continue
+        }
+        [void]$sb.Append((Invoke-SanitizeLine $lineText $secretScan $ctx)).Append($term)
+    }
+    $body = $script:Utf8NoBom.GetBytes($sb.ToString())
+    if ($facts.bomLen -gt 0) {
+        $outBytes = New-Object byte[] ($facts.bomLen + $body.Length)
+        [System.Array]::Copy($bytes, 0, $outBytes, 0, $facts.bomLen)
+        [System.Array]::Copy($body, 0, $outBytes, $facts.bomLen, $body.Length)
+    } else {
+        $outBytes = $body
+    }
+    [System.IO.File]::WriteAllBytes($path, $outBytes)
 }
 
 # --- sanitizer self-test (-SelfTest) ----------------------------------------------
@@ -326,6 +485,8 @@ if ($SelfTest) {
     $HostShort = 'testhost99'
     $HostFqdn = 'testhost99.example.com'
     $RunUser = 'testuser9'
+    $UserDomain = 'TESTDOM'
+    $DnsDomain = 'testdom.example.com'
     $vectors = @(
         @{ in = 'api key = SENTINEL-1';                                            mustNot = @('SENTINEL');            must = @('[REDACTED]') }
         # assembled at runtime so secret scanners do not flag the source
@@ -361,6 +522,9 @@ if ($SelfTest) {
         @{ in = 'destination = [2001:db8::77]:19999 unix:/run/nd.sock';            mustNot = @('2001:db8::77');        must = @('ip6-', ']:19999', 'unix:/run/nd.sock') }
         @{ in = 'password: q';                                                     mustNot = @(': q');                 must = @('[REDACTED]') }
         @{ in = '"api_token": 731942';                                             mustNot = @('731942');              must = @('[REDACTED]') }
+        # 09-permissions ACL output: the machine's own AD domain is a corporate
+        # identifier, built-in authorities are not
+        @{ in = 'BUILTIN\Administrators and TESTDOM\svc_netdata have Modify';       mustNot = @('TESTDOM');             must = @('redacted-domain', 'BUILTIN\Administrators') }
     )
     $fails = 0
     foreach ($v in $vectors) {
@@ -370,6 +534,60 @@ if ($SelfTest) {
         foreach ($p in $v.must) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false } }
         if ($ok) { Write-Output "ok:   $result" } else { Write-Output "FAIL: '$($v.in)' -> '$result'"; $fails++ }
     }
+    # --- stream.conf context (netdata/netdata#23448): the STREAMING api key is
+    # --- kept verbatim, while every other secret in the same file is redacted
+    $streamVectors = @(
+        @{ in = '    api key = 11111111-2222-3333-4444-555555555555';       mustNot = @('REDACTED'); must = @('api key = 11111111-2222-3333-4444-555555555555') }
+        @{ in = '    proxy api key = 99999999-8888-7777-6666-555555555555'; mustNot = @('REDACTED'); must = @('proxy api key = 99999999-8888-7777-6666-555555555555') }
+        @{ in = '[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]';                   mustNot = @('REDACTED'); must = @('[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]') }
+        # a NON-api-key secret in the same file is still redacted
+        @{ in = '    password = SENTINEL-STREAM-PW';                        mustNot = @('SENTINEL'); must = @('[REDACTED]') }
+        # PII obfuscation is NOT disabled by the stream context
+        @{ in = '    destination = parent.example.internal:19999';          mustNot = @('parent.example'); must = @('private-host') }
+    )
+    foreach ($v in $streamVectors) {
+        $result = Invoke-SanitizeLine $v.in $true 'stream'
+        $ok = $true
+        foreach ($p in $v.mustNot) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) { $ok = $false } }
+        foreach ($p in $v.must) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false } }
+        if ($ok) { Write-Output "ok:   [stream] $result" } else { Write-Output "FAIL: [stream] '$($v.in)' -> '$result'"; $fails++ }
+    }
+    # the SAME lines WITHOUT the stream context must still be redacted
+    $noStreamVectors = @(
+        @{ in = '    api key = 11111111-2222-3333-4444-555555555555'; mustNot = @('11111111'); must = @('[REDACTED]') }
+        @{ in = '[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]';             mustNot = @('aaaaaaaa'); must = @('[REDACTED-KEY-SECTION]') }
+    )
+    foreach ($v in $noStreamVectors) {
+        $result = Invoke-SanitizeLine $v.in
+        $ok = $true
+        foreach ($p in $v.mustNot) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) { $ok = $false } }
+        foreach ($p in $v.must) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false } }
+        if ($ok) { Write-Output "ok:   [no-ctx] $result" } else { Write-Output "FAIL (leak): [no-ctx] '$($v.in)' -> '$result'"; $fails++ }
+    }
+
+    # --- encoding fidelity (netdata/netdata#23448): a BOM, CRLF endings and a
+    # --- missing final newline must all survive redaction, and a BOM must NOT
+    # --- shift the ^-anchored rules (it used to defeat the section redaction)
+    $encTmp = Join-Path $Staging 'enc-test.conf'
+    $encText = "[11111111-2222-3333-4444-555555555555]`r`npassword = SENTINEL-ENC`r`nlast line without newline"
+    [System.IO.File]::WriteAllBytes($encTmp,
+        [byte[]](@(0xEF, 0xBB, 0xBF) + $script:Utf8NoBom.GetBytes($encText)))
+    Invoke-SanitizeFile $encTmp
+    $encOut = [System.IO.File]::ReadAllBytes($encTmp)
+    $encStr = $script:Utf8NoBom.GetString($encOut)
+    $encFails = @()
+    if (-not ($encOut.Length -ge 3 -and $encOut[0] -eq 0xEF -and $encOut[1] -eq 0xBB -and $encOut[2] -eq 0xBF)) {
+        $encFails += 'the UTF-8 BOM was stripped by sanitization'
+    }
+    if ($encStr.IndexOf('[REDACTED-KEY-SECTION]') -lt 0) { $encFails += 'a BOM defeated the [<UUID>] section redaction' }
+    if ($encStr.IndexOf('11111111-2222') -ge 0) { $encFails += 'the BOM-prefixed api key section survived' }
+    if ($encStr.IndexOf('SENTINEL-ENC') -ge 0) { $encFails += 'a secret survived in the encoding vector' }
+    if (@([regex]::Matches($encStr, "`r`n")).Count -lt 2) { $encFails += 'CRLF line endings were lost (including on the redacted line)' }
+    if ($encOut[$encOut.Length - 1] -eq 10) { $encFails += 'a final newline was added to a source that had none' }
+    if ($null -eq $script:EncJson -or $script:EncJson['bom'] -ne 'utf-8') { $encFails += 'source_encoding did not record the BOM' }
+    if ($encFails.Count -gt 0) { foreach ($e in $encFails) { Write-Output "FAIL: $e"; $fails++ } }
+    else { Write-Output 'ok:   encoding preserved (BOM + CRLF + no trailing newline) and the BOM did not defeat redaction' }
+
     # multiline PEM block must be withheld end-to-end by the file-level sanitizer
     $pemTmp = Join-Path $Staging 'pem-test.txt'
     @('before line',
@@ -395,10 +613,24 @@ function Add-Manifest([string]$rel, [string]$kind, [string]$origin, [string]$tit
     $full = Join-Path $Work $rel
     $bytes = 0
     if (Test-Path $full) { $bytes = (Get-Item $full).Length }
-    [void]$script:ManifestRows.Add(@{
+    # source_encoding is recorded for COPIED files only: for command/API captures
+    # the bytes are ours, so the facts would describe this tool, not a source
+    # file. For a capped file it describes the retained tail (see origin).
+    $enc = $script:EncJson
+    $script:EncJson = $null
+    $encNote = $script:EncNote
+    $script:EncNote = ''
+    if ($kind -eq 'file') {
+        if ($encNote) { [void]$script:EncNotes.Add($encNote) }
+    } else {
+        $enc = $null
+    }
+    $row = [ordered]@{
         path = $rel.Replace('\', '/'); kind = $kind; origin = $origin; title = $title
         bytes = [long]$bytes; pii_obfuscated = [bool]$Obfuscate
-    })
+    }
+    if ($enc) { $row['source_encoding'] = $enc }
+    [void]$script:ManifestRows.Add($row)
 }
 
 # --- collectors -------------------------------------------------------------------
@@ -448,7 +680,11 @@ function Invoke-NativeProcess([string]$exe, [string[]]$argList, [int]$timeoutSec
     return $r
 }
 
-function Save-Cmd([string]$rel, [string]$title, [scriptblock]$cmd, [string]$originText, [string]$nativeExe = '', [string[]]$nativeArgs = @()) {
+function Save-Cmd([string]$rel, [string]$title, [scriptblock]$cmd, [string]$originText, [string]$nativeExe = '', [string[]]$nativeArgs = @(), [long]$cap = 0) {
+    # $cap mirrors the POSIX "collect_cmd --cap": journal/event-log captures are
+    # documented at 5 MiB while command output defaults to 2 MiB
+    if ($cap -le 0) { $cap = 2MB }
+    $script:EncJson = $null
     if (Test-Deadline) { return }
     $full = Join-Path $Work $rel
     New-Item -ItemType Directory -Path (Split-Path $full) -Force | Out-Null
@@ -470,11 +706,11 @@ function Save-Cmd([string]$rel, [string]$title, [scriptblock]$cmd, [string]$orig
             Remove-Job $job -Force
         } catch { $result = "ERROR: $_" }
     }
-    if ($result.Length -gt 2MB) {
+    if ($result.Length -gt $cap) {
         # truncate at a LINE boundary so a secret cannot straddle the cut
-        $cut = $result.LastIndexOf("`n", 2MB)
+        $cut = $result.LastIndexOf("`n", [int]$cap)
         if ($cut -lt 0) { $result = '[content withheld: output exceeds the cap without a line break]' }
-        else { $result = $result.Substring(0, $cut + 1) + '### TRUNCATED at 2MB (line-aligned) ###' }
+        else { $result = $result.Substring(0, $cut + 1) + ("### TRUNCATED at {0} bytes (line-aligned) ###" -f $cap) }
     }
     Write-Utf8 $full ($header + "`r`n" + $result)
     Invoke-SanitizeFile $full
@@ -485,6 +721,7 @@ function Save-CmdRaw([string]$rel, [string]$title, [scriptblock]$cmd, [string]$o
     # like Save-Cmd but with NO header/trailer, for commands whose output must
     # stay parseable (JSON). Provenance lives in MANIFEST.json only. The file is
     # removed if the command produced nothing.
+    $script:EncJson = $null
     if (Test-Deadline) { return }
     $full = Join-Path $Work $rel
     New-Item -ItemType Directory -Path (Split-Path $full) -Force | Out-Null
@@ -516,9 +753,13 @@ function Save-CmdRaw([string]$rel, [string]$title, [scriptblock]$cmd, [string]$o
 }
 
 function Save-File([string]$rel, [string]$title, [string]$src, [long]$cap = 0) {
+    $script:EncJson = $null
     if (Test-Deadline) { return }
     if ($cap -eq 0) { $cap = $FileCap }
     if (-not (Test-Path $src -PathType Leaf)) { return }
+    # stream.conf is the one file whose streaming API key is kept verbatim; the
+    # context is keyed on the SOURCE name, never on the bundle path
+    $ctx = if ((Split-Path -Leaf $src) -eq 'stream.conf') { 'stream' } else { '' }
     $full = Join-Path $Work $rel
     New-Item -ItemType Directory -Path (Split-Path $full) -Force | Out-Null
     $item = Get-Item $src -Force
@@ -556,13 +797,14 @@ function Save-File([string]$rel, [string]$title, [string]$src, [long]$cap = 0) {
             $origin = "$src (unreadable - withheld)"
         }
     }
-    Invoke-SanitizeFile $full
+    Invoke-SanitizeFile $full $true $ctx
     Add-Manifest $rel 'file' $origin $title
 }
 
 $NdPort = 19999
 $CloudHost = 'app.netdata.cloud'   # reachability probe target
 function Save-Api([string]$rel, [string]$title, [string]$urlPath) {
+    $script:EncJson = $null
     if (Test-Deadline) { return }
     $full = Join-Path $Work $rel
     New-Item -ItemType Directory -Path (Split-Path $full) -Force | Out-Null
@@ -700,15 +942,50 @@ if (Test-Path $ConfDir) {
 # 05-logs (Windows: Event Log is the primary destination)
 # ============================================================================
 Show-Info "collecting: logs (last ${SinceHours}h, Event Log + files)"
-Save-Cmd '05-logs\eventlog-netdata.txt' 'Netdata events from Windows Event Log (NetdataWEL + Application)' {
-    $since = (Get-Date).AddHours(-[int]$using:SinceHours)
-    foreach ($logName in @('NetdataWEL', 'Application')) {
-        Get-WinEvent -FilterHashtable @{ LogName = $logName; StartTime = $since } -MaxEvents 2000 -ErrorAction SilentlyContinue |
-            Where-Object { $_.ProviderName -match 'Netdata' } |
-            Select-Object TimeCreated, ProviderName, LevelDisplayName, Message |
-            Format-List
+# Windows builds are ALWAYS compiled with ETW (CMakeLists.txt sets HAVE_ETW
+# unconditionally for OS_WINDOWS) and netdata-conf-logs.c then selects "etw" as
+# the default log method, so the daemon logs into five manifest-declared
+# Operational channels - Netdata/Daemon, /Collectors, /Access, /Health, /Aclk
+# (wevt_netdata_mc_generate.c). Querying only NetdataWEL therefore returned NO
+# daemon logs at all on a default install (netdata/netdata#23448).
+#
+# One merged file, ordered for triage: channel/provider state first, then Daemon
+# and Collectors (what you read first), and Access LAST with the smallest event
+# budget because it is by far the highest volume.
+Save-Cmd '05-logs\eventlog-netdata.txt' 'Netdata events from the Windows Event Log: ETW channels (Netdata/*) + NetdataWEL + Application, plus channel and provider registration state' {
+    # capture $using: into locals once: the $using: modifier is resolved when the
+    # job scriptblock is serialized and must not be relied on inside strings
+    $sinceHours = [int]$using:SinceHours
+    $since = (Get-Date).AddHours(-$sinceHours)
+    '===== channel state (a disabled or full channel loses events) ====='
+    Get-WinEvent -ListLog 'Netdata/*', 'NetdataWEL' -ErrorAction SilentlyContinue |
+        Select-Object LogName, IsEnabled, RecordCount, FileSize | Format-Table -AutoSize
+    # per-channel event budgets: Daemon/Collectors carry the diagnosis, Access is
+    # request noise, so it gets the smallest share of the file
+    $channels = @(
+        @{ Log = 'Netdata/Daemon';     Max = 3000 }
+        @{ Log = 'Netdata/Collectors'; Max = 3000 }
+        @{ Log = 'Netdata/Health';     Max = 1000 }
+        @{ Log = 'Netdata/Aclk';       Max = 1000 }
+        @{ Log = 'NetdataWEL';         Max = 2000 }
+        @{ Log = 'Application';        Max = 2000 }
+        @{ Log = 'Netdata/Access';     Max = 500 }
+    )
+    foreach ($ch in $channels) {
+        "===== channel: $($ch.Log) (max $($ch.Max) events, last ${sinceHours}h) ====="
+        $events = Get-WinEvent -FilterHashtable @{ LogName = $ch.Log; StartTime = $since } `
+                               -MaxEvents $ch.Max -ErrorAction SilentlyContinue
+        # Application is a shared channel: keep only Netdata's own records. The
+        # dedicated channels are already Netdata-only, so filtering them would
+        # drop records whose ProviderName resolves differently under ETW.
+        if ($ch.Log -eq 'Application') { $events = $events | Where-Object { $_.ProviderName -match 'Netdata' } }
+        if ($events) {
+            $events | Select-Object TimeCreated, ProviderName, LevelDisplayName, Message | Format-List
+        } else {
+            '(no events in this window, or the channel does not exist on this system)'
+        }
     }
-} "Get-WinEvent NetdataWEL/Application (Netdata providers, last ${SinceHours}h)"
+} "Get-WinEvent: Netdata/* ETW channels + NetdataWEL + Application (last ${SinceHours}h)" -cap $LogCap
 if (Test-Path $LogDir) {
     Get-ChildItem $LogDir -File -Filter '*.log' | ForEach-Object {
         Save-File "05-logs\$($_.Name)" "Agent log file: $($_.Name)" $_.FullName $LogCap
@@ -843,6 +1120,69 @@ Save-Cmd '08-network\proxy-config.txt' 'System proxy configuration' { netsh winh
 Save-Cmd '08-network\cloud-connectivity.txt' 'Reachability of Netdata Cloud (TCP/TLS only, no data sent)' { Test-NetConnection -ComputerName $using:CloudHost -Port 443 -WarningAction SilentlyContinue | Format-List ComputerName, RemotePort, TcpTestSucceeded, PingSucceeded } "Test-NetConnection ${CloudHost}:443"
 
 # ============================================================================
+# 09-permissions
+# ============================================================================
+Show-Info 'collecting: permissions'
+$PluginsDir = Join-Path $NetdataPrefix 'usr\libexec\netdata\plugins.d'
+Save-Cmd '09-permissions\plugins-d.txt' 'plugins.d: ACLs, ownership, inheritance and integrity-level state for every plugin (a broken ACL here stops a collector dead)' {
+    $d = $using:PluginsDir
+    if (-not (Test-Path $d)) { "(plugins.d not found at $d)"; return }
+    "===== $d ====="
+    Get-Acl $d | Format-List Owner, Group, Access, Sddl
+    '-- contents --'
+    Get-ChildItem $d -Force -ErrorAction SilentlyContinue |
+        Select-Object Mode, LastWriteTime, Length, Name | Format-Table -AutoSize
+    '-- per-file owner and access (non-inherited entries are the interesting ones) --'
+    Get-ChildItem $d -File -Force -ErrorAction SilentlyContinue | Select-Object -First 120 | ForEach-Object {
+        $acl = Get-Acl $_.FullName -ErrorAction SilentlyContinue
+        if ($acl) {
+            $explicit = @($acl.Access | Where-Object { -not $_.IsInherited })
+            "{0}`n    owner={1}" -f $_.Name, $acl.Owner
+            if ($explicit.Count -gt 0) {
+                foreach ($a in $explicit) {
+                    "    explicit: {0} {1} {2}" -f $a.IdentityReference, $a.AccessControlType, $a.FileSystemRights
+                }
+            } else {
+                '    explicit: (none - all access inherited)'
+            }
+        }
+    }
+    '-- alternate data streams (a Zone.Identifier marks a file as downloaded/blocked) --'
+    $ads = Get-ChildItem $d -File -Force -ErrorAction SilentlyContinue |
+        Select-Object -First 120 |
+        ForEach-Object { Get-Item $_.FullName -Stream * -ErrorAction SilentlyContinue } |
+        Where-Object { $_.Stream -ne ':$DATA' }
+    if ($ads) { $ads | Select-Object FileName, Stream, Length | Format-Table -AutoSize }
+    else { '(no alternate data streams)' }
+} "Get-Acl + Get-ChildItem -Stream on $PluginsDir"
+
+$PermPaths = @($NetdataPrefix, $ConfDir, (Join-Path $ConfDir 'netdata.conf'), (Join-Path $ConfDir 'stream.conf'),
+               (Join-Path $ConfDir 'ssl'), $LogDir, $LibDir, (Join-Path $LibDir 'cloud.d'), $CacheDir,
+               $PluginsDir, $NetdataExe) | Where-Object { $_ } | Select-Object -Unique
+Save-Cmd '09-permissions\netdata-paths.txt' 'Ownership, ACLs, inheritance and integrity levels for netdata directories, configs and the binary' {
+    foreach ($p in $using:PermPaths) {
+        if (-not (Test-Path $p)) { continue }
+        "===== $p ====="
+        $acl = Get-Acl $p -ErrorAction SilentlyContinue
+        if ($acl) {
+            "owner: $($acl.Owner)"
+            "group: $($acl.Group)"
+            'access:'
+            $acl.Access | ForEach-Object {
+                "    {0} {1} {2} (inherited={3})" -f $_.IdentityReference, $_.AccessControlType, $_.FileSystemRights, $_.IsInherited
+            }
+            "sddl:  $($acl.Sddl)"
+            if ($acl.AreAccessRulesProtected) { 'NOTE: ACL inheritance is DISABLED on this path' }
+        } else {
+            '(could not read the ACL - insufficient privilege?)'
+        }
+        # mandatory integrity level, when one is explicitly set
+        $il = (icacls $p 2>$null | Select-String -SimpleMatch 'Mandatory Label') -join '; '
+        if ($il) { "integrity: $il" }
+    }
+} 'Get-Acl + icacls for netdata paths'
+
+# ============================================================================
 # summary + manifest + README
 # ============================================================================
 Show-Info 'writing summary and manifest'
@@ -860,6 +1200,18 @@ if (Test-Path $sfPath) {
     } catch { Write-Verbose "status-file.json unparsable: $_" }
 }
 $RuntimeSecs = [int]((Get-Date) - $StartTime).TotalSeconds
+$StreamNote = ''
+if (Test-Path (Join-Path $Work '04-config\stream.conf')) {
+    $StreamNote = 'streaming key:    PRESENT VERBATIM in 04-config\stream.conf (by design - see README.md)'
+}
+$EncNote = ''
+if ($script:EncNotes.Count -gt 0) {
+    $EncNote = "SOURCE FILES WITH NOTABLE ENCODING (preserved as-is in this bundle):`r`n" + ((
+        $script:EncNotes | Sort-Object -Unique | Select-Object -First 40 | ForEach-Object {
+            $parts = $_ -split "`t"
+            '  {0}: {1}' -f $parts[0], $parts[1]
+        }) -join "`r`n")
+}
 
 $summary = @"
 NETDATA SUPPORT BUNDLE SUMMARY
@@ -868,19 +1220,20 @@ tool version:     $ToolVersion (windows)
 runtime seconds:  $RuntimeSecs
 ran elevated:     $IsElevated
 pii obfuscation:  $(if ($Obfuscate) { 'on' } else { 'OFF' })
-
+$StreamNote
 agent version:    $(if ($AgentVersion) { $AgentVersion } else { 'unknown' })
 service status:   $(if ($NetdataSvc) { $NetdataSvc.Status } else { 'NOT INSTALLED' })
 agent process:    $(if ($NetdataProc) { "yes (pid $($NetdataProc.Id))" } else { 'NOT RUNNING' })
 agent api:        $(if ($ApiOk) { 'reachable' } else { 'UNREACHABLE' })
 $(if ($CrashHint) { "last exit reason: $CrashHint   <-- check 06-state\status-file.json" })
-
+$EncNote
 READ ORDER FOR TRIAGE:
   crashes/won't start -> 06-state\status-file.json, 05-logs\eventlog-netdata.txt
-  collector issues    -> 04-config\go.d*, 05-logs\
+  collector issues    -> 04-config\go.d*, 05-logs\, 09-permissions\plugins-d.txt
   streaming issues    -> 04-config\stream.conf, 07-runtime\node-instances.json, 01-system\clock-timesync.txt
   cloud/claiming      -> 06-state\claimed-id.txt, 07-runtime\aclk.json, 08-network\
   performance         -> 03-process\netdata-processes.txt, 06-state\db-disk-usage.txt
+  access denied       -> 09-permissions\ (ACLs, ownership, inheritance, service account)
 "@
 Write-Utf8 (Join-Path $Work 'summary.txt') $summary
 Add-Manifest 'summary.txt' 'file' 'generated' 'Human summary'
@@ -889,14 +1242,28 @@ $readme = @"
 # Netdata Support Bundle (Windows)
 
 Generated by ``netdata-support-bundle.ps1``. Contents are SANITIZED: secrets (tokens, api
-keys, passwords) are always redacted; by default IPs, MACs, emails and
+keys, passwords) are redacted; by default IPs, MACs, emails and
 hostnames are replaced with stable pseudonyms - consistent across all files.
 The pseudonym map stays on this machine, next to the zip - it is NOT in this
 bundle.
 
+**One deliberate exception:** the **streaming API key** is kept VERBATIM in
+``04-config\stream.conf`` (both ``api key`` values and ``[<API_KEY>]`` section
+headers). It is the value support needs to tell whether a child and its parent
+agree, so it is not treated as a secret. If your threat model differs, remove or
+mask it before sending the bundle. The same key IS still redacted where it
+appears in the Access event-log channel.
+
+Collected files keep their original bytes: a byte-order mark, CRLF or CR line
+endings and a missing final newline all survive redaction, so encoding faults
+stay visible. What was observed is recorded per file under ``source_encoding`` in
+MANIFEST.json, and anything notable is listed in summary.txt.
+
 Layout matches the POSIX bundle (see MANIFEST.json for every file):
-01-system, 02-install, 03-process, 04-config, 05-logs (Windows Event Log),
-06-state, 07-runtime, 08-network. Start with summary.txt.
+01-system, 02-install, 03-process, 04-config, 05-logs (Windows Event Log:
+Netdata/* ETW channels + NetdataWEL), 06-state, 07-runtime, 08-network,
+09-permissions (ACLs, ownership, inheritance, service account).
+Start with summary.txt.
 "@
 Write-Utf8 (Join-Path $Work 'README.md') $readme
 Add-Manifest 'README.md' 'file' 'generated' 'Bundle documentation'
@@ -909,12 +1276,15 @@ $manifest = [ordered]@{
     runtime_seconds = $RuntimeSecs
     pii_obfuscated = [bool]$Obfuscate
     secrets_redacted = $true
+    # the one documented exception to secrets_redacted (netdata/netdata#23448)
+    streaming_api_key_redacted = $false
     agent_running = [bool]$NetdataProc
     agent_api_reachable = [bool]$ApiOk
     is_container = $false
     files = $script:ManifestRows
 }
-Write-Utf8 (Join-Path $Work 'MANIFEST.json') (($manifest | ConvertTo-Json -Depth 4) + "`n")
+# depth 6: manifest -> files -> row -> source_encoding must all survive
+Write-Utf8 (Join-Path $Work 'MANIFEST.json') (($manifest | ConvertTo-Json -Depth 6) + "`n")
 
 # ============================================================================
 # zip

--- a/packaging/installer/netdata-support-bundle.ps1
+++ b/packaging/installer/netdata-support-bundle.ps1
@@ -63,11 +63,6 @@ $script:Ip6Count = 0
 $script:FqdnCount = 0
 $script:DomainCount = 0
 $script:SeededHosts = @() # child/mirrored hostnames pre-seeded from the local API
-# encoding facts of the file most recently sanitized; consumed by Add-Manifest.
-# EncNotes keeps only the ANOMALIES, which summary.txt surfaces.
-$script:EncJson = $null
-$script:EncNote = ''
-$script:EncNotes = New-Object System.Collections.ArrayList
 # byte-exact encoding preservation reads the whole file into one string; the
 # Windows perflib dump can be tens of MB, where fidelity is irrelevant (we
 # generated it) and the memory cost is not. Above this, use the line path.
@@ -150,6 +145,12 @@ function Test-DiagnosticKey([string]$key) {
         if ($k -eq $w -or $k.EndsWith(" $w")) { return $true }
     }
     return $false
+}
+
+function Test-KeyExempt([string]$key) {
+    # the two reasons a key that LOOKS secret is left alone: it names or
+    # describes a secret rather than holding one, or it is the streaming api key
+    return ((Test-DiagnosticKey $key) -or (Test-StreamingApiKey $key))
 }
 
 function Test-StreamingApiKey([string]$key) {
@@ -336,74 +337,40 @@ function Invoke-SanitizeLine([string]$line, [bool]$secretScan = $true, [string]$
 }
 
 function Get-FileEncodingFacts([string]$path) {
-    # Large GENERATED captures (the Windows perflib dump, tens of MB) have no
-    # source encoding worth reporting, and a per-byte scan over them would eat
-    # the global deadline. Probe a prefix for NUL only and let the caller take
-    # the line-based path.
+    # What the sanitizer must preserve: where the BOM ends, whether the body is
+    # valid UTF-8 (which decides the round-trip encoding), and whether it holds
+    # a NUL. The old ReadAllLines/WriteAllLines pair normalized the BOM and the
+    # line endings away silently - netdata/netdata#23448.
     $len = (Get-Item $path -Force).Length
     if ($len -gt $script:ByteExactMax) {
-        $probeLen = [Math]::Min($len, 1MB)
+        # a large GENERATED capture (the perflib dump): scanning tens of MB in a
+        # scalar loop would eat the global deadline, so probe a prefix for NUL
+        # only and let the caller take the line-based path
+        $probeLen = [int][Math]::Min($len, 1MB)
         $probe = New-Object byte[] $probeLen
         $fs = [System.IO.File]::OpenRead($path)
         try { [void]$fs.Read($probe, 0, $probeLen) } finally { $fs.Close() }
-        $hasNul = $false
-        for ($i = 0; $i -lt $probeLen; $i++) { if ($probe[$i] -eq 0) { $hasNul = $true; break } }
-        return [pscustomobject]@{ size = $len; bomLen = 0; nul = $hasNul; notes = @(); json = $null }
+        return [pscustomobject]@{
+            size = $len; bomLen = 0; utf8Valid = $true
+            nul = ([Array]::IndexOf($probe, [byte]0) -ge 0)
+        }
     }
-    # Record the encoding of a collected file BEFORE redaction touches it, so
-    # support can tell a genuine source-file encoding fault (a BOM, mixed line
-    # endings, a missing final newline) from an artifact of this tool. The old
-    # ReadAllLines/WriteAllLines pair normalized every one of these away
-    # silently - netdata/netdata#23448.
     $bytes = [System.IO.File]::ReadAllBytes($path)
-    $bom = 'none'; $bomLen = 0
-    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
-        $bom = 'utf-8'; $bomLen = 3
-    } elseif ($bytes.Length -ge 4 -and $bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE -and $bytes[2] -eq 0 -and $bytes[3] -eq 0) {
-        $bom = 'utf-32le'; $bomLen = 4
-    } elseif ($bytes.Length -ge 4 -and $bytes[0] -eq 0 -and $bytes[1] -eq 0 -and $bytes[2] -eq 0xFE -and $bytes[3] -eq 0xFF) {
-        $bom = 'utf-32be'; $bomLen = 4
-    } elseif ($bytes.Length -ge 2 -and $bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE) {
-        $bom = 'utf-16le'; $bomLen = 2
-    } elseif ($bytes.Length -ge 2 -and $bytes[0] -eq 0xFE -and $bytes[1] -eq 0xFF) {
-        $bom = 'utf-16be'; $bomLen = 2
-    }
-    $lf = 0; $crlf = 0; $crAll = 0; $nonAscii = 0; $nul = $false
-    for ($i = $bomLen; $i -lt $bytes.Length; $i++) {
-        $b = $bytes[$i]
-        if ($b -eq 0) { $nul = $true }
-        elseif ($b -eq 10) { if ($i -gt $bomLen -and $bytes[$i - 1] -eq 13) { $crlf++ } else { $lf++ } }
-        elseif ($b -eq 13) { $crAll++ }
-        if ($b -gt 127) { $nonAscii++ }
-    }
-    $cr = $crAll - $crlf; if ($cr -lt 0) { $cr = 0 }
-    # CR is a line terminator too: a CR-terminated file is not missing its
-    # final newline
-    $finalNewline = ($bytes.Length -gt $bomLen -and
-                     ($bytes[$bytes.Length - 1] -eq 10 -or $bytes[$bytes.Length - 1] -eq 13))
+    $bomLen = 0
+    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) { $bomLen = 3 }
+    elseif ($bytes.Length -ge 4 -and $bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE -and $bytes[2] -eq 0 -and $bytes[3] -eq 0) { $bomLen = 4 }
+    elseif ($bytes.Length -ge 4 -and $bytes[0] -eq 0 -and $bytes[1] -eq 0 -and $bytes[2] -eq 0xFE -and $bytes[3] -eq 0xFF) { $bomLen = 4 }
+    elseif ($bytes.Length -ge 2 -and $bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE) { $bomLen = 2 }
+    elseif ($bytes.Length -ge 2 -and $bytes[0] -eq 0xFE -and $bytes[1] -eq 0xFF) { $bomLen = 2 }
     # a strict decoder is the cheapest UTF-8 validator available here
     $utf8Valid = $true
     try {
         $strict = New-Object System.Text.UTF8Encoding($false, $true)
         [void]$strict.GetString($bytes, $bomLen, $bytes.Length - $bomLen)
     } catch { $utf8Valid = $false }
-    $notes = @()
-    if ($bom -ne 'none') { $notes += "$bom-BOM" }
-    if ($cr -gt 0) { $notes += "CR-only-line-endings($cr)" }
-    if ($crlf -gt 0 -and $lf -gt 0) { $notes += "mixed-line-endings(lf=$lf,crlf=$crlf)" }
-    if (-not $finalNewline -and $bytes.Length -gt 0) { $notes += 'no-final-newline' }
-    if (-not $utf8Valid) { $notes += 'invalid-UTF-8' }
     return [pscustomobject]@{
-        size  = $bytes.Length
-        bomLen = $bomLen
-        nul   = $nul
-        notes = $notes
-        json  = [ordered]@{
-            bom = $bom; lf = $lf; crlf = $crlf; cr = $cr
-            final_newline = [bool]$finalNewline
-            # the scan starts past the BOM, so its bytes are already excluded
-            non_ascii_bytes = $nonAscii; utf8_valid = [bool]$utf8Valid
-        }
+        size = $bytes.Length; bomLen = $bomLen; utf8Valid = $utf8Valid
+        nul = ([Array]::IndexOf($bytes, [byte]0) -ge 0)
     }
 }
 
@@ -433,7 +400,6 @@ function Convert-SanitizedText([string[]]$lines, [bool]$secretScan = $true, [str
 
 function Invoke-SanitizeFile([string]$path, [bool]$secretScan = $true, [string]$ctx = '') {
     if (-not (Test-Path $path)) { return }
-    $script:EncJson = $null
     $facts = Get-FileEncodingFacts $path
     if ($facts.nul) {
         # a NUL means binary/UTF-16: line-based redaction would be byte-unsafe
@@ -447,17 +413,6 @@ function Invoke-SanitizeFile([string]$path, [bool]$secretScan = $true, [string]$
         [System.IO.File]::WriteAllLines($path, $out, $script:Utf8NoBom)
         return
     }
-    $script:EncJson = $facts.json
-    # Staged for Add-Manifest to commit, NOT recorded here: only COPIED files have
-    # a source encoding worth reporting. A command capture's line endings are this
-    # tool's own artifact (the provenance header is CRLF-joined), so recording
-    # them would fill the report with noise that looks like user-file faults.
-    $script:EncNote = ''
-    if ($facts.notes.Count -gt 0) {
-        $encRel = $path
-        if ($path.StartsWith($Work)) { $encRel = $path.Substring($Work.Length).TrimStart('\', '/').Replace('\', '/') }
-        $script:EncNote = "{0}`t{1}" -f $encRel, ($facts.notes -join ' ')
-    }
     # byte-exact path: keep the BOM bytes, keep every line's OWN terminator, and
     # never invent a final newline the source did not have
     $bytes = [System.IO.File]::ReadAllBytes($path)
@@ -466,7 +421,7 @@ function Invoke-SanitizeFile([string]$path, [bool]$secretScan = $true, [string]$
     # username must not be reduced to Latin-1 mojibake - the replacement would
     # miss it and the real value would ship. ISO-8859-1 is only the fallback for
     # sources that are not valid UTF-8, where it is the byte-preserving choice.
-    $enc = if ($facts.json.utf8_valid) { $script:Utf8NoBom } else { $script:BytePreserving }
+    $enc = if ($facts.utf8Valid) { $script:Utf8NoBom } else { $script:BytePreserving }
     $text = $enc.GetString($bytes, $facts.bomLen, $bytes.Length - $facts.bomLen)
     $sb = New-Object System.Text.StringBuilder
     $inPem = $false
@@ -554,44 +509,27 @@ if ($SelfTest) {
         # 09-permissions ACL output: the machine's own AD domain is a corporate
         # identifier, built-in authorities are not
         @{ in = 'BUILTIN\Administrators and TESTDOM\svc_netdata have Modify';       mustNot = @('TESTDOM');             must = @('redacted-domain', 'BUILTIN\Administrators') }
-    )
-    $fails = 0
-    foreach ($v in $vectors) {
-        $result = Invoke-SanitizeLine $v.in
-        $ok = $true
-        foreach ($p in $v.mustNot) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) { $ok = $false } }
-        foreach ($p in $v.must) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false } }
-        if ($ok) { Write-Output "ok:   $result" } else { Write-Output "FAIL: '$($v.in)' -> '$result'"; $fails++ }
-    }
-    # --- stream.conf context (netdata/netdata#23448): the STREAMING api key is
-    # --- kept verbatim, while every other secret in the same file is redacted
-    $streamVectors = @(
-        @{ in = '    api key = 11111111-2222-3333-4444-555555555555';       mustNot = @('REDACTED'); must = @('api key = 11111111-2222-3333-4444-555555555555') }
-        @{ in = '    proxy api key = 99999999-8888-7777-6666-555555555555'; mustNot = @('REDACTED'); must = @('proxy api key = 99999999-8888-7777-6666-555555555555') }
-        @{ in = '[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]';                   mustNot = @('REDACTED'); must = @('[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]') }
-        # a NON-api-key secret in the same file is still redacted
-        @{ in = '    password = SENTINEL-STREAM-PW';                        mustNot = @('SENTINEL'); must = @('[REDACTED]') }
+        # stream.conf context (netdata/netdata#23448): the STREAMING api key is
+        # kept verbatim, while every other secret in the same file is redacted
+        @{ ctx = 'stream'; in = '    api key = 11111111-2222-3333-4444-555555555555';       mustNot = @('REDACTED'); must = @('api key = 11111111-2222-3333-4444-555555555555') }
+        @{ ctx = 'stream'; in = '    proxy api key = 99999999-8888-7777-6666-555555555555'; mustNot = @('REDACTED'); must = @('proxy api key = 99999999-8888-7777-6666-555555555555') }
+        @{ ctx = 'stream'; in = '[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]';                   mustNot = @('REDACTED'); must = @('[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]') }
+        @{ ctx = 'stream'; in = '    password = SENTINEL-STREAM-PW';                        mustNot = @('SENTINEL'); must = @('[REDACTED]') }
         # PII obfuscation is NOT disabled by the stream context
-        @{ in = '    destination = parent.example.internal:19999';          mustNot = @('parent.example'); must = @('private-host') }
-    )
-    foreach ($v in $streamVectors) {
-        $result = Invoke-SanitizeLine $v.in $true 'stream'
-        $ok = $true
-        foreach ($p in $v.mustNot) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) { $ok = $false } }
-        foreach ($p in $v.must) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false } }
-        if ($ok) { Write-Output "ok:   [stream] $result" } else { Write-Output "FAIL: [stream] '$($v.in)' -> '$result'"; $fails++ }
-    }
-    # the SAME lines WITHOUT the stream context must still be redacted
-    $noStreamVectors = @(
+        @{ ctx = 'stream'; in = '    destination = parent.example.internal:19999';          mustNot = @('parent.example'); must = @('private-host') }
+        # the SAME lines with NO context must still be redacted
         @{ in = '    api key = 11111111-2222-3333-4444-555555555555'; mustNot = @('11111111'); must = @('[REDACTED]') }
         @{ in = '[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]';             mustNot = @('aaaaaaaa'); must = @('[REDACTED-KEY-SECTION]') }
     )
-    foreach ($v in $noStreamVectors) {
-        $result = Invoke-SanitizeLine $v.in
+    $fails = 0
+    foreach ($v in $vectors) {
+        $ctx = if ($v.ContainsKey('ctx')) { [string]$v.ctx } else { '' }
+        $label = if ($ctx) { "[$ctx] " } else { '' }
+        $result = Invoke-SanitizeLine $v.in $true $ctx
         $ok = $true
         foreach ($p in $v.mustNot) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) { $ok = $false } }
         foreach ($p in $v.must) { if ($result.IndexOf($p, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false } }
-        if ($ok) { Write-Output "ok:   [no-ctx] $result" } else { Write-Output "FAIL (leak): [no-ctx] '$($v.in)' -> '$result'"; $fails++ }
+        if ($ok) { Write-Output "ok:   $label$result" } else { Write-Output "FAIL: $label'$($v.in)' -> '$result'"; $fails++ }
     }
 
     # --- encoding fidelity (netdata/netdata#23448): a BOM, CRLF endings and a
@@ -613,7 +551,6 @@ if ($SelfTest) {
     if ($encStr.IndexOf('SENTINEL-ENC') -ge 0) { $encFails += 'a secret survived in the encoding vector' }
     if (@([regex]::Matches($encStr, "`r`n")).Count -lt 2) { $encFails += 'CRLF line endings were lost (including on the redacted line)' }
     if ($encOut[$encOut.Length - 1] -eq 10) { $encFails += 'a final newline was added to a source that had none' }
-    if ($null -eq $script:EncJson -or $script:EncJson['bom'] -ne 'utf-8') { $encFails += 'source_encoding did not record the BOM' }
     if ($encFails.Count -gt 0) { foreach ($e in $encFails) { Write-Output "FAIL: $e"; $fails++ } }
     else { Write-Output 'ok:   encoding preserved (BOM + CRLF + no trailing newline) and the BOM did not defeat redaction' }
 
@@ -642,23 +579,10 @@ function Add-Manifest([string]$rel, [string]$kind, [string]$origin, [string]$tit
     $full = Join-Path $Work $rel
     $bytes = 0
     if (Test-Path $full) { $bytes = (Get-Item $full).Length }
-    # source_encoding is recorded for COPIED files only: for command/API captures
-    # the bytes are ours, so the facts would describe this tool, not a source
-    # file. For a capped file it describes the retained tail (see origin).
-    $enc = $script:EncJson
-    $script:EncJson = $null
-    $encNote = $script:EncNote
-    $script:EncNote = ''
-    if ($kind -eq 'file') {
-        if ($encNote) { [void]$script:EncNotes.Add($encNote) }
-    } else {
-        $enc = $null
-    }
     $row = [ordered]@{
         path = $rel.Replace('\', '/'); kind = $kind; origin = $origin; title = $title
         bytes = [long]$bytes; pii_obfuscated = [bool]$Obfuscate
     }
-    if ($enc) { $row['source_encoding'] = $enc }
     [void]$script:ManifestRows.Add($row)
 }
 
@@ -717,7 +641,6 @@ function Save-Cmd([string]$rel, [string]$title, [scriptblock]$cmd, [string]$orig
     # raise the floor; without it the job is killed and its WHOLE output is
     # replaced by "TIMEOUT after Ns", losing everything it had already gathered
     $timeout = if ($timeoutFloor -gt 0) { [Math]::Max($TimeoutSeconds, $timeoutFloor) } else { $TimeoutSeconds }
-    $script:EncJson = $null
     if (Test-Deadline) { return }
     $full = Join-Path $Work $rel
     New-Item -ItemType Directory -Path (Split-Path $full) -Force | Out-Null
@@ -754,7 +677,6 @@ function Save-CmdRaw([string]$rel, [string]$title, [scriptblock]$cmd, [string]$o
     # like Save-Cmd but with NO header/trailer, for commands whose output must
     # stay parseable (JSON). Provenance lives in MANIFEST.json only. The file is
     # removed if the command produced nothing.
-    $script:EncJson = $null
     if (Test-Deadline) { return }
     $full = Join-Path $Work $rel
     New-Item -ItemType Directory -Path (Split-Path $full) -Force | Out-Null
@@ -786,7 +708,6 @@ function Save-CmdRaw([string]$rel, [string]$title, [scriptblock]$cmd, [string]$o
 }
 
 function Save-File([string]$rel, [string]$title, [string]$src, [long]$cap = 0) {
-    $script:EncJson = $null
     if (Test-Deadline) { return }
     if ($cap -eq 0) { $cap = $FileCap }
     if (-not (Test-Path $src -PathType Leaf)) { return }
@@ -837,7 +758,6 @@ function Save-File([string]$rel, [string]$title, [string]$src, [long]$cap = 0) {
 $NdPort = 19999
 $CloudHost = 'app.netdata.cloud'   # reachability probe target
 function Save-Api([string]$rel, [string]$title, [string]$urlPath) {
-    $script:EncJson = $null
     if (Test-Deadline) { return }
     $full = Join-Path $Work $rel
     New-Item -ItemType Directory -Path (Split-Path $full) -Force | Out-Null
@@ -1236,14 +1156,6 @@ $StreamNote = ''
 if (Test-Path (Join-Path $Work '04-config\stream.conf')) {
     $StreamNote = 'streaming key:    PRESENT VERBATIM in 04-config\stream.conf (by design - see README.md)'
 }
-$EncNote = ''
-if ($script:EncNotes.Count -gt 0) {
-    $EncNote = "SOURCE FILES WITH NOTABLE ENCODING (preserved as-is in this bundle):`r`n" + ((
-        $script:EncNotes | Sort-Object -Unique | Select-Object -First 40 | ForEach-Object {
-            $parts = $_ -split "`t"
-            '  {0}: {1}' -f $parts[0], $parts[1]
-        }) -join "`r`n")
-}
 
 $summary = @"
 NETDATA SUPPORT BUNDLE SUMMARY
@@ -1258,7 +1170,7 @@ service status:   $(if ($NetdataSvc) { $NetdataSvc.Status } else { 'NOT INSTALLE
 agent process:    $(if ($NetdataProc) { "yes (pid $($NetdataProc.Id))" } else { 'NOT RUNNING' })
 agent api:        $(if ($ApiOk) { 'reachable' } else { 'UNREACHABLE' })
 $(if ($CrashHint) { "last exit reason: $CrashHint   <-- check 06-state\status-file.json" })
-$EncNote
+
 READ ORDER FOR TRIAGE:
   crashes/won't start -> 06-state\status-file.json, 05-logs\eventlog-netdata.txt
   collector issues    -> 04-config\go.d*, 05-logs\, 09-permissions\plugins-d.txt
@@ -1287,9 +1199,8 @@ mask it before sending the bundle. The same key IS still redacted where it
 appears in the Access event-log channel.
 
 Collected files keep their original bytes: a byte-order mark, CRLF or CR line
-endings and a missing final newline all survive redaction, so encoding faults
-stay visible. What was observed is recorded per file under ``source_encoding`` in
-MANIFEST.json, and anything notable is listed in summary.txt.
+endings and a missing final newline all survive redaction, so an encoding fault
+in a config file is still visible here.
 
 Layout matches the POSIX bundle (see MANIFEST.json for every file):
 01-system, 02-install, 03-process, 04-config, 05-logs (Windows Event Log:
@@ -1315,8 +1226,7 @@ $manifest = [ordered]@{
     is_container = $false
     files = $script:ManifestRows
 }
-# depth 6: manifest -> files -> row -> source_encoding must all survive
-Write-Utf8 (Join-Path $Work 'MANIFEST.json') (($manifest | ConvertTo-Json -Depth 6) + "`n")
+Write-Utf8 (Join-Path $Work 'MANIFEST.json') (($manifest | ConvertTo-Json -Depth 4) + "`n")
 
 # ============================================================================
 # zip


### PR DESCRIPTION
Closes #23448

Addresses all five items from @ralphm's issue. Each is scoped tightly and mirrored in both the POSIX and PowerShell scripts, per the parity contract in `SUPPORT-BUNDLE.md`.

### 1. The streaming API key is no longer redacted

Kept verbatim in `04-config/stream.conf` — both `api key` / `proxy api key` values and the parent-side `[<API_KEY>]` / `[<MACHINE_GUID>]` section headers. Beyond the key value itself, collapsing every section header to one `[REDACTED-KEY-SECTION]` line also made per-key settings unattributable on a parent with several keys.

The exemption is deliberately narrow:
- **file-scoped** — only when the source file is named `stream.conf`, keyed on the source path, never the bundle path;
- **key-exact** — only a key normalizing to exactly `api key` or `proxy api key`. A `password` or a PEM block in `stream.conf` is still redacted, as is a third-party `api key` in any other file;
- **not applied to logs** — the key also appears in access logs (`stream-receiver-connection.c` logs `api_key:'…'`, and children send it as a `key=` query parameter). Those stay redacted, because un-redacting there would loosen rules shared with genuinely secret parameters like `claim_token`.

Since this makes the bundle's old "secrets are ALWAYS redacted" claim untrue, the exception is now stated in the bundle's own `README.md`, in `summary.txt`, and via a new `streaming_api_key_redacted: false` flag in `MANIFEST.json`. Whoever receives a bundle can see the value is in it.

### 2. Redaction no longer obscures encoding issues

Collected files keep their original bytes through sanitization: the byte-order mark, each line's own terminator (CRLF / bare CR / LF), and the absence of a final newline. On Windows the `ReadAllLines`/`WriteAllLines` pair destroyed all three by construction, which is the BOM case in the issue.

`MANIFEST.json` also gains a `source_encoding` object per **copied** file (`bom`, `lf`, `crlf`, `cr`, `final_newline`, `non_ascii_bytes`, `utf8_valid`), and `summary.txt` lists the files with something notable. Command and API captures deliberately get no record — those bytes are the tool's own, so they would describe the script rather than a source file.

**Two defects found while testing this, both fixed:**
- A BOM shifted every `^`-anchored sanitizer rule, so a BOM-prefixed `[<API_KEY>]` header did **not** match the section rule and shipped verbatim. That is a redaction bypass on any BOM'd parent `stream.conf`, independent of item 1. Regression test added.
- Redaction rebuilt lines without their trailing `CR`, silently turning a CRLF file into a mixed-ending one.

### 3. Windows ETW logs are now collected

Every `OS_WINDOWS` build sets `HAVE_ETW` (`CMakeLists.txt`), and `netdata-conf-logs.c` then selects `etw` as the default log method, so the daemon logs into the five manifest-declared channels `Netdata/{Daemon,Collectors,Health,Aclk,Access}` (`wevt_netdata_mc_generate.c`). The collector queried only `NetdataWEL`, so a default install produced **no daemon logs at all**.

Now one merged `05-logs/eventlog-netdata.txt` covers all five ETW channels plus `NetdataWEL` and Netdata records from `Application`, ordered for triage with per-channel event budgets so `Netdata/Access` cannot drown the rest, plus channel state (a disabled or full channel silently loses events).

### 4 + 5. Extended attributes, security contexts and `plugins.d` permissions

New `09-permissions/` section:
- `plugins-d.txt` — modes, ownership, setuid/setgid bits and per-file **capabilities**, for every discovered `plugins.d` (resolved from the binary prefix, the known install prefixes, and the `[directories] plugins` list, whose default also includes `<config>/custom-plugins.d`).
- `netdata-paths.txt` — modes, ownership, extended attributes, security contexts (SELinux/AppArmor), ACLs and non-default ext2/3/4 file flags for netdata's directories, configs and binary. Windows gets the equivalents: ACLs with inheritance state, protected-ACL detection, integrity labels and alternate data streams.

Mode bits alone explain very little here — on a stock install seven plugins carry file capabilities and several more are setuid, and none of that shows in an `ls -la`. Note `getfattr` ships in the `attr` package, which is **not** installed by default on Debian/Ubuntu, so when it is missing the collector falls back to `getcap` and `lsattr` rather than reporting nothing.

The Windows ACL captures print `DOMAIN\user`, so the sanitizer also pseudonymizes the machine's own AD domain to `redacted-domain` (by exact known value, since a generic `DOMAIN\user` pattern is indistinguishable from `C:\Users\Public`). Built-in authorities are untouched.

### Compatibility

Purely additive: the `MANIFEST.json` schema id stays `netdata-support-bundle/v1`, and the new section, the `source_encoding` object and the new flag are all additions. Tool version 1.0.0 → 1.1.0.

### Validation

- Both selftests extended with vectors for the stream context (in **and** out), the BOM redaction bypass, CRLF and final-newline preservation, and the AD-domain rule.
- POSIX selftest passes on `sh`, `dash`, busybox `sh`, and busybox `awk` — the last one is not otherwise covered, since the busybox CI job resolves `awk` to mawk.
- POSIX end-to-end run against a live agent: reports all seven capability-bearing plugins with their capability sets and seven setuid binaries.
- PowerShell 7 selftest and two full runs; POSIX and PowerShell produce **byte-identical** output for the same BOM+CRLF fixture. PowerShell 5.1 is covered by CI only.
- CI gains a BOM + CRLF + no-final-newline `stream.conf` fixture on both platforms, asserting the api key survives, a planted password does not, the bytes are preserved, and the ETW channels are actually queried.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the support bundle for faster, safer triage: keeps the streaming API key in `stream.conf`, preserves file bytes, collects complete Windows ETW logs, and adds a permissions section. Adds security hardening and encoding fixes; schema stays the same.

- **New Features**
  - Streaming API key kept verbatim in `04-config/stream.conf`; disclosed in `README.md`, `summary.txt`, and `MANIFEST.json` via `streaming_api_key_redacted: false`. Logs still redact the key.
  - Byte fidelity preserved (BOM, CR/LF/CRLF, missing final newline). No manifest changes for encoding; just preservation.
  - Windows: merged `05-logs/eventlog-netdata.txt` covers all `Netdata/*`, `NetdataWEL`, and `Application`, with channel state and per‑channel budgets.
  - Permissions: new `09-permissions/` with plugin modes/owners/setuid/capabilities and path xattrs/SELinux/AppArmor/ACLs; Windows adds ACL details and AD-domain pseudonymization. `plugins.d` discovery uses the binary prefix, known install prefixes, and `<config>/custom-plugins.d`. Tool version `1.1.0`; schema unchanged.

- **Bug Fixes**
  - Fixed BOM rule that let `[UUID]` sections ship unredacted; fixed CR loss on rewritten lines.
  - CR‑only files: translate CR↔LF during redaction, preserve trailing CR, keep BOM with CR‑only, and avoid adding a final terminator.
  - Windows byte‑exact sanitize: use ISO‑8859‑1 only when the source is not valid UTF‑8; valid UTF‑8 re‑encodes identically; skipped per‑byte scans for very large files.
  - Hardened permissions collector (no `sh -c` splicing; paths as args), stopped reading a `[directories] plugins` override from `netdata.conf`, dropped raw SDDL from output, and set a 30s timeout floor for merged event logs.

<sup>Written for commit 955a05218f7541d41a7d1b7b8b0da9fac87636cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permissions diagnostics to support bundles.
  * Added Windows ETW event-log collection and expanded Windows permissions details.
  * Added encoding and file-format metadata to bundle manifests and summaries.
  * Added configurable command-output limits.

* **Bug Fixes**
  * Improved secret sanitization while preserving approved streaming configuration details.
  * Preserved BOMs, line endings, missing final newlines, and original encoding where applicable.
  * Added redaction for local AD/DNS domains and expanded privacy protections.
  * Prevented collection of binary or unsafe file contents.

* **Documentation**
  * Updated support-bundle privacy, format, and diagnostic collection guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->