### PR TITLE
logs: align timestamp filters with systemd Journal SDK 0.8.1

### DIFF
--- a/.agents/skills/project-snmp-trap-profiles-authoring/decisions/0001-go-process-and-trapwriter.md
+++ b/.agents/skills/project-snmp-trap-profiles-authoring/decisions/0001-go-process-and-trapwriter.md
@@ -1,7 +1,7 @@
 # ADR-0001: Go Process Model, Journal Writer Backend, and Output Writer Contract
 
-**Status**: Accepted for SOW-0035 implementation after reviewer round 5; amended through 2026-08-02 to use the
-published Go journal SDK `go/v0.8.0`, route the journal hot path through one reusable raw-payload serializer, place direct
+**Status**: Accepted for SOW-0035 implementation after reviewer round 5; amended through 2026-08-12 to use the
+published Go journal SDK `go/v0.8.1`, route the journal hot path through one reusable raw-payload serializer, place direct
 journals under `${NETDATA_LOG_DIR}/traps/`, classify startup environment failures as retryable HTTP-503 coded errors,
 remove profile hot reload, and give output components explicit internal package and lifecycle ownership.
 **Date**: 2026-05-25
@@ -40,7 +40,7 @@ The implementation language is **Go** (user decision, 2026-05-25). The journal w
 - Registered through the standard `collectorapi.Register(...)` path in the existing `collector/init.go` import registry as `snmp_traps`, mirroring the existing `snmp_topology` naming style. A scan found no existing go.d collector registration name containing a dot, so the module name must not use `snmp.traps`.
 - Uses V2 collector interface (`collectorapi.CollectorV2`), mirroring the `ping/` collector pattern
 - Job lifecycle managed by the existing go.d framework (`src/go/plugin/agent/jobmgr/dyncfg_collector_callbacks.go`)
-- Journal writing via a thin adapter around `github.com/netdata/systemd-journal-sdk/go/journal` `go/v0.8.0`, keeping the internal `output.Writer` abstraction and delegating journal file format, active-file indexing, rotation, retention, and writer locking to the SDK.
+- Journal writing via a thin adapter around `github.com/netdata/systemd-journal-sdk/go/journal` `go/v0.8.1`, keeping the internal `output.Writer` abstraction and delegating journal file format, active-file indexing, rotation, retention, and writer locking to the SDK.
 - Shared profile catalog: an in-process manager owned by the plugin registration, loaded on first runnable job creation
 
 ### Option B: Separate Go process (external plugin) via PLUGINSD
@@ -153,7 +153,7 @@ resources, rollback, cleanup, synchronous packet handling, and metric collection
 
 `internal/output/journal` owns the journal backend. It does **not** implement the systemd journal binary format locally;
 it delegates format, active-file indexing, writer locks, rotation, retention, and chain validation/reopen behavior to
-`github.com/netdata/systemd-journal-sdk/go/journal` `go/v0.8.0`.
+`github.com/netdata/systemd-journal-sdk/go/journal` `go/v0.8.1`.
 
 The backend has an explicit two-phase lifecycle:
 
@@ -432,7 +432,7 @@ On `Update()`, current jobmgr behavior stops the old running job before creating
 | Shared profile catalog lease leak leaves an epoch allocated | Every collector stores and closes its exact lease in `Cleanup()` and on partial initialization failure; test idempotent close, final release, retry, and concurrent acquisition |
 | Framework coded-error change breaks other collectors | Preserve existing behavior for plain errors; only `CodedError` suppresses retry and controls HTTP code; add Start and Update tests |
 | Direct journal writer cannot sustain target trap volume | Run `go test -benchmem` / throughput benchmarks for queue enqueue and the SDK-backed raw serializer/drain path; if allocation or throughput misses the tens-of-thousands/sec target, reopen batching or backend design |
