### PR TITLE
Harden release CI and installer against transient third-party failures

### DIFF
--- a/.github/scripts/deb-sign.sh
+++ b/.github/scripts/deb-sign.sh
@@ -6,8 +6,10 @@ pkgdir="${1}"
 keyid="${2}"
 
 echo "::group::Installing Dependencies"
+# Only install what signing needs. A full `apt-get upgrade` pulls in unrelated
+# runner packages, including the firefox snap transition stub, which makes
+# signing depend on the Snap Store being reachable.
 sudo apt-get update
-sudo apt-get upgrade -y
 sudo apt-get install -y debsigs
 echo "::endgroup::"
 

--- a/.github/workflows/update-mcp-registry.yml
+++ b/.github/workflows/update-mcp-registry.yml
@@ -53,11 +53,15 @@ jobs:
         run: |
           mcp-publisher login github-oidc
 
-      - name: Validate server.json (dry run)
+      - name: Validate server.json
         id: validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mcp-publisher publish server.json --dry-run
+        # `publish --dry-run` is not a dry run: mcp-publisher has no such flag,
+        # ignores it, and publishes for real, so the next step always failed with
+        # "cannot publish duplicate version". `validate` is the actual no-publish
+        # check.
+        run: mcp-publisher validate server.json
 
       - name: Publish to registry
         id: publish

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -135,9 +135,12 @@ main() {
       ;;
     prepare-offline)
       prepare_offline_install_source "${OFFLINE_TARGET}"
+      offline_status="$?"
       deferred_warnings
       trap - EXIT
-      exit 0
+      # Report the real result: automation must not be told an offline source
+      # was prepared when it was not.
+      exit "${offline_status}"
       ;;
   esac
 
@@ -753,7 +756,10 @@ handle_wget_result() {
   case "${ret}" in
     0) return 0 ;;
     8)
-      status="$(grep "HTTP/" "${dl_log}" | tail -n 1 | awk '{ print $2 }')"
+      # Anchor on the status line: a `Server:` header can also contain "HTTP/"
+      # (for example "Server: BaseHTTP/0.6"), and an unanchored match picks that
+      # up instead, yielding a nonsense status.
+      status="$(grep -E '^[[:space:]]*HTTP/' "${dl_log}" | tail -n 1 | awk '{ print $2 }')"
       [ -n "${dest}" ] && rm -f "${dest}"
       handle_http_status "${status}" "${url}" "${action}"
       return "$?"
