### PR TITLE
logs: stop advertising a range filter on the timestamp column

### DIFF
--- a/src/libnetdata/facets/facets.c
+++ b/src/libnetdata/facets/facets.c
@@ -2806,7 +2806,9 @@ void facets_report(FACETS *facets, BUFFER *wb, DICTIONARY *used_hashes_registry)
                 RRDF_FIELD_SORT_DESCENDING|RRDF_FIELD_SORT_FIXED,
                 NULL,
                 RRDF_FIELD_SUMMARY_COUNT,
-                RRDF_FIELD_FILTER_RANGE,
+                // no column filter: the time range is controlled by has_history (after/before)
+                // and the anchor-based pagination, which both key on this column
+                RRDF_FIELD_FILTER_NONE,
                 RRDF_FIELD_OPTS_WRAP | RRDF_FIELD_OPTS_VISIBLE | RRDF_FIELD_OPTS_UNIQUE_KEY,
                 NULL);
 


### PR DESCRIPTION
## Problem

The logs tables (`systemd-journal`, `windows-events`, `macos-logs`) advertise a `range` filter on the `timestamp` column that the agent cannot service.

`facets` is the only server-side filtered, anchor-paginated table we produce. Everything it advertises as filterable must round-trip to the agent through `accepted_params`. But `timestamp` is a synthetic column added in the columns block — it is never registered as an accepted param (`src/libnetdata/facets/logs_query_status.h`) and it is not a facet key, so it never lands in `accepted_params` either.

Per `src/plugins.d/FUNCTION_UI_REFERENCE.md`, `accepted_params` "drives outgoing payload (only params in this list are sent)". So the advertised range filter has no parameter to travel on.

The UI rendered the advertised RangeFilter anyway. Applying it could not produce a query, and left the Timestamp column showing only `-` until the page was reloaded.

## Why `none`

The time range of these tables is already expressed twice by other means:

- `has_history: true` — the after/before date-time picker
- `pagination` — anchor-based, and already keyed on `"column": "timestamp"`

A per-column range filter on top of those is redundant as well as unserviceable.

`none` also matches how the rest of the same table is built: `rowOptions` and every `NEVER_FACET` key already emit `none`, and all other columns emit `facet`. `timestamp` was the only outlier.

`facet` would be wrong here — the column is continuous and microsecond-resolution, so faceting it would produce a per-row value list.

## Scope

One argument at one call site. This is not a regression — the value has been `range` since the commit that introduced `facets.c` (`ce75313de0`, Aug 2023).

Other `RRDF_FIELD_FILTER_RANGE` call sites are deliberately left alone: `apps.plugin`, `network-viewer`, streaming and metrics-cardinality are all "Simple Tables" that ship every row at once and let the frontend filter locally, so a range filter there needs no accepted param and works correctly. `facets.c` is the only producer of server-side `"pagination"` in the tree.

## Validation

Built `systemd-journal.plugin` and captured real function output before and after. The emitted `columns` object — 250+ columns — differs by exactly one line:

```diff
-    "filter": "range",
+    "filter": "none",
```

After the change every column in the table is either `none` or `facet`; no `range` remains.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the range filter from the `timestamp` column in `facets`-based logs tables to prevent a broken, unserviceable UI filter. Time range is now controlled only by `has_history` and anchor-based pagination.

- **Bug Fixes**
  - `timestamp` is synthetic and not in `accepted_params`, so a range filter could not round-trip to the agent.
  - Emit `filter: "none"` for `timestamp`; avoids queries that blank the column until reload.
  - Affects `systemd-journal`, `windows-events`, and `macos-logs`; no other columns changed.

<sup>Written for commit 2e630ef8dd8790ed77d571a8170732e0df8bae6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated facets reports so timestamp columns no longer offer unsupported range filtering.
  * Time-range selection continues to be handled through history bounds and anchor-based pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->