-| SDK dependency API drifts | Pin to `github.com/netdata/systemd-journal-sdk/go v0.8.0`; review API changes before updating |
+| SDK dependency API drifts | Pin to `github.com/netdata/systemd-journal-sdk/go v0.8.1`; review API changes before updating |
 | SDK chain handling has an upstream defect | Keep `internal/output.Writer` and the internal journal adapter boundary narrow so the SDK can be updated or replaced without changing ingestion semantics |
 
 ## Validation Requirements

--- a/.agents/skills/project-snmp-trap-profiles-authoring/netdata.md
+++ b/.agents/skills/project-snmp-trap-profiles-authoring/netdata.md
@@ -147,7 +147,7 @@ The implementation language is **Go** (user decision recorded on 2026-05-25). Th
 **Process model** (accepted by SOW-0035 M1 ADR-0001): The trap plugin is a **standard in-process go.d collector V2 module** at `src/go/plugin/go.d/collector/snmp_traps/`, registered as `snmp_traps`. No separate process, no CGo, no subprocess bridge.
 
 **Journal writer backend**: The trap collector uses the Go systemd journal SDK module
-`github.com/netdata/systemd-journal-sdk/go/journal` at `go/v0.8.0` behind `internal/output.Writer`.
+`github.com/netdata/systemd-journal-sdk/go/journal` at `go/v0.8.1` behind `internal/output.Writer`.
 `internal/output/journal.Prepare()` constructs `journal.NewLog()` with `LogOpenEager` and `LogIdentityStrict`, so journal
 directory creation/open, active file creation, writer lock acquisition, machine ID parsing, boot ID parsing, rotation
 policy validation, and retention policy validation are proven during job creation. `Writer.Start()` launches the queue
@@ -1255,7 +1255,7 @@ trap-derived state gauges; see `trap-metrics-profiles.md` and
 
 Phase B resolved most of the original questions. What remains:
 
-1. **Go process / writer backend** — **ACCEPTED (SOW-0035 M1, ADR-0001; amended through 2026-08-02 for SDK `go/v0.8.0`, Netdata log directory placement, raw-payload serialization, and internal output ownership)**: Standard in-process go.d collector V2 module with a thin SDK-backed Go journal adapter over `github.com/netdata/systemd-journal-sdk/go/journal` `go/v0.8.0`. No separate process, no CGo, no subprocess bridge. See `.agents/skills/project-snmp-trap-profiles-authoring/decisions/0001-go-process-and-trapwriter.md`.
+1. **Go process / writer backend** — **ACCEPTED (SOW-0035 M1, ADR-0001; amended through 2026-08-12 for SDK `go/v0.8.1`, Netdata log directory placement, raw-payload serialization, and internal output ownership)**: Standard in-process go.d collector V2 module with a thin SDK-backed Go journal adapter over `github.com/netdata/systemd-journal-sdk/go/journal` `go/v0.8.1`. No separate process, no CGo, no subprocess bridge. See `.agents/skills/project-snmp-trap-profiles-authoring/decisions/0001-go-process-and-trapwriter.md`.
 
 2. **Profile YAML lifecycle — ACCEPTED (superseded 2026-08-02)**: operators add or edit YAML files under
    `/etc/netdata/go.d/snmp.trap-profiles/`. Profiles are immutable while the plugin-scoped catalog epoch has active job