@@ -872,44 +878,92 @@ get_redirect() {
   cd "${old_pwd}" || fatal "Failed to change current working directory to ${old_pwd}." F000A
   output="${tmpdir}/download.log"
   rm -f "${output}"
+  redirect=''
+
+  # Note: a mirror may legitimately serve a real `latest/` directory, in which
+  # case there is no redirect and `latest` itself is the correct answer. Our own
+  # artifact verification jobs are built that way. Only an HTTP error or an
+  # empty result means resolution failed.
 
   if [ -n "${CURL}" ]; then
-    run sh -c '"${1}" "${2}" -s -L -I -o /dev/null -w "%{url_effective}" > "${3}"' _ "${CURL}" "${url}" "${output}"
+    # Invoked directly rather than through run(), matching check_for_remote_file:
+    # this is a read-only query whose answer the caller needs, so it must still
+    # happen during a dry run.
+    #
+    # --fail is required for correctness, not tidiness: an HTTP error is not a
+    # redirect, so without it curl exits 0 with url_effective still set to the
+    # requested URL and the caller silently builds a download URL from it.
+    # --retry covers the transient cases (5xx, 408, 429, timeouts). The status
+    # code is written last so handle_curl_result's `tail -n 1` reads a status
+    # rather than a URL.
+    "${CURL}" --fail -q -sSL --connect-timeout 10 --retry 3 -I --output /dev/null --write-out "%{url_effective}\n%{http_code}" "${url}" > "${output}"
 
     ret="$?"
 
-    case "${ret}" in
-      0)
-        grep -Eo '[^/]+/?$' "${output}" | grep -Eo '^[^/]+'
-        rm -f "${output}"
-        return 0
-        ;;
-      *)
-        handle_curl_result "${ret}" "${url}" "${output}" "checking redirects for"
-        return "$?"
-        ;;
-    esac
+    if [ "${ret}" -ne 0 ]; then
+      handle_curl_result "${ret}" "${url}" "${output}" "checking redirects for"
+      ret="$?"
+      rm -f "${output}"
+      # Never report success: callers must be able to tell resolution failed.
+      [ "${ret}" -eq 0 ] && ret=1
+      return "${ret}"
+    fi
+
+    redirect="$(head -n 1 "${output}" | grep -Eo '[^/]+/?$' | grep -Eo '^[^/]+')"
+    rm -f "${output}"
+  elif [ -n "${WGET}" ]; then
+    # Retry in the shell rather than with wget options, because implementations
+    # differ: GNU wget treats a 5xx as fatal unless given --retry-on-http-error,
+    # and BusyBox wget has no HTTP-level retry at all. This keeps parity with
+    # curl's --retry on every wget we may be handed. The status set matches the
+    # one curl retries.
+    wget_attempt=1
+    while :; do
+      "${WGET}" -S -T 15 -o "${output}" -O /dev/null "${url}"
+      ret="$?"
+
+      [ "${ret}" -eq 0 ] && break
+      [ "${wget_attempt}" -ge 3 ] && break
+
+      # An empty status means no response at all (connection or DNS failure),
+      # which is also worth another attempt.
+      wget_status="$(grep -E '^[[:space:]]*HTTP/' "${output}" 2>/dev/null | tail -n 1 | awk '{ print $2 }')"
+      case "${wget_status}" in
+        408|429|500|502|503|504|'') ;;
+        *) break ;;
+      esac
+
+      wget_attempt=$((wget_attempt + 1))
+      sleep 1
+    done
+
+    if [ "${ret}" -ne 0 ]; then
+      handle_wget_result "${ret}" "${url}" "${output}" "checking redirects for"
+      ret="$?"
+      rm -f "${output}"
+      [ "${ret}" -eq 0 ] && ret=1
+      return "${ret}"
+    fi
+
+    # With no Location header the request was served directly; fall back to the
+    # requested URL's own final segment, which is what curl reports via
+    # url_effective in the same situation.
+    redirect="$(grep -m 1 Location "${output}" | grep -Eo '[^/]+/?$' | grep -Eo '[^/]+$')"
+    if [ -z "${redirect}" ]; then
+      redirect="$(echo "${url}" | grep -Eo '[^/]+/?$' | grep -Eo '^[^/]+')"
+    fi
+    rm -f "${output}"
+  else
+    fatal "${ERROR_F0003}" F0003
   fi
 
-  if [ -n "${WGET}" ]; then
-    run "${WGET}" -S -o "${output}" -O /dev/null "${url}"
-
-    ret="$?"
-
-    case "${ret}" in
-      0)
-        grep -m 1 Location "${output}" | grep -Eo '[^/]+/?$' | grep -Eo '[^/]+$'
-        rm -f "${output}"
-        return 0
-        ;;
-      *)
-        handle_wget_result "${ret}" "${url}" "${output}" "checking redirects for"
-        return "$?"
-        ;;
-    esac
+  if [ -z "${redirect}" ]; then
+    warning "Could not determine which release ${url} points to."
+    return 1
   fi
 
