### PR TITLE
Correct zRAM and eBPF VFS descriptions

### DIFF
--- a/src/collectors/ebpf.plugin/metadata.yaml
+++ b/src/collectors/ebpf.plugin/metadata.yaml
@@ -2141,7 +2141,7 @@ modules:
       module_name: vfs
       monitored_instance:
         name: eBPF VFS
-        description: "Monitor Linux virtual filesystem read, write, open, and unlink activity through eBPF kernel tracing."
+        description: "Monitor Linux virtual filesystem read, write, open, create, unlink, and fsync activity through eBPF kernel tracing."
         link: "https://kernel.org/"
         categories:
           - data-collection.storage

--- a/src/collectors/proc.plugin/metadata.yaml
+++ b/src/collectors/proc.plugin/metadata.yaml
@@ -1933,9 +1933,9 @@ modules:
       data_collection:
         metrics_description: |
           Monitor zRAM device capacity, compression, memory use, and I/O activity on Linux systems.
-          The data written to this block device is compressed and stored in memory.
+          zRAM, or compressed RAM, uses a portion of system memory as a block device; data written to it is compressed and stored in memory.
 
-          The collectors provides information about the operation and the effectiveness of zRAM on your system.
+          The collector provides information about the operation and effectiveness of zRAM on your system.
         method_description: ""
       supported_platforms:
         include: []


### PR DESCRIPTION
## Summary

- keep the active zRAM catalog sentence and restore the missing explanatory definition in its Overview
- correct adjacent zRAM grammar
- include create and fsync in the eBPF VFS description

## Source ownership

This PR changes only the authoritative collector metadata. Generated integration Markdown and umbrella documentation are intentionally excluded; the post-merge integration workflow owns those derived files.

## Collector consistency

- runtime code and metric identities: unchanged
- taxonomy: unchanged; no chart-context change
- configuration schema and stock configuration: unchanged
- alerts: unchanged
- authoritative documentation source: updated

## Validation

- `python3 integrations/gen_integrations.py`
- `python3 integrations/gen_docs_integrations.py --check` — 1,619 pages
- `python3 -m unittest integrations.tests.test_descriptions` — 43 passed
- `python3 integrations/gen_taxonomy.py --check-only`
- generated zRAM and eBPF VFS pages inspected locally
- generated Monitor Anything catalog inspected locally
- `git diff --check`
- local SOW and sensitive-data audit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies collector metadata for zRAM and eBPF VFS so generated docs and catalogs reflect the intended monitoring scope. No runtime, metric, taxonomy, or configuration changes.

- eBPF VFS description now lists read, write, open, create, unlink, and fsync (was read, write, open, and unlink).
- zRAM overview restores the definition of zRAM as compressed RAM used as a block device and fixes grammar (“collector”).
- Only metadata files updated; derived integration docs/catalog will update post-merge. No migrations or alert changes.

<sup>Written for commit 3e77d773720a6e3ac4e424d77d9b3734ed0a5b39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the eBPF VFS collector description to include filesystem creation and fsync activity.
  * Clarified and improved the zRAM collector description, including its role as compressed RAM used as a block device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->