--- a/src/crates/Cargo.lock
+++ b/src/crates/Cargo.lock
@@ -5180,9 +5180,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-common"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73097a1c6eac42f7d2f8ffd9f41fbac57718aea12710d279fb2dde54bdcb1157"
+checksum = "eae01bfd87b9312f7dc269a03db30fa31f3050eb5bd91ad10bea9b74ab736bb9"
 dependencies = [
  "libc",
  "rustc-hash",
@@ -5192,9 +5192,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a218b12759f7c7ecf6f0718ecd5b6d38f2a572e0d5cc25d8861a80b326b4326"
+checksum = "70bcbb634e8b55221897c5c99c8b5c511cd6d1d46baf0ae26bcb24884fe1e708"
 dependencies = [
  "hmac",
  "libc",
@@ -5221,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-engine"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3709bdd9417fcddfc3c74cc50037f8b49c466831b9e067e608cb22532d625d"
+checksum = "e4045855c6a1636a352010407b8fcde9f1e79ba9db551086a4e8c469e8204ca4"
 dependencies = [
  "chrono",
  "foyer 0.22.3",
@@ -5245,9 +5245,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-host"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf514c270a353d2097183348da2d7f7db1d47d8cdcf89c7ab834ab496264a837"
+checksum = "c8190f17fcd4a8f5c17ab77a1b57ffbad6845cd8ca195ec050eb60f1b7441e5f"
 dependencies = [
  "libc",
  "systemd-journal-sdk-common",
@@ -5257,9 +5257,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-index"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9edaf208db3d8be80c7032bbea36b7836f5bbf4245521eea8923f3c5f48a97a"
+checksum = "2a36c9e8204f313c3cf476bc0a7de5016e2931ca3c782083718dced24ac27be2"
 dependencies = [
  "regex",
  "roaring 0.11.4",
@@ -5274,9 +5274,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-log-writer"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575450016c7b3ebf8c6924b08a3f075bff2ad74395e4498ce10fc3eba4aae723"
+checksum = "f0019adeddd0ab3d42a1aae8eaf504a98de9d76ebdd70fbf79c1cc362a6fabaa"
 dependencies = [
  "itoa",
  "systemd-journal-sdk-common",
@@ -5289,9 +5289,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-journal-sdk-registry"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad6eabcb1a587947f02dab0903b1d897c8c28162ff5632fb15de750d512648f"
+checksum = "d1e524902d5c71f658e473c27da204fc38198b4619b4ad85caed440c0177e965"
 dependencies = [
  "notify",
  "parking_lot",

--- a/src/crates/Cargo.toml
+++ b/src/crates/Cargo.toml
@@ -175,13 +175,13 @@ base64 = "0.22"
 # Published systemd-journal-sdk crates (netflow-plugin). Keys use the
 # journal-sdk-* prefix because the plain journal-* names are taken by the
 # internal path crates elsewhere in this file; in-code idents are journal_sdk_*.
-journal-sdk-common = { package = "systemd-journal-sdk-common", version = "0.8.0" }
-journal-sdk-core = { package = "systemd-journal-sdk-core", version = "0.8.0" }
-journal-sdk-engine = { package = "systemd-journal-sdk-engine", version = "0.8.0" }
-journal-sdk-host = { package = "systemd-journal-sdk-host", version = "0.8.0" }
-journal-sdk-index = { package = "systemd-journal-sdk-index", version = "0.8.0" }
-journal-sdk-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.8.0" }
-journal-sdk-registry = { package = "systemd-journal-sdk-registry", version = "0.8.0" }
+journal-sdk-common = { package = "systemd-journal-sdk-common", version = "0.8.1" }
+journal-sdk-core = { package = "systemd-journal-sdk-core", version = "0.8.1" }
+journal-sdk-engine = { package = "systemd-journal-sdk-engine", version = "0.8.1" }
+journal-sdk-host = { package = "systemd-journal-sdk-host", version = "0.8.1" }
+journal-sdk-index = { package = "systemd-journal-sdk-index", version = "0.8.1" }
+journal-sdk-log-writer = { package = "systemd-journal-sdk-log-writer", version = "0.8.1" }
+journal-sdk-registry = { package = "systemd-journal-sdk-registry", version = "0.8.1" }
 
 # NetFlow-specific dependencies
 jaq-core = "3.0.0"

--- a/src/crates/journal-function/src/netdata/columns.rs
+++ b/src/crates/journal-function/src/netdata/columns.rs
@@ -121,7 +121,7 @@ impl ColumnSchema {
             sortable: false,
             sticky: false,
             summary: "count".to_string(),
-            filter: FilterType::Range,
+            filter: FilterType::None,
             full_width: false,
             wrap: true,
             default_expanded_filter: false,
@@ -217,7 +217,7 @@ impl ColumnSchema {
 /// Generate the complete column schema map for the logs table UI.
 ///
 /// This function creates the full schema including:
-/// 1. Special "timestamp" column (index 0) - with range filter
+/// 1. Special "timestamp" column (index 0) - with no filter
 /// 2. Special "rowOptions" column (index 1) - UI-only, no filter
 /// 3. All discovered fields from the histogram (index 2+) - with facet or no filter
 ///
@@ -292,4 +292,28 @@ pub fn columns_to_sorted_json(columns: &StdHashMap<String, ColumnSchema>) -> Val
     }
 
     Value::Object(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialized_columns_do_not_offer_timestamp_range_filter() {
+        let schema = generate_column_schema(&["PRIORITY".to_string()]);
+        let columns = columns_to_sorted_json(&schema);
+        let columns = columns.as_object().expect("columns should be an object");
+        let timestamp = columns
+            .get("timestamp")
+            .expect("timestamp column should be present");
+
+        assert_eq!(timestamp["filter"], "none");
+        for (key, column) in columns {
+            assert_ne!(
+                column.get("filter").and_then(Value::as_str),
+                Some("range"),
+                "column {key}"
+            );
+        }
+    }
 }

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/microsoft/go-mssqldb v1.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
-	github.com/netdata/systemd-journal-sdk/go v0.8.0
+	github.com/netdata/systemd-journal-sdk/go v0.8.1
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	go.mongodb.org/mongo-driver/v2 v2.8.0

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -355,8 +355,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netdata/systemd-journal-sdk/go v0.8.0 h1:6S2NeRFw9XGoGWWcd4u+9Y2xHvnESrQME0xCx+z8bX8=
-github.com/netdata/systemd-journal-sdk/go v0.8.0/go.mod h1:9Ja2zbfDOVEYzFSw060+KmHvfq7iHj7eOW3DgXIrMlE=
+github.com/netdata/systemd-journal-sdk/go v0.8.1 h1:Z35Y7Nasx9VJYrApzZ8WixoATmZ7H9ntxIOqyk5+oGg=
+github.com/netdata/systemd-journal-sdk/go v0.8.1/go.mod h1:9Ja2zbfDOVEYzFSw060+KmHvfq7iHj7eOW3DgXIrMlE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=

--- a/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
@@ -124,6 +124,8 @@ func TestSNMPTrapsLogsFunctionInfoAndQuery(t *testing.T) {
 	assert.Equal(t, 200, defaults.RawResponse["status"])
 	assertResponseFacetIDs(t, defaults.RawResponse, snmptrapsfunc.DefaultLogFacets())
 	assertResponseColumnVisible(t, defaults.RawResponse, "TRAP_NAME")
+	assertResponseColumnFilter(t, defaults.RawResponse, "timestamp", "none")
+	assertNoResponseColumnFilter(t, defaults.RawResponse, "range")
 
 	query := handler.HandleRaw(context.Background(), funcapiRawRequest("logs", false, []byte(`{
   "last": 10,
@@ -391,11 +393,39 @@ func assertResponseFacetIDs(t *testing.T, response map[string]any, want []string
 
 func assertResponseColumnVisible(t *testing.T, response map[string]any, key string) {
 	t.Helper()
-	columns, ok := response["columns"].(map[string]any)
-	require.True(t, ok, "response columns type = %T", response["columns"])
+	column := requireResponseColumn(t, response, key)
+	assert.Equal(t, true, column["visible"])
+}
+
+func assertResponseColumnFilter(t *testing.T, response map[string]any, key, want string) {
+	t.Helper()
+	column := requireResponseColumn(t, response, key)
+	assert.Equal(t, want, column["filter"])
+}
+
+func assertNoResponseColumnFilter(t *testing.T, response map[string]any, forbidden string) {
+	t.Helper()
+	columns := requireResponseColumns(t, response)
+	for key, columnAny := range columns {
+		column, ok := columnAny.(map[string]any)
+		require.True(t, ok, "column %s type = %T", key, columnAny)
+		assert.NotEqual(t, forbidden, column["filter"], "column %s", key)
+	}
+}
+
+func requireResponseColumn(t *testing.T, response map[string]any, key string) map[string]any {
+	t.Helper()
+	columns := requireResponseColumns(t, response)
 	column, ok := columns[key].(map[string]any)
 	require.True(t, ok, "missing column %s in %#v", key, columns)
-	assert.Equal(t, true, column["visible"])
+	return column
+}
+
+func requireResponseColumns(t *testing.T, response map[string]any) map[string]any {
+	t.Helper()
+	columns, ok := response["columns"].(map[string]any)
+	require.True(t, ok, "response columns type = %T", response["columns"])
+	return columns
 }
 
 func assertLogsSourceSelectorMetadata(t *testing.T, response map[string]any) {


### PR DESCRIPTION
##### Summary

Follow-up to #23456.

- Bump `github.com/netdata/systemd-journal-sdk/go` from `v0.8.0` to `v0.8.1`.
- Bump the seven systemd Journal SDK crates consumed by NetFlow from `0.8.0` to `0.8.1`.
- Stop advertising a range filter for the synthetic timestamp column in the repository-local Rust journal Function used by legacy OTEL logs.
- Add consumer-level regressions for the SDK-backed SNMP trap logs response and the Rust serialized column schema.

The C facets producer was corrected in #23456, but SDK-backed SNMP trap logs still received `filter: "range"` from Go SDK v0.8.0. The repository-local Rust journal Function independently emitted the same metadata. These synthetic timestamps are controlled through history bounds and anchor pagination and are not accepted filter parameters, so both producers must advertise `filter: "none"`.

##### Test Plan

- `go mod verify` with Go 1.26.2.
- `go vet ./plugin/go.d/collector/snmp_traps/...`.
- `go test -count=1 ./plugin/go.d/collector/snmp_traps/...`.
- `cargo +1.91.0 test --locked -p netflow-plugin` (740 passed; 39 manual/stress tests ignored).
- `cargo +1.91.0 check --locked -p netflow-plugin`.
- `cargo +1.91.0 test --locked -p journal-function -p otel-legacy-logs -p otel-plugin` (100 runnable tests passed; two doc tests ignored).
- `cargo +1.91.0 check --locked -p journal-function -p otel-legacy-logs -p otel-plugin`.
- Scoped `gofmt`, Rust 1.91 `rustfmt --check`, and `git diff --check`.

##### Additional Information

The Go 1.26.2 and Rust 1.91 compiler floors are unchanged. This changes no public API, journal storage format, configuration, or migration behavior; timestamp history and anchor pagination remain intact.

<details>
<summary>For users: How does this change affect me?</summary>

SNMP trap logs and legacy OTEL logs no longer show an unusable range filter on the Timestamp column. Time navigation continues to work through the existing history controls and timestamp pagination.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns log timestamp filter metadata with `systemd-journal-sdk` 0.8.1 and removes an unusable range filter. Previously the timestamp column advertised filter "range"; now it advertises "none" for SDK-backed SNMP trap logs and the Rust journal Function used by legacy OTEL logs, since time is controlled by history bounds and anchor pagination.

**Review notes**
- Dependencies: bump `github.com/netdata/systemd-journal-sdk/go` to v0.8.1 and the seven `systemd-journal-sdk-*` crates to 0.8.1.
- Go (SNMP traps): logs response now emits `filter: "none"` for `timestamp`; added assertions that no column reports `filter: "range"`.
- Rust (journal Function): `timestamp` column schema switched from `Range` to `None`; added a test ensuring no serialized column advertises `range`.
- Docs: ADR and Netdata implementation notes updated to reference 0.8.1.
- No public API, storage format, configuration, or compiler-floor changes; no migration required.

<sup>Written for commit 7e225c410e3b123049b4fd58f3842ef62ddcb30a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timestamp filtering so it is no longer treated as a range filter.
  * Improved consistency of column filter behavior in log responses.

* **Maintenance**
  * Updated the journal SDK to version 0.8.1 across supported components.

* **Tests**
  * Added regression coverage to verify timestamp filters and prevent unexpected range filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->