-  fatal "${ERROR_F0003}" F0003
+  printf '%s\n' "${redirect}"
+  return 0
 }
 
 safe_sha256sum() {
@@ -2059,7 +2113,7 @@ set_static_archive_urls() {
       export NETDATA_STATIC_ARCHIVE_OLD_NAME="netdata-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
-      latest="$(get_redirect "https://github.com/netdata/netdata/releases/latest")"
+      latest="$(get_redirect "https://github.com/netdata/netdata/releases/latest")" || return 1
       export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/${latest}/netdata-${arch}-latest.gz.run"
       export NETDATA_STATIC_ARCHIVE_NAME="netdata-${arch}-latest.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/${latest}/sha256sums.txt"
@@ -2072,7 +2126,7 @@ set_static_archive_urls() {
       export NETDATA_STATIC_ARCHIVE_OLD_NAME="netdata-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
-      tag="$(get_redirect "${NETDATA_TARBALL_BASEURL}/latest")"
+      tag="$(get_redirect "${NETDATA_TARBALL_BASEURL}/latest")" || return 1
       export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/netdata-${arch}-latest.gz.run"
       export NETDATA_STATIC_ARCHIVE_NAME="netdata-${arch}-latest.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/sha256sums.txt"
@@ -2081,7 +2135,10 @@ set_static_archive_urls() {
 }
 
 try_static_install() {
-  set_static_archive_urls "${SELECTED_RELEASE_CHANNEL}"
+  if ! set_static_archive_urls "${SELECTED_RELEASE_CHANNEL}"; then
+    warning "Unable to determine which static build to download. ${GITHUB_BADNET_MSG}"
+    return 1
+  fi
   if [ "${DRY_RUN}" -eq 1 ]; then
     progress "Would attempt to install using static build..."
   else
@@ -2173,7 +2230,7 @@ set_source_archive_urls() {
       export NETDATA_SOURCE_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-v${INSTALL_VERSION}.tar.gz"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
-      latest="$(get_redirect "https://github.com/netdata/netdata/releases/latest")"
+      latest="$(get_redirect "https://github.com/netdata/netdata/releases/latest")" || return 1
       export NETDATA_SOURCE_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/${latest}/netdata-${latest}.tar.gz"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/${latest}/sha256sums.txt"
     fi
@@ -2182,7 +2239,7 @@ set_source_archive_urls() {
       export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/netdata-latest.tar.gz"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
-      tag="$(get_redirect "${NETDATA_TARBALL_BASEURL}/latest")"
+      tag="$(get_redirect "${NETDATA_TARBALL_BASEURL}/latest")" || return 1
       export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/netdata-latest.tar.gz"
       export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/sha256sums.txt"
     fi
@@ -2273,7 +2330,9 @@ try_build_install() {
     return 1
   fi
 
-  set_source_archive_urls "${SELECTED_RELEASE_CHANNEL}"
+  if ! set_source_archive_urls "${SELECTED_RELEASE_CHANNEL}"; then
+    fatal "Failed to determine which source tarball to download. ${BADNET_MSG}." F000B
+  fi
 
   if [ -n "${INSTALL_VERSION}" ]; then
     if ! download "${NETDATA_SOURCE_ARCHIVE_URL}" "./netdata-v${INSTALL_VERSION}.tar.gz"; then
@@ -2341,7 +2400,10 @@ prepare_offline_install_source() {
 
   case "${NETDATA_REQUESTED_INSTALL_TYPE}" in
     static|auto|any)
-      set_static_archive_urls "${SELECTED_RELEASE_CHANNEL}" "x86_64"
+      if ! set_static_archive_urls "${SELECTED_RELEASE_CHANNEL}" "x86_64"; then
+        warning "Unable to determine which static build to fetch. ${GITHUB_BADNET_MSG}"
+        return 1
+      fi
 
       check_for_remote_file "${NETDATA_TARBALL_BASEURL}"
 
@@ -2355,8 +2417,16 @@ prepare_offline_install_source() {
       esac
 
       if check_for_remote_file "${NETDATA_STATIC_ARCHIVE_URL}"; then
+        # A single architecture failing is tolerated, matching how a failed
+        # download below is handled, but every architecture failing means no
+        # offline source was produced at all and must not report success.
+        resolved_any=0
         for arch in $(echo "${NETDATA_OFFLINE_ARCHES:-${STATIC_INSTALL_ARCHES}}" | awk '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}{printf("\n")}'); do
-          set_static_archive_urls "${SELECTED_RELEASE_CHANNEL}" "${arch}"
+          if ! set_static_archive_urls "${SELECTED_RELEASE_CHANNEL}" "${arch}"; then
+            warning "Unable to determine which static build to fetch for ${arch}. ${GITHUB_BADNET_MSG}"
+            continue
+          fi
+          resolved_any=1
 
           if check_for_remote_file "${NETDATA_STATIC_ARCHIVE_URL}"; then
             progress "Fetching ${NETDATA_STATIC_ARCHIVE_URL}"
@@ -2367,6 +2437,12 @@ prepare_offline_install_source() {
             progress "Skipping ${NETDATA_STATIC_ARCHIVE_URL} as it does not exist on the server."
           fi
         done
+
+        if [ "${resolved_any}" -eq 0 ]; then
+          warning "Could not determine which static builds to fetch for any architecture. ${GITHUB_BADNET_MSG}"
+          return 1
+        fi
+
         legacy=0
       else
         warning "Selected version of Netdata only provides static builds for x86_64. You will only be able to install on x86_64 systems with this offline install source."

--- a/packaging/tests/kickstart-redirect/README.md
+++ b/packaging/tests/kickstart-redirect/README.md
@@ -1,0 +1,96 @@
+# kickstart release-tag resolution tests
+
+Regression tests for the way `packaging/installer/kickstart.sh` answers the
+question *"which release does `/latest` point at?"*.
+
+## What is being guarded
+
+`get_redirect()` resolves a `.../releases/latest` URL by following the redirect
+and taking the final path segment of the resulting URL. That segment is then
+used to build download URLs.
+
+If the server answers with an HTTP error instead of a redirect, there is no
+redirect to follow — and the resolved value must not silently become the literal
+string `latest`. When it does, callers build URLs such as:
+
+```
+https://github.com/netdata/netdata-nightlies/releases/download/latest/netdata-latest.tar.gz
+```
+
+which is a 404. The user then sees a download failure whose message points at
+the wrong thing, several steps away from the real cause (a transient server
+error during tag resolution).
+
+This actually happened: a transient HTTP 503 from GitHub during the v2.11.0
+release turned into a `404 File not found` in the installer.
+
+## Why the tests drive caller flows, not just `get_redirect`
+
+The original defect was not only that `get_redirect()` returned a bad value — it
+was that **no caller checked its return status**. All four call sites are of the
+form:
+
+```sh
+tag="$(get_redirect "...")"
+export NETDATA_SOURCE_ARCHIVE_URL=".../${tag}/..."
+```
+
+The assignment's exit status is discarded, and the following `export` resets
+`$?`. So a fix that only makes `get_redirect()` return non-zero changes nothing
+observable. The tests therefore also exercise `set_source_archive_urls()` and
+`set_static_archive_urls()` and assert both that failure propagates and that no
+`/download/latest/` URL is ever constructed.
+
+## What is *not* a failure
+
+A mirror may legitimately serve a real `latest/` directory, with no redirect
+involved. Netdata's own artifact-verification jobs in
+`.github/workflows/build.yml` are built exactly that way: they create a
+`latest/` directory, serve it over HTTP, and point `NETDATA_TARBALL_BASEURL` at
+it.
+
+In that layout `latest` **is** the correct answer, so resolution returning
+`latest` must not be treated as an error. Only an HTTP error or an empty result
+means resolution failed. There is a test for this, because an earlier version of
+the fix got it wrong and would have broken those jobs.
+
+## Cases covered
+
+| Case | Expectation |
+|---|---|
+| Healthy redirect | resolves to the release tag |
+| Persistent 503 | fails; never yields a bogus tag |
+| 200 with no redirect (direct mirror) | succeeds, resolving to `latest` |
+| 503, 503, then redirect | succeeds — `curl --retry` absorbs the transient failure |
+| `--dry-run` | still resolves; the query is read-only and must not be skipped |
+| Caller flow on 503 | failure propagates; no `/download/latest/` URL built |
+| Caller flow when healthy | URL built exactly as before |
+| wget fallback | same behaviour as curl for all three outcomes |
+
+## Running
+
+```sh
+sh packaging/tests/kickstart-redirect/test-redirect-resolution.sh
+```
+
+Optionally pass a path to the kickstart script to test a different copy:
+
+```sh
+sh packaging/tests/kickstart-redirect/test-redirect-resolution.sh /path/to/kickstart.sh
+```
+
+Requires `python3` (used for a local fault-injection HTTP server, bound to
+`127.0.0.1` on an ephemeral port) and `curl`. No network access is needed and
+nothing is installed.
+
+Exit status is `0` when every case passes, `1` otherwise.
+
+## How the harness loads the functions
+
+`kickstart.sh` is a single program: its function definitions sit above a
+`# Main program` marker, and below that the installer runs. The harness slices
+the file at that marker and sources only the definitions, so the real shipped
+code is exercised without running an install.
+
+If that marker is ever removed or renamed, the harness fails loudly with a clear
+message rather than silently testing nothing.

--- a/packaging/tests/kickstart-redirect/test-redirect-resolution.sh
+++ b/packaging/tests/kickstart-redirect/test-redirect-resolution.sh
@@ -1,0 +1,278 @@
+#!/bin/sh
+# Regression tests for kickstart.sh release-tag resolution.
+#
+# get_redirect() resolves "which release does /latest point at?" by following a
+# redirect and taking the final path segment. If the server answers with an HTTP
+# error instead of a redirect, the resolved value must NOT silently become the
+# literal "latest" — callers build download URLs from it, and ".../download/
+# latest/netdata-latest.tar.gz" is a 404 that surfaces far from its cause.
+#
+# These tests drive complete caller flows (set_source_archive_urls and
+# set_static_archive_urls), not get_redirect() alone, because the failure this
+# guards against was a return value that no caller checked.
+#
+# Usage: test-redirect-resolution.sh [path-to-kickstart.sh]
+#
+# Requires: python3 (fault-injection HTTP server), curl.
+# Exit status: 0 if every case passes, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${0}")" && pwd)"
+KICKSTART="${1:-${SCRIPT_DIR}/../../installer/kickstart.sh}"
+
+[ -r "${KICKSTART}" ] || {
+    echo "ERROR: cannot read kickstart script at ${KICKSTART}" >&2
+    exit 2
+}
+command -v python3 >/dev/null 2>&1 || {
+    echo "ERROR: python3 is required for the fault-injection server" >&2
+    exit 2
+}
+command -v curl >/dev/null 2>&1 || {
+    echo "ERROR: curl is required" >&2
+    exit 2
+}
+
+WORK="$(mktemp -d)"
+SERVER_PID=''
+
+# Namespaced: kickstart.sh defines its own cleanup(), and sourcing it below
+# would otherwise silently replace this one.
+test_cleanup() {
+    [ -n "${SERVER_PID}" ] && kill "${SERVER_PID}" 2>/dev/null
+    cd / || :
+    rm -rf "${WORK}"
+    # kickstart's own scratch directory, created by set_tmpdir below.
+    case "${tmpdir:-}" in
+        */netdata-kickstart-*) rm -rf "${tmpdir}" ;;
+    esac
+}
+trap test_cleanup EXIT HUP INT QUIT TERM
+
+# ---------------------------------------------------------------- fake server
+
+cat > "${WORK}/server.py" <<'PYEOF'
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+# Separate counters: the curl and wget flaky cases must not consume each
+# other's transient failures.
+flaky = {"curl": 0, "wget": 0}
+
+
+class H(BaseHTTPRequestHandler):
+    def route(self):
+        p = self.path
+        if p.startswith("/ok/latest"):
+            self.send_response(302)
+            self.send_header("Location", "/ok/tag/v9.9.9")
+        elif p.startswith("/ok/tag/"):
+            self.send_response(200)
+        elif p.startswith("/fail503/latest"):
+            self.send_response(503)
+        elif p.startswith("/flaky/latest") or p.startswith("/flaky-wget/latest"):
+            key = "wget" if p.startswith("/flaky-wget/") else "curl"
+            flaky[key] += 1
+            if flaky[key] <= 2:
+                self.send_response(503)
+            else:
+                self.send_response(302)
+                self.send_header("Location", "/ok/tag/v9.9.9")
+        elif p.startswith("/noredirect/latest"):
+            self.send_response(200)
+        else:
+            self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    do_GET = route
+    do_HEAD = route
+
+    def log_message(self, *a):
+        pass
+
+
+if __name__ == "__main__":
+    srv = HTTPServer(("127.0.0.1", 0), H)
+    sys.stdout.write("%d\n" % srv.server_address[1])
+    sys.stdout.flush()
+    srv.serve_forever()
+PYEOF
+
+python3 "${WORK}/server.py" > "${WORK}/port" &
+SERVER_PID=$!
+
+# Wait for the server to publish its port rather than sleeping a fixed amount.
+i=0
+while [ ! -s "${WORK}/port" ]; do
+    i=$((i + 1))
+    [ "${i}" -gt 100 ] && { echo "ERROR: fault-injection server did not start" >&2; exit 2; }
+    sleep 0.1
+done
+BASE="http://127.0.0.1:$(cat "${WORK}/port")"
+
+# ------------------------------------------------- load kickstart's functions
+#
+# kickstart.sh is a single program with its function definitions above a
+# "# Main program" marker. Everything above that marker is sourceable; below it
+# the installer actually runs. Slice at the marker so the functions can be
+# exercised directly.
+
+MARKER_LINE="$(grep -n '^# Main program' "${KICKSTART}" | head -n 1 | cut -d: -f1)"
+[ -n "${MARKER_LINE}" ] || {
+    echo "ERROR: could not find the '# Main program' marker in ${KICKSTART}" >&2
+    exit 2
+}
+head -n "$((MARKER_LINE - 3))" "${KICKSTART}" > "${WORK}/functions.sh"
+
+# Globals the main program would normally establish. INSTALL_VERSION and
+# NETDATA_OFFLINE_INSTALL_SOURCE look unused here but are read by the sourced
+# kickstart functions, which branch on whether they are empty.
+# shellcheck disable=SC2034
+DRY_RUN=0
+# shellcheck disable=SC2034
+run_logfile=/dev/null
+# shellcheck disable=SC2034
+INTERACTIVE=0
+CURL="$(command -v curl)"
+# shellcheck disable=SC2034
+WGET=''
+# shellcheck disable=SC2034
+SYSARCH='x86_64'
+# shellcheck disable=SC2034
+INSTALL_VERSION=''
+# shellcheck disable=SC2034
+NETDATA_OFFLINE_INSTALL_SOURCE=''
+export DRY_RUN run_logfile INTERACTIVE CURL WGET SYSARCH
+
+# kickstart.sh is not written to run under `set -u`, and sourcing it installs
+# the installer's crash traps. Relax both for the duration of the load.
+set +eu
+# shellcheck disable=SC1091
+. "${WORK}/functions.sh"
+trap - EXIT HUP INT QUIT PIPE TERM
+trap test_cleanup EXIT HUP INT QUIT TERM
+setup_terminal >/dev/null 2>&1 || true
+
+# Establish the installer tmpdir here, in the parent shell. get_redirect calls
+# set_tmpdir itself, but it runs inside command substitution, so the assignment
+# would not propagate back and every call would leak a new directory.
+set_tmpdir >/dev/null 2>&1
+cd "${WORK}" || exit 2
+
+# ---------------------------------------------------------------------- cases
+
+pass=0
+fail=0
+
+ok()  { pass=$((pass + 1)); printf '  PASS  %s\n' "${1}"; }
+bad() { fail=$((fail + 1)); printf '  FAIL  %s\n' "${1}"; }
+
+expect() { # <desc> <want-rc> <want-stdout> <got-rc> <got-stdout>
+    if [ "${4}" = "${2}" ] && [ "${5}" = "${3}" ]; then
+        ok "${1}"
+    else
+        bad "${1} (want rc=${2} out='${3}'; got rc=${4} out='${5}')"
+    fi
+}
+
+printf '\n== get_redirect ==\n'
+
+out="$(get_redirect "${BASE}/ok/latest" 2>/dev/null)"; rc=$?
+expect "healthy redirect resolves to the release tag" 0 'v9.9.9' "${rc}" "${out}"
+
+out="$(get_redirect "${BASE}/fail503/latest" 2>/dev/null)"; rc=$?
+expect "persistent 503 fails instead of resolving to 'latest'" 6 '' "${rc}" "${out}"
+
+# A mirror may serve a real `latest/` directory with no redirect at all. That is
+# a supported layout - netdata's own artifact-verification jobs are built that
+# way - so `latest` is the correct answer here, not a failure.
+out="$(get_redirect "${BASE}/noredirect/latest" 2>/dev/null)"; rc=$?
+expect "direct 'latest' mirror (no redirect) resolves to 'latest'" 0 'latest' "${rc}" "${out}"
+
+out="$(get_redirect "${BASE}/flaky/latest" 2>/dev/null)"; rc=$?
+expect "transient 503 then redirect succeeds (curl --retry)" 0 'v9.9.9' "${rc}" "${out}"
+
+# Resolution is a read-only query, so it must still happen under --dry-run;
+# otherwise every dry run of a stable/nightly install fails to find a tag.
+DRY_RUN=1
+out="$(get_redirect "${BASE}/ok/latest" 2>/dev/null)"; rc=$?
+expect "resolves normally during a dry run" 0 'v9.9.9' "${rc}" "${out}"
+DRY_RUN=0
+
+printf '\n== caller flow: set_source_archive_urls ==\n'
+
+NETDATA_TARBALL_BASEURL="${BASE}/fail503"
+export NETDATA_TARBALL_BASEURL
+NETDATA_SOURCE_ARCHIVE_URL=''
+set_source_archive_urls 'nightly' >/dev/null 2>&1; rc=$?
+if [ "${rc}" -ne 0 ]; then
+    ok "failure propagates out of set_source_archive_urls"
+else
+    bad "set_source_archive_urls returned 0 despite a 503"
+fi
+case "${NETDATA_SOURCE_ARCHIVE_URL}" in
+    */download/latest/*) bad "built a bogus '/download/latest/' source URL: ${NETDATA_SOURCE_ARCHIVE_URL}" ;;
+    *)                   ok  "no bogus '/download/latest/' source URL was built" ;;
+esac
+
+printf '\n== caller flow: set_static_archive_urls ==\n'
+
+NETDATA_STATIC_ARCHIVE_URL=''
+set_static_archive_urls 'nightly' >/dev/null 2>&1; rc=$?
+if [ "${rc}" -ne 0 ]; then
+    ok "failure propagates out of set_static_archive_urls"
+else
+    bad "set_static_archive_urls returned 0 despite a 503"
+fi
+case "${NETDATA_STATIC_ARCHIVE_URL}" in
+    */download/latest/*) bad "built a bogus '/download/latest/' static URL: ${NETDATA_STATIC_ARCHIVE_URL}" ;;
+    *)                   ok  "no bogus '/download/latest/' static URL was built" ;;
+esac
+
+printf '\n== healthy path is unchanged ==\n'
+
+NETDATA_TARBALL_BASEURL="${BASE}/ok"
+export NETDATA_TARBALL_BASEURL
+NETDATA_SOURCE_ARCHIVE_URL=''
+set_source_archive_urls 'nightly' >/dev/null 2>&1; rc=$?
+if [ "${rc}" -eq 0 ] && [ "${NETDATA_SOURCE_ARCHIVE_URL}" = "${BASE}/ok/download/v9.9.9/netdata-latest.tar.gz" ]; then
+    ok "healthy nightly source URL is built correctly"
+else
+    bad "healthy nightly source URL wrong (rc=${rc} url=${NETDATA_SOURCE_ARCHIVE_URL})"
+fi
+
+printf '\n== wget fallback (used when curl is absent) ==\n'
+
+if command -v wget >/dev/null 2>&1; then
+    saved_curl="${CURL}"
+    CURL=''
+    WGET="$(command -v wget)"
+
+    out="$(get_redirect "${BASE}/ok/latest" 2>/dev/null)"; rc=$?
+    expect "wget: healthy redirect resolves to the release tag" 0 'v9.9.9' "${rc}" "${out}"
+
+    out="$(get_redirect "${BASE}/noredirect/latest" 2>/dev/null)"; rc=$?
+    expect "wget: direct 'latest' mirror resolves to 'latest'" 0 'latest' "${rc}" "${out}"
+
+    out="$(get_redirect "${BASE}/fail503/latest" 2>/dev/null)"; rc=$?
+    if [ "${rc}" -ne 0 ] && [ -z "${out}" ]; then
+        ok "wget: persistent 503 fails instead of resolving to 'latest'"
+    else
+        bad "wget: persistent 503 (want rc!=0 out=''; got rc=${rc} out='${out}')"
+    fi
+
+    # The retry must come from our own loop, not from a wget option: BusyBox
+    # wget has no HTTP-level retry and GNU wget needs --retry-on-http-error.
+    out="$(get_redirect "${BASE}/flaky-wget/latest" 2>/dev/null)"; rc=$?
+    expect "wget: transient 503 then redirect succeeds (shell retry)" 0 'v9.9.9' "${rc}" "${out}"
+
+    CURL="${saved_curl}"
+    WGET=''
+else
+    printf '  SKIP  wget not installed\n'
+fi
+
+printf '\n%d passed, %d failed\n' "${pass}" "${fail}"
+[ "${fail}" -eq 0 ]


### PR DESCRIPTION
## Summary

Three independent fixes for defects that surfaced during the v2.11.0 release. All
are pre-existing; none is a v2.11.0 regression. Each is one commit.

During that release, six package jobs and one build job failed. Every failure
traced to a transient third-party hiccup (GitHub's release-asset CDN, the Snap
Store) being treated as permanent. The artifacts themselves were fine — each one
was verified intact and downloadable on demand while triaging.

## 1. MCP registry workflow published twice, then failed

`mcp-publisher` has no `--dry-run` flag. It ignored the argument and published
for real, so the following step failed with a duplicate-version error.

This has failed on **every release since v2.8.3** — ten consecutive releases —
while each version did in fact reach the registry, published by the "dry run".
A permanently red job plus a Slack alert on every release is how a genuine
registry failure goes unnoticed.

`validate` is the real no-publish check: it posts to `v0/validate` rather than
`v0/publish` and sends no auth header.

## 2. DEB signing depended on the Snap Store

`deb-sign.sh` ran `apt-get upgrade -y` before installing `debsigs`. On GitHub
runners that upgrades ~40 unrelated packages including the `firefox` deb, which
is a snap transition stub — so signing reached out to `api.snapcraft.io`. During
v2.11.0 it returned HTTP 408 twice, dpkg failed, and apt exited 100.

The failure is quiet and expensive: the package **builds and passes its tests**,
then is neither signed nor uploaded. Two distros silently missed the release
until the jobs were re-run.

Installing `debsigs` alone pulls only its own dependencies and touches no snap or
browser package.

## 3. Installer turned a 503 into a confusing 404

`get_redirect()` ran curl without `--fail`. An HTTP error is not a redirect, so
curl exited 0 with `url_effective` still set to the requested URL, and the
function returned that URL's last segment — the literal string `latest`. Callers
then built:

```
.../releases/download/latest/netdata-latest.tar.gz
```

which 404s. A GitHub 503 during v2.11.0 did exactly this, and the user-facing
error pointed at a missing file rather than the transient failure that caused it.

Returning non-zero is not sufficient on its own: all four call sites use
`tag="$(get_redirect ...)"` and never check the status, and the following
`export` resets `$?`. So failure now propagates out of `set_source_archive_urls()`
and `set_static_archive_urls()` into every caller — static install, local build,
and offline install-source preparation, whose exit status previously reported
success regardless of what happened.

Note this affects the **stable** channel too, not just nightly — two of the four
call sites resolve `netdata/netdata/releases/latest`.

### Deliberately *not* treated as a failure

A mirror may legitimately serve a real `latest/` directory with no redirect, in
which case `latest` is the correct answer. This repository's own
artifact-verification jobs are built that way (`build.yml` creates `latest/`,
serves it over HTTP, and points `NETDATA_TARBALL_BASEURL` at it). Only an HTTP
error or an empty result is treated as failure. There is a test pinning this.

### Also fixed here

`handle_wget_result()` extracted the HTTP status with an unanchored
`grep "HTTP/"`, which also matches a `Server: BaseHTTP/0.6` header — so the wrong
line was parsed and every wget HTTP error fell through to the unknown-status
branch. Anchored to the status line. Pre-existing, but it defeated the wget retry
added here.

## Tests

New: `packaging/tests/kickstart-redirect/`, following the existing `rpm-parity`
convention. It starts a local fault-injection HTTP server, slices `kickstart.sh`
at its `# Main program` marker to source the real shipped functions, and drives
**complete caller flows** rather than `get_redirect()` alone — because the defect
was a return value nobody checked.

| Environment | Result |
|---|---|
| bash + GNU wget | 14/14 |
| dash (`debian:12-slim`) | 14/14 |
| BusyBox wget (`alpine:3.20`) | 14/14 |
| Against `master` | **5/14** |

The 9 failures against `master` reproduce the production bug exactly — `rc=0`,
output `latest`, building `.../download/latest/netdata-latest.tar.gz`.

Retries for the wget fallback are done in the shell rather than with wget
options, because GNU wget needs `--retry-on-http-error` and BusyBox wget has no
HTTP-level retry at all.

## Validation

- `shellcheck`: clean on the new test and `deb-sign.sh`; `kickstart.sh` finding
  count unchanged from `master`
- Parses under bash, dash and busybox ash
- `debsigs` in an `ubuntu:24.04` container: 40 packages, all genuine
  dependencies, **0** firefox/snapd
- No behaviour change on the success path; the healthy-path test asserts the
  built URL is unchanged

## Not included

A fourth issue found in the same triage — CMake's `ExternalProject` blacklists a
download URL after a single non-allowlisted curl error (our 503s and connection
resets are not on its retry list), affecting the two eBPF tarballs and the SQLite
source zip. That touches a shared cross-platform build mechanism and needs a much
larger compatibility matrix, so it is deliberately left for a separate PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden release CI and the installer against transient third‑party failures. Prevents false‑red release jobs, missed package uploads, and confusing 404s by validating, retrying, and failing fast with clear errors.

- MCP registry workflow: replace `mcp-publisher publish --dry-run` with `mcp-publisher validate`. Old behavior silently published during the “dry run” and the real publish failed with a duplicate-version error; new behavior validates without publishing and only publishes in the next step.
- DEB signing: stop `apt-get upgrade -y` and install only `debsigs`. Old behavior upgraded ~40 runner packages (including the Firefox snap stub) and depended on the Snap Store; new behavior avoids snap traffic and keeps signing independent and faster.
- Installer (`kickstart.sh`): robust `/latest` resolution. Old behavior used curl without `--fail`, returned “latest” on HTTP errors, and callers ignored status, building `/download/latest/...` URLs; new behavior uses `curl --fail --retry`, retries wget transient errors in shell with anchored status parsing, propagates failures from `set_*_archive_urls` to all callers (static install, build, offline prep), and makes `--prepare-offline` return a non‑zero status on failure. Mirrors that serve a real `latest/` directory still resolve to `latest`.

Adds `packaging/tests/kickstart-redirect` end‑to‑end tests; success paths are unchanged.

<sup>Written for commit 93391cbb51496722f2b593a7eee99d85ade179a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer handling of redirects, HTTP failures, retries, and direct download URLs.
  * Offline installation now reports unresolved archive sources and fails when no requested architecture is available.
  * Validation workflows no longer risk publishing duplicate registry entries.

* **Tests**
  * Added regression coverage for redirect resolution, retries, download failures, and fallback behavior.

* **Documentation**
  * Documented the new installer redirect-resolution test scenarios and execution requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->