### PR TITLE
fix(query): keep tier-0 evidence on source rows

### DIFF
--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -79,19 +79,19 @@ static NETDATA_DOUBLE query_point_grouping_value(
         if(likely(fpclassify((point).value) != FP_ZERO))                \
             (ops)->group_points_non_zero++;                             \
                                                                         \
-        if(unlikely((point).sp.flags & SN_FLAG_RESET)) {                \
-            time_t _row_start =                                        \
-                (now_end_time) - (ops)->view_update_every;              \
-            if((source_end_time) > _row_start &&                        \
-               (source_end_time) <= (now_end_time))                     \
-                (ops)->group_value_flags |= RRDR_VALUE_RESET;           \
-        }                                                               \
+        time_t _row_start = (now_end_time) - (ops)->view_update_every;  \
+        bool _sample_in_row = (source_end_time) > _row_start &&         \
+                              (source_end_time) <= (now_end_time);       \
+                                                                        \
+        if(unlikely((point).sp.flags & SN_FLAG_RESET) && _sample_in_row) \
+            (ops)->group_value_flags |= RRDR_VALUE_RESET;               \
                                                                         \
         NETDATA_DOUBLE grouping_value =                                    \
             query_point_grouping_value(point, ops, add_flush);             \
         time_grouping_add(r, grouping_value, add_flush);                   \
                                                                         \
-        storage_point_merge_to((ops)->group_point, (point).sp);         \
+        if((point).tier != 0 || _sample_in_row)                          \
+            storage_point_merge_to((ops)->group_point, (point).sp);     \
         if(!(point).added)                                              \
             storage_point_merge_to((ops)->query_point, (point).sp);     \
     }                                                                   \
@@ -187,6 +187,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     // when we switch plans, we read-ahead a point from the next plan
     // to join them smoothly at the exact time the next plan begins
     STORAGE_POINT next1_point = STORAGE_POINT_UNSET;
+    uint8_t next1_tier = 0;
 
     time_t now_start_time = after_wanted - ops->query_granularity;
     time_t now_end_time   = after_wanted + (ops->view_update_every - ops->query_granularity);
@@ -202,6 +203,13 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s);
             db_points_read_since_plan_switch = 0;
         }
+
+        // Interpolation can consume a tier-0 point before the row that owns its metadata.
+        if(new_point.added && new_point.tier == 0 &&
+           new_point.sp.end_time_s > now_start_time &&
+           new_point.sp.end_time_s <= now_end_time &&
+           netdata_double_isnumber(new_point.value))
+            storage_point_merge_to(ops->group_point, new_point.sp);
 
         // read all the points of the db, prior to the time we need (now_end_time)
 
@@ -233,8 +241,10 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             // fetch the new point
             {
                 STORAGE_POINT sp;
+                uint8_t sp_tier;
                 if(likely(storage_point_is_unset(next1_point))) {
                     db_points_read_since_plan_switch++;
+                    sp_tier = (uint8_t)ops->tier;
                     sp = storage_engine_query_next_metric(ops->seqh);
                     ops->db_points_read_per_tier[ops->tier]++;
                     ops->db_total_points_read++;
@@ -245,6 +255,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 else {
                     // ONE POINT READ-AHEAD
                     sp = next1_point;
+                    sp_tier = next1_tier;
                     storage_point_unset(next1_point);
                     db_points_read_since_plan_switch = 1;
                 }
@@ -262,23 +273,29 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                     // B. part of the point of the previous plan overlaps with the point from the next plan
 
                     STORAGE_POINT sp2 = storage_engine_query_next_metric(ops->seqh);
+                    uint8_t sp2_tier = (uint8_t)ops->tier;
                     ops->db_points_read_per_tier[ops->tier]++;
                     ops->db_total_points_read++;
 
                     if(unlikely(options & RRDR_OPTION_ABSOLUTE))
                         storage_point_make_positive(sp);
 
-                    if(sp.start_time_s > sp2.start_time_s)
+                    if(sp.start_time_s > sp2.start_time_s) {
                         // the point from the previous plan is useless
                         sp = sp2;
-                    else
+                        sp_tier = sp2_tier;
+                    }
+                    else {
                         // let the query run from the previous plan
                         // but setting this will also cut off the interpolation
                         // of the point from the previous plan
                         next1_point = sp2;
+                        next1_tier = sp2_tier;
+                    }
                 }
 
                 new_point.sp = sp;
+                new_point.tier = sp_tier;
                 new_point.added = false;
                 query_point_set_id(new_point, ops->db_total_points_read);
 

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -208,8 +208,12 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
         if(new_point.added && new_point.tier == 0 &&
            new_point.sp.end_time_s > now_start_time &&
            new_point.sp.end_time_s <= now_end_time &&
-           netdata_double_isnumber(new_point.value))
+           netdata_double_isnumber(new_point.value)) {
+            if(unlikely(new_point.sp.flags & SN_FLAG_RESET))
+                ops->group_value_flags |= RRDR_VALUE_RESET;
+
             storage_point_merge_to(ops->group_point, new_point.sp);
+        }
 
         // read all the points of the db, prior to the time we need (now_end_time)
 

--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -74,13 +74,18 @@ static NETDATA_DOUBLE query_point_grouping_value(
         }                                                               \
 } while(0)
 
