### PR TITLE
fix(go.d/snmp): use correct OID for Aruba fan status

### DIFF
--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/aruba-cx-switch.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/aruba-cx-switch.yaml
@@ -126,8 +126,8 @@ metrics:
           description: Current RPM read for the fan.
           family: 'Hardware/Fan/Speed'
           unit: "{revolution}/min"
-      - OID: 1.3.6.1.4.1.47196.4.1.1.3.11.5.1.1.5
-        name: arubaWiredFanState
+      - OID: 1.3.6.1.4.1.47196.4.1.1.3.11.5.1.1.10
+        name: arubaWiredFanStateEnum
         chart_meta:
           description: Current status for the fan
           family: 'Hardware/Fan/Status'


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Aruba CX fan status collection by switching to the correct SNMP OID and renaming the metric to reflect its enum values. Previously we queried 1.3.6.1.4.1.47196.4.1.1.3.11.5.1.1.5 and exposed arubaWiredFanState; now we query 1.3.6.1.4.1.47196.4.1.1.3.11.5.1.1.10 and expose arubaWiredFanStateEnum, ensuring accurate status reporting.

- Migration: Update any dashboards, alerts, or queries that reference arubaWiredFanState to arubaWiredFanStateEnum.
- Deployment: Reload or restart the agent to apply the updated `aruba-cx-switch.yaml` SNMP profile.

<sup>Written for commit ee8939a446f16266160c3d2fd129050b6d8383c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

