### PR TITLE
Fix pooled response buffers and fragmented WebSocket payload masking

### DIFF
--- a/src/aclk/aclk_query.c
+++ b/src/aclk/aclk_query.c
@@ -117,6 +117,10 @@ int http_api_v2(mqtt_wss_client client, aclk_query_t *query)
     int z_ret;
     BUFFER *z_buffer = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE, &netdata_buffers_statistics.buffers_aclk);
 
+    // set while the compressed buffer is installed in w->response.data; holds the pooled
+    // web client's own buffer so it can be put back before the client is released
+    BUFFER *uncompressed = NULL;
+
     struct web_client *w = web_client_get_from_cache();
     web_client_set_conn_cloud(w);
     w->port_acl = HTTP_ACL_ACLK | default_aclk_http_acl;
@@ -182,9 +186,22 @@ int http_api_v2(mqtt_wss_client client, aclk_query_t *query)
             z_buffer->len += bytes_to_cpy;
         } while(z_ret != Z_STREAM_END);
 
-        // so that web_client_build_http_header
-        // puts correct content length into header
-        buffer_free(w->response.data);
+        // web_client_build_http_header() reads the response buffer to size Content-Length
+        // and to emit Content-Type and the cacheability headers, so it has to see the
+        // compressed buffer. Borrow the slot instead of replacing it: response.data belongs
+        // to the pooled web client and web_client_reuse_from_cache() deliberately keeps it,
+        // so freeing it here would make every ACLK query re-grow its response buffer from
+        // NETDATA_WEB_RESPONSE_INITIAL_SIZE.
+        //
+        // Carry the description of the payload across, otherwise the headers would describe
+        // a freshly created buffer (text/plain, cacheable for a day) instead of what the API
+        // handler produced.
+        z_buffer->content_type = w->response.data->content_type;
+        z_buffer->options = w->response.data->options;
+        z_buffer->date = w->response.data->date;
+        z_buffer->expires = w->response.data->expires;
+
+        uncompressed = w->response.data;
         w->response.data = z_buffer;
         z_buffer = NULL;
     }
@@ -204,6 +221,13 @@ int http_api_v2(mqtt_wss_client client, aclk_query_t *query)
         w->response.data->len);
 
 cleanup:
+    if (uncompressed) {
+        // give the compressed buffer back to the local, so buffer_free() below releases it
+        // and the pooled client keeps its own already-grown buffer
+        z_buffer = w->response.data;
+        w->response.data = uncompressed;
+    }
+
     web_client_log_completed_request(w, false);
     web_client_release_to_cache(w);
 

--- a/src/aclk/mqtt_websockets/ws_client-unittest.c
+++ b/src/aclk/mqtt_websockets/ws_client-unittest.c
@@ -104,6 +104,141 @@ static int ws_client_unittest_verify_mqtt_payload(ws_client *client, size_t payl
     return errors;
 }
 
