### PR TITLE
Harden CI change detection for large pull requests

### DIFF
--- a/.github/scripts/test-ci-workflow-file-selection.py
+++ b/.github/scripts/test-ci-workflow-file-selection.py
@@ -23,6 +23,10 @@ GO_PATH_PATTERNS = (
     "**/go.mod",
     "**/go.sum",
 )
+CHANGED_FILES_ACTION = (
+    "uses: step-security/changed-files@"
+    "3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45"
+)
 
 
 def shell_trigger_matches(path: str) -> bool:
@@ -39,7 +43,61 @@ def go_group_matches(path: str) -> bool:
     return any(candidate.match(pattern) for pattern in GO_PATH_PATTERNS)
 
 
+def workflow_step(workflow: str, name: str) -> list[str]:
+    lines = workflow.splitlines()
+    marker = f"- name: {name}"
+    starts = [index for index, line in enumerate(lines) if line.strip() == marker]
+
+    if len(starts) != 1:
+        raise ValueError(f"expected one {name!r} step, found {len(starts)}")
+
+    start = starts[0]
+    end = next(
+        (
+            index
+            for index in range(start + 1, len(lines))
+            if lines[index].strip().startswith("- name: ")
+        ),
+        len(lines),
+    )
+    return lines[start:end]
+
+
+def literal_block(step: list[str], key: str) -> set[str]:
+    marker = f"{key}: |"
+    starts = [index for index, line in enumerate(step) if line.strip() == marker]
+
+    if len(starts) != 1:
+        raise ValueError(f"expected one {key!r} block, found {len(starts)}")
+
+    start = starts[0]
+    indentation = len(step[start]) - len(step[start].lstrip())
+    values = []
+    for line in step[start + 1:]:
+        if line.strip() and len(line) - len(line.lstrip()) <= indentation:
+            break
+        if line.strip():
+            values.append(line.strip())
+
+    return set(values)
+
+
 class WorkflowFileSelectionTest(unittest.TestCase):
