### PR TITLE
fix(query): preserve incremental sum baselines

### DIFF
--- a/src/web/api/queries/incremental_sum/incremental_sum.h
+++ b/src/web/api/queries/incremental_sum/incremental_sum.h
@@ -59,9 +59,9 @@ static inline NETDATA_DOUBLE tg_incremental_sum_flush(RRDR *r, RRDR_VALUE_FLAGS 
     }
     else {
         value = g->last - g->first;
+        g->first = g->last;
     }
 
-    g->first = g->last;
     g->last = NAN;
     g->count = 0;
 


### PR DESCRIPTION
## Summary

Preserve the previous valid sample as the baseline when an incremental-sum result bucket contains only the opening sample and therefore cannot yet produce a difference.

This extracts one complete root-cause fix from #23283 into an independently reviewable PR. It does not change timestamps, units, tier selection, storage, or public grouping semantics.

## Root cause

`tg_incremental_sum_add()` stores the first sample in `first` and does not set `last` until another sample arrives. The flush path correctly returns EMPTY when `last` is unset, but then unconditionally copied that unset `last` over the valid `first` baseline.

At one result bucket per collected sample, every bucket therefore lost the seed needed by its successor and the entire query remained empty. The fix advances `first` to `last` only after a valid difference is emitted; an empty/opening flush keeps its existing baseline.

The one-line production patch has the same stable patch ID and final file blob as combined commit `789149dcb0` in #23283.

## Test contract

The query contract corpus in #23130 directly covers this state transition:

- `CASE-027/incremental-sum-conserves-across-zoom`
  - requires one opening EMPTY followed by 59 exact `+7` rows at one bucket per sample;
  - requires the bucket totals to telescope to the first-to-last rise at several zoom levels.
- Layer-3 sparse-bucket and identity-smoothing controls verify that a one-sample bucket carries its sample forward and an empty bucket preserves the baseline it received.
- Layer-10 no-hole, finer-than-stored, and single-point-bucket invariants verify the same behavior across the registered grouping matrix and tier shapes.

Validation on this exact branch:

- Current master fails CASE-027.
- This branch passes CASE-027 and all focused Layer-3/Layer-10 controls.
- Reversing the assignment to its old unconditional position fails CASE-027 again.
- The restored branch passes the full native unit suite.
- Generated code shrinks by one instruction, with the same three conditional jumps, one unconditional jump and zero calls.
- A balanced crossed benchmark finds the unchanged multi-sample path neutral (`-0.47%`, 95% CI `[-3.32%, +2.47%]`). The corrected one-sample path does more work than broken master because it computes and returns 3,599 real differences instead of an all-empty result; no work-equivalent unchanged-path regression is present.

The corpus PR should merge before this fix so the regression contract becomes part of the normal CI surface.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves incremental-sum baselines so an opening bucket that cannot compute a difference keeps its first valid sample. Previously, an empty flush overwrote the baseline and caused downstream buckets to return empty results; now we advance the baseline only after emitting a valid difference.

- Moves the baseline update (`g->first = g->last`) inside the non-empty branch of `tg_incremental_sum_flush()`.
- Scope: incremental-sum queries only. No changes to timestamps, units, tier selection, storage, or grouping semantics.
- Expected behavior: the first bucket may be EMPTY; subsequent buckets compute correct deltas using the preserved baseline.
- Test coverage: CASE-027 ensures the opening EMPTY followed by correct incremental results. No migrations or config changes required.

<sup>Written for commit ba823c86f094148dc91815f7881d42a3278f4a99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental sum flushing by preventing empty or invalid ranges from changing the calculation state.
  * Ensured valid accumulated ranges update correctly after being flushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->