-#define query_add_point_to_group(r, point, ops, add_flush)        do {  \
+#define query_add_point_to_group(r, point, ops, add_flush, now_end_time, source_end_time) do { \
     if(likely(netdata_double_isnumber((point).value))) {                \
         if(likely(fpclassify((point).value) != FP_ZERO))                \
             (ops)->group_points_non_zero++;                             \
                                                                         \
-        if(unlikely((point).sp.flags & SN_FLAG_RESET))                  \
-            (ops)->group_value_flags |= RRDR_VALUE_RESET;               \
+        if(unlikely((point).sp.flags & SN_FLAG_RESET)) {                \
+            time_t _row_start =                                        \
+                (now_end_time) - (ops)->view_update_every;              \
+            if((source_end_time) > _row_start &&                        \
+               (source_end_time) <= (now_end_time))                     \
+                (ops)->group_value_flags |= RRDR_VALUE_RESET;           \
+        }                                                               \
                                                                         \
         NETDATA_DOUBLE grouping_value =                                    \
             query_point_grouping_value(point, ops, add_flush);             \
@@ -350,7 +355,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 if(likely(new_point.sp.end_time_s > now_start_time)) { // likely to favor tier0
                     // this db point ends after our now_start time
 
-                    query_add_point_to_group(r, new_point, ops, add_flush);
+                    query_add_point_to_group(
+                        r, new_point, ops, add_flush, now_end_time, new_point.sp.end_time_s);
                     new_point.added = true;
                 }
                 else {
@@ -415,10 +421,12 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             // but, we don't need it
 
             QUERY_POINT current_point;
+            time_t source_end_time;
 
             if(likely(now_end_time > new_point.sp.start_time_s)) {
                 // it is time for our NEW point to be used
                 current_point = new_point;
+                source_end_time = new_point.sp.end_time_s;
                 new_point.added = true; // first copy, then set it, so that new_point will not be added again
                 query_interpolate_point(current_point, last1_point, now_end_time);
 
@@ -438,6 +446,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             else if(likely(now_end_time <= last1_point.sp.end_time_s)) {
                 // our LAST point is still valid
                 current_point = last1_point;
+                source_end_time = last1_point.sp.end_time_s;
                 last1_point.added = true; // first copy, then set it, so that last1_point will not be added again
                 query_interpolate_point(current_point, last2_point, now_end_time);
 
@@ -456,9 +465,11 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             else {
                 // a GAP, we don't have a value this time
                 current_point = QUERY_POINT_EMPTY;
+                source_end_time = 0;
             }
 
-            query_add_point_to_group(r, current_point, ops, add_flush);
+            query_add_point_to_group(
+                r, current_point, ops, add_flush, now_end_time, source_end_time);
 
             rrdr_line = rrdr_line_init(r, now_end_time, rrdr_line);
             size_t rrdr_o_v_index = rrdr_line * r->d + dim_id_in_rrdr;

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -13,6 +13,7 @@
 typedef struct query_point {
     STORAGE_POINT sp;
     NETDATA_DOUBLE value;
+    uint8_t tier;
     bool added;
 #ifdef NETDATA_INTERNAL_CHECKS
     size_t id;


### PR DESCRIPTION
## Summary

Fix tier-0 RESET and anomaly evidence being attributed to rows that merely reuse or interpolate a stored value, rather than the result row whose `(start, end]` interval contains the source sample timestamp.

This extracts the complete source-row ownership repair from #23283 as one independently reviewable bug fix.

## What changes

- Preserve the source tier across query-plan read-ahead and replacement.
- Apply RESET only to the row containing the stored sample timestamp.
- Merge tier-0 anomaly metadata into that owning row exactly once, without adding the numeric value or whole-query statistics again.
- Keep higher-tier interval evidence behavior unchanged.

## Tests

The query contract corpus in #23130 directly covers this bug:

- `CASE-032/reset-annotation-is-not-redelivered`
  - exact RESET ownership on 5s, 30s, metadata-handoff 25s, and non-dividing 35s grids;
  - average and sum;
  - exact annotation and anomaly-rate controls.
- `CASE-033/anomaly-rate-counts-samples-in-the-row`
  - exact tier-0 exclusive-start/inclusive-end anomaly membership;
  - source-tier provenance across an automatic tier1-to-tier0 plan seam.

Validation on this exact branch:

- Current master fails CASE-032 and the tier-0 component of CASE-033.
- This branch passes CASE-032 and both required CASE-033 components.
- Four independent reverse mutations fail the intended contract, including the carried-RESET handoff.
- Full native unit suite passes.
- `QUERY_POINT` and `QUERY_ENGINE_OPS` sizes are unchanged from master.
- Focused crossed performance runs cover tier-0 upsampling, the metadata handoff, and an automatic tier seam; all
  measured deltas remain below the 3% material-regression gate and within the observed same-binary noise envelope.
- The complete bug-fix-plus-feature composition retains only the five approved DBENGINE/Agent-Cloud limitations in
  the corpus, with no new red contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures tier-0 RESET and anomaly evidence is attributed only to the result row whose (start, end] interval contains the source sample timestamp. Previously, evidence could attach to rows that reused or interpolated a stored value, causing double metadata merges and incorrect anomaly membership.

**Review notes**
- Preserve point tier across read-ahead, plan switches, and interpolation; `query_point` now carries `tier`.
- Gate RESET and tier-0 metadata merge on the source sample being in the current row; compute row bounds from `now_end_time` and `view_update_every`.
- Emit carried RESET on the owning row when interpolation would otherwise consume it earlier.
- Merge tier-0 anomaly metadata once into the owning row without re-adding the numeric value or whole-query statistics.
- Keep higher-tier interval evidence behavior unchanged.
- `query_add_point_to_group` now accepts `now_end_time` and `source_end_time` and merges evidence only when the source sample belongs to the row.

<sup>Written for commit eee2f6d8cef0b6fbade4d68e9bba4fd4d0877e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query results across storage tiers by preserving tier information during execution and plan changes.
  * Corrected metadata handling for interpolated and read-ahead points.
  * Ensured reset behavior applies only to samples within the relevant result row.
  * Improved merging of storage metadata for tiered and interpolated query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->