+    def test_literal_block_ignores_indentation_and_blank_lines(self) -> None:
+        workflow = """
+  - name: Example
+    with:
+      files: |
+        *.go
+
+        go.mod
+  - name: Next step
+    run: true
+"""
+
+        step = workflow_step(workflow, "Example")
+        self.assertEqual(literal_block(step, "files"), {"*.go", "go.mod"})
+
     def test_shell_trigger_and_scanner_accept_only_supported_suffixes(self) -> None:
         accepted = (
             "install.sh",
@@ -95,21 +153,24 @@ class WorkflowFileSelectionTest(unittest.TestCase):
 
     def test_workflows_use_the_tested_shell_contract(self) -> None:
         workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
+        shellcheck_step = workflow_step(workflow, "Run shellcheck")
 
         self.assertIn(r"grep -Eq '\.sh(\.in)?$'", workflow)
-        self.assertIn("pattern: |\n            *.sh\n            *.sh.in", workflow)
+        self.assertEqual(literal_block(shellcheck_step, "pattern"), {"*.sh", "*.sh.in"})
         self.assertNotIn('pattern: "*.sh*"', workflow)
 
     def test_go_decisions_do_not_consume_filename_inventories(self) -> None:
         for workflow_path in GO_WORKFLOWS:
             workflow = workflow_path.read_text(encoding="utf-8")
+            go_files_step = workflow_step(workflow, "Check Go files")
+            normalized_step = {line.strip() for line in go_files_step}
 
             with self.subTest(workflow=workflow_path.name):
-                self.assertIn("id: check-go-files", workflow)
+                self.assertIn("id: check-go-files", normalized_step)
+                self.assertIn(CHANGED_FILES_ACTION, normalized_step)
                 self.assertIn("steps.check-go-files.outputs.any_modified", workflow)
                 self.assertNotIn("other_changed_files", workflow)
-                for pattern in GO_PATH_PATTERNS:
-                    self.assertIn(f"            {pattern}\n", workflow)
+                self.assertEqual(literal_block(go_files_step, "files"), set(GO_PATH_PATTERNS))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test-ci-workflow-file-selection.py
+++ b/.github/scripts/test-ci-workflow-file-selection.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import fnmatch
+import re
+import unittest
+from pathlib import Path, PurePosixPath
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REVIEW_WORKFLOW = ROOT / ".github/workflows/review.yml"
+GO_WORKFLOWS = (
+    ROOT / ".github/workflows/build.yml",
+    ROOT / ".github/workflows/docker.yml",
+)
+
+SHELL_PATH_RE = re.compile(r"\.sh(?:\.in)?$")
+SHELL_FIND_PATTERNS = ("*.sh", "*.sh.in")
+GO_PATH_PATTERNS = (
+    "*.go",
+    "go.mod",
+    "go.sum",
+    "**/*.go",
+    "**/go.mod",
+    "**/go.sum",
+)
+
+
+def shell_trigger_matches(path: str) -> bool:
+    return SHELL_PATH_RE.search(path) is not None
+
+
+def shell_scanner_matches(path: str) -> bool:
+    name = PurePosixPath(path).name
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in SHELL_FIND_PATTERNS)
+
+
+def go_group_matches(path: str) -> bool:
+    candidate = PurePosixPath(path)
+    return any(candidate.match(pattern) for pattern in GO_PATH_PATTERNS)
+
+
+class WorkflowFileSelectionTest(unittest.TestCase):
+    def test_shell_trigger_and_scanner_accept_only_supported_suffixes(self) -> None:
+        accepted = (
+            "install.sh",
+            ".github/scripts/check.sh",
+            "packaging/templates/installer.sh.in",
+        )
+        rejected = (
+            "src/collectors/freebsd.plugin/integrations/kern.ipc.shm.md",
+            "packaging/checksums.sha256",
+            "docs/example.sh.md",
+            "scripts/shellscript",
+        )
+
+        for path in accepted:
+            with self.subTest(path=path):
+                self.assertTrue(shell_trigger_matches(path))
+                self.assertTrue(shell_scanner_matches(path))
+
+        for path in rejected:
+            with self.subTest(path=path):
+                self.assertFalse(shell_trigger_matches(path))
+                self.assertFalse(shell_scanner_matches(path))
+
+    def test_large_documentation_change_does_not_select_shellcheck(self) -> None:
+        paths = (
+            f"src/collectors/example/integrations/metric-{index}.shm.md"
+            for index in range(20_000)
+        )
+        self.assertFalse(any(shell_trigger_matches(path) for path in paths))
+
+    def test_go_group_covers_root_and_nested_go_inputs(self) -> None:
+        accepted = (
+            "main.go",
+            "go.mod",
+            "go.sum",
+            "src/go/main.go",
+            "src/go/go.mod",
+            "src/go/go.sum",
+        )
+        rejected = (
+            "main.go.md",
+            "docs/go.mod.md",
+            "src/generated/golang.txt",
+        )
+
+        for path in accepted:
+            with self.subTest(path=path):
+                self.assertTrue(go_group_matches(path))
+
+        for path in rejected:
+            with self.subTest(path=path):
+                self.assertFalse(go_group_matches(path))
+
+    def test_workflows_use_the_tested_shell_contract(self) -> None:
+        workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(r"grep -Eq '\.sh(\.in)?$'", workflow)
+        self.assertIn("pattern: |\n            *.sh\n            *.sh.in", workflow)
+        self.assertNotIn('pattern: "*.sh*"', workflow)
+
+    def test_go_decisions_do_not_consume_filename_inventories(self) -> None:
+        for workflow_path in GO_WORKFLOWS:
+            workflow = workflow_path.read_text(encoding="utf-8")
+
+            with self.subTest(workflow=workflow_path.name):
+                self.assertIn("id: check-go-files", workflow)
+                self.assertIn("steps.check-go-files.outputs.any_modified", workflow)
+                self.assertNotIn("other_changed_files", workflow)
+                for pattern in GO_PATH_PATTERNS:
+                    self.assertIn(f"            {pattern}\n", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test-ci-workflow-file-selection.py
+++ b/.github/scripts/test-ci-workflow-file-selection.py
@@ -8,9 +8,9 @@ from pathlib import Path, PurePosixPath
 
 ROOT = Path(__file__).resolve().parents[2]
 REVIEW_WORKFLOW = ROOT / ".github/workflows/review.yml"
-GO_WORKFLOWS = (
-    ROOT / ".github/workflows/build.yml",
-    ROOT / ".github/workflows/docker.yml",
+GO_WORKFLOW_STEPS = (
+    (ROOT / ".github/workflows/build.yml", "Check build files"),
+    (ROOT / ".github/workflows/docker.yml", "Check build system files"),
 )
 
 SHELL_PATH_RE = re.compile(r"\.sh(?:\.in)?$")
@@ -22,10 +22,6 @@ GO_PATH_PATTERNS = (
     "**/*.go",
     "**/go.mod",
     "**/go.sum",
-)
-CHANGED_FILES_ACTION = (
-    "uses: step-security/changed-files@"
-    "3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45"
 )
 
 
@@ -160,24 +156,21 @@ class WorkflowFileSelectionTest(unittest.TestCase):
         self.assertNotIn('pattern: "*.sh*"', workflow)
 
     def test_go_decisions_do_not_consume_filename_inventories(self) -> None:
-        for workflow_path in GO_WORKFLOWS:
+        for workflow_path, build_step_name in GO_WORKFLOW_STEPS:
             workflow = workflow_path.read_text(encoding="utf-8")
-            go_files_step = workflow_step(workflow, "Check Go files")
+            build_files_step = workflow_step(workflow, build_step_name)
             check_run_step = workflow_step(workflow, "Check Run")
             check_go_step = workflow_step(workflow, "Check Go")
-            normalized_step = {line.strip() for line in go_files_step}
 
             with self.subTest(workflow=workflow_path.name):
-                self.assertIn("id: check-go-files", normalized_step)
-                self.assertIn(CHANGED_FILES_ACTION, normalized_step)
                 self.assertTrue(
-                    any("steps.check-go-files.outputs.any_modified" in line for line in check_run_step)
+                    any("steps.check-build-files.outputs.any_modified" in line for line in check_run_step)
                 )
                 self.assertTrue(
-                    any("steps.check-go-files.outputs.any_modified" in line for line in check_go_step)
+                    any("steps.check-build-files.outputs.any_modified" in line for line in check_go_step)
                 )
                 self.assertNotIn("other_changed_files", workflow)
-                self.assertEqual(literal_block(go_files_step, "files"), set(GO_PATH_PATTERNS))
+                self.assertTrue(set(GO_PATH_PATTERNS) <= literal_block(build_files_step, "files"))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test-ci-workflow-file-selection.py
+++ b/.github/scripts/test-ci-workflow-file-selection.py
@@ -163,12 +163,19 @@ class WorkflowFileSelectionTest(unittest.TestCase):
         for workflow_path in GO_WORKFLOWS:
             workflow = workflow_path.read_text(encoding="utf-8")
             go_files_step = workflow_step(workflow, "Check Go files")
+            check_run_step = workflow_step(workflow, "Check Run")
+            check_go_step = workflow_step(workflow, "Check Go")
             normalized_step = {line.strip() for line in go_files_step}
 
             with self.subTest(workflow=workflow_path.name):
                 self.assertIn("id: check-go-files", normalized_step)
                 self.assertIn(CHANGED_FILES_ACTION, normalized_step)
-                self.assertIn("steps.check-go-files.outputs.any_modified", workflow)
+                self.assertTrue(
+                    any("steps.check-go-files.outputs.any_modified" in line for line in check_run_step)
+                )
+                self.assertTrue(
+                    any("steps.check-go-files.outputs.any_modified" in line for line in check_go_step)
+                )
                 self.assertNotIn("other_changed_files", workflow)
                 self.assertEqual(literal_block(go_files_step, "files"), set(GO_PATH_PATTERNS))
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Check Go files
         id: check-go-files
         if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@v45
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45
         with:
           files: |
             *.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Check Run
         id: check-run
         run: |
-          if [ "${{ steps.check-source-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "${{ steps.check-source-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-go-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo 'run=true' >> "${GITHUB_OUTPUT}"
           else
             echo 'run=false' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,18 @@ jobs:
             packaging/**/*.md
             packaging/repoconfig/
             src/go/tools/topology-ip-intel-downloader/README.md
+      - name: Check Go files
+        id: check-go-files
+        if: github.event_name == 'pull_request'
+        uses: step-security/changed-files@v45
+        with:
+          files: |
+            *.go
+            go.mod
+            go.sum
+            **/*.go
+            **/go.mod
+            **/go.sum
       - name: Check static build files
         id: check-static-build-files
         uses: step-security/changed-files@v45
@@ -126,7 +138,7 @@ jobs:
         id: check-go
         run: |
           if [ '${{ github.event_name }}' == 'pull_request' ]; then
-            if echo "${{ steps.check-source-files.outputs.other_changed_files }}" | grep -q '.*/(.*\.go|go\.mod|go\.sum)$' || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ]; then
+            if [ "${{ steps.check-go-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ]; then
               echo 'skip-go=' >> "${GITHUB_OUTPUT}"
             else
               echo 'skip-go=--disable-go' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,12 @@ jobs:
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
           files: |
+            *.go
+            go.mod
+            go.sum
+            **/*.go
+            **/go.mod
+            **/go.sum
             **/*.cmake
             CMakeLists.txt
             netdata-installer.sh
@@ -84,18 +90,6 @@ jobs:
             packaging/**/*.md
             packaging/repoconfig/
             src/go/tools/topology-ip-intel-downloader/README.md
-      - name: Check Go files
-        id: check-go-files
-        if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45
-        with:
-          files: |
-            *.go
-            go.mod
-            go.sum
-            **/*.go
-            **/go.mod
-            **/go.sum
       - name: Check static build files
         id: check-static-build-files
         uses: step-security/changed-files@v45
@@ -129,7 +123,7 @@ jobs:
       - name: Check Run
         id: check-run
         run: |
-          if [ "${{ steps.check-source-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-go-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "${{ steps.check-source-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo 'run=true' >> "${GITHUB_OUTPUT}"
           else
             echo 'run=false' >> "${GITHUB_OUTPUT}"
@@ -138,7 +132,7 @@ jobs:
         id: check-go
         run: |
           if [ '${{ github.event_name }}' == 'pull_request' ]; then
-            if [ "${{ steps.check-go-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ]; then
+            if [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ]; then
               echo 'skip-go=' >> "${GITHUB_OUTPUT}"
             else
               echo 'skip-go=--disable-go' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Check Run
         id: check-run
         run: |
-          if [ "${{ steps.check-source-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "${{ steps.check-source-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-go-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo 'run=true' >> "${GITHUB_OUTPUT}"
           else
             echo 'run=false' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Check Go files
         id: check-go-files
         if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@v45
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45
         with:
           files: |
             *.go

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -457,11 +457,13 @@ jobs:
       - name: Create and Push Manifest
         id: manifest
         if: github.repository == 'netdata/netdata'
-        run: docker buildx imagetools create $(.github/scripts/gen-docker-imagetool-args.py /tmp/digests '' "${{ needs.gen-tags.outputs.tags }}")
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $(.github/scripts/gen-docker-imagetool-args.py /tmp/digests '' "${{ needs.gen-tags.outputs.tags }}")
       - name: Rotate Old Image Tags
         id: rotate
         if: github.repository == 'netdata/netdata' && needs.gen-tags.outputs.nightly == '1'
-        run: .github/scripts/rotate-docker-tags.sh ${{ needs.gen-tags.outputs.docker_repo }} ${{ needs.gen-tags.outputs.nightly_tag }} ${NIGHTLY_COUNT}
+        run: .github/scripts/rotate-docker-tags.sh "${{ needs.gen-tags.outputs.docker_repo }}" "${{ needs.gen-tags.outputs.nightly_tag }}" "${NIGHTLY_COUNT}"
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -617,11 +619,13 @@ jobs:
       - name: Create and Push Manifest
         id: manifest
         if: github.repository == 'netdata/netdata'
-        run: docker buildx imagetools create $(.github/scripts/gen-docker-imagetool-args.py /tmp/digests 'quay.io' "${{ needs.gen-tags.outputs.tags }}")
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $(.github/scripts/gen-docker-imagetool-args.py /tmp/digests 'quay.io' "${{ needs.gen-tags.outputs.tags }}")
       - name: Rotate Old Image Tags
         id: rotate
         if: github.repository == 'netdata/netdata' && needs.gen-tags.outputs.nightly == '1'
-        run: .github/scripts/rotate-docker-tags.sh ${{ needs.gen-tags.outputs.quay_repo }} ${{ needs.gen-tags.outputs.nightly_tag }} ${NIGHTLY_COUNT}
+        run: .github/scripts/rotate-docker-tags.sh "${{ needs.gen-tags.outputs.quay_repo }}" "${{ needs.gen-tags.outputs.nightly_tag }}" "${NIGHTLY_COUNT}"
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -777,11 +781,13 @@ jobs:
       - name: Create and Push Manifest
         id: manifest
         if: github.repository == 'netdata/netdata'
-        run: docker buildx imagetools create $(.github/scripts/gen-docker-imagetool-args.py /tmp/digests 'ghcr.io' "${{ needs.gen-tags.outputs.tags }}")
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $(.github/scripts/gen-docker-imagetool-args.py /tmp/digests 'ghcr.io' "${{ needs.gen-tags.outputs.tags }}")
       - name: Rotate Old Image Tags
         id: rotate
         if: github.repository == 'netdata/netdata' && needs.gen-tags.outputs.nightly == '1'
-        run: .github/scripts/rotate-docker-tags.sh ${{ needs.gen-tags.outputs.ghcr_repo }} ${{ needs.gen-tags.outputs.nightly_tag }} ${NIGHTLY_COUNT}
+        run: .github/scripts/rotate-docker-tags.sh "${{ needs.gen-tags.outputs.ghcr_repo }}" "${{ needs.gen-tags.outputs.nightly_tag }}" "${NIGHTLY_COUNT}"
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,6 +87,18 @@ jobs:
           files_ignore: |
             **/*.md
             packaging/repoconfig/
+      - name: Check Go files
+        id: check-go-files
+        if: github.event_name == 'pull_request'
+        uses: step-security/changed-files@v45
+        with:
+          files: |
+            *.go
+            go.mod
+            go.sum
+            **/*.go
+            **/go.mod
+            **/go.sum
       - name: Check Docker files
         id: check-docker-files
         if: github.event_name != 'workflow_dispatch'
@@ -126,11 +138,9 @@ jobs:
           fi
       - name: Check Go
         id: check-go
-        env:
-          OTHER_CHANGED_FILES: ${{ steps.check-source-files.outputs.other_changed_files }}
         run: |
           if [ '${{ github.event_name }}' == 'pull_request' ]; then
-            if echo "${OTHER_CHANGED_FILES}" | grep -q '.*/(.*\.go|go\.mod|go\.sum)$' || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ]; then
+            if [ "${{ steps.check-go-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ]; then
               echo 'skip-go=' >> "${GITHUB_OUTPUT}"
             else
               echo 'skip-go=--disable-go' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,6 +69,12 @@ jobs:
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
           files: |
+            *.go
+            go.mod
+            go.sum
+            **/*.go
+            **/go.mod
+            **/go.sum
             .dockerignore
             CMakeLists.txt
             netdata-installer.sh
@@ -87,18 +93,6 @@ jobs:
           files_ignore: |
             **/*.md
             packaging/repoconfig/
-      - name: Check Go files
-        id: check-go-files
-        if: github.event_name == 'pull_request'
-        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45
-        with:
-          files: |
-            *.go
-            go.mod
-            go.sum
-            **/*.go
-            **/go.mod
-            **/go.sum
       - name: Check Docker files
         id: check-docker-files
         if: github.event_name != 'workflow_dispatch'
@@ -131,7 +125,7 @@ jobs:
       - name: Check Run
         id: check-run
         run: |
-          if [ "${{ steps.check-source-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-go-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "${{ steps.check-source-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo 'run=true' >> "${GITHUB_OUTPUT}"
           else
             echo 'run=false' >> "${GITHUB_OUTPUT}"
@@ -140,7 +134,7 @@ jobs:
         id: check-go
         run: |
           if [ '${{ github.event_name }}' == 'pull_request' ]; then
-            if [ "${{ steps.check-go-files.outputs.any_modified }}" == "true" ] || [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ]; then
+            if [ "${{ steps.check-build-files.outputs.any_modified }}" == "true" ]; then
               echo 'skip-go=' >> "${GITHUB_OUTPUT}"
             else
               echo 'skip-go=--disable-go' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/actionlint') }}" = "true" ]; then
             echo "run=true" >> "${GITHUB_OUTPUT}"
-          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '\.github/workflows/.*' ; then
+          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '^\.github/workflows/|^\.github/scripts/test-ci-workflow-file-selection\.py$' ; then
             echo "run=true" >> "${GITHUB_OUTPUT}"
             echo 'GitHub Actions workflows have changed, need to run actionlint.'
           else
@@ -87,7 +87,7 @@ jobs:
         run: |
           if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/shellcheck') }}" = "true" ]; then
             echo "run=true" >> "${GITHUB_OUTPUT}"
-          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '.*\.sh.*' ; then
+          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '\.sh(\.in)?$' ; then
             echo "run=true" >> "${GITHUB_OUTPUT}"
             echo 'Shell scripts have changed, need to run shellcheck.'
           else
@@ -121,6 +121,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
+      - name: Test CI workflow file selection
+        run: python3 .github/scripts/test-ci-workflow-file-selection.py
 
 #  clang-format:
 #    name: clang-format
@@ -229,7 +231,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
           path: "."
-          pattern: "*.sh*"
+          pattern: |
+            *.sh
+            *.sh.in
           exclude: |
             ./.git/*
             packaging/makeself/makeself.sh


### PR DESCRIPTION
## Summary

- restrict shellcheck selection to actual `.sh` and `.sh.in` files
- replace unbounded changed-filename parsing with dedicated Go change groups in Build and Docker
- add regression coverage for the real `.shm.md` false match, Go path boundaries, and a 20,000-document change set
- make the touched Docker workflow actionlint-clean by quoting ordinary tag arguments and documenting three intentional manifest argument expansions

## Root cause

A large documentation PR exposed two independent CI defects:

1. Shellcheck used substring matching (`*.sh*`), so generated Markdown such as `kern.ipc.shm.md` was treated as shell code.
2. Build and Docker passed the complete negative changed-file inventory through command or environment expansion to answer a boolean Go-change question. The Docker runner exceeded the process argument/environment limit before Bash started.

## Validation

- 5 focused workflow-selection tests pass
- Flake8 7.3.0 passes for the regression test
- modified workflows parse as YAML
- full actionlint, including embedded ShellCheck, passes
- `git diff --check` passes
- sensitive-data scan passes for new material
- hosted Build and Docker file-selection jobs pass

## Integration order

This is a standalone prerequisite for #23476. Merge this PR first, then rebase #23476 and address the lint findings owned by that PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI Improvements**
  - Improved detection of Go source and module-file changes in pull requests, ensuring relevant builds and checks run reliably.
  - Refined shell script detection to recognize supported `.sh` and `.sh.in` files while avoiding misleading filenames.
  - Added validation for workflow file-selection rules and expanded actionlint coverage.
  - Improved Docker image publishing workflow reliability, including manifest creation and nightly tag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->