### PR TITLE
fix(query): apply absolute to incoming plan points

### DIFF
--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -261,7 +261,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                     ops->db_total_points_read++;
 
                     if(unlikely(options & RRDR_OPTION_ABSOLUTE))
-                        storage_point_make_positive(sp);
+                        storage_point_make_positive(sp2);
 
                     if(sp.start_time_s > sp2.start_time_s)
                         // the point from the previous plan is useless


### PR DESCRIPTION
## Summary

- apply `options=absolute` to the point fetched from the incoming storage plan
- prevent one negative value from crossing an automatic tier transition unchanged
- preserve the existing query grid, plan selection, storage data, and all non-ABSOLUTE behavior

## Root cause

During a plan switch, `sp2` is the newly fetched point from the incoming tier. The existing ABSOLUTE normalization was applied to `sp`, the already-normalized point from the outgoing tier, leaving `sp2` unchanged.

This is the standalone extraction of commit `f75caacfe5` from #23283. Its production patch is exactly one operand change and has the same stable patch ID as the combined fix.

## Test contract

The focused regression contract is in #23130:

- `CASE-036/absolute-across-plan-seam`
- `tests/query-corpus/layer4c_test.go`

It discovers a real tier1-to-tier0 boundary, requires both tiers to serve the seam query, checks tier1-only and tier0-only controls, and requires every one-second row of a negative flat line to be returned at its exact positive magnitude.

Current exact results:

- upstream master: contract fails at the seam (`-37`, expected `37`)
- this branch: contract passes
- reverse mutation back to the old operand: the same contract fails again
- restored branch: contract passes and the full native unit suite reports `ALL TESTS PASSED`

The complete query-corpus PR should merge before this fix so the contract becomes part of the branch's normal CI test surface.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures ABSOLUTE normalization applies at plan seams by making the incoming point positive. Previously, ABSOLUTE normalized only the outgoing point, letting one negative sample cross a tier transition unchanged; now the incoming point is normalized, preserving consistent positive magnitudes without affecting non-ABSOLUTE behavior.

**Review notes**
- Change: in `rrd2rrdr_query_execute`, apply `storage_point_make_positive(sp2)` when `RRDR_OPTION_ABSOLUTE` is set (was `sp`).
- Scope: affects only the ABSOLUTE path at plan transitions; query grid, plan selection, and storage data remain unchanged.
- Tests: seam regression contract (tier1→tier0) now passes; upstream master returns a negative value at the boundary (e.g., `-37` instead of `37`).

<sup>Written for commit 54deb46d94f136d00945496133e87dcae5ba6d7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query plan switching so absolute-value normalization is applied to the newly fetched read-ahead point, improving query result accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->