+static int ws_client_unittest_drain(rbuf_t buf, size_t bytes)
+{
+    char tmp[256];
+
+    while (bytes) {
+        size_t want = MIN(sizeof(tmp), bytes);
+        if (rbuf_pop(buf, tmp, want) != want)
+            return 0;
+        bytes -= want;
+    }
+
+    return 1;
+}
+
+// Sends payload_len bytes through ws_client_send() with the write ringbuffer's head
+// positioned by prefill/drain, then verifies the queued frame byte for byte against the
+// reference masking of RFC6455 5.3. prefill/drain place the head close to the end of the
+// ringbuffer so the payload has to be written in two chunks.
+static int ws_client_unittest_masked_frame(size_t buf_size, size_t payload_len, size_t prefill, size_t drain,
+                                          size_t expect_written, const char *label)
+{
+    int errors = 0;
+    char msg[256];
+    ws_client client = {
+        .state = WS_ESTABLISHED,
+        .rx.parse_state = WS_FIRST_2BYTES,
+        .buf_read = rbuf_create(64, 64),
+        .buf_write = rbuf_create(buf_size, buf_size),
+        .buf_to_mqtt = rbuf_create(64, 64),
+    };
+
+    if (prefill) {
+        char *filler = mallocz(prefill);
+        memset(filler, 'x', prefill);
+        snprintfz(msg, sizeof(msg), "%s: prefill write buffer", label);
+        WS_TEST(rbuf_push(client.buf_write, filler, prefill) == prefill, msg);
+        freez(filler);
+
+        snprintfz(msg, sizeof(msg), "%s: drain write buffer", label);
+        WS_TEST(ws_client_unittest_drain(client.buf_write, drain), msg);
+    }
+
+    // exact-sized allocation on purpose: reading past the payload is then a heap
+    // overflow that ASAN/valgrind can see
+    char *payload = mallocz(payload_len);
+    ws_client_unittest_payload_fill(payload, 0, payload_len);
+
+    int written = ws_client_send(&client, WS_OP_BINARY_FRAME, payload, payload_len);
+    snprintfz(msg, sizeof(msg), "%s: ws_client_send() writes exactly the payload", label);
+    WS_TEST(written == (int)expect_written, msg);
+
+    // 2 bytes of frame header + 4 bytes of mask key, plus the extended length field
+    size_t hdr_len = 2 + 4;
+    if (expect_written > 125)
+        hdr_len += 2;
+    if (expect_written > 65535)
+        hdr_len += 6;
+
+    snprintfz(msg, sizeof(msg), "%s: queued frame size", label);
+    WS_TEST(rbuf_bytes_available(client.buf_write) == (prefill - drain) + hdr_len + expect_written, msg);
+
+    snprintfz(msg, sizeof(msg), "%s: drain bytes queued before the frame", label);
+    WS_TEST(ws_client_unittest_drain(client.buf_write, prefill - drain), msg);
+
+    char hdr[2];
+    snprintfz(msg, sizeof(msg), "%s: pop frame header", label);
+    WS_TEST(rbuf_pop(client.buf_write, hdr, sizeof(hdr)) == sizeof(hdr), msg);
+
+    snprintfz(msg, sizeof(msg), "%s: FIN and binary opcode", label);
+    WS_TEST((unsigned char)hdr[0] == (0x80 | WS_OP_BINARY_FRAME), msg);
+
+    snprintfz(msg, sizeof(msg), "%s: mask bit set", label);
+    WS_TEST(((unsigned char)hdr[1] & 0x80) != 0, msg);
+
+    size_t declared = (unsigned char)hdr[1] & 0x7f;
+    if (declared == 126) {
+        char len[2];
+        snprintfz(msg, sizeof(msg), "%s: pop 16bit length", label);
+        WS_TEST(rbuf_pop(client.buf_write, len, sizeof(len)) == sizeof(len), msg);
+        declared = ((size_t)(unsigned char)len[0] << 8) | (size_t)(unsigned char)len[1];
+    }
+
+    snprintfz(msg, sizeof(msg), "%s: declared payload length", label);
+    WS_TEST(declared == expect_written, msg);
+
+    char mask[4];
+    snprintfz(msg, sizeof(msg), "%s: pop mask key", label);
+    WS_TEST(rbuf_pop(client.buf_write, mask, sizeof(mask)) == sizeof(mask), msg);
+
+    char *masked = mallocz(expect_written);
+    snprintfz(msg, sizeof(msg), "%s: pop masked payload", label);
+    WS_TEST(rbuf_pop(client.buf_write, masked, expect_written) == expect_written, msg);
+
+    size_t mismatches = 0;
+    for (size_t i = 0; i < expect_written; i++) {
+        if (masked[i] != (char)(payload[i] ^ mask[i & 3]))
+            mismatches++;
+    }
+
+    snprintfz(msg, sizeof(msg), "%s: payload masked per RFC6455 5.3", label);
+    WS_TEST(mismatches == 0, msg);
+
+    snprintfz(msg, sizeof(msg), "%s: write buffer fully consumed", label);
+    WS_TEST(rbuf_bytes_available(client.buf_write) == 0, msg);
+
+    freez(masked);
+    freez(payload);
+    rbuf_free(client.buf_read);
+    rbuf_free(client.buf_write);
+    rbuf_free(client.buf_to_mqtt);
+    return errors;
+}
+
+static int ws_client_unittest_masking(void)
+{
+    int errors = 0;
+
+    // shorter than the word-at-a-time step, so only the byte tail runs
+    errors += ws_client_unittest_masked_frame(1024, 5, 0, 0, 5, "5 byte payload");
+
+    // not a multiple of 8: word blocks plus a 4 byte tail, and the 16bit length header
+    errors += ws_client_unittest_masked_frame(1024, 300, 0, 0, 300, "300 byte payload");
+
+    // split across the ringbuffer wrap at payload offset 18, so the mask phase has to be
+    // carried into the second chunk at a non-multiple of 4
+    errors += ws_client_unittest_masked_frame(1024, 100, 1000, 990, 100, "wrapped payload");
+
+    // free space (108) exceeds the payload (100) by less than the first chunk (18), so the
+    // second chunk (90) is larger than what is left (82) while still being <= payload size.
+    // A clamp against the payload size instead of the remainder over-copies here.
+    errors += ws_client_unittest_masked_frame(1024, 100, 1000, 90, 100, "wrapped payload, nearly full buffer");
+
+    return errors;
+}
+
 static int ws_client_unittest_create_defaults(void)
 {
     int errors = 0;
@@ -286,6 +421,7 @@ int ws_client_unittest(void)
 
     fprintf(stderr, "\nrunning ws_client unittest\n");
 
+    errors += ws_client_unittest_masking();
     errors += ws_client_unittest_create_defaults();
     errors += ws_client_unittest_clamps_mqtt_input_initial_size();
     errors += ws_client_unittest_observed_size_payload();

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -33,7 +33,9 @@ ws_client *ws_client_new(size_t buf_size, char **host)
 
     // Fixed: raw WebSocket read staging; dynamic growth is only needed after payload decoding.
     client->buf_read = rbuf_create(size, size);
-    // Fixed: the send path masks buffered bytes in-place after rbuf_bump_head().
+    // Fixed: staging for outgoing frames. ws_client_send() writes only what fits and
+    // reports a short count, which the caller turns into back-pressure (POLLOUT), so
+    // growth would only add memory.
     client->buf_write = rbuf_create(size, size);
     client->buf_to_mqtt = rbuf_create(mqtt_input_size, MAX_MQTT_INPUT_BUFFER_SIZE);
 
@@ -388,6 +390,38 @@ static size_t get_ws_hdr_size(size_t payload_size)
     return hdr_len;
 }
 
