### PR TITLE
refactor: remove unused registry_generate_curl_urls function

### DIFF
--- a/src/registry/registry_init.c
+++ b/src/registry/registry_init.c
@@ -46,22 +46,6 @@ void registry_db_stats(void) {
                      machines, machines_urls, max_urls_per_machine);
 }
 
-void registry_generate_curl_urls(void) {
-    FILE *fp = fopen("/tmp/registry.curl", "w+");
-    if (unlikely(!fp))
-        return;
-
-    REGISTRY_PERSON *p;
-    dfe_start_read(registry.persons, p) {
-        for(REGISTRY_PERSON_URL *pu = p->person_urls ; pu ;pu = pu->next) {
-            fprintf(fp, "do_curl '%s' '%s' '%s'\n", p->guid, pu->machine->guid, string2str(pu->url));
-        }
-    }
-    dfe_done(p);
-
-    fclose(fp);
-}
-
 void netdata_conf_section_registry(void) {
     FUNCTION_RUN_ONCE();
 
@@ -189,7 +173,6 @@ bool registry_load(void) {
             registry_db_save();
 
         //        registry_db_stats();
-        //        registry_generate_curl_urls();
         //        exit(0);
 
         return true;


### PR DESCRIPTION
##### Summary
- Remove the dead registry_generate_curl_urls() and its commented-out call
  - closes CodeQL 3287 and SonarCloud c:S2095 as fixed 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused internal helper that generated temporary registry URL commands.
  * Registry loading no longer attempts to create the temporary command file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->