+// Copy `len` bytes from `src` to `dst`, applying the client-to-server mask [RFC6455 5.3].
+// `stream_pos` is the offset of src[0] inside the frame payload; it selects the mask byte
+// to start from, so a payload split across a ringbuffer wrap keeps the mask phase.
+//
+// Copying and masking in one pass, at word width, matters more than it looks: this runs
+// inside the mqtt_ng hdr-buffer lock, which mqtt_ng_sync() holds across the whole send
+// path while every query thread waits to publish.
+static void ws_mask_copy(char *dst, const char *src, size_t len, const char mask[4], size_t stream_pos)
+{
+    // the mask repeats every 4 bytes and 4 divides sizeof(uint64_t), so one mask word
+    // built at stream_pos stays valid for every 8-byte block after it
+    uint8_t mask_bytes[sizeof(uint64_t)];
+    for (size_t i = 0; i < sizeof(mask_bytes); i++)
+        mask_bytes[i] = (uint8_t)mask[(stream_pos + i) & 3];
+
+    uint64_t mask_word;
+    memcpy(&mask_word, mask_bytes, sizeof(mask_word));
+
+    size_t i = 0;
+    for (; i + sizeof(uint64_t) <= len; i += sizeof(uint64_t)) {
+        uint64_t word;
+        // memcpy for the unaligned load/store: compilers turn these into single
+        // instructions, and it keeps the code endian- and alignment-agnostic
+        memcpy(&word, &src[i], sizeof(word));
+        word ^= mask_word;
+        memcpy(&dst[i], &word, sizeof(word));
+    }
+
+    for (; i < len; i++)
+        dst[i] = src[i] ^ mask[(stream_pos + i) & 3];
+}
+
 #define MAX_POSSIBLE_HDR_LEN 14
 int ws_client_send(const ws_client *client, enum websocket_opcode frame_type, const char *data, size_t size)
 {
@@ -397,8 +431,6 @@ int ws_client_send(const ws_client *client, enum websocket_opcode frame_type, co
     // one big MQTT message as single fragmented WebSocket envelope
     char hdr[MAX_POSSIBLE_HDR_LEN];
     char *ptr = hdr;
-    int size_written = 0;
-    size_t j = 0;
 
     size_t w_buff_free = rbuf_bytes_free(client->buf_write);
     size_t hdr_len = get_ws_hdr_size(size);
@@ -442,23 +474,25 @@ int ws_client_send(const ws_client *client, enum websocket_opcode frame_type, co
     if (!size)
         return 0;
 
-    // copy and mask data in the write ringbuffer
-    while (size - size_written) {
+    // copy and mask data into the write ringbuffer
+    size_t size_written = 0;
+    while (size_written < size) {
         size_t writable_bytes;
         char *w_ptr = rbuf_get_linear_insert_range(client->buf_write, &writable_bytes);
-        if(!writable_bytes)
+        if(!w_ptr || !writable_bytes)
             break;
 
-        writable_bytes = (writable_bytes > size) ? (size - size_written) : writable_bytes;
+        // the linear range can be larger than what is left of the payload, and after a
+        // wrap it can also be larger than what is left while still being <= size
+        if (writable_bytes > size - size_written)
+            writable_bytes = size - size_written;
 
-        memcpy(w_ptr, &data[size_written], writable_bytes);
+        ws_mask_copy(w_ptr, &data[size_written], writable_bytes, mask, size_written);
         rbuf_bump_head(client->buf_write, writable_bytes);
 
-        for (size_t i = 0; i < writable_bytes; i++, j++)
-            w_ptr[i] ^= mask[j % 4];
         size_written += writable_bytes;
     }
-    return size_written;
+    return (int)size_written;
 }
 
 static int check_opcode(enum websocket_opcode oc)

--- a/src/aclk/mqtt_websockets/ws_client.c
+++ b/src/aclk/mqtt_websockets/ws_client.c
@@ -595,7 +595,7 @@ int ws_client_process_rx_ws(ws_client *client)
                 char *insert = rbuf_get_linear_insert_range(client->buf_to_mqtt, &size);
                 if (!insert) {
                     nd_log(NDLS_DAEMON, NDLP_ERR,
-                           "ACLK: inbound WebSocket MQTT buffer full! Cannot process payload of %"PRIu64" bytes "
+                           "ACLK: inbound WebSocket MQTT buffer full! Cannot process payload of %zu bytes "
                            "(processed %"PRIu64"/%"PRIu64"). Buffer capacity: %zu bytes, max capacity: %zu bytes",
                            remaining, client->rx.payload_processed, client->rx.payload_length,
                            rbuf_get_capacity(client->buf_to_mqtt), rbuf_get_max_capacity(client->buf_to_mqtt));


### PR DESCRIPTION
##### Summary
- Preserve pooled response buffers and their metadata during compressed ACLK responses.
- Rewrite and optimize WebSocket masking, including payloads spanning ring-buffer boundaries, with focused regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compressed API responses now retain the correct content type and response metadata, improving client compatibility.
  * WebSocket messages are handled more reliably across larger payloads and segmented buffers.
  * Improved back-pressure handling prevents outgoing data from being accepted when insufficient buffer space is available.
  * WebSocket masking and payload delivery now report accurate write progress, including partial and zero-byte writes.

* **Tests**
  * Added coverage for masked frames, extended payloads, buffer wrapping, and segmented writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->